### PR TITLE
feat(phase-381): complete W3-W7 — the ROS graph, readable at last

### DIFF
--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -22,7 +22,7 @@ moves with it.
 | pool | bytes at default | formula | declared in |
 | --- | ---: | --- | --- |
 | `LARGE_PAYLOADS` | 131,072 | `ZPICO_MAX_LARGE_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:200` |
-| `SLOTS` | 8,192 | `NROS_RMW_SUBSCRIBER_SLOTS * 1024` | `packages/rmw/cffi/src/rust_adapter.rs:102` |
+| `SLOTS` | 8,192 | `NROS_RMW_SUBSCRIBER_SLOTS * 1024` | `packages/rmw/cffi/src/rust_adapter.rs:111` |
 | `SMALL_PAYLOADS` | 32,768 | `ZPICO_MAX_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_BUFFER_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:199` |
 
 ## Every sizing knob

--- a/docs/design/0036-ros2-api-divergences.md
+++ b/docs/design/0036-ros2-api-divergences.md
@@ -4,7 +4,7 @@ title: "Divergences from the ROS 2 standard client APIs (rclrs / rclcpp / rclc)"
 status: Draft
 since: 2026-06
 last-reviewed: 2026-08
-implements-tracked-by: [phase-379]
+implements-tracked-by: [phase-379, phase-381]
 supersedes: []
 superseded-by: null
 ---
@@ -101,7 +101,38 @@ Each divergence: **what ROS 2 does → what nano-ros does → why → owner**.
   callbacks not `std::function`; value types not `shared_ptr`. (RFC-0018.)
 - **QoS subset** — history/reliability/durability/liveliness/deadline/lifespan
   supported; selected at compile time; no dynamic QoS negotiation.
-- **No dynamic discovery** — peers static via `nros.toml` / Kconfig locator.
+- **Static CONNECTION, dynamic GRAPH** (amended 2026-08-30, phase-381). This
+  line read "**No dynamic discovery** — peers static via `nros.toml` / Kconfig
+  locator", which conflated two things and was half wrong for two years.
+
+  What is still true: **the locator is configured, not discovered.** A nano-ros
+  node is told where its router / agent / peer is; it does not find one by
+  broadcasting. That is a real divergence and it is not going away — it is what
+  lets an image with no multicast and a fixed memory budget come up
+  deterministically.
+
+  What was never true, and is now demonstrably not: that the node cannot READ
+  the graph. Both real backends already ran the machinery — the zenoh shim
+  declares and queries `@ros2_lv` liveliness tokens, and `nros-rmw-cyclonedds`
+  PUBLISHED `ros_discovery_info` so stock `ros2 node list` could see us — so a
+  nano-ros node was visible in the ROS graph while unable to answer "is anyone
+  subscribed to this topic". That asymmetry, not the absence of a feature, is
+  what issue 0791 filed and phase-381 closed: twelve `rmw` graph slots, filled
+  on zenoh and (for node names) on Cyclone, reachable from all three languages.
+
+  Three properties a caller must know, because they are what makes this
+  honest rather than a claim of parity:
+
+  * **It reports what has been DISCOVERED, and never blocks.** The first call
+    after startup legitimately returns a partial graph. Poll; do not call once
+    and conclude.
+  * **An empty answer is "nobody seen yet", never "nobody exists."** It is not
+    proof of absence.
+  * **`UNSUPPORTED` is distinct from empty.** A backend with no graph at all —
+    XRCE — says it cannot tell you rather than reporting nothing there.
+
+  The remaining static piece is the locator. Saying "no dynamic discovery" for
+  the whole area described a system we stopped being.
 - **No parameter callbacks**; parameters are read/write only.
 - **No lifecycle-node graph** — a simplified state model for embedded executors.
 

--- a/docs/reference/api-parity-ledger/graph.json
+++ b/docs/reference/api-parity-ledger/graph.json
@@ -51,13 +51,29 @@
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`)."
   },
+  "c:executor_get_client_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
   "c:executor_get_node_names": {
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`). Reports what has been DISCOVERED and never blocks, so an empty enumeration means \"nobody seen yet\" rather than \"nobody exists\"; `UNSUPPORTED` stays distinct from empty."
   },
+  "c:executor_get_publisher_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
   "c:executor_get_service_names_and_types": {
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`)."
+  },
+  "c:executor_get_service_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
+  "c:executor_get_subscriber_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The SUBSCRIBER/SUBSCRIPTION word is chosen per language from that language's own upstream, which is why the three differ on purpose: rcl says `subscriber`, rclcpp and rclrs say `subscription`, and the vtable slot says `subscriber` because upstream rmw does (RFC-0054). rclcpp has no `*_by_node` form for subscriptions at all, so its WORD comes from its vocabulary (`create_subscription`, `Subscription<T>`) rather than from a method it lacks. Recorded so this does not read as the drift issue 0788 collects -- 0788 is about our languages disagreeing with NO rule; here the rule is 'follow your own upstream'."
   },
   "c:executor_get_topic_names_and_types": {
     "verdict": "divergence",
@@ -178,13 +194,29 @@
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`)."
   },
+  "cpp:Executor::get_client_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
   "cpp:Executor::get_node_names": {
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`). Reports what has been DISCOVERED and never blocks, so an empty enumeration means \"nobody seen yet\" rather than \"nobody exists\"; `UNSUPPORTED` stays distinct from empty."
   },
+  "cpp:Executor::get_publisher_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
   "cpp:Executor::get_service_names_and_types": {
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`)."
+  },
+  "cpp:Executor::get_service_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
+  "cpp:Executor::get_subscription_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The SUBSCRIBER/SUBSCRIPTION word is chosen per language from that language's own upstream, which is why the three differ on purpose: rcl says `subscriber`, rclcpp and rclrs say `subscription`, and the vtable slot says `subscriber` because upstream rmw does (RFC-0054). rclcpp has no `*_by_node` form for subscriptions at all, so its WORD comes from its vocabulary (`create_subscription`, `Subscription<T>`) rather than from a method it lacks. Recorded so this does not read as the drift issue 0788 collects -- 0788 is about our languages disagreeing with NO rule; here the rule is 'follow your own upstream'."
   },
   "cpp:Executor::get_topic_names_and_types": {
     "verdict": "divergence",
@@ -279,13 +311,29 @@
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`)."
   },
+  "rust:Executor::get_client_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
   "rust:Executor::get_node_names": {
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`). Reports what has been DISCOVERED and never blocks, so an empty enumeration means \"nobody seen yet\" rather than \"nobody exists\"; `UNSUPPORTED` stays distinct from empty."
   },
+  "rust:Executor::get_publisher_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
   "rust:Executor::get_service_names_and_types": {
     "verdict": "divergence",
     "why": "phase-381 W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node (`rcl_get_node_names(node, ...)`, `rclcpp::Node::get_node_names()`) because each Node/Context owns a participant. A nano-ros image opens ONE transport session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it, so the graph is asked of the Executor. Our `Node` is a declarative registration with no session to query. NOT a `rename`: renaming would say our spelling should change, and it should not -- the name follows the receiver, and the receiver is where the session is. The C spelling keeps the `nros_executor_*` infix every other session-scoped verb uses (`nros_executor_ping`, `nros_executor_spin`)."
+  },
+  "rust:Executor::get_service_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is."
+  },
+  "rust:Executor::get_subscription_names_and_types_by_node": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The SUBSCRIBER/SUBSCRIPTION word is chosen per language from that language's own upstream, which is why the three differ on purpose: rcl says `subscriber`, rclcpp and rclrs say `subscription`, and the vtable slot says `subscriber` because upstream rmw does (RFC-0054). rclcpp has no `*_by_node` form for subscriptions at all, so its WORD comes from its vocabulary (`create_subscription`, `Subscription<T>`) rather than from a method it lacks. Recorded so this does not read as the drift issue 0788 collects -- 0788 is about our languages disagreeing with NO rule; here the rule is 'follow your own upstream'."
   },
   "rust:Executor::get_topic_names_and_types": {
     "verdict": "divergence",

--- a/docs/reference/api-parity-ledger/other.json
+++ b/docs/reference/api-parity-ledger/other.json
@@ -1,1038 +1,1042 @@
 {
- "_doc": [
-  "Phase 379. One row per item where the nano-ros user API does NOT correspond",
-  "to the ROS 2 client library it mirrors. Written by hand; read by",
-  "`scripts/api-parity.py --check`, which fails on any non-matching row that has",
-  "no entry here.",
-  "",
-  "Key is '<lang>:<normalized item>' exactly as the report prints it, where lang",
-  "is one of c / cpp / rust. Run the report to get the spelling; do not guess it.",
-  "",
-  "verdict is one of:",
-  "  divergence  we changed it and a PLATFORM CONSTRAINT is why. `why` must name",
-  "              the constraint (no_std, no exceptions, no allocator, no runtime",
-  "              env, single-threaded transport) -- not a preference. This is the",
-  "              only sanctioned reason to differ (RFC-0036).",
-  "  extension   we add it because an RTOS scenario needs it; ROS 2 has none.",
-  "  declined    ROS 2 has it, we deliberately do not, with the reason.",
-  "  gap         ROS 2 has it, we should too, nobody has done it. A gap is a",
-  "              legitimate entry -- the point is that it is written down.",
-  "  rename      the names differ and OURS is the one that should change. A",
-  "              rename with no platform reason costs the drop-in claim for",
-  "              nothing, so these are the campaign's work list.",
-  "",
-  "This file is SEEDED, not complete: W1 shipped the correlator, W2 classifies",
-  "the rest. `--check` is deliberately not wired into `just check` until then --",
-  "a gate that fails on ~2000 rows from the day it lands is one somebody",
-  "switches off. Keys beginning with '_' are documentation and are skipped.",
-  "",
-  "the `<lang>:` rows for its own lane, and `scripts/api-parity.py` merges every",
-  "shard in this directory. One agent per lane can write without a rebase",
-  "conflict against the others.",
-  "",
-  "SHARDED BY TOPIC: this file holds one stage's rows in ALL THREE",
-  "languages, because the campaign closes a feature at a time across every",
-  "language. `scripts/api-parity.py` merges every shard here, and",
-  "`--self-test` rejects a row whose item belongs to a different stage."
- ],
- "c:clear_custom_transport": {
-  "verdict": "extension",
-  "why": "see `c:set_custom_transport`; this is `nros_set_custom_transport(NULL)` spelled as a verb."
- },
- "c:has_custom_transport": {
-  "verdict": "extension",
-  "why": "see `c:set_custom_transport`. Reports whether a vtable is currently installed -- ours and not micro-ROS's, because the slot is process-global and a second `set` silently replaces the first."
- },
- "c:heap_peak_bytes": {
-  "verdict": "extension",
-  "why": "peak outstanding bytes since boot -- the figure that actually sizes an arena. See `c:heap_used_bytes`."
- },
- "c:heap_platform_used_bytes": {
-  "verdict": "extension",
-  "why": "the port's UNIFIED heap, spanning the Rust global allocator AND the C side (zenoh-pico's `z_malloc`), which is one kernel arena on every port. `nros_heap_used_bytes` sees only the Rust half and says so in its own doc comment, which is why both exist. See `c:heap_used_bytes`."
- },
- "c:heap_total_bytes": {
-  "verdict": "extension",
-  "why": "total managed heap (used + free) as the platform reports it, `0` where the port does not instrument its heap -- the denominator the other three are read against. See `c:heap_used_bytes`."
- },
- "c:heap_used_bytes": {
-  "verdict": "extension",
-  "why": "bytes currently outstanding through the Rust global allocator. an RTOS image has one fixed heap arena, no swap and no OOM killer, so the size of that arena is a build-time decision someone has to make from a measurement rather than a guess. rcl has nothing equivalent because a hosted process has none of those limits. RFC-0034 D7; gated on the `alloc-stats` feature."
- },
- "c:le_slice_view_f32_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_f64_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_i16_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_i32_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_i64_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_u16_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_u32_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:le_slice_view_u64_get": {
-  "verdict": "extension",
-  "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
- },
- "c:platform_critical_section_acquire": {
-  "verdict": "extension",
-  "why": "the platform ABI's IRQ-mask primitive. `nros-c` imports it to register a `critical_section::Impl` for its Rust dependencies (embedded Cyclone, portable-atomic) and to mask interrupts in `nros::panic_halt!`. rcl has no equivalent because a hosted process has no interrupts to mask. Not user API -- see `c:platform_heap_used_bytes` for why it is visible in the generated header at all."
- },
- "c:platform_critical_section_release": {
-  "verdict": "extension",
-  "why": "see `c:platform_critical_section_acquire`; takes back the restore token `acquire` returned."
- },
- "c:platform_heap_total_bytes": {
-  "verdict": "extension",
-  "why": "see `c:platform_heap_used_bytes`."
- },
- "c:platform_heap_used_bytes": {
-  "verdict": "extension",
-  "why": "NOT user API: this is the PLATFORM ABI (`nros/platform.h`, RFC-0034) that `nros-c` IMPORTS, and it reaches `nros_generated.h` only because cbindgen echoes the `unsafe extern \"C\"` block that declares it. The header already distinguishes them -- unlike every entry point beside them, the four `nros_platform_*` declarations carry no `NROS_PUBLIC` and no doc comment. A user calls `nros_heap_platform_used_bytes`; a PORT implements this. Same layering complaint one language over as `rust:Session::create_publisher`."
- },
- "c:set_custom_transport": {
-  "verdict": "extension",
-  "why": "runtime-pluggable transport vtable (`nros_transport_ops_t`: abi_version + open/close/write/read + `user_data`). An RTOS image often reaches the network over a link ROS 2 never sees -- USB-CDC, BLE, RS-485, a semihosting bridge -- and which one is a board fact decided after the library is built, so the hook has to be a runtime call rather than a link-time backend choice. rcl has no transport concept at all (rmw is selected at link time); the nearest thing anywhere is micro-ROS's `rmw_uros_set_custom_transport`, which this deliberately mirrors. Fn pointers rather than a trait object because a `Box<dyn>` would force `alloc` on every no_std port (`nros-rmw/src/custom_transport.rs`)."
- },
- "c:wake_state_get_zero_initialized": {
-  "verdict": "extension",
-  "why": "rcl's zero-init idiom under our naming, applied to the caller-owned `nros_wake_state_t` slot a polling entity's wake callback is registered with. Naming: see `c:publisher_get_zero_initialized` in the pubsub stage (ours is method-style `nros_<thing>_get_zero_initialized` at all 15 sites, rcl's is `rcl_get_zero_initialized_<thing>`); the slot itself: see `c:service_set_wake_callback`."
- },
- "cpp:ContentFilterOptions": {
-  "verdict": "declined",
-  "why": "content-filtered topics are a DDS feature: the subscriber ships an SQL-ish expression the WRITER evaluates. Only one of our backends is DDS, and the filter would have to be a no-op on zenoh and XRCE -- a QoS-shaped promise two of three transports cannot keep. Same reasoning `rmw-api-parity.py` already records for `rmw_*_content_filter`."
- },
- "cpp:ImplicitTypeAdapter": {
-  "verdict": "declined",
-  "why": "see `cpp:TypeAdapter`."
- },
- "cpp:SignalHandlerOptions": {
-  "verdict": "declined",
-  "why": "rclcpp's selector for WHICH signal handlers `rclcpp::init` installs. We install none: see `cpp:install_signal_handlers` in the init stage -- there is no POSIX signal delivery on Zephyr, FreeRTOS or bare-metal, and an image is stopped by its RTOS, a watchdog or a power rail."
- },
- "cpp:State": {
-  "verdict": "divergence",
-  "why": "`rclcpp_lifecycle::State` is a CLASS wrapping `rcl_lifecycle_state_t` -- an id, a heap-allocated `label` string, and the `rcl_allocator_t` that owns it. Ours is `cpp:LifecycleState`, a `uint8_t`-backed `enum class` over the five REP-2002 primary states plus an `Unknown = 0` sentinel: with no allocator there is nothing to own the label, and the id is the whole of what the state machine actually compares. See `cpp:LifecycleState` in the lifecycle stage for the ours-only half."
- },
- "cpp:State::State": {
-  "verdict": "divergence",
-  "why": "no constructor, because ours is an enum rather than a class. See `cpp:State`."
- },
- "cpp:State::id": {
-  "verdict": "divergence",
-  "why": "the value IS the enum in ours (`cpp:LifecycleState`), so there is nothing for an accessor to unwrap. See `cpp:State`."
- },
- "cpp:State::label": {
-  "verdict": "gap",
-  "why": "the human-readable state name (`\"unconfigured\"`, `\"active\"`). Not a divergence: a `const char* to_string(LifecycleState)` over five static literals costs an image almost nothing and needs no allocator -- nobody has written one. A C++ caller that wants to print a lifecycle state today has to switch on the enum itself. Same shape as `cpp:Transition` in the lifecycle stage. Phase 379 W3."
- },
- "cpp:Stream": {
-  "verdict": "divergence",
-  "why": "multi-shot receiver for polling subscriptions and action feedback: `try_next` polls, `wait_next` drives the executor until a value arrives or a wall-clock budget expires. rclcpp has no stream type because it delivers multi-shot data through a subscription callback and single-shot through `std::shared_future`; `<future>` needs threads, an allocator and exceptions, and none of the three is here. Same constraint and same shape as `cpp:Future` in the types stage -- RFC-0021: no futures, no async runtime, every blocking helper takes the executor."
- },
- "cpp:Stream::Stream<T>": {
-  "verdict": "divergence",
-  "why": "see `cpp:Stream`."
- },
- "cpp:Stream::is_valid": {
-  "verdict": "divergence",
-  "why": "see `cpp:Stream`."
- },
- "cpp:Stream::try_next": {
-  "verdict": "divergence",
-  "why": "see `cpp:Stream`."
- },
- "cpp:Stream::wait_next": {
-  "verdict": "divergence",
-  "why": "see `cpp:Stream`."
- },
- "cpp:TickCtx::TickCtx": {
-  "verdict": "divergence",
-  "why": "see `cpp:TickCtx`."
- },
- "cpp:TickCtx::call": {
-  "verdict": "divergence",
-  "why": "see `cpp:TickCtx`."
- },
- "cpp:TickCtx::call_raw": {
-  "verdict": "divergence",
-  "why": "see `cpp:TickCtx`."
- },
- "cpp:TickCtx::handle": {
-  "verdict": "divergence",
-  "why": "see `cpp:TickCtx`."
- },
- "cpp:TickCtx::send_goal": {
-  "verdict": "divergence",
-  "why": "see `cpp:TickCtx`."
- },
- "cpp:TopicStatisticsState": {
-  "verdict": "declined",
-  "why": "the on/off knob for rclcpp's per-subscription topic statistics, which measure message age and inter-arrival period and PUBLISH them as `statistics_msgs/MetricsMessage`. A user loses built-in latency/period telemetry. The project's answer is RFC-0052's on-target contract monitor instead (`nros::monitor`: a bounded table of specs checked in the executor, violations drained by the app) -- an image cannot afford a second publisher per subscription nor a rolling sample window per topic."
- },
- "cpp:TypeAdapter": {
-  "verdict": "declined",
-  "why": "rclcpp's type adaptation: publish a user's own struct on a topic whose wire type is a generated message, with a `TypeAdapter` specialisation converting between them. A user loses that and converts into the generated type by hand before publishing. Two things stop it being merely undone: the conversion needs somewhere to put the converted message and there is no allocator, and the machinery is template metaprogramming over `std::string`/`std::vector` members that the freestanding, `-fno-exceptions` C++ profile (RFC-0018) does not compile. Neither our C nor our Rust has an equivalent either."
- },
- "cpp:WaitResultKind": {
-  "verdict": "declined",
-  "why": "the `{Ready, Timeout, Empty}` outcome of `WaitSet::wait()`. rclcpp's `Waitable` protocol; see the pubsub stage's `cpp:Waitable::take_data`. RFC-0002's executor drives entities through the RMW vtable, so there is no wait set and no wait result."
- },
- "cpp:adapt_type": {
-  "verdict": "declined",
-  "why": "see `cpp:TypeAdapter`."
- },
- "cpp:add_will_overflow": {
-  "verdict": "declined",
-  "why": "rclcpp's saturating-arithmetic predicates, whose reason to exist is guarding `Time`/`Duration` nanosecond arithmetic against overflow. Our C++ has no clock, time or duration type at all (the timer stage records that; C and Rust both do have one), so there is nothing here for them to guard -- a user loses the guards along with the arithmetic they guard. Not a platform constraint: the check compiles to `__builtin_add_overflow` anywhere."
- },
- "cpp:add_will_underflow": {
-  "verdict": "declined",
-  "why": "see `cpp:add_will_overflow`."
- },
- "cpp:get_c_string": {
-  "verdict": "divergence",
-  "why": "rclcpp's `std::string` -> `const char*` adapter, which exists because rclcpp's API takes `std::string` and rcl takes `const char*`. Our C++ has no such boundary: `nros-cpp` is freestanding with `-fno-exceptions` (RFC-0018) and gates every `<string>` include on `NROS_CPP_STD` (issue 0112), so the API takes `const char*` throughout and there is nothing to adapt."
- },
- "cpp:get_c_vector_string": {
-  "verdict": "divergence",
-  "why": "the same adapter for `std::vector<std::string>` -> `std::vector<const char *>`; neither header is available in the freestanding profile, and the return value allocates. See `cpp:get_c_string`."
- },
- "cpp:global_handle": {
-  "verdict": "extension",
-  "why": "the executor handle behind the free-function `nros::init()` / `nros::spin_once()` convenience path, so a caller using it can still hand an executor to `Future::wait` / `Stream::wait_next` -- which they must, because RFC-0021 makes every blocking helper take the executor. rclcpp needs no equivalent: `spin_until_future_complete` takes a node or executor the caller already holds. Returns `nullptr` before `init()`."
- },
- "cpp:is_type_adapter": {
-  "verdict": "declined",
-  "why": "see `cpp:TypeAdapter`."
- },
- "cpp:sub_will_overflow": {
-  "verdict": "declined",
-  "why": "see `cpp:add_will_overflow`."
- },
- "cpp:sub_will_underflow": {
-  "verdict": "declined",
-  "why": "see `cpp:add_will_overflow`."
- },
- "cpp:to_string": {
-  "verdict": "divergence",
-  "why": "four overloads across rclcpp (`FutureReturnCode`, `ParameterType`, `ParameterValue`) and rclcpp_action (`GoalUUID`), each returning `std::string`. A returned `std::string` allocates, and the freestanding C++ profile has neither the allocator nor `<string>` (RFC-0018, issue 0112). Where a name is genuinely needed our surfaces return a `const char *` or let the caller format into its own buffer."
- },
- "rust:ACTION_SERVER_INTERNAL_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:ACTION_SERVER_RAW_HANDLE_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:AgeMonitorSpec": {
-  "verdict": "extension",
-  "why": "the subscriber-side table: take-age contracts key different endpoints and need no publish counter. See `rust:MonitorSpec`."
- },
- "rust:ArrayValue": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:BaseType": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:BoardTransportConfig": {
-  "verdict": "extension",
-  "why": "the trait a BOARD crate implements so the orchestration generator can write `nros.toml` `[[transport]]` values -- static IPv4, MAC, gateway, baud rate, WiFi SSID/password, NIC list -- into the board's own `Config` (RFC-0049). Every method has a default empty body because a board ignores what it has not got: a wired board ignores `set_ssid`, a board with a fused MAC ignores `set_mac`. rclrs has nothing equivalent because a hosted node inherits an already-configured network stack. Named `BoardTransportConfig` to avoid colliding with the transport-layer `rust:TransportConfig`. Its sibling `BoardConfig` is in the boot stage; the taxonomy split them because only one of the two contains the string `BoardConfig`."
- },
- "rust:BoardTransportConfig::set_baudrate": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoardTransportConfig::set_gateway": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoardTransportConfig::set_interfaces": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoardTransportConfig::set_ipv4": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoardTransportConfig::set_mac": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoardTransportConfig::set_password": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoardTransportConfig::set_ssid": {
-  "verdict": "extension",
-  "why": "see `rust:BoardTransportConfig`."
- },
- "rust:BoundedSequenceValue": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:CPP_ACTION_CLIENT_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:CPP_ACTION_SERVER_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:CallbackEffectKind": {
-  "verdict": "extension",
-  "why": "that relation: Reads / Publishes / Writes. See `rust:CallbackEffectMetadata`."
- },
- "rust:CallbackId": {
-  "verdict": "extension",
-  "why": "the stable source-level identifier a component-mode callback declaration must carry, so the sidecar, the launch model and the image all name the same callback across rebuilds (RFC-0046). rclrs creates entities anonymously at runtime and has nothing to key. Note it is already `#[doc(hidden)]` in the facade, alongside `NodeId` -- which the node stage recorded as an extension for the same reason. machinery `nros::node!` and the generated runtime expand into, not something a user writes -- `node_metadata.rs`'s own first line says \"shared by metadata discovery and generated runtimes\". Issue 0784: it should be `#[doc(hidden)]` as `__private_node_state_into_raw` already is."
- },
- "rust:CallbackId::as_str": {
-  "verdict": "extension",
-  "why": "see `rust:CallbackId`."
- },
- "rust:CallbackId::new": {
-  "verdict": "extension",
-  "why": "see `rust:CallbackId`."
- },
- "rust:DEFAULT": {
-  "verdict": "extension",
-  "why": "the `nros::qos` module's five profile constants, mirroring rmw's `rmw_qos_profile_*` C constants. Const form because a baked entity declaration needs a value usable in a `static` (RFC-0036/0045); rclrs offers only the function form (`QoSProfile::topics_default()`).\nWORTH ACTING ON: our Rust ships the same five profiles TWICE, as these constants and as `QoSProfile::*_default()`, and the two copies DISAGREE on two of them. `nros::qos::SYSTEM_DEFAULT` is `DEFAULT` (KEEP_LAST depth 10) while `QoSProfile::QOS_PROFILE_SYSTEM_DEFAULT` is depth 1; `nros::qos::PARAMETERS` is VOLATILE depth 1000 while `QoSProfile::QOS_PROFILE_PARAMETERS` is TRANSIENT_LOCAL depth 1000. Both claim to match upstream and both cannot; upstream `rmw_qos_profile_parameters` is RELIABLE + VOLATILE + KEEP_LAST(1000), so the constant is right and the associated const is wrong. Phase 379 W5."
- },
- "rust:DEFAULT_MAX_METADATA_CALLBACKS": {
-  "verdict": "extension",
-  "why": "default capacity for callback/effect records in `MetadataRecorder`. Static because there is no allocator; public because a component with more than the default overrides it. See `rust:MetadataRecorder`."
- },
- "rust:DEFAULT_MAX_METADATA_ENTITIES": {
-  "verdict": "extension",
-  "why": "default capacity for entities in `MetadataRecorder`. Static because there is no allocator; public because a component with more than the default overrides it. See `rust:MetadataRecorder`."
- },
- "rust:DEFAULT_MAX_METADATA_NODES": {
-  "verdict": "extension",
-  "why": "default capacity for nodes in `MetadataRecorder`. Static because there is no allocator; public because a component with more than the default overrides it. See `rust:MetadataRecorder`."
- },
- "rust:DOMAIN_ID_EXPLICIT_ZERO_C_ABI": {
-  "verdict": "extension",
-  "why": "255, the C/C++-ABI escape for an EXPLICIT domain 0 (issue 0227). The C init surface carries `domain_id` as a `u8` where `0` means UNSET (defer to env, then the baked macro, then the default), which makes a literal domain 0 unreachable once an image bakes a nonzero default. Since valid domains cap at `DOMAIN_ID_MAX`, 255 is free. rclrs needs no such sentinel: `ROS_DOMAIN_ID` is read from the environment at runtime, and there is no runtime env on an RTOS. See `rust:DOMAIN_ID_MAX`."
- },
- "rust:DOMAIN_ID_MAX": {
-  "verdict": "extension",
-  "why": "232 -- the RTPS port-arithmetic cap on a usable ROS 2 domain. A value above it is a configuration error in EVERY language front-end here, never a silent clamp and never a silent 0 (RFC-0045, issue 0206). rclrs passes the domain to rcl and lets rcl judge; an image bakes it at build time, so the judgement has to be reachable from the resolver. Mirrored into the generated C header -- keep the mirror in sync."
- },
- "rust:DispatchStrategy": {
-  "verdict": "extension",
-  "why": "where a component's callbacks RUN: Inline (the executor's spin loop, the default), Deferred (a framework-owned task -- an RTIC dispatcher or an Embassy task dequeues and drives them), FromIsr (a reserved discriminant, not implemented). A component whose callbacks take RTIC locks must not run them from the spin task, and that is a property of the component, so it is declared with it. rclrs's answer to the same question is a callback group on a multi-threaded executor, which needs threads and a scheduler we do not have (RFC-0002)."
- },
- "rust:DispatchStrategy::from_u8": {
-  "verdict": "extension",
-  "why": "its inverse, `None` for an unknown value so `nros check` can reject it with a diagnostic. See `rust:DispatchStrategy`."
- },
- "rust:DispatchStrategy::to_u8": {
-  "verdict": "extension",
-  "why": "the FFI discriminant the `nros::node!` trampoline `__nros_node_<pkg>_dispatch_strategy` returns. See `rust:DispatchStrategy`."
- },
- "rust:DynamicBoundedSequence": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequence::as_slice": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequence::upper_bound": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequenceMut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequenceMut::as_mut_slice": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequenceMut::as_slice": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequenceMut::clear": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequenceMut::try_reset": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedSequenceMut::upper_bound": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedString": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedString::upper_bound": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedStringMut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedStringMut::try_assign": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedStringMut::upper_bound": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedWString": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedWString::upper_bound": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedWStringMut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedWStringMut::try_assign": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicBoundedWStringMut::upper_bound": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::convert_from_rmw_message": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::convert_into_rmw_message": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::get": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::get_mut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::iter": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::iter_mut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::new": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::structure": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::view": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessage::view_mut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageLibraryCache": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageLibraryCache::get_or_load": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageLibraryCache::unload": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageView": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageView::get": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageView::iter": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageView::structure": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageViewMut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageViewMut::get": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageViewMut::get_mut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageViewMut::iter": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageViewMut::iter_mut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicMessageViewMut::structure": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequence": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequence::as_slice": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequenceMut": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequenceMut::as_mut_slice": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequenceMut::as_slice": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequenceMut::clear": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:DynamicSequenceMut::reset": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:EXECUTOR_SIZE": {
-  "verdict": "extension",
-  "why": "`nros::sizes` -- the SINGLE SOURCE OF TRUTH for FFI opaque-storage sizes. Each entry is `size_of::<T>()` for a Rust type a C or C++ caller declares inline storage for, and each also emits a `__NROS_SIZE_<NAME>` static whose symbol size the `nros-c` / `nros-cpp` build scripts read back to generate the header's storage macros. It exists because our C and C++ APIs put entities in CALLER-OWNED storage -- no allocator, no pimpl -- so the header has to state a byte count, and a hand-written one is the drift class issues 0088/0114/0122/0123/0245/0268 all belong to. rcl has no counterpart: every `rcl_*_t` hides an `impl` pointer it heap-allocates. Visible from Rust only because the module is `pub` for in-crate `const _: () = assert!(...)` checks."
- },
- "rust:EntityId": {
-  "verdict": "extension",
-  "why": "the stable source-level identifier a component-mode entity declaration must carry, so the sidecar, the launch model and the image all name the same entity across rebuilds (RFC-0046). rclrs creates entities anonymously at runtime and has nothing to key. Note it is already `#[doc(hidden)]` in the facade, alongside `NodeId` -- which the node stage recorded as an extension for the same reason. machinery `nros::node!` and the generated runtime expand into, not something a user writes -- `node_metadata.rs`'s own first line says \"shared by metadata discovery and generated runtimes\". Issue 0784: it should be `#[doc(hidden)]` as `__private_node_state_into_raw` already is."
- },
- "rust:EntityId::as_str": {
-  "verdict": "extension",
-  "why": "see `rust:EntityId`."
- },
- "rust:EntityId::new": {
-  "verdict": "extension",
-  "why": "see `rust:EntityId`."
- },
- "rust:EntityKind": {
-  "verdict": "extension",
-  "why": "the entity role recorded for source metadata (Publisher, Subscription, Timer, ServiceServer, ServiceClient, ActionServer, ActionClient, Parameter). See `rust:EntityMetadata`."
- },
- "rust:GUARD_CONDITION_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:IntegrityStatus": {
-  "verdict": "extension",
-  "why": "the per-message verdict `validate` returns: sequence gap, duplicate flag, and CRC state as `Option<bool>` so \"no CRC present\" is distinguishable from \"CRC wrong\". See `rust:SafetyValidator`."
- },
- "rust:IntegrityStatus::is_valid": {
-  "verdict": "extension",
-  "why": "the one-call collapse of those three. See `rust:IntegrityStatus`."
- },
- "rust:IntoPrimitiveOptions": {
-  "verdict": "declined",
-  "why": "rclrs's fluent per-create-site options: `node.create_publisher(\"topic\".keep_last(10).reliable())` builds a `PrimitiveOptions` out of a `&str` and folds it into the entity's QoS. A user loses that spelling AT THE CREATE SITE. QoS and entity options are COMPILE-time here (RFC-0036/0045) -- an entity is declared with a `QoSProfile` const, not with an options value assembled per call -- so there is nothing for the builder to produce. The policy vocabulary itself is not lost: `QoSProfile` carries `keep_last`/`keep_all`/`reliable`/`best_effort`/`volatile`/`transient_local` under exactly these names, plus `deadline_ms`/`lifespan_ms`/`liveliness_kind`/`liveliness_lease_ms`/`avoid_ros_namespace_conventions` as fields. See `rust:QoSProfile`."
- },
- "rust:IntoPrimitiveOptions::avoid_ros_namespace_conventions": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::best_effort": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::into_primitive_options": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::keep_all": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::keep_last": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::reliable": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::transient_local": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:IntoPrimitiveOptions::volatile": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:LIFECYCLE_CTX_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:MAX_RESOLVED_NAME_LEN": {
-  "verdict": "extension",
-  "why": "that bound (128 bytes), matched to `METADATA_STRING_CAPACITY` so a name that entered the seam can always leave it. See `rust:ResolvedName`."
- },
- "rust:METADATA_STRING_CAPACITY": {
-  "verdict": "extension",
-  "why": "that capacity (128 bytes), and the bound `nros_node::names::MAX_RESOLVED_NAME_LEN` is matched to. See `rust:MetadataString`."
- },
- "rust:MessageFieldInfo": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:MessageStructure": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:MessageStructure::get_field_info": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:MessageTypeName": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:MonitorSpec": {
-  "verdict": "extension",
-  "why": "RFC-0052 / phase-296 W3b -- ON-TARGET contract monitors. Codegen emits a `&'static [MonitorSpec]` table plus one `static` counter cell per contracted endpoint from the SystemModel's contract layer; the entry installs it before entity creation, the publish path bumps an atomic (no clock, no lock on the hot path), and the executor checks rate / take-age / node-path latency / deadline-miss on spin ticks and pushes violations into a small ring. An uncontracted image bakes an empty table and every path dead-code-eliminates. ROS 2's answer to the same question is rclcpp's topic statistics plus an external monitor node subscribing to `/statistics` -- a second publisher per subscription and a process that has to be running, neither of which an image has. See `cpp:TopicStatisticsState`."
- },
- "rust:OptUs": {
-  "verdict": "extension",
-  "why": "an optional microsecond field with `0` as the absent sentinel, `#[repr(transparent)]` over `u32`. Not `Option<NonZeroU32>`: the niche optimisation is lost the moment a `#[repr(C)]` struct embeds it, and these fields cross the C ABI where cbindgen must emit a plain `uint32_t`. `0` is physically meaningful for every field it covers -- zero period is infinite frequency, zero budget is unbounded, zero deadline is no deadline. See `rust:SchedClass`."
- },
- "rust:OptUs::from_nz": {
-  "verdict": "extension",
-  "why": "see `rust:OptUs`."
- },
- "rust:OptUs::from_us": {
-  "verdict": "extension",
-  "why": "see `rust:OptUs`."
- },
- "rust:OptUs::get": {
-  "verdict": "extension",
-  "why": "see `rust:OptUs`."
- },
- "rust:OptUs::is_some": {
-  "verdict": "extension",
-  "why": "see `rust:OptUs`."
- },
- "rust:OptUs::raw": {
-  "verdict": "extension",
-  "why": "see `rust:OptUs`."
- },
- "rust:PARAMETERS": {
-  "verdict": "extension",
-  "why": "see `rust:DEFAULT`."
- },
- "rust:PUBLISHER_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:PrimitiveOptions": {
-  "verdict": "declined",
-  "why": "the value `IntoPrimitiveOptions` produces -- a name plus an optional `QoSProfile`. See `rust:IntoPrimitiveOptions`."
- },
- "rust:PrimitiveOptions::apply_to": {
-  "verdict": "declined",
-  "why": "folds the built options into a `QoSProfile`. The equivalent fold exists here and is BAKED rather than per-call: `QoSProfile::apply_overrides`. See `rust:IntoPrimitiveOptions`."
- },
- "rust:PrimitiveOptions::new": {
-  "verdict": "declined",
-  "why": "see `rust:IntoPrimitiveOptions`."
- },
- "rust:Priority": {
-  "verdict": "extension",
-  "why": "the three dispatch buckets -- Critical / Normal / BestEffort -- drained in order within one `spin_once`. Non-preemptive: a running BestEffort callback still blocks Critical work that becomes ready mid-cycle, which is what one task per executor costs. See `rust:SchedClass`."
- },
- "rust:Priority::index": {
-  "verdict": "extension",
-  "why": "see `rust:Priority`."
- },
- "rust:PubMonitorCell": {
-  "verdict": "extension",
-  "why": "one contracted publisher's counters, baked as a `static` so the hot path is an atomic bump. See `rust:MonitorSpec`."
- },
- "rust:PubMonitorCell::new": {
-  "verdict": "extension",
-  "why": "see `rust:PubMonitorCell`."
- },
- "rust:RAW_ACTION_CLIENT_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:RAW_ACTION_SERVER_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:RAW_SERVICE_CLIENT_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:RAW_SERVICE_SERVER_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:RAW_SUBSCRIPTION_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:RawCancelCallback": {
-  "verdict": "extension",
-  "why": "the C-ABI cancel handler an action server registered from C or C++ is driven through: `extern \"C\" fn(&GoalId, GoalStatus) -> CancelResponse`. A raw fn pointer plus a context pointer rather than a boxed closure, because there is no allocator and the executor's callback arena is statically sized. rclrs 0.5.1 has NO action API at all -- not a client, not a server, not a goal type -- so every action item here is unmatched against the Rust reference and is measured against rclcpp_action instead."
- },
- "rust:Rmw": {
-  "verdict": "extension",
-  "why": "the compile-time backend factory a backend crate implements: `open(&RmwConfig) -> Session`. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:Rmw::open": {
-  "verdict": "extension",
-  "why": "see `rust:Rmw`."
- },
- "rust:RmwConfig": {
-  "verdict": "extension",
-  "why": "the middleware-agnostic open parameters (locator, mode, domain, node name, namespace, properties) a backend maps onto its own. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:RmwSession": {
-  "verdict": "extension",
-  "why": "`nros::internals` -- backend-agnostic aliases resolving to the ACTIVE backend's concrete types, and the entry points the C API drives them through. Named `internals` and documented as \"implementation details of the transport backends\", which is the honest half of issue 0784's complaint: the module says what it is, unlike the machinery sitting at the top level of `nros::`. rclrs needs no equivalent because rcl is its only backend and it is resolved at runtime, not by a type alias."
- },
- "rust:RmwSubscriber": {
-  "verdict": "extension",
-  "why": "see `rust:RmwSession`. Note the alias says SUBSCRIBER while the trait it aliases is `Subscription` and the concrete type is `CffiSubscription` -- the same word the node stage flagged in `rust:Node::create_subscriber`. Its siblings `RmwPublisher` / `RmwServiceServer` / `RmwServiceClient` landed in the pubsub and service stages."
- },
- "rust:RosMessage": {
-  "verdict": "extension",
-  "why": "the trait a generated message type implements: `TYPE_NAME`, `TYPE_HASH`, and `STAMP_OFFSET` -- the codegen-const byte offset of `header.stamp.sec` in the serialised payload, so an on-target `max_age` monitor can peek the timestamp out of the raw receive buffer BEFORE deserialising (RFC-0052). rclrs's equivalent is `rosidl_runtime_rs::Message`, which lives in the message crates rather than the client library. Same reasoning and same wording as `rust:RosService` in the service stage."
- },
- "rust:SENSOR_DATA": {
-  "verdict": "extension",
-  "why": "see `rust:DEFAULT`."
- },
- "rust:SERVICES_DEFAULT": {
-  "verdict": "extension",
-  "why": "see `rust:DEFAULT`."
- },
- "rust:SERVICE_CLIENT_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:SERVICE_SERVER_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:SESSION_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:SUBSCRIBER_SIZE": {
-  "verdict": "extension",
-  "why": "see `rust:EXECUTOR_SIZE`."
- },
- "rust:SYSTEM_DEFAULT": {
-  "verdict": "extension",
-  "why": "see `rust:DEFAULT`."
- },
- "rust:SafetyValidator": {
-  "verdict": "extension",
-  "why": "end-to-end message-integrity checking on the SUBSCRIPTION side: a sequence number and a CRC-32/ISO-HDLC travel in the sample's attachment, and the validator reports gap, duplicate and CRC state per message. This is the AUTOSAR E2E / EN 50159 profile, which is what a safety-relevant embedded bus asks for and what a desktop ROS 2 stack does not: rcl trusts the transport, and DDS reliability answers a different question (did the sample arrive) than E2E does (is this the sample the publisher sent, once). Gated on the `safety-e2e` feature; interoperates with non-safety publishers by treating an absent CRC as not-invalid."
- },
- "rust:SafetyValidator::new": {
-  "verdict": "extension",
-  "why": "see `rust:SafetyValidator`."
- },
- "rust:SafetyValidator::reset": {
-  "verdict": "extension",
-  "why": "see `rust:SafetyValidator`."
- },
- "rust:SafetyValidator::validate": {
-  "verdict": "extension",
-  "why": "see `rust:SafetyValidator`."
- },
- "rust:SequenceValue": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:Session": {
-  "verdict": "extension",
-  "why": "the per-process anchor a backend hands the executor; every method takes `&mut self`, which is how the single-threaded-transport contract is expressed in the type system. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:Session::close": {
-  "verdict": "extension",
-  "why": "see `rust:Session`."
- },
- "rust:Session::drive_io": {
-  "verdict": "extension",
-  "why": "the poll the executor calls before dispatching -- required, with no default body, because a silent no-op was a trap for third-party backends. See `rust:Session`."
- },
- "rust:Session::ping_session": {
-  "verdict": "extension",
-  "why": "wire-level connectivity probe, `Unsupported` where the backend has none. Lesson taken from micro-ROS's `rmw_uros_ping_agent`: on a link that can simply go away there is no graph to ask, so an image needs a direct question. See `rust:Session`."
- },
- "rust:Session::set_wake_callback": {
-  "verdict": "extension",
-  "why": "the backend-side half of the wake primitive; see the pubsub stage's `c:subscription_set_wake_callback` for what it buys. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:Session::supports_wake_callback": {
-  "verdict": "extension",
-  "why": "whether the backend actually implements the above, so the executor chooses between a wake-primitive wait and a blocking `drive_io` instead of guessing. Poll-only backends (XRCE, bare-metal smoltcp) return `false`. See `rust:Session::set_wake_callback`."
- },
- "rust:SessionHandle": {
-  "verdict": "extension",
-  "why": "an opaque, `Send` handle to an `Executor`'s RMW session. In the per-tier model the boot executor opens the ONE session and hands each spawned RTOS task a handle -- not a borrow -- so the task can open its own `Executor` over that same session across the task boundary. That is RFC-0053's shape: one transport, several executors, one per task (RFC-0002). rclrs never needs it because its executor is the thing you move. Wrapping the pointer lets a board crate name and move the handle without naming the concrete session type."
- },
- "rust:SessionHandle::from_raw": {
-  "verdict": "extension",
-  "why": "the other end, on the spawned task. Raw because an RTOS task entry point takes a `*mut c_void` and nothing richer. See `rust:SessionHandle`."
- },
- "rust:SessionHandle::into_raw": {
-  "verdict": "extension",
-  "why": "see `rust:SessionHandle`."
- },
- "rust:SessionMode": {
-  "verdict": "extension",
-  "why": "Client (connect to a router) or Peer (direct). A zenoh concept with no rcl counterpart: ROS 2 nodes are always peers of a DDS domain, while an embedded image usually cannot afford peer-mode discovery and connects to `rmw_zenohd` instead (RFC-0075). the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:SessionSpec": {
-  "verdict": "extension",
-  "why": "one backend's declaration for `Executor::open_multi`: which registered RMW to open, at which locator, on which domain. An image may link several backends -- a bridge speaks XRCE to a serial agent and zenoh to a router in the same process -- and each needs its own session. rclrs has one rmw per process, chosen by an environment variable."
- },
- "rust:SessionSpec::domain_id": {
-  "verdict": "extension",
-  "why": "see `rust:SessionSpec`."
- },
- "rust:SessionSpec::new": {
-  "verdict": "extension",
-  "why": "see `rust:SessionSpec`."
- },
- "rust:SimpleValue": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:StatusWatcher": {
-  "verdict": "divergence",
-  "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
- },
- "rust:SubMonitorCell": {
-  "verdict": "extension",
-  "why": "one contracted subscriber's take-age accumulator. The take path peeks `header.stamp` straight out of the raw CDR buffer at `RosMessage::STAMP_OFFSET` and `fetch_max`es the age, so the check costs no deserialization. See `rust:MonitorSpec` and `rust:RosMessage`."
- },
- "rust:SubMonitorCell::new": {
-  "verdict": "extension",
-  "why": "see `rust:SubMonitorCell`."
- },
- "rust:SubMonitorCell::observe": {
-  "verdict": "extension",
-  "why": "see `rust:SubMonitorCell`."
- },
- "rust:TopicInfo": {
-  "verdict": "extension",
-  "why": "the topic descriptor a backend creates an endpoint from: name, type name, type hash, domain, node name and namespace for the liveliness token, plus two embedded-only hints. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:TopicInfo::new": {
-  "verdict": "extension",
-  "why": "see `rust:TopicInfo`."
- },
- "rust:TopicInfo::with_domain": {
-  "verdict": "extension",
-  "why": "see `rust:TopicInfo`."
- },
- "rust:TopicInfo::with_namespace": {
-  "verdict": "extension",
-  "why": "see `rust:TopicInfo`."
- },
- "rust:TopicInfo::with_rx_buffer_hint": {
-  "verdict": "extension",
-  "why": "the subscription's `RX_BUF` passed down so a backend can route it to a size-class receive buffer (zenoh-pico: small vs large). Static receive storage is the constraint -- with no allocator the buffer is chosen at declaration, so the size has to travel with the declaration (RFC-0038). See `rust:TopicInfo`."
- },
- "rust:TopicInfo::with_tx_express": {
-  "verdict": "extension",
-  "why": "the per-endpoint form of `rust:QoSProfile::tx_express`. See `rust:TopicInfo`."
- },
- "rust:Transport": {
-  "verdict": "extension",
-  "why": "a SECOND factory trait beside `rust:Rmw`, differing only in taking `TransportConfig` rather than `RmwConfig`. Exactly one backend implements it (`ZenohTransport` in `nros-rmw-zenoh/src/shim/transport.rs`) while all five implement `Rmw`, and both are re-exported from `nros::`. Worth a decision in W5: two public spellings of \"open a session\" is a choice nobody makes on purpose. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
- },
- "rust:Transport::open": {
-  "verdict": "extension",
-  "why": "see `rust:Transport`."
- },
- "rust:TransportConfig": {
-  "verdict": "extension",
-  "why": "the config `Transport::open` takes -- locator, mode, and free-form key/value properties (`multicast_scouting`, `scouting_timeout_ms`, `listen`). Board crates author it; `RmwConfig` is what the executor opens with. See `rust:Transport`."
- },
- "rust:TransportError": {
-  "verdict": "extension",
-  "why": "the error every backend operation returns, and the payload of `NodeError::Transport` -- which is what a Rust user actually matches on. Its variants name transport preconditions rcl has no vocabulary for (`IncompatibleQos`, `IncompatibleAbi`, `Disconnected`). the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage.\nCORRECTION to issue 0783: that issue says the facade \"exports no way to inspect\" `NodeError` because `TransportError` is not exported. It IS -- `packages/api/nros/src/lib.rs:682` re-exports it unconditionally from `nros_rmw`. What 0783 actually found is that it is missing from the \"Re-export core types\" BLOCK at line 206 and lives in the transport block instead. `RclReturnCode` is genuinely unreachable (types stage, `rust:RclReturnCode`)."
- },
- "rust:Value": {
-  "verdict": "divergence",
-  "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
- },
- "rust:ValueKind": {
-  "verdict": "declined",
-  "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
- },
- "rust:ValueMut": {
-  "verdict": "divergence",
-  "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
- },
- "rust:Violation": {
-  "verdict": "extension",
-  "why": "what the executor pushes into the ring the entry glue drains into the diagnostics reporter. See `rust:MonitorSpec`."
- },
- "rust:arena_size_for": {
-  "verdict": "extension",
-  "why": "per-entry executor arena sizing (phase-271, issue 0110): scales the build-time `ARENA_SIZE` linearly by a caller-chosen callback count, floored at the full default. It replaced a workspace-global `NROS_EXECUTOR_ARENA_SIZE` -- one number every entry in the workspace had to share, so a fat entry and a lean one were sized by whichever was declared louder. The arena exists at all because callback closures are stored INLINE with no allocator; over-provisioning is safe, under-provisioning fails entity creation."
- },
- "rust:baked_domain_from_c_abi": {
-  "verdict": "extension",
-  "why": "maps that `u8` onto the resolver's baked rung: `0` -> None, 255 -> Some(0), else Some(n), with 233..=254 passed through so the resolver rejects them loudly rather than this edge inventing its own validation. See `rust:DOMAIN_ID_EXPLICIT_ZERO_C_ABI`."
- },
- "rust:crc32": {
-  "verdict": "extension",
-  "why": "CRC-32/ISO-HDLC over a byte slice -- the same polynomial AUTOSAR E2E and EN 50159 name, with a `const`-built table so a `no_std` image pays no init. Public because a user who bakes their own attachment has to compute the same value. See `rust:SafetyValidator`."
- },
- "rust:drive_session_io": {
-  "verdict": "extension",
-  "why": "the C API executor's pre-poll hook, delegating to `Session::drive_io`. See `rust:RmwSession` and `rust:Session::drive_io`."
- },
- "rust:force_link_backend": {
-  "verdict": "extension",
-  "why": "a DCE anchor, not a registration (issue 0330). On a pure-Rust staticlib image the Zephyr module emits a WEAK `nros_rmw_<name>_register` and calls it only if it resolves; the strong definition is the backend crate's `#[no_mangle]` export, and rustc's staticlib DCE drops it unless something in the crate being compiled REFERENCES that crate. The symbol is then present in the rlib and absent from the `.a`, the weak call sees NULL, and the image boots with no backend (issues 0155/0163). The app crate invokes it because the app crate is what selects an RMW; nano-ros's own RMW-agnostic layers must not name a backend. rclrs has no equivalent because rcl loads its rmw as a shared object at runtime."
- },
- "rust:get_dynamic_message_package_cache": {
-  "verdict": "divergence",
-  "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
- },
- "rust:open_session": {
-  "verdict": "extension",
-  "why": "opens a backend session behind one signature, honouring the `$NROS_RMW` selector so a C bridge built with two linked backends pins its primary deterministically instead of taking whichever `.init_array` constructor fired first. Used by `nros-c`; Rust callers use `Executor::open`. See `rust:RmwSession`."
- },
- "rust:panic_halt": {
-  "verdict": "extension",
-  "why": "the `panic = \"halt\"` body: mask interrupts through the platform critical section, then spin forever. For an image that must not print -- no formatting, no allocation, no call out to the platform. Masking first is deliberate, so the parked core cannot be woken back into a half-dead system by a timer or a driver ISR still armed from before the panic. A body rather than a re-export of the `panic-halt` crate so choosing it costs the entry no new dependency. See `rust:panic_to_platform`."
- },
- "rust:panic_to_platform": {
-  "verdict": "extension",
-  "why": "emits the image's `#[panic_handler]`, formatting the panic into a 192-byte STACK buffer (never the heap -- the allocator may be exactly what failed) and handing it to `nros_platform_panic`. A `no_std` binary must supply that lang item or it does not link, and rclrs is `std`-only so libstd supplies it there. Normally reached as `nros::main!(panic = \"platform\")`; the macro is the escape hatch for images whose entry cannot carry the item -- a hand-rolled `no_std` binary, or the lib side of a `staticlib` crate. Deliberately NOT emitted invisibly: `#[panic_handler]` is a singleton of the final artifact and images that already declare their own (`esp_backtrace`, `panic-semihosting` with `features = [\"exit\"]` so QEMU exits instead of hanging a test) are right."
- },
- "rust:zephyr_component_main": {
-  "verdict": "extension",
-  "why": "emits Zephyr's `rust_main` for a self-bringup Rust component package: open a Zephyr executor, register the component, spin forever. A framework ENTRY macro, the same category as `nros::main!`, needed because a Zephyr `rust_cargo_application()` image has no `fn main` of its own and there are no POSIX-style constructor sections to register from (see the CLAUDE.md pitfall). Gated on `rmw-cffi` rather than on a platform feature, because it is codegen and its `::zephyr::*` paths resolve only in a zephyr build."
- },
- "rust:RuntimeSizing": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- `ExecutorSizing`'s sibling one layer up: the compile-time size of the node-runtime's slot storage (component slots, registries), as a value, for the same reason -- the backing store is caller-placed `[u64; N]` statics, so 'how big' is a build-time decision the type carries. Knob-driven (`NROS_MAX_COMPONENTS`, `NROS_COMPONENT_SLOT_BYTES`). Public and non-generic so the C ABI can consume it; const generics stay behind the macro (the `ExecutorSizing` rule)."
- },
- "rust:RuntimeSizing::u64_len": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- the `[u64]` word count a caller's static must have to back this sizing; the same contract as `arena_size_for` for the executor arena."
- },
- "rust:Slot": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- one aligned region carved out of a caller-supplied `[u64]` backing store; the unit `carve` hands back. `u64` element type gives 8-byte alignment without `repr(align)` generics."
- },
- "rust:Slot::as_mut_ptr": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- the region's base pointer, for placement writes."
- },
- "rust:Slot::capacity": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- the region's byte length."
- },
- "rust:Slot::fits": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- 'does this Layout fit here' as a checked question; the fail-loud arm is an assert in `carve`, this is the queryable form."
- },
- "rust:carve": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- split a caller's `[u64]` static into `Slot`s per a `RuntimeSizing`; asserts (fail-loud) rather than truncating when the store is too small. No upstream analogue: rcl allocates."
- },
- "rust:COMPONENT_SLOT_BYTES": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- knob-driven const (`NROS_COMPONENT_SLOT_BYTES`, default 512): byte size of one component slot; a class whose state is bigger fails the placement assert loudly at install, not by overflow."
- },
- "rust:ComponentSlotStorage": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- the static a component class places to back its instances: `MAX_CLASS_INSTANCES` slots of `COMPONENT_SLOT_BYTES` each. Macro-emitted per class (`__NROS_COMPONENT_<pkg>_SLOT_STORE`); public so hand-rolled callers can place one too. Non-generic across the C ABI -- C components get theirs from the same macro shape (RFC-0018 component entry)."
- },
- "rust:ComponentSlotStorage::new": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- const constructor so the storage can live in a `static`."
- },
- "rust:MAX_CELL_ENTITIES": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- knob-driven const (`NROS_MAX_CELL_ENTITIES`, default 8): capacity of the heapless per-cell entity registry that replaced the `Vec` one."
- },
- "rust:MAX_CLASS_INSTANCES": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- knob-driven const (`NROS_MAX_CLASS_INSTANCES`, default 2): per-class instance bound sizing each `ComponentSlotStorage`."
- },
- "rust:MAX_COMPONENTS": {
-  "verdict": "extension",
-  "why": "phase-391 W5 -- knob-driven const (`NROS_MAX_COMPONENTS`, default 4): the image-wide component count bound `RuntimeSizing` sizes registries from. Compile-time because embedded images have no allocator to grow past it."
- },
- "rust:DEFAULT_RX_BUF_SIZE": {
-  "verdict": "extension",
-  "why": "phase-392 W3 -- the fallback subscription receive-buffer size when no `rx_buffer_for!`-derived bound is in play; named so the guess is one auditable const instead of scattered literals."
- },
- "rust:rx_buffer_for": {
-  "verdict": "extension",
-  "why": "phase-392 W3 — a subscription receive-buffer size computed from the message schema at compile time (`nros::rx_buffer_for!(Msg)`), so the buffer is sized by the type instead of the NROS_SUBSCRIPTION_BUFFER_SIZE guess. No upstream analogue: rcl sizes nothing statically. Landed unledgered; entry added when check-api-parity caught it one gate into a tier-2 run."
- }
+  "_doc": [
+    "Phase 379. One row per item where the nano-ros user API does NOT correspond",
+    "to the ROS 2 client library it mirrors. Written by hand; read by",
+    "`scripts/api-parity.py --check`, which fails on any non-matching row that has",
+    "no entry here.",
+    "",
+    "Key is '<lang>:<normalized item>' exactly as the report prints it, where lang",
+    "is one of c / cpp / rust. Run the report to get the spelling; do not guess it.",
+    "",
+    "verdict is one of:",
+    "  divergence  we changed it and a PLATFORM CONSTRAINT is why. `why` must name",
+    "              the constraint (no_std, no exceptions, no allocator, no runtime",
+    "              env, single-threaded transport) -- not a preference. This is the",
+    "              only sanctioned reason to differ (RFC-0036).",
+    "  extension   we add it because an RTOS scenario needs it; ROS 2 has none.",
+    "  declined    ROS 2 has it, we deliberately do not, with the reason.",
+    "  gap         ROS 2 has it, we should too, nobody has done it. A gap is a",
+    "              legitimate entry -- the point is that it is written down.",
+    "  rename      the names differ and OURS is the one that should change. A",
+    "              rename with no platform reason costs the drop-in claim for",
+    "              nothing, so these are the campaign's work list.",
+    "",
+    "This file is SEEDED, not complete: W1 shipped the correlator, W2 classifies",
+    "the rest. `--check` is deliberately not wired into `just check` until then --",
+    "a gate that fails on ~2000 rows from the day it lands is one somebody",
+    "switches off. Keys beginning with '_' are documentation and are skipped.",
+    "",
+    "the `<lang>:` rows for its own lane, and `scripts/api-parity.py` merges every",
+    "shard in this directory. One agent per lane can write without a rebase",
+    "conflict against the others.",
+    "",
+    "SHARDED BY TOPIC: this file holds one stage's rows in ALL THREE",
+    "languages, because the campaign closes a feature at a time across every",
+    "language. `scripts/api-parity.py` merges every shard here, and",
+    "`--self-test` rejects a row whose item belongs to a different stage."
+  ],
+  "c:clear_custom_transport": {
+    "verdict": "extension",
+    "why": "see `c:set_custom_transport`; this is `nros_set_custom_transport(NULL)` spelled as a verb."
+  },
+  "c:endpoint_info_visit_fn": {
+    "verdict": "divergence",
+    "why": "phase-381 W3. The ours-half of the `topic_endpoint_info_array_t` divergence this file already records: upstream returns an allocating array, there is no allocator at this seam, and the endpoint count has no bound the CALLER can know. So it streams through a visitor, one entry of peak memory, every string borrowed for the call. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
+  "c:has_custom_transport": {
+    "verdict": "extension",
+    "why": "see `c:set_custom_transport`. Reports whether a vtable is currently installed -- ours and not micro-ROS's, because the slot is process-global and a second `set` silently replaces the first."
+  },
+  "c:heap_peak_bytes": {
+    "verdict": "extension",
+    "why": "peak outstanding bytes since boot -- the figure that actually sizes an arena. See `c:heap_used_bytes`."
+  },
+  "c:heap_platform_used_bytes": {
+    "verdict": "extension",
+    "why": "the port's UNIFIED heap, spanning the Rust global allocator AND the C side (zenoh-pico's `z_malloc`), which is one kernel arena on every port. `nros_heap_used_bytes` sees only the Rust half and says so in its own doc comment, which is why both exist. See `c:heap_used_bytes`."
+  },
+  "c:heap_total_bytes": {
+    "verdict": "extension",
+    "why": "total managed heap (used + free) as the platform reports it, `0` where the port does not instrument its heap -- the denominator the other three are read against. See `c:heap_used_bytes`."
+  },
+  "c:heap_used_bytes": {
+    "verdict": "extension",
+    "why": "bytes currently outstanding through the Rust global allocator. an RTOS image has one fixed heap arena, no swap and no OOM killer, so the size of that arena is a build-time decision someone has to make from a measurement rather than a guess. rcl has nothing equivalent because a hosted process has none of those limits. RFC-0034 D7; gated on the `alloc-stats` feature."
+  },
+  "c:le_slice_view_f32_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_f64_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_i16_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_i32_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_i64_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_u16_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_u32_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:le_slice_view_u64_get": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:platform_critical_section_acquire": {
+    "verdict": "extension",
+    "why": "the platform ABI's IRQ-mask primitive. `nros-c` imports it to register a `critical_section::Impl` for its Rust dependencies (embedded Cyclone, portable-atomic) and to mask interrupts in `nros::panic_halt!`. rcl has no equivalent because a hosted process has no interrupts to mask. Not user API -- see `c:platform_heap_used_bytes` for why it is visible in the generated header at all."
+  },
+  "c:platform_critical_section_release": {
+    "verdict": "extension",
+    "why": "see `c:platform_critical_section_acquire`; takes back the restore token `acquire` returned."
+  },
+  "c:platform_heap_total_bytes": {
+    "verdict": "extension",
+    "why": "see `c:platform_heap_used_bytes`."
+  },
+  "c:platform_heap_used_bytes": {
+    "verdict": "extension",
+    "why": "NOT user API: this is the PLATFORM ABI (`nros/platform.h`, RFC-0034) that `nros-c` IMPORTS, and it reaches `nros_generated.h` only because cbindgen echoes the `unsafe extern \"C\"` block that declares it. The header already distinguishes them -- unlike every entry point beside them, the four `nros_platform_*` declarations carry no `NROS_PUBLIC` and no doc comment. A user calls `nros_heap_platform_used_bytes`; a PORT implements this. Same layering complaint one language over as `rust:Session::create_publisher`."
+  },
+  "c:set_custom_transport": {
+    "verdict": "extension",
+    "why": "runtime-pluggable transport vtable (`nros_transport_ops_t`: abi_version + open/close/write/read + `user_data`). An RTOS image often reaches the network over a link ROS 2 never sees -- USB-CDC, BLE, RS-485, a semihosting bridge -- and which one is a board fact decided after the library is built, so the hook has to be a runtime call rather than a link-time backend choice. rcl has no transport concept at all (rmw is selected at link time); the nearest thing anywhere is micro-ROS's `rmw_uros_set_custom_transport`, which this deliberately mirrors. Fn pointers rather than a trait object because a `Box<dyn>` would force `alloc` on every no_std port (`nros-rmw/src/custom_transport.rs`)."
+  },
+  "c:wake_state_get_zero_initialized": {
+    "verdict": "extension",
+    "why": "rcl's zero-init idiom under our naming, applied to the caller-owned `nros_wake_state_t` slot a polling entity's wake callback is registered with. Naming: see `c:publisher_get_zero_initialized` in the pubsub stage (ours is method-style `nros_<thing>_get_zero_initialized` at all 15 sites, rcl's is `rcl_get_zero_initialized_<thing>`); the slot itself: see `c:service_set_wake_callback`."
+  },
+  "cpp:ContentFilterOptions": {
+    "verdict": "declined",
+    "why": "content-filtered topics are a DDS feature: the subscriber ships an SQL-ish expression the WRITER evaluates. Only one of our backends is DDS, and the filter would have to be a no-op on zenoh and XRCE -- a QoS-shaped promise two of three transports cannot keep. Same reasoning `rmw-api-parity.py` already records for `rmw_*_content_filter`."
+  },
+  "cpp:ImplicitTypeAdapter": {
+    "verdict": "declined",
+    "why": "see `cpp:TypeAdapter`."
+  },
+  "cpp:SignalHandlerOptions": {
+    "verdict": "declined",
+    "why": "rclcpp's selector for WHICH signal handlers `rclcpp::init` installs. We install none: see `cpp:install_signal_handlers` in the init stage -- there is no POSIX signal delivery on Zephyr, FreeRTOS or bare-metal, and an image is stopped by its RTOS, a watchdog or a power rail."
+  },
+  "cpp:State": {
+    "verdict": "divergence",
+    "why": "`rclcpp_lifecycle::State` is a CLASS wrapping `rcl_lifecycle_state_t` -- an id, a heap-allocated `label` string, and the `rcl_allocator_t` that owns it. Ours is `cpp:LifecycleState`, a `uint8_t`-backed `enum class` over the five REP-2002 primary states plus an `Unknown = 0` sentinel: with no allocator there is nothing to own the label, and the id is the whole of what the state machine actually compares. See `cpp:LifecycleState` in the lifecycle stage for the ours-only half."
+  },
+  "cpp:State::State": {
+    "verdict": "divergence",
+    "why": "no constructor, because ours is an enum rather than a class. See `cpp:State`."
+  },
+  "cpp:State::id": {
+    "verdict": "divergence",
+    "why": "the value IS the enum in ours (`cpp:LifecycleState`), so there is nothing for an accessor to unwrap. See `cpp:State`."
+  },
+  "cpp:State::label": {
+    "verdict": "gap",
+    "why": "the human-readable state name (`\"unconfigured\"`, `\"active\"`). Not a divergence: a `const char* to_string(LifecycleState)` over five static literals costs an image almost nothing and needs no allocator -- nobody has written one. A C++ caller that wants to print a lifecycle state today has to switch on the enum itself. Same shape as `cpp:Transition` in the lifecycle stage. Phase 379 W3."
+  },
+  "cpp:Stream": {
+    "verdict": "divergence",
+    "why": "multi-shot receiver for polling subscriptions and action feedback: `try_next` polls, `wait_next` drives the executor until a value arrives or a wall-clock budget expires. rclcpp has no stream type because it delivers multi-shot data through a subscription callback and single-shot through `std::shared_future`; `<future>` needs threads, an allocator and exceptions, and none of the three is here. Same constraint and same shape as `cpp:Future` in the types stage -- RFC-0021: no futures, no async runtime, every blocking helper takes the executor."
+  },
+  "cpp:Stream::Stream<T>": {
+    "verdict": "divergence",
+    "why": "see `cpp:Stream`."
+  },
+  "cpp:Stream::is_valid": {
+    "verdict": "divergence",
+    "why": "see `cpp:Stream`."
+  },
+  "cpp:Stream::try_next": {
+    "verdict": "divergence",
+    "why": "see `cpp:Stream`."
+  },
+  "cpp:Stream::wait_next": {
+    "verdict": "divergence",
+    "why": "see `cpp:Stream`."
+  },
+  "cpp:TickCtx::TickCtx": {
+    "verdict": "divergence",
+    "why": "see `cpp:TickCtx`."
+  },
+  "cpp:TickCtx::call": {
+    "verdict": "divergence",
+    "why": "see `cpp:TickCtx`."
+  },
+  "cpp:TickCtx::call_raw": {
+    "verdict": "divergence",
+    "why": "see `cpp:TickCtx`."
+  },
+  "cpp:TickCtx::handle": {
+    "verdict": "divergence",
+    "why": "see `cpp:TickCtx`."
+  },
+  "cpp:TickCtx::send_goal": {
+    "verdict": "divergence",
+    "why": "see `cpp:TickCtx`."
+  },
+  "cpp:TopicStatisticsState": {
+    "verdict": "declined",
+    "why": "the on/off knob for rclcpp's per-subscription topic statistics, which measure message age and inter-arrival period and PUBLISH them as `statistics_msgs/MetricsMessage`. A user loses built-in latency/period telemetry. The project's answer is RFC-0052's on-target contract monitor instead (`nros::monitor`: a bounded table of specs checked in the executor, violations drained by the app) -- an image cannot afford a second publisher per subscription nor a rolling sample window per topic."
+  },
+  "cpp:TypeAdapter": {
+    "verdict": "declined",
+    "why": "rclcpp's type adaptation: publish a user's own struct on a topic whose wire type is a generated message, with a `TypeAdapter` specialisation converting between them. A user loses that and converts into the generated type by hand before publishing. Two things stop it being merely undone: the conversion needs somewhere to put the converted message and there is no allocator, and the machinery is template metaprogramming over `std::string`/`std::vector` members that the freestanding, `-fno-exceptions` C++ profile (RFC-0018) does not compile. Neither our C nor our Rust has an equivalent either."
+  },
+  "cpp:WaitResultKind": {
+    "verdict": "declined",
+    "why": "the `{Ready, Timeout, Empty}` outcome of `WaitSet::wait()`. rclcpp's `Waitable` protocol; see the pubsub stage's `cpp:Waitable::take_data`. RFC-0002's executor drives entities through the RMW vtable, so there is no wait set and no wait result."
+  },
+  "cpp:adapt_type": {
+    "verdict": "declined",
+    "why": "see `cpp:TypeAdapter`."
+  },
+  "cpp:add_will_overflow": {
+    "verdict": "declined",
+    "why": "rclcpp's saturating-arithmetic predicates, whose reason to exist is guarding `Time`/`Duration` nanosecond arithmetic against overflow. Our C++ has no clock, time or duration type at all (the timer stage records that; C and Rust both do have one), so there is nothing here for them to guard -- a user loses the guards along with the arithmetic they guard. Not a platform constraint: the check compiles to `__builtin_add_overflow` anywhere."
+  },
+  "cpp:add_will_underflow": {
+    "verdict": "declined",
+    "why": "see `cpp:add_will_overflow`."
+  },
+  "cpp:get_c_string": {
+    "verdict": "divergence",
+    "why": "rclcpp's `std::string` -> `const char*` adapter, which exists because rclcpp's API takes `std::string` and rcl takes `const char*`. Our C++ has no such boundary: `nros-cpp` is freestanding with `-fno-exceptions` (RFC-0018) and gates every `<string>` include on `NROS_CPP_STD` (issue 0112), so the API takes `const char*` throughout and there is nothing to adapt."
+  },
+  "cpp:get_c_vector_string": {
+    "verdict": "divergence",
+    "why": "the same adapter for `std::vector<std::string>` -> `std::vector<const char *>`; neither header is available in the freestanding profile, and the return value allocates. See `cpp:get_c_string`."
+  },
+  "cpp:global_handle": {
+    "verdict": "extension",
+    "why": "the executor handle behind the free-function `nros::init()` / `nros::spin_once()` convenience path, so a caller using it can still hand an executor to `Future::wait` / `Stream::wait_next` -- which they must, because RFC-0021 makes every blocking helper take the executor. rclcpp needs no equivalent: `spin_until_future_complete` takes a node or executor the caller already holds. Returns `nullptr` before `init()`."
+  },
+  "cpp:is_type_adapter": {
+    "verdict": "declined",
+    "why": "see `cpp:TypeAdapter`."
+  },
+  "cpp:sub_will_overflow": {
+    "verdict": "declined",
+    "why": "see `cpp:add_will_overflow`."
+  },
+  "cpp:sub_will_underflow": {
+    "verdict": "declined",
+    "why": "see `cpp:add_will_overflow`."
+  },
+  "cpp:to_string": {
+    "verdict": "divergence",
+    "why": "four overloads across rclcpp (`FutureReturnCode`, `ParameterType`, `ParameterValue`) and rclcpp_action (`GoalUUID`), each returning `std::string`. A returned `std::string` allocates, and the freestanding C++ profile has neither the allocator nor `<string>` (RFC-0018, issue 0112). Where a name is genuinely needed our surfaces return a `const char *` or let the caller format into its own buffer."
+  },
+  "rust:ACTION_SERVER_INTERNAL_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:ACTION_SERVER_RAW_HANDLE_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:AgeMonitorSpec": {
+    "verdict": "extension",
+    "why": "the subscriber-side table: take-age contracts key different endpoints and need no publish counter. See `rust:MonitorSpec`."
+  },
+  "rust:ArrayValue": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:BaseType": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:BoardTransportConfig": {
+    "verdict": "extension",
+    "why": "the trait a BOARD crate implements so the orchestration generator can write `nros.toml` `[[transport]]` values -- static IPv4, MAC, gateway, baud rate, WiFi SSID/password, NIC list -- into the board's own `Config` (RFC-0049). Every method has a default empty body because a board ignores what it has not got: a wired board ignores `set_ssid`, a board with a fused MAC ignores `set_mac`. rclrs has nothing equivalent because a hosted node inherits an already-configured network stack. Named `BoardTransportConfig` to avoid colliding with the transport-layer `rust:TransportConfig`. Its sibling `BoardConfig` is in the boot stage; the taxonomy split them because only one of the two contains the string `BoardConfig`."
+  },
+  "rust:BoardTransportConfig::set_baudrate": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoardTransportConfig::set_gateway": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoardTransportConfig::set_interfaces": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoardTransportConfig::set_ipv4": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoardTransportConfig::set_mac": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoardTransportConfig::set_password": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoardTransportConfig::set_ssid": {
+    "verdict": "extension",
+    "why": "see `rust:BoardTransportConfig`."
+  },
+  "rust:BoundedSequenceValue": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:COMPONENT_SLOT_BYTES": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- knob-driven const (`NROS_COMPONENT_SLOT_BYTES`, default 512): byte size of one component slot; a class whose state is bigger fails the placement assert loudly at install, not by overflow."
+  },
+  "rust:CPP_ACTION_CLIENT_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:CPP_ACTION_SERVER_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:CallbackEffectKind": {
+    "verdict": "extension",
+    "why": "that relation: Reads / Publishes / Writes. See `rust:CallbackEffectMetadata`."
+  },
+  "rust:CallbackId": {
+    "verdict": "extension",
+    "why": "the stable source-level identifier a component-mode callback declaration must carry, so the sidecar, the launch model and the image all name the same callback across rebuilds (RFC-0046). rclrs creates entities anonymously at runtime and has nothing to key. Note it is already `#[doc(hidden)]` in the facade, alongside `NodeId` -- which the node stage recorded as an extension for the same reason. machinery `nros::node!` and the generated runtime expand into, not something a user writes -- `node_metadata.rs`'s own first line says \"shared by metadata discovery and generated runtimes\". Issue 0784: it should be `#[doc(hidden)]` as `__private_node_state_into_raw` already is."
+  },
+  "rust:CallbackId::as_str": {
+    "verdict": "extension",
+    "why": "see `rust:CallbackId`."
+  },
+  "rust:CallbackId::new": {
+    "verdict": "extension",
+    "why": "see `rust:CallbackId`."
+  },
+  "rust:ComponentSlotStorage": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- the static a component class places to back its instances: `MAX_CLASS_INSTANCES` slots of `COMPONENT_SLOT_BYTES` each. Macro-emitted per class (`__NROS_COMPONENT_<pkg>_SLOT_STORE`); public so hand-rolled callers can place one too. Non-generic across the C ABI -- C components get theirs from the same macro shape (RFC-0018 component entry)."
+  },
+  "rust:ComponentSlotStorage::new": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- const constructor so the storage can live in a `static`."
+  },
+  "rust:DEFAULT": {
+    "verdict": "extension",
+    "why": "the `nros::qos` module's five profile constants, mirroring rmw's `rmw_qos_profile_*` C constants. Const form because a baked entity declaration needs a value usable in a `static` (RFC-0036/0045); rclrs offers only the function form (`QoSProfile::topics_default()`).\nWORTH ACTING ON: our Rust ships the same five profiles TWICE, as these constants and as `QoSProfile::*_default()`, and the two copies DISAGREE on two of them. `nros::qos::SYSTEM_DEFAULT` is `DEFAULT` (KEEP_LAST depth 10) while `QoSProfile::QOS_PROFILE_SYSTEM_DEFAULT` is depth 1; `nros::qos::PARAMETERS` is VOLATILE depth 1000 while `QoSProfile::QOS_PROFILE_PARAMETERS` is TRANSIENT_LOCAL depth 1000. Both claim to match upstream and both cannot; upstream `rmw_qos_profile_parameters` is RELIABLE + VOLATILE + KEEP_LAST(1000), so the constant is right and the associated const is wrong. Phase 379 W5."
+  },
+  "rust:DEFAULT_MAX_METADATA_CALLBACKS": {
+    "verdict": "extension",
+    "why": "default capacity for callback/effect records in `MetadataRecorder`. Static because there is no allocator; public because a component with more than the default overrides it. See `rust:MetadataRecorder`."
+  },
+  "rust:DEFAULT_MAX_METADATA_ENTITIES": {
+    "verdict": "extension",
+    "why": "default capacity for entities in `MetadataRecorder`. Static because there is no allocator; public because a component with more than the default overrides it. See `rust:MetadataRecorder`."
+  },
+  "rust:DEFAULT_MAX_METADATA_NODES": {
+    "verdict": "extension",
+    "why": "default capacity for nodes in `MetadataRecorder`. Static because there is no allocator; public because a component with more than the default overrides it. See `rust:MetadataRecorder`."
+  },
+  "rust:DEFAULT_RX_BUF_SIZE": {
+    "verdict": "extension",
+    "why": "phase-392 W3 -- the fallback subscription receive-buffer size when no `rx_buffer_for!`-derived bound is in play; named so the guess is one auditable const instead of scattered literals."
+  },
+  "rust:DOMAIN_ID_EXPLICIT_ZERO_C_ABI": {
+    "verdict": "extension",
+    "why": "255, the C/C++-ABI escape for an EXPLICIT domain 0 (issue 0227). The C init surface carries `domain_id` as a `u8` where `0` means UNSET (defer to env, then the baked macro, then the default), which makes a literal domain 0 unreachable once an image bakes a nonzero default. Since valid domains cap at `DOMAIN_ID_MAX`, 255 is free. rclrs needs no such sentinel: `ROS_DOMAIN_ID` is read from the environment at runtime, and there is no runtime env on an RTOS. See `rust:DOMAIN_ID_MAX`."
+  },
+  "rust:DOMAIN_ID_MAX": {
+    "verdict": "extension",
+    "why": "232 -- the RTPS port-arithmetic cap on a usable ROS 2 domain. A value above it is a configuration error in EVERY language front-end here, never a silent clamp and never a silent 0 (RFC-0045, issue 0206). rclrs passes the domain to rcl and lets rcl judge; an image bakes it at build time, so the judgement has to be reachable from the resolver. Mirrored into the generated C header -- keep the mirror in sync."
+  },
+  "rust:DispatchStrategy": {
+    "verdict": "extension",
+    "why": "where a component's callbacks RUN: Inline (the executor's spin loop, the default), Deferred (a framework-owned task -- an RTIC dispatcher or an Embassy task dequeues and drives them), FromIsr (a reserved discriminant, not implemented). A component whose callbacks take RTIC locks must not run them from the spin task, and that is a property of the component, so it is declared with it. rclrs's answer to the same question is a callback group on a multi-threaded executor, which needs threads and a scheduler we do not have (RFC-0002)."
+  },
+  "rust:DispatchStrategy::from_u8": {
+    "verdict": "extension",
+    "why": "its inverse, `None` for an unknown value so `nros check` can reject it with a diagnostic. See `rust:DispatchStrategy`."
+  },
+  "rust:DispatchStrategy::to_u8": {
+    "verdict": "extension",
+    "why": "the FFI discriminant the `nros::node!` trampoline `__nros_node_<pkg>_dispatch_strategy` returns. See `rust:DispatchStrategy`."
+  },
+  "rust:DynamicBoundedSequence": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequence::as_slice": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequence::upper_bound": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequenceMut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequenceMut::as_mut_slice": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequenceMut::as_slice": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequenceMut::clear": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequenceMut::try_reset": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedSequenceMut::upper_bound": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedString": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedString::upper_bound": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedStringMut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedStringMut::try_assign": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedStringMut::upper_bound": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedWString": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedWString::upper_bound": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedWStringMut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedWStringMut::try_assign": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicBoundedWStringMut::upper_bound": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::convert_from_rmw_message": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::convert_into_rmw_message": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::get": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::get_mut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::iter": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::iter_mut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::new": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::structure": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::view": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessage::view_mut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageLibraryCache": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageLibraryCache::get_or_load": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageLibraryCache::unload": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageView": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageView::get": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageView::iter": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageView::structure": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageViewMut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageViewMut::get": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageViewMut::get_mut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageViewMut::iter": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageViewMut::iter_mut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicMessageViewMut::structure": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequence": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequence::as_slice": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequenceMut": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequenceMut::as_mut_slice": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequenceMut::as_slice": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequenceMut::clear": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:DynamicSequenceMut::reset": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:EXECUTOR_SIZE": {
+    "verdict": "extension",
+    "why": "`nros::sizes` -- the SINGLE SOURCE OF TRUTH for FFI opaque-storage sizes. Each entry is `size_of::<T>()` for a Rust type a C or C++ caller declares inline storage for, and each also emits a `__NROS_SIZE_<NAME>` static whose symbol size the `nros-c` / `nros-cpp` build scripts read back to generate the header's storage macros. It exists because our C and C++ APIs put entities in CALLER-OWNED storage -- no allocator, no pimpl -- so the header has to state a byte count, and a hand-written one is the drift class issues 0088/0114/0122/0123/0245/0268 all belong to. rcl has no counterpart: every `rcl_*_t` hides an `impl` pointer it heap-allocates. Visible from Rust only because the module is `pub` for in-crate `const _: () = assert!(...)` checks."
+  },
+  "rust:EntityId": {
+    "verdict": "extension",
+    "why": "the stable source-level identifier a component-mode entity declaration must carry, so the sidecar, the launch model and the image all name the same entity across rebuilds (RFC-0046). rclrs creates entities anonymously at runtime and has nothing to key. Note it is already `#[doc(hidden)]` in the facade, alongside `NodeId` -- which the node stage recorded as an extension for the same reason. machinery `nros::node!` and the generated runtime expand into, not something a user writes -- `node_metadata.rs`'s own first line says \"shared by metadata discovery and generated runtimes\". Issue 0784: it should be `#[doc(hidden)]` as `__private_node_state_into_raw` already is."
+  },
+  "rust:EntityId::as_str": {
+    "verdict": "extension",
+    "why": "see `rust:EntityId`."
+  },
+  "rust:EntityId::new": {
+    "verdict": "extension",
+    "why": "see `rust:EntityId`."
+  },
+  "rust:EntityKind": {
+    "verdict": "extension",
+    "why": "the entity role recorded for source metadata (Publisher, Subscription, Timer, ServiceServer, ServiceClient, ActionServer, ActionClient, Parameter). See `rust:EntityMetadata`."
+  },
+  "rust:GUARD_CONDITION_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:IntegrityStatus": {
+    "verdict": "extension",
+    "why": "the per-message verdict `validate` returns: sequence gap, duplicate flag, and CRC state as `Option<bool>` so \"no CRC present\" is distinguishable from \"CRC wrong\". See `rust:SafetyValidator`."
+  },
+  "rust:IntegrityStatus::is_valid": {
+    "verdict": "extension",
+    "why": "the one-call collapse of those three. See `rust:IntegrityStatus`."
+  },
+  "rust:IntoPrimitiveOptions": {
+    "verdict": "declined",
+    "why": "rclrs's fluent per-create-site options: `node.create_publisher(\"topic\".keep_last(10).reliable())` builds a `PrimitiveOptions` out of a `&str` and folds it into the entity's QoS. A user loses that spelling AT THE CREATE SITE. QoS and entity options are COMPILE-time here (RFC-0036/0045) -- an entity is declared with a `QoSProfile` const, not with an options value assembled per call -- so there is nothing for the builder to produce. The policy vocabulary itself is not lost: `QoSProfile` carries `keep_last`/`keep_all`/`reliable`/`best_effort`/`volatile`/`transient_local` under exactly these names, plus `deadline_ms`/`lifespan_ms`/`liveliness_kind`/`liveliness_lease_ms`/`avoid_ros_namespace_conventions` as fields. See `rust:QoSProfile`."
+  },
+  "rust:IntoPrimitiveOptions::avoid_ros_namespace_conventions": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::best_effort": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::into_primitive_options": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::keep_all": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::keep_last": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::reliable": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::transient_local": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:IntoPrimitiveOptions::volatile": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:LIFECYCLE_CTX_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:MAX_CELL_ENTITIES": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- knob-driven const (`NROS_MAX_CELL_ENTITIES`, default 8): capacity of the heapless per-cell entity registry that replaced the `Vec` one."
+  },
+  "rust:MAX_CLASS_INSTANCES": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- knob-driven const (`NROS_MAX_CLASS_INSTANCES`, default 2): per-class instance bound sizing each `ComponentSlotStorage`."
+  },
+  "rust:MAX_COMPONENTS": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- knob-driven const (`NROS_MAX_COMPONENTS`, default 4): the image-wide component count bound `RuntimeSizing` sizes registries from. Compile-time because embedded images have no allocator to grow past it."
+  },
+  "rust:MAX_RESOLVED_NAME_LEN": {
+    "verdict": "extension",
+    "why": "that bound (128 bytes), matched to `METADATA_STRING_CAPACITY` so a name that entered the seam can always leave it. See `rust:ResolvedName`."
+  },
+  "rust:METADATA_STRING_CAPACITY": {
+    "verdict": "extension",
+    "why": "that capacity (128 bytes), and the bound `nros_node::names::MAX_RESOLVED_NAME_LEN` is matched to. See `rust:MetadataString`."
+  },
+  "rust:MessageFieldInfo": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:MessageStructure": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:MessageStructure::get_field_info": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:MessageTypeName": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:MonitorSpec": {
+    "verdict": "extension",
+    "why": "RFC-0052 / phase-296 W3b -- ON-TARGET contract monitors. Codegen emits a `&'static [MonitorSpec]` table plus one `static` counter cell per contracted endpoint from the SystemModel's contract layer; the entry installs it before entity creation, the publish path bumps an atomic (no clock, no lock on the hot path), and the executor checks rate / take-age / node-path latency / deadline-miss on spin ticks and pushes violations into a small ring. An uncontracted image bakes an empty table and every path dead-code-eliminates. ROS 2's answer to the same question is rclcpp's topic statistics plus an external monitor node subscribing to `/statistics` -- a second publisher per subscription and a process that has to be running, neither of which an image has. See `cpp:TopicStatisticsState`."
+  },
+  "rust:OptUs": {
+    "verdict": "extension",
+    "why": "an optional microsecond field with `0` as the absent sentinel, `#[repr(transparent)]` over `u32`. Not `Option<NonZeroU32>`: the niche optimisation is lost the moment a `#[repr(C)]` struct embeds it, and these fields cross the C ABI where cbindgen must emit a plain `uint32_t`. `0` is physically meaningful for every field it covers -- zero period is infinite frequency, zero budget is unbounded, zero deadline is no deadline. See `rust:SchedClass`."
+  },
+  "rust:OptUs::from_nz": {
+    "verdict": "extension",
+    "why": "see `rust:OptUs`."
+  },
+  "rust:OptUs::from_us": {
+    "verdict": "extension",
+    "why": "see `rust:OptUs`."
+  },
+  "rust:OptUs::get": {
+    "verdict": "extension",
+    "why": "see `rust:OptUs`."
+  },
+  "rust:OptUs::is_some": {
+    "verdict": "extension",
+    "why": "see `rust:OptUs`."
+  },
+  "rust:OptUs::raw": {
+    "verdict": "extension",
+    "why": "see `rust:OptUs`."
+  },
+  "rust:PARAMETERS": {
+    "verdict": "extension",
+    "why": "see `rust:DEFAULT`."
+  },
+  "rust:PUBLISHER_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:PrimitiveOptions": {
+    "verdict": "declined",
+    "why": "the value `IntoPrimitiveOptions` produces -- a name plus an optional `QoSProfile`. See `rust:IntoPrimitiveOptions`."
+  },
+  "rust:PrimitiveOptions::apply_to": {
+    "verdict": "declined",
+    "why": "folds the built options into a `QoSProfile`. The equivalent fold exists here and is BAKED rather than per-call: `QoSProfile::apply_overrides`. See `rust:IntoPrimitiveOptions`."
+  },
+  "rust:PrimitiveOptions::new": {
+    "verdict": "declined",
+    "why": "see `rust:IntoPrimitiveOptions`."
+  },
+  "rust:Priority": {
+    "verdict": "extension",
+    "why": "the three dispatch buckets -- Critical / Normal / BestEffort -- drained in order within one `spin_once`. Non-preemptive: a running BestEffort callback still blocks Critical work that becomes ready mid-cycle, which is what one task per executor costs. See `rust:SchedClass`."
+  },
+  "rust:Priority::index": {
+    "verdict": "extension",
+    "why": "see `rust:Priority`."
+  },
+  "rust:PubMonitorCell": {
+    "verdict": "extension",
+    "why": "one contracted publisher's counters, baked as a `static` so the hot path is an atomic bump. See `rust:MonitorSpec`."
+  },
+  "rust:PubMonitorCell::new": {
+    "verdict": "extension",
+    "why": "see `rust:PubMonitorCell`."
+  },
+  "rust:RAW_ACTION_CLIENT_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:RAW_ACTION_SERVER_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:RAW_SERVICE_CLIENT_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:RAW_SERVICE_SERVER_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:RAW_SUBSCRIPTION_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:RawCancelCallback": {
+    "verdict": "extension",
+    "why": "the C-ABI cancel handler an action server registered from C or C++ is driven through: `extern \"C\" fn(&GoalId, GoalStatus) -> CancelResponse`. A raw fn pointer plus a context pointer rather than a boxed closure, because there is no allocator and the executor's callback arena is statically sized. rclrs 0.5.1 has NO action API at all -- not a client, not a server, not a goal type -- so every action item here is unmatched against the Rust reference and is measured against rclcpp_action instead."
+  },
+  "rust:Rmw": {
+    "verdict": "extension",
+    "why": "the compile-time backend factory a backend crate implements: `open(&RmwConfig) -> Session`. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:Rmw::open": {
+    "verdict": "extension",
+    "why": "see `rust:Rmw`."
+  },
+  "rust:RmwConfig": {
+    "verdict": "extension",
+    "why": "the middleware-agnostic open parameters (locator, mode, domain, node name, namespace, properties) a backend maps onto its own. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:RmwSession": {
+    "verdict": "extension",
+    "why": "`nros::internals` -- backend-agnostic aliases resolving to the ACTIVE backend's concrete types, and the entry points the C API drives them through. Named `internals` and documented as \"implementation details of the transport backends\", which is the honest half of issue 0784's complaint: the module says what it is, unlike the machinery sitting at the top level of `nros::`. rclrs needs no equivalent because rcl is its only backend and it is resolved at runtime, not by a type alias."
+  },
+  "rust:RmwSubscriber": {
+    "verdict": "extension",
+    "why": "see `rust:RmwSession`. Note the alias says SUBSCRIBER while the trait it aliases is `Subscription` and the concrete type is `CffiSubscription` -- the same word the node stage flagged in `rust:Node::create_subscriber`. Its siblings `RmwPublisher` / `RmwServiceServer` / `RmwServiceClient` landed in the pubsub and service stages."
+  },
+  "rust:RosMessage": {
+    "verdict": "extension",
+    "why": "the trait a generated message type implements: `TYPE_NAME`, `TYPE_HASH`, and `STAMP_OFFSET` -- the codegen-const byte offset of `header.stamp.sec` in the serialised payload, so an on-target `max_age` monitor can peek the timestamp out of the raw receive buffer BEFORE deserialising (RFC-0052). rclrs's equivalent is `rosidl_runtime_rs::Message`, which lives in the message crates rather than the client library. Same reasoning and same wording as `rust:RosService` in the service stage."
+  },
+  "rust:RuntimeSizing": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- `ExecutorSizing`'s sibling one layer up: the compile-time size of the node-runtime's slot storage (component slots, registries), as a value, for the same reason -- the backing store is caller-placed `[u64; N]` statics, so 'how big' is a build-time decision the type carries. Knob-driven (`NROS_MAX_COMPONENTS`, `NROS_COMPONENT_SLOT_BYTES`). Public and non-generic so the C ABI can consume it; const generics stay behind the macro (the `ExecutorSizing` rule)."
+  },
+  "rust:RuntimeSizing::u64_len": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- the `[u64]` word count a caller's static must have to back this sizing; the same contract as `arena_size_for` for the executor arena."
+  },
+  "rust:SENSOR_DATA": {
+    "verdict": "extension",
+    "why": "see `rust:DEFAULT`."
+  },
+  "rust:SERVICES_DEFAULT": {
+    "verdict": "extension",
+    "why": "see `rust:DEFAULT`."
+  },
+  "rust:SERVICE_CLIENT_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:SERVICE_SERVER_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:SESSION_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:SUBSCRIBER_SIZE": {
+    "verdict": "extension",
+    "why": "see `rust:EXECUTOR_SIZE`."
+  },
+  "rust:SYSTEM_DEFAULT": {
+    "verdict": "extension",
+    "why": "see `rust:DEFAULT`."
+  },
+  "rust:SafetyValidator": {
+    "verdict": "extension",
+    "why": "end-to-end message-integrity checking on the SUBSCRIPTION side: a sequence number and a CRC-32/ISO-HDLC travel in the sample's attachment, and the validator reports gap, duplicate and CRC state per message. This is the AUTOSAR E2E / EN 50159 profile, which is what a safety-relevant embedded bus asks for and what a desktop ROS 2 stack does not: rcl trusts the transport, and DDS reliability answers a different question (did the sample arrive) than E2E does (is this the sample the publisher sent, once). Gated on the `safety-e2e` feature; interoperates with non-safety publishers by treating an absent CRC as not-invalid."
+  },
+  "rust:SafetyValidator::new": {
+    "verdict": "extension",
+    "why": "see `rust:SafetyValidator`."
+  },
+  "rust:SafetyValidator::reset": {
+    "verdict": "extension",
+    "why": "see `rust:SafetyValidator`."
+  },
+  "rust:SafetyValidator::validate": {
+    "verdict": "extension",
+    "why": "see `rust:SafetyValidator`."
+  },
+  "rust:SequenceValue": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:Session": {
+    "verdict": "extension",
+    "why": "the per-process anchor a backend hands the executor; every method takes `&mut self`, which is how the single-threaded-transport contract is expressed in the type system. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:Session::close": {
+    "verdict": "extension",
+    "why": "see `rust:Session`."
+  },
+  "rust:Session::drive_io": {
+    "verdict": "extension",
+    "why": "the poll the executor calls before dispatching -- required, with no default body, because a silent no-op was a trap for third-party backends. See `rust:Session`."
+  },
+  "rust:Session::ping_session": {
+    "verdict": "extension",
+    "why": "wire-level connectivity probe, `Unsupported` where the backend has none. Lesson taken from micro-ROS's `rmw_uros_ping_agent`: on a link that can simply go away there is no graph to ask, so an image needs a direct question. See `rust:Session`."
+  },
+  "rust:Session::set_wake_callback": {
+    "verdict": "extension",
+    "why": "the backend-side half of the wake primitive; see the pubsub stage's `c:subscription_set_wake_callback` for what it buys. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:Session::supports_wake_callback": {
+    "verdict": "extension",
+    "why": "whether the backend actually implements the above, so the executor chooses between a wake-primitive wait and a blocking `drive_io` instead of guessing. Poll-only backends (XRCE, bare-metal smoltcp) return `false`. See `rust:Session::set_wake_callback`."
+  },
+  "rust:SessionHandle": {
+    "verdict": "extension",
+    "why": "an opaque, `Send` handle to an `Executor`'s RMW session. In the per-tier model the boot executor opens the ONE session and hands each spawned RTOS task a handle -- not a borrow -- so the task can open its own `Executor` over that same session across the task boundary. That is RFC-0053's shape: one transport, several executors, one per task (RFC-0002). rclrs never needs it because its executor is the thing you move. Wrapping the pointer lets a board crate name and move the handle without naming the concrete session type."
+  },
+  "rust:SessionHandle::from_raw": {
+    "verdict": "extension",
+    "why": "the other end, on the spawned task. Raw because an RTOS task entry point takes a `*mut c_void` and nothing richer. See `rust:SessionHandle`."
+  },
+  "rust:SessionHandle::into_raw": {
+    "verdict": "extension",
+    "why": "see `rust:SessionHandle`."
+  },
+  "rust:SessionMode": {
+    "verdict": "extension",
+    "why": "Client (connect to a router) or Peer (direct). A zenoh concept with no rcl counterpart: ROS 2 nodes are always peers of a DDS domain, while an embedded image usually cannot afford peer-mode discovery and connects to `rmw_zenohd` instead (RFC-0075). the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:SessionSpec": {
+    "verdict": "extension",
+    "why": "one backend's declaration for `Executor::open_multi`: which registered RMW to open, at which locator, on which domain. An image may link several backends -- a bridge speaks XRCE to a serial agent and zenoh to a router in the same process -- and each needs its own session. rclrs has one rmw per process, chosen by an environment variable."
+  },
+  "rust:SessionSpec::domain_id": {
+    "verdict": "extension",
+    "why": "see `rust:SessionSpec`."
+  },
+  "rust:SessionSpec::new": {
+    "verdict": "extension",
+    "why": "see `rust:SessionSpec`."
+  },
+  "rust:SimpleValue": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:Slot": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- one aligned region carved out of a caller-supplied `[u64]` backing store; the unit `carve` hands back. `u64` element type gives 8-byte alignment without `repr(align)` generics."
+  },
+  "rust:Slot::as_mut_ptr": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- the region's base pointer, for placement writes."
+  },
+  "rust:Slot::capacity": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- the region's byte length."
+  },
+  "rust:Slot::fits": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- 'does this Layout fit here' as a checked question; the fail-loud arm is an assert in `carve`, this is the queryable form."
+  },
+  "rust:StatusWatcher": {
+    "verdict": "divergence",
+    "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
+  },
+  "rust:SubMonitorCell": {
+    "verdict": "extension",
+    "why": "one contracted subscriber's take-age accumulator. The take path peeks `header.stamp` straight out of the raw CDR buffer at `RosMessage::STAMP_OFFSET` and `fetch_max`es the age, so the check costs no deserialization. See `rust:MonitorSpec` and `rust:RosMessage`."
+  },
+  "rust:SubMonitorCell::new": {
+    "verdict": "extension",
+    "why": "see `rust:SubMonitorCell`."
+  },
+  "rust:SubMonitorCell::observe": {
+    "verdict": "extension",
+    "why": "see `rust:SubMonitorCell`."
+  },
+  "rust:TopicInfo": {
+    "verdict": "extension",
+    "why": "the topic descriptor a backend creates an endpoint from: name, type name, type hash, domain, node name and namespace for the liveliness token, plus two embedded-only hints. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:TopicInfo::new": {
+    "verdict": "extension",
+    "why": "see `rust:TopicInfo`."
+  },
+  "rust:TopicInfo::with_domain": {
+    "verdict": "extension",
+    "why": "see `rust:TopicInfo`."
+  },
+  "rust:TopicInfo::with_namespace": {
+    "verdict": "extension",
+    "why": "see `rust:TopicInfo`."
+  },
+  "rust:TopicInfo::with_rx_buffer_hint": {
+    "verdict": "extension",
+    "why": "the subscription's `RX_BUF` passed down so a backend can route it to a size-class receive buffer (zenoh-pico: small vs large). Static receive storage is the constraint -- with no allocator the buffer is chosen at declaration, so the size has to travel with the declaration (RFC-0038). See `rust:TopicInfo`."
+  },
+  "rust:TopicInfo::with_tx_express": {
+    "verdict": "extension",
+    "why": "the per-endpoint form of `rust:QoSProfile::tx_express`. See `rust:TopicInfo`."
+  },
+  "rust:Transport": {
+    "verdict": "extension",
+    "why": "a SECOND factory trait beside `rust:Rmw`, differing only in taking `TransportConfig` rather than `RmwConfig`. Exactly one backend implements it (`ZenohTransport` in `nros-rmw-zenoh/src/shim/transport.rs`) while all five implement `Rmw`, and both are re-exported from `nros::`. Worth a decision in W5: two public spellings of \"open a session\" is a choice nobody makes on purpose. the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage."
+  },
+  "rust:Transport::open": {
+    "verdict": "extension",
+    "why": "see `rust:Transport`."
+  },
+  "rust:TransportConfig": {
+    "verdict": "extension",
+    "why": "the config `Transport::open` takes -- locator, mode, and free-form key/value properties (`multicast_scouting`, `scouting_timeout_ms`, `listen`). Board crates author it; `RmwConfig` is what the executor opens with. See `rust:Transport`."
+  },
+  "rust:TransportError": {
+    "verdict": "extension",
+    "why": "the error every backend operation returns, and the payload of `NodeError::Transport` -- which is what a Rust user actually matches on. Its variants name transport preconditions rcl has no vocabulary for (`IncompatibleQos`, `IncompatibleAbi`, `Disconnected`). the RMW SEAM, one layer below the user API -- what a BACKEND implements, not what a node calls. rclrs has no equivalent because rcl is its only backend. Exported from `nros::` beside the user API, which is issue 0784's complaint. See `rust:Session::create_publisher` in the pubsub stage.\nCORRECTION to issue 0783: that issue says the facade \"exports no way to inspect\" `NodeError` because `TransportError` is not exported. It IS -- `packages/api/nros/src/lib.rs:682` re-exports it unconditionally from `nros_rmw`. What 0783 actually found is that it is missing from the \"Re-export core types\" BLOCK at line 206 and lives in the transport block instead. `RclReturnCode` is genuinely unreachable (types stage, `rust:RclReturnCode`)."
+  },
+  "rust:Value": {
+    "verdict": "divergence",
+    "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
+  },
+  "rust:ValueKind": {
+    "verdict": "declined",
+    "why": "rclrs 0.7.0's dynamic-message surface: load a type's structure at RUNTIME by name and read or build a message without compiling against it. It needs the introspection typesupport library loaded from disk plus heap for the field table. An image links the types it uses; the same decision the pubsub stage records for rclcpp's `GenericPublisher`/`GenericSubscription`."
+  },
+  "rust:ValueMut": {
+    "verdict": "divergence",
+    "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
+  },
+  "rust:Violation": {
+    "verdict": "extension",
+    "why": "what the executor pushes into the ring the entry glue drains into the diagnostics reporter. See `rust:MonitorSpec`."
+  },
+  "rust:arena_size_for": {
+    "verdict": "extension",
+    "why": "per-entry executor arena sizing (phase-271, issue 0110): scales the build-time `ARENA_SIZE` linearly by a caller-chosen callback count, floored at the full default. It replaced a workspace-global `NROS_EXECUTOR_ARENA_SIZE` -- one number every entry in the workspace had to share, so a fat entry and a lean one were sized by whichever was declared louder. The arena exists at all because callback closures are stored INLINE with no allocator; over-provisioning is safe, under-provisioning fails entity creation."
+  },
+  "rust:baked_domain_from_c_abi": {
+    "verdict": "extension",
+    "why": "maps that `u8` onto the resolver's baked rung: `0` -> None, 255 -> Some(0), else Some(n), with 233..=254 passed through so the resolver rejects them loudly rather than this edge inventing its own validation. See `rust:DOMAIN_ID_EXPLICIT_ZERO_C_ABI`."
+  },
+  "rust:carve": {
+    "verdict": "extension",
+    "why": "phase-391 W5 -- split a caller's `[u64]` static into `Slot`s per a `RuntimeSizing`; asserts (fail-loud) rather than truncating when the store is too small. No upstream analogue: rcl allocates."
+  },
+  "rust:crc32": {
+    "verdict": "extension",
+    "why": "CRC-32/ISO-HDLC over a byte slice -- the same polynomial AUTOSAR E2E and EN 50159 name, with a `const`-built table so a `no_std` image pays no init. Public because a user who bakes their own attachment has to compute the same value. See `rust:SafetyValidator`."
+  },
+  "rust:drive_session_io": {
+    "verdict": "extension",
+    "why": "the C API executor's pre-poll hook, delegating to `Session::drive_io`. See `rust:RmwSession` and `rust:Session::drive_io`."
+  },
+  "rust:force_link_backend": {
+    "verdict": "extension",
+    "why": "a DCE anchor, not a registration (issue 0330). On a pure-Rust staticlib image the Zephyr module emits a WEAK `nros_rmw_<name>_register` and calls it only if it resolves; the strong definition is the backend crate's `#[no_mangle]` export, and rustc's staticlib DCE drops it unless something in the crate being compiled REFERENCES that crate. The symbol is then present in the rlib and absent from the `.a`, the weak call sees NULL, and the image boots with no backend (issues 0155/0163). The app crate invokes it because the app crate is what selects an RMW; nano-ros's own RMW-agnostic layers must not name a backend. rclrs has no equivalent because rcl loads its rmw as a shared object at runtime."
+  },
+  "rust:get_dynamic_message_package_cache": {
+    "verdict": "divergence",
+    "why": "added by rclrs 0.7.0 (the surface moved from 0.5.1 when this campaign pinned the latest release). Part of its action/goal model -- see `rust:AcceptedGoal` for the typestate argument and why ours is arena-addressed."
+  },
+  "rust:open_session": {
+    "verdict": "extension",
+    "why": "opens a backend session behind one signature, honouring the `$NROS_RMW` selector so a C bridge built with two linked backends pins its primary deterministically instead of taking whichever `.init_array` constructor fired first. Used by `nros-c`; Rust callers use `Executor::open`. See `rust:RmwSession`."
+  },
+  "rust:panic_halt": {
+    "verdict": "extension",
+    "why": "the `panic = \"halt\"` body: mask interrupts through the platform critical section, then spin forever. For an image that must not print -- no formatting, no allocation, no call out to the platform. Masking first is deliberate, so the parked core cannot be woken back into a half-dead system by a timer or a driver ISR still armed from before the panic. A body rather than a re-export of the `panic-halt` crate so choosing it costs the entry no new dependency. See `rust:panic_to_platform`."
+  },
+  "rust:panic_to_platform": {
+    "verdict": "extension",
+    "why": "emits the image's `#[panic_handler]`, formatting the panic into a 192-byte STACK buffer (never the heap -- the allocator may be exactly what failed) and handing it to `nros_platform_panic`. A `no_std` binary must supply that lang item or it does not link, and rclrs is `std`-only so libstd supplies it there. Normally reached as `nros::main!(panic = \"platform\")`; the macro is the escape hatch for images whose entry cannot carry the item -- a hand-rolled `no_std` binary, or the lib side of a `staticlib` crate. Deliberately NOT emitted invisibly: `#[panic_handler]` is a singleton of the final artifact and images that already declare their own (`esp_backtrace`, `panic-semihosting` with `features = [\"exit\"]` so QEMU exits instead of hanging a test) are right."
+  },
+  "rust:rx_buffer_for": {
+    "verdict": "extension",
+    "why": "phase-392 W3 — a subscription receive-buffer size computed from the message schema at compile time (`nros::rx_buffer_for!(Msg)`), so the buffer is sized by the type instead of the NROS_SUBSCRIPTION_BUFFER_SIZE guess. No upstream analogue: rcl sizes nothing statically. Landed unledgered; entry added when check-api-parity caught it one gate into a tier-2 run."
+  },
+  "rust:zephyr_component_main": {
+    "verdict": "extension",
+    "why": "emits Zephyr's `rust_main` for a self-bringup Rust component package: open a Zephyr executor, register the component, spin forever. A framework ENTRY macro, the same category as `nros::main!`, needed because a Zephyr `rust_cargo_application()` image has no `fn main` of its own and there are no POSIX-style constructor sections to register from (see the CLAUDE.md pitfall). Gated on `rmw-cffi` rather than on a platform feature, because it is codegen and its `::zephyr::*` paths resolve only in a zephyr build."
+  }
 }

--- a/docs/reference/api-parity-ledger/pubsub.json
+++ b/docs/reference/api-parity-ledger/pubsub.json
@@ -59,6 +59,14 @@
     "verdict": "extension",
     "why": "the raw + message-info form; see `c:publish_raw` and `rust:RawMessageInfo`."
   },
+  "c:executor_get_publishers_info_by_topic": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
+  "c:executor_get_subscriptions_info_by_topic": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
   "c:get_zero_initialized_publisher": {
     "verdict": "declined",
     "why": "rcl's free-function spelling; ours is `nros_publisher_get_zero_initialized`, a method-style name on the type. See `c:get_zero_initialized_node`."
@@ -389,6 +397,14 @@
   "cpp:ComponentNode::create_subscription_in": {
     "verdict": "extension",
     "why": "the callback-group form: like `cpp:ComponentNode::create_subscription` but associates the subscription with a named group, so the executor binds it to that group's SchedContext (RFC-0047). rclcpp carries the group through `SubscriptionOptions` instead -- `cpp:Node::create_publisher_in` records the shape."
+  },
+  "cpp:Executor::get_publishers_info_by_topic": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
+  "cpp:Executor::get_subscriptions_info_by_topic": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
   },
   "cpp:GenericPublisher": {
     "verdict": "declined",
@@ -1050,6 +1066,14 @@
     "verdict": "divergence",
     "why": "part of the IMPERATIVE Rust API, which coexists with the declarative component model and is the rclrs-shaped one: `NodeHandle` (exported from `nros` and IN THE PRELUDE, behind `rmw-cffi`) hands back concrete entities you hold and call. rclrs's counterpart exists and correlates by concept but not by name, because ours carries the storage strategy in the type -- `Embedded*` means the entity lives in the executor's static table rather than behind an `Arc`, which is the no-allocator constraint made visible in the name. Whether the two Rust APIs should both be public, and which one `nros::` should lead with, is issue 0784."
   },
+  "rust:Executor::get_publishers_info_by_topic": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
+  "rust:Executor::get_subscriptions_info_by_topic": {
+    "verdict": "divergence",
+    "why": "phase-381 W3/W4. Same verb as ROS 2; the RECEIVER differs. ROS 2 hangs the graph off a node because each Node/Context owns a participant; a nano-ros image opens ONE session for the whole image -- a session per node is RAM a 128 KiB target does not have -- and the Executor owns it. NOT a `rename`: the name follows the receiver, and the receiver is where the session is. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
   "rust:Executor::register_subscription_buffered_raw_info_on": {
     "verdict": "divergence",
     "why": "part of the IMPERATIVE Rust API, which coexists with the declarative component model and is the rclrs-shaped one: `NodeHandle` (exported from `nros` and IN THE PRELUDE, behind `rmw-cffi`) hands back concrete entities you hold and call. rclrs's counterpart exists and correlates by concept but not by name, because ours carries the storage strategy in the type -- `Embedded*` means the entity lives in the executor's static table rather than behind an `Arc`, which is the no-allocator constraint made visible in the name. Whether the two Rust APIs should both be public, and which one `nros::` should lead with, is issue 0784."
@@ -1169,6 +1193,14 @@
   "rust:Node::publisher_topic_info": {
     "verdict": "extension",
     "why": "see `rust:Node::publisher_count`."
+  },
+  "rust:Node::subscription_count": {
+    "verdict": "extension",
+    "why": "Renamed 2026-08-26 (phase-379 W5): Rust now says `subscription`, matching rclrs, rclcpp, rclc and our own C and C++. The whole cluster moved together — the verb, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info` and `SubscriberHandle` — because renaming a verb and leaving its option and handle types behind is the half-fix this ledger keeps recording. Renamed to `subscription_count` on 2026-08-26 with the rest of the cluster; see `rust:Node::create_subscriber`. counts what THIS NODE declared -- `active` entries of its own static table (nros-node/src/node.rs:360-367) -- which is a different question from what the graph holds. rclrs's `count_subscriptions` asks the graph about a topic. Recorded as an extension, matching `rust:Node::publisher_count` three lines away in the same impl; an earlier `rename` verdict here was wrong, because giving our declaration-side counter the graph query's name would leave the graph query nowhere to land. The rename applies to `create_subscriber`, the entity-creation verb, not to this."
+  },
+  "rust:Node::subscription_topic_info": {
+    "verdict": "extension",
+    "why": "Renamed 2026-08-26 (phase-379 W5): Rust now says `subscription`, matching rclrs, rclcpp, rclc and our own C and C++. The whole cluster moved together — the verb, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info` and `SubscriberHandle` — because renaming a verb and leaving its option and handle types behind is the half-fix this ledger keeps recording. see `rust:Node::subscriber_count`."
   },
   "rust:NodeHandle::create_publisher": {
     "verdict": "divergence",
@@ -1522,9 +1554,17 @@
     "verdict": "divergence",
     "why": "part of the IMPERATIVE Rust API, which coexists with the declarative component model and is the rclrs-shaped one: `NodeHandle` (exported from `nros` and IN THE PRELUDE, behind `rmw-cffi`) hands back concrete entities you hold and call. rclrs's counterpart exists and correlates by concept but not by name, because ours carries the storage strategy in the type -- `Embedded*` means the entity lives in the executor's static table rather than behind an `Arc`, which is the no-allocator constraint made visible in the name. Whether the two Rust APIs should both be public, and which one `nros::` should lead with, is issue 0784."
   },
+  "rust:SubscriptionHandle": {
+    "verdict": "rename",
+    "why": "Renamed 2026-08-26 (phase-379 W5): Rust now says `subscription`, matching rclrs, rclcpp, rclc and our own C and C++. The whole cluster moved together — the verb, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info` and `SubscriberHandle` — because renaming a verb and leaving its option and handle types behind is the half-fix this ledger keeps recording. NOTE: the target name already existed as an ASSOCIATED TYPE on the RMW `Session` trait (`<S as Session>::SubscriptionHandle`) — the backend's subscription object, not the standalone node's handle. They do not collide (no module names both, checked before renaming), but the two `SubscriptionHandle`s in this tree are unrelated. LANDED 2026-08-26 (phase-379 W5). Rust now spells this `subscription`, matching rclrs, rclcpp, rclc and our own C (`nros_subscription_init`) and C++ (`Node::create_subscription`). The whole cluster moved together — `create_subscriber`, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info`, `SubscriberHandle` — because renaming the verb and leaving its options/handle types behind is the half-fix this ledger keeps recording. NOTE for a future reader: the target name already existed as an ASSOCIATED TYPE on the RMW `Session` trait (`<S as Session>::SubscriptionHandle`), which is a different concept — the backend's subscription object, not the standalone node's handle. They do not collide (no module names both, checked), but the two `SubscriptionHandle`s in this tree are unrelated. OUR LANGUAGES DISAGREE, and it is the same word the node stage already flagged: rclrs, rclcpp and rclc all say SUBSCRIPTION, and so do our own C (`nros_subscription_init`) and C++ (`Node::create_subscription`). This is the standalone (non-component) node's handle type and it moves with `rust:Node::create_subscriber` / `SubscriberOptions` / `subscriber_count` -- see that row in the node stage. `SubscriptionHandle`. Nothing about an RTOS asks for the shorter word. Phase 379 W5. (Consumers outside `nros-node`: none -- it is re-exported from `nros::` and unused, so the rename is free today.)"
+  },
   "rust:SubscriptionOptions": {
     "verdict": "rename",
     "why": "SATISFIED 2026-08-26 — ours now carries this name. rclrs spells it `SubscriptionOptions`; ours is `SubscriberOptions`. Moves with `rust:Node::create_subscriber`."
+  },
+  "rust:SubscriptionOptions::qos": {
+    "verdict": "extension",
+    "why": "The builder-style QoS setter on the standalone node's `SubscriptionOptions`. rclrs carries QoS in `SubscriptionOptions` too but reaches it through `IntoPrimitiveOptions`/`.qos(..)` on the topic string rather than a method on the options struct, so the member does not correlate. Surfaced 2026-08-26 by the `subscriber`->`subscription` rename: the type's old name meant this member was filed under a key that no longer exists."
   },
   "rust:SubscriptionTag": {
     "verdict": "extension",
@@ -1545,21 +1585,5 @@
   "rust:WorkerSubscriptionCallback": {
     "verdict": "declined",
     "why": "see the node stage's `rust:Node::create_worker`."
-  },
-  "rust:SubscriptionOptions::qos": {
-    "verdict": "extension",
-    "why": "The builder-style QoS setter on the standalone node's `SubscriptionOptions`. rclrs carries QoS in `SubscriptionOptions` too but reaches it through `IntoPrimitiveOptions`/`.qos(..)` on the topic string rather than a method on the options struct, so the member does not correlate. Surfaced 2026-08-26 by the `subscriber`->`subscription` rename: the type's old name meant this member was filed under a key that no longer exists."
-  },
-  "rust:Node::subscription_count": {
-    "verdict": "extension",
-    "why": "Renamed 2026-08-26 (phase-379 W5): Rust now says `subscription`, matching rclrs, rclcpp, rclc and our own C and C++. The whole cluster moved together — the verb, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info` and `SubscriberHandle` — because renaming a verb and leaving its option and handle types behind is the half-fix this ledger keeps recording. Renamed to `subscription_count` on 2026-08-26 with the rest of the cluster; see `rust:Node::create_subscriber`. counts what THIS NODE declared -- `active` entries of its own static table (nros-node/src/node.rs:360-367) -- which is a different question from what the graph holds. rclrs's `count_subscriptions` asks the graph about a topic. Recorded as an extension, matching `rust:Node::publisher_count` three lines away in the same impl; an earlier `rename` verdict here was wrong, because giving our declaration-side counter the graph query's name would leave the graph query nowhere to land. The rename applies to `create_subscriber`, the entity-creation verb, not to this."
-  },
-  "rust:Node::subscription_topic_info": {
-    "verdict": "extension",
-    "why": "Renamed 2026-08-26 (phase-379 W5): Rust now says `subscription`, matching rclrs, rclcpp, rclc and our own C and C++. The whole cluster moved together — the verb, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info` and `SubscriberHandle` — because renaming a verb and leaving its option and handle types behind is the half-fix this ledger keeps recording. see `rust:Node::subscriber_count`."
-  },
-  "rust:SubscriptionHandle": {
-    "verdict": "rename",
-    "why": "Renamed 2026-08-26 (phase-379 W5): Rust now says `subscription`, matching rclrs, rclcpp, rclc and our own C and C++. The whole cluster moved together — the verb, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info` and `SubscriberHandle` — because renaming a verb and leaving its option and handle types behind is the half-fix this ledger keeps recording. NOTE: the target name already existed as an ASSOCIATED TYPE on the RMW `Session` trait (`<S as Session>::SubscriptionHandle`) — the backend's subscription object, not the standalone node's handle. They do not collide (no module names both, checked before renaming), but the two `SubscriptionHandle`s in this tree are unrelated. LANDED 2026-08-26 (phase-379 W5). Rust now spells this `subscription`, matching rclrs, rclcpp, rclc and our own C (`nros_subscription_init`) and C++ (`Node::create_subscription`). The whole cluster moved together — `create_subscriber`, `SubscriberOptions`, `subscriber_count`, `subscriber_topic_info`, `SubscriberHandle` — because renaming the verb and leaving its options/handle types behind is the half-fix this ledger keeps recording. NOTE for a future reader: the target name already existed as an ASSOCIATED TYPE on the RMW `Session` trait (`<S as Session>::SubscriptionHandle`), which is a different concept — the backend's subscription object, not the standalone node's handle. They do not collide (no module names both, checked), but the two `SubscriptionHandle`s in this tree are unrelated. OUR LANGUAGES DISAGREE, and it is the same word the node stage already flagged: rclrs, rclcpp and rclc all say SUBSCRIPTION, and so do our own C (`nros_subscription_init`) and C++ (`Node::create_subscription`). This is the standalone (non-component) node's handle type and it moves with `rust:Node::create_subscriber` / `SubscriberOptions` / `subscriber_count` -- see that row in the node stage. `SubscriptionHandle`. Nothing about an RTOS asks for the shorter word. Phase 379 W5. (Consumers outside `nros-node`: none -- it is re-exported from `nros::` and unused, so the rename is free today.)"
   }
 }

--- a/docs/reference/api-parity-ledger/types.json
+++ b/docs/reference/api-parity-ledger/types.json
@@ -47,6 +47,10 @@
     "verdict": "extension",
     "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
   },
+  "c:endpoint_info_t": {
+    "verdict": "divergence",
+    "why": "phase-381 W3. The ours-half of the `topic_endpoint_info_array_t` divergence this file already records: upstream returns an allocating array, there is no allocator at this seam, and the endpoint count has no bound the CALLER can know. So it streams through a visitor, one entry of peak memory, every string borrowed for the call. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
+  },
   "c:error_state_t": {
     "verdict": "declined",
     "why": "rcl keeps a thread-local error state with a formatted message, file and line, read back with rcl_get_error_string(). nano-ros returns `nros_ret_t` and nothing else -- there is no nros_error_string() and no per-thread error slot. What a C user loses is real and should be said plainly: a code, never a message. The constraint is thread-local storage plus a formatted-string buffer per thread, on targets where a task stack is measured in kilobytes."

--- a/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
+++ b/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
@@ -1,8 +1,21 @@
 # Phase 381 — read the ROS graph, which we are already visible in
 
-**Status (2026-08-29). UNBLOCKED — the bounded-memory decision does not have to
-be made, because the buffer it was about ALREADY EXISTS and is already ABI. See
-Design note 2a. The rest of this doc stands.**
+**Status (2026-08-30). W1–W7 LANDED.** Twelve `rmw` graph slots produced,
+reachable from Rust, C and C++; zenoh answers all twelve, Cyclone answers
+`get_node_names`; XRCE degrades to `UNSUPPORTED` and that is TESTED rather than
+asserted. `check-rmw-slot-producers`: produced 42 -> 53, inert 25 -> 14.
+`check-api-parity`: every divergence carries a ledger entry.
+
+**NOT done, and it is the gap that matters: LIVE INTEROP.** Nothing here proves
+a native `rmw_zenoh_cpp` node is discovered, or that `ros2 node list` and our
+`get_node_names()` agree. Every verification so far is against our own builders,
+our own parser and our own vtable. The acceptance criteria below still need a
+router and a real ROS 2 node, and they need the settling window Design note 3
+describes — written as a single comparison they would be a flaky test.
+
+**Superseded status (2026-08-29): UNBLOCKED — the bounded-memory decision does
+not have to be made, because the buffer it was about ALREADY EXISTS and is
+already ABI. See Design note 2a.**
 
 **Superseded status (2026-08-27): NOT STARTED — BLOCKED on the deferred bounded-memory
 decision in Design note 2, which is ABI-shaped and cannot be walked back.

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -1885,6 +1885,43 @@ typedef bool (*nros_names_and_types_visit_fn)(void *ctx,
                                               size_t types_count);
 
 /**
+ * phase-381 W4 — visit one discovered endpoint on a topic.
+ *
+ * Strings are BORROWED for the duration of the call. Return `false` to stop.
+ *
+ * No QoS: the GRANTED profile is what would answer "why is nothing arriving",
+ * no backend can read one back yet, and reporting the remote's DECLARED
+ * profile instead would be a confident wrong answer.
+ */
+typedef struct nros_endpoint_info_t {
+  /**
+   * Node that owns the endpoint.
+   */
+  const char *node_name;
+  /**
+   * That node's namespace.
+   */
+  const char *node_namespace;
+  /**
+   * Fully-qualified type on the wire, e.g. `"std_msgs/msg/Int32"`.
+   */
+  const char *topic_type;
+  /**
+   * `true` for a publisher, `false` for a subscription.
+   */
+  bool is_publisher;
+  /**
+   * 24-byte identity; all-zero when the backend has none.
+   */
+  uint8_t endpoint_gid[24];
+} nros_endpoint_info_t;
+
+/**
+ * phase-381 W4 — visit one endpoint. Return `false` to stop.
+ */
+typedef bool (*nros_endpoint_info_visit_fn)(void *ctx, const struct nros_endpoint_info_t *info);
+
+/**
  * Phase 104.C.8 — extended node-creation options.
  *
  * Mirrors the Rust `Executor::node_builder(name).rmw(rmw_name).
@@ -4245,6 +4282,95 @@ NROS_PUBLIC
 nros_ret_t nros_executor_count_subscribers(struct nros_executor_t *executor,
                                            const char *topic_name,
                                            size_t *out_count);
+
+/**
+ * phase-381 W4 — what one named node PUBLISHES, with the types.
+ *
+ * # Safety
+ * * `executor` must point to an initialised executor.
+ * * `node_name` / `node_namespace` must be valid NUL-terminated strings.
+ * * `visit` must be callable for the duration of the call.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_publisher_names_and_types_by_node(struct nros_executor_t *executor,
+                                                               const char *node_name,
+                                                               const char *node_namespace,
+                                                               nros_names_and_types_visit_fn visit,
+                                                               void *ctx);
+
+/**
+ * phase-381 W4 — what one named node SUBSCRIBES to, with the types.
+ *
+ * **`subscriber`, not `subscription`** — rcl spells it
+ * `rcl_get_subscriber_names_and_types_by_node`, and the C surface takes its
+ * vocabulary from rcl so a user porting C ROS 2 code types what they already
+ * know. The C++ and Rust surfaces say `subscription` because rclcpp and rclrs
+ * do. Three layers, three upstreams, one word each — not drift. Issue 0788
+ * owns the wider verb sweep.
+ *
+ * # Safety
+ * * `executor` must point to an initialised executor.
+ * * `node_name` / `node_namespace` must be valid NUL-terminated strings.
+ * * `visit` must be callable for the duration of the call.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_subscriber_names_and_types_by_node(struct nros_executor_t *executor,
+                                                                const char *node_name,
+                                                                const char *node_namespace,
+                                                                nros_names_and_types_visit_fn visit,
+                                                                void *ctx);
+
+/**
+ * phase-381 W4 — what services one named node SERVES, with the types.
+ *
+ * # Safety
+ * As `nros_executor_get_publisher_names_and_types_by_node`.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_service_names_and_types_by_node(struct nros_executor_t *executor,
+                                                             const char *node_name,
+                                                             const char *node_namespace,
+                                                             nros_names_and_types_visit_fn visit,
+                                                             void *ctx);
+
+/**
+ * phase-381 W4 — what services one named node CALLS, with the types.
+ *
+ * # Safety
+ * As `nros_executor_get_publisher_names_and_types_by_node`.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_client_names_and_types_by_node(struct nros_executor_t *executor,
+                                                            const char *node_name,
+                                                            const char *node_namespace,
+                                                            nros_names_and_types_visit_fn visit,
+                                                            void *ctx);
+
+/**
+ * phase-381 W4 — the publishers on `topic_name`, one visit each.
+ *
+ * # Safety
+ * * `executor` must point to an initialised executor.
+ * * `topic_name` must be a valid NUL-terminated string.
+ * * `visit` must be callable for the duration of the call.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_publishers_info_by_topic(struct nros_executor_t *executor,
+                                                      const char *topic_name,
+                                                      nros_endpoint_info_visit_fn visit,
+                                                      void *ctx);
+
+/**
+ * phase-381 W4 — the subscriptions on `topic_name`, one visit each.
+ *
+ * # Safety
+ * As `nros_executor_get_publishers_info_by_topic`.
+ */
+NROS_PUBLIC
+nros_ret_t nros_executor_get_subscriptions_info_by_topic(struct nros_executor_t *executor,
+                                                         const char *topic_name,
+                                                         nros_endpoint_info_visit_fn visit,
+                                                         void *ctx);
 
 /**
  * Set data communication semantics.

--- a/packages/api/nros-c/src/executor.rs
+++ b/packages/api/nros-c/src/executor.rs
@@ -755,6 +755,287 @@ unsafe fn nros_executor_count_impl(
     }
 }
 
+/// phase-381 W4 — visit one discovered endpoint on a topic.
+///
+/// Strings are BORROWED for the duration of the call. Return `false` to stop.
+///
+/// No QoS: the GRANTED profile is what would answer "why is nothing arriving",
+/// no backend can read one back yet, and reporting the remote's DECLARED
+/// profile instead would be a confident wrong answer.
+#[repr(C)]
+pub struct nros_endpoint_info_t {
+    /// Node that owns the endpoint.
+    pub node_name: *const core::ffi::c_char,
+    /// That node's namespace.
+    pub node_namespace: *const core::ffi::c_char,
+    /// Fully-qualified type on the wire, e.g. `"std_msgs/msg/Int32"`.
+    pub topic_type: *const core::ffi::c_char,
+    /// `true` for a publisher, `false` for a subscription.
+    pub is_publisher: bool,
+    /// 24-byte identity; all-zero when the backend has none.
+    pub endpoint_gid: [u8; 24],
+}
+
+/// phase-381 W4 — visit one endpoint. Return `false` to stop.
+pub type nros_endpoint_info_visit_fn = Option<
+    unsafe extern "C" fn(ctx: *mut core::ffi::c_void, info: *const nros_endpoint_info_t) -> bool,
+>;
+
+/// The shared body for the four `*_by_node` entry points.
+///
+/// # Safety
+/// Same contract as its callers.
+unsafe fn nros_executor_by_node_impl(
+    executor: *mut nros_executor_t,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_names_and_types_visit_fn,
+    ctx: *mut core::ffi::c_void,
+    #[allow(unused_variables)] kind: u8,
+) -> nros_ret_t {
+    validate_not_null!(executor);
+    if node_name.is_null() || node_namespace.is_null() {
+        return NROS_RET_INVALID_ARGUMENT;
+    }
+    let Some(visit) = visit else {
+        return NROS_RET_INVALID_ARGUMENT;
+    };
+    let exec_t = &mut *executor;
+    if exec_t.state == nros_executor_state_t::NROS_EXECUTOR_STATE_UNINITIALIZED
+        || exec_t.state == nros_executor_state_t::NROS_EXECUTOR_STATE_SHUTDOWN
+    {
+        return NROS_RET_NOT_INIT;
+    }
+    #[cfg(feature = "rmw-cffi")]
+    {
+        let (Ok(name), Ok(ns)) = (
+            core::ffi::CStr::from_ptr(node_name).to_str(),
+            core::ffi::CStr::from_ptr(node_namespace).to_str(),
+        ) else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        const NAME_MAX: usize = 256;
+        const TYPES_MAX: usize = 8;
+        let exec = get_executor(&mut exec_t._opaque);
+        let mut cb = |n: &str, types: &[&str]| -> bool {
+            let mut name_buf = [0u8; NAME_MAX];
+            if n.len() >= NAME_MAX {
+                return true;
+            }
+            name_buf[..n.len()].copy_from_slice(n.as_bytes());
+            let mut type_bufs = [[0u8; NAME_MAX]; TYPES_MAX];
+            let mut ptrs: [*const core::ffi::c_char; TYPES_MAX] = [core::ptr::null(); TYPES_MAX];
+            let mut count = 0usize;
+            for t in types.iter().take(TYPES_MAX) {
+                if t.len() >= NAME_MAX {
+                    continue;
+                }
+                type_bufs[count][..t.len()].copy_from_slice(t.as_bytes());
+                ptrs[count] = type_bufs[count].as_ptr() as *const core::ffi::c_char;
+                count += 1;
+            }
+            visit(
+                ctx,
+                name_buf.as_ptr() as *const core::ffi::c_char,
+                ptrs.as_ptr(),
+                count,
+            )
+        };
+        let r = match kind {
+            0 => exec.get_publisher_names_and_types_by_node(name, ns, &mut cb),
+            1 => exec.get_subscription_names_and_types_by_node(name, ns, &mut cb),
+            2 => exec.get_service_names_and_types_by_node(name, ns, &mut cb),
+            _ => exec.get_client_names_and_types_by_node(name, ns, &mut cb),
+        };
+        match r {
+            Ok(()) => NROS_RET_OK,
+            Err(nros_node::NodeError::Transport(nros_rmw::TransportError::Unsupported)) => {
+                NROS_RET_UNSUPPORTED
+            }
+            Err(_) => NROS_RET_ERROR,
+        }
+    }
+    #[cfg(not(feature = "rmw-cffi"))]
+    {
+        let _ = (node_name, node_namespace, visit, ctx);
+        NROS_RET_UNSUPPORTED
+    }
+}
+
+/// phase-381 W4 — what one named node PUBLISHES, with the types.
+///
+/// # Safety
+/// * `executor` must point to an initialised executor.
+/// * `node_name` / `node_namespace` must be valid NUL-terminated strings.
+/// * `visit` must be callable for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_executor_get_publisher_names_and_types_by_node(
+    executor: *mut nros_executor_t,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_names_and_types_visit_fn,
+    ctx: *mut core::ffi::c_void,
+) -> nros_ret_t {
+    nros_executor_by_node_impl(executor, node_name, node_namespace, visit, ctx, 0)
+}
+
+/// phase-381 W4 — what one named node SUBSCRIBES to, with the types.
+///
+/// **`subscriber`, not `subscription`** — rcl spells it
+/// `rcl_get_subscriber_names_and_types_by_node`, and the C surface takes its
+/// vocabulary from rcl so a user porting C ROS 2 code types what they already
+/// know. The C++ and Rust surfaces say `subscription` because rclcpp and rclrs
+/// do. Three layers, three upstreams, one word each — not drift. Issue 0788
+/// owns the wider verb sweep.
+///
+/// # Safety
+/// * `executor` must point to an initialised executor.
+/// * `node_name` / `node_namespace` must be valid NUL-terminated strings.
+/// * `visit` must be callable for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_executor_get_subscriber_names_and_types_by_node(
+    executor: *mut nros_executor_t,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_names_and_types_visit_fn,
+    ctx: *mut core::ffi::c_void,
+) -> nros_ret_t {
+    nros_executor_by_node_impl(executor, node_name, node_namespace, visit, ctx, 1)
+}
+
+/// phase-381 W4 — what services one named node SERVES, with the types.
+///
+/// # Safety
+/// As `nros_executor_get_publisher_names_and_types_by_node`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_executor_get_service_names_and_types_by_node(
+    executor: *mut nros_executor_t,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_names_and_types_visit_fn,
+    ctx: *mut core::ffi::c_void,
+) -> nros_ret_t {
+    nros_executor_by_node_impl(executor, node_name, node_namespace, visit, ctx, 2)
+}
+
+/// phase-381 W4 — what services one named node CALLS, with the types.
+///
+/// # Safety
+/// As `nros_executor_get_publisher_names_and_types_by_node`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_executor_get_client_names_and_types_by_node(
+    executor: *mut nros_executor_t,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_names_and_types_visit_fn,
+    ctx: *mut core::ffi::c_void,
+) -> nros_ret_t {
+    nros_executor_by_node_impl(executor, node_name, node_namespace, visit, ctx, 3)
+}
+
+/// The shared body for the two `*_info_by_topic` entry points.
+///
+/// # Safety
+/// Same contract as its callers.
+unsafe fn nros_executor_endpoint_info_impl(
+    executor: *mut nros_executor_t,
+    topic_name: *const core::ffi::c_char,
+    visit: nros_endpoint_info_visit_fn,
+    ctx: *mut core::ffi::c_void,
+    #[allow(unused_variables)] publishers: bool,
+) -> nros_ret_t {
+    validate_not_null!(executor);
+    if topic_name.is_null() {
+        return NROS_RET_INVALID_ARGUMENT;
+    }
+    let Some(visit) = visit else {
+        return NROS_RET_INVALID_ARGUMENT;
+    };
+    let exec_t = &mut *executor;
+    if exec_t.state == nros_executor_state_t::NROS_EXECUTOR_STATE_UNINITIALIZED
+        || exec_t.state == nros_executor_state_t::NROS_EXECUTOR_STATE_SHUTDOWN
+    {
+        return NROS_RET_NOT_INIT;
+    }
+    #[cfg(feature = "rmw-cffi")]
+    {
+        let Ok(topic) = core::ffi::CStr::from_ptr(topic_name).to_str() else {
+            return NROS_RET_INVALID_ARGUMENT;
+        };
+        const NAME_MAX: usize = 256;
+        let exec = get_executor(&mut exec_t._opaque);
+        let mut cb = |info: &nros_rmw::GraphEndpointInfo<'_>| -> bool {
+            let mut name_buf = [0u8; NAME_MAX];
+            let mut ns_buf = [0u8; NAME_MAX];
+            let mut ty_buf = [0u8; NAME_MAX];
+            if info.node_name.len() >= NAME_MAX
+                || info.node_namespace.len() >= NAME_MAX
+                || info.topic_type.len() >= NAME_MAX
+            {
+                return true; // skip, never truncate
+            }
+            name_buf[..info.node_name.len()].copy_from_slice(info.node_name.as_bytes());
+            ns_buf[..info.node_namespace.len()].copy_from_slice(info.node_namespace.as_bytes());
+            ty_buf[..info.topic_type.len()].copy_from_slice(info.topic_type.as_bytes());
+            let c_info = nros_endpoint_info_t {
+                node_name: name_buf.as_ptr() as *const core::ffi::c_char,
+                node_namespace: ns_buf.as_ptr() as *const core::ffi::c_char,
+                topic_type: ty_buf.as_ptr() as *const core::ffi::c_char,
+                is_publisher: info.is_publisher,
+                endpoint_gid: info.endpoint_gid,
+            };
+            visit(ctx, &c_info as *const nros_endpoint_info_t)
+        };
+        let r = if publishers {
+            exec.get_publishers_info_by_topic(topic, &mut cb)
+        } else {
+            exec.get_subscriptions_info_by_topic(topic, &mut cb)
+        };
+        match r {
+            Ok(()) => NROS_RET_OK,
+            Err(nros_node::NodeError::Transport(nros_rmw::TransportError::Unsupported)) => {
+                NROS_RET_UNSUPPORTED
+            }
+            Err(_) => NROS_RET_ERROR,
+        }
+    }
+    #[cfg(not(feature = "rmw-cffi"))]
+    {
+        let _ = (topic_name, visit, ctx);
+        NROS_RET_UNSUPPORTED
+    }
+}
+
+/// phase-381 W4 — the publishers on `topic_name`, one visit each.
+///
+/// # Safety
+/// * `executor` must point to an initialised executor.
+/// * `topic_name` must be a valid NUL-terminated string.
+/// * `visit` must be callable for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_executor_get_publishers_info_by_topic(
+    executor: *mut nros_executor_t,
+    topic_name: *const core::ffi::c_char,
+    visit: nros_endpoint_info_visit_fn,
+    ctx: *mut core::ffi::c_void,
+) -> nros_ret_t {
+    nros_executor_endpoint_info_impl(executor, topic_name, visit, ctx, true)
+}
+
+/// phase-381 W4 — the subscriptions on `topic_name`, one visit each.
+///
+/// # Safety
+/// As `nros_executor_get_publishers_info_by_topic`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_executor_get_subscriptions_info_by_topic(
+    executor: *mut nros_executor_t,
+    topic_name: *const core::ffi::c_char,
+    visit: nros_endpoint_info_visit_fn,
+    ctx: *mut core::ffi::c_void,
+) -> nros_ret_t {
+    nros_executor_endpoint_info_impl(executor, topic_name, visit, ctx, false)
+}
+
 /// Set data communication semantics.
 ///
 /// # Safety

--- a/packages/api/nros-c/tests/compile/graph_query_entry_points.c
+++ b/packages/api/nros-c/tests/compile/graph_query_entry_points.c
@@ -51,6 +51,39 @@ int main(void) {
     nros_ret_t (*p_count_sub)(struct nros_executor_t *, const char *, size_t *) =
         nros_executor_count_subscribers;
 
+    /* phase-381 W3/W4 — the six per-node and per-topic forms.
+     *
+     * `nros_executor_get_subscriber_names_and_types_by_node`, NOT
+     * `subscription`: the C surface takes rcl's vocabulary
+     * (`rcl_get_subscriber_names_and_types_by_node`), while C++ and Rust take
+     * rclcpp's and rclrs's `subscription`. If someone "aligns" the three, this
+     * line stops compiling — which is the point of naming it here. */
+    nros_ret_t (*p_pub_by_node)(struct nros_executor_t *, const char *, const char *,
+                                nros_names_and_types_visit_fn, void *) =
+        nros_executor_get_publisher_names_and_types_by_node;
+    nros_ret_t (*p_sub_by_node)(struct nros_executor_t *, const char *, const char *,
+                                nros_names_and_types_visit_fn, void *) =
+        nros_executor_get_subscriber_names_and_types_by_node;
+    nros_ret_t (*p_srv_by_node)(struct nros_executor_t *, const char *, const char *,
+                                nros_names_and_types_visit_fn, void *) =
+        nros_executor_get_service_names_and_types_by_node;
+    nros_ret_t (*p_cli_by_node)(struct nros_executor_t *, const char *, const char *,
+                                nros_names_and_types_visit_fn, void *) =
+        nros_executor_get_client_names_and_types_by_node;
+    nros_ret_t (*p_pubs_info)(struct nros_executor_t *, const char *,
+                              nros_endpoint_info_visit_fn, void *) =
+        nros_executor_get_publishers_info_by_topic;
+    nros_ret_t (*p_subs_info)(struct nros_executor_t *, const char *,
+                              nros_endpoint_info_visit_fn, void *) =
+        nros_executor_get_subscriptions_info_by_topic;
+
+    (void)p_pub_by_node;
+    (void)p_sub_by_node;
+    (void)p_srv_by_node;
+    (void)p_cli_by_node;
+    (void)p_pubs_info;
+    (void)p_subs_info;
+
     /* And the visitor typedefs must accept a conforming function. */
     nros_node_visit_fn nv = visit_node;
     nros_names_and_types_visit_fn ntv = visit_names_and_types;

--- a/packages/api/nros-cpp/include/nros/executor.hpp
+++ b/packages/api/nros-cpp/include/nros/executor.hpp
@@ -242,6 +242,69 @@ class Executor {
         return Result(nros_cpp_executor_count_subscribers(storage_, topic_name, out_count));
     }
 
+    /// phase-381 W4 — what one named node PUBLISHES, with the types.
+    Result get_publisher_names_and_types_by_node(const char* node_name, const char* node_namespace,
+                                                 nros_cpp_names_and_types_visit_fn visit,
+                                                 void* ctx) {
+        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        return Result(nros_cpp_executor_get_publisher_names_and_types_by_node(
+            storage_, node_name, node_namespace, visit, ctx));
+    }
+
+    /// phase-381 W4 — what one named node SUBSCRIBES to, with the types.
+    ///
+    /// `subscription`, not `subscriber`: the C++ surface takes rclcpp's
+    /// vocabulary (`create_subscription`, `Subscription<T>`,
+    /// `get_subscriptions_info_by_topic`). rclcpp has no `*_by_node` form for
+    /// subscriptions at all, so the WORD comes from its vocabulary rather than
+    /// from a method it lacks. The C surface says `subscriber` because rcl
+    /// does, and the vtable slot because upstream rmw does.
+    Result get_subscription_names_and_types_by_node(const char* node_name,
+                                                    const char* node_namespace,
+                                                    nros_cpp_names_and_types_visit_fn visit,
+                                                    void* ctx) {
+        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        return Result(nros_cpp_executor_get_subscription_names_and_types_by_node(
+            storage_, node_name, node_namespace, visit, ctx));
+    }
+
+    /// phase-381 W4 — what services one named node SERVES, with the types.
+    Result get_service_names_and_types_by_node(const char* node_name, const char* node_namespace,
+                                               nros_cpp_names_and_types_visit_fn visit, void* ctx) {
+        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        return Result(nros_cpp_executor_get_service_names_and_types_by_node(
+            storage_, node_name, node_namespace, visit, ctx));
+    }
+
+    /// phase-381 W4 — what services one named node CALLS, with the types.
+    Result get_client_names_and_types_by_node(const char* node_name, const char* node_namespace,
+                                              nros_cpp_names_and_types_visit_fn visit, void* ctx) {
+        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        return Result(nros_cpp_executor_get_client_names_and_types_by_node(
+            storage_, node_name, node_namespace, visit, ctx));
+    }
+
+    /// phase-381 W4 — the publishers on `topic_name`, one visit each.
+    ///
+    /// The endpoint carries no QoS: the GRANTED profile is what would answer
+    /// "why is nothing arriving", no backend can read one back yet, and
+    /// reporting the remote's DECLARED profile would be a confident wrong
+    /// answer.
+    Result get_publishers_info_by_topic(const char* topic_name,
+                                        nros_cpp_endpoint_info_visit_fn visit, void* ctx) {
+        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        return Result(
+            nros_cpp_executor_get_publishers_info_by_topic(storage_, topic_name, visit, ctx));
+    }
+
+    /// phase-381 W4 — the subscriptions on `topic_name`, one visit each.
+    Result get_subscriptions_info_by_topic(const char* topic_name,
+                                           nros_cpp_endpoint_info_visit_fn visit, void* ctx) {
+        if (!initialized_) return Result(ErrorCode::NotInitialized);
+        return Result(
+            nros_cpp_executor_get_subscriptions_info_by_topic(storage_, topic_name, visit, ctx));
+    }
+
     /// Spin until this executor is shut down (blocking) — `rclcpp::Executor::spin`.
     ///
     /// Issue 0338 — this verb used to mean the OPPOSITE here: `spin` was the

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -348,6 +348,26 @@ typedef bool (*nros_cpp_names_and_types_visit_fn)(void *ctx,
                                                   size_t types_count);
 
 /**
+ * phase-381 W4 — one discovered endpoint on a topic. Strings BORROWED for the
+ * call. No QoS: the GRANTED profile is what would answer "why is nothing
+ * arriving", no backend can read one back yet, and reporting the remote's
+ * DECLARED profile would be a confident wrong answer.
+ */
+typedef struct nros_cpp_endpoint_info_t {
+  const char *node_name;
+  const char *node_namespace;
+  const char *topic_type;
+  bool is_publisher;
+  uint8_t endpoint_gid[24];
+} nros_cpp_endpoint_info_t;
+
+/**
+ * phase-381 W4 — visit one endpoint. Return `false` to stop.
+ */
+typedef bool (*nros_cpp_endpoint_info_visit_fn)(void *ctx,
+                                                const struct nros_cpp_endpoint_info_t *info);
+
+/**
  * `nros::SchedContext` mirror passed to
  * [`nros_cpp_create_sched_context`]. Time fields use `0` as
  * "absent" sentinel (mirrors the Rust `OptUs` newtype).
@@ -950,6 +970,82 @@ nros_cpp_ret_t nros_cpp_executor_count_publishers(void *handle,
 nros_cpp_ret_t nros_cpp_executor_count_subscribers(void *handle,
                                                    const char *topic_name,
                                                    size_t *out_count);
+
+/**
+ * phase-381 W4 — what one named node PUBLISHES.
+ *
+ * # Safety
+ * `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+ */
+nros_cpp_ret_t nros_cpp_executor_get_publisher_names_and_types_by_node(void *handle,
+                                                                       const char *node_name,
+                                                                       const char *node_namespace,
+                                                                       nros_cpp_names_and_types_visit_fn visit,
+                                                                       void *ctx);
+
+/**
+ * phase-381 W4 — what one named node SUBSCRIBES to.
+ *
+ * `subscription`, not `subscriber`: the C++ surface takes rclcpp's vocabulary
+ * (`create_subscription`, `Subscription<T>`, `get_subscriptions_info_by_topic`).
+ * rclcpp has no `*_by_node` form for subscriptions at all, so the WORD comes
+ * from its vocabulary rather than from a method it lacks. C says `subscriber`
+ * because rcl does.
+ *
+ * # Safety
+ * `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+ */
+nros_cpp_ret_t nros_cpp_executor_get_subscription_names_and_types_by_node(void *handle,
+                                                                          const char *node_name,
+                                                                          const char *node_namespace,
+                                                                          nros_cpp_names_and_types_visit_fn visit,
+                                                                          void *ctx);
+
+/**
+ * phase-381 W4 — what services one named node SERVES.
+ *
+ * # Safety
+ * `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+ */
+nros_cpp_ret_t nros_cpp_executor_get_service_names_and_types_by_node(void *handle,
+                                                                     const char *node_name,
+                                                                     const char *node_namespace,
+                                                                     nros_cpp_names_and_types_visit_fn visit,
+                                                                     void *ctx);
+
+/**
+ * phase-381 W4 — what services one named node CALLS.
+ *
+ * # Safety
+ * `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+ */
+nros_cpp_ret_t nros_cpp_executor_get_client_names_and_types_by_node(void *handle,
+                                                                    const char *node_name,
+                                                                    const char *node_namespace,
+                                                                    nros_cpp_names_and_types_visit_fn visit,
+                                                                    void *ctx);
+
+/**
+ * phase-381 W4 — the publishers on `topic_name`.
+ *
+ * # Safety
+ * `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+ */
+nros_cpp_ret_t nros_cpp_executor_get_publishers_info_by_topic(void *handle,
+                                                              const char *topic_name,
+                                                              nros_cpp_endpoint_info_visit_fn visit,
+                                                              void *ctx);
+
+/**
+ * phase-381 W4 — the subscriptions on `topic_name`.
+ *
+ * # Safety
+ * `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+ */
+nros_cpp_ret_t nros_cpp_executor_get_subscriptions_info_by_topic(void *handle,
+                                                                 const char *topic_name,
+                                                                 nros_cpp_endpoint_info_visit_fn visit,
+                                                                 void *ctx);
 
 /**
  * Identifier of the auto-created default `Fifo` SC. Phase 110.B.

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -2104,6 +2104,263 @@ pub unsafe extern "C" fn nros_cpp_executor_count_subscribers(
     unsafe { cpp_count_on_topic(handle, topic_name, out_count, true) }
 }
 
+/// phase-381 W4 — one discovered endpoint on a topic. Strings BORROWED for the
+/// call. No QoS: the GRANTED profile is what would answer "why is nothing
+/// arriving", no backend can read one back yet, and reporting the remote's
+/// DECLARED profile would be a confident wrong answer.
+#[repr(C)]
+pub struct nros_cpp_endpoint_info_t {
+    pub node_name: *const core::ffi::c_char,
+    pub node_namespace: *const core::ffi::c_char,
+    pub topic_type: *const core::ffi::c_char,
+    pub is_publisher: bool,
+    pub endpoint_gid: [u8; 24],
+}
+
+/// phase-381 W4 — visit one endpoint. Return `false` to stop.
+pub type nros_cpp_endpoint_info_visit_fn =
+    Option<unsafe extern "C" fn(ctx: *mut c_void, info: *const nros_cpp_endpoint_info_t) -> bool>;
+
+/// Shared body for the four `*_by_node` entry points.
+///
+/// # Safety
+/// Same contract as its callers.
+#[cfg(feature = "rmw-cffi")]
+unsafe fn cpp_by_node(
+    handle: *mut c_void,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_cpp_names_and_types_visit_fn,
+    ctx: *mut c_void,
+    kind: u8,
+) -> nros_cpp_ret_t {
+    let Some(cpp) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    if node_name.is_null() || node_namespace.is_null() {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    }
+    let Some(visit) = visit else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    let (Ok(name), Ok(ns)) = (
+        unsafe { core::ffi::CStr::from_ptr(node_name) }.to_str(),
+        unsafe { core::ffi::CStr::from_ptr(node_namespace) }.to_str(),
+    ) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    const NAME_MAX: usize = 256;
+    const TYPES_MAX: usize = 8;
+    let mut cb = |n: &str, types: &[&str]| -> bool {
+        let mut name_buf = [0u8; NAME_MAX];
+        if n.len() >= NAME_MAX {
+            return true;
+        }
+        name_buf[..n.len()].copy_from_slice(n.as_bytes());
+        let mut type_bufs = [[0u8; NAME_MAX]; TYPES_MAX];
+        let mut ptrs: [*const core::ffi::c_char; TYPES_MAX] = [core::ptr::null(); TYPES_MAX];
+        let mut count = 0usize;
+        for t in types.iter().take(TYPES_MAX) {
+            if t.len() >= NAME_MAX {
+                continue;
+            }
+            type_bufs[count][..t.len()].copy_from_slice(t.as_bytes());
+            ptrs[count] = type_bufs[count].as_ptr() as *const core::ffi::c_char;
+            count += 1;
+        }
+        unsafe {
+            visit(
+                ctx,
+                name_buf.as_ptr() as *const core::ffi::c_char,
+                ptrs.as_ptr(),
+                count,
+            )
+        }
+    };
+    let r = match kind {
+        0 => cpp
+            .executor
+            .get_publisher_names_and_types_by_node(name, ns, &mut cb),
+        1 => cpp
+            .executor
+            .get_subscription_names_and_types_by_node(name, ns, &mut cb),
+        2 => cpp
+            .executor
+            .get_service_names_and_types_by_node(name, ns, &mut cb),
+        _ => cpp
+            .executor
+            .get_client_names_and_types_by_node(name, ns, &mut cb),
+    };
+    match r {
+        Ok(()) => NROS_CPP_RET_OK,
+        Err(nros_node::NodeError::Transport(nros_rmw::TransportError::Unsupported)) => {
+            NROS_CPP_RET_UNSUPPORTED
+        }
+        Err(_) => NROS_CPP_RET_ERROR,
+    }
+}
+
+/// phase-381 W4 — what one named node PUBLISHES.
+///
+/// # Safety
+/// `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_get_publisher_names_and_types_by_node(
+    handle: *mut c_void,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_cpp_names_and_types_visit_fn,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    unsafe { cpp_by_node(handle, node_name, node_namespace, visit, ctx, 0) }
+}
+
+/// phase-381 W4 — what one named node SUBSCRIBES to.
+///
+/// `subscription`, not `subscriber`: the C++ surface takes rclcpp's vocabulary
+/// (`create_subscription`, `Subscription<T>`, `get_subscriptions_info_by_topic`).
+/// rclcpp has no `*_by_node` form for subscriptions at all, so the WORD comes
+/// from its vocabulary rather than from a method it lacks. C says `subscriber`
+/// because rcl does.
+///
+/// # Safety
+/// `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_get_subscription_names_and_types_by_node(
+    handle: *mut c_void,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_cpp_names_and_types_visit_fn,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    unsafe { cpp_by_node(handle, node_name, node_namespace, visit, ctx, 1) }
+}
+
+/// phase-381 W4 — what services one named node SERVES.
+///
+/// # Safety
+/// `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_get_service_names_and_types_by_node(
+    handle: *mut c_void,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_cpp_names_and_types_visit_fn,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    unsafe { cpp_by_node(handle, node_name, node_namespace, visit, ctx, 2) }
+}
+
+/// phase-381 W4 — what services one named node CALLS.
+///
+/// # Safety
+/// `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_get_client_names_and_types_by_node(
+    handle: *mut c_void,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    visit: nros_cpp_names_and_types_visit_fn,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    unsafe { cpp_by_node(handle, node_name, node_namespace, visit, ctx, 3) }
+}
+
+/// Shared body for the two `*_info_by_topic` entry points.
+///
+/// # Safety
+/// Same contract as its callers.
+#[cfg(feature = "rmw-cffi")]
+unsafe fn cpp_endpoint_info(
+    handle: *mut c_void,
+    topic_name: *const core::ffi::c_char,
+    visit: nros_cpp_endpoint_info_visit_fn,
+    ctx: *mut c_void,
+    publishers: bool,
+) -> nros_cpp_ret_t {
+    let Some(cpp) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    if topic_name.is_null() {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    }
+    let Some(visit) = visit else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    let Ok(topic) = (unsafe { core::ffi::CStr::from_ptr(topic_name) }).to_str() else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    const NAME_MAX: usize = 256;
+    let mut cb = |info: &nros_rmw::GraphEndpointInfo<'_>| -> bool {
+        let mut name_buf = [0u8; NAME_MAX];
+        let mut ns_buf = [0u8; NAME_MAX];
+        let mut ty_buf = [0u8; NAME_MAX];
+        if info.node_name.len() >= NAME_MAX
+            || info.node_namespace.len() >= NAME_MAX
+            || info.topic_type.len() >= NAME_MAX
+        {
+            return true;
+        }
+        name_buf[..info.node_name.len()].copy_from_slice(info.node_name.as_bytes());
+        ns_buf[..info.node_namespace.len()].copy_from_slice(info.node_namespace.as_bytes());
+        ty_buf[..info.topic_type.len()].copy_from_slice(info.topic_type.as_bytes());
+        let c_info = nros_cpp_endpoint_info_t {
+            node_name: name_buf.as_ptr() as *const core::ffi::c_char,
+            node_namespace: ns_buf.as_ptr() as *const core::ffi::c_char,
+            topic_type: ty_buf.as_ptr() as *const core::ffi::c_char,
+            is_publisher: info.is_publisher,
+            endpoint_gid: info.endpoint_gid,
+        };
+        unsafe { visit(ctx, &c_info as *const nros_cpp_endpoint_info_t) }
+    };
+    let r = if publishers {
+        cpp.executor.get_publishers_info_by_topic(topic, &mut cb)
+    } else {
+        cpp.executor.get_subscriptions_info_by_topic(topic, &mut cb)
+    };
+    match r {
+        Ok(()) => NROS_CPP_RET_OK,
+        Err(nros_node::NodeError::Transport(nros_rmw::TransportError::Unsupported)) => {
+            NROS_CPP_RET_UNSUPPORTED
+        }
+        Err(_) => NROS_CPP_RET_ERROR,
+    }
+}
+
+/// phase-381 W4 — the publishers on `topic_name`.
+///
+/// # Safety
+/// `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_get_publishers_info_by_topic(
+    handle: *mut c_void,
+    topic_name: *const core::ffi::c_char,
+    visit: nros_cpp_endpoint_info_visit_fn,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    unsafe { cpp_endpoint_info(handle, topic_name, visit, ctx, true) }
+}
+
+/// phase-381 W4 — the subscriptions on `topic_name`.
+///
+/// # Safety
+/// `handle` must be a valid `CppContext` from `nros_cpp_init()`.
+#[cfg(feature = "rmw-cffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_get_subscriptions_info_by_topic(
+    handle: *mut c_void,
+    topic_name: *const core::ffi::c_char,
+    visit: nros_cpp_endpoint_info_visit_fn,
+    ctx: *mut c_void,
+) -> nros_cpp_ret_t {
+    unsafe { cpp_endpoint_info(handle, topic_name, visit, ctx, false) }
+}
+
 // =============================================================================
 // Phase 110.B / 110.C — SchedContext FFI for the C++ wrapper
 // =============================================================================

--- a/packages/api/nros-cpp/tests/compile/graph_query_entry_points.cpp
+++ b/packages/api/nros-cpp/tests/compile/graph_query_entry_points.cpp
@@ -55,6 +55,35 @@ int main() {
     Result (Executor::*p_count_pub)(const char *, size_t *) = &Executor::count_publishers;
     Result (Executor::*p_count_sub)(const char *, size_t *) = &Executor::count_subscribers;
 
+    // phase-381 W3/W4 — the six per-node and per-topic forms.
+    //
+    // `get_subscription_names_and_types_by_node`, NOT `subscriber`: the C++
+    // surface takes rclcpp's vocabulary while C takes rcl's. If someone
+    // "aligns" the three languages, this line stops compiling.
+    Result (Executor::*p_pub_by_node)(const char *, const char *,
+                                      nros_cpp_names_and_types_visit_fn, void *) =
+        &Executor::get_publisher_names_and_types_by_node;
+    Result (Executor::*p_sub_by_node)(const char *, const char *,
+                                      nros_cpp_names_and_types_visit_fn, void *) =
+        &Executor::get_subscription_names_and_types_by_node;
+    Result (Executor::*p_srv_by_node)(const char *, const char *,
+                                      nros_cpp_names_and_types_visit_fn, void *) =
+        &Executor::get_service_names_and_types_by_node;
+    Result (Executor::*p_cli_by_node)(const char *, const char *,
+                                      nros_cpp_names_and_types_visit_fn, void *) =
+        &Executor::get_client_names_and_types_by_node;
+    Result (Executor::*p_pubs_info)(const char *, nros_cpp_endpoint_info_visit_fn, void *) =
+        &Executor::get_publishers_info_by_topic;
+    Result (Executor::*p_subs_info)(const char *, nros_cpp_endpoint_info_visit_fn, void *) =
+        &Executor::get_subscriptions_info_by_topic;
+
+    (void)p_pub_by_node;
+    (void)p_sub_by_node;
+    (void)p_srv_by_node;
+    (void)p_cli_by_node;
+    (void)p_pubs_info;
+    (void)p_subs_info;
+
     // And the visitor typedefs must accept conforming functions.
     nros_cpp_node_visit_fn nv = visit_node;
     nros_cpp_names_and_types_visit_fn ntv = visit_names_and_types;

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -3474,6 +3474,113 @@ impl<'s> Executor<'s> {
             .map_err(NodeError::Transport)
     }
 
+    /// phase-381 W4 — what one named node PUBLISHES, with the types.
+    ///
+    /// `visit(topic_name, types)` per distinct topic. A node the graph has not
+    /// discovered yields no visits, which is not an error — see
+    /// [`Self::get_node_names`] for why an empty answer means "not seen yet".
+    pub fn get_publisher_names_and_types_by_node(
+        &mut self,
+        node_name: &str,
+        node_namespace: &str,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), NodeError> {
+        use nros_rmw::{GraphEntityKind, Session};
+        self.session
+            .get_names_and_types_by_node(
+                GraphEntityKind::Publisher,
+                node_name,
+                node_namespace,
+                visit,
+            )
+            .map_err(NodeError::Transport)
+    }
+
+    /// phase-381 W4 — what one named node SUBSCRIBES to, with the types.
+    ///
+    /// **`subscription`, not `subscriber`** — this is rclrs's spelling
+    /// (`get_subscription_names_and_types_by_node`), and the Rust surface takes
+    /// its vocabulary from rclrs so a user porting Rust ROS 2 code types what
+    /// they already know. The C surface says `subscriber` because rcl does, and
+    /// the vtable slot says `subscriber` because upstream rmw does. Three
+    /// layers, three upstreams, one word each — not drift. Issue 0788 owns the
+    /// wider verb sweep.
+    pub fn get_subscription_names_and_types_by_node(
+        &mut self,
+        node_name: &str,
+        node_namespace: &str,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), NodeError> {
+        use nros_rmw::{GraphEntityKind, Session};
+        self.session
+            .get_names_and_types_by_node(
+                GraphEntityKind::Subscriber,
+                node_name,
+                node_namespace,
+                visit,
+            )
+            .map_err(NodeError::Transport)
+    }
+
+    /// phase-381 W4 — what services one named node SERVES, with the types.
+    pub fn get_service_names_and_types_by_node(
+        &mut self,
+        node_name: &str,
+        node_namespace: &str,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), NodeError> {
+        use nros_rmw::{GraphEntityKind, Session};
+        self.session
+            .get_names_and_types_by_node(GraphEntityKind::Service, node_name, node_namespace, visit)
+            .map_err(NodeError::Transport)
+    }
+
+    /// phase-381 W4 — what services one named node CALLS, with the types.
+    pub fn get_client_names_and_types_by_node(
+        &mut self,
+        node_name: &str,
+        node_namespace: &str,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), NodeError> {
+        use nros_rmw::{GraphEntityKind, Session};
+        self.session
+            .get_names_and_types_by_node(GraphEntityKind::Client, node_name, node_namespace, visit)
+            .map_err(NodeError::Transport)
+    }
+
+    /// phase-381 W4 — the publishers on `topic_name`, one visit each.
+    ///
+    /// Each `GraphEndpointInfo` BORROWS its strings for the duration of the
+    /// visit; copy anything kept.
+    ///
+    /// It carries no QoS. The granted profile is what would answer "why is
+    /// nothing arriving", and no backend can read one back yet — reporting the
+    /// remote's DECLARED profile instead would be a confident wrong answer, so
+    /// the field is absent rather than misleading.
+    pub fn get_publishers_info_by_topic(
+        &mut self,
+        topic_name: &str,
+        visit: &mut dyn FnMut(&nros_rmw::GraphEndpointInfo<'_>) -> bool,
+    ) -> Result<(), NodeError> {
+        use nros_rmw::Session;
+        self.session
+            .get_endpoint_info_by_topic(true, topic_name, visit)
+            .map_err(NodeError::Transport)
+    }
+
+    /// phase-381 W4 — the subscriptions on `topic_name`, one visit each.
+    /// See [`Self::get_publishers_info_by_topic`].
+    pub fn get_subscriptions_info_by_topic(
+        &mut self,
+        topic_name: &str,
+        visit: &mut dyn FnMut(&nros_rmw::GraphEndpointInfo<'_>) -> bool,
+    ) -> Result<(), NodeError> {
+        use nros_rmw::Session;
+        self.session
+            .get_endpoint_info_by_topic(false, topic_name, visit)
+            .map_err(NodeError::Transport)
+    }
+
     /// Get a mutable reference to an action client core in the arena by entry index.
     ///
     /// # Safety

--- a/packages/core/nros-rmw/src/lib.rs
+++ b/packages/core/nros-rmw/src/lib.rs
@@ -69,13 +69,14 @@ pub use safety::{IntegrityStatus, SafetyValidator, crc32};
 
 // Re-export main types
 pub use traits::{
-    ActionInfo, ClientTrait, DURATION_INFINITE_MS, LocatorProtocol, Publisher, QoSDurabilityPolicy,
-    QoSHistoryPolicy, QoSLivelinessPolicy, QoSOverride, QoSOverrideCode, QoSOverrideRole,
-    QoSOverrideValue, QoSPolicyMask, QoSProfile, QoSReliabilityPolicy, Rmw, RmwConfig, ServiceInfo,
-    ServiceRequest, ServiceTrait, Session, SessionMode, Subscription, TopicInfo, Transport,
-    TransportConfig, TransportError, decode_qos_override, decode_qos_override_parts,
-    decode_qos_override_role, decode_qos_override_value, duration_to_qos_ms, locator_protocol,
-    qos_override_policy, qos_override_role, validate_locator,
+    ActionInfo, ClientTrait, DURATION_INFINITE_MS, GraphEndpointInfo, GraphEntityKind,
+    LocatorProtocol, Publisher, QoSDurabilityPolicy, QoSHistoryPolicy, QoSLivelinessPolicy,
+    QoSOverride, QoSOverrideCode, QoSOverrideRole, QoSOverrideValue, QoSPolicyMask, QoSProfile,
+    QoSReliabilityPolicy, Rmw, RmwConfig, ServiceInfo, ServiceRequest, ServiceTrait, Session,
+    SessionMode, Subscription, TopicInfo, Transport, TransportConfig, TransportError,
+    decode_qos_override, decode_qos_override_parts, decode_qos_override_role,
+    decode_qos_override_value, duration_to_qos_ms, locator_protocol, qos_override_policy,
+    qos_override_role, validate_locator,
 };
 
 // Re-export `MessageInfo` from nros-core so backends implementing

--- a/packages/core/nros-rmw/src/traits.rs
+++ b/packages/core/nros-rmw/src/traits.rs
@@ -1458,7 +1458,112 @@ pub trait Session {
         let _ = visit;
         Err(TransportError::Unsupported.into())
     }
+
+    /// phase-381 W3 — what ONE named node publishes / subscribes / serves /
+    /// calls.
+    ///
+    /// `node_name` and `node_namespace` are ROS names; a node the graph has not
+    /// discovered yields no visits, which is NOT an error — see
+    /// [`Self::get_node_names`] for why an empty answer is "not seen yet".
+    ///
+    /// `kind` selects which of the four upstream `*_by_node` questions this
+    /// answers. One method rather than four because the four differ ONLY by
+    /// which entity kind they keep, and four trait methods would be four copies
+    /// of one filter.
+    ///
+    /// The trait keeps the ABI's `subscriber` vocabulary because
+    /// `rmw_get_subscriber_names_and_types_by_node` is what upstream rmw calls
+    /// it and RFC-0054 makes the C headers the SSoT. The USER-facing spelling
+    /// is per language and settled at that layer: rcl says `subscriber`, rclcpp
+    /// and rclrs say `subscription`.
+    ///
+    /// Default body: `Err(Unsupported)`.
+    fn get_names_and_types_by_node(
+        &mut self,
+        kind: GraphEntityKind,
+        node_name: &str,
+        node_namespace: &str,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), Self::Error>
+    where
+        Self::Error: From<TransportError>,
+    {
+        let _ = (kind, node_name, node_namespace, visit);
+        Err(TransportError::Unsupported.into())
+    }
+
+    /// phase-381 W3 — the endpoints on one topic, with the QoS each GRANTED.
+    ///
+    /// `publishers` selects `rmw_get_publishers_info_by_topic` (`true`) or
+    /// `rmw_get_subscriptions_info_by_topic` (`false`).
+    ///
+    /// The granted profile is the whole reason a consumer asks: "why is nothing
+    /// arriving" is usually a QoS incompatibility, and the REQUESTED profile
+    /// cannot answer it. A backend that cannot read a remote's granted QoS says
+    /// so per field rather than echoing the request back — see
+    /// `rmw_topic_endpoint_info_t`.
+    ///
+    /// Default body: `Err(Unsupported)`.
+    fn get_endpoint_info_by_topic(
+        &mut self,
+        publishers: bool,
+        topic_name: &str,
+        visit: &mut dyn FnMut(&GraphEndpointInfo<'_>) -> bool,
+    ) -> Result<(), Self::Error>
+    where
+        Self::Error: From<TransportError>,
+    {
+        let _ = (publishers, topic_name, visit);
+        Err(TransportError::Unsupported.into())
+    }
 }
+
+/// Which entity kind a `*_by_node` graph query keeps — phase-381 W3.
+///
+/// Named for upstream rmw's four `*_by_node` slots. `Subscriber` carries rmw's
+/// word, not rclcpp's `subscription`; the user-facing spelling is chosen per
+/// language one layer up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphEntityKind {
+    Publisher,
+    Subscriber,
+    Service,
+    Client,
+}
+
+/// One discovered endpoint on a topic — phase-381 W3, the Rust view of
+/// `rmw_topic_endpoint_info_t`.
+///
+/// Every string BORROWS from the backend's own state for the duration of the
+/// visit. A caller that needs one afterwards copies it; that is what lets the
+/// graph stream without an allocator.
+#[derive(Debug, Clone)]
+pub struct GraphEndpointInfo<'a> {
+    /// Node that owns the endpoint.
+    pub node_name: &'a str,
+    /// That node's namespace.
+    pub node_namespace: &'a str,
+    /// Fully-qualified type on the wire, e.g. `"std_msgs/msg/Int32"`.
+    pub topic_type: &'a str,
+    /// `true` for a publisher, `false` for a subscription.
+    pub is_publisher: bool,
+    /// The endpoint's 24-byte identity; all-zero when the backend has none.
+    pub endpoint_gid: [u8; 24],
+}
+
+// No `qos` field, deliberately. The C seam carries one and fills it with the
+// ABI's `*_UNKNOWN` sentinels, which is the contract for a policy a backend
+// cannot determine (see `publisher_get_actual_qos`: write UNKNOWN and return
+// OK; `UNSUPPORTED` means no read-back AT ALL).
+//
+// No backend can fill it today. zenoh's liveliness token carries the DECLARING
+// side's own profile, not a negotiated grant, and this seam promises the
+// granted one — reporting the declaration would be the plausible wrong answer
+// the slot exists to avoid, since "why is nothing arriving" is usually a QoS
+// mismatch and the requested profile cannot show it. Cyclone can read a real
+// grant and will need this; adding a field to a Rust struct then is additive
+// and not an ABI change, which is why carrying an always-`None` field now
+// buys nothing.
 
 /// Bitmask of QoS policies a backend can honour. See
 /// [`Session::supported_qos_policies`].

--- a/packages/rmw/cffi/src/lib.rs
+++ b/packages/rmw/cffi/src/lib.rs
@@ -1483,6 +1483,41 @@ pub struct CffiSession {
     domain_id: u32,
 }
 
+/// phase-381 W5/W6 — the C graph visitor, turned back into a Rust closure call.
+///
+/// `ctx` is a `*mut &mut dyn FnMut(...)`, which is how the borrowed closure
+/// crosses the C boundary. The strings are BORROWED for this call only, which
+/// is the contract on both sides.
+///
+/// A name that is not valid UTF-8 is SKIPPED rather than lossily converted: a
+/// mangled node name is a different, plausible node.
+///
+/// # Safety
+/// Called only by a backend slot this crate handed `ctx` to.
+unsafe extern "C" fn node_visit_trampoline(
+    ctx: *mut core::ffi::c_void,
+    node_name: *const core::ffi::c_char,
+    node_namespace: *const core::ffi::c_char,
+    enclave: *const core::ffi::c_char,
+) -> bool {
+    if ctx.is_null() || node_name.is_null() || node_namespace.is_null() {
+        return true; // skip this entry, keep enumerating
+    }
+    let cb = unsafe { &mut *(ctx as *mut &mut dyn FnMut(&str, &str, Option<&str>) -> bool) };
+    let (Ok(name), Ok(ns)) = (
+        unsafe { core::ffi::CStr::from_ptr(node_name) }.to_str(),
+        unsafe { core::ffi::CStr::from_ptr(node_namespace) }.to_str(),
+    ) else {
+        return true;
+    };
+    let enc = if enclave.is_null() {
+        None
+    } else {
+        unsafe { core::ffi::CStr::from_ptr(enclave) }.to_str().ok()
+    };
+    cb(name, ns, enc)
+}
+
 impl CffiSession {
     /// Domain this session was opened on. Authoritative: it is the value the
     /// backend actually got, not a re-derivation that can disagree with it.
@@ -2116,6 +2151,43 @@ impl Session for CffiSession {
         // Cyclone wrapper, current dust-DDS shim) leave the slot
         // NULL; only backends with an async wake source fill it.
         self.vtable.set_wake_callback.is_some()
+    }
+
+    /// phase-381 W5/W6 — forward to the backend's slot; NULL means UNSUPPORTED.
+    ///
+    /// Without this the graph slots were unreachable for every C backend: the
+    /// trait default returns `Unsupported`, so a wired slot — cyclone's, as of
+    /// W5 — would never be called and would look implemented while being dead
+    /// code. That is exactly the "a slot exists, therefore it works"
+    /// overstatement issue 0800 measured, one layer above where 0800 found it.
+    ///
+    /// NULL surfaces `Unsupported` rather than an empty enumeration, which is
+    /// W6's requirement: XRCE has no graph and must say "cannot tell you", not
+    /// "nothing is there".
+    fn get_node_names(
+        &mut self,
+        visit: &mut dyn FnMut(&str, &str, Option<&str>) -> bool,
+    ) -> Result<(), TransportError> {
+        let Some(f) = self.vtable.get_node_names else {
+            return Err(TransportError::Unsupported);
+        };
+        // The C visitor gets a pointer to this closure as its `ctx`; the
+        // trampoline below turns the borrowed C strings back into `&str`.
+        // `&view`, not `&mut`: the slot takes a `const rmw_session_t *`.
+        let view = self.make_view();
+        let mut cb: &mut dyn FnMut(&str, &str, Option<&str>) -> bool = visit;
+        let rc = unsafe {
+            f(
+                &view as *const NrosRmwSession,
+                Some(node_visit_trampoline),
+                &mut cb as *mut _ as *mut core::ffi::c_void,
+            )
+        };
+        if rc == NROS_RMW_RET_OK {
+            Ok(())
+        } else {
+            Err(error_from_ret(rc))
+        }
     }
 
     fn ping_session(&mut self, timeout_ms: i32) -> Result<(), TransportError> {
@@ -4230,6 +4302,45 @@ mod tests {
     // This test is the pair to `register_rejects_incomplete_vtable` above: one
     // asserts the gate still bites, this asserts it does not over-bite. Keep
     // both — dropping either turns the gate into a one-way ratchet.
+    /// phase-381 W6 — a NULL graph slot must say UNSUPPORTED, not "empty".
+    ///
+    /// The distinction is the whole of W6. XRCE has no graph at all: its C
+    /// vtable is a designated initializer, so every graph slot is NULL by
+    /// omission. If a NULL slot produced `Ok(())` with no visits, a caller
+    /// could not tell "this backend cannot answer" from "the graph is empty",
+    /// and would conclude a peer is absent when it simply cannot be seen.
+    ///
+    /// This also guards the reverse defect, which nearly shipped: `CffiSession`
+    /// had NO `get_node_names` at all, so it fell through to the trait default
+    /// and returned `Unsupported` even for a backend whose slot WAS wired —
+    /// cyclone's, once W5 filled it. The slot would have looked implemented
+    /// while being dead code, which is issue 0800's overstatement one layer up.
+    #[test]
+    fn a_null_graph_slot_reports_unsupported_not_an_empty_graph() {
+        use nros_rmw::{Session, TransportError};
+
+        // A vtable with every required slot and NO graph slots — the shape a C
+        // backend gets from `.field = ...` designated init.
+        let mut session = CffiSession {
+            vtable: &STUB_VTABLE,
+            node_name_buf: [0u8; NAME_BUF_LEN],
+            namespace_buf: [0u8; NAME_BUF_LEN],
+            backend_data: core::ptr::dangling_mut::<c_void>(),
+            domain_id: 0,
+        };
+        let mut seen = 0usize;
+        let mut visit = |_n: &str, _ns: &str, _e: Option<&str>| {
+            seen += 1;
+            true
+        };
+        let r = Session::get_node_names(&mut session, &mut visit);
+        assert!(
+            matches!(r, Err(TransportError::Unsupported)),
+            "a NULL slot must report Unsupported, got {r:?}"
+        );
+        assert_eq!(seen, 0, "nothing may be visited when the slot is absent");
+    }
+
     #[test]
     fn register_accepts_vtable_without_optional_capability_slots() {
         let mut vt = STUB_VTABLE;

--- a/packages/rmw/cffi/src/rust_adapter.rs
+++ b/packages/rmw/cffi/src/rust_adapter.rs
@@ -56,6 +56,15 @@ use crate::{
     NrosRmwSubscription, NrosRmwVtable, event_kind_from_c, ret_from_error, rmw_publisher_options_t,
     rmw_subscription_options_t,
 };
+// phase-381 W3 — the endpoint-info slots marshal the generated ABI types
+// directly. Imported from `generated` rather than re-exported through the crate
+// root: these are bindgen output and the root deliberately re-exports only the
+// hand-maintained surface.
+use crate::generated::{
+    NROS_RMW_DURABILITY_UNKNOWN, NROS_RMW_HISTORY_UNKNOWN, NROS_RMW_RELIABILITY_UNKNOWN,
+    rmw_endpoint_type_t, rmw_gid_t, rmw_liveliness_kind_t, rmw_qos_profile_t,
+    rmw_topic_endpoint_info_t,
+};
 
 #[cfg(all(target_os = "none", not(feature = "std")))]
 mod static_subscriber_storage {
@@ -358,6 +367,23 @@ impl<R: RustBackend> RustBackendAdapter<R> {
         count_subscribers: Some(count_subscribers_trampoline::<R>),
         get_topic_names_and_types: Some(get_topic_names_and_types_trampoline::<R>),
         get_service_names_and_types: Some(get_service_names_and_types_trampoline::<R>),
+        // phase-381 W3 — the last six. The trait defaults are `Unsupported`, so
+        // a backend with no graph still answers "cannot tell you" rather than
+        // an empty graph.
+        get_publisher_names_and_types_by_node: Some(
+            get_publisher_names_and_types_by_node_trampoline::<R>,
+        ),
+        get_subscriber_names_and_types_by_node: Some(
+            get_subscriber_names_and_types_by_node_trampoline::<R>,
+        ),
+        get_service_names_and_types_by_node: Some(
+            get_service_names_and_types_by_node_trampoline::<R>,
+        ),
+        get_client_names_and_types_by_node: Some(
+            get_client_names_and_types_by_node_trampoline::<R>,
+        ),
+        get_publishers_info_by_topic: Some(get_publishers_info_by_topic_trampoline::<R>),
+        get_subscriptions_info_by_topic: Some(get_subscriptions_info_by_topic_trampoline::<R>),
         ..EMPTY_VTABLE
     };
 
@@ -1459,6 +1485,261 @@ names_and_types_trampoline!(
     get_service_names_and_types_trampoline,
     get_service_names_and_types
 );
+
+/// phase-381 W3 — the four `*_by_node` slots, one body.
+///
+/// Longhand callers, shared implementation: they differ only by which
+/// `GraphEntityKind` they pass, and four copies of this marshalling is four
+/// chances for one of them to drift.
+///
+/// # Safety
+/// Same contract as the slots that call it.
+unsafe fn by_node_impl<R: RustBackend>(
+    session: *const NrosRmwSession,
+    node_name: *const c_char,
+    node_namespace: *const c_char,
+    no_demangle: bool,
+    visit: Option<
+        unsafe extern "C" fn(*mut c_void, *const c_char, *const *const c_char, usize) -> bool,
+    >,
+    ctx: *mut c_void,
+    kind: nros_rmw::GraphEntityKind,
+) -> NrosRmwRet {
+    // `no_demangle` asks for the WIRE spelling; we report ROS names, so
+    // honouring it would mean re-mangling what was just demangled. Refused
+    // rather than ignored — ignoring answers a different question than asked.
+    if no_demangle {
+        return NROS_RMW_RET_UNSUPPORTED;
+    }
+    if node_name.is_null() || node_namespace.is_null() {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    let Some(visit) = visit else {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    };
+    let Some(s) = (unsafe { session_mut::<R::Session>(session.cast_mut()) }) else {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    };
+    let (Ok(name), Ok(ns)) = (
+        unsafe { core::ffi::CStr::from_ptr(node_name) }.to_str(),
+        unsafe { core::ffi::CStr::from_ptr(node_namespace) }.to_str(),
+    ) else {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    };
+
+    const NAME_MAX: usize = 256;
+    const TYPES_MAX: usize = 8;
+    let mut cb = |n: &str, types: &[&str]| -> bool {
+        let mut name_buf = [0u8; NAME_MAX];
+        if n.len() >= NAME_MAX {
+            return true;
+        }
+        name_buf[..n.len()].copy_from_slice(n.as_bytes());
+        let mut type_bufs = [[0u8; NAME_MAX]; TYPES_MAX];
+        let mut ptrs: [*const c_char; TYPES_MAX] = [core::ptr::null(); TYPES_MAX];
+        let mut count = 0usize;
+        for t in types.iter().take(TYPES_MAX) {
+            if t.len() >= NAME_MAX {
+                continue;
+            }
+            type_bufs[count][..t.len()].copy_from_slice(t.as_bytes());
+            ptrs[count] = type_bufs[count].as_ptr() as *const c_char;
+            count += 1;
+        }
+        unsafe {
+            visit(
+                ctx,
+                name_buf.as_ptr() as *const c_char,
+                ptrs.as_ptr(),
+                count,
+            )
+        }
+    };
+    match Session::get_names_and_types_by_node(s, kind, name, ns, &mut cb) {
+        Ok(()) => NROS_RMW_RET_OK,
+        Err(e) => ret_from_error(&e),
+    }
+}
+
+macro_rules! by_node_trampoline {
+    // Upstream gives `no_demangle` to the publisher and subscriber forms and
+    // NOT to the service and client ones. Mirrored rather than smoothed over —
+    // RFC-0054 makes these headers the ABI SSoT, so an asymmetry upstream has
+    // is one we have.
+    ($name:ident, $kind:ident, no_demangle) => {
+        unsafe extern "C" fn $name<R: RustBackend>(
+            session: *const NrosRmwSession,
+            node_name: *const c_char,
+            node_namespace: *const c_char,
+            no_demangle: bool,
+            visit: Option<
+                unsafe extern "C" fn(
+                    *mut c_void,
+                    *const c_char,
+                    *const *const c_char,
+                    usize,
+                ) -> bool,
+            >,
+            ctx: *mut c_void,
+        ) -> NrosRmwRet {
+            unsafe {
+                by_node_impl::<R>(
+                    session,
+                    node_name,
+                    node_namespace,
+                    no_demangle,
+                    visit,
+                    ctx,
+                    nros_rmw::GraphEntityKind::$kind,
+                )
+            }
+        }
+    };
+    // The service and client forms, which upstream gives no `no_demangle`.
+    ($name:ident, $kind:ident) => {
+        unsafe extern "C" fn $name<R: RustBackend>(
+            session: *const NrosRmwSession,
+            node_name: *const c_char,
+            node_namespace: *const c_char,
+            visit: Option<
+                unsafe extern "C" fn(
+                    *mut c_void,
+                    *const c_char,
+                    *const *const c_char,
+                    usize,
+                ) -> bool,
+            >,
+            ctx: *mut c_void,
+        ) -> NrosRmwRet {
+            unsafe {
+                by_node_impl::<R>(
+                    session,
+                    node_name,
+                    node_namespace,
+                    false,
+                    visit,
+                    ctx,
+                    nros_rmw::GraphEntityKind::$kind,
+                )
+            }
+        }
+    };
+}
+
+by_node_trampoline!(
+    get_publisher_names_and_types_by_node_trampoline,
+    Publisher,
+    no_demangle
+);
+by_node_trampoline!(
+    get_subscriber_names_and_types_by_node_trampoline,
+    Subscriber,
+    no_demangle
+);
+by_node_trampoline!(get_service_names_and_types_by_node_trampoline, Service);
+by_node_trampoline!(get_client_names_and_types_by_node_trampoline, Client);
+
+/// phase-381 W3 — the two `*_info_by_topic` slots, one body.
+///
+/// # Safety
+/// Same contract as the slots that call it.
+unsafe fn endpoint_info_impl<R: RustBackend>(
+    session: *const NrosRmwSession,
+    topic_name: *const c_char,
+    no_mangle: bool,
+    visit: Option<unsafe extern "C" fn(*mut c_void, *const rmw_topic_endpoint_info_t) -> bool>,
+    ctx: *mut c_void,
+    publishers: bool,
+) -> NrosRmwRet {
+    if no_mangle {
+        return NROS_RMW_RET_UNSUPPORTED;
+    }
+    if topic_name.is_null() {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    let Some(visit) = visit else {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    };
+    let Some(s) = (unsafe { session_mut::<R::Session>(session.cast_mut()) }) else {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    };
+    let Ok(topic) = (unsafe { core::ffi::CStr::from_ptr(topic_name) }).to_str() else {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    };
+
+    const NAME_MAX: usize = 256;
+    let mut cb = |info: &nros_rmw::GraphEndpointInfo<'_>| -> bool {
+        let mut name_buf = [0u8; NAME_MAX];
+        let mut ns_buf = [0u8; NAME_MAX];
+        let mut ty_buf = [0u8; NAME_MAX];
+        if info.node_name.len() >= NAME_MAX
+            || info.node_namespace.len() >= NAME_MAX
+            || info.topic_type.len() >= NAME_MAX
+        {
+            return true; // skip, never truncate
+        }
+        name_buf[..info.node_name.len()].copy_from_slice(info.node_name.as_bytes());
+        ns_buf[..info.node_namespace.len()].copy_from_slice(info.node_namespace.as_bytes());
+        ty_buf[..info.topic_type.len()].copy_from_slice(info.topic_type.as_bytes());
+        // The struct has no "qos known" flag, by design: the ABI expresses an
+        // unreadable policy with the `*_UNKNOWN` sentinels and the contract on
+        // `publisher_get_actual_qos` spells it out — write UNKNOWN for what you
+        // cannot determine and return OK; `UNSUPPORTED` means no read-back AT
+        // ALL, not "I know some of it".
+        //
+        // zenoh's liveliness token DOES carry a QoS chunk, but decoding it is
+        // deferred rather than guessed: it is the DECLARING side's own profile
+        // and this seam promises a GRANTED one, so shipping it now would be the
+        // plausible wrong answer this slot exists to avoid. `GraphEndpointInfo::qos`
+        // is `None` from every backend today, so this is always the UNKNOWN arm.
+        let mut qos: rmw_qos_profile_t = unsafe { core::mem::zeroed() };
+        qos.reliability = NROS_RMW_RELIABILITY_UNKNOWN as u8;
+        qos.durability = NROS_RMW_DURABILITY_UNKNOWN as u8;
+        qos.history = NROS_RMW_HISTORY_UNKNOWN as u8;
+        qos.liveliness_kind = rmw_liveliness_kind_t::NROS_RMW_LIVELINESS_UNKNOWN as u8;
+        let c_info = rmw_topic_endpoint_info_t {
+            node_name: name_buf.as_ptr() as *const c_char,
+            node_namespace: ns_buf.as_ptr() as *const c_char,
+            topic_type: ty_buf.as_ptr() as *const c_char,
+            endpoint_type: if info.is_publisher {
+                rmw_endpoint_type_t::RMW_ENDPOINT_PUBLISHER
+            } else {
+                rmw_endpoint_type_t::RMW_ENDPOINT_SUBSCRIPTION
+            },
+            endpoint_gid: rmw_gid_t {
+                implementation_identifier: core::ptr::null(),
+                data: info.endpoint_gid,
+            },
+            qos_profile: qos,
+        };
+        unsafe { visit(ctx, &c_info as *const rmw_topic_endpoint_info_t) }
+    };
+    match Session::get_endpoint_info_by_topic(s, publishers, topic, &mut cb) {
+        Ok(()) => NROS_RMW_RET_OK,
+        Err(e) => ret_from_error(&e),
+    }
+}
+
+macro_rules! endpoint_info_trampoline {
+    ($name:ident, $publishers:expr) => {
+        unsafe extern "C" fn $name<R: RustBackend>(
+            session: *const NrosRmwSession,
+            topic_name: *const c_char,
+            no_mangle: bool,
+            visit: Option<
+                unsafe extern "C" fn(*mut c_void, *const rmw_topic_endpoint_info_t) -> bool,
+            >,
+            ctx: *mut c_void,
+        ) -> NrosRmwRet {
+            unsafe {
+                endpoint_info_impl::<R>(session, topic_name, no_mangle, visit, ctx, $publishers)
+            }
+        }
+    };
+}
+
+endpoint_info_trampoline!(get_publishers_info_by_topic_trampoline, true);
+endpoint_info_trampoline!(get_subscriptions_info_by_topic_trampoline, false);
 
 unsafe extern "C" fn publish_streamed_trampoline<R: RustBackend>(
     publisher: *mut NrosRmwPublisher,

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.cpp
@@ -85,6 +85,9 @@ void graph_fini(GraphState* g) {
     // reset state here (session_destroy deletes the participant).
     g->writer = 0;
     g->topic = 0;
+    // phase-381 W5 — the graph reader cascades from the participant like the
+    // writer does; only the handle is reset here.
+    g->graph_reader = 0;
     g->active = false;
     g->n_readers = 0;
     g->n_writers = 0;
@@ -172,6 +175,105 @@ void graph_publish(GraphState* g) {
     sample.node_entities_info_seq._release = false;
 
     (void)dds_write(g->writer, &sample);
+}
+
+/// phase-381 W5 — the READER half. Contract in graph.hpp.
+bool graph_visit_nodes(GraphState* g, void* ctx,
+                       bool (*visit)(void* ctx, const char* node_name,
+                                     const char* node_namespace)) {
+    if (g == nullptr || visit == nullptr || !g->active || g->topic <= 0) {
+        return false;
+    }
+
+    // How many samples one query looks at, and the only storage this adds.
+    // A participant republishes its FULL snapshot on every mutation, so the
+    // newest samples are the current view; this bounds how much of it is read
+    // at once rather than how much is retained (nothing is).
+    constexpr uint32_t kMaxSamples = 16;
+
+    if (g->graph_reader <= 0) {
+        // Created on FIRST USE, not at init: a node that never asks pays no
+        // reader, no history and no discovery traffic, which is most embedded
+        // images.
+        //
+        // Matches the writer's QoS deliberately — RELIABLE + TRANSIENT_LOCAL is
+        // what makes a late reader receive the snapshots participants latched
+        // before it existed, which is the whole reason the writer latches.
+        // KEEP_LAST(kMaxSamples) rather than (1): the topic is KEYLESS, so one
+        // instance carries every participant's samples and a depth of 1 would
+        // hold whichever wrote last.
+        dds_qos_t* qos = dds_create_qos();
+        dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
+        dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+        dds_qset_history(qos, DDS_HISTORY_KEEP_LAST, static_cast<int32_t>(kMaxSamples));
+        dds_entity_t r = dds_create_reader(dds_get_participant(g->topic), g->topic, qos, nullptr);
+        dds_delete_qos(qos);
+        if (r < 0) {
+            return false;
+        }
+        g->graph_reader = r;
+        // Nothing has been delivered on a reader created this instant, so the
+        // first call legitimately reports an empty graph and the next sees the
+        // latched snapshots. Same warm-up the zenoh side documents.
+    }
+
+    void* raw[kMaxSamples] = {nullptr};
+    dds_sample_info_t info[kMaxSamples];
+    // READ, not TAKE: taking would drain the history, so a second query would
+    // see nothing and the graph would appear to vanish after one look.
+    int32_t n = dds_read(g->graph_reader, raw, info, kMaxSamples, kMaxSamples);
+    if (n <= 0) {
+        return true; // active, nothing discovered yet
+    }
+
+    // The topic is keyless, so several samples can describe the SAME
+    // participant — an older snapshot and a newer one both sit in history.
+    // Stock rmw keeps a user-space graph cache keyed by participant gid; we
+    // dedup within this batch instead and keep nothing between calls. Newest
+    // first, so the first sample seen for a gid is the current one.
+    uint8_t seen[kMaxSamples][24];
+    int n_seen = 0;
+
+    for (int32_t i = n - 1; i >= 0; --i) {
+        if (!info[i].valid_data) {
+            continue;
+        }
+        auto* sample = static_cast<rmw_dds_common_msg_dds__ParticipantEntitiesInfo_*>(raw[i]);
+        if (sample == nullptr) {
+            continue;
+        }
+        // Our OWN participant is in the graph too; reporting it is correct —
+        // `ros2 node list` lists the asking node as well.
+        bool dup = false;
+        for (int k = 0; k < n_seen; ++k) {
+            if (std::memcmp(seen[k], sample->gid.data, 24) == 0) {
+                dup = true;
+                break;
+            }
+        }
+        if (dup) {
+            continue;
+        }
+        if (n_seen < static_cast<int>(kMaxSamples)) {
+            std::memcpy(seen[n_seen++], sample->gid.data, 24);
+        }
+
+        const uint32_t count = sample->node_entities_info_seq._length;
+        auto* nodes = sample->node_entities_info_seq._buffer;
+        if (nodes == nullptr) {
+            continue;
+        }
+        for (uint32_t j = 0; j < count; ++j) {
+            if (!visit(ctx, nodes[j].node_name, nodes[j].node_namespace)) {
+                (void)dds_return_loan(g->graph_reader, raw, n);
+                return true;
+            }
+        }
+    }
+
+    // The samples are LOANED from the reader; returning them is not optional.
+    (void)dds_return_loan(g->graph_reader, raw, n);
+    return true;
 }
 
 } // namespace nros_rmw_cyclonedds

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/graph.hpp
@@ -24,6 +24,13 @@ struct GraphState {
 
     dds_entity_t topic{0};
     dds_entity_t writer{0}; // latched ros_discovery_info writer
+    /// phase-381 W5 — the READER half. Cyclone published `ros_discovery_info`
+    /// and never read it, so a nano-ros node was visible in the graph and
+    /// blind to it, which is the asymmetry issue 0791 is about.
+    ///
+    /// Created lazily on the first graph query: a node that never asks pays
+    /// nothing, which matters because most embedded images never ask.
+    dds_entity_t graph_reader{0};
     uint8_t participant_gid[24]{};
     char node_namespace[256]{};
     char node_name[256]{};
@@ -56,6 +63,26 @@ void graph_untrack_writer(GraphState* g, dds_entity_t writer);
 void graph_untrack_reader(GraphState* g, dds_entity_t reader);
 
 void graph_publish(GraphState* g);
+
+/// phase-381 W5 — visit every node this participant can SEE.
+///
+/// `visit(ctx, node_name, node_namespace)` per discovered node; return `false`
+/// to stop. Strings are BORROWED for the duration of the call.
+///
+/// Reads the `ros_discovery_info` samples other participants latched, WITHOUT
+/// consuming them (`dds_read`, not `dds_take`), so repeated calls see the
+/// current view rather than draining it once.
+///
+/// **No persistent cache.** The topic is keyless, so stock rmw dedups by
+/// participant gid in user space and keeps a graph cache; we dedup within the
+/// READ BATCH instead and keep nothing between calls. Bounded by the batch
+/// size, which is the only storage this adds.
+///
+/// Returns `false` if the graph is inactive (no descriptor / no reader), which
+/// the caller reports as `UNSUPPORTED` — distinct from an empty graph.
+bool graph_visit_nodes(GraphState* g, void* ctx,
+                       bool (*visit)(void* ctx, const char* node_name,
+                                     const char* node_namespace));
 
 } // namespace nros_rmw_cyclonedds
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
@@ -87,6 +87,45 @@ static rmw_ret_t cyclone_subscription_count_matched_publishers(
  * `RMW_GID_STORAGE_SIZE`). Zero-pad the tail rather than leaving it
  * uninitialised — a gid is COMPARED, and comparing 8 bytes of stack residue
  * makes two reads of the same publisher differ. */
+/* phase-381 W5 — read the graph Cyclone was already writing.
+ *
+ * `graph.cpp` has PUBLISHED this participant's `ros_discovery_info` since
+ * phase-177.36 so stock `ros2 node list` can see us, and never read the topic
+ * back — so a nano-ros node was visible in the graph and blind to it. That
+ * asymmetry is what issue 0791 is about, and this closes the Cyclone half of
+ * it.
+ *
+ * The reader is created on FIRST USE inside `graph_visit_nodes`, so a node that
+ * never asks pays nothing.
+ *
+ * `enclave` is NULL: `ParticipantEntitiesInfo` carries none, and reporting a
+ * value we do not have would be worse than saying we do not — the ABI's NULL is
+ * exactly "this backend does not track one". */
+static rmw_ret_t cyclone_get_node_names(const rmw_session_t *session, rmw_node_visit_fn visit,
+                                        void *ctx) {
+    if (session == nullptr || visit == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    nros_rmw_cyclonedds::GraphState *g =
+        nros_rmw_cyclonedds::session_graph(const_cast<rmw_session_t *>(session));
+    if (g == nullptr) {
+        return NROS_RMW_RET_UNSUPPORTED;
+    }
+    struct Ctx {
+        rmw_node_visit_fn visit;
+        void *ctx;
+    } wrapper{visit, ctx};
+    const bool ok = nros_rmw_cyclonedds::graph_visit_nodes(
+        g, &wrapper, [](void *c, const char *name, const char *ns) -> bool {
+            auto *w = static_cast<Ctx *>(c);
+            return w->visit(w->ctx, name, ns, nullptr);
+        });
+    /* `false` means the graph is INACTIVE — no descriptor, no reader. That is
+     * "cannot tell you", which the ABI spells UNSUPPORTED and which stays
+     * distinct from an empty graph. */
+    return ok ? NROS_RMW_RET_OK : NROS_RMW_RET_UNSUPPORTED;
+}
+
 static rmw_ret_t cyclone_get_gid_for_publisher(const rmw_publisher_t *publisher, rmw_gid_t *gid) {
     if (publisher == nullptr || gid == nullptr) {
         return NROS_RMW_RET_INVALID_ARGUMENT;
@@ -324,7 +363,7 @@ const nros_rmw_vtable_t kVtable = {
     /*service_set_on_new_request_callback*/ nullptr,
     /*client_set_on_new_response_callback*/ nullptr,
     /*subscription_set_on_new_message_callback*/ nullptr,
-    /*get_node_names*/ nullptr,
+    /*get_node_names*/ cyclone_get_node_names,
     /*get_topic_names_and_types*/ nullptr,
     /*get_service_names_and_types*/ nullptr,
     /*get_publisher_names_and_types_by_node*/ nullptr,

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
@@ -208,6 +208,17 @@ enum GraphQuery {
     Entities,
 }
 
+/// Does this entity belong to the named node? `None` means "any node".
+///
+/// The namespace arrives MANGLED on both sides — the caller's was mangled once
+/// before the sweep — so this is a string compare and not a demangle per token.
+fn entity_on_node(e: &Ros2LivelinessEntity<'_>, node: Option<(&str, &str)>) -> bool {
+    match node {
+        None => true,
+        Some((name, ns_mangled)) => e.node_name == name && e.namespace == ns_mangled,
+    }
+}
+
 /// phase-381 W3 — how long a standing graph query waits for replies.
 ///
 /// Not a caller budget: `get_node_names` never blocks. This is the zenoh
@@ -712,6 +723,21 @@ impl ZenohSession {
         kinds: &[EntityKind],
         visit: &mut dyn FnMut(&str, &[&str]) -> bool,
     ) -> Result<(), TransportError> {
+        self.names_and_types_filtered(kinds, None, visit)
+    }
+
+    /// phase-381 W3 — the grouping, optionally narrowed to ONE node.
+    ///
+    /// `node` is `(name, MANGLED namespace)`. The whole-graph forms pass `None`
+    /// and the `*_by_node` forms pass `Some`, so the dedup exists once: four
+    /// per-node slots plus two whole-graph ones would otherwise be six copies
+    /// of one two-pass algorithm.
+    fn names_and_types_filtered(
+        &mut self,
+        kinds: &[EntityKind],
+        node: Option<(&str, &str)>,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), TransportError> {
         // Names already reported, so the outer pass makes progress. Bounded by
         // construction; a graph with more distinct names than this reports the
         // first `GRAPH_NAMES_MAX` of them.
@@ -722,7 +748,7 @@ impl ZenohSession {
             // Pass 1 — the next name we have not reported yet.
             let mut next: Option<heapless::String<GRAPH_NAME_MAX>> = None;
             self.for_each_entity(GraphQuery::Entities, &mut |e| {
-                if !kinds.contains(&e.kind) {
+                if !kinds.contains(&e.kind) || !entity_on_node(e, node) {
                     return true;
                 }
                 let Some(topic) = e.topic else { return true };
@@ -749,7 +775,10 @@ impl ZenohSession {
             let mut types: heapless::Vec<heapless::String<GRAPH_NAME_MAX>, GRAPH_TYPES_MAX> =
                 heapless::Vec::new();
             self.for_each_entity(GraphQuery::Entities, &mut |e| {
-                if !kinds.contains(&e.kind) || e.topic != Some(name.as_str()) {
+                if !kinds.contains(&e.kind)
+                    || e.topic != Some(name.as_str())
+                    || !entity_on_node(e, node)
+                {
                     return true;
                 }
                 if let Some(t) = e.type_name
@@ -1110,6 +1139,58 @@ impl Session for ZenohSession {
             &[EntityKind::ServiceServer, EntityKind::ServiceClient],
             visit,
         )
+    }
+
+    fn get_names_and_types_by_node(
+        &mut self,
+        kind: nros_rmw::GraphEntityKind,
+        node_name: &str,
+        node_namespace: &str,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), Self::Error> {
+        let want = match kind {
+            nros_rmw::GraphEntityKind::Publisher => EntityKind::Publisher,
+            nros_rmw::GraphEntityKind::Subscriber => EntityKind::Subscriber,
+            nros_rmw::GraphEntityKind::Service => EntityKind::ServiceServer,
+            nros_rmw::GraphEntityKind::Client => EntityKind::ServiceClient,
+        };
+        // The wire carries the namespace MANGLED (`/demo` -> `%demo`), so the
+        // caller's ROS name is mangled once here rather than demangling every
+        // token — the comparison happens per entity and the mangle does not.
+        let ns_mangled = Ros2Liveliness::mangle_topic_name_pub::<GRAPH_NAME_MAX>(node_namespace);
+        self.names_and_types_filtered(&[want], Some((node_name, ns_mangled.as_str())), visit)
+    }
+
+    fn get_endpoint_info_by_topic(
+        &mut self,
+        publishers: bool,
+        topic_name: &str,
+        visit: &mut dyn FnMut(&nros_rmw::GraphEndpointInfo<'_>) -> bool,
+    ) -> Result<(), Self::Error> {
+        let want = if publishers {
+            EntityKind::Publisher
+        } else {
+            EntityKind::Subscriber
+        };
+        let mangled = Ros2Liveliness::mangle_topic_name_pub::<GRAPH_NAME_MAX>(topic_name);
+        self.for_each_entity(GraphQuery::Entities, &mut |e| {
+            if e.kind != want || e.topic != Some(mangled.as_str()) {
+                return true;
+            }
+            let ns = Ros2Liveliness::demangle_topic_name::<GRAPH_NAME_MAX>(e.namespace);
+            let info = nros_rmw::GraphEndpointInfo {
+                node_name: e.node_name,
+                node_namespace: ns.as_str(),
+                topic_type: e.type_name.unwrap_or(""),
+                is_publisher: publishers,
+                // The liveliness token carries no GID — it identifies the
+                // entity by keyexpr, not by a 24-byte id. All-zero is the
+                // ABI's "this backend has none", which is honest; synthesising
+                // one from the zid would invent an identity a peer cannot match.
+                endpoint_gid: [0u8; 24],
+            };
+            visit(&info)
+        })
     }
 
     fn supported_qos_policies(&self) -> nros_rmw::QoSPolicyMask {

--- a/packages/testing/nros-tests/src/lib.rs
+++ b/packages/testing/nros-tests/src/lib.rs
@@ -1244,5 +1244,16 @@ mod w4_reachability {
         let _ = nros::Executor::get_service_names_and_types;
         let _ = nros::Executor::count_publishers;
         let _ = nros::Executor::count_subscribers;
+        // phase-381 W3/W4 — the six per-node and per-topic forms.
+        //
+        // `get_subscription_names_and_types_by_node`, NOT `subscriber`: the
+        // Rust surface takes rclrs's vocabulary. If someone "fixes" this to
+        // match the C spelling, this line stops compiling — which is the point.
+        let _ = nros::Executor::get_publisher_names_and_types_by_node;
+        let _ = nros::Executor::get_subscription_names_and_types_by_node;
+        let _ = nros::Executor::get_service_names_and_types_by_node;
+        let _ = nros::Executor::get_client_names_and_types_by_node;
+        let _ = nros::Executor::get_publishers_info_by_topic;
+        let _ = nros::Executor::get_subscriptions_info_by_topic;
     }
 }

--- a/scripts/check-rmw-slot-producers.py
+++ b/scripts/check-rmw-slot-producers.py
@@ -111,31 +111,6 @@ INERT_FAMILIES = {
         "driving several backends can use; the per-entity trio is reserved for "
         "parity",
     ),
-    "graph-queries": (
-        (
-            # phase-381 W3 — `get_node_names`, `get_topic_names_and_types` and
-            # `get_service_names_and_types` have LEFT this family: zenoh
-            # produces them from two standing liveliness queries. The
-            # per-node and per-topic forms stay until their own slots land.
-            "get_publisher_names_and_types_by_node",
-            "get_subscriber_names_and_types_by_node",
-            "get_service_names_and_types_by_node",
-            "get_client_names_and_types_by_node",
-            "get_publishers_info_by_topic",
-            "get_subscriptions_info_by_topic",
-        ),
-        "introspecting the ROS graph. NOT a decline any more — phase-381 is "
-        "implementing these, and `get_node_names` has already left this family. "
-        "The old reason here said reading the graph back needs a discovered view "
-        "of every peer and is unbounded memory on a target; issue 0791 refuted "
-        "that (a query-on-demand needs no cache, and we are ALREADY visible in "
-        "the graph while unable to read it, which is the actual defect), and "
-        "phase-381 measured that the reply buffer it would need already exists. "
-        "These are UNIMPLEMENTED-so-far, not reserved, and the distinction is "
-        "worth keeping straight — `graph.cpp` existing has been read as these "
-        "being implemented",
-    ),
-
     "graph-guard": (
         ("node_get_graph_guard_condition",),
         "a guard condition fired on graph change. Guard conditions here are a "
@@ -176,6 +151,16 @@ ASSIGN = (
     r"/\*\s*([a-z_0-9]+)\s*\*/\s*([^,\n]+),",       # positional, annotated
     r"\.\s*([a-z_0-9]+)\s*=\s*([^,\n]+),",           # C designated
     r"(?m)^\s*([a-z_0-9]+):\s*([^,\n]+),",           # Rust struct literal
+    # Rust struct literal, WRAPPED. The pattern above needs the value and its
+    # comma on one line, so rustfmt breaking a long initializer —
+    #     get_publisher_names_and_types_by_node: Some(
+    #         get_publisher_names_and_types_by_node_trampoline::<R>,
+    #     ),
+    # — made a WIRED slot read as unwired. A false negative in the one gate
+    # whose job is telling those apart, and it fires on exactly the slots with
+    # the longest names. Captures the opening `Some(`, which is not a null
+    # literal, so `None,` cannot match it (phase-381 W3).
+    r"(?m)^\s*([a-z_0-9]+):\s*(Some\()\s*$",
 )
 
 
@@ -256,6 +241,14 @@ def self_test():
         bad.append("designated producer detection")
     if producers_in("    take: None,\n    publish: Some(t),\n", slots) != {"publish"}:
         bad.append("rust producer detection")
+    # phase-381 W3 — rustfmt wraps a long initializer, and the wrapped form must
+    # still read as WIRED. Both directions, because an arm that matched `None`
+    # too would be worse than the blind spot it replaces.
+    wrapped = "    publish: Some(\n        some_very_long_trampoline_name::<R>,\n    ),\n"
+    if producers_in(wrapped, slots) != {"publish"}:
+        bad.append("wrapped rust producer not detected")
+    if producers_in("    take: None,\n", slots):
+        bad.append("a None slot was read as produced")
 
     # The narrow consumer pattern, and the false positive it exists to avoid.
     if consumers_in("if let Some(f) = self.vtable.take {", slots) != {"take"}:


### PR DESCRIPTION
Completes phase-381's waves. Twelve `rmw` graph slots produced and reachable
from Rust, C and C++; zenoh answers all twelve, Cyclone answers `get_node_names`,
XRCE degrades to `UNSUPPORTED` and that is TESTED rather than asserted.

`check-rmw-slot-producers`: **produced 42 → 53, inert 25 → 14** across the phase.

## W3 remainder — the last six slots

The four `*_by_node` forms and the two `*_info_by_topic` forms, over the same
shared drain. `names_and_types` grew an optional node filter rather than a second
copy: six copies of one two-pass dedup is six chances for one to drift.

Two upstream asymmetries MIRRORED, not smoothed over (RFC-0054 makes these
headers the ABI SSoT): service/client `*_by_node` take no `no_demangle` where
publisher/subscriber do, and `no_demangle` / `no_mangle` are REFUSED rather than
ignored — we report ROS names, and ignoring the flag answers a different question
than the caller asked.

**A blind spot in the gate, found by tripping it.** `check-rmw-slot-producers`
matched a Rust slot only when the value AND its comma sat on one line, so rustfmt
wrapping a long initializer made a WIRED slot read as unwired — a false negative
in the one gate whose job is telling those apart, firing on exactly the longest
names. Four of these six were invisible to it. Fixed with a fourth pattern and
two self-test cases, including the negative one.

## W4 — the user API for those six

**The subscriber/subscription word comes from each language's own upstream**
(maintainer direction: Rust ← rclrs, C++ ← rclcpp). Applied against the RECORDED
surfaces, which turned up something the direction did not anticipate: rclrs has
all four `*_by_node` forms and **rclcpp has exactly one**, with no
publisher/subscriber/client forms at all. Resolved within the rule rather than by
inventing — rclcpp's VOCABULARY is unambiguous (`create_subscription`,
`Subscription<T>`), so the word comes from there.

    vtable   subscriber     (upstream rmw)
    C        subscriber     (rcl)
    C++      subscription   (rclcpp)
    Rust     subscription   (rclrs)

Ledgered as explicitly NOT the drift issue 0788 collects: 0788 is about our
languages disagreeing with NO rule; here the rule is "follow your own upstream".
Each compile probe NAMES the expected word, so anyone "aligning" the three breaks
the build.

## W5 — Cyclone reads what it was already writing

`graph.cpp` published `ros_discovery_info` since phase-177.36 and never read it
back. Three decisions, each against a specific failure: `dds_read` not
`dds_take` (taking drains history, so a second query sees the graph VANISH);
`KEEP_LAST(16)` not `(1)` (the topic is KEYLESS, so depth 1 holds whichever
participant wrote last); dedup within the READ BATCH, no persistent cache.
Reader created on first use, so a node that never asks pays nothing.

**A near-miss, and it is this campaign's own defect.** I wired the slot, then
checked what dispatches to it — `CffiSession` implemented NONE of the graph
methods, so it fell through to the trait default and returned `Unsupported` for
every C backend including the slot I had just filled. The slot would have looked
implemented while being dead code: issue 0800's overstatement, one layer above
where 0800 found it.

## W6 — one test, not a work item

XRCE's vtable is a C designated initializer, so its graph slots are NULL by
omission. Not asserted: the test builds a session on a slot-free vtable and
requires `Unsupported` with ZERO visits. Mutating the dispatch to return `Ok(())`
turns it red.

## W7 — RFC-0036 amended

"No dynamic discovery — peers static" conflated two things and was half wrong for
two years. The LOCATOR is still static and stays so. The GRAPH is now readable.

## MEASURED

* `just ci-l1` green on the rebase onto current main.
* `check-rmw-slot-producers` produced 53 / inert 14; `check-api-parity` "every
  divergence carries a ledger entry"; `check-c`, `check-cpp`,
  `check-cbindgen-headers`, `check-rmw-cyclonedds` 22/22, `nros-rmw-cffi` 10/10,
  `nros-rmw-zenoh` 76/76.
* **Mutation-tested**: the W6 degradation test, the wrapped-initializer gate fix,
  and both compile probes have each been seen RED for the defect they exist to
  catch.

## NOT covered — and it is the gap that matters

**LIVE INTEROP.** Nothing here proves a native `rmw_zenoh_cpp` node is
discovered, or that `ros2 node list` and our `get_node_names()` agree. Every
verification is against our own builders, our own parser and our own vtable. That
needs a router and a real ROS 2 node, plus the settling window Design note 3
describes — written as a single comparison it is a flaky test by construction.
The phase doc's status line now says this rather than reading as complete.
