### PR TITLE
fix(#0951): a board did not record its own rustc triple

### DIFF
--- a/docs/issues/0951-site-config-keys-on-deploy-not-board.md
+++ b/docs/issues/0951-site-config-keys-on-deploy-not-board.md
@@ -89,6 +89,44 @@ Landed so far:
   fallback, `doctor`, `board_facts`, and `synthesise_self_bringup` (which wrote
   no images at all, silently losing every value for self-bringup packages).
 
+* **`resolve_target` selects an IMAGE** (`--image`, alias `--target` → the sole
+  image `select_default_images` picks → the sole deprecated `[deploy.<t>]`).
+  `[system].default_target` is retired: it named the deploy era's concept and
+  is authored nowhere. The field still parses — `SystemToml` is
+  `deny_unknown_fields`, so deleting it would turn an unused key into a hard
+  parse error for an out-of-tree user — and a warning says it decides nothing.
+  A `default_images` naming no declared image now FAILS the plan instead of
+  silently downgrading it to target-agnostic.
+
+### A board did not record its own rustc triple
+
+Found while making the plan derive the triple instead of copying
+`[deploy.*].target`, which `[image.*]` deliberately does not carry (RFC-0065
+D9 — the board descriptor owns it).
+
+It did not own it. `BoardDescriptor::target` expects a scalar `target = "..."`
+on the `[[board]]` table, and **no shipped descriptor uses that spelling**. The
+triple is written inside the `cargo_config` STRING TEMPLATE — as
+`[build] target = "..."`, or implied by the sole `[target.<triple>]` header —
+so the field was `None` for every board in the tree.
+
+Two consumers read it, and both failed open:
+
+* `cmd/build.rs` drops `--target` when it is `None`, with a comment saying that
+  "builds the image for the HOST — silently, since cargo is happy to", and
+  claiming phase-383 W9 had fixed it. The fix never fired. Measured, by
+  disabling the new inference and re-running: `nros build --dry-run freertos`
+  in `examples/workspaces/rust` emits `cargo build -p freertos_entry` with **no
+  `--target`**; with the inference it emits `--target thumbv7m-none-eabi`.
+* `builder/preflight.rs` checks whether the board's Rust target is installed,
+  so `rustup target add <triple>` was never suggested either.
+
+Fixed by parsing the triple out of the `cargo_config` template — as TOML, not
+by regex, so a triple mentioned inside a rustflag is not mistaken for a
+declaration — and only when unambiguous (`[build].target`, else exactly one
+`[target.*]` key). `shipped_boards_resolve_their_rustc_triple` is the
+regression pin, at the layer where the fact lives.
+
 Still open — the build half:
 * **the last `[deploy.*]` block per bringup** — one `kind = "self"` each, the
   implicit machine the system runs on. It is a machine, so it belongs in

--- a/packages/cli/nros-build/src/lib.rs
+++ b/packages/cli/nros-build/src/lib.rs
@@ -230,6 +230,11 @@ pub fn generate_run_plan_with(opts: &Options) -> Result<PathBuf> {
     let plan_options = PlanOptions {
         system_pkg: opts.system_pkg.clone(),
         workspace_root: opts.workspace_root.clone(),
+        // Issue 0951 — let the planner run its own ladder (`NROS_REPO_DIR`,
+        // then an autodetect walk from the workspace). A build script has no
+        // better answer than that, and inventing one here would be a second
+        // opinion about where the board catalog lives.
+        nano_ros_path: None,
         launch_file: model_path.clone(),
         record_file: Some(record_tmp),
         out_root: plan_out_root.clone(),

--- a/packages/cli/nros-cli-core/src/cmd/plan.rs
+++ b/packages/cli/nros-cli-core/src/cmd/plan.rs
@@ -71,12 +71,22 @@ pub struct Args {
     #[arg(long = "rmw")]
     pub rmw: Option<String>,
 
-    /// Phase 256 — select the `[image.<t>]` (or deprecated `[deploy.<t>]`) the
-    /// planner resolves per-target values against (RMW override, build tuning,
-    /// domain/locator). Omitted → `[system].default_target` → the sole
-    /// `[image.<t>]`, then the sole `[deploy.<t>]` → target-agnostic.
-    #[arg(long = "target")]
+    /// Phase 256 / issue 0951 — select the `[image.<id>]` the planner resolves
+    /// per-target values against (RMW override, build tuning, the rustc
+    /// triple). Omitted → the sole image `default_images` picks → the sole
+    /// deprecated `[deploy.<t>]` → target-agnostic.
+    ///
+    /// `--target` is kept as an ALIAS, not a second flag: it named the deploy
+    /// era's concept, and the value callers pass is now an image id.
+    #[arg(long = "image", alias = "target")]
     pub target: Option<String>,
+
+    /// nano-ros checkout holding `packages/boards`, used to derive the selected
+    /// image's rustc triple from its board descriptor. Defaults to
+    /// `NROS_REPO_DIR`, then an autodetect walk — the same ladder
+    /// `nros build` uses.
+    #[arg(long = "nano-ros-path")]
+    pub nano_ros_path: Option<std::path::PathBuf>,
 
     /// Launch arguments forwarded as name:=value or name=value
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -146,6 +156,7 @@ pub fn run(args: Args) -> Result<()> {
         let tmp = tempfile::NamedTempFile::new()?;
         std::fs::write(tmp.path(), serde_json::to_string_pretty(&record)?)?;
         let output = plan_system(PlanOptions {
+            nano_ros_path: args.nano_ros_path.clone(),
             system_pkg,
             workspace_root,
             launch_file: model_path.clone(),
@@ -194,6 +205,7 @@ pub fn run(args: Args) -> Result<()> {
         let tmp = tempfile::NamedTempFile::new()?;
         std::fs::write(tmp.path(), serde_json::to_string_pretty(&record)?)?;
         let output = plan_system(PlanOptions {
+            nano_ros_path: args.nano_ros_path.clone(),
             system_pkg,
             workspace_root,
             launch_file: launch_input_path.clone(),
@@ -234,6 +246,7 @@ pub fn run(args: Args) -> Result<()> {
     let resolved_path = launch_input_path.clone();
 
     let output = plan_system(PlanOptions {
+        nano_ros_path: args.nano_ros_path.clone(),
         system_pkg,
         workspace_root,
         launch_file: resolved_path,

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -2151,6 +2151,11 @@ fn generate_bridge_configs(
                 launch_args: Vec::new(),
                 rmw: None,
                 target: None,
+                // Issue 0951 — this bridge plan runs inside the user's
+                // workspace, not a nano-ros checkout, so the resolver's own
+                // ladder (NROS_REPO_DIR, then an autodetect walk) is the right
+                // answer rather than a path invented here.
+                nano_ros_path: None,
             },
         )
         .wrap_err_with(|| format!("sync: plan bridge bringup {}", pkg.name))?;

--- a/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
@@ -414,6 +414,65 @@ struct BoardFile {
     boards: Vec<BoardDescriptor>,
 }
 
+/// The `[build]` / `[target.<triple>]` shape of a `cargo_config` template.
+#[derive(Debug, Default, Deserialize)]
+struct CargoConfigTemplate {
+    #[serde(default)]
+    build: Option<CargoConfigBuild>,
+    #[serde(default)]
+    target: std::collections::BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CargoConfigBuild {
+    #[serde(default)]
+    target: Option<String>,
+}
+
+/// The rustc triple a board's `cargo_config` template states.
+///
+/// Issue 0951 — a board descriptor does not record its triple as DATA. It
+/// records a `.cargo/config.toml` template, and the triple is in there: as
+/// `[build] target = "..."`, or as the sole `[target.<triple>]` header. Every
+/// shipped descriptor uses one of those two and NONE sets the `target` field
+/// on `[[board]]` that `BoardDescriptor::target` expects — so that field has
+/// been `None` for every board, and `nros build` has been copying the `None`
+/// into `ImagePlan.target` (build.rs) without anyone noticing.
+///
+/// Parsed as TOML rather than matched with a regex: it IS a TOML document, and
+/// a regex over it would also match a triple mentioned inside a rustflag.
+///
+/// Inferred only when UNAMBIGUOUS — `[build].target` wins; otherwise exactly
+/// one `[target.*]` key. A template with several is genuinely multi-triple and
+/// must not be collapsed to whichever came first.
+fn target_from_cargo_config(cargo_config: &str) -> Option<String> {
+    let parsed: CargoConfigTemplate = toml::from_str(cargo_config).ok()?;
+    if let Some(t) = parsed.build.and_then(|b| b.target) {
+        return Some(t);
+    }
+    let mut keys = parsed.target.into_keys();
+    match (keys.next(), keys.next()) {
+        (Some(only), None) => Some(only),
+        _ => None,
+    }
+}
+
+impl BoardFile {
+    /// Fill each board's `target` from its `cargo_config` template when the
+    /// board did not state one. An authored `target` always wins.
+    fn with_inferred_targets(mut self) -> Vec<BoardDescriptor> {
+        for b in &mut self.boards {
+            if b.target.is_none()
+                && let Some(cfg) = b.cargo_config.as_deref()
+                && let Some(t) = target_from_cargo_config(cfg)
+            {
+                b.target = Some(t);
+            }
+        }
+        self.boards
+    }
+}
+
 /// Every board descriptor discovered under `<workspace>/packages/boards`.
 #[derive(Debug, Default)]
 pub struct BoardCatalog {
@@ -514,7 +573,7 @@ impl BoardCatalog {
             // not in one.
             let abs = descriptor_path.display().to_string();
             self.descriptors
-                .extend(file.boards.into_iter().map(|mut b| {
+                .extend(file.with_inferred_targets().into_iter().map(|mut b| {
                     b.source = Some(abs.clone());
                     b
                 }));
@@ -560,7 +619,7 @@ impl BoardCatalog {
                     .join("/"),
                 None => descriptor_path.display().to_string(),
             };
-            descriptors.extend(file.boards.into_iter().map(|mut b| {
+            descriptors.extend(file.with_inferred_targets().into_iter().map(|mut b| {
                 b.source = Some(rel.clone());
                 b
             }));
@@ -1398,6 +1457,78 @@ signature = "#[nros_board_stm32f4::entry]\nfn main() -> !"
             DeployResolution::Board(d) => assert_eq!(d.chip.as_deref(), Some("stm32f407")),
             other => panic!("unique platform must resolve, got {other:?}"),
         }
+    }
+
+    /// Issue 0951 — every shipped board's triple comes out of its
+    /// `cargo_config` template, because no descriptor sets the `target` field
+    /// on `[[board]]`. Before this, `BoardDescriptor::target` was `None` for
+    /// EVERY board in the tree and both readers silently got nothing.
+    #[test]
+    fn shipped_boards_resolve_their_rustc_triple() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("repo root")
+            .to_path_buf();
+        let catalog = BoardCatalog::load(&repo).expect("in-tree catalog");
+        for (board, want) in [
+            ("mps2-an385-freertos", "thumbv7m-none-eabi"),
+            ("mps3-an536-freertos", "armv8r-none-eabihf"),
+            ("esp32-qemu", "riscv32imc-unknown-none-elf"),
+        ] {
+            let d = match catalog.resolve_deploy(board) {
+                DeployResolution::Board(d) => d,
+                other => panic!("{board} does not resolve: {other:?}"),
+            };
+            assert_eq!(
+                d.target.as_deref(),
+                Some(want),
+                "{board} must state its triple"
+            );
+        }
+        // A host board has no cross triple, and inventing one would be worse
+        // than `None` — the caller's default IS the host.
+        let host = match catalog.resolve_deploy("threadx-linux") {
+            DeployResolution::Board(d) => d,
+            other => panic!("threadx-linux does not resolve: {other:?}"),
+        };
+        assert_eq!(host.target, None);
+    }
+
+    /// `[build].target` wins, and several `[target.*]` tables are ambiguous
+    /// rather than first-wins — collapsing them is how one board answers for
+    /// another.
+    #[test]
+    fn a_triple_is_inferred_only_when_unambiguous() {
+        assert_eq!(
+            target_from_cargo_config("[target.thumbv7m-none-eabi]\nrunner = \"q\"\n").as_deref(),
+            Some("thumbv7m-none-eabi")
+        );
+        assert_eq!(
+            target_from_cargo_config(
+                "[build]\ntarget = \"riscv32imc-unknown-none-elf\"\n\
+                 [target.riscv32imc-unknown-none-elf]\nrunner = \"q\"\n"
+            )
+            .as_deref(),
+            Some("riscv32imc-unknown-none-elf")
+        );
+        assert_eq!(
+            target_from_cargo_config(
+                "[target.thumbv7m-none-eabi]\nrunner = \"a\"\n\
+                 [target.armv8r-none-eabihf]\nrunner = \"b\"\n"
+            ),
+            None,
+            "two triples, no `[build]` — ambiguous"
+        );
+        // A triple MENTIONED in a rustflag is not a declaration. This is why
+        // the template is parsed as TOML rather than matched with a regex.
+        assert_eq!(
+            target_from_cargo_config(
+                "[build]\nrustflags = [\"--sysroot=/x/thumbv7m-none-eabi\"]\n"
+            ),
+            None
+        );
+        assert_eq!(target_from_cargo_config("not = valid toml ["), None);
     }
 
     #[test]

--- a/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
@@ -896,37 +896,75 @@ impl SystemToml {
         blocks
     }
 
-    /// Phase 256 — the deploy target a target-agnostic caller (the planner) should
-    /// resolve per-target values against, when no explicit target was selected:
-    /// `cli` (a `--target` flag) → `[system].default_target` → the sole
-    /// `[image.<t>]` key, then the sole `[deploy.<t>]` key, when exactly one is
-    /// declared → `None`. This is the shared "which target am I?" key the
-    /// per-target classes (RMW override, build tuning, domain/locator override)
-    /// resolve through.
+    /// Phase 256 / issue 0951 — which per-target block a target-agnostic caller
+    /// (the planner) resolves values against when none was named:
+    /// `cli` (`--image`, alias `--target`) → the sole image
+    /// [`select_default_images`] picks → the sole DEPRECATED `[deploy.<t>]` →
+    /// `None`.
     ///
-    /// Issue 0951 — the IMAGE rung is what lets a workspace finish migrating
-    /// off `[deploy.*]`. Without it, deleting the last deploy block does not
-    /// fail: this returns `None`, every per-target lookup misses, and the plan
-    /// silently reverts to the `x86_64` / `native` / `debug` defaults. A build
-    /// for the wrong target that reports success is the failure mode this
-    /// whole table is arranged to prevent.
+    /// The image rung DELEGATES to `select_default_images` rather than
+    /// reimplementing "explicit list, else the only one". That function is what
+    /// a bare `nros build` already uses to decide which images to build, so
+    /// routing this through it means `nros plan` and `nros build` cannot
+    /// disagree about which image a bringup means by default — the drift issue
+    /// 0938 fixed for `rmw`, applied to selection itself. It also inherits the
+    /// rule that a `default_images` entry naming no declared image is an ERROR,
+    /// not a silent skip.
     ///
-    /// Images are tried BEFORE deploys because a workspace carrying both is
-    /// mid-migration, and the image is the half that survives.
+    /// Only a selection of exactly ONE image answers here. Several is not an
+    /// ambiguity to break by picking: a bringup that builds eight images has no
+    /// single "the" target, and `None` makes the caller fall back to its own
+    /// defaults rather than resolve half a workspace against one arbitrary
+    /// member.
+    ///
+    /// `[system].default_target` no longer decides. It is authored NOWHERE in
+    /// this tree and named the deploy era's concept; `default_images` is its
+    /// replacement. The FIELD still parses — `SystemToml` is
+    /// `deny_unknown_fields`, so deleting it would turn an unused key into a
+    /// hard parse error for an out-of-tree user — and
+    /// [`Self::deprecated_default_target_warning`] is what tells them.
     pub fn resolve_target(&self, cli: Option<&str>) -> Option<String> {
         if let Some(c) = cli {
             return Some(c.to_string());
         }
-        if let Some(t) = &self.system.default_target {
-            return Some(t.clone());
-        }
-        if self.image.len() == 1 {
-            return self.image.keys().next().cloned();
+        if let Ok(super::image::ImageSelection::Images(picked)) =
+            super::image::select_default_images(&self.image, &self.system.default_images)
+            && let [only] = picked.as_slice()
+        {
+            return Some(only.clone());
         }
         if self.deploy.len() == 1 {
             return self.deploy.keys().next().cloned();
         }
         None
+    }
+
+    /// `default_images` names only declared images, or say which it does not.
+    ///
+    /// [`Self::resolve_target`] must return an `Option`, so it can only IGNORE
+    /// a bad `default_images` — and ignoring it means a typo silently
+    /// downgrades a plan to target-agnostic instead of failing. Callers with an
+    /// error channel call this first; `select_default_images` is the one
+    /// implementation of the rule, so this cannot drift from what
+    /// `nros build` enforces.
+    pub fn validate_default_images(&self) -> Result<(), String> {
+        super::image::select_default_images(&self.image, &self.system.default_images).map(|_| ())
+    }
+
+    /// Issue 0951 — `[system].default_target` is set but no longer consulted.
+    ///
+    /// A key that silently stopped working is worse than one that was deleted,
+    /// so the retirement says so out loud. `None` when unset, which is every
+    /// bringup in this tree.
+    #[must_use]
+    pub fn deprecated_default_target_warning(&self) -> Option<String> {
+        let t = self.system.default_target.as_deref()?;
+        Some(format!(
+            "[system].default_target = \"{t}\" is retired and no longer selects \
+             anything — it named the `[deploy.*]` era's concept. Use \
+             `default_images = [\"{t}\"]`, which is also what a bare `nros build` \
+             reads."
+        ))
     }
 
     /// Phase 256 Wave 8 — the ROS domain id for `target`: `[deploy.<target>].domain_id`
@@ -1809,21 +1847,57 @@ board = "native"
         assert_eq!(bare.resolved_rmw(None, None), "zenoh");
     }
 
-    /// Phase 256 — `resolve_target`: `--target` → `[system].default_target` →
-    /// the sole `[deploy.<t>]` → `None`.
+    /// Phase 256 / issue 0951 — `resolve_target`: `--image` → the sole image
+    /// `default_images` picks → the sole `[deploy.<t>]` → `None`.
     #[test]
     fn resolve_target_precedence() {
         // CLI flag wins.
         let two: SystemToml = toml::from_str(
-            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\ndefault_target=\"native\"\n\
-             [deploy.native]\nkind=\"self\"\n[deploy.qemu]\nkind=\"qemu\"\n",
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             default_images=[\"native\"]\n\
+             [image.native]\nboard=\"native\"\n[image.qemu]\nboard=\"native\"\n",
         )
         .unwrap();
         assert_eq!(two.resolve_target(Some("qemu")).as_deref(), Some("qemu"));
-        // No flag → default_target.
+        // No flag → the one image `default_images` names.
         assert_eq!(two.resolve_target(None).as_deref(), Some("native"));
 
-        // No default_target, two deploys → ambiguous → None.
+        // `default_images` naming SEVERAL is not an answer to "which one".
+        // A bringup that builds three images has no single "the" target, and
+        // picking a member arbitrarily would resolve the whole workspace
+        // against it.
+        let many: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             default_images=[\"a\",\"b\"]\n\
+             [image.a]\nboard=\"native\"\n[image.b]\nboard=\"native\"\n",
+        )
+        .unwrap();
+        assert_eq!(many.resolve_target(None), None);
+
+        // `[system].default_target` is RETIRED — it named the deploy era's
+        // concept. The field still parses (deleting it from a
+        // `deny_unknown_fields` struct would be a hard error for an
+        // out-of-tree user), but it decides nothing, and the warning is what
+        // says so.
+        let retired: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\ndefault_target=\"a\"\n\
+             [image.a]\nboard=\"native\"\n[image.b]\nboard=\"native\"\n",
+        )
+        .unwrap();
+        assert_eq!(retired.resolve_target(None), None, "it must not decide");
+        let w = retired
+            .deprecated_default_target_warning()
+            .expect("set, so warned");
+        assert!(w.contains("default_images"), "{w}");
+        assert!(
+            toml::from_str::<SystemToml>("[system]\nname=\"d\"\nrmw=\"z\"\ndomain_id=0\n")
+                .unwrap()
+                .deprecated_default_target_warning()
+                .is_none(),
+            "unset must not warn"
+        );
+
+        // Two deploys → ambiguous → None.
         let ambiguous: SystemToml = toml::from_str(
             "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
              [deploy.a]\nkind=\"self\"\n[deploy.b]\nkind=\"self\"\n",
@@ -1831,7 +1905,7 @@ board = "native"
         .unwrap();
         assert_eq!(ambiguous.resolve_target(None), None);
 
-        // No default_target, sole deploy → that one.
+        // Sole deploy → that one (the deprecated rung, still live).
         let sole: SystemToml = toml::from_str(
             "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n[deploy.only]\nkind=\"self\"\n",
         )

--- a/packages/cli/nros-cli-core/src/orchestration/planner.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/planner.rs
@@ -32,11 +32,20 @@ pub struct PlanOptions {
     /// `plan.build.rmw` regardless of `system.toml`. `None` ⇒ resolve from
     /// `system.toml`.
     pub rmw: Option<String>,
-    /// Phase 256 — `--target` selects the `[deploy.<t>]` the planner resolves
-    /// per-target values against (RMW override, and later build tuning / domain /
-    /// locator). `None` ⇒ `[system].default_target` → the sole `[deploy.<t>]` →
-    /// target-agnostic. See `SystemToml::resolve_target`.
+    /// Phase 256 / issue 0951 — `--image` (alias `--target`) selects the
+    /// `[image.<id>]` the planner resolves per-target values against (RMW
+    /// override, build tuning). `None` ⇒ the sole image `default_images` picks
+    /// → the sole deprecated `[deploy.<t>]` → target-agnostic. See
+    /// `SystemToml::resolve_target`.
     pub target: Option<String>,
+    /// nano-ros checkout holding `packages/boards`, for deriving the selected
+    /// image's rustc triple from its board descriptor.
+    ///
+    /// `None` ⇒ `NROS_REPO_DIR`, then an autodetect walk from the workspace —
+    /// the same ladder `nros build` uses, because the two must agree about
+    /// which board descriptors exist. Finding none is not an error: a plan that
+    /// needs no triple is still a valid plan.
+    pub nano_ros_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -170,11 +179,32 @@ pub fn plan_system(options: PlanOptions) -> Result<PlanningOutput> {
     // `[[transport]]`) from the typed `system.toml` (the selected `[deploy.<t>]`) +
     // `--rmw`/`--target`, then validate the transport semantics with a clear error
     // before the plan is written.
+    // Issue 0951 — the board catalog, so the plan's rustc triple is DERIVED
+    // from the selected image's board rather than copied from a `[deploy.*]`
+    // field that is going away.
+    //
+    // Resolved exactly as `nros build` resolves it (`--nano-ros-path` →
+    // `NROS_REPO_DIR` → an autodetect walk), because the two must agree about
+    // which descriptors exist. Unlike `build`, a MISSING checkout is not fatal
+    // here: `nros plan` legitimately runs outside a nano-ros tree, and every
+    // plan that needs no triple still works. What is fatal is an image naming a
+    // board the catalog HAS and cannot resolve — that is a wrong plan, not an
+    // absent one, and `schema_build_json` refuses it.
+    let nano_ros_root = options
+        .nano_ros_path
+        .clone()
+        .or_else(|| std::env::var_os("NROS_REPO_DIR").map(PathBuf::from))
+        .or_else(|| crate::cmd::ws::autodetect_nano_ros_path(&options.workspace_root));
+    let catalog = nano_ros_root
+        .as_deref()
+        .and_then(|r| super::board_descriptor::BoardCatalog::load(r).ok());
+
     let build_json = schema_build_json(
         system_toml_path.as_deref(),
         options.rmw.as_deref(),
         options.target.as_deref(),
-    );
+        catalog.as_ref(),
+    )?;
     let build: PlanBuildOptions = serde_json::from_value(build_json.clone())
         .wrap_err("invalid [build] / [[transport]] section in system.toml")?;
     let transport_problems = build.validate_transports();
@@ -710,7 +740,8 @@ fn schema_build_json(
     system_toml: Option<&Path>,
     cli_rmw: Option<&str>,
     cli_target: Option<&str>,
-) -> Value {
+    catalog: Option<&super::board_descriptor::BoardCatalog>,
+) -> Result<Value> {
     let mut build = json!({
         "target": "x86_64-unknown-linux-gnu",
         "board": "native",
@@ -722,14 +753,19 @@ fn schema_build_json(
     });
     let obj = build.as_object_mut().expect("build is an object");
     // Phase 255/256 — `[system].rmw` (resolved) is the SSoT; `--rmw` tops the
-    // ladder. Phase 256 makes the planner target-aware: it resolves the selected
-    // deploy target (`--target` → `[system].default_target` → sole `[deploy.<t>]`)
-    // and feeds it to `resolved_rmw`, so `[deploy.<t>].rmw` finally reaches the plan
-    // (the phase-255 stub resolved at target=None). With no system.toml, `--rmw`
-    // alone still drives the plan.
+    // ladder. The planner resolves the selected target (`--image`, alias
+    // `--target` → the sole image `default_images` picks → the sole deprecated
+    // `[deploy.<t>]`) and feeds it to `resolved_rmw`. With no system.toml,
+    // `--rmw` alone still drives the plan.
     let sys = system_toml
         .and_then(|p| std::fs::read_to_string(p).ok())
         .and_then(|s| toml::from_str::<super::cargo_metadata_schema::SystemToml>(&s).ok());
+    // A bad `default_images` must FAIL, not quietly downgrade the plan to
+    // target-agnostic. `resolve_target` returns an `Option` and can only ignore
+    // it; this is the rung with an error channel.
+    if let Some(s) = &sys {
+        s.validate_default_images().map_err(|e| eyre!("{e}"))?;
+    }
     // The selected deploy target (phase-256 W3a): shared by RMW + build-tuning.
     let selected_target = sys.as_ref().and_then(|s| s.resolve_target(cli_target));
     let resolved_rmw = match &sys {
@@ -789,8 +825,33 @@ fn schema_build_json(
         if let Some(f) = features {
             obj.insert("features".to_string(), json!(f));
         }
-        if let Some(t) = dep.and_then(|d| d.target.clone()) {
-            obj.insert("target".to_string(), json!(t));
+        // The rustc triple. Issue 0951 — DERIVED from the image's board, not
+        // copied from a `[deploy.*]` field.
+        //
+        // `[image.*]` deliberately carries no `target` (RFC-0065 D9): the board
+        // descriptor already states it, and a second copy is free to disagree
+        // with the board it claims to describe. `build.rs` has always derived
+        // it this way (`descriptor.target.clone()`); this is the same
+        // derivation, so the plan and the build cannot differ about what a
+        // board compiles to.
+        //
+        // It matters more than a provenance string: `is_hosted_target` below
+        // tests `build.target.contains("linux")` to choose hosted vs bare
+        // metal, and `metadata_build` reads it to decide `-Z build-std`. An
+        // embedded image falling back to the host default is silently built as
+        // if it were hosted.
+        //
+        // An image that names a board no descriptor claims is an ERROR here,
+        // not a fallback to the host triple — that is the whole point.
+        let derived = match (&img, catalog) {
+            (Some(i), Some(cat)) if i.board.is_some() => {
+                let d = super::image::resolve_image_board(cat, t, i).map_err(|e| eyre!("{e}"))?;
+                d.target.clone()
+            }
+            _ => None,
+        };
+        if let Some(triple) = derived.or_else(|| dep.and_then(|d| d.target.clone())) {
+            obj.insert("target".to_string(), json!(triple));
         }
         if let Some(o) = dep.and_then(|d| d.optimize.clone()) {
             obj.insert("optimize".to_string(), json!(o));
@@ -816,7 +877,7 @@ fn schema_build_json(
             obj.insert("transports".to_string(), json!(transports));
         }
     }
-    build
+    Ok(build)
 }
 
 /// Issue 0099 — resolve a `[[bridge]]` endpoint selector to `(rmw, domain_id,
@@ -3486,7 +3547,7 @@ mod tests {
     fn schema_build_json_defaults() {
         // No system.toml ⇒ pre-173.5 defaults, empty transports — keeps existing
         // plans byte-identical.
-        let build = schema_build_json(None, None, None);
+        let build = schema_build_json(None, None, None, None).expect("build json");
         assert_eq!(build["board"], "native");
         assert_eq!(build["rmw"], "zenoh");
         assert_eq!(build["target"], "x86_64-unknown-linux-gnu");
@@ -3508,11 +3569,11 @@ mod tests {
         .unwrap();
 
         // --rmw xrce beats system.toml's cyclonedds.
-        let build = schema_build_json(Some(&st), Some("xrce"), None);
+        let build = schema_build_json(Some(&st), Some("xrce"), None, None).expect("build json");
         assert_eq!(build["rmw"], "xrce");
 
         // --rmw with no system.toml still drives (top rung).
-        let bare = schema_build_json(None, Some("xrce"), None);
+        let bare = schema_build_json(None, Some("xrce"), None, None).expect("build json");
         assert_eq!(bare["rmw"], "xrce");
     }
 
@@ -3530,13 +3591,13 @@ mod tests {
         )
         .unwrap();
 
-        let build = schema_build_json(Some(&st), None, None);
+        let build = schema_build_json(Some(&st), None, None, None).expect("build json");
         assert_eq!(build["bridged_rmws"], json!(["zenoh", "cyclonedds"]));
 
         // No bridges → no `bridged_rmws` field (single-RMW build byte-identical).
         let st2 = dir.path().join("plain.toml");
         std::fs::write(&st2, "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n").unwrap();
-        let plain = schema_build_json(Some(&st2), None, None);
+        let plain = schema_build_json(Some(&st2), None, None, None).expect("build json");
         assert!(plain.get("bridged_rmws").is_none());
     }
 
@@ -3557,7 +3618,7 @@ mod tests {
         )
         .unwrap();
 
-        let build = schema_build_json(Some(&st), None, None);
+        let build = schema_build_json(Some(&st), None, None, None).expect("build json");
         // Deserializing proves the emitted JSON is a valid transports table; two
         // entries ⇒ bridge mode.
         let opts: crate::orchestration::plan::PlanBuildOptions =
@@ -3725,8 +3786,8 @@ mod tests {
 
     /// Phase 256 — planner target-awareness: `[deploy.<t>].rmw` now reaches the
     /// plan (the phase-255 stub resolved at target=None, so it never did). The
-    /// selected target comes from `--target`, else `default_target`, else the
-    /// sole deploy.
+    /// selected target comes from `--image`, else the sole image
+    /// `default_images` picks, else the sole deploy.
     #[test]
     fn schema_build_json_resolves_per_deploy_rmw_via_target() {
         let dir = tempfile::tempdir().unwrap();
@@ -3739,28 +3800,31 @@ mod tests {
         .unwrap();
 
         // --target qemu → the deploy override reaches the plan.
-        let picked = schema_build_json(Some(&st), None, Some("qemu"));
+        let picked = schema_build_json(Some(&st), None, Some("qemu"), None).expect("build json");
         assert_eq!(picked["rmw"], "cyclonedds");
 
-        // No target, no default_target, sole deploy → resolve_target picks it.
-        let sole = schema_build_json(Some(&st), None, None);
+        // No flag, no images at all → the deprecated sole-deploy rung.
+        let sole = schema_build_json(Some(&st), None, None, None).expect("build json");
         assert_eq!(
             sole["rmw"], "cyclonedds",
             "sole deploy is the selected target"
         );
 
-        // default_target drives when set + no --target.
+        // `default_images` drives when set + no --image.
         let st2 = dir.path().join("two.toml");
         std::fs::write(
             &st2,
-            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\ndefault_target=\"a\"\n\
-             [deploy.a]\nkind=\"self\"\nrmw=\"xrce\"\n[deploy.b]\nkind=\"self\"\n",
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\ndefault_images=[\"a\"]\n\
+             [image.a]\nboard=\"native\"\nrmw=\"xrce\"\n[image.b]\nboard=\"native\"\n",
         )
         .unwrap();
-        assert_eq!(schema_build_json(Some(&st2), None, None)["rmw"], "xrce");
-        // --target b → b has no rmw → falls to [system].rmw.
         assert_eq!(
-            schema_build_json(Some(&st2), None, Some("b"))["rmw"],
+            schema_build_json(Some(&st2), None, None, None).expect("build json")["rmw"],
+            "xrce"
+        );
+        // --image b → b has no rmw → falls to [system].rmw.
+        assert_eq!(
+            schema_build_json(Some(&st2), None, Some("b"), None).expect("build json")["rmw"],
             "zenoh"
         );
     }
@@ -3774,29 +3838,125 @@ mod tests {
         let st = dir.path().join("system.toml");
         std::fs::write(
             &st,
-            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\ndefault_target=\"embedded\"\n\
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
              [deploy.embedded]\nkind=\"flash\"\ntarget=\"thumbv7m-none-eabi\"\nboard=\"stm32f4\"\n\
              profile=\"release\"\noptimize=\"size\"\nfeatures=[\"a\",\"b\"]\n\
              [deploy.native]\nkind=\"self\"\n",
         )
         .unwrap();
 
-        // default_target = embedded → its build shape (W3-tail: target/board) + tuning land.
-        let emb = schema_build_json(Some(&st), None, None);
+        // The DEPRECATED path, named explicitly: this block's fields still
+        // reach the plan, including the two `[image.*]` does not carry
+        // (`target`, `optimize`). `default_images` is deliberately absent —
+        // it names IMAGES, and this fixture declares none.
+        let emb = schema_build_json(Some(&st), None, Some("embedded"), None).expect("build json");
         assert_eq!(emb["target"], "thumbv7m-none-eabi");
         assert_eq!(emb["board"], "stm32f4");
         assert_eq!(emb["profile"], "release");
         assert_eq!(emb["optimize"], "size");
         assert_eq!(emb["features"], json!(["a", "b"]));
 
-        // --target native → nothing declared → pre-256 defaults (native / x86_64 /
+        // --image native → nothing declared → pre-256 defaults (native / x86_64 /
         // debug, no optimize, empty features).
-        let nat = schema_build_json(Some(&st), None, Some("native"));
+        let nat = schema_build_json(Some(&st), None, Some("native"), None).expect("build json");
         assert_eq!(nat["target"], "x86_64-unknown-linux-gnu");
         assert_eq!(nat["board"], "native");
         assert_eq!(nat["profile"], "debug");
         assert!(nat.get("optimize").is_none());
         assert_eq!(nat["features"], json!([]));
+    }
+
+    /// Issue 0951 — the rustc triple is DERIVED from the image's board.
+    ///
+    /// `[image.*]` carries no `target` (RFC-0065 D9), so without this the plan
+    /// falls back to the host default and an embedded image is silently
+    /// planned as hosted — `is_hosted_target` tests
+    /// `build.target.contains("linux")`, and `metadata_build` reads the same
+    /// field to decide `-Z build-std`.
+    #[test]
+    fn the_triple_is_derived_from_the_images_board() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("repo root")
+            .to_path_buf();
+        let catalog = crate::orchestration::board_descriptor::BoardCatalog::load(&repo)
+            .expect("in-tree catalog");
+        let dir = tempfile::tempdir().unwrap();
+        let st = dir.path().join("system.toml");
+        std::fs::write(
+            &st,
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             [image.fw]\nboard=\"mps2-an385-freertos\"\n",
+        )
+        .unwrap();
+
+        let with = schema_build_json(Some(&st), None, None, Some(&catalog)).expect("build json");
+        assert_eq!(with["board"], "mps2-an385-freertos");
+        assert_eq!(
+            with["target"], "thumbv7m-none-eabi",
+            "derived from the board descriptor, not authored"
+        );
+        assert!(
+            !with["target"].as_str().expect("string").contains("linux"),
+            "an embedded image must not read as hosted"
+        );
+
+        // No catalog (a plan run outside a nano-ros checkout) — the board still
+        // lands, the triple falls back. That is the degradation, and it is why
+        // `nros build` resolves the catalog too rather than trusting the plan.
+        let without = schema_build_json(Some(&st), None, None, None).expect("build json");
+        assert_eq!(without["board"], "mps2-an385-freertos");
+        assert_eq!(without["target"], "x86_64-unknown-linux-gnu");
+    }
+
+    /// An image naming a board the catalog cannot resolve is an ERROR, not a
+    /// fall back to the host triple. Falling back would plan a board that does
+    /// not exist as if it were this machine.
+    #[test]
+    fn an_unresolvable_board_fails_rather_than_defaulting() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("repo root")
+            .to_path_buf();
+        let catalog = crate::orchestration::board_descriptor::BoardCatalog::load(&repo)
+            .expect("in-tree catalog");
+        let dir = tempfile::tempdir().unwrap();
+        let st = dir.path().join("system.toml");
+        std::fs::write(
+            &st,
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             [image.fw]\nboard=\"no-such-board-xyz\"\n",
+        )
+        .unwrap();
+        let e = schema_build_json(Some(&st), None, None, Some(&catalog))
+            .expect_err("no descriptor claims it")
+            .to_string();
+        assert!(e.contains("no-such-board-xyz"), "{e}");
+    }
+
+    /// A `default_images` naming no declared image must FAIL the plan.
+    ///
+    /// `resolve_target` returns an `Option`, so it can only ignore the bad
+    /// value — and ignoring it downgrades the plan to target-agnostic, which
+    /// looks like success and silently drops every per-image value. That is the
+    /// silent-skip shape, so the rung with an error channel refuses it.
+    #[test]
+    fn a_default_images_naming_no_image_fails_the_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let st = dir.path().join("system.toml");
+        std::fs::write(
+            &st,
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
+             default_images=[\"typo\"]\n[image.real]\nboard=\"native\"\n",
+        )
+        .unwrap();
+        let e = schema_build_json(Some(&st), None, None, None)
+            .expect_err("a typo must not read as target-agnostic")
+            .to_string();
+        assert!(e.contains("typo"), "{e}");
+        assert!(e.contains("real"), "names what IS declared: {e}");
     }
 
     /// Issue 0951 — the same tuning, read from `[image.<t>]`, which is where a
@@ -3808,12 +3968,12 @@ mod tests {
         std::fs::write(
             &st,
             "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
-             default_target=\"embedded\"\n\
+             default_images=[\"embedded\"]\n\
              [image_defaults]\nprofile=\"release\"\n\
              [image.embedded]\nboard=\"mps2-an385-freertos\"\nfeatures=[\"safety\"]\n",
         )
         .unwrap();
-        let v = schema_build_json(Some(&st), None, None);
+        let v = schema_build_json(Some(&st), None, None, None).expect("build json");
         let o = v.as_object().expect("object");
         assert_eq!(
             o.get("board").and_then(|b| b.as_str()),
@@ -3840,13 +4000,13 @@ mod tests {
         std::fs::write(
             &st,
             "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
-             default_target=\"embedded\"\n\
+             default_images=[\"embedded\"]\n\
              [image.embedded]\nboard=\"mps2-an385-freertos\"\n\
              [deploy.embedded]\nkind=\"embedded\"\n\
              target=\"thumbv7m-none-eabi\"\nboard=\"stale-board\"\n",
         )
         .unwrap();
-        let v = schema_build_json(Some(&st), None, None);
+        let v = schema_build_json(Some(&st), None, None, None).expect("build json");
         let o = v.as_object().expect("object");
         assert_eq!(
             o.get("board").and_then(|b| b.as_str()),
@@ -3905,6 +4065,7 @@ mod tests {
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -3969,6 +4130,7 @@ mod tests {
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -4033,6 +4195,7 @@ mod tests {
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -4120,6 +4283,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -4457,6 +4621,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -4612,6 +4777,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -4844,6 +5010,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -4959,6 +5126,7 @@ topics:
         make_metadata(&listener_md, "Listener");
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -5059,6 +5227,7 @@ topics:
         )
         .unwrap();
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -5123,6 +5292,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -5207,6 +5377,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -5285,6 +5456,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,
@@ -5487,6 +5659,7 @@ topics:
         fs::write(&metadata, metadata_json).unwrap();
 
         plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.to_path_buf(),
             launch_file: launch,
@@ -5519,6 +5692,7 @@ topics:
         fs::write(&metadata, metadata_json).unwrap();
 
         plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.to_path_buf(),
             launch_file: launch,
@@ -5601,6 +5775,7 @@ topics:
         .unwrap();
 
         let output = plan_system(PlanOptions {
+            nano_ros_path: None,
             system_pkg: "system_pkg".to_string(),
             workspace_root: root.clone(),
             launch_file: launch,

--- a/packages/cli/nros-cli-core/tests/orchestration_cli.rs
+++ b/packages/cli/nros-cli-core/tests/orchestration_cli.rs
@@ -29,6 +29,7 @@ fn orchestration_metadata_plan_check_commands_share_artifacts() {
     assert!(preserved_metadata.is_file());
 
     plan::run(plan::Args {
+        nano_ros_path: None,
         system_pkg: "system_pkg".to_string(),
         launch_file: root.join("system.launch.xml"),
         record: Some(root.join("record.json")),

--- a/packages/cli/nros-cli-core/tests/orchestration_self_bringup_cargo_metadata.rs
+++ b/packages/cli/nros-cli-core/tests/orchestration_self_bringup_cargo_metadata.rs
@@ -141,6 +141,7 @@ fn plan_system_succeeds_with_cargo_metadata_alpha_bridge() {
 
     let out_root = root.join("build/cargo_self_bringup/nros");
     let output = plan_system(PlanOptions {
+        nano_ros_path: None,
         system_pkg: "cargo_self_bringup".to_string(),
         workspace_root: root.clone(),
         launch_file,
@@ -258,6 +259,7 @@ domain_id = 0
     fs::write(&launch_file, "").unwrap();
 
     let err = plan_system(PlanOptions {
+        nano_ros_path: None,
         system_pkg: "pure_empty_bringup".to_string(),
         workspace_root: root.clone(),
         launch_file,

--- a/packages/cli/nros-cli-core/tests/plan_pipeline_e2e.rs
+++ b/packages/cli/nros-cli-core/tests/plan_pipeline_e2e.rs
@@ -75,6 +75,7 @@ fn fixture_workspace_plans_and_checks() {
     let model = resolve_demo_pkg_model(&demo_pkg, &output);
 
     plan::run(plan::Args {
+        nano_ros_path: None,
         system_pkg: "e2e_system".to_string(),
         // R-code.1 — the launch parse path is deleted; `plan` takes a resolved
         // model, so the dir argument is only the discovery root now.


### PR DESCRIPTION
This is **option A** for the `[deploy.*]` endgame — the plan derives the selected image's rustc triple from its board instead of copying `[deploy.<t>].target`, which `[image.*]` deliberately does not carry (RFC-0065 D9: the board descriptor owns it).

## It did not own it

`BoardDescriptor::target` expects a scalar `target = "..."` on the `[[board]]` table, and **no shipped descriptor uses that spelling**. The triple is written inside the `cargo_config` **string template** — as `[build] target = "..."`, or implied by the sole `[target.<triple>]` header — so the field has been `None` for every board in this tree.

Two consumers read it, and both failed open:

- **`cmd/build.rs` drops `--target` when it is `None`.** The comment right there says that "builds the image for the HOST — silently, since cargo is happy to", and credits phase-383 W9 with fixing it. The fix never fired.
- `builder/preflight.rs` checks whether the board's Rust target is installed, so `rustup target add <triple>` was never offered either.

Measured, by disabling the new inference and re-running the same command:

```
# without the inference (shipped behaviour)
$ nros build --dry-run freertos        # examples/workspaces/rust
cargo build -p freertos_entry                              # ← no --target: HOST build

# with it
cargo build -p freertos_entry --target thumbv7m-none-eabi
```

The triple is parsed out of the template **as TOML, not by regex** — it is a TOML document, and a regex would also match a triple mentioned inside a rustflag — and only when unambiguous: `[build].target` wins, else exactly one `[target.*]` key. A template with several is genuinely multi-triple and must not collapse to whichever came first — the same rule that keeps the two boards sharing `nros-board-nuttx-qemu/nros-board.toml` distinct.

## Selection, the other half

- `resolve_target` now picks an **image**: `--image` (alias `--target`, since the value callers pass is an image id) → the sole image `select_default_images` picks → the sole deprecated `[deploy.<t>]`. It **delegates** to `select_default_images` rather than reimplementing "explicit list, else the only one", so `nros plan` and `nros build` cannot disagree about which image a bringup means by default.
- Only a selection of exactly **one** image answers. A bringup that builds eight has no single "the" target.
- `[system].default_target` is **retired** — it named the deploy era's concept and is authored nowhere. The *field* still parses (`SystemToml` is `deny_unknown_fields`, so deleting it would turn an unused key into a hard parse error for an out-of-tree user); a warning says it decides nothing.
- A `default_images` naming no declared image now **fails** the plan. `resolve_target` returns an `Option` and can only ignore it — and ignoring it silently downgrades the plan to target-agnostic, which looks like success.

## Verification

Models regenerated for all 31 workspaces from a wiped cache: **byte-identical**, as expected for a plan-path change. `just ci-l1` green — read from the tier's own exit status, not a wrapper's. `just check fast` 146/146. 809 lib tests.

`shipped_boards_resolve_their_rustc_triple` is the regression pin, at the layer where the fact lives.

## Next

With the triple derived, the remaining `[deploy.*]` work is unblocked: the 4 misfiled fixture blocks become `[image.*]`, and the 20 `kind = "self"` machines become `[host.*]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG