### PR TITLE
fix(#903): the graph is a SUBSCRIPTION, not a question asked repeatedly

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -106,6 +106,8 @@ which already has it. Regenerate with `scripts/gen-issue-index.py`;
 
 <!-- END GENERATED open-issue list -->
 
+Recently resolved (2026-08-30): **#0903** (rmw) — graph enumeration returned an empty topic list against a live `rmw_zenoh_cpp` node. `z_liveliness_get` is not a query: `_z_liveliness_query` sends an INTEREST, and a token reaches a get's callback only when the router tags its declaration with THAT interest id — so a sweep saw 2-4 of the domain's tokens, a different subset each run. Replaced by a standing liveliness SUBSCRIBER with `history`, the mechanism `rmw_zenoh_cpp` uses for its own graph cache: `cached=256 dropped=0`, and both node and topic enumeration now agree with `ros2 node list` / `ros2 topic list`. Four earlier defects (restart on first reply, refresh inside the drain, four undispatched `CffiSession` slots, `collect` set after the get) were real and are fixed. One earlier conclusion is RETRACTED: "two concurrent liveliness gets starve each other" was an artifact of the acceptance script writing `GRAPH_PROBE_SKIP_NODES=${SKIP_NODES:-}`, which always SETS the variable, against a probe reading it with `var_os(..).is_some()`, for which empty is set — so both arms of that comparison skipped nodes and were identical. See `archived/0903-*`.
+
 Recently resolved (2026-08-29): **#0888** (rmw) — FreeRTOS was the only platform arm of the embedded
 Cyclone config with no `AllowMulticast`, so it inherited the Cyclone default (multicast for data) while
 ThreadX states `spdp` and native_sim states `false`. Not a platform limit — `LWIP_IGMP` is on, the netif

--- a/docs/issues/archived/0903-graph-topic-enumeration-empty-against-live-ros2.md
+++ b/docs/issues/archived/0903-graph-topic-enumeration-empty-against-live-ros2.md
@@ -2,7 +2,7 @@
 id: 903
 title: "`get_topic_names_and_types` returns EMPTY against a live rmw_zenoh_cpp
   node, while `get_node_names` on the same session returns the node"
-status: open
+status: resolved
 type: bug
 area: rmw
 related: [phase-381, issue-0791]
@@ -140,3 +140,68 @@ Two things remain unexplained and are the next measurements, not guesses:
   reply buffer: `ZPICO_GET_REPLY_BUF_SIZE` is 4096 and these keyexprs are ~140
   bytes. Not a timeout truncation either — the deadlocked sweep stayed open
   indefinitely and still saw two.
+
+
+## Update 2026-08-30 (second) — RESOLVED, and one earlier conclusion RETRACTED
+
+Fixed by replacing the per-question liveliness GET with a standing liveliness
+SUBSCRIBER (`history = true`) — the same mechanism `rmw_zenoh_cpp` uses for its
+own graph cache. Measured against a stock `demo_nodes_cpp talker`, clean build,
+no instrumentation:
+
+```
+GRAPH_NODE /|talker
+GRAPH_PROBE_NODE_COUNT  1
+GRAPH_TOPIC /chatter          [std_msgs::msg::dds_::String_]
+GRAPH_TOPIC /parameter_events [rcl_interfaces::msg::dds_::ParameterEvent_]
+GRAPH_TOPIC /rosout           [rcl_interfaces::msg::dds_::Log_]
+GRAPH_PROBE_TOPIC_COUNT 3
+GRAPH_PROBE_SAW talker
+probe_rc=0
+```
+
+Both forms now agree with `ros2 node list` / `ros2 topic list`.
+
+### Why the get form could not work
+
+`z_liveliness_get` is not a query. `_z_liveliness_query` sends an INTEREST
+(`TOKENS | KEYEXPRS | RESTRICTED | CURRENT`), and `_z_liveliness_process_token_
+declare` only reaches a get's callback when the router tags the declaration with
+THAT interest id. A subscriber has no such indirection — it matches. Measured
+difference: the sweep saw 2-4 tokens, a different subset each run; the cache sees
+the whole domain (`cached=256 dropped=0`, 39,032 bytes).
+
+`**` is right for the cache and wrong for a get, for the same reason.
+
+### RETRACTED: "two concurrent liveliness gets starve each other"
+
+The previous update, the commit that carried it, and PR #67 all state this as
+measured. **It is not supported by the evidence, and I no longer believe it.**
+
+The comparison behind it ran the acceptance script with `SKIP_NODES` set versus
+unset. The script spelled that as:
+
+```sh
+GRAPH_PROBE_SKIP_NODES=${SKIP_NODES:-} \
+```
+
+which sets the variable UNCONDITIONALLY — to the empty string when `SKIP_NODES`
+is unset — and the probe read it with `std::env::var_os(..).is_some()`, for which
+an empty value is still SET. So the node phase was skipped in BOTH arms: the two
+configurations I was comparing were identical, and the `arrived=0` vs `arrived=2`
+difference came from something else in the build, not from concurrency.
+
+The same harness bug is why node enumeration "regressed to 0" for several runs
+while topics improved: nodes were never being enumerated at all. Two of the fixes
+in the previous update were chosen to explain that regression — serializing the
+sweeps behind one slot, and the poll floor under `collect_done` — so their
+justification was wrong even where the code was harmless. They are gone now
+along with the sweep.
+
+The four defects listed in the previous update were real and independently
+verified; only the concurrency claim is withdrawn.
+
+**Lesson worth keeping: `var_os(..).is_some()` treats an empty value as SET, and
+`VAR=${OTHER:-}` always sets it.** A flag spelled that way is on permanently.
+Pair a presence test with a shell form that leaves the variable absent, or test
+the value rather than the presence.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -67,6 +67,5 @@ fails if this block drifts.
 - **#0899** (rmw, boards) — The FreeRTOS C talker dies mid-run inside zenoh-pico's write buffer — two different asserts, both after tens of successful publishes See `0899-*`.
 - **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
 - **#0902** (build, rmw) — Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed files out of the whole library, so a patch is silently not compiled See `0902-*`.
-- **#0903** (rmw) — `get_topic_names_and_types` returns EMPTY against a live rmw_zenoh_cpp node, while `get_node_names` on the same session returns the node See `0903-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
@@ -757,6 +757,27 @@ impl Ros2Liveliness {
         key
     }
 
+    /// phase-381 / issue 0903 — the GRAPH CACHE keyexpr: every liveliness token
+    /// on a domain, both shapes.
+    ///
+    /// `**` matches any number of chunks, so this covers the 9-chunk node token
+    /// and the 13-chunk entity token alike — which no single-`*` pattern can.
+    ///
+    /// This width was tried once for the liveliness GET form and made things
+    /// worse there (two tokens arrived, none of them a node token), because a
+    /// get is an interest whose replies the router tags per interest id. A
+    /// SUBSCRIBER has no such indirection: it simply matches, and the measured
+    /// result is the whole graph rather than an arbitrary handful. Use this for
+    /// the cache and the chunk-exact patterns for anything still querying.
+    pub fn graph_keyexpr_wildcard<const N: usize>(domain_id: u32) -> heapless::String<N> {
+        let mut out = heapless::String::new();
+        let _ = core::fmt::write(
+            &mut out,
+            format_args!("{}/{}/**", LIVELINESS_PREFIX, domain_id),
+        );
+        out
+    }
+
     /// phase-381 W3 — wildcard ENTITY liveliness keyexpr, all four kinds.
     ///
     /// NOTE (issue 0903): a `**` pattern was tried here to collapse this and

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
@@ -203,15 +203,8 @@ pub struct ZenohSession {
     /// One query serves all four entity kinds — the kind chunk is wildcarded —
     /// rather than one query per slot, which would put four sweeps on the wire
     /// to answer four questions about the same graph.
-    query: Option<(GraphQuery, i32)>,
-    /// Drains served by the sweep in `query`, so a sweep that never reports
-    /// `done` cannot own the single slot forever.
-    ///
-    /// Issue 0903 measured exactly that deadlock: one `GRAPH_WILDCARD` line and
-    /// 98 identical drains — the entity sweep's dropper never fired, so the
-    /// node sweep never got a turn and `get_node_names` went from working to
-    /// empty. `collect_done` is the fast path; this is the floor under it.
-    query_polls: u32,
+    /// Whether the standing liveliness subscriber has been declared.
+    graph_cache_started: bool,
 }
 
 /// Which standing query a drain is reading — phase-381 W3.
@@ -248,12 +241,8 @@ fn entity_on_node(e: &Ros2LivelinessEntity<'_>, node: Option<(&str, &str)>) -> b
 /// Not a caller budget: `get_node_names` never blocks. This is the zenoh
 /// dropper's window, i.e. how long the slot keeps accepting replies before it
 /// is finished and restarted.
-/// Drains a single liveliness sweep may serve before it is retired regardless
-/// of whether its dropper ever fired — see `RmwSession::query_polls`.
-const GRAPH_QUERY_MAX_POLLS: u32 = 4;
-
-const GRAPH_QUERY_TIMEOUT_MS: u32 = 500;
-
+/// Bytes of the graph-cache snapshot a drain copies out of the C side.
+///
 /// Longest liveliness keyexpr this enumeration will read.
 ///
 /// A stack buffer, so it is bounded by construction. An entry longer than this
@@ -441,8 +430,7 @@ impl ZenohSession {
             wake_ctx: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),
             entity_counter: portable_atomic::AtomicU32::new(1),
             domain_id: config.domain_id,
-            query: None,
-            query_polls: 0,
+            graph_cache_started: false,
         };
 
         if !config.node_name.is_empty() {
@@ -611,80 +599,37 @@ impl ZenohSession {
         which: GraphQuery,
         f: &mut dyn FnMut(&Ros2LivelinessEntity<'_>) -> bool,
     ) -> Result<(), TransportError> {
-        let handle = match self.query {
-            // A sweep for the OTHER shape is in flight. Do not start a second
-            // one — that is what starves both. Report empty; the next call
-            // after this sweep finishes starts ours.
-            Some((in_flight, _)) if in_flight != which => return Ok(()),
-            Some((_, h)) => h,
-            None => {
-                let key = match which {
-                    GraphQuery::Nodes => {
-                        Ros2Liveliness::node_keyexpr_wildcard::<256>(self.domain_id)
-                    }
-                    GraphQuery::Entities => {
-                        Ros2Liveliness::entity_keyexpr_wildcard::<256>(self.domain_id)
-                    }
-                };
-                #[cfg(feature = "std")]
-                if std::env::var_os("NROS_GRAPH_DUMP").is_some() {
-                    log::warn!("GRAPH_WILDCARD[{:?}] {}", which_label(which), key.as_str());
-                }
-                let mut buf = [0u8; 257];
-                let bytes = key.as_bytes();
-                if bytes.len() >= buf.len() {
-                    return Err(TransportError::InvalidArgument);
-                }
-                buf[..bytes.len()].copy_from_slice(bytes);
-                buf[bytes.len()] = 0;
-                let h = unsafe {
-                    zpico_sys::zpico_liveliness_collect_start(
-                        self.context.handle(),
-                        buf.as_ptr() as *const core::ffi::c_char,
-                        GRAPH_QUERY_TIMEOUT_MS,
-                    )
-                };
-                if h < 0 {
-                    return Err(TransportError::Unsupported);
-                }
-                self.query = Some((which, h));
-                self.query_polls = 0;
-                // Nothing can have arrived on a query started this instant.
-                // An empty answer is the honest one; the next call sees what
-                // landed meanwhile.
-                return Ok(());
-            }
-        };
+        // Used only to label the diagnostics below; the cache is shape-agnostic.
+        let _ = which;
+        // One standing cache serves every caller and every shape (issue 0903).
+        // `which` no longer selects a query — a node token and an entity token
+        // arrive through the same subscriber, and callers already filter by
+        // `EntityKind`. It survives only to label the diagnostics.
+        self.ensure_graph_cache()?;
 
-        let stored =
-            unsafe { zpico_sys::zpico_liveliness_entry_count(self.context.handle(), handle) };
-        // The discriminator any "the graph is empty" report needs: replies
-        // ARRIVED vs entries STORED. Equal-and-zero means the query matched
-        // nothing; arrived-without-stored means the collector dropped them.
-        // Guessing between those cost two wrong fixes on issue 0903.
+        let mut dropped: u32 = 0;
+        let count =
+            unsafe { zpico_sys::zpico_graph_entry_count(self.context.handle(), &mut dropped) };
+        if count < 0 {
+            return Err(TransportError::Unsupported);
+        }
+        let count = count as u32;
+
         #[cfg(feature = "std")]
         if std::env::var_os("NROS_GRAPH_DUMP").is_some() {
-            let arrived =
-                unsafe { zpico_sys::zpico_liveliness_get_count(self.context.handle(), handle) };
             log::warn!(
-                "GRAPH_COUNTS[{:?}] arrived={} stored={}",
+                "GRAPH_COUNTS[{:?}] cached={} dropped={}",
                 which_label(which),
-                arrived,
-                stored
+                count,
+                dropped
             );
         }
-        if stored < 0 {
-            // The slot was recycled underneath us; start again next call.
-            self.clear_query(which);
-            return Ok(());
-        }
 
-        for index in 0..stored as u32 {
+        for index in 0..count {
             let mut key = [0i8; GRAPH_KEYEXPR_MAX];
             let n = unsafe {
-                zpico_sys::zpico_liveliness_entry(
+                zpico_sys::zpico_graph_entry_at(
                     self.context.handle(),
-                    handle,
                     index,
                     key.as_mut_ptr() as *mut core::ffi::c_char,
                     key.len(),
@@ -729,52 +674,56 @@ impl ZenohSession {
                 break;
             }
         }
+        Ok(())
+    }
 
-        // NOTE the absence of a restart here, which is deliberate and was a
-        // defect twice over.
-        //
-        // Retiring a finished sweep belongs to `refresh_query`, called ONCE per
-        // public entry point — not per drain. `names_and_types` drains twice per
-        // reported name (find the next unreported name, then collect its types),
-        // so clearing at the end of a drain made the second pass restart the
-        // query the first pass had just used: the algorithm oscillated between
-        // "just started, empty" and "just cleared" and could never report a
-        // single topic. Measured against a live `rmw_zenoh_cpp` talker —
-        // `get_node_names` worked while `get_topic_names_and_types` returned
-        // zero against a node that plainly had topics.
+    /// Declare the standing liveliness subscriber, once.
+    ///
+    /// `**` covers both token shapes — a node token is 9 chunks and an entity
+    /// token 13 — which a single-`*` pattern cannot. That width failed for the
+    /// GET form, where the router tags replies per interest; it is the natural
+    /// fit for a subscriber, which simply matches.
+    fn ensure_graph_cache(&mut self) -> Result<(), TransportError> {
+        if self.graph_cache_started {
+            return Ok(());
+        }
+        let key = Ros2Liveliness::graph_keyexpr_wildcard::<256>(self.domain_id);
+        #[cfg(feature = "std")]
+        if std::env::var_os("NROS_GRAPH_DUMP").is_some() {
+            log::warn!("GRAPH_CACHE_START {}", key.as_str());
+        }
+        let mut buf = [0u8; 257];
+        let bytes = key.as_bytes();
+        if bytes.len() >= buf.len() {
+            return Err(TransportError::InvalidArgument);
+        }
+        buf[..bytes.len()].copy_from_slice(bytes);
+        buf[bytes.len()] = 0;
+        let rc = unsafe {
+            zpico_sys::zpico_graph_cache_start(
+                self.context.handle(),
+                buf.as_ptr() as *const core::ffi::c_char,
+            )
+        };
+        if rc < 0 {
+            return Err(TransportError::Unsupported);
+        }
+        self.graph_cache_started = true;
         Ok(())
     }
 
     /// Retire a FINISHED sweep so the next public call starts a fresh one.
     ///
     /// Called once per public entry point, after every drain that call needs.
-    /// Not inside `for_each_entity`: a multi-drain algorithm would then pull the
-    /// query out from under itself between passes.
-    /// Retire the standing sweep once it is finished — or once it has had its
-    /// turn.
+    /// Refresh the graph view before a public entry point reads it.
     ///
-    /// Ages the sweep that is IN FLIGHT, whichever shape the caller wants.
-    /// A caller asking for the other shape is precisely the one that needs the
-    /// slot freed, so keying the aging on `which` would let a stuck sweep block
-    /// the very caller waiting on it (issue 0903).
+    /// With the sweep gone there is nothing to retire: the subscriber keeps the
+    /// cache current on its own, so this only guarantees the subscriber EXISTS
+    /// before the first read. Kept as a named step because the call sites read
+    /// better for it, and because the ordering it used to protect — refresh once
+    /// per entry point, never inside a drain — is still the rule.
     fn refresh_query(&mut self, _which: GraphQuery) {
-        let Some((in_flight, handle)) = self.query else {
-            return;
-        };
-        // `collect_done` reports the DROPPER firing. `liveliness_get_check`
-        // reports the FIRST reply, which truncates a sweep to one poll window.
-        let done =
-            unsafe { zpico_sys::zpico_liveliness_collect_done(self.context.handle(), handle) };
-        self.query_polls = self.query_polls.saturating_add(1);
-        if done == 1 || self.query_polls >= GRAPH_QUERY_MAX_POLLS {
-            self.clear_query(in_flight);
-        }
-    }
-
-    fn clear_query(&mut self, which: GraphQuery) {
-        let _ = which;
-        self.query = None;
-        self.query_polls = 0;
+        let _ = self.ensure_graph_cache();
     }
 
     /// Count the entities of one kind on a topic — phase-381 W3.

--- a/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
+++ b/packages/rmw/zenoh/zpico-sys/c/include/zpico.h
@@ -293,6 +293,38 @@ typedef void (*ZpicoQueryCallback)(const char *keyexpr,
  * the NUL, or a negative `ZPICO_ERR_*`.
  */
 /**
+ * The PURE half of `zpico_liveliness_entry`: index into a NUL-separated
+ * run. Reachable without a live session, which is why the graph cache
+ * reuses it to walk its snapshot instead of growing a second walk.
+ */
+/**
+ * phase-381 / issue 0903 — the GRAPH CACHE, which replaces the per-question
+ * liveliness sweep.
+ *
+ * A liveliness get is an INTEREST under the hood, and a token only reaches
+ * a get's callback when the router tags its declaration with that interest
+ * id. Measured against a live `rmw_zenoh_cpp` talker, two sweeps in flight
+ * did not both receive replies, and a single sweep saw 2-4 of the dozen
+ * tokens the talker declares — a different subset each run. A SUBSCRIBER
+ * with `history` is what `rmw_zenoh_cpp` uses for its own graph cache and
+ * removes the class: one standing declaration, current tokens delivered
+ * once, later changes pushed.
+ *
+ * Idempotent, so every graph entry point may call it without coordinating.
+ */
+/**
+ * Stop the cache and release the subscriber. Idempotent.
+ */
+/**
+ * How many tokens the cache holds, and how many did not fit.
+ */
+/**
+ * Copy cached keyexpr `index` into `out`, NUL-terminated. ONE entry per
+ * call, under the C side's lock — the cache is sized for a real ROS graph
+ * (tens of KB), which cannot live on an embedded caller's stack, and this
+ * keeps that capacity a fact about the C side alone.
+ */
+/**
  * The session's pool index (0..ZPICO_MAX_SESSIONS), or -1 if the handle is
  * not a valid pool slot. Used to scope the Rust shim's process-global
  * service-buffer / reply-waker tables per session (issue 0376).
@@ -806,6 +838,31 @@ int32_t zpico_liveliness_entry(struct zpico_session_t *_session,
                                uint32_t _index,
                                char *_out,
                                size_t _cap);
+
+/**
+ * phase-381 / issue 0903 — start the standing graph cache (a liveliness
+ * SUBSCRIBER with history), replacing the per-question sweep. Idempotent.
+ */
+int32_t zpico_graph_cache_start(struct zpico_session_t *_session, const char *_keyexpr);
+
+/**
+ * Stop the graph cache and release its subscriber. Idempotent.
+ */
+int32_t zpico_graph_cache_stop(struct zpico_session_t *_session);
+
+/**
+ * How many tokens the graph cache holds; `out_dropped` receives how many
+ * did not fit.
+ */
+int32_t zpico_graph_entry_count(struct zpico_session_t *_session, uint32_t *_out_dropped);
+
+/**
+ * Copy cached keyexpr `index` into `out`, NUL-terminated.
+ */
+int32_t zpico_graph_entry_at(struct zpico_session_t *_session,
+                             uint32_t _index,
+                             char *_out,
+                             size_t _cap);
 
 /**
  * The PURE half of `zpico_liveliness_entry`: index into a NUL-separated

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -199,6 +199,21 @@ typedef struct {
 #ifndef ZPICO_LEASE_TASK_PRIORITY
 #define ZPICO_LEASE_TASK_PRIORITY 16
 #endif
+#ifndef ZPICO_GRAPH_CACHE_SIZE
+/* Bytes of NUL-separated liveliness keyexprs the graph cache holds.
+ *
+ * A ROS 2 liveliness keyexpr runs ~140 bytes. Measured against a host running
+ * one stock `talker` plus the ROS 2 daemon, the domain carried 222 tokens —
+ * ~31 KB — so 8192 held 51 of them and dropped 171. Sized for that measurement
+ * rather than for the talker alone, and still a KNOB: an embedded image with a
+ * small graph should turn it down. Overflow is COUNTED, never silently
+ * truncated —
+ * `dropped` is what `zpico_graph_cache_copy` reports, because a graph answer
+ * that quietly omits entries is the plausible-wrong-answer failure phase-381
+ * exists to avoid. */
+#define ZPICO_GRAPH_CACHE_SIZE 65536
+#endif
+
 #ifndef ZPICO_GET_REPLY_BUF_SIZE
 #define ZPICO_GET_REPLY_BUF_SIZE 4096
 #endif
@@ -287,6 +302,35 @@ typedef struct {
     _z_condvar_t cond;
 #endif
 } get_reply_ctx_t;
+
+/* phase-381 / issue 0903 — the GRAPH CACHE.
+ *
+ * Enumeration used to be a `z_liveliness_get` per question. That is an INTEREST
+ * declaration under the hood (`_z_liveliness_query` sends TOKENS | KEYEXPRS |
+ * RESTRICTED | CURRENT), and a token only reaches a get's callback when the
+ * router tags its declaration with THAT interest id. Measured against a live
+ * `rmw_zenoh_cpp` talker, two sweeps in flight did not both receive replies —
+ * whichever started first got tokens and the other got `arrived=0` across 99
+ * drains — and a single sweep saw 2-4 of the dozen tokens the talker declares,
+ * a different subset each run. Widening the pattern to `**` made it worse.
+ *
+ * A SUBSCRIBER with `history` is what `rmw_zenoh_cpp` itself uses for its graph
+ * cache, and it removes the whole class: one standing declaration, the current
+ * tokens delivered once, every later change pushed. No sweeps, so nothing to
+ * serialize, nothing to starve, and no per-sweep truncation. */
+typedef struct {
+    /* NUL-separated keyexprs, same layout `zpico_entry_at` already walks. */
+    uint8_t buf[ZPICO_GRAPH_CACHE_SIZE];
+    size_t len;
+    uint32_t entry_count;
+    /* Tokens that did not fit. Reported, never hidden. */
+    uint32_t dropped;
+    bool active;
+    z_owned_subscriber_t sub;
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_t mutex;
+#endif
+} graph_cache_t;
 
 // Static slots for non-blocking z_get operations
 // ZPICO_MAX_PENDING_GETS is provided via -D compiler flag from build.rs,
@@ -387,6 +431,7 @@ struct zpico_session {
     publisher_entry_t publishers[ZPICO_MAX_PUBLISHERS];
     subscriber_entry_t subscribers[ZPICO_MAX_SUBSCRIBERS];
     liveliness_entry_t liveliness[ZPICO_MAX_LIVELINESS];
+    graph_cache_t graph_cache;
     queryable_entry_t queryables[ZPICO_MAX_QUERYABLES];
 
     // Phase 237 — per-queryable seq-keyed reply slots. Each slot holds one
@@ -3411,6 +3456,199 @@ int32_t zpico_liveliness_entry_count(zpico_session_t* session, int32_t handle) {
  * reason the handler drops rather than truncates: half a keyexpr names a
  * different, plausible entity.
  */
+/* phase-381 / issue 0903 — graph cache: find `key` in the NUL-separated run.
+ *
+ * Returns the offset of the entry, or `SIZE_MAX` when absent. Split out so the
+ * PUT and DELETE arms of the sample handler share one notion of identity, and
+ * so it is testable without a session. */
+static size_t graph_cache_find(const graph_cache_t* c, const char* key, size_t klen) {
+    size_t off = 0;
+    while (off < c->len) {
+        const char* e = (const char*)c->buf + off;
+        size_t n = strlen(e);
+        if (n == klen && memcmp(e, key, klen) == 0) {
+            return off;
+        }
+        off += n + 1;
+    }
+    return SIZE_MAX;
+}
+
+/* Sample handler for the liveliness subscriber.
+ *
+ * A liveliness sample carries its meaning in the KEYEXPR and its KIND: PUT is
+ * "this token exists", DELETE is "it is gone". The payload is empty, as it is
+ * for the query form. */
+static void graph_cache_sample_handler(z_loaned_sample_t* sample, void* arg) {
+    struct zpico_session* s = (struct zpico_session*)arg;
+    if (s == NULL || !s->graph_cache.active) {
+        return;
+    }
+    z_view_string_t ks;
+    z_keyexpr_as_view_string(z_sample_keyexpr(sample), &ks);
+    const char* key = z_string_data(z_view_string_loan(&ks));
+    size_t klen = z_string_len(z_view_string_loan(&ks));
+    if (key == NULL || klen == 0) {
+        return;
+    }
+    graph_cache_t* c = &s->graph_cache;
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_lock(&c->mutex);
+#endif
+    size_t at = graph_cache_find(c, key, klen);
+    if (z_sample_kind(sample) == Z_SAMPLE_KIND_DELETE) {
+        if (at != SIZE_MAX) {
+            /* Close the gap so the run stays dense and `entry_count` keeps
+             * indexing it. */
+            size_t n = strlen((const char*)c->buf + at) + 1;
+            memmove(c->buf + at, c->buf + at + n, c->len - at - n);
+            c->len -= n;
+            c->entry_count--;
+        }
+    } else if (at == SIZE_MAX) {
+        if (c->len + klen + 1 <= sizeof(c->buf)) {
+            memcpy(c->buf + c->len, key, klen);
+            c->buf[c->len + klen] = '\0';
+            c->len += klen + 1;
+            c->entry_count++;
+        } else {
+            c->dropped++;
+        }
+    }
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_unlock(&c->mutex);
+#endif
+}
+
+/* Start the standing graph cache on `keyexpr`.
+ *
+ * `history = true` is the whole point: the subscriber is delivered the tokens
+ * that ALREADY exist, then every later change. Without it the cache would only
+ * ever see nodes that appear after us, which is the same blind spot the query
+ * form had for a different reason.
+ *
+ * Idempotent — a second call while active is a no-op, so every graph entry
+ * point can call it without coordinating.
+ */
+int32_t zpico_graph_cache_start(zpico_session_t* session, const char* keyexpr) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (s == NULL || keyexpr == NULL) {
+        return ZPICO_ERR_INVALID;
+    }
+    if (s->graph_cache.active) {
+        return 0;
+    }
+    graph_cache_t* c = &s->graph_cache;
+    c->len = 0;
+    c->entry_count = 0;
+    c->dropped = 0;
+#if Z_FEATURE_MULTI_THREAD == 1
+    if (_z_mutex_init(&c->mutex) != _Z_RES_OK) {
+        return ZPICO_ERR_INVALID;
+    }
+#endif
+    z_view_keyexpr_t ke;
+    if (z_view_keyexpr_from_str(&ke, keyexpr) != _Z_RES_OK) {
+#if Z_FEATURE_MULTI_THREAD == 1
+        _z_mutex_drop(&c->mutex);
+#endif
+        return ZPICO_ERR_INVALID;
+    }
+    z_owned_closure_sample_t closure;
+    z_closure_sample(&closure, graph_cache_sample_handler, NULL, s);
+    z_liveliness_subscriber_options_t opts;
+    z_liveliness_subscriber_options_default(&opts);
+    opts.history = true;
+    /* Set active BEFORE declaring: the handler can fire from the RX path the
+     * moment the declaration lands, and a flag set afterwards drops exactly the
+     * history burst this call exists to collect. That ordering was defect 4 in
+     * the query form (issue 0903); it is not repeated here. */
+    c->active = true;
+    z_result_t ret = z_liveliness_declare_subscriber(z_session_loan(&s->session), &c->sub,
+                                                     z_view_keyexpr_loan(&ke),
+                                                     z_closure_sample_move(&closure), &opts);
+    if (ret != _Z_RES_OK) {
+        c->active = false;
+#if Z_FEATURE_MULTI_THREAD == 1
+        _z_mutex_drop(&c->mutex);
+#endif
+        return ZPICO_ERR_INVALID;
+    }
+    return 0;
+}
+
+/* Stop the cache and release the subscriber. Idempotent. */
+int32_t zpico_graph_cache_stop(zpico_session_t* session) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (s == NULL) {
+        return ZPICO_ERR_INVALID;
+    }
+    if (!s->graph_cache.active) {
+        return 0;
+    }
+    s->graph_cache.active = false;
+    z_undeclare_subscriber(z_subscriber_move(&s->graph_cache.sub));
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_drop(&s->graph_cache.mutex);
+#endif
+    return 0;
+}
+
+int32_t zpico_entry_at(const uint8_t* buf, size_t len, uint32_t count, uint32_t index, char* out,
+                       size_t cap);
+
+/* How many tokens the cache currently holds, and how many did not fit.
+ *
+ * `out_dropped` is reported beside the count rather than folded into it,
+ * because a graph answer that silently omits entries is the plausible-wrong-
+ * answer failure this path exists to avoid.
+ */
+int32_t zpico_graph_entry_count(zpico_session_t* session, uint32_t* out_dropped) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (s == NULL || !s->graph_cache.active) {
+        return ZPICO_ERR_INVALID;
+    }
+    graph_cache_t* c = &s->graph_cache;
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_lock(&c->mutex);
+#endif
+    uint32_t n = c->entry_count;
+    if (out_dropped != NULL) {
+        *out_dropped = c->dropped;
+    }
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_unlock(&c->mutex);
+#endif
+    return (int32_t)n;
+}
+
+/* Copy cached keyexpr `index` into `out`, NUL-terminated.
+ *
+ * ONE entry per call, under the lock, rather than a bulk snapshot: the cache is
+ * sized for a real ROS graph (tens of KB) and the callers are embedded, where a
+ * buffer that size cannot live on the stack. It also keeps the capacity a fact
+ * about the C side alone — a bulk copy forced the Rust caller to know
+ * `ZPICO_GRAPH_CACHE_SIZE`, and two constants that must agree eventually do not.
+ *
+ * A token may appear or vanish between calls; that is inherent to enumerating a
+ * LIVE graph and is why callers poll to convergence.
+ */
+int32_t zpico_graph_entry_at(zpico_session_t* session, uint32_t index, char* out, size_t cap) {
+    struct zpico_session* s = (struct zpico_session*)session;
+    if (s == NULL || out == NULL || !s->graph_cache.active) {
+        return ZPICO_ERR_INVALID;
+    }
+    graph_cache_t* c = &s->graph_cache;
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_lock(&c->mutex);
+#endif
+    int32_t ret = zpico_entry_at(c->buf, c->len, c->entry_count, index, out, cap);
+#if Z_FEATURE_MULTI_THREAD == 1
+    _z_mutex_unlock(&c->mutex);
+#endif
+    return ret;
+}
+
 int32_t zpico_entry_at(const uint8_t* buf, size_t len, uint32_t count, uint32_t index, char* out,
                        size_t cap) {
     if (buf == NULL || out == NULL || index >= count) {

--- a/packages/rmw/zenoh/zpico-sys/src/ffi.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/ffi.rs
@@ -821,6 +821,43 @@ mod cbindgen_stubs {
         -1 // stub: not available
     }
 
+    /// phase-381 / issue 0903 — start the standing graph cache (a liveliness
+    /// SUBSCRIBER with history), replacing the per-question sweep. Idempotent.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_graph_cache_start(
+        _session: *mut zpico_session_t,
+        _keyexpr: *const c_char,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
+    /// Stop the graph cache and release its subscriber. Idempotent.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_graph_cache_stop(_session: *mut zpico_session_t) -> i32 {
+        -1 // stub: not available
+    }
+
+    /// How many tokens the graph cache holds; `out_dropped` receives how many
+    /// did not fit.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_graph_entry_count(
+        _session: *mut zpico_session_t,
+        _out_dropped: *mut u32,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
+    /// Copy cached keyexpr `index` into `out`, NUL-terminated.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn zpico_graph_entry_at(
+        _session: *mut zpico_session_t,
+        _index: u32,
+        _out: *mut c_char,
+        _cap: usize,
+    ) -> i32 {
+        -1 // stub: not available
+    }
+
     /// The PURE half of `zpico_liveliness_entry`: index into a NUL-separated
     /// run. Split out so the walk is testable WITHOUT a live session, because
     /// this is where an off-by-one costs a WRONG keyexpr rather than a missing

--- a/packages/rmw/zenoh/zpico-sys/src/lib.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/lib.rs
@@ -381,6 +381,53 @@ unsafe extern "C" {
         cap: usize,
     ) -> i32;
 
+    /// The PURE half of `zpico_liveliness_entry`: index into a NUL-separated
+    /// run. Reachable without a live session, which is why the graph cache
+    /// reuses it to walk its snapshot instead of growing a second walk.
+    pub fn zpico_entry_at(
+        buf: *const u8,
+        len: usize,
+        count: u32,
+        index: u32,
+        out: *mut core::ffi::c_char,
+        cap: usize,
+    ) -> i32;
+
+    /// phase-381 / issue 0903 — the GRAPH CACHE, which replaces the per-question
+    /// liveliness sweep.
+    ///
+    /// A liveliness get is an INTEREST under the hood, and a token only reaches
+    /// a get's callback when the router tags its declaration with that interest
+    /// id. Measured against a live `rmw_zenoh_cpp` talker, two sweeps in flight
+    /// did not both receive replies, and a single sweep saw 2-4 of the dozen
+    /// tokens the talker declares — a different subset each run. A SUBSCRIBER
+    /// with `history` is what `rmw_zenoh_cpp` uses for its own graph cache and
+    /// removes the class: one standing declaration, current tokens delivered
+    /// once, later changes pushed.
+    ///
+    /// Idempotent, so every graph entry point may call it without coordinating.
+    pub fn zpico_graph_cache_start(
+        session: *mut zpico_session_t,
+        keyexpr: *const core::ffi::c_char,
+    ) -> i32;
+
+    /// Stop the cache and release the subscriber. Idempotent.
+    pub fn zpico_graph_cache_stop(session: *mut zpico_session_t) -> i32;
+
+    /// How many tokens the cache holds, and how many did not fit.
+    pub fn zpico_graph_entry_count(session: *mut zpico_session_t, out_dropped: *mut u32) -> i32;
+
+    /// Copy cached keyexpr `index` into `out`, NUL-terminated. ONE entry per
+    /// call, under the C side's lock — the cache is sized for a real ROS graph
+    /// (tens of KB), which cannot live on an embedded caller's stack, and this
+    /// keeps that capacity a fact about the C side alone.
+    pub fn zpico_graph_entry_at(
+        session: *mut zpico_session_t,
+        index: u32,
+        out: *mut core::ffi::c_char,
+        cap: usize,
+    ) -> i32;
+
     /// The session's pool index (0..ZPICO_MAX_SESSIONS), or -1 if the handle is
     /// not a valid pool slot. Used to scope the Rust shim's process-global
     /// service-buffer / reply-waker tables per session (issue 0376).


### PR DESCRIPTION
Graph enumeration returned an empty topic list against a live `rmw_zenoh_cpp`
node. It now returns what `ros2 node list` / `ros2 topic list` do, measured
against a stock `demo_nodes_cpp talker`:

```
GRAPH_NODE /|talker
GRAPH_TOPIC /chatter          [std_msgs::msg::dds_::String_]
GRAPH_TOPIC /parameter_events [rcl_interfaces::msg::dds_::ParameterEvent_]
GRAPH_TOPIC /rosout           [rcl_interfaces::msg::dds_::Log_]
probe_rc=0
```

## Why the sweep could never work

`z_liveliness_get` is **not a query**. `_z_liveliness_query` sends an INTEREST
(`TOKENS | KEYEXPRS | RESTRICTED | CURRENT`), and a token reaches a get's
callback only when the router tags its declaration with **that** interest id. So
a sweep saw 2-4 of the domain's tokens, a different subset each run — and
widening the pattern never helped, because the pattern was not what lost them.

## The fix

A standing liveliness **subscriber** with `history = true` — the mechanism
`rmw_zenoh_cpp` uses for its own graph cache. Existing tokens delivered once,
later changes pushed, no sweep to truncate or starve. Measured `cached=256
dropped=0` where the sweep saw two.

Read ONE entry at a time under the C lock rather than snapshotted: the cache is
sized for a real graph (8192 held 51 tokens and dropped 171; default is now
65536) and that does not belong on an embedded caller's stack. It also keeps the
capacity a fact about the C side alone.

## Retraction

The merged PR #67 states, as measured, that **"two concurrent liveliness gets
starve each other"**. That is withdrawn.

The comparison behind it ran the acceptance script with `SKIP_NODES` set vs
unset, but the script wrote:

```sh
GRAPH_PROBE_SKIP_NODES=${SKIP_NODES:-}
```

which sets the variable **unconditionally** — empty when unset — against a probe
reading it with `var_os(..).is_some()`, for which empty is still *set*. Both arms
skipped the node phase, so the two configurations were identical. The same bug is
why nodes "regressed to zero" for several runs: they were never enumerated at all.

Two fixes in #67 were chosen to explain that artifact (serializing the sweeps
behind one slot; the poll floor under `collect_done`) and are gone with the sweep.
The four defects #67 fixed were real and independently verified — only the
concurrency claim was wrong.

**Lesson kept in the code and the issue:** `var_os(..).is_some()` treats an empty
value as set, and `VAR=${OTHER:-}` always sets it.

Issue 0903 is resolved and archived. Tier 1 green (1019 ran, 2 skipped for host
capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP