### PR TITLE
docs(phase-408): closed as delivered by phase-403 W3/W5

### DIFF
--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1005,6 +1005,13 @@ should treat that doc as the specification and these commits as its delivery --
 or close phase-408 as delivered, citing this. The two should not both land as
 open work.
 
+**Closed as delivered 2026-08-31**, by phase-408's author, citing this
+section. That doc now carries a DELIVERED status pointing here, keeps its
+waves as the acceptance criteria this phase's measurement can be read
+against, and records the premise it got wrong: "C/C++ has no site that names
+the type" is true of the hand-written C API and not of C++, where
+`bind_subscription<M, C, Method>` keeps `M` to the last call.
+
 One correction to carry across: phase-408 scopes itself to "the C and C++ path",
 and the C++ path turned out NOT to need the ABI work the phase anticipated.
 `NROS_SUBSCRIBE` -> `create_subscription<M, C, Method>` -> `bind_subscription`

--- a/docs/roadmap/phase-408-cpp-message-derived-buffers.md
+++ b/docs/roadmap/phase-408-cpp-message-derived-buffers.md
@@ -116,6 +116,11 @@ about anything.
 
 ## Waves
 
+**All of the below are delivered by phase 403 W3/W5 except where noted. They are
+kept as written, because the acceptance criteria are the useful part and phase
+403's measurement should be readable against them.**
+
+
 **W1 — emit the constant.** Issue 0896 layers 1–2: one traversal in
 `rosidl-codegen` that builds the `nros_serdes::FieldType` value alongside the
 existing expression string, so a new variant handled by one output and forgotten


### PR DESCRIPTION
phase-403 was implementing the same conclusion from a bring-up on the day phase-408 was written from a design review. Its "Relationship to phase-408" section offered the choice of treating 408 as the specification or closing it as delivered, and asked that the two not both land as open work.

This is that close, by 408's author.

**Verified in the tree, not taken on the summary.** `add_arena_subscription_c_callback` derives `rx_bytes` from `rx_buffer_hint` when the caller states one, falling back to `RX_BUF` otherwise, and spends that on `buffered_region_size` and the `TripleBuffer`/`SpscRing` init — 408 W3 exactly. `bind_subscription` supplies `M::SERIALIZED_SIZE_MAX` where the type is erased — W4's delivery.

The waves stay as written rather than deleted: the acceptance criteria are the useful residue, and phase-403's measurement should be readable against them.

**One premise of 408 was wrong, and the correction is worth more than the document.** It asserts "C/C++ has no site that names the type". True of the hand-written C API; not true of C++, where `NROS_SUBSCRIBE` reaches `bind_subscription` with `M` still a template parameter, in a header, and the arena owns the buffer there. The type-erased framing came from issue 0896 — which is about the C path — and was carried one language too far.

phase-403 gains a line recording the close, so the relationship reads correctly from either end.

Docs only. Two local gates fail in a fresh worktree with `nros: command not found` (no `setup-cli` run); unrelated to this diff.
