### PR TITLE
fix(#0901): the identity gate resolves its tree instead of naming a dead path

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -423,6 +423,26 @@ jobs:
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: just build-compile-check-fixtures cxx-syntax
 
+      # issue 0898 — the OTHER artifact `check-build` asserts and this job never
+      # produced. phase-396 W1 named both halves when it took the build tier off
+      # the merge group: "PR #14 adds build-compile-check-fixtures; the bindings
+      # half is unowned". This is the bindings half.
+      #
+      #   native check: 40 example(s) are missing their generated message bindings
+      #
+      # Example msg crates (`generated/<msg>/`) are build-time AND
+      # ROS-version-dependent, so they are gitignored and never shipped. `just
+      # check` deliberately refuses to sync them — that would couple a static
+      # check to a live ROS environment and rewrite each example's
+      # `[patch.crates-io]` — so it GATES instead and names this remedy. The gate
+      # is right; the job simply never ran the remedy.
+      #
+      # Affordable because this image HAS ROS: measured 23 s on a humble host for
+      # the whole tree, against the ~587 s tier it unblocks.
+      - name: generate message bindings (native::check asserts them)
+        if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
+        run: just generate-bindings
+
       - name: just check-build + no_std (nightly / manual only)
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |

--- a/changelog.d/0898.fix.md
+++ b/changelog.d/0898.fix.md
@@ -1,0 +1,1 @@
+CI generates message bindings before the compile tier, so native::check can run at all

--- a/changelog.d/0901.fix.md
+++ b/changelog.d/0901.fix.md
@@ -1,0 +1,1 @@
+the artifact-identity gate resolves its build tree instead of naming a path nothing writes

--- a/docs/issues/0899-freertos-talker-wbuf-overrun-after-40-publishes.md
+++ b/docs/issues/0899-freertos-talker-wbuf-overrun-after-40-publishes.md
@@ -1,0 +1,107 @@
+---
+id: 899
+title: "The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer —
+  two different asserts, both after tens of successful publishes"
+status: open
+type: bug
+area: rmw, boards
+related: [issue-0877, issue-0135]
+---
+
+## Symptom
+
+The `mps2-an385` FreeRTOS C talker publishes correctly for tens of messages and
+then aborts inside zenoh-pico. TWO different assertions, from two runs of the
+SAME binary:
+
+    Publishing: 'Hello World: 40'
+    assertion "i < _z_iosli_svec_len(&wbf->_ioss)" failed:
+      zenoh-pico/src/protocol/iobuf.c, line 374, function: _z_wbuf_put
+
+    Publishing: 'Hello World: 19'
+    FreeRTOS ASSERT FAILED: third-party/freertos/kernel/queue.c:1673
+
+Delivery WORKS up to that point — a paired listener received all 40.
+
+## Reproduction (reliable, ~1 minute)
+
+Both guests, host router, the harness's own QEMU arguments:
+
+    ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=false;listen/endpoints=["tcp/0.0.0.0:7900"]' \
+      "$(ros2 pkg prefix rmw_zenoh_cpp)/lib/rmw_zenoh_cpp/rmw_zenohd" &
+    qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -icount shift=auto \
+      -semihosting-config enable=on,target=native \
+      -nic user,model=lan9118,net=192.0.3.0/24,host=192.0.3.1 \
+      -kernel examples/qemu-arm-freertos/c/listener/build-zenoh/c_listener &
+    sleep 22
+    qemu-system-arm … -kernel examples/qemu-arm-freertos/c/talker/build-zenoh/c_talker
+
+The talker ALONE, with no listener, ran 67 publishes without asserting — so the
+fault needs the traffic a real peer generates, not just publishing.
+
+## What the two asserts have in common
+
+* `iobuf.c:374` is `_z_wbuf_put(wbf, b, pos)` walking the io-slice list for
+  `pos`. It fires when `pos` exceeds the total capacity of every slice — a
+  BACKFILL past the end of the write buffer, i.e. wrong position arithmetic or a
+  buffer that shrank/was reused underneath.
+* `queue.c:1673` is `configASSERT(pxQueue->uxItemSize == 0)` inside
+  `xQueueSemaphoreTake` — a handle taken as a SEMAPHORE that is actually a
+  QUEUE.
+
+Neither is a clean out-of-resources report; both are the shape of memory being
+used as something it is not. Two distinct bad-state assertions from one binary
+points at corruption rather than at either subsystem's own logic.
+
+## Checked and ruled out
+
+* **Buffer sizing.** `Z_FRAG_MAX_SIZE 2048` / `Z_BATCH_UNICAST_SIZE 1500`, and
+  the payload is `Hello World: N`. The failure is accumulation over tens of
+  messages, not one oversized write.
+* **The condvar ABI mirror.** `nros_freertos_condvar_t` mirrors zenoh-pico's
+  `_z_condvar_t` and the offsets are `_Static_assert`ed. On THIS board
+  `configSUPPORT_STATIC_ALLOCATION` is 0, so zenoh-pico's struct is exactly
+  `{mutex, sem, waiters}` and the mirror matches.
+* **Generated-config divergence.** Five copies of `zenoh_generic_config.h` exist
+  in the leaf's cargo dir with three distinct hashes, differing by
+  `#define Z_FEATURE_LINK_CAN 0`. That define is emitted by OUR generator and
+  referenced NOWHERE in vendored zenoh-pico, so it is inert — these are stale
+  build-script outputs from different times, not the issue-0135 live mismatch.
+
+## A claimed "adjacent defect" that was NOT one — retracted
+
+An earlier revision of this issue claimed `nros_freertos_condvar_t` was a latent
+size mismatch on `nros-board-freertos-posix`, because zenoh-pico's
+`_z_condvar_t` gains two `StaticSemaphore_t` under
+`configSUPPORT_STATIC_ALLOCATION == 1` while the mirror does not.
+
+That is wrong, and the reasoning that made it look right is worth recording.
+The mirror comment says it pins field OFFSETS and not total SIZE, which reads
+like an oversight — a trailing conditional field is exactly what slips through
+an offsets-only check. So I "fixed" it by adding the two buffers.
+
+The build refused, and it was right to: an existing assert,
+`NROS_PLATFORM_CONDVAR_STORAGE_SIZE >= sizeof(nros_freertos_condvar_t)`, failed
+because the honest-looking struct no longer fit the 256-byte opaque storage the
+platform ABI reserves.
+
+The direction of ownership is what settles it. `zpico-sys/c/zpico/platform_aliases.c`
+REDIRECTS zenoh-pico's condvar API at ours:
+
+    int8_t _z_condvar_init(void *cv) { return nros_platform_condvar_init(cv); }
+
+so zenoh-pico never interprets those bytes — it allocates opaque `[u8; N]`
+storage (its own header comment says the threading primitives are opaque
+precisely because they "do not match `nros_platform_task_t` shapes 1:1") and
+calls us. The storage only ever holds OUR three fields. Pinning offsets and not
+size is therefore correct, and the tail of zenoh-pico's struct is irrelevant
+because nothing on this path ever writes it.
+
+Reverted. Recorded because the mistake is re-derivable: the comment looks like
+an admission of a gap, and it is actually a statement of scope.
+
+## Acceptance
+
+* The talker survives a sustained run with a peer attached.
+* Whatever is corrupted is named, rather than surfacing as two unrelated
+  assertions.

--- a/docs/issues/archived/0898-ci-check-build-missing-generated-bindings.md
+++ b/docs/issues/archived/0898-ci-check-build-missing-generated-bindings.md
@@ -1,0 +1,59 @@
+---
+id: 898
+title: "`check-build` asserts generated message bindings that no CI job produces
+  — the second half of the tier that could never pass"
+status: resolved
+type: bug
+area: ci, build
+related: [issue-0871, phase-396]
+resolved_in: "issue 0898"
+---
+
+## The half that was left unowned
+
+phase-396 W1 took the build tier off the merge group because it was NOT RUNNABLE
+there, and named exactly two missing artifacts:
+
+    native check: 40 example(s) are missing their generated message bindings
+    BuildFailed("Test fixture binary not prebuilt: …/platform_hdr_posix_cpp_heap/.compile-ok")
+
+and said plainly what restoring it needs: "giving the job its artifacts FIRST
+(PR #14 adds build-compile-check-fixtures; **the bindings half is unowned**)".
+Issue 0871 did the fixture half. This is the bindings half.
+
+## Why the gate is right and the job was wrong
+
+Example msg crates (`generated/<msg>/`) are build-time AND ROS-version-dependent,
+so they are gitignored and never shipped in git. `just check` deliberately
+refuses to materialise them — that would couple a pure static check to a live
+ROS environment and silently rewrite each example's `[patch.crates-io]` block —
+so it GATES instead, with one clear error naming the remedy
+(`just generate-bindings`) rather than a cryptic per-example cargo failure deep
+in parallel output.
+
+That design is sound. The defect was only that no CI job ever ran the remedy,
+so a required-adjacent tier asserted an artifact nothing produced.
+
+## Fix
+
+`just generate-bindings` as a step ahead of `check-build`, on the same
+`schedule`/`workflow_dispatch` condition the tier itself now uses — so it never
+runs on the cheap pull-request path.
+
+Affordable because the CI image already has ROS (`nano-ros-ci:humble`).
+
+## Measured
+
+* `just generate-bindings` on a humble host: **rc=0, 23 s** for the whole tree,
+  against the ~587 s tier it unblocks.
+* `just native check` afterwards: the bindings precondition reports **0**
+  failures and the run proceeds into per-example clippy — i.e. it gets past the
+  gate that previously stopped it dead.
+
+## What remains, and is NOT this
+
+Restoring `check-build` to the merge group is a separate decision with its own
+cost argument (phase-396 W1 moved it off deliberately, and post-submit already
+catches compile-tier breaks on `main` minutes later). This issue only makes the
+tier RUNNABLE where it still runs — nightly and manual. Whether it should also
+gate merges again is phase-396's call, not a side effect of this.

--- a/docs/issues/archived/0901-identity-budget-gate-reads-a-path-the-build-no-longer-writes.md
+++ b/docs/issues/archived/0901-identity-budget-gate-reads-a-path-the-build-no-longer-writes.md
@@ -1,0 +1,75 @@
+---
+id: 901
+title: "The artifact-identity gate read a path nothing writes, and told you to
+  run a build that does not produce it"
+status: resolved
+type: bug
+area: build, testing
+related: [issue-0499, issue-0616, phase-340]
+resolved_in: "issue 0901"
+---
+
+## Symptom
+
+Two failure modes, opposite in appearance, one cause.
+
+On a long-lived machine the gate reported a budget breach — `nros` at 8
+identities against a ceiling of 5. On a fresh checkout it SKIPPED, because the
+tree it reads did not exist. Its own remedy, followed literally, fixed neither.
+
+## Cause: a hardcoded path with no producer
+
+    TREE="${NROS_IDENTITY_BUDGET_TREE:-examples/workspaces/mixed/build-workspace-fixtures}"
+
+Nothing writes that directory any more. The workspace build gained PER-PLATFORM
+suffixes — `build-workspace-fixtures-freertos`, `-threadx`, … — and the
+unsuffixed name was left behind. Every `examples/workspaces/mixed` row in
+`fixtures.toml` now builds into `build/posix-zenoh-native/cmake` and siblings.
+
+So the directory survives only as residue on machines old enough to predate the
+rename, and what the gate measured there was accumulation: rlibs cargo never
+collects, from builds before the layout changed. 8 identities of history,
+reported as a regression.
+
+Deleting it — which the gate suggests — did not help either, because no lane
+recreates it.
+
+## And the advice was wrong
+
+    BUILD_HINT="… just build-test-fixtures lane=native"
+
+Measured: a full `lane=native` run (**2 616 s**) left every
+`examples/workspaces/*/build-workspace-fixtures*` at its previous mtime. Those
+trees come from the WORKSPACE build, not that lane. Advice that does not produce
+the artifact is worse than none — it costs the reader forty minutes and leaves
+the gate exactly as silent as before.
+
+## Fix
+
+* **Resolve the tree, do not name it.** Take the newest
+  `examples/workspaces/*/build-workspace-fixtures*` that actually contains
+  cargo output, so the gate reads what the last build produced whatever the
+  layout is called this month. `NROS_IDENTITY_BUDGET_TREE` still overrides, and
+  the historical name remains the fallback so the SKIP message points somewhere
+  recognisable.
+* **Name a command that builds it**: `just build-test-fixtures`.
+* `just prune-artifacts` carried the SAME dead path as its default — the sibling
+  of the class, fixed with it.
+
+## Verified
+
+* Before: `[SKIP] … no build tree at …/mixed/build-workspace-fixtures`.
+* After: the gate finds a real tree (333 rlibs in `features/`) and reports
+  honestly that they predate the current `started_at` — "this tree is history,
+  not that build".
+* Given a tree WITH in-window artifacts it measures:
+  `nros_core 3/4 identities; worst crate 3/5; worst identity 1/5 copies`.
+* `--self-test`: 2/2.
+
+## The residual skip is correct, and worth stating
+
+On an up-to-date tree a fixture build compiles nothing, so no artifact falls
+inside the `started_at` window and the gate skips. That is issue 0499's design
+working: it counts THIS build's artifacts, never history. The gate measures
+after a build that actually compiled, and says plainly when it cannot — which
+is the opposite of the silent green it used to give.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,5 +66,6 @@ fails if this block drifts.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 - **#0891** (testing) — Six nuttx `rtos_e2e` cells fail in-sweep and pass solo — the group cap was never measured, and a slow boot is reported as a dead image See `0891-*`.
+- **#0899** (rmw, boards) — The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer — two different asserts, both after tens of successful publishes See `0899-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/justfile
+++ b/justfile
@@ -5908,7 +5908,7 @@ check-artifact-identity-budget:
 # Keeping the newest per (dir, crate, ext) is free: that copy is the one cargo
 # links and the older ones are unreferenced, so nothing rebuilds. `just prune-artifacts`
 # is a DRY RUN; add `apply=1` to delete.
-prune-artifacts dir="examples/workspaces/mixed/build-workspace-fixtures" apply="":
+prune-artifacts dir="examples/workspaces/features/build-workspace-fixtures" apply="":
     @python3 scripts/build/prune-superseded-artifacts.py {{dir}} {{ if apply == "" { "" } else { "--apply" } }}
 
 # phase-340 W3 — ONE `--target` spelling for every cargo command cmake emits.

--- a/scripts/check-artifact-identity-budget.sh
+++ b/scripts/check-artifact-identity-budget.sh
@@ -181,7 +181,37 @@ if [ "${1:-}" = "--self-test" ]; then
     exit 0
 fi
 
-TREE="${NROS_IDENTITY_BUDGET_TREE:-examples/workspaces/mixed/build-workspace-fixtures}"
+# issue 0901 — RESOLVE the tree, do not hardcode one path.
+#
+# This read `examples/workspaces/mixed/build-workspace-fixtures` literally. That
+# directory has no producer any more: the workspace build gained PER-PLATFORM
+# suffixes (`-freertos`, `-threadx`, …) and the unsuffixed name was left behind.
+# So on a fresh checkout the gate SKIPPED — the tree cannot exist — while on a
+# long-lived machine it read a directory nothing had written since the rename
+# and reported pure accumulation as a budget breach. Measured here: 8 identities
+# for `nros` against a ceiling of 5, entirely history, and a full
+# `build-test-fixtures lane=native` (2 616 s) did not recreate the path, which is
+# what the SKIP message told the user to run.
+#
+# Both failure modes come from naming a path instead of finding one. Take the
+# NEWEST tree that actually has cargo artifacts, so the gate reads what the last
+# build produced whatever the layout is called this month.
+if [ -n "${NROS_IDENTITY_BUDGET_TREE:-}" ]; then
+    TREE="$NROS_IDENTITY_BUDGET_TREE"
+else
+    TREE=""
+    for _cand in $(ls -1dt examples/workspaces/*/build-workspace-fixtures* 2>/dev/null); do
+        # A tree is usable when it holds cargo output; a bare cmake dir is not
+        # what this gate measures.
+        if [ -n "$(find "$_cand" -name '*.rlib' -print -quit 2>/dev/null)" ]; then
+            TREE="$_cand"
+            break
+        fi
+    done
+    # Nothing found: keep the historical name so the SKIP message still points
+    # somewhere recognisable rather than at an empty string.
+    TREE="${TREE:-examples/workspaces/mixed/build-workspace-fixtures}"
+fi
 
 # --- the budget -------------------------------------------------------------
 # Recorded 2026-08-07. See "THE NUMBERS" above before changing any of these.
@@ -250,7 +280,13 @@ CEILING_IDENTITIES=5
 CEILING_COPIES=5
 # ----------------------------------------------------------------------------
 
-BUILD_HINT="source ./activate.sh && just build-test-fixtures lane=native"
+# issue 0901 — `lane=native` was the advice and it does not build these trees.
+# Measured: a full `just build-test-fixtures lane=native` (2 616 s) left every
+# `examples/workspaces/*/build-workspace-fixtures*` untouched at its previous
+# mtime. The workspace fixtures come from the WORKSPACE build, so name that.
+# Advice that does not produce the artifact is worse than no advice: it costs
+# the reader 40 minutes and leaves the gate exactly as silent as before.
+BUILD_HINT="source ./activate.sh && just build-test-fixtures"
 
 if [ ! -d "$TREE" ]; then
     echo "[SKIP] artifact-identity budget: no build tree at $TREE"


### PR DESCRIPTION
Two failure modes, opposite in appearance, one cause. On a long-lived machine the gate reported `nros` at **8 identities against a ceiling of 5**. On a fresh checkout it **skipped**. Its own remedy fixed neither.

```
TREE="${NROS_IDENTITY_BUDGET_TREE:-examples/workspaces/mixed/build-workspace-fixtures}"
```

## Nothing writes that directory

The workspace build gained per-platform suffixes (`-freertos`, `-threadx`, …) and the unsuffixed name was left behind — every `examples/workspaces/mixed` row now builds into `build/posix-zenoh-native/cmake` and siblings.

So the path survives only as **residue** on machines old enough to predate the rename, and what the gate measured there was accumulation: rlibs cargo never collects, from builds before the layout changed. Eight identities of history, reported as a regression. Deleting the tree — which the gate suggests — didn't help either, because no lane recreates it.

## And the advice was wrong

`BUILD_HINT` said `just build-test-fixtures lane=native`. **Measured:** a full `lane=native` run (**2 616 s**) left every `examples/workspaces/*/build-workspace-fixtures*` at its previous mtime. Those trees come from the *workspace* build. Advice that doesn't produce the artifact is worse than none — it costs the reader forty minutes and leaves the gate exactly as silent as before.

## Fix

- **Resolve** the tree rather than name it: newest `examples/workspaces/*/build-workspace-fixtures*` that actually holds cargo output, so the gate reads what the last build produced whatever the layout is called this month. `NROS_IDENTITY_BUDGET_TREE` still overrides; the historical name stays as fallback so the SKIP points somewhere recognisable.
- Name a command that builds it.
- `just prune-artifacts` defaulted to the **same dead path** — sibling of the class, fixed with it.

## Verified

- before: `[SKIP] … no build tree at …/mixed/build-workspace-fixtures`
- after: finds a real tree (333 rlibs) and honestly reports they predate the current `started_at` — *"this tree is history, not that build"*
- given in-window artifacts it **measures**: `nros_core 3/4 identities; worst crate 3/5; worst identity 1/5 copies`
- `--self-test` 2/2; 135/135 fast gates

## The residual skip is correct

On an up-to-date tree a fixture build compiles nothing, so no artifact falls inside the `started_at` window. That's #0499's design working — it counts *this* build's artifacts, never history — and saying so plainly is the opposite of the silent green it used to give.

Closes #0901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk