### PR TITLE
fix(#832, #881): the XRCE half, and a fast-line lane that actually compiles the funnel

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-44 open. One line each — the detail lives in the issue file,
+42 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -84,7 +84,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0829** (api, rmw) — Two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on depth — 1 in `nros-rmw`, 10 in the `nros::qos` façade, each with two callers See `0829-*`.
 - **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
 - **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
-- **#0832** (platform, rmw) — `nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and xrce native images — the vendor allocators bypass the funnel See `0832-*`.
 - **#0834** (cmake) — The per-build `nros_cpp_config_generated.h` mirror can reach a state no re-run repairs — only wiping the west build dir recovers it See `0834-*`.
 - **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
 - **#0836** (rmw) — A FreeRTOS/lwIP image receives every small ROS topic and never a fragmented one — a 13 KiB Autoware trajectory never arrives See `0836-*`.
@@ -100,7 +99,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0880** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0880-*`.
-- **#0881** (ci) — Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into See `0881-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/archived/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
+++ b/docs/issues/archived/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
@@ -2,7 +2,7 @@
 id: 832
 title: "`nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and
   xrce native images — the vendor allocators bypass the funnel"
-status: open
+status: resolved
 type: bug
 area: platform, rmw
 related: [phase-391, issue-0817]
@@ -136,11 +136,55 @@ is guarded to `__APPLE__ || (__linux && (__GLIBC__ || __UCLIBC__))` and
 platform's heap and libc's differ, and where it does exist it pairs with a
 block `backtrace_symbols` allocated from glibc itself.
 
-**Still open: the XRCE half.** `get_ip_from_iface` was not touched, so the xrce
-row of the table above stands.
+## Resolution, XRCE half (2026-08-29)
 
-**Also open: coverage.** The funnel-ON path is built by no fast-line lane — see
-issue 0881. The verification above is by hand.
+The bypass was never where this issue said it was. `get_ip_from_iface` is a
+**zenoh-pico** symbol (`src/system/{unix,windows,freertos,rpi_pico}/network.c`)
+and appears nowhere in the XRCE tree, so that row was a misattribution. The
+vendored micro-XRCE-DDS-Client and micro-CDR call no allocator directly at all.
+
+The real bypass is **our own shim** — 38 raw `calloc`/`free` calls across six
+files of `packages/rmw/xrce/nros-rmw-xrce/src/`, in-tree code needing no fork:
+
+| file | calloc | free |
+| --- | ---: | ---: |
+| `session.c` | 1 | 7 |
+| `service.c` | 2 | 4 |
+| `publisher.c` | 1 | 2 |
+| `subscriber.c` | 1 | 2 |
+| `transport_nros_udp.c` | 2 | 10 |
+| `transport_zephyr_udp.c` | 2 | 4 |
+
+All of them go through `nros_xrce_calloc` / `nros_xrce_free` in `src/internal.h`,
+two `static inline`s over `nros_platform_alloc`/`_dealloc`. The zeroing lives in
+the helper rather than at the call sites: every allocation was
+`calloc(1, sizeof(X))` on a struct only partly assigned afterwards, so it is
+load-bearing, and a `memset` to be remembered nine times is one forgotten at the
+tenth.
+
+Measured: `libnros_rmw_xrce.a` — vendored client and micro-CDR included — has
+**zero** objects referencing a raw libc allocator, and 10 funnel references.
+
+Two things fell out of it. The standalone check project took platform HEADERS
+via a cache var but linked no implementation, so it stopped linking the moment
+the shim called the funnel; it now pulls `nros-platform-posix` in the same
+style, which is what `nros-rmw-xrce-cffi`'s build.rs already required of the
+image path ("as long as the consumer links a platform-provider library"). And
+`tests/smoke.c` carried NINE local definitions of platform symbols, added by
+issue 0787 for exactly the reason that no longer holds. They are deleted: the
+real archive defines every one. Only two collided at link time (`clock_ns`,
+`sleep_ms`) because the linker pulls an archive member only for an
+already-unresolved reference, so the local UDP definitions meant `net.c.o` was
+never reached — a second implementation of the platform ABI selected silently by
+link order, which is the hazard the issue-0050 policy exists to prevent,
+arrived at with no weak symbol involved.
+
+## Coverage (2026-08-29)
+
+Closed too — see issue 0881. The standalone cyclone project now links a
+platform implementation, so the fast-line lane compiles the funnel: the three
+executables that caught the original missing link dependency each carry 7 funnel
+call sites and run as part of the 22-test suite.
 
 ## Method note
 

--- a/docs/issues/archived/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
+++ b/docs/issues/archived/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
@@ -1,7 +1,7 @@
 ---
 id: 881
 title: "Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into"
-status: open
+status: resolved
 area: ci
 severity: medium
 found: 2026-08-29
@@ -94,3 +94,36 @@ breakage, at no new build.
 Funnel-off on native is not a defect. `unified` is an embedded promise, native
 hosts have a real libc heap, and a `find_package` Cyclone cannot be funnelled at
 all. The gap is in TESTING the embedded shape cheaply, not in the shape itself.
+
+## Resolved (2026-08-29)
+
+Candidate 2, as expected — and the XRCE half of issue 0832 forced the same
+change one project over, which is what settled it. `nros-rmw-xrce`'s shim
+started allocating through the funnel, so its standalone project stopped
+linking until it gained a platform implementation; the pattern that fixed it
+transfers verbatim.
+
+The cyclone project now resolves `NROS_PLATFORM_IMPL_DIR` (a cache PATH
+defaulted to the sibling `nros-platform-posix`, the same convention
+`CYCLONEDDS_SOURCE_DIR` and the header vars already use) and aliases it as
+`NanoRos::Platform`, which is what the funnel gate asks for. Both guarded on
+the targets not already existing, so a parent nano-ros build still wins.
+
+Measured on `just check-rmw-cyclonedds`:
+
+```
+-- nano-ros: CycloneDDS ddsrt heap -> nros_platform_alloc (issue 0832)
+libddsc.a  heap.c.o -> U nros_platform_{alloc,realloc,dealloc}
+           one object left on a raw libc allocator (sysdeps.c.o's free)
+nros_rmw_cyclonedds_ros2_{sub,srv_client,srv_server}: 7 funnel call sites each
+100% tests passed, 0 tests failed out of 22
+```
+
+Those three executables are the ones that caught the original missing link
+dependency, so the lane is back to covering the shape it covered before the
+dependency fix — this time with the funnel actually compiled, and end to end
+rather than at link only.
+
+Cost: the lane builds a platform archive it did not build before. Cyclone
+itself was already built from source here, so there is no second Cyclone build
+and the ~22 s figure in the recipe's own comment is unaffected in kind.

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
@@ -36,6 +36,37 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 #   defaults it to the pinned third-party submodule, sccache-accelerated).
 # So a bare cmake build needs no `just cyclonedds` pre-step. Sets
 # NROS_CYCLONEDDS_PROVENANCE (target|find_package|source).
+# ---- Platform implementation (issue 0881) ----------------------------------
+# The funnel is enabled by `nros_provide_cyclonedds()` only when a platform
+# target exists to funnel INTO, so before this block the standalone project
+# built Cyclone with its libc heap and the funnel-ON path had no lane at all:
+# a native nano-ros build resolves Cyclone through `find_package` (already
+# compiled, nothing to define into), and only a cross build reached the
+# funnel — tier 2, a day of latency, and a cross toolchain.
+#
+# That mattered because the funnel is a LINK-shape change. It was this
+# project's three test executables that caught the missing link dependency the
+# first time; after the dependency landed, this project stopped compiling the
+# funnel and the next regression of that shape would have surfaced in tier 2.
+#
+# The location arrives as a cache PATH defaulted to the sibling project, the
+# same convention `CYCLONEDDS_SOURCE_DIR` and the header vars already use, so
+# this file still never searches the tree and a consumer can override it.
+# Guarded on the targets not already existing, so a parent project providing
+# its own platform wins.
+set(NROS_PLATFORM_IMPL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../platform/nros-platform-posix"
+    CACHE PATH "Path to a project providing the nros platform ABI implementation")
+if(NOT TARGET nros_platform_posix AND NOT TARGET NanoRos::Platform
+   AND EXISTS "${NROS_PLATFORM_IMPL_DIR}/CMakeLists.txt")
+    add_subdirectory("${NROS_PLATFORM_IMPL_DIR}" nros_platform_impl_build)
+endif()
+# `NanoRos::Platform` is the Phase-138 §A canonical alias the funnel gate asks
+# for. A parent nano-ros build already defines it over its INTERFACE wrapper;
+# standalone there is no wrapper, so alias the archive directly.
+if(NOT TARGET NanoRos::Platform AND TARGET nros_platform_posix)
+    add_library(NanoRos::Platform ALIAS nros_platform_posix)
+endif()
+
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ProvideCycloneDDS.cmake")
 nros_provide_cyclonedds()
 

--- a/packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt
+++ b/packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt
@@ -173,6 +173,25 @@ foreach(_rel IN LISTS _ucdr_src)
     list(APPEND _ucdr_all_src "${MICROCDR_DIR}/src/c/${_rel}")
 endforeach()
 
+# ---- Platform implementation ----------------------------------------------
+# Issue 0832 — the backend ALLOCATES through `nros_platform_alloc` (see the
+# `nros_xrce_calloc`/`nros_xrce_free` helpers in src/internal.h), so headers
+# alone are no longer enough to link. `nros-rmw-xrce-cffi`'s build.rs states
+# the same contract for the image path: these sources compile on every target
+# "as long as the consumer links a platform-provider library". This project
+# was the one consumer that did not.
+#
+# Same convention as the two header vars above: the location arrives as a
+# cache PATH defaulted to the sibling project, so an out-of-tree consumer can
+# point it elsewhere and this file still never searches the tree. Guarded on
+# the target not already existing, so a parent project that provides its own
+# platform wins.
+set(NROS_PLATFORM_IMPL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../platform/nros-platform-posix"
+    CACHE PATH "Path to a project providing the nros platform ABI implementation")
+if(NOT TARGET nros_platform_posix AND EXISTS "${NROS_PLATFORM_IMPL_DIR}/CMakeLists.txt")
+    add_subdirectory("${NROS_PLATFORM_IMPL_DIR}" nros_platform_impl_build)
+endif()
+
 # ---- Static library --------------------------------------------------------
 add_library(nros_rmw_xrce STATIC
     src/vtable.c
@@ -203,6 +222,22 @@ target_include_directories(nros_rmw_xrce
         ${CMAKE_CURRENT_BINARY_DIR}/uxr_generated
         ${CMAKE_CURRENT_BINARY_DIR}/ucdr_generated
 )
+
+# PUBLIC so consumers get the provider AFTER this archive on the link line:
+# the references live in this library's own objects, and being a dependency is
+# what orders it. Without it the smoke test fails with `undefined reference to
+# nros_platform_alloc` from `transport_nros_udp.c.o` — the same shape as the
+# cyclone funnel's link (issue 0832), and fixed the same way rather than with a
+# weak fallback, which would resolve the reference by calling libc and put back
+# exactly the second heap this change removes.
+if(TARGET nros_platform_posix)
+    target_link_libraries(nros_rmw_xrce PUBLIC nros_platform_posix)
+    message(STATUS "nano-ros: nros-rmw-xrce allocates via nros_platform_alloc (issue 0832)")
+else()
+    message(FATAL_ERROR
+        "nros-rmw-xrce needs a platform ABI implementation (nros_platform_alloc/dealloc). "
+        "Set -DNROS_PLATFORM_IMPL_DIR=<path> or define an `nros_platform_posix` target.")
+endif()
 
 target_compile_definitions(nros_rmw_xrce PRIVATE
     # POSIX feature gate — `time.c` calls `clock_gettime`, which

--- a/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
@@ -13,6 +13,7 @@
  * module-static `XrceSessionState` it relies on.
  */
 
+#include "nros/platform.h"
 #include "nros/rmw_entity.h"
 #include "nros/rmw_event.h"
 #include "nros/rmw_ret.h"
@@ -24,9 +25,50 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <string.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Issue 0832 — this backend allocates through the platform funnel, never libc.
+ *
+ * The shim is linked ABOVE the platform layer, so libc's heap is not
+ * necessarily the heap the platform owns: on Zephyr, FreeRTOS, ThreadX and
+ * NuttX it is a different allocator entirely, and the `unified` tier promises
+ * that every allocation reaches `nros_platform_alloc`. A raw `calloc`/`free`
+ * here allocates from one heap and, once a board routes the other way, frees
+ * to another.
+ *
+ * The zeroing lives in the helper rather than at the call sites. Every
+ * allocation in this backend was `calloc(1, sizeof(X))` on a struct whose
+ * fields are then only partly assigned, so the zeroing is load-bearing — and a
+ * `memset` that has to be remembered at nine call sites is one that gets
+ * forgotten at the tenth.
+ */
+static inline void *nros_xrce_calloc(size_t count, size_t size) {
+    size_t total;
+    void *ptr;
+
+    if (count == 0 || size == 0) {
+        count = size = 1;
+    }
+    /* The multiply is the one thing calloc does that alloc cannot, so keep its
+       overflow check rather than trusting the product. */
+    total = count * size;
+    if (total / size != count) {
+        return NULL;
+    }
+    if ((ptr = nros_platform_alloc(total)) != NULL) {
+        memset(ptr, 0, total);
+    }
+    return ptr;
+}
+
+static inline void nros_xrce_free(void *ptr) {
+    /* `nros_platform_dealloc` is a documented no-op on NULL, matching free(). */
+    nros_platform_dealloc(ptr);
+}
 
 /* ---- Tunables (must mirror packages/rmw/xrce/nros-rmw-xrce/build.rs
  *      defaults so the C backend behaves the same as the Rust one

--- a/packages/rmw/xrce/nros-rmw-xrce/src/publisher.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/publisher.c
@@ -44,7 +44,7 @@ rmw_ret_t xrce_publisher_create(const rmw_node_t* node,
     }
 
     xrce_publisher_state *ps = (xrce_publisher_state *)
-        calloc(1, sizeof(xrce_publisher_state));
+        nros_xrce_calloc(1, sizeof(xrce_publisher_state));
     if (ps == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -87,7 +87,7 @@ rmw_ret_t xrce_publisher_create(const rmw_node_t* node,
     uint8_t  statuses[3] = { 0, 0, 0 };
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 3);
     if (cret != NROS_RMW_RET_OK) {
-        free(ps);
+        nros_xrce_free(ps);
         return cret;
     }
 
@@ -113,7 +113,7 @@ rmw_ret_t xrce_publisher_destroy(rmw_publisher_t *publisher) {
                                             ps->datawriter_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(ps);
+    nros_xrce_free(ps);
     publisher->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/service.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/service.c
@@ -142,7 +142,7 @@ rmw_ret_t xrce_service_create(const rmw_node_t* node, const char* service_name,
     }
 
     xrce_service_server_state* ss =
-        (xrce_service_server_state*)calloc(1, sizeof(xrce_service_server_state));
+        (xrce_service_server_state*)nros_xrce_calloc(1, sizeof(xrce_service_server_state));
     if (ss == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -185,7 +185,7 @@ rmw_ret_t xrce_service_create(const rmw_node_t* node, const char* service_name,
     uint8_t statuses[1] = {0};
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 1);
     if (cret != NROS_RMW_RET_OK) {
-        free(ss);
+        nros_xrce_free(ss);
         return cret;
     }
 
@@ -231,7 +231,7 @@ rmw_ret_t xrce_service_destroy(rmw_service_t* server) {
     uint16_t req = uxr_buffer_delete_entity(&st->session, st->output_reliable, ss->replier_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(ss);
+    nros_xrce_free(ss);
     server->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }
@@ -552,7 +552,7 @@ rmw_ret_t xrce_client_create(const rmw_node_t* node, const char* service_name,
     }
 
     xrce_service_client_state* cs =
-        (xrce_service_client_state*)calloc(1, sizeof(xrce_service_client_state));
+        (xrce_service_client_state*)nros_xrce_calloc(1, sizeof(xrce_service_client_state));
     if (cs == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -589,7 +589,7 @@ rmw_ret_t xrce_client_create(const rmw_node_t* node, const char* service_name,
     uint8_t statuses[1] = {0};
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 1);
     if (cret != NROS_RMW_RET_OK) {
-        free(cs);
+        nros_xrce_free(cs);
         return cret;
     }
 
@@ -630,7 +630,7 @@ rmw_ret_t xrce_client_destroy(rmw_client_t* client) {
     uint16_t req = uxr_buffer_delete_entity(&st->session, st->output_reliable, cs->requester_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(cs);
+    nros_xrce_free(cs);
     client->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/session.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/session.c
@@ -302,7 +302,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         return NROS_RMW_RET_ERROR;
     }
 
-    xrce_session_state_t* st = (xrce_session_state_t*)calloc(1, sizeof(xrce_session_state_t));
+    xrce_session_state_t* st = (xrce_session_state_t*)nros_xrce_calloc(1, sizeof(xrce_session_state_t));
     if (st == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -344,7 +344,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         st->use_custom_transport = true;
         rmw_ret_t ret = xrce_custom_transport_install(st, /*framing=*/false);
         if (ret != NROS_RMW_RET_OK) {
-            free(st);
+            nros_xrce_free(st);
             return ret;
         }
         uxr_init_session(&st->session, &st->custom.comm, hash_session_key(node_name));
@@ -353,7 +353,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         st->use_custom_transport = true;
         rmw_ret_t sret = xrce_posix_serial_init(st, serial_path);
         if (sret != NROS_RMW_RET_OK) {
-            free(st);
+            nros_xrce_free(st);
             return sret;
         }
         uxr_init_session(&st->session, &st->custom.comm, hash_session_key(node_name));
@@ -376,7 +376,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         if (parse_host_port(addr_locator, host, sizeof(host), &port) == 0) {
             size_t hlen = strlen(addr_locator);
             if (hlen == 0 || hlen + 1 > sizeof(host)) {
-                free(st);
+                nros_xrce_free(st);
                 return NROS_RMW_RET_INVALID_ARGUMENT;
             }
             memcpy(host, addr_locator, hlen + 1);
@@ -390,7 +390,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         st->use_custom_transport = true;
         rmw_ret_t udp_ret = xrce_nros_udp_init(st, host, port_str);
         if (udp_ret != NROS_RMW_RET_OK) {
-            free(st);
+            nros_xrce_free(st);
             return udp_ret;
         }
         uxr_init_session(&st->session, &st->custom.comm, hash_session_key(node_name));
@@ -408,7 +408,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         /* Both UDP and `custom://` paths now go through
          * uxrCustomTransport — close via custom_transport. */
         uxr_close_custom_transport(&st->custom);
-        free(st);
+        nros_xrce_free(st);
         return NROS_RMW_RET_ERROR;
     }
 
@@ -436,7 +436,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
     if (cret != NROS_RMW_RET_OK) {
         (void)uxr_delete_session(&st->session);
         uxr_close_custom_transport(&st->custom);
-        free(st);
+        nros_xrce_free(st);
         return cret;
     }
 
@@ -458,7 +458,7 @@ rmw_ret_t xrce_session_destroy(rmw_session_t* session) {
      * UDP through the same surface to match xrce-sys's legacy
      * shape. Close once, regardless of `use_custom_transport`. */
     uxr_close_custom_transport(&st->custom);
-    free(st);
+    nros_xrce_free(st);
     session->backend_data = NULL;
     return NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
@@ -139,7 +139,7 @@ rmw_ret_t xrce_subscription_create(const rmw_node_t* node,
     }
 
     xrce_subscriber_state *ss = (xrce_subscriber_state *)
-        calloc(1, sizeof(xrce_subscriber_state));
+        nros_xrce_calloc(1, sizeof(xrce_subscriber_state));
     if (ss == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -179,7 +179,7 @@ rmw_ret_t xrce_subscription_create(const rmw_node_t* node,
     uint8_t  statuses[3] = { 0, 0, 0 };
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 3);
     if (cret != NROS_RMW_RET_OK) {
-        free(ss);
+        nros_xrce_free(ss);
         return cret;
     }
 
@@ -234,7 +234,7 @@ rmw_ret_t xrce_subscription_destroy(rmw_subscription_t *subscriber) {
                                             ss->datareader_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(ss);
+    nros_xrce_free(ss);
     subscriber->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/transport_nros_udp.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/transport_nros_udp.c
@@ -41,12 +41,12 @@ static bool nros_udp_close(struct uxrCustomTransport *t) {
     if (b == NULL) return true;
     if (b->sock != NULL) {
         nros_platform_udp_close(b->sock);
-        free(b->sock);
+        nros_xrce_free(b->sock);
         b->sock = NULL;
     }
     if (b->endpoint != NULL) {
         nros_platform_udp_free_endpoint(b->endpoint);
-        free(b->endpoint);
+        nros_xrce_free(b->endpoint);
         b->endpoint = NULL;
     }
     return true;
@@ -91,11 +91,11 @@ rmw_ret_t xrce_nros_udp_init(xrce_session_state_t *st,
     }
 
     xrce_nros_udp_bridge *bridge = (xrce_nros_udp_bridge *)&st->udp_bridge;
-    bridge->sock = calloc(1, XRCE_NROS_SOCK_STORAGE_BYTES);
-    bridge->endpoint = calloc(1, XRCE_NROS_ENDPOINT_STORAGE_BYTES);
+    bridge->sock = nros_xrce_calloc(1, XRCE_NROS_SOCK_STORAGE_BYTES);
+    bridge->endpoint = nros_xrce_calloc(1, XRCE_NROS_ENDPOINT_STORAGE_BYTES);
     if (bridge->sock == NULL || bridge->endpoint == NULL) {
-        free(bridge->sock);
-        free(bridge->endpoint);
+        nros_xrce_free(bridge->sock);
+        nros_xrce_free(bridge->endpoint);
         bridge->sock = NULL;
         bridge->endpoint = NULL;
         return NROS_RMW_RET_ERROR;
@@ -104,16 +104,16 @@ rmw_ret_t xrce_nros_udp_init(xrce_session_state_t *st,
     if (nros_platform_udp_create_endpoint(bridge->endpoint,
                                           (const uint8_t *)host,
                                           (const uint8_t *)port) != 0) {
-        free(bridge->sock);
-        free(bridge->endpoint);
+        nros_xrce_free(bridge->sock);
+        nros_xrce_free(bridge->endpoint);
         bridge->sock = NULL;
         bridge->endpoint = NULL;
         return NROS_RMW_RET_ERROR;
     }
     if (nros_platform_udp_open(bridge->sock, bridge->endpoint, 100) != 0) {
         nros_platform_udp_free_endpoint(bridge->endpoint);
-        free(bridge->sock);
-        free(bridge->endpoint);
+        nros_xrce_free(bridge->sock);
+        nros_xrce_free(bridge->endpoint);
         bridge->sock = NULL;
         bridge->endpoint = NULL;
         return NROS_RMW_RET_ERROR;
@@ -127,8 +127,8 @@ rmw_ret_t xrce_nros_udp_init(xrce_session_state_t *st,
         bridge, {
             nros_platform_udp_close(bridge->sock);
             nros_platform_udp_free_endpoint(bridge->endpoint);
-            free(bridge->sock);
-            free(bridge->endpoint);
+            nros_xrce_free(bridge->sock);
+            nros_xrce_free(bridge->endpoint);
             bridge->sock = NULL;
             bridge->endpoint = NULL;
         });

--- a/packages/rmw/xrce/nros-rmw-xrce/src/transport_zephyr_udp.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/transport_zephyr_udp.c
@@ -26,8 +26,8 @@ static bool zephyr_udp_close(struct uxrCustomTransport *t) {
     if (b->endpoint != NULL) {
         nros_platform_udp_free_endpoint(b->endpoint);
     }
-    free(b->sock);
-    free(b->endpoint);
+    nros_xrce_free(b->sock);
+    nros_xrce_free(b->endpoint);
     b->sock = NULL;
     b->endpoint = NULL;
     return true;
@@ -41,8 +41,8 @@ static void zephyr_udp_bridge_cleanup(xrce_zephyr_udp_bridge *b) {
     if (b->endpoint != NULL) {
         nros_platform_udp_free_endpoint(b->endpoint);
     }
-    free(b->sock);
-    free(b->endpoint);
+    nros_xrce_free(b->sock);
+    nros_xrce_free(b->endpoint);
     b->sock = NULL;
     b->endpoint = NULL;
 }
@@ -77,8 +77,8 @@ rmw_ret_t xrce_zephyr_udp_init(xrce_session_state_t *st,
     }
 
     xrce_zephyr_udp_bridge *bridge = (xrce_zephyr_udp_bridge *)&st->udp_bridge;
-    bridge->sock = calloc(1, sizeof(int));
-    bridge->endpoint = calloc(1, sizeof(void *));
+    bridge->sock = nros_xrce_calloc(1, sizeof(int));
+    bridge->endpoint = nros_xrce_calloc(1, sizeof(void *));
     if (bridge->sock == NULL || bridge->endpoint == NULL) {
         zephyr_udp_bridge_cleanup(bridge);
         return NROS_RMW_RET_ERROR;

--- a/packages/rmw/xrce/nros-rmw-xrce/tests/smoke.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/tests/smoke.c
@@ -35,53 +35,29 @@ rmw_ret_t nros_rmw_cffi_register_named(const char *name, const nros_rmw_vtable_t
     return NROS_RMW_RET_OK;
 }
 
-/* The platform clock + sleep this backend's session drive loop calls. Same
- * reason as the UDP stubs below. */
-uint64_t nros_platform_clock_ns(void) { return 0; }
-void nros_platform_sleep_ms(size_t ms) { (void) ms; }
-void nros_platform_udp_set_recv_timeout(const void *sock, uint32_t timeout_ms) {
-    (void) sock;
-    (void) timeout_ms;
-}
-
-/* Issue 0787 — the platform UDP primitives this backend's `nros_udp`
- * transport calls. They live in the Rust platform layer, which a standalone C
- * build of this backend does not link, so the smoke test stubs them exactly as
- * it already stubs the registry entry point. Every one FAILS: the test never
- * opens a transport, and a stub that pretended to succeed would make the test
- * assert against a socket that does not exist.
+/* Issue 0832 — the platform clock, sleep and UDP primitives are NOT stubbed
+ * here any more.
  *
- * Without these the test did not LINK, which is why nothing built this backend
- * on a host and why five phase-376 signature changes crossed it unchecked. */
-int8_t nros_platform_udp_create_endpoint(void *ep, const uint8_t *address,
-                                         const uint8_t *port) {
-    (void) ep;
-    (void) address;
-    (void) port;
-    return -1;
-}
-void nros_platform_udp_free_endpoint(void *ep) { (void) ep; }
-int8_t nros_platform_udp_open(void *sock, const void *endpoint, uint32_t timeout_ms) {
-    (void) sock;
-    (void) endpoint;
-    (void) timeout_ms;
-    return -1;
-}
-void nros_platform_udp_close(void *sock) { (void) sock; }
-size_t nros_platform_udp_read(const void *sock, uint8_t *buf, size_t len) {
-    (void) sock;
-    (void) buf;
-    (void) len;
-    return 0;
-}
-size_t nros_platform_udp_send(const void *sock, const uint8_t *buf, size_t len,
-                              const void *endpoint) {
-    (void) sock;
-    (void) buf;
-    (void) len;
-    (void) endpoint;
-    return 0;
-}
+ * Issue 0787 added nine local definitions because "they live in the Rust
+ * platform layer, which a standalone C build of this backend does not link".
+ * That is no longer true: the backend allocates through `nros_platform_alloc`,
+ * so this project links `nros_platform_posix`, and the same archive defines
+ * every one of these — `clock_ns` and `sleep_ms` in `platform.c`, all fifteen
+ * `udp_*` entry points in `net.c`.
+ *
+ * Keeping the stubs would be a second implementation of the platform ABI
+ * chosen by link order, and the two disagree: the stubs deliberately FAIL every
+ * call while the real ones work. Only two collided at link time — `clock_ns`
+ * and `sleep_ms` — because the linker pulls an archive member only for an
+ * already-unresolved reference, so the local UDP definitions meant `net.c.o`
+ * was never reached. A silent win by link order is exactly the hazard the
+ * issue-0050 weak-symbol policy exists to prevent, arrived at without any weak
+ * symbol.
+ *
+ * `nros_rmw_cffi_register{,_named}` above stay stubbed: those live in the Rust
+ * cffi crate, which this project genuinely does not link, and the stub IS the
+ * assertion — it records the vtable the backend hands over.
+ */
 
 /* Issue 0782 — the streamed-publish chunk loop.
  *


### PR DESCRIPTION
Stacked on #28. Closes **both** #832 and #881 — they turned out to be the same change one project apart.

## #832, XRCE half

**The bypass was never where the issue said it was.** `get_ip_from_iface` is a *zenoh-pico* symbol (`src/system/{unix,windows,freertos,rpi_pico}/network.c`) and appears nowhere in the XRCE tree — that row was a misattribution. The vendored micro-XRCE-DDS-Client and micro-CDR call no allocator directly at all.

The real bypass is **our own shim**: 38 raw `calloc`/`free` calls across six files, in-tree, no fork needed.

| file | calloc | free |
| --- | ---: | ---: |
| `session.c` | 1 | 7 |
| `service.c` | 2 | 4 |
| `publisher.c` | 1 | 2 |
| `subscriber.c` | 1 | 2 |
| `transport_nros_udp.c` | 2 | 10 |
| `transport_zephyr_udp.c` | 2 | 4 |

All now go through `nros_xrce_calloc`/`nros_xrce_free` — two `static inline`s over the platform ABI in `internal.h`. The zeroing lives in the helper, not at the call sites: every allocation was `calloc(1, sizeof(X))` on a struct only partly assigned afterwards, so it is load-bearing, and a `memset` to be remembered nine times is one forgotten at the tenth.

**Measured:** `libnros_rmw_xrce.a` — vendored client and micro-CDR included — has **zero** objects referencing a raw libc allocator, and 10 funnel references.

### Two things fell out

The standalone check project took platform *headers* via a cache var but linked no implementation, so it stopped linking the moment the shim called the funnel. It now pulls `nros-platform-posix` in the same style — which is what `nros-rmw-xrce-cffi`'s build.rs already required of the image path ("as long as the consumer links a platform-provider library"). This project was the one consumer that did not.

And `tests/smoke.c` carried **nine local definitions of platform symbols**, added by #787 for a reason that no longer holds. Deleted — the real archive defines every one. Only two collided at link time, because the linker pulls an archive member only for an already-unresolved reference and the local UDP definitions meant `net.c.o` was never reached. So seven of the nine were a second implementation of the platform ABI selected silently by link order, with the two implementations **disagreeing**: the stubs fail every call, the real ones work. That is the hazard the issue-0050 policy exists to prevent, reached with no weak symbol involved.

## #881, the coverage gap

Candidate 2, and the XRCE work is what settled it — the pattern transfers verbatim. The cyclone project resolves `NROS_PLATFORM_IMPL_DIR` (cache PATH defaulted to the sibling project, the convention `CYCLONEDDS_SOURCE_DIR` already uses) and aliases it as `NanoRos::Platform`, which is what the funnel gate asks for. Both guarded on the targets not already existing, so a parent nano-ros build still wins.

`just check-rmw-cyclonedds` now prints `CycloneDDS ddsrt heap -> nros_platform_alloc`, and `nros_rmw_cyclonedds_ros2_{sub,srv_client,srv_server}` carry **7 funnel call sites each**. Those three are the executables that caught the original missing link dependency — the lane is back to covering that shape, this time with the funnel actually compiled and end-to-end rather than at link only. 22/22.

No second Cyclone build; this lane already built it from source. It gains a platform archive it did not build before.

## Not done here

`packages/rmw/xrce/nros-rmw-xrce/src` is **not covered by `check-c-fmt`**, and those files use right-pointer style against the repo's `PointerAlignment: Left`. Running the pinned clang-format over them produced ~350 lines of churn unrelated to this change, so the edits follow the files' existing style. Widening the gate is a separate change with a reformat attached.

## Verification

- `just check-rmw-xrce`: 1/1
- `just check-rmw-cyclonedds`: 22/22, funnel ON
- `just ci-l1`: green

Both issues moved to `docs/issues/archived/` with the measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa