### PR TITLE
feat(zephyr): task stacks in DTCM — 192 KiB of TCM was sitting at 0% while SRAM was exhausted

### DIFF
--- a/docs/issues/0880-tcm-unused-while-sram-exhausted.md
+++ b/docs/issues/0880-tcm-unused-while-sram-exhausted.md
@@ -1,0 +1,103 @@
+---
+id: 880
+title: "192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted —
+  the Zephyr images place nothing in ITCM or DTCM"
+status: open
+type: bug
+area: platform, embedded
+related: [issue-0852, issue-0810]
+---
+
+## Measurement
+
+The MR-CANHUBK344 action image, clean build, before this change:
+
+```
+RAM   323 528 / 327 680   98.73 %
+ITCM        0 /  65 536    0.00 %   @ 0x00000000
+DTCM        0 / 131 072    0.00 %   @ 0x20000000
+```
+
+The image could not be instrumented — adding a stack sentinel and a debug
+console pushed it past the ceiling and the node stopped completing entity
+creation — while **192 KiB of memory on the same die went unused.**
+
+Both regions are already declared. The devicetree gives them
+`zephyr,memory-region = "ITCM"` / `"DTCM"`, and Zephyr's generated linker
+script emits matching output sections:
+
+```
+ITCM (NOLOAD) : { KEEP(*(ITCM)) KEEP(*(ITCM.*)) } > ITCM
+DTCM (NOLOAD) : { KEEP(*(DTCM)) KEEP(*(DTCM.*)) } > DTCM
+```
+
+Nothing in nano-ros or in the images ever placed a symbol in either. Grepping
+the tree for a section attribute finds exactly one, and it is `.noinit`.
+
+## Where the SRAM goes
+
+Top consumers of the 323 KiB, from the ELF:
+
+| bytes | symbol | kind |
+| ---: | --- | --- |
+| 67 248 | `nros_platform::zephyr_heap::HEAP` | nano-ros heap |
+| 65 536 | `nros_rmw_zenoh…subscriber::LARGE_PAYLOADS` | static pool |
+| 49 152 | `nros_thread_stacks` | 6 x 8 KiB task stacks |
+| 32 852 | `kheap__system_heap` | Zephyr heap |
+| 26 568 | `nros_rmw_zenoh…service::SERVICE_BUFFERS` | static pool |
+| 16 384 | `z_main_stack` | executor thread |
+| 16 384 | `…subscriber::SMALL_PAYLOADS` | static pool |
+| 8 192 | `…static_subscriber_storage::SLOTS` | |
+| 8 192 | `malloc_arena` | **dead** — see below |
+
+Two things stand out beyond the TCM gap.
+
+**Three heaps, 108 KiB.** `HEAP` (67 KiB) + `kheap__system_heap` (33 KiB) +
+`malloc_arena` (8 KiB). This is the case the heap-unification campaign exists to
+make.
+
+**`malloc_arena` is dead weight, again.** The image contains no `malloc` and no
+`free` — nano-ros routes every allocation through `nros_platform_alloc` — yet
+the arena is reserved because `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` reserves
+its pool whether or not any caller survives the linker. Dead code is collected;
+dead *reservations* are not. This is the second time the same 8 KiB has been
+found on this board.
+
+## What landed here
+
+`CONFIG_NROS_ZEPHYR_STACKS_IN_DTCM` places the task stack array in DTCM using
+`Z_KERNEL_STACK_ARRAY_DEFINE_IN`. Off by default: a DTCM is a property of the
+part, not of Zephyr, and a SoC without the region should fail to link rather
+than silently place elsewhere.
+
+Stacks are the right first tenant. They are CPU-private, never the target of a
+DMA transfer, and TCM access does not contend with the system bus — so this is
+a latency improvement as well as an SRAM saving.
+
+Measured on the action image, with the libc arena also zeroed:
+
+| | SRAM | DTCM |
+| --- | ---: | ---: |
+| before | 98.73 % | 0 % |
+| after | **85.60 %** | 37.50 % |
+
+and the board boots, registers every entity and reaches its ready state with
+zero faults — which the 98.73 % image could not do.
+
+## Remaining opportunities, in order of size
+
+1. **`LARGE_PAYLOADS`, 64 KiB** → DTCM. 80 KiB of DTCM is still free. **Verify
+   first** whether this pool is ever a DMA target: on Cortex-M7 the TCMs hang
+   off the CPU's private bus and are typically unreachable from other bus
+   masters, so moving a buffer there would break an eDMA path. The serial link
+   is polled/ISR today, but issue 0852's fix direction includes DMA.
+2. **Heap unification, up to ~40 KiB.** Three heaps sized independently for
+   worst cases that do not co-occur.
+3. **`z_main_stack`, 16 KiB.** Zephyr owns the placement; needs a different
+   mechanism than the array above.
+4. **ITCM, 64 KiB, still entirely unused.** It does not relieve SRAM — code
+   lives in flash, which is at 8 % — but `CONFIG_CODE_DATA_RELOCATION` would put
+   hot paths in zero-wait-state memory. A determinism lever, not a capacity one.
+5. **The RX path allocates twice per frame** (`_Z_SERIAL_MAX_COBS_BUF_SIZE` +
+   `_Z_SERIAL_MFS_SIZE`) inside the receive loop. Static buffers would cut both
+   peak heap and an unbounded-latency call on the hot path.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-46 open. One line each — the detail lives in the issue file,
+47 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -103,6 +103,7 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
+- **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 
 <!-- END GENERATED open-issue list -->
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -96,6 +96,9 @@ endif()
 if(CONFIG_NROS_ZEPHYR_TASK_SLOTS)
     zephyr_compile_definitions(NROS_ZEPHYR_MAX_THREADS=${CONFIG_NROS_ZEPHYR_TASK_SLOTS})
 endif()
+if(CONFIG_NROS_ZEPHYR_STACKS_IN_DTCM)
+    zephyr_compile_definitions(NROS_ZEPHYR_STACKS_IN_DTCM=1)
+endif()
 zephyr_include_directories(${NROS_REPO_DIR}/packages/platform/nros-platform-api/include)
 zephyr_library_sources(
     ${NROS_REPO_DIR}/packages/platform/nros-platform-zephyr/src/platform.c

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -269,6 +269,29 @@ config NROS_ZEPHYR_TASK_STACK_SIZE
       0 keeps upstream behaviour. Set it to size the zenoh tasks for their own
       deepest call chain, which is the expiry teardown, independently of main.
 
+config NROS_ZEPHYR_STACKS_IN_DTCM
+    bool "Place nano-ros task stacks in DTCM"
+    default n
+    help
+      Put the nano-ros task stack array in the SoC's data tightly-coupled
+      memory instead of SRAM, using the linker region the devicetree's
+      `zephyr,memory-region = "DTCM"` generates.
+
+      Off by default because a DTCM is a property of the part, not of Zephyr:
+      a SoC without one, or one whose DTCM another component already claims,
+      must keep the default placement. Enabling it on a board with no DTCM
+      region is a link error, which is the right failure.
+
+      Stacks are the ideal tenant. They are CPU-private, never the target of a
+      DMA transfer, and TCM access does not contend with the system bus — so
+      this is a latency improvement as well as an SRAM saving. On the
+      MR-CANHUBK344 the array is 48 KiB against 128 KiB of DTCM that was
+      reporting 0 %% while SRAM sat at 98.7 %%.
+
+      Do NOT extend this to buffers a DMA engine touches without checking
+      whether this part's TCM is reachable from the relevant bus master. On
+      Cortex-M7 the TCMs hang off the CPU's private bus and typically are not.
+
 config NROS_ZEPHYR_TASK_SLOTS
     int "nano-ros Zephyr task stack slots"
     default 4

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -342,7 +342,29 @@ ssize_t nros_zephyr_sendto(int fd, const void* buf, size_t len, int flags,
 #define NROS_ZEPHYR_STACK_SIZE CONFIG_MAIN_STACK_SIZE
 #endif
 
+/* Transport/task stacks live in DTCM, not SRAM.
+ *
+ * The MR-CANHUBK344 has 128 KiB of DTCM and 64 KiB of ITCM that this image was
+ * not using at all -- both reported 0 %% while SRAM sat at 98.7 %% and the
+ * action image could no longer be instrumented for want of a few KiB. Stacks
+ * are the ideal tenant: CPU-private, never a DMA target, and TCM access does
+ * not contend with the system bus, so putting them here is a latency
+ * improvement as well as an SRAM saving.
+ *
+ * `NROS_ZEPHYR_STACKS_IN_DTCM` gates it because the region is a property of
+ * the SoC, not of Zephyr: a part without a DTCM (or one whose DTCM another
+ * component already claims) must keep the default placement. The section name
+ * comes from the devicetree `zephyr,memory-region = "DTCM"`, which is what
+ * generates the linker region.
+ *
+ * DTCM is NOLOAD, which is correct for stacks -- they are uninitialised. */
+#if defined(NROS_ZEPHYR_STACKS_IN_DTCM) && NROS_ZEPHYR_STACKS_IN_DTCM
+Z_KERNEL_STACK_ARRAY_DEFINE_IN(nros_thread_stacks, NROS_ZEPHYR_MAX_THREADS,
+                               NROS_ZEPHYR_STACK_SIZE,
+                               __attribute__((section("DTCM"))));
+#else
 K_THREAD_STACK_ARRAY_DEFINE(nros_thread_stacks, NROS_ZEPHYR_MAX_THREADS, NROS_ZEPHYR_STACK_SIZE);
+#endif
 
 /* Stack slots are CLAIMED and RELEASED. The counter this replaces
  * (`static int nros_thread_index`, used as `nros_thread_stacks[idx++]`) only


### PR DESCRIPTION
Closes #0880.

## The gap

The MR-CANHUBK344 action image, clean build:

```
RAM   323 528 / 327 680   98.73 %
ITCM        0 /  65 536    0.00 %
DTCM        0 / 131 072    0.00 %
```

The image could not be **instrumented** — adding a stack sentinel and a console
pushed it past the ceiling and the node stopped completing entity creation —
while 192 KiB on the same die went unused.

Both regions were already declared. The devicetree gives them
`zephyr,memory-region`, and Zephyr's generated linker script emits matching
`NOLOAD` output sections. Nothing in this tree ever placed a symbol in either;
grepping the platform layer for a section attribute finds exactly one, and it is
a `.noinit`.

## The change

`CONFIG_NROS_ZEPHYR_STACKS_IN_DTCM` places the task stack array in DTCM via
`Z_KERNEL_STACK_ARRAY_DEFINE_IN`.

**Off by default.** A DTCM is a property of the part, not of Zephyr: a SoC
without the region should fail to link rather than silently place the stacks
somewhere else.

Stacks are the right first tenant — CPU-private, never the target of a DMA
transfer, and TCM access does not contend with the system bus, so this buys
latency as well as capacity.

## Measured

On the action image, with the dead libc arena also zeroed (the image contains no
`malloc` and no `free`; the arena is reserved regardless of whether any caller
survives the linker — the second time that same 8 KiB has been found on this
board):

| | SRAM | DTCM |
| --- | ---: | ---: |
| before | 98.73 % | 0 % |
| after | **85.60 %** | 37.50 % |

The board boots, registers every entity and reaches its ready state with **zero
faults** — which the 98.73 % image could not do.

## What the issue also records

A full symbol inventory of where the 323 KiB went, and the ranked remainder:

- `LARGE_PAYLOADS`, 64 KiB, → DTCM (80 KiB still free). **Verify DMA
  reachability first**: on Cortex-M7 the TCMs hang off the CPU's private bus and
  are typically invisible to other bus masters, so moving a buffer there would
  break an eDMA path — and #0852's fix direction includes DMA.
- Three separate heaps totalling 108 KiB (`HEAP` 67 KiB + `kheap__system_heap`
  33 KiB + `malloc_arena` 8 KiB).
- `z_main_stack`, 16 KiB — Zephyr owns that placement, needs a different lever.
- ITCM, 64 KiB, still entirely unused. Does not relieve SRAM (code is in flash,
  at 8 %) but `CONFIG_CODE_DATA_RELOCATION` would put hot paths in zero-wait
  memory. A determinism lever, not a capacity one.
- The serial RX path allocates **twice per frame** inside the receive loop.

No behaviour change when the option is off, which is the default.