### PR TITLE
fix(#0935): a `.launch.py` resolves again — context crosses the dlopen boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "nros-platform-esp32-qemu",
  "nros-platform-mps2-an385",
  "nros-platform-stm32f4",
+ "nros-zephyr-build",
  "zpico-alloc",
 ]
 

--- a/docs/issues/archived/0935-launch-py-aborts-through-the-shipped-pyexec.md
+++ b/docs/issues/archived/0935-launch-py-aborts-through-the-shipped-pyexec.md
@@ -2,7 +2,7 @@
 id: 935
 title: "Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s
   inputs and outputs travel by a thread-local the dlopen split duplicated"
-status: open
+status: resolved
 type: bug
 area: tooling, cli
 related: [0914, 0897, 0915, phase-332]
@@ -105,3 +105,45 @@ shape issue 0914 asked for and the fixtures already exist. It must SKIP (not
 pass) where no interpreter is usable, or it re-creates the hole one level down.
 Note `multihost_partition_bake` currently has no Python probe, so on a
 Python-less host it fails rather than skipping.
+
+## Resolved (2026-08-30)
+
+`exec_file` now carries its context BOTH ways — the shape `$(eval …)` always had
+and the reason that half never broke:
+
+* the request carries `configs`, so the object stands up ITS OWN launch context
+  around the execution;
+* the response carries `captures` — nodes, containers, load_nodes and the global
+  parameters `SetParameter` writes — which the loader merges into the caller's
+  context. They used to be written to the object's copy and discarded when the
+  call returned.
+
+`merge_into` APPENDS rather than replaces: the traverser may already hold
+captures from XML siblings or an earlier include, and a `.launch.py` adds to
+that tree rather than becoming it.
+
+ABI version 1 -> 2 on both sides, and the loader rejects a missing `captures`
+explicitly. A v1 object with a v2 loader would run the file and return nothing —
+a tree resolving to no nodes, indistinguishable from an empty launch file — so
+it has to be a sentence rather than a silence.
+
+play_launch: NEWSLabNTU/play_launch@d16b354. Submodule pin bumped.
+
+### Tested at the two levels this needed
+
+* **ABI level** (play_launch): two tests asserting on the RESPONSE — captures
+  come back, and a configuration sent in the request reaches Python. That is the
+  only place this is visible in-process, since every in-process test links ONE
+  copy of the parser and a thread-local therefore looks shared.
+* **Packaging level** (nano-ros): `launch_py_resolves_as_shipped` invokes the
+  INSTALLED binary by path and asserts the Python-declared node reaches the
+  model.
+
+Both confirmed by removing the fix and watching them go red.
+
+### Issue 0914's residue, closed with it
+
+`host_python_available()` is now a shared helper and `multihost_partition_bake`
+uses it too. Without a probe those tests FAILED on a Python-less host where they
+should skip — "no Python here" and "the pair is broken" produce the same parse
+error, which is the vacuous shape 0914 named.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,6 +66,5 @@ fails if this block drifts.
 - **#0914** (testing) — Nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot evaluate anything passes every check See `0914-*`.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
 - **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
-- **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -551,6 +551,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -551,6 +551,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/testing/nros-tests/src/lib.rs
+++ b/packages/testing/nros-tests/src/lib.rs
@@ -798,6 +798,28 @@ pub fn build_dir(kind: &str, coords: &[&str]) -> std::path::PathBuf {
     out
 }
 
+/// Is there an interpreter the resolver's Python half can load?
+///
+/// Issue 0935 / 0914. "No Python on this host" and "the shipped pair is broken"
+/// produce the SAME parse error, and a test that cannot tell them apart is
+/// worse than none — it is the vacuous-test class `check-no-vacuous-tests`
+/// exists for. So a test that needs Python asks this first and
+/// `nros_tests::skip!`s, keeping a genuine break a FAILURE.
+///
+/// Deliberately probes the same way `pyload` does — a `python3` that answers —
+/// rather than looking for a file, because what matters is that an interpreter
+/// runs, not that one is installed somewhere.
+#[must_use]
+pub fn host_python_available() -> bool {
+    std::process::Command::new("python3")
+        .arg("-c")
+        .arg("import sys; sys.exit(0)")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
 /// The `nros-launch-resolve` helper, by ABSOLUTE path (issue 0285 — never
 /// `$PATH`, where a stale `~/.nros/bin` copy shadows the in-tree one).
 /// `just setup-launch-resolve` builds it; `None` means it has not been built.

--- a/packages/testing/nros-tests/tests/launch_py_resolves_as_shipped.rs
+++ b/packages/testing/nros-tests/tests/launch_py_resolves_as_shipped.rs
@@ -1,0 +1,75 @@
+//! A `.launch.py` must resolve through the resolver AS SHIPPED — issue 0935.
+//!
+//! `nros-launch-resolve` is two artifacts: the binary, and
+//! `libplay_launch_parser_pyexec.so` beside it, which the binary `dlopen`s
+//! against a discovered interpreter. Every test that links the Python half
+//! IN-PROCESS proves the mechanism and not the packaging, and that gap is not
+//! theoretical: both halves statically link `play_launch_parser`, so each had
+//! its own thread-local launch context, and every `.launch.py` ABORTED as
+//! shipped while passing in-process.
+//!
+//! So this invokes the INSTALLED binary by path and asserts a model comes out.
+//! `multihost_partition_bake` is the sibling that covers `$(eval …)` from XML;
+//! this covers the Python-file half, which nothing did.
+
+use std::process::Command;
+
+/// The smallest launch file that cannot resolve without a working Python half:
+/// `generate_launch_description` has to RUN, and the `Node` it returns has to
+/// travel back across the boundary as a capture.
+const LAUNCH_PY: &str = r#"
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(package="demo_pkg", executable="demo_exe", name="from_python"),
+    ])
+"#;
+
+#[test]
+fn a_python_launch_file_resolves_through_the_shipped_pair() {
+    let Some(resolver) = nros_tests::launch_resolver_bin() else {
+        nros_tests::skip!("nros-launch-resolve not built (run `just setup-launch-resolve`)");
+    };
+    if !nros_tests::host_python_available() {
+        // NOT a pass: a host with no interpreter cannot answer this question,
+        // and saying "green" would be the vacuous shape issue 0914 warned about.
+        nros_tests::skip!("no usable python3 on this host");
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let launch = tmp.path().join("shipped.launch.py");
+    std::fs::write(&launch, LAUNCH_PY).expect("write launch file");
+    let model = tmp.path().join("model.yaml");
+
+    let out = Command::new(&resolver)
+        .arg(&launch)
+        .arg("-o")
+        .arg(&model)
+        .output()
+        .expect("spawn nros-launch-resolve");
+
+    assert!(
+        out.status.success(),
+        "resolving a .launch.py failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let yaml = std::fs::read_to_string(&model).expect("the resolver wrote no model");
+
+    // The node came from Python, so its presence is the whole assertion: it
+    // exists only if `generate_launch_description` ran AND its captures crossed
+    // back. Before issue 0935 the process aborted here instead.
+    assert!(
+        yaml.contains("from_python"),
+        "the Python-declared node is missing from the model — captures did not \
+         cross the boundary:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("demo_pkg") && yaml.contains("demo_exe"),
+        "the node crossed without its package/executable:\n{yaml}"
+    );
+}

--- a/packages/testing/nros-tests/tests/multihost_partition_bake.rs
+++ b/packages/testing/nros-tests/tests/multihost_partition_bake.rs
@@ -66,6 +66,12 @@ fn resolving_with_host_arg_partitions_the_model() {
     if launch_resolver().is_none() {
         nros_tests::skip!("nros-launch-resolve not built (run `just setup-launch-resolve`)");
     }
+    if !nros_tests::host_python_available() {
+        // Issue 0914's residue: `$(eval …)` needs an interpreter, and without
+        // one this failed rather than skipping — "no Python here" and "the
+        // shipped pair is broken" produce the same parse error.
+        nros_tests::skip!("no usable python3 on this host");
+    }
     let tmp = tempfile::tempdir().expect("tempdir");
 
     // robot1 → the talker only.
@@ -115,6 +121,12 @@ fn resolving_with_host_arg_partitions_the_model() {
 fn per_host_resolves_partition_and_carry_their_binding() {
     if launch_resolver().is_none() {
         nros_tests::skip!("nros-launch-resolve not built (run `just setup-launch-resolve`)");
+    }
+    if !nros_tests::host_python_available() {
+        // Issue 0914's residue: `$(eval …)` needs an interpreter, and without
+        // one this failed rather than skipping — "no Python here" and "the
+        // shipped pair is broken" produce the same parse error.
+        nros_tests::skip!("no usable python3 on this host");
     }
     let tmp = tempfile::tempdir().expect("tempdir");
     // (workspace, host, must-contain node keys, must-NOT-contain node keys)
@@ -204,6 +216,12 @@ fn multihost_bake_emits_only_the_hosts_node() {
     }
     if launch_resolver().is_none() {
         nros_tests::skip!("nros-launch-resolve not built (run `just setup-launch-resolve`)");
+    }
+    if !nros_tests::host_python_available() {
+        // Issue 0914's residue: `$(eval …)` needs an interpreter, and without
+        // one this failed rather than skipping — "no Python here" and "the
+        // shipped pair is broken" produce the same parse error.
+        nros_tests::skip!("no usable python3 on this host");
     }
     let tmp = tempfile::tempdir().expect("tempdir");
 


### PR DESCRIPTION
Every Python launch file **aborted** through the shipped resolver, including one that imports nothing:

```
No LaunchContext set - Python execution must be called through LaunchTraverser
panic in a function that cannot unwind / thread caused non-unwinding panic
```

### Cause

`exec_file` communicated through a process-wide thread-local that stopped being process-wide. Since issue 0897 split the Python half into a `dlopen`ed object, **both** sides statically link `play_launch_parser`, so each has its own `CURRENT_LAUNCH_CONTEXT`. The binary set one; Python ran inside the object and read the other, found `None`, and took the process down.

`$(eval …)` never noticed because its request carries the expression and its response the result. `exec_file` now has that shape too — configurations in the request, captures in the response (NEWSLabNTU/play_launch@d16b354, ABI 1 → 2).

### The test that was missing

`launch_py_resolves_as_shipped` invokes the **installed** binary by path against a `.launch.py` and asserts the Python-declared node reaches the model. Every existing test linked the Python half in-process, where one copy of the parser makes a thread-local look shared — which is exactly why this passed everywhere while being broken as shipped. Confirmed by deleting `libplay_launch_parser_pyexec.so`: it goes red.

play_launch also gains two ABI-level tests asserting on the **response**; both fail when the drain is removed.

### Issue 0914 residue, closed with it

`host_python_available()` becomes a shared helper and `multihost_partition_bake` uses it. Without a probe those tests *failed* on a Python-less host where they should skip — "no Python here" and "the pair is broken" produce the same parse error.

### Also: three locks main left behind

`Cargo.lock` and the two `nros-nuttx-*-ffi` leaf locks are one line each, adding no package entries — the refresh the gate permits, not a dependency change. They are red on main itself, so any branch cut from it fails `check fast` before running its own code. Not mine to have caused, cheaper to fix here.

`just ci l1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG