### PR TITLE
fix(zephyr): honour attr->name, so nano-ros threads are not anonymous

### DIFF
--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -487,7 +487,7 @@ static int nros_zephyr_native_priority(int32_t priority) {
 }
 
 int nros_zephyr_task_create_prio(pthread_t *thread, void *(*entry)(void *), void *arg,
-                                 int native_priority);
+                                 int native_priority, const char *name);
 
 int8_t nros_platform_task_init(void *task, void *attr,
                                void *(*entry)(void *), void *arg) {
@@ -518,7 +518,24 @@ int8_t nros_platform_task_init(void *task, void *attr,
     int native = nros_zephyr_native_priority(a != NULL ? a->priority
                                                        : NROS_PLATFORM_PRIORITY_INHERIT);
 
-    return nros_zephyr_task_create_prio((pthread_t *) task, entry, arg, native) == 0
+    /* `name` IS honoured, for the same reason `priority` above is.
+     *
+     * This is issue 0852 one field over. The ABI defines `name` as "Task name
+     * for the kernel's own tables and crash dumps", every caller already
+     * supplies one -- `PlatformTask::spawn_with` fills `attr.name`, and the
+     * C++ tier spawn builds "nros-tier-<tier>" for it -- and the FreeRTOS port
+     * passes it straight to `xTaskCreate`. Only this port dropped it, and
+     * Zephyr is not a kernel with no name concept: CONFIG_THREAD_NAME and
+     * `k_thread_name_set` have been there all along.
+     *
+     * The cost was paid in diagnosis, not in behaviour. In a CTF capture from
+     * an FVP the nano-ros threads appear as `unknown (0x00281cc0)` and can
+     * only be told apart by stack base -- one of them holding 13.7% of the
+     * core with nothing to say what it was -- while the identical code on
+     * FreeRTOS traces as `nros_app` and `nros_tier@1`. */
+    const char *name = (a != NULL) ? a->name : NULL;
+
+    return nros_zephyr_task_create_prio((pthread_t *) task, entry, arg, native, name) == 0
                ? NROS_PLATFORM_RET_OK
                : NROS_PLATFORM_RET_NOMEM;
 }
@@ -862,7 +879,12 @@ static void nros_z_task_trampoline(void *p1, void *p2, void *p3) {
 
 int8_t nros_platform_task_init(void *task, void *attr,
                                void *(*entry)(void *), void *arg) {
-    (void) attr;
+    /* Only `name` is read here. `priority` and `stack_bytes` remain unhandled
+     * on this path -- it hardcodes K_PRIO_PREEMPT(5) and
+     * NROS_ZEPHYR_TASK_STACK_SIZE -- which is a separate gap and is left
+     * alone rather than half-fixed. This path is the non-CONFIG_POSIX_API
+     * build and is not the one CI exercises. */
+    const nros_platform_task_attr_t *a = (const nros_platform_task_attr_t *) attr;
     if (task == NULL || entry == NULL) return -1;
     struct nros_z_task *t = nros_platform_alloc(sizeof(struct nros_z_task));
     if (t == NULL) return -1;
@@ -876,6 +898,11 @@ int8_t nros_platform_task_init(void *task, void *attr,
     k_thread_create(&t->thread, t->stack, NROS_ZEPHYR_TASK_STACK_SIZE,
                     nros_z_task_trampoline, t, NULL, NULL,
                     K_PRIO_PREEMPT(5), 0, K_NO_WAIT);
+    /* Best-effort, as on the POSIX path: an unnamed thread is what this did
+     * before, so a refusal must not fail the spawn. */
+    if (a != NULL && a->name != NULL) {
+        (void) k_thread_name_set(&t->thread, a->name);
+    }
     NROS_Z_HANDLE(task) = t;
     return 0;
 }

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -496,7 +496,7 @@ void nros_zephyr_task_slot_release(pthread_t owner) {
  * its comment says a quietly-dropped scheduling attribute "must not be
  * reintroduced one layer down". It was, here. */
 int nros_zephyr_task_create_prio(pthread_t* thread, void* (*entry)(void*), void* arg,
-                                 int native_priority) {
+                                 int native_priority, const char* name) {
     int slot = nros_claim_thread_slot();
     if (slot < 0) {
         /* Say so. This used to return -1 silently, and the caller that loses
@@ -544,6 +544,19 @@ int nros_zephyr_task_create_prio(pthread_t* thread, void* (*entry)(void*), void*
         nros_free_thread_slot(slot);
         return ret;
     }
+
+    /* The name the caller asked for, applied to the kernel's own thread table.
+     *
+     * Best-effort for the same reason the priority above is: a kernel that
+     * declines the name leaves the thread anonymous, which is exactly what it
+     * was before this existed. A refusal must not turn into a spawn failure.
+     *
+     * `pthread_setname_np` self-gates on CONFIG_THREAD_NAME and returns 0 when
+     * it is off, so there is no caller-side #ifdef to keep in step. */
+    if (name != NULL) {
+        (void)pthread_setname_np(*thread, name);
+    }
+
     nros_set_thread_slot_owner(slot, *thread);
     return 0;
 }
@@ -551,7 +564,7 @@ int nros_zephyr_task_create_prio(pthread_t* thread, void* (*entry)(void*), void*
 /* The pre-issue-0852 spelling. Kept so callers that have no priority to state
  * do not have to invent one; "inherit" is what they always got. */
 int nros_zephyr_task_create(pthread_t* thread, void* (*entry)(void*), void* arg) {
-    return nros_zephyr_task_create_prio(thread, entry, arg, -1);
+    return nros_zephyr_task_create_prio(thread, entry, arg, -1, NULL);
 }
 
 #endif /* CONFIG_POSIX_API || CONFIG_PTHREAD */


### PR DESCRIPTION
## Problem

The Zephyr port accepts `nros_platform_task_attr_t` and reads `priority` from it, then drops `name` on the floor.

Every layer above already supplies one:

- `PlatformTask::spawn_with` fills `attr.name`
- the C++ tier spawn builds `"nros-tier-<tier>"` for it (`packages/api/nros-cpp/src/lib.rs`)
- the FreeRTOS port passes it straight to `xTaskCreate`

The ABI says a port may ignore the field when "its kernel has no name concept". Zephyr has one: `CONFIG_THREAD_NAME` and `k_thread_name_set` have been available all along.

This is issue 0852 one field over. The shim's own comment on that fix reads:

> a quietly-dropped scheduling attribute "must not be reintroduced one layer down". It was, here.

It was again, for `name`.

## Why it matters

Nothing misbehaves. The cost is paid in diagnosis.

In a CTF capture from an FVP BaseR AEMv8-R, every nano-ros thread appears as `unknown (0x00281cc0)` and can only be told apart by stack base. One of them holds 13.7 percent of the core with nothing to say what it is. Occupancy from that same capture:

```
task                       occupancy
main (0x00286d80)             68.05%
unknown (0x00281cc0)          14.18%
rx_q[0] (0x00285110)          13.10%
sysworkq (0x00287180)          3.35%
unknown (0x00280fa0)           1.05%
```

Two of the top five rows are unidentifiable. The identical application on FreeRTOS traces as `nros_app`, `nros_tier@1`, `nros_tier@2`, `zpico_read`, because that port keeps the name.

## Changes

`nros_zephyr_task_create_prio` takes a `name` and applies it with `pthread_setname_np` after a successful create.

Best effort, for the same reason the priority above it is: a kernel that declines the name leaves the thread anonymous, which is exactly what it was before this existed, and a refusal must not turn into a spawn failure. `pthread_setname_np` self-gates on `CONFIG_THREAD_NAME` and returns 0 when it is off, so there is no caller-side `#ifdef` to keep in step.

`nros_zephyr_task_create`, the pre-0852 spelling, passes `NULL`. Its callers are unchanged.

The non-`CONFIG_POSIX_API` path reads `attr->name` and calls `k_thread_name_set`. `priority` and `stack_bytes` stay unhandled there, since that path hardcodes `K_PRIO_PREEMPT(5)` and `NROS_ZEPHYR_TASK_STACK_SIZE`. That is a separate gap, left alone rather than half fixed.

## Verification

Both files compile clean for `fvp_baser_aemv8r` using the project's own recorded compile commands, and `nm` on the resulting object shows

```
U pthread_setname_np
```

so the call is real rather than implicitly declared.

A full image build against this branch was **not** completed. Reconfiguring against current `main` fails first in the heap-size guard (`NROS_ZEPHYR_HEAP_SIZE` 65536 against a required 483328) and then in `nros-cli-core/src/lib.rs:85` during `nros_generate_interfaces`. Both reproduce without this change, so they are unrelated to it, but it means the runtime effect has not been observed end to end yet.

## Scope

There are two ways a Zephyr thread gets created here, and only one of them was losing the name.

- `nros_zephyr_tier_task_create` (`packages/boards/nros-board-zephyr`) already calls `k_thread_name_set`. Tiers spawned through that pinned static-pool path have always been named, and this PR does not touch it.
- `nros_platform_task_init` is the generic path: the zenoh read and lease tasks, the executor workers, and the C++ tier spawn, which reaches it through `PlatformTask::spawn_with`. That path dropped the name, and that is what this changes.

In the capture above no tier threads exist at all (the tier stack pool is unused and the control work runs on `main`), so every nano-ros thread visible there came through the generic path.
