### PR TITLE
feat(zephyr): post-mortem fault log — and action goals now complete

### DIFF
--- a/docs/issues/0910-zenoh-pico-1-10-migration.md
+++ b/docs/issues/0910-zenoh-pico-1-10-migration.md
@@ -1,0 +1,86 @@
+---
+id: 910
+title: "migrating to zenoh-pico 1.10: the serial layer moved, `config.h` is no
+  longer shipped, and our config generator is 54 knobs behind"
+status: open
+type: task
+area: rmw, build
+related: [issue-0852, issue-0882]
+---
+
+## Why
+
+Our pin is 1863 upstream commits behind. The gap matters for serial specifically:
+upstream **restructured the link transports** and now ships its own Zephyr UART
+backend, so most of our Zephyr serial code has an upstream equivalent that did
+not exist when we wrote it.
+
+## What upstream changed
+
+| | our pin (`dac320e3`) | upstream 1.10 |
+| --- | --- | --- |
+| Zephyr serial | ours, in `src/system/zephyr/network.c` | theirs, `src/link/transport/serial/uart_zephyr.c` |
+| serial protocol | `src/system/common/serial.c` (ours) | `src/link/transport/upper/serial_protocol.c` |
+| lwIP / sockets | `src/system/freertos/lwip` | `src/link/transport/**`, `src/system/socket` |
+| `include/zenoh-pico/config.h` | checked in | **generated** from `config.h.in` by their CMake |
+| system ABI (`_z_mutex_*`, `_z_task_*`) | `src/system/zephyr/` | unchanged — nano-ros's shims still fit |
+
+The last row is the good news: `src/system/zephyr/system.c` still exists, so
+`nros_zenoh_zephyr_system.c` continues to override the symbols it always did.
+
+## Progress so far
+
+Two branches on the fork (`jerry73204/zenoh-pico`), both off `upstream/main`:
+
+- **`serial-fixes`** — one commit, for the upstream PR. Fixes
+  `_z_zephyr_uart_read`, which busy-spins on `uart_poll_in` with no timeout, no
+  yield and no `uart_err_check`, and returns `len` regardless. All three are
+  defects we hit and fixed on our own port; the third is
+  [issue 0852](0852-*), where a silent overrun cost a long investigation that
+  ended in a bug report against an innocent peer.
+- **`nros-integration`** — `serial-fixes` plus a passthrough
+  `include/zenoh-pico/config.h`, which upstream no longer ships. Not for
+  upstream. A passthrough suffices because every platform in
+  `config/*/nros-platform.toml` defines `ZENOH_GENERIC`; the 48 `@TOKEN@`
+  substitutions are all in the dead `#else` branch, which is now an `#error` so
+  a platform that forgets the define fails loudly.
+
+Build progress against `nros-integration`, each item found by building and
+fixed in turn:
+
+1. `nros-platform.toml` named `system/freertos/lwip`, which no longer exists →
+   `system/freertos`. (Reverted for now; correct only against the new pin.)
+2. `zenoh-pico/config.h` missing → the passthrough above.
+3. **Current blocker**, below.
+
+## Current blocker — the config generator is 54 knobs behind
+
+`nros-zpico-build`'s `config_header()` emits 49 of the 95 `Z_*` knobs upstream's
+template defines. The build stops on the first missing ones:
+`Z_CONFIG_SESSION_ZID_KEY`, `Z_GET_TIMEOUT_DEFAULT`, `Z_RUNTIME_MAX_TASKS`,
+`Z_ZID_LENGTH`.
+
+Of the 54 missing: **27 are `*_KEY`** (fixed protocol strings, not tunables),
+**12 are `*_DEFAULT`**, and the rest are numeric knobs whose values are the 54
+`set(Z_… CACHE STRING …)` lines in upstream's `CMakeLists.txt`.
+
+**Do not transcribe them by hand.** That is what leaves us 54 behind again at
+the next bump. `config_header()` should emit only the knobs nano-ros actually
+*tunes* — buffer sizes, lease, feature flags — and derive the rest from
+upstream's `CMakeLists.txt` defaults at build time. Then a bump costs nothing.
+
+## Also outstanding
+
+- One TU compiles without `ZENOH_GENERIC` and trips the new `#error`. Which one
+  is not yet identified; the `#error` exists so it cannot be missed.
+- Once it builds, our Zephyr serial code in `src/system/zephyr/network.c`
+  should be **deleted** in favour of upstream's `uart_zephyr.c` plus the
+  `serial-fixes` commit. That is the point of the migration.
+- The INIT-retry scoping (fork commit `67ee0224`) is **not** needed upstream:
+  upstream's `_z_connect_serial` never retries, so it never had the flood. That
+  commit fixed a regression of ours and should not be carried forward.
+
+## State
+
+The submodule pin is back on `dac320e3` and the board builds. Nothing here is
+half-applied; the migration lives on the two fork branches.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -67,5 +67,7 @@ fails if this block drifts.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
 - **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
 - **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
+- **#0903** (rmw) — `get_topic_names_and_types` returns EMPTY against a live rmw_zenoh_cpp node, while `get_node_names` on the same session returns the node See `0903-*`.
+- **#0910** (rmw, build) — migrating to zenoh-pico 1.10: the serial layer moved, `config.h` is no longer shipped, and our config generator is 54 knobs behind See `0910-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -62,12 +62,11 @@ fails if this block drifts.
 - **#0899** (rmw, boards) — The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer — two different asserts, both after tens of successful publishes See `0899-*`.
 - **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
 - **#0902** (rmw) — action goals complete between 20 % and 90 % of the time on the same build, with no session expiry and no fault to explain the difference See `0902-*`.
+- **#0910** (rmw, build) — migrating to zenoh-pico 1.10: the serial layer moved, `config.h` is no longer shipped, and our config generator is 54 knobs behind See `0910-*`.
 - **#0913** (testing, embedded) — attaching pyocd RTT kills the zenoh session — the debugger perturbs the system under test, and issue 0879 makes the perturbation permanent See `0913-*`.
 - **#0914** (testing) — Nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot evaluate anything passes every check See `0914-*`.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
 - **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
 - **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
-- **#0903** (rmw) — `get_topic_names_and_types` returns EMPTY against a live rmw_zenoh_cpp node, while `get_node_names` on the same session returns the node See `0903-*`.
-- **#0910** (rmw, build) — migrating to zenoh-pico 1.10: the serial layer moved, `config.h` is no longer shipped, and our config generator is 54 knobs behind See `0910-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
Implements phase-392 amendment D. Files #0881.

## The measurement that motivated it

Same image, same router, same board. Only the probe varies:

```
no probe attached      ros2 action list -> /fibonacci   (twice)
pyocd rtt attached     ros2 action list -> empty        (twice)
probe detached again   ros2 action list -> empty        (twice)
router restarted       ros2 action list -> /fibonacci
```

pyocd reads target memory by halting the core. On a link whose liveness is a
keepalive against `Z_TRANSPORT_LEASE`, that means missed keepalives and an
expired session — and #0879 turns the transient stall into a permanent one.

**A fault visible only under a probe is a fault the probe helped cause.**

## The consequence, which is the headline

With the probe detached, and the image at 92 % SRAM after the DTCM relocation
(#0880 / PR #42), **action goals complete**:

```
Goal accepted with ID: d61436d4548c4377ba43e6e701ac8219
Result: sequence: [0, 1, 1, 2, 3]
Goal finished with status: SUCCEEDED
```

**6 of 7** across a soak. This was 0 of 5 for the entire campaign.

So the crash filed as #0852's root cause — `_z_network_message_elem_copy`,
"Illegal load of EXC_RETURN into PC" — was captured with RTT attached on a
98.7 % SRAM image, and does not reproduce with either condition removed. It was
at least partly **induced by the conditions of its own observation**. #0852's
surviving claim is the polled-versus-ISR A/B, which never depended on RTT.

## What this adds

`CONFIG_NROS_FAULT_LOG` overrides `k_sys_fatal_error_handler` to capture reason,
PC/LR/PSR and the thread **name** into `.noinit`, and reports it at the next
boot. `CONFIG_NROS_FAULT_LOG_FLASH` adds a durable copy in the storage
partition.

Two stages deliberately: the handler runs with interrupts off on a stack that
may be the damaged one, so it does a few stores and nothing that can fail; the
flash write happens at the next boot from thread context. `.noinit` survives the
reset a fault produces — the case this is for — and flash adds a power cycle at
**zero SRAM cost**, on a part using 8.8 % of 4 MiB.

Silent on a clean boot: a message every start would train the reader to ignore
the block.

## Honest status

Verified **linked** — our strong `k_sys_fatal_error_handler` overrides the
kernel's weak one, `SYS_INIT` present, record in `.noinit`. The **firing path is
not yet proven on hardware**, because no fault has occurred since it was
enabled. That is the good news above, but it does mean this ships unexercised.

Both options default off.