### PR TITLE
docs(phase-391/392, #900): status lines said "nothing landed" while the work was on main

### DIFF
--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -5,7 +5,7 @@ status: open
 area: core, memory
 severity: medium
 found: 2026-08-29
-related: [0896, 0271, 0739, phase-392]
+related: [0896, 0271, 0739, phase-392, phase-392-W2]
 ---
 
 # The arena is sized for the entity an image does not have
@@ -235,6 +235,28 @@ first-spin advisory, set the knob, and be told plainly if it was set too low.
 **Not yet done:** nothing sets it automatically. Deriving `action_clients` from
 a declared entity inventory is still the real fix, and still blocked on the
 inventory existing — see below.
+
+## This is phase-392 W2, found from the other end
+
+Filed from a measurement — `ARENA_SIZE` is 74,240 bytes on every generated
+config in the tree — and only afterwards met
+[phase-392](../roadmap/phase-392-static-memory-space-campaign.md)'s **W2,
+"precise executor arena"**, which had already planned this work and even
+anticipated the runtime-measurement half:
+
+> the likely answer is a runtime high-water mark reported at teardown plus a CI
+> lane that fails when it exceeds the configured arena
+
+W1 here delivered that half (exactly, not approximately: the arena is a bump
+allocator, so `arena_used()` is the claimed total rather than a high-water
+estimate). W2 here added `NROS_EXECUTOR_ACTION_CLIENTS`, a lever the phase did
+not have.
+
+Still owed to the phase: the STATIC half — `NROS_ARENA_REQUIRED` emitted by
+entry codegen, checked by `nm` — plus a CI lane. **With one correction the phase
+could not have known:** the arena is inline on the TASK STACK, not in `.bss`, so
+a linker-symbol check cannot see it. That half needs rethinking, not just
+writing.
 
 ## Direction for the rest
 

--- a/docs/roadmap/phase-391-allocation-unification-and-tier-model.md
+++ b/docs/roadmap/phase-391-allocation-unification-and-tier-model.md
@@ -1,10 +1,23 @@
 # Phase 391 — one funnel, one arena, a constant-time allocator behind it, and a link-time gate that proves it
 
-**Status (2026-08-26). Plan, one prerequisite landed.** Opened from a
+**Status (2026-08-30). W1-W5 landed; the tier is real and gated.** Opened from a
 memory-allocation review. [Issue 0817](../issues/archived/0817-platform-funnel-bypassed-in-zephyr-port.md)
-(the sixteen Zephyr funnel bypasses) is fixed and archived; everything below is
-unstarted. Depends on [phase 390](phase-390-storage-mode-rename-inline-heap-view.md)
-for vocabulary only, not for code.
+(the sixteen Zephyr funnel bypasses) is fixed and archived.
+
+Landed since: **W1/W1b/W4** (`heap-free` tier declared per image and gated in
+`ci-l3` on a real heap-free build), **W2** (rlsf behind the funnel, O(1)
+alloc/free, pool bound compiler-checked, measured before/after on a named
+image), **W3** (Zephyr's funnel is rlsf-backed; `kheap` 65,536 -> 1,024,
+measured A/B on `build-c-talker-zenoh`), and the **W5 endgame** — per-class
+exact cell registries via `Node::ENTITY_BOUNDS`, trampoline contexts moved into
+the cell, and `node_runtime` finally dropping its `alloc` gate, which was the
+finish signal this phase was written to reach.
+
+Read the per-wave "LANDED — measured" blocks below rather than this summary
+before quoting a number; each carries its own A/B.
+
+Depends on [phase 390](phase-390-storage-mode-rename-inline-heap-view.md) for
+vocabulary only, not for code.
 
 ## Where this starts from
 

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1,7 +1,21 @@
 # Phase 392 — 27% of a safety-island image is message buffers nobody can price
 
-**Status (2026-08-26). Survey + plan, nothing landed.** Opened from a
-memory-allocation review that measured a real 320 KiB-class board image. Sizes
+**Status (2026-08-30). W1, W3 and most of W5 landed; W2 is now issue 0900.**
+Opened from a memory-allocation review that measured a real 320 KiB-class board
+image.
+
+Landed since: **W1** (pool inventory to full coverage, plus `just mem-report`
+and the `static_memory_declared_pools` test that makes a published pool figure
+answer to the linker), **W3a/W3b** (a subscription buffer sized from the
+message's own `MAX_SERIALIZED_SIZE_*` rather than by hand — Rust only; the
+C/C++ half is [issue 0896](../issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md)),
+and **W5.b1/c/d/e/f** (the queryable table sized by declaration — 143,456 B off
+a talker — with an exhausted table that names the declaration and a knob that is
+checked at build time).
+
+Still open: **W5.g**, which is the MEASUREMENT of W5 on a real cmake workspace
+image and has not been run; W5.d's 143,456 B was measured on a pure-cargo leaf
+that this wave changes by zero bytes. Sizes
 below are `nm` output from `build-board/zephyr/zephyr.elf` on
 mr_canhubk3/s32k344 (zenoh over serial), not estimates. Depends on
 [phase 390](phase-390-storage-mode-rename-inline-heap-view.md) for vocabulary
@@ -263,6 +277,29 @@ it away**: the likely answer is a runtime high-water mark reported at teardown
 plus a CI lane that fails when it exceeds the configured arena — the generated
 path proves its number statically, the hand-written path measures it, and both
 report through one figure.
+
+**W2 IS [issue 0900](../issues/0900-arena-slots-budgeted-at-action-client-worst-case.md),
+and its runtime half has landed.** The issue was filed from the other end —
+measuring that `ARENA_SIZE` is 74,240 bytes on every generated config in the
+tree, a talker included, while a timer-only executor claims **32 bytes** — and
+only then met this wave. Recorded here so the two do not diverge into separate
+efforts against one defect.
+
+Delivered against the plan above:
+
+* the runtime measurement this wave predicted — `Executor::arena_used()` /
+  `arena_capacity()` plus a one-shot first-spin advisory naming the
+  `NROS_EXECUTOR_ARENA_SIZE` value to set. The arena is a BUMP allocator, so
+  that figure is exact rather than a high-water estimate;
+* `NROS_EXECUTOR_ACTION_CLIENTS`, which stops every slot being budgeted at the
+  ActionClient worst case (74,240 -> 16,384 at the defaults, with the default
+  byte-identical to the old formula so no image moves).
+
+Still owed by this wave: the STATIC half — `NROS_ARENA_REQUIRED` emitted by
+entry codegen and checked by `nm` — and a CI lane. Note the correction issue
+0900 records: the arena is **inline on the task stack**, not in `.bss`, so
+`mem-report` cannot see it and a linker-symbol check will not either. Sizing it
+needs a stack probe, which this wave's `nm` plan did not anticipate.
 
 **W3 — per-subscriber wire sizing.** Lever 1. Requires W1 so the saving is
 measured rather than asserted.


### PR DESCRIPTION
`check-roadmap-status` gates that a phase **has** a status line, not that it's true. Both campaign phases read as unstarted while their work sat merged on `main`.

- **phase-391** said *"Plan, one prerequisite landed"* — with W1/W1b/W4 (heap-free tier gated in `ci-l3`), W2 (rlsf behind the funnel), W3 (Zephyr rlsf; `kheap` 65,536 → 1,024, measured A/B) and the entire W5 endgame already landed, including `node_runtime` dropping its `alloc` gate — the finish signal the phase was written to reach.
- **phase-392** said *"Survey + plan, nothing landed"* — with W1, W3a/W3b and W5.b1/c/d/e/f landed, the last taking 143,456 B off a talker.

Both now say what shipped and point at the per-wave *"LANDED — measured"* blocks rather than asking anyone to quote the summary. phase-392 also records that **W5.g — the measurement on a real cmake image — has not been run**; W5.d's number came from a pure-cargo leaf that wave changes by zero bytes.

## The find that matters more

**phase-392 W2 "precise executor arena" *is* issue #0900**, reached from the other end.

The issue was filed from a measurement — `ARENA_SIZE` is 74,240 bytes on every generated config in the tree, a talker included, while a timer-only executor claims **32** — and only then met a wave that had already planned the work, and even anticipated its runtime half:

> the likely answer is a runtime high-water mark reported at teardown plus a CI lane that fails when it exceeds the configured arena

0900 W1 delivered that half — exactly rather than approximately, since the arena is a bump allocator, so `arena_used()` is the claimed total and not an estimate. 0900 W2 added `NROS_EXECUTOR_ACTION_CLIENTS`, a lever the phase didn't have.

Both documents now cross-link, so two efforts don't diverge against one defect.

**Still owed, with a correction the phase couldn't have known:** the static half was to be `NROS_ARENA_REQUIRED` checked by `nm` — but the arena is inline on the **task stack**, not in `.bss`, so a linker-symbol check cannot see it. That half needs rethinking, not just writing.

Docs only. `just check-fast` green (136 gates).