### PR TITLE
fix(#832): cyclone's ddsrt heap funnels through the platform ABI, by target dependency

### DIFF
--- a/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
@@ -92,6 +92,58 @@ list: an image whose resolved model contains zero subscriptions needs zero of
 it, and that derivation needs no infrastructure accounting — unlike the
 queryable one above, the runtime creates no large-payload subscriber of its own.
 
+## Measured 2026-08-29 — the "easiest win" is NOT available with the existing knob
+
+The section above calls `LARGE_PAYLOADS` "the single easiest win ... an image
+whose resolved model contains zero subscriptions needs zero of it". Zero is
+**not expressible**. `packages/rmw/zenoh/nros-rmw-zenoh/build.rs:45`:
+
+```rust
+let max_large: usize = env_usize("ZPICO_MAX_LARGE_SUBSCRIBERS", 2).max(1);
+```
+
+The `.max(1)` floor means the smallest reachable pool is
+`1 * ZPICO_SUBSCRIBER_RING_DEPTH(4) * ZPICO_SUBSCRIBER_LARGE_SIZE(16384)` =
+**65,536 bytes**, not 0. So wiring the resolved model to this knob — the fix
+this issue proposes — buys half of what the issue claims: 131,072 -> 65,536 on
+a talker, with the other half structurally out of reach until the floor goes.
+
+MEASURED, not read — three builds of `examples/native/rust/talker`, the knob
+varied, `llvm-nm -S` on each binary:
+
+| `ZPICO_MAX_LARGE_SUBSCRIBERS` | `LARGE_PAYLOADS` |
+| ---: | ---: |
+| 2 (default) | 131,072 |
+| 1 | 65,536 |
+| **0** | **65,536** |
+
+Note the third row: asking for zero does not fail, it silently yields one. A
+codegen deriving "no subscriptions -> 0" would emit a config that reads as
+satisfied while still reserving 64 KiB — the same shape as every other defect
+this campaign has found, a value that looks applied and is not. If the floor
+stays, the knob should REJECT 0 rather than round it up.
+
+Baseline confirming the arithmetic, `just mem-report` on
+`build/cargo-fixtures/linux-14372940/nros-relwithdebinfo/talker`:
+
+```
+       131,072   35.8%  nros_rmw_zenoh::shim::subscriber::LARGE_PAYLOADS
+       131,072  LARGE_PAYLOADS  — agrees with `ZPICO_MAX_LARGE_SUBSCRIBERS *
+                                  ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE`
+```
+
+Removing the floor is not free to reason about: `.max(1)` exists so a pool
+index is always valid, and the sibling `max_nodes` floor documents exactly that
+intent ("so a session always has room for its own primary node"). A zero-length
+pool needs the *lookup* path to refuse a large subscription rather than index an
+empty array — a code change, not a knob change. Whoever takes this should price
+both halves separately: the knob wiring (65,536, mechanical) and the floor
+removal (a further 65,536, needs the refusal path).
+
+The same floor applies to `ZPICO_MAX_QUERYABLES`-style derivations. Check for it
+before quoting a saving off the inventory: the inventory prints the formula, not
+the floor.
+
 ## Reproduce
 
 ```sh

--- a/docs/issues/0872-pr-arm-example-check-needs-nros-sync.md
+++ b/docs/issues/0872-pr-arm-example-check-needs-nros-sync.md
@@ -1,0 +1,79 @@
+---
+id: 872
+title: "The PR/nightly check arm has never run to completion — each fix exposes the next environment gap"
+status: open
+area: ci
+severity: medium
+found: 2026-08-28
+related: [phase-395, 0816]
+---
+
+# The PR/nightly check arm has never run to completion
+
+## What was measured
+
+PR #7 is the first pull request through the merge queue (phase-395 W7). Its
+required check — `check (fast on push; full on PR/nightly)` — has failed seven
+times, each time on a DIFFERENT gate, each one further into the job than the
+last. The push lane runs only `check-fast`, so the PR/nightly arm's steps had
+never executed against the CI container at all; every failure below is a
+pre-existing gap that the queue's arrival made visible, not a regression from
+the PR's payload.
+
+Fixed inside PR #7 (each verified locally, most with a negative control):
+
+| # | gate | gap |
+| --- | --- | --- |
+| 1 | `check-source-gates` | the compile-check fixtures it consumes were never built by the job |
+| 2 | `compile-check-fixtures.sh` | the cmake-lane prereq probe hard-exits even when the selection contains no cmake row |
+| 3 | `check-source-gates` | bare `cargo test` counts a `skip!` panic as a failure (no junit rewrite) |
+| 4 | `check-build` | `msg_to_cyclone_idl.py` imports `rosidl_adapter` at BUILD time; the ROS env was not sourced |
+| 5 | `check-sched-dim-arms` | probes that `arm-none-eabi-gcc` EXISTS; the container's has no newlib, so every arm failed on `<string.h>` |
+
+**Rows 1-3 were fixed independently and better on `main`** (phase-395 W19/W20),
+while this branch was in flight: `check-source-gates` now builds its own
+`cxx-syntax` lane and runs through the shared `_nextest-tolerant`, and the lane
+filter short-circuits the cmake prereq probe before it can exit. Two convergent
+diagnoses of the same three defects, from opposite ends. Only rows 4 and 5
+survive in PR #7; the rest of this table is history, kept because the PATTERN is
+the finding — an arm nothing executes accumulates gaps at roughly one per gate.
+
+## Still open — the gate this issue is filed for
+
+(Whether this still reproduces under phase-395 W20's restructure is UNVERIFIED:
+the compile tier moved to `merge_group`, so the example check now runs per
+BATCH rather than per PR, and this branch has not yet been through the queue.)
+
+With those five fixed the arm reaches the example check inside `just check`,
+which reports:
+
+```
+native check: 33 example(s) are missing their generated message bindings
+```
+
+The examples' `generated/` trees are USER-side codegen (`nros sync`), absent in
+a fresh clone by design. The job builds the CLI and provisions `-sys` sources
+but never syncs any example leaf, so this gate cannot pass as the workflow
+stands. Two candidate shapes, neither yet chosen:
+
+* run `nros sync` for the leaves the check walks (cost: unmeasured), or
+* have the example check SKIP legibly when `generated/` is absent, the way the
+  cross-toolchain gates now skip — consistent with "probe what you use, skip
+  legibly, never fail on a lane you did not enter", which is the vocabulary the
+  other four fixes converged on.
+
+## Why this is not "just fix it in the PR"
+
+Each fix has been one line of insight and one round of ~25 minutes of CI. The
+payload of PR #7 (the heap-free tier image, issue 0843) is unrelated to any of
+this and is verified locally by `ci-l1` + `ci-l3` + native e2e. Continuing to
+grow that PR with workflow archaeology couples an unrelated change to an
+open-ended CI debug loop; the remaining gap is worth its own change, with the
+skip-vs-sync decision made deliberately rather than under merge pressure.
+
+## Method note
+
+`gh run view --job <id> --log-failed` truncates the failing step's own name to
+`UNKNOWN STEP` for container jobs, so the failing RECIPE has to be read out of
+the log body (`error: recipe \`X\` failed`) rather than the step header. The
+first four rounds were diagnosed that way.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-40 open. One line each — the detail lives in the issue file,
+41 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -97,6 +97,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0860** (boards, rmw) — The ESP32-C3 workspace Entry boots ESP-IDF and never reaches `Application setup complete` — first runtime look since W2 broke the build See `0860-*`.
 - **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
 - **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -107,6 +107,21 @@ seconds later, which is exactly how 0371 cost as much time as it did.
 | `22150fbf` | fix(freertos): avoid TLS-only DDS state |
 | `99cfac88` | ddsrt: give every FreeRTOS thread its lwIP per-thread netconn semaphore |
 
+### 6. The platform allocation funnel (1 commit)
+
+| commit | subject |
+| --- | --- |
+| `6e2ad36f` | ddsrt/posix: route the heap through nano-ros's platform allocation funnel |
+
+Behind `-DNROS_DDSRT_PLATFORM_FUNNEL`, set by `ProvideCycloneDDS.cmake` on
+`ddsc` only (never on the tools-side `ddsrt-internal`: idlc and confgen link no
+platform layer). Undefined, the file is byte-identical to stock, so cyclone's
+own ctest suite is unaffected. Issue 0832 measured the funnel DEFINED and
+UNREFERENCED in native cyclone images; it now has 4 inbound edges and the whole
+`ddsrt_{malloc,malloc_s,calloc_s,realloc_s,free}` family is off `malloc@plt`.
+Compile-time rather than weak-linked on purpose: weak linkage leaves the libc
+branch in the binary, and its absence is what a tier gate has to read.
+
 With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
 its own netconn semaphore. ddsrt creates its own threads and never called
 `lwip_socket_thread_init()`, so the first socket call from one asserted

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
@@ -179,26 +179,82 @@ macro(nros_provide_cyclonedds)
             # EXCLUDE_FROM_ALL: built only because nros_rmw_cyclonedds links
             # CycloneDDS::ddsc, not as part of `all`.
             add_subdirectory("${CYCLONEDDS_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds" EXCLUDE_FROM_ALL)
-            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`, not
-            # libc. Set on the ddsrt targets rather than globally: the switch is
-            # read by ONE fork TU (src/ddsrt/src/heap/*/heap.c), and a global
-            # define would also reach idlc and the confgen host tools, which
-            # link no platform layer. `ddsrt` is the object library the static
-            # `ddsc` absorbs; `ddsrt-internal` is its tools-side twin, which
-            # must NOT get the define for exactly that reason.
+            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`,
+            # not libc.
+            #
+            # The define and the LINK DEPENDENCY are one decision, made here.
+            # Compiling the funnel in turns three platform-ABI symbols into
+            # undefined references in every archive that absorbs `heap.c`, so a
+            # build that sets the define without linking a provider does not
+            # fail at the switch — it fails much later, at whichever executable
+            # happens to link ddsc first. That is why the provider is resolved
+            # BEFORE the define is set, and why the same block does both.
+            #
+            # Resolution is by target, not by guess: `NanoRos::Platform` is the
+            # Phase-138 §A canonical alias every platform module exposes, and
+            # every port defines the three symbols. When it is absent — the
+            # standalone `just cyclonedds ci` project builds the backend with no
+            # platform layer at all — the funnel stays OFF and Cyclone keeps its
+            # libc heap, which is the correct answer for a build that has no
+            # platform to funnel into. Both outcomes print, because a silently
+            # disabled funnel and an enabled one look identical from the recipe.
+            #
+            # The `unified`-tier gate (`scripts/check-no-alloc-image.py`) is what
+            # makes "off" safe to allow: it measures the linked ELF, so an image
+            # that was supposed to funnel and did not is caught there rather
+            # than trusted here.
+            #
+            # SCOPE, measured: this is the SELF-PROVISION branch, so the funnel
+            # reaches only builds that compile Cyclone from source. A
+            # find_package build links a Cyclone whose `heap.c` was already
+            # compiled — there is nothing left to define into it — and on a host
+            # with an SDK-store or ROS Cyclone that is what a NATIVE build
+            # resolves. Which is the right split for the tier model: `unified`
+            # is an embedded promise, a cross build skips find_package outright
+            # (see the CMAKE_CROSSCOMPILING branch above) and so always lands
+            # here with a platform target present.
+            #
+            # NOT a global define: the switch is read by ONE fork TU
+            # (src/ddsrt/src/heap/*/heap.c), and a global would also reach idlc
+            # and the confgen host tools, which link no platform layer.
             # `ddsrt` is an INTERFACE target in this layout — its sources
-            # compile INSIDE `ddsc`, so that is where the define has to land.
-            # `ddsrt-internal` (the tools-side twin that idlc/confgen link) is
-            # deliberately left alone: those hosts link no platform layer.
-            foreach(_nros_cdds_tgt ddsc ddsrt)
-                if(TARGET ${_nros_cdds_tgt})
-                    get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
-                    if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
-                        target_compile_definitions(${_nros_cdds_tgt}
-                            PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+            # compile INSIDE `ddsc`, so that is where both the define and the
+            # dependency have to land. `ddsrt-internal` (the tools-side twin
+            # idlc/confgen link) is deliberately left alone for the same reason.
+            if(TARGET NanoRos::Platform)
+                foreach(_nros_cdds_tgt ddsc ddsrt)
+                    if(TARGET ${_nros_cdds_tgt})
+                        get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
+                        if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
+                            target_compile_definitions(${_nros_cdds_tgt}
+                                PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+                            # PUBLIC: the reference lives in ddsc's own objects,
+                            # and consumers must get the provider AFTER ddsc on
+                            # the link line. Expressing it as a dependency is
+                            # what orders it — the alternative (a weak fallback
+                            # definition) would resolve the reference by
+                            # reintroducing the libc heap this issue exists to
+                            # remove, which the issue-0050 audit has no legal
+                            # `body:` label for.
+                            #
+                            # `$<BUILD_INTERFACE:>` because Cyclone `install
+                            # (EXPORT)`s `ddsc`, and an exported target may not
+                            # name a dependency outside its own export set —
+                            # without the genex, configure dies with "requires
+                            # target nros_platform_posix_iface that is not in
+                            # any export set". We never install this Cyclone
+                            # (it is added EXCLUDE_FROM_ALL and consumed from
+                            # the build tree), so the dependency is exactly a
+                            # build-tree one and the genex says so.
+                            target_link_libraries(${_nros_cdds_tgt}
+                                PUBLIC $<BUILD_INTERFACE:NanoRos::Platform>)
+                        endif()
                     endif()
-                endif()
-            endforeach()
+                endforeach()
+                message(STATUS "nano-ros: CycloneDDS ddsrt heap -> nros_platform_alloc (issue 0832)")
+            else()
+                message(STATUS "nano-ros: CycloneDDS ddsrt heap -> libc (no NanoRos::Platform target to funnel into)")
+            endif()
             # Where Cyclone generated its headers (dds/config.h, version.h, …) —
             # the backend needs this on the source path (see CMakeLists.txt).
             set(NROS_CYCLONEDDS_SOURCE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds")

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
@@ -179,6 +179,26 @@ macro(nros_provide_cyclonedds)
             # EXCLUDE_FROM_ALL: built only because nros_rmw_cyclonedds links
             # CycloneDDS::ddsc, not as part of `all`.
             add_subdirectory("${CYCLONEDDS_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds" EXCLUDE_FROM_ALL)
+            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`, not
+            # libc. Set on the ddsrt targets rather than globally: the switch is
+            # read by ONE fork TU (src/ddsrt/src/heap/*/heap.c), and a global
+            # define would also reach idlc and the confgen host tools, which
+            # link no platform layer. `ddsrt` is the object library the static
+            # `ddsc` absorbs; `ddsrt-internal` is its tools-side twin, which
+            # must NOT get the define for exactly that reason.
+            # `ddsrt` is an INTERFACE target in this layout — its sources
+            # compile INSIDE `ddsc`, so that is where the define has to land.
+            # `ddsrt-internal` (the tools-side twin that idlc/confgen link) is
+            # deliberately left alone: those hosts link no platform layer.
+            foreach(_nros_cdds_tgt ddsc ddsrt)
+                if(TARGET ${_nros_cdds_tgt})
+                    get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
+                    if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
+                        target_compile_definitions(${_nros_cdds_tgt}
+                            PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+                    endif()
+                endif()
+            endforeach()
             # Where Cyclone generated its headers (dds/config.h, version.h, …) —
             # the backend needs this on the source path (see CMakeLists.txt).
             set(NROS_CYCLONEDDS_SOURCE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds")

--- a/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
@@ -34,7 +34,7 @@ fn main() {
     // Phase 124.D.3.c — SPSC ring depth per subscriber. Default 4
     // keeps the static-RAM bump small (4 × SUBSCRIBER_BUFFER_SIZE
     // per subscriber); raise for burst-heavy topics. Must be ≥ 1.
-    let ring_depth: usize = env_usize("ZPICO_SUBSCRIBER_RING_DEPTH", 4).max(1);
+    let ring_depth: usize = env_usize_min("ZPICO_SUBSCRIBER_RING_DEPTH", 4, 1);
     // Phase 231 (RFC-0038) — size-class receive buffers. `SUBSCRIBER_BUFFER_SIZE`
     // above is the `small` class slot size; the `large` class is for big
     // messages (images, point clouds). A subscription routes to `large` when its
@@ -42,13 +42,13 @@ fn main() {
     // so the big slots don't multiply across every subscriber.
     let large_size: usize = env_usize("ZPICO_SUBSCRIBER_LARGE_SIZE", 16384);
     let size_threshold: usize = env_usize("ZPICO_SUBSCRIBER_SIZE_THRESHOLD", 2048);
-    let max_large: usize = env_usize("ZPICO_MAX_LARGE_SUBSCRIBERS", 2).max(1);
+    let max_large: usize = env_usize_min("ZPICO_MAX_LARGE_SUBSCRIBERS", 2, 1);
     // Phase 268 — per-session per-node NN liveliness token cap. One zenoh
     // session hosts at most the executor's node cap of graph nodes, so this
     // tracks `nros-node`'s `NROS_EXECUTOR_MAX_NODES` (default 4); keep them in
     // sync — set the same env var for both. `.max(1)` so a session always has
     // room for its own primary node.
-    let max_nodes: usize = env_usize("NROS_EXECUTOR_MAX_NODES", 4).max(1);
+    let max_nodes: usize = env_usize_min("NROS_EXECUTOR_MAX_NODES", 4, 1);
     // Issue 0813 — per-publisher TX arena capacity for the zero-copy loan path
     // (`SlotLending`). This was a bare `const` in `shim/publisher.rs`, so its
     // 1 KiB ceiling was neither raisable by a consumer nor visible to
@@ -116,6 +116,39 @@ const KCONFIG_KNOBS: &[(&str, &str)] = &[
         "CONFIG_NROS_SERVICE_BUFFER_SIZE",
     ),
 ];
+
+/// issue 0827 — a floored knob must REFUSE a value below its floor, never
+/// round it up.
+///
+/// These three pools cannot be zero-length: the lookup paths index them
+/// unconditionally, which is what the `.max(1)` this replaces was protecting.
+/// But `.max(1)` protected it by SILENTLY substituting 1, so
+/// `ZPICO_MAX_LARGE_SUBSCRIBERS=0` built a 65,536-byte pool and reported
+/// nothing — measured on `examples/native/rust/talker`, knob 0 and knob 1
+/// produce byte-identical `LARGE_PAYLOADS`.
+///
+/// That matters now because 0827's fix derives these knobs from the resolved
+/// model: an image with no subscriptions would ask for 0, get 1, and reserve
+/// 64 KiB while every config file and inventory line read as satisfied. A knob
+/// that cannot honour a value has to say so at BUILD time, where the person
+/// who set it is standing — the alternative is a saving that looks applied and
+/// is not, which is the defect class this campaign keeps finding.
+///
+/// Unset stays silent: the defaults are all above the floor.
+fn env_usize_min(name: &str, default: usize, min: usize) -> usize {
+    let v = env_usize(name, default);
+    if v < min {
+        panic!(
+            "{name}={v} is below this pool's floor of {min}.\n  \
+             The lookup path indexes the pool unconditionally, so a shorter one \
+             is not representable — raise the value, or change the lookup to \
+             refuse the entity kind first (issue 0827).\n  \
+             This used to be silently rounded up to {min}, which reserved the \
+             memory anyway while reading as though the knob had been honoured."
+        );
+    }
+    v
+}
 
 fn env_usize(name: &str, default: usize) -> usize {
     match KCONFIG_KNOBS.iter().find(|(env, _)| *env == name) {

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -60,6 +60,16 @@ KNOB_PATTERNS = [
     # wrapper is the natural thing to write when several knobs share a
     # resolution rule, so match the shape rather than asking each crate not to.
     re.compile(r'\bknob\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*\)'),
+    # `env_usize_min("NAME", default, floor)` — a knob whose reader REFUSES a
+    # value below a floor instead of silently rounding it up (issue 0827). The
+    # reported figure is the DEFAULT, exactly as for every other spelling: the
+    # floor is a validity rule on what a user may ask for, not a size the image
+    # pays. Added with the spelling, not after it: renaming the two zpico reads
+    # to this wrapper made `ZPICO_SUBSCRIBER_RING_DEPTH` and
+    # `ZPICO_MAX_LARGE_SUBSCRIBERS` invisible here, and with them the byte
+    # figures for BOTH payload pools -- the `SLOTS` regression this list already
+    # records, one wrapper later.
+    re.compile(r'\benv_usize_min\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*,\s*[0-9_]+\s*\)'),
 ]
 
 # `// nros-pool: NAME = KNOB * KNOB * 4` — products of knobs and integers only.
@@ -90,7 +100,7 @@ def crate_of(rel):
 # the ones issue-0271's failure mode hides (executor arena, zpico batch/frag
 # buffers: the LARGEST consumers). They must appear in the table, not be
 # silently dropped by a literal-only regex.
-KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat)?|knob)\(\s*"([A-Z0-9_]+)"')
+KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat|_min)?|knob)\(\s*"([A-Z0-9_]+)"')
 
 
 def scan(files=None):
@@ -222,7 +232,15 @@ def self_test():
     assert got == 128 and err is None, f"product at defaults wrong: {got} {err}"
     got, err = pool_bytes("A * NOPE", knobs)
     assert got is None and "NOPE" in err, "an unknown knob must not silently vanish"
-    probe = 'let x = env_usize("NROS_PROBE_SLOTS", 12);\n// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
+    # Every reader spelling gets a probe line. A spelling with no case here is
+    # a spelling that can be added, break the scan, and still self-test green —
+    # which is how `env_usize_min` deleted two knobs and two pool figures.
+    probe = (
+        'let x = env_usize("NROS_PROBE_SLOTS", 12);\n'
+        'let y = env_usize_min("NROS_PROBE_DEPTH", 3, 1);\n'
+        '// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
+        '// nros-pool: Q = NROS_PROBE_DEPTH * NROS_PROBE_SLOTS\n'
+    )
     tmp = os.path.join(ROOT, "tmp")
     os.makedirs(tmp, exist_ok=True)
     p = os.path.join(tmp, "_pool_probe.rs")
@@ -231,8 +249,16 @@ def self_test():
     k, pl = scan([os.path.relpath(p, ROOT)])
     os.unlink(p)
     assert k.get("NROS_PROBE_SLOTS", (None,))[0] == 12, "knob not scanned"
-    assert pl and pl[0][0] == "P", "pool annotation not scanned"
-    assert pool_bytes(pl[0][1], k)[0] == 96, "annotated pool bytes wrong"
+    assert k.get("NROS_PROBE_DEPTH", (None,))[0] == 3, (
+        "env_usize_min knob not scanned — its DEFAULT is the reported figure, "
+        "not its floor (issue 0827)"
+    )
+    by_name = {name: expr for name, expr, *_ in pl}
+    assert "P" in by_name, "pool annotation not scanned"
+    assert pool_bytes(by_name["P"], k)[0] == 96, "annotated pool bytes wrong"
+    assert pool_bytes(by_name["Q"], k)[0] == 36, (
+        "a pool sized by an env_usize_min knob must resolve to bytes"
+    )
     sys.stdout.write("gen-pool-inventory self-test: OK\n")
 
 


### PR DESCRIPTION
**Stacked on #7** (`fix/heap-free-tier-gate`) — a PR off `main` would hit the same five required-check failures #7 is fixing.

Routes cyclone's `ddsrt` heap through `nros_platform_alloc` behind a compile-time switch set on `ddsc` only.

**Measured** — `examples/native/c/talker/build-cyclonedds/c_talker`, rebuilt via `just build-test-fixtures lane=native`, objdump caller attribution counting `call` AND `jmp` (the issue's own method note):

| | malloc@plt callers | funnel inbound edges |
| --- | --- | --- |
| before | `ddsi_config_init`, `ddsrt_malloc`, `ddsrt_malloc_s`, `network_interface_find_or_append`, `nros_platform_alloc` | 0 |
| after | `ddsi_config_init`, `network_interface_find_or_append`, `nros_platform_alloc` | 4 |

Compile-time, not weak linkage: weak keeps both branches in the binary, and the libc edge's *absence* is what a tier gate reads.

**Not fixed here** (0832 stays open): the two survivors are one bare `malloc` at `ddsi_config.c:2349` and its inlining. Editing that file re-runs cyclone's `_confgen`, which resolves `${CMAKE_SOURCE_DIR}/cmake/AppendHashScript.cmake` against *our* root in the nested `add_subdirectory` build and dies — a latent vendoring bug worth its own fix.

**Also measured:** 0832's XRCE half is already resolved — that image's only `malloc@plt` caller is the funnel, and `get_ip_from_iface` (a zenoh-pico TU, not XRCE as the issue's table records) calls through it.

Fork commit `6e2ad36f` pushed to `NEWSLabNTU/cyclonedds` `nano-ros` before the pin bump, per the vendored-fork workflow; delta doc updated. Also carries issue #872 documenting the CI-arm gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)