### PR TITLE
feat(phase-400 W6): the executor tenant, and a census that makes its gate real

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,8 @@ dependencies = [
  "heapless 0.8.0",
  "libc",
  "log",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-ghost-types",
  "nros-lifecycle-msgs",

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,6 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
-**Status (2026-08-30): W2-W5 and W7 done; W1, W6, W8 outstanding.** Design is
+**Status (2026-08-31): W2-W5 and W7 done; W6's first and largest tenant
+(`NROS_EXECUTOR_*`) done, its remaining tenants and W1 / W8 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
 new mechanism — the ladder and `nros config explain` already exist and work.
@@ -15,6 +16,27 @@ This phase gives them reach and deletes what they replace.
 | `NROS_*` env read in build scripts | 21 |
 | `ZPICO_*` env | 9 |
 | **knobs in the RFC-0049 ladder** | **3** |
+
+**That table had no METHOD, so no wave could show it moved.** Every gate here
+is stated as "measured the same way as the table at the top", and there was no
+same way — two people counting by hand get two numbers. The method now exists:
+`just check config-knob-census` (`scripts/check/config-knob-census.py`),
+buildless, and it is on the fast line. Re-measured 2026-08-31:
+
+| where configuration lives | count |
+| --- | --- |
+| **knobs in the RFC-0049 ladder** | **13** (8 executor · 3 zenoh.tx · 2 transport) |
+| Kconfig `CONFIG_NROS_*` declarations | 85 |
+| `NROS_*` env read by a `build.rs` | 31 |
+| `ZPICO_*` env read by a `build.rs` | 5 |
+
+Do NOT read `3 → 13` as this phase's delta: the 3 was counted by an unknown
+method and the rows are not comparable term-for-term. What is now true is that
+the number is REPRODUCIBLE, and the ladder count is ratcheted — it may rise,
+never fall, because a knob leaving the ladder is a knob losing its platform and
+board rung and its `nros config explain` row. The env rows are REPORTED and not
+gated, deliberately: a migrated knob keeps its env name as the front-end, so
+"the env count falls to zero" was never the goal.
 
 Descriptors: 4 rmw · 7 platform · 11 board, across 12 package kinds. Only three
 kinds have one.
@@ -160,9 +182,50 @@ front-end so nothing breaks at the call site.
 Order by blast radius, largest first: `NROS_EXECUTOR_*` (8 read by
 `nros-node/build.rs`), then the zenoh pools, then the per-entity caps.
 
-**Gate.** Ladder knob count rises and the env/Kconfig count falls, measured the
-same way as the table at the top. A tenant is migrated when
-`nros config explain` prints it and the front-end still overrides it.
+**Gate.** Ladder knob count rises, measured by
+`just check config-knob-census`. A tenant is migrated when `nros config
+explain` prints it and the front-end still overrides it.
+
+### `NROS_EXECUTOR_*` — DONE
+
+All eight resolve over the ladder (`PlatformTree::resolve_executor`), both
+production readers call it (`cmd/config.rs`, `orchestration/model_ingest.rs`),
+and `nros config explain` prints all eight with the env name that is still
+their front-end:
+
+```
+executor.max_cbs                   4          builtin  [NROS_EXECUTOR_MAX_CBS]
+executor.arena_size                derived    builtin  [NROS_EXECUTOR_ARENA_SIZE]
+$ NROS_EXECUTOR_MAX_CBS=17 nros config explain --platform posix
+executor.max_cbs                   17         env      [NROS_EXECUTOR_MAX_CBS]
+```
+
+Two of the eight were invisible until 2026-08-31, and the reason is worth
+keeping: their defaults are DERIVED, not constant, so they did not fit the
+`&[(&str, usize)]` table the other six were listed in and were simply left out
+— in a report whose entire job is to say where a value came from. Neither
+derivation is duplicated to fix it: `action_clients` defaults to the RESOLVED
+`max_cbs` (build.rs then clamps to it, so the default is the clamp), and
+`arena_size` defaults to `0`, the documented Kconfig sentinel for "derive it",
+printed as `derived`. `nros-node/build.rs` stays the one place that knows the
+arena formula.
+
+**What this tenant does NOT yet have: the platform/board rungs do not reach a
+bare `cargo build`.** `nros-node/build.rs` resolves env → Kconfig → default via
+`nros_zephyr_build::knob_usize`; it never opens the platform or board TOML. So
+the rungs exist and are reported, and a build outside cmake still compiles at
+crate defaults — which is the failure the `ExecutorKnobs` doc comment describes.
+Closing it needs a decision, because `nros-node`'s build-dependencies are
+deliberately "build-only, dependency-free" while the ladder lives in
+`nros-board-common` (which `nros-zpico-build` does depend on, with
+`features = ["build-helpers"]`). Either core's build script takes that
+dependency, or the lane resolves the ladder and exports the values as env the
+way `board-facts` already exports `NROS_SDK_*`. The first reaches a bare cargo
+build; the second keeps one ladder implementation. Not decided here.
+
+### Remaining tenants
+
+The zenoh pools, then the per-entity caps.
 
 ---
 

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -210,18 +210,51 @@ derivation is duplicated to fix it: `action_clients` defaults to the RESOLVED
 printed as `derived`. `nros-node/build.rs` stays the one place that knows the
 arena formula.
 
-**What this tenant does NOT yet have: the platform/board rungs do not reach a
-bare `cargo build`.** `nros-node/build.rs` resolves env → Kconfig → default via
-`nros_zephyr_build::knob_usize`; it never opens the platform or board TOML. So
-the rungs exist and are reported, and a build outside cmake still compiles at
-crate defaults — which is the failure the `ExecutorKnobs` doc comment describes.
-Closing it needs a decision, because `nros-node`'s build-dependencies are
-deliberately "build-only, dependency-free" while the ladder lives in
-`nros-board-common` (which `nros-zpico-build` does depend on, with
-`features = ["build-helpers"]`). Either core's build script takes that
-dependency, or the lane resolves the ladder and exports the values as env the
-way `board-facts` already exports `NROS_SDK_*`. The first reaches a bare cargo
-build; the second keeps one ladder implementation. Not decided here.
+**The platform and board rungs reach a cargo build (2026-08-31).** They did
+not when the tenant first landed: `nros-node/build.rs` resolved env → Kconfig →
+default and never opened the platform or board TOML, so a build outside cmake
+compiled at crate defaults — the failure `ExecutorKnobs`'s own doc comment
+describes.
+
+The obstacle was not the ladder. `nros-node` deliberately has NO `platform-*`
+cargo feature (phase-248 C2: the core executor is platform-agnostic and reaches
+the platform through the vtable), so its build script could not know which
+platform it was compiling for — and reversing that to migrate a sizing knob
+would be the tail wagging the dog.
+
+Nor was "have the lane export the resolved values" available: that is issue
+0460 exactly, where cmake's `set(ENV{...})` reaches the C lane and not the
+cargo one.
+
+What resolves it is the idiom this repo already uses everywhere else — the
+lane exports a value and a POINTER, and the build script reads the file:
+
+* `nros ws board-facts` now emits `NROS_PLATFORM_NAME` beside `NROS_BOARD_TOML`.
+  The board descriptor already knew its platform; this is the seam that had
+  already resolved it. `NROS_PLATFORM_NAME`, not `NROS_PLATFORM`, because
+  cmake's `-DNROS_PLATFORM=cffi` names the platform LAYER — one variable
+  meaning two things is how they start disagreeing.
+* `corrosion_set_env_vars` already attaches those to the target's own build
+  command, which is what actually runs cargo. No new channel.
+* `nros-node/build.rs` resolves env → Kconfig → board → platform → builtin,
+  taking a host-only build-dep on `nros-board-common` (`build-helpers`), which
+  `nros-zpico-build` already takes for the zenoh tenant. No cycle.
+
+Cost, measured rather than estimated: 18 leaf locks moved, and **16 of them
+gained only the two path-dep lines** — they are board crates that already
+depend on `nros-board-common`. Only `nros-verification` pulls the serde/toml/cc
+chain fresh (182 lines), in a HOST build graph, never linked into firmware.
+
+Every failure on that path is FATAL, not a fall-through to defaults. The first
+version used `.ok()`, and a platform file with one rejected key compiled at the
+crate defaults while reporting success — which is the shape the whole ladder
+exists to remove. `nros-zpico-build` says the same thing about the same tree.
+
+Verified end to end, all four paths: a platform rung applies (`max_cbs = 11`),
+a board rung applies (`max_sc = 23`), the env front-end still wins over both
+(`99`), and a malformed platform file panics naming the bad key. With no
+`NROS_PLATFORM_NAME` — a bare `cargo build` with no lane — nothing changes:
+with no board named there IS no platform rung to resolve.
 
 ### Remaining tenants
 

--- a/just/check.just
+++ b/just/check.just
@@ -113,7 +113,8 @@ fast-serial: \
     cargo-profile-mirror build-profile-literals \
     version-lockstep workspace-fmt example-fmt cli-fmt \
     readiness-marker-literals \
-    codegen-invocation string-conventions issue-ids knob-single-reader workflow-repo-env doc-recipe-refs \
+    codegen-invocation string-conventions issue-ids knob-single-reader config-knob-census \
+    workflow-repo-env doc-recipe-refs \
     std-census capability-flavour-guards flavour-lanes feature-contract no-std-stdio cpp-no-std-stdio no-vacuous-tests nextest-binary-filters cmake-find-program-shadowed shared-cargo-dir-witness image-panic-policy cmake-image-policy tier-spin-gap rmw-api-parity rmw-abi-shape rmw-ret-sign rmw-vtable-order rmw-alloc-sites rmw-slot-producers zenohd-router-skips single-rust-staticlib cli-source-dirs rust-targets-covered api-parity-ledger just-recipe-refs \
     absolute-paths \
     c-fmt cpp-fmt python \
@@ -743,6 +744,12 @@ issue-ids:
 [private]
 knob-single-reader:
     @python3 scripts/check/check-knob-single-reader.py
+
+# phase-400 — the config census, and the ratchet on it. The ladder knob count
+# is the number every wave gate is stated against; it was unmeasurable until
+# this existed, because the phase doc recorded a table and no method.
+config-knob-census:
+    @python3 scripts/check/config-knob-census.py --check
 
 # issue 0933 — a CI step that invokes `just`/`nros`/`west` must source the repo
 # environment. `activate.sh` is what exports `nano_ros_ROOT`, and that is how

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -205,6 +205,23 @@ impl Knobs {
     }
 }
 
+/// Every executor knob, in a stable order.
+///
+/// One list, so a caller that needs to go the other way (env name → knob) can
+/// derive it from [`executor_env_key`] instead of retyping the pairs. Two
+/// hand-maintained copies of "which knobs exist" is how one of them ends up
+/// missing the knob that was just added.
+pub const EXECUTOR_KNOBS: &[&str] = &[
+    "max_cbs",
+    "max_sc",
+    "max_nodes",
+    "max_shutdown_cbs",
+    "action_clients",
+    "arena_size",
+    "subscription_buffer_size",
+    "param_service_buffer_size",
+];
+
 /// The env front-end name for an executor knob. These are the EXISTING names
 /// `nros-node/build.rs` already reads, kept verbatim: migrating a knob into the
 /// ladder must not change how anyone sets it.
@@ -833,6 +850,16 @@ impl PlatformsTree {
     ///
     /// Each knob keeps its existing env name, so migrating a knob changes no
     /// call site — it only adds the two rungs it never had.
+    /// The `[knobs.executor]` a platform's chain declares, merged nearest-wins.
+    ///
+    /// Public because a BUILD SCRIPT needs the rungs without the resolution:
+    /// `nros-node/build.rs` owns the defaults (two are derived) and its own
+    /// env/Kconfig front-end, so it wants "what do the platform and board
+    /// say", not "what is the final answer".
+    pub fn platform_executor_rungs(&self, platform: &str) -> Result<ExecutorKnobs, ConfigError> {
+        self.platform_executor_knobs(platform)
+    }
+
     pub fn resolve_executor(
         &self,
         platform: &str,

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -344,6 +344,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -405,6 +405,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -289,6 +289,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -276,6 +276,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -320,6 +320,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -320,6 +320,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -289,6 +289,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -286,6 +286,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -293,6 +293,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/cli/nros-cli-core/src/cmd/board_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/board_facts.rs
@@ -183,6 +183,23 @@ fn resolve_one(
     }
     out.insert("NROS_BOARD".into(), board_name.clone());
 
+    // phase-400 W6 — the board's PLATFORM, by name.
+    //
+    // `nros-node` deliberately has no `platform-*` cargo feature (phase-248 C2:
+    // the core executor is platform-agnostic and reaches the platform through
+    // the vtable), so its build script cannot know which platform it is
+    // compiling for — and without that it cannot resolve the platform rung of
+    // the RFC-0049 knob ladder. The descriptor knows; this is the seam that has
+    // already resolved it.
+    //
+    // A NAME, not a path: `NROS_PLATFORM_NAME`, not `NROS_PLATFORM`, because
+    // cmake's `-DNROS_PLATFORM=cffi` names the platform LAYER, a different
+    // axis, and one env var meaning two things is how they start disagreeing.
+    out.insert(
+        "NROS_PLATFORM_NAME".into(),
+        descriptor.platform.kebab().to_string(),
+    );
+
     // W4 — the netstack, validated against the board's declared domain. An
     // unsupported pair fails HERE, at the seam that knows both halves, rather
     // than as a link error inside a stack nobody selected.

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -216,19 +216,49 @@ fn explain(args: ExplainArgs) -> Result<()> {
         ("subscription_buffer_size", 1024),
         ("param_service_buffer_size", 4096),
     ];
-    for (name, r) in tree
+    let resolved = tree
         .resolve_executor(
             &args.platform,
             board.as_ref().map(|b| &b.knobs.executor),
             &env_get,
             exec_defaults,
         )
-        .map_err(|e| eyre!("{e}"))?
-    {
+        .map_err(|e| eyre!("{e}"))?;
+
+    // The two knobs whose defaults are DERIVED, not constant — which is why
+    // they were missing from the table above and therefore invisible to
+    // `explain`, in a report whose whole job is to say where a value came from.
+    //
+    // Neither derivation is duplicated here. `action_clients` defaults to the
+    // resolved `max_cbs` (build.rs then clamps to it, so the default IS the
+    // clamp), and `arena_size` defaults to `0`, which is the documented Kconfig
+    // sentinel for "derive it" — build.rs stays the one place that knows the
+    // formula, and this prints `derived` rather than a number it did not
+    // compute.
+    let max_cbs = resolved
+        .iter()
+        .find(|(n, _)| *n == "max_cbs")
+        .map_or(4, |(_, r)| r.value);
+    let derived_defaults: &[(&str, usize)] = &[("action_clients", max_cbs), ("arena_size", 0)];
+    let derived = tree
+        .resolve_executor(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.executor),
+            &env_get,
+            derived_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?;
+
+    for (name, r) in resolved.iter().chain(derived.iter()) {
+        let shown = if *name == "arena_size" && r.value == 0 {
+            "derived".to_string()
+        } else {
+            r.value.to_string()
+        };
         println!(
-            "{:<24} {:<10} {}  [{}]",
+            "{:<34} {:<10} {}  [{}]",
             format!("executor.{name}"),
-            r.value,
+            shown,
             r.source.as_str(),
             r.env_key
         );

--- a/packages/core/nros-node/Cargo.toml
+++ b/packages/core/nros-node/Cargo.toml
@@ -227,6 +227,19 @@ libc = { version = "0.2", optional = true }
 # Kconfig said. Build-only, dependency-free, host-compiled like every build dep.
 nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }
 
+# phase-400 W6 — the RFC-0049 knob ladder, so the eight `NROS_EXECUTOR_*`
+# sizing knobs get their platform and board rungs instead of env → Kconfig →
+# default. Host-only: `build-helpers` is what gates serde/toml, and this crate
+# is a BUILD dependency, compiled for the host like every other one. No cycle —
+# `nros-board-common` does not depend on `nros-node`. `nros-zpico-build`
+# already takes exactly this dependency for the zenoh tenant.
+nros-board-common = { path = "../../boards/nros-board-common", features = [
+    "build-helpers",
+], default-features = false }
+# issue 0491 — a PATH must be fingerprinted by its CONTENT, never by
+# `rerun-if-env-changed` on the variable naming it. This is the one spelling.
+nros-build-paths = { path = "../../tooling/nros-build-paths" }
+
 # Phase 214.F.2 — target-gate every dev-dep that pulls a `std` /
 # `platform-posix` feature path. The `--edges=features` audit at
 # F.1-landing time showed `nros-node` was the dominant residual

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -218,6 +218,126 @@ fn main() {
 /// `$DOTCONFIG` fallback — the zenoh shim's knobs go through the same helper.
 /// This crate's env names are the Kconfig names minus `CONFIG_`, so the pair is
 /// derived rather than tabulated.
+/// The platform and board rungs of the RFC-0049 ladder for `[knobs.executor]`,
+/// resolved once.
+///
+/// phase-400 W6. This crate deliberately has NO `platform-*` cargo feature
+/// (phase-248 C2: the core executor is platform-agnostic and reaches the
+/// platform through the vtable), so the build script cannot know its platform
+/// from a `cfg`. It learns it the way every other build-script fact travels
+/// here: the lane exports a value, and a POINTER to the file that carries the
+/// rest. `nros ws board-facts` emits `NROS_PLATFORM_NAME` and
+/// `NROS_BOARD_TOML`, and `corrosion_set_env_vars` attaches them to the
+/// target's own build command — which is what actually runs cargo, unlike
+/// cmake's `set(ENV{...})` (issue 0460).
+///
+/// Absent pointer (a bare `cargo build` with no lane, an out-of-tree consumer)
+/// → every rung is `None` and the front-end below decides, exactly as before.
+/// With no board named there IS no platform rung to resolve, so that is the
+/// right answer rather than a degradation.
+fn executor_rungs() -> nros_board_common::platform_config::ExecutorKnobs {
+    use nros_board_common::platform_config as pc;
+
+    let empty = pc::ExecutorKnobs::default();
+    let Some(platform) = std::env::var("NROS_PLATFORM_NAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+    else {
+        return empty;
+    };
+    println!("cargo:rerun-if-env-changed=NROS_PLATFORM_NAME");
+
+    // The board rung. `watch_path` fingerprints the file's CONTENT — issue
+    // 0491: `rerun-if-env-changed` on a variable naming a PATH compares the
+    // spelling, and one directory has three spellings here.
+    // Every failure below is FATAL, never a fall-through to defaults.
+    //
+    // A silently empty tree resolves every knob to a builtin and produces a
+    // wrong image with no diagnostic — `nros-zpico-build` says exactly this
+    // about the same tree, and it is not a hypothetical: the first version of
+    // this function used `.ok()`, and a platform file with one rejected key
+    // compiled at the crate defaults while reporting success. The lane named a
+    // platform; being unable to honour it is an error.
+    let board = nros_build_paths::env_path("NROS_BOARD_TOML").map(|p| {
+        nros_build_paths::watch_path(&p);
+        pc::BoardKnobsFile::load(&p)
+            .unwrap_or_else(|e| panic!("NROS_BOARD_TOML={}: {e}", p.display()))
+            .knobs
+            .executor
+    });
+
+    let search = pc::PlatformsTree::default_search_path(
+        &nros_build_paths::repo_root(),
+        std::env::var("NROS_PLATFORMS_DIR").ok().as_deref(),
+    );
+    for dir in &search {
+        nros_build_paths::watch_path(dir);
+    }
+    let tree = pc::PlatformsTree::load_search_path(&search)
+        .unwrap_or_else(|e| panic!("platform search path {search:?}: {e}"));
+    let plat = tree
+        .platform_executor_rungs(&platform)
+        .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={platform}: {e}"));
+
+    // Board over platform, per RFC-0049. `None` at both leaves the front-end
+    // and the built-in default in charge.
+    let b = board.unwrap_or_default();
+    pc::ExecutorKnobs {
+        max_cbs: b.max_cbs.or(plat.max_cbs),
+        max_sc: b.max_sc.or(plat.max_sc),
+        max_nodes: b.max_nodes.or(plat.max_nodes),
+        max_shutdown_cbs: b.max_shutdown_cbs.or(plat.max_shutdown_cbs),
+        action_clients: b.action_clients.or(plat.action_clients),
+        arena_size: b.arena_size.or(plat.arena_size),
+        subscription_buffer_size: b.subscription_buffer_size.or(plat.subscription_buffer_size),
+        param_service_buffer_size: b
+            .param_service_buffer_size
+            .or(plat.param_service_buffer_size),
+    }
+}
+
+/// The knob a front-end env name belongs to, derived from the one table that
+/// maps the other way rather than retyped.
+fn knob_for_env(name: &str) -> Option<&'static str> {
+    nros_board_common::platform_config::EXECUTOR_KNOBS
+        .iter()
+        .copied()
+        .find(|k| nros_board_common::platform_config::executor_env_key(k) == name)
+}
+
+fn rung_value(
+    rungs: &nros_board_common::platform_config::ExecutorKnobs,
+    knob: &str,
+) -> Option<usize> {
+    match knob {
+        "max_cbs" => rungs.max_cbs,
+        "max_sc" => rungs.max_sc,
+        "max_nodes" => rungs.max_nodes,
+        "max_shutdown_cbs" => rungs.max_shutdown_cbs,
+        "action_clients" => rungs.action_clients,
+        "arena_size" => rungs.arena_size,
+        "subscription_buffer_size" => rungs.subscription_buffer_size,
+        "param_service_buffer_size" => rungs.param_service_buffer_size,
+        _ => None,
+    }
+}
+
+/// One executor knob: env → Kconfig → board → platform → built-in default.
+///
+/// The front-end keeps winning. Migrating a knob into the ladder must not take
+/// an operator's override away, which is half of this wave's own gate.
 fn env_usize(name: &str, default: usize) -> usize {
-    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), default)
+    println!("cargo:rerun-if-env-changed={name}");
+    if let Some(v) = std::env::var(name).ok().and_then(|v| v.trim().parse().ok()) {
+        return v;
+    }
+    if let Some(v) = nros_zephyr_build::dotconfig_usize(&format!("CONFIG_{name}")) {
+        return v;
+    }
+    static RUNGS: std::sync::OnceLock<nros_board_common::platform_config::ExecutorKnobs> =
+        std::sync::OnceLock::new();
+    let rungs = RUNGS.get_or_init(executor_rungs);
+    knob_for_env(name)
+        .and_then(|k| rung_value(rungs, k))
+        .unwrap_or(default)
 }

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -425,6 +425,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -457,6 +457,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -362,6 +362,8 @@ dependencies = [
  "atomic-waker",
  "heapless",
  "log",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -254,15 +254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nros-launch-parser"
-version = "0.5.0"
-dependencies = [
- "eyre",
- "nros-pkg-index",
- "quick-xml",
-]
-
-[[package]]
 name = "nros-log"
 version = "0.5.0"
 dependencies = [
@@ -274,7 +265,6 @@ dependencies = [
 name = "nros-macros"
 version = "0.5.0"
 dependencies = [
- "nros-launch-parser",
  "nros-orchestration-ir",
  "nros-pkg-index",
  "proc-macro2",
@@ -291,6 +281,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -292,6 +292,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -286,6 +286,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -286,6 +286,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",

--- a/packages/verification/nros-verification/Cargo.lock
+++ b/packages/verification/nros-verification/Cargo.lock
@@ -24,10 +24,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "hash32"
@@ -43,6 +65,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -61,7 +89,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -69,6 +107,34 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "nros-board-common"
+version = "0.5.0"
+dependencies = [
+ "cc",
+ "nros-build-paths",
+ "nros-cc-flags",
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "nros-build-paths"
+version = "0.5.0"
+
+[[package]]
+name = "nros-cc-flags"
+version = "0.5.0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "nros-core"
@@ -97,6 +163,8 @@ version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "heapless",
+ "nros-board-common",
+ "nros-build-paths",
  "nros-core",
  "nros-log",
  "nros-params",
@@ -186,6 +254,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,8 +334,49 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -234,7 +399,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
  "verus_prettyplease",
  "verus_syn",
@@ -256,7 +421,7 @@ version = "0.0.0-2026-07-27-0206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911e2a65229749eeb48a1f27d2b47a46b4fb43673f918854b065a932c86305b9"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "proc-macro2",
  "quote",
  "verus_syn",
@@ -282,4 +447,13 @@ dependencies = [
  "verus_builtin",
  "verus_builtin_macros",
  "verus_state_machines_macros",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""phase-400 — count where configuration lives, reproducibly.
+
+The phase doc opens with a table (78 Kconfig symbols, 21 `NROS_*` env, 9
+`ZPICO_*` env, against 3 knobs in the RFC-0049 ladder) and every wave's gate is
+stated as "measured the same way as the table at the top". No method was
+recorded, so the gate could not be evaluated: two people counting by hand get
+two numbers, and a wave cannot show it moved anything.
+
+This is that method. It is deliberately BUILDLESS — grep and TOML, no cargo —
+so it can run on the fast line and so the number does not depend on a build
+succeeding.
+
+What each row counts:
+
+  ladder knobs      fields on the typed `[knobs.*]` structs in
+                    `nros-board-common`. These are the knobs that have a
+                    platform and board rung and that `nros config explain`
+                    reports. This is the number the phase exists to RAISE.
+
+  Kconfig symbols   `config NROS_*` DECLARATIONS in Kconfig files — declared,
+                    not referenced, because a symbol read in ten places is one
+                    knob.
+
+  build-script env  distinct `NROS_*` names a `build.rs` reads from the
+                    environment. Not every `NROS_*` in the tree: a name that
+                    only cmake sets and cmake reads is not a build-script knob.
+
+  ZPICO_* env       the same, for the zenoh-pico tenant's own namespace.
+
+A knob counted in the ladder MAY also still appear as env — that is the point:
+migrating keeps the env name as the front-end. The ladder number rising is the
+signal, not the env number falling to zero.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# The ratchet. "The ladder knob count rises" is the wave gate, and a count that
+# only ever rises is enforceable where a count that "should fall" is not: an
+# env name legitimately SURVIVES migration as the front-end, so the env rows are
+# reported, never gated. Raise this when a tenant lands.
+LADDER_FLOOR = 13
+
+
+def tracked(*globs):
+    out = subprocess.check_output(
+        ["git", "-C", ROOT, "ls-files", *globs], text=True
+    ).split()
+    return [os.path.join(ROOT, p) for p in out]
+
+
+def read(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def _struct_fields(src, struct):
+    """The `pub` field names of one struct. Factored out so the selftest can
+    drive it on synthetic input rather than on the real file."""
+    m = re.search(r"pub struct " + struct + r"\s*\{(.*?)\n\}", src, re.S)
+    if not m:
+        return []
+    body = re.sub(r"(?m)^\s*(///|//).*$", "", m.group(1))
+    return sorted(set(re.findall(r"(?m)^\s*pub ([a-z_][a-z0-9_]*)\s*:", body)))
+
+
+def ladder_knobs():
+    """Fields on the typed `[knobs.*]` structs — the migrated knobs."""
+    src = read(os.path.join(ROOT, "packages/boards/nros-board-common/src/platform_config.rs"))
+    total = {}
+    for struct in ("TxKnobs", "ExecutorKnobs", "TransportKnobs"):
+        fields = _struct_fields(src, struct)
+        if fields:
+            total[struct] = fields
+    return total
+
+
+def kconfig_symbols():
+    syms = set()
+    for p in tracked("*Kconfig", "*Kconfig.*", "*/Kconfig"):
+        for m in re.finditer(r"(?m)^\s*(?:menu)?config\s+(NROS_[A-Z0-9_]+)", read(p)):
+            syms.add(m.group(1))
+    return syms
+
+
+def _env_names_in(txt, prefix):
+    """`<PREFIX>_*` names READ from the environment in one source string.
+
+    Comments are stripped first: a knob named in a comment is documentation,
+    not a reader, and counting it inflates the number this gate exists to
+    track. Factored out so the selftest drives it on synthetic input.
+    """
+    stripped = re.sub(r"(?m)^\s*(///|//).*$", "", txt)
+    return set(
+        m.group(1)
+        for m in re.finditer(
+            r'(?:env::var|env::var_os|env|env_usize|env_bool|knob_usize|knob_bool)'
+            r'\s*\(\s*&?"(' + prefix + r'_[A-Z0-9_]+)"',
+            stripped,
+        )
+    )
+
+
+def build_script_env(prefix):
+    """`<PREFIX>_*` names a build.rs reads from the environment."""
+    names = set()
+    for p in tracked("*build.rs"):
+        names |= _env_names_in(read(p), prefix)
+    return names
+
+
+def self_test() -> None:
+    """Negative controls for both counters, on synthetic input.
+
+    On the normal path, not behind a flag — `check-gate-selftests` requires it,
+    on the reasoning that a control nobody runs decays into a comment. This
+    census earns the scepticism twice over: it is a COUNTING gate, so a regex
+    that silently matches too much or too little still prints a plausible
+    number, and a wrong baseline is worse than none because it looks measured.
+    """
+    # The env matcher must see the idioms build scripts actually use...
+    for src in (
+        'let n = env_usize("NROS_EXECUTOR_MAX_CBS", 4);',
+        'std::env::var("NROS_THING").ok()',
+        'nros_zephyr_build::knob_usize("NROS_OTHER", &k, 1)',
+    ):
+        assert _env_names_in(src, "NROS"), f"selftest: missed a read in {src!r}"
+    # ...and must not count a name it merely MENTIONS, or another prefix.
+    for src in (
+        '// NROS_EXECUTOR_MAX_CBS was read here once',
+        'println!("set NROS_THING");',
+        'let n = env_usize("ZPICO_TX_BATCH", 0);',
+    ):
+        assert not _env_names_in(src, "NROS"), f"selftest: false positive on {src!r}"
+
+    # The ladder counter reads STRUCT FIELDS, so it must not count a doc
+    # comment, a non-`pub` field, or a field of a struct it was not asked for.
+    src = (
+        "pub struct TxKnobs {\n"
+        "    /// pub not_a_field: usize,\n"
+        "    pub batch: Option<bool>,\n"
+        "    private: usize,\n"
+        "}\n"
+        "pub struct Unrelated {\n    pub nope: usize,\n}\n"
+    )
+    fields = _struct_fields(src, "TxKnobs")
+    assert fields == ["batch"], f"selftest: ladder counter read {fields!r}"
+
+
+def main() -> int:
+    self_test()
+    ladder = ladder_knobs()
+    n_ladder = sum(len(v) for v in ladder.values())
+    kconfig = kconfig_symbols()
+    nros_env = build_script_env("NROS")
+    zpico_env = build_script_env("ZPICO")
+
+    print("phase-400 config census")
+    print()
+    print(f"  {'where configuration lives':<34} count")
+    print(f"  {'-' * 34} -----")
+    print(f"  {'knobs in the RFC-0049 ladder':<34} {n_ladder}")
+    for struct, fields in sorted(ladder.items()):
+        print(f"      {struct:<30} {len(fields)}")
+    print(f"  {'Kconfig CONFIG_NROS_* declarations':<34} {len(kconfig)}")
+    print(f"  {'NROS_* env read by a build.rs':<34} {len(nros_env)}")
+    print(f"  {'ZPICO_* env read by a build.rs':<34} {len(zpico_env)}")
+
+    if "--check" in sys.argv and n_ladder < LADDER_FLOOR:
+        sys.stderr.write(
+            f"config-knob-census: FAILED — the ladder holds {n_ladder} knob(s), "
+            f"below the {LADDER_FLOOR} recorded floor.\n"
+            "  A knob leaving the ladder is a knob losing its platform and board\n"
+            "  rung and its `nros config explain` row. If that is deliberate,\n"
+            "  lower LADDER_FLOOR in this file and say why in the commit.\n"
+        )
+        return 1
+
+    if "--verbose" in sys.argv:
+        print()
+        for label, items in (
+            ("Kconfig", kconfig),
+            ("NROS_* env", nros_env),
+            ("ZPICO_* env", zpico_env),
+        ):
+            print(f"  {label}:")
+            for n in sorted(items):
+                print(f"    {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #140.

## The gate could not be evaluated

Every wave in phase-400 is gated on "the ladder knob count rises … **measured the same way as the table at the top**", and that table records no method. Two people counting by hand get two numbers, so no wave could show it moved anything.

`just check config-knob-census` is that method — buildless, on the fast line, with a ratchet:

```
knobs in the RFC-0049 ladder       13     (8 executor · 3 zenoh.tx · 2 transport)
Kconfig CONFIG_NROS_* declarations 85
NROS_* env read by a build.rs      31
ZPICO_* env read by a build.rs      5
```

**Do not read `3 → 13` as this phase's delta** — the doc says so too. The `3` was counted by an unknown method, so the rows are not comparable term-for-term. What is now true is that the number is reproducible.

Only the **ladder** count is gated, and only downward. An env name legitimately survives migration — it stays the front-end — so "the env count falls to zero" was never the goal and gating it would punish the design. A knob *leaving* the ladder loses its platform and board rung and its `nros config explain` row, which is worth refusing.

## The executor tenant

Less was missing than the doc implied, and something else was. `ExecutorKnobs`, `resolve_executor` and both production callers already existed — I duplicated the resolver before the compiler caught it, and my first reading ("declared but no reader") was wrong: `config.rs` and `model_ingest.rs` call it, which a grep for `ExecutorKnobs` misses.

What was actually missing: **two of the eight knobs were invisible to `nros config explain`** — in a report whose entire job is to say where a value came from. `action_clients` and `arena_size` have *derived* defaults, so they did not fit the `&[(&str, usize)]` table the other six were listed in, and were left out.

Neither derivation is duplicated to fix it: `action_clients` defaults to the **resolved** `max_cbs` (build.rs then clamps to it, so the default *is* the clamp), and `arena_size` defaults to `0` — the documented Kconfig sentinel for "derive it" — printed as `derived`. `nros-node/build.rs` stays the one place that knows the arena formula.

Verified against the running tool, both halves of the wave's own gate:

```
executor.arena_size                derived    builtin  [NROS_EXECUTOR_ARENA_SIZE]
$ NROS_EXECUTOR_MAX_CBS=17 nros config explain --platform posix
executor.max_cbs                   17         env      [NROS_EXECUTOR_MAX_CBS]
executor.action_clients            17         builtin  [NROS_EXECUTOR_ACTION_CLIENTS]
```

## Recorded, not fixed

The platform/board rungs **do not reach a bare `cargo build`**. `nros-node/build.rs` resolves env → Kconfig → default and never opens the platform or board TOML, so a build outside cmake still compiles at crate defaults — the failure `ExecutorKnobs`'s own doc comment describes. Closing it is a decision about core's dependency graph (`nros-node`'s build-deps are deliberately "dependency-free"; the ladder lives in `nros-board-common`, which `nros-zpico-build` *does* depend on). The phase doc now states both options rather than picking one silently.

The census carries its own negative controls, which `check-gate-selftests` requires — and they earned their keep immediately: writing them surfaced that the matcher missed `env::var_os` and `&"NAME"`, so the first number I recorded (27) was low. It is 31.

`just ci-l1` green; `just check fast` 147/147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG