### PR TITLE
docs(#0820, #0972): the sibling seams, swept — the missing edge really was one-of-a-kind

### DIFF
--- a/docs/issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md
+++ b/docs/issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md
@@ -177,13 +177,49 @@ So this seam had been building every NuttX C example in the configuration the
 tree documents as broken, while `nros profile carve-out nuttx-rust` — which
 exists to prevent exactly that — sat unused.
 
-### Still open
+### The sibling seams, swept (2026-09-01) — this one IS one-of-a-kind
 
-The sibling seams. `FREERTOS_QEMU_PROFILE` is also `MINSIZEREL` (a QEMU timing
-floor rather than a miscompile, but the same "must be built at" shape), and the
-freertos / threadx / esp-idf paths are the same custom-command construction. A
-missing edge is rarely one-of-a-kind and neither is a hardcoded `--release`;
-neither has been checked.
+The open item assumed "freertos / threadx / esp-idf are the same custom-command
+construction". They are not, and that is the answer rather than a reprieve.
+
+**The missing edge.** Every tracked cmake file that contains both
+`add_custom_command` and `cargo`:
+
+    cmake/NanoRosCodegenCore.cmake                      codegen tool
+    cmake/NanoRosCorrosion.cmake                        corrosion's own targets
+    cmake/NanoRosGenerateInterfaces.cmake               codegen
+    cmake/NanoRosNodeRegister.cmake                     codegen
+    packages/api/nros-c/CMakeLists.txt                  config-header mirror
+    packages/api/nros-cpp/CMakeLists.txt                config-header mirror
+    .../NrosRmwCycloneddsTypeSupport.cmake              codegen
+    zephyr/cmake/nros_generate_interfaces.cmake         codegen
+    packages/api/nros-c/cmake/nros-nuttx.cmake          DEPFILE x3   <- the seam
+
+`nros-freertos.cmake` and `nros-threadx.cmake` contain no `cargo` reference at
+all; they reach Rust through corrosion, which creates real targets with real
+file-level edges. So NuttX is the only place a custom command drives a cargo
+build of nano-ros Rust, which is exactly why it was the only place the edge went
+missing — the construction, not the platform, is what carries the hazard.
+
+**The hardcoded profile.** `just freertos` does NOT hardcode: it passes the
+`freertos-qemu` carve-out through `NROS_CARGO_PROFILE`, with the reason written
+at the call site (`just/freertos.just:115`). The remaining `--release` literals
+are `NanoRosCodegenCore.cmake:427` (a HOST codegen tool, no carve-out applies)
+and `integrations/px4/NanoRosPx4Module.cmake` (no px4 carve-out is declared, so
+nothing contradicts it).
+
+**One real remnant, fixed here:** this file's own docstring still said
+"Schedules a `cargo build --release`" — the very text the fix below replaced in
+the code. A comment contradicting the code it documents is how the next reader
+re-derives the wrong thing, and it is the same shape as the NuttX settle-delay
+contradiction recorded further up this issue.
+
+So the class is closed by measurement rather than by fixing more sites: there
+were no more sites. What would keep it closed is a gate asserting that a cargo
+build driven by a custom command carries a `DEPFILE` — not written, because with
+exactly one instance it would be a rule inferred from a single example, and the
+codegen commands legitimately have no depfile, so the predicate would be
+guesswork.
 
 ### A note on method, because it cost most of the investigation
 
@@ -321,7 +357,8 @@ Everything that was built on that claim was wrong with it: a "domain mismatch
 root cause", a comparison to issue 0801, and a suspected sentinel defect at
 `packages/api/nros-c/src/node.rs` (`if support_domain != 0`, where 0 is both a
 legal ROS domain and the unset marker). That sentinel ambiguity IS real code and
-may deserve its own issue, but it is NOT what broke this test — the native C
+now has its own issue — [[issue-0972]], filed 2026-09-01, still live at
+`node.rs:739` — but it is NOT what broke this test — the native C
 talker, same source, resolves to domain 0 with no split, and the instrumented
 riscv image now does too.
 

--- a/docs/issues/0972-domain-zero-is-both-a-value-and-the-unset-marker.md
+++ b/docs/issues/0972-domain-zero-is-both-a-value-and-the-unset-marker.md
@@ -1,0 +1,79 @@
+---
+id: 972
+title: "ROS domain 0 is both a legal domain and the `unset` marker, so asking for domain 0 explicitly is silently overridden"
+status: open
+type: bug
+area: api-c, rmw
+related: [issue-0820, issue-0801, issue-0161]
+---
+
+## The code
+
+`packages/api/nros-c/src/node.rs:739`:
+
+```rust
+let support_domain = support_mut.domain_id as u32;
+let session = support_mut.get_session_mut()?;
+let domain_id = if support_domain != 0 {
+    support_domain
+} else {
+    session.domain_id()
+};
+```
+
+The comment directly above states the ambiguity without resolving it:
+*"`support.domain_id` is resolved from the C ABI argument, where 0 means
+'unset' and resolves to 0"*.
+
+## Why it is a defect and not a convention
+
+`0` is **the default ROS domain** — the one a user gets by not setting
+`ROS_DOMAIN_ID` at all, and therefore the most commonly intended value. So the
+branch reads:
+
+| caller meant | `support_domain` | what happens |
+| --- | --- | --- |
+| "I did not specify" | 0 | falls back to the session's domain — correct |
+| "I want domain 0" | 0 | **falls back to the session's domain — wrong** |
+
+The two are indistinguishable at this point, and the second is silent: no error,
+no warning, and the entity simply lands on a different domain than asked for.
+When the session was configured for a non-zero domain — which is exactly the
+configuration `CONFIG_NROS_DOMAIN_ID` exists to produce — an explicit
+`domain_id = 0` cannot be honoured at all.
+
+The failure mode is the one issue 0801 already records for a neighbouring cause:
+discovery never matches, and nothing reports an error, *"because the domain is
+just the first element of the key"*.
+
+## Where it came from
+
+Extracted from [[issue-0820]], which hit it while chasing a museum binary that
+published on domain 1. That investigation named this sentinel as a suspect,
+then cleared it — the museum binary was a missing rebuild edge, not this — and
+recorded that the ambiguity "IS real code and may deserve its own issue". This
+is that issue. **Nothing here is evidence of a failure in the field yet**; it is
+a latent ambiguity found by reading, and it should be reproduced before it is
+fixed.
+
+## Direction
+
+The fix is to stop overloading the value. `Option<u32>` at the Rust boundary, or
+a sentinel that is not a legal domain (`u32::MAX`), or an explicit
+`has_domain_id` flag beside the field in the C ABI struct. Which one depends on
+whether the C ABI can change compatibly — the field is part of a `repr(C)`
+struct that RFC-0054 makes the headers' SSoT, so this is an ABI question first
+and a Rust question second.
+
+Note `CONFIG_NROS_CYCLONE_DOMAIN_ID` has the same shape one layer down and
+CLAUDE.md already warns about it ("never pin it to a literal in confs — the
+phase-180 split-brain silently ran every cyclone image on domain 0"). Whatever
+spelling is chosen here should be checked against that one so the tree ends up
+with one answer rather than two.
+
+## Acceptance
+
+* Requesting domain 0 explicitly, against a session configured for a non-zero
+  domain, either honours 0 or fails loudly — not silently substitutes.
+* "Unset" is representable without colliding with a legal domain value.
+* A test covers the explicit-zero case; today nothing distinguishes it.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -75,5 +75,6 @@ fails if this block drifts.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
+- **#0972** (api-c, rmw) — ROS domain 0 is both a legal domain and the `unset` marker, so asking for domain 0 explicitly is silently overridden See `0972-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/packages/api/nros-c/cmake/nros-nuttx.cmake
+++ b/packages/api/nros-c/cmake/nros-nuttx.cmake
@@ -38,8 +38,14 @@
 #                            [SOURCES <extra-c-files…>]
 #                            [COMPILE_DEFS <defs…>]
 #                            [LINK_INTERFACES <codegen-libs…>])
-#       Schedules a `cargo build --release` of the FFI crate at
-#       `FFI_CRATE_DIR`, with env vars wiring the user's main +
+#       Schedules a `cargo build` of the FFI crate at `FFI_CRATE_DIR` at
+#       the `nuttx-rust` CARVE-OUT profile — NOT `--release`, which this
+#       docstring claimed after issue 0820 changed the code beneath it.
+#       Cargo's built-in `release` is `lto = "off"`, and at `lto = off` a
+#       cross-CGU miscompile corrupts std's `lang_start` closure and the
+#       image reboots before `main` with no console output
+#       (phase-177.8.c). The carve-out exists to prevent exactly that.
+#       Env vars wire the user's main +
 #       includes + extra sources + compile defs + FFI staticlibs into
 #       the crate's build.rs. Produces an ELF at
 #       <build>/<NAME>. Each LINK_INTERFACES entry's


### PR DESCRIPTION
#0820's remaining open item assumed the freertos / threadx / esp-idf paths were
"the same custom-command construction" as the NuttX seam whose missing rebuild
edge produced a museum binary. They are not, and measuring that is the answer
rather than a reprieve.

THE MISSING EDGE. Every tracked cmake file containing both `add_custom_command`
and `cargo`:

  NanoRosCodegenCore / NanoRosGenerateInterfaces / NanoRosNodeRegister /
  NrosRmwCycloneddsTypeSupport / zephyr's generate_interfaces   — codegen tools
  NanoRosCorrosion                                              — corrosion's own targets
  nros-c/CMakeLists.txt, nros-cpp/CMakeLists.txt                — config-header mirrors
  nros-c/cmake/nros-nuttx.cmake                                 — DEPFILE x3, the seam

`nros-freertos.cmake` and `nros-threadx.cmake` contain no `cargo` reference at
all: they reach Rust through corrosion, which creates real targets with real
file-level edges. NuttX is the ONLY place a custom command drives a cargo build
of nano-ros Rust, which is why it was the only place the edge went missing. The
construction carries the hazard, not the platform.

THE HARDCODED PROFILE. `just freertos` does not hardcode — it passes the
`freertos-qemu` carve-out through `NROS_CARGO_PROFILE`, with the reason at the
call site. The remaining `--release` literals are a HOST codegen tool
(no carve-out applies) and the px4 module (no px4 carve-out is declared, so
nothing contradicts it).

ONE REAL REMNANT, FIXED: `nros-nuttx.cmake`'s own docstring still said
"Schedules a `cargo build --release`" — the exact text #0820 replaced in the code
below it. A comment contradicting its code is how the next reader re-derives the
wrong thing, and it is the same shape as the NuttX settle-delay contradiction
already recorded in that issue.

I did NOT write a gate. The rule would be "a cargo build driven by a custom
command carries a DEPFILE", and with exactly one instance that is a rule inferred
from a single example — while the codegen commands legitimately have no depfile,
so the predicate would be guesswork. Said so in the issue rather than shipping a
gate that encodes a guess.

#0972 — FILED, the one thing #0820 deliberately left. `node.rs:739` uses domain
`0` as both a legal ROS domain and the "unset" marker:

    let domain_id = if support_domain != 0 { support_domain }
                    else { session.domain_id() };

0 is the DEFAULT ROS domain, so "I did not specify" and "I want domain 0" are
indistinguishable, and the second is silently overridden by the session's domain
whenever that differs. No error — the failure mode #0801 records, where
discovery never matches because the domain is just the first element of the key.
Latent, found by reading, and the issue says so: it should be reproduced before
it is fixed. It also notes `CONFIG_NROS_CYCLONE_DOMAIN_ID` has the same shape one
layer down, so the tree should end up with one answer rather than two.

156/156 fast gates.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk