### PR TITLE
feat(#0951): the per-target readers resolve `[image.*]` first

### DIFF
--- a/docs/issues/0951-site-config-keys-on-deploy-not-board.md
+++ b/docs/issues/0951-site-config-keys-on-deploy-not-board.md
@@ -94,6 +94,38 @@ Still open — the build half:
   destination is not uniform — the first version sent `domain_id` and `locator`
   to `[image.*]`, a table with no such keys.
 
+Found by an audit of every remaining `[deploy.*]` reader, and NOT yet fixed:
+
+* **`resolved_domain_id` / `resolved_locator` never read `[host.*]`.** The
+  deprecation lint tells users to move `domain_id` and `locator` there, and
+  `SystemToml::host` then has ZERO production readers in this repo — only the
+  upstream rlm placement resolver consumes it. A user who follows the lint's own
+  advice gets the `[system]` default silently baked into firmware
+  (`NROS_SYSTEM_DOMAIN_ID`). No in-tree fixture misbehaves today, because
+  nothing authors either key outside `[system]`; it is a hole the lint opened by
+  pointing at a table nobody reads. The wrinkle to solve first: `resolve_target`
+  returns an IMAGE id while `[host.*]` is keyed by MACHINE name, and the link
+  between them is the image's `args.host` binding — so a plain
+  `self.host.get(t)` would be wrong too.
+* **`nros new --deploy` still scaffolds into the retiring table.**
+  `scaffold_deploy.rs` writes `board` and `target` into `[deploy.<name>]` —
+  exactly the two fields the lint measured as actually firing — so the
+  scaffolder emits a workspace that immediately trips its own deprecation
+  warning and whose board is invisible to the image rungs. `--from-profile` can
+  only fork a `[deploy.*]`, never an `[image.*]`.
+
+Confirmed DEAD by the same audit (authored nowhere in the tree, and in the
+first two cases unauthorable, since upstream's `DeployBlock` is
+`deny_unknown_fields`):
+
+* `doctor::check_deprecated_verbs` — scans `[deploy.*]` blocks for `build` /
+  `package` shell-step arrays. Zero such keys exist and none could parse.
+* `rtos_realizer::sched_caps_from_deploy` + `derive.rs` — read `edf` / `cores`
+  from the resolved IR's deploy extras. `system.toml` cannot feed them.
+  `scripts/gen-sched-matrix.py` nonetheless generates documentation asserting
+  `[deploy.<board>] edf = <bool>` is a supported knob; the syntax it shows would
+  be a hard parse error.
+
 ## Trap for whoever does the build half
 
 `multi_board` in rlm is `deploy.values().any(|b| b.kind == "embedded")`, and it

--- a/packages/cli/nros-cli-core/src/cmd/board_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/board_facts.rs
@@ -633,7 +633,7 @@ sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
             Some("/opt/nuttx")
         );
         assert!(
-            nuttx.get("NROS_SDK_FREERTOS").is_none(),
+            !nuttx.contains_key("NROS_SDK_FREERTOS"),
             "the other board's site block must not leak in: {nuttx:?}"
         );
     }

--- a/packages/cli/nros-cli-core/src/cmd/board_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/board_facts.rs
@@ -71,10 +71,10 @@ pub fn resolve(
     // table is keyed by board (issue 0951) — so what survives here is the
     // genuinely ambiguous case: blocks on DIFFERENT boards, where answering
     // with either one would hand the build another board's SDK roots.
-    let (candidates, site, origin) = pick_deploys(ws, deploy, board)?;
+    let (candidates, site, origin) = pick_deploys(ws, nano_ros_root, deploy, board)?;
     let mut resolved: Vec<(String, BTreeMap<String, String>)> = Vec::new();
-    for (name, target) in candidates {
-        let facts = resolve_one(&origin, nano_ros_root, &name, &target, &site, env)?;
+    for (name, board) in candidates {
+        let facts = resolve_one(&origin, nano_ros_root, &name, &board, &site, env)?;
         resolved.push((name, facts));
     }
     if let Some((first_name, first)) = resolved.first()
@@ -101,6 +101,19 @@ pub fn resolve(
         .ok_or_else(|| eyre!("{}: no [deploy.*] blocks", ws.display()))
 }
 
+/// Do two spellings name the SAME board?
+///
+/// Compared by `names`, which is per-ENTRY, and NOT by `source`, which is the
+/// descriptor FILE. `packages/boards/nros-board-nuttx/nros-board.toml` declares
+/// two distinct boards — `nuttx-qemu-arm` and `nuttx-qemu-riscv` — so a
+/// file-level compare answers "yes" for two boards that differ in ISA, and
+/// `--board nuttx-qemu-riscv` silently resolves the arm board's facts. That is
+/// the same collapse `check-site-config.py`'s alias map has to avoid, and it is
+/// worth stating in both places: a directory is not a board.
+fn same_board(a: &BoardDescriptor, b: &BoardDescriptor) -> bool {
+    a.names == b.names
+}
+
 /// Find the `[board_config.<key>]` block that describes `descriptor`.
 ///
 /// The key is matched by RESOLUTION, not by text: `resolve_board` is the same
@@ -116,22 +129,19 @@ fn site_for_board<'a>(
 ) -> Option<(&'a String, &'a toml::Value)> {
     table
         .iter()
-        .find(|(key, _)| resolve_board(catalog, key).is_some_and(|d| d.source == descriptor.source))
+        .find(|(key, _)| resolve_board(catalog, key).is_some_and(|d| same_board(d, descriptor)))
 }
 
 fn resolve_one(
     origin: &str,
     nano_ros_root: &Path,
     deploy_name: &str,
-    target: &crate::orchestration::cargo_metadata_schema::DeployTarget,
+    board_name: &str,
     site_table: &BTreeMap<String, toml::Value>,
     env: &dyn Fn(&str) -> Option<String>,
 ) -> Result<BTreeMap<String, String>> {
     let deploy_name = deploy_name.to_string();
-    let board_name = target
-        .board
-        .clone()
-        .ok_or_else(|| eyre!("[deploy.{deploy_name}] names no `board`"))?;
+    let board_name = board_name.to_string();
 
     let catalog = BoardCatalog::load(nano_ros_root)
         .map_err(|e| eyre!("board catalog under {}: {e}", nano_ros_root.display()))?;
@@ -229,10 +239,14 @@ pub fn resolve_board<'a>(catalog: &'a BoardCatalog, board: &str) -> Option<&'a B
     }
 }
 
-type PickedDeploy = (
-    String,
-    crate::orchestration::cargo_metadata_schema::DeployTarget,
-);
+/// One candidate: the name it was selected by, and the board it resolves to.
+///
+/// A BOARD, not the whole block: since the site table became board-keyed
+/// (issue 0951) the board is the only thing `resolve_one` needs, and carrying
+/// the deploy block instead is what kept images invisible here — the board can
+/// come from `[image.<id>]` just as well, and in a migrated workspace that is
+/// the ONLY place it comes from.
+type PickedDeploy = (String, String);
 
 /// A STANDALONE leaf's deploy, from its `Cargo.toml`.
 ///
@@ -277,20 +291,25 @@ fn deploys_from_manifest(ws: &Path) -> Result<Option<Vec<PickedDeploy>>> {
             _ => return Ok(None),
         },
     };
-    let block = nros.get("deploy").and_then(|d| d.get(&deploy_key));
-    let target = crate::orchestration::cargo_metadata_schema::DeployTarget {
-        board: Some(deploy_key.to_string()),
-        nros: block.and_then(|b| b.get("nros")).cloned(),
-        ..Default::default()
-    };
-    Ok(Some(vec![(deploy_key, target)]))
+    // The deploy KEY is the board here, so the candidate is (key, key). The
+    // per-block `nros` sub-table this used to read is gone with issue 0951 —
+    // and it was already unreachable: `DeployTargetMetadata` is
+    // `deny_unknown_fields` and declares no such field, and no leaf manifest in
+    // the tree carries one.
+    let board = deploy_key.clone();
+    Ok(Some(vec![(deploy_key, board)]))
 }
 
 /// The picked deploys, the site table to resolve them against, and the file
 /// that supplied both (for error text).
 type Picked = (Vec<PickedDeploy>, BTreeMap<String, toml::Value>, String);
 
-fn pick_deploys(ws: &Path, deploy: Option<&str>, board: Option<&str>) -> Result<Picked> {
+fn pick_deploys(
+    ws: &Path,
+    nano_ros_root: &Path,
+    deploy: Option<&str>,
+    board: Option<&str>,
+) -> Result<Picked> {
     // A standalone leaf first: it has a Cargo.toml and no bringup, and asking
     // for a system.toml there would fail naming a file that is not supposed to
     // exist. Such a leaf carries no site table — it gets the board rung only.
@@ -300,23 +319,68 @@ fn pick_deploys(ws: &Path, deploy: Option<&str>, board: Option<&str>) -> Result<
     let (path, system) = load_system_toml(ws)?;
     let origin = path.display().to_string();
     let site = system.board_config.clone();
-    let mut candidates: Vec<(String, _)> = system.deploy.into_iter().collect();
+    // Candidates come from `[image.*]` AND `[deploy.*]`, because either can
+    // name the board and a migrated workspace has only the first. Reading
+    // deploys alone is what made `examples/workspaces/realtime-rust` — seven
+    // images, zero deploy blocks — unresolvable while its site table demanded
+    // SDK roots: the gate and this resolver disagreeing about which boards a
+    // workspace builds for.
+    //
+    // A name present in both tables is ONE candidate, with the image's board
+    // winning: mid-migration the two can disagree, and the image is the half
+    // that survives.
+    let mut boards: BTreeMap<String, String> = BTreeMap::new();
+    for (name, dt) in &system.deploy {
+        if let Some(b) = &dt.board {
+            boards.insert(name.clone(), b.clone());
+        }
+    }
+    for name in system.image.keys() {
+        if let Some(b) = system.image_for(name).and_then(|i| i.board) {
+            boards.insert(name.clone(), b);
+        }
+    }
+
+    let mut candidates: Vec<PickedDeploy> = boards.into_iter().collect();
     if let Some(want) = deploy {
         candidates.retain(|(k, _)| k == want);
         if candidates.is_empty() {
-            return Err(eyre!("{}: no [deploy.{want}]", path.display()));
+            return Err(eyre!(
+                "{}: no [image.{want}] or [deploy.{want}] naming a board",
+                path.display()
+            ));
         }
     } else if let Some(want) = board {
-        candidates.retain(|(_, t)| t.board.as_deref() == Some(want));
+        // Match by RESOLUTION, not by text. A board has several legal
+        // spellings, and which one an author used is not a fact about the
+        // build: `examples/workspaces/realtime-rust` writes `board =
+        // "freertos"` on its image while cmake passes the directory spelling
+        // `mps2-an385-freertos`, and `check-site-config` canonicalises both to
+        // the same block. A textual compare here makes the gate and the
+        // resolver disagree about which boards a workspace builds for — issue
+        // 0606's failure, one table over.
+        let catalog = BoardCatalog::load(nano_ros_root)
+            .map_err(|e| eyre!("board catalog under {}: {e}", nano_ros_root.display()))?;
+        let wanted = resolve_board(&catalog, want).map(|d| d.names.clone());
+        candidates.retain(|(_, b)| {
+            b == want
+                || (wanted.is_some()
+                    && resolve_board(&catalog, b).map(|d| d.names.clone()) == wanted)
+        });
         if candidates.is_empty() {
             return Err(eyre!(
-                "{}: no [deploy.*] with board = \"{want}\"",
+                "{}: no [image.*] or [deploy.*] with board = \"{want}\" \
+                 (matched through the board catalog, so every spelling of one \
+                 board is tried)",
                 path.display()
             ));
         }
     }
     if candidates.is_empty() {
-        return Err(eyre!("{}: no [deploy.*] blocks", path.display()));
+        return Err(eyre!(
+            "{}: no [image.*] or [deploy.*] names a board",
+            path.display()
+        ));
     }
     Ok((candidates, site, origin))
 }
@@ -571,6 +635,131 @@ sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
         assert!(
             nuttx.get("NROS_SDK_FREERTOS").is_none(),
             "the other board's site block must not leak in: {nuttx:?}"
+        );
+    }
+
+    /// The regression this file's own gate demanded and this resolver could
+    /// not serve: `examples/workspaces/realtime-rust` has SEVEN images and ZERO
+    /// deploy blocks, so selecting candidates from `[deploy.*]` alone made its
+    /// site table — which `check-site-config` requires — unreachable.
+    #[test]
+    fn an_image_only_workspace_resolves() {
+        let ws = ws_with(
+            r#"
+[system]
+name = "demo"
+rmw = "zenoh"
+domain_id = 0
+
+[image.fw]
+board = "mps2-an385-freertos"
+
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "/opt/freertos", lwip = "/opt/lwip" }
+"#,
+        );
+        let facts = resolve(ws.path(), &repo_root(), None, None, &|_| None)
+            .expect("an image names the board just as a deploy does");
+        assert_eq!(
+            facts.get("NROS_BOARD").map(String::as_str),
+            Some("mps2-an385-freertos")
+        );
+        assert_eq!(facts.get("NROS_NETSTACK").map(String::as_str), Some("lwip"));
+        // And both selectors reach it.
+        assert!(resolve(ws.path(), &repo_root(), Some("fw"), None, &|_| None).is_ok());
+        assert!(
+            resolve(
+                ws.path(),
+                &repo_root(),
+                None,
+                Some("mps2-an385-freertos"),
+                &|_| None
+            )
+            .is_ok()
+        );
+    }
+
+    /// Two boards share `packages/boards/nros-board-nuttx/nros-board.toml`, so
+    /// a descriptor compared by its FILE answers "same board" for an arm and a
+    /// riscv target. `--board nuttx-qemu-riscv` would then hand the build the
+    /// arm board's facts — a wrong answer that reports success.
+    #[test]
+    fn two_boards_in_one_descriptor_file_stay_distinct() {
+        let ws = ws_with(
+            r#"
+[system]
+name = "demo"
+rmw = "zenoh"
+domain_id = 0
+
+[image.arm]
+board = "nuttx-qemu-arm"
+
+[image.riscv]
+board = "nuttx-riscv"
+
+[board_config."nuttx-qemu-arm"]
+sdk = { nuttx = "/opt/arm", nuttx_apps = "/opt/arm-apps" }
+
+[board_config."nuttx-qemu-riscv"]
+sdk = { nuttx = "/opt/riscv", nuttx_apps = "/opt/riscv-apps" }
+"#,
+        );
+        let arm = resolve(
+            ws.path(),
+            &repo_root(),
+            None,
+            Some("nuttx-qemu-arm"),
+            &|_| None,
+        )
+        .expect("arm resolves");
+        assert_eq!(
+            arm.get("NROS_SDK_NUTTX").map(String::as_str),
+            Some("/opt/arm")
+        );
+        // `nuttx-riscv` is the descriptor's declared name; `nuttx-qemu-riscv`
+        // is another spelling of the SAME entry, so both must find the riscv
+        // block and neither may find the arm one.
+        for spelling in ["nuttx-riscv", "nuttx-qemu-riscv"] {
+            let r = resolve(ws.path(), &repo_root(), None, Some(spelling), &|_| None)
+                .unwrap_or_else(|e| panic!("{spelling} resolves: {e}"));
+            assert_eq!(
+                r.get("NROS_SDK_NUTTX").map(String::as_str),
+                Some("/opt/riscv"),
+                "{spelling} must not resolve the arm board"
+            );
+        }
+    }
+
+    /// A name in BOTH tables is one candidate, and the image's board wins —
+    /// mid-migration they can disagree, and the image is the half that
+    /// survives. Two candidates here would instead be reported as an ambiguity.
+    #[test]
+    fn an_image_outranks_a_deploy_of_the_same_name() {
+        let ws = ws_with(
+            r#"
+[system]
+name = "demo"
+rmw = "zenoh"
+domain_id = 0
+
+[image.fw]
+board = "mps2-an385-freertos"
+
+[deploy.fw]
+kind = "embedded"
+board = "threadx-linux"
+
+[board_config."mps2-an385-freertos"]
+netstack = "lwip"
+sdk = { freertos = "/opt/freertos", lwip = "/opt/lwip" }
+"#,
+        );
+        let facts = resolve(ws.path(), &repo_root(), None, None, &|_| None).expect("one answer");
+        assert_eq!(
+            facts.get("NROS_BOARD").map(String::as_str),
+            Some("mps2-an385-freertos")
         );
     }
 

--- a/packages/cli/nros-cli-core/src/cmd/check.rs
+++ b/packages/cli/nros-cli-core/src/cmd/check.rs
@@ -179,10 +179,15 @@ pub fn run(args: Args) -> Result<()> {
             eprintln!("nros check: warning: {w}");
         }
         eprintln!(
-            "nros check: ok (system '{}', {} component(s), {} deploy target(s), {} overlay \
-             warning(s), {})",
+            // Issue 0951 — BOTH counts. `examples/workspaces/realtime-rust`
+            // has seven buildable images and zero deploy blocks, so the deploy
+            // count alone reported `0 deploy target(s)` for a workspace that
+            // builds seven things.
+            "nros check: ok (system '{}', {} component(s), {} image(s), {} deploy target(s), \
+             {} overlay warning(s), {})",
             sys.system.name,
             sys.components.len(),
+            sys.image.len(),
             sys.deploy.len(),
             overlay_warnings.len(),
             path.display()

--- a/packages/cli/nros-cli-core/src/cmd/codegen_system.rs
+++ b/packages/cli/nros-cli-core/src/cmd/codegen_system.rs
@@ -885,6 +885,30 @@ fn render_plan_json(
     let launch_file: Option<String> = resolved_launch
         .map(|s| s.to_string())
         .or_else(|| {
+            // Issue 0951 — the SELECTED target's launch, from `[image.<t>]`
+            // first, then the DEPRECATED `[deploy.<t>]`.
+            //
+            // Two differences from what this used to do, both improvements
+            // that come free with the target being known here:
+            //
+            //  * it is scoped to the target rather than "the first deploy
+            //    block that has a `launch`, in BTreeMap order" — arbitrary
+            //    whenever several were declared;
+            //  * an image's `launch` is relative to the bringup's `launch/`
+            //    directory (`validate_image_launch` joins it that way), while
+            //    a deploy's is authored both ways in this tree. So the image
+            //    value gets the prefix and the deploy value is carried
+            //    verbatim, which is what each already means.
+            let t = target?;
+            let sys = &bringup.system;
+            sys.image_for(t)
+                .and_then(|img| img.launch)
+                .map(|l| format!("launch/{l}"))
+                .or_else(|| sys.deploy.get(t).and_then(|d| d.launch.clone()))
+        })
+        .or_else(|| {
+            // Any deploy block's launch, as before — the pre-0951 behaviour,
+            // kept for a workspace whose target does not resolve.
             bringup
                 .system
                 .deploy

--- a/packages/cli/nros-cli-core/src/cmd/codegen_system.rs
+++ b/packages/cli/nros-cli-core/src/cmd/codegen_system.rs
@@ -102,7 +102,8 @@ pub struct Args {
     pub model: Option<PathBuf>,
 
     /// Phase 255 Wave 4 — RMW override, the TOP of the precedence ladder
-    /// (`--rmw` > `[deploy.<target>].rmw` > `[system].rmw` > `zenoh`). Forces
+    /// (`--rmw` > `[image.<target>].rmw` > the deprecated
+    /// `[deploy.<target>].rmw` > `[system].rmw` > `zenoh`). Forces
     /// the `NROS_SYSTEM_RMW*` define for this bake regardless of `system.toml`.
     #[arg(long = "rmw")]
     pub rmw: Option<String>,

--- a/packages/cli/nros-cli-core/src/cmd/doctor.rs
+++ b/packages/cli/nros-cli-core/src/cmd/doctor.rs
@@ -376,8 +376,37 @@ fn check_deploy_targets(config: &Path) -> Result<Option<usize>> {
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from("."));
 
-    eprintln!("nros doctor: deploy targets ({})", config.display());
+    // Issue 0951 — IMAGES are the buildable unit (RFC-0065 D6), so they get
+    // their own section rather than being folded into the deploy display: the
+    // two tables answer different questions, and a workspace that has finished
+    // migrating has an empty deploy table and everything to say here.
+    //
+    // The launch check delegates to `validate_image_launch` rather than
+    // re-deriving the path. That function already knows an image's `launch` is
+    // relative to the bringup's `launch/` directory — a second implementation
+    // of that join is how doctor would come to disagree with the builder about
+    // whether a workspace is healthy — and its message lists the launch files
+    // that DO exist, which is the thing a reader needs at that moment.
     let mut problems = 0usize;
+    if !system.image.is_empty() {
+        eprintln!("nros doctor: images ({})", config.display());
+        for id in system.image.keys() {
+            let img = system.image_for(id).expect("key just enumerated");
+            let board = img.board.as_deref().unwrap_or("(derived)");
+            match crate::orchestration::image::validate_image_launch(id, &img, &bringup_dir) {
+                Ok(()) => eprintln!("  [OK] {id}: board={board}"),
+                Err(e) => {
+                    eprintln!("  [!!] {id}: board={board} — {e}");
+                    problems += 1;
+                }
+            }
+        }
+    }
+
+    if system.deploy.is_empty() {
+        return Ok(Some(problems));
+    }
+    eprintln!("nros doctor: deploy targets ({})", config.display());
     for (name, deploy) in &system.deploy {
         let kind = deploy.kind.as_deref().unwrap_or("(derived)");
         let target = deploy.target.as_deref().unwrap_or("(derived)");
@@ -608,6 +637,36 @@ mod tests {
         assert_eq!(check_deploy_targets(&system_toml).unwrap(), None);
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Issue 0951 — images get their own section, and their launch check is
+    /// `validate_image_launch`, so doctor and the builder cannot disagree
+    /// about whether a workspace is healthy. Note the path base differs from
+    /// the deploy side: an image's `launch` is relative to `launch/`.
+    #[test]
+    fn images_are_checked_against_their_launch_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("system.toml");
+        let head = "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n";
+
+        // No launch key at all — nothing to verify, no problem.
+        std::fs::write(&cfg, format!("{head}[image.a]\nboard=\"native\"\n")).unwrap();
+        assert_eq!(check_deploy_targets(&cfg).unwrap(), Some(0));
+
+        // Names a file that does not exist.
+        std::fs::write(
+            &cfg,
+            format!("{head}[image.a]\nboard=\"native\"\nlaunch=\"gone.launch.xml\"\n"),
+        )
+        .unwrap();
+        assert_eq!(check_deploy_targets(&cfg).unwrap(), Some(1));
+
+        // The same name, present — under `launch/`, which is the base an
+        // image's value is relative to. A copy of the deploy side's join
+        // (bringup_dir/<value>) would report this one missing.
+        std::fs::create_dir_all(dir.path().join("launch")).unwrap();
+        std::fs::write(dir.path().join("launch/gone.launch.xml"), "<launch/>").unwrap();
+        assert_eq!(check_deploy_targets(&cfg).unwrap(), Some(0));
     }
 
     #[test]

--- a/packages/cli/nros-cli-core/src/cmd/plan.rs
+++ b/packages/cli/nros-cli-core/src/cmd/plan.rs
@@ -65,14 +65,16 @@ pub struct Args {
     pub manifests: Vec<PathBuf>,
 
     /// Phase 255 Wave 4 — RMW override, the TOP of the precedence ladder
-    /// (`--rmw` > `[deploy.<t>].rmw` > `[system].rmw` > `zenoh`). Sets
-    /// `plan.build.rmw` regardless of `system.toml` / the `[build].rmw` overlay.
+    /// (`--rmw` > `[image.<t>].rmw` > the deprecated `[deploy.<t>].rmw` >
+    /// `[system].rmw` > `zenoh`). Sets `plan.build.rmw` regardless of
+    /// `system.toml` / the `[build].rmw` overlay.
     #[arg(long = "rmw")]
     pub rmw: Option<String>,
 
-    /// Phase 256 — select the `[deploy.<t>]` the planner resolves per-target
-    /// values against (RMW override, build tuning, domain/locator). Omitted →
-    /// `[system].default_target` → the sole `[deploy.<t>]` → target-agnostic.
+    /// Phase 256 — select the `[image.<t>]` (or deprecated `[deploy.<t>]`) the
+    /// planner resolves per-target values against (RMW override, build tuning,
+    /// domain/locator). Omitted → `[system].default_target` → the sole
+    /// `[image.<t>]`, then the sole `[deploy.<t>]` → target-agnostic.
     #[arg(long = "target")]
     pub target: Option<String>,
 

--- a/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
@@ -899,15 +899,29 @@ impl SystemToml {
     /// Phase 256 — the deploy target a target-agnostic caller (the planner) should
     /// resolve per-target values against, when no explicit target was selected:
     /// `cli` (a `--target` flag) → `[system].default_target` → the sole
-    /// `[deploy.<t>]` key when exactly one is declared → `None`. This is the
-    /// shared "which deploy am I?" key the per-target classes (RMW override,
-    /// build tuning, domain/locator override) resolve through.
+    /// `[image.<t>]` key, then the sole `[deploy.<t>]` key, when exactly one is
+    /// declared → `None`. This is the shared "which target am I?" key the
+    /// per-target classes (RMW override, build tuning, domain/locator override)
+    /// resolve through.
+    ///
+    /// Issue 0951 — the IMAGE rung is what lets a workspace finish migrating
+    /// off `[deploy.*]`. Without it, deleting the last deploy block does not
+    /// fail: this returns `None`, every per-target lookup misses, and the plan
+    /// silently reverts to the `x86_64` / `native` / `debug` defaults. A build
+    /// for the wrong target that reports success is the failure mode this
+    /// whole table is arranged to prevent.
+    ///
+    /// Images are tried BEFORE deploys because a workspace carrying both is
+    /// mid-migration, and the image is the half that survives.
     pub fn resolve_target(&self, cli: Option<&str>) -> Option<String> {
         if let Some(c) = cli {
             return Some(c.to_string());
         }
         if let Some(t) = &self.system.default_target {
             return Some(t.clone());
+        }
+        if self.image.len() == 1 {
+            return self.image.keys().next().cloned();
         }
         if self.deploy.len() == 1 {
             return self.deploy.keys().next().cloned();
@@ -942,8 +956,22 @@ impl SystemToml {
     /// `nros build` cannot drift apart on the same workspace (issue 0938).
     #[must_use]
     pub fn image_rmw_for(&self, id: &str) -> Option<String> {
+        self.image_for(id).and_then(|img| img.rmw)
+    }
+
+    /// `[image.<id>]` folded over `[image_defaults]` — the one place that
+    /// performs the merge.
+    ///
+    /// Every per-image reader goes through this rather than reaching into
+    /// `self.image` directly, because forgetting the base is a silent wrong
+    /// answer: the block parses, the field is `None`, and the caller falls
+    /// through to a default the author already overrode workspace-wide.
+    /// `image_rmw_for` was the only image reader on this type and it hardcoded
+    /// one field; this is that function with the field removed.
+    #[must_use]
+    pub fn image_for(&self, id: &str) -> Option<ImageBlock> {
         let base = self.image_defaults.clone().unwrap_or_default();
-        self.image.get(id).and_then(|img| img.with_base(&base).rmw)
+        self.image.get(id).map(|img| img.with_base(&base))
     }
 
     /// The RMW backend name for `target`: the CLI `--rmw` flag, then
@@ -1809,6 +1837,56 @@ board = "native"
         )
         .unwrap();
         assert_eq!(sole.resolve_target(None).as_deref(), Some("only"));
+
+        // Issue 0951 — the sole IMAGE resolves the same way, so a workspace
+        // that has finished migrating off `[deploy.*]` still has a target.
+        // Without this rung, deleting the last deploy block does not fail: the
+        // plan quietly falls back to the x86_64 / native / debug defaults.
+        let sole_image: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             [image.firmware]\nboard=\"mps2-an385-freertos\"\n",
+        )
+        .unwrap();
+        assert_eq!(sole_image.resolve_target(None).as_deref(), Some("firmware"));
+
+        // Two images are as ambiguous as two deploys.
+        let two_images: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             [image.a]\nboard=\"native\"\n[image.b]\nboard=\"native\"\n",
+        )
+        .unwrap();
+        assert_eq!(two_images.resolve_target(None), None);
+
+        // Mid-migration: one image and one deploy. The IMAGE is the half that
+        // survives, so it decides — picking the deploy would resolve to a name
+        // that is about to stop existing.
+        let both: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             [image.firmware]\nboard=\"native\"\n[deploy.legacy]\nkind=\"self\"\n",
+        )
+        .unwrap();
+        assert_eq!(both.resolve_target(None).as_deref(), Some("firmware"));
+    }
+
+    /// `image_for` folds `[image_defaults]` under the block. Forgetting the
+    /// base is a silent wrong answer — the field reads `None` and the caller
+    /// falls through to a default the author already overrode workspace-wide.
+    #[test]
+    fn image_for_folds_the_defaults_table() {
+        let sys: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             [image_defaults]\nrmw=\"cyclonedds\"\nprofile=\"release\"\n\
+             [image.a]\nboard=\"native\"\n\
+             [image.b]\nboard=\"native\"\nprofile=\"debug\"\n",
+        )
+        .unwrap();
+        let a = sys.image_for("a").expect("declared");
+        assert_eq!(a.rmw.as_deref(), Some("cyclonedds"), "inherited");
+        assert_eq!(a.profile.as_deref(), Some("release"), "inherited");
+        let b = sys.image_for("b").expect("declared");
+        assert_eq!(b.profile.as_deref(), Some("debug"), "the block wins");
+        assert_eq!(b.rmw.as_deref(), Some("cyclonedds"), "still inherited");
+        assert!(sys.image_for("nope").is_none());
     }
 
     /// Phase 256 Wave 8 — `[deploy.<t>].domain_id`/`.locator` override the

--- a/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
@@ -657,6 +657,24 @@ fn synthesise_self_bringup(comp: &ComponentPackageEntry) -> BringupPackageEntry 
         );
     }
 
+    // Issue 0951 — project the same rows as images. `resolve_target`'s image
+    // rung and every `image_for` reader see a synthesised bringup exactly as
+    // they see an authored one.
+    let image: BTreeMap<String, crate::orchestration::image::ImageBlock> = nros
+        .deploy
+        .iter()
+        .map(|(target_name, dt)| {
+            (
+                target_name.clone(),
+                crate::orchestration::image::ImageBlock {
+                    board: dt.board.clone(),
+                    rmw: dt.rmw.clone(),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+
     let system = SystemToml {
         board_config: Default::default(),
         system: system_header,
@@ -667,7 +685,20 @@ fn synthesise_self_bringup(comp: &ComponentPackageEntry) -> BringupPackageEntry 
         // placement over a single implicit host is what the empty map already
         // means.
         host: Default::default(),
-        image: Default::default(),
+        // Issue 0951 — the same `[package.metadata.nros.deploy.<t>]` rows, ALSO
+        // projected as images.
+        //
+        // Not "as well as, for tidiness": every consumer migrating from
+        // `[deploy.*]` to `[image.*]` would otherwise read an empty map here
+        // and silently lose its values for self-bringup packages — a component
+        // package with deploy metadata and no sibling bringup. That is the
+        // quiet half of the migration, because a self-bringup is synthesised
+        // rather than authored, so no file in the tree shows the gap.
+        //
+        // Only the fields an image OWNS cross over: `board` and `rmw`. `kind`
+        // and `target` are placement and stay on the deploy side; nothing here
+        // sets profile/features, so they stay absent rather than defaulted.
+        image,
         image_defaults: None,
         domains: Vec::new(),
         bridges: Vec::new(),
@@ -1009,6 +1040,22 @@ locator = "tcp/127.0.0.1:7447"
             .expect("native deploy block synthesised");
         assert_eq!(native.kind.as_deref(), Some("self"));
         assert_eq!(native.board.as_deref(), Some("native_sim/native/64"));
+
+        // Issue 0951 — the SAME row, also projected as an image. A synthesised
+        // bringup is not authored anywhere, so nothing in the tree would show
+        // this gap: a consumer switched to `[image.*]` would just read an empty
+        // map and lose the value.
+        let img = entry
+            .system
+            .image_for("native")
+            .expect("native image projected");
+        assert_eq!(img.board.as_deref(), Some("native_sim/native/64"));
+        // Placement stays on the deploy side — an image has no `kind`.
+        assert_eq!(
+            entry.system.resolve_target(None).as_deref(),
+            Some("native"),
+            "the sole image resolves the target"
+        );
     }
 
     #[test]

--- a/packages/cli/nros-cli-core/src/orchestration/planner.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/planner.rs
@@ -27,7 +27,8 @@ pub struct PlanOptions {
     pub manifest_files: Vec<PathBuf>,
     pub launch_args: Vec<String>,
     /// Phase 255 Wave 4 — `--rmw` override, the top of the precedence ladder
-    /// (`--rmw` > `[deploy.<t>].rmw` > `[system].rmw` > `zenoh`). Sets
+    /// (`--rmw` > `[image.<t>].rmw` > the deprecated `[deploy.<t>].rmw` >
+    /// `[system].rmw` > `zenoh`). Sets
     /// `plan.build.rmw` regardless of `system.toml`. `None` ⇒ resolve from
     /// `system.toml`.
     pub rmw: Option<String>,

--- a/packages/cli/nros-cli-core/src/orchestration/planner.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/planner.rs
@@ -738,30 +738,61 @@ fn schema_build_json(
     if let Some(rmw) = resolved_rmw {
         obj.insert("rmw".to_string(), json!(rmw));
     }
-    // Phase 256 Wave 3 / W3-tail — the build shape from the selected `[deploy.<t>]`
-    // (target / board / profile / optimize / features) drives the plan. Build shape
-    // is per-deploy (a system targets native AND an MCU from one `system.toml`), so
-    // its home is the deploy block. `target`/`board` drive the codegen board-crate +
-    // entry-kind selection (the bake's `--target` overrides the cargo `--target` at
-    // build time, but `generate` must pick the right board from the plan).
-    if let Some(dt) = selected_target
-        .as_deref()
-        .and_then(|t| sys.as_ref().and_then(|s| s.deploy.get(t)))
+    // Phase 256 Wave 3 / W3-tail — the build shape for the selected target
+    // (board / profile / features) drives the plan. Build shape is per-target
+    // (a system targets native AND an MCU from one `system.toml`), so its home
+    // is the per-target block. `board` drives the codegen board-crate +
+    // entry-kind selection (the bake's `--target` overrides the cargo
+    // `--target` at build time, but `generate` must pick the right board from
+    // the plan).
+    //
+    // Issue 0951 — `[image.<t>]` first, then the DEPRECATED `[deploy.<t>]`,
+    // per field rather than per block: mid-migration a workspace legitimately
+    // has the board on the image and nothing else anywhere, and taking the
+    // whole block from whichever table won would drop the other's fields.
+    //
+    // `target` and `optimize` are deliberately deploy-only. `target` is the
+    // rustc triple, which `[image.*]` does not carry because the board
+    // descriptor derives it; `optimize` has an `[image.*]` counterpart nowhere
+    // and is authored NOWHERE in this tree — zero occurrences across every
+    // `system.toml` — so it is carried for the deploy path only rather than
+    // given a new home it has no user for.
+    if let Some(t) = selected_target.as_deref()
+        && let Some(s) = sys.as_ref()
     {
-        if let Some(t) = &dt.target {
-            obj.insert("target".to_string(), json!(t));
-        }
-        if let Some(b) = &dt.board {
+        let img = s.image_for(t);
+        let dep = s.deploy.get(t);
+
+        let board = img
+            .as_ref()
+            .and_then(|i| i.board.clone())
+            .or_else(|| dep.and_then(|d| d.board.clone()));
+        if let Some(b) = board {
             obj.insert("board".to_string(), json!(b));
         }
-        if let Some(p) = &dt.profile {
+        let profile = img
+            .as_ref()
+            .and_then(|i| i.profile.clone())
+            .or_else(|| dep.and_then(|d| d.profile.clone()));
+        if let Some(p) = profile {
             obj.insert("profile".to_string(), json!(p));
         }
-        if let Some(o) = &dt.optimize {
-            obj.insert("optimize".to_string(), json!(o));
+        let features = img
+            .as_ref()
+            .filter(|i| !i.features.is_empty())
+            .map(|i| i.features.clone())
+            .or_else(|| {
+                dep.filter(|d| !d.features.is_empty())
+                    .map(|d| d.features.clone())
+            });
+        if let Some(f) = features {
+            obj.insert("features".to_string(), json!(f));
         }
-        if !dt.features.is_empty() {
-            obj.insert("features".to_string(), json!(dt.features));
+        if let Some(t) = dep.and_then(|d| d.target.clone()) {
+            obj.insert("target".to_string(), json!(t));
+        }
+        if let Some(o) = dep.and_then(|d| d.optimize.clone()) {
+            obj.insert("optimize".to_string(), json!(o));
         }
     }
     // Phase 255 Wave 5 — cross-RMW `[[bridge]]`s make a single binary link the
@@ -3765,6 +3796,67 @@ mod tests {
         assert_eq!(nat["profile"], "debug");
         assert!(nat.get("optimize").is_none());
         assert_eq!(nat["features"], json!([]));
+    }
+
+    /// Issue 0951 — the same tuning, read from `[image.<t>]`, which is where a
+    /// migrated workspace keeps it.
+    #[test]
+    fn schema_build_json_reads_build_tuning_from_the_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let st = dir.path().join("system.toml");
+        std::fs::write(
+            &st,
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             default_target=\"embedded\"\n\
+             [image_defaults]\nprofile=\"release\"\n\
+             [image.embedded]\nboard=\"mps2-an385-freertos\"\nfeatures=[\"safety\"]\n",
+        )
+        .unwrap();
+        let v = schema_build_json(Some(&st), None, None);
+        let o = v.as_object().expect("object");
+        assert_eq!(
+            o.get("board").and_then(|b| b.as_str()),
+            Some("mps2-an385-freertos")
+        );
+        // Folded from `[image_defaults]`, not from the block itself.
+        assert_eq!(o.get("profile").and_then(|p| p.as_str()), Some("release"));
+        assert_eq!(
+            o.get("features").and_then(|f| f.as_array()).map(Vec::len),
+            Some(1)
+        );
+        // Neither has an `[image.*]` counterpart, and neither is authored
+        // anywhere in the tree.
+        assert!(o.get("optimize").is_none(), "{o:?}");
+    }
+
+    /// Mid-migration a workspace has the board on the image and the rustc
+    /// triple only on the deploy. Taking the whole block from whichever table
+    /// "won" would drop the other's fields, so the merge is per-FIELD.
+    #[test]
+    fn schema_build_json_merges_image_and_deploy_per_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let st = dir.path().join("system.toml");
+        std::fs::write(
+            &st,
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             default_target=\"embedded\"\n\
+             [image.embedded]\nboard=\"mps2-an385-freertos\"\n\
+             [deploy.embedded]\nkind=\"embedded\"\n\
+             target=\"thumbv7m-none-eabi\"\nboard=\"stale-board\"\n",
+        )
+        .unwrap();
+        let v = schema_build_json(Some(&st), None, None);
+        let o = v.as_object().expect("object");
+        assert_eq!(
+            o.get("board").and_then(|b| b.as_str()),
+            Some("mps2-an385-freertos"),
+            "the image outranks the deploy on a field both carry"
+        );
+        assert_eq!(
+            o.get("target").and_then(|t| t.as_str()),
+            Some("thumbv7m-none-eabi"),
+            "and the deploy still supplies one the image cannot carry"
+        );
     }
 
     #[cfg(feature = "play-launch-parser")]

--- a/packages/cli/nros-cli-core/src/orchestration/tier_resolver.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/tier_resolver.rs
@@ -109,13 +109,31 @@ pub fn resolve_system_tiers(
     )
 }
 
-/// Best-effort RTOS name for tier resolution from the selected deploy target.
-/// Defaults to `posix` (native); embedded targets refine it from the deploy
-/// `board`/`kind` hint.
+/// Best-effort RTOS name for tier resolution from the selected target.
+///
+/// Defaults to `posix` (native); embedded targets refine it from a board hint.
+///
+/// Issue 0951 — the hint comes from `[image.<t>].board` first, then the
+/// DEPRECATED `[deploy.<t>].board`, then `[deploy.<t>].kind`. Images are the
+/// buildable unit, so a workspace that has migrated has its board only there;
+/// the `kind` rung is last because it is the coarsest — it was only ever a
+/// stand-in for a board name, and the two boards it has to separate
+/// (`nuttx-qemu-arm` vs `nuttx-qemu-riscv`) it cannot.
+///
+/// Still a SUBSTRING match on the hint rather than a board-catalog lookup. The
+/// catalog would answer properly — `BoardDescriptor::platform` is exactly this
+/// axis — but taking one here means threading a `&BoardCatalog` through
+/// `codegen_system`, which is a larger change than this rung deserves; see the
+/// issue.
 pub fn derive_target_rtos(system: &SystemToml, target: Option<&str>) -> String {
     target
-        .and_then(|t| system.deploy.get(t))
-        .and_then(|d| d.board.as_deref().or(d.kind.as_deref()))
+        .and_then(|t| {
+            system
+                .image_for(t)
+                .and_then(|img| img.board)
+                .or_else(|| system.deploy.get(t).and_then(|d| d.board.clone()))
+                .or_else(|| system.deploy.get(t).and_then(|d| d.kind.clone()))
+        })
         .map(|hint| {
             for rtos in ["freertos", "zephyr", "threadx", "nuttx"] {
                 if hint.contains(rtos) {
@@ -130,6 +148,68 @@ pub fn derive_target_rtos(system: &SystemToml, target: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue 0951 — `derive_target_rtos` had NO direct test for two phases.
+    /// It decides which `[tiers.<name>.<rtos>]` sub-table is read, so a wrong
+    /// answer silently applies another RTOS's scheduling parameters.
+    mod target_rtos {
+        use super::*;
+
+        fn sys(body: &str) -> SystemToml {
+            toml::from_str(&format!(
+                "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n{body}"
+            ))
+            .expect("fixture parses")
+        }
+
+        #[test]
+        fn an_image_board_decides() {
+            let s = sys("[image.fw]\nboard=\"mps2-an385-freertos\"\n");
+            assert_eq!(derive_target_rtos(&s, Some("fw")), "freertos");
+        }
+
+        #[test]
+        fn the_image_outranks_a_deploy_naming_another_board() {
+            // Mid-migration a workspace carries both. The image is the half
+            // that survives, so it decides — reading the deploy would resolve
+            // the RTOS of a block that is about to be deleted.
+            let s = sys("[image.fw]\nboard=\"nuttx-qemu-arm\"\n\
+                 [deploy.fw]\nkind=\"embedded\"\nboard=\"mps2-an385-freertos\"\n");
+            assert_eq!(derive_target_rtos(&s, Some("fw")), "nuttx");
+        }
+
+        #[test]
+        fn a_deploy_board_still_answers_when_no_image_exists() {
+            let s = sys("[deploy.fw]\nkind=\"embedded\"\nboard=\"threadx-linux\"\n");
+            assert_eq!(derive_target_rtos(&s, Some("fw")), "threadx");
+        }
+
+        /// The coarsest rung, and the reason it is last: `kind` was only ever a
+        /// stand-in for a board name.
+        #[test]
+        fn kind_is_the_last_resort() {
+            let s = sys("[deploy.fw]\nkind=\"zephyr\"\n");
+            assert_eq!(derive_target_rtos(&s, Some("fw")), "zephyr");
+        }
+
+        #[test]
+        fn an_unknown_or_absent_target_is_posix() {
+            let s = sys("[image.fw]\nboard=\"native\"\n");
+            assert_eq!(derive_target_rtos(&s, Some("fw")), "posix");
+            assert_eq!(derive_target_rtos(&s, Some("nope")), "posix");
+            assert_eq!(derive_target_rtos(&s, None), "posix");
+        }
+
+        /// `[image_defaults]` folds under the block here as everywhere else —
+        /// reaching into `system.image` directly would miss it.
+        #[test]
+        fn the_defaults_table_supplies_a_board_the_block_omits() {
+            let s = sys(
+                "[image_defaults]\nboard=\"nuttx-qemu-riscv\"\n[image.fw]\nprofile=\"release\"\n",
+            );
+            assert_eq!(derive_target_rtos(&s, Some("fw")), "nuttx");
+        }
+    }
     use crate::orchestration::{
         cargo_metadata_schema::{SystemComponentEntry, SystemToml},
         nros_config::NrosConfig,

--- a/scripts/build/cargo-out-dir-headers.py
+++ b/scripts/build/cargo-out-dir-headers.py
@@ -76,6 +76,11 @@ def copy_headers(out_dir: str, dest: str) -> list:
     include, whichever package produced it.
     """
     pairs = []
+    # walk-ok: `out_dir` is cargo's OUT_DIR — a build directory whose generated
+    # headers are UNTRACKED by construction, so `git ls-files` cannot see them.
+    # This is the case the gate's own text carves out ("scanning for UNTRACKED
+    # artifacts is fine — scope it to a build dir"), and the scope here is one
+    # crate's OUT_DIR, not `examples/` or `packages/`.
     for root, _dirs, files in os.walk(out_dir):
         rel_root = os.path.relpath(root, out_dir)
         head = rel_root.split(os.sep)[0]

--- a/scripts/check-deploy-board-resolves.py
+++ b/scripts/check-deploy-board-resolves.py
@@ -64,11 +64,25 @@ def deploy_values():
                     doc = tomllib.load(fh)
             except Exception:
                 continue
-            for name, blk in (doc.get("deploy") or {}).items():
-                if isinstance(blk, dict) and blk.get("board"):
-                    out.setdefault(blk["board"], []).append(
-                        f"{os.path.relpath(path, ROOT)} [deploy.{name}]"
-                    )
+            # `[image.*]` as well as `[deploy.*]` (issue 0951). Images are the
+            # buildable unit, so most authored board strings live there now —
+            # two in this tree (`nuttx-riscv`, `s32z270-freertos`) are named
+            # ONLY on an image, and were therefore never verified by the gate
+            # whose whole promise is that an unresolvable board fails HERE,
+            # named, instead of becoming a silent skip three layers down.
+            # `[image_defaults]` counts too: a board declared there is inherited
+            # by every image that omits one.
+            for table in ("deploy", "image"):
+                for name, blk in (doc.get(table) or {}).items():
+                    if isinstance(blk, dict) and blk.get("board"):
+                        out.setdefault(blk["board"], []).append(
+                            f"{os.path.relpath(path, ROOT)} [{table}.{name}]"
+                        )
+            defaults = doc.get("image_defaults")
+            if isinstance(defaults, dict) and defaults.get("board"):
+                out.setdefault(defaults["board"], []).append(
+                    f"{os.path.relpath(path, ROOT)} [image_defaults]"
+                )
     # Standalone leaves: the deploy KEY is the board (no `board =` there).
     # issue 0721 / 0726 — the INDEX, not a walk. `examples/` holds build output
     # (measured 5769 Cargo.toml on disk against 237 git tracks), and a recursive
@@ -100,7 +114,10 @@ def main():
     known = descriptors()
     values = deploy_values()
     if not values:
-        sys.exit("check-deploy-board-resolves: found no [deploy.*] values — wrong root?")
+        sys.exit(
+            "check-deploy-board-resolves: found no [deploy.*] / [image.*] board "
+            "values — wrong root?"
+        )
 
     unknown, ambiguous = [], []
     for value, wheres in sorted(values.items()):


### PR DESCRIPTION
Stacked on #123 (its two commits are the first two here and will disappear once #123 merges).

`[image.<id>]` has been the buildable unit since RFC-0065, but the readers answering per-target questions still consulted `[deploy.<t>]` alone. A workspace that finished migrating would not fail — **it would get DEFAULTS**, which is the failure mode this table exists to prevent.

## Two foundations

- **`SystemToml::image_for`** — `[image.<id>]` folded over `[image_defaults]`, in one place. `image_rmw_for` was the only image reader on this type and it hardcoded one field; this is that function with the field removed. Forgetting the base is a silent wrong answer: the block parses, the field reads `None`, and the caller falls through to a default the author already overrode workspace-wide.
- **`resolve_target` gains an image rung**, above deploy. Without it, deleting the last deploy block does not fail: the ladder returns `None`, every per-target lookup misses, and the plan quietly reverts to `x86_64` / `native` / `debug`.

## The readers

| reader | note |
| --- | --- |
| `derive_target_rtos` | decides which `[tiers.<n>.<rtos>]` sub-table is read, so a wrong answer silently applies another RTOS's scheduling parameters. **Had no direct test for two phases**; has six now. `kind` is the last rung because it cannot separate `nuttx-qemu-arm` from `nuttx-qemu-riscv`. |
| `schema_build_json` | merged per **field**, not per block — mid-migration a workspace legitimately has the board on the image and the rustc triple only on the deploy. `target`/`optimize` stay deploy-only: the first is derived from the board descriptor, the second is authored **nowhere** in this tree. |
| `codegen_system` launch fallback | now scoped to the selected target rather than "the first deploy block with a `launch`, in BTreeMap order" — arbitrary whenever several were declared. Image `launch` is relative to `launch/`; a deploy's is not. |
| `doctor` | images get their own section, delegating to `validate_image_launch` rather than re-deriving the join — a second implementation is how doctor comes to disagree with the builder about whether a workspace is healthy. |

## The quiet one

`synthesise_self_bringup` wrote `image: Default::default()` while filling `deploy` from `[package.metadata.nros.deploy.*]`. Every reader above would have read an empty map there and **lost its values for self-bringup packages**. Nothing in the tree shows that gap, because a self-bringup is synthesised rather than authored. It now projects both.

## Verification

`rm -rf <ws>/build/nros/models && nros sync` across all 31 workspaces, before and after — a plain sync serves a content-addressed cache and reads as "no change". **Model content is byte-identical.** The only diff is `system.toml` provenance hashes, which moved because the issue-number comment fix edited those files after the previous capture.

`just ci-l1` green; `just check fast` 146/146; 800 lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG