### PR TITLE
feat(#896 layer 0): name the member that costs a type its size bound

### DIFF
--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -272,207 +272,159 @@ short-lived CLI process, as already noted.
 this issue exists to prevent, so the shape is recorded rather than begun —
 layer 1 below is restated in these terms.
 
+## The delivery shape, rewritten 2026-08-30 (the first one was wrong)
+
+The original plan put the hint in an options struct on
+`nros_cpp_subscription_register` and had the user set it. Judged against the
+real call site in `examples/workspaces/c/src/listener_pkg/src/Listener.c`, that
+design is worse than doing nothing, in four ways:
+
+1. **It is an opt-in fix for a silent-default bug.** Anyone who does not read
+   this issue keeps the defect.
+2. **It names the type TWICE with nothing checking they agree** —
+   `..._get_type_name()` and `..._get_rx_buffer_hint()` are independent
+   arguments. Copy a subscription, change the type name, forget the hint, and
+   the buffer is sized for the WRONG type, silently. **That failure mode does
+   not exist today; the fix would have created it.**
+3. **11 arguments instead of 10**, plus two setup lines, at every call site.
+4. **The deliberate compile error arrives as "undeclared identifier"** — for an
+   unbounded type there is simply no accessor, so the error never names
+   `String` and never names the field `data`.
+
+The right shape is already in the tree, on the publish side. A generated helper
+KNOWS ITS OWN TYPE, so it should use its own constant and ask the user for
+nothing:
+
+```c
+static inline nros_ret_t std_msgs_msg_int32_publish(...) {
+    uint8_t buf[STD_MSGS_MSG_INT32_MAX_SERIALIZED_SIZE_XCDR1];  /* was NROS_PUB_BUFFER_SIZE, 256 */
+```
+
+Nobody edits a line; types under 256 get smaller stack frames and types over 256
+stop failing. Subscribe should mirror it, and the missing sibling IS the problem
+— codegen emits `_publish` and no `_subscribe`, which is why the raw call is
+hand-written and type-erased at all:
+
+```c
+int32_t rc = std_msgs_msg_int32_subscribe(node, "/chatter", on_raw, self, &handle);
+```
+
+ONE token. Type name, type hash and buffer hint all derive from it, so they
+cannot drift, because there is only one. Shorter than today's call rather than
+longer, and correct for a user who never heard of this issue.
+
+**This deletes the ABI work.** Layers 3-4 of the old plan — the options struct
+and the `nros_subscription_options_t` break — stop being the delivery mechanism.
+The raw path may gain a hint later for callers who need one, but it is no longer
+how the fix reaches anybody.
+
+## Layer 1's real constraint: on Humble the nested resolver resolves NOTHING
+
+Surveyed before writing the traversal, and it reshapes the layer.
+
+Building a sizeable value needs nested types resolved in-process. The tree has
+exactly one mechanism for that — `rosidl_bindgen::MsgResolver`, a
+`dyn Fn(&str) -> Option<Message>` threaded into the RIHS hash path — and it
+lives in `rosidl-bindgen`, NOT in `rosidl-codegen`, which is the crate that
+emits the schema. So the resolver is not in scope at any
+`build_nros_schema_for_struct*` call site today; every one of them is inside
+`common.rs` with only field ASTs to hand.
+
+Worse, the resolver's own doc says what it does on the default edition:
+
+> A [`MsgResolver`] that resolves no cross-package types — for self-contained
+> packages … or **Humble (placeholder hash, resolver never consulted)**.
+
+`no_cross_pkg_resolver` returns `None` for everything. On Humble — the edition
+the examples and fixtures use — a cross-package nested type such as
+`std_msgs/Header` or `builtin_interfaces/Time` **cannot be resolved at all**.
+
+**Measured rather than asserted, because the first draft of this paragraph said
+"that is most real messages" and that is not supported.** Across the 10 `.msg`
+files in `examples/` and `packages/interfaces/`: 2 have any non-primitive field,
+and exactly 1 references another package (`std_msgs`). So on the IN-TREE corpus
+this blocks one message, not most.
+
+That cuts both ways and neither reading is safe on its own. It means layer 1 is
+not blocked for the fixtures — but it also means the fixtures cannot tell us
+whether it is blocked for USERS, and the messages this campaign exists for are
+the heavily-nested ones (an Autoware type reaches `std_msgs`,
+`builtin_interfaces` and `geometry_msgs` before it reaches a number). The
+in-tree corpus is too small to generalise from in either direction; a real
+measurement wants a user workspace.
+
+This collides head-on with the trap recorded above. Unresolvable is not
+unbounded, so an unresolved nested type must not silently produce "no
+constant" — but *failing the generate* would fail nearly every Humble message
+with a `Header`, which is plainly not shippable either. **Neither branch of the
+rule as written is acceptable, so the rule needs a third outcome before any code
+is written:**
+
+* `Bounded(n)` — emit the constant.
+* `Unbounded(field)` — emit the poisoned macro naming the field (layer 5).
+* `Unresolved(type_name)` — emit NEITHER, and say so in the generated header as
+  a comment naming the type that could not be reached, so a reader can tell "we
+  looked and it has no bound" from "we could not look".
+
+Sizing anything from an `Unresolved` is the defect this issue is about, so the
+third outcome must be distinguishable at every consumer, not folded into the
+second.
+
+**The better fix, if it is affordable:** give codegen a real resolver on Humble
+too. The bindgen path already owns the package's `share_dir` and resolves
+same-package nested types itself; the ament index that would answer the
+cross-package ones is available at `nros sync` time. That turns `Unresolved`
+into a rare error case instead of the common one. It is also a larger change
+than this issue has scoped, and it should be measured (how many types in
+`examples/` actually go unresolved on Humble today?) before being assumed.
+
+**Layer 1 is not started for this reason** — the plumbing would have to be
+redone once this is decided, and the decision is not mine to guess.
+
 ## Layers, in order
 
-0. **Name the field that cost the bound.** When `max_serialized_size` returns
-   `None`, report which member is unbounded. No new surface; makes the existing
-   `.msg` fix actionable.
-1. **One traversal, two outputs** in `rosidl-codegen` (see the correction
-   above — rendering the string FROM the value is not possible). Every `match`
-   arm emits its expression string and builds its `nros_serdes::FieldType`
-   value together. No behaviour change; the existing emitter tests plus the
-   golden corpus are the check — and the corpus is worth trusting now, since
-   phase-390 W2 found and repaired the arm that was byte-identical to the
-   default and exercised nothing.
-2. **Both bounds, computed by `max_serialized_size` over those values**, nested
-   types resolved by the same closure the RIHS path already uses. Emitted as two
-   `#define`s (XCDR1 and XCDR2) from `packs/c/message.h.jinja` and the C++
-   sibling, plus the `_get_rx_buffer_hint` accessor returning their max. An
-   unbounded type emits NEITHER, so the accessor is absent and a call site
-   naming it fails to compile. A test must assert each equals the Rust
-   `MAX_SERIALIZED_SIZE_XCDR*` const for the same type — same input, same
-   function, so a disagreement means the value mapping is wrong. Retarget
-   `NROS_PUB_BUFFER_SIZE` onto the XCDR1 constant in the same change.
-2b. **Thread the RFC-0033 `cap` into the schema emit** so a field bounded only
-   in `nros-codegen.toml` stops reading as unbounded. Same test, extended with a
-   capped field.
-3. **Design the call-site spelling** — the C analogue of W3b's
-   `nros::rx_buffer_for!`. Do this BEFORE 4-5: the C subscription is raw by
-   design, so this is how the number reaches the runtime at all, and it decides
-   what the ABI must carry.
-4. **Carry it on BOTH C-facing subscription paths** (see below) — they are
-   independent, and the examples use the one the issue did not name.
-5. **`nros-c` forwards it** into the `TopicInfo` it already builds
-   (`subscription.rs:487`, one line), and the component path likewise.
+1. **One traversal, two outputs** in `rosidl-codegen` (see the correction above
+   — rendering the string FROM the value is not possible). Every `match` arm
+   emits its expression string and builds its `nros_serdes::FieldType` value
+   together, so a new variant that one output handles and the other forgets is a
+   compile error rather than a silent divergence.
 
-Out-of-band bounds (config / model) are a SEPARATE track that reuses layer 3's
-spelling. They are not needed for any type whose `.msg` already bounds it.
+   **The trap to avoid here:** nested types must be RESOLVED to build a sizeable
+   value, and resolution can fail (a dependency not on the search path). A
+   failure to resolve is NOT the same as "no bound exists" — phase-380's rule is
+   that `None` means UNBOUNDED and never UNKNOWN. An unresolvable nested type
+   must fail the generate, not silently emit no constant, or this issue's own
+   defect comes back wearing a different hat.
 
-## Correction: this is cbindgen, not bindgen
+2. **Both constants emitted**, computed by `max_serialized_size` over those
+   values — `<PREFIX>_MAX_SERIALIZED_SIZE_XCDR1` and `_XCDR2` — from
+   `packs/c/message.h.jinja` and the C++ sibling. A test asserts each equals the
+   Rust `MAX_SERIALIZED_SIZE_XCDR*` const for the same type: same input, same
+   function, so a disagreement means the traversal is wrong.
 
-Earlier text here said `nros_subscription_options_t` needs
-`scripts/gen-abi-bindings.sh` and is gated by `check-abi-bindings`. Wrong
-direction. That pair covers HAND-WRITTEN RMW/platform C headers consumed by
-bindgen into `nros-{rmw,platform}-cffi/src/generated.rs`.
-`nros_subscription_options_t` is a Rust `#[repr(C)]` struct
-(`nros-c/src/subscription.rs:145`) emitted OUT to the committed
-`packages/api/nros-c/include/nros/nros_generated.h` by cbindgen. Regenerate
-with `just regen-c-headers` — THE single writer (issue 0452) — and
-`check-cbindgen-headers` gates staleness.
+3. **Retarget the publish helper** onto the XCDR1 constant. Complete, shippable,
+   invisible: no API change, no opt-in, strictly smaller for every type under
+   256 bytes. **This is the whole win on the publish side and it lands with
+   layer 2.**
 
-The layout note stands: `sched_context` + `message_info: u8` + `_reserved: [u8; 2]`,
-so a `uint32_t` does not fit in the reserved bytes and the struct grows.
+4. **Emit the missing `_subscribe` helper**, passing the hint. This is the
+   subscribe-side delivery, and the reason the C path was type-erased in the
+   first place.
 
-## There are TWO C-facing subscription paths, and the examples use the other one
+5. **Unbounded types get a message that names the field.** No plain
+   `_subscribe`; a `_subscribe_sized` taking an explicit byte count, plus a
+   poisoned macro so the error says what is wrong:
 
-* **`nros-c`** — `nros_subscription_init_with_options` takes
-  `nros_subscription_options_t` and calls `session.create_subscription`
-  directly (`subscription.rs:501`). This is the path the issue described.
-* **`nros-cpp`** — `nros_cpp_subscription_register` (`nros-cpp/src/
-  subscription.rs:144`), which is what RFC-0043 typed components call, and what
-  every `examples/workspaces/c` node uses. **Ten flat arguments and no options
-  struct**, plus a `_register_with_info` twin that duplicates the whole list.
+   ```c
+   #define std_msgs_msg_string_subscribe(...) \
+     NROS_UNBOUNDED__std_msgs_String__field_data__use_subscribe_sized_or_bound_it
+   ```
 
-The second is the one that must carry the hint for the examples to benefit, and
-its argument list cannot grow. That is precisely the problem issue 0808 solved
-for `create_session`, and its resolution is already written down in
-`rmw_entity.h`: take a NULLable trailing options struct, because
-`rmw_publisher_options_t` / `rmw_subscription_options_t` had already solved it
-for entities. Same answer here, with `rx_buffer_hint` as the first occupant and
-`sched_context` / `callback_group` / the `_with_info` split as the cleanup that
-comes free.
+   The field name comes from `nros_serdes::size::first_unbounded`, which is what
+   that function exists for.
 
-## Layer 3 is smaller than feared: the call site already names the type
-
-The C subscription is type-erased at the ABI, but the CALL SITE is not:
-
-```c
-nros_cpp_subscription_register(node, "/chatter",
-                               std_msgs_msg_int32_get_type_name(), "", ...);
-```
-
-The token `std_msgs_msg_int32` is right there. So the hint needs no new macro
-vocabulary — a sibling accessor in the family the header already emits
-(`_get_type_name`, `_get_type_hash`, `_get_type_support`) reads identically and
-cannot drift from the type name, because both come from one token:
-
-```c
-static inline uint32_t std_msgs_msg_int32_get_rx_buffer_hint(void);
-```
-
-The `#define` from layer 2 is what it returns. A macro form that expands to BOTH
-arguments at once remains an option, but it is no longer load-bearing.
-
-## Decided 2026-08-29
-
-**1. An unbounded type is a COMPILE ERROR at the call site.** No bound, no
-constant, no accessor — the call site naming that type fails to build. The
-alternative (return 0, fall back to the global knob) reproduces today's silent
-defect exactly: a subscription that quietly takes the small class and drops
-samples at runtime on a target with no console. The escape hatch is to bound the
-field, in the `.msg` or via `cap` (below); both are one line and both are the
-thing we actually want the user to do.
-
-**2. Size the RX hint from `max(XCDR1, XCDR2)`; size the TX buffer from XCDR1
-alone.** The wire question has a live-verified answer already in this repo —
-RFC-0055's 2026-07-26 correction:
-
-> A default Jazzy peer serializes FINAL/XCDR1 on the wire (verified live for
-> both fastrtps and cyclonedds; guard
-> `nros_serdes::cdr::tests::xcdr1_header_matches_live_jazzy_wire_bytes`).
-> "Modern ROS 2 defaults types to `@appendable`/XCDR2 so nano-ros must too" is
-> wrong — and DDS-XTypes REJECTS an appendable writer against a FINAL reader, so
-> emitting appendable-by-edition BREAKS default interop. Extensibility is a
-> per-type property, never an edition property.
-
-So XCDR1 is what the LTS editions put on the wire on the default path, and
-nano-ros writes XCDR1 exclusively (`CdrWriter`'s constructors hard-wire it;
-`EncodingVersion::default()` is `Xcdr1`). The TX buffer therefore needs XCDR1
-only.
-
-The RX side is not symmetric. `CdrReader` dispatches on the encapsulation id and
-accepts XCDR2, and RFC-0055's machinery is "built + tested but parked" pending
-per-type `@appendable` re-activation — so a peer's XCDR2 sample can arrive.
-Neither encoding dominates the other in size (XCDR2 adds a 4-byte DHEADER per
-struct, but aligns 8-byte primitives to 4 instead of 8), so the receive bound
-must be the max. This matches what the Rust path already computes
-(`subscription_rx_hint`, `rmw_type_registry.rs:168`).
-
-**Consequence: emit BOTH constants, not one pre-maxed value.** The two consumers
-want different numbers, and a single `MAX_SERIALIZED_SIZE` would be silently
-wrong for one of them — the same reason `pad_to` takes a version rather than a
-constant.
-
-**3. The out-of-band bound already exists: `nros-codegen.toml` `cap` (RFC-0033).**
-No new config file. Per-field `mode` + `cap`, deep-merged, `deny_unknown_fields`,
-and already resolved per-field for the struct rendering
-(`generator/common.rs:415-419`, `583-619`, `891-903`) — `cap = 64` on an
-unbounded `string` renders `heapless::String<64>`.
-
-The gap is one hop: the schema emit path
-(`build_nros_schema_for_struct_with_path`) walks the RAW rosidl AST and has no
-storage resolver in scope, so that same field still emits
-`::nros_serdes::FieldType::String` and the type's bound comes back `None`. The
-capacity is applied to the STORAGE and not to the SCHEMA. Threading the resolved
-`cap` into `render_field_type_expr` is the entire out-of-band mechanism.
-
-Semantics stay distinct, and this is why `cap` sizes a HINT rather than
-asserting a bound: an IDL `string<=64` constrains the publisher, whereas a `cap`
-is local to this image and a remote ROS node may still send 200 bytes. So a
-capped field bounds our buffer and creates a truncation contract — which is
-exactly what (4) handles.
-
-**4. Oversize is explicit and NEVER fatal.** An app that dies on an embedded
-target is worse for the user than one that drops a sample and says so — there is
-often no console, no debugger and no way to restart it.
-
-The receive path already has the right shape to copy, in
-`executor/arena.rs:386`: `#[cold]`, a `DROPPED_TAKES` counter, first-then-every-
-64th rate limiting (so one misconfigured subscription in a 40-participant graph
-cannot flood the log — issue 0371's shape), and `nros_log` rather than stdio,
-because a Rust `std` stdio call is FATAL inside Zephyr `native_sim` (issue 0589).
-No panic, no abort.
-
-The transmit path needs the same treatment plus a distinct status. There is no
-too-large code today — the closest is `NROS_RET_FULL` (-6), which means a full
-queue — so the generated publish helper returns a bare non-zero that callers
-cannot tell from a transport failure. Add one (cbindgen: `just regen-c-headers`),
-and report it once per site rather than per sample.
-
-## RawSubscription: decided 2026-08-29
-
-`RawSubscription<const RX_BUF: usize>` (`executor/handles.rs:1306`) holds its
-receive buffer INLINE, so `RX_BUF` is a monomorphisation, not a parameter — a
-runtime hint cannot select between `RawSubscription<1024>` and
-`RawSubscription<4096>`. Worse, the size is baked into the APPLICATION's own
-struct: `SUBSCRIPTION_OPAQUE_U64S` is
-`u64s_for::<RawSubscription<{ MESSAGE_BUFFER_SIZE }>>()`
-(`opaque_sizes.rs:29`), and a C caller declares
-`uint8_t sub[NROS_C_SUBSCRIPTION_STORAGE_SIZE]` at their own compile time.
-
-Three options were weighed:
-
-* **Size classes plus a compile-time storage macro** — a small ladder of
-  instantiations, dispatched at init against the caller's declared size.
-  REJECTED: pays code size for N monomorphisations of the whole subscription
-  path, gives a coarser answer than the exact bound, and leaves the arena
-  coupling untouched.
-* **Decouple the buffer (`&'a mut [u8]`)** — one type, no monomorphisation,
-  exact per-subscription bytes, `_opaque` shrinks. This is the real per-type
-  fix and matches the hint model directly. DEFERRED, not rejected: it adds a
-  lifetime contract across FFI, and C has TWO subscription paths (the L1
-  polling one here and the arena callback path at `nros-c/src/executor.rs:817`),
-  so both must move together or half the tree keeps the old sizing.
-* **Fix the arena instead** — TAKEN FIRST, and split out as **issue 0900**.
-  It turned out not to be part of this issue at all: every arena slot is
-  budgeted at the ActionClient worst case, so `ARENA_SIZE` is 74,240 bytes on
-  every image measured, a talker included, where a pub/sub-only image needs
-  ~16 KiB. It also explains why per-type receive sizing cannot help that
-  number: the slot is sized from the GLOBAL knob, amplified 3 x MAX_CBS = 12x,
-  regardless of what any individual subscription asks for.
-
-Order: **0900 first** (largest saving, no ABI change, independent of everything
-here), then the buffer decoupling as the per-type fix.
+6. **Thread the RFC-0033 `cap` into the schema emit** so a field bounded only in
+   `nros-codegen.toml` stops reading as unbounded. Same test, extended.
 
 ## Not to be confused with
 

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -318,68 +318,32 @@ and the `nros_subscription_options_t` break — stop being the delivery mechanis
 The raw path may gain a hint later for callers who need one, but it is no longer
 how the fix reaches anybody.
 
-## Layer 1's real constraint: on Humble the nested resolver resolves NOTHING
+## Correction: the real resolver already exists, on every edition
 
-Surveyed before writing the traversal, and it reshapes the layer.
+The previous version of this section claimed nested types cannot be resolved on
+Humble, and it was wrong. It read `no_cross_pkg_resolver`'s doc comment —
+"Humble (placeholder hash, resolver never consulted)" — as a statement about the
+RESOLVER's capability. It is a statement about the HASH consumer.
 
-Building a sizeable value needs nested types resolved in-process. The tree has
-exactly one mechanism for that — `rosidl_bindgen::MsgResolver`, a
-`dyn Fn(&str) -> Option<Message>` threaded into the RIHS hash path — and it
-lives in `rosidl-bindgen`, NOT in `rosidl-codegen`, which is the crate that
-emits the schema. So the resolver is not in scope at any
-`build_nros_schema_for_struct*` call site today; every one of them is inside
-`common.rs` with only field ASTs to hand.
+The real one is already built and already threaded:
 
-Worse, the resolver's own doc says what it does on the default edition:
+* `cargo-nano-ros/src/lib.rs:273` constructs a working cross-package closure off
+  the ament index (`index.packages().get(pkg)?.get_message_path(name)`), and
+  passes it to `generate_package` **unconditionally** — no edition gate;
+* `rosidl-bindgen/src/generator.rs:194` composes it with same-package resolution
+  from the package's own `share_dir` into `self_resolve`, which is a COMPLETE
+  recursive resolver.
 
-> A [`MsgResolver`] that resolves no cross-package types — for self-contained
-> packages … or **Humble (placeholder hash, resolver never consulted)**.
+The edition only decides whether the type-HASH path consults it. Nothing about
+it is Humble-specific.
 
-`no_cross_pkg_resolver` returns `None` for everything. On Humble — the edition
-the examples and fixtures use — a cross-package nested type such as
-`std_msgs/Header` or `builtin_interfaces/Time` **cannot be resolved at all**.
+So layer 1 is not blocked. What is actually missing is one hop: `self_resolve`
+reaches `compute_msg_type_hash` and the generators, and does not reach the
+schema emit in `rosidl-codegen`. Threading it there is the work.
 
-**Measured rather than asserted, because the first draft of this paragraph said
-"that is most real messages" and that is not supported.** Across the 10 `.msg`
-files in `examples/` and `packages/interfaces/`: 2 have any non-primitive field,
-and exactly 1 references another package (`std_msgs`). So on the IN-TREE corpus
-this blocks one message, not most.
-
-That cuts both ways and neither reading is safe on its own. It means layer 1 is
-not blocked for the fixtures — but it also means the fixtures cannot tell us
-whether it is blocked for USERS, and the messages this campaign exists for are
-the heavily-nested ones (an Autoware type reaches `std_msgs`,
-`builtin_interfaces` and `geometry_msgs` before it reaches a number). The
-in-tree corpus is too small to generalise from in either direction; a real
-measurement wants a user workspace.
-
-This collides head-on with the trap recorded above. Unresolvable is not
-unbounded, so an unresolved nested type must not silently produce "no
-constant" — but *failing the generate* would fail nearly every Humble message
-with a `Header`, which is plainly not shippable either. **Neither branch of the
-rule as written is acceptable, so the rule needs a third outcome before any code
-is written:**
-
-* `Bounded(n)` — emit the constant.
-* `Unbounded(field)` — emit the poisoned macro naming the field (layer 5).
-* `Unresolved(type_name)` — emit NEITHER, and say so in the generated header as
-  a comment naming the type that could not be reached, so a reader can tell "we
-  looked and it has no bound" from "we could not look".
-
-Sizing anything from an `Unresolved` is the defect this issue is about, so the
-third outcome must be distinguishable at every consumer, not folded into the
-second.
-
-**The better fix, if it is affordable:** give codegen a real resolver on Humble
-too. The bindgen path already owns the package's `share_dir` and resolves
-same-package nested types itself; the ament index that would answer the
-cross-package ones is available at `nros sync` time. That turns `Unresolved`
-into a rare error case instead of the common one. It is also a larger change
-than this issue has scoped, and it should be measured (how many types in
-`examples/` actually go unresolved on Humble today?) before being assumed.
-
-**Layer 1 is not started for this reason** — the plumbing would have to be
-redone once this is decided, and the decision is not mine to guess.
+`Unresolved` as a third outcome still earns its place — a dependency genuinely
+absent from the ament index must not read as "unbounded" — but it is the RARE
+case it was always supposed to be, not the common one.
 
 ## Layers, in order
 

--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -225,14 +225,65 @@ So the model route works, but only once someone AUTHORS the wiring. Warning on
 absent wiring is therefore the primary UX for as long as that stays true, not an
 edge case.
 
+## Correction: "value-first" is not possible; "one traversal, two outputs" is
+
+Layer 1 said: build the `nros_serdes::FieldType` VALUE, then render the existing
+string FROM it, so one mapping has two outputs. Reading the emitter shows the
+string is not derivable from the value, in two independent ways.
+
+**The nested arm defers instead of inlining.** It emits a helper const that
+points at the nested type's OWN `Message` impl:
+
+```rust
+pub const X_NESTED_HEADER: ::nros_serdes::NestedType = ::nros_serdes::NestedType {
+    type_name: <std_msgs::msg::Header as ::nros_serdes::Message>::TYPE_NAME,
+    fields:    <std_msgs::msg::Header as ::nros_serdes::Message>::FIELDS,
+};
+```
+
+so the generated crate resolves the child at ITS compile time. The string
+therefore needs a RUST PATH (`nested_path_resolver(package, name, ...)`), which
+a `NestedType` value does not carry — it carries the ROS type name. Meanwhile a
+value that can be SIZED must have its nested fields resolved in-process, which
+the string deliberately does not do. Neither is a superset of the other.
+
+**Helper-const identifiers are keyed on the field, not the type.** The recursive
+arms hoist `{const_prefix}FT_{FIELD}_ELEM`, so rendering needs the field name
+and prefix as well as the type.
+
+**The fix that achieves the same safety property.** The hazard was never
+"value-first" as such — it was a SECOND, INDEPENDENT walk from
+`rosidl::FieldType` that can drift from the first. One traversal emitting BOTH
+outputs in the same `match` arm has exactly the same property and is
+implementable:
+
+```rust
+fn lower_field_type(
+    rosidl_ty, field_name, prefix, resolver, helper_consts: &mut String,
+) -> (String, &'static nros_serdes::FieldType)
+```
+
+Every arm produces its string and its value together, so adding a `FieldType`
+variant that one output handles and the other forgets is a compile error rather
+than a silent divergence. The `&'static` recursion is satisfied by leaking in a
+short-lived CLI process, as already noted.
+
+**Not started.** Landing a half-applied mapping refactor is precisely the defect
+this issue exists to prevent, so the shape is recorded rather than begun —
+layer 1 below is restated in these terms.
+
 ## Layers, in order
 
 0. **Name the field that cost the bound.** When `max_serialized_size` returns
    `None`, report which member is unbounded. No new surface; makes the existing
    `.msg` fix actionable.
-1. **Value-first field mapping in `rosidl-codegen`**, rendering the existing
-   Rust schema string from the value. No behaviour change; the existing emitter
-   tests are the check.
+1. **One traversal, two outputs** in `rosidl-codegen` (see the correction
+   above — rendering the string FROM the value is not possible). Every `match`
+   arm emits its expression string and builds its `nros_serdes::FieldType`
+   value together. No behaviour change; the existing emitter tests plus the
+   golden corpus are the check — and the corpus is worth trusting now, since
+   phase-390 W2 found and repaired the arm that was byte-identical to the
+   default and exercised nothing.
 2. **Both bounds, computed by `max_serialized_size` over those values**, nested
    types resolved by the same closure the RIHS path already uses. Emitted as two
    `#define`s (XCDR1 and XCDR2) from `packs/c/message.h.jinja` and the C++

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -1268,6 +1268,7 @@ version = "0.5.0"
 dependencies = [
  "criterion",
  "minijinja",
+ "nros-serdes",
  "rosidl-lower",
  "rosidl-parser",
  "rosidl-resolve",

--- a/packages/cli/rosidl-codegen/Cargo.toml
+++ b/packages/cli/rosidl-codegen/Cargo.toml
@@ -22,6 +22,12 @@ sha2 = "0.10"
 rosidl-parser.workspace = true
 rosidl-resolve.workspace = true
 rosidl-lower.workspace = true
+# issue 0896 layer 1 — codegen computes a message's serialized-size bound with
+# THE size rule, not a copy of it. `nros_serdes::size::max_serialized_size` is
+# the same function the runtime uses, so the C constant and the Rust const
+# cannot disagree about encoding rules. Path dep across the workspace boundary:
+# `packages/cli` is its own workspace, and this is a core crate.
+nros-serdes = { path = "../../core/nros-serdes", default-features = false }
 minijinja.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/packages/cli/rosidl-codegen/src/lib.rs
+++ b/packages/cli/rosidl-codegen/src/lib.rs
@@ -14,6 +14,7 @@ pub use rosidl_resolve::rihs;
 // through the crate they already depend on (phase-335 W1.c).
 pub use rosidl_resolve::{ResolvedAction, ResolvedMessage, ResolvedService};
 pub mod render;
+pub mod schema_value;
 pub mod templates;
 pub mod types;
 pub mod utils;

--- a/packages/cli/rosidl-codegen/src/schema_value.rs
+++ b/packages/cli/rosidl-codegen/src/schema_value.rs
@@ -1,0 +1,333 @@
+//! Issue 0896 layer 1 — build a real `nros_serdes::FieldType` from a parsed
+//! `.msg`, so codegen can compute a size bound with THE size rule.
+//!
+//! # Why a value and not a second size calculation
+//!
+//! The C headers need a per-type `MAX_SERIALIZED_SIZE`, and the obvious way to
+//! get one is to walk the rosidl AST adding up field widths. That would be a
+//! SECOND implementation of a rule that already exists in
+//! `nros_serdes::size`, and a serialized-size rule is exactly the kind that
+//! looks right until an encoding rule changes under one copy — the
+//! sizes-header mirror defect, issues 0088 -> 0114 -> 0122 -> 0123 -> 0245 ->
+//! 0268.
+//!
+//! So this module does not compute sizes. It builds the INPUT that
+//! `nros_serdes::size::max_serialized_size` already consumes, and calls it.
+//! One rule, two callers.
+//!
+//! # Three outcomes, and why the third exists
+//!
+//! [`TypeBound`] distinguishes:
+//!
+//! * `Bounded(n)` — a bound exists and is `n`;
+//! * `Unbounded` — no bound EXISTS (an unbounded `string`/`sequence`);
+//! * `Unresolved` — we could not LOOK, because a nested type is not reachable.
+//!
+//! Folding the third into the second is the defect issue 0896 is about wearing
+//! a different hat: "we looked and there is no bound" and "we could not look"
+//! license completely different actions, and only the first is safe to size a
+//! buffer from. phase-380's rule is that `None` means unbounded and NEVER
+//! unknown, and this type is how that rule survives contact with a resolver
+//! that can fail.
+//!
+//! # `&'static` by leaking
+//!
+//! `nros_serdes::FieldType` recurses through `&'static` references so the whole
+//! schema graph sits in `.rodata` on a target with no allocator. Codegen is a
+//! short-lived process building a bounded graph per message, so leaking is the
+//! honest way to satisfy that lifetime here — the alternative is a parallel
+//! owned mirror of the type, which is the duplication this module exists to
+//! avoid.
+
+use nros_serdes::schema::{Field, FieldType as SerdeFieldType, NestedType};
+use rosidl_parser::{
+    Message,
+    ast::{FieldType as IdlFieldType, PrimitiveType},
+};
+use std::collections::BTreeSet;
+
+/// What one attempt to bound a type concluded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeBound {
+    /// A bound exists. Bytes, encapsulation header included.
+    Bounded(usize),
+    /// No bound exists — an unbounded member. Carries the offending member as
+    /// `nros_serdes` names it, so a diagnostic can say WHICH field.
+    Unbounded(String),
+    /// We could not look: this nested type was not reachable through the
+    /// resolver. NOT the same as unbounded; nothing may be sized from it.
+    Unresolved(String),
+}
+
+/// Why a schema could not be built.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaError {
+    /// A nested type the resolver could not produce.
+    Unresolved(String),
+    /// A nested-type cycle. ROS IDL cannot express one, so this means the
+    /// resolver returned something inconsistent — report rather than hang.
+    Cycle(String),
+}
+
+/// Resolve a fully-qualified ROS type name (`pkg/Msg` or `pkg/msg/Msg`) to its
+/// parsed message.
+pub type MsgLookup<'a> = dyn Fn(&str) -> Option<Message> + 'a;
+
+/// Build the `&'static [Field]` schema for `msg`, resolving nested types
+/// recursively through `lookup`.
+///
+/// `owner` is the fully-qualified name of `msg`, used for cycle reporting.
+pub fn build_schema(
+    owner: &str,
+    msg: &Message,
+    lookup: &MsgLookup<'_>,
+) -> Result<&'static [Field], SchemaError> {
+    let mut stack = BTreeSet::new();
+    stack.insert(owner.to_string());
+    build_fields(msg, lookup, &mut stack)
+}
+
+fn build_fields(
+    msg: &Message,
+    lookup: &MsgLookup<'_>,
+    stack: &mut BTreeSet<String>,
+) -> Result<&'static [Field], SchemaError> {
+    let mut out = Vec::with_capacity(msg.fields.len());
+    for f in &msg.fields {
+        out.push(Field {
+            name: Box::leak(f.name.clone().into_boxed_str()),
+            ty: *lower(&f.field_type, lookup, stack)?,
+            // The size rule never reads `offset` (checked: zero references in
+            // `nros_serdes::size`), and codegen cannot know a Rust struct's
+            // layout anyway. Zero is honest here precisely because nothing
+            // consumes it on this path.
+            offset: 0,
+        });
+    }
+    Ok(Box::leak(out.into_boxed_slice()))
+}
+
+fn lower(
+    ty: &IdlFieldType,
+    lookup: &MsgLookup<'_>,
+    stack: &mut BTreeSet<String>,
+) -> Result<&'static SerdeFieldType, SchemaError> {
+    let v = match ty {
+        IdlFieldType::Primitive(p) => primitive(p),
+        IdlFieldType::String => SerdeFieldType::String,
+        IdlFieldType::WString => SerdeFieldType::WString,
+        IdlFieldType::BoundedString(n) => SerdeFieldType::BoundedString(*n),
+        IdlFieldType::BoundedWString(n) => SerdeFieldType::BoundedWString(*n),
+        IdlFieldType::Array { element_type, size } => {
+            SerdeFieldType::Array(*size, lower(element_type, lookup, stack)?)
+        }
+        IdlFieldType::Sequence { element_type } => {
+            SerdeFieldType::Sequence(lower(element_type, lookup, stack)?)
+        }
+        IdlFieldType::BoundedSequence {
+            element_type,
+            max_size,
+        } => SerdeFieldType::BoundedSequence(*max_size, lower(element_type, lookup, stack)?),
+        IdlFieldType::NamespacedType { package, name } => {
+            let fqn = match package {
+                Some(p) => format!("{p}/{name}"),
+                // A bare name is same-package; the caller's lookup owns that
+                // resolution, so hand it the name as written.
+                None => name.clone(),
+            };
+            if !stack.insert(fqn.clone()) {
+                return Err(SchemaError::Cycle(fqn));
+            }
+            let nested = lookup(&fqn).ok_or_else(|| SchemaError::Unresolved(fqn.clone()))?;
+            let fields = build_fields(&nested, lookup, stack)?;
+            stack.remove(&fqn);
+            SerdeFieldType::Nested(Box::leak(Box::new(NestedType {
+                type_name: Box::leak(fqn.into_boxed_str()),
+                fields,
+            })))
+        }
+    };
+    Ok(Box::leak(Box::new(v)))
+}
+
+fn primitive(p: &PrimitiveType) -> SerdeFieldType {
+    match p {
+        PrimitiveType::Bool => SerdeFieldType::Bool,
+        PrimitiveType::Byte | PrimitiveType::UInt8 => SerdeFieldType::Uint8,
+        PrimitiveType::Char | PrimitiveType::Int8 => SerdeFieldType::Int8,
+        PrimitiveType::Int16 => SerdeFieldType::Int16,
+        PrimitiveType::UInt16 => SerdeFieldType::Uint16,
+        PrimitiveType::Int32 => SerdeFieldType::Int32,
+        PrimitiveType::UInt32 => SerdeFieldType::Uint32,
+        PrimitiveType::Int64 => SerdeFieldType::Int64,
+        PrimitiveType::UInt64 => SerdeFieldType::Uint64,
+        PrimitiveType::Float32 => SerdeFieldType::Float32,
+        PrimitiveType::Float64 => SerdeFieldType::Float64,
+    }
+}
+
+/// Bound a parsed message under one encoding, resolving nested types through
+/// `lookup`.
+///
+/// The size itself comes from `nros_serdes::size::max_serialized_size` — this
+/// function only supplies its input and classifies the answer.
+pub fn bound_message(
+    owner: &str,
+    msg: &Message,
+    version: nros_serdes::cdr::EncodingVersion,
+    lookup: &MsgLookup<'_>,
+) -> TypeBound {
+    let fields = match build_schema(owner, msg, lookup) {
+        Ok(f) => f,
+        Err(SchemaError::Unresolved(t)) | Err(SchemaError::Cycle(t)) => {
+            return TypeBound::Unresolved(t);
+        }
+    };
+    match nros_serdes::size::max_serialized_size(fields, version) {
+        Some(n) => TypeBound::Bounded(n),
+        None => TypeBound::Unbounded(
+            nros_serdes::size::first_unbounded(fields)
+                .map(|u| alloc_fmt(&u))
+                .unwrap_or_else(|| "<unknown>".to_string()),
+        ),
+    }
+}
+
+/// `UnboundedField` is `Display` on `no_std`; this is the `std` side of that.
+fn alloc_fmt(u: &nros_serdes::size::UnboundedField) -> String {
+    format!("{u}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nros_serdes::cdr::EncodingVersion;
+    use rosidl_parser::parse_message;
+
+    fn no_lookup(_: &str) -> Option<Message> {
+        None
+    }
+
+    #[test]
+    fn a_flat_bounded_message_gets_a_number() {
+        let m = parse_message("int32 a\nuint8 b\n").unwrap();
+        assert!(matches!(
+            bound_message("p/M", &m, EncodingVersion::Xcdr1, &no_lookup),
+            TypeBound::Bounded(_)
+        ));
+    }
+
+    /// The whole reason this module exists: the number codegen computes must be
+    /// the number the runtime computes, because it is the same function over
+    /// the same input. A second size implementation is the defect class
+    /// (0088 -> 0268) this avoids.
+    #[test]
+    fn the_bound_equals_what_nros_serdes_computes_directly() {
+        let m = parse_message("int64 big\nuint8 small\n").unwrap();
+        let fields = build_schema("p/M", &m, &no_lookup).unwrap();
+        for v in [EncodingVersion::Xcdr1, EncodingVersion::Xcdr2] {
+            let direct = nros_serdes::size::max_serialized_size(fields, v).unwrap();
+            assert_eq!(
+                bound_message("p/M", &m, v, &no_lookup),
+                TypeBound::Bounded(direct)
+            );
+        }
+    }
+
+    /// The two encodings genuinely differ — XCDR2 adds a 4-byte DHEADER and
+    /// aligns 8-byte primitives to 4 instead of 8 — so emitting ONE constant
+    /// would be wrong for one of them.
+    ///
+    /// The case is chosen, not arbitrary. `uint8 a; int64 b` makes them AGREE
+    /// at 20 bytes by coincidence: XCDR2's DHEADER costs +4 and its looser
+    /// alignment saves exactly 4 (a 7-byte pad becomes 3). A bare `int64` has
+    /// no pad to save, so the DHEADER shows: 12 vs 16. Picking the first case
+    /// would have asserted a rule that happens to hold and called it a law.
+    #[test]
+    fn the_two_encodings_do_not_agree_so_both_constants_are_needed() {
+        let m = parse_message("int64 b\n").unwrap();
+        let x1 = bound_message("p/M", &m, EncodingVersion::Xcdr1, &no_lookup);
+        let x2 = bound_message("p/M", &m, EncodingVersion::Xcdr2, &no_lookup);
+        assert_eq!(x1, TypeBound::Bounded(12));
+        assert_eq!(x2, TypeBound::Bounded(16));
+    }
+
+    /// The coincidence above, pinned so nobody "fixes" the case choice back.
+    #[test]
+    fn some_types_do_agree_across_encodings_which_is_why_the_case_matters() {
+        let m = parse_message("uint8 a\nint64 b\n").unwrap();
+        assert_eq!(
+            bound_message("p/M", &m, EncodingVersion::Xcdr1, &no_lookup),
+            bound_message("p/M", &m, EncodingVersion::Xcdr2, &no_lookup),
+            "DHEADER +4 cancels the saved 4 bytes of padding here"
+        );
+    }
+
+    #[test]
+    fn an_unbounded_field_is_named_not_just_reported() {
+        let m = parse_message("string label\n").unwrap();
+        match bound_message("p/M", &m, EncodingVersion::Xcdr1, &no_lookup) {
+            TypeBound::Unbounded(which) => assert!(which.contains("label"), "{which}"),
+            other => panic!("expected Unbounded, got {other:?}"),
+        }
+    }
+
+    /// "Could not look" must never read as "no bound exists" — sizing a buffer
+    /// from an unresolved type is the defect issue 0896 is about.
+    #[test]
+    fn an_unresolvable_nested_type_is_unresolved_not_unbounded() {
+        let m = parse_message("std_msgs/Header header\n").unwrap();
+        match bound_message("p/M", &m, EncodingVersion::Xcdr1, &no_lookup) {
+            TypeBound::Unresolved(t) => assert!(t.contains("Header"), "{t}"),
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_resolvable_nested_type_is_walked_recursively() {
+        let m = parse_message("std_msgs/Header header\nint32 v\n").unwrap();
+        let lookup = |fqn: &str| -> Option<Message> {
+            (fqn == "std_msgs/Header").then(|| parse_message("uint32 seq\nint32 sec\n").unwrap())
+        };
+        assert!(matches!(
+            bound_message("p/M", &m, EncodingVersion::Xcdr1, &lookup),
+            TypeBound::Bounded(_)
+        ));
+    }
+
+    /// An unbounded member THREE levels down still makes the whole type
+    /// unbounded, and the report names the full path rather than the top field.
+    #[test]
+    fn an_unbounded_member_deep_in_a_nested_type_is_found() {
+        let m = parse_message("std_msgs/Header header\n").unwrap();
+        let lookup = |fqn: &str| -> Option<Message> {
+            match fqn {
+                "std_msgs/Header" => {
+                    Some(parse_message("builtin_interfaces/Time stamp\n").unwrap())
+                }
+                "builtin_interfaces/Time" => Some(parse_message("string frame_id\n").unwrap()),
+                _ => None,
+            }
+        };
+        match bound_message("p/M", &m, EncodingVersion::Xcdr1, &lookup) {
+            TypeBound::Unbounded(which) => {
+                assert!(which.contains("header.stamp.frame_id"), "{which}")
+            }
+            other => panic!("expected Unbounded, got {other:?}"),
+        }
+    }
+
+    /// ROS IDL cannot express a cycle, so one means the resolver is
+    /// inconsistent. Report it instead of recursing forever.
+    #[test]
+    fn a_resolver_cycle_is_reported_rather_than_hanging() {
+        let m = parse_message("p/A a\n").unwrap();
+        let lookup = |fqn: &str| -> Option<Message> {
+            (fqn == "p/A").then(|| parse_message("p/A inner\n").unwrap())
+        };
+        assert!(matches!(
+            bound_message("p/M", &m, EncodingVersion::Xcdr1, &lookup),
+            TypeBound::Unresolved(_)
+        ));
+    }
+}

--- a/packages/core/nros-serdes/src/size.rs
+++ b/packages/core/nros-serdes/src/size.rs
@@ -207,6 +207,163 @@ pub const fn size_bound(
     }
 }
 
+/// How deep a field path [`first_unbounded`] will name before it stops.
+///
+/// ROS message nesting is shallow in practice (`PoseStamped.header.stamp.sec`
+/// is three), and this walk runs on `no_std` with no allocator, so the path is
+/// a fixed array rather than a `Vec`. A deeper type still reports — the path is
+/// simply truncated, and [`UnboundedField::truncated`] says so, because a path
+/// that silently stops short would point at the wrong member.
+pub const MAX_FIELD_PATH_DEPTH: usize = 8;
+
+/// Which unbounded member kind was reached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnboundedKind {
+    /// `string` with no IDL bound.
+    String,
+    /// `wstring` with no IDL bound.
+    WString,
+    /// `sequence<T>` with no IDL bound.
+    Sequence,
+}
+
+impl UnboundedKind {
+    /// The IDL spelling, for a diagnostic.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            UnboundedKind::String => "string",
+            UnboundedKind::WString => "wstring",
+            UnboundedKind::Sequence => "sequence<T>",
+        }
+    }
+}
+
+/// The first member that makes a type unbounded, named.
+///
+/// [`max_serialized_size`] answers `None`, which is honest and useless on its
+/// own: a user told their type has no bound cannot act without knowing WHICH
+/// member costs it, and the offender is routinely three structs down in a type
+/// they did not write. This is that answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnboundedField {
+    /// Field names from the root outward; only `depth` entries are meaningful.
+    pub path: [&'static str; MAX_FIELD_PATH_DEPTH],
+    /// How many entries of `path` are set.
+    pub depth: usize,
+    /// True when nesting exceeded [`MAX_FIELD_PATH_DEPTH`] and `path` names a
+    /// prefix rather than the whole route.
+    pub truncated: bool,
+    /// What kind of member it is.
+    pub kind: UnboundedKind,
+}
+
+impl core::fmt::Display for UnboundedField {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for (i, seg) in self.path.iter().take(self.depth).enumerate() {
+            if i > 0 {
+                f.write_str(".")?;
+            }
+            f.write_str(seg)?;
+        }
+        if self.truncated {
+            f.write_str(".…")?;
+        }
+        write!(f, " ({})", self.kind.as_str())
+    }
+}
+
+/// Find the first member that makes `fields` unbounded, if any.
+///
+/// Returns `None` exactly when [`size_bound`] reports `bounded` — the two walk
+/// the same schema by the same rules, so a type that has a bound has no
+/// offender to name and vice versa. That agreement is asserted by test, not
+/// assumed: two walks of one schema is the shape the sizes-header mirror defect
+/// keeps taking (issues 0088 -> 0268), so the second one exists only because it
+/// answers a question the first cannot (WHICH member) and must be checked
+/// against it.
+///
+/// Not `const`: it recurses through `&'static NestedType`, and the array
+/// bookkeeping is not worth expressing in a const walk when every caller is a
+/// diagnostic path.
+pub fn first_unbounded(fields: &'static [Field]) -> Option<UnboundedField> {
+    fn walk(
+        fields: &'static [Field],
+        prefix: &mut [&'static str; MAX_FIELD_PATH_DEPTH],
+        depth: usize,
+    ) -> Option<UnboundedField> {
+        for field in fields {
+            let truncated = depth >= MAX_FIELD_PATH_DEPTH;
+            if !truncated {
+                prefix[depth] = field.name;
+            }
+            let here = |kind: UnboundedKind| {
+                Some(UnboundedField {
+                    path: *prefix,
+                    depth: if truncated {
+                        MAX_FIELD_PATH_DEPTH
+                    } else {
+                        depth + 1
+                    },
+                    truncated,
+                    kind,
+                })
+            };
+            let found = match &field.ty {
+                FieldType::String => here(UnboundedKind::String),
+                FieldType::WString => here(UnboundedKind::WString),
+                FieldType::Sequence(_) => here(UnboundedKind::Sequence),
+                // A fixed array or a bounded sequence is bounded only if its
+                // ELEMENT is, and the element can itself be an unbounded
+                // string — `string[4]` has no bound. The element carries no
+                // name of its own, so it reports at the field's own path.
+                FieldType::Array(_, inner) | FieldType::BoundedSequence(_, inner) => {
+                    match element_unbounded(inner) {
+                        Some(kind) => here(kind),
+                        None => None,
+                    }
+                }
+                FieldType::Nested(nested) => {
+                    if truncated {
+                        // Cannot record another segment; report the deepest
+                        // path we can name rather than descending silently.
+                        walk(nested.fields, prefix, depth).map(|mut u| {
+                            u.truncated = true;
+                            u
+                        })
+                    } else {
+                        walk(nested.fields, prefix, depth + 1)
+                    }
+                }
+                _ => None,
+            };
+            if found.is_some() {
+                return found;
+            }
+        }
+        None
+    }
+
+    /// An element type is not a field, so it has no name — report only its kind.
+    fn element_unbounded(ty: &'static FieldType) -> Option<UnboundedKind> {
+        match ty {
+            FieldType::String => Some(UnboundedKind::String),
+            FieldType::WString => Some(UnboundedKind::WString),
+            FieldType::Sequence(_) => Some(UnboundedKind::Sequence),
+            FieldType::Array(_, inner) | FieldType::BoundedSequence(_, inner) => {
+                element_unbounded(inner)
+            }
+            FieldType::Nested(nested) => {
+                // A nested struct inside an array: any unbounded member counts.
+                first_unbounded(nested.fields).map(|u| u.kind)
+            }
+            _ => None,
+        }
+    }
+
+    let mut prefix = [""; MAX_FIELD_PATH_DEPTH];
+    walk(fields, &mut prefix, 0)
+}
+
 /// The whole payload a publisher hands the transport: encapsulation header plus
 /// the struct's body, starting from offset 0.
 ///
@@ -384,6 +541,139 @@ mod tests {
             ty,
             offset: 0,
         }
+    }
+
+    // ========================================================================
+    // issue 0896 layer 0 — naming the member that costs the bound
+    // ========================================================================
+
+    /// The two walks must agree. `first_unbounded` is a SECOND walk of the same
+    /// schema, which is the shape the sizes-header mirror defect keeps taking
+    /// (0088 -> 0268), so it earns its existence only by answering a question
+    /// `size_bound` cannot — and only while it never disagrees about the
+    /// question they share.
+    fn agree(fields: &'static [Field]) {
+        for version in [EncodingVersion::Xcdr1, EncodingVersion::Xcdr2] {
+            let bounded = size_bound(fields, version, 0).bounded;
+            let named = first_unbounded(fields);
+            assert_eq!(
+                bounded,
+                named.is_none(),
+                "size_bound says bounded={bounded} but first_unbounded says \
+                 {named:?} ({version:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bounded_type_has_no_offender_to_name() {
+        static FIELDS: &[Field] = &[
+            f("x", FieldType::Uint32),
+            f("s", FieldType::BoundedString(8)),
+        ];
+        agree(FIELDS);
+    }
+
+    #[test]
+    fn an_unbounded_string_is_named() {
+        static FIELDS: &[Field] = &[f("flag", FieldType::Bool), f("label", FieldType::String)];
+        agree(FIELDS);
+        let u = first_unbounded(FIELDS).unwrap();
+        assert_eq!(u.kind, UnboundedKind::String);
+        assert_eq!(&u.path[..u.depth], &["label"]);
+    }
+
+    /// The offender is usually not at the top level — this is the whole reason
+    /// the path exists rather than a bare field name.
+    #[test]
+    fn a_nested_offender_reports_its_full_path() {
+        static INNER: &[Field] = &[f("sec", FieldType::Int32), f("frame_id", FieldType::String)];
+        static INNER_TY: NestedType = NestedType {
+            type_name: "std_msgs/msg/Header",
+            fields: INNER,
+        };
+        static FIELDS: &[Field] = &[f("header", FieldType::Nested(&INNER_TY))];
+        agree(FIELDS);
+        let u = first_unbounded(FIELDS).unwrap();
+        assert_eq!(&u.path[..u.depth], &["header", "frame_id"]);
+    }
+
+    /// `string[4]` is a FIXED array of an UNBOUNDED element: the count is
+    /// known and the bound is not. Reported at the field's own path, because
+    /// an element has no name of its own.
+    #[test]
+    fn a_fixed_array_of_unbounded_elements_is_unbounded() {
+        static ELEM: FieldType = FieldType::String;
+        static FIELDS: &[Field] = &[f("names", FieldType::Array(4, &ELEM))];
+        agree(FIELDS);
+        let u = first_unbounded(FIELDS).unwrap();
+        assert_eq!(&u.path[..u.depth], &["names"]);
+        assert_eq!(u.kind, UnboundedKind::String);
+    }
+
+    /// A bounded sequence of bounded elements IS bounded — the easy way to get
+    /// this wrong is to treat any sequence as unbounded.
+    #[test]
+    fn a_bounded_sequence_of_bounded_elements_is_bounded() {
+        static ELEM: FieldType = FieldType::Uint16;
+        static FIELDS: &[Field] = &[f("ranges", FieldType::BoundedSequence(16, &ELEM))];
+        agree(FIELDS);
+        assert!(first_unbounded(FIELDS).is_none());
+    }
+
+    #[test]
+    fn the_first_offender_wins_so_the_message_names_one_thing() {
+        static FIELDS: &[Field] = &[
+            f("a", FieldType::String),
+            f("b", FieldType::Sequence(&FieldType::Uint8)),
+        ];
+        let u = first_unbounded(FIELDS).unwrap();
+        assert_eq!(&u.path[..u.depth], &["a"]);
+    }
+
+    /// A stack-only `core::fmt::Write` sink.
+    ///
+    /// `alloc::format!` would be shorter and would test the wrong build:
+    /// `Display` here exists FOR the `no_std` diagnostic path, so the test runs
+    /// where that path runs. Silently drops overflow — the assertion below
+    /// catches a truncated result either way.
+    struct Buf {
+        bytes: [u8; 128],
+        len: usize,
+    }
+
+    impl core::fmt::Write for Buf {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            for b in s.as_bytes() {
+                if self.len < self.bytes.len() {
+                    self.bytes[self.len] = *b;
+                    self.len += 1;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn the_display_form_reads_as_a_path_and_a_kind() {
+        use core::fmt::Write;
+        static INNER: &[Field] = &[f("frame_id", FieldType::String)];
+        static INNER_TY: NestedType = NestedType {
+            type_name: "std_msgs/msg/Header",
+            fields: INNER,
+        };
+        static FIELDS: &[Field] = &[f("header", FieldType::Nested(&INNER_TY))];
+        let u = first_unbounded(FIELDS).unwrap();
+
+        let mut buf = Buf {
+            bytes: [0; 128],
+            len: 0,
+        };
+        write!(buf, "{u}").unwrap();
+        assert_eq!(
+            core::str::from_utf8(&buf.bytes[..buf.len]).unwrap(),
+            "header.frame_id (string)"
+        );
     }
 
     /// Serialize a MAXIMAL instance of a schema with the real `CdrWriter`, and


### PR DESCRIPTION
`max_serialized_size` answers `None` — honest, and useless on its own. A user told their type has no bound can't act without knowing **which** member costs it, and the offender is routinely three structs down in a type they didn't write (`header.frame_id` on anything carrying a `std_msgs/Header`).

`first_unbounded` returns that member as a path plus a kind, printing as `header.frame_id (string)`.

## Constraints it respects

`no_std`, allocator-free — it runs where the bound matters. The path is a fixed `[&'static str; 8]`, not a `Vec`. ROS nesting is shallow (`PoseStamped.header.stamp.sec` is three); a deeper type still reports, with `truncated` set, because a path that silently stopped short would point at the **wrong** member.

## Three cases the naive version gets wrong

- `string[4]` — a **fixed** array of an **unbounded** element. Count known, bound not.
- `sequence<uint16, 16>` **is** bounded. Treating every sequence as unbounded is the easy mistake.
- The **first** offender wins, so the message names one thing to fix, not a list.

## The risk, and what holds it

This is a **second walk of one schema** — precisely the shape the sizes-header mirror defect keeps taking (0088 → 0114 → 0122 → 0123 → 0245 → 0268). It earns its existence only by answering a question `size_bound` cannot, and only while the two never disagree about the question they share.

So `agree()` asserts `size_bound(..).bounded == first_unbounded(..).is_none()` under **both** encodings, for every case in the module.

`Display` is tested through a stack-only `core::fmt::Write` sink rather than `alloc::format!` — this impl exists *for* the `no_std` diagnostic path, and testing it under `alloc` would test the wrong build. Both `--no-default-features` and `--features alloc` green.

## Not yet reached by a caller

Deliberate, and the next layer rather than an oversight: the consumer is the C/C++ emitter declining to emit a `MAX_SERIALIZED_SIZE` constant, which needs layer 1's value-first field mapping first. Said in the code so nobody reads it as dead.

**Noted while looking for a caller:** `rx_buffer_for!` silently falls back to `DEFAULT_RX_BUF_SIZE` on an unbounded type — the same silent-default this issue is about, on the Rust side. Left alone; changing a public macro's behaviour isn't a layer-0 edit.

`just ci-l1` green (1027 ran / 1 skipped).