### PR TITLE
docs(#0899, #0902): the FreeRTOS corruption hunt — one real bug found, and it is not the cause

### DIFF
--- a/changelog.d/0902.fix.md
+++ b/changelog.d/0902.fix.md
@@ -1,0 +1,1 @@
+record that a zenoh-pico edit rebuilds nothing — zpico-sys watches 7 files out of the library

--- a/docs/issues/0899-freertos-talker-wbuf-overrun-after-40-publishes.md
+++ b/docs/issues/0899-freertos-talker-wbuf-overrun-after-40-publishes.md
@@ -100,6 +100,49 @@ because nothing on this path ever writes it.
 Reverted. Recorded because the mistake is re-derivable: the comment looks like
 an admission of a gap, and it is actually a statement of scope.
 
+## Investigated: a real zenoh-pico bug found, and it is NOT the cause
+
+`_z_wbuf_reset` removes while iterating:
+
+    for (size_t i = 0; i < _z_iosli_svec_len(&wbf->_ioss); i++) {
+        if (!ios->_is_alloc) { _z_iosli_svec_remove(&wbf->_ioss, i, false); }
+        else                 { _z_iosli_reset(ios); }
+    }
+
+`_z_svec_remove` shifts the tail down and decrements `_len`, so `i++` SKIPS the
+element that moved into the freed slot. Borrowed (non-alloc) slices therefore
+survive a reset while the buffer keeps counting their capacity.
+
+It is reachable, and precisely: `_z_wbuf_wrap_bytes` appends TWO ADJACENT
+non-alloc slices (the wrapped payload, then the previous slice's remaining
+space) and `_z_buf_encode` takes that path for any payload over `Z_ZID_LENGTH`
+on an expandable wbuf — every publish here. Two adjacent removals is exactly the
+case the skip mishandles. Present at our pin AND on the fork's `main`, so it is
+an unfixed upstream defect.
+
+**It does not fix this issue.** With the corrected loop compiled in and the
+example RELINKED, the assert still fires at 40 publishes, twice:
+
+    run 1: publishes=40 delivered=40 asserts=1
+    run 2: publishes=40 delivered=40 asserts=1
+
+One earlier run showed 61 publishes and no assert, which looked like success —
+but it had `delivered=0`, so the peer never attached and the failing path was
+never exercised. An outlier, not evidence. Recorded because it was momentarily
+convincing.
+
+## The measurement was nearly wrong for a second reason — issue 0902
+
+The first attempt at the above tested a binary that did not contain the fix:
+`zpico-sys` lists SEVEN zenoh-pico files in `rerun-if-changed` and `iobuf.c` is
+not among them, so editing it recompiles nothing. And even once `zpico-sys`
+rebuilds, the C example is not relinked (issue 0475's class). Getting a
+zenoh-pico edit into an image currently needs a touch of a watched file AND a
+touch of the leaf's `main.c`.
+
+Anyone continuing this issue must do that first, or they will measure the old
+binary — as I did.
+
 ## Acceptance
 
 * The talker survives a sustained run with a peer attached.

--- a/docs/issues/0899-freertos-talker-wbuf-overrun-after-40-publishes.md
+++ b/docs/issues/0899-freertos-talker-wbuf-overrun-after-40-publishes.md
@@ -143,6 +143,73 @@ touch of the leaf's `main.c`.
 Anyone continuing this issue must do that first, or they will measure the old
 binary — as I did.
 
+## ROOT CAUSE OF THE ASSERT, proven under gdb
+
+`gdb-multiarch` against the QEMU guest (`-s -S`), breaking on `__assert_func`:
+
+    #1  _z_wbuf_put
+    #2  __unsafe_z_prepare_wbuf
+    #3  _z_transport_tx_send_n_msg
+    #4  _z_write
+    #5  _z_publisher_put_impl
+    #6  zpico_publish_with_attachment
+
+It fires on `__unsafe_z_prepare_wbuf`'s OWN FIRST WRITE — the stream length
+prefix, `_z_wbuf_put(buf, 0, 0)` — immediately after `_z_wbuf_reset`. The buffer
+comes out of reset with no capacity at position 0.
+
+Why: `_z_wbuf_wrap_bytes` does
+
+    ios->_capacity = ios->_w_pos;   // "Block writing on this ioslice"
+
+and `_z_iosli_reset` clears only the positions:
+
+    static inline void _z_iosli_reset(_z_iosli_t *ios) {
+        ios->_r_pos = 0;
+        ios->_w_pos = 0;            // _capacity NOT restored
+    }
+
+So the truncation is PERMANENT and ratchets the owned slice down on every
+wrap-path publish, until nothing is writable. `_expansion_step` holds the true
+slice size (`_z_wbuf_make` sets it to the requested capacity and makes the first
+slice exactly that big), so it is recoverable.
+
+## Patch, and what it does and does not achieve
+
+In `_z_wbuf_reset`, restore an owned slice's capacity from `_expansion_step`,
+and stop skipping elements after a removal (the `i++`-past-a-shift bug already
+described above).
+
+Measured, three runs each, same reproduction:
+
+    before:  publishes 40, 40, 40   (assert every time, deterministic)
+    after:   publishes 19, 60, 67   (one run reached 67 with NO assert)
+
+So the capacity ratchet is A cause — the failure stops being deterministic — and
+it is NOT the only one. Stated plainly rather than shipped as a fix.
+
+## The remaining fault looks like use-after-free
+
+A later gdb run tripped the FREERTOS assert rather than zenoh-pico's, and the
+argument register held **`0xdeadbeef`** — a poison value, not a pointer. That
+points at freed memory being used, which is a different defect from the capacity
+ratchet and would explain why the two original assertions looked unrelated.
+
+That is the thread to pull next. The reproduction and the tooling are recorded
+below so it can be picked up directly.
+
+## Tooling notes for whoever continues
+
+* `arm-none-eabi-gdb` on this host is BROKEN — `libncursesw.so.5` missing. Use
+  `gdb-multiarch` with `set architecture arm`.
+* zenoh-pico is compiled without DWARF, so fields cannot be evaluated by name;
+  the backtrace above came from symbol names plus AAPCS argument registers
+  (`r0`, `r1`, `r2`).
+* Start the talker with `-s -S` and attach; the listener and router run normally.
+* **Apply the issue-0902 workaround first** or you will debug a stale binary:
+  touch a WATCHED zenoh-pico file (e.g. `src/net/primitives.c`) AND the leaf's
+  own `main.c`, or the edit reaches neither the archive nor the image.
+
 ## Acceptance
 
 * The talker survives a sustained run with a peer attached.

--- a/docs/issues/0902-zpico-sys-no-rebuild-edge-on-zenoh-pico-sources.md
+++ b/docs/issues/0902-zpico-sys-no-rebuild-edge-on-zenoh-pico-sources.md
@@ -1,0 +1,72 @@
+---
+id: 902
+title: "Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed
+  files out of the whole library, so a patch is silently not compiled"
+status: open
+type: bug
+area: build, rmw
+related: [issue-0475, issue-0820, issue-0899]
+---
+
+## Symptom
+
+Patch a zenoh-pico source, rebuild, run: the change is not there. No error, no
+warning — the old code runs and the test result is about a binary that does not
+contain the edit.
+
+Measured while working issue 0899: an edit to
+`zenoh-pico/src/protocol/iobuf.c`, a full fixture rebuild (`rc=0`), and a
+reproduction that behaved exactly as before, because `iobuf.c` had never been
+recompiled.
+
+## Cause
+
+`nros-zpico-build/src/runner.rs` names its inputs one at a time:
+
+    println!("cargo:rerun-if-changed=zenoh-pico/src/system/unix/network.c");
+    println!("cargo:rerun-if-changed=zenoh-pico/include/zenoh-pico/system/platform/unix.h");
+    println!("cargo:rerun-if-changed=zenoh-pico/src/system/freertos/system.c");
+    println!("cargo:rerun-if-changed=zenoh-pico/src/system/freertos/lwip/network.c");
+    println!("cargo:rerun-if-changed=zenoh-pico/src/net/primitives.c");
+    println!("cargo:rerun-if-changed=c/zenoh-pico-version.h.in");
+    println!("cargo:rerun-if-changed=zenoh-pico/version.txt");
+
+Seven files. zenoh-pico has hundreds, and the build COMPILES them all — the
+protocol, transport, collections and codec sources that carry almost every bug
+worth patching are absent from the list. Cargo therefore considers the build
+script up to date and never re-runs it.
+
+This is issue 0820's finding in a second crate, and its words apply unchanged:
+"Hand-listing the closure here would be a maintained approximation of a graph
+[the compiler] already computes exactly."
+
+## Why it is worse than a slow build
+
+A missing `rerun-if-changed` does not fail. It produces a museum binary that
+tests green, so the conclusion drawn from the run is about code that is not in
+it. During 0899 this cost an entire measure-fix-measure cycle and nearly
+produced a "this fix does not work" verdict about a fix that had never been
+compiled.
+
+## Not the only edge missing on this path
+
+Even after `zpico-sys` recompiles, the C example binary is NOT relinked — the
+build log shows `Compiling zpico-sys` and never mentions `c_talker`. That is
+issue 0475's class (a lib reached through a whole-archive link flag gets no
+rebuild edge), and it means a zenoh-pico patch needs BOTH edges before an
+example image contains it. Today the only reliable way to get an edit into an
+image is to touch the leaf's own `main.c` as well.
+
+## Direction
+
+Watch the directory, not a list. `cargo:rerun-if-changed` accepts a directory
+and cargo walks it, so `zenoh-pico/src` and `zenoh-pico/include` would cover the
+compiled set with two lines and no maintenance. The cost is that any touch under
+those trees re-runs the build script; for a vendored library that changes only
+when someone patches it, that is the correct trade.
+
+## Acceptance
+
+* Editing any compiled zenoh-pico source causes it to be recompiled.
+* An edit reaches the C/C++ example images without hand-touching their sources,
+  or the remaining gap is named where a patcher will read it.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -68,5 +68,6 @@ fails if this block drifts.
 - **#0896** (rmw, api) — Every C/C++ subscription takes the small size class regardless of its message type — nothing fills `rx_buffer_hint` See `0896-*`.
 - **#0899** (rmw, boards) — The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer — two different asserts, both after tens of successful publishes See `0899-*`.
 - **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
+- **#0902** (build, rmw) — Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed files out of the whole library, so a patch is silently not compiled See `0902-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
## #0899 investigated, not fixed

`_z_wbuf_reset` removes while iterating:

```c
for (size_t i = 0; i < _z_iosli_svec_len(&wbf->_ioss); i++) {
    if (!ios->_is_alloc) { _z_iosli_svec_remove(&wbf->_ioss, i, false); }
    else                 { _z_iosli_reset(ios); }
}
```

`_z_svec_remove` shifts the tail down and decrements `_len`, so `i++` **skips** the element that moved into the freed slot — borrowed slices survive a reset while the buffer keeps counting their capacity.

Reachable, and precisely: `_z_wbuf_wrap_bytes` appends **two adjacent** non-alloc slices, and `_z_buf_encode` takes that path for any payload over `Z_ZID_LENGTH` on an expandable wbuf — every publish here. Two adjacent removals is exactly what the skip mishandles. Present at our pin *and* on the fork's `main`: an unfixed upstream defect.

**It does not fix the issue.** With the corrected loop compiled and the example relinked, the assert still fires at 40 publishes, twice:

```
run 1: publishes=40 delivered=40 asserts=1
run 2: publishes=40 delivered=40 asserts=1
```

One earlier run showed 61 publishes and no assert — but `delivered=0`, so the peer never attached and the failing path was never exercised. An outlier, recorded because it was momentarily convincing: a green run with a disconnected peer is exactly the shape of a false fix.

The patch is **not shipped** — it's a vendored fork needing a maintainer push, and third-party changes earn their place by fixing something observable. #0899 carries the full analysis so it can be re-applied on its own merits.

## #0902 filed — it nearly invalidated the whole investigation

`zpico-sys` names **seven** zenoh-pico files in `rerun-if-changed`. The library has hundreds and the build compiles them all. `src/protocol/iobuf.c` isn't among them, so my first measure-fix-measure cycle tested a binary **that did not contain the fix** and produced a confident "this doesn't work" about code that had never been compiled.

That's #0820's finding in a second crate, and its words apply unchanged: hand-listing is *"a maintained approximation of a graph [the compiler] already computes exactly."*

A second edge is missing behind it: even once `zpico-sys` recompiles, the C example is **not relinked** (the log never mentions `c_talker`) — #0475's class. Today a zenoh-pico edit reaches an image only if you touch a watched file **and** the leaf's `main.c`.

135/135 fast gates. Tree and submodule left clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk