### PR TITLE
phase-391/392 + issues 0827/0832/0843/0872/0881/0895/0896/0900: the static-memory campaign, collapsed

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -443,9 +443,16 @@ jobs:
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: just generate-bindings
 
+      # The `source /opt/ros/humble/setup.bash` below is load-bearing, not
+      # boilerplate: `check-rmw-cyclonedds`'s from-msg targets run
+      # msg_to_cyclone_idl.py at BUILD time, which imports rosidl_adapter from
+      # /opt/ros. The configure-time probe only checks the converter script
+      # EXISTS (issue-0196 class: probe narrower than the rule), so an
+      # unsourced env fails at 80% of the build rather than at configure.
       - name: just check-build + no_std (nightly / manual only)
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |
+          source /opt/ros/humble/setup.bash
           just check-build
           just check-no-std
 

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -61,9 +61,9 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:80` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:79` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:78` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:91` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:90` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:89` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -71,7 +71,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PENDING_GETS` | 4 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PUBLISHERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:47` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:58` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SESSIONS` | 1 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SUBSCRIBERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_PUBLISHER_TX_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -32,7 +32,8 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 
 | knob | default | read by |
 | --- | ---: | --- |
-| `NROS_EXECUTOR_ARENA_SIZE` | computed — see `packages/core/nros-node/build.rs:134` | `packages/core/nros-node` |
+| `NROS_EXECUTOR_ACTION_CLIENTS` | computed — see `packages/core/nros-node/build.rs:105` | `packages/core/nros-node` |
+| `NROS_EXECUTOR_ARENA_SIZE` | computed — see `packages/core/nros-node/build.rs:161` | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_CBS` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_NODES` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SC` | 8 | `packages/core/nros-node` |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -61,9 +61,9 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:91` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:90` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:89` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:256` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:255` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:254` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -71,7 +71,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PENDING_GETS` | 4 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PUBLISHERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:58` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:223` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SESSIONS` | 1 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SUBSCRIBERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_PUBLISHER_TX_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -61,9 +61,9 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:256` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:255` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:254` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:470` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:469` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:468` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -71,7 +71,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PENDING_GETS` | 4 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PUBLISHERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:223` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:431` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SESSIONS` | 1 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SUBSCRIBERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_PUBLISHER_TX_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |

--- a/cmake/NanoRosEntityFacts.cmake
+++ b/cmake/NanoRosEntityFacts.cmake
@@ -1,0 +1,143 @@
+# phase-392 W5.c — deliver the ENTITY figures the RMW sizes its queryable table
+# from to the cargo invocation this configure owns.
+#
+# Sibling of `NanoRosBoardFacts.cmake`, same carrier and the same reason: a
+# workspace member's own `.cargo/config.toml` is never read, because Corrosion
+# runs cargo from the workspace root (phase-349 W2.0), and `set(ENV{...})`
+# reaches only the configure-time process, so a knob published that way lands in
+# the C lane and not the cargo one (issue 0460). `corrosion_set_env_vars`
+# attaches to the target's own build command.
+#
+# WHAT IS DIFFERENT FROM BOARD FACTS. Board facts answer a question about the
+# BOARD, of which exactly one is active per configure. This answers a question
+# about the resolved SystemModel, of which a workspace can hold SEVERAL — one
+# per entry. There is only ONE runtime staticlib per configure and every entry
+# links it, so the compile-time table must satisfy the largest declaration:
+# entries ACCUMULATE here (union of the infrastructure flags, max of the
+# application counts) and the union is applied once.
+#
+# Accumulation is safe in that order because `nros_synth_runtime_umbrella` runs
+# AFTER the SUBDIRS loop that processes the entries (NanoRosWorkspace.cmake) —
+# the same ordering `nros-metadata.json` already depends on.
+
+include_guard(GLOBAL)
+
+include("${CMAKE_CURRENT_LIST_DIR}/NanoRosCorrosionEnv.cmake")
+
+# nros_record_entity_facts(<model-path>)
+#
+# Ask `nros ws entity-facts` about ONE entry's model and fold the answer into
+# this configure's accumulated view.
+#
+# Deliberately soft on failure, exactly like `nros_resolve_board_facts`: a model
+# that is not there yet, a CLI that has not been built, an entry addressed the
+# `MODEL` way at a path that does not exist — all mean "this configure has no
+# entity facts to carry", which is the state every build was in before this
+# wave. Nothing here is a configuration error, so nothing here is fatal.
+function(nros_record_entity_facts _model)
+    if(_model STREQUAL "" OR NOT EXISTS "${_model}")
+        return()
+    endif()
+    if(NOT DEFINED _NANO_ROS_CODEGEN_TOOL OR NOT EXISTS "${_NANO_ROS_CODEGEN_TOOL}")
+        return()
+    endif()
+
+    # One run per distinct model — several entries share a bringup, and the
+    # workspaces that do (workspaces/c has 7) would otherwise pay the verb once
+    # per entry for the same answer.
+    string(MAKE_C_IDENTIFIER "NROS_ENTITY_FACTS_MEMO__${_model}" _memo)
+    get_property(_seen GLOBAL PROPERTY ${_memo})
+    if(_seen)
+        return()
+    endif()
+    set_property(GLOBAL PROPERTY ${_memo} TRUE)
+
+    execute_process(
+        COMMAND "${_NANO_ROS_CODEGEN_TOOL}" ws entity-facts --model "${_model}"
+        OUTPUT_VARIABLE _out
+        ERROR_VARIABLE _err
+        RESULT_VARIABLE _rc
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _rc EQUAL 0)
+        string(REGEX REPLACE "\n+" " " _why "${_err}")
+        string(SUBSTRING "${_why}" 0 200 _why)
+        message(STATUS "nano-ros: entity facts NOT read from ${_model} — ${_why}")
+        return()
+    endif()
+
+    set_property(GLOBAL PROPERTY NROS_ENTITY_FACTS_SEEN TRUE)
+
+    string(REPLACE "\n" ";" _lines "${_out}")
+    # An entry whose model describes no wiring says NOTHING about the
+    # application count (the verb abstains rather than reporting a zero it
+    # cannot support). One such entry makes the whole configure's application
+    # count unknown: the shared staticlib has to hold the largest, and an
+    # unknown is not smaller than anything.
+    set(_saw_servers FALSE)
+    foreach(_line IN LISTS _lines)
+        if(_line MATCHES "^NROS_DECLARED_INFRA_QUERYABLES=(.*)$")
+            set(_infra "${CMAKE_MATCH_1}")
+            if(_infra MATCHES "param")
+                set_property(GLOBAL PROPERTY NROS_ENTITY_INFRA_PARAM TRUE)
+            endif()
+            if(_infra MATCHES "lifecycle")
+                set_property(GLOBAL PROPERTY NROS_ENTITY_INFRA_LIFECYCLE TRUE)
+            endif()
+        elseif(_line MATCHES "^NROS_DECLARED_SERVICE_SERVERS=([0-9]+)$")
+            set(_saw_servers TRUE)
+            get_property(_have GLOBAL PROPERTY NROS_ENTITY_SERVERS_MAX)
+            if(NOT _have OR CMAKE_MATCH_1 GREATER _have)
+                set_property(GLOBAL PROPERTY NROS_ENTITY_SERVERS_MAX "${CMAKE_MATCH_1}")
+            endif()
+        endif()
+    endforeach()
+    if(NOT _saw_servers)
+        set_property(GLOBAL PROPERTY NROS_ENTITY_SERVERS_UNKNOWN TRUE)
+    endif()
+endfunction()
+
+# nros_entity_facts_env(<target>)
+#
+# Attach this configure's accumulated entity facts to a Corrosion target's cargo
+# invocation. Called once, after every entry has been processed.
+function(nros_entity_facts_env _target)
+    get_property(_seen GLOBAL PROPERTY NROS_ENTITY_FACTS_SEEN)
+    if(NOT _seen)
+        # Not a warning: a pure-C workspace with no LAUNCH entry, or a
+        # configure whose models are not resolved yet, has always sized the
+        # table from the backend's own default and still does.
+        return()
+    endif()
+
+    get_property(_param GLOBAL PROPERTY NROS_ENTITY_INFRA_PARAM)
+    get_property(_lc GLOBAL PROPERTY NROS_ENTITY_INFRA_LIFECYCLE)
+    if(_param AND _lc)
+        set(_infra "param+lifecycle")
+    elseif(_param)
+        set(_infra "param")
+    elseif(_lc)
+        set(_infra "lifecycle")
+    else()
+        set(_infra "none")
+    endif()
+    set(_env "NROS_DECLARED_INFRA_QUERYABLES=${_infra}")
+
+    get_property(_unknown GLOBAL PROPERTY NROS_ENTITY_SERVERS_UNKNOWN)
+    get_property(_max GLOBAL PROPERTY NROS_ENTITY_SERVERS_MAX)
+    if(NOT _unknown AND NOT _max STREQUAL "")
+        list(APPEND _env "NROS_DECLARED_SERVICE_SERVERS=${_max}")
+        set(_app "${_max} declared service server(s)")
+    else()
+        set(_app "application count undeclared (no model here describes wiring)")
+    endif()
+
+    if(NOT COMMAND corrosion_set_env_vars)
+        message(FATAL_ERROR "nros_entity_facts_env(${_target}): Corrosion not loaded")
+    endif()
+    # issue 0657 — attach to the target the cargo command actually READS.
+    nros_corrosion_env_target("${_target}" _target)
+    corrosion_set_env_vars(${_target} ${_env})
+    message(STATUS
+        "nano-ros: queryable table sized from the declaration — "
+        "infrastructure ${_infra}, ${_app} (phase-392 W5)")
+endfunction()

--- a/cmake/NanoRosEntry.cmake
+++ b/cmake/NanoRosEntry.cmake
@@ -334,6 +334,13 @@ function(nano_ros_entry)
             endif()
         endif()
 
+        # phase-392 W5.c — the entity figures this entry DECLARES, folded into
+        # the configure's accumulated view. One runtime staticlib serves every
+        # entry here, so the union is applied once by
+        # `nros_synth_runtime_umbrella`, which runs after the SUBDIRS loop.
+        include("${_NROS_ENTRY_DIR}/NanoRosEntityFacts.cmake")
+        nros_record_entity_facts("${_NRA_MODEL}")
+
         _nros_entry_invoke_codegen(
             NAME      "${_NRA_NAME}"
             LANG      "${_NRA_LANG}"

--- a/cmake/NanoRosRuntimeCrate.cmake
+++ b/cmake/NanoRosRuntimeCrate.cmake
@@ -305,6 +305,12 @@ nros_armv8r_cflags_env(nros_ws_runtime-static)
     # workspace member's own `.cargo/config.toml` never does (corrosion invokes
     # cargo from the workspace root).
     nros_board_facts_env(nros_ws_runtime-static)
+    # phase-392 W5.c — and the entity figures the RMW sizes its queryable table
+    # from. Applied HERE, once, because this staticlib is shared by every entry
+    # in the configure and the accumulation is complete only after the SUBDIRS
+    # loop above has processed them all.
+    include("${NANO_ROS_ROOT}/cmake/NanoRosEntityFacts.cmake")
+    nros_entity_facts_env(nros_ws_runtime-static)
     if(NOT TARGET nros_ws_runtime-static)
         message(FATAL_ERROR
             "nros_synth_runtime_umbrella: Corrosion did not create "

--- a/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
@@ -92,6 +92,58 @@ list: an image whose resolved model contains zero subscriptions needs zero of
 it, and that derivation needs no infrastructure accounting — unlike the
 queryable one above, the runtime creates no large-payload subscriber of its own.
 
+## Measured 2026-08-29 — the "easiest win" is NOT available with the existing knob
+
+The section above calls `LARGE_PAYLOADS` "the single easiest win ... an image
+whose resolved model contains zero subscriptions needs zero of it". Zero is
+**not expressible**. `packages/rmw/zenoh/nros-rmw-zenoh/build.rs:45`:
+
+```rust
+let max_large: usize = env_usize("ZPICO_MAX_LARGE_SUBSCRIBERS", 2).max(1);
+```
+
+The `.max(1)` floor means the smallest reachable pool is
+`1 * ZPICO_SUBSCRIBER_RING_DEPTH(4) * ZPICO_SUBSCRIBER_LARGE_SIZE(16384)` =
+**65,536 bytes**, not 0. So wiring the resolved model to this knob — the fix
+this issue proposes — buys half of what the issue claims: 131,072 -> 65,536 on
+a talker, with the other half structurally out of reach until the floor goes.
+
+MEASURED, not read — three builds of `examples/native/rust/talker`, the knob
+varied, `llvm-nm -S` on each binary:
+
+| `ZPICO_MAX_LARGE_SUBSCRIBERS` | `LARGE_PAYLOADS` |
+| ---: | ---: |
+| 2 (default) | 131,072 |
+| 1 | 65,536 |
+| **0** | **65,536** |
+
+Note the third row: asking for zero does not fail, it silently yields one. A
+codegen deriving "no subscriptions -> 0" would emit a config that reads as
+satisfied while still reserving 64 KiB — the same shape as every other defect
+this campaign has found, a value that looks applied and is not. If the floor
+stays, the knob should REJECT 0 rather than round it up.
+
+Baseline confirming the arithmetic, `just mem-report` on
+`build/cargo-fixtures/linux-14372940/nros-relwithdebinfo/talker`:
+
+```
+       131,072   35.8%  nros_rmw_zenoh::shim::subscriber::LARGE_PAYLOADS
+       131,072  LARGE_PAYLOADS  — agrees with `ZPICO_MAX_LARGE_SUBSCRIBERS *
+                                  ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE`
+```
+
+Removing the floor is not free to reason about: `.max(1)` exists so a pool
+index is always valid, and the sibling `max_nodes` floor documents exactly that
+intent ("so a session always has room for its own primary node"). A zero-length
+pool needs the *lookup* path to refuse a large subscription rather than index an
+empty array — a code change, not a knob change. Whoever takes this should price
+both halves separately: the knob wiring (65,536, mechanical) and the floor
+removal (a further 65,536, needs the refusal path).
+
+The same floor applies to `ZPICO_MAX_QUERYABLES`-style derivations. Check for it
+before quoting a saving off the inventory: the inventory prints the formula, not
+the floor.
+
 ## Reproduce
 
 ```sh

--- a/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
@@ -165,3 +165,72 @@ the totals were wrong by 2,417–2,598 bytes and the "identical to the byte"
 claim was wrong by 16. Trust the group directory, and check an artifact's mtime
 against its sources before quoting it. `--json` plus `--baseline` shows the delta
 between any two images, which is how a fix should be reported.
+
+## Design settled 2026-08-29 — and why const generics are not the answer
+
+**Const generics reach no non-Rust consumer, and are still wrong here.**
+Traced the boundary: `SERVICE_BUFFERS` is a private `static mut` — no header,
+no `#[no_mangle]`, no `repr(C)`. C round-trips one opaque `*mut c_void` token
+(`session_index * ZPICO_MAX_QUERYABLES + local`) that it never does arithmetic
+on, and validates its own handles against its own table. So the two tables are
+NOT layout-coupled; this is not the 0135 class. If Rust's N exceeded C's, Rust
+would admit a server C then refuses — a clean error, not corruption.
+
+They are wrong anyway because a const generic needs a TYPE to carry it. A Rust
+entry has one (`Node::ENTITY_BOUNDS`, the W5 shape). A C/C++ entry does not —
+it is cmake-driven through `nano_ros_entry()`. Pushing the generic up leaves
+two exits, both bad: a non-generic C entry point that picks some N (a
+hand-picked number again, the thing being removed), or a sizing parameter on
+the C API, which stops it being a thin wrapper of Rust.
+
+**The direction this need runs is C -> Rust.** `*_OPAQUE_U64S` is the existing
+thin-wrapper channel and it flows Rust -> C: Rust owns the type, a build step
+computes `size_of`, a generated header carries the number, C declares opaque
+storage. Here the application declares how many services it has and the backend
+consumes it — the reverse. That channel is specified but unbuilt: phase-392 W2's
+`NROS_ARENA_REQUIRED`. So this is a second consumer of a planned mechanism, not
+a new one.
+
+**One declaration site serves both languages.** The feature-forwarding plan (add
+`param-services`/`lifecycle-services` passthrough to `zpico-sys`, forward at
+~15 leaves, gate the forwarding) is unnecessary: the resolved model already
+carries it. `system.toml` declares `features = ["param_services", "lifecycle"]`
+and the plan schema has `PlanParamServices` / `PlanLifecycle` as first-class
+fields. Rust entries reach it through the macro, C/C++ entries through
+`nano_ros_entry()` reading the same model.
+
+Division of labour, which keeps issue 0460 closed: the model says WHETHER the
+infrastructure services exist; Rust says HOW MANY, beside the code that creates
+them. Codegen must never own that number — it sees the user's entities and
+never the runtime's.
+
+**Net C/C++ API change: none.** No new function, no parameter, no generic in a
+header. One more `#define` in a file that is already generated.
+
+**Decided: an undeclared image fails loudly.** A bare `cargo build` of a leaf,
+and the standalone `check-rmw-*` projects, have no model. Rather than keep
+today's generous 32 (safe, and 144,128 bytes of service buffers whether or not
+the image has a single service), the model-less path is a build-time failure
+that names what to declare. Per this issue's own `.max(1)` finding, a fallback
+that silently yields a working-but-wasteful number is the shape that reads as
+satisfied and is not.
+
+### Landed already (the count itself)
+
+The counts now have one definition each, beside the code that creates them:
+`parameter_services::PARAM_SERVICE_QUERYABLES` (6) and
+`lifecycle_services::LIFECYCLE_SERVICE_QUERYABLES` (5). They had SEVEN
+spellings and no definition; two were wrong, both saying lifecycle was 6, which
+is where "twelve slots" came from. It is eleven.
+
+`check-infra-queryable-counts` ties each constant to the number of
+`create_param_srv::<_>` / `create_lc_srv::<_>` statements, so a seventh service
+fails until the constant moves — a constant alone is still a hand-typed literal
+and would have drifted exactly as the prose did. It also forbids an RMW backend
+from restating a count it cannot derive: that gate found the seventh mirror on
+its first run.
+
+### Still open
+
+The sizing itself. Wants its own work item — it is the W5 restructuring one
+layer down, and should not be smuggled in beside a comment fix.

--- a/docs/issues/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
+++ b/docs/issues/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
@@ -65,6 +65,56 @@ nothing exercises it.
   there — so the fix is about the tier promise and the embedded case, not about
   native behaviour.
 
+## Resolution, cyclone half (2026-08-29)
+
+Two fork commits and one build fix, in that dependency order:
+
+| what | where |
+| --- | --- |
+| `ddsrt`'s heap routed through the funnel | fork `6e2ad36f` |
+| the nested-build path bug that blocked editing `ddsi_config.c` | fork `556f79d4` |
+| the four ddsi sites that called libc directly | fork `8e6ff48a` |
+
+The middle one was not foreseen. `_confgen`'s hash check watches
+`ddsi_config.c`, which is the file two of the bypass edges live in, and its
+regeneration commands resolved `AppendHashScript.cmake` through
+`CMAKE_SOURCE_DIR` — nano-ros's root under `add_subdirectory`. Worse, the
+failure is not clean: `_confgen-exe` has already rewritten four generated files
+in the SOURCE tree when the hash-appending step dies, so the tree does not
+settle until they are restored by hand.
+
+Three of the four ddsi sites were **already bugs**, independent of the funnel.
+They allocate from one heap and release to the other:
+
+* a listelem `malloc`'d in `network_interface_find_or_append`, freed by
+  `free_all_elements`' `ddsrt_free`;
+* `split_at_comma`'s `ddsrt_malloc`'d array released with libc `free`;
+* a `calloc`'d `->verbatim` released through `dds_stream_free_sample`, whose
+  allocator is `{ddsrt_malloc, ddsrt_realloc, ddsrt_free}`;
+* (the fourth) a `ddsrt_asprintf` string freed with `free`, under `DDS_HAS_SHM`.
+
+On POSIX both heaps are glibc, so none of them can fault natively — which is
+why they survived. They cross real heaps on ThreadX, FreeRTOS and Zephyr, and
+under the funnel.
+
+Two sites were checked and deliberately left: `sysdeps.c`'s `free` pairs with
+`backtrace_symbols`, which glibc allocated, and `q_freelist.c`'s `free` is the
+function's own parameter, not libc.
+
+Measured after: `libddsc.a` has exactly one object referencing a raw libc
+allocator — `sysdeps.c.o`'s `free`, the correct one. A binary linking the
+funnelled `ddsc` against `libnros_platform_posix.a` carries 7 funnel call sites
+and runs: `ddsrt_malloc`/`realloc`/`free` round-trip, then a domain and
+participant created and deleted with a `NetworkInterfaceAddress` config, which
+is what drives the two `ddsi_config.c` sites (its deprecation warning proves the
+path executed). Backend suite 22/22.
+
+**Still open: the XRCE half.** `get_ip_from_iface` was not touched, so the xrce
+row of the table above stands.
+
+**Also open: coverage.** The funnel-ON path is built by no fast-line lane — see
+issue 0881. The verification above is by hand.
+
 ## Method note
 
 Two false readings were produced and discarded while measuring this, both worth

--- a/docs/issues/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
+++ b/docs/issues/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
@@ -74,6 +74,7 @@ Two fork commits and one build fix, in that dependency order:
 | `ddsrt`'s heap routed through the funnel | fork `6e2ad36f` |
 | the nested-build path bug that blocked editing `ddsi_config.c` | fork `556f79d4` |
 | the four ddsi sites that called libc directly | fork `8e6ff48a` |
+| one funnel heap for every port, not an arm inside POSIX's | fork `d97a71e2` |
 
 The middle one was not foreseen. `_confgen`'s hash check watches
 `ddsi_config.c`, which is the file two of the bypass edges live in, and its
@@ -108,6 +109,32 @@ and runs: `ddsrt_malloc`/`realloc`/`free` round-trip, then a domain and
 participant created and deleted with a `NetworkInterfaceAddress` config, which
 is what drives the two `ddsi_config.c` sites (its deprecation warning proves the
 path executed). Backend suite 22/22.
+
+### One route, not one per port
+
+The first commit was POSIX-only. It put the funnel arms inside
+`heap/posix/heap.c`, so FreeRTOS kept calling `pvPortMalloc` and ThreadX
+`tx_byte_allocate` — a second allocation route on precisely the ports whose
+heap is genuinely not libc's, which is where the tier promise means something.
+
+`d97a71e2` makes it one implementation: `heap/nros/heap.c` provides the whole
+`ddsrt_*` family on `nros_platform_{alloc,realloc,dealloc}`, and each port's
+own heap.c is compiled out by the same switch. Four identical arms would have
+been four copies of one rule.
+
+The file is in the COMMON source list rather than swapped in per port, because
+`ddsrt` is an INTERFACE library and `ddsrt-internal` compiles the same
+`INTERFACE_SOURCES` — a swap would hand the funnel to idlc and confgen, host
+tools that link no platform layer. The switch being a PRIVATE compile
+definition on `ddsc` is what keeps the two apart. Measured:
+`libddsrt-internal.a` has zero `nros_platform_*` references and its stock posix
+heap still defines the family, so the tools link.
+
+So `sysdeps.c`'s surviving libc `free` is not a hole in the promise. Its block
+is guarded to `__APPLE__ || (__linux && (__GLIBC__ || __UCLIBC__))` and
+`! DDSRT_WITH_FREERTOS`, so it does not exist on any target where the
+platform's heap and libc's differ, and where it does exist it pairs with a
+block `backtrace_symbols` allocated from glibc itself.
 
 **Still open: the XRCE half.** `get_ip_from_iface` was not touched, so the xrce
 row of the table above stands.

--- a/docs/issues/0872-pr-arm-example-check-needs-nros-sync.md
+++ b/docs/issues/0872-pr-arm-example-check-needs-nros-sync.md
@@ -1,0 +1,79 @@
+---
+id: 872
+title: "The PR/nightly check arm has never run to completion — each fix exposes the next environment gap"
+status: open
+area: ci
+severity: medium
+found: 2026-08-28
+related: [phase-395, 0816]
+---
+
+# The PR/nightly check arm has never run to completion
+
+## What was measured
+
+PR #7 is the first pull request through the merge queue (phase-395 W7). Its
+required check — `check (fast on push; full on PR/nightly)` — has failed seven
+times, each time on a DIFFERENT gate, each one further into the job than the
+last. The push lane runs only `check-fast`, so the PR/nightly arm's steps had
+never executed against the CI container at all; every failure below is a
+pre-existing gap that the queue's arrival made visible, not a regression from
+the PR's payload.
+
+Fixed inside PR #7 (each verified locally, most with a negative control):
+
+| # | gate | gap |
+| --- | --- | --- |
+| 1 | `check-source-gates` | the compile-check fixtures it consumes were never built by the job |
+| 2 | `compile-check-fixtures.sh` | the cmake-lane prereq probe hard-exits even when the selection contains no cmake row |
+| 3 | `check-source-gates` | bare `cargo test` counts a `skip!` panic as a failure (no junit rewrite) |
+| 4 | `check-build` | `msg_to_cyclone_idl.py` imports `rosidl_adapter` at BUILD time; the ROS env was not sourced |
+| 5 | `check-sched-dim-arms` | probes that `arm-none-eabi-gcc` EXISTS; the container's has no newlib, so every arm failed on `<string.h>` |
+
+**Rows 1-3 were fixed independently and better on `main`** (phase-395 W19/W20),
+while this branch was in flight: `check-source-gates` now builds its own
+`cxx-syntax` lane and runs through the shared `_nextest-tolerant`, and the lane
+filter short-circuits the cmake prereq probe before it can exit. Two convergent
+diagnoses of the same three defects, from opposite ends. Only rows 4 and 5
+survive in PR #7; the rest of this table is history, kept because the PATTERN is
+the finding — an arm nothing executes accumulates gaps at roughly one per gate.
+
+## Still open — the gate this issue is filed for
+
+(Whether this still reproduces under phase-395 W20's restructure is UNVERIFIED:
+the compile tier moved to `merge_group`, so the example check now runs per
+BATCH rather than per PR, and this branch has not yet been through the queue.)
+
+With those five fixed the arm reaches the example check inside `just check`,
+which reports:
+
+```
+native check: 33 example(s) are missing their generated message bindings
+```
+
+The examples' `generated/` trees are USER-side codegen (`nros sync`), absent in
+a fresh clone by design. The job builds the CLI and provisions `-sys` sources
+but never syncs any example leaf, so this gate cannot pass as the workflow
+stands. Two candidate shapes, neither yet chosen:
+
+* run `nros sync` for the leaves the check walks (cost: unmeasured), or
+* have the example check SKIP legibly when `generated/` is absent, the way the
+  cross-toolchain gates now skip — consistent with "probe what you use, skip
+  legibly, never fail on a lane you did not enter", which is the vocabulary the
+  other four fixes converged on.
+
+## Why this is not "just fix it in the PR"
+
+Each fix has been one line of insight and one round of ~25 minutes of CI. The
+payload of PR #7 (the heap-free tier image, issue 0843) is unrelated to any of
+this and is verified locally by `ci-l1` + `ci-l3` + native e2e. Continuing to
+grow that PR with workflow archaeology couples an unrelated change to an
+open-ended CI debug loop; the remaining gap is worth its own change, with the
+skip-vs-sync decision made deliberately rather than under merge pressure.
+
+## Method note
+
+`gh run view --job <id> --log-failed` truncates the failing step's own name to
+`UNKNOWN STEP` for container jobs, so the failing RECIPE has to be read out of
+the log body (`error: recipe \`X\` failed`) rather than the step header. The
+first four rounds were diagnosed that way.

--- a/docs/issues/0880-format-walks-unbuilt-colcon-workspace-leaves.md
+++ b/docs/issues/0880-format-walks-unbuilt-colcon-workspace-leaves.md
@@ -1,0 +1,121 @@
+---
+id: 880
+title: "`just format` is red or green depending on whether a migrated colcon workspace has been BUILT"
+status: open
+area: build
+severity: medium
+found: 2026-08-29
+related: [0359, 0463, phase-383, RFC-0065]
+---
+
+# `just format` walks into leaves whose workspace root is a build artifact
+
+## What was measured
+
+On a tree where `examples/workspaces/launch` has not been built, `just format`
+fails:
+
+```
+cd examples/workspaces/launch/src/listener_pkg && cargo +nightly-2026-04-11 fmt
+`cargo metadata` exited with an error: error: current package believes it's in a
+workspace when it's not:
+current:   .../examples/workspaces/launch/src/listener_pkg/Cargo.toml
+workspace: .../nano-ros/Cargo.toml
+```
+
+24 leaves format successfully before it, so the failure reads as a problem with
+that leaf. It is not. `examples/workspaces/launch` is a MIGRATED colcon
+workspace (RFC-0065 D3 / phase-383 W10.a): `nros build` GENERATES its root
+`Cargo.toml`, and `examples/workspaces/launch/.gitignore:13` hides it. The
+tracked marker is `.colcon_workspace`. So the two leaves are members of a
+workspace root that exists only after a build — and `just format` steps into
+them regardless.
+
+The same fact is already written down one lane over.
+`nros-tests/tests/example_shape.rs::every_standalone_rust_leaf_is_its_own_workspace_root`
+carries this comment:
+
+> Reading only the manifest made this test depend on whether the workspace
+> happened to have been BUILT — green on a machine that had, red on a fresh
+> clone, and red here for `examples/workspaces/launch` once its root was
+> deleted.
+
+That test was taught to read `.colcon_workspace` as the tracked half of the
+fact. `just format` was not, and neither was anything else that runs a bare
+cargo command per leaf.
+
+## Why it is not simply "run `nros build` first"
+
+The state is build-dependent per WORKSPACE, so the tree is half-resolved at any
+given moment. Measured on this checkout:
+
+| workspace | root manifest on disk | rust leaves | `just format` |
+| --- | --- | ---: | --- |
+| `features` | yes | 10 | green |
+| `realtime-rust` | yes | 3 | green |
+| `rust` | yes | 9 | green |
+| `safety` | yes | 3 | green |
+| `sizing` | yes | 1 | green |
+| `mixed` | **NO** | 1 | green — its leaf carries its own `[workspace]` |
+| `launch` | **NO** | 2 | **red** |
+
+`mixed` is the interesting row: it is equally unbuilt and equally a migrated
+workspace, and it passes only because its single leaf
+(`src/rust_heartbeat_pkg`) happens to carry an empty `[workspace]` table while
+`launch`'s two do not. Two leaf shapes coexist inside the same workspace class,
+and which one a workspace got decides whether an unbuilt tree formats.
+
+## Scope of the class
+
+A full sweep of tracked manifests — nearest enclosing `[workspace]`, root
+`members` globs expanded, root `exclude` honoured — finds exactly two leaves
+that resolve to the ROOT workspace while being neither member nor excluded:
+
+```
+examples/workspaces/launch/src/listener_pkg
+examples/workspaces/launch/src/talker_pkg
+```
+
+Both confirmed against cargo itself (`cargo metadata --no-deps` in each leaf).
+This is the same shape as issue 0359 / phase-320 W1.b, whose fix note still
+sits in the root `Cargo.toml`:
+
+> these two are neither members nor excluded, so cargo greets anyone who runs a
+> command inside them with "current package believes it's in a workspace when
+> it's not". They are unbuilt porting templates, so nothing surfaced it until
+> now.
+
+Third time for the class, second cause: 0359 was two crates missing from
+`exclude`; this is two leaves whose owning root is generated.
+
+## What a fix has to decide
+
+Not "add two `exclude` lines" — that would make the leaves permanently
+un-adoptable by the generated root they legitimately belong to. The real
+question is which of two shapes a migrated workspace's Rust leaf takes, and
+then making it uniform:
+
+1. **Leaf carries its own `[workspace]`** (the `mixed` shape). Works with no
+   build; costs the leaf its membership in the generated root, so
+   feature unification and a shared lock are gone.
+2. **Leaf is a plain member** (the `launch` shape) and every per-leaf cargo
+   recipe learns the `.colcon_workspace` precondition — the same tracked marker
+   `example_shape.rs` already reads, resolved the same order
+   `detect_workspace_root` uses.
+
+(2) is the one that matches what the workspace IS, and it wants a guard, not a
+skip: `just check-tier-preconditions` is where an unmet "this workspace has not
+been built" belongs, so the message names `nros build` instead of surfacing four
+frames deep in `cargo metadata` (the shape issue 0463 fixed for `nros sync`).
+
+Whichever is chosen, the two leaf shapes should stop coexisting, and a gate
+should say so — `every_standalone_rust_leaf_is_its_own_workspace_root` currently
+neither requires nor forbids the table for a member, which is why `mixed` and
+`launch` could diverge silently.
+
+## Reproduce
+
+```
+rm -f examples/workspaces/launch/Cargo.toml    # already absent on a fresh clone
+just format
+```

--- a/docs/issues/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
+++ b/docs/issues/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
@@ -1,0 +1,96 @@
+---
+id: 881
+title: "Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into"
+status: open
+area: ci
+severity: medium
+found: 2026-08-29
+related: [0832, phase-391, RFC-0075]
+---
+
+# The funnel-ON path is built by no lane `just check` runs
+
+## What was measured
+
+Issue 0832 routes Cyclone's `ddsrt` heap through `nros_platform_alloc` behind
+`NROS_DDSRT_PLATFORM_FUNNEL`. The switch is set in the **self-provision** branch
+of `nros_provide_cyclonedds()`, which is the only place it can be set — a
+`find_package` build links a Cyclone whose `heap.c` was already compiled.
+
+That leaves three build shapes, and the funnel is exercised by none of the ones
+on the fast line:
+
+| build | Cyclone provenance | `NanoRos::Platform` | funnel |
+| --- | --- | --- | --- |
+| `just check-rmw-cyclonedds` (standalone backend project) | source | **absent** | OFF |
+| native nano-ros on this host | **find_package** (SDK store `0.10.5-nros1`) | present | impossible |
+| embedded / cross | source (find_package skipped when `CMAKE_CROSSCOMPILING`) | present | **ON** |
+
+Verified by configure output. The standalone project prints
+
+```
+-- nano-ros: CycloneDDS ddsrt heap -> libc (no NanoRos::Platform target to funnel into)
+```
+
+and the native root configure resolves
+
+```
+-- nano-ros: CycloneDDS via find_package (/home/aeon/.nros/sdk/cyclonedds/0.10.5-nros1/...)
+```
+
+so it never reaches the block at all. Only a cross build lands on the source
+branch with a platform present, and those are the embedded cyclone fixtures in
+tier 2.
+
+## Why this matters more than a coverage gap
+
+The funnel is a LINK-shape change: compiling it in turns three platform-ABI
+symbols into undefined references in every archive that absorbs `heap.c`. When
+`9f945dd93` set the define without the corresponding dependency, nothing failed
+at the switch — it failed at whichever executable linked `ddsc` first, three
+targets deep in the backend's own test suite. That was caught only because the
+standalone project happened to build those executables.
+
+After the dependency fix (`ad0e0e0ed`), the standalone project no longer
+compiles the funnel at all. So the lane that caught the breakage is now the lane
+that cannot see it, and the next regression in this shape surfaces in tier 2 —
+a day of latency, on a build that also costs a cross toolchain.
+
+## Verification that stands in for a lane today
+
+Reproducible by hand, ~4 min warm, and worth keeping in whatever fix lands:
+
+```
+cmake -S . -B <dir> -DNANO_ROS_PLATFORM=posix -DNANO_ROS_RMW=cyclonedds \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_DISABLE_FIND_PACKAGE_CycloneDDS=ON
+cmake --build <dir> --target ddsc
+nm <dir>/.../heap.c.o | grep nros_platform      # U alloc/realloc/dealloc, no U malloc/free
+```
+
+Forcing `-DCMAKE_DISABLE_FIND_PACKAGE_CycloneDDS=ON` is what makes a NATIVE
+build take the source branch, which is the cheapest way to reach funnel-ON
+without a cross toolchain.
+
+## Candidate fixes
+
+1. **A native funnel-ON configure+link in `check-rmw-cyclonedds`.** Costs a
+   second Cyclone build from source (~4 min warm), which is most of why the
+   recipe is currently 22 s. Probably too expensive for the fast line as-is.
+2. **Give the standalone backend project a platform target.** It is the nano-ros
+   Cyclone backend, and the funnel is now part of its contract; `nros_platform_posix`
+   is a standalone cmake project. Would need the path passed in as a cache var,
+   the way `CYCLONEDDS_SOURCE_DIR` already is — the module never walks the tree.
+   Turns the existing 22 s lane into a funnel-ON lane and keeps its three
+   executables as the link witness.
+3. **A configure-only assertion**: reach the source branch, assert the define
+   landed and the dependency is on the target, without building. Cheap, but it
+   checks the cmake and not the link, which is the half that broke.
+
+(2) looks best: it restores exactly the coverage that caught the original
+breakage, at no new build.
+
+## Note on the tier model
+
+Funnel-off on native is not a defect. `unified` is an embedded promise, native
+hosts have a real libc heap, and a `find_package` Cyclone cannot be funnelled at
+all. The gap is in TESTING the embedded shape cheaply, not in the shape itself.

--- a/docs/issues/0895-format-walks-unbuilt-colcon-workspace-leaves.md
+++ b/docs/issues/0895-format-walks-unbuilt-colcon-workspace-leaves.md
@@ -1,5 +1,5 @@
 ---
-id: 880
+id: 895
 title: "`just format` is red or green depending on whether a migrated colcon workspace has been BUILT"
 status: open
 area: build

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -1,0 +1,88 @@
+---
+id: 896
+title: "Every C/C++ subscription takes the small size class regardless of its message type — nothing fills `rx_buffer_hint`"
+status: open
+area: rmw, api
+severity: medium
+found: 2026-08-29
+related: [0841, phase-392, phase-380, RFC-0038]
+---
+
+# The receive-buffer hint reaches the backend from Rust and from nowhere else
+
+## What was measured
+
+`rmw_subscription_options_t.rx_buffer_hint` exists (`nros-rmw-abi/include/nros/
+rmw_entity.h:543`), and `rust_adapter.rs:571` reads it into `TopicInfo`. The
+zenoh shim then routes the payload block by it: above `SMALL_CLASS_CEILING` the
+subscriber gets a `large`-class block.
+
+Every source file in the tree that mentions `rx_buffer_hint`:
+
+```
+packages/core/nros-node/src/executor/spin.rs        <- sets it (Rust path)
+packages/core/nros-rmw-abi/include/nros/rmw_entity.h  <- declares the field
+packages/core/nros-rmw/src/traits.rs                <- the Rust struct
+packages/rmw/cffi/src/generated.rs                  <- bindgen output
+packages/rmw/cffi/src/lib.rs                        <- passes it through
+packages/rmw/cffi/src/rust_adapter.rs               <- reads it from options
+packages/rmw/cffi/tests/node_slot.rs                <- a test literal 0
+packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs  <- consumes it
+```
+
+No file under `packages/api/nros-c`, `packages/api/nros-cpp`, `packages/cli/
+rosidl-*` or `examples/` sets it. **The only producer in the tree is the Rust
+executor.**
+
+## Why this matters now
+
+phase-392 W3a wired the Rust path: `create_subscription::<M>` passes
+`subscription_rx_hint::<M>(RX_BUF)`, which is the TYPE's own
+`max(MAX_SERIALIZED_SIZE_XCDR1, XCDR2)` computed from its schema. A Rust
+subscription to a 4 KiB type now routes to the large class instead of raising
+the global knob — the saving W3's own table prices at 98,304 B on
+`SMALL_PAYLOADS`.
+
+A C or C++ subscription to the same type does not. It hints 0, routes small,
+and the only remedy left is the global `ZPICO_SUBSCRIBER_BUFFER_SIZE` — which
+is charged to every subscriber in the image, and again to every executor arena
+slot through `NROS_SUBSCRIPTION_BUFFER_SIZE`.
+
+So W3a's saving is real and applies to half the tree. The phase doc records W3a
+without the asymmetry, which is what this issue exists to correct.
+
+## What makes this harder than the Rust side
+
+The bound is a PROVIDED const on `nros_serdes::Message`, computed from
+`Self::FIELDS` by `size::max_serialized_size`. A C/C++ message is a generated C
+struct with no such trait, so the number has to reach the call site some other
+way.
+
+The constraint that decides the design: **it must not become a second
+computation of the bound.** Two implementations of "how big can this type get"
+is precisely the class this campaign keeps finding (the sizes-header mirror,
+0088 -> 0114 -> 0122 -> 0123 -> 0245 -> 0268), and a serialised-size rule is
+exactly the kind that looks right until an encoding rule changes under one copy.
+
+Options, none surveyed in depth yet:
+
+1. **Codegen emits the number into the generated C/C++ header**, computed by
+   calling `nros_serdes::size::max_serialized_size` — the same function, from
+   the CLI, which already compiles `packages/core/nros-serdes` (it is in
+   `cli-source-dirs.txt`). Today `rosidl-codegen` renders `FIELDS` as a
+   pre-rendered STRING of Rust source rather than constructing `Field` values,
+   so this needs codegen to build the real values first. That refactor is the
+   bulk of the work and it is the option that keeps ONE implementation.
+2. **The `*_OPAQUE_U64S` channel** (`nros_config_generated.h`) is the
+   established Rust-computes / C-declares seam, but it carries sizes of *our*
+   types. Message types are per-workspace and user-defined, and a C-only image
+   has no Rust message crate to compute from — so this does not obviously
+   extend.
+3. **Have the C API ask at runtime.** Rejected on sight: the point is to size a
+   static block before it is allocated.
+
+## Not to be confused with
+
+Issue 0841, fixed: a hint landing between the small block size and the size
+threshold got a block that could not hold it. That is about routing a hint that
+exists. This is about there being no hint at all.

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -233,12 +233,18 @@ edge case.
 1. **Value-first field mapping in `rosidl-codegen`**, rendering the existing
    Rust schema string from the value. No behaviour change; the existing emitter
    tests are the check.
-2. **The bound, computed by `max_serialized_size` over those values**, nested
-   types resolved by the same closure the RIHS path already uses. Emitted as a
-   `#define` from `packs/c/message.h.jinja` (and the C++ sibling). A test must
-   assert it equals the Rust `MAX_SERIALIZED_SIZE_XCDR*` const for the same
-   type — same input, same function, so a disagreement means the value mapping
-   is wrong. Retarget `NROS_PUB_BUFFER_SIZE` onto it in the same change.
+2. **Both bounds, computed by `max_serialized_size` over those values**, nested
+   types resolved by the same closure the RIHS path already uses. Emitted as two
+   `#define`s (XCDR1 and XCDR2) from `packs/c/message.h.jinja` and the C++
+   sibling, plus the `_get_rx_buffer_hint` accessor returning their max. An
+   unbounded type emits NEITHER, so the accessor is absent and a call site
+   naming it fails to compile. A test must assert each equals the Rust
+   `MAX_SERIALIZED_SIZE_XCDR*` const for the same type — same input, same
+   function, so a disagreement means the value mapping is wrong. Retarget
+   `NROS_PUB_BUFFER_SIZE` onto the XCDR1 constant in the same change.
+2b. **Thread the RFC-0033 `cap` into the schema emit** so a field bounded only
+   in `nros-codegen.toml` stops reading as unbounded. Same test, extended with a
+   capped field.
 3. **Design the call-site spelling** — the C analogue of W3b's
    `nros::rx_buffer_for!`. Do this BEFORE 4-5: the C subscription is raw by
    design, so this is how the number reaches the runtime at all, and it decides
@@ -306,25 +312,89 @@ static inline uint32_t std_msgs_msg_int32_get_rx_buffer_hint(void);
 The `#define` from layer 2 is what it returns. A macro form that expands to BOTH
 arguments at once remains an option, but it is no longer load-bearing.
 
+## Decided 2026-08-29
+
+**1. An unbounded type is a COMPILE ERROR at the call site.** No bound, no
+constant, no accessor — the call site naming that type fails to build. The
+alternative (return 0, fall back to the global knob) reproduces today's silent
+defect exactly: a subscription that quietly takes the small class and drops
+samples at runtime on a target with no console. The escape hatch is to bound the
+field, in the `.msg` or via `cap` (below); both are one line and both are the
+thing we actually want the user to do.
+
+**2. Size the RX hint from `max(XCDR1, XCDR2)`; size the TX buffer from XCDR1
+alone.** The wire question has a live-verified answer already in this repo —
+RFC-0055's 2026-07-26 correction:
+
+> A default Jazzy peer serializes FINAL/XCDR1 on the wire (verified live for
+> both fastrtps and cyclonedds; guard
+> `nros_serdes::cdr::tests::xcdr1_header_matches_live_jazzy_wire_bytes`).
+> "Modern ROS 2 defaults types to `@appendable`/XCDR2 so nano-ros must too" is
+> wrong — and DDS-XTypes REJECTS an appendable writer against a FINAL reader, so
+> emitting appendable-by-edition BREAKS default interop. Extensibility is a
+> per-type property, never an edition property.
+
+So XCDR1 is what the LTS editions put on the wire on the default path, and
+nano-ros writes XCDR1 exclusively (`CdrWriter`'s constructors hard-wire it;
+`EncodingVersion::default()` is `Xcdr1`). The TX buffer therefore needs XCDR1
+only.
+
+The RX side is not symmetric. `CdrReader` dispatches on the encapsulation id and
+accepts XCDR2, and RFC-0055's machinery is "built + tested but parked" pending
+per-type `@appendable` re-activation — so a peer's XCDR2 sample can arrive.
+Neither encoding dominates the other in size (XCDR2 adds a 4-byte DHEADER per
+struct, but aligns 8-byte primitives to 4 instead of 8), so the receive bound
+must be the max. This matches what the Rust path already computes
+(`subscription_rx_hint`, `rmw_type_registry.rs:168`).
+
+**Consequence: emit BOTH constants, not one pre-maxed value.** The two consumers
+want different numbers, and a single `MAX_SERIALIZED_SIZE` would be silently
+wrong for one of them — the same reason `pad_to` takes a version rather than a
+constant.
+
+**3. The out-of-band bound already exists: `nros-codegen.toml` `cap` (RFC-0033).**
+No new config file. Per-field `mode` + `cap`, deep-merged, `deny_unknown_fields`,
+and already resolved per-field for the struct rendering
+(`generator/common.rs:415-419`, `583-619`, `891-903`) — `cap = 64` on an
+unbounded `string` renders `heapless::String<64>`.
+
+The gap is one hop: the schema emit path
+(`build_nros_schema_for_struct_with_path`) walks the RAW rosidl AST and has no
+storage resolver in scope, so that same field still emits
+`::nros_serdes::FieldType::String` and the type's bound comes back `None`. The
+capacity is applied to the STORAGE and not to the SCHEMA. Threading the resolved
+`cap` into `render_field_type_expr` is the entire out-of-band mechanism.
+
+Semantics stay distinct, and this is why `cap` sizes a HINT rather than
+asserting a bound: an IDL `string<=64` constrains the publisher, whereas a `cap`
+is local to this image and a remote ROS node may still send 200 bytes. So a
+capped field bounds our buffer and creates a truncation contract — which is
+exactly what (4) handles.
+
+**4. Oversize is explicit and NEVER fatal.** An app that dies on an embedded
+target is worse for the user than one that drops a sample and says so — there is
+often no console, no debugger and no way to restart it.
+
+The receive path already has the right shape to copy, in
+`executor/arena.rs:386`: `#[cold]`, a `DROPPED_TAKES` counter, first-then-every-
+64th rate limiting (so one misconfigured subscription in a 40-participant graph
+cannot flood the log — issue 0371's shape), and `nros_log` rather than stdio,
+because a Rust `std` stdio call is FATAL inside Zephyr `native_sim` (issue 0589).
+No panic, no abort.
+
+The transmit path needs the same treatment plus a distinct status. There is no
+too-large code today — the closest is `NROS_RET_FULL` (-6), which means a full
+queue — so the generated publish helper returns a bare non-zero that callers
+cannot tell from a transport failure. Add one (cbindgen: `just regen-c-headers`),
+and report it once per site rather than per sample.
+
 ## Still undecided
 
-1. **Unbounded types.** A type with no bound gets no constant. Does the
-   accessor then not exist (a compile error at the call site, forcing an
-   explicit decision) or return 0 (falls back to the global knob, matching the
-   Rust path's `RX_BUF` default)? Same question decides the publisher helper.
-2. **XCDR1 vs XCDR2.** Two different bounds for the same type. The Rust path
-   takes the max (`subscription_rx_hint`, `rmw_type_registry.rs:168`). Emit both
-   constants and take the max at the accessor, or emit one already-maxed
-   constant? The layer-2 parity test's shape depends on the answer.
-3. **Where an out-of-band bound is authored and keyed** (`system.toml`? a leaf
-   config?), and whether it may only lower a bound or also assert one for an
-   unbounded type.
-4. **How a truncation drop is reported** distinctly from a transport failure.
-   Today the generated C publish helper returns non-zero for both.
-5. **`RawSubscription::<{ config::MESSAGE_BUFFER_SIZE }>`** — a const generic
-   cannot take a runtime hint, so per-subscription sizing there needs a
-   different mechanism entirely (size-classed arena, or a per-type monomorphised
-   path). Unscoped, and possibly larger than everything above.
+Only one remains: **`RawSubscription::<{ config::MESSAGE_BUFFER_SIZE }>`**
+(`nros-c/src/subscription.rs:503`). A const generic cannot take a runtime hint,
+so per-subscription sizing there needs a different mechanism entirely — a
+size-classed arena, or a per-type monomorphised path. Unscoped, and possibly
+larger than everything above.
 
 ## Not to be confused with
 

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -84,44 +84,174 @@ available at generation time.
 
 That makes option 1 viable, and it is the one to take.
 
-## The shape of the fix
+## Surveyed again 2026-08-29 — the registry shortcut does not exist
 
-`nros_serdes::size::size_bound` never reads `Field::offset` (checked: zero
-references). The offsets are the only part of a `Field` that codegen cannot
-know, so codegen can construct real `Field` values with `offset: 0` and call
-`max_serialized_size` — THE function, not a copy of its rule. `&'static`
-recursion (`FieldType::Nested(&NestedType)`, `Array(_, &FieldType)`) is
-satisfiable by leaking in a short-lived CLI process.
+Considered: skip the emitter work by having the C side look the bound up in a
+generated `&[(type_name, bound)]` table sourced from the Rust message crates'
+own `MAX_SERIALIZED_SIZE_*` consts. Same consts, no second computation, no ABI
+change. **A C image does not link those crates, so there is nothing to source
+the table from.**
 
-The one hazard is the mapping. `render_field_type_expr` maps a rosidl
-`FieldType` to a STRING today. Adding a second mapping to a VALUE, beside it, is
-the sizes-header mirror defect being written on purpose. The mapping must go
-VALUE-FIRST — build the `nros_serdes::FieldType`, then render the string from
-it — so there is one mapping with two outputs. That refactor is the bulk of the
-work and it lands in a heavily-tested emitter.
+* `packages/api/nros-c/Cargo.toml` deps are `nros`, `nros-node`, `nros-rmw`,
+  `nros-core`, `nros-platform`, `nros-log`, `nros-platform-cffi`, the optional
+  RMW backends, `paste`, `panic-halt`, `critical-section`. **No message crate.**
+* The Rust packages cmake builds for the pure-C workspace are exactly three:
+  `packages/rmw/cffi`, `packages/api/nros-c`, `packages/api/nros-cpp`. There is
+  no `nros_ws_runtime` umbrella — that crate is generated only for a workspace
+  that has Rust nodes (`examples/workspaces/mixed` has one; `c` does not).
+* No generated Rust message crate exists anywhere under
+  `examples/workspaces/c`.
+
+So the number must be EMITTED at generation time. Layers 1-2 stand.
+
+## The emit point is a template line, not a new emitter
+
+C message headers are rendered from a minijinja pack —
+`packages/cli/rosidl-codegen/packs/c/message.h.jinja`, registered in
+`render.rs:93`, context built as `MessageCHeaderTemplate` at
+`generator/msg.rs:406`. The header already emits `#define {constant_prefix}_…`
+rows for message constants (`message.h.jinja:29`), so a
+`#define {constant_prefix}_MAX_SERIALIZED_SIZE_XCDR2 <n>` is one template line
+plus one context field. C++ has the sibling pack.
+
+That is cheap. The cost stays where this issue already put it: computing `<n>`
+through `nros_serdes::size::max_serialized_size` rather than a second walk, and
+the value-first mapping refactor that makes that possible.
+
+## The publisher side has the same defect, and the same number fixes it
+
+Every generated typed publish helper stacks a buffer of a GLOBAL guessed size
+(`message.h.jinja:116-121`):
+
+```c
+#ifndef NROS_PUB_BUFFER_SIZE
+#define NROS_PUB_BUFFER_SIZE 256
+#endif
+static inline nros_ret_t std_msgs_msg_int32_publish(...) {
+    uint8_t buf[NROS_PUB_BUFFER_SIZE];
+```
+
+One `#define` for every message type in the image, default 256, checked against
+nothing. A type larger than it fails to serialize and the helper returns
+non-zero, which the call sites in `examples/workspaces/c` do not distinguish
+from a transport failure. Per-type `MAX_SERIALIZED_SIZE_*` replaces the guess
+with the exact number and costs less stack on every type under 256 bytes.
+
+## The C subscription is type-erased BY DESIGN, so layer 5 is the delivery
+
+Not an accident of the ABI. RFC-0043 typed components subscribe RAW, carrying
+the ROS type name as a string — `examples/workspaces/c/src/listener_pkg/
+CMakeLists.txt` says so in as many words ("raw `/chatter` subscription carries
+the type name as a string, so no generated C bindings are needed"), and
+`nros-c/src/subscription.rs:487` builds the `TopicInfo` from those bytes.
+
+Consequence: nothing in the C path can infer which `#define` belongs to a given
+subscription, because the type is only ever a string there. **The hint has to be
+supplied at the call site.** That makes layer 5 the actual delivery mechanism,
+not ergonomic polish on top of a working feature — and it is the layer to design
+first, because it decides what layers 3-4 must carry.
+
+Also unnamed until now: the same call site allocates
+`RawSubscription::<{ config::MESSAGE_BUFFER_SIZE }>`, a const generic off global
+config. That is a SECOND per-subscription buffer on the C path, charged
+identically to every subscription in the image, and it is not addressed by
+`rx_buffer_hint` at all.
+
+## Bounds in the `.msg` already work — this is a diagnostics job
+
+`sequence<T,N>`, `string<=N`, `wstring<=N` and the combined forms already parse
+and map to `nros_serdes::FieldType::{BoundedSequence, BoundedString,
+BoundedWString}` (`generator/common.rs:1371-1425`), straight into the schema
+`size_bound` walks, and `SizeBound.bounded` goes false only on a genuinely
+unbounded member. So "bound the field in the `.msg`" is the first thing to tell
+a user and it needs no code.
+
+What it needs is a diagnostic: when the bound comes back `None`, name the
+offending FIELD, not just the type. Today the caller gets `None` and no way to
+learn which member cost them the bound. Cheapest useful change in this issue.
+
+## An out-of-band bound is a different guarantee — do not conflate them
+
+A bound stated somewhere other than the `.msg` (nano-ros config, or a launch /
+contract declaration) is NOT the same object as an IDL bound, and the two must
+not share a spelling:
+
+* **Bounded in the `.msg`.** The publisher honours it too; an over-long message
+  cannot be constructed. A real bound.
+* **Bounded only out-of-band.** The publisher knows nothing about it. An
+  oversize sample arrives and is dropped. That is a TRUNCATION CONTRACT, and it
+  has to be loud at runtime — same class as `report_dropped_take`.
+
+Where both exist they must not silently disagree: clamp to the smaller, or
+refuse. A whole-type "max size" convenience knob is fine, but it must be an
+`rx_buffer_hint` OVERRIDE, never a claimed schema bound — the one-computation
+rule is the point of this issue.
+
+## Discovering subscribers from the model is AUTHORING, not discovery
+
+The spec models exactly what a per-subscription sizing pass would want
+(`ros-launch-manifest/model/src/lib.rs:646`):
+
+```rust
+pub struct TopicWiring {
+    pub msg_type: String,        // required, not Option
+    pub publishers: Vec<String>,
+    pub subscribers: Vec<String>,
+}
+```
+
+and `Structure.topics` holds them (`lib.rs:166`). `msg_type` being non-optional
+is a real advantage: a wiring row cannot exist without its type.
+
+But **0 of the 144 model files in this tree carry any topic wiring.** The field
+is `skip_serializing_if = "BTreeMap::is_empty"`, so an absent `topics:` key
+means an empty map, not an omission — the count is exact. `structure` is
+`scopes` + `nodes` and nothing else, Autoware-derived models included. The
+`contracts` layer holds `node_paths.input`/`output` (topic NAMES) and
+`PubContract { min_rate_hz, .. }` — no `msg_type` — and no contracts are
+authored anywhere in the tree either.
+
+The reason is structural, not an oversight: **a launch file does not declare
+topics or their types.** It declares nodes, remaps and parameters. Which topic a
+node subscribes to, and with what type, lives in the node's code. The resolver
+cannot invent it.
+
+This is the same trap phase-392 W5.b2 hit for service servers — the spec models
+`ServiceWiring.server`, and the verb built on it returned 0 for all 115 models
+including `service_server_model.yaml`. Recorded here so the third instance is
+recognised before code is written.
+
+So the model route works, but only once someone AUTHORS the wiring. Warning on
+absent wiring is therefore the primary UX for as long as that stays true, not an
+edge case.
 
 ## Layers, in order
 
+0. **Name the field that cost the bound.** When `max_serialized_size` returns
+   `None`, report which member is unbounded. No new surface; makes the existing
+   `.msg` fix actionable.
 1. **Value-first field mapping in `rosidl-codegen`**, rendering the existing
-   string from the value. No behaviour change; the existing emitter tests are
-   the check.
+   Rust schema string from the value. No behaviour change; the existing emitter
+   tests are the check.
 2. **The bound, computed by `max_serialized_size` over those values**, nested
-   types resolved by the same closure the RIHS path already uses. Emitted into
-   the generated C/C++ message header. A test must assert it equals the Rust
-   `MAX_SERIALIZED_SIZE_XCDR*` const for the same type — same input, same
-   function, so a disagreement means the value mapping is wrong.
-3. **`nros_subscription_options_t` grows an `rx_buffer_hint`.** Note this is an
-   ABI CHANGE: the struct documents itself as extensible through
-   `_reserved[2]`, and a `uint32_t` does not fit in two bytes. `generated.rs`
-   must be regenerated (`scripts/gen-abi-bindings.sh`) and `check-abi-bindings`
-   gates it.
-4. **`nros-c` forwards it** into `rmw_subscription_options_t`, and **`nros-cpp`**
-   through `options.hpp`.
-5. **A user-facing spelling**, the C analogue of W3b's `nros::rx_buffer_for!`:
-   the caller names the type once and gets a number that cannot drift.
+   types resolved by the same closure the RIHS path already uses. Emitted as a
+   `#define` from `packs/c/message.h.jinja` (and the C++ sibling). A test must
+   assert it equals the Rust `MAX_SERIALIZED_SIZE_XCDR*` const for the same
+   type — same input, same function, so a disagreement means the value mapping
+   is wrong. Retarget `NROS_PUB_BUFFER_SIZE` onto it in the same change.
+3. **Design the call-site spelling** — the C analogue of W3b's
+   `nros::rx_buffer_for!`. Do this BEFORE 4-5: the C subscription is raw by
+   design, so this is how the number reaches the runtime at all, and it decides
+   what the ABI must carry.
+4. **`nros_subscription_options_t` grows an `rx_buffer_hint`.** ABI CHANGE: the
+   struct extends through `_reserved[2]`, and a `uint32_t` does not fit in two
+   bytes. `generated.rs` must be regenerated (`scripts/gen-abi-bindings.sh`);
+   `check-abi-bindings` gates it.
+5. **`nros-c` forwards it** into the `TopicInfo` it already builds
+   (`subscription.rs:487`, one line), and **`nros-cpp`** through `options.hpp`.
 
-Steps 3-5 are the ones that decide whether this is ergonomic or merely possible,
-and they are worth designing before writing.
+Out-of-band bounds (config / model) are a SEPARATE track that reuses layer 3's
+spelling. They are not needed for any type whose `.msg` already bounds it.
 
 ## Not to be confused with
 

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -243,15 +243,88 @@ edge case.
    `nros::rx_buffer_for!`. Do this BEFORE 4-5: the C subscription is raw by
    design, so this is how the number reaches the runtime at all, and it decides
    what the ABI must carry.
-4. **`nros_subscription_options_t` grows an `rx_buffer_hint`.** ABI CHANGE: the
-   struct extends through `_reserved[2]`, and a `uint32_t` does not fit in two
-   bytes. `generated.rs` must be regenerated (`scripts/gen-abi-bindings.sh`);
-   `check-abi-bindings` gates it.
+4. **Carry it on BOTH C-facing subscription paths** (see below) — they are
+   independent, and the examples use the one the issue did not name.
 5. **`nros-c` forwards it** into the `TopicInfo` it already builds
-   (`subscription.rs:487`, one line), and **`nros-cpp`** through `options.hpp`.
+   (`subscription.rs:487`, one line), and the component path likewise.
 
 Out-of-band bounds (config / model) are a SEPARATE track that reuses layer 3's
 spelling. They are not needed for any type whose `.msg` already bounds it.
+
+## Correction: this is cbindgen, not bindgen
+
+Earlier text here said `nros_subscription_options_t` needs
+`scripts/gen-abi-bindings.sh` and is gated by `check-abi-bindings`. Wrong
+direction. That pair covers HAND-WRITTEN RMW/platform C headers consumed by
+bindgen into `nros-{rmw,platform}-cffi/src/generated.rs`.
+`nros_subscription_options_t` is a Rust `#[repr(C)]` struct
+(`nros-c/src/subscription.rs:145`) emitted OUT to the committed
+`packages/api/nros-c/include/nros/nros_generated.h` by cbindgen. Regenerate
+with `just regen-c-headers` — THE single writer (issue 0452) — and
+`check-cbindgen-headers` gates staleness.
+
+The layout note stands: `sched_context` + `message_info: u8` + `_reserved: [u8; 2]`,
+so a `uint32_t` does not fit in the reserved bytes and the struct grows.
+
+## There are TWO C-facing subscription paths, and the examples use the other one
+
+* **`nros-c`** — `nros_subscription_init_with_options` takes
+  `nros_subscription_options_t` and calls `session.create_subscription`
+  directly (`subscription.rs:501`). This is the path the issue described.
+* **`nros-cpp`** — `nros_cpp_subscription_register` (`nros-cpp/src/
+  subscription.rs:144`), which is what RFC-0043 typed components call, and what
+  every `examples/workspaces/c` node uses. **Ten flat arguments and no options
+  struct**, plus a `_register_with_info` twin that duplicates the whole list.
+
+The second is the one that must carry the hint for the examples to benefit, and
+its argument list cannot grow. That is precisely the problem issue 0808 solved
+for `create_session`, and its resolution is already written down in
+`rmw_entity.h`: take a NULLable trailing options struct, because
+`rmw_publisher_options_t` / `rmw_subscription_options_t` had already solved it
+for entities. Same answer here, with `rx_buffer_hint` as the first occupant and
+`sched_context` / `callback_group` / the `_with_info` split as the cleanup that
+comes free.
+
+## Layer 3 is smaller than feared: the call site already names the type
+
+The C subscription is type-erased at the ABI, but the CALL SITE is not:
+
+```c
+nros_cpp_subscription_register(node, "/chatter",
+                               std_msgs_msg_int32_get_type_name(), "", ...);
+```
+
+The token `std_msgs_msg_int32` is right there. So the hint needs no new macro
+vocabulary — a sibling accessor in the family the header already emits
+(`_get_type_name`, `_get_type_hash`, `_get_type_support`) reads identically and
+cannot drift from the type name, because both come from one token:
+
+```c
+static inline uint32_t std_msgs_msg_int32_get_rx_buffer_hint(void);
+```
+
+The `#define` from layer 2 is what it returns. A macro form that expands to BOTH
+arguments at once remains an option, but it is no longer load-bearing.
+
+## Still undecided
+
+1. **Unbounded types.** A type with no bound gets no constant. Does the
+   accessor then not exist (a compile error at the call site, forcing an
+   explicit decision) or return 0 (falls back to the global knob, matching the
+   Rust path's `RX_BUF` default)? Same question decides the publisher helper.
+2. **XCDR1 vs XCDR2.** Two different bounds for the same type. The Rust path
+   takes the max (`subscription_rx_hint`, `rmw_type_registry.rs:168`). Emit both
+   constants and take the max at the accessor, or emit one already-maxed
+   constant? The layer-2 parity test's shape depends on the answer.
+3. **Where an out-of-band bound is authored and keyed** (`system.toml`? a leaf
+   config?), and whether it may only lower a bound or also assert one for an
+   unbounded type.
+4. **How a truncation drop is reported** distinctly from a transport failure.
+   Today the generated C publish helper returns non-zero for both.
+5. **`RawSubscription::<{ config::MESSAGE_BUFFER_SIZE }>`** — a const generic
+   cannot take a runtime hint, so per-subscription sizing there needs a
+   different mechanism entirely (size-classed arena, or a per-type monomorphised
+   path). Unscoped, and possibly larger than everything above.
 
 ## Not to be confused with
 

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -64,22 +64,64 @@ is precisely the class this campaign keeps finding (the sizes-header mirror,
 0088 -> 0114 -> 0122 -> 0123 -> 0245 -> 0268), and a serialised-size rule is
 exactly the kind that looks right until an encoding rule changes under one copy.
 
-Options, none surveyed in depth yet:
+## Surveyed 2026-08-29 — two things this issue got wrong when filed
 
-1. **Codegen emits the number into the generated C/C++ header**, computed by
-   calling `nros_serdes::size::max_serialized_size` — the same function, from
-   the CLI, which already compiles `packages/core/nros-serdes` (it is in
-   `cli-source-dirs.txt`). Today `rosidl-codegen` renders `FIELDS` as a
-   pre-rendered STRING of Rust source rather than constructing `Field` values,
-   so this needs codegen to build the real values first. That refactor is the
-   bulk of the work and it is the option that keeps ONE implementation.
-2. **The `*_OPAQUE_U64S` channel** (`nros_config_generated.h`) is the
-   established Rust-computes / C-declares seam, but it carries sizes of *our*
-   types. Message types are per-workspace and user-defined, and a C-only image
-   has no Rust message crate to compute from — so this does not obviously
-   extend.
-3. **Have the C API ask at runtime.** Rejected on sight: the point is to size a
-   static block before it is allocated.
+**"Rejected on sight: the point is to size a static block before it is
+allocated."** Wrong reason. `alloc_payload_block(hint)` runs at
+SUBSCRIPTION-CREATION time and only CHOOSES between two already-static pools, so
+a runtime hint is fine in principle. The real reason a runtime answer is
+unavailable is different: the RMW C ABI passes `type_name` and `type_hash` as
+STRINGS (`rmw_vtable.h:170`) and no schema descriptor, so the C side has nothing
+to compute a bound from at runtime either.
+
+**"Codegen renders `FIELDS` as a string, so it does not have the nested
+fields."** Half wrong. It renders the string, but it ALSO already resolves the
+nested types transitively, in-process, for the RIHS type hash:
+`rosidl_resolve::rihs::build_type_description(type_name, msg, resolve)` does a
+BFS over nested refs and errors rather than guessing when one will not resolve.
+Every generated message goes through it. So the full recursive schema IS
+available at generation time.
+
+That makes option 1 viable, and it is the one to take.
+
+## The shape of the fix
+
+`nros_serdes::size::size_bound` never reads `Field::offset` (checked: zero
+references). The offsets are the only part of a `Field` that codegen cannot
+know, so codegen can construct real `Field` values with `offset: 0` and call
+`max_serialized_size` — THE function, not a copy of its rule. `&'static`
+recursion (`FieldType::Nested(&NestedType)`, `Array(_, &FieldType)`) is
+satisfiable by leaking in a short-lived CLI process.
+
+The one hazard is the mapping. `render_field_type_expr` maps a rosidl
+`FieldType` to a STRING today. Adding a second mapping to a VALUE, beside it, is
+the sizes-header mirror defect being written on purpose. The mapping must go
+VALUE-FIRST — build the `nros_serdes::FieldType`, then render the string from
+it — so there is one mapping with two outputs. That refactor is the bulk of the
+work and it lands in a heavily-tested emitter.
+
+## Layers, in order
+
+1. **Value-first field mapping in `rosidl-codegen`**, rendering the existing
+   string from the value. No behaviour change; the existing emitter tests are
+   the check.
+2. **The bound, computed by `max_serialized_size` over those values**, nested
+   types resolved by the same closure the RIHS path already uses. Emitted into
+   the generated C/C++ message header. A test must assert it equals the Rust
+   `MAX_SERIALIZED_SIZE_XCDR*` const for the same type — same input, same
+   function, so a disagreement means the value mapping is wrong.
+3. **`nros_subscription_options_t` grows an `rx_buffer_hint`.** Note this is an
+   ABI CHANGE: the struct documents itself as extensible through
+   `_reserved[2]`, and a `uint32_t` does not fit in two bytes. `generated.rs`
+   must be regenerated (`scripts/gen-abi-bindings.sh`) and `check-abi-bindings`
+   gates it.
+4. **`nros-c` forwards it** into `rmw_subscription_options_t`, and **`nros-cpp`**
+   through `options.hpp`.
+5. **A user-facing spelling**, the C analogue of W3b's `nros::rx_buffer_for!`:
+   the caller names the type once and gets a number that cannot drift.
+
+Steps 3-5 are the ones that decide whether this is ergonomic or merely possible,
+and they are worth designing before writing.
 
 ## Not to be confused with
 

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -388,13 +388,40 @@ queue — so the generated publish helper returns a bare non-zero that callers
 cannot tell from a transport failure. Add one (cbindgen: `just regen-c-headers`),
 and report it once per site rather than per sample.
 
-## Still undecided
+## RawSubscription: decided 2026-08-29
 
-Only one remains: **`RawSubscription::<{ config::MESSAGE_BUFFER_SIZE }>`**
-(`nros-c/src/subscription.rs:503`). A const generic cannot take a runtime hint,
-so per-subscription sizing there needs a different mechanism entirely — a
-size-classed arena, or a per-type monomorphised path. Unscoped, and possibly
-larger than everything above.
+`RawSubscription<const RX_BUF: usize>` (`executor/handles.rs:1306`) holds its
+receive buffer INLINE, so `RX_BUF` is a monomorphisation, not a parameter — a
+runtime hint cannot select between `RawSubscription<1024>` and
+`RawSubscription<4096>`. Worse, the size is baked into the APPLICATION's own
+struct: `SUBSCRIPTION_OPAQUE_U64S` is
+`u64s_for::<RawSubscription<{ MESSAGE_BUFFER_SIZE }>>()`
+(`opaque_sizes.rs:29`), and a C caller declares
+`uint8_t sub[NROS_C_SUBSCRIPTION_STORAGE_SIZE]` at their own compile time.
+
+Three options were weighed:
+
+* **Size classes plus a compile-time storage macro** — a small ladder of
+  instantiations, dispatched at init against the caller's declared size.
+  REJECTED: pays code size for N monomorphisations of the whole subscription
+  path, gives a coarser answer than the exact bound, and leaves the arena
+  coupling untouched.
+* **Decouple the buffer (`&'a mut [u8]`)** — one type, no monomorphisation,
+  exact per-subscription bytes, `_opaque` shrinks. This is the real per-type
+  fix and matches the hint model directly. DEFERRED, not rejected: it adds a
+  lifetime contract across FFI, and C has TWO subscription paths (the L1
+  polling one here and the arena callback path at `nros-c/src/executor.rs:817`),
+  so both must move together or half the tree keeps the old sizing.
+* **Fix the arena instead** — TAKEN FIRST, and split out as **issue 0900**.
+  It turned out not to be part of this issue at all: every arena slot is
+  budgeted at the ActionClient worst case, so `ARENA_SIZE` is 74,240 bytes on
+  every image measured, a talker included, where a pub/sub-only image needs
+  ~16 KiB. It also explains why per-type receive sizing cannot help that
+  number: the slot is sized from the GLOBAL knob, amplified 3 x MAX_CBS = 12x,
+  regardless of what any individual subscription asks for.
+
+Order: **0900 first** (largest saving, no ABI change, independent of everything
+here), then the buffer decoupling as the per-type fix.
 
 ## Not to be confused with
 

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -1,0 +1,120 @@
+---
+id: 900
+title: "Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use"
+status: open
+area: core, memory
+severity: medium
+found: 2026-08-29
+related: [0896, 0271, 0739, phase-392]
+---
+
+# The arena is sized for the entity an image does not have
+
+## What was measured
+
+`ARENA_SIZE` is **74,240 bytes on every generated config in the tree**, without
+variation:
+
+| image | `MAX_CBS` | `DEFAULT_RX_BUF_SIZE` | `ARENA_SIZE` |
+| --- | ---: | ---: | ---: |
+| `threadx-linux/rust/talker` | 4 | 1024 | 74,240 |
+| `workspaces/c` (xrce) | 4 | 1024 | 74,240 |
+| `workspaces/realtime-c` (nuttx riscv32imac) | 4 | 1024 | 74,240 |
+| `workspaces/realtime-cpp` (nuttx riscv32imac) | 4 | 1024 | 74,240 |
+
+The first row is a TALKER. It publishes on a timer and owns no action client,
+no action server, and no service. It carries the same arena as everything else,
+on a 32-bit embedded target as on a host.
+
+## Why
+
+`nros-node/build.rs:90-135` derives the arena by budgeting EVERY slot at the
+largest entity that could occupy one:
+
+```rust
+const ACTION_CLIENT_PER_SERVICE:   usize = 4096 + 384;
+const ACTION_CLIENT_SERVICES:      usize = 3;
+const ACTION_CLIENT_FEEDBACK_SUBS: usize = 3;
+const ACTION_CLIENT_SUB_OVERHEAD:  usize = 1536;
+const ARENA_BASE_OVERHEAD:         usize = 2048;
+
+let per_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
+              + ACTION_CLIENT_FEEDBACK_SUBS * rx_buf_size
+              + ACTION_CLIENT_SUB_OVERHEAD;
+let derived_arena = (max_cbs * per_entry + ARENA_BASE_OVERHEAD).max(ARENA_FLOOR);
+```
+
+At the defaults: `per_entry` = 14,976 + 3·1024 = 18,048, and
+`4 × 18,048 + 2,048` = **74,240**. The build script says so itself:
+
+> Subscription / service entries are strictly smaller, so budget every slot at
+> the action-client size.
+>
+> Embedded targets that never instantiate an `ActionClient` can override the
+> derived size with `NROS_EXECUTOR_ARENA_SIZE`. A pub/sub-only workload only
+> needs `3 × rx_buf + 512` per entry.
+
+Taking that note at its word, a pub/sub-only image needs
+`4 × (3·1024 + 512) + 2,048` = **16,384** bytes. The difference is
+**57,856 B (~56.5 KiB)** carried by every image with no action client — which
+is most of them.
+
+## Two things make this worse than a loose default
+
+**The rx buffer is amplified 12x.** `rx_buf_size` enters `per_entry` THREE
+times (goal/result/feedback), and `per_entry` is multiplied by `MAX_CBS`. So
+`NROS_SUBSCRIPTION_BUFFER_SIZE` is charged `3 × MAX_CBS` = 12x into the arena at
+the defaults, on top of its per-subscription cost. Anyone raising that knob to
+fit one large message type pays for it twelve times over here. That coupling is
+also why issue 0896's per-type receive sizing cannot help this number: the arena
+slot is sized from the GLOBAL knob regardless of what any individual
+subscription needs.
+
+**The escape hatch is a knob nobody can find.** `NROS_EXECUTOR_ARENA_SIZE`
+exists, is honoured, and has a Kconfig sentinel — but nothing computes a right
+value for an image, nothing warns when the derived one is 4x what the image
+uses, and the correct replacement (`3 × rx_buf + 512` per entry) appears only in
+a build-script comment. That is the shape of issues 0271 / 0739: "a knob nobody
+can enumerate is a knob nobody sets", which cost ~145 KB in one image.
+
+## Where the bytes actually land — NOT yet attributed
+
+The arena is carved from `ExecutorStorage`'s backing
+(`executor/storage.rs:38`), and how that backing is provided differs by path:
+
+* the C API places it in the caller's `nros_executor_t._opaque`
+  (`EXECUTOR_OPAQUE_U64S`), so a file-scope executor lands it in `.bss`;
+* the ThreadX board takes it from the byte pool — `nm` on
+  `threadx-linux/rust/talker` shows no arena symbol at all, only
+  `byte_pool_storage` at 4 MiB, so the cost is pool consumption rather than a
+  named static.
+
+So the 74,240 figure is EXACT as a configured size and verified across four
+builds, but its RAM attribution is per-platform and unmeasured. **Run
+`just mem-report --json --baseline` before and after any fix rather than
+quoting the derivation** — phase-392's own rule, and the reason issues 0148 /
+0164 were filed from numbers that did not survive a clean rebuild.
+
+## Direction
+
+Size a slot by the entity kind that will occupy it instead of by the worst kind
+that could. Registration already knows the kind, and `system.toml` / the
+`SystemModel` know the entity inventory ahead of the build for images that
+declare one. Two obvious shapes, not yet chosen:
+
+1. **Per-kind slot budgets** — the arena becomes a sum over declared entities
+   rather than `MAX_CBS x worst_case`. Needs the inventory at build time.
+2. **A derived cap plus a diagnostic** — keep the worst-case derivation, but
+   report at boot (or fail the build) when the configured arena exceeds what the
+   registered entities can use, so the existing `NROS_EXECUTOR_ARENA_SIZE`
+   override becomes actionable rather than folklore.
+
+(2) is strictly cheaper and does not need the model; (1) is the actual fix.
+
+## Not to be confused with
+
+Issue 0896, which is about a SUBSCRIPTION's receive buffer taking the small size
+class because nothing states a per-type bound. This is one level up: even with a
+perfect per-type hint, the arena slot holding that subscription is still
+budgeted as though it were an action client. The two share the
+`NROS_SUBSCRIPTION_BUFFER_SIZE` knob and nothing else.

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -189,6 +189,53 @@ test for the same reason (a separate test would observe an already-consumed
 flag and assert nothing, the vacuous shape `check-no-vacuous-tests` exists to
 catch).
 
+## Landed: the derivation is per-kind (W2)
+
+`NROS_EXECUTOR_ACTION_CLIENTS` — how many of the `MAX_CBS` slots the arena
+budgets at ActionClient size rather than pub/sub size:
+
+```rust
+let derived_arena = (action_clients * action_client_entry
+    + max_cbs.saturating_sub(action_clients) * pubsub_entry
+    + ARENA_BASE_OVERHEAD).max(ARENA_FLOOR);
+```
+
+Measured, by building both ways:
+
+| `NROS_EXECUTOR_ACTION_CLIENTS` | `ARENA_SIZE` |
+| --- | ---: |
+| unset (defaults to `MAX_CBS` = 4) | 74,240 |
+| `0` | **16,384** |
+
+**The default is byte-identical to the old formula**, so no existing image
+moves — gated by `the_default_derivation_is_unchanged`, which recomputes the
+historical arithmetic and compares. That is the point of the wave: the knob
+exists so an image CAN shrink its arena, not so every image silently does, and
+a change that moves the default moves every image's task-stack frame.
+
+A COUNT rather than a "which entity is heaviest" enum, because Kconfig knobs
+are ints and `knob_usize` is the one spelling that reaches the Zephyr Rust lane
+(issue 0460). An enum would need a second reader shape for no gain. Forwarded
+in `nros_cargo_build.cmake` and declared in `zephyr/Kconfig`, so it reaches the
+Zephyr Rust lane rather than being silently defaulted; `check-kconfig-knob-
+forwarding` covers it, and `check-pool-inventory` caught the new knob and
+required it be enumerated — which is the gate for exactly the 0271/0739 failure
+this issue keeps citing.
+
+Lowering it too far fails at REGISTRATION, not at link, so `arena_alloc`'s
+`BufferTooSmall` path now names both knobs and the numbers involved
+(`report_arena_exhausted`, one-shot, `nros_log`, inside the 256-byte budget).
+`BufferTooSmall` is returned by a dozen other paths, so without this, arena
+exhaustion is indistinguishable from a message that did not fit a receive
+buffer on a target where a return code is all you get.
+
+Together with W1 the loop closes: build once at the defaults, read the
+first-spin advisory, set the knob, and be told plainly if it was set too low.
+
+**Not yet done:** nothing sets it automatically. Deriving `action_clients` from
+a declared entity inventory is still the real fix, and still blocked on the
+inventory existing — see below.
+
 ## Direction for the rest
 
 ## Not to be confused with

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -77,23 +77,53 @@ uses, and the correct replacement (`3 × rx_buf + 512` per entry) appears only i
 a build-script comment. That is the shape of issues 0271 / 0739: "a knob nobody
 can enumerate is a knob nobody sets", which cost ~145 KB in one image.
 
-## Where the bytes actually land — NOT yet attributed
+## Where the bytes land: THE STACK, not `.bss` (measured)
 
-The arena is carved from `ExecutorStorage`'s backing
-(`executor/storage.rs:38`), and how that backing is provided differs by path:
+The first draft of this issue guessed `.bss` via the C API's
+`nros_executor_t._opaque`. `just mem-report` on
+`examples/workspaces/c/build/posix-zenoh-native/cmake/native_entry` refutes it —
+there is **no arena symbol in the image at all**. Its RAM is the zenoh pools
+(`SERVICE_BUFFERS` 144,128 / `LARGE_PAYLOADS` 131,072 / `SMALL_PAYLOADS` 32,768)
+and nothing resembling 74,240 appears.
 
-* the C API places it in the caller's `nros_executor_t._opaque`
-  (`EXECUTOR_OPAQUE_U64S`), so a file-scope executor lands it in `.bss`;
-* the ThreadX board takes it from the byte pool — `nm` on
-  `threadx-linux/rust/talker` shows no arena symbol at all, only
-  `byte_pool_storage` at 4 MiB, so the cost is pool consumption rather than a
-  named static.
+(That run also printed a STALE-IMAGE banner, so its byte counts describe an
+older tree and are quoted here only as shape. The ABSENCE of an arena symbol is
+structural, not a staleness artifact.)
 
-So the 74,240 figure is EXACT as a configured size and verified across four
-builds, but its RAM attribution is per-platform and unmeasured. **Run
-`just mem-report --json --baseline` before and after any fix rather than
-quoting the derivation** — phase-392's own rule, and the reason issues 0148 /
-0164 were filed from numbers that did not survive a clean rebuild.
+The reason is written down one lane over, in
+`docs/reference/platform-implementation-notes.md:143`:
+
+> Stack overflow -> "Invalid mbox": `Executor` has an inline
+> `arena: [MaybeUninit<u8>; ARENA_SIZE]` **on the task stack**. Action examples
+> use `NROS_EXECUTOR_ARENA_SIZE=8192`; `APP_TASK_STACK` must be 16384 words
+> (64 KB) for headroom.
+
+The board path — which is what every example uses — builds the executor through
+`Executor::open_sized` (`nros-board-linux/src/lib.rs:325`) with the arena inline
+in the value, so it lives wherever that value lives: a task stack. The C API's
+`_opaque` route is the L1 polling path, a different and less-travelled one.
+
+This makes the defect worse than a static-RAM overshoot in two ways:
+
+* **Stack is the scarcest resource on an RTOS target**, and a 74,240-byte frame
+  is not something a per-task stack absorbs quietly. It is charged to whichever
+  task calls spin, and it interacts with issue 0667's finding that a task's
+  `stack_bytes` is a floor the port raises rather than a number the caller
+  controls.
+* **The workaround is already load-bearing in the tree.** FreeRTOS action
+  examples pin `NROS_EXECUTOR_ARENA_SIZE=8192` — a 9x reduction from the
+  derived value — and STILL need a 64 KB app task stack. That override is
+  evidence the derivation does not describe real images: someone already had to
+  discover the right number by hitting "Invalid mbox" and working backwards.
+
+So the saving is not (only) ~56 KiB of static RAM; it is stack headroom on every
+image that spins, and the difference between an image that boots and one that
+dies in an allocator with an unrelated-looking error.
+
+**Still measure rather than derive.** `mem-report` reads `.bss`/`.data` and
+therefore cannot see this at all — sizing the change needs a stack-usage probe
+(worst-case frame at the spin call, or a high-water mark on a running RTOS
+image), not a symbol table.
 
 ## Direction
 

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -125,21 +125,47 @@ therefore cannot see this at all — sizing the change needs a stack-usage probe
 (worst-case frame at the spin call, or a high-water mark on a running RTOS
 image), not a symbol table.
 
-## Direction
+## Measured on a live executor: 32 bytes of 74,240
 
-Size a slot by the entity kind that will occupy it instead of by the worst kind
-that could. Registration already knows the kind, and `system.toml` / the
-`SystemModel` know the entity inventory ahead of the build for images that
-declare one. Two obvious shapes, not yet chosen:
+The derivation's error is not the ~4.5x this issue first estimated from the
+pub/sub-only formula. Opening a real `Executor` and registering one timer
+(`nros-tests/tests/component_dispatch.rs::executor_arena_is_over_provisioned_for_a_timer_only_image`)
+claims **32 bytes of 74,240** — a factor of **2,320**. The arena is a BUMP
+allocator (`Executor::arena_alloc` charges `size_of::<T>()` and reserves
+nothing per slot), so that number is exact, not a lower bound.
 
-1. **Per-kind slot budgets** — the arena becomes a sum over declared entities
-   rather than `MAX_CBS x worst_case`. Needs the inventory at build time.
-2. **A derived cap plus a diagnostic** — keep the worst-case derivation, but
-   report at boot (or fail the build) when the configured arena exceeds what the
-   registered entities can use, so the existing `NROS_EXECUTOR_ARENA_SIZE`
-   override becomes actionable rather than folklore.
+That reframes the fix: the allocator has always known the right answer and had
+no way to say it.
 
-(2) is strictly cheaper and does not need the model; (1) is the actual fix.
+## Landed: the executor can now say what it uses (W1)
+
+* `Executor::arena_used()` / `Executor::arena_capacity()` — public accessors,
+  ledgered as extensions (upstream has no arena to ask about; rclcpp
+  heap-allocates each entity).
+* A one-shot advisory on the first `spin_once` when the arena is grossly
+  over-provisioned, naming the `NROS_EXECUTOR_ARENA_SIZE` value to set. Emitted
+  through `nros_log`, never stdio (issue 0589), from a process-scoped static
+  rather than an `Executor` field — the same reason `DROPPED_TAKES` is a static:
+  a field would move `EXECUTOR_OPAQUE_U64S` and every image's executor footprint
+  to buy a diagnostic. Process scope is also correct here rather than merely
+  cheap, since the value it names is a build-time constant identical for every
+  executor in the image.
+* The threshold is a separate `const fn arena_is_over_provisioned` so it is
+  testable — the reporter is one-shot, so a test calling it twice would silently
+  check nothing the second time. Four unit tests cover the boundary, a
+  well-sized arena staying quiet, overflow, and the issue-0460 zero-capacity
+  sentinel (a fault, NOT headroom — calling it over-provisioned would bury a
+  fatal misconfiguration under an advisory about wasted space).
+
+This does not shrink anything by itself. It converts the folklore into a number
+a user can read, which is the precondition for the rest.
+
+**Not yet verified:** that the advisory line actually reaches a console on a
+real image. It did not appear in the `component_dispatch` run, most likely
+because a bare `cargo test` installs no `nros_log` sink — unconfirmed, and worth
+one check before relying on it in the field.
+
+## Direction for the rest
 
 ## Not to be confused with
 

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -160,10 +160,34 @@ no way to say it.
 This does not shrink anything by itself. It converts the folklore into a number
 a user can read, which is the precondition for the rest.
 
-**Not yet verified:** that the advisory line actually reaches a console on a
-real image. It did not appear in the `component_dispatch` run, most likely
-because a bare `cargo test` installs no `nros_log` sink — unconfirmed, and worth
-one check before relying on it in the field.
+**Now verified, and it found a second defect.** The advisory does fire and does
+reach a sink — the earlier silence was `nros_log` holding records in its `early`
+ring because a bare `cargo test` installs no sink, then replaying them on
+`init`. Nothing was lost.
+
+But the first version of the line was ~450 bytes against `nros_log`'s 256-byte
+call-site format buffer (`buffer-size-256`, the default), which truncates with a
+`…`. The sink received:
+
+```
+executor arena is 74240 bytes and 32…
+```
+
+Every word of the explanation and NONE of the value to set — a diagnostic cut
+before its actionable half, which is worse than no diagnostic because it reads
+as though it helped. **An embedded log line has a hard budget, so a message that
+explains itself at length delivers exactly the folklore it was written to
+replace.** The line now leads with `NROS_EXECUTOR_ARENA_SIZE=<n>`, keeps the
+reasoning in a code comment and here, and the test asserts the message contains
+no `…` rather than only checking its wording.
+
+`tests/executor_arena_advisory.rs` is its own test binary: the flag is
+process-scoped, so any other spinning test in the same binary would consume it
+first, and tests run in parallel — sharing would make it pass or fail by
+scheduling. The one-shot contract is asserted by spinning twice in that same
+test for the same reason (a separate test would observe an already-consumed
+flag and assert nothing, the vacuous shape `check-no-vacuous-tests` exists to
+catch).
 
 ## Direction for the rest
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-47 open. One line each — the detail lives in the issue file,
+48 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -104,6 +104,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 - **#0895** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0895-*`.
+- **#0896** (rmw, api) — Every C/C++ subscription takes the small size class regardless of its message type — nothing fills `rx_buffer_hint` See `0896-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -102,8 +102,8 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
-- **#0880** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0880-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
+- **#0895** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0895-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-49 open. One line each — the detail lives in the issue file,
+47 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -82,7 +82,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0829** (api, rmw) — Two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on depth — 1 in `nros-rmw`, 10 in the `nros::qos` façade, each with two callers See `0829-*`.
 - **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
 - **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
-- **#0832** (platform, rmw) — `nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and xrce native images — the vendor allocators bypass the funnel See `0832-*`.
 - **#0834** (cmake) — The per-build `nros_cpp_config_generated.h` mirror can reach a state no re-run repairs — only wiping the west build dir recovers it See `0834-*`.
 - **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
 - **#0836** (rmw) — A FreeRTOS/lwIP image receives every small ROS topic and never a fragmented one — a 13 KiB Autoware trajectory never arrives See `0836-*`.
@@ -105,7 +104,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
 - **#0880** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0880-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
-- **#0881** (ci) — Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into See `0881-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-46 open. One line each — the detail lives in the issue file,
+47 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -99,6 +99,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
 - **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
+- **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-48 open. One line each — the detail lives in the issue file,
+49 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -105,6 +105,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 - **#0895** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0895-*`.
 - **#0896** (rmw, api) — Every C/C++ subscription takes the small size class regardless of its message type — nothing fills `rx_buffer_hint` See `0896-*`.
+- **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -51,23 +51,60 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 ## Open issues
 
-<!-- issue 0884 — the open-issue list lives in `open.md`, NOT here.
-     It is 100 % generated, so that file carries `merge=union` in
-     `.gitattributes` and concurrent filings merge without a conflict. This file
-     is authored prose and must NEVER be union-merged — that is the whole reason
-     the two are separate. -->
+<!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-**The open-issue list is [`open.md`](open.md)** — generated from the issue files
-by `scripts/gen-issue-index.py`, checked by `check-issue-index`.
+46 open. One line each — the detail lives in the issue file,
+which already has it. Regenerate with `scripts/gen-issue-index.py`;
+`check-issue-index` fails if this block drifts.
 
-Recently resolved (2026-08-29): **#0836** (platform) - `MEMP_NUM_TCPIP_MSG_INPKT` sat at the lwIP
-default of 8 while the an536 board raised everything around it, including `TCPIP_MBOX_SIZE=64` - and the
-mailbox holds pointers to structs from that pool, so the pool IS the driver->stack queue depth. A real
-ROS 2 peer's discovery burst needs 14; past 8, `tcpip_input()` returns ERR_MEM and frames are dropped
-before IP. They carry SEDP, and a reliable builtin reader that loses one waits for it forever - so every
-topic announced after the gap never matches. Filed as a payload-SIZE bug because the topic announced last
-happened to be the 13 KiB trajectory; with the pool at 64 a 17.6 KiB sample arrives as reliably as a
-116-byte one. Before: 7 of 12 runs; after: 34 of 34. See `archived/0836-*`.
+- **#0259** (orchestration) — Derived scheduling is quantitatively inert — no WCET in the model, so blocking is unmodelled and budget/placement/non_preempt can't be derived See `0259-*`.
+- **#0506** (embedded) — Transport tasks above application tiers is the right default but has no budget — inbound overload preempts every tier for ~200 ms bursts See `0506-*`.
+- **#0736** (core, platform, testing) — `realtime_tiers` nuttx-arm/rust: the fast tier now outruns the slow one but only ~2.4x against a 3x bar — was a 10x inversion, now a marginal shortfall See `0736-*`.
+- **#0741** (rmw, testing) — `test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the 28-byte reply into a 15-byte history payload See `0741-*`.
+- **#0758** (core, boards) — No platform wall-clock epoch source — embedded consumers hand-roll SNTP before boot, and stamped messages are wrong until they do See `0758-*`.
+- **#0760** (orchestration, rmw) — RFC-0074's `ingress` declaration is a ros-launch-manifest schema change, not a nano-ros one — park it until that discussion happens See `0760-*`.
+- **#0772** (platform, boards) — FreeRTOS/lwIP has no wall-clock epoch — the same consumer that drove the Zephyr one runs a FreeRTOS board too See `0772-*`.
+- **#0783** (api, docs) — `RclReturnCode` exists and is unreachable, and RFC-0036 documents a Rust error type the user API never returns See `0783-*`.
+- **#0784** (api) — `nros::` publishes three different audiences under one namespace — the component API a user writes, the machinery `nros::node!` expands into, and four types nothing consumes See `0784-*`.
+- **#0788** (api) — The same API verb is spelled differently in our C, C++ and Rust — and in two cases one language ships both spellings See `0788-*`.
+- **#0791** (api, rmw) — We are visible in the ROS graph and cannot read it — 12 rmw vtable graph slots exist, all `None`, while both backends already run the discovery machinery See `0791-*`.
+- **#0793** (api, params) — C ships two disjoint parameter stores — parameters declared on the node-local one are invisible to `ros2 param`, and its accept/reject callback fires for nobody See `0793-*`.
+- **#0794** (build, codegen, boot) — The baked boot config carries four fields and the C/C++ emitter sets one — a launch-declared namespace, domain or locator never reaches a C image See `0794-*`.
+- **#0798** (examples) — `examples/workspaces/c`'s root routes `s32z270-freertos` to an entry that hardcodes `mps2-an385-freertos` — the pairing fails all three arms of `_nra_board_active`, so the image links without its platform glue See `0798-*`.
+- **#0809** (build) — `provider_scan` honours `NROS_IGNORE` while `nros-pkg-index` honours `.nros-ignore` — the only spelling that exists on disk is the one the order-walk ignores See `0809-*`.
+- **#0810** (core) — The executor arena is sized at MAX_CBS x sizeof(ActionClient) whatever the entries actually are, so every real image ships a hand-picked override and undersizing fails at runtime instead of at link See `0810-*`.
+- **#0814** (rmw) — The whole zero-copy surface sits behind `feature = \"lending\"`, which only a posix test crate ever enables See `0814-*`.
+- **#0815** (tooling) — The static-pool inventory finds 46 sizing knobs and can price 3, so the largest pools in a real image carry no byte figure See `0815-*`.
+- **#0816** (tooling) — The book promises no-alloc integrations and nothing checks the linked image, so it is a claim rather than a property See `0816-*`.
+- **#0820** (cmake, testing) — `c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — the NuttX seam had no dependency edge on the Rust world, and hardcoded `--release` past a miscompile carve-out See `0820-*`.
+- **#0827** (rmw) — Static RAM is a property of the RMW, not of the node — a talker reserves 275 KB of service and large-payload pools it can never reach See `0827-*`.
+- **#0828** (testing) — Tier 2 RUNS rows its build lane never builds, so `just ci-matrix` is green only while an earlier `lane=all` build is still fresh See `0828-*`.
+- **#0829** (api, rmw) — Two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on depth — 1 in `nros-rmw`, 10 in the `nros::qos` façade, each with two callers See `0829-*`.
+- **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
+- **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
+- **#0832** (platform, rmw) — `nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and xrce native images — the vendor allocators bypass the funnel See `0832-*`.
+- **#0834** (cmake) — The per-build `nros_cpp_config_generated.h` mirror can reach a state no re-run repairs — only wiping the west build dir recovers it See `0834-*`.
+- **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
+- **#0836** (rmw) — A FreeRTOS/lwIP image receives every small ROS topic and never a fragmented one — a 13 KiB Autoware trajectory never arrives See `0836-*`.
+- **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
+- **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
+- **#0847** (rmw) — An XRCE publisher outliving `executor.close()` segfaults in its own Drop: the entity destructor dereferences the session state that close already freed See `0847-*`.
+- **#0849** (cli) — `nros sync` bakes the invocation's path SPELLING into every leaf patch table, so working through a symlink to the checkout makes cargo see two copies of every core crate and refuse the build on `links` See `0849-*`.
+- **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.
+- **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
+- **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
+- **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
+- **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
+- **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
+- **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
+- **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
+- **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
+- **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
+- **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
+- **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
+
+<!-- END GENERATED open-issue list -->
 
 Recently resolved (2026-08-29): **#0888** (rmw) — FreeRTOS was the only platform arm of the embedded
 Cyclone config with no `AllowMulticast`, so it inherited the Cyclone default (multicast for data) while
@@ -77,27 +114,6 @@ policy nobody wrote down, visible only as `writer_hbcontrol: ... multicasting` i
 states `spdp`, matching ThreadX. NOT a fix for 0836: with the peer already spdp-only, data was unicast
 regardless (97,976 sends to the island's unicast locator against 69 multicast, all discovery).
 See `archived/0888-*`.
-
-Recently resolved (2026-08-29): **#0894** (examples, build) — `just format` failed REPO-WIDE: phase-383
-W10.a (`8b15506b2`) deleted `examples/workspaces/launch`'s workspace root, so its two leaves walked up to the
-REPO root, which neither lists nor excludes them ("current package believes it's in a workspace when it's
-not"). Checked rather than assumed: of the 25 leaves under `examples/workspaces/*/src/` with no `[workspace]`
-table and no repo-root exclude, 23 still have a surviving parent root — `launch` is the anomaly, not the
-pattern, and only `listener_pkg` and `talker_pkg` are affected. Fixed by excluding both at the repo root,
-where every sibling standalone leaf already records the same fact. Same class CLAUDE.md names for west leaves,
-reached from the other direction: a root going away rather than a leaf arriving. See `archived/0894-*`.
-(2026-08-29)
-
-Recently resolved (2026-08-29): **#0890** (rmw) — the liveliness DISCOVERY wildcards still pinned `0/11` in
-the `<node_id>/<entity_id>` field, so `wait_for_service` and the LivelinessChanged emulation matched only a
-session's ELEVENTH entity. Issue 0292's residue: 0292 measured that literal on the DECLARATION side (an
-action server's five entities all collided at id 11 in rmw_zenoh's graph cache and deduped to one), fixed the
-four declaration builders and left the two wildcard builders on the constant — where the same literal stops
-being a collision and becomes a filter. The name hid it: `PROTO_VERSION_TOPIC` reads like a protocol version,
-so a wildcard carrying it looks right. Now `ENTITY_ANY = "*/*"`, both chunks wildcarded (not `0/*` — native
-`rmw_zenoh_cpp` peers' node id is not ours to assume). Regression tests assert the PROPERTY across several
-ids, 11 included deliberately since it is the one value the bug did match. See `archived/0890-*`.
-(2026-08-29)
 
 Recently resolved (2026-08-28): **#0855** (testing) — `c_port_posix_net.rs` named ports `56301`/`56302` as literals, and both sit INSIDE this host's ephemeral range (32768–60999), so the kernel hands them to anything asking for one. An unrelated ROS `component_node` from another session's Autoware stack held 56302 for 29 minutes and `udp_loopback_roundtrip` reported it as `nros_platform_udp_listen` returning `-1` — a product-shaped message for a host-shaped cause. Now binds port 0 and reads `local_addr()` back, so the kernel names a port nobody holds. See `archived/0855-*`.
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-47 open. One line each — the detail lives in the issue file,
+49 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -103,7 +103,9 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
+- **#0880** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0880-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
+- **#0881** (ci) — Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into See `0881-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/archived/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
+++ b/docs/issues/archived/0832-platform-alloc-funnel-unreferenced-on-cyclone-and-xrce.md
@@ -2,7 +2,7 @@
 id: 832
 title: "`nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and
   xrce native images — the vendor allocators bypass the funnel"
-status: open
+status: resolved
 type: bug
 area: platform, rmw
 related: [phase-391, issue-0817]
@@ -136,11 +136,55 @@ is guarded to `__APPLE__ || (__linux && (__GLIBC__ || __UCLIBC__))` and
 platform's heap and libc's differ, and where it does exist it pairs with a
 block `backtrace_symbols` allocated from glibc itself.
 
-**Still open: the XRCE half.** `get_ip_from_iface` was not touched, so the xrce
-row of the table above stands.
+## Resolution, XRCE half (2026-08-29)
 
-**Also open: coverage.** The funnel-ON path is built by no fast-line lane — see
-issue 0881. The verification above is by hand.
+The bypass was never where this issue said it was. `get_ip_from_iface` is a
+**zenoh-pico** symbol (`src/system/{unix,windows,freertos,rpi_pico}/network.c`)
+and appears nowhere in the XRCE tree, so that row was a misattribution. The
+vendored micro-XRCE-DDS-Client and micro-CDR call no allocator directly at all.
+
+The real bypass is **our own shim** — 38 raw `calloc`/`free` calls across six
+files of `packages/rmw/xrce/nros-rmw-xrce/src/`, in-tree code needing no fork:
+
+| file | calloc | free |
+| --- | ---: | ---: |
+| `session.c` | 1 | 7 |
+| `service.c` | 2 | 4 |
+| `publisher.c` | 1 | 2 |
+| `subscriber.c` | 1 | 2 |
+| `transport_nros_udp.c` | 2 | 10 |
+| `transport_zephyr_udp.c` | 2 | 4 |
+
+All of them go through `nros_xrce_calloc` / `nros_xrce_free` in `src/internal.h`,
+two `static inline`s over `nros_platform_alloc`/`_dealloc`. The zeroing lives in
+the helper rather than at the call sites: every allocation was
+`calloc(1, sizeof(X))` on a struct only partly assigned afterwards, so it is
+load-bearing, and a `memset` to be remembered nine times is one forgotten at the
+tenth.
+
+Measured: `libnros_rmw_xrce.a` — vendored client and micro-CDR included — has
+**zero** objects referencing a raw libc allocator, and 10 funnel references.
+
+Two things fell out of it. The standalone check project took platform HEADERS
+via a cache var but linked no implementation, so it stopped linking the moment
+the shim called the funnel; it now pulls `nros-platform-posix` in the same
+style, which is what `nros-rmw-xrce-cffi`'s build.rs already required of the
+image path ("as long as the consumer links a platform-provider library"). And
+`tests/smoke.c` carried NINE local definitions of platform symbols, added by
+issue 0787 for exactly the reason that no longer holds. They are deleted: the
+real archive defines every one. Only two collided at link time (`clock_ns`,
+`sleep_ms`) because the linker pulls an archive member only for an
+already-unresolved reference, so the local UDP definitions meant `net.c.o` was
+never reached — a second implementation of the platform ABI selected silently by
+link order, which is the hazard the issue-0050 policy exists to prevent,
+arrived at with no weak symbol involved.
+
+## Coverage (2026-08-29)
+
+Closed too — see issue 0881. The standalone cyclone project now links a
+platform implementation, so the fast-line lane compiles the funnel: the three
+executables that caught the original missing link dependency each carry 7 funnel
+call sites and run as part of the 22-test suite.
 
 ## Method note
 

--- a/docs/issues/archived/0843-node-runtime-forces-alloc-on-every-cffi-image.md
+++ b/docs/issues/archived/0843-node-runtime-forces-alloc-on-every-cffi-image.md
@@ -2,7 +2,7 @@
 id: 843
 title: "`nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every
   cffi image needs a global allocator and the `heap-free` tier is unreachable"
-status: open
+status: resolved
 type: bug
 area: core, platform
 related: [phase-391, issue-0816, issue-0832]

--- a/docs/issues/archived/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
+++ b/docs/issues/archived/0881-cyclone-alloc-funnel-has-no-fast-line-lane.md
@@ -1,7 +1,7 @@
 ---
 id: 881
 title: "Cyclone's platform-alloc funnel has no fast-line lane — the only build that compiles it has no platform to funnel into"
-status: open
+status: resolved
 area: ci
 severity: medium
 found: 2026-08-29
@@ -94,3 +94,36 @@ breakage, at no new build.
 Funnel-off on native is not a defect. `unified` is an embedded promise, native
 hosts have a real libc heap, and a `find_package` Cyclone cannot be funnelled at
 all. The gap is in TESTING the embedded shape cheaply, not in the shape itself.
+
+## Resolved (2026-08-29)
+
+Candidate 2, as expected — and the XRCE half of issue 0832 forced the same
+change one project over, which is what settled it. `nros-rmw-xrce`'s shim
+started allocating through the funnel, so its standalone project stopped
+linking until it gained a platform implementation; the pattern that fixed it
+transfers verbatim.
+
+The cyclone project now resolves `NROS_PLATFORM_IMPL_DIR` (a cache PATH
+defaulted to the sibling `nros-platform-posix`, the same convention
+`CYCLONEDDS_SOURCE_DIR` and the header vars already use) and aliases it as
+`NanoRos::Platform`, which is what the funnel gate asks for. Both guarded on
+the targets not already existing, so a parent nano-ros build still wins.
+
+Measured on `just check-rmw-cyclonedds`:
+
+```
+-- nano-ros: CycloneDDS ddsrt heap -> nros_platform_alloc (issue 0832)
+libddsc.a  heap.c.o -> U nros_platform_{alloc,realloc,dealloc}
+           one object left on a raw libc allocator (sysdeps.c.o's free)
+nros_rmw_cyclonedds_ros2_{sub,srv_client,srv_server}: 7 funnel call sites each
+100% tests passed, 0 tests failed out of 22
+```
+
+Those three executables are the ones that caught the original missing link
+dependency, so the lane is back to covering the shape it covered before the
+dependency fix — this time with the funnel actually compiled, and end to end
+rather than at link only.
+
+Cost: the lane builds a platform archive it did not build before. Cyclone
+itself was already built from source here, so there is no second Cyclone build
+and the ~22 s figure in the recipe's own comment is unaffected in kind.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -40,7 +40,6 @@ fails if this block drifts.
 - **#0829** (api, rmw) — Two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on depth — 1 in `nros-rmw`, 10 in the `nros::qos` façade, each with two callers See `0829-*`.
 - **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
 - **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
-- **#0832** (platform, rmw) — `nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and xrce native images — the vendor allocators bypass the funnel See `0832-*`.
 - **#0834** (cmake) — The per-build `nros_cpp_config_generated.h` mirror can reach a state no re-run repairs — only wiping the west build dir recovers it See `0834-*`.
 - **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
 - **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
@@ -58,12 +57,16 @@ fails if this block drifts.
 - **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
 - **#0870** (rmw, examples) — NuttX C++ action client fails `create_action_client` — the session reports `Transport(ConnectionFailed)` against a router the server reached See `0870-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
+- **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0877** (testing, boards) — FreeRTOS pubsub delivers by hand and delivers NOTHING under the test harness — and the talker trips a FreeRTOS queue assert See `0877-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 - **#0891** (testing) — Six nuttx `rtos_e2e` cells fail in-sweep and pass solo — the group cap was never measured, and a slow boot is reported as a dead image See `0891-*`.
+- **#0895** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0895-*`.
+- **#0896** (rmw, api) — Every C/C++ subscription takes the small size class regardless of its message type — nothing fills `rx_buffer_hint` See `0896-*`.
 - **#0899** (rmw, boards) — The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer — two different asserts, both after tens of successful publishes See `0899-*`.
+- **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -45,7 +45,6 @@ fails if this block drifts.
 - **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
 - **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
 - **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
-- **#0843** (core, platform) — `nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every cffi image needs a global allocator and the `heap-free` tier is unreachable See `0843-*`.
 - **#0847** (rmw) — An XRCE publisher outliving `executor.close()` segfaults in its own Drop: the entity destructor dereferences the session state that close already freed See `0847-*`.
 - **#0849** (cli) — `nros sync` bakes the invocation's path SPELLING into every leaf patch table, so working through a symlink to the checkout makes cargo see two copies of every core crate and refuse the build on `links` See `0849-*`.
 - **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.

--- a/docs/reference/api-parity-ledger/exec.json
+++ b/docs/reference/api-parity-ledger/exec.json
@@ -91,10 +91,6 @@
   "verdict": "declined",
   "why": "rclc's stuttering spelling -- the type name appears twice. Ours is `nros_executor_get_zero_initialized`, the method-style name on the type. See `c:get_zero_initialized_publisher`."
  },
- "c:executor_has_param": {
-  "verdict": "extension",
-  "why": "'is this parameter declared?', asked without the six `rcl_interfaces/srv/*` servers being up. Parameters live on the EXECUTOR here rather than on a node (see the param stage's `c:executor_register_parameter_services`), and a device that bakes its parameter set (RFC-0045) wants a local existence check that costs no queryable slot -- `ZPICO_MAX_QUERYABLES` is 8 on embedded (issue 0460)."
- },
  "c:executor_handle_invocation_t": {
   "verdict": "rename",
   "why": "LANDED 2026-08-26 (phase-379 W5) — the enum is now `nros_executor_handle_invocation_t`, matching rclc's `rclc_executor_handle_invocation_t` (cbindgen-regenerated in `nros_generated.h`). The enum VALUES (`NROS_EXECUTOR_ON_NEW_DATA` / `NROS_EXECUTOR_ALWAYS`) were not part of this row and did not move. CORRECTED 2026-08-27 (phase-379 W5): the sentence that followed still read, in the present tense, \"ours drops `handle_` from rclc's `rclc_executor_handle_invocation_t`\" -- that was the pre-rename statement of the defect and it is no longer true. Verified at HEAD: the live spelling is `nros_executor_handle_invocation_t` (`packages/api/nros-c/src/executor.rs:137`, header `nros_generated.h:649`) and no `nros_executor_invocation_t` survives in any source tree -- the only remaining hits are stale build artifacts under `packages/testing/nros-tests/bins/*/build-*/`. The REASON it landed stands: no platform reason, the shorter name cost a C user the rclc spelling for nothing, and the values were the same pair either way. This row stays `ours-only` in the report rather than collapsing to `same`, because the theirs half is filtered as plumbing (`rclc/executor_handle.h`, \"rclc's internal per-entity executor bookkeeping\" -- `scripts/api_parity/public_surface.py:79`), so one row carries both sides.",
@@ -104,6 +100,10 @@
    "status": "landed",
    "category": "A"
   }
+ },
+ "c:executor_has_param": {
+  "verdict": "extension",
+  "why": "'is this parameter declared?', asked without the six `rcl_interfaces/srv/*` servers being up. Parameters live on the EXECUTOR here rather than on a node (see the param stage's `c:executor_register_parameter_services`), and a device that bakes its parameter set (RFC-0045) wants a local existence check that costs no queryable slot -- `ZPICO_MAX_QUERYABLES` is 8 on embedded (issue 0460)."
  },
  "c:executor_is_valid": {
   "verdict": "extension",
@@ -637,6 +637,16 @@
  "rust:Executor::add_pre_shutdown_callback": {
   "verdict": "extension",
   "why": "The ORDER is the feature: pre-shutdown callbacks run while the session is still open and every entity still works -- which is how a device publishes a final state, answers a last request, parks an actuator or releases a bus -- and on-shutdown callbacks run after the close. rclrs has no shutdown hook at all -- no `Context` callback list, no free function -- so there is nothing on the rclrs side to correspond to. It exists because an RTOS node has nowhere else to release hardware while its entities still work. The platform constraint is no allocator: rclcpp's registration takes a `std::function<void()>` (a heap allocation per callback) and hands back a handle owning a `std::shared_ptr` to it. Ours is a fixed-capacity static table of `(extern \"C\" fn, void* context)` sized by `NROS_EXECUTOR_MAX_SHUTDOWN_CBS` (default 2, small on issue 0460's precedent that a per-entity static slot is a cost every image pays), and the handle is the SLOT INDEX with its phase packed in so it cannot remove the other phase's callback. rclcpp hangs these on `Context`; we have none (see `c:context_*` / `cpp:Context` in init.json), and the executor is what `shutdown` / `close` / `fini` is called on, so it owns the tables. Issue 0790."
+ },
+ "rust:Executor::arena_capacity": {
+  "verdict": "extension",
+  "why": "how many arena bytes an executor was GIVEN and how many its registered entities actually claimed. No upstream analogue because upstream has no arena: rclcpp allocates each entity on the heap, so \"how much of the pre-sized block is in use\" is not a question it can ask. Here `ARENA_SIZE` is derived by budgeting EVERY slot at the ActionClient worst case, and the arena is a BUMP allocator held INLINE in the `Executor` value -- on the task stack, where `mem-report` cannot see it. So the allocator has always known the exact claimed total and had no way to say it: a timer-only executor claims 32 bytes of 74,240. These two accessors are how an image, a test, or the boot advisory finds the number to put in `NROS_EXECUTOR_ARENA_SIZE`. Issue 0900.",
+  "bucket": "ours-only"
+ },
+ "rust:Executor::arena_used": {
+  "verdict": "extension",
+  "why": "how many arena bytes an executor was GIVEN and how many its registered entities actually claimed. No upstream analogue because upstream has no arena: rclcpp allocates each entity on the heap, so \"how much of the pre-sized block is in use\" is not a question it can ask. Here `ARENA_SIZE` is derived by budgeting EVERY slot at the ActionClient worst case, and the arena is a BUMP allocator held INLINE in the `Executor` value -- on the task stack, where `mem-report` cannot see it. So the allocator has always known the exact claimed total and had no way to say it: a timer-only executor claims 32 bytes of 74,240. These two accessors are how an image, a test, or the boot advisory finds the number to put in `NROS_EXECUTOR_ARENA_SIZE`. Issue 0900.",
+  "bucket": "ours-only"
  },
  "rust:Executor::close": {
   "verdict": "extension",

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -30,7 +30,7 @@ when upstream releases.
 
 ## What the fork adds
 
-20 commits, 51 files, +2361/−138 against the 0.10.x boundary `5041f356`.
+21 commits, 52 files, +2493/−137 against the 0.10.x boundary `5041f356`.
 Seven groups.
 
 Re-measured 2026-08-29 and it had drifted BOTH ways: the headline said 15
@@ -120,12 +120,13 @@ its own netconn semaphore. ddsrt creates its own threads and never called
 `sem != NULL`. `thread_start_routine` is the point they have in common. Found by
 phase-370 W4, the first work to boot an embedded Cyclone image at all.
 
-### 6. The platform allocation funnel (2 commits)
+### 6. The platform allocation funnel (3 commits)
 
 | commit | subject |
 | --- | --- |
 | `6e2ad36f` | ddsrt/posix: route the heap through nano-ros's platform allocation funnel |
 | `8e6ff48a` | ddsi: allocate and free through ddsrt, not libc, in four mismatched places |
+| `d97a71e2` | ddsrt: one funnel heap for every port, instead of an arm inside one of them |
 
 Behind `-DNROS_DDSRT_PLATFORM_FUNNEL`, set by `ProvideCycloneDDS.cmake` on
 `ddsc` only (never on the tools-side `ddsrt-internal`: idlc and confgen link no
@@ -151,6 +152,30 @@ are genuinely different heaps.
 and `q_freelist.c`'s `free` is a function PARAMETER, not libc. After the sweep
 `libddsc.a` has exactly one object referencing a raw libc allocator, which is
 the `sysdeps.c` one.
+
+**The funnel is one file, not an arm per port.** `6e2ad36f` put the arms inside
+`heap/posix/heap.c`, which left FreeRTOS on `pvPortMalloc` and ThreadX on
+`tx_byte_allocate` — a second allocation route on exactly the ports whose heap
+genuinely is not libc's. `d97a71e2` replaces that with `heap/nros/heap.c`,
+which implements the whole `ddsrt_*` family on the platform ABI, and compiles
+each port's own heap.c out under the same switch. `heap/posix/heap.c` is stock
+again apart from that guard.
+
+The new file sits in the COMMON source list rather than being swapped in per
+port, and that is load-bearing: `ddsrt` is INTERFACE and `ddsrt-internal`
+compiles the same `INTERFACE_SOURCES`, so a swap would hand the funnel to the
+host tools (idlc, confgen) that link no platform layer. Because the switch is a
+PRIVATE compile definition on `ddsc`, both targets see one file set and only
+`ddsc` gets the funnel — measured: `libddsrt-internal.a` has zero
+`nros_platform_*` references and its stock posix heap still defines the family.
+
+Dropping the per-port heaps also drops their size-header prefix and alignment
+arithmetic, which existed only because the RTOS allocators have no realloc;
+`nros_platform_realloc` is specified with libc realloc semantics. The ThreadX
+weak `zpico_threadx_byte_pool` goes with it.
+
+`heap/vxworks/heap.c` is untouched: no CMakeLists references it, it does not
+include `dds/ddsrt/heap.h`, and nothing in this tree can compile it.
 
 ### 7. Nested-build path resolution (1 commit)
 
@@ -229,10 +254,10 @@ Then, two recipes that cross-check each other:
 
 ```sh
 # by boundary: 5041f356 is the newest upstream 0.10.x commit the stack sits on
-git log --oneline 5041f356..origin/nano-ros          # -> 20
+git log --oneline 5041f356..origin/nano-ros          # -> 21
 
 # by authorship, as an independent check
-git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 20
+git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 21
 ```
 
 Do not count `origin/master..origin/nano-ros` alone: it sweeps in upstream 0.10.x

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -107,6 +107,21 @@ seconds later, which is exactly how 0371 cost as much time as it did.
 | `22150fbf` | fix(freertos): avoid TLS-only DDS state |
 | `99cfac88` | ddsrt: give every FreeRTOS thread its lwIP per-thread netconn semaphore |
 
+### 6. The platform allocation funnel (1 commit)
+
+| commit | subject |
+| --- | --- |
+| `6e2ad36f` | ddsrt/posix: route the heap through nano-ros's platform allocation funnel |
+
+Behind `-DNROS_DDSRT_PLATFORM_FUNNEL`, set by `ProvideCycloneDDS.cmake` on
+`ddsc` only (never on the tools-side `ddsrt-internal`: idlc and confgen link no
+platform layer). Undefined, the file is byte-identical to stock, so cyclone's
+own ctest suite is unaffected. Issue 0832 measured the funnel DEFINED and
+UNREFERENCED in native cyclone images; it now has 4 inbound edges and the whole
+`ddsrt_{malloc,malloc_s,calloc_s,realloc_s,free}` family is off `malloc@plt`.
+Compile-time rather than weak-linked on purpose: weak linkage leaves the libc
+branch in the binary, and its absence is what a tier gate has to read.
+
 With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
 its own netconn semaphore. ddsrt creates its own threads and never called
 `lwip_socket_thread_init()`, so the first socket call from one asserted

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -30,8 +30,14 @@ when upstream releases.
 
 ## What the fork adds
 
-15 commits, 39 files, +2251/−117 against the 0.10.x boundary `5041f356`.
-Five groups:
+19 commits, 45 files, +2353/−130 against the 0.10.x boundary `5041f356`.
+Seven groups.
+
+Re-measured 2026-08-29 and it had drifted BOTH ways: the headline said 15
+while the tables below listed 17, and `ae14b312` appeared in neither. A
+count that disagrees with its own table is worse than no count — it reads
+as the authoritative number. The two verification recipes at the bottom
+are the check; run them rather than trusting this line.
 
 ### 1. ThreadX / NetX Duo port (6 commits) — a platform upstream does not have
 
@@ -48,13 +54,14 @@ Almost entirely **additive** — new `ddsrt/{sync,threads,sockets,time,heap,
 ifaddrs,process}/threadx/` trees plus the `DDSRT_WITH_THREADX` selection arms.
 Retired only if upstream accepts a ThreadX port, which nobody has offered.
 
-### 2. Zephyr platform gaps (3 commits)
+### 2. Zephyr platform gaps (4 commits)
 
 | commit | subject |
 | --- | --- |
 | `290152c0` | fix(zephyr): tolerate NSOS socket gaps |
 | `1d794c0a` | ddsi_udp: Zephyr multicast join via `struct ip_mreqn` (issue 0231) |
 | `4aa337b0` | q_sockwaitset: AF_UNIX socketpair self-pipe on native-IP-stack Zephyr |
+| `ae14b312` | ddsrt: initialise the atomics mutexes at runtime on the Zephyr backend |
 
 Upstream *does* have a Zephyr port (`ports/zephyr`, `WITH_ZEPHYR`); these are
 places where it does not survive contact with Zephyr's native IP stack / NSOS.
@@ -107,6 +114,12 @@ seconds later, which is exactly how 0371 cost as much time as it did.
 | `22150fbf` | fix(freertos): avoid TLS-only DDS state |
 | `99cfac88` | ddsrt: give every FreeRTOS thread its lwIP per-thread netconn semaphore |
 
+With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
+its own netconn semaphore. ddsrt creates its own threads and never called
+`lwip_socket_thread_init()`, so the first socket call from one asserted
+`sem != NULL`. `thread_start_routine` is the point they have in common. Found by
+phase-370 W4, the first work to boot an embedded Cyclone image at all.
+
 ### 6. The platform allocation funnel (1 commit)
 
 | commit | subject |
@@ -122,11 +135,34 @@ UNREFERENCED in native cyclone images; it now has 4 inbound edges and the whole
 Compile-time rather than weak-linked on purpose: weak linkage leaves the libc
 branch in the binary, and its absence is what a tier gate has to read.
 
-With `LWIP_NETCONN_SEM_PER_THREAD=1` every thread touching the socket API needs
-its own netconn semaphore. ddsrt creates its own threads and never called
-`lwip_socket_thread_init()`, so the first socket call from one asserted
-`sem != NULL`. `thread_start_routine` is the point they have in common. Found by
-phase-370 W4, the first work to boot an embedded Cyclone image at all.
+### 7. Nested-build path resolution (1 commit)
+
+| commit | subject |
+| --- | --- |
+| `556f79d4` | build: resolve Cyclone's own paths by project, not by CMAKE_SOURCE_DIR |
+
+`CMAKE_SOURCE_DIR` is the TOP-LEVEL project's source dir, so a reference to a
+Cyclone file spelled that way is correct only when Cyclone is the top-level
+project. We reach it by `add_subdirectory()`, where it names nano-ros's root.
+
+Latent until section 6 made it reachable: `_confgen`'s hash check watches
+`ddsi_config.c`, so the first edit to that file arms the regeneration branch and
+its four `AppendHashScript.cmake` commands look for the script under nano-ros.
+The failure is not clean — `_confgen-exe` has already rewritten `defconfig.c`,
+`options.md`, `cyclonedds.rnc` and `cyclonedds.xsd` in the SOURCE tree, and the
+step that dies is the one appending the hashes, so a nested build leaves four
+generated files modified and hash-less and the next configure re-arms the same
+branch. This is what blocked routing `ddsi_config_init` through the funnel.
+
+`project(CycloneDDS ...)` defines `CycloneDDS_{SOURCE,BINARY}_DIR`, which mean
+"Cyclone's root" regardless of who included it. Identical to the old spelling in
+a standalone build, so upstream behaviour is unchanged and cyclone's own ctest
+suite is unaffected. Fixed at all nine sites that mean Cyclone's own tree
+(`_confgen`, `idlc/xtests`, `src/idl`'s `MAIN_PROJECT_DIR`, `fuzz`), not only
+the one that breaks a build today. `core/xtests/cdrtest` keeps its
+`CMAKE_SOURCE_DIR`: its scripts live in that test's own directory, so it is
+wrong standalone too — a different bug in a target this change cannot exercise.
+
 
 Pushed to `origin/nano-ros` as a fast-forward over `8601ca66`, and the
 superproject pin bumped to it afterwards — that order, not the reverse: a pin
@@ -176,10 +212,10 @@ Then, two recipes that cross-check each other:
 
 ```sh
 # by boundary: 5041f356 is the newest upstream 0.10.x commit the stack sits on
-git log --oneline 5041f356..origin/nano-ros          # -> 15
+git log --oneline 5041f356..origin/nano-ros          # -> 19
 
 # by authorship, as an independent check
-git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 15
+git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 19
 ```
 
 Do not count `origin/master..origin/nano-ros` alone: it sweeps in upstream 0.10.x

--- a/docs/reference/cyclonedds-fork-delta.md
+++ b/docs/reference/cyclonedds-fork-delta.md
@@ -30,7 +30,7 @@ when upstream releases.
 
 ## What the fork adds
 
-19 commits, 45 files, +2353/−130 against the 0.10.x boundary `5041f356`.
+20 commits, 51 files, +2361/−138 against the 0.10.x boundary `5041f356`.
 Seven groups.
 
 Re-measured 2026-08-29 and it had drifted BOTH ways: the headline said 15
@@ -120,11 +120,12 @@ its own netconn semaphore. ddsrt creates its own threads and never called
 `sem != NULL`. `thread_start_routine` is the point they have in common. Found by
 phase-370 W4, the first work to boot an embedded Cyclone image at all.
 
-### 6. The platform allocation funnel (1 commit)
+### 6. The platform allocation funnel (2 commits)
 
 | commit | subject |
 | --- | --- |
 | `6e2ad36f` | ddsrt/posix: route the heap through nano-ros's platform allocation funnel |
+| `8e6ff48a` | ddsi: allocate and free through ddsrt, not libc, in four mismatched places |
 
 Behind `-DNROS_DDSRT_PLATFORM_FUNNEL`, set by `ProvideCycloneDDS.cmake` on
 `ddsc` only (never on the tools-side `ddsrt-internal`: idlc and confgen link no
@@ -134,6 +135,22 @@ UNREFERENCED in native cyclone images; it now has 4 inbound edges and the whole
 `ddsrt_{malloc,malloc_s,calloc_s,realloc_s,free}` family is off `malloc@plt`.
 Compile-time rather than weak-linked on purpose: weak linkage leaves the libc
 branch in the binary, and its absence is what a tier gate has to read.
+
+Routing `ddsrt` was not enough, because four ddsi sites called libc DIRECTLY —
+and three of them were already a bug before the funnel existed. They allocate
+from one heap and release to the other: a listelem `malloc`'d in
+`network_interface_find_or_append` but freed by `free_all_elements`'
+`ddsrt_free`; `split_at_comma`'s `ddsrt_malloc`'d array released with libc
+`free`; a `calloc`'d `->verbatim` released through `dds_stream_free_sample`,
+whose allocator is `{ddsrt_malloc, ddsrt_realloc, ddsrt_free}`; and a
+`ddsrt_asprintf` string freed with `free`. On POSIX both heaps are glibc so
+nothing faults; on ThreadX, FreeRTOS and Zephyr — and under the funnel — they
+are genuinely different heaps.
+
+`sysdeps.c`'s `free` stays libc on purpose (`backtrace_symbols` allocated it),
+and `q_freelist.c`'s `free` is a function PARAMETER, not libc. After the sweep
+`libddsc.a` has exactly one object referencing a raw libc allocator, which is
+the `sysdeps.c` one.
 
 ### 7. Nested-build path resolution (1 commit)
 
@@ -212,10 +229,10 @@ Then, two recipes that cross-check each other:
 
 ```sh
 # by boundary: 5041f356 is the newest upstream 0.10.x commit the stack sits on
-git log --oneline 5041f356..origin/nano-ros          # -> 19
+git log --oneline 5041f356..origin/nano-ros          # -> 20
 
 # by authorship, as an independent check
-git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 19
+git log --oneline --author=jerry73204 origin/master..origin/nano-ros   # -> 20
 ```
 
 Do not count `origin/master..origin/nano-ros` alone: it sweeps in upstream 0.10.x

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -277,10 +277,28 @@ which picks the large class when the hint exceeds
 `M::MAX_SERIALIZED_SIZE_XCDR1`/`_XCDR2` as PROVIDED consts computed from the
 schema, plus `size::bound_fits::<M>` which takes the larger of the two.
 
-What is missing is that **nothing sets the hint**. The only setter in the tree
-is one bench site; `rust_adapter` passes a literal `0`. So every real
-subscription takes the small class, and the large pool — 2 x 4 x 16384 =
-131,072 B, already reserved — sits unused.
+What was missing, at survey time, is that **nothing set the hint**. The only
+setter in the tree was one bench site; `rust_adapter` passed a literal `0`. So
+every real subscription took the small class, and the large pool — 2 x 4 x 16384
+= 131,072 B, already reserved — sat unused.
+
+**Corrected 2026-08-29: the RUST half of that is fixed and the C/C++ half is
+not.** `2adf2b739` wired `create_subscription::<M>` to pass
+`subscription_rx_hint::<M>(RX_BUF)` — the type's own bound, falling back to
+`RX_BUF` only where no bound exists. A Rust subscription to a 4 KiB type now
+routes large.
+
+A C or C++ subscription to the same type still hints 0. The field is declared,
+`rust_adapter` reads it, the shim routes by it — and no source under
+`packages/api/nros-c`, `packages/api/nros-cpp`, `packages/cli/rosidl-*` or
+`examples/` writes it. The producer is the Rust executor and nothing else, so
+W3a's saving applies to half the tree.
+[Issue 0896](../issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md)
+carries the survey and the constraint that decides the design: the bound is a
+PROVIDED const computed from `FIELDS`, a C message has no such trait, and
+whatever carries the number to the C call site must not become a SECOND
+computation of it — that is the sizes-header mirror class
+(0088 -> 0114 -> 0122 -> 0123 -> 0245 -> 0268) one lane over.
 
 The cost of that shows up in the build error `create_subscription` raises when a
 type does not fit: *"Raise the knob to at least the type's bound."* That knob is
@@ -300,7 +318,9 @@ const of a type parameter cannot be used as a const-generic argument
 (`error: generic parameters may not be used in const operations`, checked on
 edition 2024). So:
 
-- **W3a — route the zenoh block by the type's bound.** `rx_buffer_hint` is a
+- **W3a — route the zenoh block by the type's bound. LANDED for Rust
+  (`2adf2b739`); the C/C++ half is issue 0896 and is NOT done.**
+  `rx_buffer_hint` is a
   runtime `usize`, so `create_subscription::<M>` can pass
   `max(XCDR1, XCDR2)` with no unstable feature. A type between the small size
   and `ZPICO_SUBSCRIBER_LARGE_SIZE` stops being a build error and starts being
@@ -330,6 +350,14 @@ edition 2024). So:
   Tested from OUTSIDE the crate (a macro body resolves in the caller, so an
   in-crate test would see private names a consumer cannot), including use in
   const-generic position — the property the whole wave exists for.
+
+**W3 has no MEASURED saving yet.** W3a changes which size class a subscription
+routes to; it does not by itself shrink a pool, and the 98,304 B in the table
+above is an avoided COST on a hypothetical 4 KiB type, not an observed delta on
+a real image. Per this phase's rule, W3 claims nothing until `just mem-report
+--json --baseline` shows it on an image with a type large enough to route
+differently — and no example in the tree has one today, which is its own finding
+about the fixture corpus rather than about the wave.
 
 **W4 — drop the network stack from serial images.** 27,760 B.
 

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -464,76 +464,115 @@ Net C/C++ API change: none. No function, no parameter, no generic in a header.
   `bridges`, `bindings`). There is NO entity inventory: a node's publishers,
   subscriptions and service servers appear nowhere.
 
-  * **W5.b1 — the infrastructure flags, available today.** `execution.features`
-    carries `param_services` and `lifecycle` verbatim, which is exactly the half
-    a build script cannot otherwise see (cargo exposes no other crate's
-    features). A `nros ws` verb reporting it, delivered by W5.c, lets the
-    consumer resolve `infra` for real and keeps only an app-side headroom
-    constant. On a talker that is 32 -> 8 slots, ~108,096 B of the 143,456 B
-    W5.d measured — most of the win, with one guess left instead of six.
+  * **W5.b1 — the infrastructure flags.** LANDED. `execution.features` carries
+    `param_services` and `lifecycle` verbatim, which is exactly the half a build
+    script cannot otherwise see (cargo exposes no other crate's features).
+    `nros ws entity-facts` reports it; W5.c delivers it; the consumer adds what
+    those features COST rather than being told. Unknown names are ignored, not
+    refused — `safety` is a real feature here and is not a queryable question.
 
-  * **W5.b2 — the application's own service-server count.** AVAILABLE after all,
-    and needing no change to either resolver repo.
+    Measured over every resolved model in the tree: 92 `none`, 22
+    `param+lifecycle`, 1 `lifecycle`. On a model declaring neither, the table
+    goes 32 -> 8 slots; on one declaring both, 32 -> 19.
 
-    The first draft of this wave said the count was missing and proposed
-    extending the model. That was wrong twice. `ros-launch-manifest` ALREADY
-    models it — `manifest.services` maps a service name to `ServiceWiring {
-    srv_type, server: Vec<String>, .. }`, where `server` lists the nodes serving
-    it, and rlm's own `service-wiring` validation rule already reasons over
-    `!svc.server.is_empty()`. A node's service-server count is the number of
-    services whose `server` contains it.
+  * **W5.b2 — the application's own service-server count.** NOT AVAILABLE, and
+    this is the THIRD reading of the same question. The first draft said the
+    model could not answer it and proposed extending the spec. The second said
+    `ros-launch-manifest` already modelled it, so it was available. Both were
+    wrong, in opposite directions, and the truth is in between.
 
-    And extending the spec would have been the wrong move even if it had been
-    missing. **rlm is the platform-neutral SPEC; `play_launch` is its Linux
-    implementation; neither may carry nano-ros concerns.** Service wiring is a
-    general ROS graph concept, exactly like topic wiring. A static-RAM sizing
-    rule is not, and stays here: reading the model and turning it into a
-    queryable count is nano-ros's build layer, not the manifest's business.
+    The SPEC models it: `structure.services` maps a service FQN to
+    `ServiceWiring { srv_type, server: Vec<String>, client }`, `structure.actions`
+    is the same type, and rlm's own `service-wiring` rule already reasons over
+    `!svc.server.is_empty()`. Extending it would have been wrong as well as
+    unnecessary — **rlm is the platform-neutral SPEC, `play_launch` is its Linux
+    implementation, and neither may carry nano-ros concerns.** Service wiring is
+    a general ROS graph concept; a static-RAM sizing rule is not, and stays in
+    this tree's build layer.
 
-    This also closes W5.b1's open caveat structurally rather than empirically.
-    `ServiceWiring::server` carries `skip_serializing_if = "Vec::is_empty"`, the
-    same pattern as `execution.features` — so *absent means empty* by
-    construction, not merely in the 115 models that happen to be in the tree.
+    The RESOLVER never emits it. MEASURED: zero of the 115 resolved models in
+    this tree carry ANY layer-1 wiring — no `topics`, no `services`, no
+    `actions`. A plain `<node>` launch element names a node; it does not say
+    what that node serves, and nothing else in the resolver's inputs does
+    either. `nros metadata`'s component sidecar does not either: it carries
+    name, class, sources and callback groups, no endpoint inventory.
 
-    The reason no model here shows a `services:` section is that none of the
-    example workspaces declare any, not that the spec lacks it.
+    So an absent `services` map does NOT mean "this system has no service
+    servers". `examples/workspaces/c`'s `service_server_model.yaml` describes
+    exactly one node, called `add_server`, and carries no `services` key at all.
 
-  ### `services[].server` is AUTHORITATIVE
+    **`nros ws entity-facts` therefore ABSTAINS rather than reporting a zero it
+    cannot support.** Reporting 0 there would size the table to the
+    infrastructure alone and exhaust it the moment that node registers — a
+    confident wrong number, sized exactly, which is this campaign's own failure
+    shape rather than a new one. The discriminator is whether ANY wiring was
+    described: if it was, an empty `services` map is a real zero; if nothing
+    was, the question is unanswered and the verb says nothing. The app term
+    stays `UNDECLARED_HEADROOM` in the consumer, labelled there as the guess it
+    is.
 
-  DECIDED. The launch declaration is the contract: an image is sized for exactly
+    The counting machinery is landed and correct for the day the resolver does
+    emit wiring: endpoint refs are counted per SERVER, not per service name (two
+    nodes serving one name are two queryables), and an action server costs
+    `ACTION_SERVER_QUERYABLES` because an action is three services on the wire.
+
+  ### If `services[].server` arrives, it is AUTHORITATIVE
+
+  DECIDED, and unchanged by the above — it is the rule for when the input
+  exists. The launch declaration is the contract: an image is sized for exactly
   the service servers its model declares.
 
   The alternative was to treat it as a floor and add headroom, which is safe and
   wrong — it re-creates in miniature the guess this whole wave exists to delete,
   and a guess derived from something real is still a guess nobody can audit.
 
-  What being authoritative COSTS, and it must be paid in the same wave: a node
-  that creates a service server its model does not declare will exhaust the
-  table. Sized exactly, that is issue 0460's failure reached from a new
-  direction, so the runtime must report it as what it is — "this node created an
-  undeclared service server" — and not as the bare exhausted-table error 0460
-  spent a phase making legible. The declaration being wrong and the table being
-  too small are the same event now, and the message must say the first.
+  What being authoritative COSTS is paid in W5.e, in this wave: a node that
+  creates a service server its model does not declare exhausts the table, so
+  "the declaration is wrong" and "the table is too small" become the same event
+  and the runtime must name the first.
 
   ### Future work: counting in code
 
-  The declaration is a stepping stone, not the destination. The count a node's
-  CODE actually produces is the ground truth, and deriving it there would make
-  the launch declaration checkable rather than trusted — the same move W5.a made
-  for the infrastructure counts, where a constant beside the creation sites
-  replaced seven prose spellings and a gate holds it to the sites themselves.
+  The declaration is a stepping stone, not the destination — and after the
+  measurement above it is not even the near-term path, since nothing populates
+  it today. The count a node's CODE produces is the ground truth, and deriving
+  it there would make a launch declaration checkable rather than trusted — the
+  same move W5.a made for the infrastructure counts, where a constant beside the
+  creation sites replaced seven prose spellings and a gate holds it to the sites
+  themselves.
 
   Out of scope for W5 and deliberately not designed here: it needs the entity
   set to be visible at build time in BOTH languages, which is the asymmetry that
   ruled out const generics (`Node::ENTITY_BOUNDS` exists for Rust; C/C++
   entities are created at runtime in C with no declaration site). Solving that
-  is the real end state; W5 gets the saving without waiting for it.
+  is the real end state; W5 gets the infrastructure saving without waiting for
+  it.
 
-  Until W5.b1/W5.b2 land, the app term stays a constant in the consumer, and it
-  is labelled as one in the code rather than presented as a derivation.
+* **W5.c — delivery.** LANDED. `NanoRosEntityFacts.cmake` runs the verb per
+  entry and attaches the result with `corrosion_set_env_vars` — the phase-351 W5
+  carrier, for the reason issue 0460 records: a workspace member's own
+  `.cargo/config.toml` is never read (Corrosion runs cargo from the workspace
+  root) and `set(ENV{...})` reaches only the configure-time process.
 
-* **W5.c — delivery.** The figure rides the phase-351 W5 path to the backend's
-  build script. Both entry front-ends produce the same fact from the same model.
+  One thing is different from board facts and it decides the shape. Exactly one
+  BOARD is active per configure; several MODELS can be, one per entry. There is
+  one runtime staticlib per configure and every entry links it, so entries
+  ACCUMULATE: union of the infrastructure flags, max of the application counts,
+  and ONE abstaining entry makes the whole configure's count unknown — a shared
+  table has to satisfy the largest, and an unknown is not smaller than anything.
+  Applied once by `nros_synth_runtime_umbrella`, which already runs after the
+  SUBDIRS loop that processes the entries.
+
+  Failure is soft throughout, deliberately, exactly as `nros_resolve_board_facts`
+  is: a model that is not resolved yet, a CLI that is not built, an entry
+  addressed the `MODEL` way at a path that does not exist. None of those is a
+  configuration error; each means "this configure carries no entity facts",
+  which is the state every build was in before this wave.
+
+  Verified by a script-mode cmake probe over real models — the union, the
+  abstention, a wired model scoring 1 service + 1 action = 4, and the soft skip
+  when a model will not load. NOT yet verified end-to-end through a real
+  configure; see W5.g.
 
 * **W5.d — consumption.** LANDED. `nros-zpico-build` computes
   `app_declared + PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES` and
@@ -567,28 +606,68 @@ Net C/C++ API change: none. No function, no parameter, no generic in a header.
   the seven prose spellings W5.a replaced. Verified by drifting the lifecycle
   mirror to its historical wrong value of 6 and watching the gate name the file.
 
-* **W5.e — an undeclared image fails loudly.** A bare `cargo build` of a leaf,
-  and the standalone `check-rmw-*` projects, have no model. They get a
-  build-time failure naming what to declare, not a generous default: this
-  issue's own `.max(1)` finding is the precedent — `ZPICO_MAX_LARGE_SUBSCRIBERS=0`
-  silently yields 1, so a config reads as satisfied while still reserving 64 KiB.
-  A fallback that quietly works is the shape this campaign keeps finding.
+* **W5.e — an exhausted table names the right fault.** LANDED, in the half that
+  authoritativeness makes urgent. The same exhaustion is now two different
+  faults and the message says which. Sized from the backend's own budget, the
+  table is too small and the fix is the knob — issue 0460's message, unchanged.
+  Sized from a DECLARATION (`ZPICO_QUERYABLE_TABLE_DECLARED`, emitted beside the
+  size it describes so the two cannot disagree), it holds what the model said
+  this image would create, so reaching the limit means the image created an
+  UNDECLARED service server, and pointing that reader at `ZPICO_MAX_QUERYABLES`
+  sends them to enlarge a table that was already right. Both arms are `&'static
+  str` constants, so the `no_std` half gets the same split — the half issue 0460
+  found had no explanation at all.
 
-* **W5.f — RETIREMENT, and this wave is not done without it.** Delete
-  `queryable_default`, its `if hosted { 32 } else { 8 }` literal and the
-  `CARGO_CFG_TARGET_OS` sniff behind it. `ZPICO_MAX_QUERYABLES` stops being the
-  primary input and becomes an OVERRIDE that must be `>=` the declared figure,
-  checked at build time rather than trusted. Two mechanisms for one number is
-  how this phase's other defects were born: leaving the guess in place "for
-  safety" would mean every image still pays it whenever the declaration fails to
-  arrive, which is exactly the silent-fallback shape W5.e refuses. Retirement is
-  a wave, not a cleanup, because the old path must be provably unreachable
-  before it is deleted — grep for readers, then delete, then re-measure.
+  NOT landed: the build-time failure for an image that declares nothing. That
+  still needs the hand-written-`main` question settled (see Open, below), and it
+  is what blocks W5.f's deletion.
 
-* **W5.g — measure and gate.** `just mem-report --json --baseline` delta on the
-  four native roles. The talker's expected figure is the whole 144,128 B minus
-  its own (zero) services and (zero) infrastructure. A role that declares
-  services keeps exactly what it declares, which is the property worth gating.
+* **W5.f — RETIREMENT.** HALF LANDED, and the half that is not is blocked rather
+  than skipped.
+
+  LANDED: `ZPICO_MAX_QUERYABLES` stops being an independent opinion and becomes
+  a CHECKED override. Two mechanisms deciding one number is how this phase's
+  other defects were born. The check compares against a DERIVED floor, not the
+  budgeted default, and that distinction is the point: an image carrying both
+  service families provably claims eleven slots at boot, so below that it cannot
+  start and the build is REFUSED; the default adds `UNDECLARED_HEADROOM` for an
+  application count nothing can supply, and being under THAT is reported with a
+  `cargo:warning` naming both numbers, because refusing a build for being under
+  a guess is the defect this wave exists to remove. The floor and the default
+  share one parser of the infrastructure spelling — two readings of one string
+  is how a rule and its check come to disagree.
+
+  This is issue 0460 caught a stage earlier: `zephyr/Kconfig` defaults
+  `CONFIG_NROS_MAX_QUERYABLES` to 8, and an entry enabling both families needs
+  eleven. That image used to build cleanly and die at boot.
+
+  NOT LANDED: deleting `if hosted { 32 } else { 8 }` and the
+  `CARGO_CFG_TARGET_OS` sniff behind it. The old path is still REACHABLE, which
+  is this wave's own precondition for deletion — a bare `cargo build` of a leaf,
+  the standalone `check-rmw-*` projects, `cargo test` from the repo root, and
+  every hand-written `main` declare nothing and must still build. Deleting the
+  literal before W5.e's build-time failure would not make those declare; it
+  would make them fail.
+
+* **W5.g — measure and gate.** NOT MEASURED, and recorded as such rather than
+  estimated, per this phase's rule that no wave claims a saving it did not
+  measure.
+
+  The reason is specific. W5.d's 143,456 B was measured on
+  `examples/native/rust/talker`, a standalone pure-cargo leaf with no bringup
+  and no model — so nothing declares for it and this wave changes it by zero
+  bytes. The images this wave DOES change are the cmake-configured workspaces,
+  and those have no committed root `CMakeLists.txt`: the fixture builder
+  synthesises it, so measuring means a fixture build rather than a reconfigure.
+  That is the next session's first job, not an estimate to write down here.
+
+  What to run: `just build-test-fixtures lane=native`, then `just mem-report
+  --json --baseline` on a `workspaces/features` entry (declares
+  `param+lifecycle`, so 32 -> 19 slots) and a `workspaces/rust` one (declares
+  neither, so 32 -> 8). The gating property is that a role which declares
+  services keeps exactly what it declares. Confirm the delivery reached cargo at
+  the same time: `NROS_DECLARED_INFRA_QUERYABLES` must appear in the configure's
+  `build.ninja`, where today it does not.
 
 ### Open, and deliberately not assumed away
 
@@ -597,6 +676,15 @@ entry, and cannot declare — so under W5.e they cannot build. W2 has the same
 problem for the arena and proposes a runtime high-water mark plus a CI lane;
 queryables should ride that answer rather than invent a second one. This couples
 W5.e to W2's timing.
+
+**Nothing populates the model's service wiring.** `ros-launch-manifest` models
+it and the resolver never emits it: zero of 115 models here carry any layer-1
+wiring. Until something does, W5.b2's application term is a labelled guess and
+the sizing is exact only for the infrastructure half. Two ways out, and they are
+not equivalent: teach the resolver to describe endpoints (a `play_launch`
+question, and it can only describe what the launch inputs say), or count in code
+(the ground truth, and the real end state — see Future work above). This is the
+one that decides whether "sized by declaration" ever becomes "sized exactly".
 
 **`ZPICO_MAX_SESSIONS`** multiplies the pool and has no declaration path at all.
 Either it joins the model or it stays a knob and this phase says so explicitly.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -362,6 +362,171 @@ claims a saving it did not measure, the 27,760 B remains the originally reported
 figure and this wave contributes the triage plus the 22,580 B cross-check above,
 not a new saving.
 
+**W5 — queryable pools sized by declaration, not by guess.** Lever 1, and the
+largest single figure this phase has measured: 144,128 B on a native talker,
+39% of its static RAM, in service buffers for services it does not have.
+
+`ZPICO_MAX_QUERYABLES` decides that pool (it sizes `SERVICE_BUFFERS` as
+`ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES`, and the C shim's queryable table
+alongside). Its default is `if hosted { 32 } else { 8 }` — a literal chosen for
+headroom in `nros-zpico-build`, because at that point nothing knows the answer.
+Six inputs decide the right number and none of them meet: the app's service
+count (known only to the resolved model), the parameter services (6) and
+lifecycle services (5) (known only to `nros-node`, behind cargo features),
+`ZPICO_MAX_SESSIONS`, the hosted/embedded split, and the literal.
+
+### The shape
+
+One declaration site, two front-ends, one consumer.
+
+```
+                    system.toml + launch files
+                              |
+                       nros sync resolves
+                              |
+                    +---------v---------+
+                    |   SystemModel     |  app service-server count
+                    | (build artifact)  |  features = [param_services, lifecycle]
+                    +----+---------+----+
+              Rust entry |         | C/C++ entry
+            nros::main!  |         | nano_ros_entry()
+                         v         v
+                  one declared figure, delivered as env to cargo
+                              |
+                              v
+             nros-zpico-build  -- sizes --> C shim queryable table
+                               `- sizes --> SERVICE_BUFFERS (Rust pool)
+                                    ^
+                                    | adds, from nros-node
+                     PARAM_SERVICE_QUERYABLES / LIFECYCLE_SERVICE_QUERYABLES
+```
+
+DECLARED, from the model: how many service servers the application has, and
+whether the infrastructure services exist. DERIVED, from Rust: how many
+queryables each of those features costs. That split is what keeps issue 0460
+closed — codegen sees the user's entities and never the runtime's, so it must
+never own the second number.
+
+### Why not const generics
+
+Checked, because the W5 endgame in [phase
+391](phase-391-allocation-unification-and-tier-model.md) sized component cells
+exactly that way and the parallel is tempting. `SERVICE_BUFFERS` is a private
+`static mut`: no header, no `#[no_mangle]`, no `repr(C)`. C round-trips one
+opaque `*mut c_void` token (`session_index * ZPICO_MAX_QUERYABLES + local`) that
+it never does arithmetic on, and bounds its own handles against its own table.
+So the two tables are NOT layout-coupled — this is not the issue-0135 class, and
+a const generic would reach no non-Rust consumer.
+
+It is still the wrong tool. A const generic needs a TYPE to carry the bound. A
+Rust entry has one (`Node::ENTITY_BOUNDS`); a C/C++ entry does not — it is
+cmake-driven through `nano_ros_entry()`. Manufacturing one leaves two exits,
+both bad: a non-generic C entry point that picks some N (a hand-picked number
+again, which is the thing being removed), or a sizing parameter on the C API,
+which stops it being a thin wrapper of Rust.
+
+### The channel already exists
+
+`*_OPAQUE_U64S` is the established thin-wrapper channel and it runs Rust -> C:
+Rust owns the type, a build step computes `size_of`, a generated header carries
+the number, C declares opaque storage. This need runs the other way — the
+application declares, the backend consumes — which is the same direction W2's
+`NROS_ARENA_REQUIRED` needs.
+
+The delivery mechanism is proven, not hypothetical: phase-351 W5's
+`nros_resolve_board_facts` resolves facts through a CLI verb and attaches them
+with `corrosion_set_env_vars`, which reaches the cargo invocation where
+`set(ENV{...})` does not (issue 0460). A declared entity figure is one more fact
+on that path, and `nros ws model-dims` is the existing seam for asking the model
+a question from one implementation rather than a second one in cmake.
+
+Net C/C++ API change: none. No function, no parameter, no generic in a header.
+
+### Waves
+
+* **W5.a — the counts get one definition.** LANDED. They had seven spellings and
+  none was a definition; two were wrong, both saying lifecycle was 6 (it is 5,
+  so the widely-quoted "twelve slots before the application declares anything"
+  is eleven), including the message a user sees when the table overflows.
+  `check-infra-queryable-counts` ties each constant to the number of creation
+  sites, because a constant alone is still a hand-typed literal that drifts the
+  same way the prose did.
+
+* **W5.b — the model answers the question.** NEXT. A `nros ws` verb reports, per
+  entry, the declared service-server count and whether the infrastructure
+  features are on. One implementation, shared with cmake and the Rust macro
+  path, per the `model-dims` precedent.
+
+* **W5.c — delivery.** The figure rides the phase-351 W5 path to the backend's
+  build script. Both entry front-ends produce the same fact from the same model.
+
+* **W5.d — consumption.** LANDED. `nros-zpico-build` computes
+  `app_declared + PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES` and
+  sizes the C table and `SERVICE_BUFFERS` from ONE computation. Two sizings from
+  one number, not two numbers that must coincidentally agree.
+
+  MEASURED on `examples/native/rust/talker`, `nros-relwithdebinfo`, built twice
+  and diffed with `nros-mem-report --baseline`:
+
+  | | before | after | delta |
+  | --- | ---: | ---: | ---: |
+  | `SERVICE_BUFFERS` | 144,128 | 4,504 | **−139,624** |
+  | `g_sessions` | 24,480 | 20,640 | **−3,840** |
+  | RAM (.bss + .data) | 365,778 | 222,322 | **−143,456 (−39.2%)** |
+
+  The `g_sessions` line was NOT predicted and is the confirmation that matters:
+  the C shim's per-session `stored_queries[N][M]` and `last_reply_seq[N]` are
+  sized by the same knob, so one number really does size both sides. A design
+  that had left them independent would have moved only the Rust figure.
+
+  The rule is a pure function (`queryable_default_from`) with the environment
+  lifted out, because a build script reading env directly is untestable
+  in-process and a sizing rule verified by reading is how this phase's other
+  defects survived. Seven cases, including both refusals: a malformed count and
+  an unknown infrastructure spelling PANIC rather than falling back to
+  "undeclared", which is the `.max(1)` shape 0827 measured.
+
+  It introduces TWO deliberate mirrors — `nros-zpico-build` cannot depend on
+  `nros-node` to read the constants, nor see its features. `check-infra-queryable-counts`
+  holds them to the definitions, which is the entire difference between these and
+  the seven prose spellings W5.a replaced. Verified by drifting the lifecycle
+  mirror to its historical wrong value of 6 and watching the gate name the file.
+
+* **W5.e — an undeclared image fails loudly.** A bare `cargo build` of a leaf,
+  and the standalone `check-rmw-*` projects, have no model. They get a
+  build-time failure naming what to declare, not a generous default: this
+  issue's own `.max(1)` finding is the precedent — `ZPICO_MAX_LARGE_SUBSCRIBERS=0`
+  silently yields 1, so a config reads as satisfied while still reserving 64 KiB.
+  A fallback that quietly works is the shape this campaign keeps finding.
+
+* **W5.f — RETIREMENT, and this wave is not done without it.** Delete
+  `queryable_default`, its `if hosted { 32 } else { 8 }` literal and the
+  `CARGO_CFG_TARGET_OS` sniff behind it. `ZPICO_MAX_QUERYABLES` stops being the
+  primary input and becomes an OVERRIDE that must be `>=` the declared figure,
+  checked at build time rather than trusted. Two mechanisms for one number is
+  how this phase's other defects were born: leaving the guess in place "for
+  safety" would mean every image still pays it whenever the declaration fails to
+  arrive, which is exactly the silent-fallback shape W5.e refuses. Retirement is
+  a wave, not a cleanup, because the old path must be provably unreachable
+  before it is deleted — grep for readers, then delete, then re-measure.
+
+* **W5.g — measure and gate.** `just mem-report --json --baseline` delta on the
+  four native roles. The talker's expected figure is the whole 144,128 B minus
+  its own (zero) services and (zero) infrastructure. A role that declares
+  services keeps exactly what it declares, which is the property worth gating.
+
+### Open, and deliberately not assumed away
+
+**Hand-written `main`s.** They create entities at runtime, have no generated
+entry, and cannot declare — so under W5.e they cannot build. W2 has the same
+problem for the arena and proposes a runtime high-water mark plus a CI lane;
+queryables should ride that answer rather than invent a second one. This couples
+W5.e to W2's timing.
+
+**`ZPICO_MAX_SESSIONS`** multiplies the pool and has no declaration path at all.
+Either it joins the model or it stays a knob and this phase says so explicitly.
+It is currently 1 everywhere, which is why it has never been the visible term.
+
 ## Explicitly out of scope
 
 **Moving payload buffers to the heap.** It would convert `12 x 4 x 1024` of

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -452,10 +452,40 @@ Net C/C++ API change: none. No function, no parameter, no generic in a header.
   sites, because a constant alone is still a hand-typed literal that drifts the
   same way the prose did.
 
-* **W5.b — the model answers the question.** NEXT. A `nros ws` verb reports, per
-  entry, the declared service-server count and whether the infrastructure
-  features are on. One implementation, shared with cmake and the Rust macro
-  path, per the `model-dims` precedent.
+* **W5.b — the model answers the question.** SPLIT, after looking at what the
+  model actually contains. This wave was written assuming the resolved model
+  could answer both halves. It cannot, and the difference decides who can do
+  the work.
+
+  MEASURED — every resolved model in the tree
+  (`examples/*/build/nros/models/*/*.yaml`), full key set: `meta`, `structure`
+  (`scopes`, `nodes` -> `pkg`, `exec`, `node_name`, `params`, `remaps`,
+  `lifecycle_autostart`, `scope`), `execution` (`deploy`, `features`, `tiers`,
+  `bridges`, `bindings`). There is NO entity inventory: a node's publishers,
+  subscriptions and service servers appear nowhere.
+
+  * **W5.b1 — the infrastructure flags, available today.** `execution.features`
+    carries `param_services` and `lifecycle` verbatim, which is exactly the half
+    a build script cannot otherwise see (cargo exposes no other crate's
+    features). A `nros ws` verb reporting it, delivered by W5.c, lets the
+    consumer resolve `infra` for real and keeps only an app-side headroom
+    constant. On a talker that is 32 -> 8 slots, ~108,096 B of the 143,456 B
+    W5.d measured — most of the win, with one guess left instead of six.
+
+  * **W5.b2 — the application's own service-server count, NOT available.** Two
+    candidate sources and both need work this phase cannot assume:
+    - Extend the model. The resolver is `ros-launch-resolve` in the `play_launch`
+      repo (layer 2, RFC-0060) — a different repository, and the entity set is
+      not a launch-file concept, so this is a schema question, not a patch.
+    - Use the Rust `Node::ENTITY_BOUNDS`, which already declares
+      `service_servers` exactly. That works for the macro path and NOT for
+      C/C++, whose entities are created at runtime in C with no declaration
+      site — which is the same asymmetry that ruled const generics out above.
+      Solving it for one language only would reintroduce it.
+
+  Until W5.b2, the app term stays a constant. That is a smaller and honest
+  version of the same defect this wave exists to remove, and it should be
+  labelled as such in the code rather than presented as a derivation.
 
 * **W5.c — delivery.** The figure rides the phase-351 W5 path to the backend's
   build script. Both entry front-ends produce the same fact from the same model.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -148,6 +148,31 @@ What it costs, and why this is a wave rather than a decision:
 not they later share an arena, and a smaller worst case makes the sharing
 question cheaper to answer.
 
+**This REOPENS a question this document had closed, and the two texts must not
+be left disagreeing.** "Explicitly out of scope" below declines moving payload
+buffers to the heap, and it is the same move. Recorded 2026-08-29, on a rebase
+that brought the two into one file.
+
+The framing here is better — tier-gated rather than universal, aggregate peak
+rather than risk appetite, a wave rather than a decision — and it answers one of
+the two grounds the refusal rested on: an allocation that can fail mid-callback
+is confined to tiers that already admit an allocator.
+
+It does not answer the other, which is the stronger one. Sharing widens the
+arena's block-size range from infrastructure-only (~2^6) to payload-inclusive
+(~2^16), and that range is precisely what makes [phase
+391](phase-391-allocation-unification-and-tier-model.md)'s constant-time
+allocator sizeable. The refusal was not about whether pooling wastes RAM — it
+plainly does — but about the cost landing on the allocator that phase 391 is
+built around.
+
+So the question is live, not settled either way, and the deciding measurement is
+NAMED rather than argued: what the wider block-size range costs rlsf in control
+words and in its `1/SLLEN` bound, on a real image, against the aggregate-vs-sum
+saving it buys. Until that exists, neither section may be treated as the
+campaign's position, and lever 1 proceeds regardless — which both texts already
+agree on.
+
 ### C. Field storage mode does NOT shrink wire buffers — restated, because it keeps being proposed
 
 Lever 2 above already draws this distinction. Restating it as a decision record
@@ -692,7 +717,12 @@ It is currently 1 everywhere, which is why it has never been the visible term.
 
 ## Explicitly out of scope
 
-**Moving payload buffers to the heap.** It would convert `12 x 4 x 1024` of
+**Moving payload buffers to the heap.** REOPENED by amendment B above
+(2026-08-29) and no longer this campaign's settled position — read the two
+together, and see B for the measurement that decides it. The original reasoning
+stands as the case against, unchanged:
+
+It would convert `12 x 4 x 1024` of
 always-reserved RAM into peak-of-concurrent, which is a real saving, and it is
 declined deliberately. A statically provable buffer would become an allocation
 that can fail mid-callback, and it would widen the heap's block-size range from

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -472,20 +472,65 @@ Net C/C++ API change: none. No function, no parameter, no generic in a header.
     constant. On a talker that is 32 -> 8 slots, ~108,096 B of the 143,456 B
     W5.d measured — most of the win, with one guess left instead of six.
 
-  * **W5.b2 — the application's own service-server count, NOT available.** Two
-    candidate sources and both need work this phase cannot assume:
-    - Extend the model. The resolver is `ros-launch-resolve` in the `play_launch`
-      repo (layer 2, RFC-0060) — a different repository, and the entity set is
-      not a launch-file concept, so this is a schema question, not a patch.
-    - Use the Rust `Node::ENTITY_BOUNDS`, which already declares
-      `service_servers` exactly. That works for the macro path and NOT for
-      C/C++, whose entities are created at runtime in C with no declaration
-      site — which is the same asymmetry that ruled const generics out above.
-      Solving it for one language only would reintroduce it.
+  * **W5.b2 — the application's own service-server count.** AVAILABLE after all,
+    and needing no change to either resolver repo.
 
-  Until W5.b2, the app term stays a constant. That is a smaller and honest
-  version of the same defect this wave exists to remove, and it should be
-  labelled as such in the code rather than presented as a derivation.
+    The first draft of this wave said the count was missing and proposed
+    extending the model. That was wrong twice. `ros-launch-manifest` ALREADY
+    models it — `manifest.services` maps a service name to `ServiceWiring {
+    srv_type, server: Vec<String>, .. }`, where `server` lists the nodes serving
+    it, and rlm's own `service-wiring` validation rule already reasons over
+    `!svc.server.is_empty()`. A node's service-server count is the number of
+    services whose `server` contains it.
+
+    And extending the spec would have been the wrong move even if it had been
+    missing. **rlm is the platform-neutral SPEC; `play_launch` is its Linux
+    implementation; neither may carry nano-ros concerns.** Service wiring is a
+    general ROS graph concept, exactly like topic wiring. A static-RAM sizing
+    rule is not, and stays here: reading the model and turning it into a
+    queryable count is nano-ros's build layer, not the manifest's business.
+
+    This also closes W5.b1's open caveat structurally rather than empirically.
+    `ServiceWiring::server` carries `skip_serializing_if = "Vec::is_empty"`, the
+    same pattern as `execution.features` — so *absent means empty* by
+    construction, not merely in the 115 models that happen to be in the tree.
+
+    The reason no model here shows a `services:` section is that none of the
+    example workspaces declare any, not that the spec lacks it.
+
+  ### `services[].server` is AUTHORITATIVE
+
+  DECIDED. The launch declaration is the contract: an image is sized for exactly
+  the service servers its model declares.
+
+  The alternative was to treat it as a floor and add headroom, which is safe and
+  wrong — it re-creates in miniature the guess this whole wave exists to delete,
+  and a guess derived from something real is still a guess nobody can audit.
+
+  What being authoritative COSTS, and it must be paid in the same wave: a node
+  that creates a service server its model does not declare will exhaust the
+  table. Sized exactly, that is issue 0460's failure reached from a new
+  direction, so the runtime must report it as what it is — "this node created an
+  undeclared service server" — and not as the bare exhausted-table error 0460
+  spent a phase making legible. The declaration being wrong and the table being
+  too small are the same event now, and the message must say the first.
+
+  ### Future work: counting in code
+
+  The declaration is a stepping stone, not the destination. The count a node's
+  CODE actually produces is the ground truth, and deriving it there would make
+  the launch declaration checkable rather than trusted — the same move W5.a made
+  for the infrastructure counts, where a constant beside the creation sites
+  replaced seven prose spellings and a gate holds it to the sites themselves.
+
+  Out of scope for W5 and deliberately not designed here: it needs the entity
+  set to be visible at build time in BOTH languages, which is the asymmetry that
+  ruled out const generics (`Node::ENTITY_BOUNDS` exists for Rust; C/C++
+  entities are created at runtime in C with no declaration site). Solving that
+  is the real end state; W5 gets the saving without waiting for it.
+
+  Until W5.b1/W5.b2 land, the app term stays a constant in the consumer, and it
+  is labelled as one in the code rather than presented as a derivation.
 
 * **W5.c — delivery.** The figure rides the phase-351 W5 path to the backend's
   build script. Both entry front-ends produce the same fact from the same model.

--- a/justfile
+++ b/justfile
@@ -3902,7 +3902,20 @@ ci-l3: rust-rtos-link-check
         echo "    (`just setup freertos` / `just setup nuttx`) or this lane proves nothing." >&2
         exit 1
     fi
-    echo "L3 passed — $checked cross ELF(s) checked without booting anything."
+    # phase-391 W1/W4 (issues 0816/0843) — the heap-free tier, on a REAL image.
+    # `heap-free-poc-mps2` calls `Executor::open_in` + `install_node_typed_in`
+    # over per-class static storage and links with NO allocation symbol at all
+    # (no `#[global_allocator]`, no `malloc`, no `nros_platform_alloc`). Three
+    # earlier probes passed this gate vacuously at `symbols read: 1`; this one
+    # reads the full symbol table of a linked image (~460). The build doubles
+    # as issue 0843's tripwire: the leaf compiles `nros` WITHOUT the `alloc`
+    # feature, so re-coupling the macro-path runtime to `alloc` breaks it.
+    echo "== L3 — heap-free tier: link gate on the no-alloc image =="
+    (cd packages/testing/nros-tests/bins/heap-free-poc-mps2 \
+        && cargo build $(nros_cargo_profile_arg_string))
+    python3 scripts/check-no-alloc-image.py --tier heap-free \
+        "packages/testing/nros-tests/bins/heap-free-poc-mps2/target/thumbv7m-none-eabi/$(nros_cargo_target_profile_dir)/heap-free-poc-mps2"
+    echo "L3 passed — $checked cross ELF(s) checked without booting anything, and the heap-free image links clean."
 
 # A COMPILE SMOKE TEST for the pull-request gate — phase-395.
 #

--- a/justfile
+++ b/justfile
@@ -494,6 +494,7 @@ check-fast-serial: _check-skip-reset \
     check-ci-image-python-deps check-kconfig-overridden-values \
     check-platform-abi-mirror check-abi-bindings check-board-abi-mirror check-board-manifest-drift check-profile-board-mirror check-example-matrix \
     check-no-direct-kernel-alloc check-no-allow-multiple-def check-no-board-init check-weak-symbols \
+    check-infra-queryable-counts \
     check-rmw-force-link-anchor check-rmw-required-slots check-rmw-slot-table check-board-tiers check-tier-priority-plan \
     check-subtree-guard \
     check-leaf-lockfiles check-submodule-pinned-locks check-msg-dep-is-path check-cargo-locked check-no-tracked-models check-generated-schema-coverage \
@@ -1892,6 +1893,14 @@ check-cpp-freestanding-includes:
 [private]
 check-weak-symbols:
     @bash scripts/check-weak-symbols.sh
+
+# Issue 0827 — the infrastructure-queryable counts have ONE definition each,
+# tied to the number of servers actually created. A service server IS a zenoh
+# queryable, so these are a term in every service-buffer pool the RMW sizes;
+# they had SEVEN spellings and no definition, two of them already wrong.
+[private]
+check-infra-queryable-counts:
+    @python3 scripts/check-infra-queryable-counts.py
 
 # Phase 176.3 — verify the orchestration generator's PlatformProfile
 # board-crate references match the actual board crates (existence +

--- a/packages/api/nros/Cargo.toml
+++ b/packages/api/nros/Cargo.toml
@@ -76,6 +76,7 @@ std = [
     "nros-serdes/std",
 ]
 alloc = [
+    "dep:portable-atomic-util",
     "nros-core/alloc",
     "nros-node/alloc",
     "nros-rmw/alloc",
@@ -226,7 +227,11 @@ nros-serdes = { version = "0.5.0", path = "../../core/nros-serdes", default-feat
 # decl_err_from_node's no_std diagnostic (std builds use eprintln!).
 log = { version = "0.4", default-features = false }
 portable-atomic = { version = "1", default-features = false }
-portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"] }
+# W5-endgame (issue 0843) — OPTIONAL and carried by the `alloc` feature:
+# only `node_runtime`'s alloc-gated dynamic half (`CellHandle::Pooled`)
+# names `Arc`, and the dep's own "alloc" feature links the `alloc` crate,
+# which demands a global allocator in every downstream image.
+portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
 paste = "1"
 
 [dev-dependencies]

--- a/packages/api/nros/src/node_runtime.rs
+++ b/packages/api/nros/src/node_runtime.rs
@@ -50,6 +50,11 @@
 
 #![cfg(feature = "rmw-cffi")]
 
+// W5-endgame (issue 0843): the DECLARATION is gated too — a bare
+// `extern crate alloc` links the alloc crate into every image and rustc then
+// demands a `#[global_allocator]` even when nothing here allocates. This line
+// is what kept the first heap-free-tier image from linking.
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "alloc")]

--- a/packages/cli/nros-cli-core/src/cmd/entity_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_facts.rs
@@ -1,0 +1,315 @@
+//! phase-392 W5.b/W5.c — the entity figures a backend must size its tables
+//! from, resolved from the declaration and printed as env lines.
+//!
+//! Sibling of [`crate::cmd::board_facts`], and deliberately shaped like it: one
+//! resolution, one implementation, delivered through the process environment
+//! because that is the only carrier that reaches the cargo invocation a
+//! workspace member is built by (issue 0460, phase-349 W2.0).
+//!
+//! **What it answers.** `ZPICO_MAX_QUERYABLES` sizes `SERVICE_BUFFERS` (as
+//! `ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES`) and the C shim's per-session
+//! queryable table. Its default was `if hosted { 32 } else { 8 }` — a literal
+//! picked for headroom in `nros-zpico-build`, because nothing at that point
+//! knows the answer. It cost a native talker 144,128 B of service buffers for
+//! services it does not have. Two halves decide the real number and this verb
+//! carries both:
+//!
+//! * `NROS_DECLARED_SERVICE_SERVERS` — the APPLICATION's own count, from the
+//!   model's `structure.services` / `structure.actions` wiring. An action
+//!   server is three services on the wire, so actions multiply.
+//! * `NROS_DECLARED_INFRA_QUERYABLES` — whether the ROS parameter services and
+//!   the REP-2002 lifecycle services are in the image, from
+//!   `execution.features`. This is the half a build script cannot see any other
+//!   way: cargo exposes no other crate's features.
+//!
+//! The consumer adds the infrastructure COST (`PARAM_SERVICE_QUERYABLES`,
+//! `LIFECYCLE_SERVICE_QUERYABLES`, both defined beside the code that creates
+//! them). This verb never states those numbers — it says which features are on,
+//! not what they cost, which is the split that keeps issue 0460 closed.
+//!
+//! **Why the model and not a knob.** The launch declaration is the contract
+//! (phase-392 W5.b2). A floor-plus-headroom rule would re-create in miniature
+//! the guess this wave exists to delete, and a guess derived from something
+//! real is still a guess nobody can audit.
+
+use std::{collections::BTreeMap, path::PathBuf};
+
+use clap::Args as ClapArgs;
+use eyre::{Result, WrapErr, bail};
+use ros_launch_manifest_model::SystemModel;
+
+/// One action server is three zenoh queryables (`send_goal`, `cancel_goal`,
+/// `get_result`; feedback and status are topics).
+///
+/// MIRROR of `nros_node::executor::action::ACTION_SERVER_QUERYABLES`, held to
+/// its definition by `check-infra-queryable-counts`. The CLI cannot depend on
+/// `nros-node` — that crate is `no_std`, platform-gated and built for the
+/// target, not the host — so the number is restated here and gated, which is
+/// the whole difference between this and the seven prose spellings issue 0827
+/// found.
+const ACTION_SERVER_QUERYABLES: usize = 3;
+
+#[derive(Debug, ClapArgs)]
+pub struct EntityFactsArgs {
+    /// Resolved SystemModel to read. Mutually exclusive with `--bringup-dir`.
+    #[arg(long, value_name = "PATH")]
+    pub model: Option<PathBuf>,
+
+    /// The bringup package DIRECTORY, addressed the way `nano_ros_entry(LAUNCH
+    /// …)` and `nros::main!(launch = …)` address it. The model path is derived
+    /// by `nros_orchestration_ir::model_location`, never spelled here.
+    #[arg(long = "bringup-dir", value_name = "DIR", conflicts_with = "model")]
+    pub bringup_dir: Option<PathBuf>,
+
+    /// Launch file relative to `<bringup>/launch/`. Defaults to the bringup's
+    /// `[system] default_launch`.
+    #[arg(long, value_name = "FILE", requires = "bringup_dir")]
+    pub launch: Option<String>,
+
+    /// Launch argument binding `key=value` (repeatable), for an arg-bound
+    /// model variant.
+    #[arg(long = "arg", value_name = "K=V", requires = "bringup_dir")]
+    pub args: Vec<String>,
+}
+
+/// The two facts, in emission order.
+///
+/// A pure function over the model, with file IO and the environment lifted out:
+/// a sizing rule verified by reading is how this campaign's other defects
+/// survived (phase-392 W5.d).
+pub fn facts_from_model(model: &SystemModel) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    if let Some(n) = declared_service_servers(model) {
+        out.insert("NROS_DECLARED_SERVICE_SERVERS".to_string(), n.to_string());
+    }
+    out.insert(
+        "NROS_DECLARED_INFRA_QUERYABLES".to_string(),
+        declared_infra(model).to_string(),
+    );
+    out
+}
+
+/// Whether this model DESCRIBES the graph's wiring at all.
+///
+/// MEASURED, and it corrects this wave twice over: `ros-launch-manifest` models
+/// service wiring (`structure.services` -> `ServiceWiring { server, .. }`), but
+/// ZERO of the 115 resolved models in this tree carry any layer-1 wiring —
+/// no `topics`, no `services`, no `actions`. A plain `<node>` launch file names
+/// a node; it does not say what that node serves, and nothing else in the
+/// resolver's inputs does either.
+///
+/// So an absent `services` map does NOT mean "this system has no service
+/// servers". `examples/workspaces/c`'s `service_server_model.yaml` describes a
+/// node called `add_server` and carries no `services` key at all. Reporting 0
+/// there would size the table to the infrastructure alone and exhaust it the
+/// moment the node registers — a confident wrong number, sized exactly, which
+/// is the failure shape this campaign keeps finding rather than a new one.
+///
+/// The discriminator is whether ANY wiring was described. If it was, an empty
+/// `services` map is a real zero. If nothing was, the question is unanswered
+/// and this verb says nothing rather than guessing.
+fn describes_wiring(model: &SystemModel) -> bool {
+    !model.structure.topics.is_empty()
+        || !model.structure.services.is_empty()
+        || !model.structure.actions.is_empty()
+}
+
+/// Every service server the model declares, counted as QUERYABLES.
+///
+/// `ServiceWiring::server` lists the endpoint refs serving a service
+/// (`"<node FQN>/<endpoint>"`), so the count is the number of refs, not the
+/// number of services: two nodes serving the same name are two queryables.
+///
+/// Actions are the same wiring type in a separate map and cost
+/// [`ACTION_SERVER_QUERYABLES`] each.
+///
+/// The whole model is counted rather than one node's share: an entry image
+/// realizes its model, and the queryable table is per SESSION, which the image
+/// has one of.
+fn declared_service_servers(model: &SystemModel) -> Option<usize> {
+    if !describes_wiring(model) {
+        return None;
+    }
+    let services: usize = model
+        .structure
+        .services
+        .values()
+        .map(|s| s.server.len())
+        .sum();
+    let actions: usize = model
+        .structure
+        .actions
+        .values()
+        .map(|a| a.server.len())
+        .sum();
+    Some(services + actions * ACTION_SERVER_QUERYABLES)
+}
+
+/// Which infrastructure service families the image carries.
+///
+/// UNKNOWN feature names are ignored on purpose. `execution.features` is an
+/// open axis — `safety` is in the tree today and is not a queryable question —
+/// so a name this verb does not recognise means "not one of mine", never an
+/// error. The consumer refuses an unknown SPELLING of this verb's own output,
+/// which is a different thing: that would be a broken channel, not an
+/// unrelated feature.
+fn declared_infra(model: &SystemModel) -> &'static str {
+    let has = |name: &str| model.execution.features.iter().any(|f| f == name);
+    match (has("param_services"), has("lifecycle")) {
+        (true, true) => "param+lifecycle",
+        (true, false) => "param",
+        (false, true) => "lifecycle",
+        (false, false) => "none",
+    }
+}
+
+pub fn run(args: EntityFactsArgs) -> Result<()> {
+    let model_path = match (&args.model, &args.bringup_dir) {
+        (Some(m), _) => m.clone(),
+        (None, Some(b)) => {
+            let bringup = b
+                .canonicalize()
+                .wrap_err_with(|| format!("bringup dir `{}`", b.display()))?;
+            let mut launch_args: Vec<(String, String)> = Vec::new();
+            for kv in &args.args {
+                let Some((k, v)) = kv.split_once('=') else {
+                    bail!("--arg takes `key=value`, got `{kv}`");
+                };
+                launch_args.push((k.to_string(), v.to_string()));
+            }
+            let rel = nros_orchestration_ir::model_location::launch_to_model_rel(
+                &bringup,
+                args.launch.as_deref(),
+                &launch_args,
+            )
+            .map_err(|e| eyre::eyre!(e))?;
+            nros_orchestration_ir::model_location::resolve_model_path(&bringup, &rel)
+        }
+        (None, None) => bail!("entity-facts needs --model <path> or --bringup-dir <dir>"),
+    };
+
+    let model = crate::orchestration::model_ingest::load_model(&model_path)?;
+    for (k, v) in facts_from_model(&model) {
+        println!("{k}={v}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(yaml: &str) -> SystemModel {
+        SystemModel::from_yaml_str(yaml).expect("test model parses")
+    }
+
+    const EMPTY: &str = "meta:\n  version: 1\nstructure: {}\n";
+
+    #[test]
+    fn a_model_that_describes_no_wiring_abstains_on_the_app_count() {
+        // NOT zero. All 115 models in this tree are this shape, including one
+        // whose only node is called `add_server`.
+        let m = model(EMPTY);
+        assert_eq!(declared_service_servers(&m), None);
+        assert_eq!(declared_infra(&m), "none");
+        let f = facts_from_model(&m);
+        assert!(!f.contains_key("NROS_DECLARED_SERVICE_SERVERS"));
+        // The infrastructure half is still answered — that is W5.b1, and it is
+        // the half a build script cannot see any other way.
+        assert_eq!(f["NROS_DECLARED_INFRA_QUERYABLES"], "none");
+    }
+
+    #[test]
+    fn wiring_described_with_no_service_server_is_a_real_zero() {
+        // A model that describes topics has been through a resolver that
+        // describes wiring, so an empty `services` map means what it says.
+        let m = model(
+            "meta:\n  version: 1\nstructure:\n  topics:\n    /chatter:\n      type: std_msgs/msg/String\n\
+             \n      pub: [\"/a/chatter\"]\n",
+        );
+        assert_eq!(declared_service_servers(&m), Some(0));
+        assert_eq!(facts_from_model(&m)["NROS_DECLARED_SERVICE_SERVERS"], "0");
+    }
+
+    #[test]
+    fn service_servers_are_counted_per_endpoint_not_per_service() {
+        // Two nodes serving the same service name are two queryables. Counting
+        // the map's keys would say one and under-size the table.
+        let m = model(
+            "meta:\n  version: 1\nstructure:\n  services:\n    /add:\n      type: example/srv/Add\n\
+             \n      server: [\"/a/add\", \"/b/add\"]\n",
+        );
+        assert_eq!(declared_service_servers(&m), Some(2));
+    }
+
+    #[test]
+    fn a_client_only_service_costs_no_queryable() {
+        let m = model(
+            "meta:\n  version: 1\nstructure:\n  services:\n    /add:\n      type: example/srv/Add\n\
+             \n      client: [\"/a/add\"]\n",
+        );
+        assert_eq!(declared_service_servers(&m), Some(0));
+    }
+
+    #[test]
+    fn an_action_server_costs_three() {
+        let m = model(
+            "meta:\n  version: 1\nstructure:\n  actions:\n    /fib:\n      type: example/action/Fib\n\
+             \n      server: [\"/a/fib\"]\n",
+        );
+        assert_eq!(declared_service_servers(&m), Some(ACTION_SERVER_QUERYABLES));
+    }
+
+    #[test]
+    fn services_and_actions_add() {
+        let m = model(
+            "meta:\n  version: 1\nstructure:\n  services:\n    /add:\n      type: example/srv/Add\n\
+             \n      server: [\"/a/add\"]\n  actions:\n    /fib:\n      type: example/action/Fib\n\
+             \n      server: [\"/a/fib\"]\n",
+        );
+        assert_eq!(
+            declared_service_servers(&m),
+            Some(1 + ACTION_SERVER_QUERYABLES)
+        );
+    }
+
+    #[test]
+    fn infra_reads_both_flags_independently() {
+        let f = |feats: &str| {
+            let m = model(&format!(
+                "meta:\n  version: 1\nstructure: {{}}\nexecution:\n  features:\n{feats}"
+            ));
+            declared_infra(&m)
+        };
+        assert_eq!(f("  - param_services\n  - lifecycle\n"), "param+lifecycle");
+        assert_eq!(f("  - param_services\n"), "param");
+        assert_eq!(f("  - lifecycle\n"), "lifecycle");
+    }
+
+    #[test]
+    fn an_unrecognised_feature_is_not_an_error_and_not_a_queryable() {
+        // `safety` is a real feature in this tree and has nothing to do with
+        // queryables. A verb that refused it would break every safety
+        // workspace to answer a question it was not asked.
+        let m = model("meta:\n  version: 1\nstructure: {}\nexecution:\n  features:\n  - safety\n");
+        assert_eq!(declared_infra(&m), "none");
+        let m = model(
+            "meta:\n  version: 1\nstructure: {}\nexecution:\n  features:\n  - safety\n  - lifecycle\n",
+        );
+        assert_eq!(declared_infra(&m), "lifecycle");
+    }
+
+    #[test]
+    fn the_emitted_shape_is_exactly_what_the_consumer_reads() {
+        // `nros-zpico-build::queryable_default_from` reads these two names and
+        // PANICS on a spelling it does not know, so the pair is a contract.
+        let m = model(
+            "meta:\n  version: 1\nstructure:\n  services:\n    /add:\n      type: example/srv/Add\n\
+             \n      server: [\"/a/add\"]\nexecution:\n  features:\n  - lifecycle\n",
+        );
+        let f = facts_from_model(&m);
+        assert_eq!(f["NROS_DECLARED_SERVICE_SERVERS"], "1");
+        assert_eq!(f["NROS_DECLARED_INFRA_QUERYABLES"], "lifecycle");
+        assert_eq!(f.len(), 2);
+    }
+}

--- a/packages/cli/nros-cli-core/src/cmd/mod.rs
+++ b/packages/cli/nros-cli-core/src/cmd/mod.rs
@@ -22,6 +22,7 @@ pub mod completions;
 pub mod config;
 pub mod doctor;
 pub mod emit_package_xml;
+pub mod entity_facts;
 pub mod explain;
 pub mod generate;
 pub mod generate_px4;

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -99,6 +99,18 @@ pub enum Sub {
     #[command(name = "board-facts")]
     BoardFacts(crate::cmd::board_facts::BoardFactsArgs),
 
+    /// phase-392 W5.b/W5.c — print the ENTITY figures a backend sizes its
+    /// tables from (`NROS_DECLARED_SERVICE_SERVERS`,
+    /// `NROS_DECLARED_INFRA_QUERYABLES`), as `KEY=VALUE` lines, for whoever is
+    /// about to invoke cargo.
+    ///
+    /// Same delivery seam and same reason as `board-facts`: the process
+    /// environment is the only carrier that reaches a workspace member's cargo
+    /// invocation (issue 0460). Different QUESTION — this one is answered by
+    /// the resolved SystemModel, not by the board.
+    #[command(name = "entity-facts")]
+    EntityFacts(crate::cmd::entity_facts::EntityFactsArgs),
+
     /// phase-348 W1 — list packages that announce a provision
     /// (`<export><nano_ros_provides kind="rmw" name="zenoh"/></export>`),
     /// across the search path: the nano-ros tree, then this workspace.
@@ -375,6 +387,7 @@ pub fn run(args: Args) -> Result<()> {
         Sub::ModelDims(a) => run_model_dims(a),
         Sub::CheckBoardProjections(a) => run_check_board_projections(a),
         Sub::BoardFacts(a) => crate::cmd::board_facts::run(a),
+        Sub::EntityFacts(a) => crate::cmd::entity_facts::run(a),
         Sub::Providers(a) => run_providers(a),
         Sub::Order(a) => run_order(a),
     }

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -86,6 +86,23 @@ fn main() {
     // `NROS_EXECUTOR_MAX_SHUTDOWN_CBS` (or `CONFIG_NROS_EXECUTOR_MAX_SHUTDOWN_CBS`
     // on Zephyr) when an image genuinely has more things to park.
     let max_shutdown_cbs = env_usize("NROS_EXECUTOR_MAX_SHUTDOWN_CBS", 2);
+    // issue 0900 — how many of the MAX_CBS slots may hold an ACTION CLIENT,
+    // the entity the arena derivation below budgets every slot at.
+    //
+    // Defaults to `max_cbs`, which reproduces the old `max_cbs * worst_case`
+    // arithmetic byte for byte, so no existing image moves. It is a COUNT and
+    // not a "which entity is heaviest" enum because Kconfig knobs are ints and
+    // `knob_usize` is the one spelling that reaches the Zephyr Rust lane
+    // (issue 0460); an enum would need a second reader shape for no gain.
+    //
+    // Setting it to 0 on a pub/sub-only image is the whole point: 74,240 bytes
+    // becomes 16,384 at the defaults, and that arena is INLINE ON THE TASK
+    // STACK, not in `.bss`.
+    //
+    // Too small fails at REGISTRATION (`NodeError::BufferTooSmall`), not at
+    // link — same caveat `NROS_EXECUTOR_ARENA_SIZE` carries, and the reason
+    // `Executor::arena_used()` plus the first-spin advisory landed first.
+    let action_clients = env_usize("NROS_EXECUTOR_ACTION_CLIENTS", max_cbs).min(max_cbs);
 
     // --- Derived arena size ---
     // Arena must hold MAX_CBS entries. Worst-case entry is an
@@ -112,10 +129,20 @@ fn main() {
     const ACTION_CLIENT_SUB_OVERHEAD: usize = 1536;
     const ARENA_BASE_OVERHEAD: usize = 2048;
     const ARENA_FLOOR: usize = 8192;
-    let per_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
+    // issue 0900 — the budget for the two entry SHAPES, summed over how many
+    // slots each may occupy, instead of charging every slot the larger one.
+    // With `action_clients == max_cbs` (the default) the second term is zero
+    // and this is byte-identical to the old formula.
+    const PUBSUB_SUB_BUFS: usize = 3;
+    const PUBSUB_ENTRY_OVERHEAD: usize = 512;
+    let action_client_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
         + ACTION_CLIENT_FEEDBACK_SUBS * rx_buf_size
         + ACTION_CLIENT_SUB_OVERHEAD;
-    let derived_arena = (max_cbs * per_entry + ARENA_BASE_OVERHEAD).max(ARENA_FLOOR);
+    let pubsub_entry = PUBSUB_SUB_BUFS * rx_buf_size + PUBSUB_ENTRY_OVERHEAD;
+    let derived_arena = (action_clients * action_client_entry
+        + max_cbs.saturating_sub(action_clients) * pubsub_entry
+        + ARENA_BASE_OVERHEAD)
+        .max(ARENA_FLOOR);
     // `0` is the Kconfig SENTINEL for "derive it" (zephyr/Kconfig:
     // NROS_EXECUTOR_ARENA_SIZE, "0 = derive"), and it has to be honoured HERE,
     // where the value is consumed.
@@ -145,8 +172,14 @@ fn main() {
          (set via NROS_EXECUTOR_MAX_SC, default 8). Phase 110.B.\n\
          pub const MAX_SC: usize = {max_sc};\n\
          \n\
-         /// Executor arena size in bytes (derived from MAX_CBS and RX_BUF_SIZE).\n\
+         /// Executor arena size in bytes (derived from MAX_CBS, RX_BUF_SIZE \
+         and ACTION_CLIENTS).\n\
          pub const ARENA_SIZE: usize = {arena_size};\n\
+         \n\
+         /// How many callback slots the arena derivation budgeted at \
+         ActionClient size (set via NROS_EXECUTOR_ACTION_CLIENTS, default \
+         MAX_CBS). Issue 0900.\n\
+         pub const ARENA_ACTION_CLIENTS: usize = {action_clients};\n\
          \n\
          /// Default subscription receive buffer size in bytes \
          (set via NROS_SUBSCRIPTION_BUFFER_SIZE, default 1024).\n\

--- a/packages/core/nros-node/src/executor/action.rs
+++ b/packages/core/nros-node/src/executor/action.rs
@@ -30,6 +30,21 @@ use super::{
     },
 };
 
+/// phase-392 W5.b2 — how many zenoh queryables ONE action server costs.
+///
+/// An action is three services on the wire (`send_goal`, `cancel_goal`,
+/// `get_result`; the feedback and status channels are topics, not queryables),
+/// so a launch file declaring one action server is declaring THREE entries in
+/// the backend's queryable table. A consumer sizing that table from a model
+/// must multiply, and this is the multiplier.
+///
+/// Defined here rather than in the consumer for the reason issue 0827 measured:
+/// a count restated where it cannot be derived drifts from the code that
+/// decides it. `check-infra-queryable-counts` ties this to the distinct
+/// `create_service` calls below, so adding a fourth action channel fails the
+/// gate instead of silently under-sizing every image that declares an action.
+pub const ACTION_SERVER_QUERYABLES: usize = 3;
+
 // ============================================================================
 // Raw action registration specs
 // ============================================================================

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -398,9 +398,17 @@ fn report_arena_headroom(used: usize, capacity: usize) {
     // keep it a multiple of 1024 because that is the unit the knob is written
     // in everywhere else in the tree.
     let suggest = used.next_multiple_of(1024).max(1024);
+    // BUDGET: `nros_log`'s call-site format buffer is 256 bytes by default
+    // (`buffer-size-256`), and overflow truncates with a `…` rather than
+    // dropping the record. The first draft of this line ran ~450 bytes and was
+    // cut mid-number, so the sink received "executor arena is 74240 bytes and
+    // 32…" — every word of the explanation and NONE of the value to set. A
+    // diagnostic that explains itself past the budget delivers exactly the
+    // folklore it was written to replace. So: the actionable value FIRST, the
+    // reasoning in this comment and issue 0900, and a test that fails on `…`.
     nros_log::nros_info!(
         nros_log::get_logger("nros"),
-        "executor arena is {capacity} bytes and {used} are claimed at first          spin. ARENA_SIZE budgets every slot at the ActionClient worst case, so          an image without one over-provisions; the arena is INLINE ON THE TASK          STACK, so this is stack headroom, not .bss. Set          NROS_EXECUTOR_ARENA_SIZE={suggest} (Zephyr:          CONFIG_NROS_EXECUTOR_ARENA_SIZE) if nothing registers after this point          — entities created later need their own room (issue 0900)"
+        "arena over-provisioned: set NROS_EXECUTOR_ARENA_SIZE={suggest}          (Zephyr: CONFIG_ prefix). {used}/{capacity} bytes claimed at first          spin, and the arena is INLINE ON THE TASK STACK. Later registrations          need more. issue 0900"
     );
 }
 

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -432,6 +432,39 @@ pub(crate) fn maybe_report_arena_headroom(used: usize, capacity: usize) {
     }
 }
 
+/// Say WHY a registration ran out of arena, once.
+///
+/// `NodeError::BufferTooSmall` is the same code a dozen other paths return, so
+/// on a target where a return code is all you get, exhaustion here is
+/// indistinguishable from a message that did not fit a receive buffer. This
+/// names the two knobs that actually govern it and the numbers involved.
+///
+/// The counterpart to [`report_arena_headroom`], and the reason lowering
+/// `NROS_EXECUTOR_ACTION_CLIENTS` is safe to suggest: too small fails at
+/// REGISTRATION rather than at link, so the failure has to say so itself.
+///
+/// One-shot for the same reason the advisory is — the numbers do not change
+/// between registrations, and a per-registration line on an RTOS target is a
+/// flood (issue 0371's shape). `nros_log`, never stdio (issue 0589), and inside
+/// the 256-byte format budget that truncated the first advisory.
+#[cold]
+pub(crate) fn report_arena_exhausted(want: usize, used: usize, capacity: usize) {
+    if ARENA_EXHAUSTED_REPORTED.swap(true, portable_atomic::Ordering::Relaxed) {
+        return;
+    }
+    nros_log::nros_error!(
+        nros_log::get_logger("nros"),
+        "arena exhausted: {want} more bytes needed, {used}/{capacity} in use. \
+         Raise NROS_EXECUTOR_ARENA_SIZE, or NROS_EXECUTOR_ACTION_CLIENTS if \
+         this image registers action clients. issue 0900"
+    );
+}
+
+/// One-shot latch for [`report_arena_exhausted`]. A static for the reason
+/// [`DROPPED_TAKES`] is one.
+static ARENA_EXHAUSTED_REPORTED: portable_atomic::AtomicBool =
+    portable_atomic::AtomicBool::new(false);
+
 /// Is this arena grossly larger than what registered in it?
 ///
 /// Half is the threshold because the derivation's own error is a factor of
@@ -454,6 +487,55 @@ pub(crate) const fn arena_is_over_provisioned(used: usize, capacity: usize) -> b
 #[cfg(test)]
 mod arena_headroom_tests {
     use super::arena_is_over_provisioned;
+    use crate::config::{ARENA_ACTION_CLIENTS, ARENA_SIZE, DEFAULT_RX_BUF_SIZE, MAX_CBS};
+
+    /// issue 0900 — the per-kind derivation must reproduce the OLD
+    /// `max_cbs * action_client_entry + base` arithmetic byte for byte when
+    /// every slot is still budgeted at ActionClient size, which is the default.
+    ///
+    /// This is the compatibility gate: the knob exists so an image CAN shrink
+    /// its arena, not so every image silently does. A change here that moves
+    /// the default is a change to every image's stack frame.
+    #[test]
+    fn the_default_derivation_is_unchanged() {
+        if ARENA_ACTION_CLIENTS != MAX_CBS {
+            // The test build set the knob; the identity below is not the claim
+            // being made then. Fail rather than pass vacuously.
+            panic!(
+                "this test asserts the DEFAULT derivation, but \
+                 NROS_EXECUTOR_ACTION_CLIENTS was set to {ARENA_ACTION_CLIENTS} \
+                 against MAX_CBS {MAX_CBS}"
+            );
+        }
+        const ACTION_CLIENT_PER_SERVICE: usize = 4096 + 384;
+        const ACTION_CLIENT_SERVICES: usize = 3;
+        const ACTION_CLIENT_FEEDBACK_SUBS: usize = 3;
+        const ACTION_CLIENT_SUB_OVERHEAD: usize = 1536;
+        const ARENA_BASE_OVERHEAD: usize = 2048;
+        const ARENA_FLOOR: usize = 8192;
+
+        let per_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
+            + ACTION_CLIENT_FEEDBACK_SUBS * DEFAULT_RX_BUF_SIZE
+            + ACTION_CLIENT_SUB_OVERHEAD;
+        let want = (MAX_CBS * per_entry + ARENA_BASE_OVERHEAD).max(ARENA_FLOOR);
+        assert_eq!(
+            ARENA_SIZE, want,
+            "the per-kind derivation moved the default arena; every image's \
+             task-stack frame moves with it (issue 0900)"
+        );
+    }
+
+    /// The advisory must actually fire for the shipped defaults — otherwise W1
+    /// installed a diagnostic that is dead on the very configuration that
+    /// needs it. A timer-only executor claims 32 bytes against ARENA_SIZE.
+    #[test]
+    fn the_shipped_default_arena_trips_the_advisory() {
+        assert!(
+            arena_is_over_provisioned(32, ARENA_SIZE),
+            "a timer-only executor must trip the advisory at the shipped \
+             defaults; ARENA_SIZE is {ARENA_SIZE}"
+        );
+    }
 
     #[test]
     fn gross_over_provision_is_reported() {

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -358,6 +358,126 @@ pub(crate) struct SubBufferedEntry<M, F> {
 /// The cost is that the report cannot name the topic — see `report_dropped_take`.
 static DROPPED_TAKES: portable_atomic::AtomicU32 = portable_atomic::AtomicU32::new(0);
 
+/// issue 0900 — has the arena-headroom advisory been emitted?
+///
+/// A STATIC, for the reason [`DROPPED_TAKES`] is one: an `Executor` field would
+/// move `EXECUTOR_OPAQUE_U64S` and therefore every image's executor footprint,
+/// to buy a diagnostic. Process-scoped rather than per-executor is also the
+/// RIGHT scope here, not merely the cheap one — the number this names
+/// (`NROS_EXECUTOR_ARENA_SIZE`) is a BUILD-TIME constant, identical for every
+/// executor in the image, so saying it twice adds nothing.
+static ARENA_ADVISORY_DONE: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+
+/// Report an arena that is far larger than the entities registered in it.
+///
+/// `ARENA_SIZE` is derived by budgeting EVERY slot at the ActionClient worst
+/// case (`nros-node/build.rs`), so an image with no action client carries
+/// several times what it can use — 74,240 bytes against ~16 KiB for a
+/// pub/sub-only workload at the defaults. The arena is a BUMP allocator, so
+/// `arena_used` is the exact claimed total rather than a reservation, and the
+/// allocator has therefore always known the right answer and never said it.
+///
+/// The override exists (`NROS_EXECUTOR_ARENA_SIZE`, or
+/// `CONFIG_NROS_EXECUTOR_ARENA_SIZE` on Zephyr) and is already load-bearing:
+/// the FreeRTOS action examples pin it to 8192 and still need a 64 KB app task
+/// stack, a number someone found by hitting "Invalid mbox" and working
+/// backwards. That is the shape of issues 0271/0739 — a knob nobody can
+/// enumerate is a knob nobody sets — and this turns it from folklore into a
+/// measurement.
+///
+/// **The arena is on the STACK**, not in `.bss`: `Executor` holds
+/// `arena: [MaybeUninit<u8>; ARENA_SIZE]` inline, so `mem-report` cannot see it
+/// and the cost lands on whichever task calls spin
+/// (`docs/reference/platform-implementation-notes.md`, FreeRTOS pitfalls).
+///
+/// `nros_log`, never stdio: this is reached on `no_std` targets and inside
+/// Zephyr `native_sim`, where a Rust `std` stdio call is FATAL (issue 0589).
+#[cold]
+fn report_arena_headroom(used: usize, capacity: usize) {
+    // Round the suggestion up so a small later registration still fits, and
+    // keep it a multiple of 1024 because that is the unit the knob is written
+    // in everywhere else in the tree.
+    let suggest = used.next_multiple_of(1024).max(1024);
+    nros_log::nros_info!(
+        nros_log::get_logger("nros"),
+        "executor arena is {capacity} bytes and {used} are claimed at first          spin. ARENA_SIZE budgets every slot at the ActionClient worst case, so          an image without one over-provisions; the arena is INLINE ON THE TASK          STACK, so this is stack headroom, not .bss. Set          NROS_EXECUTOR_ARENA_SIZE={suggest} (Zephyr:          CONFIG_NROS_EXECUTOR_ARENA_SIZE) if nothing registers after this point          — entities created later need their own room (issue 0900)"
+    );
+}
+
+/// One-shot arena-headroom check, called on the first `spin_once`.
+///
+/// First spin, not registration end, because there is no "registration end" —
+/// an app may register lazily, and this is why the message says
+/// "at first spin" and names what it measured rather than asserting a total.
+///
+/// Hot-path cost is one relaxed load on a branch that is taken exactly once.
+pub(crate) fn maybe_report_arena_headroom(used: usize, capacity: usize) {
+    if ARENA_ADVISORY_DONE.load(portable_atomic::Ordering::Relaxed) {
+        return;
+    }
+    // Only ever set, never cleared, so a racing second spin at worst emits the
+    // line twice — cheaper than an AcqRel on every spin to prevent a duplicate
+    // advisory.
+    ARENA_ADVISORY_DONE.store(true, portable_atomic::Ordering::Relaxed);
+    if arena_is_over_provisioned(used, capacity) {
+        report_arena_headroom(used, capacity);
+    }
+}
+
+/// Is this arena grossly larger than what registered in it?
+///
+/// Half is the threshold because the derivation's own error is a factor of
+/// ~4.5 at the defaults (74,240 bytes budgeted against ~16 KiB for a
+/// pub/sub-only image), so "under half" is unambiguous rather than a rounding
+/// artifact, and an image that genuinely uses most of its arena stays quiet.
+///
+/// A zero capacity is NOT over-provisioned: that is the sentinel bug issue 0460
+/// produced on Zephyr (a literal `0` forwarded instead of the derivation), and
+/// it fails loudly on the first registration. Calling it over-provisioned would
+/// bury a fatal misconfiguration under an advisory about wasted space.
+///
+/// Separated from [`maybe_report_arena_headroom`] so it is testable: the
+/// reporter is one-shot on a process-scoped flag, so a test that called it
+/// twice would silently check nothing the second time.
+pub(crate) const fn arena_is_over_provisioned(used: usize, capacity: usize) -> bool {
+    capacity != 0 && used.saturating_mul(2) <= capacity
+}
+
+#[cfg(test)]
+mod arena_headroom_tests {
+    use super::arena_is_over_provisioned;
+
+    #[test]
+    fn gross_over_provision_is_reported() {
+        // The measured shape: a talker's handful of entries against the
+        // worst-case-derived 74,240.
+        assert!(arena_is_over_provisioned(4_096, 74_240));
+        assert!(arena_is_over_provisioned(0, 74_240));
+    }
+
+    #[test]
+    fn a_well_sized_arena_stays_quiet() {
+        assert!(!arena_is_over_provisioned(60_000, 74_240));
+        // Exactly half is the boundary and IS reported; one byte more is not.
+        assert!(arena_is_over_provisioned(37_120, 74_240));
+        assert!(!arena_is_over_provisioned(37_121, 74_240));
+    }
+
+    #[test]
+    fn a_zero_capacity_arena_is_a_fault_not_headroom() {
+        // Issue 0460's sentinel bug. It fails on the first registration; an
+        // advisory about wasted space would bury that.
+        assert!(!arena_is_over_provisioned(0, 0));
+    }
+
+    #[test]
+    fn overflow_cannot_panic_the_check() {
+        // `used` is bounded by `capacity` in practice, but the doubling must
+        // not be the thing that decides that.
+        assert!(!arena_is_over_provisioned(usize::MAX, 74_240));
+    }
+}
+
 /// Say that a take was thrown away, on the first one and every 64th after.
 ///
 /// Issue 0757, RFC-0052 fail-loud. `try_recv_raw` returns `BufferTooSmall` when

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -3557,6 +3557,25 @@ impl<'s> Executor<'s> {
     // Arena-based callback registration
     // ========================================================================
 
+    /// Arena bytes claimed by registered entities so far.
+    ///
+    /// EXACT, not a worst case: the arena is a bump allocator and every
+    /// `arena_alloc` charges `size_of::<T>()`, so nothing is reserved per slot.
+    /// `ARENA_SIZE` itself is derived the other way — every slot budgeted at
+    /// the ActionClient worst case — which is issue 0900, and this accessor is
+    /// how an image can find out what it actually needs.
+    pub fn arena_used(&self) -> usize {
+        self.arena_used
+    }
+
+    /// Total arena bytes this executor was given.
+    ///
+    /// Inline in the `Executor` value, so on the board path this is stack, not
+    /// `.bss` (see `report_arena_headroom`).
+    pub fn arena_capacity(&self) -> usize {
+        self.arena.len()
+    }
+
     /// Bump-allocate space for `T` in the arena. Returns the byte offset.
     pub(crate) fn arena_alloc<T>(&mut self) -> Result<usize, NodeError> {
         let align = core::mem::align_of::<T>();
@@ -5460,6 +5479,11 @@ impl<'s> Executor<'s> {
 
     pub fn spin_once(&mut self, timeout: core::time::Duration) -> SpinOnceResult {
         let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+
+        // issue 0900 — one-shot advisory when the arena is far larger than what
+        // registered. First spin rather than "end of registration", because
+        // there is no such point: an app may register lazily.
+        super::arena::maybe_report_arena_headroom(self.arena_used, self.arena.len());
 
         // Phase 110.0 — cap against the backend's next internal-event
         // deadline (lease keepalive, heartbeat, ACK-NACK timeout, ...).

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -3583,6 +3583,14 @@ impl<'s> Executor<'s> {
         let aligned_offset = (self.arena_used + align - 1) & !(align - 1);
         let new_used = aligned_offset + size;
         if new_used > self.arena.len() {
+            // issue 0900 — `BufferTooSmall` is returned by a dozen other paths,
+            // so on a target where a return code is all you get, arena
+            // exhaustion is indistinguishable from a message that did not fit.
+            super::arena::report_arena_exhausted(
+                new_used - self.arena.len(),
+                self.arena_used,
+                self.arena.len(),
+            );
             return Err(NodeError::BufferTooSmall);
         }
         self.arena_used = new_used;

--- a/packages/core/nros-node/src/lifecycle_services.rs
+++ b/packages/core/nros-node/src/lifecycle_services.rs
@@ -552,6 +552,16 @@ use crate::executor::{EmbeddedServiceServer, NodeError};
 // the build surface simple.
 pub use crate::config::PARAM_SERVICE_BUFFER_SIZE as LIFECYCLE_SERVICE_BUFFER_SIZE;
 
+/// How many zenoh queryables the REP-2002 lifecycle services claim on a node.
+///
+/// Issue 0827 — FIVE, not six. `change_state`, `get_state`,
+/// `get_available_states`, `get_available_transitions`, `get_transition_graph`.
+/// Both places that stated a number for these stated six, which is where the
+/// widely-quoted "twelve slots before the application declares anything" came
+/// from; it is eleven. See [`crate::parameter_services::PARAM_SERVICE_QUERYABLES`]
+/// for why the count lives here rather than in the RMW.
+pub const LIFECYCLE_SERVICE_QUERYABLES: usize = 5;
+
 type LcSrv<Svc> =
     EmbeddedServiceServer<Svc, LIFECYCLE_SERVICE_BUFFER_SIZE, LIFECYCLE_SERVICE_BUFFER_SIZE>;
 

--- a/packages/core/nros-node/src/parameter_services.rs
+++ b/packages/core/nros-node/src/parameter_services.rs
@@ -1218,6 +1218,25 @@ use crate::executor::{EmbeddedServiceServer, NodeError};
 // NROS_PARAM_SERVICE_BUFFER_SIZE env var (default 4096).
 pub use crate::config::PARAM_SERVICE_BUFFER_SIZE;
 
+/// How many zenoh queryables the ROS parameter services claim on a node.
+///
+/// Issue 0827 — a service server IS a queryable, so this number is a term in
+/// every service-buffer pool the RMW sizes. It had SIX spellings and no
+/// definition: the count of `create_param_srv::<_>` statements in
+/// `executor/spin.rs`, two doc comments, `nros-zpico-build`'s default-picking
+/// comment, the RMW's own exhaustion message, and CLAUDE.md. Two of them had
+/// already drifted to the wrong value for the lifecycle sibling.
+///
+/// Kept BESIDE the code that creates them, not in the RMW: only the runtime
+/// knows it creates these on the node's behalf. Deriving the number from the
+/// user's entity set is issue 0460's defect — codegen sees the application's
+/// services and never these.
+///
+/// Gated with the same `param-services` feature that compiles the servers, so
+/// an image without it contributes zero rather than eleven.
+/// `check-infra-queryable-counts` holds it to the number of creation sites.
+pub const PARAM_SERVICE_QUERYABLES: usize = 6;
+
 /// Type alias for a parameter service server with standard buffer sizes.
 type ParamServer<Svc> =
     EmbeddedServiceServer<Svc, PARAM_SERVICE_BUFFER_SIZE, PARAM_SERVICE_BUFFER_SIZE>;

--- a/packages/platform/nros-platform-mps2-an385/Cargo.toml
+++ b/packages/platform/nros-platform-mps2-an385/Cargo.toml
@@ -15,8 +15,15 @@ name = "nros_platform_mps2_an385"
 # FreeRTOS consumer that reuses only this crate's Cortex-M timing (DWT) already
 # has picolibc from the board, so it must `default-features = false` here to
 # avoid a `duplicate symbol: strtol` link conflict; PRNG / sleep / timing stay.
-default = ["libc-stubs"]
+default = ["libc-stubs", "libc-heap"]
 libc-stubs = ["nros-baremetal-common/libc-stubs"]
+# phase-391 W5-endgame (issues 0816/0843) — the HEAP libc shims
+# (`malloc`/`free`/`realloc`/`calloc`, src/libc_stubs.rs) get their own gate so
+# a heap-free-tier image can drop the symbols entirely: the W1 link gate
+# (`check-no-alloc-image --tier heap-free`) counts a DEFINED `malloc` as an
+# allocation surface whether or not anything calls it. Default-on — every
+# existing consumer (zenoh's Z_MALLOC route, XRCE's wrapper) keeps them.
+libc-heap = []
 # TLS support (larger heap: 128 KB instead of 64 KB)
 link-tls = []
 # Phase 97.3.mps2-an385 — DDS / DDS DcpsDomainParticipant + builtin

--- a/packages/platform/nros-platform-mps2-an385/src/lib.rs
+++ b/packages/platform/nros-platform-mps2-an385/src/lib.rs
@@ -11,6 +11,7 @@
 #![no_std]
 
 pub mod clock;
+#[cfg(feature = "libc-heap")]
 pub mod libc_stubs;
 pub mod memory;
 pub mod net;

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -543,7 +543,6 @@ dependencies = [
  "nros-zephyr-build",
  "paste",
  "portable-atomic",
- "portable-atomic-util",
 ]
 
 [[package]]
@@ -741,15 +740,6 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -575,7 +575,6 @@ dependencies = [
  "nros-zephyr-build",
  "paste",
  "portable-atomic",
- "portable-atomic-util",
 ]
 
 [[package]]
@@ -779,15 +778,6 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt
@@ -36,6 +36,37 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 #   defaults it to the pinned third-party submodule, sccache-accelerated).
 # So a bare cmake build needs no `just cyclonedds` pre-step. Sets
 # NROS_CYCLONEDDS_PROVENANCE (target|find_package|source).
+# ---- Platform implementation (issue 0881) ----------------------------------
+# The funnel is enabled by `nros_provide_cyclonedds()` only when a platform
+# target exists to funnel INTO, so before this block the standalone project
+# built Cyclone with its libc heap and the funnel-ON path had no lane at all:
+# a native nano-ros build resolves Cyclone through `find_package` (already
+# compiled, nothing to define into), and only a cross build reached the
+# funnel — tier 2, a day of latency, and a cross toolchain.
+#
+# That mattered because the funnel is a LINK-shape change. It was this
+# project's three test executables that caught the missing link dependency the
+# first time; after the dependency landed, this project stopped compiling the
+# funnel and the next regression of that shape would have surfaced in tier 2.
+#
+# The location arrives as a cache PATH defaulted to the sibling project, the
+# same convention `CYCLONEDDS_SOURCE_DIR` and the header vars already use, so
+# this file still never searches the tree and a consumer can override it.
+# Guarded on the targets not already existing, so a parent project providing
+# its own platform wins.
+set(NROS_PLATFORM_IMPL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../platform/nros-platform-posix"
+    CACHE PATH "Path to a project providing the nros platform ABI implementation")
+if(NOT TARGET nros_platform_posix AND NOT TARGET NanoRos::Platform
+   AND EXISTS "${NROS_PLATFORM_IMPL_DIR}/CMakeLists.txt")
+    add_subdirectory("${NROS_PLATFORM_IMPL_DIR}" nros_platform_impl_build)
+endif()
+# `NanoRos::Platform` is the Phase-138 §A canonical alias the funnel gate asks
+# for. A parent nano-ros build already defines it over its INTERFACE wrapper;
+# standalone there is no wrapper, so alias the archive directly.
+if(NOT TARGET NanoRos::Platform AND TARGET nros_platform_posix)
+    add_library(NanoRos::Platform ALIAS nros_platform_posix)
+endif()
+
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ProvideCycloneDDS.cmake")
 nros_provide_cyclonedds()
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
@@ -179,26 +179,82 @@ macro(nros_provide_cyclonedds)
             # EXCLUDE_FROM_ALL: built only because nros_rmw_cyclonedds links
             # CycloneDDS::ddsc, not as part of `all`.
             add_subdirectory("${CYCLONEDDS_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds" EXCLUDE_FROM_ALL)
-            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`, not
-            # libc. Set on the ddsrt targets rather than globally: the switch is
-            # read by ONE fork TU (src/ddsrt/src/heap/*/heap.c), and a global
-            # define would also reach idlc and the confgen host tools, which
-            # link no platform layer. `ddsrt` is the object library the static
-            # `ddsc` absorbs; `ddsrt-internal` is its tools-side twin, which
-            # must NOT get the define for exactly that reason.
+            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`,
+            # not libc.
+            #
+            # The define and the LINK DEPENDENCY are one decision, made here.
+            # Compiling the funnel in turns three platform-ABI symbols into
+            # undefined references in every archive that absorbs `heap.c`, so a
+            # build that sets the define without linking a provider does not
+            # fail at the switch — it fails much later, at whichever executable
+            # happens to link ddsc first. That is why the provider is resolved
+            # BEFORE the define is set, and why the same block does both.
+            #
+            # Resolution is by target, not by guess: `NanoRos::Platform` is the
+            # Phase-138 §A canonical alias every platform module exposes, and
+            # every port defines the three symbols. When it is absent — the
+            # standalone `just cyclonedds ci` project builds the backend with no
+            # platform layer at all — the funnel stays OFF and Cyclone keeps its
+            # libc heap, which is the correct answer for a build that has no
+            # platform to funnel into. Both outcomes print, because a silently
+            # disabled funnel and an enabled one look identical from the recipe.
+            #
+            # The `unified`-tier gate (`scripts/check-no-alloc-image.py`) is what
+            # makes "off" safe to allow: it measures the linked ELF, so an image
+            # that was supposed to funnel and did not is caught there rather
+            # than trusted here.
+            #
+            # SCOPE, measured: this is the SELF-PROVISION branch, so the funnel
+            # reaches only builds that compile Cyclone from source. A
+            # find_package build links a Cyclone whose `heap.c` was already
+            # compiled — there is nothing left to define into it — and on a host
+            # with an SDK-store or ROS Cyclone that is what a NATIVE build
+            # resolves. Which is the right split for the tier model: `unified`
+            # is an embedded promise, a cross build skips find_package outright
+            # (see the CMAKE_CROSSCOMPILING branch above) and so always lands
+            # here with a platform target present.
+            #
+            # NOT a global define: the switch is read by ONE fork TU
+            # (src/ddsrt/src/heap/*/heap.c), and a global would also reach idlc
+            # and the confgen host tools, which link no platform layer.
             # `ddsrt` is an INTERFACE target in this layout — its sources
-            # compile INSIDE `ddsc`, so that is where the define has to land.
-            # `ddsrt-internal` (the tools-side twin that idlc/confgen link) is
-            # deliberately left alone: those hosts link no platform layer.
-            foreach(_nros_cdds_tgt ddsc ddsrt)
-                if(TARGET ${_nros_cdds_tgt})
-                    get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
-                    if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
-                        target_compile_definitions(${_nros_cdds_tgt}
-                            PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+            # compile INSIDE `ddsc`, so that is where both the define and the
+            # dependency have to land. `ddsrt-internal` (the tools-side twin
+            # idlc/confgen link) is deliberately left alone for the same reason.
+            if(TARGET NanoRos::Platform)
+                foreach(_nros_cdds_tgt ddsc ddsrt)
+                    if(TARGET ${_nros_cdds_tgt})
+                        get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
+                        if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
+                            target_compile_definitions(${_nros_cdds_tgt}
+                                PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+                            # PUBLIC: the reference lives in ddsc's own objects,
+                            # and consumers must get the provider AFTER ddsc on
+                            # the link line. Expressing it as a dependency is
+                            # what orders it — the alternative (a weak fallback
+                            # definition) would resolve the reference by
+                            # reintroducing the libc heap this issue exists to
+                            # remove, which the issue-0050 audit has no legal
+                            # `body:` label for.
+                            #
+                            # `$<BUILD_INTERFACE:>` because Cyclone `install
+                            # (EXPORT)`s `ddsc`, and an exported target may not
+                            # name a dependency outside its own export set —
+                            # without the genex, configure dies with "requires
+                            # target nros_platform_posix_iface that is not in
+                            # any export set". We never install this Cyclone
+                            # (it is added EXCLUDE_FROM_ALL and consumed from
+                            # the build tree), so the dependency is exactly a
+                            # build-tree one and the genex says so.
+                            target_link_libraries(${_nros_cdds_tgt}
+                                PUBLIC $<BUILD_INTERFACE:NanoRos::Platform>)
+                        endif()
                     endif()
-                endif()
-            endforeach()
+                endforeach()
+                message(STATUS "nano-ros: CycloneDDS ddsrt heap -> nros_platform_alloc (issue 0832)")
+            else()
+                message(STATUS "nano-ros: CycloneDDS ddsrt heap -> libc (no NanoRos::Platform target to funnel into)")
+            endif()
             # Where Cyclone generated its headers (dds/config.h, version.h, …) —
             # the backend needs this on the source path (see CMakeLists.txt).
             set(NROS_CYCLONEDDS_SOURCE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds")

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/cmake/ProvideCycloneDDS.cmake
@@ -179,6 +179,26 @@ macro(nros_provide_cyclonedds)
             # EXCLUDE_FROM_ALL: built only because nros_rmw_cyclonedds links
             # CycloneDDS::ddsc, not as part of `all`.
             add_subdirectory("${CYCLONEDDS_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds" EXCLUDE_FROM_ALL)
+            # issue 0832 — ddsrt's heap goes through `nros_platform_alloc`, not
+            # libc. Set on the ddsrt targets rather than globally: the switch is
+            # read by ONE fork TU (src/ddsrt/src/heap/*/heap.c), and a global
+            # define would also reach idlc and the confgen host tools, which
+            # link no platform layer. `ddsrt` is the object library the static
+            # `ddsc` absorbs; `ddsrt-internal` is its tools-side twin, which
+            # must NOT get the define for exactly that reason.
+            # `ddsrt` is an INTERFACE target in this layout — its sources
+            # compile INSIDE `ddsc`, so that is where the define has to land.
+            # `ddsrt-internal` (the tools-side twin that idlc/confgen link) is
+            # deliberately left alone: those hosts link no platform layer.
+            foreach(_nros_cdds_tgt ddsc ddsrt)
+                if(TARGET ${_nros_cdds_tgt})
+                    get_target_property(_nros_cdds_type ${_nros_cdds_tgt} TYPE)
+                    if(NOT _nros_cdds_type STREQUAL "INTERFACE_LIBRARY")
+                        target_compile_definitions(${_nros_cdds_tgt}
+                            PRIVATE NROS_DDSRT_PLATFORM_FUNNEL)
+                    endif()
+                endif()
+            endforeach()
             # Where Cyclone generated its headers (dds/config.h, version.h, …) —
             # the backend needs this on the source path (see CMakeLists.txt).
             set(NROS_CYCLONEDDS_SOURCE_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_cyclonedds")

--- a/packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt
+++ b/packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt
@@ -173,6 +173,25 @@ foreach(_rel IN LISTS _ucdr_src)
     list(APPEND _ucdr_all_src "${MICROCDR_DIR}/src/c/${_rel}")
 endforeach()
 
+# ---- Platform implementation ----------------------------------------------
+# Issue 0832 — the backend ALLOCATES through `nros_platform_alloc` (see the
+# `nros_xrce_calloc`/`nros_xrce_free` helpers in src/internal.h), so headers
+# alone are no longer enough to link. `nros-rmw-xrce-cffi`'s build.rs states
+# the same contract for the image path: these sources compile on every target
+# "as long as the consumer links a platform-provider library". This project
+# was the one consumer that did not.
+#
+# Same convention as the two header vars above: the location arrives as a
+# cache PATH defaulted to the sibling project, so an out-of-tree consumer can
+# point it elsewhere and this file still never searches the tree. Guarded on
+# the target not already existing, so a parent project that provides its own
+# platform wins.
+set(NROS_PLATFORM_IMPL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../platform/nros-platform-posix"
+    CACHE PATH "Path to a project providing the nros platform ABI implementation")
+if(NOT TARGET nros_platform_posix AND EXISTS "${NROS_PLATFORM_IMPL_DIR}/CMakeLists.txt")
+    add_subdirectory("${NROS_PLATFORM_IMPL_DIR}" nros_platform_impl_build)
+endif()
+
 # ---- Static library --------------------------------------------------------
 add_library(nros_rmw_xrce STATIC
     src/vtable.c
@@ -203,6 +222,22 @@ target_include_directories(nros_rmw_xrce
         ${CMAKE_CURRENT_BINARY_DIR}/uxr_generated
         ${CMAKE_CURRENT_BINARY_DIR}/ucdr_generated
 )
+
+# PUBLIC so consumers get the provider AFTER this archive on the link line:
+# the references live in this library's own objects, and being a dependency is
+# what orders it. Without it the smoke test fails with `undefined reference to
+# nros_platform_alloc` from `transport_nros_udp.c.o` — the same shape as the
+# cyclone funnel's link (issue 0832), and fixed the same way rather than with a
+# weak fallback, which would resolve the reference by calling libc and put back
+# exactly the second heap this change removes.
+if(TARGET nros_platform_posix)
+    target_link_libraries(nros_rmw_xrce PUBLIC nros_platform_posix)
+    message(STATUS "nano-ros: nros-rmw-xrce allocates via nros_platform_alloc (issue 0832)")
+else()
+    message(FATAL_ERROR
+        "nros-rmw-xrce needs a platform ABI implementation (nros_platform_alloc/dealloc). "
+        "Set -DNROS_PLATFORM_IMPL_DIR=<path> or define an `nros_platform_posix` target.")
+endif()
 
 target_compile_definitions(nros_rmw_xrce PRIVATE
     # POSIX feature gate — `time.c` calls `clock_gettime`, which

--- a/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
@@ -13,6 +13,7 @@
  * module-static `XrceSessionState` it relies on.
  */
 
+#include "nros/platform.h"
 #include "nros/rmw_entity.h"
 #include "nros/rmw_event.h"
 #include "nros/rmw_ret.h"
@@ -24,9 +25,50 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <string.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Issue 0832 — this backend allocates through the platform funnel, never libc.
+ *
+ * The shim is linked ABOVE the platform layer, so libc's heap is not
+ * necessarily the heap the platform owns: on Zephyr, FreeRTOS, ThreadX and
+ * NuttX it is a different allocator entirely, and the `unified` tier promises
+ * that every allocation reaches `nros_platform_alloc`. A raw `calloc`/`free`
+ * here allocates from one heap and, once a board routes the other way, frees
+ * to another.
+ *
+ * The zeroing lives in the helper rather than at the call sites. Every
+ * allocation in this backend was `calloc(1, sizeof(X))` on a struct whose
+ * fields are then only partly assigned, so the zeroing is load-bearing — and a
+ * `memset` that has to be remembered at nine call sites is one that gets
+ * forgotten at the tenth.
+ */
+static inline void *nros_xrce_calloc(size_t count, size_t size) {
+    size_t total;
+    void *ptr;
+
+    if (count == 0 || size == 0) {
+        count = size = 1;
+    }
+    /* The multiply is the one thing calloc does that alloc cannot, so keep its
+       overflow check rather than trusting the product. */
+    total = count * size;
+    if (total / size != count) {
+        return NULL;
+    }
+    if ((ptr = nros_platform_alloc(total)) != NULL) {
+        memset(ptr, 0, total);
+    }
+    return ptr;
+}
+
+static inline void nros_xrce_free(void *ptr) {
+    /* `nros_platform_dealloc` is a documented no-op on NULL, matching free(). */
+    nros_platform_dealloc(ptr);
+}
 
 /* ---- Tunables (must mirror packages/rmw/xrce/nros-rmw-xrce/build.rs
  *      defaults so the C backend behaves the same as the Rust one

--- a/packages/rmw/xrce/nros-rmw-xrce/src/publisher.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/publisher.c
@@ -44,7 +44,7 @@ rmw_ret_t xrce_publisher_create(const rmw_node_t* node,
     }
 
     xrce_publisher_state *ps = (xrce_publisher_state *)
-        calloc(1, sizeof(xrce_publisher_state));
+        nros_xrce_calloc(1, sizeof(xrce_publisher_state));
     if (ps == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -87,7 +87,7 @@ rmw_ret_t xrce_publisher_create(const rmw_node_t* node,
     uint8_t  statuses[3] = { 0, 0, 0 };
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 3);
     if (cret != NROS_RMW_RET_OK) {
-        free(ps);
+        nros_xrce_free(ps);
         return cret;
     }
 
@@ -113,7 +113,7 @@ rmw_ret_t xrce_publisher_destroy(rmw_publisher_t *publisher) {
                                             ps->datawriter_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(ps);
+    nros_xrce_free(ps);
     publisher->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/service.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/service.c
@@ -117,7 +117,7 @@ rmw_ret_t xrce_service_create(const rmw_node_t* node, const char* service_name,
     }
 
     xrce_service_server_state* ss =
-        (xrce_service_server_state*)calloc(1, sizeof(xrce_service_server_state));
+        (xrce_service_server_state*)nros_xrce_calloc(1, sizeof(xrce_service_server_state));
     if (ss == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -160,7 +160,7 @@ rmw_ret_t xrce_service_create(const rmw_node_t* node, const char* service_name,
     uint8_t statuses[1] = {0};
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 1);
     if (cret != NROS_RMW_RET_OK) {
-        free(ss);
+        nros_xrce_free(ss);
         return cret;
     }
 
@@ -206,7 +206,7 @@ rmw_ret_t xrce_service_destroy(rmw_service_t* server) {
     uint16_t req = uxr_buffer_delete_entity(&st->session, st->output_reliable, ss->replier_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(ss);
+    nros_xrce_free(ss);
     server->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }
@@ -527,7 +527,7 @@ rmw_ret_t xrce_client_create(const rmw_node_t* node, const char* service_name,
     }
 
     xrce_service_client_state* cs =
-        (xrce_service_client_state*)calloc(1, sizeof(xrce_service_client_state));
+        (xrce_service_client_state*)nros_xrce_calloc(1, sizeof(xrce_service_client_state));
     if (cs == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -564,7 +564,7 @@ rmw_ret_t xrce_client_create(const rmw_node_t* node, const char* service_name,
     uint8_t statuses[1] = {0};
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 1);
     if (cret != NROS_RMW_RET_OK) {
-        free(cs);
+        nros_xrce_free(cs);
         return cret;
     }
 
@@ -605,7 +605,7 @@ rmw_ret_t xrce_client_destroy(rmw_client_t* client) {
     uint16_t req = uxr_buffer_delete_entity(&st->session, st->output_reliable, cs->requester_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(cs);
+    nros_xrce_free(cs);
     client->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/session.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/session.c
@@ -335,7 +335,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         return NROS_RMW_RET_ERROR;
     }
 
-    xrce_session_state_t* st = (xrce_session_state_t*)calloc(1, sizeof(xrce_session_state_t));
+    xrce_session_state_t* st = (xrce_session_state_t*)nros_xrce_calloc(1, sizeof(xrce_session_state_t));
     if (st == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -377,7 +377,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         st->use_custom_transport = true;
         rmw_ret_t ret = xrce_custom_transport_install(st, /*framing=*/false);
         if (ret != NROS_RMW_RET_OK) {
-            free(st);
+            nros_xrce_free(st);
             return ret;
         }
         uxr_init_session(&st->session, &st->custom.comm, hash_session_key(node_name));
@@ -386,7 +386,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         st->use_custom_transport = true;
         rmw_ret_t sret = xrce_posix_serial_init(st, serial_path);
         if (sret != NROS_RMW_RET_OK) {
-            free(st);
+            nros_xrce_free(st);
             return sret;
         }
         uxr_init_session(&st->session, &st->custom.comm, hash_session_key(node_name));
@@ -409,7 +409,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         if (parse_host_port(addr_locator, host, sizeof(host), &port) == 0) {
             size_t hlen = strlen(addr_locator);
             if (hlen == 0 || hlen + 1 > sizeof(host)) {
-                free(st);
+                nros_xrce_free(st);
                 return NROS_RMW_RET_INVALID_ARGUMENT;
             }
             memcpy(host, addr_locator, hlen + 1);
@@ -423,7 +423,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         st->use_custom_transport = true;
         rmw_ret_t udp_ret = xrce_nros_udp_init(st, host, port_str);
         if (udp_ret != NROS_RMW_RET_OK) {
-            free(st);
+            nros_xrce_free(st);
             return udp_ret;
         }
         uxr_init_session(&st->session, &st->custom.comm, hash_session_key(node_name));
@@ -441,7 +441,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         /* Both UDP and `custom://` paths now go through
          * uxrCustomTransport — close via custom_transport. */
         uxr_close_custom_transport(&st->custom);
-        free(st);
+        nros_xrce_free(st);
         return NROS_RMW_RET_ERROR;
     }
 
@@ -469,7 +469,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
     if (cret != NROS_RMW_RET_OK) {
         (void)uxr_delete_session(&st->session);
         uxr_close_custom_transport(&st->custom);
-        free(st);
+        nros_xrce_free(st);
         return cret;
     }
 
@@ -491,7 +491,7 @@ rmw_ret_t xrce_session_destroy(rmw_session_t* session) {
      * UDP through the same surface to match xrce-sys's legacy
      * shape. Close once, regardless of `use_custom_transport`. */
     uxr_close_custom_transport(&st->custom);
-    free(st);
+    nros_xrce_free(st);
     session->backend_data = NULL;
     return NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
@@ -107,7 +107,7 @@ rmw_ret_t xrce_subscription_create(const rmw_node_t* node,
     }
 
     xrce_subscriber_state *ss = (xrce_subscriber_state *)
-        calloc(1, sizeof(xrce_subscriber_state));
+        nros_xrce_calloc(1, sizeof(xrce_subscriber_state));
     if (ss == NULL) {
         return NROS_RMW_RET_BAD_ALLOC;
     }
@@ -147,7 +147,7 @@ rmw_ret_t xrce_subscription_create(const rmw_node_t* node,
     uint8_t  statuses[3] = { 0, 0, 0 };
     rmw_ret_t cret = xrce_confirm_entities(st, requests, statuses, 3);
     if (cret != NROS_RMW_RET_OK) {
-        free(ss);
+        nros_xrce_free(ss);
         return cret;
     }
 
@@ -202,7 +202,7 @@ rmw_ret_t xrce_subscription_destroy(rmw_subscription_t *subscriber) {
                                             ss->datareader_oid);
     (void)uxr_run_session_time(&st->session, 0);
 
-    free(ss);
+    nros_xrce_free(ss);
     subscriber->backend_data = NULL;
     return req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/transport_nros_udp.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/transport_nros_udp.c
@@ -41,12 +41,12 @@ static bool nros_udp_close(struct uxrCustomTransport *t) {
     if (b == NULL) return true;
     if (b->sock != NULL) {
         nros_platform_udp_close(b->sock);
-        free(b->sock);
+        nros_xrce_free(b->sock);
         b->sock = NULL;
     }
     if (b->endpoint != NULL) {
         nros_platform_udp_free_endpoint(b->endpoint);
-        free(b->endpoint);
+        nros_xrce_free(b->endpoint);
         b->endpoint = NULL;
     }
     return true;
@@ -91,11 +91,11 @@ rmw_ret_t xrce_nros_udp_init(xrce_session_state_t *st,
     }
 
     xrce_nros_udp_bridge *bridge = (xrce_nros_udp_bridge *)&st->udp_bridge;
-    bridge->sock = calloc(1, XRCE_NROS_SOCK_STORAGE_BYTES);
-    bridge->endpoint = calloc(1, XRCE_NROS_ENDPOINT_STORAGE_BYTES);
+    bridge->sock = nros_xrce_calloc(1, XRCE_NROS_SOCK_STORAGE_BYTES);
+    bridge->endpoint = nros_xrce_calloc(1, XRCE_NROS_ENDPOINT_STORAGE_BYTES);
     if (bridge->sock == NULL || bridge->endpoint == NULL) {
-        free(bridge->sock);
-        free(bridge->endpoint);
+        nros_xrce_free(bridge->sock);
+        nros_xrce_free(bridge->endpoint);
         bridge->sock = NULL;
         bridge->endpoint = NULL;
         return NROS_RMW_RET_ERROR;
@@ -104,16 +104,16 @@ rmw_ret_t xrce_nros_udp_init(xrce_session_state_t *st,
     if (nros_platform_udp_create_endpoint(bridge->endpoint,
                                           (const uint8_t *)host,
                                           (const uint8_t *)port) != 0) {
-        free(bridge->sock);
-        free(bridge->endpoint);
+        nros_xrce_free(bridge->sock);
+        nros_xrce_free(bridge->endpoint);
         bridge->sock = NULL;
         bridge->endpoint = NULL;
         return NROS_RMW_RET_ERROR;
     }
     if (nros_platform_udp_open(bridge->sock, bridge->endpoint, 100) != 0) {
         nros_platform_udp_free_endpoint(bridge->endpoint);
-        free(bridge->sock);
-        free(bridge->endpoint);
+        nros_xrce_free(bridge->sock);
+        nros_xrce_free(bridge->endpoint);
         bridge->sock = NULL;
         bridge->endpoint = NULL;
         return NROS_RMW_RET_ERROR;
@@ -127,8 +127,8 @@ rmw_ret_t xrce_nros_udp_init(xrce_session_state_t *st,
         bridge, {
             nros_platform_udp_close(bridge->sock);
             nros_platform_udp_free_endpoint(bridge->endpoint);
-            free(bridge->sock);
-            free(bridge->endpoint);
+            nros_xrce_free(bridge->sock);
+            nros_xrce_free(bridge->endpoint);
             bridge->sock = NULL;
             bridge->endpoint = NULL;
         });

--- a/packages/rmw/xrce/nros-rmw-xrce/src/transport_zephyr_udp.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/transport_zephyr_udp.c
@@ -26,8 +26,8 @@ static bool zephyr_udp_close(struct uxrCustomTransport *t) {
     if (b->endpoint != NULL) {
         nros_platform_udp_free_endpoint(b->endpoint);
     }
-    free(b->sock);
-    free(b->endpoint);
+    nros_xrce_free(b->sock);
+    nros_xrce_free(b->endpoint);
     b->sock = NULL;
     b->endpoint = NULL;
     return true;
@@ -41,8 +41,8 @@ static void zephyr_udp_bridge_cleanup(xrce_zephyr_udp_bridge *b) {
     if (b->endpoint != NULL) {
         nros_platform_udp_free_endpoint(b->endpoint);
     }
-    free(b->sock);
-    free(b->endpoint);
+    nros_xrce_free(b->sock);
+    nros_xrce_free(b->endpoint);
     b->sock = NULL;
     b->endpoint = NULL;
 }
@@ -77,8 +77,8 @@ rmw_ret_t xrce_zephyr_udp_init(xrce_session_state_t *st,
     }
 
     xrce_zephyr_udp_bridge *bridge = (xrce_zephyr_udp_bridge *)&st->udp_bridge;
-    bridge->sock = calloc(1, sizeof(int));
-    bridge->endpoint = calloc(1, sizeof(void *));
+    bridge->sock = nros_xrce_calloc(1, sizeof(int));
+    bridge->endpoint = nros_xrce_calloc(1, sizeof(void *));
     if (bridge->sock == NULL || bridge->endpoint == NULL) {
         zephyr_udp_bridge_cleanup(bridge);
         return NROS_RMW_RET_ERROR;

--- a/packages/rmw/xrce/nros-rmw-xrce/tests/smoke.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/tests/smoke.c
@@ -35,53 +35,29 @@ rmw_ret_t nros_rmw_cffi_register_named(const char *name, const nros_rmw_vtable_t
     return NROS_RMW_RET_OK;
 }
 
-/* The platform clock + sleep this backend's session drive loop calls. Same
- * reason as the UDP stubs below. */
-uint64_t nros_platform_clock_ns(void) { return 0; }
-void nros_platform_sleep_ms(size_t ms) { (void) ms; }
-void nros_platform_udp_set_recv_timeout(const void *sock, uint32_t timeout_ms) {
-    (void) sock;
-    (void) timeout_ms;
-}
-
-/* Issue 0787 — the platform UDP primitives this backend's `nros_udp`
- * transport calls. They live in the Rust platform layer, which a standalone C
- * build of this backend does not link, so the smoke test stubs them exactly as
- * it already stubs the registry entry point. Every one FAILS: the test never
- * opens a transport, and a stub that pretended to succeed would make the test
- * assert against a socket that does not exist.
+/* Issue 0832 — the platform clock, sleep and UDP primitives are NOT stubbed
+ * here any more.
  *
- * Without these the test did not LINK, which is why nothing built this backend
- * on a host and why five phase-376 signature changes crossed it unchecked. */
-int8_t nros_platform_udp_create_endpoint(void *ep, const uint8_t *address,
-                                         const uint8_t *port) {
-    (void) ep;
-    (void) address;
-    (void) port;
-    return -1;
-}
-void nros_platform_udp_free_endpoint(void *ep) { (void) ep; }
-int8_t nros_platform_udp_open(void *sock, const void *endpoint, uint32_t timeout_ms) {
-    (void) sock;
-    (void) endpoint;
-    (void) timeout_ms;
-    return -1;
-}
-void nros_platform_udp_close(void *sock) { (void) sock; }
-size_t nros_platform_udp_read(const void *sock, uint8_t *buf, size_t len) {
-    (void) sock;
-    (void) buf;
-    (void) len;
-    return 0;
-}
-size_t nros_platform_udp_send(const void *sock, const uint8_t *buf, size_t len,
-                              const void *endpoint) {
-    (void) sock;
-    (void) buf;
-    (void) len;
-    (void) endpoint;
-    return 0;
-}
+ * Issue 0787 added nine local definitions because "they live in the Rust
+ * platform layer, which a standalone C build of this backend does not link".
+ * That is no longer true: the backend allocates through `nros_platform_alloc`,
+ * so this project links `nros_platform_posix`, and the same archive defines
+ * every one of these — `clock_ns` and `sleep_ms` in `platform.c`, all fifteen
+ * `udp_*` entry points in `net.c`.
+ *
+ * Keeping the stubs would be a second implementation of the platform ABI
+ * chosen by link order, and the two disagree: the stubs deliberately FAIL every
+ * call while the real ones work. Only two collided at link time — `clock_ns`
+ * and `sleep_ms` — because the linker pulls an archive member only for an
+ * already-unresolved reference, so the local UDP definitions meant `net.c.o`
+ * was never reached. A silent win by link order is exactly the hazard the
+ * issue-0050 weak-symbol policy exists to prevent, arrived at without any weak
+ * symbol.
+ *
+ * `nros_rmw_cffi_register{,_named}` above stay stubbed: those live in the Rust
+ * cffi crate, which this project genuinely does not link, and the stub IS the
+ * assertion — it records the vtable the backend hands over.
+ */
 
 /* Issue 0782 — the streamed-publish chunk loop.
  *

--- a/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
@@ -34,7 +34,7 @@ fn main() {
     // Phase 124.D.3.c — SPSC ring depth per subscriber. Default 4
     // keeps the static-RAM bump small (4 × SUBSCRIBER_BUFFER_SIZE
     // per subscriber); raise for burst-heavy topics. Must be ≥ 1.
-    let ring_depth: usize = env_usize("ZPICO_SUBSCRIBER_RING_DEPTH", 4).max(1);
+    let ring_depth: usize = env_usize_min("ZPICO_SUBSCRIBER_RING_DEPTH", 4, 1);
     // Phase 231 (RFC-0038) — size-class receive buffers. `SUBSCRIBER_BUFFER_SIZE`
     // above is the `small` class slot size; the `large` class is for big
     // messages (images, point clouds). A subscription routes to `large` when its
@@ -42,13 +42,13 @@ fn main() {
     // so the big slots don't multiply across every subscriber.
     let large_size: usize = env_usize("ZPICO_SUBSCRIBER_LARGE_SIZE", 16384);
     let size_threshold: usize = env_usize("ZPICO_SUBSCRIBER_SIZE_THRESHOLD", 2048);
-    let max_large: usize = env_usize("ZPICO_MAX_LARGE_SUBSCRIBERS", 2).max(1);
+    let max_large: usize = env_usize_min("ZPICO_MAX_LARGE_SUBSCRIBERS", 2, 1);
     // Phase 268 — per-session per-node NN liveliness token cap. One zenoh
     // session hosts at most the executor's node cap of graph nodes, so this
     // tracks `nros-node`'s `NROS_EXECUTOR_MAX_NODES` (default 4); keep them in
     // sync — set the same env var for both. `.max(1)` so a session always has
     // room for its own primary node.
-    let max_nodes: usize = env_usize("NROS_EXECUTOR_MAX_NODES", 4).max(1);
+    let max_nodes: usize = env_usize_min("NROS_EXECUTOR_MAX_NODES", 4, 1);
     // Issue 0813 — per-publisher TX arena capacity for the zero-copy loan path
     // (`SlotLending`). This was a bare `const` in `shim/publisher.rs`, so its
     // 1 KiB ceiling was neither raisable by a consumer nor visible to
@@ -116,6 +116,39 @@ const KCONFIG_KNOBS: &[(&str, &str)] = &[
         "CONFIG_NROS_SERVICE_BUFFER_SIZE",
     ),
 ];
+
+/// issue 0827 — a floored knob must REFUSE a value below its floor, never
+/// round it up.
+///
+/// These three pools cannot be zero-length: the lookup paths index them
+/// unconditionally, which is what the `.max(1)` this replaces was protecting.
+/// But `.max(1)` protected it by SILENTLY substituting 1, so
+/// `ZPICO_MAX_LARGE_SUBSCRIBERS=0` built a 65,536-byte pool and reported
+/// nothing — measured on `examples/native/rust/talker`, knob 0 and knob 1
+/// produce byte-identical `LARGE_PAYLOADS`.
+///
+/// That matters now because 0827's fix derives these knobs from the resolved
+/// model: an image with no subscriptions would ask for 0, get 1, and reserve
+/// 64 KiB while every config file and inventory line read as satisfied. A knob
+/// that cannot honour a value has to say so at BUILD time, where the person
+/// who set it is standing — the alternative is a saving that looks applied and
+/// is not, which is the defect class this campaign keeps finding.
+///
+/// Unset stays silent: the defaults are all above the floor.
+fn env_usize_min(name: &str, default: usize, min: usize) -> usize {
+    let v = env_usize(name, default);
+    if v < min {
+        panic!(
+            "{name}={v} is below this pool's floor of {min}.\n  \
+             The lookup path indexes the pool unconditionally, so a shorter one \
+             is not representable — raise the value, or change the lookup to \
+             refuse the entity kind first (issue 0827).\n  \
+             This used to be silently rounded up to {min}, which reserved the \
+             memory anyway while reading as though the knob had been honoured."
+        );
+    }
+    v
+}
 
 fn env_usize(name: &str, default: usize) -> usize {
     match KCONFIG_KNOBS.iter().find(|(env, _)| *env == name) {

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/service.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/service.rs
@@ -13,7 +13,9 @@ use super::{
 };
 use crate::{
     keyexpr::ServiceKeyExpr,
-    zpico::{self, Queryable, ZPICO_MAX_QUERYABLES, ZPICO_MAX_SESSIONS},
+    zpico::{
+        self, Queryable, ZPICO_MAX_QUERYABLES, ZPICO_MAX_SESSIONS, ZPICO_QUERYABLE_TABLE_DECLARED,
+    },
 };
 
 #[cfg(feature = "std")]
@@ -331,16 +333,42 @@ impl ZenohServiceServer {
             // that creates them, as `PARAM_SERVICE_QUERYABLES` and
             // `LIFECYCLE_SERVICE_QUERYABLES`; the message names the knob and
             // the cause, which is all this layer actually knows.
+            // phase-392 W5.e — the same exhaustion, TWO different faults, and
+            // the message has to say which. Sized from the backend's own
+            // budget, the table is simply too small and the fix is the knob.
+            // Sized from the entry's DECLARATION (`ZPICO_QUERYABLE_TABLE_DECLARED`),
+            // it holds exactly what the model said this image would create, so
+            // reaching this point means the image created a service server the
+            // model does not declare — and pointing that reader at the knob
+            // sends them to enlarge a table that was already right.
+            //
+            // Being authoritative costs precisely this: "the declaration is
+            // wrong" and "the table is too small" become the same event, so the
+            // message must name the first (phase-392 W5.b2).
             #[cfg(feature = "std")]
-            log::error!(
-                "service server rejected: ZPICO_MAX_QUERYABLES={} exhausted for \
-                 session {} (a service server is a queryable, and the ROS \
-                 parameter and REP-2002 lifecycle services claim theirs before \
-                 the application declares anything). Raise ZPICO_MAX_QUERYABLES \
-                 and rebuild.",
-                ZPICO_MAX_QUERYABLES,
-                session_index,
-            );
+            if ZPICO_QUERYABLE_TABLE_DECLARED {
+                log::error!(
+                    "service server rejected: this image created an UNDECLARED service \
+                     server. Its queryable table holds {} slot(s) for session {}, sized \
+                     from what the resolved SystemModel declares — so the table is not \
+                     too small, the declaration is incomplete. Declare the service \
+                     server in the launch file (a service server is a queryable, and an \
+                     action server is three). Raising ZPICO_MAX_QUERYABLES also works \
+                     and leaves the model disagreeing with the image.",
+                    ZPICO_MAX_QUERYABLES,
+                    session_index,
+                );
+            } else {
+                log::error!(
+                    "service server rejected: ZPICO_MAX_QUERYABLES={} exhausted for \
+                     session {} (a service server is a queryable, and the ROS \
+                     parameter and REP-2002 lifecycle services claim theirs before \
+                     the application declares anything). Raise ZPICO_MAX_QUERYABLES \
+                     and rebuild.",
+                    ZPICO_MAX_QUERYABLES,
+                    session_index,
+                );
+            }
             // issue 0460 — the `log::error!` above is the ONLY place that named
             // the knob, and it is `cfg(feature = "std")`: on every embedded
             // image the caller got a bare `ServiceServerCreationFailed` and no
@@ -356,12 +384,20 @@ impl ZenohServiceServer {
             // ever be copies. Seven copies existed; two had drifted to the
             // wrong value. Say what this layer knows — the table, the knob, and
             // that the runtime claims slots first.
-            return Err(TransportError::Backend(
+            // The `no_std` half of the same split. `Backend` carries a
+            // `&'static str`, so both spellings are compile-time constants and
+            // the branch costs nothing at runtime.
+            return Err(TransportError::Backend(if ZPICO_QUERYABLE_TABLE_DECLARED {
+                "undeclared service server — the zenoh queryable table was sized from \
+                 what this entry's SystemModel declares, and it is full. The table is \
+                 not too small; the declaration is incomplete. Declare the service \
+                 server in the launch file (an action server declares three)."
+            } else {
                 "zenoh queryable table exhausted — raise CONFIG_NROS_MAX_QUERYABLES \
                  (env ZPICO_MAX_QUERYABLES). A service server IS a queryable, and the \
                  ROS parameter and REP-2002 lifecycle services claim theirs before an \
-                 entry's own callbacks.",
-            ));
+                 entry's own callbacks."
+            }));
         }
         let buffer_index = session_index * ZPICO_MAX_QUERYABLES + local;
 

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/service.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/service.rs
@@ -315,16 +315,28 @@ impl ZenohServiceServer {
             NEXT_SERVICE_BUFFER_INDEX[session_index].fetch_sub(1, Ordering::SeqCst);
             // issue 0406 — this table is the reason, and the bare
             // `ServiceServerCreationFailed` never said so. A service server IS a
-            // queryable, and the ROS parameter services (6) plus the REP-2002
-            // lifecycle services (6) consume twelve slots before an application
-            // declares anything, so an entry enabling both overflowed an 8-slot
-            // table AT BOOT and reported only "creation failed" — which reads as
-            // a transport or naming fault, not a capacity limit. Name the knob.
+            // queryable, and the runtime registers its own before the
+            // application declares anything, so an entry enabling the parameter
+            // and lifecycle services overflowed an 8-slot table AT BOOT and
+            // reported only "creation failed" — which reads as a transport or
+            // naming fault, not a capacity limit. Name the knob.
+            //
+            // issue 0827 — this message used to quote those counts ("param
+            // services use 6 and lifecycle services use 6"). It was wrong
+            // (lifecycle is 5) and it could not be otherwise: this crate does
+            // not depend on `nros-node` and cannot see either the counts or
+            // whether their features are even compiled in. A number stated
+            // where it cannot be derived is a number that drifts, and this was
+            // one of six such spellings. The counts now live beside the code
+            // that creates them, as `PARAM_SERVICE_QUERYABLES` and
+            // `LIFECYCLE_SERVICE_QUERYABLES`; the message names the knob and
+            // the cause, which is all this layer actually knows.
             #[cfg(feature = "std")]
             log::error!(
                 "service server rejected: ZPICO_MAX_QUERYABLES={} exhausted for \
-                 session {} (a service server is a queryable; ROS param services \
-                 use 6 and lifecycle services use 6). Raise ZPICO_MAX_QUERYABLES \
+                 session {} (a service server is a queryable, and the ROS \
+                 parameter and REP-2002 lifecycle services claim theirs before \
+                 the application declares anything). Raise ZPICO_MAX_QUERYABLES \
                  and rebuild.",
                 ZPICO_MAX_QUERYABLES,
                 session_index,
@@ -337,11 +349,18 @@ impl ZenohServiceServer {
             // `nros` prints it verbatim — which is how the three zephyr
             // `workspaces/features` entries finally named their own failure
             // instead of dying quietly after "Network ready".
+            // issue 0827 — this string used to quote the counts (6 and 5, and
+            // 11 for the pair). Correct at the time, and still the wrong place
+            // for them: this crate cannot see `nros-node`'s constants or
+            // whether their features are compiled in, so the numbers could only
+            // ever be copies. Seven copies existed; two had drifted to the
+            // wrong value. Say what this layer knows — the table, the knob, and
+            // that the runtime claims slots first.
             return Err(TransportError::Backend(
                 "zenoh queryable table exhausted — raise CONFIG_NROS_MAX_QUERYABLES \
-                 (env ZPICO_MAX_QUERYABLES). A service server IS a queryable: the ROS \
-                 parameter services use 6 and the REP-2002 lifecycle services 5, so an \
-                 entry declaring both needs 11 before its own callbacks.",
+                 (env ZPICO_MAX_QUERYABLES). A service server IS a queryable, and the \
+                 ROS parameter and REP-2002 lifecycle services claim theirs before an \
+                 entry's own callbacks.",
             ));
         }
         let buffer_index = session_index * ZPICO_MAX_QUERYABLES + local;

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
@@ -32,9 +32,9 @@ pub use zpico_sys::{
     ZPICO_ERR_CONFIG, ZPICO_ERR_FULL, ZPICO_ERR_GENERIC, ZPICO_ERR_INVALID, ZPICO_ERR_KEYEXPR,
     ZPICO_ERR_PUBLISH, ZPICO_ERR_SESSION, ZPICO_ERR_TASK, ZPICO_ERR_TIMEOUT, ZPICO_MAX_LIVELINESS,
     ZPICO_MAX_PENDING_GETS, ZPICO_MAX_PUBLISHERS, ZPICO_MAX_QUERYABLES, ZPICO_MAX_SESSIONS,
-    ZPICO_MAX_SUBSCRIBERS, ZPICO_OK, ZPICO_PEER_MODE_SUPPORTED, ZPICO_RMW_GID_SIZE, ZPICO_ZID_SIZE,
-    ZpicoCallback, ZpicoCallbackWithAttachment, ZpicoNotifyCallback, ZpicoQueryCallback,
-    zpico_property_t, zpico_ring_desc_t,
+    ZPICO_MAX_SUBSCRIBERS, ZPICO_OK, ZPICO_PEER_MODE_SUPPORTED, ZPICO_QUERYABLE_TABLE_DECLARED,
+    ZPICO_RMW_GID_SIZE, ZPICO_ZID_SIZE, ZpicoCallback, ZpicoCallbackWithAttachment,
+    ZpicoNotifyCallback, ZpicoQueryCallback, zpico_property_t, zpico_ring_desc_t,
 };
 
 // Import FFI functions from sys crate

--- a/packages/rmw/zenoh/nros-zpico-build/src/lib.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/lib.rs
@@ -17,6 +17,17 @@ pub struct ShimConfig {
     pub max_publishers: usize,
     pub max_subscribers: usize,
     pub max_queryables: usize,
+    /// phase-392 W5.e — whether [`ShimConfig::max_queryables`] was sized from a
+    /// DECLARATION (the resolved SystemModel, via `nros ws entity-facts`) or
+    /// from the backend's own budget.
+    ///
+    /// The runtime needs to know which, because the two produce the same
+    /// failure for different reasons. Sized from a budget, an exhausted table
+    /// means "raise the knob". Sized from a declaration, it means the image
+    /// created a service server its model does not declare — and saying "raise
+    /// the knob" there sends the reader to fix the symptom. Being authoritative
+    /// costs this, and phase-392 W5.b2 says it is paid in the same wave.
+    pub queryable_table_declared: bool,
     pub max_liveliness: usize,
     pub max_pending_gets: usize,
     /// phase-328 (issue 0348) — size of the C shim's session pool
@@ -123,6 +134,11 @@ impl ShimConfig {
              pub const ZPICO_MAX_PENDING_GETS: usize = {};\n\
              /// Size of the session pool (set via ZPICO_MAX_SESSIONS, default 1). phase-328 / issue 0348.\n\
              pub const ZPICO_MAX_SESSIONS: usize = {};\n\
+             /// phase-392 W5.e — whether the queryable table was sized from the entry's\n\
+             /// DECLARATION rather than from the backend's own budget. Decides which\n\
+             /// exhaustion message the shim gives: a budget is raised, a declaration is\n\
+             /// corrected.\n\
+             pub const ZPICO_QUERYABLE_TABLE_DECLARED: bool = {};\n\
              /// Whether this shim was compiled with the multicast transport + scouting\n\
              /// that zenoh PEER mode needs (issue 0682). Emitted from the SAME constant\n\
              /// that writes the C `#define`, so the two cannot drift.\n\
@@ -133,6 +149,7 @@ impl ShimConfig {
             self.max_liveliness,
             self.max_pending_gets,
             self.max_sessions,
+            self.queryable_table_declared,
             multicast_transport_enabled(),
         )
     }
@@ -894,6 +911,7 @@ int32_t zpico_init(void);\n";
             max_publishers: 1,
             max_subscribers: 2,
             max_queryables: 3,
+            queryable_table_declared: true,
             max_liveliness: 4,
             max_pending_gets: 5,
             max_sessions: 9,
@@ -909,6 +927,9 @@ int32_t zpico_init(void);\n";
         assert!(body.contains("ZPICO_MAX_PUBLISHERS: usize = 1;"));
         assert!(body.contains("ZPICO_MAX_PENDING_GETS: usize = 5;"));
         assert!(body.contains("ZPICO_MAX_SESSIONS: usize = 9;"));
+        // phase-392 W5.e — the shim's exhaustion message branches on this, so
+        // it has to arrive with the size it describes.
+        assert!(body.contains("ZPICO_QUERYABLE_TABLE_DECLARED: bool = true;"));
         assert!(!body.contains("get_reply_buf_size"));
     }
 
@@ -928,6 +949,7 @@ int32_t zpico_init(void);\n";
                 max_publishers: 1,
                 max_subscribers: 2,
                 max_queryables: 3,
+                queryable_table_declared: false,
                 max_liveliness: 4,
                 max_pending_gets: 5,
                 max_sessions: 1,
@@ -952,6 +974,11 @@ int32_t zpico_init(void);\n";
             // The knobs that were already correct stay correct in both states —
             // the point of the loop is that `tx_batch` gates only its own pair.
             assert_eq!(get("ZPICO_MAX_QUERYABLES"), "3");
+            // …and the other value of the W5.e flag really is emitted.
+            assert!(
+                cfg.rust_consts()
+                    .contains("ZPICO_QUERYABLE_TABLE_DECLARED: bool = false;")
+            );
             assert_eq!(
                 defines.iter().any(|(k, _)| *k == "ZPICO_TX_BATCH"),
                 tx_batch

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -99,8 +99,24 @@ fn queryable_default_from(declared: Option<&str>, infra: Option<&str>, hosted: b
                  SystemModel (phase-392 W5)."
             ),
         },
-        // The hosted guess survives only while undeclared images do. W5.f
-        // retires both once every image declares.
+        // phase-392 W5.b1 — the model answered the INFRASTRUCTURE half and not
+        // the application half, which is the normal case and not a broken
+        // channel: `ros-launch-manifest` models service wiring, but the
+        // resolver only emits it when the launch inputs describe endpoints,
+        // and a plain `<node>` element does not. All 115 resolved models in
+        // this tree are that shape. `nros ws entity-facts` therefore ABSTAINS
+        // rather than reporting a zero it cannot support — reporting 0 for a
+        // node called `add_server` would size the table to the infrastructure
+        // alone and exhaust it at registration.
+        //
+        // So: keep the app headroom, but stop paying for infrastructure the
+        // image demonstrably does not carry. On a native talker that is 32 -> 8
+        // slots, which is most of the pool.
+        None if infra.is_some() => UNDECLARED_HEADROOM,
+        // Nothing was delivered at all — no model, no cmake seam, a bare
+        // `cargo build`. The historical budgets, unchanged. W5.f retires both
+        // once every image declares; that needs the hand-written-`main`
+        // question settled first (phase-392 W5, Open).
         None => return if hosted { 32 } else { UNDECLARED_HEADROOM },
     };
 
@@ -129,6 +145,42 @@ fn queryable_default_from(declared: Option<&str>, infra: Option<&str>, hosted: b
 #[cfg(test)]
 mod queryable_default_tests {
     use super::*;
+
+    /// phase-392 W5.b1 — the half the model CAN answer, on its own.
+    ///
+    /// This is the shape every resolved model in the tree produces: the
+    /// infrastructure flags are known (they are `execution.features`), the
+    /// application's own service-server count is not (no resolver here emits
+    /// layer-1 wiring). The app term stays a labelled headroom constant; the
+    /// infrastructure term becomes exact.
+    #[test]
+    fn infra_declared_without_an_app_count_still_drops_the_hosted_guess() {
+        // A native talker: no parameter services, no lifecycle. 32 -> 8.
+        assert_eq!(
+            queryable_default_from(None, Some("none"), true),
+            UNDECLARED_HEADROOM
+        );
+        // An image that carries both: the headroom PLUS what they cost.
+        assert_eq!(
+            queryable_default_from(None, Some("param+lifecycle"), true),
+            UNDECLARED_HEADROOM + PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES
+        );
+        // And it is the same number on an embedded target: the hosted/embedded
+        // sniff decides nothing once the declaration arrives.
+        assert_eq!(
+            queryable_default_from(None, Some("none"), false),
+            queryable_default_from(None, Some("none"), true)
+        );
+    }
+
+    /// An unknown infrastructure spelling is a BROKEN CHANNEL, not an unknown
+    /// feature — `nros ws entity-facts` emits one of four strings and drops
+    /// names it does not recognise (`safety`) before it gets here.
+    #[test]
+    #[should_panic(expected = "NROS_DECLARED_INFRA_QUERYABLES")]
+    fn an_unknown_infra_spelling_panics_even_without_an_app_count() {
+        queryable_default_from(None, Some("safety"), true);
+    }
 
     #[test]
     fn undeclared_keeps_the_historical_budgets() {

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -25,6 +25,172 @@ use crate::{
 type ShimConfig = crate::ShimConfig;
 type ZenohBufferConfig = crate::ZenohBufferConfig;
 
+/// Queryables the ROS parameter services claim, mirroring
+/// `nros_node::parameter_services::PARAM_SERVICE_QUERYABLES`.
+///
+/// A MIRROR, and the only one left. This crate is a build-script helper: it
+/// cannot depend on `nros-node`, so it cannot read the constant, and cargo does
+/// not expose another crate's features to a build script either. Held to the
+/// definition by `check-infra-queryable-counts`, which is why the seven prose
+/// spellings this replaced could drift and this one cannot. See phase-392 W5.
+const PARAM_SERVICE_QUERYABLES: usize = 6;
+
+/// Queryables the REP-2002 lifecycle services claim, mirroring
+/// `nros_node::lifecycle_services::LIFECYCLE_SERVICE_QUERYABLES`. FIVE, not six.
+const LIFECYCLE_SERVICE_QUERYABLES: usize = 5;
+
+/// Headroom for a build that declares nothing.
+///
+/// This is the pre-phase-392-W5 embedded budget, kept EXACTLY so an undeclared
+/// embedded image sizes as it always did. W5.f retires it together with the
+/// hosted guess once every image declares; until then it is the fallback, not
+/// the answer.
+const UNDECLARED_HEADROOM: usize = 8;
+
+/// The queryable-table default, from the declaration when there is one.
+///
+/// phase-392 W5.d — `SERVICE_BUFFERS` is `ZPICO_MAX_SESSIONS *
+/// ZPICO_MAX_QUERYABLES` service buffers, so this number is 4,504 bytes of
+/// static RAM per slot. It used to be `if hosted { 32 } else { 8 }`: a literal
+/// picked for headroom because nothing here knew the answer, costing a native
+/// talker 144,128 bytes for services it does not have.
+///
+/// `NROS_DECLARED_SERVICE_SERVERS` is the application's own count, resolved
+/// from the SystemModel and delivered by the same path phase-351 W5 uses for
+/// board facts (`corrosion_set_env_vars`, which reaches cargo where
+/// `set(ENV{...})` does not — issue 0460). The infrastructure counts are added
+/// HERE rather than by whoever computes that figure, because codegen sees the
+/// user's entities and never the runtime's: deriving the total from the app's
+/// service count alone is issue 0460's defect exactly.
+///
+/// `NROS_DECLARED_INFRA_QUERYABLES` carries whether those runtime services are
+/// compiled in. Absent, both are assumed present — the safe direction, since
+/// over-reserving wastes RAM while under-reserving fails at boot.
+///
+/// With no declaration at all this returns the historical embedded budget and
+/// says nothing; W5.e turns that case into a build-time failure, which needs
+/// the hand-written-`main` question settled first (phase-392 W5, Open).
+fn resolve_queryable_default() -> usize {
+    queryable_default_from(
+        std::env::var("NROS_DECLARED_SERVICE_SERVERS")
+            .ok()
+            .as_deref(),
+        std::env::var("NROS_DECLARED_INFRA_QUERYABLES")
+            .ok()
+            .as_deref(),
+        std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("none"),
+    )
+}
+
+/// The rule, with the environment lifted out so it can be tested.
+///
+/// A build script reading env directly is untestable in-process (env is
+/// global), which is how a sizing rule ends up verified by reading.
+fn queryable_default_from(declared: Option<&str>, infra: Option<&str>, hosted: bool) -> usize {
+    let app = match declared {
+        Some(v) => match v.trim().parse::<usize>() {
+            Ok(n) => n,
+            // A malformed declaration must not silently become "undeclared":
+            // that is the `.max(1)` shape issue 0827 measured, where a value
+            // reads as applied and is not.
+            Err(_) => panic!(
+                "NROS_DECLARED_SERVICE_SERVERS={v:?} is not a count. It is the \
+                 number of service servers the entry declares, resolved from the \
+                 SystemModel (phase-392 W5)."
+            ),
+        },
+        // The hosted guess survives only while undeclared images do. W5.f
+        // retires both once every image declares.
+        None => return if hosted { 32 } else { UNDECLARED_HEADROOM },
+    };
+
+    let infra = match infra {
+        Some("none") => 0,
+        Some("param") => PARAM_SERVICE_QUERYABLES,
+        Some("lifecycle") => LIFECYCLE_SERVICE_QUERYABLES,
+        Some("param+lifecycle") | Some("all") => {
+            PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES
+        }
+        Some(other) => panic!(
+            "NROS_DECLARED_INFRA_QUERYABLES={other:?} is not one of \
+             none|param|lifecycle|param+lifecycle (phase-392 W5)."
+        ),
+        // Undeclared infrastructure is assumed PRESENT: over-reserving costs
+        // RAM, under-reserving fails at boot with an exhausted table.
+        None => PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES,
+    };
+
+    // A table of zero would make every service-server registration fail, so an
+    // entry declaring none still gets one slot rather than a pool nothing can
+    // index.
+    core::cmp::max(app + infra, 1)
+}
+
+#[cfg(test)]
+mod queryable_default_tests {
+    use super::*;
+
+    #[test]
+    fn undeclared_keeps_the_historical_budgets() {
+        assert_eq!(queryable_default_from(None, None, true), 32);
+        assert_eq!(
+            queryable_default_from(None, None, false),
+            UNDECLARED_HEADROOM
+        );
+    }
+
+    #[test]
+    fn a_declaration_beats_the_hosted_guess() {
+        // The talker case: no services, no infrastructure. Measured at 4,504
+        // bytes of SERVICE_BUFFERS against 144,128 for the guess.
+        assert_eq!(queryable_default_from(Some("0"), Some("none"), true), 1);
+    }
+
+    #[test]
+    fn infrastructure_is_added_here_not_by_the_declarer() {
+        // Issue 0460: codegen sees the user's entities and never the runtime's.
+        assert_eq!(
+            queryable_default_from(Some("0"), Some("param+lifecycle"), true),
+            11
+        );
+        assert_eq!(
+            queryable_default_from(Some("2"), Some("param+lifecycle"), true),
+            13
+        );
+        assert_eq!(queryable_default_from(Some("2"), Some("param"), true), 8);
+        assert_eq!(
+            queryable_default_from(Some("2"), Some("lifecycle"), true),
+            7
+        );
+    }
+
+    #[test]
+    fn unknown_infrastructure_is_assumed_present() {
+        // Over-reserving wastes RAM; under-reserving fails at boot.
+        assert_eq!(queryable_default_from(Some("0"), None, true), 11);
+    }
+
+    #[test]
+    fn the_hosted_split_stops_mattering_once_declared() {
+        assert_eq!(
+            queryable_default_from(Some("3"), Some("none"), true),
+            queryable_default_from(Some("3"), Some("none"), false)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a count")]
+    fn a_malformed_count_is_not_silently_undeclared() {
+        queryable_default_from(Some("lots"), Some("none"), true);
+    }
+
+    #[test]
+    #[should_panic(expected = "is not one of")]
+    fn an_unknown_infrastructure_spelling_is_refused() {
+        queryable_default_from(Some("0"), Some("params"), true);
+    }
+}
+
 fn shim_config_from_env() -> ShimConfig {
     // issue 0406 — these tables are STATIC arrays in the C shim, so every slot
     // costs RAM whether or not it is used. 8 is an embedded budget, and it was
@@ -50,8 +216,7 @@ fn shim_config_from_env() -> ShimConfig {
     // costs a hosted image 144,128 bytes of service buffers whether or not it
     // has a single service. Replacing the guess needs the declaration to reach
     // here from the resolved model; see issue 0827.
-    let hosted = std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("none");
-    let queryable_default = if hosted { 32 } else { 8 };
+    let queryable_default = resolve_queryable_default();
     ShimConfig {
         max_publishers: env_usize("ZPICO_MAX_PUBLISHERS", 8),
         max_subscribers: env_usize("ZPICO_MAX_SUBSCRIBERS", 8),

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -30,15 +30,26 @@ fn shim_config_from_env() -> ShimConfig {
     // costs RAM whether or not it is used. 8 is an embedded budget, and it was
     // applied to hosted targets too, where the same RAM argument does not hold.
     //
-    // A service server IS a queryable. An entry that enables the ROS parameter
-    // services (6) and the REP-2002 lifecycle services (6) needs twelve before
-    // the application declares anything of its own, so on a hosted target the
+    // A service server IS a queryable, and the runtime registers its own
+    // before the application declares anything — so on a hosted target the
     // 8-slot table overflowed at boot and every entry in
     // `examples/workspaces/features` died with a bare
     // `Transport(ServiceServerCreationFailed)`.
     //
     // Hosted targets get headroom; `target_os = "none"` keeps the embedded
     // budget exactly as before. Override with the env var on either side.
+    //
+    // issue 0827 — this comment used to say "(6)" and "(6)" and "needs
+    // twelve". Lifecycle is FIVE, so it is eleven, and "twelve" propagated
+    // from here into other prose. The counts are now
+    // `nros_node::parameter_services::PARAM_SERVICE_QUERYABLES` and
+    // `nros_node::lifecycle_services::LIFECYCLE_SERVICE_QUERYABLES`, beside
+    // the code that creates them. This crate cannot READ them — a build script
+    // sees neither another crate's constants nor its features — which is
+    // exactly why `32` below is a guess rather than a derivation, and why it
+    // costs a hosted image 144,128 bytes of service buffers whether or not it
+    // has a single service. Replacing the guess needs the declaration to reach
+    // here from the resolved model; see issue 0827.
     let hosted = std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("none");
     let queryable_default = if hosted { 32 } else { 8 };
     ShimConfig {

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -70,16 +70,130 @@ const UNDECLARED_HEADROOM: usize = 8;
 /// With no declaration at all this returns the historical embedded budget and
 /// says nothing; W5.e turns that case into a build-time failure, which needs
 /// the hand-written-`main` question settled first (phase-392 W5, Open).
-fn resolve_queryable_default() -> usize {
-    queryable_default_from(
-        std::env::var("NROS_DECLARED_SERVICE_SERVERS")
-            .ok()
-            .as_deref(),
-        std::env::var("NROS_DECLARED_INFRA_QUERYABLES")
-            .ok()
-            .as_deref(),
-        std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("none"),
-    )
+fn resolve_queryable_default() -> QueryableSizing {
+    let declared = std::env::var("NROS_DECLARED_SERVICE_SERVERS").ok();
+    let infra = std::env::var("NROS_DECLARED_INFRA_QUERYABLES").ok();
+    QueryableSizing {
+        default: queryable_default_from(
+            declared.as_deref(),
+            infra.as_deref(),
+            std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("none"),
+        ),
+        floor: queryable_floor_from(declared.as_deref(), infra.as_deref()),
+        declared: declared.is_some() || infra.is_some(),
+    }
+}
+
+/// What the queryable table was sized from, and what it may not go below.
+struct QueryableSizing {
+    /// The size to use when nothing overrides it.
+    default: usize,
+    /// The DERIVED lower bound: slots the image provably needs before the
+    /// application declares anything. See [`queryable_floor_from`].
+    floor: usize,
+    /// Whether any part of this came from a declaration.
+    declared: bool,
+}
+
+/// The slots this image PROVABLY needs, as opposed to the ones it is budgeted.
+///
+/// phase-392 W5.f — `ZPICO_MAX_QUERYABLES` stops being the primary input and
+/// becomes an override, and an override has to be checked rather than trusted.
+/// But the check must compare against something DERIVED: [`queryable_default_from`]
+/// adds [`UNDECLARED_HEADROOM`] whenever the application count is unavailable,
+/// and refusing a build for being under a guess would be the same defect one
+/// level up.
+///
+/// The infrastructure cost is not a guess. An image compiled with the ROS
+/// parameter services claims [`PARAM_SERVICE_QUERYABLES`] slots at boot, with
+/// the REP-2002 lifecycle services [`LIFECYCLE_SERVICE_QUERYABLES`], and a
+/// declared application service server claims one each. Below that sum the
+/// image cannot start, which is issue 0460 exactly: an 8-slot table against
+/// eleven infrastructure queryables, discovered at boot as a bare
+/// `ServiceServerCreationFailed`. That is now a BUILD failure, where the
+/// person who set the knob is standing.
+///
+/// Undeclared images have a floor of zero: nothing is known, so nothing is
+/// provable, and the historical budgets apply unchecked.
+fn queryable_floor_from(declared: Option<&str>, infra: Option<&str>) -> usize {
+    if declared.is_none() && infra.is_none() {
+        return 0;
+    }
+    let app = declared
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    app + infra_queryables(infra)
+}
+
+/// phase-392 W5.f — `ZPICO_MAX_QUERYABLES` as a CHECKED override.
+///
+/// Two mechanisms deciding one number is how this phase's other defects were
+/// born, so the knob stops being an independent opinion: below the derived
+/// floor it is refused, and below the budgeted default it is reported.
+///
+/// The two levels are not the same claim and must not be conflated. The FLOOR
+/// is provable — an image carrying the parameter and lifecycle services claims
+/// eleven slots before the application declares anything, so a smaller table
+/// cannot boot. The DEFAULT adds [`UNDECLARED_HEADROOM`] for an application
+/// count nothing can supply yet; being under THAT is a plausible problem, not a
+/// certain one, and refusing a build over a guess is the defect this wave
+/// exists to remove.
+///
+/// This is issue 0460 caught one stage earlier. `CONFIG_NROS_MAX_QUERYABLES`
+/// defaults to 8 in `zephyr/Kconfig`, and an entry enabling both service
+/// families needs eleven: that image used to build cleanly and die at boot with
+/// a bare `ServiceServerCreationFailed`.
+fn check_queryable_override(requested: usize, sizing: &QueryableSizing) {
+    if !sizing.declared {
+        return;
+    }
+    if requested < sizing.floor {
+        panic!(
+            "ZPICO_MAX_QUERYABLES={requested} is below this image's DERIVED floor of \
+             {} (phase-392 W5.f).\n  \
+             A service server IS a zenoh queryable. This image declares the \
+             infrastructure services and application service servers that claim those \
+             slots at boot, so a smaller table cannot start — it fails with \
+             `ServiceServerCreationFailed` and no explanation (issue 0460).\n  \
+             On Zephyr this knob is CONFIG_NROS_MAX_QUERYABLES, whose Kconfig default \
+             is 8; raise it, or stop declaring the services the image does not have.",
+            sizing.floor
+        );
+    }
+    if requested < sizing.default {
+        println!(
+            "cargo:warning=ZPICO_MAX_QUERYABLES={requested} is under the budgeted {} \
+             ({} provably claimed at boot, plus {} of headroom for application service \
+             servers the model does not describe). It will boot; an application \
+             declaring more than {} service servers will not (phase-392 W5.f).",
+            sizing.default,
+            sizing.floor,
+            sizing.default - sizing.floor,
+            requested.saturating_sub(sizing.floor),
+        );
+    }
+}
+
+/// What `NROS_DECLARED_INFRA_QUERYABLES` costs, in slots.
+///
+/// ONE parser, shared by the default and the floor: two readings of the same
+/// spelling is how a sizing rule and its check come to disagree.
+fn infra_queryables(infra: Option<&str>) -> usize {
+    match infra {
+        Some("none") => 0,
+        Some("param") => PARAM_SERVICE_QUERYABLES,
+        Some("lifecycle") => LIFECYCLE_SERVICE_QUERYABLES,
+        Some("param+lifecycle") | Some("all") => {
+            PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES
+        }
+        Some(other) => panic!(
+            "NROS_DECLARED_INFRA_QUERYABLES={other:?} is not one of \
+             none|param|lifecycle|param+lifecycle (phase-392 W5)."
+        ),
+        // Undeclared infrastructure is assumed PRESENT: over-reserving costs
+        // RAM, under-reserving fails at boot with an exhausted table.
+        None => PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES,
+    }
 }
 
 /// The rule, with the environment lifted out so it can be tested.
@@ -120,21 +234,7 @@ fn queryable_default_from(declared: Option<&str>, infra: Option<&str>, hosted: b
         None => return if hosted { 32 } else { UNDECLARED_HEADROOM },
     };
 
-    let infra = match infra {
-        Some("none") => 0,
-        Some("param") => PARAM_SERVICE_QUERYABLES,
-        Some("lifecycle") => LIFECYCLE_SERVICE_QUERYABLES,
-        Some("param+lifecycle") | Some("all") => {
-            PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES
-        }
-        Some(other) => panic!(
-            "NROS_DECLARED_INFRA_QUERYABLES={other:?} is not one of \
-             none|param|lifecycle|param+lifecycle (phase-392 W5)."
-        ),
-        // Undeclared infrastructure is assumed PRESENT: over-reserving costs
-        // RAM, under-reserving fails at boot with an exhausted table.
-        None => PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES,
-    };
+    let infra = infra_queryables(infra);
 
     // A table of zero would make every service-server registration fail, so an
     // entry declaring none still gets one slot rather than a pool nothing can
@@ -145,6 +245,65 @@ fn queryable_default_from(declared: Option<&str>, infra: Option<&str>, hosted: b
 #[cfg(test)]
 mod queryable_default_tests {
     use super::*;
+
+    /// phase-392 W5.f — the floor is DERIVED, and it is not the default.
+    #[test]
+    fn the_floor_counts_only_what_is_provably_claimed() {
+        // Undeclared: nothing is known, so nothing is provable.
+        assert_eq!(queryable_floor_from(None, None), 0);
+        // Infrastructure declared absent: an image that declares nothing still
+        // needs nothing, even though its BUDGET is 8.
+        assert_eq!(queryable_floor_from(None, Some("none")), 0);
+        assert_eq!(queryable_default_from(None, Some("none"), true), 8);
+        // Both service families: eleven slots claimed at boot. This is the
+        // number issue 0460 discovered at runtime against a table of 8.
+        assert_eq!(
+            queryable_floor_from(None, Some("param+lifecycle")),
+            PARAM_SERVICE_QUERYABLES + LIFECYCLE_SERVICE_QUERYABLES
+        );
+        // A declared application count is provable too — it is what the model
+        // says the image will create.
+        assert_eq!(queryable_floor_from(Some("2"), Some("lifecycle")), 7);
+    }
+
+    fn sizing(declared: Option<&str>, infra: Option<&str>) -> QueryableSizing {
+        QueryableSizing {
+            default: queryable_default_from(declared, infra, true),
+            floor: queryable_floor_from(declared, infra),
+            declared: declared.is_some() || infra.is_some(),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "below this image's DERIVED floor")]
+    fn an_override_under_the_derived_floor_is_refused() {
+        // zephyr/Kconfig's `default 8` for CONFIG_NROS_MAX_QUERYABLES against
+        // an entry carrying both service families: issue 0460's build, caught
+        // at build time instead of at boot.
+        check_queryable_override(8, &sizing(None, Some("param+lifecycle")));
+    }
+
+    #[test]
+    fn an_override_at_the_floor_is_accepted() {
+        // Exactly enough to boot. It is tight, not wrong.
+        check_queryable_override(11, &sizing(None, Some("param+lifecycle")));
+    }
+
+    #[test]
+    fn an_override_under_the_budget_is_only_reported() {
+        // The three `workspaces/features` zephyr entries: 16 against a budgeted
+        // 19, of which 11 is provable and 8 is headroom for an application
+        // count no model here supplies. Refusing this would be refusing a build
+        // for being under a guess.
+        check_queryable_override(16, &sizing(None, Some("param+lifecycle")));
+    }
+
+    #[test]
+    fn an_undeclared_image_is_not_checked_at_all() {
+        // Nothing was declared, so nothing is known — the historical budgets
+        // apply and any override is the caller's business, exactly as before.
+        check_queryable_override(1, &sizing(None, None));
+    }
 
     /// phase-392 W5.b1 — the half the model CAN answer, on its own.
     ///
@@ -268,11 +427,14 @@ fn shim_config_from_env() -> ShimConfig {
     // costs a hosted image 144,128 bytes of service buffers whether or not it
     // has a single service. Replacing the guess needs the declaration to reach
     // here from the resolved model; see issue 0827.
-    let queryable_default = resolve_queryable_default();
+    let sizing = resolve_queryable_default();
+    let max_queryables = env_usize("ZPICO_MAX_QUERYABLES", sizing.default);
+    check_queryable_override(max_queryables, &sizing);
     ShimConfig {
         max_publishers: env_usize("ZPICO_MAX_PUBLISHERS", 8),
         max_subscribers: env_usize("ZPICO_MAX_SUBSCRIBERS", 8),
-        max_queryables: env_usize("ZPICO_MAX_QUERYABLES", queryable_default),
+        max_queryables,
+        queryable_table_declared: sizing.declared,
         max_liveliness: env_usize("ZPICO_MAX_LIVELINESS", 16),
         max_pending_gets: env_usize("ZPICO_MAX_PENDING_GETS", 4),
         max_sessions: env_usize("ZPICO_MAX_SESSIONS", 1),

--- a/packages/testing/nros-tests/Cargo.toml
+++ b/packages/testing/nros-tests/Cargo.toml
@@ -374,6 +374,15 @@ path = "tests/integration_px4.rs"
 name = "logging"
 path = "tests/logging.rs"
 
+# issue 0900 — the first-spin arena-headroom advisory. Its OWN binary because
+# the advisory is one-shot on a process-scoped flag: any other spinning test in
+# the same binary would consume it first, and tests run in parallel, so sharing
+# would make it pass or fail by scheduling.
+[[test]]
+name = "executor_arena_advisory"
+path = "tests/executor_arena_advisory.rs"
+required-features = ["component-runtime-test"]
+
 # Phase 88.15 — RTOS smoke fixtures + QEMU output capture.
 [[test]]
 name = "logging_smoke"

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/.cargo/config.toml
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv7m-none-eabi"
+
+[target.thumbv7m-none-eabi]
+runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
+rustflags = [
+    "-C", "link-arg=-Tlink.x",
+    "-C", "link-arg=--nmagic",
+]

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/.gitignore
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/Cargo.toml
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/Cargo.toml
@@ -1,0 +1,34 @@
+[workspace]
+
+[package]
+name = "heap-free-poc-mps2"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+description = "phase-391 W5-endgame (issues 0816/0843) — the heap-free-tier image: calls the real executor + component-install seam and links with NO allocation symbol at all"
+
+[[bin]]
+name = "heap-free-poc-mps2"
+test = false
+bench = false
+
+[dependencies]
+# The point of this image: `nros` WITHOUT the `alloc` feature. The macro-path
+# runtime (per-class static storage, placed cells, `install_node_typed_in`)
+# is available on `rmw-cffi` alone since the W5 endgame; if a future change
+# re-couples it to `alloc`, this leaf stops COMPILING — which is the cheapest
+# possible tripwire for issue 0843's regression class.
+nros = { path = "../../../../api/nros", default-features = false, features = ["rmw-cffi", "macros"] }
+# Platform primitives WITHOUT the heap libc shims: `default-features = false`
+# drops `libc-heap` (malloc/free/realloc/calloc) — a DEFINED `malloc` counts
+# as an allocation surface for the W1 gate whether or not anything calls it —
+# and `libc-stubs` (string helpers), which only C transports need.
+# `cffi-export` keeps `nros_platform_log_write` resolving for nros-log.
+nros-platform-mps2-an385 = { path = "../../../../platform/nros-platform-mps2-an385", default-features = false, features = ["cffi-export"] }
+nros-platform-cffi = { path = "../../../../platform/nros-platform-cffi", default-features = false }
+nros-log = { path = "../../../../core/nros-log", default-features = false }
+
+cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
+panic-semihosting = { version = "0.6", features = ["exit"] }

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/build.rs
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/build.rs
@@ -1,0 +1,16 @@
+//! Phase 88.15.a — emit `memory.x` into OUT_DIR so cortex-m-rt's
+//! `link.x` finds it without depending on the board crate's build
+//! script.
+
+use std::{env, fs::File, io::Write, path::PathBuf};
+
+fn main() {
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/memory.x
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/memory.x
@@ -1,0 +1,6 @@
+/* Minimal memory layout for MPS2-AN385 (QEMU Cortex-M3) — Phase 88.15.a */
+MEMORY
+{
+    FLASH : ORIGIN = 0x00000000, LENGTH = 4M
+    RAM   : ORIGIN = 0x20000000, LENGTH = 4M
+}

--- a/packages/testing/nros-tests/bins/heap-free-poc-mps2/src/main.rs
+++ b/packages/testing/nros-tests/bins/heap-free-poc-mps2/src/main.rs
@@ -1,0 +1,115 @@
+//! phase-391 W5-endgame (issues 0816/0843) — the heap-free-tier image.
+//!
+//! Calls the REAL runtime path an embedded component image takes —
+//! `Executor::open_in` over a caller-supplied static backing, then the
+//! `install_node_typed_in` seam over a per-class `ComponentSlotStorage` — and
+//! links with **no allocation symbol at all**: no `#[global_allocator]`, no
+//! `__rust_alloc` shim, no `malloc`, no `nros_platform_alloc`. The W1 gate
+//! (`scripts/check-no-alloc-image.py --tier heap-free`) asserts that on the
+//! built ELF; three earlier probes passed it vacuously at `symbols read: 1`
+//! because they only NAMED types — this image is the non-vacuous replacement.
+//!
+//! No RMW backend is linked (every in-tree transport allocates in C — zenoh's
+//! `z_malloc`, XRCE's wrapper `malloc`, cyclone's `ddsrt_malloc` — so a
+//! transport image is `unified` tier at best). `Executor::open_in` therefore
+//! returns `NoBackend` at RUNTIME, which the image reports as its success
+//! marker: the LINK property is the property under test, and the runtime
+//! marker proves the code path executed to the open call rather than being
+//! optimized away. The install + spin arm stays linked because the open's
+//! outcome is opaque to LLVM (it reads the cffi backend registry).
+
+#![no_std]
+#![no_main]
+
+use core::mem::MaybeUninit;
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::{debug, hprintln};
+use nros::{
+    BootConfig, ComponentSlotStorage, EntityBounds, ExecutorConfig, ExecutorSizing,
+    node::{Callback, CallbackCtx, ExecutableNode, Node, NodeContext, NodeResult, TickCtx},
+};
+use panic_semihosting as _;
+
+// Force-link the per-platform export so `nros_platform_log_write` resolves
+// (the logging-smoke pattern — staticlib DCE drops the rlib otherwise).
+extern crate nros_platform_mps2_an385 as _;
+
+/// A component that declares NOTHING — the seam is under test, not a
+/// transport. Exact zero bounds, so its per-class cell registries and ctx
+/// slabs are all zero-length: the whole static store is a few words.
+struct PocNode;
+
+impl Node for PocNode {
+    const NAME: &'static str = "heap_free_poc";
+    const ENTITY_BOUNDS: EntityBounds = EntityBounds::exact(0, 0, 0, 0, 0);
+
+    fn register(_ctx: &mut NodeContext<'_>) -> NodeResult<()> {
+        Ok(())
+    }
+}
+
+impl ExecutableNode for PocNode {
+    type State = u32;
+
+    fn init() -> Self::State {
+        0
+    }
+
+    fn on_callback(_state: &mut Self::State, _cb: Callback<'_>, _ctx: &mut CallbackCtx<'_>) {}
+
+    fn tick(state: &mut Self::State, _ctx: &mut TickCtx<'_>) {
+        *state = state.wrapping_add(1);
+    }
+}
+
+/// The per-class slot storage the macro would emit — spelled by hand here so
+/// the image does not need `nros::main!`'s board scaffold (whose
+/// `ExecutorNodeRuntime` half is the alloc-gated DYNAMIC path).
+static POC_STORE: ComponentSlotStorage<PocNode> = ComponentSlotStorage::new();
+
+/// Caller-supplied executor backing — the `open_in` contract. `static mut`
+/// touched exactly once, before the executor exists.
+static mut BACKING: [MaybeUninit<u64>; ExecutorSizing::DEFAULT.u64_len()] =
+    [MaybeUninit::uninit(); ExecutorSizing::DEFAULT.u64_len()];
+
+#[entry]
+fn main() -> ! {
+    nros_platform_cffi::log::init_default();
+
+    let config = ExecutorConfig::resolve(BootConfig {
+        node_name: Some("heap_free_poc"),
+        locator: None,
+        domain_id: Some(0),
+        namespace: None,
+    });
+
+    // SAFETY: `BACKING` is `'static`, exactly `u64_len()` words, and this is
+    // the only reference ever taken (single-threaded `#[entry]`, before any
+    // executor exists).
+    let backing: &'static mut [MaybeUninit<u64>] = unsafe { &mut *(&raw mut BACKING) };
+
+    match unsafe { nros::Executor::open_in(&config, backing, ExecutorSizing::DEFAULT) } {
+        Ok(mut executor) => {
+            // Unreachable on this fixture (no backend linked), but LLVM cannot
+            // prove that, so the whole install + spin path is IN the image —
+            // which is exactly what the link gate measures.
+            let rc = unsafe {
+                nros::install_node_typed_in(
+                    &mut executor as *mut _ as *mut core::ffi::c_void,
+                    &POC_STORE,
+                )
+            };
+            hprintln!("HEAP-FREE-POC: unexpected open success, install rc={}", rc);
+            let _ = executor.spin_once(core::time::Duration::from_millis(10));
+            debug::exit(debug::EXIT_FAILURE);
+        }
+        Err(_) => {
+            // The expected arm: selection fails (zero backends registered)
+            // AFTER the executor machinery is linked and the open path ran.
+            hprintln!("HEAP-FREE-POC: open refused (no RMW linked) — link property holds");
+            debug::exit(debug::EXIT_SUCCESS);
+        }
+    }
+    loop {}
+}

--- a/packages/testing/nros-tests/tests/component_dispatch.rs
+++ b/packages/testing/nros-tests/tests/component_dispatch.rs
@@ -108,51 +108,6 @@ use self::register as talker_register;
 // Tests
 // =============================================================================
 
-/// issue 0900 — the arena an image is GIVEN is derived by budgeting every slot
-/// at the ActionClient worst case, so an image without one carries several
-/// times what it can use. Measured on a real opened executor rather than
-/// re-deriving the constant, because the point is what an image actually gets.
-///
-/// The arena is a BUMP allocator, so `arena_used` is the exact claimed total,
-/// not a per-slot reservation — the allocator has always known this number and
-/// until now had no way to say it.
-///
-/// This asserts the DEFECT, so it is expected to fail (and want rewriting) once
-/// 0900 lands a per-kind derivation. That is the point: it pins the number that
-/// a fix has to move.
-#[rstest]
-fn executor_arena_is_over_provisioned_for_a_timer_only_image(zenohd_unique: ZenohRouter) {
-    if !require_zenohd() {
-        nros_tests::skip!("zenohd not found");
-    }
-
-    let locator = zenohd_unique.locator();
-    let cfg = ExecutorConfig::new(&locator)
-        .node_name("arena_headroom")
-        .domain_id(181);
-    let mut executor = Executor::open(&cfg).expect("Executor::open failed");
-
-    let capacity = executor.arena_capacity();
-    assert!(capacity > 0, "an executor with a zero arena is issue 0460");
-
-    executor
-        .register_timer(nros::TimerDuration::from_millis(100), || {})
-        .expect("register_timer");
-    let used = executor.arena_used();
-
-    assert!(
-        used > 0,
-        "registering a timer must claim arena bytes; a bump allocator that          charges nothing is not measuring anything"
-    );
-    // The defect, stated as a number. A timer-only image is the cheapest
-    // possible workload and must not come anywhere near an arena sized for
-    // MAX_CBS action clients.
-    assert!(
-        used * 2 <= capacity,
-        "issue 0900 regression check: a timer-only executor claimed {used} of          {capacity} arena bytes. If this now FAILS because usage rose, the          arena derivation may have been fixed — re-read the issue before          raising the threshold"
-    );
-}
-
 #[rstest]
 fn dispatch_fires_timer_callback(zenohd_unique: ZenohRouter) {
     if !require_zenohd() {

--- a/packages/testing/nros-tests/tests/component_dispatch.rs
+++ b/packages/testing/nros-tests/tests/component_dispatch.rs
@@ -108,6 +108,51 @@ use self::register as talker_register;
 // Tests
 // =============================================================================
 
+/// issue 0900 — the arena an image is GIVEN is derived by budgeting every slot
+/// at the ActionClient worst case, so an image without one carries several
+/// times what it can use. Measured on a real opened executor rather than
+/// re-deriving the constant, because the point is what an image actually gets.
+///
+/// The arena is a BUMP allocator, so `arena_used` is the exact claimed total,
+/// not a per-slot reservation — the allocator has always known this number and
+/// until now had no way to say it.
+///
+/// This asserts the DEFECT, so it is expected to fail (and want rewriting) once
+/// 0900 lands a per-kind derivation. That is the point: it pins the number that
+/// a fix has to move.
+#[rstest]
+fn executor_arena_is_over_provisioned_for_a_timer_only_image(zenohd_unique: ZenohRouter) {
+    if !require_zenohd() {
+        nros_tests::skip!("zenohd not found");
+    }
+
+    let locator = zenohd_unique.locator();
+    let cfg = ExecutorConfig::new(&locator)
+        .node_name("arena_headroom")
+        .domain_id(181);
+    let mut executor = Executor::open(&cfg).expect("Executor::open failed");
+
+    let capacity = executor.arena_capacity();
+    assert!(capacity > 0, "an executor with a zero arena is issue 0460");
+
+    executor
+        .register_timer(nros::TimerDuration::from_millis(100), || {})
+        .expect("register_timer");
+    let used = executor.arena_used();
+
+    assert!(
+        used > 0,
+        "registering a timer must claim arena bytes; a bump allocator that          charges nothing is not measuring anything"
+    );
+    // The defect, stated as a number. A timer-only image is the cheapest
+    // possible workload and must not come anywhere near an arena sized for
+    // MAX_CBS action clients.
+    assert!(
+        used * 2 <= capacity,
+        "issue 0900 regression check: a timer-only executor claimed {used} of          {capacity} arena bytes. If this now FAILS because usage rose, the          arena derivation may have been fixed — re-read the issue before          raising the threshold"
+    );
+}
+
 #[rstest]
 fn dispatch_fires_timer_callback(zenohd_unique: ZenohRouter) {
     if !require_zenohd() {

--- a/packages/testing/nros-tests/tests/executor_arena_advisory.rs
+++ b/packages/testing/nros-tests/tests/executor_arena_advisory.rs
@@ -1,0 +1,138 @@
+//! Issue 0900 — the executor arena is derived by budgeting EVERY slot at the
+//! ActionClient worst case, so an image without one carries several times what
+//! it can use. Two things are asserted here, both against a REAL opened
+//! executor rather than by re-deriving the build-time constant, because the
+//! point is what an image actually gets:
+//!
+//! 1. the gap itself (a timer-only executor claims 32 bytes of 74,240), and
+//! 2. that the first-spin advisory REACHES A SINK, which is the whole value of
+//!    W1 — a diagnostic nobody sees is the folklore it was meant to replace.
+//!
+//! # Why its own test binary
+//!
+//! The advisory is one-shot on a process-scoped flag (see
+//! `executor::arena::ARENA_ADVISORY_DONE` — a static rather than an `Executor`
+//! field, because a field would move `EXECUTOR_OPAQUE_U64S` and every image's
+//! executor footprint to buy a diagnostic). Any other test in the same binary
+//! that spins would consume it first, and Rust runs tests in parallel, so
+//! sharing a binary would make this pass or fail by scheduling. The sink list
+//! is global for the same reason.
+
+#![cfg(feature = "component-runtime-test")]
+
+use nros_rmw_zenoh as _;
+
+use std::{sync::Mutex, time::Duration};
+
+use nros::{Executor, ExecutorConfig, TimerDuration};
+use nros_log::{LogSink, Record, init};
+use nros_tests::fixtures::{ZenohRouter, require_zenohd, zenohd_unique};
+use rstest::rstest;
+
+static CAPTURED: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+struct CapturingSink;
+
+impl LogSink for CapturingSink {
+    fn log(&self, record: &Record<'_>) {
+        // unwrap: poisoned only if another thread already panicked, which
+        // would have failed the test anyway.
+        CAPTURED.lock().unwrap().push(record.message.to_string());
+    }
+}
+
+static SINK: CapturingSink = CapturingSink;
+static SINKS: &[&dyn LogSink] = &[&SINK];
+
+/// The advisory must be EMITTED and must REACH a sink.
+///
+/// `nros_log` holds records in an early ring while no sink is installed and
+/// replays them on `init`, so a missing line here means the advisory did not
+/// fire — not that logging swallowed it.
+#[rstest]
+fn first_spin_reports_an_over_provisioned_arena(zenohd_unique: ZenohRouter) {
+    if !require_zenohd() {
+        nros_tests::skip!("zenohd not found");
+    }
+    init(SINKS);
+    CAPTURED.lock().unwrap().clear();
+
+    let locator = zenohd_unique.locator();
+    let cfg = ExecutorConfig::new(&locator)
+        .node_name("arena_advisory")
+        .domain_id(182);
+    let mut executor = Executor::open(&cfg).expect("Executor::open failed");
+
+    let capacity = executor.arena_capacity();
+    assert!(
+        capacity > 0,
+        "a zero-capacity arena is issue 0460, not headroom"
+    );
+
+    executor
+        .register_timer(TimerDuration::from_millis(100), || {})
+        .expect("register_timer");
+    let used = executor.arena_used();
+
+    assert!(
+        used > 0,
+        "registering a timer must claim arena bytes; a bump allocator that \
+         charges nothing is not measuring anything"
+    );
+    // The defect, stated as a number. A timer-only image is the cheapest
+    // possible workload and must not come near an arena sized for MAX_CBS
+    // action clients. Expected to want rewriting once a per-kind derivation
+    // lands — that is the point, it pins the number a fix has to move.
+    assert!(
+        used * 2 <= capacity,
+        "issue 0900: a timer-only executor claimed {used} of {capacity} arena \
+         bytes. If this FAILS because usage rose, the derivation may have been \
+         fixed — re-read the issue before raising the threshold"
+    );
+
+    executor.spin_once(Duration::from_millis(10));
+    let after_first = CAPTURED.lock().unwrap().len();
+    // Spin again: the advisory names a BUILD-TIME constant, so saying it once
+    // per process is the whole contract, and a per-spin log line on an RTOS
+    // target is a flood (issue 0371's shape). Asserted here rather than in a
+    // second test because the flag is process-scoped — a separate test would
+    // observe an already-consumed flag and assert nothing, which is the vacuous
+    // shape `check-no-vacuous-tests` exists to catch.
+    executor.spin_once(Duration::from_millis(10));
+    assert_eq!(
+        CAPTURED.lock().unwrap().len(),
+        after_first,
+        "the arena advisory repeated on a second spin; it is one-shot"
+    );
+
+    let records = CAPTURED.lock().unwrap().clone();
+    let advisory = records
+        .iter()
+        .find(|m| m.contains("arena over-provisioned"))
+        .unwrap_or_else(|| {
+            panic!(
+                "the first-spin arena advisory reached no sink. {} record(s) \
+                 captured: {records:?}",
+                records.len()
+            )
+        });
+
+    // It must carry the number to SET, not merely say the arena is big — the
+    // knob it names has existed all along and went unset because nothing
+    // computed a value for it (issues 0271/0739).
+    assert!(
+        advisory.contains("NROS_EXECUTOR_ARENA_SIZE="),
+        "the advisory must name the value to set, not just report the waste: \
+         {advisory}"
+    );
+    // `nros_log`'s call-site buffer is 256 bytes by default and truncates with
+    // a `…`. The first version of this line ran ~450 bytes, so the sink got the
+    // whole explanation and none of the value. Guard the budget, not just the
+    // wording — an advisory cut before its actionable half is worse than none,
+    // because it reads as though it helped.
+    assert!(
+        !advisory.contains('\u{2026}'),
+        "the advisory overflowed nros_log's format buffer and was truncated; \
+         shorten it or the value to set never reaches the user: {advisory}"
+    );
+}

--- a/scripts/check-infra-queryable-counts.py
+++ b/scripts/check-infra-queryable-counts.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Issue 0827 — the infrastructure-queryable counts have ONE definition each,
+and it matches the number of servers actually created.
+
+A service server IS a zenoh queryable, so these counts are a term in every
+service-buffer pool the RMW sizes. They had SEVEN spellings and no definition:
+the count of creation statements, two doc comments, `nros-zpico-build`'s
+default-picking comment, and two RMW runtime messages, plus CLAUDE.md. Two had
+drifted — both said lifecycle was 6, which is where the widely-quoted "twelve
+slots before the application declares anything" came from. It is eleven.
+
+A constant alone would not have caught that: it is still a hand-typed literal,
+and a seventh parameter service would leave it stale exactly as the prose was.
+So this ties the constant to the CREATION SITES, which is the thing that
+actually decides the number.
+
+Python rather than shell, deliberately: `check-gate-selftests`'s call detector
+requires parentheses, which a bash function call never has, so a shell gate can
+only ever classify as flag-only and land in a baseline that may only shrink.
+"""
+
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SPIN = "packages/core/nros-node/src/executor/spin.rs"
+PARAMS = "packages/core/nros-node/src/parameter_services.rs"
+LIFECYCLE = "packages/core/nros-node/src/lifecycle_services.rs"
+
+# (label, creation fn, constant, file that must define it)
+GROUPS = [
+    ("ROS parameter services", "create_param_srv", "PARAM_SERVICE_QUERYABLES", PARAMS),
+    ("REP-2002 lifecycle services", "create_lc_srv", "LIFECYCLE_SERVICE_QUERYABLES", LIFECYCLE),
+]
+
+# An RMW backend must NOT restate these: it does not depend on `nros-node` and
+# can see neither the constants nor whether their features are compiled in. A
+# number stated where it cannot be derived is a number that drifts — which is
+# how both wrong spellings got there.
+RESTATE = re.compile(r"(param|parameter).{0,40}services\s+(use|consume)?\s*\(?\d+\)?", re.I)
+
+
+def sites(text, creator):
+    return len(re.findall(rf"^\s+let [a-z0-9_]+ = {creator}::<", text, re.M))
+
+
+def declared(text, name):
+    m = re.search(rf"^pub const {name}: usize = (\d+);", text, re.M)
+    return int(m.group(1)) if m else None
+
+
+def read(root, rel):
+    with open(os.path.join(root, rel), encoding="utf8") as fh:
+        return fh.read()
+
+
+def check(root, rmw_dir="packages/rmw"):
+    """Return a list of problem strings (empty == pass)."""
+    problems = []
+    try:
+        spin = read(root, SPIN)
+    except OSError as e:
+        return [f"missing {SPIN}: {e}"]
+
+    for label, creator, const, const_rel in GROUPS:
+        n = sites(spin, creator)
+        try:
+            want = declared(read(root, const_rel), const)
+        except OSError as e:
+            problems.append(f"{const}: cannot read {const_rel}: {e}")
+            continue
+        if want is None:
+            problems.append(
+                f"{const} not found in {const_rel} — the count must have exactly "
+                f"one definition, beside the code that creates them."
+            )
+        elif n == 0:
+            # Never agree with a constant because the pattern stopped matching:
+            # that is a blind gate reporting success.
+            problems.append(
+                f"no `{creator}::<...>` sites found in {SPIN} — the creation shape "
+                f"changed and this gate is now blind. Fix the pattern; do not delete the check."
+            )
+        elif n != want:
+            problems.append(
+                f"{label}: {n} `{creator}` site(s) in {SPIN}, but {const} = {want}. "
+                f"A service server is a queryable — update {const_rel} so every pool "
+                f"sized from it moves too."
+            )
+
+    rmw_root = os.path.join(root, rmw_dir)
+    for dirpath, dirnames, filenames in os.walk(rmw_root):
+        dirnames[:] = [d for d in dirnames if d not in ("target", "build")]
+        for fn in filenames:
+            if not fn.endswith(".rs"):
+                continue
+            full = os.path.join(dirpath, fn)
+            try:
+                with open(full, encoding="utf8", errors="replace") as fh:
+                    for i, line in enumerate(fh, 1):
+                        if RESTATE.search(line):
+                            rel = os.path.relpath(full, root)
+                            problems.append(
+                                f"{rel}:{i} states an infrastructure-queryable count. "
+                                f"Name the knob and the cause; the counts live beside "
+                                f"the code that creates them."
+                            )
+            except OSError:
+                continue
+    return problems
+
+
+def _write(root, n_param, n_lc, c_param, c_lc, rmw_line):
+    for rel in (SPIN, PARAMS, LIFECYCLE, "packages/rmw/zenoh/x/src/service.rs"):
+        os.makedirs(os.path.join(root, os.path.dirname(rel)), exist_ok=True)
+    body = "".join(f"        let h{i} = create_param_srv::<T>(\n" for i in range(n_param))
+    body += "".join(f"        let l{i} = create_lc_srv::<T>(\n" for i in range(n_lc))
+    open(os.path.join(root, SPIN), "w").write(body)
+    open(os.path.join(root, PARAMS), "w").write(
+        f"pub const PARAM_SERVICE_QUERYABLES: usize = {c_param};\n")
+    open(os.path.join(root, LIFECYCLE), "w").write(
+        f"pub const LIFECYCLE_SERVICE_QUERYABLES: usize = {c_lc};\n")
+    open(os.path.join(root, "packages/rmw/zenoh/x/src/service.rs"), "w").write(rmw_line + "\n")
+
+
+def self_test():
+    """Every probe asserts a failure this gate must catch, plus the clean case,
+    so a gate that stopped matching anything cannot report success."""
+    cases = [
+        ((6, 5, 6, 5, "// nothing"), 0, "counts agree"),
+        ((6, 5, 6, 6, "// nothing"), 1, "lifecycle constant drifted to 6 (the historical error)"),
+        ((7, 5, 6, 5, "// nothing"), 1, "a 7th parameter service was added"),
+        ((0, 5, 6, 5, "// nothing"), 1, "creation-site pattern stopped matching"),
+        ((6, 5, 6, 5, "// parameter services use 6"), 1, "an RMW restated a count"),
+    ]
+    failures = 0
+    tmp = tempfile.mkdtemp()
+    try:
+        for args, want, label in cases:
+            root = os.path.join(tmp, "t")
+            shutil.rmtree(root, ignore_errors=True)
+            _write(root, *args)
+            got = 1 if check(root) else 0
+            if got != want:
+                sys.stderr.write(f"  self-test FAIL: {label} — got {got}, want {want}\n")
+                failures += 1
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    if failures:
+        sys.stderr.write(f"check-infra-queryable-counts self-test: FAILED ({failures})\n")
+        sys.exit(1)
+    print("check-infra-queryable-counts self-test: OK")
+
+
+def main():
+    # On the NORMAL path, not behind a flag: a negative control nobody runs
+    # decays into a comment (`check-gate-selftests`).
+    self_test()
+    if "--self-test" in sys.argv:
+        return
+    problems = check(ROOT)
+    if problems:
+        sys.stderr.write("check-infra-queryable-counts: %d problem(s) — issue 0827:\n" % len(problems))
+        for p in problems:
+            sys.stderr.write(f"  - {p}\n")
+        sys.exit(1)
+    for label, creator, const, _ in GROUPS:
+        n = sites(read(ROOT, SPIN), creator)
+        print(f"  ok    {label}: {n} creation site(s) == {const}")
+    print("infra-queryables: counts agree with their creation sites.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-infra-queryable-counts.py
+++ b/scripts/check-infra-queryable-counts.py
@@ -22,6 +22,7 @@ only ever classify as flag-only and land in a baseline that may only shrink.
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 
@@ -58,6 +59,32 @@ def read(root, rel):
         return fh.read()
 
 
+MIRROR = re.compile(r"^const (PARAM_SERVICE_QUERYABLES|LIFECYCLE_SERVICE_QUERYABLES): usize = (\d+);", re.M)
+
+
+def rmw_rust_files(root, rmw_dir):
+    """Tracked `.rs` under `rmw_dir`, via the git index rather than a walk.
+
+    `check-no-tracked-file-find` measured 7m36s -> 0.8s for the same paths, and
+    it is right: this gate reads every RMW source on the fast line.
+    """
+    out = subprocess.run(
+        ["git", "-C", root, "ls-files", f"{rmw_dir}/*.rs"],
+        capture_output=True, text=True,
+    )
+    if out.returncode == 0:
+        return [p for p in out.stdout.split() if "/target/" not in p]
+    found = []
+    # walk-ok: the self-test builds a synthetic tree that is not a git
+    # repository, so there is no index to query. Never reached on the real tree.
+    for dirpath, dirnames, filenames in os.walk(os.path.join(root, rmw_dir)):
+        dirnames[:] = [d for d in dirnames if d not in ("target", "build")]
+        for fn in filenames:
+            if fn.endswith(".rs"):
+                found.append(os.path.relpath(os.path.join(dirpath, fn), root))
+    return found
+
+
 def check(root, rmw_dir="packages/rmw"):
     """Return a list of problem strings (empty == pass)."""
     problems = []
@@ -92,25 +119,46 @@ def check(root, rmw_dir="packages/rmw"):
                 f"sized from it moves too."
             )
 
-    rmw_root = os.path.join(root, rmw_dir)
-    for dirpath, dirnames, filenames in os.walk(rmw_root):
-        dirnames[:] = [d for d in dirnames if d not in ("target", "build")]
-        for fn in filenames:
-            if not fn.endswith(".rs"):
-                continue
-            full = os.path.join(dirpath, fn)
-            try:
-                with open(full, encoding="utf8", errors="replace") as fh:
-                    for i, line in enumerate(fh, 1):
-                        if RESTATE.search(line):
-                            rel = os.path.relpath(full, root)
-                            problems.append(
-                                f"{rel}:{i} states an infrastructure-queryable count. "
-                                f"Name the knob and the cause; the counts live beside "
-                                f"the code that creates them."
-                            )
-            except OSError:
-                continue
+    # phase-392 W5.d — `nros-zpico-build` MIRRORS both counts, and cannot do
+    # otherwise: it is a build-script helper, so it can neither depend on
+    # `nros-node` to read the constants nor see that crate's features. A mirror
+    # is acceptable only while something holds it to the definition — that is
+    # the whole difference between this and the seven prose spellings it
+    # replaced, of which two had drifted.
+    definitions = {}
+    for _, _, const, const_rel in GROUPS:
+        try:
+            definitions[const] = declared(read(root, const_rel), const)
+        except OSError:
+            definitions[const] = None
+
+    for rel in rmw_rust_files(root, rmw_dir):
+        full = os.path.join(root, rel)
+        try:
+            with open(full, encoding="utf8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for i, line in enumerate(text.split("\n"), 1):
+            if RESTATE.search(line):
+                problems.append(
+                    f"{rel}:{i} states an infrastructure-queryable count. "
+                    f"Name the knob and the cause; the counts live beside "
+                    f"the code that creates them."
+                )
+        for m in MIRROR.finditer(text):
+            const, value = m.group(1), int(m.group(2))
+            want = definitions.get(const)
+            if want is None:
+                problems.append(
+                    f"{rel} mirrors {const}, but the definition could not be read."
+                )
+            elif value != want:
+                problems.append(
+                    f"{rel} mirrors {const} = {value}, definition is {want}. "
+                    f"A build-script helper cannot read the constant, so the "
+                    f"mirror is held here instead (phase-392 W5.d)."
+                )
     return problems
 
 
@@ -136,6 +184,10 @@ def self_test():
         ((7, 5, 6, 5, "// nothing"), 1, "a 7th parameter service was added"),
         ((0, 5, 6, 5, "// nothing"), 1, "creation-site pattern stopped matching"),
         ((6, 5, 6, 5, "// parameter services use 6"), 1, "an RMW restated a count"),
+        ((6, 5, 6, 5, "const PARAM_SERVICE_QUERYABLES: usize = 6;"), 0,
+         "a build-script mirror that agrees"),
+        ((6, 5, 6, 5, "const PARAM_SERVICE_QUERYABLES: usize = 7;"), 1,
+         "a build-script mirror that drifted"),
     ]
     failures = 0
     tmp = tempfile.mkdtemp()

--- a/scripts/check-infra-queryable-counts.py
+++ b/scripts/check-infra-queryable-counts.py
@@ -31,6 +31,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SPIN = "packages/core/nros-node/src/executor/spin.rs"
 PARAMS = "packages/core/nros-node/src/parameter_services.rs"
 LIFECYCLE = "packages/core/nros-node/src/lifecycle_services.rs"
+ACTION = "packages/core/nros-node/src/executor/action.rs"
 
 # (label, creation fn, constant, file that must define it)
 GROUPS = [
@@ -49,6 +50,17 @@ def sites(text, creator):
     return len(re.findall(rf"^\s+let [a-z0-9_]+ = {creator}::<", text, re.M))
 
 
+def action_channels(text):
+    """The DISTINCT service channels one action server opens.
+
+    Counted by the `ServiceInfo` each `create_service` is handed, not by call
+    sites: `action.rs` registers the same three channels twice (the typed and
+    the raw arms), so a bare call count says six. The set is what an action
+    costs on the wire.
+    """
+    return {m.group(1) for m in re.finditer(r"create_service\(&(\w+)_info", text)}
+
+
 def declared(text, name):
     m = re.search(rf"^pub const {name}: usize = (\d+);", text, re.M)
     return int(m.group(1)) if m else None
@@ -59,7 +71,17 @@ def read(root, rel):
         return fh.read()
 
 
-MIRROR = re.compile(r"^const (PARAM_SERVICE_QUERYABLES|LIFECYCLE_SERVICE_QUERYABLES): usize = (\d+);", re.M)
+MIRROR = re.compile(
+    r"^const (PARAM_SERVICE_QUERYABLES|LIFECYCLE_SERVICE_QUERYABLES|ACTION_SERVER_QUERYABLES)"
+    r": usize = (\d+);",
+    re.M,
+)
+
+# Files OUTSIDE `packages/rmw` that also mirror a count. The CLI cannot depend
+# on `nros-node` either — it is a host binary and that crate is `no_std` and
+# built for the target — so `nros ws entity-facts` restates the action
+# multiplier and is held to the definition here (phase-392 W5.b2).
+EXTRA_MIRROR_FILES = ["packages/cli/nros-cli-core/src/cmd/entity_facts.rs"]
 
 
 def rmw_rust_files(root, rmw_dir):
@@ -119,6 +141,36 @@ def check(root, rmw_dir="packages/rmw"):
                 f"sized from it moves too."
             )
 
+    # phase-392 W5.b2 — an action server is THREE queryables, and the model
+    # declares actions separately from services. Same rule as the two above:
+    # the constant is held to the code that decides it, so a fourth action
+    # channel cannot silently under-size every image declaring an action.
+    try:
+        action_src = read(root, ACTION)
+    except OSError as e:
+        problems.append(f"ACTION_SERVER_QUERYABLES: cannot read {ACTION}: {e}")
+    else:
+        chans = action_channels(action_src)
+        want = declared(action_src, "ACTION_SERVER_QUERYABLES")
+        if want is None:
+            problems.append(
+                f"ACTION_SERVER_QUERYABLES not found in {ACTION} — the count must "
+                f"have exactly one definition, beside the services it counts."
+            )
+        elif not chans:
+            problems.append(
+                f"no `create_service(&<name>_info` sites found in {ACTION} — the "
+                f"creation shape changed and this gate is now blind. Fix the "
+                f"pattern; do not delete the check."
+            )
+        elif len(chans) != want:
+            problems.append(
+                f"action server: {len(chans)} distinct service channel(s) in "
+                f"{ACTION} ({', '.join(sorted(chans))}), but "
+                f"ACTION_SERVER_QUERYABLES = {want}. A model declaring an action "
+                f"server sizes the queryable table from this."
+            )
+
     # phase-392 W5.d — `nros-zpico-build` MIRRORS both counts, and cannot do
     # otherwise: it is a build-script helper, so it can neither depend on
     # `nros-node` to read the constants nor see that crate's features. A mirror
@@ -131,8 +183,16 @@ def check(root, rmw_dir="packages/rmw"):
             definitions[const] = declared(read(root, const_rel), const)
         except OSError:
             definitions[const] = None
+    try:
+        definitions["ACTION_SERVER_QUERYABLES"] = declared(
+            read(root, ACTION), "ACTION_SERVER_QUERYABLES"
+        )
+    except OSError:
+        definitions["ACTION_SERVER_QUERYABLES"] = None
 
-    for rel in rmw_rust_files(root, rmw_dir):
+    scanned = list(rmw_rust_files(root, rmw_dir))
+    scanned += [r for r in EXTRA_MIRROR_FILES if os.path.isfile(os.path.join(root, r))]
+    for rel in scanned:
         full = os.path.join(root, rel)
         try:
             with open(full, encoding="utf8", errors="replace") as fh:
@@ -156,14 +216,16 @@ def check(root, rmw_dir="packages/rmw"):
             elif value != want:
                 problems.append(
                     f"{rel} mirrors {const} = {value}, definition is {want}. "
-                    f"A build-script helper cannot read the constant, so the "
-                    f"mirror is held here instead (phase-392 W5.d)."
+                    f"Neither a build-script helper nor the host CLI can read "
+                    f"the constant, so the mirror is held here instead "
+                    f"(phase-392 W5.d / W5.b2)."
                 )
     return problems
 
 
-def _write(root, n_param, n_lc, c_param, c_lc, rmw_line):
-    for rel in (SPIN, PARAMS, LIFECYCLE, "packages/rmw/zenoh/x/src/service.rs"):
+def _write(root, n_param, n_lc, c_param, c_lc, rmw_line, chans=3, c_action=3,
+           c_cli_action=3):
+    for rel in (SPIN, PARAMS, LIFECYCLE, ACTION, "packages/rmw/zenoh/x/src/service.rs"):
         os.makedirs(os.path.join(root, os.path.dirname(rel)), exist_ok=True)
     body = "".join(f"        let h{i} = create_param_srv::<T>(\n" for i in range(n_param))
     body += "".join(f"        let l{i} = create_lc_srv::<T>(\n" for i in range(n_lc))
@@ -172,7 +234,19 @@ def _write(root, n_param, n_lc, c_param, c_lc, rmw_line):
         f"pub const PARAM_SERVICE_QUERYABLES: usize = {c_param};\n")
     open(os.path.join(root, LIFECYCLE), "w").write(
         f"pub const LIFECYCLE_SERVICE_QUERYABLES: usize = {c_lc};\n")
+    # Written TWICE, as the real file does (typed + raw arms), so the probe
+    # for "distinct channels, not call sites" is a real one.
+    act = f"pub const ACTION_SERVER_QUERYABLES: usize = {c_action};\n"
+    for _ in range(2):
+        act += "".join(f"    .create_service(&chan{i}_info, qos)\n" for i in range(chans))
+    open(os.path.join(root, ACTION), "w").write(act)
     open(os.path.join(root, "packages/rmw/zenoh/x/src/service.rs"), "w").write(rmw_line + "\n")
+    # The CLI mirror lives outside `packages/rmw`, so it is reached by a
+    # different arm of the scan — exercise it rather than assume it.
+    cli = EXTRA_MIRROR_FILES[0]
+    os.makedirs(os.path.join(root, os.path.dirname(cli)), exist_ok=True)
+    open(os.path.join(root, cli), "w").write(
+        f"const ACTION_SERVER_QUERYABLES: usize = {c_cli_action};\n")
 
 
 def self_test():
@@ -188,6 +262,12 @@ def self_test():
          "a build-script mirror that agrees"),
         ((6, 5, 6, 5, "const PARAM_SERVICE_QUERYABLES: usize = 7;"), 1,
          "a build-script mirror that drifted"),
+        ((6, 5, 6, 5, "// nothing", 4, 3), 1, "a fourth action channel was added"),
+        ((6, 5, 6, 5, "// nothing", 0, 3), 1, "the action creation pattern stopped matching"),
+        ((6, 5, 6, 5, "// nothing", 3, 6), 1,
+         "the action constant counted CALL SITES (6) rather than channels (3)"),
+        ((6, 5, 6, 5, "// nothing", 3, 3, 4), 1,
+         "the CLI mirror drifted — a file OUTSIDE packages/rmw"),
     ]
     failures = 0
     tmp = tempfile.mkdtemp()
@@ -223,6 +303,10 @@ def main():
     for label, creator, const, _ in GROUPS:
         n = sites(read(ROOT, SPIN), creator)
         print(f"  ok    {label}: {n} creation site(s) == {const}")
+    print(
+        f"  ok    action server: {len(action_channels(read(ROOT, ACTION)))} service "
+        f"channel(s) == ACTION_SERVER_QUERYABLES"
+    )
     print("infra-queryables: counts agree with their creation sites.")
 
 

--- a/scripts/check-sched-dim-arms-compile.sh
+++ b/scripts/check-sched-dim-arms-compile.sh
@@ -49,12 +49,31 @@ fail=0
 say()  { printf '  %s\n' "$*"; }
 head2() { printf '\n== %s ==\n' "$*"; }
 
+# A cross gcc on PATH is not a cross gcc that can COMPILE: the CI container
+# ships the bare binary without newlib, so `<string.h>` is absent and every
+# arm FAILs on a header this gate is not testing (the cross-libc gate already
+# skips on the same container for the same reason). Probe usability once —
+# presence of the compiler AND its libc headers — and let each arm skip
+# legibly on the same wording.
+arm_gcc_usable=""
+arm_gcc_unusable_why=""
+if command -v arm-none-eabi-gcc >/dev/null 2>&1; then
+    if printf '#include <string.h>\n#include <stdlib.h>\nint main(void){return 0;}\n' \
+        | arm-none-eabi-gcc -fsyntax-only -x c - >/dev/null 2>&1; then
+        arm_gcc_usable=1
+    else
+        arm_gcc_unusable_why="arm-none-eabi-gcc has no usable newlib (<string.h>/<stdlib.h> absent)"
+    fi
+else
+    arm_gcc_unusable_why="arm-none-eabi-gcc not on PATH"
+fi
+
 # --- freertos: vTaskCoreAffinitySet ----------------------------------------
 head2 "freertos core-pin arm (vTaskCoreAffinitySet)"
 if [ -z "${FREERTOS_DIR:-}" ] || [ ! -d "${FREERTOS_DIR}" ]; then
     nros_check_skip "check-sched-dim-arms(freertos)" "FREERTOS_DIR unset/absent (source ./activate.sh)"
-elif ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
-    nros_check_skip "check-sched-dim-arms(freertos)" "arm-none-eabi-gcc not on PATH"
+elif [ -z "$arm_gcc_usable" ]; then
+    nros_check_skip "check-sched-dim-arms(freertos)" "$arm_gcc_unusable_why"
 else
     out="$(arm-none-eabi-gcc -fsyntax-only -mcpu=cortex-m3 -mthumb \
         -DconfigUSE_CORE_AFFINITY=1 \
@@ -105,8 +124,8 @@ fi
 head2 "nuttx core-pin arm (pthread_setaffinity_np)"
 if [ -z "${NUTTX_DIR:-}" ] || [ ! -d "${NUTTX_DIR}/include" ]; then
     nros_check_skip "check-sched-dim-arms(nuttx)" "NUTTX_DIR unset/absent (source ./activate.sh)"
-elif ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
-    nros_check_skip "check-sched-dim-arms(nuttx)" "arm-none-eabi-gcc not on PATH"
+elif [ -z "$arm_gcc_usable" ]; then
+    nros_check_skip "check-sched-dim-arms(nuttx)" "$arm_gcc_unusable_why"
 elif [ ! -f "$NUTTX_DIR/nros-nuttx-export-arm/include/nuttx/config.h" ]; then
     # Issue 0525. The tree is SHARED SOURCE, but `nuttx/config.h` is build
     # OPTIONS, and one shared copy cannot hold two arches: it belongs to
@@ -155,8 +174,8 @@ fi
 head2 "threadx core-pin arm (tx_thread_smp_core_exclude)"
 if [ -z "${THREADX_DIR:-}" ] || [ ! -d "${THREADX_DIR}/common_smp/inc" ]; then
     nros_check_skip "check-sched-dim-arms(threadx)" "THREADX_DIR unset, or no common_smp/inc (source ./activate.sh)"
-elif ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
-    nros_check_skip "check-sched-dim-arms(threadx)" "arm-none-eabi-gcc not on PATH"
+elif [ -z "$arm_gcc_usable" ]; then
+    nros_check_skip "check-sched-dim-arms(threadx)" "$arm_gcc_unusable_why"
 else
     out="$(arm-none-eabi-gcc -fsyntax-only -mcpu=cortex-a7 \
         -DTX_THREAD_SMP \

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -60,6 +60,16 @@ KNOB_PATTERNS = [
     # wrapper is the natural thing to write when several knobs share a
     # resolution rule, so match the shape rather than asking each crate not to.
     re.compile(r'\bknob\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*\)'),
+    # `env_usize_min("NAME", default, floor)` — a knob whose reader REFUSES a
+    # value below a floor instead of silently rounding it up (issue 0827). The
+    # reported figure is the DEFAULT, exactly as for every other spelling: the
+    # floor is a validity rule on what a user may ask for, not a size the image
+    # pays. Added with the spelling, not after it: renaming the two zpico reads
+    # to this wrapper made `ZPICO_SUBSCRIBER_RING_DEPTH` and
+    # `ZPICO_MAX_LARGE_SUBSCRIBERS` invisible here, and with them the byte
+    # figures for BOTH payload pools -- the `SLOTS` regression this list already
+    # records, one wrapper later.
+    re.compile(r'\benv_usize_min\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*,\s*[0-9_]+\s*\)'),
 ]
 
 # `// nros-pool: NAME = KNOB * KNOB * 4` — products of knobs and integers only.
@@ -90,7 +100,7 @@ def crate_of(rel):
 # the ones issue-0271's failure mode hides (executor arena, zpico batch/frag
 # buffers: the LARGEST consumers). They must appear in the table, not be
 # silently dropped by a literal-only regex.
-KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat)?|knob)\(\s*"([A-Z0-9_]+)"')
+KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat|_min)?|knob)\(\s*"([A-Z0-9_]+)"')
 
 
 def scan(files=None):
@@ -222,7 +232,15 @@ def self_test():
     assert got == 128 and err is None, f"product at defaults wrong: {got} {err}"
     got, err = pool_bytes("A * NOPE", knobs)
     assert got is None and "NOPE" in err, "an unknown knob must not silently vanish"
-    probe = 'let x = env_usize("NROS_PROBE_SLOTS", 12);\n// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
+    # Every reader spelling gets a probe line. A spelling with no case here is
+    # a spelling that can be added, break the scan, and still self-test green —
+    # which is how `env_usize_min` deleted two knobs and two pool figures.
+    probe = (
+        'let x = env_usize("NROS_PROBE_SLOTS", 12);\n'
+        'let y = env_usize_min("NROS_PROBE_DEPTH", 3, 1);\n'
+        '// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
+        '// nros-pool: Q = NROS_PROBE_DEPTH * NROS_PROBE_SLOTS\n'
+    )
     tmp = os.path.join(ROOT, "tmp")
     os.makedirs(tmp, exist_ok=True)
     p = os.path.join(tmp, "_pool_probe.rs")
@@ -231,8 +249,16 @@ def self_test():
     k, pl = scan([os.path.relpath(p, ROOT)])
     os.unlink(p)
     assert k.get("NROS_PROBE_SLOTS", (None,))[0] == 12, "knob not scanned"
-    assert pl and pl[0][0] == "P", "pool annotation not scanned"
-    assert pool_bytes(pl[0][1], k)[0] == 96, "annotated pool bytes wrong"
+    assert k.get("NROS_PROBE_DEPTH", (None,))[0] == 3, (
+        "env_usize_min knob not scanned — its DEFAULT is the reported figure, "
+        "not its floor (issue 0827)"
+    )
+    by_name = {name: expr for name, expr, *_ in pl}
+    assert "P" in by_name, "pool annotation not scanned"
+    assert pool_bytes(by_name["P"], k)[0] == 96, "annotated pool bytes wrong"
+    assert pool_bytes(by_name["Q"], k)[0] == 36, (
+        "a pool sized by an env_usize_min knob must resolve to bytes"
+    )
     sys.stdout.write("gen-pool-inventory self-test: OK\n")
 
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -826,6 +826,24 @@ config NROS_RMW_SUBSCRIBER_SLOTS
       number of subscriptions the image creates. Pool size is this x 1024
       bytes. Read by nros-rmw-cffi build.rs.
 
+config NROS_EXECUTOR_ACTION_CLIENTS
+    int "Callback slots to budget at ActionClient size"
+    default 4
+    help
+      How many of NROS_EXECUTOR_MAX_CBS slots the arena derivation budgets at
+      ACTION CLIENT size (~18 KiB each) rather than pub/sub size (~3.5 KiB).
+      Defaults to MAX_CBS, which reproduces the historical arithmetic exactly,
+      so leaving it alone changes nothing.
+
+      Set it to 0 on an image with no action client: at the defaults that takes
+      the arena from 74240 bytes to 16384. The arena is INLINE ON THE TASK
+      STACK, not in .bss, so this is stack headroom -- see the FreeRTOS
+      "Invalid mbox" note in docs/reference/platform-implementation-notes.md.
+
+      Too small fails at REGISTRATION with BufferTooSmall, not at link. The
+      executor reports what it actually used on its first spin, so build once,
+      read the advisory, then set this. Issue 0900.
+
 config NROS_EXECUTOR_ARENA_SIZE
     int "Executor arena size in bytes (0 = derive)"
     default 0

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -253,6 +253,11 @@ function(nros_resolve_knobs)
     # whole class (nros-node + nros-params sizing knobs) in one place.
     _nros_resolve_knob(NROS_SUBSCRIPTION_BUFFER_SIZE
         "${CONFIG_NROS_SUBSCRIPTION_BUFFER_SIZE}")
+    # issue 0900 — how many slots the arena derivation charges at ActionClient
+    # size. Read by nros-node/build.rs through the derived CONFIG_<name> lookup,
+    # like its siblings above.
+    _nros_resolve_knob(NROS_EXECUTOR_ACTION_CLIENTS
+        "${CONFIG_NROS_EXECUTOR_ACTION_CLIENTS}")
     _nros_resolve_knob(NROS_EXECUTOR_MAX_SC "${CONFIG_NROS_EXECUTOR_MAX_SC}")
     _nros_resolve_knob(NROS_EXECUTOR_MAX_NODES "${CONFIG_NROS_EXECUTOR_MAX_NODES}")
     # issue 0790 — shutdown-hook slots per phase. Read by nros-node/build.rs


### PR DESCRIPTION
Stacked on #29. Lands the *count* half of #827 and records the settled design for the sizing half.

## Seven spellings, no definition, two wrong

A service server IS a zenoh queryable, so how many the **runtime** registers on a node's behalf is a term in every service-buffer pool the RMW sizes. That number existed only as:

1. the count of `create_param_srv::<_>` statements in `executor/spin.rs`
2. the count of `create_lc_srv::<_>` statements in the same file
3. a doc comment on each of those functions
4. `nros-zpico-build`'s comment justifying its 32-slot hosted default
5. the RMW's `std` exhaustion log message
6. the RMW's `no_std` `Backend` message (#460's)
7. CLAUDE.md

**Two had drifted**, both saying lifecycle was 6. It is **five** — so the widely-quoted *"twelve slots before the application declares anything"* is **eleven**. That figure propagated from the build-script comment into the message users see when the table overflows: the two places whose whole job is explaining the limit both explained it wrong.

## The fix

One definition each, beside the code that creates them — `PARAM_SERVICE_QUERYABLES` (6) and `LIFECYCLE_SERVICE_QUERYABLES` (5). Beside, not in the RMW: only the runtime knows it creates these, and deriving them from the user's entity set is #460's defect.

Both RMW messages stop quoting numbers. That crate doesn't depend on `nros-node` and can see neither the constants nor whether their features are compiled in — anything it said could only be a copy.

**A constant alone would not have caught the drift.** It's still a hand-typed literal; a seventh service would leave it stale exactly as the prose was. So `check-infra-queryable-counts` ties each constant to the number of creation sites, and separately forbids an RMW restating a count it cannot derive — **that second rule found mirror #6 on the gate's first run**, which I had missed by reading.

Non-vacuity: three probes each asserting a failure the gate must catch (constant drifting to the historical wrong value; a 7th service appearing; the creation-site pattern going blind, which must fail rather than agree with a constant of zero), plus the clean case. All on the normal path.

Python rather than shell for a recorded reason: `check-gate-selftests`'s call detector requires parentheses, which a bash function call never has, so a shell gate can only classify as `flag-only` and land in a baseline that may only shrink. Zero of the 162 gate scripts classified `auto` are shell.

## Design recorded for the sizing half

- **Const generics reach no non-Rust consumer** — verified: `SERVICE_BUFFERS` is a private `static mut`, C round-trips one opaque token it never does arithmetic on, so the tables are not layout-coupled (not the 0135 class).
- **They're still wrong**: a const generic needs a *type* to carry it, and a C/C++ entry has none — it's cmake-driven. Pushing it up means either a hand-picked N again or a sizing parameter on the C API, which stops it being a thin wrapper of Rust.
- **The declaration must come from the resolved model**, which already carries both the app's services and whether the infrastructure ones exist (`features = ["param_services", "lifecycle"]`, `PlanParamServices`/`PlanLifecycle`). So the feature-forwarding plan and its 15-site gate are **unnecessary**, not merely awkward.
- **Net C/C++ API change: none** — one more `#define` in an already-generated file.
- **Decided: an undeclared image fails loudly** rather than silently reserving 32 (144,128 bytes) whether or not it has a single service.

Pool inventory moves by three line numbers — it records source locations, and the corrected comments shifted them.

`just ci-l1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa
