### PR TITLE
feat(#896): layer 5 + a real nested-type resolver

### DIFF
--- a/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
+++ b/docs/issues/0896-c-cpp-subscriptions-never-state-a-buffer-hint.md
@@ -390,6 +390,49 @@ case it was always supposed to be, not the common one.
 6. **Thread the RFC-0033 `cap` into the schema emit** so a field bounded only in
    `nros-codegen.toml` stops reading as unbounded. Same test, extended.
 
+## Layer 6 is TWO bounds, not one — correction found while implementing
+
+Layer 6 said: thread the RFC-0033 `cap` into the schema emit so a field bounded
+only in `nros-codegen.toml` stops reading as unbounded. That is half right and
+the wrong half is dangerous.
+
+A `cap` bounds OUR STORAGE. `"…/Shapes.text" = { cap = 32 }` emits
+`char text[32]` in the generated C struct. So:
+
+* **Transmit** — we physically cannot serialize more than 32 bytes of that
+  field, so the cap IS a real bound on what this image emits. Legitimate input
+  to a publish-buffer size.
+* **Receive** — a remote ROS publisher is bound by the `.msg`, not by our
+  config, and may send 200 bytes. The cap says nothing about incoming wire size.
+  Sizing a receive buffer from it reintroduces exactly the drop this issue
+  exists to stop.
+
+**Consequence: `MAX_SERIALIZED_SIZE_XCDR*` cannot serve both consumers once
+caps are honoured.** They are currently one constant used by the publish helper,
+which is safe only because caps are NOT yet threaded. The moment they are, the
+transmit number and the receive number are genuinely different values and need
+different names — `..._TX_MAX_SERIALIZED_SIZE_XCDR1` (caps honoured) and
+`..._RX_MAX_SERIALIZED_SIZE_*` (IDL bounds only).
+
+This is the same mistake as emitting one maxed value across encodings, one
+level up: a single number serving two consumers with different questions. It is
+recorded before implementation rather than after, because the failure it
+produces is a silently undersized receive buffer, which is the original defect.
+
+## Layer 4 cannot pass the hint yet, and should ship anyway
+
+`nros_cpp_subscription_register` takes ten flat arguments and has **no slot for
+a buffer hint**. So a generated `_subscribe` helper can deliver the one-token
+ergonomics — type name and type hash bound to a single spelling, a shorter call,
+no drift — but not the buffer fix, until the register gains an options struct
+(issue 0808's precedent, and the ABI change the UX rewrite was pleased to avoid;
+it turns out to be needed after all, just not for the reason first given).
+
+It should still land: the drift hazard it removes is real and independent of the
+hint, and the helper is where the hint goes once the slot exists. But the issue
+title is about the buffer, and a `_subscribe` helper alone does not fix it —
+saying otherwise would overclaim.
+
 ## Not to be confused with
 
 Issue 0841, fixed: a hint landing between the small block size and the size

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -867,6 +867,37 @@ pub fn generate_c_from_args_file(config: GenerateCConfig) -> Result<()> {
     let mut srv_headers = Vec::new();
     let mut action_headers = Vec::new();
 
+    // issue 0896 — nested-type resolver for the size bound. SAME-PACKAGE only:
+    // the interface files handed to this entry point are siblings, so a bare or
+    // same-package reference resolves off their directory. Cross-package
+    // (`std_msgs/Header`) needs the ament index, which this args-file path does
+    // not carry — those report `Unresolved` and emit NO constant, which is the
+    // honest answer. Never a guessed bound.
+    let msg_dirs: Vec<PathBuf> = args
+        .interface_files
+        .iter()
+        .filter_map(|p| p.parent().map(PathBuf::from))
+        .collect();
+    let pkg_for_lookup = args.package_name.clone();
+    let nested_lookup = move |fqn: &str| -> Option<rosidl_parser::Message> {
+        let mut parts = fqn.split('/');
+        let first = parts.next()?;
+        let name = parts.next_back().unwrap_or(first);
+        // A qualified reference to another package cannot be answered here.
+        if first != name && first != pkg_for_lookup {
+            return None;
+        }
+        for dir in &msg_dirs {
+            let candidate = dir.join(format!("{name}.msg"));
+            if let Ok(body) = std::fs::read_to_string(&candidate)
+                && let Ok(m) = rosidl_parser::parse_message(&body)
+            {
+                return Some(m);
+            }
+        }
+        None
+    };
+
     // Process each interface file
     for file_path in &args.interface_files {
         let extension = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -885,12 +916,13 @@ pub fn generate_c_from_args_file(config: GenerateCConfig) -> Result<()> {
                 let parsed = rosidl_parser::parse_message(&content)
                     .wrap_err_with(|| format!("Failed to parse message: {}", file_name))?;
 
-                let generated = rosidl_codegen::generate_c_message_package(
+                let generated = rosidl_codegen::generate_c_message_package_with_lookup(
                     &args.package_name,
                     file_name,
                     &parsed,
                     type_hash,
                     &resolver,
+                    &nested_lookup,
                 )
                 .wrap_err_with(|| {
                     format!("Failed to generate C code for message: {}", file_name)

--- a/packages/cli/rosidl-codegen/packs/c/message.h.jinja
+++ b/packages/cli/rosidl-codegen/packs/c/message.h.jinja
@@ -131,6 +131,15 @@ const nros_message_type_t* {{ struct_name }}_get_type_support(void);
 /// `nros-codegen.toml`. "could not be resolved" means the bound was NOT
 /// computed, because a nested type was not reachable; that is a search-path
 /// problem, not a property of the message. Issue 0896.
+
+/* issue 0896 layer 5 -- naming the size constant of an unbounded type is a
+   deliberate error, and this makes the compiler SAY SO. Without it the
+   constant is simply absent and the user gets "undeclared identifier", which
+   names neither the type nor the member that costs it the bound. */
+#define {{ constant_prefix }}_MAX_SERIALIZED_SIZE_XCDR1 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+#define {{ constant_prefix }}_MAX_SERIALIZED_SIZE_XCDR2 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
 {% endif %}
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the

--- a/packages/cli/rosidl-codegen/src/generator/mod.rs
+++ b/packages/cli/rosidl-codegen/src/generator/mod.rs
@@ -16,7 +16,8 @@ pub use cpp::{
 };
 pub use msg::{
     GeneratedCPackage, GeneratedNrosPackage, GeneratedPackage, generate_c_message_package,
-    generate_message_package, generate_nros_inline_message, generate_nros_message_package,
+    generate_c_message_package_with_lookup, generate_message_package, generate_nros_inline_message,
+    generate_nros_message_package,
 };
 pub use srv::{
     GeneratedCServicePackage, GeneratedNrosServicePackage, GeneratedServicePackage,

--- a/packages/cli/rosidl-codegen/src/lib.rs
+++ b/packages/cli/rosidl-codegen/src/lib.rs
@@ -28,11 +28,11 @@ pub use generator::{
     GeneratedCppActionPackage, GeneratedCppPackage, GeneratedCppServicePackage, GeneratedFfiRs,
     GeneratedNrosActionPackage, GeneratedNrosPackage, GeneratedNrosServicePackage,
     GeneratedPackage, GeneratedServicePackage, GeneratorError, generate_action_package,
-    generate_c_action_package, generate_c_message_package, generate_c_service_package,
-    generate_cpp_action_package, generate_cpp_message_package, generate_cpp_service_package,
-    generate_message_package, generate_nros_action_package, generate_nros_inline_action,
-    generate_nros_inline_message, generate_nros_inline_service, generate_nros_message_package,
-    generate_nros_service_package, generate_service_package,
+    generate_c_action_package, generate_c_message_package, generate_c_message_package_with_lookup,
+    generate_c_service_package, generate_cpp_action_package, generate_cpp_message_package,
+    generate_cpp_service_package, generate_message_package, generate_nros_action_package,
+    generate_nros_inline_action, generate_nros_inline_message, generate_nros_inline_service,
+    generate_nros_message_package, generate_nros_service_package, generate_service_package,
 };
 pub use idl_generator::{GeneratedIdlCode, extract_annotations, generate_idl_file};
 pub use types::{

--- a/packages/cli/rosidl-codegen/src/schema_value.rs
+++ b/packages/cli/rosidl-codegen/src/schema_value.rs
@@ -445,6 +445,35 @@ mod tests {
         }
     }
 
+    /// A same-package nested type resolved off sibling `.msg` files is the
+    /// case the CLI wiring actually serves, so it is tested with a real
+    /// directory rather than a closure that always answers.
+    ///
+    /// The previous state of this path is what makes it worth asserting: with
+    /// no resolver EVERY nested type reported `Unresolved` and got no
+    /// constant, so the layer-2 win landed only on flat messages.
+    #[test]
+    fn a_sibling_msg_file_resolves_and_yields_a_bound() {
+        let dir = std::env::temp_dir().join(format!("nros0896-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("Inner.msg"), "int32 sec\nuint32 nanosec\n").unwrap();
+
+        let outer = parse_message("Inner stamp\nint32 v\n").unwrap();
+        let d = dir.clone();
+        let lookup = move |fqn: &str| -> Option<Message> {
+            let name = fqn.rsplit('/').next()?;
+            let body = std::fs::read_to_string(d.join(format!("{name}.msg"))).ok()?;
+            parse_message(&body).ok()
+        };
+
+        let got = bound_message("p/Outer", &outer, EncodingVersion::Xcdr1, &lookup);
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(
+            matches!(got, TypeBound::Bounded(_)),
+            "a resolvable nested type must produce a bound, got {got:?}"
+        );
+    }
+
     /// ROS IDL cannot express a cycle, so one means the resolver is
     /// inconsistent. Report it instead of recursing forever.
     #[test]

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.h
@@ -84,6 +84,15 @@ const nros_message_type_t* fingerprint_corpus_msg_nested_get_type_support(void);
 /// computed, because a nested type was not reachable; that is a search-path
 /// problem, not a property of the message. Issue 0896.
 
+/* issue 0896 layer 5 -- naming the size constant of an unbounded type is a
+   deliberate error, and this makes the compiler SAY SO. Without it the
+   constant is simply absent and the user gets "undeclared identifier", which
+   names neither the type nor the member that costs it the bound. */
+#define FINGERPRINT_CORPUS_MSG_NESTED_MAX_SERIALIZED_SIZE_XCDR1 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+#define FINGERPRINT_CORPUS_MSG_NESTED_MAX_SERIALIZED_SIZE_XCDR2 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the
 /// type's own bound where one exists, and from `NROS_PUB_BUFFER_SIZE`

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.h
@@ -131,6 +131,15 @@ const nros_message_type_t* fingerprint_corpus_msg_shapes_get_type_support(void);
 /// computed, because a nested type was not reachable; that is a search-path
 /// problem, not a property of the message. Issue 0896.
 
+/* issue 0896 layer 5 -- naming the size constant of an unbounded type is a
+   deliberate error, and this makes the compiler SAY SO. Without it the
+   constant is simply absent and the user gets "undeclared identifier", which
+   names neither the type nor the member that costs it the bound. */
+#define FINGERPRINT_CORPUS_MSG_SHAPES_MAX_SERIALIZED_SIZE_XCDR1 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+#define FINGERPRINT_CORPUS_MSG_SHAPES_MAX_SERIALIZED_SIZE_XCDR2 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the
 /// type's own bound where one exists, and from `NROS_PUB_BUFFER_SIZE`

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.h
@@ -84,6 +84,15 @@ const nros_message_type_t* fingerprint_corpus_msg_nested_get_type_support(void);
 /// computed, because a nested type was not reachable; that is a search-path
 /// problem, not a property of the message. Issue 0896.
 
+/* issue 0896 layer 5 -- naming the size constant of an unbounded type is a
+   deliberate error, and this makes the compiler SAY SO. Without it the
+   constant is simply absent and the user gets "undeclared identifier", which
+   names neither the type nor the member that costs it the bound. */
+#define FINGERPRINT_CORPUS_MSG_NESTED_MAX_SERIALIZED_SIZE_XCDR1 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+#define FINGERPRINT_CORPUS_MSG_NESTED_MAX_SERIALIZED_SIZE_XCDR2 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the
 /// type's own bound where one exists, and from `NROS_PUB_BUFFER_SIZE`

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.h
@@ -98,6 +98,15 @@ const nros_message_type_t* fingerprint_corpus_msg_shapes_get_type_support(void);
 /// computed, because a nested type was not reachable; that is a search-path
 /// problem, not a property of the message. Issue 0896.
 
+/* issue 0896 layer 5 -- naming the size constant of an unbounded type is a
+   deliberate error, and this makes the compiler SAY SO. Without it the
+   constant is simply absent and the user gets "undeclared identifier", which
+   names neither the type nor the member that costs it the bound. */
+#define FINGERPRINT_CORPUS_MSG_SHAPES_MAX_SERIALIZED_SIZE_XCDR1 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+#define FINGERPRINT_CORPUS_MSG_SHAPES_MAX_SERIALIZED_SIZE_XCDR2 \
+    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
+
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the
 /// type's own bound where one exists, and from `NROS_PUB_BUFFER_SIZE`


### PR DESCRIPTION
Stacked on **#78** (layer 2) by content, but based on `main` — #78's commits drop out on rebase once it merges. Deliberately not a stacked PR; that cost this session a six-deep collapse earlier.

## The resolver — the part that makes layer 2 matter

Layer 2 shipped with a lookup that resolved nothing, so **every nested type reported `Unresolved` and got no constant**. The win landed only on flat messages, which aren't the ones this campaign exists for.

`generate_c_from_args_file` now builds a resolver from the interface files it was handed — they're siblings, so a same-package reference resolves off their directory. Those types now get a bound and a constant.

**Same-package only, deliberately.** Cross-package (`std_msgs/Header`) needs the ament index, which this entry point doesn't carry. Those still report `Unresolved` and emit **no** constant — "we could not look" is not "there is no bound", and the third outcome exists so that difference survives to the header as a reason a reader can act on. A guessed bound would be the defect this issue is about.

Tested against a **real directory**, not a closure that always answers — the always-answering closure is exactly what let earlier tests pass while the shipped path resolved nothing.

## Layer 5

An unbounded type's size constant is now a deliberate error that says so:

```c
#define FINGERPRINT_CORPUS_MSG_SHAPES_MAX_SERIALIZED_SIZE_XCDR1 \
    NROS_NO_SIZE_BOUND__see_the_reason_above_in_this_header
```

Absence gave "undeclared identifier", naming neither the type nor the member. The reason sits two lines above, from layer 0's `first_unbounded`.

## Layers 4 and 6: corrections, not implementations

**Layer 6 is two bounds.** A `cap` bounds *our storage* (`cap = 32` → `char text[32]`). On **transmit** that's a real bound — we can't serialize more than we can store. On **receive** it isn't: a remote publisher is bound by the `.msg`, not our config. Threading caps as specified would produce a silently undersized receive buffer — the original defect. So `MAX_SERIALIZED_SIZE_*` can't serve both consumers once caps are honoured; they need different names.

**Layer 4 can't pass the hint.** `nros_cpp_subscription_register` has ten flat args and no slot. So the ABI change the UX rewrite was pleased to avoid is needed after all — just not for the reason first given. A `_subscribe` helper still earns its place on ergonomics, but shipping it and calling the issue fixed would overclaim.

`just ci-l1` green (1026 ran / 2 skipped). Full `packages/cli` suite green.