### PR TITLE
fix(#0874): sccache 0.8.2 speaks a GitHub cache API that no longer exists

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -195,15 +195,39 @@ jobs:
             echo "::warning::sccache absent from the image — the compile tier runs UNCACHED."
             exit 0
           fi
-          {
-            echo "SCCACHE_GHA_ENABLED=true"
-            echo "ACTIONS_RESULTS_URL=${ACTIONS_RESULTS_URL:-}"
-            echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN:-}"
-            # Well under the 10 GB cap this store does NOT share; the justfile's
-            # 30G default is a developer-workstation figure.
-            echo "SCCACHE_CACHE_SIZE=2G"
-          } >> "$GITHUB_ENV"
           sccache --version
+
+          # issue 0874 — an ABSENT sccache degrades gracefully (above); a BROKEN
+          # one used to be fatal, and the asymmetry is the bug. `RUSTC_WRAPPER`
+          # makes sccache a prefix on every `rustc`, so a backend that cannot
+          # start does not lose a cache — it fails the compiler:
+          #
+          #   sccache: error: Server startup failed: create gha cache failed:
+          #     ConfigInvalid (permanent) => ACTIONS_CACHE_URL not found
+          #   error: process didn't exit successfully: `sccache rustc -vV`
+          #
+          # That took down `main` and every open PR at once. So PROVE the
+          # backend before handing it the compiler: export the config into this
+          # step only, start a server, and publish to `$GITHUB_ENV` only if that
+          # worked. On failure sccache stays on PATH with its LOCAL disk cache,
+          # which is the same uncached-but-working state as the absent case.
+          export SCCACHE_GHA_ENABLED=true
+          export ACTIONS_RESULTS_URL="${ACTIONS_RESULTS_URL:-}"
+          export ACTIONS_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN:-}"
+          export SCCACHE_CACHE_SIZE=2G
+          if sccache --start-server >/tmp/sccache-start.log 2>&1; then
+            {
+              echo "SCCACHE_GHA_ENABLED=true"
+              echo "ACTIONS_RESULTS_URL=${ACTIONS_RESULTS_URL:-}"
+              echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN:-}"
+              # Well under the 10 GB cap this store does NOT share; the
+              # justfile's 30G default is a developer-workstation figure.
+              echo "SCCACHE_CACHE_SIZE=2G"
+            } >> "$GITHUB_ENV"
+          else
+            echo "::warning::sccache GHA backend unavailable — the compile tier runs UNCACHED (issue 0874)."
+            sed 's/^/  /' /tmp/sccache-start.log || true
+          fi
 
       # ----- CLI + sources: build tier (non-push) only -----
       # check-fast is BUILDLESS *and* SOURCE-FREE (no cargo build/clippy/test, no

--- a/ci/docker/ci-base/Dockerfile
+++ b/ci/docker/ci-base/Dockerfile
@@ -135,15 +135,23 @@ RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-
 #
 # BAKED, not installed per run: `nros setup --tool sccache` builds it from
 # source (vendored-openssl), which is minutes on a cold runner and would cost
-# more than it saves. The prebuilt release tarball is the same 0.8.2 the
+# more than it saves. The prebuilt release tarball is the same 0.17.0 the
 # `[tool.sccache]` index row pins — keep the two in lockstep.
+#
+# issue 0874 — 0.8.2 (2024-09-28) predates GitHub's Actions Cache v2, which
+# replaced the v1 service on 2025-02-01. Its GHA backend asks for the retired
+# `ACTIONS_CACHE_URL` and fails permanently; because sccache is the
+# `RUSTC_WRAPPER`, that failed every `rustc` rather than merely losing a cache,
+# and took down `main` plus every open PR. ghac v2 landed in sccache 0.10.0
+# ("Bump opendal to 0.52 to support ghac v2") and moved to v4 in 0.11.0, so the
+# floor is 0.10.0 and this takes the current release.
 #
 # Why sccache rather than caching `target/`: it is CONTENT-hashed, so a restored
 # cache cannot make a stale artifact read as fresh. Restoring a `target/` dir
 # into a fresh checkout gives artifacts mtimes newer than their sources, which
 # is exactly the museum-binary class CLAUDE.md's fixture-mtime treadmill
 # describes. Content addressing sidesteps it entirely.
-ARG SCCACHE_VERSION=0.8.2
+ARG SCCACHE_VERSION=0.17.0
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \

--- a/docs/issues/0874-sccache-ghac-v1-sunset-breaks-every-rustc.md
+++ b/docs/issues/0874-sccache-ghac-v1-sunset-breaks-every-rustc.md
@@ -1,0 +1,90 @@
+---
+id: 874
+title: "sccache 0.8.2 speaks a GitHub cache API that no longer exists — and
+  because it is the `RUSTC_WRAPPER`, that fails every `rustc`"
+status: open
+type: bug
+area: ci, tooling
+related: [issue-0871, phase-395]
+---
+
+## Symptom
+
+`main` and every open pull request fail the required check at once:
+
+    sccache: error: Server startup failed: create gha cache failed:
+      ConfigInvalid (permanent) at Builder::build => ACTIONS_CACHE_URL not found,
+      maybe not in github action environment?
+    error: process didn't exit successfully:
+      `/usr/local/bin/sccache …/rustc -vV` (exit status: 2)
+
+`main`'s own `pr-checks` was green at 2026-08-28 16:57 and failing by 2026-08-29
+02:22, with no change to the sccache configuration in between.
+
+## Cause
+
+Two facts that only bite together.
+
+**The image ships sccache 0.8.2** (`ci/docker/ci-base/Dockerfile`,
+`ARG SCCACHE_VERSION`), released 2024-09-28. GitHub replaced the Actions Cache
+service with **v2 on 2025-02-01** and sunset v1 the same day. 0.8.2's GHA
+backend only knows the v1 variable `ACTIONS_CACHE_URL`, which no longer exists —
+so its backend is permanently unavailable, not intermittently.
+
+The workflow already exports the *correct* v2 variables (`ACTIONS_RESULTS_URL`,
+`ACTIONS_RUNTIME_TOKEN`), matching the current upstream docs. The configuration
+was right; the binary was too old to read it.
+
+**And sccache is the `RUSTC_WRAPPER`** — the justfile sets it whenever the
+binary is on PATH. So a cache backend that cannot start does not degrade to an
+uncached build: it prefixes every `rustc` invocation with a command that exits
+2. A cache failure became a compiler failure.
+
+Note the asymmetry that made this worse than it needed to be: an **absent**
+sccache was already handled gracefully (`::warning::… runs UNCACHED`), while a
+**broken** one was fatal. The graceful path existed and the failure took the
+other one.
+
+## Fix
+
+Both halves, because either alone leaves a hole.
+
+1. **Bump to sccache 0.17.0** (latest; 2026-07-29), in `ci/docker/ci-base/
+   Dockerfile` and `nros-sdk-index.toml` together — the Dockerfile comment
+   already requires those to move in lockstep, or `nros setup --tool sccache`
+   provisions a different sccache than CI runs. ghac v2 landed upstream in
+   0.10.0 ("Bump opendal to 0.52 to support ghac v2") and moved to v4 in 0.11.0,
+   so 0.10.0 is the floor and this takes the current release.
+
+2. **Prove the backend before handing it the compiler.** The workflow step now
+   exports the GHA config into itself, runs `sccache --start-server`, and
+   publishes to `$GITHUB_ENV` only if that succeeded. On failure it warns and
+   leaves the config unset, so sccache falls back to its local disk cache —
+   the same uncached-but-working state as the absent case.
+
+The second is the durable part: it makes ANY future backend breakage cost a
+cache rather than a build, which is what should have happened this time.
+
+## Measured
+
+On the maintainer host, against the 0.17.0 release tarball:
+
+* the Dockerfile's constructed URL resolves and the binary runs
+  (`sccache 0.17.0`); asset naming is unchanged from 0.8.2.
+* GHA enabled with no cache vars — the CI condition — exits **2**, so the new
+  guard detects it. Its message no longer names `ACTIONS_CACHE_URL`, confirming
+  the newer backend.
+* the same environment with GHA left unset exits **0**, and `sccache rustc`
+  compiles and runs a test program — so the fallback is genuinely working, not
+  merely starting.
+
+NOT measured, and stated rather than implied: that 0.17.0 talks to GitHub's
+live cache service successfully. That needs a real Actions runner, and the only
+place it can be observed is CI itself. If it cannot, the guard now makes the
+result an uncached build rather than a red tree.
+
+## Acceptance
+
+* The required check passes on `main`.
+* A cache backend that cannot start costs the cache, never the compiler —
+  verified by the warning appearing with the build still green.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-41 open. One line each — the detail lives in the issue file,
+42 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -98,6 +98,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0860** (boards, rmw) — The ESP32-C3 workspace Entry boots ESP-IDF and never reaches `Application setup complete` — first runtime look since W2 broke the build See `0860-*`.
 - **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
 - **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -162,11 +162,11 @@ dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/
 # on NEWSLabNTU/nano-ros-sdk, so `nros setup --tool sccache` falls back to the
 # source recipe (`cargo install sccache`).
 [tool.sccache]
-version = "0.8.2-nros1"
-upstream = "0.8.2" # = source.ref (mozilla/sccache release tag, without the `v`)
+version = "0.17.0-nros1"
+upstream = "0.17.0" # = source.ref (mozilla/sccache release tag, without the `v`)
 [tool.sccache.source]
 git = "https://github.com/mozilla/sccache"
-ref = "v0.8.2"
+ref = "v0.17.0"
 # vendored-openssl: the default features pull openssl-sys, which hard-fails
 # on any host without libssl-dev (observed 2026-08-03; the RFC-0062 class —
 # an undeclared system dep). Vendoring removes the system dep entirely.


### PR DESCRIPTION
**This is why `main` and every open PR are red.** Not anyone's diff — GitHub changed under us.

```
sccache: error: Server startup failed: create gha cache failed:
  ConfigInvalid (permanent) => ACTIONS_CACHE_URL not found
error: process didn't exit successfully: `sccache …/rustc -vV` (exit 2)
```

`main` was green at 2026-08-28 16:57 and red by 02:22, with no change to the sccache configuration in between — because nothing here changed.

## Two facts that only bite together

**The image ships sccache 0.8.2** (2024-09-28). GitHub replaced the Actions Cache service with **v2 on 2025-02-01** and sunset v1 the same day. 0.8.2's GHA backend only knows the v1 variable `ACTIONS_CACHE_URL`, which no longer exists — permanently unavailable, not intermittent.

The workflow was already exporting the **correct** v2 variables (`ACTIONS_RESULTS_URL`, `ACTIONS_RUNTIME_TOKEN`), matching [current upstream docs](https://github.com/mozilla/sccache/blob/main/docs/GHA.md). The configuration was right; the binary was too old to read it.

**And sccache is the `RUSTC_WRAPPER`.** So a backend that can't start doesn't degrade to an uncached build — it prefixes every `rustc` with a command that exits 2. A cache failure became a compiler failure.

The asymmetry is the real defect: an **absent** sccache was already handled gracefully ("runs UNCACHED"); a **broken** one was fatal. The graceful path existed and the failure took the other one.

## Both halves

1. **0.8.2 → 0.17.0**, in `ci/docker/ci-base/Dockerfile` *and* `nros-sdk-index.toml` together — the Dockerfile comment already requires lockstep, or `nros setup --tool sccache` provisions a different sccache than CI runs. ghac v2 landed upstream in **0.10.0** ("Bump opendal to 0.52 to support ghac v2") and moved to v4 in 0.11.0, so 0.10.0 is the floor and this takes the current release.

2. **Prove the backend before handing it the compiler.** The step exports the GHA config into itself, runs `sccache --start-server`, and publishes to `$GITHUB_ENV` only if that worked. On failure it warns and leaves it unset, so sccache falls back to local disk — the same uncached-but-working state as the absent case.

The second is the durable part: it makes *any* future backend breakage cost a cache rather than a build.

## Measured

Against the 0.17.0 release tarball on the maintainer host:

- the Dockerfile's constructed URL resolves; binary runs (`sccache 0.17.0`); asset naming unchanged from 0.8.2, so the URL template still holds
- GHA enabled with no cache vars — CI's exact condition — exits **2**, so the guard detects it; its message no longer names `ACTIONS_CACHE_URL`, confirming the newer backend
- the same environment with GHA unset exits **0**, and `sccache rustc` compiles *and runs* a test program — the fallback works, not merely starts
- 133/133 fast gates

## Not measured

That 0.17.0 talks to GitHub's **live** cache service successfully. That needs a real Actions runner and can only be observed in CI. If it can't, the guard now makes that an uncached build rather than a red tree.

**Note:** the CI image must be rebuilt for the version bump to take effect.

Closes #0874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk