### PR TITLE
fix(#945 item 1): witness that cargo writes into the shared cargo dir

### DIFF
--- a/cmake/NanoRosCorrosion.cmake
+++ b/cmake/NanoRosCorrosion.cmake
@@ -418,8 +418,24 @@ endfunction()
 # for the reason the header of this file gives.
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosSharedCargoDir.cmake")
 
+# Issue 0945 item 1 — captured at FILE scope, CACHE INTERNAL, because
+# `nros_assert_shared_cargo_dir_used()` below is a function and a plain
+# `set(_X ${CMAKE_CURRENT_LIST_DIR})` does not survive the frame pop (the
+# `_NROS_ENTRY_DIR` pattern; it broke every freertos workspace member once).
+set(_NROS_SHARED_CARGO_CHECK_SH
+    "${CMAKE_CURRENT_LIST_DIR}/../scripts/check-shared-cargo-dir-used.sh"
+    CACHE INTERNAL "issue 0945 — shared-cargo-dir redirect assertion")
+
 
 function(nros_share_corrosion_cargo_dir)
+    # Issue 0945 item 1 — report to the caller whether the redirect is ACTUALLY
+    # in place, so it can arm `nros_assert_shared_cargo_dir_used()`. Empty by
+    # default: every path below that does not end with a symlink at the chosen
+    # directory leaves it empty, and the caller must not assert on those. The
+    # degrade branch ("a real `cargo` directory from an earlier build") is a
+    # supported state, not a violation, and arming the check there would turn
+    # every pre-existing build dir red.
+    set(NROS_SHARED_CARGO_DIR "" PARENT_SCOPE)
     # Delegate the keying to `nros_shared_cargo_dir()` above — ONE normalise,
     # hash and record. This function's own job is the part Corrosion forces:
     # redirecting a `--target-dir` it computes itself, which only a symlink can
@@ -478,8 +494,10 @@ function(nros_share_corrosion_cargo_dir)
             "nano-ros: shared-cargo key changed, re-pointing ${_link}\n"
             "  was: ${_prev_key}\n"
             "  now: ${_key_text}")
+        set(NROS_SHARED_CARGO_DIR "${NROS_SHARED_CARGO_DIR}" PARENT_SCOPE)
         return()
         endif()
+        set(NROS_SHARED_CARGO_DIR "${NROS_SHARED_CARGO_DIR}" PARENT_SCOPE)
         return()
     endif()
 
@@ -508,6 +526,58 @@ function(nros_share_corrosion_cargo_dir)
     endif()
     message(STATUS
         "nano-ros: sharing Corrosion cargo dir -> ${NROS_SHARED_CARGO_DIR}")
+    set(NROS_SHARED_CARGO_DIR "${NROS_SHARED_CARGO_DIR}" PARENT_SCOPE)
+endfunction()
+
+# --------------------------------------------------------------------------
+# nros_assert_shared_cargo_dir_used(<shared-dir> <corrosion-target>)
+#
+# Issue 0945 item 1 — make a Corrosion move FAIL instead of silently degrading.
+#
+# The symlink above redirects a `--target-dir` Corrosion derives privately, and
+# Corrosion offers no knob for it — still true on upstream `master` as of
+# 2026-08-31, not merely on the pinned v0.6.1. So the redirect cannot be
+# retired; what it can be given is a witness. If a future Corrosion moves that
+# path, the link points where cargo no longer writes, the build SUCCEEDS, and
+# the only symptom is six platforms getting slower with nobody watching the
+# number.
+#
+# This asserts the RESULT rather than re-deriving the formula: after the target
+# builds, the shared directory must hold this artifact, and the redirect must
+# still be a symlink at the directory this configure chose. A second copy of
+# Corrosion's path rule would drift from it silently, which is the defect and
+# not the fix. See the script for what the check can and cannot catch.
+#
+# Only call this when `nros_share_corrosion_cargo_dir()` reported a live
+# redirect — it leaves `NROS_SHARED_CARGO_DIR` empty on the supported degrade
+# paths (sharing not requested; a real `cargo` directory from an earlier
+# build), and asserting there would turn every pre-existing build dir red.
+# --------------------------------------------------------------------------
+function(nros_assert_shared_cargo_dir_used shared_dir target)
+    if(NOT shared_dir)
+        return()
+    endif()
+    if(NOT TARGET ${target})
+        message(FATAL_ERROR
+            "nros_assert_shared_cargo_dir_used: no target '${target}'. Call "
+            "this AFTER corrosion_import_crate().")
+    endif()
+    set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/nros-shared-cargo-dir-${target}.checked")
+    # A real OUTPUT with a file-level DEPENDS on the artifact, not a POST_BUILD:
+    # issue 0268's rule. The check must re-run whenever cargo produces a new
+    # archive, and only then — a cached build has nothing new to witness.
+    add_custom_command(
+        OUTPUT "${_stamp}"
+        COMMAND bash "${_NROS_SHARED_CARGO_CHECK_SH}"
+            --shared-dir "${shared_dir}"
+            --link "${CMAKE_BINARY_DIR}/cargo"
+            --artifact "$<TARGET_FILE:${target}>"
+            --label "${target}"
+        COMMAND "${CMAKE_COMMAND}" -E touch "${_stamp}"
+        DEPENDS "$<TARGET_FILE:${target}>"
+        COMMENT "nano-ros: checking cargo wrote ${target} into the shared dir (issue 0945)"
+        VERBATIM)
+    add_custom_target(nros_shared_cargo_dir_check_${target} ALL DEPENDS "${_stamp}")
 endfunction()
 
 # A macro, not a function: `find_package` / `FetchContent_MakeAvailable` define

--- a/docs/issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md
+++ b/docs/issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md
@@ -40,10 +40,52 @@ BLAST RADIUS: six platforms (freertos, native, nuttx, qemu-baremetal,
 threadx-linux, threadx-riscv64). This is the campaign's single largest
 dependency on someone else's internals, and it PREDATES phase-400.
 
-MITIGATION IF IT MATTERS: assert at configure time that the symlink target is
-the directory cargo actually writes to — one `find` for a known artifact after
-the first build, compared against the link — so a Corrosion move fails loudly
-instead of degrading.
+MITIGATED 2026-08-31 — the redirect stays, but it is now WITNESSED.
+
+First the retirement question, since it is the better outcome and had not been
+asked: is there a supported knob yet? No. Read against the pinned v0.6.1 AND
+against upstream `master`: the same
+`cmake_path(APPEND CMAKE_BINARY_DIR ${build_dir} cargo "<folder>_<hash5>")`,
+still a plain local, still no cache variable, no `corrosion_import_crate()`
+argument, no target property. So the symlink is not a workaround for a version
+we are behind on — it is the only override point that exists, and "bump
+Corrosion and use the knob" is not available.
+
+What landed instead is `nros_assert_shared_cargo_dir_used()`
+(cmake/NanoRosCorrosion.cmake) driving `scripts/check-shared-cargo-dir-used.sh`
+as a build-time check on every Corrosion leaf that shares. It asserts the
+RESULT, never the formula — a second copy of Corrosion's path rule would drift
+from it silently, which is the defect rather than the fix:
+
+  1. `${CMAKE_BINARY_DIR}/cargo` is still a symlink at the directory THIS
+     configure chose;
+  2. an artifact with the built target's name exists under that directory and
+     its size matches the copy Corrosion produced.
+
+Everything it consumes is documented or ours — `$<TARGET_FILE:...>` and
+stat(2). It parses nothing.
+
+Measured on `examples/native/c/talker` with sharing on: the healthy build prints
+`shared-cargo-dir OK (nros_c-static)`, and all four dead-redirect states fail
+with the artifact paths named. `ninja -t query` puts `libnros_c.a` above the
+`||` line, so the witness re-runs on a real archive change and not on an
+order-only edge (issue 0268's rule); a no-op rebuild does not re-run it.
+
+WHAT IT STILL CANNOT CATCH, precisely: a long-lived build dir that shared
+successfully BEFORE a Corrosion upgrade keeps a same-named artifact in place,
+so with no code change the sizes can still match and this passes. It cannot
+pass for long — any edit moves the size — and it cannot pass at all for a new
+key, which is what a reconfigure after an upgrade produces. Byte-comparing
+would close the hole and cost a full read of a multi-hundred-MB archive on
+every leaf build; not worth it for a performance-regression detector.
+
+Escape hatch: `NROS_ALLOW_UNSHARED_CARGO_DIR=1` downgrades the failure to a
+warning, for someone mid-upgrade who wants the build to finish.
+
+The witness's own negative control (five fixtures, including the state only the
+symlink arm can catch) runs on the NORMAL path, not behind the flag — a witness
+that had quietly stopped witnessing would be this very defect one level up.
+`just check shared-cargo-dir-witness` (fast line) runs it standalone.
 
 ### 2. `--artifact-dir` is an explicitly unstable cargo flag
 
@@ -128,7 +170,17 @@ version exposure.
 
 ## Suggested order if this is picked up
 
-1. **#1**, because it is the largest, the quietest, and it predates the campaign.
-2. **#4**, already in progress — finishing it deletes a whole class.
+1. ~~**#1**, because it is the largest, the quietest, and it predates the
+   campaign.~~ DONE 2026-08-31 — witnessed, not retired; Corrosion still
+   offers no knob to retire it with. See item 1.
+2. **#4**, the one still worth work. W5.c gave the Zephyr lane the OUT_DIR
+   placer, so the W5 blocker is gone and the side channel has one fewer
+   reader — but the WRITE is still there, because the other readers are not
+   migrated: `NanoRosNodeRegister.cmake`, `NanoRosVerbs.cmake`, the px4
+   integration module, and ~20 `just check` lanes that compile against
+   `-Itarget/nros-c-generated`. Counted, not estimated: `git grep -n
+   'nros-c-generated\|nros-cpp-generated'`. Deleting
+   `write_header_to_target_dir` needs all of them moved first, which is a wave,
+   not an afternoon.
 3. **#2** only if the NuttX lane's nightly pin is ever revisited.
 4. **#3** and **#5** are acceptable as-is: both fail loudly, neither gates CI.

--- a/just/check.just
+++ b/just/check.just
@@ -114,7 +114,7 @@ fast-serial: \
     version-lockstep workspace-fmt example-fmt cli-fmt \
     readiness-marker-literals \
     codegen-invocation string-conventions issue-ids knob-single-reader workflow-repo-env doc-recipe-refs \
-    std-census capability-flavour-guards flavour-lanes feature-contract no-std-stdio no-vacuous-tests nextest-binary-filters cmake-find-program-shadowed image-panic-policy cmake-image-policy tier-spin-gap rmw-api-parity rmw-abi-shape rmw-ret-sign rmw-vtable-order rmw-alloc-sites rmw-slot-producers zenohd-router-skips single-rust-staticlib cli-source-dirs rust-targets-covered api-parity-ledger just-recipe-refs \
+    std-census capability-flavour-guards flavour-lanes feature-contract no-std-stdio no-vacuous-tests nextest-binary-filters cmake-find-program-shadowed shared-cargo-dir-witness image-panic-policy cmake-image-policy tier-spin-gap rmw-api-parity rmw-abi-shape rmw-ret-sign rmw-vtable-order rmw-alloc-sites rmw-slot-producers zenohd-router-skips single-rust-staticlib cli-source-dirs rust-targets-covered api-parity-ledger just-recipe-refs \
     absolute-paths \
     c-fmt cpp-fmt python \
     nuttx-integration-makefile eyre-context-alias core-only-predicate workspace-build-output cc-build-policy ffi-struct-mirrors sizes-header-mirrors retired-submodule-refs no-absolute-model-paths \
@@ -1947,6 +1947,18 @@ nextest-binary-filters:
 cmake-find-program-shadowed:
     @python3 scripts/check-cmake-find-program-shadowed.py --self-test
     @python3 scripts/check-cmake-find-program-shadowed.py
+
+# Issue 0945 item 1 — the SELF-TEST half of the shared-cargo-dir witness.
+#
+# The witness itself is a BUILD-time check (it needs an artifact and a build
+# dir, so there is nothing for it to look at here) armed by
+# `nros_assert_shared_cargo_dir_used()` on every Corrosion leaf that shares.
+# What this lane keeps honest is the check's own logic: five fixtures covering
+# the healthy state and the four ways the redirect can be dead, including the
+# one only the symlink arm can catch. A witness that silently stopped
+# witnessing would be the defect it exists to prevent, one level up.
+shared-cargo-dir-witness:
+    @bash scripts/check-shared-cargo-dir-used.sh --self-test
 
 # Issue 0660 — every `just <recipe>` inside a recipe body must name a real one.
 #

--- a/packages/api/nros-c/CMakeLists.txt
+++ b/packages/api/nros-c/CMakeLists.txt
@@ -120,6 +120,23 @@ corrosion_import_crate(
     PROFILE       ${NROS_CARGO_PROFILE}
     LOCKED
 )
+# Issue 0945 item 1 — witness that cargo actually built into the shared
+# directory. The redirect above works by symlinking over a path Corrosion
+# derives privately and offers no knob for, so a Corrosion upgrade that moves
+# that path stops the sharing SILENTLY: the build still succeeds, just slower.
+# No-op unless the redirect is live (`NROS_SHARED_CARGO_DIR` is empty when
+# sharing was not requested, and on the degrade path where `cargo` is already a
+# real directory).
+#
+# Armed on `nros-c` alone and that is deliberate: `${CMAKE_BINARY_DIR}/cargo` is
+# ONE link per build dir, and `nros-cpp` — the only other Corrosion crate that
+# rides it — is imported from a sibling directory scope that cannot see this
+# variable. One witness answers the question for both, and a second would only
+# double the stat(2) calls.
+if(COMMAND nros_assert_shared_cargo_dir_used)
+    nros_assert_shared_cargo_dir_used("${NROS_SHARED_CARGO_DIR}" nros_c-static)
+endif()
+
 # The preset's definition, so the crate resolves `--profile nros-…` without a
 # `[profile.*]` block of its own. No-op for a user-owned profile.
 nros_cargo_profile_env(nros_c-static)

--- a/scripts/check-shared-cargo-dir-used.sh
+++ b/scripts/check-shared-cargo-dir-used.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#
+# Issue 0945 item 1 — did cargo actually write into the shared directory?
+#
+# WHAT THIS GUARDS
+#
+# `nros_share_corrosion_cargo_dir()` collapses a leaf's private cargo target dir
+# onto a shared one by SYMLINKING over `${CMAKE_BINARY_DIR}/cargo`, because
+# Corrosion derives its `--target-dir` as
+#
+#     ${CMAKE_BINARY_DIR}/${build_dir}/cargo/<workspace-folder>_<hash5>
+#
+# and exposes no knob for it — verified against the pinned v0.6.1 AND against
+# upstream `master` (2026-08-31): same `cmake_path(APPEND ...)` line, still no
+# cache variable, no `corrosion_import_crate()` argument, no target property.
+# So the symlink is not a workaround for a version we are behind on; it is the
+# only override point that exists.
+#
+# The exposure is that the redirect depends on a path Corrosion computes
+# PRIVATELY. If a future Corrosion renames or moves that directory, the symlink
+# points somewhere cargo no longer looks. Nothing fails: the build succeeds and
+# silently stops sharing, so the only symptom is that six platforms get slower
+# and no one notices. That is the failure mode this script converts into a loud
+# one.
+#
+# WHAT IT CHECKS, AND WHY THESE TWO THINGS
+#
+# Deliberately NOT a re-implementation of Corrosion's formula — a second copy of
+# the thing we do not control would drift from it silently, which is the defect
+# rather than the fix. Instead it observes the RESULT:
+#
+#   1. `${CMAKE_BINARY_DIR}/cargo` is still a symlink to the shared directory
+#      this configure chose. Catches something replacing the link with a real
+#      directory (an out-of-band `mkdir`, a cleanup script, a stray tool).
+#
+#   2. an artifact with the built target's file NAME exists under the shared
+#      directory, and its SIZE matches the copy Corrosion produced. If cargo has
+#      started writing elsewhere, the shared directory is either empty (a fresh
+#      key — the common case, caught immediately) or holds an artifact stale
+#      against the one just built, whose size differs as soon as any code does.
+#
+# BE HONEST ABOUT THE HOLE IN (2): a long-lived build dir that shared
+# successfully before a Corrosion upgrade keeps a same-named artifact around, so
+# if the code has not changed the sizes can still match and this passes. It
+# cannot pass for long — any edit moves the size — and it cannot pass at all for
+# a new key, which is what a reconfigure after an upgrade produces. A check that
+# fires on the first fresh configure is worth more than one that pretends to be
+# exact.
+#
+# Byte-comparing instead of size-comparing would close that hole and cost a full
+# read of a multi-hundred-MB archive on EVERY leaf build. Not worth it for a
+# performance regression detector.
+#
+# WHY THIS IS NOT ITSELF AN INTERNALS DEPENDENCY
+#
+# Everything it consumes is documented or ours: the artifact path and name come
+# from `$<TARGET_FILE:...>` / `$<TARGET_FILE_NAME:...>` (documented CMake
+# generator expressions), the shared directory is ours, and the rest is stat(2).
+# Nothing here parses Corrosion or cargo internals.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage: check-shared-cargo-dir-used.sh --shared-dir DIR --link PATH --artifact FILE [--label NAME]
+       check-shared-cargo-dir-used.sh --self-test
+
+  --shared-dir  the keyed directory nros_shared_cargo_dir() chose
+  --link        the path symlinked at it (${CMAKE_BINARY_DIR}/cargo)
+  --artifact    the built artifact Corrosion copied out ($<TARGET_FILE:...>)
+  --label       name used in messages (defaults to the artifact basename)
+
+Set NROS_ALLOW_UNSHARED_CARGO_DIR=1 to downgrade a failure to a warning — for
+someone mid-upgrade who wants the build to finish while they fix the redirect.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# The check itself, as a function so `--self-test` can drive it on fixtures.
+# Returns 0 on OK, 1 on a violation; prints its own diagnosis.
+# ---------------------------------------------------------------------------
+shared_cargo_dir_used() {
+    local shared_dir="$1" link="$2" artifact="$3" label="$4"
+    local rc=0
+
+    if [ ! -d "$shared_dir" ]; then
+        echo "shared-cargo-dir: FAIL — the shared directory does not exist:" >&2
+        echo "    $shared_dir" >&2
+        return 1
+    fi
+
+    # --- 1. the redirect is still a symlink at the directory we chose --------
+    if [ ! -L "$link" ]; then
+        echo "shared-cargo-dir: FAIL — $link is not a symlink." >&2
+        if [ -d "$link" ]; then
+            echo "  It is a real directory, so cargo built into this leaf's own" >&2
+            echo "  tree and nothing was shared. Something created it after" >&2
+            echo "  configure, or this build dir predates sharing and the" >&2
+            echo "  configure-time degrade path fired (issue 0805)." >&2
+        fi
+        rc=1
+    else
+        local current
+        current="$(readlink -f "$link" || true)"
+        local want
+        want="$(readlink -f "$shared_dir" || true)"
+        if [ "$current" != "$want" ]; then
+            echo "shared-cargo-dir: FAIL — $link points somewhere else." >&2
+            echo "    points at: ${current:-<dangling>}" >&2
+            echo "    expected:  $want" >&2
+            rc=1
+        fi
+    fi
+
+    # --- 2. the shared directory actually received this artifact ------------
+    local name
+    name="$(basename "$artifact")"
+    if [ ! -f "$artifact" ]; then
+        echo "shared-cargo-dir: FAIL — the built artifact is missing:" >&2
+        echo "    $artifact" >&2
+        return 1
+    fi
+    local want_size
+    want_size="$(stat -c '%s' "$artifact")"
+
+    # maxdepth 6: <shared>/<folder>_<hash>/<triple>/<profile>/<name> is 4, and
+    # a no-triple (host) layout is 3. Six leaves room for a layout change
+    # WITHIN the shared dir without this turning into a second formula.
+    local found
+    found="$(find "$shared_dir" -maxdepth 6 -type f -name "$name" 2>/dev/null || true)"
+
+    if [ -z "$found" ]; then
+        echo "shared-cargo-dir: FAIL — no \`$name\` anywhere under the shared dir." >&2
+        echo "    shared dir: $shared_dir" >&2
+        echo "    built:      $artifact" >&2
+        echo "  cargo is not writing where the symlink points. The likely cause" >&2
+        echo "  is a Corrosion upgrade that moved the \`--target-dir\` it derives" >&2
+        echo "  privately (issue 0945 item 1) — re-read" >&2
+        echo "  nros_share_corrosion_cargo_dir() against the installed" >&2
+        echo "  Corrosion.cmake and move the redirect to the new path." >&2
+        echo "  To build anyway, drop -DNROS_SHARED_CARGO_ROOT (correct, just" >&2
+        echo "  slower) or set NROS_ALLOW_UNSHARED_CARGO_DIR=1." >&2
+        return 1
+    fi
+
+    local matched=0 sizes=""
+    local f sz
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        sz="$(stat -c '%s' "$f")"
+        sizes="${sizes:+$sizes
+}    $sz  $f"
+        if [ "$sz" = "$want_size" ]; then
+            matched=1
+        fi
+    done <<< "$found"
+
+    if [ "$matched" -eq 0 ]; then
+        echo "shared-cargo-dir: FAIL — \`$name\` under the shared dir is STALE." >&2
+        echo "    just built: $want_size bytes  $artifact" >&2
+        echo "    shared dir holds:" >&2
+        printf '%s\n' "$sizes" >&2
+        echo "  Corrosion copied an artifact that did not come from the shared" >&2
+        echo "  directory, so this leaf built into a private tree and the shared" >&2
+        echo "  copy is left over from before (issue 0945 item 1)." >&2
+        return 1
+    fi
+
+    if [ "$rc" -eq 0 ]; then
+        echo "shared-cargo-dir OK ($label): cargo wrote $name into $shared_dir"
+    fi
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# self_test — the five states this can be in, on real files.
+#
+# phase-395 — this runs on the NORMAL path, not only behind the flag. A
+# negative control nobody runs decays into a comment, and that is a sharper
+# risk here than for most gates: this script's whole job is to notice that
+# something upstream moved. A witness that had quietly stopped witnessing would
+# be the exact defect it exists to catch, one level up. Five temp files against
+# a cargo build is not a cost worth reasoning about.
+#
+# Pass `verbose` to print per-case lines (what `--self-test` does); silent
+# otherwise, so a normal build says nothing unless something is wrong.
+# ---------------------------------------------------------------------------
+self_test() {
+    local verbose="${1:-}"
+    local st_fails=0 st_tmp
+    st_tmp="$(mktemp -d)"
+
+    st_case() { # name expected_rc cmd...
+        local name="$1" want="$2"
+        shift 2
+        local got=0
+        "$@" >/dev/null 2>&1 || got=$?
+        if [ "$got" -ne "$want" ]; then
+            echo "  [FAIL] $name: expected rc=$want, got rc=$got" >&2
+            st_fails=$((st_fails + 1))
+        elif [ "$verbose" = "verbose" ]; then
+            echo "  [ok]   $name"
+        fi
+    }
+
+    # (a) the healthy state: link points at the shared dir, cargo wrote there.
+    mkdir -p "$st_tmp/a/shared/nano-ros_1147c/armv7a/release" "$st_tmp/a/build"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/a/shared/nano-ros_1147c/armv7a/release/libnros_c.a"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/a/build/libnros_c.a"   # Corrosion's copy
+    ln -s "$st_tmp/a/shared" "$st_tmp/a/build/cargo"
+    st_case "healthy: link + fresh artifact in the shared dir" 0 \
+        shared_cargo_dir_used "$st_tmp/a/shared" "$st_tmp/a/build/cargo" \
+                              "$st_tmp/a/build/libnros_c.a" nros_c
+
+    # (b) Corrosion moved: it wrote into the leaf's own tree, shared dir empty.
+    #     This is the case a fresh configure after an upgrade produces, and the
+    #     one this script exists for.
+    mkdir -p "$st_tmp/b/shared" "$st_tmp/b/build"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/b/build/libnros_c.a"
+    ln -s "$st_tmp/b/shared" "$st_tmp/b/build/cargo"
+    st_case "moved: shared dir never received the artifact" 1 \
+        shared_cargo_dir_used "$st_tmp/b/shared" "$st_tmp/b/build/cargo" \
+                              "$st_tmp/b/build/libnros_c.a" nros_c
+
+    # (c) Corrosion moved on a build dir that HAD been sharing: the shared copy
+    #     survives but is stale, so the sizes disagree.
+    mkdir -p "$st_tmp/c/shared/nano-ros_1147c/armv7a/release" "$st_tmp/c/build"
+    printf 'OLD' > "$st_tmp/c/shared/nano-ros_1147c/armv7a/release/libnros_c.a"
+    printf 'NEW-AND-LONGER' > "$st_tmp/c/build/libnros_c.a"
+    ln -s "$st_tmp/c/shared" "$st_tmp/c/build/cargo"
+    st_case "moved: shared copy survives but is stale" 1 \
+        shared_cargo_dir_used "$st_tmp/c/shared" "$st_tmp/c/build/cargo" \
+                              "$st_tmp/c/build/libnros_c.a" nros_c
+
+    # (d) the redirect is gone — a real directory where the symlink was.
+    mkdir -p "$st_tmp/d/shared/nano-ros_1147c/armv7a/release" "$st_tmp/d/build/cargo"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/d/shared/nano-ros_1147c/armv7a/release/libnros_c.a"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/d/build/libnros_c.a"
+    st_case "redirect replaced by a real directory" 1 \
+        shared_cargo_dir_used "$st_tmp/d/shared" "$st_tmp/d/build/cargo" \
+                              "$st_tmp/d/build/libnros_c.a" nros_c
+
+    # (e) the link points at a DIFFERENT key's directory — the artifact is
+    #     found (so check 2 passes) and only check 1 can catch it. Guards
+    #     against the two checks being collapsed into one.
+    mkdir -p "$st_tmp/e/shared/nano-ros_1147c/armv7a/release" "$st_tmp/e/other" "$st_tmp/e/build"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/e/shared/nano-ros_1147c/armv7a/release/libnros_c.a"
+    printf 'ARCHIVE-BYTES' > "$st_tmp/e/build/libnros_c.a"
+    ln -s "$st_tmp/e/other" "$st_tmp/e/build/cargo"
+    st_case "link points at another key's directory" 1 \
+        shared_cargo_dir_used "$st_tmp/e/shared" "$st_tmp/e/build/cargo" \
+                              "$st_tmp/e/build/libnros_c.a" nros_c
+
+    rm -rf "$st_tmp"
+    if [ "$st_fails" -ne 0 ]; then
+        echo "check-shared-cargo-dir-used: self-test FAILED ($st_fails case(s))" >&2
+        echo "  The witness cannot be trusted to report on anything else." >&2
+        return 1
+    fi
+    [ "$verbose" = "verbose" ] && echo "check-shared-cargo-dir-used --self-test: 5 case(s) OK"
+    return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    self_test verbose
+    exit $?
+fi
+
+SHARED_DIR=""
+LINK=""
+ARTIFACT=""
+LABEL=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --shared-dir) SHARED_DIR="$2"; shift 2 ;;
+        --link)       LINK="$2";       shift 2 ;;
+        --artifact)   ARTIFACT="$2";   shift 2 ;;
+        --label)      LABEL="$2";      shift 2 ;;
+        -h|--help)    usage; exit 0 ;;
+        *) echo "check-shared-cargo-dir-used: unknown argument '$1'" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [ -z "$SHARED_DIR" ] || [ -z "$LINK" ] || [ -z "$ARTIFACT" ]; then
+    usage
+    exit 2
+fi
+[ -n "$LABEL" ] || LABEL="$(basename "$ARTIFACT")"
+
+# The negative control, on the normal path — see the note above `self_test`.
+self_test || exit 1
+
+if shared_cargo_dir_used "$SHARED_DIR" "$LINK" "$ARTIFACT" "$LABEL"; then
+    exit 0
+fi
+
+if [ "${NROS_ALLOW_UNSHARED_CARGO_DIR:-}" = "1" ]; then
+    echo "shared-cargo-dir: NROS_ALLOW_UNSHARED_CARGO_DIR=1 — continuing unshared." >&2
+    exit 0
+fi
+exit 1


### PR DESCRIPTION
Closes the largest and quietest item on the #945 register: `nros_share_corrosion_cargo_dir()` redirects a `--target-dir` Corrosion derives privately, by symlinking over `${CMAKE_BINARY_DIR}/cargo`. If a Corrosion upgrade moves that path, the link points where cargo no longer writes — the build still **succeeds** and silently stops sharing, so the only symptom is six platforms getting slower with nobody watching the number.

## Retirement was checked first, and is not available

Read against the pinned v0.6.1 **and** upstream `master`: the same
`cmake_path(APPEND CMAKE_BINARY_DIR ${build_dir} cargo "<folder>_<hash5>")`, still a plain local, no cache variable, no `corrosion_import_crate()` argument, no target property. The symlink is the only override point that exists, so "bump Corrosion and use the knob" was off the table before any code was written.

## So the redirect stays and gains a witness

`nros_assert_shared_cargo_dir_used()` drives `scripts/check-shared-cargo-dir-used.sh` as a build-time check on every Corrosion leaf that shares. It asserts the **result**, never the formula — a second copy of Corrosion's path rule would drift from it silently, which is the defect rather than the fix:

1. `${CMAKE_BINARY_DIR}/cargo` is still a symlink at the directory *this* configure chose;
2. an artifact with the built target's name exists under it, sized like the copy Corrosion produced.

Everything consumed is documented or ours: `$<TARGET_FILE:...>` and `stat(2)`. Nothing is parsed.

`nros_share_corrosion_cargo_dir()` now reports the live redirect through `NROS_SHARED_CARGO_DIR` in `PARENT_SCOPE`, empty on both supported degrade paths (sharing not requested; a real `cargo` directory from an earlier build), so the check cannot arm where not sharing is correct.

## Measured

On `examples/native/c/talker` with sharing on:

| case | result |
| --- | --- |
| healthy | `shared-cargo-dir OK (nros_c-static)` — `libnros_c.a` in `<root>/93742a6d5143` |
| empty shared dir | FAIL, paths named |
| stale shared copy | FAIL, sizes printed |
| link replaced by a real dir | FAIL |
| link points at another key | FAIL (only the symlink arm catches this) |

`ninja -t query` puts `libnros_c.a` **above** the `||` line — a real file input, not an order-only edge (issue 0268's rule). A no-op rebuild does not re-run the witness; an archive change does.

`just check fast`: 147/147.

## Two notes

The witness's own negative control runs on the **normal path**, not behind the flag — a witness that had quietly stopped witnessing is this very defect one level up (phase-395). Hence `scripts/` rather than `scripts/build/`, which the selftest ratchet excludes as non-asserting.

What it cannot catch, stated in the issue: a build dir that shared successfully *before* an upgrade keeps a same-named artifact, so with no code change the sizes can still match. It cannot pass for long — any edit moves the size — and cannot pass at all for a new key, which is what a reconfigure after an upgrade produces. Byte-comparing would close the hole and cost a full read of a multi-hundred-MB archive on every leaf build; not worth it for a performance-regression detector.

Escape hatch: `NROS_ALLOW_UNSHARED_CARGO_DIR=1` downgrades the failure to a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe