### PR TITLE
fix(#0889): wire Cyclone data_available to the executor wake

### DIFF
--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
@@ -155,6 +155,13 @@ rmw_ret_t session_create(const char *locator, uint8_t mode,
                             const rmw_session_options_t *options,
                             rmw_session_t *out);
 rmw_ret_t session_destroy(rmw_session_t *session);
+
+/* Phase 124.B.1 / issue 0889 — install the executor's wake callback. Cyclone
+ * fires it from its delivery thread via a participant-level data_available
+ * listener, which is what lets `spin_once` block on its wake primitive instead
+ * of polling on a timer. `cb == nullptr` clears. */
+rmw_ret_t session_set_wake_callback(rmw_session_t *session, void (*cb)(void *),
+                                    void *ctx);
 rmw_ret_t session_drive_io(rmw_session_t *session, int32_t timeout_ms);
 
 /* ---- publisher.cpp ---- */

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/session.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/session.cpp
@@ -47,6 +47,12 @@ struct SessionState {
     dds_entity_t domain{0};
     dds_entity_t participant{0};
     GraphState graph{};  // Phase 177.36 — ros_discovery_info publisher state
+    /* Phase 124.B.1 wake path (issue 0889). Written by
+     * `session_set_wake_callback` on the runtime thread, read by
+     * `on_data_available` on a Cyclone worker thread. */
+    void (*wake_cb)(void *){nullptr};
+    void *wake_ctx{nullptr};
+    dds_listener_t *listener{nullptr};
 };
 
 inline SessionState* as_state(rmw_session_t* s) {
@@ -162,6 +168,89 @@ constexpr const char* kEmbeddedCycloneConfig =
 
 } // namespace
 
+namespace {
+
+/// Cyclone calls this from its own receive/delivery thread the moment a reader
+/// has data. Handing that to the executor is the WHOLE point: without it
+/// `spin_once` has no asynchronous wake and its wait degenerates to a blind
+/// sleep, so the runtime polls on a timer and mostly misses (measured on the
+/// an536 lane: 5,069 takes per reader for 42 deliveries, a 0.8% hit rate).
+///
+/// Safe to call from a foreign thread by contract: the runtime callback does a
+/// flag write plus a condvar signal and nothing else. That is what separates
+/// this from the STATUS-event listeners `subscriber.cpp` deliberately declines
+/// — those would need a buffer, a lock, and a safe context to deliver into.
+void on_data_available(dds_entity_t /*reader*/, void *arg) {
+    auto *state = static_cast<SessionState *>(arg);
+    if (state == nullptr) {
+        return;
+    }
+    /* Read once: a concurrent clear could otherwise null it between the test
+     * and the call. */
+    void (*cb)(void *) = state->wake_cb;
+    void *ctx = state->wake_ctx;
+    if (cb != nullptr) {
+        cb(ctx);
+    }
+}
+
+} // namespace
+
+rmw_ret_t session_set_wake_callback(rmw_session_t* session,
+                                    void (*cb)(void*),
+                                    void* ctx) {
+    if (session == nullptr || session->backend_data == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    auto* state = as_state(session);
+
+    if (cb == nullptr) {
+        /* Detach FIRST, then drop the stored pair: after `dds_set_listener`
+         * returns with no data_available handler, Cyclone will not call us
+         * again, so nothing can observe the half-cleared state. */
+        if (state->listener != nullptr) {
+            (void)dds_set_listener(state->participant, nullptr);
+            dds_delete_listener(state->listener);
+            state->listener = nullptr;
+        }
+        state->wake_cb = nullptr;
+        state->wake_ctx = nullptr;
+        return NROS_RMW_RET_OK;
+    }
+
+    /* Publish the pair BEFORE the listener exists, so the first callback
+     * cannot see a null cb. */
+    state->wake_ctx = ctx;
+    state->wake_cb = cb;
+
+    if (state->listener == nullptr) {
+        state->listener = dds_create_listener(state);
+        if (state->listener == nullptr) {
+            state->wake_cb = nullptr;
+            state->wake_ctx = nullptr;
+            return NROS_RMW_RET_ERROR;
+        }
+        /* On the PARTICIPANT, not per reader: DDS propagates an unhandled
+         * event up to the parent, so one listener covers every reader this
+         * session will ever create, including ones created later. Readers set
+         * no data_available handler of their own (subscriber.cpp polls), so
+         * nothing is being overridden.
+         *
+         * reset_on_invoke = false: this is a level signal, not a one-shot. The
+         * executor may still be draining an earlier batch when the next one
+         * lands, and it must be woken again. */
+        dds_lset_data_available_arg(state->listener, on_data_available, state, false);
+        if (dds_set_listener(state->participant, state->listener) < 0) {
+            dds_delete_listener(state->listener);
+            state->listener = nullptr;
+            state->wake_cb = nullptr;
+            state->wake_ctx = nullptr;
+            return NROS_RMW_RET_ERROR;
+        }
+    }
+    return NROS_RMW_RET_OK;
+}
+
 rmw_ret_t session_create(const char* /*locator*/, uint8_t /*mode*/, uint32_t domain_id,
                             const char* node_name, const rmw_session_options_t* options,
                             rmw_session_t* out) {
@@ -264,6 +353,12 @@ GraphState* session_graph(rmw_session_t* session) {
 }
 
 rmw_ret_t session_destroy(rmw_session_t* session) {
+    /* Drop the wake path before anything it points at goes away — the ctx
+     * belongs to the executor, and Cyclone must stop calling us first. */
+    if (session != nullptr && session->backend_data != nullptr) {
+        (void)session_set_wake_callback(session, nullptr, nullptr);
+    }
+
     if (session == nullptr) {
         return NROS_RMW_RET_INVALID_ARGUMENT;
     }

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
@@ -245,7 +245,7 @@ const nros_rmw_vtable_t kVtable = {
      * callback into those listeners is a follow-up (lives in the
      * listener-installation path, not this static vtable). nullptr
      * today; runtime drains on deadline-bound cv-wait boundary. */
-    /*set_wake_callback*/         nullptr,
+    /*set_wake_callback*/         session_set_wake_callback,
 
     /* Phase 124.A — zero-copy ABI. Cyclone DDS supports loan via
      * dds_loan_sample / dds_return_loan; wire-up is a follow-up


### PR DESCRIPTION
fix(#0889): wire Cyclone's data_available to the executor wake

The Cyclone RMW left `set_wake_callback` NULL, so `Executor::has_async_wake`
stayed false, `spin_once` never used its wake primitive, and the runtime polled
every reader on a timer. Measured on the an536 lane before this change: 5,069
takes per reader for 42 deliveries — 0.8% of takes found data. The executor's
own comment already names what poll-only costs elsewhere: "a no-op sleep that
starves reliable retransmission" (phase-127.C.4).

Implementation. A participant-level `data_available` listener, installed when
the runtime hands over its callback and torn down in `session_destroy` before
the ctx it points at can go away. On the participant rather than per reader
because DDS propagates an unhandled event to the parent, so one listener covers
every reader the session will ever create, including later ones.

This is the one listener shape that is safe here, and the distinction matters
because `subscriber.cpp` deliberately declines listeners for STATUS events:
those would need a buffer, a lock and a delivery context. The wake callback
needs none — the runtime side writes a flag and signals a condvar, which is
exactly what the contract says a backend may call from its transport thread.

Verification, and the honest limits of it. `reset_on_invoke = false` is the flag
that keeps listener invocation from consuming the communication status this
backend's `take`/`has_data` path polls; that was the concrete risk, and it is
the thing that needed proving rather than asserting. Two runs of the ASI an536
lane with this change: the island receives its inputs in both (acceleration
after 6 and 5 waits), with a trajectory in one — the same spread the unpatched
lane shows. So the polling path still sees data with the listener attached.

What this does NOT do is fix issue 0836; the trajectory remains intermittent
and is a separate problem.

Two rigs were tried first and are worth recording, because both look like they
should work and neither does: the in-tree native Cyclone talker/listener test
needs seven provisioned build sources in a fresh worktree, and the ASI
freertos-posix island segfaults on this host UNPATCHED, so it cannot be a
control. That left repeated runs on a lane whose variance is documented in
0836, which is why the claim above is "delivery is not broken" and not a
hit-rate number.

Issue text lands in #44, which files 0888 and 0889 together; merge that first
and this flips 0889 to resolved.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
