### PR TITLE
docs(#0935): every `.launch.py` aborts through the shipped resolver — and #0914's premise was wrong

### DIFF
--- a/docs/issues/0914-resolver-shipped-pair-untested.md
+++ b/docs/issues/0914-resolver-shipped-pair-untested.md
@@ -8,6 +8,24 @@ area: testing
 related: [issue-0897, issue-0400, phase-332]
 ---
 
+> **CORRECTION (2026-08-30).** The headline claim below — "no test runs that
+> pair as installed" — is FALSE, and was already false when this was filed.
+> `packages/testing/nros-tests/tests/multihost_partition_bake.rs` invokes the
+> INSTALLED binary by path against `multihost.launch.xml` with `host:=`, which
+> needs `$(eval …)` and therefore the Python half. It predates this issue
+> (phase 211.F-2) and runs in `host-tests`' integration job. Verified by
+> removing `libplay_launch_parser_pyexec.so`: all three of its tests FAIL.
+>
+> So the interval this issue describes was not undetected — that red WAS this
+> test, which is why `host-tests` was red on the launch file it names.
+>
+> What survives, and is worse than what was filed: the coverage is XML-only.
+> **Every `.launch.py` aborts through the shipped resolver** — issue 0935, root
+> cause found, and it hides behind in-process tests exactly as this issue's
+> reasoning predicted. The one remaining gap here is that
+> `multihost_partition_bake` has no interpreter probe, so a Python-less host
+> gets a failure where this issue correctly asked for a skip.
+
 ## Problem
 
 `nros-launch-resolve` is TWO artifacts since issue 0897 W3: the binary, and

--- a/docs/issues/0935-launch-py-aborts-through-the-shipped-pyexec.md
+++ b/docs/issues/0935-launch-py-aborts-through-the-shipped-pyexec.md
@@ -1,0 +1,107 @@
+---
+id: 935
+title: "Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s
+  inputs and outputs travel by a thread-local the dlopen split duplicated"
+status: open
+type: bug
+area: tooling, cli
+related: [0914, 0897, 0915, phase-332]
+---
+
+## Symptom
+
+The shipped `nros-launch-resolve` cannot resolve ANY Python launch file. Not a
+clean error — an abort:
+
+    $ nros-launch-resolve <anything>.launch.py -o m.yaml
+    thread '<unnamed>' panicked at crates/play_launch_parser/src/bridge.rs:367:
+      No LaunchContext set - Python execution must be called through LaunchTraverser
+    --- PyO3 is resuming a panic after fetching a PanicException from Python. ---
+    panic in a function that cannot unwind
+    thread caused non-unwinding panic. aborting.
+
+Measured on all three in-tree fixtures, including `test_no_import.launch.py`,
+which imports nothing — so it is not about ROS packages being on `sys.path`.
+
+XML is unaffected: `$(eval …)` works, and `multihost_partition_bake` passes and
+fails correctly when `libplay_launch_parser_pyexec.so` is removed.
+
+## Cause
+
+`exec_file` communicates through a **process-wide thread-local that is no longer
+process-wide.** The C ABI carries `{op, arg}` and nothing else, and both sides
+say so in their own comments:
+
+`c_abi.rs`, on the response value:
+
+> Empty for `exec_file`, whose effects land in the parser's thread-local launch
+> context, not here.
+
+`executor.rs`, before running the file:
+
+> Launch configurations are already in the thread-local LaunchContext
+> (set by `execute_python_file()` before calling this executor)
+
+`execute_python_file()` runs in the BINARY. The executor runs in the `.so`. And
+**both statically link `play_launch_parser`** — `with_launch_context` is present
+in each and exported by neither:
+
+    nros-launch-resolve              internal=2  exported=0
+    libplay_launch_parser_pyexec.so  internal=12 exported=0
+
+So there are two `CURRENT_LAUNCH_CONTEXT` thread-locals. The binary sets its
+own; Python runs inside the `.so` and calls that copy, which is `None`. Same
+thread, different variable.
+
+`$(eval …)` survives because its request carries the expression and its response
+carries the result — that path never touches the shared state. `exec_file`
+carries neither direction, which is exactly why it is the one that broke.
+
+## Why every test says it is fine
+
+`play_launch_parser` has a **dev-dependency on `pyexec`**, so its own
+`.launch.py` tests link the executor IN-PROCESS: one copy of the crate, one
+thread-local, green. The shipped configuration `dlopen`s a second copy.
+
+That is issue 0914's thesis — "a test that builds its own Python half proves the
+mechanism and not the packaging" — with a worse consequence than 0914 described.
+0914 was wrong that nothing covers the shipped pair (`multihost_partition_bake`
+does, by path, and fails when the `.so` is removed); it was right that the
+coverage is shaped so this class hides in it, and the `.launch.py` half is not
+merely untested but broken.
+
+## Fix
+
+`exec_file` needs both directions in the protocol, since the shared state it was
+written against does not exist:
+
+1. **Request carries the launch configurations**, so the `.so` can establish its
+   OWN `LaunchContextGuard` for the duration of execution.
+2. **Response carries the captures** (nodes, containers, load_nodes, global
+   params), which the binary merges into its context — today they are written to
+   the `.so`'s copy and discarded when it returns.
+
+Rejected alternatives, and why:
+
+* **Export the bridge symbols from the binary** so the `.so` resolves them at
+  load. Makes the ABI the whole Rust surface rather than two C functions, and
+  reintroduces exactly the coupling issue 0897 removed.
+* **Make `play_launch_parser` a shared library** so one copy exists. Same
+  coupling, plus a second `.so` to ship and version.
+
+Both are worse than serialising two more fields.
+
+## Also worth fixing while there
+
+A `panic!` inside a PyO3 callback becomes a PanicException and then a
+non-unwinding abort with a 27-frame backtrace. `with_launch_context` should
+return a `Result` a caller can report, so a missing context reads as an error
+about a launch file rather than a crash in the tool.
+
+## Verifying
+
+A test that resolves a `.launch.py` through the INSTALLED binary by path — the
+shape issue 0914 asked for and the fixtures already exist. It must SKIP (not
+pass) where no interpreter is usable, or it re-creates the hole one level down.
+Note `multihost_partition_bake` currently has no Python probe, so on a
+Python-less host it fails rather than skipping.

--- a/docs/issues/archived/0932-arm64-toolchain-dist-unbundled.md
+++ b/docs/issues/archived/0932-arm64-toolchain-dist-unbundled.md
@@ -2,7 +2,7 @@
 id: 932
 title: "The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle
   nor the gdb Python, and its gdb fails EARLIER than x86_64's did"
-status: open
+status: resolved
 type: bug
 area: tooling
 related: [0926, 0928, 0929]
@@ -60,3 +60,56 @@ Nothing here can be checked on an x86_64 developer host. The release job's own
 `gdb-python: OK` assertion runs per host, so an arm64 fix proves itself in CI —
 and `nros setup --tool arm-none-eabi-gcc --check` reports `[BROKEN]` on an arm64
 host until it lands, via the `smoke` probe (phase-404 / issue 0929).
+
+## Resolved (2026-08-30) — `arm-none-eabi-gcc` 13.2-nros4
+
+Both fixes now land on arm64, and the route is DIFFERENT from x86_64's because
+the hosts embed Python differently — which is exactly why one fix had not
+covered both.
+
+**The shared library comes from Ubuntu's own archive.** 22.04 packages no
+python3.8; focal does, for arm64, at `ports.ubuntu.com`. That is the same
+publisher as the runner's own packages — not a PPA (a supply-chain decision
+nobody asked for) and not a source build (which would turn a repackage into a
+compile). It needs at most GLIBC_2.29 against the runner's 2.35, so a
+focal-built library runs on jammy.
+
+Of the four directions this issue listed, the one taken was **none of them**:
+direction 3 said python.org publishes no Linux binaries, which is true, and I
+had not thought to ask whether UBUNTU publishes an older one. It does.
+
+**Ordering was the thing that had failed before.** libpython goes into the
+prefix and the rpath is set BEFORE `bundle_linux_libs`, because the bundler
+resolves through `ldd` and cannot copy what it cannot find — `bundle: cannot
+resolve libpython3.8.so.1.0` is precisely how this host stayed broken. It then
+recognises the library as already ours and walks its needs without copying it
+onto itself, the case added when the bundler was first shared.
+
+**arm64 now has MORE working Python than x86_64.** `struct` and `math` are built
+into Ubuntu's libpython (`nm -D` finds `PyInit__struct`) and 41 more modules
+arrive in lib-dynload, all resolving against the shared library gdb loaded. On
+x86_64 no extension can ever load, because ARM's static build exports no C-API.
+
+Proven on the arm64 runner, which is the only place it can be:
+
+    gdb-python: gdb LINKS libpython3.8 — taking it from Ubuntu focal
+    bundled 5 libs into lib/ (rpath $ORIGIN/../lib)
+    gdb-check: runs — GNU gdb (Arm GNU Toolchain 13.2.rel1 ...)
+    gdb-check: embedded python — PYOK 3.8.10
+    gdb-check: extension modules load (shared libpython)
+
+The verification moved OUT of `ship_gdb_python` into `verify_gdb_runs` so it
+runs after bundling: on arm64 gdb also needs the ncurses the bundler supplies,
+so checking earlier would have failed for the wrong reason.
+
+The arm64 tarball's sha256 finally CHANGED — it had been byte-identical to
+-nros2 across three releases, which is how each of those proved it had touched
+only x86_64.
+
+## Residue
+
+A few lib-dynload modules carry focal-era dependencies jammy lacks (`_ssl` and
+`_hashlib` want `libssl.so.1.1`), so those imports fail with an ImportError
+naming the library. That is the normal shape of an optional extension with an
+unmet dependency, a debugger needs none of them, and bundling a deprecated TLS
+stack so `import ssl` works inside gdb would ship it for no user.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,7 +66,7 @@ fails if this block drifts.
 - **#0902** (build, rmw) — Editing zenoh-pico rebuilds nothing — `zpico-sys` watches 7 hand-listed files out of the whole library, so a patch is silently not compiled See `0902-*`.
 - **#0914** (testing) — Nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot evaluate anything passes every check See `0914-*`.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
-- **#0932** (tooling) — The linux-arm64 arm-none-eabi-gcc dist gets neither the ncurses bundle nor the gdb Python, and its gdb fails EARLIER than x86_64's did See `0932-*`.
 - **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
+- **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -90,12 +90,19 @@ install = "make -j$(nproc) && make install"
 # system python3.8. Pretty-printers, `gdb.execute`, `re`/`collections`/`json`
 # all work; the 34 modules ARM built in are the whole surface.
 #
-# linux-arm64 gets NEITHER fix: there gdb links `libpython3.8.so.1.0`
-# dynamically, so it needs the shared library and not merely a stdlib, and 22.04
-# packages none. Its tarball is byte-identical to -nros2 (same sha256), which is
-# the check that this release touched only x86_64.
+# -nros4 fixes linux-arm64 too (issue 0932), by a DIFFERENT route, because the
+# two hosts embed Python differently: there gdb LINKS `libpython3.8.so.1.0` and
+# fails at the loader before any interpreter runs, so a stdlib alone could not
+# help. 22.04 packages no python3.8 — Ubuntu's own focal archive does, for
+# arm64, and a library needing at most GLIBC_2.29 runs on the runner's 2.35.
+#
+# arm64 therefore ends up with MORE working Python than x86_64: `struct` and
+# `math` are built into Ubuntu's libpython and 41 more modules arrive in
+# lib-dynload, all resolving against the shared library — so `import struct`
+# works there and can never work on x86_64. The build asserts exactly that, per
+# host, before publishing.
 [tool.arm-none-eabi-gcc]
-version = "13.2-nros3"
+version = "13.2-nros4"
 smoke = [
     { run = "bin/arm-none-eabi-gcc --version", expect = "Arm GNU Toolchain" },
     { run = "bin/arm-none-eabi-gdb --version", expect = "GNU gdb" },
@@ -107,9 +114,9 @@ smoke = [
 system = ["libcrypt1"]
 upstream = "13.2.rel1" # ARM release id (SSOT — build script no longer hand-derives)
 # Repackaged from ARM's release; no in-repo source build (binary toolchain).
-dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "1e5f6dbf853b70ae5b1fcc17dd3d3a877172f5520adc7ddb1d1da40ce73282ea" }
-dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "127136d54db66f2ed405d8bc01b1280a9cc78f2cbcc04466894c75c109b942d7" }
-dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros3/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
+dist.linux-x86_64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-x86_64.tar.zst", sha256 = "27d5e5f6f9428157df7900c91b000486184f99fbc1a35ea5c3ca219be9068197" }
+dist.linux-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-linux-arm64.tar.zst", sha256 = "841e456d571e3f60244652a5ac7287f9e06a9c61f1fc93d2fbbc037b05f5a6ab" }
+dist.macos-arm64 = { url = "https://github.com/NEWSLabNTU/nano-ros-sdk/releases/download/arm-none-eabi-gcc-13.2-nros4/arm-none-eabi-gcc-macos-arm64.tar.zst", sha256 = "d1a2311ff7590e6370be8df34e6dea3d572df83aa95672eb484026f2fd4b6748" }
 
 [tool.zephyr-sdk]
 # The Zephyr SDK, host-keyed (issue 0610). `scripts/zephyr/setup.sh` used to


### PR DESCRIPTION
Checking #0914 on request turned up both a correction and a worse bug.

### #0914 was wrong

Its headline — "no test runs that pair as installed" — was already false when filed. `multihost_partition_bake` invokes the **installed** binary by path against `multihost.launch.xml` with `host:=`, which needs `$(eval …)` and therefore the Python half. It predates the issue (phase 211.F-2) and runs in host-tests integration. Verified by removing `libplay_launch_parser_pyexec.so`: all three of its tests fail. The red interval that issue describes *was* this test firing.

### And the capability it gestured at is broken outright

The shipped `nros-launch-resolve` cannot resolve **any** Python launch file — it aborts:

```
No LaunchContext set - Python execution must be called through LaunchTraverser
panic in a function that cannot unwind / thread caused non-unwinding panic
```

Including `test_no_import.launch.py`, which imports nothing — so it is not about ROS packages on `sys.path`.

### Root cause

`exec_file` communicates through a process-wide thread-local that is no longer process-wide. The C ABI carries `{op, arg}` and both sides document the assumption — the response is *"empty for exec_file, whose effects land in the parser thread-local launch context"*, and the executor expects configurations *"set by execute_python_file() before calling this executor"*. But `execute_python_file` runs in the **binary** and the executor in the **.so**, and both statically link `play_launch_parser`:

```
nros-launch-resolve              internal=2  exported=0
libplay_launch_parser_pyexec.so  internal=12 exported=0
```

Two thread-locals. The binary sets one, Python reads the other.

`$(eval …)` survives because its request carries the expression and its response the result. `exec_file` carries neither direction, which is why it is the half that broke.

Every test says otherwise because `play_launch_parser` **dev-depends on `pyexec`**, so its `.launch.py` tests link the executor in-process: one copy, one thread-local, green.

Docs only. The fix is in the play_launch repo — carry configurations in the request, captures in the response; the issue records why exporting the bridge symbols or making the parser a shared library are both worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG