### PR TITLE
docs(#880, #881): two gaps found while fixing the cyclone funnel's link

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -423,9 +423,17 @@ jobs:
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: just build-compile-check-fixtures cxx-syntax
 
+      #
+      # The `source /opt/ros/humble/setup.bash` below is load-bearing, not
+      # boilerplate: `check-rmw-cyclonedds`'s from-msg targets run
+      # msg_to_cyclone_idl.py at BUILD time, which imports rosidl_adapter from
+      # /opt/ros. The configure-time probe only checks the converter script
+      # EXISTS (issue-0196 class: probe narrower than the rule), so an
+      # unsourced env fails at 80% of the build rather than at configure.
       - name: just check-build + no_std (nightly / manual only)
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |
+          source /opt/ros/humble/setup.bash
           just check-build
           just check-no-std
 

--- a/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
@@ -92,6 +92,58 @@ list: an image whose resolved model contains zero subscriptions needs zero of
 it, and that derivation needs no infrastructure accounting — unlike the
 queryable one above, the runtime creates no large-payload subscriber of its own.
 
+## Measured 2026-08-29 — the "easiest win" is NOT available with the existing knob
+
+The section above calls `LARGE_PAYLOADS` "the single easiest win ... an image
+whose resolved model contains zero subscriptions needs zero of it". Zero is
+**not expressible**. `packages/rmw/zenoh/nros-rmw-zenoh/build.rs:45`:
+
+```rust
+let max_large: usize = env_usize("ZPICO_MAX_LARGE_SUBSCRIBERS", 2).max(1);
+```
+
+The `.max(1)` floor means the smallest reachable pool is
+`1 * ZPICO_SUBSCRIBER_RING_DEPTH(4) * ZPICO_SUBSCRIBER_LARGE_SIZE(16384)` =
+**65,536 bytes**, not 0. So wiring the resolved model to this knob — the fix
+this issue proposes — buys half of what the issue claims: 131,072 -> 65,536 on
+a talker, with the other half structurally out of reach until the floor goes.
+
+MEASURED, not read — three builds of `examples/native/rust/talker`, the knob
+varied, `llvm-nm -S` on each binary:
+
+| `ZPICO_MAX_LARGE_SUBSCRIBERS` | `LARGE_PAYLOADS` |
+| ---: | ---: |
+| 2 (default) | 131,072 |
+| 1 | 65,536 |
+| **0** | **65,536** |
+
+Note the third row: asking for zero does not fail, it silently yields one. A
+codegen deriving "no subscriptions -> 0" would emit a config that reads as
+satisfied while still reserving 64 KiB — the same shape as every other defect
+this campaign has found, a value that looks applied and is not. If the floor
+stays, the knob should REJECT 0 rather than round it up.
+
+Baseline confirming the arithmetic, `just mem-report` on
+`build/cargo-fixtures/linux-14372940/nros-relwithdebinfo/talker`:
+
+```
+       131,072   35.8%  nros_rmw_zenoh::shim::subscriber::LARGE_PAYLOADS
+       131,072  LARGE_PAYLOADS  — agrees with `ZPICO_MAX_LARGE_SUBSCRIBERS *
+                                  ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE`
+```
+
+Removing the floor is not free to reason about: `.max(1)` exists so a pool
+index is always valid, and the sibling `max_nodes` floor documents exactly that
+intent ("so a session always has room for its own primary node"). A zero-length
+pool needs the *lookup* path to refuse a large subscription rather than index an
+empty array — a code change, not a knob change. Whoever takes this should price
+both halves separately: the knob wiring (65,536, mechanical) and the floor
+removal (a further 65,536, needs the refusal path).
+
+The same floor applies to `ZPICO_MAX_QUERYABLES`-style derivations. Check for it
+before quoting a saving off the inventory: the inventory prints the formula, not
+the floor.
+
 ## Reproduce
 
 ```sh

--- a/docs/issues/0872-pr-arm-example-check-needs-nros-sync.md
+++ b/docs/issues/0872-pr-arm-example-check-needs-nros-sync.md
@@ -1,0 +1,79 @@
+---
+id: 872
+title: "The PR/nightly check arm has never run to completion — each fix exposes the next environment gap"
+status: open
+area: ci
+severity: medium
+found: 2026-08-28
+related: [phase-395, 0816]
+---
+
+# The PR/nightly check arm has never run to completion
+
+## What was measured
+
+PR #7 is the first pull request through the merge queue (phase-395 W7). Its
+required check — `check (fast on push; full on PR/nightly)` — has failed seven
+times, each time on a DIFFERENT gate, each one further into the job than the
+last. The push lane runs only `check-fast`, so the PR/nightly arm's steps had
+never executed against the CI container at all; every failure below is a
+pre-existing gap that the queue's arrival made visible, not a regression from
+the PR's payload.
+
+Fixed inside PR #7 (each verified locally, most with a negative control):
+
+| # | gate | gap |
+| --- | --- | --- |
+| 1 | `check-source-gates` | the compile-check fixtures it consumes were never built by the job |
+| 2 | `compile-check-fixtures.sh` | the cmake-lane prereq probe hard-exits even when the selection contains no cmake row |
+| 3 | `check-source-gates` | bare `cargo test` counts a `skip!` panic as a failure (no junit rewrite) |
+| 4 | `check-build` | `msg_to_cyclone_idl.py` imports `rosidl_adapter` at BUILD time; the ROS env was not sourced |
+| 5 | `check-sched-dim-arms` | probes that `arm-none-eabi-gcc` EXISTS; the container's has no newlib, so every arm failed on `<string.h>` |
+
+**Rows 1-3 were fixed independently and better on `main`** (phase-395 W19/W20),
+while this branch was in flight: `check-source-gates` now builds its own
+`cxx-syntax` lane and runs through the shared `_nextest-tolerant`, and the lane
+filter short-circuits the cmake prereq probe before it can exit. Two convergent
+diagnoses of the same three defects, from opposite ends. Only rows 4 and 5
+survive in PR #7; the rest of this table is history, kept because the PATTERN is
+the finding — an arm nothing executes accumulates gaps at roughly one per gate.
+
+## Still open — the gate this issue is filed for
+
+(Whether this still reproduces under phase-395 W20's restructure is UNVERIFIED:
+the compile tier moved to `merge_group`, so the example check now runs per
+BATCH rather than per PR, and this branch has not yet been through the queue.)
+
+With those five fixed the arm reaches the example check inside `just check`,
+which reports:
+
+```
+native check: 33 example(s) are missing their generated message bindings
+```
+
+The examples' `generated/` trees are USER-side codegen (`nros sync`), absent in
+a fresh clone by design. The job builds the CLI and provisions `-sys` sources
+but never syncs any example leaf, so this gate cannot pass as the workflow
+stands. Two candidate shapes, neither yet chosen:
+
+* run `nros sync` for the leaves the check walks (cost: unmeasured), or
+* have the example check SKIP legibly when `generated/` is absent, the way the
+  cross-toolchain gates now skip — consistent with "probe what you use, skip
+  legibly, never fail on a lane you did not enter", which is the vocabulary the
+  other four fixes converged on.
+
+## Why this is not "just fix it in the PR"
+
+Each fix has been one line of insight and one round of ~25 minutes of CI. The
+payload of PR #7 (the heap-free tier image, issue 0843) is unrelated to any of
+this and is verified locally by `ci-l1` + `ci-l3` + native e2e. Continuing to
+grow that PR with workflow archaeology couples an unrelated change to an
+open-ended CI debug loop; the remaining gap is worth its own change, with the
+skip-vs-sync decision made deliberately rather than under merge pressure.
+
+## Method note
+
+`gh run view --job <id> --log-failed` truncates the failing step's own name to
+`UNKNOWN STEP` for container jobs, so the failing RECIPE has to be read out of
+the log body (`error: recipe \`X\` failed`) rather than the step header. The
+first four rounds were diagnosed that way.

--- a/docs/issues/0880-format-walks-unbuilt-colcon-workspace-leaves.md
+++ b/docs/issues/0880-format-walks-unbuilt-colcon-workspace-leaves.md
@@ -1,0 +1,121 @@
+---
+id: 880
+title: "`just format` is red or green depending on whether a migrated colcon workspace has been BUILT"
+status: open
+area: build
+severity: medium
+found: 2026-08-29
+related: [0359, 0463, phase-383, RFC-0065]
+---
+
+# `just format` walks into leaves whose workspace root is a build artifact
+
+## What was measured
+
+On a tree where `examples/workspaces/launch` has not been built, `just format`
+fails:
+
+```
+cd examples/workspaces/launch/src/listener_pkg && cargo +nightly-2026-04-11 fmt
+`cargo metadata` exited with an error: error: current package believes it's in a
+workspace when it's not:
+current:   .../examples/workspaces/launch/src/listener_pkg/Cargo.toml
+workspace: .../nano-ros/Cargo.toml
+```
+
+24 leaves format successfully before it, so the failure reads as a problem with
+that leaf. It is not. `examples/workspaces/launch` is a MIGRATED colcon
+workspace (RFC-0065 D3 / phase-383 W10.a): `nros build` GENERATES its root
+`Cargo.toml`, and `examples/workspaces/launch/.gitignore:13` hides it. The
+tracked marker is `.colcon_workspace`. So the two leaves are members of a
+workspace root that exists only after a build — and `just format` steps into
+them regardless.
+
+The same fact is already written down one lane over.
+`nros-tests/tests/example_shape.rs::every_standalone_rust_leaf_is_its_own_workspace_root`
+carries this comment:
+
+> Reading only the manifest made this test depend on whether the workspace
+> happened to have been BUILT — green on a machine that had, red on a fresh
+> clone, and red here for `examples/workspaces/launch` once its root was
+> deleted.
+
+That test was taught to read `.colcon_workspace` as the tracked half of the
+fact. `just format` was not, and neither was anything else that runs a bare
+cargo command per leaf.
+
+## Why it is not simply "run `nros build` first"
+
+The state is build-dependent per WORKSPACE, so the tree is half-resolved at any
+given moment. Measured on this checkout:
+
+| workspace | root manifest on disk | rust leaves | `just format` |
+| --- | --- | ---: | --- |
+| `features` | yes | 10 | green |
+| `realtime-rust` | yes | 3 | green |
+| `rust` | yes | 9 | green |
+| `safety` | yes | 3 | green |
+| `sizing` | yes | 1 | green |
+| `mixed` | **NO** | 1 | green — its leaf carries its own `[workspace]` |
+| `launch` | **NO** | 2 | **red** |
+
+`mixed` is the interesting row: it is equally unbuilt and equally a migrated
+workspace, and it passes only because its single leaf
+(`src/rust_heartbeat_pkg`) happens to carry an empty `[workspace]` table while
+`launch`'s two do not. Two leaf shapes coexist inside the same workspace class,
+and which one a workspace got decides whether an unbuilt tree formats.
+
+## Scope of the class
+
+A full sweep of tracked manifests — nearest enclosing `[workspace]`, root
+`members` globs expanded, root `exclude` honoured — finds exactly two leaves
+that resolve to the ROOT workspace while being neither member nor excluded:
+
+```
+examples/workspaces/launch/src/listener_pkg
+examples/workspaces/launch/src/talker_pkg
+```
+
+Both confirmed against cargo itself (`cargo metadata --no-deps` in each leaf).
+This is the same shape as issue 0359 / phase-320 W1.b, whose fix note still
+sits in the root `Cargo.toml`:
+
+> these two are neither members nor excluded, so cargo greets anyone who runs a
+> command inside them with "current package believes it's in a workspace when
+> it's not". They are unbuilt porting templates, so nothing surfaced it until
+> now.
+
+Third time for the class, second cause: 0359 was two crates missing from
+`exclude`; this is two leaves whose owning root is generated.
+
+## What a fix has to decide
+
+Not "add two `exclude` lines" — that would make the leaves permanently
+un-adoptable by the generated root they legitimately belong to. The real
+question is which of two shapes a migrated workspace's Rust leaf takes, and
+then making it uniform:
+
+1. **Leaf carries its own `[workspace]`** (the `mixed` shape). Works with no
+   build; costs the leaf its membership in the generated root, so
+   feature unification and a shared lock are gone.
+2. **Leaf is a plain member** (the `launch` shape) and every per-leaf cargo
+   recipe learns the `.colcon_workspace` precondition — the same tracked marker
+   `example_shape.rs` already reads, resolved the same order
+   `detect_workspace_root` uses.
+
+(2) is the one that matches what the workspace IS, and it wants a guard, not a
+skip: `just check-tier-preconditions` is where an unmet "this workspace has not
+been built" belongs, so the message names `nros build` instead of surfacing four
+frames deep in `cargo metadata` (the shape issue 0463 fixed for `nros sync`).
+
+Whichever is chosen, the two leaf shapes should stop coexisting, and a gate
+should say so — `every_standalone_rust_leaf_is_its_own_workspace_root` currently
+neither requires nor forbids the table for a member, which is why `mixed` and
+`launch` could diverge silently.
+
+## Reproduce
+
+```
+rm -f examples/workspaces/launch/Cargo.toml    # already absent on a fresh clone
+just format
+```

--- a/docs/issues/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
+++ b/docs/issues/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
@@ -1,0 +1,96 @@
+---
+id: 881
+title: "Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into"
+status: open
+area: ci
+severity: medium
+found: 2026-08-29
+related: [0832, phase-391, RFC-0075]
+---
+
+# The funnel-ON path is built by no lane `just check` runs
+
+## What was measured
+
+Issue 0832 routes Cyclone's `ddsrt` heap through `nros_platform_alloc` behind
+`NROS_DDSRT_PLATFORM_FUNNEL`. The switch is set in the **self-provision** branch
+of `nros_provide_cyclonedds()`, which is the only place it can be set — a
+`find_package` build links a Cyclone whose `heap.c` was already compiled.
+
+That leaves three build shapes, and the funnel is exercised by none of the ones
+on the fast line:
+
+| build | Cyclone provenance | `NanoRos::Platform` | funnel |
+| --- | --- | --- | --- |
+| `just check-rmw-cyclonedds` (standalone backend project) | source | **absent** | OFF |
+| native nano-ros on this host | **find_package** (SDK store `0.10.5-nros1`) | present | impossible |
+| embedded / cross | source (find_package skipped when `CMAKE_CROSSCOMPILING`) | present | **ON** |
+
+Verified by configure output. The standalone project prints
+
+```
+-- nano-ros: CycloneDDS ddsrt heap -> libc (no NanoRos::Platform target to funnel into)
+```
+
+and the native root configure resolves
+
+```
+-- nano-ros: CycloneDDS via find_package (/home/aeon/.nros/sdk/cyclonedds/0.10.5-nros1/...)
+```
+
+so it never reaches the block at all. Only a cross build lands on the source
+branch with a platform present, and those are the embedded cyclone fixtures in
+tier 2.
+
+## Why this matters more than a coverage gap
+
+The funnel is a LINK-shape change: compiling it in turns three platform-ABI
+symbols into undefined references in every archive that absorbs `heap.c`. When
+`9f945dd93` set the define without the corresponding dependency, nothing failed
+at the switch — it failed at whichever executable linked `ddsc` first, three
+targets deep in the backend's own test suite. That was caught only because the
+standalone project happened to build those executables.
+
+After the dependency fix (`ad0e0e0ed`), the standalone project no longer
+compiles the funnel at all. So the lane that caught the breakage is now the lane
+that cannot see it, and the next regression in this shape surfaces in tier 2 —
+a day of latency, on a build that also costs a cross toolchain.
+
+## Verification that stands in for a lane today
+
+Reproducible by hand, ~4 min warm, and worth keeping in whatever fix lands:
+
+```
+cmake -S . -B <dir> -DNANO_ROS_PLATFORM=posix -DNANO_ROS_RMW=cyclonedds \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_DISABLE_FIND_PACKAGE_CycloneDDS=ON
+cmake --build <dir> --target ddsc
+nm <dir>/.../heap.c.o | grep nros_platform      # U alloc/realloc/dealloc, no U malloc/free
+```
+
+Forcing `-DCMAKE_DISABLE_FIND_PACKAGE_CycloneDDS=ON` is what makes a NATIVE
+build take the source branch, which is the cheapest way to reach funnel-ON
+without a cross toolchain.
+
+## Candidate fixes
+
+1. **A native funnel-ON configure+link in `check-rmw-cyclonedds`.** Costs a
+   second Cyclone build from source (~4 min warm), which is most of why the
+   recipe is currently 22 s. Probably too expensive for the fast line as-is.
+2. **Give the standalone backend project a platform target.** It is the nano-ros
+   Cyclone backend, and the funnel is now part of its contract; `nros_platform_posix`
+   is a standalone cmake project. Would need the path passed in as a cache var,
+   the way `CYCLONEDDS_SOURCE_DIR` already is — the module never walks the tree.
+   Turns the existing 22 s lane into a funnel-ON lane and keeps its three
+   executables as the link witness.
+3. **A configure-only assertion**: reach the source branch, assert the define
+   landed and the dependency is on the target, without building. Cheap, but it
+   checks the cmake and not the link, which is the half that broke.
+
+(2) looks best: it restores exactly the coverage that caught the original
+breakage, at no new build.
+
+## Note on the tier model
+
+Funnel-off on native is not a defect. `unified` is an embedded promise, native
+hosts have a real libc heap, and a `find_package` Cyclone cannot be funnelled at
+all. The gap is in TESTING the embedded shape cheaply, not in the shape itself.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-46 open. One line each — the detail lives in the issue file,
+48 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -103,6 +103,8 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
+- **#0880** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0880-*`.
+- **#0881** (ci) — Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into See `0881-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-45 open. One line each — the detail lives in the issue file,
+46 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -99,6 +99,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
 - **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
+- **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-46 open. One line each — the detail lives in the issue file,
+45 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -88,7 +88,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0836** (rmw) — A FreeRTOS/lwIP image receives every small ROS topic and never a fragmented one — a 13 KiB Autoware trajectory never arrives See `0836-*`.
 - **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
 - **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
-- **#0843** (core, platform) — `nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every cffi image needs a global allocator and the `heap-free` tier is unreachable See `0843-*`.
 - **#0847** (rmw) — An XRCE publisher outliving `executor.close()` segfaults in its own Drop: the entity destructor dereferences the session state that close already freed See `0847-*`.
 - **#0849** (cli) — `nros sync` bakes the invocation's path SPELLING into every leaf patch table, so working through a symlink to the checkout makes cargo see two copies of every core crate and refuse the build on `links` See `0849-*`.
 - **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.

--- a/docs/issues/archived/0843-node-runtime-forces-alloc-on-every-cffi-image.md
+++ b/docs/issues/archived/0843-node-runtime-forces-alloc-on-every-cffi-image.md
@@ -2,7 +2,7 @@
 id: 843
 title: "`nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every
   cffi image needs a global allocator and the `heap-free` tier is unreachable"
-status: open
+status: resolved
 type: bug
 area: core, platform
 related: [phase-391, issue-0816, issue-0832]

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -107,6 +107,21 @@ seconds later, which is exactly how 0371 cost as much time as it did.
 | `22150fbf` | fix(freertos): avoid TLS-only DDS state |
 | `99cfac88` | ddsrt: give every FreeRTOS thread its lwIP per-thread netconn semaphore |
 
+### 6. The platform allocation funnel (1 commit)
+
+| commit | subject |
+| --- | --- |
+| `6e2ad36f` | ddsrt/posix: route the heap through nano-ros's platform allocation funnel |
+
+Behind `-DNROS_DDSRT_PLATFORM_FUNNEL`, set by `ProvideCycloneDDS.cmake` on
+`ddsc` only (never on the tools-side `ddsrt-internal`: idlc and confgen link no
+platform layer). Undefined, the file is byte-identical to stock, so cyclone's
+own ctest suite is unaffected. Issue 0832 measured the funnel DEFINED and
+UNREFERENCED in native cyclone images; it now has 4 inbound edges and the whole
+`ddsrt_{malloc,malloc_s,calloc_s,realloc_s,free}` family is off `malloc@plt`.
+Compile-time rather than weak-linked on purpose: weak linkage leaves the libc
+branch in the binary, and its absence is what a tier gate has to read.
+
 With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
 its own netconn semaphore. ddsrt creates its own threads and never called
 `lwip_socket_thread_init()`, so the first socket call from one asserted

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -30,8 +30,14 @@ when upstream releases.
 
 ## What the fork adds
 
-15 commits, 39 files, +2251/−117 against the 0.10.x boundary `5041f356`.
-Five groups:
+19 commits, 45 files, +2353/−130 against the 0.10.x boundary `5041f356`.
+Seven groups.
+
+Re-measured 2026-08-29 and it had drifted BOTH ways: the headline said 15
+while the tables below listed 17, and `ae14b312` appeared in neither. A
+count that disagrees with its own table is worse than no count — it reads
+as the authoritative number. The two verification recipes at the bottom
+are the check; run them rather than trusting this line.
 
 ### 1. ThreadX / NetX Duo port (6 commits) — a platform upstream does not have
 
@@ -48,13 +54,14 @@ Almost entirely **additive** — new `ddsrt/{sync,threads,sockets,time,heap,
 ifaddrs,process}/threadx/` trees plus the `DDSRT_WITH_THREADX` selection arms.
 Retired only if upstream accepts a ThreadX port, which nobody has offered.
 
-### 2. Zephyr platform gaps (3 commits)
+### 2. Zephyr platform gaps (4 commits)
 
 | commit | subject |
 | --- | --- |
 | `290152c0` | fix(zephyr): tolerate NSOS socket gaps |
 | `1d794c0a` | ddsi_udp: Zephyr multicast join via `struct ip_mreqn` (issue 0231) |
 | `4aa337b0` | q_sockwaitset: AF_UNIX socketpair self-pipe on native-IP-stack Zephyr |
+| `ae14b312` | ddsrt: initialise the atomics mutexes at runtime on the Zephyr backend |
 
 Upstream *does* have a Zephyr port (`ports/zephyr`, `WITH_ZEPHYR`); these are
 places where it does not survive contact with Zephyr's native IP stack / NSOS.
@@ -107,6 +114,12 @@ seconds later, which is exactly how 0371 cost as much time as it did.
 | `22150fbf` | fix(freertos): avoid TLS-only DDS state |
 | `99cfac88` | ddsrt: give every FreeRTOS thread its lwIP per-thread netconn semaphore |
 
+With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
+its own netconn semaphore. ddsrt creates its own threads and never called
+`lwip_socket_thread_init()`, so the first socket call from one asserted
+`sem != NULL`. `thread_start_routine` is the point they have in common. Found by
+phase-370 W4, the first work to boot an embedded Cyclone image at all.
+
 ### 6. The platform allocation funnel (1 commit)
 
 | commit | subject |
@@ -122,11 +135,34 @@ UNREFERENCED in native cyclone images; it now has 4 inbound edges and the whole
 Compile-time rather than weak-linked on purpose: weak linkage leaves the libc
 branch in the binary, and its absence is what a tier gate has to read.
 
-With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
-its own netconn semaphore. ddsrt creates its own threads and never called
-`lwip_socket_thread_init()`, so the first socket call from one asserted
-`sem != NULL`. `thread_start_routine` is the point they have in common. Found by
-phase-370 W4, the first work to boot an embedded Cyclone image at all.
+### 7. Nested-build path resolution (1 commit)
+
+| commit | subject |
+| --- | --- |
+| `556f79d4` | build: resolve Cyclone's own paths by project, not by CMAKE_SOURCE_DIR |
+
+`CMAKE_SOURCE_DIR` is the TOP-LEVEL project's source dir, so a reference to a
+Cyclone file spelled that way is correct only when Cyclone is the top-level
+project. We reach it by `add_subdirectory()`, where it names nano-ros's root.
+
+Latent until section 6 made it reachable: `_confgen`'s hash check watches
+`ddsi_config.c`, so the first edit to that file arms the regeneration branch and
+its four `AppendHashScript.cmake` commands look for the script under nano-ros.
+The failure is not clean — `_confgen-exe` has already rewritten `defconfig.c`,
+`options.md`, `cyclonedds.rnc` and `cyclonedds.xsd` in the SOURCE tree, and the
+step that dies is the one appending the hashes, so a nested build leaves four
+generated files modified and hash-less and the next configure re-arms the same
+branch. This is what blocked routing `ddsi_config_init` through the funnel.
+
+`project(CycloneDDS ...)` defines `CycloneDDS_{SOURCE,BINARY}_DIR`, which mean
+"Cyclone's root" regardless of who included it. Identical to the old spelling in
+a standalone build, so upstream behaviour is unchanged and cyclone's own ctest
+suite is unaffected. Fixed at all nine sites that mean Cyclone's own tree
+(`_confgen`, `idlc/xtests`, `src/idl`'s `MAIN_PROJECT_DIR`, `fuzz`), not only
+the one that breaks a build today. `core/xtests/cdrtest` keeps its
+`CMAKE_SOURCE_DIR`: its scripts live in that test's own directory, so it is
+wrong standalone too — a different bug in a target this change cannot exercise.
+
 
 Pushed to `origin/nano-ros` as a fast-forward over `8601ca66`, and the
 superproject pin bumped to it afterwards — that order, not the reverse: a pin
@@ -176,10 +212,10 @@ Then, two recipes that cross-check each other:
 
 ```sh
 # by boundary: 5041f356 is the newest upstream 0.10.x commit the stack sits on
-git log --oneline 5041f356..origin/nano-ros          # -> 15
+git log --oneline 5041f356..origin/nano-ros          # -> 19
 
 # by authorship, as an independent check
-git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 15
+git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 19
 ```
 
 Do not count `origin/master..origin/nano-ros` alone: it sweeps in upstream 0.10.x

--- a/justfile
+++ b/justfile
@@ -3843,7 +3843,20 @@ ci-l3: rust-rtos-link-check
         echo "    (`just setup freertos` / `just setup nuttx`) or this lane proves nothing." >&2
         exit 1
     fi
-    echo "L3 passed — $checked cross ELF(s) checked without booting anything."
+    # phase-391 W1/W4 (issues 0816/0843) — the heap-free tier, on a REAL image.
+    # `heap-free-poc-mps2` calls `Executor::open_in` + `install_node_typed_in`
+    # over per-class static storage and links with NO allocation symbol at all
+    # (no `#[global_allocator]`, no `malloc`, no `nros_platform_alloc`). Three
+    # earlier probes passed this gate vacuously at `symbols read: 1`; this one
+    # reads the full symbol table of a linked image (~460). The build doubles
+    # as issue 0843's tripwire: the leaf compiles `nros` WITHOUT the `alloc`
+    # feature, so re-coupling the macro-path runtime to `alloc` breaks it.
+    echo "== L3 — heap-free tier: link gate on the no-alloc image =="
+    (cd packages/testing/nros-tests/bins/heap-free-poc-mps2 \
+        && cargo build $(nros_cargo_profile_arg_string))
+    python3 scripts/check-no-alloc-image.py --tier heap-free \
+        "packages/testing/nros-tests/bins/heap-free-poc-mps2/target/thumbv7m-none-eabi/$(nros_cargo_target_profile_dir)/heap-free-poc-mps2"
+    echo "L3 passed — $checked cross ELF(s) checked without booting anything, and the heap-free image links clean."
 
 # A COMPILE SMOKE TEST for the pull-request gate — phase-395.
 #

--- a/packages/api/nros/Cargo.toml
+++ b/packages/api/nros/Cargo.toml
@@ -76,6 +76,7 @@ std = [
     "nros-serdes/std",
 ]
 alloc = [
+    "dep:portable-atomic-util",
     "nros-core/alloc",
     "nros-node/alloc",
     "nros-rmw/alloc",
@@ -226,7 +227,11 @@ nros-serdes = { version = "0.5.0", path = "../../core/nros-serdes", default-feat
 # decl_err_from_node's no_std diagnostic (std builds use eprintln!).
 log = { version = "0.4", default-features = false }
 portable-atomic = { version = "1", default-features = false }
-portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"] }
+# W5-endgame (issue 0843) — OPTIONAL and carried by the `alloc` feature:
+# only `node_runtime`'s alloc-gated dynamic half (`CellHandle::Pooled`)
+# names `Arc`, and the dep's own "alloc" feature links the `alloc` crate,
+# which demands a global allocator in every downstream image.
+portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
 paste = "1"
 
 [dev-dependencies]

--- a/packages/api/nros/src/node_runtime.rs
+++ b/packages/api/nros/src/node_runtime.rs
@@ -50,6 +50,11 @@
 
 #![cfg(feature = "rmw-cffi")]
 
+// W5-endgame (issue 0843): the DECLARATION is gated too — a bare
+// `extern crate alloc` links the alloc crate into every image and rustc then
+// demands a `#[global_allocator]` even when nothing here allocates. This line
+// is what kept the first heap-free-tier image from linking.
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "alloc")]

--- a/packages/platform/nros-platform-mps2-an385/Cargo.toml
+++ b/packages/platform/nros-platform-mps2-an385/Cargo.toml
@@ -15,8 +15,15 @@ name = "nros_platform_mps2_an385"
 # FreeRTOS consumer that reuses only this crate's Cortex-M timing (DWT) already
 # has picolibc from the board, so it must `default-features = false` here to
 # avoid a `duplicate symbol: strtol` link conflict; PRNG / sleep / timing stay.
-default = ["libc-stubs"]
+default = ["libc-stubs", "libc-heap"]
 libc-stubs = ["nros-baremetal-common/libc-stubs"]
+# phase-391 W5-endgame (issues 0816/0843) — the HEAP libc shims
+# (`malloc`/`free`/`realloc`/`calloc`, src/libc_stubs.rs) get their own gate so
+# a heap-free-tier image can drop the symbols entirely: the W1 link gate
+# (`check-no-alloc-image --tier heap-free`) counts a DEFINED `malloc` as an
+# allocation surface whether or not anything calls it. Default-on — every
+# existing consumer (zenoh's Z_MALLOC route, XRCE's wrapper) keeps them.
+libc-heap = []
 # TLS support (larger heap: 128 KB instead of 64 KB)
 link-tls = []
 # Phase 97.3.mps2-an385 — DDS / DDS DcpsDomainParticipant + builtin

--- a/packages/platform/nros-platform-mps2-an385/src/lib.rs
+++ b/packages/platform/nros-platform-mps2-an385/src/lib.rs
@@ -11,6 +11,7 @@
 #![no_std]
 
 pub mod clock;
+#[cfg(feature = "libc-heap")]
 pub mod libc_stubs;
 pub mod memory;
 pub mod net;

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -543,7 +543,6 @@ dependencies = [
  "nros-zephyr-build",
  "paste",
  "portable-atomic",
- "portable-atomic-util",
 ]
 
 [[package]]
@@ -741,15 +740,6 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -575,7 +575,6 @@ dependencies = [
  "nros-zephyr-build",
  "paste",
  "portable-atomic",
- "portable-atomic-util",
 ]
 
 [[package]]
@@ -779,15 +778,6 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
@@ -179,26 +179,82 @@ macro(nros_provide_cyclonedds)
             # EXCLUDE_FROM_ALL: built only because nros_rmw_cyclonedds links
             # CycloneDDS::ddsc, not as part of `all`.
             add_subdirectory("${CYCLONEDDS_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds" EXCLUDE_FROM_ALL)
-            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`, not
-            # libc. Set on the ddsrt targets rather than globally: the switch is
-            # read by ONE fork TU (src/ddsrt/src/heap/*/heap.c), and a global
-            # define would also reach idlc and the confgen host tools, which
-            # link no platform layer. `ddsrt` is the object library the static
-            # `ddsc` absorbs; `ddsrt-internal` is its tools-side twin, which
-            # must NOT get the define for exactly that reason.
+            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`,
+            # not libc.
+            #
+            # The define and the LINK DEPENDENCY are one decision, made here.
+            # Compiling the funnel in turns three platform-ABI symbols into
+            # undefined references in every archive that absorbs `heap.c`, so a
+            # build that sets the define without linking a provider does not
+            # fail at the switch — it fails much later, at whichever executable
+            # happens to link ddsc first. That is why the provider is resolved
+            # BEFORE the define is set, and why the same block does both.
+            #
+            # Resolution is by target, not by guess: `NanoRos::Platform` is the
+            # Phase-138 §A canonical alias every platform module exposes, and
+            # every port defines the three symbols. When it is absent — the
+            # standalone `just cyclonedds ci` project builds the backend with no
+            # platform layer at all — the funnel stays OFF and Cyclone keeps its
+            # libc heap, which is the correct answer for a build that has no
+            # platform to funnel into. Both outcomes print, because a silently
+            # disabled funnel and an enabled one look identical from the recipe.
+            #
+            # The `unified`-tier gate (`scripts/check-no-alloc-image.py`) is what
+            # makes "off" safe to allow: it measures the linked ELF, so an image
+            # that was supposed to funnel and did not is caught there rather
+            # than trusted here.
+            #
+            # SCOPE, measured: this is the SELF-PROVISION branch, so the funnel
+            # reaches only builds that compile Cyclone from source. A
+            # find_package build links a Cyclone whose `heap.c` was already
+            # compiled — there is nothing left to define into it — and on a host
+            # with an SDK-store or ROS Cyclone that is what a NATIVE build
+            # resolves. Which is the right split for the tier model: `unified`
+            # is an embedded promise, a cross build skips find_package outright
+            # (see the CMAKE_CROSSCOMPILING branch above) and so always lands
+            # here with a platform target present.
+            #
+            # NOT a global define: the switch is read by ONE fork TU
+            # (src/ddsrt/src/heap/*/heap.c), and a global would also reach idlc
+            # and the confgen host tools, which link no platform layer.
             # `ddsrt` is an INTERFACE target in this layout — its sources
-            # compile INSIDE `ddsc`, so that is where the define has to land.
-            # `ddsrt-internal` (the tools-side twin that idlc/confgen link) is
-            # deliberately left alone: those hosts link no platform layer.
-            foreach(_nros_cdds_tgt ddsc ddsrt)
-                if(TARGET ${_nros_cdds_tgt})
-                    get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
-                    if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
-                        target_compile_definitions(${_nros_cdds_tgt}
-                            PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+            # compile INSIDE `ddsc`, so that is where both the define and the
+            # dependency have to land. `ddsrt-internal` (the tools-side twin
+            # idlc/confgen link) is deliberately left alone for the same reason.
+            if(TARGET NanoRos::Platform)
+                foreach(_nros_cdds_tgt ddsc ddsrt)
+                    if(TARGET ${_nros_cdds_tgt})
+                        get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
+                        if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
+                            target_compile_definitions(${_nros_cdds_tgt}
+                                PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+                            # PUBLIC: the reference lives in ddsc's own objects,
+                            # and consumers must get the provider AFTER ddsc on
+                            # the link line. Expressing it as a dependency is
+                            # what orders it — the alternative (a weak fallback
+                            # definition) would resolve the reference by
+                            # reintroducing the libc heap this issue exists to
+                            # remove, which the issue-0050 audit has no legal
+                            # `body:` label for.
+                            #
+                            # `$<BUILD_INTERFACE:>` because Cyclone `install
+                            # (EXPORT)`s `ddsc`, and an exported target may not
+                            # name a dependency outside its own export set —
+                            # without the genex, configure dies with "requires
+                            # target nros_platform_posix_iface that is not in
+                            # any export set". We never install this Cyclone
+                            # (it is added EXCLUDE_FROM_ALL and consumed from
+                            # the build tree), so the dependency is exactly a
+                            # build-tree one and the genex says so.
+                            target_link_libraries(${_nros_cdds_tgt}
+                                PUBLIC $<BUILD_INTERFACE:NanoRos::Platform>)
+                        endif()
                     endif()
-                endif()
-            endforeach()
+                endforeach()
+                message(STATUS "nano-ros: CycloneDDS ddsrt heap -> nros_platform_alloc (issue 0832)")
+            else()
+                message(STATUS "nano-ros: CycloneDDS ddsrt heap -> libc (no NanoRos::Platform target to funnel into)")
+            endif()
             # Where Cyclone generated its headers (dds/config.h, version.h, …) —
             # the backend needs this on the source path (see CMakeLists.txt).
             set(NROS_CYCLONEDDS_SOURCE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds")

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
@@ -179,6 +179,26 @@ macro(nros_provide_cyclonedds)
             # EXCLUDE_FROM_ALL: built only because nros_rmw_cyclonedds links
             # CycloneDDS::ddsc, not as part of `all`.
             add_subdirectory("${CYCLONEDDS_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds" EXCLUDE_FROM_ALL)
+            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`, not
+            # libc. Set on the ddsrt targets rather than globally: the switch is
+            # read by ONE fork TU (src/ddsrt/src/heap/*/heap.c), and a global
+            # define would also reach idlc and the confgen host tools, which
+            # link no platform layer. `ddsrt` is the object library the static
+            # `ddsc` absorbs; `ddsrt-internal` is its tools-side twin, which
+            # must NOT get the define for exactly that reason.
+            # `ddsrt` is an INTERFACE target in this layout — its sources
+            # compile INSIDE `ddsc`, so that is where the define has to land.
+            # `ddsrt-internal` (the tools-side twin that idlc/confgen link) is
+            # deliberately left alone: those hosts link no platform layer.
+            foreach(_nros_cdds_tgt ddsc ddsrt)
+                if(TARGET ${_nros_cdds_tgt})
+                    get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
+                    if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
+                        target_compile_definitions(${_nros_cdds_tgt}
+                            PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+                    endif()
+                endif()
+            endforeach()
             # Where Cyclone generated its headers (dds/config.h, version.h, …) —
             # the backend needs this on the source path (see CMakeLists.txt).
             set(NROS_CYCLONEDDS_SOURCE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds")

--- a/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
@@ -34,7 +34,7 @@ fn main() {
     // Phase 124.D.3.c — SPSC ring depth per subscriber. Default 4
     // keeps the static-RAM bump small (4 × SUBSCRIBER_BUFFER_SIZE
     // per subscriber); raise for burst-heavy topics. Must be ≥ 1.
-    let ring_depth: usize = env_usize("ZPICO_SUBSCRIBER_RING_DEPTH", 4).max(1);
+    let ring_depth: usize = env_usize_min("ZPICO_SUBSCRIBER_RING_DEPTH", 4, 1);
     // Phase 231 (RFC-0038) — size-class receive buffers. `SUBSCRIBER_BUFFER_SIZE`
     // above is the `small` class slot size; the `large` class is for big
     // messages (images, point clouds). A subscription routes to `large` when its
@@ -42,13 +42,13 @@ fn main() {
     // so the big slots don't multiply across every subscriber.
     let large_size: usize = env_usize("ZPICO_SUBSCRIBER_LARGE_SIZE", 16384);
     let size_threshold: usize = env_usize("ZPICO_SUBSCRIBER_SIZE_THRESHOLD", 2048);
-    let max_large: usize = env_usize("ZPICO_MAX_LARGE_SUBSCRIBERS", 2).max(1);
+    let max_large: usize = env_usize_min("ZPICO_MAX_LARGE_SUBSCRIBERS", 2, 1);
     // Phase 268 — per-session per-node NN liveliness token cap. One zenoh
     // session hosts at most the executor's node cap of graph nodes, so this
     // tracks `nros-node`'s `NROS_EXECUTOR_MAX_NODES` (default 4); keep them in
     // sync — set the same env var for both. `.max(1)` so a session always has
     // room for its own primary node.
-    let max_nodes: usize = env_usize("NROS_EXECUTOR_MAX_NODES", 4).max(1);
+    let max_nodes: usize = env_usize_min("NROS_EXECUTOR_MAX_NODES", 4, 1);
     // Issue 0813 — per-publisher TX arena capacity for the zero-copy loan path
     // (`SlotLending`). This was a bare `const` in `shim/publisher.rs`, so its
     // 1 KiB ceiling was neither raisable by a consumer nor visible to
@@ -116,6 +116,39 @@ const KCONFIG_KNOBS: &[(&str, &str)] = &[
         "CONFIG_NROS_SERVICE_BUFFER_SIZE",
     ),
 ];
+
+/// issue 0827 — a floored knob must REFUSE a value below its floor, never
+/// round it up.
+///
+/// These three pools cannot be zero-length: the lookup paths index them
+/// unconditionally, which is what the `.max(1)` this replaces was protecting.
+/// But `.max(1)` protected it by SILENTLY substituting 1, so
+/// `ZPICO_MAX_LARGE_SUBSCRIBERS=0` built a 65,536-byte pool and reported
+/// nothing — measured on `examples/native/rust/talker`, knob 0 and knob 1
+/// produce byte-identical `LARGE_PAYLOADS`.
+///
+/// That matters now because 0827's fix derives these knobs from the resolved
+/// model: an image with no subscriptions would ask for 0, get 1, and reserve
+/// 64 KiB while every config file and inventory line read as satisfied. A knob
+/// that cannot honour a value has to say so at BUILD time, where the person
+/// who set it is standing — the alternative is a saving that looks applied and
+/// is not, which is the defect class this campaign keeps finding.
+///
+/// Unset stays silent: the defaults are all above the floor.
+fn env_usize_min(name: &str, default: usize, min: usize) -> usize {
+    let v = env_usize(name, default);
+    if v < min {
+        panic!(
+            "{name}={v} is below this pool's floor of {min}.\n  \
+             The lookup path indexes the pool unconditionally, so a shorter one \
+             is not representable — raise the value, or change the lookup to \
+             refuse the entity kind first (issue 0827).\n  \
+             This used to be silently rounded up to {min}, which reserved the \
+             memory anyway while reading as though the knob had been honoured."
+        );
+    }
+    v
+}
 
 fn env_usize(name: &str, default: usize) -> usize {
     match KCONFIG_KNOBS.iter().find(|(env, _)| *env == name) {

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/.cargo/config.toml
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv7m-none-eabi"
+
+[target.thumbv7m-none-eabi]
+runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
+rustflags = [
+    "-C", "link-arg=-Tlink.x",
+    "-C", "link-arg=--nmagic",
+]

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/.gitignore
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/Cargo.toml
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/Cargo.toml
@@ -1,0 +1,34 @@
+[workspace]
+
+[package]
+name = "heap-free-poc-mps2"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+description = "phase-391 W5-endgame (issues 0816/0843) — the heap-free-tier image: calls the real executor + component-install seam and links with NO allocation symbol at all"
+
+[[bin]]
+name = "heap-free-poc-mps2"
+test = false
+bench = false
+
+[dependencies]
+# The point of this image: `nros` WITHOUT the `alloc` feature. The macro-path
+# runtime (per-class static storage, placed cells, `install_node_typed_in`)
+# is available on `rmw-cffi` alone since the W5 endgame; if a future change
+# re-couples it to `alloc`, this leaf stops COMPILING — which is the cheapest
+# possible tripwire for issue 0843's regression class.
+nros = { path = "../../../../api/nros", default-features = false, features = ["rmw-cffi", "macros"] }
+# Platform primitives WITHOUT the heap libc shims: `default-features = false`
+# drops `libc-heap` (malloc/free/realloc/calloc) — a DEFINED `malloc` counts
+# as an allocation surface for the W1 gate whether or not anything calls it —
+# and `libc-stubs` (string helpers), which only C transports need.
+# `cffi-export` keeps `nros_platform_log_write` resolving for nros-log.
+nros-platform-mps2-an385 = { path = "../../../../platform/nros-platform-mps2-an385", default-features = false, features = ["cffi-export"] }
+nros-platform-cffi = { path = "../../../../platform/nros-platform-cffi", default-features = false }
+nros-log = { path = "../../../../core/nros-log", default-features = false }
+
+cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
+panic-semihosting = { version = "0.6", features = ["exit"] }

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/build.rs
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/build.rs
@@ -1,0 +1,16 @@
+//! Phase 88.15.a — emit `memory.x` into OUT_DIR so cortex-m-rt's
+//! `link.x` finds it without depending on the board crate's build
+//! script.
+
+use std::{env, fs::File, io::Write, path::PathBuf};
+
+fn main() {
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/memory.x
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/memory.x
@@ -1,0 +1,6 @@
+/* Minimal memory layout for MPS2-AN385 (QEMU Cortex-M3) — Phase 88.15.a */
+MEMORY
+{
+    FLASH : ORIGIN = 0x00000000, LENGTH = 4M
+    RAM   : ORIGIN = 0x20000000, LENGTH = 4M
+}

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/src/main.rs
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/src/main.rs
@@ -1,0 +1,115 @@
+//! phase-391 W5-endgame (issues 0816/0843) — the heap-free-tier image.
+//!
+//! Calls the REAL runtime path an embedded component image takes —
+//! `Executor::open_in` over a caller-supplied static backing, then the
+//! `install_node_typed_in` seam over a per-class `ComponentSlotStorage` — and
+//! links with **no allocation symbol at all**: no `#[global_allocator]`, no
+//! `__rust_alloc` shim, no `malloc`, no `nros_platform_alloc`. The W1 gate
+//! (`scripts/check-no-alloc-image.py --tier heap-free`) asserts that on the
+//! built ELF; three earlier probes passed it vacuously at `symbols read: 1`
+//! because they only NAMED types — this image is the non-vacuous replacement.
+//!
+//! No RMW backend is linked (every in-tree transport allocates in C — zenoh's
+//! `z_malloc`, XRCE's wrapper `malloc`, cyclone's `ddsrt_malloc` — so a
+//! transport image is `unified` tier at best). `Executor::open_in` therefore
+//! returns `NoBackend` at RUNTIME, which the image reports as its success
+//! marker: the LINK property is the property under test, and the runtime
+//! marker proves the code path executed to the open call rather than being
+//! optimized away. The install + spin arm stays linked because the open's
+//! outcome is opaque to LLVM (it reads the cffi backend registry).
+
+#![no_std]
+#![no_main]
+
+use core::mem::MaybeUninit;
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::{debug, hprintln};
+use nros::{
+    BootConfig, ComponentSlotStorage, EntityBounds, ExecutorConfig, ExecutorSizing,
+    node::{Callback, CallbackCtx, ExecutableNode, Node, NodeContext, NodeResult, TickCtx},
+};
+use panic_semihosting as _;
+
+// Force-link the per-platform export so `nros_platform_log_write` resolves
+// (the logging-smoke pattern — staticlib DCE drops the rlib otherwise).
+extern crate nros_platform_mps2_an385 as _;
+
+/// A component that declares NOTHING — the seam is under test, not a
+/// transport. Exact zero bounds, so its per-class cell registries and ctx
+/// slabs are all zero-length: the whole static store is a few words.
+struct PocNode;
+
+impl Node for PocNode {
+    const NAME: &'static str = "heap_free_poc";
+    const ENTITY_BOUNDS: EntityBounds = EntityBounds::exact(0, 0, 0, 0, 0);
+
+    fn register(_ctx: &mut NodeContext<'_>) -> NodeResult<()> {
+        Ok(())
+    }
+}
+
+impl ExecutableNode for PocNode {
+    type State = u32;
+
+    fn init() -> Self::State {
+        0
+    }
+
+    fn on_callback(_state: &mut Self::State, _cb: Callback<'_>, _ctx: &mut CallbackCtx<'_>) {}
+
+    fn tick(state: &mut Self::State, _ctx: &mut TickCtx<'_>) {
+        *state = state.wrapping_add(1);
+    }
+}
+
+/// The per-class slot storage the macro would emit — spelled by hand here so
+/// the image does not need `nros::main!`'s board scaffold (whose
+/// `ExecutorNodeRuntime` half is the alloc-gated DYNAMIC path).
+static POC_STORE: ComponentSlotStorage<PocNode> = ComponentSlotStorage::new();
+
+/// Caller-supplied executor backing — the `open_in` contract. `static mut`
+/// touched exactly once, before the executor exists.
+static mut BACKING: [MaybeUninit<u64>; ExecutorSizing::DEFAULT.u64_len()] =
+    [MaybeUninit::uninit(); ExecutorSizing::DEFAULT.u64_len()];
+
+#[entry]
+fn main() -> ! {
+    nros_platform_cffi::log::init_default();
+
+    let config = ExecutorConfig::resolve(BootConfig {
+        node_name: Some("heap_free_poc"),
+        locator: None,
+        domain_id: Some(0),
+        namespace: None,
+    });
+
+    // SAFETY: `BACKING` is `'static`, exactly `u64_len()` words, and this is
+    // the only reference ever taken (single-threaded `#[entry]`, before any
+    // executor exists).
+    let backing: &'static mut [MaybeUninit<u64>] = unsafe { &mut *(&raw mut BACKING) };
+
+    match unsafe { nros::Executor::open_in(&config, backing, ExecutorSizing::DEFAULT) } {
+        Ok(mut executor) => {
+            // Unreachable on this fixture (no backend linked), but LLVM cannot
+            // prove that, so the whole install + spin path is IN the image —
+            // which is exactly what the link gate measures.
+            let rc = unsafe {
+                nros::install_node_typed_in(
+                    &mut executor as *mut _ as *mut core::ffi::c_void,
+                    &POC_STORE,
+                )
+            };
+            hprintln!("HEAP-FREE-POC: unexpected open success, install rc={}", rc);
+            let _ = executor.spin_once(core::time::Duration::from_millis(10));
+            debug::exit(debug::EXIT_FAILURE);
+        }
+        Err(_) => {
+            // The expected arm: selection fails (zero backends registered)
+            // AFTER the executor machinery is linked and the open path ran.
+            hprintln!("HEAP-FREE-POC: open refused (no RMW linked) — link property holds");
+            debug::exit(debug::EXIT_SUCCESS);
+        }
+    }
+    loop {}
+}

--- a/scripts/check-sched-dim-arms-compile.sh
+++ b/scripts/check-sched-dim-arms-compile.sh
@@ -49,12 +49,31 @@ fail=0
 say()  { printf '  %s\n' "$*"; }
 head2() { printf '\n== %s ==\n' "$*"; }
 
+# A cross gcc on PATH is not a cross gcc that can COMPILE: the CI container
+# ships the bare binary without newlib, so `<string.h>` is absent and every
+# arm FAILs on a header this gate is not testing (the cross-libc gate already
+# skips on the same container for the same reason). Probe usability once —
+# presence of the compiler AND its libc headers — and let each arm skip
+# legibly on the same wording.
+arm_gcc_usable=""
+arm_gcc_unusable_why=""
+if command -v arm-none-eabi-gcc >/dev/null 2>&1; then
+    if printf '#include <string.h>\n#include <stdlib.h>\nint main(void){return 0;}\n' \
+        | arm-none-eabi-gcc -fsyntax-only -x c - >/dev/null 2>&1; then
+        arm_gcc_usable=1
+    else
+        arm_gcc_unusable_why="arm-none-eabi-gcc has no usable newlib (<string.h>/<stdlib.h> absent)"
+    fi
+else
+    arm_gcc_unusable_why="arm-none-eabi-gcc not on PATH"
+fi
+
 # --- freertos: vTaskCoreAffinitySet ----------------------------------------
 head2 "freertos core-pin arm (vTaskCoreAffinitySet)"
 if [ -z "${FREERTOS_DIR:-}" ] || [ ! -d "${FREERTOS_DIR}" ]; then
     nros_check_skip "check-sched-dim-arms(freertos)" "FREERTOS_DIR unset/absent (source ./activate.sh)"
-elif ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
-    nros_check_skip "check-sched-dim-arms(freertos)" "arm-none-eabi-gcc not on PATH"
+elif [ -z "$arm_gcc_usable" ]; then
+    nros_check_skip "check-sched-dim-arms(freertos)" "$arm_gcc_unusable_why"
 else
     out="$(arm-none-eabi-gcc -fsyntax-only -mcpu=cortex-m3 -mthumb \
         -DconfigUSE_CORE_AFFINITY=1 \
@@ -105,8 +124,8 @@ fi
 head2 "nuttx core-pin arm (pthread_setaffinity_np)"
 if [ -z "${NUTTX_DIR:-}" ] || [ ! -d "${NUTTX_DIR}/include" ]; then
     nros_check_skip "check-sched-dim-arms(nuttx)" "NUTTX_DIR unset/absent (source ./activate.sh)"
-elif ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
-    nros_check_skip "check-sched-dim-arms(nuttx)" "arm-none-eabi-gcc not on PATH"
+elif [ -z "$arm_gcc_usable" ]; then
+    nros_check_skip "check-sched-dim-arms(nuttx)" "$arm_gcc_unusable_why"
 elif [ ! -f "$NUTTX_DIR/nros-nuttx-export-arm/include/nuttx/config.h" ]; then
     # Issue 0525. The tree is SHARED SOURCE, but `nuttx/config.h` is build
     # OPTIONS, and one shared copy cannot hold two arches: it belongs to
@@ -155,8 +174,8 @@ fi
 head2 "threadx core-pin arm (tx_thread_smp_core_exclude)"
 if [ -z "${THREADX_DIR:-}" ] || [ ! -d "${THREADX_DIR}/common_smp/inc" ]; then
     nros_check_skip "check-sched-dim-arms(threadx)" "THREADX_DIR unset, or no common_smp/inc (source ./activate.sh)"
-elif ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
-    nros_check_skip "check-sched-dim-arms(threadx)" "arm-none-eabi-gcc not on PATH"
+elif [ -z "$arm_gcc_usable" ]; then
+    nros_check_skip "check-sched-dim-arms(threadx)" "$arm_gcc_unusable_why"
 else
     out="$(arm-none-eabi-gcc -fsyntax-only -mcpu=cortex-a7 \
         -DTX_THREAD_SMP \

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -60,6 +60,16 @@ KNOB_PATTERNS = [
     # wrapper is the natural thing to write when several knobs share a
     # resolution rule, so match the shape rather than asking each crate not to.
     re.compile(r'\bknob\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*\)'),
+    # `env_usize_min("NAME", default, floor)` — a knob whose reader REFUSES a
+    # value below a floor instead of silently rounding it up (issue 0827). The
+    # reported figure is the DEFAULT, exactly as for every other spelling: the
+    # floor is a validity rule on what a user may ask for, not a size the image
+    # pays. Added with the spelling, not after it: renaming the two zpico reads
+    # to this wrapper made `ZPICO_SUBSCRIBER_RING_DEPTH` and
+    # `ZPICO_MAX_LARGE_SUBSCRIBERS` invisible here, and with them the byte
+    # figures for BOTH payload pools -- the `SLOTS` regression this list already
+    # records, one wrapper later.
+    re.compile(r'\benv_usize_min\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*,\s*[0-9_]+\s*\)'),
 ]
 
 # `// nros-pool: NAME = KNOB * KNOB * 4` — products of knobs and integers only.
@@ -90,7 +100,7 @@ def crate_of(rel):
 # the ones issue-0271's failure mode hides (executor arena, zpico batch/frag
 # buffers: the LARGEST consumers). They must appear in the table, not be
 # silently dropped by a literal-only regex.
-KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat)?|knob)\(\s*"([A-Z0-9_]+)"')
+KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat|_min)?|knob)\(\s*"([A-Z0-9_]+)"')
 
 
 def scan(files=None):
@@ -222,7 +232,15 @@ def self_test():
     assert got == 128 and err is None, f"product at defaults wrong: {got} {err}"
     got, err = pool_bytes("A * NOPE", knobs)
     assert got is None and "NOPE" in err, "an unknown knob must not silently vanish"
-    probe = 'let x = env_usize("NROS_PROBE_SLOTS", 12);\n// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
+    # Every reader spelling gets a probe line. A spelling with no case here is
+    # a spelling that can be added, break the scan, and still self-test green —
+    # which is how `env_usize_min` deleted two knobs and two pool figures.
+    probe = (
+        'let x = env_usize("NROS_PROBE_SLOTS", 12);\n'
+        'let y = env_usize_min("NROS_PROBE_DEPTH", 3, 1);\n'
+        '// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
+        '// nros-pool: Q = NROS_PROBE_DEPTH * NROS_PROBE_SLOTS\n'
+    )
     tmp = os.path.join(ROOT, "tmp")
     os.makedirs(tmp, exist_ok=True)
     p = os.path.join(tmp, "_pool_probe.rs")
@@ -231,8 +249,16 @@ def self_test():
     k, pl = scan([os.path.relpath(p, ROOT)])
     os.unlink(p)
     assert k.get("NROS_PROBE_SLOTS", (None,))[0] == 12, "knob not scanned"
-    assert pl and pl[0][0] == "P", "pool annotation not scanned"
-    assert pool_bytes(pl[0][1], k)[0] == 96, "annotated pool bytes wrong"
+    assert k.get("NROS_PROBE_DEPTH", (None,))[0] == 3, (
+        "env_usize_min knob not scanned — its DEFAULT is the reported figure, "
+        "not its floor (issue 0827)"
+    )
+    by_name = {name: expr for name, expr, *_ in pl}
+    assert "P" in by_name, "pool annotation not scanned"
+    assert pool_bytes(by_name["P"], k)[0] == 96, "annotated pool bytes wrong"
+    assert pool_bytes(by_name["Q"], k)[0] == 36, (
+        "a pool sized by an env_usize_min knob must resolve to bytes"
+    )
     sys.stdout.write("gen-pool-inventory self-test: OK\n")
 
 


### PR DESCRIPTION
Stacked on #17 (`fix/0832-cyclone-funnel`), per the FIFO merge-queue rule — not on `main`.

Docs only. Two issues filed for gaps measured while fixing #17; neither is fixed here.

**#0880 — `just format` is build-state dependent.** `examples/workspaces/launch`'s two Rust leaves are members of a workspace root that `nros build` generates and `.gitignore` hides, so the recipe is green on a tree that built that workspace and red on one that did not. `example_shape.rs` already records this fact and reads the tracked `.colcon_workspace` marker; nothing else does.

Swept the class, not the site — nearest enclosing `[workspace]`, root `members` globs expanded, `exclude` honoured, each candidate cross-checked against `cargo metadata`. Exactly two leaves, both under `launch`. Third occurrence of the shape issue 0359 named, second distinct cause.

The detail that makes it a design question rather than two `exclude` lines: `mixed` is equally unbuilt and equally migrated, and formats fine only because its one leaf carries its own `[workspace]` while `launch`'s two do not. Two leaf shapes coexist in one workspace class, and the gate that could forbid that currently does neither.

**#0881 — the funnel-ON cyclone path has no fast-line lane.** The switch only exists on the self-provision branch, so: standalone backend project has no platform to funnel into; native host resolves `find_package` from the SDK store; only a cross build lands on source-with-platform. Before #17 the standalone project was what caught the missing link dependency — after it, that lane no longer compiles the funnel, so the next regression of this shape surfaces in tier 2. Issue carries three candidate fixes and the ~4 min by-hand check that stands in meanwhile.

`just check-fast`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa