### PR TITLE
docs(rfc-0002, phase-392/394): the executor arena is a named static, not the callers stack

### DIFF
--- a/docs/design/0002-rt-execution-model.md
+++ b/docs/design/0002-rt-execution-model.md
@@ -382,6 +382,65 @@ tier's spin period quantizes to the spin grid (33 ms on a 5 ms spin alternates
 so no rule fires — correctly — but the jitter is predictable at resolve time and
 would be better as a resolver warning than a surprise on target.
 
+### 4.4b Arena placement: a named static, not the caller's stack
+
+**Decision.** The executor arena is a named static in `.bss`, not an inline
+`[MaybeUninit<u8>; ARENA_SIZE]` field of `Executor`.
+
+Today it is the latter, so the arena lands on whichever task calls `spin`. Three
+consequences, all of them working against the properties this RFC exists to
+provide:
+
+* **It is invisible to the tools that are supposed to bound it.** `mem-report`
+  reads symbols; a stack-resident arena has none. The largest single RAM
+  consumer in an image is the one thing the memory instrument cannot see.
+* **It pushes its cost onto a number nobody derives.** The FreeRTOS action
+  examples pin an 8192-byte arena and still need a 64 KB app-task stack — a
+  figure found by hitting `Invalid mbox` and working backwards (issues
+  0271/0739). A task stack sized by bisection is not an analysable bound.
+* **It scales with subscription buffers.** Each `SubInfoEntry` embeds
+  `buffer: [u8; RX_BUF]`, so raising `NROS_SUBSCRIPTION_BUFFER_SIZE` for one
+  large topic multiplies across every subscription and lands on that stack. An
+  image with five subscriptions at a 64 KiB default reserves ~320 KiB of
+  **stack** for ~20 KiB of actual need.
+
+As a named static the same bytes are a linker-visible symbol: `mem-report` sees
+it, the map file bounds it, and the task stack no longer carries a term that
+depends on how many topics the application happens to subscribe to.
+
+**Orthogonal, and deliberately not decided here: whether payload buffers
+themselves become heap-backed.** Phase 392 amendment B reopened that as a
+measurement wave — pools are each sized for their own worst case and then
+SUMMED, and an arena sized for the aggregate peak could be the larger win. This
+decision is about WHERE the arena lives, not what backs the buffers inside it,
+and it does not pre-empt that wave: a `.bss` arena is a better starting point
+for it, because the thing being measured becomes visible to `mem-report`.
+
+The standing case against, which amendment B must answer rather than assume:
+timing is not the objection — rlsf is O(1) (phase 391 W2) — but a heap-backed
+payload converts a compile-time constant into a bound that depends on worst-case
+concurrent in-flight samples across every topic, widens the heap's block-size
+spread (what Robson's bound scales with, and what phase 391 says makes TLSF
+sizeable at all), and puts an allocation failure on the receive path, where the
+existing failure mode is already "received, ACKed, then silently discarded"
+(`report_dropped_take`, issue 0757).
+
+**Rejected alternative: one buffer shared by all subscriptions.** LET sampling
+settles it: `SubInfoEntry::sampled_len` records pre-sampled data that must
+survive the LET window, so the buffer cannot be reused by another subscription
+in the meantime. Sharing would also require mutual exclusion across
+receive→deserialize, which couples the WCET of unrelated topics and introduces
+a priority-inversion channel between tiers — the opposite of § 4.2's intent. And
+it does not even pay: sized to the largest type it saves the difference between
+`max` and `sum`, which for a typical island graph is a few KiB against the loss
+of per-topic independence.
+
+**What makes the static affordable** is sizing each subscription to its own
+type rather than to a global default — `MAX_SERIALIZED_SIZE_XCDR{1,2}` (phase
+380) via `rx_buffer_for!`. That is a separate lever (phase 392 W3a) and this
+decision does not depend on it, but the two together are what turn the arena
+from a stack-resident unknown into a static the linker can print.
+
 ### 4.5 ISR ↔ Executor SPSC Ring
 
 ReadySet is single-threaded (no `Sync`). When an ISR (transport RX, hardware timer, GuardCondition fire) needs to activate a callback, it writes into a **lock-free SPSC ring** read by the executor at the top of `spin_once`. Mirrors FreeRTOS `xQueueSendFromISR` / `xQueueReceive`.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -49,7 +49,10 @@ and `malloc` itself had been garbage-collected because nothing calls it. Setting
 **7.7% of SRAM held by a heap with no allocator**, invisible until someone
 listed symbols by size. That is the shape of everything below.
 
-## The three levers, in order of leverage
+## The levers, in order of leverage
+
+Three shrink what is reserved; **1b shrinks nothing and is listed anyway**,
+because it is what makes the other three measurable.
 
 ### 1. Wire buffers — 48 bytes of RAM per byte of knob
 
@@ -70,6 +73,31 @@ Half the mechanism already exists: `MAX_LARGE_SUBSCRIBERS` /
 `SUBSCRIBER_LARGE_SIZE` is a two-class split (1x4x2048 large, 12x4x1024 small).
 It is simply **decoupled from codegen**, so a human picks which subscribers are
 "large".
+
+### 1b. The arena is on the STACK, so none of lever 1 is visible
+
+`Executor` holds `arena: [MaybeUninit<u8>; ARENA_SIZE]` inline, so the arena —
+and every `SubInfoEntry::buffer` inside it — lands on whichever task calls
+`spin`, not in `.bss`.
+
+That defeats this campaign's own instrument. W1 exists to price every pool by
+reading symbols; a stack-resident arena has no symbol, so **the largest single
+RAM consumer in an image is the one thing `mem-report` cannot see**. It is also
+why the FreeRTOS action examples pin an 8192-byte arena and still need a 64 KB
+app-task stack — a number found by hitting `Invalid mbox` and working backwards
+(issues 0271/0739).
+
+And it makes lever 1 land in the worst place: raising
+`SUBSCRIPTION_BUFFER_SIZE` for one large topic multiplies across every
+subscription and lands on a *stack*. A five-subscription image at the 64 KiB
+default reserves ~320 KiB of stack for ~20 KiB of real need.
+
+Moving it to a named static changes no allocation strategy — the same bytes,
+reserved the same way — and buys three things this campaign is otherwise
+paying for: a symbol `mem-report` can price, a map-file bound, and a task stack
+that no longer carries a term proportional to the subscription graph. Decision
+recorded in [RFC-0002 § 4.4b](../design/0002-rt-execution-model.md); wave W6
+below.
 
 ### 2. Component buffers — 1:1 with per-field storage mode
 
@@ -779,6 +807,40 @@ one that decides whether "sized by declaration" ever becomes "sized exactly".
 **`ZPICO_MAX_SESSIONS`** multiplies the pool and has no declaration path at all.
 Either it joins the model or it stays a knob and this phase says so explicitly.
 It is currently 1 everywhere, which is why it has never been the visible term.
+
+### W6 — the executor arena becomes a named static
+
+**Why it is a wave and not a patch.** The move itself is small; what it touches
+is where every image's largest allocation is accounted. Do it after W1 so the
+instrument can show the before/after, and measure on a named image rather than
+asserting the saving.
+
+Steps:
+
+1. Replace `Executor`'s inline `arena` field with a reference to a
+   platform-provided static. The arena is already bound to `Dispatcher` at
+   construction as a stable pointer (RFC-0002 § 4.4), so the ownership change
+   is confined to construction.
+2. Give the static a name the instrument can find, and a section a linker
+   script can place — TCM is a candidate on parts that have it (amendment A).
+3. `mem-report` gains a row it previously could not see. That row IS the
+   acceptance evidence.
+4. Re-derive one over-large task stack against the new figure. The FreeRTOS
+   action examples' 64 KB app task is the honest test: if it can drop, the
+   number was carrying the arena and the campaign can say so with a diff.
+
+**Acceptance.** A named image shows the arena as a priced symbol in
+`mem-report`, and one task-stack knob is reduced by a measured amount rather
+than by bisection.
+
+**Interaction with amendment B.** This does not decide whether payload buffers
+become heap-backed; it makes that question measurable, because the pools stop
+being invisible. If B later moves them, this wave is not wasted work — the
+arena still needs an address.
+
+**Non-goal.** Sizing each subscription to its type is W3a's job, not this
+wave's. The two compound (a static sized by type is both smaller and visible)
+but neither depends on the other.
 
 ## Explicitly out of scope
 

--- a/docs/roadmap/phase-394-memory-campaign-ledger.md
+++ b/docs/roadmap/phase-394-memory-campaign-ledger.md
@@ -19,6 +19,23 @@ in this campaign covered:
 | The libc arena regresses because only the symbol is gated, not the config | phase-391 W1b | gate item added |
 | Flash is 4 MiB at 8.3 % and is NOT fungible with RAM | phase-392 amendment D | scoped: post-mortem log, config storage, ITCM |
 
+## Amendment 2026-08-31 — the arena has no symbol, so the instrument cannot price it
+
+A design review of the subscription buffer, from the ASI consumer side, found
+that the campaign's largest single consumer is invisible to the campaign's own
+instrument. `Executor` holds its arena inline, so it lands on whichever task
+calls `spin` rather than in `.bss` — and W1 prices pools by reading symbols.
+
+| item | where it landed | status |
+| --- | --- | --- |
+| The executor arena is stack-resident, so `mem-report` cannot see it and task stacks carry a term proportional to the subscription graph | [RFC-0002 § 4.4b](../design/0002-rt-execution-model.md) decision; phase-392 lever 1b + wave W6 | opened |
+
+Two things it does NOT change, recorded so they are not re-litigated from this
+amendment: it does not decide whether payload buffers become heap-backed (that
+is amendment B's wave, and a `.bss` arena only makes it measurable), and it does
+not size subscriptions to their type (that is phase-392 W3a). The three
+compound; none depends on another.
+
 One correction is recorded rather than a gap: *field storage mode does not
 shrink wire buffers.* Phase-392 lever 2 already said so; it has since been
 proposed twice in the opposite direction, so the amendment restates it as a


### PR DESCRIPTION
From a subscription-buffer design review on the ASI consumer.

The finding is not that the arena is too big. It is that **the campaign's largest single consumer has no symbol, so the campaign's own instrument cannot price it.**

`Executor` holds `arena: [MaybeUninit<u8>; ARENA_SIZE]` inline, so the arena — and every `SubInfoEntry::buffer` inside it — lands on whichever task calls `spin` rather than in `.bss`. Three consequences, all working against what these docs exist to provide:

- **W1 prices pools by reading symbols**, and a stack-resident arena has none.
- **The cost lands on a number nobody derives.** The FreeRTOS action examples pin an 8192-byte arena and still need a 64 KB app-task stack — found by hitting `Invalid mbox` and working backwards (issues 0271/0739).
- **Lever 1 lands in the worst place.** Raising `SUBSCRIPTION_BUFFER_SIZE` for one large topic multiplies across every subscription *onto a stack*. A five-subscription image at the 64 KiB default reserves ~320 KiB of stack for ~20 KiB of real need — which is exactly what the ASI an536 lane is doing today.

Moving it to a named static changes no allocation strategy — same bytes, reserved the same way — and buys a symbol `mem-report` can price, a map-file bound, and a task stack that no longer carries a term proportional to the subscription graph.

## What each doc gains

**RFC-0002 § 4.4b** — the decision, with both alternatives and why each is declined.

Sharing one buffer across subscriptions is settled by LET rather than by preference: `SubInfoEntry::sampled_len` must survive the LET window, so the buffer cannot be reused by another subscription meanwhile. Sharing would additionally couple the WCET of unrelated topics across tiers, for a saving of *max* versus *sum*.

**Whether payload buffers themselves become heap-backed is deliberately not decided here.** Phase 392 amendment B reopened that as a measurement wave; this is about *where the arena lives*, not what backs the buffers inside it. A `.bss` arena is a better starting point for that wave, because the thing being measured stops being invisible. The standing case against (Robson's bound scaling with block-size spread, an allocation failure on the RX path) is restated as something B must **answer rather than assume**.

**phase-392** — lever 1b and wave W6. Acceptance is a `mem-report` row that did not previously exist, plus one task-stack knob reduced by measurement rather than bisection. The "three levers" heading is corrected: 1b shrinks nothing and is listed anyway, because it is what makes the other three measurable.

**phase-394** — the amendment, and explicitly the two things it does *not* change (amendment B's wave, W3a's per-type sizing) so neither is re-litigated from here. The three compound; none depends on another.

## Provenance

Found while investigating why the an536 lane needs `NROS_SUBSCRIPTION_BUFFER_SIZE=65536` — see #0917. Docs only; no code moves in this PR.

`just ci-fast` — passed.
