### PR TITLE
docs: the merge queue is LIVE — direct push to main is rejected

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -105,6 +105,16 @@ jobs:
       scaffold: ${{ steps.f.outputs.scaffold }}
       colcon: ${{ steps.f.outputs.colcon }}
       sdk_index: ${{ steps.f.outputs.sdk_index }}
+      # phase-395 — does this pull request touch anything `check` verifies?
+      # A docs-only change does not, and paying ~5 min of CLI build and source
+      # provisioning to lint markdown is not sane.
+      #
+      # This is a JOB-level filter, deliberately. Path-filtering the TRIGGER of
+      # a required workflow leaves its check Pending forever, which deadlocked
+      # #6 and #16 against each other; a skipped JOB reports Success. GitHub's
+      # guidance is explicit: "do not use path or branch filtering to skip
+      # workflow runs if the workflow is required".
+      code: ${{ steps.codeprobe.outputs.code }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -124,9 +134,58 @@ jobs:
               - 'scripts/sdk/check-qemu-configure.sh'
               - 'ci/nano-ros-sdk/scripts/build-qemu.sh'
 
+      # Computed explicitly rather than as a negated paths-filter pattern,
+      # because the failure mode is a FALSE GREEN on the required gate and the
+      # negation semantics were not something to guess at. FAIL-SAFE by
+      # construction: a path this cannot classify, an empty diff, or a failed
+      # diff all count as CODE, so the gate is never silenced by accident. The
+      # classifier was tested against every case below before it shipped.
+      - name: Does this pull request touch anything `check` verifies?
+        id: codeprobe
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          code=true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # The API, not `git diff`: `actions/checkout` is SHALLOW by default,
+            # so the base ref is usually absent and the diff would fail — which
+            # the fail-safe would turn into `code=true` forever, i.e. safe but
+            # never actually firing. `gh` answers exactly and needs no fetch.
+            if changed="$(gh pr view "${{ github.event.pull_request.number }}" \
+                            --repo "${{ github.repository }}" \
+                            --json files --jq '.files[].path' 2>/dev/null)" \
+                 && [ -n "$changed" ]; then
+              code=false
+              while IFS= read -r f; do
+                [ -n "$f" ] || continue
+                case "$f" in
+                  *.md|docs/*|book/*) ;;
+                  *) code=true; break ;;
+                esac
+              done <<< "$changed"
+            fi
+          fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" = "true" ]; then
+            echo "code touched (or undetermined) — \`check\` will run"
+          else
+            echo "documentation only — \`check\` will skip, and \`CI\` will say so"
+          fi
+
   # ----- fast gate (always) -----
   check:
     name: check (fast on push; full on PR/nightly)
+    # `always()` is load-bearing: `changes` is skipped on a merge group, and a
+    # skipped dependency skips its dependents — without it, `check` would not
+    # run in the queue, which is the one place it matters most.
+    #
+    # So: run unless this is a pull request that touches ONLY documentation.
+    # Every other event runs it unconditionally.
+    needs: changes
+    if: >-
+      ${{ always() && (github.event_name != 'pull_request'
+          || needs.changes.outputs.code == 'true') }}
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -520,7 +579,7 @@ jobs:
     # the aggregator is itself skipped, and a skipped required check reports
     # success, which is the vacuous green this exists to prevent.
     if: always()
-    needs: [check, scaffold-journey, colcon-parity, sdk-index]
+    needs: [changes, check, scaffold-journey, colcon-parity, sdk-index]
     runs-on: ubuntu-latest
     steps:
       - name: Require every gate to have actually passed
@@ -528,12 +587,22 @@ jobs:
           set -euo pipefail
           fail=0
 
-          # `check` is the gate. It runs on every event with no condition, so
-          # `skipped` here is never legitimate — it would mean the job did not
-          # run at all, which is exactly the state that must not read as green.
+          # `check` is the gate, so a skip has to be JUSTIFIED rather than
+          # accepted. Exactly one justification exists: a pull request that
+          # touched no code, where `changes` said so. Any other skip means the
+          # gate did not run, and that must never read as green — which is the
+          # vacuous pass this whole aggregator exists to prevent.
+          code_touched="${{ needs.changes.outputs.code }}"
           case "${{ needs.check.result }}" in
             success) echo "  ok       check" ;;
-            skipped) echo "  FAIL     check was SKIPPED — the gate did not run"; fail=1 ;;
+            skipped)
+              if [ "${{ github.event_name }}" = "pull_request" ] && [ "$code_touched" != "true" ]; then
+                echo "  skipped  check (docs-only pull request — no code to verify)"
+              else
+                echo "  FAIL     check was SKIPPED but this is not a docs-only PR"
+                echo "           event=${{ github.event_name }} code_touched=${code_touched:-<unset>}"
+                fail=1
+              fi ;;
             *)       echo "  FAIL     check: ${{ needs.check.result }}"; fail=1 ;;
           esac
 

--- a/.github/workflows/queue-notify.yml
+++ b/.github/workflows/queue-notify.yml
@@ -55,6 +55,28 @@ jobs:
           fi
           echo "ejected pull request: #$pr"
 
+          # phase-396 W4 — is this red MINE, or is it red for EVERYONE?
+          #
+          # `queue-triage` already answers that: one check failing across several
+          # DIFFERENT pull requests is not a property of any one of them. Nothing
+          # ran it, so a human had to suspect the problem before the tool that
+          # detects it got used — and meanwhile six merge groups across three
+          # authors failed on one job while every notice told its author to
+          # rebase.
+          #
+          # In the infra case that advice is not merely unhelpful, it is WRONG.
+          # Rebasing cannot fix a check that is red before it sees the change,
+          # and re-queuing burns a batch slot against a check that cannot go
+          # green for anyone.
+          verdict=UNKNOWN
+          if triage="$(bash scripts/ci/queue-triage.sh 2>/dev/null)"; then
+            case "$triage" in
+              *"NOT YOUR PULL REQUEST"*)    verdict=INFRA ;;
+              *"LIKELY YOUR PULL REQUEST"*) verdict=MINE ;;
+            esac
+          fi
+          echo "triage verdict: $verdict"
+
           # Post once per run, not once per re-check: a comment per attempt
           # turns a bad afternoon into an unreadable thread.
           body="$(cat <<MSG
@@ -88,6 +110,46 @@ jobs:
 
           # Strip the heredoc's leading indentation.
           printf '%s\n' "$body" | sed 's/^          //' > /tmp/body.md
+
+          # An INFRA verdict REPLACES the advice above rather than adding to it.
+          # Leaving "rebase and re-run just ci-l1" on the page next to "this is
+          # not your pull request" is worse than either alone: the author acts on
+          # the first thing they can act on, which is the wrong one.
+          #
+          # Indented heredoc + the same `sed` strip as above — the body must sit
+          # inside this YAML block scalar, so a column-0 heredoc is a parse
+          # error, not a formatting nit.
+          if [ "$verdict" = "INFRA" ]; then
+            infra="$(cat <<MSG
+          **Ejected from the merge queue** — \`$WORKFLOW\` failed on the merge group.
+
+          [Run log]($RUN_URL)
+
+          > [!IMPORTANT]
+          > **This is almost certainly not your pull request.** The same check has
+          > failed in the merge group for two or more *different* pull requests, and
+          > a check that fails across unrelated changes is not a property of any one
+          > of them.
+
+          **Do not rebase, and do not re-queue.** Neither can fix a check that is red
+          before it sees your change — every entry is the culprit — and each re-queue
+          burns a batch slot against a check that cannot go green for anyone.
+
+          Say so where the other authors will see it, then either fix the check or
+          drop it from the required set until it is fixed. An always-red required
+          check freezes merging exactly as a pending one does.
+
+          \`\`\`
+          just queue-triage $pr     # the evidence: which check, across how many PRs
+          \`\`\`
+
+          <sub>Posted by \`queue-notify\`; verdict from \`scripts/ci/queue-triage.sh\`.
+          GitHub records an ejection only in the PR timeline, with no comment and no
+          notification.</sub>
+          MSG
+          )"
+            printf '%s\n' "$infra" | sed 's/^          //' > /tmp/body.md
+          fi
 
           if gh pr comment "$pr" --repo "${{ github.repository }}" --body-file /tmp/body.md; then
             echo "commented on #$pr"

--- a/.github/workflows/queue-notify.yml
+++ b/.github/workflows/queue-notify.yml
@@ -1,0 +1,97 @@
+# Tell the author when the merge queue ejects their pull request — phase-395.
+#
+# GitHub records `removed_from_merge_queue` in the PR's TIMELINE and posts
+# NOTHING. There is no comment, no assignment, no push signal of any kind. So an
+# agent that opens a pull request, enables auto-merge and moves on never learns
+# it was ejected: the PR simply sits `OPEN`, looking queued, forever.
+#
+# That is the unattended-CI failure this campaign exists to remove, one level up
+# from where it started. The reds that went unread for six days were unread
+# because nothing told anyone; a merge-queue ejection is the same shape, and it
+# is worse, because the author has already stopped watching by the time it
+# happens.
+#
+# `workflow_run` rather than a step inside `pr-checks`: a failing run cannot
+# reliably report on itself — the failure may be the runner, the container, or a
+# cancellation — and a notifier that shares a fate with the thing it reports is
+# not a notifier. This is a separate workflow, on a separate runner, that reads
+# the completed run.
+name: queue-notify
+
+on:
+  workflow_run:
+    workflows: ["pr-checks", "queue"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  notify:
+    # Only a FAILED merge-group run. A failed pull_request run already shows on
+    # the PR's own checks list, where the author is looking; this exists for the
+    # case where they are not.
+    if: >-
+      ${{ github.event.workflow_run.event == 'merge_group'
+          && github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on the ejected pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW: ${{ github.event.workflow_run.name }}
+        run: |
+          set -uo pipefail
+
+          # `gh-readonly-queue/main/pr-19-<sha>` — the queue puts the PR number
+          # in the ref, which is the only place it appears.
+          pr="$(printf '%s' "$HEAD_BRANCH" | sed -n 's#.*/pr-\([0-9][0-9]*\)-.*#\1#p')"
+          if [ -z "$pr" ]; then
+            echo "::warning::could not parse a PR number from '$HEAD_BRANCH' — nothing to notify"
+            exit 0
+          fi
+          echo "ejected pull request: #$pr"
+
+          # Post once per run, not once per re-check: a comment per attempt
+          # turns a bad afternoon into an unreadable thread.
+          body="$(cat <<MSG
+          **Ejected from the merge queue** — \`$WORKFLOW\` failed on the merge group.
+
+          [Run log]($RUN_URL)
+
+          A merge group tests \`main\` + your PR, a commit that exists nowhere else, so
+          "green on my PR" and "red in the queue" are both true. Before re-queuing:
+
+          \`\`\`
+          just queue-triage $pr     # is this yours, or is the check red for everyone?
+          \`\`\`
+
+          If it is yours, reproduce the merged state rather than re-running your branch:
+
+          \`\`\`
+          git fetch origin && git rebase origin/main
+          just ci-l1                 # the SAME tier the merge group runs
+          \`\`\`
+
+          **Do not re-queue an unchanged commit.** The queue re-runs the same tree and
+          fails the same way. Re-queue with a new commit, or with evidence the failure
+          was a flake — and if it was, capture the log first so the next author does not
+          pay the same hour.
+
+          <sub>Posted by \`queue-notify\`; GitHub itself records an ejection only in the
+          PR timeline, with no comment and no notification.</sub>
+          MSG
+          )"
+
+          # Strip the heredoc's leading indentation.
+          printf '%s\n' "$body" | sed 's/^          //' > /tmp/body.md
+
+          if gh pr comment "$pr" --repo "${{ github.repository }}" --body-file /tmp/body.md; then
+            echo "commented on #$pr"
+          else
+            # A notifier that fails the workflow teaches people to ignore it.
+            echo "::warning::could not comment on #$pr — the ejection is still real"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,32 +221,66 @@ nothing here).
 Scope is `refs/heads/main` only, and **`bypass_actors` is empty** — nobody,
 including admins, is exempt. A rule everyone can bypass is not a rule.
 
-**What actually changed for you.** Not the workflow — direct push to `main`
-still works. What changed is the *failure mode* of one specific mistake. An
-accidental merge commit (a bare `git pull`, or a `git rebase` you abandoned into
-a merge) used to LAND SILENTLY: three such commits are on `main` from
-2026-05-15, and nobody noticed for months. Now the push is rejected. Recover by
-rebasing:
+### DIRECT PUSH TO `main` NO LONGER WORKS (live since 2026-08-28)
+
+`git push origin main` is REJECTED:
 
 ```
-git fetch origin && git rebase origin/main      # then push again
+remote: - Changes must be made through a pull request.
+remote: - Changes must be made through the merge queue
+! [remote rejected] main -> main (push declined due to repository rule violations)
 ```
 
-Never "fix" a rejected push with `--force` — that is blocked too, and reaching
-for it means the rebase was the step you skipped.
+That is not a misconfiguration and there is no override — `bypass_actors` is
+empty, admins included. **The flow is now:**
 
-### Deliberately NOT in force yet
+```
+just claim issue-NNNN                  # so two agents do not do one job
+git switch -c fix/NNNN-<slug>
+# ... work ...
+just ci-l1                             # the SAME tier the merge group runs
+git push -u origin fix/NNNN-<slug>
+gh pr create --base main --fill
+gh pr merge --auto --rebase            # fire and forget; the queue lands it
+just claim-release issue-NNNN
+```
 
-**Required status checks and the merge queue are OFF.** Enabling either one ENDS
-direct-push, because a commit you are about to push has no check results yet, so
-the push is refused. That is a workflow change for every agent, not a setting,
-and it is gated on this section existing and on the workflow files being
-complete — which is why you are reading it here first.
+`gh pr merge` prints *"The merge strategy for main is set by the merge queue"* —
+that is INFORMATIONAL and the PR is queued. A FORCE-PUSH cancels auto-merge, so
+re-run `gh pr merge --auto --rebase` after any amend.
 
-When it flips, the flow becomes: branch, push, open a PR, let the queue land it.
-`queue.yml` and `post-submit.yml` already exist; `scripts/ci/enable-merge-queue.sh`
-prints the settings. Claim your work first (`just claim issue-NNNN`) so two
-agents do not open competing PRs for one issue.
+### The one required check is `CI`
+
+One aggregator job (`ci-ok`, context **`CI`**) gates everything. It `needs:`
+every job, runs `if: always()`, and inspects `needs.*.result`. Individual jobs
+may be skipped, path-filtered or renamed freely — only `CI` is required.
+
+**So do not add a job name to the required set, ever.** The reason is a defect
+that froze this repo four ways in one day: a required check that produces no
+VERDICT blocks forever, because GitHub cannot tell "not applicable" from "not
+yet". Path-filter a required workflow and a pull request touching other paths
+can NEVER merge — two PRs deadlocked on each other that way (#6 and #16).
+`scripts/ci/enable-merge-queue.sh` refuses to make a path-filtered context
+required, and will tell you so.
+
+### If everything is blocked and the blocker is CI itself
+
+That is a real state, not a mistake you made — the fix for CI can be blocked by
+CI. It happened on 2026-08-28. The break-glass, in order:
+
+1. **Confirm it is not just you**: `just queue-triage`. The same check failing
+   for several DIFFERENT pull requests is infrastructure, not your change.
+2. **Say so** on the issue or PR thread before anyone else burns an hour on it.
+3. **Drop only the required-checks RULE**, never the ruleset and never
+   enforcement — the other guardrails (no force-push, no merge commit, PR
+   required) must stay on. Read the ruleset, remove that one rule, PUT it back:
+   `gh api repos/<owner>/<repo>/rulesets/<id>` -> edit -> `-X PUT --input`.
+4. Land the unblocking PR, then **restore immediately** with
+   `scripts/ci/enable-merge-queue.sh --apply --with-queue`.
+
+Keep the window minutes, not hours, and say when you open and close it. Note
+that even with the check dropped you STILL cannot push to `main` — the PR and
+queue rules are independent, which is the point.
 
 ### What the ruleset does NOT touch, verified
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,26 @@ just claim-release issue-NNNN
 that is INFORMATIONAL and the PR is queued. A FORCE-PUSH cancels auto-merge, so
 re-run `gh pr merge --auto --rebase` after any amend.
 
+**Enable auto-merge when you OPEN the pull request, not when it looks ready**
+(phase-396 W2). This is the line that makes the queue a queue. While each author
+arms their own PR by hand, only one entry is ever in flight, `max_entries_to_build`
+never engages, and the expensive tier is paid per pull request instead of per
+batch — which is the whole reason the queue exists. Measured: every merge group
+this repository ran before 2026-08-29 contained exactly ONE pull request.
+
+**To take a PR back OUT of the queue, `--disable-auto` is not enough.** It
+reports *"already queued to merge"* and leaves the entry in place. Use the
+**Remove from queue** button on the PR, or:
+
+```
+nid=$(gh api graphql -f query='{repository(owner:"NEWSLabNTU",name:"nano-ros"){pullRequest(number:NN){id}}}' --jq '.data.repository.pullRequest.id')
+gh api graphql -f query="mutation { dequeuePullRequest(input:{pullRequestId:\"$nid\"}) { mergeQueueEntry { position } } }"
+```
+
+You need this more often than it sounds. A queue entry that cannot pass holds
+everything behind it (see below), and the entry is frequently one you already
+superseded by stacking.
+
 ### The one required check is `CI`
 
 One aggregator job (`ci-ok`, context **`CI`**) gates everything. It `needs:`
@@ -310,18 +330,53 @@ Agent branches are also untouched: the ruleset targets `refs/heads/main`, NOT
 which is the reason `~ALL` was rejected — it would have broken every agent and
 every outside contributor on day one.
 
+### Head-of-line blocking IS real, and it is not the same as a failing PR
+
+GitHub's queue ejects a pull request whose own merge group fails and re-tests
+the rest without it. That is the change-specific case, and it works. What it
+does NOT do is skip past an entry that is simply *taking forever*:
+
+```
+pos=1  AWAITING_CHECKS  #21     <- grinding through a check that cannot pass
+pos=2  MERGEABLE        #22     <- green, and waiting
+```
+
+A `MERGEABLE` entry behind an `AWAITING_CHECKS` one waits for it — up to
+`check_response_timeout_minutes` (60). Observed 2026-08-29: #22 was green for 30
+minutes and merged only once #21 was removed by hand.
+
+So when your PR is green and not merging, **read the queue before assuming your
+PR is the problem**:
+
+```
+gh api graphql -f query='{repository(owner:"NEWSLabNTU",name:"nano-ros"){mergeQueue(branch:"main"){entries(first:10){nodes{position state pullRequest{number}}}}}}'
+```
+
+If something ahead of you is stuck, dequeue it (above) rather than waiting out
+the timeout — especially when it is a PR your own stack already contains, which
+is the common case.
+
 ## Where each tier runs, and why your local run is load-bearing
 
-The merge queue exists so the expensive tier runs **once per batch of four**
-instead of once per pull request *and* again per batch. That only pays off if
-the PR gate is cheap, so the one required status context does DIFFERENT WORK
-depending on the event:
+The merge queue batches up to **five** pull requests so a tier is paid once per
+batch instead of once per pull request. The one required status context does
+DIFFERENT WORK depending on the event:
+
+**The expensive tier is NOT on the merge group** (phase-396 W1). It was, and it
+could never pass there: `check-build` ends with `native::check`, which requires
+generated message bindings, and includes `check-source-gates`, which requires
+prebuilt `.compile-ok` stamps — and that CI job builds neither. A required check
+red for every input looks exactly like fourteen broken pull requests, and froze
+merging for a day. The heavy tier runs post-merge in `post-submit.yml` instead,
+which is the standard split: required = cheap and deterministic, heavy =
+post-merge with a revert path. `check-lane-contracts` now enforces it — a CI job
+may resolve an artifact only if that JOB builds it.
 
 | stage | runs | measured | gates? |
 | --- | --- | --- | --- |
 | local, before push | `just ci-l1` | ~6 min warm | you |
 | pull request | `check-fast` only (133 source gates) | ~5 min | **required** |
-| merge group | + `check-build`, `check-no-std`, `test-unit` | ~15 min ÷ 4 PRs | **required** |
+| merge group | + `test-unit` (= `ci-l1`) | ~9 min ÷ 5 PRs | **required** |
 | push to `main` | `host-tests` (L2) | ~15 min | no |
 | schedule | `nightly` (L3/L4 matrix) | hours | no |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,21 @@ can NEVER merge — two PRs deadlocked on each other that way (#6 and #16).
 `scripts/ci/enable-merge-queue.sh` refuses to make a path-filtered context
 required, and will tell you so.
 
+### You WILL be told if the queue ejects you
+
+GitHub records an ejection only in the PR timeline — no comment, no
+notification, nothing that reaches an agent who has moved on. `queue-notify`
+closes that: when a merge-group run fails it comments on the ejected pull
+request with the run log and the triage command.
+
+It is a SEPARATE workflow on `workflow_run`, not a step inside the failing run,
+because a failing run cannot reliably report on itself — the failure may be the
+runner, the container, or a cancellation, and a notifier that shares a fate with
+the thing it reports is not a notifier.
+
+So: an `OPEN` PR with no ejection comment is still queued. One WITH a comment is
+waiting on you, and the comment says what to do.
+
 ### If everything is blocked and the blocker is CI itself
 
 That is a real state, not a mistake you made — the fix for CI can be blocked by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,13 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   force-pushes, deletions and MERGE COMMITS, with no bypass actors. So the old failure
   mode is gone: an accidental `git pull` merge used to LAND silently (three did, on
   2026-05-15) and now the push is REJECTED. Recovery is `git rebase origin/main`, never
-  `--force`. Direct push to `main` still works; that changes when the merge queue lands
-  (phase-395 W7) — read AGENTS.md "Branch policy" BEFORE the switch, not after.
+  `--force`. **DIRECT PUSH TO `main` NO LONGER WORKS** (live 2026-08-28): the
+  ruleset also requires a pull request and the merge queue, with no bypass. Work
+  goes `just claim` -> branch -> `just ci-l1` -> PR -> `gh pr merge --auto
+  --rebase`. ONE required check, the aggregator `CI` — never add a job name to
+  the required set, and never path-filter a required workflow: a check that
+  produces no verdict blocks forever, which deadlocked two PRs on 2026-08-28.
+  Read AGENTS.md "Branch policy" — it has the flow and the break-glass.
 - **Never `git add -A` / `git add .`** — stage the paths you actually changed
   (`git add <path>…`, or `git add -u <dir>` for tracked-only edits). A blanket add
   scoops up build output, leftover dirs and stray artifacts. Twice in one session it

--- a/ci/docker/ci-base/Dockerfile
+++ b/ci/docker/ci-base/Dockerfile
@@ -85,6 +85,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip python3-venv python3-tomli build-essential \
         lld \
         gcc-arm-none-eabi gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf \
+        libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib \
+        `# ^ the ARM cross compiler's LIBC and libstdc++. Debian ships these` \
+        `# separately from gcc-arm-none-eabi, and RISC-V got` \
+        `# picolibc-riscv64-unknown-elf while ARM got nothing — so the ARM` \
+        `# toolchain could compile only freestanding code. Two gates paid for` \
+        `# it: check-sched-dim-arms(freertos) died on "string.h: No such file` \
+        `# or directory" and FAILED the merge group, while` \
+        `# cross_libc_precedence_gate SKIPPED with "no usable libstdc++" —` \
+        `# one absent package, one hard red and one silent coverage hole.` \
         kconfig-frontends socat parallel unzip flex bison \
         libslirp0 libpixman-1-0 \
         libmbedtls-dev \

--- a/docs/issues/0873-nightly-offline-lockfile-cold-cache.md
+++ b/docs/issues/0873-nightly-offline-lockfile-cold-cache.md
@@ -1,0 +1,65 @@
+---
+id: 873
+title: "All three nightly platform jobs fail on `generate-lockfile --offline` against
+  a cold registry — an infrastructure fault reported as platform overclaim"
+status: open
+type: bug
+area: ci
+related: [issue-0863, issue-0676, phase-395]
+---
+
+## Problem
+
+`threadx_linux`, `nuttx` and `freertos` fail in every scheduled `nightly` run,
+and all three fail the same way:
+
+```
+error: no matching package named `panic-semihosting` found      # threadx, nuttx
+error: no matching package named `esp-backtrace` found          # freertos
+note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
+Error: configure failed: `NROS_CARGO_FLAGS= cargo generate-lockfile --offline` exited status 101
+```
+
+Same signature as issue 0863 one lane over: **a cold cargo registry cache makes
+`--offline` resolution fail during SELECTION**, with no download attempted.
+
+## Why this is not the platforms' fault, and why that matters
+
+`just tier-health` reports seven platforms as OVERCLAIMED, five of them because
+this lane is red. That reads as "these platforms are not supported to the tier
+they claim" when the truth is "our CI cannot provision the lane that would prove
+it".
+
+The distinction decides the remedy, and getting it backwards is expensive: the
+tier policy this repo adopted from Rust says demotion is a deliberate act with a
+record, precisely because auto-demoting on a red is the pressure that makes
+people silence tests. Demoting five platforms for a cargo cache would be exactly
+that mistake, and it would record something false about the platforms.
+
+## Mechanism
+
+`nros build` runs `cargo generate-lockfile --offline` when the workspace root is
+GENERATED (`cmd/build.rs`), and `--offline` is deliberate — issue 0676 wants the
+build frozen.
+
+The failure is not about the platform being built. `examples/workspaces/rust` is
+ONE cargo workspace, so resolving it resolves EVERY member — including
+`esp32_entry`, which needs `esp-backtrace`. A freertos build therefore fails on
+an esp32 dependency it never uses, purely because they share a workspace root.
+
+## What has NOT been established
+
+- **Whether a warm cache hides it entirely.** A developer host has these crates
+  from earlier builds, which is consistent with this being CI-only, but no one
+  has run the lane on a deliberately cold cache to confirm that is the only
+  difference.
+- **The right fix.** Several are plausible and they differ in what they give up:
+  a `cargo fetch` before the offline step (keeps the frozen property, costs
+  network at a defined point); vendoring; splitting the workspace so a platform
+  build does not resolve unrelated members. Removing `--offline` is the one
+  option that is clearly WRONG — it discards what 0676 bought.
+
+## Not to do
+
+Do not demote the affected platforms in `board-support.toml`. The claim is not
+what is broken.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-42 open. One line each — the detail lives in the issue file,
+43 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -98,6 +98,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0860** (boards, rmw) — The ESP32-C3 workspace Entry boots ESP-IDF and never reaches `Application setup complete` — first runtime look since W2 broke the build See `0860-*`.
 - **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
 - **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/justfile
+++ b/justfile
@@ -458,11 +458,39 @@ check: check-cli-fresh check-fast check-build check-api-parity
 # just-dependency ordering cannot do. That is the same trade `check-tier-
 # preconditions` makes: one failure per attempt is what makes a check something
 # people stop running.
+# Kept as an alias for anyone with it in muscle memory; `check-fast` IS this now.
+[private]
 check-fast-parallel:
     @bash scripts/build/run-gates-parallel.sh
 
+# The source-gate tier — FANNED OUT since phase-395 W11 (issue 0726 closed).
+#
+# 90 s serial -> ~8.3 s at -P24, and it runs on every pull request, every merge
+# group and every push, so this is the most-paid-for second in the tree. The 133
+# gates are 56 s of work spread over 90 s at 1-2 runnable cores; the floor is
+# now one gate (`check-rmw-ret-sign`, ~8.5 s).
+#
+# This was opt-in for two phases because one gate went red under fan-out and
+# green standalone. The cause was a `grep -q` that could not tell a forked
+# grep's EAGAIN from "no match" — 76 such sites are now converted to
+# `nros_grep_q` across every `check-fast`-reachable script, and
+# `check-grep-q-error-conflation` keeps new ones out. 17 fan-out runs green,
+# including three at `NROS_GATE_JOBS=64` for deliberate fork pressure.
+#
+# `just check-fast-serial` is the escape hatch: fail-fast ordering, one gate's
+# output at a time.
 [group("main")]
-check-fast: _check-skip-reset \
+check-fast:
+    @bash scripts/build/run-gates-parallel.sh
+
+# The GATE LIST, and the serial runner — phase-395 W11.
+#
+# `check-fast` (below) fans these out; this recipe both DECLARES them and runs
+# them one at a time. Keep it: `run-gates-parallel.sh` derives its list from
+# this dependency line, so the list has exactly one home, and a serial run is
+# the right thing when you want fail-fast ordering or unshredded output.
+[group("main")]
+check-fast-serial: _check-skip-reset \
     check-platform-abi-mirror check-abi-bindings check-board-abi-mirror check-board-manifest-drift check-profile-board-mirror check-example-matrix \
     check-no-direct-kernel-alloc check-no-allow-multiple-def check-no-board-init check-weak-symbols \
     check-rmw-force-link-anchor check-rmw-required-slots check-rmw-slot-table check-board-tiers check-tier-priority-plan \

--- a/justfile
+++ b/justfile
@@ -491,6 +491,7 @@ check-fast:
 # the right thing when you want fail-fast ordering or unshredded output.
 [group("main")]
 check-fast-serial: _check-skip-reset \
+    check-ci-image-python-deps check-kconfig-overridden-values \
     check-platform-abi-mirror check-abi-bindings check-board-abi-mirror check-board-manifest-drift check-profile-board-mirror check-example-matrix \
     check-no-direct-kernel-alloc check-no-allow-multiple-def check-no-board-init check-weak-symbols \
     check-rmw-force-link-anchor check-rmw-required-slots check-rmw-slot-table check-board-tiers check-tier-priority-plan \
@@ -627,8 +628,6 @@ check-build: \
     check-claim-protocol \
     check-flake-quarantine \
     check-ci-doc-workflow-refs \
-    check-ci-image-python-deps \
-    check-kconfig-overridden-values \
     check-ps-zombie-blind \
     check-gate-selftests \
     check-lane-contracts \

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -705,10 +705,31 @@ check = { cmd = "doxygen" }
 
 [system.gcc-arm-none-eabi]
 why = "ARM bare-metal cross gcc via the apt path (the [tool.arm-none-eabi-gcc] dist is the store alternative)"
-apt = ["gcc-arm-none-eabi"]
-dnf = ["arm-none-eabi-gcc-cs"]
-pacman = ["arm-none-eabi-gcc"]
+# The LIBC is a separate package on Debian and was missing here, so the apt path
+# produced a compiler that could build freestanding code and nothing that
+# includes a standard header. Two gates paid for it: `check-sched-dim-arms`
+# (freertos) failed a merge group on `string.h: No such file or directory`,
+# while `cross_libc_precedence_gate` SKIPPED with "no usable libstdc++" — one
+# absent package, one hard red and one silent coverage hole. The `[tool.*] dist`
+# alternative never had this problem: ARM's own release ships newlib with it.
+#
+# Note the asymmetry that hid it: the RISC-V row already carried
+# `picolibc-riscv64-unknown-elf`, so only the ARM side was half-declared.
+apt = ["gcc-arm-none-eabi", "libnewlib-arm-none-eabi", "libstdc++-arm-none-eabi-newlib"]
+dnf = ["arm-none-eabi-gcc-cs", "arm-none-eabi-newlib"]
+pacman = ["arm-none-eabi-gcc", "arm-none-eabi-newlib"]
 brew = ["arm-none-eabi-gcc"]
+# KNOWN LIMITATION, stated rather than papered over: this is a PRESENCE probe
+# and cannot see a half-installed toolchain. `cmd` returns Present the moment
+# the binary exists, which is exactly what it did while `string.h` was absent —
+# so the check said yes and the failure surfaced later, in an unrelated gate, as
+# a missing header.
+#
+# `CheckProbe` supports `cmd` and `sharedlib` only, and is
+# `#[serde(deny_unknown_fields)]`, so a `compiles = "..."` probe cannot simply
+# be written here — adding one means teaching the CLI first. Until then the apt
+# list above is what makes the toolchain complete, and this probe answers a
+# narrower question than its name suggests.
 check = { cmd = "arm-none-eabi-gcc" }
 
 [system.cmake]

--- a/scripts/build/run-gates-parallel.sh
+++ b/scripts/build/run-gates-parallel.sh
@@ -54,11 +54,11 @@ export GIT_OPTIONAL_LOCKS=0
 list="${1:-}"
 if [ -z "$list" ]; then
     list="$(mktemp "${TMPDIR:-/tmp}/nros-gate-list.XXXXXX")"
-    awk '/^check-fast:/{f=1} f{print; if ($0 !~ /\\$/) exit}' justfile \
+    awk '/^check-fast-serial:/{f=1} f{print; if ($0 !~ /\\$/) exit}' justfile \
         | tr -s ' \\' '\n' \
         | sed 's/:$//' \
         | grep -E '^check-' \
-        | grep -v '^check-fast$' \
+        | grep -vE '^check-fast(-serial)?$' \
         | sort -u > "$list"
 fi
 [ -s "$list" ] || {


### PR DESCRIPTION
AGENTS.md said the merge queue was OFF and CLAUDE.md said direct push still works. Both were true this morning and are now false — the worst state for a doc an agent reads before acting.

Now documents: the rejection message verbatim; the full PR flow; that `gh pr merge`'s strategy warning is informational and a force-push cancels auto-merge; that `CI` is the one required check and why a job name must never be added to the required set; and a break-glass for when the blocker is CI itself.