### PR TITLE
fix(ci): workflows stop hand-rolling provisioning, and the board stops assuming zenoh

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -104,15 +104,8 @@ jobs:
       # lanes SKIP and announce it (`check-zenohd-router-skips` enforces that
       # they can), which is a worse result than running them but a far better
       # one than a job that always fails.
-      - name: Provision zenohd (ROS rmw_zenoh_cpp)
-        run: |
-          if apt-get install -y --no-install-recommends "ros-${ROS_DISTRO}-rmw-zenoh-cpp" 2>/dev/null; then
-            echo "installed ros-${ROS_DISTRO}-rmw-zenoh-cpp"
-          else
-            apt-get update -qq || true
-            apt-get install -y --no-install-recommends "ros-${ROS_DISTRO}-rmw-zenoh-cpp" \
-              || echo "::warning::no rmw_zenoh_cpp available — zenoh lanes will skip"
-          fi
+      - name: just ci provision-zenohd
+        run: just ci provision-zenohd
 
       - name: just test-unit
         run: just test-unit
@@ -160,14 +153,8 @@ jobs:
                      --source cyclonedds-src --source nuttx-libc
 
       # `test-integration` spawns zenohd to back the Phase 211/212 host tests.
-      - name: Provision zenohd
-        run: |
-          # See the note on the unit job's provisioning step: `just zenohd setup`
-          # was removed with the vendored router (RFC-0075 / phase-362).
-          apt-get install -y --no-install-recommends "ros-${ROS_DISTRO}-rmw-zenoh-cpp" 2>/dev/null \
-            || { apt-get update -qq || true; apt-get install -y --no-install-recommends \
-                 "ros-${ROS_DISTRO}-rmw-zenoh-cpp" \
-                 || echo "::warning::no rmw_zenoh_cpp available — zenoh lanes will skip"; }
+      - name: just ci provision-zenohd
+        run: just ci provision-zenohd
 
       # Test prerequisites the way a user gets them — via `nros setup` (#25): the
       # patched qemu-system-arm (build/qemu/), the prebuilt Micro-XRCE-DDS Agent

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,8 +203,24 @@ jobs:
         uses: actions/checkout@v4
 
       # ----- shared setup -----
-      - name: Install clang-format (pinned via pypi wheel)
-        run: pip install --no-cache-dir "clang-format==17.0.5"
+      #
+      # `just setup-clang-format`, NOT a pip install with a literal version.
+      #
+      # This step used to be `pip install "clang-format==17.0.5"` while
+      # `.clang-format-version` pinned 17.0.6 — two sources of truth for one
+      # version, already drifted. And they drifted INVISIBLY: the resolver
+      # (`scripts/dev/clang-format.sh`) prefers `build/clang-format/bin/`, which
+      # only the recipe creates, so CI fell through to the PATH copy and printed
+      # `WARN: clang-format 17.0.5 on PATH != pinned 17.0.6` to stderr in a lane
+      # nobody reads unless it fails. Different clang-format versions reformat
+      # differently, so CI was checking a different standard than every local
+      # run.
+      #
+      # The recipe reads the pin, installs project-locally into
+      # `build/clang-format/`, and no-ops when the right version is already
+      # there — so this is also the same command a contributor runs.
+      - name: Provision clang-format (pinned by .clang-format-version)
+        run: just setup-clang-format
 
       # Compiler cache for the COMPILE tier — phase-395. `check-build` compiles
       # the whole workspace from scratch: 587 s of an 878 s gate, measured. Only

--- a/just/ci.just
+++ b/just/ci.just
@@ -250,6 +250,65 @@ full:
 #   just colcon-parity     (needs ROS 2 + colcon on the host)
 #   just acceptance        (builds the CLI + a scaffolded project)
 # The full heavy lane stays `just ci` / `just test-all`.
+# Provision the zenoh router ROS itself ships (RFC-0075 / phase-362).
+#
+# ONE spelling. `host-tests.yml` carried this twice — once as an if/else, once
+# as a `||` chain — in two jobs that need the same thing, which is the second
+# spelling CLAUDE.md warns about wearing CI clothes. There is no `just zenohd
+# setup` any more because the vendored router was deleted; what remains is a
+# distro package, and installing it is the only provisioning step.
+#
+# Absence is NOT a failure: the zenoh lanes SKIP and announce it, and
+# `check-zenohd-router-skips` enforces that they can. A job that always fails
+# is worse than lanes that honestly report what the host lacks.
+#
+# Needs root, which CI has and a workstation should not be asked for — so when
+# it cannot install, it PRINTS the command instead of running `sudo` (CLAUDE.md:
+# never sudo, tell the user).
+[group("ci")]
+provision-zenohd:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    distro="${ROS_DISTRO:-humble}"
+    pkg="ros-${distro}-rmw-zenoh-cpp"
+    if [ -n "$(command -v rmw_zenohd 2>/dev/null)" ] || \
+       ls /opt/ros/"$distro"/lib/rmw_zenoh_cpp/rmw_zenohd >/dev/null 2>&1; then
+        echo "provision-zenohd: $pkg already present"
+        exit 0
+    fi
+    if [ "$(id -u)" != "0" ]; then
+        # The remedy is DERIVED, never hand-written: `ros-rmw-zenoh-cpp` is
+        # declared in `nros-sdk-index.toml` `[prereq.*]`, and `nros setup
+        # --system` composes the native install command for whatever package
+        # manager this host has. `check-sysdep-remedies` enforces that, and it
+        # rejected a hand-written apt remedy here on the first run — the same
+        # ad-hoc provisioning this change exists to remove. (That gate is a text
+        # scan, so it also rejects a comment QUOTING the forbidden command,
+        # which is why this one describes it instead.)
+        # The protocol, not `echo … ; exit 0`. This step genuinely did not do
+        # its job, and issue 0650's rule is that such a step must not report
+        # success. `check-lane-skip-protocol` rejected the bare form here on
+        # the first run — the third of this repo's own gates to catch this one
+        # recipe while it was being written to remove ad-hoc provisioning.
+        #
+        # CI runs as root, so this branch is the workstation case: nothing is
+        # installed behind your back, and the command comes from the index.
+        source scripts/build/lane-skip.sh
+        nros_lane_skip "not root: $pkg not installed. It is a declared prereq, so 'nros setup --system' prints the install command for this host and --sudo runs it. Without it the zenoh lanes report [SKIPPED:capability]."
+    fi
+    if apt-get install -y --no-install-recommends "$pkg" 2>/dev/null; then
+        echo "provision-zenohd: installed $pkg"
+        exit 0
+    fi
+    # One retry after refreshing the index — a container image's apt lists are
+    # often older than the package.
+    apt-get update -qq || true
+    if apt-get install -y --no-install-recommends "$pkg"; then
+        echo "provision-zenohd: installed $pkg (after apt-get update)"
+        exit 0
+    fi
+    echo "::warning::no rmw_zenoh_cpp available — zenoh lanes will skip"
+
 [group("ci")]
 fast:
     @just check fast check::no-std

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -703,6 +703,19 @@ pacman = ["doxygen"]
 brew = ["doxygen"]
 check = { cmd = "doxygen" }
 
+# Doxygen's call/collaboration diagrams are drawn by graphviz's `dot`, so a
+# doxygen without it silently produces a docs build with no diagrams — a
+# DEGRADED result, not an error, which is why it went undeclared while
+# `.github/workflows/docs.yml` installed the two together in one apt line. The
+# workflow was the only place that knew they belong together.
+[prereq.graphviz]
+why = "doxygen's diagrams (HAVE_DOT); without it the C API docs build with no graphs and say nothing about it"
+apt = ["graphviz"]
+dnf = ["graphviz"]
+pacman = ["graphviz"]
+brew = ["graphviz"]
+check = { cmd = "dot" }
+
 [prereq.gcc-arm-none-eabi]
 why = "ARM bare-metal cross gcc via the apt path (the [tool.arm-none-eabi-gcc] dist is the store alternative)"
 # The LIBC is a separate package on Debian and was missing here, so the apt path

--- a/packages/boards/nros-board-linux/src/lib.rs
+++ b/packages/boards/nros-board-linux/src/lib.rs
@@ -432,7 +432,18 @@ impl LinuxBoard {
         // Best-effort like every other priority on this port — without
         // `CAP_SYS_NICE` the attribute is ignored at spawn and the tiers'
         // own refusal line has already said why.
-        #[cfg(unix)]
+        // `feature = "rmw-zenoh"` as well as `unix`: the symbol below lives in
+        // zpico-sys's C shim, which is only in the graph when the zenoh backend
+        // is selected. Guarded on `unix` alone, a board built for another RMW
+        // referenced a symbol nothing linked — `undefined symbol:
+        // zpico_set_task_config`, at LINK time in the consumer, naming neither
+        // this crate nor the missing backend.
+        //
+        // Same family as issue 0919 one layer up: a component assuming zenoh is
+        // present because it usually is. The priority plan below is about
+        // TRANSPORT tasks, and a build with no zenoh transport has none to
+        // place — so skipping it is the correct behaviour, not a degradation.
+        #[cfg(all(unix, feature = "rmw-zenoh"))]
         {
             // RFC-0079 — the RESERVED band's floor, not `max_tier + 1`.
             //


### PR DESCRIPTION
Two changes. The first is the requested cleanup; the second is what it takes to
get `host-tests` further, and it was found the same way as #0919.

## 1. A clang-format version that had already drifted

`pr-checks.yml` ran `pip install "clang-format==17.0.5"` while
`.clang-format-version` pins **17.0.6** — two sources of truth for one version,
already separated.

They separated **invisibly**. `scripts/dev/clang-format.sh` prefers
`build/clang-format/bin/`, which only `just setup-clang-format` creates, so CI
fell through to the PATH copy and printed

```
WARN: clang-format 17.0.5 on PATH != pinned 17.0.6
```

to stderr, in a lane nobody reads unless it fails. Different versions reformat
differently, so CI has been checking C/C++ formatting against a different
standard than every local run. The step is now `just setup-clang-format`,
which reads the pin, installs project-locally, and no-ops when correct.

**One spelling for the router.** `host-tests.yml` provisioned
`ros-<distro>-rmw-zenoh-cpp` twice — an if/else in one job, a `||` chain in the
other. Both are now `just ci provision-zenohd`. Absence stays a SKIP, which
`check-zenohd-router-skips` enforces.

**`graphviz` was undeclared** while `doxygen` was, though `docs.yml` installed
them in one apt line — the workflow was the only place that knew they belong
together. Doxygen's diagrams are drawn by graphviz's `dot`, so without it the C
API docs build with no graphs and say nothing: degraded, not failed, which is
why it went unnoticed.

### Three of this repo's own gates caught the new recipe

Recorded because the recipe exists to *remove* ad-hoc provisioning and kept
reintroducing it: `check-sysdep-remedies` rejected a hand-written apt remedy
(remedies are derived from the index — and this package is already declared
there), then rejected a **comment quoting** the forbidden command since it is a
text scan; `check-lane-skip-protocol` rejected `echo "…SKIP…"; exit 0`.

### Not done, deliberately

`docs.yml` (doxygen, graphviz, mdbook-mermaid), `nightly.yml` (clang,
libclang-dev) and the ROS apt repository still install directly. Most of those
packages **are** declared in the index, but the only surface that installs from
it is `nros setup --system --sudo`, which resolves the whole closure and needs
the CLI built first — neither of which those jobs do. Routing them through it
would add a CLI build to a docs job to install two packages. Real tradeoff, own
change.

## 2. The board referenced a zenoh symbol unconditionally

After #0919 landed, `host-tests` moved from sixteen undefined symbols to one:

```
rust-lld: error: undefined symbol: zpico_set_task_config
```

The link line names the cause: `libnros_board_linux` present, **no
`libzpico_sys` and no zenoh crate anywhere**. `run_tiers` places transport
tasks in the reserved priority band via `zpico_set_task_config`, guarded on
`#[cfg(unix)]` alone — but that symbol lives in zpico-sys's C shim, reachable
only through the zenoh backend. A board built for another RMW referenced a
symbol nothing linked. Now gated on `feature = "rmw-zenoh"` too.

Skipping is correct, not a degradation: the call places *zenoh's* read/lease
tasks, and a build without zenoh has none to place.

Reproduced before fixing, on the workspace CI names:

```
realtime-rust, board on a non-zenoh RMW
  -> undefined symbol: zpico_set_task_config    (before)
  -> Finished                                    (after)
normal zenoh configuration                       -> Finished
```

### The pattern, since it has now cost two issues

The default generated inputs on a dev host enable `rmw-zenoh`, so neither this
nor #0919 reproduces by building what is checked out. Both needed the graph
FORCED into the shape CI had — and both times the **rlib list in the link
line** was the evidence, not the symbol name. #0919 took eight non-reproducing
routes before I read it; this one took minutes because I read it first.

## Verification

`just ci l1` green (1027 tests, 1 host-capability skip); `just check fast` 138
ran / 1 skipped (`bindgen-cli` genuinely absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
