### PR TITLE
docs(#0882): a `--target <exe>` deletes the NuttX kernel it claims to build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,20 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   building the header target directly does not help; only `rm -rf` on the west build dir
   does. Survey with: for each `zephyr-workspace/build-*/nros-rust/nros-{cpp,c}-generated/nros`,
   a `.stamp` with no `.h` beside it. Two such leaves stopped a whole `lane=all` sweep.
+- **`rm -rf` + rebuild is an ANTIPATTERN — it destroys the evidence and fixes nothing.**
+  The build system supports incremental builds; if an incremental build produces a wrong
+  artifact, that is a MISSING DEPENDENCY EDGE and the edge is the bug. Wiping proves only
+  that a full build works, which was never in doubt, and it costs the one reproduction you
+  needed to find the edge. It also teaches the next person that the tree is untrustworthy,
+  so they wipe too, and the real defect never gets filed.
+  Before reaching for `rm -rf`, in this order: `ninja -C <dir> -t query <target>` (does the
+  artifact actually depend on what changed?), `touch` the input and confirm a relink, and
+  read the `.d`/`build.ninja` edge. Issue 0475 is the canonical case — a lib inside a raw
+  `-Wl,` flag gets NO edge, and the fix was `LINK_DEPENDS`, not a wipe.
+  The rule has exactly two exemptions, both documented and both about a build that CANNOT
+  converge: the sizes-header mirror reaching a state no re-run repairs (issue 0834), and a
+  core-crate/`repr(C)` change mixing pre/post-append objects. Outside those, if you wiped
+  and it worked, you have a lead — not a diagnosis; say so, and go find the edge.
 - **Build-side stale probes must watch the same inputs as test-side gates** — a probe that misses
   `generated/**` lets a museum binary pass every sweep while tests fail STALE (issue 0196).
 - **Sweep contract:** every `just <plat>` invocation needs `source ./activate.sh` first (PATH wires

--- a/docs/issues/0882-nuttx-carrier-target-deletes-the-kernel-it-claims-to-build.md
+++ b/docs/issues/0882-nuttx-carrier-target-deletes-the-kernel-it-claims-to-build.md
@@ -1,0 +1,88 @@
+---
+id: 882
+title: "`cmake --build --target <exe>` DELETES the NuttX kernel it is documented
+  to produce — two producers write one path and only one can succeed"
+status: open
+type: bug
+area: cmake, boards
+related: [issue-0475, issue-0870, phase-385]
+---
+
+## The claim, and the measurement that contradicts it
+
+`cmake/board/nano-ros-board-nuttx-qemu-arm.cmake:394` documents the arrangement:
+
+>     EXCLUDE_FROM_ALL — keep it out of the default build
+>     add_dependencies(carrier <name>_build) — `cmake --build . --target <name>`
+>       still produces the kernel ELF via the cargo path
+
+It does not. Run against a good tree:
+
+    $ sha256sum build-zenoh/cpp_action_client        # 7196a77b40bc…, 826 620 bytes
+    $ cmake --build build-zenoh --target cpp_action_client
+    …
+    collect2: error: ld returned 1 exit status
+    ninja: build stopped: subcommand failed.
+    rc=1
+    $ ls build-zenoh/cpp_action_client
+    ls: cannot access …: No such file or directory
+
+The command fails AND takes the working kernel with it, because ninja deletes a
+failed rule's output.
+
+## Why
+
+Two producers write `build-zenoh/<exe>`:
+
+* `build <exe>: CXX_EXECUTABLE_LINKER…` — `main.cpp` plus the message archives
+  and nothing else. It CANNOT link: `undefined reference to _lseek / _read /
+  _exit / _kill / _getpid`, the NuttX syscalls that only the cargo path
+  supplies. The comment above it already knows this, which is why the target is
+  `EXCLUDE_FROM_ALL`.
+* `CMakeFiles/<exe>_build.util` — `cmake -E copy nros-nuttx-ffi-out/nros-nuttx-ffi
+  <exe>`, the REAL kernel. Its declared ninja output is the `.util` stamp, so
+  the file it actually writes is an **undeclared output**.
+
+Ninja therefore believes the unbuildable link owns that path, and the copy
+writes it behind ninja's back. `add_dependencies` makes `<exe>_build` run
+FIRST — it does not stop the link from running afterwards and clobbering the
+result.
+
+## Blast radius: dormant by default, live by name
+
+* A plain `ninja` is SAFE — `ninja -n` shows only `Copying <exe> to build
+  directory`. The link is `EXCLUDE_FROM_ALL`, so `all` never reaches it. This
+  is why every fixture build passes.
+* Asking for the target BY NAME triggers it: `cmake --build . --target <exe>`
+  or `ninja <exe>`. That form is not hypothetical —
+  `scripts/build/workspace-fixtures-build.sh:10` documents
+  `cmake --build … --target <entry>` as one of its two build paths.
+
+So the tree is one `--target` away from silently losing a fixture, and the
+failure mode is a MISSING BINARY, which the test side reports as "not prebuilt"
+— pointing at the fixture build rather than at the thing that deleted it.
+
+## Fix, not applied here
+
+The copy should be a `POST_BUILD` step of a target that can actually build, or
+the carrier should declare the kernel as its `BYPRODUCTS`/`OUTPUT` so ninja
+knows who owns the path. What must not remain is two rules writing one file
+with only `add_dependencies` between them.
+
+## Found while chasing issue 0870, and NOT yet shown to cause it
+
+0870's nuttx C++ action cell fails intermittently. This defect is a plausible
+mechanism — a deleted or stale image explains a lot — but it is **not
+demonstrated** to be the cause: normal fixture builds never invoke the
+destructive path, and the 0870 flake has not reproduced in 17+ consecutive runs
+since. Recorded as its own bug because it is one regardless of 0870.
+
+Found by following the "do not `rm -rf`, find the edge" practice: `ninja -t
+query <exe>` showed `<exe>_build` as an ORDER-ONLY (`||`) dependency, which is
+what prompted looking at who really writes the file.
+
+## Acceptance
+
+* `cmake --build . --target <exe>` either produces a working kernel or fails
+  without destroying the existing one.
+* One rule owns `build-zenoh/<exe>`, and ninja knows which.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-46 open. One line each — the detail lives in the issue file,
+47 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -103,6 +103,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0870** (rmw, examples) — NuttX C++ action client fails `create_action_client` — the session reports `Transport(ConnectionFailed)` against a router the server reached See `0870-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0877** (testing, boards) — FreeRTOS pubsub delivers by hand and delivers NOTHING under the test harness — and the talker trips a FreeRTOS queue assert See `0877-*`.
+- **#0882** (cmake, boards) — `cmake --build --target <exe>` DELETES the NuttX kernel it is documented to produce — two producers write one path and only one can succeed See `0882-*`.
 
 <!-- END GENERATED open-issue list -->
 


### PR DESCRIPTION
**Stacked on #10** (per the stacking policy — base B on `fix/a`, never on `main`).

Two producers write `build-zenoh/<exe>` on the nuttx-qemu-arm carrier:

- `build <exe>: CXX_EXECUTABLE_LINKER…` — `main.cpp` + message archives and nothing else. It **cannot link**: `undefined reference to _lseek / _read / _exit / _kill / _getpid`, the NuttX syscalls only the cargo path supplies. The comment above it knows this, which is why it's `EXCLUDE_FROM_ALL`.
- `CMakeFiles/<exe>_build.util` — `cmake -E copy nros-nuttx-ffi → <exe>`, the **real** kernel. Its declared ninja output is the `.util` stamp, so the file it writes is an **undeclared output**.

Ninja therefore believes the unbuildable link owns that path. `add_dependencies` makes the copy run *first*; it does not stop the link running after.

## The documented claim is false

`cmake/board/nano-ros-board-nuttx-qemu-arm.cmake:394` says `cmake --build . --target <name>` "still produces the kernel ELF via the cargo path". Measured:

```
sha256 before   7196a77b40bc…   826 620 bytes
cmake --build build-zenoh --target cpp_action_client   ->  rc=1
ls build-zenoh/cpp_action_client -> No such file or directory
```

It fails **and takes the working kernel with it**, because ninja deletes a failed rule's output.

## Blast radius

Dormant by default — `ninja -n` shows only `Copying <exe> to build directory`, which is why every fixture build passes. Live the moment the target is asked for **by name**, and that form is in-tree: `scripts/build/workspace-fixtures-build.sh:10`. The failure presents as a *missing binary*, which the test side reports as "not prebuilt" — pointing at the fixture build rather than at what deleted it.

## Not claimed

That this causes #0870's flake. Normal builds never invoke the destructive path and the flake hasn't reproduced in 17+ runs. Filed on its own merits.

## Also: CLAUDE.md gains the practice that found it

`rm -rf` + rebuild is an **antipattern** — a wrong incremental artifact is a *missing dependency edge*, and the edge is the bug. Wiping proves only that a full build works and destroys the reproduction. Prescribes `ninja -t query`, touch-and-relink, and reading the edge first, with #0475 as the canonical case. Two exemptions kept (#0834's sizes-header state; core-crate object mixing).

That practice is exactly what found this: `ninja -t query <exe>` showed `<exe>_build` as an **order-only** (`||`) dependency, which prompted asking who really writes the file.

Fix not applied — the copy should be a `POST_BUILD` of a buildable target, or the carrier should declare the kernel as its output so ninja knows the owner.

Closes #0882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk