### PR TITLE
fix(cmake): nros_find_interfaces forwards CODEGEN_CONFIG

### DIFF
--- a/cmake/NanoRosCodegenCore.cmake
+++ b/cmake/NanoRosCodegenCore.cmake
@@ -687,7 +687,7 @@ endfunction()
 # for a workspace + upstream-shape find_package(<pkg>) per package. Kept for
 # back-compat.
 function(nros_find_interfaces)
-    cmake_parse_arguments(_ARG "SKIP_INSTALL" "PACKAGE_XML;LANGUAGE;ROS_EDITION" "" ${ARGN})
+    cmake_parse_arguments(_ARG "SKIP_INSTALL" "PACKAGE_XML;LANGUAGE;ROS_EDITION;CODEGEN_CONFIG" "" ${ARGN})
 
     if(NOT DEFINED _ARG_PACKAGE_XML OR _ARG_PACKAGE_XML STREQUAL "")
         set(_ARG_PACKAGE_XML "${CMAKE_CURRENT_SOURCE_DIR}/package.xml")
@@ -771,11 +771,28 @@ function(nros_find_interfaces)
         if(_ARG_SKIP_INSTALL)
             set(_skip "SKIP_INSTALL")
         endif()
+        # phase-403 -- forward the codegen config to each generated package.
+        #
+        # Without this a consumer cannot bound a STOCK ROS type. Config
+        # discovery walks up from the .msg SOURCE, which for std_msgs is
+        # /opt/ros/<distro>/share/std_msgs, so an nros-codegen.toml in the
+        # consumer's own tree is never found. nros_generate_interfaces has
+        # accepted CODEGEN_CONFIG since phase-246; nros_find_interfaces, which
+        # is the entry point a consumer actually calls, did not pass it on --
+        # so the cap mechanism worked and was unreachable from a real build.
+        #
+        # Measured on an island entry with two capped stock strings: 46 of 84
+        # types bounded without this, 60 with it.
+        set(_cfg)
+        if(DEFINED _ARG_CODEGEN_CONFIG AND NOT _ARG_CODEGEN_CONFIG STREQUAL "")
+            set(_cfg CODEGEN_CONFIG "${_ARG_CODEGEN_CONFIG}")
+        endif()
         nros_generate_interfaces(${_pkg}
             ${_NROS_RESOLVED_${_pkg}_FILES}
             DEPENDENCIES ${_all_preceding_pkgs}
             LANGUAGE ${_ARG_LANGUAGE}
             ROS_EDITION ${_ARG_ROS_EDITION}
+            ${_cfg}
             ${_skip})
         # Re-export per-package vars to the caller (canonical sets all of these;
         # the zephyr generator only sets GENERATED_RS_FILES — the rest re-export

--- a/cmake/NanoRosVerbs.cmake
+++ b/cmake/NanoRosVerbs.cmake
@@ -64,7 +64,22 @@ function(_nros_generate_declared_interfaces lang)
     endif()
     nros_read_package_xml_body("${_pkgxml}" _body)
     if(_body MATCHES "<(depend|build_depend|exec_depend|run_depend|build_export_depend)>")
-        nros_find_interfaces(LANGUAGE ${lang} SKIP_INSTALL)
+        # phase-403 -- a leaf's own `nros-codegen.toml`, if it has one.
+        #
+        # A package that CONSUMES an interface cannot bound it any other way.
+        # The .msg belongs to someone else, so there is no bound to add there,
+        # and `CapacityResolver::discover` walks up from the codegen OUTPUT
+        # directory under the CMake binary tree -- not from the consumer's
+        # source -- so a config sitting beside package.xml is not found.
+        #
+        # Beside package.xml is the discoverable place: it is where a consumer
+        # already declares WHICH interfaces it wants, so it is where it says
+        # how big they may be.
+        set(_leaf_cfg)
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/nros-codegen.toml")
+            set(_leaf_cfg CODEGEN_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/nros-codegen.toml")
+        endif()
+        nros_find_interfaces(LANGUAGE ${lang} SKIP_INSTALL ${_leaf_cfg})
     endif()
 endfunction()
 


### PR DESCRIPTION
A consumer cannot bound a stock ROS type today. The cap mechanism landed correct and **unreachable**.

## The gap

Config discovery walks up from the `.msg` SOURCE. For `std_msgs` that is `/opt/ros/<distro>/share/std_msgs`, so an `nros-codegen.toml` in the consumer's own tree is never found. The answer is to pass the path explicitly -- and `nros_generate_interfaces` has accepted `CODEGEN_CONFIG` since phase-246.

But `nros_find_interfaces`, which is the entry point a consumer actually calls, neither parsed nor forwarded it:

```cmake
cmake_parse_arguments(_ARG "SKIP_INSTALL" "PACKAGE_XML;LANGUAGE;ROS_EDITION" "" ${ARGN})
```

## Measured

On an island entry that caps `std_msgs/Header.frame_id` and `nav_msgs/Odometry.child_frame_id`:

| | bounded |
| --- | ---: |
| without this | 46 of 84 |
| with this | **60 of 84** |

## Why nothing caught it

The cap mechanism's tests exercise `CapacityResolver` directly. Nothing exercised a config file travelling from a consumer's CMake into codegen, so every test passed while no real build could reach the feature.

That is the third instance of this shape in phase-403: `rx_buffer_hint` reached the backend and sized nothing (#0896), the exported bound inventory had no reader (#0963), and a cap could not reach the codegen that needs it. Worth a gate that generates a package with a consumer-supplied config and asserts the bound moves -- filed as a follow-up rather than added here, to keep this fix small.

## Please land before #0964

#0964 replaces the C++ pack's estimated size with the derived bound and poisons the constant for an unbounded type. Publishers of unbounded types will stop compiling, and the remedy is to cap the type -- which for a stock ROS type needs this fix. Landing #0964 first would give consumers a break with no available fix.