### PR TITLE
feat(lan9118): drive RX from the interrupt, not a 5 ms poll (#0917)

### DIFF
--- a/packages/boards/nros-board-freertos/c/freertos_c_entry.c
+++ b/packages/boards/nros-board-freertos/c/freertos_c_entry.c
@@ -186,9 +186,17 @@ static inline UBaseType_t clamp_prio(uint32_t p) {
 static void poll_task_entry(void *arg) {
     (void)arg;
     const uint32_t poll_ms = NROS_APP_CONFIG.scheduling.poll_interval_ms;
+    /* Register as the RX wake target, then treat poll_interval_ms as a CEILING
+     * rather than the cadence: an RX interrupt wakes this task immediately, and
+     * the timeout still covers boards whose netif has no interrupt wired.
+     * Drain FIRST and wait second - the old order slept before ever looking,
+     * so a burst that landed just after a wakeup sat in the NIC for a full
+     * interval, which on this board is longer than the FIFO can hold it.
+     * Issue 0917. */
+    nros_freertos_net_register_drain_task();
     for (;;) {
-        vTaskDelay(pdMS_TO_TICKS(poll_ms));
         nros_freertos_poll_network();
+        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(poll_ms));
     }
 }
 

--- a/packages/boards/nros-board-freertos/c/network_glue.c
+++ b/packages/boards/nros-board-freertos/c/network_glue.c
@@ -148,6 +148,29 @@ int nros_freertos_init_network(
  * the poll task. Default weak impl is a no-op (boards with
  * IRQ-driven RX or no Ethernet leave it alone).
  */
+/* RX wake (issue 0917).
+ *
+ * The drain task used to sleep a fixed poll_interval_ms and look afterwards,
+ * which on a burst is exactly the wrong order: the NIC's RX FIFO holds about
+ * 10.5 KB on this board, an 8-fragment RTPS sample is ~11.4 KB of back-to-back
+ * frames, and nothing drained between them. Waiting on a notification instead
+ * makes the interval a CEILING rather than the normal cadence — boards with no
+ * RX interrupt keep the old behaviour, because the wait still times out. */
+static TaskHandle_t s_net_task;
+
+void nros_freertos_net_register_drain_task(void) {
+    s_net_task = xTaskGetCurrentTaskHandle();
+}
+
+void nros_freertos_net_wake_from_isr(void) {
+    if (s_net_task == NULL) {
+        return;
+    }
+    BaseType_t higher = pdFALSE;
+    vTaskNotifyGiveFromISR(s_net_task, &higher);
+    portYIELD_FROM_ISR(higher);
+}
+
 void nros_freertos_poll_network(void) {
     nros_board_poll_netif();
 }

--- a/packages/boards/nros-board-mps3-an536-freertos/c/board_an536.c
+++ b/packages/boards/nros-board-mps3-an536-freertos/c/board_an536.c
@@ -60,6 +60,10 @@
 /* Generic timer PPI: EL1 physical timer is INTID 30 on every ARM core. */
 #define TIMER_PPI_INTID 30
 
+/* The LAN9118 sits on GIC input 18 (hw/arm/mps3r.c: lan9118_init(0xe0300000,
+ * qdev_get_gpio_in(gicdev, 18))). SPI n is INTID 32 + n, so 50. Issue 0917. */
+#define ETH_SPI_INTID   50
+
 /* CMSDK APB UART registers. */
 #define UART_DATA     0x00
 #define UART_STATE    0x04
@@ -70,6 +74,10 @@
 /* GICv3 distributor. */
 #define GICD_CTLR       0x0000
 #define GICD_IGROUPR    0x0080
+#define GICD_ISENABLER  0x0100
+#define GICD_IPRIORITYR 0x0400
+#define GICD_ICFGR      0x0c00
+#define GICD_IROUTER    0x6000
 /* GICv3 redistributor: RD_base then SGI_base one 64 KiB frame later. */
 #define GICR_WAKER      0x0014
 #define GICR_SGI_OFFSET 0x10000
@@ -246,6 +254,35 @@ static inline uint32_t icc_read_iar1(void) {
 }
 static inline void icc_write_eoir1(uint32_t v) { __asm volatile("mcr " ICC_EOIR1 :: "r"(v)); }
 
+/* Enable one SPI on the distributor.
+ *
+ * Deliberately NOT called from gicv3_init(). The LAN9118's interrupt output is
+ * active-LOW until the driver programs IRQ_CFG with IRQ_POL|IRQ_TYPE, so
+ * between reset and lan9118_lwip_init() the model holds the line ASSERTED.
+ * Enabling the SPI before then takes an interrupt immediately, against a netif
+ * that does not exist yet — the image hangs before its first print. Enable it
+ * once the driver has configured the source. Issue 0917.
+ */
+static void gic_enable_spi(uint32_t id, uint8_t prio) {
+    mmio_w32(AN536_GICD_BASE, GICD_IGROUPR + 4u * (id / 32u),
+             mmio_r32(AN536_GICD_BASE, GICD_IGROUPR + 4u * (id / 32u))
+                 | (1u << (id % 32u)));
+    *(volatile uint8_t *)(AN536_GICD_BASE + GICD_IPRIORITYR + id) = prio;
+    /* ICFGR: 2 bits per interrupt, 0 = level-sensitive. The MAC holds the line
+     * while its RX status FIFO is non-empty, which is what lets the handler
+     * mask-and-defer instead of racing the next frame. */
+    mmio_w32(AN536_GICD_BASE, GICD_ICFGR + 4u * (id / 16u),
+             mmio_r32(AN536_GICD_BASE, GICD_ICFGR + 4u * (id / 16u))
+                 & ~(3u << (2u * (id % 16u))));
+    /* With ARE_NS an SPI needs a route or it targets nobody. Affinity 0, and
+     * two 32-bit stores rather than one 64-bit: this is device memory on an
+     * AArch32 PE. */
+    mmio_w32(AN536_GICD_BASE, GICD_IROUTER + 8u * id, 0u);
+    mmio_w32(AN536_GICD_BASE, GICD_IROUTER + 8u * id + 4u, 0u);
+    mmio_w32(AN536_GICD_BASE, GICD_ISENABLER + 4u * (id / 32u),
+             1u << (id % 32u));
+}
+
 static void gicv3_init(void) {
     /* Distributor: affinity routing + non-secure group 1. */
     mmio_w32(AN536_GICD_BASE, GICD_CTLR, GICD_CTLR_ARE_NS | GICD_CTLR_ENABLE_G1NS);
@@ -320,12 +357,19 @@ void nros_board_clear_tick_interrupt(void) {
  */
 extern void FreeRTOS_Tick_Handler(void);
 
+/* Defined below, next to the netif it services: masks the MAC's RX interrupt
+ * and wakes the drain task. Declared here because the dispatch sits above
+ * the definition. */
+void nros_board_eth_isr(void);
+
 __attribute__((used)) void vApplicationIRQHandler(void) {
     uint32_t iar = icc_read_iar1();
     uint32_t intid = iar & 0xffffffu;
 
     if (intid == TIMER_PPI_INTID) {
         FreeRTOS_Tick_Handler();
+    } else if (intid == ETH_SPI_INTID) {
+        nros_board_eth_isr();
     }
 
     /* 1020-1023 are the spurious/special IDs: no EOI is owed for them. */
@@ -370,9 +414,29 @@ int nros_board_register_netif(
     netifapi_netif_set_default(&lan9118_netif);
     netifapi_netif_set_up(&lan9118_netif);
     netifapi_netif_set_link_up(&lan9118_netif);
+    /* Arm RX interrupts: source first (the MAC's own mask), then the GIC.
+     * Order matters — see gic_enable_spi. Issue 0917. */
+    lan9118_lwip_rx_irq_enable(&lan9118_netif);
+    gic_enable_spi(ETH_SPI_INTID, 0xa0);
+
     return 0;
 }
 
 void nros_board_poll_netif(void) {
     lan9118_lwip_poll(&lan9118_netif);
+    /* Re-arm once the FIFO is empty. Doing it here rather than in the ISR is
+     * what makes the mask safe: the line stays masked for exactly as long as
+     * there is work, so a burst cannot re-enter the handler per frame. */
+    if (!lan9118_lwip_rx_pending(&lan9118_netif)) {
+        lan9118_lwip_rx_irq_enable(&lan9118_netif);
+    }
+}
+
+/* Called from vApplicationIRQHandler with the SPI acknowledged but not yet
+ * EOI'd. Do the minimum: silence the source, wake the drain task, return.
+ * lwIP must not be touched from here — `netif->input` takes locks and
+ * allocates. Issue 0917. */
+void nros_board_eth_isr(void) {
+    lan9118_lwip_rx_irq_mask(&lan9118_netif);
+    nros_freertos_net_wake_from_isr();
 }

--- a/packages/drivers/net/lan9118-lwip/include/lan9118_lwip.h
+++ b/packages/drivers/net/lan9118-lwip/include/lan9118_lwip.h
@@ -69,6 +69,14 @@ void lan9118_lwip_poll(struct netif *netif);
  */
 int lan9118_lwip_link_is_up(struct netif *netif);
 
+/* ---- RX interrupt support (issue 0917) ----
+ * The board owns the interrupt controller; the driver owns the MAC's own mask.
+ * Wire them as: enable once at bring-up, mask in the ISR, drain in a task, and
+ * enable again when `lan9118_lwip_rx_pending` reports the FIFO empty. */
+void lan9118_lwip_rx_irq_enable(struct netif *netif);
+void lan9118_lwip_rx_irq_mask(struct netif *netif);
+int  lan9118_lwip_rx_pending(struct netif *netif);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/drivers/net/lan9118-lwip/src/lan9118_lwip.c
+++ b/packages/drivers/net/lan9118-lwip/src/lan9118_lwip.c
@@ -486,6 +486,42 @@ err_t lan9118_lwip_init(struct netif *netif) {
     return ERR_OK;
 }
 
+/* ---- RX interrupt support (issue 0917) ----
+ *
+ * The controller drives its IRQ pin from INT_STS & INT_EN. RSFL ("RX status
+ * FIFO level") asserts while the RX status FIFO is non-empty, so it is a LEVEL
+ * condition, not an edge: it stays asserted until the frames are drained.
+ * An ISR must therefore MASK it rather than try to clear it, or the line
+ * re-asserts the instant the handler returns and the core livelocks.
+ *
+ * The split is: ISR masks and hands off; the drain task unmasks when the FIFO
+ * is empty. IRQ_CFG is already programmed with IRQ_EN|IRQ_POL|IRQ_TYPE by
+ * lan9118_lwip_init (active-high, push-pull), which is what the QEMU model
+ * requires to assert the line at all — with either bit clear it treats the
+ * output as active-low and holds the line asserted while IDLE.
+ */
+#define INT_STS_RSFL (1u << 3)
+
+void lan9118_lwip_rx_irq_enable(struct netif *netif) {
+    struct lan9118_config *cfg = (struct lan9118_config *)netif->state;
+    uint32_t base = cfg->base_addr;
+    reg_write(base, REG_INT_STS, INT_STS_RSFL);
+    reg_write(base, REG_INT_EN, reg_read(base, REG_INT_EN) | INT_STS_RSFL);
+}
+
+void lan9118_lwip_rx_irq_mask(struct netif *netif) {
+    struct lan9118_config *cfg = (struct lan9118_config *)netif->state;
+    uint32_t base = cfg->base_addr;
+    reg_write(base, REG_INT_EN, reg_read(base, REG_INT_EN) & ~INT_STS_RSFL);
+    /* Write-1-to-clear the latched status so the next frame re-raises it. */
+    reg_write(base, REG_INT_STS, INT_STS_RSFL);
+}
+
+int lan9118_lwip_rx_pending(struct netif *netif) {
+    struct lan9118_config *cfg = (struct lan9118_config *)netif->state;
+    return rx_packets_pending(cfg->base_addr) > 0;
+}
+
 void lan9118_lwip_poll(struct netif *netif) {
     struct lan9118_config *cfg = (struct lan9118_config *)netif->state;
     uint32_t base = cfg->base_addr;


### PR DESCRIPTION
Follows the analysis in #0917. The driver drained its RX FIFO from a task that slept `poll_interval_ms` and looked afterwards; on this part that ordering cannot work.

## Why a poll cannot service this NIC

The LAN9118 is a 10/100 controller whose usable RX FIFO is 9 024 B after the `can_receive` headroom — six 1440-byte frames — so at line rate it fills in **691 µs**:

```
frame on wire   1440 B at 100 Mbps        ->  115 us
usable FIFO     10560 - 1536 headroom     ->  6 frames
time to fill                              ->  691 us
8-fragment RTPS burst                     ->  922 us of wire
```

| drain latency | verdict |
| --- | --- |
| `poll_interval_ms = 5` (today) | 5000 µs — **7× too slow** |
| polling every 1 ms | 1000 µs — still too slow |
| RX interrupt (~50 µs) | fits, an order of magnitude to spare |

RTPS fragmentation of an ordinary ROS 2 topic sends far more than six back-to-back frames, so any real peer reaches this.

## The change

- **driver** — `lan9118_lwip_rx_irq_enable` / `_mask` / `_rx_pending`. `RSFL` is a *level* condition (asserted while the RX status FIFO is non-empty), so the ISR **masks** rather than clears and the drain task re-enables once the FIFO reads empty. `IRQ_CFG` was already `IRQ_EN|IRQ_POL|IRQ_TYPE` from `lan9118_lwip_init`; only `INT_EN` sat at 0.
- **board** — GICv3 wiring. `hw/arm/mps3r.c` gives the part `gpio_in(gicdev, 18)` ⇒ SPI 18 ⇒ **INTID 50**. Unlike the timer PPI this lives in the *distributor*, and with `GICD_CTLR.ARE_NS` set it also needs an `IROUTER` entry or it is enabled and targets nobody.
- **glue** — ISR masks and posts `vTaskNotifyGiveFromISR`; the drain task waits with `ulTaskNotifyTake`. `poll_interval_ms` becomes a **ceiling** rather than the cadence, and the task drains *first*, waits second. Boards with no RX interrupt keep the old behaviour, because the wait still times out.

## One trap worth having in the tree

Enabling the SPI in `gicv3_init()` **hangs the image before its first print**. The model treats the interrupt output as active-**low** until the driver sets `IRQ_POL|IRQ_TYPE`, so between reset and `lan9118_lwip_init()` the line is held asserted and the interrupt fires against a netif that does not exist. `gic_enable_spi` is therefore called after the source is configured, and the comment says why.

## What the measurements support — and what they don't

Packet loss below IP (wire datagrams vs the island's `ip.recv`):

| build | loss |
| --- | --- |
| polled, 5 ms | steady 12.1, 12.1, 11.9, 11.6, 13.1, 13.7 % |
| this change | **-0.3, 13.3, 17.3, -0.3, 14.1 %** |

Bimodal, not an average: two runs of five lose essentially nothing, three lose 13–17 %. So it **demonstrably reaches zero loss where polling never does**, and does not do so reliably. One run at a 5-fragment payload delivered the topic to the application at the full **10 Hz** publish rate against **2.1 Hz** polled; other runs of the same build stalled.

The lane's run-to-run variance is large enough (documented in #0917) that a stable end-to-end number is not available, and **none is claimed here**. The case for the change is the timing budget; the measurements are consistent with it and do not prove it on this lane.

## Explicitly not fixed

Payloads above the FIFO's capacity. At eight fragments the sample still does not arrive — 11.4 KB of back-to-back frames against a 10.5 KB FIFO, which no drain latency can absorb. **Necessary, not sufficient.**

`just ci-fast` — passed. Built and run on the an536 lane via the ASI consumer.
