### PR TITLE
docs(issues): file 0269-0273 — autoware_sentinel phase-14 pin-bump walls

### DIFF
--- a/docs/issues/0269-freertos-zpico-aggregate-declare-threshold.md
+++ b/docs/issues/0269-freertos-zpico-aggregate-declare-threshold.md
@@ -1,0 +1,61 @@
+---
+id: 269
+title: "freertos/zenoh-pico: SubscriberCreationFailed once aggregate entity count crosses a threshold — every component passes alone, the union fails"
+status: open
+type: bug
+severity: high
+area: zpico
+related: [issue-0255]
+---
+
+## Finding (autoware_sentinel phase-14 pin bump, 2026-07-25)
+
+The sentinel's monolithic node (comp-all: 37 pubs / 21 services / 5 subs /
+1 timer on ONE zenoh-pico session, MPS2-AN385 QEMU, lwIP + LAN9118, zenohd
+over SLIRP) fails at wiring time with `Transport(SubscriberCreationFailed)`.
+Bisection with the sentinel's per-component feature gates:
+
+- every component feature ALONE boots and spins;
+- the 4-combo (mrm + cmd-gate-extra + validator + op-mode-mgr,
+  ~33 pubs / 19 svcs / 3 subs) boots and spins;
+- adding comp-engagement (+4 pubs / +2 subs / +2 svcs) tips it into
+  `SubscriberCreationFailed`.
+
+Ruled out (reproduced with all of): `ZPICO_MAX_SUBSCRIBERS=64`,
+`ZPICO_MAX_LIVELINESS=160`, `ZPICO_MAX_LARGE_SUBSCRIBERS=8`,
+`ZPICO_MAX_PUBLISHERS=56`, `ZPICO_MAX_QUERYABLES=32`, 2.5 MiB FreeRTOS
+heap, 768 KiB app-task stack. Subscriptions use the default 1024 B rx
+hint (small payload class; 5 subs ≪ 64 slots), so neither shim pool cap
+in `shim/subscriber.rs` should trip — suspicion falls on the
+`declare_subscriber_ring_raw` error path (`TransportError::from(e)`)
+after ~50+ prior declares on the session.
+
+**The identical comp-all topology boots and spins on
+nros-board-nuttx-qemu-arm** (std platform, BSD sockets) on the same pin
+(`21a3a4248`) — the wall is specific to the freertos+lwip platform layer.
+
+This looks like the same class as the sentinel's Phase-13.K1
+"declare-storm" hang (the reason those bisection gates exist) — now a
+hard error instead of a hang.
+
+## Repro
+
+autoware_sentinel branch `phase-14`, `src/autoware_sentinel_freertos`:
+
+```sh
+cargo build --release --features comp-all
+zenohd --listen tcp/0.0.0.0:7447 &
+qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic \
+  -semihosting-config enable=on,target=native \
+  -kernel target/thumbv7m-none-eabi/release/autoware_sentinel_freertos
+# → "Application error: Transport(SubscriberCreationFailed)"
+# 4-combo control: --features comp-mrm,comp-cmd-gate-extra,comp-validator,comp-op-mode-mgr → spins
+```
+
+## Ask
+
+Diagnosis needs visibility: `ZENOH_DEBUG` is hardcoded `0` in
+nros-zpico-build's config (runner.rs) and the rmw shim's `log::debug!`
+lines are `feature = "std"`-gated — there is no way for an embedded
+consumer to see WHICH declare fails or why. Either surface the zenoh-pico
+error code in `TransportError`, or make the debug define overridable.

--- a/docs/issues/0270-rmw-zenoh-default-features-zpico-aliases-collision.md
+++ b/docs/issues/0270-rmw-zenoh-default-features-zpico-aliases-collision.md
@@ -1,0 +1,44 @@
+---
+id: 270
+title: "nros-rmw-zenoh deps zpico-sys with default features — platform-aliases TU double-defines clock symbols on orin-spe"
+status: open
+type: bug
+severity: medium
+area: build
+---
+
+## Finding (autoware_sentinel phase-14 SPE build, 2026-07-25)
+
+`nros-rmw-zenoh/Cargo.toml` line ~99:
+
+```toml
+zpico-sys = { version = "0.5.0", path = "../zpico-sys" }
+```
+
+Default features ON → `platform-aliases` + `link-ip`. zpico-sys's own
+`orin-spe` feature documents that the alias TU must be OFF there ("the
+SPE's system.c implements the `_z_*` surface natively via the FSP
+V10.4.3 FreeRTOS API, so `platform-aliases` is OFF for orin-spe to
+avoid double-define") — but cargo feature-unification cannot subtract:
+any consumer linking `nros-rmw-zenoh` + `zpico-sys/orin-spe` gets BOTH
+`system.c` and `platform_aliases.c`, and the spe.elf link dies:
+
+```
+multiple definition of `z_time_elapsed_ms';  (system.o vs platform_aliases.o)
+multiple definition of `z_time_elapsed_s'
+multiple definition of `_z_get_time_since_epoch'
+```
+
+## Workaround shipped in autoware_sentinel
+
+`just build-spe-firmware` ar-strips `*platform_aliases.o` from the
+staticlib after cargo (safe: every symbol the alias TU forwards exists
+natively in the orin-spe system.c).
+
+## Fix direction
+
+`nros-rmw-zenoh` should declare
+`zpico-sys = { default-features = false, ... }` and re-add `link-ip` /
+`platform-aliases` only from its own platform-* features (posix et al),
+mirroring how the `platform-posix` feature already forwards
+`zpico-sys/posix`.

--- a/docs/issues/0271-orin-spe-btcm-footprint-regression.md
+++ b/docs/issues/0271-orin-spe-btcm-footprint-regression.md
@@ -1,0 +1,53 @@
+---
+id: 271
+title: "Orin SPE BTCM footprint regressed ~+195 KB between d9af52be and 21a3a4248 — minimal Executor::open+spin image no longer fits 256 KB"
+status: open
+type: regression
+severity: high
+area: embedded
+related: [issue-0257]
+---
+
+## Finding (autoware_sentinel phase-14 pin bump, 2026-07-25)
+
+On pin `d9af52be` (post-11.3.C size campaign) the sentinel's DEFAULT SPE
+image (`Executor::open` + `spin` over zenoh-pico/IVC, no algorithm
+wiring) fit the 256 KB BTCM with **31 KB headroom** (~224 KB
+text+data+bss). On `21a3a4248`, the same build — same slot rightsizing
+envs (`ZPICO_MAX_PUBLISHERS=8 / SUBSCRIBERS=4 / QUERYABLES=2 /
+LIVELINESS=16`, `NROS_EXECUTOR_MAX_CBS=8`, 256 B buffers), same
+`.cargo` hardening (armv7r-none-eabi softfp, build-std core+alloc,
+`panic=immediate-abort`, `-Os` + LTO) — **overflows BTCM by 164 KB**
+(ld names `.data`): a ~+195 KB swing.
+
+Staticlib pre-gc totals for scale: text 464 KB / bss 158 KB;
+`compiler_builtins` alone contributes 118 KB text pre-gc.
+
+Suspected contributors (unverified): the rmw-cffi vtable seam now on the
+default path, the node-registry/wake/monitor machinery (phase 271/273 /
+RFC-0052 tables), and zenoh-pico feature growth (interest/matching).
+Needs an 11.3.C-style per-component size audit on the new pin; the
+sentinel's fallback is the 11.3.E DRAM/AST mapping, but a 2× regression
+of the minimal image hurts every 256 KB-class target, not just the SPE.
+
+## Repro
+
+autoware_sentinel branch `phase-14`:
+
+```sh
+just build-spe-image
+# → ld: region `btcm' overflowed by 164464 bytes
+```
+
+## Side notes from the same bump (consumer-side, already absorbed)
+
+- The retired `nros-platform-orin-spe` crate used to compile the
+  platform C port; `nros-platform-freertos` is now a source-only C
+  package with no compiler at the SPE site — the sentinel added a
+  build.rs compiling `platform.c`/`timer.c` against the FSP headers
+  (with `configTOTAL_HEAP_SIZE` undefined there — see the define
+  fallback in that build.rs).
+- zpico.c's session-seed path (`#elif defined(CLOCK_REALTIME)`) calls
+  `clock_gettime`, which newlib does not back on the SPE; the sentinel
+  shims it off `nros_platform_time_now_ms`. Consider gating that seed
+  branch off for `ZENOH_ORIN_SPE` builds.

--- a/docs/issues/0272-nros-patch-include-dead-on-stable-cargo.md
+++ b/docs/issues/0272-nros-patch-include-dead-on-stable-cargo.md
@@ -1,0 +1,49 @@
+---
+id: 272
+title: "nros sync's `include = [nros-patch.toml]` is silently dead on stable cargo — external consumers get 'no matching package named nros'"
+status: open
+type: bug
+severity: medium
+area: cli
+---
+
+## Finding (autoware_sentinel phase-14 pin bump, 2026-07-25)
+
+`nros sync` writes the consumer's `.cargo/config.toml` with
+
+```toml
+include = ["../../nano-ros/nros-patch.toml"]
+```
+
+as the sole source of the nros/nros-core/nros-serdes `[patch.crates-io]`
+rows. Cargo's config `include` key is still nightly-only
+(`-Z config-include`); stable cargo (verified on 1.96.0) ignores the
+line WITHOUT a warning, so an external consumer's first build fails
+with:
+
+```
+error: no matching package named `nros` found
+location searched: crates.io index
+```
+
+with no hint that the patch mechanism was dropped. In-tree example
+workspaces dodge this because their crates carry direct `path =` deps
+into the checkout; a colcon-mode external consumer (patch authority =
+its own workspace root) has nothing else.
+
+## Workaround shipped in autoware_sentinel
+
+Hand-maintained trio rows appended to the same `[patch.crates-io]`
+table (sync preserves rows it does not manage):
+
+```toml
+nros = { path = "../nano-ros/packages/core/nros" }
+nros-core = { path = "../nano-ros/packages/core/nros-core" }
+nros-serdes = { path = "../nano-ros/packages/core/nros-serdes" }
+```
+
+## Fix direction
+
+Have `nros sync` inline the trio rows directly (marked `# nros-managed`
+like the msg rows) when the resolved toolchain is stable, or at minimum
+emit a loud post-sync warning that the include line needs nightly.

--- a/docs/issues/0273-mps2-freertos-board-entry-descriptor-stale.md
+++ b/docs/issues/0273-mps2-freertos-board-entry-descriptor-stale.md
@@ -1,0 +1,29 @@
+---
+id: 273
+title: "nros-board-mps2-an385-freertos nros-board.toml still advertises the retired `_start` entry signature"
+status: open
+type: bug
+severity: low
+area: boards
+---
+
+## Finding (autoware_sentinel phase-14 pin bump, 2026-07-25)
+
+`packages/boards/nros-board-mps2-an385-freertos/nros-board.toml`:
+
+```toml
+[board.entry]
+signature = "#[unsafe(no_mangle)]\nextern \"C\" fn _start() -> !"
+```
+
+but `c/board_mps2.c`'s `Reset_Handler` calls `main` — the `_start`
+shape was retired (commit d99386173, the file's own comment block says
+so). A legacy-`run()` consumer following the descriptor links with
+
+```
+rust-lld: error: undefined symbol: main
+```
+
+Update the descriptor's `[board.entry] signature` to the
+`extern "C" fn main() -> i32` shape so codegen'd entries and
+hand-written firmware agree with the C startup.


### PR DESCRIPTION
Consumer-wall intake from bumping **autoware_sentinel** from `682f1404`/`d9af52be` to `21a3a4248` — the zenoh-pico/embedded counterpart of ASI's phase-292 W2.a round.

| # | Wall | Severity |
|---|------|----------|
| 0269 | freertos/zenoh-pico: `SubscriberCreationFailed` past an aggregate entity threshold (37 pubs/21 svcs); every component passes alone; **identical topology spins on NuttX** — freertos+lwip platform layer. Ask: surface the zenoh-pico declare error / make `ZENOH_DEBUG` overridable | high |
| 0270 | `nros-rmw-zenoh` deps `zpico-sys` with default features → `platform-aliases` TU double-defines clock symbols on orin-spe (contract in zpico-sys's own `orin-spe` feature comment). Workaround: ar-strip; fix: `default-features = false` + per-platform forwards | medium |
| 0271 | Orin SPE BTCM footprint regressed **~+195 KB** pin-to-pin: minimal `Executor::open`+spin image went from 31 KB headroom to 164 KB overflow on 256 KB BTCM (same slot/env/profile hardening) | high |
| 0272 | `nros sync`'s `include = [nros-patch.toml]` silently dead on stable cargo (config-include is nightly) → external consumers hit "no matching package named `nros`" with no hint | medium |
| 0273 | mps2-an385-freertos `nros-board.toml` `[board.entry]` still advertises the retired `_start` signature; `board_mps2.c` calls `main` | low |

Full repros in each doc. Sentinel-side workarounds are on autoware_sentinel branch `phase-14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RxHcGZxhynnWsNkzKepfP