### PR TITLE
fix(0269): embedded subscription pool env-sized; executor stops masking transport errors; lwIP write_all

### DIFF
--- a/packages/boards/nros-board-mps2-an385-freertos/config/lwipopts.h
+++ b/packages/boards/nros-board-mps2-an385-freertos/config/lwipopts.h
@@ -83,7 +83,12 @@
 
 /* ---- TCP tuning ---- */
 #define TCP_MSS                         1460
-#define TCP_SND_BUF                     (4 * TCP_MSS)
+/* nano-ros issue 0269: 4*MSS starved many-entity DECLARE bursts —
+ * TCP_SND_QUEUELEN (derived below) capped in-flight small segments at
+ * ~16 and forced the send path into its retry loop during session
+ * open. 8*MSS doubles both byte- and segment-headroom; MEM_SIZE (32 KB)
+ * comfortably covers the extra unacked segments. */
+#define TCP_SND_BUF                     (8 * TCP_MSS)
 #define TCP_SND_QUEUELEN                ((4 * TCP_SND_BUF) / TCP_MSS)
 #define TCP_WND                         (4 * TCP_MSS)
 #define LWIP_TCP_KEEPALIVE              1

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -371,7 +371,7 @@ impl<'a> NodeHandle<'a> {
         let handle = self
             .session
             .create_subscription(&topic, qos)
-            .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?;
+            .map_err(NodeError::Transport)?;
         // W3b.5 — attach the contracted endpoint's age cell (stamped
         // types only; needs an epoch source).
         let age_mon = match (<M as RosMessage>::STAMP_OFFSET, self.epoch_us_fn) {
@@ -432,7 +432,7 @@ impl<'a> NodeHandle<'a> {
         let handle = self
             .session
             .create_subscription(&topic, qos)
-            .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?;
+            .map_err(NodeError::Transport)?;
         Ok(crate::executor::handles::RawSubscription {
             handle,
             buffer: [0u8; RX_BUF],

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -2901,7 +2901,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         // Phase 231 Wave 0.2 (RFC-0038) — in-place dispatch when the backend
@@ -3030,7 +3030,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
         let handle_id = self.add_arena_subscription_callback::<F, RX_BUF>(handle, qos, callback)?;
         // Phase 104.C.4 — apply Node's default SchedContext.
@@ -3094,7 +3094,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let (_slot_count, trailing_bytes) = buffered_region_size(qos.depth, RX_BUF);
@@ -3173,7 +3173,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let offset = self.arena_alloc::<Entry<F, RX_BUF>>()?;
@@ -3249,7 +3249,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let offset = self.arena_alloc::<Entry<F, RX_BUF>>()?;
@@ -3393,7 +3393,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let offset = self.arena_alloc::<Entry<M, F, RX_BUF>>()?;
@@ -3469,7 +3469,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let offset = self.arena_alloc::<Entry<M, F, RX_BUF>>()?;
@@ -3863,7 +3863,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let (_slot_count, trailing_bytes) = buffered_region_size(qos.depth, RX_BUF);
@@ -3948,7 +3948,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let offset = self.arena_alloc::<Entry<RX_BUF>>()?;
@@ -4031,7 +4031,7 @@ impl<'s> Executor<'s> {
                 .ok_or(NodeError::BackendMismatch)?;
             session
                 .create_subscription(&topic, qos)
-                .map_err(|_| NodeError::Transport(TransportError::SubscriberCreationFailed))?
+                .map_err(NodeError::Transport)?
         };
 
         let offset = self.arena_alloc::<Entry<RX_BUF>>()?;

--- a/packages/core/nros-rmw-cffi/build.rs
+++ b/packages/core/nros-rmw-cffi/build.rs
@@ -16,6 +16,7 @@
 
 fn main() {
     emit_max_backends();
+    emit_subscriber_slots();
     maybe_build_c_stub();
 }
 
@@ -39,6 +40,33 @@ fn emit_max_backends() {
     }
 
     println!("cargo:rustc-env=NROS_RMW_MAX_BACKENDS={parsed}");
+}
+
+/// Issue 0269 — size the embedded (`target_os = "none"`, no-std)
+/// subscription-handle pool in `rust_adapter::static_subscriber_storage`.
+/// The old hardcoded 4 silently capped a session at four subscriptions:
+/// the fifth `create_subscription` returned BAD_ALLOC, which the
+/// executor then surfaced as an opaque `SubscriberCreationFailed`.
+fn emit_subscriber_slots() {
+    println!("cargo:rerun-if-env-changed=NROS_RMW_SUBSCRIBER_SLOTS");
+
+    let raw = std::env::var("NROS_RMW_SUBSCRIBER_SLOTS").unwrap_or_else(|_| "8".to_string());
+    let parsed: usize = raw.trim().parse().unwrap_or_else(|err| {
+        panic!(
+            "NROS_RMW_SUBSCRIBER_SLOTS=\"{raw}\" is not a valid usize: {err}. \
+             Set a positive integer (default 8)."
+        )
+    });
+
+    if !(1..=128).contains(&parsed) {
+        panic!(
+            "NROS_RMW_SUBSCRIBER_SLOTS={parsed} out of range [1, 128]. Each \
+             slot is a 1 KiB static; bump the upper bound only with the \
+             memory budget in hand."
+        );
+    }
+
+    println!("cargo:rustc-env=NROS_RMW_SUBSCRIBER_SLOTS={parsed}");
 }
 
 fn maybe_build_c_stub() {

--- a/packages/core/nros-rmw-cffi/src/lib.rs
+++ b/packages/core/nros-rmw-cffi/src/lib.rs
@@ -381,15 +381,21 @@ pub fn event_kind_from_c(k: NrosRmwEventKind) -> nros_rmw::EventKind {
 pub const MAX_BACKENDS: usize = parse_max_backends(env!("NROS_RMW_MAX_BACKENDS"));
 
 const fn parse_max_backends(s: &str) -> usize {
+    parse_env_usize(s, "NROS_RMW_MAX_BACKENDS must be a decimal integer")
+}
+
+/// Const decimal parser for build.rs-emitted envs (`MAX_BACKENDS`,
+/// `NROS_RMW_SUBSCRIBER_SLOTS`).
+pub(crate) const fn parse_env_usize(s: &str, msg: &str) -> usize {
     let bytes = s.as_bytes();
     let mut i = 0usize;
     let mut acc: usize = 0;
     while i < bytes.len() {
         let d = bytes[i];
-        assert!(
-            d.is_ascii_digit(),
-            "NROS_RMW_MAX_BACKENDS must be a decimal integer"
-        );
+        if !d.is_ascii_digit() {
+            let _ = msg;
+            panic!("nros-rmw-cffi: build-time env must be a decimal integer");
+        }
         acc = acc * 10 + (d - b'0') as usize;
         i += 1;
     }

--- a/packages/core/nros-rmw-cffi/src/rust_adapter.rs
+++ b/packages/core/nros-rmw-cffi/src/rust_adapter.rs
@@ -60,7 +60,17 @@ mod static_subscriber_storage {
 
     use portable_atomic::{AtomicBool, Ordering};
 
-    const SLOT_COUNT: usize = 4;
+    // Issue 0269 — the pool size is build-time configurable via
+    // `NROS_RMW_SUBSCRIBER_SLOTS` (build.rs, default 8). The old
+    // hardcoded 4 silently capped every embedded session at four
+    // subscriptions: the fifth `create_subscription` hit the exhausted
+    // pool, returned BAD_ALLOC, and the executor surfaced it as an
+    // opaque `SubscriberCreationFailed` (the autoware_sentinel comp-all
+    // wall — every std target Boxes instead and never sees a limit).
+    const SLOT_COUNT: usize = crate::parse_env_usize(
+        env!("NROS_RMW_SUBSCRIBER_SLOTS"),
+        "NROS_RMW_SUBSCRIBER_SLOTS must be a decimal integer",
+    );
     const SLOT_SIZE: usize = 1024;
     const SLOT_ALIGN: usize = 16;
 


### PR DESCRIPTION
Fixes the freertos wall from the autoware_sentinel phase-14 intake (issue doc 0269 in #3).

**Root cause** — not zenoh-pico, not slot-cap envs: `rust_adapter::static_subscriber_storage` (the no-std subscription-handle home on `target_os = "none"`) was hardcoded to **4 slots**. The 5th `create_subscription` returned BAD_ALLOC, and all 12 `register_subscription*` sites in the executor flattened every transport error to `SubscriberCreationFailed`, hiding it. std targets Box the handle — which is why the identical 37-pub/21-svc/5-sub topology passed on NuttX and made the wall look like a platform-layer mystery.

Changes:
- **nros-rmw-cffi**: pool sized via `NROS_RMW_SUBSCRIBER_SLOTS` (build.rs; default 8, range [1,128]; +4 KiB static vs old 4). Const parser shared with `MAX_BACKENDS`.
- **nros-node**: `.map_err(|_| SubscriberCreationFailed)` → `.map_err(NodeError::Transport)` at all 12 sites — BAD_ALLOC/QoS/keyexpr failures now surface as themselves (the 0269 visibility ask).
- **zenoh-pico submodule** → `jerry73204/zenoh-pico` branch `fix-lwip-send-all`: `_z_send_tcp` drain loop — write_all semantics on lwIP's tiny buffers (short writes / ERR_MEM under the session-open DECLARE burst were hard errors).
- **mps2-an385 lwipopts**: `TCP_SND_BUF` 4→8 MSS.

Verified: autoware_sentinel comp-all boots + spins on MPS2-AN385 QEMU (was: hard failure at the 5th subscription); `cargo check -p nros-rmw-cffi -p nros-node` green on host.

Note: the submodule bump points at a branch on the zenoh-pico fork — merge `jerry73204/zenoh-pico#fix-lwip-send-all` (or cherry-pick onto the fork's mainline) before/with this PR so the pointer lands on a stable rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RxHcGZxhynnWsNkzKepfP