### PR TITLE
feat(ci): gate that every submodule pin is one a clone can actually obtain

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -111,6 +111,54 @@ if [ -x "$pins" ]; then
     done < "$hook_stdin"
 fi
 
+# A submodule pin must name a commit the REMOTE can serve.
+#
+# The push is the only moment this can still be fixed cheaply. Afterwards the
+# superproject commit is published naming a commit nobody else can obtain, and
+# the fix is a rewrite or a revert — a pin cannot point at nothing. AGENTS.md
+# has required "push the submodule commit FIRST" all along; this is the first
+# thing that checks.
+#
+# Scoped to pins this push MOVES, so the cost is proportional to what is being
+# published rather than to the number of submodules. An unchanged pin was
+# already reachable or the tree would not build today.
+reach="$repo_root/scripts/ci/submodule-commits-reachable.sh"
+if [ -x "$reach" ]; then
+    while IFS= read -r line; do
+        set -- $line
+        remote_ref="${3:-}"
+        remote_sha="${4:-}"
+        local_sha="${2:-}"
+        case "$remote_ref" in refs/heads/*) ;; *) continue ;; esac
+        [ -n "$local_sha" ] || continue
+        # A NEW branch (all-zero remote sha) has no baseline to diff against,
+        # so check every pin rather than skipping — a new branch is exactly
+        # where a fresh, unpushed submodule commit tends to arrive.
+        case "$remote_sha" in
+            *[!0]*) out="$("$reach" --changed "$remote_sha" 2>&1)" ;;
+            *)      out="$("$reach" 2>&1)" ;;
+        esac
+        rc=$?
+        # 2 = could not ask the remotes. Say so and let the push through: a
+        # push is already a network operation, so if the network were truly
+        # gone this would not be running — and refusing on an unanswerable
+        # question is worse than reporting it.
+        if [ "$rc" -eq 2 ]; then
+            echo "pre-push: submodule reachability NOT verified (no network)." >&2
+            continue
+        fi
+        if [ "$rc" -ne 0 ]; then
+            printf '%s\n' "$out" >&2
+            echo "" >&2
+            echo "pre-push: REFUSING to push — a submodule pin names a commit no clone can get." >&2
+            echo "" >&2
+            echo "  Push the submodule branch first, then push this. Order matters:" >&2
+            echo "  the superproject may only pin what is already published." >&2
+            exit 1
+        fi
+    done < "$hook_stdin"
+fi
+
 # (c) The fast gate tier — issue 0840.
 #
 # On 2026-08-27 four independent reds landed on main in one day, across two

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -329,6 +329,24 @@ jobs:
       - name: just check-fast
         run: just check-fast
 
+      # A pin naming a commit no remote can serve is a repo that builds only on
+      # the machine that made it: every clone and every CI run dies at
+      # `git submodule update` with `reference is not a tree`, and the
+      # superproject commit has to be rewritten because a pin cannot point at
+      # nothing. AGENTS.md has said "push the submodule commit FIRST" since
+      # forever and nothing enforced it.
+      #
+      # Not in `check-fast`: that tier is source-free AND network-free by
+      # contract, and this gate's whole job is to ask the REMOTE. Asking the
+      # local clone instead would pass on exactly the one host where the
+      # mistake is invisible.
+      #
+      # Every pin, not only the moved ones: a PR is where a reviewer's fresh
+      # clone gets its first chance, and 20 `--depth=1` existence probes cost
+      # seconds.
+      - name: just check-submodule-commits-reachable
+        run: just check-submodule-commits-reachable
+
       # ----- build tier (PR + nightly + dispatch, NOT per-push) -----
       # THE ARRANGEMENT, phase-395. This job is ONE required status context and
       # it deliberately does DIFFERENT WORK per event:

--- a/just/check.just
+++ b/just/check.just
@@ -1100,6 +1100,44 @@ check-cpp-ffi-error-mapping:
 check-submodule-pins:
     @bash scripts/ci/submodule-pins-check.sh
 
+# The sibling of `check-submodule-pins`: that one asks whether a pin moved the
+# right DIRECTION, this one asks whether the commit it names exists anywhere a
+# CLONE can reach.
+#
+# AGENTS.md's first submodule rule is "push the submodule commit BEFORE the
+# superproject pins it", because nothing downstream recovers from getting it
+# wrong — every clone and every CI run dies at `git submodule update` with
+# `reference is not a tree`, and the offending commit has to be rewritten,
+# since a pin cannot point at nothing. The rule was written down and nothing
+# enforced it; `git push` will happily publish a gitlink naming a commit that
+# exists only in someone's working tree.
+#
+# NOT on the `check-fast` line, and that is deliberate rather than an
+# oversight: that tier is source-free and network-free by contract, while this
+# gate's entire job is to ask the REMOTE. A local `cat-file -e` would be free
+# and would pass on precisely the one host where the mistake is invisible.
+# It runs as its own step on pull requests, and the pre-push hook runs it over
+# the pins a push actually MOVES.
+#
+# Exit 2 (network unavailable) is reported, not swallowed and not treated as a
+# failure — "your submodule is unpushed" is a false and very specific
+# accusation to make at an offline laptop, and the remedy it implies is wrong.
+[group("check")]
+check-submodule-commits-reachable:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    source scripts/build/lane-skip.sh
+    bash scripts/ci/submodule-commits-reachable.sh
+    rc=$?
+    # `nros_lane_skip`, NOT `echo … ; exit 0`. A gate that cannot ask its
+    # question must report a THIRD verdict, or "nobody checked" is indexed as
+    # "nothing wrong" — issue 0658, and `check-lane-skip-protocol` caught
+    # exactly that spelling here on the first run.
+    if [ "$rc" -eq 2 ]; then
+        nros_lane_skip "no network: submodule pins were NOT verified against their remotes"
+    fi
+    exit "$rc"
+
 # Issue 0589 — `std::println!`/`eprintln!` from a crate Zephyr links does not
 # print on native_sim, it recurses in `zvfs_write` until the stack is gone. Go
 # through `cpp_diag!`, which uses std stdio only where that is safe.

--- a/scripts/ci/submodule-commits-reachable.sh
+++ b/scripts/ci/submodule-commits-reachable.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Every recorded submodule pin must be OBTAINABLE FROM ITS REMOTE.
+#
+# The sibling of `submodule-pins-check.sh`: that one asks whether a pin moved
+# the right DIRECTION, this one asks whether the commit it names exists
+# anywhere a clone can reach.
+#
+# WHY THIS EXISTS. AGENTS.md's first submodule rule is "push the submodule
+# commit BEFORE the superproject pins it", and the reason is that nothing
+# downstream can recover from getting it wrong: a pin naming an unpushed commit
+# is a repository that only builds on the machine that made it. Every clone and
+# every CI run dies at `git submodule update` with `reference is not a tree`,
+# and the superproject commit has to be rewritten or reverted, because a pin
+# cannot point at nothing.
+#
+# The rule was written down and nothing enforced it. `git push` is happy to
+# publish a superproject commit whose gitlink names a commit that exists only
+# in someone's working tree.
+#
+# WHAT "REACHABLE" MEANS HERE, precisely. Not "present in my clone" — that is
+# exactly the state a bad pin produces on the machine that made it, so a local
+# `cat-file -e` would pass on the one host where the bug is invisible. The
+# question is whether a FRESH clone can get it, so it is asked of the REMOTE,
+# with the same operation `git submodule update` performs: fetch the sha from
+# the URL.
+#
+# Note this also passes for a commit on no branch but reachable from one, and
+# fails for a commit on no ref at all — which is correct, because that is
+# precisely what a clone can and cannot obtain.
+#
+# A FALSE ALARM THIS AVOIDS. A submodule clone's fetch refspec is often
+# NARROWED (ours carry `+refs/heads/main:...` plus one branch), so a plain
+# `git fetch` in the submodule does not see commits on other branches and a
+# local lookup reports "missing" for a commit that is perfectly well published.
+# That misreading happened while writing this, and cost a wrong claim that main
+# pinned an unpushed commit. Asking the remote for the sha directly is immune:
+# it does not depend on which refs the local clone chose to track.
+#
+# Usage:
+#   scripts/ci/submodule-commits-reachable.sh [--changed <baseline-ref>]
+#
+#   With no argument every pin is checked. `--changed <ref>` checks only pins
+#   that DIFFER from that ref, which is what the pre-push hook wants: the cost
+#   is then proportional to what the push actually moves, and an unchanged pin
+#   was already published or the repo would not build today.
+#
+# Exit: 0 all reachable (or nothing to check), 1 a pin is unreachable,
+#       2 the network is unavailable and the check could not be performed.
+set -uo pipefail
+
+# Prove the two verdicts on every run, against a LOCAL remote.
+#
+# `check-gate-selftests` requires this and is right to: the whole value here is
+# a negative control, and one that only ever ran by hand during development
+# decays into a comment. It is also the half most likely to rot silently — a
+# refactor that made every pin "reachable" would look like a green gate.
+#
+# `file://` rather than the network, so the selftest costs milliseconds, works
+# offline, and does not depend on any host being up. The code path exercised is
+# the real one: same `git fetch --depth=1 <url> <sha>`.
+selftest() {
+    local tmp good bad out rc
+    tmp="$(mktemp -d)" || return 1
+    (
+        set -e
+        export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t
+        export GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+        git init -q "$tmp/dep.git" --bare
+        git init -q "$tmp/work"
+        git -C "$tmp/work" commit -q --allow-empty -m one
+        git -C "$tmp/work" push -q "$tmp/dep.git" HEAD:refs/heads/main
+    ) >/dev/null 2>&1 || { rm -rf "$tmp"; return 1; }
+    good="$(git -C "$tmp/work" rev-parse HEAD)"
+    bad="0123456789abcdef0123456789abcdef01234567"
+
+    _mk_super() {
+        rm -rf "$tmp/super"
+        (
+            set -e
+            export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t
+            export GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+            git init -q "$tmp/super"
+            printf '[submodule "dep"]\n\tpath = dep\n\turl = %s\n' "$tmp/dep.git" \
+                > "$tmp/super/.gitmodules"
+            git -C "$tmp/super" add .gitmodules
+            git -C "$tmp/super" update-index --add --cacheinfo "160000,$1,dep"
+            git -C "$tmp/super" commit -q -m pin
+        ) >/dev/null 2>&1
+    }
+
+    local ok=0 fail=0
+    _mk_super "$good"
+    out="$(cd "$tmp/super" && NROS_SUBMODULE_REACH_SELFTEST=1 bash "$self" 2>&1)"; rc=$?
+    if [ "$rc" -eq 0 ]; then ok=$((ok+1)); else
+        fail=$((fail+1)); echo "  FAIL selftest: a published pin was rejected: $out" >&2
+    fi
+
+    _mk_super "$bad"
+    out="$(cd "$tmp/super" && NROS_SUBMODULE_REACH_SELFTEST=1 bash "$self" 2>&1)"; rc=$?
+    if [ "$rc" -eq 1 ]; then ok=$((ok+1)); else
+        fail=$((fail+1))
+        echo "  FAIL selftest: an UNREACHABLE pin was accepted (rc=$rc). This gate" >&2
+        echo "       cannot fail, so it is reporting nothing: $out" >&2
+    fi
+
+    rm -rf "$tmp"
+    if [ "$fail" -gt 0 ]; then
+        echo "submodule-commits-reachable: SELFTEST FAILED ($fail of $((ok+fail)))" >&2
+        return 1
+    fi
+    echo "submodule-commits-reachable --selftest: 2 case(s) OK (published accepted, unreachable rejected)"
+    return 0
+}
+
+self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+# The env var stops the selftest's own child invocations from recursing.
+if [ -z "${NROS_SUBMODULE_REACH_SELFTEST:-}" ]; then
+    selftest || exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root" || exit 1
+
+changed_against=""
+if [ "${1:-}" = "--changed" ]; then
+    changed_against="${2:-}"
+    if [ -z "$changed_against" ]; then
+        echo "submodule-commits-reachable: --changed needs a ref" >&2
+        exit 1
+    fi
+fi
+
+# `git config -f .gitmodules` rather than `git submodule foreach`: this must
+# work from a checkout where a submodule is UNINITIALISED, which is the normal
+# state for most of them here (RFC-0060 keeps layer-3 uninitialised on purpose)
+# and is also the state a reviewer's fresh clone is in.
+mapfile -t paths < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}')
+if [ "${#paths[@]}" -eq 0 ]; then
+    echo "submodule-commits-reachable: no submodules declared"
+    exit 0
+fi
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+git init -q --bare "$scratch/probe" || exit 1
+
+bad=0
+checked=0
+skipped_unchanged=0
+network_failed=0
+
+for path in "${paths[@]}"; do
+    name="$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' \
+        | awk -v p="$path" '$2 == p {print $1}' | sed 's/^submodule\.//;s/\.path$//')"
+    url="$(git config -f .gitmodules --get "submodule.$name.url" 2>/dev/null)"
+    [ -n "$url" ] || continue
+
+    pin="$(git ls-tree HEAD "$path" 2>/dev/null | awk '{print $3}')"
+    [ -n "$pin" ] || continue
+
+    if [ -n "$changed_against" ]; then
+        base="$(git ls-tree "$changed_against" "$path" 2>/dev/null | awk '{print $3}')"
+        if [ "$base" = "$pin" ]; then
+            skipped_unchanged=$((skipped_unchanged + 1))
+            continue
+        fi
+    fi
+
+    checked=$((checked + 1))
+    # `--depth=1`: the question is existence, not history. Nothing is kept.
+    if err="$(git -C "$scratch/probe" fetch --quiet --depth=1 --no-tags "$url" "$pin" 2>&1)"; then
+        continue
+    fi
+    # Tell a network failure apart from a missing commit. Reporting "not
+    # pushed" for an offline laptop would be a false and very specific
+    # accusation, and the remedy it implies (push the submodule) is wrong.
+    case "$err" in
+        *"Could not resolve host"*|*"unable to access"*|*"Connection timed out"* \
+        |*"Operation timed out"*|*"network is unreachable"*|*"Temporary failure"*)
+            echo "submodule-commits-reachable: NETWORK UNAVAILABLE while checking $path" >&2
+            echo "  $err" >&2
+            network_failed=1
+            break
+            ;;
+    esac
+    bad=$((bad + 1))
+    echo "[FAIL] $path pins $pin, which $url cannot serve." >&2
+    echo "       A clone cannot obtain it, so this commit builds only where it was made." >&2
+    echo "       Push the submodule commit FIRST, then pin it (AGENTS.md, Submodules #1):" >&2
+    echo "         git -C $path push <remote> <branch>" >&2
+    echo "       git said: $err" >&2
+done
+
+if [ "$network_failed" -eq 1 ]; then
+    echo "submodule-commits-reachable: SKIPPED — cannot ask the remotes." >&2
+    exit 2
+fi
+
+if [ "$bad" -gt 0 ]; then
+    echo "" >&2
+    echo "submodule-commits-reachable: $bad unreachable pin(s)." >&2
+    exit 1
+fi
+
+msg="submodule-commits-reachable: OK — $checked pin(s) served by their remotes"
+if [ "$skipped_unchanged" -gt 0 ]; then
+    msg="$msg ($skipped_unchanged unchanged, not re-checked)"
+fi
+echo "$msg"
+exit 0


### PR DESCRIPTION
AGENTS.md's first submodule rule is *"push the submodule commit BEFORE the
superproject pins it"*, because nothing downstream recovers from getting it
wrong: a pin naming an unpushed commit is a repository that builds only on the
machine that made it. Every clone and every CI run dies at `git submodule
update` with `reference is not a tree`, and the fix is a rewrite or a revert —
a pin cannot point at nothing.

The rule was written down and nothing enforced it. `git push` will happily
publish a gitlink naming a commit that exists only in someone's working tree.

`scripts/ci/submodule-commits-reachable.sh` is the sibling of
`submodule-pins-check.sh`: that one asks whether a pin moved the right
**direction**, this one asks whether the commit it names exists anywhere a
clone can reach.

## Why it asks the remote

Not "present in my clone" — that is exactly the state a bad pin produces on the
machine that made it, so a local `cat-file -e` would be free and would pass on
the one host where the mistake is invisible. It performs the same operation
`git submodule update` does: fetch the sha from the URL, `--depth=1`, into a
throwaway bare repo.

**A false alarm this avoids, learned the hard way.** A submodule clone's fetch
refspec is often narrowed — ours carry `+refs/heads/main:…` plus one branch —
so a plain `git fetch` inside the submodule does not see commits on other
branches, and a local lookup reports "missing" for a commit that is perfectly
well published. That misreading happened while writing this and produced a
wrong claim that `main` pinned an unpushed zenoh-pico commit; it was on
`archive/1.10-integration-isr-v1` all along. Asking the remote for the sha is
immune, because it does not depend on which refs the local clone tracks.

## Where it runs

- **Pull requests**, as its own step — all 20 pins, seconds, because a PR is
  where a reviewer's fresh clone gets its first chance.
- **`pre-push`**, over the pins the push actually *moves*, since that is the
  last moment the mistake is cheap. A **new branch** checks everything: it has
  no baseline, and is exactly where a fresh unpushed submodule commit arrives.

**Not on the `check-fast` line**, deliberately: that tier is source-free and
network-free by contract, while this gate's entire job is to ask the network.

## Two verdicts it must keep telling apart

**Network-unavailable is a third verdict**, via `nros_lane_skip`, not a pass —
"your submodule is unpushed" is a false and very specific accusation to make at
an offline laptop, and the remedy it implies is wrong.

Both of those were caught by this repo's own gates rather than by me, while
writing a gate about enforcement:

- the first draft wrote `echo … ; exit 0` and **`check-lane-skip-protocol`
  rejected it** (issue 0658 working as designed);
- it shipped with no self-test and **`check-gate-selftests` rejected it** —
  *"a negative control nobody runs decays into a comment"*, which was precisely
  true of the one I had run by hand.

So the selftest now proves both verdicts on every invocation against a
`file://` remote — milliseconds, works offline, same real code path:

```
submodule-commits-reachable --selftest: 2 case(s) OK (published accepted, unreachable rejected)
submodule-commits-reachable: OK — 20 pin(s) served by their remotes
```

The rejection half is the one most likely to rot silently: a refactor making
every pin "reachable" would look like a green gate.

## Verification

All 20 real pins pass. A fabricated pin fails with the registry's own
`upload-pack: not our ref` plus the remedy. `just check-fast` 138/138;
`just ci-l1` green (1027 tests). Selftest ratchet `47/164 → 48/165`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
