### PR TITLE
chore(play_launch): pin W3 — the shipped resolver links no libpython

### DIFF
--- a/packages/cli/nros-launch-resolve/Cargo.lock
+++ b/packages/cli/nros-launch-resolve/Cargo.lock
@@ -588,6 +588,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,17 +733,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "play_launch_parser_pyexec"
+name = "play_launch_parser_pyload"
 version = "0.1.0"
 dependencies = [
+ "libloading",
  "log",
- "once_cell",
  "play_launch_parser",
- "pyo3",
- "regex",
  "serde",
  "serde_json",
- "serde_yaml_ng",
 ]
 
 [[package]]
@@ -958,9 +965,10 @@ dependencies = [
  "clap",
  "eyre",
  "indexmap",
+ "log",
  "num_cpus",
  "play_launch_parser",
- "play_launch_parser_pyexec",
+ "play_launch_parser_pyload",
  "pyo3",
  "ros-launch-manifest-check",
  "ros-launch-manifest-model",


### PR DESCRIPTION
Moves the play_launch pin `f7f6d2cf` → `4798eabd`: the two issue-0897 W3
commits, now on play_launch `main` (pushed `cb2d6567..4798eabd`, rebased onto
upstream first). Forward from both this base's pin and the one nano-ros main
carried before it, checked with `git merge-base --is-ancestor` in both
directions rather than by eye — `-Subproject commit <hex>` is two hex strings
no reviewer can order.

## What the pin buys

W3 replaces a link with a load. The resolver no longer depends on the Python
half; it depends on a loader that discovers a CPython at runtime and `dlopen`s
it. The leaf lock changes exactly as that implies — `play_launch_parser_pyexec`
out, `play_launch_parser_pyload` + `libloading` in. That dependency change *is*
the fix, not a side effect of it.

Verified on the built artifact rather than on the manifests:

```
$ readelf -d packages/cli/nros-launch-resolve/target/release/nros-launch-resolve
  NEEDED  libgcc_s.so.1
  NEEDED  libc.so.6
  NEEDED  ld-linux-x86-64.so.2
```

No `libpython3.10.so.1.0`, which is what the binary carried before. One build
now serves any CPython at or above the floor, and a host with no usable
interpreter gets an error value instead of a loader abort before `main` —
which is the whole ask: scan and resolve XML/YAML launch files, and fail only
where Python is genuinely required.

Upstream side: 500 tests green in the parser workspace on the rebased base,
including the end-to-end loader test that asserts the test binary itself has no
`libpython` in `DT_NEEDED` before loading one and evaluating `1 + 1` across the
C boundary.

## Lockfile

`just lock-update` on `packages/cli/nros-launch-resolve`, never a bare
`cargo generate-lockfile` (issues 0359/0378). Diff reviewed as the recipe
demands, since added/removed packages are a dependency change rather than a
refresh: +`libloading`, +`play_launch_parser_pyload`, −`play_launch_parser_pyexec`.

## CI note

`just ci-l1` on this branch fails only `check-api-parity`, and that red is
**main's, not this branch's** — `nros_set_trace_sink` landed without a ledger
row, so every branch cut from main fails it. #65 fixes it. Everything else in
the lane is green here (1020 passed, 1 skipped for an unmet host capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
