### PR TITLE
feat(#0951): `[deploy.*]` is gone from the tree

### DIFF
--- a/docs/issues/0951-site-config-keys-on-deploy-not-board.md
+++ b/docs/issues/0951-site-config-keys-on-deploy-not-board.md
@@ -127,7 +127,28 @@ declaration — and only when unambiguous (`[build].target`, else exactly one
 `[target.*]` key). `shipped_boards_resolve_their_rustc_triple` is the
 regression pin, at the layer where the fact lives.
 
-Still open — the build half:
+* **`[deploy.*]` is GONE from the tree** — 0 blocks, against 96 at the start.
+  The 4 misfiled fixture blocks (whose `kind` named a platform family, not a
+  placement) became `[image.*]`; the 20 `kind = "self"` machines became
+  unscoped `[host.<name>]` with no `nodes`, which is what a sole governing
+  self-block already meant. Two templates carried `board` on the machine block
+  and were split — a board is a build fact, and a machine is not a build.
+
+  Model effect, measured across all 20 resolving workspaces: `deploy_name` +
+  `kind` become `host_name`, and `target` disappears (a host says WHERE a node
+  runs; the entry's `--board` decides what it is built as). Two fixtures lose
+  their `execution:` section entirely, because their sole block was a platform
+  family acting as placement by accident — nothing live reads per-node
+  `domain`/`rmw` from a model, and `keep()`'s empty-map arm keeps every node.
+  Verified the way that matters: `nros codegen entry` for
+  freertos/nuttx/zephyr/native, before and after, is byte-identical for every
+  board.
+
+  The SCHEMA keeps `[deploy.*]` and every reader keeps its deploy fallback —
+  out-of-tree users still author it, and the deprecation warnings are what move
+  them.
+
+Still open:
 * **the last `[deploy.*]` block per bringup** — one `kind = "self"` each, the
   implicit machine the system runs on. It is a machine, so it belongs in
   `[host.*]`; moving it empties the table and gives `target = None` by

--- a/examples/templates/c-and-cpp-mixed-workspace/src/demo_bringup/system.toml
+++ b/examples/templates/c-and-cpp-mixed-workspace/src/demo_bringup/system.toml
@@ -14,12 +14,9 @@ pkg = "cpp_listener_pkg"
 class = "cpp_listener_pkg::Listener"
 name = "listener"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]

--- a/examples/templates/multi-node-workspace-cpp/src/demo_bringup/system.toml
+++ b/examples/templates/multi-node-workspace-cpp/src/demo_bringup/system.toml
@@ -17,13 +17,15 @@ pkg = "listener_pkg"
 class = "listener_pkg::Listener"
 name = "listener"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
+
+# Issue 0951 — the buildable unit. Split out of the `kind = "self"` deploy
+# block, which carried a `board`: that is a build fact, and a machine is not a
+# build.
+[image.native]
 board = "native"

--- a/examples/templates/multi-node-workspace/src/demo_bringup/system.toml
+++ b/examples/templates/multi-node-workspace/src/demo_bringup/system.toml
@@ -20,13 +20,15 @@ pkg = "listener_pkg"
 class = "listener_pkg::Listener"
 name = "listener"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
+
+# Issue 0951 — the buildable unit. Split out of the `kind = "self"` deploy
+# block, which carried a `board`: that is a build fact, and a machine is not a
+# build.
+[image.native]
 board = "native"

--- a/examples/workspaces/c/src/demo_bringup/system.toml
+++ b/examples/workspaces/c/src/demo_bringup/system.toml
@@ -45,19 +45,12 @@ pkg = "action_client_pkg"
 class = "action_client_pkg::FibClient"
 name = "fib_client"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# Issue 0951 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
-# what it is built as comes from `[image.*]`. The old blocks carried
-# `kind`/`target`, which are build facts: per-host models are board-agnostic
-# and each entry's own board supplies the target.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [host.robot1]
 launch = "multihost.launch.xml"
 nodes = ["/talker"]

--- a/examples/workspaces/cpp/src/demo_bringup/system.toml
+++ b/examples/workspaces/cpp/src/demo_bringup/system.toml
@@ -46,26 +46,12 @@ pkg = "action_client_pkg"
 class = "action_client_pkg::FibClient"
 name = "fib_client"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# phase-326 (issue 0364) — per-host deploy targets for the multi-host launch
-# (`launch/multihost.launch.xml`: talker on robot1, listener on robot2, chosen at RESOLVE time by the `host`
-# launch argument). Each per-host model (`config/multihost_robot<N>_model.yaml`,
-# resolved with `host:=robot<N>`) contains only that host's nodes;
-# `native_entry_robot{1,2}` consume those models via `nano_ros_entry(MODEL …)`.
-# The explicit `nodes = [..]` below places them — with `machine=` gone there is
-# no launch-derived placement fact, so every node needs a list entry.
-# Issue 0951 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
-# what it is built as comes from `[image.*]`. The old blocks carried
-# `kind`/`target`, which are build facts: per-host models are board-agnostic
-# and each entry's own board supplies the target.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [host.robot1]
 launch = "multihost.launch.xml"
 nodes = ["/talker"]

--- a/examples/workspaces/features/src/demo_bringup/system.toml
+++ b/examples/workspaces/features/src/demo_bringup/system.toml
@@ -123,18 +123,12 @@ pkg = "rust_remap_talker_pkg"
 class = "rust_remap_talker_pkg::RemapTalker"
 name = "rust_remap_remap_talker"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
 
-# phase-331 W2 — one model per theme launch (phase-330 W4.0 `[[model]]`).
-
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [[model]]
 launch = "c_custom_msg_listener.launch.xml"
 out    = "c_custom_msg_listener_model.yaml"

--- a/examples/workspaces/managed/src/demo_bringup/system.toml
+++ b/examples/workspaces/managed/src/demo_bringup/system.toml
@@ -24,19 +24,12 @@ pkg = "cpp_lifecycle_talker_pkg"
 class = "cpp_lifecycle_talker_pkg::ManagedTalker"
 name = "managed_talker"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
 
-# --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
-# Derived from the entry packages that existed at migration time; each
-# entry's `deploy` token picked its board, and its `launch` its topology.
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [image_defaults]
 rmw = "zenoh"
 

--- a/examples/workspaces/mixed/src/demo_bringup/system.toml
+++ b/examples/workspaces/mixed/src/demo_bringup/system.toml
@@ -38,26 +38,12 @@ pkg = "c_fib_client_pkg"
 class = "c_fib_client_pkg::FibClient"
 name = "fib_client"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# phase-326 (issue 0364) — per-host deploy targets for the multi-host launch
-# (`launch/multihost.launch.xml`: C talker + Rust heartbeat on robot1, C++ listener on robot2, chosen at RESOLVE time by the `host`
-# launch argument). Each per-host model (`config/multihost_robot<N>_model.yaml`,
-# resolved with `host:=robot<N>`) contains only that host's nodes;
-# `native_entry_robot{1,2}` consume those models via `nano_ros_entry(MODEL …)`.
-# The explicit `nodes = [..]` below places them — with `machine=` gone there is
-# no launch-derived placement fact, so every node needs a list entry.
-# Issue 0951 — MACHINES live in `[host.*]`. A host says WHERE a node runs;
-# what it is built as comes from `[image.*]`. The old blocks carried
-# `kind`/`target`, which are build facts: per-host models are board-agnostic
-# and each entry's own board supplies the target.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [host.robot1]
 launch = "multihost.launch.xml"
 nodes = ["/talker", "/heartbeat"]

--- a/examples/workspaces/realtime-c/src/demo_bringup/system.toml
+++ b/examples/workspaces/realtime-c/src/demo_bringup/system.toml
@@ -90,27 +90,12 @@ priority = 10
 # the other side must SAY so with `above = "transport"` on the tier.
 priority = 98
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# phase-315 — the embedded BOARD BUILDS of this system.
-#
-# Not placements: `kind = "self"` blocks are machines and PARTITION the nodes;
-# a `kind = "embedded"` block is the whole system compiled for another board,
-# running every node. The resolver excludes embedded blocks from placement.
-#
-# Missing while entries named them, which was invisible until the SystemModel
-# started carrying real `execution.deploy` — then those entries failed with
-# "places no nodes on board <x>". Ids are the DEPLOY values the entries pass.
-# --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
-# Derived from the entry packages that existed at migration time; each
-# entry's `deploy` token picked its board, and its `launch` its topology.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [image_defaults]
 rmw = "zenoh"
 

--- a/examples/workspaces/realtime-c/src/smp_bringup/system.toml
+++ b/examples/workspaces/realtime-c/src/smp_bringup/system.toml
@@ -110,27 +110,12 @@ priority = 10
 # the other side must SAY so with `above = "transport"` on the tier.
 priority = 98
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# phase-315 — the embedded BOARD BUILDS of this system.
-#
-# Not placements: `kind = "self"` blocks are machines and PARTITION the nodes;
-# a `kind = "embedded"` block is the whole system compiled for another board,
-# running every node. The resolver excludes embedded blocks from placement.
-#
-# Missing while entries named them, which was invisible until the SystemModel
-# started carrying real `execution.deploy` — then those entries failed with
-# "places no nodes on board <x>". Ids are the DEPLOY values the entries pass.
-# --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
-# Derived from the entry packages that existed at migration time; each
-# entry's `deploy` token picked its board, and its `launch` its topology.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [image_defaults]
 rmw = "zenoh"
 

--- a/examples/workspaces/realtime-cpp-subnode-portable/src/deploy_bringup/system.toml
+++ b/examples/workspaces/realtime-cpp-subnode-portable/src/deploy_bringup/system.toml
@@ -25,19 +25,12 @@ spin_period = "100000us"
 [tiers.bulk.posix]
 priority = 10
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
 
-# --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
-# Derived from the entry packages that existed at migration time; each
-# entry's `deploy` token picked its board, and its `launch` its topology.
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [image_defaults]
 rmw = "zenoh"
 

--- a/examples/workspaces/realtime-cpp/src/demo_bringup/system.toml
+++ b/examples/workspaces/realtime-cpp/src/demo_bringup/system.toml
@@ -125,24 +125,12 @@ priority = 10
 # the other side must SAY so with `above = "transport"` on the tier.
 priority = 98
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# phase-315 — the embedded BOARD BUILDS of this system.
-#
-# Not placements: `kind = "self"` blocks are machines and PARTITION the nodes;
-# a `kind = "embedded"` block is the whole system compiled for another board,
-# running every node. The resolver excludes embedded blocks from placement.
-#
-# Missing while entries named them, which was invisible until the SystemModel
-# started carrying real `execution.deploy` — then those entries failed with
-# "places no nodes on board <x>". Ids are the DEPLOY values the entries pass.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [[model]]
 launch = "subnode_system.launch.xml"
 out    = "subnode_system_model.yaml"

--- a/examples/workspaces/rust/src/demo_bringup/system.toml
+++ b/examples/workspaces/rust/src/demo_bringup/system.toml
@@ -48,20 +48,12 @@ pkg = "action_client_pkg"
 class = "action_client_pkg::FibonacciClient"
 name = "fibonacci_client"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
-# Issue 0951 — these are MACHINES, so they live in `[host.*]` now. A host says
-# WHERE a node runs; what it is built as comes from `[image.*]`. The old blocks
-# carried `target = "x86_64-unknown-linux-gnu"`, which is a build fact: the
-# per-host models are board-agnostic and each entry's own board supplies the
-# target.
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [host.robot1]
 launch = "multihost.launch.xml"
 nodes = ["/talker"]

--- a/examples/workspaces/safety/src/demo_bringup/system.toml
+++ b/examples/workspaces/safety/src/demo_bringup/system.toml
@@ -49,18 +49,12 @@ pkg = "rust_safety_listener_pkg"
 class = "rust_safety_listener_pkg::SafeListener"
 name = "rust_safety_listener"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
 
-# phase-331 W4 — one model per language launch.
-
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [[model]]
 launch = "c_safety_listener.launch.xml"
 out    = "c_safety_listener_model.yaml"

--- a/examples/workspaces/sizing/src/demo_bringup/system.toml
+++ b/examples/workspaces/sizing/src/demo_bringup/system.toml
@@ -16,19 +16,12 @@ pkg = "burst_pkg"
 class = "burst_pkg::BurstTalker"
 name = "burst_talker"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
 
-# --- phase-383 W9 (RFC-0065 D6) — images are the buildable unit.
-# Derived from the entry packages that existed at migration time; each
-# entry's `deploy` token picked its board, and its `launch` its topology.
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]
 [image_defaults]
 rmw = "zenoh"
 

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_esp_idf/demo_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_esp_idf/demo_bringup/system.toml
@@ -14,8 +14,10 @@ pkg  = "listener_pkg"
 class = "listener_pkg::listener"
 name = "listener"
 
-[deploy.esp_idf_esp32c3]
-kind   = "esp-idf"
-target = "x86_64-unknown-linux-gnu"
-board  = "esp32c3"
-launch = "launch/system.launch.xml"
+# Issue 0951 — a BOARD BUILD is an image, not a placement. `kind` here named a
+# platform family, which `[image.*]` reads off the board, and `target` restated
+# the rustc triple the board descriptor already states. `launch` loses its
+# `launch/` prefix: an image's value is resolved against that directory.
+[image.esp_idf_esp32c3]
+board = "esp32c3"
+launch = "system.launch.xml"

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/demo_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/demo_bringup/system.toml
@@ -19,7 +19,9 @@ rmw            = "zenoh"
 domain_id      = 0
 locator        = "tcp/10.0.2.2:7447"
 
-[deploy.qemu-mps2-an385]
-kind   = "freertos"
-target = "thumbv7m-none-eabi"
-board  = "qemu-mps2-an385"
+# Issue 0951 — a BOARD BUILD is an image, not a placement. `kind` here named a
+# platform family, which `[image.*]` reads off the board, and `target` restated
+# the rustc triple the board descriptor already states. `launch` loses its
+# `launch/` prefix: an image's value is resolved against that directory.
+[image.qemu-mps2-an385]
+board = "qemu-mps2-an385"

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_nuttx/src/demo_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_nuttx/src/demo_bringup/system.toml
@@ -14,14 +14,12 @@ pkg  = "listener_pkg"
 class = "listener_pkg::listener"
 name = "listener"
 
-[deploy.qemu-arm-nuttx]
-kind = "nuttx"
+# Issue 0951 — a BOARD BUILD is an image, not a placement. `kind` here named a
+# platform family, which `[image.*]` reads off the board, and `target` restated
+# the rustc triple the board descriptor already states. `launch` loses its
+# `launch/` prefix: an image's value is resolved against that directory.
+[image.qemu-arm-nuttx]
 board = "qemu-armv7a-nsh"
-target = "armv7a-nuttx-eabihf"
-launch = "launch/system.launch.xml"
-
-# SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
-# SDK roots it builds against. Keyed by BOARD, not by a deploy or image
-# name, because that is what the fact is about (issue 0951).
+launch = "system.launch.xml"
 [board_config."qemu-armv7a-nsh"]
 sdk = { nuttx = "{env:NUTTX_DIR}", nuttx_apps = "{env:NUTTX_APPS_DIR}" }

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_zephyr/demo_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_zephyr/demo_bringup/system.toml
@@ -14,8 +14,10 @@ pkg  = "listener_pkg"
 class = "listener_pkg::listener"
 name = "listener"
 
-[deploy.zephyr_native_sim]
-kind   = "zephyr"
-target = "x86_64-unknown-linux-gnu"
-board  = "native_sim/native/64"
-launch = "launch/system.launch.xml"
+# Issue 0951 — a BOARD BUILD is an image, not a placement. `kind` here named a
+# platform family, which `[image.*]` reads off the board, and `target` restated
+# the rustc triple the board descriptor already states. `launch` loses its
+# `launch/` prefix: an image's value is resolved against that directory.
+[image.zephyr_native_sim]
+board = "native_sim/native/64"
+launch = "system.launch.xml"

--- a/packages/testing/nros-tests/fixtures/orchestration_composable/demo_container_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/orchestration_composable/demo_container_bringup/system.toml
@@ -15,12 +15,9 @@ pkg = "demo_container"
 class = "demo_container::demo_container_Talker"
 name = "Talker"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]

--- a/packages/testing/nros-tests/fixtures/orchestration_conditionals/demo_cond_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/orchestration_conditionals/demo_cond_bringup/system.toml
@@ -15,12 +15,9 @@ pkg = "demo_cond"
 class = "demo_cond::demo_cond_logger"
 name = "logger"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]

--- a/packages/testing/nros-tests/fixtures/orchestration_e2e/demo_pkg_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/orchestration_e2e/demo_pkg_bringup/system.toml
@@ -10,12 +10,9 @@ pkg = "demo_pkg"
 class = "demo_pkg::talker"
 name = "talker"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]

--- a/packages/testing/nros-tests/fixtures/orchestration_includes/demo_inc_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/orchestration_includes/demo_inc_bringup/system.toml
@@ -10,12 +10,9 @@ pkg = "demo_inc"
 class = "demo_inc::demo_inc_leaf"
 name = "leaf"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]

--- a/packages/testing/nros-tests/fixtures/orchestration_set_remap_env/demo_se_bringup/system.toml
+++ b/packages/testing/nros-tests/fixtures/orchestration_set_remap_env/demo_se_bringup/system.toml
@@ -15,12 +15,9 @@ pkg = "demo_se"
 class = "demo_se::demo_se_worker_b"
 name = "worker_b"
 
-# The LAST `[deploy.*]` block: the implicit machine this system runs on.
-#
-# Everything else has moved — placement to `[host.<name>]`, board builds to
-# `[image.<id>]`, site config to `[board_config.<board>]`. This one is a
-# machine too, so it belongs in `[host.*]`; it stays here until that move is
-# measured, because it is the block that currently makes placement HAPPEN
-# (issue 0951).
-[deploy.native]
-kind = "self"
+
+# Issue 0951 — the implicit machine this system runs on. A host says WHERE a
+# node runs; what it is built as comes from `[image.*]`. Unscoped and with no
+# `nodes`, so it governs every launch file and every node — which is what the
+# `kind = "self"` deploy block it replaces already meant.
+[host.native]


### PR DESCRIPTION
Stacked on #132.

**96 `[deploy.*]` blocks at the start of this issue, 0 now.** The table conflated three facts and each has its own home: placement in `[host.<name>]`, build description in `[image.<id>]`, site config in `[board_config.<board>]`.

## Two populations, not one

**4 misfiled images.** The `multi_pkg_workspace_*` fixtures whose `kind` was a *platform family* (`esp-idf`/`freertos`/`nuttx`/`zephyr`) rather than `self` or `embedded` — board builds the earlier sweep skipped because it matched `kind = "embedded"`. They become `[image.*]`, losing the `launch/` prefix (an image's `launch` resolves against that directory) and their `target`, now derived from the board (#132).

One was a real disagreement worth naming: the esp_idf fixture declared `target = "x86_64-unknown-linux-gnu"` for board `esp32c3`, whose descriptor states `riscv32imc-unknown-none-elf`. That fixture builds through `idf.py set-target esp32c3`, which reads no rustc triple — the host triple was inert, and deriving the board's own is the correction, not a regression.

**20 machines.** `[deploy.native] kind = "self"`, all with no `nodes`, `launch`, or overrides → unscoped `[host.native]` with no `nodes`, which is what a sole governing self-block already meant. Two templates carried `board` on the machine block; those split into a `[host.*]` and an `[image.*]` — a board is a build fact, and a machine is not a build.

## Model effect, measured

Regenerated across all 20 resolving workspaces from a wiped cache. `deploy_name` + `kind` → `host_name`, and `target` disappears — `target = None` reached **by construction** rather than by the special case issue 0356 needed.

Two fixtures lose their `execution:` section outright, because their sole block was a platform family acting as placement *by accident*. Checked before accepting that: nothing live reads per-node `domain`/`rmw` from a model (the one reader, `sched_caps_from_deploy`, keys on `edf`/`cores` extras that `deny_unknown_fields` makes unauthorable), and `keep()`'s empty-map arm keeps every node.

Verified the way that matters rather than by reading the resolver — `nros codegen entry --board {freertos,nuttx,zephyr,native}` against the model before and after, for a host-migrated workspace *and* for the fixture that lost its `execution:` section:

```
examples_workspaces_rust-freertos.rs          identical (2 registers)
examples_workspaces_rust-nuttx.rs             identical (2 registers)
...multi_pkg_workspace_nuttx-freertos.rs      identical (2 registers)
...multi_pkg_workspace_nuttx-zephyr.rs        identical (2 registers)
```

## Scope

The **schema** keeps `[deploy.*]` and every reader keeps its deploy fallback — out-of-tree users still author it, and the deprecation warnings are what move them. This is the tree catching up with its own advice.

Not in this PR: `nros new --deploy` still scaffolds `board`/`target` into `[deploy.<name>]`, so a freshly scaffolded workspace trips its own deprecation lint. Fixing it means renaming a user-facing verb (`--image` / `--host`), which deserves its own decision rather than being folded in here. Recorded in the issue.

`just ci-l1` green (the tier's own exit status). `just check fast` 146/146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG