### PR TITLE
fix(ci): a stacked PR's events were filtered out, so #71 had NO VERDICT for 13 hours

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,8 +38,38 @@ on:
       - ".gitmodules"
       - ".github/workflows/pr-checks.yml"
   pull_request:
-    branches: [main]
-    # NO `paths:` filter, and this is load-bearing rather than an oversight.
+    # NO `branches:` filter and NO `paths:` filter. Both are load-bearing rather
+    # than oversights, and they are the same trap on two different axes.
+    #
+    # `branches: [main]` was here until PR #71 deadlocked on it. That PR was
+    # STACKED — opened against `fix/0041-zephyr-heap-knob` (PR #61's branch),
+    # not against main — so every `pull_request` event it produced was filtered
+    # out before a workflow could be dispatched:
+    #
+    #   01:32  opened            base is not main  -> filtered
+    #   01:57  synchronize       base is not main  -> filtered
+    #   01:58  base retargeted to main             -> GitHub emits
+    #          `pull_request.edited`, which is NOT one of the default types
+    #          (`opened`, `synchronize`, `reopened`), so nothing dispatched
+    #   01:58  auto-merge enabled
+    #
+    # Net: ZERO check suites for the head sha, thirteen hours and counting,
+    # auto-merge armed against a required check that was never requested. Not
+    # failing — permanently ineligible, exactly like PR #13 below.
+    #
+    # Retargeting is the trap's teeth: it is the natural thing to do when the
+    # PR underneath you merges, it looks like it should re-run everything, and
+    # it re-runs nothing. Dropping the filter fixes it at the root instead of
+    # subscribing to `edited` (which would also fire on every title and body
+    # edit): a stacked PR now gets its checks while it is still stacked, and
+    # because check runs attach to the COMMIT rather than to the PR, the
+    # retarget inherits them and the rollup is already populated.
+    #
+    # A stacked PR's checks are not wasted work either — its head sha is what
+    # eventually reaches the queue, so this is the same verification, earlier.
+    #
+    # And the `paths:` half, which is the older lesson:
+    #
     #
     # `check` is a REQUIRED status check. A path-filtered required check never
     # runs for a pull request outside those paths, so it never REPORTS, so the
@@ -47,9 +77,12 @@ on:
     # (docs only) hit exactly this: zero checks in its rollup and no way to
     # merge.
     #
-    # The same sentence is already written under `merge_group:` below. It was
-    # true here too and applying it only there is the "fix the reported site,
-    # not the class" mistake CLAUDE.md names.
+    # The same sentence is already written under `merge_group:` below, and it
+    # was true of `branches:` above. Three spellings of one rule: a required
+    # check must be reachable from every event that can produce the head sha
+    # a merge is asked to admit. Applying the rule to one axis at a time is
+    # the "fix the reported site, not the class" mistake CLAUDE.md names —
+    # each of the three was fixed only after it had already frozen a PR.
     #
     # Affordable because the PR gate is now cheap — `check-fast` plus a compile
     # smoke, not the full tier — so a docs-only PR pays a few minutes rather

--- a/justfile
+++ b/justfile
@@ -2035,6 +2035,16 @@ tier-health *args:
 nightly-triage runs="3":
     @python3 scripts/ci/nightly-triage.py --runs {{runs}}
 
+# Which open PRs can never merge because nothing ever ran on them? A PR with
+# ZERO check suites is not failing and not pending — it is silently ineligible,
+# and auto-merge can sit armed against a check that was never requested (PR #71,
+# thirteen hours). Read-only; never gates (needs network + authenticated gh).
+#
+#   just pr-verdicts           just pr-verdicts --min-age 5
+[group("setup")]
+pr-verdicts *ARGS:
+    @bash scripts/ci/pr-verdict-check.sh {{ARGS}}
+
 # Triage a merge-queue ejection — answers the one question GitHub cannot:
 # is this MY defect, or is the check red for everybody? Re-queuing an unchanged
 # commit re-runs the same tree and fails the same way, one batch slot at a time.

--- a/scripts/ci/pr-verdict-check.sh
+++ b/scripts/ci/pr-verdict-check.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Which open pull requests can never be merged because nothing ever ran on them?
+#
+# WHY THIS EXISTS
+#
+# A pull request has three states people plan for — green, red, still running —
+# and a fourth nobody watches: NO VERDICT. GitHub never dispatched a workflow
+# for the head commit, so the required check is not failing, not pending, and
+# not present. The PR sits BLOCKED forever. Auto-merge can be armed against it,
+# which makes it look handled.
+#
+# It is invisible in every place you would normally look. The PR page shows no
+# red X. `gh pr list` shows it as open like any other. `gh pr checks` prints
+# "no checks reported on this branch", which reads as "too early" rather than
+# "never". Only asking for the head commit's check SUITES distinguishes the two,
+# because a dispatched-then-skipped workflow still creates a suite and an
+# undispatched one creates nothing at all.
+#
+# PR #71 sat this way for thirteen hours. It was STACKED — opened against
+# another PR's branch — and `pr-checks.yml` filtered `pull_request` on
+# `branches: [main]`, so its `opened` and `synchronize` events were dropped.
+# Retargeting it to main afterwards emitted `pull_request.edited`, which is not
+# one of the default event types, so that dispatched nothing either. The filter
+# is gone now; this script is the part that does not depend on having predicted
+# the mechanism, because the next no-verdict cause will be a different one — a
+# workflow file that fails to parse at the head commit, an Actions outage, a
+# run-limit rejection — and all of them look identical from here.
+#
+# Read-only. Never gates: it needs the network and an authenticated `gh`, which
+# is exactly what a gate may not assume.
+#
+# Usage:
+#   just pr-verdicts              # audit every open PR
+#   just pr-verdicts --min-age 5  # call a head sha stale after 5 minutes
+set -euo pipefail
+
+MIN_AGE_MIN=15
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --min-age) MIN_AGE_MIN="${2:?--min-age needs minutes}"; shift 2 ;;
+        -h|--help) sed -n '2,32p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) echo "pr-verdict-check: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "pr-verdict-check: needs the gh CLI" >&2; exit 2; }
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+NOW="$(date -u +%s)"
+
+# `--json` once, not per PR: the list is the only call that scales with the
+# number of open PRs, and the per-PR suite query below is already one round
+# trip each.
+prs="$(gh pr list --repo "$REPO" --state open --limit 100 \
+        --json number,title,headRefOid,isDraft,autoMergeRequest,baseRefName \
+        -q '.[]|[.number,.headRefOid,(.isDraft|tostring),(.autoMergeRequest!=null|tostring),.baseRefName,.title]|@tsv')"
+
+stuck=0
+pending=0
+ok=0
+
+while IFS=$'\t' read -r num sha draft automerge base title; do
+    [ -n "${num:-}" ] || continue
+
+    suites="$(gh api "repos/$REPO/commits/$sha/check-suites" -q .total_count 2>/dev/null || echo "?")"
+    if [ "$suites" = "?" ]; then
+        echo "#$num — could not read check suites for $sha (transient?)"
+        continue
+    fi
+    if [ "$suites" -gt 0 ]; then
+        ok=$((ok + 1))
+        continue
+    fi
+
+    # Zero suites is only actionable once GitHub has had time to dispatch.
+    # A head sha pushed a minute ago legitimately has none yet, and reporting
+    # that as a deadlock would train people to ignore this script.
+    pushed="$(gh api "repos/$REPO/commits/$sha" -q .commit.committer.date 2>/dev/null || echo "")"
+    age_min=9999
+    if [ -n "$pushed" ]; then
+        pushed_s="$(date -u -d "$pushed" +%s 2>/dev/null || echo 0)"
+        [ "$pushed_s" -gt 0 ] && age_min=$(( (NOW - pushed_s) / 60 ))
+    fi
+
+    if [ "$age_min" -lt "$MIN_AGE_MIN" ]; then
+        pending=$((pending + 1))
+        echo "#$num — no checks yet, head is ${age_min}m old (below --min-age ${MIN_AGE_MIN}m); recheck later"
+        continue
+    fi
+
+    stuck=$((stuck + 1))
+    echo
+    echo "#$num NO VERDICT — head $sha has ZERO check suites after ${age_min}m"
+    echo "    $title"
+    echo "    base=$base draft=$draft auto-merge=$automerge"
+    [ "$automerge" = "true" ] && \
+        echo "    auto-merge is ARMED against a check that was never requested — it will never fire."
+    echo "    Remedy (either forces a fresh pull_request event):"
+    echo "      gh pr close $num && gh pr reopen $num      # fires 'reopened'; clears auto-merge, re-arm after"
+    echo "      git commit --allow-empty && git push        # fires 'synchronize'"
+done <<EOF
+$prs
+EOF
+
+echo
+if [ "$stuck" -gt 0 ]; then
+    echo "pr-verdict-check: $stuck pull request(s) with NO VERDICT, $pending too fresh to judge, $ok reporting."
+    echo "  A no-verdict PR is not failing and not running. It is ineligible, silently."
+    exit 1
+fi
+echo "pr-verdict-check: OK — $ok pull request(s) reporting, $pending too fresh to judge, none stuck."


### PR DESCRIPTION
PR #71 had **zero check suites** for its head commit. Not red, not pending — nothing was ever dispatched, so the required `CI` check could not report and the PR was permanently ineligible. Auto-merge sat armed against it, which made it look handled.

### Mechanism

`pr-checks.yml` filtered `pull_request` on `branches: [main]`. #71 was **stacked**: opened against `fix/0041-zephyr-heap-knob` (PR #61's branch), whose head commit is the middle of #71's three-commit chain.

```
01:32  opened            base is not main  -> filtered
01:57  synchronize       base is not main  -> filtered
01:58  base retargeted to main             -> pull_request.edited, not one of the
       default types (opened/synchronize/reopened) -> nothing dispatched
01:58  auto-merge enabled
```

Retargeting is the trap's teeth: it is the natural move when the PR underneath you merges, it looks like it should re-run everything, and it re-runs nothing.

### Third spelling of one rule

This file already documents the other two at length. A required check must be reachable from **every** event that can produce the head sha a merge is asked to admit:

| filter | froze |
| --- | --- |
| `paths:` on `pull_request` | PR #13 (docs-only) |
| missing `merge_group:` trigger | PR #6 |
| `branches:` on `pull_request` | **PR #71** |

Each was fixed only after it had already frozen a PR — one axis at a time, the "fix the reported site, not the class" mistake.

Dropping the filter fixes it at the root rather than subscribing to `edited` (which would also fire on every title and body edit): a stacked PR gets its checks while still stacked, and because check runs attach to the **commit**, a later retarget inherits them. Not wasted work — that head sha is what eventually reaches the queue, so it is the same verification, earlier.

Audit: `pr-checks.yml` was the only `pull_request` trigger across all nine workflows carrying a `branches`, `paths` or `types` filter.

### `just pr-verdicts`

A filter fix cannot cover the class alone — the next no-verdict cause will be a different mechanism (a workflow file that fails to parse at the head commit, an Actions outage, a run-limit rejection) and all of them look identical from the PR page. The detector asks the one question that separates them: does the head commit have any check **suites**? A dispatched-then-skipped workflow creates one; an undispatched workflow creates none. `gh pr checks` cannot tell these apart — it prints "no checks reported on this branch" for both, which reads as *too early* rather than *never*.

It holds a fresh head sha for `--min-age` (default 15m) rather than calling it stuck. Against the current backlog it names #71 and only #71, holds #94 at 9m, and passes 9.

Gates: `just check fast` green (137 ran, 4 skipped for host preconditions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB