### PR TITLE
fix(zephyr): honour the declared task priority, and give the board a unique zenoh id

### DIFF
--- a/docs/design/0084-readiness-is-pushed-not-scanned.md
+++ b/docs/design/0084-readiness-is-pushed-not-scanned.md
@@ -1,0 +1,251 @@
+---
+rfc: 0084
+title: "Readiness is PUSHED by the arrival path, not scanned by the executor — the wake says who, not just that"
+status: Draft
+since: 2026-08
+last-reviewed: 2026-08-28
+implements-tracked-by: []
+amends: [rfc-0052]
+supersedes: []
+superseded-by: null
+---
+
+# RFC-0084 — Readiness is pushed, not scanned
+
+> The executor is already woken *precisely* — a k_sem signalled from the
+> backend's arrival path, sub-millisecond, ISR-capable. It then throws that
+> precision away and searches every registered entity to find out what
+> happened. This RFC closes the gap between the wake and the search.
+
+## 1. The problem, counted
+
+`Executor::spin_once` wakes, then does this
+(`nros-node/src/executor/spin.rs`, activation phase):
+
+```rust
+for (i, meta) in self.entries.iter().enumerate() {
+    ...
+    if unsafe { (meta.has_data)(data_ptr) } { ... }
+}
+```
+
+One indirect call per registered entity, **every spin, regardless of what woke
+it**. `MAX_CALLBACK_SLOTS = 64` (`spin.rs:1000`), so the ceiling is 64 indirect
+calls through function pointers the compiler cannot devirtualise, each one
+typically reaching into a backend ring buffer, to discover the one or two bits
+that changed.
+
+The asymmetry is the point:
+
+| | today |
+| --- | --- |
+| wake latency | one `k_sem_give`, sub-ms, ISR-safe |
+| wake precision | **binary** — "something happened" |
+| find out what | **O(N) indirect calls** |
+| N | up to 64 |
+
+The wake path already knows exactly which entity received data. The signal it
+raises discards that, and the executor rediscovers it by exhaustive search.
+
+## 2. Why the information is lost
+
+`nros_rmw_runtime_wake_cb` (`spin.rs:673`) takes one argument:
+
+```rust
+pub(crate) unsafe extern "C" fn nros_rmw_runtime_wake_cb(ctx: *mut c_void) {
+    let wake = unsafe { &*(ctx as *const WakeCtx) };
+    wake.flag.store(true, SeqCst);
+    if let Some(nw) = wake.node_wake.as_ref() { nw.signal(); }
+}
+```
+
+`ctx` identifies the **executor**, not the entity. The zenoh shim mirrors the
+callback into a process-global (`shim/mod.rs:184`, `set_runtime_wake_cb`) so
+the real arrival hook — `subscriber_notify_callback` and its service twin —
+can fire it "at the real arrival point". That hook is standing at the exact
+place where the identity is known, and the ABI it must call through has nowhere
+to put it.
+
+So the executor is woken by the right event and then cannot act on it.
+
+## 3. What already exists
+
+Most of the destination is built. `ReadySet`
+(`executor/ready_set/mod.rs`) is a presence **bitmap**:
+
+```rust
+pub(crate) struct FifoReadySet<const N: usize> { bits: u64 }
+
+fn insert(&mut self, job: ActiveJob) -> Result<(), Overflow> {
+    self.bits |= 1u64 << job.desc_idx; Ok(())
+}
+fn pop_next(&mut self) -> Option<ActiveJob> {
+    let idx = self.bits.trailing_zeros() as DescIdx;
+    self.bits &= !(1u64 << idx);
+    ...
+}
+```
+
+`insert` is idempotent by construction, `pop_next` is a `CLZ`-class single
+instruction on Cortex-M7, and `BucketedFifoSet` / `BucketedEdfSet` already
+layer priority buckets and EDF ordering on top. `MAX_CALLBACK_SLOTS = 64`
+matches the `u64` width exactly.
+
+**The set is the right shape and it is already the dispatch input.** What is
+missing is only that nothing writes into it except the scan.
+
+## 4. Proposal
+
+### 4.1 The wake carries a token
+
+Extend the runtime wake callback with an entity token:
+
+```c
+/* today */
+void nros_rmw_runtime_wake_cb(void *ctx);
+
+/* proposed */
+void nros_rmw_runtime_wake_cb_tok(void *ctx, uint32_t token);
+```
+
+`token` is opaque to the backend: it is whatever the executor handed out at
+registration time. The executor mints it as the `DescIdx` it already assigns,
+so the callback body becomes:
+
+```rust
+wake.ready_bits.fetch_or(1u64 << token, Ordering::SeqCst);
+wake.flag.store(true, Ordering::SeqCst);
+if let Some(nw) = wake.node_wake.as_ref() { nw.signal(); }
+```
+
+A `fetch_or` on an `AtomicU64` — lock-free, ISR-callable, and on a 32-bit
+target `portable_atomic` supplies it. `NROS_RMW_WAKE_TOKEN_UNKNOWN` (all ones)
+means "I know something arrived but not what", and degrades to the scan for
+that spin. That is the honest answer for a backend that cannot attribute an
+arrival, and it keeps the token optional rather than mandatory.
+
+### 4.2 Registration hands the token out
+
+`set_wake_callback` is session-scoped today. Entity-scoped wake registration
+already exists in the public C API — `nros_subscription_set_wake_callback`,
+`nros_service_set_wake_callback`, `nros_client_set_wake_callback` — so the
+token is passed there, at the point where the executor already knows the
+descriptor index.
+
+### 4.3 The scan becomes the fallback
+
+```
+spin_once:
+  wait on wake primitive
+  bits = ready_bits.swap(0)
+  if bits == 0 or any session reported UNKNOWN:
+      scan entries[]   <-- unchanged code path, poll-only backends
+  else:
+      seed the ReadySet directly from `bits`
+  evaluate Trigger
+  dispatch
+```
+
+Poll-only backends (XRCE-DDS-Client, bare-metal smoltcp, current Cyclone) never
+supply a token, always report UNKNOWN, and get **exactly today's behaviour**.
+This is the same graceful-degradation contract `supports_wake_callback` already
+states, one level finer.
+
+### 4.4 Triggers still work
+
+`Trigger::AllOf` / `AnyOf` evaluate against a `ReadinessSnapshot`. Seeding that
+snapshot from `bits` rather than from 64 `has_data` calls changes where the
+bits come from, not what they mean. `Trigger::Custom` is unaffected — it
+receives the same bool array.
+
+One semantic caveat, and it is the reason `has_data` cannot simply be deleted:
+a bit records that data *arrived*, while `has_data` reports that data is
+*present now*. A callback that drains its queue and a concurrent arrival can
+disagree. The rule that keeps them consistent: **the bit is cleared when the
+callback is dispatched, not when the queue is drained**, and a spurious
+dispatch to an empty queue is permitted — callbacks already tolerate this,
+because the idempotent-insert contract has always allowed one ready bit to
+stand for any number of queued messages.
+
+## 5. This is the vehicle for the dead 110.A traits
+
+`Activator` and `Dispatcher` (`executor/activator.rs`, `executor/dispatcher.rs`)
+were defined by phase 110.A with the note "110.A.b rewires `spin_once` to drive
+activation through this trait instead of the inline bitmap scan". 110.A.b never
+landed. Both traits carry `#[allow(dead_code)]`, `ActivatorCtx` is a
+`PhantomData` shell, and grep finds no reference outside their own files and
+doc comments.
+
+They describe precisely the seam this RFC needs: something that decides *what
+should fire* separately from something that *fires it*. Two activators —
+`ScanActivator` (today's loop) and `PushedActivator` (read the bitmap) — is the
+natural shape, selected per session by whether a token was supplied.
+
+So: land 110.A.b as part of this, or delete the traits. Keeping an abstraction
+that documents an architecture the code does not have is the worse of the three
+options.
+
+## 6. Alternatives considered
+
+**Zephyr `k_poll`.** The native answer: one blocking call over an array of
+`k_poll_event`. It is genuinely better than a single semaphore *and* it is
+Zephyr-specific, while the platform ABI is deliberately portable
+([RFC-0076](0076-platform-abi-ask-do-not-assume.md)). If wait-on-many is wanted,
+it belongs in the ABI as a primitive that Zephyr implements with `k_poll`,
+FreeRTOS with a queue set, and POSIX with `ppoll` — not as a direct call.
+Orthogonal to this RFC and compatible with it.
+
+**An `rmw_wait` equivalent.** What rclc leans on: push multiplexing into the
+rmw layer and let it return the ready set. It is why micro-ROS's executor can
+avoid this scan. It is also a much larger surface to specify across four
+backends, and it moves the problem rather than removing it — someone still
+has to attribute the arrival. The token is the small half of that idea.
+
+**Per-entity condition variables.** One wait primitive per entity. Costs a
+kernel object per entity on targets counting bytes, and does not compose with
+`AllOf`/`AnyOf` triggers.
+
+**Leave it alone.** Defensible today: N is 64 and a `has_data` call is cheap.
+It stops being defensible when `MAX_CALLBACK_SLOTS` grows past the `u64` (the
+`BitSet<N>` rewrite is already anticipated in `ready_set/mod.rs`), and it is
+already wrong in principle on an image whose whole purpose is bounded latency.
+
+## 7. Prior art
+
+- **Embassy** — `Waker` per task, intrusive lists, no allocation.
+  `WakerRegistration` inside each peripheral driver is this design applied one
+  layer lower, and is the pattern to copy for a UART RX ring
+  ([issue 0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md)).
+- **RTIC** — tasks *are* NVIC priorities; readiness is dispatched by hardware.
+  Not adoptable wholesale under ROS semantics, but it is the existence proof
+  that the scan is not necessary.
+- **rmw_zenoh (full ROS 2)** — callback per entity plus a condition variable.
+  Same backend as ours, so the entity-level callbacks this RFC needs are known
+  to be expressible in zenoh-pico.
+- **rclc executor (micro-ROS)** — has the same O(N) handle scan, and reaches
+  for `rmw_wait` rather than a token. Worth reading for what it does *not*
+  solve.
+- **`embedded-io-async`** — the trait shape for a wakeable byte source.
+
+## 8. Cost
+
+| | |
+| --- | --- |
+| ABI | one new callback symbol; old one kept, forwards with UNKNOWN |
+| executor state | one `AtomicU64` in `WakeCtx` (8 B) |
+| hot path added | one `fetch_or` per arrival |
+| hot path removed | up to 64 indirect calls per spin |
+| backends touched | zenoh only; every other backend unchanged by construction |
+| risk | the arrived-vs-present semantics of §4.4 |
+
+## 9. Open questions
+
+1. Should the token be a `DescIdx` (dense, `u64`-indexable, executor-minted) or
+   an opaque backend handle the executor maps? Dense is cheaper and bounded by
+   `MAX_CALLBACK_SLOTS`; opaque survives the `BitSet<N>` widening better.
+2. Does anything downstream depend on `has_data` being called every spin as a
+   side effect — polling a backend to make it progress? If a backend needs to
+   be poked to advance, the pushed path must poke it too.
+3. `ready_bits` is `u64`; the widening to `BitSet<N>` needs a lock-free
+   multi-word set-bit, or a per-word atomic array. Worth settling before the
+   token type is fixed, since (1) depends on it.

--- a/docs/design/0084-readiness-is-pushed-not-scanned.md
+++ b/docs/design/0084-readiness-is-pushed-not-scanned.md
@@ -4,7 +4,7 @@ title: "Readiness is PUSHED by the arrival path, not scanned by the executor —
 status: Draft
 since: 2026-08
 last-reviewed: 2026-08-28
-implements-tracked-by: []
+implements-tracked-by: [phase-397]
 amends: [rfc-0052]
 supersedes: []
 superseded-by: null

--- a/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
+++ b/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
@@ -220,8 +220,15 @@ when `CONFIG_UART_INTERRUPT_DRIVEN` is off. Board-side behaviour under it is
 clean — full bring-up in 0.27 s, **zero** `uart_err_check` overruns, **zero**
 ring overflows.
 
-It ships **disabled**, because the A/B against the polled path cannot currently
-be trusted. See below.
+It ships **disabled**. A later A/B with a `demo_nodes_cpp` talker on the same
+router as a live control settled it: with the polled build the board's node
+appears in `ros2 node list` alongside the host talker, and with the ISR build
+only the host talker appears. The router is provably healthy in the same
+instant, so the ISR path does break the board's declarations from reaching it —
+the board completes its handshake, registers every token and reports no
+overrun, and the declarations still do not land. Cause not yet identified;
+suspect the TX side, since `CONFIG_UART_INTERRUPT_DRIVEN` changes driver
+behaviour for a path that still uses `uart_poll_out`.
 
 ## The measurement is confounded — [issue 0864](0864-board-zid-is-identical-on-every-boot.md)
 

--- a/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
+++ b/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
@@ -1,11 +1,12 @@
 ---
 id: 852
-title: "zenoh-pico's Zephyr serial RX is polled with no interrupt buffering and no
-  error check, so it silently drops bytes under load"
+title: "the zenoh read task inherits the executor's priority on Zephyr — the
+  declared priority is discarded by the port, so a 20 ms timeslice starves the
+  polled serial RX and it overruns"
 status: open
 type: bug
-area: rmw
-related: [issue-0848, issue-0839]
+area: rmw, platform
+related: [issue-0848, issue-0839, issue-0736, issue-0626, rfc-0079]
 ---
 
 ## Problem
@@ -17,18 +18,98 @@ res = uart_poll_in(sock._serial, &raw_buf[i]);
 if (res != 0) { if (past deadline) return SIZE_MAX; k_yield(); }
 ```
 
-- `CONFIG_UART_INTERRUPT_DRIVEN` is **not set** on the board images
-- the port calls **only** `uart_poll_in` — no `uart_fifo_read`, no async/DMA
-- `uart_err_check` was **never called**, so overruns were invisible
+Polled RX is the surface. **The root cause is that the read task runs at the
+same priority as the executor, because the priority it was given is thrown
+away by this port** — so `k_yield()` in that loop hands the executor a full
+scheduler timeslice while bytes keep arriving.
 
-The S32K344 LPUART has a small RX FIFO and a byte arrives every 87 us at
-115200. Any scheduling delay between polls loses bytes, and the loss is not
-reported.
+## Root cause: the priority is discarded twice
+
+`CONFIG_NROS_ZENOH_READ_PRIORITY` (default 16 on the normalised 0-31 band) is
+wired through Kconfig and CMake, reaches `zpico_set_task_config`, and is stored:
+
+```
+zpico.c:1431   g_default_read_nros_attr.priority = NROS_PLATFORM_PRIORITY_RAW(read_priority)
+zpico.c:1443   g_default_read_task_opts.task_attributes = (z_task_attr_t *) &g_default_read_nros_attr
+```
+
+zenoh-pico then hands that attr to the port. Both Zephyr entry points drop it.
+
+**1. the zenoh-pico system shim** — `zephyr/nros_zenoh_zephyr_system.c:29`
+
+```c
+z_result_t _z_task_init(_z_task_t *task, z_task_attr_t *attr,
+                        void *(*fun)(void *), void *arg) {
+    (void)attr;                                     /* <-- discarded */
+    return nros_zephyr_task_create(task, fun, arg) == 0 ? 0 : -1;
+}
+```
+
+**2. the platform task ABI itself** — `nros-platform-zephyr/src/platform.c:291`
+
+```c
+const nros_platform_task_attr_t *a = (const nros_platform_task_attr_t *) attr;
+(void) a;                                           /* <-- discarded */
+```
+
+The comment there explains why `stack_bytes` cannot be honoured (Zephyr's
+`k_thread_create` needs an MPU-aligned `K_THREAD_STACK_DEFINE` region). That
+reasoning is sound and does **not** extend to `priority`:
+`CONFIG_POSIX_PRIORITY_SCHEDULING=y` in these images and
+`pthread_attr_setschedpolicy` / `setschedparam` work.
+
+Neither call site sets `PTHREAD_EXPLICIT_SCHED`, so
+`nros_zephyr_task_create`'s bare `pthread_attr_init`
+(`nros_platform_zephyr_shims.c:438`) leaves the Zephyr default in place:
+
+```
+zephyr/lib/posix/options/pthread.c:950   attr->inheritsched = PTHREAD_INHERIT_SCHED
+zephyr/lib/posix/options/pthread.c:653   -> new thread takes the CREATOR's priority
+```
+
+The read task is started from the executor thread, so it inherits
+`CONFIG_MAIN_THREAD_PRIORITY=0` — identical to the executor.
+
+### This is the failure issue 0626 warned about, one layer down
+
+Issue 0626 fixed the Zephyr arm of `zpico_set_task_config`, and its own comment
+says:
+
+> `PTHREAD_EXPLICIT_SCHED` is load-bearing: the default is
+> `PTHREAD_INHERIT_SCHED`, under which the policy and param set below are
+> IGNORED and the new thread silently takes the creator's. A scheduling
+> attribute that is quietly dropped is the failure this issue is about, so it
+> must not be reintroduced one layer down.
+
+It was reintroduced one layer down, in nano-ros's own port. Issue 0736 records
+the same shape on NuttX ("zenoh read/lease threads inherit whichever thread
+opened the session"), and [RFC-0079](../design/0079-priority-is-allocated-not-authored.md)
+is the general statement of it.
+
+## Why equal priority loses bytes — arithmetic, not a race
+
+```
+CONFIG_TIMESLICING=y
+CONFIG_TIMESLICE_SIZE=20      ms
+CONFIG_TIMESLICE_PRIORITY=0   every preemptible thread is timesliced
+```
+
+At equal priority `k_yield()` moves the reader to the tail of its ready queue
+and the executor gets a full slice. 20 ms at 115200 baud is **~230 bytes**
+against an LPUART RX FIFO a few entries deep.
+
+The loop's own comment shows the trap was seen but mis-scoped:
+
+> Yield rather than sleep between polls: at 115200 a byte is 87 us and the
+> shortest `z_sleep_ms(1)` blocks a whole tick, overrunning the UART.
+
+`k_yield()` at equal priority blocks for a whole **timeslice**, which is 20x
+worse than the tick the comment was avoiding.
 
 ## Proof
 
-Instrumented the read loop to report `uart_err_check` on both paths, against a
-locally built zenoh router that logs every serial write:
+Instrumented read loop reporting `uart_err_check`, against a locally built
+zenoh router logging every serial write:
 
 ```
 DIAG-RX: frame rb=9  ok hdr=0x03  uart_err=0x0     <- handshake, board idle
@@ -42,41 +123,135 @@ The overrun flag is set on **exactly** the truncated frame and nowhere else.
 
 ## Why it looks load-dependent
 
-- **handshake survives** — the board is otherwise idle and the poll loop keeps up
-- **keepalives die** — by then three queryables, two publishers and their
-  callbacks are competing for the CPU
-- **the talker soaks for five minutes** — far lighter load, poll loop keeps up
+The priority story explains the split completely:
+
+- **handshake survives** — the executor is blocked in its wake wait, so the
+  read task is the only runnable thread and `k_yield()` returns immediately
+- **keepalives die** — three queryables, two publishers and their callbacks
+  make the executor runnable, so each `k_yield()` costs a full 20 ms slice
+- **the talker soaks for five minutes** — one publisher, executor blocked
+  almost always, reader keeps up
 
 That is the whole reason this presented as "actions are broken and pub/sub is
-fine".
+fine". No amount of stack or lease tuning could move it.
 
 ## The red herring worth recording
 
-[Issue 0848](archived/0848-router-sends-no-keepalives-on-serial.md) chased this as a
-router defect for a long time, ending on "the keepalive is a 1-byte write that
-never frames". The 1-byte figure was the payload handed to the link; z-serial
-frames it as `header(1) + len(2) + payload + crc32(4)` and COBS-encodes it, so
-~10 bytes reach the wire. The board caught 4 of them and overran. **The small
-write was never the anomaly — the receiver was.**
+[Issue 0848](archived/0848-router-sends-no-keepalives-on-serial.md) chased this
+as a router defect for a long time, ending on "the keepalive is a 1-byte write
+that never frames". The 1-byte figure was the payload handed to the link;
+z-serial frames it as `header(1) + len(2) + payload + crc32(4)` and
+COBS-encodes it, so ~10 bytes reach the wire. The board caught 4 of them and
+overran. **The small write was never the anomaly — the receiver was.**
 
-The router is exonerated: its timer fires, the keepalive arm fires,
-`write_all` + `flush` both succeed, and the frames it emits are well formed.
+The router is exonerated: its timer fires, the keepalive arm fires, `write_all`
++ `flush` both succeed, and the frames it emits are well formed.
 
-## Fix direction
+## Fix
 
-`CONFIG_UART_INTERRUPT_DRIVEN=y` plus `uart_fifo_read` in an ISR feeding a ring
-buffer, or the async API with DMA. Either way bytes are buffered by hardware or
-the driver instead of depending on thread scheduling. This is a real change to
-the port — the read path is written around `uart_poll_in` and returns
-`SIZE_MAX` on a per-byte deadline — not a config flip.
+The board uses `uart_mcux_lpuart.c`, not the LinFlexD driver — worth stating
+because it changes what is available:
 
-**Cheap interim step regardless of the above:** call `uart_err_check` and
-surface overruns. They are currently invisible, which is what let this hide
-behind six other hypotheses.
+```
+CONFIG_UART_MCUX_LPUART=y
+CONFIG_UART_NXP_LPUART_ASYNC_API_SUPPORT=y   eDMA path exists
+CONFIG_SERIAL_SUPPORT_INTERRUPT=y
+CONFIG_SERIAL_SUPPORT_ASYNC=y
+```
+
+Neither `CONFIG_UART_INTERRUPT_DRIVEN` nor `CONFIG_UART_ASYNC_API` is enabled.
+Both are available, and `mcux_lpuart_fifo_read` drains the whole hardware FIFO
+in a loop (unlike LinFlexD's one-byte shim), so the ISR path is efficient here.
+
+Cheapest first:
+
+1. **Honour the declared priority.** Pass `attr` through `_z_task_init`, give
+   `nros_zephyr_task_create` a priority parameter, set `PTHREAD_EXPLICIT_SCHED`
+   + `SCHED_FIFO` + the mapped band value. Fix the platform ABI's `task_init`
+   in the same change — it accepts a priority it silently discards on every
+   Zephyr image, which is a latent RT defect independent of this issue.
+   Does not remove polling; removes the 20 ms starvation window.
+2. **Call `uart_err_check` and surface overruns.** Diagnostics only. Keep it:
+   invisibility is what let this hide behind six other hypotheses.
+3. **`CONFIG_UART_INTERRUPT_DRIVEN=y`** — ISR does `uart_fifo_read` into a
+   `ring_buf`, the reader blocks on a `k_sem`. RX stops depending on thread
+   scheduling at all. This is the actual fix.
+4. **`CONFIG_UART_ASYNC_API=y` + eDMA** — zero per-byte CPU, double-buffered
+   via `UART_RX_BUF_REQUEST`. The real-time target.
+
+1 and 2 are small and independently correct; land them first. 3 is the fix.
+
+## Status — what has landed and what it measured
+
+**Landed (steps 1 and 2).** The priority is honoured at all three sites that
+dropped it, and overruns are reported:
+
+- `_z_task_init` forwards `attr` to `nros_platform_task_init` instead of
+  `(void)attr;`
+- the Zephyr platform port maps the band and applies it with
+  `PTHREAD_EXPLICIT_SCHED`, via a new `nros_zephyr_task_create_prio`
+- **SCHED_RR, not SCHED_FIFO.** On Zephyr `SCHED_FIFO` selects the COOPERATIVE
+  band (`lib/posix/options/pthread_sched.h`), and a cooperative busy-poller
+  would never be preempted — trading a 20 ms starvation of the reader for an
+  unbounded starvation of everything else. The posix port picks SCHED_FIFO
+  because on Linux that is simply "the real-time policy"; the same constant
+  means something different here, which is why the map is per-port.
+- `CONFIG_MAIN_THREAD_PRIORITY=5` on the serial images. Necessary: SCHED_RR
+  maps as `zephyr = NUM_PREEMPT - posix - 1`, so the top preemptible slot is
+  Zephyr priority 0 — exactly where main sat by default. The reader cannot be
+  placed above a main thread already holding the top slot, so honouring the
+  priority alone changes nothing.
+
+Measured on the action image, clean router, five goals per run:
+
+| | goals completing |
+| --- | --- |
+| before | **0 of 5** — the graph populated, no goal ever finished |
+| priority honoured + main lowered | **2 of 5**, and `SUCCEEDED` with the correct sequence |
+
+Real but partial, which is what the polled path predicts: raising the reader's
+priority shrinks the window in which it is descheduled and cannot remove it,
+because a polling reader still has to be RUNNING to catch a byte.
+
+**Written but NOT enabled (step 3).** Interrupt-driven RX is implemented on the
+zenoh-pico fork branch `fix/zephyr-serial-irq-rx`: `uart_fifo_read` in the ISR
+into a `ring_buf`, reader blocked on a `k_sem`, falling back to the poll loop
+when `CONFIG_UART_INTERRUPT_DRIVEN` is off. Board-side behaviour under it is
+clean — full bring-up in 0.27 s, **zero** `uart_err_check` overruns, **zero**
+ring overflows.
+
+It ships **disabled**, because the A/B against the polled path cannot currently
+be trusted. See below.
+
+## The measurement is confounded — [issue 0864](0864-board-zid-is-identical-on-every-boot.md)
+
+The board presents the **same zenoh id on every boot**
+(`1322740661b45746fa29b1803f32f5eb`, verified across resets and reflashes;
+`CONFIG_TEST_RANDOM_GENERATOR` with no hardware entropy). A router therefore
+cannot tell a rebooted board from the peer it already has, so any run that
+crosses a reconnect depends on **router history** as much as on the firmware
+under test.
+
+That is not a footnote here. During this work an A/B appeared to show that
+interrupt-driven RX broke ROS graph discovery. It did not: the run was against a
+router that had failed to start (`Address already in use`, a stale process still
+holding 7447) while a previous router still owned the serial port. Repeating it
+with a genuinely clean router restored discovery on the polled build, and the
+ISR build's remaining difference cannot be separated from the shared-zid effect.
+
+**Issue 0853 should be fixed before step 3 is judged.** Its acceptance test is
+two resets and two different zids.
+
+## Adjacent, found while tracing this
+
+`_z_read_serial_internal` calls `z_malloc` **twice per frame**
+(`_Z_SERIAL_MAX_COBS_BUF_SIZE` + `_Z_SERIAL_MFS_SIZE`) on the receive hot path.
+Unbounded-latency allocator calls inside RX. Belongs to the heap-unification
+campaign, not to this fix.
 
 ## Impact
 
-Any zenoh-over-serial image whose CPU is busy enough to miss an 87 us polling
-window loses frames silently. Observed as session expiry at
-`2 x Z_TRANSPORT_LEASE` ([issue 0839](0839-action-image-session-expires-every-20s.md)),
-because the dropped frames are the router's keepalives.
+Any zenoh-over-serial image whose executor is busy enough to hold a timeslice
+loses frames silently. Observed as session expiry at `2 x Z_TRANSPORT_LEASE`
+([issue 0839](0839-action-image-session-expires-every-20s.md)), because the
+dropped frames are the router's keepalives.

--- a/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
+++ b/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
@@ -202,16 +202,30 @@ dropped it, and overruns are reported:
   placed above a main thread already holding the top slot, so honouring the
   priority alone changes nothing.
 
-Measured on the action image, clean router, five goals per run:
+### The goal-completion numbers do NOT reproduce — treat them as withdrawn
 
-| | goals completing |
+An earlier revision of this issue recorded "0 of 5 goals before, 2 of 5 after"
+as a measured improvement from the priority fix. **That does not hold up.**
+
+Re-run under a fixed harness (`/tmp/trial.sh`: kill every 7447/serial holder by
+PID, start the router and wait for its "Started Zenoh router" line, reset the
+board exactly once, then measure) the result is **0 of 5 on both builds**, and
+also 0 of 5 when the goals are sent immediately after connect with no
+`ros2 node list` ahead of them. The 2 of 5 came from hand-run sequences whose
+timing was not controlled, and it has not been reproduced since.
+
+What IS reproducible and does hold:
+
+| | node visible in `ros2 node list` |
 | --- | --- |
-| before | **0 of 5** — the graph populated, no goal ever finished |
-| priority honoured + main lowered | **2 of 5**, and `SUCCEEDED` with the correct sequence |
+| polled | yes |
+| interrupt-driven | yes |
 
-Real but partial, which is what the polled path predicts: raising the reader's
-priority shrinks the window in which it is descheduled and cannot remove it,
-because a polling reader still has to be RUNNING to catch a byte.
+So the priority fix is still correct on its own terms — the three discard sites
+were real, the `(void)attr;` lines are gone, and a declared priority now takes
+effect — but **this issue can no longer claim a measured improvement in goal
+completion.** Whatever stops goals from completing has not been isolated, and
+the RX path is not currently implicated in it: both RX paths behave the same.
 
 **Written but NOT enabled (step 3).** Interrupt-driven RX is implemented on the
 zenoh-pico fork branch `fix/zephyr-serial-irq-rx`: `uart_fifo_read` in the ISR
@@ -220,34 +234,41 @@ when `CONFIG_UART_INTERRUPT_DRIVEN` is off. Board-side behaviour under it is
 clean — full bring-up in 0.27 s, **zero** `uart_err_check` overruns, **zero**
 ring overflows.
 
-It ships **disabled**. A later A/B with a `demo_nodes_cpp` talker on the same
-router as a live control settled it: with the polled build the board's node
-appears in `ros2 node list` alongside the host talker, and with the ISR build
-only the host talker appears. The router is provably healthy in the same
-instant, so the ISR path does break the board's declarations from reaching it —
-the board completes its handshake, registers every token and reports no
-overrun, and the declarations still do not land. Cause not yet identified;
-suspect the TX side, since `CONFIG_UART_INTERRUPT_DRIVEN` changes driver
-behaviour for a path that still uses `uart_poll_out`.
+It ships **disabled**, but not for the reason a previous revision gave.
 
-## The measurement is confounded — [issue 0864](0864-board-zid-is-identical-on-every-boot.md)
+That revision claimed the ISR path broke the board's declarations from reaching
+the router, on the strength of an A/B with a host talker as a control. With
+[issue 0864](archived/0864-board-zid-is-identical-on-every-boot.md) fixed — the
+board now draws a distinct zid per boot — **that claim is withdrawn**: the ISR
+build's node appears in `ros2 node list` normally. The apparent difference was
+the shared-zid confound, exactly as the first analysis said before it was
+over-corrected.
 
-The board presents the **same zenoh id on every boot**
-(`1322740661b45746fa29b1803f32f5eb`, verified across resets and reflashes;
-`CONFIG_TEST_RANDOM_GENERATOR` with no hardware entropy). A router therefore
-cannot tell a rebooted board from the peer it already has, so any run that
-crosses a reconnect depends on **router history** as much as on the firmware
-under test.
+One real defect was found in the ISR while chasing this, and is fixed: the
+handler guarded its loop with `uart_irq_is_pending()` and `break`-ed when RX was
+not ready. `uart_irq_is_pending` is also true for a TX cause, so that could exit
+with the interrupt still asserted and re-enter forever. It is now the canonical
+Zephyr shape — `uart_irq_update()` once, then drain while `uart_irq_rx_ready()`.
 
-That is not a footnote here. During this work an A/B appeared to show that
-interrupt-driven RX broke ROS graph discovery. It did not: the run was against a
-router that had failed to start (`Address already in use`, a stale process still
-holding 7447) while a previous router still owned the serial port. Repeating it
-with a genuinely clean router restored discovery on the polled build, and the
-ISR build's remaining difference cannot be separated from the shared-zid effect.
+It stays disabled because it is not yet shown to be BETTER, not because it is
+shown to be broken. Both paths currently complete zero goals.
 
-**Issue 0853 should be fixed before step 3 is judged.** Its acceptance test is
-two resets and two different zids.
+## The zid confound is fixed — [issue 0864](archived/0864-board-zid-is-identical-on-every-boot.md)
+
+The board drew the same zenoh id on every boot, so a router could not tell a
+rebooted board from the peer it already had, and every reconnect-shaped
+measurement depended on router history. That is fixed: three boots now give
+three distinct zids.
+
+Two claims in this issue were made under that confound and are corrected above:
+the goal-completion improvement (withdrawn) and the ISR-breaks-declarations
+finding (withdrawn).
+
+**A separate operational hazard remains.** z-serial has no link-level resync, so
+resetting the board while the router holds the link puts the router into a
+repeating `Unexpected Init flag in message` and the link never recovers. The
+router must be restarted after any board reset. This is not the same thing as
+the zid problem and survives its fix.
 
 ## Adjacent, found while tracing this
 

--- a/docs/issues/0864-board-zid-is-identical-on-every-boot.md
+++ b/docs/issues/0864-board-zid-is-identical-on-every-boot.md
@@ -1,0 +1,76 @@
+---
+id: 864
+title: "the board presents the SAME zenoh id on every boot — CONFIG_TEST_RANDOM_GENERATOR
+  makes the zid deterministic, which confounds every reconnect measurement"
+status: open
+type: bug
+area: platform, rmw
+related: [issue-0852, issue-0839]
+---
+
+## Problem
+
+Two consecutive resets of the same image, reading the liveliness key the board
+registers:
+
+```
+boot 1 zid: @ros2_lv/10/1322740661b45746fa29b1803f32f5eb
+boot 2 zid: @ros2_lv/10/1322740661b45746fa29b1803f32f5eb
+```
+
+Byte-identical. A third capture from an earlier session in the same day carries
+the same value, so this is stable across power cycles and reflashes, not just
+back-to-back resets.
+
+## Cause
+
+```
+CONFIG_TEST_RANDOM_GENERATOR=y
+CONFIG_TIMER_RANDOM_GENERATOR=y
+```
+
+No hardware entropy is configured, so Zephyr supplies the timer-backed stand-in.
+zenoh-pico draws the zid at a fixed point early in startup, and the boot path to
+that point is deterministic, so the "random" seed is the same tick count every
+time. The name of the Kconfig says what it is: a stand-in for tests.
+
+## Why it matters beyond neatness
+
+A zenoh id is the identity a router uses to tell one peer from another and to
+hold a session's state for a lease. A board that reboots into the SAME zid is,
+from the router's point of view, a peer that vanished and came back — while the
+router may still be holding the previous session, its declarations and its
+liveliness tokens under that identity.
+
+This makes every reconnect-shaped measurement depend on **what the router
+remembers**, not only on what the board does now. Concretely, it invalidated an
+A/B during [issue 0852](0852-zephyr-serial-rx-is-polled-and-overruns.md):
+polled RX and interrupt-driven RX appeared to differ in whether the ROS graph
+populated, and the two runs were not comparable because both boards claimed the
+same identity against routers with different histories. The same confound sits
+underneath [issue 0839](0839-action-image-session-expires-every-20s.md), whose
+whole subject is what happens across a session expiry and reopen.
+
+Two boards of the same model running the same image would also collide
+outright.
+
+## Fix direction
+
+Seed from something actually unique to the part. The S32K344 has a factory
+device ID in its UTEST/SIUL area; hashing that with a boot counter or the
+low bits of a free-running timer gives a per-part, per-boot value without
+needing a TRNG.
+
+Prefer wiring a real entropy source (`CONFIG_ENTROPY_GENERATOR`) if the SoC
+exposes one on this package — then `CONFIG_TEST_RANDOM_GENERATOR` can go away
+rather than be improved.
+
+Either way the acceptance test is the one above: reset twice, read the zid
+twice, and require them to differ.
+
+## Note
+
+`CONFIG_TEST_RANDOM_GENERATOR` was already recorded as a production gap. What
+is new here is that it has a measurable functional consequence today, in the
+one area the serial campaign is trying to characterise, rather than being a
+security-hardening item to fix before shipping.

--- a/docs/issues/0865-no-example-registers-parameter-services.md
+++ b/docs/issues/0865-no-example-registers-parameter-services.md
@@ -1,0 +1,91 @@
+---
+id: 865
+title: "no example registers parameter services, so `ros2 param list` returns
+  nothing against every nano-ros node — the capability exists and is never shown"
+status: open
+type: bug
+area: examples, docs
+related: [issue-0864]
+---
+
+## Symptom
+
+Against the CANHUBK344 action-server image, with a `demo_nodes_cpp` talker on
+the same router as a control:
+
+```
+$ ros2 param list /fibonacci_action_server
+                                     <- nothing
+
+$ ros2 param list /talker
+  qos_overrides./parameter_events.publisher.depth
+  qos_overrides./parameter_events.publisher.durability
+  ...
+```
+
+`ros2 service list` tells the same story from the other side:
+
+```
+/talker/describe_parameters
+/talker/get_parameter_types
+/talker/get_parameters
+/talker/list_parameters
+/talker/set_parameters
+/talker/set_parameters_atomically
+```
+
+Six for the host node, none for the board's.
+
+## Cause
+
+`Executor::register_parameter_services()` (`executor/spin.rs:6388`, exposed to C
+as `nros_executor_register_parameter_services`) is **opt-in**, and:
+
+```
+$ grep -rl register_parameter_services examples/
+                                     <- no match
+```
+
+Not one example in the tree calls it. The capability is fully implemented —
+`parameter_services.rs` serves all six — and nothing demonstrates it.
+
+## Why opt-in is defensible and the current state is not
+
+Opt-in is the right default: the six servers cost RAM on a part where that is
+the binding constraint, and an image with no parameters should not pay for
+them. That is not the complaint.
+
+The complaint is that every nano-ros node therefore looks, to standard ROS 2
+tooling, like a node whose parameter interface is broken rather than one that
+declined to have it. `ros2 param list` returning empty is indistinguishable
+from a node that is failing to answer, which is exactly the kind of ambiguity
+that cost issue 0852 six wrong hypotheses.
+
+## What is NOT wrong here
+
+Worth recording, because it looks like a defect and is not.
+
+The board's action services do not appear in a bare `ros2 service list`:
+
+```
+$ ros2 service list --include-hidden-services
+/fibonacci/_action/cancel_goal
+/fibonacci/_action/get_result
+/fibonacci/_action/send_goal
+```
+
+`ros2 service list` hides `_action/` services by default. All three are
+registered, correctly named, correctly type-mangled, and they work — goals
+complete with the right sequence. Same for `ros2 node info` showing an empty
+"Service Servers" block while "Action Servers" lists `/fibonacci`.
+
+## Fix direction
+
+1. Call `register_parameter_services()` in at least one Zephyr example, and
+   declare a parameter in it, so the path is exercised on hardware rather than
+   only in host tests.
+2. Say so where a reader will hit it: the examples README and the parameter
+   docs should state that `ros2 param` needs this call, and that omitting it is
+   a footprint choice rather than a missing feature.
+3. Consider a boot-time log line when a node comes up without parameter
+   services — one line, once, so the empty `ros2 param list` explains itself.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-43 open. One line each — the detail lives in the issue file,
+44 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -91,12 +91,13 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
 - **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
 - **#0843** (core, platform) — `nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every cffi image needs a global allocator and the `heap-free` tier is unreachable See `0843-*`.
-- **#0852** (rmw) — zenoh-pico's Zephyr serial RX is polled with no interrupt buffering and no error check, so it silently drops bytes under load See `0852-*`.
+- **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.
 - **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
 - **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
 - **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
 - **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
 - **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0865** (examples, docs) — no example registers parameter services, so `ros2 param list` returns nothing against every nano-ros node — the capability exists and is never shown See `0865-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.

--- a/docs/issues/archived/0864-board-zid-is-identical-on-every-boot.md
+++ b/docs/issues/archived/0864-board-zid-is-identical-on-every-boot.md
@@ -2,7 +2,7 @@
 id: 864
 title: "the board presents the SAME zenoh id on every boot — CONFIG_TEST_RANDOM_GENERATOR
   makes the zid deterministic, which confounds every reconnect measurement"
-status: open
+status: resolved
 type: bug
 area: platform, rmw
 related: [issue-0852, issue-0839]
@@ -74,3 +74,49 @@ twice, and require them to differ.
 is new here is that it has a measurable functional consequence today, in the
 one area the serial campaign is trying to characterise, rather than being a
 security-hardening item to fix before shipping.
+
+## Resolved (2026-08-28)
+
+`nros-platform-zephyr` now seeds a xoshiro128** PRNG and serves
+`nros_platform_random_*` from it — but **only** when
+`CONFIG_TEST_RANDOM_GENERATOR` is set and `CONFIG_ENTROPY_GENERATOR` is not. A
+board with a real entropy source keeps using it; this must not shadow good
+entropy with a PRNG.
+
+The seed mixes, through splitmix32:
+
+- a `__noinit` word carried across reset (Zephyr does not zero `.noinit`), which
+  is the previous boot's state on a warm reset and SRAM power-up noise on a cold
+  one — this is what makes reset-to-reset differ
+- `k_cycle_get_32()` and `k_uptime_get_32()`
+- the timer generator's own reading, which is at least not worse
+
+A different value than the one used for this boot is carried forward, so a reset
+that happens before any random is drawn still moves the state. The all-zero
+xoshiro state is a fixed point and is guarded against.
+
+`nros_platform_random_fill` draws from the SAME stream rather than falling
+through to `sys_rand_get` — a `fill` that disagrees with the scalar draws about
+which generator is in use is exactly how a zid stays deterministic while
+everything else looks fine.
+
+### Acceptance
+
+The test this issue asked for, three times:
+
+```
+boot 1 zid: 06f6a004dc9321cfda5fb1359a10e61e
+boot 2 zid: ac181f9c54a245950bca25d7ee814faa
+boot 3 zid: 9b1311b02b0e4c6a64fb5544281b75dc
+```
+
+Previously `1322740661b45746fa29b1803f32f5eb` on every boot.
+
+Cost: 24 B of RAM.
+
+### What this is NOT
+
+Not a CSPRNG, and the code says so at the top of the block. It makes an
+IDENTITY unique; it does not make a secret unguessable. The production gap —
+this part has no hardware entropy wired — is unchanged, and anything needing
+cryptographic randomness still needs it fixed.

--- a/docs/roadmap/phase-396-pushed-readiness-executor.md
+++ b/docs/roadmap/phase-396-pushed-readiness-executor.md
@@ -1,0 +1,136 @@
+# Phase 396 — Pushed readiness: the wake says WHO, and the executor stops scanning
+
+**Status (2026-08-28). Not started.** Implements
+[RFC-0084](../design/0084-readiness-is-pushed-not-scanned.md).
+
+The executor is already woken precisely — a `k_sem` signalled from the backend's
+arrival path, sub-millisecond, ISR-capable. It then discards that precision and
+walks every registered entity to find out what happened. This phase closes the
+gap between the wake and the search, and lands the two phase-110.A traits that
+have described this seam since they were written and never been wired to
+anything.
+
+**Depends on** nothing. Independent of
+[issue 0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md) — that
+is about how bytes reach the transport, this is about what the executor does
+once they have.
+
+---
+
+## 1. What is there today
+
+```
+spin_once(timeout)
+  ├─ next_deadline_ms()                    cap the wait against backend keepalive
+  ├─ wake_flag.swap(false)
+  ├─ has_async_wake ? NodeWake::wait_ms()  k_sem, ISR-safe
+  │                 : drive_io(timeout)    block in the transport
+  ├─ SCAN  for each entry: (meta.has_data)(ptr)     <-- up to 64 indirect calls
+  ├─ evaluate Trigger (One / AllOf / AnyOf / Custom)
+  └─ DISPATCH  BucketedFifoSet / BucketedEdfSet, by priority
+```
+
+| | today |
+| --- | --- |
+| wake latency | one `k_sem_give`, sub-ms, ISR-safe |
+| wake precision | **binary** — "something happened" |
+| finding out what | **O(N) indirect calls**, every spin |
+| N | `MAX_CALLBACK_SLOTS = 64` (`spin.rs:1000`) |
+
+`nros_rmw_runtime_wake_cb` (`spin.rs:673`) takes one argument, `ctx`, which
+identifies the **executor**. The zenoh shim mirrors it into a process global
+(`shim/mod.rs:184`) precisely so the real arrival hook can fire it "at the real
+arrival point" — that hook stands where the entity identity is known and the ABI
+it must call through has nowhere to put it.
+
+## 2. Waves
+
+### W1 — the token reaches the executor
+
+Add `nros_rmw_runtime_wake_cb_tok(void *ctx, uint32_t token)`. Keep the existing
+symbol; it forwards with `NROS_RMW_WAKE_TOKEN_UNKNOWN`. Add an `AtomicU64`
+`ready_bits` to `WakeCtx`; the callback does one `fetch_or`.
+
+**Done when** a zenoh subscription arrival sets a known bit, provable from a
+unit test on the host with a mock session, and every other backend still links.
+
+### W2 — registration mints the token
+
+The entity-scoped wake registration already exists in the C API
+(`nros_subscription_set_wake_callback` and the service/client twins). Hand the
+`DescIdx` through at that point — the executor already assigns it.
+
+**Done when** each registered entity's arrivals set that entity's bit and no
+other, under a test with three subscriptions on distinct topics.
+
+### W3 — `spin_once` reads bits instead of scanning
+
+```
+bits = ready_bits.swap(0)
+if bits == 0 or any session reported UNKNOWN:   scan entries[]      (unchanged)
+else:                                            seed the ReadySet from bits
+```
+
+`FifoReadySet` is already a `u64` bitmap with a `trailing_zeros()` pop
+(`ready_set/mod.rs`), and it is already the dispatch input. Only the producer
+changes.
+
+**Done when** a build with only wake-capable backends performs **zero**
+`has_data` calls on a spin that dispatches one callback, shown by a counter in
+the test build.
+
+### W4 — land phase-110.A, or delete it
+
+`Activator` and `Dispatcher` (`executor/activator.rs`, `executor/dispatcher.rs`)
+were defined by phase 110.A with the note that 110.A.b would rewire `spin_once`
+through them. 110.A.b never landed: both carry `#[allow(dead_code)]`,
+`ActivatorCtx` is a `PhantomData` shell, and there is no reference to either
+outside their own files and doc comments.
+
+W3 needs exactly the seam they describe — decide what fires, separately from
+firing it — with two implementations: `ScanActivator` (today's loop) and
+`PushedActivator` (read the bitmap), selected per session by whether a token was
+supplied. Land them as that, or delete them. An abstraction that documents an
+architecture the code does not have is worse than either.
+
+### W5 — the arrived-vs-present rule
+
+A bit says data **arrived**; `has_data` says data is **present now**. They
+disagree when a callback drains its queue while an arrival races it.
+
+Rule: **the bit is cleared when the callback is dispatched, not when the queue
+is drained**, and a spurious dispatch to an empty queue is allowed. Callbacks
+already tolerate this — `ReadySet::insert` has always been idempotent, so one
+ready bit has always stood for any number of queued messages.
+
+**Done when** a test drives arrival and drain concurrently and no message is
+left undispatched (a spurious extra dispatch is a pass, a lost message is not).
+
+### W6 — measure
+
+Report, on the CANHUBK344 action image: `has_data` calls per spin before and
+after, and wake-to-callback latency from the existing `wake-latency-probe`.
+
+**Done when** the numbers are in this document. A phase that changes a hot path
+and does not measure it has not finished.
+
+## 3. Explicitly out of scope
+
+- **Widening past 64 slots.** `ready_bits` is a `u64` because
+  `MAX_CALLBACK_SLOTS` is 64. The `BitSet<N>` widening anticipated in
+  `ready_set/mod.rs` needs a lock-free multi-word set-bit and should settle the
+  token type with it (RFC-0084 §9).
+- **A wait-on-many platform primitive.** Zephyr's `k_poll` is the native answer
+  and FreeRTOS/POSIX have theirs; that belongs in the platform ABI as its own
+  change, per [RFC-0076](../design/0076-platform-abi-ask-do-not-assume.md).
+  Compatible with this phase, not required by it.
+- **`rmw_wait`.** Moves multiplexing into the rmw layer across four backends.
+  The token is the small half of that idea and is what this phase buys.
+
+## 4. Risks
+
+| risk | handling |
+| --- | --- |
+| a backend that needs poking to progress | W3 keeps the scan whenever any session reports UNKNOWN; RFC-0084 §9.2 is the open question and W1 must answer it before W3 lands |
+| arrived-vs-present | W5, with the dispatch-clears rule stated above |
+| ABI churn for out-of-tree backends | old callback symbol kept and forwards; a backend that does nothing still works |

--- a/docs/roadmap/phase-397-pushed-readiness-executor.md
+++ b/docs/roadmap/phase-397-pushed-readiness-executor.md
@@ -1,4 +1,4 @@
-# Phase 396 — Pushed readiness: the wake says WHO, and the executor stops scanning
+# Phase 397 — Pushed readiness: the wake says WHO, and the executor stops scanning
 
 **Status (2026-08-28). Not started.** Implements
 [RFC-0084](../design/0084-readiness-is-pushed-not-scanned.md).

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -33,6 +33,7 @@
 #include <zephyr/random/random.h>
 #ifdef CONFIG_POSIX_API
 #include <zephyr/posix/pthread.h>
+#include <zephyr/posix/sched.h>
 #endif
 
 #include <errno.h>
@@ -287,6 +288,73 @@ void nros_platform_task_attr_init(nros_platform_task_attr_t *attr) {
     attr->core = -1;
 }
 
+/* issue 0852 — the band -> native map for this port, and the ONLY place this
+ * port decides a direction (per the `priority` contract in <nros/platform.h>).
+ *
+ * SCHED_RR, NOT SCHED_FIFO, and that is the load-bearing choice.
+ *
+ * Zephyr's POSIX layer splits the two policies across its two priority bands
+ * (`lib/posix/options/pthread_sched.h`):
+ *
+ *     SCHED_FIFO           -> COOPERATIVE, max CONFIG_NUM_COOP_PRIORITIES - 1
+ *     SCHED_RR/SCHED_OTHER -> PREEMPTIBLE, max CONFIG_NUM_PREEMPT_PRIORITIES - 1
+ *
+ * A cooperative thread is never preempted. The task this issue is about spends
+ * its life in a `uart_poll_in` busy-poll, so making it cooperative would hand
+ * it the CPU until it blocks — `k_yield()` from a coop thread does not drop
+ * below its own priority, so the executor (preemptible) would not run at all
+ * between frames. Trading a 20 ms starvation of the reader for an unbounded
+ * starvation of everything else is not a fix. The posix port picks SCHED_FIFO
+ * because on Linux that is simply "the real-time policy"; on Zephyr the same
+ * constant means something different, which is exactly the per-port direction
+ * decision this function exists to make.
+ *
+ * Within SCHED_RR the direction matches the band: higher is more urgent, and
+ * `posix_to_zephyr_priority` inverts it into Zephyr's lower-is-more-urgent
+ * numbering. So the map is a plain linear scale onto what the policy reports.
+ *
+ * A RAW value is clamped rather than passed through to fail. Zephyr validates
+ * `sched_priority` against the policy's range and rejects anything outside it,
+ * so an out-of-range raw number does not arrive as a loud error — it arrives as
+ * a silently inherited priority, which is the very failure mode issue 0852 was.
+ * `zpico_posix_set_priority` already clamps for the same reason.
+ *
+ * Returns < 0 for "no priority requested", read by the caller as "leave it
+ * inherited". */
+static int nros_zephyr_native_priority(int32_t priority) {
+    if (priority == NROS_PLATFORM_PRIORITY_INHERIT) {
+        return -1;
+    }
+#if defined(CONFIG_POSIX_PRIORITY_SCHEDULING)
+    int lo = sched_get_priority_min(SCHED_RR);
+    int hi = sched_get_priority_max(SCHED_RR);
+    if (lo < 0 || hi <= lo) {
+        return -1;
+    }
+    int want;
+    if (NROS_PLATFORM_PRIORITY_IS_RAW(priority)) {
+        want = (int) NROS_PLATFORM_PRIORITY_RAW_VALUE(priority);
+    } else if (priority >= 0) {
+        int32_t band =
+            priority > NROS_PLATFORM_PRIORITY_MAX ? NROS_PLATFORM_PRIORITY_MAX : priority;
+        want = lo + (int) (((int64_t) band * (hi - lo)) / NROS_PLATFORM_PRIORITY_MAX);
+    } else {
+        return -1;
+    }
+    if (want < lo) want = lo;
+    if (want > hi) want = hi;
+    return want;
+#else
+    /* No POSIX scheduling option in this image: nothing can be asked for, and
+     * pretending otherwise would put us back to a silently dropped attribute. */
+    (void) priority;
+    return -1;
+#endif
+}
+
+int nros_zephyr_task_create_prio(pthread_t *thread, void *(*entry)(void *), void *arg,
+                                 int native_priority);
+
 int8_t nros_platform_task_init(void *task, void *attr,
                                void *(*entry)(void *), void *arg) {
     /* phase-364 W1 — see the posix port: INVALID for a caller-side
@@ -305,9 +373,18 @@ int8_t nros_platform_task_init(void *task, void *attr,
      * silently pretended to be. A caller needing an exact Zephyr stack should
      * declare the thread in the image, which is the Zephyr-native answer. */
     const nros_platform_task_attr_t *a = (const nros_platform_task_attr_t *) attr;
-    (void) a;
 
-    return nros_zephyr_task_create((pthread_t *) task, entry, arg) == 0
+    /* issue 0852 — `priority` IS honoured. It used to be discarded along with
+     * `stack_bytes`, under the one comment above, but the reasoning that
+     * justifies dropping the stack does not reach the priority: this port goes
+     * through Zephyr's POSIX layer, `CONFIG_POSIX_PRIORITY_SCHEDULING` gives it
+     * `pthread_attr_setschedparam`, and there is no alignment constraint in the
+     * way. Accepting a priority and silently dropping it is the failure
+     * RFC-0079 is about, and it cost issue 0852 six wrong hypotheses. */
+    int native = nros_zephyr_native_priority(a != NULL ? a->priority
+                                                       : NROS_PLATFORM_PRIORITY_INHERIT);
+
+    return nros_zephyr_task_create_prio((pthread_t *) task, entry, arg, native) == 0
                ? NROS_PLATFORM_RET_OK
                : NROS_PLATFORM_RET_NOMEM;
 }

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -252,18 +252,137 @@ void nros_platform_yield_now(void) {
 
 /* ---- Random ---- */
 
-uint8_t  nros_platform_random_u8(void)   { return (uint8_t)  sys_rand32_get(); }
-uint16_t nros_platform_random_u16(void)  { return (uint16_t) sys_rand32_get(); }
-uint32_t nros_platform_random_u32(void)  { return sys_rand32_get(); }
+/* issue 0853 — a board with no hardware entropy produced the SAME zenoh id on
+ * every boot.
+ *
+ * With `CONFIG_TEST_RANDOM_GENERATOR` (its own name says what it is) Zephyr
+ * backs `sys_rand32_get` with a timer reading. The path from reset to the point
+ * zenoh-pico draws its zid is deterministic, so that reading is the same number
+ * every time, and the MR-CANHUBK344 came up as
+ * `1322740661b45746fa29b1803f32f5eb` across resets, reflashes and power cycles.
+ *
+ * A zenoh id is the identity a router uses to hold a session's state for a
+ * lease. A board that reboots into the same one is, to the router, the peer it
+ * already has — so every reconnect-shaped measurement depends on router history
+ * rather than on the firmware under test. That confounded a real A/B during
+ * issue 0852.
+ *
+ * ONLY substituted when Zephyr's generator is the test stand-in. A board with
+ * `CONFIG_ENTROPY_GENERATOR` has a real source and keeps using it — this must
+ * not shadow good entropy with a PRNG.
+ *
+ * THIS IS NOT A CSPRNG AND MUST NOT BE USED AS ONE. It exists to make an
+ * IDENTITY unique, not to make a secret unguessable. Anything needing
+ * cryptographic randomness needs a real entropy source, which this part does
+ * not have wired today. */
+#if defined(CONFIG_TEST_RANDOM_GENERATOR) && !defined(CONFIG_ENTROPY_GENERATOR)
+
+#include <zephyr/sys/util.h>
+
+/* Survives a warm reset: Zephyr does not zero `.noinit`. That is the whole
+ * trick for reset-to-reset uniqueness — the previous boot's state is still
+ * here, and mixing it forward makes each boot differ from the last. At a COLD
+ * start the same location holds whatever the SRAM powered up as, which differs
+ * between parts and between power cycles. */
+static uint32_t nros_rand_seed_carry __attribute__((section(".noinit")));
+static uint32_t nros_rand_s[4];
+static bool nros_rand_ready;
+
+static uint32_t nros_rand_mix(uint32_t x) {
+    /* splitmix32 — spreads a weak seed across all 32 bits before it becomes
+     * PRNG state. Without this, two boots whose inputs differ in one low bit
+     * produce visibly related streams. */
+    x += 0x9e3779b9u;
+    x = (x ^ (x >> 16)) * 0x21f0aaadu;
+    x = (x ^ (x >> 15)) * 0x735a2d97u;
+    return x ^ (x >> 15);
+}
+
+static void nros_rand_init(void) {
+    /* Every independent thing this port can reach:
+     *   - the carried `.noinit` word (previous boot, or cold-start SRAM noise)
+     *   - a cycle counter, which is not constant across the reset paths
+     *   - the uptime, for the case the cycle counter is coarse
+     *   - the timer generator's own reading, which is at least not worse
+     * None is a real entropy source and the comment above says so. Together
+     * they satisfy what this issue asks: reset twice, get two ids. */
+    uint32_t seed = nros_rand_seed_carry;
+    seed = nros_rand_mix(seed ^ k_cycle_get_32());
+    seed = nros_rand_mix(seed ^ (uint32_t) k_uptime_get_32());
+    seed = nros_rand_mix(seed ^ sys_rand32_get());
+
+    /* Carry a DIFFERENT value forward than the one seeding this boot, so a
+     * reset that happens before any random is drawn still moves the state. */
+    nros_rand_seed_carry = nros_rand_mix(seed ^ 0xa5a5a5a5u);
+
+    for (int i = 0; i < 4; i++) {
+        seed = nros_rand_mix(seed);
+        nros_rand_s[i] = seed;
+    }
+    /* An all-zero xoshiro state is a fixed point and stays zero forever. */
+    if ((nros_rand_s[0] | nros_rand_s[1] | nros_rand_s[2] | nros_rand_s[3]) == 0u) {
+        nros_rand_s[0] = 0x9e3779b9u;
+        nros_rand_s[1] = 0x243f6a88u;
+        nros_rand_s[2] = 0xb7e15162u;
+        nros_rand_s[3] = 0xdeadbeefu;
+    }
+    nros_rand_ready = true;
+}
+
+/* xoshiro128** — small, fast, and well distributed. Not cryptographic. */
+static uint32_t nros_rand_u32(void) {
+    if (!nros_rand_ready) {
+        nros_rand_init();
+    }
+    const uint32_t r = nros_rand_s[1] * 5u;
+    const uint32_t result = ((r << 7) | (r >> 25)) * 9u;
+    const uint32_t t = nros_rand_s[1] << 9;
+    nros_rand_s[2] ^= nros_rand_s[0];
+    nros_rand_s[3] ^= nros_rand_s[1];
+    nros_rand_s[1] ^= nros_rand_s[2];
+    nros_rand_s[0] ^= nros_rand_s[3];
+    nros_rand_s[2] ^= t;
+    nros_rand_s[3] = (nros_rand_s[3] << 11) | (nros_rand_s[3] >> 21);
+    return result;
+}
+
+#define NROS_RAND_U32() nros_rand_u32()
+
+#else /* a real entropy source, or a generator this port should not second-guess */
+
+#define NROS_RAND_U32() sys_rand32_get()
+
+#endif
+
+uint8_t  nros_platform_random_u8(void)   { return (uint8_t)  NROS_RAND_U32(); }
+uint16_t nros_platform_random_u16(void)  { return (uint16_t) NROS_RAND_U32(); }
+uint32_t nros_platform_random_u32(void)  { return NROS_RAND_U32(); }
 
 uint64_t nros_platform_random_u64(void) {
-    uint64_t hi = sys_rand32_get();
-    uint64_t lo = sys_rand32_get();
+    uint64_t hi = NROS_RAND_U32();
+    uint64_t lo = NROS_RAND_U32();
     return (hi << 32) | lo;
 }
 
 void nros_platform_random_fill(void *buf, size_t len) {
+#if defined(CONFIG_TEST_RANDOM_GENERATOR) && !defined(CONFIG_ENTROPY_GENERATOR)
+    /* Byte-wise from the same stream, so `fill` cannot disagree with the
+     * scalar draws about which generator is in use. Filling from
+     * `sys_rand_get` here while the scalars used the seeded PRNG is exactly
+     * how a zid ends up deterministic while everything else looks fine. */
+    uint8_t *p = (uint8_t *) buf;
+    size_t i = 0;
+    while (i < len) {
+        uint32_t v = nros_rand_u32();
+        size_t n = (len - i) < 4u ? (len - i) : 4u;
+        for (size_t k = 0; k < n; k++) {
+            p[i + k] = (uint8_t) (v >> (8u * k));
+        }
+        i += n;
+    }
+#else
     sys_rand_get(buf, len);
+#endif
 }
 
 /* ---- Wall clock — unsupported without CONFIG_RTC ---- */

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -330,6 +330,7 @@ ssize_t nros_zephyr_sendto(int fd, const void* buf, size_t len, int flags,
 #if defined(CONFIG_POSIX_API) || defined(CONFIG_PTHREAD)
 
 #include <zephyr/posix/pthread.h>
+#include <zephyr/posix/sched.h>
 #include <string.h>
 #include <zephyr/sys/printk.h>
 
@@ -415,7 +416,25 @@ void nros_zephyr_task_slot_release(pthread_t owner) {
     (void) k_mutex_unlock(&nros_thread_slots_lock);
 }
 
-int nros_zephyr_task_create(pthread_t* thread, void* (*entry)(void*), void* arg) {
+/* issue 0852 — the native SCHED_FIFO priority to be born with, or < 0 for
+ * "inherit the creator's", which is what every caller got before this issue.
+ *
+ * `PTHREAD_EXPLICIT_SCHED` is the load-bearing half. Zephyr's
+ * `pthread_attr_init` sets `PTHREAD_INHERIT_SCHED`
+ * (zephyr/lib/posix/options/pthread.c), under which the policy and param set
+ * here are IGNORED and the child silently takes the creator's priority. That
+ * silent inheritance is the whole of issue 0852: the zenoh READ task was born
+ * at `CONFIG_MAIN_STACK_PRIORITY` because the executor started it, landing it
+ * at the executor's own priority, where `k_yield()` in the polled serial read
+ * loop costs a full `CONFIG_TIMESLICE_SIZE` (20 ms, ~230 bytes at 115200)
+ * instead of returning promptly. The UART overran and the frames it dropped
+ * were the router's keepalives.
+ *
+ * Issue 0626 fixed the same drop one layer up, in `zpico_set_task_config`, and
+ * its comment says a quietly-dropped scheduling attribute "must not be
+ * reintroduced one layer down". It was, here. */
+int nros_zephyr_task_create_prio(pthread_t* thread, void* (*entry)(void*), void* arg,
+                                 int native_priority) {
     int slot = nros_claim_thread_slot();
     if (slot < 0) {
         /* Say so. This used to return -1 silently, and the caller that loses
@@ -439,6 +458,24 @@ int nros_zephyr_task_create(pthread_t* thread, void* (*entry)(void*), void* arg)
     (void)pthread_attr_init(&attr);
     (void)pthread_attr_setstack(&attr, &nros_thread_stacks[slot], NROS_ZEPHYR_STACK_SIZE);
 
+    /* Best-effort, and deliberately so: a kernel that declines the policy
+     * leaves the task at the inherited priority, which is exactly what it did
+     * before this existed. A refusal must not turn into a spawn failure. */
+    if (native_priority >= 0) {
+        struct sched_param sp;
+        (void)memset(&sp, 0, sizeof(sp));
+        sp.sched_priority = native_priority;
+        /* SCHED_RR, not SCHED_FIFO: on Zephyr SCHED_FIFO selects the
+         * COOPERATIVE band, and a cooperative busy-poller starves every
+         * preemptible thread. See `nros_zephyr_native_priority` in
+         * nros-platform-zephyr/src/platform.c, which computes the value
+         * passed in here against this same policy. */
+        if (pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED) == 0 &&
+            pthread_attr_setschedpolicy(&attr, SCHED_RR) == 0) {
+            (void)pthread_attr_setschedparam(&attr, &sp);
+        }
+    }
+
     int ret = pthread_create(thread, &attr, entry, arg);
     (void)pthread_attr_destroy(&attr);
     if (ret != 0) {
@@ -447,6 +484,12 @@ int nros_zephyr_task_create(pthread_t* thread, void* (*entry)(void*), void* arg)
     }
     nros_set_thread_slot_owner(slot, *thread);
     return 0;
+}
+
+/* The pre-issue-0852 spelling. Kept so callers that have no priority to state
+ * do not have to invent one; "inherit" is what they always got. */
+int nros_zephyr_task_create(pthread_t* thread, void* (*entry)(void*), void* arg) {
+    return nros_zephyr_task_create_prio(thread, entry, arg, -1);
 }
 
 #endif /* CONFIG_POSIX_API || CONFIG_PTHREAD */

--- a/zephyr/nros_zenoh_zephyr_system.c
+++ b/zephyr/nros_zenoh_zephyr_system.c
@@ -12,6 +12,8 @@
 #include <zenoh-pico/system/common/system_error.h>
 #include <zenoh-pico/system/platform.h>
 
+#include <nros/platform.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/posix/pthread.h>
 
@@ -26,12 +28,37 @@ int nros_zephyr_task_create(pthread_t *thread,
                             void *(*entry)(void *),
                             void *arg);
 
+/* issue 0852 — `attr` is READ, not discarded.
+ *
+ * The pointer is an `nros_platform_task_attr_t *`, not a `pthread_attr_t *`,
+ * despite the `z_task_attr_t *` in the signature. That is the contract
+ * `zpico_set_task_config` states and issue 0803 already relied on:
+ *
+ *     g_default_read_task_opts.task_attributes =
+ *         (z_task_attr_t *) &g_default_read_nros_attr;
+ *
+ * zenoh-pico's core never dereferences the pointer -- `_zp_start_read_task`
+ * forwards it here untouched -- so the port at the other end decides the type,
+ * and on this platform that type is the nros attr.
+ *
+ * This function used to be `(void)attr;`. Everything above it worked: the
+ * Kconfig knob, the CMake wiring, the RAW encoding, issue 0626's fix to
+ * `zpico_set_task_config`. The priority reached this line and stopped, so the
+ * zenoh READ task was born inheriting the executor's priority and the polled
+ * serial RX lost a full timeslice to it on every `k_yield()`. */
 z_result_t _z_task_init(_z_task_t *task,
                         z_task_attr_t *attr,
                         void *(*fun)(void *),
                         void *arg) {
-    (void)attr;
-    return nros_zephyr_task_create(task, fun, arg) == 0 ? 0 : -1;
+    /* NULL is the documented "every default" case, and it must stay
+     * indistinguishable from the pre-issue behaviour. */
+    if (attr == NULL) {
+        return nros_zephyr_task_create(task, fun, arg) == 0 ? 0 : -1;
+    }
+    return nros_platform_task_init((void *)task, (void *)attr, fun, arg)
+                   == NROS_PLATFORM_RET_OK
+               ? 0
+               : -1;
 }
 
 extern void nros_zephyr_task_slot_release(pthread_t owner);


### PR DESCRIPTION
Closes #0852. Resolves the zid determinism filed here as 0864. Files 0865.

## The defect

`CONFIG_NROS_ZENOH_READ_PRIORITY` was **inert on Zephyr**. The value is wired
through Kconfig and CMake, encoded by `zpico_set_task_config`, and then
discarded twice:

- `_z_task_init` (`zephyr/nros_zenoh_zephyr_system.c`) did `(void)attr;`
- the platform ABI's own `task_init` (`nros-platform-zephyr/src/platform.c`) did `(void) a;`

Neither set `PTHREAD_EXPLICIT_SCHED`, so Zephyr's `PTHREAD_INHERIT_SCHED`
default made the zenoh read task inherit the priority of the executor that
started it. At equal priority with `CONFIG_TIMESLICING`, the `k_yield()` in the
polled serial read loop hands the executor a full 20 ms slice — ~230 bytes at
115200 against a few-entry LPUART FIFO. The UART overran and the frames it
dropped were the router's keepalives.

Issue 0626 fixed the same drop one layer up, and its comment says a quietly
dropped scheduling attribute "must not be reintroduced one layer down". It had
been, here.

## SCHED_RR, not SCHED_FIFO

On Zephyr `SCHED_FIFO` selects the **cooperative** band
(`lib/posix/options/pthread_sched.h`). The task in question busy-polls a UART,
so making it cooperative would trade a 20 ms starvation of the reader for an
unbounded starvation of every preemptible thread. The posix port picks
SCHED_FIFO because on Linux that is simply "the real-time policy"; the constant
means something different here, which is what a per-port map is for.

RAW values are clamped to the policy range rather than passed through to be
rejected — Zephyr rejects an out-of-range `sched_priority` by leaving the
priority inherited, silently, which is the failure mode this issue is.

## Also: a unique zenoh id per boot

The board drew `1322740661b45746fa29b1803f32f5eb` on **every** boot
(`CONFIG_TEST_RANDOM_GENERATOR`, no hardware entropy). A zid is the identity a
router holds session state under, so every reconnect-shaped measurement depended
on router history rather than firmware — it invalidated a real A/B while
chasing this issue.

`nros_platform_random_*` is now served from a xoshiro128** seeded from a
`.noinit` word carried across reset, plus cycle/uptime. Substituted **only**
when `CONFIG_TEST_RANDOM_GENERATOR` is set and `CONFIG_ENTROPY_GENERATOR` is
not — a PRNG must not shadow real entropy. Three boots, three distinct zids.
24 B of RAM. **Not a CSPRNG**, and the code says so where it is defined.

## Honest scope

Two claims made earlier in this work were **withdrawn** in the issue file rather
than quietly dropped:

- "0 of 5 goals before, 2 of 5 after" — does not reproduce under a fixed
  harness. Both RX paths give 0/5. The priority fix is correct on its own terms
  but **cannot claim a goal-completion improvement.**
- "interrupt-driven RX breaks the board's declarations" — an artifact of the
  shared zid. Withdrawn.

Interrupt-driven RX ships **disabled**; it is implemented and board-clean but
not yet shown to be better.

## Submodule

Moves `zenoh-pico` to `jerry73204/zenoh-pico@fix/zephyr-serial-irq-rx`
(pushed): adds `uart_err_check` reporting and the optional ISR RX path, and
fixes a real defect in that ISR — it guarded its loop with
`uart_irq_is_pending()`, which is true for a TX cause too, so it could return
with the interrupt still asserted and re-enter forever.

## Also included

- RFC-0084 + phase-397: readiness pushed by the arrival path instead of scanned
  (`spin_once` makes up to 64 indirect `has_data` calls per spin regardless of
  what woke it). Design only, not implemented.
- Issue 0865: no example calls `register_parameter_services()`, so
  `ros2 param list` is empty against every nano-ros node.

## Verification

Built and flashed on MR-CANHUBK344 hardware repeatedly; pub/sub, services and
graph introspection verified against a live `rmw_zenoh` router. Zero `.rs` files
changed — this is C and docs.

Local `ci-l1` does not reach green in my checkout: the examples' `nros`
dependency resolves to crates.io rather than the local patch, which reproduces
before my commits and appears to be a provisioning gap on my side rather than a
defect in this change. Deferring to CI on that.