### PR TITLE
docs(#0889): resolve — the wake callback landed in bd522b841

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,7 +53,7 @@ Issues cross-link to the RFCs and phases that inform or resolve them via the
 
 <!-- BEGIN GENERATED open-issue list — scripts/gen-issue-index.py -->
 
-48 open. One line each — the detail lives in the issue file,
+47 open. One line each — the detail lives in the issue file,
 which already has it. Regenerate with `scripts/gen-issue-index.py`;
 `check-issue-index` fails if this block drifts.
 
@@ -104,7 +104,6 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
-- **#0889** (rmw) — The Cyclone RMW installs no wake callback, so the executor polls on a timer and mostly misses See `0889-*`.
 
 <!-- END GENERATED open-issue list -->
 
@@ -259,15 +258,13 @@ callback PARAMETERS (`cb`, `chunk_cb`, `size_cb`) that share the `(*name)(` shap
 rejects those by paren depth, which matters because counting one shifts every later slot NUMBER.
 See `archived/0826-*`. (2026-08-27)
 
-**#0889** (rmw, open 2026-08-29) - the Cyclone RMW leaves `set_wake_callback` NULL, so
-`has_async_wake` is false, `spin_once` never uses its wake primitive, and the executor polls every reader on
-a timer. Measured on the an536 lane: 5,069 takes per reader for 42 deliveries - **0.8% of takes find data**.
-The executor's own comment already names the cost for poll-only backends ("a no-op sleep that starves
-reliable retransmission", phase-127.C.4). A participant-level `data_available` listener is implemented and
-builds, but is NOT landed: one run showed zero deliveries and so did a run with it reverted, because the
-lane's variance swamps the signal - and listener invocation consumes the communication status this backend
-polls, which `reset_on_invoke=false` is meant to prevent and nobody has confirmed. Needs a repeatable rig.
-See `0889-*`. (2026-08-29)
+Recently resolved (2026-08-29): **#0889** (rmw) — the Cyclone RMW left
+`set_wake_callback` NULL, so `Executor::has_async_wake` stayed false, `spin_once` never used its wake
+primitive, and the runtime polled every reader on a timer: 5,069 takes per reader for 42 deliveries on the
+an536 lane, a 0.8% hit rate. Fixed with a participant-level `data_available` listener — safe from
+Cyclone's thread because the runtime callback only writes a flag and signals a condvar. Verified as
+non-breaking (delivery unchanged across two an536 runs) rather than by a hit-rate number; the rig that
+would produce one is still missing. See `archived/0889-*`.
 
 **#0835** (testing, open 2026-08-27) — the cmake and rust fixture families RE-STALE EACH OTHER, so
 `check-fixtures-stale` never reaches a fixed point: three consecutive runs on a tree with a green `lane=all`

--- a/docs/issues/archived/0889-cyclone-executor-busy-polls.md
+++ b/docs/issues/archived/0889-cyclone-executor-busy-polls.md
@@ -2,7 +2,7 @@
 id: 889
 title: "The Cyclone RMW installs no wake callback, so the executor polls on a
   timer and mostly misses"
-status: open
+status: resolved
 type: bug
 area: rmw
 related: [issue-0836, issue-0780, phase-385]
@@ -66,21 +66,34 @@ Implemented and building:
   is torn down from `session_destroy` before the ctx can go away
 * the vtable slot points at it
 
-**It is not landed because it could not be verified.** One run with it showed
-zero deliveries — but so did a run with the change reverted. The an536 lane's
-run-to-run variance is large enough to swamp the signal (documented in 0836:
-3,200 frames in one run against 84,524 in another of the same length), so
-neither run proves anything about the patch.
+**Landed** in `bd522b841`, as a participant-level `data_available` listener:
+one listener covers every reader the session creates, because DDS propagates an
+unhandled event to the parent. Installed when the runtime hands over its
+callback, torn down in `session_destroy` before the ctx it points at can go
+away.
 
-There is also a real mechanism for harm that a stable rig must rule out:
-invoking a listener consumes the communication status, and this backend's
-`take`/`has_data` path polls that status. `reset_on_invoke = false` is meant to
-prevent exactly that, and needs to be confirmed rather than assumed.
+The listener is safe here for a reason worth stating, because `subscriber.cpp`
+deliberately declines listeners for STATUS events: those would need a buffer, a
+lock, and a delivery context. A wake callback needs none — the runtime side
+writes a flag and signals a condvar, which is exactly what the contract permits
+a backend to do from its transport thread.
 
-## What would settle it
+## What was verified, and what was not
 
-A rig where delivery is repeatable — a native or QEMU lane with a fixed
-publisher, not the full Autoware stack — running the poll/delivery counters
-above with and without the listener. If the hit rate rises and delivery is
-unchanged, land it; if `has_data` goes quiet, the status-consumption concern is
-real and the wake path needs a waitset on its own thread instead.
+The concrete risk was that invoking a listener consumes the communication
+status this backend's `take`/`has_data` path polls — `reset_on_invoke = false`
+is meant to prevent that, and asserting it was not enough. Two runs of the ASI
+an536 lane with the change: the island receives its inputs in both
+(acceleration after 6 and 5 waits), with a trajectory in one — the same spread
+the unpatched lane shows. So the polling path still sees data with the listener
+attached, and the status-consumption failure mode did not happen.
+
+What is NOT measured is the hit rate this issue opened on. The rig that would
+settle it — a fixed publisher, poll/delivery counters with and without the
+listener — was attempted twice and neither attempt held: the in-tree native
+Cyclone talker/listener test needs seven provisioned build sources in a fresh
+worktree, and the ASI freertos-posix island segfaults on this host UNPATCHED,
+so it cannot serve as a control. The claim here is therefore "delivery is not
+broken by the listener", not a number.
+
+This does not fix 0836: the trajectory remains intermittent on that lane.


### PR DESCRIPTION
0889 was filed and fixed on the same day but in two PRs (#44 filed it, #46 fixed it), and the merge queue took them in that order — so `main` carries the fix while the issue file still says `status: open` and describes the change as unlanded. This closes that gap.

**What changed**
- `0889-*.md` → `status: resolved`, moved to `docs/issues/archived/`.
- The "It is not landed because it could not be verified" section is replaced with what the landed change actually is (a participant-level `data_available` listener, `bd522b841`) and, separately, what was and was not verified.
- The README row converts to the "Recently resolved" spelling; index regenerated.

**On the verification claim.** The concrete risk was that listener invocation consumes the communication status this backend's `take`/`has_data` path polls — `reset_on_invoke = false` is meant to prevent that, and asserting it was not enough. Two ASI an536 runs with the change show the island still receiving its inputs (acceleration after 6 and 5 waits, trajectory in one), the same spread the unpatched lane shows. That rules the failure mode out; it is **not** a hit-rate measurement, and the issue now says so rather than implying the 0.8% number was re-measured. Both rigs that would produce one fell over for reasons unrelated to the patch, and that is recorded too.

Does not fix #0836.

**Note, unrelated to this PR:** `check-workspace-order` fails on clean `origin/main` in my worktree (panic at `nros-cli-core/src/lib.rs:85:20`), taking two dependent gates with it — 3 of 135. Verified pre-existing by stashing this change. This PR is docs-only.

Build/test: `just check-fast` — 132/135 pass, the 3 failures are the pre-existing ones above. `just check-issue-index` OK (47 open rows = 47 files).
