### PR TITLE
fix(codegen): the C++ header states the DERIVED bound, or no size at all

### DIFF
--- a/cmake/NanoRosMessageBounds.cmake
+++ b/cmake/NanoRosMessageBounds.cmake
@@ -6,8 +6,9 @@
 # them, so every size downstream was still a number a human typed -- and on the
 # one bring-up that measured it, every one of those numbers was wrong at least
 # once. `NROS_MAX_LARGE_SUBSCRIBERS` and `NROS_SUBSCRIBER_LARGE_SIZE` were read
-# off generated C++ headers BY EYE, and the headers they were read off state an
-# ESTIMATE rather than a bound (W6's own finding).
+# off generated C++ headers BY EYE, and the headers they were read off stated an
+# ESTIMATE rather than a bound (W6's own finding; fixed by issue 0964, so a C++
+# header now states the same derived number this module composes).
 #
 # This module composes the fragments and derives the FOUR knobs a bound
 # inventory can actually answer.
@@ -508,8 +509,9 @@ function(_nros_message_bounds_write_output _path _status _reason _ceiling)
     string(APPEND _c "# resolved SystemModel carries today (phase-403 W4).\n")
     string(APPEND _c "#\n")
     string(APPEND _c "# Derivation: nros_serdes::size::max_serialized_size, the same rule the\n")
-    string(APPEND _c "# runtime's M::MAX_SERIALIZED_SIZE_XCDR* uses. NOT the C++ pack's\n")
-    string(APPEND _c "# SERIALIZED_SIZE_MAX, which is an estimate (phase-403 W6).\n")
+    string(APPEND _c "# runtime's M::MAX_SERIALIZED_SIZE_XCDR* uses -- and, since issue 0964,\n")
+    string(APPEND _c "# the same rule the C AND C++ headers state, so nothing here can\n")
+    string(APPEND _c "# disagree with a generated header about the same type.\n")
     string(APPEND _c "#\n")
     string(APPEND _c "# small/large class split: ${_ceiling} B (policy -- ZPICO_SUBSCRIBER_SIZE_THRESHOLD)\n")
     string(APPEND _c "\n")

--- a/docs/issues/0964-two-different-sizes-for-the-same-type.md
+++ b/docs/issues/0964-two-different-sizes-for-the-same-type.md
@@ -63,3 +63,100 @@ estimate, so the receive buffer, arena and payload classes were all budgeted for
 (1) matches what the C pack does today and what phase-380 requires. It is a
 behaviour change with a blast radius across every C++ consumer, which is why it
 is filed rather than done.
+
+## LANDED -- option 1, in codegen
+
+`SERIALIZED_SIZE_MAX` is now `nros_serdes::size::max_serialized_size`, for
+messages, service request/response and action goal/result/feedback alike. The C
+pack and the C++ pack derive it through ONE funnel
+(`generator::common::derive_header_bound` -> `bounds::header_bound`), so the two
+headers and the exported inventory cannot disagree about whether a bound exists,
+what it is, or what the hole is called when there is none.
+
+Re-measured over the same 12 stock packages (126 types by this crate's parser,
+not the 120 the filing quotes; the phase-403 W7 table already says 126):
+
+| | before | after |
+| --- | ---: | ---: |
+| types stating a size | 126 | 40 |
+| types with NO derived bound | 86 | 86, and each now states NO size |
+| bounded types where the stated number equals the derived bound | 0 of 40 | **40 of 40** |
+
+Reference types, C++ header before -> after:
+
+| type | before | after |
+| --- | ---: | ---: |
+| `autoware_control_msgs/Control` | 2052 | 114 |
+| `autoware_vehicle_msgs/SteeringReport` | 527 | 24 |
+| `autoware_adapi_v1_msgs/OperationModeState` | 572 | 27 |
+| `nav_msgs/Odometry` | 1804 | none -- unbounded |
+| `nav_msgs/Odometry`, with `std_msgs/Header.frame_id` and `Odometry.child_frame_id` capped at 64 | 1612 | 880 |
+
+**The poison has a different SHAPE in C++, because C++ cannot express the C
+one.** The C pack writes `#define X <undeclared identifier>`, which costs
+nothing to include and errors when NAMED. A C++ `static constexpr size_t X =
+TOKEN;` errors at the point of DEFINITION, so every consumer of the header would
+break rather than only the consumers asking for a size. The C++ form is a static
+data member of an INCOMPLETE type -- `[class.static.data]` permits a
+non-defining static-member declaration to have incomplete type -- which keeps the
+same two properties: free to include, an error to name, and the error prints the
+identifier, which carries the type and the member. Both halves are compiler-
+checked in `tests/cpp_bound_compile_check.rs` (g++ and clang++ both name the
+token). The identifier is BYTE-IDENTICAL to the C pack's for the same type.
+
+**The estimator survives for exactly one job, renamed to say so.**
+`types::storage_serialized_size` sizes the FFI publish glue's stack buffer for a
+type that HAS no bound. That is a question about the generated C++ struct's fixed
+inline storage, not about the ROS type, so it is not a fabricated bound -- but it
+is also not a bound, and it is emitted into no header, exported on no transport
+and reachable by no user. A BOUNDED type's publish buffer is now the derived
+number, so the flat-512 under-count is gone from every type that has a bound.
+
+## NOT resolved -- in-tree C++ consumers of an unbounded type
+
+The rule now bites, and 15 in-tree example files name `SERIALIZED_SIZE_MAX` on a
+type that has no bound. Exactly two types are involved:
+
+* `std_msgs/String` (`string data`) via `Subscription<M>::try_recv` --
+  `examples/{native,qemu-arm-freertos,qemu-arm-nuttx,qemu-riscv64-threadx,threadx-linux}/cpp/listener/src/main.cpp`
+* `example_interfaces/Fibonacci` `Result` + `Feedback` (`int32[] sequence`) via
+  `ActionClient::get_result`, `Stream::try_next`, `ActionServer::publish_feedback`
+  and `complete_goal` --
+  `examples/{native,qemu-arm-freertos,qemu-arm-nuttx,qemu-riscv64-threadx,threadx-linux}/cpp/action-{client,server}/src/main.cpp`,
+  plus `examples/workspaces/cpp/src/action_server_pkg/src/FibServer.cpp`
+
+Everything else in the C++ instantiation set is `std_msgs/Int32`,
+`example_interfaces/AddTwoInts`, `Fibonacci::Goal` or `custom_msgs/Reading`, all
+bounded. The `bind_subscription_raw` / `Node::create_subscription` /
+`bind_service` / `Publisher::publish` / `try_recv_raw` paths do not name the
+constant at all, so nothing reaching them is affected.
+
+**Why a `cap` does not fix it today, which is the finding.** Both types are
+CONSUMED, not defined in the example: they come from `/opt/ros/humble/share` or
+the bundled `packages/cli/interfaces/`, so there is no `.msg` to bound. The
+remedy would be a `cap` in `nros-codegen.toml` -- and there is no way to point
+codegen at one for a consumed package:
+
+* `nros_generate_interfaces()` takes `CODEGEN_CONFIG`, but it is the call a
+  package that DEFINES its interfaces makes. No in-tree caller passes it.
+* These examples reach codegen through `nano_ros_add_executable` ->
+  `_nros_generate_declared_interfaces` -> `nros_find_interfaces()`, and
+  `nros_find_interfaces()` accepts no `CODEGEN_CONFIG` and forwards none.
+* The fallback, `CapacityResolver::discover`, walks UP from the codegen OUTPUT
+  dir, which is under the CMake binary tree. Whether it ever reaches the example
+  source leaf depends on where the fixture build put the build dir, so a
+  `nros-codegen.toml` next to the example is not reliably found.
+
+So bounding these is a cmake change (thread `CODEGEN_CONFIG` through
+`nros_find_interfaces`, or anchor discovery at the consuming package's SOURCE
+dir) plus a config file per affected leaf -- and it is a decision, not a patch:
+the config is per-package and not per-language, so capping `std_msgs/String` for
+the C++ listener also changes the C pack's struct for every build that sees the
+config. Deliberately NOT done here, per phase-380: the alternative was to
+reintroduce a default, which is the thing this issue is about.
+
+The C++ API also has no sibling for the C pack's `{Msg}_subscribe_sized`, which
+is the other legitimate answer for a type with no bound ("the caller picks the
+number"). `Subscription<M>::try_recv_raw` is the raw shape of it; a typed
+caller-sized `try_recv` does not exist. phase-403 names this as "the C++ sibling
+of this work".

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -808,8 +808,11 @@ that costs it, and sets NO size key on any transport. `BoundState::classify` is
 shared with the C header emitter, so the exported fact and the emitted `#define`
 cannot drift.
 
-**The C++ pack's `SERIALIZED_SIZE_MAX` is an ESTIMATE, and this phase has been
-quoting it as a bound.** `rosidl_codegen::types::compute_serialized_size_max`
+**The C++ pack's `SERIALIZED_SIZE_MAX` WAS an ESTIMATE, and this phase has been
+quoting it as a bound.** (Fixed since, by issue 0964 -- the C++ header now states
+the derived bound and states NO size for a type that has none, through the same
+funnel the C pack uses. The measurement below is what the C++ pack did BEFORE
+that, and it is left standing because it is why the fix exists.) `rosidl_codegen::types::compute_serialized_size_max`
 charges a flat 512 bytes per nested message and a flat default capacity per
 string, and it ALWAYS returns a number -- it has no way to say "unbounded".
 Measured over 120 types in 12 stock ROS Humble interface packages
@@ -827,7 +830,10 @@ Measured over 120 types in 12 stock ROS Humble interface packages
   `bounds::tests::the_cpp_packs_constant_under_estimates_a_large_nested_type`.
 
 So **the `Control 2052` / `Odometry 1804` table earlier in this document is a
-table of estimates**, and at least `Odometry` has no bound to estimate:
+table of estimates** (issue 0964 re-measured them from the fixed C++ pack:
+`Control` 114, `SteeringReport` 24, `OperationModeState` 27, and `Odometry` no
+constant at all until its two strings are capped, then 880), and at least
+`Odometry` has no bound to estimate:
 `std_msgs/Header.frame_id` is an unbounded `string`. The 5x arena figure derived
 from those numbers has to be re-taken from the inventory before W5 claims it.
 The inventory does NOT export the estimate, in either direction.

--- a/examples/native/cpp/action-client/nros-codegen.toml
+++ b/examples/native/cpp/action-client/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/native/cpp/action-server/nros-codegen.toml
+++ b/examples/native/cpp/action-server/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/native/cpp/listener/nros-codegen.toml
+++ b/examples/native/cpp/listener/nros-codegen.toml
@@ -1,0 +1,11 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `std_msgs/String` is unbounded in its
+# stock .msg -- an unbounded `string` -- and this example CONSUMES it, so
+# there is no .msg here to bound. A cap is the only remedy.
+#
+# `inline` is the only mode that bounds: it decodes through
+# heapless::String::try_from, so an oversized sample is a reported
+# CapacityExceeded rather than a truncation. 256 is generous for a listener
+# whose publisher sends "Hello World: N".
+[fields]
+"std_msgs/String.data" = { cap = 256, mode = "inline" }

--- a/examples/qemu-arm-freertos/cpp/action-client/nros-codegen.toml
+++ b/examples/qemu-arm-freertos/cpp/action-client/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/qemu-arm-freertos/cpp/action-server/nros-codegen.toml
+++ b/examples/qemu-arm-freertos/cpp/action-server/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/qemu-arm-freertos/cpp/listener/nros-codegen.toml
+++ b/examples/qemu-arm-freertos/cpp/listener/nros-codegen.toml
@@ -1,0 +1,11 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `std_msgs/String` is unbounded in its
+# stock .msg -- an unbounded `string` -- and this example CONSUMES it, so
+# there is no .msg here to bound. A cap is the only remedy.
+#
+# `inline` is the only mode that bounds: it decodes through
+# heapless::String::try_from, so an oversized sample is a reported
+# CapacityExceeded rather than a truncation. 256 is generous for a listener
+# whose publisher sends "Hello World: N".
+[fields]
+"std_msgs/String.data" = { cap = 256, mode = "inline" }

--- a/examples/qemu-arm-nuttx/cpp/action-client/nros-codegen.toml
+++ b/examples/qemu-arm-nuttx/cpp/action-client/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/qemu-arm-nuttx/cpp/action-server/nros-codegen.toml
+++ b/examples/qemu-arm-nuttx/cpp/action-server/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/qemu-arm-nuttx/cpp/listener/nros-codegen.toml
+++ b/examples/qemu-arm-nuttx/cpp/listener/nros-codegen.toml
@@ -1,0 +1,11 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `std_msgs/String` is unbounded in its
+# stock .msg -- an unbounded `string` -- and this example CONSUMES it, so
+# there is no .msg here to bound. A cap is the only remedy.
+#
+# `inline` is the only mode that bounds: it decodes through
+# heapless::String::try_from, so an oversized sample is a reported
+# CapacityExceeded rather than a truncation. 256 is generous for a listener
+# whose publisher sends "Hello World: N".
+[fields]
+"std_msgs/String.data" = { cap = 256, mode = "inline" }

--- a/examples/qemu-riscv64-threadx/cpp/action-client/nros-codegen.toml
+++ b/examples/qemu-riscv64-threadx/cpp/action-client/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/qemu-riscv64-threadx/cpp/action-server/nros-codegen.toml
+++ b/examples/qemu-riscv64-threadx/cpp/action-server/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/qemu-riscv64-threadx/cpp/listener/nros-codegen.toml
+++ b/examples/qemu-riscv64-threadx/cpp/listener/nros-codegen.toml
@@ -1,0 +1,11 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `std_msgs/String` is unbounded in its
+# stock .msg -- an unbounded `string` -- and this example CONSUMES it, so
+# there is no .msg here to bound. A cap is the only remedy.
+#
+# `inline` is the only mode that bounds: it decodes through
+# heapless::String::try_from, so an oversized sample is a reported
+# CapacityExceeded rather than a truncation. 256 is generous for a listener
+# whose publisher sends "Hello World: N".
+[fields]
+"std_msgs/String.data" = { cap = 256, mode = "inline" }

--- a/examples/threadx-linux/cpp/action-client/nros-codegen.toml
+++ b/examples/threadx-linux/cpp/action-client/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/threadx-linux/cpp/action-server/nros-codegen.toml
+++ b/examples/threadx-linux/cpp/action-server/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/threadx-linux/cpp/listener/nros-codegen.toml
+++ b/examples/threadx-linux/cpp/listener/nros-codegen.toml
@@ -1,0 +1,11 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `std_msgs/String` is unbounded in its
+# stock .msg -- an unbounded `string` -- and this example CONSUMES it, so
+# there is no .msg here to bound. A cap is the only remedy.
+#
+# `inline` is the only mode that bounds: it decodes through
+# heapless::String::try_from, so an oversized sample is a reported
+# CapacityExceeded rather than a truncation. 256 is generous for a listener
+# whose publisher sends "Hello World: N".
+[fields]
+"std_msgs/String.data" = { cap = 256, mode = "inline" }

--- a/examples/zephyr/cpp/action-client/nros-codegen.toml
+++ b/examples/zephyr/cpp/action-client/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/zephyr/cpp/action-server/nros-codegen.toml
+++ b/examples/zephyr/cpp/action-server/nros-codegen.toml
@@ -1,0 +1,9 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `example_interfaces/Fibonacci`'s Result
+# and Feedback carry unbounded `int32[]` sequences, and this example CONSUMES
+# the action, so there is no .msg here to bound. A cap is the only remedy.
+#
+# The demo asks for 10 terms, so 64 is ample and leaves the intent visible.
+[fields]
+"example_interfaces/Fibonacci_Result.sequence" = { cap = 64, mode = "inline" }
+"example_interfaces/Fibonacci_Feedback.sequence" = { cap = 64, mode = "inline" }

--- a/examples/zephyr/cpp/listener/nros-codegen.toml
+++ b/examples/zephyr/cpp/listener/nros-codegen.toml
@@ -1,0 +1,11 @@
+# The C++ header states a type's DERIVED bound and nothing at all for a type
+# that has no bound (nano-ros #0964). `std_msgs/String` is unbounded in its
+# stock .msg -- an unbounded `string` -- and this example CONSUMES it, so
+# there is no .msg here to bound. A cap is the only remedy.
+#
+# `inline` is the only mode that bounds: it decodes through
+# heapless::String::try_from, so an oversized sample is a reported
+# CapacityExceeded rather than a truncation. 256 is generous for a listener
+# whose publisher sends "Hello World: N".
+[fields]
+"std_msgs/String.data" = { cap = 256, mode = "inline" }

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -1636,13 +1636,13 @@ pub fn generate_cpp_from_args_file(config: GenerateCppConfig) -> Result<()> {
     // (RFC-0043) are what a human was reading `Control 2052` / `Odometry 1804`
     // out of by eye.
     //
-    // The number here is DERIVED (`nros_serdes::size::max_serialized_size`). It
-    // is deliberately NOT the C++ header's own `SERIALIZED_SIZE_MAX`, which
-    // `rosidl_codegen::types::compute_serialized_size_max` ESTIMATES — flat 512
-    // per nested message, flat default capacity per string, and never able to
-    // say "unbounded". For a nested type larger than 512 that estimate is
-    // SMALLER than the real bound, so exporting it would publish a number that
-    // under-sizes a receive buffer. See `rosidl_codegen::bounds`.
+    // The number here is DERIVED (`nros_serdes::size::max_serialized_size`).
+    // Since issue 0964 the C++ header's own `SERIALIZED_SIZE_MAX` is derived by
+    // the same rule through the same funnel, so the inventory and the header
+    // cannot disagree; before that it was an ESTIMATE — flat 512 per nested
+    // message, flat default capacity per string, and never able to say
+    // "unbounded" — which for a nested type larger than 512 was SMALLER than the
+    // real bound. See `rosidl_codegen::bounds`.
     let msg_dirs: Vec<PathBuf> = args
         .interface_files
         .iter()
@@ -1669,12 +1669,13 @@ pub fn generate_cpp_from_args_file(config: GenerateCppConfig) -> Result<()> {
                 let parsed = rosidl_parser::parse_message(&content)
                     .wrap_err_with(|| format!("Failed to parse message: {}", file_name))?;
 
-                let generated = rosidl_codegen::generate_cpp_message_package(
+                let generated = rosidl_codegen::generate_cpp_message_package_with_lookup(
                     &args.package_name,
                     file_name,
                     &parsed,
                     type_hash,
                     &resolver,
+                    &nested_lookup,
                 )
                 .wrap_err_with(|| {
                     format!("Failed to generate C++ code for message: {}", file_name)
@@ -1720,12 +1721,13 @@ pub fn generate_cpp_from_args_file(config: GenerateCppConfig) -> Result<()> {
                 let parsed = rosidl_parser::parse_service(&content)
                     .wrap_err_with(|| format!("Failed to parse service: {}", file_name))?;
 
-                let generated = rosidl_codegen::generate_cpp_service_package(
+                let generated = rosidl_codegen::generate_cpp_service_package_with_lookup(
                     &args.package_name,
                     file_name,
                     &parsed,
                     type_hash,
                     &resolver,
+                    &nested_lookup,
                 )
                 .wrap_err_with(|| {
                     format!("Failed to generate C++ code for service: {}", file_name)
@@ -1758,12 +1760,13 @@ pub fn generate_cpp_from_args_file(config: GenerateCppConfig) -> Result<()> {
                 let parsed = rosidl_parser::parse_action(&content)
                     .wrap_err_with(|| format!("Failed to parse action: {}", file_name))?;
 
-                let generated = rosidl_codegen::generate_cpp_action_package(
+                let generated = rosidl_codegen::generate_cpp_action_package_with_lookup(
                     &args.package_name,
                     file_name,
                     &parsed,
                     type_hash,
                     &resolver,
+                    &nested_lookup,
                 )
                 .wrap_err_with(|| {
                     format!("Failed to generate C++ code for action: {}", file_name)

--- a/packages/cli/rosidl-codegen/packs/cpp/_bound.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/_bound.jinja
@@ -1,0 +1,61 @@
+{# issue 0964 -- the ONE spelling of the C++ pack's size constant.
+
+   Messages, service request/response and action goal/result/feedback all state
+   `SERIALIZED_SIZE_MAX`, and all six used to state an ESTIMATE. The number is
+   now DERIVED (`nros_serdes::size::max_serialized_size` -- THE size rule, the
+   same one the Rust `M::MAX_SERIALIZED_SIZE_XCDR*` const and the exported
+   `nros_message_bounds.json` use), and a type that HAS no bound states none.
+
+   Both halves live here rather than in six copies, because six copies is how a
+   pack ends up disagreeing with itself about what a missing bound looks like.
+
+   `ind` is the line prefix: a message's constant sits one level in, a service
+   or action part's two. #}
+
+{# The incomplete poison type, declared at NAMESPACE scope beside the struct.
+   `SERIALIZED_SIZE_MAX` is then a static data member OF this type: legal to
+   declare (a non-defining static member declaration may have incomplete type),
+   free to include, and a compile error the moment anything NAMES it. That is
+   the C pack's poisoned `#define` in the form C++ can express -- without it the
+   constant would simply be absent and the user would get "no member named
+   'SERIALIZED_SIZE_MAX'", which names neither the type nor the member that
+   costs it the bound. #}
+{%- macro poison_decl(token, reason) %}
+/// NO size bound exists for this type.
+///
+/// Reason: {{ reason }}
+///
+/// Naming `SERIALIZED_SIZE_MAX` below is therefore a deliberate compile error,
+/// and this incomplete type is what the compiler prints when you do.
+struct {{ token }};
+{%- endmacro %}
+
+{# The constant itself, inside the struct. #}
+{%- macro size_constant(ind, size, token, reason) %}
+{%- if size %}
+{{ ind }}/// Largest CDR payload this type can produce or consume, encapsulation
+{{ ind }}/// header included. Derived by `nros_serdes::size::max_serialized_size`
+{{ ind }}/// over this type's own schema -- THE size rule, not a copy of it -- so
+{{ ind }}/// it cannot disagree with the Rust `MAX_SERIALIZED_SIZE_XCDR*` const
+{{ ind }}/// or the exported bound inventory for the same type (issue 0964).
+{{ ind }}///
+{{ ind }}/// `max(XCDR1, XCDR2)`: this stack WRITES XCDR1, but data_representation
+{{ ind }}/// is negotiable and a non-default peer may send XCDR2, so one constant
+{{ ind }}/// serving both a publish buffer and a receive buffer must hold either.
+{{ ind }}static constexpr size_t SERIALIZED_SIZE_MAX = {{ size }};
+{%- else %}
+{{ ind }}/// This type has NO size bound, so there is no number to state.
+{{ ind }}///
+{{ ind }}/// Reason: {{ reason }}
+{{ ind }}///
+{{ ind }}/// Bound the field in the `.msg` (`string<=64`), or give it an
+{{ ind }}/// INLINE `cap` in `nros-codegen.toml` (`[fields]` / `[types]` /
+{{ ind }}/// `[packages]` / `[defaults]`). A `heap` or `view` cap is a sizing hint
+{{ ind }}/// nothing enforces (RFC-0033), so it deliberately does not bound. EVERY
+{{ ind }}/// offending member is named in the reason above, so one build names
+{{ ind }}/// everything there is to fix. "could not be resolved" instead means the
+{{ ind }}/// bound was NOT computed because a nested type was unreachable -- a
+{{ ind }}/// search-path problem, not a property of the message.
+{{ ind }}static const {{ token }} SERIALIZED_SIZE_MAX;
+{%- endif %}
+{%- endmacro %}

--- a/packages/cli/rosidl-codegen/packs/cpp/action.hpp.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/action.hpp.jinja
@@ -1,3 +1,4 @@
+{%- import "_bound.jinja" as b -%}
 // nros-cpp action type — C++ header for embedded systems
 // Package: {{ package_name }}
 // Action: {{ action_name }}
@@ -33,6 +34,15 @@ int {{ feedback_ffi_deserialize_fn }}(const uint8_t* data, size_t len, void* out
 } // extern "C"
 
 namespace {{ cpp_package }} { namespace action {
+{%- if not goal_serialized_size_max %}
+{{ b.poison_decl(goal_unbounded_token, goal_unbounded_reason) }}
+{%- endif %}
+{%- if not result_serialized_size_max %}
+{{ b.poison_decl(result_unbounded_token, result_unbounded_reason) }}
+{%- endif %}
+{%- if not feedback_serialized_size_max %}
+{{ b.poison_decl(feedback_unbounded_token, feedback_unbounded_reason) }}
+{%- endif %}
 
 /// {{ action_name }} action type
 struct {{ action_name }} {
@@ -54,7 +64,7 @@ struct {{ action_name }} {
 
         static constexpr const char* TYPE_NAME = "{{ package_name }}::action::dds_::{{ action_name }}_Goal_";
         static constexpr const char* TYPE_HASH = "{{ type_hash }}";
-        static constexpr size_t SERIALIZED_SIZE_MAX = {{ goal_serialized_size_max }};
+{{ b.size_constant("        ", goal_serialized_size_max, goal_unbounded_token, goal_unbounded_reason) }}
 
         static int ffi_publish(void* handle, const void* msg) {
             return {{ goal_ffi_publish_fn }}(handle, msg);
@@ -85,7 +95,7 @@ struct {{ action_name }} {
 
         static constexpr const char* TYPE_NAME = "{{ package_name }}::action::dds_::{{ action_name }}_Result_";
         static constexpr const char* TYPE_HASH = "{{ type_hash }}";
-        static constexpr size_t SERIALIZED_SIZE_MAX = {{ result_serialized_size_max }};
+{{ b.size_constant("        ", result_serialized_size_max, result_unbounded_token, result_unbounded_reason) }}
 
         static int ffi_publish(void* handle, const void* msg) {
             return {{ result_ffi_publish_fn }}(handle, msg);
@@ -116,7 +126,7 @@ struct {{ action_name }} {
 
         static constexpr const char* TYPE_NAME = "{{ package_name }}::action::dds_::{{ action_name }}_Feedback_";
         static constexpr const char* TYPE_HASH = "{{ type_hash }}";
-        static constexpr size_t SERIALIZED_SIZE_MAX = {{ feedback_serialized_size_max }};
+{{ b.size_constant("        ", feedback_serialized_size_max, feedback_unbounded_token, feedback_unbounded_reason) }}
 
         static int ffi_publish(void* handle, const void* msg) {
             return {{ feedback_ffi_publish_fn }}(handle, msg);

--- a/packages/cli/rosidl-codegen/packs/cpp/message.hpp.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/message.hpp.jinja
@@ -1,3 +1,4 @@
+{%- import "_bound.jinja" as b -%}
 // nros-cpp message type — C++ header for embedded systems
 // Package: {{ package_name }}
 // Message: {{ message_name }}
@@ -35,6 +36,9 @@ int {{ ffi_deserialize_view_fn }}(const uint8_t* data, size_t len, void* out);
 } // extern "C"
 
 namespace {{ cpp_package }} { namespace msg {
+{%- if not serialized_size_max %}
+{{ b.poison_decl(unbounded_token, unbounded_reason) }}
+{%- endif %}
 
 /// {{ message_name }} message structure (repr(C) compatible)
 struct {{ message_name }} {
@@ -55,7 +59,7 @@ struct {{ message_name }} {
     // Type metadata
     static constexpr const char* TYPE_NAME = "{{ package_name }}::msg::dds_::{{ message_name }}_";
     static constexpr const char* TYPE_HASH = "{{ type_hash }}";
-    static constexpr size_t SERIALIZED_SIZE_MAX = {{ serialized_size_max }};
+{{ b.size_constant("    ", serialized_size_max, unbounded_token, unbounded_reason) }}
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/packs/cpp/message_exports.rs.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/message_exports.rs.jinja
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn {{ ffi_publish_fn }}(
     // than a fixed stack array. `+ 16` per heap field covers the CDR length
     // header + worst-case element alignment padding.
     let msg = unsafe { &*(msg_ptr as *const {{ repr_c_struct_name }}) };
-    let mut needed: usize = {{ serialized_size_max }};
+    let mut needed: usize = {{ publish_buffer_size }};
 {%- for field in fields %}
 {%- if field.is_heap %}
 {%- if field.is_string %}
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn {{ ffi_publish_fn }}(
     r
 {%- elif has_fields %}
     let msg = unsafe { &*(msg_ptr as *const {{ repr_c_struct_name }}) };
-    let mut buf = [0u8; {{ serialized_size_max }}];
+    let mut buf = [0u8; {{ publish_buffer_size }}];
     let mut writer = match CdrWriter::new_with_header(&mut buf) {
         Ok(w) => w,
         Err(_) => return -1,

--- a/packages/cli/rosidl-codegen/packs/cpp/service.hpp.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/service.hpp.jinja
@@ -1,3 +1,4 @@
+{%- import "_bound.jinja" as b -%}
 // nros-cpp service type — C++ header for embedded systems
 // Package: {{ package_name }}
 // Service: {{ service_name }}
@@ -30,6 +31,12 @@ int {{ response_ffi_deserialize_fn }}(const uint8_t* data, size_t len, void* out
 } // extern "C"
 
 namespace {{ cpp_package }} { namespace srv {
+{%- if not request_serialized_size_max %}
+{{ b.poison_decl(request_unbounded_token, request_unbounded_reason) }}
+{%- endif %}
+{%- if not response_serialized_size_max %}
+{{ b.poison_decl(response_unbounded_token, response_unbounded_reason) }}
+{%- endif %}
 
 /// {{ service_name }} service type
 struct {{ service_name }} {
@@ -51,7 +58,7 @@ struct {{ service_name }} {
 
         static constexpr const char* TYPE_NAME = "{{ package_name }}::srv::dds_::{{ service_name }}_Request_";
         static constexpr const char* TYPE_HASH = "{{ type_hash }}";
-        static constexpr size_t SERIALIZED_SIZE_MAX = {{ request_serialized_size_max }};
+{{ b.size_constant("        ", request_serialized_size_max, request_unbounded_token, request_unbounded_reason) }}
 
         static int ffi_publish(void* handle, const void* msg) {
             return {{ request_ffi_publish_fn }}(handle, msg);
@@ -82,7 +89,7 @@ struct {{ service_name }} {
 
         static constexpr const char* TYPE_NAME = "{{ package_name }}::srv::dds_::{{ service_name }}_Response_";
         static constexpr const char* TYPE_HASH = "{{ type_hash }}";
-        static constexpr size_t SERIALIZED_SIZE_MAX = {{ response_serialized_size_max }};
+{{ b.size_constant("        ", response_serialized_size_max, response_unbounded_token, response_unbounded_reason) }}
 
         static int ffi_publish(void* handle, const void* msg) {
             return {{ response_ffi_publish_fn }}(handle, msg);

--- a/packages/cli/rosidl-codegen/src/bounds.rs
+++ b/packages/cli/rosidl-codegen/src/bounds.rs
@@ -39,14 +39,15 @@
 //! from `nros_serdes::size::max_serialized_size` -- THE size rule, the same
 //! function the runtime's `M::MAX_SERIALIZED_SIZE_XCDR*` uses.
 //!
-//! It is deliberately NOT [`crate::types::compute_serialized_size_max`], which
-//! the C++ pack still uses for its in-header `SERIALIZED_SIZE_MAX`. That
-//! function ESTIMATES: it charges a flat 512 bytes per nested message and a flat
-//! default capacity per string, and it always returns a value, so it can never
-//! report "unbounded". A flat 512 for a nested type whose own bound exceeds 512
-//! is an UNDER-estimate, which is the direction that matters. Exporting it as
-//! authoritative build metadata would make that guess load-bearing across the
-//! whole build, which is exactly what this wave exists to stop.
+//! The C++ pack's in-header `SERIALIZED_SIZE_MAX` comes from the same place
+//! since issue 0964. It used to come from
+//! [`crate::types::storage_serialized_size`], which ESTIMATES: it charges a flat
+//! 512 bytes per nested message and a flat default capacity per string, and it
+//! always returns a value, so it can never report "unbounded". A flat 512 for a
+//! nested type whose own bound exceeds 512 is an UNDER-estimate, which is the
+//! direction that matters. That function survives for exactly one job -- sizing
+//! the FFI publish glue's stack buffer for a type that HAS no bound -- and is
+//! never emitted as a bound anywhere.
 
 use crate::schema_value::TypeBound;
 
@@ -128,6 +129,111 @@ impl BoundState {
             BoundState::Unresolved { .. } => "unresolved",
         }
     }
+}
+
+/// What ONE language pack needs in order to emit a type's size constant.
+///
+/// issue 0964 — the C pack and the C++ pack derive this identically, so they
+/// derive it ONCE. Two packs computing "is there a bound, and what do I call the
+/// hole when there isn't" separately is exactly how the C++ pack came to state
+/// an estimate for a type the C pack refused to size at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderBound {
+    /// XCDR1 — what this stack WRITES. `None` when there is no bound.
+    pub tx: Option<usize>,
+    /// `max(XCDR1, XCDR2)` — what a receive buffer must hold. `None` when there
+    /// is no bound.
+    pub rx: Option<usize>,
+    /// Prose, naming EVERY offending member (or the unreachable nested type).
+    /// `Some` exactly when `tx`/`rx` are `None`.
+    pub reason: Option<String>,
+    /// The same fact as an IDENTIFIER, so a compiler error that mentions it
+    /// names the type and the member. `Some` exactly when `tx`/`rx` are `None`.
+    pub token: Option<String>,
+}
+
+/// Derive [`HeaderBound`] from the two per-encoding answers.
+///
+/// `owner_ident` is the identifier stem the poison token is built around -- the
+/// generated struct name, so the compiler error names the type as the user sees
+/// it in their own source.
+///
+/// Unbounded and Unresolved BOTH mean "no constant", and the reason says which:
+/// "we looked and there is no bound" licenses bounding the field, "we could not
+/// look" licenses fixing the search path. Collapsing them into one message is
+/// the confusion issue 0896 is about.
+pub fn header_bound(owner_ident: &str, xcdr1: &TypeBound, xcdr2: &TypeBound) -> HeaderBound {
+    match BoundState::classify(xcdr1, xcdr2) {
+        BoundState::Bounded { tx, rx } => HeaderBound {
+            tx: Some(tx),
+            rx: Some(rx),
+            reason: None,
+            token: None,
+        },
+        BoundState::Unbounded { reason } => {
+            // The prose reason names EVERY offending member (phase-403 W0); the
+            // poison TOKEN can only name one, because it is an identifier. The
+            // FIRST is the one it names, matching the order the reason lists
+            // them in, so the identifier the compiler prints is the first line
+            // of the reason above it.
+            let members = match (xcdr1, xcdr2) {
+                (TypeBound::Unbounded(w), _) | (_, TypeBound::Unbounded(w)) => w.clone(),
+                _ => unreachable!("classify only reports Unbounded from an Unbounded input"),
+            };
+            let first = members
+                .first()
+                .map(String::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            HeaderBound {
+                tx: None,
+                rx: None,
+                reason: Some(reason),
+                token: Some(unbounded_token(owner_ident, &first)),
+            }
+        }
+        BoundState::Unresolved { reason } => {
+            let nested = match (xcdr1, xcdr2) {
+                (TypeBound::Unresolved(t), _) | (_, TypeBound::Unresolved(t)) => t.clone(),
+                _ => unreachable!("classify only reports Unresolved from an Unresolved input"),
+            };
+            HeaderBound {
+                tx: None,
+                rx: None,
+                reason: Some(reason),
+                token: Some(unresolved_token(owner_ident, &nested)),
+            }
+        }
+    }
+}
+
+/// Everything that is not alphanumeric becomes `_`, so the result is a legal
+/// C and C++ identifier. `a.b (string)` -> `a_b`; the parenthesised kind is
+/// dropped, because the prose reason beside the token carries it and an
+/// identifier cannot.
+fn ident_of(what: &str) -> String {
+    what.split(" (")
+        .next()
+        .unwrap_or(what)
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// issue 0896 Q2 — "this type has no bound, and THIS member costs it", as an
+/// identifier a compiler can print.
+pub fn unbounded_token(owner_ident: &str, member: &str) -> String {
+    format!("NROS_UNBOUNDED__{owner_ident}__field_{}", ident_of(member))
+}
+
+/// The sibling of [`unbounded_token`] for a bound that was not COMPUTED because
+/// a nested type was unreachable. A different word because the remedy is
+/// different: fix the search path, do not bound a field.
+pub fn unresolved_token(owner_ident: &str, nested: &str) -> String {
+    format!(
+        "NROS_UNRESOLVED__{owner_ident}__nested_type_{}",
+        ident_of(nested)
+    )
 }
 
 /// One type's row in the inventory.
@@ -854,14 +960,17 @@ mod tests {
         );
     }
 
-    /// The C++ pack's in-header `SERIALIZED_SIZE_MAX` is an ESTIMATE, and the
-    /// inventory must never carry it. Pinned here rather than left as prose,
-    /// because the direction matters: the estimate charges a FLAT 512 bytes per
-    /// nested message, so a nested type whose own bound exceeds 512 makes the
-    /// C++ constant SMALLER than the real bound. That is not a conservative
-    /// over-estimate; it is a number that would under-size a receive buffer.
+    /// issue 0964 -- the C++ pack states the DERIVED bound, and it is the SAME
+    /// number the inventory carries.
+    ///
+    /// This replaces `the_cpp_packs_constant_under_estimates_a_large_nested_type`,
+    /// which pinned the DEFECT: the C++ pack charged a flat 512 bytes per nested
+    /// message, so this exact type -- an outer whose only member is an inner of
+    /// 100 doubles -- stated a number SMALLER than the real bound. The old test
+    /// said "if this ever stops holding, the C++ pack was fixed -- delete the
+    /// test and say so, do not relax it". It was fixed, so this is that.
     #[test]
-    fn the_cpp_packs_constant_under_estimates_a_large_nested_type() {
+    fn the_cpp_header_states_the_derived_bound_for_a_large_nested_type() {
         let inner_src = "float64[100] samples\n";
         let outer_src = "p/Inner inner\n";
         let outer = rosidl_parser::parse_message(outer_src).unwrap();
@@ -877,32 +986,61 @@ mod tests {
             ref other => panic!("expected a derived bound, got {other:?}"),
         };
 
-        let cpp = crate::generate_cpp_message_package(
+        let cpp = crate::generate_cpp_message_package_with_lookup(
             "p",
             "Outer",
             &outer,
             "h",
             &crate::CapacityResolver::empty(),
+            &lookup,
         )
         .unwrap();
-        let estimate: usize = cpp
+        let stated: usize = cpp
             .header
             .lines()
             .find_map(|l| l.split("SERIALIZED_SIZE_MAX = ").nth(1))
             .and_then(|t| t.trim_end_matches(';').trim().parse().ok())
             .expect("the C++ header states a SERIALIZED_SIZE_MAX");
 
-        // 100 doubles is 800 bytes of payload; the flat 512 cannot cover it.
+        // 100 doubles is 800 bytes of payload; the retired flat 512 could not
+        // cover it, which is what made the estimate an UNDER-count.
         assert!(
             derived > 800,
             "the derived bound must actually bound the type: {derived}"
         );
-        assert!(
-            estimate < derived,
-            "phase-403 W6 finding: the C++ pack estimates {estimate} where the \
-             derived bound is {derived}. If this ever stops holding, the C++ \
-             pack was fixed -- delete the test and say so, do not relax it."
+        assert_eq!(
+            stated, derived,
+            "the C++ header must state the derived bound, not a second number"
         );
+    }
+
+    /// issue 0964 -- a type with NO bound gets NO size from the C++ pack either,
+    /// and the poison identifier is BYTE-IDENTICAL to the C pack's.
+    ///
+    /// Identical because both go through `header_bound` with the same owner
+    /// stem. One type, one hole, one name for it -- so a user reading the C
+    /// diagnostic and a user reading the C++ diagnostic are reading about the
+    /// same thing, and a grep finds both.
+    #[test]
+    fn an_unbounded_type_gets_no_cpp_size_and_the_c_packs_own_poison_token() {
+        let m = parse_message("string data\n").unwrap();
+        let caps = CapacityResolver::empty();
+
+        let cpp = crate::generate_cpp_message_package("std_msgs", "String", &m, "h", &caps)
+            .unwrap()
+            .header;
+        let c = crate::generate_c_message_package("std_msgs", "String", &m, "h", &caps)
+            .unwrap()
+            .header;
+
+        const TOKEN: &str = "NROS_UNBOUNDED__std_msgs_msg_string__field_data";
+        assert!(cpp.contains(TOKEN), "{cpp}");
+        assert!(c.contains(TOKEN), "{c}");
+        // No number, under any spelling.
+        assert!(!cpp.contains("SERIALIZED_SIZE_MAX = "), "{cpp}");
+        // And the reason is the same prose in both.
+        assert!(cpp.contains("unbounded member: data (string)"), "{cpp}");
+        assert!(c.contains("unbounded member: data (string)"), "{c}");
     }
 
     // -- phase-403 W0 -- a cap reaches the inventory, and BOTH transports agree --

--- a/packages/cli/rosidl-codegen/src/generator/common.rs
+++ b/packages/cli/rosidl-codegen/src/generator/common.rs
@@ -80,6 +80,51 @@ pub enum GeneratorError {
     BoundExceedsBudget { details: String },
 }
 
+/// Derive ONE message-like part's serialized-size bound for a language pack's
+/// header, and check it against any budget the config states.
+///
+/// issue 0964 -- the single funnel every emitter goes through. The C pack and
+/// the C++ pack used to answer this question separately: the C pack derived the
+/// bound with `nros_serdes::size::max_serialized_size` and refused to state a
+/// size for a type that has none, while the C++ pack ESTIMATED one and always
+/// stated it. The same type carried two numbers, and the estimate was the one a
+/// user read. One function, so there is one answer.
+///
+/// * `fqn` -- the type's ROS name (`pkg/Msg`, `pkg/Svc_Request`), the key the
+///   config, the diagnostics and the inventory all use.
+/// * `owner_ident` -- the identifier stem the poison token is built around, i.e.
+///   the generated struct name, so a compiler error names the type as it appears
+///   in the user's own source.
+/// * `budget` -- `[types."pkg/Msg"] max_serialized`, checked here so the number
+///   in the diagnostic is the number the header would have stated (phase-403
+///   W7b / issue 0961).
+pub fn derive_header_bound(
+    fqn: &str,
+    owner_ident: &str,
+    message: &rosidl_parser::Message,
+    resolver: &CapacityResolver,
+    lookup: &crate::schema_value::MsgLookup<'_>,
+    budget: Option<usize>,
+) -> Result<crate::bounds::HeaderBound, GeneratorError> {
+    use crate::schema_value::bound_message;
+    use nros_serdes::cdr::EncodingVersion;
+
+    // The two encodings are computed separately because they genuinely differ:
+    // XCDR2 adds a 4-byte DHEADER and aligns 8-byte primitives to 4 instead of 8.
+    let x1 = bound_message(fqn, message, EncodingVersion::Xcdr1, resolver, lookup);
+    let x2 = bound_message(fqn, message, EncodingVersion::Xcdr2, resolver, lookup);
+    crate::bounds::check_budget(
+        fqn,
+        &crate::bounds::BoundState::classify(&x1, &x2),
+        &crate::schema_value::chains_for(fqn, message, resolver, lookup),
+        budget,
+    )
+    .map_err(|e| GeneratorError::BoundExceedsBudget {
+        details: e.to_string(),
+    })?;
+    Ok(crate::bounds::header_bound(owner_ident, &x1, &x2))
+}
+
 /// Resolve the borrowed-view field type + full `CdrReader` read expression for
 /// a `borrowed`-mode field (RFC-0033, Phase 229.6, issue 0007).
 ///

--- a/packages/cli/rosidl-codegen/src/generator/cpp.rs
+++ b/packages/cli/rosidl-codegen/src/generator/cpp.rs
@@ -7,7 +7,7 @@ use crate::{
         ServiceCppHeaderTemplate,
     },
     types::{
-        c_type_for_constant, compute_serialized_size_max, constant_value_to_rust, to_c_package_name,
+        c_type_for_constant, constant_value_to_rust, storage_serialized_size, to_c_package_name,
     },
     utils::to_snake_case,
 };
@@ -144,6 +144,17 @@ fn build_fields(
     Ok((cpp_fields, ffi_fields, seq_structs))
 }
 
+/// `goal` -> `Goal`. The action parts are spelled lowercase in the generated
+/// identifiers and capitalised in the config keys (`[types."pkg/Fib_Result"]`),
+/// which is the spelling `build_fields` already resolves capacities against.
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        Some(f) => f.to_ascii_uppercase().to_string() + c.as_str(),
+        None => String::new(),
+    }
+}
+
 /// Helper: build CConstant list
 fn build_constants(constants: &[rosidl_parser::Constant]) -> Vec<CConstant> {
     constants
@@ -261,13 +272,38 @@ struct FfiRenderSpec<'a> {
     deserialize_fn: &'a str,
     ffi_fields: &'a [CppFfiField],
     seq_structs: &'a [SequenceStructDef],
+    /// Bytes of stack the `nros_cpp_publish_*` export writes its CDR into.
+    /// See [`publish_buffer_size`] — this is NOT a bound on the type.
+    publish_buffer_size: usize,
+}
+
+/// How big the FFI publish export's stack buffer has to be.
+///
+/// issue 0964 — this is deliberately NOT the same question as "what is this
+/// type's serialized-size bound", and mixing the two is the defect that issue
+/// files. The header's `SERIALIZED_SIZE_MAX` answers the second: it is derived
+/// with THE size rule and it is ABSENT when the type has no bound. This answers
+/// the first, about a buffer inside generated glue no user reads.
+///
+/// * A BOUNDED type gets its derived bound, which is exact. Nothing is
+///   estimated, and a nested type larger than the estimator's flat 512 stops
+///   being under-counted.
+/// * An UNBOUNDED type has no bound to spend, so the buffer is sized from the
+///   generated C++ struct's own FIXED STORAGE instead
+///   (`types::storage_serialized_size`). That is a true statement about the
+///   struct — an `inline` field cannot hold more than its capacity — and never a
+///   claim about the ROS type, which is why it is not exported, not named in a
+///   header, and not reachable by a user. A `heap` field is the one shape the
+///   storage cannot bound, and the heap arm of the template adds each heap
+///   field's RUNTIME length on top of this figure.
+fn publish_buffer_size(derived: Option<usize>, ffi_fields: &[CppFfiField]) -> usize {
+    derived.unwrap_or_else(|| storage_serialized_size(ffi_fields))
 }
 
 /// Generate the split Rust FFI glue pair for a message-like struct
 /// (phase-306 W1, issue 0253): TYPES half + EXPORTS half.
 fn render_ffi_rs(spec: FfiRenderSpec<'_>) -> Result<GeneratedFfiRs, GeneratorError> {
     let has_fields = !spec.ffi_fields.is_empty();
-    let serialized_size_max = compute_serialized_size_max(spec.ffi_fields);
     let has_heap = spec.ffi_fields.iter().any(|f| f.is_heap);
     let has_heap_string = spec.ffi_fields.iter().any(|f| f.is_heap && f.is_string);
     let has_borrowed = spec.ffi_fields.iter().any(|f| f.is_borrowed);
@@ -305,7 +341,7 @@ fn render_ffi_rs(spec: FfiRenderSpec<'_>) -> Result<GeneratedFfiRs, GeneratorErr
         deserialize_fn: spec.deserialize_fn.to_string(),
         fields: spec.ffi_fields.to_vec(),
         has_fields,
-        serialized_size_max,
+        publish_buffer_size: spec.publish_buffer_size,
         has_heap,
         has_borrowed,
         view_repr_struct_name,
@@ -323,13 +359,40 @@ fn render_ffi_rs(spec: FfiRenderSpec<'_>) -> Result<GeneratedFfiRs, GeneratorErr
     })
 }
 
-/// Generate C++ code for a message type
+/// Generate C++ code for a message type, with no cross-package search path.
+///
+/// A nested type this cannot reach reports `Unresolved`, which is a search-path
+/// problem and not a property of the message (issue 0896) -- so every driver
+/// that HAS an interface index calls
+/// [`generate_cpp_message_package_with_lookup`] instead. This form exists for
+/// tests and for callers with a single self-contained `.msg`.
 pub fn generate_cpp_message_package(
     package_name: &str,
     message_name: &str,
     message: &Message,
     type_hash: &str,
     resolver: &CapacityResolver,
+) -> Result<GeneratedCppPackage, GeneratorError> {
+    generate_cpp_message_package_with_lookup(
+        package_name,
+        message_name,
+        message,
+        type_hash,
+        resolver,
+        &|_| None,
+    )
+}
+
+/// Emit the C++ header + split FFI glue for one message, resolving nested types
+/// through `lookup` so the header can carry the type's DERIVED serialized-size
+/// bound (issue 0964).
+pub fn generate_cpp_message_package_with_lookup(
+    package_name: &str,
+    message_name: &str,
+    message: &Message,
+    type_hash: &str,
+    resolver: &CapacityResolver,
+    lookup: &crate::schema_value::MsgLookup<'_>,
 ) -> Result<GeneratedCppPackage, GeneratorError> {
     let c_pkg_name = to_c_package_name(package_name);
     let msg_snake = to_snake_case(message_name);
@@ -361,7 +424,23 @@ pub fn generate_cpp_message_package(
     let intra_package_includes = extract_intra_package_includes(&message.fields, package_name);
     let has_fields = !cpp_fields.is_empty();
     let has_borrowed = cpp_fields.iter().any(|f| f.is_borrowed);
-    let serialized_size_max = compute_serialized_size_max(&ffi_fields);
+
+    // issue 0964 — the type's own size bound, computed with THE size rule
+    // through the one funnel the C pack uses. `poison_ident` is the C pack's
+    // struct name for the SAME type, deliberately: a type that has no bound gets
+    // one identifier across both languages, so the two headers cannot name the
+    // same hole differently.
+    let poison_ident = format!("{}_msg_{}", c_pkg_name, msg_snake);
+    let fqn = format!("{package_name}/{message_name}");
+    let bound = super::common::derive_header_bound(
+        &fqn,
+        &poison_ident,
+        message,
+        resolver,
+        lookup,
+        resolver.max_serialized(package_name, message_name),
+    )?;
+    let publish_buffer = publish_buffer_size(bound.rx, &ffi_fields);
 
     // Render C++ header
     let header_template = MessageCppHeaderTemplate {
@@ -378,7 +457,9 @@ pub fn generate_cpp_message_package(
         dependencies,
         intra_package_includes,
         has_fields,
-        serialized_size_max,
+        serialized_size_max: bound.rx,
+        unbounded_reason: bound.reason,
+        unbounded_token: bound.token,
         has_borrowed,
         ffi_deserialize_view_fn: format!("{}_borrowed", ffi_deserialize_fn),
     };
@@ -398,6 +479,7 @@ pub fn generate_cpp_message_package(
         deserialize_fn: &deserialize_fn,
         ffi_fields: &ffi_fields,
         seq_structs: &seq_structs,
+        publish_buffer_size: publish_buffer,
     })?;
 
     Ok(GeneratedCppPackage {
@@ -407,13 +489,34 @@ pub fn generate_cpp_message_package(
     })
 }
 
-/// Generate C++ code for a service type
+/// Generate C++ code for a service type, with no cross-package search path.
+/// See [`generate_cpp_message_package`].
 pub fn generate_cpp_service_package(
     package_name: &str,
     service_name: &str,
     service: &Service,
     type_hash: &str,
     resolver: &CapacityResolver,
+) -> Result<GeneratedCppServicePackage, GeneratorError> {
+    generate_cpp_service_package_with_lookup(
+        package_name,
+        service_name,
+        service,
+        type_hash,
+        resolver,
+        &|_| None,
+    )
+}
+
+/// Emit the C++ header + split FFI glue for one service, resolving nested types
+/// through `lookup` so each part can carry its DERIVED bound (issue 0964).
+pub fn generate_cpp_service_package_with_lookup(
+    package_name: &str,
+    service_name: &str,
+    service: &Service,
+    type_hash: &str,
+    resolver: &CapacityResolver,
+    lookup: &crate::schema_value::MsgLookup<'_>,
 ) -> Result<GeneratedCppServicePackage, GeneratorError> {
     let c_pkg_name = to_c_package_name(package_name);
     let srv_snake = to_snake_case(service_name);
@@ -450,7 +553,17 @@ pub fn generate_cpp_service_package(
         resolver,
     )?;
     let req_constants = build_constants(&service.request.constants);
-    let req_serialized_size = compute_serialized_size_max(&req_ffi_fields);
+    // issue 0964 -- each part is bounded on its own, under its own config key
+    // (`[types."pkg/Svc_Request"]`), through the same funnel the C pack uses.
+    let req_bound = super::common::derive_header_bound(
+        &format!("{package_name}/{service_name}_Request"),
+        &format!("{c_pkg_name}_srv_{srv_snake}_request"),
+        &service.request,
+        resolver,
+        lookup,
+        resolver.max_serialized(package_name, &format!("{service_name}_Request")),
+    )?;
+    let req_publish_buffer = publish_buffer_size(req_bound.rx, &req_ffi_fields);
 
     // Response
     let resp_struct = format!("{}_srv_{}_response_t", c_pkg_name, srv_snake);
@@ -477,7 +590,15 @@ pub fn generate_cpp_service_package(
         resolver,
     )?;
     let resp_constants = build_constants(&service.response.constants);
-    let resp_serialized_size = compute_serialized_size_max(&resp_ffi_fields);
+    let resp_bound = super::common::derive_header_bound(
+        &format!("{package_name}/{service_name}_Response"),
+        &format!("{c_pkg_name}_srv_{srv_snake}_response"),
+        &service.response,
+        resolver,
+        lookup,
+        resolver.max_serialized(package_name, &format!("{service_name}_Response")),
+    )?;
+    let resp_publish_buffer = publish_buffer_size(resp_bound.rx, &resp_ffi_fields);
 
     let dependencies = {
         let mut deps = extract_deps(&service.request.fields);
@@ -521,8 +642,12 @@ pub fn generate_cpp_service_package(
         intra_package_includes,
         has_request_fields: !service.request.fields.is_empty(),
         has_response_fields: !service.response.fields.is_empty(),
-        request_serialized_size_max: req_serialized_size,
-        response_serialized_size_max: resp_serialized_size,
+        request_serialized_size_max: req_bound.rx,
+        request_unbounded_reason: req_bound.reason,
+        request_unbounded_token: req_bound.token,
+        response_serialized_size_max: resp_bound.rx,
+        response_unbounded_reason: resp_bound.reason,
+        response_unbounded_token: resp_bound.token,
     };
     let header = crate::render::render("service_cpp.hpp", &header_template)
         .map_err(|e| GeneratorError::RenderError(e.to_string()))?;
@@ -540,6 +665,7 @@ pub fn generate_cpp_service_package(
         deserialize_fn: &req_deser_fn_inner,
         ffi_fields: &req_ffi_fields,
         seq_structs: &req_seq_structs,
+        publish_buffer_size: req_publish_buffer,
     })?;
 
     let response_ffi = render_ffi_rs(FfiRenderSpec {
@@ -554,6 +680,7 @@ pub fn generate_cpp_service_package(
         deserialize_fn: &resp_deser_fn_inner,
         ffi_fields: &resp_ffi_fields,
         seq_structs: &resp_seq_structs,
+        publish_buffer_size: resp_publish_buffer,
     })?;
 
     Ok(GeneratedCppServicePackage {
@@ -564,13 +691,34 @@ pub fn generate_cpp_service_package(
     })
 }
 
-/// Generate C++ code for an action type
+/// Generate C++ code for an action type, with no cross-package search path.
+/// See [`generate_cpp_message_package`].
 pub fn generate_cpp_action_package(
     package_name: &str,
     action_name: &str,
     action: &Action,
     type_hash: &str,
     resolver: &CapacityResolver,
+) -> Result<GeneratedCppActionPackage, GeneratorError> {
+    generate_cpp_action_package_with_lookup(
+        package_name,
+        action_name,
+        action,
+        type_hash,
+        resolver,
+        &|_| None,
+    )
+}
+
+/// Emit the C++ header + split FFI glue for one action, resolving nested types
+/// through `lookup` so each part can carry its DERIVED bound (issue 0964).
+pub fn generate_cpp_action_package_with_lookup(
+    package_name: &str,
+    action_name: &str,
+    action: &Action,
+    type_hash: &str,
+    resolver: &CapacityResolver,
+    lookup: &crate::schema_value::MsgLookup<'_>,
 ) -> Result<GeneratedCppActionPackage, GeneratorError> {
     let c_pkg_name = to_c_package_name(package_name);
     let act_snake = to_snake_case(action_name);
@@ -594,7 +742,10 @@ pub fn generate_cpp_action_package(
         ffi_fields: Vec<CppFfiField>,
         seq_structs: Vec<SequenceStructDef>,
         constants: Vec<CConstant>,
-        size: usize,
+        /// The part's DERIVED bound, `None` when it has none.
+        bound: crate::bounds::HeaderBound,
+        /// Stack bytes the FFI publish export writes into -- NOT a bound.
+        publish_buffer: usize,
     }
 
     let build_part = |part_name: &str, msg: &Message| -> Result<ActionPart, GeneratorError> {
@@ -607,7 +758,19 @@ pub fn generate_cpp_action_package(
             resolver,
         )?;
         let constants = build_constants(&msg.constants);
-        let size = compute_serialized_size_max(&ffi_f);
+        // issue 0964 -- one part, one derivation, the same funnel as the C pack.
+        // `Goal` / `Result` / `Feedback` are the config's own spelling for the
+        // parts, matching the `[fields]` keys `build_fields` resolves against.
+        let cfg_name = format!("{action_name}_{}", capitalize(part_name));
+        let bound = super::common::derive_header_bound(
+            &format!("{package_name}/{cfg_name}"),
+            &format!("{c_pkg_name}_action_{act_snake}_{part_name}"),
+            msg,
+            resolver,
+            lookup,
+            resolver.max_serialized(package_name, &cfg_name),
+        )?;
+        let publish_buffer = publish_buffer_size(bound.rx, &ffi_f);
         Ok(ActionPart {
             publish_fn: format!(
                 "nros_cpp_publish_{}_action_{}_{}",
@@ -634,7 +797,8 @@ pub fn generate_cpp_action_package(
             ffi_fields: ffi_f,
             seq_structs: seq_s,
             constants,
-            size,
+            bound,
+            publish_buffer,
         })
     };
 
@@ -700,9 +864,15 @@ pub fn generate_cpp_action_package(
         has_goal_fields: !action.spec.goal.fields.is_empty(),
         has_result_fields: !action.spec.result.fields.is_empty(),
         has_feedback_fields: !action.spec.feedback.fields.is_empty(),
-        goal_serialized_size_max: goal.size,
-        result_serialized_size_max: result.size,
-        feedback_serialized_size_max: feedback.size,
+        goal_serialized_size_max: goal.bound.rx,
+        goal_unbounded_reason: goal.bound.reason.clone(),
+        goal_unbounded_token: goal.bound.token.clone(),
+        result_serialized_size_max: result.bound.rx,
+        result_unbounded_reason: result.bound.reason.clone(),
+        result_unbounded_token: result.bound.token.clone(),
+        feedback_serialized_size_max: feedback.bound.rx,
+        feedback_unbounded_reason: feedback.bound.reason.clone(),
+        feedback_unbounded_token: feedback.bound.token.clone(),
     };
     let header = crate::render::render("action_cpp.hpp", &header_template)
         .map_err(|e| GeneratorError::RenderError(e.to_string()))?;
@@ -720,6 +890,7 @@ pub fn generate_cpp_action_package(
         deserialize_fn: &goal.deser_fn_inner,
         ffi_fields: &goal.ffi_fields,
         seq_structs: &goal.seq_structs,
+        publish_buffer_size: goal.publish_buffer,
     })?;
 
     let result_ffi = render_ffi_rs(FfiRenderSpec {
@@ -734,6 +905,7 @@ pub fn generate_cpp_action_package(
         deserialize_fn: &result.deser_fn_inner,
         ffi_fields: &result.ffi_fields,
         seq_structs: &result.seq_structs,
+        publish_buffer_size: result.publish_buffer,
     })?;
 
     let feedback_ffi = render_ffi_rs(FfiRenderSpec {
@@ -748,6 +920,7 @@ pub fn generate_cpp_action_package(
         deserialize_fn: &feedback.deser_fn_inner,
         ffi_fields: &feedback.ffi_fields,
         seq_structs: &feedback.seq_structs,
+        publish_buffer_size: feedback.publish_buffer,
     })?;
 
     Ok(GeneratedCppActionPackage {

--- a/packages/cli/rosidl-codegen/src/generator/mod.rs
+++ b/packages/cli/rosidl-codegen/src/generator/mod.rs
@@ -12,7 +12,9 @@ pub use action::{
 pub use common::GeneratorError;
 pub use cpp::{
     GeneratedCppActionPackage, GeneratedCppPackage, GeneratedCppServicePackage, GeneratedFfiRs,
-    generate_cpp_action_package, generate_cpp_message_package, generate_cpp_service_package,
+    generate_cpp_action_package, generate_cpp_action_package_with_lookup,
+    generate_cpp_message_package, generate_cpp_message_package_with_lookup,
+    generate_cpp_service_package, generate_cpp_service_package_with_lookup,
 };
 pub use msg::{
     GeneratedCPackage, GeneratedNrosPackage, GeneratedPackage, generate_c_message_package,

--- a/packages/cli/rosidl-codegen/src/generator/msg.rs
+++ b/packages/cli/rosidl-codegen/src/generator/msg.rs
@@ -447,85 +447,23 @@ pub fn generate_c_message_package_with_lookup(
     //
     // The two encodings are computed separately because they genuinely differ;
     // see `MessageCHeaderTemplate::max_serialized_size_xcdr1`.
+    //
+    // phase-403 W6 / issue 0964 — the derivation, the budget check and the
+    // poison identifiers all live in `common::derive_header_bound`, so this
+    // header, the C++ header and the exported inventory cannot drift into
+    // disagreeing about which encoding feeds which direction, or about what the
+    // hole is called when there is no bound at all.
     let fqn = format!("{package_name}/{message_name}");
-    let (tx_bound, rx_bound, unbounded_reason, unbounded_token) = {
-        use crate::schema_value::{TypeBound, bound_message};
-        use nros_serdes::cdr::EncodingVersion;
-        let x1 = bound_message(&fqn, message, EncodingVersion::Xcdr1, resolver, lookup);
-        let x2 = bound_message(&fqn, message, EncodingVersion::Xcdr2, resolver, lookup);
-        // phase-403 W7b (issue 0961) — a stated `max_serialized` budget is
-        // checked HERE, against the same classification the header's constants
-        // come from, so the number in the diagnostic is the number in the
-        // `#define`. A type with no budget is untouched: `check_budget` returns
-        // `Ok` and nothing about the derivation changes.
-        crate::bounds::check_budget(
-            &fqn,
-            &crate::bounds::BoundState::classify(&x1, &x2),
-            &crate::schema_value::chains_for(&fqn, message, resolver, lookup),
-            resolver.max_serialized(package_name, message_name),
-        )
-        .map_err(|e| GeneratorError::BoundExceedsBudget {
-            details: e.to_string(),
-        })?;
-        // issue 0896 Q2 — the compiler error must name the TYPE and the FIELD,
-        // not just say "no bound". A C identifier cannot hold `.` or `(`, so
-        // the path is flattened; the prose reason sits above it in the header
-        // for the parts an identifier cannot carry.
-        let token = |what: &str| {
-            let ident: String = what
-                .split(" (")
-                .next()
-                .unwrap_or(what)
-                .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-                .collect();
-            format!("NROS_UNBOUNDED__{struct_name}__field_{ident}")
-        };
-        let unresolved_token = |t: &str| {
-            let ident: String = t
-                .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-                .collect();
-            format!("NROS_UNRESOLVED__{struct_name}__nested_type_{ident}")
-        };
-        // phase-403 W6 — the TX/RX classification lives in `bounds::BoundState`
-        // so this header and the exported inventory cannot drift into
-        // disagreeing about which encoding feeds which direction. The poison
-        // TOKENS stay here: they are C identifiers, which only this emitter
-        // needs.
-        //
-        // Unbounded and Unresolved BOTH mean "no constant", and the reason says
-        // which — "we looked and there is no bound" licenses bounding the field,
-        // "we could not look" licenses fixing the search path. Collapsing them
-        // into one message is the confusion issue 0896 is about.
-        match crate::bounds::BoundState::classify(&x1, &x2) {
-            // TX writes XCDR1; RX must hold either encoding, so it takes the max.
-            crate::bounds::BoundState::Bounded { tx, rx } => (Some(tx), Some(rx), None, None),
-            crate::bounds::BoundState::Unbounded { reason } => {
-                // The prose reason names EVERY offending member (phase-403 W0);
-                // the poison TOKEN can only name one, because it is a C
-                // identifier. The FIRST is the one it names, matching the order
-                // the reason lists them in, so the identifier the compiler
-                // prints is the first line of the reason above it.
-                let members = match (&x1, &x2) {
-                    (TypeBound::Unbounded(w), _) | (_, TypeBound::Unbounded(w)) => w.clone(),
-                    _ => unreachable!("classify only reports Unbounded from an Unbounded input"),
-                };
-                let first = members
-                    .first()
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                (None, None, Some(reason), Some(token(&first)))
-            }
-            crate::bounds::BoundState::Unresolved { reason } => {
-                let nested = match (&x1, &x2) {
-                    (TypeBound::Unresolved(t), _) | (_, TypeBound::Unresolved(t)) => t.clone(),
-                    _ => unreachable!("classify only reports Unresolved from an Unresolved input"),
-                };
-                (None, None, Some(reason), Some(unresolved_token(&nested)))
-            }
-        }
-    };
+    let bound = super::common::derive_header_bound(
+        &fqn,
+        &struct_name,
+        message,
+        resolver,
+        lookup,
+        resolver.max_serialized(package_name, message_name),
+    )?;
+    let (tx_bound, rx_bound, unbounded_reason, unbounded_token) =
+        (bound.tx, bound.rx, bound.reason, bound.token);
 
     // Generate header
     let header_template = MessageCHeaderTemplate {

--- a/packages/cli/rosidl-codegen/src/lib.rs
+++ b/packages/cli/rosidl-codegen/src/lib.rs
@@ -36,20 +36,23 @@ pub use generator::{
     GeneratedNrosActionPackage, GeneratedNrosPackage, GeneratedNrosServicePackage,
     GeneratedPackage, GeneratedServicePackage, GeneratorError, generate_action_package,
     generate_c_action_package, generate_c_message_package, generate_c_message_package_with_lookup,
-    generate_c_service_package, generate_cpp_action_package, generate_cpp_message_package,
-    generate_cpp_service_package, generate_message_package, generate_nros_action_package,
-    generate_nros_inline_action, generate_nros_inline_message, generate_nros_inline_service,
-    generate_nros_message_package, generate_nros_service_package, generate_service_package,
+    generate_c_service_package, generate_cpp_action_package,
+    generate_cpp_action_package_with_lookup, generate_cpp_message_package,
+    generate_cpp_message_package_with_lookup, generate_cpp_service_package,
+    generate_cpp_service_package_with_lookup, generate_message_package,
+    generate_nros_action_package, generate_nros_inline_action, generate_nros_inline_message,
+    generate_nros_inline_service, generate_nros_message_package, generate_nros_service_package,
+    generate_service_package,
 };
 pub use idl_generator::{GeneratedIdlCode, extract_annotations, generate_idl_file};
 pub use types::{
     C_DEFAULT_SEQUENCE_CAPACITY, C_DEFAULT_STRING_CAPACITY, CPP_DEFAULT_SEQUENCE_CAPACITY,
     CPP_DEFAULT_STRING_CAPACITY, CodegenBackend, FieldTypeExt, IdlTypeExt,
     NROS_DEFAULT_SEQUENCE_CAPACITY, NROS_DEFAULT_STRING_CAPACITY, NrosCodegenMode, RosEdition,
-    c_array_suffix_for_field, c_type_for_constant, c_type_for_field, compute_serialized_size_max,
-    cpp_type_for_field, escape_keyword, idl_constant_value_to_rust, nros_type_for_constant,
-    nros_type_for_field, nros_type_for_field_with_mode, repr_c_type_for_field, rust_type_for_field,
-    rust_type_for_idl, rust_type_for_idl_constant, to_c_package_name,
+    c_array_suffix_for_field, c_type_for_constant, c_type_for_field, cpp_type_for_field,
+    escape_keyword, idl_constant_value_to_rust, nros_type_for_constant, nros_type_for_field,
+    nros_type_for_field_with_mode, repr_c_type_for_field, rust_type_for_field, rust_type_for_idl,
+    rust_type_for_idl_constant, storage_serialized_size, to_c_package_name,
 };
 
 #[cfg(test)]

--- a/packages/cli/rosidl-codegen/src/render.rs
+++ b/packages/cli/rosidl-codegen/src/render.rs
@@ -140,6 +140,7 @@ const PACKS: &[(&str, &str)] = &[
         include_str!("../packs/rust/action.rs.jinja"),
     ),
     // C++ pack (packs/cpp)
+    ("_bound.jinja", include_str!("../packs/cpp/_bound.jinja")),
     (
         "message_cpp.hpp",
         include_str!("../packs/cpp/message.hpp.jinja"),

--- a/packages/cli/rosidl-codegen/src/templates.rs
+++ b/packages/cli/rosidl-codegen/src/templates.rs
@@ -744,7 +744,27 @@ pub struct MessageCppHeaderTemplate<'a> {
     /// Same-package type includes (relative paths like "msg/pkg_msg_foo.hpp")
     pub intra_package_includes: Vec<String>,
     pub has_fields: bool,
-    pub serialized_size_max: usize,
+    /// issue 0964 -- the type's DERIVED serialized-size bound,
+    /// `max(XCDR1, XCDR2)`, from `nros_serdes::size::max_serialized_size`.
+    ///
+    /// ONE number serves both directions here: the C++ `SERIALIZED_SIZE_MAX` is
+    /// spent on publish buffers AND on receive buffers, and the RX figure covers
+    /// TX because it is the max of the two encodings.
+    ///
+    /// `None` when the type has NO bound, or when one could not be computed. The
+    /// header then declares the constant with an INCOMPLETE poison type instead
+    /// of stating a size -- see `unbounded_token`.
+    pub serialized_size_max: Option<usize>,
+    /// Prose naming EVERY member that costs the bound (or the nested type that
+    /// could not be resolved). `Some` exactly when `serialized_size_max` is
+    /// `None`.
+    pub unbounded_reason: Option<String>,
+    /// The same fact as a C++ identifier. `SERIALIZED_SIZE_MAX` is declared as a
+    /// static member of this INCOMPLETE struct type, so including the header
+    /// costs nothing and NAMING the constant is a compile error that prints the
+    /// token -- which carries the type and the offending member. The C pack's
+    /// `#define` poison, in the form C++ can express.
+    pub unbounded_token: Option<String>,
     /// RFC-0033 borrowed (Phase 235): emit `{Msg}View` + `deserialize_view`
     /// + `<nros/span.hpp>` when any field is `mode = "view"`.
     pub has_borrowed: bool,
@@ -801,7 +821,14 @@ pub struct MessageCppExportsTemplate<'a> {
     /// Heap publish-path sizing reads the heap fields' runtime lengths.
     pub fields: Vec<CppFfiField>,
     pub has_fields: bool,
-    pub serialized_size_max: usize,
+    /// Stack bytes the `nros_cpp_publish_*` export writes its CDR into.
+    ///
+    /// issue 0964 -- NOT a bound and never emitted as one. It is the type's
+    /// derived bound where one exists, and the generated struct's own fixed
+    /// STORAGE size where it does not, because a buffer inside generated glue
+    /// still needs a number when the ROS type has none. See
+    /// `generator::cpp::publish_buffer_size`.
+    pub publish_buffer_size: usize,
     /// RFC-0033: gates the heap publish-buffer path.
     pub has_heap: bool,
     /// RFC-0033 borrowed (Phase 235): emit the `{Msg}_ffi_deserialize_view`
@@ -836,8 +863,14 @@ pub struct ServiceCppHeaderTemplate<'a> {
     pub intra_package_includes: Vec<String>,
     pub has_request_fields: bool,
     pub has_response_fields: bool,
-    pub request_serialized_size_max: usize,
-    pub response_serialized_size_max: usize,
+    /// See [`MessageCppHeaderTemplate::serialized_size_max`]; per part, because
+    /// a service can have a bounded request and an unbounded response.
+    pub request_serialized_size_max: Option<usize>,
+    pub request_unbounded_reason: Option<String>,
+    pub request_unbounded_token: Option<String>,
+    pub response_serialized_size_max: Option<usize>,
+    pub response_unbounded_reason: Option<String>,
+    pub response_unbounded_token: Option<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -867,7 +900,15 @@ pub struct ActionCppHeaderTemplate<'a> {
     pub has_goal_fields: bool,
     pub has_result_fields: bool,
     pub has_feedback_fields: bool,
-    pub goal_serialized_size_max: usize,
-    pub result_serialized_size_max: usize,
-    pub feedback_serialized_size_max: usize,
+    /// See [`MessageCppHeaderTemplate::serialized_size_max`]; per part, because
+    /// an action routinely has a bounded goal and an unbounded result.
+    pub goal_serialized_size_max: Option<usize>,
+    pub goal_unbounded_reason: Option<String>,
+    pub goal_unbounded_token: Option<String>,
+    pub result_serialized_size_max: Option<usize>,
+    pub result_unbounded_reason: Option<String>,
+    pub result_unbounded_token: Option<String>,
+    pub feedback_serialized_size_max: Option<usize>,
+    pub feedback_unbounded_reason: Option<String>,
+    pub feedback_unbounded_token: Option<String>,
 }

--- a/packages/cli/rosidl-codegen/src/types.rs
+++ b/packages/cli/rosidl-codegen/src/types.rs
@@ -1671,15 +1671,27 @@ pub fn cpp_array_suffix_for_field(field_type: &FieldType) -> String {
     }
 }
 
-/// Compute the maximum serialized CDR size for a set of C++ FFI fields.
+/// Size a stack buffer from the generated C++ struct's own FIXED STORAGE.
 ///
-/// Uses conservative estimates:
+/// **This is NOT a serialized-size bound and must never be emitted as one.**
+/// issue 0964: it used to be, as the C++ header's `SERIALIZED_SIZE_MAX`, and
+/// over 126 types in 12 stock ROS Humble packages it matched the derived bound
+/// ZERO times while stating a number for all 86 types that have no bound at all.
+/// The bound is `nros_serdes::size::max_serialized_size`, reached through
+/// [`crate::schema_value::bound_message`] -- THE size rule, the one the Rust
+/// `M::MAX_SERIALIZED_SIZE_XCDR*` const and the exported inventory both use.
+///
+/// The one remaining caller is the FFI publish glue's stack buffer for a type
+/// that HAS no bound (`generator::cpp::publish_buffer_size`), where the question
+/// really is "how much can this struct's inline storage produce" and not "what
+/// does this ROS type bound to". It stays an approximation:
 /// - Primitives: type size + up to 7 bytes alignment padding
 /// - Strings: 4 (length) + capacity + 1 (null) + 3 (alignment)
-/// - Arrays: element_count × element_size (with alignment)
-/// - Sequences: 4 (length) + capacity × element_size (with alignment)
-/// - Nested: uses a fixed estimate (512 bytes per nested type)
-pub fn compute_serialized_size_max(fields: &[super::templates::CppFfiField]) -> usize {
+/// - Arrays: element_count x element_size (with alignment)
+/// - Sequences: 4 (length) + capacity x element_size (with alignment)
+/// - Nested: a FLAT 512 bytes per nested type, which is why it can UNDER-count
+///   and why it is not allowed anywhere a bound is claimed.
+pub fn storage_serialized_size(fields: &[super::templates::CppFfiField]) -> usize {
     let mut size = 4; // CDR header
 
     for field in fields {

--- a/packages/cli/rosidl-codegen/tests/cpp_bound_compile_check.rs
+++ b/packages/cli/rosidl-codegen/tests/cpp_bound_compile_check.rs
@@ -1,0 +1,162 @@
+//! issue 0964 — what the C++ pack's `SERIALIZED_SIZE_MAX` does, checked against
+//! a real compiler rather than against the header text.
+//!
+//! The C pack poisons an unbounded type's size constant with a `#define` whose
+//! body is an undeclared identifier: costless to include, a compile error to
+//! NAME. C++ cannot express that shape — a `static constexpr size_t X = TOKEN;`
+//! is an error at the point of DEFINITION, so every consumer of the header would
+//! break rather than only the consumers that ask for a size.
+//!
+//! The C++ form is a static data member of an INCOMPLETE type. `[class.static.
+//! data]` allows a non-defining static-member declaration to have incomplete
+//! type, so:
+//!
+//!   * including the header, declaring the message, and reading its fields all
+//!     compile clean, even under `-Wall -Wextra -Werror`;
+//!   * `M::SERIALIZED_SIZE_MAX` in an array bound or a `size_t` context is an
+//!     error naming the incomplete type — which carries the message AND the
+//!     member that costs it the bound.
+//!
+//! That claim is only worth anything if a compiler agrees, hence this file. Both
+//! halves are asserted, because either one alone passes for the wrong reason: a
+//! header that never compiles "poisons" everything, and a header that compiles
+//! but poisons nothing states a size again.
+//!
+//! Ignored by default (spawns g++); run with:
+//!
+//!     cargo test -p rosidl-codegen --test cpp_bound_compile_check -- --ignored
+//!
+//! and it is on the `just test-ignored` lane.
+
+use rosidl_codegen::{CapacityResolver, generate_cpp_message_package};
+use rosidl_parser::parse_message;
+use std::{fs, path::PathBuf, process::Command};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Write the generated header plus a stub `nros/platform.h` (the real one needs
+/// per-build config) into a temp dir and hand back the include roots.
+fn stage(header: &str, header_name: &str, probe: &str) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("nros")).unwrap();
+    fs::write(
+        dir.path().join("nros/platform.h"),
+        "#ifndef PSTUB\n#define PSTUB\n#include <cstddef>\n\
+         extern \"C\" void* nros_platform_malloc(size_t);\n\
+         extern \"C\" void nros_platform_free(void*);\n#endif\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join(header_name), header).unwrap();
+    let probe_path = dir.path().join("probe.cpp");
+    fs::write(&probe_path, probe).unwrap();
+    (dir, probe_path)
+}
+
+fn compile(dir: &tempfile::TempDir, probe: &PathBuf, strict: bool) -> std::process::Output {
+    let inc = repo_root().join("packages/api/nros-cpp/include");
+    let mut cmd = Command::new("g++");
+    cmd.args([
+        "-std=c++14",
+        "-fno-exceptions",
+        "-fno-rtti",
+        "-fsyntax-only",
+    ]);
+    if strict {
+        cmd.args(["-Wall", "-Wextra", "-Werror"]);
+    }
+    cmd.arg("-I")
+        .arg(&inc)
+        .arg("-I")
+        .arg(dir.path())
+        .arg(probe)
+        .output()
+        .expect("spawn g++")
+}
+
+/// A BOUNDED type states its derived bound, and the constant is usable where a
+/// size is required — an array bound, which is the shape every consumer of it
+/// uses (`uint8_t buf[M::SERIALIZED_SIZE_MAX]`).
+#[test]
+#[ignore = "spawns g++"]
+fn a_bounded_type_states_a_usable_constant() {
+    let msg = parse_message("int32 data\n").unwrap();
+    let pkg =
+        generate_cpp_message_package("std_msgs", "Int32", &msg, "h", &CapacityResolver::empty())
+            .unwrap();
+    assert!(
+        pkg.header.contains("SERIALIZED_SIZE_MAX = 12;"),
+        "expected the derived bound (12 = max of the two encodings):\n{}",
+        pkg.header
+    );
+    let (dir, probe) = stage(
+        &pkg.header,
+        "std_msgs_msg_int32.hpp",
+        "#include \"std_msgs_msg_int32.hpp\"\n\
+         static_assert(std_msgs::msg::Int32::SERIALIZED_SIZE_MAX == 12, \"\");\n\
+         int f() { unsigned char b[std_msgs::msg::Int32::SERIALIZED_SIZE_MAX]; return (int)sizeof(b); }\n",
+    );
+    let out = compile(&dir, &probe, true);
+    assert!(
+        out.status.success(),
+        "a bounded type's header must compile and its constant must be usable:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// An UNBOUNDED type states NO size. Two halves, both required:
+/// the header is clean to include and use, and NAMING the constant is an error
+/// that prints the poison identifier.
+#[test]
+#[ignore = "spawns g++"]
+fn an_unbounded_type_costs_nothing_to_include_and_poisons_only_on_use() {
+    let msg = parse_message("string data\n").unwrap();
+    let pkg =
+        generate_cpp_message_package("std_msgs", "String", &msg, "h", &CapacityResolver::empty())
+            .unwrap();
+    assert!(
+        !pkg.header.contains("SERIALIZED_SIZE_MAX = "),
+        "an unbounded type must state no size:\n{}",
+        pkg.header
+    );
+
+    // Half 1 — include, declare, read a field. Clean, under -Werror.
+    let (dir, probe) = stage(
+        &pkg.header,
+        "std_msgs_msg_string.hpp",
+        "#include \"std_msgs_msg_string.hpp\"\n\
+         static std_msgs::msg::String g;\n\
+         int f() { return (int)g.data.length(); }\n",
+    );
+    let out = compile(&dir, &probe, true);
+    assert!(
+        out.status.success(),
+        "an unbounded type's header must still be free to include and use:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Half 2 — naming the constant is an error, and the error names the type
+    // AND the member. Not `-Werror`: this must fail as an ERROR, not a warning.
+    let (dir, probe) = stage(
+        &pkg.header,
+        "std_msgs_msg_string.hpp",
+        "#include \"std_msgs_msg_string.hpp\"\n\
+         int f() { unsigned char b[std_msgs::msg::String::SERIALIZED_SIZE_MAX]; return (int)sizeof(b); }\n",
+    );
+    let out = compile(&dir, &probe, false);
+    assert!(
+        !out.status.success(),
+        "naming an unbounded type's size constant must be a compile error"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NROS_UNBOUNDED__std_msgs_msg_string__field_data"),
+        "the diagnostic must name the type and the member that costs the bound, \
+         not just report a missing member:\n{stderr}"
+    );
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
@@ -37,7 +37,17 @@ struct Bounded {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Bounded_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 1170;
+
+    /// Largest CDR payload this type can produce or consume, encapsulation
+    /// header included. Derived by `nros_serdes::size::max_serialized_size`
+    /// over this type's own schema -- THE size rule, not a copy of it -- so
+    /// it cannot disagree with the Rust `MAX_SERIALIZED_SIZE_XCDR*` const
+    /// or the exported bound inventory for the same type (issue 0964).
+    ///
+    /// `max(XCDR1, XCDR2)`: this stack WRITES XCDR1, but data_representation
+    /// is negotiable and a non-default peer may send XCDR2, so one constant
+    /// serving both a publish buffer and a receive buffer must hold either.
+    static constexpr size_t SERIALIZED_SIZE_MAX = 133;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
@@ -33,7 +33,17 @@ struct Capped {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Capped_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 1190;
+
+    /// Largest CDR payload this type can produce or consume, encapsulation
+    /// header included. Derived by `nros_serdes::size::max_serialized_size`
+    /// over this type's own schema -- THE size rule, not a copy of it -- so
+    /// it cannot disagree with the Rust `MAX_SERIALIZED_SIZE_XCDR*` const
+    /// or the exported bound inventory for the same type (issue 0964).
+    ///
+    /// `max(XCDR1, XCDR2)`: this stack WRITES XCDR1, but data_representation
+    /// is negotiable and a non-default peer may send XCDR2, so one constant
+    /// serving both a publish buffer and a receive buffer must hold either.
+    static constexpr size_t SERIALIZED_SIZE_MAX = 157;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.hpp
@@ -25,6 +25,14 @@ int nros_cpp_deserialize_fingerprint_corpus_msg_nested(const uint8_t* data, size
 
 namespace fingerprint_corpus { namespace msg {
 
+/// NO size bound exists for this type.
+///
+/// Reason: nested type `fingerprint-corpus/Shapes` could not be resolved
+///
+/// Naming `SERIALIZED_SIZE_MAX` below is therefore a deliberate compile error,
+/// and this incomplete type is what the compiler prints when you do.
+struct NROS_UNRESOLVED__fingerprint_corpus_msg_nested__nested_type_fingerprint_corpus_Shapes;
+
 /// Nested message structure (repr(C) compatible)
 struct Nested {
     fingerprint-corpus::msg::Shapes one = {};
@@ -33,7 +41,20 @@ struct Nested {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Nested_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 33288;
+
+    /// This type has NO size bound, so there is no number to state.
+    ///
+    /// Reason: nested type `fingerprint-corpus/Shapes` could not be resolved
+    ///
+    /// Bound the field in the `.msg` (`string<=64`), or give it an
+    /// INLINE `cap` in `nros-codegen.toml` (`[fields]` / `[types]` /
+    /// `[packages]` / `[defaults]`). A `heap` or `view` cap is a sizing hint
+    /// nothing enforces (RFC-0033), so it deliberately does not bound. EVERY
+    /// offending member is named in the reason above, so one build names
+    /// everything there is to fix. "could not be resolved" instead means the
+    /// bound was NOT computed because a nested type was unreachable -- a
+    /// search-path problem, not a property of the message.
+    static const NROS_UNRESOLVED__fingerprint_corpus_msg_nested__nested_type_fingerprint_corpus_Shapes SERIALIZED_SIZE_MAX;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.hpp
@@ -26,6 +26,14 @@ int nros_cpp_deserialize_fingerprint_corpus_msg_shapes_borrowed(const uint8_t* d
 
 namespace fingerprint_corpus { namespace msg {
 
+/// NO size bound exists for this type.
+///
+/// Reason: unbounded members: text (string), seq_prim (sequence<T>), seq_string (sequence<T>)
+///
+/// Naming `SERIALIZED_SIZE_MAX` below is therefore a deliberate compile error,
+/// and this incomplete type is what the compiler prints when you do.
+struct NROS_UNBOUNDED__fingerprint_corpus_msg_shapes__field_text;
+
 /// Shapes message structure (repr(C) compatible)
 struct Shapes {
     bool flag = {};
@@ -49,7 +57,20 @@ struct Shapes {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Shapes_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 18137;
+
+    /// This type has NO size bound, so there is no number to state.
+    ///
+    /// Reason: unbounded members: text (string), seq_prim (sequence<T>), seq_string (sequence<T>)
+    ///
+    /// Bound the field in the `.msg` (`string<=64`), or give it an
+    /// INLINE `cap` in `nros-codegen.toml` (`[fields]` / `[types]` /
+    /// `[packages]` / `[defaults]`). A `heap` or `view` cap is a sizing hint
+    /// nothing enforces (RFC-0033), so it deliberately does not bound. EVERY
+    /// offending member is named in the reason above, so one build names
+    /// everything there is to fix. "could not be resolved" instead means the
+    /// bound was NOT computed because a nested type was unreachable -- a
+    /// search-path problem, not a property of the message.
+    static const NROS_UNBOUNDED__fingerprint_corpus_msg_shapes__field_text SERIALIZED_SIZE_MAX;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
@@ -37,7 +37,17 @@ struct Bounded {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Bounded_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 1170;
+
+    /// Largest CDR payload this type can produce or consume, encapsulation
+    /// header included. Derived by `nros_serdes::size::max_serialized_size`
+    /// over this type's own schema -- THE size rule, not a copy of it -- so
+    /// it cannot disagree with the Rust `MAX_SERIALIZED_SIZE_XCDR*` const
+    /// or the exported bound inventory for the same type (issue 0964).
+    ///
+    /// `max(XCDR1, XCDR2)`: this stack WRITES XCDR1, but data_representation
+    /// is negotiable and a non-default peer may send XCDR2, so one constant
+    /// serving both a publish buffer and a receive buffer must hold either.
+    static constexpr size_t SERIALIZED_SIZE_MAX = 133;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.hpp
@@ -24,6 +24,14 @@ int nros_cpp_deserialize_fingerprint_corpus_msg_capped(const uint8_t* data, size
 
 namespace fingerprint_corpus { namespace msg {
 
+/// NO size bound exists for this type.
+///
+/// Reason: unbounded members: label (string), samples (sequence<T>), tags (sequence<T>)
+///
+/// Naming `SERIALIZED_SIZE_MAX` below is therefore a deliberate compile error,
+/// and this incomplete type is what the compiler prints when you do.
+struct NROS_UNBOUNDED__fingerprint_corpus_msg_capped__field_label;
+
 /// Capped message structure (repr(C) compatible)
 struct Capped {
     nros::FixedString<256> label = {};
@@ -33,7 +41,20 @@ struct Capped {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Capped_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 18132;
+
+    /// This type has NO size bound, so there is no number to state.
+    ///
+    /// Reason: unbounded members: label (string), samples (sequence<T>), tags (sequence<T>)
+    ///
+    /// Bound the field in the `.msg` (`string<=64`), or give it an
+    /// INLINE `cap` in `nros-codegen.toml` (`[fields]` / `[types]` /
+    /// `[packages]` / `[defaults]`). A `heap` or `view` cap is a sizing hint
+    /// nothing enforces (RFC-0033), so it deliberately does not bound. EVERY
+    /// offending member is named in the reason above, so one build names
+    /// everything there is to fix. "could not be resolved" instead means the
+    /// bound was NOT computed because a nested type was unreachable -- a
+    /// search-path problem, not a property of the message.
+    static const NROS_UNBOUNDED__fingerprint_corpus_msg_capped__field_label SERIALIZED_SIZE_MAX;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.hpp
@@ -25,6 +25,14 @@ int nros_cpp_deserialize_fingerprint_corpus_msg_nested(const uint8_t* data, size
 
 namespace fingerprint_corpus { namespace msg {
 
+/// NO size bound exists for this type.
+///
+/// Reason: nested type `fingerprint-corpus/Shapes` could not be resolved
+///
+/// Naming `SERIALIZED_SIZE_MAX` below is therefore a deliberate compile error,
+/// and this incomplete type is what the compiler prints when you do.
+struct NROS_UNRESOLVED__fingerprint_corpus_msg_nested__nested_type_fingerprint_corpus_Shapes;
+
 /// Nested message structure (repr(C) compatible)
 struct Nested {
     fingerprint-corpus::msg::Shapes one = {};
@@ -33,7 +41,20 @@ struct Nested {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Nested_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 33288;
+
+    /// This type has NO size bound, so there is no number to state.
+    ///
+    /// Reason: nested type `fingerprint-corpus/Shapes` could not be resolved
+    ///
+    /// Bound the field in the `.msg` (`string<=64`), or give it an
+    /// INLINE `cap` in `nros-codegen.toml` (`[fields]` / `[types]` /
+    /// `[packages]` / `[defaults]`). A `heap` or `view` cap is a sizing hint
+    /// nothing enforces (RFC-0033), so it deliberately does not bound. EVERY
+    /// offending member is named in the reason above, so one build names
+    /// everything there is to fix. "could not be resolved" instead means the
+    /// bound was NOT computed because a nested type was unreachable -- a
+    /// search-path problem, not a property of the message.
+    static const NROS_UNRESOLVED__fingerprint_corpus_msg_nested__nested_type_fingerprint_corpus_Shapes SERIALIZED_SIZE_MAX;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.hpp
@@ -24,6 +24,14 @@ int nros_cpp_deserialize_fingerprint_corpus_msg_shapes(const uint8_t* data, size
 
 namespace fingerprint_corpus { namespace msg {
 
+/// NO size bound exists for this type.
+///
+/// Reason: unbounded members: text (string), seq_prim (sequence<T>), seq_string (sequence<T>)
+///
+/// Naming `SERIALIZED_SIZE_MAX` below is therefore a deliberate compile error,
+/// and this incomplete type is what the compiler prints when you do.
+struct NROS_UNBOUNDED__fingerprint_corpus_msg_shapes__field_text;
+
 /// Shapes message structure (repr(C) compatible)
 struct Shapes {
     bool flag = {};
@@ -47,7 +55,20 @@ struct Shapes {
     // Type metadata
     static constexpr const char* TYPE_NAME = "fingerprint-corpus::msg::dds_::Shapes_";
     static constexpr const char* TYPE_HASH = "h";
-    static constexpr size_t SERIALIZED_SIZE_MAX = 18361;
+
+    /// This type has NO size bound, so there is no number to state.
+    ///
+    /// Reason: unbounded members: text (string), seq_prim (sequence<T>), seq_string (sequence<T>)
+    ///
+    /// Bound the field in the `.msg` (`string<=64`), or give it an
+    /// INLINE `cap` in `nros-codegen.toml` (`[fields]` / `[types]` /
+    /// `[packages]` / `[defaults]`). A `heap` or `view` cap is a sizing hint
+    /// nothing enforces (RFC-0033), so it deliberately does not bound. EVERY
+    /// offending member is named in the reason above, so one build names
+    /// everything there is to fix. "could not be resolved" instead means the
+    /// bound was NOT computed because a nested type was unreachable -- a
+    /// search-path problem, not a property of the message.
+    static const NROS_UNBOUNDED__fingerprint_corpus_msg_shapes__field_text SERIALIZED_SIZE_MAX;
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {


### PR DESCRIPTION
Fixes #964.

## The problem

The C++ pack computed `SERIALIZED_SIZE_MAX` with an *estimator*: a flat 512 per
nested message, a flat default capacity per string, and it ALWAYS returned a
value, so it could never say "unbounded".

Measured over 126 types in 12 stock ROS Humble packages:

* 86 have no derived bound, and the header stated a size for every one of them.
* Across the 40 that ARE bounded, the estimate matched the derived bound
  **zero times**.

So one type carried two numbers. phase-403 W6 exports the derived bound on three
transports while the header went on advertising the estimate, and the estimate is
the one a user reads, because it is what the constant is named.

It also breaks phase-380's rule head-on: a number nobody chose, substituted where
the honest answer is "no bound exists". That rule is why an unbounded type is a
build error at all, and this path opted out of it silently.

The cost was not hypothetical. The island's receive buffer, arena and payload
classes were budgeted for `Control` at 2052 bytes when it serializes to 114.

## What changed

`SERIALIZED_SIZE_MAX` is now `nros_serdes::size::max_serialized_size` -- for
messages, service request/response and action goal/result/feedback alike -- and a
type with no bound states no size.

The C pack already did this. The two packs now derive it through ONE funnel
(`generator::common::derive_header_bound` -> `bounds::header_bound`), which also
owns the budget check and the poison identifiers, so the two headers and the
exported inventory cannot drift into disagreeing about whether a bound exists,
what it is, or what the hole is called when there is none.

The poison has a different SHAPE in C++, because C++ cannot express the C one. A
`#define X <undeclared identifier>` costs nothing to include and errors when
NAMED; a `static constexpr size_t X = TOKEN;` errors at the point of DEFINITION,
which would break every consumer of the header rather than only the ones asking
for a size. The C++ form is a static data member of an INCOMPLETE type
([class.static.data] permits a non-defining static-member declaration to have
incomplete type), which keeps both properties, and the diagnostic prints the
identifier, so it names the type and the member that costs it the bound.

Both halves are compiler-checked, not asserted in prose:
`tests/cpp_bound_compile_check.rs` compiles the generated header under
`-Wall -Wextra -Werror`, then compiles a use of the constant and greps the error
for the token. g++ and clang++ both name it.

The estimator survives for exactly one job and is renamed to say so.
`types::storage_serialized_size` sizes the FFI publish glue's stack buffer for a
type that has NO bound -- a question about the generated struct's fixed inline
storage, not about the ROS type -- and it is emitted into no header, exported on
no transport, and reachable by no user. A BOUNDED type's publish buffer is now
the derived number, so the flat-512 under-count is gone wherever a bound exists.

The C++ drivers also gained the cross-package nested lookup the C drivers got in
W6, so a C++ type that nests across packages reports a real bound instead of
`Unresolved`.

## Second commit: the two consumed types

The first commit makes an example that names `SERIALIZED_SIZE_MAX` for an
unbounded type stop compiling. Two types are affected, across 21 call sites in
15 files:

| type | reached via |
| --- | --- |
| `std_msgs/String` | `Subscription<M>::try_recv` |
| `example_interfaces/Fibonacci` Result + Feedback | `get_result`, `Stream::try_next`, `publish_feedback`, `complete_goal` |

Both are CONSUMED, not defined here, so there is no `.msg` to bound and a cap in
`nros-codegen.toml` is the only remedy. That remedy only became reachable when
`nros_find_interfaces` and `_nros_generate_declared_interfaces` learned to
forward `CODEGEN_CONFIG` (#152, merged) -- before that, a consuming package could
not bound a stock type at all.

## Measured, before -> after

C++ header:

| type | before | after |
| --- | ---: | ---: |
| `autoware_control_msgs/Control` | 2052 | 114 |
| `autoware_vehicle_msgs/SteeringReport` | 527 | 24 |
| `autoware_adapi_v1_msgs/OperationModeState` | 572 | 27 |
| `nav_msgs/Odometry` | 1804 | none (unbounded) |
| `nav_msgs/Odometry`, both `frame_id` fields capped at 64 | 1612 | 880 |

12-package stock corpus: 126 types stating a size -> 40, and all 40 now equal the
derived bound (0 of 40 did before). The other 86 state none.

Verified end to end on `examples/native/cpp/listener`: it builds, and the
generated `std_msgs/msg/String` header states

    static constexpr size_t SERIALIZED_SIZE_MAX = 269;

which is the 256-byte cap plus CDR framing. The cap set the BOUND, not just the
storage container. I checked the value rather than the exit code, because a cap
keyed on a name that does not exist does nothing and says nothing.

## Goldens

The eight fingerprint-corpus `.hpp` files moved, deliberately. Nothing else did:
the C `.h` goldens are byte-identical, which is the point, and the C++ ones now
agree with them type for type. Regenerate with
`NROS_UPDATE_GOLDEN=1 cargo test -p rosidl-codegen --test codegen_golden`.

## Gate status

Rebased onto `main` at 97dc38946, clean. Three gates are red on this branch and
all three are red on untouched `main`, verified by running them in a worktree at
that same commit:

* `fixtures-manifest` and `kconfig-overridden-values` -- both `nros: command not
  found`. Green once the CLI is on PATH.
* `cli-tests` / `a_missing_framework_names_how_to_supply_it` -- fails identically
  on `main`.

Note that `cli-tests` is inside `check::build`, and a red step withdraws every
step after it, so a bare `just ci l1` on this branch never reaches the C++
compile. Run `just build-examples` with `NANO_ROS_ROOT` pinned to the checkout to
get that coverage.
