### PR TITLE
fix: two gates whose verdicts were not about the code

### DIFF
--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -34,7 +34,6 @@ scripts/check-doc-refs.sh
 scripts/check-emitter-just-spelling.sh
 scripts/check-example-leaf-build-dirs.py
 scripts/check-example-matrix.sh
-scripts/check-export-f-closure.sh
 scripts/check-eyre-context-alias.sh
 scripts/check-feature-contract.py
 scripts/check-feature-set-ssot.sh

--- a/scripts/check-decoupling.sh
+++ b/scripts/check-decoupling.sh
@@ -36,10 +36,25 @@ FEATURE_RE='dep:nros-rmw-(zenoh|dds|xrce-cffi|cyclonedds)|dep:nros-platform-(pos
 
 check_manifest() {
     local crate=$1
-    local manifest="packages/core/$crate/Cargo.toml"
+    # Resolve the LAYER rather than hardcoding it. `nros` moved from
+    # `packages/core/` to `packages/api/`, so this printed
+    #
+    #     FAIL: packages/core/nros/Cargo.toml not found
+    #
+    # on every run: a FAILING verdict whose stated reason was false, about a
+    # crate that was never checked at all. The guard is advisory
+    # (`continue-on-error` in pr-checks.yml, and deliberately outside
+    # `just check` since RFC-0031 superseded the goal it guards), so nothing was
+    # gated on the lie — it just made the one output nobody could trust.
+    #
+    # A glob keeps the answer right across the next move too. `head -1` because
+    # two crates of one name in different layers is itself a defect, and this
+    # guard is not the place to discover it.
+    local manifest
+    manifest=$(ls -d packages/*/"$crate"/Cargo.toml 2>/dev/null | head -1)
 
-    if [[ ! -f "$manifest" ]]; then
-        echo "FAIL: $manifest not found"
+    if [[ -z "$manifest" || ! -f "$manifest" ]]; then
+        echo "FAIL: no packages/*/$crate/Cargo.toml found"
         return 1
     fi
 

--- a/scripts/check-export-f-closure.sh
+++ b/scripts/check-export-f-closure.sh
@@ -235,9 +235,17 @@ EOF
     return $ok
 }
 
+# The negative control runs on EVERY invocation, not only behind the flag.
+#
+# `check-gate-selftests` states the reason: *a negative control nobody runs
+# decays into a comment.* Behind `--self-test` this was run once, by its author,
+# on the day it was written. It costs 0.12 s.
+#
+# The flag is kept for running the control ALONE while working on it — it now
+# exits straight after, rather than being the only way to reach it.
+self_test || exit 1
 if [ "${1:-}" = "--self-test" ]; then
-    self_test
-    exit $?
+    exit 0
 fi
 
 SOURCES=("$ROOT"/scripts/build/*.sh)

--- a/scripts/check-gate-selftests.py
+++ b/scripts/check-gate-selftests.py
@@ -52,6 +52,29 @@ BASELINE = os.path.join(ROOT, ".config", "gate-selftest-baseline.txt")
 # A call to a selftest routine. Definitions and flag-dispatch lines are excluded
 # by the caller, not here, so both halves are visible at the use site.
 CALL = re.compile(r"\b(self_?test|_selftest|selftest)\s*\(")
+# The same call as SHELL writes it: a bare command at statement position, no
+# parentheses.
+#
+# Without this the rule was UNSATISFIABLE for shell. `CALL` requires `name(`,
+# which bash call syntax never produces, so a `.sh` could only ever classify
+# `none` or `flag-only` however good its negative control was — and the two
+# spellings were indistinguishable. Demonstrated by running the classifier on
+# a script that does the right thing:
+#
+#     self_test() { return 0; }
+#     self_test || exit 1        →  classified `flag-only`
+#
+# identical to the verdict for the same call hidden behind `--self-test`.
+#
+# Measured when this was found: of 159 gate scripts, 75 are shell and 0 of them
+# were compliant; all 40 compliant scripts were `.py`. A ratchet one whole
+# language cannot pay into is not a ratchet on that language, it is a silent
+# exemption for it — and it was silent in the direction that matters, since
+# those 75 sat in the "still owe one" count looking like ordinary debt.
+#
+# `DEFN` still excludes the definition line (`self_test() {`), so this matches
+# the invocation only, and the flag-branch lookback below applies unchanged.
+BASH_CALL = re.compile(r"^\s*[A-Za-z0-9_]*self_?test[A-Za-z0-9_]*\s*(?:\|\||&&|;|$)")
 DEFN = re.compile(r"^\s*(def |function |\w+\s*\(\)\s*\{)")
 FLAG = re.compile(r"--self")
 HAS_SELFTEST = re.compile(r"self.?test", re.I)
@@ -94,7 +117,7 @@ def classify(rel):
         stripped = line.strip()
         if stripped.startswith("#") or DEFN.match(line) or FLAG.search(line):
             continue
-        if not CALL.search(line):
+        if not CALL.search(line) and not BASH_CALL.match(line):
             continue
         # A call INSIDE the flag branch is not an automatic run. Line matching
         # alone cannot see that — `self_test()` under `if "--selftest" in argv:`
@@ -222,6 +245,17 @@ def self_test(quiet=True):
         ("flag-only", 'def selftest():\n    pass\n\nif a == "--self-test": selftest()\n'),
         # A commented-out call must not count either.
         ("flag-only", "def self_test():\n    pass\n\n#    self_test()\n"),
+        # SHELL call syntax — no parentheses. Before `BASH_CALL` these read as
+        # `flag-only` however good the control was, so 0 of 75 shell gate
+        # scripts could ever comply.
+        ("auto", "self_test() {\n    return 0\n}\n\nself_test || exit 1\n"),
+        ("auto", "_cc_selftest() {\n    return 0\n}\n\n_cc_selftest\n"),
+        # …and a shell call behind a flag branch must STILL be flag-only,
+        # exactly as the Python one is. Without this case the fix above would
+        # be free to classify every shell selftest as automatic, which trades a
+        # silent exemption for a false pass.
+        ("flag-only", 'self_test() {\n    return 0\n}\n\nif [ "$1" = "--self-test" ]; then\n'
+                      "    self_test\nfi\n"),
     ]
     fails = []
     with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Two gates reported earlier and left standing while the merge-queue work landed. Both still reproduce on `967c9d09`. **Neither is red** — that is the problem in each case.

## `check-decoupling` failed on a crate it never read

```
FAIL: packages/core/nros/Cargo.toml not found
```

`nros` moved to `packages/api/`. So the guard printed a **failing verdict whose stated reason was false**, about a crate it had not checked. It's advisory (`continue-on-error`, and deliberately outside `just check` since RFC-0031 superseded its goal), so nothing was gated on the lie — it just made the one output nobody could trust.

Resolves the layer by glob. Both crates are now actually checked, and both are clean, so the guard **passes** — which the `# EXPECTED TO FAIL until Phase 104.A` comment no longer describes for the manifest half of that goal. Whether it should therefore lose `continue-on-error` and rejoin `just check` is an RFC-0031/phase-104 call and is **not** taken here.

Mutation-checked, because a guard that passes is worth exactly what its ability to fail is worth: injecting `nros-rmw-zenoh` into `packages/api/nros/Cargo.toml` gives `FAIL: nros Cargo.toml carries concrete backend / platform refs`, naming the line.

## `check-gate-selftests` could not be satisfied by a shell script

Its `CALL` regex needs `name(`, which bash never produces. Shown by **running** the classifier, not reading it — a script doing exactly the right thing:

```
self_test() { return 0; }
self_test || exit 1          →  classified `flag-only`
```

identical to the verdict for the same call hidden behind `--self-test`. Indistinguishable, so no shell script could ever comply.

Measured: of 159 gate scripts, **75 are shell and 0 were compliant**; all 40 compliant were `.py`. A ratchet one whole language cannot pay into is not a ratchet on it, it's a silent exemption — and silent in the direction that matters, since those 75 sat in the "still owe one" count looking like ordinary debt.

`BASH_CALL` matches a bare command at statement position. `DEFN` still excludes the definition and the flag-branch lookback is unchanged, so a shell call behind `--self-test` still reads `flag-only` — asserted as a case, because without it this fix would be free to call every shell selftest automatic and trade a silent exemption for a false pass.

### Proved on a real script, not only on probes

`check-export-f-closure.sh` had a genuine `self_test` reachable only by flag. It now runs on the normal path (0.12 s); its baseline line is removed.

**40 → 41 compliant, 119 → 118 owing** — the first shell gate in the tree to comply.

Mutation-checked in all three directions: broken selftest reds the *normal* invocation (rc 1), intact passes, `--self-test` still runs it alone. The flag is kept for iterating on the control; it's just no longer the only way to reach it.

## Verified

`just ci-l1` green — the tier the merge group runs.

Every claim above is a command that ran; nothing is inferred from reading the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)