### PR TITLE
docs(#859,#861,#862): retract three issues — the run that produced them was invalid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,17 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   coordinate producing no runtime result. Exemptions have ONE spelling
   (`nros_tests::fixtures::staleness::exempt_probe_input`, gated by
   `check-staleness-probe-exemptions`) because per-arm subsets ARE 0442.
+- **A test result is only about the tree its FIXTURES were built from — check the mtimes
+  before filing (issues 0859/0860/0861/0862, all four retracted).** A sweep, then a rebase,
+  then reading the sweep's output is four ghost issues: the artifacts were built at 03:19
+  against a tree rebased past 04:48, so each red reproduced a bug that had ALREADY BEEN
+  FIXED, in convincing detail. Two of the four also got a confident wrong ROOT CAUSE written
+  into them (an allocator that was fine; a "no compilation inside tests" violation in a test
+  that answers in 82 ms), which is worse than the bogus filing — it aims the next person at
+  a dead end. Before filing from a failing fixture: `stat -c '%y' <artifact>` against
+  `git log -1 --format=%ci` of the code being blamed, and re-run the single test SOLO — a
+  60 s timeout under a 32-way build was 0.082 s alone. `Real failures: N` from the junit
+  rewrite counts what the RUN saw, not what is true of HEAD.
 - **Test greps use `nros_tests::output::*` constants, never literal strings** — example
   banners/markers get slimmed (phase-277 broke ~10 tests grepping `"Result:"`/`"[OK]"`/old
   banners while delivery worked). If a test times out, FIRST diff the grep pattern against what

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -92,9 +92,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.
 - **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
 - **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
-- **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
-- **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
-- **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
 - **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
 - **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.

--- a/docs/issues/archived/0859-action-server-copies-diverge-across-platforms.md
+++ b/docs/issues/archived/0859-action-server-copies-diverge-across-platforms.md
@@ -2,12 +2,43 @@
 id: 859
 title: "`rust/action-server` diverges from its native copy on all four RTOS
   platforms — one copy of a portability group was edited alone"
-status: open
+status: resolved
+resolution: retracted
 type: bug
 area: examples, testing
 related: [phase-338, phase-394]
 ---
 
+> **RETRACTED — not a defect.** The original report is kept below
+> unaltered, because a retraction that deletes its own evidence cannot
+> be checked.
+
+## Retracted 2026-08-28 — the run that produced this was invalid
+
+This was filed from a `just ci-matrix` run whose FIXTURES PREDATED THE TREE.
+The sweep built its artifacts at 03:19, the tree was then rebased past 04:48,
+and the old results were read as current. Re-run against fixtures matching the
+tree, it passes.
+
+That is not a flake and not a partial fix: nothing about the reported behaviour
+was real. See the retraction note at the bottom for the shared cause, which took
+all four issues from that run.
+
+## Re-check
+
+```
+$ cargo nextest run -E 'test(copies_within_a_group_are_identical)'
+    PASS [   0.008s] (1/1) nros-tests::example_portability copies_within_a_group_are_identical
+     Summary [   0.018s] 1 test run: 1 passed
+```
+
+This gate reads example SOURCES (`collect_sources()`), not fixtures, so it was
+decidable immediately and needed no rebuild. The divergence had already been
+fixed on main; my checkout simply predated the fix.
+
+---
+
+# Original report (retracted, kept for the record)
 ## Symptom
 
 `nros-tests::example_portability copies_within_a_group_are_identical` fails on

--- a/docs/issues/archived/0861-rust-lifecycle-autostart-node-not-active-at-boot.md
+++ b/docs/issues/archived/0861-rust-lifecycle-autostart-node-not-active-at-boot.md
@@ -2,12 +2,51 @@
 id: 861
 title: "`[lifecycle] autostart = \"active\"` does not reach `active` at boot in
   the rust workspace-features cell"
-status: open
+status: resolved
+resolution: retracted
 type: bug
 area: core, examples
 related: [phase-263, phase-264, phase-331]
 ---
 
+> **RETRACTED — not a defect.** The original report is kept below
+> unaltered, because a retraction that deletes its own evidence cannot
+> be checked.
+
+## Retracted 2026-08-28 — the run that produced this was invalid
+
+This was filed from a `just ci-matrix` run whose FIXTURES PREDATED THE TREE.
+The sweep built its artifacts at 03:19, the tree was then rebased past 04:48,
+and the old results were read as current. Re-run against fixtures matching the
+tree, it passes.
+
+That is not a flake and not a partial fix: nothing about the reported behaviour
+was real. See the retraction note at the bottom for the shared cause, which took
+all four issues from that run.
+
+## Re-check
+
+```
+$ cargo nextest run -E 'test(workspace_features::case_01_rust_lifecycle)'
+    PASS [   2.108s] (1/1) nros-tests::workspace_features_e2e workspace_features::case_01_rust_lifecycle
+     Summary [   2.121s] 1 test run: 1 passed
+```
+
+Passes in 2.1 s against freshly built native fixtures, having failed at ~30 s
+against stale ones. The autostart path works: `[lifecycle] autostart = "active"`
+does reach `active` at boot.
+
+## What I got wrong in the original analysis
+
+The report made much of the observed state printing EMPTY after `got:`, and
+proposed separating "no services registered" from "services present, state
+wrong", with a side-suspicion of the queryable-slot budget. The empty string was
+simply a node that never came up from a stale image — there was no state to
+read. Every branch of that investigation plan led nowhere.
+
+---
+
+# Original report (retracted, kept for the record)
 ## Symptom
 
 `nros-tests::workspace_features_e2e workspace_features::case_01_rust_lifecycle`

--- a/docs/issues/archived/0862-zpico-sys-no-cmake-dep-test-times-out.md
+++ b/docs/issues/archived/0862-zpico-sys-no-cmake-dep-test-times-out.md
@@ -2,12 +2,55 @@
 id: 862
 title: "`zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a
   static question"
-status: open
+status: resolved
+resolution: retracted
 type: bug
 area: testing, rmw
 related: [phase-391]
 ---
 
+> **RETRACTED — not a defect.** The original report is kept below
+> unaltered, because a retraction that deletes its own evidence cannot
+> be checked.
+
+## Retracted 2026-08-28 — the run that produced this was invalid
+
+This was filed from a `just ci-matrix` run whose FIXTURES PREDATED THE TREE.
+The sweep built its artifacts at 03:19, the tree was then rebased past 04:48,
+and the old results were read as current. Re-run against fixtures matching the
+tree, it passes.
+
+That is not a flake and not a partial fix: nothing about the reported behaviour
+was real. See the retraction note at the bottom for the shared cause, which took
+all four issues from that run.
+
+## Re-check
+
+```
+$ cargo nextest run -E 'test(zpico_sys_has_no_cmake_dep)'
+    PASS [   0.082s] (1/1) nros-tests::zpico_build_matrix zpico_sys_has_no_cmake_dep
+     Summary [   0.092s] 1 test run: 1 passed
+```
+
+**0.082 s solo, against a 60 s timeout in the sweep.** The issue's own step 1
+said to retest solo before treating the timeout as deterministic; doing that
+answers it. The machine was running a 32-way fixture build plus other agents'
+work at the time.
+
+## What I got wrong in the original analysis
+
+The core argument was wrong, and confidently so. I reasoned that "a build-graph
+question answered in 60 s is doing something other than reading the graph", and
+concluded the test probably compiles at run time — a "No compilation inside
+tests" violation worth fixing on its own. It answers in 82 ms. It reads the
+graph exactly as intended; it was starved, not misdesigned.
+
+A timeout under load is evidence about the MACHINE, not about the code. Reading
+it as a design defect produced a specific, false, and plausible-sounding claim.
+
+---
+
+# Original report (retracted, kept for the record)
 ## Symptom
 
 `nros-tests::zpico_build_matrix zpico_sys_has_no_cmake_dep` TIMEOUTs at exactly

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -49,9 +49,6 @@ fails if this block drifts.
 - **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.
 - **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
 - **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
-- **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
-- **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
-- **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
 - **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
 - **#0867** (testing, rmw) — `test_rtos_action_e2e` nuttx/C fails 3/3 SOLO — the client's goal send times out (-2) against a server sitting at its ready banner See `0867-*`.
 - **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.


### PR DESCRIPTION
## What this changes, and why

Retracts #859, #861 and #862, archives them, and adds the pitfall to `CLAUDE.md`.

All three pass on re-check against fixtures that match the tree:

| issue | filed as | re-check |
| --- | --- | --- |
| #859 | `action-server` copies diverge on four platforms | `PASS [0.008s]` |
| #861 | lifecycle autostart never reaches `active` | `PASS [2.108s]` (was ~30s FAIL) |
| #862 | `zpico_sys_has_no_cmake_dep` times out at 60s | `PASS [0.082s]` (was TIMEOUT) |

**One cause, and it is mine.** I ran `just ci-matrix`, rebased the tree past the
sweep, and then read the sweep's output as current. The artifacts were built at
03:19 and the tree moved to 04:48+, so every red reproduced a bug that had
already been fixed on main. #860 went the same way and is PR #9 (duplicate of
#857). Four issues from one run, none of them real.

The junit rewrite's `Real failures: 4 / 4` was correct about what the RUN saw.
It says nothing about HEAD, and I read it as though it did.

They are folded into one PR rather than three because they are **one finding**
with one cause; three PRs would imply three independent discoveries. This is a
deliberate exception to the one-issue-per-PR rule, made at the maintainer's
direction, and flagged here rather than left to be noticed.

### The part that would have cost someone else time

Two of the three carry a confident WRONG ROOT CAUSE, retracted explicitly in the
files:

- **#862** argued that "a build-graph question answered in 60s is doing
  something other than reading the graph" and proposed a `No compilation inside
  tests` fix. It answers in **82ms**. The machine was running a 32-way fixture
  build plus other agents' work — a timeout under load is evidence about the
  MACHINE, not the code.
- **#861** built an investigation plan around the observed state printing EMPTY
  (registered-but-wrong vs never-registered, with a queryable-budget suspicion).
  There was no state to read, because the node never came up.

A bogus issue wastes a re-run. A bogus issue with a plausible root cause aims
the next person at a dead end, which is worse.

Each file keeps its original report **verbatim** under a RETRACTED banner. A
retraction that deletes its own evidence cannot be checked.

Refs #857, #860.

---

## 1. Which lanes did you run, and what was the result?

`just ci-l1` — **passed**, exit 0, ending `CI L1 passed (compile + unit; no
fixtures were built or needed)`. Two skips, reported rather than left to read as
passes:

- `skip: generator not present … colcon-nano-ros submodule not checked out`
- `check-skip-budget: 1 skip(s) — capability=1`, noting `(no coordinate file;
  the out-of-lane assertion was NOT checked)`

The three re-checks that justify the retraction, run individually against freshly
built native fixtures (`just native build-fixtures`, rc=0):

```
cargo nextest run -E 'test(copies_within_a_group_are_identical)'          PASS 0.008s
cargo nextest run -E 'test(workspace_features::case_01_rust_lifecycle)'   PASS 2.108s
cargo nextest run -E 'test(zpico_sys_has_no_cmake_dep)'                   PASS 0.082s
```

## 2. What could you NOT verify, and why?

**I have not re-run the full tier-2 sweep**, so I cannot claim tier 2 is green.
What is established is narrower and sufficient for a retraction: these three
tests pass individually against current fixtures. Whether the whole matrix is
clean needs `just build-test-fixtures lane=tier2 && just ci-matrix` on a tree
that does not move underneath it — which is the discipline this PR is about.

#862 in particular passed **solo**. It has not been re-run under a loaded
machine, so I cannot say it will never time out in a sweep again; what I can say
is that the timeout was not the design defect the issue claimed.

The diff touches only `docs/issues/**` and `CLAUDE.md`, so no lane above L0 can
be affected by it.

## 3. Was this authored with AI assistance?

Yes, entirely — filed, investigated, and now retracted by Claude Opus 5.

This PR is the failure mode the template describes, in its pure form: four
issues that were confident, specific, internally consistent, and wrong, each
passing every gate it was subject to. Reviewing the reasoning rather than the
diff is the right emphasis here — the diff is trivial, and the claim worth
checking is that the re-checks above actually mean what I say they mean.
