### PR TITLE
docs(0900): the arena remedy assumed information the tree does not carry

### DIFF
--- a/changelog.d/0900.feat.md
+++ b/changelog.d/0900.feat.md
@@ -1,0 +1,1 @@
+`check-action-client-arena-budget` compares an image's `NROS_EXECUTOR_ACTION_CLIENTS` against what it actually links, so an image that budgets 0 arena slots for an action entity it does link is caught at build time instead of at runtime registration

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -299,6 +299,20 @@ Measured from `target/nros-cpp-generated/nros/nros_cpp_config_generated.h`
     NROS_CPP_RAW_ACTION_CLIENT_OPAQUE_U64S = 654  ->  5,232 B
     NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S = 799  ->  6,392 B
 
+**Caveat on those two numbers, added on integration.** `NROS_CPP_RAW_ACTION_*_
+OPAQUE_U64S` are the C++ FFI OPAQUE HANDLE sizes, not arena entry sizes. The
+arena budgets an action client at 18,048 B from a different formula
+(`3 x (4096+384) + 3 x rx_buf + 1536`), so 6,392 vs 5,232 does NOT say the
+action-server ARENA ENTRY exceeds the client's — only that the C++ handle does.
+
+The conclusion the gate acts on survives the correction, for a different reason:
+the arena demonstrably stores action servers (`ActionServerArenaEntry`,
+`ActionServerRawArenaEntry` in `arena.rs`), so an action-server image occupies
+slots and must not be advised to zero the knob. Treating both entities as heavy
+is conservative and correct whichever handle is larger. The size ORDERING is
+recorded as suggestive, not as the justification.
+
+
 against a pub/sub entry budgeted at `3 x rx_buf + 512` = 3,584 B. So an action
 server needs a slot a pub/sub budget cannot hold either, and advising an
 action-server image to set `NROS_EXECUTOR_ACTION_CLIENTS=0` would have traded the

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -326,3 +326,64 @@ whether the entity justifying its size was linked in.
 
 Recorded rather than acted on: choosing between these is a design decision, and
 this issue's original remedy assumed information the tree does not carry.
+
+## Option 1 explored — cheaper than stated, and unsafe alone (2026-09-01)
+
+Two objections raised against option 1 above were WRONG, and the correction
+matters because it made option 1 look more expensive than it is:
+
+* **"Costs a migration for every existing model"** — no. `SourceMetadata` is a
+  DERIVED sidecar, content-addressed by `inputs_digest` and stamped with a
+  generator version. It is regenerated, not hand-maintained. A new field needs
+  `#[serde(default)]` (the struct is `deny_unknown_fields`) and nothing else.
+* **"Asks users to declare what they construct"** — no. Users declare nothing.
+  `metadata_mode::record_entity` already captures the client when the node
+  builds it, and `EntityKind` ALREADY HAS `ActionClient` and `ServiceClient`.
+
+The gap is one place. `node_metadata.rs:782-784` writes arrays for publishers,
+subscribers, timers, `services` (`ServiceServer`) and `actions`
+(`ActionServer`) — and never writes one for the client kinds. The data is
+recorded and then dropped on the way out.
+
+So the change is small: two more `write_entity_array` calls, two small structs
+(clients register no callbacks, so they are simpler than their server
+counterparts), a sum in `entity-facts`, and one more key through the cmake seam
+that already delivers the queryable figures. `build.rs` needs no change.
+
+### The hazard that stops it being sufficient
+
+**A cross-compiled component is UNPROBEABLE by construction.** Metadata mode
+runs the component to capture entities and needs a host build;
+`metadata_build.rs`'s own test is named
+`build_std_with_a_foreign_target_is_unprobeable`, and the probe comments record
+that "ONE unprobeable component degrades to the sidecar-less path". Four
+embedded example leaves carry `.unprobeable.` markers today — including
+`examples/qemu-arm-freertos/rust/action-client`, which is an action client.
+
+If the derivation sums clients from a sidecar-less component it gets **0**, and
+sizes the arena DOWN for an image that may well have an action client. That is
+option 2's registration failure arriving silently, on the targets least able to
+report it.
+
+So the count must be a TRI-STATE, not a number: `known(n)` versus `unknown`,
+with `unknown` falling back to today's worst-case default. Absence of evidence
+is not evidence of absence, and this is the shape where that distinction is
+load-bearing.
+
+### And that limits what option 1 can buy
+
+With the tri-state, the tight arena reaches PROBED components — host and native
+— and never reaches the unprobeable cross builds. The 56.5 KiB is a stack cost,
+so it matters most exactly where option 1 cannot help.
+
+**Option 3 covers that half.** `nm` works fine on a cross ELF: an image that
+never references `ActionClientCore::new` cannot have an action client, so the
+knob can be CHECKED against the linked reality precisely where it cannot be
+derived.
+
+So the two are complements, not alternatives:
+
+* **1** — automatic and tight where the component can be probed;
+* **3** — a checked manual knob where it cannot.
+
+Neither alone is both safe and useful across the tree.

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -267,3 +267,62 @@ class because nothing states a per-type bound. This is one level up: even with a
 perfect per-type hint, the arena slot holding that subscription is still
 budgeted as though it were an action client. The two share the
 `NROS_SUBSCRIPTION_BUFFER_SIZE` knob and nothing else.
+
+## The remedy this issue assumed does not exist (2026-08-31)
+
+The obvious fix — derive `NROS_EXECUTOR_ACTION_CLIENTS` from what the image
+declares, the way `entity-facts` already derives the queryable figures —
+**cannot be done**, and the reason is structural rather than missing plumbing.
+
+**The mechanism is already in place.** `nros-node/build.rs` takes
+`NROS_EXECUTOR_ACTION_CLIENTS` (default `max_cbs`, so the old formula reproduces
+byte for byte and no existing image moves) and budgets the two entry SHAPES
+separately instead of charging every slot the larger one. The knob is plumbed
+through `zephyr/Kconfig`, `platform_config.rs`, the generated configuration
+surface, and the runtime advisory names it when an arena is too small. Setting
+it to 0 takes 74,240 bytes to 16,384.
+
+**Nothing sets it, and nothing can.** `source_metadata.rs` — the structure a
+model is built from — contains ZERO occurrences of "client". Its entity types
+are:
+
+```
+SourcePublisher   SourceSubscriber   SourceTimer
+SourceService   (a `callback` — the SERVER side)
+SourceAction    (goal/cancel/accepted callbacks — the SERVER side)
+```
+
+nano-ros declares the entities that need CODEGEN REGISTRATION: publishers,
+subscribers, timers, and the server halves of services and actions. A client —
+`ActionClientCore::new`, a service client — is constructed imperatively in user
+code and is invisible to the build. That is a coherent design; it simply means
+the arena cannot be sized from the model, because the model does not know.
+
+So the count is not "not yet wired". It is **not expressible**.
+
+## The decision this needs
+
+1. **Declare client-side entities.** Extend `SourceMetadata` with action and
+   service clients so `entity-facts` can report them. Buys the automatic
+   derivation, and would let other table sizing tighten too. Costs a schema
+   addition, a resolver change and a migration for every existing model — and
+   asks users to declare something they currently just construct.
+2. **Leave the knob manual and flip the DEFAULT.** Today it defaults to
+   `max_cbs`, the worst case, so nobody pays a surprise. Defaulting to 0 would
+   make every pub/sub image 56.5 KiB smaller and break every action-client image
+   at REGISTRATION rather than at link — a runtime failure for a compile-time
+   fact, which `arena_used()` and the first-spin advisory soften but do not fix.
+3. **Derive it from the LINKER, not the model.** An image that never references
+   `ActionClientCore::new` cannot have one. That is a post-link fact, so it
+   cannot size a compile-time constant — but it can power a GATE that fails an
+   image whose knob is larger than its linked reality, turning a manual setting
+   into a checked one.
+
+(3) is the interesting one: it keeps the knob manual but stops it being a guess,
+needs no schema change, and is the only option verifiable with `nm`. That last
+point matters here — the arena is INLINE ON THE TASK STACK, so `just mem-report`
+cannot see it at all. A symbol probe cannot measure the arena, but it can see
+whether the entity justifying its size was linked in.
+
+Recorded rather than acted on: choosing between these is a design decision, and
+this issue's original remedy assumed information the tree does not carry.

--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -236,6 +236,105 @@ first-spin advisory, set the knob, and be told plainly if it was set too low.
 a declared entity inventory is still the real fix, and still blocked on the
 inventory existing — see below.
 
+## Landed: the knob is now checked against the LINKED image (W3, option 3)
+
+`scripts/check-action-client-arena-budget.py`, on the fast line as
+`just check action-client-arena-budget`. An image that never links the
+action-client creation path cannot have an action client. That is a post-link
+fact, so it cannot SIZE a compile-time constant — but it can GATE one:
+
+* **knob > 0, nothing heavy linked** — the image carries arena it cannot use.
+  **ADVISORY.** It is the shipped state of nearly everything (the knob defaults
+  to `MAX_CBS`, and nothing has ever set it), so failing on it would produce a
+  uniformly red lane, which has no signal capacity at all: a regression landing
+  in it would look exactly like yesterday's red.
+* **knob == 0, an action entity IS linked** — registration fails at RUNTIME with
+  `NodeError::BufferTooSmall`, on a target where a return code is all you get.
+  **FAILS.**
+
+**This is the only half of the fix that reaches embedded images.** The
+sidecar/metadata half cannot: a cross-compiled component is unprobeable by
+construction (`metadata_build.rs`'s own test is named
+`build_std_with_a_foreign_target_is_unprobeable`). `nm` reads a cross ELF
+perfectly well, which is exactly where a 56.5 KiB stack frame decides whether an
+image boots.
+
+### The obvious symbol was the wrong one, and would have passed vacuously
+
+`ActionClientCore::new` fails twice over. It is **inlined away** — it appears in
+NO image in the tree, action clients included — and `ActionClientCore` as a TYPE
+appears in **every** image that links the executor: 6 symbols (drop glue + five
+methods) in `qemu-rtic-talker`, a pub/sub-only image, byte-identical in count to
+`qemu-rtic-action-client`. `spin.rs` names the default-sized monomorphisation
+directly, so the dispatch code is linked whether or not anything creates a
+client. A probe on the type name would have reported "has an action client" for
+the whole tree and never fired.
+
+The discriminator is the CREATION path. Measured over 58 built ELFs on
+2026-09-01 (20 Cortex-M `thumbv7m-none-eabi`, 38 x86_64), `create_action_client*`
+and `create_action_server*` matched exactly the four action clients and the three
+action servers and nothing else; `service-client` / `service-server` are the
+nearest misses and score 0:
+
+| image | client | server | `ActionClientCore` |
+| --- | ---: | ---: | ---: |
+| `qemu-rtic-action-client` | 1 | 0 | 6 |
+| `qemu-rtic-action-server` | 0 | 1 | 6 |
+| `qemu-rtic-talker` | 0 | 0 | 6 |
+| `qemu-rtic-service-client` | 0 | 0 | 6 |
+| `action-client` (x86_64) | 1 | 0 | 6 |
+| `action-server` (x86_64) | 0 | 1 | 6 |
+
+Over all 221 images the tool can reach on a fully built tree, the verdicts and
+the file NAMES agree exactly: 35 "matched", every one of them an
+`*action-client*` or `*action-server*` binary.
+
+### The action SERVER counts too, though the knob is named for clients
+
+The knob's real meaning is "how many slots are budgeted at the WORST-CASE entry
+size", and `build.rs` picked the action client as that worst case. It is not.
+Measured from `target/nros-cpp-generated/nros/nros_cpp_config_generated.h`
+(x86_64, default 1024-byte buffers):
+
+    NROS_CPP_RAW_ACTION_CLIENT_OPAQUE_U64S = 654  ->  5,232 B
+    NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S = 799  ->  6,392 B
+
+against a pub/sub entry budgeted at `3 x rx_buf + 512` = 3,584 B. So an action
+server needs a slot a pub/sub budget cannot hold either, and advising an
+action-server image to set `NROS_EXECUTOR_ACTION_CLIENTS=0` would have traded the
+advisory for the exact `BufferTooSmall` this gate exists to prevent. Both
+entities are "heavy" here. (A follow-up worth filing: the derivation's own
+comment still calls the action client the worst case, and it is 1,160 bytes
+short of one.)
+
+### What it cannot decide, and says so
+
+A C or C++ image links `nros-c` / `nros-cpp` with `--whole-archive` (the issue
+0475 shape), so the staticlib is in the image whether or not the app calls any
+of it. `NodeHandle::create_action_client_raw` is a GLOBAL in **every** C entry:
+`native_entry` (a talker) and `native_action_client_entry` are indistinguishable
+on this probe. Those are reported INDETERMINATE, never OK, detected by the FFI
+surface itself (`nros_cpp_action_client_create` / `nros_action_client_init`),
+which is absent from every pure-Rust image measured. CMake-built entries outside
+a cargo profile dir are unreachable for a second, independent reason — there is
+no `nros_node_config.rs` to attribute to them — so the knob half is missing for
+exactly the same population.
+
+A tree with nothing built exits 78 and records a **SKIP**, never a pass: a gate
+that examined zero images must not read like one that agreed.
+
+### What the tree looks like today
+
+Zero images are in the dangerous direction — nothing anywhere sets the knob to
+0, so there is no live `BufferTooSmall` to find. **181 of 221 images are
+over-budgeted, 28 of them cross-compiled** (`thumbv7m-none-eabi`,
+`riscv32imc-unknown-none-elf`), each carrying a 74,240-byte arena on a task
+stack for an entity it does not have. The gate does not fix that; it makes it
+enumerable, which is what `NROS_EXECUTOR_ACTION_CLIENTS` never was.
+
+**Still not done:** nothing sets the knob automatically. This gate reports the
+mismatch, it does not resolve it.
+
 ## This is phase-392 W2, found from the other end
 
 Filed from a measurement — `ARENA_SIZE` is 74,240 bytes on every generated

--- a/just/check.just
+++ b/just/check.just
@@ -139,7 +139,7 @@ fast-serial: \
     interface-glob-configure-depends \
     wait-evidence-discarded \
     path-env-fingerprints retired-platform-clock-symbols \
-    cmake-support-library message-bound-knobs \
+    cmake-support-library message-bound-knobs action-client-arena-budget \
     tests-can-fail
     # `_check-skip-reset` is shared skip-ledger infrastructure at the ROOT
     # (`run-gates-parallel.sh` calls it too), not a gate — and a module cannot
@@ -854,6 +854,34 @@ message-bound-knobs:
         exit 0
     fi
     ./tests/cmake-message-bounds-tests.sh
+
+# Issue 0900 (option 3) -- does an image's NROS_EXECUTOR_ACTION_CLIENTS agree
+# with what it actually LINKS? The knob decides how many executor arena slots
+# are budgeted at the worst-case (ActionClient) size, and the arena is inline on
+# the TASK STACK, so `just mem-report` cannot see it: the checkable thing is the
+# ENTITY that justifies the size, and `nm` reads a cross ELF perfectly well.
+# This is the only half of 0900 that reaches embedded images -- the
+# sidecar/metadata half cannot, because a cross-compiled component is
+# unprobeable by construction.
+#
+# Cheap where it matters: instant on a tree with nothing built (it exits 78 and
+# records a SKIP rather than reporting a pass over zero images), ~18 s on a
+# fully built 100 GB dev tree, which is one `nm` per image and no compilation.
+action-client-arena-budget:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    _rc=0
+    python3 scripts/check-action-client-arena-budget.py || _rc=$?
+    if [ "$_rc" -eq 78 ]; then
+        # 78 is `lane-skip.sh`'s "I did no work", reused so there is ONE
+        # spelling of it. A gate that examined nothing must not read as a pass.
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip action-client-arena-budget \
+            "no built image with an attributable nros_node_config.rs in this tree"
+        exit 0
+    fi
+    exit "$_rc"
 
 abi-bindings:
     #!/usr/bin/env bash

--- a/packages/api/nros/src/metadata_mode.rs
+++ b/packages/api/nros/src/metadata_mode.rs
@@ -227,6 +227,49 @@ mod tests {
         reset();
     }
 
+    /// issue 0900 — the CLIENT halves reach the sidecar.
+    ///
+    /// `record_entity` has always accepted `ActionClient`/`ServiceClient`, and
+    /// the serializer dropped them: a sidecar described only what a component
+    /// SERVES. The executor arena is sized from the client count, so the
+    /// omission had a size cost (74,240 vs 16,384 bytes, on the task stack) and
+    /// not merely a descriptive one.
+    #[test]
+    fn client_entities_reach_the_sidecar() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset();
+        assert!(begin_node("client_node", "/", 0));
+        assert!(record_entity(
+            EntityKind::ActionClient,
+            "/fibonacci",
+            "example_interfaces/action/Fibonacci",
+            None,
+            None
+        ));
+        assert!(record_entity(
+            EntityKind::ServiceClient,
+            "/add_two_ints",
+            "example_interfaces/srv/AddTwoInts",
+            None,
+            None
+        ));
+        let export = SourceMetadataExport::new("client_pkg", "client_node").language("rust");
+        let json = to_json(&export).expect("serialize");
+        assert!(json.contains("\"action_clients\":[{"), "got: {json}");
+        assert!(json.contains("\"service_clients\":[{"), "got: {json}");
+        // A client registers no callbacks. The server writers emit a
+        // `callback`/`goal_callback` field; the client writer must not, which is
+        // why it is a separate function rather than a reused one.
+        let tail = &json[json.find("\"action_clients\"").expect("array")..];
+        let end = tail.find(']').expect("array end");
+        assert!(
+            !tail[..end].contains("callback"),
+            "a client must carry no callback field: {}",
+            &tail[..end]
+        );
+        reset();
+    }
+
     /// An entity recorded with no open node is a bug in the adapter, and must
     /// be refused rather than silently attributed or dropped — a dropped entity
     /// is an under-sized executor at boot.

--- a/packages/api/nros/src/node_metadata.rs
+++ b/packages/api/nros/src/node_metadata.rs
@@ -781,7 +781,17 @@ impl<const MAX_NODES: usize, const MAX_ENTITIES: usize, const MAX_CALLBACKS: usi
         out.write_char(',')?;
         self.write_entity_array(out, "services", node_id, EntityKind::ServiceServer)?;
         out.write_char(',')?;
-        self.write_entity_array(out, "actions", node_id, EntityKind::ActionServer)
+        self.write_entity_array(out, "actions", node_id, EntityKind::ActionServer)?;
+        // issue 0900 — the CLIENT halves. `record_entity` has always captured
+        // them (`EntityKind::{ActionClient,ServiceClient}`, set in node.rs) and
+        // this writer dropped them on the way out, so a sidecar described only
+        // what a component SERVES. The executor arena is sized from the client
+        // count, which is why the omission had a size cost and not just a
+        // descriptive one.
+        out.write_char(',')?;
+        self.write_entity_array(out, "action_clients", node_id, EntityKind::ActionClient)?;
+        out.write_char(',')?;
+        self.write_entity_array(out, "service_clients", node_id, EntityKind::ServiceClient)
     }
 
     #[cfg(feature = "alloc")]
@@ -808,6 +818,12 @@ impl<const MAX_NODES: usize, const MAX_ENTITIES: usize, const MAX_CALLBACKS: usi
                 EntityKind::Timer => write_timer_json(out, entity)?,
                 EntityKind::ServiceServer => write_service_json(out, entity)?,
                 EntityKind::ActionServer => write_action_json(out, entity)?,
+                // issue 0900 — a client registers no callbacks, so it needs
+                // none of the server writers' callback fields. One writer
+                // serves both client kinds.
+                EntityKind::ActionClient | EntityKind::ServiceClient => {
+                    write_client_json(out, entity)?
+                }
                 _ => {}
             }
         }
@@ -1164,6 +1180,35 @@ fn write_service_json(
     if let Some(callback_slot) = entity.callback_slot {
         write!(out, ",\"callback_slot\":{}", callback_slot.index())?;
     }
+    write!(out, "}}")
+}
+
+/// issue 0900 — a client entity: identity, name and interface, no callbacks.
+///
+/// Deliberately ONE writer for both `ActionClient` and `ServiceClient`. They
+/// differ only in the interface KIND word, and the server-side pair is already
+/// two near-identical functions; a third and fourth would be the second
+/// spelling this repo keeps paying for.
+#[cfg(feature = "alloc")]
+fn write_client_json(
+    out: &mut impl core::fmt::Write,
+    entity: &EntityMetadata,
+) -> core::fmt::Result {
+    let interface_kind = if entity.kind == EntityKind::ActionClient {
+        "action"
+    } else {
+        "service"
+    };
+    write!(out, "{{")?;
+    write_json_field(out, "id", entity.id.as_str())?;
+    out.write_char(',')?;
+    if let Some(slot) = entity.slot {
+        write!(out, "\"declaration_slot\":{},", slot.index())?;
+    }
+    write!(out, "\"unresolved_name\":")?;
+    write_source_name(out, entity.source_name.as_str(), entity.source_name_kind)?;
+    out.write_char(',')?;
+    write_interface(out, entity.type_name, interface_kind)?;
     write!(out, "}}")
 }
 

--- a/packages/cli/nros-cli-core/src/orchestration/source_metadata.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/source_metadata.rs
@@ -60,6 +60,17 @@ pub struct SourceNode {
     pub timers: Vec<SourceTimer>,
     pub services: Vec<SourceService>,
     pub actions: Vec<SourceAction>,
+    /// issue 0900 — the CLIENT halves, which size the executor arena.
+    ///
+    /// `#[serde(default)]` because this struct is `deny_unknown_fields` and a
+    /// sidecar emitted before these existed must still parse. An empty vector
+    /// from an OLD sidecar is indistinguishable from a component that genuinely
+    /// has no clients, which is why the consumer keys on the sidecar's presence
+    /// rather than on the count being zero — see `entity_facts`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub action_clients: Vec<SourceClient>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_clients: Vec<SourceClient>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -156,6 +167,21 @@ pub struct SourceService {
     pub callback: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub callback_slot: Option<u32>,
+}
+
+/// issue 0900 — an action or service CLIENT.
+///
+/// One struct for both: a client registers no callbacks, so unlike the server
+/// pair (`SourceService` carries a `callback`, `SourceAction` carries three)
+/// they differ in nothing but which array they arrive in.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceClient {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declaration_slot: Option<u32>,
+    pub unresolved_name: SourceName,
+    pub interface: InterfaceRef,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/scripts/build/run-gates-parallel.sh
+++ b/scripts/build/run-gates-parallel.sh
@@ -123,7 +123,16 @@ fi
 # Still exit 0: these are missing tools and build products, not failures, and
 # `check-fast` must stay green on a bare worktree. What changes is only that
 # the sentence stops overstating what happened.
-skips="$(pwd)/build/check-skips/checks.skipped"
+# Derive the ledger path, do NOT spell it (RFC-0070). `nros_check_skip` writes
+# through `nros_build_dir`, which honours `NROS_BUILD_ROOT` and resolves against
+# the REPO rather than `$PWD` — so a literal `$(pwd)/build/...` reads a
+# different file in a git worktree or with the cache root moved, and every skip
+# is invisible exactly where it was recorded. Found while adding
+# `action-client-arena-budget`, which skips whenever nothing is built and
+# therefore skips in most CI runs.
+# shellcheck source=scripts/build/check-skip.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-skip.sh"
+skips="$(nros_build_dir "$NROS_KIND_CHECK_SKIPS")/checks.skipped"
 skipped=0
 if [ -s "$skips" ]; then
     skipped=$(wc -l <"$skips")

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -78,6 +78,18 @@ measured from `target/nros-cpp-generated/nros/nros_cpp_config_generated.h`
 
     NROS_CPP_RAW_ACTION_CLIENT_OPAQUE_U64S = 654  ->  5,232 B
     NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S = 799  ->  6,392 B
+# **Caveat on those two numbers, added on integration.** `NROS_CPP_RAW_ACTION_*_
+# OPAQUE_U64S` are the C++ FFI OPAQUE HANDLE sizes, not arena entry sizes. The
+# arena budgets an action client at 18,048 B from a different formula
+# (`3 x (4096+384) + 3 x rx_buf + 1536`), so 6,392 vs 5,232 does NOT say the
+# action-server ARENA ENTRY exceeds the client's — only that the C++ handle does.
+#
+# The conclusion the gate acts on survives the correction, for a different reason:
+# the arena demonstrably stores action servers (`ActionServerArenaEntry`,
+# `ActionServerRawArenaEntry` in `arena.rs`), so an action-server image occupies
+# slots and must not be advised to zero the knob. Treating both entities as heavy
+# is conservative and correct whichever handle is larger. The size ORDERING is
+# recorded as suggestive, not as the justification.
 
 against a pub/sub entry budgeted at `3 * rx_buf + 512` = 3,584 B. So an action
 SERVER also needs a slot a pub/sub budget cannot hold, and telling an

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Does an image's `NROS_EXECUTOR_ACTION_CLIENTS` match what it actually links?
+
+Issue 0900, option 3.
+
+WHAT THIS ANSWERS AND WHY IT IS THE ONLY MECHANISM THAT REACHES EMBEDDED
+
+`NROS_EXECUTOR_ACTION_CLIENTS` decides how many of the `MAX_CBS` executor arena
+slots are budgeted at ActionClient size rather than pub/sub size. It defaults to
+`MAX_CBS`, which reproduces the pre-0900 arithmetic byte for byte: 74,240 bytes
+at the shipped defaults against 16,384 with the knob at 0. That arena is INLINE
+ON THE TASK STACK (`Executor::open_sized`), not in `.bss`, so `just mem-report`
+cannot see it at all and never will — do not try to measure the arena here. What
+is checkable is the ENTITY whose size justifies the budget.
+
+An image that never links the action-client creation path cannot have an action
+client. That is a post-link fact, so it cannot SIZE a compile-time constant, but
+it can GATE one:
+
+  knob > 0, machinery NOT linked -> the image carries arena it cannot use.
+      ADVISORY. This is the common case today (the knob defaults to the worst
+      case and nothing ever set it), and a gate that fails on every image in the
+      tree has no signal capacity — a regression landing in it would look
+      exactly like yesterday's red.
+  knob == 0, machinery IS linked  -> registration will fail at RUNTIME with
+      `NodeError::BufferTooSmall`, on a target where a return code is all you
+      get. FAILS. This is the direction that has to be loud.
+
+The sidecar/metadata half of issue 0900 cannot cover embedded at all: a
+cross-compiled component is unprobeable by construction (`metadata_build.rs`'s
+own test is named `build_std_with_a_foreign_target_is_unprobeable`). `nm` reads a
+cross ELF perfectly well, which is why this half exists and why it is the only
+one that reaches the targets where a 56.5 KiB stack frame decides whether an
+image boots.
+
+WHICH SYMBOL — MEASURED, NOT ASSUMED
+
+The obvious candidate, `ActionClientCore::new`, is WRONG TWICE and a probe on it
+would have passed vacuously:
+
+  * `ActionClientCore::new` is inlined away. It appears in NO image in the tree,
+    action clients included.
+  * `ActionClientCore` as a type appears in EVERY image that links the executor:
+    6 symbols (drop glue + five methods) in `qemu-rtic-talker`, a pub/sub-only
+    image, identical to `qemu-rtic-action-client`. `spin.rs` names the
+    default-sized monomorphisation directly, so the dispatch code is linked
+    whether or not anything creates a client.
+
+The discriminator is the CREATION path, `create_action_client*` /
+`create_action_server*` on `NodeHandle` / `DeclaredNode`. Measured over 58 built
+ELFs on 2026-09-01 — 20 Cortex-M (thumbv7m-none-eabi) and 38 x86_64 — the two
+families matched exactly the four action clients and the three action servers,
+and nothing else. `service-client` and `service-server` are the nearest misses
+and both score 0:
+
+    image                      client  server  ActionClientCore
+    qemu-rtic-action-client       1       0          6
+    qemu-rtic-action-server       0       1          6
+    qemu-rtic-talker              0       0          6
+    qemu-rtic-service-client      0       0          6
+    action-client (x86_64)        1       0          6
+    action-server (x86_64)        0       1          6
+    native-rs-async-action-client 1       0          3
+    rtic-action-client            1       0          2
+    rtic-action-server            0       1          0
+
+The substring survives with or without a demangler: the legacy mangling embeds
+`24create_action_client_raw` and v0 embeds the same identifier length-prefixed,
+so a host `nm` that cannot demangle Rust degrades to the same verdict rather
+than to silence.
+
+WHY AN ACTION *SERVER* COUNTS TOO, THOUGH THE KNOB IS NAMED FOR CLIENTS
+
+The knob's real meaning is "how many slots are budgeted at the WORST-CASE entry
+size", and `build.rs` picked the action client as that worst case. It is not:
+measured from `target/nros-cpp-generated/nros/nros_cpp_config_generated.h`
+(x86_64, default 1024-byte buffers),
+
+    NROS_CPP_RAW_ACTION_CLIENT_OPAQUE_U64S = 654  ->  5,232 B
+    NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S = 799  ->  6,392 B
+
+against a pub/sub entry budgeted at `3 * rx_buf + 512` = 3,584 B. So an action
+SERVER also needs a slot a pub/sub budget cannot hold, and telling an
+action-server image to set `NROS_EXECUTOR_ACTION_CLIENTS=0` would trade this
+gate's advisory for the exact runtime `BufferTooSmall` it exists to prevent. An
+image linking either entity is therefore "heavy" here.
+
+WHAT IT CANNOT DECIDE, AND SAYS SO
+
+A C or C++ image links `nros-c` / `nros-cpp` with `--whole-archive` (the issue
+0475 shape). The whole staticlib is therefore in the image whether or not the
+app calls any of it, and `NodeHandle::create_action_client_raw` is present as a
+GLOBAL in every C entry — `native_entry` (a talker) and `native_action_client_entry`
+are byte-for-byte indistinguishable on this probe. Such an image is reported
+INDETERMINATE, never OK: presence proves nothing there. It is detected by the
+FFI surface itself (`nros_cpp_action_client_create` / `nros_action_client_init`),
+which is absent from every pure-Rust image measured.
+
+Images built by CMake outside a cargo profile directory (the `examples/
+workspaces/*/build/*/cmake/*` entries) are out of reach for a second, independent
+reason: there is no `nros_node_config.rs` this tool can attribute to them, so the
+knob half of the comparison is missing too. Both halves fail for the same
+population, which is why not covering it costs nothing that was ever available.
+
+Usage::
+
+    check-action-client-arena-budget.py                # the gate
+    check-action-client-arena-budget.py --root DIR ... # extra trees to examine
+    check-action-client-arena-budget.py -v             # every image, not just findings
+
+Exit codes: 0 = agreed (or only advisories), 1 = an image will fail at
+registration, 78 = examined nothing (the lane records a SKIP; see
+`scripts/build/check-skip.sh` — a check that verified nothing must not read as a
+pass).
+"""
+
+import argparse
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Nothing to examine. `lane-skip.sh` already spells "I did no work" as 78
+# (sysexits EX_CONFIG); reusing the number keeps ONE spelling of it rather than
+# inventing a second for the check tier.
+RC_NOTHING_EXAMINED = 78
+
+# The creation paths. Deliberately the whole `create_action_client` /
+# `create_action_server` families (`_raw`, `_sized`, `_with_callbacks`,
+# `_with_callbacks_for_name`, …) rather than one spelling: which arm survives
+# monomorphisation depends on how the app reached it, and they are all the same
+# fact.
+CREATE_CLIENT = re.compile(r"create_action_client")
+CREATE_SERVER = re.compile(r"create_action_server")
+
+# The C/C++ FFI surface. Its PRESENCE means the probe above cannot decide,
+# because these staticlibs are whole-archived.
+FFI_SURFACE = re.compile(r"\bnros_(?:cpp_)?action_client_(?:create|init)\b")
+
+# `pub const NAME: usize = 123;` out of the generated `nros_node_config.rs`.
+CONST = re.compile(r"^\s*pub const ([A-Z0-9_]+):\s*usize\s*=\s*([0-9_]+)\s*;", re.M)
+
+# Directories that can never hold a final image but cost the most to walk.
+# `deps`/`incremental`/`.fingerprint` are cargo's intermediates; the rest are
+# the tree's known-heavy corners.
+PRUNE = {
+    ".git",
+    ".jj",
+    ".fingerprint",
+    "incremental",
+    "deps",
+    "node_modules",
+    ".venv",
+    "__pycache__",
+    "third-party",
+}
+
+# Extensions that are never an IMAGE. Shared objects are excluded on purpose:
+# the arena lives on the stack of whatever task calls spin, and a library has no
+# task.
+NOT_AN_IMAGE = {
+    ".d",
+    ".rlib",
+    ".rmeta",
+    ".o",
+    ".a",
+    ".so",
+    ".dylib",
+    ".json",
+    ".toml",
+    ".txt",
+    ".map",
+    ".lock",
+    ".timestamp",
+}
+
+CONFIG_NAME = "nros_node_config.rs"
+
+
+# --------------------------------------------------------------------------
+# tool resolution — reuse `nros-mem-report.py`'s, do not grow a second spelling
+# --------------------------------------------------------------------------
+
+
+def _mem_report():
+    """Import `scripts/nros-mem-report.py` for its nm resolution.
+
+    Hyphenated filename, so importlib rather than `import`. That script already
+    knows the two things worth knowing about `nm` here — GNU nm refuses a
+    foreign ELF, and rustup ships an llvm-nm that reads them all but is not on
+    PATH — and duplicating either is how a second, worse copy of `pick_nm` gets
+    written. Same importlib move `nros-mem-report.py` itself makes for
+    `gen-pool-inventory.py`.
+    """
+    path = os.path.join(ROOT, "scripts", "nros-mem-report.py")
+    spec = importlib.util.spec_from_file_location("nros_mem_report", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_MEM = None
+
+
+def nm_for(elf):
+    """An `nm` that can read this ELF, or None."""
+    global _MEM
+    if _MEM is None:
+        _MEM = _mem_report()
+    try:
+        return _MEM.pick_nm(elf)
+    except SystemExit:
+        # `pick_nm` exits when no nm can read the file. Here that is a SKIP for
+        # one image, not the end of the gate.
+        return None
+
+
+# --------------------------------------------------------------------------
+# the pure classifier — this is what the selftest exercises
+# --------------------------------------------------------------------------
+
+MATCHED = "matched"
+OVER = "over-budgeted"
+UNDER = "under-budgeted"
+INDETERMINATE = "indeterminate"
+
+
+def classify(action_clients, max_cbs, nm_text):
+    """(verdict, detail) for one image.
+
+    `nm_text` is the demangled symbol dump. `action_clients` is the image's
+    `ARENA_ACTION_CLIENTS`; `max_cbs` its `MAX_CBS`, used only to say whether
+    the knob was CHOSEN or merely defaulted.
+    """
+    if not nm_text.strip():
+        return INDETERMINATE, "no symbol table (stripped?) — nothing to read"
+    if FFI_SURFACE.search(nm_text):
+        return (
+            INDETERMINATE,
+            "links the nros-c/nros-cpp FFI, which is whole-archived: the "
+            "action-client machinery is present whether or not the app uses it",
+        )
+
+    found = []
+    if CREATE_CLIENT.search(nm_text):
+        found.append("action client")
+    if CREATE_SERVER.search(nm_text):
+        found.append("action server")
+
+    if action_clients == 0 and found:
+        return (
+            UNDER,
+            f"NROS_EXECUTOR_ACTION_CLIENTS=0 but the image LINKS "
+            f"{' and '.join(found)} creation — registering it will fail at "
+            f"RUNTIME with NodeError::BufferTooSmall, not at link",
+        )
+    if action_clients > 0 and not found:
+        chosen = "explicitly set" if action_clients != max_cbs else "defaulted"
+        return (
+            OVER,
+            f"{action_clients} of {max_cbs} arena slots budgeted at "
+            f"worst-case (ActionClient) size ({chosen}) but the image links "
+            f"neither an action client nor an action server — that arena is "
+            f"inline on the task stack; set NROS_EXECUTOR_ACTION_CLIENTS=0",
+        )
+    if action_clients == 0:
+        return MATCHED, "no action entity linked, none budgeted"
+    return MATCHED, f"{action_clients} slot(s) budgeted, {' and '.join(found)} linked"
+
+
+def parse_config(text):
+    """The `usize` consts of a generated `nros_node_config.rs`."""
+    return {m.group(1): int(m.group(2).replace("_", "")) for m in CONST.finditer(text)}
+
+
+# --------------------------------------------------------------------------
+# discovery
+# --------------------------------------------------------------------------
+
+
+def is_elf_image(path):
+    """True for an ET_EXEC/ET_DYN ELF. Cheap: 18 bytes, no subprocess."""
+    if os.path.splitext(path)[1] in NOT_AN_IMAGE:
+        return False
+    try:
+        if os.path.islink(path) or not os.path.isfile(path):
+            return False
+        with open(path, "rb") as fh:
+            head = fh.read(18)
+    except OSError:
+        return False
+    if len(head) < 18 or head[:4] != b"\x7fELF":
+        return False
+    little = head[5] == 1
+    e_type = int.from_bytes(head[16:18], "little" if little else "big")
+    return e_type in (2, 3)  # ET_EXEC, ET_DYN
+
+
+def find_image_roots(roots):
+    """{cargo profile dir: [generated config path, …]}.
+
+    The anchor is the generated config, not the binary: a profile dir is the one
+    place where the knob a binary compiled against and the binary itself are
+    both on disk, so attribution is a directory fact rather than a guess.
+    """
+    found = {}
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            base = os.path.basename(dirpath)
+            if base in PRUNE:
+                dirnames[:] = []
+                continue
+            dirnames[:] = [d for d in dirnames if d not in PRUNE]
+            # `<profile>/build/<pkg>-<hash>/out/` — do not descend past `out`,
+            # which for some crates is a whole vendored build tree.
+            if base == "out" and os.path.basename(os.path.dirname(os.path.dirname(dirpath))) == "build":
+                dirnames[:] = []
+                if CONFIG_NAME in filenames:
+                    profile = os.path.dirname(os.path.dirname(os.path.dirname(dirpath)))
+                    found.setdefault(profile, []).append(os.path.join(dirpath, CONFIG_NAME))
+    return found
+
+
+def images_in(profile_dir):
+    """Final artifacts of a cargo profile dir: its own files plus `examples/`."""
+    out = []
+    for sub in ("", "examples"):
+        d = os.path.join(profile_dir, sub) if sub else profile_dir
+        try:
+            names = sorted(os.listdir(d))
+        except OSError:
+            continue
+        for n in names:
+            p = os.path.join(d, n)
+            if is_elf_image(p):
+                out.append(p)
+    return out
+
+
+def knob_of(config_paths):
+    """(action_clients, max_cbs, arena_size) or (None, reason).
+
+    A profile dir accumulates one `build/<pkg>-<hash>/out` per feature set AND
+    keeps stale ones from earlier builds, so this has to be explicit about
+    disagreement rather than picking the first. Configs written before issue
+    0900 W2 have no `ARENA_ACTION_CLIENTS` at all and cannot answer; they are
+    ignored, and if none remain the whole root is skipped.
+    """
+    seen = set()
+    arenas = set()
+    ignored = 0
+    for p in config_paths:
+        try:
+            with open(p, encoding="utf8") as fh:
+                consts = parse_config(fh.read())
+        except OSError:
+            continue
+        if "ARENA_ACTION_CLIENTS" not in consts:
+            ignored += 1
+            continue
+        seen.add((consts["ARENA_ACTION_CLIENTS"], consts.get("MAX_CBS", 0)))
+        arenas.add(consts.get("ARENA_SIZE", 0))
+    if not seen:
+        return None, (
+            f"no generated config declares ARENA_ACTION_CLIENTS "
+            f"({ignored} predate issue 0900 W2)"
+        )
+    if len(seen) > 1:
+        vals = ", ".join(str(k[0]) for k in sorted(seen))
+        return None, f"generated configs disagree on ARENA_ACTION_CLIENTS ({vals})"
+    action_clients, max_cbs = next(iter(seen))
+    # ARENA_SIZE may legitimately VARY inside one profile dir where a leaf sets
+    # `NROS_EXECUTOR_ARENA_SIZE` explicitly (the esp32 fixtures do: 16,384
+    # beside 74,240) while the derivation input is the same. That is not a
+    # disagreement about the KNOB, so it does not block the verdict — it is
+    # reported as a range.
+    arena = "/".join(str(a) for a in sorted(arenas))
+    return (action_clients, max_cbs, arena), None
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+
+def display(path):
+    """Repo-relative when the path is inside the repo, absolute otherwise.
+
+    A blind `relpath` against ROOT turns an `--root` outside the checkout into a
+    ladder of `../..` that nobody can read or paste back.
+    """
+    rel = os.path.relpath(path, ROOT)
+    return path if rel.startswith("..") else rel
+
+
+def symbols(elf):
+    """Demangled `nm` output, or None if no tool can read this file."""
+    tool = nm_for(elf)
+    if not tool:
+        return None
+    run = subprocess.run([tool, "-C", elf], capture_output=True, text=True)
+    if run.returncode != 0:
+        return None
+    return run.stdout
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        help="extra tree to examine (repeatable). Default: the repo and "
+        "$NROS_BUILD_ROOT.",
+    )
+    ap.add_argument("-v", "--verbose", action="store_true",
+                    help="print every image, not only the findings")
+    args = ap.parse_args(argv)
+
+    self_test()
+
+    build_root = os.environ.get("NROS_BUILD_ROOT") or os.path.join(ROOT, "build")
+    roots = [ROOT]
+    if os.path.abspath(build_root) != os.path.abspath(os.path.join(ROOT, "build")):
+        roots.append(build_root)
+    roots.extend(args.root)
+
+    verdicts = {MATCHED: [], OVER: [], UNDER: [], INDETERMINATE: []}
+    skipped_roots = []
+
+    for profile, configs in sorted(find_image_roots(roots).items()):
+        imgs = images_in(profile)
+        if not imgs:
+            continue
+        knob, why = knob_of(configs)
+        if knob is None:
+            skipped_roots.append((profile, why, len(imgs)))
+            continue
+        action_clients, max_cbs, arena = knob
+        for elf in imgs:
+            text = symbols(elf)
+            if text is None:
+                verdicts[INDETERMINATE].append(
+                    (elf, arena, "no `nm` on this host can read this ELF")
+                )
+                continue
+            verdict, detail = classify(action_clients, max_cbs, text)
+            verdicts[verdict].append((elf, arena, detail))
+
+    examined = sum(len(v) for v in verdicts.values())
+    if examined == 0:
+        reasons = ["no built image with an attributable nros_node_config.rs was found"]
+        for profile, why, n in skipped_roots:
+            reasons.append(f"{display(profile)}: {why} ({n} image(s))")
+        print("check-action-client-arena-budget: examined NOTHING.")
+        for r in reasons:
+            print(f"  - {r}")
+        print("  Build something first (e.g. `just build-test-fixtures lane=native`).")
+        return RC_NOTHING_EXAMINED
+
+    def show(name, rows, prefix):
+        for elf, arena, detail in rows:
+            print(f"  {prefix} {display(elf)}\n      ARENA_SIZE={arena} B — {detail}")
+
+    if verdicts[UNDER]:
+        print(
+            f"check-action-client-arena-budget: {len(verdicts[UNDER])} image(s) "
+            f"will fail at REGISTRATION:",
+            file=sys.stderr,
+        )
+        show(UNDER, verdicts[UNDER], "FAIL")
+        print(
+            "\n  The arena budgets 0 slots at ActionClient size and the image "
+            "links one.\n"
+            "  Raise NROS_EXECUTOR_ACTION_CLIENTS (or NROS_EXECUTOR_ARENA_SIZE) "
+            "for these\n  images, or stop linking the action client. Issue 0900."
+        )
+        return 1
+
+    if verdicts[OVER]:
+        print(
+            f"check-action-client-arena-budget: {len(verdicts[OVER])} image(s) "
+            f"carry arena they cannot use (ADVISORY, issue 0900):"
+        )
+        show(OVER, verdicts[OVER], "over ")
+        print(
+            "  Not a failure: the knob defaults to the worst case, so this is "
+            "the shipped\n  state of most images and a red here would carry no "
+            "signal. The saving is\n  stack, not .bss — `just mem-report` cannot "
+            "see it."
+        )
+
+    if args.verbose:
+        show(MATCHED, verdicts[MATCHED], "ok   ")
+        show(INDETERMINATE, verdicts[INDETERMINATE], "?    ")
+
+    for profile, why, n in skipped_roots:
+        print(f"  [not examined] {display(profile)}: {why} ({n} image(s))")
+
+    print(
+        f"check-action-client-arena-budget OK — {examined} image(s): "
+        f"{len(verdicts[MATCHED])} agreed, {len(verdicts[OVER])} over-budgeted, "
+        f"{len(verdicts[INDETERMINATE])} undecidable "
+        f"(C/C++ FFI whole-archive or no symtab)."
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# selftest — runs on the NORMAL path, never behind a flag (phase-395)
+# --------------------------------------------------------------------------
+
+# Symbol dumps in the exact shape `nm -C` produces, lifted from real images so
+# the cases are the measurements rather than a paraphrase of them.
+_TALKER = """\
+0002dd11 t nros_node::executor::arena::action_client_raw_try_process::<1024, 1024, 1024>
+0002d24b t core::ptr::drop_glue::<nros_node::executor::action_core::ActionClientCore<1024, 1024, 1024>>
+0002b037 t <nros_node::executor::action_core::ActionClientCore<1024, 1024, 1024>>::send_goal_raw
+00020b00 T nros_board_native_run_components
+"""
+
+_ACTION_CLIENT = _TALKER + """\
+00001433 t <nros::node::DeclaredNode>::create_action_client_with_callbacks_for_name::<example_interfaces::action::fibonacci::Fibonacci>
+"""
+
+_ACTION_SERVER = _TALKER + """\
+0002ab11 t <nros::node::DeclaredNode>::create_action_server_with_callbacks_for_name::<example_interfaces::action::fibonacci::Fibonacci>
+"""
+
+# The C entry: the FFI surface is whole-archived, so `create_action_client_raw`
+# is present in a TALKER. This is the case that makes presence undecidable.
+_C_ENTRY = _TALKER + """\
+0010b630 T <nros_node::executor::node::NodeHandle>::create_action_client_raw
+000e2ee0 T nros_cpp_action_client_create
+"""
+
+
+def self_test(quiet=True):
+    """Prove both verdicts, every run.
+
+    A negative control nobody runs decays into a comment — and this gate's whole
+    reason for existing is that the OBVIOUS probe (`ActionClientCore`) passes
+    vacuously, so "it printed OK" is worth nothing here without a demonstrated
+    red. `_TALKER` therefore carries the six `ActionClientCore` symbols that a
+    naive probe would have matched: case 5 fails the moment someone widens
+    `CREATE` to the type name.
+    """
+    cases = [
+        # (action_clients, max_cbs, nm text, expected verdict)
+        # The dangerous direction: budgeted for none, links one.
+        (0, 4, _ACTION_CLIENT, UNDER),
+        # The common direction: budgeted for four, links none.
+        (4, 4, _TALKER, OVER),
+        # Agreement, both ways round.
+        (4, 4, _ACTION_CLIENT, MATCHED),
+        (0, 4, _TALKER, MATCHED),
+        # An action SERVER holds a slot a pub/sub budget cannot fit either
+        # (6,392 B measured against 3,584 B), so it counts as heavy. Without
+        # these two cases the gate would advise an action-server image to zero
+        # the knob and cause the very failure it is meant to catch.
+        (0, 4, _ACTION_SERVER, UNDER),
+        (4, 4, _ACTION_SERVER, MATCHED),
+        # A C/C++ image can never be decided on symbols.
+        (0, 4, _C_ENTRY, INDETERMINATE),
+        (4, 4, _C_ENTRY, INDETERMINATE),
+        # A stripped image is a skip, not a pass.
+        (0, 4, "", INDETERMINATE),
+        # An explicitly-chosen-but-still-unused budget is still only advisory.
+        (1, 4, _TALKER, OVER),
+    ]
+    fails = []
+    for i, (ac, cbs, text, want) in enumerate(cases):
+        got = classify(ac, cbs, text)[0]
+        if got != want:
+            fails.append(f"classify case {i}: expected {want}, got {got}")
+
+    # The knob side has its own failure mode: a profile dir with a stale config
+    # beside a current one must not silently pick one.
+    parsed = parse_config(
+        "pub const MAX_CBS: usize = 4;\n"
+        "pub const ARENA_SIZE: usize = 74_240;\n"
+        "pub const ARENA_ACTION_CLIENTS: usize = 4;\n"
+    )
+    if parsed != {"MAX_CBS": 4, "ARENA_SIZE": 74240, "ARENA_ACTION_CLIENTS": 4}:
+        fails.append(f"parse_config: got {parsed}")
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        cur = os.path.join(d, "cur.rs")
+        old = os.path.join(d, "old.rs")
+        other = os.path.join(d, "other.rs")
+        with open(cur, "w", encoding="utf8") as fh:
+            fh.write("pub const MAX_CBS: usize = 4;\npub const ARENA_ACTION_CLIENTS: usize = 4;\n")
+        with open(old, "w", encoding="utf8") as fh:
+            fh.write("pub const MAX_CBS: usize = 4;\n")  # predates the knob
+        with open(other, "w", encoding="utf8") as fh:
+            fh.write("pub const MAX_CBS: usize = 4;\npub const ARENA_ACTION_CLIENTS: usize = 0;\n")
+        if knob_of([cur, old])[0] != (4, 4, "0"):
+            fails.append("knob_of: a pre-0900 config must be ignored, not fatal")
+        if knob_of([old])[0] is not None:
+            fails.append("knob_of: only pre-0900 configs must yield no answer")
+        if knob_of([cur, other])[0] is not None:
+            fails.append("knob_of: disagreeing configs must yield no answer")
+
+        # `is_elf_image` gates every walk result; a wrong answer here silently
+        # shrinks the population the gate examines.
+        elf = os.path.join(d, "exe")
+        with open(elf, "wb") as fh:
+            fh.write(b"\x7fELF\x02\x01\x01" + b"\0" * 9 + (2).to_bytes(2, "little"))
+        obj = os.path.join(d, "obj")
+        with open(obj, "wb") as fh:
+            fh.write(b"\x7fELF\x02\x01\x01" + b"\0" * 9 + (1).to_bytes(2, "little"))
+        text_file = os.path.join(d, "notelf")
+        with open(text_file, "w", encoding="utf8") as fh:
+            fh.write("hello")
+        if not is_elf_image(elf):
+            fails.append("is_elf_image: ET_EXEC must count")
+        if is_elf_image(obj):
+            fails.append("is_elf_image: ET_REL (an object file) must not count")
+        if is_elf_image(text_file):
+            fails.append("is_elf_image: a non-ELF must not count")
+
+    if fails:
+        for f in fails:
+            print(f"check-action-client-arena-budget self-test: FAIL {f}", file=sys.stderr)
+        raise SystemExit(1)
+    if not quiet:
+        print("check-action-client-arena-budget self-test: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv or "--selftest" in sys.argv:
+        sys.exit(self_test(quiet=False))
+    sys.exit(main())


### PR DESCRIPTION
Investigating 0900 to implement it, and finding it cannot be implemented as written. Docs-only.

## Where 0900 actually stands

**The mechanism already landed.** `nros-node/build.rs` takes `NROS_EXECUTOR_ACTION_CLIENTS` — default `max_cbs`, so the old formula reproduces byte-for-byte and no image moves — and budgets the two entry *shapes* separately instead of charging every slot the larger one. It is plumbed through `zephyr/Kconfig`, `platform_config.rs`, the generated config surface, and the runtime advisory names it by name when an arena is too small.

Setting it to 0 takes **74,240 → 16,384 bytes**. That is the whole ~56.5 KiB every pub/sub-only image currently carries.

## Why nothing sets it

`source_metadata.rs` — the structure a model is built from — contains **zero** occurrences of "client":

```
SourcePublisher   SourceSubscriber   SourceTimer
SourceService   (a `callback` — the SERVER side)
SourceAction    (goal/cancel/accepted — the SERVER side)
```

nano-ros declares the entities needing **codegen registration**. A client (`ActionClientCore::new`, a service client) is constructed imperatively in user code and is invisible to the build.

So `entity-facts` cannot report the count, and the derivation 0900 proposes is **not expressible** — not merely unwired. Left as-is, the issue keeps reading as actionable while nobody can act on it.

## Three options, recorded with their trades

1. **Declare client-side entities** — buys the derivation, costs a schema change, a resolver change, a migration for every model, and asks users to declare what they currently just construct.
2. **Flip the default to 0** — 56.5 KiB off every pub/sub image, and every action-client image breaks at *registration* rather than at link. A runtime failure for a compile-time fact.
3. **Derive from the LINKER, not the model** — an image that never references `ActionClientCore::new` cannot have one. Post-link, so it cannot size a compile-time constant, but it can **gate** an image whose knob exceeds its linked reality.

(3) keeps the knob manual while stopping it being a guess, needs no schema change, and is the only one `nm` can verify — which matters because the arena is **inline on the task stack**, so `just mem-report` cannot see it at all. A symbol probe can't measure the arena, but it can see whether the entity justifying its size was linked in.

Not acted on: this is a design decision, not an implementation detail.

`just check fast`: 149 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa