### PR TITLE
fix(zephyr): forward NROS_ZEPHYR_HEAP_SIZE to cargo

### DIFF
--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -565,6 +565,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
  "nros-platform-mps2-an385",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -510,6 +510,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -497,6 +497,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -510,6 +510,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -507,6 +507,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -514,6 +514,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/platform/nros-platform/Cargo.toml
+++ b/packages/platform/nros-platform/Cargo.toml
@@ -202,3 +202,10 @@ nros-platform-esp32-qemu = { version = "0.4.0", path = "../../platform/nros-plat
 
 [lints]
 workspace = true
+
+[build-dependencies]
+# issue 0460 — the shared Kconfig-via-$DOTCONFIG knob fallback. A Zephyr RUST
+# image inherits none of the cmake `set(ENV{...})` knob exports, so a bare
+# environment read compiles the crate default whatever Kconfig says. Needed
+# here since phase-8 made NROS_ZEPHYR_HEAP_SIZE a forwarded knob; see build.rs.
+nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }

--- a/packages/platform/nros-platform/build.rs
+++ b/packages/platform/nros-platform/build.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026, NEWSLab NTU.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolve `NROS_ZEPHYR_HEAP_SIZE` for `src/zephyr_heap.rs`.
+//!
+//! The arena size used to be read straight from the environment with
+//! `option_env!`. That has two defects this build script exists to fix, and
+//! `check-kconfig-knob-forwarding` fails the build without it.
+//!
+//! 1. A bare environment read does not reach the Zephyr Rust lane. Kconfig
+//!    knobs live in `$DOTCONFIG`, and `nros_zephyr_build::knob_usize` is the
+//!    one spelling that resolves BOTH (issue 0460) -- environment first, then
+//!    `CONFIG_*`, then the default.
+//!
+//! 2. `option_env!` is baked at compile time and, with no build script, cargo
+//!    never invalidates on a change to it: an already-built rlib is reused
+//!    with the previous size compiled in, and the image starves exactly as if
+//!    the knob had never been set. Reading the variable here emits the
+//!    `rerun-if-env-changed` that makes a change take effect.
+//!
+//! The default stays 64 KiB, matching the zenoh images' previous
+//! `CONFIG_HEAP_MEM_POOL_SIZE=65536`, so a converted image is RAM-neutral
+//! before tuning.
+
+const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
+
+fn main() {
+    let size = nros_zephyr_build::knob_usize(
+        "NROS_ZEPHYR_HEAP_SIZE",
+        "CONFIG_NROS_ZEPHYR_HEAP_SIZE",
+        DEFAULT_HEAP_SIZE,
+    );
+
+    // `zephyr_heap.rs` keeps its `option_env!` read; this simply makes the
+    // value it sees the RESOLVED one rather than whatever happened to be in
+    // the ambient environment.
+    println!("cargo:rustc-env=NROS_ZEPHYR_HEAP_SIZE={size}");
+    println!("cargo:rerun-if-env-changed=NROS_ZEPHYR_HEAP_SIZE");
+}

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -613,6 +613,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -645,6 +645,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -491,6 +491,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -343,6 +343,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -513,6 +513,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -452,6 +452,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -452,6 +452,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/scripts/check-kconfig-knob-forwarding.sh
+++ b/scripts/check-kconfig-knob-forwarding.sh
@@ -62,6 +62,12 @@ DERIVED_READERS=(
     # NROS_RMW_SUBSCRIBER_SLOTS, NROS_RMW_MESSAGE_INFO_SLOTS). Added when
     # #0752 forwarded SUBSCRIBER_SLOTS and this file was still env-only.
     packages/rmw/cffi/build.rs
+    # phase-8 — NROS_ZEPHYR_HEAP_SIZE, the rlsf arena behind the Zephyr
+    # allocation funnel. Resolved here rather than with `option_env!` in source
+    # for both reasons this gate exists: a bare environment read misses
+    # `$DOTCONFIG` on the Rust lane, and with no build script cargo never
+    # invalidates on a change to the knob.
+    packages/platform/nros-platform/build.rs
 )
 
 # Knobs the cmake side exports that no Rust build script reads. Each needs a

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -902,6 +902,22 @@ config NROS_EXECUTOR_ACTION_CLIENTS
       executor reports what it actually used on its first spin, so build once,
       read the advisory, then set this. Issue 0900.
 
+config NROS_ZEPHYR_HEAP_SIZE
+    int "Application heap arena size (bytes)"
+    default 65536
+    help
+      Size of the rlsf arena in nros-platform's zephyr_heap, which backs
+      BOTH z_malloc and __rust_alloc since the allocation funnel moved off
+      Zephyr's kernel heap.
+
+      CONFIG_HEAP_MEM_POOL_SIZE does NOT govern application allocation any
+      more; this does. An application that outgrows the arena does not
+      fault or log -- it stops, so size this to what the application
+      actually needs rather than leaving the default in place and
+      inferring from a hang.
+
+      An NROS_ZEPHYR_HEAP_SIZE environment variable overrides this value.
+
 config NROS_EXECUTOR_ARENA_SIZE
     int "Executor arena size in bytes (0 = derive)"
     default 0

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -221,6 +221,19 @@ function(nros_resolve_knobs)
             "${CONFIG_NROS_EXECUTOR_ARENA_SIZE}")
     endif()
 
+    # Application heap arena (phase-391 W3). `nros-platform`'s zephyr_heap
+    # reads NROS_ZEPHYR_HEAP_SIZE via `option_env!`, but nothing forwarded it
+    # into the cargo environment, so the knob was documented and unreachable
+    # from a Zephyr build: exporting it had no effect and the arena stayed at
+    # its 64 KiB default.
+    #
+    # That matters because 60b4e0c1e moved z_malloc AND __rust_alloc off the
+    # kernel heap onto this arena, so CONFIG_HEAP_MEM_POOL_SIZE no longer
+    # governs application allocation. A consumer needing more than 64 KiB has
+    # no working way to ask for it, and starvation presents as a silent hang
+    # rather than an error. See NEWSLabNTU/nano-ros#41.
+    _nros_resolve_knob(NROS_ZEPHYR_HEAP_SIZE "${CONFIG_NROS_ZEPHYR_HEAP_SIZE}")
+
     # XRCE transport tuning.
     #
     # `XRCE_TRANSPORT_MTU` is read unprefixed by xrce-sys/build.rs. The pool


### PR DESCRIPTION
Fixes #41.

## The problem

`NROS_ZEPHYR_HEAP_SIZE` is documented in `nros-platform`'s `zephyr_heap` and **unreachable from a Zephyr build**. The Zephyr integration forwards an explicit set of knobs into the cargo environment via `_nros_resolve_knob`, and this one was never registered — so it never appeared in the generated cargo command. Exporting it had no effect whatsoever; the arena stayed at its 64 KiB default.

This matters because `60b4e0c1e` moved `z_malloc` **and** `__rust_alloc` off Zephyr's kernel heap onto that arena. `CONFIG_HEAP_MEM_POOL_SIZE` therefore no longer governs application allocation, and a consumer needing more than 64 KiB had no working way to ask for it.

Starvation presents as a **silent hang** — no fault, no log, no error code. The image stops between `Network interfaces found: 1` and node startup and stays there. It took a 9-step bisect to attribute, and then several more wrong turns to work out why setting the documented knob changed nothing.

## The fix

Register the knob the same way every other one is registered, and add the matching Kconfig symbol so it is settable from a `.conf` fragment like its neighbours, with the environment still winning.

The help text says outright that `CONFIG_HEAP_MEM_POOL_SIZE` is no longer the knob, and that outgrowing the arena hangs rather than errors — because the next person to hit this will read Kconfig, not the commit log.

## Verification

Measured, not inferred — I had already talked myself into three wrong explanations, so this is checked at the two points where it can be observed directly.

**In the generated build rule** (`build.ninja`):

```
before:  (absent)
after:   NROS_ZEPHYR_HEAP_SIZE=4194304
```

**In the linked ELF** (`nm -S | grep zephyr_heap4HEAP`):

```
before:  0000000000010b38   (68,408 bytes — the 64 KiB default)
after:   0000000000400b38   (4,197,176 bytes)
```

**At runtime**, a consumer image on `fvp_baser_aemv8r` that previously hung now boots, and its full FVP CI passes all six phases — controller smoke, unit tests, DDS loopback, CAN loopback, TAP networking, scheduling statistics.

## Note on scope

This is deliberately separate from #40 (callback tracing). The two are unrelated concerns and the consumer happens to need both; they should be reviewable independently.

## Still open from #41, not addressed here

Arena starvation remains silent. This change makes the arena *settable*, so a consumer can now fix it once they know — but the first encounter is still a hang with nothing in the log naming the heap. A message at allocation failure would have turned that bisect into a one-line read, and is worth doing separately.
