### PR TITLE
docs(phase-394): timing is testable after all, and take the flow-control work

### DIFF
--- a/docs/roadmap/phase-394-can-unicast-for-zenoh-pico.md
+++ b/docs/roadmap/phase-394-can-unicast-for-zenoh-pico.md
@@ -391,6 +391,17 @@ MIT, vendored to `zenoh-pico/third_party/isotp-c/` with provenance and the
 licence verbatim in `VENDOR.md`. Only the six library files are taken; upstream's
 build system, tests and submodules are not.
 
+The copy now comes from `jerry73204/isotp-c`, one commit above that pin, adding
+an `ISO_TP_NO_FORMATTED_ERRORS` flag that drops the library's only use of
+`snprintf` -- two formatted diagnostics, each writing into a 128-byte stack
+buffer, which between them made a full `snprintf` a hard requirement of the
+whole library on the targets it exists for. Off by default. On Cortex-M4 at
+`-Os -DNDEBUG -ffreestanding` it takes `.text` from 2235 to 2091 bytes and the
+largest stack frame from 160 to 32, after which the object needs nothing from
+libc but `memcpy` and `memset`. The fork is staging, not a destination:
+[SimonCahill/isotp-c#75](https://github.com/SimonCahill/isotp-c/pull/75) is
+open to retire it.
+
 `scripts/can/isotp-c-mcu-check.sh` builds it for a bare-metal Cortex-M4 and
 fails if an allocator appears. It does not: the caller supplies both buffers to
 `isotp_init_link`. What it does need from outside is the three hooks plus
@@ -640,26 +651,68 @@ seconds, and the checksum in `nros-sdk-index.toml` verifies it either way.
   ROS topic traffic over ISO-TP on a shared `vcan0`
   (`scripts/test/isotp-zephyr-tier2.sh`).
 
+### Also proven, after a correction
+
+The earlier draft of this section said flatly that **nothing** about timing was
+testable without hardware. That was too broad, and measuring it showed why.
+
+`STmin` and `BS` live in the kernel's ISO-TP state machine, driven by hrtimers
+rather than by the CAN controller, so they behave identically on `vcan` and on
+a wire. A probe settled it: at `stmin=0` the ConsecutiveFrames came out 0.06 ms
+apart, at `stmin=5ms` they came out 5.07 ms apart, and `bs=4` turned one
+FlowControl into eleven.
+
+So the ISO-TP link now takes `stmin` and `bs` as endpoint parameters, and
+`transport_unicast_isotp_flow_control_reaches_the_wire` asserts they arrive:
+1024 bytes at `stmin=1ms` is about 147 ConsecutiveFrames and cannot complete
+sooner than roughly 147 ms, against 12 ms unpaced. Removing the parameters
+fails the test, so it is measuring the pacing and not merely the transfer.
+
+These are the only two knobs ISO 15765-2 gives a receiver, and they are what a
+small peer has to defend itself with against a Linux box that would otherwise
+send 4 KiB as fast as its controller will take it.
+
+**Several pairs on one bus** is proven too, for correctness:
+`transport_unicast_isotp_two_pairs_share_a_bus` runs two independent identifier
+pairs concurrently and asserts exact per-pair message counts, so a socket
+accepting the other pair's frames fails it. Pointing both pairs at the same
+identifiers does fail it, with `pair 0 received 35 messages, expected exactly
+20`.
+
 ### Not proven
 
-* **Anything about timing.** See §5. `vcan` has no bit rate; Zephyr's own suite
-  skips `stmin`. No latency, bandwidth or arbitration claim in this phase is
-  supported by evidence.
-* **More than one peer per bus.** ISO-TP addresses a peer by a directed
-  identifier pair; nothing here tests several pairs sharing one physical bus,
-  where arbitration and bus load start to matter.
-* **Anything upstream.** No issue filed, no PR opened, ECA and `Signed-off-by`
-  outstanding.
+* **The bus itself.** Bit rate, propagation delay, and above all
+  **arbitration**. `vcan` queues frames rather than contending for them, so
+  every ordering observed on it is a scheduling artefact. The priority-major
+  identifier layout is the CAN link's central design claim and it has never
+  been seen winning a collision. `scripts/can/arbitration-check.sh` is the
+  experiment, written and refusing to run on a virtual interface; it needs a
+  real bus.
+* **Contention between peers.** Two pairs transfer correctly side by side, but
+  nothing yet measures what happens when they compete for the wire under load.
 
 ### Next, in the order that retires the most risk
 
-1. **Tier 3 hardware.** MR-CANHUBK344 to a Linux host, on a real bit rate. This
-   is the only item that closes the one open risk, and everything else is
-   waiting behind an assumption it would test.
-2. **Several peers on one bus.** Two identifier pairs first, then contention.
-3. **Upstream.** An issue on `eclipse-zenoh/zenoh` describing the multicast
-   query limitation, and PRs for the two link crates. The branches are pushed;
-   the ECA and sign-off are the author's to give.
+1. **Tier 3 hardware.** MR-CANHUBK344 to a Linux host at a real bit rate. Now
+   the only open item, and the only one that can settle arbitration. Run
+   `scripts/can/arbitration-check.sh --dev can0`: it compares the tail latency
+   of an urgent stream against a saturating bulk stream with the identifiers
+   assigned both ways round. If the two cases look alike, the priority mapping
+   buys nothing on real hardware and the claim in the link's documentation
+   should be withdrawn rather than defended.
+2. **Contention under load.** Once a bus exists, extend the two-pair test to
+   measure rather than merely assert: throughput per pair, and what a
+   saturating transfer does to a concurrent one.
+Upstream is done and in review:
+
+| PR | what |
+| --- | --- |
+| [eclipse-zenoh/zenoh#2757](https://github.com/eclipse-zenoh/zenoh/pull/2757) | the two link crates |
+| [eclipse-zenoh/zenoh-pico#1298](https://github.com/eclipse-zenoh/zenoh-pico/pull/1298) | the same pair for zenoh-pico |
+| [eclipse-zenoh/zenoh-c#1322](https://github.com/eclipse-zenoh/zenoh-c/pull/1322) | feature passthroughs; waits on zenoh#2757 |
+| [SimonCahill/isotp-c#75](https://github.com/SimonCahill/isotp-c/pull/75) | `ISO_TP_NO_FORMATTED_ERRORS`, to retire the vendoring fork |
+
+rmw_zenoh is held until zenoh#2757 lands.
 ---
 
 ## 12. Branch inventory
@@ -671,12 +724,17 @@ is the set to build against today.
 
 | repo | `feat/can-links` (upstream main) | `feat/can-links-ros` (ROS stable) |
 | --- | --- | --- |
-| `jerry73204/zenoh` | `93cf1b3e5` — on main, 1.10.0 | `bf01b3ac1` — on 1.8.0 |
-| `jerry73204/zenoh-pico` | `75bbb28e` — on upstream main | `0fdd49ce` — on release/1.8.0 |
-| `jerry73204/zenoh-c` | `0c401df8` — on main | `911db8e8` — on `05bd370`, the commit rmw_zenoh pins |
-| `jerry73204/rmw_zenoh` | `a24b450` — on rolling | `5b4c693` — on humble |
+| `jerry73204/zenoh` | `80ff24441` -- on main, 1.10.0 | `a84e9c0c8` -- on 1.8.0 |
+| `jerry73204/zenoh-pico` | `cb486dbf` -- on upstream main | `9ab534b5` -- on release/1.8.0 |
+| `jerry73204/zenoh-c` | `67f9b1dc` -- on main | `1bc04fd6` -- on `05bd370`, the commit rmw_zenoh pins |
+| `jerry73204/rmw_zenoh` | `019f058` -- on rolling | `0346674` -- on humble |
 
-`jerry73204/zenoh-pico`'s **`nano-ros`** branch (`8e08e8b8`) is separate from
+Each `feat/can-links*` is **two commits**, one per link, so the CAN link can be
+reviewed and taken without the ISO-TP one. The first adds no ISO-TP files at
+all. Every commit is authored `jerry73204 <jerry73204@gmail.com>` and carries a
+`Signed-off-by`, which the Eclipse ECA check requires.
+
+`jerry73204/zenoh-pico`'s **`nano-ros`** branch (`dac320e3`) is separate from
 both and is what this repository's submodule tracks. The two `feat/can-links*`
 branches are PORTS of the same work onto clean upstream bases; nothing moved off
 `nano-ros`.

--- a/scripts/can/arbitration-check.sh
+++ b/scripts/can/arbitration-check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Measure whether zenoh's priority really wins CAN arbitration.
+#
+#   ./scripts/can/arbitration-check.sh --dev can0 [--bitrate 500000] [--seconds 20]
+#
+# THIS NEEDS REAL HARDWARE and will refuse a virtual interface. `vcan` queues
+# frames rather than contending for them, so every result on it is an artefact
+# of scheduling order. That is the whole reason this script exists separately
+# from the test suite: arbitration is the one claim the CAN link makes that a
+# virtual bus cannot check.
+#
+# The experiment: saturate the bus with background traffic on a HIGH (losing)
+# identifier, then send control-priority traffic on a LOW (winning) identifier,
+# and compare the latency of the urgent frames against the same run with the
+# priorities swapped. If arbitration is doing what the design claims, the
+# urgent stream's tail latency barely moves under load and the bulk stream's
+# grows.
+set -euo pipefail
+
+DEV=can0
+BITRATE=500000
+SECONDS_RUN=20
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dev) DEV="$2"; shift 2 ;;
+        --bitrate) BITRATE="$2"; shift 2 ;;
+        --seconds) SECONDS_RUN="$2"; shift 2 ;;
+        -h|--help) awk 'NR>1 && /^#/ { sub(/^# ?/,""); print; next } NR>1 { exit }' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+# A virtual bus cannot arbitrate. Refuse rather than produce a number that
+# looks like a measurement.
+if [ -d "/sys/class/net/$DEV" ] && \
+   [ "$(cat "/sys/class/net/$DEV/type" 2>/dev/null || echo 0)" = "280" ] && \
+   ! [ -d "/sys/class/net/$DEV/device" ]; then
+    echo "[arbitration] $DEV has no backing device, so it is virtual." >&2
+    echo "[arbitration] vcan queues frames and never contends; this measures nothing there." >&2
+    exit 1
+fi
+command -v cangen >/dev/null || { echo "[arbitration] need can-utils (cangen, candump)" >&2; exit 1; }
+
+echo "[arbitration] $DEV at $BITRATE bit/s, ${SECONDS_RUN}s per direction"
+echo "[arbitration] bring the interface up yourself, e.g.:"
+echo "    sudo ip link set $DEV type can bitrate $BITRATE && sudo ip link set up $DEV"
+
+run_case() {
+    local name=$1 urgent_id=$2 bulk_id=$3 out
+    out=$(mktemp -d)
+    echo "[arbitration] case: $name  (urgent=0x$urgent_id  bulk=0x$bulk_id)"
+    stdbuf -o0 candump -ta "$DEV" > "$out/dump.log" 2>&1 &
+    local dump=$!
+    # Bulk: saturate. Urgent: one frame every 10ms.
+    cangen "$DEV" -I "$bulk_id"   -L 8 -g 0  -n 100000 >/dev/null 2>&1 &
+    local bulk=$!
+    cangen "$DEV" -I "$urgent_id" -L 8 -g 10 -n $((SECONDS_RUN * 100)) >/dev/null 2>&1
+    kill $bulk 2>/dev/null || true
+    sleep 0.5
+    kill $dump 2>/dev/null || true
+    python3 - "$out/dump.log" "$urgent_id" "$name" <<'PY'
+import sys, re
+path, uid, name = sys.argv[1], sys.argv[2].lower(), sys.argv[3]
+ts = [float(m.group(1)) for m in
+      (re.match(r'\s*\(([\d.]+)\)\s+\S+\s+' + uid + r'\s', l.lower()) for l in open(path)) if m]
+if len(ts) < 10:
+    print(f"    {name}: only {len(ts)} urgent frames seen; check wiring"); raise SystemExit
+g = sorted((ts[i+1] - ts[i]) * 1000 for i in range(len(ts) - 1))
+p50, p99, mx = g[len(g)//2], g[int(len(g)*0.99)], g[-1]
+print(f"    {name}: urgent frames {len(ts)}  p50 {p50:.2f} ms  p99 {p99:.2f} ms  max {mx:.2f} ms")
+PY
+    rm -rf "$out"
+}
+
+# Lower identifier wins arbitration on CAN.
+run_case "urgent LOW id (should win)"  "020" "700"
+run_case "urgent HIGH id (should lose)" "700" "020"
+
+cat <<'NOTE'
+
+[arbitration] Reading the result: the first case is the layout the CAN link
+uses, with zenoh's Control priority mapped to the lowest identifiers. If
+arbitration is working, its p99 and max stay close to the 10ms send interval
+while the second case, where the urgent stream has to wait for the bulk one,
+shows a visibly worse tail. If the two cases look the same, the priority
+mapping is not buying anything on this hardware and the claim should be
+withdrawn.
+NOTE


### PR DESCRIPTION
Supersedes #38, which pinned a commit the ASCII pass has since rewritten. Same content plus the prose cleanup, so the pin still only moves forward in substance.

## What changed

**The close-out was wrong about timing.** It said nothing about timing could be shown without hardware. STmin and BS are kernel hrtimer logic, not CAN controller behaviour, so they are measurable on `vcan`:

| | measured |
| --- | --- |
| `stmin=0` | 0.06 ms between ConsecutiveFrames |
| `stmin=5ms` | 5.07 ms |
| `bs=0` | 1 FlowControl |
| `bs=4` | 11 FlowControls |

The ISO-TP link now takes `stmin` and `bs` as endpoint parameters (upstream in eclipse-zenoh/zenoh#2757), with a test that fails when they are removed.

**Arbitration still needs hardware.** `scripts/can/arbitration-check.sh` is the experiment, and it refuses to run on a virtual interface rather than produce a meaningless number.

**Housekeeping:** the isotp-c fork is recorded, the branch inventory refreshed to current SHAs, and the upstream to-do replaced with the four PRs in review.

## Verified

Submodule bump is content-equivalent to #38's plus the ASCII pass; same parent, nothing dropped, zephyr serial fix still contained.