### PR TITLE
fix(zephyr 4.4): nothing ever created the venv the line requires, so 12 cells never ran

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -476,6 +476,10 @@ jobs:
           - rust/action-server
     env:
       NROS_ZEPHYR_VERSION: ${{ matrix.line }}
+      # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to create
+      # on a host it does not own. A CI container IS owned: this image ships `uv`
+      # for exactly this. Ignored by the 3.7 line.
+      NROS_ZEPHYR_CREATE_VENV: "1"
     steps:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
@@ -575,6 +579,11 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.zephyr == 'true' && (github.event_name != 'schedule' || github.event.schedule == '0 5 * * *') }}
     name: zephyr ci-both (3.7 + 4.4)
+    env:
+      # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to
+      # create on a host it does not own. A CI container IS owned: the image
+      # ships `uv` for this. Issue 0933 follow-up.
+      NROS_ZEPHYR_CREATE_VENV: "1"
     runs-on: ubuntu-latest
     concurrency:
       group: nightly-zephyr-summary-${{ github.ref }}-${{ github.event_name }}
@@ -668,6 +677,11 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.zephyr == 'true' && (github.event_name != 'schedule' || github.event.schedule == '0 5 * * *') }}
     name: zephyr copy-out check (4.4)
+    env:
+      # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to
+      # create on a host it does not own. A CI container IS owned: the image
+      # ships `uv` for this. Issue 0933 follow-up.
+      NROS_ZEPHYR_CREATE_VENV: "1"
     runs-on: ubuntu-latest
     concurrency:
       group: nightly-zephyr-copyout-${{ github.ref }}-${{ github.event_name }}

--- a/scripts/zephyr/patches/4.4.sh
+++ b/scripts/zephyr/patches/4.4.sh
@@ -12,8 +12,16 @@ REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 cd "$REPO_ROOT"
 WORKSPACE="${1:?usage: patches/4.4.sh <zephyr-workspace-dir>}"
 
-echo "[zephyr setup] 4.4 line: provisioning Python 3.12 venv (Zephyr 4.4 requires >=3.12)..."
-bash ./scripts/zephyr/provision-py312-venv.sh "$WORKSPACE"
+# CHECKS by default; CREATES only when the caller owns its interpreter and says
+# so. A CI container is that caller — the zephyr CI image ships `uv` for exactly
+# this ("uv (Python 3.12 for the Zephyr 4.4 line)") — and nothing ever ran it, so
+# every 4.4 cell died here from the day provisioning was removed. Threaded as an
+# env var rather than a separate workflow step so the venv PATH stays derived in
+# one place instead of pasted into three jobs.
+CREATE_VENV=""
+[ "${NROS_ZEPHYR_CREATE_VENV:-0}" = "1" ] && CREATE_VENV="--create"
+echo "[zephyr setup] 4.4 line: Python 3.12 venv (Zephyr 4.4 requires >=3.12)${CREATE_VENV:+ — creating}..."
+bash ./scripts/zephyr/provision-py312-venv.sh "$WORKSPACE" $CREATE_VENV
 echo "[zephyr setup] 4.4 line: applying 4.4 NSOS patches (Phase 180.A)..."
 # Task 5 — NSOS recvmsg (cyclonedds UDP receive). Task 6 — NSOS
 # IPv4-multicast forwarding (SPDP discovery): guest half first

--- a/scripts/zephyr/provision-py312-venv.sh
+++ b/scripts/zephyr/provision-py312-venv.sh
@@ -16,10 +16,24 @@
 # What is left is the part worth keeping: saying exactly what the 4.4 line needs
 # and where, so a host can be made ready in one obvious step.
 #
-# Usage: provision-py312-venv.sh <workspace-dir>
+# `--create` is the ONE exception, and it is for a host that owns its own
+# interpreter: a CI container. There the workflow IS the host, the image ships
+# `uv` for exactly this ("uv (Python 3.12 for the Zephyr 4.4 line)"), and the
+# alternative is pasting this venv path and package list into three workflow
+# jobs — a second copy of the list that drifts from
+# `scripts/check-python-deps.py`, which is the single source. It stays OPT-IN,
+# so a developer machine still gets the refusal and the remedy above.
+#
+# Without it the 4.4 line could not set up at all: nothing in CI ever created
+# the venv, so every 4.4 cell died at `Set up Zephyr 4.4 workspace` from the day
+# provisioning was removed (2026-08-19), and twelve cells reported nothing.
+#
+# Usage: provision-py312-venv.sh <workspace-dir> [--create]
 set -euo pipefail
 
-WS="${1:?usage: provision-py312-venv.sh <workspace-dir>}"
+WS="${1:?usage: provision-py312-venv.sh <workspace-dir> [--create]}"
+CREATE=0
+[ "${2:-}" = "--create" ] && CREATE=1
 VENV="$WS/.venv312"
 PY="$VENV/bin/python"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
@@ -41,6 +55,42 @@ remedy() {
       $VENV/bin/python -m west build ...    (or prepend $VENV/bin to PATH)
 EOF
 }
+
+if [ ! -x "$PY" ] && [ "$CREATE" = 1 ]; then
+    echo "[py312] --create: no venv at $VENV; making one."
+    # The package list comes from `check-python-deps.py`, the single source the
+    # checker below reads too — never a second copy in this file or in YAML.
+    # NOTE `--list` ignores its group arguments and prints every group, so the
+    # filtering is here: the header line names the group, and the block's SECOND
+    # indented line is the packages.
+    pkgs="$(python3 "$here/scripts/check-python-deps.py" --list \
+        | awk 'BEGIN{split("west zephyr-build",w," "); for(i in w) want[w[i]]=1}
+               /^[^ ]/ {g=$1; blk=0; next}
+               {blk++; if (blk==2 && (g in want)) print}')"
+    if [ -z "$pkgs" ]; then
+        echo "ERROR: could not read the package list from check-python-deps.py --list." >&2
+        exit 1
+    fi
+    echo "[py312] installing:$(echo " $pkgs" | tr -s ' ')"
+
+    if command -v uv >/dev/null 2>&1; then
+        uv venv --python 3.12 "$VENV"
+        # `uv venv` makes a venv with NO pip in it — `$PY -m pip` here fails
+        # with `No module named pip`, and the failure lands mid-script where it
+        # reads as a broken interpreter. `uv pip` installs into it directly.
+        # shellcheck disable=SC2086
+        uv pip install --python "$PY" --quiet $pkgs
+    elif command -v python3.12 >/dev/null 2>&1; then
+        python3.12 -m venv "$VENV"
+        "$PY" -m pip install --quiet --upgrade pip
+        # shellcheck disable=SC2086
+        "$PY" -m pip install --quiet $pkgs
+    else
+        echo 'ERROR: --create needs uv or python3.12 on PATH; neither is here.' >&2
+        remedy
+        exit 1
+    fi
+fi
 
 if [ ! -x "$PY" ]; then
     echo "ERROR: the Zephyr 4.4 line needs a Python >=3.12 venv at $VENV — none found." >&2


### PR DESCRIPTION
With the two-site `EXTRA_CARGO_ARGS` injection fixed (#105), `Set up Zephyr 4.4 workspace` gets further and stops at the next thing:

```
[cargo-features-patch] patched .../modules/lang/rust/CMakeLists.txt
ERROR: the Zephyr 4.4 line needs a Python >=3.12 venv at
       ../nano-ros-workspace-4.4/.venv312 — none found.
```

`2f2086720` (2026-08-19) correctly stopped nano-ros from installing Python packages — PEP 668, `--user` vs venv vs pipx, distro package names make it a host decision. It turned the provisioner into a **checker**. Nothing took over the creating half: no workflow, no image step, nothing. So every 4.4 cell has died on this line for twelve days — **twelve cells producing no verdict**, which is worse than twelve failures.

The host that owns this interpreter is the CI container, and that image **already ships `uv` for exactly this purpose**:

```dockerfile
# uv (Python 3.12 for the Zephyr 4.4 line) + just (recipe runner).
```

It was installed and never used.

## The fix

`--create` is an **opt-in** mode on the same script: the default still refuses with its remedy, and only a caller that owns its interpreter asks. Threaded to CI as `NROS_ZEPHYR_CREATE_VENV=1` on the three zephyr jobs rather than a separate workflow step, so the venv path stays derived in one place instead of pasted into three YAML blocks — and the package list comes from `check-python-deps.py --list`, the same single source the checker reads, never a second copy.

## Three bugs this cost, all worth recording

- **`uv venv` creates a venv with no pip.** `$PY -m pip install` fails `No module named pip` halfway through, reading as a broken interpreter. The uv path uses `uv pip install --python "$PY"`; the `python3.12` path keeps `-m pip`.
- **`--list` ignores its group arguments** and prints every group. Passing `west zephyr-build` and trusting it returned six groups' packages, including `clang-format==17.0.5`. Filtering is done at the call site.
- **A duplicate YAML key.** The job-level `env:` I first added to `zephyr-example-matrix` was a second `env:` — the job already had one further down, YAML takes the last, and mine was silently dead. Caught by parsing the file back rather than reading the diff; merged into the live block.

## Verification

On this host (which also has `uv`): default refuses (rc=1); `--create` builds a Python 3.12.14 venv and installs `pyelftools PyYAML pykwalify packaging west` (rc=0); a second run is idempotent (rc=0); the checker then reports `has west, zephyr-build`. `just check fast` 140 gates, 4 host-precondition skips. All three jobs parse with the variable set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB