### PR TITLE
fix(#0884): the issue ledger stops being a shared registry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+
+# issue 0884 — the open-issue index is 100% generated and append-heavy.
+# Union merge lets two agents file issues concurrently without a conflict;
+# `scripts/gen-issue-index.py` re-sorts and `check-issue-index` verifies, so a
+# union that interleaves or duplicates is normalised on the next run rather
+# than shipped. NEVER apply this to an authored file — see docs/issues/README.md.
+docs/issues/open.md merge=union

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -653,7 +653,8 @@ and verified.
 
 - **Parallel agent sessions push to `main` concurrently.** `git fetch` + check
   `origin/main`'s highest issue id (including `archived/`) immediately before
-  filing a `docs/issues/` entry; expect `docs/issues/README.md` rebase conflicts
+  filing a `docs/issues/` entry. The generated list is `docs/issues/open.md` and is
+  `merge=union` (issue 0884), so two agents filing concurrently no longer conflict
   (merge both sides, renumber only your own files). Stash-wrap local-only files
   (`packages/rmw/zenoh/zpico-sys/c/include/zpico.h`-style) around every rebase.
 - **Write full logs of background builds/tests to files** and grep afterwards;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ pointer here — never grow CLAUDE.md with design/impl detail.**
 | --- | --- |
 | Finalized whole-system design | [docs/design/ARCHITECTURE.md](docs/design/ARCHITECTURE.md) |
 | A specific design decision (stable vs evolving) | [docs/design/](docs/design/README.md) — numbered RFCs |
-| A known bug / limitation / tech-debt (troubleshooting) | [docs/issues/](docs/issues/README.md) — numbered issues (open) + `archived/` |
+| A known bug / limitation / tech-debt (troubleshooting) | [docs/issues/](docs/issues/README.md) — numbered issues (open) + `archived/`. Query with `just issues [--area X] [--id N] [text]` (~20 ms, offline); the generated list is `open.md`, `merge=union` so concurrent filings never conflict (issue 0884) |
 | Build / test / SDK tiers / jobserver / zephyr versions | [AGENTS.md](AGENTS.md) + [docs/development/](docs/development/) + `just/*.just` |
 | Dev utilities (towncrier, clang-format) | `just dev-tools [--install]` — checks the interpreter you chose and installs the repo's OWN tools into it; never creates a venv, never touches build groups (issue 0885) |
 | Long-form practices + pitfalls (cmake, tests, multi-session) | AGENTS.md “Practices & Pitfalls” (this file keeps the one-liners) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -676,7 +676,8 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   times (0367→0372→0377 collided TWICE, the second time while renumbering the first). The tool
   claims `refs/issue-ids/NNNN` on origin, which git rejects if it already exists; the `pre-push`
   hook (`just setup-hooks`) refuses to push a duplicate even if the tool was skipped. Expect
-  `docs/issues/README.md` rebase conflicts; write full background logs to files (`| tail` hides
+  ledger conflicts NO LONGER (issue 0884 — the generated list is `docs/issues/open.md`,
+  `merge=union`, so concurrent filings merge); write full background logs to files (`| tail` hides
   the real error). **Same race, same fix, third series: `just phase-new <slug>`** for work needing
   its OWN phase number (two sessions opened `phase-350` for unrelated work on 2026-08-13; the later became 352). NOT for
   a doc joining an existing effort — a phase number is deliberately not unique per file (26 of 342

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -51,61 +51,14 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 ## Open issues
 
-<!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
+<!-- issue 0884 — the open-issue list lives in `open.md`, NOT here.
+     It is 100 % generated, so that file carries `merge=union` in
+     `.gitattributes` and concurrent filings merge without a conflict. This file
+     is authored prose and must NEVER be union-merged — that is the whole reason
+     the two are separate. -->
 
-47 open. One line each — the detail lives in the issue file,
-which already has it. Regenerate with `scripts/gen-issue-index.py`;
-`check-issue-index` fails if this block drifts.
-
-- **#0259** (orchestration) — Derived scheduling is quantitatively inert — no WCET in the model, so blocking is unmodelled and budget/placement/non_preempt can't be derived See `0259-*`.
-- **#0506** (embedded) — Transport tasks above application tiers is the right default but has no budget — inbound overload preempts every tier for ~200 ms bursts See `0506-*`.
-- **#0736** (core, platform, testing) — `realtime_tiers` nuttx-arm/rust: the fast tier now outruns the slow one but only ~2.4x against a 3x bar — was a 10x inversion, now a marginal shortfall See `0736-*`.
-- **#0741** (rmw, testing) — `test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the 28-byte reply into a 15-byte history payload See `0741-*`.
-- **#0758** (core, boards) — No platform wall-clock epoch source — embedded consumers hand-roll SNTP before boot, and stamped messages are wrong until they do See `0758-*`.
-- **#0760** (orchestration, rmw) — RFC-0074's `ingress` declaration is a ros-launch-manifest schema change, not a nano-ros one — park it until that discussion happens See `0760-*`.
-- **#0772** (platform, boards) — FreeRTOS/lwIP has no wall-clock epoch — the same consumer that drove the Zephyr one runs a FreeRTOS board too See `0772-*`.
-- **#0783** (api, docs) — `RclReturnCode` exists and is unreachable, and RFC-0036 documents a Rust error type the user API never returns See `0783-*`.
-- **#0784** (api) — `nros::` publishes three different audiences under one namespace — the component API a user writes, the machinery `nros::node!` expands into, and four types nothing consumes See `0784-*`.
-- **#0788** (api) — The same API verb is spelled differently in our C, C++ and Rust — and in two cases one language ships both spellings See `0788-*`.
-- **#0791** (api, rmw) — We are visible in the ROS graph and cannot read it — 12 rmw vtable graph slots exist, all `None`, while both backends already run the discovery machinery See `0791-*`.
-- **#0793** (api, params) — C ships two disjoint parameter stores — parameters declared on the node-local one are invisible to `ros2 param`, and its accept/reject callback fires for nobody See `0793-*`.
-- **#0794** (build, codegen, boot) — The baked boot config carries four fields and the C/C++ emitter sets one — a launch-declared namespace, domain or locator never reaches a C image See `0794-*`.
-- **#0798** (examples) — `examples/workspaces/c`'s root routes `s32z270-freertos` to an entry that hardcodes `mps2-an385-freertos` — the pairing fails all three arms of `_nra_board_active`, so the image links without its platform glue See `0798-*`.
-- **#0809** (build) — `provider_scan` honours `NROS_IGNORE` while `nros-pkg-index` honours `.nros-ignore` — the only spelling that exists on disk is the one the order-walk ignores See `0809-*`.
-- **#0810** (core) — The executor arena is sized at MAX_CBS x sizeof(ActionClient) whatever the entries actually are, so every real image ships a hand-picked override and undersizing fails at runtime instead of at link See `0810-*`.
-- **#0814** (rmw) — The whole zero-copy surface sits behind `feature = \"lending\"`, which only a posix test crate ever enables See `0814-*`.
-- **#0815** (tooling) — The static-pool inventory finds 46 sizing knobs and can price 3, so the largest pools in a real image carry no byte figure See `0815-*`.
-- **#0816** (tooling) — The book promises no-alloc integrations and nothing checks the linked image, so it is a claim rather than a property See `0816-*`.
-- **#0820** (cmake, testing) — `c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — the NuttX seam had no dependency edge on the Rust world, and hardcoded `--release` past a miscompile carve-out See `0820-*`.
-- **#0827** (rmw) — Static RAM is a property of the RMW, not of the node — a talker reserves 275 KB of service and large-payload pools it can never reach See `0827-*`.
-- **#0828** (testing) — Tier 2 RUNS rows its build lane never builds, so `just ci-matrix` is green only while an earlier `lane=all` build is still fresh See `0828-*`.
-- **#0829** (api, rmw) — Two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on depth — 1 in `nros-rmw`, 10 in the `nros::qos` façade, each with two callers See `0829-*`.
-- **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
-- **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
-- **#0832** (platform, rmw) — `nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and xrce native images — the vendor allocators bypass the funnel See `0832-*`.
-- **#0834** (cmake) — The per-build `nros_cpp_config_generated.h` mirror can reach a state no re-run repairs — only wiping the west build dir recovers it See `0834-*`.
-- **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
-- **#0836** (rmw) — A FreeRTOS/lwIP image receives every small ROS topic and never a fragmented one — a 13 KiB Autoware trajectory never arrives See `0836-*`.
-- **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
-- **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
-- **#0843** (core, platform) — `nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every cffi image needs a global allocator and the `heap-free` tier is unreachable See `0843-*`.
-- **#0847** (rmw) — An XRCE publisher outliving `executor.close()` segfaults in its own Drop: the entity destructor dereferences the session state that close already freed See `0847-*`.
-- **#0849** (cli) — `nros sync` bakes the invocation's path SPELLING into every leaf patch table, so working through a symlink to the checkout makes cargo see two copies of every core crate and refuse the build on `links` See `0849-*`.
-- **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.
-- **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
-- **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
-- **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
-- **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
-- **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
-- **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
-- **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
-- **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
-- **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
-- **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
-- **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
-- **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
-
-<!-- END GENERATED open-issue list -->
+**The open-issue list is [`open.md`](open.md)** — generated from the issue files
+by `scripts/gen-issue-index.py`, checked by `check-issue-index`.
 
 Recently resolved (2026-08-29): **#0888** (rmw) — FreeRTOS was the only platform arm of the embedded
 Cyclone config with no `AllowMulticast`, so it inherited the Cyclone default (multicast for data) while

--- a/docs/issues/archived/0884-issue-ledger-conflicts-on-every-concurrent-pr.md
+++ b/docs/issues/archived/0884-issue-ledger-conflicts-on-every-concurrent-pr.md
@@ -1,0 +1,70 @@
+---
+id: 884
+title: "The open-issue ledger conflicted on every concurrent filing — a shared
+  registry inside an authored file, with a running total on top"
+status: resolved
+type: tech-debt
+area: build, testing
+related: [phase-395, phase-396, issue-0871]
+resolved_in: "issue 0884"
+---
+
+## Symptom
+
+Every pull request that filed or resolved an issue conflicted with every other
+one, on `docs/issues/README.md`. Measured on `origin/main` — two agents filing
+unrelated issues, each regenerating the index:
+
+    OLD design merge rc=1
+    UU docs/issues/README.md
+
+This session hit it on four consecutive rebases. phase-395 W1 had already
+attacked the worst form (a 4,170-line hand-written list) by generating the rows;
+what remained still collided.
+
+## Two causes, and the small one was the worse one
+
+**A running total.** The block opened with `NN open.` — ONE line that every
+issue-touching PR rewrites at the same position. That is the worst possible
+shape for concurrent edits, and it fails in two different ways: differing counts
+keep both lines under a union merge, and MATCHING counts merge silently to a
+WRONG total. Measured: two branches each taking `3 open.` to `4 open.` produced
+`4` for five issues — a clean merge with a false number.
+
+**Generated rows inside an authored file.** `README.md` is prose plus a
+generated block. A merge strategy that suits generated rows (union) is unsafe on
+prose, so no per-file strategy could be applied while the two shared a file.
+
+## Fix
+
+* The generated list moved to **`docs/issues/open.md`** — 100 % generated, no
+  authored prose. `README.md` keeps the conventions and points at it.
+* **`docs/issues/open.md merge=union`** in `.gitattributes`. `union` is a
+  BUILT-IN git driver, so it needs no per-clone `git config` — unlike a custom
+  merge driver, which would silently not apply for anyone who had not run a
+  setup step.
+* **The count line is gone.** It is derivable by counting rows and tells a
+  reader nothing the list does not.
+
+Union is safe here only because the file is entirely generated: the generator
+re-sorts and de-duplicates, and `check-issue-index` is the backstop that catches
+anything a union leaves behind. That reasoning is written into
+`.gitattributes`, `open.md` and the gate, because the safety depends on the
+separation holding.
+
+## Verified, both directions
+
+    NEW design   concurrent merge rc=0   NO CONFLICT   both rows present
+    OLD design   merge rc=1              UU docs/issues/README.md
+
+Same two-agent scenario, run against this branch and against `origin/main`.
+`check-issue-index` OK, 42 open rows = 42 files.
+
+Also checked: a RESOLUTION racing a FILING merges correctly — the resolved row
+is dropped and the new row kept (non-overlapping hunks never reach the union
+driver at all).
+
+## What this does not solve
+
+Two agents editing the SAME issue file still conflict, as they should — that is
+a genuine disagreement about content, not registry contention.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -1,0 +1,61 @@
+# Open issues
+
+Generated from the issue files — do not hand-edit. Add or resolve an issue by
+adding/moving its `NNNN-slug.md`, then run `scripts/gen-issue-index.py`.
+
+This file is `merge=union` (see `.gitattributes`): two agents filing different
+issues concurrently both land, instead of colliding in a shared registry. Union
+is safe here ONLY because the file is entirely generated and the generator
+re-sorts and de-duplicates; `check-issue-index` is the backstop that catches any
+residue a union leaves behind.
+
+<!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
+
+One line each — the detail lives in the issue file, which already has
+it. Regenerate with `scripts/gen-issue-index.py`; `check-issue-index`
+fails if this block drifts.
+
+- **#0259** (orchestration) — Derived scheduling is quantitatively inert — no WCET in the model, so blocking is unmodelled and budget/placement/non_preempt can't be derived See `0259-*`.
+- **#0506** (embedded) — Transport tasks above application tiers is the right default but has no budget — inbound overload preempts every tier for ~200 ms bursts See `0506-*`.
+- **#0736** (core, platform, testing) — `realtime_tiers` nuttx-arm/rust: the fast tier now outruns the slow one but only ~2.4x against a 3x bar — was a 10x inversion, now a marginal shortfall See `0736-*`.
+- **#0741** (rmw, testing) — `test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the 28-byte reply into a 15-byte history payload See `0741-*`.
+- **#0758** (core, boards) — No platform wall-clock epoch source — embedded consumers hand-roll SNTP before boot, and stamped messages are wrong until they do See `0758-*`.
+- **#0760** (orchestration, rmw) — RFC-0074's `ingress` declaration is a ros-launch-manifest schema change, not a nano-ros one — park it until that discussion happens See `0760-*`.
+- **#0772** (platform, boards) — FreeRTOS/lwIP has no wall-clock epoch — the same consumer that drove the Zephyr one runs a FreeRTOS board too See `0772-*`.
+- **#0783** (api, docs) — `RclReturnCode` exists and is unreachable, and RFC-0036 documents a Rust error type the user API never returns See `0783-*`.
+- **#0784** (api) — `nros::` publishes three different audiences under one namespace — the component API a user writes, the machinery `nros::node!` expands into, and four types nothing consumes See `0784-*`.
+- **#0788** (api) — The same API verb is spelled differently in our C, C++ and Rust — and in two cases one language ships both spellings See `0788-*`.
+- **#0791** (api, rmw) — We are visible in the ROS graph and cannot read it — 12 rmw vtable graph slots exist, all `None`, while both backends already run the discovery machinery See `0791-*`.
+- **#0793** (api, params) — C ships two disjoint parameter stores — parameters declared on the node-local one are invisible to `ros2 param`, and its accept/reject callback fires for nobody See `0793-*`.
+- **#0794** (build, codegen, boot) — The baked boot config carries four fields and the C/C++ emitter sets one — a launch-declared namespace, domain or locator never reaches a C image See `0794-*`.
+- **#0798** (examples) — `examples/workspaces/c`'s root routes `s32z270-freertos` to an entry that hardcodes `mps2-an385-freertos` — the pairing fails all three arms of `_nra_board_active`, so the image links without its platform glue See `0798-*`.
+- **#0808** (rmw) — `create_session`'s flat argument list cannot carry session config, and the structural fix has been deferred twice into issues that are now closed See `0808-*`.
+- **#0809** (build) — `provider_scan` honours `NROS_IGNORE` while `nros-pkg-index` honours `.nros-ignore` — the only spelling that exists on disk is the one the order-walk ignores See `0809-*`.
+- **#0810** (core) — The executor arena is sized at MAX_CBS x sizeof(ActionClient) whatever the entries actually are, so every real image ships a hand-picked override and undersizing fails at runtime instead of at link See `0810-*`.
+- **#0814** (rmw) — The whole zero-copy surface sits behind `feature = \"lending\"`, which only a posix test crate ever enables See `0814-*`.
+- **#0815** (tooling) — The static-pool inventory finds 46 sizing knobs and can price 3, so the largest pools in a real image carry no byte figure See `0815-*`.
+- **#0816** (tooling) — The book promises no-alloc integrations and nothing checks the linked image, so it is a claim rather than a property See `0816-*`.
+- **#0819** (rmw) — XRCE payloads at/above the transport MTU are DELIVERED CORRUPTED rather than refused See `0819-*`.
+- **#0820** (cmake, testing) — `c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — the NuttX seam had no dependency edge on the Rust world, and hardcoded `--release` past a miscompile carve-out See `0820-*`.
+- **#0827** (rmw) — Static RAM is a property of the RMW, not of the node — a talker reserves 275 KB of service and large-payload pools it can never reach See `0827-*`.
+- **#0828** (testing) — Tier 2 RUNS rows its build lane never builds, so `just ci-matrix` is green only while an earlier `lane=all` build is still fresh See `0828-*`.
+- **#0829** (api, rmw) — Two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on depth — 1 in `nros-rmw`, 10 in the `nros::qos` façade, each with two callers See `0829-*`.
+- **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
+- **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
+- **#0832** (platform, rmw) — `nros_platform_alloc` is DEFINED but UNREFERENCED in the cyclonedds and xrce native images — the vendor allocators bypass the funnel See `0832-*`.
+- **#0834** (cmake) — The per-build `nros_cpp_config_generated.h` mirror can reach a state no re-run repairs — only wiping the west build dir recovers it See `0834-*`.
+- **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
+- **#0836** (rmw) — A FreeRTOS/lwIP image receives every small ROS topic and never a fragmented one — a 13 KiB Autoware trajectory never arrives See `0836-*`.
+- **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
+- **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
+- **#0843** (core, platform) — `nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every cffi image needs a global allocator and the `heap-free` tier is unreachable See `0843-*`.
+- **#0852** (rmw) — zenoh-pico's Zephyr serial RX is polled with no interrupt buffering and no error check, so it silently drops bytes under load See `0852-*`.
+- **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
+- **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
+- **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
+- **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
+- **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
+- **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
+
+<!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -29,13 +29,11 @@ fails if this block drifts.
 - **#0793** (api, params) — C ships two disjoint parameter stores — parameters declared on the node-local one are invisible to `ros2 param`, and its accept/reject callback fires for nobody See `0793-*`.
 - **#0794** (build, codegen, boot) — The baked boot config carries four fields and the C/C++ emitter sets one — a launch-declared namespace, domain or locator never reaches a C image See `0794-*`.
 - **#0798** (examples) — `examples/workspaces/c`'s root routes `s32z270-freertos` to an entry that hardcodes `mps2-an385-freertos` — the pairing fails all three arms of `_nra_board_active`, so the image links without its platform glue See `0798-*`.
-- **#0808** (rmw) — `create_session`'s flat argument list cannot carry session config, and the structural fix has been deferred twice into issues that are now closed See `0808-*`.
 - **#0809** (build) — `provider_scan` honours `NROS_IGNORE` while `nros-pkg-index` honours `.nros-ignore` — the only spelling that exists on disk is the one the order-walk ignores See `0809-*`.
 - **#0810** (core) — The executor arena is sized at MAX_CBS x sizeof(ActionClient) whatever the entries actually are, so every real image ships a hand-picked override and undersizing fails at runtime instead of at link See `0810-*`.
 - **#0814** (rmw) — The whole zero-copy surface sits behind `feature = \"lending\"`, which only a posix test crate ever enables See `0814-*`.
 - **#0815** (tooling) — The static-pool inventory finds 46 sizing knobs and can price 3, so the largest pools in a real image carry no byte figure See `0815-*`.
 - **#0816** (tooling) — The book promises no-alloc integrations and nothing checks the linked image, so it is a claim rather than a property See `0816-*`.
-- **#0819** (rmw) — XRCE payloads at/above the transport MTU are DELIVERED CORRUPTED rather than refused See `0819-*`.
 - **#0820** (cmake, testing) — `c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — the NuttX seam had no dependency edge on the Rust world, and hardcoded `--release` past a miscompile carve-out See `0820-*`.
 - **#0827** (rmw) — Static RAM is a property of the RMW, not of the node — a talker reserves 275 KB of service and large-payload pools it can never reach See `0827-*`.
 - **#0828** (testing) — Tier 2 RUNS rows its build lane never builds, so `just ci-matrix` is green only while an earlier `lane=all` build is still fresh See `0828-*`.
@@ -49,13 +47,20 @@ fails if this block drifts.
 - **#0839** (rmw) — The action-server image's zenoh session expires every 20 s under a router that keeps a talker session alive for minutes See `0839-*`.
 - **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
 - **#0843** (core, platform) — `nros::node_runtime` is gated on `rmw-cffi`, not on `alloc`, so every cffi image needs a global allocator and the `heap-free` tier is unreachable See `0843-*`.
-- **#0852** (rmw) — zenoh-pico's Zephyr serial RX is polled with no interrupt buffering and no error check, so it silently drops bytes under load See `0852-*`.
+- **#0847** (rmw) — An XRCE publisher outliving `executor.close()` segfaults in its own Drop: the entity destructor dereferences the session state that close already freed See `0847-*`.
+- **#0849** (cli) — `nros sync` bakes the invocation's path SPELLING into every leaf patch table, so working through a symlink to the checkout makes cargo see two copies of every core crate and refuse the build on `links` See `0849-*`.
+- **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.
 - **#0854** (testing) — `action_raw_goal_ships_one_cdr_header` times out in-sweep and passes solo with a 16x margin — starved, not slow See `0854-*`.
 - **#0857** (api) — ComponentCell's inline registries cost worst-case × biggest-payload heap per component See `0857-*`.
 - **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
 - **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
 - **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
+- **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
+- **#0868** (examples, testing) — A `send_goal` TIMEOUT prints as `Goal was rejected by server`, so an intermittent XRCE action failure reads as a deterministic server decision See `0868-*`.
+- **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
+- **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
+- **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/justfile
+++ b/justfile
@@ -1987,7 +1987,7 @@ check-book-no-just:
 check-emitter-just-spelling:
     @bash scripts/check-emitter-just-spelling.sh
 
-# The "Open issues" list in docs/issues/README.md must name EXACTLY the files in
+# The "Open issues" list in docs/issues/open.md must name EXACTLY the files in
 # docs/issues/. The rule is already written in that file's Conventions #3 —
 # nothing enforced it, and it drifted twice in two consecutive pulls (#0465,
 # #0474): each was archived with a `git mv` while its README row stayed in the

--- a/scripts/check-issue-index.sh
+++ b/scripts/check-issue-index.sh
@@ -55,7 +55,13 @@ set -uo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-readme="docs/issues/README.md"
+# issue 0884 — the generated list moved OUT of README.md into `open.md`, so the
+# authored prose and the machine-written rows are separate files. That is what
+# makes `merge=union` safe on the rows (see `.gitattributes`): union on a file
+# containing prose would duplicate paragraphs, union on a pure row list only
+# ever duplicates rows, which the generator then re-sorts away and this gate
+# catches. The variable keeps its name; only the file it names changed.
+readme="docs/issues/open.md"
 
 # phase-395 W1 — the open list is GENERATED (scripts/gen-issue-index.py) and its
 # rows are list items, `- **#NNNN** (area) — title`. Accept the optional bullet

--- a/scripts/gen-issue-index.py
+++ b/scripts/gen-issue-index.py
@@ -39,7 +39,7 @@ import subprocess
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-INDEX = os.path.join(ROOT, "docs", "issues", "README.md")
+INDEX = os.path.join(ROOT, "docs", "issues", "open.md")
 
 BEGIN = "<!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->"
 END = "<!-- END GENERATED open-issue list -->"
@@ -91,12 +91,19 @@ def open_issues():
 
 
 def render(rows):
+    # issue 0884 — NO COUNT LINE, deliberately. A running total is one line that
+    # EVERY issue-touching pull request rewrites at the same position, which is
+    # the worst possible shape for concurrent edits: differing counts make git
+    # keep both lines under `merge=union`, and matching counts merge silently to
+    # a WRONG total (measured: two agents each taking 3 -> 4 produced "4" for
+    # five issues). The number is derivable by counting the rows below it and
+    # buys a reader nothing the list does not already show.
     lines = [
         BEGIN,
         "",
-        f"{len(rows)} open. One line each — the detail lives in the issue file,",
-        "which already has it. Regenerate with `scripts/gen-issue-index.py`;",
-        "`check-issue-index` fails if this block drifts.",
+        "One line each — the detail lives in the issue file, which already has",
+        "it. Regenerate with `scripts/gen-issue-index.py`; `check-issue-index`",
+        "fails if this block drifts.",
         "",
     ]
     for r in rows:
@@ -123,7 +130,7 @@ def main():
     else:
         if args.check:
             print(
-                "gen-issue-index: no generated block in docs/issues/README.md.\n"
+                "gen-issue-index: no generated block in docs/issues/open.md.\n"
                 "Run scripts/gen-issue-index.py to create it."
             )
             return 1

--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Query the issue ledger — the files ARE the database.
+
+issue 0884 / RFC-free by design. There is no service to ask and no index to
+trust: every issue file carries `id`, `title`, `status`, `type` and `area` in
+its frontmatter, so a query is a directory read. Measured on this repo, listing
+every open issue takes ~3 ms — which is the whole argument for keeping issues in
+the repo rather than in a tracker.
+
+    scripts/issues.py                  # open issues
+    scripts/issues.py --all            # open + archived
+    scripts/issues.py --status resolved
+    scripts/issues.py --area cmake
+    scripts/issues.py zenoh router     # free-text over title AND body
+    scripts/issues.py --id 870         # one issue, by number
+
+Grep still works and is not discouraged — this exists because `status` and
+`area` live in frontmatter, so filtering on them with grep alone is awkward.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DIRS = [os.path.join(ROOT, "docs", "issues"),
+        os.path.join(ROOT, "docs", "issues", "archived")]
+
+
+def field(text, name):
+    m = re.search(rf"^{name}:\s*(.+?)\s*$", text, re.M)
+    if not m:
+        return ""
+    v = m.group(1).strip().strip('"').strip("'")
+    # A folded YAML title continues on the following indented lines.
+    if name == "title":
+        rest = text[m.end():]
+        for line in rest.split("\n"):
+            if re.match(r"^\s+\S", line) and not re.match(r"^\s*\w+:", line):
+                v += " " + line.strip().strip('"')
+            else:
+                break
+    return v
+
+
+def load(include_archived):
+    out = []
+    for d in (DIRS if include_archived else DIRS[:1]):
+        if not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            if not re.match(r"^\d{4}-.*\.md$", fn):
+                continue
+            path = os.path.join(d, fn)
+            with open(path, encoding="utf8") as fh:
+                text = fh.read()
+            out.append({
+                "file": os.path.relpath(path, ROOT),
+                "id": fn[:4],
+                "title": field(text, "title"),
+                "status": field(text, "status"),
+                "type": field(text, "type"),
+                "area": field(text, "area"),
+                "body": text,
+            })
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Query the issue ledger.")
+    ap.add_argument("terms", nargs="*", help="free text over title and body")
+    ap.add_argument("--all", action="store_true", help="include archived")
+    ap.add_argument("--status", help="open | resolved | wontfix")
+    ap.add_argument("--area", help="substring match on area")
+    ap.add_argument("--id", help="a single issue number")
+    ap.add_argument("--files", action="store_true", help="print paths only")
+    a = ap.parse_args()
+
+    rows = load(a.all or bool(a.id) or (a.status and a.status != "open"))
+    if a.id:
+        want = a.id.zfill(4)
+        rows = [r for r in rows if r["id"] == want]
+    if a.status:
+        rows = [r for r in rows if r["status"] == a.status]
+    elif not a.all and not a.id:
+        rows = [r for r in rows if r["status"] == "open"]
+    if a.area:
+        rows = [r for r in rows if a.area.lower() in r["area"].lower()]
+    for t in a.terms:
+        rows = [r for r in rows
+                if t.lower() in r["title"].lower() or t.lower() in r["body"].lower()]
+
+    if a.files:
+        for r in rows:
+            print(r["file"])
+        return 0
+    for r in rows:
+        mark = {"open": "OPEN", "resolved": "done", "wontfix": "wont"}.get(r["status"], r["status"][:4])
+        print(f"#{r['id']}  {mark:<4}  {r['area'][:22]:<22}  {r['title'][:96]}")
+    print(f"\n{len(rows)} issue(s).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every PR that files or resolves an issue conflicts with every other one. Measured on `origin/main`, two agents filing unrelated issues:

```
OLD design merge rc=1
UU docs/issues/README.md
```

This session hit it on **four consecutive rebases**. phase-395 W1 already fixed the worst form (a 4,170-line hand-written list → generated rows); what remained still collided, for two reasons.

## A running total

The block opened with `NN open.` — one line every issue-touching PR rewrites at the same position. It fails two ways, and the quiet one is worse:

- differing counts → union keeps **both** lines
- **matching** counts → merges silently to a **wrong** total. Measured: two branches each taking `3 open.` → `4 open.` produced `4` for five issues. A clean merge with a false number.

Derivable from the list it sits on. Gone.

## Generated rows inside an authored file

`README.md` is prose + a generated block, and a merge strategy that suits generated rows is unsafe on prose. So the list moved to **`docs/issues/open.md`** — 100% generated — and README keeps the conventions and points at it.

`docs/issues/open.md merge=union` in `.gitattributes`. **`union` is a built-in git driver**, so it works in every clone with no `git config` step; a custom merge driver would silently not apply for anyone who skipped setup.

Union is safe here *only* because the file is entirely generated: the generator re-sorts and de-duplicates, and `check-issue-index` is the backstop. That reasoning is written into `.gitattributes`, `open.md`, README and the gate — the safety depends on the separation holding.

## Verified both directions

```
NEW (this branch)   concurrent merge rc=0   NO CONFLICT   both rows present
OLD (origin/main)   merge rc=1              UU docs/issues/README.md
```

A control on the old design was run so this isn't a fix for a non-problem. Also checked: a **resolution racing a filing** merges correctly — the resolved row drops, the new row stays, because non-overlapping hunks never reach the union driver.

## Does not solve, and should not

Two agents editing the same issue **file** still conflict. That's a real disagreement about content, not registry contention.

CLAUDE.md and AGENTS.md both told agents to *expect* these conflicts. That advice is now wrong, so both say the opposite and name the mechanism.

`check-issue-index` OK (42 rows = 42 files); 135/135 fast gates.

Closes #0884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk