### PR TITLE
docs: file the serial link's inability to resync, and correct #0865

### DIFF
--- a/docs/issues/0865-no-example-registers-parameter-services.md
+++ b/docs/issues/0865-no-example-registers-parameter-services.md
@@ -1,91 +1,82 @@
 ---
 id: 865
-title: "no example registers parameter services, so `ros2 param list` returns
-  nothing against every nano-ros node — the capability exists and is never shown"
+title: "parameter services are implemented and tested but undiscoverable: no
+  example calls them, and the C header declares the entry point unconditionally
+  so a caller without the feature gets a bare `undefined reference`"
 status: open
 type: bug
 area: examples, docs
 related: [issue-0864]
 ---
 
-## Symptom
+## What is actually true
 
-Against the CANHUBK344 action-server image, with a `demo_nodes_cpp` talker on
-the same router as a control:
-
-```
-$ ros2 param list /fibonacci_action_server
-                                     <- nothing
-
-$ ros2 param list /talker
-  qos_overrides./parameter_events.publisher.depth
-  qos_overrides./parameter_events.publisher.durability
-  ...
-```
-
-`ros2 service list` tells the same story from the other side:
+An earlier revision of this issue claimed the parameter-service capability was
+"implemented and never demonstrated". That was filed on incomplete evidence and
+is **wrong**. The capability is exercised and tested:
 
 ```
-/talker/describe_parameters
-/talker/get_parameter_types
-/talker/get_parameters
-/talker/list_parameters
-/talker/set_parameters
-/talker/set_parameters_atomically
+packages/testing/nros-tests/bins/param-chatter-talker/src/main.rs:30
+    .register_parameter_services()
+packages/testing/nros-tests/tests/params.rs:177
+    fn test_ros2_param_list(zenohd_unique: ZenohRouter)
 ```
 
-Six for the host node, none for the board's.
+That test drives a real `ros2 param list` against a running node. The path works
+and is covered.
 
-## Cause
+Nor is "no example calls it" an oversight. Phase-277 W3.a moved the
+`param-services` build **out** of the talker example and into a dedicated
+fixture bin precisely so the example would stay cfg-free, and recorded that
+intent in `examples/fixtures.toml`. Adding the call back to an example would
+reverse a considered decision.
 
-`Executor::register_parameter_services()` (`executor/spin.rs:6388`, exposed to C
-as `nros_executor_register_parameter_services`) is **opt-in**, and:
+## The real defect: it fails unhelpfully, and late
 
-```
-$ grep -rl register_parameter_services examples/
-                                     <- no match
-```
+Two narrower things are wrong, and they share a shape.
 
-Not one example in the tree calls it. The capability is fully implemented —
-`parameter_services.rs` serves all six — and nothing demonstrates it.
+**1. The C header declares the entry point unconditionally.**
+`nros_generated.h:3213` declares:
 
-## Why opt-in is defensible and the current state is not
-
-Opt-in is the right default: the six servers cost RAM on a part where that is
-the binding constraint, and an image with no parameters should not pay for
-them. That is not the complaint.
-
-The complaint is that every nano-ros node therefore looks, to standard ROS 2
-tooling, like a node whose parameter interface is broken rather than one that
-declined to have it. `ros2 param list` returning empty is indistinguishable
-from a node that is failing to answer, which is exactly the kind of ambiguity
-that cost issue 0852 six wrong hypotheses.
-
-## What is NOT wrong here
-
-Worth recording, because it looks like a defect and is not.
-
-The board's action services do not appear in a bare `ros2 service list`:
-
-```
-$ ros2 service list --include-hidden-services
-/fibonacci/_action/cancel_goal
-/fibonacci/_action/get_result
-/fibonacci/_action/send_goal
+```c
+NROS_PUBLIC nros_ret_t nros_executor_register_parameter_services(struct nros_executor_t *executor);
 ```
 
-`ros2 service list` hides `_action/` services by default. All three are
-registered, correctly named, correctly type-mangled, and they work — goals
-complete with the right sequence. Same for `ros2 node info` showing an empty
-"Service Servers" block while "Action Servers" lists `/fibonacci`.
+with no `#if` guard and no note. The implementation is gated:
+
+```rust
+#[cfg(all(feature = "param-services", feature = "rmw-cffi"))]   // parameter.rs:769
+```
+
+`param-services` is not a default feature. So a C caller who reads the header,
+writes the obvious call, and builds gets:
+
+```
+main.c:(.text+0x302): undefined reference to `nros_executor_register_parameter_services'
+```
+
+A linker error naming a symbol is the least informative way to say "you need to
+enable a capability". The header should either be guarded by the same condition
+or carry the requirement in its doc comment — the declaration currently promises
+something the library may not contain.
+
+**2. The absence is indistinguishable from a fault.**
+A node built without the feature answers `ros2 param list` with silence, which
+looks exactly like a node whose parameter interface is broken. This is the same
+observer problem as hidden `_action/` services: the system is behaving correctly
+and nothing says so.
 
 ## Fix direction
 
-1. Call `register_parameter_services()` in at least one Zephyr example, and
-   declare a parameter in it, so the path is exercised on hardware rather than
-   only in host tests.
-2. Say so where a reader will hit it: the examples README and the parameter
-   docs should state that `ros2 param` needs this call, and that omitting it is
-   a footprint choice rather than a missing feature.
-3. Consider a boot-time log line when a node comes up without parameter
-   services — one line, once, so the empty `ros2 param list` explains itself.
+- Guard the declaration, or document the required capability at the declaration.
+  A caller should learn the requirement from the header, not from `ld`.
+- Say in the parameter docs which capability is needed and how a CMake consumer
+  asks for it (`nros_feature_set` capability `param_services`).
+- Consider one line at node startup when parameter services are absent, so an
+  empty `ros2 param list` explains itself.
+
+## Not to do
+
+Do not add the call to an example to "demonstrate" it. That is what phase-277
+W3.a deliberately undid, and it would make the example's build feature-dependent
+again.

--- a/docs/issues/0879-serial-link-has-no-resync-after-peer-reset.md
+++ b/docs/issues/0879-serial-link-has-no-resync-after-peer-reset.md
@@ -1,0 +1,73 @@
+---
+id: 879
+title: "the serial link cannot resynchronise after a peer reset — the router
+  loops on `Unexpected Init flag in message` until it is restarted"
+status: open
+type: bug
+area: rmw
+related: [issue-0852, issue-0839]
+---
+
+## Problem
+
+Reset the board while the `rmw_zenoh` router holds the serial link, and the
+router enters a repeating error it never leaves:
+
+```
+ERROR rx-0 ThreadId(06) zenoh_link_serial::unicast:
+  Read error on Serial link serial//dev/ttyUSB0 => serial/<uuid>:
+  Unexpected Init flag in message
+  at io/zenoh-links/zenoh-link-serial/src/unicast.rs:164
+```
+
+It repeats every ~18 s indefinitely. The board is healthy and re-sending `INIT`
+as it should on a fresh boot; the router still holds the previous link-level
+session and treats an `INIT` arriving mid-session as a protocol violation rather
+than as a peer that restarted.
+
+**The only recovery is restarting the router.** No timeout, lease expiry or
+retry on either side clears it.
+
+## Why this is not the same as a lost session
+
+A TCP peer that reboots gives the router a closed socket, so the transport is
+torn down and rebuilt. A serial link is a permanently-open file descriptor: the
+pipe never "closes", so there is no event that tells the router its peer is
+gone. The `INIT` byte IS that event, and it is currently rejected instead of
+acted on.
+
+## Why it matters beyond convenience
+
+It silently corrupts measurements. Any experiment that resets the board — every
+A/B of two firmware builds, every reconnect test — must restart the router
+between runs, or the second run is conducted against a router stuck in this
+loop and reports a dead link that has nothing to do with the firmware under
+test. Several results during [issue 0852](0852-*) had to be discarded for
+exactly this reason before the pattern was recognised.
+
+It is also a real deployment property, not only a lab annoyance: a board that
+watchdog-resets in the field does not come back until someone restarts the
+router.
+
+## Distinguishing it from the identity problem
+
+[Issue 0864](archived/0864-board-zid-is-identical-on-every-boot.md) had a
+similar symptom — measurements that depended on router history — and is fixed.
+This is a **different** layer and survives that fix. 0864 was the zenoh session
+identity; this is the serial link-level framing state, one layer below, and it
+does not care what zid the board presents.
+
+## Fix direction
+
+`INIT` arriving on an established serial link is not a protocol error; it is the
+peer announcing it restarted. The link should tear down its session state and
+complete the new handshake, which is what `_Z_FLAG_SERIAL_RESET` appears to
+exist for.
+
+That is a change in `zenoh-link-serial` (the Rust router side), so it belongs
+upstream in eclipse-zenoh rather than in nano-ros. Worth confirming first
+whether zenoh-pico's own serial link has the same asymmetry when the ROUTER
+restarts.
+
+Interim, and worth writing into any bring-up runbook: **restart the router after
+any board reset.**

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-44 open. One line each — the detail lives in the issue file,
+45 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -101,6 +101,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
+- **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -97,7 +97,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0859** (examples, testing) — `rust/action-server` diverges from its native copy on all four RTOS platforms — one copy of a portability group was edited alone See `0859-*`.
 - **#0861** (core, examples) — `[lifecycle] autostart = \"active\"` does not reach `active` at boot in the rust workspace-features cell See `0861-*`.
 - **#0862** (testing, rmw) — `zpico_sys_has_no_cmake_dep` times out at 60 s instead of answering a static question See `0862-*`.
-- **#0865** (examples, docs) — no example registers parameter services, so `ros2 param list` returns nothing against every nano-ros node — the capability exists and is never shown See `0865-*`.
+- **#0865** (examples, docs) — parameter services are implemented and tested but undiscoverable: no example calls them, and the C header declares the entry point unconditionally so a caller without the feature gets a bare `undefined reference` See `0865-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.


### PR DESCRIPTION
Two documentation changes, one new and one a correction.

## New: #0879 — the serial link cannot resync after a peer reset

Resetting the board while the `rmw_zenoh` router holds the serial link puts the
router into a repeating `Unexpected Init flag in message` it never leaves. Only
restarting the router clears it.

A TCP peer that reboots closes its socket and the transport is rebuilt. A serial
link is a permanently-open fd, so nothing tells the router its peer is gone —
the `INIT` byte *is* that event, and it is currently rejected as a protocol
violation rather than acted on.

Filed because it silently corrupts measurements: any experiment that resets the
board must restart the router between runs, or the run is conducted against a
stuck router and the result blames the firmware. Several results during #0852
were discarded for exactly this before the pattern was recognised. It is also a
deployment property — a board that watchdog-resets does not come back until
someone restarts the router.

Distinct from #0864 and survives its fix: that was the zenoh session identity,
this is serial link-level framing state one layer below.

The fix is in `zenoh-link-serial` on the router side, so it belongs upstream in
eclipse-zenoh rather than here.

## Correction: #0865 was filed on bad evidence

It claimed parameter services were "implemented and never demonstrated". **Wrong.**
`param-chatter-talker` calls `register_parameter_services()` and
`tests/params.rs::test_ros2_param_list` drives a real `ros2 param list` against
it. The path works and is covered.

"No example calls it" is also not an oversight — phase-277 W3.a deliberately
moved that build out of the talker example into a fixture bin to keep the
example cfg-free. I had started changing an example before finding that, and
reverted it.

What *is* wrong is narrower: `nros_generated.h` declares
`nros_executor_register_parameter_services` unconditionally while the
implementation is gated behind a non-default `param-services` feature, so a C
caller who reads the header and writes the obvious call gets a bare
`undefined reference` from `ld`. The declaration promises something the library
may not contain. Fix direction is to guard or document the declaration.

Docs only — no code changes.