### PR TITLE
fix(#0929): arm-none-eabi-gdb works — the dist ships the Python ARM's gdb cannot find

### DIFF
--- a/docs/issues/0932-arm64-toolchain-dist-unbundled.md
+++ b/docs/issues/0932-arm64-toolchain-dist-unbundled.md
@@ -1,0 +1,62 @@
+---
+id: 932
+title: "The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle
+  nor the gdb Python, and its gdb fails EARLIER than x86_64's did"
+status: open
+type: bug
+area: tooling
+related: [0926, 0928, 0929]
+---
+
+## What is missing
+
+`arm-none-eabi-gcc` 13.2-nros3 ships two fixes on **linux-x86_64** and neither
+on **linux-arm64**, whose tarball is byte-identical to -nros2 (same sha256 —
+that identity is how the release proved it touched only one host):
+
+* **ncurses 5 bundling** (issue 0928). Skipped because the arm64 leg then failed
+  on the NEXT library.
+* **the gdb Python stdlib** (issue 0929). Skipped because the arm64 gdb needs
+  more than a stdlib.
+
+## Why arm64 is a different problem, not the same one deferred
+
+The two hosts fail at different STAGES, and the arm64 one fails earlier:
+
+| | linux-x86_64 | linux-arm64 |
+| --- | --- | --- |
+| Python | STATIC in gdb; no `libpython` in `NEEDED` | DYNAMIC — links `libpython3.8.so.1.0` |
+| failure | interpreter init aborts (stdlib absent) | the LOADER fails; gdb never starts |
+| fix | ship the stdlib, point `PYTHONHOME` | needs the `.so` too, and 22.04 packages no python3.8 |
+
+Measured during the -nros2 build: `bundle: cannot resolve libpython3.8.so.1.0`.
+The bundler refused, correctly — it fails rather than shipping a dist bundled
+everywhere except the one library it could not resolve.
+
+Also note the ncurses spelling differs by architecture: x86_64 links
+`libncursesw.so.5`, arm64 links `libncurses.so.5`. A package list derived from
+one host is wrong for the other by construction, which already cost one build.
+
+## What it would take
+
+The blocker is obtaining `libpython3.8.so.1.0` for arm64 on a 22.04 runner:
+
+1. **deadsnakes PPA** — cheapest, but adds a third-party apt source to a release
+   build, which is a supply-chain decision rather than a packaging one.
+2. **Build CPython 3.8 in the job** — self-contained and slow, and it makes the
+   toolchain repackage a source build, which it deliberately is not today.
+3. **Take the `.so` from python.org's build** — no compiler needed, but their
+   binaries are not distributed for Linux, so this may not exist.
+4. **Accept and declare** — leave arm64 as-is and let `smoke` report `[BROKEN]`
+   there, which is honest and costs nothing. `system = ["libcrypt1"]` already
+   holds for both hosts.
+
+Direction 4 is the current de-facto state and is not wrong; this issue exists so
+it is a CHOICE rather than an oversight.
+
+## Verifying any fix
+
+Nothing here can be checked on an x86_64 developer host. The release job's own
+`gdb-python: OK` assertion runs per host, so an arm64 fix proves itself in CI —
+and `nros setup --tool arm-none-eabi-gcc --check` reports `[BROKEN]` on an arm64
+host until it lands, via the `smoke` probe (phase-404 / issue 0929).

--- a/docs/issues/archived/0929-arm-gdb-embedded-python-fails-to-initialise.md
+++ b/docs/issues/archived/0929-arm-gdb-embedded-python-fails-to-initialise.md
@@ -2,7 +2,7 @@
 id: 929
 title: "`arm-none-eabi-gdb` starts but produces no output — ARM's embedded
   Python cannot initialise, and no declaration can fix it"
-status: open
+status: resolved
 type: bug
 area: tooling
 related: [0926, 0928]
@@ -140,3 +140,38 @@ stops working.
 
 So direction 4 is now a legitimate choice rather than a quiet lie. The debugger
 is still broken, and this issue stays open for that.
+
+## Resolved (2026-08-30) — x86_64
+
+`arm-none-eabi-gcc` **13.2-nros3** ships the matching CPython 3.8 stdlib inside
+the dist with a launcher pointing `PYTHONHOME` at it. 46 MB of `Lib/` trimmed to
+11 MB on disk, **1.6 MB compressed**; no build, no compiler.
+
+Three details worth keeping:
+
+* **The Python minor is derived from the binary and an unpinned one FAILS the
+  build.** ARM bumps it between releases and a stdlib for the wrong minor
+  installs cleanly then fails at run time.
+* **The launcher stays in `bin/` with the real binary beside it**, unlike the
+  macOS bundler which moves binaries to `lib/`. gdb derives `--data-directory`
+  from its own location; moving it out of `bin/` moves `share/gdb` out from
+  under it. Verified: the data directory still resolves.
+* **The release job verifies `--version` prints `GNU gdb` before publishing**, so
+  this issue's exact symptom is now a build failure rather than a user's.
+
+Confirmed on the released tarball, and the `smoke` probe added for this issue
+flipped on its own across all three surfaces:
+
+    nros setup --tool arm-none-eabi-gcc --check  ->  [OK] ... 13.2-nros3
+    nros setup --check                           ->  0 installed but not working
+    just doctor                                  ->  [OK] installed tools run
+
+**The ceiling is ARM's, and this reaches it.** Their x86_64 gdb exports ZERO
+Python C-API symbols, so no `.so` extension module can load into it on ANY host
+— `import struct` and `import math` fail even with a full system python3.8
+installed. The 34 modules they built in are the whole surface; pretty-printer
+machinery, `gdb.execute`, `re`, `collections` and `json` all work.
+
+**linux-arm64 is NOT fixed and is now issue 0932** — there gdb links
+`libpython3.8.so.1.0` dynamically, so it fails at the LOADER rather than at
+interpreter init, and needs the shared library rather than a stdlib.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,6 +66,6 @@ fails if this block drifts.
 - **#0902** (build, rmw) — Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed files out of the whole library, so a patch is silently not compiled See `0902-*`.
 - **#0914** (testing) — Nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot evaluate anything passes every check See `0914-*`.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
-- **#0929** (tooling) — `arm-none-eabi-gdb` starts but produces no output — ARM's embedded Python cannot initialise, and no declaration can fix it See `0929-*`.
+- **#0932** (tooling) — The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle nor the gdb Python, and its gdb fails EARLIER than x86_64's did See `0932-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -77,22 +77,25 @@ install = "make -j$(nproc) && make install"
 # declaration with them. `arm-none-eabi-gdb` no longer dies at the loader with
 # `libncursesw.so.5: cannot open shared object file`.
 #
-# IT IS NOT FULLY FIXED, and this is deliberately not papered over. ARM embeds
-# Python in gdb and it fails to initialise on a host without the exact Python
-# it expects, so gdb now STARTS and still prints nothing:
+# -nros3 FIXES the debugger too (issue 0929). ARM embeds a CPython STATICALLY
+# and bakes its `sys.prefix` to their build container, so the interpreter found
+# no stdlib and aborted — fatally, taking gdb with it, which is why gdb exited 0
+# printing NOTHING. The dist now ships the matching stdlib and a launcher points
+# `PYTHONHOME` at it: 1.6 MB compressed, no build, and the release job VERIFIES
+# `--version` prints `GNU gdb` before publishing.
 #
-#   Could not find platform independent libraries <prefix>
+# `import struct` and `import math` still fail, and that is ARM's ceiling rather
+# than ours: their x86_64 gdb exports ZERO Python C-API symbols, so no `.so`
+# extension module can load into it on ANY host — including one with a full
+# system python3.8. Pretty-printers, `gdb.execute`, `re`/`collections`/`json`
+# all work; the 34 modules ARM built in are the whole surface.
 #
-# No declaration can help: the x86_64 gdb has no `libpython` in its NEEDED list
-# at all (it is statically embedded), so `check-dist-runtime-deps` cannot see
-# it, and the arm64 gdb wants `libpython3.8.so.1.0`, which Ubuntu 22.04 has no
-# package for. A prereq naming a package apt cannot provide is worse than
-# silence. Tracked in 0928; the compiler, assembler and linker are unaffected.
-#
-# linux-arm64 is NOT bundled for that reason — the build refuses rather than
-# shipping a dist bundled everywhere except the library it could not resolve.
+# linux-arm64 gets NEITHER fix: there gdb links `libpython3.8.so.1.0`
+# dynamically, so it needs the shared library and not merely a stdlib, and 22.04
+# packages none. Its tarball is byte-identical to -nros2 (same sha256), which is
+# the check that this release touched only x86_64.
 [tool.arm-none-eabi-gcc]
-version = "13.2-nros2"
+version = "13.2-nros3"
 smoke = [
     { run = "bin/arm-none-eabi-gcc --version", expect = "Arm GNU Toolchain" },
     { run = "bin/arm-none-eabi-gdb --version", expect = "GNU gdb" },
@@ -104,9 +107,9 @@ smoke = [
 system = ["libcrypt1"]
 upstream = "13.2.rel1" # ARM release id (SSOT — build script no longer hand-derives)
 # Repackaged from ARM's release; no in-repo source build (binary toolchain).
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros2/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "ee8e89d54db50834832e9e8894c486aeba1477fdc06c607223f0b123e73ebcec" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros2/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "127136d54db66f2ed405d8bc01b1280a9cc78f2cbcc04466894c75c109b942d7" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros2/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "1e5f6dbf853b70ae5b1fcc17dd3d3a877172f5520adc7ddb1d1da40ce73282ea" }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "127136d54db66f2ed405d8bc01b1280a9cc78f2cbcc04466894c75c109b942d7" }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
 
 [tool.zephyr-sdk]
 # The Zephyr SDK, host-keyed (issue 0610). `scripts/zephyr/setup.sh` used to


### PR DESCRIPTION
ARM links a CPython into gdb **statically** and bakes `sys.prefix` to a path from their build container, so on any other machine the interpreter finds no stdlib and aborts — fatally, taking gdb with it. The symptom was a debugger that exits 0 printing **nothing**, which reads as "installed fine": the compiler worked, the debugger did not.

`arm-none-eabi-gcc` 13.2-nros3 ships the matching 3.8 stdlib with a launcher pointing `PYTHONHOME` at it — 46 MB of `Lib/` trimmed to 11 MB on disk, **1.6 MB compressed**, no build and no compiler (NEWSLabNTU/nano-ros-sdk@9b60122).

The verdict is not my assertion — the `smoke` probe added for this issue flipped on its own, on all three surfaces that used to report `[BROKEN]`:

```
nros setup --tool arm-none-eabi-gcc --check  ->  [OK] ... 13.2-nros3
nros setup --check                           ->  0 installed but not working
just doctor                                  ->  [OK] installed tools run
```

### Three details, each learned by trying the other thing

- The Python minor is **derived from the binary**, and an unpinned one fails the build. ARM bumps it between releases; a stdlib for the wrong minor installs cleanly then fails at run time.
- The launcher stays in `bin/` with the real binary beside it, unlike the macOS bundler which moves binaries to `lib/`. gdb derives `--data-directory` from its own location, so moving it moves `share/gdb` out from under it. Verified it still resolves.
- The release job asserts `--version` prints `GNU gdb` before publishing, so this issue exact symptom is now a build failure rather than a user problem.

### The ceiling is ARM own, and this reaches it

Their x86_64 gdb exports **zero** Python C-API symbols, so no `.so` extension can load into it on any host — `import struct` and `import math` fail even with a full system python3.8 installed. This corrects my earlier claim that a pure stdlib sufficed for everything: it suffices for everything *attainable*. Pretty-printer machinery, `gdb.execute`, `re`/`collections`/`json` all work.

### Not fixed

`linux-arm64` becomes issue 0932 — there gdb links `libpython3.8.so.1.0` dynamically, so it fails at the **loader** rather than at interpreter init and needs the shared library rather than a stdlib. Its tarball is byte-identical to -nros2 (same sha256), which is how the release proved it touched only x86_64.

`just ci l1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG