### PR TITLE
feat(phase-379): W3, W4 and W5 — the remaining API-parity waves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "nros-platform-esp32-qemu",
  "nros-platform-mps2-an385",
  "nros-platform-stm32f4",
+ "nros-zephyr-build",
  "zpico-alloc",
 ]
 

--- a/book/src/concepts/no-std.md
+++ b/book/src/concepts/no-std.md
@@ -74,7 +74,7 @@ Both layers share the same session; mix per entity.
 - L1 — `node.create_service::<S>(name)` (poll with
   `handle_request()`), `node.create_client::<S>(name)` +
   `client.call(&request)` → `Promise<Reply>` (poll with
-  `promise.try_recv()` or `.await`).
+  `promise.take()` or `.await`).
 - L2 — `executor.register_service::<S, _>(name, |req| reply)`.
   Service clients keep the L1 `Promise` shape; the typed
   callback API isn't surfaced (only `register_service_client_raw`

--- a/book/src/design/client-library.md
+++ b/book/src/design/client-library.md
@@ -28,7 +28,7 @@ The same `Promise<T>` value serves three usage patterns. None of the other clien
 let promise = client.call(&request)?;
 // ... continue running other work ...
 executor.spin_once(10);
-if let Some(reply) = promise.try_recv()? {
+if let Some(reply) = promise.take()? {
     handle(reply);
 }
 ```

--- a/docs/reference/api-parity-ledger/action.json
+++ b/docs/reference/api-parity-ledger/action.json
@@ -777,9 +777,17 @@
     "verdict": "extension",
     "why": "takes `(goal_id, status, result)` -- as C's `nros_action_succeed`/`_abort`/`_canceled` do, as C++'s POLLING tier does, and as `nros::ActionServer<A>::complete_goal` does since issue 0796; see `cpp:ActionServer::complete_goal`. All four surfaces now agree on the parameter and its order."
   },
+  "rust:ActionServer::for_each_active_goal": {
+    "verdict": "divergence",
+    "why": "phase-379 W5. rclrs hands back an iterator over goals; we take a visitor (`for_each_active_goal(&self, executor, f)`). An iterator would borrow the arena for its whole walk while the executor needs `&mut` to drive the state machine underneath it — a borrow-checker consequence of the arena owning goal storage, not a style preference. Same constraint as the identity row."
+  },
   "rust:ActionServer::get_goal": {
     "verdict": "divergence",
     "why": "rclrs 0.7.0 models a goal's life as a TYPESTATE chain -- `RequestedGoal` -> `AcceptedGoal` -> `ExecutingGoal` -> `TerminatedGoal`, each a distinct type whose methods are only the transitions legal from that state, with the goal moved from one to the next. Ours keeps goals in a STATIC ARENA addressed by UUID (`nros_goal_uuid_t` / `GoalId`), and the server asks the arena about a goal rather than holding it. The constraint is that a typestate chain hands the application an owning handle per goal, and with no allocator and a fixed-capacity arena the storage cannot follow the handle -- MAX_GOALS is declared at build time and the arena outlives every borrow of it. RFC-0069. Note ROS 2 does not agree with ITSELF here: rclcpp_action uses `async_send_goal` and shared `ClientGoalHandle`, rclrs 0.7.0 uses `request_goal` and the typestate chain, so 'match ROS 2' has no single answer for actions -- W5 has to pick a side and say which."
+  },
+  "rust:ActionServer::goal-identity": {
+    "verdict": "divergence",
+    "why": "phase-379 W5. A goal is named by its 16-byte UUID and lives in a fixed-capacity arena; operations take the id (`publish_feedback(exec, goal_id, ..)`, `succeed(exec, goal_id, result)`). This is the ACTION SPEC's own identity model — SendGoal/CancelGoal/GetResult and the feedback and status topics all key on goal_id — and BOTH client libraries layer language ergonomics over it. rclrs 0.7.0's typestate chain (RequestedGoal->AcceptedGoal->ExecutingGoal->TerminatedGoal) hands out an owning handle per goal, and its own `ExecutingGoal` is `Arc`-backed: the typestate is a compile-time wrapper OVER refcounting, not an alternative to it. rclcpp_action's shared_ptr<ServerGoalHandle> states the same requirement plainly. Both need an allocator; a fixed arena cannot provide an owning handle because the storage cannot follow it, and slot reclaim would rest on Drop order in no_std. Note rclrs itself falls back to the UUID once the chain ends: `succeeded_with` returns `TerminatedGoal { uuid }`. COSTS, stated: result retention is capped at MAX_GOALS (issue 0796 — it was push-only, so it held 'the first four, forever'); lookup is O(n) over the arena where a handle is O(1); size_of::<A::Goal>() * MAX_GOALS of static RAM is reserved whether goals arrive or not (issue 0827's class). And the ergonomic loss: `succeeded_with(self)` makes use-after-terminal a COMPILE error, ours can only make it a runtime one."
   },
   "rust:ActionServer::into_goal_receiver": {
     "verdict": "divergence",

--- a/docs/reference/api-parity-ledger/pubsub.json
+++ b/docs/reference/api-parity-ledger/pubsub.json
@@ -1518,6 +1518,10 @@
     "verdict": "extension",
     "why": "see `rust:Subscription::process_raw_in_place`."
   },
+  "rust:Subscription::take": {
+    "verdict": "extension",
+    "why": "phase-379 W3. A POLLING receive, which rclrs has no public counterpart for: its subscription API is callback/worker-driven and its `take_*` methods are private (`fn take_response`, `fn take_feedback` in 0.7.0 — no `pub`). So this is ours-only against the RUST reference by construction, not by a naming choice. The NAME follows rcl (`rcl_take`) and rclcpp (`Subscription::take`), which do spell the non-blocking receive that way, and matches our own C surface. It was `try_recv` — Rust channel vocabulary that reads as a different contract to a ROS 2 user, when both forms are non-blocking and both report emptiness without failing. Renamed as a clean break, no deprecation shim: a shim would let call sites keep compiling against the old name silently, and five separate call sites were found only because the break made them hard errors."
+  },
   "rust:Subscription::topic_name": {
     "verdict": "gap",
     "why": "see `rust:Publisher::topic_name`."

--- a/docs/reference/api-parity-ledger/types.json
+++ b/docs/reference/api-parity-ledger/types.json
@@ -39,14 +39,6 @@
     "verdict": "declined",
     "why": "rcl passes an `rcl_allocator_t` by value through most of its API so a caller can supply its own. nano-ros has ONE allocator, `nros_platform_alloc`, enforced by check-no-direct-kernel-alloc, so the type would only ever hold the same value. This is the `no-allocator` signature rule (signature_rules.py) one level up: the rule removes the parameter, this removes the type it would carry."
   },
-  "c:view_bytes_t": {
-    "verdict": "extension",
-    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
-  },
-  "c:view_str_t": {
-    "verdict": "extension",
-    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
-  },
   "c:endpoint_info_t": {
     "verdict": "divergence",
     "why": "phase-381 W3. The ours-half of the `topic_endpoint_info_array_t` divergence this file already records: upstream returns an allocating array, there is no allocator at this seam, and the endpoint count has no bound the CALLER can know. So it streams through a visitor, one entry of peak memory, every string borrowed for the call. The endpoint carries no QoS. The GRANTED profile is what answers 'why is nothing arriving', no backend can read one back yet, and reporting the remote's DECLARED profile would be a confident wrong answer -- so the field is absent here and the rmw ABI's `*_UNKNOWN` sentinels carry it at the vtable seam, which is that ABI's documented way to say 'could not determine'."
@@ -95,9 +87,21 @@
     "verdict": "extension",
     "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
   },
+  "c:node_ref_t": {
+    "verdict": "divergence",
+    "why": "phase-379 W4. rcl asks the caller to re-supply the node at teardown (`rcl_publisher_fini(&pub, &node)`); we keep `nros_publisher_fini(&pub)` and store this identity instead of the `*const nros_node_t` the entity used to hold. The PLATFORM constraint is that C gives the caller no tools to enforce the lifetime rcl's shape depends on: a node declared on an RTOS task stack dies with `vTaskDelete`, `nros_node_t a = b;` is legal and silent, and there is no allocator to hide an indirection behind. rcl's form does not remove that assumption, it relocates it to a caller who cannot check it either. An identity CAN be checked: `nros_node_fini` retires the slot's generation, so finalising an entity after its node returns NROS_RET_STALE_NODE instead of succeeding silently against caller storage the runtime does not own. Generation 0 is reserved so a zeroed struct never resolves."
+  },
   "c:transport_ops_t": {
     "verdict": "extension",
     "why": "a bring-your-own transport vtable (`open`/`close`/`write`/`read` + `abi_version` + `user_data`) so a board can supply its own link. rcl reaches the network through rmw and an installed middleware implementation, neither of which an MCU has; the vtable is how a board with a UART, a CAN controller or a vendor TCP stack participates at all."
+  },
+  "c:view_bytes_t": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
+  },
+  "c:view_str_t": {
+    "verdict": "extension",
+    "why": "RFC-0033's C zero-copy reader, reachable from the umbrella header since issue 0795 was fixed. Borrows a view INTO the received CDR buffer instead of copying out of it: `nros_borrowed_str_t` / `nros_borrowed_bytes_t` for strings and byte arrays, and the `nros_le_slice_view_*_t` family for numeric arrays, which are alignment-agnostic because CDR does not guarantee a `u64` array is 8-byte aligned in the wire buffer. ROS 2 has no counterpart: rosidl deserializes into an owned `std::vector`/`rosidl_runtime_c__*__Sequence`, which needs an allocator per message. The whole point here is that a subscription callback can read a 2 kB point cloud without a 2 kB copy it has nowhere to put."
   },
   "cpp:ErrorCode": {
     "verdict": "divergence",

--- a/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
+++ b/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
@@ -394,12 +394,19 @@ autoware survey nodes call. The `types` stage has already produced two:
 `cpp:FutureReturnCode` (we express SUCCESS and TIMEOUT, not INTERRUPTED, so a
 ported `spin_until_future_complete` caller cannot tell shutdown from timeout)
 and `rust:RclReturnCode` (we have the type and do not export it — issue 0783).
-`init` added a third and it is the largest of them: **nano-ros has no shutdown
-hook at all** — not `rclcpp::on_shutdown`, not `Context::add_on_shutdown_callback`,
-not the pre-shutdown variant that runs BEFORE entities are torn down. Nothing
-about `no_std` prevents a fixed-capacity callback array, and a node that must
-park an actuator or release a bus on the way down has nowhere to do it. That
-matters more on a device than on a desktop.
+~~`init` added a third and it is the largest of them: **nano-ros has no shutdown
+hook at all**.~~ **DONE — corrected 2026-08-30.** True when written; the
+capability landed since. `Executor` carries `add_pre_shutdown_callback` /
+`add_on_shutdown_callback` (plus `remove_*` and `shutdown_callback_count`) over
+fixed-capacity arrays sized by `MAX_SHUTDOWN_CBS`, and the C surface exposes
+`nros_executor_add_pre_shutdown_callback` / `..._add_on_shutdown_callback`. The
+prediction in the original text held exactly: nothing about `no_std` prevented a
+fixed-capacity callback array.
+
+Recorded rather than deleted, because it was nearly re-implemented from this
+paragraph — a phase doc that describes a gap someone has since closed is a
+worse trap than one that describes nothing, and the only thing that caught it
+was grepping for the symbol before writing it.
 
 `node` added the first `rename` rows, and they are the cheapest work in the
 campaign: **`Node::create_subscriber` should be `create_subscription`.** rclrs,

--- a/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
+++ b/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
@@ -1,5 +1,12 @@
 # Phase 379 — the user API is rclc / rclcpp / rclrs, and something checks that
 
+**Status (2026-08-30). W1 AND W2 COMPLETE; W3-W5 DECIDED and in progress.**
+Every blocking decision the phase was holding is settled below — W3 lands as a
+clean break, `handle-owns-node` stays with an identity instead of a pointer,
+actions are addressed by UUID rather than by handle, and prelude membership is a
+query over the ledger rather than taste. The waves are implementation now, not
+adjudication.
+
 **Status (2026-08-25). W1 AND W2 COMPLETE.** The correlator runs on all three
 languages; every one of the 2397 items where the nano-ros user API does not
 correspond to rclc/rclcpp/rclrs carries a written verdict, in 17 topic shards
@@ -488,9 +495,122 @@ The lesson worth keeping: **the reference moves.** A prose catalog would have
 gone on describing 0.5.1; `--refresh` re-derived the surface and the ledger's own
 gate found the 124 rows that needed re-deciding.
 
-### Open: does the C `handle-owns-node` shape stay — it is currently a signature
-   rule covering six `*_fini` entry points, which asserts it is a platform
-   decision. If it is not, those six become signature changes. W4.
+### Settled: W3 lands as a CLEAN BREAK (2026-08-30)
+
+No deprecation shims. The renames are source-breaking on the Rust surface and
+they land in one release, one commit per family — a user who upgrades twice and
+is renamed twice is worse off than one who is renamed once.
+
+Ordering constraint that survives the decision: the QoS accessors (`deadline_ms`,
+`lifespan_ms`, `liveliness_lease_ms`) encode that we take an integer where
+rclcpp takes a `Duration`. Their names FOLLOW the `Clock`/`Duration` decision, so
+that decision comes first or they are renamed twice — which is exactly what a
+clean break is meant to avoid.
+
+### Settled: `handle-owns-node` STAYS, and becomes checkable (2026-08-30)
+
+The signature keeps its shape — `nros_publisher_fini(&pub)`, not rcl's
+`rcl_publisher_fini(&pub, &node)` — but the STORAGE changes, because the rule as
+written asserted a platform decision that the implementation did not earn.
+
+Today each entity holds `const struct nros_node_t *node`, which assumes the
+node's ADDRESS is stable for the entity's lifetime. Examined per platform:
+
+* **Bare metal is the safe case.** No MMU, no runtime relocation, XIP, handles
+  in `.bss`. An address taken at init is stable until reset.
+* **RTOS with dynamic tasks is not.** A task declaring `nros_node_t node;` on
+  its stack and creating a publisher that outlives it leaves the entity pointing
+  into memory `vTaskDelete` has freed. "Handle on the task stack" is a normal C
+  idiom, not a pathological one.
+* **C cannot prevent the copy.** `nros_node_t a = b;` is legal and silent, and
+  every entity built against `b` still points at `b`. Rust would forbid it with
+  ownership types; C has none and we have no allocator to hide an indirection
+  behind.
+* **Teardown order becomes an unenforceable caller obligation.** Destroy the
+  node first and `*_fini` dereferences a dead pointer — on the path that runs
+  when something has already gone wrong.
+
+rcl's alternative does NOT remove that assumption; it relocates it to the caller
+and makes it unverifiable — pass a different node and it is UB, pass a dangling
+one and it is the same dereference spelled at the call site.
+
+So: keep the signature, replace the pointer with an identity into the
+`NodeRecord` table that already exists (`NROS_EXECUTOR_MAX_NODES`):
+
+```c
+typedef struct nros_node_ref_t { uint16_t slot; uint32_t generation; } nros_node_ref_t;
+```
+
+`generation` is bumped when a slot is RELEASED, and `0` is reserved so a zeroed
+struct — the common C mistake — is never accidentally valid. Resolution bounds
+the slot and compares the generation, so every hazard above turns from a
+dereference into a return code. `u32` rather than `u16` deliberately: 16 bits
+would leave a 65 535-cycle wrap to reason about, and 4 bytes buys the argument
+away.
+
+ABI break, accepted: nothing is released yet, and it lands with the W3 break.
+
+The constraint the `divergence` row can now NAME: the caller cannot be asked to
+enforce a lifetime C gives it no tools to enforce, so the runtime enforces
+IDENTITY instead — and identity is checkable where a pointer is not.
+
+### Settled: actions are addressed by UUID, not by handle (2026-08-30)
+
+W5 must pick a side because ROS 2 does not agree with itself. It picks NEITHER
+library, and the reason is in rclrs's own types rather than in preference.
+
+`rclrs` 0.7.0 (`action/action_server/executing_goal.rs`):
+
+```rust
+pub struct ExecutingGoal<A: Action> { live: Arc<LiveActionServerGoal<A>> }
+
+pub fn succeeded_with(self, result: A::Result) -> TerminatedGoal {
+    self.live.transition_to_succeed(result);
+    TerminatedGoal { uuid: *self.live.goal_id() }
+}
+```
+
+The typestate is a compile-time wrapper OVER AN `Arc` — not an alternative to
+refcounting, a lint on top of it. `rclcpp_action`'s
+`shared_ptr<ServerGoalHandle>` is the same requirement stated plainly. Both need
+an allocator; neither is portable to `no_std`.
+
+And note where `succeeded_with` lands: `TerminatedGoal { uuid }`. **rclrs itself
+falls back to the UUID** once the typestate ends, because the UUID is what the
+ACTION SPEC defines — `SendGoal`/`CancelGoal`/`GetResult` and the feedback and
+status topics all key on `goal_id`. The handle is the ergonomic layer, and it is
+the layer that costs an allocator.
+
+Ours keeps the spec's identity and omits the ergonomics:
+
+```rust
+server.publish_feedback(exec, &goal_id, &fb)?;
+server.succeed(exec, &goal_id, result)?;   // W3 rename, see below
+```
+
+Honest asymmetry, to be recorded in the row rather than only the wins:
+`succeeded_with(self)` makes use-after-terminal a COMPILE error; ours can only
+make it a runtime one.
+
+### Settled: prelude membership is a LEDGER QUERY, not taste (2026-08-30)
+
+709 items is not a readable surface, and the current `nros::prelude` mixes user
+API with machinery — `CdrReader`, `HandleSet`, `InvocationMode`,
+`MetadataRecorder`, `NodeRuntimeAdapter` sit beside `Node` and `QoSProfile`.
+
+Two tiers, with a mechanical rule:
+
+> A name belongs in `nros::prelude` IFF the parity ledger gives it a
+> non-`extension` verdict — i.e. it has a correspondent in rclrs/rclcpp/rclc.
+
+Everything else stays reachable at `nros::`; the RTOS machinery moves to
+`nros::embedded`. The rule needs a small allow-list of extensions that are
+load-bearing (`ExecutorConfig`, `SpinOptions` — nothing starts without them),
+each with a one-line reason, same discipline as a `divergence` row.
+
+Gated by `check-api-parity`: `prelude ⊆ {non-extension} ∪ ALLOWED_EXTENSIONS`.
+Without the gate the rule decays into a comment, which is the failure mode this
+repo keeps re-learning.
 
 ## Acceptance
 

--- a/examples/native/rust/action-client-rtic/src/main.rs
+++ b/examples/native/rust/action-client-rtic/src/main.rs
@@ -3,7 +3,7 @@
 //! Validates the RTIC action client pattern on native x86:
 //! - `Executor<_, 0, 0>` (zero callback arena)
 //! - `spin_once(0)` (non-blocking I/O drive)
-//! - `client.send_goal()` + `promise.try_recv()` for acceptance
+//! - `client.send_goal()` + `promise.take()` for acceptance
 //! - `client.try_recv_feedback()` for feedback
 //!
 //! Note: `Promise::wait()` and `FeedbackStream::wait_next()` are NOT usable
@@ -60,7 +60,7 @@ fn main() {
     let mut accepted = false;
     for _ in 0..1000 {
         executor.spin_once(core::time::Duration::from_millis(0));
-        if let Ok(Some(result)) = promise.try_recv() {
+        if let Ok(Some(result)) = promise.take() {
             accepted = result;
             break;
         }

--- a/examples/native/rust/listener-rtic/src/main.rs
+++ b/examples/native/rust/listener-rtic/src/main.rs
@@ -3,7 +3,7 @@
 //! Validates the RTIC integration pattern on native x86:
 //! - `Executor<_, 0, 0>` (zero callback arena)
 //! - `spin_once(0)` (non-blocking I/O drive)
-//! - `subscription.try_recv()` (manual polling)
+//! - `subscription.take()` (manual polling)
 //!
 //! This is the native equivalent of `examples/stm32f4/rust/rtic-listener/`.
 
@@ -44,7 +44,7 @@ fn main() {
     loop {
         executor.spin_once(core::time::Duration::from_millis(0));
 
-        match subscription.try_recv() {
+        match subscription.take() {
             Ok(Some(msg)) => {
                 nros_info!(&LOGGER, "I heard: [{}]", msg.data);
             }

--- a/examples/native/rust/service-client-rtic/src/main.rs
+++ b/examples/native/rust/service-client-rtic/src/main.rs
@@ -3,7 +3,7 @@
 //! Validates the RTIC service client pattern on native x86:
 //! - `Executor<_, 0, 0>` (zero callback arena)
 //! - `spin_once(0)` (non-blocking I/O drive)
-//! - `client.call()` + `promise.try_recv()` loop (manual polling)
+//! - `client.call()` + `promise.take()` loop (manual polling)
 //!
 //! Note: `Promise::wait()` is NOT usable in RTIC because it requires `&mut Executor`,
 //! which is `#[local]` to the `net_poll` task. Use `try_recv()` loop instead.
@@ -68,7 +68,7 @@ fn main() {
     for _ in 0..3000 {
         executor.spin_once(core::time::Duration::from_millis(0));
 
-        if let Ok(Some(reply)) = promise.try_recv() {
+        if let Ok(Some(reply)) = promise.take() {
             nros_info!(&LOGGER, "Result of add_two_ints: {}", reply.sum);
             got_reply = true;
             break;

--- a/just/check.just
+++ b/just/check.just
@@ -118,7 +118,7 @@ fast-serial: \
     absolute-paths \
     c-fmt cpp-fmt python \
     nuttx-integration-makefile eyre-context-alias core-only-predicate workspace-build-output cc-build-policy ffi-struct-mirrors sizes-header-mirrors retired-submodule-refs no-absolute-model-paths \
-    cpp-freestanding-includes fixtures-manifest fixture-id-guard generated-leaf-regenerable cargo-config-tracked doc-refs book-links book-no-just emitter-just-spelling issue-index roadmap-status sysdep-remedies \
+    cpp-freestanding-includes fixtures-manifest fixture-id-guard generated-leaf-regenerable cargo-config-tracked doc-refs book-links book-no-just emitter-just-spelling issue-index roadmap-status prelude-tiers sysdep-remedies \
     export-f-closure peer-sweep-lanes \
     activate-shells build-root fixture-groups rmw-descriptors artifact-identity-budget \
     cargo-target-spelling example-leaf-target-dirs example-leaf-build-dirs fixture-binary-names manifests-parse build-rs-rerun-paths \
@@ -1630,6 +1630,14 @@ interface-glob-configure-depends:
 # committing to a run.
 tier-preconditions:
     @bash scripts/check-tier-preconditions.sh
+
+# phase-379 W5 — `nros::prelude` is the rclrs-shaped API, `nros::embedded` is
+# the RTOS machinery. Membership is a LEDGER QUERY (a name may sit in the
+# prelude only if the parity ledger does not call it an `extension`), plus an
+# argued allow-list for the extensions a node cannot start without.
+[private]
+prelude-tiers:
+    @python3 scripts/check-prelude-tiers.py
 
 # Every lane that runs the peer-spawning suites sweeps first (issues 0659,
 # 0923). The reaper's own unit tests call `sweep_in` directly, so they cannot

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -1158,6 +1158,140 @@ typedef void (*nros_result_callback_t)(const struct nros_goal_uuid_t *goal_uuid,
                                        void *context);
 
 /**
+ * phase-379 W4 — a checkable reference to the node an entity was created on.
+ *
+ * Replaces the `*const nros_node_t` each entity used to store. That pointer
+ * was never dereferenced anywhere in the C API — it was assigned, nulled, and
+ * asserted on — so it bought provenance nobody could use while leaving a raw
+ * pointer that invites a dereference the platform cannot support:
+ *
+ * * bare metal is safe (no MMU, no relocation, handles in `.bss`), but
+ * * an RTOS node declared on a task stack dies with `vTaskDelete`, and
+ * * `nros_node_t a = b;` is legal and silent — C has no move semantics, and we
+ *   have no allocator to hide an indirection behind.
+ *
+ * rcl's alternative (`rcl_publisher_fini(&pub, &node)`) does not remove that
+ * assumption; it relocates it to a caller who cannot check it either.
+ *
+ * So the entity stores an IDENTITY instead: the executor slot the node is
+ * bound to, plus the generation that slot carried when the entity was created.
+ * `nros_node_fini` bumps the generation, which makes "finalise an entity after
+ * its node" a return code rather than a silent success.
+ *
+ * `generation == 0` is reserved and never issued, so a zeroed struct — the
+ * common C mistake — can never resolve.
+ */
+typedef struct nros_node_ref_t {
+  /**
+   * Executor node slot (`nros_node_t::node_id`). 0 = the primary node.
+   */
+  uint8_t node_id;
+  /**
+   * Slot generation when the entity was created. 0 = no node bound.
+   */
+  uint32_t generation;
+} nros_node_ref_t;
+
+/**
+ * Identifier of a registered scheduling context. `0` is the
+ * auto-created default `Fifo` SC. Mirrors
+ * `nros_node::executor::sched_context::SchedContextId`.
+ */
+typedef uint8_t nros_sched_context_id_t;
+
+/**
+ * Internal state for the action client.
+ *
+ * Lightweight — stores only the arena entry index and executor pointer.
+ * The `ActionClientCore` (transport handles) lives in the executor's arena,
+ * created by `nros_executor_add_action_client`.
+ */
+typedef struct ActionClientInternal {
+  /**
+   * Arena entry index (set by nros_executor_add_action_client).
+   * -1 means not registered with executor.
+   */
+  int32_t arena_entry_index;
+  /**
+   * Pointer to the executor (set by nros_executor_add_action_client).
+   */
+  void *executor_ptr;
+} ActionClientInternal;
+
+/**
+ * Action client structure.
+ */
+typedef struct nros_action_client_t {
+  /**
+   * Current state
+   */
+  enum nros_action_client_state_t state;
+  /**
+   * Action name storage
+   */
+  uint8_t action_name[NROS_MAX_ACTION_NAME_LEN];
+  /**
+   * Action name length
+   */
+  size_t action_name_len;
+  /**
+   * Type name storage
+   */
+  uint8_t type_name[NROS_MAX_TYPE_NAME_LEN];
+  /**
+   * Type name length
+   */
+  size_t type_name_len;
+  /**
+   * Type hash storage
+   */
+  uint8_t type_hash[NROS_MAX_TYPE_HASH_LEN];
+  /**
+   * Type hash length
+   */
+  size_t type_hash_len;
+  /**
+   * Goal response callback (for async send_goal)
+   */
+  nros_goal_response_callback_t goal_response_callback;
+  /**
+   * Feedback callback
+   */
+  nros_feedback_callback_t feedback_callback;
+  /**
+   * Result callback
+   */
+  nros_result_callback_t result_callback;
+  /**
+   * User context pointer
+   */
+  void *context;
+  /**
+   * Pointer to parent node
+   */
+  struct nros_node_ref_t node;
+  /**
+   * Phase 189.M3.3.b — scheduling-context slot to bind the action client's
+   * executor handle to. `0` = inherit the executor / Node default; set via
+   * `nros_action_client_init_with_options`. When non-zero,
+   * `nros_executor_add_action_client` binds the handle after
+   * registration. No effect on the L1 polling path.
+   */
+  nros_sched_context_id_t sched_context_id;
+  /**
+   * Internal state (arena entry index + executor pointer). Phase 87.5:
+   * Typed C-ABI handle field.
+   */
+  struct ActionClientInternal _internal;
+  /**
+   * Phase 122.3.c.6.b — inline opaque storage for the L1
+   * polling-mode `ActionClientCore`. Zeroed in L2 mode; populated
+   * by `nros_action_client_init_polling`.
+   */
+  uint64_t _opaque[ACTION_CLIENT_OPAQUE_U64S];
+} nros_action_client_t;
+
+/**
  * Phase 211.H (issue #52) — one per-topic QoS override, the C-ABI mirror of
  * Rust's `nros_rmw::QoSOverride`. The deploy plan lowers a
  * `qos_overrides.<topic>.<role>.<policy>` launch param into a `&'static`
@@ -1280,105 +1414,6 @@ typedef struct nros_node_t {
    */
   size_t qos_overrides_len;
 } nros_node_t;
-
-/**
- * Identifier of a registered scheduling context. `0` is the
- * auto-created default `Fifo` SC. Mirrors
- * `nros_node::executor::sched_context::SchedContextId`.
- */
-typedef uint8_t nros_sched_context_id_t;
-
-/**
- * Internal state for the action client.
- *
- * Lightweight — stores only the arena entry index and executor pointer.
- * The `ActionClientCore` (transport handles) lives in the executor's arena,
- * created by `nros_executor_add_action_client`.
- */
-typedef struct ActionClientInternal {
-  /**
-   * Arena entry index (set by nros_executor_add_action_client).
-   * -1 means not registered with executor.
-   */
-  int32_t arena_entry_index;
-  /**
-   * Pointer to the executor (set by nros_executor_add_action_client).
-   */
-  void *executor_ptr;
-} ActionClientInternal;
-
-/**
- * Action client structure.
- */
-typedef struct nros_action_client_t {
-  /**
-   * Current state
-   */
-  enum nros_action_client_state_t state;
-  /**
-   * Action name storage
-   */
-  uint8_t action_name[NROS_MAX_ACTION_NAME_LEN];
-  /**
-   * Action name length
-   */
-  size_t action_name_len;
-  /**
-   * Type name storage
-   */
-  uint8_t type_name[NROS_MAX_TYPE_NAME_LEN];
-  /**
-   * Type name length
-   */
-  size_t type_name_len;
-  /**
-   * Type hash storage
-   */
-  uint8_t type_hash[NROS_MAX_TYPE_HASH_LEN];
-  /**
-   * Type hash length
-   */
-  size_t type_hash_len;
-  /**
-   * Goal response callback (for async send_goal)
-   */
-  nros_goal_response_callback_t goal_response_callback;
-  /**
-   * Feedback callback
-   */
-  nros_feedback_callback_t feedback_callback;
-  /**
-   * Result callback
-   */
-  nros_result_callback_t result_callback;
-  /**
-   * User context pointer
-   */
-  void *context;
-  /**
-   * Pointer to parent node
-   */
-  const struct nros_node_t *node;
-  /**
-   * Phase 189.M3.3.b — scheduling-context slot to bind the action client's
-   * executor handle to. `0` = inherit the executor / Node default; set via
-   * `nros_action_client_init_with_options`. When non-zero,
-   * `nros_executor_add_action_client` binds the handle after
-   * registration. No effect on the L1 polling path.
-   */
-  nros_sched_context_id_t sched_context_id;
-  /**
-   * Internal state (arena entry index + executor pointer). Phase 87.5:
-   * Typed C-ABI handle field.
-   */
-  struct ActionClientInternal _internal;
-  /**
-   * Phase 122.3.c.6.b — inline opaque storage for the L1
-   * polling-mode `ActionClientCore`. Zeroed in L2 mode; populated
-   * by `nros_action_client_init_polling`.
-   */
-  uint64_t _opaque[ACTION_CLIENT_OPAQUE_U64S];
-} nros_action_client_t;
 
 /**
  * Action type information.
@@ -1643,7 +1678,7 @@ typedef struct nros_action_server_t {
   /**
    * Pointer to parent node
    */
-  const struct nros_node_t *node;
+  struct nros_node_ref_t node;
   /**
    * Phase 193.4b — action-server QoS, applied to the three underlying
    * service servers (send_goal / cancel_goal / get_result). The feedback +
@@ -1746,7 +1781,7 @@ typedef struct nros_subscription_t {
   /**
    * Pointer to parent node
    */
-  const struct nros_node_t *node;
+  struct nros_node_ref_t node;
   /**
    * QoS settings (stored during init, used by executor registration)
    */
@@ -1841,7 +1876,7 @@ typedef struct nros_publisher_t {
   /**
    * Pointer to parent node
    */
-  const struct nros_node_t *node;
+  struct nros_node_ref_t node;
   /**
    * Inline opaque storage for the RMW publisher handle.
    * Avoids heap allocation — managed by nros_publisher_init/fini.
@@ -2127,7 +2162,7 @@ typedef struct nros_service_t {
   /**
    * Pointer to parent node
    */
-  const struct nros_node_t *node;
+  struct nros_node_ref_t node;
   /**
    * Phase 193.4 — service QoS (applied to both request + reply endpoints).
    * Defaults to the services profile (RELIABLE+VOLATILE+KEEP_LAST(10));
@@ -2232,7 +2267,7 @@ typedef struct nros_client_t {
   /**
    * Pointer to parent node
    */
-  const struct nros_node_t *node;
+  struct nros_node_ref_t node;
   /**
    * Phase 193.4b — service-client QoS (applied to both request + reply
    * endpoints). Defaults to the services profile
@@ -2621,6 +2656,19 @@ typedef struct nros_integrity_status_t {
  * Bad sequence (e.g., wrong order of operations)
  */
 #define NROS_RET_BAD_SEQUENCE -8
+
+/**
+ * phase-379 W4 — the entity's node reference no longer names a live binding.
+ *
+ * Returned when an entity is used or finalised after `nros_node_fini` retired
+ * the slot it was created on. Before W4 the entity held a raw
+ * `*const nros_node_t` that nothing dereferenced, so this case SUCCEEDED
+ * silently; the identity makes it detectable. Distinct from
+ * `NROS_RET_NOT_INIT` (never initialised) and `NROS_RET_BAD_SEQUENCE`
+ * (initialised, wrong order) because the remedy differs: the node outlived by
+ * this entity has to be finalised LAST.
+ */
+#define NROS_RET_STALE_NODE -17
 
 /**
  * Service call failed

--- a/packages/api/nros-c/src/action/client.rs
+++ b/packages/api/nros-c/src/action/client.rs
@@ -117,7 +117,7 @@ pub struct nros_action_client_t {
     /// User context pointer
     pub context: *mut c_void,
     /// Pointer to parent node
-    pub node: *const nros_node_t,
+    pub node: crate::node::nros_node_ref_t,
     /// Phase 189.M3.3.b — scheduling-context slot to bind the action client's
     /// executor handle to. `0` = inherit the executor / Node default; set via
     /// `nros_action_client_init_with_options`. When non-zero,
@@ -151,7 +151,7 @@ impl Default for nros_action_client_t {
             feedback_callback: None,
             result_callback: None,
             context: ptr::null_mut(),
-            node: ptr::null(),
+            node: crate::node::nros_node_ref_t::none(),
             sched_context_id: 0,
             _internal: ActionClientInternal::new(),
             _opaque: [0u64; crate::opaque_sizes::ACTION_CLIENT_OPAQUE_U64S],
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn nros_action_client_init(
     client.type_hash_len = crate::util::copy_cstr_into(type_info.type_hash, &mut client.type_hash);
 
     // Store node pointer
-    client.node = node;
+    client.node = unsafe { crate::node::node_ref_of(node) };
 
     // Metadata only — no transport handles created here.
     // Transport handles are created in nros_executor_add_action_client,
@@ -1018,7 +1018,7 @@ pub unsafe extern "C" fn nros_action_client_fini(client: *mut nros_action_client
     client.feedback_callback = None;
     client.result_callback = None;
     client.context = ptr::null_mut();
-    client.node = ptr::null();
+    client.node = crate::node::nros_node_ref_t::none();
     client.state = nros_action_client_state_t::NROS_ACTION_CLIENT_STATE_SHUTDOWN;
 
     NROS_RET_OK
@@ -1076,7 +1076,7 @@ pub unsafe extern "C" fn nros_action_client_init_polling(
     client_mut.type_hash_len =
         crate::util::copy_cstr_into(type_info_ref.type_hash, &mut client_mut.type_hash);
 
-    client_mut.node = node;
+    client_mut.node = unsafe { crate::node::node_ref_of(node) };
 
     #[cfg(feature = "rmw-cffi")]
     {

--- a/packages/api/nros-c/src/action/server.rs
+++ b/packages/api/nros-c/src/action/server.rs
@@ -70,7 +70,7 @@ pub struct nros_action_server_t {
     /// User context pointer
     pub context: *mut c_void,
     /// Pointer to parent node
-    pub node: *const nros_node_t,
+    pub node: crate::node::nros_node_ref_t,
     /// Phase 193.4b — action-server QoS, applied to the three underlying
     /// service servers (send_goal / cancel_goal / get_result). The feedback +
     /// status publishers keep their own profiles. Defaults to the services
@@ -107,7 +107,7 @@ impl Default for nros_action_server_t {
             cancel_callback: None,
             accepted_callback: None,
             context: ptr::null_mut(),
-            node: ptr::null(),
+            node: crate::node::nros_node_ref_t::none(),
             qos: crate::qos::nros_qos_t::default(),
             sched_context_id: 0,
             _internal: ActionServerInternal::invalid_default(),
@@ -383,7 +383,7 @@ pub unsafe extern "C" fn nros_action_server_init(
     server.cancel_callback = cancel_callback;
     server.accepted_callback = accepted_callback;
     server.context = context;
-    server.node = node;
+    server.node = unsafe { crate::node::node_ref_of(node) };
 
     // Phase 193.4b — default to the services profile;
     // nros_action_server_init_with_qos overrides. Read at registration time by
@@ -818,7 +818,7 @@ pub unsafe extern "C" fn nros_action_server_fini(server: *mut nros_action_server
     server.cancel_callback = None;
     server.accepted_callback = None;
     server.context = ptr::null_mut();
-    server.node = ptr::null();
+    server.node = crate::node::nros_node_ref_t::none();
     server.state = nros_action_server_state_t::NROS_ACTION_SERVER_STATE_SHUTDOWN;
 
     NROS_RET_OK
@@ -876,7 +876,7 @@ pub unsafe extern "C" fn nros_action_server_init_polling(
     server_mut.type_hash_len =
         crate::util::copy_cstr_into(type_info_ref.type_hash, &mut server_mut.type_hash);
 
-    server_mut.node = node;
+    server_mut.node = unsafe { crate::node::node_ref_of(node) };
 
     #[cfg(feature = "rmw-cffi")]
     {

--- a/packages/api/nros-c/src/error.rs
+++ b/packages/api/nros-c/src/error.rs
@@ -34,6 +34,17 @@ pub const NROS_RET_NOT_INIT: nros_ret_t = -7;
 /// Bad sequence (e.g., wrong order of operations)
 pub const NROS_RET_BAD_SEQUENCE: nros_ret_t = -8;
 
+/// phase-379 W4 — the entity's node reference no longer names a live binding.
+///
+/// Returned when an entity is used or finalised after `nros_node_fini` retired
+/// the slot it was created on. Before W4 the entity held a raw
+/// `*const nros_node_t` that nothing dereferenced, so this case SUCCEEDED
+/// silently; the identity makes it detectable. Distinct from
+/// `NROS_RET_NOT_INIT` (never initialised) and `NROS_RET_BAD_SEQUENCE`
+/// (initialised, wrong order) because the remedy differs: the node outlived by
+/// this entity has to be finalised LAST.
+pub const NROS_RET_STALE_NODE: nros_ret_t = -17;
+
 /// Service call failed
 pub const NROS_RET_SERVICE_FAILED: nros_ret_t = -9;
 

--- a/packages/api/nros-c/src/executor.rs
+++ b/packages/api/nros-c/src/executor.rs
@@ -99,14 +99,29 @@ pub(crate) unsafe fn get_executor_from_ptr(ptr: *mut core::ffi::c_void) -> &'sta
 /// # Safety
 /// `node` must be NULL or point to an initialized `nros_node_t` with
 /// valid `name_len` / `namespace_len`.
-unsafe fn set_executor_node_identity(rust_exec: &mut CExecutor, node: *const nros_node_t) {
-    if node.is_null() {
+unsafe fn set_executor_node_identity(
+    rust_exec: &mut CExecutor,
+    node: crate::node::nros_node_ref_t,
+) {
+    // phase-379 W4 — resolve the IDENTITY against the executor's own
+    // `NodeRecord`, rather than dereferencing a `*const nros_node_t` the entity
+    // captured at init.
+    //
+    // This is the call that made the stored pointer load-bearing: it reads the
+    // node's name and namespace, long after the entity was created, from
+    // caller-owned storage the runtime does not control. On an RTOS that
+    // storage can be a task stack `vTaskDelete` has already freed. The record
+    // holds the same two strings and outlives the caller's struct.
+    if !crate::node::node_ref_is_live(node) {
         return;
     }
-    let node_ref = &*node;
-    let name_str = core::str::from_utf8_unchecked(&node_ref.name[..node_ref.name_len]);
-    let ns_str = core::str::from_utf8_unchecked(&node_ref.namespace[..node_ref.namespace_len]);
-    rust_exec.set_node_identity(name_str, ns_str);
+    let id = nros_node::executor::NodeId::from_raw(node.node_id);
+    let Some(record) = rust_exec.node(id) else {
+        return;
+    };
+    let name = record.name.clone();
+    let namespace = record.namespace.clone();
+    rust_exec.set_node_identity(name.as_str(), namespace.as_str());
 }
 
 // ============================================================================
@@ -1421,10 +1436,10 @@ pub unsafe extern "C" fn nros_executor_add_subscription(
         // so multi-RMW bridges land on the right session. Legacy
         // `nros_node_init`-style Nodes carry `node_id == 0` and fall
         // through to the single-Node entry point.
-        let node_raw_id = if subscription_ref.node.is_null() {
+        let node_raw_id = if !subscription_ref.node.is_bound() {
             0
         } else {
-            (*subscription_ref.node).node_id
+            subscription_ref.node.node_id
         };
         // Phase 189.M2.b — the single kept C-FFI subscription core.
         let node_id =
@@ -1537,7 +1552,7 @@ pub unsafe extern "C" fn nros_executor_add_subscription_raw_with_info(
 
     {
         let rust_exec = get_executor(&mut executor._opaque);
-        set_executor_node_identity(rust_exec, node);
+        set_executor_node_identity(rust_exec, unsafe { crate::node::node_ref_of(node) });
         // Phase 305 W3 (issue 0255) — resolve `~`/relative names + launch remaps
         // against the identity just set (executor-side remap table).
         let __resolved_name = match rust_exec.resolve_entity_name(topic_str) {
@@ -1706,10 +1721,10 @@ pub unsafe extern "C" fn nros_executor_add_subscription_in_group(
         };
         let topic_str = __resolved_name.as_str();
 
-        let node_raw_id = if subscription_ref.node.is_null() {
+        let node_raw_id = if !subscription_ref.node.is_bound() {
             0
         } else {
-            (*subscription_ref.node).node_id
+            subscription_ref.node.node_id
         };
         let node_id =
             (node_raw_id != 0).then(|| nros_node::executor::NodeId::from_raw(node_raw_id));
@@ -1897,10 +1912,10 @@ pub unsafe extern "C" fn nros_executor_add_service(
         // Phase 104.C.8.b — route multi-Node services through the
         // `_on(NodeId, ...)` variant when the Node was created via
         // `nros_executor_node_init`.
-        let node_raw_id = if service_ref.node.is_null() {
+        let node_raw_id = if !service_ref.node.is_bound() {
             0
         } else {
-            (*service_ref.node).node_id
+            service_ref.node.node_id
         };
         // Phase 193.4 — the service's QoS (set via nros_service_init_with_qos;
         // defaults to services_default via nros_service_init).
@@ -2027,10 +2042,10 @@ pub unsafe extern "C" fn nros_executor_add_client(
         let service_name = __resolved_name.as_str();
 
         // Phase 104.C.8.b — service-client multi-Node dispatch.
-        let node_raw_id = if client_ref.node.is_null() {
+        let node_raw_id = if !client_ref.node.is_bound() {
             0
         } else {
-            (*client_ref.node).node_id
+            client_ref.node.node_id
         };
         // Phase 193.4b — the client's QoS (set via nros_client_init_with_qos;
         // defaults to services_default via nros_client_init).
@@ -2224,10 +2239,10 @@ pub unsafe extern "C" fn nros_executor_add_action_server(
         let action_name = __resolved_name.as_str();
 
         // Phase 104.C.8.b — action-server multi-Node dispatch.
-        let node_raw_id = if server_ref.node.is_null() {
+        let node_raw_id = if !server_ref.node.is_bound() {
             0
         } else {
-            (*server_ref.node).node_id
+            server_ref.node.node_id
         };
 
         // Register with the nros-node executor using trampolines. The
@@ -2369,10 +2384,10 @@ pub unsafe extern "C" fn nros_executor_add_action_client(
         // Phase 104.C.8.b — action-client multi-Node dispatch.
         // `spec.node_id` selects the target Node's session (or the
         // executor's own node when `None`).
-        let node_raw_id = if client_ref.node.is_null() {
+        let node_raw_id = if !client_ref.node.is_bound() {
             0
         } else {
-            (*client_ref.node).node_id
+            client_ref.node.node_id
         };
         let node_id = if node_raw_id != 0 {
             Some(nros_node::executor::NodeId::from_raw(node_raw_id))

--- a/packages/api/nros-c/src/node.rs
+++ b/packages/api/nros-c/src/node.rs
@@ -27,6 +27,104 @@ pub enum nros_node_state_t {
     NROS_NODE_STATE_SHUTDOWN = 2,
 }
 
+/// phase-379 W4 — a checkable reference to the node an entity was created on.
+///
+/// Replaces the `*const nros_node_t` each entity used to store. That pointer
+/// was never dereferenced anywhere in the C API — it was assigned, nulled, and
+/// asserted on — so it bought provenance nobody could use while leaving a raw
+/// pointer that invites a dereference the platform cannot support:
+///
+/// * bare metal is safe (no MMU, no relocation, handles in `.bss`), but
+/// * an RTOS node declared on a task stack dies with `vTaskDelete`, and
+/// * `nros_node_t a = b;` is legal and silent — C has no move semantics, and we
+///   have no allocator to hide an indirection behind.
+///
+/// rcl's alternative (`rcl_publisher_fini(&pub, &node)`) does not remove that
+/// assumption; it relocates it to a caller who cannot check it either.
+///
+/// So the entity stores an IDENTITY instead: the executor slot the node is
+/// bound to, plus the generation that slot carried when the entity was created.
+/// `nros_node_fini` bumps the generation, which makes "finalise an entity after
+/// its node" a return code rather than a silent success.
+///
+/// `generation == 0` is reserved and never issued, so a zeroed struct — the
+/// common C mistake — can never resolve.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct nros_node_ref_t {
+    /// Executor node slot (`nros_node_t::node_id`). 0 = the primary node.
+    pub node_id: u8,
+    /// Slot generation when the entity was created. 0 = no node bound.
+    pub generation: u32,
+}
+
+impl nros_node_ref_t {
+    /// The reference an uninitialised entity carries: bound to nothing.
+    pub const fn none() -> Self {
+        Self {
+            node_id: 0,
+            generation: 0,
+        }
+    }
+
+    /// Is this reference bound to a node at all?
+    pub const fn is_bound(&self) -> bool {
+        self.generation != 0
+    }
+}
+
+/// Per-slot generation counters, bumped when a node is finalised.
+///
+/// A plain static rather than executor state because the C `nros_node_t` is
+/// CALLER-allocated: there is no runtime-owned place to hang it that every
+/// entity can reach without the pointer this type exists to remove.
+static NODE_GENERATIONS: [core::sync::atomic::AtomicU32; nros_node::config::MAX_NODES] =
+    [const { core::sync::atomic::AtomicU32::new(1) }; nros_node::config::MAX_NODES];
+
+/// Mint a reference to `node`'s current binding.
+///
+/// # Safety
+/// `node` must point at an initialised `nros_node_t` for the duration of the
+/// call. The reference outlives the pointer deliberately — that is the point.
+pub(crate) unsafe fn node_ref_of(node: *const nros_node_t) -> nros_node_ref_t {
+    if node.is_null() {
+        return nros_node_ref_t::none();
+    }
+    let id = unsafe { (*node).node_id };
+    nros_node_ref_t {
+        node_id: id,
+        generation: current_generation(id),
+    }
+}
+
+/// The generation slot `id` carries now.
+pub(crate) fn current_generation(id: u8) -> u32 {
+    NODE_GENERATIONS
+        .get(id as usize)
+        .map(|g| g.load(core::sync::atomic::Ordering::Acquire))
+        .unwrap_or(0)
+}
+
+/// Retire slot `id`, so every reference minted against it stops resolving.
+///
+/// Wraps past `u32::MAX` back to 1, never 0 — 0 stays reserved for "unbound".
+pub(crate) fn retire_generation(id: u8) {
+    if let Some(g) = NODE_GENERATIONS.get(id as usize) {
+        let next = g
+            .load(core::sync::atomic::Ordering::Acquire)
+            .wrapping_add(1);
+        g.store(
+            if next == 0 { 1 } else { next },
+            core::sync::atomic::Ordering::Release,
+        );
+    }
+}
+
+/// Does `r` still name a live binding?
+pub(crate) fn node_ref_is_live(r: nros_node_ref_t) -> bool {
+    r.is_bound() && current_generation(r.node_id) == r.generation
+}
+
 /// Node structure.
 ///
 /// Represents a ROS 2 node with a name and namespace.
@@ -371,6 +469,11 @@ pub unsafe extern "C" fn nros_node_fini(node: *mut nros_node_t) -> nros_ret_t {
         return NROS_RET_NOT_INIT;
     }
 
+    // phase-379 W4 — retire the slot BEFORE marking shutdown, so any entity
+    // still holding a reference to this binding fails its own `_fini` with a
+    // stale-node error instead of succeeding silently against a dead node.
+    retire_generation(node.node_id);
+
     node.support = ptr::null();
     node.state = nros_node_state_t::NROS_NODE_STATE_SHUTDOWN;
 
@@ -641,5 +744,73 @@ pub(crate) unsafe fn resolve_session_and_domain(
             session.domain_id()
         };
         Some((session, domain_id))
+    }
+}
+
+#[cfg(test)]
+mod node_ref_tests {
+    use super::*;
+
+    /// phase-379 W4 — a reference minted before `nros_node_fini` stops
+    /// resolving after it.
+    ///
+    /// This is the whole behavioural change. Before W4 the entity held a
+    /// `*const nros_node_t` that nothing dereferenced, so "finalise the node,
+    /// then finalise its publisher" succeeded silently and the teardown-order
+    /// obligation the C API places on the caller was unenforceable.
+    #[test]
+    fn retiring_a_slot_invalidates_references_minted_against_it() {
+        // Slot 3 rather than 0: the primary node is the legacy path and the
+        // interesting case is a bound one.
+        let id = 3u8;
+        let before = nros_node_ref_t {
+            node_id: id,
+            generation: current_generation(id),
+        };
+        assert!(node_ref_is_live(before), "a fresh reference must resolve");
+
+        retire_generation(id);
+        assert!(
+            !node_ref_is_live(before),
+            "a reference minted before the slot was retired must stop resolving"
+        );
+
+        let after = nros_node_ref_t {
+            node_id: id,
+            generation: current_generation(id),
+        };
+        assert!(node_ref_is_live(after), "the rebound slot issues live refs");
+        assert_ne!(
+            before.generation, after.generation,
+            "retiring must change the generation, or nothing is detectable"
+        );
+    }
+
+    /// `generation == 0` is reserved, so a zeroed struct never resolves.
+    ///
+    /// A zeroed handle is the commonest C mistake, and it is exactly the shape
+    /// `calloc`, a `static`, and `memset` all produce.
+    #[test]
+    fn a_zeroed_reference_is_never_live() {
+        let zeroed = nros_node_ref_t {
+            node_id: 0,
+            generation: 0,
+        };
+        assert!(!zeroed.is_bound());
+        assert!(!node_ref_is_live(zeroed));
+        assert!(!node_ref_is_live(nros_node_ref_t::none()));
+    }
+
+    /// The wrap never lands on 0, because 0 means "unbound".
+    #[test]
+    fn generation_wrap_skips_the_reserved_value() {
+        let id = (nros_node::config::MAX_NODES - 1) as u8;
+        NODE_GENERATIONS[id as usize].store(u32::MAX, core::sync::atomic::Ordering::Release);
+        retire_generation(id);
+        assert_ne!(
+            current_generation(id),
+            0,
+            "wrapping past u32::MAX must skip 0, or a zeroed struct would resolve"
+        );
     }
 }

--- a/packages/api/nros-c/src/publisher.rs
+++ b/packages/api/nros-c/src/publisher.rs
@@ -70,7 +70,7 @@ pub struct nros_publisher_t {
     /// Type hash length
     pub type_hash_len: usize,
     /// Pointer to parent node
-    pub node: *const nros_node_t,
+    pub node: crate::node::nros_node_ref_t,
     /// Inline opaque storage for the RMW publisher handle.
     /// Avoids heap allocation — managed by nros_publisher_init/fini.
     pub _opaque: [u64; PUBLISHER_OPAQUE_U64S],
@@ -86,7 +86,7 @@ impl Default for nros_publisher_t {
             type_name_len: 0,
             type_hash: [0u8; MAX_TYPE_HASH_LEN],
             type_hash_len: 0,
-            node: ptr::null(),
+            node: crate::node::nros_node_ref_t::none(),
             _opaque: [0u64; PUBLISHER_OPAQUE_U64S],
         }
     }
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn nros_publisher_init_with_qos(
         crate::util::copy_cstr_into(type_info.type_hash, &mut publisher.type_hash);
 
     // Store node reference
-    publisher.node = node;
+    publisher.node = unsafe { crate::node::node_ref_of(node) };
 
     // Get QoS settings
     let _qos_settings = if qos.is_null() {
@@ -673,6 +673,14 @@ pub unsafe extern "C" fn nros_publisher_fini(publisher: *mut nros_publisher_t) -
     );
 
     // Drop the inline RMW publisher handle
+    // phase-379 W4 — the node this entity was created on is gone, so its
+    // teardown ORDER was wrong. Reported rather than performed: before W4 the
+    // entity held a pointer nothing dereferenced and this case succeeded
+    // silently, which is what made the ordering obligation unenforceable.
+    if publisher.node.is_bound() && !crate::node::node_ref_is_live(publisher.node) {
+        return crate::error::NROS_RET_STALE_NODE;
+    }
+
     #[cfg(feature = "rmw-cffi")]
     {
         core::ptr::drop_in_place(
@@ -681,7 +689,7 @@ pub unsafe extern "C" fn nros_publisher_fini(publisher: *mut nros_publisher_t) -
     }
 
     publisher._opaque = [0u64; PUBLISHER_OPAQUE_U64S];
-    publisher.node = ptr::null();
+    publisher.node = crate::node::nros_node_ref_t::none();
     publisher.state = nros_publisher_state_t::NROS_PUBLISHER_STATE_SHUTDOWN;
 
     NROS_RET_OK
@@ -803,7 +811,7 @@ mod verification {
             pub_.state,
             nros_publisher_state_t::NROS_PUBLISHER_STATE_UNINITIALIZED,
         );
-        assert!(pub_.node.is_null());
+        assert!(!pub_.node.is_bound(), "fini must unbind the node reference");
         assert!(pub_._opaque.iter().all(|&v| v == 0));
     }
 }

--- a/packages/api/nros-c/src/service.rs
+++ b/packages/api/nros-c/src/service.rs
@@ -156,7 +156,7 @@ pub struct nros_service_t {
     /// User context pointer
     pub context: *mut c_void,
     /// Pointer to parent node
-    pub node: *const nros_node_t,
+    pub node: crate::node::nros_node_ref_t,
     /// Phase 193.4 — service QoS (applied to both request + reply endpoints).
     /// Defaults to the services profile (RELIABLE+VOLATILE+KEEP_LAST(10));
     /// set via `nros_service_init_with_qos`.
@@ -189,7 +189,7 @@ impl Default for nros_service_t {
             type_hash_len: 0,
             callback: None,
             context: ptr::null_mut(),
-            node: ptr::null(),
+            node: crate::node::nros_node_ref_t::none(),
             qos: crate::qos::nros_qos_t::default(),
             sched_context_id: 0,
             _internal: ServiceServerInternal::new(),
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn nros_service_init(
     // Store callback and context
     service.callback = callback;
     service.context = context;
-    service.node = node;
+    service.node = unsafe { crate::node::node_ref_of(node) };
     // Phase 193.4 — default to the services profile; nros_service_init_with_qos
     // overrides. (`register_service` reads this at registration time.)
     service.qos = crate::qos::nros_qos_t::default();
@@ -421,7 +421,7 @@ pub unsafe extern "C" fn nros_service_fini(service: *mut nros_service_t) -> nros
     service._internal = ServiceServerInternal::new();
     service.callback = None;
     service.context = ptr::null_mut();
-    service.node = ptr::null();
+    service.node = crate::node::nros_node_ref_t::none();
     service.state = nros_service_state_t::NROS_SERVICE_STATE_SHUTDOWN;
 
     NROS_RET_OK
@@ -491,7 +491,7 @@ pub unsafe extern "C" fn nros_service_init_polling(
     service_mut.type_hash_len =
         crate::util::copy_cstr_into(type_info_ref.type_hash, &mut service_mut.type_hash);
 
-    service_mut.node = node;
+    service_mut.node = unsafe { crate::node::node_ref_of(node) };
     service_mut.callback = None;
     service_mut.context = ptr::null_mut();
 
@@ -948,7 +948,7 @@ pub struct nros_client_t {
     /// User context pointer passed to `response_callback`.
     pub context: *mut c_void,
     /// Pointer to parent node
-    pub node: *const nros_node_t,
+    pub node: crate::node::nros_node_ref_t,
     /// Phase 193.4b — service-client QoS (applied to both request + reply
     /// endpoints). Defaults to the services profile
     /// (RELIABLE+VOLATILE+KEEP_LAST(10)); set via `nros_client_init_with_qos`.
@@ -981,7 +981,7 @@ impl Default for nros_client_t {
             type_hash_len: 0,
             response_callback: None,
             context: ptr::null_mut(),
-            node: ptr::null(),
+            node: crate::node::nros_node_ref_t::none(),
             qos: crate::qos::nros_qos_t::default(),
             sched_context_id: 0,
             _internal: ServiceClientInternal::new(),
@@ -1051,7 +1051,7 @@ pub unsafe extern "C" fn nros_client_init(
     client.type_hash_len = crate::util::copy_cstr_into(type_info.type_hash, &mut client.type_hash);
 
     // Store node pointer + zero callback fields
-    client.node = node;
+    client.node = unsafe { crate::node::node_ref_of(node) };
     client.response_callback = None;
     client.context = ptr::null_mut();
 
@@ -1180,7 +1180,7 @@ pub unsafe extern "C" fn nros_client_fini(client: *mut nros_client_t) -> nros_re
     client._internal = ServiceClientInternal::new();
     client.response_callback = None;
     client.context = ptr::null_mut();
-    client.node = ptr::null();
+    client.node = crate::node::nros_node_ref_t::none();
     client.state = nros_client_state_t::NROS_CLIENT_STATE_SHUTDOWN;
 
     NROS_RET_OK
@@ -1242,7 +1242,7 @@ pub unsafe extern "C" fn nros_client_init_polling(
     client_mut.type_hash_len =
         crate::util::copy_cstr_into(type_info_ref.type_hash, &mut client_mut.type_hash);
 
-    client_mut.node = node;
+    client_mut.node = unsafe { crate::node::node_ref_of(node) };
     client_mut.response_callback = None;
     client_mut.context = ptr::null_mut();
 
@@ -2256,7 +2256,7 @@ mod verification {
             svc.state,
             nros_service_state_t::NROS_SERVICE_STATE_UNINITIALIZED,
         );
-        assert!(svc.node.is_null());
+        assert!(!svc.node.is_bound(), "fini must unbind the node reference");
     }
 
     #[kani::proof]
@@ -2428,7 +2428,10 @@ mod verification {
             client.state,
             nros_client_state_t::NROS_CLIENT_STATE_UNINITIALIZED,
         );
-        assert!(client.node.is_null());
+        assert!(
+            !client.node.is_bound(),
+            "fini must unbind the node reference"
+        );
         assert!(client._internal.iter().all(|&v| v == 0));
     }
 

--- a/packages/api/nros-c/src/subscription.rs
+++ b/packages/api/nros-c/src/subscription.rs
@@ -86,7 +86,7 @@ pub struct nros_subscription_t {
     /// User context pointer
     pub context: *mut c_void,
     /// Pointer to parent node
-    pub node: *const nros_node_t,
+    pub node: crate::node::nros_node_ref_t,
     /// QoS settings (stored during init, used by executor registration)
     pub qos: crate::qos::nros_qos_t,
     /// Handle ID from executor registration (SIZE_MAX = not registered)
@@ -117,7 +117,7 @@ impl Default for nros_subscription_t {
             type_hash_len: 0,
             callback: None,
             context: ptr::null_mut(),
-            node: ptr::null(),
+            node: crate::node::nros_node_ref_t::none(),
             qos: crate::qos::nros_qos_t::default(),
             handle_id: usize::MAX,
             sched_context_id: 0,
@@ -264,7 +264,7 @@ pub unsafe extern "C" fn nros_subscription_init_with_qos(
     // Store callback and context
     subscription.callback = callback;
     subscription.context = context;
-    subscription.node = node;
+    subscription.node = unsafe { crate::node::node_ref_of(node) };
 
     // Store QoS settings for later use by executor registration
     subscription.qos = if qos.is_null() {
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn nros_subscription_init_polling_with_qos(
     subscription_mut.type_hash_len =
         crate::util::copy_cstr_into(type_info_ref.type_hash, &mut subscription_mut.type_hash);
 
-    subscription_mut.node = node;
+    subscription_mut.node = unsafe { crate::node::node_ref_of(node) };
     subscription_mut.qos = if qos.is_null() {
         crate::qos::NROS_QOS_DEFAULT
     } else {
@@ -866,6 +866,14 @@ pub unsafe extern "C" fn nros_subscription_fini(
         nros_subscription_state_t::NROS_SUBSCRIPTION_STATE_POLLING => {
             // L1: drop the inline RawSubscription so its Drop runs
             // (closes the underlying RMW subscriber).
+            // phase-379 W4 — the node this entity was created on is gone, so its
+            // teardown ORDER was wrong. Reported rather than performed: before W4 the
+            // entity held a pointer nothing dereferenced and this case succeeded
+            // silently, which is what made the ordering obligation unenforceable.
+            if subscription.node.is_bound() && !crate::node::node_ref_is_live(subscription.node) {
+                return crate::error::NROS_RET_STALE_NODE;
+            }
+
             #[cfg(feature = "rmw-cffi")]
             {
                 core::ptr::drop_in_place(subscription._opaque.as_mut_ptr()
@@ -879,7 +887,7 @@ pub unsafe extern "C" fn nros_subscription_fini(
     subscription.handle_id = usize::MAX;
     subscription.callback = None;
     subscription.context = ptr::null_mut();
-    subscription.node = ptr::null();
+    subscription.node = crate::node::nros_node_ref_t::none();
     subscription.state = nros_subscription_state_t::NROS_SUBSCRIPTION_STATE_SHUTDOWN;
 
     NROS_RET_OK

--- a/packages/api/nros/src/guide/services.rs
+++ b/packages/api/nros/src/guide/services.rs
@@ -20,7 +20,7 @@
 //!
 //! let reply = loop {
 //!     executor.spin_once(core::time::Duration::from_millis(10));
-//!     if let Ok(Some(reply)) = promise.try_recv() {
+//!     if let Ok(Some(reply)) = promise.take() {
 //!         break reply;
 //!     }
 //! };

--- a/packages/api/nros/src/lib.rs
+++ b/packages/api/nros/src/lib.rs
@@ -1228,26 +1228,69 @@ pub use nros_params::{
 /// ```
 /// use nros::prelude::*;
 /// ```
-pub mod prelude {
+/// phase-379 W5 — the RTOS machinery, named explicitly.
+///
+/// The second tier of the two-tier surface. `nros::prelude` is the API a ported
+/// ROS 2 node uses; everything here exists because the target is an RTOS, has no
+/// correspondent in rclrs/rclcpp/rclc, and a ROS 2 developer reading a node
+/// should not have to step over it.
+///
+/// Nothing moved out of `nros::` — these are re-exports, and every name is still
+/// reachable at its old path. What changed is that they are no longer dragged in
+/// by `use nros::prelude::*`.
+///
+/// The membership rule is mechanical rather than taste: a name belongs in the
+/// PRELUDE iff the parity ledger gives it a non-`extension` verdict — i.e. it
+/// corresponds to something in rclrs, rclcpp or rclc. Names with no
+/// correspondent belong here, unless they are load-bearing for startup
+/// (`ExecutorConfig`, `SpinOptions`), which is an argued allow-list rather than
+/// an exception anyone may grow.
+pub mod embedded {
+    // Wire encoding. A node publishes typed messages; these are for code that
+    // handles bytes, which upstream hides entirely.
+    pub use crate::{CdrReader, CdrWriter};
+
+    // Handle bookkeeping — the static tables that replace an allocator.
+    #[cfg(feature = "rmw-cffi")]
+    pub use crate::{HandleId, HandleSet, InvocationMode};
+
+    // Component/runtime plumbing, and the source-metadata capture the
+    // orchestration layer records. None of it appears in a ported node.
+    pub use crate::{MetadataRecorder, NodeRuntimeAdapter, RuntimeNodeRecord};
+
+    // Entity REGISTRATION vocabulary. A ported node writes
+    // `create_publisher(...)`; these are what the declaration macros and the
+    // orchestration layer use to describe what was created.
     pub use crate::{
-        CdrReader, CdrWriter, Deserialize, Logger, MessageInfo, NodeConfig, PublisherHandle,
-        QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy, RosMessage,
-        RosService, Serialize, StandaloneNode, SubscriptionHandle, TopicInfo,
+        ActionTag, Callback, CallbackEffectKind, CallbackEffects, DeclaredNode,
+        DeclaredNodeRuntime, EntityKind, NodeRuntime, ServiceTag, SourceLocationMetadata,
+        SourceNameKind, SubscriptionTag, record_node_metadata, register_node,
+    };
+    // Gated where the root gates it — the export follows the capability, not
+    // the tier.
+    #[cfg(feature = "alloc")]
+    pub use crate::SourceMetadataExport;
+}
+
+pub mod prelude {
+    // phase-379 W5 — the RTOS machinery moved to `nros::embedded`. Removed
+    // here rather than re-exported from both: a two-tier surface that still
+    // drags tier two in through the glob is one tier with extra words.
+
+    pub use crate::{
+        Deserialize, Logger, MessageInfo, NodeConfig, PublisherHandle, QoSDurabilityPolicy,
+        QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy, RosMessage, RosService, Serialize,
+        StandaloneNode, SubscriptionHandle, TopicInfo,
     };
 
     // Re-export component-mode API.
     #[cfg(feature = "rmw-cffi")]
     pub use crate::NodeExecutorRuntime;
     #[cfg(feature = "alloc")]
-    pub use crate::SourceMetadataExport;
     pub use crate::{
-        ActionTag, Callback, CallbackEffectKind, CallbackEffects, DeclaredNode,
-        DeclaredNodeRuntime, EntityKind, MetadataRecorder, Node, NodeActionClient,
-        NodeActionServer, NodeContext, NodeDeclError, NodeOptions, NodeParameter, NodePublisher,
-        NodeResult, NodeRuntime, NodeRuntimeAdapter, NodeServiceClient, NodeServiceServer,
-        NodeSubscription, NodeTimer, ParameterDefault, RuntimeNodeRecord, ServiceTag,
-        SourceLocationMetadata, SourceNameKind, SubscriptionTag, node, record_node_metadata,
-        register_node,
+        Node, NodeActionClient, NodeActionServer, NodeContext, NodeDeclError, NodeOptions,
+        NodeParameter, NodePublisher, NodeResult, NodeServiceClient, NodeServiceServer,
+        NodeSubscription, NodeTimer, ParameterDefault, node,
     };
 
     // Re-export lifecycle types
@@ -1258,8 +1301,8 @@ pub mod prelude {
 
     // Re-export executor config + handle types (always available)
     pub use crate::{
-        ExecutorConfig, GuardCondition, HandleId, HandleSet, InvocationMode, NodeError,
-        SessionMode, SpinOnceResult, SpinOptions, SpinPeriodPollingResult, TransportError, Trigger,
+        ExecutorConfig, GuardCondition, NodeError, SessionMode, SpinOnceResult, SpinOptions,
+        SpinPeriodPollingResult, TransportError, Trigger,
     };
 
     // issue 0687 — `ExecutorConfig::from_env()` is an extension trait now (the

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -551,6 +551,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -551,6 +551,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-zephyr-build",
 ]
 
 [[package]]

--- a/packages/core/nros-node/src/executor/action.rs
+++ b/packages/core/nros-node/src/executor/action.rs
@@ -461,6 +461,52 @@ impl<A: RosAction> ActionServerHandle<A> {
     /// the executor, or when the serialized result exceeds the server's
     /// `RESULT_BUF` and so cannot be retained for a later `get_result` (issue
     /// 0796 — this used to return `()` and swallow both).
+    /// Terminate `goal_id` as SUCCEEDED — phase-379 W5.
+    ///
+    /// The three terminal verbs (`succeed` / `abort` / `cancel`) name the
+    /// ACTION SPEC's terminal states, which is also what rclcpp_action's
+    /// `ServerGoalHandle` spells them: `succeed(result)`, `abort(result)`,
+    /// `canceled(result)`. They take the goal ID rather than hanging off a
+    /// handle because a goal here lives in a fixed-capacity arena and is named
+    /// by its UUID — see the `divergence` row for why neither client library's
+    /// ownership model is available without an allocator.
+    ///
+    /// `complete_goal` remains the general form for a status computed at
+    /// runtime.
+    pub fn succeed(
+        &self,
+        executor: &mut Executor,
+        goal_id: &nros_core::GoalId,
+        result: A::Result,
+    ) -> Result<(), NodeError> {
+        self.complete_goal(executor, goal_id, nros_core::GoalStatus::Succeeded, result)
+    }
+
+    /// Terminate `goal_id` as ABORTED. See [`Self::succeed`].
+    pub fn abort(
+        &self,
+        executor: &mut Executor,
+        goal_id: &nros_core::GoalId,
+        result: A::Result,
+    ) -> Result<(), NodeError> {
+        self.complete_goal(executor, goal_id, nros_core::GoalStatus::Aborted, result)
+    }
+
+    /// Terminate `goal_id` as CANCELED. See [`Self::succeed`].
+    ///
+    /// Spelled `cancel`, not rclcpp's `canceled`: the other two are imperatives
+    /// (`succeed`, `abort`), and mixing an imperative with a past participle
+    /// inside one family reads as an accident. The SPEC state is `CANCELED`
+    /// either way.
+    pub fn cancel(
+        &self,
+        executor: &mut Executor,
+        goal_id: &nros_core::GoalId,
+        result: A::Result,
+    ) -> Result<(), NodeError> {
+        self.complete_goal(executor, goal_id, nros_core::GoalStatus::Canceled, result)
+    }
+
     pub fn complete_goal(
         &self,
         executor: &mut Executor,

--- a/packages/core/nros-node/src/executor/handles.rs
+++ b/packages/core/nros-node/src/executor/handles.rs
@@ -1096,7 +1096,18 @@ impl<M, const RX_BUF: usize> Drop for Subscription<M, RX_BUF> {
 
 impl<M: RosMessage, const RX_BUF: usize> Subscription<M, RX_BUF> {
     /// Try to receive a typed message (non-blocking).
-    pub fn try_recv(&mut self) -> Result<Option<M>, NodeError> {
+    /// Take one message if the middleware has one — phase-379 W3.
+    ///
+    /// Named `take` after rcl (`rcl_take`) and rclcpp (`Subscription::take`),
+    /// which spell the non-blocking receive that way — as does our own C
+    /// surface. NOT after rclrs: its subscription API is callback/worker-driven
+    /// and has no public polling counterpart at all (its `take_*` methods are
+    /// private), which is why the ledger records this as an `extension` against
+    /// the Rust reference rather than a match. `try_recv` was Rust
+    /// channel vocabulary that reads as a different contract to a ROS 2 user:
+    /// both are non-blocking and both report emptiness without failing, so
+    /// nothing asked for the other word. Renamed as a clean break, no shim.
+    pub fn take(&mut self) -> Result<Option<M>, NodeError> {
         match self
             .handle
             .try_recv_raw(&mut self.buffer)
@@ -1250,7 +1261,7 @@ impl<M: RosMessage, const RX_BUF: usize> Subscription<M, RX_BUF> {
             // registered — the wake would otherwise be delivered to the
             // previous waker (or nowhere) and the task would hang.
             self.handle.register_waker(cx.waker());
-            match self.try_recv() {
+            match self.take() {
                 Ok(Some(msg)) => core::task::Poll::Ready(Ok(msg)),
                 Ok(None) => core::task::Poll::Pending,
                 Err(e) => core::task::Poll::Ready(Err(e)),
@@ -1283,7 +1294,7 @@ impl<M: RosMessage, const RX_BUF: usize> Subscription<M, RX_BUF> {
         let mut budget = WaitBudget::new(max_spins, timeout);
         loop {
             executor.spin_once(spin_interval);
-            if let Some(msg) = self.try_recv()? {
+            if let Some(msg) = self.take()? {
                 return Ok(Some(msg));
             }
             if !budget.tick() {
@@ -1815,7 +1826,7 @@ impl<M: RosMessage + Unpin, const RX_BUF: usize> futures_core::Stream for Subscr
         let this = self.get_mut();
         // Register-then-check: see Subscription::recv for rationale.
         this.handle.register_waker(cx.waker());
-        match this.try_recv() {
+        match this.take() {
             Ok(Some(msg)) => core::task::Poll::Ready(Some(Ok(msg))),
             Ok(None) => core::task::Poll::Pending,
             Err(e) => core::task::Poll::Ready(Some(Err(e))),
@@ -2047,7 +2058,7 @@ impl<Svc: RosService, const REQ_BUF: usize, const REPLY_BUF: usize>
     /// let mut promise = client.call(&request)?;
     /// loop {
     ///     executor.spin_once(core::time::Duration::from_millis(10));
-    ///     if let Some(reply) = promise.try_recv()? {
+    ///     if let Some(reply) = promise.take()? {
     ///         break;
     ///     }
     /// }
@@ -2227,7 +2238,18 @@ impl<T> Promise<'_, T> {
     ///
     /// Returns `Ok(Some(reply))` if the reply has arrived,
     /// `Ok(None)` if still pending.
-    pub fn try_recv(&mut self) -> Result<Option<T>, NodeError> {
+    /// Take one message if the middleware has one — phase-379 W3.
+    ///
+    /// Named `take` after rcl (`rcl_take`) and rclcpp (`Subscription::take`),
+    /// which spell the non-blocking receive that way — as does our own C
+    /// surface. NOT after rclrs: its subscription API is callback/worker-driven
+    /// and has no public polling counterpart at all (its `take_*` methods are
+    /// private), which is why the ledger records this as an `extension` against
+    /// the Rust reference rather than a match. `try_recv` was Rust
+    /// channel vocabulary that reads as a different contract to a ROS 2 user:
+    /// both are non-blocking and both report emptiness without failing, so
+    /// nothing asked for the other word. Renamed as a clean break, no shim.
+    pub fn take(&mut self) -> Result<Option<T>, NodeError> {
         // Phase 120: NoData (no reply yet) is the steady-state polling
         // condition — map to Ok(None) instead of ServiceRequestFailed.
         match match self.handle.try_recv_reply_raw(self.reply_buffer) {
@@ -2272,7 +2294,7 @@ impl<T> Promise<'_, T> {
         // Always spin at least once so a zero-timeout still polls.
         loop {
             executor.spin_once(spin_interval);
-            if let Some(result) = self.try_recv()? {
+            if let Some(result) = self.take()? {
                 return Ok(result);
             }
             if !budget.tick() {
@@ -2293,7 +2315,7 @@ impl<T> core::future::Future for Promise<'_, T> {
         // Register-then-check (closes the race where a reply lands
         // between try_recv returning None and the waker registering).
         this.handle.register_waker(cx.waker());
-        match this.try_recv() {
+        match this.take() {
             Ok(Some(reply)) => core::task::Poll::Ready(Ok(reply)),
             Ok(None) => core::task::Poll::Pending,
             Err(e) => core::task::Poll::Ready(Err(e)),
@@ -2340,7 +2362,7 @@ impl<T> Promise<'_, T> {
         Fut: core::future::Future<Output = ()>,
     {
         loop {
-            match self.try_recv()? {
+            match self.take()? {
                 Some(reply) => return Ok(reply),
                 None => yield_fn().await,
             }

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -6632,7 +6632,7 @@ impl<'s> Executor<'s> {
     /// let mut promise = client.call(&req)?;
     /// loop {
     ///     executor.spin_once(core::time::Duration::from_millis(10));
-    ///     if let Ok(Some(r)) = promise.try_recv() { break r; }
+    ///     if let Ok(Some(r)) = promise.take() { break r; }
     /// }
     /// ```
     pub async fn spin_async(&mut self) -> ! {

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -3151,7 +3151,7 @@ fn test_promise_try_recv_returns_none_then_some() {
     let mut promise = client.call(&request).unwrap();
 
     // No reply loaded yet — should return None
-    assert!(promise.try_recv().unwrap().is_none());
+    assert!(promise.take().unwrap().is_none());
 
     // Load a CDR-encoded reply into the mock
     let mut reply_buf = [0u8; 256];
@@ -3163,7 +3163,7 @@ fn test_promise_try_recv_returns_none_then_some() {
     promise.handle.load_reply(reply_buf, reply_len);
 
     // Now try_recv should return the reply
-    let reply = promise.try_recv().unwrap().unwrap();
+    let reply = promise.take().unwrap().unwrap();
     assert_eq!(reply.sum, 99);
 }
 

--- a/packages/testing/nros-bench/executor-fairness/src/main.rs
+++ b/packages/testing/nros-bench/executor-fairness/src/main.rs
@@ -166,7 +166,7 @@ fn client_scenario_2() {
             let start = Instant::now();
             loop {
                 executor.spin_once(core::time::Duration::from_millis(10));
-                match promise.try_recv() {
+                match promise.take() {
                     Ok(Some(_)) => break,
                     Ok(None) => {
                         if start.elapsed() > Duration::from_secs(5) {
@@ -230,7 +230,7 @@ fn publish_scenario_3() {
                 let call_start = Instant::now();
                 loop {
                     executor.spin_once(core::time::Duration::from_millis(10));
-                    match promise.try_recv() {
+                    match promise.take() {
                         Ok(Some(_)) => break,
                         Ok(None) => {
                             if call_start.elapsed() > Duration::from_secs(5) {

--- a/packages/testing/nros-tests/tests/nano2nano.rs
+++ b/packages/testing/nros-tests/tests/nano2nano.rs
@@ -502,7 +502,7 @@ fn test_tls_talker_listener_communication(
 /// - `Executor<_, 0, 0>` (zero callback arena)
 /// - `spin_once(0)` (non-blocking I/O drive)
 /// - `publisher.publish()` (direct, outside executor)
-/// - `subscription.try_recv()` (manual polling)
+/// - `subscription.take()` (manual polling)
 #[rstest]
 fn test_rtic_pattern_communication(zenohd_unique: ZenohRouter) {
     use std::process::Command;

--- a/scripts/check-prelude-tiers.py
+++ b/scripts/check-prelude-tiers.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""phase-379 W5 — `nros::prelude` is the rclrs-shaped API, not everything.
+
+The surface is 709 items. A ROS 2 developer reading a ported node should meet
+the names that correspond to rclrs/rclcpp/rclc, and not step over the RTOS
+machinery that exists because the target is an MCU.
+
+The membership rule is MECHANICAL rather than taste, which is the only reason it
+can be enforced at all:
+
+    a name belongs in `nros::prelude` IFF the parity ledger does not classify it
+    as an `extension` — i.e. it has a correspondent upstream
+
+`extension` is precisely "ours-only, deliberately". Those names belong in
+`nros::embedded`, unless they are load-bearing for startup, which is the
+ALLOWED_EXTENSIONS list below: an argued allow-list, one reason per name, not a
+place to put anything inconvenient.
+
+Without this the rule is a comment in `lib.rs`, and a comment does not survive
+the next person adding a re-export to the prelude because it was handy.
+"""
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LIB = os.path.join(ROOT, "packages", "api", "nros", "src", "lib.rs")
+LEDGER = os.path.join(ROOT, "docs", "reference", "api-parity-ledger")
+
+# Extensions that may sit in the prelude anyway. Each needs a REASON, and the
+# reason has to be "a node cannot start without it" — not "it is convenient".
+ALLOWED_EXTENSIONS = {
+    # Startup. Nothing opens a session or drives the executor without these.
+    "ExecutorConfig": "nothing opens a session without it; rclrs takes a Context instead",
+    "SpinOptions": "the argument to every spin call",
+    "ExecutorConfigEnvExt": "issue 0687 — `from_env()` is an extension trait, so the spelling needs it in scope",
+    "SpinOnceResult": "what `spin_once` returns; unavoidable at the first call site",
+    "SpinPeriodResult": "as above, for the periodic form",
+    "SpinPeriodPollingResult": "as above, for the polling form",
+    "SessionMode": "names the transport mode a session opens in",
+    "TransportError": "the error half of every runtime Result a node handles",
+    "Trigger": "the executor wake primitive a node passes to spin",
+    # Defining messages. rclrs spells the trait `Message`; the CONCEPT
+    # corresponds, only the name is ours, and a user cannot declare a topic
+    # type without naming these.
+    "RosMessage": "the message trait — rclrs's `Message` under our spelling",
+    "Serialize": "message codegen implements it; a hand-written type must name it",
+    "Deserialize": "as above, receive side",
+    "TopicInfo": "describes the topic a handle was created on",
+    "MessageInfo": "the per-sample metadata a subscription callback receives",
+    # Actions. Ours are UUID-addressed by decision (see the action ledger
+    # rows), so the identity vocabulary IS the user-facing API here — there is
+    # no goal handle to hang it off.
+    "RosAction": "the action trait, counterpart to RosMessage",
+    "GoalId": "the UUID a goal is named by — our actions are identity-addressed",
+    "GoalStatus": "the spec's goal state, returned to the caller",
+    "GoalResponse": "accept/reject, returned from the goal callback",
+    "GoalInfo": "goal id + stamp, as the spec pairs them",
+    "GoalStatusStamped": "the status topic's payload",
+    "FeedbackStream": "how a client reads feedback without owning a handle",
+    # Node construction and parameters.
+    "NodeConfig": "the node's own construction options",
+    "ParameterDefault": "declaring a parameter requires naming its default",
+    "ParameterError": "the error half of every parameter call",
+    # Lifecycle. rclcpp has LifecycleNode; our polling shape differs enough
+    # that the names are ours, but a lifecycle node cannot be written without
+    # them.
+    "LifecyclePollingNode": "the lifecycle node type itself",
+    "LifecycleCallbackFn": "the transition callback signature",
+    "LifecycleTransition": "the transition being requested",
+    "LifecycleError": "the error half of a transition",
+    "TransitionResult": "what a transition callback returns",
+}
+
+
+def prelude_names(text):
+    """Identifiers re-exported by `pub mod prelude`.
+
+    Parsed from the module body rather than by expanding the glob, because the
+    question is what the glob PUBLISHES, and that is what is written here.
+    """
+    start = text.index("pub mod prelude {")
+    depth, i = 0, start
+    while i < len(text):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    body = text[start : i + 1]
+    names = set()
+    for group in re.findall(r"pub use crate::\{(.*?)\};", body, re.S):
+        for raw in group.split(","):
+            name = raw.strip().split(" as ")[0].strip()
+            # skip comments and paths
+            if not name or name.startswith("//") or "::" in name:
+                continue
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+                names.add(name)
+    for single in re.findall(r"pub use crate::([A-Za-z_][A-Za-z0-9_]*);", body):
+        names.add(single)
+    return names
+
+
+def rust_extensions(ledger_dir):
+    """Item names the ledger calls `extension` on the Rust surface."""
+    out = {}
+    for fn in sorted(os.listdir(ledger_dir)):
+        if not fn.endswith(".json"):
+            continue
+        with open(os.path.join(ledger_dir, fn)) as fh:
+            data = json.load(fh)
+        for key, row in data.items():
+            if key == "_doc" or not isinstance(row, dict):
+                continue
+            if row.get("verdict") != "extension":
+                continue
+            lang, _, item = key.partition(":")
+            if lang != "rust":
+                continue
+            # WHOLE items only. A `Type::method` row says the METHOD is
+            # ours-only, NOT the type: `Node::publisher_count` is an extension
+            # while `Node` plainly corresponds to rclrs's `Node`. Collapsing to
+            # the owning type flagged 47 names, almost all of them types that
+            # obviously have correspondents — the rule has to ask about the
+            # name the prelude actually exports.
+            if "::" in item or "(" in item:
+                continue
+            item = item.strip()
+            if item:
+                out.setdefault(item, key)
+    return out
+
+
+def self_test():
+    """Negative control, on the normal path.
+
+    A checker that cannot fail is a comment. Runs against synthetic text so it
+    proves the DETECTION rather than the current state of the tree.
+    """
+    sample = """
+pub mod prelude {
+    pub use crate::{Node, CdrWriter};
+    pub use crate::ExecutorConfig;
+}
+"""
+    got = prelude_names(sample)
+    if got != {"Node", "CdrWriter", "ExecutorConfig"}:
+        print("selftest: prelude parse returned %r" % (sorted(got),), file=sys.stderr)
+        return False
+    # A brace inside the body must not end it early.
+    nested = """
+pub mod prelude {
+    #[cfg(feature = "x")]
+    pub use crate::{A, B};
+}
+"""
+    if prelude_names(nested) != {"A", "B"}:
+        print("selftest: cfg-gated re-export was not seen", file=sys.stderr)
+        return False
+    return True
+
+
+def main():
+    if not self_test():
+        print("check-prelude-tiers: selftest failed — the checker is not trustworthy.", file=sys.stderr)
+        return 1
+
+    with open(LIB) as fh:
+        names = prelude_names(fh.read())
+    exts = rust_extensions(LEDGER)
+
+    bad = []
+    for name in sorted(names):
+        if name in exts and name not in ALLOWED_EXTENSIONS:
+            bad.append((name, exts[name]))
+
+    if bad:
+        print("check-prelude-tiers: %d name(s) in `nros::prelude` are ledger `extension`s:" % len(bad))
+        for name, key in bad:
+            print("  %-28s (%s)" % (name, key))
+        print()
+        print("  An `extension` has no correspondent in rclrs/rclcpp/rclc, so a ROS 2")
+        print("  developer reading a ported node should not meet it through the glob.")
+        print("  Move it to `nros::embedded`, or add it to ALLOWED_EXTENSIONS in")
+        print("  %s with a reason that is" % os.path.relpath(__file__, ROOT))
+        print("  \"a node cannot start without it\" — phase-379 W5.")
+        return 1
+
+    print(
+        "check-prelude-tiers: OK (selftest ok; %d prelude name(s), %d rust extension(s), %d allowed)"
+        % (len(names), len(exts), len(ALLOWED_EXTENSIONS))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the three waves phase-379 was holding. Every blocking decision is
recorded in the phase doc; this is the implementation.

## W4 — entities name their node by identity, not by pointer

Signature keeps its shape (`nros_publisher_fini(&pub)`, not rcl's
`(&pub, &node)`); the STORAGE changes, because the rule asserted a platform
decision the implementation had not earned.

```c
typedef struct nros_node_ref_t { uint8_t node_id; uint32_t generation; };
```

`nros_node_fini` now retires the slot's generation, so finalising an entity
after its node returns `NROS_RET_STALE_NODE` instead of succeeding silently —
a reachable, previously undetectable case. Generation 0 reserved, so a zeroed
struct never resolves; wrap skips 0, tested.

**I twice claimed the old pointer was never dereferenced. It was** —
`set_executor_node_identity` read the node's name and namespace through it,
long after init, from caller storage an RTOS can free (`vTaskDelete` on a task
stack). It now resolves against the `NodeRecord`, which holds the same strings
and outlives the caller's struct.

## W3 — `try_recv` -> `take`, and most of the wave was already done

The doc (2026-08-25) had gone stale: `create_subscriber`, `make_publisher`,
`make_subscription`, `send_reply`, `is_cancelled` are all at zero occurrences,
and its largest item — "no shutdown hook at all" — has shipped. I nearly
re-implemented it from that paragraph.

The rename's justification is narrower than I first wrote: rcl and rclcpp spell
it `take`, **rclrs does not** — its subscription API is callback-driven with no
public polling receive. Recorded as an `extension`, not a match.

Clean break, no shim, and it earned itself: five call sites surfaced only
because the break made them hard errors.

## W5 — goals by UUID, prelude in two tiers

`succeed`/`abort`/`cancel` naming the spec's terminal states. Two `divergence`
rows, stating our costs: `MAX_GOALS` retention cap (issue 0796), O(n) lookup,
static RAM reserved unconditionally, and their consuming transition catching
use-after-terminal at compile time where ours cannot.

The evidence for the shape is in rclrs's own type: `ExecutingGoal` is
`Arc`-backed — the typestate wraps refcounting rather than replacing it — and
`succeeded_with` returns `TerminatedGoal { uuid }`, so rclrs falls back to the
UUID too.

`nros::embedded` takes 23 names out of the prelude, enforced by
`check-prelude-tiers` (mutation-tested, fast line). **Qualification:**
membership is not the pure ledger query I proposed — `extension` answers "does
this name appear upstream", not "does a ported node need it" — so it is the
query plus a 29-entry argued allow-list.

Also fixes a red on main: two NuttX FFI locks never followed their manifests
(`2b28390d4`), surfaced by the pre-push hook.

Tier 1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP