### PR TITLE
docs: the config docs catch up with the tree

### DIFF
--- a/book/src/getting-started/anatomy.md
+++ b/book/src/getting-started/anatomy.md
@@ -47,9 +47,10 @@ pkg = "talker_pkg"
 class = "talker_pkg::Talker"
 name = "talker"
 
-[deploy.native]                      # one block per build target
-kind = "self"
+[image.native]                       # one block per BUILDABLE image
 board = "native"
+
+[host.native]                        # WHERE the nodes run; no `nodes` = all
 ```
 
 The launch file is the **ROS 2 launch XML schema, verbatim** —
@@ -64,7 +65,7 @@ even carries a per-topic QoS override to show the plumbing:
 </node>
 ```
 
-When you later target hardware, you add a `[deploy.<name>]` block per
+When you later target hardware, you add an `[image.<id>]` block per
 board — the code and topology stay put. That is the growth rule:
 **configuration is a new block, never a restructure.**
 

--- a/book/src/getting-started/how-integration-works.md
+++ b/book/src/getting-started/how-integration-works.md
@@ -78,16 +78,17 @@ reusable and shareable. Discovery: the CLI's board catalog scans
 `packages/boards/`), so an out-of-tree board dir is seen without
 copying it into the checkout.
 
-**2. A `[deploy.<name>]` block — facts about this checkout, this
+**2. An `[image.<id>]` block, and a `[board_config.<board>]` beside it — facts about this checkout, this
 machine, this application.** It lives in your bringup package's
 `system.toml`, next to your nodes and launch files:
 
 ```toml
-[deploy.my-board]
-kind   = "embedded"
-board  = "my-board"        # joins to the board package by name
-target = "thumbv7em-none-eabihf"
-# site facts: where YOUR SDK lives, which config headers are yours, …
+[image.my-board]
+board = "my-board"         # joins to the board package by name
+                           # the rustc triple comes from that board's descriptor
+
+[board_config."my-board"]  # site facts: where YOUR SDK lives, which config
+sdk.vendor = "{env:VENDOR_SDK_DIR}"     # headers are yours — keyed by BOARD
 ```
 
 SDK paths, config-header locations, serial ports: anything another

--- a/book/src/getting-started/workspace-bringup.md
+++ b/book/src/getting-started/workspace-bringup.md
@@ -61,7 +61,7 @@ into the Entry pkg.
 ```
 src/demo_bringup/
 ├── package.xml          # ROS 2 manifest; <exec_depend> per node pkg
-├── system.toml          # [system] + [[component]] + [deploy.<target>]
+├── system.toml          # [system] + [[component]] + [image.<id>] + [host.<name>]
 ├── launch/
 │   └── system.launch.xml   # ROS 2 launch schema, verbatim
 └── config/                 # optional — params.yaml, per-target overrides
@@ -94,9 +94,10 @@ pkg = "listener_pkg"
 class = "listener_pkg::Listener"
 name = "listener"
 
-[deploy.native]
-kind = "self"
-target = "x86_64-unknown-linux-gnu"
+[image.native]
+board = "native"
+
+[host.native]
 ```
 
 Key fields:
@@ -109,9 +110,10 @@ Key fields:
 | `[[component]] pkg` | The ROS package name (matches `<name>` in `package.xml`) |
 | `[[component]] class` | Fully-qualified Rust type (`crate::TypeName`) |
 | `[[component]] name` | Node name at runtime |
-| `[deploy.<target>]` | Deploy target block; read by `nros check` and Entry codegen |
-| `[deploy.<t>] kind` | `"self"` = host native binary; `"flash"` = embedded target |
-| `[deploy.<t>] target` | Rust target triple |
+| `[image.<id>]` | A buildable image; read by `nros build`, `nros check` and Entry codegen |
+| `[image.<id>] board` | The board this image is built for; its descriptor supplies the rustc triple |
+| `[host.<name>]` | A machine nodes run on. No `nodes` means every node |
+| `[board_config.<board>]` | Site facts for that board (SDK roots, netstack) |
 
 For multi-domain setups or cross-domain bridges add `[[domain]]` and
 `[[bridge]]` sections — see `docs/design/0024-multi-node-workspace-layout.md` §11

--- a/book/src/getting-started/workspace-entry-pkg.md
+++ b/book/src/getting-started/workspace-entry-pkg.md
@@ -81,7 +81,7 @@ domain_id = 0
 `deploy` is the key that `nros check` and the Entry macro use to
 find the board crate and verify the topology. Keep it short and descriptive —
 it becomes the identifier in `nros plan` output and in `system.toml`'s
-`[deploy.<name>]` table when you later add a Bringup pkg.
+`[image.<id>]` table when you later add a Bringup pkg.
 
 ## `nros::main!()` — the forms
 

--- a/book/src/internals/rmw-backends.md
+++ b/book/src/internals/rmw-backends.md
@@ -175,7 +175,7 @@ backend binaries with one auto-registering backend Just Work
 without user code mentioning the backend's name.
 
 The user-facing knob is a **declared, language-agnostic, per-deploy
-value** (`system.toml` `[system].rmw` / `[deploy.<t>].rmw`, or a
+value** (`system.toml` `[system].rmw` / `[image.<id>].rmw`, or a
 CLI/build flag) that the toolchain **lowers** to each language's
 native link mechanism. The Cargo feature / shim dep and the CMake
 cache var below are those *lowering targets* — what the build uses,

--- a/book/src/porting/custom-platform.md
+++ b/book/src/porting/custom-platform.md
@@ -283,7 +283,7 @@ nros = { features = ["rmw-zenoh", "platform-cffi"] }
 
 > The `rmw-zenoh` feature is the *lowering* of the declared RMW: the
 > backend is declared once in `system.toml` (`[system].rmw` /
-> `[deploy.<t>].rmw`) and the toolchain emits the cargo feature. The
+> `[image.<id>].rmw`) and the toolchain emits the cargo feature. The
 > feature is the build mechanism, not the user-facing knob — see
 > [RFC-0031](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0031-rmw-selection-and-lowering.md).
 

--- a/book/src/reference/build-commands.md
+++ b/book/src/reference/build-commands.md
@@ -120,7 +120,7 @@ nros = { features = ["rmw-zenoh", "platform-bare-metal", "link-tcp", "link-udp-u
 
 > The `rmw-zenoh` feature here is the *lowering* of the declared RMW —
 > you declare the backend once in `system.toml` (`[system].rmw` /
-> `[deploy.<t>].rmw`) and the toolchain sets the cargo feature; the
+> `[image.<id>].rmw`) and the toolchain sets the cargo feature; the
 > feature is what the build uses, not the user-facing selector. See
 > [RFC-0031](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0031-rmw-selection-and-lowering.md).
 

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -177,7 +177,7 @@ Validate an `nros-plan.json` (default `build/nros/nros-plan.json`):
 static checker — catches unconnected required topics, conflicting QoS,
 missing parameters, and SchedContext binding errors before the platform
 build runs. A `.toml` argument is instead validated as a **root `nros.toml`**
-(the workspace deployment SSOT) — `[system]`/`[deploy.<name>]` shape,
+(the workspace deployment SSOT) — `[system]`/`[image.<id>]`/`[host.<name>]` shape,
 default-deploy + system references, bridge endpoints, etc.
 
 ### `nros explain [<plan>]`

--- a/book/src/user-guide/component-and-entry-pkg.md
+++ b/book/src/user-guide/component-and-entry-pkg.md
@@ -48,7 +48,7 @@ per-target deploy config, and contains no compiled code:
 ```
 src/demo_bringup/
 ├── package.xml          # <name>demo_bringup</name>, <exec_depend> per node
-├── system.toml          # [system] + [[component]] + [deploy.<target>] (+ [[domain]]/[[bridge]])
+├── system.toml          # [system] + [[component]] + [image.<id>] + [host.<name>] (+ [[domain]]/[[bridge]])
 ├── launch/
 │   └── system.launch.xml   # ROS 2 launch schema, verbatim
 └── config/                 # optional — params.yaml, etc.

--- a/book/src/user-guide/configuration.md
+++ b/book/src/user-guide/configuration.md
@@ -42,7 +42,7 @@ Mirrors [RFC-0004 §3](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/des
 
 Where a concern has both a native-idiom projection and a `system.toml`, the
 resolution is a **fixed precedence ladder**, not a merge: explicit CLI/build
-flag (`--rmw` / `-DNANO_ROS_*`) > `system.toml` (`[deploy.<t>]` > `[system]`)
+flag (`--rmw` / `-DNANO_ROS_*`) > `system.toml` (`[image.<id>]` > `[system]`)
 > the per-package projection (`[package.metadata.nros.*]` / CMake) > built-in
 default. `nros config show` prints the resolved effective config with
 per-value provenance; `nros check` flags values still sourced from legacy

--- a/book/src/user-guide/deployment.md
+++ b/book/src/user-guide/deployment.md
@@ -68,12 +68,12 @@ contract is a documented three-step sequence (per
 [RFC-0003 §4](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0003-rtos-integration-pattern.md)):
 
 1. **Bake** — `nros codegen-system --bringup <pkg>` reads
-   `system.toml` + `[deploy.<board>]` + `launch/*.xml` and emits the
+   `system.toml` + `[image.<id>]` + `launch/*.xml` and emits the
    baked tree under `build/<board>/`.
 2. **Build** — the vendor tool builds it: `cargo build` / `cmake --build`
    / `west build` / `idf.py build` (**contributors:** the in-tree
    `just <plat> build*` recipes wrap these with the right `-D` args
-   derived from `[deploy.<board>]`).
+   derived from `[image.<id>]`).
 3. **Flash + monitor** — the vendor tool again: `probe-rs run` /
    `west flash` / `idf.py flash monitor`, or the platform's QEMU runner.
 

--- a/book/src/user-guide/rmw-backends.md
+++ b/book/src/user-guide/rmw-backends.md
@@ -169,7 +169,7 @@ Full walkthrough: [Cross-backend Bridges](./cross-backend-bridges.md).
 
 RMW selection is a **declared, language-agnostic, per-deploy value** —
 you set it once in `system.toml` (`[system].rmw`, optionally overridden
-per target by `[deploy.<t>].rmw`) or via a CLI/build flag, and the
+per image by `[image.<id>].rmw`) or via a CLI/build flag, and the
 toolchain **lowers** that declaration to each language's native build
 mechanism: a Rust cargo `rmw-<x>` feature, or a CMake `-DNANO_ROS_RMW`
 cache var. The cargo feature and the CMake var below are the *lowering
@@ -182,26 +182,29 @@ for the full selection-and-lowering model and precedence rules.
 
 ### Cargo.toml (Rust)
 
-Lowered form of the declared RMW: add `nros` with the platform feature
-plus exactly one `nros-rmw-<x>` shim dep (cyclonedds is the exception —
-see below):
+Lowered form of the declared RMW. The selection point is the **board crate**
+(RFC-0031's phase-248 C5b amendment): an app declares one `rmw-<x>` feature
+that activates the backend dep *and* forwards to the board crate's matching
+feature. Codegen no longer emits `nros/rmw-<x>` or `nros/platform-<y>` — the
+board brings both.
 
 ```toml
-# Zenoh backend
-[dependencies]
-nros = { path = "<...>/packages/api/nros",
-         default-features = false,
-         features = ["std", "rmw-cffi", "platform-posix"] }
-nros-rmw-zenoh = { path = "<...>/packages/rmw/zenoh/nros-rmw-zenoh",
-                   features = ["std", "platform-posix", "ros-humble"] }
+[features]
+default = ["rmw-zenoh"]
+# Each `rmw-*` activates the app-owned optional backend dep and forwards to
+# the board crate, which is what actually selects the backend.
+rmw-zenoh = ["dep:nros-rmw-zenoh", "nros-board-linux/rmw-zenoh"]
+rmw-cyclonedds = [
+    "nros/rmw-cyclonedds",              # the marker feature; see below
+    "dep:nros-rmw-cyclonedds-sys",
+    "nros-board-linux/rmw-cyclonedds",
+]
+```
 
-# XRCE-DDS backend
-[dependencies]
-nros = { path = "<...>/packages/api/nros",
-         default-features = false,
-         features = ["std", "rmw-cffi", "platform-posix"] }
-nros-rmw-xrce-cffi = { path = "<...>/packages/rmw/xrce/nros-rmw-xrce-cffi",
-                       features = ["std"] }
+In a WORKSPACE you write none of this: `[image.<id>].rmw` in the bringup's
+`system.toml` is the declaration, and the Entry pkg's generated manifest carries
+the lowered form. The block above is the standalone copy-out shape, where there
+is no bringup to declare it in.
 
 # Cyclone DDS backend — Rust runtime sees the generic rmw-cffi C-ABI
 # vtable; actual Cyclone wiring lives C++-side under

--- a/docs/design/0004-configuration-and-transports.md
+++ b/docs/design/0004-configuration-and-transports.md
@@ -134,7 +134,7 @@ sign, and "what is the effective config?" needs N files reconciled in your head.
 
 **Resolution, where a concern has both a native-idiom projection and a `system.toml`,** is a
 **fixed, short precedence ladder** (not an open merge): explicit CLI/build flag
-(`--rmw` / `-DNANO_ROS_*`) > `system.toml` (`[deploy.<t>]` > `[system]`) > the per-package
+(`--rmw` / `-DNANO_ROS_*`) > `system.toml` (`[image.<id>]` > `[system]`) > the per-package
 native projection (`[package.metadata.nros.*]` / CMake) > built-in default. One ladder, each
 rung a known file — auditable, unlike an arbitrary-file overlay.
 
@@ -173,10 +173,11 @@ pkg   = "talker_pkg"
 class = "talker_pkg::Talker"
 name  = "talker"
 
-[deploy.native]
-kind   = "self"
-target = "x86_64-unknown-linux-gnu"
-# rmw  = "cyclonedds"        # optional per-deploy override of [system].rmw
+[image.native]
+board = "native"
+# rmw = "cyclonedds"         # optional per-image override of [system].rmw
+
+[host.native]                # WHERE the nodes run; no `nodes` means all of them
 
 # Declared capability axes (RFC-0031 §Generalization; phase-250/252/254). Typed,
 # system-wide, optional. Lower to build features (and, for the C/C++ bake, a
@@ -203,9 +204,9 @@ is retired by phase-254: `nros.toml` is the embedded direct-mode runtime file on
 not a build-capability overlay.
 
 The same single-source rule applies to **RMW** (phase-255, **landed**): `[system].rmw` +
-`[deploy.<t>].rmw` is the one declared home — both the Rust board-feature lowering and the
+`[image.<id>].rmw` is the one declared home — both the Rust board-feature lowering and the
 C/C++ `#define NROS_SYSTEM_RMW_<TOKEN>` resolve from it via `SystemToml::resolved_rmw(target,
-cli)` (RFC-0031 precedence `--rmw` > `[deploy.<t>]` > `[system]` > `zenoh`; `--rmw` is on `nros
+cli)` (RFC-0031 precedence `--rmw` > `[image.<id>]` > `[system]` > `zenoh`; `--rmw` is on `nros
 plan` + `nros codegen-system`). The legacy `[build].rmw` / `[[transport]].rmw` `nros.toml`
 overlay is now a **deprecated fallback that warns** (no fixture declares it), retired after the
 next release; a binary's multi-RMW link set comes from `[[bridge]]` here (`bridged_rmws()` →
@@ -377,7 +378,7 @@ scope, issue 0079; `[[scheduling.contexts]]` → `[tiers]`, decision A); (2) **r
 `nros.toml` file entirely** (no surviving role); (3) scrub the `config.toml` reader;
 (4) treat transport/network as part of the **`deploy` class**, not a separate file surface;
 (5) make the `deploy`-class precedence (`[..deploy.<t>]` projection vs `system.toml
-[deploy.<t>]`) explicit. Option *scope* classes: **node** (identity/params/remaps/qos/
+[image.<id>]`) explicit. Option *scope* classes: **node** (identity/params/remaps/qos/
 callback-groups), **system** (topology/capabilities/tiers — agnostic),
 **deploy** (target/board/build-tuning + net + rmw/domain/locator overrides),
 **build/capability** (lowered, not authored).
@@ -428,6 +429,23 @@ on the next callback.
 
 ## Changelog
 
+- 2026-08-31 (`[deploy.*]` retired; issue 0951) — This page described
+  `[deploy.<t>]` as the per-target rung of the precedence ladder and showed it
+  in the §4 example, while mentioning `[image.*]` and `[host.*]` nowhere. The
+  tree had moved: `[deploy.*]` conflated three facts and split into
+  `[image.<id>]` (what is BUILT), `[host.<name>]` (WHERE it runs) and
+  `[board_config.<board>]` (site config), and there are now **zero**
+  `[deploy.*]` blocks in any `system.toml`.
+
+  Corrected: the ladder rung is `[image.<id>]` (§5, §6, §9), and the §4 example
+  declares an image and a host instead of a deploy. Being a **Stable** page is
+  what made this worth doing promptly rather than at leisure — a stable doc is
+  the one people trust without checking, so it is the most expensive one to
+  leave wrong. RFC-0031 had already been amended for the same split; this page
+  was the one that had not.
+
+  `[deploy.*]` still PARSES, for out-of-tree users who have not migrated, and
+  warns. Removal is phase-383 W10.b, a 0.6.0 action.
 - 2026-06 (config.toml kept as a file path; issue 0081 wontfix) — Reversed the
   "config.toml fully retired" stance. The OLD `[network]/[zenoh]/[scheduling]` schema
   stays retired, but the direct-mode `config.toml` (`[node]`/`[[transport]]`/`[node.rt]`)

--- a/docs/design/0031-rmw-selection-and-lowering.md
+++ b/docs/design/0031-rmw-selection-and-lowering.md
@@ -290,11 +290,18 @@ the Rust `nros/safety-e2e` feature (targets 1-3) AND the C/C++ `#define NROS_SYS
   Rust uses the cargo feature directly).
 - Converge examples so zenoh / xrce / cyclonedds all lower uniformly from the
   declared value.
-- Make `nros new --rmw <x>` actually template the scaffold (today it only prints
-  a "next steps" banner).
-- Sync the contradictory book pages (`user-guide/rmw-backends.md`,
-  `internals/rmw-backends.md` say "not by features"; `reference/build-commands.md`,
-  `porting/custom-platform.md` show the bare feature).
+- ~~Make `nros new --rmw <x>` actually template the scaffold~~ — **CLOSED
+  (verified 2026-08-31).** `args.rmw` is threaded into the scaffold structs at
+  `cmd/new.rs:302`, `:460`/`:472` and `:507`, each with a real default. No
+  "next steps" banner remains. The RFC had simply not been updated.
+- ~~Sync the contradictory book pages~~ — **CLOSED (2026-08-31).**
+  `user-guide/rmw-backends.md` had kept documenting the PRE-C5b lowering ("add
+  `nros` with the platform feature plus one `nros-rmw-<x>` shim"), which the
+  C5b amendment below retired when the board crate became the selection point.
+  Measured against real leaves before rewriting: they forward to
+  `nros-board-linux/rmw-<x>`, and workspace node pkgs say so in a comment. The
+  page now shows that shape and says a workspace declares
+  `[image.<id>].rmw` instead of writing any of it.
 
 ## Changelog
 

--- a/docs/design/0072-rtos-integration-nano-ros-is-a-guest.md
+++ b/docs/design/0072-rtos-integration-nano-ros-is-a-guest.md
@@ -95,7 +95,7 @@ A design that assumes a configure-time hook silently excludes PX4 and PIO.
 | home | count | holds | read by | when |
 | --- | ---: | --- | --- | --- |
 | `packages/boards/*/nros-board.toml` | 8 files, 9 boards | the descriptor | `BoardCatalog` (CLI) | `nros sync` / `setup` |
-| `<bringup>/system.toml` `[deploy.<name>]` | 59 blocks | `kind`, `board`, `target`, `launch`, `nodes`, `rmw`, `framework` | `nros codegen system` | codegen |
+| `<bringup>/system.toml` `[image.<id>]` / `[host.<name>]` / `[board_config.<board>]` | 123 / 28 / 24 blocks | build description, placement, site config — one table each | `nros codegen system`, `nros build` | codegen |
 | `<leaf>/.cargo/nros-board.toml` | 44 | projection of `cargo_config` | cargo | every build |
 | `cmake/board/nano-ros-board-*.cmake` | 7 | toolchain file, kernel/stack targets | cmake, **by filename** | configure |
 | `just/sdk-env.just` | — | `FREERTOS_DIR`, `LWIP_DIR`, … | build scripts, via shell env | build |
@@ -272,39 +272,46 @@ everything §2b measured as site content in six of nine descriptors.
 
 ### Where site facts go (category B) — no new file
 
-`[deploy.<name>]` in the bringup's `system.toml` **already exists**, already
-keyed per board, already read at codegen time — 59 blocks in the tree, nine in
-one workspace. It gains the site keys rather than a sibling file being invented:
+The bringup's `system.toml` **already exists** and is already read at codegen
+time, so the site keys go in it rather than in a sibling file nobody would
+discover. They go in a table keyed by the BOARD, because that is what the fact
+is about:
 
 ```toml
-[deploy.nucleo-h723zg]
-kind    = "self"
-board   = "nucleo-h723zg"     # the join key to the board package (already there)
-target  = "thumbv7em-none-eabihf"
-
+[board_config."nucleo-h723zg"]                       # (B)
 sdk.cube      = "{env:CUBE_PROJECT}"      # machine path, env-interpolated
 netstack      = "lwip"
 config_files  = { tx_user = "Core/Inc/tx_user.h", nx_user = "Core/Inc/nx_user.h" }
 upload        = { port = "/dev/ttyACM0" }  # instance params; MECHANISM is the board's
 ```
 
+The board and what is built for it are declared separately, in the table that
+owns each — `[image.<id>] board = "nucleo-h723zg"` says what to build, and the
+descriptor supplies the rustc triple, so no block restates it.
+
 This satisfies the SSoT requirement (one file, per workspace, greppable),
-survives multi-board workspaces (keyed per deploy), and needs no new discovery
-path. `config_files` is a **named map** rather than a directory, because ThreadX
-needs `TX_USER_FILE` *and* `NX_USER_FILE` and FreeRTOS+TCP needs
-`FreeRTOSConfig.h` *and* `FreeRTOSIPConfig.h`.
+survives multi-board workspaces (keyed per board, so a workspace with two
+FreeRTOS boards cannot reach the wrong block), and needs no new discovery path.
+`config_files` is a **named map** rather than a directory, because ThreadX needs
+`TX_USER_FILE` *and* `NX_USER_FILE` and FreeRTOS+TCP needs `FreeRTOSConfig.h`
+*and* `FreeRTOSIPConfig.h`.
 
 #### Amendment 1 — the key is the BOARD, not the deploy (issue 0951)
 
 `[deploy.<name>.nros]` was the shipped spelling for three phases. It is now
-`[board_config.<board>]` in the same file. The rest of this section stands
-unchanged: same struct, same file, same `{env:…}` interpolation, same named
-`config_files` map.
+`[board_config.<board>]` in the same file: same struct, same file, same
+`{env:…}` interpolation, same named `config_files` map.
+
+*(This amendment originally said "the rest of this section stands unchanged".
+It did not — the section's block count, its worked example, its sequencing step
+and all eight §6 examples still showed `[deploy.*]`. They were rewritten on
+2026-08-31 when `[deploy.*]` reached zero blocks tree-wide. Fixing the key
+without the prose left the page teaching the shape it had just retired.)*
 
 What was wrong was one clause above — "already keyed per board". A deploy name
-is *usually* a board name, and the example on this page
-(`[deploy.nucleo-h723zg]`) is one of the cases where it is. But the two are not
-in bijection, and the tree drifted apart in both directions:
+is *usually* a board name — the `nucleo-h723zg` block this section used to show
+was one of the cases where it is, which is exactly why the clause read as true.
+But the two are not in bijection, and the tree drifted apart in both directions:
 `[deploy.threadx-linux]` pairs with `[image.threadx]`, `[deploy.an536]` with
 `[image.mps3_an536]`, and several workspaces carry BOTH `[deploy.freertos]` and
 `[deploy.mps2-an385-freertos]` for one board.
@@ -337,7 +344,7 @@ them.
 | --- | --- | --- |
 | our fixtures | nothing | — |
 | Zephyr / NuttX / ESP-IDF | one manifest line (unchanged) | board packages |
-| vendored FreeRTOS or ThreadX, CMake host | one board package + one `[deploy.*]` block | nano-ros itself |
+| vendored FreeRTOS or ThreadX, CMake host | one board package + one `[image.*]` block | nano-ros itself |
 | IDE host (CubeIDE, IAR, MTB) | the same, plus `nros emit` | — |
 | PX4 | `EXTERNAL_MODULES_LOCATION` | everything else — and they get no per-board opt-in (§2c) |
 
@@ -349,7 +356,7 @@ this is new value, not repackaging.
 
 ### Sequencing
 
-1. `[deploy.*]` gains the site keys; `nros config explain` reports file, section
+1. `[board_config.*]` carries the site keys; `nros config explain` reports file, section
    and rung. Nothing moves yet.
 2. Generate this repo's site values from `just/sdk-env.just`; both live, gated
    for agreement (the phase-347 pattern).
@@ -378,10 +385,8 @@ net_stack  = "host"               # the OS has sockets; nothing to choose
 ```
 ```toml
 # <bringup>/system.toml                                     (B)
-[deploy.native]
-kind = "self"
+[image.native]
 board = "native"
-target = "x86_64-unknown-linux-gnu"
 ```
 
 No SDK root, no netstack, no flashing. Every other row is a delta from this.
@@ -402,10 +407,10 @@ supported_netstacks = ["lwip", "freertos_plus_tcp"]     # the pairing domain
 toolchain_file = "cmake/toolchain/arm-freertos-armcm3.cmake"   # must precede project()
 ```
 ```toml
-[deploy.freertos]                                          # (B)
-kind = "self"
+[image.freertos]
 board = "mps2-an385-freertos"
-target = "thumbv7m-none-eabi"
+
+[board_config."mps2-an385-freertos"]                       # (B)
 netstack     = "lwip"
 sdk.freertos = "{env:FREERTOS_DIR}"
 sdk.lwip     = "{env:LWIP_DIR}"
@@ -438,10 +443,10 @@ supported_netstacks = ["lwip"]
 mechanism = "st-link"             # HOW this board is programmed — a board fact
 ```
 ```toml
-[deploy.nucleo]                                            # (B)
-kind = "self"
+[image.nucleo]
 board = "nucleo-h723zg"
-target = "thumbv7em-none-eabihf"
+
+[board_config."nucleo-h723zg"]                       # (B)
 netstack = "lwip"
 sdk.cube = "{env:CUBE_PROJECT}"
 include_dirs = [
@@ -470,9 +475,10 @@ entry_kind = "zephyr-staticlib"   # a west module, not main()
 net_stack  = "rtos-owned"         # zsock; nothing for us to choose
 ```
 ```toml
-[deploy.zephyr]                                            # (B)
-kind = "self"
+[image.zephyr]
 board = "zephyr"
+
+[board_config."zephyr"]                       # (B)
 zephyr_board = "qemu_cortex_m3"   # west's namespace, not ours
 ```
 
@@ -491,10 +497,10 @@ link_kind = "nuttx-staging"      # we land on EXTRA_LIBS
 net_stack  = "rtos-owned"
 ```
 ```toml
-[deploy.nuttx]                                             # (B)
-kind = "self"
+[image.nuttx]
 board = "nuttx"
-target = "armv7a-nuttx-eabihf"
+
+[board_config."nuttx"]                       # (B)
 sdk.nuttx      = "{env:NUTTX_DIR}"
 sdk.nuttx_apps = "{env:NUTTX_APPS_DIR}"
 ```
@@ -513,16 +519,17 @@ link_kind = "px4-external"
 net_stack  = "rtos-owned"
 ```
 ```toml
-[deploy.px4]                                               # (B)
-kind = "self"
+[image.px4]
 board = "px4-fmu-v6x"
+
+[board_config."px4-fmu-v6x"]                       # (B)
 px4.dir    = "{env:PX4_DIR}"
 px4.target = "px4_fmu-v6x_default"        # <vendor>_<model>_<label>
 ```
 
 PX4's configuration namespace is **closed to out-of-tree code**: everything a
 board declares is Kconfig-selectable per label; nothing an external module
-provides is. So a `[deploy.*]` block **cannot** produce a `<label>.px4board`
+provides is. So no block in `system.toml` **can** produce a `<label>.px4board`
 opt-in, and codegen must run *ahead* of the vendor tool (RFC-0003's hookless
 path), emitting module dirs into `$PX4_DIR/src/modules/`. Per-board selection
 would require being in-tree, as PX4 itself did for zenoh.
@@ -547,9 +554,10 @@ entry_kind = "board-run"
 supported_netstacks = ["netxduo"]
 ```
 ```toml
-[deploy.threadx_rv64]                                      # (B)
-kind = "self"
+[image.threadx_rv64]
 board = "threadx-riscv64"
+
+[board_config."threadx-riscv64"]                       # (B)
 sdk.threadx = "{env:THREADX_DIR}"
 sdk.netxduo = "{env:NETXDUO_DIR}"
 config_files = { tx_user = "boards/rv64/tx_user.h", nx_user = "boards/rv64/nx_user.h" }
@@ -569,9 +577,10 @@ entry_kind = "board-run"
 net_stack = "rtos-owned"          # esp_netif over IDF's lwIP fork
 ```
 ```toml
-[deploy.esp32]                                             # (B)
-kind = "self"
+[image.esp32]
 board = "esp32-qemu"
+
+[board_config."esp32-qemu"]                       # (B)
 idf.dir = "{env:IDF_PATH}"
 ```
 
@@ -720,7 +729,8 @@ it with the principle.
 **Draft 2 put `[board.integration]` in the board descriptor.** Every field in it
 (`rtos`, `netstack`, `include_dirs`, `defines`) is site configuration, so it
 belonged in the project, not the board package. §5 relocates it to
-`[deploy.<name>]`.
+`[board_config.<board>]` (via `[deploy.<name>.nros]`, which Amendment 1
+re-keyed).
 
 **Draft 2 also proposed a `netstack` provider kind with selection.** The survey
 found no vendor leaves the stack selectable — NXP's lwIP fork *contains* the

--- a/docs/roadmap/phase-383-colcon-like-builder.md
+++ b/docs/roadmap/phase-383-colcon-like-builder.md
@@ -9,8 +9,10 @@
 (who owns `build/`), [RFC-0077](../design/0077-image-runtime-is-the-images-choice.md)
 (the `panic` policy this forwards)
 
-**Status (2026-08-27). W1–W8 COMPLETE. W9.a COMPLETE — all 16 bringups declare
-`[image.*]`, 99 images, every one resolving.** The W10 chain is PROVEN on one
+**Status (2026-08-31). W1–W9 and W10.a / W10.c / W10.d COMPLETE — all bringups
+declare `[image.*]` (123 images tree-wide, every one resolving), and `panic` /
+`args` are carried (see the W9.a note below). W10.b alone remains, and is NOT
+DUE: it is a 0.6.0 action.** The W10 chain is PROVEN on one
 real workspace: `examples/workspaces/rust` built with its hand-written root and
 entry deleted and the generated pair compiling. That proof found three more
 defects (all fixed) and was then reverted — the tree is unchanged.
@@ -31,17 +33,21 @@ the migration:
   failures. Tier 2 is green today only on residue from an older `lane=all`.
   W9.c therefore runs against a `lane=all` build until 0828 lands.
 
-**W9.a is not as complete as it was marked.** All 16 bringups declare
-`[image.*]` and every image resolves, but two keys were never carried over from
-the entries they were derived from: **zero images declare `panic`** (6 entries
-do — `esp32_entry`, `freertos_entry`, `nuttx_entry` in `workspaces/rust`;
-`nuttx_entry`, `riscv_nuttx_entry`, `freertos_realtime_entry` in
-`workspaces/realtime-rust`) and **zero declare `args`**, so the three
-args-bearing entries (`native_entry_robot1`, `native_entry_robot2`,
-`zephyr_entry_robot1`) have no image at all. Nine declarations missing. A
-generated entry would silently lose its panic policy or its machine binding —
-which is a build that succeeds and is wrong, the worst shape. Fix belongs with
-the first workspace migration.
+**W9.a's gap is CLOSED (re-measured 2026-08-31).** It was real when written:
+two keys had never been carried over from the entries the images were derived
+from, and a generated entry would have silently lost its panic policy or its
+machine binding — a build that succeeds and is wrong.
+
+Both are carried now. Measured against the tree rather than re-read:
+**7 images declare `panic`** (`workspaces/rust`: esp32, freertos, nuttx;
+`workspaces/realtime-rust`: freertos_realtime, nuttx, riscv_nuttx;
+`workspaces/cpp`: native) and **9 declare `args`** (the robot1/robot2 pairs in
+`c`, `cpp`, `mixed`, `rust`, plus `rust`'s `zephyr_robot1`). The count is higher
+than the nine this note predicted because every multihost image needs its own
+binding. On the entry side the keys are simply gone: across 67 entry packages,
+**zero** declare `panic` or `args` — `[package.metadata.nros.entry]` now carries
+only `deploy` / `name` / `class` / `default_namespace` / `board` / `rmw` /
+`node_pkgs` / `domain_id`.
 
 **What remains needs a validated build cycle, not more code:** W9.b (retarget
 `examples/fixtures.toml`'s rows at `nros build`), W9.c (`just build-test-fixtures
@@ -422,14 +428,12 @@ found only because these trees are not uniform the way ours are.
 
 ## W9 — Migrate the nine (RFC-0065 D13, stage 2)
 
-- [~] **W9.a** Migrate all nine workspace roots and their entry packages, one
+- [x] **W9.a** Migrate all nine workspace roots and their entry packages, one
       commit per workspace so a regression bisects to one.
 
-      **Images declared, but nine declarations are missing** — see the status
-      note at the top. No image carries `panic` (6 entries declare one) and
-      none carries `args` (so the 3 args-bearing entries have no image). Both
-      would generate an entry that builds and is WRONG. Close with the first
-      workspace migration.
+      Images declared AND complete: 7 carry `panic`, 9 carry `args`, and no
+      entry package declares either any more. See the re-measured status note
+      at the top — this item was marked `[~]` for a gap that has since closed.
 - [x] **W9.b** Update `examples/fixtures.toml` rows to invoke `nros build`.
       **Done for every row it can apply to. The "337 rows" figure conflated two
       tables that are not the same kind of thing** — measured 2026-08-29:
@@ -683,69 +687,51 @@ found only because these trees are not uniform the way ours are.
       **So the deletion is mechanically safe for all 42**, and what remains is
       a shape decision rather than a correctness risk.
 
-      **SURVEYED 2026-08-31, and the retirement premise does not hold.** Three
-      parallel surveys (readers, TOML inventory, upstream schema) plus one
-      decisive experiment. Recorded here because the previous paragraph — which
-      said placement "moves to `[image.*]` too" — was extrapolation, and the
-      code says otherwise.
+      **SURVEYED 2026-08-31, and OVERTAKEN the same day.** The survey below is
+      kept because its method was right and its conclusion has an expiry date
+      worth seeing. Everything it measured was true when measured; issue 0951
+      landed hours later and removed the subject.
 
-      * **`[deploy.*]` is upstream's, and upstream has no image concept.** The
-        table is `ros_launch_manifest_model::system_config::DeployBlock`, pinned
-        at a tag. rlm's `apply_to_launch` is the SOLE source of placement (node
-        FQN → target/domain/locator/rmw); there is no `ImageBlock` anywhere in
-        that crate. nano-ros's own `image.rs` header agrees: "An image needs no
-        deploy block and a deploy block needs no image" — `[image.*]` is a NEW
-        table, explicitly not a rename.
-      * **The table is mostly placement.** 77 deploy blocks across 26 files:
-        `kind` in all 77, plus `launch` 11 and `nodes` 8, against `board` 27,
-        `target` 13, `rmw` 2. And a `[deploy.<n>.nros]` site layer — 30 `sdk` +
-        17 `netstack` keys — with no `[image.*]` counterpart at all, wired into
-        cmake and two `just` gates.
-      * **The build fields are NOT inert, which kills W10.b as written.**
-        Measured: removing `target` from `[deploy.robot1]`/`[robot2]` DROPS
-        `target: x86_64-unknown-linux-gnu` from the generated SystemModels.
-        `board_facts.rs` hard-ERRORS when `.board` is absent, and
-        `cmake/NanoRosBoardFacts.cmake` shells that verb;
-        `check-deploy-board-resolves.py` errors if it finds zero deploy values.
-        13 production reader sites across `plan`, `codegen-system`,
-        `ws board-facts`, `doctor`, `check`.
-      * **`nros build --dry-run` cannot see any of this.** It reads deploy ONLY
-        to emit the deprecation lint; no deploy value influences a build
-        decision. Seven images came back byte-identical under a deletion that
-        does change generated models — the proof method W10.a established is
-        sound for the build path and silent about the model path.
+      What it found, and what is true now:
 
-      **What landed instead: the 2 `[deploy.*].rmw` fields are gone**, the one
-      slice that is provably inert now that the image rung outranks them (issue
-      0938). Both duplicated the `[system].rmw` they would fall through to.
-      Zero `[deploy.*].rmw` remain in the tree.
+      | survey claim (2026-08-31, morning) | now |
+      | --- | --- |
+      | "77 deploy blocks across 26 files" | **0** in any `system.toml`. 123 `[image.*]`, 28 `[host.*]`. |
+      | "a `[deploy.<n>.nros]` site layer — 30 `sdk` + 17 `netstack` — with no `[image.*]` counterpart" | 24 `[board_config.<board>]` blocks. The 30 held 3 distinct value-sets; keying on the board removed 25 duplicates. |
+      | "`board_facts.rs` hard-ERRORS when `.board` is absent" | It selects candidates from `[image.*] ∪ [deploy.*]` and matches `--board` through the board catalog. |
+      | "`check-deploy-board-resolves.py` errors if it finds zero deploy values" | It reads `[image.*]` and `[image_defaults]` too. Run today: `deploy boards resolve: OK (20 distinct value(s))`. |
+      | "13 production reader sites … the build fields are NOT inert" | Every one migrated to `[image.*]`-first with a deploy fallback: `resolve_target`, `derive_target_rtos`, `schema_build_json`, the `codegen_system` launch fallback, `doctor`, `board_facts`, and `synthesise_self_bringup`. |
+      | "`nros build --dry-run` cannot see any of this" | Still true, and it is why 0951 verified with regenerated SystemModels plus `nros codegen entry` before/after, not with dry-runs. |
 
-      **What retirement would actually require**, in ascending cost: delete the
-      lints and the `nros check` counter (cheap); find an `[image.*]` home for
-      `launch`, `domain_id`, `locator`, and the `.nros` site block (medium);
-      and replace rlm's placement projection, which is consumed OUTSIDE this
-      repo and drives which nodes land in which entry binary (hard, and a
-      schema change in another repository). Issues 0356/0370 record what
-      silently emptying that projection looks like.
+      The one claim that stands is the first: `[deploy.*]` is upstream's type
+      and rlm has no image concept. That did not block the retirement — it
+      shaped it. Placement moved to `[host.<name>]`, which is ALSO upstream's
+      (rlm v0.1.21), so the projection other repositories consume still exists;
+      it is keyed by machine now instead of by a table that also described
+      builds.
+
+      **What W10.b therefore means at 0.6.0:** delete the PARSING of a table
+      nothing in the tree authors — `SystemToml::deploy`, the deprecation
+      lints, the fallback rungs in the readers above, and the `nros check`
+      counter. Not a migration; a subtraction. The three surviving
+      `[deploy.*]` blocks are in
+      `packages/cli/testing_workspaces/orchestration_e2e/nros.toml`, the root
+      overlay `cmd/check.rs` already reports as "retired; unsupported and
+      ignored" — dead text in a file no reader loads.
+
+      **What it still needs:** out-of-tree users may author `[deploy.*]`, and
+      the deprecation warning is what moves them. That warning was never
+      emitted until it was wired to `collect_images`, so the clock started
+      then, not when the lint was written.
 
       **Superseded direction (2026-08-31, kept for the record): `[deploy.*]`
       retires ENTIRELY, not just its build fields.** This item was scoped to the build fields, on the standing
       claim that "`[deploy.*]` keeps PLACEMENT and is not being retired" — the
       deprecation message said exactly that, and it has been corrected. Placement
-      moves to `[image.*]` too, so the eventual state is one table describing a
-      buildable unit and where it runs, rather than two describing halves of it.
+      moved to `[host.*]`, so the eventual state is one table describing a
+      buildable unit and another describing where it runs, rather than one
+      describing halves of both.
 
-      That does not change what 0.6.0 does here — the build fields go first,
-      because they are the redundant half and their removal is provably inert.
-      Placement retirement needs its own work item: `kind`, `nodes` and `launch`
-      have live readers, and unlike the build fields there is no second table
-      already carrying the same values.
-
-      **What 0.6.0 must therefore decide, and it is a design question:** which
-      of the 14 deploys deserve to be images. Several are placement-only
-      (`robot1`/`robot2` carrying a host `target`), and giving those an image
-      declares them separately buildable — which may be right, but is a choice
-      about the workspace's shape rather than a rename.
 - [x] **W10.c** Add `check-no-tracked-workspace-roots` so the shape cannot
       return. Every gate in this repo exists because a class recurred; this one
       is cheap and the class is "someone re-adds a hand-written root".

--- a/packages/cli/nros-cli-core/src/cmd/doctor.rs
+++ b/packages/cli/nros-cli-core/src/cmd/doctor.rs
@@ -40,8 +40,8 @@ pub struct Args {
     pub workspace: Option<PathBuf>,
 
     /// Bringup `system.toml` (or a directory containing one) whose
-    /// `[deploy.<target>]` blocks to health-check (RFC-0004 §4). When
-    /// omitted, the cwd's `system.toml` is used if present.
+    /// `[image.<id>]` blocks to health-check — and any `[deploy.*]` still
+    /// declared. When omitted, the cwd's `system.toml` is used if present.
     #[arg(long)]
     pub config: Option<PathBuf>,
 }
@@ -126,7 +126,7 @@ pub fn run(args: Args) -> Result<()> {
             Err(_) if deploy_problems.is_some() => {
                 eprintln!(
                     "nros doctor: no nano-ros workspace here — skipped `just doctor` \
-                     (checked deploy targets only)"
+                     (checked the bringup's images only)"
                 );
                 None
             }
@@ -145,7 +145,7 @@ pub fn run(args: Args) -> Result<()> {
 
     let problems = deploy_problems.unwrap_or(0) + gate_problems;
     if problems > 0 {
-        bail!("nros doctor: {problems} problem(s) (deploy targets + license gates)");
+        bail!("nros doctor: {problems} problem(s) (images + license gates)");
     }
     Ok(())
 }
@@ -497,7 +497,7 @@ mod tests {
     use super::*;
 
     /// RFC-0004 §4 — `check_deploy_targets` parses a bringup `system.toml`,
-    /// reports each `[deploy.<target>]`, and flags a deploy whose `launch`
+    /// reports each `[image.<id>]`, and flags one whose `launch`
     /// file is missing relative to the bringup dir.
     #[test]
     fn deploy_targets_flag_missing_launch_file() {


### PR DESCRIPTION
`[deploy.*]` reached zero blocks tree-wide and the docs did not follow. Every claim below was **re-measured against the tree**, not re-read.

## phase-383 was stale in three places, all pessimistic

| doc claim | measured now |
| --- | --- |
| "77 deploy blocks across 26 files" | **0** in any `system.toml` |
| "a `[deploy.<n>.nros]` site layer — 30 `sdk` + 17 `netstack` — with no `[image.*]` counterpart" | 24 `[board_config.*]`; the 30 held 3 distinct value-sets |
| "`board_facts.rs` hard-ERRORS when `.board` is absent" | selects from `[image.*] ∪ [deploy.*]`, matches `--board` through the catalog |
| "`check-deploy-board-resolves.py` errors if it finds zero deploy values" | passes: `OK (20 distinct value(s))` |
| "13 production reader sites … the build fields are NOT inert" | all migrated to image-first |
| W9.a `[~]`: "no image carries `panic`… none carries `args`" | **7 carry `panic`, 9 carry `args`**; across 67 entry packages, zero declare either |

W10.b's survey is kept as a then-vs-now table — the method was right and the conclusion had an expiry date worth seeing. It now means "delete the parsing of a table nothing authors", a subtraction at 0.6.0. W9.a goes to `[x]`. The header also claimed W9.a COMPLETE 20 lines above a note saying it was not.

## RFC-0004 (Stable) described a table the tree no longer has

Ladder read `[deploy.<t>] > [system]`; §4 example declared a deploy; `[image.*]`/`[host.*]` appeared **nowhere**. Corrected with a changelog entry — a Stable page is the one people trust without checking, so it is the most expensive one to leave wrong.

## RFC-0072's Amendment 1 was mine, and too narrow

It re-keyed the site table and asserted "the rest of this section stands unchanged". It did not: the section claimed 59 blocks in the tree, its example carried `sdk`/`netstack`/`upload` on a deploy, sequencing step 1 was "`[deploy.*]` gains the site keys" — a step that can never run — and all eight §6 examples showed the old shape. Each is now split into the table that owns each half; the amendment records the correction rather than hiding it.

## The book taught the retired table on the getting-started path

Three copyable blocks (`anatomy`, `how-integration-works`, `workspace-bringup`) — one teaching `target = "thumbv7em-none-eabihf"`, the field the board descriptor derives — plus nine prose sites and a field table.

## Two RFC-0031 open questions were already answered by the tree

`nros new --rmw` does template the scaffold (`cmd/new.rs:302`, `:460`, `:507`). And `user-guide/rmw-backends.md` documented the **pre-C5b** lowering, which the board-crate amendment retired; measured real leaves before rewriting — they forward to `nros-board-linux/rmw-<x>`.

Also: `nros doctor`'s `--config` help and two failure strings said "deploy targets" though it reports images.

`just ci-l1` green; `just check fast` 146/146; `just book` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG