### PR TITLE
fix(api-parity): main is red — the trace sink landed with no ledger row

### DIFF
--- a/docs/reference/api-parity-ledger/other.json
+++ b/docs/reference/api-parity-ledger/other.json
@@ -115,6 +115,10 @@
     "verdict": "extension",
     "why": "runtime-pluggable transport vtable (`nros_transport_ops_t`: abi_version + open/close/write/read + `user_data`). An RTOS image often reaches the network over a link ROS 2 never sees -- USB-CDC, BLE, RS-485, a semihosting bridge -- and which one is a board fact decided after the library is built, so the hook has to be a runtime call rather than a link-time backend choice. rcl has no transport concept at all (rmw is selected at link time); the nearest thing anywhere is micro-ROS's `rmw_uros_set_custom_transport`, which this deliberately mirrors. Fn pointers rather than a trait object because a `Box<dyn>` would force `alloc` on every no_std port (`nros-rmw/src/custom_transport.rs`)."
   },
+  "c:set_trace_sink": {
+    "verdict": "extension",
+    "why": "callback-level tracing at the dispatch leaves (autoware-safety-island `docs/design/callback_tracing.rst`). rclc/rcl has no sink of this kind: upstream tracing is LTTng tracepoints compiled into the client library, which needs a tracing daemon, a session and a userspace tracer -- none of which exists on an RTOS image. `nros_set_trace_sink` is instead one function pointer called on the dispatch path, so an image can record callback entry/exit into whatever it already has (a ring buffer, a GPIO, a cycle counter) with no runtime behind it. It is exported from `nros-c` rather than `nros-cpp` because `nros-c` is linked in BOTH the C-API and the C++-only configurations, so one export covers both."
+  },
   "c:wake_state_get_zero_initialized": {
     "verdict": "extension",
     "why": "rcl's zero-init idiom under our naming, applied to the caller-owned `nros_wake_state_t` slot a polling entity's wake callback is registered with. Naming: see `c:publisher_get_zero_initialized` in the pubsub stage (ours is method-style `nros_<thing>_get_zero_initialized` at all 15 sites, rcl's is `rcl_get_zero_initialized_<thing>`); the slot itself: see `c:service_set_wake_callback`."


### PR DESCRIPTION
`just check-api-parity` fails on `origin/main`:

```
1 item(s) differ with no ledger entry. Add a row to
docs/reference/api-parity-ledger/<lang>.json
with one of: divergence, extension, declined, gap, rename
  c:set_trace_sink  (ours-only)
```

`36f6ccc71 feat(trace): callback-level tracing hooks at the dispatch leaves`
exported `nros_set_trace_sink` without classifying it. Because the gate is on
the tier-1 lane, **every branch cut from main fails `ci-l1` on it** — this was
found on a branch whose only content is a submodule pin bump and a lockfile
refresh.

## The verdict

`extension`, and it is one on the merits rather than by default. Upstream's
equivalent is LTTng tracepoints compiled into the client library, which need a
tracing daemon, a session and a userspace tracer — none of which exists on an
RTOS image. Ours is one function pointer called on the dispatch path, so an
image records callback entry/exit into whatever it already has (a ring buffer,
a GPIO, a cycle counter) with no runtime behind it. It is exported from
`nros-c` rather than `nros-cpp` because `nros-c` is linked in both the C-API
and the C++-only configurations, so one export covers both.

Filed in `other.json` because that is where `topics.topic_of` puts it — the
shard is not a preference, and `--self-test` rejects a row that disagrees with
the classifier.

## Verification

- `scripts/api-parity.py --self-test` — `0 checks failed`
- `just check-api-parity` — now ends `every divergence carries a ledger entry`
- `just ci-l1` — green (1020 passed, 1 skipped for an unmet host capability)

Four added lines; existing key order and formatting preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
