### PR TITLE
docs(phase-381): live interop PASSES — and the two things it does not cover

### DIFF
--- a/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
+++ b/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
@@ -1,17 +1,36 @@
 # Phase 381 — read the ROS graph, which we are already visible in
 
-**Status (2026-08-30). W1–W7 LANDED.** Twelve `rmw` graph slots produced,
-reachable from Rust, C and C++; zenoh answers all twelve, Cyclone answers
-`get_node_names`; XRCE degrades to `UNSUPPORTED` and that is TESTED rather than
-asserted. `check-rmw-slot-producers`: produced 42 -> 53, inert 25 -> 14.
+**Status (2026-08-30). W1–W7 LANDED, and LIVE INTEROP now PASSES — the phase
+meets its own acceptance.** Twelve `rmw` graph slots produced, reachable from
+Rust, C and C++; zenoh answers all twelve, Cyclone answers `get_node_names`;
+XRCE degrades to `UNSUPPORTED` and that is TESTED rather than asserted.
+`check-rmw-slot-producers`: produced 42 -> 53, inert 25 -> 14.
 `check-api-parity`: every divergence carries a ledger entry.
 
-**NOT done, and it is the gap that matters: LIVE INTEROP.** Nothing here proves
-a native `rmw_zenoh_cpp` node is discovered, or that `ros2 node list` and our
-`get_node_names()` agree. Every verification so far is against our own builders,
-our own parser and our own vtable. The acceptance criteria below still need a
-router and a real ROS 2 node, and they need the settling window Design note 3
-describes — written as a single comparison they would be a flaky test.
+Measured against a stock `demo_nodes_cpp talker` on `rmw_zenoh_cpp`, in the
+repo's `ros2` distrobox on its own tree: our `get_node_names()` reports
+`/talker`, our `get_topic_names_and_types()` reports `/chatter`,
+`/parameter_events` and `/rosout`, and `ros2 node list` reports ours — both
+directions, `probe_rc=0`. `graph_interop.rs` is the committed form of that
+comparison.
+
+Getting there took issue 0903, and the lesson is the one the phase doc's own
+"NOT done" paragraph predicted: every check up to that point tested our code
+against our own builders, our own parser and our own vtable, and the feature did
+not work. The mechanism was wrong underneath the defects — `z_liveliness_get` is
+an INTEREST, and a token reaches a get's callback only when the router tags its
+declaration with that interest id, so a sweep saw an arbitrary handful of the
+domain's tokens. A standing liveliness SUBSCRIBER with history replaced it.
+
+**Still open, beyond acceptance:**
+
+* **Cyclone's graph reader has never run live.** `native-graph-rust-cyclone-r2n`
+  exists in `interop::CELLS` and has never been executed; W5's reader is
+  verified against our own builders only, which is exactly the state zenoh was
+  in before 0903.
+* **Ten of the twelve slots are unproven live.** Only `get_node_names` and
+  `get_topic_names_and_types` have been measured against a real peer. The
+  service forms, the counts and the six by-node forms are still self-verified.
 
 **Superseded status (2026-08-29): UNBLOCKED — the bounded-memory decision does
 not have to be made, because the buffer it was about ALREADY EXISTS and is

--- a/packages/testing/nros-tests/tests/graph_interop.rs
+++ b/packages/testing/nros-tests/tests/graph_interop.rs
@@ -6,12 +6,18 @@
 //! Phase-381 shipped twelve `rmw` graph slots: produced, reachable from Rust, C
 //! and C++, with mutation-tested unit coverage and a clean `check-api-parity`.
 //! Every one of those checks tested our code against our own builders, our own
-//! parser and our own vtable — and the feature did not work. Issue 0903 was
-//! THREE stacked defects (a drain restarting on the first reply rather than the
-//! finished sweep; a runtime that dispatched exactly one of eleven graph
-//! methods; a `collect` flag set AFTER the query went on the wire, so every
-//! reply took the single-response path), and no unit test could see any of
-//! them, because each one only manifests against a real peer.
+//! parser and our own vtable — and the feature did not work.
+//!
+//! Issue 0903 was several stacked defects (a drain restarting on the first
+//! reply rather than the finished sweep; a runtime that dispatched exactly one
+//! of eleven graph methods; a `collect` flag set AFTER the query went on the
+//! wire) sitting on top of a MECHANISM that could not work at all:
+//! `z_liveliness_get` is an INTEREST, and a token reaches a get's callback only
+//! when the router tags its declaration with that interest id, so a sweep saw
+//! an arbitrary handful of the domain's tokens. The fix was a standing
+//! liveliness SUBSCRIBER with history — a graph cache, not a question asked
+//! repeatedly. No unit test could see any of it, because none of it manifests
+//! except against a real peer.
 //!
 //! So the assertion here is deliberately the one thing a self-contained test
 //! cannot make: a nano-ros node enumerates a live `rmw_zenoh_cpp` peer, and


### PR DESCRIPTION
The phase doc's headline still read *"NOT done, and it is the gap that matters:
LIVE INTEROP"*, which stopped being true when issue 0903 was fixed. It now
records what was measured against a stock `demo_nodes_cpp talker` on
`rmw_zenoh_cpp`:

```
GRAPH_NODE /|talker
GRAPH_TOPIC /chatter          [std_msgs::msg::dds_::String_]
GRAPH_TOPIC /parameter_events [rcl_interfaces::msg::dds_::ParameterEvent_]
GRAPH_TOPIC /rosout           [rcl_interfaces::msg::dds_::Log_]
probe_rc=0
```

Both directions — ours enumerates the talker, `ros2 node list` enumerates ours —
so all three acceptance criteria are met.

## What it deliberately does NOT claim

"Acceptance met" is the phrase most likely to be read as "done", so the status
now names what is still uncovered:

* **Cyclone's graph reader has never run live.** `native-graph-rust-cyclone-r2n`
  exists in `interop::CELLS` and has never been executed — exactly the state
  zenoh was in before 0903.
* **Ten of the twelve slots are unproven live.** Only `get_node_names` and
  `get_topic_names_and_types` have met a real peer; the service forms, the counts
  and the six by-node forms are still verified against our own builders.

Also corrects `graph_interop.rs`'s header, which said 0903 was "THREE stacked
defects". The defects were real, but they sat on a mechanism that could not work
at all — `z_liveliness_get` is an INTEREST, and a token reaches a get's callback
only when the router tags its declaration with that interest id. That file is
where the next person reads why the test exists, so it should say the real
reason.

Tier 1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP