### PR TITLE
fix(#873): the offline lockfile step escalates instead of failing cold

### DIFF
--- a/docs/issues/archived/0873-nightly-offline-lockfile-cold-cache.md
+++ b/docs/issues/archived/0873-nightly-offline-lockfile-cold-cache.md
@@ -2,7 +2,7 @@
 id: 873
 title: "All three nightly platform jobs fail on `generate-lockfile --offline` against
   a cold registry — an infrastructure fault reported as platform overclaim"
-status: open
+status: resolved
 type: bug
 area: ci
 related: [issue-0863, issue-0676, phase-395]
@@ -63,3 +63,38 @@ an esp32 dependency it never uses, purely because they share a workspace root.
 
 Do not demote the affected platforms in `board-support.toml`. The claim is not
 what is broken.
+
+## Fix — the offline step escalates instead of failing
+
+`cmd/build.rs::run_configure` runs the configure step, and on failure
+retries it ONCE with `--offline` dropped (`Handoff::without_offline`,
+`None` when the step never asked for offline — so nothing re-runs an
+identical command and reports the second failure as new information).
+
+The reasoning that picks this over the alternatives: **`--offline` is an
+OPTIMIZATION on this path, never a semantic choice.** The step resolves a
+lock for a root this process just generated, and issue 0676's frozen
+property belongs to the BUILD, which stays `--locked` either way. So
+offline buys "do not touch the network when the answer is already local",
+and nothing else — which is worth keeping as the fast path, and worth
+nothing at all when the answer is not local.
+
+The retry cannot change WHAT resolves: the offline cache is a subset of the
+registry, so a lock that resolves offline resolves identically online. It
+changes only whether resolution can happen. A genuinely missing package
+still fails, now with the registry's own error rather than cargo's
+`offline mode (via --offline) can sometimes cause surprising resolution
+failures` note — which is a strict improvement on the diagnostic that sent
+this issue to the platforms in the first place.
+
+Not chosen, and why:
+
+- **`cargo fetch` before the offline step** — puts network at a defined
+  point, but at EVERY build, including the warm-cache case that is the
+  common one and currently costs nothing.
+- **Vendoring** — a large permanent artifact for a transient cache
+  problem.
+- **Splitting `examples/workspaces/rust`** — addresses the real
+  amplifier (a freertos build resolving `esp-backtrace` because they share
+  a root) and is worth doing on its own merits, but it is a layout change
+  with its own fallout, and it would not fix the general cold-cache case.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -58,7 +58,6 @@ fails if this block drifts.
 - **#0870** (rmw, examples) — NuttX C++ action client fails `create_action_client` — the session reports `Transport(ConnectionFailed)` against a router the server reached See `0870-*`.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
 - **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
-- **#0873** (ci) — All three nightly platform jobs fail on `generate-lockfile --offline` against a cold registry — an infrastructure fault reported as platform overclaim See `0873-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
 - **#0877** (testing, boards) — FreeRTOS pubsub delivers by hand and delivers NOTHING under the test harness — and the talker trips a FreeRTOS queue assert See `0877-*`.
 - **#0879** (rmw) — the serial link cannot resynchronise after a peer reset — the router loops on `Unexpected Init flag in message` until it is restarted See `0879-*`.

--- a/packages/cli/nros-cli-core/src/builder/handoff.rs
+++ b/packages/cli/nros-cli-core/src/builder/handoff.rs
@@ -91,6 +91,23 @@ impl Handoff {
         self
     }
 
+    /// The same handoff with `--offline` dropped, or `None` when it
+    /// carried none.
+    ///
+    /// For escalating an offline step that failed for want of a warm
+    /// registry cache (issue 0873). `None` is the signal that offline
+    /// was not why it failed, so there is nothing to retry — never a
+    /// silent no-op retry of the identical command.
+    #[must_use]
+    pub fn without_offline(&self) -> Option<Self> {
+        if !self.args.iter().any(|a| a == "--offline") {
+            return None;
+        }
+        let mut next = self.clone();
+        next.args.retain(|a| a != "--offline");
+        Some(next)
+    }
+
     /// Render the command the way a user could retype it.
     ///
     /// For `--dry-run` and for error messages. NOT shell-quoted, and it must
@@ -266,5 +283,29 @@ mod tests {
             code.contains("cmd.exec()"),
             "the handoff must still be an exec"
         );
+    }
+
+    #[test]
+    fn escalating_offline_drops_exactly_that_flag() {
+        // Issue 0873: the retry must differ from the original in
+        // ONE way. Anything else and a cold-cache retry would run a
+        // command the caller never authorised.
+        let h = Handoff::new("cargo", vec!["generate-lockfile", "--offline"])
+            .in_dir("/w")
+            .with_env("NROS_CARGO_FLAGS", "");
+        let online = h.without_offline().expect("it carries --offline");
+        assert_eq!(online.args, vec![OsString::from("generate-lockfile")]);
+        assert_eq!(online.cwd, h.cwd, "the retry must run in the same dir");
+        assert_eq!(online.env, h.env, "and with the same environment");
+        assert_eq!(online.program, h.program);
+    }
+
+    #[test]
+    fn a_step_that_never_asked_for_offline_has_no_retry() {
+        // `None` is what stops `run_configure` from re-running an
+        // identical command and reporting the second failure as if
+        // it were new information.
+        let h = Handoff::new("cmake", vec!["--build", "."]);
+        assert!(h.without_offline().is_none());
     }
 }

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -621,17 +621,63 @@ pub fn run(args: Args) -> Result<()> {
         // code path. It is a subprocess, not an exec: the exec below has to
         // survive it.
         if let Some(cfg) = &p.configure {
-            let st = cfg
-                .command()
-                .status()
-                .wrap_err_with(|| format!("running `{}`", cfg.display()))?;
-            if !st.success() {
-                eyre::bail!("configure failed: `{}` exited {}", cfg.display(), st);
-            }
+            run_configure(cfg)?;
         }
         // Never returns on success: this process BECOMES the build.
         let err = crate::builder::handoff::exec(hand).unwrap_err();
         eyre::bail!("{err}");
+    }
+    Ok(())
+}
+
+/// Run a configure step, escalating an `--offline` failure to one
+/// online retry.
+///
+/// `--offline` is an OPTIMIZATION on this path, never a semantic
+/// choice. The step resolves a lock for a root this process just
+/// generated, and issue 0676's frozen property belongs to the BUILD,
+/// which stays `--locked` either way — so offline buys "do not touch
+/// the network when the answer is already local", and nothing else.
+///
+/// Offline resolution fails for exactly one reason a retry fixes: the
+/// registry cache does not hold some member's dependency yet. On CI
+/// that cache is cold every run, which is why all three nightly
+/// platform lanes died here — on `esp-backtrace` and
+/// `panic-semihosting`, dependencies of workspace MEMBERS the built
+/// platform never uses, reached only because `examples/workspaces/rust`
+/// is one cargo workspace and resolving it resolves every member
+/// (issue 0873). Reported as five OVERCLAIMED platforms, which is a
+/// claim about the platforms rather than about our registry cache.
+///
+/// The retry cannot change WHAT resolves: the offline cache is a subset
+/// of the registry, so a lock that resolves offline resolves identically
+/// online. It changes only whether resolution can happen at all. A
+/// genuinely missing package still fails, now with the registry's own
+/// error instead of cargo's "offline mode (via `--offline`) can
+/// sometimes cause surprising resolution failures" note.
+fn run_configure(cfg: &Handoff) -> Result<()> {
+    let st = cfg
+        .command()
+        .status()
+        .wrap_err_with(|| format!("running `{}`", cfg.display()))?;
+    if st.success() {
+        return Ok(());
+    }
+
+    let Some(online) = cfg.without_offline() else {
+        eyre::bail!("configure failed: `{}` exited {}", cfg.display(), st);
+    };
+    eprintln!(
+        "nros build: warning: `{}` failed against a cold registry cache; \
+         retrying online (issue 0873)",
+        cfg.display()
+    );
+    let st = online
+        .command()
+        .status()
+        .wrap_err_with(|| format!("running `{}`", online.display()))?;
+    if !st.success() {
+        eyre::bail!("configure failed: `{}` exited {}", online.display(), st);
     }
     Ok(())
 }


### PR DESCRIPTION
All three nightly platform lanes — `threadx_linux`, `nuttx`, `freertos` —
died in `nros build`'s prepare step:

```
error: no matching package named `panic-semihosting` found
error: no matching package named `esp-backtrace` found
note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
Error: configure failed: `NROS_CARGO_FLAGS= cargo generate-lockfile --offline` exited status 101
```

Neither crate is a dependency of the platform being built. Both are
dependencies of workspace **members** it never uses, reached only because
`examples/workspaces/rust` is one cargo workspace and resolving it resolves
every member. On CI the registry cache is cold every run, so offline
resolution cannot select them and the step fails.

## The fix, and why it is an escalation rather than a removal

`--offline` is an **optimization** on this path, never a semantic choice.
The step resolves a lock for a root this process just generated, and issue
0676's frozen property belongs to the **build**, which stays `--locked`
either way. So offline buys "do not touch the network when the answer is
already local" — worth keeping as the fast path, and worth nothing at all
when the answer is not local.

`run_configure` now retries once with `--offline` dropped
(`Handoff::without_offline`, which returns `None` when the step never asked
for offline — so nothing re-runs an identical command and reports the second
failure as new information).

The retry cannot change **what** resolves: the offline cache is a subset of
the registry, so a lock that resolves offline resolves identically online.
It changes only whether resolution can happen at all. A genuinely missing
package still fails, now with the registry's own error rather than cargo's
"surprising resolution failures" note — which is the diagnostic that sent
this issue to the platforms in the first place.

## Not chosen

- **`cargo fetch` before the offline step** — network at a defined point, but
  at *every* build, including the warm-cache case that is the common one and
  currently costs nothing.
- **Vendoring** — a large permanent artifact for a transient cache problem.
- **Splitting `examples/workspaces/rust`** — addresses the real amplifier and
  is worth doing on its own merits, but it is a layout change with its own
  fallout and would not fix the general cold-cache case.

`just tier-health` reported five platforms OVERCLAIMED off this red. None are
demoted: the claim was never what was broken.

## Verification

`just ci-l1` green (1020 passed, 1 skipped for an unmet host capability, 0
real failures); clippy `-D warnings` and rustfmt clean on `nros-cli-core`.
Two unit tests: the retry differs from the original in exactly one flag, and
a step that never asked for offline gets no retry.

Closes #873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
