### PR TITLE
phase-407 + phase-410: the scope you name is the specification, and CI is breadth × depth

### DIFF
--- a/.github/workflows/build-wide.yml
+++ b/.github/workflows/build-wide.yml
@@ -1,0 +1,81 @@
+# BUILD + LINK, wide — the mandatory promise (phase-410 W2).
+#
+# CI is BREADTH x DEPTH, and only DEPTH is expensive:
+#
+#   breadth  which coordinates a run visits   tier1 tier2 nightly full   low cost
+#   depth    what it does with each           build+link | build+run     HIGH cost
+#
+# MEASURED 2026-08-31: `just ci l3` — cross build + link plus ELF symbol
+# interrogation, no QEMU and no tests — is 46 s. The tier-2 RUN over the same
+# tree is 9.5 min on top of an 11 min warm fixture rebuild. Depth is ~25x
+# breadth, so build depth can afford to gate every merge and run depth cannot.
+#
+# "It compiles and links for every target" is the regression that hurts most and
+# costs least to catch. That is this lane.
+#
+# WHY push(main) AND NOT the merge queue
+#
+# The queue's budget is the required `CI` context, deliberately cheap so ten
+# agents can land (phase-395). This runs AFTER a merge, where its job is to
+# bound how far a link regression travels — one commit, not one nightly.
+#
+# WHY cancel-in-progress IS correct here and is NOT correct for run-depth
+#
+# A newer commit's answer subsumes an older one's, and at 46 s this run
+# FINISHES before the next merge arrives. A 20-minute run-depth lane under the
+# same setting starves: with ten agents landing through a queue that batches
+# four, each merge cancels the last and the tier completes never — a lane that
+# always cancels looks busy while reporting nothing. Run depth is on a clock,
+# in the `run-*` workflows.
+name: build-wide
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: build-wide-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  l3:
+    name: build + link (cross ELFs, no boot)
+    # Gated for the same reason as post-submit's tier-2 job: this needs the RTOS
+    # cross toolchains, and a job that cannot start is not a signal.
+    if: ${{ vars.NROS_SELF_HOSTED_READY == 'true' }}
+    runs-on: [self-hosted, linux, nros-sdk-zephyr, nros-big]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify this runner's labels are true
+        run: ./scripts/ci/runner-doctor.sh nros-sdk-zephyr,nros-big
+      # phase-407: a CI job is `just setup <scope>` then one command a developer
+      # can type. Nothing here is CI-only orchestration.
+      - name: just setup tier2
+        run: |
+          source ./activate.sh
+          just setup tier2
+      - name: just ci l3
+        run: |
+          source ./activate.sh
+          just ci l3
+      - name: Sweep orphans and disk
+        if: always()
+        run: ./scripts/ci/runner-sweep.sh || true
+
+  coverage:
+    name: coverage report (did build-wide run?)
+    needs: [l3]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Report whether the interlocked lane ran
+        run: ./scripts/ci/report-interlock-coverage.sh "build + link (cross ELFs, no boot)" "${{ needs.l3.result }}" "${{ vars.NROS_SELF_HOSTED_READY }}"

--- a/.github/workflows/build-wide.yml
+++ b/.github/workflows/build-wide.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify this runner's labels are true
         run: ./scripts/ci/runner-doctor.sh nros-sdk-zephyr,nros-big
-      # phase-407: a CI job is `just setup <scope>` then one command a developer
+      # phase-411: a CI job is `just setup <scope>` then one command a developer
       # can type. Nothing here is CI-only orchestration.
       - name: just setup tier2
         run: |

--- a/.github/workflows/build-wide.yml
+++ b/.github/workflows/build-wide.yml
@@ -5,8 +5,8 @@
 #   breadth  which coordinates a run visits   tier1 tier2 nightly full   low cost
 #   depth    what it does with each           build+link | build+run     HIGH cost
 #
-# MEASURED 2026-08-31: `just ci l3` — cross build + link plus ELF symbol
-# interrogation, no QEMU and no tests — is 46 s. The tier-2 RUN over the same
+# MEASURED 2026-08-31: `just ci matrix build` — cross build + link plus ELF
+# symbol interrogation, no QEMU and no tests — is 27-46 s. The tier-2 RUN over the same
 # tree is 9.5 min on top of an 11 min warm fixture rebuild. Depth is ~25x
 # breadth, so build depth can afford to gate every merge and run depth cannot.
 #
@@ -21,7 +21,7 @@
 #
 # WHY cancel-in-progress IS correct here and is NOT correct for run-depth
 #
-# A newer commit's answer subsumes an older one's, and at 46 s this run
+# A newer commit's answer subsumes an older one's, and at well under a minute this run
 # FINISHES before the next merge arrives. A 20-minute run-depth lane under the
 # same setting starves: with ten agents landing through a queue that batches
 # four, each merge cancels the last and the tier completes never — a lane that
@@ -62,10 +62,13 @@ jobs:
         run: |
           source ./activate.sh
           just setup tier2
-      - name: just ci l3
+      # `ci matrix build` — the (breadth, depth) pair, not a lane letter.
+      # phase-410 W4: `l3` survives as the implementation; this spelling says
+      # WHICH breadth at WHICH depth, which is what the file is for.
+      - name: just ci matrix build
         run: |
           source ./activate.sh
-          just ci l3
+          just ci matrix build
       - name: Sweep orphans and disk
         if: always()
         run: ./scripts/ci/runner-sweep.sh || true

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -265,7 +265,7 @@ jobs:
                  exit 1; }
           echo "after workspace ($(wc -l < build/ci-logs/workspace.log) lines suppressed):"; df -h / | tail -1
 
-      # phase-407 — run the TIER, not a hand-rolled approximation of it.
+      # phase-411 — run the TIER, not a hand-rolled approximation of it.
       #
       # This lane built `native build-fixture-rust-core` + `build-workspace-
       # fixtures` and then `just test-integration`, which is roughly tier 1 —

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -265,30 +265,29 @@ jobs:
                  exit 1; }
           echo "after workspace ($(wc -l < build/ci-logs/workspace.log) lines suppressed):"; df -h / | tail -1
 
-      - name: just test-integration
+      # phase-407 — run the TIER, not a hand-rolled approximation of it.
+      #
+      # This lane built `native build-fixture-rust-core` + `build-workspace-
+      # fixtures` and then `just test-integration`, which is roughly tier 1 —
+      # and "roughly" is the problem: `check-tier-has-ci-owner` found Tier1
+      # declared in the RFC-0061 ladder and invoked by NO workflow, so the
+      # tier's definition and this lane's behaviour could drift with nothing
+      # to notice. `just ci tier1` is preconditions + check +
+      # rust-rtos-link-check + test-all, narrowed to the tier-1 coordinates.
+      #
+      # The fixture builds above stay: the tier ASSERTS its preconditions, it
+      # does not provision them.
+      - name: just ci tier1
         env:
-          # phase-407 W4 — NROS_FIXTURES_OPTIONAL is GONE from CI. Its job was
-          # converting an absent fixture into a skip, i.e. tolerating a mismatch
-          # between what this lane asked for and what it got. Under phase-407
-          # the scope IS the specification: this lane names `native`, so a gap
-          # in native is a FAILURE and nothing else was expected. The flag made
-          # correctness depend on remembering to unset a variable — this file's
-          # own comment admitted the full tier "leaves the var unset and still
-          # hard-fails".
-          #
-          # The READER in nros-tests survives on purpose: it is a legitimate
-          # local opt-in for a developer who has provisioned one platform.
-          # Deleting it would remove a real affordance to fix a CI-only defect.
-          # `check-ci-no-fixture-tolerance` enforces the where, not the what.
           CARGO_BUILD_JOBS: "2"
         run: |
           source ./activate.sh
           mkdir -p build/ci-logs
           set +e
-          just test-integration > build/ci-logs/test-integration.log 2>&1
+          just ci tier1 > build/ci-logs/ci-tier1.log 2>&1
           rc=$?
           set -e
-          echo "::group::test-integration output (tail)"; tail -200 build/ci-logs/test-integration.log; echo "::endgroup::"
+          echo "::group::ci tier1 output (tail)"; tail -200 build/ci-logs/ci-tier1.log; echo "::endgroup::"
           exit $rc
 
       - name: Report skipped fixtures (post-run)

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -267,7 +267,19 @@ jobs:
 
       - name: just test-integration
         env:
-          NROS_FIXTURES_OPTIONAL: "1"
+          # phase-407 W4 — NROS_FIXTURES_OPTIONAL is GONE from CI. Its job was
+          # converting an absent fixture into a skip, i.e. tolerating a mismatch
+          # between what this lane asked for and what it got. Under phase-407
+          # the scope IS the specification: this lane names `native`, so a gap
+          # in native is a FAILURE and nothing else was expected. The flag made
+          # correctness depend on remembering to unset a variable — this file's
+          # own comment admitted the full tier "leaves the var unset and still
+          # hard-fails".
+          #
+          # The READER in nros-tests survives on purpose: it is a legitimate
+          # local opt-in for a developer who has provisioned one platform.
+          # Deleting it would remove a real affordance to fix a CI-only defect.
+          # `check-ci-no-fixture-tolerance` enforces the where, not the what.
           CARGO_BUILD_JOBS: "2"
         run: |
           source ./activate.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -804,7 +804,7 @@ jobs:
       - name: Run bootstrap probe
         run: PROBE_BRANCH=probe-under-test ./scripts/probe/run-bootstrap-probe.sh
 
-  # phase-407 — tier 2 NIGHTLY, actually invoked.
+  # phase-411 — tier 2 NIGHTLY, actually invoked.
   #
   # This file's header has said "the 07:00 cron is also where
   # `just ci-matrix-nightly` lives" since RFC-0061, and three places echo that

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -803,3 +803,49 @@ jobs:
 
       - name: Run bootstrap probe
         run: PROBE_BRANCH=probe-under-test ./scripts/probe/run-bootstrap-probe.sh
+
+  # phase-407 — tier 2 NIGHTLY, actually invoked.
+  #
+  # This file's header has said "the 07:00 cron is also where
+  # `just ci-matrix-nightly` lives" since RFC-0061, and three places echo that
+  # string into a summary — but nothing ran it. `check-tier-has-ci-owner`
+  # found the tier declared in the ladder and owned by no workflow. Prose is
+  # not an owner.
+  #
+  # Interlocked like post-submit's tier-2 job: the pairwise cover needs the
+  # RTOS toolchains, so it is self-hosted, so a job that cannot start must not
+  # look like one that passed. `coverage-matrix-nightly` reports the skip.
+  matrix-nightly:
+    name: tier 2 nightly (pairwise cover)
+    if: ${{ vars.NROS_SELF_HOSTED_READY == 'true' }}
+    runs-on: [self-hosted, linux, nros-qemu, nros-sdk-zephyr, nros-big]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Verify this runner's labels are true
+        run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
+      - name: just setup tier2-nightly
+        run: |
+          source ./activate.sh
+          just setup tier2-nightly
+      - name: just ci matrix-nightly
+        run: |
+          source ./activate.sh
+          just ci matrix-nightly
+      - name: Sweep orphans and disk
+        if: always()
+        run: ./scripts/ci/runner-sweep.sh || true
+
+  coverage-matrix-nightly:
+    name: coverage report (did tier 2 nightly run?)
+    needs: [matrix-nightly]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Report whether the interlocked lane ran
+        run: ./scripts/ci/report-interlock-coverage.sh "tier 2 nightly (pairwise cover)" "${{ needs.matrix-nightly.result }}" "${{ vars.NROS_SELF_HOSTED_READY }}"

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -13,6 +13,18 @@
 # runs once per landed change and its job is to bound how far a regression can
 # travel before anyone notices.
 #
+# phase-410 — TIER 2 MOVED OUT, to `run-matrix.yml` on a clock.
+#
+# It ran here on `push(main)` with `cancel-in-progress: true`. That setting is
+# right for "is main good NOW", and fatal for a lane this long: measured
+# 2026-08-31, tier 2 is an 11 min warm fixture rebuild plus a 9.5 min run. With
+# ten agents landing through a merge queue that batches four, merges arrive
+# faster than that, so every run is cancelled by the next merge and the tier
+# COMPLETES NEVER — a lane that always cancels looks busy while reporting
+# nothing, which is worse than the skipped job phase-407 made visible.
+#
+# What stays here is `dep-chain`: hosted, 158 s, genuinely per-merge.
+#
 # WHAT THIS DOES NOT DO YET
 #
 # The plan names `ci-l4-tier1` — the tier-1 boards' cross-RUN coverage. That
@@ -85,71 +97,12 @@ jobs:
           source ./activate.sh
           just check dep-chain
 
-  matrix:
-    name: tier 2 (1-wise matrix)
-    # Gated for the same reason as queue.yml's L3: this needs the RTOS
-    # toolchains, and a job that cannot start is not a signal.
-    if: ${{ vars.NROS_SELF_HOSTED_READY == 'true' }}
-    runs-on: [self-hosted, linux, nros-qemu, nros-sdk-zephyr, nros-big]
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: false
-      - name: Verify this runner's labels are true
-        run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
-      # A lane answers two questions with different answers: which fixtures must
-      # be FRESH (its cell cover) and which must EXIST (a property of the run).
-      # `lane=tier2` is the build tier 2's run requires — see #482 / phase-340 W3.
-      # phase-407 W4 — a CI job is `just setup <scope>` then `just test <scope>`.
-      # Only the SCOPE differs between lanes, so this file reads as a transcript
-      # of a user session and "does CI do what I do?" is answerable by looking.
-      #
-      # What these two lines replaced: a `build-test-fixtures lane=tier2` step
-      # plus a `ci matrix` step, i.e. the lane vocabulary spelled twice with the
-      # reader left to know they must agree. `just test tier2` builds what that
-      # scope needs and runs exactly it.
-      - name: just setup tier2
-        run: |
-          source ./activate.sh
-          just setup tier2
-      # `just ci matrix`, NOT `just test tier2`. phase-407 W4 briefly used the
-      # latter and that was a COVERAGE REGRESSION caught by
-      # check-tier-has-ci-owner: the tier recipe is `_lane-gate` + `check` +
-      # `rust-rtos-link-check` + `test-all`, and `just test tier2` is only the
-      # last of those. Provisioning by scope + running the TIER keeps the
-      # transcript shape without quietly narrowing what runs.
-      - name: just ci matrix
-        run: |
-          source ./activate.sh
-          just ci matrix
-      - name: Upload junit and logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: post-submit-junit
-          path: |
-            target/nextest/**/junit*.xml
-            build/**/*.log
-          if-no-files-found: ignore
-          retention-days: 14
-      - name: Sweep orphans and disk
-        if: always()
-        run: ./scripts/ci/runner-sweep.sh || true
-
-  # phase-405 — make the interlocked job's SKIP visible in the run that skipped
-  # it. See scripts/ci/report-interlock-coverage.sh for why this warns rather
-  # than fails when no runner is registered, and fails when one supposedly is.
-  #
-  # `if: always()` so it reports on a skip; `needs` so it sees the result.
   coverage:
-    name: coverage report (did tier 2 run?)
-    needs: [dep-chain, matrix]
+    name: coverage report (did dep-chain run?)
+    needs: [dep-chain]
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Report whether the interlocked lane ran
-        run: ./scripts/ci/report-interlock-coverage.sh "tier 2 (1-wise matrix)" "${{ needs.matrix.result }}" "${{ vars.NROS_SELF_HOSTED_READY }}"
+        run: ./scripts/ci/report-interlock-coverage.sh "dep-chain" "${{ needs.dep-chain.result }}" "true"

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -115,10 +115,16 @@ jobs:
         run: |
           source ./activate.sh
           just setup tier2
-      - name: just test tier2
+      # `just ci matrix`, NOT `just test tier2`. phase-407 W4 briefly used the
+      # latter and that was a COVERAGE REGRESSION caught by
+      # check-tier-has-ci-owner: the tier recipe is `_lane-gate` + `check` +
+      # `rust-rtos-link-check` + `test-all`, and `just test tier2` is only the
+      # last of those. Provisioning by scope + running the TIER keeps the
+      # transcript shape without quietly narrowing what runs.
+      - name: just ci matrix
         run: |
           source ./activate.sh
-          just test tier2
+          just ci matrix
       - name: Upload junit and logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -21,7 +21,7 @@
 # ten agents landing through a merge queue that batches four, merges arrive
 # faster than that, so every run is cancelled by the next merge and the tier
 # COMPLETES NEVER — a lane that always cancels looks busy while reporting
-# nothing, which is worse than the skipped job phase-407 made visible.
+# nothing, which is worse than the skipped job phase-411 made visible.
 #
 # What stays here is `dep-chain`: hosted, 158 s, genuinely per-merge.
 #

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -103,14 +103,22 @@ jobs:
       # A lane answers two questions with different answers: which fixtures must
       # be FRESH (its cell cover) and which must EXIST (a property of the run).
       # `lane=tier2` is the build tier 2's run requires — see #482 / phase-340 W3.
-      - name: Build tier-2 fixtures
+      # phase-407 W4 — a CI job is `just setup <scope>` then `just test <scope>`.
+      # Only the SCOPE differs between lanes, so this file reads as a transcript
+      # of a user session and "does CI do what I do?" is answerable by looking.
+      #
+      # What these two lines replaced: a `build-test-fixtures lane=tier2` step
+      # plus a `ci matrix` step, i.e. the lane vocabulary spelled twice with the
+      # reader left to know they must agree. `just test tier2` builds what that
+      # scope needs and runs exactly it.
+      - name: just setup tier2
         run: |
           source ./activate.sh
-          just build-test-fixtures lane=tier2
-      - name: just ci matrix
+          just setup tier2
+      - name: just test tier2
         run: |
           source ./activate.sh
-          just ci matrix
+          just test tier2
       - name: Upload junit and logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -50,7 +50,7 @@ jobs:
       # A lane answers two questions with different answers: which fixtures must
       # be FRESH (its cell cover) and which must EXIST (a property of the run).
       # `lane=tier2` is the build tier 2's run requires — see #482 / phase-340 W3.
-      # phase-407 W4 — a CI job is `just setup <scope>` then `just test <scope>`.
+      # phase-411 W4 — a CI job is `just setup <scope>` then `just test <scope>`.
       # Only the SCOPE differs between lanes, so this file reads as a transcript
       # of a user session and "does CI do what I do?" is answerable by looking.
       #
@@ -62,7 +62,7 @@ jobs:
         run: |
           source ./activate.sh
           just setup tier2
-      # `just ci matrix`, NOT `just test tier2`. phase-407 W4 briefly used the
+      # `just ci matrix`, NOT `just test tier2`. phase-411 W4 briefly used the
       # latter and that was a COVERAGE REGRESSION caught by
       # check-tier-has-ci-owner: the tier recipe is `_lane-gate` + `check` +
       # `rust-rtos-link-check` + `test-all`, and `just test tier2` is only the

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -1,0 +1,103 @@
+# TIER 2 — build+run, 1-wise cover, ON A CLOCK (phase-410 W3).
+#
+# CI is BREADTH x DEPTH and only depth is expensive. This is RUN depth over the
+# 1-wise breadth: measured 2026-08-31, an 11 min warm fixture rebuild plus a
+# 9.5 min run, against 46 s for the build-depth lane in `build-wide.yml`.
+#
+# WHY A SCHEDULE AND NOT push(main)
+#
+# It used to live in `post-submit.yml` on `push(main)` with
+# `cancel-in-progress: true`. With ten agents landing through a merge queue,
+# merges arrive faster than 20 minutes, so each run was cancelled by the next
+# merge and the tier completed NEVER. A scheduled run always finishes.
+#
+# The cost is latency: a regression is caught within a cycle rather than within
+# a commit. That is the honest trade for a lane that actually reports.
+#
+# `cancel-in-progress: false` for the same reason — a newer schedule tick must
+# not cancel a run that is most of the way through.
+name: run-matrix
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: run-matrix
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  matrix:
+    name: tier 2 (1-wise matrix)
+    # Gated for the same reason as queue.yml's L3: this needs the RTOS
+    # toolchains, and a job that cannot start is not a signal.
+    if: ${{ vars.NROS_SELF_HOSTED_READY == 'true' }}
+    runs-on: [self-hosted, linux, nros-qemu, nros-sdk-zephyr, nros-big]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Verify this runner's labels are true
+        run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
+      # A lane answers two questions with different answers: which fixtures must
+      # be FRESH (its cell cover) and which must EXIST (a property of the run).
+      # `lane=tier2` is the build tier 2's run requires — see #482 / phase-340 W3.
+      # phase-407 W4 — a CI job is `just setup <scope>` then `just test <scope>`.
+      # Only the SCOPE differs between lanes, so this file reads as a transcript
+      # of a user session and "does CI do what I do?" is answerable by looking.
+      #
+      # What these two lines replaced: a `build-test-fixtures lane=tier2` step
+      # plus a `ci matrix` step, i.e. the lane vocabulary spelled twice with the
+      # reader left to know they must agree. `just test tier2` builds what that
+      # scope needs and runs exactly it.
+      - name: just setup tier2
+        run: |
+          source ./activate.sh
+          just setup tier2
+      # `just ci matrix`, NOT `just test tier2`. phase-407 W4 briefly used the
+      # latter and that was a COVERAGE REGRESSION caught by
+      # check-tier-has-ci-owner: the tier recipe is `_lane-gate` + `check` +
+      # `rust-rtos-link-check` + `test-all`, and `just test tier2` is only the
+      # last of those. Provisioning by scope + running the TIER keeps the
+      # transcript shape without quietly narrowing what runs.
+      - name: just ci matrix
+        run: |
+          source ./activate.sh
+          just ci matrix
+      - name: Upload junit and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-submit-junit
+          path: |
+            target/nextest/**/junit*.xml
+            build/**/*.log
+          if-no-files-found: ignore
+          retention-days: 14
+      - name: Sweep orphans and disk
+        if: always()
+        run: ./scripts/ci/runner-sweep.sh || true
+
+  # phase-405 — make the interlocked job's SKIP visible in the run that skipped
+  # it. See scripts/ci/report-interlock-coverage.sh for why this warns rather
+  # than fails when no runner is registered, and fails when one supposedly is.
+  #
+  # `if: always()` so it reports on a skip; `needs` so it sees the result.
+
+  coverage:
+    name: coverage report (did tier 2 run?)
+    needs: [matrix]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Report whether the interlocked lane ran
+        run: ./scripts/ci/report-interlock-coverage.sh "tier 2 (1-wise matrix)" "${{ needs.matrix.result }}" "${{ vars.NROS_SELF_HOSTED_READY }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,34 @@ through.
 - `scripts/bootstrap.sh base`: first-time native/ROS/zenoh quick-start setup.
 - `scripts/bootstrap.sh all`: contributor/full-matrix setup; pulls and installs every supported SDK tier.
 - `scripts/bootstrap.sh platform <platform>`: first-time focused setup for one platform.
+**One verb, one scope, one position (phase-407 W3).** `setup`, `doctor`, `build`
+and `test` all take the same word in their first argument: a PLATFORM (`native
+zephyr freertos nuttx threadx_linux threadx_riscv64 esp32 esp_idf qemu px4 xrce
+cyclonedds`) or a PRESET, which today is exactly the fixture lanes (`all native
+tier1 tier2 tier2-nightly`). `just setup zephyr` was already this shape; the
+other three now follow it. The vocabulary is `scripts/build/scope.sh`, one
+namespace, gated by `check-scope-namespace` — a preset may share a platform's
+name only while it denotes the same scope, which is why `native` is legal as
+both. `NROS_SCOPE_EXPLAIN=1 just build tier2` prints the command a scope
+resolves to without running it.
+
+Naming a scope IS the specification of what you asked to be covered; a bare
+`just test` is best effort over what is provisioned, and prints the probed set
+rather than reading a recorded one. `just <platform> <verb>` still works and
+still is the implementation — it prints a deprecation for one release.
+
 - `just setup`: print setup choices; does not fetch/install.
 - `just setup base`: install the base quick-start SDK/tooling tier.
 - `just setup all` or `just setup tier=all`: install the full contributor/test-all tier.
-- `just <platform> setup`: install a focused platform SDK/tooling tier.
-- `just doctor` and `just doctor tier=all`: diagnose base or full setup readiness.
+- `just setup <scope>`: install a focused platform SDK/tooling tier.
+- `just doctor`: host tooling, then a PROBE of every platform (the derived default scope).
+- `just doctor <scope>` / `just doctor tier=all`: one scope's readiness, or the pre-407 tier walk.
+- `just build <scope>`: that scope's test fixtures — a lane routes through
+  `build-test-fixtures lane=<lane>` (which stamps coverage), a platform through
+  `just <platform> build-fixtures` (which does not).
+- `just test <scope>`: that scope's tests. Verbosity is a FLAG now (`verbose` /
+  `-v` / `--verbose`, anywhere in the arguments) — `just test 1` no longer means
+  verbose, which is the incompatibility phase-407 accepts.
 - `just build`: build the workspace plus generated bindings and transport artifacts.
 - `just build-examples`: build the workspace and example matrix.
 - `just build-test-fixtures`: prebuild binaries required by the full test matrix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ through.
 - `scripts/bootstrap.sh base`: first-time native/ROS/zenoh quick-start setup.
 - `scripts/bootstrap.sh all`: contributor/full-matrix setup; pulls and installs every supported SDK tier.
 - `scripts/bootstrap.sh platform <platform>`: first-time focused setup for one platform.
-**One verb, one scope, one position (phase-407 W3).** `setup`, `doctor`, `build`
+**One verb, one scope, one position (phase-411 W3).** `setup`, `doctor`, `build`
 and `test` all take the same word in their first argument: a PLATFORM (`native
 zephyr freertos nuttx threadx_linux threadx_riscv64 esp32 esp_idf qemu px4 xrce
 cyclonedds`) or a PRESET, which today is exactly the fixture lanes (`all native
@@ -79,7 +79,7 @@ still is the implementation — it prints a deprecation for one release.
   `just <platform> build-fixtures` (which does not).
 - `just test <scope>`: that scope's tests. Verbosity is a FLAG now (`verbose` /
   `-v` / `--verbose`, anywhere in the arguments) — `just test 1` no longer means
-  verbose, which is the incompatibility phase-407 accepts.
+  verbose, which is the incompatibility phase-411 accepts.
 - `just build`: build the workspace plus generated bindings and transport artifacts.
 - `just build-examples`: build the workspace and example matrix.
 - `just build-test-fixtures`: prebuild binaries required by the full test matrix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,12 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
 ## Practices
 - **Run the TIER your change earns, after every task** (RFC-0061 / phase-318).
   **Never `sudo`** — tell the user.
-  - `just ci l1` — **compile + unit, ~6 min, NO FIXTURES** (phase-395 W2).
+  - `just ci gate` (was `just ci l1`, still forwards) — **compile + unit, NO
+    FIXTURES** (phase-395 W2; renamed phase-410 W4 because it visits no
+    coordinates, so it was never a rung on the breadth ladder). Measured 230 s.
+    Depth is a positional arg on the tiers: `just ci matrix` runs, `just ci
+    matrix build` builds+links only (27 s) — `name=value` does NOT parse for a
+    module recipe.
     Run this before every push. It is `check` + `test-unit`, and it needs no
     fixture build, no SDK, no QEMU and no cross toolchain — only `test`/
     `test-all` depend on fixtures, and 74 of 163 test files never needed them.

--- a/docs/design/0061-fixture-freshness-and-test-tiers.md
+++ b/docs/design/0061-fixture-freshness-and-test-tiers.md
@@ -386,6 +386,36 @@ completes. With ten agents landing through a queue that batches four, a 20-minut
 tier is cancelled before it finishes, every time — and a lane that always cancels
 looks busy while reporting nothing. Run-depth belongs on a clock.
 
+### The vocabulary (phase-410 W4)
+
+"Lane" named three things here, meaning two:
+
+| name | means |
+| --- | --- |
+| `CiTier` | the ladder rung |
+| `CiLane` | the COMPUTED cell selection for a rung |
+| `_NROS_LANES` | the fixture coordinate set — breadth |
+| `ci l1` / `ci l3` | DEPTH — compile+unit / cross build+link |
+
+Tier-vs-lane is a real distinction and stands: a rung is a name, a lane is the
+selection computed for it. What collided was `l1`/`l3` using "l" for DEPTH.
+
+Resolved as:
+
+```
+just ci gate                  compile + unit; visits NO coordinates
+just ci <tier>                build + run at that breadth        (default)
+just ci <tier> build          build + link only at that breadth
+```
+
+`l1` was never a rung — it selects no platform and boots no QEMU, so it has no
+breadth at all. It is the GATE. `l3` is a depth on a breadth, and survives as
+the implementation of `ci matrix build`.
+
+The argument is POSITIONAL, and that is forced rather than chosen: `just` does
+not parse `name=value` for a recipe inside a MODULE — `just ci matrix
+depth=build` yields the literal string. Measured 2026-08-31.
+
 phase-410 restructures the workflows accordingly. This RFC keeps the ladder; it
 gains the axis the ladder was missing.
 

--- a/docs/design/0061-fixture-freshness-and-test-tiers.md
+++ b/docs/design/0061-fixture-freshness-and-test-tiers.md
@@ -1,6 +1,6 @@
 # RFC-0061 — Fixture freshness by tool OUTPUT, and a tiered test ladder
 
-**Status:** Draft (2026-07-28)
+**Status:** Draft (2026-07-28; amended 2026-08-31 — see the breadth/depth amendment)
 **Supersedes nothing. Amends:** the fixture-freshness contract established by
 issue #182 (tool in the signature) and phase-300 W2.1 (git-index enumeration).
 **Motivated by:** a `just ci` run on 2026-07-28 that passed every code stage and
@@ -351,6 +351,43 @@ over the cartesian product:
 Greedy is adequate (within a `ln n` factor; the input is tiny). The cover must be
 **recomputed from `matrix::CELLS`**, never stored as a hand-edited list — adding a
 platform must extend tier 2 without touching a second file.
+
+## Amendment (2026-08-31, phase-410) — tiers are BREADTH; DEPTH is a second axis
+
+Proposal 2 defines the tiers as a ladder of COVERAGE: which coordinates a run
+visits. That is one axis, and the expensive one is the other.
+
+| axis | values | cost |
+| --- | --- | --- |
+| **breadth** — which coordinates | tier1, tier2, nightly, full | low |
+| **depth** — what we do with each | build+link, build+run | **high** |
+
+Measured 2026-08-31 on one host: `just ci l3` (cross build + link + ELF symbol
+interrogation, no QEMU, no tests) is **46 s**. The tier-2 run over the same tree
+is **9.5 min** on top of an **11 min** warm fixture rebuild. Depth is roughly
+**25x** breadth.
+
+This ladder already contained the second axis without naming it: the LANE
+vocabulary (`just ci l1`, `just ci l3`) is depth, while `just ci <tier>` is
+breadth-with-depth-fixed-at-build+run. Two ladders sharing the `ci` namespace is
+why `ci l3` and `ci full` read as siblings and are not.
+
+**The operational rule that follows:**
+
+> Build+link is MANDATORY and WIDE. Build+run is SCHEDULED and NARROW.
+
+"It compiles and links for every target" is the regression that hurts most and
+costs least to catch, so it can afford to gate every merge. Running cannot.
+
+**And a constraint the original ladder could not have known**, because it
+predates the merge queue: a run-depth tier on `push(main)` with
+`cancel-in-progress: true` STARVES once merges arrive faster than the tier
+completes. With ten agents landing through a queue that batches four, a 20-minute
+tier is cancelled before it finishes, every time — and a lane that always cancels
+looks busy while reporting nothing. Run-depth belongs on a clock.
+
+phase-410 restructures the workflows accordingly. This RFC keeps the ladder; it
+gains the axis the ladder was missing.
 
 ## Operational corollaries
 

--- a/docs/issues/0955-lane-guards-cannot-fire-sdk-env-always-exports.md
+++ b/docs/issues/0955-lane-guards-cannot-fire-sdk-env-always-exports.md
@@ -1,0 +1,81 @@
+---
+id: 955
+title: "Six lane guards can never fire — they test `-z` on a variable `sdk-env.just` always exports"
+status: open
+area: build
+severity: medium
+found: 2026-08-31
+related: [0599, 0650, phase-407]
+---
+
+# A guard predicate that cannot be true
+
+Six platform-lane skip guards are written:
+
+```sh
+if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
+    nros_lane_skip_note nuttx "NUTTX_DIR unset and third-party/nuttx/nuttx absent"; exit 0
+fi
+```
+
+`just/sdk-env.just:19` exports it unconditionally, with a default:
+
+```
+export NUTTX_DIR := env("NUTTX_DIR", justfile_directory() / "third-party/nuttx/nuttx")
+```
+
+So `-z` is never true, so the `&&` is never true, and **the skip can never
+fire**. 23 variables are exported this way; six guards depend on one of them
+being unset.
+
+Sites:
+
+```
+just/threadx-linux.just:119
+just/nuttx.just:204, 343, 403, 442, 476
+```
+
+## Why it matters, and which direction it breaks
+
+Under a broad lane, that step does not skip — it proceeds into cmake and
+**fails** where the author intended a skip. So an unprovisioned host gets a hard
+build failure with a cmake-level message instead of
+`== nuttx == SKIPPED (NUTTX_DIR unset …)`.
+
+That is the opposite of this repo's usual skip defect and worth stating plainly:
+these do not launder a failure into a pass, they turn an intended skip into a
+confusing red. phase-407 W2 (a NAMED platform must fail) does not fix it —
+under W2 the failure is now *correct* when the platform was named, and still
+wrong when it was merely included.
+
+## The two idioms, one of which works
+
+The same files contain guards that DO fire, testing the resolved directory
+rather than the variable:
+
+```
+just/nuttx.just:96          if [ ! -d "$NUTTX_DIR/include" ]; then
+just/threadx-linux.just:72  if [ ! -d "$THREADX_DIR/common/inc" ] || [ ! -d "$NETX_DIR/common/inc" ]; then
+just/threadx-linux.just:190 if [ ! -d "$THREADX_DIR/common/inc" ]; then
+```
+
+This is the "second spelling instead of one shared helper" that CLAUDE.md files
+under #282 -> #326: two idioms for one question, and the newer one is the broken
+one. The fix is to converge on the working shape — probe the resolved path, not
+the variable — and ideally through ONE helper rather than a third spelling.
+
+## Work
+
+1. Replace the six `-z`-on-an-exported-var guards with a resolved-path probe.
+2. Prefer a single helper (`nros_sdk_present <var> <marker-subdir>`) over
+   correcting six sites in place, so a seventh site cannot reintroduce the dead
+   form.
+3. Gate it: a `-z "${X:-}"` test on any variable `sdk-env.just` exports is
+   statically detectable, and the export list is right there to read.
+4. Verify on a host where the SDK is genuinely absent — env overrides exercise
+   the code path but not the real condition.
+
+Found while implementing phase-407 W2, which is also why it is filed rather than
+folded in: changing which lanes skip versus fail is exactly what W2 was
+scoped to do deliberately and narrowly, and this changes it for a different
+reason.

--- a/docs/issues/0957-format-blocked-by-unexcluded-workspace-leaf.md
+++ b/docs/issues/0957-format-blocked-by-unexcluded-workspace-leaf.md
@@ -1,0 +1,65 @@
+---
+id: 957
+title: "`just format` fails whole-tree — a workspace leaf is in neither the root members nor the exclude list"
+status: open
+area: build
+severity: low
+found: 2026-08-31
+related: [phase-383, phase-407]
+---
+
+# The documented pre-change practice does not run
+
+CLAUDE.md says "**`just format` before broad changes**". It cannot complete:
+
+```
+$ just format
+parallel: This job failed:
+cd examples/workspaces/bridge-xrce/src/talker_pkg && cargo +nightly-2026-04-11 fmt
+error: recipe `format` failed with exit code 1
+```
+
+The cause:
+
+```
+`cargo metadata` exited with an error: current package believes it's in a
+workspace when it's not:
+current:   examples/workspaces/bridge-xrce/src/talker_pkg/Cargo.toml
+workspace: <repo-root>/Cargo.toml
+```
+
+The leaf is in neither the root `workspace.members` nor `workspace.exclude`, and
+carries no `[workspace]` table of its own — so cargo resolves it into the root
+workspace, which does not list it.
+
+This is the class CLAUDE.md already records for west-built Zephyr entry leaves:
+they "need BOTH the nested workspace `exclude` AND a repo-root `Cargo.toml`
+exclude". `bridge-xrce` has neither half.
+
+## Pre-existing, and measured as such
+
+* the leaf's last commit is `e7c47132e feat(phase-383 W10.a/W10.c)` — the bridge
+  migration, not any phase-405/407 work;
+* `git show origin/main:Cargo.toml | grep -c bridge-xrce` -> **0**, so `main` is
+  identical;
+* `cargo +nightly fmt --check` over the ROOT workspace is clean (rc=0), so the
+  failure is the leaf's membership, not formatting drift.
+
+## Why it is only `low`
+
+`just format` fails LOUDLY, at the offending leaf, naming the fix cargo itself
+suggests. Nothing is silently unformatted, and per-crate `cargo +nightly fmt`
+works everywhere else. The cost is that the whole-tree practice has to be
+skipped or worked around, which is how a documented habit quietly stops being
+one.
+
+## Work
+
+1. Decide which half applies — an `[workspace]` table in the leaf, a root
+   `exclude` entry, or both (the west-leaf precedent takes both).
+2. Sweep for siblings: any `examples/workspaces/*/src/*/Cargo.toml` that is in
+   neither list. Fixing only the reported leaf is the failure mode CLAUDE.md
+   files under "fix the CLASS, not the reported site".
+3. Gate it — membership is statically checkable from the root manifest plus the
+   leaf list, and this is at least the third time the two-excludes rule has been
+   half-applied.

--- a/docs/issues/0957-format-blocked-by-unexcluded-workspace-leaf.md
+++ b/docs/issues/0957-format-blocked-by-unexcluded-workspace-leaf.md
@@ -5,7 +5,7 @@ status: open
 area: build
 severity: low
 found: 2026-08-31
-related: [phase-383, phase-407]
+related: [phase-383, phase-411]
 ---
 
 # The documented pre-change practice does not run

--- a/docs/issues/0968-tier2-runtime-failures-unreproduced.md
+++ b/docs/issues/0968-tier2-runtime-failures-unreproduced.md
@@ -1,0 +1,85 @@
+---
+id: 968
+title: "Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time"
+status: open
+area: testing
+severity: medium
+found: 2026-08-31
+related: [0967, phase-410, RFC-0061]
+---
+
+# What was measured, and what was not
+
+A full tier-2 run on a frozen tree with freshly rebuilt fixtures (8/8 modules
+OK):
+
+```
+1795 tests run · 1595 passed (2 flaky) · 6 skipped
+Real failures: 17
+```
+
+`Real failures` is the junit-rewritten count. Nextest's raw line said **200
+failed** — the difference is `nros_tests::skip!` panics, which a bare read
+counts as failures. Any triage starting from 200 is starting from the wrong
+number.
+
+Of the 17, **five were lane/justfile meta-tests** and are fixed (they failed
+identically on a fresh `origin/main` worktree; the tier ladder had drifted from
+the justfile and its own gate could not see module recipes).
+
+The remaining **12 are runtime e2e**, and this issue exists so they are tracked
+rather than remembered:
+
+```
+emulator        test_qemu_rtic_service_e2e
+esp32_emulator  test_esp32_talker_listener_e2e, test_esp32_workspace_entry_e2e,
+                test_esp32_to_native, test_native_to_esp32
+native_api      test_threadx_linux_cyclonedds_{action,service,talker_to_native_listener}
+zephyr          example_e2e::case_{21,24,27}_xrce_cpp_{pubsub,service,action}_e2e
+logging_smoke   logging_smoke_esp32_qemu_emits_every_severity
+```
+
+They fail SOLO as well as in the sweep, so they are not the QEMU load-flakiness
+CLAUDE.md warns about.
+
+## They are not from the phase-405/407/410 work — proved by diff, not argued
+
+Across every tree that feeds a built image — `packages/`, `examples/`,
+`zephyr/`, `integrations/`, `cmake/` — that branch changes exactly two files,
+both in `packages/testing/nros-tests/src/` (the test harness; compiled into no
+target image). The esp32, zephyr, threadx and QEMU images are therefore
+byte-identical to main's, so a runtime difference cannot originate there.
+
+## Why nobody noticed
+
+`post-submit`'s tier-2 job has **never run** — it is interlocked on
+`vars.NROS_SELF_HOSTED_READY`, which is not set, and a skipped job does not
+colour its run. `host-tests`, the only other lane that executes E2E, has been
+red for 20 consecutive runs on issue 0967, dying before its tests start.
+
+So between them, no fixture-backed test has run in CI for a long time. A
+backlog of undetected runtime failures is exactly what that predicts.
+
+## NOT DIAGNOSED — read this before acting
+
+**No root cause is claimed for any of the 12.** One sample was examined
+(`test_threadx_linux_cyclonedds_service`): the client printed `Locator:` empty
+and the server produced no output at all, i.e. it did not start. Whether that
+is one cause or several is unknown.
+
+This issue deliberately stops at the list. Four issues (0859–0862) were filed
+from a sweep in this repo and all four retracted, two of them carrying confident
+wrong root causes — which is worse than the bogus filing, because it aims the
+next person at a dead end.
+
+## Work
+
+1. Rebuild tier-2 fixtures and re-run the 12 — the artifacts from the measuring
+   run were cleared by `runner-sweep.sh` afterwards, so nothing here is
+   currently reproducible.
+2. Triage per suite, not per test: esp32 (5 of 12) and threadx-cyclone (3) are
+   the two clusters and likely share a cause each.
+3. Check each against main at the commit the fixtures were built from —
+   `stat -c '%y'` on the artifact against `git log -1 --format=%ci`, per the
+   0859-0862 rule.
+4. File per cause, once reproduced. Not before.

--- a/docs/issues/archived/0955-lane-guards-cannot-fire-sdk-env-always-exports.md
+++ b/docs/issues/archived/0955-lane-guards-cannot-fire-sdk-env-always-exports.md
@@ -1,7 +1,7 @@
 ---
 id: 955
 title: "Six lane guards can never fire — they test `-z` on a variable `sdk-env.just` always exports"
-status: open
+status: resolved
 area: build
 severity: medium
 found: 2026-08-31
@@ -79,3 +79,44 @@ Found while implementing phase-407 W2, which is also why it is filed rather than
 folded in: changing which lanes skip versus fail is exactly what W2 was
 scoped to do deliberately and narrowly, and this changes it for a different
 reason.
+
+## Resolved — 2026-08-31
+
+One helper, not six corrections. `nros_sdk_missing VAR marker` lives in
+`scripts/build/lane-skip.sh`, beside the skip protocol it guards, and tests the
+RESOLVED directory the way the working guards in the same files already did:
+
+```sh
+if nros_sdk_missing NUTTX_DIR include; then
+    nros_lane_skip_note nuttx "NuttX not found at $NUTTX_DIR — run: just setup nuttx"; exit 0
+fi
+```
+
+An UNSET variable still counts as missing — that is the case the `-z` arm was
+reaching for, and it stays true without being the only thing asked.
+
+The skip reason changed too. It used to say "NUTTX_DIR unset and
+third-party/nuttx/nuttx absent", describing a condition that could not hold; it
+now names the path actually consulted and the command that fixes it.
+
+**Measured**, all three states:
+
+```
+NUTTX_DIR=<real tree>   -> found    (no skip)
+NUTTX_DIR=/nonexistent  -> MISSING  (skip)
+NUTTX_DIR unset         -> MISSING  (skip)
+```
+
+Gated by `check-sdk-guard-can-fire` on the fast line: a `-z "${VAR:-}"` test on
+any of the 23 variables `sdk-env.just` exports is a failure, naming the site and
+the replacement. Proven red-capable by planting one, rc=1, restored rc=0.
+
+**Its selftest caught a bug in the gate itself while it was being written** —
+the export regex lacked `re.M`, so `^` matched only the first line and the gate
+would have compared guards against a one-element export set. A gate whose
+selftest runs on the normal path found its own defect before it shipped, which
+is the argument for the ratchet in one line.
+
+Not verified: no NuttX or ThreadX build was run — the guards were exercised
+directly with real and synthetic paths, not through a provisioning cycle on a
+host genuinely lacking the SDK.

--- a/docs/issues/archived/0955-lane-guards-cannot-fire-sdk-env-always-exports.md
+++ b/docs/issues/archived/0955-lane-guards-cannot-fire-sdk-env-always-exports.md
@@ -5,7 +5,7 @@ status: resolved
 area: build
 severity: medium
 found: 2026-08-31
-related: [0599, 0650, phase-407]
+related: [0599, 0650, phase-411]
 ---
 
 # A guard predicate that cannot be true
@@ -44,7 +44,7 @@ build failure with a cmake-level message instead of
 
 That is the opposite of this repo's usual skip defect and worth stating plainly:
 these do not launder a failure into a pass, they turn an intended skip into a
-confusing red. phase-407 W2 (a NAMED platform must fail) does not fix it —
+confusing red. phase-411 W2 (a NAMED platform must fail) does not fix it —
 under W2 the failure is now *correct* when the platform was named, and still
 wrong when it was merely included.
 
@@ -75,7 +75,7 @@ the variable — and ideally through ONE helper rather than a third spelling.
 4. Verify on a host where the SDK is genuinely absent — env overrides exercise
    the code path but not the real condition.
 
-Found while implementing phase-407 W2, which is also why it is filed rather than
+Found while implementing phase-411 W2, which is also why it is filed rather than
 folded in: changing which lanes skip versus fail is exactly what W2 was
 scoped to do deliberately and narrowly, and this changes it for a different
 reason.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -77,5 +77,6 @@ fails if this block drifts.
 - **#0963** (codegen, memory, build) — The derived-bound inventory is exported and nothing reads it, so every size downstream is still set by hand See `0963-*`.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
+- **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -69,9 +69,7 @@ fails if this block drifts.
 - **#0945** (build) — The shared-cargo-dir campaign rests on five unsupported build-system internals — a Corrosion path formula, an unstable cargo flag, cargo's private `.fingerprint` format, a side channel inside cargo's target dir, and an undocumented depfile location See `0945-*`.
 - **#0953** (tooling) — A panic in the Python half crosses `extern \"C\"` and ABORTS the resolver — 0897 removed the loader abort and left this one See `0953-*`.
 - **#0954** (api-c, boards) — The committed NuttX fallback sizes header is a hand-maintained twin with no gate, and went stale again See `0954-*`.
-- **#0956** (rmw) — Four W4 parity slots are declared, unfilled, and undecided: content filtering and network flow endpoints See `0956-*`.
 - **#0957** (build) — `just format` fails whole-tree — a workspace leaf is in neither the root members nor the exclude list See `0957-*`.
-- **#0960** (rmw) — The per-entity readiness callback trio is declared, unfilled, and undecided — and `set_wake_callback` does not answer it See `0960-*`.
 - **#0961** (core, memory) — Executor::open_in needs more than 32 KiB of the calling thread's stack, and nothing says so See `0961-*`.
 - **#0962** (codegen, memory) — A bound over nested bounded sequences is the PRODUCT of the caps, so a uniform cap does not terminate See `0962-*`.
 - **#0963** (codegen, memory, build) — The derived-bound inventory is exported and nothing reads it, so every size downstream is still set by hand See `0963-*`.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -86,5 +86,6 @@ fails if this block drifts.
 - **#0949** (build) — For a migrated workspace, board facts are never delivered — `_ws` resolves to the generated root, which has no `system.toml` See `0949-*`.
 - **#0950** (build) — `macro_deploy_token` hands an mps2 image `DEPLOY freertos`, and `--deploy` outranks `--board`, so it resolves a boardless target See `0950-*`.
 - **#0955** (build) — Six lane guards can never fire — they test `-z` on a variable `sdk-env.just` always exports See `0955-*`.
+- **#0957** (build) — `just format` fails whole-tree — a workspace leaf is in neither the root members nor the exclude list See `0957-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -69,23 +69,13 @@ fails if this block drifts.
 - **#0945** (build) — The shared-cargo-dir campaign rests on five unsupported build-system internals — a Corrosion path formula, an unstable cargo flag, cargo's private `.fingerprint` format, a side channel inside cargo's target dir, and an undocumented depfile location See `0945-*`.
 - **#0953** (tooling) — A panic in the Python half crosses `extern \"C\"` and ABORTS the resolver — 0897 removed the loader abort and left this one See `0953-*`.
 - **#0954** (api-c, boards) — The committed NuttX fallback sizes header is a hand-maintained twin with no gate, and went stale again See `0954-*`.
+- **#0956** (rmw) — Four W4 parity slots are declared, unfilled, and undecided: content filtering and network flow endpoints See `0956-*`.
+- **#0957** (build) — `just format` fails whole-tree — a workspace leaf is in neither the root members nor the exclude list See `0957-*`.
+- **#0960** (rmw) — The per-entity readiness callback trio is declared, unfilled, and undecided — and `set_wake_callback` does not answer it See `0960-*`.
 - **#0961** (core, memory) — Executor::open_in needs more than 32 KiB of the calling thread's stack, and nothing says so See `0961-*`.
 - **#0962** (codegen, memory) — A bound over nested bounded sequences is the PRODUCT of the caps, so a uniform cap does not terminate See `0962-*`.
 - **#0963** (codegen, memory, build) — The derived-bound inventory is exported and nothing reads it, so every size downstream is still set by hand See `0963-*`.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
-- **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
-- **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
-- **#0936** (tooling) — `check-just-recipe-refs` never reads a document, so 129 `just <recipe>` call sites in docs/ and book/ name recipes that do not exist See `0936-*`.
-- **#0931** (build, api) — `MODEL` has no users and should be retired; `LAUNCH default` is ceremony on 26 entries See `0931-*`.
-- **#0931** (build, api) — `nano_ros_entry` has eleven arguments; four have no users and three restate the bringup See `0931-*`.
-- **#0934** (build, api) — The same fact is authored in up to five config surfaces; no SSoT is declared for rmw, board or domain See `0934-*`.
-- **#0939** (tooling) — The metadata probe links the node NAME, which is not a target — so every C/C++ component reports `no producer`, once, and then silently See `0939-*`.
-- **#0946** (build) — Two independent per-platform locator ladders in cmake, and they disagree on threadx and freertos See `0946-*`.
-- **#0947** (build) — NuttX has two ROS-edition surfaces that cannot express each other, and `jazzy` is unreachable on one See `0947-*`.
-- **#0949** (build) — For a migrated workspace, board facts are never delivered — `_ws` resolves to the generated root, which has no `system.toml` See `0949-*`.
-- **#0950** (build) — `macro_deploy_token` hands an mps2 image `DEPLOY freertos`, and `--deploy` outranks `--board`, so it resolves a boardless target See `0950-*`.
-- **#0955** (build) — Six lane guards can never fire — they test `-z` on a variable `sdk-env.just` always exports See `0955-*`.
-- **#0957** (build) — `just format` fails whole-tree — a workspace leaf is in neither the root members nor the exclude list See `0957-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -74,5 +74,17 @@ fails if this block drifts.
 - **#0963** (codegen, memory, build) — The derived-bound inventory is exported and nothing reads it, so every size downstream is still set by hand See `0963-*`.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
+- **#0933** (ci) — 28 CI steps invoke `just`/`nros` without sourcing `./activate.sh`, and nothing gates the class See `0933-*`.
+- **#0935** (tooling, cli) — Every `.launch.py` ABORTS through the shipped resolver — `exec_file`'s inputs and outputs travel by a thread-local the dlopen split duplicated See `0935-*`.
+- **#0936** (tooling) — `check-just-recipe-refs` never reads a document, so 129 `just <recipe>` call sites in docs/ and book/ name recipes that do not exist See `0936-*`.
+- **#0931** (build, api) — `MODEL` has no users and should be retired; `LAUNCH default` is ceremony on 26 entries See `0931-*`.
+- **#0931** (build, api) — `nano_ros_entry` has eleven arguments; four have no users and three restate the bringup See `0931-*`.
+- **#0934** (build, api) — The same fact is authored in up to five config surfaces; no SSoT is declared for rmw, board or domain See `0934-*`.
+- **#0939** (tooling) — The metadata probe links the node NAME, which is not a target — so every C/C++ component reports `no producer`, once, and then silently See `0939-*`.
+- **#0946** (build) — Two independent per-platform locator ladders in cmake, and they disagree on threadx and freertos See `0946-*`.
+- **#0947** (build) — NuttX has two ROS-edition surfaces that cannot express each other, and `jazzy` is unreachable on one See `0947-*`.
+- **#0949** (build) — For a migrated workspace, board facts are never delivered — `_ws` resolves to the generated root, which has no `system.toml` See `0949-*`.
+- **#0950** (build) — `macro_deploy_token` hands an mps2 image `DEPLOY freertos`, and `--deploy` outranks `--board`, so it resolves a boardless target See `0950-*`.
+- **#0955** (build) — Six lane guards can never fire — they test `-z` on a variable `sdk-env.just` always exports See `0955-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-407-scope-is-the-spec-verb-first-workflow.md
+++ b/docs/roadmap/phase-407-scope-is-the-spec-verb-first-workflow.md
@@ -1,0 +1,165 @@
+# phase-407 — the scope you name IS the specification
+
+**Status (2026-08-31). Design agreed; W1–W4 open.**
+
+Implements the workflow half of RFC-0061's tier discipline. Sibling of
+phase-399 (the justfile surface) and phase-395 (the CI event design); it does
+not supersede either, it makes their vocabularies agree.
+
+## The defect
+
+A test that cannot run skips, and a skip is indistinguishable from a pass.
+
+That is CORRECT for the local dev cycle and must stay: a developer working on
+Zephyr does not provision FreeRTOS, NuttX, ThreadX and ESP-IDF, and a run that
+demanded all of them would be a run nobody performs. The skip is what makes a
+focused checkout usable.
+
+The caveat is the whole issue: **when someone EXPECTS a platform to be covered
+and the prerequisite is missing, the same mechanism reports success.** Forget to
+provision, forget to build the fixtures, and the tests skip and the lane is
+green. Nothing distinguishes "I did not ask for FreeRTOS" from "I asked for
+FreeRTOS and it silently did not happen".
+
+Measured on 2026-08-31, three instances of one shape:
+
+* `just zephyr build-fixtures` on an unprovisioned host calls
+  `nros_lane_skip "ZEPHYR_WORKSPACE not set up — run \`just zephyr setup\`"` and
+  exits 78. **The user typed `zephyr`.** There is no lane ambiguity to resolve
+  and the remedy is already in the message; it is simply not a failure.
+* `nros_fixtures_stamp_write` records `nros_lane_coords_file "$lane"` — the
+  lane's NOMINAL coordinates from the manifest, not what the build achieved. A
+  platform that skipped still appears in the stamp as covered, so
+  `_require-fixtures` answers "yes, covered" and the run proceeds to skip its
+  tests. **The skip is laundered into a coverage claim** that every downstream
+  consumer then reads instead of reality.
+* `host-tests.yml` sets `NROS_FIXTURES_OPTIONAL=1` unconditionally in CI, which
+  converts absent fixtures to skips wholesale. Its own comment notes the full
+  tier "leaves the var unset and still hard-fails" — which makes correctness
+  depend on remembering to unset a variable.
+
+This is the same shape as three defects already fixed this week, one level up:
+`check-submodule-pins` skipping silently on an unresolvable baseline,
+`check-feature-set-ssot` matching a spelling no site used, and `post-submit`
+reporting success with its only expensive job skipped. A lane that reports
+success for work it did not do is a gate that reports OK for a comparison it
+did not make.
+
+## The rule
+
+> **Named → must work. Unnamed → may skip, and is always reported.**
+
+Naming IS the specification. There is no second declaration to keep in step —
+which is the trap an earlier draft of this design fell into: it added an
+"expected coverage" statement beside the selection, i.e. two sources of one
+fact, the exact antipattern phase-405 spent a week deleting.
+
+Skip legitimacy reduces to one question: **was this platform NAMED, or merely
+INCLUDED by a preset or the default?**
+
+The default scope is DERIVED, never recorded: "what I have provisioned" is a
+probe (`doctor` already performs it per item, with remedies), so it cannot drift
+from a stored file.
+
+## Surface: `just <verb> [scope…]`
+
+One vocabulary in one argument position.
+
+| | today | after |
+| --- | --- | --- |
+| provision | `just setup zephyr` | `just setup zephyr` (unchanged) |
+| readiness | `just doctor tier=all` | `just doctor zephyr` |
+| fixtures | `just build-test-fixtures lane=tier2` | `just build tier2` |
+| test | `just zephyr test` | `just test zephyr` |
+
+`just setup <platform>` is ALREADY verb-first — the platform modules are the
+inconsistent half, and this makes the rest follow the half that was right.
+
+Modules do not disappear; `zephyr::build-fixtures` remains as implementation.
+What changes is that the DOCUMENTED surface is verb-first, so there is one shape
+to learn rather than two.
+
+**Scope is one namespace.** Platform names and preset names occupy the same
+position. `native` is already both a platform module and a lane name — they must
+denote the same scope, and a gate must assert that no preset name collides with
+a platform meaning something else.
+
+## CI is the user workflow, with a different scope
+
+```yaml
+      - uses: actions/checkout@v4
+      - run: just setup tier2
+      - run: just test  tier2
+```
+
+A CI job becomes `setup <scope>` then `test <scope>`. **Only the scope differs
+between lanes.** The workflow file reads as a transcript of a user session, so
+"does CI do what I do?" is answerable by looking at it.
+
+Measured baseline: `pr-checks.yml`'s `check` job is 16 steps, NINE of which
+re-source `activate.sh`, plus a hand-rolled submodule init, a hand-rolled
+`cargo build --bin nros`, six `nros setup --source` flags, and a separate
+fixture-build step. `host-tests.yml` adds `NROS_FIXTURES_OPTIONAL=1`.
+
+What absorbs it:
+
+| boilerplate | absorbed by |
+| --- | --- |
+| `source ./activate.sh` ×9 | recipes self-activate |
+| submodule init, CLI build, `nros setup --source …` | `just setup <scope>` |
+| separate fixture-build step | `just test <scope>` |
+| `NROS_FIXTURES_OPTIONAL` | deleted — its job was tolerating the mismatch |
+| `lane=` ↔ platform translation | one scope vocabulary |
+
+Runner tuning (`NROS_BUILD_JOBS`, `RUSTFLAGS`, job counts) STAYS in `env:`. That
+is environment, not boilerplate, and pretending otherwise would hide the one
+thing a runner legitimately configures.
+
+## Work items
+
+**W1 — the stamp records what was ACHIEVED, not what was REQUESTED.**
+`nros_fixtures_stamp_write` writes the lane's nominal coordinates. It must write
+the coordinates whose artifacts exist. Then `_require-fixtures` starts failing
+with "you asked for threadx, the build did not produce it" instead of letting
+the run skip. Smallest change, and it makes every existing over-claim visible
+immediately — including a tier-2 run in flight while this doc was written.
+
+**W2 — a NAMED platform never skips.** ~12 `nros_lane_skip_note …; exit 0` sites
+across the platform lanes gain the named/included distinction. Named and
+unprovisioned is a FAILURE, and the failure text is the remedy those sites
+already print. `nros_lane_skip` keeps its job for a platform the spec did not
+name — under a precise spec that should be unreachable, so it degrades to a
+caller-bug signal rather than a routine outcome.
+
+**W3 — `just <verb> [scope…]`.** Verb-first surface, preset expansion to
+platform sets, `just <plat> <verb>` kept as a deprecated alias for one release.
+`just test`'s first positional is currently `verbose`, so its signature changes;
+that is a real incompatibility for anyone typing `just test 1`.
+
+**W4 — CI as transcripts.** Only safe once W1–W3 hold, because the YAML stops
+carrying the compensating boilerplate. `NROS_FIXTURES_OPTIONAL` is deleted here.
+
+## Accepted consequences
+
+* **`lane=all` changes meaning** — today "everything, minus whatever is
+  missing"; after, "every platform, fail if unprovisioned". The best-effort
+  meaning moves to the bare `just test`, which is what a developer actually
+  wants. This is the change most likely to annoy, and the reason the list forms
+  must be easy to type: **if the narrow spec is awkward, people reach for a
+  bypass and the gate dies.**
+* **`just test 1` breaks** (verbosity moves to a flag).
+* **Self-activating recipes** need a prototype before commitment —
+  `activate.sh` is the env SSoT and interacts with the `scripts/bin/cargo` shim
+  and `NROS_CARGO_FLAGS`.
+* **CI does more visible work in `setup`** — same total, one name.
+
+## Acceptance
+
+* A named-but-unprovisioned platform FAILS, naming the prerequisite, at the
+  point of decision — not twenty minutes later as a missing artifact.
+* The stamp cannot claim a coordinate whose artifact does not exist.
+* Every build/test run prints a coverage line: scope, what ran, what did not,
+  and how to provision the rest.
+* A CI job for any lane is `setup <scope>` + `test <scope>`.
+* Gate: no preset name collides with a platform name meaning something else.
+* `just ci l1`, `just check fast` and every lane preset NAME are unchanged.

--- a/docs/roadmap/phase-407-scope-is-the-spec-verb-first-workflow.md
+++ b/docs/roadmap/phase-407-scope-is-the-spec-verb-first-workflow.md
@@ -1,6 +1,6 @@
 # phase-407 — the scope you name IS the specification
 
-**Status (2026-08-31). Design agreed; W1–W4 open.**
+**Status (2026-08-31). W1–W4 landed.**
 
 Implements the workflow half of RFC-0061's tier discipline. Sibling of
 phase-399 (the justfile surface) and phase-395 (the CI event design); it does
@@ -108,7 +108,7 @@ What absorbs it:
 | `source ./activate.sh` ×9 | recipes self-activate |
 | submodule init, CLI build, `nros setup --source …` | `just setup <scope>` |
 | separate fixture-build step | `just test <scope>` |
-| `NROS_FIXTURES_OPTIONAL` | deleted — its job was tolerating the mismatch |
+| `NROS_FIXTURES_OPTIONAL` | banned from CI (`check-ci-no-fixture-tolerance`) |
 | `lane=` ↔ platform translation | one scope vocabulary |
 
 Runner tuning (`NROS_BUILD_JOBS`, `RUSTFLAGS`, job counts) STAYS in `env:`. That
@@ -137,7 +137,12 @@ platform sets, `just <plat> <verb>` kept as a deprecated alias for one release.
 that is a real incompatibility for anyone typing `just test 1`.
 
 **W4 — CI as transcripts.** Only safe once W1–W3 hold, because the YAML stops
-carrying the compensating boilerplate. `NROS_FIXTURES_OPTIONAL` is deleted here.
+carrying the compensating boilerplate. `NROS_FIXTURES_OPTIONAL` is banned from CI here — NOT deleted outright, which
+is a deliberate amendment to this doc's earlier wording. The reader in
+`nros-tests` is a legitimate LOCAL opt-in for a developer who has provisioned
+one platform; deleting it would remove a real affordance in order to fix a
+CI-only defect. The rule is about WHO SETS IT, so the gate is about where it
+appears.
 
 ## Accepted consequences
 

--- a/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
+++ b/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
@@ -3,12 +3,12 @@
 **Status (2026-08-31). W2, W3 and W4 landed; W1 deferred with reasons.**
 
 Restructures the CI workflows so a tier's file keeps the promise the tier makes.
-Consumes phase-407 (`just <verb> <scope>`) and phase-395 (the event design);
+Consumes phase-411 (`just <verb> <scope>`) and phase-395 (the event design);
 amends RFC-0061's tier ladder rather than replacing it.
 
 ## The defect this fixes
 
-phase-407 gave every RFC-0061 tier a CI owner. That exposed the next question:
+phase-411 gave every RFC-0061 tier a CI owner. That exposed the next question:
 the owners are correct but the SHAPE is wrong, in three ways that only appear
 under load.
 
@@ -61,7 +61,7 @@ queueing.
 With ten agents landing through a merge queue that batches up to four, merges
 arrive faster than that. Each cancels the last, so **tier 2 completes never** —
 and a lane that always cancels looks busy while reporting nothing, which is
-strictly worse than the skipped job phase-407 just made visible.
+strictly worse than the skipped job phase-411 just made visible.
 
 So run-depth tiers move to a CLOCK, not to `push(main)`. A scheduled run always
 finishes.
@@ -98,7 +98,7 @@ run-nightly.yml   build+run, pairwise      on: schedule 07:00
 run-full.yml      build+run, everything    on: dispatch
 ```
 
-Each file is phase-407 shaped: `just setup <scope>` then one tier command.
+Each file is phase-411 shaped: `just setup <scope>` then one tier command.
 Filename ↔ tier ↔ local command, 1:1.
 
 `cancel-in-progress: true` ONLY where a newer answer subsumes an older one AND

--- a/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
+++ b/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
@@ -1,0 +1,192 @@
+# phase-410 — CI is BREADTH × DEPTH, and only depth is expensive
+
+**Status (2026-08-31). W2 and W3 landed; W1 deferred with reasons; W4 open.**
+
+Restructures the CI workflows so a tier's file keeps the promise the tier makes.
+Consumes phase-407 (`just <verb> <scope>`) and phase-395 (the event design);
+amends RFC-0061's tier ladder rather than replacing it.
+
+## The defect this fixes
+
+phase-407 gave every RFC-0061 tier a CI owner. That exposed the next question:
+the owners are correct but the SHAPE is wrong, in three ways that only appear
+under load.
+
+**1. A tier's file is named for its EVENT, not its tier.** Tier 1 lives in
+`host-tests.yml`, tier 2 in `post-submit.yml`, tier-2-nightly in `nightly.yml`,
+tier 3 nowhere. "Where does tier 2 run?" needed a gate to answer.
+
+**2. `pr-checks.yml` does different work for five events in 850 lines.**
+Deliberate (phase-395's economics) and unreadable: a developer cannot answer
+"what runs on my PR?" without reading all of it. `nightly.yml` is another 851.
+
+**3. The ladder collapses two independent axes.** This is the substantive one.
+
+## BREADTH × DEPTH
+
+| axis | values | cost |
+| --- | --- | --- |
+| **breadth** — which coordinates | tier1, tier2, nightly, full | low |
+| **depth** — what we do with each | build+link, build+run | **high** |
+
+Nearly all cost is DEPTH. Building wide is affordable; RUNNING wide is not.
+
+RFC-0061's ladder encodes breadth only, so `just ci <tier>` always means
+build AND run. The build-only depth exists — `just ci l3` is "cross build +
+link", `rust-rtos-link-check` plus ELF symbol interrogation, no QEMU and no
+tests — but it lives in the LANE vocabulary (L1/L3), a second ladder sharing
+the `ci` namespace. `ci l3` and `ci full` read as siblings and are unrelated.
+
+An earlier draft of this design proposed retiring the lane vocabulary into the
+tiers. That was wrong and is recorded because the mistake is instructive: it
+would have destroyed the build-only depth, which is the CHEAP half and the one
+that can afford to be mandatory.
+
+## The rule
+
+> **Build+link is MANDATORY and WIDE. Build+run is SCHEDULED and NARROW.**
+
+"It compiles and links for every target" is the regression that hurts most and
+costs least to catch. Running is what cannot be afforded per merge.
+
+## Why per-merge run-depth STARVES with ten agents
+
+`post-submit.yml` sets `cancel-in-progress: true` — correct for "is main good
+NOW", where a newer commit's answer subsumes an older one's.
+
+Measured on this host, 2026-08-31: tier-2 fixtures rebuild in **11 min warm**
+(~45 cold) and the tier-2 run takes **9.5 min** — 20+ minutes warm, before any
+queueing.
+
+With ten agents landing through a merge queue that batches up to four, merges
+arrive faster than that. Each cancels the last, so **tier 2 completes never** —
+and a lane that always cancels looks busy while reporting nothing, which is
+strictly worse than the skipped job phase-407 just made visible.
+
+So run-depth tiers move to a CLOCK, not to `push(main)`. A scheduled run always
+finishes.
+
+## Caching is a REPOSITORY-wide budget, not a per-job one
+
+`pr-checks.yml` already records why sccache is used over caching `target/`, and
+the constraint that matters here: **the GitHub Actions Cache limit is 10 GB per
+REPOSITORY**, and GitHub evicts entries "created and deleted at a high
+frequency" (hence `SCCACHE_CACHE_SIZE=2G`).
+
+Ten agents on ten concurrent PRs, each writing cache entries, thrash a shared
+budget and make the cache worse than none.
+
+**Rule: only `main`-branch runs WRITE the cache; PR runs READ it.** Any new
+workflow must state which it is.
+
+## Target structure
+
+```
+gate.yml          REQUIRED · check fast + test-unit
+                  on: pull_request, merge_group           cheap; never starves
+
+build-wide.yml    BUILD + LINK only, wide breadth         ← the mandatory promise
+                  on: push(main)                            no fixtures, no QEMU
+
+run-host.yml      build+run, host coordinates (tier 1)
+                  on: push(main), schedule 03:00
+
+run-matrix.yml    build+run, 1-wise (tier 2)
+                  on: schedule 06:00, dispatch            ← clock, not per-merge
+
+run-nightly.yml   build+run, pairwise      on: schedule 07:00
+run-full.yml      build+run, everything    on: dispatch
+```
+
+Each file is phase-407 shaped: `just setup <scope>` then one tier command.
+Filename ↔ tier ↔ local command, 1:1.
+
+`cancel-in-progress: true` ONLY where a newer answer subsumes an older one AND
+the run is short enough to finish — `gate`, `build-wide`. The scheduled `run-*`
+files use `cancel-in-progress: false` so a run completes rather than being
+perpetually superseded.
+
+## THE MIGRATION CONSTRAINT — read before touching anything
+
+The required status check is the job **named `CI`** (`ci-ok` in
+`pr-checks.yml`), and CLAUDE.md records that a required check producing no
+verdict **deadlocked two pull requests**: a check that never reports blocks
+forever rather than failing.
+
+So: the aggregator must keep the literal name `CI` and must emit a verdict on
+EVERY event, including when its dependencies skip. Its current `if: always()`
+plus justified-skip logic moves VERBATIM; it is well built and this phase does
+not improve it.
+
+W1 lands that file ALONE and confirms the context still reports before anything
+else moves.
+
+## Work items
+
+**W1 — DEFERRED, deliberately. `pr-checks.yml` keeps its name for now.**
+
+The plan was to rename it `gate.yml`. The inference that this is safe is
+strong: the ruleset requires the bare context `CI`, which cannot come from the
+file name or from the workflow's `name: pr-checks` — so GitHub is matching the
+JOB name, `ci-ok`'s `name: CI`, and a rename preserves it.
+
+Strong is not verified. `gh pr checks` reports no contexts for this branch even
+though a `pr-checks` run succeeded, so the association cannot be observed from
+here. CLAUDE.md records that a required check producing no verdict DEADLOCKED
+two pull requests — with ten agents landing through a merge queue, that blocks
+everyone, and the benefit on offer is a better filename.
+
+So the rename is its own change, made when someone can watch the context report
+on a real PR. W2 and W3 add NEW files and touch no required context; they carry
+the substance of this phase — the breadth/depth split, the starvation fix and
+the cache rule — without betting the queue on an inference.
+
+**W2 — `build-wide.yml`.** The mandatory build+link lane on `push(main)`.
+
+MEASURED 2026-08-31: `just ci l3` = **46 s**, exit 0 — `rust-rtos-link-check`
+plus three cross ELFs interrogated and the heap-free image link-gated, without
+booting anything. Against 20+ minutes for run-depth, build depth is roughly
+**25x cheaper**, so per-merge is comfortable and the starvation argument does
+not apply to it.
+
+Caveat, stated because it changes the number and not the conclusion: 46 s is
+WARM, on a tree where the cross artifacts already exist. A cold runner pays the
+cross builds themselves, which is the bulk. The RATIO is what the design rests
+on, and no plausible cold cost closes a 25x gap.
+
+**W3 LANDED (tier 2). Tier 1 and nightly stay where they are, deliberately.**
+
+Tier 2 moved out of `post-submit.yml` into `run-matrix.yml` on a 06:00 cron with
+`cancel-in-progress: false`. That is the starvation fix and the measured case.
+`dep-chain` stays in post-submit: hosted, 158 s, genuinely per-merge.
+
+Tier 1 (`host-tests.yml`) keeps `push(main)` — it is the cheapest run depth, it
+is path-filtered, and that file has NO concurrency group, so runs QUEUE rather
+than cancel. Queueing wastes runner time under ten agents but it does not
+starve, and changing it is a separate judgement about hosted-runner budget
+rather than about correctness. Recorded here so the inconsistency is a decision
+and not an oversight.
+
+Tier-2-nightly is already on a clock by construction.
+
+**W4 — the vocabulary.** Decide whether L1/L3 stay as a lane ladder or become
+`--depth` on the tier commands. This is a decision, not an implementation, and
+it touches `CiLane`, `check-lane-contracts` and the queue.
+
+## Acceptance
+
+* every tier's file name names its tier, and its body is a command a developer
+  can type;
+* build+link is mandatory per merge; no run-depth lane is per-merge;
+* exactly one cache writer;
+* the `CI` context never stops reporting, on any event;
+* `check-tier-has-ci-owner` still passes, and its OWNERLESS list does not grow.
+
+## The open number, now closed
+
+`just ci l3` = **46 s warm** (exit 0). W2 is per-merge.
+
+Still unmeasured, and W2 should report it once the lane exists: the same
+command on a COLD runner. It cannot change the structure — a 25x gap does not
+close — but it decides whether `build-wide` needs the sccache read path to be
+fast or merely present.

--- a/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
+++ b/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
@@ -1,6 +1,6 @@
 # phase-410 — CI is BREADTH × DEPTH, and only depth is expensive
 
-**Status (2026-08-31). W2 and W3 landed; W1 deferred with reasons; W4 open.**
+**Status (2026-08-31). W2, W3 and W4 landed; W1 deferred with reasons.**
 
 Restructures the CI workflows so a tier's file keeps the promise the tier makes.
 Consumes phase-407 (`just <verb> <scope>`) and phase-395 (the event design);
@@ -169,9 +169,50 @@ and not an oversight.
 
 Tier-2-nightly is already on a clock by construction.
 
-**W4 — the vocabulary.** Decide whether L1/L3 stay as a lane ladder or become
-`--depth` on the tier commands. This is a decision, not an implementation, and
-it touches `CiLane`, `check-lane-contracts` and the queue.
+**W4 LANDED — depth is a dimension, and "lane" was overloaded three ways.**
+
+The word named three things in one repo, meaning two:
+
+| name | where | means |
+| --- | --- | --- |
+| `CiTier` | `buckets.rs` | the ladder rung (4, incl. Tier3) |
+| `CiLane` | `ci_lane.rs` | the COMPUTED cell selection for a rung (3) |
+| `_NROS_LANES` | `fixture-lane.sh` | the fixture coordinate set — breadth |
+| `ci l1` / `ci l3` | `just/ci.just` | DEPTH — compile+unit / cross build+link |
+
+Tier-vs-lane is a real distinction (rung vs its computed selection) and is left
+alone: `CiLane` (71 refs) and `nros_lane_*` (222 refs) are BREADTH and this work
+does not touch them. The collision was narrow — `l1`/`l3` used "l" for depth.
+
+**`l1` is not a rung and never was.** It visits no coordinates: `check` +
+`test-unit`, no fixture, no platform, no QEMU. It is now `just ci gate`, with
+`l1` kept as a forwarder. Forcing it into (breadth, depth) is the error an
+earlier draft made.
+
+**`l3` becomes a depth on a breadth**: `just ci matrix build`. `l3` survives as
+the implementation.
+
+**MEASURED, and it changed the design twice:**
+
+* `just ci matrix depth=build` does NOT work. `just` does not parse `name=value`
+  for a MODULE recipe — it yields the literal `depth=build`. Positional
+  (`just ci matrix build`) does. The named-argument design was abandoned on this
+  measurement, not on taste.
+* `just ci matrix build` = **27 s** (`ci l3` measured 46 s earlier on a colder
+  tree). Build depth stays comfortably per-merge; `build-wide.yml` now names the
+  pair rather than a lane letter.
+
+**Each depth dispatches to a FIXED inner recipe** (`_matrix-run`,
+`_matrix-build`) rather than branching inside one parameterised body, because
+`check-lane-contracts` proves affordability by WALKING a recipe body and cannot
+verify a conditional one.
+
+**And that gate could not see private recipes at all.** Its `RECIPE` pattern
+required `^[a-z]`, so every `_`-prefixed recipe was invisible — including
+`_lane-gate`, which `ci matrix` calls. The closure silently stopped at each
+private boundary, which is the vacuous-pass shape the file's own header warns
+about. Widened; the larger closure still reports clean, now across 3
+affordability tiers instead of 2.
 
 ## Acceptance
 

--- a/docs/roadmap/phase-411-scope-is-the-spec-verb-first-workflow.md
+++ b/docs/roadmap/phase-411-scope-is-the-spec-verb-first-workflow.md
@@ -1,4 +1,4 @@
-# phase-407 — the scope you name IS the specification
+# phase-411 — the scope you name IS the specification
 
 **Status (2026-08-31). W1–W4 landed.**
 

--- a/just/check.just
+++ b/just/check.just
@@ -126,6 +126,7 @@ fast-serial: \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
     interlock-visibility fixture-stamp-honesty ci-no-fixture-tolerance sdk-guard-can-fire \
+    tier-has-ci-owner \
     board-facts-delivery deploy-board-resolves \
     opaque-storage-guards cpp-ffi-error-mapping submodule-pins \
     rust-stdio-on-zephyr \
@@ -1376,6 +1377,13 @@ cpp-ffi-error-mapping:
 # commit about issue-ID renumbering moved zenoh-pico BACK over a Zephyr
 # `socklen_t` build fix, and nothing noticed for seven hours.
 # Deliberate rollback: NROS_ALLOW_SUBMODULE_REWIND=1 (and say why).
+# Every tier RFC-0061 declares must be RUN by some workflow. Two of four were
+# invoked by nothing at all, and a tier nobody runs cannot go red to say so
+# (phase-407).
+[private]
+tier-has-ci-owner:
+    @python3 scripts/check-tier-has-ci-owner.py
+
 # A `-z "${VAR:-}"` guard on a variable sdk-env.just always exports can never
 # fire. Six did, and they broke the UNUSUAL way: an intended skip became a cmake
 # failure on an unprovisioned host (issue 0955).

--- a/just/check.just
+++ b/just/check.just
@@ -1379,7 +1379,7 @@ cpp-ffi-error-mapping:
 # Deliberate rollback: NROS_ALLOW_SUBMODULE_REWIND=1 (and say why).
 # Every tier RFC-0061 declares must be RUN by some workflow. Two of four were
 # invoked by nothing at all, and a tier nobody runs cannot go red to say so
-# (phase-407).
+# (phase-411).
 [private]
 tier-has-ci-owner:
     @python3 scripts/check-tier-has-ci-owner.py
@@ -1393,7 +1393,7 @@ sdk-guard-can-fire:
 
 # CI may not set NROS_FIXTURES_OPTIONAL. A lane names its scope, so a missing
 # fixture INSIDE that scope is a failure; the flag turned it into a skip and made
-# correctness depend on remembering to unset a variable (phase-407 W4). The
+# correctness depend on remembering to unset a variable (phase-411 W4). The
 # reader survives as a local opt-in — the rule is about WHERE it is set.
 [private]
 ci-no-fixture-tolerance:
@@ -1402,7 +1402,7 @@ ci-no-fixture-tolerance:
 # A fixture stamp may not claim what the build did not achieve. The stamp used
 # to record the lane's NOMINAL coordinates, so a module that skipped a missing
 # prerequisite still read as covered and the run skipped its tests to a green
-# sweep (phase-407 W1).
+# sweep (phase-411 W1).
 [private]
 fixture-stamp-honesty:
     @python3 scripts/check-fixture-stamp-honesty.py
@@ -3136,7 +3136,7 @@ fixture-binary-names:
 manifests-parse:
     @python3 scripts/check-manifests-parse.py
 
-# phase-407 W3 — `just <verb> <scope>` puts platform names and preset names in
+# phase-411 W3 — `just <verb> <scope>` puts platform names and preset names in
 # ONE argument position, so a name may not mean two things. `native` is both a
 # platform module and a fixture lane, which is legal only while they denote the
 # same scope; nothing checked that, and a preset that quietly means something
@@ -3155,7 +3155,7 @@ scope-namespace:
 lane-skip-protocol:
     @python3 scripts/check-lane-skip-protocol.py
 
-# phase-407 W2 — 0599/0650 gave a lane the SKIPPED verdict; this says WHO MAY
+# phase-411 W2 — 0599/0650 gave a lane the SKIPPED verdict; this says WHO MAY
 # HAVE IT. A platform reached by a preset or the broad default may skip and is
 # reported; a platform the operator NAMED (`just zephyr build-fixtures`) must
 # work, because naming it is the whole specification. Runs the protocol both

--- a/just/check.just
+++ b/just/check.just
@@ -122,7 +122,7 @@ fast-serial: \
     export-f-closure peer-sweep-lanes \
     activate-shells build-root fixture-groups rmw-descriptors artifact-identity-budget \
     cargo-target-spelling example-leaf-target-dirs example-leaf-build-dirs fixture-binary-names manifests-parse build-rs-rerun-paths \
-    lane-skip-protocol skip-marker-matching \
+    lane-skip-protocol named-lane-fails skip-marker-matching \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
     interlock-visibility fixture-stamp-honesty \
@@ -3120,6 +3120,16 @@ manifests-parse:
 [private]
 lane-skip-protocol:
     @python3 scripts/check-lane-skip-protocol.py
+
+# phase-407 W2 — 0599/0650 gave a lane the SKIPPED verdict; this says WHO MAY
+# HAVE IT. A platform reached by a preset or the broad default may skip and is
+# reported; a platform the operator NAMED (`just zephyr build-fixtures`) must
+# work, because naming it is the whole specification. Runs the protocol both
+# directions on every invocation — a named skip regressing to a pass is
+# invisible to a grep, so the gate makes the call instead of reading it.
+[private]
+named-lane-fails:
+    @python3 scripts/check-named-lane-fails.py
 
 # issue 0658 — `[SKIPPED:<class>]` does not contain `[SKIPPED]`, so a hand-rolled
 # literal match reclassifies every CLASSED skip as a FAILURE. Five matrix

--- a/just/check.just
+++ b/just/check.just
@@ -125,7 +125,7 @@ fast-serial: \
     lane-skip-protocol named-lane-fails skip-marker-matching scope-namespace \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
-    interlock-visibility fixture-stamp-honesty \
+    interlock-visibility fixture-stamp-honesty ci-no-fixture-tolerance \
     board-facts-delivery deploy-board-resolves \
     opaque-storage-guards cpp-ffi-error-mapping submodule-pins \
     rust-stdio-on-zephyr \
@@ -1376,6 +1376,14 @@ cpp-ffi-error-mapping:
 # commit about issue-ID renumbering moved zenoh-pico BACK over a Zephyr
 # `socklen_t` build fix, and nothing noticed for seven hours.
 # Deliberate rollback: NROS_ALLOW_SUBMODULE_REWIND=1 (and say why).
+# CI may not set NROS_FIXTURES_OPTIONAL. A lane names its scope, so a missing
+# fixture INSIDE that scope is a failure; the flag turned it into a skip and made
+# correctness depend on remembering to unset a variable (phase-407 W4). The
+# reader survives as a local opt-in — the rule is about WHERE it is set.
+[private]
+ci-no-fixture-tolerance:
+    @python3 scripts/check-ci-no-fixture-tolerance.py
+
 # A fixture stamp may not claim what the build did not achieve. The stamp used
 # to record the lane's NOMINAL coordinates, so a module that skipped a missing
 # prerequisite still read as covered and the run skipped its tests to a green

--- a/just/check.just
+++ b/just/check.just
@@ -122,7 +122,7 @@ fast-serial: \
     export-f-closure peer-sweep-lanes \
     activate-shells build-root fixture-groups rmw-descriptors artifact-identity-budget \
     cargo-target-spelling example-leaf-target-dirs example-leaf-build-dirs fixture-binary-names manifests-parse build-rs-rerun-paths \
-    lane-skip-protocol named-lane-fails skip-marker-matching \
+    lane-skip-protocol named-lane-fails skip-marker-matching scope-namespace \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
     interlock-visibility fixture-stamp-honesty \
@@ -3112,6 +3112,17 @@ fixture-binary-names:
 [private]
 manifests-parse:
     @python3 scripts/check-manifests-parse.py
+
+# phase-407 W3 — `just <verb> <scope>` puts platform names and preset names in
+# ONE argument position, so a name may not mean two things. `native` is both a
+# platform module and a fixture lane, which is legal only while they denote the
+# same scope; nothing checked that, and a preset that quietly means something
+# else re-scopes a run without changing a single command anyone types. Buildless
+# (NROS_SCOPE_NO_BUILD=1) — a collision whose expansion needs a compiled
+# selector is itself the failure. Self-tests its own rule on every run.
+[private]
+scope-namespace:
+    @python3 scripts/check-scope-namespace.py
 
 # issue 0650 — a fixture lane that cannot run must report SKIPPED (rc 78), never
 # build nothing and print "<platform> test fixtures built." with exit 0. That

--- a/just/check.just
+++ b/just/check.just
@@ -125,6 +125,7 @@ fast-serial: \
     lane-skip-protocol skip-marker-matching \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
+    interlock-visibility fixture-stamp-honesty \
     board-facts-delivery deploy-board-resolves \
     opaque-storage-guards cpp-ffi-error-mapping submodule-pins \
     rust-stdio-on-zephyr \
@@ -1375,6 +1376,22 @@ cpp-ffi-error-mapping:
 # commit about issue-ID renumbering moved zenoh-pico BACK over a Zephyr
 # `socklen_t` build fix, and nothing noticed for seven hours.
 # Deliberate rollback: NROS_ALLOW_SUBMODULE_REWIND=1 (and say why).
+# A fixture stamp may not claim what the build did not achieve. The stamp used
+# to record the lane's NOMINAL coordinates, so a module that skipped a missing
+# prerequisite still read as covered and the run skipped its tests to a green
+# sweep (phase-407 W1).
+[private]
+fixture-stamp-honesty:
+    @python3 scripts/check-fixture-stamp-honesty.py
+
+# Every CI job gated on a `vars.*` interlock must have a job that reports
+# whether it ran. A skipped job does not colour its run, so post-submit reported
+# SUCCESS on runs where the tier-2 matrix — every fixture build and every E2E
+# cell in that lane — had not executed at all.
+[private]
+interlock-visibility:
+    @python3 scripts/check-interlock-visibility.py
+
 [private]
 submodule-pins:
     @bash scripts/ci/submodule-pins-check.sh

--- a/just/check.just
+++ b/just/check.just
@@ -125,7 +125,7 @@ fast-serial: \
     lane-skip-protocol named-lane-fails skip-marker-matching scope-namespace \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
-    interlock-visibility fixture-stamp-honesty ci-no-fixture-tolerance \
+    interlock-visibility fixture-stamp-honesty ci-no-fixture-tolerance sdk-guard-can-fire \
     board-facts-delivery deploy-board-resolves \
     opaque-storage-guards cpp-ffi-error-mapping submodule-pins \
     rust-stdio-on-zephyr \
@@ -1376,6 +1376,13 @@ cpp-ffi-error-mapping:
 # commit about issue-ID renumbering moved zenoh-pico BACK over a Zephyr
 # `socklen_t` build fix, and nothing noticed for seven hours.
 # Deliberate rollback: NROS_ALLOW_SUBMODULE_REWIND=1 (and say why).
+# A `-z "${VAR:-}"` guard on a variable sdk-env.just always exports can never
+# fire. Six did, and they broke the UNUSUAL way: an intended skip became a cmake
+# failure on an unprovisioned host (issue 0955).
+[private]
+sdk-guard-can-fire:
+    @python3 scripts/check-sdk-guard-can-fire.py
+
 # CI may not set NROS_FIXTURES_OPTIONAL. A lane names its scope, so a missing
 # fixture INSIDE that scope is a failure; the flag turned it into a skip and made
 # correctness depend on remembering to unset a variable (phase-407 W4). The

--- a/just/ci.just
+++ b/just/ci.just
@@ -37,13 +37,29 @@ set working-directory := '..'
 default: tier1
 
 
-# L1 — compile, lint and unit tests. No fixtures, no platforms, no QEMU.
+# THE GATE — compile, lint and unit. Visits NO coordinates (phase-410 W4).
+#
+# Renamed from `l1`. It was never a rung on the breadth ladder: it builds no
+# fixture, selects no platform and boots no QEMU, so it has no coordinates at
+# all. Calling it `l1` put it in a ladder it is not on, next to `l3` (which DOES
+# have coordinates, at build depth) and next to `ci full` (breadth), so three
+# unrelated things read as siblings.
+#
+# `just ci l1` still works — see the forwarder below. The old spelling is in
+# CLAUDE.md, two workflows and ~180 doc references; phase-399's precedent is
+# that a rename keeps its forwarder.
 [group("main")]
-l1:
+gate:
     @just check cli-fresh check::fast check::build check::api-parity
     @just test-unit
     @just test-lane-contracts
-    @echo "CI L1 passed (compile + unit; no fixtures were built or needed)."
+    @echo "CI gate passed (compile + unit; no fixtures were built or needed)."
+
+# Deprecated spelling of `just ci gate`. Kept because it is what CLAUDE.md,
+# queue-notify.yml and the docs say today.
+[group("main")]
+l1: gate
+
 
 [group("ci")]
 tier1:
@@ -185,8 +201,33 @@ l3:
 # instead of missing. Build-set and run-set are then one computation — the same
 # `row_coord` against the same coordinate file — which is the invariant issue
 # 0482 exists to protect. See `nros_tests::fixtures::lane`.
+# `just ci matrix` runs at RUN depth; `just ci matrix build` at BUILD depth.
+#
+# CI is BREADTH x DEPTH (RFC-0061, amended by phase-410) and only depth is
+# expensive: measured 2026-08-31, build depth is 46 s against 20+ minutes for
+# run depth over the same tree. The argument is POSITIONAL because `just` does
+# not parse `name=value` for a MODULE recipe — `just ci matrix depth=build`
+# sets depth to the literal string `depth=build`, measured.
+#
+# Each depth dispatches to a FIXED inner recipe rather than branching inside
+# one body, so `check-lane-contracts` can walk each and prove its affordability
+# claim. A parameterised body with conditionals is exactly what that gate
+# cannot verify.
 [group("ci")]
-matrix:
+matrix depth="run":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{ depth }}" in
+        run)   just ci::_matrix-run ;;
+        build) just ci::_matrix-build ;;
+        *) echo "just ci matrix: unknown depth '{{ depth }}' — expected 'run' or 'build'." >&2
+           echo "  run   = build + execute (the 1-wise cover)" >&2
+           echo "  build = build + link only, no boot" >&2
+           exit 2 ;;
+    esac
+
+[private]
+_matrix-run:
     #!/usr/bin/env bash
     set -euo pipefail
     just _lane-gate tier2
@@ -220,6 +261,17 @@ matrix:
 # platform matrix from it, and its `lane-coverage` job asserts every module in the
 # cover actually has a job. Change the lane here and CI follows, with no second
 # edit — that is the whole reason the selection is computed.
+# BUILD depth over the tier-2 breadth: cross build + link, no boot. This is
+# what `build-wide.yml` runs on every merge.
+#
+# It IS `l3` — build depth means build, link, AND verify the link, which is the
+# ELF symbol interrogation plus the heap-free gate that `l3` already does.
+# Defining it as `rust-rtos-link-check` alone would have been build-without-
+# verify, and would also have invalidated the 46 s measurement this lane's
+# per-merge placement rests on.
+[private]
+_matrix-build: l3
+
 [group("ci")]
 matrix-nightly:
     #!/usr/bin/env bash

--- a/just/cyclonedds.just
+++ b/just/cyclonedds.just
@@ -34,6 +34,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh cyclonedds doctor "just doctor cyclonedds"
     set +e
     missing=0
     # Phase 186.6.5 — Cyclone self-provisions from source; there is no host
@@ -131,6 +132,7 @@ build-rmw:
 # the POSIX E2E pub/sub interop harness against stock rmw_cyclonedds.
 [group("main")]
 test: build-rmw
+    @bash scripts/dev/deprecated-scope-alias.sh cyclonedds test "just test cyclonedds"
     ctest --test-dir packages/rmw/cyclonedds/nros-rmw-cyclonedds/build --output-on-failure
 
 # Composite: build RMW backend (self-provisions Cyclone) + run tests. Wired

--- a/just/esp32.just
+++ b/just/esp32.just
@@ -45,6 +45,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh esp32 doctor "just doctor esp32"
     set +e
     fail=0
     if command -v qemu-system-riscv32 &>/dev/null \
@@ -211,6 +212,7 @@ build-logging-smoke:
 [group("full-matrix")]
 build-fixtures: build-qemu build-logging-smoke
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh esp32 build-fixtures "just build esp32"
     set -e
     # The ESP32-C3 QEMU workspace Entry (`esp32_entry`) that
     # `test_esp32_workspace_entry_e2e` consumes via
@@ -274,6 +276,7 @@ test-basic: build-qemu
 # build-then-test sequencing.
 [group("main")]
 test verbose="": build-fixtures
+    @bash scripts/dev/deprecated-scope-alias.sh esp32 test "just test esp32"
     # Delegate to the shared skip-tolerant runner: the esp32_emulator tests
     # `skip!` when the Espressif QEMU fork / espflash / riscv32 target are absent
     # (best-effort emulator), and _nextest-platform treats an all-[SKIPPED] run

--- a/just/esp_idf.just
+++ b/just/esp_idf.just
@@ -20,6 +20,7 @@ setup *args:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh esp_idf doctor "just doctor esp_idf"
     set +e
     fail=0
     if [ -f "{{ESP_IDF_WORKSPACE}}/export.sh" ]; then
@@ -73,6 +74,7 @@ build-examples:
 # Build ESP-IDF test fixtures.
 [group("full-matrix")]
 build-fixtures target='esp32c3': (build-c-port target)
+    @bash scripts/dev/deprecated-scope-alias.sh esp_idf build-fixtures "just build esp_idf"
     @echo "ESP-IDF fixtures built."
 
 # Build every ESP-IDF tier: core artifacts, examples, and test fixtures.

--- a/just/freertos.just
+++ b/just/freertos.just
@@ -35,6 +35,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh freertos doctor "just doctor freertos"
     set +e
     fail=0
     if [ -d "$FREERTOS_DIR/include" ]; then
@@ -184,6 +185,7 @@ build-fixtures-posix:
 [group("full-matrix")]
 build-fixtures: build-examples build-fixture-extras build-fixtures-posix
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh freertos build-fixtures "just build freertos"
     set -e
     # issue 0650 — the ONE place this lane says it built its fixtures, and it
     # refuses to when a step was skipped. Before this the claim was an
@@ -308,6 +310,7 @@ build-all: build-fixtures
 [group("main")]
 test verbose="": build-fixtures
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh freertos test "just test freertos"
     set -e
     if [ ! -d "$FREERTOS_DIR/include" ]; then
         echo "ERROR: FreeRTOS not found at $FREERTOS_DIR. Run: just setup-freertos"

--- a/just/native.just
+++ b/just/native.just
@@ -159,6 +159,7 @@ build-examples JOBS=env_var_or_default("NROS_BUILD_JOBS", "75%"):
 # Build all example binaries used as test fixtures (Rust + C + C++ + workspaces).
 [group("full-matrix")]
 build-fixtures: build-fixture-rust build-fixture-extras build-workspace-fixtures
+    @bash scripts/dev/deprecated-scope-alias.sh native build-fixtures "just build native"
     @echo "Native test fixtures built."
 
 # Build native workspace fixtures from examples/fixtures.toml.
@@ -665,6 +666,7 @@ clean-cpp:
 [group("main")]
 test verbose="": build-fixtures
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh native test "just test native"
     set -e
     source scripts/build/cargo.sh
     cargo_nextest_args=($(nros_cargo_nextest_args))

--- a/just/nuttx.just
+++ b/just/nuttx.just
@@ -83,7 +83,7 @@ build-integration-app:
 build-examples:
     #!/usr/bin/env bash
     set -e
-    # phase-407 W2 — this `source` was MISSING, and the gate that found it is
+    # phase-411 W2 — this `source` was MISSING, and the gate that found it is
     # `check-named-lane-fails`. The skip below therefore never ran: on a host
     # without NuttX the recipe died at `nros_lane_skip_note: command not found`
     # (rc 127, under `set -e`), naming nothing and reaching neither the ledger
@@ -334,7 +334,7 @@ build-fixtures-arm-smp:
     # the nuttx lane runs. That is the honest price of one shared tree and it is
     # bounded; the alternative is a row-level lane predicate, which does not
     # exist and should not be invented for one fixture.
-    # phase-407 W2 — `nros_lane_out_of_scope_note`, not `nros_lane_skip_note`: nothing
+    # phase-411 W2 — `nros_lane_out_of_scope_note`, not `nros_lane_skip_note`: nothing
     # is missing here. The run's LANE selected no nuttx coordinate, and naming
     # the platform cannot change that, so this stays a skip in both directions.
     if ! nros_lane_wants_platform nuttx; then
@@ -358,12 +358,12 @@ build-fixtures-arm-smp:
 build-fixtures-riscv:
     #!/usr/bin/env bash
     set -e
-    # phase-407 W2 — as in `build-examples`: this `source` was missing, so the
+    # phase-411 W2 — as in `build-examples`: this `source` was missing, so the
     # narrowing note below was `command not found` rather than a note.
     # shellcheck source=scripts/build/lane-skip.sh
     source scripts/build/lane-skip.sh
     source scripts/build/fixture-lane.sh
-    # phase-407 W2 — a lane narrowing, not a missing prerequisite; see
+    # phase-411 W2 — a lane narrowing, not a missing prerequisite; see
     # `build-fixtures-arm-smp` above and `nros_lane_out_of_scope_note`'s comment.
     if ! nros_lane_wants_platform nuttx-riscv; then
         nros_lane_out_of_scope_note nuttx "NuttX riscv: no nuttx-riscv coordinate in this run's lane — skipping"

--- a/just/nuttx.just
+++ b/just/nuttx.just
@@ -202,8 +202,8 @@ build-fixtures-arm:
     if ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
         nros_lane_skip_note nuttx "arm-none-eabi-gcc not found"; exit 0
     fi
-    if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
-        nros_lane_skip_note nuttx "NUTTX_DIR unset and third-party/nuttx/nuttx absent"; exit 0
+    if nros_sdk_missing NUTTX_DIR include; then
+        nros_lane_skip_note nuttx "NuttX not found at $NUTTX_DIR — run: just setup nuttx"; exit 0
     fi
     # Issue 0583 — drop the build-std artifacts when the vendored NuttX libc
     # pin moves. `workspace-fixture-signature.sh` hashes the pin so the STAMP
@@ -341,8 +341,8 @@ build-fixtures-arm-smp:
         nros_lane_out_of_scope_note nuttx "NuttX arm-smp: no nuttx coordinate in this run's lane — skipping"
         exit 0
     fi
-    if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
-        nros_lane_skip_note nuttx "NUTTX_DIR unset and third-party/nuttx/nuttx absent"; exit 0
+    if nros_sdk_missing NUTTX_DIR include; then
+        nros_lane_skip_note nuttx "NuttX not found at $NUTTX_DIR — run: just setup nuttx"; exit 0
     fi
     nuttx_dir="${NUTTX_DIR:-$(pwd)/third-party/nuttx/nuttx}"
     smp_defconfig="$(pwd)/packages/boards/nros-board-nuttx-qemu/nuttx-config/arm-smp/defconfig"
@@ -401,8 +401,8 @@ build-riscv-c:
     if ! command -v riscv-none-elf-gcc >/dev/null 2>&1; then
         nros_lane_skip_note nuttx "riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)"; exit 0
     fi
-    if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
-        nros_lane_skip_note nuttx "NUTTX_DIR unset and third-party/nuttx/nuttx absent"; exit 0
+    if nros_sdk_missing NUTTX_DIR include; then
+        nros_lane_skip_note nuttx "NuttX not found at $NUTTX_DIR — run: just setup nuttx"; exit 0
     fi
     nuttx_dir="${NUTTX_DIR:-$(pwd)/third-party/nuttx/nuttx}"
     rv_defconfig="$(pwd)/packages/boards/nros-board-nuttx-qemu/nuttx-config/riscv/defconfig"
@@ -440,8 +440,8 @@ build-riscv-c-workspaces:
     if ! command -v riscv-none-elf-gcc >/dev/null 2>&1; then
         nros_lane_skip_note nuttx "riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)"; exit 0
     fi
-    if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
-        nros_lane_skip_note nuttx "NUTTX_DIR unset and third-party/nuttx/nuttx absent"; exit 0
+    if nros_sdk_missing NUTTX_DIR include; then
+        nros_lane_skip_note nuttx "NuttX not found at $NUTTX_DIR — run: just setup nuttx"; exit 0
     fi
     nuttx_dir="${NUTTX_DIR:-$(pwd)/third-party/nuttx/nuttx}"
     rv_defconfig="$(pwd)/packages/boards/nros-board-nuttx-qemu/nuttx-config/riscv/defconfig"
@@ -474,8 +474,8 @@ build-riscv-rust:
     if ! command -v riscv-none-elf-gcc >/dev/null 2>&1; then
         nros_lane_skip_note nuttx "riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)"; exit 0
     fi
-    if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
-        nros_lane_skip_note nuttx "NUTTX_DIR unset and third-party/nuttx/nuttx absent"; exit 0
+    if nros_sdk_missing NUTTX_DIR include; then
+        nros_lane_skip_note nuttx "NuttX not found at $NUTTX_DIR — run: just setup nuttx"; exit 0
     fi
     nuttx_dir="${NUTTX_DIR:-$(pwd)/third-party/nuttx/nuttx}"
     rv_defconfig="$(pwd)/packages/boards/nros-board-nuttx-qemu/nuttx-config/riscv/defconfig"

--- a/just/nuttx.just
+++ b/just/nuttx.just
@@ -83,6 +83,14 @@ build-integration-app:
 build-examples:
     #!/usr/bin/env bash
     set -e
+    # phase-407 W2 — this `source` was MISSING, and the gate that found it is
+    # `check-named-lane-fails`. The skip below therefore never ran: on a host
+    # without NuttX the recipe died at `nros_lane_skip_note: command not found`
+    # (rc 127, under `set -e`), naming nothing and reaching neither the ledger
+    # nor `just nuttx setup`. A recipe is its own process; nothing else in this
+    # body brings the protocol in.
+    # shellcheck source=scripts/build/lane-skip.sh
+    source scripts/build/lane-skip.sh
     source scripts/build/cargo.sh
     cargo_profile_args="$(nros_cargo_profile_arg_string)"
     if [ ! -d "$NUTTX_DIR/include" ]; then
@@ -325,8 +333,11 @@ build-fixtures-arm-smp:
     # the nuttx lane runs. That is the honest price of one shared tree and it is
     # bounded; the alternative is a row-level lane predicate, which does not
     # exist and should not be invented for one fixture.
+    # phase-407 W2 — `nros_lane_out_of_scope_note`, not `nros_lane_skip_note`: nothing
+    # is missing here. The run's LANE selected no nuttx coordinate, and naming
+    # the platform cannot change that, so this stays a skip in both directions.
     if ! nros_lane_wants_platform nuttx; then
-        nros_lane_skip_note nuttx "NuttX arm-smp: no nuttx coordinate in this run's lane — skipping"
+        nros_lane_out_of_scope_note nuttx "NuttX arm-smp: no nuttx coordinate in this run's lane — skipping"
         exit 0
     fi
     if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
@@ -346,9 +357,15 @@ build-fixtures-arm-smp:
 build-fixtures-riscv:
     #!/usr/bin/env bash
     set -e
+    # phase-407 W2 — as in `build-examples`: this `source` was missing, so the
+    # narrowing note below was `command not found` rather than a note.
+    # shellcheck source=scripts/build/lane-skip.sh
+    source scripts/build/lane-skip.sh
     source scripts/build/fixture-lane.sh
+    # phase-407 W2 — a lane narrowing, not a missing prerequisite; see
+    # `build-fixtures-arm-smp` above and `nros_lane_out_of_scope_note`'s comment.
     if ! nros_lane_wants_platform nuttx-riscv; then
-        nros_lane_skip_note nuttx "NuttX riscv: no nuttx-riscv coordinate in this run's lane — skipping"
+        nros_lane_out_of_scope_note nuttx "NuttX riscv: no nuttx-riscv coordinate in this run's lane — skipping"
         exit 0
     fi
     # Issue 0583 — same build-std/vendored-libc coupling as the arm half; the

--- a/just/nuttx.just
+++ b/just/nuttx.just
@@ -162,6 +162,7 @@ build-examples:
 [group("full-matrix")]
 build-fixtures: build-fixtures-arm build-fixtures-riscv
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh nuttx build-fixtures "just build nuttx"
     set -e
     # issue 0650 — this lane had NO body at all, so it inherited `just`'s exit 0
     # from its two steps and reported success whether or not either built
@@ -505,6 +506,7 @@ build-all: build build-examples build-fixtures
 [group("main")]
 test verbose="": build-fixtures-arm
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh nuttx test "just test nuttx"
     set -e
     if [ ! -d "$NUTTX_DIR/include" ]; then
         echo "ERROR: NuttX not found at $NUTTX_DIR. Run: just nuttx setup"
@@ -583,6 +585,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh nuttx doctor "just doctor nuttx"
     set +e
     fail=0
     if [ -d "$NUTTX_DIR/arch" ]; then

--- a/just/px4.just
+++ b/just/px4.just
@@ -44,6 +44,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh px4 doctor "just doctor px4"
     set +e
     fail=0
     if [ -d "third-party/px4/px4-rs/crates" ]; then
@@ -242,6 +243,7 @@ build-examples: build-sitl-cpp
 [group("full-matrix")]
 build-fixtures:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh px4 build-fixtures "just build px4"
     set -e
     source scripts/build/cargo.sh
     PX4_DIR="${PX4_AUTOPILOT_DIR:-$(pwd)/third-party/px4/PX4-Autopilot}"

--- a/just/px4.just
+++ b/just/px4.just
@@ -246,6 +246,7 @@ build-fixtures:
     source scripts/build/cargo.sh
     PX4_DIR="${PX4_AUTOPILOT_DIR:-$(pwd)/third-party/px4/PX4-Autopilot}"
     source scripts/build/lane-skip.sh   # issue 0599 — SKIPPED, not OK
+    nros_lane_platform px4                 # phase-407 W2 — named `px4` must work
     if [ ! -d "$PX4_DIR/msg" ]; then
         nros_lane_skip "PX4-Autopilot .msg tree not found at $PX4_DIR/msg — run: just px4 setup"
     fi

--- a/just/px4.just
+++ b/just/px4.just
@@ -248,7 +248,7 @@ build-fixtures:
     source scripts/build/cargo.sh
     PX4_DIR="${PX4_AUTOPILOT_DIR:-$(pwd)/third-party/px4/PX4-Autopilot}"
     source scripts/build/lane-skip.sh   # issue 0599 — SKIPPED, not OK
-    nros_lane_platform px4                 # phase-407 W2 — named `px4` must work
+    nros_lane_platform px4                 # phase-411 W2 — named `px4` must work
     if [ ! -d "$PX4_DIR/msg" ]; then
         nros_lane_skip "PX4-Autopilot .msg tree not found at $PX4_DIR/msg — run: just px4 setup"
     fi

--- a/just/qemu-baremetal.just
+++ b/just/qemu-baremetal.just
@@ -174,6 +174,7 @@ build:
 [group("full-matrix")]
 build-fixtures:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh qemu build-fixtures "just build qemu"
     set -e
     source scripts/build/cargo.sh
     cargo_profile_args="$(nros_cargo_profile_arg_string)"
@@ -229,6 +230,7 @@ build-examples: build-fixtures
 [group("main")]
 test verbose="": build-fixtures
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh qemu test "just test qemu"
     set +e
     failed=0
     just init-test-logs
@@ -462,6 +464,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh qemu doctor "just doctor qemu"
     set +e
     # phase-334 W2.b step 2 — path from the ONE derivation (RFC-0070 R3).
     # NOTE: `QEMU_PREFIX` at the top of this file stays a literal on purpose —

--- a/just/qemu-baremetal.just
+++ b/just/qemu-baremetal.just
@@ -179,7 +179,7 @@ build-fixtures:
     source scripts/build/cargo.sh
     cargo_profile_args="$(nros_cargo_profile_arg_string)"
     source scripts/build/lane-skip.sh   # issue 0599 — SKIPPED, not OK
-    nros_lane_platform qemu                # phase-407 W2 — named `qemu` must work
+    nros_lane_platform qemu                # phase-411 W2 — named `qemu` must work
     if ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
         nros_lane_skip "arm-none-eabi-gcc not found — install the ARM bare-metal toolchain"
     fi

--- a/just/qemu-baremetal.just
+++ b/just/qemu-baremetal.just
@@ -178,6 +178,7 @@ build-fixtures:
     source scripts/build/cargo.sh
     cargo_profile_args="$(nros_cargo_profile_arg_string)"
     source scripts/build/lane-skip.sh   # issue 0599 — SKIPPED, not OK
+    nros_lane_platform qemu                # phase-407 W2 — named `qemu` must work
     if ! command -v arm-none-eabi-gcc >/dev/null 2>&1; then
         nros_lane_skip "arm-none-eabi-gcc not found — install the ARM bare-metal toolchain"
     fi

--- a/just/threadx-linux.just
+++ b/just/threadx-linux.just
@@ -118,7 +118,7 @@ build-fixture-extras:
     export cargo_profile_args
     cargo_frontends="$(nros_cargo_frontend_jobs)"
     cmake_frontends="$(nros_cmake_frontend_jobs)"
-    if [ -z "${THREADX_DIR:-}" ] && [ ! -d third-party/threadx/kernel ]; then
+    if nros_sdk_missing THREADX_DIR common/inc; then
         nros_lane_skip_note threadx-linux "THREADX_DIR unset and third-party/threadx/kernel absent"; exit 0
     fi
     echo "Building ThreadX-Linux test fixtures..."

--- a/just/threadx-linux.just
+++ b/just/threadx-linux.just
@@ -32,6 +32,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh threadx_linux doctor "just doctor threadx_linux"
     set +e
     fail=0
     if [ -d "$THREADX_DIR/common/inc" ]; then
@@ -93,6 +94,7 @@ build-examples:
 [group("full-matrix")]
 build-fixtures: build-examples build-fixture-extras
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh threadx_linux build-fixtures "just build threadx_linux"
     set -e
     # issue 0650 — the ONE place this lane says it built its fixtures, and it
     # refuses to when a step was skipped. Before this the claim was an
@@ -186,6 +188,7 @@ build-all: build-fixtures
 [group("main")]
 test verbose="": build-fixtures
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh threadx_linux test "just test threadx_linux"
     set -e
     if [ ! -d "$THREADX_DIR/common/inc" ]; then
         echo "ERROR: ThreadX not found at $THREADX_DIR. Run: just threadx-linux setup"

--- a/just/threadx-riscv64.just
+++ b/just/threadx-riscv64.just
@@ -32,6 +32,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh threadx_riscv64 doctor "just doctor threadx_riscv64"
     set +e
     fail=0
     if [ -d "$THREADX_DIR/common/inc" ]; then
@@ -170,6 +171,7 @@ build-examples:
 [group("full-matrix")]
 build-fixtures: build-examples build-fixture-extras
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh threadx_riscv64 build-fixtures "just build threadx_riscv64"
     set -e
     # issue 0650 — the ONE place this lane says it built its fixtures, and it
     # refuses to when a step was skipped. Before this the claim was an
@@ -420,6 +422,7 @@ build-all: build-fixtures
 [group("main")]
 test verbose="": build-fixtures
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh threadx_riscv64 test "just test threadx_riscv64"
     set -e
     if [ ! -d "$THREADX_DIR/common/inc" ]; then
         echo "ERROR: ThreadX not found at $THREADX_DIR. Run: just threadx-linux setup"

--- a/just/xrce.just
+++ b/just/xrce.just
@@ -21,6 +21,7 @@ setup:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh xrce doctor "just doctor xrce"
     set +e
     source scripts/build/build-root.sh
     adir="$(nros_build_dir "$NROS_KIND_XRCE_AGENT")"
@@ -54,6 +55,7 @@ clean-agent:
 [group("main")]
 test verbose="":
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh xrce test "just test xrce"
     set -e
     source scripts/build/cargo.sh
     cargo_nextest_args=($(nros_cargo_nextest_args))

--- a/just/zephyr-ci.just
+++ b/just/zephyr-ci.just
@@ -28,6 +28,11 @@ build-fixtures:
     # nothing, and the four west-owned compile-check fixtures went missing
     # twenty minutes downstream instead of being reported here.
     source scripts/build/lane-skip.sh
+    # phase-407 W2 — this recipe IS the zephyr platform lane, so `just zephyr
+    # build-fixtures` on an unprovisioned host FAILS with the remedy below
+    # instead of reporting SKIPPED. Reached through the fixture fan-out
+    # (`NROS_LANE_INCLUDED` set) it still skips, and is still reported.
+    nros_lane_platform zephyr
     trap 'for pid in $(jobs -pr); do kill "$pid" 2>/dev/null || true; done; wait; exit 130' INT TERM
     # issue 0698 follow-up — the Zephyr venv is this lane's, not the session's.
     source scripts/build/zephyr-python.sh

--- a/just/zephyr-ci.just
+++ b/just/zephyr-ci.just
@@ -29,7 +29,7 @@ build-fixtures:
     # nothing, and the four west-owned compile-check fixtures went missing
     # twenty minutes downstream instead of being reported here.
     source scripts/build/lane-skip.sh
-    # phase-407 W2 — this recipe IS the zephyr platform lane, so `just zephyr
+    # phase-411 W2 — this recipe IS the zephyr platform lane, so `just zephyr
     # build-fixtures` on an unprovisioned host FAILS with the remedy below
     # instead of reporting SKIPPED. Reached through the fixture fan-out
     # (`NROS_LANE_INCLUDED` set) it still skips, and is still reported.

--- a/just/zephyr-ci.just
+++ b/just/zephyr-ci.just
@@ -21,6 +21,7 @@
 [group("full-matrix")]
 build-fixtures:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh zephyr build-fixtures "just build zephyr"
     set -e
     source scripts/build/cargo.sh
     # issue 0599 — SKIPPED is its own verdict. These two used to `exit 0`, so a

--- a/just/zephyr-dev.just
+++ b/just/zephyr-dev.just
@@ -234,6 +234,7 @@ build-all: build build-examples build-fixtures
 [group("main")]
 test verbose="": build-fixtures
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh zephyr test "just test zephyr"
     set -e
     source scripts/build/cargo.sh
     cargo_nextest_args=($(nros_cargo_nextest_args))

--- a/just/zephyr-setup.just
+++ b/just/zephyr-setup.just
@@ -66,6 +66,7 @@ kconfig-trees *ARGS:
 [group("setup")]
 doctor:
     #!/usr/bin/env bash
+    bash scripts/dev/deprecated-scope-alias.sh zephyr doctor "just doctor zephyr"
     set +e
     fail=0
     WORKSPACE="{{ZEPHYR_WORKSPACE}}"

--- a/justfile
+++ b/justfile
@@ -3697,6 +3697,47 @@ setup target="" tier="":
                     just setup-cli
                     exec just "$target" setup
                 fi
+                # phase-407 W4 — a PRESET provisions the set it names.
+                #
+                # The menu above has advertised "Preset scopes … all native
+                # tier1 tier2 tier2-nightly" since W3, while the dispatch fell
+                # through to the legacy `--target=<platform>-<rmw>` arm and
+                # died with "is not a <platform>-<rmw> tuple". A documented
+                # scope that does not resolve is the same two-vocabularies
+                # defect one verb over, and it is what stopped a CI job from
+                # being `just setup <scope>` + `just test <scope>`.
+                #
+                # Expansion comes from `nros_lane_modules`, the same function
+                # `build` uses, so setup and build cannot disagree about what a
+                # preset contains.
+                if nros_scope_is_preset "$target"; then
+                    source scripts/build/fixture-lane.sh
+                    mods="$(nros_lane_modules "$target")" || exit 1
+                    if [ -z "$(echo $mods)" ]; then
+                        # `all` means "no narrowing", so its module list is
+                        # EMPTY — and an empty loop below would provision
+                        # nothing and exit 0, which is the silent no-op this
+                        # whole phase exists to stop. `all` is caught by the
+                        # tier arm above and cannot reach here; any other
+                        # preset that expands to nothing is a bug in the lane
+                        # tables, not a reason to succeed.
+                        printf 'setup: preset %s expands to NO modules — refusing to\n' "$target" >&2
+                        printf '       report success for provisioning nothing. Use `just setup all`\n' >&2
+                        printf '       for the full contributor setup, or name platforms.\n' >&2
+                        exit 1
+                    fi
+                    printf 'setup: preset %s -> %s\n' "$target" "$(echo $mods)"
+                    just setup-cli
+                    for m in $mods; do
+                        if nros_scope_module_has_verb "$m" setup; then
+                            printf '\n=== just setup %s ===\n' "$m"
+                            just "$m" setup
+                        else
+                            printf 'setup: %s has no `setup` recipe — nothing to provision\n' "$m"
+                        fi
+                    done
+                    exit 0
+                fi
                 exec "$(pwd)/tools/setup.sh" --target="$target"
                 ;;
         esac

--- a/justfile
+++ b/justfile
@@ -149,7 +149,7 @@ default:
         "    just ci matrix             tier 2 — 1-wise platform cover" \
         "    just ci full               tier 3 — the whole matrix" \
         "" \
-        "  A SCOPE  (phase-407 — one word, one position, every verb)" \
+        "  A SCOPE  (phase-411 — one word, one position, every verb)" \
         "    just setup  <scope>        provision it" \
         "    just doctor <scope>        is it ready? (no scope: probe them all)" \
         "    just build  <scope>        build its test fixtures" \
@@ -214,7 +214,7 @@ list-all:
 # is the only supported C/C++ consumption shape. CMake-driven crates
 # build in-tree via Corrosion when an example invokes them.
 #
-# phase-407 W3 — `just build [<scope>…]`. A scope in the first argument
+# phase-411 W3 — `just build [<scope>…]`. A scope in the first argument
 # position, the same word `setup`, `doctor` and `test` take:
 #
 #   just build tier2       the tier-2 fixture cover (was: build-test-fixtures lane=tier2)
@@ -1186,7 +1186,7 @@ test-zpico-multisession verbose="":
 # (nextest 0.9.133+), so the list lives here rather than under a
 # `[profile.fast]` default-filter.
 #
-# phase-407 W3 — `just test [<scope>…]`, one vocabulary in one position:
+# phase-411 W3 — `just test [<scope>…]`, one vocabulary in one position:
 #
 #   just test              this host, best effort: what is provisioned runs,
 #                          what is not SKIPS — and the scope line says which
@@ -1194,7 +1194,7 @@ test-zpico-multisession verbose="":
 #   just test tier2        the lane's run, narrowed to the lane's coordinates
 #
 # The first positional used to be `verbose`, so `just test 1` no longer means
-# what it did — the incompatibility phase-407 accepts. `verbose` / `-v` /
+# what it did — the incompatibility phase-411 accepts. `verbose` / `-v` /
 # `--verbose` are still recognised, as FLAGS anywhere in the argument list, so
 # the spelling people actually type keeps working.
 #
@@ -1222,7 +1222,7 @@ test *scope:
         exit "$rc"
     fi
     # The DEFAULT scope: derived by probing, reported before anything runs.
-    # phase-407's "best-effort" meaning lives here and nowhere else — a NAMED
+    # phase-411's "best-effort" meaning lives here and nowhere else — a NAMED
     # platform must work (W2), an unnamed one may skip and is always reported.
     nros_scope_report test
     echo ""
@@ -1233,7 +1233,7 @@ test *scope:
     # `|| exit` is load-bearing: this body has no `set -e` (the nextest tallying
     # below manages its own exit codes), and a dependency that used to ABORT the
     # recipe must not degrade into a warning the run continues past. That would
-    # be exactly the defect phase-407 is about — a preflight that reports and is
+    # be exactly the defect phase-411 is about — a preflight that reports and is
     # then ignored.
     just _require-build-sources _require-fixtures-ready test-zpico-multisession || exit 1
     # issue 0923 — sweep BEFORE nextest, for the same reason `test-all` does
@@ -1543,7 +1543,7 @@ build-test-fixtures-leaves lane="all": _require-leaf-includes
         # the module is filtered OUT (a false compound command is a failure), so
         # the skip is an explicit `if`.
         #
-        # phase-407 W2 — `NROS_LANE_INCLUDED` is what makes a skip legitimate
+        # phase-411 W2 — `NROS_LANE_INCLUDED` is what makes a skip legitimate
         # here: the operator asked for a LANE, not for these platforms by name,
         # so an unprovisioned one is reported (78 -> SKIPPED) rather than failed.
         # It is set per stage rather than exported once, so it names the platform
@@ -1672,7 +1672,7 @@ build-test-fixtures-leaves lane="all": _require-leaf-includes
             # until `_lane-gate` failed on artifacts twenty minutes later. The
             # reason comes back through the lane log's `NROS_LANE_SKIP:` marker.
             #
-            # phase-407 W2 — `NROS_LANE_INCLUDED=<platform>` is what ENTITLES
+            # phase-411 W2 — `NROS_LANE_INCLUDED=<platform>` is what ENTITLES
             # this stage to that third verdict. These platforms were selected by
             # a lane, not typed by the operator, so an absent SDK is reported and
             # not failed. A direct `just <plat> build-fixtures` leaves the
@@ -3631,7 +3631,7 @@ setup target="" tier="":
           "  just setup <scope>           # focused setup, e.g. zephyr, freertos, nuttx" \
           "  just setup all               # full contributor/test-all setup; fetches all SDKs" \
           "" \
-          "SCOPE is one word in one position, for every verb (phase-407):" \
+          "SCOPE is one word in one position, for every verb (phase-411):" \
           "" \
           "  just setup zephyr            # provision it" \
           "  just doctor zephyr           # is it ready?" \
@@ -3673,7 +3673,7 @@ setup target="" tier="":
             base|quickstart|minimal|default|all|everything|contributor|extended)
                 chosen_tier="$target"
                 ;;
-            # phase-407 W3 — the platform arm is now the SCOPE predicate, not a
+            # phase-411 W3 — the platform arm is now the SCOPE predicate, not a
             # second hand-written list of platform names. The list had already
             # drifted (`native` was missing, `rmw_zenoh` names no module), and a
             # scope that resolves for `doctor`/`build`/`test` and silently falls
@@ -3697,7 +3697,7 @@ setup target="" tier="":
                     just setup-cli
                     exec just "$target" setup
                 fi
-                # phase-407 W4 — a PRESET provisions the set it names.
+                # phase-411 W4 — a PRESET provisions the set it names.
                 #
                 # The menu above has advertised "Preset scopes … all native
                 # tier1 tier2 tier2-nightly" since W3, while the dispatch fell
@@ -3772,7 +3772,7 @@ setup-platform platform:
 
 # Diagnose install status (read-only) — `just doctor [<scope>…]`.
 #
-# phase-407 W3. The scope is the SPECIFICATION, in the same argument position
+# phase-411 W3. The scope is the SPECIFICATION, in the same argument position
 # every other verb takes it:
 #
 #   just doctor              this host: the shared tooling, then a PROBE of
@@ -3867,7 +3867,7 @@ _doctor-scope tok:
     nros_scope_reject "$tok"
 
 # The host's shared tooling — the CLI, python, clang-format, sccache, the ROS
-# router. Extracted from `doctor` by phase-407 W3 so `just doctor native` and
+# router. Extracted from `doctor` by phase-411 W3 so `just doctor native` and
 # the default scope reach the SAME block rather than a second copy of it.
 [private]
 _doctor-host:

--- a/justfile
+++ b/justfile
@@ -1378,10 +1378,17 @@ build-test-fixtures-leaves lane="all": _require-leaf-includes
         # `in_lane … && run_stage …` would abort the recipe under `set -e` when
         # the module is filtered OUT (a false compound command is a failure), so
         # the skip is an explicit `if`.
-        if in_lane zephyr; then run_stage zephyr just zephyr build-fixtures; fi
+        #
+        # phase-407 W2 — `NROS_LANE_INCLUDED` is what makes a skip legitimate
+        # here: the operator asked for a LANE, not for these platforms by name,
+        # so an unprovisioned one is reported (78 -> SKIPPED) rather than failed.
+        # It is set per stage rather than exported once, so it names the platform
+        # in the child's environment and cannot leak to an unrelated `just` this
+        # recipe might later run. Unset is NAMED — see scripts/build/lane-skip.sh.
+        if in_lane zephyr; then run_stage zephyr env NROS_LANE_INCLUDED=zephyr just zephyr build-fixtures; fi
         for platform in native qemu freertos nuttx threadx_linux threadx_riscv64 esp32 px4; do
             in_lane "$platform" || continue
-            run_stage "$platform" just "$platform" build-fixtures
+            run_stage "$platform" env "NROS_LANE_INCLUDED=$platform" just "$platform" build-fixtures
         done
         exit 0
     fi
@@ -1500,8 +1507,16 @@ build-test-fixtures-leaves lane="all": _require-leaf-includes
             # printing it as OK is what hid an unprovisioned Zephyr workspace
             # until `_lane-gate` failed on artifacts twenty minutes later. The
             # reason comes back through the lane log's `NROS_LANE_SKIP:` marker.
-            printf '\t+@start=$$(date +%%s); status=0; echo "== %s =="; ( env %s NROS_BUILD_JOBS=%q just %q build-fixtures ) >%q 2>&1 || status=$$?; end=$$(date +%%s); printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" %q "$$start" "$$end" "$$((end - start))" "$$status" >>%q; if [ "$$status" -eq 78 ]; then echo "== %s == SKIPPED ($$(sed -n "s/^NROS_LANE_SKIP: //p" %q | tail -1))"; else if [ "$$status" -ne 0 ]; then echo "== %s == FAILED (rc=$$status); log tail:"; tail -40 %q || true; exit "$$status"; fi; echo "== %s == OK"; fi\n\n' \
-                "$platform" "$NROS_STAGE_ENV" "$child_jobs" "$platform" "$log" "$platform" "$joblog" "$platform" "$log" "$platform" "$log" "$platform"
+            #
+            # phase-407 W2 — `NROS_LANE_INCLUDED=<platform>` is what ENTITLES
+            # this stage to that third verdict. These platforms were selected by
+            # a lane, not typed by the operator, so an absent SDK is reported and
+            # not failed. A direct `just <plat> build-fixtures` leaves the
+            # variable unset, is therefore NAMED, and fails instead. Unset =
+            # NAMED is the deliberate default: a driver that forgets this
+            # assignment goes red rather than quietly staying green.
+            printf '\t+@start=$$(date +%%s); status=0; echo "== %s =="; ( env %s NROS_LANE_INCLUDED=%q NROS_BUILD_JOBS=%q just %q build-fixtures ) >%q 2>&1 || status=$$?; end=$$(date +%%s); printf "%%s\\t%%s\\t%%s\\t%%s\\t%%s\\n" %q "$$start" "$$end" "$$((end - start))" "$$status" >>%q; if [ "$$status" -eq 78 ]; then echo "== %s == SKIPPED ($$(sed -n "s/^NROS_LANE_SKIP: //p" %q | tail -1))"; else if [ "$$status" -ne 0 ]; then echo "== %s == FAILED (rc=$$status); log tail:"; tail -40 %q || true; exit "$$status"; fi; echo "== %s == OK"; fi\n\n' \
+                "$platform" "$NROS_STAGE_ENV" "$platform" "$child_jobs" "$platform" "$log" "$platform" "$joblog" "$platform" "$log" "$platform" "$log" "$platform"
         done
     } > "$makefile"
     # issue 0762 — run the fan-out under ONE process group, so killing this

--- a/justfile
+++ b/justfile
@@ -149,9 +149,20 @@ default:
         "    just ci matrix             tier 2 — 1-wise platform cover" \
         "    just ci full               tier 3 — the whole matrix" \
         "" \
-        "  A PLATFORM" \
-        "    just native build|test     also: zephyr freertos nuttx esp32 qemu" \
-        "    just <plat> setup          provision its toolchain/SDK" \
+        "  A SCOPE  (phase-407 — one word, one position, every verb)" \
+        "    just setup  <scope>        provision it" \
+        "    just doctor <scope>        is it ready? (no scope: probe them all)" \
+        "    just build  <scope>        build its test fixtures" \
+        "    just test   <scope>        run its tests" \
+        "" \
+        "    scope = a platform   native zephyr freertos nuttx threadx_linux" \
+        "                         threadx_riscv64 esp32 esp_idf qemu px4 xrce" \
+        "                         cyclonedds" \
+        "         or a preset     all native tier1 tier2 tier2-nightly" \
+        "" \
+        "    Naming a scope IS the specification: it is what you asked to be" \
+        "    covered. Unnamed = best effort over what is provisioned, reported." \
+        "    (\`just <plat> <verb>\` still works, deprecated for one release.)" \
         "" \
         "  SETUP" \
         "    source ./activate.sh       REQUIRED once per shell" \
@@ -202,12 +213,75 @@ list-all:
 # Phase 140 — `install-local` removed; `add_subdirectory(<repo-root>)`
 # is the only supported C/C++ consumption shape. CMake-driven crates
 # build in-tree via Corrosion when an example invokes them.
+#
+# phase-407 W3 — `just build [<scope>…]`. A scope in the first argument
+# position, the same word `setup`, `doctor` and `test` take:
+#
+#   just build tier2       the tier-2 fixture cover (was: build-test-fixtures lane=tier2)
+#   just build native      every native fixture row     (was: lane=native)
+#   just build zephyr      one platform's fixtures      (was: just zephyr build-fixtures)
+#
+# A LANE token routes through `build-test-fixtures`, because that is what
+# writes the coverage stamp `_require-fixtures` reads; a PLATFORM token routes
+# to `just <plat> build-fixtures`, which is the same call that recipe's own
+# fan-out makes. Same scope, the machinery each already has.
+#
+# WITH NO SCOPE this stays the workspace build — deliberately NOT "the fixtures
+# for everything provisioned". `just build` is the documented fast inner loop
+# (book/src/internals/build-system.md), minutes not hours, and silently
+# promoting it to a fixture sweep would be the most expensive surprise in the
+# tree. What it gains instead is the derived default scope PRINTED, so the
+# question "what would `just build <scope>` cover here?" is answered without
+# anyone recording an answer.
+#
+# Workspace + transports; with a scope, that scope's test fixtures.
 [group("main")]
-build: \
-    generate-bindings \
-    build-workspace build-workspace-embedded \
-    qemu::build-zenoh-pico
-    @echo 'Workspace + transports built. Run "just build-examples" for example crates, "just build-test-fixtures" for `test-all` staging, or "just build-all" for everything.'
+build *scope:
+    #!/usr/bin/env bash
+    set -e
+    # shellcheck source=scripts/build/scope.sh
+    source scripts/build/scope.sh
+    scoped=({{scope}})
+    if [ "${#scoped[@]}" -gt 0 ]; then
+        nros_scope_validate_all "${scoped[@]}" || exit 2
+        nros_scope_report build "${scoped[@]}"
+        for tok in "${scoped[@]}"; do
+            just _build-scope "$tok"
+        done
+        exit 0
+    fi
+    # The pre-407 dependency list, called rather than depended on: a recipe
+    # with a variadic parameter still runs its dependencies unconditionally,
+    # and a scoped `just build zephyr` must not first rebuild the workspace.
+    just generate-bindings build-workspace build-workspace-embedded
+    just qemu build-zenoh-pico
+    echo 'Workspace + transports built. Run "just build-examples" for example crates, "just build <scope>" for `test-all` fixture staging, or "just build-all" for everything.'
+    echo ""
+    nros_scope_report build
+
+# One scope token's fixture build.
+[private]
+_build-scope tok:
+    #!/usr/bin/env bash
+    set -e
+    # shellcheck source=scripts/build/scope.sh
+    source scripts/build/scope.sh
+    tok="$(nros_scope_normalize "{{tok}}")"
+    # LANE first, unlike `_test-scope`: a lane build stamps its coverage
+    # (`nros_fixtures_stamp_write`), and `native` is a lane, so the stamped
+    # path is the better answer for the one token that is both.
+    if nros_scope_is_lane "$tok"; then
+        nros_scope_exec just build-test-fixtures "lane=$tok"
+        exit 0
+    fi
+    if nros_scope_is_platform "$tok"; then
+        nros_scope_require_module_verb "$tok" build-fixtures
+        echo "note: a single-platform build writes no fixture stamp; \`just test\` still" >&2
+        echo "      wants a lane build (\`just build native|tier1|tier2|all\`)." >&2
+        nros_scope_exec just "$tok" build-fixtures
+        exit 0
+    fi
+    nros_scope_reject "$tok"
 
 # `build` + every example crate + per-RTOS example builds (native,
 # freertos, threadx_linux, threadx_riscv64). Use to verify the
@@ -1111,9 +1185,57 @@ test-zpico-multisession verbose="":
 # `.config/nextest.toml`. `group(...)` is a CLI-only predicate
 # (nextest 0.9.133+), so the list lives here rather than under a
 # `[profile.fast]` default-filter.
+#
+# phase-407 W3 — `just test [<scope>…]`, one vocabulary in one position:
+#
+#   just test              this host, best effort: what is provisioned runs,
+#                          what is not SKIPS — and the scope line says which
+#   just test zephyr       one platform, NAMED, so it must work rather than skip
+#   just test tier2        the lane's run, narrowed to the lane's coordinates
+#
+# The first positional used to be `verbose`, so `just test 1` no longer means
+# what it did — the incompatibility phase-407 accepts. `verbose` / `-v` /
+# `--verbose` are still recognised, as FLAGS anywhere in the argument list, so
+# the spelling people actually type keeps working.
+#
+# Run the tests for a scope; with no scope, this host, best effort.
 [group("main")]
-test verbose="": _require-build-sources _require-fixtures-ready test-zpico-multisession
+test *scope:
     #!/usr/bin/env bash
+    # shellcheck source=scripts/build/scope.sh
+    source scripts/build/scope.sh
+    verbose=""
+    scoped=()
+    for tok in {{scope}}; do
+        case "$tok" in
+            -v | --verbose | verbose) verbose="verbose" ;;
+            *) scoped+=("$tok") ;;
+        esac
+    done
+    if [ "${#scoped[@]}" -gt 0 ]; then
+        nros_scope_validate_all "${scoped[@]}" || exit 2
+        nros_scope_report test "${scoped[@]}"
+        rc=0
+        for tok in "${scoped[@]}"; do
+            just _test-scope "$tok" "$verbose" || rc=1
+        done
+        exit "$rc"
+    fi
+    # The DEFAULT scope: derived by probing, reported before anything runs.
+    # phase-407's "best-effort" meaning lives here and nowhere else — a NAMED
+    # platform must work (W2), an unnamed one may skip and is always reported.
+    nros_scope_report test
+    echo ""
+    # Pre-407 these were recipe DEPENDENCIES. A dependency runs whatever the
+    # arguments say, so a scoped `just test zephyr` would have paid for the
+    # host fixture preflight it does not use.
+    #
+    # `|| exit` is load-bearing: this body has no `set -e` (the nextest tallying
+    # below manages its own exit codes), and a dependency that used to ABORT the
+    # recipe must not degrade into a warning the run continues past. That would
+    # be exactly the defect phase-407 is about — a preflight that reports and is
+    # then ignored.
+    just _require-build-sources _require-fixtures-ready test-zpico-multisession || exit 1
     # issue 0923 — sweep BEFORE nextest, for the same reason `test-all` does
     # (issue 0659). This lane runs the same suites and spawns the same peers,
     # and a SIGKILLed run leaves them: `PR_SET_PDEATHSIG` reaches `bash` only,
@@ -1140,7 +1262,9 @@ test verbose="": _require-build-sources _require-fixtures-ready test-zpico-multi
     # instead of skipping. All three binaries are entirely QEMU/Zephyr e2e.
     exclude='not (group(=qemu-baremetal) or group(=qemu-freertos) or group(=qemu-nuttx) or group(=qemu-threadx-riscv) or binary(esp32_emulator) or group(=threadx-linux) or group(=qemu-zephyr) or group(=qemu-zephyr-xrce) or group(=zephyr-fvp) or group(=ros2-interop) or binary(xrce_ros2_interop) or binary(rtos_e2e) or binary(zephyr))'
     args=(--workspace "${nextest_run_profile_args[@]}" "${nextest_fail_fast_args[@]}" -E "$exclude")
-    if [ -z "{{verbose}}" ]; then
+    # A shell variable, not a recipe parameter: the first positional is SCOPE
+    # now, and verbosity is a flag parsed out of it at the top of this body.
+    if [ -z "$verbose" ]; then
         args+=(--success-output never --failure-output never)
     fi
     nros_nextest_record_begin test
@@ -1177,6 +1301,46 @@ test verbose="": _require-build-sources _require-fixtures-ready test-zpico-multi
     else
         echo "All standard tests passed! (Miri skipped — run \`just test-miri\` or \`just test-all\`.)"
     fi
+
+# One scope token's test run.
+#
+# PLATFORM first, unlike `_build-scope`: `native` is both a platform module and
+# a lane, and for a RUN the module is the right machinery — `just native test`
+# is that platform's suite, whereas the `native` LANE narrows nothing (it is
+# module-level) and would hand `test-all` the whole tree. Both readings are the
+# same SCOPE, which is what `check-scope-namespace` asserts; only the machinery
+# differs, and each verb picks the one that exists for it.
+[private]
+_test-scope tok verbose="":
+    #!/usr/bin/env bash
+    set -e
+    # shellcheck source=scripts/build/scope.sh
+    source scripts/build/scope.sh
+    tok="$(nros_scope_normalize "{{tok}}")"
+    if nros_scope_is_platform "$tok"; then
+        nros_scope_require_module_verb "$tok" test
+        nros_scope_exec just "$tok" test {{verbose}}
+        exit 0
+    fi
+    if nros_scope_is_preset "$tok"; then
+        # shellcheck source=scripts/build/fixture-lane.sh
+        source scripts/build/fixture-lane.sh
+        if [ "$tok" = "all" ]; then
+            nros_scope_exec env NROS_FIXTURE_LANE=all just test-all {{verbose}}
+            exit 0
+        fi
+        # The lane's own coordinate file reaching BOTH the preflight and the
+        # run — the same two-variable pairing `ci::matrix` uses, and for the
+        # same reason (issue 0482: a lane-scoped build accepted for an
+        # unnarrowed run fails ~231 fixtures later).
+        coords="$(nros_lane_coords_file "$tok")"
+        coords="$(cd "$(dirname "$coords")" && pwd)/$(basename "$coords")"
+        nros_scope_exec env "NROS_FIXTURE_LANE=$tok" "NROS_TEST_COORDS=$coords" \
+            just test-all {{verbose}}
+        exit 0
+    fi
+    nros_scope_reject "$tok"
+
 # Build ONLY the compile-check fixtures (issue 0034 / issue 0871).
 #
 # `check::source-gates` runs three `cargo test`s that ASSERT a prebuilt
@@ -3464,24 +3628,30 @@ setup target="" tier="":
           "nano-ros setup choices:" \
           "" \
           "  just setup base              # first-time native/ROS/zenoh quick start" \
-          "  just setup <platform>        # focused platform setup, e.g. zephyr, freertos, nuttx" \
+          "  just setup <scope>           # focused setup, e.g. zephyr, freertos, nuttx" \
           "  just setup all               # full contributor/test-all setup; fetches all SDKs" \
           "" \
-          "Common platform setup commands:" \
+          "SCOPE is one word in one position, for every verb (phase-407):" \
           "" \
-          "  just setup zephyr" \
-          "  just setup freertos" \
-          "  just setup nuttx" \
-          "  just setup threadx_linux" \
-          "  just setup threadx_riscv64" \
-          "  just setup esp32" \
-          "  just setup esp_idf" \
-          "  just setup px4" \
+          "  just setup zephyr            # provision it" \
+          "  just doctor zephyr           # is it ready?" \
+          "  just build zephyr            # build its test fixtures" \
+          "  just test zephyr             # run its tests" \
+          "" \
+          "Platform scopes:" \
+          "" \
+          "  native zephyr freertos nuttx threadx_linux threadx_riscv64" \
+          "  esp32 esp_idf qemu px4 xrce cyclonedds" \
+          "" \
+          "Preset scopes (a named set of platforms — the fixture lanes):" \
+          "" \
+          "  all native tier1 tier2 tier2-nightly" \
           "" \
           "Readiness checks:" \
           "" \
-          "  just doctor                  # base readiness" \
-          "  just doctor tier=all         # full contributor readiness" \
+          "  just doctor                  # host tooling + a PROBE of every platform" \
+          "  just doctor <scope>          # one platform, or a preset's set" \
+          "  just doctor tier=all         # the pre-407 tier walk (adds workspace/verification)" \
           "" \
           "Fresh checkout without just:" \
           "" \
@@ -3503,13 +3673,30 @@ setup target="" tier="":
             base|quickstart|minimal|default|all|everything|contributor|extended)
                 chosen_tier="$target"
                 ;;
-            workspace|verification|qemu|freertos|nuttx|threadx_linux|threadx_riscv64|esp32|zephyr|xrce|rmw_zenoh|cyclonedds|esp_idf|px4)
-                # Focused platform setup may still shell `nros setup …`;
-                # build the CLI first so the binary is on disk.
+            # phase-407 W3 — the platform arm is now the SCOPE predicate, not a
+            # second hand-written list of platform names. The list had already
+            # drifted (`native` was missing, `rmw_zenoh` names no module), and a
+            # scope that resolves for `doctor`/`build`/`test` and silently falls
+            # through here is exactly the two-vocabularies defect this phase
+            # exists to remove.
+            #
+            # `workspace` and `verification` stay spelled out: they are
+            # deliberately NOT scope tokens (see scripts/build/scope.sh) but
+            # they do have `setup`, and `just setup workspace` predates 407.
+            workspace | verification | rmw_zenoh)
                 just setup-cli
                 exec just "$target" setup
                 ;;
             *)
+                # shellcheck source=scripts/build/scope.sh
+                source scripts/build/scope.sh
+                if nros_scope_is_platform "$target" \
+                   && nros_scope_module_has_verb "$target" setup; then
+                    # Focused platform setup may still shell `nros setup …`;
+                    # build the CLI first so the binary is on disk.
+                    just setup-cli
+                    exec just "$target" setup
+                fi
                 exec "$(pwd)/tools/setup.sh" --target="$target"
                 ;;
         esac
@@ -3542,18 +3729,109 @@ setup target="" tier="":
 setup-platform platform:
     @just "{{platform}}" setup
 
-# Diagnose install status (read-only). Tier matches `just setup`.
+# Diagnose install status (read-only) — `just doctor [<scope>…]`.
+#
+# phase-407 W3. The scope is the SPECIFICATION, in the same argument position
+# every other verb takes it:
+#
+#   just doctor              this host: the shared tooling, then a PROBE of
+#                            every platform, so the answer to "what am I
+#                            covered for?" is derived rather than remembered
+#   just doctor zephyr       one platform's readiness, with its remedies
+#   just doctor tier2        every platform that lane covers
+#   just doctor tier=all     the pre-407 tier spelling, still honoured
+#
+# The tier form stays because it is in the book, in `scripts/bootstrap.sh` and
+# in muscle memory, and because the tier fan-out reaches modules that are not
+# scopes (`workspace`, `verification`) — see `scripts/build/scope.sh` for why
+# those are deliberately outside the scope namespace.
+#
+# Readiness for a scope; with no scope, the host plus a probe of every platform.
 [group("setup")]
-doctor tier="":
+doctor *scope:
     #!/usr/bin/env bash
     set -e
-    chosen_tier="{{tier}}"
-    if [[ "$chosen_tier" == tier=* ]]; then
-        chosen_tier="${chosen_tier#tier=}"
+    # shellcheck source=scripts/build/scope.sh
+    source scripts/build/scope.sh
+    chosen_tier=""
+    scoped=()
+    for tok in {{scope}}; do
+        case "$tok" in
+            # The TIER vocabulary (`_orchestrate`), which is not the scope
+            # vocabulary: it walks tooling modules too. Kept verbatim.
+            tier=*) chosen_tier="${tok#tier=}" ;;
+            # `all` takes the TIER reading here, so `just setup all` and
+            # `just doctor all` mirror each other and `scripts/bootstrap.sh
+            # doctor all` keeps working. The tier is a strict superset of the
+            # `all` PRESET (it adds `workspace` and `verification`), so nothing
+            # a scope reading would have reported is lost.
+            all|base|quickstart|minimal|default|everything|contributor|extended)
+                chosen_tier="$tok" ;;
+            *) scoped+=("$tok") ;;
+        esac
+    done
+    if [ "${#scoped[@]}" -gt 0 ]; then
+        if [ -n "$chosen_tier" ]; then
+            echo "doctor: 'tier=$chosen_tier' and a scope name together — pick one." >&2
+            echo "        The scope namespace replaces the tier one:  just doctor ${scoped[*]}" >&2
+            exit 2
+        fi
+        nros_scope_validate_all "${scoped[@]}" || exit 2
+        nros_scope_report doctor "${scoped[@]}"
+        rc=0
+        for tok in "${scoped[@]}"; do
+            just _doctor-scope "$tok" || rc=1
+        done
+        exit "$rc"
     fi
     if [[ -z "$chosen_tier" ]]; then
         chosen_tier="${NROS_SETUP_TIER:-base}"
     fi
+    just _doctor-host
+    just _orchestrate doctor "$chosen_tier"
+    # The DERIVED default scope — every platform probed, nothing recorded.
+    # This is the line that makes an absent platform visible at the moment a
+    # person is asking about readiness, instead of as a skip inside a green run.
+    echo ""
+    nros_scope_report doctor
+
+# One scope token's readiness. `native` is the host, so its readiness IS the
+# shared-tooling block — there is no `native` module `doctor` to call and there
+# should not be one, since a second host probe is a second answer.
+[private]
+_doctor-scope tok:
+    #!/usr/bin/env bash
+    set -e
+    # shellcheck source=scripts/build/scope.sh
+    source scripts/build/scope.sh
+    tok="$(nros_scope_normalize "{{tok}}")"
+    if nros_scope_is_platform "$tok"; then
+        echo ""
+        echo "=== $tok ==="
+        if [ "$tok" = "native" ]; then
+            nros_scope_exec just _doctor-host
+            exit 0
+        fi
+        nros_scope_require_module_verb "$tok" doctor
+        nros_scope_exec just "$tok" doctor
+        exit 0
+    fi
+    if nros_scope_is_preset "$tok"; then
+        rc=0
+        for p in $(nros_scope_preset_expand "$tok"); do
+            just _doctor-scope "$p" || rc=1
+        done
+        exit "$rc"
+    fi
+    nros_scope_reject "$tok"
+
+# The host's shared tooling — the CLI, python, clang-format, sccache, the ROS
+# router. Extracted from `doctor` by phase-407 W3 so `just doctor native` and
+# the default scope reach the SAME block rather than a second copy of it.
+[private]
+_doctor-host:
+    #!/usr/bin/env bash
+    set -e
     # Phase 218.D.4 — CLI binary + version on a single line. Read-only;
     # uses the same resolver as every recipe that shells `nros …`, so a
     # skew between resolver and what doctor reports is impossible.
@@ -3713,7 +3991,6 @@ doctor tier="":
         echo "         than as absent coverage."
         echo "         Install:  nros setup --system    (declared in nros-sdk-index.toml)"
     fi
-    just _orchestrate doctor "$chosen_tier"
 
 # Internal: walk every module in `tier` calling the requested recipe
 # (setup or doctor). `base` is the safe quick-start tier; `all` is the

--- a/justfile
+++ b/justfile
@@ -4075,7 +4075,13 @@ _orchestrate verb tier="everything":
             run esp32
             run zephyr
             run xrce
-            run rmw_zenoh
+            # No `run rmw_zenoh` — phase-362 / RFC-0075 retired the vendored
+            # router (`third-party/zenoh/zenoh/` and `build/zenohd/` are GONE);
+            # the router now comes from ROS as `rmw_zenoh_cpp`. The line
+            # survived the retirement and named a module that does not exist,
+            # so `just setup all` / `just doctor tier=all` reported a failure
+            # nobody could fix — measured 2026-08-31: "doctor finished with 3
+            # failure(s): workspace verification rmw_zenoh".
             run cyclonedds
             run esp_idf
             run px4

--- a/packages/testing/nros-tests/src/buckets.rs
+++ b/packages/testing/nros-tests/src/buckets.rs
@@ -43,12 +43,38 @@ impl CiTier {
     /// The `just` recipe that runs this tier. This is the wiring point: the
     /// justfile tier recipes ARE the ladder the bucket map declares, and
     /// `ci_tier_ladder_matches_justfile_recipes` gates that they stay in step.
+    /// The justfile TEXT that defines this tier's recipe, plus the bare recipe
+    /// name inside it — `("just/ci.just" body, "matrix")`.
+    ///
+    /// phase-399 moved the tiers into `mod ci`, so a tier recipe is NOT at
+    /// column 0 of the root justfile any more. Two tests needed to know that
+    /// and only one was taught, so the other kept failing on a rung it could
+    /// not see. One resolver, used by both — a second spelling of this lookup
+    /// is what produced the split in the first place.
+    pub fn justfile_source(self) -> Option<(String, &'static str)> {
+        let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../justfile");
+        match self.just_recipe().split_once(' ') {
+            Some((module, name)) => {
+                let path = format!("{}/../../../just/{module}.just", env!("CARGO_MANIFEST_DIR"));
+                std::fs::read_to_string(path).ok().map(|t| (t, name))
+            }
+            None => std::fs::read_to_string(root)
+                .ok()
+                .map(|t| (t, self.just_recipe())),
+        }
+    }
+
     pub fn just_recipe(self) -> &'static str {
         match self {
-            CiTier::Tier1 => "ci",
-            CiTier::Tier2 => "ci-matrix",
-            CiTier::Tier2Nightly => "ci-matrix-nightly",
-            CiTier::Tier3 => "ci-full",
+            // phase-399 moved the tiers into `mod ci`, so the canonical
+            // spelling is `just ci <tier>`. The flat `ci-matrix` forwarders
+            // still resolve, but naming a deprecated spelling in the SSoT is
+            // how the ladder drifts from the surface — which is exactly what
+            // this ladder exists to prevent, one level up.
+            CiTier::Tier1 => "ci tier1",
+            CiTier::Tier2 => "ci matrix",
+            CiTier::Tier2Nightly => "ci matrix-nightly",
+            CiTier::Tier3 => "ci full",
         }
     }
 
@@ -247,21 +273,27 @@ mod tests {
     /// justfile is a checked consumer of the Rust-side ladder.
     #[test]
     fn ci_tier_ladder_matches_justfile_recipes() {
-        let justfile = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../justfile");
-        let Ok(text) = std::fs::read_to_string(justfile) else {
-            return; // out-of-tree checkout; nothing to gate
-        };
+        // No root-justfile read here: `justfile_source()` resolves the file
+        // per tier (module recipes live in `just/<mod>.just`) and returns None
+        // out-of-tree, which is the same guard this used to do by hand.
         for tier in CiTier::ALL {
             let recipe = tier.just_recipe();
+            // `just <mod> <recipe>` since phase-399: the tiers live in
+            // `just/<mod>.just`, not at column 0 of the root justfile. The
+            // previous version of this check only knew the flat form, so it
+            // could not see ANY module recipe and failed on `Tier1` for as
+            // long as the tiers had been modules — a red that carried no
+            // signal because it never went green.
+            let Some((body, name)) = tier.justfile_source() else {
+                continue; // out-of-tree checkout; nothing to gate
+            };
             // A recipe line is `<name>:` or `<name> <args>:` at column 0.
-            let found = text.lines().any(|l| {
-                l.starts_with(recipe)
-                    && l[recipe.len()..].starts_with([':', ' '])
-                    && l.contains(':')
+            let found = body.lines().any(|l| {
+                l.starts_with(name) && l[name.len()..].starts_with([':', ' ']) && l.contains(':')
             });
             assert!(
                 found,
-                "CiTier::{tier:?} declares `just {recipe}` but the justfile has no such \
+                "CiTier::{tier:?} declares `just {recipe}` but its justfile has no `{name}` \
                  recipe — the tier ladder and the justfile drifted (rename one to match)"
             );
         }

--- a/packages/testing/nros-tests/src/ci_lane.rs
+++ b/packages/testing/nros-tests/src/ci_lane.rs
@@ -506,6 +506,8 @@ mod tests {
     /// fails here instead of in a sweep three hours later.
     #[test]
     fn build_fanout_names_every_module_the_matrix_can_select() {
+        // This one DOES read the root justfile: the fan-out loop lives there,
+        // not in a module.
         let justfile = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../justfile");
         let Ok(text) = std::fs::read_to_string(justfile) else {
             return; // out-of-tree checkout; nothing to gate
@@ -556,19 +558,23 @@ mod tests {
     fn recipes_run_the_scope_their_lane_declares() {
         use crate::buckets::CiTier;
 
-        let justfile = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../justfile");
-        let Ok(text) = std::fs::read_to_string(justfile) else {
-            return; // out-of-tree checkout; nothing to gate
-        };
+        // No root-justfile read: `justfile_source()` resolves the file per tier
+        // (module recipes live in `just/<mod>.just`) and returns None
+        // out-of-tree, which is the guard this used to do by hand.
 
         for lane in ALL {
-            let recipe = CiTier::of_lane(lane).just_recipe();
+            let tier = CiTier::of_lane(lane);
+            let recipe = tier.just_recipe();
+            // Same resolver as ci_tier_ladder_matches_justfile_recipes — the
+            // tiers are module recipes since phase-399 and this test used to
+            // look only at column 0 of the root justfile.
+            let Some((text, name)) = tier.justfile_source() else {
+                continue;
+            };
             // The recipe body: from the `<name>:`/`<name> <args>:` line to the
             // next line at column 0 that is not blank and not indented.
             let mut lines = text.lines().skip_while(|l| {
-                !(l.starts_with(recipe)
-                    && l[recipe.len()..].starts_with([':', ' '])
-                    && l.contains(':'))
+                !(l.starts_with(name) && l[name.len()..].starts_with([':', ' ']) && l.contains(':'))
             });
             let header = lines.next().unwrap_or_else(|| {
                 panic!("justfile has no `{recipe}` recipe (gated by ci_tier_ladder_matches_justfile_recipes)")

--- a/scripts/build/fixture-lane.sh
+++ b/scripts/build/fixture-lane.sh
@@ -323,6 +323,28 @@ nros_fixtures_stamp_clear() {
     printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${NROS_FIXTURE_STAMP}.started" 2>/dev/null || true
 }
 
+# nros_fixtures_skipped_modules [joblog]
+#
+# The modules this build did NOT achieve, from the fan-out's own joblog — one
+# `<stage>\t<start>\t<end>\t<dur>\t<status>` row per module, status 78 being
+# `nros_lane_skip` ("a precondition is missing"), issue 0599.
+#
+# phase-407 W1. The stamp used to record the lane's NOMINAL coordinates, from
+# the manifest, regardless of what the build achieved — so a module that skipped
+# for a missing toolchain still read as covered, `nros_fixtures_stamp_require`
+# answered "yes, covered", and the run proceeded to skip its tests. The skip was
+# laundered into a coverage claim, and every consumer downstream read the claim
+# instead of the reality.
+#
+# The build already knew. This just writes it down.
+nros_fixtures_skipped_modules() {
+    local joblog="${1:-tmp/build-test-fixtures-latest/build-test-fixtures.joblog}"
+    [ -r "$joblog" ] || return 0
+    # Field 5 is the status. 78 = SKIPPED; a non-zero, non-78 status aborts the
+    # fan-out, so it cannot reach the stamp and needs no arm here.
+    awk -F'\t' 'NR>1 && $5==78 {print $1}' "$joblog" 2>/dev/null | sort -u
+}
+
 # nros_fixtures_stamp_write <lane>
 #
 # Called only after a build succeeds. Records the lane AND the coordinate set,
@@ -334,6 +356,8 @@ nros_fixtures_stamp_write() {
     if [ "$lane" != "all" ]; then
         coords="$(nros_lane_coords_file "$lane")" || return 1
     fi
+    local skipped
+    skipped="$(nros_fixtures_skipped_modules | tr '\n' ' ')"
     mkdir -p "$(dirname "$NROS_FIXTURE_STAMP")"
     {
         echo "# nano-ros fixture build stamp (issue 0393) — lane + coordinates built"
@@ -345,10 +369,34 @@ nros_fixtures_stamp_write() {
             echo "started_at=$(cat "${NROS_FIXTURE_STAMP}.started")"
         fi
         echo "lane=$lane"
+        # phase-407 W1 — what the build ACHIEVED, not only what it was asked
+        # for. A consumer that reads `lane=` alone is reading an intention.
+        local m
+        for m in $skipped; do echo "skipped_module=$m"; done
         if [ -n "$coords" ]; then sed 's/^/coord=/' "$coords"; fi
     } > "$NROS_FIXTURE_STAMP"
     rm -f "${NROS_FIXTURE_STAMP}.started"
     echo "fixture stamp: $NROS_FIXTURE_STAMP (lane=$lane)"
+    if [ -n "$skipped" ]; then
+        # Loud, and at the moment the fact is known. The 0599 header records
+        # what a skip invisible at the point of decision costs: it resurfaces as
+        # an artifact error twenty minutes later, with a remedy naming the
+        # command that had just "succeeded".
+        echo ""
+        echo "  NOT BUILT — these modules skipped a missing prerequisite:"
+        for m in $skipped; do echo "      $m    (provision: just setup $m)"; done
+        echo "  A run needing them will FAIL rather than skip. This stamp does"
+        echo "  not claim them."
+        echo ""
+    fi
+}
+
+# Echo the modules the recorded build did NOT achieve (phase-407 W1).
+# Empty for a legacy stamp, which is why the caller must treat absence as
+# "cannot tell", never as "nothing was skipped".
+nros_fixtures_stamp_skipped() {
+    [ -f "$NROS_FIXTURE_STAMP" ] || return 1
+    sed -n 's/^skipped_module=//p' "$NROS_FIXTURE_STAMP"
 }
 
 # Echo the stamp's lane, or `all` for a legacy timestamp-only stamp.
@@ -469,6 +517,36 @@ nros_fixtures_stamp_require() {
     # present, an unnarrowed run is fine, and `NROS_FIXTURE_LANE=tier2` on top
     # of a full build is a legitimate combination (scope the FRESHNESS gate,
     # keep the run wide).
+    # phase-407 W1 — a build of everything covers every lane ONLY if it built
+    # everything. This early return is where a skip became a coverage claim:
+    # `lane=all` with an unprovisioned module skipped still answered "covered",
+    # so the run proceeded and its tests skipped for absent binaries, and the
+    # sweep was green. The stamp now records what was achieved, so ask it.
+    #
+    # A legacy stamp has no `skipped_module=` lines and this is empty — which
+    # means "cannot tell", not "nothing was skipped", so behaviour there is
+    # unchanged rather than newly strict.
+    local stamp_skipped
+    stamp_skipped="$(nros_fixtures_stamp_skipped 2>/dev/null)"
+    if [ -n "$stamp_skipped" ]; then
+        echo "ERROR: the recorded fixture build did not cover every module." >&2
+        echo "" >&2
+        echo "  These skipped a missing prerequisite and were NOT built:" >&2
+        local m
+        for m in $stamp_skipped; do
+            echo "      $m    (provision: just setup $m)" >&2
+        done
+        echo "" >&2
+        echo "  A run over them would report SKIPPED and the sweep would be" >&2
+        echo "  green, which is why this is an error and not a warning." >&2
+        echo "" >&2
+        echo "  Either provision them and rebuild, or run only what you have:" >&2
+        echo "      just <module> test        # e.g. just native test" >&2
+        echo "" >&2
+        echo "  (deliberately accepting the gap?  NROS_SKIP_FIXTURE_CHECK=1 )" >&2
+        return 1
+    fi
+
     if [ "$have" = "all" ]; then
         return 0
     fi

--- a/scripts/build/fixture-lane.sh
+++ b/scripts/build/fixture-lane.sh
@@ -329,7 +329,7 @@ nros_fixtures_stamp_clear() {
 # `<stage>\t<start>\t<end>\t<dur>\t<status>` row per module, status 78 being
 # `nros_lane_skip` ("a precondition is missing"), issue 0599.
 #
-# phase-407 W1. The stamp used to record the lane's NOMINAL coordinates, from
+# phase-411 W1. The stamp used to record the lane's NOMINAL coordinates, from
 # the manifest, regardless of what the build achieved — so a module that skipped
 # for a missing toolchain still read as covered, `nros_fixtures_stamp_require`
 # answered "yes, covered", and the run proceeded to skip its tests. The skip was
@@ -369,7 +369,7 @@ nros_fixtures_stamp_write() {
             echo "started_at=$(cat "${NROS_FIXTURE_STAMP}.started")"
         fi
         echo "lane=$lane"
-        # phase-407 W1 — what the build ACHIEVED, not only what it was asked
+        # phase-411 W1 — what the build ACHIEVED, not only what it was asked
         # for. A consumer that reads `lane=` alone is reading an intention.
         local m
         for m in $skipped; do echo "skipped_module=$m"; done
@@ -391,7 +391,7 @@ nros_fixtures_stamp_write() {
     fi
 }
 
-# Echo the modules the recorded build did NOT achieve (phase-407 W1).
+# Echo the modules the recorded build did NOT achieve (phase-411 W1).
 # Empty for a legacy stamp, which is why the caller must treat absence as
 # "cannot tell", never as "nothing was skipped".
 nros_fixtures_stamp_skipped() {
@@ -517,7 +517,7 @@ nros_fixtures_stamp_require() {
     # present, an unnarrowed run is fine, and `NROS_FIXTURE_LANE=tier2` on top
     # of a full build is a legitimate combination (scope the FRESHNESS gate,
     # keep the run wide).
-    # phase-407 W1 — a build of everything covers every lane ONLY if it built
+    # phase-411 W1 — a build of everything covers every lane ONLY if it built
     # everything. This early return is where a skip became a coverage claim:
     # `lane=all` with an unprovisioned module skipped still answered "covered",
     # so the run proceeded and its tests skipped for absent binaries, and the

--- a/scripts/build/lane-skip.sh
+++ b/scripts/build/lane-skip.sh
@@ -183,6 +183,33 @@ _nros_lane_skip_file() {
     printf '%s/%s.skips' "$(nros_build_dir "$NROS_KIND_LANE_SKIPS")" "$lane"
 }
 
+# nros_sdk_missing <VAR_NAME> <marker-relative-path>
+#
+# True when the SDK that <VAR_NAME> points at is not present. Issue 0955.
+#
+# Six guards used to ask `[ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/... ]`.
+# `just/sdk-env.just` EXPORTS all 23 such variables with a default, so `-z` is
+# never true, so the `&&` is never true, and the skip could never fire. Under a
+# broad lane those steps did not skip — they walked into cmake and FAILED where
+# the author intended a skip, so an unprovisioned host got a cmake-level message
+# instead of `== nuttx == SKIPPED (...)`.
+#
+# The same files already carried the idiom that works, testing the RESOLVED
+# directory rather than the variable (`[ ! -d "$NUTTX_DIR/include" ]`). Two
+# spellings of one question with the newer one broken is the #282 -> #326 shape,
+# so this is ONE helper rather than six corrections — a seventh site cannot
+# reintroduce the dead form by copying a neighbour.
+#
+# An UNSET variable still counts as missing: that is the case the `-z` arm was
+# reaching for, and it stays true here without being the only thing asked.
+nros_sdk_missing() {
+    local var="${1:?nros_sdk_missing: variable name}"
+    local marker="${2:?nros_sdk_missing: marker path}"
+    local dir="${!var-}"
+    [ -n "$dir" ] || return 0
+    [ ! -e "$dir/$marker" ]
+}
+
 nros_lane_skip_reset() {
     local f
     f="$(_nros_lane_skip_file "${1:?nros_lane_skip_reset: lane}")"

--- a/scripts/build/lane-skip.sh
+++ b/scripts/build/lane-skip.sh
@@ -30,6 +30,109 @@ if ! command -v nros_build_dir >/dev/null 2>&1; then
     . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/build-root.sh"
 fi
 
+# ---------------------------------------------------------------------------
+# Named vs included — phase-407 W2
+#
+# Everything above is intact and stays: SKIPPED is still a third verdict, and
+# `nros_lane_skip` still exits 78 for a lane whose prerequisite is absent. What
+# 0599/0650 could not express is WHO ASKED.
+#
+#   just build-test-fixtures lane=all      zephyr was INCLUDED by a broad lane.
+#                                          The operator did not claim to have
+#                                          provisioned it. A skip is correct and
+#                                          must be reported.
+#
+#   just zephyr build-fixtures             zephyr was NAMED. There is no lane to
+#                                          disambiguate and no second reading of
+#                                          the command line. "ZEPHYR_WORKSPACE
+#                                          not set up" is then not a skip, it is
+#                                          the answer to what was asked, and
+#                                          exiting 78 makes the run green.
+#
+# The rule (phase-407): **named must work; unnamed may skip, and is reported.**
+# Naming IS the specification, so no second declaration is kept in step with it.
+#
+# THE SIGNAL, AND WHY ITS DEFAULT POINTS THIS WAY
+#
+# `NROS_LANE_INCLUDED` is set by the fixture fan-out in `justfile`'s
+# `build-test-fixtures-leaves` — the ONE place that reaches a platform lane
+# without the operator having typed its name. Unset means NAMED.
+#
+# That polarity is deliberate and is the whole safety argument. A site or a
+# driver this change fails to reach keeps `NROS_LANE_INCLUDED` unset, so it
+# reads as NAMED and FAILS LOUDLY. The opposite default ("included unless
+# proven named") would leave every missed site quietly behaving as it does
+# today — indistinguishable from a correct one, which is the exact failure
+# shape this work exists to remove.
+#
+# The value is the platform token, for the log; only EMPTINESS is tested.
+# Matching the value against the lane name would be a second SSoT and would
+# break immediately: the fan-out's tokens are `threadx_linux`/`threadx_riscv64`
+# while the lanes' own skip ledgers are named `threadx-linux`/`threadx-riscv64`.
+#
+# WHAT IS AND IS NOT SUBJECT TO THE RULE
+#
+# Two things use `nros_lane_skip` and only one of them is a platform lane:
+#
+#  * A PLATFORM LANE declares itself with `nros_lane_platform <lane>`. It is the
+#    thing a user names, so the rule applies. (`nros_lane_skip_note` needs no
+#    declaration — it already takes the lane as its first argument, which is the
+#    same fact; that is why all ~14 step sites are covered without touching one
+#    of them.)
+#  * A CHECK GATE or a license-gated optional recipe (`check-submodule-pins`
+#    with no network, the ARM FVP recipes, the root-only package probe in
+#    `just/ci.just`) declares no platform and keeps 0599's behaviour exactly.
+#    Those skips are not about a platform anyone named.
+#
+# AND A THIRD KIND OF SKIP, WHICH IS NOT A PREREQUISITE AT ALL
+#
+# `nros_lane_out_of_scope_note` exists because two nuttx sites were skipping for a
+# reason that has nothing to do with provisioning: `nros_lane_wants_platform`
+# said this run's LANE selected no such coordinate. Naming the platform cannot
+# make that step runnable and must not turn it into a failure, so it is a
+# separate spelling rather than an exemption string. Both spellings still land
+# in the same ledger and are still reported by the flush.
+
+NROS_LANE_NAMED_RC=1
+
+# nros_lane_platform <lane>
+#
+# "This recipe IS the <lane> platform lane." One line, at the top of a lane that
+# uses the whole-recipe `nros_lane_skip`. Gated by `check-named-lane-fails`, so
+# a new platform-lane skip site cannot silently forget it.
+nros_lane_platform() {
+    _NROS_LANE_PLATFORM="${1:?nros_lane_platform: lane}"
+}
+
+# nros_lane_named
+#
+# True when the caller's platform was NAMED rather than included by a fan-out.
+nros_lane_named() {
+    [ -z "${NROS_LANE_INCLUDED:-}" ]
+}
+
+# _nros_lane_named_fail <lane> <reason…>
+#
+# The verdict a NAMED platform gets instead of SKIPPED. The reason is the site's
+# OWN text, unchanged — those messages already name the remedy, and rewording
+# them here would put the remedy in two places. What is added is why this is a
+# failure, because "run `just zephyr setup`" printed under a red exit is a
+# different instruction from the same words printed under a green one.
+_nros_lane_named_fail() {
+    local lane="${1:?_nros_lane_named_fail: lane}"
+    shift
+    local reason="$*"
+    echo "NROS_LANE_NAMED_FAIL: ${lane}: ${reason}" >&2
+    echo "" >&2
+    echo "error: you named \`${lane}\`, so this is a FAILURE, not a skip." >&2
+    echo "  ${reason}" >&2
+    echo "" >&2
+    echo "  Naming a platform IS the specification (phase-407). The same platform" >&2
+    echo "  reached by a preset or the broad default — \`just build-test-fixtures" >&2
+    echo "  lane=<lane>\` — would SKIP here and say so in the summary." >&2
+    exit "${NROS_LANE_NAMED_RC}"
+}
+
 # nros_lane_skip <reason…>
 #
 # Exits the calling lane with the SKIPPED verdict. The reason is printed twice
@@ -37,8 +140,14 @@ fi
 # `NROS_LANE_SKIP:` marker the driver greps out of that log to put in the
 # summary. Keep the reason short and name the remedy — it is what the operator
 # sees instead of "OK".
+#
+# phase-407 W2: when the recipe declared `nros_lane_platform` and its platform was
+# NAMED, this is a failure instead.
 nros_lane_skip() {
     local reason="$*"
+    if [ -n "${_NROS_LANE_PLATFORM:-}" ] && nros_lane_named; then
+        _nros_lane_named_fail "${_NROS_LANE_PLATFORM}" "${reason}"
+    fi
     echo "NROS_LANE_SKIP: ${reason}"
     echo "lane skipped: ${reason}"
     exit "${NROS_LANE_SKIP_RC}"
@@ -81,8 +190,40 @@ nros_lane_skip_reset() {
     : > "$f"
 }
 
+# nros_lane_skip_note <lane> <reason…>
+#
+# A STEP of <lane> cannot run because a PREREQUISITE is missing. Its lane
+# argument is already the named/included question's subject, so phase-407 W2
+# needed no edit at any of its call sites: when <lane> was NAMED, a missing
+# prerequisite is a failure and this does not return.
 nros_lane_skip_note() {
     local lane="${1:?nros_lane_skip_note: lane}"
+    shift
+    local reason="$*"
+    if nros_lane_named; then
+        _nros_lane_named_fail "$lane" "$reason"
+    fi
+    local f
+    f="$(_nros_lane_skip_file "$lane")"
+    mkdir -p "$(dirname "$f")"
+    printf '%s\n' "$reason" >> "$f"
+    echo "${lane} skip: ${reason}"
+}
+
+# nros_lane_out_of_scope_note <lane> <reason…>
+#
+# A STEP of <lane> is OUT OF THIS RUN'S COORDINATES — `nros_lane_wants_platform`
+# said the lane selected no such row (phase-340). Nothing is missing and nothing
+# is broken, so naming the platform must NOT turn this into a failure: the user
+# named `nuttx`, the lane narrowed away `nuttx-riscv`, and both are true at once.
+#
+# Recorded and printed exactly like a prerequisite skip — the flush still refuses
+# to claim the lane built its fixtures — but never promoted to a failure. It is a
+# distinct spelling rather than a reason-string exemption because the difference
+# is in the KIND of skip, and a substring match on prose is how the wrong half of
+# a class gets fixed.
+nros_lane_out_of_scope_note() {
+    local lane="${1:?nros_lane_out_of_scope_note: lane}"
     shift
     local reason="$*"
     local f
@@ -99,6 +240,12 @@ nros_lane_skip_note() {
 # driver records SKIPPED and the operator learns it here rather than twenty
 # minutes later from a missing artifact (0599's lesson, which is why the reasons
 # are repeated in full).
+#
+# phase-407 W2 leaves this unchanged, and that is the correct outcome rather than
+# an omission: under a NAMED platform a PREREQUISITE note never reaches the
+# ledger (it failed at the step), so anything the flush finds here got in through
+# `nros_lane_out_of_scope_note` — a lane narrowing, which is reportable and not a
+# failure. SKIPPED remains the right verdict for it.
 nros_lane_skip_flush() {
     local lane="${1:?nros_lane_skip_flush: lane}"
     shift

--- a/scripts/build/lane-skip.sh
+++ b/scripts/build/lane-skip.sh
@@ -31,7 +31,7 @@ if ! command -v nros_build_dir >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# Named vs included — phase-407 W2
+# Named vs included — phase-411 W2
 #
 # Everything above is intact and stays: SKIPPED is still a third verdict, and
 # `nros_lane_skip` still exits 78 for a lane whose prerequisite is absent. What
@@ -49,7 +49,7 @@ fi
 #                                          the answer to what was asked, and
 #                                          exiting 78 makes the run green.
 #
-# The rule (phase-407): **named must work; unnamed may skip, and is reported.**
+# The rule (phase-411): **named must work; unnamed may skip, and is reported.**
 # Naming IS the specification, so no second declaration is kept in step with it.
 #
 # THE SIGNAL, AND WHY ITS DEFAULT POINTS THIS WAY
@@ -127,7 +127,7 @@ _nros_lane_named_fail() {
     echo "error: you named \`${lane}\`, so this is a FAILURE, not a skip." >&2
     echo "  ${reason}" >&2
     echo "" >&2
-    echo "  Naming a platform IS the specification (phase-407). The same platform" >&2
+    echo "  Naming a platform IS the specification (phase-411). The same platform" >&2
     echo "  reached by a preset or the broad default — \`just build-test-fixtures" >&2
     echo "  lane=<lane>\` — would SKIP here and say so in the summary." >&2
     exit "${NROS_LANE_NAMED_RC}"
@@ -141,7 +141,7 @@ _nros_lane_named_fail() {
 # summary. Keep the reason short and name the remedy — it is what the operator
 # sees instead of "OK".
 #
-# phase-407 W2: when the recipe declared `nros_lane_platform` and its platform was
+# phase-411 W2: when the recipe declared `nros_lane_platform` and its platform was
 # NAMED, this is a failure instead.
 nros_lane_skip() {
     local reason="$*"
@@ -220,7 +220,7 @@ nros_lane_skip_reset() {
 # nros_lane_skip_note <lane> <reason…>
 #
 # A STEP of <lane> cannot run because a PREREQUISITE is missing. Its lane
-# argument is already the named/included question's subject, so phase-407 W2
+# argument is already the named/included question's subject, so phase-411 W2
 # needed no edit at any of its call sites: when <lane> was NAMED, a missing
 # prerequisite is a failure and this does not return.
 nros_lane_skip_note() {
@@ -268,7 +268,7 @@ nros_lane_out_of_scope_note() {
 # minutes later from a missing artifact (0599's lesson, which is why the reasons
 # are repeated in full).
 #
-# phase-407 W2 leaves this unchanged, and that is the correct outcome rather than
+# phase-411 W2 leaves this unchanged, and that is the correct outcome rather than
 # an omission: under a NAMED platform a PREREQUISITE note never reaches the
 # ledger (it failed at the step), so anything the flush finds here got in through
 # `nros_lane_out_of_scope_note` — a lane narrowing, which is reportable and not a

--- a/scripts/build/scope.sh
+++ b/scripts/build/scope.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# The SCOPE vocabulary — phase-407 W3.
+# The SCOPE vocabulary — phase-411 W3.
 #
 # Sourced, not executed. One namespace for the thing every verb takes in its
 # first argument position:
@@ -222,7 +222,7 @@ nros_scope_expand() {
 
 # Reject the whole argument list before ANY of it runs. A typo in the third
 # token must not be discovered after the first two have built for ten minutes,
-# which is the same "fail at the point of decision" phase-407 asks of an
+# which is the same "fail at the point of decision" phase-411 asks of an
 # unprovisioned platform.
 nros_scope_validate_all() {
     local tok rc=0
@@ -278,7 +278,7 @@ nros_scope_require_module_verb() {
 # The dispatch layer is the one part of this surface whose whole job is to
 # choose a command, so "which command does `just build tier2` become?" must be
 # answerable without paying for the command. It is also how a CI author reads
-# the mapping (phase-407 W4) and how this layer gets verified at all: the
+# the mapping (phase-411 W4) and how this layer gets verified at all: the
 # alternative is starting a multi-hour fixture build to watch the first line.
 nros_scope_exec() {
     if [ "${NROS_SCOPE_EXPLAIN:-0}" != "0" ]; then
@@ -323,7 +323,7 @@ nros_scope_provisioned() {
     done
 }
 
-# The coverage line every scoped verb prints — phase-407's acceptance item
+# The coverage line every scoped verb prints — phase-411's acceptance item
 # "scope, what ran, what did not, and how to provision the rest".
 #
 # `<verb>` only shapes the wording. With no scope tokens it PROBES and reports

--- a/scripts/build/scope.sh
+++ b/scripts/build/scope.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# The SCOPE vocabulary — phase-407 W3.
+#
+# Sourced, not executed. One namespace for the thing every verb takes in its
+# first argument position:
+#
+#   just setup  <scope…>      provision it
+#   just doctor <scope…>      is it ready?
+#   just build  <scope…>      build its fixtures
+#   just test   <scope…>      run its tests
+#
+# `just setup <platform>` was ALREADY verb-first; this is the rest of the
+# surface following the half that was right. The platform MODULES do not go
+# away — `just zephyr build-fixtures` remains the implementation, and the verbs
+# below dispatch to it. What changes is that the documented surface is
+# verb-first, so there is one shape to learn instead of two.
+#
+# # One namespace
+#
+# A scope token is EITHER a platform or a preset, and the two share one
+# position, so a name may not mean two things:
+#
+#   platform   a `mod` in the justfile that owns build/test artifacts
+#   preset     a name for a SET of platforms — today exactly the fixture LANES
+#              (`_NROS_LANES` in fixture-lane.sh), because a lane already is a
+#              named platform set and inventing a second vocabulary beside it
+#              is how two spellings of one fact start.
+#
+# `native` is deliberately in BOTH sets: it is a platform module and a lane
+# name. That is legal precisely because they denote the SAME scope — the
+# `native` lane is every row of the `native` module, which `nros_lane_modules`
+# spells out. `check-scope-namespace` asserts it, so a future preset that
+# collides with a platform meaning something else fails on the fast line
+# instead of silently re-scoping somebody's run.
+#
+# # The verb reaches the scope through its own machinery
+#
+# A token names a SCOPE, not an implementation. Each verb then uses whatever
+# already exists for that scope:
+#
+#   build  a lane token goes to `build-test-fixtures lane=…` (which writes the
+#          coverage stamp `_require-fixtures` reads); a platform token goes to
+#          `just <plat> build-fixtures`, the same call that recipe's own
+#          fan-out makes.
+#   test   a coordinate-scoped lane (tier1/tier2/tier2-nightly) and `all` go to
+#          the lane run (`test-all` narrowed by `NROS_TEST_COORDS`); a platform
+#          token — `native` included — goes to `just <plat> test`, because the
+#          module IS that platform's run.
+#
+# So `native` resolves through the lane for `build` and through the module for
+# `test`. Same scope, different machinery, which is the point of naming the
+# scope rather than the recipe.
+#
+# # The default scope is DERIVED, never recorded
+#
+# "What do I have provisioned?" is a PROBE (`nros_scope_provisioned`), run
+# against each module's own `doctor` — the authority that already knows the
+# prerequisite and already prints the remedy. It is never read from a file: a
+# recorded set is a second source of one fact, and it goes stale in the
+# direction that reports coverage nobody has.
+
+# shellcheck shell=bash
+
+_nros_scope_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The lanes are the presets, so the lane list is sourced rather than copied.
+if ! command -v nros_lane_validate >/dev/null 2>&1; then
+    # shellcheck source=scripts/build/fixture-lane.sh
+    . "${_nros_scope_dir}/fixture-lane.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# The namespace
+# ---------------------------------------------------------------------------
+
+# Platform scope tokens: the justfile modules that own build/test artifacts for
+# a target platform or an RMW backend. Ordered host-first, then by how often a
+# person names them.
+_NROS_SCOPE_PLATFORMS="native zephyr freertos nuttx threadx_linux threadx_riscv64 esp32 esp_idf qemu px4 xrce cyclonedds"
+
+# Modules that are deliberately NOT scope tokens, with the reason — because
+# "why is `docker` not a scope?" is the question a reader will have, and an
+# unexplained subtraction reads as an oversight. `check-scope-namespace` asserts
+# this list plus the one above PARTITIONS the justfile's modules, so a new
+# module has to be classified rather than silently landing in neither.
+#
+#   check ci        verb modules, not scopes (`just check fast`, `just ci l1`)
+#   workspace       the ROS/colcon workspace tooling — an environment, not a
+#                   target. Also the one module whose `doctor` costs ~75 s, so
+#                   probing it per default-scope report would make every bare
+#                   `just test` pay for a ROS install probe.
+#   verification    Kani/Verus, a proof lane over the host build
+#   docker          a RUNNER (`just docker test …` runs a recipe in a container)
+#   probe           the book-bootstrap prober
+#   ros_editions    the ROS distro axis, not a platform (issue 0327)
+_NROS_SCOPE_NON_PLATFORM_MODULES="check ci workspace verification docker probe ros_editions"
+
+nros_scope_platforms() {
+    printf '%s\n' $_NROS_SCOPE_PLATFORMS
+}
+
+# The presets. Exactly the fixture lanes — see the header for why there is no
+# second vocabulary.
+nros_scope_presets() {
+    printf '%s\n' $_NROS_LANES
+}
+
+# Normalize a token as it arrives from `just`.
+#
+# `just <recipe> lane=tier2` / `tier=all` pass `lane=tier2` / `tier=all`
+# VERBATIM as the positional value (just's `name=value` CLI form sets
+# variables, not recipe parameters), and both spellings are in the docs, in CI
+# and in muscle memory. `nros_lane_arg` already strips `lane=`; this strips the
+# scope-position prefixes and maps the setup-tier aliases onto the scope that
+# means the same thing.
+nros_scope_normalize() {
+    local tok="${1:-}"
+    tok="${tok#lane=}"
+    tok="${tok#tier=}"
+    tok="${tok#scope=}"
+    case "$tok" in
+        # `just setup all` and lane `all` both mean "everything"; the aliases
+        # come from `_orchestrate`'s tier table.
+        everything | contributor | extended) tok="all" ;;
+        # The base setup tier is the host quick start.
+        base | quickstart | minimal | default) tok="base" ;;
+    esac
+    printf '%s' "$tok"
+}
+
+nros_scope_is_platform() {
+    local tok
+    tok="$(nros_scope_normalize "${1:-}")"
+    local p
+    for p in $_NROS_SCOPE_PLATFORMS; do
+        [ "$tok" = "$p" ] && return 0
+    done
+    return 1
+}
+
+nros_scope_is_preset() {
+    local tok
+    tok="$(nros_scope_normalize "${1:-}")"
+    local p
+    for p in $_NROS_LANES; do
+        [ "$tok" = "$p" ] && return 0
+    done
+    return 1
+}
+
+# Is this token a fixture LANE — i.e. can it be handed to
+# `build-test-fixtures lane=…` / `NROS_FIXTURE_LANE`? Every preset is, today;
+# the question is asked separately because the verbs ask it, and a future
+# preset that is not a lane must not silently become one.
+nros_scope_is_lane() {
+    nros_scope_is_preset "$1"
+}
+
+# platform | preset | unknown.
+#
+# PLATFORM-first, and only for the human-readable label: `native` is both, and
+# "platform" is the more informative of the two true answers. It cannot change
+# any resolution, because the two denote the same scope — which is exactly what
+# `check-scope-namespace` asserts, and the reason a collision is allowed at all.
+nros_scope_kind() {
+    if nros_scope_is_platform "$1"; then
+        echo platform
+    elif nros_scope_is_preset "$1"; then
+        echo preset
+    else
+        echo unknown
+    fi
+}
+
+# The platform set a preset denotes, one per line.
+#
+# `all` and `native` answer statically. The tier lanes answer through
+# `nros_lane_modules`, which is `lane-coords --modules` — the SAME selection
+# the fixture build fans out over, so a tier's scope cannot differ between what
+# `doctor` reports and what `build` builds. That costs a `cargo run` when no
+# prebuilt selector is current, so `NROS_SCOPE_NO_BUILD=1` makes it refuse
+# instead: the gate runs on the fast line, which is buildless by contract.
+nros_scope_preset_expand() {
+    local tok
+    tok="$(nros_scope_normalize "${1:-}")"
+    case "$tok" in
+        all)
+            printf '%s\n' $_NROS_SCOPE_PLATFORMS
+            return 0
+            ;;
+        native)
+            echo native
+            return 0
+            ;;
+    esac
+    if ! nros_scope_is_preset "$tok"; then
+        echo "scope: '$tok' is not a preset" >&2
+        return 2
+    fi
+    if [ "${NROS_SCOPE_NO_BUILD:-0}" != "0" ]; then
+        echo "scope: expanding preset '$tok' needs lane-coords, and NROS_SCOPE_NO_BUILD is set" >&2
+        return 3
+    fi
+    nros_lane_modules "$tok"
+}
+
+# Every platform a scope token covers, one per line (a platform token covers
+# itself). This is the ONE expansion; `doctor` and the reporting both use it so
+# a preset cannot mean one set to one verb and another to the next.
+nros_scope_expand() {
+    local tok
+    tok="$(nros_scope_normalize "${1:-}")"
+    if nros_scope_is_platform "$tok"; then
+        echo "$tok"
+    elif nros_scope_is_preset "$tok"; then
+        nros_scope_preset_expand "$tok"
+    else
+        nros_scope_reject "$tok"
+        return 2
+    fi
+}
+
+# Reject the whole argument list before ANY of it runs. A typo in the third
+# token must not be discovered after the first two have built for ten minutes,
+# which is the same "fail at the point of decision" phase-407 asks of an
+# unprovisioned platform.
+nros_scope_validate_all() {
+    local tok rc=0
+    for tok in "$@"; do
+        if [ "$(nros_scope_kind "$tok")" = "unknown" ]; then
+            nros_scope_reject "$tok" || rc=2
+        fi
+    done
+    return "$rc"
+}
+
+# The failure a mistyped scope gets. It prints the whole namespace, because the
+# one thing a person needs at that moment is the list of legal words.
+nros_scope_reject() {
+    local tok="${1:-}"
+    echo "unknown scope '$tok'." >&2
+    echo "" >&2
+    echo "  platforms: $_NROS_SCOPE_PLATFORMS" >&2
+    echo "  presets  : $_NROS_LANES" >&2
+    echo "" >&2
+    echo "  A scope is one word in one position:  just <verb> <scope…>" >&2
+    echo "  e.g.  just setup zephyr    just build tier2    just test zephyr" >&2
+    return 2
+}
+
+# Does `just <module>` define `<verb>`? ASKED, not tabulated — `just --list
+# <module>` is the authority, so a module that gains or loses a verb needs no
+# edit here. ~50 ms.
+nros_scope_module_has_verb() {
+    local mod="${1:?nros_scope_module_has_verb: module}"
+    local verb="${2:?nros_scope_module_has_verb: verb}"
+    just --list "$mod" 2>/dev/null | awk '{print $1}' | grep -qx -- "$verb"
+}
+
+# The refusal a scope gets when the verb has no implementation for it. A named
+# scope must WORK or say why — reaching `just esp_idf test` and letting `just`
+# answer "justfile does not contain recipe" names neither the scope nor the
+# verb the person actually typed.
+nros_scope_require_module_verb() {
+    local mod="${1:?}" verb="${2:?}"
+    nros_scope_module_has_verb "$mod" "$verb" && return 0
+    echo "scope '$mod' has no '$verb' lane — \`just $mod $verb\` does not exist." >&2
+    echo "  What it does have:" >&2
+    just --list "$mod" 2>/dev/null | awk '{print $1}' \
+        | grep -E '^(setup|doctor|build|build-fixtures|build-examples|test)' \
+        | sed 's/^/    just '"$mod"' /' >&2
+    return 2
+}
+
+# Run the command a scope resolved to — or, under NROS_SCOPE_EXPLAIN=1, print
+# it and stop.
+#
+# The dispatch layer is the one part of this surface whose whole job is to
+# choose a command, so "which command does `just build tier2` become?" must be
+# answerable without paying for the command. It is also how a CI author reads
+# the mapping (phase-407 W4) and how this layer gets verified at all: the
+# alternative is starting a multi-hour fixture build to watch the first line.
+nros_scope_exec() {
+    if [ "${NROS_SCOPE_EXPLAIN:-0}" != "0" ]; then
+        echo "would run: $*"
+        return 0
+    fi
+    exec "$@"
+}
+
+# ---------------------------------------------------------------------------
+# The default scope: what this host has provisioned, PROBED
+# ---------------------------------------------------------------------------
+
+# Does `<platform>` have a module `doctor` to probe? `native` is the host — the
+# machine you are typing on — so it has no separate provisioning question and
+# the root `doctor`'s host block is its readiness report.
+nros_scope_has_module_doctor() {
+    local p
+    p="$(nros_scope_normalize "${1:-}")"
+    [ "$p" != "native" ]
+}
+
+# rc 0 when `<platform>` is provisioned. The probe IS the module's own
+# `doctor`, which already knows the prerequisite and already prints the remedy;
+# a second definition of "provisioned" here would be the drift this file exists
+# to avoid. Output is captured — callers that want the detail re-run the doctor.
+nros_scope_probe() {
+    local p
+    p="$(nros_scope_normalize "${1:?nros_scope_probe: platform}")"
+    nros_scope_has_module_doctor "$p" || return 0
+    just "$p" doctor >/dev/null 2>&1
+}
+
+# The provisioned platforms, one per line. ~2 s for the twelve (measured
+# 2026-08-31: px4 973 ms and esp32 382 ms dominate; the rest are under 100 ms).
+nros_scope_provisioned() {
+    local p
+    for p in $_NROS_SCOPE_PLATFORMS; do
+        if nros_scope_probe "$p"; then
+            echo "$p"
+        fi
+    done
+}
+
+# The coverage line every scoped verb prints — phase-407's acceptance item
+# "scope, what ran, what did not, and how to provision the rest".
+#
+# `<verb>` only shapes the wording. With no scope tokens it PROBES and reports
+# the derived default; with them it reports the resolution, so a run always
+# says what it was about before it starts costing time.
+nros_scope_report() {
+    local verb="${1:?nros_scope_report: verb}"
+    shift
+    if [ "$#" -gt 0 ]; then
+        local tok
+        echo "scope: $* (named — naming it IS the specification)"
+        for tok in "$@"; do
+            echo "  $tok -> $(nros_scope_kind "$tok")"
+        done
+        return 0
+    fi
+    local have missing p
+    have=""
+    missing=""
+    for p in $_NROS_SCOPE_PLATFORMS; do
+        if nros_scope_probe "$p"; then
+            have="$have $p"
+        else
+            missing="$missing $p"
+        fi
+    done
+    echo "scope: default — DERIVED by probing, never recorded"
+    echo "  provisioned  :${have:- (none)}"
+    if [ -n "$missing" ]; then
+        echo "  unprovisioned:$missing"
+        echo "  ^ these will SKIP. Provision one:  just setup <name>"
+    fi
+    echo "  Name a scope to require it:  just $verb <scope…>"
+}

--- a/scripts/check-ci-no-fixture-tolerance.py
+++ b/scripts/check-ci-no-fixture-tolerance.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""CI may not tolerate a missing fixture — phase-407 W4.
+
+`NROS_FIXTURES_OPTIONAL=1` converts an absent fixture binary into a `skip!`
+instead of a failure. That is a legitimate LOCAL opt-in: a developer working on
+one platform has not provisioned the others, and a run demanding all of them is
+a run nobody performs.
+
+It is never legitimate in CI. A lane names its scope, and under phase-407 naming
+IS the specification — so a gap in what CI asked for is a failure, and nothing
+else was expected in the first place. `host-tests.yml` set it unconditionally,
+which made the lane's correctness depend on remembering to unset a variable, and
+its own comment admitted as much ("the FULL `test-all` tier leaves the var
+unset and still hard-fails").
+
+This is why the reader in `nros-tests` SURVIVES while CI's use of it does not:
+deleting it would remove a real local affordance to fix a CI-only defect. The
+rule is about who sets it, so the gate is about where it appears.
+
+Buildless: greps the workflow files.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+FLAG = "NROS_FIXTURES_OPTIONAL"
+# A line that merely EXPLAINS the ban (like the one this gate exists for) is
+# not a violation. A `#` comment is prose; an env assignment is policy.
+SETS = re.compile(rf"^\s*(?!#)\S*\b{FLAG}\s*[:=]")
+
+
+def analyze(lines):
+    return [(i, l.rstrip()) for i, l in enumerate(lines, 1) if SETS.search(l)]
+
+
+def selftest():
+    """Both verdicts, on the normal path — phase-395."""
+    assert analyze([f'          {FLAG}: "1"\n']), "an env assignment must be caught"
+    assert analyze([f'    {FLAG}=1 just test-all\n']), "a shell assignment must be caught"
+    assert not analyze([f'          # {FLAG} is GONE — see phase-407 W4\n']), \
+        "a comment explaining the ban must not be a violation"
+    assert not analyze(["          CARGO_BUILD_JOBS: \"2\"\n"]), "unrelated env is fine"
+
+
+def main():
+    selftest()
+    problems = []
+    for fn in sorted(os.listdir(WORKFLOWS)):
+        if not fn.endswith((".yml", ".yaml")):
+            continue
+        with open(os.path.join(WORKFLOWS, fn), encoding="utf-8") as fh:
+            for lineno, line in analyze(fh.readlines()):
+                problems.append(
+                    f"{fn}:{lineno}: sets {FLAG} — CI names its scope, so a "
+                    f"missing fixture inside that scope is a FAILURE, not a "
+                    f"skip. Narrow the scope instead (`just test <scope>`).\n"
+                    f"      {line.strip()}")
+    if problems:
+        sys.stderr.write("check-ci-no-fixture-tolerance: FAILED\n")
+        for p in problems:
+            sys.stderr.write(f"  {p}\n")
+        return 1
+    print(f"ci fixture tolerance: OK (no workflow sets {FLAG})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-ci-no-fixture-tolerance.py
+++ b/scripts/check-ci-no-fixture-tolerance.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""CI may not tolerate a missing fixture — phase-407 W4.
+"""CI may not tolerate a missing fixture — phase-411 W4.
 
 `NROS_FIXTURES_OPTIONAL=1` converts an absent fixture binary into a `skip!`
 instead of a failure. That is a legitimate LOCAL opt-in: a developer working on
 one platform has not provisioned the others, and a run demanding all of them is
 a run nobody performs.
 
-It is never legitimate in CI. A lane names its scope, and under phase-407 naming
+It is never legitimate in CI. A lane names its scope, and under phase-411 naming
 IS the specification — so a gap in what CI asked for is a failure, and nothing
 else was expected in the first place. `host-tests.yml` set it unconditionally,
 which made the lane's correctness depend on remembering to unset a variable, and
@@ -40,7 +40,7 @@ def selftest():
     """Both verdicts, on the normal path — phase-395."""
     assert analyze([f'          {FLAG}: "1"\n']), "an env assignment must be caught"
     assert analyze([f'    {FLAG}=1 just test-all\n']), "a shell assignment must be caught"
-    assert not analyze([f'          # {FLAG} is GONE — see phase-407 W4\n']), \
+    assert not analyze([f'          # {FLAG} is GONE — see phase-411 W4\n']), \
         "a comment explaining the ban must not be a violation"
     assert not analyze(["          CARGO_BUILD_JOBS: \"2\"\n"]), "unrelated env is fine"
 

--- a/scripts/check-fixture-stamp-honesty.py
+++ b/scripts/check-fixture-stamp-honesty.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""A fixture stamp may not claim what the build did not achieve — phase-407 W1.
+
+THE DEFECT
+
+`nros_fixtures_stamp_write` recorded the lane's NOMINAL coordinates, read from
+the manifest, regardless of what the build produced. A module that skipped for a
+missing prerequisite (`nros_lane_skip`, exit 78 — issue 0599) still appeared as
+covered, so `nros_fixtures_stamp_require` answered "yes, covered", the run
+proceeded, and its tests skipped for absent binaries. Green sweep, nothing run.
+
+The skip was laundered into a coverage claim, and every consumer downstream read
+the claim rather than the reality. Same shape as three defects fixed this week
+one level up: `check-submodule-pins` skipping on an unresolvable baseline,
+`check-feature-set-ssot` matching a spelling no site used, and `post-submit`
+reporting success with its only expensive job skipped.
+
+WHAT IS REQUIRED
+
+  H1  the writer consults the fan-out's joblog, so the stamp records what was
+      ACHIEVED — a `skipped_module=` line per module that did not build;
+  H2  the reader exposes it (`nros_fixtures_stamp_skipped`);
+  H3  the `have = all` early return — "a build of everything covers every
+      lane" — is not reached while modules are recorded as skipped. That line
+      is where the laundering happened, so it is the line that must be guarded.
+
+Buildless: reads one shell file.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LANE = os.path.join(ROOT, "scripts", "build", "fixture-lane.sh")
+
+
+def analyze(text):
+    """[] when the honesty rules hold, else a list of problems."""
+    problems = []
+
+    if "nros_fixtures_skipped_modules" not in text:
+        problems.append(
+            "H1: no `nros_fixtures_skipped_modules` — the writer has no way to "
+            "know what the build achieved, so the stamp can only record what it "
+            "was asked for.")
+    if "skipped_module=" not in text:
+        problems.append(
+            "H1: the stamp never writes a `skipped_module=` line, so a skipped "
+            "module is indistinguishable from a built one.")
+    if "nros_fixtures_stamp_skipped" not in text:
+        problems.append(
+            "H2: no reader for `skipped_module=`; a fact nothing can read is "
+            "not a fact the gate can act on.")
+
+    # H3 — the guard must come BEFORE the `have = all` early return, not after.
+    # After it, `lane=all` (the common case, and the one that laundered) returns
+    # 0 without ever consulting the skip list.
+    guard = text.find("nros_fixtures_stamp_skipped 2>/dev/null")
+    early = text.find('if [ "$have" = "all" ]; then')
+    if guard == -1 or early == -1:
+        problems.append(
+            "H3: could not locate both the skip guard and the `have = all` "
+            "early return in nros_fixtures_stamp_require — the check cannot "
+            "confirm their order, which is the whole invariant.")
+    elif guard > early:
+        problems.append(
+            "H3: the skip guard sits AFTER the `have = all` early return, so a "
+            "full-lane build returns `covered` without consulting it — exactly "
+            "the laundering this exists to stop.")
+    return problems
+
+
+def selftest():
+    """Exercise both verdicts on every run — phase-395."""
+    good = ('nros_fixtures_skipped_modules() { :; }\n'
+            'nros_fixtures_stamp_skipped() { :; }\n'
+            'echo "skipped_module=$m"\n'
+            'stamp_skipped="$(nros_fixtures_stamp_skipped 2>/dev/null)"\n'
+            'if [ "$have" = "all" ]; then\n')
+    assert not analyze(good), f"a correct file must pass: {analyze(good)}"
+
+    # The ORDER is the invariant, so swapping it must be caught — a file with
+    # every required symbol present and the guard one line too late.
+    swapped = ('nros_fixtures_skipped_modules() { :; }\n'
+               'nros_fixtures_stamp_skipped() { :; }\n'
+               'echo "skipped_module=$m"\n'
+               'if [ "$have" = "all" ]; then\n'
+               'stamp_skipped="$(nros_fixtures_stamp_skipped 2>/dev/null)"\n')
+    assert any("H3" in p for p in analyze(swapped)), \
+        "a guard after the early return must be caught — that is the defect"
+
+    assert any("H1" in p for p in analyze("nothing here\n")), \
+        "a file with no achievement tracking must fail H1"
+
+
+def main():
+    selftest()
+    with open(LANE, encoding="utf-8") as fh:
+        problems = analyze(fh.read())
+    if problems:
+        sys.stderr.write("check-fixture-stamp-honesty: FAILED\n")
+        for p in problems:
+            sys.stderr.write(f"  {p}\n")
+        return 1
+    print("fixture stamp honesty: OK (records achieved modules; the "
+          "`have = all` shortcut is guarded)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-fixture-stamp-honesty.py
+++ b/scripts/check-fixture-stamp-honesty.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""A fixture stamp may not claim what the build did not achieve — phase-407 W1.
+"""A fixture stamp may not claim what the build did not achieve — phase-411 W1.
 
 THE DEFECT
 

--- a/scripts/check-lane-contracts.py
+++ b/scripts/check-lane-contracts.py
@@ -60,7 +60,15 @@ TESTS_DIR = os.path.join(ROOT, "packages", "testing", "nros-tests", "tests")
 # lane that had simply moved, which is the same false-staleness it exists to
 # catch elsewhere.
 LANES = {
-    "ci::l1": "compile + unit, NO fixture build (CLAUDE.md)",
+    # phase-410 W4 — `ci::l1` is now `ci::gate`. It visits no coordinates, so it
+    # was never a rung on the breadth ladder; `l1` survives as a forwarder and
+    # the CLAIM belongs to the recipe that holds the body.
+    "ci::gate": "compile + unit, NO fixture build (CLAUDE.md)",
+    # BUILD depth over the tier-2 breadth. Same affordability shape as the gate
+    # — it must not resolve a fixture — for a different reason: it is the
+    # MANDATORY per-merge lane (build-wide.yml), so a fixture dependency here
+    # would make every merge pay a fixture build.
+    "ci::_matrix-build": "cross build + link, NO fixture build (phase-410)",
     "check::fast": "buildless and source-only",
 }
 
@@ -249,8 +257,15 @@ COMPILE_RESOLVERS = ("require_compile_check", "require_compile_check_bin")
 # is a real recipe header, and the old `[a-z_]+=\S*` matched neither the
 # name nor the `"75%"`. It therefore skipped `native::check`, which is the
 # one recipe whose missing precondition froze the merge queue (phase-396).
+# phase-410 W4 — a leading `_` is allowed. `[private]` recipes in this repo are
+# `_`-prefixed by convention (`_lane-gate`, `_require-fixtures`,
+# `_matrix-build`), and this pattern could not match ANY of them. So the closure
+# below silently stopped at every private boundary — `ci::matrix` calls
+# `just _lane-gate tier2` and the walk never followed it. A gate that cannot see
+# the preconditions it exists to check is the vacuous-pass shape this file's own
+# header describes.
 RECIPE = re.compile(
-    r"^([a-z][a-z0-9-]*)"
+    r"^(_?[a-z][a-z0-9-]*)"
     r"(?:\s+[A-Za-z_][A-Za-z0-9_]*(?:=(?:\"[^\"]*\"|'[^']*'|\S+))?)*"
     r"\s*:(.*)$"
 )
@@ -326,7 +341,7 @@ def _parse_one(lines, mod):
 # check-fast check-build check-api-parity` in its body, so a header-only walk
 # found a closure of size 1 and cheerfully reported "0 test target(s)" — a gate
 # that verified nothing while printing OK.
-JUST_CALL = re.compile(r"^\s*@?just\s+([a-z0-9-]+(?:\s+[a-z0-9-]+)*)\s*$")
+JUST_CALL = re.compile(r"^\s*@?just\s+((?:[a-z0-9_:-]+)(?:\s+[a-z0-9_:-]+)*)\s*$")
 
 
 def closure(recipes, root):

--- a/scripts/check-lane-skip-protocol.py
+++ b/scripts/check-lane-skip-protocol.py
@@ -49,7 +49,9 @@ SCAN_DIR = os.path.join(ROOT, "just")
 ANNOUNCES = re.compile(r"^\s*(echo|printf)\b[^\n]*\bskip", re.IGNORECASE)
 SAME_LINE_EXIT = re.compile(r";\s*exit\s+0\s*$")
 BARE_EXIT_0 = re.compile(r"^\s*exit\s+0\s*$")
-PROTOCOL = re.compile(r"\bnros_(lane|check)_skip(_note|_flush|_reset|_report)?\b")
+PROTOCOL = re.compile(
+    r"\bnros_(lane|check)_(skip(_note|_flush|_reset|_report)?|scope|scope_note)\b"
+)
 
 # Sites that are NOT a lane precondition, with the reason. A skip line here is
 # about a case inside an already-running step, not about a lane that cannot run.

--- a/scripts/check-named-lane-fails.py
+++ b/scripts/check-named-lane-fails.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""phase-407 W2 — a platform you NAMED may not skip its way to green.
+
+# What came before, and is not being undone
+
+Issue 0599 gave a fixture lane a THIRD verdict: `nros_lane_skip` prints a
+`NROS_LANE_SKIP:` marker and exits 78 (EX_CONFIG), and the fan-out records
+SKIPPED instead of the `exit 0` that used to read as OK. Issue 0650 extended it
+to lanes whose STEPS have separate preconditions. Both are correct and both
+stay. This gate does not revert either; it adds the one distinction neither
+could express.
+
+# The distinction
+
+A skip is legitimate when the platform was INCLUDED — by a preset, or by the
+broad default — because the operator asked for a lane and never claimed to have
+provisioned every member of it. A developer working on Zephyr does not provision
+FreeRTOS, NuttX, ThreadX and ESP-IDF, and a run that demanded all of them is a
+run nobody performs.
+
+It is not legitimate when the platform was NAMED. `just zephyr build-fixtures`
+on an unprovisioned host prints "ZEPHYR_WORKSPACE not set up — run `just zephyr
+setup`" and then exits 78, and the run is green. The user typed `zephyr`. There
+is no lane to disambiguate and no second reading of the command line; the
+message is already the remedy, it is simply not a skip.
+
+    Named -> must work.  Unnamed -> may skip, and is always reported.
+
+# What this gate holds
+
+1. THE BEHAVIOUR, by running it. `scripts/build/lane-skip.sh` is sourced and
+   both directions are exercised for every entry point, on the normal path of
+   this script — see `self_test`. A named-platform skip regressing to a pass is
+   exactly the mutation the gate exists to catch, so the gate must fail when it
+   is made, and the only way to know that is to make it.
+
+2. THE SOURCE LINE. A recipe that calls `nros_lane_*` must `source
+   scripts/build/lane-skip.sh` in its own body. Recipes are separate processes,
+   so an unsourced call is `command not found` — which `set -e` turns into rc
+   127 and a message naming nothing. Three recipes were in this state before
+   this gate; `just nuttx build-examples` on a host without NuttX died on
+   `nros_lane_skip_note: command not found` instead of reporting the skip its
+   author wrote.
+
+3. THE SCOPE DECLARATION. In a platform module, a recipe using the whole-recipe
+   `nros_lane_skip` must declare `nros_lane_platform <lane>`, or be listed in
+   NOT_A_PLATFORM_LANE with a reason. This is where a MISSED site becomes loud:
+   the runtime default is already "named" (see lane-skip.sh), so a forgotten
+   declaration cannot silently keep today's behaviour, and a deliberately
+   exempt recipe has to say why in this file.
+
+4. THE FAN-OUT SETS THE SIGNAL. `build-test-fixtures-leaves` has two drivers
+   (the serial jobserver launcher and the generated make graph) and both must
+   set `NROS_LANE_INCLUDED`. If one stops, its platforms become NAMED and go
+   red — loud, but the point of asserting it here is that "loud" should not be
+   how it is discovered.
+
+Run: python3 scripts/check-named-lane-fails.py
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LANE_SKIP = os.path.join(ROOT, "scripts", "build", "lane-skip.sh")
+
+# The nine platform modules the fixture fan-out schedules, by the FILES that
+# implement them. `zephyr` is three files; `qemu` is `qemu-baremetal.just`.
+PLATFORM_MODULE_FILES = (
+    "esp32.just",
+    "esp_idf.just",
+    "freertos.just",
+    "native.just",
+    "nuttx.just",
+    "px4.just",
+    "qemu-baremetal.just",
+    "threadx-linux.just",
+    "threadx-riscv64.just",
+    "zephyr.just",
+    "zephyr-ci.just",
+    "zephyr-dev.just",
+    "zephyr-setup.just",
+)
+
+# (file, recipe) -> why this recipe is NOT a platform lane despite living in a
+# platform module and using `nros_lane_skip`. A skip here is not about a
+# platform anyone named, so the named/included rule does not apply.
+#
+# Keep this list short and keep the reasons specific. "It was failing" is not a
+# reason; the fix for that is a `nros_lane_platform` line.
+NOT_A_PLATFORM_LANE = {
+    ("zephyr-setup.just", "build-fvp-ws-entry"): (
+        "ARM FVP is license-gated and USER-SUPPLIED — nothing in `just zephyr "
+        "setup` provisions it, so there is no remedy a failure could name."
+    ),
+    ("zephyr-setup.just", "run-fvp-ws-entry"): (
+        "ARM FVP model, as above; also a RUN verb, not a fixture lane."
+    ),
+    ("zephyr-setup.just", "build-fvp-board-import"): (
+        "ARM FVP is license-gated and user-supplied."
+    ),
+    ("zephyr-setup.just", "run-fvp-board-import"): (
+        "ARM FVP model, as above; also a RUN verb, not a fixture lane."
+    ),
+    ("qemu-baremetal.just", "test-rtic-main-e2e"): (
+        "The absent prerequisite is the ROS zenoh router, which is not part of "
+        "this platform's provisioning (RFC-0075: we ship no router)."
+    ),
+}
+
+# A `just` recipe header at column 0. Excludes assignments (`X := …`), module
+# imports and attribute lines (`[private]`), which the body scan then attaches
+# to the following recipe as `just` itself does.
+RECIPE_HEADER = re.compile(r"^([@a-zA-Z_][a-zA-Z0-9_-]*)[^:=\n]*:(?!=)")
+
+# A call at COMMAND POSITION — start of line, or after a separator. Not a bare
+# `\bnros_lane_skip\b`: that also matches the function name quoted inside an
+# `echo`, and a recipe explaining the protocol in prose is not using it.
+_CMD = r"(?:^|[;&|(!]|\bthen\b|\belse\b|\bdo\b)[ \t]*"
+CALLS_ANY = re.compile(
+    _CMD + r"nros_lane_(?:skip|skip_note|skip_reset|skip_flush|scope|scope_note|named)\b",
+    re.M,
+)
+# The whole-recipe form: `nros_lane_skip` NOT followed by `_`.
+CALLS_WHOLE_SKIP = re.compile(_CMD + r"nros_lane_skip(?![_a-zA-Z0-9])", re.M)
+DECLARES_PLATFORM = re.compile(_CMD + r"nros_lane_platform[ \t]+\S", re.M)
+SOURCES = re.compile(r"^\s*(source|\.)\s+\S*scripts/build/lane-skip\.sh")
+
+
+def recipes(text):
+    """[(name, body)] for one justfile. Body excludes the header line."""
+    out = []
+    lines = text.splitlines()
+    name = None
+    body = []
+    for line in lines:
+        if line[:1] not in ("", " ", "\t", "#"):
+            m = RECIPE_HEADER.match(line)
+            if name is not None:
+                out.append((name, "\n".join(body)))
+                name, body = None, []
+            if m:
+                name = m.group(1).lstrip("@")
+                body = []
+            continue
+        if name is not None:
+            body.append(line)
+    if name is not None:
+        out.append((name, "\n".join(body)))
+    return out
+
+
+def audit_file(rel, text):
+    """[(recipe, why)] — every violation of rules 2 and 3 in one justfile."""
+    bad = []
+    is_platform = os.path.basename(rel) in PLATFORM_MODULE_FILES
+    for name, body in recipes(text):
+        code = "\n".join(
+            l for l in body.splitlines() if not l.lstrip().startswith("#")
+        )
+        if not CALLS_ANY.search(code):
+            continue
+        if not any(SOURCES.match(l) for l in body.splitlines()):
+            bad.append(
+                (
+                    name,
+                    "calls nros_lane_* but never sources scripts/build/lane-skip.sh "
+                    "— a recipe is its own process, so the call is `command not found`",
+                )
+            )
+        if not is_platform or not CALLS_WHOLE_SKIP.search(code):
+            continue
+        if DECLARES_PLATFORM.search(code):
+            continue
+        if (os.path.basename(rel), name) in NOT_A_PLATFORM_LANE:
+            continue
+        bad.append(
+            (
+                name,
+                "uses the whole-recipe `nros_lane_skip` in a platform module but "
+                "declares no `nros_lane_platform <lane>` — a NAMED platform would "
+                "still skip here (phase-407 W2)",
+            )
+        )
+    return bad
+
+
+# ---------------------------------------------------------------------------
+# The selftest, on the normal path.
+
+
+def _bash(script, env=None, reason=""):
+    """Run `script` with lane-skip.sh sourced. The reason arrives as `$1`.
+
+    NOT interpolated into the script text, and the distinction is not
+    theoretical: the real remedy strings contain backticks (``run `just zephyr
+    setup` ``), and the first version of this selftest pasted one into a
+    double-quoted bash string. Bash ran it. The gate hung for four minutes
+    while `just zephyr setup` downloaded a 248 MB Zephyr SDK into the worktree.
+    The recipes themselves are safe — `just` hands bash `\\``-escaped text — but
+    a harness that re-quotes their strings is not, so it stops re-quoting them.
+    """
+    e = dict(os.environ)
+    e.pop("NROS_LANE_INCLUDED", None)
+    if env:
+        e.update(env)
+    return subprocess.run(
+        ["bash", "-c", f". {LANE_SKIP}\n{script}", "lane-skip-selftest", reason],
+        cwd=ROOT,
+        env=e,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def self_test():
+    """Both directions, for every entry point.
+
+    A classifier that stopped classifying looks exactly like a pass, and the
+    mutation this gate guards against — "named skips again" — is invisible to
+    any amount of grepping. So run it.
+    """
+    bad = []
+    included = {"NROS_LANE_INCLUDED": "zephyr"}
+
+    def check(label, script, env, want_rc, want_in_output=None, forbid=None, reason=""):
+        r = _bash(script, env, reason)
+        out = r.stdout + r.stderr
+        if r.returncode != want_rc:
+            bad.append(
+                f"self-test: {label}: expected rc {want_rc}, got {r.returncode}\n{out}"
+            )
+            return
+        if want_in_output and want_in_output not in out:
+            bad.append(f"self-test: {label}: expected {want_in_output!r} in output\n{out}")
+        if forbid and forbid in out:
+            bad.append(f"self-test: {label}: unexpected {forbid!r} in output\n{out}")
+
+    # 1. The whole-recipe skip. A declared platform lane, named, must FAIL —
+    #    carrying the site's own remedy text — and must not print the marker
+    #    that the fan-out reads as SKIPPED.
+    # The exact string zephyr-ci.just prints, backticks and all — so the
+    # selftest proves the operator gets the remedy VERBATIM under the new
+    # verdict, which is the whole claim of "reuse the text, change the exit".
+    remedy = "ZEPHYR_WORKSPACE not set up — run `just zephyr setup`"
+    check(
+        "nros_lane_skip: named + scope declared",
+        'nros_lane_platform zephyr; nros_lane_skip "$1"',
+        None,
+        1,
+        want_in_output=remedy,
+        forbid="NROS_LANE_SKIP:",
+        reason=remedy,
+    )
+    check(
+        "nros_lane_skip: included + scope declared",
+        'nros_lane_platform zephyr; nros_lane_skip "$1"',
+        included,
+        78,
+        want_in_output="NROS_LANE_SKIP: " + remedy,
+        reason=remedy,
+    )
+    # 2. No scope declared — a check gate or a license-gated recipe. 0599's
+    #    behaviour must be untouched in BOTH directions.
+    check(
+        "nros_lane_skip: named, no scope (a check gate)",
+        'nros_lane_skip "$1"',
+        None,
+        78,
+        want_in_output="NROS_LANE_SKIP:",
+        reason="no network: submodule pins were NOT verified",
+    )
+    check(
+        "nros_lane_skip: included, no scope",
+        'nros_lane_skip "$1"',
+        included,
+        78,
+        want_in_output="NROS_LANE_SKIP:",
+        reason="no network",
+    )
+    # 3. The step form carries its lane, so it needs no declaration.
+    check(
+        "nros_lane_skip_note: named",
+        'nros_lane_skip_note nuttx "$1"',
+        None,
+        1,
+        want_in_output="arm-none-eabi-gcc not found",
+        reason="arm-none-eabi-gcc not found",
+    )
+    check(
+        "nros_lane_skip_note: included",
+        'nros_lane_skip_reset nuttx; nros_lane_skip_note nuttx "$1"; echo NOTED',
+        included,
+        0,
+        want_in_output="NOTED",
+        reason="arm-none-eabi-gcc not found",
+    )
+    # 4. A lane NARROWING is not a missing prerequisite and never fails.
+    check(
+        "nros_lane_out_of_scope_note: named",
+        'nros_lane_skip_reset nuttx; nros_lane_out_of_scope_note nuttx "$1"; echo NOTED',
+        None,
+        0,
+        want_in_output="NOTED",
+        reason="no nuttx-riscv coordinate in this run's lane",
+    )
+    # 5. …and it still reaches the flush, which still reports SKIPPED rather
+    #    than claiming the lane built its fixtures. Named does not suppress the
+    #    report; it only forbids a prerequisite skip.
+    check(
+        "nros_lane_skip_flush: named lane with a narrowing note",
+        'nros_lane_skip_reset nuttx; nros_lane_out_of_scope_note nuttx "$1"; nros_lane_skip_flush nuttx "NuttX fixtures built."',
+        None,
+        78,
+        want_in_output="NROS_LANE_SKIP:",
+        forbid="NuttX fixtures built.",
+        reason="no nuttx-riscv coordinate",
+    )
+    check(
+        "nros_lane_skip_flush: nothing skipped",
+        'nros_lane_skip_reset nuttx; nros_lane_skip_flush nuttx "NuttX fixtures built."',
+        None,
+        0,
+        want_in_output="NuttX fixtures built.",
+    )
+    # 6. The static half, both directions, on synthetic bodies — so a
+    #    classifier that stops classifying is caught too.
+    must_flag = (
+        "build-fixtures:\n"
+        "    source scripts/build/lane-skip.sh\n"
+        '    nros_lane_skip "no sdk"\n',
+        "build-fixtures:\n" '    nros_lane_skip_note zephyr "no sdk"\n',
+    )
+    must_pass = (
+        "build-fixtures:\n"
+        "    source scripts/build/lane-skip.sh\n"
+        "    nros_lane_platform zephyr\n"
+        '    nros_lane_skip "no sdk"\n',
+        "build-fixtures:\n"
+        "    source scripts/build/lane-skip.sh\n"
+        '    nros_lane_skip_note zephyr "no sdk"\n',
+        "build-fixtures:\n" '    echo "nros_lane_skip is only prose here"\n',
+    )
+    for body in must_flag:
+        if not audit_file("zephyr-ci.just", body):
+            bad.append(f"self-test: expected a violation for:\n{body}")
+    for body in must_pass:
+        got = audit_file("zephyr-ci.just", body)
+        if got:
+            bad.append(f"self-test: unexpected violation {got} for:\n{body}")
+    # 7. A non-platform file is out of scope for rule 3 but not for rule 2.
+    if audit_file("check.just", must_flag[0]):
+        bad.append("self-test: rule 3 must not apply outside the platform modules")
+
+    if bad:
+        for b in bad:
+            sys.stderr.write(b + "\n")
+        sys.stderr.write(
+            "\ncheck-named-lane-fails: the gate's OWN selftest failed — the "
+            "protocol in scripts/build/lane-skip.sh no longer behaves as "
+            "phase-407 W2 specifies.\n"
+        )
+        sys.exit(2)
+
+
+def main():
+    self_test()
+
+    files = [("justfile", os.path.join(ROOT, "justfile"))]
+    just_dir = os.path.join(ROOT, "just")
+    for f in sorted(os.listdir(just_dir)):
+        if f.endswith(".just"):
+            files.append((os.path.join("just", f), os.path.join(just_dir, f)))
+
+    failures = []
+    for rel, path in files:
+        text = open(path, encoding="utf-8").read()
+        for name, why in audit_file(rel, text):
+            failures.append((rel, name, why))
+
+    # Rule 4 — both fan-out drivers hand their children the INCLUDED signal.
+    root_just = open(os.path.join(ROOT, "justfile"), encoding="utf-8").read()
+    n_signals = root_just.count("NROS_LANE_INCLUDED")
+    if n_signals < 2:
+        failures.append(
+            (
+                "justfile",
+                "build-test-fixtures-leaves",
+                "sets NROS_LANE_INCLUDED at fewer than 2 sites — it has TWO "
+                "drivers (the serial jobserver launcher and the generated make "
+                "graph) and a driver that does not set it turns every platform "
+                "it schedules into a NAMED one",
+            )
+        )
+
+    if failures:
+        sys.stderr.write("check-named-lane-fails: FAILED\n\n")
+        for rel, name, why in failures:
+            sys.stderr.write(f"  {rel}: recipe `{name}`:\n      {why}\n\n")
+        sys.stderr.write(
+            "  Named -> must work. Unnamed -> may skip, and is reported "
+            "(phase-407 W2).\n"
+            "    nros_lane_platform <lane>       this recipe IS that platform lane\n"
+            "    nros_lane_skip_note <lane>   a STEP's prerequisite is missing\n"
+            "    nros_lane_out_of_scope_note <lane>  this run's LANE selected no such\n"
+            "                                 coordinate — never a failure\n"
+            "  A recipe that is genuinely not a platform lane goes in\n"
+            "  NOT_A_PLATFORM_LANE with its reason, not into a missing line.\n"
+        )
+        return 1
+
+    print(
+        f"named-lane failure protocol: OK ({len(files)} justfile(s), "
+        f"{len(NOT_A_PLATFORM_LANE)} documented non-lane(s))"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-named-lane-fails.py
+++ b/scripts/check-named-lane-fails.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""phase-407 W2 — a platform you NAMED may not skip its way to green.
+"""phase-411 W2 — a platform you NAMED may not skip its way to green.
 
 # What came before, and is not being undone
 
@@ -181,7 +181,7 @@ def audit_file(rel, text):
                 name,
                 "uses the whole-recipe `nros_lane_skip` in a platform module but "
                 "declares no `nros_lane_platform <lane>` — a NAMED platform would "
-                "still skip here (phase-407 W2)",
+                "still skip here (phase-411 W2)",
             )
         )
     return bad
@@ -361,7 +361,7 @@ def self_test():
         sys.stderr.write(
             "\ncheck-named-lane-fails: the gate's OWN selftest failed — the "
             "protocol in scripts/build/lane-skip.sh no longer behaves as "
-            "phase-407 W2 specifies.\n"
+            "phase-411 W2 specifies.\n"
         )
         sys.exit(2)
 
@@ -402,7 +402,7 @@ def main():
             sys.stderr.write(f"  {rel}: recipe `{name}`:\n      {why}\n\n")
         sys.stderr.write(
             "  Named -> must work. Unnamed -> may skip, and is reported "
-            "(phase-407 W2).\n"
+            "(phase-411 W2).\n"
             "    nros_lane_platform <lane>       this recipe IS that platform lane\n"
             "    nros_lane_skip_note <lane>   a STEP's prerequisite is missing\n"
             "    nros_lane_out_of_scope_note <lane>  this run's LANE selected no such\n"

--- a/scripts/check-scope-namespace.py
+++ b/scripts/check-scope-namespace.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""One namespace for `just <verb> <scope>` — phase-407 W3.
+
+Scope is the specification: `just test zephyr`, `just build tier2`,
+`just doctor native`. Platform names and preset names share ONE argument
+position, which buys a surface with one shape to learn — and costs exactly one
+invariant, the one this gate holds:
+
+    A name may not mean two things.
+
+`native` is deliberately both a platform module and a fixture lane. That is
+legal only because they denote the SAME scope: the `native` lane is every row
+of the `native` module. Nothing enforced it. A preset added tomorrow that
+happens to share a platform's name — or a lane whose module set quietly grows
+past the platform it is named after — would silently re-scope somebody's run,
+and the failure mode is the one phase-407 exists to remove: a run that reports
+success for coverage it did not have.
+
+Three things are checked, all buildlessly (this is on the fast line):
+
+  1. Every justfile `mod` is CLASSIFIED — either a scope platform or an
+     explicitly excluded tooling module. A new module has to be placed, rather
+     than landing in neither list and being unreachable as a scope while
+     looking like one.
+  2. Every scope platform names a module that exists.
+  3. Every name that is BOTH a preset and a platform expands to exactly that
+     platform. `NROS_SCOPE_NO_BUILD=1` makes the expansion refuse to compile
+     `lane-coords`, so a colliding preset whose meaning is only knowable after
+     a build fails HERE — an unverifiable collision is itself the defect.
+
+The preset list is not written here: it is `_NROS_LANES` in
+`scripts/build/fixture-lane.sh`, read through the same shell functions the
+recipes use, so this gate cannot check a vocabulary the verbs do not have.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCOPE_SH = os.path.join("scripts", "build", "scope.sh")
+MOD = re.compile(r"^mod\s+([A-Za-z0-9_]+)\s", re.M)
+
+
+def sh(snippet, env=None):
+    """Run a snippet against the real scope.sh and return its stdout words."""
+    full = dict(os.environ)
+    full["NROS_SCOPE_NO_BUILD"] = "1"
+    if env:
+        full.update(env)
+    out = subprocess.run(
+        ["bash", "-c", f". {SCOPE_SH}; {snippet}"],
+        cwd=ROOT,
+        env=full,
+        capture_output=True,
+        text=True,
+    )
+    return out.returncode, out.stdout.split(), out.stderr
+
+
+def justfile_modules():
+    with open(os.path.join(ROOT, "justfile"), encoding="utf8") as fh:
+        return sorted(set(MOD.findall(fh.read())))
+
+
+def analyse(modules, platforms, non_platform, presets, expand):
+    """The rule, as a pure function — so the selftest can exercise a red.
+
+    `expand` maps a preset name to the platform set it denotes, or to None when
+    it cannot be resolved without a build.
+    """
+    problems = []
+    classified = set(platforms) | set(non_platform)
+    for m in modules:
+        if m not in classified:
+            problems.append(
+                f"justfile module `{m}` is in neither _NROS_SCOPE_PLATFORMS nor "
+                f"_NROS_SCOPE_NON_PLATFORM_MODULES — classify it in {SCOPE_SH} "
+                f"(a scope people can type, or a tooling module with the reason why not)"
+            )
+    for p in platforms:
+        if p not in modules:
+            problems.append(
+                f"scope platform `{p}` names no `mod {p}` in the justfile — "
+                f"`just {p} <verb>` cannot resolve, so no verb can dispatch to it"
+            )
+    for name in sorted(set(presets) & set(platforms)):
+        got = expand.get(name)
+        if got is None:
+            problems.append(
+                f"preset `{name}` collides with the platform of the same name and its "
+                f"expansion needs a build to know — an unverifiable collision. Give it a "
+                f"static arm in nros_scope_preset_expand, or rename one of the two."
+            )
+        elif set(got) != {name}:
+            problems.append(
+                f"preset `{name}` collides with the platform `{name}` and means something "
+                f"ELSE: it expands to {' '.join(sorted(got)) or '(nothing)'}. One name, two "
+                f"scopes — rename the preset or make it denote exactly `{name}`."
+            )
+    return problems
+
+
+def self_test():
+    """Prove the rule can go red, on the normal path, every run.
+
+    A negative control nobody runs decays into a comment (check-board-tiers.py),
+    so this is not behind a flag. It costs nothing: `analyse` is pure.
+    """
+    healthy = analyse(
+        modules=["native", "zephyr", "check"],
+        platforms=["native", "zephyr"],
+        non_platform=["check"],
+        presets=["all", "native"],
+        expand={"native": ["native"]},
+    )
+    assert healthy == [], f"selftest: healthy input reported {healthy}"
+
+    collide = analyse(
+        modules=["native", "zephyr", "check"],
+        platforms=["native", "zephyr"],
+        non_platform=["check"],
+        presets=["all", "native"],
+        expand={"native": ["native", "zephyr"]},
+    )
+    assert len(collide) == 1 and "means something ELSE" in collide[0], collide
+
+    unresolvable = analyse(
+        modules=["native"],
+        platforms=["native"],
+        non_platform=[],
+        presets=["native"],
+        expand={"native": None},
+    )
+    assert len(unresolvable) == 1 and "unverifiable collision" in unresolvable[0], unresolvable
+
+    unclassified = analyse(
+        modules=["native", "newthing"],
+        platforms=["native"],
+        non_platform=[],
+        presets=[],
+        expand={},
+    )
+    assert len(unclassified) == 1 and "neither" in unclassified[0], unclassified
+
+    missing_mod = analyse(
+        modules=["native"],
+        platforms=["native", "ghost"],
+        non_platform=[],
+        presets=[],
+        expand={},
+    )
+    assert len(missing_mod) == 1 and "names no `mod" in missing_mod[0], missing_mod
+
+
+def main():
+    self_test()
+
+    rc, platforms, err = sh("nros_scope_platforms")
+    if rc != 0:
+        print(f"check-scope-namespace: cannot read the platform list:\n{err}", file=sys.stderr)
+        return 1
+    rc, presets, err = sh("nros_scope_presets")
+    if rc != 0:
+        print(f"check-scope-namespace: cannot read the preset list:\n{err}", file=sys.stderr)
+        return 1
+    _, non_platform, _ = sh('printf "%s\\n" $_NROS_SCOPE_NON_PLATFORM_MODULES')
+    modules = justfile_modules()
+
+    expand = {}
+    for name in sorted(set(presets) & set(platforms)):
+        rc, got, _ = sh(f"nros_scope_preset_expand {name}")
+        expand[name] = got if rc == 0 else None
+
+    problems = analyse(modules, platforms, non_platform, presets, expand)
+    if problems:
+        print("check-scope-namespace: the scope namespace is not one namespace.", file=sys.stderr)
+        print("", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"  platforms: {' '.join(platforms)}", file=sys.stderr)
+        print(f"  presets  : {' '.join(presets)}", file=sys.stderr)
+        return 1
+
+    shared = sorted(set(presets) & set(platforms))
+    print(
+        f"check-scope-namespace: OK — {len(platforms)} platform(s), {len(presets)} preset(s), "
+        f"{len(modules)} module(s); shared name(s): {' '.join(shared) or 'none'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-scope-namespace.py
+++ b/scripts/check-scope-namespace.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One namespace for `just <verb> <scope>` — phase-407 W3.
+"""One namespace for `just <verb> <scope>` — phase-411 W3.
 
 Scope is the specification: `just test zephyr`, `just build tier2`,
 `just doctor native`. Platform names and preset names share ONE argument
@@ -13,7 +13,7 @@ legal only because they denote the SAME scope: the `native` lane is every row
 of the `native` module. Nothing enforced it. A preset added tomorrow that
 happens to share a platform's name — or a lane whose module set quietly grows
 past the platform it is named after — would silently re-scope somebody's run,
-and the failure mode is the one phase-407 exists to remove: a run that reports
+and the failure mode is the one phase-411 exists to remove: a run that reports
 success for coverage it did not have.
 
 Three things are checked, all buildlessly (this is on the fast line):

--- a/scripts/check-sdk-guard-can-fire.py
+++ b/scripts/check-sdk-guard-can-fire.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""A guard on an always-exported SDK variable can never fire — issue 0955.
+
+Six platform-lane skip guards were written:
+
+    if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then
+        nros_lane_skip_note nuttx "NUTTX_DIR unset and ... absent"; exit 0
+    fi
+
+`just/sdk-env.just` EXPORTS all 23 such variables with a default, so `-z` is
+never true, so the `&&` is never true, and the skip could never fire. Under a
+broad lane that step did not skip — it walked into cmake and FAILED where the
+author intended a skip, so an unprovisioned host got a cmake-level error instead
+of `== nuttx == SKIPPED (...)`.
+
+Unusually for this repo, that breaks the OTHER way: it does not launder a
+failure into a pass, it turns an intended skip into a confusing red. Which is
+also why nothing caught it — every gate here looks for the first direction.
+
+The fix was one shared helper, `nros_sdk_missing VAR marker`, testing the
+RESOLVED directory the way the working guards in the same files already did.
+This keeps a seventh site from reintroducing the dead form by copying a
+neighbour — the #282 -> #326 shape CLAUDE.md files under "one shared helper
+rather than a second spelling".
+
+Buildless: the export list and the guards are both plain text.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SDK_ENV = os.path.join(ROOT, "just", "sdk-env.just")
+JUST_DIR = os.path.join(ROOT, "just")
+
+EXPORT = re.compile(r"^export\s+([A-Z0-9_]+)\s*:=", re.M)
+
+
+def exported_vars(text):
+    """Variables sdk-env.just exports — every one of them always has a value."""
+    return set(EXPORT.findall(text))
+
+
+def dead_guards(text, exported):
+    """[(lineno, var, line)] for `-z` tests on a variable that is always set."""
+    out = []
+    for i, line in enumerate(text.split("\n"), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        for var in re.findall(r'-z\s+"\$\{([A-Z0-9_]+)(?::?-)?\}"', line):
+            if var in exported:
+                out.append((i, var, line.strip()))
+    return out
+
+
+def selftest():
+    """Both verdicts, on the normal path — phase-395."""
+    exported = exported_vars(
+        'export NUTTX_DIR := env("NUTTX_DIR", "x")\n'
+        'export THREADX_DIR := env("THREADX_DIR", "y")\n')
+    assert exported == {"NUTTX_DIR", "THREADX_DIR"}, exported
+
+    bad = 'if [ -z "${NUTTX_DIR:-}" ] && [ ! -d third-party/nuttx/nuttx ]; then'
+    assert dead_guards(bad, exported), "a -z on an exported var must be caught"
+
+    # The fixed shape, and the working idiom it was modelled on.
+    assert not dead_guards('if nros_sdk_missing NUTTX_DIR include; then', exported)
+    assert not dead_guards('if [ ! -d "$NUTTX_DIR/include" ]; then', exported)
+
+    # A -z on a variable sdk-env does NOT export is a legitimate question.
+    assert not dead_guards('if [ -z "${SOME_LOCAL:-}" ]; then', exported)
+
+    # A comment describing the defect is prose, not policy.
+    assert not dead_guards('    # was: [ -z "${NUTTX_DIR:-}" ]', exported)
+
+
+def main():
+    selftest()
+    with open(SDK_ENV, encoding="utf-8") as fh:
+        exported = exported_vars(fh.read())
+    if not exported:
+        sys.exit("check-sdk-guard-can-fire: no exports found in just/sdk-env.just")
+
+    problems = []
+    for fn in sorted(os.listdir(JUST_DIR)):
+        if not fn.endswith(".just"):
+            continue
+        path = os.path.join(JUST_DIR, fn)
+        with open(path, encoding="utf-8") as fh:
+            for lineno, var, line in dead_guards(fh.read(), exported):
+                problems.append(
+                    f"just/{fn}:{lineno}: tests `-z` on ${var}, which "
+                    f"sdk-env.just always exports — this guard can never fire.\n"
+                    f"      {line}\n"
+                    f"      Use: nros_sdk_missing {var} <marker-subdir>")
+    if problems:
+        sys.stderr.write("check-sdk-guard-can-fire: FAILED\n")
+        for p in problems:
+            sys.stderr.write(f"  {p}\n")
+        return 1
+    print(f"sdk guards can fire: OK ({len(exported)} exported var(s), no "
+          f"`-z` guard on any of them)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-tier-has-ci-owner.py
+++ b/scripts/check-tier-has-ci-owner.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Every declared CI tier must be RUN by something — phase-407.
+
+RFC-0061 declares four tiers and `CiTier::just_recipe()` names the command for
+each. A tier nothing invokes is a promise with no owner: the ladder says "host
+only, every commit", the workflows say nothing, and the difference is invisible
+because a lane that does not exist cannot go red.
+
+Measured 2026-08-31, before this gate:
+
+  Tier1  `just ci tier1`         0 references in .github/workflows  -- UNOWNED
+  Tier2  `just ci matrix`        post-submit, skipped on the self-hosted interlock
+  Tier2N `just ci matrix-nightly` nightly.yml
+  Tier3  `just ci full`          0 references                       -- UNOWNED
+
+Two of four tiers were run by nothing at all, and `host-tests` hand-rolled a
+subset of tier 1 (`native build-fixture-rust-core` + `build-workspace-fixtures`
++ `test-integration`) instead of invoking it — so the tier's definition and CI's
+behaviour could drift silently, and did.
+
+WHAT COUNTS AS AN OWNER
+
+A workflow that invokes the tier's recipe, in any spelling `just` accepts
+(`just ci matrix` or the flat `just ci-matrix` forwarder), or a documented
+OWNERLESS entry below with the reason. Being gated on an interlock still counts
+as owned — `check-interlock-visibility` is what makes a skipped owner visible;
+this gate answers the prior question of whether anyone runs it at all.
+
+Buildless: the ladder is Rust source, the owners are YAML.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BUCKETS = os.path.join(ROOT, "packages", "testing", "nros-tests", "src", "buckets.rs")
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+# A tier may be deliberately unowned, with the reason recorded HERE so the
+# absence is a decision someone can read rather than an accident nobody saw.
+OWNERLESS = {
+    "ci full": (
+        "tier 3 is pre-release and on demand by design (RFC-0061). It needs the "
+        "full SDK set and hours; wiring it to an event would make it a lane "
+        "nobody can afford, which is how a tier gets switched off."
+    ),
+}
+
+RECIPE = re.compile(r'CiTier::\w+\s*=>\s*"([^"]+)"')
+
+
+def declared_tiers(text):
+    """The recipe each tier declares, from `just_recipe`'s match arms."""
+    m = re.search(r"fn just_recipe\(self\).*?\{(.*?)\n    \}", text, re.S)
+    return RECIPE.findall(m.group(1)) if m else []
+
+
+def owners(workflow_texts, recipe):
+    """Workflows invoking `recipe`, in any spelling just accepts."""
+    flat = recipe.replace(" ", "-")          # `ci matrix` -> `ci-matrix`
+    pats = (re.compile(rf"just\s+{re.escape(recipe)}(\s|$)"),
+            re.compile(rf"just\s+{re.escape(flat)}(\s|$)"))
+    return sorted(fn for fn, t in workflow_texts.items()
+                  for line in t.split("\n")
+                  if not line.lstrip().startswith("#")
+                  and any(p.search(line) for p in pats))
+
+
+def selftest():
+    """Both verdicts, on the normal path — phase-395."""
+    src = ('fn just_recipe(self) -> &\'static str {\n'
+           '        match self {\n'
+           '            CiTier::Tier1 => "ci tier1",\n'
+           '            CiTier::Tier3 => "ci full",\n'
+           '        }\n    }\n')
+    assert declared_tiers(src) == ["ci tier1", "ci full"], declared_tiers(src)
+
+    wf = {"a.yml": "      - run: just ci tier1\n"}
+    assert owners(wf, "ci tier1") == ["a.yml"], "a direct invocation must count"
+    assert owners({"a.yml": "  - run: just ci-tier1\n"}, "ci tier1") == ["a.yml"], \
+        "the flat forwarder spelling must count"
+    assert owners({"a.yml": "  # just ci tier1 is not run here\n"}, "ci tier1") == [], \
+        "a comment is prose, not an owner"
+    assert owners({"a.yml": "  - run: just ci tier1-extra\n"}, "ci tier1") == [], \
+        "a longer recipe name must not count as this tier"
+
+
+def main():
+    selftest()
+    with open(BUCKETS, encoding="utf-8") as fh:
+        tiers = declared_tiers(fh.read())
+    if not tiers:
+        sys.exit("check-tier-has-ci-owner: could not parse CiTier::just_recipe")
+
+    wfs = {}
+    for fn in sorted(os.listdir(WORKFLOWS)):
+        if fn.endswith((".yml", ".yaml")):
+            with open(os.path.join(WORKFLOWS, fn), encoding="utf-8") as fh:
+                wfs[fn] = fh.read()
+
+    problems, lines = [], []
+    for recipe in tiers:
+        own = owners(wfs, recipe)
+        if own:
+            lines.append(f"  just {recipe:<20} <- {', '.join(own)}")
+        elif recipe in OWNERLESS:
+            lines.append(f"  just {recipe:<20} <- (deliberately unowned)")
+        else:
+            problems.append(
+                f"`just {recipe}` is declared in the CI ladder but NO workflow "
+                f"runs it. A tier nothing invokes is a promise with no owner, "
+                f"and it cannot go red to tell you. Wire it to an event, or add "
+                f"it to OWNERLESS in {os.path.basename(__file__)} with the reason.")
+
+    if problems:
+        sys.stderr.write("check-tier-has-ci-owner: FAILED\n")
+        for p in problems:
+            sys.stderr.write(f"  {p}\n")
+        return 1
+    print(f"tier CI owners: OK ({len(tiers)} tier(s))")
+    for l in lines:
+        print(l)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-tier-has-ci-owner.py
+++ b/scripts/check-tier-has-ci-owner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Every declared CI tier must be RUN by something — phase-407.
+"""Every declared CI tier must be RUN by something — phase-411.
 
 RFC-0061 declares four tiers and `CiTier::just_recipe()` names the command for
 each. A tier nothing invokes is a promise with no owner: the ladder says "host

--- a/scripts/dev/deprecated-scope-alias.sh
+++ b/scripts/dev/deprecated-scope-alias.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# The `just <platform> <verb>` deprecation notice — phase-407 W3.
+#
+# The module recipes STAY: they are the implementation `just <verb> <scope>`
+# dispatches to, and deleting them would delete the work. What is deprecated is
+# the module-first SPELLING as a user surface, for one release, so there is one
+# shape to learn instead of two.
+#
+# # Why this is one script and not a line in each recipe
+#
+# The notice must fire when a PERSON types `just zephyr test`, and must NOT
+# fire when the tree calls the same recipe as implementation — from `just test
+# zephyr`, from `build-test-fixtures-leaves`' fan-out, from `_orchestrate`, or
+# as an intra-module dependency (`test: build-fixtures`). Those are the same
+# recipe reached four ways, and a naive `echo` in the body prints for all of
+# them: a deprecation notice attached to the tree's own internals is noise that
+# teaches people to ignore deprecation notices.
+#
+# Nothing `just` exports distinguishes the four (verified on just 1.58: a
+# recipe's environment carries no `JUST_*` at all). What DOES distinguish them
+# is the process tree, and it answers exactly the right question:
+#
+#   * more than one `just` among our ancestors  => the tree called us, not a
+#     person. Silent.
+#   * the verb is absent from the invoking `just`'s own argv  => we are a
+#     DEPENDENCY of the recipe that was named, not the recipe. Silent.
+#   * otherwise                                  => somebody typed it. Notice.
+#
+# The second test is what keeps `just native test` from printing a second,
+# confusing notice for the `build-fixtures` dependency it pulls in.
+#
+# Never fails, never changes an exit status: a deprecation that can break a
+# build is a worse defect than the one it announces. Silence it wholesale with
+# NROS_NO_DEPRECATION=1.
+#
+# Usage:  bash scripts/dev/deprecated-scope-alias.sh <module> <module-verb> <new spelling…>
+
+set -u
+
+module="${1:-}"
+verb="${2:-}"
+shift 2 2>/dev/null || true
+replacement="$*"
+
+[ -n "$module" ] && [ -n "$verb" ] || exit 0
+[ "${NROS_NO_DEPRECATION:-0}" = "0" ] || exit 0
+
+# Walk the ancestor chain, collecting the pids whose comm is `just`. /proc is
+# the only reader here; a host without it (macOS) gets silence rather than a
+# wrong answer, which is the safe direction for a cosmetic notice.
+[ -r /proc/self/stat ] || exit 0
+
+just_pids=""
+pid="$PPID"
+hops=0
+while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$hops" -lt 32 ]; do
+    hops=$((hops + 1))
+    comm_file="/proc/$pid/comm"
+    stat_file="/proc/$pid/stat"
+    [ -r "$comm_file" ] && [ -r "$stat_file" ] || break
+    if [ "$(cat "$comm_file" 2>/dev/null)" = "just" ]; then
+        just_pids="$just_pids $pid"
+    fi
+    # field 4 of /proc/<pid>/stat is the ppid; comm (field 2) can contain
+    # spaces and parentheses, so cut at the LAST ')' before splitting.
+    stat_line="$(cat "$stat_file" 2>/dev/null)" || break
+    pid="$(printf '%s' "${stat_line##*) }" | cut -d' ' -f2)"
+    case "$pid" in ''|*[!0-9]*) break ;; esac
+done
+
+set -- $just_pids
+[ "$#" -eq 1 ] || exit 0
+
+# The one `just` above us: was this recipe NAMED, or pulled in as a dependency?
+argv="$(tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null)" || exit 0
+case " $argv " in
+    *" $verb "*) ;;
+    *) exit 0 ;;
+esac
+
+echo "note: \`just $module $verb\` is deprecated — use \`$replacement\` (phase-407; the module recipe stays as the implementation)." >&2
+exit 0

--- a/scripts/dev/deprecated-scope-alias.sh
+++ b/scripts/dev/deprecated-scope-alias.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# The `just <platform> <verb>` deprecation notice — phase-407 W3.
+# The `just <platform> <verb>` deprecation notice — phase-411 W3.
 #
 # The module recipes STAY: they are the implementation `just <verb> <scope>`
 # dispatches to, and deleting them would delete the work. What is deprecated is
@@ -78,5 +78,5 @@ case " $argv " in
     *) exit 0 ;;
 esac
 
-echo "note: \`just $module $verb\` is deprecated — use \`$replacement\` (phase-407; the module recipe stays as the implementation)." >&2
+echo "note: \`just $module $verb\` is deprecated — use \`$replacement\` (phase-411; the module recipe stays as the implementation)." >&2
 exit 0


### PR DESCRIPTION
Split out of #138. **Stacked on #149** (the CI reporting fixes) — review that one first.

Two phases that turned out to be one change: what a run is asked to cover, and what CI does with the answer.

## phase-407 — the scope you name IS the specification

> **Named → must work. Unnamed → may skip, and is always reported.**

A test that cannot run skips, and a skip is indistinguishable from a pass. That is *correct* locally — a developer on Zephyr has not provisioned FreeRTOS. The caveat is the whole issue: when someone **expects** a platform and the prerequisite is missing, the same mechanism reports success.

- **W1** — the fixture stamp recorded the lane's *nominal* coordinates, so a module that skipped a missing prerequisite still read as covered. The laundering was one line: `if [ "$have" = "all" ]; then return 0`. The build already knew, via a joblog it has written since issue 0599 — the fix is one `awk`, no new bookkeeping.
- **W2** — 21 skip sites; the decision moved into `lane-skip.sh` so 14 needed no edit. `NROS_LANE_INCLUDED` unset means *named*, so a missed site fails loudly.
- **W3** — `just <verb> [scope…]`: `just test zephyr`, not `just zephyr test`. Default scope is **probed, never stored** (a stored set drifts).
- **W4** — a CI job is `just setup <scope>` + one tier command. `just setup` could not take a preset while its own menu advertised presets.

## phase-410 — CI is BREADTH × DEPTH, and only depth is expensive

```
just ci l3 / ci matrix build   cross build + link, no boot      27–46 s
tier 2 run + warm fixtures     9.5 min + 11 min                 20+ min
```

**~25×.** So build depth gates every merge and run depth cannot.

**Run depth on `push(main)` STARVES with ten agents.** `post-submit` sets `cancel-in-progress: true` — right for "is main good now", fatal for a 20-minute lane: merges arrive faster than it completes, so every run is cancelled by the next and tier 2 **completes never**. Moved to a clock.

**Two of four declared tiers were run by nothing at all**, and `check-tier-has-ci-owner` now enforces that a tier nobody invokes is a failure, not a silent gap. It caught a coverage regression I had introduced an hour earlier (`just test tier2` runs only ¼ of what `just ci matrix` does).

**W4 — "lane" was overloaded three ways**, meaning two. `l1` was never a rung — it visits no coordinates — so it is now `just ci gate`. Depth is positional because **`just` does not parse `name=value` for a module recipe** (measured: yields the literal string).

## Two finds underneath

`check-lane-contracts` **could not see private recipes at all** — its pattern required `^[a-z]`, so every `_`-prefixed recipe was invisible, including `_lane-gate` which `ci matrix` calls. Its closure stopped silently at each private boundary. Widened; still clean, now across 3 tiers instead of 2.

Six lane guards **could never fire** (issue 0955): `[ -z "${NUTTX_DIR:-}" ]` where `sdk-env.just` exports all 23 such variables with a default. They break the *unusual* way — an intended skip became a cmake failure.

## Not verified

The interlocked jobs cannot run until a self-hosted runner is registered. `just check fast`: 155 gates OK; `ci l1`/`ci gate`, `ci matrix build` and the scope routes exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa