### PR TITLE
feat(phase-400 W5): turn on shared cargo dirs for Zephyr — a subsequent image costs about half

### DIFF
--- a/docs/roadmap/phase-400-rust-dependency-weight-audit.md
+++ b/docs/roadmap/phase-400-rust-dependency-weight-audit.md
@@ -976,6 +976,51 @@ getting the generated headers to each image while the dependency mass is shared.
 Three candidate routes, none free, all recorded above and in the design-fork
 section.
 
+### W5 — TURNED ON 2026-08-31, and measured. ~2x on a subsequent image.
+
+The Zephyr lane now passes `-DNROS_SHARED_CARGO_ROOT` (the same
+`nros_build_dir "$NROS_KIND_CORROSION_CARGO" zephyr` call the six other platforms
+make), and W5.b's `FATAL_ERROR` is lifted — because the reason for it is gone,
+not tolerated. W5.c's placer takes the headers from `$OUT_DIR`, which cargo
+reports even on a cache hit, so the second image gets its headers without its
+build script running. **Verified in the run itself:** image 2 took the cache hit
+and still reported both placements, with the header present in its own dir.
+
+Two keyed directories appear under the shared root, one per package — features
+are in the key, as W5.b's note explains.
+
+#### The measurement, and the confound that nearly buried it
+
+With `sccache` DISABLED, which is the honest configuration for this question:
+
+```
+first image,  empty shared root   wall 15.1 s   CPU 24.6 s
+second image, warm shared root    wall  8.4 s   CPU 12.9 s
+```
+
+**A subsequent image costs about half.** That is the wave's payoff, and it is the
+first CPU number in this phase that is a saving rather than an estimate.
+
+With `sccache` ENABLED the same pair reads the other way — 61.8 CPU-s shared
+against 24.9 unshared — and that comparison is INVALID. The unshared baseline
+drew on an sccache warmed by hundreds of unshared builds in the same session,
+while the shared runs use a different path spelling and therefore different
+`-C metadata`, so they hit no existing entries and paid population cost. The two
+configurations do not share cache keys, so the pair never measured sharing at
+all.
+
+Recorded because the wrong reading was the FIRST one taken, and it looked like a
+clean refutation. The phase's own rule applies to a disappointing number exactly
+as it does to a flattering one: ask what else changed before believing it.
+
+*Still to measure before quoting a sweep figure:* a run on a machine with no
+pre-warmed sccache — CI, or after `sccache --zero-stats` and a cache clear — to
+learn what the pairing is worth in production rather than on this host.
+
+*Still open:* the target-dir side channel is still written, and the Corrosion and
+NuttX lanes still read it. Zephyr no longer does, which is why sharing is safe
+there now; retiring it everywhere is the follow-up that lets the write go.
+
 ### W5 open items — closed 2026-08-30, and the path-divergence finding is RETRACTED
 
 **1. The `DOTCONFIG` exemption reason — rewritten.**

--- a/just/zephyr-dev.just
+++ b/just/zephyr-dev.just
@@ -12,6 +12,10 @@ build-one example rmw="zenoh" board="native_sim/native/64":
     #!/usr/bin/env bash
     set -euo pipefail
     source scripts/build/cargo.sh
+    # phase-400 W5 — `nros_build_dir` and the KIND constants come from here, and
+    # this must happen BEFORE the recipe changes into the west workspace: the
+    # path is relative to the repo root.
+    source scripts/build/build-root.sh
     # Phase 180.B — examples read the ROS interface package dirs from env
     # (no more hardcoded /opt/ros/humble/share/* PKG_DIR). Default to the
     # stock Humble install; override per package if your ROS lives elsewhere.
@@ -117,8 +121,21 @@ build-one example rmw="zenoh" board="native_sim/native/64":
     bd="build-$(echo '{{example}}' | tr '/' '-')-{{rmw}}"
     echo "Zephyr {{NROS_ZEPHYR_VERSION}}: building zephyr/{{example}} ({{rmw}}, {{board}}) -> $workspace/$bd"
     cd "$workspace"
+    # phase-400 W5 — share the cargo dependency mass across images.
+    #
+    # Zephyr was the one platform building every image against its own cargo
+    # target dir: 191 of them across 89 west build trees, each recompiling the
+    # same ~86 host crates. The six other platforms have passed a shared root
+    # since issue 0805; this is the same call they make.
+    #
+    # Safe here only because the generated headers no longer come from inside
+    # that directory (W5.c): they are placed from `$OUT_DIR`, which cargo reports
+    # even on a cache hit. Before that, sharing left every image after the first
+    # without its headers.
+    shared_cargo_root="$(nros_build_dir "$NROS_KIND_CORROSION_CARGO" zephyr)"
     "${west_cmd[@]}" build -b "{{board}}" -d "$bd" "$src" -- \
-        -DCONF_FILE="$conf" -D_NANO_ROS_CODEGEN_TOOL="$codegen_tool"
+        -DCONF_FILE="$conf" -D_NANO_ROS_CODEGEN_TOOL="$codegen_tool" \
+        -DNROS_SHARED_CARGO_ROOT="$shared_cargo_root"
     echo "Built: $workspace/$bd/zephyr/zephyr.elf"
 
 # Phase 180.B item 5 — copy-out CI check. Copies an example OUT of the

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -432,43 +432,18 @@ endfunction()
 # stable and the NuttX eviction mechanism is unavailable here.
 function(_nros_root_cargo_dir out_var features)
     set(_dir "")
-    if(NROS_SHARED_CARGO_ROOT AND NOT NROS_ZEPHYR_SHARED_CARGO_UNSAFE_OK)
-        # phase-400 W5.b — the key below is ready; the LANE is not. Refusing is
-        # deliberate, and it is not caution: enabling sharing here produces a
-        # BROKEN BUILD today, and this was demonstrated rather than predicted.
-        #
-        # `nros-{c,cpp}`'s build script writes the per-build config headers under
-        # `$CARGO_TARGET_DIR`. Share that dir and image B gets a cargo cache hit,
-        # so the script does not re-run and never writes B's copy — while the
-        # consumers (`_nros_generated_header_dir`, per-image since W5.a) look in
-        # B's own directory. Observed exactly that way, from a stale
-        # `-DNROS_SHARED_CARGO_ROOT` left in ONE build dir by an earlier reverted
-        # experiment:
-        #
-        #   ninja: error: 'nros-rust/nros-c-generated/nros/nros_generated.h',
-        #   needed by '.../Listener.cpp.obj', missing and no known rule to make it
-        #
-        # W5.c has to make the headers reach each image before this can open.
-        # None of the three candidate routes is free — fingerprinting the
-        # destination is a path env var (issue 0491) plus churn; a cmake copy from
-        # the shared dir is issue 0834's POST_BUILD shape; sharing them under a
-        # key that covers them collides across the two packages, which is the D1
-        # failure recorded in the phase doc.
-        #
-        # A FATAL_ERROR rather than a silent fallback to per-image: a caller who
-        # passed the flag asked for sharing, and quietly not doing it is how a
-        # measurement gets attributed to a build that never shared anything.
-        message(FATAL_ERROR
-            "nano-ros: -DNROS_SHARED_CARGO_ROOT is not supported on the Zephyr "
-            "lane yet (phase-400 W5.c). The per-build config headers are written "
-            "into the cargo target dir, so sharing it leaves every image after "
-            "the first without them:\n"
-            "  ninja: error: '<build>/nros-rust/nros-c-generated/nros/"
-            "nros_generated.h' ... missing and no known rule to make it\n"
-            "Unset it for this build. If you are DEVELOPING W5.c, pass "
-            "-DNROS_ZEPHYR_SHARED_CARGO_UNSAFE_OK=ON and expect that error until "
-            "the header path is solved.")
-    endif()
+    # phase-400 W5.c — the refusal that stood here is LIFTED, because the
+    # reason for it is gone rather than tolerated.
+    #
+    # It read: sharing the target dir leaves image B without its generated
+    # headers, because B takes a cargo cache hit, its build script never runs,
+    # and the per-image directory the consumers include is never written. That
+    # was true while the headers came from a side channel inside the target dir.
+    #
+    # They no longer do. `cargo-out-dir-headers.py` places them from `$OUT_DIR`,
+    # which cargo reports on its JSON stream EVEN ON A CACHE HIT (measured: 13
+    # `build-script-executed` events with nothing to rebuild), and the BYPRODUCTS
+    # name the per-image directory. So a cache hit still places the headers.
     if(COMMAND nros_shared_cargo_dir AND NROS_SHARED_CARGO_ROOT)
         if(NOT DEFINED NROS_RESOLVED_KNOBS)
             message(FATAL_ERROR


### PR DESCRIPTION
Finishes W5. Zephyr was the one platform building every image against its own cargo target dir — 191 of them across 89 west trees — while the six others have shared since issue 0805.

## Why it is safe now

W5.b left a `FATAL_ERROR` here on purpose: sharing left image B without its generated headers, because B takes a cargo cache hit, its build script never runs, and the per-image directory consumers include is never written.

W5.c removed that. The headers are placed from `$OUT_DIR`, which cargo reports on its JSON stream **even when nothing rebuilds**. Verified in the run itself — image 2 took the cache hit and still reported both placements, header present in its own directory.

## Measured, sccache disabled

| | wall | CPU |
|---|---|---|
| first image, empty shared root | 15.1 s | 24.6 s |
| second image, warm shared root | 8.4 s | **12.9 s** |

A subsequent image costs about half. First CPU figure in this phase that is a saving rather than an estimate.

## The confound, recorded because it was the first reading

With sccache **enabled** the same pair reads 61.8 CPU-s shared against 24.9 unshared — sharing apparently costing double. That comparison is invalid: the unshared baseline drew on an sccache warmed by hundreds of unshared builds in the same session, while the shared runs use a different path spelling and therefore different `-C metadata`, so they hit nothing and paid population cost. The two configurations do not share cache keys.

It looked like a clean refutation. The phase's own rule applies to a disappointing number exactly as to a flattering one.

## Also fixed

Two ordering bugs found by running it: `NROS_KIND_CORROSION_CARGO` and `nros_build_dir` come from `build-root.sh`, which the recipe never sourced; and sourcing it late fails because the recipe has already changed into the west workspace while the path is repo-relative.

## Not done

- A run with no pre-warmed sccache (CI, or a cleared cache) to learn what this is worth in production rather than on this host.
- The target-dir side channel is still written. Zephyr no longer reads it — that is what makes sharing safe here — but Corrosion and NuttX still do.

## Verification

```
just zephyr build-one c/listener zenoh   # cold shared root, green
just zephyr build-one c/talker zenoh     # cache hit, headers still placed
just check fast                          # 145/145
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe