### PR TITLE
fix(#897 W3): the resolver never loaded the Python half it stopped linking

### DIFF
--- a/justfile
+++ b/justfile
@@ -6341,7 +6341,15 @@ setup-launch-resolve:
     # (`node '/listener' is not placed`) looked like a code regression on main
     # rather than a museum binary. Same class as issue 0196: a build-side probe
     # that misses an input the build consumes.
-    if [ -x "$bin" ]; then
+    # The Python half is HALF THE TOOL, so "already built" has to mean both
+    # artifacts. Keyed on the binary alone, this recipe short-circuits on a tree
+    # that has the resolver and no `libplay_launch_parser_pyexec.so` beside it —
+    # which is precisely the state that left `host-tests` red: the recipe
+    # reported success, and every `$(eval …)` launch file failed at parse time
+    # with "this build has no Python backend" on hosts that have Python.
+    if [ -x "$bin" ] && [ ! -f "$(dirname "$bin")/libplay_launch_parser_pyexec.so" ]; then
+        echo "[setup-launch-resolve] the Python half is missing beside the binary; rebuilding."
+    elif [ -x "$bin" ]; then
         # `git ls-files` + mtime walk, not `find`. The resolver tree lives inside
         # the play_launch SUBMODULE, so `git ls-files` is run inside it (`-C`) —
         # from the superproject the index holds only the gitlink, which would
@@ -6393,6 +6401,43 @@ setup-launch-resolve:
     export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
     # profile-literal-ok: host tool: builds nros-launch-resolve
     cargo build --release --manifest-path "$crate/Cargo.toml"
+    # The Python HALF, and it is not optional packaging — it is half the tool.
+    #
+    # 0897 W3 made the resolver load an interpreter at RUNTIME instead of linking
+    # one, which is what lets ONE binary serve any CPython and lets a host with
+    # none still resolve XML/YAML. The loader finds the Python half by looking
+    # beside the executable (`pyload::pyexec_beside_exe`), so a build that emits
+    # only the binary produces a resolver that is *correctly* version-agnostic
+    # and *cannot evaluate anything*: `$(eval …)` and `.launch.py` fail with "this
+    # build has no Python backend" on a host that has Python installed.
+    #
+    # That is exactly what happened. `host-tests` went red on main the moment the
+    # W2b pin removed the link, on
+    # `demo_bringup/launch/multihost.launch.xml`'s `$(eval "robot1" in (...))`,
+    # and stayed red — the artifact SHAPE was verified (`readelf -d` shows no
+    # `libpython`) while the capability was not.
+    #
+    # `--features extension-module` is the half that must NOT link libpython:
+    # its `Py_*` symbols stay undefined so they bind to whichever interpreter the
+    # loader `dlopen`s with RTLD_GLOBAL. Built from the parser's own workspace,
+    # which is where the crate lives and is deliberately NOT in the resolver's
+    # dependency graph — a normal dep would put the link back.
+    _pyexec_ws="$crate/../third-party/play_launch/src/ros-launch-resolve/parser"
+    echo "[setup-launch-resolve] building the Python half (dlopen'ed at runtime)…"
+    # profile-literal-ok: host tool: the resolver's own Python half
+    cargo build --release --manifest-path "$_pyexec_ws/Cargo.toml" \
+        -p play_launch_parser_pyexec --lib --features extension-module
+    _pyexec_so="$(dirname "$bin")/libplay_launch_parser_pyexec.so"
+    # profile-literal-ok: host tool: reads back where that build put it
+    _pyexec_built="${CARGO_TARGET_DIR:-$_pyexec_ws/target}/release/libplay_launch_parser_pyexec.so"
+    if [ ! -f "$_pyexec_built" ]; then
+        echo "[setup-launch-resolve] FAILED: the Python half was not produced at" >&2
+        echo "  $_pyexec_built" >&2
+        echo "  Without it the resolver cannot evaluate \`\$(eval …)\` or a" >&2
+        echo "  .launch.py, and says so at parse time rather than here." >&2
+        exit 1
+    fi
+    cp "$_pyexec_built" "$_pyexec_so"
     # Record WHAT it was built from. Without this the content check has nothing
     # to compare against and reports stale forever — issue 0596's shape, one
     # mechanism over.

--- a/packages/cli/nros-launch-resolve/src/main.rs
+++ b/packages/cli/nros-launch-resolve/src/main.rs
@@ -39,6 +39,7 @@ use eyre::Result;
 use ros_launch_resolve::{
     model::{ModelBuildInputs, build_checked_model},
     ros::launch_dump::LaunchDump,
+    verbs::parse_launch_file,
 };
 
 #[derive(Parser)]
@@ -135,7 +136,18 @@ fn main() -> Result<()> {
         // a `host:=robot1`-style override that stops short of the parser
         // silently resolves the default configuration (phase-326 found this
         // resolving the multihost per-host models — both nodes survived).
-        play_launch_parser::parse_launch_file(&launch_path, arg_binding.clone())
+        // `verbs::parse_launch_file`, NOT `play_launch_parser`'s — the verb
+        // wrapper is where the Python half is discovered and `dlopen`ed
+        // (issue 0897 W3), and it is deliberately the ONE place that happens.
+        //
+        // This binary called the parser directly and so never reached it, which
+        // is not a missing nicety: after W2b removed the compile-time libpython
+        // link, nothing installed a backend here at all, and every `$(eval …)`
+        // or `.launch.py` failed with "this build has no Python backend" — on
+        // hosts that have Python. `host-tests` was red on main from that pin
+        // until this line changed. A failure to load stays non-fatal, so a host
+        // with no usable interpreter still resolves XML and YAML.
+        parse_launch_file(&launch_path, arg_binding.clone())
             .map_err(|e| eyre::eyre!("parsing {}: {e}", launch_path.display()))?
     };
     let dump: LaunchDump = serde_json::from_str(&serde_json::to_string(&record)?)?;


### PR DESCRIPTION
**`host-tests` has been red on `main` since the W2b pin merged**, every run, on
the same line:

```
Error: sync: nros-launch-resolve failed for `demo_bringup`
  (…/demo_bringup/launch/multihost.launch.xml):
this build has no Python backend, and a `$(eval …)` substitution needs one:
  $(eval "robot1" in ("robot1", "all"))
```

On hosts that **have** Python. W2b removed the compile-time `libpython` link
and W3 replaced it with a runtime `dlopen`. Two things had to be true for that
to work, and neither was.

### 1. This binary never reached the loader

`ros_launch_resolve::verbs::parse_launch_file` is where `pyload::install()`
runs, and its own doc comment says putting it there "means there is one place
to change". There were **two** entry points: nano-ros's `nros-launch-resolve`
called `play_launch_parser::parse_launch_file` directly. So nothing installed a
backend, and the parser behaved exactly as designed for a host with no
interpreter — on a host with one. Now routed through the verb; a load failure
stays non-fatal, so a host with no usable interpreter still resolves XML/YAML.

### 2. The Python half was never shipped

The loader finds it beside the executable (`pyexec_beside_exe`), and
`setup-launch-resolve` built only the binary. `--features extension-module` is
the half that must **not** link libpython: its `Py_*` symbols stay undefined so
they bind to whichever interpreter the loader `dlopen`s with `RTLD_GLOBAL`.
Built from the parser's own workspace, since the crate is deliberately not in
the resolver's dependency graph — a normal dep would put the link back.

Also: **"already built" now means both artifacts.** The recipe short-circuits on
an unchanged source tree, so on a tree holding the binary and no `.so` it
reported success and produced a resolver that could not evaluate anything.

### What this was

The artifact **shape** was verified — `readelf -d` shows no `libpython`, still
true of both artifacts — while the **capability** was not. Removing a link and
loading one are two claims and only the first was tested. The end-to-end test
that would have caught it exists upstream in `pyload`, but it builds its own
copy of the Python half, so nothing ever exercised the shipped pair.

### Verification — the exact file and the exact step CI dies on

```
$ nros-launch-resolve …/multihost.launch.xml host:=robot1
SystemModel: system_model.yaml (1 nodes, 0 topics, 0 tier(s))

$ nros sync examples/workspaces/rust
sync: done.

$ readelf -d …/nros-launch-resolve | grep -c python
0
```

`just ci-l1` green (1020 passed, 1 skipped for an unmet host capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
