### PR TITLE
feat(#0951): site config keys on the BOARD — `[board_config.<board>]`

### DIFF
--- a/cmake/NanoRosBoardFacts.cmake
+++ b/cmake/NanoRosBoardFacts.cmake
@@ -2,7 +2,7 @@
 # cargo invocations this configure owns.
 #
 # RFC-0072 §5 splits board information into A (board facts, in the board
-# package) and B (site config, in the user's `[deploy.<name>.nros]`). W1–W4 gave
+# package) and B (site config, in the user's `[board_config.<board>]`). W1–W4 gave
 # both a home and a validity domain. Delivery is this file.
 #
 # WHY THE INVOKER. Cargo discovers config from the invocation CWD upward, and

--- a/docs/design/0072-rtos-integration-nano-ros-is-a-guest.md
+++ b/docs/design/0072-rtos-integration-nano-ros-is-a-guest.md
@@ -294,6 +294,36 @@ path. `config_files` is a **named map** rather than a directory, because ThreadX
 needs `TX_USER_FILE` *and* `NX_USER_FILE` and FreeRTOS+TCP needs
 `FreeRTOSConfig.h` *and* `FreeRTOSIPConfig.h`.
 
+#### Amendment 1 — the key is the BOARD, not the deploy (issue 0951)
+
+`[deploy.<name>.nros]` was the shipped spelling for three phases. It is now
+`[board_config.<board>]` in the same file. The rest of this section stands
+unchanged: same struct, same file, same `{env:…}` interpolation, same named
+`config_files` map.
+
+What was wrong was one clause above — "already keyed per board". A deploy name
+is *usually* a board name, and the example on this page
+(`[deploy.nucleo-h723zg]`) is one of the cases where it is. But the two are not
+in bijection, and the tree drifted apart in both directions:
+`[deploy.threadx-linux]` pairs with `[image.threadx]`, `[deploy.an536]` with
+`[image.mps3_an536]`, and several workspaces carry BOTH `[deploy.freertos]` and
+`[deploy.mps2-an385-freertos]` for one board.
+
+The cost was measured rather than argued: **30 authored site blocks held
+exactly THREE distinct value-sets**, because a block had to be repeated under
+every deploy name that reached its board. `board_facts` grew a comparison that
+refused two blocks disagreeing about one board — detection standing in for a
+shape that should not be representable. Keying on the board removes the shape:
+`[board_config.freertos]` and `[board_config."mps2-an385-freertos"]` resolve to
+one block through `BoardCatalog::resolve_deploy`, the same rule every other
+board spelling goes through (issue 0606).
+
+This also detaches category B from the `[deploy.*]` retirement. The original
+argument for putting site keys on `[deploy.*]` was that the table "already
+exists" — which stops being a reason once that table is being taken apart into
+`[host.*]` (placement) and `[image.*]` (build). Site config belongs to neither,
+and a board-keyed table is what lets it outlive both.
+
 ### Test-harness config is a third thing
 
 QEMU invocations are neither board nor project — they are how *our tests* run a

--- a/docs/issues/0951-site-config-keys-on-deploy-not-board.md
+++ b/docs/issues/0951-site-config-keys-on-deploy-not-board.md
@@ -1,0 +1,117 @@
+---
+id: 951
+title: "`[deploy.*]` is three unrelated facts in one table — site config keyed
+  on the deploy name, not the board, is the half that duplicates"
+status: open
+type: tech-debt
+area: orchestration, tooling
+related: [rfc-0065, rfc-0072, phase-383, issue-0842, issue-0606]
+---
+
+## Problem
+
+`[deploy.<name>]` accumulated three facts that have nothing to do with each
+other, and each wants a different key:
+
+| fact | example keys | what it is really about |
+| --- | --- | --- |
+| PLACEMENT | `kind`, `nodes` | a MACHINE |
+| build description | `board`, `rmw`, `profile`, `features` | an IMAGE |
+| site config | `nros.sdk`, `nros.netstack` | a BOARD |
+
+One table, three keys, so two of the three are always keyed wrong. The
+measurable consequence is duplication: **30 authored `[deploy.<n>.nros]` blocks
+across 8 files held exactly THREE distinct value-sets.**
+
+```
+13 blocks  {netstack=lwip,   sdk={freertos,lwip}}       boards: mps2-an385-freertos
+13 blocks  {                 sdk={nuttx,nuttx_apps}}    boards: nuttx-qemu-arm, nuttx-qemu-riscv, qemu-armv7a-nsh
+ 4 blocks  {netstack=netxduo,sdk={threadx,netxduo}}     boards: threadx-linux
+```
+
+The 25 duplicates exist only because the deploy key is sometimes the friendly
+name (`[deploy.freertos.nros]`) and sometimes the board spelling
+(`[deploy.mps2-an385-freertos.nros]`) — **two keys for one board, which is two
+places for one fact to drift.** `board_facts` grew machinery to compare the
+candidates and refuse a disagreement, which is detection standing in for a
+shape that should not be representable.
+
+Issue 0842 named this in its title — "site config keys on deploy target, not
+board" — for a workspace with two FreeRTOS boards whose site block was
+reachable from the wrong one. Its root cause turned out to lie elsewhere (the
+image inherited the default `rmw`), so the keying survived the fix.
+
+## Why the deploy key is the wrong one, concretely
+
+A deploy name and a board name are not in bijection, in either direction:
+
+* `[deploy.threadx-linux]` ↔ `[image.threadx]`, `[deploy.an536]` ↔
+  `[image.mps3_an536]` — a mechanical `deploy.X.nros → image.X.nros` rename
+  loses three site blocks in `examples/workspaces/cpp` alone;
+* `examples/workspaces/rust` declares eleven `board = "native"` images, so a
+  per-image site table would multiply the duplication rather than remove it;
+* `examples/workspaces/rust` also carries boardless `[deploy.freertos.nros]`
+  and `[deploy.nuttx.nros]` blocks whose board is only discoverable through the
+  same-named image.
+
+## Fix
+
+`[board_config.<board>]`, a nano-ros-owned table on `SystemToml`, holding the
+existing `SiteConfig` struct. The key is resolved through
+`BoardCatalog::resolve_deploy` — the same rule every other board spelling goes
+through (issue 0606) — so an alias finds the block exactly as it does
+everywhere else, and `[board_config.freertos]` and
+`[board_config."mps2-an385-freertos"]` are the same block rather than two.
+
+Two blocks disagreeing about one board becomes **unrepresentable** instead of
+detected, which is why `board_facts`'s agree/disagree comparison now has
+nothing to catch for that case. It still fires for the genuinely ambiguous one:
+blocks on DIFFERENT boards when the caller named neither.
+
+## Status
+
+Landed so far:
+
+* **placement → `[host.<name>]`** — rlm v0.1.21 added the table; 8 machine
+  blocks migrated. (The commit that landed this, `70297f148`, cites `#0939` in
+  its title by mistake; 0939 is an unrelated metadata-probe bug. This issue is
+  the correct number, reserved after the fact.)
+* **site config → `[board_config.<board>]`** — 30 blocks became 20, plus 4 the
+  generator wrote for a workspace that had none.
+
+Still open — the build half:
+
+* 42 `kind = "embedded"` blocks whose build description moves to `[image.*]`;
+* the readers that still consult `[deploy.*]`: `tier_resolver::derive_target_rtos`,
+  `planner::schema_build_json`, `codegen_system`'s `.launch` fallback,
+  `doctor::check_deploy_targets`, `check.rs`'s counter;
+* `SystemToml::resolve_target` has no image rung, so a workspace that deletes
+  its deploy blocks silently falls back to the `x86_64` / `native` / `debug`
+  defaults;
+* `synthesise_self_bringup` writes `image: Default::default()`, so any consumer
+  switched to `[image.*]` loses its values for self-bringup packages;
+* `DEPRECATED_DEPLOY_FIELDS` now records a DESTINATION per field, because the
+  destination is not uniform — the first version sent `domain_id` and `locator`
+  to `[image.*]`, a table with no such keys.
+
+## Trap for whoever does the build half
+
+`multi_board` in rlm is `deploy.values().any(|b| b.kind == "embedded")`, and it
+forces `target = None` for every placed node. Deleting the embedded blocks
+flips it to `false`, so a surviving `kind = "self"` block pins every node to
+`Some(Target::Linux)`. That is benign — both `keep()` implementations compute
+`board_mentioned` first, and a Linux-pinned model "mentions" only `native` and
+`posix`, so an embedded board short-circuits to keeping everything, which is
+the shape `examples/workspaces/features` already ships. The case to avoid is a
+surviving NON-embedded block that names an MCU board: that makes
+`board_mentioned` true and silently narrows every other board's entry to zero
+nodes (issues 0356 / 0358 / 0320). No such block exists in-tree today.
+
+## Verification used
+
+Models are the artifact that would show an accident, and `nros sync` is
+content-addressed — a plain sync serves a stale cache and reads as "no change".
+So: `rm -rf <ws>/build/nros/models && nros sync` across all 31 workspaces,
+before and after, then diff. For the site-config move the whole 456-line diff
+was `sha256:` provenance lines and nothing else, which is the expected result:
+site config is build environment and never reaches a SystemModel.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -68,5 +68,6 @@ fails if this block drifts.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
 - **#0939** (tooling) — The metadata probe links the node NAME, which is not a target — so every C/C++ component reports `no producer`, once, and then silently See `0939-*`.
 - **#0945** (build) — The shared-cargo-dir campaign rests on five unsupported build-system internals — a Corrosion path formula, an unstable cargo flag, cargo's private `.fingerprint` format, a side channel inside cargo's target dir, and an undocumented depfile location See `0945-*`.
+- **#0951** (orchestration, tooling) — `[deploy.*]` is three unrelated facts in one table — site config keyed on the deploy name, not the board, is the half that duplicates See `0951-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/examples/workspaces/c/src/demo_bringup/system.toml
+++ b/examples/workspaces/c/src/demo_bringup/system.toml
@@ -108,7 +108,7 @@ board = "nuttx-qemu-arm"
 [deploy.zephyr]
 kind = "embedded"
 
-# Issue 0939 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
+# Issue 0951 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
 # what it is built as comes from `[image.*]`. The old blocks carried
 # `kind`/`target`, which are build facts: per-host models are board-agnostic
 # and each entry's own board supplies the target.
@@ -135,45 +135,6 @@ args   = { host = "robot1" }
 launch = "multihost.launch.xml"
 out    = "multihost_robot2_model.yaml"
 args   = { host = "robot2" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.threadx-linux.nros]
-netstack = "netxduo"
-sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.mps2-an385-freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-arm.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -246,3 +207,23 @@ board = "threadx-linux"
 [image.zephyr]
 board = "native_sim/native/64"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."threadx-linux"]
+netstack = "netxduo"
+sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }

--- a/examples/workspaces/cpp/src/demo_bringup/system.toml
+++ b/examples/workspaces/cpp/src/demo_bringup/system.toml
@@ -79,7 +79,7 @@ board = "threadx-linux"
 # `native_entry_robot{1,2}` consume those models via `nano_ros_entry(MODEL …)`.
 # The explicit `nodes = [..]` below places them — with `machine=` gone there is
 # no launch-derived placement fact, so every node needs a list entry.
-# Issue 0939 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
+# Issue 0951 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
 # what it is built as comes from `[image.*]`. The old blocks carried
 # `kind`/`target`, which are build facts: per-host models are board-agnostic
 # and each entry's own board supplies the target.
@@ -131,31 +131,6 @@ args   = { host = "robot1" }
 launch = "multihost.launch.xml"
 out    = "multihost_robot2_model.yaml"
 args   = { host = "robot2" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.threadx-linux.nros]
-netstack = "netxduo"
-sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.mps2-an385-freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -226,3 +201,17 @@ board = "threadx-linux"
 [image.zephyr]
 board = "native_sim/native/64"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."threadx-linux"]
+netstack = "netxduo"
+sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }

--- a/examples/workspaces/mixed/src/demo_bringup/system.toml
+++ b/examples/workspaces/mixed/src/demo_bringup/system.toml
@@ -60,7 +60,7 @@ board = "threadx-linux"
 # `native_entry_robot{1,2}` consume those models via `nano_ros_entry(MODEL …)`.
 # The explicit `nodes = [..]` below places them — with `machine=` gone there is
 # no launch-derived placement fact, so every node needs a list entry.
-# Issue 0939 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
+# Issue 0951 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
 # what it is built as comes from `[image.*]`. The old blocks carried
 # `kind`/`target`, which are build facts: per-host models are board-agnostic
 # and each entry's own board supplies the target.
@@ -104,31 +104,6 @@ args   = { host = "robot1" }
 launch = "multihost.launch.xml"
 out    = "multihost_robot2_model.yaml"
 args   = { host = "robot2" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.threadx-linux.nros]
-netstack = "netxduo"
-sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.mps2-an385-freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -176,3 +151,17 @@ board = "threadx-linux"
 [image.zephyr]
 board = "native_sim/native/64"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."threadx-linux"]
+netstack = "netxduo"
+sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }

--- a/examples/workspaces/realtime-c/src/demo_bringup/system.toml
+++ b/examples/workspaces/realtime-c/src/demo_bringup/system.toml
@@ -142,44 +142,6 @@ kind = "embedded"
 [deploy.mps2-an385-freertos]
 kind = "embedded"
 board = "mps2-an385-freertos"
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-arm.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-riscv.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.mps2-an385-freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -201,3 +163,22 @@ board = "nuttx-qemu-riscv"
 [image.zephyr]
 board = "native_sim/native/64"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-riscv"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }

--- a/examples/workspaces/realtime-c/src/smp_bringup/system.toml
+++ b/examples/workspaces/realtime-c/src/smp_bringup/system.toml
@@ -162,44 +162,6 @@ kind = "embedded"
 [deploy.mps2-an385-freertos]
 kind = "embedded"
 board = "mps2-an385-freertos"
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-arm.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-riscv.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.mps2-an385-freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -221,3 +183,22 @@ board = "nuttx-qemu-riscv"
 [image.zephyr]
 board = "native_sim/native/64"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-riscv"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }

--- a/examples/workspaces/realtime-cpp/src/demo_bringup/system.toml
+++ b/examples/workspaces/realtime-cpp/src/demo_bringup/system.toml
@@ -191,44 +191,6 @@ out    = "subnode_system_model.yaml"
 [[model]]
 launch = "freertos_system.launch.xml"
 out    = "freertos_system_model.yaml"
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-arm.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx-qemu-riscv.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.mps2-an385-freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -268,3 +230,22 @@ board = "nuttx-qemu-riscv"
 board = "native_sim/native/64"
 entry = "zephyr_entry"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-riscv"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }

--- a/examples/workspaces/realtime-rust/src/demo_bringup/system.toml
+++ b/examples/workspaces/realtime-rust/src/demo_bringup/system.toml
@@ -178,3 +178,37 @@ board = "threadx-linux"
 [image.zephyr]
 board = "zephyr"
 conf = ["prj-zenoh.conf"]
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951). Generated
+# from `just/sdk-env.just`; this gate keeps the two in step. `{env:…}`
+# rather than a literal so the value survives a second checkout.
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951). Generated
+# from `just/sdk-env.just`; this gate keeps the two in step. `{env:…}`
+# rather than a literal so the value survives a second checkout.
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951). Generated
+# from `just/sdk-env.just`; this gate keeps the two in step. `{env:…}`
+# rather than a literal so the value survives a second checkout.
+[board_config."nuttx-qemu-riscv"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951). Generated
+# from `just/sdk-env.just`; this gate keeps the two in step. `{env:…}`
+# rather than a literal so the value survives a second checkout.
+[board_config."threadx-linux"]
+netstack = "netxduo"
+sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }

--- a/examples/workspaces/rust/src/demo_bringup/system.toml
+++ b/examples/workspaces/rust/src/demo_bringup/system.toml
@@ -89,7 +89,7 @@ board = "threadx-linux"
 kind = "embedded"
 board = "esp32-qemu"
 
-# Issue 0939 — these are MACHINES, so they live in `[host.*]` now. A host says
+# Issue 0951 — these are MACHINES, so they live in `[host.*]` now. A host says
 # WHERE a node runs; what it is built as comes from `[image.*]`. The old blocks
 # carried `target = "x86_64-unknown-linux-gnu"`, which is a build fact: the
 # per-host models are board-agnostic and each entry's own board supplies the
@@ -117,30 +117,6 @@ args   = { host = "robot1" }
 launch = "multihost.launch.xml"
 out    = "multihost_robot2_model.yaml"
 args   = { host = "robot2" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.freertos.nros]
-netstack = "lwip"
-sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.nuttx.nros]
-sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
-
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.threadx-linux.nros]
-netstack = "netxduo"
-sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }
-
 # --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
 # Derived from the entry packages that existed at migration time; each
 # entry's `deploy` token picked its board, and its `launch` its topology.
@@ -233,3 +209,23 @@ entry = "zephyr_entry_robot1"
 conf = ["prj-zenoh.conf"]
 launch = "multihost.launch.xml"
 args = { host = "robot1" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }
+
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."threadx-linux"]
+netstack = "netxduo"
+sdk = { threadx = "{env:THREADX_DIR}", netxduo = "{env:NETX_DIR}" }

--- a/packages/cli/nros-cli-core/src/cmd/board_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/board_facts.rs
@@ -2,7 +2,7 @@
 //!
 //! [RFC-0072](../../../../../docs/design/0072-rtos-integration-nano-ros-is-a-guest.md)
 //! §5 splits board information into A (board facts, in the board package), B
-//! (site config, in the user's `[deploy.<name>.nros]`) and C (test harness).
+//! (site config, in the user's `[board_config.<board>]`) and C (test harness).
 //! W1–W4 gave both halves a home and a validity domain. This is DELIVERY: the
 //! resolved pair, printed in one shape, for whoever is about to invoke cargo.
 //!
@@ -66,15 +66,15 @@ pub fn resolve(
     board: Option<&str>,
     env: &dyn Fn(&str) -> Option<String>,
 ) -> Result<BTreeMap<String, String>> {
-    // Several deploy blocks may name the SAME board — `examples/workspaces/mixed`
-    // has `[deploy.freertos]` and `[deploy.mps2-an385-freertos]`, both on
-    // `mps2-an385-freertos`. That is only ambiguous if they RESOLVE differently:
-    // the caller asked what this board builds with, and two blocks agreeing on
-    // the answer are one answer. Refuse only when they actually disagree.
-    let candidates = pick_deploys(ws, deploy, board)?;
+    // Several blocks may be in scope when the caller named neither a deploy
+    // nor a board. Two naming the SAME board can no longer disagree — the site
+    // table is keyed by board (issue 0951) — so what survives here is the
+    // genuinely ambiguous case: blocks on DIFFERENT boards, where answering
+    // with either one would hand the build another board's SDK roots.
+    let (candidates, site, origin) = pick_deploys(ws, deploy, board)?;
     let mut resolved: Vec<(String, BTreeMap<String, String>)> = Vec::new();
     for (name, target) in candidates {
-        let facts = resolve_one(ws, nano_ros_root, &name, &target, env)?;
+        let facts = resolve_one(&origin, nano_ros_root, &name, &target, &site, env)?;
         resolved.push((name, facts));
     }
     if let Some((first_name, first)) = resolved.first()
@@ -89,8 +89,8 @@ pub fn resolve(
             .cloned()
             .collect();
         return Err(eyre!(
-            "deploys `{first_name}` and `{other_name}` name the same board but resolve \
-                 DIFFERENTLY ({}); pass --deploy to say which one this build is",
+            "deploys `{first_name}` and `{other_name}` resolve DIFFERENTLY ({}); \
+             pass --deploy or --board to say which one this build is",
             differing.join(", ")
         ));
     }
@@ -101,11 +101,30 @@ pub fn resolve(
         .ok_or_else(|| eyre!("{}: no [deploy.*] blocks", ws.display()))
 }
 
+/// Find the `[board_config.<key>]` block that describes `descriptor`.
+///
+/// The key is matched by RESOLUTION, not by text: `resolve_board` is the same
+/// rule `[deploy.*].board` and `[image.*].board` go through (issue 0606), so
+/// every legal spelling of one board finds the same block. Two keys resolving
+/// to one descriptor is an authoring mistake — it is the duplicate-fact shape
+/// this table exists to remove — so it is refused rather than silently
+/// order-dependent.
+fn site_for_board<'a>(
+    table: &'a BTreeMap<String, toml::Value>,
+    catalog: &BoardCatalog,
+    descriptor: &BoardDescriptor,
+) -> Option<(&'a String, &'a toml::Value)> {
+    table
+        .iter()
+        .find(|(key, _)| resolve_board(catalog, key).is_some_and(|d| d.source == descriptor.source))
+}
+
 fn resolve_one(
-    ws: &Path,
+    origin: &str,
     nano_ros_root: &Path,
     deploy_name: &str,
     target: &crate::orchestration::cargo_metadata_schema::DeployTarget,
+    site_table: &BTreeMap<String, toml::Value>,
     env: &dyn Fn(&str) -> Option<String>,
 ) -> Result<BTreeMap<String, String>> {
     let deploy_name = deploy_name.to_string();
@@ -124,9 +143,21 @@ fn resolve_one(
         )
     })?;
 
-    let site = match target.nros.as_ref() {
-        Some(v) => SiteConfig::from_value(v, &deploy_name, "system.toml")?,
-        None => SiteConfig::default(),
+    // The site block is keyed by BOARD (issue 0951), and a board has several
+    // legal spellings — the descriptor's `names`, its directory, its
+    // downstream framework id. Matching the key TEXTUALLY would make
+    // `[board_config."qemu-armv7a-nsh"]` invisible to a build that spelled the
+    // same board `nuttx-qemu-arm`, which is issue 0606 one table over. So
+    // resolve both sides through the catalog and compare DESCRIPTORS.
+    let (site_section, site) = match site_for_board(site_table, &catalog, descriptor) {
+        Some((key, value)) => {
+            let section = format!("board_config.{key}");
+            (
+                section.clone(),
+                SiteConfig::from_value(value, &section, origin)?,
+            )
+        }
+        None => (format!("board_config.{board_name}"), SiteConfig::default()),
     };
 
     let mut out = BTreeMap::new();
@@ -152,19 +183,18 @@ fn resolve_one(
         out.insert("NROS_NETSTACK".into(), stack.to_string());
     }
 
-    let origin = format!("{}: [deploy.{deploy_name}.nros]", ws.display());
     for (name, raw) in &site.sdk {
-        let r = site.interpolate(raw, &deploy_name, &origin, env)?;
+        let r = site.interpolate(raw, &site_section, origin, env)?;
         out.insert(format!("NROS_SDK_{}", env_key(name)), r.value);
     }
     for (role, raw) in &site.config_files {
-        let r = site.interpolate(raw, &deploy_name, &origin, env)?;
+        let r = site.interpolate(raw, &site_section, origin, env)?;
         out.insert(format!("NROS_CONFIG_FILE_{}", env_key(role)), r.value);
     }
     if !site.include_dirs.is_empty() {
         let mut dirs = Vec::new();
         for raw in &site.include_dirs {
-            dirs.push(site.interpolate(raw, &deploy_name, &origin, env)?.value);
+            dirs.push(site.interpolate(raw, &site_section, origin, env)?.value);
         }
         out.insert("NROS_INCLUDE_DIRS".into(), dirs.join(";"));
     }
@@ -172,7 +202,7 @@ fn resolve_one(
         out.insert("NROS_DEFINES".into(), site.defines.join(";"));
     }
     for (key, raw) in &site.upload {
-        let r = site.interpolate(raw, &deploy_name, &origin, env)?;
+        let r = site.interpolate(raw, &site_section, origin, env)?;
         out.insert(format!("NROS_UPLOAD_{}", env_key(key)), r.value);
     }
     Ok(out)
@@ -256,14 +286,20 @@ fn deploys_from_manifest(ws: &Path) -> Result<Option<Vec<PickedDeploy>>> {
     Ok(Some(vec![(deploy_key, target)]))
 }
 
-fn pick_deploys(ws: &Path, deploy: Option<&str>, board: Option<&str>) -> Result<Vec<PickedDeploy>> {
+/// The picked deploys, the site table to resolve them against, and the file
+/// that supplied both (for error text).
+type Picked = (Vec<PickedDeploy>, BTreeMap<String, toml::Value>, String);
+
+fn pick_deploys(ws: &Path, deploy: Option<&str>, board: Option<&str>) -> Result<Picked> {
     // A standalone leaf first: it has a Cargo.toml and no bringup, and asking
     // for a system.toml there would fail naming a file that is not supposed to
-    // exist.
+    // exist. Such a leaf carries no site table — it gets the board rung only.
     if let Some(from_manifest) = deploys_from_manifest(ws)? {
-        return Ok(from_manifest);
+        return Ok((from_manifest, BTreeMap::new(), ws.display().to_string()));
     }
     let (path, system) = load_system_toml(ws)?;
+    let origin = path.display().to_string();
+    let site = system.board_config.clone();
     let mut candidates: Vec<(String, _)> = system.deploy.into_iter().collect();
     if let Some(want) = deploy {
         candidates.retain(|(k, _)| k == want);
@@ -282,7 +318,7 @@ fn pick_deploys(ws: &Path, deploy: Option<&str>, board: Option<&str>) -> Result<
     if candidates.is_empty() {
         return Err(eyre!("{}: no [deploy.*] blocks", path.display()));
     }
-    Ok(candidates)
+    Ok((candidates, site, origin))
 }
 
 fn load_system_toml(
@@ -384,7 +420,7 @@ domain_id = 0
 board = "mps2-an385-freertos"
 rmw = "zenoh"
 
-[deploy.freertos.nros]
+[board_config."mps2-an385-freertos"]
 netstack = "lwip"
 sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
 "#;
@@ -442,16 +478,18 @@ sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
         assert!(format!("{err:#}").contains("FREERTOS_DIR"), "{err:#}");
     }
 
-    /// Two deploy blocks on the same board are ONE answer when they resolve the
-    /// same — `examples/workspaces/mixed` ships exactly that pair, and refusing
-    /// it would block every cmake build of that workspace over a distinction
-    /// with no consequence.
+    /// Two deploy blocks on the same board are ONE answer — `examples/workspaces/mixed`
+    /// ships exactly that pair, and refusing it would block every cmake build of
+    /// that workspace over a distinction with no consequence.
+    ///
+    /// Under a board-keyed site table they cannot even differ: both reach the
+    /// same `[board_config.*]` block. This used to need a per-block site table
+    /// on each deploy, which is the duplication issue 0951 removed.
     #[test]
     fn duplicate_deploys_that_agree_are_not_ambiguous() {
         let ws = ws_with(&format!(
             "{FREERTOS_WS}\n[deploy.mps2-an385-freertos]\nboard = \"mps2-an385-freertos\"\n\
-             rmw = \"zenoh\"\n\n[deploy.mps2-an385-freertos.nros]\nnetstack = \"lwip\"\n\
-             sdk = {{ freertos = \"{{env:FREERTOS_DIR}}\", lwip = \"{{env:LWIP_DIR}}\" }}\n"
+             rmw = \"zenoh\"\n"
         ));
         let env = |k: &str| match k {
             "FREERTOS_DIR" => Some("/opt/freertos".to_string()),
@@ -469,69 +507,101 @@ sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
         assert_eq!(facts.get("NROS_NETSTACK").map(String::as_str), Some("lwip"));
     }
 
-    /// …and DISAGREEING duplicates are refused, naming the keys that differ —
-    /// that is the case where picking one silently would build the wrong thing.
+    /// …and DISAGREEING duplicates are no longer REFUSED — they are
+    /// UNREPRESENTABLE.
+    ///
+    /// Two deploy blocks naming one board used to carry a site table each, so
+    /// they could state different SDK roots for the same hardware; `resolve`
+    /// compared the resolutions and refused a conflict. Keying the table by
+    /// board deletes the shape instead of detecting it, which is why the
+    /// agree/disagree comparison in `resolve` now has nothing to catch. This
+    /// test is what says that is deliberate rather than a lost check.
     #[test]
-    fn duplicate_deploys_that_disagree_are_refused() {
+    fn two_deploys_on_one_board_cannot_disagree() {
         let ws = ws_with(&format!(
-            "{FREERTOS_WS}\n[deploy.other]\nboard = \"mps2-an385-freertos\"\n\
-             rmw = \"zenoh\"\n\n[deploy.other.nros]\nnetstack = \"lwip\"\n\
-             sdk = {{ freertos = \"/elsewhere\", lwip = \"{{env:LWIP_DIR}}\" }}\n"
+            "{FREERTOS_WS}\n[deploy.other]\nboard = \"mps2-an385-freertos\"\nrmw = \"zenoh\"\n"
         ));
         let env = |k: &str| match k {
             "FREERTOS_DIR" => Some("/opt/freertos".to_string()),
             "LWIP_DIR" => Some("/opt/lwip".to_string()),
             _ => None,
         };
-        let err = resolve(
+        let by_board = resolve(
             ws.path(),
             &repo_root(),
             None,
             Some("mps2-an385-freertos"),
             &env,
         )
-        .expect_err("two different SDK roots for one board");
-        let msg = format!("{err:#}");
-        assert!(msg.contains("NROS_SDK_FREERTOS"), "{msg}");
-        assert!(msg.contains("--deploy"), "{msg}");
+        .expect("one board, one answer");
+        let by_name =
+            resolve(ws.path(), &repo_root(), Some("other"), None, &env).expect("named deploy");
+        assert_eq!(by_board, by_name, "the board decides, not the deploy key");
+        assert_eq!(
+            by_board.get("NROS_SDK_FREERTOS").map(String::as_str),
+            Some("/opt/freertos")
+        );
     }
 
-    /// issue 0755 — the ambiguity the previous test proves is REFUSABLE is
-    /// also RESOLVABLE, by naming the deploy. That is the whole point of
-    /// threading `--deploy` from the cmake wrapper: the entry knows which
-    /// deploy this build is, and without it a multi-deploy `system.toml`
-    /// (one bringup, deploys for posix + fvp + hardware) turns board facts
-    /// into a silent skip.
+    /// issue 0755 — `--deploy` still selects, but among DIFFERENT BOARDS.
+    ///
+    /// That is what threading it from the cmake wrapper buys: one bringup with
+    /// deploys for posix + fvp + hardware turns board facts into a silent skip
+    /// without it. What it no longer arbitrates is two spellings of ONE board —
+    /// see `two_deploys_on_one_board_cannot_disagree`.
     #[test]
-    fn naming_the_deploy_resolves_what_the_board_alone_cannot() {
+    fn naming_the_deploy_picks_among_boards() {
         let ws = ws_with(&format!(
-            "{FREERTOS_WS}\n[deploy.other]\nboard = \"mps2-an385-freertos\"\n\
-             rmw = \"zenoh\"\n\n[deploy.other.nros]\nnetstack = \"lwip\"\n\
-             sdk = {{ freertos = \"/elsewhere\", lwip = \"{{env:LWIP_DIR}}\" }}\n"
+            "{FREERTOS_WS}\n[deploy.nuttx]\nboard = \"nuttx-qemu-arm\"\nrmw = \"zenoh\"\n\n\
+             [board_config.\"nuttx-qemu-arm\"]\n\
+             sdk = {{ nuttx = \"{{env:NUTTX_DIR}}\" }}\n"
         ));
         let env = |k: &str| match k {
             "FREERTOS_DIR" => Some("/opt/freertos".to_string()),
             "LWIP_DIR" => Some("/opt/lwip".to_string()),
+            "NUTTX_DIR" => Some("/opt/nuttx".to_string()),
             _ => None,
         };
-        // By board alone: refused (the previous test).
-        assert!(
-            resolve(
-                ws.path(),
-                &repo_root(),
-                None,
-                Some("mps2-an385-freertos"),
-                &env
-            )
-            .is_err()
-        );
-        // By deploy name: each one answers for itself.
-        let other = resolve(ws.path(), &repo_root(), Some("other"), None, &env)
+        let nuttx = resolve(ws.path(), &repo_root(), Some("nuttx"), None, &env)
             .expect("the named deploy resolves");
         assert_eq!(
-            other.get("NROS_SDK_FREERTOS").map(String::as_str),
-            Some("/elsewhere"),
-            "the named deploy's own SDK root, not the other one's"
+            nuttx.get("NROS_SDK_NUTTX").map(String::as_str),
+            Some("/opt/nuttx")
+        );
+        assert!(
+            nuttx.get("NROS_SDK_FREERTOS").is_none(),
+            "the other board's site block must not leak in: {nuttx:?}"
+        );
+    }
+
+    /// The site key is matched by RESOLUTION, not by text — a board has several
+    /// legal spellings and every one of them must find the same block. Keying
+    /// on the string is issue 0606 one table over: a block authored under the
+    /// descriptor's declared name would be invisible to a build spelling the
+    /// board by its directory.
+    #[test]
+    fn a_site_block_under_an_alias_spelling_still_resolves() {
+        let ws = ws_with(
+            r#"
+[system]
+name = "demo"
+rmw = "zenoh"
+domain_id = 0
+
+[deploy.freertos]
+board = "mps2-an385-freertos"
+
+[board_config.freertos]
+netstack = "lwip"
+sdk = { freertos = "/opt/freertos" }
+"#,
+        );
+        let facts = resolve(ws.path(), &repo_root(), None, None, &|_| None)
+            .expect("the `freertos` key names the same board as the directory spelling");
+        assert_eq!(facts.get("NROS_NETSTACK").map(String::as_str), Some("lwip"));
+        assert_eq!(
+            facts.get("NROS_SDK_FREERTOS").map(String::as_str),
+            Some("/opt/freertos")
         );
     }
 

--- a/packages/cli/nros-cli-core/src/cmd/new_system.rs
+++ b/packages/cli/nros-cli-core/src/cmd/new_system.rs
@@ -355,6 +355,7 @@ fn render_system_toml(pkg_name: &str, components: &[String]) -> Result<String> {
     );
 
     let model = SystemToml {
+        board_config: Default::default(),
         image,
         image_defaults: None,
         system: SystemHeader {

--- a/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
@@ -301,7 +301,7 @@ pub struct BoardCmake {
     pub toolchain_file: String,
 }
 
-/// phase-351 W4 — why a `[deploy.<name>.nros].netstack` was refused.
+/// phase-351 W4 — why a `[board_config.<board>].netstack` was refused.
 ///
 /// Both arms name what IS available, because the whole point of declaring the
 /// domain is that a user who picked outside it can see the edge.
@@ -363,7 +363,7 @@ impl BoardDescriptor {
     /// phase-351 W4 — the netstack this deploy will build with, or an error
     /// naming what the board actually supports.
     ///
-    /// `requested` is `[deploy.<name>.nros].netstack`. `None` takes the board's
+    /// `requested` is `[board_config.<board>].netstack`. `None` takes the board's
     /// first declared stack, which is why the list is ordered. A board that
     /// declares NO stacks makes no choice: naming one there is an error too,
     /// because silently ignoring it is how a deploy ends up believing it

--- a/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
@@ -551,7 +551,7 @@ pub struct SystemToml {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub deploy: BTreeMap<String, DeployTarget>,
     /// `[host.<name>]` — the machines, and the only thing that partitions
-    /// nodes (issue 0939).
+    /// nodes (issue 0951).
     ///
     /// The placement half of `[deploy.*]`, on its own terms. A host says WHERE
     /// a node runs; `[image.*]` says WHAT gets built. `[deploy.*]` conflated
@@ -587,6 +587,27 @@ pub struct SystemToml {
     /// back to [`SystemHeader`] as they always have.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_defaults: Option<ImageBlock>,
+    /// `[board_config.<board>]` — the SITE half of a board (RFC-0072 §5,
+    /// issue 0951).
+    ///
+    /// Keyed by BOARD, not by image or deploy name, because that is what the
+    /// fact is about. It was authored as `[deploy.<name>.nros]` until the 30
+    /// blocks in this tree were measured: they held exactly THREE distinct
+    /// value-sets over five boards, and the 25 duplicates existed only because
+    /// the deploy key was sometimes the friendly name (`freertos`) and
+    /// sometimes the board spelling (`mps2-an385-freertos`) — two keys for one
+    /// board, which is two places for one fact to drift.
+    ///
+    /// Keying by board also makes "two blocks disagree about one board"
+    /// unrepresentable rather than merely detected: `board_facts` used to
+    /// compare candidates and refuse a conflict, and that check now has
+    /// nothing to catch.
+    ///
+    /// The key is matched through the same `BoardCatalog::resolve_deploy`
+    /// rule every other board spelling uses (issue 0606), so an alias resolves
+    /// here exactly as it does everywhere else.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub board_config: BTreeMap<String, toml::Value>,
     #[serde(default, rename = "domain", skip_serializing_if = "Vec::is_empty")]
     pub domains: Vec<SystemDomainEntry>,
     #[serde(default, rename = "bridge", skip_serializing_if = "Vec::is_empty")]
@@ -1139,7 +1160,7 @@ pub struct SystemComponentEntry {
 /// One schema now; `deny_unknown_fields` lives on it, so the next divergence
 /// is a parse error rather than a dropped key.
 pub use ros_launch_manifest_model::system_config::DeployBlock as DeployTarget;
-/// `[host.<name>]` — a machine (issue 0939). Re-exported for the same reason
+/// `[host.<name>]` — a machine (issue 0951). Re-exported for the same reason
 /// `DeployTarget` is: the schema has one definition, upstream.
 pub use ros_launch_manifest_model::system_config::HostBlock as HostTarget;
 

--- a/packages/cli/nros-cli-core/src/orchestration/image.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/image.rs
@@ -697,21 +697,63 @@ entry_kind = "board-run"
     }
 }
 
-/// Build fields on an upstream `[deploy.<id>]` that `[image.<id>]` now owns
-/// (phase-383 W1.f).
+/// Fields on an upstream `[deploy.<id>]` that a nano-ros table now owns, each
+/// paired with WHERE it went (phase-383 W1.f, issue 0951).
 ///
 /// `kind`, `nodes` and `launch` are absent by design: those are PLACEMENT, they
 /// stay upstream's, and they are not being retired.
-pub const DEPRECATED_DEPLOY_BUILD_FIELDS: &[&str] = &[
-    "board",
-    "target",
-    "rmw",
-    "domain_id",
-    "locator",
-    "profile",
-    "optimize",
-    "features",
+///
+/// The destination is part of the datum because it is not uniform, and a lint
+/// that guesses one destination for every field sends people to a table with no
+/// such key. `domain_id` and `locator` are RUNTIME facts about a machine and
+/// live on `[host.<name>]`; `nros` is SITE config about a BOARD and lives on
+/// `[board_config.<board>]`; only the rest are build description.
+pub const DEPRECATED_DEPLOY_FIELDS: &[(&str, DeployFieldHome)] = &[
+    ("board", DeployFieldHome::Image),
+    ("target", DeployFieldHome::Image),
+    ("rmw", DeployFieldHome::Image),
+    ("profile", DeployFieldHome::Image),
+    ("optimize", DeployFieldHome::Image),
+    ("features", DeployFieldHome::Image),
+    ("domain_id", DeployFieldHome::Host),
+    ("locator", DeployFieldHome::Host),
+    ("nros", DeployFieldHome::BoardConfig),
 ];
+
+/// Which table a retired `[deploy.*]` field moved to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeployFieldHome {
+    /// `[image.<id>]` — build description, keyed by the same id.
+    Image,
+    /// `[host.<name>]` — a machine's runtime facts.
+    Host,
+    /// `[board_config.<board>]` — site config, keyed by BOARD.
+    BoardConfig,
+}
+
+impl DeployFieldHome {
+    fn destination(self, id: &str) -> String {
+        match self {
+            DeployFieldHome::Image => format!("`[image.{id}]`"),
+            DeployFieldHome::Host => format!("`[host.{id}]`"),
+            DeployFieldHome::BoardConfig => {
+                "`[board_config.<board>]`, keyed by the BOARD rather than by \
+                 this block's name"
+                    .to_string()
+            }
+        }
+    }
+
+    /// Whether a same-named `[image.<id>]` means this field has already moved.
+    ///
+    /// Only true for fields whose home IS that image. A site block is keyed by
+    /// board, so an image of the same name says nothing about whether the site
+    /// config was migrated — skipping on it would silence the one warning that
+    /// most needs to fire.
+    fn satisfied_by_image(self) -> bool {
+        matches!(self, DeployFieldHome::Image)
+    }
+}
 
 /// One deprecation warning per `[deploy.<id>]` still carrying build fields with
 /// no `[image.<id>]` beside it.
@@ -739,25 +781,31 @@ pub fn deprecated_deploy_build_field_warnings(
     }
     let mut out = Vec::new();
     for (id, present) in deploy_blocks {
-        if images.contains_key(id) {
-            continue;
+        let has_image = images.contains_key(id);
+        // Group by destination so one block yields one warning per table it
+        // must migrate into, not one per field.
+        let mut grouped: BTreeMap<String, Vec<&str>> = BTreeMap::new();
+        for field in present.iter().map(String::as_str) {
+            let Some((_, home)) = DEPRECATED_DEPLOY_FIELDS.iter().find(|(f, _)| *f == field) else {
+                continue;
+            };
+            if has_image && home.satisfied_by_image() {
+                continue;
+            }
+            grouped.entry(home.destination(id)).or_default().push(field);
         }
-        let mut hits: Vec<&str> = present
-            .iter()
-            .map(String::as_str)
-            .filter(|f| DEPRECATED_DEPLOY_BUILD_FIELDS.contains(f))
-            .collect();
-        if hits.is_empty() {
-            continue;
+        for (destination, mut hits) in grouped {
+            hits.sort_unstable();
+            out.push(format!(
+                "[deploy.{id}] carries {} — {} now owns {}. `[deploy.*]` keeps \
+                 PLACEMENT (kind / nodes / launch) — that half is upstream's \
+                 schema and is not being retired. Set \
+                 NROS_SUPPRESS_DEPRECATION=1 to silence.",
+                hits.join(", "),
+                destination,
+                if hits.len() == 1 { "it" } else { "them" },
+            ));
         }
-        hits.sort_unstable();
-        out.push(format!(
-            "[deploy.{id}] carries build field(s) {} — these move to \
-             `[image.{id}]`. `[deploy.*]` keeps PLACEMENT (kind / nodes / \
-             launch) — that half is upstream's schema and has no `[image.*]` \
-             counterpart. Set NROS_SUPPRESS_DEPRECATION=1 to silence.",
-            hits.join(", ")
-        ));
     }
     out
 }
@@ -783,6 +831,43 @@ mod deprecation_tests {
                 )
             })
             .collect()
+    }
+
+    /// The site block is keyed by BOARD, so a same-named `[image.<id>]` says
+    /// NOTHING about whether it was migrated. Skipping on the image's presence
+    /// would silence exactly the workspaces furthest along — the ones that have
+    /// images for everything and an unmigrated site table underneath.
+    #[test]
+    fn a_site_block_still_warns_when_a_same_named_image_exists() {
+        let mut images = BTreeMap::new();
+        images.insert("freertos".to_string(), ImageBlock::default());
+        let w = deprecated_deploy_build_field_warnings(
+            &blocks(&[("freertos", &["board", "nros"])]),
+            &images,
+            false,
+        );
+        assert_eq!(w.len(), 1, "the image satisfies `board`, not `nros`: {w:?}");
+        assert!(w[0].contains("nros"), "{}", w[0]);
+        assert!(w[0].contains("board_config"), "{}", w[0]);
+        assert!(
+            !w[0].contains("[image.freertos]"),
+            "must not send the reader to a table with no such key: {}",
+            w[0]
+        );
+    }
+
+    /// `domain_id` / `locator` are a machine's RUNTIME facts and live on
+    /// `[host.*]`. The first version of this list called them build fields, so
+    /// the warning named `[image.*]` — a table that has no such key.
+    #[test]
+    fn runtime_fields_point_at_the_host_table() {
+        let w = deprecated_deploy_build_field_warnings(
+            &blocks(&[("robot1", &["domain_id", "locator"])]),
+            &BTreeMap::new(),
+            false,
+        );
+        assert_eq!(w.len(), 1, "one destination, one warning: {w:?}");
+        assert!(w[0].contains("[host.robot1]"), "{}", w[0]);
     }
 
     #[test]
@@ -837,10 +922,26 @@ mod deprecation_tests {
 
     #[test]
     fn target_is_a_build_field_and_kind_is_not() {
-        assert!(DEPRECATED_DEPLOY_BUILD_FIELDS.contains(&"target"));
-        assert!(!DEPRECATED_DEPLOY_BUILD_FIELDS.contains(&"kind"));
-        assert!(!DEPRECATED_DEPLOY_BUILD_FIELDS.contains(&"nodes"));
-        assert!(!DEPRECATED_DEPLOY_BUILD_FIELDS.contains(&"launch"));
+        let field = |n: &str| DEPRECATED_DEPLOY_FIELDS.iter().find(|(f, _)| *f == n);
+        assert_eq!(
+            field("target").map(|(_, h)| *h),
+            Some(DeployFieldHome::Image)
+        );
+        // Placement stays upstream's and is not being retired.
+        assert!(field("kind").is_none());
+        assert!(field("nodes").is_none());
+        assert!(field("launch").is_none());
+        // The two fields that do NOT move to the image — a warning naming
+        // `[image.*]` for these would send the reader to a table with no such
+        // key.
+        assert_eq!(
+            field("domain_id").map(|(_, h)| *h),
+            Some(DeployFieldHome::Host)
+        );
+        assert_eq!(
+            field("nros").map(|(_, h)| *h),
+            Some(DeployFieldHome::BoardConfig)
+        );
     }
     #[test]
     fn a_launch_that_names_no_file_is_refused_with_the_alternatives() {

--- a/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
@@ -658,10 +658,11 @@ fn synthesise_self_bringup(comp: &ComponentPackageEntry) -> BringupPackageEntry 
     }
 
     let system = SystemToml {
+        board_config: Default::default(),
         system: system_header,
         components,
         deploy,
-        // Issue 0939 — a synthesised self-bringup declares no machines. It IS
+        // Issue 0951 — a synthesised self-bringup declares no machines. It IS
         // one machine by construction (the component package's own host), and
         // placement over a single implicit host is what the empty map already
         // means.

--- a/packages/cli/nros-cli-core/src/orchestration/site_config.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/site_config.rs
@@ -1,4 +1,10 @@
-//! phase-351 W1 — the SITE half of a deploy target.
+//! phase-351 W1 — the SITE half of a BOARD.
+//!
+//! It was the site half of a DEPLOY TARGET until issue 0951. Issue 0842 had
+//! already named that as a hazard in its title — "site config keys on deploy
+//! target, not board" — for a workspace with two FreeRTOS boards whose site
+//! block was reachable from the wrong one. Its root cause turned out to lie
+//! elsewhere, so the keying survived; this is the fix it described.
 //!
 //! [RFC-0072](../../../../../docs/design/0072-rtos-integration-nano-ros-is-a-guest.md)
 //! §5. Board information splits three ways:
@@ -10,8 +16,11 @@
 //!   network stack it chose, where its config headers are, how it flashes.
 //! * **C — test harness**: how *we* run a payload. Neither of the above.
 //!
-//! B lives in `[deploy.<name>.nros]` of the bringup's `system.toml` — the file
-//! that already carries `[deploy.<name>]`, 59 blocks across this tree. No new
+//! B lives in `[board_config.<board>]` of the bringup's `system.toml`. It is
+//! keyed by BOARD because that is what the fact is about: 30 authored blocks
+//! held exactly 3 distinct value-sets, and the 25 duplicates existed only
+//! because the old `[deploy.<name>.nros]` key was sometimes the friendly name
+//! and sometimes the board spelling (issue 0951). No new
 //! file: a second location would undercut the one-file debuggability the split
 //! exists to provide.
 //!
@@ -25,7 +34,7 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
-/// `[deploy.<name>.nros]` — the site half of one deploy target.
+/// `[board_config.<board>]` — the site half of one board.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SiteConfig {
@@ -88,8 +97,8 @@ pub struct SiteConfig {
 /// value came from only relocates the mystery. Mirrors RFC-0049's `KnobSource`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SiteSource {
-    /// A `[deploy.<name>.nros]` block.
-    Deploy,
+    /// An authored site block — `[board_config.<board>]`.
+    Config,
     /// Interpolated from the environment.
     Env,
 }
@@ -97,7 +106,7 @@ pub enum SiteSource {
 impl SiteSource {
     pub fn as_str(self) -> &'static str {
         match self {
-            SiteSource::Deploy => "deploy",
+            SiteSource::Config => "config",
             SiteSource::Env => "env",
         }
     }
@@ -114,10 +123,10 @@ pub struct Resolved {
 
 #[derive(Debug, thiserror::Error)]
 pub enum SiteError {
-    #[error("{origin}: [deploy.{deploy}.nros] is not valid: {source}")]
+    #[error("{origin}: [{section}] is not valid: {source}")]
     Parse {
         origin: String,
-        deploy: String,
+        section: String,
         /// Boxed because `toml::de::Error` is ~144 bytes on its own, which made
         /// every `Result<_, SiteError>` in this module trip clippy's
         /// `result_large_err` under rust 1.96. The error path is cold; the Ok
@@ -125,29 +134,29 @@ pub enum SiteError {
         source: Box<toml::de::Error>,
     },
     #[error(
-        "{origin}: [deploy.{deploy}.nros] refers to {reference}, which is not set.\n  \
+        "{origin}: [{section}] refers to {reference}, which is not set.\n  \
          `{{env:VAR}}` reads the environment; `{{sdk.NAME}}` reads a key of the same \
          block's `sdk` table."
     )]
     Unresolved {
         origin: String,
-        deploy: String,
+        section: String,
         reference: String,
     },
 }
 
 impl SiteConfig {
-    /// Parse the opaque `[deploy.<name>.nros]` value with nano-ros's schema.
+    /// Parse an authored site block with nano-ros's schema.
     ///
     /// `origin` is the `system.toml` path, carried only so an error names the
     /// file rather than the value.
-    pub fn from_value(value: &toml::Value, deploy: &str, origin: &str) -> Result<Self, SiteError> {
+    pub fn from_value(value: &toml::Value, section: &str, origin: &str) -> Result<Self, SiteError> {
         value
             .clone()
             .try_into::<SiteConfig>()
             .map_err(|source| SiteError::Parse {
                 origin: origin.to_string(),
-                deploy: deploy.to_string(),
+                section: section.to_string(),
                 source: Box::new(source),
             })
     }
@@ -159,7 +168,7 @@ impl SiteConfig {
     pub fn interpolate(
         &self,
         raw: &str,
-        deploy: &str,
+        section: &str,
         origin: &str,
         env: &dyn Fn(&str) -> Option<String>,
     ) -> Result<Resolved, SiteError> {
@@ -187,11 +196,11 @@ impl SiteConfig {
                         let (resolved, hit_env) =
                             resolve_env_only(v, env).ok_or_else(|| SiteError::Unresolved {
                                 origin: origin.to_string(),
-                                deploy: deploy.to_string(),
+                                section: section.to_string(),
                                 reference: v.clone(),
                             })?;
                         // An sdk value that itself reads the environment makes
-                        // the RESULT env-derived. Reporting `deploy` here would
+                        // the RESULT env-derived. Reporting `config` here would
                         // tell the reader the value is committed when it varies
                         // per machine — the opposite of what explain is for.
                         used_env |= hit_env;
@@ -210,7 +219,7 @@ impl SiteConfig {
             let Some(replacement) = replacement else {
                 return Err(SiteError::Unresolved {
                     origin: origin.to_string(),
-                    deploy: deploy.to_string(),
+                    section: section.to_string(),
                     reference: format!("{{{token}}}"),
                 });
             };
@@ -224,9 +233,9 @@ impl SiteConfig {
             source: if used_env {
                 SiteSource::Env
             } else {
-                SiteSource::Deploy
+                SiteSource::Config
             },
-            origin: format!("{origin} [deploy.{deploy}.nros]"),
+            origin: format!("{origin} [{section}]"),
         })
     }
 }
@@ -285,23 +294,33 @@ mod tests {
         let c = parse(r#"sdk = { freertos = "{env:FREERTOS_DIR}" }"#);
         let env = env_of(&[("FREERTOS_DIR", "/opt/freertos")]);
         let r = c
-            .interpolate("{sdk.freertos}/include", "freertos", "system.toml", &env)
+            .interpolate(
+                "{sdk.freertos}/include",
+                "board_config.mps2-an385-freertos",
+                "system.toml",
+                &env,
+            )
             .unwrap();
         assert_eq!(r.value, "/opt/freertos/include");
         assert_eq!(r.source, SiteSource::Env);
-        assert!(r.origin.contains("[deploy.freertos.nros]"));
+        assert!(r.origin.contains("[board_config.mps2-an385-freertos]"));
     }
 
-    /// A literal value is `deploy`-sourced, so `explain` can distinguish a
+    /// A literal value is `config`-sourced, so `explain` can distinguish a
     /// committed decision from a machine-dependent one.
     #[test]
-    fn a_literal_is_deploy_sourced() {
+    fn a_literal_is_config_sourced() {
         let c = parse(r#"netstack = "lwip""#);
         let env = env_of(&[]);
         let r = c
-            .interpolate("boards/mps2/lwipopts.h", "freertos", "system.toml", &env)
+            .interpolate(
+                "boards/mps2/lwipopts.h",
+                "board_config.mps2-an385-freertos",
+                "system.toml",
+                &env,
+            )
             .unwrap();
-        assert_eq!(r.source, SiteSource::Deploy);
+        assert_eq!(r.source, SiteSource::Config);
     }
 
     /// An unset reference must NAME what is missing. The failure this design
@@ -311,7 +330,12 @@ mod tests {
         let c = parse(r#"sdk = { cube = "{env:CUBE_PROJECT}" }"#);
         let env = env_of(&[]);
         let e = c
-            .interpolate("{sdk.cube}/Core/Inc", "nucleo", "my/system.toml", &env)
+            .interpolate(
+                "{sdk.cube}/Core/Inc",
+                "board_config.nucleo",
+                "my/system.toml",
+                &env,
+            )
             .unwrap_err()
             .to_string();
         assert!(e.contains("CUBE_PROJECT"), "got: {e}");

--- a/packages/core/nros-orchestration-ir/src/mapper_input.rs
+++ b/packages/core/nros-orchestration-ir/src/mapper_input.rs
@@ -92,7 +92,7 @@ fn node_paths_for(model: &SystemModel, fqn: &str, wcet: Option<&WcetProfile>) ->
             exec_ms: wcet.and_then(|w| w.exec_ms(path_ref)),
             inputs: pc.input.clone(),
             outputs: pc.output.clone(),
-            // Issue 0939's pin bump (rlm v0.1.11 -> v0.1.21) added these two.
+            // Issue 0951's pin bump (rlm v0.1.11 -> v0.1.21) added these two.
             // `None` is the correct value rather than a placeholder: nano-ros
             // authors neither a jitter budget nor a weakly-hard miss tolerance
             // today, and rlm treats `None` as UNDECLARED and says so — the same

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_nuttx/src/demo_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_nuttx/src/demo_bringup/system.toml
@@ -20,9 +20,8 @@ board = "qemu-armv7a-nsh"
 target = "armv7a-nuttx-eabihf"
 launch = "launch/system.launch.xml"
 
-# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS
-# checkout's SDKs live and which stack it uses. Generated from
-# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.
-# `{env:…}` rather than a literal so the value survives a second checkout.
-[deploy.qemu-arm-nuttx.nros]
+# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
+# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
+# name, because that is what the fact is about (issue 0951).
+[board_config."qemu-armv7a-nsh"]
 sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }

--- a/packages/testing/nros-tests/tests/multihost_partition_bake.rs
+++ b/packages/testing/nros-tests/tests/multihost_partition_bake.rs
@@ -172,7 +172,7 @@ fn per_host_resolves_partition_and_carry_their_binding() {
             );
         }
         // The placement SSOT still names this host — `[host.<host>]` since
-        // issue 0939, with an explicit `nodes = [..]` (with `machine=` gone
+        // issue 0951, with an explicit `nodes = [..]` (with `machine=` gone
         // there is no launch-derived placement fact). It was `[deploy.<host>]`
         // until the machine half moved out of that table.
         let system_toml = nros_tests::project_root().join(format!(

--- a/scripts/check-site-config.py
+++ b/scripts/check-site-config.py
@@ -97,6 +97,48 @@ def board_netstacks():
     return out
 
 
+def board_aliases():
+    """Every legal spelling of a board -> the BOARDS key it resolves to.
+
+    `[board_config.<key>]` is matched by RESOLUTION, not by text (issue 0951),
+    because a board has several legal spellings: the descriptor's `names`, its
+    directory, and the downstream framework id. The Rust side does this through
+    `BoardCatalog::resolve_deploy`; this is the same rule, so the gate and the
+    resolver cannot disagree about which block describes which board.
+
+    Resolution is per BOARD ENTRY, not per directory: `nros-board-nuttx/`
+    declares two distinct boards (`nuttx-qemu-arm` and `nuttx-qemu-riscv`), so
+    folding a directory's entries together would map both spellings onto
+    whichever one was seen first — two boards collapsed into one, with the
+    riscv site block silently answering for the arm build. The directory alias
+    is therefore only honoured when the directory holds exactly one entry.
+    """
+    out = {}
+    for path in sorted(glob.glob(os.path.join(ROOT, "packages/boards/*/nros-board.toml"))):
+        with open(path, "rb") as fh:
+            doc = tomllib.load(fh)
+        dir_name = os.path.basename(os.path.dirname(path))
+        from_dir = dir_name[len("nros-board-"):] if dir_name.startswith("nros-board-") else dir_name
+        entries = doc.get("board", [])
+        for entry in entries:
+            spellings = set(entry.get("names", []))
+            if len(entries) == 1:
+                spellings.add(from_dir)
+            # Canonicalise onto the BOARDS key when this board has one;
+            # otherwise onto its own first spelling, so a board with no SDK
+            # roots still RESOLVES (S1/S3 simply have nothing to say about it)
+            # rather than reading as an unknown name.
+            canonical = next(
+                (b for b in BOARDS if b in spellings),
+                min(spellings) if spellings else None,
+            )
+            if canonical is None:
+                continue
+            for sp in spellings:
+                out[sp] = canonical
+    return out
+
+
 def exported_vars():
     """Names `just/sdk-env.just` exports."""
     with open(SDK_ENV, encoding="utf-8") as fh:
@@ -113,14 +155,15 @@ def system_tomls():
     return sorted(out)
 
 
-def render_block(deploy, sdk_map, netstack):
+def render_block(board, sdk_map, netstack):
     lines = [
         "",
-        f"# phase-351 W2 — SITE config for this deploy (RFC-0072 §5): where THIS",
-        f"# checkout's SDKs live and which stack it uses. Generated from",
-        f"# `just/sdk-env.just`; `scripts/check-site-config.py` keeps them in step.",
-        f"# `{{env:…}}` rather than a literal so the value survives a second checkout.",
-        f"[deploy.{deploy}.nros]",
+        f"# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the",
+        f"# SDK roots it builds against. Keyed by BOARD, not by a deploy or image",
+        f"# name, because that is what the fact is about (issue 0951). Generated",
+        f"# from `just/sdk-env.just`; this gate keeps the two in step. `{{env:…}}`",
+        f"# rather than a literal so the value survives a second checkout.",
+        f'[board_config."{board}"]',
     ]
     if netstack:
         lines.append(f'netstack = "{netstack}"')
@@ -139,6 +182,7 @@ def main():
     if not exported:
         sys.exit("check-site-config: no exports found in just/sdk-env.just")
 
+    aliases = board_aliases()
     problems, wrote, checked = [], 0, 0
 
     for path in system_tomls():
@@ -150,42 +194,75 @@ def main():
                 problems.append(f"{rel}: not valid TOML: {e}")
                 continue
 
-        missing = []
-        for name, blk in (doc.get("deploy") or {}).items():
-            board = blk.get("board")
-            if board not in BOARDS:
+        # Which boards does this file build for? Any board a deploy or an image
+        # names. `[image.*]` is the buildable unit now (RFC-0065 D6), so a
+        # workspace that has finished migrating off `[deploy.*]` still needs its
+        # SDK roots checked.
+        in_scope = {}
+        for table in ("deploy", "image"):
+            for name, blk in (doc.get(table) or {}).items():
+                board = aliases.get(blk.get("board"))
+                if board is not None:
+                    in_scope.setdefault(board, f"[{table}.{name}]")
+        # Only boards with SDK roots to declare are MISSING a block when they
+        # have none; the rest are merely in scope, so a site block for them is
+        # legitimate rather than dead.
+        needs_roots = {b: c for b, c in in_scope.items() if b in BOARDS}
+
+        site_blocks = doc.get("board_config") or {}
+        # Resolve the authored keys the same way the Rust side does.
+        by_board = {}
+        for key, val in site_blocks.items():
+            board = aliases.get(key)
+            if board is None:
+                problems.append(
+                    f"{rel}: [board_config.{key!r}] names no known board — "
+                    f"the key is a board spelling, resolved like every other "
+                    f"`board = ` value"
+                )
                 continue
-            checked += 1
+            if board in by_board:
+                problems.append(
+                    f"{rel}: two [board_config.*] blocks resolve to board "
+                    f"`{board}` — one board, one block"
+                )
+                continue
+            by_board[board] = (key, val)
+
+        missing = []
+        for board, cited_by in sorted(needs_roots.items()):
             sdk_map = BOARDS[board]
             stacks = netstacks.get(board, [])
-            site = blk.get("nros")
-
-            if site is None:
-                missing.append((name, sdk_map, stacks[0] if stacks else None))
+            found = by_board.get(board)
+            if found is None:
+                missing.append((board, sdk_map, stacks[0] if stacks else None))
                 continue
+            key, site = found
+            checked += 1
+            section = f"board_config.{key}"
 
             # S1 — every needed root declared, and as {env:VAR}
             declared = site.get("sdk") or {}
-            for key, var in sdk_map.items():
-                got = declared.get(key)
+            for sdk_key, var in sdk_map.items():
+                got = declared.get(sdk_key)
                 if got is None:
                     problems.append(
-                        f"{rel}: [deploy.{name}.nros].sdk is missing `{key}` "
+                        f"{rel}: [{section}].sdk is missing `{sdk_key}` "
                         f"(board `{board}` needs it; expected \"{{env:{var}}}\")"
                     )
                 elif got != f"{{env:{var}}}":
                     problems.append(
-                        f"{rel}: [deploy.{name}.nros].sdk.{key} = {got!r}, expected "
+                        f"{rel}: [{section}].sdk.{sdk_key} = {got!r}, expected "
                         f'"{{env:{var}}}" — a literal path does not survive a '
                         f"second checkout"
                     )
 
             # S2 — every referenced var is really exported
-            for key, val in declared.items():
+            for sdk_key, val in declared.items():
                 for var in re.findall(r"\{env:([A-Z0-9_]+)\}", str(val)):
                     if var not in exported:
                         problems.append(
-                            f"{rel}: [deploy.{name}.nros].sdk.{key} names ${var}, "
+                            f"{rel}: [{section}].sdk.{sdk_key} names ${var}, "
                             f"which just/sdk-env.just does not export — renamed?"
                         )
 
@@ -195,23 +272,32 @@ def main():
             want = site.get("netstack")
             if want is not None and want not in stacks:
                 problems.append(
-                    f"{rel}: [deploy.{name}.nros].netstack = {want!r}, which board "
+                    f"{rel}: [{section}].netstack = {want!r}, which board "
                     f"`{board}` does not support. Its descriptor declares: "
                     + (", ".join(stacks) if stacks else
                        "NONE (its RTOS or host owns the stack — drop the key)")
                 )
 
+        # S4 — a site block for a board this file never builds is dead config:
+        # nothing resolves it, so a wrong value in it is invisible.
+        for board, (key, _) in sorted(by_board.items()):
+            if board not in in_scope:
+                problems.append(
+                    f"{rel}: [board_config.{key}] describes a board no "
+                    f"[deploy.*] or [image.*] in this file targets"
+                )
+
         if missing and args.write:
             with open(path, "a", encoding="utf-8") as fh:
-                for name, sdk_map, netstack in missing:
-                    fh.write(render_block(name, sdk_map, netstack))
+                for board, sdk_map, netstack in missing:
+                    fh.write(render_block(board, sdk_map, netstack))
                     wrote += 1
         elif missing:
-            for name, _, _ in missing:
+            for board, _, _ in missing:
                 problems.append(
-                    f"{rel}: [deploy.{name}] targets a board needing SDK roots but "
-                    f"has no [deploy.{name}.nros] block — run "
-                    f"`python3 scripts/check-site-config.py --write`"
+                    f"{rel}: {needs_roots[board]} targets board `{board}`, which needs "
+                    f"SDK roots, but the file has no [board_config.\"{board}\"] "
+                    f"block — run `python3 scripts/check-site-config.py --write`"
                 )
 
     if args.write:
@@ -225,7 +311,7 @@ def main():
         return 1
 
     print(
-        f"site config: OK ({checked} deploy block(s) across {len(BOARDS)} board(s) "
+        f"site config: OK ({checked} board_config block(s) across {len(BOARDS)} board(s) "
         f"agree with just/sdk-env.just; netstacks inside the domain declared by "
         f"{len(netstacks)} board name(s))"
     )


### PR DESCRIPTION
`[deploy.<name>]` carries three unrelated facts, and each wants a different key: placement is about a MACHINE, build description about an IMAGE, site config about a BOARD. One table, three keys, so two of the three are always keyed wrong.

The site half is the one that duplicates, measurably: **30 authored `[deploy.<n>.nros]` blocks across 8 files held exactly THREE distinct value-sets.**

```
13 blocks  {netstack=lwip,    sdk={freertos,lwip}}     mps2-an385-freertos
13 blocks  {                  sdk={nuttx,nuttx_apps}}  nuttx-qemu-arm, nuttx-qemu-riscv, qemu-armv7a-nsh
 4 blocks  {netstack=netxduo, sdk={threadx,netxduo}}   threadx-linux
```

The 25 duplicates existed only because the deploy key is sometimes the friendly name (`[deploy.freertos.nros]`) and sometimes the board spelling (`[deploy.mps2-an385-freertos.nros]`). Issue 0842 named this in its title; its root cause turned out to lie elsewhere, so the keying survived the fix.

## Change

`[board_config.<board>]`, holding the existing `SiteConfig`. The key resolves through `BoardCatalog::resolve_deploy` — the same rule every other board spelling goes through (issue 0606) — so an alias finds the block exactly as it does everywhere else. 30 blocks became 20.

Two blocks disagreeing about one board is now **unrepresentable** rather than detected. `two_deploys_on_one_board_cannot_disagree` is what says that is deliberate rather than a lost check; `board_facts`'s comparison still fires for the genuinely ambiguous case (blocks on *different* boards when the caller named neither).

## Two defects found on the way

- The gate only looked at `[deploy.*]`, so `examples/workspaces/realtime-rust` — four embedded images, no deploy blocks naming their boards — **was never checked and declared no SDK roots at all.** It now reads `[image.*]` too; the generator wrote the four missing blocks.
- `DEPRECATED_DEPLOY_BUILD_FIELDS` listed `domain_id`/`locator` as build fields, so the warning told users to move them to `[image.*]` — a table with no such keys. The list now records a DESTINATION per field (`Image`/`Host`/`BoardConfig`). A site block also warns even when a same-named image exists: the image satisfies `board`, never `nros`.

## Verification

Models are what would show an accident, and `nros sync` is content-addressed — a plain sync serves a stale cache and reads as "no change". So `rm -rf <ws>/build/nros/models && nros sync` across all 31 workspaces, before and after. **The whole 456-line diff is `sha256:` provenance and nothing else**, the expected result: site config is build environment and never reaches a SystemModel.

Six negative controls on the gate, each confirmed to fire: literal path, missing SDK root, netstack outside the board's domain, block for an untargeted board, two keys resolving to one board, missing block for a targeted board.

`just ci-l1` green; `just check fast` 146/146.

Also corrects the issue number — 70297f148 cited `#0939` in its title, which is an unrelated metadata-probe bug. 0951 is the reserved id.

Follow-up (tracked in the issue): the build half — 42 `kind = "embedded"` blocks to `[image.*]`, plus the readers that still consult `[deploy.*]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG