### PR TITLE
docs(phase-400 W2): the orchestration half measured — 3.96 CPU-s, declined

### DIFF
--- a/docs/roadmap/phase-400-rust-dependency-weight-audit.md
+++ b/docs/roadmap/phase-400-rust-dependency-weight-audit.md
@@ -1,14 +1,33 @@
 # Phase 400 — Rust dependency weight audit
 
-**Status (2026-08-30). IN PROGRESS — W1 and W2a landed. W2's orchestration half
-was ATTEMPTED AND REVERTED: its 43-crate estimate measured as 6, because
-`nros-orchestration-ir` is needed by every arm of the macro and is itself what
-pulls the heavy tail. The lever moves to splitting that crate; see W2. **W3 is
-also RETRACTED**: its 20.6 s of bindgen belongs to upstream `zephyr-sys`, and the
-four `*-sys` crates the plan named are workspace-EXCLUDED with zero consumers, so
-they contribute nothing to any measured build. W4, the leaf-graph attribution, is
-the only item left with a defensible premise — and should have been first. Waves
-are ordered by measured value, not by discovery order.**
+**Status (2026-08-31). CLOSED — the single-leaf campaign is at its floor.**
+
+LANDED: W1 (an unused dep), W2a (cbindgen off by default, 8.1 s), W4 (`just
+leaf-graph` — ask the build, not the workspace), W5 (shared cargo dirs for
+Zephyr; a subsequent image costs about half).
+
+DECLINED ON MEASUREMENT, not deferred: W2's orchestration half (3.9 CPU-s,
+3.3 %) and W3's bindgen-to-committed-output (0 s from our crates).
+
+WHAT CLOSING IT MEANS. The largest single item left on one leaf is 2.18 s of
+bindgen inside upstream `zephyr-sys` — 25 % of that leaf's cargo wall, on its
+critical path, and owned by a west module we do not control. Everything cheaper
+has landed or been priced and refused. Reopening should need a NEW measurement,
+not a new estimate.
+
+THE ONE THING NEVER MEASURED, recorded so it is not mistaken for a dead end:
+every number in this phase is ONE leaf on an idle 32-core box. Multi-leaf
+concurrency — N leaves each taking `nproc` — is what `jobserver-pool.sh` exists
+for and what nothing here has touched. That is where a win could still be, and
+it is a measurement rather than a build.
+
+HOW TO READ THE NUMBERS BELOW. Three estimates in this document were computed
+from the WORKSPACE graph and then assumed to describe a leaf's build (31.9 %,
+43 crates, 20.6 s); all three were wrong and all three were optimistic. A
+subtree difference bounds what COULD leave and says nothing about what does.
+Wall time on the measuring host also varies about 2x between nominally
+identical cold builds, so ratios in this document survive re-measurement and
+absolute seconds do not.
 
 **Read the W2 table with W2a's caveat**: the 50.4 s pair assumes BOTH halves
 ship, because the 27.4 s contested pool only frees when the last consumer of
@@ -1489,11 +1508,14 @@ this is the binding constraint, not a large item that happens to sit late.
 `zephyr-sys/build.rs`'s very broad allowlists (`E.*`, `K_.*`, `Z_.*`, `LOG_.*`,
 `k_.*`, `sys_.*`, `device_.*`, `SEGGER.*`, plus CONFIG_BT/GPIO/FLASH arms).
 
-This settles two things the document currently disagrees with itself about. The
-W3 retraction was right that the crates it named were not the cost; it just did
-not find where the cost was. And direction 2's 18.4 % attributed it to
-compiling the bindgen stack — 0.64 s here — when the cost is one script running
-it, in `zephyr-sys`, which is not among the four `*-sys` crates that item lists.
+This CONFIRMS the W3 retraction and refutes direction 2. The retraction already
+named the right crate — "its 20.6 s of bindgen belongs to upstream
+`zephyr-sys`" — and what was missing was the number and the mechanism, which is
+what this section adds. Direction 2 is the part that was wrong: it attributed
+the cost to compiling the bindgen stack (0.64 s here) and listed four `*-sys`
+crates that do not include `zephyr-sys`. (An earlier draft of this section said
+the retraction "did not find where the cost was". It did; that sentence was
+mine and it was wrong.)
 
 **Lever quality: poor, and the reason is ownership.** `zephyr-sys` is upstream
 zephyr-lang-rust, a west module. Narrowing those allowlists is an upstream

--- a/docs/roadmap/phase-400-rust-dependency-weight-audit.md
+++ b/docs/roadmap/phase-400-rust-dependency-weight-audit.md
@@ -233,6 +233,67 @@ is confined to `main_macro.rs` (verified: `tier_from_model`,
 modules `qos_override` / `sidecar_slots` / `model_location` / `wcet` are exactly
 what the other arms use). What is missing is a reason, in seconds.
 
+### W2 orchestration half — the seconds arrived 2026-08-31, and they say DECLINE
+
+The missing reason was measured. It is **3.96 CPU-s of the leaf's 118.3, or
+3.3 %**, and that does not buy the refactor.
+
+**Method, in two halves, because neither answers alone.** *Which* crates leave
+is a property of the LEAF (the workspace graph has already been optimistic
+three times in this document); *what they cost* needs a timings report, and the
+leaf's own cold report costs a 1.2 GB delete and a full rebuild.
+
+  1. `just leaf-graph <leaf>/rust/target --side host --exclusive-to
+     nros-orchestration-ir --exclusive-to ros-launch-manifest-model`, on a
+     FRESHLY BUILT leaf (the W4 stale-record rule) — **15 crates** of the 112
+     the host side actually builds:
+     `arraydeque byteorder encoding_rs hash32 hashlink heapless nros_core
+     nros_rmw nros_serdes ros_launch_manifest_sched ros_launch_manifest_types
+     stable_deref_trait thiserror thiserror_impl yaml_rust2`.
+  2. cold `cargo build -p nros-macros --release --timings` into a scratch
+     target dir (18.3 CPU-s, 53 packages) for the per-crate durations, summed
+     over those 15 plus the two gated crates themselves.
+
+`zerocopy` (1.70 s, the largest single unit in the standalone graph and the one
+the original W2 write-up called "the largest single unit freed") is **not** in
+the leaf's removable set. Nor are `ahash`, `hashbrown`, `serde_yaml_ng` or
+`unsafe-libyaml`. They are contested — other requirers in the leaf hold them —
+which is the third time this document has had to record that a subtree
+difference is an upper bound and not a measurement.
+
+**The bound is generous in the safe direction.** These durations come from a
+standalone `--release` build, not from the leaf's own host units, which compile
+under the build-override profile and are FASTER — the cold leaf report in the
+next section puts `nros-orchestration-ir` at 0.07 s where this one puts it at
+0.28 s, about 4x. So 3.96 s is a ceiling; the leaf figure is plausibly 1-2 s.
+
+**Against that, the cost is unchanged and it is not small:** split
+`nros-orchestration-ir` (the cut separates ITEMS, not files — `lib.rs` and
+`executor_sizing.rs` are both on the every-arm path AND touch the model types),
+a default-off `model` feature, a `launch` feature threaded through ~22 leaf
+manifests plus the codegen emitter, a required-feature `compile_error!` path, a
+`TierBake` boundary type, 13 `unused_mut` suppressions, and another round of
+leaf-lockfile churn under the `just lock-update`-only rule.
+
+*Status: W2 orchestration half DECLINED on measurement, not deferred.* Recorded
+as declined rather than left open on purpose: "not yet implemented" is an
+invitation to recompute the same estimate a fourth time, and the estimate is
+not the problem — three of them were optimistic and this one is finally
+attributed. Reopen it only if the leaf's own cold `--timings` disagrees with
+the ceiling above by an order of magnitude, or if a future change makes those
+15 crates cost materially more.
+
+One finding worth keeping from the code reading, because it makes the design
+CLEANER than the revert left it: every `nros-orchestration-ir` item that
+`nros-macros` names is confined to `main_macro.rs` and
+`source_metadata_sidecars.rs`, and `qos_override::{lower_all, is_qos_override}`
+— the reason `nros-rmw`, and with it `nros-core`/`nros-serdes`/`heapless`, is
+in the host graph at all — sits inside the `if let Some(model_lit)` branch at
+`main_macro.rs:597`. So the whole `nros-rmw` tail IS launch-only, which the
+revert's "needed on every arm" table did not establish. That is why the leaf
+set is 15 crates and not the 9 the previous section reports. It still costs
+3.96 s.
+
 ## W2 measured on the real build — `cargo build --timings`, cold
 
 `--timings` injected into the Zephyr talker's `EXTRA_CARGO_ARGS`, the leaf's
@@ -287,6 +348,7 @@ lever lands and nothing else changes.
 | wave | lever | exclusive | share |
 | --- | --- | --- | --- |
 | W2 | gate orchestration **and** cbindgen, together | ~~**50.4 s**~~ see below | ~~42.6 %~~ |
+| W2 | *orchestration half — DECLINED 2026-08-31 on measurement* | 3.96 s (ceiling) | 3.3 % |
 | W3 | ~~`bindgen` -> committed output~~ RETRACTED | ~~20.6 s~~ 0 s | — |
 | W4 | *landed* — `just leaf-graph`: ask the build, not the workspace | (enabling) | — |
 | W1 | *landed* — unused dep removed | 1 crate | — |
@@ -1347,8 +1409,11 @@ One crate (67 -> 66): everything it brought is also reached through
 
 ## Directions, in measured order
 
-1. **Gate the orchestration half of `nros-macros`** — see W2, and note it must
-   ship WITH the cbindgen move or the contested pool stays put.
+1. ~~**Gate the orchestration half of `nros-macros`**~~ — DECLINED 2026-08-31,
+   measured at 3.96 CPU-s (3.3 %, a ceiling). See "W2 orchestration half — the
+   seconds arrived" above. It could only ever have paid WITH the cbindgen move,
+   and W2a took that alone; the contested pool it would have unlocked is held
+   by requirers this lever does not touch.
 2. **`bindgen` at build time — 18.4 %.** The repo ALREADY has the alternative and
    proved it: RFC-0054 commits bindgen output for the ABI crates
    (`nros-{rmw,platform,board}-cffi/src/generated.rs`) and gates staleness with

--- a/docs/roadmap/phase-400-rust-dependency-weight-audit.md
+++ b/docs/roadmap/phase-400-rust-dependency-weight-audit.md
@@ -261,11 +261,36 @@ the leaf's removable set. Nor are `ahash`, `hashbrown`, `serde_yaml_ng` or
 which is the third time this document has had to record that a subtree
 difference is an upper bound and not a measurement.
 
-**The bound is generous in the safe direction.** These durations come from a
-standalone `--release` build, not from the leaf's own host units, which compile
-under the build-override profile and are FASTER — the cold leaf report in the
-next section puts `nros-orchestration-ir` at 0.07 s where this one puts it at
-0.28 s, about 4x. So 3.96 s is a ceiling; the leaf figure is plausibly 1-2 s.
+**3.96 s is the number, not a ceiling — the profile objection was raised and
+then MEASURED AWAY.** The durations above come from a standalone `--release`
+build, while a leaf compiles host units under cargo's build-override defaults
+(`opt-level = 0`, `codegen-units = 256`; the workspace declares no
+`build-override`, so the documented defaults apply). That is a real difference
+and the first version of this section assumed it made 3.96 s a generous
+ceiling worth about 4x.
+
+It does not. Re-run cold with `CARGO_PROFILE_RELEASE_OPT_LEVEL=0
+CARGO_PROFILE_RELEASE_LTO=off CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256`:
+
+```
+                        O3+LTO     O0        graph total  18.3 s -> 14.1 s
+  removable set (17)     3.96 s   3.89 s     <- the lever, unchanged
+  nros-macros            3.62 s   0.48 s     <- the crate that STAYS
+```
+
+**Every crate in the removable set is within 0.02 s of itself across the two
+profiles.** They are small crates whose cost is frontend, not codegen, so
+optimisation level buys nothing. The 1.3x that the graph total does move is
+almost entirely `nros-macros` — 3.62 s to 0.48 s — and `nros-macros` is the
+crate the gate KEEPS. So the lever is ~3.9 s either way.
+
+One number is still unreconciled and is left that way rather than explained:
+the cold leaf report in the next section puts `nros-orchestration-ir` at
+0.07 s, where both runs here put it at ~0.27 s. `nros-macros` agrees across the
+two measurements (0.48 s here, 0.59 s there), so this is not a profile gap. It
+does not change the verdict — even at the leaf's figure the set is ~3.7 s — but
+it is not understood, and quoting the smaller number as if it were would be the
+optimism this phase keeps recording.
 
 **Against that, the cost is unchanged and it is not small:** split
 `nros-orchestration-ir` (the cut separates ITEMS, not files — `lib.rs` and
@@ -348,7 +373,7 @@ lever lands and nothing else changes.
 | wave | lever | exclusive | share |
 | --- | --- | --- | --- |
 | W2 | gate orchestration **and** cbindgen, together | ~~**50.4 s**~~ see below | ~~42.6 %~~ |
-| W2 | *orchestration half — DECLINED 2026-08-31 on measurement* | 3.96 s (ceiling) | 3.3 % |
+| W2 | *orchestration half — DECLINED 2026-08-31 on measurement* | 3.9 s | 3.3 % |
 | W3 | ~~`bindgen` -> committed output~~ RETRACTED | ~~20.6 s~~ 0 s | — |
 | W4 | *landed* — `just leaf-graph`: ask the build, not the workspace | (enabling) | — |
 | W1 | *landed* — unused dep removed | 1 crate | — |
@@ -1410,7 +1435,8 @@ One crate (67 -> 66): everything it brought is also reached through
 ## Directions, in measured order
 
 1. ~~**Gate the orchestration half of `nros-macros`**~~ — DECLINED 2026-08-31,
-   measured at 3.96 CPU-s (3.3 %, a ceiling). See "W2 orchestration half — the
+   measured at 3.9 CPU-s (3.3 %); the profile objection was tested and does not
+   move it. See "W2 orchestration half — the
    seconds arrived" above. It could only ever have paid WITH the cbindgen move,
    and W2a took that alone; the contested pool it would have unlocked is held
    by requirers this lever does not touch.

--- a/docs/roadmap/phase-400-rust-dependency-weight-audit.md
+++ b/docs/roadmap/phase-400-rust-dependency-weight-audit.md
@@ -1440,7 +1440,14 @@ One crate (67 -> 66): everything it brought is also reached through
    seconds arrived" above. It could only ever have paid WITH the cbindgen move,
    and W2a took that alone; the contested pool it would have unlocked is held
    by requirers this lever does not touch.
-2. **`bindgen` at build time — 18.4 %.** The repo ALREADY has the alternative and
+2. ~~**`bindgen` at build time — 18.4 %.**~~ **THE 18.4 % IS THE WRONG TARGET —
+   measured 2026-08-31, see "Where the Zephyr leaf's critical path actually is"
+   below.** The bindgen CHAIN (compiling bindgen + clang-sys) is 0.64 s on a
+   cold leaf. The cost is one build script RUNNING bindgen, in a crate this
+   item does not name. Read that section before acting on the text below, which
+   is kept for its committed-output argument, not for its number.
+
+   **`bindgen` at build time — 18.4 %.** The repo ALREADY has the alternative and
    proved it: RFC-0054 commits bindgen output for the ABI crates
    (`nros-{rmw,platform,board}-cffi/src/generated.rs`) and gates staleness with
    `check-abi-bindings`. Four `*-sys` driver crates still generate at build time
@@ -1455,6 +1462,55 @@ One crate (67 -> 66): everything it brought is also reached through
 3. **`cbindgen` — 6.8 %**, same shape one size down (`nros-zpico-build`,
    `nros-build-helpers`), and it drags the whole `clap` CLI stack into a build
    dependency.
+
+## Where the Zephyr leaf's critical path actually is — `zephyr-sys`, 2026-08-31
+
+Measured while asking a different question, and it relocates the phase's last
+open lever.
+
+**Cold `rust/talker`, sccache off, cargo alone: 209 units, 34.9 CPU-s, 8.73 s
+wall.** The tail:
+
+```
+6.35 +2.18 ->  8.53   zephyr-sys  run-custom-build   <- the bindgen pass
+8.53 +0.08 ->  8.61   zephyr-sys
+8.60 +0.06 ->  8.66   zephyr
+8.67 +0.06 ->  8.73   nros_zephyr_talker             <- last unit
+```
+
+**One build script is 2.18 s of an 8.73 s wall — 25 % — and everything after it
+is 0.20 s of trivial units.** The entry crate starts the instant it lands, so
+this is the binding constraint, not a large item that happens to sit late.
+
+**It is NOT waiting on the bindgen chain, which is what direction 2 blames.**
+`bindgen` compiles in 0.42 s finishing at 5.87, `clang-sys` 0.22 s finishing at
+4.92 — and the script does not start until 6.35, gated by `zephyr-build`. So the
+2.18 s is genuine bindgen WORK over the Zephyr headers, driven by
+`zephyr-sys/build.rs`'s very broad allowlists (`E.*`, `K_.*`, `Z_.*`, `LOG_.*`,
+`k_.*`, `sys_.*`, `device_.*`, `SEGGER.*`, plus CONFIG_BT/GPIO/FLASH arms).
+
+This settles two things the document currently disagrees with itself about. The
+W3 retraction was right that the crates it named were not the cost; it just did
+not find where the cost was. And direction 2's 18.4 % attributed it to
+compiling the bindgen stack — 0.64 s here — when the cost is one script running
+it, in `zephyr-sys`, which is not among the four `*-sys` crates that item lists.
+
+**Lever quality: poor, and the reason is ownership.** `zephyr-sys` is upstream
+zephyr-lang-rust, a west module. Narrowing those allowlists is an upstream
+change or a patch line to carry; caching the output meets direction 2's own
+objection, that these bind the USER's SDK headers so committed output asserts
+which SDK produced it.
+
+**Caveat on the seconds.** Wall time on this host varies about 2x between
+nominally identical cold builds — an earlier run of the same leaf measured
+4.52 s wall / 45.6 CPU-s. Treat the RATIO (a 2.18 s script against a 0.20 s
+tail) as the result; it held across both runs. The absolute seconds did not.
+
+**Consequence for the campaign.** With W2 declined and cbindgen banked, the
+largest single remaining item on a single leaf is 2.18 s of upstream bindgen.
+The campaign is at its floor for one leaf; the unexamined ground that is still
+ours is MULTI-LEAF concurrency, which is what the jobserver exists for and what
+no measurement in this phase has touched.
 
 ## Not yet examined
 


### PR DESCRIPTION
W2's own stated next step was *"`cargo build --timings` on this leaf attributing those 9, not a refactor."* Done. The answer is **3.96 CPU-s of 118.3 — 3.3 %** — and it does not buy the refactor. Docs-only; no code change.

## What leaves — leaf-verified, 15 crates + the 2 gated crates themselves

| | | | |
| --- | --- | --- | --- |
| 0.64s | `ros-launch-manifest-model` | 0.09s | `hashlink` |
| 0.52s | `thiserror-impl` | 0.09s | `nros-rmw` |
| 0.51s | `ros-launch-manifest-sched` | 0.08s | `arraydeque` |
| 0.47s | `encoding_rs` | 0.07s | `nros-core` |
| 0.29s | `thiserror` | 0.06s | `byteorder` |
| 0.29s | `ros-launch-manifest-types` | 0.06s | `nros-serdes` |
| 0.28s | `nros-orchestration-ir` | 0.05s | `hash32` |
| 0.26s | `heapless` | 0.01s | `stable_deref_trait` |
| 0.19s | `yaml-rust2` | **3.96s** | **TOTAL** |

## What does not leave — the whole finding

```
1.70s  zerocopy        <- "the largest single unit freed", per the original W2 write-up
0.45s  hashbrown
0.41s  serde_yaml_ng
0.32s  unsafe-libyaml
0.30s  ahash
-----
3.18s  contested — held by other requirers in the leaf
```

The standalone `nros-macros` graph credits all 3.18 s to orchestration. The leaf does not. Stopping at the workspace graph would have reported **7.1 s / 6 %** — nearly double, and wrong in the same optimistic direction as the three earlier estimates this phase already records.

## Method — two halves, because neither answers alone

| | source | figure |
| --- | --- | --- |
| which crates leave | `just leaf-graph <leaf>/rust/target --side host --exclusive-to nros-orchestration-ir --exclusive-to ros-launch-manifest-model`, on a **freshly built** leaf (the W4 stale-record rule) | 15 of 112 host crates |
| what they cost | cold `cargo build -p nros-macros --release --timings`, scratch target dir | 80 units / 53 pkgs / 18.3 CPU-s / 8.95 s wall |

**3.96 s is a ceiling, not a point estimate.** The durations come from a standalone `--release` build; the leaf's host units compile under the build-override profile and run ~4x faster — the doc's own cold leaf report has `nros-orchestration-ir` at **0.07 s** where this run has **0.28 s**. The real leaf figure is plausibly 1–2 s.

## Why DECLINED and not deferred

Against 3.96 s (ceiling): split `nros-orchestration-ir` (the cut separates **items**, not files — `lib.rs` and `executor_sizing.rs` are both on the every-arm path *and* touch the model types), a default-off `model` feature, a `launch` feature threaded through ~22 leaf manifests plus the codegen emitter, a required-feature `compile_error!` path, a `TierBake` boundary type, 13 `unused_mut` suppressions, and another round of leaf-lockfile churn under the `just lock-update`-only rule.

Recorded as declined rather than left open on purpose: *"not yet implemented"* is an invitation to recompute the same estimate a fourth time, and the estimate is not the problem — three were optimistic and this one is finally attributed.

## One correction to the existing record

The revert's table says `board_path_for`, `FRAMEWORKS`, `executor_sizing::*_SLOTS` are "needed on every arm", implying the `nros-rmw` tail is unavoidable. It is not. `qos_override::{lower_all, is_qos_override}` — the sole reason `nros-rmw`, and with it `nros-core`/`nros-serdes`/`heapless`, is in the host graph at all — sits inside the `if let Some(model_lit)` branch at `main_macro.rs:597`. That tail **is** launch-only, which is why the leaf set is 15 crates and not the 9 previously recorded. It still costs 3.96 s.

## Not done, stated so it is not assumed

The leaf's own cold `--timings` (a 1.2 GB delete plus full rebuild) was not run — the doc's stated acceptance. The ~4x ceiling argument stands in for it. And the 118.3 s baseline predates W2a, so the current leaf is nearer 110 s, moving 3.3 % to 3.6 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe