### PR TITLE
fix(zephyr): heap starvation says so, and an impossible size fails the build

### DIFF
--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -565,6 +565,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
  "nros-platform-mps2-an385",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -510,6 +510,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -497,6 +497,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -510,6 +510,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -507,6 +507,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -514,6 +514,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -184,6 +184,21 @@ void *nros_platform_alloc(size_t size) {
     k_spinlock_key_t key = k_spin_lock(&nros_heap_lock);
     void *out = nros_zephyr_heap_alloc(size);
     k_spin_unlock(&nros_heap_lock, key);
+    if (out == NULL) {
+        /* phase-8 diagnosis — arena exhaustion was completely silent. The
+         * caller gets NULL and whatever it does next (retry, block, ignore)
+         * is the only evidence, which is how a 64 KiB default cost a 9-step
+         * bisect to attribute.
+         *
+         * printk, not LOG_*: the logging subsystem may itself allocate, and
+         * this is the path that just failed to allocate. Emitted AFTER the
+         * spinlock is released for the same reason -- never call into
+         * anything reentrant while holding the funnel's lock. */
+        extern size_t nros_zephyr_heap_capacity(void);
+        printk("nros: HEAP EXHAUSTED: request %zu bytes, arena %zu bytes "
+               "(raise CONFIG_NROS_ZEPHYR_HEAP_SIZE / NROS_ZEPHYR_HEAP_SIZE)\n",
+               size, nros_zephyr_heap_capacity());
+    }
     return out;
 }
 

--- a/packages/platform/nros-platform/Cargo.toml
+++ b/packages/platform/nros-platform/Cargo.toml
@@ -202,3 +202,10 @@ nros-platform-esp32-qemu = { version = "0.4.0", path = "../../platform/nros-plat
 
 [lints]
 workspace = true
+
+[build-dependencies]
+# issue 0460 — the shared Kconfig-via-$DOTCONFIG knob fallback. A Zephyr RUST
+# image inherits none of the cmake `set(ENV{...})` knob exports, so a bare
+# environment read compiles the crate default whatever Kconfig says. Needed
+# here since phase-8 made NROS_ZEPHYR_HEAP_SIZE a forwarded knob; see build.rs.
+nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }

--- a/packages/platform/nros-platform/build.rs
+++ b/packages/platform/nros-platform/build.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026, NEWSLab NTU.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolve `NROS_ZEPHYR_HEAP_SIZE` for `src/zephyr_heap.rs`.
+//!
+//! The arena size used to be read straight from the environment with
+//! `option_env!`. That has two defects this build script exists to fix, and
+//! `check-kconfig-knob-forwarding` fails the build without it.
+//!
+//! 1. A bare environment read does not reach the Zephyr Rust lane. Kconfig
+//!    knobs live in `$DOTCONFIG`, and `nros_zephyr_build::knob_usize` is the
+//!    one spelling that resolves BOTH (issue 0460) -- environment first, then
+//!    `CONFIG_*`, then the default.
+//!
+//! 2. `option_env!` is baked at compile time and, with no build script, cargo
+//!    never invalidates on a change to it: an already-built rlib is reused
+//!    with the previous size compiled in, and the image starves exactly as if
+//!    the knob had never been set. Reading the variable here emits the
+//!    `rerun-if-env-changed` that makes a change take effect.
+//!
+//! The default stays 64 KiB, matching the zenoh images' previous
+//! `CONFIG_HEAP_MEM_POOL_SIZE=65536`, so a converted image is RAM-neutral
+//! before tuning.
+
+const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
+
+fn main() {
+    let size = nros_zephyr_build::knob_usize(
+        "NROS_ZEPHYR_HEAP_SIZE",
+        "CONFIG_NROS_ZEPHYR_HEAP_SIZE",
+        DEFAULT_HEAP_SIZE,
+    );
+
+    // `zephyr_heap.rs` keeps its `option_env!` read; this simply makes the
+    // value it sees the RESOLVED one rather than whatever happened to be in
+    // the ambient environment.
+    println!("cargo:rustc-env=NROS_ZEPHYR_HEAP_SIZE={size}");
+    println!("cargo:rerun-if-env-changed=NROS_ZEPHYR_HEAP_SIZE");
+}

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -613,6 +613,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -645,6 +645,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -491,6 +491,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -343,6 +343,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -513,6 +513,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -452,6 +452,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -452,6 +452,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/scripts/check-kconfig-knob-forwarding.sh
+++ b/scripts/check-kconfig-knob-forwarding.sh
@@ -62,6 +62,12 @@ DERIVED_READERS=(
     # NROS_RMW_SUBSCRIBER_SLOTS, NROS_RMW_MESSAGE_INFO_SLOTS). Added when
     # #0752 forwarded SUBSCRIBER_SLOTS and this file was still env-only.
     packages/rmw/cffi/build.rs
+    # phase-8 — NROS_ZEPHYR_HEAP_SIZE, the rlsf arena behind the Zephyr
+    # allocation funnel. Resolved here rather than with `option_env!` in source
+    # for both reasons this gate exists: a bare environment read misses
+    # `$DOTCONFIG` on the Rust lane, and with no build script cargo never
+    # invalidates on a change to the knob.
+    packages/platform/nros-platform/build.rs
 )
 
 # Knobs the cmake side exports that no Rust build script reads. Each needs a

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -902,6 +902,22 @@ config NROS_EXECUTOR_ACTION_CLIENTS
       executor reports what it actually used on its first spin, so build once,
       read the advisory, then set this. Issue 0900.
 
+config NROS_ZEPHYR_HEAP_SIZE
+    int "Application heap arena size (bytes)"
+    default 65536
+    help
+      Size of the rlsf arena in nros-platform's zephyr_heap, which backs
+      BOTH z_malloc and __rust_alloc since the allocation funnel moved off
+      Zephyr's kernel heap.
+
+      CONFIG_HEAP_MEM_POOL_SIZE does NOT govern application allocation any
+      more; this does. An application that outgrows the arena does not
+      fault or log -- it stops, so size this to what the application
+      actually needs rather than leaving the default in place and
+      inferring from a hang.
+
+      An NROS_ZEPHYR_HEAP_SIZE environment variable overrides this value.
+
 config NROS_EXECUTOR_ARENA_SIZE
     int "Executor arena size in bytes (0 = derive)"
     default 0

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -221,6 +221,19 @@ function(nros_resolve_knobs)
             "${CONFIG_NROS_EXECUTOR_ARENA_SIZE}")
     endif()
 
+    # Application heap arena (phase-391 W3). `nros-platform`'s zephyr_heap
+    # reads NROS_ZEPHYR_HEAP_SIZE via `option_env!`, but nothing forwarded it
+    # into the cargo environment, so the knob was documented and unreachable
+    # from a Zephyr build: exporting it had no effect and the arena stayed at
+    # its 64 KiB default.
+    #
+    # That matters because 60b4e0c1e moved z_malloc AND __rust_alloc off the
+    # kernel heap onto this arena, so CONFIG_HEAP_MEM_POOL_SIZE no longer
+    # governs application allocation. A consumer needing more than 64 KiB has
+    # no working way to ask for it, and starvation presents as a silent hang
+    # rather than an error. See NEWSLabNTU/nano-ros#41.
+    _nros_resolve_knob(NROS_ZEPHYR_HEAP_SIZE "${CONFIG_NROS_ZEPHYR_HEAP_SIZE}")
+
     # XRCE transport tuning.
     #
     # `XRCE_TRANSPORT_MTU` is read unprefixed by xrce-sys/build.rs. The pool

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -234,6 +234,46 @@ function(nros_resolve_knobs)
     # rather than an error. See NEWSLabNTU/nano-ros#41.
     _nros_resolve_knob(NROS_ZEPHYR_HEAP_SIZE "${CONFIG_NROS_ZEPHYR_HEAP_SIZE}")
 
+    # phase-8 — the two arenas are coupled, and nothing used to check it.
+    #
+    # On this path the EXECUTOR arena is a single heap allocation out of the
+    # PLATFORM arena, plus a fixed overhead, so the sizes are not independent:
+    #
+    #     NROS_EXECUTOR_ARENA_SIZE + overhead  <=  NROS_ZEPHYR_HEAP_SIZE
+    #
+    # Violate it and the image does not fail at link, does not fault, and does
+    # not log. It stops mid-boot on a NULL from an allocation that could never
+    # have succeeded. Measured on an FVP consumer: an executor arena of 458752
+    # against the 64 KiB default asked for 477104 bytes from a 66048-byte arena
+    # -- 7.2x the whole arena, in ONE request, decided entirely at build time.
+    # Attributing it took a nine-step bisect.
+    #
+    # Both values are known here, so this is a build error rather than a runtime
+    # hang. The overhead is EMPIRICAL, not derived: two builds differing only in
+    # NROS_EXECUTOR_ARENA_SIZE (458752 -> 100000) moved the failing request by
+    # exactly that delta, leaving a constant 18352. Treat it as a floor, not a
+    # formula -- which is why this adds margin instead of comparing bare sizes.
+    if(DEFINED NROS_RESOLVED_NROS_EXECUTOR_ARENA_SIZE
+       AND NOT "${NROS_RESOLVED_NROS_EXECUTOR_ARENA_SIZE}" STREQUAL ""
+       AND NOT "${NROS_RESOLVED_NROS_EXECUTOR_ARENA_SIZE}" STREQUAL "0")
+        set(_nros_arena_overhead 24576)   # 18352 measured, rounded up to 24 KiB
+        math(EXPR _nros_arena_need
+             "${NROS_RESOLVED_NROS_EXECUTOR_ARENA_SIZE} + ${_nros_arena_overhead}")
+        if(_nros_arena_need GREATER "${NROS_RESOLVED_NROS_ZEPHYR_HEAP_SIZE}")
+            message(FATAL_ERROR
+                "nros: the executor arena cannot fit in the platform heap.\n"
+                "  NROS_EXECUTOR_ARENA_SIZE = ${NROS_RESOLVED_NROS_EXECUTOR_ARENA_SIZE}\n"
+                "  NROS_ZEPHYR_HEAP_SIZE    = ${NROS_RESOLVED_NROS_ZEPHYR_HEAP_SIZE}\n"
+                "  needed (arena + ~${_nros_arena_overhead} overhead) = ${_nros_arena_need}\n"
+                "\n"
+                "The executor arena is ONE heap allocation out of the platform "
+                "arena. Built as configured, this image would stop mid-boot on a "
+                "NULL with no fault and no log. Raise CONFIG_NROS_ZEPHYR_HEAP_SIZE "
+                "(or the NROS_ZEPHYR_HEAP_SIZE environment override) to at least "
+                "${_nros_arena_need}, or lower NROS_EXECUTOR_ARENA_SIZE.")
+        endif()
+    endif()
+
     # XRCE transport tuning.
     #
     # `XRCE_TRANSPORT_MTU` is read unprefixed by xrce-sys/build.rs. The pool


### PR DESCRIPTION
Addresses the remaining half of #41. **Stacked on #61** — the build-time check reads the resolved knob that PR registers, so review that one first.

## The problem

Arena exhaustion is completely silent. `nros_platform_alloc` returns NULL, the caller stalls, and the image stops mid-boot: no fault, no log, no error code. The only evidence is *where* it stopped.

That is how a 64 KiB default cost a nine-step bisect to attribute, and then several more wrong turns to explain.

## What it actually was

Instrumenting the allocator gave the answer in one line:

```
nros: HEAP EXHAUSTED: request 477104 bytes, arena 66048 bytes
```

A **single allocation 7.2× the size of the whole arena**. Not gradual exhaustion, not a marginal shortfall — one request that could never have succeeded, fully determined at build time.

It is the executor arena. Confirmed causally rather than by correlation — two builds differing only in `NROS_EXECUTOR_ARENA_SIZE`:

```
executor arena 458752  →  failing request 477104   (Δ 18352)
executor arena 100000  →  failing request 118352   (Δ 18352)
```

Same constant overhead both times. So the executor arena is one heap allocation out of the platform arena, and the two sizes are coupled by an invariant nothing checked:

```
NROS_EXECUTOR_ARENA_SIZE + overhead  <=  NROS_ZEPHYR_HEAP_SIZE
```

## The fix

**Build time** — the important half. Both values are known at configure time, so an impossible combination is now a build error naming both knobs and the required size, rather than an image that builds, links, and hangs:

```
nros: the executor arena cannot fit in the platform heap.
  NROS_EXECUTOR_ARENA_SIZE = 458752
  NROS_ZEPHYR_HEAP_SIZE    = 65536
  needed (arena + ~24576 overhead) = 483328
```

**Runtime** — for exhaustion that is not statically decidable. `printk` rather than `LOG_*`, because the logging subsystem may itself allocate and this is the path that just failed to allocate; emitted after the spinlock is released, so nothing reentrant runs under the funnel's lock.

## On the overhead constant

It is **empirical, not derived**, and the comment in the source says so. The two-point measurement above pins it at 18352; the check rounds to 24 KiB and treats it as a floor rather than a formula, which is why it adds margin instead of comparing bare sizes. If someone knows the real composition, tightening it is welcome — but a slightly conservative check that fires is worth more than an exact one that does not exist.

## Verification

- Fires on 458752-against-65536, with the message above.
- Passes at the sizes a working consumer image actually uses.
- The runtime message is the output quoted at the top — produced by a real image, not constructed by hand.
