### PR TITLE
fix(#0911, #0966): the zenoh-pico rebuild edge reaches main, and stop rebuilding it every time

### DIFF
--- a/changelog.d/0966.fix.md
+++ b/changelog.d/0966.fix.md
@@ -1,0 +1,1 @@
+zenoh builds no longer recompile zpico-sys on every invocation

--- a/docs/issues/archived/0911-zpico-sys-no-rebuild-edge-on-zenoh-pico-sources.md
+++ b/docs/issues/archived/0911-zpico-sys-no-rebuild-edge-on-zenoh-pico-sources.md
@@ -77,6 +77,36 @@ This shared id 902 with "action goal completion is variable" -- two unrelated
 open issues under one number, which is exactly the confusion this ledger exists
 to prevent. Renumbered to 911; the action issue keeps 902.
 
+## Correction: the fix did not reach main until 2026-08-31
+
+This was archived as resolved on the strength of `73a14a0dd`, which lives only
+on `origin/feat/zenoh-pico-1.10` and has never been merged. Main kept the
+five-file watch, so the bug was LIVE for everyone reading this issue as closed —
+and it cost another wrong-binary cycle on 2026-08-31, in exactly the way the
+symptom section describes.
+
+The watch change is separable from the 1.10 upgrade it was committed alongside,
+so it has now been ported to main on its own: two `rerun-if-changed` lines for
+the `zenoh-pico/src` and `zenoh-pico/include` trees. The rest of `73a14a0dd`
+(the `@TOKEN@` defaults, and the platform manifests naming files 1.10 deleted)
+is 1.10-specific and stays on that branch.
+
+Re-verified on main against the acceptance below:
+
+* an edit to `src/protocol/iobuf.c` — absent from the old list — recompiles;
+* a no-op build after it recompiles nothing.
+
+The second one did NOT hold at first, for an unrelated reason that this issue's
+acceptance criterion is what surfaced: `zpico-sys` was recompiling on every
+invocation because of a `rerun-if-changed` on a path that does not exist. That
+is [[issue-0966]].
+
+**Lesson for the ledger, not for this bug:** an issue may only be archived
+against a commit reachable from `main`. Archiving against work on a feature
+branch produces a closed issue and a live defect, which is worse than leaving it
+open — the next person reads "resolved" and trusts a build that is lying to
+them.
+
 ## Resolved
 
 `nros-zpico-build` now watches `zenoh-pico/src` and `zenoh-pico/include` as

--- a/docs/issues/archived/0966-zpico-sys-always-dirty-from-missing-watch-path.md
+++ b/docs/issues/archived/0966-zpico-sys-always-dirty-from-missing-watch-path.md
@@ -1,0 +1,86 @@
+---
+id: 966
+title: "`zpico-sys` recompiled on EVERY cargo invocation — a `rerun-if-changed` on a path that does not exist"
+status: resolved
+type: bug
+area: build, rmw
+related: [issue-0490, issue-0911, issue-0899]
+---
+
+## What happened
+
+Every `cargo build` in a zenoh-enabled tree recompiled `zpico-sys` and
+`nros-rmw-zenoh`, warm or not. Not slow, not failing — just never fresh.
+
+`CARGO_LOG=cargo::core::compiler::fingerprint=info` names it in one line:
+
+    stale: missing ".../packages/platform/bare-metal/nros-platform.toml"
+
+`nros-zpico-build` emitted the CROSS PRODUCT of (platform search roots) x
+(platform names):
+
+    for root in &platform_search_path {
+        for name in tree.names() {
+            println!("cargo:rerun-if-changed={}", root.join(name).join(FILENAME));
+        }
+    }
+
+A platform's manifest lives under exactly ONE root. With both
+`packages/platform` and `config` on the search path (phase-400 W1 made it a path
+rather than a single directory), `bare-metal` — which lives in `config/` — also
+produced `packages/platform/bare-metal/nros-platform.toml`, which does not
+exist. Cargo treats a missing `rerun-if-changed` input as permanently dirty, so
+that single path invalidated the crate and everything above it, forever.
+
+## Same class as issue 0490
+
+0490 was the same failure one crate over: a `rerun-if-changed` pointing at
+`../nros-rmw-abi` after the crate moved, so the path named a directory that did
+not exist and `nros-rmw-cffi` rebuilt on every invocation. CLAUDE.md already
+records the rule — *"cargo treats a MISSING `rerun-if-changed` input as
+permanently dirty (`StaleItem(MissingFile)`) … Silent: the build always
+succeeded, it was just never fresh"*.
+
+What is new here is the SHAPE. 0490 was one stale hand-written path. This one is
+generated, and it became wrong the moment the search path grew a second root:
+the loop was correct when there was one root and silently wrong afterwards.
+
+## Fix
+
+Emit only the manifests that exist. One `is_file()` guard.
+
+The trade, stated in the code: a manifest CREATED later under a higher-priority
+root does not by itself trigger a rebuild. Cargo cannot watch a nonexistent path
+without being permanently dirty, so watching what exists is the only stable
+option, and authoring a new platform descriptor is a deliberate act that arrives
+with other edits. `PlatformsTree` merges by name and does not record which root
+each came from; if it ever does, watch exactly those instead and the trade
+disappears.
+
+## Measured
+
+    before:  no-op `cargo build` -> 2 crates recompiled, every time
+    after:   no-op `cargo build` -> 0
+
+and the rebuild edge still works: touching
+`zenoh-pico/src/protocol/iobuf.c` recompiles, and the following no-op is clean
+again.
+
+## How it was found
+
+Looking for [[issue-0911]] (the opposite defect — editing zenoh-pico rebuilt
+NOTHING) and discovering its fix had never reached main. Porting that fix made
+the always-dirty behaviour visible, because "does a no-op rebuild recompile
+anything" is 0911's own first acceptance criterion and it failed for a reason
+that had nothing to do with 0911.
+
+Worth recording: my first measurement blamed the port. The control run — the
+same build with my change stashed — also rebuilt, which looked like proof the
+problem was pre-existing. It was, but the control was contaminated: `git stash`
+rewrites the file's mtime, so both arms were dirty for a reason I had introduced
+by measuring. Only a straight build-twice-with-no-git-in-between separated them.
+
+## Acceptance
+
+* ~~A no-op build recompiles nothing.~~ Met.
+* ~~An edit under the compiled zenoh-pico set still rebuilds.~~ Met.

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -672,14 +672,36 @@ pub fn run() {
             }
             // Watch every root, not just the one a descriptor happens to live
             // in today: moving a file between roots must invalidate the build.
+            // issue 0966 — emit only the manifests that EXIST.
+            //
+            // This is a cross product of (search roots) x (platform names), and
+            // a given platform's manifest lives under exactly ONE root: with
+            // `packages/platform` and `config` both on the path, `bare-metal`
+            // (which lives in `config/`) also produced
+            // `packages/platform/bare-metal/nros-platform.toml`, which does not
+            // exist. Cargo treats a MISSING `rerun-if-changed` input as
+            // permanently dirty, so that one path recompiled `zpico-sys` and
+            // everything above it on EVERY invocation — silently, because the
+            // build always succeeded, it was just never fresh
+            // (`stale: missing .../packages/platform/bare-metal/nros-platform.toml`
+            // under `CARGO_LOG=cargo::core::compiler::fingerprint=info`).
+            // Same class as issue 0490.
+            //
+            // The trade in filtering: a manifest CREATED later under a
+            // higher-priority root does not by itself trigger a rebuild. Cargo
+            // cannot watch a nonexistent path without being permanently dirty,
+            // so watching what exists is the only stable option, and authoring a
+            // new platform descriptor is a deliberate act that comes with other
+            // edits. `PlatformsTree` does not record which root each name was
+            // loaded from; if it ever does, watch exactly those instead.
             for root in &platform_search_path {
                 for name in tree.names() {
-                    println!(
-                        "cargo:rerun-if-changed={}",
-                        root.join(name)
-                            .join(platform_config::PLATFORM_CONFIG_FILENAME)
-                            .display()
-                    );
+                    let manifest = root
+                        .join(name)
+                        .join(platform_config::PLATFORM_CONFIG_FILENAME);
+                    if manifest.is_file() {
+                        println!("cargo:rerun-if-changed={}", manifest.display());
+                    }
                 }
             }
             let m = tree.as_platform_manifest();
@@ -1349,11 +1371,24 @@ pub fn run() {
     // shadow the OUT_DIR-generated header on the bare-metal shim include path;
     // deleted in the #135 fix (every TU now consumes the generated config).
     println!("cargo:rerun-if-changed=c/platform/zenoh_generic_platform.h");
-    println!("cargo:rerun-if-changed=zenoh-pico/src/system/unix/network.c");
-    println!("cargo:rerun-if-changed=zenoh-pico/include/zenoh-pico/system/platform/unix.h");
-    println!("cargo:rerun-if-changed=zenoh-pico/src/system/freertos/system.c");
-    println!("cargo:rerun-if-changed=zenoh-pico/src/system/freertos/lwip/network.c");
-    println!("cargo:rerun-if-changed=zenoh-pico/src/net/primitives.c");
+    // Watch the TREES, not a list of files (issue 0911).
+    //
+    // This used to name five zenoh-pico sources out of the several hundred the
+    // build actually compiles. Everything else — protocol, transport, codec,
+    // collections, the link implementations — had no rebuild edge, so patching
+    // one of them changed nothing: cargo saw no watched input move, skipped the
+    // build script, and the test ran against a binary without the edit. That
+    // does not fail; it produces a green run whose conclusion is about code that
+    // was never compiled. It cost a full measure-fix-measure cycle in issue 0899
+    // and nearly produced a "the fix does not work" verdict about a fix that had
+    // never been built.
+    //
+    // `cargo:rerun-if-changed` accepts a directory and cargo walks it, so two
+    // lines cover the compiled set with no list to maintain. The cost is that any
+    // touch under these trees re-runs the build script; for a vendored library
+    // that changes only when someone patches it, that is the right trade.
+    println!("cargo:rerun-if-changed=zenoh-pico/src");
+    println!("cargo:rerun-if-changed=zenoh-pico/include");
     println!("cargo:rerun-if-changed=c/zenoh-pico-version.h.in");
     println!("cargo:rerun-if-changed=zenoh-pico/version.txt");
     println!("cargo:rerun-if-changed=src/ffi.rs");


### PR DESCRIPTION
TWO OPPOSITE DEFECTS on the same build script. One made an edit compile nothing;
the other made everything compile always.

#0911 — ARCHIVED AS RESOLVED AGAINST A COMMIT THAT NEVER REACHED MAIN.
`73a14a0dd` lives only on `origin/feat/zenoh-pico-1.10`. Main kept the five-file
watch, so the bug was live for everyone reading the issue as closed, and it cost
another wrong-binary cycle today: a fix "verified" against a binary that did not
contain it, producing identical numbers and very nearly a "the fix does not work"
verdict. The watch change is separable from the 1.10 upgrade it was committed
beside, so it is ported alone — two `rerun-if-changed` lines for the
`zenoh-pico/src` and `zenoh-pico/include` trees, replacing five hand-listed files
out of the several hundred the build compiles. The rest of that commit (the
`@TOKEN@` defaults, manifests naming files 1.10 deleted) stays on its branch.

I have also written the ledger rule into 0911: an issue may only be archived
against a commit reachable from `main`. A closed issue over a live defect is
worse than an open one — the next person trusts a build that is lying.

#0966 — AND THE PORT EXPOSED THAT `zpico-sys` REBUILT ON EVERY INVOCATION.
0911's own first acceptance criterion is "a no-op rebuild recompiles nothing",
and it failed for an unrelated reason:

    stale: missing ".../packages/platform/bare-metal/nros-platform.toml"

The script emitted the CROSS PRODUCT of (platform search roots) x (platform
names). A manifest lives under exactly one root, so with both
`packages/platform` and `config` on the path — phase-400 W1 made it a path
rather than a directory — `bare-metal` also produced a
`packages/platform/bare-metal/…` path that does not exist. Cargo treats a
missing `rerun-if-changed` input as permanently dirty, so one nonexistent path
invalidated the crate and everything above it, forever, silently. Same class as
#0490; new in that the path is GENERATED and became wrong the moment the search
path grew a second root.

Fixed with an `is_file()` guard. The trade is in the code: a manifest created
later under a higher-priority root will not by itself trigger a rebuild, because
cargo cannot watch a nonexistent path without being permanently dirty.
`PlatformsTree` merges by name without recording origins; if it ever records
them, watch exactly those and the trade disappears.

MEASURED:

    no-op `cargo build`   before: 2 crates recompiled, every time
                          after:  0
    touch iobuf.c         recompiles (it was absent from the old watch list)
    then no-op            0 again

A METHOD NOTE, because my first reading was wrong. I blamed the port, then ran a
control with my change stashed — it also rebuilt, which looked like proof the
problem pre-existed. It did, but the control was contaminated: `git stash`
rewrites mtimes, so both arms were dirty for a reason I created by measuring.
Only build-twice-with-no-git-in-between separated them.

149/149 fast gates.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk