### PR TITLE
docs(0953): a panic in the Python half aborts the resolver — and 0897's scope was overstated

### DIFF
--- a/docs/issues/0953-pyexec-panic-crosses-c-abi.md
+++ b/docs/issues/0953-pyexec-panic-crosses-c-abi.md
@@ -1,0 +1,93 @@
+---
+id: 953
+title: "A panic in the Python half crosses `extern \"C\"` and ABORTS the resolver —
+  0897 removed the loader abort and left this one"
+status: open
+type: bug
+area: tooling
+related: [0897, 0915, 0914]
+---
+
+## What happens
+
+Resolving a `.launch.py` with the shipped `nros-launch-resolve` does not fail —
+it **aborts and dumps core**:
+
+```
+$ nros-launch-resolve .../tests/fixtures/launch/test_simple_python.launch.py
+thread '<unnamed>' panicked at crates/play_launch_parser/src/bridge.rs:367:10:
+No LaunchContext set - Python execution must be called through LaunchTraverser
+--- PyO3 is resuming a panic after fetching a PanicException from Python. ---
+pyo3_runtime.PanicException: No LaunchContext set …
+thread '<unnamed>' panicked at library/core/src/panicking.rs:225:5:
+panic in a function that cannot unwind
+…
+thread caused non-unwinding panic. aborting.
+Segmentation fault (core dumped)
+```
+
+The first panic is arguably a misuse — that fixture belongs to the parser's own
+harness and expects to be driven through `LaunchTraverser`. **The abort is not.**
+A caller passing a file the resolver cannot handle should get a message.
+
+## Why it aborts rather than returns
+
+`pyexec`'s C entry point has no panic guard:
+
+```rust
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn play_launch_py_call(req: *const c_char) -> *mut c_char {
+```
+
+`grep -c catch_unwind c_abi.rs` → **0**. A panic unwinding out of an
+`extern "C"` function is undefined behaviour, and rustc's guard turns it into an
+immediate abort. So *any* panic anywhere in the Python half — the parser, a
+`#[pyclass]` mock, or a `PanicException` PyO3 resumes from Python — takes the
+whole process down with no diagnostic from us.
+
+The function is otherwise careful about exactly this: it returns a structured
+error for a null request, for non-UTF-8, and even for a NUL byte in its own
+response ("returning null on it would be an unannounced second failure mode").
+Panics are the one path out that it does not cover.
+
+## Why this matters beyond one fixture
+
+This is the failure mode [issue 0897](archived/0897-resolver-libpython-runtime-discovery.md)
+was filed to remove. Its `pyload` header states the contract:
+
+> **What the caller gets** — A `Result`, never an abort.
+
+0897 delivered that for the *loader*: a missing or mismatched `libpython` is now
+a caught error naming the remedy. The `.launch.py` execution path still has an
+abort in it, from a different cause. One artifact, two ways to die, one of them
+now fixed — which is easy to mistake for the whole thing being fixed.
+
+It also defeats the degradation 0897 built. The point of dispatching by
+extension was that an unusable Python path fails *while naming the file*. An
+abort names nothing, returns no exit status the caller can interpret, and in
+`nros sync` surfaces as a child that died on a signal.
+
+## Fix
+
+Wrap the body in `std::panic::catch_unwind` and convert a panic into the
+`Response { ok: false, error }` the ABI already defines. The payload's message
+is recoverable via `downcast_ref::<String>` / `&str`, so the report can name the
+original panic rather than "panicked".
+
+Two details worth getting right:
+
+* `AssertUnwindSafe` will be needed around the closure; the alternative
+  (making every captured type `UnwindSafe`) is not worth it at a boundary that
+  already deals in JSON strings.
+* `play_launch_py_abi_version` should bump if the error shape changes, since
+  `pyload` checks it.
+
+## Scope note for 0897
+
+0897's Q4 section says "zero tracked `.launch.py` files exist in nano-ros …
+so the `.py` path is exercised by no fixture". The first half is true —
+`git ls-files` does not descend into submodules — but the conclusion is too
+strong: `play_launch` carries several `.launch.py` fixtures in its own tests.
+The abi3 measurement there covered the `$(eval)` path only, which is what the
+`nano-ros` workspaces exercise; it says nothing about `.launch.py` execution
+cost. Corrected in the same change that files this.

--- a/docs/issues/archived/0897-resolver-libpython-runtime-discovery.md
+++ b/docs/issues/archived/0897-resolver-libpython-runtime-discovery.md
@@ -526,7 +526,13 @@ Conclusion: **abi3 is free at any scale this project plausibly reaches.**
 The heaviest Python workload in EITHER repository is two `$(eval)` calls:
 
 * **zero** tracked `.launch.py` files exist in nano-ros — `git ls-files | grep
-  'launch\.py$'` is empty, so the `.py` path is exercised by no fixture;
+  'launch\.py$'` is empty. **CORRECTION (2026-08-31):** that command does not
+  descend into submodules, and `play_launch` carries several `.launch.py`
+  fixtures in its own test suite. So "no fixture exercises the `.py` path" was
+  too strong: the measurement below covers the `$(eval)` path only, which is
+  what the nano-ros workspaces exercise, and says nothing about `.launch.py`
+  EXECUTION cost. Trying to measure that path is how issue 0953 was found — it
+  aborts;
 * four XML files use `$(eval)` (`multihost.launch.xml` in the c / cpp / mixed /
   rust workspaces), each twice — which is exactly the CORRECTION above: XML is
   not a Python-free path;

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -69,5 +69,6 @@ fails if this block drifts.
 - **#0939** (tooling) — The metadata probe links the node NAME, which is not a target — so every C/C++ component reports `no producer`, once, and then silently See `0939-*`.
 - **#0945** (build) — The shared-cargo-dir campaign rests on five unsupported build-system internals — a Corrosion path formula, an unstable cargo flag, cargo's private `.fingerprint` format, a side channel inside cargo's target dir, and an undocumented depfile location See `0945-*`.
 - **#0951** (orchestration, tooling) — `[deploy.*]` is three unrelated facts in one table — site config keyed on the deploy name, not the board, is the half that duplicates See `0951-*`.
+- **#0953** (tooling) — A panic in the Python half crosses `extern \"C\"` and ABORTS the resolver — 0897 removed the loader abort and left this one See `0953-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
A background search I'd started during the 0897 work finished **after** that issue merged, and it contradicted a claim I had already committed. Both halves are fixed here.

## The claim that was too strong

0897's Q4 section says *"zero tracked `.launch.py` files exist in nano-ros … so the `.py` path is exercised by no fixture"*. The first half is true — `git ls-files` doesn't descend into submodules — but the conclusion isn't: `play_launch` carries several `.launch.py` fixtures in its own tests. The abi3 measurement covered the `$(eval)` path only, which is what the nano-ros workspaces exercise; it says nothing about `.launch.py` execution cost. The sentence now says so.

## What trying to measure that path found

Resolving one of those fixtures doesn't fail — it **aborts**:

```
panicked at crates/play_launch_parser/src/bridge.rs:367:10:
No LaunchContext set - Python execution must be called through LaunchTraverser
--- PyO3 is resuming a panic after fetching a PanicException from Python. ---
panic in a function that cannot unwind
thread caused non-unwinding panic. aborting.
Segmentation fault (core dumped)
```

The first panic is arguably misuse — that fixture expects to be driven through `LaunchTraverser`. **The abort is not.** `play_launch_py_call` is `extern "C"` and `grep -c catch_unwind c_abi.rs` is **0**, so a panic unwinding out of it is UB and rustc aborts. *Any* panic in the Python half takes the process down with no diagnostic.

That is the failure mode 0897 was filed to remove — its `pyload` header promises *"A `Result`, never an abort."* 0897 delivered that for the **loader**; the execution path still has an abort in it, from a different cause. One artifact, two ways to die, one of them now fixed — which is easy to mistake for the whole thing being fixed.

Filed as **0953** with the `catch_unwind` fix and the two details that make it work (`AssertUnwindSafe`; bump `play_launch_py_abi_version` if the error shape changes).

Worth noting the entry point is otherwise careful about exactly this class — it returns a structured error for a null request, for non-UTF-8, even for a NUL byte in its own response (*"returning null on it would be an unannounced second failure mode"*). Panics are the one path out it doesn't cover.

## Verification

`check-doc-refs` and `check-issue-index` OK. `check-fast` has one unrelated red — `submodule-pinned-locks` — which fails identically with this change **stashed**: this checkout's `play_launch` is at `caab6fbc` while main pins `7ecdee1f`, and syncing a submodule isn't mine to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB