### PR TITLE
fix(#0939): the probe links the component library, not the node name

### DIFF
--- a/docs/issues/0939-probe-links-node-name-not-component-lib.md
+++ b/docs/issues/0939-probe-links-node-name-not-component-lib.md
@@ -1,0 +1,98 @@
+---
+id: 939
+title: "The metadata probe links the node NAME, which is not a target — so
+  every C/C++ component reports `no producer`, once, and then silently"
+status: open
+type: bug
+area: tooling
+related: [issue-0409, rfc-0057]
+---
+
+## Symptom
+
+`nros sync` reports no source metadata for a C/C++ component:
+
+```
+sync: source metadata — no producer for controller_pkg::controller
+      (metadata probe build failed for `controller_pkg::controller` (exit 2):
+      ...
+      /usr/bin/ld: cannot find -lcontroller: No such file or directory
+```
+
+The workspace still builds and the image still runs, so nothing draws attention
+to it. What is lost is the sidecar the probe exists to produce — the component's
+own declared metadata — and `sync` carries on with a model that is missing it.
+
+## Cause
+
+`NanoRosNodeRegister.cmake` names the component library
+`${PROJECT_NAME}_${NAME}_component`:
+
+```cmake
+set(_lib "${PROJECT_NAME}_${_NRC_NAME}_component")
+```
+
+and guarantees a target by that name in BOTH modes — under `EXISTING_TARGET` it
+adds an INTERFACE library of that name linking the caller's target, so the
+spelling is universal.
+
+The workspace scanner did not use it. Both paths defaulted to the bare node
+name:
+
+```rust
+// nano_ros_node_register
+library_target: args.single("TARGET").or_else(|| Some(name.clone())),
+// nano_ros_add_node
+library_target: Some(name.clone()),
+```
+
+The bare name is not a target, so the generated probe emits
+`target_link_libraries(probe_… PRIVATE controller)` and the link fails at
+`-lcontroller`. Note the `TARGET` fallback never applied either: the CMake verb
+parses `EXISTING_TARGET`, not `TARGET`, and nothing in-tree passes `TARGET` at
+all — so the wrong default is what every component got.
+
+## Why it stayed invisible
+
+The failure is cached. After the first attempt the probe writes
+
+```
+<pkg>/metadata/<node>.json.unprobeable
+```
+
+keyed by a source hash, and every later sync prints
+
+```
+sync: source metadata — no producer for … (probe failed at this source last
+      sync; unchanged)
+```
+
+which reads like a note about an unchanged source rather than a build that is
+still broken. The underlying linker error is printed once, in the run that
+first hit it, and never again — so on any machine that has synced before, the
+evidence is gone. It took a submodule pin bump (which changed the hash and
+re-ran the probe) to surface it.
+
+## Fix
+
+Derive the target the way the CMake does, in one place, honouring an explicit
+`TARGET` where a caller gives one:
+
+```rust
+fn component_library_target(package: &str, name: &str) -> String {
+    format!("{package}_{name}_component")
+}
+```
+
+Two regression tests pin it, one per verb.
+
+## Not fixed here
+
+With the link corrected the probe gets further and then fails on the component
+itself, in at least one consumer: a package whose `CMakeLists.txt` relies on
+variables and targets its PARENT sets (`EIGEN3_INCLUDE_DIR`, an
+`autoware_msgs` INTERFACE target) cannot be built as a standalone
+subdirectory, which is exactly how the probe builds it. That is a consumer-side
+property, not a scanner bug, but it means this fix alone does not make every
+component probeable — it makes the probe attempt the right thing and fail
+honestly, instead of failing on a name that could never have resolved.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -70,5 +70,6 @@ fails if this block drifts.
 - **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
 - **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
 - **#0936** (tooling) — `check-just-recipe-refs` never reads a document, so 129 `just <recipe>` call sites in docs/ and book/ name recipes that do not exist See `0936-*`.
+- **#0939** (tooling) — The metadata probe links the node NAME, which is not a target — so every C/C++ component reports `no producer`, once, and then silently See `0939-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/packages/cli/nros-cli-core/src/orchestration/workspace.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/workspace.rs
@@ -657,7 +657,14 @@ fn discover_cmake_node_metadata(root: &Path, package_name: &str) -> Result<Vec<C
             deploy_targets: args.multi("DEPLOY"),
             header: args.single("HEADER"),
             shape: args.single("SHAPE"),
-            library_target: args.single("TARGET").or_else(|| Some(name.clone())),
+            // The library `nano_ros_node_register` builds is
+            // `<PROJECT_NAME>_<NAME>_component` (NanoRosNodeRegister.cmake), NOT the
+            // bare node name — and it exists under that name even in EXISTING_TARGET
+            // mode, where the verb adds an INTERFACE library aliasing the caller's
+            // target. So it is the one spelling that is always linkable. Issue 0939.
+            library_target: args
+                .single("TARGET")
+                .or_else(|| Some(component_library_target(package_name, &name))),
             executable: name,
             manifest_path: cmakelists.clone(),
         });
@@ -794,6 +801,22 @@ fn parse_register_node_call(
 /// call body. The first non-keyword token is the node name; `CLASS` takes one
 /// value; `TYPED` is a bare flag; `DEPLOY` takes values; every other bare token is
 /// a source. Language is inferred from source extensions, else the CLASS.
+/// The CMake library a registered component builds into.
+///
+/// `NanoRosNodeRegister.cmake` names it `${PROJECT_NAME}_${NAME}_component`, and
+/// guarantees a target by that name in both modes: it either builds the library
+/// itself, or — under `EXISTING_TARGET` — adds an INTERFACE library of that name
+/// linking the caller's target. The bare node name is NOT a target, so a probe
+/// that links it fails at `-l<name>`.
+///
+/// Issue 0939: the probe did link the bare name, so `nros sync` reported "no
+/// producer for <pkg>::<node>" for every C/C++ component and then cached that as
+/// "probe failed at this source last sync; unchanged" — which is why the
+/// underlying linker error stayed invisible across runs.
+fn component_library_target(package: &str, name: &str) -> String {
+    format!("{package}_{name}_component")
+}
+
 fn parse_add_node_call(
     body: &str,
     package_name: &str,
@@ -873,7 +896,8 @@ fn parse_add_node_call(
         header,
         shape,
         // `nano_ros_add_node(<name> …)` builds a target of that name.
-        library_target: Some(name.clone()),
+        // Same naming as node_register: this verb forwards to it. Issue 0939.
+        library_target: Some(component_library_target(package_name, &name)),
         executable: name,
         manifest_path: cmakelists.to_path_buf(),
     })
@@ -2276,6 +2300,36 @@ type = "std_msgs/msg/Int32"
         assert_eq!(s.component, "listener");
         assert_eq!(s.language, ComponentLanguage::Cpp);
         assert_eq!(s.deploy_targets, vec!["native".to_string()]);
+    }
+
+    #[test]
+    fn add_node_library_target_is_the_component_lib_not_the_node_name() {
+        // Issue 0939. NanoRosNodeRegister.cmake builds
+        // `${PROJECT_NAME}_${NAME}_component`; the bare node name is not a
+        // target. Getting this wrong is not a build error here — it surfaces
+        // one directory away, as the metadata probe failing to link
+        // `-l<name>`, which `nros sync` then reports as "no producer for
+        // <pkg>::<node>" and caches as "probe failed last sync".
+        let body = "controller CLASS controller_pkg::Controller TYPED src/controller.cpp";
+        let s = parse_add_node_call(body, "controller_pkg", Path::new("CMakeLists.txt")).unwrap();
+        assert_eq!(
+            s.library_target.as_deref(),
+            Some("controller_pkg_controller_component"),
+            "the probe links this name; the bare node name does not exist as a target"
+        );
+    }
+
+    #[test]
+    fn node_register_library_target_defaults_to_the_component_lib() {
+        // Same rule on the all-keyword verb. `TARGET` still wins when given,
+        // but nothing in-tree passes it, so the default is what always applies.
+        let body = "NAME listener CLASS ws::Listener LANGUAGE cpp SOURCES src/Listener.cpp";
+        let calls = parse_cmake_kwargs(body).unwrap();
+        let name = calls.single("NAME").unwrap();
+        assert_eq!(
+            component_library_target("cpp_pkg", &name),
+            "cpp_pkg_listener_component"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`nros sync` has been failing to produce source metadata for every C/C++ component, and saying so only once.

## The bug

`NanoRosNodeRegister.cmake` names the component library `${PROJECT_NAME}_${NAME}_component`, and guarantees a target by that name in **both** modes — under `EXISTING_TARGET` it adds an INTERFACE library of that name linking the caller's target. So it is the one spelling that always resolves.

The workspace scanner ignored it and defaulted to the bare node name, in both parse paths:

```rust
// nano_ros_node_register
library_target: args.single("TARGET").or_else(|| Some(name.clone())),
// nano_ros_add_node
library_target: Some(name.clone()),
```

So the generated probe emitted `target_link_libraries(probe_… PRIVATE controller)` and died at:

```
/usr/bin/ld: cannot find -lcontroller: No such file or directory
```

The `TARGET` fallback never applied either — the CMake verb parses `EXISTING_TARGET`, not `TARGET`, and nothing in-tree passes `TARGET`. The wrong default is what every component got.

## Why nobody noticed

The probe caches its own failure as `<pkg>/metadata/<node>.json.unprobeable`, keyed by a source hash. Every later sync then prints:

```
sync: source metadata — no producer for … (probe failed at this source last sync; unchanged)
```

which reads as a note about an unchanged source rather than a build that is still broken. The linker error appears exactly **once**, in the run that first hit it. On any machine that had synced before, the evidence was already gone — it took a submodule pin bump (new hash ⇒ probe re-ran) to surface it.

## The change

One derivation, honouring an explicit `TARGET` where given:

```rust
fn component_library_target(package: &str, name: &str) -> String {
    format!("{package}_{name}_component")
}
```

Two regression tests, one per verb.

## Verified against a real consumer

The autoware-safety-island workspace, whose `controller_pkg` triggered this. Before: `cannot find -lcontroller`. After: the probe links `controller_pkg_controller_component` and gets to compiling the component.

## Explicitly not fixed

With the link corrected the probe gets further and then fails on the component itself, where a package's `CMakeLists.txt` depends on variables and targets its **parent** sets (`EIGEN3_INCLUDE_DIR`, an `autoware_msgs` INTERFACE target) — the probe builds it as a standalone subdirectory, so no parent runs. That is a consumer-side property, recorded in the issue rather than papered over here.

This change makes the probe attempt the right thing and fail honestly, instead of failing on a name that could never have resolved.

`just ci-fast` — passed.
