### PR TITLE
feat(trace): callback-level tracing hooks at the dispatch leaves

### DIFF
--- a/packages/api/nros-c/Cargo.toml
+++ b/packages/api/nros-c/Cargo.toml
@@ -61,6 +61,14 @@ safety-e2e = ["nros/safety-e2e", "nros-rmw-zenoh?/safety-e2e"]
 # `nros-rmw-cffi/lending` cargo bound through.
 lending = ["rmw-cffi", "nros/lending"]
 
+# Phase 8 (autoware-safety-island `docs/design/callback_tracing.rst`) —
+# callback-level dispatch tracing. Pure forward to `nros`; the hooks and the
+# runtime-installed `extern "C" fn(u32, u32)` sink live in `nros-node`. A C
+# image installs the sink itself — the ABI is deliberately the C signature a
+# platform trace shim already has — so nothing here names a platform. Off by
+# default.
+trace-callbacks = ["nros/trace-callbacks"]
+
 # Phase 123.A.11 — `cffi-xrce-c` / `cffi-dds-cffi` / `cffi-zenoh-cffi`
 # DELETED. They previously selected which `extern fn
 # nros_rmw_<x>_register()` call site got compiled into

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -3262,6 +3262,35 @@ extern void nros_platform_sleep_us(size_t us);
 extern uint64_t nros_platform_time_now_ns(void);
 
 /**
+ * Install the callback trace sink, or clear it with `NULL`.
+ *
+ * `sink` is called as `sink(marker_id, arg)` — the signature of a
+ * two-`uint32` platform trace event, chosen so a platform shim is
+ * installable verbatim:
+ *
+ * | `marker_id` | event    | `arg`                                     |
+ * |-------------|----------|-------------------------------------------|
+ * | 16          | register | `handle << 8 \| kind`                     |
+ * | 17          | name     | next 4 name bytes, byte *i* in bits `8*i` |
+ * | 18          | start    | `handle`                                  |
+ * | 19          | end      | `handle`                                  |
+ *
+ * Call it once at startup, BEFORE anything is registered on the executor: a
+ * sink installed later misses the registration events, and the decoder then
+ * has handles with no names.
+ *
+ * No-op unless the crate was built with `trace-callbacks`.
+ *
+ * # Safety
+ * `sink` must be a valid function pointer with the C ABI above, or `NULL`.
+ * It is called from the executor's dispatch path — including from an
+ * OS-priority worker task, i.e. a different thread — so it must be
+ * re-entrant and must not unwind. It must remain valid until it is replaced
+ * or cleared.
+ */
+NROS_PUBLIC void nros_set_trace_sink(void (*sink)(uint32_t, uint32_t));
+
+/**
  * Phase 115.C — register a custom transport vtable.
  *
  * Must be called BEFORE `nros_support_init`. Subsequent calls

--- a/packages/api/nros-c/src/lib.rs
+++ b/packages/api/nros-c/src/lib.rs
@@ -270,6 +270,11 @@ mod opaque_sizes;
 mod parameter;
 mod platform;
 mod qos;
+// phase-8 — `nros_set_trace_sink`. Deliberately UNGATED so the symbol exists
+// in every build (the body is what the feature gates), which is also what puts
+// it in the generated `c_surface_anchor` and keeps DCE from dropping it when
+// `nros-c` is bundled as an rlib by the `nros-cpp` umbrella.
+mod trace;
 mod transport;
 mod util;
 

--- a/packages/api/nros-c/src/trace.rs
+++ b/packages/api/nros-c/src/trace.rs
@@ -1,0 +1,61 @@
+//! Phase 8 — the C entry point that installs the callback trace sink.
+//!
+//! Design: autoware-safety-island `docs/design/callback_tracing.rst`.
+//!
+//! `nros_node::executor::callback_trace::set_trace_sink` is a Rust `pub fn`,
+//! so a C entry funnel cannot call it. The Zephyr entry path IS C
+//! (`nros-board-zephyr`'s `c/zephyr_run_tiers.c` — the crate's Rust half is
+//! not in every image's link graph, only that translation unit is), and it is
+//! the one place that runs before the executor registers anything, which is
+//! the deadline the registration events have to beat.
+//!
+//! It lives in `nros-c` rather than `nros-cpp` deliberately: `nros-c` is
+//! linked in BOTH the C-API path and the C++-only path, so one export covers
+//! both configurations. `wake_probe::set_cycle_reader` — the seam this
+//! copies — has no C export at all (its only caller is a pure-Rust bin), so
+//! there is no prior spelling to match here.
+//!
+//! ## Why the symbol is unconditional and the body is not
+//!
+//! The same idiom the Zephyr platform shims use
+//! (cf. `nros_zephyr_epoch_acquire_configured`): an unconditional symbol with
+//! a gated body. The C caller then needs no `#ifdef` and no Kconfig knob has
+//! to reach the cargo lane — an image built without `trace-callbacks` still
+//! links, and the call is simply a no-op.
+//!
+//! The `rmw-cffi` half of the gate is not optional: `callback_trace` lives
+//! under `nros-node`'s `has_rmw` cfg (there is no executor to trace without an
+//! RMW seam), and `rmw-cffi` is what puts it there.
+
+/// Install the callback trace sink, or clear it with `NULL`.
+///
+/// `sink` is called as `sink(marker_id, arg)` — the signature of a
+/// two-`uint32` platform trace event, chosen so a platform shim is
+/// installable verbatim:
+///
+/// | `marker_id` | event    | `arg`                                     |
+/// |-------------|----------|-------------------------------------------|
+/// | 16          | register | `handle << 8 \| kind`                     |
+/// | 17          | name     | next 4 name bytes, byte *i* in bits `8*i` |
+/// | 18          | start    | `handle`                                  |
+/// | 19          | end      | `handle`                                  |
+///
+/// Call it once at startup, BEFORE anything is registered on the executor: a
+/// sink installed later misses the registration events, and the decoder then
+/// has handles with no names.
+///
+/// No-op unless the crate was built with `trace-callbacks`.
+///
+/// # Safety
+/// `sink` must be a valid function pointer with the C ABI above, or `NULL`.
+/// It is called from the executor's dispatch path — including from an
+/// OS-priority worker task, i.e. a different thread — so it must be
+/// re-entrant and must not unwind. It must remain valid until it is replaced
+/// or cleared.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_set_trace_sink(sink: Option<unsafe extern "C" fn(u32, u32)>) {
+    #[cfg(all(feature = "trace-callbacks", feature = "rmw-cffi"))]
+    nros_node::executor::callback_trace::set_trace_sink(sink);
+    #[cfg(not(all(feature = "trace-callbacks", feature = "rmw-cffi")))]
+    let _ = sink;
+}

--- a/packages/api/nros-cpp/Cargo.toml
+++ b/packages/api/nros-cpp/Cargo.toml
@@ -103,6 +103,14 @@ rmw-cyclonedds-cffi = ["rmw-cffi", "nros-c/rmw-cyclonedds"]
 # `_discard`, `nros_cpp_subscription_borrow` / `_release`).
 lending = ["rmw-cffi", "nros/lending"]
 
+# Phase 8 (autoware-safety-island `docs/design/callback_tracing.rst`) —
+# callback-level dispatch tracing. Forwards to BOTH `nros` and `nros-c`: a C++
+# image links `libnros_c.a` too, and the two crates must agree on whether the
+# hooks are compiled in (a half-enabled pair would give a trace with the C
+# entry points' callbacks missing). Hooks + sink live in `nros-node`. Off by
+# default.
+trace-callbacks = ["nros/trace-callbacks", "nros-c/trace-callbacks"]
+
 # Phase 241.D3-rev (W8) — expose the param / lifecycle service surfaces through the
 # umbrella. The C++ executor headers call the gated nros-c C entry points
 # (nros_executor_register_parameter_services, nros_executor_lifecycle_*, …); a C++

--- a/packages/api/nros/Cargo.toml
+++ b/packages/api/nros/Cargo.toml
@@ -119,6 +119,13 @@ rmw-cyclonedds = ["nros-node/needs-type-descriptors"]
 # feature for backend support matrix.
 rmw-lending = ["nros-node/rmw-lending"]
 
+# Phase 8 (autoware-safety-island `docs/design/callback_tracing.rst`) —
+# callback-level dispatch tracing. Pure forward to `nros-node`, which owns the
+# hooks and the runtime-installed `extern "C" fn(u32, u32)` sink; see the
+# rationale on `nros-node/trace-callbacks`. Off by default — the hooks sit on
+# the executor's hot path and must vanish in production.
+trace-callbacks = ["nros-node/trace-callbacks"]
+
 # Phase 128.G — bridge surface. `bridge` re-exports `nros_bridge`'s
 # Rust API (PubSubBridge etc.); `config` additionally pulls the TOML
 # loader (`run_from_config`).

--- a/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
+++ b/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
@@ -55,6 +55,14 @@ extern uint32_t nros_zephyr_current_cpu(void);
 /* issue 0758 W4 — see zephyr/nros_platform_zephyr_shims.c. */
 extern void nros_zephyr_epoch_acquire_configured(void);
 
+/* phase-8 W4 — callback tracing. The shim is an unconditional symbol whose
+ * body is `#ifdef CONFIG_TRACING_CTF`; the setter is an unconditional export
+ * from nros-c whose body is feature-gated. So this pair links in EVERY
+ * configuration and costs a single stored null pointer when either half is
+ * absent — which is what lets the call below stay unguarded. */
+extern void nros_zephyr_trace_marker(uint32_t marker_id, uint32_t arg);
+extern void nros_set_trace_sink(void (*sink)(uint32_t, uint32_t));
+
 extern int nros_zephyr_tier_task_create(void* (*entry)(void*), void* arg, int32_t priority,
                                         const char* name, size_t stack_bytes,
                                         uint32_t core_plus1, int* pin_rc);
@@ -499,6 +507,12 @@ int32_t nros_board_zephyr_run_tiers(const char* locator, uint8_t domain_id,
      * the cargo lane (issue 0460). One decision in C is the only shape in which
      * the two arms cannot drift. */
     nros_zephyr_epoch_acquire_configured();
+
+    /* phase-8 W4 — install the CTF sink BEFORE the executor is opened, so the
+     * registration events emitted as callbacks are added are not lost. A sink
+     * installed later is not an error, but every callback registered before it
+     * decodes as a bare `handle N` with no name. */
+    nros_set_trace_sink(nros_zephyr_trace_marker);
 
     /* --- Open the primary (owning) executor on the boot thread --- */
     const char* sn = (session_name != NULL && session_name[0] != '\0') ? session_name : "node";

--- a/packages/core/nros-node/Cargo.toml
+++ b/packages/core/nros-node/Cargo.toml
@@ -91,6 +91,18 @@ signal-fd-wake = ["dep:libc"]
 # the host harness drains over UART (141.C). Off by default —
 # production builds stay clean.
 wake-latency-probe = ["portable-atomic/fallback"]
+# Phase 8 (autoware-safety-island `docs/design/callback_tracing.rst`) —
+# callback-level dispatch tracing. Emits `nros_callback_register(handle,
+# kind, name)` once per executor entry at registration, then
+# `callback_start(handle)` / `callback_end(handle)` around each leaf
+# callback invocation in `executor/arena.rs`. Same shape as
+# `wake-latency-probe` above and for the same reason: hot-path hooks that
+# must VANISH in production, so a Cargo feature (not the `tracing` crate
+# facade, whose no-op subscriber still costs span construction per
+# dispatch). The sink is a runtime-installed `extern "C" fn(u32, u32)` —
+# core names no platform; the board/app installs one at startup
+# (`executor::callback_trace::set_trace_sink`). Off by default.
+trace-callbacks = []
 # Phase 128.C.3 — per-backend `rmw-*-cffi` features deleted. The
 # walker (`nros_rmw_cffi_walk_init_section`) discovers whichever
 # backend the manifest pulled in; `rmw-cffi` alone gates the vtable

--- a/packages/core/nros-node/src/executor/action.rs
+++ b/packages/core/nros-node/src/executor/action.rs
@@ -12,7 +12,7 @@ use super::{
     action_core::{ActionClientCore, ActionServerCore, RawActiveGoal},
     arena::{
         ActionClientCallbackEntry, ActionClientRawArenaEntry, ActionServerArenaEntry,
-        ActionServerRawArenaEntry, BufferStrategy, CallbackMeta, EntryKind,
+        ActionServerRawArenaEntry, BufferStrategy, CallbackMeta, EntryKind, TraceName,
         action_client_callback_try_process, action_client_raw_try_process,
         action_server_raw_try_process, action_server_try_process, always_ready,
         as_active_goal_count, as_complete_goal, as_for_each_active_goal, as_publish_feedback,
@@ -297,7 +297,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ActionServer,
             has_data: always_ready,
@@ -315,7 +315,8 @@ impl<'s> Executor<'s> {
             drop_fn: drop_entry::<
                 Entry<A, GoalF, CancelF, GOAL_BUF, RESULT_BUF, FEEDBACK_BUF, MAX_GOALS>,
             >,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(action_name));
 
         Ok(ActionServerHandle {
             entry_index: slot,
@@ -718,7 +719,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ActionServer,
             has_data: always_ready,
@@ -731,7 +732,8 @@ impl<'s> Executor<'s> {
                 MAX_GOALS,
             >,
             drop_fn: drop_entry::<Entry<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF, MAX_GOALS>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(spec.action_name));
         self.apply_node_default_sched(slot, node_id, None);
 
         Ok(ActionServerRawHandle {
@@ -1174,7 +1176,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ActionClient,
             has_data: always_ready,
@@ -1182,7 +1184,8 @@ impl<'s> Executor<'s> {
             invocation: InvocationMode::Always,
             try_process: action_client_raw_try_process::<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>,
             drop_fn: drop_entry::<Entry<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(spec.action_name));
         self.apply_node_default_sched(slot, node_id, None);
 
         Ok(ActionClientRawHandle { entry_index: slot })
@@ -1364,7 +1367,7 @@ impl<'s> Executor<'s> {
             &mut (*entry_ptr).core as *mut ActionClientCore<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>
         };
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ActionClient,
             has_data: always_ready,
@@ -1380,7 +1383,8 @@ impl<'s> Executor<'s> {
                 FEEDBACK_BUF,
             >,
             drop_fn: drop_entry::<Entry<A, GRespF, FbF, ResF, GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(action_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok((HandleId(slot), core_ptr))
     }
@@ -1425,7 +1429,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ActionClient,
             has_data: always_ready,
@@ -1433,7 +1437,8 @@ impl<'s> Executor<'s> {
             invocation: InvocationMode::Always,
             try_process: action_client_raw_try_process::<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>,
             drop_fn: drop_entry::<Entry<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Slot("action_client", slot));
 
         Ok(ActionClientRawHandle { entry_index: slot })
     }

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -25,6 +25,44 @@ use crate::session;
 // Callback metadata
 // ============================================================================
 
+// ============================================================================
+// Phase 8 — callback dispatch hooks (paired stubs)
+// ============================================================================
+//
+// `docs/design/callback_tracing.rst`. The hooks bracket the LEAF callback
+// invocation rather than the `try_process` boundary, because that boundary
+// gets both granularity and truth wrong: one `try_process` for an action
+// server fires up to three distinct user callbacks, a ring-buffered
+// subscription fires the user callback once per queued message, and
+// `Ok(false)` — "ran, fired nothing", the common outcome for a timer that is
+// not yet due — would be recorded as an invocation that never happened.
+//
+// Paired stubs (the `entry_tiers.rs` idiom) so the call sites read IDENTICALLY
+// whether or not the feature is on; the `#[cfg]` lives here, once, instead of
+// wrapping every hook site.
+
+/// Emit `callback_start(handle)` immediately before invoking a user callback.
+#[cfg(feature = "trace-callbacks")]
+#[inline]
+fn trace_cb_start(desc_idx: u8) {
+    super::callback_trace::start(desc_idx);
+}
+
+#[cfg(not(feature = "trace-callbacks"))]
+#[inline]
+fn trace_cb_start(_desc_idx: u8) {}
+
+/// Emit `callback_end(handle)` immediately after a user callback returns.
+#[cfg(feature = "trace-callbacks")]
+#[inline]
+fn trace_cb_end(desc_idx: u8) {
+    super::callback_trace::end(desc_idx);
+}
+
+#[cfg(not(feature = "trace-callbacks"))]
+#[inline]
+fn trace_cb_end(_desc_idx: u8) {}
+
 /// Kind of registered callback entry.
 #[derive(Clone, Copy)]
 pub(crate) enum EntryKind {
@@ -35,6 +73,42 @@ pub(crate) enum EntryKind {
     ActionServer,
     ActionClient,
     GuardCondition,
+}
+
+/// What a registration site calls the callback it is registering.
+///
+/// Phase 8 (`docs/design/callback_tracing.rst`) — the payload of the
+/// `nros_callback_register` event, resolved to a string only inside the
+/// feature-gated emitter so a build without `trace-callbacks` pays nothing
+/// for the two synthesised forms.
+///
+/// The three variants exist because the executor does NOT have a name for
+/// every entry kind:
+///
+/// * subscriptions / services / actions carry a topic or service name;
+/// * a timer carries only a period — so the period IS its identity;
+/// * a guard condition, and an arena subscription attached to an already-open
+///   `RmwSubscriber`, carry nothing at all — the slot index is the only
+///   thing that distinguishes one from another.
+///
+/// Naming them here rather than at the 25 emplace sites keeps the synthesis
+/// rules in one place; a new registration site that gets the name wrong is
+/// then a wrong ARGUMENT, not a second convention.
+// Only the feature-gated emitter READS these, so a build with the feature off
+// constructs them and never matches on them. That is the intended shape (the
+// call sites must read identically either way), not dead code to delete.
+#[cfg_attr(not(feature = "trace-callbacks"), allow(dead_code))]
+#[derive(Clone, Copy)]
+pub(crate) enum TraceName<'a> {
+    /// A real name the caller already has: topic, service, or action name.
+    Text(&'a str),
+    /// A timer, rendered `timer@<period_us>us`.
+    TimerPeriod(u64),
+    /// An entry with no name anywhere in the executor, rendered
+    /// `<label>#<slot>` — `guard#3`, `sub#7`. The slot index is exactly what
+    /// the runtime `callback_start` / `callback_end` events key on, so this
+    /// label is not a placeholder: it is the identity, spelled out.
+    Slot(&'static str, usize),
 }
 
 /// Metadata for a type-erased callback stored in the arena.
@@ -50,7 +124,22 @@ pub(crate) struct CallbackMeta {
     /// Monomorphized dispatch: tries to receive and process one message/request.
     /// Returns `Ok(true)` if work was done, `Ok(false)` if nothing available.
     /// The `u64` parameter is `delta_us` (used by timer entries, ignored by others).
-    pub(crate) try_process: unsafe fn(*mut u8, u64) -> Result<bool, TransportError>,
+    ///
+    /// The trailing `u8` is the entry's SLOT INDEX (phase 8,
+    /// `docs/design/callback_tracing.rst`). Inside a leaf the only identity
+    /// otherwise in scope is the address `arena_base + offset` — unique and
+    /// stable, but an address, and `arena_base` is not reachable from the
+    /// leaf. Threading the index in is the design's preferred fix over
+    /// publishing an `offset -> index` map: it needs no side table, it cannot
+    /// go stale if the arena moves, and attribution is exact at the point of
+    /// use. All three producers already have the index (the drain loop, the
+    /// trigger-fail timer sweep, and `os_priority::WorkItem`).
+    ///
+    /// Passed unconditionally rather than behind `feature = "trace-callbacks"`:
+    /// a cfg-dependent function-pointer signature would have to be threaded
+    /// through 21 leaf definitions as a macro. The cost when tracing is off is
+    /// one constant register argument per dispatch that the leaf ignores.
+    pub(crate) try_process: unsafe fn(*mut u8, u64, u8) -> Result<bool, TransportError>,
     /// Monomorphized readiness check: returns true if the entry has data.
     pub(crate) has_data: unsafe fn(*const u8) -> bool,
     /// Monomorphized LET pre-sample: reads data from transport into the entry's
@@ -427,6 +516,16 @@ unsafe fn drain_into_buffer<M, F>(
     Ok(())
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized dispatch for buffered subscriptions.
 ///
 /// First drains the RMW subscriber into the buffer strategy (triple buffer
@@ -437,6 +536,7 @@ unsafe fn drain_into_buffer<M, F>(
 pub(crate) unsafe fn sub_buffered_try_process<M, F>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     M: RosMessage,
@@ -514,6 +614,16 @@ pub(crate) struct SubInplaceEntry<M, F> {
     pub(crate) _phantom: PhantomData<M>,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized in-place dispatch for typed subscriptions.
 ///
 /// Drains all pending messages from the backend, deserializing + invoking the
@@ -525,6 +635,7 @@ pub(crate) struct SubInplaceEntry<M, F> {
 pub(crate) unsafe fn sub_inplace_try_process<M, F>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     M: RosMessage,
@@ -623,6 +734,16 @@ unsafe fn drain_into_buffer_raw<F>(
     Ok(())
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Dispatch for zero-copy raw buffered subscriptions.
 ///
 /// Drains the RMW handle into the buffer, then passes the raw CDR slice
@@ -633,6 +754,7 @@ unsafe fn drain_into_buffer_raw<F>(
 pub(crate) unsafe fn sub_buffered_raw_try_process<F>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     F: FnMut(&[u8]),
@@ -697,6 +819,16 @@ pub(crate) struct SubBufferedBorrowedEntry<B, F> {
     pub(crate) _phantom: PhantomData<B>,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Dispatch for borrowed (zero-copy) buffered subscriptions.
 ///
 /// Drains the RMW handle into the triple buffer, then materialises a borrowed
@@ -709,6 +841,7 @@ pub(crate) struct SubBufferedBorrowedEntry<B, F> {
 pub(crate) unsafe fn sub_buffered_borrowed_try_process<B, F>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     B: BorrowedMessage,
@@ -787,6 +920,16 @@ pub(crate) struct SubBufferedRawInfoEntry<F, const RX_BUF: usize> {
     pub(crate) callback: F,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Dispatch for raw buffered subscriptions with attachment.
 ///
 /// # Safety
@@ -794,6 +937,7 @@ pub(crate) struct SubBufferedRawInfoEntry<F, const RX_BUF: usize> {
 pub(crate) unsafe fn sub_buffered_raw_info_try_process<F, const RX_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     F: FnMut(&[u8], &RawMessageInfo),
@@ -836,6 +980,16 @@ pub(crate) struct SubBufferedRawInfoCEntry<const RX_BUF: usize> {
     pub(crate) context: *mut core::ffi::c_void,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Dispatch for the C-style raw buffered subscription with attachment.
 ///
 /// # Safety
@@ -843,6 +997,7 @@ pub(crate) struct SubBufferedRawInfoCEntry<const RX_BUF: usize> {
 pub(crate) unsafe fn sub_buffered_raw_info_c_try_process<const RX_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError> {
     let entry = unsafe { &mut *(ptr as *mut SubBufferedRawInfoCEntry<RX_BUF>) };
     match entry
@@ -891,6 +1046,16 @@ pub(crate) struct SubBufferedRawSafetyEntry<F, const RX_BUF: usize> {
     pub(crate) callback: F,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Dispatch for the generic raw safety subscription: validate-receive into the
 /// buffer, then pass the raw slice + status to the callback.
 ///
@@ -900,6 +1065,7 @@ pub(crate) struct SubBufferedRawSafetyEntry<F, const RX_BUF: usize> {
 pub(crate) unsafe fn sub_buffered_raw_safety_try_process<F, const RX_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     F: FnMut(&[u8], &nros_rmw::IntegrityStatus),
@@ -941,6 +1107,16 @@ pub(crate) struct SubBufferedRawSafetyCEntry<const RX_BUF: usize> {
     pub(crate) context: *mut core::ffi::c_void,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Dispatch for the C-style raw validated subscription: validate-receive into the
 /// buffer, then pass the raw slice + unpacked integrity scalars to the callback.
 ///
@@ -950,6 +1126,7 @@ pub(crate) struct SubBufferedRawSafetyCEntry<const RX_BUF: usize> {
 pub(crate) unsafe fn sub_buffered_raw_safety_c_try_process<const RX_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError> {
     let entry = unsafe { &mut *(ptr as *mut SubBufferedRawSafetyCEntry<RX_BUF>) };
     match entry.handle.try_recv_validated(&mut entry.buffer) {
@@ -1041,6 +1218,7 @@ unsafe fn drain_into_buffer_raw_c(entry: &mut SubBufferedRawCEntry) -> Result<()
 pub(crate) unsafe fn sub_buffered_raw_c_try_process(
     ptr: *mut u8,
     _delta_us: u64,
+    desc_idx: u8,
 ) -> Result<bool, TransportError> {
     let entry = unsafe { &mut *(ptr as *mut SubBufferedRawCEntry) };
 
@@ -1049,17 +1227,29 @@ pub(crate) unsafe fn sub_buffered_raw_c_try_process(
     unsafe { drain_into_buffer_raw_c(entry)? };
 
     match &entry.buffer {
+        // Phase 8 — hooked. Triple-buffered: at most one invocation per
+        // `try_process`, so exactly one start/end pair, and none at all when
+        // `reader_acquire` comes back empty.
         BufferStrategy::Triple(tb) => match tb.reader_acquire() {
             Some((data, len)) => {
+                trace_cb_start(desc_idx);
                 unsafe { (entry.callback)(data.as_ptr(), len, entry.context) };
+                trace_cb_end(desc_idx);
                 Ok(true)
             }
             None => Ok(false),
         },
+        // Phase 8 — hooked INSIDE the loop, deliberately. A ring drains N
+        // queued messages per `try_process` and fires the user callback once
+        // per message; a pair outside the loop would report N invocations as
+        // one, which is the granularity failure that ruled out hooking the
+        // `try_process` boundary in the first place.
         BufferStrategy::Ring(ring) => {
             let mut did_work = false;
             while let Some((data, len)) = ring.try_pop() {
+                trace_cb_start(desc_idx);
                 unsafe { (entry.callback)(data.as_ptr(), len, entry.context) };
+                trace_cb_end(desc_idx);
                 ring.commit_pop();
                 did_work = true;
             }
@@ -1081,6 +1271,16 @@ pub(crate) unsafe fn sub_buffered_raw_c_has_data(ptr: *const u8) -> bool {
 // Dispatch functions
 // ============================================================================
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized subscription dispatch function (with MessageInfo).
 ///
 /// # Safety
@@ -1088,6 +1288,7 @@ pub(crate) unsafe fn sub_buffered_raw_c_has_data(ptr: *const u8) -> bool {
 pub(crate) unsafe fn sub_info_try_process<M, F, const RX_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     M: RosMessage,
@@ -1120,6 +1321,16 @@ where
     }
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized subscription dispatch function (with safety validation).
 ///
 /// # Safety
@@ -1128,6 +1339,7 @@ where
 pub(crate) unsafe fn sub_safety_try_process<M, F, const RX_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     M: RosMessage,
@@ -1167,6 +1379,16 @@ where
     }
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized service dispatch function.
 ///
 /// # Safety
@@ -1174,6 +1396,7 @@ where
 pub(crate) unsafe fn srv_try_process<Svc, F, const REQ_BUF: usize, const REPLY_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     Svc: RosService,
@@ -1208,6 +1431,7 @@ pub(crate) unsafe fn drop_entry<T>(ptr: *mut u8) {
 pub(crate) unsafe fn timer_try_process<F>(
     ptr: *mut u8,
     delta_us: u64,
+    desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     F: FnMut(),
@@ -1222,7 +1446,13 @@ where
     entry.elapsed_us = entry.elapsed_us.saturating_add(delta_us);
 
     if entry.elapsed_us >= entry.period_us {
+        // Phase 8 — hooked. Inside the due-check, so a timer polled on every
+        // spin and not yet due emits nothing: `Ok(false)` is the COMMON
+        // outcome here, and it is exactly the over-reporting that a hook at
+        // the `try_process` boundary would have produced.
+        trace_cb_start(desc_idx);
         (entry.callback)();
+        trace_cb_end(desc_idx);
         if entry.oneshot {
             entry.fired = true;
         } else if entry.period_us == 0 {
@@ -1254,6 +1484,16 @@ where
     }
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized action server dispatch function.
 ///
 /// Polls goal acceptance, cancel handling, and result serving.
@@ -1271,6 +1511,7 @@ pub(crate) unsafe fn action_server_try_process<
 >(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     A: RosAction,
@@ -1322,6 +1563,16 @@ where
     Ok(did_work)
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized raw action server dispatch function.
 ///
 /// Polls goal acceptance, cancel handling, and result serving using raw bytes.
@@ -1336,6 +1587,7 @@ pub(crate) unsafe fn action_server_raw_try_process<
 >(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError> {
     let entry = unsafe {
         &mut *(ptr as *mut ActionServerRawArenaEntry<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF, MAX_GOALS>)
@@ -1452,6 +1704,16 @@ fn read_action_field<M: nros_serdes::Deserialize, const CAP: usize>(
     M::deserialize(&mut reader).ok()
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 pub(crate) unsafe fn action_client_raw_try_process<
     const GOAL_BUF: usize,
     const RESULT_BUF: usize,
@@ -1459,6 +1721,7 @@ pub(crate) unsafe fn action_client_raw_try_process<
 >(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError> {
     let entry = unsafe {
         &mut *(ptr as *mut ActionClientRawArenaEntry<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF>)
@@ -1603,6 +1866,16 @@ pub(crate) unsafe fn action_client_raw_try_process<
     Ok(did_work)
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized raw service-client dispatch function.
 ///
 /// Checks `reply_ready` (set by the transport waker) before calling
@@ -1614,6 +1887,7 @@ pub(crate) unsafe fn action_client_raw_try_process<
 pub(crate) unsafe fn service_client_raw_try_process<const REPLY_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError> {
     use core::sync::atomic::Ordering;
     use nros_rmw::ClientTrait;
@@ -1671,6 +1945,16 @@ pub(crate) struct ServiceClientCallbackEntry<Svc: RosService, F, const REPLY_BUF
     pub(crate) _phantom: PhantomData<Svc>,
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized typed service-client dispatch (RFC-0041, Phase 239.1).
 ///
 /// Mirrors [`service_client_raw_try_process`] but deserializes the reply into
@@ -1682,6 +1966,7 @@ pub(crate) struct ServiceClientCallbackEntry<Svc: RosService, F, const REPLY_BUF
 pub(crate) unsafe fn service_client_callback_try_process<Svc, F, const REPLY_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     Svc: RosService,
@@ -1762,6 +2047,14 @@ fn goal_id_from_counter(counter: u64) -> nros_core::GoalId {
     nros_core::GoalId { uuid }
 }
 
+// TODO(phase-8): NOT hooked, and the one leaf that needs a signature change
+// of its own. `dispatch_feedback(data, offset, on_feedback)` carries NO
+// identity at all — not the slot index, not even the arena address — so
+// hooking it means threading `desc_idx` down from
+// `action_client_callback_try_process`. Hook it HERE rather than at its two
+// call sites: it returns without firing when the payload is short, which at a
+// call site would re-introduce exactly the false positive the leaf-hook
+// placement exists to avoid. See `docs/design/callback_tracing.rst`.
 /// Decode one raw feedback slot (outer header + GoalId at [4..20] + inner-CDR
 /// payload at `offset`) and invoke the typed feedback closure (Phase 239.5).
 #[inline]
@@ -1786,6 +2079,16 @@ fn dispatch_feedback<A, F, const FEEDBACK_BUF: usize>(
     }
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized typed action-client dispatch (RFC-0041, Phase 239.2). Mirrors
 /// [`action_client_raw_try_process`] but deserializes the feedback / result
 /// payloads into `A::Feedback` / `A::Result` and invokes the typed closures.
@@ -1804,6 +2107,7 @@ pub(crate) unsafe fn action_client_callback_try_process<
 >(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     A: RosAction,
@@ -1910,6 +2214,16 @@ where
     Ok(did_work)
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized raw service dispatch function.
 ///
 /// # Safety
@@ -1917,6 +2231,7 @@ where
 pub(crate) unsafe fn srv_raw_try_process<const REQ_BUF: usize, const REPLY_BUF: usize>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError> {
     let entry = unsafe { &mut *(ptr as *mut SrvRawEntry<REQ_BUF, REPLY_BUF>) };
     let SrvRawEntry {
@@ -1957,6 +2272,16 @@ pub(crate) unsafe fn srv_raw_try_process<const REQ_BUF: usize, const REPLY_BUF: 
     Ok(true)
 }
 
+// TODO(phase-8): NOT hooked. The user-callback invocation(s) in this
+// function carry no `trace_cb_start` / `trace_cb_end` pair, so a capture
+// reports this callback as `registered, not instrumented` rather than
+// omitting it — see `docs/design/callback_tracing.rst`, "Registration is
+// exhaustive; instrumentation is staged". The design counts 33 leaf sites
+// in total; this change hooks the 3 the safety island actually runs (one
+// timer, and the C-FFI subscription's triple + ring paths). Hooking the
+// rest is mechanical — bracket the invocation, not the `try_process`
+// boundary — but landing 33 at once is the "looks like coverage and isn't"
+// hazard this design exists to avoid.
 /// Monomorphized guard condition dispatch function.
 ///
 /// # Safety
@@ -1964,6 +2289,7 @@ pub(crate) unsafe fn srv_raw_try_process<const REQ_BUF: usize, const REPLY_BUF: 
 pub(crate) unsafe fn guard_try_process<F>(
     ptr: *mut u8,
     _delta_us: u64,
+    _desc_idx: u8,
 ) -> Result<bool, TransportError>
 where
     F: FnMut(),
@@ -2530,8 +2856,12 @@ mod timer_overrun_tests {
     fn step<F: FnMut()>(entry: &mut TimerEntry<F>, delta_ms: u64) -> bool {
         // SAFETY: `entry` is a live, aligned `TimerEntry<F>`.
         unsafe {
-            timer_try_process::<F>((entry as *mut TimerEntry<F>).cast::<u8>(), delta_ms * 1000)
-                .unwrap()
+            timer_try_process::<F>(
+                (entry as *mut TimerEntry<F>).cast::<u8>(),
+                delta_ms * 1000,
+                0,
+            )
+            .unwrap()
         }
     }
 
@@ -2539,7 +2869,7 @@ mod timer_overrun_tests {
     fn step_us<F: FnMut()>(entry: &mut TimerEntry<F>, delta_us: u64) -> bool {
         // SAFETY: `entry` is a live, aligned `TimerEntry<F>`.
         unsafe {
-            timer_try_process::<F>((entry as *mut TimerEntry<F>).cast::<u8>(), delta_us).unwrap()
+            timer_try_process::<F>((entry as *mut TimerEntry<F>).cast::<u8>(), delta_us, 0).unwrap()
         }
     }
 

--- a/packages/core/nros-node/src/executor/callback_trace.rs
+++ b/packages/core/nros-node/src/executor/callback_trace.rs
@@ -1,0 +1,258 @@
+//! Phase 8 — callback-level dispatch tracing.
+//!
+//! Design: autoware-safety-island `docs/design/callback_tracing.rst`
+//! (plan: `docs/roadmap/phase-8-callback-tracing.md`).
+//!
+//! A CTF capture shows THREADS. A callback does not run on a thread of its
+//! own — it runs inside an executor wake, as an ordinary function call — so
+//! thread-level tracing can see the executor's cadence and cannot see where
+//! any individual callback begins or ends. The fix every runtime with the
+//! same shape (tokio, Go, ros2_tracing) reaches for is to instrument the
+//! MULTIPLEXER: the dispatcher is the only place that knows both identities.
+//!
+//! Three events, named after ros2_tracing so the concepts carry over:
+//!
+//! - [`register`] — once, when an entry is added to the executor. Records
+//!   handle → (kind, name). This is ros2_tracing's init/runtime split, and
+//!   it is what removes the hand-maintained handle→name enum that phase 7
+//!   had to carry (and whose renumbering silently reinterpreted every trace
+//!   taken before it).
+//! - [`start`] / [`end`] — per dispatch, immediately around the leaf
+//!   callback invocation. Handle only; no strings in the hot path.
+//!
+//! ## The sink
+//!
+//! Core must not name a platform (`nros-node`'s manifest states the policy:
+//! the executor reaches the platform through a runtime vtable, "never via a
+//! compile-time `#[cfg(feature = "platform-*")]` branch"). So the transport
+//! is a runtime-installed function pointer in an [`AtomicPtr`], structurally
+//! the same seam `wake_probe.rs` already uses for the same reason — hot-path
+//! hooks that must vanish in production.
+//!
+//! [`TraceSink`]'s ABI is deliberately `unsafe extern "C" fn(u32, u32)`: that
+//! IS the signature of a two-`uint32` platform trace event (on Zephyr,
+//! `sys_trace_app_marker` behind an out-of-tree CTF patch), so a C caller can
+//! install its shim directly with no Rust-side adapter and nano-ros never
+//! references a symbol that only one downstream image defines.
+//!
+//! ## Wire encoding
+//!
+//! The carrier event has exactly two `u32` fields, `(marker_id, arg)`. Three
+//! events, one of them carrying a variable-length name, are packed into it:
+//!
+//! | `marker_id` | event    | `arg`                                          |
+//! |-------------|----------|------------------------------------------------|
+//! | 16          | register | `handle << 8 \| kind`                          |
+//! | 17          | name     | next 4 name bytes, byte *i* in bits `8*i`      |
+//! | 18          | start    | `handle`                                       |
+//! | 19          | end      | `handle`                                       |
+//!
+//! Name chunks repeat until the name is spent and are NUL-padded; a chunk
+//! run binds to the register event it FOLLOWS. That is adjacency, not
+//! keying — stated plainly because it is a real weakness: a dropped or
+//! interleaved event inside a registration burst mis-attributes a NAME. It
+//! is tolerable only because registration is init-time, once per callback,
+//! on one thread, before any traffic worth measuring — and because a wrong
+//! name can never corrupt a DURATION, which is keyed on the handle carried
+//! by the runtime events alone. A capture that starts after init simply has
+//! no names and the decoder falls back to `handle N`.
+//!
+//! Marker ids 1..7 belong to the application's hand-placed phase markers and
+//! must never be reused: captured traces carry them, and renumbering
+//! silently reinterprets every trace taken before it. The block starts at 16
+//! rather than 8 so those keep room to grow contiguously.
+//!
+//! Gated behind `feature = "trace-callbacks"` so production builds carry zero
+//! overhead and the call sites become `#[cfg]`-elided no-ops. NOT built on
+//! the `tracing` crate facade: a no-op subscriber still costs span
+//! construction and a level check on every dispatch.
+
+#![cfg(feature = "trace-callbacks")]
+
+use core::{
+    fmt::Write as _,
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+use super::arena::{EntryKind, TraceName};
+
+/// `nros_callback_register(handle, kind, name)` — once, at registration.
+pub const MARKER_REGISTER: u32 = 16;
+/// One 4-byte chunk of the name belonging to the preceding register event.
+pub const MARKER_NAME: u32 = 17;
+/// `callback_start(handle)` — immediately before the callback is invoked.
+pub const MARKER_START: u32 = 18;
+/// `callback_end(handle)` — immediately after it returns.
+pub const MARKER_END: u32 = 19;
+
+/// Names longer than this are truncated. Matches the decoder's `CB_NAME_MAX`;
+/// both sides must agree or the tail of a long name is read as a chunk of
+/// the next registration's.
+pub const NAME_MAX: usize = 64;
+
+/// The trace sink, installed at app startup.
+///
+/// `unsafe extern "C" fn(u32, u32)` so a C-side shim (e.g. a Zephyr
+/// `sys_trace_app_marker` wrapper) is installable verbatim.
+///
+/// # Safety
+/// The installed function is called from the executor's dispatch path,
+/// including from an OS-priority worker TASK — so it must be re-entrant and
+/// safe to call from any thread that runs callbacks. It must not unwind.
+pub type TraceSink = unsafe extern "C" fn(u32, u32);
+
+/// `AtomicPtr<()>` holding the installed [`TraceSink`]. A plain
+/// `Option<TraceSink>` cannot be atomic because a function pointer is not
+/// `AtomicPtr<T>`'s `T`; store as `*mut ()` and `transmute` on read. Same
+/// shape as `wake_probe::CYCLE_READER`.
+static SINK: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+/// Install the trace sink. Call once at app startup, BEFORE the executor
+/// registers anything — a sink installed later misses the registration
+/// events and the decoder falls back to `handle N` labels. `None` disables
+/// tracing (hooks become no-ops on the next call).
+pub fn set_trace_sink(sink: Option<TraceSink>) {
+    let ptr = match sink {
+        Some(f) => f as *mut (),
+        None => core::ptr::null_mut(),
+    };
+    SINK.store(ptr, Ordering::Release);
+}
+
+#[inline]
+fn sink() -> Option<TraceSink> {
+    let ptr = SINK.load(Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: the pointer was installed via `set_trace_sink` from a real
+        // `TraceSink` fn pointer; same ABI on load. The producer's `Release`
+        // pairs with this `Acquire`.
+        Some(unsafe { core::mem::transmute::<*mut (), TraceSink>(ptr) })
+    }
+}
+
+#[inline]
+fn emit(sink: TraceSink, marker_id: u32, arg: u32) {
+    // SAFETY: `sink` came from `sink()`, i.e. from a `TraceSink` installed by
+    // `set_trace_sink`, whose contract (see [`TraceSink`]) covers being called
+    // from the dispatch path on any executor thread.
+    unsafe { sink(marker_id, arg) }
+}
+
+/// Wire `kind` for the register event.
+///
+/// The design's table is `0` timer, `1` subscription, `2` service, `3`
+/// action. `EntryKind` has SEVEN variants, not four: clients fold onto their
+/// server's kind (a service client is still service traffic, an action client
+/// still action traffic), which loses nothing the handle does not already
+/// distinguish.
+///
+/// `GuardCondition` is the one that does not fit — the design's four-kind
+/// framing omits it. It gets `4` rather than being squeezed into a wrong
+/// bucket or dropped from the registration sweep; the decoder's kind table
+/// falls back to a literal `kind 4` label for anything outside `0..=3`, so
+/// this degrades to a readable row rather than a misattribution.
+#[inline]
+fn wire_kind(kind: EntryKind) -> u32 {
+    match kind {
+        EntryKind::Timer => 0,
+        EntryKind::Subscription => 1,
+        EntryKind::Service | EntryKind::ServiceClient => 2,
+        EntryKind::ActionServer | EntryKind::ActionClient => 3,
+        EntryKind::GuardCondition => 4,
+    }
+}
+
+/// Stream a name as 4-byte little-endian chunks, NUL-padded, truncated at
+/// [`NAME_MAX`].
+fn stream_name(sink: TraceSink, name: &str) {
+    let bytes = name.as_bytes();
+    let n = bytes.len().min(NAME_MAX);
+    let mut i = 0;
+    while i < n {
+        let mut word: u32 = 0;
+        let mut j = 0usize;
+        while j < 4 {
+            if i + j < n {
+                word |= (bytes[i + j] as u32) << (8 * j as u32);
+            }
+            j += 1;
+        }
+        emit(sink, MARKER_NAME, word);
+        i += 4;
+    }
+}
+
+/// Emit `nros_callback_register(handle, kind, name)` plus the name chunks.
+///
+/// Called once per executor entry, from the single `emplace_entry` choke
+/// point every registration site funnels through. Init-time, so the cost of
+/// streaming the name is paid once and steady-state tracing carries handles
+/// only.
+///
+/// `handle` is the entry slot index — stable (no code path writes
+/// `entries[i] = None` after registration; `cancel_timer` only sets a flag),
+/// unique across every kind (one flat table), and bounded by
+/// `MAX_CALLBACK_SLOTS`, so it fits the 24 bits left after the kind byte with
+/// room to spare.
+pub(crate) fn register(handle: usize, kind: EntryKind, name: TraceName<'_>) {
+    let Some(sink) = sink() else { return };
+
+    emit(
+        sink,
+        MARKER_REGISTER,
+        ((handle as u32 & 0x00ff_ffff) << 8) | wire_kind(kind),
+    );
+
+    // Synthesised names go through a stack buffer — no allocator, and the
+    // formatting only exists in a build that enabled this feature.
+    let mut scratch: heapless::String<NAME_MAX> = heapless::String::new();
+    let text: &str = match name {
+        TraceName::Text(s) => s,
+        // Timers carry no name anywhere in the executor, so the period is
+        // the only thing that distinguishes one from another in a trace.
+        TraceName::TimerPeriod(period_us) => {
+            // A truncated synthesised name is still more useful than none;
+            // `write!` failing means the buffer filled, not that the value
+            // was bad.
+            let _ = write!(&mut scratch, "timer@{period_us}us");
+            scratch.as_str()
+        }
+        // Some entries carry nothing at all — not even a period (guard
+        // conditions; an arena subscription handed an already-open
+        // `RmwSubscriber`). The slot index is the only identity there is, and
+        // it is exactly what the runtime events key on.
+        TraceName::Slot(label, slot) => {
+            let _ = write!(&mut scratch, "{label}#{slot}");
+            scratch.as_str()
+        }
+    };
+    stream_name(sink, text);
+}
+
+/// `callback_start(handle)` — immediately before a leaf callback is invoked.
+///
+/// O(1), allocation-free, lock-free; one relaxed-ordering pointer load plus
+/// the sink call. No state is kept across the pair, which is what makes it
+/// safe to fire from the OS-priority worker thread as well as the executor's
+/// own (`os_priority.rs` runs `try_process` on a different thread, so any
+/// depth counter or open-span slot here would have had to be per-thread from
+/// day one). Pairing is done offline by the decoder, keyed on the handle.
+#[inline]
+pub(crate) fn start(handle: u8) {
+    if let Some(sink) = sink() {
+        emit(sink, MARKER_START, handle as u32);
+    }
+}
+
+/// `callback_end(handle)` — immediately after the callback returns.
+///
+/// See [`start`]. A callback that panics or long-jumps out skips its `end`;
+/// the decoder counts that as an unbalanced span rather than a duration.
+#[inline]
+pub(crate) fn end(handle: u8) {
+    if let Some(sink) = sink() {
+        emit(sink, MARKER_END, handle as u32);
+    }
+}

--- a/packages/core/nros-node/src/executor/mod.rs
+++ b/packages/core/nros-node/src/executor/mod.rs
@@ -27,6 +27,13 @@ pub mod action_core;
 pub(crate) mod activator;
 #[cfg(any(has_rmw, test))]
 mod arena;
+// Phase 8 (autoware-safety-island `docs/design/callback_tracing.rst`) —
+// callback-level dispatch tracing. Same gating shape as `wake_probe`, for the
+// same reason: hot-path hooks that must vanish in production. The module ALSO
+// self-gates (`#![cfg(feature = "trace-callbacks")]`), so the call sites use
+// paired stubs rather than naming it directly.
+#[cfg(all(any(has_rmw, test), feature = "trace-callbacks"))]
+pub mod callback_trace;
 #[cfg(any(has_rmw, test))]
 pub(crate) mod dispatcher;
 #[cfg(any(has_rmw, test))]

--- a/packages/core/nros-node/src/executor/os_priority.rs
+++ b/packages/core/nros-node/src/executor/os_priority.rs
@@ -91,8 +91,17 @@ pub(crate) const MAX_PRIORITY_LEVELS: usize = 8;
 pub(crate) struct WorkItem {
     pub(crate) arena_base: usize,
     pub(crate) arena_offset: usize,
-    pub(crate) try_process: unsafe fn(*mut u8, u64) -> Result<bool, nros_rmw::TransportError>,
+    pub(crate) try_process: unsafe fn(*mut u8, u64, u8) -> Result<bool, nros_rmw::TransportError>,
     pub(crate) delta_us: u64,
+    /// The entry's slot index, carried so the leaf callback hooks can name
+    /// the callback they bracket (phase 8,
+    /// `docs/design/callback_tracing.rst`). This path is the reason those
+    /// hooks had to be thread-safe from day one: it runs `try_process` on a
+    /// WORKER task, so two callbacks can legitimately be in flight at once
+    /// and their events interleave in the capture. Keying every event on the
+    /// handle — rather than holding an open span in a single slot — is what
+    /// lets the decoder pair them anyway.
+    pub(crate) desc_idx: u8,
 }
 
 // SAFETY: Phase 110.F per-DescIdx exclusive-access invariant — the activator
@@ -137,7 +146,7 @@ unsafe extern "C" fn worker_entry(arg: *mut c_void) -> *mut c_void {
             // arena, which outlives this task — `Executor::drop` halts and
             // JOINS every worker before the arena is released.
             let data = (item.arena_base as *mut u8).wrapping_add(item.arena_offset);
-            let _ = unsafe { (item.try_process)(data, item.delta_us) };
+            let _ = unsafe { (item.try_process)(data, item.delta_us, item.desc_idx) };
         }
         // Bounded wait: the producer signals after every enqueue, and the
         // timeout bounds how long a halt takes to observe.

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -21,7 +21,7 @@ use super::{
         ServiceClientRawArenaEntry, ServiceClientSendHeader, SrvEntry, SrvRawEntry,
         SubBufferedBorrowedEntry, SubBufferedEntry, SubBufferedRawCEntry, SubBufferedRawEntry,
         SubBufferedRawInfoCEntry, SubBufferedRawInfoEntry, SubInfoEntry, SubInplaceEntry,
-        TimerEntry, TimerHeader, TimerOverrunPolicy, always_ready, buffered_region_size,
+        TimerEntry, TimerHeader, TimerOverrunPolicy, TraceName, always_ready, buffered_region_size,
         drop_entry, guard_has_data, guard_try_process, no_pre_sample,
         service_client_callback_try_process, service_client_raw_try_process, srv_has_data,
         srv_raw_has_data, srv_raw_try_process, srv_try_process, sub_buffered_borrowed_has_data,
@@ -43,6 +43,26 @@ use super::{
         Trigger,
     },
 };
+
+// ============================================================================
+// Phase 8 — callback registration event (paired stubs)
+// ============================================================================
+//
+// `docs/design/callback_tracing.rst`. Paired stubs (the `entry_tiers.rs`
+// idiom) so `emplace_entry` reads identically whether or not the feature is
+// on, and the `#[cfg]` lives in exactly one place.
+
+/// Emit `nros_callback_register(handle, kind, name)` for a newly installed
+/// executor entry.
+#[cfg(feature = "trace-callbacks")]
+#[inline]
+fn trace_register(slot: usize, kind: EntryKind, name: TraceName<'_>) {
+    super::callback_trace::register(slot, kind, name);
+}
+
+#[cfg(not(feature = "trace-callbacks"))]
+#[inline]
+fn trace_register(_slot: usize, _kind: EntryKind, _name: TraceName<'_>) {}
 
 // ============================================================================
 // Executor::open() factory method
@@ -3521,6 +3541,29 @@ impl<'s> Executor<'s> {
             .ok_or(NodeError::ExecutorFull)
     }
 
+    /// Install a finished [`CallbackMeta`] into its slot.
+    ///
+    /// phase-8 (`docs/design/callback_tracing.rst`) — the ONE choke point
+    /// every registration site funnels through, so the
+    /// `nros_callback_register(handle, kind, name)` event is emitted once,
+    /// here, rather than at the 25 sites that build a `CallbackMeta`. The
+    /// design's registration half is deliberately EXHAUSTIVE across every
+    /// `EntryKind` even though the leaf hooks are staged: a callback that was
+    /// registered but never observed then prints as "registered, not
+    /// instrumented" instead of being silently absent, so an incomplete hook
+    /// set announces itself in the output rather than looking like a
+    /// measurement.
+    ///
+    /// It is the assignment — not [`next_entry_slot`](Self::next_entry_slot)
+    /// — because a slot is claimed BEFORE the fallible work (session lookup,
+    /// arena allocation, handle creation) that can still return `Err`.
+    /// Emitting at slot-claim time would announce callbacks that do not
+    /// exist.
+    pub(crate) fn emplace_entry(&mut self, slot: usize, meta: CallbackMeta, name: TraceName<'_>) {
+        trace_register(slot, meta.kind, name);
+        self.entries[slot] = Some(meta);
+    }
+
     /// Typed buffered subscription core (the `node_mut(id).subscription(t)
     /// .typed::<M>()` builder lowers here). Routes the typed subscription
     /// through the [`NodeId`]'s session + identity (rclcpp `add_node` pattern).
@@ -3599,7 +3642,7 @@ impl<'s> Executor<'s> {
                         },
                     );
                 }
-                self.entries[slot] = Some(CallbackMeta {
+                let meta = CallbackMeta {
                     offset: entry_offset,
                     kind: EntryKind::Subscription,
                     try_process: sub_inplace_try_process::<M, F>,
@@ -3607,7 +3650,8 @@ impl<'s> Executor<'s> {
                     pre_sample: no_pre_sample,
                     invocation: InvocationMode::OnNewData,
                     drop_fn: drop_entry::<SubInplaceEntry<M, F>>,
-                });
+                };
+                self.emplace_entry(slot, meta, TraceName::Text(topic_name));
                 self.apply_node_default_sched(slot, Some(node_id), group);
                 return Ok(HandleId(slot));
             }
@@ -3641,7 +3685,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset: entry_offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_try_process::<M, F>,
@@ -3649,7 +3693,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<M, F>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         // Phase 104.C.4 — apply Node's default SchedContext.
         self.apply_node_default_sched(slot, Some(node_id), group);
         Ok(HandleId(slot))
@@ -3810,7 +3855,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset: entry_offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_borrowed_try_process::<B, F>,
@@ -3818,7 +3863,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<B, F>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, Some(node_id), None);
         Ok(HandleId(slot))
     }
@@ -3884,7 +3930,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_raw_info_try_process::<F, RX_BUF>,
@@ -3892,7 +3938,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<F, RX_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, Some(node_id), None);
         Ok(HandleId(slot))
     }
@@ -3961,7 +4008,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_raw_safety_try_process::<F, RX_BUF>,
@@ -3969,7 +4016,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<F, RX_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, Some(node_id), None);
         Ok(HandleId(slot))
     }
@@ -4034,7 +4082,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset: entry_offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_raw_try_process::<F>,
@@ -4042,7 +4090,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<F>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Slot("sub", slot));
         Ok(HandleId(slot))
     }
 
@@ -4109,7 +4158,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Subscription,
             try_process: sub_info_try_process::<M, F, RX_BUF>,
@@ -4117,7 +4166,8 @@ impl<'s> Executor<'s> {
             pre_sample: sub_info_pre_sample::<M, F, RX_BUF>,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<M, F, RX_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok(HandleId(slot))
     }
@@ -4186,7 +4236,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Subscription,
             try_process: sub_safety_try_process::<M, F, RX_BUF>,
@@ -4194,7 +4244,8 @@ impl<'s> Executor<'s> {
             pre_sample: sub_safety_pre_sample::<M, F, RX_BUF>,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<M, F, RX_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok(HandleId(slot))
     }
@@ -4268,7 +4319,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Service,
             try_process: srv_try_process::<Svc, F, REQ_BUF, REPLY_BUF>,
@@ -4276,7 +4327,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<Svc, F, REQ_BUF, REPLY_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(service_name));
         Ok(HandleId(slot))
     }
 
@@ -4344,7 +4396,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Service,
             try_process: srv_try_process::<Svc, F, REQ_BUF, REPLY_BUF>,
@@ -4352,7 +4404,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<Svc, F, REQ_BUF, REPLY_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(service_name));
         self.apply_node_default_sched(slot, Some(node_id), None);
         Ok(HandleId(slot))
     }
@@ -4417,7 +4470,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Timer,
             try_process: timer_try_process::<F>,
@@ -4425,7 +4478,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::Always,
             drop_fn: drop_entry::<TimerEntry<F>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::TimerPeriod(period.as_micros()));
         Ok(HandleId(slot))
     }
 
@@ -4462,7 +4516,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Timer,
             try_process: timer_try_process::<F>,
@@ -4470,7 +4524,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::Always,
             drop_fn: drop_entry::<TimerEntry<F>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::TimerPeriod(delay.as_micros()));
         Ok(HandleId(slot))
     }
 
@@ -4514,7 +4569,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Timer,
             try_process: timer_try_process::<F>,
@@ -4522,7 +4577,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::Always,
             drop_fn: drop_entry::<TimerEntry<F>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::TimerPeriod(period.as_micros()));
         // Phase 273 — apply group sched binding (group > node default > SC 0).
         self.apply_node_default_sched(slot, node_id, group);
         Ok(HandleId(slot))
@@ -4603,7 +4659,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset: entry_offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_raw_c_try_process,
@@ -4611,7 +4667,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<SubBufferedRawCEntry>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, node_id, group);
         Ok(HandleId(slot))
     }
@@ -4679,7 +4736,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_raw_info_c_try_process::<RX_BUF>,
@@ -4687,7 +4744,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<RX_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok(HandleId(slot))
     }
@@ -4763,7 +4821,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Subscription,
             try_process: sub_buffered_raw_safety_c_try_process::<RX_BUF>,
@@ -4771,7 +4829,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<Entry<RX_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(topic_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok(HandleId(slot))
     }
@@ -4909,7 +4968,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::Service,
             try_process: srv_raw_try_process::<REQ_BUF, REPLY_BUF>,
@@ -4917,7 +4976,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::OnNewData,
             drop_fn: drop_entry::<SrvRawEntry<REQ_BUF, REPLY_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(service_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok(HandleId(slot))
     }
@@ -5060,7 +5120,7 @@ impl<'s> Executor<'s> {
             );
         }
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ServiceClient,
             try_process: service_client_raw_try_process::<REPLY_BUF>,
@@ -5068,7 +5128,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::Always,
             drop_fn: drop_entry::<ServiceClientRawArenaEntry<REPLY_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(service_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok(HandleId(slot))
     }
@@ -5141,7 +5202,7 @@ impl<'s> Executor<'s> {
             &mut (*entry_ptr).hdr as *mut ServiceClientSendHeader<REPLY_BUF>
         };
 
-        self.entries[slot] = Some(CallbackMeta {
+        let meta = CallbackMeta {
             offset,
             kind: EntryKind::ServiceClient,
             try_process: service_client_callback_try_process::<Svc, F, REPLY_BUF>,
@@ -5149,7 +5210,8 @@ impl<'s> Executor<'s> {
             pre_sample: no_pre_sample,
             invocation: InvocationMode::Always,
             drop_fn: drop_entry::<ServiceClientCallbackEntry<Svc, F, REPLY_BUF>>,
-        });
+        };
+        self.emplace_entry(slot, meta, TraceName::Text(service_name));
         self.apply_node_default_sched(slot, node_id, None);
         Ok((HandleId(slot), hdr_ptr))
     }
@@ -5195,7 +5257,7 @@ impl<'s> Executor<'s> {
                 guard_handle.set_wake_cb(nros_rmw_runtime_wake_cb, ctx);
             }
 
-            self.entries[slot] = Some(CallbackMeta {
+            let meta = CallbackMeta {
                 offset,
                 kind: EntryKind::GuardCondition,
                 try_process: guard_try_process::<F>,
@@ -5203,7 +5265,8 @@ impl<'s> Executor<'s> {
                 pre_sample: no_pre_sample,
                 invocation: InvocationMode::OnNewData,
                 drop_fn: drop_entry::<GuardConditionEntry<F>>,
-            });
+            };
+            self.emplace_entry(slot, meta, TraceName::Slot("guard", slot));
 
             Ok((HandleId(slot), guard_handle))
         }
@@ -5623,10 +5686,20 @@ impl<'s> Executor<'s> {
 
         if !trigger_passes {
             // Timers still need delta accumulation even when trigger doesn't pass
-            for meta in self.entries.iter().flatten() {
+            //
+            // phase-8 — `.enumerate()` (rather than a bare `.flatten()`) because
+            // `try_process` now carries the entry's slot index for the callback
+            // trace hooks. This sweep FIRES timer callbacks, so it is a real
+            // dispatch path and must attribute them like the drain below does.
+            for (i, meta) in self
+                .entries
+                .iter()
+                .enumerate()
+                .filter_map(|(i, e)| e.as_ref().map(|m| (i, m)))
+            {
                 if matches!(meta.kind, EntryKind::Timer) {
                     let data_ptr = unsafe { arena_ptr.add(meta.offset) };
-                    let _ = unsafe { (meta.try_process)(data_ptr, delta_us) };
+                    let _ = unsafe { (meta.try_process)(data_ptr, delta_us, i as u8) };
                 }
             }
 
@@ -5884,6 +5957,11 @@ impl<'s> Executor<'s> {
                         arena_offset: meta.offset,
                         try_process: meta.try_process,
                         delta_us,
+                        // phase-8 — the worker runs the leaf on a DIFFERENT
+                        // thread, so it has to carry the slot index with it;
+                        // nothing on the far side can recover it from the
+                        // arena address alone.
+                        desc_idx: i as u8,
                     };
                     // phase-359 W10 — `try_dispatch` now reports whether the
                     // entry was actually handed to a worker. It can decline:
@@ -5959,6 +6037,7 @@ impl<'s> Executor<'s> {
         // corresponding `entries[i]` slot was `Some`; no Executor
         // mutation happens between that scan and this dispatch.
         let dispatch_one = |meta: &CallbackMeta,
+                            desc_idx: usize,
                             arena_ptr: *mut u8,
                             delta_us: u64,
                             result: &mut SpinOnceResult| {
@@ -5976,7 +6055,11 @@ impl<'s> Executor<'s> {
                 super::wake_probe::on_dispatch();
             }
             let data_ptr = unsafe { arena_ptr.add(meta.offset) };
-            match unsafe { (meta.try_process)(data_ptr, delta_us) } {
+            // phase-8 — `desc_idx` is the entry slot index, threaded through so
+            // the leaf hooks in `arena.rs` can name the callback they bracket.
+            // `MAX_CALLBACK_SLOTS` is 64 (enforced by the `u64` ready-set
+            // bitmask), so the `as u8` cannot truncate a live slot.
+            match unsafe { (meta.try_process)(data_ptr, delta_us, desc_idx as u8) } {
                 Ok(true) => match meta.kind {
                     EntryKind::Subscription => result.subscriptions_processed += 1,
                     EntryKind::Service
@@ -6124,7 +6207,7 @@ impl<'s> Executor<'s> {
                     // no_std arm this replaces — the std arm used to measure
                     // unconditionally.
                     let start_us = measure_us.then(&read_us);
-                    dispatch_one(meta, arena_ptr, delta_us, &mut result);
+                    dispatch_one(meta, i, arena_ptr, delta_us, &mut result);
                     let elapsed_us: Option<u32> = start_us
                         .map(|t0| read_us().saturating_sub(t0))
                         .map(|d| d.min(u32::MAX as u64) as u32);
@@ -6164,7 +6247,7 @@ impl<'s> Executor<'s> {
                     // no_std arm this replaces — the std arm used to measure
                     // unconditionally.
                     let start_us = measure_us.then(&read_us);
-                    dispatch_one(meta, arena_ptr, delta_us, &mut result);
+                    dispatch_one(meta, i, arena_ptr, delta_us, &mut result);
                     let elapsed_us: Option<u32> = start_us
                         .map(|t0| read_us().saturating_sub(t0))
                         .map(|d| d.min(u32::MAX as u64) as u32);

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -5015,7 +5015,7 @@ fn a_deferred_goal_reaches_the_accepted_callback_exactly_once() {
     let ptr = (&mut entry) as *mut _ as *mut u8;
 
     // No request pending → no work, and certainly no accept.
-    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0) }.unwrap();
+    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0, 0) }.unwrap();
     assert!(!did_work, "an idle server must report no work");
     assert_eq!(ACCEPTED_CALLS.load(SeqCst), 0);
 
@@ -5023,7 +5023,7 @@ fn a_deferred_goal_reaches_the_accepted_callback_exactly_once() {
     let (req, len) = mk_send_goal_req(&g);
     entry.core.send_goal_server.load(req, len);
 
-    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0) }.unwrap();
+    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0, 0) }.unwrap();
     assert!(did_work);
     assert_eq!(
         ACCEPTED_CALLS.load(SeqCst),
@@ -5046,7 +5046,7 @@ fn a_deferred_goal_reaches_the_accepted_callback_exactly_once() {
     assert_eq!(entry.core.active_goals.len(), 1);
 
     // Spinning again with nothing pending must not re-fire the hook.
-    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0) }.unwrap();
+    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0, 0) }.unwrap();
     assert!(!did_work);
     assert_eq!(
         ACCEPTED_CALLS.load(SeqCst),
@@ -5059,7 +5059,7 @@ fn a_deferred_goal_reaches_the_accepted_callback_exactly_once() {
     let g2 = GoalId { uuid: [0x5Au8; 16] };
     let (req2, len2) = mk_send_goal_req(&g2);
     entry.core.send_goal_server.load(req2, len2);
-    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0) }.unwrap();
+    let did_work = unsafe { action_server_raw_try_process::<GB, RB, FB, MG>(ptr, 0, 0) }.unwrap();
     assert!(did_work);
     assert_eq!(
         ACCEPTED_CALLS.load(SeqCst),

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -234,6 +234,29 @@ if(_nros_panic_feature)
     set(_nros_panic_suffix ",${_nros_panic_feature}")
 endif()
 
+# phase-8 W4 — callback tracing. This is the ONE read of
+# `CONFIG_NROS_TRACE_CALLBACKS`; every feature string below appends the result,
+# so the knob cannot reach one cargo build and miss another.
+#
+# It is spelled as a suffix rather than as a per-site `if()` (the shape
+# `param-services` uses) because the C/C++ lane compiles nros-c AND nros-cpp
+# from the same nros-node dep graph, in two separate cargo invocations, and
+# BOTH are linked into a C++-only image (see the `NOT CONFIG_NROS_C_API` block
+# below, whose own comment requires "the SAME RMW + platform feature set").
+# Two cargo units of nros-node differing in a feature is the 0135 ABI-split
+# class, not a missing optimisation — so the sites must move together, and one
+# variable is how they are kept in step.
+#
+# Appended to the feature STRINGS, not to the `nros_cargo_build` FEATURES
+# argument like `_nros_panic_suffix`, because the mixed-workspace umbrella
+# re-splits `_nros_cpp_features` (`string(REPLACE "," ";" ...)` below) and
+# would otherwise build the one archive that actually gets linked without the
+# feature.
+set(_nros_trace_suffix "")
+if(CONFIG_NROS_TRACE_CALLBACKS)
+    set(_nros_trace_suffix ",trace-callbacks")
+endif()
+
 # =============================================================================
 # C API path: build nros-c via Cargo and link it
 # =============================================================================
@@ -285,6 +308,9 @@ if(CONFIG_NROS_C_API)
     if(CONFIG_BOARD_NATIVE_SIM OR CONFIG_BOARD_NATIVE_POSIX)
         string(APPEND _nros_features ",std")
     endif()
+
+    # phase-8 W4 — callback tracing (see `_nros_trace_suffix` above).
+    string(APPEND _nros_features "${_nros_trace_suffix}")
 
     # Build nros-c static library via Cargo
     nros_cargo_build(
@@ -499,6 +525,11 @@ if(CONFIG_NROS_CPP_API)
         add_compile_definitions(NROS_SYSTEM_PARAM_SERVICES)
     endif()
 
+    # phase-8 W4 — callback tracing (see `_nros_trace_suffix` above). Appended
+    # BEFORE the umbrella's `string(REPLACE "," ";" _umb_feats ...)` below, so
+    # a mixed workspace's single linked archive carries it too.
+    string(APPEND _nros_cpp_features "${_nros_trace_suffix}")
+
     # Phase 168.X gap 1 — `nros_log_emit` + `nros_log_emit_fmt`
     # symbols (the C-side log glue every `NROS_LOG_*` macro from
     # `<nros/log.h>` expands to) ship only with `libnros_c.a`.
@@ -527,6 +558,10 @@ if(CONFIG_NROS_CPP_API)
         if(CONFIG_BOARD_NATIVE_SIM OR CONFIG_BOARD_NATIVE_POSIX)
             string(APPEND _nros_c_for_cpp_features ",std")
         endif()
+        # phase-8 W4 — callback tracing. MUST match the nros-cpp string above:
+        # both archives are linked into this image from one nros-node dep
+        # graph, and a feature that reaches only one of them splits the unit.
+        string(APPEND _nros_c_for_cpp_features "${_nros_trace_suffix}")
         nros_cargo_build(
             PACKAGE nros-c
             FEATURES "${_nros_c_for_cpp_features}${_nros_panic_suffix}"

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -168,6 +168,39 @@ config NROS_SNTP_TIMEOUT_MS
       reach a time source still runs, it just cannot stamp absolute time.
 
 # =============================================================================
+# Callback-level tracing (phase-8)
+# =============================================================================
+
+config NROS_TRACE_CALLBACKS
+    bool "Emit callback register / start / end trace events"
+    help
+      Turn on the `trace-callbacks` cargo feature, so the executor emits a
+      registration event per callback at init and a start/end pair around
+      every dispatch. With this off the hooks are not compiled: the feature
+      is absent from the cargo feature string, so the dispatch path is the
+      same code it is today rather than a branch that is never taken.
+
+      What it buys: a capture attributes time to EVERY registered callback,
+      including the ones nobody thought to instrument. Thread-level tracing
+      cannot do this — a callback does not run on a thread of its own, it
+      runs inside an executor wake as an ordinary function call, so the
+      tracer sees the carrier and not the payload.
+
+      Where the events GO is the consumer's business, not this symbol's.
+      The core calls an installed sink (`set_trace_sink`) whose signature is
+      a plain `extern "C" fn(uint32_t, uint32_t)`; nothing here presumes CTF.
+      On a Zephyr image that also sets CONFIG_TRACING_CTF, the sink that the
+      entry path installs (`nros_zephyr_trace_marker`, in
+      `nros_platform_zephyr_shims.c`) forwards to an out-of-tree `app_marker`
+      CTF event; without CONFIG_TRACING_CTF that shim is empty and the events
+      cost a call and a return. Enabling this alone therefore instruments the
+      executor but records nothing — pair it with a tracing backend.
+
+      Cost, stated honestly: two events per dispatch, none in steady state
+      for registration. The per-event cost has NOT been measured in isolation
+      on any target, so this is opt-in and defaults off.
+
+# =============================================================================
 # Cyclone DDS tuning
 # =============================================================================
 

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -159,6 +159,46 @@ void nros_zephyr_epoch_acquire_configured(void) {
 #endif
 }
 
+/* phase-8 W4 — callback-tracing sink for the Zephyr CTF backend.
+ *
+ * This is the C ABI the core's `set_trace_sink` takes:
+ * `unsafe extern "C" fn(u32, u32)`, chosen to BE this signature. The core
+ * calls whatever pointer is installed and knows nothing about Zephyr; the
+ * entry path installs this function; the dependency stays one-directional.
+ *
+ * WHY THE DECISION LIVES IN C, same reason as
+ * `nros_zephyr_epoch_acquire_configured` above. Two facts force it:
+ *
+ *  1. `sys_trace_app_marker` is an OUT-OF-TREE Zephyr patch carried by the
+ *     consumer, not by nano-ros (`patches/zephyr/0002-ctf-app-marker-event.patch`
+ *     in autoware-safety-island; absent from `zephyr/patches/` here). If any
+ *     nano-ros crate or TU named the symbol unconditionally, every Zephyr image
+ *     built WITHOUT that patch would fail to link. Naming it only inside this
+ *     `#ifdef`, in a TU the module already compiles, keeps an unpatched image
+ *     linking against an empty function.
+ *  2. The symbol exists only under `CONFIG_TRACING_CTF`, and Kconfig knobs
+ *     reach the Zephyr C lane and NOT the cargo one (issue 0460) — so no Rust
+ *     arm can hold this `#ifdef` without a build-script knob read.
+ *
+ * Declared `extern` at the call site rather than by including
+ * <zephyr/tracing/tracing.h>: the header's `sys_trace_*` set is macro-driven
+ * and an out-of-tree event is not in it, so the declaration has to be local
+ * either way, and keeping it inside the guard means the name appears in the
+ * TU only when the patch that defines it is present.
+ *
+ * `marker_id` / `arg` are the wire encoding agreed with the decoder
+ * (`scripts/parse-zephyr-ctf.py`); this shim is a pure forwarder and imposes
+ * no meaning on either field. */
+void nros_zephyr_trace_marker(uint32_t marker_id, uint32_t arg) {
+#ifdef CONFIG_TRACING_CTF
+    extern void sys_trace_app_marker(uint32_t, uint32_t);
+    sys_trace_app_marker(marker_id, arg);
+#else
+    (void)marker_id;
+    (void)arg;
+#endif
+}
+
 /* Phase 110.E.b — periodic timer for Sporadic-server budget refill.
  * Wraps `k_timer_*` (static inlines) plus a per-timer bridge struct
  * holding (callback, user_data) so the Rust side can pass an


### PR DESCRIPTION
## What this adds

An optional `trace-callbacks` feature that makes the **callback** the unit of observation instead of the thread.

Thread-level tracing cannot see a callback boundary. Callbacks run *inside* an executor wake as ordinary function calls, so a CTF capture shows the executor's cadence and cost but cannot say where any individual callback began or ended. This is the same problem tokio solves by instrumenting poll boundaries, Go by instrumenting the scheduler, and ros2_tracing by instrumenting the rclcpp executor (`callback_start` / `callback_end`). The pattern is unanimous: **instrument the multiplexer, not the payload** — the dispatcher is the only place that knows both identities.

## Shape

Follows `wake-latency-probe`, the existing precedent in this repo for a probe with hot-path hooks that must vanish in production.

- **`executor/callback_trace.rs`** — `AtomicPtr` sink, self-gated `#![cfg(feature = "trace-callbacks")]`. Core stays platform-agnostic: the sink is `unsafe extern "C" fn(u32, u32)`, a C ABI chosen so a C caller installs it directly. Core never names a platform.
- **Registration is exhaustive from day one**, through one new choke point `Executor::emplace_entry`, which all 25 `CallbackMeta` assignments route through. Emitted at assignment rather than slot-claim, because a slot is claimed before fallible work.
- **Leaf hooks are staged** — timer plus the C-FFI subscription path. The remaining leaves carry 20 `TODO(phase-8)` blocks so the gap is visible *in the source*, and the consumer's decoder reports them as `registered, not instrumented` rather than omitting them or showing zero. A partial hook set that looks like coverage is the failure this design exists to prevent, so it announces itself.

### Why the hooks are at the leaves

All three dispatch paths — the normal drain (`spin.rs`), the trigger-fail timer sweep, and the OS-priority worker — call the *same* `CallbackMeta::try_process` pointer with the same `arena_base + offset`, and all 19 such symbols are defined in `arena.rs`. Hooking the leaves therefore covers every path with no extra sites, counts an action server's three callbacks separately, counts a ring subscription's N messages as N, and emits nothing on the common `Ok(false)` "ran, fired nothing" return.

### The one cost, stated plainly

`CallbackMeta::try_process` gains a `u8` desc index so a leaf can identify itself — inside a leaf, only the arena *address* is otherwise in scope, and `arena_base` is not reachable there. Chosen over an offset→index map because such a map keys on absolute addresses recorded at registration, which go stale if the `Executor` is moved.

**The parameter is unconditional**, so a feature-disabled build is *not* byte-identical to before: it carries one constant register argument per dispatch that the leaf ignores. Everything else — hook bodies, register emit, name synthesis — compiles out. Making the signature `cfg`-dependent would mean macro-generating 21 leaf definitions, which trades a register move for a large amount of unreadable code.

### Platform binding stays one-directional

`sys_trace_app_marker` is an out-of-tree Zephyr patch carried by the *consumer*, not by nano-ros, so no crate here may name it. Both halves are unconditional symbols with gated bodies, so they link in every configuration and cost a stored null pointer when absent:

- `nros_zephyr_trace_marker()` — `#ifdef CONFIG_TRACING_CTF` body, mirroring `nros_zephyr_epoch_acquire_configured` (Kconfig reaches the C lane, not the cargo one).
- `nros_set_trace_sink()` — unconditional export from `nros-c`, feature-gated body. In `nros-c` rather than `nros-cpp` because it is linked in both the C-API and C++-only paths.

## Verification

| check | result |
|---|---|
| `cargo check -p nros-node --features rmw-cffi,std,alloc[,trace-callbacks]` | ok both ways |
| `cargo test -p nros-node --features rmw-cffi,std,alloc[,trace-callbacks]` | 142 + 5 pass, 0 fail, both ways |
| `cargo check -p nros-c` / `-p nros-cpp` with the feature | ok |
| `cargo check --target armv7r-none-eabihf` (no_std bare metal) | ok |
| `clippy -D warnings` | clean both ways |
| `just check-cbindgen-headers` / `check-feature-contract` / `check-source-manifest` | OK on this base |

**Runtime proof**, captured on a real autonomous driving mission on `fvp_baser_aemv8r`:

```
6 callbacks registered, 3756 dispatches paired
dropped: 1 unbalanced, 0 spanning a WFI counter jump, 0 out of order

callback                                kind            n   total ms   p50 ms    max ms
timer@30000us                           timer        2942  34656.437    1.137  1584.608
/planning/scenario_planning/trajectory  subscription   96    176.040    1.920     4.176
/localization/kinematic_state           subscription  238     20.647    0.088     0.090
/localization/acceleration              subscription  238     10.916    0.047     0.050
/vehicle/status/steering_status         subscription  237      1.365    0.006     0.008
/system/operation_mode/state            subscription    5      0.027    0.006     0.006
```

The cross-check is the part worth trusting: **2943** application-level cycle markers against **2942** timer dispatches. Two entirely independent instrumentation paths agreeing to a single event, which is the capture ending mid-dispatch.

## Known limitation, not closed

The slot index is unique within **one** `Executor`. An image running several tier executors emits colliding handles, and a decoder will silently merge two different callbacks into one row. Nothing detects this yet. Options for a follow-up: an executor id in the register payload, or a decoder warning when one handle is registered twice under different names.

## Notes for review

- Default off. `trace-callbacks = []` in `nros-node`, forwarded through `nros` / `nros-c` / `nros-cpp`.
- Reaches a Zephyr build through `CONFIG_NROS_TRACE_CALLBACKS`, read exactly once in `zephyr/CMakeLists.txt` and appended to every feature string — deliberately a suffix variable rather than three `if()` blocks, because both `libnros_c.a` and `libnros_cpp.a` come from one `nros-node` dep graph and a feature reaching only one of them is an ABI split.
- This repo does not use the `tracing` crate first-party (every hit is vendored Dust DDS), and this change does not introduce it. A no-op `tracing` subscriber would still cost span construction on every dispatch.
