### PR TITLE
docs(#0966): a codegen change stops every consumer, and only a manual step recovers

### DIFF
--- a/docs/issues/0966-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md
+++ b/docs/issues/0966-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md
@@ -1,0 +1,79 @@
+---
+id: 966
+title: "A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them"
+status: open
+area: build, codegen
+severity: medium
+related: [0963, 0965, phase-403]
+---
+
+# The staleness check is right, and it is the only thing holding the chain together
+
+## The dependency
+
+```
+rosidl-codegen sources  ->  the in-tree `nros` CLI  ->  every consumer's generated interfaces
+```
+
+Neither arrow is automatic. `just setup-cli` rebuilds the CLI by hand, and a
+consumer's interfaces regenerate only when its own build runs. The single thing
+connecting them is `NanoRosCodegenCore.cmake`'s staleness check:
+
+```
+Error: in-tree nros CLI is STALE -- its sources changed since it was built
+```
+
+## What it costs
+
+Observed three times in one afternoon of phase-403 work, each time from an
+ordinary action:
+
+1. editing `rosidl-codegen` (the whole point of the phase),
+2. moving the submodule pin forward to a merged `main`,
+3. editing it again for the follow-up wave.
+
+Each stop needs the same manual recovery -- rebuild the CLI, rebuild the image
+-- and the second case is the interesting one: nothing in the consumer's tree
+changed at all. Taking a NEWER upstream is enough to stale the CLI, so a user
+who did nothing but update a pin is told their CLI is out of date.
+
+## Why the check must stay
+
+It is doing real work, and it caught a case that would have been silent. The
+C emitter's sequence-of-strings dimensions were transposed in all three emission
+sites (`string[]` produced `char data[256][64]` instead of `[64][256]`); the fix
+lives in codegen. Without the staleness check the consumer would have
+regenerated with the OLD binary and reported success, with the tree claiming the
+fix was in. Same shape for phase-403's derived bounds: a stale CLI emits the
+previous rule's numbers and nothing says so.
+
+So this is not "delete the check". It is that the check is the ONLY thing
+holding the chain, and it holds it by stopping the build rather than by fixing
+it.
+
+## What would resolve it
+
+Options, none chosen:
+
+1. **Make the CLI a build dependency of codegen**, so a consumer's build rebuilds
+   it rather than refusing. Cost: every consumer build can now compile a Rust
+   binary, which on the Zephyr lane is a surprise, and it hides the cost of a
+   codegen change rather than naming it.
+2. **Stamp the generated output with the CLI's source hash** and regenerate when
+   it differs, which is what the fixture stamps already do elsewhere in this
+   tree. The consumer then rebuilds interfaces without rebuilding the CLI,
+   and the CLI rebuild stays explicit.
+3. **Keep the refusal and make recovery one step** -- the message names
+   `just setup-cli`, so a `--fix` affordance or a recipe that does both would
+   turn three manual recoveries into three keystrokes.
+
+(2) matches how this repo already handles derived state elsewhere, and it is
+the only one that distinguishes "the CLI is stale" from "your generated code is
+stale", which are different problems with different costs.
+
+## Adjacent
+
+The same shape as issue 0963: the build knows a fact -- here, that the CLI
+predates its sources -- and can only say so by stopping. 0963 is about numbers
+that are computed and never read; this is about a dependency that is detected
+and never acted on.

--- a/docs/issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md
+++ b/docs/issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md
@@ -1,5 +1,5 @@
 ---
-id: 966
+id: 1018
 title: "A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them"
 status: open
 area: build, codegen

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -88,5 +88,6 @@ fails if this block drifts.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
+- **#0966** (build, codegen) — A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them See `0966-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,7 +66,6 @@ fails if this block drifts.
 - **#0963** (codegen, memory, build) — The derived-bound inventory has readers now — what is left is the executor arena alone (was: nothing reads it) See `0963-*`.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
-- **#0966** (build, codegen) — A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them See `0966-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
 - **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `take_serialized` costs a decode, an encode and two heap allocations per take See `0969-*`.
 - **#0973** (orchestration) — No resolved SystemModel describes endpoint wiring — 0 of 119 carry topics, services or actions See `0973-*`.
@@ -85,10 +84,10 @@ fails if this block drifts.
 - **#1009** (testing, ci) — Our DDS interop tests share a bus with the whole LAN, so a foreign peer on another host can fail them — and `ROS_LOCALHOST_ONLY=1` alone does NOT fix it See `1009-*`.
 - **#1012** (docs, api) — Parity-ledger `why` prose names symbols a rename retired — 15 rows describe current state using dead spellings, and nothing checks it See `1012-*`.
 - **#1013** (testing) — `test_rtos_pubsub_e2e` SIGKILLs its talker after ~12 publishes, so the cell exercises twelve seconds of a free-running publisher See `1013-*`.
+- **#1018** (build, codegen) — A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them See `1018-*`.
 - **#1019** (api, docs) — Every `RCLCPP_*` log call in a ported C++ node is discarded on embedded, and `RCLCPP_*_STREAM` drops its message on every target See `1019-*`.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
-- **#0966** (build, codegen) — A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them See `0966-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -66,6 +66,7 @@ fails if this block drifts.
 - **#0963** (codegen, memory, build) — The derived-bound inventory has readers now — what is left is the executor arena alone (was: nothing reads it) See `0963-*`.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
+- **#0966** (build, codegen) — A codegen change invalidates every consumer's generated interfaces, and only a manual `setup-cli` connects them See `0966-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
 - **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `take_serialized` costs a decode, an encode and two heap allocations per take See `0969-*`.
 - **#0973** (orchestration) — No resolved SystemModel describes endpoint wiring — 0 of 119 carry topics, services or actions See `0973-*`.


### PR DESCRIPTION
Files an issue, no code change.

`rosidl-codegen` sources feed the in-tree `nros` CLI, which feeds every consumer's generated interfaces. Neither arrow is automatic; the only thing connecting them is the staleness check, which holds the chain by STOPPING the build.

Hit three times in one afternoon of phase-403 work: editing codegen, then moving a submodule pin forward to a merged `main`, then editing codegen again. The second is the notable one -- nothing in the consumer's tree changed, so a user who only updated a pin is told their CLI is stale.

**The check must stay.** It caught a transposed sequence-of-strings dimension in the C emitter that would otherwise have regenerated silently from the old binary, with the tree claiming the fix was in. The problem is that it is the only thing holding the chain.

Records three options and prefers stamping generated output with the CLI's source hash, since that is how this tree already handles derived state and it is the only one that separates "the CLI is stale" from "your generated code is stale" -- different problems with different costs.