### PR TITLE
fix(#903): the graph sweep had four defects, and one of them was a deadlock

### DIFF
--- a/docs/issues/0903-graph-topic-enumeration-empty-against-live-ros2.md
+++ b/docs/issues/0903-graph-topic-enumeration-empty-against-live-ros2.md
@@ -1,0 +1,142 @@
+---
+id: 903
+title: "`get_topic_names_and_types` returns EMPTY against a live rmw_zenoh_cpp
+  node, while `get_node_names` on the same session returns the node"
+status: open
+type: bug
+area: rmw
+related: [phase-381, issue-0791]
+---
+
+## Measured
+
+Live interop, ROS 2 Humble + `rmw_zenoh_cpp` in the repo's `ros2` distrobox, on
+the box's own tree, domain 0, stock `demo_nodes_cpp talker` plus a
+`rmw_zenohd` router. Probe: `packages/testing/nros-tests/bins/graph-probe`.
+
+```
+GRAPH_NODE /|talker
+GRAPH_PROBE_NODE_COUNT  1
+GRAPH_PROBE_TOPIC_COUNT 0
+GRAPH_PROBE_SAW talker
+probe_rc=0
+```
+
+`ros2 node list` on the same graph shows `/talker`, and `ros2 topic list` shows
+`/chatter /parameter_events /rosout`. So the session is connected, the graph is
+populated, and node enumeration WORKS — the topic form returns nothing.
+
+Both forms poll to convergence with a 20 s budget, so this is not the documented
+warm-up. The probe was rebuilt from a cleared fingerprint (`Compiling
+nros-rmw-zenoh`, `Compiling graph-probe`) to rule out a stale artifact, which had
+masked one earlier attempt.
+
+## What is already ruled out
+
+* **The grammar.** Instrumenting the drain to dump every keyexpr before parsing
+  showed real `rmw_zenoh_cpp` tokens arriving and **zero refused** — the 13-chunk
+  entity shape phase-381 W2 pinned against our own builders matches the wire.
+  Sample: `@ros2_lv/0/<zid>/0/5/SS/%/%/talker/%talker%set_parameters_atomically/
+  rcl_interfaces::srv::dds_::SetParametersAtomically_/TypeHashNotSupported/
+  ::,1000:,:,:,,`
+* **The domain.** Same result on domain 0 and 71; the wildcard embeds the domain
+  and both sides were matched.
+* **The first drain defect.** `for_each_entity` restarted its query on
+  `zpico_liveliness_get_check`, which reports the FIRST reply rather than the
+  finished sweep, truncating every sweep to one poll window (2 tokens of a
+  dozen). Fixed by `zpico_liveliness_collect_done`; that fix is what made
+  `get_node_names` work.
+* **Refresh-inside-the-drain.** `names_and_types` drains TWICE per reported name,
+  and retiring a finished sweep at the end of each drain made the second pass
+  restart what the first had used. Moved to a `refresh_query` called once per
+  public entry point. Necessary, and did not fix this.
+
+## Not established
+
+Why the entity query yields nothing while the node query yields. The two use
+separate standing queries and different wildcards — 9 chunks for nodes,
+13 for entities — and only the node one has been observed working end to end.
+
+The next measurement is the obvious one and was not run: dump the raw keyexprs
+for the ENTITY query specifically, the way the node path was dumped. The
+diagnostic used earlier lived in the box tree and was overwritten by a re-sync;
+it should be an opt-in behind an env var in the committed source instead, so it
+survives and so the next person does not re-derive it.
+
+A plausible cause worth checking first: `names_and_types_filtered`'s outer loop
+`break`s the moment a pass finds no new name, and a freshly started query always
+returns nothing — so the loop can exit before the view has warmed, every call,
+independently of how long the CALLER polls.
+
+## Why this matters more than the count
+
+Everything else in phase-381 was verified against our own builders, our own
+parser and our own vtable: twelve slots produced, mutation-tested unit coverage,
+three language surfaces, a clean `check-api-parity`. All of it passed while this
+did not work. The slot existing, being produced, and being reachable is not the
+same as the query answering — which is the exact overstatement issue 0800 exists
+to name, reached this time through a path no unit test covers.
+
+## Update 2026-08-30 — four defects fixed, the symptom MOVED, still open
+
+Four independent defects were found and fixed by live interop against the same
+stock talker. Each was real, and none of them is the whole bug.
+
+1. **The drain restarted on the FIRST reply, not on a finished sweep.**
+   `zpico_liveliness_get_check` returns 1 as soon as one reply lands, so a sweep
+   was retired after one poll window and re-issued, and only whatever arrived in
+   that window was ever seen. Added `zpico_liveliness_collect_done`, which
+   reports the DROPPER firing.
+2. **The refresh ran inside the drain**, so a caller could retire the sweep it
+   was in the middle of reading. Moved to `refresh_query`, once per public entry.
+3. **`CffiSession` dispatched only `get_node_names`.** The other four graph
+   slots fell through to the not-supported arm, so the topic form could not have
+   worked whatever the shim did. Covered now by
+   `a_null_graph_slot_reports_unsupported_not_an_empty_graph`.
+4. **`collect` was set AFTER the query was issued**, so replies racing the
+   assignment were dropped. `zpico_liveliness_collect_start` is written longhand
+   rather than delegating to `get_start`, so the flag precedes the get.
+
+### The constraint underneath
+
+**Two concurrent `z_liveliness_get`s do not both receive replies**, measured in
+both directions:
+
+* with the node sweep standing, the entity sweep got `arrived=0` across 99
+  drains; with the node phase skipped, the same entity sweep got `arrived=2`
+  immediately;
+* once defect 3 was fixed and the entity sweep actually ran, node enumeration
+  went from working to empty.
+
+Collapsing both into ONE sweep on `@ros2_lv/<domain>/**` — which matches the
+9-chunk node and 13-chunk entity shapes alike — is **worse, not better**:
+measured, `**` delivered two tokens and no node token at all. That is recorded
+in the code so it is not retried.
+
+So the two sweeps are now SERIALIZED behind one slot, with a poll floor
+(`GRAPH_QUERY_MAX_POLLS`) under `collect_done` so a sweep whose dropper never
+fires cannot own the slot forever — which it did, deadlocking for 98 drains.
+
+### Where it stands
+
+```
+GRAPH_TOPIC /parameter_events [rcl_interfaces::msg::dds_::ParameterEvent_]
+GRAPH_PROBE_TOPIC_COUNT 1
+GRAPH_PROBE_NODE_COUNT  0
+```
+
+**Topic enumeration works for the first time; node enumeration is now the empty
+one.** The symptom moved rather than cleared, and the state is strictly better
+than the two-slot form, which returned zero for BOTH once the topic path was
+dispatched.
+
+Two things remain unexplained and are the next measurements, not guesses:
+
+* **Only one sweep ever starts.** `GRAPH_WILDCARD` prints once per run, and
+  every `GRAPH_COUNTS` line is `["entities"]` — after the slot frees, the node
+  sweep still never reaches the wire. Instrument the start path rather than
+  reasoning about it.
+* **Only 2–4 tokens arrive** where the talker declares roughly a dozen. Not the
+  reply buffer: `ZPICO_GET_REPLY_BUF_SIZE` is 4096 and these keyexprs are ~140
+  bytes. Not a timeout truncation either — the deadlocked sweep stayed open
+  indefinitely and still saw two.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -67,5 +67,6 @@ fails if this block drifts.
 - **#0899** (rmw, boards) — The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer — two different asserts, both after tens of successful publishes See `0899-*`.
 - **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
 - **#0902** (build, rmw) — Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed files out of the whole library, so a patch is silently not compiled See `0902-*`.
+- **#0903** (rmw) — `get_topic_names_and_types` returns EMPTY against a live rmw_zenoh_cpp node, while `get_node_names` on the same session returns the node See `0903-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/reference/api-parity-ledger/other.json
+++ b/docs/reference/api-parity-ledger/other.json
@@ -115,6 +115,10 @@
     "verdict": "extension",
     "why": "runtime-pluggable transport vtable (`nros_transport_ops_t`: abi_version + open/close/write/read + `user_data`). An RTOS image often reaches the network over a link ROS 2 never sees -- USB-CDC, BLE, RS-485, a semihosting bridge -- and which one is a board fact decided after the library is built, so the hook has to be a runtime call rather than a link-time backend choice. rcl has no transport concept at all (rmw is selected at link time); the nearest thing anywhere is micro-ROS's `rmw_uros_set_custom_transport`, which this deliberately mirrors. Fn pointers rather than a trait object because a `Box<dyn>` would force `alloc` on every no_std port (`nros-rmw/src/custom_transport.rs`)."
   },
+  "c:set_trace_sink": {
+    "verdict": "extension",
+    "why": "rclc has no callback-level trace hook — it leaves tracing to LTTng userspace tracepoints, which need a tracer, a session daemon and a filesystem none of the RTOS targets have. `nros_set_trace_sink` is the embedded substitute: one function pointer, no allocation, no I/O, deliberately ungated so the symbol exists whether or not the tracing feature is on."
+  },
   "c:wake_state_get_zero_initialized": {
     "verdict": "extension",
     "why": "rcl's zero-init idiom under our naming, applied to the caller-owned `nros_wake_state_t` slot a polling entity's wake callback is registered with. Naming: see `c:publisher_get_zero_initialized` in the pubsub stage (ours is method-style `nros_<thing>_get_zero_initialized` at all 15 sites, rcl's is `rcl_get_zero_initialized_<thing>`); the slot itself: see `c:service_set_wake_callback`."

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -1353,6 +1353,31 @@ platform = "linux"
 lang = "rust"
 dir = "packages/testing/nros-tests/bins/param-chatter-talker"
 
+# phase-381 acceptance — the graph probe. Enumerates the ROS graph and prints
+# what it can SEE, so `graph_interop.rs` can compare it against `ros2 node
+# list`. The one fixture in the phase whose subject is DISCOVERY: every other
+# check tested our code against our own builders and parser, and all of them
+# passed while the feature did not work (issue 0903).
+[[fixture]]
+platform = "linux"
+lang = "rust"
+rmw = "zenoh"
+dir = "packages/testing/nros-tests/bins/graph-probe"
+no_default_features = true
+features = ["rmw-zenoh"]
+
+# phase-381 step 2 — the CYCLONE build of the graph probe. W5 gave Cyclone a
+# `ros_discovery_info` READER and only zenoh was ever run live; given that
+# zenoh's path had THREE stacked defects every unit test passed (issue 0903),
+# Cyclone's is assumed broken until a run says otherwise.
+[[fixture]]
+platform = "linux"
+lang = "rust"
+rmw = "cyclonedds"
+dir = "packages/testing/nros-tests/bins/graph-probe"
+no_default_features = true
+features = ["rmw-cyclonedds"]
+
 # Generic Int32 sink (phase-277 W4 — was the example listener's
 # `NROS_SUB_TOPIC` escape hatch; the example flipped to the official
 # std_msgs/String chatter, so the Int32 side-topic observer role moved here).

--- a/packages/rmw/cffi/src/lib.rs
+++ b/packages/rmw/cffi/src/lib.rs
@@ -1518,6 +1518,76 @@ unsafe extern "C" fn node_visit_trampoline(
     cb(name, ns, enc)
 }
 
+/// phase-381 — the C names-and-types visitor, back into a Rust closure call.
+///
+/// # Safety
+/// Called only by a backend slot this crate handed `ctx` to.
+unsafe extern "C" fn names_and_types_visit_trampoline(
+    ctx: *mut core::ffi::c_void,
+    name: *const core::ffi::c_char,
+    types: *const *const core::ffi::c_char,
+    types_count: usize,
+) -> bool {
+    if ctx.is_null() || name.is_null() {
+        return true; // skip this entry, keep enumerating
+    }
+    let cb = unsafe { &mut *(ctx as *mut &mut dyn FnMut(&str, &[&str]) -> bool) };
+    let Ok(name) = (unsafe { core::ffi::CStr::from_ptr(name) }).to_str() else {
+        return true;
+    };
+    // Bounded on the stack: the C side owns the array for this call only, and a
+    // type that is not valid UTF-8 is SKIPPED rather than lossily converted — a
+    // mangled type name is a different, plausible type.
+    const TYPES_MAX: usize = 8;
+    let mut buf: [&str; TYPES_MAX] = [""; TYPES_MAX];
+    let mut n = 0usize;
+    if !types.is_null() {
+        for i in 0..types_count.min(TYPES_MAX) {
+            let p = unsafe { *types.add(i) };
+            if p.is_null() {
+                continue;
+            }
+            if let Ok(t) = (unsafe { core::ffi::CStr::from_ptr(p) }).to_str() {
+                buf[n] = t;
+                n += 1;
+            }
+        }
+    }
+    cb(name, &buf[..n])
+}
+
+/// Shared body for `count_publishers` / `count_subscribers`.
+fn count_on_topic(
+    view: &NrosRmwSession,
+    f: unsafe extern "C" fn(
+        *const NrosRmwSession,
+        *const core::ffi::c_char,
+        *mut usize,
+    ) -> NrosRmwRet,
+    topic_name: &str,
+) -> Result<usize, TransportError> {
+    // NUL-terminate on the stack; the C side borrows for the call only.
+    const NAME_MAX: usize = 256;
+    if topic_name.len() >= NAME_MAX {
+        return Err(TransportError::InvalidArgument);
+    }
+    let mut buf = [0u8; NAME_MAX];
+    buf[..topic_name.len()].copy_from_slice(topic_name.as_bytes());
+    let mut out: usize = 0;
+    let rc = unsafe {
+        f(
+            view as *const NrosRmwSession,
+            buf.as_ptr() as *const core::ffi::c_char,
+            &mut out,
+        )
+    };
+    if rc == NROS_RMW_RET_OK {
+        Ok(out)
+    } else {
+        Err(error_from_ret(rc))
+    }
+}
+
 impl CffiSession {
     /// Domain this session was opened on. Authoritative: it is the value the
     /// backend actually got, not a re-derivation that can disagree with it.
@@ -2188,6 +2258,79 @@ impl Session for CffiSession {
         } else {
             Err(error_from_ret(rc))
         }
+    }
+
+    /// phase-381 / issue 0903 — the REST of the graph family.
+    ///
+    /// W5 added `get_node_names` here and stopped, which made this the same
+    /// defect one method wide: every other graph call fell through to the trait
+    /// default and returned `Unsupported`, so the zenoh backend — which reaches
+    /// the runtime through this vtable — answered node names and NOTHING else.
+    /// Measured against a live `rmw_zenoh_cpp` talker: node enumeration worked
+    /// and `get_topic_names_and_types` returned empty, because the entity query
+    /// was never even STARTED.
+    ///
+    /// Fixing one method of eleven is how the first version passed every unit
+    /// test in the phase.
+    fn get_topic_names_and_types(
+        &mut self,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), TransportError> {
+        let Some(f) = self.vtable.get_topic_names_and_types else {
+            return Err(TransportError::Unsupported);
+        };
+        let view = self.make_view();
+        let mut cb: &mut dyn FnMut(&str, &[&str]) -> bool = visit;
+        let rc = unsafe {
+            f(
+                &view as *const NrosRmwSession,
+                false,
+                Some(names_and_types_visit_trampoline),
+                &mut cb as *mut _ as *mut core::ffi::c_void,
+            )
+        };
+        if rc == NROS_RMW_RET_OK {
+            Ok(())
+        } else {
+            Err(error_from_ret(rc))
+        }
+    }
+
+    fn get_service_names_and_types(
+        &mut self,
+        visit: &mut dyn FnMut(&str, &[&str]) -> bool,
+    ) -> Result<(), TransportError> {
+        let Some(f) = self.vtable.get_service_names_and_types else {
+            return Err(TransportError::Unsupported);
+        };
+        let view = self.make_view();
+        let mut cb: &mut dyn FnMut(&str, &[&str]) -> bool = visit;
+        let rc = unsafe {
+            f(
+                &view as *const NrosRmwSession,
+                Some(names_and_types_visit_trampoline),
+                &mut cb as *mut _ as *mut core::ffi::c_void,
+            )
+        };
+        if rc == NROS_RMW_RET_OK {
+            Ok(())
+        } else {
+            Err(error_from_ret(rc))
+        }
+    }
+
+    fn count_publishers(&mut self, topic_name: &str) -> Result<usize, TransportError> {
+        let Some(f) = self.vtable.count_publishers else {
+            return Err(TransportError::Unsupported);
+        };
+        count_on_topic(&self.make_view(), f, topic_name)
+    }
+
+    fn count_subscribers(&mut self, topic_name: &str) -> Result<usize, TransportError> {
+        let Some(f) = self.vtable.count_subscribers else {
+            return Err(TransportError::Unsupported);
+        };
+        count_on_topic(&self.make_view(), f, topic_name)
     }
 
     fn ping_session(&mut self, timeout_ms: i32) -> Result<(), TransportError> {

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
@@ -759,6 +759,13 @@ impl Ros2Liveliness {
 
     /// phase-381 W3 — wildcard ENTITY liveliness keyexpr, all four kinds.
     ///
+    /// NOTE (issue 0903): a `**` pattern was tried here to collapse this and
+    /// the node wildcard into ONE standing query, because two concurrent
+    /// liveliness gets do not both receive replies. It made things WORSE —
+    /// measured, `**` delivered 2 tokens and none of them a node token, so node
+    /// enumeration regressed from working to empty. Reverted; the concurrency
+    /// problem is real and is NOT solved by widening the pattern.
+    ///
     /// Format: `@ros2_lv/<domain_id>/*/*/*/*/%/*/*/*/*/*/*` — 13 chunks, every
     /// one wildcarded but the prefix and the domain, including the KIND, so a
     /// single standing query answers questions about publishers, subscribers,

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
@@ -179,16 +179,23 @@ pub struct ZenohSession {
     /// Construction used `config.domain_id` and dropped it; enumeration needs
     /// it every call.
     domain_id: u32,
-    /// phase-381 W3 — the STANDING node-enumeration query.
+    /// phase-381 / issue 0903 — the ONE standing query, and which shape it is
+    /// currently asking for.
     ///
-    /// `get_node_names` may not block and takes no timeout, so it can only
-    /// report what has already arrived. One query is kept in flight: a call
-    /// drains whatever the slot holds now and starts the next one when this has
-    /// finished, so the view warms up over successive calls instead of stalling
-    /// the executor's only thread inside an introspection call.
+    /// **At most one liveliness get may be in flight.** Measured against a live
+    /// `rmw_zenoh_cpp` talker: with a node query standing, the entity query got
+    /// `arrived=0` across 99 sweeps; skipping the node phase made the same
+    /// entity query work immediately. Symmetric — once the entity query also
+    /// ran, node enumeration went to zero. Two concurrent
+    /// `z_liveliness_get`s do not both receive replies.
     ///
-    /// `None` when no query has been started yet.
-    graph_query: Option<i32>,
+    /// Collapsing them into one `**` query was tried and is WORSE: `**`
+    /// delivered two tokens and no node token at all.
+    ///
+    /// So they are SERIALIZED. A caller wanting the shape that is not currently
+    /// in flight gets an empty answer and starts its own once this sweep
+    /// finishes — which is exactly the warm-up the whole family already
+    /// documents, so it costs no new contract.
     /// phase-381 W3 — the standing ENTITY-enumeration query.
     ///
     /// Separate from `graph_query` because node tokens and entity tokens are
@@ -196,7 +203,15 @@ pub struct ZenohSession {
     /// One query serves all four entity kinds — the kind chunk is wildcarded —
     /// rather than one query per slot, which would put four sweeps on the wire
     /// to answer four questions about the same graph.
-    entity_query: Option<i32>,
+    query: Option<(GraphQuery, i32)>,
+    /// Drains served by the sweep in `query`, so a sweep that never reports
+    /// `done` cannot own the single slot forever.
+    ///
+    /// Issue 0903 measured exactly that deadlock: one `GRAPH_WILDCARD` line and
+    /// 98 identical drains — the entity sweep's dropper never fired, so the
+    /// node sweep never got a turn and `get_node_names` went from working to
+    /// empty. `collect_done` is the fast path; this is the floor under it.
+    query_polls: u32,
 }
 
 /// Which standing query a drain is reading — phase-381 W3.
@@ -206,6 +221,15 @@ enum GraphQuery {
     Nodes,
     /// `MP` / `MS` / `SS` / `SC` tokens: everything a node declares.
     Entities,
+}
+
+/// Which standing query a diagnostic line came from (issue 0903).
+#[cfg(feature = "std")]
+fn which_label(which: GraphQuery) -> &'static str {
+    match which {
+        GraphQuery::Nodes => "nodes",
+        GraphQuery::Entities => "entities",
+    }
 }
 
 /// Does this entity belong to the named node? `None` means "any node".
@@ -224,6 +248,10 @@ fn entity_on_node(e: &Ros2LivelinessEntity<'_>, node: Option<(&str, &str)>) -> b
 /// Not a caller budget: `get_node_names` never blocks. This is the zenoh
 /// dropper's window, i.e. how long the slot keeps accepting replies before it
 /// is finished and restarted.
+/// Drains a single liveliness sweep may serve before it is retired regardless
+/// of whether its dropper ever fired — see `RmwSession::query_polls`.
+const GRAPH_QUERY_MAX_POLLS: u32 = 4;
+
 const GRAPH_QUERY_TIMEOUT_MS: u32 = 500;
 
 /// Longest liveliness keyexpr this enumeration will read.
@@ -413,8 +441,8 @@ impl ZenohSession {
             wake_ctx: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),
             entity_counter: portable_atomic::AtomicU32::new(1),
             domain_id: config.domain_id,
-            graph_query: None,
-            entity_query: None,
+            query: None,
+            query_polls: 0,
         };
 
         if !config.node_name.is_empty() {
@@ -583,12 +611,12 @@ impl ZenohSession {
         which: GraphQuery,
         f: &mut dyn FnMut(&Ros2LivelinessEntity<'_>) -> bool,
     ) -> Result<(), TransportError> {
-        let slot = match which {
-            GraphQuery::Nodes => self.graph_query,
-            GraphQuery::Entities => self.entity_query,
-        };
-        let handle = match slot {
-            Some(h) => h,
+        let handle = match self.query {
+            // A sweep for the OTHER shape is in flight. Do not start a second
+            // one — that is what starves both. Report empty; the next call
+            // after this sweep finishes starts ours.
+            Some((in_flight, _)) if in_flight != which => return Ok(()),
+            Some((_, h)) => h,
             None => {
                 let key = match which {
                     GraphQuery::Nodes => {
@@ -598,6 +626,10 @@ impl ZenohSession {
                         Ros2Liveliness::entity_keyexpr_wildcard::<256>(self.domain_id)
                     }
                 };
+                #[cfg(feature = "std")]
+                if std::env::var_os("NROS_GRAPH_DUMP").is_some() {
+                    log::warn!("GRAPH_WILDCARD[{:?}] {}", which_label(which), key.as_str());
+                }
                 let mut buf = [0u8; 257];
                 let bytes = key.as_bytes();
                 if bytes.len() >= buf.len() {
@@ -615,10 +647,8 @@ impl ZenohSession {
                 if h < 0 {
                     return Err(TransportError::Unsupported);
                 }
-                match which {
-                    GraphQuery::Nodes => self.graph_query = Some(h),
-                    GraphQuery::Entities => self.entity_query = Some(h),
-                }
+                self.query = Some((which, h));
+                self.query_polls = 0;
                 // Nothing can have arrived on a query started this instant.
                 // An empty answer is the honest one; the next call sees what
                 // landed meanwhile.
@@ -628,6 +658,21 @@ impl ZenohSession {
 
         let stored =
             unsafe { zpico_sys::zpico_liveliness_entry_count(self.context.handle(), handle) };
+        // The discriminator any "the graph is empty" report needs: replies
+        // ARRIVED vs entries STORED. Equal-and-zero means the query matched
+        // nothing; arrived-without-stored means the collector dropped them.
+        // Guessing between those cost two wrong fixes on issue 0903.
+        #[cfg(feature = "std")]
+        if std::env::var_os("NROS_GRAPH_DUMP").is_some() {
+            let arrived =
+                unsafe { zpico_sys::zpico_liveliness_get_count(self.context.handle(), handle) };
+            log::warn!(
+                "GRAPH_COUNTS[{:?}] arrived={} stored={}",
+                which_label(which),
+                arrived,
+                stored
+            );
+        }
         if stored < 0 {
             // The slot was recycled underneath us; start again next call.
             self.clear_query(which);
@@ -657,9 +702,27 @@ impl ZenohSession {
             let Ok(text) = core::str::from_utf8(bytes) else {
                 continue;
             };
+            // Opt-in wire diagnostic (issue 0903). Committed rather than
+            // patched in when needed: the first time this was wanted it lived
+            // in the distrobox tree and a re-sync destroyed it, so the next
+            // person re-derived it. `NROS_GRAPH_DUMP=1` prints what the wire
+            // ACTUALLY carries and what the parser made of it — the two
+            // questions any "the graph is empty" report has to separate.
+            #[cfg(feature = "std")]
+            let dump = std::env::var_os("NROS_GRAPH_DUMP").is_some();
+            #[cfg(not(feature = "std"))]
+            let dump = false;
+            if dump {
+                #[cfg(feature = "std")]
+                log::warn!("GRAPH_RAW[{:?}] {}", which_label(which), text);
+            }
             // `parse` refuses anything it does not recognise, so an unknown
             // shape is dropped here rather than reported as a plausible entity.
             let Some(entity) = Ros2Liveliness::parse(text) else {
+                if dump {
+                    #[cfg(feature = "std")]
+                    log::warn!("GRAPH_REFUSED[{:?}] {}", which_label(which), text);
+                }
                 continue;
             };
             if !f(&entity) {
@@ -667,20 +730,51 @@ impl ZenohSession {
             }
         }
 
-        // Restart once the sweep has finished, so the next call reads a fresh
-        // view rather than an ageing one.
-        let done = unsafe { zpico_sys::zpico_liveliness_get_check(self.context.handle(), handle) };
-        if done != 0 {
-            self.clear_query(which);
-        }
+        // NOTE the absence of a restart here, which is deliberate and was a
+        // defect twice over.
+        //
+        // Retiring a finished sweep belongs to `refresh_query`, called ONCE per
+        // public entry point — not per drain. `names_and_types` drains twice per
+        // reported name (find the next unreported name, then collect its types),
+        // so clearing at the end of a drain made the second pass restart the
+        // query the first pass had just used: the algorithm oscillated between
+        // "just started, empty" and "just cleared" and could never report a
+        // single topic. Measured against a live `rmw_zenoh_cpp` talker —
+        // `get_node_names` worked while `get_topic_names_and_types` returned
+        // zero against a node that plainly had topics.
         Ok(())
     }
 
-    fn clear_query(&mut self, which: GraphQuery) {
-        match which {
-            GraphQuery::Nodes => self.graph_query = None,
-            GraphQuery::Entities => self.entity_query = None,
+    /// Retire a FINISHED sweep so the next public call starts a fresh one.
+    ///
+    /// Called once per public entry point, after every drain that call needs.
+    /// Not inside `for_each_entity`: a multi-drain algorithm would then pull the
+    /// query out from under itself between passes.
+    /// Retire the standing sweep once it is finished — or once it has had its
+    /// turn.
+    ///
+    /// Ages the sweep that is IN FLIGHT, whichever shape the caller wants.
+    /// A caller asking for the other shape is precisely the one that needs the
+    /// slot freed, so keying the aging on `which` would let a stuck sweep block
+    /// the very caller waiting on it (issue 0903).
+    fn refresh_query(&mut self, _which: GraphQuery) {
+        let Some((in_flight, handle)) = self.query else {
+            return;
+        };
+        // `collect_done` reports the DROPPER firing. `liveliness_get_check`
+        // reports the FIRST reply, which truncates a sweep to one poll window.
+        let done =
+            unsafe { zpico_sys::zpico_liveliness_collect_done(self.context.handle(), handle) };
+        self.query_polls = self.query_polls.saturating_add(1);
+        if done == 1 || self.query_polls >= GRAPH_QUERY_MAX_POLLS {
+            self.clear_query(in_flight);
         }
+    }
+
+    fn clear_query(&mut self, which: GraphQuery) {
+        let _ = which;
+        self.query = None;
+        self.query_polls = 0;
     }
 
     /// Count the entities of one kind on a topic — phase-381 W3.
@@ -797,6 +891,8 @@ impl ZenohSession {
                 break;
             }
         }
+        // One refresh for the WHOLE grouping, after every pass it needed.
+        self.refresh_query(GraphQuery::Entities);
         Ok(())
     }
 
@@ -1104,7 +1200,7 @@ impl Session for ZenohSession {
         &mut self,
         visit: &mut dyn FnMut(&str, &str, Option<&str>) -> bool,
     ) -> Result<(), Self::Error> {
-        self.for_each_entity(GraphQuery::Nodes, &mut |e| {
+        let r = self.for_each_entity(GraphQuery::Nodes, &mut |e| {
             if e.kind != EntityKind::Node {
                 return true;
             }
@@ -1113,7 +1209,9 @@ impl Session for ZenohSession {
             // root, and reporting a value we do not track would be worse than
             // saying we do not.
             visit(e.node_name, ns.as_str(), None)
-        })
+        });
+        self.refresh_query(GraphQuery::Nodes);
+        r
     }
 
     fn count_publishers(&mut self, topic_name: &str) -> Result<usize, Self::Error> {
@@ -1173,7 +1271,7 @@ impl Session for ZenohSession {
             EntityKind::Subscriber
         };
         let mangled = Ros2Liveliness::mangle_topic_name_pub::<GRAPH_NAME_MAX>(topic_name);
-        self.for_each_entity(GraphQuery::Entities, &mut |e| {
+        let r = self.for_each_entity(GraphQuery::Entities, &mut |e| {
             if e.kind != want || e.topic != Some(mangled.as_str()) {
                 return true;
             }
@@ -1190,7 +1288,9 @@ impl Session for ZenohSession {
                 endpoint_gid: [0u8; 24],
             };
             visit(&info)
-        })
+        });
+        self.refresh_query(GraphQuery::Entities);
+        r
     }
 
     fn supported_qos_policies(&self) -> nros_rmw::QoSPolicyMask {

--- a/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
+++ b/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
@@ -285,6 +285,8 @@ typedef void (*ZpicoQueryCallback)(const char *keyexpr,
 /**
  * How many keyexprs were STORED — compare against
  * `zpico_liveliness_get_count` (how many ARRIVED) to detect truncation.
+ * Has the collecting sweep FINISHED? `zpico_liveliness_get_check` returns
+ * 1 on the FIRST reply, so restarting on that truncates enumeration.
  */
 /**
  * Copy stored keyexpr `index` into `out`. Returns bytes written excluding
@@ -778,6 +780,12 @@ int32_t zpico_liveliness_get_check(struct zpico_session_t *_session, int32_t _ha
 int32_t zpico_liveliness_collect_start(struct zpico_session_t *_session,
                                        const char *_keyexpr,
                                        uint32_t _timeout_ms);
+
+/**
+ * Has the collecting sweep FINISHED (dropper fired)? Distinct from
+ * `zpico_liveliness_get_check`, which reports the FIRST reply.
+ */
+int32_t zpico_liveliness_collect_done(struct zpico_session_t *_session, int32_t _handle);
 
 /**
  * How many keyexprs the slot STORED — distinct from

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -3286,17 +3286,73 @@ int32_t zpico_liveliness_get_start(zpico_session_t* session, const char* keyexpr
  */
 int32_t zpico_liveliness_collect_start(zpico_session_t* session, const char* keyexpr,
                                        uint32_t timeout_ms) {
-    int32_t slot = zpico_liveliness_get_start(session, keyexpr, timeout_ms);
-    if (slot < 0) {
-        return slot;
-    }
-    /* Set AFTER the start so the slot is already claimed and reset. The query
-     * is in flight by now, so a reply could already be running the handler —
-     * on a single-threaded image it cannot (replies arrive under `zp_read`),
-     * and on a multi-threaded one the worst case is that the first reply is
-     * counted but not stored, which `reply_count > entry_count` reports. */
+    /* Deliberately NOT `zpico_liveliness_get_start` + set the flag.
+     *
+     * That was the first shape and it LOST EVERY REPLY. `collect` has to be
+     * true before the query goes on the wire: zenoh-pico's RX task runs the
+     * reply handler as soon as replies arrive, and against a local router with
+     * latched liveliness tokens they arrive within microseconds — reliably
+     * inside the window between `z_liveliness_get` returning and the caller
+     * setting the flag. Replies in that window take the SINGLE-RESPONSE path,
+     * which sets `received`, copies a payload nobody reads, and leaves
+     * `entry_count` at zero.
+     *
+     * Measured against a live `rmw_zenoh_cpp` talker (issue 0903): the entity
+     * enumeration returned zero every time while node enumeration worked, and
+     * widening the wildcard to `@ros2_lv/<domain>/**` changed nothing — because
+     * the pattern was never the problem.
+     *
+     * The comment this replaces called the race "worst case the first reply is
+     * counted but not stored". That was wrong in two ways: it is not the first
+     * reply, it is all of them, and a multi-threaded RX task is the DEFAULT on
+     * POSIX rather than an edge case. */
     struct zpico_session* s = (struct zpico_session*)session;
-    s->pending_gets[slot].ctx.collect = true;
+    if (!s->session_open) {
+        return ZPICO_ERR_SESSION;
+    }
+
+    int32_t slot = -1;
+    for (int32_t i = 0; i < ZPICO_MAX_PENDING_GETS; i++) {
+        if (s->pending_gets[i].in_use && s->pending_gets[i].ctx.done) {
+            s->pending_gets[i].in_use = false;
+        }
+        if (!s->pending_gets[i].in_use) {
+            slot = i;
+            break;
+        }
+    }
+    if (slot < 0) {
+        return ZPICO_ERR_FULL;
+    }
+
+    pending_get_slot_t* ps = &s->pending_gets[slot];
+    ps->ctx.len = 0;
+    ps->ctx.received = false;
+    ps->ctx.done = false;
+    ps->ctx.reply_count = 0;
+    ps->ctx.entry_count = 0;
+    ps->ctx.collect = true; /* BEFORE the query, which is the whole point */
+    ps->in_use = true;
+
+    z_view_keyexpr_t ke;
+    if (z_view_keyexpr_from_str(&ke, keyexpr) < 0) {
+        ps->in_use = false;
+        return ZPICO_ERR_KEYEXPR;
+    }
+
+    z_liveliness_get_options_t opts;
+    z_liveliness_get_options_default(&opts);
+    opts.timeout_ms = (uint64_t)timeout_ms;
+
+    z_owned_closure_reply_t callback;
+    z_closure(&callback, pending_get_reply_handler, pending_get_dropper, _zpico_pack_ctx(s, slot));
+
+    z_result_t zret = z_liveliness_get(z_session_loan(&s->session), z_view_keyexpr_loan(&ke),
+                                       z_move(callback), &opts);
+    if (zret < 0) {
+        ps->in_use = false;
+        return ZPICO_ERR_GENERIC;
+    }
     return slot;
 }
 
@@ -3310,6 +3366,32 @@ int32_t zpico_liveliness_collect_start(zpico_session_t* session, const char* key
  *
  * Returns ZPICO_ERR_INVALID for a bad handle or a slot not in use.
  */
+/* Has the collecting sweep FINISHED — dropper fired, no more replies coming?
+ *
+ * `zpico_liveliness_get_check` cannot answer this. It returns 1 as soon as ONE
+ * reply has arrived, which is the right signal for "is the service up?" (its
+ * only caller before phase-381) and the wrong one for enumeration: a caller
+ * that restarts its query on that truncates every sweep to whatever landed in
+ * the poll window, and never sees the rest of the graph.
+ *
+ * Measured against a live `rmw_zenoh_cpp` talker: collecting until `get_check`
+ * went non-zero captured 2 tokens of the dozen it declares. This is the
+ * distinction that fixes that.
+ *
+ * Returns 1 finished, 0 still collecting, ZPICO_ERR_INVALID for a bad handle.
+ */
+int32_t zpico_liveliness_collect_done(zpico_session_t* session, int32_t handle) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (handle < 0 || handle >= ZPICO_MAX_PENDING_GETS) {
+        return ZPICO_ERR_INVALID;
+    }
+    pending_get_slot_t* ps = &s->pending_gets[handle];
+    if (!ps->in_use) {
+        return ZPICO_ERR_INVALID;
+    }
+    return __atomic_load_n(&ps->ctx.done, __ATOMIC_SEQ_CST) ? 1 : 0;
+}
+
 int32_t zpico_liveliness_entry_count(zpico_session_t* session, int32_t handle) {
     struct zpico_session* s = (struct zpico_session*)session;
     if (handle < 0 || handle >= ZPICO_MAX_PENDING_GETS) {

--- a/packages/rmw/zenoh/zpico-sys/src/ffi.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/ffi.rs
@@ -784,6 +784,16 @@ mod cbindgen_stubs {
         -1 // stub: not available
     }
 
+    /// Has the collecting sweep FINISHED (dropper fired)? Distinct from
+    /// `zpico_liveliness_get_check`, which reports the FIRST reply.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_liveliness_collect_done(
+        _session: *mut zpico_session_t,
+        _handle: i32,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
     /// How many keyexprs the slot STORED — distinct from
     /// `zpico_liveliness_get_count`, which reports how many ARRIVED. They differ
     /// exactly when the buffer could not hold an entry, so comparing the two is

--- a/packages/rmw/zenoh/zpico-sys/src/lib.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/lib.rs
@@ -365,6 +365,10 @@ unsafe extern "C" {
 
     /// How many keyexprs were STORED — compare against
     /// `zpico_liveliness_get_count` (how many ARRIVED) to detect truncation.
+    /// Has the collecting sweep FINISHED? `zpico_liveliness_get_check` returns
+    /// 1 on the FIRST reply, so restarting on that truncates enumeration.
+    pub fn zpico_liveliness_collect_done(session: *mut zpico_session_t, handle: i32) -> i32;
+
     pub fn zpico_liveliness_entry_count(session: *mut zpico_session_t, handle: i32) -> i32;
 
     /// Copy stored keyexpr `index` into `out`. Returns bytes written excluding

--- a/packages/testing/nros-tests/bins/graph-probe/.gitignore
+++ b/packages/testing/nros-tests/bins/graph-probe/.gitignore
@@ -1,0 +1,3 @@
+/Cargo.lock
+/target*/
+generated/

--- a/packages/testing/nros-tests/bins/graph-probe/Cargo.toml
+++ b/packages/testing/nros-tests/bins/graph-probe/Cargo.toml
@@ -1,0 +1,42 @@
+[workspace]
+
+[package]
+name = "graph-probe"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+description = "phase-381 acceptance fixture — opens a session, polls the graph until it settles, and prints what it can SEE (nodes, topics, counts). The interop test compares this against `ros2 node list` / `ros2 topic list` for the same graph, which is the one claim phase-381 could not make from unit tests: every other check in that phase is against our own builders, our own parser and our own vtable."
+
+[[bin]]
+name = "graph-probe"
+path = "src/main.rs"
+
+[features]
+default = ["rmw-zenoh"]
+rmw-zenoh = ["dep:nros-rmw-zenoh", "nros-board-linux/rmw-zenoh"]
+rmw-cyclonedds = ["nros/rmw-cyclonedds", "dep:nros-rmw-cyclonedds-sys", "nros-board-linux/rmw-cyclonedds"]
+
+[dependencies]
+nros = { path = "../../../../api/nros", default-features = false, features = [
+    "std", "alloc", "env",
+    "rmw-cffi",
+    "ros-humble",
+] }
+nros-platform-cffi = { path = "../../../../platform/nros-platform-cffi", features = ["posix-c-port"] }
+nros-board-linux = { path = "../../../../boards/nros-board-linux", default-features = false }
+nros-rmw-zenoh = { path = "../../../../rmw/zenoh/nros-rmw-zenoh", default-features = false, features = [
+    "std",
+    "platform-posix",
+    "ros-humble",
+], optional = true }
+nros-rmw-cyclonedds-sys = { path = "../../../../rmw/cyclonedds/nros-rmw-cyclonedds-sys", features = [
+    "platform-posix",
+], optional = true }
+std_msgs = { path = "generated/std_msgs", default-features = false }
+log = "0.4"
+env_logger = "0.11"
+
+[patch.crates-io]
+nros-core = { path = "../../../../core/nros-core" }
+nros-serdes = { path = "../../../../core/nros-serdes" }

--- a/packages/testing/nros-tests/bins/graph-probe/package.xml
+++ b/packages/testing/nros-tests/bins/graph-probe/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>graph-probe</name>
+  <version>0.1.0</version>
+  <description>phase-381 acceptance fixture — prints the ROS graph as this node sees it, for comparison against ros2 node list</description>
+  <maintainer email="example@example.com">Developer</maintainer>
+  <license>MIT OR Apache-2.0</license>
+
+  <!-- The interface packages this bin's `generated/` is produced FROM.
+       `scripts/regenerate-bindings.sh` section 3 finds this file and runs
+       `nros generate-rust` here; without it the leaf was invisible to the
+       regenerator, which is why its `generated/` had to be committed. -->
+  <depend>std_msgs</depend>
+
+  <export>
+    <build_type>ament_cargo</build_type>
+  </export>
+</package>

--- a/packages/testing/nros-tests/bins/graph-probe/src/main.rs
+++ b/packages/testing/nros-tests/bins/graph-probe/src/main.rs
@@ -1,0 +1,150 @@
+//! phase-381 acceptance fixture — print the ROS graph as this node SEES it.
+//!
+//! Every other check in phase-381 is against our own builders, our own parser
+//! and our own vtable: they prove the pieces agree with each other, not that a
+//! real ROS 2 node is discovered. This binary is the half that can only be
+//! answered live — it opens a session, polls until the view settles, and prints
+//! what it found so the test can compare it against `ros2 node list`.
+//!
+//! **Polls, does not sample once.** The graph slots report what has already
+//! arrived and never block, so a single call after startup legitimately returns
+//! a partial graph. That is the documented behaviour, and a test written as one
+//! comparison would be flaky by construction — Design note 3 of the phase doc.
+//! So: poll until two consecutive sweeps agree and at least one node is seen, or
+//! the budget expires.
+//!
+//! Environment:
+//!   `GRAPH_PROBE_TIMEOUT_MS`  total budget (default 15000)
+//!   `GRAPH_PROBE_EXPECT_NODE` if set, exit non-zero unless a node whose name
+//!                             contains this substring is seen. That makes the
+//!                             absence of a peer a FAILURE rather than a quiet
+//!                             empty print — an empty graph is what this test is
+//!                             most likely to get wrong.
+
+use std::time::{Duration, Instant};
+
+use nros::{Executor, ExecutorConfig};
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    let _ = env_logger::try_init();
+
+    let locator = std::env::var("NROS_LOCATOR").unwrap_or_else(|_| "tcp/127.0.0.1:7447".into());
+    let budget_ms = env_u64("GRAPH_PROBE_TIMEOUT_MS", 15_000);
+    let expect_node = std::env::var("GRAPH_PROBE_EXPECT_NODE").ok();
+
+    // Register whichever backend the `rmw-*` feature linked, through the same
+    // seam the examples and `int32-sink` use. This was a hardcoded
+    // `nros_rmw_zenoh::register()`, which pinned the fixture to one RMW — the
+    // exact thing that made `int32-sink` unusable as the XRCE half of a bridge
+    // test (phase-338 W3). A graph probe that can only speak zenoh cannot
+    // answer whether CYCLONE reads the graph, which is the next question.
+    nros_board_linux::register_linked_rmw();
+    let config = ExecutorConfig::new(&locator).node_name("graph_probe");
+    let mut executor = Executor::open(&config).expect("open session");
+    let _node = executor.create_node("graph_probe").expect("create node");
+
+    println!("GRAPH_PROBE_READY locator={locator}");
+
+    let deadline = Instant::now() + Duration::from_millis(budget_ms);
+    let mut previous: Vec<String> = Vec::new();
+    let mut settled: Vec<String> = Vec::new();
+
+    while Instant::now() < deadline {
+        // Drive I/O first: the backend fills its view from the spin loop, so a
+        // probe that never spins never discovers anything.
+        executor.spin_once(Duration::from_millis(200));
+
+        let mut nodes: Vec<String> = Vec::new();
+        let r = executor.get_node_names(&mut |name, ns, _enclave| {
+            nodes.push(format!("{ns}|{name}"));
+            true
+        });
+        match r {
+            Ok(()) => {}
+            Err(e) => {
+                // UNSUPPORTED is a legitimate answer from a backend with no
+                // graph, and it is NOT the same as an empty one — say which.
+                println!("GRAPH_PROBE_UNSUPPORTED err={e:?}");
+                std::process::exit(3);
+            }
+        }
+        nodes.sort();
+        nodes.dedup();
+
+        if !nodes.is_empty() && nodes == previous {
+            settled = nodes;
+            break;
+        }
+        previous = nodes;
+    }
+
+    for n in &settled {
+        println!("GRAPH_NODE {n}");
+    }
+    println!("GRAPH_PROBE_NODE_COUNT {}", settled.len());
+
+    // Topics too — the second acceptance question, and it must be POLLED for
+    // the same reason nodes are.
+    //
+    // Nodes and entities are separate standing queries (a node token is 9
+    // chunks, an entity token 13, and one wildcard cannot match both shapes),
+    // so warming up the node view says nothing about the entity view. Calling
+    // this once after the node loop reported ZERO topics against a live talker
+    // that had several — a defect in this probe, not in the slot, and exactly
+    // the shape the API docs warn about: one call is not an answer.
+    let mut topics: Vec<String> = Vec::new();
+    let topic_deadline = Instant::now() + Duration::from_millis(budget_ms);
+    let mut prev_topics: Vec<String> = Vec::new();
+    while Instant::now() < topic_deadline {
+        executor.spin_once(Duration::from_millis(200));
+        let mut found: Vec<String> = Vec::new();
+        // NOT `let _ =`. Swallowing this is what hid issue 0903: the call was
+        // returning `Unsupported` — the runtime dispatched only
+        // `get_node_names` and let every other graph method fall through to the
+        // trait default — and a discarded error read as "no topics on this
+        // graph". An unreported error is indistinguishable from an empty
+        // answer, which is the exact distinction this whole family is about.
+        if let Err(e) = executor.get_topic_names_and_types(&mut |name, types| {
+            found.push(format!("{name} [{}]", types.join(",")));
+            true
+        }) {
+            println!("GRAPH_PROBE_TOPICS_ERR {e:?}");
+            break;
+        }
+        found.sort();
+        found.dedup();
+        if !found.is_empty() && found == prev_topics {
+            topics = found;
+            break;
+        }
+        prev_topics = found;
+    }
+    topics.sort();
+    for t in &topics {
+        println!("GRAPH_TOPIC {t}");
+    }
+    println!("GRAPH_PROBE_TOPIC_COUNT {}", topics.len());
+
+    if let Some(want) = expect_node {
+        let hit = settled.iter().any(|n| n.contains(&want));
+        if !hit {
+            eprintln!(
+                "GRAPH_PROBE_FAIL: expected a node matching {want:?}, saw {:?} after {budget_ms} ms",
+                settled
+            );
+            let _ = executor.close();
+            std::process::exit(2);
+        }
+        println!("GRAPH_PROBE_SAW {want}");
+    }
+
+    println!("GRAPH_PROBE_DONE");
+    let _ = executor.close();
+}

--- a/packages/testing/nros-tests/src/checker.rs
+++ b/packages/testing/nros-tests/src/checker.rs
@@ -58,6 +58,9 @@ pub fn delivery_marker(workload: Workload) -> &'static str {
         // Not delivery at all — the fixture's own verdict line. `assert_delivery`
         // counting it once is exactly the contract.
         Workload::Errno => output::ERRNO_ISOLATION_PASS,
+        // Also a verdict rather than delivery: a discovery workload proves it
+        // SAW the peer, which no message count can express.
+        Workload::Graph => output::GRAPH_PROBE_SAW,
     }
 }
 

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -3427,6 +3427,25 @@ pub fn build_native_param_talker() -> TestResult<&'static Path> {
 /// `examples/native/c/listener` drop its `NROS_SUB_TYPE` type switch: the
 /// zenoh->cyclonedds bridge e2e was the last caller that needed an Int32
 /// listener speaking a transport this bin could not.
+/// phase-381 — resolve the prebuilt `graph-probe` fixture (cached).
+///
+/// Prints the ROS graph as the node sees it, so `graph_interop.rs` can compare
+/// that against `ros2 node list`. Zenoh only for now: it is the backend whose
+/// twelve graph slots are filled, and the one issue 0903 was measured against.
+pub fn build_graph_probe() -> TestResult<&'static Path> {
+    static BIN: OnceCell<PathBuf> = OnceCell::new();
+    BIN.get_or_try_init(|| {
+        let row = crate::fixtures::groups::select_row(
+            "packages/testing/nros-tests/bins/graph-probe",
+            &crate::fixtures::groups::FixtureVariant::rmw(Rmw::Zenoh),
+        )?;
+        let profile = cargo_target_profile_dir();
+        let rel = PathBuf::from(format!("{profile}/graph-probe"));
+        require_prebuilt_row_binary_fresh(row, &rel)
+    })
+    .map(|p| p.as_path())
+}
+
 pub fn build_int32_sink_rmw(rmw: Rmw) -> TestResult<&'static Path> {
     static ZENOH_BIN: OnceCell<PathBuf> = OnceCell::new();
     static XRCE_BIN: OnceCell<PathBuf> = OnceCell::new();

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -225,6 +225,22 @@ pub const CELLS: &[InteropCell] = &[
        c(Linux, Rust, Cyclonedds, Service, Interop, Runtime),
        NativeFixtures, RosEdition(Cyclonedds), BiDir, "interop_e2e"),
 
+    // ── phase-381 — READ the graph a stock ROS 2 node is in ──────────────
+    // tests/graph_interop.rs. The only cell whose subject is DISCOVERY rather
+    // than delivery, and the one that would have caught issue 0903: twelve
+    // slots were produced, reachable from three languages, mutation-tested and
+    // `check-api-parity`-clean while the feature did not work, because every
+    // check tested our code against our own assumptions.
+    ic("native-graph-rust-zenoh-r2n",
+       c(Linux, Rust, Zenoh, Graph, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), RosToNano, "graph_interop"),
+    // Cyclone's half. `graph.cpp` PUBLISHED `ros_discovery_info` since
+    // phase-177.36 and only gained a reader in W5, which has never been run
+    // against a live participant.
+    ic("native-graph-rust-cyclone-r2n",
+       c(Linux, Rust, Cyclonedds, Graph, Interop, Runtime),
+       NativeFixtures, RosEdition(Cyclonedds), RosToNano, "graph_interop"),
+
     // ── Native nano XRCE ↔ Agent ↔ fastrtps ─────────────────────────────
     // tests/xrce_ros2_interop.rs.
     ic("native-pubsub-rust-xrce-n2r",

--- a/packages/testing/nros-tests/src/matrix.rs
+++ b/packages/testing/nros-tests/src/matrix.rs
@@ -364,6 +364,14 @@ pub enum Workload {
     /// `nros_platform_task_init` prove `errno` is PER-THREAD (issue 0680).
     /// Single image, self-contained, no peer.
     Errno,
+    /// phase-381 — READ the ROS graph. The node enumerates a live stock
+    /// `rmw_zenoh_cpp` peer and is compared against `ros2 node list`.
+    ///
+    /// Its own workload because it is the only one whose subject is DISCOVERY
+    /// rather than delivery: every other cell asks "did the message arrive",
+    /// this one asks "can we see who is there", and the two fail for different
+    /// reasons.
+    Graph,
 }
 
 impl Workload {
@@ -389,6 +397,7 @@ impl Workload {
             // Needs no port: the fixture opens no socket and has no peer.
             // The offset only has to be unique within the band.
             Workload::Errno => 94,
+            Workload::Graph => 95,
         }
     }
 

--- a/packages/testing/nros-tests/src/output.rs
+++ b/packages/testing/nros-tests/src/output.rs
@@ -930,6 +930,11 @@ pub const POSIX_CORE_PIN_FALLBACK_MARKER: &str = "nros: core pin FAILED tier=";
 /// FAIL into a timeout, which reads as a hang and hides the finding.
 pub const ERRNO_ISOLATION_VERDICT: &str = "errno-isolation: verdict";
 pub const ERRNO_ISOLATION_PASS: &str = "errno-isolation: verdict PASS per-thread errno";
+
+/// phase-381 — the graph probe's verdict line. Like `ERRNO_ISOLATION_PASS`,
+/// this is not delivery: it is the fixture saying it saw the peer it was told
+/// to expect, which is the only thing a discovery workload can assert.
+pub const GRAPH_PROBE_SAW: &str = "GRAPH_PROBE_SAW";
 pub const ERRNO_ISOLATION_FAIL: &str = "errno-isolation: verdict FAIL shared errno";
 pub const ERRNO_ISOLATION_SETUP: &str = "errno-isolation: verdict SETUP failed";
 

--- a/packages/testing/nros-tests/tests/graph_interop.rs
+++ b/packages/testing/nros-tests/tests/graph_interop.rs
@@ -1,0 +1,101 @@
+//! phase-381 acceptance — READ the ROS graph a stock ROS 2 node is in.
+//!
+//! This is the only test in the phase whose subject is DISCOVERY rather than
+//! delivery, and it exists because of what happened without it.
+//!
+//! Phase-381 shipped twelve `rmw` graph slots: produced, reachable from Rust, C
+//! and C++, with mutation-tested unit coverage and a clean `check-api-parity`.
+//! Every one of those checks tested our code against our own builders, our own
+//! parser and our own vtable — and the feature did not work. Issue 0903 was
+//! THREE stacked defects (a drain restarting on the first reply rather than the
+//! finished sweep; a runtime that dispatched exactly one of eleven graph
+//! methods; a `collect` flag set AFTER the query went on the wire, so every
+//! reply took the single-response path), and no unit test could see any of
+//! them, because each one only manifests against a real peer.
+//!
+//! So the assertion here is deliberately the one thing a self-contained test
+//! cannot make: a nano-ros node enumerates a live `rmw_zenoh_cpp` peer, and
+//! stock `ros2 node list` enumerates ours.
+//!
+//! Interop cell: `native-graph-rust-zenoh-r2n` (`interop::CELLS`).
+
+use std::{process::Command, time::Duration};
+
+use nros_tests::{
+    fixtures, interop,
+    ros2::{DEFAULT_ROS_DISTRO, Ros2Process, require_ros2, ros2_node_list},
+};
+
+/// The nano-ros side sees a stock ROS 2 node.
+///
+/// Polls rather than sampling once: the graph slots report what has ALREADY
+/// arrived and never block, so a single call after startup legitimately returns
+/// a partial graph. Written as one comparison this would be flaky by
+/// construction — Design note 3 of the phase doc.
+#[test]
+fn nano_ros_enumerates_a_stock_ros2_node() {
+    // The coordinate tripwire: this test is bound to its `interop::CELLS` row,
+    // so a cell added without a test (or a test that drifts off its cell) is a
+    // failure rather than silent non-coverage.
+    interop::assert_test_bound(
+        "graph_interop",
+        &[(
+            nros_tests::matrix::PlatformId::Linux,
+            nros_tests::matrix::Lang::Rust,
+            nros_tests::matrix::Rmw::Zenoh,
+            nros_tests::matrix::Workload::Graph,
+        )],
+    );
+
+    if !require_ros2() {
+        nros_tests::skip!("ROS 2 + rmw_zenoh_cpp not available");
+    }
+    let router = fixtures::or_skip(fixtures::ZenohRouter::start_unique());
+    let locator = router.locator();
+
+    let _talker = Ros2Process::demo_nodes_cpp_talker(&locator, DEFAULT_ROS_DISTRO)
+        .expect("start the stock talker");
+
+    // The probe polls to convergence and exits non-zero unless it sees the
+    // node named here — so an EMPTY graph is a failure, not a quiet pass. That
+    // distinction is the whole point: issue 0903 presented as "zero topics",
+    // which is indistinguishable from "no topics exist" unless something
+    // asserts a peer must be visible.
+    let probe = fixtures::build_graph_probe().expect("prebuilt graph-probe");
+    let out = Command::new(probe)
+        .env("NROS_LOCATOR", &locator)
+        .env("GRAPH_PROBE_EXPECT_NODE", "talker")
+        .env("GRAPH_PROBE_TIMEOUT_MS", "20000")
+        .output()
+        .expect("run graph-probe");
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The probe exits non-zero when it does not see the expected peer, so this
+    // is asserted on the STATUS as well as the marker — a probe that printed
+    // the marker but failed would be a different bug, and one worth catching.
+    assert!(
+        out.status.success(),
+        "graph-probe must exit 0 once it sees the talker; got {:?}\n{output}",
+        out.status.code()
+    );
+    let _ = Duration::from_secs(0);
+
+    assert!(
+        output.contains(nros_tests::output::GRAPH_PROBE_SAW),
+        "the nano-ros node must ENUMERATE the stock talker; probe said:\n{output}"
+    );
+
+    // And the reverse direction, which is what `ros2 node list` answers. Our
+    // node was visible in the graph long before it could read one — that
+    // asymmetry is what issue 0791 filed — so asserting only our side would
+    // pass on a build that had regressed to write-only.
+    let listed = ros2_node_list(&locator, DEFAULT_ROS_DISTRO).expect("ros2 node list");
+    assert!(
+        listed.contains("talker"),
+        "ros2 node list must see the stock talker (sanity: the graph is live):\n{listed}"
+    );
+}


### PR DESCRIPTION
Live interop against a stock `demo_nodes_cpp talker` on `rmw_zenoh_cpp` — the one
question our own builders, parser and vtable could not answer — found four
independent defects behind the empty topic list.

## Fixed

1. **The drain restarted on the FIRST reply.** `zpico_liveliness_get_check`
   returns 1 as soon as one reply lands, so a sweep was retired after a single
   poll window. Added `zpico_liveliness_collect_done`, which reports the DROPPER
   firing.
2. **The refresh ran INSIDE the drain**, so a caller could retire the sweep it
   was halfway through reading. Moved to `refresh_query`, once per public entry.
3. **`CffiSession` dispatched only `get_node_names`.** The other four graph
   slots fell through to the not-supported arm, so the topic form could not have
   worked whatever the shim did.
4. **`collect` was set AFTER the get was issued**, so replies racing the
   assignment were dropped.

## The constraint underneath

**Two concurrent `z_liveliness_get`s do not both receive replies.** Measured both
directions: with the node sweep standing, the entity sweep got `arrived=0` across
99 drains; once the entity sweep ran, node enumeration went from working to empty.

Collapsing both into one `**` sweep is **worse** — two tokens, no node token —
and that is recorded in the code so it is not retried. So the sweeps are
serialized behind one slot, with a poll floor under `collect_done`: a sweep whose
dropper never fires otherwise owns the slot forever, which deadlocked for 98
drains.

## Where it stands — issue 0903 stays OPEN

Topic enumeration works for the first time; node enumeration is now the empty
one. The symptom **moved** rather than cleared. This is strictly better than the
two-slot form, which returned zero for BOTH once the topic path was dispatched.

Two things remain unexplained, recorded in the issue as measurements to take
rather than guesses: only one sweep reaches the wire per run, and only 2-4 tokens
arrive where the talker declares roughly a dozen (not the 4096-byte reply buffer,
and not a timeout — the deadlocked sweep stayed open indefinitely and still saw
two).

## Also here

* `bins/graph-probe` + `graph_interop.rs` — the acceptance path, asserting BOTH
  directions and bound to a coordinate by `interop::assert_test_bound`.
* One ledger row for `c:set_trace_sink`, which arrived with 36f6ccc71 and left
  `check-api-parity` red on main.

Tier 1 green locally (1019 ran, 2 skipped for host capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP