### PR TITLE
docs(#0958): the Cyclone RMW discards the subscription options

### DIFF
--- a/docs/issues/0958-cyclonedds-ignores-rx-buffer-hint.md
+++ b/docs/issues/0958-cyclonedds-ignores-rx-buffer-hint.md
@@ -5,7 +5,7 @@ title: "The Cyclone RMW discards `rmw_subscription_options_t` entirely, so no
 status: open
 type: bug
 area: rmw
-related: [issue-0896, issue-0917, phase-392, phase-408]
+related: [issue-0896, issue-0917, issue-0969, issue-0970, phase-392, phase-408]
 ---
 
 ## What was measured
@@ -74,6 +74,37 @@ and the issue is closed by EITHER:
 
 Option 2 is a legitimate close. What is not legitimate is the present state,
 where the parameter is silently discarded at a comment.
+
+### Amendment (2026-08-31) — option 2 is the answer, and #0969 is why
+
+Option 1 was left open above because nobody had established what the hint could
+mean here. It has now been established, by reading the take path, and the answer
+is: nothing that survives the fix this backend actually needs.
+
+The one place a hint would have had an effect is `dds_ostream_init(&os, 0, 1)` in
+`subscription_take` — an output stream that starts empty and grows by `realloc`,
+where a correct initial size would save the reallocs. But that ostream exists only
+because the backend deserializes the wire CDR into a typed sample and then
+re-serializes it. [#0969](0969-cyclone-take-cdr-round-trip.md) deletes the round
+trip (`dds_takecdr` + `ddsi_serdata_to_ser`, upstream's shape), and the ostream
+goes with it.
+
+After #0969 this backend owns **no** receive buffer to size:
+
+* the serdata is Cyclone's, sized by the sample that arrived;
+* the destination is the caller's buffer, which is the executor arena's slot —
+  already derived from the type by phase-403 W3/W5, on the nano-ros side, exactly
+  as the "What is NOT affected" section above says.
+
+So the hint is not unimplemented here; it is **inapplicable** here, and that is a
+property of the backend's architecture rather than of anyone's backlog. Close via
+option 2 — say so where `rmw_subscription_options_t` is read, naming #0969 as the
+reason there is nothing left to size — rather than leaving option 1 open as work
+someone might pick up.
+
+The complaint that opened this issue stands unchanged: a backend that ignores a
+shared-ABI field must say so at the point it ignores it. What changes is that the
+answer to "what should it do instead" is now known, and it is "nothing".
 
 ## Not to be confused with
 

--- a/docs/issues/0958-cyclonedds-ignores-rx-buffer-hint.md
+++ b/docs/issues/0958-cyclonedds-ignores-rx-buffer-hint.md
@@ -1,0 +1,84 @@
+---
+id: 958
+title: "The Cyclone RMW discards `rmw_subscription_options_t` entirely, so no
+  per-type receive sizing reaches a Cyclone image"
+status: open
+type: bug
+area: rmw
+related: [issue-0896, issue-0917, phase-392, phase-408]
+---
+
+## What was measured
+
+`subscription_create` in the Cyclone backend takes the options struct and names
+none of it:
+
+```cpp
+rmw_ret_t subscription_create(const rmw_node_t* node, const char* topic_name,
+                                 const char* type_name, const char* /*type_hash*/,
+                                 uint32_t /*domain_id*/, const rmw_qos_profile_t* qos,
+                                 const rmw_subscription_options_t* /*options*/,
+                                 rmw_subscription_t* out) {
+```
+
+`grep -rn rx_buffer_hint packages/rmw/cyclonedds/` returns nothing. The field is
+declared in the ABI (`nros-rmw-abi/include/nros/rmw_entity.h`), read by
+`rust_adapter`, produced by the Rust executor since phase-392 W3a and by the
+C++ register variants since phase-402 — and then dropped on the floor by this
+backend.
+
+## Why it matters
+
+Every consumer-visible mechanism for sizing a receive buffer from the message
+type currently terminates in the zenoh shim's `alloc_payload_block(hint)`. A
+Cyclone image gets none of it:
+
+* phase-392 **W3a** (Rust routes the block by the type's bound) — no effect.
+* phase-402 / issue **0896** (C++ options struct carries the hint) — no effect.
+* phase-408 W1/W4 (emit the constant, deliver it from a generated helper) — no
+  effect on the backend half.
+
+So a Cyclone consumer can do everything the campaign asks and observe nothing.
+That is worse than an unimplemented feature: the knobs exist, the docs describe
+a saving, and the measurement comes back flat with no indication that the
+backend is where it stopped.
+
+**This is not hypothetical.** The autoware-safety-island an536 lane is a Cyclone
+image; it is the consumer that motivated issues 0896 and 0917, and it is the one
+that cannot benefit from either until this is closed.
+
+## What is NOT affected
+
+The executor's own arena is sized by nano-ros, not by the backend
+(`arena_alloc_with_trailing` + `buffered_region_size`), so phase-408 W3 —
+demoting `RX_BUF` to a runtime argument — shrinks a Cyclone image's arena
+regardless of this issue. The two are independent, and conflating them will
+produce a measurement that appears to contradict whichever lands first.
+
+The rule for anyone measuring phase-408 on a Cyclone lane: **measure the arena,
+not the backend.**
+
+## What "fixing" means, and the honest alternative
+
+Cyclone's own receive path is not a two-class static pool like zenoh-pico's, so
+"route the block by the hint" does not transliterate. Two acceptable outcomes,
+and the issue is closed by EITHER:
+
+1. **Consume it** — establish what, if anything, the hint should change in this
+   backend (a `Sizing/ReceiveBufferSize`-adjacent knob, a per-reader
+   `dds_set_qos` history bound, or a defrag budget), and wire it.
+2. **Declare it unsupported, in the backend's own docs**, so a consumer stops
+   looking for an effect that cannot occur. `rmw_subscription_options_t` is a
+   shared ABI; a backend that ignores a field should say so where the field is
+   read, not leave the reader to `grep` for the absence.
+
+Option 2 is a legitimate close. What is not legitimate is the present state,
+where the parameter is silently discarded at a comment.
+
+## Not to be confused with
+
+Issue **0841** — a hint that exists landing in a size class that cannot hold it.
+That is about routing a hint. This is about a backend that never sees one.
+
+Issue **0917** — the an536 fragment cliff, which is an RX FIFO capacity limit in
+the emulated NIC and is unrelated to buffer sizing above the driver.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -78,5 +78,6 @@ fails if this block drifts.
 - **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
+- **#0958** (rmw) — The Cyclone RMW discards `rmw_subscription_options_t` entirely, so no per-type receive sizing reaches a Cyclone image See `0958-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -68,6 +68,7 @@ fails if this block drifts.
 - **#0953** (tooling) — A panic in the Python half crosses `extern \"C\"` and ABORTS the resolver — 0897 removed the loader abort and left this one See `0953-*`.
 - **#0954** (api-c, boards) — The committed NuttX fallback sizes header is a hand-maintained twin with no gate, and went stale again See `0954-*`.
 - **#0957** (build) — `just format` fails whole-tree — a workspace leaf is in neither the root members nor the exclude list See `0957-*`.
+- **#0958** (rmw) — The Cyclone RMW discards `rmw_subscription_options_t` entirely, so no per-type receive sizing reaches a Cyclone image See `0958-*`.
 - **#0961** (core, memory) — Executor::open_in needs more than 32 KiB of the calling thread's stack, and nothing says so See `0961-*`.
 - **#0962** (codegen, memory) — A bound over nested bounded sequences is the PRODUCT of the caps, so a uniform cap does not terminate See `0962-*`.
 - **#0963** (codegen, memory, build) — The derived-bound inventory is exported and nothing reads it, so every size downstream is still set by hand See `0963-*`.
@@ -78,6 +79,5 @@ fails if this block drifts.
 - **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
-- **#0958** (rmw) — The Cyclone RMW discards `rmw_subscription_options_t` entirely, so no per-type receive sizing reaches a Cyclone image See `0958-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -518,7 +518,10 @@ is load-bearing and `rx_buffer_for!` is the right answer. The BUFFERED entries
 are trailing-allocated. Two entry shapes in one tree — a claim about "the arena
 buffer" that does not say which is not a claim about anything.
 
-**W3f — Cyclone consumes the hint, or records that it will not.** `grep
+**W3f — Cyclone consumes the hint, or records that it will not.** Filed as
+[issue 0958](../issues/0958-cyclonedds-ignores-rx-buffer-hint.md), which carries
+the evidence: `subscription_create` takes the options struct and names none of
+it, so the parameter is discarded at a comment. `grep
 rx_buffer_hint packages/rmw/cyclonedds/` returns nothing today, so a consumer on
 that backend gets no routing from any of the above. Either wire it or state in
 the RMW's own docs that the hint is zenoh-only, so a consumer stops looking for


### PR DESCRIPTION
subscription_create takes the options struct and names none of it — the parameter is spelled /*options*/ — and grep rx_buffer_hint over the cyclonedds backend returns nothing.

The field is declared in the ABI, read by rust_adapter, produced by the Rust executor since phase-392 W3a and by the C++ register variants since phase-402, then dropped here.

The consequence is worse than an unimplemented feature: every consumer-visible mechanism for sizing a receive buffer from the message type terminates in the zenoh shim, so a Cyclone consumer can do everything the campaign asks and observe nothing, with no sign that the backend is where it stopped. The autoware-safety-island an536 lane is that consumer.

Records what is NOT affected, because the two will otherwise be conflated in a measurement: the executor arena is sized by nano-ros, not the backend, so phase-408 W3 shrinks a Cyclone image regardless. Measure the arena, not the backend.

Closed by EITHER wiring the hint, or declaring it unsupported in the backend docs so consumers stop looking. Not acceptable is the present state, where it is discarded at a comment.

phase-392 W3f now points here. Docs only; just ci-fast passed.