### PR TITLE
fix(host-tests): no step sourced the repo env, so find_package(nano_ros) could not resolve

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -11,6 +11,21 @@
 # Medium/heavy lanes: PR (path-scoped) + nightly + on-demand — NOT every direct
 # push to main (a per-push run was cancelled by the next push within ~10 min and
 # never completed; #57 root). See docs/development/ci-workflow-reorg.md.
+#
+# EVERY step that invokes `just` or `nros` sources `./activate.sh` first. That is
+# the repo's activation SSoT and CLAUDE.md's sweep contract; three steps here
+# used to source `/opt/ros/humble/setup.bash` alone and six sourced nothing.
+# activate.sh is a strict superset of the ROS line — it sources ROS itself
+# (nounset-guarded, issue 0639) and additionally exports `nano_ros_ROOT`, which
+# is how `find_package(nano_ros)` resolves: the config lives at the checkout
+# root, not in a CMake prefix. Without it the workspace fixture build died at
+#
+#   CMake Error at CMakeLists.txt:23 (find_package):
+#     ... CMake did not find one.
+#
+# for every generated workspace root, because a generated root deliberately sets
+# no prefix. activate.sh only ever PREPENDS to PATH, so the `$GITHUB_PATH`
+# entries earlier steps add (the in-tree CLI, play_launch_parser) survive it.
 name: host-tests
 
 on:
@@ -85,6 +100,7 @@ jobs:
 
       - name: Provision workspace sources via nros
         run: |
+          source ./activate.sh
           nros setup --source px4-rs --source zenoh-pico --source mbedtls \
                      --source micro-cdr --source micro-xrce-dds-client \
                      --source cyclonedds-src
@@ -105,10 +121,14 @@ jobs:
       # they can), which is a worse result than running them but a far better
       # one than a job that always fails.
       - name: just ci provision-zenohd
-        run: just ci provision-zenohd
+        run: |
+          source ./activate.sh
+          just ci provision-zenohd
 
       - name: just test-unit
-        run: just test-unit
+        run: |
+          source ./activate.sh
+          just test-unit
 
   # ----- nros-tests integration (heavy; always completes) -----
   integration:
@@ -148,19 +168,23 @@ jobs:
 
       - name: Provision workspace sources via nros
         run: |
+          source ./activate.sh
           nros setup --source px4-rs --source zenoh-pico --source mbedtls \
                      --source micro-cdr --source micro-xrce-dds-client \
                      --source cyclonedds-src --source nuttx-libc
 
       # `test-integration` spawns zenohd to back the Phase 211/212 host tests.
       - name: just ci provision-zenohd
-        run: just ci provision-zenohd
+        run: |
+          source ./activate.sh
+          just ci provision-zenohd
 
       # Test prerequisites the way a user gets them — via `nros setup` (#25): the
       # patched qemu-system-arm (build/qemu/), the prebuilt Micro-XRCE-DDS Agent
       # (nros store), and play_launch_parser (launch-graph tool; best-effort).
       - name: Provision QEMU + XRCE agent + play_launch_parser (nros setup --tool)
         run: |
+          source ./activate.sh
           nros setup --tool qemu --prefix "$GITHUB_WORKSPACE/build/qemu" --index nros-sdk-index.toml
           nros setup --tool xrce-agent --index nros-sdk-index.toml
           nros setup --tool play_launch_parser --index nros-sdk-index.toml \
@@ -180,7 +204,9 @@ jobs:
       # swallowed (see below), and 296 tests then skipping for fixtures that were
       # never built.
       - name: Build nros-launch-resolve (nros sync needs it beside the CLI)
-        run: just setup-launch-resolve
+        run: |
+          source ./activate.sh
+          just setup-launch-resolve
 
       # The native integration tests spawn PREBUILT example binaries via
       # `require_prebuilt_binary`. Stage them by building the fixtures the way a
@@ -198,7 +224,7 @@ jobs:
           NROS_BUILD_JOBS: "2"
           CARGO_BUILD_JOBS: "2"
         run: |
-          source /opt/ros/humble/setup.bash
+          source ./activate.sh
           mkdir -p build/ci-logs
           echo "before:"; df -h / | tail -1
           # FAIL, do not swallow. This used to end `|| { tail; echo "partial —
@@ -222,7 +248,7 @@ jobs:
           NROS_BUILD_JOBS: "2"
           CARGO_BUILD_JOBS: "2"
         run: |
-          source /opt/ros/humble/setup.bash
+          source ./activate.sh
           just native build-workspace-fixtures > build/ci-logs/workspace.log 2>&1 \
             || { echo "::group::workspace FAILED tail"; tail -120 build/ci-logs/workspace.log; echo "::endgroup::"; \
                  echo "::group::issue 0919 — feature resolution for zpico-sys"; \
@@ -244,7 +270,7 @@ jobs:
           NROS_FIXTURES_OPTIONAL: "1"
           CARGO_BUILD_JOBS: "2"
         run: |
-          source /opt/ros/humble/setup.bash
+          source ./activate.sh
           mkdir -p build/ci-logs
           set +e
           just test-integration > build/ci-logs/test-integration.log 2>&1

--- a/docs/issues/0933-workflow-steps-missing-repo-env.md
+++ b/docs/issues/0933-workflow-steps-missing-repo-env.md
@@ -1,0 +1,100 @@
+---
+id: 933
+title: "28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and
+  nothing gates the class"
+status: open
+type: bug
+area: ci
+related: [0639]
+---
+
+## What is wrong
+
+CLAUDE.md's sweep contract says every `just <plat>` invocation needs
+`source ./activate.sh` first, and `just doctor` enforces it *for a developer's
+shell*. Nothing enforces it for a CI step, and CI steps are the one place where
+the shell is fresh every time.
+
+An audit of `.github/workflows/*.yml` — a step counts if its `run:` invokes
+`just` or `nros` and its body contains neither `source ./activate.sh` nor
+`source ./setup.bash`:
+
+| workflow | steps missing the repo environment |
+| --- | --- |
+| `host-tests.yml` | 9 — **fixed**, see below |
+| `nightly.yml` | 14 |
+| `pr-checks.yml` | 11 |
+| `post-submit.yml` | 2 |
+| `queue-notify.yml` | 1 |
+| `docs.yml`, `images.yml`, `nightly-report.yml`, `queue.yml` | 0 |
+
+The `host-tests.yml` nine are fixed in the commit that files this issue. The
+remaining 28 are untouched, deliberately — see "Why the rest is not fixed here".
+
+## How it surfaced
+
+`host-tests`' "Build workspace fixtures" step sourced `/opt/ros/humble/setup.bash`
+and nothing else, so `nano_ros_ROOT` was unset and the generated workspace root
+could not resolve its own package:
+
+```
+CMake Error at CMakeLists.txt:23 (find_package):
+  By not providing "Findnano_ros.cmake" in CMAKE_MODULE_PATH this project has
+  asked CMake to find a package configuration file provided by "nano_ros",
+  but CMake did not find one.
+```
+
+`nano_rosConfig.cmake` lives at the **checkout root** and is located via
+`nano_ros_ROOT`, which `activate.sh` exports (`activate.sh:83`). A generated
+workspace root sets no prefix on purpose — its paths stay relative so they are
+byte-identical across machines — so the environment is the only channel.
+
+The failure was invisible locally in both directions at once, which is why it
+took a cold reproduction to see:
+
+- a developer shell has always sourced `activate.sh`, so the variable is set;
+- a warm build directory carries `nano_ros_DIR:PATH=<checkout>` in its
+  `CMakeCache.txt`, so even an unsourced re-configure succeeds on a tree that
+  once worked.
+
+Reproduce cold, and confirm the fix, with:
+
+```bash
+cd examples/workspaces/c
+env -u CMAKE_PREFIX_PATH -u nano_ros_ROOT \
+  cmake -S build/posix-zenoh-native -B /tmp/cold -DNROS_RMW=zenoh   # the error above
+( source ./activate.sh && cmake -S build/posix-zenoh-native -B /tmp/warm -DNROS_RMW=zenoh )
+                                                                    # -- Configuring done
+```
+
+`activate.sh` is a strict superset of the bare ROS line: it sources ROS itself
+(picking the file the current shell can read, and nounset-guarded — issue 0639)
+and additionally exports `NROS_REPO_DIR`, `nano_ros_ROOT`, the cargo `--locked`
+PATH shim, and the toolchain directories. It only ever *prepends* to `PATH`, so
+`$GITHUB_PATH` entries an earlier step added survive it.
+
+## Why the rest is not fixed here
+
+Adding `source ./activate.sh` is not behaviour-neutral. `activate.sh` puts
+`scripts/bin/cargo` on `PATH`, which injects `--locked` project-wide
+(`NROS_CARGO_FLAGS`, issues 0359/0378). Every one of the 11 `pr-checks.yml`
+steps sits under the **required** `CI` aggregator check, so applying the sweep
+blind would risk the merge queue on a change nobody had run. The 14 nightly
+steps cannot be verified from a developer host at all.
+
+That is a reason to sequence the sweep, not to skip it.
+
+## What would close this
+
+1. Apply `source ./activate.sh` to the remaining 28 steps, one workflow per
+   pull request, each one observed green before the next — `post-submit.yml`
+   and `queue-notify.yml` (3 steps) first, `nightly.yml` next, `pr-checks.yml`
+   last.
+2. Add a gate for the class. It is a pure source-level check over
+   `.github/workflows/*.yml` — parse the YAML, and for each step whose `run:`
+   invokes `just` or `nros`, require the body to source the activation script —
+   so it belongs on the fast, buildless line. `check-just-recipe-refs` reads
+   `just/*.just` and has never read `.github/workflows/`, which is the coverage
+   gap that let three different spellings of "activate" coexist in one file.
+3. Where a step legitimately needs no environment, it should say so in a
+   comment and the gate should key on that marker rather than on absence.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -67,5 +67,6 @@ fails if this block drifts.
 - **#0914** (testing) — Nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot evaluate anything passes every check See `0914-*`.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
 - **#0932** (tooling) — The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle nor the gdb Python, and its gdb fails EARLIER than x86_64's did See `0932-*`.
+- **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
`host-tests`' workspace fixture build died at

```
CMake Error at CMakeLists.txt:23 (find_package):
  By not providing "Findnano_ros.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "nano_ros",
  but CMake did not find one.
```

`nano_rosConfig.cmake` lives at the checkout root and is located via `nano_ros_ROOT`, which `activate.sh:83` exports. A generated workspace root sets no CMake prefix on purpose — its paths stay relative so they are byte-identical across machines — so the environment is the only channel that can carry it.

Three steps sourced `/opt/ros/humble/setup.bash` alone and six sourced nothing. All nine now source `./activate.sh`, the activation SSoT and what CLAUDE.md's sweep contract requires before any `just <plat>` invocation. It is a strict superset of the bare ROS line — it sources ROS itself (choosing the file the current shell can read, nounset-guarded, issue 0639) and additionally exports `nano_ros_ROOT`. It only ever *prepends* to `PATH`, so the `$GITHUB_PATH` entries earlier steps add (the in-tree CLI, `play_launch_parser`) survive it.

### Why it was invisible locally

Both directions at once: a developer shell has always sourced `activate.sh`, and a warm build directory carries `nano_ros_DIR:PATH=<checkout>` in its `CMakeCache.txt`, so even an unsourced re-configure succeeds on a tree that once worked. Verified cold, both ways:

```bash
cd examples/workspaces/c
env -u CMAKE_PREFIX_PATH -u nano_ros_ROOT \
  cmake -S build/posix-zenoh-native -B /tmp/cold -DNROS_RMW=zenoh   # the error above
( source ./activate.sh && cmake -S build/posix-zenoh-native -B /tmp/warm -DNROS_RMW=zenoh )
                                                                    # -- Configuring done
```

### Sweep

A step counts when its `run:` invokes `just`/`nros` and sources neither activation script:

| workflow | missing |
| --- | --- |
| `host-tests.yml` | 9 — fixed here |
| `nightly.yml` | 14 |
| `pr-checks.yml` | 11 |
| `post-submit.yml` | 2 |
| `queue-notify.yml` | 1 |
| `docs`, `images`, `nightly-report`, `queue` | 0 |

The other 28 are filed as **issue 0933** rather than swept blind: sourcing `activate.sh` is not behaviour-neutral (it puts `scripts/bin/cargo` on `PATH`, which injects `--locked` project-wide), and all 11 `pr-checks` steps sit under the required `CI` aggregator. 0933 sequences them one workflow per PR and asks for the gate this class never had — `check-just-recipe-refs` reads `just/*.just` and has never read `.github/workflows/`.

Gates: `just check fast` green (137 ran, 4 skipped for host preconditions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB