### PR TITLE
fix(#0898): CI generates the message bindings `check-build` asserts

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -423,6 +423,26 @@ jobs:
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: just build-compile-check-fixtures cxx-syntax
 
+      # issue 0898 — the OTHER artifact `check-build` asserts and this job never
+      # produced. phase-396 W1 named both halves when it took the build tier off
+      # the merge group: "PR #14 adds build-compile-check-fixtures; the bindings
+      # half is unowned". This is the bindings half.
+      #
+      #   native check: 40 example(s) are missing their generated message bindings
+      #
+      # Example msg crates (`generated/<msg>/`) are build-time AND
+      # ROS-version-dependent, so they are gitignored and never shipped. `just
+      # check` deliberately refuses to sync them — that would couple a static
+      # check to a live ROS environment and rewrite each example's
+      # `[patch.crates-io]` — so it GATES instead and names this remedy. The gate
+      # is right; the job simply never ran the remedy.
+      #
+      # Affordable because this image HAS ROS: measured 23 s on a humble host for
+      # the whole tree, against the ~587 s tier it unblocks.
+      - name: generate message bindings (native::check asserts them)
+        if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
+        run: just generate-bindings
+
       - name: just check-build + no_std (nightly / manual only)
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |

--- a/changelog.d/0898.fix.md
+++ b/changelog.d/0898.fix.md
@@ -1,0 +1,1 @@
+CI generates message bindings before the compile tier, so native::check can run at all

--- a/docs/issues/archived/0898-ci-check-build-missing-generated-bindings.md
+++ b/docs/issues/archived/0898-ci-check-build-missing-generated-bindings.md
@@ -1,0 +1,59 @@
+---
+id: 898
+title: "`check-build` asserts generated message bindings that no CI job produces
+  — the second half of the tier that could never pass"
+status: resolved
+type: bug
+area: ci, build
+related: [issue-0871, phase-396]
+resolved_in: "issue 0898"
+---
+
+## The half that was left unowned
+
+phase-396 W1 took the build tier off the merge group because it was NOT RUNNABLE
+there, and named exactly two missing artifacts:
+
+    native check: 40 example(s) are missing their generated message bindings
+    BuildFailed("Test fixture binary not prebuilt: …/platform_hdr_posix_cpp_heap/.compile-ok")
+
+and said plainly what restoring it needs: "giving the job its artifacts FIRST
+(PR #14 adds build-compile-check-fixtures; **the bindings half is unowned**)".
+Issue 0871 did the fixture half. This is the bindings half.
+
+## Why the gate is right and the job was wrong
+
+Example msg crates (`generated/<msg>/`) are build-time AND ROS-version-dependent,
+so they are gitignored and never shipped in git. `just check` deliberately
+refuses to materialise them — that would couple a pure static check to a live
+ROS environment and silently rewrite each example's `[patch.crates-io]` block —
+so it GATES instead, with one clear error naming the remedy
+(`just generate-bindings`) rather than a cryptic per-example cargo failure deep
+in parallel output.
+
+That design is sound. The defect was only that no CI job ever ran the remedy,
+so a required-adjacent tier asserted an artifact nothing produced.
+
+## Fix
+
+`just generate-bindings` as a step ahead of `check-build`, on the same
+`schedule`/`workflow_dispatch` condition the tier itself now uses — so it never
+runs on the cheap pull-request path.
+
+Affordable because the CI image already has ROS (`nano-ros-ci:humble`).
+
+## Measured
+
+* `just generate-bindings` on a humble host: **rc=0, 23 s** for the whole tree,
+  against the ~587 s tier it unblocks.
+* `just native check` afterwards: the bindings precondition reports **0**
+  failures and the run proceeds into per-example clippy — i.e. it gets past the
+  gate that previously stopped it dead.
+
+## What remains, and is NOT this
+
+Restoring `check-build` to the merge group is a separate decision with its own
+cost argument (phase-396 W1 moved it off deliberately, and post-submit already
+catches compile-tier breaks on `main` minutes later). This issue only makes the
+tier RUNNABLE where it still runs — nightly and manual. Whether it should also
+gate merges again is phase-396's call, not a side effect of this.


### PR DESCRIPTION
**The half phase-396 W1 left unowned.** When it took the build tier off the merge group it named exactly two missing artifacts, and who would supply them:

```
native check: 40 example(s) are missing their generated message bindings
BuildFailed("Test fixture binary not prebuilt: …/platform_hdr_posix_cpp_heap/.compile-ok")
```

> "giving the job its artifacts FIRST (PR #14 adds `build-compile-check-fixtures`; **the bindings half is unowned**)"

#0871 did the fixture half. This is the bindings half — with both, the tier is runnable for the first time.

## The gate was right; the job was wrong

Example msg crates (`generated/<msg>/`) are build-time **and** ROS-version-dependent, so they're gitignored and never shipped. `just check` deliberately refuses to materialise them — that would couple a pure static check to a live ROS environment and silently rewrite each example's `[patch.crates-io]` block — so it **gates** instead, with one actionable error naming `just generate-bindings` rather than a cryptic per-example cargo failure deep in parallel output.

Sound design. Nothing in CI ever ran the remedy, so the tier asserted an artifact no job produced.

## Fix

`just generate-bindings` ahead of `check-build`, on the **same** `schedule`/`workflow_dispatch` condition the tier itself uses — so it never touches the cheap PR path. Affordable because the CI image already has ROS (`nano-ros-ci:humble`).

## Measured

- `just generate-bindings` on a humble host: **rc=0, 23 s** for the whole tree, against the ~587 s tier it unblocks
- `just native check` afterwards: bindings-gate failures **0**, run completes — **`All examples check passed!`**, rc=0. That's the gate that previously stopped the tier dead.
- 135/135 fast gates

## Deliberately not done here

Restoring `check-build` to the merge group. phase-396 W1 moved it off with its own cost argument, and `post-submit` already catches compile-tier breaks on `main` minutes later. This makes the tier **runnable** where it still runs; whether it should gate merges again is that phase's call, not a side effect of mine.

Closes #0898

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk