### PR TITLE
docs(0953): the crash I filed was a stale checkout — the unguarded boundary is not

### DIFF
--- a/docs/issues/0953-pyexec-panic-crosses-c-abi.md
+++ b/docs/issues/0953-pyexec-panic-crosses-c-abi.md
@@ -8,7 +8,30 @@ area: tooling
 related: [0897, 0915, 0914]
 ---
 
-## What happens
+## CORRECTION — the reproduction below was against a STALE checkout
+
+The `No LaunchContext set` panic that produced the core dump is **already
+fixed** at the commit nano-ros pins (`7ecdee1f`, via issue 0935 — "exec_file
+carries its context BOTH ways across the dlopen boundary"). My checkout was at
+`caab6fbc`, one pin behind, and I read a crash from it as current behaviour.
+Re-tested at the pin with NO guard: the same file resolves cleanly.
+
+That is the stale-tree trap this repository documents at length ("a test result
+is only about the tree its FIXTURES were built from"), and it is the reason the
+transcript below is kept rather than deleted — a filing whose evidence turned
+out to be an artefact should say so.
+
+**What survives, and it survives on its own:** the boundary is unguarded.
+`grep -c catch_unwind c_abi.rs` at the pin is **0**, so ANY panic in the Python
+half still aborts the process. It is now a latent robustness gap rather than an
+observed crash, and it is worth closing because the abort is unconditional when
+it happens and carries no diagnostic.
+
+Fixed in `play_launch` on `fix/0953-catch-unwind-at-c-abi`, proved by a
+mutation check: with the guard deleted the pyexec suite does not fail, it dies
+with `SIGABRT` / "thread caused non-unwinding panic. aborting".
+
+## What happens (against `caab6fbc` — see the correction above)
 
 Resolving a `.launch.py` with the shipped `nros-launch-resolve` does not fail —
 it **aborts and dumps core**:


### PR DESCRIPTION
Went to fix 0953 and found **its evidence was wrong.**

The `No LaunchContext set` panic that dumped core is **already fixed** at the commit nano-ros pins (`7ecdee1f`, via issue 0935 — *"exec_file carries its context BOTH ways across the dlopen boundary"*). My submodule checkout was at `caab6fbc`, one pin behind, and I read a crash from it as current behaviour. Re-tested at the pin with **no** guard: the same file resolves cleanly, 1 node.

That's the stale-tree trap this repository documents at length — *"a test result is only about the tree its FIXTURES were built from"* — and I'd quoted it to the user twice in this same session before walking into it.

The transcript stays in the issue rather than being deleted: a filing whose evidence turned out to be an artefact should say so, or the next reader re-derives the wrong conclusion from a convincing-looking log.

## What survives — and it never depended on the repro

The boundary is unguarded. `grep -c catch_unwind c_abi.rs` at the pin is **0**, so any panic in the Python half aborts the process — unconditionally, with no diagnostic. That's a *latent robustness gap* rather than an observed crash, which is a weaker claim than the one I filed, and still worth closing.

## The fix, proved by mutation

Committed in `play_launch` on `fix/0953-catch-unwind-at-c-abi`:

- body moves to `call_inner` returning a `Response`, so the `extern "C"` shim owns both the guard and the serialisation — one place turns one into the other;
- `panic_message` reads the two payload shapes `panic!` produces, so the original text survives ("panicked" alone leaves the reader no better off than the abort did);
- **not** an ABI change — no new field, no new shape, one more `ok: false` reason on a channel that already carries them, so `play_launch_py_abi_version` is deliberately unchanged.

A `#[cfg(test)]`-only `__test_panic` op is the only way to drive a panic through the *real* export; it's compiled out of the shipped cdylib. Mutation-checked — with the `catch_unwind` deleted the suite doesn't fail, it **dies**:

```
thread caused non-unwinding panic. aborting.
process didn't exit successfully: … (signal: 6, SIGABRT)
```

With it, 17 tests pass.

**The submodule branch is committed locally and not pushed** — bumping the nano-ros pin is the maintainer's call, after it lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB