### PR TITLE
feat(provisioning): make + ninja come from `nros setup`, not bespoke recipes

### DIFF
--- a/activate.fish
+++ b/activate.fish
@@ -110,13 +110,11 @@ if test -d $_nros_sdk
     end
 end
 
-# Pinned ninja + make (Phase 176 jobserver tooling)
-if test -x $_nros_root/third-party/ninja/ninja
-    set -gx PATH $_nros_root/third-party/ninja $PATH
-end
-if test -x $_nros_root/third-party/make/make
-    set -gx PATH $_nros_root/third-party/make $PATH
-end
+# Pinned ninja + make (Phase 176 jobserver tooling) — no block here any more:
+# both are ordinary SDK-store tools, so the generic store loop above puts them
+# on PATH via `scripts/sdk-path-tools.txt`. Keeping a hand-written block in each
+# shell is exactly the drift that file was created to end (issue 0663 —
+# `espflash` was in the bash one and not this one).
 
 # Project `.env` — fish doesn't natively `source` POSIX dotenv files;
 # parse KEY=value pairs manually. Lines with comments or empty are

--- a/activate.sh
+++ b/activate.sh
@@ -335,19 +335,13 @@ EOF
 fi
 unset _nros_sdk
 
-# Pinned ninja (>=1.13, GNU-jobserver client — Phase 176) installed by
-# `just workspace install-ninja`. Wins over Ubuntu's apt 1.10 (no
-# jobserver). Required by `just build-all-jobserver` to scale cargo +
-# cmake + ninja under one token pool.
-if [ -x "$_nros_root/third-party/ninja/ninja" ]; then
-    export PATH="$_nros_root/third-party/ninja:$PATH"
-fi
-
-# Pinned GNU make (>=4.4, fifo jobserver — Phase 176) installed by
-# `just workspace install-make`. Wins over Ubuntu's 4.3.
-if [ -x "$_nros_root/third-party/make/make" ]; then
-    export PATH="$_nros_root/third-party/make:$PATH"
-fi
+# Pinned make (>=4.4, fifo jobserver server) and ninja (>=1.13, its client) —
+# Phase 176. NO block here any more: both are ordinary SDK-store tools now
+# (`nros setup --tool make` / `--tool ninja`), so the generic store loop above
+# puts them on PATH via `scripts/sdk-path-tools.txt`. They used to live under
+# `third-party/` behind two bespoke `just workspace install-*` recipes, which
+# meant a second version pin (`MAKE_VERSION`/`NINJA_VERSION`) that could drift
+# from the index's.
 
 # Zephyr's `west` is NOT put on PATH here. It is resolved when a Zephyr lane
 # needs it, by `nros_zephyr_activate` in scripts/build/zephyr-python.sh.

--- a/book/src/internals/build-system.md
+++ b/book/src/internals/build-system.md
@@ -50,9 +50,11 @@ Phase 176 fifo jobserver; Make was dropped from the staleness path because
 - Generator-mismatch wipe: a dir configured with the *other* generator is
   `rm -rf`'d and reconfigured (you can't switch generators in place).
 - Pinned tools: the unified jobserver needs `make ≥ 4.4` + `ninja ≥ 1.13`
-  (apt's 4.3/1.10 lack the fifo jobserver). `just workspace install-make` /
-  `install-ninja` build them into `third-party/{make,ninja}`; `.envrc` puts them
-  on `PATH` (incl. a `gmake` → make-4.4 alias).
+  (apt's 4.3/1.10 lack the fifo jobserver). Both are SDK-store tools —
+  `nros setup --tool make` (source tarball; upstream ships no binary) and
+  `nros setup --tool ninja` (upstream prebuilt zip) — and
+  `scripts/sdk-path-tools.txt` puts them on `PATH` (incl. a `gmake` → make-4.4
+  alias). Resolve an exact path with `nros sdk-path <tool>`.
 
 ## Per-RMW build dirs = cache isolation
 

--- a/build-all.mk
+++ b/build-all.mk
@@ -1,7 +1,7 @@
 # Phase 176 — unified-jobserver build orchestration.
 #
 # Run via `just build-all-jobserver` (or directly:
-#   third-party/make/make -j$(nproc) --jobserver-style=fifo -f build-all.mk
+#   $(nros sdk-path make)/bin/make -j$(nproc) --jobserver-style=fifo -f build-all.mk
 # ). The pinned make >=4.4 hands out a fifo-based jobserver; every
 # `+`-prefixed recipe below shares it, and because fifo auth is a PATH
 # (not inherited fds) every descendant tool — cargo, its build-script
@@ -12,8 +12,8 @@
 # tokens flow to the long pole (zephyr) automatically.
 #
 # Requirements (checked by `just workspace doctor`):
-#   - make >=4.4   (third-party/make/make) — fifo jobserver provider
-#   - ninja >=1.13 (third-party/ninja/ninja) — fifo jobserver client
+#   - make >=4.4   (`nros setup --tool make`) — fifo jobserver provider
+#   - ninja >=1.13 (`nros setup --tool ninja`) — fifo jobserver client
 # Both must be first on PATH (direnv .envrc) so the sub-tools pick them
 # up. Tools must NOT be passed an explicit -j / --parallel (that detaches
 # them from the pool); the `just` recipes default their inner fan-out to

--- a/docs/development/ros2-on-non-ubuntu.md
+++ b/docs/development/ros2-on-non-ubuntu.md
@@ -268,10 +268,11 @@ is the same checkout, so `NROS_REPO_DIR` matches the host either way.
   with `just doctor`, fix with `sudo apt-get install ros-<distro>-rmw-zenoh-cpp`
   inside the box.
 - **The vendored `make` and `nros-launch-resolve` are host binaries in a shared
-  tree**, exactly like the CLI. `third-party/make/make` used to link the build
-  host's guile and died here as `libguile-3.0.so.1: cannot open shared object
-  file` (fixed: the recipe configures `--without-guile`, so one binary serves
-  both sides — rebuild it once in the box with `just workspace install-make`).
+  tree**, exactly like the CLI. The pinned make used to link the build host's
+  guile and died here as `libguile-3.0.so.1: cannot open shared object file`
+  (fixed: the index's source recipe configures `--without-guile`, so one binary
+  serves both sides — rebuild it once in the box with
+  `nros setup --tool make`).
   `nros-launch-resolve` is per-environment by design (issue 0409): a stale one
   fails `nros sync` with a TOML `unknown field` error naming a field the current
   schema does have, which reads as a broken `system.toml` rather than a stale

--- a/just/workspace.just
+++ b/just/workspace.just
@@ -2,18 +2,6 @@ set working-directory := '..'
 
 NIGHTLY := `awk '/^channel/ {gsub(/"/, "", $3); print $3; exit}' tools/rust-toolchain.toml`
 
-# Pinned ninja version. Ubuntu's apt `ninja-build` lags (1.10); we need
-# ≥1.13 for the GNU-jobserver client (Phase 176). Installed as a static
-# binary under `third-party/ninja/`; `.envrc` prepends it to PATH.
-NINJA_VERSION := "1.13.2"
-
-# Pinned GNU make version. Ubuntu ships 4.3, whose jobserver is
-# pipe-fd-based; ninja 1.13's jobserver client speaks ONLY the
-# fifo protocol (make ≥4.4, `--jobserver-style=fifo`). Phase 176's
-# unified jobserver needs 4.4. Built from source to third-party/make/;
-# `.envrc` prepends it to PATH.
-MAKE_VERSION := "4.4.1"
-
 # Pinned Corrosion version. Corrosion is the cmake-side Rust bridge used
 # by mixed-language workspaces (Phase 212 — `corrosion_import_crate` in
 # `cmake/NanoRosThreadxSystemCodegen.cmake` etc.). Installed to
@@ -71,8 +59,11 @@ setup:
     # system-package step is LAST and only PRINTS (a missing OS package must
     # never abort the sudo-less remainder — one sudo failure here used to
     # cascade into zephyr/esp32/px4).
-    @just workspace install-ninja
-    @just workspace install-make
+    # make + ninja: store tools, not bespoke recipes (see the note where those
+    # recipes used to be). `--tool` so a `just workspace setup` still provisions
+    # the jobserver pair without the user knowing they moved.
+    @nros setup --tool ninja
+    @nros setup --tool make
     @just workspace install-corrosion
     @just workspace install-play-launch-parser
     @just workspace rust-pinned-toolchains
@@ -96,111 +87,18 @@ build-codegen:
     nros_cargo_ensure_codegen_c
     echo "[codegen] nros tool: $(nros_cargo_codegen_c_bin)"
 
-# Build the pinned GNU make (>=4.4) from source under third-party/make/.
-# Ubuntu's make 4.3 jobserver is pipe-fd-based; ninja 1.13's jobserver
-# client only speaks fifo (make 4.4 `--jobserver-style=fifo`). Needed
-# for the Phase 176 unified jobserver. `.envrc` puts it first on PATH.
-# Lives under third-party/ (survives `just clean`). Idempotent.
-[group("setup")]
-install-make:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    want="{{MAKE_VERSION}}"
-    dest="third-party/make"
-    bin="$dest/make"
-    if [ -x "$bin" ] && "$bin" --version 2>/dev/null | head -1 | grep -q "$want"; then
-        echo "[make] $want already installed ($bin)"
-        exit 0
-    fi
-    mkdir -p "$dest"
-    tmp="$(mktemp -d)"
-    trap 'rm -rf "$tmp"' EXIT
-    echo "[make] downloading $want..."
-    curl -fSL "https://ftp.gnu.org/gnu/make/make-$want.tar.gz" -o "$tmp/make.tar.gz"
-    tar xzf "$tmp/make.tar.gz" -C "$tmp"
-    echo "[make] building (./configure && ./build.sh)..."
-    # --without-guile: make's configure AUTODETECTS a host guile and links it,
-    # which is how this binary became unportable across the ROS distrobox. The
-    # tree is shared with the box (same paths, different distro), so an Arch
-    # build landed a `libguile-3.0.so.1` dependency that Ubuntu 22.04 cannot
-    # satisfy, and every box-side `just <plat> build-fixtures` died as
-    # `make: error while loading shared libraries` — the same one-path-two-worlds
-    # collision the box CLI has (ros2-box-env.sh `nros_box_publish`), for the
-    # same reason. Guile only powers make's `$(guile …)` function, which nothing
-    # in this repo calls; dropping it makes ONE binary serve both sides.
-    # Bootstrap with a make that is NOT the one we are replacing. `activate.sh`
-    # puts `third-party/make` first on PATH, and make's own configure needs a
-    # working make to bootstrap its depfile fragments — so when the installed
-    # binary is broken (the guile case above, or any half-written copy) the
-    # recipe that FIXES it fails first, on an error that names dependency
-    # tracking and never mentions PATH. Drop our own dir for the build only.
-    _boot_path=""
-    for _d in ${PATH//:/ }; do
-        case "$_d" in
-          */third-party/make|*/third-party/make/) ;;
-          *) _boot_path="${_boot_path:+$_boot_path:}$_d" ;;
-        esac
-    done
-    # Log rather than discard: a silenced build reports only "exit code 1", and
-    # this recipe runs in two different distros over one tree.
-    if ! ( cd "$tmp/make-$want" && export PATH="$_boot_path" \
-             && ./configure --without-guile > cfg.log 2>&1 \
-             && ./build.sh > build.log 2>&1 ); then
-        echo "[make] build failed; last lines:" >&2
-        tail -20 "$tmp/make-$want/build.log" "$tmp/make-$want/cfg.log" 2>/dev/null >&2 || true
-        exit 1
-    fi
-    # issue 0726 — `nros_grep_q` rather than a bare `grep -q`: in an `if`, a
-    # grep that fails to START reads as "no guile", which is the answer that
-    # lets the bad binary install. It exits 2 instead.
-    # shellcheck source=scripts/lib/grep-q.sh
-    source scripts/lib/grep-q.sh
-    if ldd "$tmp/make-$want/make" 2>/dev/null | nros_grep_q guile; then
-        echo "[make] refusing to install: built make still links guile — a host-only" >&2
-        echo "       binary breaks the distrobox (see the --without-guile note above)." >&2
-        exit 1
-    fi
-    cp "$tmp/make-$want/make" "$bin"
-    chmod +x "$bin"
-    # Some sub-builds (cmake generators, RTOS kernel makefiles) invoke
-    # `gmake`, not `make`. Provide a gmake -> make 4.4 alias so they too
-    # are fifo-jobserver-capable; otherwise a stray make 4.3 chokes on
-    # the inherited `--jobserver-auth=fifo:` in MAKEFLAGS.
-    ln -sf make "$dest/gmake"
-    echo "[make] installed: $("$bin" --version | head -1) ($bin) (+ gmake alias)"
-    echo "[make] ensure third-party/make is on PATH (direnv .envrc does this)."
-
-# Install the pinned ninja static binary under third-party/ninja/.
-# Ubuntu's apt ninja is too old (1.10) for the GNU-jobserver client;
-# `.envrc` puts third-party/ninja first on PATH so this one wins. Lives
-# under third-party/ (not build/) so `just clean` doesn't wipe it.
-# Idempotent: skips when the pinned version is already present.
-[group("setup")]
-install-ninja:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    want="{{NINJA_VERSION}}"
-    dest="third-party/ninja"
-    bin="$dest/ninja"
-    if [ -x "$bin" ] && [ "$("$bin" --version 2>/dev/null)" = "$want" ]; then
-        echo "[ninja] $want already installed ($bin)"
-        exit 0
-    fi
-    case "$(uname -m)" in
-        x86_64)  asset="ninja-linux.zip" ;;
-        aarch64) asset="ninja-linux-aarch64.zip" ;;
-        *) echo "[ninja] unsupported arch $(uname -m); install ninja >=1.13 manually" >&2; exit 1 ;;
-    esac
-    url="https://github.com/ninja-build/ninja/releases/download/v$want/$asset"
-    echo "[ninja] downloading $want ($asset)..."
-    mkdir -p "$dest"
-    tmp="$(mktemp -d)"
-    trap 'rm -rf "$tmp"' EXIT
-    curl -fSL "$url" -o "$tmp/ninja.zip"
-    unzip -o "$tmp/ninja.zip" -d "$dest" >/dev/null
-    chmod +x "$bin"
-    echo "[ninja] installed: $("$bin" --version) ($bin)"
-    echo "[ninja] ensure third-party/ninja is on PATH (direnv .envrc does this)."
+# make + ninja are NOT installed here any more.
+#
+# They were two bespoke recipes filling `third-party/{make,ninja}/`, each with
+# its own version variable — a second pin beside `nros-sdk-index.toml`'s, free
+# to drift from it. They are ordinary store tools now:
+#
+#     nros setup --tool make      # 4.4.1, source tarball (upstream ships no binary)
+#     nros setup --tool ninja     # 1.13.2, upstream prebuilt zip
+#
+# Policy: prebuilt when upstream publishes one, source only as the fallback.
+# `scripts/sdk-path-tools.txt` puts both on PATH; consumers resolve the exact
+# path with `nros sdk-path <tool>`, constructed from the pin (issue 0625).
 
 # Install Corrosion (cmake ↔ Rust bridge) into `~/.nros/sdk/corrosion/`.
 # Mixed-language workspaces (Phase 212) use `find_package(Corrosion)` +
@@ -398,11 +296,14 @@ doctor:
     fi
 
     # --- pinned ninja (>=1.13 for the GNU-jobserver client, Phase 176) ---
-    ninja_bin="third-party/ninja/ninja"
-    if [ -x "$ninja_bin" ] && [ "$("$ninja_bin" --version 2>/dev/null)" = "{{NINJA_VERSION}}" ]; then
-        echo "  [OK] ninja {{NINJA_VERSION}} (third-party/ninja; jobserver-capable)"
+    # Store tool now; path CONSTRUCTED from the index pin (issue 0625), so this
+    # cannot drift from what `nros setup --tool ninja` installed. The version is
+    # the index's — there is no second pin here to disagree with it.
+    ninja_bin="$(nros sdk-path ninja 2>/dev/null)/bin/ninja"
+    if [ -x "$ninja_bin" ]; then
+        echo "  [OK] ninja $("$ninja_bin" --version) (SDK store; jobserver-capable)"
     else
-        echo "  [MISSING] ninja {{NINJA_VERSION}} (run: just workspace install-ninja)"
+        echo "  [MISSING] ninja (run: nros setup --tool ninja)"
         fail=1
     fi
 
@@ -510,11 +411,11 @@ doctor:
     fi
 
     # --- pinned make (>=4.4 for the fifo jobserver, Phase 176) ---
-    make_bin="third-party/make/make"
-    if [ -x "$make_bin" ] && "$make_bin" --version 2>/dev/null | head -1 | grep -q "{{MAKE_VERSION}}"; then
-        echo "  [OK] make {{MAKE_VERSION}} (third-party/make; fifo jobserver)"
+    make_bin="$(nros sdk-path make 2>/dev/null)/bin/make"
+    if [ -x "$make_bin" ]; then
+        echo "  [OK] make $("$make_bin" --version | head -1 | awk '{print $NF}') (SDK store; fifo jobserver)"
     else
-        echo "  [MISSING] make {{MAKE_VERSION}} (run: just workspace install-make)"
+        echo "  [MISSING] make (run: nros setup --tool make)"
         fail=1
     fi
 

--- a/just/zephyr-ci.just
+++ b/just/zephyr-ci.just
@@ -125,11 +125,11 @@ build-fixtures:
     ccache_dir="${NROS_ZEPHYR_CCACHE_DIR:-$nros_root/build/zephyr-cache/ccache}"
     ccache_tmpdir="${NROS_ZEPHYR_CCACHE_TEMPDIR:-$nros_root/build/zephyr-cache/ccache-tmp}"
     mkdir -p "$ccache_dir" "$ccache_tmpdir"
-    make_bin="$nros_root/third-party/make/make"
+    make_bin="$(nros sdk-path make 2>/dev/null)/bin/make"
     if [ ! -x "$make_bin" ]; then
         make_bin="$(command -v make)"
     fi
-    tool_path="$nros_root/third-party/make:$nros_root/third-party/ninja:$PATH"
+    tool_path="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     # Phase 178.J — fail/regenerate Zephyr Rust generated crates before
     # scheduling expensive west builds. Direct `just zephyr build-fixtures`
     # is allowed, so do not rely solely on the root `generate-bindings`

--- a/just/zephyr-dev.just
+++ b/just/zephyr-dev.just
@@ -276,11 +276,11 @@ build-c-port:
         echo "$WORKSPACE/env.sh missing — run: just zephyr setup" >&2
         exit 2
     fi
-    make_bin="$(pwd)/third-party/make/make"
+    make_bin="$(nros sdk-path make 2>/dev/null)/bin/make"
     if [ ! -x "$make_bin" ]; then
         make_bin="$(command -v make)"
     fi
-    export PATH="$(pwd)/third-party/make:$(pwd)/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     source "$WORKSPACE/env.sh"
     # issue 0698 follow-up — the Zephyr venv is this lane's, not the session's.
     source scripts/build/zephyr-python.sh

--- a/just/zephyr-setup.just
+++ b/just/zephyr-setup.just
@@ -174,12 +174,12 @@ build-fvp-ws-entry:
     source scripts/build/cargo.sh
     nros_cargo_ensure_codegen_c
     codegen_tool="$(nros_cargo_codegen_c_bin)"
-    make_bin="$nros_root/third-party/make/make"
+    make_bin="$(nros sdk-path make 2>/dev/null)/bin/make"
     if [ ! -x "$make_bin" ]; then
         make_bin="$(command -v make)"
     fi
     cd "$workspace"
-    export PATH="$nros_root/third-party/make:$nros_root/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     export ZEPHYR_SDK_INSTALL_DIR="$sdk"
     export NROS_REPO_DIR="$nros_root"
     # phase-298 W3 — bake the fast-sim flag into the configure-time
@@ -231,7 +231,7 @@ run-fvp-ws-entry:
     fi
     nros_root="$(pwd)"
     cd "$workspace"
-    export PATH="$nros_root/third-party/make:$nros_root/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     export ZEPHYR_SDK_INSTALL_DIR="$nros_root/scripts/zephyr/sdk/zephyr-sdk-0.16.8"
     export NROS_REPO_DIR="$nros_root"
     export ARMFVP_EXTRA_FLAGS="-C cache_state_modelled=0"
@@ -287,13 +287,13 @@ build-fvp-board-import:
     source scripts/build/cargo.sh
     nros_cargo_ensure_codegen_c
     codegen_tool="$(nros_cargo_codegen_c_bin)"
-    make_bin="$nros_root/third-party/make/make"
+    make_bin="$(nros sdk-path make 2>/dev/null)/bin/make"
     if [ ! -x "$make_bin" ]; then
         make_bin="$(command -v make)"
     fi
     src="$nros_root/packages/testing/nros-tests/fixtures/board_import_fvp"
     cd "$workspace"
-    export PATH="$nros_root/third-party/make:$nros_root/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     export ZEPHYR_SDK_INSTALL_DIR="$sdk"
     # Phase 215.B — the fixture's CMakeLists includes
     # `$ENV{NROS_REPO_DIR}/zephyr/cmake/nano_ros_use_board.cmake` BEFORE
@@ -342,7 +342,7 @@ run-fvp-board-import:
     fi
     nros_root="$(pwd)"
     cd "$workspace"
-    export PATH="$nros_root/third-party/make:$nros_root/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     export ZEPHYR_SDK_INSTALL_DIR="$nros_root/scripts/zephyr/sdk/zephyr-sdk-0.16.8"
     west fvp run -d build-fvp-board-import
 

--- a/justfile
+++ b/justfile
@@ -347,7 +347,7 @@ build-all:
         echo "build-all: unified jobserver path (make 4.4 + ninja 1.13; NROS_NO_JOBSERVER=1 to opt out)"
         exec just build-all-jobserver
     fi
-    echo "build-all: static split (install make>=4.4 + ninja>=1.13 — just workspace install-make/install-ninja — for the jobserver path)"
+    echo "build-all: static split (install make>=4.4 + ninja>=1.13 — nros setup --tool make / --tool ninja — for the jobserver path)"
     just build
     just build-example-extras
     just build-test-fixtures-leaves
@@ -361,8 +361,8 @@ build-all:
 # every stage (cargo + build-script cc + ninja-via-west + cmake), instead
 # of the static per-platform scheduler split. When the fast
 # platforms finish, their tokens flow to the long pole automatically.
-# Needs the pinned make >=4.4 + ninja >=1.13 (just workspace install-make
-# / install-ninja). NROS_BUILD_JOBS (default nproc) = the token budget.
+# Needs the pinned make >=4.4 + ninja >=1.13 (`nros setup --tool make` /
+# `--tool ninja`). NROS_BUILD_JOBS (default nproc) = the token budget.
 # Recipes detect the inherited jobserver (NROS_JOBSERVER=1) and skip their
 # own explicit -j so the tools draw from the shared pool.
 [group("full-matrix")]

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -442,6 +442,92 @@ ref = "0.5.7"
 configure = "make genromfs"
 install = "install -D -m 0755 genromfs {prefix}/bin/genromfs"
 
+# ninja — the generator every cmake configure in this repo emits for, and the
+# JOBSERVER CLIENT half of the Phase 176 unified pool.
+#
+# WHY A VERSION FLOOR AND NOT "whatever the distro ships"
+#
+# Ninja gained GNU Make jobserver support in 1.13 ("Since version 1.13, Ninja
+# builds can follow the GNU Make jobserver client protocol"), and only the
+# FIFO flavour — the one make 4.4 speaks. Below 1.13 ninja simply ignores an
+# inherited `MAKEFLAGS` and takes `-j <nproc>` of its own, so a build nested
+# under a pool silently oversubscribes instead of sharing the budget. That is
+# the same shape as `[prereq.openocd]`: a system copy is fine WHEN it is new
+# enough, and `min` is what makes "new enough" decidable rather than a hope.
+# Ubuntu 22.04 ships 1.10.1, so on that distro the chain falls through to the
+# store and the user installs nothing by hand.
+#
+# Note the client/server split, because it decides what this buys: ninja is a
+# jobserver CLIENT ONLY — it never hands tokens to the cargo IT spawns. Pairing
+# it with pinned make 4.4 (the server) is what bounds a nested build; ninja
+# alone does not.
+#
+# Source-built rather than dist: upstream ships prebuilt zips, but this index's
+# `dist.*` rows are assets on the NEWSLabNTU/nano-ros-sdk mirror and none is
+# seeded for ninja yet. Per the header, leaving `dist.<host>` out makes
+# `nros setup` fall back to this recipe. Cheap and self-contained — cmake plus
+# a C++ compiler, both already prereqs, and no autotools.
+# Verified 2026-08-31: depth-1 fetch of v1.13.2 + this configure/install pair
+# produces a `ninja --version` of 1.13.2.
+[tool.ninja]
+version = "1.13.2"
+upstream = "v1.13.2" # = the ninja-build/ninja release tag
+# PREBUILT FIRST — upstream publishes these, so we take them rather than
+# rebuilding what they already built. The `[tool.ninja.source]` recipe below is
+# the FALLBACK for a host they ship no asset for; `dist_for(host)` is consulted
+# first, so it only runs where it has to.
+#
+# Each carries its own `install`, because the default unpack (`tar -xf` into the
+# prefix) cannot take these: they are zips, and they hold a BARE `ninja` with no
+# `bin/` directory. That is what an upstream asset looks like when it was not
+# built to our mirror's shape, and it is why `DistArtifact.install` exists.
+dist.linux-x86_64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux.zip", sha256 = "5749cbc4e668273514150a80e387a957f933c6ed3f5f11e03fb30955e2bbead6", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja" }
+dist.linux-arm64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linux-aarch64.zip", sha256 = "fd2cacc8050a7f12a16a2e48f9e06fca5c14fc4c2bee2babb67b58be17a607fc", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja" }
+dist.macos-arm64 = { url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip", sha256 = "c99048673aa765960a99cf10c6ddb9f1fad506099ff0a0e137ad8960a88f321b", install = "unzip -o {archive} -d {prefix}/bin && chmod +x {prefix}/bin/ninja" }
+system = ["unzip"]
+# Fallback only. Verified 2026-08-31 that it does produce a 1.13.2 binary, so a
+# host off the three asset arches is not stranded.
+[tool.ninja.source]
+git = "https://github.com/ninja-build/ninja"
+ref = "v1.13.2"
+# BUILD_TESTING=OFF — the test target fetches googletest, and a provisioning
+# step must not need the network mid-build.
+configure = "cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF"
+install = "cmake --build build -j$(nproc) && install -D -m 0755 build/ninja {prefix}/bin/ninja"
+
+# make — the jobserver SERVER half. Source-built because upstream ships NO
+# prebuilt binary: ftp.gnu.org carries release tarballs only, so the policy's
+# fallback arm is the only arm available here.
+#
+# A TARBALL and not `git`, because GNU make's git tree at 4.4.1 ships no
+# `configure` — only `bootstrap`, which wants autoconf/automake/gettext and
+# pulls gnulib. That is what `[tool.*.source].url` was added for.
+#
+# The install step carries what the retired `just workspace install-make`
+# recipe knew:
+#   --without-guile   make's configure AUTODETECTS a host guile and links it,
+#                     which made the binary unportable across the ROS
+#                     distrobox (one tree, two distros): an Arch build linked
+#                     libguile-3.0.so.1 that Ubuntu 22.04 could not satisfy and
+#                     every box-side build died in the loader. Nothing here
+#                     calls make's `$(guile ...)`.
+#   ./build.sh        make's own bootstrap build — you need a make to build
+#                     make, and this is how the project avoids that.
+#   the ldd refusal   an install that silently linked guile is the failure
+#                     above, deferred to someone else's machine.
+#   gmake             cmake generators and RTOS kernel makefiles invoke `gmake`;
+#                     without the alias a stray system make 4.3 answers and
+#                     chokes on the inherited `--jobserver-auth=fifo:`.
+[tool.make]
+version = "4.4.1"
+upstream = "4.4.1"
+system = ["curl"]
+[tool.make.source]
+url = "https://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz"
+sha256 = "dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3"
+configure = "./configure --without-guile"
+install = "./build.sh && if ldd make 2>/dev/null | grep -q guile; then echo 'refusing: built make links guile (see the index note)' >&2; exit 1; fi && install -D -m 0755 make {prefix}/bin/make && ln -sf make {prefix}/bin/gmake"
+
 # --- source packages (built with the app for the user's target) ---
 #
 # Phase 195.B — data-driven provisioning. Each source is a committed submodule,
@@ -821,6 +907,59 @@ dnf = ["cmake"]
 pacman = ["cmake"]
 brew = ["cmake"]
 check = { cmd = "cmake" }
+
+[prereq.unzip]
+why = "unpacks the upstream ninja release zips ([tool.ninja] dist install step); tar cannot read a zip"
+apt = ["unzip"]
+dnf = ["unzip"]
+pacman = ["unzip"]
+brew = ["unzip"]
+check = { cmd = "unzip" }
+
+[prereq.curl]
+why = "every dist download and the [tool.make] source tarball fetch shell out to it"
+apt = ["curl"]
+dnf = ["curl"]
+pacman = ["curl"]
+brew = ["curl"]
+check = { cmd = "curl" }
+
+[prereq.ninja]
+why = "the generator every cmake configure emits for; >=1.13 also speaks the make-4.4 fifo jobserver protocol, so a nested build shares one token budget instead of taking nproc of its own"
+# Same chain as `[prereq.openocd]`: a system copy is fine WHEN new enough.
+# Ubuntu 22.04 ships 1.10.1 and Ubuntu 24.04 1.11.1, both below the jobserver
+# floor, so on those distros this falls through to the store.
+providers = ["system", "sdk"]
+source = "ninja"
+apt = ["ninja-build"]
+dnf = ["ninja-build"]
+pacman = ["ninja"]
+brew = ["ninja"]
+check = { cmd = "ninja", version = { run = "ninja --version", min = "1.13" } }
+
+# make — the jobserver SERVER half, and the only half that hands out tokens.
+#
+# NOT `providers = ["system", "sdk"]` like ninja above, because there is no
+# `[tool.make]` to fall through TO yet. `ToolSource` is git-only, and GNU
+# make's git tree ships no `configure` — only `bootstrap`, which wants
+# autoconf/automake/gettext and pulls gnulib. The repo already solved this the
+# other way: `just workspace install-make` builds 4.4.1 from the RELEASE
+# TARBALL into `third-party/make/`, carrying two hard-won details (`--without-guile`,
+# and bootstrapping with a make that is not the one being replaced).
+#
+# So this entry is deliberately DIAGNOSIS ONLY: it makes `just doctor` say that
+# the system make is too old for `--jobserver-style=fifo`, instead of leaving a
+# silently-unbounded build. Provisioning it through `nros setup` needs tarball
+# support in `[tool.*.source]` (`url` + `sha256` beside `git` + `ref`); adding a
+# SECOND make provisioning path before then would be the drift this repo keeps
+# paying for.
+[prereq.make]
+why = "GNU make >=4.4 serves `--jobserver-style=fifo`, the only jobserver flavour ninja 1.13 can join; 4.3 and older serve a pipe-fd jobserver that ninja ignores. Until [tool.make] exists, install with `just workspace install-make`"
+apt = ["make"]
+dnf = ["make"]
+pacman = ["make"]
+brew = ["make"]
+check = { cmd = "make", version = { run = "make --version", min = "4.4" } }
 
 [prereq.genromfs]
 why = "NuttX riscv rv-virt etc/ ROMFS image (the [tool.genromfs] source recipe is the store alternative)"

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -943,7 +943,7 @@ check = { cmd = "ninja", version = { run = "ninja --version", min = "1.13" } }
 # `[tool.make]` to fall through TO yet. `ToolSource` is git-only, and GNU
 # make's git tree ships no `configure` — only `bootstrap`, which wants
 # autoconf/automake/gettext and pulls gnulib. The repo already solved this the
-# other way: `just workspace install-make` builds 4.4.1 from the RELEASE
+# other way: the retired `just workspace install-make` built 4.4.1 from the RELEASE
 # TARBALL into `third-party/make/`, carrying two hard-won details (`--without-guile`,
 # and bootstrapping with a make that is not the one being replaced).
 #
@@ -954,7 +954,7 @@ check = { cmd = "ninja", version = { run = "ninja --version", min = "1.13" } }
 # SECOND make provisioning path before then would be the drift this repo keeps
 # paying for.
 [prereq.make]
-why = "GNU make >=4.4 serves `--jobserver-style=fifo`, the only jobserver flavour ninja 1.13 can join; 4.3 and older serve a pipe-fd jobserver that ninja ignores. Until [tool.make] exists, install with `just workspace install-make`"
+why = "GNU make >=4.4 serves `--jobserver-style=fifo`, the only jobserver flavour ninja 1.13 can join; 4.3 and older serve a pipe-fd jobserver that ninja ignores. install with `nros setup --tool make`"
 apt = ["make"]
 dnf = ["make"]
 pacman = ["make"]

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
@@ -623,16 +623,57 @@ pub struct BoardEntry {
 pub struct DistArtifact {
     pub url: String,
     pub sha256: String,
+    /// How to turn the downloaded file into a populated prefix, when the
+    /// default cannot.
+    ///
+    /// Default (absent): `tar -xf <archive> -C <prefix>` — right for the
+    /// `.tar.zst` assets on the nano-ros-sdk mirror, which are built to unpack
+    /// prefix-rooted (`bin/…`).
+    ///
+    /// It is wrong for an UPSTREAM asset, and that is the case this exists for.
+    /// Policy is prebuilt-when-upstream-ships-one, source only as fallback, so
+    /// the index has to take assets shaped the way their projects publish them
+    /// rather than the way our mirror does. ninja's `ninja-linux.zip` is both
+    /// kinds of wrong at once: not a tar, and a bare binary with no `bin/`.
+    ///
+    /// Free-form shell, like `[tool.*.source].install` — the same reason, that
+    /// the unpack step genuinely varies per project and a fixed vocabulary of
+    /// archive types would just be a smaller ad-hoc recipe. `{archive}` is the
+    /// downloaded file, `{prefix}` the install prefix.
+    #[serde(default)]
+    pub install: Option<String>,
 }
 
 /// The source-build fallback recipe — installs into the same prefix as `dist`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ToolSource {
-    pub git: String,
+    /// Git remote to fetch from. Mutually exclusive with [`url`](Self::url);
+    /// exactly one of the two must be set (checked by `validate`).
+    #[serde(default)]
+    pub git: Option<String>,
     /// Git ref (tag/sha) — pinned in lockstep with the prebuilt `version`.
-    #[serde(rename = "ref")]
-    pub git_ref: String,
+    #[serde(rename = "ref", default)]
+    pub git_ref: Option<String>,
+    /// A source TARBALL to fetch instead of cloning.
+    ///
+    /// Exists because git is not always a way to get a buildable tree. GNU
+    /// make's git tree at `4.4.1` ships no `configure` at all — only
+    /// `bootstrap`, which wants autoconf/automake/gettext and pulls gnulib —
+    /// so the release tarball is the only sane input, and a git-only schema
+    /// pushed `make` out of the index into an ad-hoc `just` recipe.
+    ///
+    /// The archive is fetched, sha256-verified and unpacked into the build
+    /// directory with `--strip-components=1`, so `configure`/`install` see the
+    /// project root exactly as the git path leaves it. Everything after the
+    /// fetch is therefore identical between the two modes.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Checksum for [`url`](Self::url). Required with it — an unverified
+    /// download is a supply-chain hole, and the git path gets its integrity
+    /// from the pinned ref.
+    #[serde(default)]
+    pub sha256: Option<String>,
     /// Configure step; `{prefix}` is substituted with the install prefix.
     #[serde(default)]
     pub configure: Option<String>,
@@ -939,6 +980,34 @@ impl SdkIndex {
                     );
                 }
             }
+            // A source recipe fetches from EXACTLY ONE place. Both fields are
+            // `Option` so either mode parses, which means neither and both are
+            // now expressible states — and both fail late and confusingly
+            // (neither: an empty build dir and a configure that "cannot find
+            // ./configure"; both: whichever the executor happens to check
+            // first, silently). Reject them here, where the message can say
+            // which tool.
+            if let Some(src) = &tool.source {
+                match (&src.git, &src.url) {
+                    (Some(_), Some(_)) => bail!(
+                        "[tool.{name}.source] sets both `git` and `url` — a \
+                         recipe fetches from exactly one place"
+                    ),
+                    (None, None) => bail!(
+                        "[tool.{name}.source] sets neither `git` nor `url` — \
+                         nothing to fetch"
+                    ),
+                    _ => {}
+                }
+                if src.git.is_some() && src.git_ref.is_none() {
+                    bail!("[tool.{name}.source] has `git` but no `ref` to pin it to");
+                }
+                // Unverified download = supply-chain hole. The git path gets
+                // its integrity from the pinned ref; the url path has only this.
+                if src.url.is_some() && src.sha256.is_none() {
+                    bail!("[tool.{name}.source] has `url` but no `sha256` to verify it");
+                }
+            }
         }
         for (key, dep) in &self.system {
             if dep.apt.is_empty()
@@ -1077,11 +1146,62 @@ installer = "nvidia-sdk-manager"
         assert_eq!(qemu.dist_for("linux-x86_64").unwrap().sha256, "aa");
         assert!(qemu.dist_for("windows-x86_64").is_none());
         let src = qemu.source.as_ref().expect("qemu has a source recipe");
-        assert_eq!(src.git_ref, "v11.0-nros1"); // the `ref` key
+        assert_eq!(src.git_ref.as_deref(), Some("v11.0-nros1")); // the `ref` key
         assert!(src.configure.as_deref().unwrap().contains("{prefix}"));
 
         assert_eq!(idx.source["freertos-kernel"].version, "10.6.2");
         assert_eq!(idx.gated["nv-spe-fsp"].env, "NV_SPE_FSP_DIR");
+    }
+
+    /// A source recipe fetches from exactly one place. Both `git` and `url` are
+    /// `Option`, so "neither" and "both" became expressible the moment the
+    /// tarball mode landed — and both fail LATE and confusingly if they get
+    /// past here (neither: an empty build dir and a configure that cannot find
+    /// `./configure`; both: whichever the executor checks first, silently).
+    #[test]
+    fn tool_source_fetches_from_exactly_one_place() {
+        let both = SdkIndex::parse(
+            "[tool.t]\nversion=\"1\"\n[tool.t.source]\ngit=\"g\"\nref=\"r\"\n\
+             url=\"u\"\nsha256=\"s\"\n",
+        )
+        .expect("parses");
+        let err = both
+            .validate()
+            .expect_err("both git and url must be rejected");
+        assert!(format!("{err}").contains("exactly one place"), "{err}");
+
+        let neither =
+            SdkIndex::parse("[tool.t]\nversion=\"1\"\n[tool.t.source]\nconfigure=\"x\"\n")
+                .expect("parses");
+        let err = neither.validate().expect_err("neither must be rejected");
+        assert!(format!("{err}").contains("nothing to fetch"), "{err}");
+
+        // An unverified download is a supply-chain hole; the git path gets its
+        // integrity from the pinned ref, the url path has only the checksum.
+        let no_sum = SdkIndex::parse("[tool.t]\nversion=\"1\"\n[tool.t.source]\nurl=\"u\"\n")
+            .expect("parses");
+        let err = no_sum
+            .validate()
+            .expect_err("url without sha256 must be rejected");
+        assert!(format!("{err}").contains("sha256"), "{err}");
+
+        let no_ref = SdkIndex::parse("[tool.t]\nversion=\"1\"\n[tool.t.source]\ngit=\"g\"\n")
+            .expect("parses");
+        let err = no_ref
+            .validate()
+            .expect_err("git without ref must be rejected");
+        assert!(format!("{err}").contains("no `ref`"), "{err}");
+
+        // And the two legal shapes still pass.
+        for ok in [
+            "[tool.t]\nversion=\"1\"\n[tool.t.source]\ngit=\"g\"\nref=\"r\"\n",
+            "[tool.t]\nversion=\"1\"\n[tool.t.source]\nurl=\"u\"\nsha256=\"s\"\n",
+        ] {
+            SdkIndex::parse(ok)
+                .expect("parses")
+                .validate()
+                .expect("legal shape");
+        }
     }
 
     #[test]

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -198,17 +198,36 @@ impl SdkLock {
     }
 }
 
+/// Where a source recipe's tree comes from.
+///
+/// Two modes because git is not always a way to GET a buildable tree: GNU
+/// make's git tree ships no `configure`, only a `bootstrap` that wants
+/// autotools and gnulib. Everything after the fetch — `configure`, `install`,
+/// the toolchain choice — is identical between them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceFetch {
+    Git { git: String, git_ref: String },
+    Tarball { url: String, sha256: String },
+}
+
 /// The decided install action for a tool on a host.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InstallAction {
     /// Already at the prefix (idempotent skip).
     Present,
     /// Fetch + verify + unpack the prebuilt artifact.
-    Prebuilt { url: String, sha256: String },
+    Prebuilt {
+        url: String,
+        sha256: String,
+        /// Optional unpack override — see `DistArtifact::install`. `None` keeps
+        /// the mirror-shaped default (`tar -xf` into the prefix).
+        install: Option<String>,
+    },
     /// Build from source into the same prefix.
     Source {
-        git: String,
-        git_ref: String,
+        /// Where the tree comes from. Exactly one variant, enforced by
+        /// `SdkIndex::validate`.
+        fetch: SourceFetch,
         configure: Option<String>,
         install: Option<String>,
         /// Issue 0374 d4 — build with the checkout's own `rust-toolchain.toml`
@@ -229,12 +248,26 @@ pub fn plan_install(tool: &ToolPackage, host: &str, prefix: &Path) -> InstallAct
         return InstallAction::Prebuilt {
             url: d.url.clone(),
             sha256: d.sha256.clone(),
+            install: d.install.clone(),
         };
     }
     if let Some(s) = &tool.source {
+        // `validate` has already rejected neither-and-both, so this only has to
+        // pick. Preferring `git` when present keeps the pre-tarball behaviour
+        // byte-identical for every existing recipe.
+        let fetch = match (&s.git, &s.url) {
+            (Some(git), _) => SourceFetch::Git {
+                git: git.clone(),
+                git_ref: s.git_ref.clone().unwrap_or_default(),
+            },
+            (None, Some(url)) => SourceFetch::Tarball {
+                url: url.clone(),
+                sha256: s.sha256.clone().unwrap_or_default(),
+            },
+            (None, None) => return InstallAction::Unavailable,
+        };
         return InstallAction::Source {
-            git: s.git.clone(),
-            git_ref: s.git_ref.clone(),
+            fetch,
             configure: s.configure.clone(),
             install: s.install.clone(),
             respect_toolchain: s.respect_toolchain,
@@ -254,7 +287,11 @@ pub fn execute(
     match action {
         InstallAction::Present => Provenance::read(prefix)
             .ok_or_else(|| eyre!("{tool}: present but no provenance marker")),
-        InstallAction::Prebuilt { url, sha256 } => {
+        InstallAction::Prebuilt {
+            url,
+            sha256,
+            install,
+        } => {
             // The prebuilt dists are `.tar.zst`; `tar -xf` shells out to the
             // external `zstd` binary to decompress. A host without it (stock
             // Ubuntu 22.04 ships no `zstd`) otherwise fails DEEP inside tar with
@@ -289,17 +326,32 @@ pub fn execute(
             )
             .wrap_err_with(|| format!("download {url}"))?;
             verify_sha256(&archive, sha256)?;
-            sh(
-                &[
-                    "tar",
-                    "-xf",
-                    &archive.to_string_lossy(),
-                    "-C",
-                    &prefix.to_string_lossy(),
-                ],
-                None,
-            )
-            .wrap_err("unpack prebuilt archive")?;
+            // Default: the mirror shape (a prefix-rooted tar). An UPSTREAM
+            // asset often is not that — ninja publishes a zip holding a bare
+            // binary — so a dist may carry its own unpack step. Same free-form
+            // shell as a source recipe's `install`, for the same reason.
+            match install {
+                None => {
+                    sh(
+                        &[
+                            "tar",
+                            "-xf",
+                            &archive.to_string_lossy(),
+                            "-C",
+                            &prefix.to_string_lossy(),
+                        ],
+                        None,
+                    )
+                    .wrap_err("unpack prebuilt archive")?;
+                }
+                Some(cmd) => {
+                    let cmd = cmd
+                        .replace("{archive}", &archive.to_string_lossy())
+                        .replace("{prefix}", &prefix.to_string_lossy());
+                    sh(&["sh", "-c", &cmd], None)
+                        .wrap_err("unpack prebuilt archive (dist install step)")?;
+                }
+            }
             let _ = std::fs::remove_file(&archive);
             let p = Provenance {
                 kind: ProvenanceKind::Prebuilt,
@@ -310,8 +362,7 @@ pub fn execute(
             Ok(p)
         }
         InstallAction::Source {
-            git,
-            git_ref,
+            fetch,
             configure,
             install,
             respect_toolchain,
@@ -333,30 +384,71 @@ pub fn execute(
             let src = prefix.with_extension("src");
             let _ = std::fs::remove_dir_all(&src);
             let src_str = src.to_string_lossy();
-            // `git_ref` may be a raw SHA (index tools with no upstream tag pin the
-            // commit), and `git clone --depth 1 --branch <sha>` is rejected ("Remote
-            // branch <sha> not found"). Mirror the `[source.*]` shallow path: init +
-            // fetch-by-ref at depth 1 (works for sha/tag/branch via the server's
-            // reachable-SHA support) + detached checkout of the fetched commit.
-            sh(&["git", "init", "-q", &src_str], None)
-                .wrap_err_with(|| format!("git init {src_str} ({tool})"))?;
-            sh(
-                &["git", "-C", &src_str, "remote", "add", "origin", git],
-                None,
-            )
-            .wrap_err_with(|| format!("git remote add ({tool})"))?;
-            sh(
-                &[
-                    "git", "-C", &src_str, "fetch", "-q", "--depth", "1", "origin", git_ref,
-                ],
-                None,
-            )
-            .wrap_err_with(|| format!("git fetch --depth 1 {git_ref} ({tool})"))?;
-            sh(
-                &["git", "-C", &src_str, "checkout", "-q", "FETCH_HEAD"],
-                None,
-            )
-            .wrap_err_with(|| format!("git checkout FETCH_HEAD ({tool})"))?;
+            match fetch {
+                SourceFetch::Git { git, git_ref } => {
+                    // `git_ref` may be a raw SHA (index tools with no upstream tag pin
+                    // the commit), and `git clone --depth 1 --branch <sha>` is rejected
+                    // ("Remote branch <sha> not found"). Mirror the `[source.*]` shallow
+                    // path: init + fetch-by-ref at depth 1 (works for sha/tag/branch via
+                    // the server's reachable-SHA support) + detached checkout.
+                    sh(&["git", "init", "-q", &src_str], None)
+                        .wrap_err_with(|| format!("git init {src_str} ({tool})"))?;
+                    sh(
+                        &["git", "-C", &src_str, "remote", "add", "origin", git],
+                        None,
+                    )
+                    .wrap_err_with(|| format!("git remote add ({tool})"))?;
+                    sh(
+                        &[
+                            "git", "-C", &src_str, "fetch", "-q", "--depth", "1", "origin", git_ref,
+                        ],
+                        None,
+                    )
+                    .wrap_err_with(|| format!("git fetch --depth 1 {git_ref} ({tool})"))?;
+                    sh(
+                        &["git", "-C", &src_str, "checkout", "-q", "FETCH_HEAD"],
+                        None,
+                    )
+                    .wrap_err_with(|| format!("git checkout FETCH_HEAD ({tool})"))?;
+                }
+                SourceFetch::Tarball { url, sha256 } => {
+                    // `--strip-components=1` so `configure`/`install` see the
+                    // project root exactly as the git path leaves it: every step
+                    // after the fetch is then mode-independent, which is the
+                    // point of putting both behind one enum.
+                    std::fs::create_dir_all(&src)
+                        .wrap_err_with(|| format!("create {src_str} ({tool})"))?;
+                    let archive = prefix.with_extension("src.download");
+                    sh(
+                        &[
+                            "curl",
+                            "-L",
+                            "--fail",
+                            "--silent",
+                            "--show-error",
+                            "-o",
+                            &archive.to_string_lossy(),
+                            url,
+                        ],
+                        None,
+                    )
+                    .wrap_err_with(|| format!("download {url} ({tool})"))?;
+                    verify_sha256(&archive, sha256)?;
+                    sh(
+                        &[
+                            "tar",
+                            "-xf",
+                            &archive.to_string_lossy(),
+                            "-C",
+                            &src_str,
+                            "--strip-components=1",
+                        ],
+                        None,
+                    )
+                    .wrap_err_with(|| format!("unpack source tarball ({tool})"))?;
+                    let _ = std::fs::remove_file(&archive);
+                }
+            }
             let prefix_abs = prefix.to_string_lossy().to_string();
             if let Some(cfg) = configure {
                 sh_with_toolchain(

--- a/scripts/build-all-jobserver.sh
+++ b/scripts/build-all-jobserver.sh
@@ -6,11 +6,11 @@ source scripts/build/cargo.sh
 make_bin="$(nros sdk-path make)/bin/make"
 ninja_bin="$(nros sdk-path ninja)/bin/ninja"
 if [ ! -x "$make_bin" ] || ! "$make_bin" --version | head -1 | grep -q "4.4"; then
-    echo "jobserver build needs make >=4.4 — run: just workspace install-make" >&2
+    echo "jobserver build needs make >=4.4 — run: nros setup --tool make" >&2
     exit 1
 fi
 if [ ! -x "$ninja_bin" ]; then
-    echo "jobserver build needs ninja >=1.13 — run: just workspace install-ninja" >&2
+    echo "jobserver build needs ninja >=1.13 — run: nros setup --tool ninja" >&2
     exit 1
 fi
 

--- a/scripts/build-all-jobserver.sh
+++ b/scripts/build-all-jobserver.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 source scripts/build/cargo.sh
 
-make_bin="third-party/make/make"
-ninja_bin="third-party/ninja/ninja"
+make_bin="$(nros sdk-path make)/bin/make"
+ninja_bin="$(nros sdk-path ninja)/bin/ninja"
 if [ ! -x "$make_bin" ] || ! "$make_bin" --version | head -1 | grep -q "4.4"; then
     echo "jobserver build needs make >=4.4 — run: just workspace install-make" >&2
     exit 1
@@ -15,7 +15,7 @@ if [ ! -x "$ninja_bin" ]; then
 fi
 
 n="${NROS_BUILD_JOBS:-$(nproc 2>/dev/null || echo 8)}"
-export PATH="$(pwd)/third-party/make:$(pwd)/third-party/ninja:$PATH"
+export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
 echo "build-all (jobserver): $make_bin -j$n --jobserver-style=fifo -f build-all.mk"
 echo "  make=$(make --version | head -1), ninja=$(ninja --version)"
 echo "  cargo-profile=$(nros_cargo_profile_name), cargo-frontends=${NROS_CARGO_FRONTENDS:-auto}"

--- a/scripts/build/fixture-make-driver.sh
+++ b/scripts/build/fixture-make-driver.sh
@@ -235,12 +235,12 @@ rm -f "$leaf_file"
 make_bin="make"
 make_args=()
 jobs="${NROS_BUILD_JOBS:-$(nproc 2>/dev/null || echo 8)}"
-if [ -x "$repo_root/third-party/make/make" ] && \
-   "$repo_root/third-party/make/make" --version | head -1 | grep -q "4.4" && \
-   [ -x "$repo_root/third-party/ninja/ninja" ]; then
-    make_bin="$repo_root/third-party/make/make"
+if [ -x "$(nros sdk-path make)/bin/make" ] && \
+   "$(nros sdk-path make)/bin/make" --version | head -1 | grep -q "4.4" && \
+   [ -x "$(nros sdk-path ninja)/bin/ninja" ]; then
+    make_bin="$(nros sdk-path make)/bin/make"
     make_args=(-j"$jobs" --jobserver-style=fifo)
-    export PATH="$repo_root/third-party/make:$repo_root/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     echo "fixture-make-driver: using pinned fifo make"
 else
     make_args=(-j"$jobs")

--- a/scripts/build/fixtures-build.sh
+++ b/scripts/build/fixtures-build.sh
@@ -195,9 +195,9 @@ run_with_make() {
 
     jobs="$(nros_cargo_frontend_jobs)"
     make_bin="make"
-    if [ -x "$PWD/third-party/make/make" ] && \
-       "$PWD/third-party/make/make" --version | head -1 | grep -q "4.4"; then
-        make_bin="$PWD/third-party/make/make"
+    if [ -x "$(nros sdk-path make)/bin/make" ] && \
+       "$(nros sdk-path make)/bin/make" --version | head -1 | grep -q "4.4"; then
+        make_bin="$(nros sdk-path make)/bin/make"
     fi
 
     "$make_bin" -j"$jobs" -f "$makefile"

--- a/scripts/build/jobserver-pool.sh
+++ b/scripts/build/jobserver-pool.sh
@@ -40,12 +40,25 @@
 #     a second pool would double-count them.
 #   * pinned make 4.4 is required for `--jobserver-style=fifo`; the system make
 #     may be 4.3, whose pipe-based jobserver child tools cannot join.
+# The pinned make's absolute path, or empty. CONSTRUCTED via `nros sdk-path`
+# (issue 0625) rather than searched, and deliberately NOT taken from PATH: a
+# system make 4.3 first on PATH would answer, and its pipe-FD jobserver is the
+# thing that does not work. `$repo_root` is unused now that the binary lives in
+# the store rather than `third-party/make/`.
+nros_pinned_make() {
+    command -v nros >/dev/null 2>&1 || return 1
+    local dir
+    dir="$(nros sdk-path make 2>/dev/null)" || return 1
+    [ -n "$dir" ] && [ -x "$dir/bin/make" ] || return 1
+    printf '%s\n' "$dir/bin/make"
+}
+
 nros_pool_available() {
-    local repo_root="$1" units="$2"
+    local units="$2"
     [ "${NROS_JOBSERVER:-}" = "1" ] && return 1
     [ "${units:-0}" -gt 1 ] || return 1
-    local pinned_make="$repo_root/third-party/make/make"
-    [ -x "$pinned_make" ] || return 1
+    local pinned_make
+    pinned_make="$(nros_pinned_make)" || return 1
     "$pinned_make" --version | head -1 | grep -q "4.4" || return 1
     return 0
 }
@@ -105,7 +118,7 @@ nros_pool_run() {
     source "$repo_root/scripts/build/subtree-guard.sh"
     nros_guard_exec "jobserver-pool" \
         env -u MAKEFLAGS -u CARGO_MAKEFLAGS \
-        "$repo_root/third-party/make/make" -j"$pool_jobs" --jobserver-style=fifo \
+        "$(nros_pinned_make)" -j"$pool_jobs" --jobserver-style=fifo \
         -f "$makefile" || rc=$?
     rm -f "$makefile"
     return $rc

--- a/scripts/build/workspace-fixtures-build.sh
+++ b/scripts/build/workspace-fixtures-build.sh
@@ -566,7 +566,7 @@ for dir in "${group_dirs[@]:-}"; do
     ( cd "$repo_root/$dir" && "$nros_cli" sync --no-provider-index >/dev/null )
 done
 
-pinned_make="$repo_root/third-party/make/make"
+pinned_make="$(nros sdk-path make)/bin/make"
 use_pool=0
 if [ "${NROS_JOBSERVER:-}" != "1" ] && [ "${#group_dirs[@]}" -gt 1 ] && \
    [ -x "$pinned_make" ] && "$pinned_make" --version | head -1 | grep -q "4.4"; then

--- a/scripts/build/zephyr-fixture-leaves.sh
+++ b/scripts/build/zephyr-fixture-leaves.sh
@@ -21,7 +21,7 @@ Options:
   --codegen-tool PATH       host codegen tool used in signatures
                             (default: resolved nros CLI, or build/host-codegen/nros-codegen
                             when nros is unavailable)
-  --make-bin PATH           make path used in signatures (default: third-party/make/make
+  --make-bin PATH           make path used in signatures (default: $(nros sdk-path make)/bin/make
                             when executable, else command -v make)
   --toolchain-cache-dir DIR Zephyr toolchain capability cache dir
                             (default: build/zephyr-cache/ToolchainCapabilityDatabase)
@@ -178,7 +178,7 @@ if [ -z "$toolchain_cache_dir" ]; then
     toolchain_cache_dir="$nros_root/build/zephyr-cache/ToolchainCapabilityDatabase"
 fi
 if [ -z "$make_bin" ]; then
-    make_bin="$nros_root/third-party/make/make"
+    make_bin="$(nros sdk-path make)/bin/make"
     if [ ! -x "$make_bin" ]; then
         make_bin="$(command -v make)"
     fi

--- a/scripts/build/zephyr-fixture-make-driver.sh
+++ b/scripts/build/zephyr-fixture-make-driver.sh
@@ -116,9 +116,9 @@ make_bin="make"
 make_args=()
 fallback_ninja_jobs="${NROS_ZEPHYR_NINJA_JOBS:-${NROS_BUILD_JOBS:-$(nproc 2>/dev/null || echo 8)}}"
 jobserver_mode=0
-if [ -x "$repo_root/third-party/make/make" ] && \
-   "$repo_root/third-party/make/make" --version | head -1 | grep -q "4.4"; then
-    make_bin="$repo_root/third-party/make/make"
+if [ -x "$(nros sdk-path make)/bin/make" ] && \
+   "$(nros sdk-path make)/bin/make" --version | head -1 | grep -q "4.4"; then
+    make_bin="$(nros sdk-path make)/bin/make"
     # In fifo-jobserver mode the -j value IS the shared token pool: every
     # leaf's ninja joins it, so it bounds TOTAL concurrency across the
     # family, and leaves build into disjoint build-<name> dirs (parallel-safe
@@ -136,7 +136,7 @@ if [ -x "$repo_root/third-party/make/make" ] && \
     outer_jobs="${NROS_ZEPHYR_JOBSERVER_TOKENS:-${NROS_ZEPHYR_BUILD_JOBS:-${NROS_BUILD_JOBS:-$(nproc 2>/dev/null || echo 8)}}}"
     make_args=(-j"$outer_jobs" --jobserver-style=fifo)
     jobserver_mode=1
-    export PATH="$repo_root/third-party/make:$repo_root/third-party/ninja:$PATH"
+    export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
     echo "zephyr-fixture-make-driver: using pinned fifo make"
 else
     # No shared token pool here: each leaf's ninja runs -j$fallback_ninja_jobs

--- a/scripts/check-tier-preconditions.sh
+++ b/scripts/check-tier-preconditions.sh
@@ -252,24 +252,38 @@ fi
 #    system make on Ubuntu 22.04 is 4.3, whose pipe-FD jobserver a grandchild
 #    (cargo, or cmake's sub-make) cannot join. Without it every jobserver
 #    fan-out in the tree — example checks, fixture builds, the compile-check
-#    sweep — silently walks SERIALLY. `just install-make` builds it to
-#    `third-party/make/` and `.envrc` puts it first on PATH.
+#    sweep — silently walks SERIALLY.
 #
-#    Deliberately NOT a `[system.make]` entry in nros-sdk-index.toml: the apt
-#    package is 4.3 on the LTS we target, so provisioning it would satisfy a
-#    `check = { cmd = "make" }` probe while still not giving a usable jobserver.
-#    The index has no version predicate (cmd / sharedlib / pkg_config only), so
-#    an entry there would assert something false.
+#    It is now an ORDINARY store tool: `nros setup --tool make` builds 4.4.1
+#    from the release tarball, and `scripts/sdk-path-tools.txt` puts it on PATH.
+#    The path is resolved with `nros sdk-path` — CONSTRUCTED from the index pin,
+#    never searched (issue 0625) — so this cannot drift from what provisioning
+#    installed.
+#
+#    This block used to read `third-party/make/make`, filled by a bespoke
+#    `just workspace install-make`, and its comment justified that with "the
+#    index has no version predicate (cmd / sharedlib / pkg_config only), so an
+#    entry there would assert something false". That was true when written and
+#    is not any more: `check = { cmd = …, version = { min = … } }` exists (see
+#    `[prereq.openocd]`), which is exactly the predicate that was missing. So
+#    `[prereq.make]` now asserts `min = "4.4"` truthfully, and the apt-installs-4.3
+#    objection is answered by the version floor rather than by staying out of
+#    the index.
 #
 #    WARN, not fail: a serial walk is correct, only slow.
-if [ ! -x "third-party/make/make" ] ||
-    ! third-party/make/make --version 2>/dev/null | head -1 | grep -q "4\.4"; then
+_pre_make=""
+if command -v nros >/dev/null 2>&1; then
+    _pre_make="$(nros sdk-path make 2>/dev/null)/bin/make"
+fi
+if [ -z "$_pre_make" ] || [ ! -x "$_pre_make" ] ||
+    ! "$_pre_make" --version 2>/dev/null | head -1 | grep -q "4\.4"; then
     echo "check-tier-preconditions: WARNING — pinned GNU make 4.4 absent;" >&2
     echo "  every jobserver fan-out degrades to a SERIAL walk (the system make" >&2
     echo "  is 4.3 on Ubuntu LTS, and its pipe-FD jobserver cannot be joined by" >&2
     echo "  cargo or by cmake's sub-make)." >&2
-    echo "  Remedy: just install-make" >&2
+    echo "  Remedy: nros setup --tool make" >&2
 fi
+unset _pre_make
 
 # 9. A lane that silently DEGRADES is worse than one that fails: without GNU
 #    parallel the example check walks ~99 leaves serially and reads as a hung

--- a/scripts/dev/ros2-box-sync.sh
+++ b/scripts/dev/ros2-box-sync.sh
@@ -136,10 +136,21 @@ exclusions=(
     #   make: error while loading shared libraries: libguile-3.0.so.1
     #
     # and it dies at the TOP of the fixture build, where it reads as a broken
-    # recipe rather than as a wrong-libc binary. Each tree builds its own; the
-    # box's absence of one is caught by `check-tier-preconditions.sh`, which
-    # warns that jobserver fan-outs degrade to a serial walk and names
-    # `just install-make`.
+    # recipe rather than as a wrong-libc binary.
+    #
+    # The two excludes below are now VESTIGIAL and kept only so a leftover
+    # directory from before the move is not mirrored: make and ninja are SDK
+    # store tools (`~/.nros/sdk/...`), which is outside this tree and so was
+    # never synced by this script anyway.
+    #
+    # Note what that changes, because it is not nothing: a distrobox shares
+    # $HOME, so host and box now see ONE make binary rather than one per tree.
+    # That is safe for exactly the reason the guile bug was fixed — the index's
+    # source recipe configures `--without-guile`, so the binary carries no
+    # distro-specific shared-library dependency and genuinely serves both
+    # sides. If a future recipe change reintroduces such a dependency, this
+    # becomes a two-distro breakage again, and `check-tier-preconditions.sh`
+    # (which names `nros setup --tool make`) is what reports it.
     --exclude '/third-party/make/'
     --exclude '/third-party/ninja/'
     --exclude '/tmp/'

--- a/scripts/sdk-path-tools.txt
+++ b/scripts/sdk-path-tools.txt
@@ -49,3 +49,17 @@ genromfs
 sccache
 espflash
 idlc
+# make + ninja — the two halves of the Phase 176 unified jobserver, and both
+# invoked by BARE NAME by things we do not control: cmake generators and RTOS
+# kernel makefiles call `make`/`gmake`, every cmake configure emits for `ninja`.
+#
+# They moved here from two hand-written PATH blocks in activate.sh pointing at
+# `third-party/{make,ninja}/`, which `just workspace install-{make,ninja}`
+# filled. Those recipes are gone: provisioning is `nros setup --tool {make,ninja}`
+# like every other tool, so the version pin lives in the index instead of a
+# `just` variable that could drift from it.
+#
+# Listing `make` is enough to put its bin dir on PATH — the `gmake` alias sits
+# beside it in the same directory, and this list gates the DIRECTORY.
+make
+ninja

--- a/scripts/zephyr/check-copy-out.sh
+++ b/scripts/zephyr/check-copy-out.sh
@@ -122,11 +122,11 @@ echo "[copy-out] workspace : $workspace (4.4 line)"
 conf="prj.conf;prj-$RMW.conf;$line_overlay"
 bd="$tmp_root/build"
 
-make_bin="$NROS_ROOT/third-party/make/make"
+make_bin="$(nros sdk-path make)/bin/make"
 [ -x "$make_bin" ] || make_bin="$(command -v make)"
 
 export ZEPHYR_TOOLCHAIN_VARIANT=host
-export PATH="$NROS_ROOT/third-party/make:$NROS_ROOT/third-party/ninja:$PATH"
+export PATH="$(nros sdk-path make)/bin:$(nros sdk-path ninja)/bin:$PATH"
 
 echo "[copy-out] building (west via venv python) ..."
 set +e

--- a/scripts/zephyr/setup.sh
+++ b/scripts/zephyr/setup.sh
@@ -225,7 +225,7 @@ if [ $MISSING -eq 1 ]; then
     else
         echo "  (build the CLI first — just setup-cli — then run: nros setup --system)"
     fi
-    echo "  ninja (sudo-less): just workspace install-ninja"
+    echo "  ninja (sudo-less): nros setup --tool ninja"
     echo "  rust:  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
     exit 1
 fi


### PR DESCRIPTION
Two tools were provisioned by hand-written `just workspace install-*` recipes into `third-party/{make,ninja}/`, each carrying its own version variable — `MAKE_VERSION` / `NINJA_VERSION` — sitting beside `nros-sdk-index.toml` and free to drift from it. They are ordinary store tools now:

```
nros setup --tool make     4.4.1,  source tarball
nros setup --tool ninja    1.13.2, upstream prebuilt zip
```

**Policy: prebuilt when upstream publishes one, source only as the fallback.** ninja carries all three upstream assets (linux-x86_64 / linux-arm64 / macos-arm64) *plus* a source recipe, so an arch upstream does not ship is not stranded. make has no prebuilt arm at all — ftp.gnu.org carries tarballs only.

## Two schema additions, because neither tool fits the existing shapes

**`DistArtifact.install`** — optional shell (`{archive}`, `{prefix}`). The default `tar -xf` into the prefix is right for the mirror's prefix-rooted `.tar.zst` and cannot take an *upstream* asset: `ninja-linux.zip` is not a tar **and** holds a bare binary with no `bin/`. Taking assets as published is what the prebuilt-first policy costs.

**`ToolSource.url` + `sha256`**, mutually exclusive with `git` + `ref`. git is not always a way to *get* a buildable tree: GNU make's git tree at 4.4.1 ships no `configure`, only a `bootstrap` wanting autotools and gnulib. The tarball unpacks `--strip-components=1`, so everything after the fetch is mode-independent.

`validate()` rejects neither/both, `git` without `ref`, `url` without `sha256` — both fields being `Option` made "neither" and "both" newly expressible, and both fail late and confusingly. Covered by `tool_source_fetches_from_exactly_one_place`.

The make recipe carries what the retired shell knew: `--without-guile` (an autodetected guile linked `libguile-3.0.so.1`, unsatisfiable in the ROS distrobox — one tree, two distros), `./build.sh`, the `ldd | grep guile` refusal, and the `gmake` alias cmake generators and RTOS makefiles need.

## Migration — the class, not the reported site

Every consumer moved off `third-party/`: both activate files (their hand-written PATH blocks are gone; `scripts/sdk-path-tools.txt` covers both shells, which is the drift issue 0663 created that file to end), `jobserver-pool`, `check-tier-preconditions`, four fixture drivers, `build-all-jobserver`, `check-copy-out`, three zephyr lanes, the book and two docs — 20 lines across 7 scripts plus the just files.

Paths resolve via `nros sdk-path <tool>` — **constructed** from the pin, never searched (issue 0625) — and deliberately not from PATH, since a system make 4.3 first on PATH would answer and its pipe-FD jobserver is the thing that does not work.

Also corrects a comment in `check-tier-preconditions.sh` that justified keeping make *out* of the index: *"the index has no version predicate (cmd / sharedlib / pkg_config only), so an entry there would assert something false."* True when written, false now — `version = { min = … }` exists (`[prereq.openocd]`), so `[prereq.make]` asserts min 4.4 truthfully.

## Verified

- both `nros setup --tool` paths install end to end (ninja via dist + unzip, make via tarball + `build.sh`, `gmake` alias present)
- a fresh `activate.sh` resolves `make` / `gmake` / `ninja` from the store
- the version floors report `[MISSING]` against a faked make 4.3 / ninja 1.10.1 and `[OK]` against the real ones
- `verify-index --structure-only` coherent; `check-just-recipe-refs`, `check-activate-shells`, `check-cli-fmt` green; every touched script passes `bash -n`

## Note for reviewers

A distrobox shares `$HOME`, so host and box now see **one** make binary rather than one per tree. That is safe only because `--without-guile` leaves it free of distro-specific shared libs — written into `ros2-box-sync.sh` rather than left implicit, so a future recipe change that reintroduces such a dependency has something to trip over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe