### PR TITLE
docs(#0969, #0970): the Cyclone take path decodes the wire and encodes it again

### DIFF
--- a/docs/design/0038-zero-copy-data-transport.md
+++ b/docs/design/0038-zero-copy-data-transport.md
@@ -141,6 +141,30 @@ embedded no-alloc backend**:
 Not portable: the true zero-copy variant needs shared memory (iceoryx) /
 data-sharing QoS — desktop-only.
 
+**Amendment (2026-08-31), from reading the implementation rather than the API.**
+"desktop-only" understates it: over network transport `rmw_cyclonedds_cpp` does not
+implement the loan API at all. Without shared-memory support compiled in, its
+`rmw_take_loan_int` is
+
+```cpp
+RMW_SET_ERROR_MSG("rmw_take_loaned_message not implemented for rmw_cyclonedds_cpp");
+return RMW_RET_UNSUPPORTED;
+```
+
+(`rmw_cyclonedds_cpp/src/rmw_node.cpp:3785`), and even the shared-memory fast path
+ends in a copy — `rmw_take_ser_int_from_shm` finishes with
+`std::memcpy(serialized_message->buffer, d->loan->sample_ptr, size)` (`:3523`).
+The loan model's premise is that the payload already sits in a buffer with a
+lifetime the middleware controls; iceoryx provides that, a socket does not. This
+is the same premise our borrow slot rests on, which is why the slot is right for
+zenoh-pico and wrong for a network DDS backend — see the per-backend table below.
+
+The buffered path is where a DDS backend has something to gain, and for Cyclone
+that gain is large but unrelated to loans: upstream's serialized take is
+`dds_takecdr` → `ddsi_serdata_to_ser` into the caller's buffer, one `memcpy`
+(`rmw_node.cpp:3572`), where ours decodes to a typed struct and re-encodes. See
+[#0969](../issues/0969-cyclone-take-cdr-round-trip.md).
+
 ### micro-XRCE-DDS (the production MCU peer — most relevant)
 
 Keeps **two copies** on purpose: transport stream → a **shared static buffer
@@ -459,7 +483,7 @@ backend calls.
 | zenoh-pico C backend | n/a | **populate** the slot → call the Rust `ZenohSubscriber` leaf |
 | zpico `ZenohSubscriber` (Rust leaf) | implemented (subscriber.rs:1043) | the leaf the slot invokes; gains size-class pools (D1) |
 | xrce (C backend) | no slot | populate the slot over its shared static pool, or leave NULL (buffered) |
-| cyclonedds (C backend) | no slot | leave NULL (buffered) first; native loan path a later follow-up |
+| cyclonedds (C backend) | no slot | leave NULL (buffered) — **permanently**, not "first". Upstream returns `RMW_RET_UNSUPPORTED` for the loan take without shared memory, and its SHM path copies anyway (see the survey amendment). The win for this backend is on the buffered path: [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) |
 | mock (Rust, test-only) | falls back | buffered fallback permanently |
 
 Land the executor scaffold first (done, behind the fallback), then the CFFI vtable

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -1,0 +1,140 @@
+---
+id: 969
+title: "The Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a decode, an encode and two heap allocations per take"
+status: open
+area: [rmw, memory]
+severity: high
+related: [0958, 0781, 0896, phase-391, phase-403, rfc-0035, 0038]
+---
+
+# We take CDR off the wire, decode it, encode it again, and hand back the second copy
+
+## What the code does
+
+`nros-rmw-cyclonedds`'s `subscription_take` (`src/subscriber.cpp:134`) runs this
+sequence for every sample:
+
+```cpp
+void* sample = ddsrt_calloc(1, state->desc->m_size);   // typed sample, heap
+dds_return_t taken = dds_take(state->reader, samples, si, 1, 1);
+// ... Cyclone deserializes wire CDR into `sample`, allocating for every
+//     variable-length member as it goes ...
+dds_ostream_t os;
+dds_ostream_init(&os, 0, 1 /*xcdr1*/);                 // starts empty, grows by realloc
+bool ok = dds_stream_write_sample(&os, sample, state->st->as_sertype());
+// ... re-serializes the typed sample back to CDR ...
+uint32_t paylen = os.m_index;
+uint32_t total = paylen + 4;
+if (buf_len < total) { /* NROS_RMW_RET_BUFFER_TOO_SMALL */ }
+```
+
+The caller asked for bytes. The bytes were already there. We decoded them,
+allocated a typed struct plus one block per variable-length member, allocated and
+grew an output stream, encoded the struct back to bytes, copied those into the
+caller's buffer, and freed everything.
+
+The publish direction is the mirror image: CDR bytes → `dds_stream_read_sample` →
+typed buffer → `dds_write` → Cyclone serializes again.
+
+## This is deliberate, and the reason it was accepted no longer holds
+
+`src/sertype_min.hpp:6-29` states the tradeoff outright:
+
+> Cyclone's `dds_writecdr` / `dds_takecdr` raw-CDR API needs a real
+> `ddsi_sertype *` linked to a `ddsi_domaingv`, which our backend can't get to
+> without reaching into Cyclone's private struct layout. We sidestep that path
+> entirely: […]
+> **Cost: a 2× CDR roundtrip per publish + per recv.** Acceptable for an in-tree
+> smoke; low-throughput control loops on Cortex-A/R safety MCUs run well under the
+> headroom. A future zero-copy fast path can replace this once Cyclone exposes
+> `dds_writer_lookup_serdatatype` upstream.
+
+Two things are wrong with that reasoning as it applies to **receive**.
+
+**The stated blocker is transmit-only.** `dds_takecdr` takes no sertype:
+
+```c
+dds_return_t dds_takecdr(dds_entity_t reader_or_condition,
+                         struct ddsi_serdata **buf, uint32_t maxs,
+                         dds_sample_info_t *si, uint32_t mask);
+```
+
+(`third-party/dds/cyclonedds/src/core/ddsc/include/dds/dds.h:3783`.) The reader
+already owns its sertype from `dds_create_topic(desc)`. `dds_writer_lookup_serdatatype`
+is what the *publish* path would need, to build a serdata from raw bytes. Receive
+never needed it. The blocker was written once and applied to both directions.
+
+**"Acceptable for an in-tree smoke" is no longer the deployment.** The
+autoware-safety-island an536 lane is a real consumer running a control loop over
+this backend, and it is the lane that motivated issues 0896, 0917 and 0958.
+
+## What the reference implementation does
+
+`ros2/rmw_cyclonedds`'s `rmw_take_ser_int` (`rmw_cyclonedds_cpp/src/rmw_node.cpp:3572`)
+is the shape we should have:
+
+```cpp
+while (dds_takecdr(sub->enth, &d, 1, &info, DDS_ANY_STATE) == 1) {
+  size_t size = ddsi_serdata_size(d);
+  rmw_serialized_message_resize(serialized_message, size);
+  ddsi_serdata_to_ser(d, 0, size, serialized_message->buffer);
+  serialized_message->buffer_length = size;
+  ddsi_serdata_unref(d);
+```
+
+One `memcpy` out of the serdata. No typed sample, no member allocations, no
+ostream, no re-serialization. `ddsi_serdata_to_ser` on Cyclone's default sertype
+reads the CDR the serdata is already holding.
+
+## Three costs, not one
+
+**Throughput and jitter.** Per take: two-plus heap allocations, a full decode, a
+full encode. On a Cortex-R safety MCU this sits directly in the receive path of a
+control loop.
+
+**Real-time bound.** [phase 391](../roadmap/phase-391-allocation-unification-and-tier-model.md) argues
+the heap holds infrastructure while payload buffers stay static, and derives a
+Robson bound from that. Every Cyclone take allocates a *payload-sized* block, and
+the ostream's growth-by-realloc allocates a second one whose size depends on the
+sample. The bound as stated does not describe a Cyclone image.
+
+**Correctness of the bytes, not only their cost.** `dds_ostream_init(&os, 0, 1)`
+requests **XCDR1 in native byte order**. A ROS 2 publisher emits XCDR2, and a
+big-endian peer emits big-endian. So the caller does not receive the wire
+representation — it receives a re-encoding, with an encapsulation header we
+synthesized. This is why the sizing work has to reason about
+`MAX_SERIALIZED_SIZE_XCDR1` for this backend while the wire carries XCDR2
+(see [#0964](0964-two-different-sizes-for-the-same-type.md)). Taking the serdata's
+own bytes removes the discrepancy rather than documenting it.
+
+## Direction
+
+Rewrite `subscription_take` to the `dds_takecdr` + `ddsi_serdata_to_ser` shape:
+take the serdata, read `ddsi_serdata_size`, refuse with
+`NROS_RMW_RET_BUFFER_TOO_SMALL` when the caller's buffer is smaller, otherwise one
+`memcpy` into it, then `ddsi_serdata_unref`. The caller-owns-the-buffer contract
+costs exactly one copy; everything above that copy is removable today, inside this
+backend, with no change to Cyclone.
+
+`subscription_take_multi` (`src/subscriber.cpp:281`) has the same body and gets
+the same treatment. The request path in `src/service.cpp:657` mirrors it and
+should be checked, not assumed.
+
+**Not in scope here:** the publish direction, which genuinely needs the sertype we
+do not own — that is [#0970](0970-cyclone-rmw-should-own-its-sertype.md), and it
+subsumes this fix if it lands first.
+
+**Also not in scope:** filling the ABI's `take_loaned_message` slot for this
+backend. Upstream returns `RMW_RET_UNSUPPORTED` for it without shared-memory
+support, and even its SHM path ends in a `memcpy`; see the amendment to
+[design 0038](../design/0038-zero-copy-data-transport.md). Removing the round trip
+is the whole of the available win on the buffered path.
+
+## Verification
+
+Before/after on the an536 lane: allocation count per take (the rlsf ledger from
+[phase 394](../roadmap/phase-394-memory-campaign-ledger.md) can report it), and delivery
+rate at the fragment sizes characterized in
+[#0917](0917-an536-fragmented-sample-never-syncs.md). The bytes the caller sees should
+become byte-identical to the wire payload, encapsulation header included — that
+equality is the sharpest test that the round trip is gone.

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -130,11 +130,55 @@ support, and even its SHM path ends in a `memcpy`; see the amendment to
 [design 0038](../design/0038-zero-copy-data-transport.md). Removing the round trip
 is the whole of the available win on the buffered path.
 
-## Verification
+## Verification — measured
 
-Before/after on the an536 lane: allocation count per take (the rlsf ledger from
-[phase 394](../roadmap/phase-394-memory-campaign-ledger.md) can report it), and delivery
-rate at the fragment sizes characterized in
-[#0917](0917-an536-fragmented-sample-never-syncs.md). The bytes the caller sees should
-become byte-identical to the wire payload, encapsulation header included — that
-equality is the sharpest test that the round trip is gone.
+**Allocation count: 9.93 per message → 2.00.** `data_roundtrip` gained
+`NROS_ROUNDTRIP_ITERS`; two runs at different counts under valgrind cancel
+session and entity setup and give the per-message cost as a slope. Same harness,
+this backend against `origin/main`'s:
+
+| | allocs @1 | allocs @200 | per message |
+| --- | ---: | ---: | ---: |
+| before | 984 | 2,960 | **9.93** |
+| after | 968 | 1,366 | **2.00** |
+
+The remaining 2 are one serdata object and its payload buffer — on the loopback
+path Cyclone hands the same serdata to the local reader by reference, so one
+message costs one serdata.
+
+The before figure is not an integer, and that is information: the old path's
+ostream grew by `realloc`, so its allocation count depended on the sample. Part
+of what the round trip cost varied with the message, which is the property a
+real-time budget most dislikes. The after figure is exactly 2.00 across 199
+messages.
+
+**Correcting this section as first written:** it said the
+[phase 394](../roadmap/phase-394-memory-campaign-ledger.md) ledger could report
+allocation count per take. It cannot — that instrument reads static RAM out of an
+ELF symbol table. Runtime allocation needed an instrument and did not have one.
+
+**Byte-identity: confirmed, with a qualification that matters for sizing.**
+`ros2_pubsub_e2e` now prints what a real ROS 2 Humble peer over stock
+`rmw_cyclonedds` actually delivers (the payload was widened to 16 characters
+first, because the old one came to exactly 24 bytes of CDR — already 4-aligned,
+so it could not tell wire bytes from a padded re-encode):
+
+```
+WIRE=len:28 hdr:00010000 cdr:25
+```
+
+The backend adds nothing — `get_size` returns exactly what `from_ser` was handed.
+But **transparent is not unpadded**: the three extra bytes are the RTPS
+submessage's 4-byte alignment applied by the SENDER, and the encapsulation
+options read `0000` rather than `0003`, so the pad length is not recoverable from
+the header either. Two consequences survive this issue rather than being removed
+by it — a deserialiser must tolerate trailing bytes (nros-serdes reads by
+position, so it does), and a receive buffer cut to a type's exact
+`MAX_SERIALIZED_SIZE` can be up to 3 bytes short of what a remote peer delivers.
+That belongs to [#0964](0964-two-different-sizes-for-the-same-type.md).
+
+**Not measured, and not expected to move:** delivery rate at the fragment sizes
+in [#0917](0917-an536-fragmented-sample-never-syncs.md). That cliff is the
+LAN9118's RX FIFO capacity and has nothing to do with serialisation. What should
+move on that lane is per-message CPU and allocation, so the rate below the cliff
+and the jitter — an an536 measurement still owed.

--- a/docs/issues/0970-cyclone-rmw-should-own-its-sertype.md
+++ b/docs/issues/0970-cyclone-rmw-should-own-its-sertype.md
@@ -1,0 +1,105 @@
+---
+id: 970
+title: "The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish"
+status: open
+area: [rmw]
+severity: medium
+related: [0969, 0958, 0896, phase-391, 0038]
+---
+
+# The blocker we recorded was "Cyclone hasn't exposed this yet". It was "we don't own the sertype".
+
+## The claim on file
+
+`packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/sertype_min.hpp:6-29`:
+
+> Cyclone's `dds_writecdr` / `dds_takecdr` raw-CDR API needs a real
+> `ddsi_sertype *` linked to a `ddsi_domaingv`, which our backend can't get to
+> without reaching into Cyclone's private struct layout. We sidestep that path
+> entirely:
+>
+>     publish_raw  : CDR bytes →  dds_stream_read_sample → typed buf
+>                    → dds_write (Cyclone re-serialises) → wire
+>     try_recv_raw : wire → dds_take (typed buf)
+>                    → dds_stream_write_sample → CDR bytes → caller
+>
+> […] Cost: a 2× CDR roundtrip per publish + per recv. […] A future zero-copy fast
+> path can replace this once Cyclone exposes `dds_writer_lookup_serdatatype`
+> upstream.
+
+`SertypeMin` is therefore not a sertype the domain knows about. It is a
+hand-populated `ddsi_sertype_default` used purely as an argument to the public
+cdrstream helpers (`dds_stream_read_sample` / `dds_stream_write_sample`), with
+`serpool` and every other gv-derived field zeroed. The topic itself is created
+from the generated `dds_topic_descriptor_t`, so the reader and writer use
+**Cyclone's** sertype, and Cyclone's sertype deals in typed C structs. Hence the
+round trip in both directions.
+
+## What the reference implementation does instead
+
+`ros2/rmw_cyclonedds` never uses Cyclone's generated descriptor. It builds its own
+sertype and registers it:
+
+```cpp
+tp = dds_create_topic_sertype(pp, name, &sertype, nullptr, nullptr, nullptr);
+```
+
+(`rmw_cyclonedds_cpp/src/rmw_node.cpp:1993`.) Its serdata is the bytes
+(`src/serdata.hpp:57-60`):
+
+```cpp
+size_t m_size {0};
+/* first two bytes of data is CDR encoding
+   second two bytes are encoding options */
+std::unique_ptr<byte[]> m_data {nullptr};
+```
+
+Wire CDR arrives, is kept as CDR, and is only decoded if some caller asks for a
+typed message (`serdata_rmw_to_sample_impl`). Publishing goes the other way with
+no typed struct at all — `serdata_rmw_from_serialized_message(...)` then
+`dds_forwardcdr(pub->enth, d)` (`rmw_node.cpp:2098`, `:2146`).
+
+`dds_writer_lookup_serdatatype` never appears in that file. It is not needed,
+because when you register the sertype you already hold the pointer that a serdata
+has to be constructed against. The API we were waiting on is the API for
+recovering a sertype you don't own; owning it makes the question moot.
+
+`dds_create_topic_sertype` is public, and present in our vendored Cyclone
+(`third-party/dds/cyclonedds/src/core/ddsc/include/dds/dds.h:1393`, guarded by the
+`DDS_HAS_CREATE_TOPIC_SERTYPE` feature macro at `:1351`).
+
+## Why this is filed separately from #0969
+
+[#0969](0969-cyclone-take-cdr-round-trip.md) removes the **receive** round trip
+with `dds_takecdr`, which needs no sertype at all and is landable now, in that one
+function. This issue is the larger change: an nros sertype and serdata, which
+removes the **publish** round trip too and makes #0969's receive fix fall out for
+free. It carries real risk that #0969 does not — the sertype's op table is a
+Cyclone-internal contract, keys and instance handling have to be right, and
+`service.cpp`'s request-header wrapping (`cdds_request_wrapper_t` upstream) is
+entangled with it.
+
+So: #0969 first, this after, and this subsumes it. Recorded now so the retracted
+blocker doesn't get re-derived from the comment a third time.
+
+## Direction
+
+1. Land #0969, so receive stops round-tripping regardless of what happens here.
+2. Prototype an `nros_sertype` / `nros_serdata` pair modelled on
+   `rmw_cyclonedds_cpp/src/serdata.{hpp,cpp}` — serdata holds CDR, `to_ser` is a
+   `memcpy`, `to_sample` is only implemented if something actually needs a typed
+   struct (nothing in nano-ros does; the whole point is that our callers speak
+   bytes).
+3. Switch topic creation to `dds_create_topic_sertype`, publish via
+   `dds_forwardcdr`, delete `SertypeMin`.
+4. Check `service.cpp` request/reply header handling against the upstream
+   `cdds_request_wrapper_t` treatment before assuming step 3 covers it.
+
+## What this does not buy
+
+Not zero copy. The buffered take contract has the caller own the buffer, so one
+`memcpy` out of the serdata remains, and upstream's loaned-message path is
+`RMW_RET_UNSUPPORTED` without shared memory — see the amendment to
+[design 0038](../design/0038-zero-copy-data-transport.md). What it buys is the
+removal of a decode and an encode, and every heap allocation that goes with them,
+from both directions of a control loop's data path.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -75,5 +75,7 @@ fails if this block drifts.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
+- **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a decode, an encode and two heap allocations per take See `0969-*`.
+- **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -74,8 +74,8 @@ fails if this block drifts.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
-- **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 - **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a decode, an encode and two heap allocations per take See `0969-*`.
 - **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
+- **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
Filed from reading `ros2/rmw_cyclonedds` against our own backend. Docs only — two issues and one RFC amendment.

## What the Cyclone backend does today

`subscription_take` allocates a typed sample, lets `dds_take` deserialize the wire CDR into it, initializes a growing `dds_ostream`, re-serializes with `dds_stream_write_sample`, and copies *that* into the caller's buffer. The caller asked for bytes; the bytes were already there.

`sertype_min.hpp` records this as a deliberate tradeoff — *"Cost: a 2× CDR roundtrip per publish + per recv"* — pending Cyclone exposing `dds_writer_lookup_serdatatype` upstream.

## Two corrections

**The blocker is transmit-only.** `dds_takecdr(reader, &serdata, maxs, si, mask)` takes no sertype; the reader already owns one from `dds_create_topic(desc)`. Only publish needs to build a serdata from raw bytes. **#0969** removes the receive round trip inside one function, with no change to Cyclone.

**And the lookup isn't needed for publish either.** `rmw_cyclonedds_cpp` never calls it — it registers its own sertype via `dds_create_topic_sertype` (public, present in our vendored tree), so there is no typed struct in either direction. The API we were waiting on recovers a sertype you don't own; owning it makes the question moot. That's **#0970**, filed separately: the sertype op table, key handling, and `service.cpp`'s request-header wrapping carry risk #0969 doesn't. #0970 subsumes #0969 if it lands first, so the order is #0969 → #0970.

## Why this isn't only a throughput note

- Per-take heap allocations sized by the **payload** contradict phase-391's Robson argument that payload buffers stay static.
- `dds_ostream_init(&os, 0, 1)` re-encodes as XCDR1 native-endian, so the caller never sees the wire representation — the discrepancy #0964 currently documents rather than removes.

## RFC-0038 amendment

The survey said the DDS loan model's zero-copy variant is "desktop-only". Reading the implementation, it's stronger: over network transport `rmw_cyclonedds_cpp` doesn't implement the loan API at all (`RMW_RET_UNSUPPORTED`, `rmw_node.cpp:3785`), and even its shared-memory path finishes with a `memcpy`. The loan premise — payload already in a middleware-controlled buffer — is what iceoryx provides and a socket doesn't. Same premise our borrow slot rests on, which is why the slot is right for zenoh-pico and wrong for a network DDS backend.

So the per-backend table now says the Cyclone slot stays NULL **permanently**, not "first", and points at the buffered path as where the win actually is.

## Testing

Docs only. `just check` fails two gates (`fixtures-manifest`, `kconfig-overridden-values`) identically with and without this diff — `nros: command not found` in a fresh worktree, no `setup-cli` run. Verified by stashing and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
