### PR TITLE
docs(#0971): take_sequence cannot say why a drain stopped, and its two implementations disagree

### DIFF
--- a/docs/issues/0971-take-sequence-cannot-say-why-it-stopped.md
+++ b/docs/issues/0971-take-sequence-cannot-say-why-it-stopped.md
@@ -1,10 +1,10 @@
 ---
 id: 971
-title: "`take_sequence` cannot say why a drain stopped, its two implementations disagree about it, and the message that stopped it is consumed and lost"
+title: "`take_sequence` cannot say why a drain stopped, and its two implementations disagree about it"
 status: open
 area: [rmw, api]
 severity: high
-related: [0969, 0773, phase-124, phase-376]
+related: [0969, 0773, phase-124, phase-376, phase-384]
 ---
 
 # A partial drain and an empty reader are the same answer
@@ -105,9 +105,10 @@ Note that the dead branch was ALSO the wrong fix: returning
 `BUFFER_TOO_SMALL` from a partial drain is what the contract forbids. Making it
 reachable would have traded a silent drop for a contract violation.
 
-## The same root, one level down
+## What `subscription_take` (single) does is CORRECT — a correction to this issue
 
-`subscription_take` (single) has the same consume-then-refuse ordering:
+This section originally claimed the single take had "the same root, one level
+down", on the grounds that it too destroys the message:
 
 ```cpp
 const uint32_t total = ddsi_serdata_size(d);
@@ -117,45 +118,88 @@ if (buf_len < total) {
 }
 ```
 
-The caller at least gets a distinct status here, so this is materially better
-than the sequence path — but the message is equally gone, and a caller that
-enlarges its buffer and retries receives the *next* message, not the one it was
-told about. Also pre-existing: the pre-0969 body freed its typed sample and
-returned the same status. Worth fixing with the same change rather than
-separately, because the ordering problem is identical: **the size is only
-knowable after the take consumes the sample.**
+That was wrong, and the tree says so twice.
 
-## Why this is not a one-line fix
+**Live zenoh does the identical thing, deliberately**
+(`packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:1019`):
 
-Every obvious option loses something:
+```rust
+// Oversized for the caller's buffer — drop the slot so the
+// subscription isn't permanently stuck.
+buffer.consume_head();
+return Err(TransportError::BufferTooSmall);
+```
+
+**And it is formally verified.** `nros-verification/src/e2e.rs`'s
+`try_recv_post_fix` models the take path after the 31.6 fix, and its listed
+difference from the pre-fix version is exactly this:
+
+> 2. On `BufferTooSmall` (stored_len > rx_buf_len) → clears `has_data`
+>    (**FIXED: no longer stuck**)
+
+with proof `no_silent_truncation` establishing that the consumer "**never**
+receives truncated data" — it gets the complete message or an explicit error.
+
+So the invariant is **no stuck subscription and no silent truncation**, not
+"the message survives". Consume-then-refuse is the design, Cyclone's single take
+already implements it, and it needs no change. The defect in this issue is
+narrower than first written: it is the SEQUENCE path only, and only because that
+is the one place the explicit error has nowhere to go.
+
+## The fix
+
+Where the error cannot be returned inline, carry it to the next call. That is
+the same shape `try_recv_post_fix` already has — check a flag first, clear it,
+return the error, take nothing — applied one call later.
+
+**Cyclone.** `SubState` gains `pending_too_small`:
+
+* `subscription_take_sequence_count`, at the top: flag set → clear it, return
+  the negated `BUFFER_TOO_SMALL`, take nothing.
+* in the loop, on an oversized sample: set the flag, `break`, return the count.
+  Partial drains still use the count form, as the contract requires.
+* `subscription_take`, at the top: the same check, so a caller that mixes the
+  two entry points still hears about it. Its own oversize path keeps returning
+  the status inline, because it can.
+
+**Runtime fallback.** `CffiSubscriber` gains `pending: Option<TransportError>`:
+
+* loop hits `BufferTooSmall` with `count > 0` → stash it, return `Ok(count)`.
+* with `count == 0` → return the error directly, as it does now.
+* at the top, `pending.take()` → return it.
+
+Both paths then emit the identical *sequence* of answers, which is what makes
+`rmw_vtable.h`'s "identical observable behaviour" claim true rather than
+something to delete. No signature change, so no `abi_version` bump.
+
+The error arrives one call late. That is the price of a contract that forbids
+erroring out of a partial drain, and it is strictly better than never.
+
+## Rejected, and why
 
 1. **Return negated `BUFFER_TOO_SMALL` from the batch.** Contract-forbidden, and
    worse in practice — the caller loses the count for messages that were
    delivered fine.
 2. **Skip the oversized sample and keep draining.** Delivers more, still
-   destroys the message silently. Trades one silent loss for a quieter one.
-3. **Report the count AND an overflow signal.** Correct, and needs a signature
-   change: an out-parameter, or a documented convention that `out_lens[count]`
-   carries the length that did not fit. The ABI slot is already
-   `(…, size_t *out_lens, size_t *taken)` returning `rmw_ret_t`, so there is
-   room for a third out-parameter, at the cost of an `abi_version` bump.
-4. **Size before consuming.** `dds_readcdr` peeks without removing, so the
-   backend could size the head sample, refuse it while leaving it in the cache,
-   and let a caller with a bigger buffer actually retry. Two passes per sample
-   on the batch path, and only Cyclone can do it — the fallback cannot peek
-   through `try_recv_raw`.
-
-(3) and (4) are complementary rather than alternative: (3) tells the caller what
-happened, (4) makes the message survivable. Both change the contract, which is
-why this is filed rather than fixed.
+   destroys the message with no signal. Violates `no_silent_truncation`.
+3. **An overflow out-parameter plus an `abi_version` bump.** Works, and is
+   unnecessary: the pending flag carries the same fact with no ABI change.
+4. **`dds_readcdr` to size before consuming, leaving the sample in the cache so
+   a caller with a bigger buffer can retry.** This was offered here as the
+   option that "makes the message survivable". It is the bug that was already
+   fixed: a sample left in the cache that no caller can ever take is precisely
+   the stuck subscription `try_recv_post_fix` exists to rule out, and a caller
+   whose buffer is sized from the type bound will not come back with a bigger
+   one anyway.
 
 ## What a fix must satisfy
 
 * A caller can distinguish "reader drained" from "a message did not fit", on
   BOTH the native and the fallback path, with the same answer.
-* Whatever the doc claims about the fallback being observationally identical is
-  either made true or deleted.
+* The doc's claim that the fallback is observationally identical is made true.
 * Messages already written are never lost to the reporting of a later failure.
+* No subscription is left stuck, and nothing is truncated silently — the
+  invariants `no_silent_truncation` already fixes in place.
 * The behaviour is stated where the slot is declared, not inferred from two
   implementations that currently disagree.
 

--- a/docs/issues/0971-take-sequence-cannot-say-why-it-stopped.md
+++ b/docs/issues/0971-take-sequence-cannot-say-why-it-stopped.md
@@ -1,0 +1,172 @@
+---
+id: 971
+title: "`take_sequence` cannot say why a drain stopped, its two implementations disagree about it, and the message that stopped it is consumed and lost"
+status: open
+area: [rmw, api]
+severity: high
+related: [0969, 0773, phase-124, phase-376]
+---
+
+# A partial drain and an empty reader are the same answer
+
+## The contract
+
+`rmw_vtable.h:681` and the batch-take note above it:
+
+> Returns:
+>   * `>= 0` — count of messages taken (0..=max_msgs).
+>   * `< 0` — `rmw_ret_t` error code; **partial drains MUST use the count
+>     form, not error-out**.
+>
+> […] `*taken` is written only on `NROS_RMW_RET_OK`; **a partial drain reports
+> what it got rather than erroring**.
+
+And, of the runtime's loop fallback for backends with no native batch:
+
+> The fallback gives **identical observable behaviour** (each call still costs N
+> vtable hops) but lets user code commit to the batched API.
+
+Three claims. The first two are honoured. The third is not, and the first two
+are not enough.
+
+## What actually happens on an oversized message
+
+`subscription_take_sequence_count`
+(`packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/subscriber.cpp`):
+
+```cpp
+const uint32_t total = ddsi_serdata_size(ds[i]);
+if (per_msg_cap < total) {
+    break;
+}
+```
+
+then, at the bottom, every serdata taken this call is unref'd and `produced` is
+returned as a count. So:
+
+* the batch ends,
+* the samples already written are reported,
+* **and the oversized message is gone.** `dds_takecdr` removed it from the
+  reader cache before its size could be known, and the unref is the last
+  reference. It is not deferred to the next call; there is no next chance.
+
+The caller receives a number, and that number is the same shape it receives when
+the reader is simply empty. It cannot distinguish "you have everything" from "a
+message was too big for your slots and has been destroyed".
+
+## And the fallback answers differently
+
+`CffiSubscriber::try_recv_sequence`'s loop (`packages/rmw/cffi/src/lib.rs`):
+
+```rust
+match self.try_recv_raw(slot)? {
+    Some(len) => { out_lens[i] = len; count += 1; }
+    None => break,
+}
+```
+
+`try_recv_raw` returns `BUFFER_TOO_SMALL` for the same message, and `?`
+propagates it. The fallback therefore returns `Err(TransportError::BufferTooSmall)`
+where the native path returns `Ok(partial_count)`.
+
+The messages already written into `buf` are still there in both cases, but the
+fallback discards the count on its way out, so a caller has no way to know how
+many slots are valid. Same input, two different answers, on precisely the
+condition the doc says is indistinguishable. A consumer that develops against
+zenoh-pico (fallback) and deploys on Cyclone (native) changes behaviour without
+changing a line.
+
+## The error branch that was already dead
+
+This is not a regression from **#0969**, and
+the shape predates it. The pre-0969 body read:
+
+```cpp
+if (per_msg_cap < total) {
+    dds_ostream_fini(&os);
+    err = NROS_RMW_RET_BUFFER_TOO_SMALL;
+    break;
+}
+...
+if (err < 0) {
+    return err;
+}
+```
+
+`err < 0` is never true. Every `nros_rmw_ret_t` is non-negative (`rmw_ret.h`),
+which is exactly why this function's other returns negate
+(`-static_cast<int32_t>(...)`, issue 0773). So the error was unreachable from
+the day it was written, and every caller has only ever seen the partial count.
+#0969 rewrote the body onto `dds_takecdr` and kept the behaviour deliberately,
+with a comment saying so, rather than change semantics inside a data-path
+rewrite. This issue is that comment's promised follow-up.
+
+Note that the dead branch was ALSO the wrong fix: returning
+`BUFFER_TOO_SMALL` from a partial drain is what the contract forbids. Making it
+reachable would have traded a silent drop for a contract violation.
+
+## The same root, one level down
+
+`subscription_take` (single) has the same consume-then-refuse ordering:
+
+```cpp
+const uint32_t total = ddsi_serdata_size(d);
+if (buf_len < total) {
+    ddsi_serdata_unref(d);
+    return NROS_RMW_RET_BUFFER_TOO_SMALL;
+}
+```
+
+The caller at least gets a distinct status here, so this is materially better
+than the sequence path — but the message is equally gone, and a caller that
+enlarges its buffer and retries receives the *next* message, not the one it was
+told about. Also pre-existing: the pre-0969 body freed its typed sample and
+returned the same status. Worth fixing with the same change rather than
+separately, because the ordering problem is identical: **the size is only
+knowable after the take consumes the sample.**
+
+## Why this is not a one-line fix
+
+Every obvious option loses something:
+
+1. **Return negated `BUFFER_TOO_SMALL` from the batch.** Contract-forbidden, and
+   worse in practice — the caller loses the count for messages that were
+   delivered fine.
+2. **Skip the oversized sample and keep draining.** Delivers more, still
+   destroys the message silently. Trades one silent loss for a quieter one.
+3. **Report the count AND an overflow signal.** Correct, and needs a signature
+   change: an out-parameter, or a documented convention that `out_lens[count]`
+   carries the length that did not fit. The ABI slot is already
+   `(…, size_t *out_lens, size_t *taken)` returning `rmw_ret_t`, so there is
+   room for a third out-parameter, at the cost of an `abi_version` bump.
+4. **Size before consuming.** `dds_readcdr` peeks without removing, so the
+   backend could size the head sample, refuse it while leaving it in the cache,
+   and let a caller with a bigger buffer actually retry. Two passes per sample
+   on the batch path, and only Cyclone can do it — the fallback cannot peek
+   through `try_recv_raw`.
+
+(3) and (4) are complementary rather than alternative: (3) tells the caller what
+happened, (4) makes the message survivable. Both change the contract, which is
+why this is filed rather than fixed.
+
+## What a fix must satisfy
+
+* A caller can distinguish "reader drained" from "a message did not fit", on
+  BOTH the native and the fallback path, with the same answer.
+* Whatever the doc claims about the fallback being observationally identical is
+  either made true or deleted.
+* Messages already written are never lost to the reporting of a later failure.
+* The behaviour is stated where the slot is declared, not inferred from two
+  implementations that currently disagree.
+
+## Not to be confused with
+
+**#0969** (`0969-cyclone-take-cdr-round-trip.md`, filed in PR #154 — not linked
+here because it has not landed on `main` yet, and `check-doc-refs` is right to
+say so) — the CDR round trip on the take
+path. It touched this function, kept this behaviour unchanged on purpose, and
+named this issue as the place the question belongs.
+
+[#0964](0964-two-different-sizes-for-the-same-type.md) — how big a receive
+buffer should be. That is about picking `per_msg_cap`; this is about what
+happens when the pick is wrong.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -79,5 +79,7 @@ fails if this block drifts.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, its two implementations disagree about it, and the message that stopped it is consumed and lost See `0971-*`.
+- **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it See `0971-*`.
+- **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -76,10 +76,8 @@ fails if this block drifts.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
 - **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a decode, an encode and two heap allocations per take See `0969-*`.
 - **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
-- **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
-- **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
-- **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, its two implementations disagree about it, and the message that stopped it is consumed and lost See `0971-*`.
 - **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it See `0971-*`.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
+- **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -78,5 +78,6 @@ fails if this block drifts.
 - **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
+- **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, its two implementations disagree about it, and the message that stopped it is consumed and lost See `0971-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
The follow-up #0969 promised. Docs only, one issue.

## The claim in the header

`rmw_vtable.h:681` says three things about the batch-take slot:

1. `>= 0` is a count; `< 0` is an error — **partial drains MUST use the count form, not error-out**.
2. `*taken` is written only on `OK`; **a partial drain reports what it got rather than erroring**.
3. The loop fallback for backends with no native batch gives **identical observable behaviour**.

The first two hold. The third does not, and the first two turn out not to be enough.

## What happens when a message does not fit

`subscription_take_sequence_count` breaks out of the batch and returns `produced` as a count — the same shape a caller gets from an empty reader. It cannot tell "you have everything" from "a message was too big for your slots".

And the message is **gone**. `dds_takecdr` removed it from the reader cache before its size could be known, and the unref at the bottom is the last reference. No next chance at it.

## The two paths disagree

`CffiSubscriber::try_recv_sequence`'s fallback drives `try_recv_raw` with `?`, so `BUFFER_TOO_SMALL` propagates:

```rust
match self.try_recv_raw(slot)? {
    Some(len) => { out_lens[i] = len; count += 1; }
    None => break,
}
```

Native returns `Ok(partial_count)`. Fallback returns `Err(BufferTooSmall)` and discards the count, so the caller cannot tell how many of the slots it can already see are valid. Same input, two answers, on exactly the condition the doc calls indistinguishable. A consumer written against zenoh-pico and deployed on Cyclone changes behaviour without changing a line.

## The dead branch, and why it was also the wrong fix

Pre-existing, not a #0969 regression. The old body assigned `err = NROS_RMW_RET_BUFFER_TOO_SMALL` then tested `if (err < 0)` — never true, because every `nros_rmw_ret_t` is non-negative, which is precisely why this function's other returns negate (issue 0773). Dead from the day it was written.

Worth stating plainly: making it reachable would not have been a fix. Erroring out of a partial drain is what claim (1) forbids, so that trade is a silent drop for a contract violation. #0969 kept the behaviour deliberately, with a comment, rather than change semantics inside a data-path rewrite.

## One level down

`subscription_take` (single) has the same consume-then-refuse ordering. It returns a distinct status, which is better — but the message is equally gone, and a caller that enlarges its buffer and retries gets the *next* one. Same root: **the size is only knowable after the take consumes the sample.**

## Four options, what each loses

| | |
|---|---|
| error out of the batch | contract-forbidden, and loses the count for messages that were fine |
| skip and keep draining | delivers more, still destroys the message silently |
| count **and** an overflow signal | correct; needs a signature change and an `abi_version` bump |
| `dds_readcdr` to size before consuming | makes the message survivable; two passes, and the fallback cannot peek |

The last two are complementary rather than alternative — one tells the caller what happened, the other makes the message recoverable. Both change the contract, which is why this is filed rather than fixed.

## Testing

Docs only. `just check` — 2 of 156 gates fail (`kconfig-overridden-values`, `fixtures-manifest`), the same two that fail on a clean tree: `nros: command not found`, no `setup-cli` in a fresh worktree.

`check-doc-refs` initially failed on this file and was right to: it linked `0969-*.md`, which lives in #154 and has not landed on `main`. The reference is now plain text naming the PR, and gets a link when #154 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
