### PR TITLE
refactor(ci): `just ci <lane>`, `just post-rebase`, and a lane that stops overstating its result

### DIFF
--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -103,10 +103,10 @@ jobs:
         run: |
           source ./activate.sh
           just build-test-fixtures lane=tier2
-      - name: just ci-matrix
+      - name: just ci matrix
         run: |
           source ./activate.sh
-          just ci-matrix
+          just ci matrix
       - name: Upload junit and logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/queue-notify.yml
+++ b/.github/workflows/queue-notify.yml
@@ -95,7 +95,7 @@ jobs:
 
           \`\`\`
           git fetch origin && git rebase origin/main
-          just ci-l1                 # the SAME tier the merge group runs
+          just ci l1                 # the SAME tier the merge group runs
           \`\`\`
 
           **Do not re-queue an unchanged commit.** The queue re-runs the same tree and

--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -68,10 +68,10 @@ jobs:
       # lands on the author's change looking like a code failure. Assert first.
       - name: Verify this runner's labels are true
         run: ./scripts/ci/runner-doctor.sh nros-sdk-zephyr,nros-big
-      - name: just ci-l3
+      - name: just ci l3
         run: |
           source ./activate.sh
-          just ci-l3
+          just ci l3
       - name: Upload logs and size reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ passes through.
 - `just test`: standard dev tier; skips heavy platform/ROS 2 groups.
 - `just test-all`: full matrix, doctests, Miri, and C codegen tests. Run `just build-test-fixtures` first.
 - `just check`: formatting and clippy checks across Rust, C, C++, and Python surfaces.
-- `just ci-l1`: `check` plus `test-unit`. ~6 min, and it builds **no fixtures** —
+- `just ci l1`: `check` plus `test-unit`. ~6 min, and it builds **no fixtures** —
   only `test`/`test-all` require them. This is the verb to run before a push
   (phase-395 W2); it catches the compile-tier reds that the `pre-push`
   `check-fast` hook deliberately excludes.
@@ -97,7 +97,7 @@ Project naming:
 
 Prefer the narrowest tier that covers the change. Reusable Rust integration tests belong in `packages/testing/nros-tests/tests/`; shell tests belong in `tests/`; temporary tests can start as Bash and should be promoted when reused. Tests must fail on unmet preconditions with `assert!`, `bail!`, or the project skip helper; do not silently `eprintln!` and return from a test.
 
-**New runtime tests join a matrix, not a new file.** A (platform × language × RMW × workload) coordinate belongs as a cell in `matrix::CELLS` (self-contained/baked) or `interop::CELLS` (live ROS 2 peer + direction), consumed by the existing rstest consumers — phase-331 W4 put workspace RMW cells there too. Hand-coordinated per-cell test files are the pre-RFC-0051 shape the tree keeps having to re-consolidate (phase-295, phase-329); the taxonomy and the fold-in plan are `docs/roadmap/phase-329-test-taxonomy-completion.md`. Fixture builds are **lane-scoped** (#393): `just build-test-fixtures lane=<all|native|tier1|tier2|tier2-nightly>` builds exactly the lane's coordinates and stamps the scope; build the lane you will test rather than the whole matrix. **But a lane's coordinates are what it keeps FRESH, not what its run needs to EXIST** (#482) — the two are separate questions, mapped by `nros_lane_build_lane` (declared by `CiLane::run_scope`), and `_require-fixtures` refuses a mismatch instead of letting the run discover it 231 failures later. Each lane narrows its run in the way its cost lives: tier 1 by test/binary NAME (`NROS_TEST_SCOPE=native`), so it needs the broader `lane=native` build; tier 2 and the nightly lane by fixture COORDINATE (`NROS_TEST_COORDS`, phase-340 W3), so each is its own build lane — `just build-test-fixtures lane=tier2 && just ci-matrix`. Name filtering cannot express tier 2: it is 1-wise over platform, so every platform is in the lane and a platform-token filter excludes nothing, while the saving is in lang x rmw *within* a platform (#357). The coordinate narrowing therefore happens in the fixture RESOLVER (`nros_tests::fixtures::lane`), which attributes a resolved artifact back to its `examples/fixtures.toml` row through `row_artifact_root()` — the sibling of `row_coord()`, so the BUILD's `--coords-from` filter and the RUN's skip are one predicate over one coordinate file. Out-of-lane fixtures report `[SKIPPED] out of lane`; an IN-lane fixture that is absent or stale still fails hard, and a path no manifest row claims (zephyr west leaves, the compile-check lane, the shared `build/cargo-fixtures` dirs — all built module-level) is never skipped.
+**New runtime tests join a matrix, not a new file.** A (platform × language × RMW × workload) coordinate belongs as a cell in `matrix::CELLS` (self-contained/baked) or `interop::CELLS` (live ROS 2 peer + direction), consumed by the existing rstest consumers — phase-331 W4 put workspace RMW cells there too. Hand-coordinated per-cell test files are the pre-RFC-0051 shape the tree keeps having to re-consolidate (phase-295, phase-329); the taxonomy and the fold-in plan are `docs/roadmap/phase-329-test-taxonomy-completion.md`. Fixture builds are **lane-scoped** (#393): `just build-test-fixtures lane=<all|native|tier1|tier2|tier2-nightly>` builds exactly the lane's coordinates and stamps the scope; build the lane you will test rather than the whole matrix. **But a lane's coordinates are what it keeps FRESH, not what its run needs to EXIST** (#482) — the two are separate questions, mapped by `nros_lane_build_lane` (declared by `CiLane::run_scope`), and `_require-fixtures` refuses a mismatch instead of letting the run discover it 231 failures later. Each lane narrows its run in the way its cost lives: tier 1 by test/binary NAME (`NROS_TEST_SCOPE=native`), so it needs the broader `lane=native` build; tier 2 and the nightly lane by fixture COORDINATE (`NROS_TEST_COORDS`, phase-340 W3), so each is its own build lane — `just build-test-fixtures lane=tier2 && just ci matrix`. Name filtering cannot express tier 2: it is 1-wise over platform, so every platform is in the lane and a platform-token filter excludes nothing, while the saving is in lang x rmw *within* a platform (#357). The coordinate narrowing therefore happens in the fixture RESOLVER (`nros_tests::fixtures::lane`), which attributes a resolved artifact back to its `examples/fixtures.toml` row through `row_artifact_root()` — the sibling of `row_coord()`, so the BUILD's `--coords-from` filter and the RUN's skip are one predicate over one coordinate file. Out-of-lane fixtures report `[SKIPPED] out of lane`; an IN-lane fixture that is absent or stale still fails hard, and a path no manifest row claims (zephyr west leaves, the compile-check lane, the shared `build/cargo-fixtures` dirs — all built module-level) is never skipped.
 
 **No compilation inside tests.** A test must not invoke `cargo build`, `cmake --build`, `idf.py build`, `west build`, `nros generate` + compile, or any other compiler/build at run time. Compilation belongs in the **build stage** — `just build-test-fixtures` and the per-platform `build-fixtures` lanes (driven by `examples/fixtures.toml`). A test consumes a **prebuilt fixture artifact** and exercises its behavior. Reasons: in-test builds make the test wall-clock dominated by compile time (so they blow the per-test timeout under any load and report as spurious `timed out` failures), serialize on the cargo/cmake build locks, and conflate "does it build" with "does it behave". If a test's *intent* is to verify that something compiles (a macro form, a codegen output, an API shape), make it a **fixture in the build step** — add a row to `examples/fixtures.toml` (or a build-lane target) so the artifact is built once during `build-test-fixtures`, and have the test assert the fixture exists / inspect the built artifact, the same way the native C/XRCE tests consume their prebuilt CMake fixtures. The build either succeeds (fixture present → test checks it) or fails loudly in the build stage where it belongs.
 
@@ -254,7 +254,7 @@ empty, admins included. **The flow is now:**
 just claim issue-NNNN                  # so two agents do not do one job
 git switch -c fix/NNNN-<slug>
 # ... work ...
-just ci-l1                             # STRICTER than the gate (see below)
+just ci l1                             # STRICTER than the gate (see below)
 git push -u origin fix/NNNN-<slug>
 gh pr create --base main --fill
 gh pr merge --auto --rebase            # fire and forget; the queue lands it
@@ -390,11 +390,11 @@ may resolve an artifact only if that JOB builds it.
 
 | stage | runs | measured | gates? |
 | --- | --- | --- | --- |
-| local, before push | `just ci-l1` | ~6 min warm | you |
+| local, before push | `just ci l1` | ~6 min warm | you |
 | pull request | `check-fast` only (133 source gates) | ~5 min | **required** |
 | merge group | + `test-unit` | ~9 min | **required** |
 
-**`just ci-l1` is NOT what CI runs, and that is deliberate** (phase-399 W3).
+**`just ci l1` is NOT what CI runs, and that is deliberate** (phase-399 W3).
 CI's required context is `check-fast` + `test-unit`; `ci-l1` additionally runs
 `check-build` and `check-api-parity`. So the local tier is a SUPERSET of the
 gate — you catch compile-tier breakage before the queue does, and the queue
@@ -421,14 +421,14 @@ that: a lane in an affordability tier may resolve a compile-stage stamp only if
 it builds it (~13 s), and may never reach a runtime fixture. Fixture-bearing
 lanes are post-merge.
 
-### Why `just ci-l1` locally is not optional
+### Why `just ci l1` locally is not optional
 
 The PR gate no longer compiles. That means **a compile error in your branch is
 caught by the merge queue, not by your PR** — and there it ejects the other
 pull requests batched with it. GitHub re-tests them in smaller groups, so the
 damage is bounded, but it is real and it is paid by other agents.
 
-`just ci-l1` is exactly the tier the merge group runs. Running it before you
+`just ci l1` is exactly the tier the merge group runs. Running it before you
 push is what makes the cheap PR gate affordable for everyone else. Skipping it
 does not save you time; it moves your time onto three other agents.
 
@@ -480,14 +480,14 @@ here.
 
 ```
 git fetch origin && git rebase origin/main
-just ci-l1        # STRICTER than the gate (see 'Where each tier runs')
+just ci l1        # STRICTER than the gate (see 'Where each tier runs')
 ```
 
 Two things reproduce this way, and the second is the reason the queue exists:
 
 * **Your PR is simply broken.** The PR gate is deliberately cheap (source gates
   only), so a compile error reaches the queue rather than your PR. Rebasing is
-  incidental; `just ci-l1` finds it.
+  incidental; `just ci l1` finds it.
 * **A semantic conflict.** Your change and something that landed while you
   waited are each correct alone and wrong together — a caller you added against
   a signature someone else changed. No textual conflict, so git merges cleanly
@@ -562,7 +562,7 @@ and verified.
 
 ### Agent Practices
 
-- **Run `just ci-l1` before every push** (~6 min, no fixtures); run `just ci` when the change earns fixture-backed coverage. Never `sudo` — tell the user.
+- **Run `just ci l1` before every push** (~6 min, no fixtures); run `just ci` when the change earns fixture-backed coverage. Never `sudo` — tell the user.
 - **Green CI locally BEFORE pushing** — run `just format` then `just ci`. CI stops at the first failing step; re-run until fully green. A toolchain bump can surface new pre-existing lints (e.g. rust-1.96 `unnecessary_cast` / `drop_non_drop` / `not_unsafe_ptr_arg_deref`) — fix them locally rather than discovering them remotely.
 - **Always nightly for `rustfmt`** — `rustfmt.toml` enables nightly-only options; stable produces different output. Run `cargo +nightly fmt`.
 - **Never merge in git.** Use `git pull --rebase` or `git fetch` + `git rebase`. Never create merge commits unless asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
 ## Practices
 - **Run the TIER your change earns, after every task** (RFC-0061 / phase-318).
   **Never `sudo`** — tell the user.
-  - `just ci-l1` — **compile + unit, ~6 min, NO FIXTURES** (phase-395 W2).
+  - `just ci l1` — **compile + unit, ~6 min, NO FIXTURES** (phase-395 W2).
     Run this before every push. It is `check` + `test-unit`, and it needs no
     fixture build, no SDK, no QEMU and no cross toolchain — only `test`/
     `test-all` depend on fixtures, and 74 of 163 test files never needed them.
@@ -84,7 +84,7 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   - `just ci` — **tier 1**, host only. Gates and runs only native fixtures, so a
     stale ThreadX fixture cannot block it. Costs a fixture build; run it when
     you need fixture-backed coverage, not as the reflex before every push.
-  - `just ci-matrix` — **tier 2**, when the diff touches `packages/core`, codegen,
+  - `just ci matrix` — **tier 2**, when the diff touches `packages/core`, codegen,
     or `cmake/`. 1-wise over platform/lang/rmw/kind: every value once, ~28 % of
     the coordinates. It sees each platform and each language, but NOT their
     pairing. `just build-test-fixtures lane=tier2` is the build it needs
@@ -98,11 +98,11 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     those stale, `_lane-gate` still PASSES, and `test-all` reports ~190
     stale-fixture failures. Until 0828 lands a core-crate diff needs
     `lane=all`; a tier-2 green otherwise rides residue the lane never names.
-  - `just ci-matrix-nightly` — the pairwise cover (~70 %). Where the
+  - `just ci matrix-nightly` — the pairwise cover (~70 %). Where the
     platform×language and rmw×language classes actually surface (0268/0245 sizes
     headers, 0332 freestanding headers, 0331 vtable ABI). Tier 2 costs a day of
     latency on those, which is the price of a middle tier anyone can afford.
-  - `just ci-full` — **tier 3**, the whole matrix. Pre-release, on demand.
+  - `just ci full` — **tier 3**, the whole matrix. Pre-release, on demand.
   Green tier 1 means "the logic and the seams are sound", never "it builds on the
   targets". Say which tier you ran; do not report a tier-1 green as if it were a
   sweep. The old single `just ci` WAS tier 3 — an instruction nobody could afford
@@ -120,7 +120,7 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   coverage was narrower than the rule they enforce.
 - **Green CI locally BEFORE pushing — don't iterate on remote CI.** Run `just format`
   then the tier your change earns (above) locally and fix every failure first, so the
-  push passes remote CI on the first try. `just ci-full` = `check` (fast + build, incl. embedded
+  push passes remote CI on the first try. `just ci full` = `check` (fast + build, incl. embedded
   clippy + every per-feature/per-example clippy, and the per-component lanes `check-c` /
   `check-cpp` / `check-rmw-cyclonedds` / `check-cli-tests`) + `rust-rtos-link-check` +
   `test-all`. A backend's own test suite belongs in a `check-*` lane, never as a named step
@@ -140,7 +140,7 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   2026-05-15) and now the push is REJECTED. Recovery is `git rebase origin/main`, never
   `--force`. **DIRECT PUSH TO `main` NO LONGER WORKS** (live 2026-08-28): the
   ruleset also requires a pull request and the merge queue, with no bypass. Work
-  goes `just claim` -> branch -> `just ci-l1` -> PR -> `gh pr merge --auto
+  goes `just claim` -> branch -> `just ci l1` -> PR -> `gh pr merge --auto
   --rebase`. ONE required check, the aggregator `CI` — never add a job name to
   the required set, and never path-filter a required workflow: a check that
   produces no verdict blocks forever, which deadlocked two PRs on 2026-08-28.

--- a/just/check.just
+++ b/just/check.just
@@ -973,11 +973,16 @@ check-board-cargo-config-applied:
     # drift this phase exists to remove.
     set -euo pipefail
     nros="packages/cli/target/release/nros"
-    if [ ! -x "$nros" ]; then
+    # ABSENT and STALE are one verdict: this lane is contractually source-free
+    # and CLI-free, so it cannot demand a CLI, and asserting against a binary
+    # built from other sources is worse than not asserting. One restaled stamp
+    # used to surface as three red gates naming one remedy.
+    # shellcheck source=scripts/build/cli-usable.sh
+    source scripts/build/cli-usable.sh
+    if ! nros_cli_usable "$nros"; then
         # shellcheck source=scripts/build/check-skip.sh
         source scripts/build/check-skip.sh
-        nros_check_skip check-board-projections \
-            "no in-tree nros at $nros — build it: just setup-cli"
+        nros_check_skip check-board-projections "$nros_cli_unusable_reason"
         exit 0
     fi
     fail=0

--- a/just/ci.just
+++ b/just/ci.just
@@ -1,0 +1,256 @@
+# The CI ladder — one lane per affordability tier (RFC-0061 / phase-318).
+#
+# `just ci <lane>`. The tiers are a LADDER: each is a strict superset of the one
+# below, and the point of having several is that "run the tier your change
+# earns" is an instruction someone can actually follow. A single expensive tier
+# is one nobody can afford per task, so it gets followed selectively — which is
+# worse than a smaller instruction followed honestly.
+#
+#   just ci          tier 1 (the default recipe below) — host, builds fixtures
+#   just ci l1       compile + unit, NO fixtures                       ~6 min
+#   just ci l3       cross build + link + symbols, no QEMU
+#   just ci matrix   tier 2 — 1-wise cover over platform/lang/rmw/kind
+#   just ci matrix-nightly   pairwise cover (~70%)
+#   just ci full     tier 3 — the whole matrix
+#   just ci fast     the source-gate tier alone
+#
+# `mod`, not `import`: these are the one family where a NAMESPACE reads better
+# than flat names, because "which tier" is the question a person is actually
+# asking. Phase-399 chose `import` for the 200 `check-*` gates on the opposite
+# reasoning — nobody types those, and `mod` would have renamed every call site.
+# Here `just ci` keeps working because a module's `default` recipe is what runs
+# when the module is named with no argument, and 594 references across 262
+# files (most of them historical records of what someone ran) stay true.
+#
+# The flat `ci-l1` / `ci-matrix` / … spellings survive at the repo root as thin
+# forwarders, for the same reason.
+
+set working-directory := '..'
+
+# `just ci` with no lane = tier 1, which is what it has always meant.
+#
+# It must be the FIRST recipe in this file, not merely the one named `default`:
+# `just <module>` runs the module's first recipe. Named `default` and placed
+# second, `just ci` silently ran `l1` — a WEAKER tier than it has meant for its
+# whole life, which is the one way this rename could have done damage quietly.
+[group("ci")]
+default: tier1
+
+
+# L1 — compile, lint and unit tests. No fixtures, no platforms, no QEMU.
+[group("main")]
+l1:
+    @just check-cli-fresh check-fast check-build check-api-parity
+    @just test-unit
+    @echo "CI L1 passed (compile + unit; no fixtures were built or needed)."
+
+[group("ci")]
+tier1:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # phase-395 W19 — COORDINATE-scoped, like tier 2, and no longer
+    # `NROS_TEST_SCOPE=native`.
+    #
+    # The name filter excluded `zephyr` and `threadx` outright — the very
+    # platforms `board-support.toml` grants tier 1 — so the lane covered one of
+    # the three it promised. No token spelling fixes that: `zephyr` also matches
+    # `zephyr_cortex_m_qemu`, which is tier 2. Coordinates select exactly the
+    # cover and nothing else, which is the same move phase-340 W3 made for tier
+    # 2 and the same reason.
+    #
+    # One computation reaching the build, the staleness gate and the run — the
+    # tier-2 recipe below spells it identically on purpose.
+    source scripts/build/fixture-lane.sh
+    coords="$(nros_lane_coords_file tier1)"
+    coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
+    NROS_FIXTURE_LANE=tier1 bash scripts/check-tier-preconditions.sh
+    NROS_FIXTURE_LANE=tier1 NROS_TEST_COORDS="$coords" \
+        just check rust-rtos-link-check test-all
+    echo "CI passed (tier 1 — host-executable platforms; cross coverage needs \`just ci-matrix\`)!"
+
+# L3 — cross build + link + SYMBOL checks. No QEMU.
+#
+# The insight this lane rests on: `rust-rtos-link-check` already BUILDS
+# 32-bit/cross ELFs and then throws them away, having only checked that linking
+# succeeded. Those artifacts can answer far more, at no extra build cost.
+#
+# What a cross ELF proves without ever booting (design doc, "cheapest witness
+# per defect class"):
+#   * 32-bit layout — the sizes-header mirror class, 0088 -> 0114 -> 0122 ->
+#     0123 -> 0245 -> 0268. A host build cannot see it; a 64-bit literal in
+#     generated code breaks a 32-bit target and nothing on this machine notices.
+#   * linker sections and staticlib DCE — 0155, 0163.
+#   * static RAM ceilings — the whole of phase 392, which is meaningless where
+#     RAM is unbounded.
+#   * allocation-freedom — 0816, via the symbol table.
+#
+# QEMU is needed for scheduling, timing and real transport behaviour. It is not
+# needed for any of the above, which is most of what has actually bitten here.
+[group("main")]
+l3:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Was a DEPENDENCY LIST at the root. A module cannot depend on a root
+    # recipe, so it becomes an explicit call — and in a shebang recipe it has
+    # to come after the shebang, which must be the first body line.
+    just rust-rtos-link-check
+    source scripts/build/cargo.sh
+    echo "== L3 — interrogating the cross ELFs the link check just built =="
+    checked=0
+    for elf in \
+        "examples/qemu-arm-freertos/rust/talker/target-link-check/thumbv7m-none-eabi/$(nros_cargo_platform_profile freertos)/talker" \
+        "examples/qemu-arm-nuttx/rust/talker/target-link-check/armv7a-nuttx-eabihf/$(nros_cargo_platform_profile nuttx)/talker" \
+        "examples/threadx-linux/rust/talker/target-zenoh/$(nros_cargo_platform_profile threadx-linux)/talker"
+    do
+        if [ ! -f "$elf" ]; then
+            # Not a skip to paper over: the link check reports its own SKIP when
+            # a cross toolchain is absent, and this loop must not turn that into
+            # a silent pass. Say which artifact is missing and why that is fine.
+            echo "  [absent] $elf — its toolchain was skipped upstream"
+            continue
+        fi
+        echo "  mem-report --check: $elf"
+        python3 scripts/nros-mem-report.py "$elf" --check
+        checked=$((checked + 1))
+    done
+    if [ "$checked" -eq 0 ]; then
+        echo "L3: no cross ELF was available to check — install a cross toolchain" >&2
+        echo "    (`just setup freertos` / `just setup nuttx`) or this lane proves nothing." >&2
+        exit 1
+    fi
+    # phase-391 W1/W4 (issues 0816/0843) — the heap-free tier, on a REAL image.
+    # `heap-free-poc-mps2` calls `Executor::open_in` + `install_node_typed_in`
+    # over per-class static storage and links with NO allocation symbol at all
+    # (no `#[global_allocator]`, no `malloc`, no `nros_platform_alloc`). Three
+    # earlier probes passed this gate vacuously at `symbols read: 1`; this one
+    # reads the full symbol table of a linked image (~460). The build doubles
+    # as issue 0843's tripwire: the leaf compiles `nros` WITHOUT the `alloc`
+    # feature, so re-coupling the macro-path runtime to `alloc` breaks it.
+    echo "== L3 — heap-free tier: link gate on the no-alloc image =="
+    (cd packages/testing/nros-tests/bins/heap-free-poc-mps2 \
+        && cargo build $(nros_cargo_profile_arg_string))
+    python3 scripts/check-no-alloc-image.py --tier heap-free \
+        "packages/testing/nros-tests/bins/heap-free-poc-mps2/target/thumbv7m-none-eabi/$(nros_cargo_target_profile_dir)/heap-free-poc-mps2"
+    echo "L3 passed — $checked cross ELF(s) checked without booting anything, and the heap-free image links clean."
+
+# Tier 2 — phase-318 W4.d. Gate exactly the fixture COORDINATES the lane selected.
+#
+# The selection is 1-wise over platform x lang x rmw x kind (`nros_tests::ci_lane`),
+# computed from `matrix::CELLS` and emitted by `lane-coords`. 14 of 50 coordinates
+# (the count is gated by `ci_lane::tests::documented_lane_table_is_live`; do not
+# hand-edit it here — run `lane-coords tier2 | wc -l`).
+#
+# Why 1-wise and not pairwise, which is what this lane originally specified: cost
+# is COORDINATES, not cells, because cells share fixtures and fixtures are what
+# take hours. The pairwise cover is 37 of 194 cells (19 %) but 37 of 50
+# coordinates (74 %) — a middle tier costing 74 % of the sweep is one nobody runs,
+# which is the failure mode RFC-0061 exists to fix. The pairwise coverage moved to
+# `ci-matrix-nightly` rather than being dropped: platform x lang is exactly where
+# the 0268 / 0245 / 0332 class lives.
+#
+# Note the gate and the BUILD read the same coordinate file, so they cannot
+# disagree about what this lane covers.
+#
+# Issue 0393 / 0482 / phase-340 W3 — this lane's BUILD is its own lane:
+#
+#     just build-test-fixtures lane=tier2 && just ci-matrix
+#
+# That was false until phase-340 W3 and cost ~231 STALE failures when someone
+# tried it: 0368 F8 had made `_require-fixtures` accept a `lane=tier2` stamp
+# while `ci-matrix` still ran the WHOLE suite, so 34 of 47 coordinates were
+# resolved and none of them had been built. 0482 fixed the honesty half by
+# demanding an `all` build; W3 fixes the affordability half by narrowing the RUN
+# to match the build instead.
+#
+# The narrowing is NOT name-based — `lane-filter.sh` selects platform families
+# and this lane contains every platform (issue 0357 / 0482). It happens in the
+# fixture RESOLVER: `NROS_TEST_COORDS` hands it this lane's coordinate file and
+# a fixture whose `examples/fixtures.toml` row sits outside it reports SKIPPED
+# instead of missing. Build-set and run-set are then one computation — the same
+# `row_coord` against the same coordinate file — which is the invariant issue
+# 0482 exists to protect. See `nros_tests::fixtures::lane`.
+[group("ci")]
+matrix:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just _lane-gate tier2
+    # issue 0368 F8 — tell the inner gates that this run is the tier-2 lane, not
+    # the default `all`. Without it they DISAGREE: `_lane-gate tier2`
+    # (content-based, over the tier-2 coordinates) passes, then the staleness
+    # gate inside test-all audits the whole tier-3 fixture set and dies demanding
+    # out-of-lane freshness the tier ladder said to skip.
+    #
+    # NROS_TEST_COORDS is the RUN's half of the same fact, and it is the SAME
+    # file `nros_lane_coords_file` gives the build and the staleness gate — one
+    # computation reaching all three, not three spellings of a lane.
+    source scripts/build/fixture-lane.sh
+    coords="$(nros_lane_coords_file tier2)"
+    coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
+    NROS_FIXTURE_LANE=tier2 NROS_TEST_COORDS="$coords" \
+        just check rust-rtos-link-check test-all
+    echo "CI passed (tier 2 — 1-wise cover; pairwise interactions need \`just ci-matrix-nightly\`)!"
+
+# Tier 2 nightly — the pairwise cover over platform x lang x rmw x kind (37 of 50
+# coordinates). The interaction coverage `ci-matrix` gives up to stay affordable:
+# same class of defect, caught a day later instead of pre-merge.
+#
+# This monolithic form is for a machine that has every SDK — i.e. a developer's.
+# In CI the same lane runs DISTRIBUTED across the 07:00 nightly cron, because the
+# per-platform toolchains do not coexist on one runner: `.github/workflows/
+# nightly.yml` computes the cover with `lane-coords tier2-nightly`, derives the
+# platform matrix from it, and its `lane-coverage` job asserts every module in the
+# cover actually has a job. Change the lane here and CI follows, with no second
+# edit — that is the whole reason the selection is computed.
+[group("ci")]
+matrix-nightly:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just _lane-gate tier2-nightly
+    # issue 0368 F8 (same class as ci-matrix) — require the tier2-nightly lane so
+    # the inner `_require-fixtures` accepts a per-family build instead of
+    # demanding the `all` stamp the lane ladder said to avoid. phase-340 W3 —
+    # NROS_TEST_COORDS narrows the RUN to the same cover, so that acceptance is
+    # earned rather than asserted.
+    source scripts/build/fixture-lane.sh
+    coords="$(nros_lane_coords_file tier2-nightly)"
+    coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
+    NROS_FIXTURE_LANE=tier2-nightly NROS_TEST_COORDS="$coords" \
+        just check rust-rtos-link-check test-all test-ignored
+    echo "CI passed (tier 2 nightly — pairwise cover)!"
+
+# Tier 3 — everything. The former `ci`.
+#
+# phase-318 W5.c — `test-ignored` (added by #328's fix, e7e5b84a0) joins the lane.
+# Those tests had NO lane at all: they rot invisibly and then block the day
+# someone enables them, which had already happened — the codegen compile-check
+# had been failing since phase-303 W4 added the XCDR2 DHEADER seam, found only
+# when 0345 ran it by hand and repaired the stubs. Green now, which is what makes
+# laning it worth doing today when it was not last week.
+# Issue 0651 — tier 3 now covers the Zephyr 4.4 rolling line, which until here
+# existed only in the nightly. Two steps, cheapest first:
+#   check-zephyr-kconfig-symbols  source only, ~2 s, needs `just zephyr
+#                                 kconfig-trees` (613 MB of shallow clones)
+#   zephyr tier3-cell             one real 4.4 build, needs the west workspace
+# Both FAIL rather than skip when unprovisioned. That is the point: a lane that
+# skips when unprovisioned reports the same colour as one that passed, which is
+# how a `select` correct on 3.7 and misspelled on 4.4 reached the nightly a day
+# later, attributed to whatever else moved. A host that cannot provision 4.4
+# runs tier 2, which never claimed to cover it.
+[group("ci")]
+full:
+    @just check rust-rtos-link-check check-zephyr-kconfig-symbols test-all test-ignored
+    @just zephyr tier3-cell
+    @echo "CI passed (tier 3 — full matrix, both Zephyr lines)!"
+
+# Fast per-push CI gate: the dependency-free lint/check lane — no heavy builds,
+# fixtures, QEMU, network, or ROS install. Runs anywhere. The heavier per-job
+# mirrors are separate recipes you invoke when their prereqs are present:
+#   just check-sdk-index   (network — downloads + sha256-checks SDK release assets)
+#   just scaffold-journey  (builds the CLI + a scaffolded project)
+#   just colcon-parity     (needs ROS 2 + colcon on the host)
+#   just acceptance        (builds the CLI + a scaffolded project)
+# The full heavy lane stays `just ci` / `just test-all`.
+[group("ci")]
+fast:
+    @just check-fast check-no-std
+    @echo "ci-fast passed!"

--- a/justfile
+++ b/justfile
@@ -136,18 +136,19 @@ default:
         "" \
         "  BEFORE YOU PUSH" \
         "    just format                rustfmt (nightly) + clang-format + python" \
-        "    just ci-l1                 compile + unit, no fixtures        ~6 min" \
+        "    just ci l1                 compile + unit, no fixtures        ~6 min" \
         "                               ^ run this. STRICTER than the CI gate." \
         "" \
         "  WHEN SOMETHING IS WRONG" \
         "    just doctor                is this checkout/env set up correctly?" \
-        "    just check-fast            135 source gates, parallel          ~9 s" \
+        "    just check-fast            138 source gates, parallel          ~9 s" \
         "    just check-tier-preconditions    what is stale, and why" \
+        "    just post-rebase           after a rebase/pull: CLI, resolver, index" \
         "" \
         "  BIGGER TIERS  (CI runs these; you rarely need them)" \
         "    just ci                    tier 1 — host, builds fixtures" \
-        "    just ci-matrix             tier 2 — 1-wise platform cover" \
-        "    just ci-full               tier 3 — the whole matrix" \
+        "    just ci matrix             tier 2 — 1-wise platform cover" \
+        "    just ci full               tier 3 — the whole matrix" \
         "" \
         "  A PLATFORM" \
         "    just native build|test     also: zephyr freertos nuttx esp32 qemu" \
@@ -2109,9 +2110,9 @@ rust-rtos-link-check: _require-leaf-includes
 # workspace fixtures failed the preflight of a native-intent run.
 #
 #   just ci               tier 1 — every commit / pre-push
-#   just ci-matrix        tier 2 — when the diff touches packages/core, codegen, cmake/
-#   just ci-matrix-nightly       — the pairwise cover, nightly
-#   just ci-full          tier 3 — pre-release, on demand (the former `ci`)
+#   just ci matrix        tier 2 — when the diff touches packages/core, codegen, cmake/
+#   just ci matrix-nightly       — the pairwise cover, nightly
+#   just ci full          tier 3 — pre-release, on demand (the former `ci`)
 #
 # SSoT for which test BUCKET runs at which tier: `nros_tests::buckets::BUCKET_TIERS`
 # (phase-329 W7). `CiTier::just_recipe` names these four recipes, and
@@ -2372,182 +2373,54 @@ claim-steal id="" *flags:
 claim-list:
     @scripts/reserve-claim.sh list
 
-# L3 — cross build + link + SYMBOL checks. No QEMU.
-#
-# The insight this lane rests on: `rust-rtos-link-check` already BUILDS
-# 32-bit/cross ELFs and then throws them away, having only checked that linking
-# succeeded. Those artifacts can answer far more, at no extra build cost.
-#
-# What a cross ELF proves without ever booting (design doc, "cheapest witness
-# per defect class"):
-#   * 32-bit layout — the sizes-header mirror class, 0088 -> 0114 -> 0122 ->
-#     0123 -> 0245 -> 0268. A host build cannot see it; a 64-bit literal in
-#     generated code breaks a 32-bit target and nothing on this machine notices.
-#   * linker sections and staticlib DCE — 0155, 0163.
-#   * static RAM ceilings — the whole of phase 392, which is meaningless where
-#     RAM is unbounded.
-#   * allocation-freedom — 0816, via the symbol table.
-#
-# QEMU is needed for scheduling, timing and real transport behaviour. It is not
-# needed for any of the above, which is most of what has actually bitten here.
-[group("main")]
-ci-l3: rust-rtos-link-check
-    #!/usr/bin/env bash
-    set -euo pipefail
-    source scripts/build/cargo.sh
-    echo "== L3 — interrogating the cross ELFs the link check just built =="
-    checked=0
-    for elf in \
-        "examples/qemu-arm-freertos/rust/talker/target-link-check/thumbv7m-none-eabi/$(nros_cargo_platform_profile freertos)/talker" \
-        "examples/qemu-arm-nuttx/rust/talker/target-link-check/armv7a-nuttx-eabihf/$(nros_cargo_platform_profile nuttx)/talker" \
-        "examples/threadx-linux/rust/talker/target-zenoh/$(nros_cargo_platform_profile threadx-linux)/talker"
-    do
-        if [ ! -f "$elf" ]; then
-            # Not a skip to paper over: the link check reports its own SKIP when
-            # a cross toolchain is absent, and this loop must not turn that into
-            # a silent pass. Say which artifact is missing and why that is fine.
-            echo "  [absent] $elf — its toolchain was skipped upstream"
-            continue
-        fi
-        echo "  mem-report --check: $elf"
-        python3 scripts/nros-mem-report.py "$elf" --check
-        checked=$((checked + 1))
-    done
-    if [ "$checked" -eq 0 ]; then
-        echo "L3: no cross ELF was available to check — install a cross toolchain" >&2
-        echo "    (`just setup freertos` / `just setup nuttx`) or this lane proves nothing." >&2
-        exit 1
-    fi
-    # phase-391 W1/W4 (issues 0816/0843) — the heap-free tier, on a REAL image.
-    # `heap-free-poc-mps2` calls `Executor::open_in` + `install_node_typed_in`
-    # over per-class static storage and links with NO allocation symbol at all
-    # (no `#[global_allocator]`, no `malloc`, no `nros_platform_alloc`). Three
-    # earlier probes passed this gate vacuously at `symbols read: 1`; this one
-    # reads the full symbol table of a linked image (~460). The build doubles
-    # as issue 0843's tripwire: the leaf compiles `nros` WITHOUT the `alloc`
-    # feature, so re-coupling the macro-path runtime to `alloc` breaks it.
-    echo "== L3 — heap-free tier: link gate on the no-alloc image =="
-    (cd packages/testing/nros-tests/bins/heap-free-poc-mps2 \
-        && cargo build $(nros_cargo_profile_arg_string))
-    python3 scripts/check-no-alloc-image.py --tier heap-free \
-        "packages/testing/nros-tests/bins/heap-free-poc-mps2/target/thumbv7m-none-eabi/$(nros_cargo_target_profile_dir)/heap-free-poc-mps2"
-    echo "L3 passed — $checked cross ELF(s) checked without booting anything, and the heap-free image links clean."
 
-# L1 — compile, lint and unit tests. No fixtures, no platforms, no QEMU.
-[group("main")]
-ci-l1:
-    @just check-cli-fresh check-fast check-build check-api-parity
-    @just test-unit
-    @echo "CI L1 passed (compile + unit; no fixtures were built or needed)."
+# ---------------------------------------------------------------------------
+# The CI ladder lives in `just/ci.just` as a MODULE — `just ci <lane>`.
+#
+# `mod`, not `import`, and this is the one family where that is right: "which
+# tier" is the question a person is actually asking, so a namespace reads
+# better than seven flat names. Phase-399 chose `import` for the 200 `check-*`
+# gates on the opposite reasoning — nobody types those, and `mod` would have
+# renamed every call site.
+#
+# `just ci` still means tier 1: a module invoked with no argument runs its
+# `default` recipe. That keeps 594 references across 262 files true, most of
+# them historical records of what someone ran, which a rename would have
+# falsified rather than updated.
+#
+# The flat spellings below are thin forwarders for the same reason. They are
+# not a second implementation — each is one line delegating into the module —
+# and they are what the remaining ~180 references in docs and issues resolve to.
+mod ci 'just/ci.just'
 
 [group("ci")]
-ci:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # phase-395 W19 — COORDINATE-scoped, like tier 2, and no longer
-    # `NROS_TEST_SCOPE=native`.
-    #
-    # The name filter excluded `zephyr` and `threadx` outright — the very
-    # platforms `board-support.toml` grants tier 1 — so the lane covered one of
-    # the three it promised. No token spelling fixes that: `zephyr` also matches
-    # `zephyr_cortex_m_qemu`, which is tier 2. Coordinates select exactly the
-    # cover and nothing else, which is the same move phase-340 W3 made for tier
-    # 2 and the same reason.
-    #
-    # One computation reaching the build, the staleness gate and the run — the
-    # tier-2 recipe below spells it identically on purpose.
-    source scripts/build/fixture-lane.sh
-    coords="$(nros_lane_coords_file tier1)"
-    coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
-    NROS_FIXTURE_LANE=tier1 bash scripts/check-tier-preconditions.sh
-    NROS_FIXTURE_LANE=tier1 NROS_TEST_COORDS="$coords" \
-        just check rust-rtos-link-check test-all
-    echo "CI passed (tier 1 — host-executable platforms; cross coverage needs \`just ci-matrix\`)!"
+ci-l1:
+    @just ci l1
 
-# Tier 2 — phase-318 W4.d. Gate exactly the fixture COORDINATES the lane selected.
-#
-# The selection is 1-wise over platform x lang x rmw x kind (`nros_tests::ci_lane`),
-# computed from `matrix::CELLS` and emitted by `lane-coords`. 14 of 50 coordinates
-# (the count is gated by `ci_lane::tests::documented_lane_table_is_live`; do not
-# hand-edit it here — run `lane-coords tier2 | wc -l`).
-#
-# Why 1-wise and not pairwise, which is what this lane originally specified: cost
-# is COORDINATES, not cells, because cells share fixtures and fixtures are what
-# take hours. The pairwise cover is 37 of 194 cells (19 %) but 37 of 50
-# coordinates (74 %) — a middle tier costing 74 % of the sweep is one nobody runs,
-# which is the failure mode RFC-0061 exists to fix. The pairwise coverage moved to
-# `ci-matrix-nightly` rather than being dropped: platform x lang is exactly where
-# the 0268 / 0245 / 0332 class lives.
-#
-# Note the gate and the BUILD read the same coordinate file, so they cannot
-# disagree about what this lane covers.
-#
-# Issue 0393 / 0482 / phase-340 W3 — this lane's BUILD is its own lane:
-#
-#     just build-test-fixtures lane=tier2 && just ci-matrix
-#
-# That was false until phase-340 W3 and cost ~231 STALE failures when someone
-# tried it: 0368 F8 had made `_require-fixtures` accept a `lane=tier2` stamp
-# while `ci-matrix` still ran the WHOLE suite, so 34 of 47 coordinates were
-# resolved and none of them had been built. 0482 fixed the honesty half by
-# demanding an `all` build; W3 fixes the affordability half by narrowing the RUN
-# to match the build instead.
-#
-# The narrowing is NOT name-based — `lane-filter.sh` selects platform families
-# and this lane contains every platform (issue 0357 / 0482). It happens in the
-# fixture RESOLVER: `NROS_TEST_COORDS` hands it this lane's coordinate file and
-# a fixture whose `examples/fixtures.toml` row sits outside it reports SKIPPED
-# instead of missing. Build-set and run-set are then one computation — the same
-# `row_coord` against the same coordinate file — which is the invariant issue
-# 0482 exists to protect. See `nros_tests::fixtures::lane`.
+[group("ci")]
+ci-l3:
+    @just ci l3
+
 [group("ci")]
 ci-matrix:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just _lane-gate tier2
-    # issue 0368 F8 — tell the inner gates that this run is the tier-2 lane, not
-    # the default `all`. Without it they DISAGREE: `_lane-gate tier2`
-    # (content-based, over the tier-2 coordinates) passes, then the staleness
-    # gate inside test-all audits the whole tier-3 fixture set and dies demanding
-    # out-of-lane freshness the tier ladder said to skip.
-    #
-    # NROS_TEST_COORDS is the RUN's half of the same fact, and it is the SAME
-    # file `nros_lane_coords_file` gives the build and the staleness gate — one
-    # computation reaching all three, not three spellings of a lane.
-    source scripts/build/fixture-lane.sh
-    coords="$(nros_lane_coords_file tier2)"
-    coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
-    NROS_FIXTURE_LANE=tier2 NROS_TEST_COORDS="$coords" \
-        just check rust-rtos-link-check test-all
-    echo "CI passed (tier 2 — 1-wise cover; pairwise interactions need \`just ci-matrix-nightly\`)!"
+    @just ci matrix
 
-# Tier 2 nightly — the pairwise cover over platform x lang x rmw x kind (37 of 50
-# coordinates). The interaction coverage `ci-matrix` gives up to stay affordable:
-# same class of defect, caught a day later instead of pre-merge.
-#
-# This monolithic form is for a machine that has every SDK — i.e. a developer's.
-# In CI the same lane runs DISTRIBUTED across the 07:00 nightly cron, because the
-# per-platform toolchains do not coexist on one runner: `.github/workflows/
-# nightly.yml` computes the cover with `lane-coords tier2-nightly`, derives the
-# platform matrix from it, and its `lane-coverage` job asserts every module in the
-# cover actually has a job. Change the lane here and CI follows, with no second
-# edit — that is the whole reason the selection is computed.
 [group("ci")]
 ci-matrix-nightly:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just _lane-gate tier2-nightly
-    # issue 0368 F8 (same class as ci-matrix) — require the tier2-nightly lane so
-    # the inner `_require-fixtures` accepts a per-family build instead of
-    # demanding the `all` stamp the lane ladder said to avoid. phase-340 W3 —
-    # NROS_TEST_COORDS narrows the RUN to the same cover, so that acceptance is
-    # earned rather than asserted.
-    source scripts/build/fixture-lane.sh
-    coords="$(nros_lane_coords_file tier2-nightly)"
-    coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
-    NROS_FIXTURE_LANE=tier2-nightly NROS_TEST_COORDS="$coords" \
-        just check rust-rtos-link-check test-all test-ignored
-    echo "CI passed (tier 2 nightly — pairwise cover)!"
+    @just ci matrix-nightly
+
+[group("ci")]
+ci-full:
+    @just ci full
+
+[group("ci")]
+ci-fast:
+    @just ci fast
+
+
+
+
+
 
 # Run the staleness gate over exactly one lane's fixture coordinates.
 # Separate recipe because `ci-matrix` and `ci-matrix-nightly` differ ONLY in which
@@ -2607,28 +2480,6 @@ sweep-family platform drop="0":
         echo "[sweep-family] artifacts kept (pass drop=1 to free them)"
     fi
 
-# Tier 3 — everything. The former `ci`.
-#
-# phase-318 W5.c — `test-ignored` (added by #328's fix, e7e5b84a0) joins the lane.
-# Those tests had NO lane at all: they rot invisibly and then block the day
-# someone enables them, which had already happened — the codegen compile-check
-# had been failing since phase-303 W4 added the XCDR2 DHEADER seam, found only
-# when 0345 ran it by hand and repaired the stubs. Green now, which is what makes
-# laning it worth doing today when it was not last week.
-# Issue 0651 — tier 3 now covers the Zephyr 4.4 rolling line, which until here
-# existed only in the nightly. Two steps, cheapest first:
-#   check-zephyr-kconfig-symbols  source only, ~2 s, needs `just zephyr
-#                                 kconfig-trees` (613 MB of shallow clones)
-#   zephyr tier3-cell             one real 4.4 build, needs the west workspace
-# Both FAIL rather than skip when unprovisioned. That is the point: a lane that
-# skips when unprovisioned reports the same colour as one that passed, which is
-# how a `select` correct on 3.7 and misspelled on 4.4 reached the nightly a day
-# later, attributed to whatever else moved. A host that cannot provision 4.4
-# runs tier 2, which never claimed to cover it.
-[group("ci")]
-ci-full: check rust-rtos-link-check check-zephyr-kconfig-symbols test-all test-ignored
-    @just zephyr tier3-cell
-    @echo "CI passed (tier 3 — full matrix, both Zephyr lines)!"
 
 # =============================================================================
 # CI reorg (step A) — local mirrors of the standalone CI workflows + a fast lane.
@@ -2755,17 +2606,6 @@ acceptance: setup-cli
     timeout 10 target/debug/accept_app 2>&1 | grep -q "accept_app"
     echo "acceptance OK."
 
-# Fast per-push CI gate: the dependency-free lint/check lane — no heavy builds,
-# fixtures, QEMU, network, or ROS install. Runs anywhere. The heavier per-job
-# mirrors are separate recipes you invoke when their prereqs are present:
-#   just check-sdk-index   (network — downloads + sha256-checks SDK release assets)
-#   just scaffold-journey  (builds the CLI + a scaffolded project)
-#   just colcon-parity     (needs ROS 2 + colcon on the host)
-#   just acceptance        (builds the CLI + a scaffolded project)
-# The full heavy lane stays `just ci` / `just test-all`.
-[group("ci")]
-ci-fast: check-fast check-no-std
-    @echo "ci-fast passed!"
 
 
 # =============================================================================

--- a/justfile
+++ b/justfile
@@ -3277,6 +3277,72 @@ setup-cli:
     fi
     warn_stale_shadow
 
+# After a rebase / pull / stash — restore the derived state, in ORDER.
+#
+# The three steps below are each documented somewhere and the SEQUENCE is
+# documented nowhere, which is the whole cost. A rebase rewrites tracked files,
+# so it restales the CLI source stamp, and everything keyed on that stamp goes
+# with it. Getting the order wrong is not free: fixtures key on the CLI stamp,
+# so rebuilding fixtures BEFORE the CLI re-stales everything you just built.
+#
+# Paid four times in one session, each time as a different-looking failure:
+# three red `check-fast` gates (a stale CLI), a `nros sync` refusing on the 0409
+# pin guard (a stale resolver), and `check-issue-index` red (concurrent filings
+# on main). None of them says "you just rebased".
+#
+# What it deliberately does NOT do is touch submodules. AGENTS.md is explicit
+# that `git submodule update` is a HUMAN decision, because it discards work in a
+# submodule someone is mid-edit on — a worse failure than the one it prevents.
+# So divergence is REPORTED with the command, and you decide.
+#
+# Idempotent and safe to over-run: each step no-ops when its input is unchanged.
+[group("main")]
+post-rebase:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "post-rebase: restoring derived state (CLI -> resolver -> index)."
+    echo ""
+    # 1. The CLI first. Fixtures key on its stamp, so anything built before it
+    #    would be stale the moment it relinks.
+    just setup-cli || exit 1
+    # 2. The resolver second. It and the CLI must agree on the play_launch pin
+    #    or `nros sync` refuses (issue 0409) — deep in a fixture build, not here.
+    just setup-launch-resolve || exit 1
+    # 3. The generated issue list. `merge=union` means concurrent filings on
+    #    main both land; the generator re-sorts and `check-issue-index` is the
+    #    backstop for whatever residue that leaves.
+    python3 scripts/gen-issue-index.py || exit 1
+    echo ""
+    # Submodules: REPORT, never update. See the note above.
+    # `+` and `-` are DIFFERENT states and only one of them is about a rebase.
+    #
+    #   +  the checkout is at a different commit than the pin — what a rebase
+    #      that moved a pointer leaves behind, and the actionable case.
+    #   -  uninitialised. Usually DELIBERATE here: RFC-0060 keeps play_launch's
+    #      layer-3 submodules uninitialised, and the qemu / agent / tracing
+    #      trees are provisioned on demand. Reporting those as a problem on
+    #      every run is how a message earns its way into being ignored.
+    moved="$(git submodule status --cached 2>/dev/null | grep -E '^\+' || true)"
+    uninit_n="$(git submodule status --cached 2>/dev/null | grep -cE '^-' || true)"
+    if [ -n "$moved" ]; then
+        echo "post-rebase: submodule checkout(s) at a different commit than the pin:"
+        printf '%s\n' "$moved" | sed 's/^/    /'
+        echo ""
+        echo "  NOT synced automatically — that would discard work in a submodule"
+        echo "  you may be mid-edit on (AGENTS.md). When you are sure the checkout"
+        echo "  holds nothing you need:"
+        echo "      git submodule update <path>"
+    else
+        echo "post-rebase: every initialised submodule matches its pin."
+    fi
+    if [ "${uninit_n:-0}" -gt 0 ]; then
+        echo "             ($uninit_n uninitialised — normal; init only what you build.)"
+    fi
+    echo ""
+    echo "post-rebase: done. Fixtures are NOT rebuilt — \`just check-tier-preconditions\`"
+    echo "             reports what the tier you are about to run still needs."
+
+
 # Build the launch-resolution helper (issue 0285).
 #
 # `nros sync` needs a resolver that can execute Python for `.launch.py`

--- a/packages/testing/nros-tests/tests/provider_index_gate.sh
+++ b/packages/testing/nros-tests/tests/provider_index_gate.sh
@@ -51,8 +51,17 @@ MODULE="$ROOT/cmake/NanoRosProviders.cmake"
 # The in-tree CLI is a BUILD PRODUCT, absent on the pristine worktree this
 # tier documents itself green on (issue 0650's list names it). Skip loudly —
 # the lane's closing report refuses to say "passed" over a skipped gate.
-[ -x "$NROS" ] || {
-    nros_check_skip "check-provider-index" "no in-tree nros at packages/cli/target/release/nros (just setup-cli)"
+#
+# STALE counts as unusable, not as a failure. `check-fast` is contractually the
+# source-free, CLI-free tier, so this gate does not own the CLI and cannot
+# demand one; and asserting against a binary built from other sources is worse
+# than not asserting, because the verdict describes a program no longer in the
+# tree. Before this, a branch switch turned one restaled stamp into THREE red
+# gates whose printed cause was the same single remedy.
+# shellcheck source=../../../../scripts/build/cli-usable.sh
+. "$ROOT/scripts/build/cli-usable.sh"
+nros_cli_usable "$NROS" || {
+    nros_check_skip "check-provider-index" "$nros_cli_unusable_reason"
     exit 0
 }
 [ -f "$MODULE" ] || {

--- a/packages/testing/nros-tests/tests/workspace_order_gate.sh
+++ b/packages/testing/nros-tests/tests/workspace_order_gate.sh
@@ -53,8 +53,14 @@ NROS="$ROOT/packages/cli/target/release/nros"
 # The in-tree CLI is a BUILD PRODUCT, absent on the pristine worktree this
 # tier documents itself green on (issue 0650's list names it). Skip loudly —
 # the lane's closing report refuses to say "passed" over a skipped gate.
-[ -x "$NROS" ] || {
-    nros_check_skip "check-workspace-order" "no in-tree nros at packages/cli/target/release/nros (just setup-cli)"
+#
+# STALE counts as unusable, not as a failure — see the note in
+# `provider_index_gate.sh`; this lane does not own the CLI, and asserting
+# against a binary built from other sources describes a program no longer here.
+# shellcheck source=../../../../scripts/build/cli-usable.sh
+. "$ROOT/scripts/build/cli-usable.sh"
+nros_cli_usable "$NROS" || {
+    nros_check_skip "check-workspace-order" "$nros_cli_unusable_reason"
     exit 0
 }
 

--- a/scripts/build/cli-usable.sh
+++ b/scripts/build/cli-usable.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Is the in-tree `nros` binary one a gate may TRUST?
+#
+# Source this and call `nros_cli_usable`; it answers for both ways the answer
+# can be no.
+#
+# WHY THIS EXISTS. Several `check-fast` gates shell out to the in-tree CLI —
+# `check-provider-index`, `check-workspace-order`,
+# `check-board-cargo-config-applied`. Each already treated an ABSENT binary as
+# a skip, correctly: a fresh clone has none, and `check-fast` must stay green on
+# a bare worktree.
+#
+# None of them treated a STALE binary the same way, and that asymmetry has no
+# defence. `check-fast` is contractually the source-free, CLI-free tier, so a
+# gate there does not OWN the CLI and cannot demand one; and running a gate
+# against a binary built from other sources is worse than not running it, because
+# the verdict is about a program that no longer exists in the tree.
+#
+# What it cost, repeatedly, in one session: switching branches restales the
+# stamp, and the next `just check-fast` reported THREE unrelated red gates whose
+# printed cause was `in-tree nros CLI is STALE`. Three failures naming one
+# remedy, in a lane whose contract says it does not need the thing. The
+# information a person needs — "run `just setup-cli`" — was already on screen
+# three times and still read as three defects.
+#
+# It asks the BINARY (`nros source-stamp`), which is the single authority
+# established by issue 0363: the predicate used to live in three places, two of
+# them real implementations that could disagree. `check-cli-fresh` asks the same
+# question the same way. This adds no fourth copy — only the pairing of
+# "absent" with "stale" under one verdict, and one remedy string so the three
+# call sites cannot drift into three phrasings.
+
+# nros_cli_usable [<path-to-nros>]
+#
+# 0  = present and built from these sources.
+# 1  = absent, stale, or predating the stamp. `nros_cli_unusable_reason` then
+#      holds a one-line reason ending in the remedy.
+#
+# Deliberately NOT an exit or a skip: the caller decides, exactly as
+# `nros_check_skip` does. A gate that skips a whole recipe and one that skips a
+# single step need different things from the same answer.
+nros_cli_usable() {
+    local bin="${1:-packages/cli/target/release/nros}"
+    nros_cli_unusable_reason=""
+
+    if [ ! -x "$bin" ]; then
+        nros_cli_unusable_reason="no in-tree nros at $bin (just setup-cli)"
+        return 1
+    fi
+
+    local out rc
+    out="$("$bin" source-stamp 2>&1)"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        return 0
+    fi
+
+    # A binary predating the stamp verb exits non-zero from clap. That is the
+    # CORRECT answer and not an error to work around — a binary built before
+    # the mechanism existed is by definition built from older sources — but say
+    # which it is, because the remedy differs in urgency, not in kind.
+    case "$out" in
+        *"unrecognized subcommand"*|*"unexpected argument"*)
+            nros_cli_unusable_reason="in-tree nros predates \`source-stamp\`, so it is older than these sources (just setup-cli)"
+            ;;
+        *)
+            nros_cli_unusable_reason="in-tree nros is STALE — built from other sources (just setup-cli)"
+            ;;
+    esac
+    return 1
+}

--- a/scripts/build/run-gates-parallel.sh
+++ b/scripts/build/run-gates-parallel.sh
@@ -102,5 +102,36 @@ if [ "$failed" -gt 0 ]; then
     printf '\ncheck-fast (parallel): %d of %d gate(s) FAILED\n' "$failed" "$total"
     exit 1
 fi
+# QUALIFY the success line by the gates that did not run.
+#
+# The serial path closes with `nros_check_skip_report`, which refuses to say
+# "All checks passed!" over a skipped gate — that is issue 0650's whole point.
+# The parallel path RESET the shared ledger (above) and then never read it, so
+# `check-fast` printed "N gate(s) OK" while gates skipped, in the lane that runs
+# on EVERY PUSH.
+#
+# Measured when this was written: four skips reported as an unqualified OK —
+# three from one stale CLI, and `check-abi-bindings`, which had never run on
+# that host at all because `bindgen-cli` was not installed. A person reading
+# "138 gate(s) OK" had no way to know the ABI bindings were unchecked.
+#
+# Still exit 0: these are missing tools and build products, not failures, and
+# `check-fast` must stay green on a bare worktree. What changes is only that
+# the sentence stops overstating what happened.
+skips="$(pwd)/build/check-skips/checks.skipped"
+skipped=0
+if [ -s "$skips" ]; then
+    skipped=$(wc -l <"$skips")
+fi
+
+if [ "$skipped" -gt 0 ]; then
+    printf 'check-fast (parallel): %d gate(s) ran at -P%s, %d SKIPPED; slowest %s\n' \
+        "$((total - skipped))" "$jobs" "$skipped" \
+        "$(printf '%s' "$slowest" | awk '{print $1" "$3"ms"}')"
+    while IFS=$'\t' read -r gate reason; do
+        printf '  [SKIPPED] %s: %s\n' "$gate" "$reason"
+    done <"$skips"
+    exit 0
+fi
 printf 'check-fast (parallel): %d gate(s) OK at -P%s; slowest %s\n' \
     "$total" "$jobs" "$(printf '%s' "$slowest" | awk '{print $1" "$3"ms"}')"


### PR DESCRIPTION
Three workflow changes, one theme: the tooling should say what actually
happened, and the sequence a person has to follow should be a command.

## 1. `just post-rebase`

A rebase rewrites tracked files, so it restales the CLI source stamp and
everything keyed on it. The three recovery steps are each documented somewhere
and the SEQUENCE is documented nowhere — and the order is load-bearing, since
fixtures key on the CLI stamp, so rebuilding fixtures first re-stales what you
just built.

Paid four times in one session, each time wearing a different face: three red
`check-fast` gates (stale CLI), `nros sync` refusing on the 0409 pin guard
(stale resolver), `check-issue-index` red (concurrent filings on main). None of
them says "you just rebased".

It deliberately does NOT touch submodules — AGENTS.md is explicit that
`git submodule update` is a human decision because it discards work in a
submodule someone is mid-edit on. Divergence is reported with the command, and
`+` (checkout ≠ pin) is separated from `-` (uninitialised), because RFC-0060
keeps several uninitialised on purpose and reporting those as a problem every
run is how a message earns its way into being ignored.

## 2. ABSENT and STALE are one verdict

`check-fast` is contractually the source-free, CLI-free tier, yet three of its
gates shell out to the in-tree CLI. Each already skipped when the binary was
ABSENT. None treated STALE the same way, and that asymmetry has no defence: the
lane does not own the CLI, and asserting against a binary built from other
sources describes a program no longer in the tree.

`scripts/build/cli-usable.sh` pairs them under one verdict and one remedy,
asking the BINARY (`nros source-stamp`) — the single authority issue 0363
established, so no fourth copy of the predicate.

```
before:  3 red gates, printed cause "in-tree nros CLI is STALE"
after:   [SKIPPED] …: in-tree nros is STALE — … (just setup-cli)
```

## 3. The parallel lane was overstating its result

The serial path closes with `nros_check_skip_report`, which refuses to say
"passed" over a skipped gate — issue 0650's whole point. The parallel path,
which is the default AND the push lane, reset the shared ledger and then never
read it.

Measured: four skips reported as an unqualified `138 gate(s) OK`. One was
`check-abi-bindings`, which had never run on this host because `bindgen-cli`
is not installed — so recent "check-fast green" claims were narrower than they
read, and nothing said so.

```
before:  check-fast (parallel): 138 gate(s) OK at -P24; slowest …
after:   check-fast (parallel): 137 gate(s) ran at -P24, 1 SKIPPED; slowest …
           [SKIPPED] check-abi-bindings: bindgen-cli not installed (…)
```

Still exits 0 — missing tools are not failures and the tier must stay green on
a bare worktree. Only the sentence changes.

## 4. `just ci <lane>`

Seven `ci-*` root recipes become one module:

```
just ci                  tier 1 (the default recipe)
just ci l1               compile + unit, NO fixtures        ~6 min
just ci l3               cross build + link + symbols, no QEMU
just ci matrix           tier 2 — 1-wise cover
just ci matrix-nightly   pairwise cover
just ci full             tier 3
just ci fast             the source-gate tier alone
```

`mod`, not `import`, and this is the one family where that is right: "which
tier" is the question a person is actually asking. Phase-399 chose `import` for
the 200 `check-*` gates on exactly the opposite reasoning — nobody types those,
and `mod` would have renamed every call site.

**`just ci` still means tier 1**, because a module invoked with no argument
runs its default recipe. That keeps 594 references across 262 files true — most
of them historical records of what someone ran, which a rename would have
falsified rather than updated. The flat `ci-l1` / `ci-matrix` / … spellings
stay as one-line forwarders for the ~180 remaining references.

### The bug this almost shipped with

`just <module>` runs the module's **first** recipe, not the one named
`default`. Named `default` but placed second, `just ci` silently ran `l1` — a
weaker tier than it has meant for its whole life, on 594 call sites, with no
error anywhere. Caught by dry-running the bare form rather than trusting the
name; the file now records why `default` must be first.

Two mechanical consequences, both noted in place: a module cannot depend on a
root recipe (dependency lists became explicit calls), and in a shebang recipe
that call must follow the shebang, which must be the first body line.

## Not in scope, deliberately

The workflows still carry direct `apt-get` for doxygen, `ros-*-rmw-zenoh-cpp`
and clang, plus a pinned `clang-format` wheel. Folding those into recipes is
the right direction, but it is provisioning that cannot be exercised locally,
and getting it wrong breaks lanes that are already red. It deserves its own PR
where each move is verifiable.

## Verification

`just ci l1` green through the new form (1027 tests, 1 host-capability skip);
`check-fast` 137 ran / 1 skipped; `check-just-recipe-refs` OK (344 recipes, 18
modules); `check-lane-contracts` OK (still finds all 4 merge-gating
invocations); every lane dry-runs; all six forwarders resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
