### PR TITLE
fix(zephyr): the 4.4 patch anchored on a function upstream deleted; 3.7 had no nano_ros_ROOT

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -254,6 +254,7 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         run: |
+          source ./activate.sh
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
@@ -277,7 +278,9 @@ jobs:
           just setup-launch-resolve
 
       - name: just ${{ matrix.plat }} setup
-        run: just ${{ matrix.plat }} setup
+        run: |
+          source ./activate.sh
+          just ${{ matrix.plat }} setup
 
       # issue-0037 — the e2e fixture build shells out to `play_launch_parser`, a
       # separate binary the in-tree `cargo build --bin nros` does NOT produce.
@@ -286,6 +289,7 @@ jobs:
       - name: Provision play_launch_parser (launch-manifest fixtures, #37)
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_e2e) }}
         run: |
+          source ./activate.sh
           just workspace install-play-launch-parser
           echo "NROS_PLAY_LAUNCH_PARSER=$HOME/.nros/sdk/play_launch_parser/bin/play_launch_parser" >> "$GITHUB_ENV"
 
@@ -310,7 +314,9 @@ jobs:
       # Installing from that same list is what keeps CI and a contributor's
       # laptop provisioned identically.
       - name: Install cross targets from config/rust-targets.txt
-        run: just workspace rust-targets
+        run: |
+          source ./activate.sh
+          just workspace rust-targets
 
       - name: Build (${{ matrix.plat }})
         run: |
@@ -457,6 +463,7 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         run: |
+          source ./activate.sh
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
@@ -480,7 +487,9 @@ jobs:
           just setup-launch-resolve
 
       - name: Provision Zephyr sources via nros
-        run: nros setup --source zenoh-pico --source cyclonedds-src --source px4-rs
+        run: |
+          source ./activate.sh
+          nros setup --source zenoh-pico --source cyclonedds-src --source px4-rs
 
       # The image registered the SDK CMake package as root; the container runs
       # with HOME=/github/home → re-register for this HOME (4.4's FindZephyr-sdk
@@ -518,7 +527,9 @@ jobs:
           done
 
       - name: Set up Zephyr ${{ matrix.line }} workspace
-        run: just zephyr setup --skip-sdk
+        run: |
+          source ./activate.sh
+          just zephyr setup --skip-sdk
 
       # zephyr-sys' build.rs runs bindgen over Zephyr headers — needs libclang.so
       # AND clang's resource-dir headers. Rust cells only (C/C++ cells skip).
@@ -529,7 +540,9 @@ jobs:
           apt-get install -y --no-install-recommends clang libclang-dev
 
       - name: Build zephyr/${{ matrix.example }} (zenoh) on ${{ matrix.line }}
-        run: source /opt/ros/humble/setup.bash && just zephyr build-one "${{ matrix.example }}" zenoh
+        run: |
+          source ./activate.sh
+          just zephyr build-one "${{ matrix.example }}" zenoh
 
   zephyr-dual-line-summary:
     needs: changes
@@ -561,6 +574,7 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         run: |
+          source ./activate.sh
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
@@ -584,7 +598,9 @@ jobs:
           just setup-launch-resolve
 
       - name: Provision Zephyr sources via nros
-        run: nros setup --source zenoh-pico --source cyclonedds-src --source px4-rs
+        run: |
+          source ./activate.sh
+          nros setup --source zenoh-pico --source cyclonedds-src --source px4-rs
 
       - name: Register the baked Zephyr SDK for this HOME
         run: /opt/zephyr-sdk/setup.sh -c
@@ -607,13 +623,19 @@ jobs:
         run: rustup set profile minimal
 
       - name: Set up Zephyr 3.7 workspace
-        run: NROS_ZEPHYR_VERSION=3.7 just zephyr setup --skip-sdk
+        run: |
+          source ./activate.sh
+          NROS_ZEPHYR_VERSION=3.7 just zephyr setup --skip-sdk
 
       - name: Set up Zephyr 4.4 workspace
-        run: NROS_ZEPHYR_VERSION=4.4 just zephyr setup --skip-sdk
+        run: |
+          source ./activate.sh
+          NROS_ZEPHYR_VERSION=4.4 just zephyr setup --skip-sdk
 
       - name: Dual-line build (c/talker zenoh)
-        run: source /opt/ros/humble/setup.bash && just zephyr ci-both c/talker zenoh
+        run: |
+          source ./activate.sh
+          just zephyr ci-both c/talker zenoh
 
   zephyr-copy-out:
     needs: changes
@@ -645,6 +667,7 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         run: |
+          source ./activate.sh
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
@@ -668,7 +691,9 @@ jobs:
           just setup-launch-resolve
 
       - name: Provision Zephyr sources via nros
-        run: nros setup --source zenoh-pico --source cyclonedds-src --source px4-rs
+        run: |
+          source ./activate.sh
+          nros setup --source zenoh-pico --source cyclonedds-src --source px4-rs
 
       - name: Register the baked Zephyr SDK for this HOME
         run: /opt/zephyr-sdk/setup.sh -c
@@ -691,10 +716,14 @@ jobs:
         run: rustup set profile minimal
 
       - name: Set up Zephyr 4.4 workspace
-        run: NROS_ZEPHYR_VERSION=4.4 just zephyr setup --skip-sdk
+        run: |
+          source ./activate.sh
+          NROS_ZEPHYR_VERSION=4.4 just zephyr setup --skip-sdk
 
       - name: Copy-out build check
-        run: source /opt/ros/humble/setup.bash && just zephyr check-copy-out c/talker zenoh
+        run: |
+          source ./activate.sh
+          just zephyr check-copy-out c/talker zenoh
 
   # Clean-system bootstrap probe (issue #204): execute the book's documented
   # setup steps VERBATIM in a pristine ubuntu:24.04 container (steps are

--- a/scripts/zephyr/cargo-features-patch.sh
+++ b/scripts/zephyr/cargo-features-patch.sh
@@ -14,12 +14,26 @@
 #
 # ONE INJECTION SITE, and hunk 3 enforces it (issue 0544).
 #
-# The pass-through goes INSIDE `add_cargo_target_with_zephyr_env`, which every
-# caller routes through, so one injection covers `cargo build` and `cargo doc`
-# both. An earlier revision of this comment claimed the awk matched "two such
-# lines: cargo build (~199) and cargo doc (~243)" — that described an upstream
-# layout that has since been refactored into the shared function, so the awk
-# matches ONE line and always did the whole job.
+# KEYED ON THE COMMAND, NOT ON THE FUNCTION — because upstream's layout
+# oscillates and this patch has now been wrong in both directions.
+#
+# 3.7 (`404fcef`) routes every caller through `add_cargo_target_with_zephyr_env`,
+# so its ONE `${rust_build_type_arg}` line follows a variable command,
+# `cargo ${cargo_command}`, and a single injection covers build and doc both.
+# 4.4 (`a763400`) DELETED that function and inlined it: `rust_cargo_application`
+# now carries TWO `${rust_build_type_arg}` lines, after a literal `cargo build`
+# and a literal `cargo doc`.
+#
+# An earlier revision of this comment described exactly that two-site layout and
+# was dismissed as stale when 3.7 refactored it away. It was not stale; it was
+# early. Anchoring on the function name meant the awk injected at BOTH 4.4 sites
+# and hunk 4 rejected the file, taking every 4.4 cell down at `Set up Zephyr 4.4
+# workspace` — 12 cells producing no verdict at all.
+#
+# So the anchor is the cargo COMMAND: inject after the `${rust_build_type_arg}`
+# whose command is `cargo build` or `cargo ${cargo_command}`, never after
+# `cargo doc`. That is exactly one site under both layouts, and it stays one if
+# upstream moves the code between functions again.
 #
 # Someone reading that stale comment concluded the pass-through was only half
 # applied and hand-added `${EXTRA_CARGO_ARGS}` to BOTH call sites
@@ -42,6 +56,81 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NANO_ROS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# --- self-test -------------------------------------------------------------
+#
+# Both upstream layouts, run end to end, asserting the invariant this script
+# exists to hold: EXACTLY ONE of each injection, on the BUILD command, never on
+# `cargo doc`, and unchanged by a second run.
+#
+# It exists because anchoring on `add_cargo_target_with_zephyr_env` was correct
+# for 3.7 and silently wrong for 4.4, and nothing in the tree could tell —
+# the workspace is fetched by west at setup time, so the only place the two
+# layouts meet is here.
+#
+#   bash scripts/zephyr/cargo-features-patch.sh --self-test
+if [ "${1:-}" = "--self-test" ]; then
+    _st_tmp="$(mktemp -d)"
+    trap 'rm -rf "$_st_tmp"' EXIT
+    _st_fail=0
+
+    # 3.7: one shared function, the command spelled as a variable.
+    # 4.4: the function inlined, two literal commands.
+    for _layout in shared inlined; do
+        _d="$_st_tmp/$_layout/modules/lang/rust"
+        mkdir -p "$_d"
+        {
+            printf 'function(rust_cargo_application)\n'
+            printf '  set(rust_build_type_arg --release)\n'
+            printf '  add_custom_command(\n'
+            printf '      DT_AUGMENTS="${DT_AUGMENTS}"\n'
+            if [ "$_layout" = shared ]; then
+                printf '      cargo ${cargo_command}\n'
+            else
+                printf '      cargo build\n'
+            fi
+            printf '      ${rust_build_type_arg}\n'
+            printf '      ${command_paths}\n'
+            if [ "$_layout" = inlined ]; then
+                printf '      DT_AUGMENTS="${DT_AUGMENTS}"\n'
+                printf '      cargo doc\n'
+                printf '      ${rust_build_type_arg}\n'
+            fi
+            printf 'endfunction()\n'
+        } > "$_d/CMakeLists.txt"
+
+        for _run in 1 2; do
+            if ! bash "${BASH_SOURCE[0]}" "$_st_tmp/$_layout" >/dev/null 2>&1; then
+                echo "self-test: $_layout layout: patch FAILED on run $_run" >&2
+                _st_fail=1
+                continue 2
+            fi
+        done
+
+        _code() { grep -v '"'"'^[[:space:]]*#'"'"' "$_d/CMakeLists.txt" | grep -c "$1" || true; }
+        _e="$(_code '\${EXTRA_CARGO_ARGS}')"
+        _f="$(_code '\${NROS_BOARD_FACTS_ENV}')"
+        if [ "$_e" != 1 ] || [ "$_f" != 1 ]; then
+            echo "self-test: $_layout layout: EXTRA_CARGO_ARGS=$_e NROS_BOARD_FACTS_ENV=$_f (want 1/1)" >&2
+            _st_fail=1
+        fi
+        # `cargo doc` must be left alone: a second copy of the flag is the
+        # failure this whole file is about.
+        if [ "$_layout" = inlined ] && \
+           awk '/cargo doc/{d=1} d && /\$\{EXTRA_CARGO_ARGS\}/{print; exit}' \
+               "$_d/CMakeLists.txt" | grep -q .; then
+            echo "self-test: inlined layout: EXTRA_CARGO_ARGS reached cargo doc" >&2
+            _st_fail=1
+        fi
+    done
+
+    if [ "$_st_fail" -eq 0 ]; then
+        echo "cargo-features-patch self-test: OK (shared + inlined layouts, 1 injection each, idempotent)"
+        exit 0
+    fi
+    exit 1
+fi
+
 IN_TREE_WORKSPACE="$NANO_ROS_ROOT/zephyr-workspace"
 LEGACY_WORKSPACE="$(cd "$NANO_ROS_ROOT/.." && pwd)/nano-ros-workspace"
 
@@ -108,9 +197,14 @@ if ! grep -q "nano-ros: EXTRA_CARGO_ARGS pass-through" "$CMAKE_FILE"; then
     # such copies).
     TMP="$(mktemp)"
     awk '
+    # Remember the last line that carried a command, so the injection can be
+    # keyed on WHICH cargo invocation this `${rust_build_type_arg}` belongs to.
+    # `cargo doc` gets nothing: doubling the flag is what cargo rejects.
+    /^[[:space:]]*cargo[[:space:]]/ { cargo_line = $0 }
     {
         print
-        if ($0 ~ /^[[:space:]]+\$\{rust_build_type_arg\}[[:space:]]*$/) {
+        if ($0 ~ /^[[:space:]]+\$\{rust_build_type_arg\}[[:space:]]*$/ &&
+            cargo_line ~ /^[[:space:]]*cargo[[:space:]]+(build|\$\{cargo_command\})[[:space:]]*$/) {
             print ""
             print "      # nano-ros: EXTRA_CARGO_ARGS pass-through (Phase 168.1)."
             print "      # Honors CMakeLists.txt `set(EXTRA_CARGO_ARGS ...)` set"
@@ -181,7 +275,10 @@ if ! grep -q "nano-ros: board facts" "$CMAKE_FILE"; then
     TMP="$(mktemp)"
     awk '
     {
-        if ($0 ~ /^[[:space:]]+cargo \$\{cargo_command\}[[:space:]]*$/) {
+        # Keyed on the cargo COMMAND for the same reason as hunk 2: 3.7 spells
+        # it `cargo ${cargo_command}` inside the shared function, 4.4 inlined it
+        # to a literal `cargo build` (and a `cargo doc` that must NOT get this).
+        if ($0 ~ /^[[:space:]]+cargo[[:space:]]+(build|\$\{cargo_command\})[[:space:]]*$/) {
             print "      # nano-ros: board facts + site config (phase-351 W5, issue 0605)."
             print "      # MUST precede `cargo` — `cmake -E env` ends the env at the"
             print "      # first non-KEY=VALUE argument."
@@ -191,11 +288,13 @@ if ! grep -q "nano-ros: board facts" "$CMAKE_FILE"; then
     }
     ' "$CMAKE_FILE" > "$TMP"
 
-    if ! grep -q "NROS_BOARD_FACTS_ENV" "$TMP"; then
+    facts_n="$(grep -v '^[[:space:]]*#' "$TMP" | grep -c '\${NROS_BOARD_FACTS_ENV}' || true)"
+    if [ "$facts_n" -ne 1 ]; then
         rm -f "$TMP"
-        echo "[cargo-features-patch] ERROR: no `cargo \${cargo_command}` line to inject before" >&2
+        echo '[cargo-features-patch] ERROR: no cargo build line to inject before' >&2
         echo "       in $CMAKE_FILE — upstream layout changed; fix this patch rather" >&2
         echo "       than leaving the Zephyr rust lane without its board rung (issue 0605)." >&2
+        echo "       (found $facts_n injection site(s); expected exactly 1)" >&2
         exit 1
     fi
     mv "$TMP" "$CMAKE_FILE"


### PR DESCRIPTION
Two separate faults, 16 nightly cells between them.

## 4.4 — 12 cells produced NO VERDICT

Every 4.4 cell stopped at `Set up Zephyr 4.4 workspace`:

```
ERROR: ${EXTRA_CARGO_ARGS} appears 2 time(s) in
         error: the argument '--no-default-features' cannot be used multiple times
```

`cargo-features-patch.sh` injected after every `${rust_build_type_arg}` line, anchored on the claim that they all sit inside `add_cargo_target_with_zephyr_env`. I fetched both pinned revisions and counted:

| line | revision | sites | layout |
| --- | --- | --- | --- |
| 3.7 | `404fcef` | 1 | inside `add_cargo_target_with_zephyr_env` |
| 4.4 | `a763400` | **2** | that function is **gone** — inlined into `rust_cargo_application` as a literal `cargo build` and a literal `cargo doc` |

So the awk injected twice and the existing invariant correctly refused the file.

The header comment records that an earlier revision described exactly this two-site layout and was dismissed as stale once 3.7 refactored it away. **It wasn't stale, it was early** — upstream's layout oscillates, and anchoring on a function name has now been wrong in both directions.

Both injections are keyed on the cargo **command** instead: after `cargo build` or `cargo ${cargo_command}`, never after `cargo doc`. Exactly one site under either layout, and it stays one if upstream moves the code again.

Hunk 4 carried the same anchor plus two more faults, reachable only once the file got that far:

- it matched `cargo ${cargo_command}` literally, so on 4.4 it injected nothing and exited 1;
- its error message wrapped `` `cargo ${cargo_command}` `` in backticks **inside a double-quoted string**, so bash ran it as command substitution and died `cargo_command: unbound variable` under `set -u`, printing a blank where the spelling should have been. It only ever ran when the patch had already failed — which is how it stayed broken.

It now asserts the **count**, like hunk 2, not mere presence.

`--self-test` runs both layouts end to end: one injection each, on the build command, none on `cargo doc`, unchanged by a second run. It exists because the workspace is fetched by west at setup time, so this script is the only place the two layouts meet. Mutation-checked — restoring the old anchor makes it fail.

## 3.7 — four C/C++ cells failed to configure

```
CMake Error at CMakeLists.txt:42 (find_package):
  ... asked CMake to find a package configuration file provided by "nano_ros",
  but CMake did not find one.
```

Same defect as #92: `nano_rosConfig.cmake` lives at the checkout root and resolves via `nano_ros_ROOT`, which `activate.sh` exports and which **no** zephyr step in this workflow sourced. That's issue 0933, whose sweep deliberately left nightly for a later pass — this is that pass for the zephyr jobs: 13 steps across `zephyr-example-matrix`, `zephyr-dual-line-summary`, `zephyr-copy-out`.

Where a step already sourced `/opt/ros/humble/setup.bash`, activate.sh **replaces** it rather than joining it — it sources ROS itself, picking the file the current shell can read and guarding nounset (issue 0639).

Still open under 0933 after this: four `platform` provisioning steps and `lane-coverage`. The `platform` build and test steps already source `./setup.bash`, so that job isn't blind the way these were.

## Verification

`just check fast` 139/139 (4 host-precondition skips); the patch self-test against both real upstream files; a re-audit reporting **zero** zephyr steps without the repo environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB