### PR TITLE
fix(setup): provision every RMW a platform's lane builds, not just zenoh

### DIFF
--- a/just/freertos.just
+++ b/just/freertos.just
@@ -12,8 +12,24 @@ default:
 # target. `source setup.bash` afterwards to put the provisioned tools on PATH.
 [group("setup")]
 setup:
-    nros setup qemu-arm-freertos
-    @"{{justfile_directory()}}/tools/host-env.sh" freertos
+    #!/usr/bin/env bash
+    # Every RMW this platform's lane BUILDS, not just zenoh.
+    #
+    # `nros setup <board>` takes `--rmw`'s zenoh default, so a lane that also
+    # builds a cyclonedds coordinate never got its host tools — the freertos
+    # nightly died at cmake configure with `idlc (Cyclone DDS IDL compiler, a
+    # host tool) not found`. `[rmw.cyclonedds]` declares exactly what that
+    # needs and calls itself "a complete provisioner"; nothing requested it.
+    #
+    # The backend list is DERIVED from `examples/fixtures.toml`, not written
+    # here, so it cannot drift from the coordinates the lane actually builds.
+    # A SHEBANG recipe: `just` runs each line of a line-based recipe in its
+    # own shell, so a sourced helper does not survive to the next line — and
+    # the default shell is `sh`, which has no `source` at all.
+    set -euo pipefail
+    source scripts/build/platform-rmws.sh
+    nros_setup_board_rmws qemu-arm-freertos freertos
+    "{{justfile_directory()}}/tools/host-env.sh" freertos
 
 # Diagnose FreeRTOS install status (read-only).
 [group("setup")]

--- a/just/threadx-linux.just
+++ b/just/threadx-linux.just
@@ -9,8 +9,24 @@ default:
 # Does NOT build example binaries — use `just threadx_linux build-examples` for that.
 [group("setup")]
 setup:
-    nros setup threadx-linux
-    @"{{justfile_directory()}}/tools/host-env.sh" threadx
+    #!/usr/bin/env bash
+    # Every RMW this platform's lane BUILDS, not just zenoh.
+    #
+    # `nros setup <board>` takes `--rmw`'s zenoh default, so a lane that also
+    # builds a cyclonedds coordinate never got its host tools — the freertos
+    # nightly died at cmake configure with `idlc (Cyclone DDS IDL compiler, a
+    # host tool) not found`. `[rmw.cyclonedds]` declares exactly what that
+    # needs and calls itself "a complete provisioner"; nothing requested it.
+    #
+    # The backend list is DERIVED from `examples/fixtures.toml`, not written
+    # here, so it cannot drift from the coordinates the lane actually builds.
+    # A SHEBANG recipe: `just` runs each line of a line-based recipe in its
+    # own shell, so a sourced helper does not survive to the next line — and
+    # the default shell is `sh`, which has no `source` at all.
+    set -euo pipefail
+    source scripts/build/platform-rmws.sh
+    nros_setup_board_rmws threadx-linux threadx-linux
+    "{{justfile_directory()}}/tools/host-env.sh" threadx
 
 # Diagnose ThreadX Linux install status (read-only).
 [group("setup")]

--- a/just/threadx-riscv64.just
+++ b/just/threadx-riscv64.just
@@ -9,8 +9,24 @@ default:
 # target). Does NOT build example binaries — use `build-examples`.
 [group("setup")]
 setup:
-    nros setup qemu-riscv64-threadx
-    @"{{justfile_directory()}}/tools/host-env.sh" threadx
+    #!/usr/bin/env bash
+    # Every RMW this platform's lane BUILDS, not just zenoh.
+    #
+    # `nros setup <board>` takes `--rmw`'s zenoh default, so a lane that also
+    # builds a cyclonedds coordinate never got its host tools — the freertos
+    # nightly died at cmake configure with `idlc (Cyclone DDS IDL compiler, a
+    # host tool) not found`. `[rmw.cyclonedds]` declares exactly what that
+    # needs and calls itself "a complete provisioner"; nothing requested it.
+    #
+    # The backend list is DERIVED from `examples/fixtures.toml`, not written
+    # here, so it cannot drift from the coordinates the lane actually builds.
+    # A SHEBANG recipe: `just` runs each line of a line-based recipe in its
+    # own shell, so a sourced helper does not survive to the next line — and
+    # the default shell is `sh`, which has no `source` at all.
+    set -euo pipefail
+    source scripts/build/platform-rmws.sh
+    nros_setup_board_rmws qemu-riscv64-threadx threadx-riscv64
+    "{{justfile_directory()}}/tools/host-env.sh" threadx
 
 # Diagnose ThreadX RISC-V 64 install status (read-only).
 [group("setup")]

--- a/scripts/build/platform-rmws.sh
+++ b/scripts/build/platform-rmws.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Which RMW backends does a PLATFORM's lane actually build?
+#
+# Source this and call `nros_platform_rmws <platform>`; it echoes the backend
+# names, one per line, derived from `examples/fixtures.toml`.
+#
+# WHY THIS EXISTS. `nros setup <board>` provisions `board.packages ∪
+# rmw.packages` and defaults `--rmw` to zenoh. Every platform setup recipe took
+# that default, and no recipe anywhere passed `--rmw` — so the flag and the
+# `[rmw.*]` rows existed and nothing used them.
+#
+# Six platforms build a non-zenoh coordinate (freertos, freertos-posix, linux,
+# threadx-linux, threadx-riscv64, zephyr), and for those the host tools of the
+# other backend were never installed. The freertos nightly died at cmake
+# configure with
+#
+#     idlc (Cyclone DDS IDL compiler, a host tool) not found.
+#
+# on a lane that builds `freertos-cyclonedds-s32z270-freertos`. `[rmw.cyclonedds]`
+# declares exactly what that needs — `cyclonedds` (which carries idlc),
+# `cyclonedds-src`, `rosidl` — and calls itself "a complete provisioner"; the
+# packages were declared and simply never requested.
+#
+# DERIVED, not listed. A hand-written map here would be a second copy of
+# `fixtures.toml`'s `rmw =` fields and would drift the first time a row moves —
+# the failure mode CLAUDE.md names for the sizes-header mirror and the fixture
+# probes. `fixtures.toml` already says which coordinates a platform builds, so
+# it is the only honest source for which backends that platform needs.
+#
+# Deliberately NOT silent on failure: a platform with no rows is a caller error
+# (a typo'd name), and returning "nothing to provision" for it would reproduce
+# the bug this fixes one level up.
+
+# nros_platform_rmws <platform>
+#
+# Echoes one backend per line, sorted and deduped. Exit 1 with a message if the
+# platform has no fixture rows at all.
+nros_platform_rmws() {
+    local platform="${1:?nros_platform_rmws: platform}"
+    local root
+    root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+    local out
+    # `coords` is the same subcommand the lane filters use, so this reads the
+    # manifest through the one parser rather than re-implementing TOML in awk.
+    # Its fields are separated by 0x1f, NOT tab — a tab-split silently yields
+    # one field and an empty answer, which looks exactly like "no rows".
+    out="$(python3 "$root/scripts/build/fixtures-manifest.py" coords 2>/dev/null \
+        | awk -F'\x1f' -v p="$platform" '$2 == p { print $4 }' \
+        | grep -v '^$' \
+        | sort -u)"
+
+    if [ -z "$out" ]; then
+        echo "nros_platform_rmws: no fixture rows for platform '$platform'" >&2
+        echo "  (known platforms come from examples/fixtures.toml)" >&2
+        return 1
+    fi
+    printf '%s\n' "$out"
+}
+
+# nros_setup_board_rmws <board> <platform>
+#
+# `nros setup <board> --rmw <r>` for every backend the platform's lane builds.
+#
+# Replaces a bare `nros setup <board>`, which takes `--rmw`'s zenoh default and
+# so provisions the zenoh host tools only. The calls are cumulative and
+# idempotent — each resolves `board.packages ∪ rmw.packages`, and the board half
+# is the same set every time — so this costs one extra resolve per extra
+# backend and installs nothing twice.
+#
+# Ordered by `sort -u`, which puts `cyclonedds` before `zenoh`; nothing depends
+# on the order, but a stable one keeps the log diffable between runs.
+nros_setup_board_rmws() {
+    local board="${1:?nros_setup_board_rmws: board}"
+    local platform="${2:?nros_setup_board_rmws: platform}"
+    local rmws
+    rmws="$(nros_platform_rmws "$platform")" || return 1
+    local r
+    while IFS= read -r r; do
+        [ -n "$r" ] || continue
+        echo "  nros setup $board --rmw $r"
+        nros setup "$board" --rmw "$r" || return 1
+    done <<<"$rmws"
+}


### PR DESCRIPTION
The freertos nightly dies at cmake configure:

```
CMake Error at …/NrosRmwCycloneddsTypeSupport.cmake
  idlc (Cyclone DDS IDL compiler, a host tool) not found.
```

on a lane whose examples include `freertos-cyclonedds-s32z270-freertos`.

## The flag existed; nothing used it

`nros setup <board>` resolves `board.packages ∪ rmw.packages` and defaults
`--rmw` to zenoh. Every platform setup recipe took that default, and **no
recipe anywhere passed `--rmw`** — so the flag and the `[rmw.*]` rows existed
and were never exercised. `[rmw.cyclonedds]` declares exactly what the failure
needs (`cyclonedds`, which carries `idlc`, plus `cyclonedds-src` and `rosidl`)
and its own comment calls it *"a complete provisioner"*. The packages were
declared and simply never requested.

## Six platforms, including three of the four failing nightly jobs

Derived from `examples/fixtures.toml`:

```
freertos          cyclonedds zenoh
freertos-posix    cyclonedds
linux             cyclonedds xrce zenoh
threadx-linux     cyclonedds zenoh
threadx-riscv64   cyclonedds zenoh
zephyr            cyclonedds xrce zenoh
```

`freertos`, `threadx_linux` and `threadx_riscv64` all build a cyclonedds
coordinate and none provisioned its host tools. That those two threadx lanes
may share this cause is not a guess — the fixture manifest says so.

## Derived, not listed

`nros_platform_rmws` asks `fixtures-manifest.py coords` which backends a
platform's rows declare. A hand-written map would be a second copy of those
`rmw =` fields and would drift the first time a row moves — the failure mode
CLAUDE.md names for the sizes-header mirror and the fixture probes. It
**refuses** on an unknown platform rather than answering "nothing to
provision", which would reproduce this bug one level up.

For the next reader: `coords` separates fields with `0x1f`, **not** tab. A
tab-split silently yields one field and an empty answer — indistinguishable
from "this platform needs nothing".

## Scope

Wired for the three platforms where a board maps cleanly to a setup recipe —
the three failing lanes. `native` has no setup recipe (host platform) and
`zephyr setup` is a different west-based shape; both are noted rather than
guessed at, since neither can be exercised here.

Two `just` mechanics are recorded in place, each having cost a cycle: a
line-based recipe runs every line in its **own** shell (a sourced helper does
not survive to the next line) and that shell is `sh` — no `source`, no
`set -o pipefail`; and the shebang that fixes both must be the **first** body
line, comments included.

## Verified

```
just freertos setup
  nros setup qemu-arm-freertos --rmw cyclonedds
  … cyclonedds-src … [provisioned]
  nros setup qemu-arm-freertos --rmw zenoh
~/.nros/sdk/cyclonedds/0.10.5-nros1/bin/idlc     <- exists
```

which is exactly the `_nros_cyclonedds_sdk_bins` HINT path the failing cmake
searches. `just ci l1` green (1027 tests); `just check fast` 138 ran / 1
skipped.

One flake seen and retested rather than filed:
`nros_rmw_cyclonedds_ros2_srv_e2e` failed inside a saturated `ci l1` and passes
22/22 solo — a ROS-peer e2e under load, the same shape as
`sigusr1_handler_wakes_spin_once` earlier. The cyclonedds submodule was checked
and is at its recorded pin, so provisioning did not move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB
