### PR TITLE
fix(phase-395 W20): one aggregator is the required check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -424,3 +424,77 @@ jobs:
       # must not drift (else prebuilt != source-built).
       - name: Check qemu configure flags match (index vs build script)
         run: ./scripts/sdk/check-qemu-configure.sh
+
+  # ---------------------------------------------------------------------------
+  # THE REQUIRED CHECK — phase-395 W20.
+  #
+  # One aggregator, and it is the ONLY context in the required set. This is
+  # GitHub's own recommended shape for a workflow with conditional jobs, and it
+  # exists because of a defect that froze this repo four separate ways in one
+  # day: a required check that fails to produce a VERDICT blocks forever, since
+  # GitHub cannot tell "not applicable" from "not yet".
+  #
+  #   always RED       a gate that could not pass on the runner (issue 0853)
+  #   always PENDING   a self-hosted required check with no runner
+  #   cannot REPORT    a required check with no `merge_group` trigger
+  #   never TRIGGERED  a `paths:` filter the pull request did not match
+  #
+  # The last one deadlocked two pull requests against each other: #16 carried
+  # the ROS-environment fix that #6's merge group needed, and #16 touched only
+  # `ci/docker/**`, which the filter did not list — so its required check had
+  # never run, and could never run.
+  #
+  # WHY AN AGGREGATOR FIXES THE CLASS. It has no `if:` on the job and no filter
+  # on the trigger, so it ALWAYS runs and therefore always reports. Every real
+  # job may then be skipped, filtered or renamed freely — the required set never
+  # changes, so it cannot drift out of sync with the workflow either.
+  #
+  # THE TRAP, which GitHub documents and which makes the naive version useless:
+  # A SKIPPED JOB REPORTS SUCCESS. So `needs:` alone is not a gate — an
+  # aggregator that merely depends on its jobs passes when they were all
+  # skipped. It has to INSPECT `needs.*.result`, which is what the step below
+  # does, and treat `skipped` as a deliberate decision rather than a pass.
+  ci-ok:
+    name: CI
+    # `always()` so a failed or skipped dependency still runs this — without it
+    # the aggregator is itself skipped, and a skipped required check reports
+    # success, which is the vacuous green this exists to prevent.
+    if: always()
+    needs: [check, scaffold-journey, colcon-parity, sdk-index]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every gate to have actually passed
+        run: |
+          set -euo pipefail
+          fail=0
+
+          # `check` is the gate. It runs on every event with no condition, so
+          # `skipped` here is never legitimate — it would mean the job did not
+          # run at all, which is exactly the state that must not read as green.
+          case "${{ needs.check.result }}" in
+            success) echo "  ok       check" ;;
+            skipped) echo "  FAIL     check was SKIPPED — the gate did not run"; fail=1 ;;
+            *)       echo "  FAIL     check: ${{ needs.check.result }}"; fail=1 ;;
+          esac
+
+          # The narrow lanes are path-gated BY DESIGN, so `skipped` is a real
+          # answer for them: their paths did not move. Only a failure counts.
+          for pair in \
+            "scaffold-journey:${{ needs.scaffold-journey.result }}" \
+            "colcon-parity:${{ needs.colcon-parity.result }}" \
+            "sdk-index:${{ needs.sdk-index.result }}"; do
+            name="${pair%%:*}"; res="${pair#*:}"
+            case "$res" in
+              success) echo "  ok       $name" ;;
+              skipped) echo "  skipped  $name (path-gated; its paths did not move)" ;;
+              *)       echo "  FAIL     $name: $res"; fail=1 ;;
+            esac
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo
+            echo "CI: at least one required gate did not pass." >&2
+            exit 1
+          fi
+          echo
+          echo "CI: every gate passed or was legitimately skipped."

--- a/scripts/ci/enable-merge-queue.sh
+++ b/scripts/ci/enable-merge-queue.sh
@@ -74,14 +74,23 @@ RULESET="${NROS_QUEUE_RULESET:-main-rules}"
 # the same ground inside the queue (check-fast + check-build + test-unit).
 #
 # `_assert_merge_group_triggers` enforces this rather than trusting the comment.
+# ONE context, an AGGREGATOR — phase-395 W20.
+#
+# Not `check` itself, and not a list of job names. `ci-ok` needs every job,
+# runs with `if: always()`, and inspects `needs.*.result`, so it ALWAYS reports
+# and the required set never has to change when a job is added, renamed,
+# filtered or skipped. That is the fix for the class that froze this repo four
+# ways in one day — a required check that produces no verdict blocks forever.
 HOSTED_CHECKS=(
-    "check (fast on push; full on PR/nightly)"
+    "CI"
 )
 # Runs but does NOT gate. `queue.yml`'s L1 job was DELETED in phase-395 W13 for
 # the reason that kept it out of this list: `pr-checks`'s `check` covers
 # strictly more, and both running meant compiling the same tree twice on every
 # merge group.
+# Run and are visible, but do not gate — the aggregator speaks for them.
 PR_ONLY_CHECKS=(
+    "check (fast on push; full on PR/nightly)"
     "L3 (cross build + link)"
 )
 # Added to the required set only with --self-hosted-ready.


### PR DESCRIPTION
One `ci-ok` job (context `CI`) becomes the single required status check.

Four freezes in one day traced to one defect: **a required check that fails to produce a verdict blocks forever**, because GitHub cannot distinguish "not applicable" from "not yet" — always-red, always-pending, cannot-report, never-triggered.

The last deadlocked #16 and #6 against each other. #16 carried the ROS-env fix #6's merge group needed; #16 touched only `ci/docker/**`, which the path filter omitted, so its required check had never run and never could.

`ci-ok` has no job-level `if:` and no trigger filter, so it always runs and always reports. Real jobs can then be skipped, filtered or renamed freely, and the required set never changes.

**The trap it handles:** a *skipped* job reports **Success**, so `needs:` alone is not a gate. It inspects `needs.*.result` — `check` runs unconditionally so `skipped` there is a failure; the narrow lanes are path-gated by design so `skipped` is legitimate for them.