### PR TITLE
fix(#0932): arm64's gdb works too — libpython from Ubuntu's own archive

### DIFF
--- a/docs/issues/archived/0932-arm64-toolchain-dist-unbundled.md
+++ b/docs/issues/archived/0932-arm64-toolchain-dist-unbundled.md
@@ -2,7 +2,7 @@
 id: 932
 title: "The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle
   nor the gdb Python, and its gdb fails EARLIER than x86_64's did"
-status: open
+status: resolved
 type: bug
 area: tooling
 related: [0926, 0928, 0929]
@@ -60,3 +60,56 @@ Nothing here can be checked on an x86_64 developer host. The release job's own
 `gdb-python: OK` assertion runs per host, so an arm64 fix proves itself in CI —
 and `nros setup --tool arm-none-eabi-gcc --check` reports `[BROKEN]` on an arm64
 host until it lands, via the `smoke` probe (phase-404 / issue 0929).
+
+## Resolved (2026-08-30) — `arm-none-eabi-gcc` 13.2-nros4
+
+Both fixes now land on arm64, and the route is DIFFERENT from x86_64's because
+the hosts embed Python differently — which is exactly why one fix had not
+covered both.
+
+**The shared library comes from Ubuntu's own archive.** 22.04 packages no
+python3.8; focal does, for arm64, at `ports.ubuntu.com`. That is the same
+publisher as the runner's own packages — not a PPA (a supply-chain decision
+nobody asked for) and not a source build (which would turn a repackage into a
+compile). It needs at most GLIBC_2.29 against the runner's 2.35, so a
+focal-built library runs on jammy.
+
+Of the four directions this issue listed, the one taken was **none of them**:
+direction 3 said python.org publishes no Linux binaries, which is true, and I
+had not thought to ask whether UBUNTU publishes an older one. It does.
+
+**Ordering was the thing that had failed before.** libpython goes into the
+prefix and the rpath is set BEFORE `bundle_linux_libs`, because the bundler
+resolves through `ldd` and cannot copy what it cannot find — `bundle: cannot
+resolve libpython3.8.so.1.0` is precisely how this host stayed broken. It then
+recognises the library as already ours and walks its needs without copying it
+onto itself, the case added when the bundler was first shared.
+
+**arm64 now has MORE working Python than x86_64.** `struct` and `math` are built
+into Ubuntu's libpython (`nm -D` finds `PyInit__struct`) and 41 more modules
+arrive in lib-dynload, all resolving against the shared library gdb loaded. On
+x86_64 no extension can ever load, because ARM's static build exports no C-API.
+
+Proven on the arm64 runner, which is the only place it can be:
+
+    gdb-python: gdb LINKS libpython3.8 — taking it from Ubuntu focal
+    bundled 5 libs into lib/ (rpath $ORIGIN/../lib)
+    gdb-check: runs — GNU gdb (Arm GNU Toolchain 13.2.rel1 ...)
+    gdb-check: embedded python — PYOK 3.8.10
+    gdb-check: extension modules load (shared libpython)
+
+The verification moved OUT of `ship_gdb_python` into `verify_gdb_runs` so it
+runs after bundling: on arm64 gdb also needs the ncurses the bundler supplies,
+so checking earlier would have failed for the wrong reason.
+
+The arm64 tarball's sha256 finally CHANGED — it had been byte-identical to
+-nros2 across three releases, which is how each of those proved it had touched
+only x86_64.
+
+## Residue
+
+A few lib-dynload modules carry focal-era dependencies jammy lacks (`_ssl` and
+`_hashlib` want `libssl.so.1.1`), so those imports fail with an ImportError
+naming the library. That is the normal shape of an optional extension with an
+unmet dependency, a debugger needs none of them, and bundling a deprecated TLS
+stack so `import ssl` works inside gdb would ship it for no user.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,7 +66,6 @@ fails if this block drifts.
 - **#0902** (build, rmw) — Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed files out of the whole library, so a patch is silently not compiled See `0902-*`.
 - **#0914** (testing) — Nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot evaluate anything passes every check See `0914-*`.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
-- **#0932** (tooling) — The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle nor the gdb Python, and its gdb fails EARLIER than x86_64's did See `0932-*`.
 - **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -90,12 +90,19 @@ install = "make -j$(nproc) && make install"
 # system python3.8. Pretty-printers, `gdb.execute`, `re`/`collections`/`json`
 # all work; the 34 modules ARM built in are the whole surface.
 #
-# linux-arm64 gets NEITHER fix: there gdb links `libpython3.8.so.1.0`
-# dynamically, so it needs the shared library and not merely a stdlib, and 22.04
-# packages none. Its tarball is byte-identical to -nros2 (same sha256), which is
-# the check that this release touched only x86_64.
+# -nros4 fixes linux-arm64 too (issue 0932), by a DIFFERENT route, because the
+# two hosts embed Python differently: there gdb LINKS `libpython3.8.so.1.0` and
+# fails at the loader before any interpreter runs, so a stdlib alone could not
+# help. 22.04 packages no python3.8 — Ubuntu's own focal archive does, for
+# arm64, and a library needing at most GLIBC_2.29 runs on the runner's 2.35.
+#
+# arm64 therefore ends up with MORE working Python than x86_64: `struct` and
+# `math` are built into Ubuntu's libpython and 41 more modules arrive in
+# lib-dynload, all resolving against the shared library — so `import struct`
+# works there and can never work on x86_64. The build asserts exactly that, per
+# host, before publishing.
 [tool.arm-none-eabi-gcc]
-version = "13.2-nros3"
+version = "13.2-nros4"
 smoke = [
     { run = "bin/arm-none-eabi-gcc --version", expect = "Arm GNU Toolchain" },
     { run = "bin/arm-none-eabi-gdb --version", expect = "GNU gdb" },
@@ -107,9 +114,9 @@ smoke = [
 system = ["libcrypt1"]
 upstream = "13.2.rel1" # ARM release id (SSOT — build script no longer hand-derives)
 # Repackaged from ARM's release; no in-repo source build (binary toolchain).
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "1e5f6dbf853b70ae5b1fcc17dd3d3a877172f5520adc7ddb1d1da40ce73282ea" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "127136d54db66f2ed405d8bc01b1280a9cc78f2cbcc04466894c75c109b942d7" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "27d5e5f6f9428157df7900c91b000486184f99fbc1a35ea5c3ca219be9068197" }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "841e456d571e3f60244652a5ac7287f9e06a9c61f1fc93d2fbbc037b05f5a6ab" }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
 
 [tool.zephyr-sdk]
 # The Zephyr SDK, host-keyed (issue 0610). `scripts/zephyr/setup.sh` used to


### PR DESCRIPTION
The arm64 leg had **neither** fix — no ncurses bundle, no gdb Python — and its tarball had been byte-identical to -nros2 across three releases, which is how each of those proved it touched only x86_64. That sha256 has finally changed.

### Why one fix did not cover both hosts

```
x86_64  Python is STATIC in gdb, exporting no C-API symbols.
        A stdlib is all it can use, and all it needs.
arm64   gdb LINKS libpython3.8.so.1.0 — it fails at the LOADER, before any
        interpreter runs, so a stdlib alone could not help.
```

22.04 packages no python3.8. **Ubuntu own archive does** — focal, arm64, at ports.ubuntu.com: the same publisher as the runner packages, rather than a PPA or a source build. It needs at most GLIBC_2.29 against the runner 2.35.

Of the four directions issue 0932 listed, the one taken was none of them. I had written that python.org publishes no Linux binaries — true — without asking whether *Ubuntu* publishes an older one. It does.

### Ordering is what had failed before

libpython goes into the prefix and the rpath is set **before** `bundle_linux_libs`, because the bundler resolves through `ldd` and cannot copy what it cannot find. `bundle: cannot resolve libpython3.8.so.1.0` is exactly how this host stayed broken.

### arm64 now has more working Python than x86_64

`struct` and `math` are built into Ubuntu libpython and 41 more modules arrive in lib-dynload, all resolving against the shared library — so `import struct` works there and can never work on x86_64.

Proven on the arm64 runner, the only place it can be:

```
gdb-python: gdb LINKS libpython3.8 — taking it from Ubuntu focal
bundled 5 libs into lib/ (rpath $ORIGIN/../lib)
gdb-check: runs — GNU gdb (Arm GNU Toolchain 13.2.rel1 ...)
gdb-check: embedded python — PYOK 3.8.10
gdb-check: extension modules load (shared libpython)
```

sdk side: NEWSLabNTU/nano-ros-sdk@53e2871. `just ci l1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG