### PR TITLE
fix(esp32): DRAM overflow was service buffers for services the image lacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,9 +3044,9 @@ checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -62,9 +62,9 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:470` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:469` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:468` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:482` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:481` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:480` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -72,7 +72,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PENDING_GETS` | 4 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_PUBLISHERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:431` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_MAX_QUERYABLES` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:443` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SESSIONS` | 1 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_SUBSCRIBERS` | 8 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_PUBLISHER_TX_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -349,7 +349,23 @@ target = "riscv32imc-unknown-none-elf"
 # component's ~17.5 KiB Arc<ComponentCell> OOMs the 48 KiB esp-alloc heap. The
 # two components here declare one publisher + one subscription, so 2 is exact.
 # Interim until the W5-endgame per-class exact cells retire the worst-case pad.
-env = { RUSTUP_TOOLCHAIN = "nightly-2026-04-11", CARGO_UNSTABLE_BUILD_STD = "core,alloc", ESP_LOG = "info", NROS_EXECUTOR_ARENA_SIZE = "16384", NROS_SMOLTCP_MAX_UDP_SOCKETS = "2", ZPICO_SUBSCRIBER_LARGE_SIZE = "4096", NROS_RUNTIME_MAX_CELL_ENTITIES = "2" }
+# ZPICO_MAX_QUERYABLES: this image is a talker and a listener — pub/sub only,
+# no service servers, and `entity-facts` reports INFRA_QUERYABLES=none. The
+# undeclared embedded budget is 8, which costs 35,424 B of SERVICE_BUFFERS
+# (`ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES`) for services this image does
+# not have — and that is what overflowed DRAM by 8,804 B, blocking the whole
+# esp32 nightly lane.
+#
+# 2, not 0, and the difference is the point: a model cannot describe service
+# wiring (ZERO of the tree's 115 resolved models carry any), so `entity-facts`
+# correctly REFUSES to report a count rather than guess. This row is where the
+# image's own author can state it. The build prints
+#   `ZPICO_MAX_QUERYABLES=2 is under the budgeted 8 (0 provably claimed at
+#    boot, plus 8 of headroom …). It will boot; an application declaring more
+#    than 2 service servers will not`
+# which is the tradeoff stated out loud — the checked-override behaviour
+# phase-392 W5.f added for exactly this.
+env = { RUSTUP_TOOLCHAIN = "nightly-2026-04-11", CARGO_UNSTABLE_BUILD_STD = "core,alloc", ESP_LOG = "info", NROS_EXECUTOR_ARENA_SIZE = "16384", NROS_SMOLTCP_MAX_UDP_SOCKETS = "2", ZPICO_SUBSCRIBER_LARGE_SIZE = "4096", NROS_RUNTIME_MAX_CELL_ENTITIES = "2", ZPICO_MAX_QUERYABLES = "2" }
 
 # Phase 225.O follow-up (known-issue #18) — NuttX QEMU ARM virt
 # (Cortex-A7) workspace Entry. Built by the cargo lane

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -282,7 +282,7 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
             Driver::Cargo => {
                 // W3.b — generate the entry package. This is D4's headline
                 // claim: the entry stops being hand-written.
-                let entry_dir = generate_entry(
+                let generated = generate_entry(
                     &root,
                     &bringup_dir,
                     &bringup,
@@ -292,6 +292,8 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
                     &platform,
                     nano_ros_root.as_deref(),
                 )?;
+                let entry_dir = generated.as_ref().map(|(d, _)| d.clone());
+                let entity_facts = generated.map(|(_, f)| f).unwrap_or_default();
                 if let Some(d) = &entry_dir {
                     eprintln!("nros build:   entry → {}", d.display());
                 }
@@ -436,7 +438,18 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
                 // live there. Building from build/<coord> would lose every one
                 // of them and resolve message crates against the public
                 // registry — issue 0378 by a different road.
-                Some(Handoff::new("cargo", a).in_dir(&root))
+                // The ENTITY facts ride the handoff (phase-392 W5). The env is
+                // the only carrier that reaches a build script inside the cargo
+                // invocation, which is what `entity_facts` was designed around —
+                // and this is the cargo half of that delivery, the CMake half
+                // being `NanoRosEntityFacts.cmake`. Without it the zenoh backend
+                // sizes SERVICE_BUFFERS for 8 service servers an image may not
+                // have, which overflows DRAM on esp32.
+                let mut h = Handoff::new("cargo", a).in_dir(&root);
+                for (k, v) in &entity_facts {
+                    h = h.with_env(k, v);
+                }
+                Some(h)
             }
             Driver::CMake => {
                 // Unlike cargo, cmake imposes no root/member hierarchy rule, so
@@ -836,7 +849,7 @@ fn generate_entry(
     descriptor: &crate::orchestration::board_descriptor::BoardDescriptor,
     platform: &str,
     nano_ros_root: Option<&std::path::Path>,
-) -> Result<Option<PathBuf>> {
+) -> Result<Option<(PathBuf, std::collections::BTreeMap<String, String>)>> {
     use crate::{
         builder::entry::{BoardFacts, EntrySpec},
         orchestration::model_location,
@@ -991,7 +1004,42 @@ fn generate_entry(
     let parent = root.join("build").join(coordinate(platform, image));
     let dir = crate::builder::entry::write(&spec, &facts, &parent)
         .map_err(|e| eyre::eyre!("generating the entry for `{image_id}`: {e}"))?;
-    Ok(Some(dir))
+
+    // phase-392 W5 — the ENTITY facts, from the SAME model resolved above.
+    //
+    // `entity_facts`'s own docs say these are "delivered through the process
+    // environment because that is the only carrier that reaches the cargo
+    // invocation a workspace member is built by" — and until now only
+    // `cmake/NanoRosEntityFacts.cmake` wired them, so the CMake path got
+    // declaration-sized tables and the CARGO path silently kept the undeclared
+    // fallback (32 hosted / 8 embedded).
+    //
+    // That is not a missing optimisation, it is a hard failure on a small
+    // target: `esp32_entry` overflowed DRAM by 8,804 B while carrying
+    // `SERVICE_BUFFERS` sized for 8 service servers it does not have. Measured
+    // on a native talker when the CMake side landed: 144,128 -> 4,504 B.
+    //
+    // Resolved here rather than by a second call so there is ONE model read,
+    // which is the property `entity_facts` was written to have.
+    let entity_facts = match std::fs::read_to_string(&model_path)
+        .map_err(|e| e.to_string())
+        .and_then(|y| {
+            ros_launch_manifest_model::SystemModel::from_yaml_str(&y).map_err(|e| e.to_string())
+        }) {
+        Ok(m) => crate::cmd::entity_facts::facts_from_model(&m),
+        Err(e) => {
+            // Not fatal: an unreadable model here means the entry was still
+            // generated, and the undeclared fallback is the historical
+            // behaviour. Say so rather than silently sizing for 8.
+            eprintln!(
+                "nros build: warning: cannot read `{}` for entity facts, so the \
+                 backend keeps its undeclared table budget: {e}",
+                model_path.display()
+            );
+            std::collections::BTreeMap::new()
+        }
+    };
+    Ok(Some((dir, entity_facts)))
 }
 
 /// The crates a BRIDGE entry must name directly, derived from the bringup.
@@ -1193,7 +1241,7 @@ fn all_cargo_entry_dirs(
         if plan::driver_for(&platform, image_has_non_rust(&image, &bringup_dir)) != Driver::Cargo {
             continue;
         }
-        let Some(dir) = generate_entry(
+        let Some((dir, _facts)) = generate_entry(
             root,
             &bringup_dir,
             bringup,

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -71,6 +71,18 @@ const UNDECLARED_HEADROOM: usize = 8;
 /// says nothing; W5.e turns that case into a build-time failure, which needs
 /// the hand-written-`main` question settled first (phase-392 W5, Open).
 fn resolve_queryable_default() -> QueryableSizing {
+    // WATCH what we READ. Both were consumed here and neither was declared, so
+    // cargo had no reason to re-run this script when a declaration changed: an
+    // entry that gained or lost a service server kept its previously-sized
+    // tables until something ELSE forced a rebuild. The sizing then reads as
+    // applied while being stale — the shape issue 0491 documents for path
+    // variables, here with no watch at all.
+    //
+    // It also makes the knob untestable by hand: setting either variable and
+    // rebuilding produces a byte-identical image, which is exactly how this was
+    // found.
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_SERVICE_SERVERS");
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_INFRA_QUERYABLES");
     let declared = std::env::var("NROS_DECLARED_SERVICE_SERVERS").ok();
     let infra = std::env::var("NROS_DECLARED_INFRA_QUERYABLES").ok();
     QueryableSizing {

--- a/scripts/build/workspace-fixtures-build.sh
+++ b/scripts/build/workspace-fixtures-build.sh
@@ -330,13 +330,41 @@ build_workspace() {
                     echo "     nros build --all --dry-run   (generate the root)"
                     "$nros_cli" build --all --dry-run >/dev/null
                 fi
+                # The ENTITY facts, the same way `NanoRosEntityFacts.cmake`
+                # delivers them on the CMake path (phase-392 W5). The process
+                # environment is the only carrier that reaches a build script
+                # inside this cargo invocation, and without it the zenoh backend
+                # falls back to its undeclared budget — 8 service servers on an
+                # embedded target, whether or not the entry has any.
+                #
+                # That is not a lost optimisation: `esp32_entry` declares NO
+                # services and overflowed DRAM by 8,804 B carrying buffers for
+                # eight. Soft on failure, like the CMake side: a model that
+                # cannot be read leaves the historical budget in place and says
+                # so, rather than failing a build over a sizing hint.
+                local entity_env=()
+                if [ -n "$bringup" ] && [ -d "$bringup" ]; then
+                    local facts
+                    if facts="$("$nros_cli" ws entity-facts --bringup-dir "$bringup" 2>/dev/null)"; then
+                        while IFS= read -r line; do
+                            [ -n "$line" ] && entity_env+=("$line")
+                        done <<<"$facts"
+                    else
+                        echo "     (entity facts unavailable for $bringup — backend keeps its undeclared table budget)"
+                    fi
+                fi
                 local cargo_args=(build "${profile_args[@]}" -p "$entry")
                 if [ -n "$target_dir" ]; then
                     cargo_args+=(--target-dir "$target_dir")
                 fi
                 cargo_args+=("${extra_args[@]}")
-                echo "     cargo ${cargo_args[*]}"
-                cargo "${cargo_args[@]}"
+                if [ "${#entity_env[@]}" -gt 0 ]; then
+                    echo "     ${entity_env[*]} cargo ${cargo_args[*]}"
+                    env "${entity_env[@]}" cargo "${cargo_args[@]}"
+                else
+                    echo "     cargo ${cargo_args[*]}"
+                    cargo "${cargo_args[@]}"
+                fi
             fi
 
             local out_root="${target_dir:-target}"


### PR DESCRIPTION
Every nightly run that actually builds esp32 dies at link:

```
rust-lld: error: section '.bss' will not fit in region 'DRAM': overflowed by 8804 bytes
```

`SERVICE_BUFFERS` is `ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES` and was
**35,424 B** on an image that is a talker and a listener — pub/sub only, no
service servers. phase-392 W5 built the machinery to size that from the
DECLARATION (measured 144,128 → 4,504 B on a native talker). Three things kept
esp32 from getting it.

## 1. The knob was read and never watched

`resolve_queryable_default` consumes `NROS_DECLARED_SERVICE_SERVERS` and
`NROS_DECLARED_INFRA_QUERYABLES` and declared `rerun-if-env-changed` for
**neither**. Cargo therefore had no reason to re-run the script when a
declaration changed: an entry that gained or lost a service server kept its
previously-sized tables until something else forced a rebuild — sizing that
reads as applied while being stale.

It also makes the knob untestable by hand, which is how it was found: setting
either variable and rebuilding produced a **byte-identical** image, and I first
read that as "the declaration is not the lever" instead of asking why nothing
recompiled.

## 2. Only the CMake path delivered the facts

`entity_facts`'s own docs say these are *"delivered through the process
environment because that is the only carrier that reaches the cargo invocation
a workspace member is built by"* — and only `NanoRosEntityFacts.cmake` wired
them. Both cargo paths now do:

- `nros build`'s stage-5 handoff carries them, from the **same model read**
  that generates the entry;
- `workspace-fixtures-build.sh`'s hand-written-entry branch asks
  `nros ws entity-facts` and exports the answer, soft on failure like the CMake
  side. esp32 is that branch (`entry = "esp32_entry"`, not `image =`), which is
  why the handoff change alone did not reach it.

## 3. The image had to state its own budget

With delivery fixed, esp32 gets `INFRA_QUERYABLES=none` and **no** service
count — correctly. `describes_wiring` refuses to report one because **zero of
the tree's 115 resolved models carry layer-1 wiring**, so an absent `services`
map does not mean "no service servers"; reporting 0 would be a confident wrong
number that exhausts the table the moment a node registers. My first attempt
set 0 by hand and would have shipped exactly that defect.

So the image declares it, in the fixture row that already tunes this image knob
by knob: `ZPICO_MAX_QUERYABLES = "2"`. The build states the tradeoff out loud,
which is what W5.f's checked override is for:

```
ZPICO_MAX_QUERYABLES=2 is under the budgeted 8 (0 provably claimed at boot,
plus 8 of headroom for application service servers the model does not
describe). It will boot; an application declaring more than 2 service servers
will not.
```

## Measured

```
SERVICE_BUFFERS   35,424 -> 8,856     -26,568
.bss                          295,876  (was overflowing by 8,804)
```

~17.7 KB of margin against an 8.8 KB overflow.

## Ruled out, recorded because it looked right

esp32 has no size carve-out in `nros_cargo_platform_profile` — it falls through
to the ambient `nros-relwithdebinfo` (opt-level 2, LTO off) while nuttx and
freertos both map to `nros-minsizerel`. That is issue 0511's "Also found"
exactly, one platform over, and a real inconsistency. It is **not** this
failure: rebuilt under `nros-minsizerel` the overflow is 8,968 B — slightly
**worse**, because `.bss` is static arrays and opt-level does not shrink them.
Left for its own change rather than shipped as a fix measurement refutes.

## Second commit: a yanked pin

The root lock named `spin 0.9.8`, yanked 2026-07-13, seven minutes after
`0.9.9` was published. `just lock-update spin 0.9.9`; diff is exactly two lines.

**Not claimed as the freertos nightly fix**, though that lane reports the yank:
`0.9.9` has been available since July so any online resolve already had a good
answer, and the timestamps put that error on the `--offline` attempt
immediately before the issue-0873 escalation retries online. That lane's real
terminal failure is `idlc (Cyclone DDS IDL compiler, a host tool) not found` —
provisioning, filed separately.

## Verification

esp32 fixture builds from the row alone with no hand-set environment; the whole
`linux rust` fixture set still builds, including the service-server entries
that are the under-sizing risk; `just ci l1` green (1027 tests);
`just check fast` 138 ran / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
