### PR TITLE
fix(0949): publish the workspace root — board facts never reached a migrated workspace

### DIFF
--- a/cmake/NanoRosWorkspace.cmake
+++ b/cmake/NanoRosWorkspace.cmake
@@ -244,6 +244,27 @@ function(nano_ros_workspace)
     get_filename_component(_NRW_WORKSPACE_ROOT "${_NRW_WORKSPACE_ROOT}"
         ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
+    # issue 0949 — PUBLISH it. `nros_resolve_board_facts` looks for the
+    # workspace in this order:
+    #
+    #     NROS_WORKSPACE_DIR -> APPLICATION_SOURCE_DIR -> CMAKE_SOURCE_DIR
+    #
+    # and NOTHING SET THE FIRST ONE. So a GENERATED root fell through to
+    # `CMAKE_SOURCE_DIR`, which for RFC-0065 D8 is `build/<coord>/` — a
+    # directory with no `system.toml`. Board facts were therefore never
+    # delivered for a migrated workspace: no NROS_BOARD, no NROS_BOARD_TOML, no
+    # NROS_NETSTACK, for embedded images too. The resolution above already knew
+    # the right answer; it just kept it to itself.
+    #
+    # CACHE INTERNAL because board-facts resolves in a different scope, and a
+    # plain `set()` here dies with this function's frame — the `_NROS_ENTRY_DIR`
+    # pitfall.
+    #
+    # NB the near-homonym above: `_NROS_WORKSPACE_DIR` (underscore) is the cmake
+    # MODULE directory, unrelated to this. Pre-existing, and worth reading twice.
+    set(NROS_WORKSPACE_DIR "${_NRW_WORKSPACE_ROOT}"
+        CACHE INTERNAL "issue 0949: the workspace root board-facts resolves from")
+
     # Defaults: backend = zenoh, platform = posix, ROS edition = humble.
     if(NOT _NRW_BACKEND)
         set(_NRW_BACKEND zenoh)


### PR DESCRIPTION
One `set()`. Split out of #138 so it can land on its own.

`nros_resolve_board_facts` looks for the workspace as

    NROS_WORKSPACE_DIR -> APPLICATION_SOURCE_DIR -> CMAKE_SOURCE_DIR

and **nothing set the first one**. Meanwhile `nano_ros_workspace` already receives `WORKSPACE_ROOT` from the generated root (`cmake_root.rs` writes it) and resolves it carefully — then keeps it to itself.

So a GENERATED root fell through to `CMAKE_SOURCE_DIR`, which for RFC-0065 D8 is `build/<coord>/` — a directory with no `system.toml`. Board facts were never delivered for a migrated workspace: no `NROS_BOARD`, no `NROS_BOARD_TOML`, no `NROS_NETSTACK`, embedded images included.

**#0951 did not touch this.** It changed which KEY holds site config (`[deploy.<t>.nros]` → `[board_config.<board>]`); this is about which FILE is read at all. Orthogonal — which is why the defect survived a redesign of the same area.

## Measured

`examples/workspaces/mixed`, `demo_bringup:freertos`:

```
BEFORE  board facts NOT delivered from .../mixed/build/freertos-zenoh-mps2-an385-freertos
AFTER   board facts from .../examples/workspaces/mixed — 5 value(s) delivered to cargo
```

The first attempt at that measurement was **invalid** and announced itself by printing identical lines: `NROS_WORKSPACE_DIR` is `CACHE INTERNAL`, so the "before" configure read what the fixed one had cached. `cmake -U NROS_BOARD_FACTS_ENV*` alone does not clear it.

`CACHE INTERNAL` rather than a plain `set()`: board-facts resolves in a different scope and a normal variable dies with the function frame (the `_NROS_ENTRY_DIR` pitfall).

`just check fast`: 148 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa