### PR TITLE
fix(esp32): the DRAM fix landed on one row; its three siblings kept overflowing

### DIFF
--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -3181,6 +3181,17 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "examples/qemu-esp32-baremetal/rust/talker"
 skip_probe = true
+# ZPICO_MAX_QUERYABLES: same cause as `workspace-rust-esp32` above, one row
+# over. These are talker/listener images — the listener says so itself ("no
+# publishers/services/actions") — so the undeclared embedded budget of 8 buys
+# SERVICE_BUFFERS (`ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES`) for services
+# the image does not have, and that is what overflows DRAM.
+#
+# The first fix set this on the workspace row ONLY, because that was the row the
+# failure named. These three build through `just esp32 build-qemu` and kept
+# overflowing — by 8,644 B in `esp32_qemu_talker` — which is the "fix the CLASS,
+# not the reported site" rule applied a row too narrowly the first time.
+env = { ZPICO_MAX_QUERYABLES = "2" }
 
 [[fixture]]
 id = "qemu-esp32-baremetal-listener"
@@ -3188,6 +3199,7 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "examples/qemu-esp32-baremetal/rust/listener"
 skip_probe = true
+env = { ZPICO_MAX_QUERYABLES = "2" }  # see the talker row above
 
 [[fixture]]
 id = "qemu-esp32-baremetal-logging-smoke"
@@ -3195,6 +3207,7 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "packages/testing/nros-tests/bins/logging-smoke-esp32-qemu"
 skip_probe = true
+env = { ZPICO_MAX_QUERYABLES = "2" }  # see the talker row above
 
 # =============================================================================
 # Compile-check lane (phase-319 W2, issue 0351) — built by


### PR DESCRIPTION
`b792b6a83` fixed the esp32 DRAM overflow by declaring `ZPICO_MAX_QUERYABLES=2` on `workspace-rust-esp32` — **the row the failure named**. The nightly then moved that cell from failing at Build to failing at Test/e2e, which read as progress. It wasn't: the build failure had moved to a different binary.

```
rust-lld: error: section '.bss' will not fit in region 'DRAM': overflowed by 8644 bytes
error: could not compile `esp32_qemu_talker` (bin "esp32_qemu_talker")
error: recipe `build-qemu` failed with exit code 101
```

Three rows build through `just esp32 build-qemu` — `qemu-esp32-baremetal-{talker,listener,logging-smoke}` — and **none carried any `env` at all**, so none got the override. Same cause one row over: the undeclared embedded budget of 8 buys `SERVICE_BUFFERS` (`ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES`) for services these images don't have.

That the reasoning transfers is **checked, not assumed**: these are talker/listener images and the listener says so itself —

```rust
// no publishers/services/actions, so the static cell pays ~nothing.
```

— and the manifest record carries `<dir>\x1f<env>\x1f<cargo-args>`, so a row `env` does reach this build path.

This is CLAUDE.md's *"fix the class, not the reported site"* rule, applied a row too narrowly the first time by me. The sweep is one line:

```bash
grep -n '^platform = "qemu-esp32-baremetal"' examples/fixtures.toml
```

## Verification

Manifest parses (3 esp32 coordinates); `check-fixtures-manifest` and `check-fixture-id-guard` OK; `just check fast` 141 gates, 4 host-precondition skips. The link itself isn't reproducible here — it needs the esp nightly toolchain — so the nightly esp32 cell is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB