### PR TITLE
docs(#0951): resolved — `[deploy.*]` is gone, 96 blocks to 0

### DIFF
--- a/docs/issues/archived/0951-site-config-keys-on-deploy-not-board.md
+++ b/docs/issues/archived/0951-site-config-keys-on-deploy-not-board.md
@@ -2,10 +2,11 @@
 id: 951
 title: "`[deploy.*]` is three unrelated facts in one table — site config keyed
   on the deploy name, not the board, is the half that duplicates"
-status: open
+status: resolved
 type: tech-debt
 area: orchestration, tooling
 related: [rfc-0065, rfc-0072, phase-383, issue-0842, issue-0606]
+resolved_in: ae3e2aa47
 ---
 
 ## Problem
@@ -148,15 +149,12 @@ regression pin, at the layer where the fact lives.
   out-of-tree users still author it, and the deprecation warnings are what move
   them.
 
-Still open:
-* **the last `[deploy.*]` block per bringup** — one `kind = "self"` each, the
-  implicit machine the system runs on. It is a machine, so it belongs in
-  `[host.*]`; moving it empties the table and gives `target = None` by
-  construction, which is the shape issue 0356 wanted. It stays for now because
-  it is the block that currently makes placement HAPPEN, and deleting the
-  embedded blocks around it already flipped every placed node to
-  `target: linux` (see below) — one measured change at a time.
-* `DEPRECATED_DEPLOY_FIELDS` now records a DESTINATION per field, because the
+Also landed:
+* **the last `[deploy.*]` block per bringup is gone too.** Each was a
+  `kind = "self"` machine and became an unscoped `[host.<name>]`, which gives
+  `target = None` by construction — the shape issue 0356 wanted. Tree-wide the
+  count is now `deploy=0`, against 96 when this issue was filed.
+* `DEPRECATED_DEPLOY_FIELDS` records a DESTINATION per field, because the
   destination is not uniform — the first version sent `domain_id` and `locator`
   to `[image.*]`, a table with no such keys.
 

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -68,7 +68,6 @@ fails if this block drifts.
 - **#0925** (tooling) — `ros2-box-sync.sh` copies the GENERATED workspace manifests while excluding the `build/` members they list, so every box fixture build dies in `cargo metadata` See `0925-*`.
 - **#0939** (tooling) — The metadata probe links the node NAME, which is not a target — so every C/C++ component reports `no producer`, once, and then silently See `0939-*`.
 - **#0945** (build) — The shared-cargo-dir campaign rests on five unsupported build-system internals — a Corrosion path formula, an unstable cargo flag, cargo's private `.fingerprint` format, a side channel inside cargo's target dir, and an undocumented depfile location See `0945-*`.
-- **#0951** (orchestration, tooling) — `[deploy.*]` is three unrelated facts in one table — site config keyed on the deploy name, not the board, is the half that duplicates See `0951-*`.
 - **#0953** (tooling) — A panic in the Python half crosses `extern \"C\"` and ABORTS the resolver — 0897 removed the loader abort and left this one See `0953-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
Closes issue 0951 and archives it.

Its "Still open" section had gone stale — it listed the `kind = "self"` blocks as remaining, and #133 migrated those to `[host.*]` in the same series.

Measured on merged main:

```
deploy=0   host=28   image=123   board_config=24
```

against `deploy=96` when the issue was filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG