### PR TITLE
feat(phase-403): a payload class is about what the image RECEIVES, not what it links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,16 @@
 # --- nros-node (Rust API) ---
 
 # Max executor callback slots — controls static array size at compile time (default: 4)
+#
+# It counts HANDLES, not callbacks, and a PUBLISHER IS NOT ONE: every
+# registration that claims a slot calls Executor::next_entry_slot(), and
+# create_publisher does not. Subscriptions, timers, service servers, service
+# clients, action servers/clients and guard conditions do.
+#
+# phase-403 W9 (issue 0965): on Zephyr this is DERIVED from the image's entity
+# inventory when Kconfig leaves CONFIG_NROS_EXECUTOR_MAX_CBS at -1 and every
+# component declared `nano_ros_node_register(... ENTITIES ...)`. Setting this
+# variable still WINS over the derivation — it is rung 1 of the ladder.
 #NROS_EXECUTOR_MAX_CBS=4
 
 # Subscription/service receive buffer size, bytes (default: 1024)

--- a/book/src/getting-started/workspace-cpp.md
+++ b/book/src/getting-started/workspace-cpp.md
@@ -116,8 +116,27 @@ nano_ros_auto_add_library(talker_lib STATIC src/Talker.cpp)
 nros_components_register_node(talker_lib
     PLUGIN talker_pkg::Talker      # any qualified name — upstream namespaces port verbatim
     EXECUTABLE talker
-    SHAPE configure)               # this walkthrough uses the configure(Node&) shape
+    SHAPE configure                # this walkthrough uses the configure(Node&) shape
+    ENTITIES pub:std_msgs/msg/Int32:/chatter timer)
 ```
+
+`ENTITIES` (optional) states what this component's constructor creates, so the
+build can size the executor instead of a human counting call sites. Each entry
+is `<kind>[:<type>[:<topic>]]`, with an optional `*N` repeat on the kind
+(`pub*5`); the kinds are `publisher`, `subscription`, `timer`,
+`service_server`, `service_client`, `action_server`, `action_client` and
+`guard_condition`. Write `ENTITIES NONE` for a component that creates none.
+
+It is worth stating even though it is optional: `NROS_EXECUTOR_MAX_CBS` is
+derived from it, and the derivation is all-or-nothing. **If any component in an
+image omits `ENTITIES`, nothing is derived for that image** — a count taken over
+only the components that answered is smaller than the image needs, and a short
+`MAX_CBS` fails entity creation at boot. Inspect the composed answer with
+`nros ws entity-inventory --metadata <build>/nros-metadata.json`.
+
+Note that a publisher is inventoried but claims no callback slot, so the
+declared entity count and the derived `MAX_CBS` are legitimately different
+numbers.
 
 ```cpp
 // src/talker_pkg/include/talker_pkg/Talker.hpp

--- a/changelog.d/0965.feat.md
+++ b/changelog.d/0965.feat.md
@@ -1,0 +1,1 @@
+An image can state WHICH ENTITIES it creates -- `nano_ros_node_register(... ENTITIES ...)` -- and `NROS_EXECUTOR_MAX_CBS` derives from it instead of being hand-counted; a component that declares nothing makes the whole image refuse rather than derive a number that is short, and a publisher is counted but claims no callback slot

--- a/cmake/NanoRosCodegenCore.cmake
+++ b/cmake/NanoRosCodegenCore.cmake
@@ -24,6 +24,13 @@ include_guard(GLOBAL)
 # them without knowing which generator produced them.
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosMessageBounds.cmake")
 
+# phase-403 step 1 -- and its second input. `nros_find_interfaces()` below hands
+# the entity inventory's fragment to the bound reader so the payload classes
+# derive over the types this image RECEIVES, so it needs that module's path
+# helpers (`nros_entity_inventory_knobs_file`, `..._seed_knobs_file`) here. The
+# include is a no-op when `nano_ros_entry()` has already pulled it in.
+include("${CMAKE_CURRENT_LIST_DIR}/NanoRosEntityInventory.cmake")
+
 # _nros_collect_rs_closure(<out_var> DEPS <pkgs...> OWN <rs-files...>)
 #
 # Compute the de-duplicated transitive closure of generated FFI `.rs` files:
@@ -821,8 +828,37 @@ function(nros_find_interfaces)
     #    The result is written to one image-wide file. A consumer reads THAT,
     #    never these variables -- the readers run in other files at other points
     #    of the configure, where a function-scoped variable does not reach.
+    #
+    #    phase-403 step 1 -- and the ENTITY inventory is the second input, so
+    #    the three PAYLOAD-CLASS knobs derive over the types this image actually
+    #    RECEIVES rather than over everything it links. On the island that is
+    #    the difference between a small class set by a `std_msgs/Float64MultiArray`
+    #    nothing subscribes to and one set by the largest type that is.
+    #
+    #    ORDERING, stated rather than assumed. The entity inventory is composed
+    #    by `nano_ros_entry()`, which runs LATER in a configure than this does --
+    #    it has to, because it is the first point after every
+    #    `nano_ros_node_register()`. So the fragment read here is the one the
+    #    PREVIOUS configure wrote, which is exactly the lag the Zephyr knob
+    #    resolver already has against this file, and it is closed the same way:
+    #    `CMAKE_CONFIGURE_DEPENDS` plus a write-if-changed producer, so ninja
+    #    re-runs cmake by itself once the entity lane writes different bytes.
+    #    An image whose declaration has just changed builds once at its old
+    #    payload classes, re-configures, and builds again at the derived ones --
+    #    never silently, since the status line says which basis was used.
+    nros_entity_inventory_knobs_file(_entity_knobs)
+    nros_entity_inventory_seed_knobs_file("${_entity_knobs}")
+    set_property(DIRECTORY APPEND PROPERTY
+        CMAKE_CONFIGURE_DEPENDS "${_entity_knobs}")
     nros_message_bounds_knobs_file(_bounds_knobs)
-    nros_derive_message_bound_knobs(OUTPUT_FILE "${_bounds_knobs}")
+    nros_derive_message_bound_knobs(
+        OUTPUT_FILE "${_bounds_knobs}"
+        ENTITY_INVENTORY "${_entity_knobs}")
     set(NROS_MESSAGE_BOUNDS_STATUS "${NROS_MESSAGE_BOUNDS_STATUS}" PARENT_SCOPE)
     set(NROS_MESSAGE_BOUNDS_REASON "${NROS_MESSAGE_BOUNDS_REASON}" PARENT_SCOPE)
+    set(NROS_MESSAGE_BOUNDS_BASIS "${NROS_MESSAGE_BOUNDS_BASIS}" PARENT_SCOPE)
+    set(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS
+        "${NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS}" PARENT_SCOPE)
+    set(NROS_MESSAGE_BOUNDS_PAYLOAD_REASON
+        "${NROS_MESSAGE_BOUNDS_PAYLOAD_REASON}" PARENT_SCOPE)
 endfunction()

--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -38,14 +38,24 @@
 #   DERIVABLE HERE:
 #     NROS_EXECUTOR_MAX_CBS      the executor's callback-entry slot demand
 #
+#   SUPPLIED HERE, derived NEXT DOOR (phase-403 step 1):
+#     the zenoh payload classes  `NROS_ENTITY_SUBSCRIBED_TYPES` is the JOIN KEY
+#                                `nros_derive_message_bound_knobs` reads through
+#                                its `ENTITY_INVENTORY` argument. This module
+#                                says WHICH types are received; that one prices
+#                                them. Neither half derives a class alone.
+#     the arena                  `NROS_ENTITY_RECEIVED_TYPES` is the wider set
+#                                it needs -- a service server, a service client
+#                                and both action roles all carry receive
+#                                buffers that no payload class covers.
+#
 #   NOT YET, and deliberately left alone:
-#     NROS_EXECUTOR_ARENA_SIZE   needs the slot count TIMES the per-entity
-#                                receive-buffer cost, which is the bound
-#                                inventory joined to this one PER SUBSCRIPTION.
-#                                The join is what phase-403 W5 wants; a total
-#                                derived from only one half would be the
-#                                confident wrong number this campaign removes.
-#     the zenoh payload classes  same join, narrowed to the SUBSCRIBED types.
+#     NROS_EXECUTOR_ARENA_SIZE   the type set above is necessary and not
+#                                sufficient: the per-subscription cost is
+#                                `(depth + 1) * bound + (depth + 1) * 8`, and an
+#                                entity record carries no QoS DEPTH. Defaulting
+#                                it is wrong by up to 10x in either direction,
+#                                so depth must be declared first (step 2).
 #
 # =============================================================================
 # A PUBLISHER CLAIMS NO SLOT
@@ -130,7 +140,14 @@ include_guard(GLOBAL)
 # `NROS_MESSAGE_BOUNDS_SCHEMA_SUPPORTED` gives at length: this file is reachable
 # from inside a function frame, and with `include_guard(GLOBAL)` a file-scope
 # `set()` that lands in such a frame is gone when it pops and never comes back.
-set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 1 CACHE INTERNAL
+#
+# **2** (phase-403 step 1) added the join key -- `NROS_ENTITY_SUBSCRIBED_TYPES`
+# and `NROS_ENTITY_RECEIVED_TYPES`, each with its own status. Nothing MOVED, and
+# it still bumps: a version-1 fragment carries neither, and a reader that took
+# their absence for "this image receives nothing" would derive a payload class
+# over an EMPTY set. Absence has to be distinguishable from zero here for the
+# same reason `ENTITIES NONE` exists.
+set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 2 CACHE INTERNAL
     "phase-403 W9: the nros_entity_inventory fragment schema this tree reads")
 
 # nros_entity_inventory_knobs_file(<out_var>)
@@ -280,7 +297,8 @@ function(nros_derive_entity_inventory_knobs)
         message(FATAL_ERROR
             "nros: ${_output} sets no NROS_ENTITY_INVENTORY_SCHEMA_VERSION.\n"
             "  Either it is not an entity-inventory fragment, or it predates the "
-            "schema. Rebuild the `nros` CLI (`just setup-cli`).")
+            "schema. Rebuild the `nros` CLI: `./scripts/bootstrap.sh` "
+            "(contributors: `just setup-cli`).")
     endif()
     if(NOT NROS_ENTITY_INVENTORY_SCHEMA_VERSION EQUAL
        NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED)
@@ -290,7 +308,8 @@ function(nros_derive_entity_inventory_knobs)
             "${NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED}.\n"
             "  Refusing rather than reading fields that may have moved.\n"
             "  Rebuild the `nros` CLI so the producer and the reader come from "
-            "one tree: `just setup-cli`.")
+            "one tree: `./scripts/bootstrap.sh` (contributors: "
+            "`just setup-cli`).")
     endif()
 
     # Republish everything the fragment set. `include()` inside a function keeps
@@ -313,6 +332,19 @@ function(nros_derive_entity_inventory_knobs)
             _nros_entity_publish(NROS_ENTITY_COUNT_${_kind}
                 "${NROS_ENTITY_COUNT_${_kind}}")
         endif()
+    endforeach()
+    # phase-403 step 1 -- the JOIN KEY. `nros_derive_message_bound_knobs`
+    # includes the fragment itself rather than reading these, so republishing
+    # them buys a caller that wants to inspect the set, not the join. Both views
+    # travel: SUBSCRIBED is the payload-class population, RECEIVED is the wider
+    # set the arena needs.
+    foreach(_view SUBSCRIBED RECEIVED)
+        foreach(_field TYPES_STATUS TYPES_REASON TYPES TYPE_COUNTS ENTITY_COUNT)
+            if(DEFINED NROS_ENTITY_${_view}_${_field})
+                _nros_entity_publish(NROS_ENTITY_${_view}_${_field}
+                    "${NROS_ENTITY_${_view}_${_field}}")
+            endif()
+        endforeach()
     endforeach()
 
     if(_E_QUIET)
@@ -377,7 +409,15 @@ if(CMAKE_SCRIPT_MODE_FILE AND
         NROS_ENTITY_COUNT_SERVICE_CLIENT
         NROS_ENTITY_COUNT_ACTION_SERVER
         NROS_ENTITY_COUNT_ACTION_CLIENT
-        NROS_ENTITY_COUNT_GUARD_CONDITION)
+        NROS_ENTITY_COUNT_GUARD_CONDITION
+        NROS_ENTITY_SUBSCRIBED_TYPES_STATUS
+        NROS_ENTITY_SUBSCRIBED_TYPES
+        NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS
+        NROS_ENTITY_SUBSCRIBED_ENTITY_COUNT
+        NROS_ENTITY_RECEIVED_TYPES_STATUS
+        NROS_ENTITY_RECEIVED_TYPES
+        NROS_ENTITY_RECEIVED_TYPE_COUNTS
+        NROS_ENTITY_RECEIVED_ENTITY_COUNT)
         if(DEFINED ${_v})
             message(STATUS "${_v}=${${_v}}")
         endif()

--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -1,0 +1,388 @@
+# NanoRosEntityInventory.cmake -- phase-403 W9 (issue 0965): the READER for the
+# ENTITY inventory, and the second half `NanoRosMessageBounds.cmake` says it
+# needs by name.
+#
+# That module's own header states the split:
+#
+#   NOT DERIVABLE HERE -- a question about entity COUNTS, which needs a second
+#   source (an entity inventory), not this one:
+#     NROS_EXECUTOR_MAX_CBS, NROS_EXECUTOR_ARENA_SIZE, ...
+#
+# This is that second source. A bound inventory prices a TYPE; this one counts
+# the ENTITIES an image creates, which is the half `NROS_EXECUTOR_MAX_CBS` has
+# always needed and never had.
+#
+# =============================================================================
+# Where the answer comes from
+# =============================================================================
+#
+# Every `nano_ros_node_register(... ENTITIES ...)` in the image, composed
+# through the file that call already writes -- `${CMAKE_BINARY_DIR}/
+# nros-metadata.json`. `nros ws entity-inventory` reads it and renders the same
+# three transports `bounds.rs` does (JSON, this CMake fragment, and env lines
+# for the cargo carrier), from one data model.
+#
+# It is AUTHOR-STATED, and the reason is timing rather than taste. RFC-0043/0044
+# components wire themselves in CONSTRUCTORS; `NROS_SUBSCRIBE` /
+# `create_publisher` / `NROS_CREATE_TIMER` do know the kind and the type `M`,
+# and a descriptor emitted from them would name every entity -- but that
+# descriptor is a LINK-SECTION fact and exists only after linking, while
+# `NROS_EXECUTOR_MAX_CBS` is a `const` compiled into `nros-node` before a single
+# component TU is compiled. Emitted evidence can VERIFY a count; it cannot
+# SUPPLY one. So the declaration supplies, and the running image verifies.
+#
+# =============================================================================
+# What it derives, and what it does not
+# =============================================================================
+#
+#   DERIVABLE HERE:
+#     NROS_EXECUTOR_MAX_CBS      the executor's callback-entry slot demand
+#
+#   NOT YET, and deliberately left alone:
+#     NROS_EXECUTOR_ARENA_SIZE   needs the slot count TIMES the per-entity
+#                                receive-buffer cost, which is the bound
+#                                inventory joined to this one PER SUBSCRIPTION.
+#                                The join is what phase-403 W5 wants; a total
+#                                derived from only one half would be the
+#                                confident wrong number this campaign removes.
+#     the zenoh payload classes  same join, narrowed to the SUBSCRIBED types.
+#
+# =============================================================================
+# A PUBLISHER CLAIMS NO SLOT
+# =============================================================================
+#
+# `NROS_EXECUTOR_MAX_CBS` sizes the executor's callback-entry table. Every
+# registration that claims an entry calls `Executor::next_entry_slot()`, and the
+# 24 sites that do are subscriptions, timers, services, service clients, action
+# servers, action clients and guard conditions. `create_publisher` is not one:
+# on the C++ path it writes an `RmwPublisher` into caller-owned storage, and on
+# the C path there is no `nros_executor_add_publisher` to increment
+# `handle_count`.
+#
+# This is why the derived number is SMALLER than the entity count, and both are
+# published. The mr-canhubk344 bring-up recorded "33 handles" for the island and
+# set `MAX_CBS=36` from it; 33 is the entity total and 14 of those are
+# publishers. `nros_cli_core::entity_inventory::EntityKind::callback_slots` is
+# the one place that difference is spelled, and
+# `scripts/check-entity-slot-costs.py` holds it to those 24 sites.
+#
+# The other way this could be short is an entity the executor creates that no
+# component declares. There are two candidates and neither claims a slot:
+# `ParamState` is stored outside the arena precisely so it does not consume
+# `MAX_CBS` slots, and the five REP-2002 lifecycle servers go through
+# `create_lc_srv`, which calls `session.create_service` directly rather than
+# `Executor::register_service_*`. The declared application entities are the
+# whole demand.
+#
+# =============================================================================
+# An incomplete inventory is REFUSED, never averaged
+# =============================================================================
+#
+# If ANY component in the image states no `ENTITIES`, nothing is derived at all
+# and every knob keeps its configured value. That is the same rule
+# `nros_derive_message_bound_knobs` holds when any type in the closure is
+# unbounded, and for the same reason: a count composed over the components that
+# did answer is SMALLER than the image needs, and a short `MAX_CBS` fails entity
+# creation on a board.
+#
+# The derived value also carries NO headroom. It is exactly the declared demand,
+# which makes the running image a checker of its own declaration: one entity
+# more than declared and registration returns `NodeError::ExecutorFull`, which
+# names this knob, and `ComponentNode`'s `ok()` flag halts boot naming the
+# failing node. `MAX_CBS` is the right FIRST consumer precisely because that
+# failure is loud -- an under-sized ARENA halts during entity creation, before
+# the first spin, which is why issue 0900 W1's advisory cannot cover it.
+#
+# =============================================================================
+# Usage
+# =============================================================================
+#
+#   include(NanoRosEntityInventory.cmake)
+#   nros_derive_entity_inventory_knobs(
+#       CLI <path to nros>                  # required
+#       [METADATA <nros-metadata.json>]     # default ${CMAKE_BINARY_DIR}/...
+#       [OUTPUT_FILE <path>]                # default the knobs file below
+#       [QUIET])
+#
+# Sets in the CALLER's scope:
+#
+#   NROS_ENTITY_INVENTORY_STATUS          derived | refused
+#   NROS_ENTITY_INVENTORY_REASON          prose, when refused
+#   NROS_ENTITY_INVENTORY_COMPONENT_COUNT components composed
+#   NROS_ENTITY_INVENTORY_ENTITY_TOTAL    entities declared (slots or not)
+#   NROS_ENTITY_COUNT_<KIND>              per-kind counts
+#   NROS_DERIVED_EXECUTOR_MAX_CBS         unset when not derivable -- ABSENT
+#                                         means "no answer", never a default
+#
+# A derived value is a DEFAULT. Every consumer applies it only where nothing
+# else stated a number -- see `_nros_resolve_derivable_knob` in
+# `zephyr/cmake/nros_cargo_build.cmake` for the precedence ladder
+# (env > Kconfig/board > derived > crate default).
+
+include_guard(GLOBAL)
+
+# The inventory schema this reader understands --
+# `nros_cli_core::entity_inventory::ENTITY_INVENTORY_SCHEMA_VERSION`. A fragment
+# that states anything else is REFUSED, never read field-by-field on the hope
+# that nothing moved.
+#
+# `CACHE INTERNAL` and not a plain variable, for the reason
+# `NROS_MESSAGE_BOUNDS_SCHEMA_SUPPORTED` gives at length: this file is reachable
+# from inside a function frame, and with `include_guard(GLOBAL)` a file-scope
+# `set()` that lands in such a frame is gone when it pops and never comes back.
+set(NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED 1 CACHE INTERNAL
+    "phase-403 W9: the nros_entity_inventory fragment schema this tree reads")
+
+# nros_entity_inventory_knobs_file(<out_var>)
+#
+# Where the composed, image-wide answer is written, and where a consumer reads
+# it. ONE path, because the writer and the reader are in different files, run at
+# different points of one configure, and a second spelling is how a derived
+# value silently stops arriving.
+#
+# `CMAKE_BINARY_DIR` and not a per-package dir: the answer is a property of the
+# IMAGE. It sits beside `message_bound_knobs.cmake`, its sibling.
+function(nros_entity_inventory_knobs_file _out_var)
+    set(${_out_var} "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake" PARENT_SCOPE)
+endfunction()
+
+# nros_entity_inventory_metadata_file(<out_var>)
+#
+# The input: the file `nano_ros_node_register` rewrites on every call
+# (`_nros_metadata_emit`). Spelled once here so a reader never hand-derives it.
+function(nros_entity_inventory_metadata_file _out_var)
+    set(${_out_var} "${CMAKE_BINARY_DIR}/nros-metadata.json" PARENT_SCOPE)
+endfunction()
+
+# nros_entity_inventory_seed_knobs_file(<path>)
+#
+# Write a "nothing composed yet" fragment, for a reader that runs BEFORE the
+# entry lane in the same configure.
+#
+# Exactly the mechanical reason `nros_message_bounds_seed_knobs_file` exists: a
+# consumer registers this path with `CMAKE_CONFIGURE_DEPENDS`, and a ninja input
+# that does not exist and has no rule producing it is a hard `missing and no
+# known rule to make it` at LOAD, before any rule runs. Seeding makes the
+# dependency well-formed on the first configure; the real answer overwrites it
+# later in that same configure and the next build picks it up.
+#
+# Does NOT overwrite an existing file: the point is that it may already hold an
+# answer.
+function(nros_entity_inventory_seed_knobs_file _path)
+    if(EXISTS "${_path}")
+        return()
+    endif()
+    get_filename_component(_dir "${_path}" DIRECTORY)
+    file(MAKE_DIRECTORY "${_dir}")
+    file(WRITE "${_path}"
+        "# GENERATED by nros (phase-403 W9, issue 0965). Do not edit.\n"
+        "#\n"
+        "# Placeholder: no entity inventory had been composed when this configure\n"
+        "# first needed one. It is rewritten with the real answer by\n"
+        "# nros_derive_entity_inventory_knobs(), and its rewrite re-runs cmake.\n"
+        "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION ${NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED})\n"
+        "set(NROS_ENTITY_INVENTORY_STATUS \"refused\")\n"
+        "set(NROS_ENTITY_INVENTORY_REASON \"no entity inventory composed yet\")\n")
+endfunction()
+
+# _nros_entity_publish(<name> <value>)
+#
+# Set a result BOTH locally and in the caller's scope. A macro, not a function,
+# for the reason `_nros_bounds_publish` is one: a macro runs in the CALLER's
+# scope, so its `PARENT_SCOPE` is the caller's parent, which is what the name
+# promises. Publishing to only one of the two scopes is the shape that reads as
+# working while half the values are empty.
+macro(_nros_entity_publish _name _value)
+    set(${_name} "${_value}")
+    set(${_name} "${_value}" PARENT_SCOPE)
+endmacro()
+
+# nros_derive_entity_inventory_knobs(...)  -- see the header comment.
+function(nros_derive_entity_inventory_knobs)
+    cmake_parse_arguments(_E "QUIET" "CLI;METADATA;OUTPUT_FILE" "" ${ARGN})
+
+    set(_metadata "${_E_METADATA}")
+    if(NOT _metadata)
+        nros_entity_inventory_metadata_file(_metadata)
+    endif()
+    set(_output "${_E_OUTPUT_FILE}")
+    if(NOT _output)
+        nros_entity_inventory_knobs_file(_output)
+    endif()
+
+    # ---- Nothing derived until proven otherwise -------------------------
+    # Every out-variable starts UNSET, in BOTH scopes. A knob that cannot be
+    # derived must be ABSENT, so a consumer either reads a number this function
+    # computed or reads nothing; and a refusal after a successful call must not
+    # leave the previous numbers standing, which is what clearing this frame's
+    # copy is for (a function inherits the caller's variables through the scope
+    # chain).
+    _nros_entity_publish(NROS_ENTITY_INVENTORY_STATUS "refused")
+    _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "")
+    _nros_entity_publish(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 0)
+    foreach(_v NROS_DERIVED_EXECUTOR_MAX_CBS NROS_ENTITY_INVENTORY_ENTITY_TOTAL)
+        unset(${_v})
+        unset(${_v} PARENT_SCOPE)
+    endforeach()
+
+    if(NOT _E_CLI OR NOT EXISTS "${_E_CLI}")
+        set(_why "the `nros` CLI was not available to this configure")
+        _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "${_why}")
+        nros_entity_inventory_seed_knobs_file("${_output}")
+        return()
+    endif()
+
+    # A MISSING metadata file is a refusal, not a fatal: a configure that has
+    # registered no component yet is the state every build was in before this
+    # wave, and it is the state a pure-Rust or launch-only image stays in.
+    if(NOT EXISTS "${_metadata}")
+        set(_why
+            "no component metadata at ${_metadata} -- nothing in this image called nano_ros_node_register()")
+        _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "${_why}")
+        nros_entity_inventory_seed_knobs_file("${_output}")
+        return()
+    endif()
+
+    # The verb renders the fragment. It is the ONE derivation: the counting
+    # rule, the per-kind slot cost and the refusal all live in
+    # `nros_cli_core::entity_inventory`, and this file only reads what it wrote.
+    # A second count in cmake is how two green tools come to disagree.
+    execute_process(
+        COMMAND "${_E_CLI}" ws entity-inventory
+                --metadata "${_metadata}"
+                --output-cmake "${_output}"
+                --output-json "${CMAKE_BINARY_DIR}/nros/entity_inventory.json"
+        OUTPUT_VARIABLE _out
+        ERROR_VARIABLE _err
+        RESULT_VARIABLE _rc
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _rc EQUAL 0)
+        # A non-zero exit is a BROKEN DECLARATION -- an unknown entity kind, a
+        # component claiming NONE beside real entities -- not an absent one, and
+        # the CLI's message names the component. That is a configuration error
+        # and it is fatal, the same way a malformed message-bound fragment is.
+        message(FATAL_ERROR
+            "nros: the entity declaration in this image is not readable.\n"
+            "  ${_err}\n"
+            "  Fix the `ENTITIES` argument of the named nano_ros_node_register().")
+    endif()
+
+    if(NOT EXISTS "${_output}")
+        set(_why "`nros ws entity-inventory` wrote no fragment")
+        _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "${_why}")
+        nros_entity_inventory_seed_knobs_file("${_output}")
+        return()
+    endif()
+
+    unset(NROS_ENTITY_INVENTORY_SCHEMA_VERSION)
+    include("${_output}")
+    if(NOT DEFINED NROS_ENTITY_INVENTORY_SCHEMA_VERSION)
+        message(FATAL_ERROR
+            "nros: ${_output} sets no NROS_ENTITY_INVENTORY_SCHEMA_VERSION.\n"
+            "  Either it is not an entity-inventory fragment, or it predates the "
+            "schema. Rebuild the `nros` CLI (`just setup-cli`).")
+    endif()
+    if(NOT NROS_ENTITY_INVENTORY_SCHEMA_VERSION EQUAL
+       NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED)
+        message(FATAL_ERROR
+            "nros: ${_output} states entity-inventory schema version "
+            "${NROS_ENTITY_INVENTORY_SCHEMA_VERSION}; this reader understands "
+            "${NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED}.\n"
+            "  Refusing rather than reading fields that may have moved.\n"
+            "  Rebuild the `nros` CLI so the producer and the reader come from "
+            "one tree: `just setup-cli`.")
+    endif()
+
+    # Republish everything the fragment set. `include()` inside a function keeps
+    # its `set()`s in THIS frame, so without this the caller sees nothing.
+    _nros_entity_publish(NROS_ENTITY_INVENTORY_STATUS "${NROS_ENTITY_INVENTORY_STATUS}")
+    _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "${NROS_ENTITY_INVENTORY_REASON}")
+    _nros_entity_publish(NROS_ENTITY_INVENTORY_COMPONENT_COUNT
+        "${NROS_ENTITY_INVENTORY_COMPONENT_COUNT}")
+    if(DEFINED NROS_ENTITY_INVENTORY_ENTITY_TOTAL)
+        _nros_entity_publish(NROS_ENTITY_INVENTORY_ENTITY_TOTAL
+            "${NROS_ENTITY_INVENTORY_ENTITY_TOTAL}")
+    endif()
+    if(DEFINED NROS_DERIVED_EXECUTOR_MAX_CBS)
+        _nros_entity_publish(NROS_DERIVED_EXECUTOR_MAX_CBS
+            "${NROS_DERIVED_EXECUTOR_MAX_CBS}")
+    endif()
+    foreach(_kind PUBLISHER SUBSCRIPTION TIMER SERVICE_SERVER SERVICE_CLIENT
+                  ACTION_SERVER ACTION_CLIENT GUARD_CONDITION)
+        if(DEFINED NROS_ENTITY_COUNT_${_kind})
+            _nros_entity_publish(NROS_ENTITY_COUNT_${_kind}
+                "${NROS_ENTITY_COUNT_${_kind}}")
+        endif()
+    endforeach()
+
+    if(_E_QUIET)
+        return()
+    endif()
+    if(NROS_ENTITY_INVENTORY_STATUS STREQUAL "derived")
+        message(STATUS
+            "nros: entity inventory DERIVED from "
+            "${NROS_ENTITY_INVENTORY_COMPONENT_COUNT} components -- "
+            "${NROS_ENTITY_INVENTORY_ENTITY_TOTAL} entities, "
+            "${NROS_DERIVED_EXECUTOR_MAX_CBS} executor callback slots "
+            "-> NROS_EXECUTOR_MAX_CBS")
+        if(DEFINED NROS_ENTITY_COUNT_PUBLISHER AND
+           NROS_ENTITY_COUNT_PUBLISHER GREATER 0)
+            message(STATUS
+                "nros:   ${NROS_ENTITY_COUNT_PUBLISHER} of them are publishers, "
+                "which claim no callback slot")
+        endif()
+    else()
+        message(STATUS
+            "nros: entity sizing not available this configure -- "
+            "NROS_EXECUTOR_MAX_CBS keeps its configured value.\n"
+            "  ${NROS_ENTITY_INVENTORY_REASON}")
+    endif()
+endfunction()
+
+# -----------------------------------------------------------------------------
+# `cmake -P` entry point.
+#
+# Running the derivation without configuring a project is what makes it
+# TESTABLE, and it is how the message-bound reader beside it is tested
+# (`tests/cmake-message-bounds-tests.sh`):
+#
+#   cmake -DNROS_ENTITY_CLI=<nros> -DNROS_ENTITY_METADATA=<meta.json> \
+#         [-DNROS_ENTITY_OUTPUT=out.cmake] \
+#         -P cmake/NanoRosEntityInventory.cmake
+#
+# `CMAKE_BINARY_DIR` in script mode is the invocation CWD, which is what makes
+# the default output path land somewhere writable.
+# -----------------------------------------------------------------------------
+if(CMAKE_SCRIPT_MODE_FILE AND
+   CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
+    if(NOT DEFINED NROS_ENTITY_CLI OR NOT DEFINED NROS_ENTITY_METADATA)
+        message(FATAL_ERROR
+            "usage: cmake -DNROS_ENTITY_CLI=<nros> -DNROS_ENTITY_METADATA=<meta.json> "
+            "[-DNROS_ENTITY_OUTPUT=path] -P cmake/NanoRosEntityInventory.cmake")
+    endif()
+    set(_args CLI "${NROS_ENTITY_CLI}" METADATA "${NROS_ENTITY_METADATA}")
+    if(DEFINED NROS_ENTITY_OUTPUT)
+        list(APPEND _args OUTPUT_FILE "${NROS_ENTITY_OUTPUT}")
+    endif()
+    nros_derive_entity_inventory_knobs(${_args})
+    message(STATUS "NROS_ENTITY_INVENTORY_STATUS=${NROS_ENTITY_INVENTORY_STATUS}")
+    foreach(_v
+        NROS_ENTITY_INVENTORY_COMPONENT_COUNT
+        NROS_ENTITY_INVENTORY_ENTITY_TOTAL
+        NROS_DERIVED_EXECUTOR_MAX_CBS
+        NROS_ENTITY_COUNT_PUBLISHER
+        NROS_ENTITY_COUNT_SUBSCRIPTION
+        NROS_ENTITY_COUNT_TIMER
+        NROS_ENTITY_COUNT_SERVICE_SERVER
+        NROS_ENTITY_COUNT_SERVICE_CLIENT
+        NROS_ENTITY_COUNT_ACTION_SERVER
+        NROS_ENTITY_COUNT_ACTION_CLIENT
+        NROS_ENTITY_COUNT_GUARD_CONDITION)
+        if(DEFINED ${_v})
+            message(STATUS "${_v}=${${_v}}")
+        endif()
+    endforeach()
+    if(NROS_ENTITY_INVENTORY_REASON)
+        message(STATUS "NROS_ENTITY_INVENTORY_REASON=${NROS_ENTITY_INVENTORY_REASON}")
+    endif()
+endif()

--- a/cmake/NanoRosEntry.cmake
+++ b/cmake/NanoRosEntry.cmake
@@ -857,6 +857,24 @@ function(_nros_entry_invoke_codegen)
             "  stderr: ${_stderr}")
     endif()
 
+    # phase-403 W9 (issue 0965) — compose this image's ENTITY inventory.
+    #
+    # HERE and not in `nano_ros_node_register()` because the answer is a
+    # property of the whole IMAGE: `NROS_EXECUTOR_MAX_CBS` sizes ONE executor
+    # and an image has one. Same reason `nros_derive_message_bound_knobs` runs
+    # at the end of `nros_find_interfaces()` rather than per package.
+    #
+    # And here specifically because this is the first point in a configure that
+    # is guaranteed to be AFTER every `nano_ros_node_register()`: the entry is
+    # declared last, which is exactly what the `--metadata` argument two blocks
+    # up already relies on.
+    #
+    # Never fatal on absence. The knobs file is a promise on a clean tree, and
+    # every image built before this wave has no `ENTITIES` at all — those keep
+    # their configured `MAX_CBS` and are unaffected.
+    include("${_NROS_ENTRY_DIR}/NanoRosEntityInventory.cmake")
+    nros_derive_entity_inventory_knobs(CLI "${_nros_bin}")
+
     # #182 — the generated TU is a function of the CODEGEN TOOL too, not just
     # its inputs: a `nros` rebuild that changes the emitter (e.g. the fd32a0f75
     # group-split fallback, the phase-281 tier seams) must re-run this

--- a/cmake/NanoRosMessageBounds.cmake
+++ b/cmake/NanoRosMessageBounds.cmake
@@ -36,6 +36,15 @@
 #   this inventory would produce exactly the plausible-wrong-number this
 #   campaign exists to remove.
 #
+#   THAT SECOND SOURCE NOW EXISTS: `cmake/NanoRosEntityInventory.cmake`
+#   (phase-403 W9, issue 0965), composed from every
+#   `nano_ros_node_register(... ENTITIES ...)` in the image. It derives
+#   NROS_EXECUTOR_MAX_CBS. The other three still are not derived, and that is
+#   deliberate rather than unfinished: the arena and the payload classes need
+#   the two inventories JOINED per subscription -- this one's per-type size
+#   against that one's per-entity list -- and a total taken from either half
+#   alone is the same confident wrong number.
+#
 # =============================================================================
 # The derived numbers are an UPPER BOUND on what the image needs
 # =============================================================================
@@ -51,6 +60,10 @@
 # number a user cannot account for is a number they will eventually "fix".
 #
 # Narrowing it needs the same entity inventory the out-of-scope knobs need.
+# That inventory landed in W9 and this reader does NOT yet consult it: narrowing
+# means intersecting the closure with the SUBSCRIBED type names, which is a join
+# of two artifacts and a change to what these numbers mean. Left for the wave
+# that does it deliberately rather than bolted on here.
 #
 # =============================================================================
 # An unbounded type is not silently dropped

--- a/cmake/NanoRosMessageBounds.cmake
+++ b/cmake/NanoRosMessageBounds.cmake
@@ -46,24 +46,69 @@
 #   alone is the same confident wrong number.
 #
 # =============================================================================
-# The derived numbers are an UPPER BOUND on what the image needs
+# TWO BASES, because the four knobs are not four answers to one question
 # =============================================================================
 #
-# The inventory holds every type in the LINKED INTERFACE CLOSURE, not just the
-# subscribed ones. A package is linked because something in the image mentions
-# one of its types; the other 90 come along. So a derived class size is the
-# largest type the image COULD receive, not the largest it DOES.
+# The bound inventory holds every type in the LINKED INTERFACE CLOSURE, not just
+# the received ones. A package is linked because something in the image mentions
+# one of its types; the other 90 come along. Derived over that, a class size is
+# the largest type the image COULD receive, not the largest it DOES -- and on
+# the reference island that gap is the dominant term, not a rounding error: one
+# `std_msgs/Float64MultiArray`, linked and never received, sets the small class
+# for every subscription in the image.
 #
-# That errs in the safe direction -- too big, never too small -- and it is the
-# same direction the hand-set numbers were supposed to err in and did not. It
-# is stated here, in the generated output, and in the Kconfig help, because a
-# number a user cannot account for is a number they will eventually "fix".
+# So this reader derives on TWO bases and says which it used for what.
 #
-# Narrowing it needs the same entity inventory the out-of-scope knobs need.
-# That inventory landed in W9 and this reader does NOT yet consult it: narrowing
-# means intersecting the closure with the SUBSCRIBED type names, which is a join
-# of two artifacts and a change to what these numbers mean. Left for the wave
-# that does it deliberately rather than bolted on here.
+#   BASIS `subscribed` -- the THREE PAYLOAD-CLASS knobs
+#     NROS_SUBSCRIBER_BUFFER_SIZE, NROS_SUBSCRIBER_LARGE_SIZE,
+#     NROS_MAX_LARGE_SUBSCRIBERS
+#   These size the backend's two topic payload pools. Those pools are reached
+#   through exactly one allocation -- `alloc_payload_block(rx_buffer_hint)` in
+#   `shim/subscriber.rs` -- with exactly one caller, the `declare_subscriber`
+#   path. So their population is the image's SUBSCRIPTIONS, and the entity
+#   inventory (`cmake/NanoRosEntityInventory.cmake`, phase-403 W9) names them.
+#   The join is this file's `ENTITY_INVENTORY` argument.
+#
+#   BASIS `closure` -- the take buffer
+#     NROS_SUBSCRIPTION_BUFFER_SIZE
+#   This one is NOT subscription-only, whatever its name says, and narrowing it
+#   to the subscribed set would size a buffer too small. `nros-node/build.rs`
+#   turns it into `DEFAULT_RX_BUF_SIZE`, which is the DEFAULT const generic for
+#   `RawSubscription`, `RawServiceServer`, `RawServiceClient`,
+#   `ActionServerCore` and `ActionClientCore` -- and `executor/types.rs` then
+#   defines `DEFAULT_TX_BUF = DEFAULT_RX_BUF_SIZE`, so it is also the stack
+#   array `EmbeddedPublisher::publish` serialises into. A type this image only
+#   PUBLISHES still has to fit. The closure over-approximates that, in the safe
+#   direction, and stays.
+#
+# =============================================================================
+# The join REFUSES; it never quietly widens
+# =============================================================================
+#
+# Once an image declares its entities, the payload classes are derived from
+# them or not at all. Specifically, with `ENTITY_INVENTORY` naming a fragment
+# whose own status is `derived`:
+#
+#   * its subscribed-type set REFUSED (a component declared no `ENTITIES`, or a
+#     subscription states no type)      -> the payload classes REFUSE
+#   * it names a type this bound inventory does not price at all
+#                                       -> the payload classes REFUSE, naming it
+#   * it names a type that is `unbounded`/`unresolved`
+#                                       -> the whole derivation already refused
+#
+# None of those fall back to the closure. Falling back would publish the WRONG
+# ROW of the table above while every status still read "derived", which is the
+# shape that looks like it worked.
+#
+# The one case that DOES derive over the closure is the image that declared
+# NOTHING -- no `ENTITIES` anywhere, so the entity fragment is absent or its own
+# status is `refused`. That is every image built before phase-403 W9, and it
+# keeps exactly the numbers it has today: `NROS_MESSAGE_BOUNDS_BASIS` reads
+# `closure`, the status line says so, and the generated file carries the
+# paragraph explaining what the declaration would buy. Refusing there instead
+# would take those images from an over-approximate derived number back to the
+# hand-set ones this whole wave exists to replace, which is a regression, not a
+# safety property.
 #
 # =============================================================================
 # An unbounded type is not silently dropped
@@ -83,6 +128,7 @@
 #   include(NanoRosMessageBounds.cmake)
 #   nros_derive_message_bound_knobs(
 #       FRAGMENTS <nros_message_bounds.cmake>...   # or omit: uses the cache list
+#       [ENTITY_INVENTORY <entity_inventory.cmake>]# the join; see above
 #       [SMALL_CLASS_CEILING 2048]                 # policy, see below
 #       [OUTPUT_FILE <path>]                       # write the answer + why
 #       [QUIET])
@@ -95,6 +141,15 @@
 #   NROS_MESSAGE_BOUNDS_TYPE_COUNT    types seen
 #   NROS_MESSAGE_BOUNDS_BOUNDED_COUNT types with a derived bound
 #   NROS_MESSAGE_BOUNDS_OPEN_TYPES    the unbounded/unresolved ones
+#   NROS_MESSAGE_BOUNDS_BASIS         subscribed | closure -- which set the
+#                                     three payload-class knobs were derived
+#                                     over. UNSET when they were not derived.
+#   NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS  derived | refused, for those three
+#                                     alone. It can refuse while the take
+#                                     buffer still derives, and that is not a
+#                                     contradiction: two bases, two questions.
+#   NROS_MESSAGE_BOUNDS_PAYLOAD_REASON  prose, when it refused
+#   NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT  subscribing ENTITIES joined
 #   NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE     \
 #   NROS_DERIVED_SUBSCRIBER_LARGE_SIZE       |  unset when not derivable --
 #   NROS_DERIVED_MAX_LARGE_SUBSCRIBERS       |  ABSENT means "no answer",
@@ -125,6 +180,21 @@ include_guard(GLOBAL)
 # never read field-by-field on the hope that nothing moved.
 set(NROS_MESSAGE_BOUNDS_SCHEMA_SUPPORTED 1 CACHE INTERNAL
     "phase-403 W8: the nros_message_bounds fragment schema this tree reads")
+
+# Where this module lives, so the join can reach its sibling
+# `NanoRosEntityInventory.cmake` for the ENTITY fragment's schema constant.
+#
+# `CACHE INTERNAL` for the same `_NROS_ENTRY_DIR` reason the constant above
+# gives -- this file is reachable from inside a function frame, and a file-scope
+# `set()` that lands there is gone when the frame pops while `include_guard`
+# makes every later include a no-op.
+#
+# Reading `NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED` from that module rather than
+# restating the number here is deliberate: a second spelling of a version
+# constant is how a producer and a reader come to disagree while both look
+# right, which is the failure the constant exists to prevent.
+set(_NROS_MESSAGE_BOUNDS_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL
+    "phase-403: the directory NanoRosMessageBounds.cmake was included from")
 
 # The split between the small and the large payload class, in bytes.
 #
@@ -232,7 +302,8 @@ endfunction()
 
 # nros_derive_message_bound_knobs(...)  -- see the header comment.
 function(nros_derive_message_bound_knobs)
-    cmake_parse_arguments(_B "QUIET" "SMALL_CLASS_CEILING;OUTPUT_FILE" "FRAGMENTS" ${ARGN})
+    cmake_parse_arguments(_B "QUIET"
+        "SMALL_CLASS_CEILING;OUTPUT_FILE;ENTITY_INVENTORY" "FRAGMENTS" ${ARGN})
 
     set(_fragments "${_B_FRAGMENTS}")
     if(NOT _fragments)
@@ -253,6 +324,10 @@ function(nros_derive_message_bound_knobs)
     _nros_bounds_publish(NROS_MESSAGE_BOUNDS_TYPE_COUNT 0)
     _nros_bounds_publish(NROS_MESSAGE_BOUNDS_BOUNDED_COUNT 0)
     _nros_bounds_publish(NROS_MESSAGE_BOUNDS_OPEN_TYPES "")
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS "refused")
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_PAYLOAD_REASON
+        "the derivation did not reach the payload classes")
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT 0)
     # Cleared in BOTH scopes. The parent's copy so a second call cannot leave a
     # stale answer standing; this frame's copy because a function inherits the
     # caller's variables through the scope chain, and
@@ -266,7 +341,8 @@ function(nros_derive_message_bound_knobs)
         NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE
         NROS_DERIVED_LARGEST_TYPE
         NROS_DERIVED_LARGEST_RX
-        NROS_DERIVED_LARGE_TYPES)
+        NROS_DERIVED_LARGE_TYPES
+        NROS_MESSAGE_BOUNDS_BASIS)
         unset(${_v})
         unset(${_v} PARENT_SCOPE)
     endforeach()
@@ -423,35 +499,70 @@ function(nros_derive_message_bound_knobs)
         return()
     endif()
 
+    # ---- The JOIN: which of those types does this image RECEIVE? ---------
+    #
+    # phase-403 step 1. Everything above is a fact about the closure. The three
+    # payload-class knobs are a fact about the SUBSCRIPTIONS, and this is where
+    # the second inventory supplies them. See the header for why the take
+    # buffer deliberately does not take part.
+    _nros_bounds_join_subscribed("${_B_ENTITY_INVENTORY}" "${_ceiling}"
+        _basis _payload_status _payload_why _sub_count
+        _sub_small _sub_large_types _sub_large_max _sub_large_count)
+
     # ---- Derive ----------------------------------------------------------
     #
     # Buffer 1, the runtime-owned take buffer: ONE global size for every
-    # subscription in the image (`RX_BUF` is a const generic and the C/C++ path
-    # is type-erased), so it must hold the largest type the image could
-    # receive.
+    # ENTITY in the image (`RX_BUF` is a const generic and the C/C++ path is
+    # type-erased), so it must hold the largest type the image could receive --
+    # and, because `DEFAULT_TX_BUF` aliases it, the largest it could publish.
+    # BASIS `closure`, always. Narrowing this one is the under-derivation.
     _nros_bounds_publish(NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE "${_max_rx}")
     _nros_bounds_publish(NROS_DERIVED_LARGEST_TYPE "${_max_type}")
     _nros_bounds_publish(NROS_DERIVED_LARGEST_RX "${_max_rx}")
 
-    # Buffer 2, the backend's staging pools: two classes, split at the policy
-    # ceiling. `_small` is the largest bound AT OR UNDER the ceiling, so the
-    # shim's own `min(threshold, SUBSCRIBER_BUFFER_SIZE)` picks it and the
-    # classification here is the routing at runtime.
-    #
-    # `_small == 0` means no type fits under the ceiling. The small class is
-    # still USED -- a caller that states no hint (`rx_buffer_hint == 0`, which
-    # is still every C/C++ subscription until W3/W5) is served from it -- so
-    # there is nothing to derive from the type set and the configured value
-    # stands.
-    if(_small GREATER 0)
-        _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE "${_small}")
-    endif()
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS "${_payload_status}")
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_PAYLOAD_REASON "${_payload_why}")
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT "${_sub_count}")
 
-    list(LENGTH _large_types _large_count)
-    _nros_bounds_publish(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS "${_large_count}")
-    _nros_bounds_publish(NROS_DERIVED_LARGE_TYPES "${_large_types}")
-    if(_large_count GREATER 0)
-        _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE "${_large_max}")
+    if(_payload_status STREQUAL "derived")
+        _nros_bounds_publish(NROS_MESSAGE_BOUNDS_BASIS "${_basis}")
+
+        # BASIS `closure` -- this image declared no entities, so there is no
+        # join to make and the payload classes keep exactly the answer W8
+        # published: derived over every type in the linked closure. The label
+        # and the status line are what stop that being mistaken for the joined
+        # row.
+        if(_basis STREQUAL "closure")
+            set(_sub_small "${_small}")
+            set(_sub_large_types "${_large_types}")
+            set(_sub_large_max "${_large_max}")
+            list(LENGTH _large_types _sub_large_count)
+        endif()
+
+        # Buffer 2, the backend's staging pools: two classes, split at the
+        # policy ceiling. `_sub_small` is the largest bound AT OR UNDER the
+        # ceiling among the receiving set, so the shim's own
+        # `min(threshold, SUBSCRIBER_BUFFER_SIZE)` picks it and the
+        # classification here is the routing at runtime.
+        #
+        # `_sub_small == 0` means nothing received fits under the ceiling --
+        # including the case where nothing is received at all. The small class
+        # is still USED (a caller that states no hint is served from it), so
+        # there is nothing to derive and the configured value stands.
+        if(_sub_small GREATER 0)
+            _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE "${_sub_small}")
+        endif()
+
+        # The large COUNT is a count of BLOCKS, so on the `subscribed` basis it
+        # counts subscribing ENTITIES and not distinct types: two subscriptions
+        # on one large type need two blocks, and a type count would under-reserve
+        # by exactly the duplicates. On the `closure` basis there are no entities
+        # to count and it stays a type count, which is what it has always been.
+        _nros_bounds_publish(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS "${_sub_large_count}")
+        _nros_bounds_publish(NROS_DERIVED_LARGE_TYPES "${_sub_large_types}")
+        if(_sub_large_count GREATER 0)
+            _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE "${_sub_large_max}")
+        endif()
     endif()
     # A count of ZERO is an ANSWER, not an abstention -- W4 made
     # `ZPICO_MAX_LARGE_SUBSCRIBERS = 0` legal precisely so an image whose types
@@ -471,26 +582,219 @@ function(nros_derive_message_bound_knobs)
             "${_pkg_count} interface packages (all bounded)")
         message(STATUS
             "nros:   largest type ${_max_type} at ${_max_rx} B -> "
-            "NROS_SUBSCRIPTION_BUFFER_SIZE")
-        if(_small GREATER 0)
+            "NROS_SUBSCRIPTION_BUFFER_SIZE (basis: the whole closure -- this "
+            "knob is also DEFAULT_TX_BUF and every raw entity's default "
+            "buffer, so a type this image only publishes still has to fit)")
+        if(NOT _payload_status STREQUAL "derived")
+            message(WARNING
+                "nros: the three PAYLOAD-CLASS knobs are REFUSED -- "
+                "NROS_SUBSCRIBER_BUFFER_SIZE, NROS_SUBSCRIBER_LARGE_SIZE and "
+                "NROS_MAX_LARGE_SUBSCRIBERS keep their configured values.\n"
+                "  ${_payload_why}\n"
+                "  They are NOT falling back to the closure: this image states "
+                "what it receives, and a class sized over types it does not "
+                "receive is the wrong answer wearing a `derived` status.")
+        else()
+            if(_sub_small GREATER 0)
+                message(STATUS
+                    "nros:   small payload class ${_sub_small} B -> "
+                    "NROS_SUBSCRIBER_BUFFER_SIZE")
+            endif()
             message(STATUS
-                "nros:   small payload class ${_small} B -> "
-                "NROS_SUBSCRIBER_BUFFER_SIZE")
+                "nros:   ${_sub_large_count} over the ${_ceiling} B ceiling -> "
+                "NROS_MAX_LARGE_SUBSCRIBERS")
+            if(_sub_large_count GREATER 0)
+                message(STATUS
+                    "nros:   large payload class ${_sub_large_max} B -> "
+                    "NROS_SUBSCRIBER_LARGE_SIZE")
+            endif()
+            if(_basis STREQUAL "subscribed")
+                message(STATUS
+                    "nros:   payload classes derived over the ${_sub_count} "
+                    "SUBSCRIPTIONS this image declares, not the "
+                    "${_type_count}-type closure")
+            else()
+                message(STATUS
+                    "nros:   payload classes are an UPPER BOUND -- this image "
+                    "declares no entities, so they derive over the whole "
+                    "linked closure and are sized for the largest type it "
+                    "COULD receive. Declare "
+                    "`nano_ros_node_register(... ENTITIES sub:<pkg>/msg/<Name> "
+                    "...)` to narrow them to what it does.")
+            endif()
         endif()
-        message(STATUS
-            "nros:   ${_large_count} types over the ${_ceiling} B ceiling -> "
-            "NROS_MAX_LARGE_SUBSCRIBERS")
-        if(_large_count GREATER 0)
-            message(STATUS
-                "nros:   large payload class ${_large_max} B -> "
-                "NROS_SUBSCRIBER_LARGE_SIZE")
-        endif()
-        message(STATUS
-            "nros:   these are UPPER BOUNDS -- the inventory holds the whole "
-            "linked closure, not only the subscribed types")
     endif()
 
     _nros_message_bounds_write_output("${_B_OUTPUT_FILE}" "derived" "" "${_ceiling}")
+endfunction()
+
+# _nros_bounds_join_subscribed(<entity_fragment> <ceiling>
+#                              <out_basis> <out_status> <out_why> <out_count>
+#                              <out_small> <out_large_types> <out_large_max>
+#                              <out_large_count>)
+#
+# phase-403 step 1 -- the JOIN. Reads the ENTITY inventory's subscribed-type
+# set and classifies each of those types against the bounds this frame has
+# already composed.
+#
+# Called from inside `nros_derive_message_bound_knobs`, so it reads the
+# per-type `NROS_MESSAGE_BOUND_<key>_STATE` / `_RX` variables through the SCOPE
+# CHAIN -- the same way `_nros_message_bounds_write_output` reads the published
+# results. That is what makes it a function rather than a second composition:
+# there is one `include()` of the fragments per call, and re-including them here
+# would be a second read of the same files with a second chance to differ.
+#
+# `<out_basis>` is `subscribed` or `closure`; on `closure` the four
+# classification outputs are left EMPTY and the caller substitutes its own
+# closure-wide values. `<out_status>` is `derived` or `refused`, and a refusal
+# NEVER degrades to `closure` -- see the header.
+function(_nros_bounds_join_subscribed _frag _ceiling
+         _o_basis _o_status _o_why _o_count _o_small _o_large_types _o_large_max
+         _o_large_count)
+    set(${_o_basis} "" PARENT_SCOPE)
+    set(${_o_status} "derived" PARENT_SCOPE)
+    set(${_o_why} "" PARENT_SCOPE)
+    set(${_o_count} 0 PARENT_SCOPE)
+    set(${_o_small} 0 PARENT_SCOPE)
+    set(${_o_large_types} "" PARENT_SCOPE)
+    set(${_o_large_max} 0 PARENT_SCOPE)
+    set(${_o_large_count} 0 PARENT_SCOPE)
+
+    # No fragment named, or none written yet. The image declared nothing, which
+    # is every image built before phase-403 W9. Keep W8's closure answer and
+    # label it; see the header for why this one case is not a refusal.
+    if(NOT _frag OR NOT EXISTS "${_frag}")
+        set(${_o_basis} "closure" PARENT_SCOPE)
+        return()
+    endif()
+
+    # The entity fragment carries its own schema, and it is checked HERE too
+    # rather than trusted because this reader has landed since it was written --
+    # a version-1 fragment predates the subscribed-type set entirely, and
+    # reading it would silently derive a payload class over an EMPTY set.
+    #
+    # The constant comes from the module that OWNS the fragment, so there is one
+    # spelling of the number. The include is a no-op when that module is already
+    # in (the usual case: `nano_ros_entry()` includes it), and its constants are
+    # `CACHE INTERNAL`, so they survive an include from inside this frame.
+    include("${_NROS_MESSAGE_BOUNDS_DIR}/NanoRosEntityInventory.cmake")
+    unset(NROS_ENTITY_INVENTORY_SCHEMA_VERSION)
+    unset(NROS_ENTITY_INVENTORY_STATUS)
+    unset(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS)
+    unset(NROS_ENTITY_SUBSCRIBED_TYPES)
+    unset(NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS)
+    unset(NROS_ENTITY_SUBSCRIBED_TYPES_REASON)
+    include("${_frag}")
+
+    if(NOT DEFINED NROS_ENTITY_INVENTORY_SCHEMA_VERSION OR
+       NOT NROS_ENTITY_INVENTORY_SCHEMA_VERSION EQUAL
+           NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED)
+        # LOUD, and deliberately NOT a FATAL_ERROR, which is the one place this
+        # module departs from its own "refuse rather than read a moved field"
+        # rule. The fragment's PRODUCER (`nano_ros_entry()`) runs LATER in this
+        # same configure than this reader does, so a fatal here aborts the
+        # configure before the stale fragment can ever be rewritten -- the build
+        # dir would be stuck until someone deleted the file by hand. Nothing is
+        # read from the fragment either way: the payload classes fall to the
+        # closure, which over-approximates in the safe direction.
+        message(WARNING
+            "nros: ${_frag} states entity-inventory schema version "
+            "`${NROS_ENTITY_INVENTORY_SCHEMA_VERSION}`; the payload-class join "
+            "understands ${NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED}. It is being "
+            "IGNORED -- nothing is read from it field-by-field.\n"
+            "  A fragment that predates the join carries no subscribed-type set "
+            "at all, so this image's payload classes derive over its whole "
+            "LINKED CLOSURE, which is an upper bound and not the answer its "
+            "declaration would give.\n"
+            "  Rebuild the `nros` CLI so the producer and the reader come from "
+            "one tree (`./scripts/bootstrap.sh`; contributors: "
+            "`just setup-cli`) and re-configure; the fragment is "
+            "rewritten by `nano_ros_entry()` later in that configure and this "
+            "reader picks it up on the one after.")
+        set(${_o_basis} "closure" PARENT_SCOPE)
+        return()
+    endif()
+
+    # The image registered components but at least one declared no `ENTITIES`,
+    # so W9 refused for the whole image. Nothing was declared that this join can
+    # narrow to; the pre-W9 state, and it keeps the pre-W9 answer.
+    if(NOT NROS_ENTITY_INVENTORY_STATUS STREQUAL "derived")
+        set(${_o_basis} "closure" PARENT_SCOPE)
+        return()
+    endif()
+
+    # From here the image HAS declared, so the join is live and every failure
+    # below is a REFUSAL. A fall-back to the closure would publish a number
+    # derived over types this image never receives while the status still read
+    # `derived`.
+    if(NOT DEFINED NROS_ENTITY_SUBSCRIBED_TYPES_STATUS)
+        # The version matches, so the producer is current and the field must be
+        # there. Its absence is a hand-edited or half-written fragment. REFUSED
+        # and not widened to the closure: the image DID declare, so a closure
+        # answer here would be the wrong row wearing a `derived` status.
+        set(${_o_status} "refused" PARENT_SCOPE)
+        set(${_o_why}
+            "${_frag} states entity-inventory schema ${NROS_ENTITY_INVENTORY_SCHEMA_SUPPORTED}, which carries a subscribed-type set, and sets no NROS_ENTITY_SUBSCRIBED_TYPES_STATUS. The fragment is malformed -- delete it and re-configure, or regenerate the `nros` CLI with `./scripts/bootstrap.sh` (contributors: `just setup-cli`)."
+            PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT NROS_ENTITY_SUBSCRIBED_TYPES_STATUS STREQUAL "resolved")
+        set(${_o_status} "refused" PARENT_SCOPE)
+        set(${_o_why}
+            "this image declares its entities, so the payload classes are derived from them or not at all -- and the subscribed-type set did not resolve:\n${NROS_ENTITY_SUBSCRIBED_TYPES_REASON}"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    set(_count 0)
+    set(_small 0)
+    set(_large_types "")
+    set(_large_max 0)
+    set(_large_count 0)
+    set(_unpriced "")
+    foreach(_entry IN LISTS NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS)
+        string(REGEX REPLACE "=[0-9]+$" "" _t "${_entry}")
+        string(REGEX REPLACE "^.*=" "" _n "${_entry}")
+        math(EXPR _count "${_count} + ${_n}")
+        string(REGEX REPLACE "[^A-Za-z0-9]" "_" _key "${_t}")
+        if(NOT DEFINED NROS_MESSAGE_BOUND_${_key}_STATE)
+            list(APPEND _unpriced "${_t}")
+            continue()
+        endif()
+        set(_rx "${NROS_MESSAGE_BOUND_${_key}_RX}")
+        if(_rx GREATER _ceiling)
+            list(APPEND _large_types "${_t}=${_rx}")
+            math(EXPR _large_count "${_large_count} + ${_n}")
+            if(_rx GREATER _large_max)
+                set(_large_max "${_rx}")
+            endif()
+        elseif(_rx GREATER _small)
+            set(_small "${_rx}")
+        endif()
+    endforeach()
+
+    # A type the entity inventory names and the bound inventory does not price
+    # is the join failing, and it is loud. Today the commonest cause is
+    # structural rather than a typo: the bound inventory records MESSAGES only
+    # (`BoundInventory::record_message` is called for `.msg` and for nothing
+    # else), so a `pkg/srv/Name_Request` or a `pkg/action/Name_Result` has no
+    # entry however well-formed the declaration is.
+    if(_unpriced)
+        list(LENGTH _unpriced _unpriced_count)
+        string(REPLACE ";" "\n    " _unpriced_block "${_unpriced}")
+        set(${_o_status} "refused" PARENT_SCOPE)
+        set(${_o_why}
+            "${_unpriced_count} type(s) this image receives are not in the bound inventory, so their payload class cannot be derived:\n    ${_unpriced_block}\n  Either the declaration names a type this image does not link, or it names a service/action type -- the bound inventory prices MESSAGES (`pkg/msg/Name`) and nothing else, so `pkg/srv/*` and `pkg/action/*` have no entry to join against."
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    set(${_o_basis} "subscribed" PARENT_SCOPE)
+    set(${_o_count} "${_count}" PARENT_SCOPE)
+    set(${_o_small} "${_small}" PARENT_SCOPE)
+    set(${_o_large_types} "${_large_types}" PARENT_SCOPE)
+    set(${_o_large_max} "${_large_max}" PARENT_SCOPE)
+    set(${_o_large_count} "${_large_count}" PARENT_SCOPE)
 endfunction()
 
 # _nros_message_bounds_write_output(<path> <status> <reason> <ceiling>)
@@ -515,10 +819,13 @@ function(_nros_message_bounds_write_output _path _status _reason _ceiling)
     string(APPEND _c "# environment override states a number and WINS; this file only fills in\n")
     string(APPEND _c "# what nobody stated.\n")
     string(APPEND _c "#\n")
-    string(APPEND _c "# Each is an UPPER BOUND on what the image needs: the inventory holds every\n")
-    string(APPEND _c "# type in the LINKED interface closure, not only the subscribed ones. Too\n")
-    string(APPEND _c "# big, never too small. Narrowing it needs an ENTITY inventory, which no\n")
-    string(APPEND _c "# resolved SystemModel carries today (phase-403 W4).\n")
+    string(APPEND _c "# There are TWO BASES here and the file says which each number used.\n")
+    string(APPEND _c "# NROS_SUBSCRIPTION_BUFFER_SIZE is always derived over the LINKED closure:\n")
+    string(APPEND _c "# it is also DEFAULT_TX_BUF and the default buffer of every raw service,\n")
+    string(APPEND _c "# client and action entity, so a type this image only PUBLISHES still has\n")
+    string(APPEND _c "# to fit and narrowing it would size a buffer too small. The three payload\n")
+    string(APPEND _c "# classes are derived over the SUBSCRIBED set when the image declares its\n")
+    string(APPEND _c "# entities (phase-403 W9), and over the closure when it declares none.\n")
     string(APPEND _c "#\n")
     string(APPEND _c "# Derivation: nros_serdes::size::max_serialized_size, the same rule the\n")
     string(APPEND _c "# runtime's M::MAX_SERIALIZED_SIZE_XCDR* uses. NOT the C++ pack's\n")
@@ -540,29 +847,64 @@ function(_nros_message_bounds_write_output _path _status _reason _ceiling)
             "# ${NROS_DERIVED_LARGEST_TYPE} is the largest type in the closure.\n")
         string(APPEND _c
             "set(NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE ${NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE})\n")
-        if(DEFINED NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE)
+        string(APPEND _c "\n")
+        string(APPEND _c
+            "# ---- the three PAYLOAD-CLASS knobs, and the set they were derived over ----\n")
+        string(APPEND _c
+            "set(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS \"${NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS}\")\n")
+        if(NOT NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS STREQUAL "derived")
+            string(REPLACE "\\" "\\\\" _pr "${NROS_MESSAGE_BOUNDS_PAYLOAD_REASON}")
+            string(REPLACE "\"" "\\\"" _pr "${_pr}")
+            string(REPLACE "\n" "\\n" _pr "${_pr}")
+            string(APPEND _c "set(NROS_MESSAGE_BOUNDS_PAYLOAD_REASON \"${_pr}\")\n")
             string(APPEND _c
-                "# The largest type at or under the class split.\n")
-            string(APPEND _c
-                "set(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE ${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE})\n")
+                "# NROS_SUBSCRIBER_BUFFER_SIZE, NROS_SUBSCRIBER_LARGE_SIZE and\n"
+                "# NROS_MAX_LARGE_SUBSCRIBERS are NOT derived and do NOT fall back to the\n"
+                "# closure. This image states what it receives, so the classes come from\n"
+                "# that or from nowhere; each keeps its configured value.\n")
         else()
             string(APPEND _c
-                "# No type fits under the ${_ceiling} B split, so the small class size is\n"
-                "# not derivable from the type set -- but the class is still used, by any\n"
-                "# caller that states no hint. NROS_SUBSCRIBER_BUFFER_SIZE keeps its\n"
-                "# configured value.\n")
+                "set(NROS_MESSAGE_BOUNDS_BASIS \"${NROS_MESSAGE_BOUNDS_BASIS}\")\n")
+            if(NROS_MESSAGE_BOUNDS_BASIS STREQUAL "subscribed")
+                string(APPEND _c
+                    "# Derived over the ${NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT} SUBSCRIPTIONS this image declares\n"
+                    "# (`nano_ros_node_register(... ENTITIES ...)`), not over the\n"
+                    "# ${NROS_MESSAGE_BOUNDS_TYPE_COUNT}-type linked closure. A type the image links and never\n"
+                    "# receives cannot set a class here.\n")
+            else()
+                string(APPEND _c
+                    "# UPPER BOUND: this image declares no entities, so the classes are derived\n"
+                    "# over the whole ${NROS_MESSAGE_BOUNDS_TYPE_COUNT}-type linked closure and are sized for the largest\n"
+                    "# type it COULD receive, not the largest it does. Declare\n"
+                    "# `nano_ros_node_register(... ENTITIES sub:<pkg>/msg/<Name> ...)` on every\n"
+                    "# component to narrow them.\n")
+            endif()
         endif()
-        string(APPEND _c
-            "# Types over the split: ${NROS_DERIVED_LARGE_TYPES}\n")
-        string(APPEND _c
-            "set(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS ${NROS_DERIVED_MAX_LARGE_SUBSCRIBERS})\n")
-        if(DEFINED NROS_DERIVED_SUBSCRIBER_LARGE_SIZE)
+        if(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS STREQUAL "derived")
+            if(DEFINED NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE)
+                string(APPEND _c
+                    "# The largest received type at or under the class split.\n")
+                string(APPEND _c
+                    "set(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE ${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE})\n")
+            else()
+                string(APPEND _c
+                    "# Nothing this image receives fits under the ${_ceiling} B split, so the small\n"
+                    "# class size is not derivable from that set -- but the class is still used,\n"
+                    "# by any caller that states no hint. NROS_SUBSCRIBER_BUFFER_SIZE keeps its\n"
+                    "# configured value.\n")
+            endif()
             string(APPEND _c
-                "set(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE ${NROS_DERIVED_SUBSCRIBER_LARGE_SIZE})\n")
-        else()
+                "# Received types over the split: ${NROS_DERIVED_LARGE_TYPES}\n")
             string(APPEND _c
-                "# Zero large-class blocks, so the pool is zero bytes whatever size it\n"
-                "# would name -- NROS_SUBSCRIBER_LARGE_SIZE is deliberately not derived.\n")
+                "set(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS ${NROS_DERIVED_MAX_LARGE_SUBSCRIBERS})\n")
+            if(DEFINED NROS_DERIVED_SUBSCRIBER_LARGE_SIZE)
+                string(APPEND _c
+                    "set(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE ${NROS_DERIVED_SUBSCRIBER_LARGE_SIZE})\n")
+            else()
+                string(APPEND _c
+                    "# Zero large-class blocks, so the pool is zero bytes whatever size it\n"
+                    "# would name -- NROS_SUBSCRIBER_LARGE_SIZE is deliberately not derived.\n")
+            endif()
         endif()
     endif()
     set(_write TRUE)
@@ -589,6 +931,7 @@ endfunction()
 #
 #   cmake -DNROS_BOUNDS_FRAGMENTS="a.cmake;b.cmake" \
 #         [-DNROS_BOUNDS_CEILING=2048] [-DNROS_BOUNDS_OUTPUT=out.cmake] \
+#         [-DNROS_BOUNDS_ENTITY_INVENTORY=entity_inventory.cmake] \
 #         -P cmake/NanoRosMessageBounds.cmake
 # -----------------------------------------------------------------------------
 if(CMAKE_SCRIPT_MODE_FILE AND
@@ -606,11 +949,17 @@ if(CMAKE_SCRIPT_MODE_FILE AND
     if(DEFINED NROS_BOUNDS_OUTPUT)
         list(APPEND _args OUTPUT_FILE "${NROS_BOUNDS_OUTPUT}")
     endif()
+    if(DEFINED NROS_BOUNDS_ENTITY_INVENTORY)
+        list(APPEND _args ENTITY_INVENTORY "${NROS_BOUNDS_ENTITY_INVENTORY}")
+    endif()
     nros_derive_message_bound_knobs(${_args})
     message(STATUS "NROS_MESSAGE_BOUNDS_STATUS=${NROS_MESSAGE_BOUNDS_STATUS}")
     foreach(_v
         NROS_MESSAGE_BOUNDS_TYPE_COUNT
         NROS_MESSAGE_BOUNDS_BOUNDED_COUNT
+        NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS
+        NROS_MESSAGE_BOUNDS_BASIS
+        NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT
         NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE
         NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE
         NROS_DERIVED_MAX_LARGE_SUBSCRIBERS
@@ -621,4 +970,8 @@ if(CMAKE_SCRIPT_MODE_FILE AND
             message(STATUS "${_v}=${${_v}}")
         endif()
     endforeach()
+    if(NOT NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS STREQUAL "derived")
+        message(STATUS
+            "NROS_MESSAGE_BOUNDS_PAYLOAD_REASON=${NROS_MESSAGE_BOUNDS_PAYLOAD_REASON}")
+    endif()
 endif()

--- a/cmake/NanoRosNodeRegister.cmake
+++ b/cmake/NanoRosNodeRegister.cmake
@@ -11,6 +11,31 @@
 #         link glue. CLASS is any namespace-qualified name (RFC-0057; the
 #         L.4 prefix rule is retired — pkg is explicit metadata).
 #
+#     phase-403 W9 (issue 0965) adds the optional
+#       `ENTITIES <spec>...`  |  `ENTITIES NONE`
+#     argument — WHICH entities this component's constructor creates. Each
+#     spec is `<kind>[:<type>[:<name>]]`, with an optional `*N` repeat on the
+#     kind:
+#
+#         ENTITIES sub:nav_msgs/msg/Odometry:/localization/kinematic_state
+#                  pub*5 timer service_client*2
+#
+#     Kinds: publisher, subscription, timer, service_server, service_client,
+#     action_server, action_client, guard_condition (short forms pub / sub /
+#     srv / client are accepted). `nros ws entity-inventory` owns the grammar.
+#
+#     WHY THE AUTHOR STATES IT. RFC-0043/0044 components wire themselves in
+#     CONSTRUCTORS, at runtime; the macros know the kind and the type `M`, but
+#     anything they emit is a link-section fact and exists only after linking,
+#     while `NROS_EXECUTOR_MAX_CBS` and the arena are `const` sizes compiled
+#     INTO nros-node before a component TU is compiled. Emitted evidence can
+#     VERIFY a count; it can never SUPPLY one.
+#
+#     ABSENT IS NOT ZERO. Omitting `ENTITIES` writes no `entities` key at all,
+#     and one such component makes the whole image REFUSE to derive rather than
+#     derive a total that is short. `ENTITIES NONE` is how a component that
+#     really creates nothing says so.
+#
 #   * `nano_ros_entry(NAME <name> SOURCES <files...> [BOARD <board>]
 #       DEPLOY <target1> [<target2> ...])`
 #       — declares an Entry pkg entity. Renamed from
@@ -145,7 +170,7 @@ function(_nros_json_strlist out_var)
 endfunction()
 
 function(nano_ros_node_register)
-    cmake_parse_arguments(_NRC "TYPED" "NAME;CLASS;LANGUAGE;HEADER;SHAPE;EXISTING_TARGET" "SOURCES;DEPLOY;CALLBACK_GROUPS" ${ARGN})
+    cmake_parse_arguments(_NRC "TYPED" "NAME;CLASS;LANGUAGE;HEADER;SHAPE;EXISTING_TARGET" "SOURCES;DEPLOY;CALLBACK_GROUPS;ENTITIES" ${ARGN})
     # RFC-0057 (phase-305 W1.1) — EXISTING_TARGET mode: the component library
     # was created separately (`nano_ros_auto_add_library`); attach
     # registration (class define, metadata row, carrier glue) to it instead
@@ -972,6 +997,43 @@ function(nano_ros_node_register)
     _nros_json_strlist(_sources_json ${_NRC_SOURCES})
     _nros_json_strlist(_deploy_json  ${_NRC_DEPLOY})
     _nros_json_strlist(_cbgs_json    ${_NRC_CALLBACK_GROUPS})
+
+    # phase-403 W9 (issue 0965) — the ENTITY declaration.
+    #
+    # `"entities"` is EMITTED ONLY WHEN THE KEYWORD WAS GIVEN, and that is the
+    # whole design rather than a nicety. `nros ws entity-inventory` must be able
+    # to tell "this component creates nothing" from "this component said
+    # nothing": the first is an answer it can compose, the second makes the
+    # WHOLE image refuse to derive. An always-present `"entities": []` collapses
+    # exactly those two, and the collapse is an under-report — a `MAX_CBS`
+    # smaller than the image needs, which fails entity creation at boot.
+    #
+    # So: keyword absent  -> no key at all -> "did not say".
+    #     ENTITIES NONE   -> ["none"]      -> "creates none", derivable.
+    #     ENTITIES <spec>… -> the specs.
+    #
+    # `KEYWORDS_MISSING_VALUES` catches the third shape, `ENTITIES` with nothing
+    # after it, which cmake would otherwise leave indistinguishable from absent.
+    # It is a typo rather than a claim, so it is a hard error here — the one
+    # validation this side does, because it is the one the CLI cannot see.
+    set(_entities_field "")
+    if("ENTITIES" IN_LIST _NRC_KEYWORDS_MISSING_VALUES)
+        message(FATAL_ERROR
+            "nano_ros_node_register(${_NRC_NAME}): ENTITIES was given with no values.\n"
+            "  Write `ENTITIES NONE` if this component creates no entities, or list them:\n"
+            "    ENTITIES sub:nav_msgs/msg/Odometry:/odom pub*2 timer\n"
+            "  Omitting ENTITIES entirely is also legal and means \"not declared\" — the\n"
+            "  image then keeps its configured NROS_EXECUTOR_MAX_CBS instead of a derived one.")
+    endif()
+    if(DEFINED _NRC_ENTITIES)
+        # The specs are NOT parsed here. `nros ws entity-inventory` owns the
+        # grammar and the kind vocabulary; a second parser in cmake is how the
+        # two spellings drift, and its error would name a token rather than a
+        # component.
+        _nros_json_strlist(_entities_json ${_NRC_ENTITIES})
+        set(_entities_field ", \"entities\": [${_entities_json}]")
+    endif()
+
     get_property(_acc GLOBAL PROPERTY NROS_COMPONENTS_JSON)
     if(_acc)
         set(_sep ",")
@@ -983,7 +1045,7 @@ function(nano_ros_node_register)
 \"class_header\": \"${_nrc_header}\", \"shape\": \"${_nrc_shape}\", \
 \"sources\": [${_sources_json}], \"deploy\": [${_deploy_json}], \
 \"pkg_dir\": \"${CMAKE_CURRENT_SOURCE_DIR}\", \"lang\": \"${_nrc_lang_lc}\", \
-\"callback_groups\": [${_cbgs_json}]}")
+\"callback_groups\": [${_cbgs_json}]${_entities_field}}")
     set_property(GLOBAL APPEND_STRING PROPERTY NROS_COMPONENTS_JSON "${_entry}")
     _nros_metadata_emit()
 endfunction()

--- a/cmake/NanoRosVerbs.cmake
+++ b/cmake/NanoRosVerbs.cmake
@@ -373,7 +373,7 @@ endfunction()
 # have; the legacy `configure(Node&)` shape is the explicit opt-in.
 # ---------------------------------------------------------------------------
 function(nros_components_register_node target)
-    cmake_parse_arguments(_NCR "TYPED" "PLUGIN;EXECUTABLE;HEADER;SHAPE" "DEPLOY;CALLBACK_GROUPS" ${ARGN})
+    cmake_parse_arguments(_NCR "TYPED" "PLUGIN;EXECUTABLE;HEADER;SHAPE" "DEPLOY;CALLBACK_GROUPS;ENTITIES" ${ARGN})
     foreach(_req PLUGIN EXECUTABLE)
         if(NOT _NCR_${_req})
             message(FATAL_ERROR
@@ -417,6 +417,21 @@ function(nros_components_register_node target)
     endif()
     if(_NCR_CALLBACK_GROUPS)
         list(APPEND _extra CALLBACK_GROUPS ${_NCR_CALLBACK_GROUPS})
+    endif()
+    # phase-403 W9 (issue 0965) — forward the ENTITY declaration.
+    #
+    # `DEFINED` and not truthiness, unlike every sibling above. A `list(APPEND)`
+    # gated on the VALUE cannot express "the caller declared something", only
+    # "the caller declared something cmake reads as true" — and cmake reads
+    # `0`, `OFF`, `NO`, `N`, `IGNORE`, `NOTFOUND` and anything `*-NOTFOUND` as
+    # false. None of those is a legal entity spec today, so the difference is
+    # currently invisible; it stops being invisible the first time the grammar
+    # grows a spelling that collides, and what it would cost then is exactly
+    # the under-report this wave exists to make impossible. Forwarding the
+    # keyword-missing case too is deliberate: `nano_ros_node_register` raises
+    # the error, so a bare `ENTITIES` fails identically through either spelling.
+    if(DEFINED _NCR_ENTITIES OR "ENTITIES" IN_LIST _NCR_KEYWORDS_MISSING_VALUES)
+        list(APPEND _extra ENTITIES ${_NCR_ENTITIES})
     endif()
     nano_ros_node_register(
         NAME ${_NCR_EXECUTABLE}

--- a/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
+++ b/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
@@ -115,3 +115,24 @@ A knob nobody can enumerate is a knob nobody sets, which is the 0271 / 0739
 shape this repo keeps rediscovering. The difference here is that the number is
 no longer unknowable: it is computed, written to disk in three formats, and
 then ignored.
+
+## Update 2026-08-31 (phase-403 W9, issue 0965): item 1 has its source
+
+The "second source" this issue named -- per image, the number of subscriptions,
+publishers, timers and service entities, each bound to a type NAME the bound
+inventory can price -- now exists: `nros_cli_core::entity_inventory`, composed
+from `nano_ros_node_register(... ENTITIES ...)` and read by
+`cmake/NanoRosEntityInventory.cmake`. Item **1** of "What would resolve it" is
+done: `NROS_EXECUTOR_MAX_CBS` derives.
+
+It also corrects a number this issue repeats. "`MAX_CBS` counts total HANDLES"
+is right; "the answer was 33" is not. 33 is the island's ENTITY count and 14 of
+those are publishers, which claim no callback slot -- `create_publisher` never
+reaches `Executor::next_entry_slot()`. The slot demand is **19** against a
+hand-set 36.
+
+Items **2** (the arena) and **3** (the payload classes) are still open, and now
+for a different reason than "no entity inventory exists": both need the two
+inventories JOINED per subscription -- W8's per-type size against W9's
+per-entity list. A total from either half alone is the same plausible wrong
+number, so the join is its own work.

--- a/docs/issues/0965-no-entity-inventory-so-three-consumers-cannot-be-derived.md
+++ b/docs/issues/0965-no-entity-inventory-so-three-consumers-cannot-be-derived.md
@@ -71,3 +71,102 @@ Two plausible producers, neither chosen:
 what codegen can see, and have the executor's first-spin advisory report any
 delta -- is likely the honest answer, and issue 0900 W1 already landed the
 reporting half.
+
+## Partly fixed 2026-08-31 (phase-403 W9): the inventory exists and has a consumer
+
+Still `open`, and the remaining half is named below rather than implied.
+
+### The fork, decided
+
+The HYBRID, with the halves assigned by what each can actually do rather than
+by preference.
+
+Candidate 1 (emit a descriptor from the registration macros) cannot be the
+producer, and the reason is the timing the issue already suspected, sharpened:
+`NROS_EXECUTOR_MAX_CBS` and `NROS_EXECUTOR_ARENA_SIZE` are `const` sizes
+compiled INTO `nros-node`, which is built before a single component TU is
+compiled, let alone linked. A link-section manifest can VERIFY a count; it can
+never SUPPLY one. That is the direction of the build graph, not a gap.
+
+So the declaration supplies and the running image verifies:
+
+* **Supply.** `nano_ros_node_register(... ENTITIES <spec>...)`, stated beside
+  `CLASS` / `SHAPE` / `CALLBACK_GROUPS` and travelling the channel that
+  declaration already travels, `nros-metadata.json`.
+* **Verify.** The derived value carries NO headroom, so it is exactly the
+  declared demand. One entity more than declared and registration returns
+  `NodeError::ExecutorFull`, which names the knob; `ComponentNode`'s `ok()`
+  flag then halts boot naming the failing node.
+
+### What landed
+
+* `nros_cli_core::entity_inventory` -- ONE data model, three transports (JSON,
+  an `include()`able CMake fragment, `KEY=VALUE` env lines), shaped after
+  `rosidl_codegen::bounds` rather than as a second mechanism. The env line is
+  the cargo transport, because the knob is read from the environment by
+  `nros-node/build.rs`.
+* `nros ws entity-inventory` -- the verb, sibling of `ws entity-facts`.
+* `cmake/NanoRosEntityInventory.cmake` -- the reader, sibling of
+  `NanoRosMessageBounds.cmake`, invoked from `nano_ros_entry()` (the first
+  point in a configure guaranteed to be after every registration).
+* `NROS_EXECUTOR_MAX_CBS` moved onto the derivable ladder with `-1` as its
+  Kconfig sentinel. Environment > Kconfig / board `.conf` > derived > crate
+  default, unchanged from W8.
+
+### The number the bring-up got wrong
+
+A PUBLISHER CLAIMS NO CALLBACK SLOT. Every registration that claims one calls
+`Executor::next_entry_slot()` -- 24 sites, all subscriptions, timers, services,
+service clients, action servers, action clients and guard conditions.
+`create_publisher` is not among them: on the C++ path it writes an
+`RmwPublisher` into caller-owned storage, and on the C path there is no
+`nros_executor_add_publisher` to increment `handle_count`.
+
+So the "33 handles" this issue quotes is the ENTITY count, and 14 of those 33
+are publishers. Measured over the island's own `build-board/nros-metadata.json`:
+
+| | value |
+| --- | ---: |
+| hand-set in `mr_canhubk3_s32k344.conf` | 36 |
+| entities declared | 33 |
+| **executor callback slots** | **19** |
+
+The bring-up table's per-node columns are mis-attributed too -- it reads 6
+timers and 2 services where the source has 4 timers, 2 service servers and 2
+service clients. The total comes out right by coincidence, which is the best
+argument in this issue for not counting by hand.
+
+`EntityKind::callback_slots()` is a MIRROR (the CLI cannot depend on the
+`no_std` target crate) and is held to those 24 sites by
+`just check entity-slot-costs`, the same way `ACTION_SERVER_QUERYABLES` is held
+to its creation sites.
+
+### An under-report cannot be silent
+
+1. Composition REFUSES for the whole image if ANY component declared no
+   entities -- W8's rule for an unbounded type, applied to an undeclared
+   component. `ENTITIES NONE` is the explicit "creates nothing", so absence
+   always means "nobody said".
+2. The derived value has no headroom, which makes the image check its own
+   declaration.
+3. A short declaration is a named, boot-fatal `ExecutorFull`, not a silent
+   mis-size. This is exactly why `MAX_CBS` was the right first consumer and the
+   arena was not: an under-sized arena halts DURING entity creation, before the
+   first spin, so issue 0900 W1's advisory never prints.
+
+### What is still uncovered
+
+* **The arena** and **the zenoh payload classes** need the two inventories
+  JOINED per subscription -- this one's per-entity list against W8's per-type
+  size. Either half alone yields the confident wrong number. Named as its own
+  work rather than bolted onto either reader.
+* **`NROS_MAX_SUBSCRIBERS` / `NROS_MAX_PUBLISHERS`** are a straight read of
+  `NROS_ENTITY_COUNT_SUBSCRIPTION` / `_PUBLISHER`. Left out for scope
+  discipline, not for a reason.
+* **No image in this tree declares `ENTITIES` yet**, so nothing derives today;
+  every existing image refuses and keeps its configured value. The island's own
+  declaration is four `nros_components_register_node(... ENTITIES ...)` edits
+  in the consumer repo.
+* **Not measured on hardware.** The island was not flashed. The code claim (a
+  publisher claims no slot) is verified by reading all 24 registration sites
+  and by the gate; the byte saving is not.

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -975,6 +975,147 @@ codegen). It pins the derived VALUES, the composition across packages, the
 refusal and its negative control, the per-fragment schema check, and the
 write-if-changed.
 
+### W9 LANDED 2026-08-31 (issue 0965) -- the ENTITY inventory, and the number the bring-up got wrong
+
+W8's boundary was honest and it was also the end of what a BOUND inventory can
+do. It prices a TYPE; three consumers need to know WHICH ENTITIES AN IMAGE
+CREATES, and until something said, `NROS_EXECUTOR_MAX_CBS` stayed hand-counted,
+the arena stayed six bisections deep, and W4's payload classes derived over the
+LINKED closure at a measured cost of 2176 bytes instead of a 27392-byte saving.
+
+**The design fork, and why the choice is not a matter of taste.** Issue 0965
+named two producers -- a descriptor emitted from the registration macros, or an
+author-stated manifest -- and a hybrid. The macros DO know the entity kind and
+the type `M`; that is how W3 got the per-type bound to the arena. But anything
+they emit is a LINK-SECTION fact and exists only after linking, while
+`NROS_EXECUTOR_MAX_CBS` is a `const` compiled into `nros-node` before a single
+component TU is compiled. Emitted evidence can VERIFY a count and can never
+SUPPLY one. That is the direction of the build graph, not a gap in the tooling,
+so the declaration supplies and the running image verifies -- the hybrid, with
+the halves assigned by what each can actually do.
+
+**Where the author states it.** `nano_ros_node_register(... ENTITIES ...)`,
+beside `CLASS`, `SHAPE` and `CALLBACK_GROUPS`, travelling the channel that
+declaration already travels: `nros-metadata.json`. Each spec is
+`<kind>[:<type>[:<name>]]` with an optional `*N` repeat, and the type name is
+the `pkg/msg/Name` spelling the bound inventory already keys on, so the two
+inventories join without a second naming convention.
+
+**One data model, three transports** -- `nros_cli_core::entity_inventory`,
+shaped after `rosidl_codegen::bounds` rather than as a second mechanism: the
+canonical JSON, the `include()`able CMake fragment, and `KEY=VALUE` env lines.
+The env line IS the cargo transport here, because the knob it feeds is read
+from the environment by `nros-node/build.rs` and there is no generated crate to
+hang a `links` key on; it is the same carrier `nros ws entity-facts` already
+publishes through `corrosion_set_env_vars`.
+
+**A publisher claims NO callback slot, and this is the wave's real finding.**
+`MAX_CBS` sizes the executor's callback-entry table. Every registration that
+claims an entry calls `Executor::next_entry_slot()`; the 24 sites that do are
+subscriptions, timers, services, service clients, action servers, action
+clients and guard conditions. `create_publisher` is not one -- on the C++ path
+it writes an `RmwPublisher` into caller-owned storage, and on the C path there
+is no `nros_executor_add_publisher` to increment `handle_count`.
+
+So the bring-up log's table is wrong in a way nobody could see. It records "33
+handles" for the island and sets `MAX_CBS=36` from it; 33 is the ENTITY count
+and 14 of those are publishers. The slot demand is 19. (Its per-node columns
+are also mis-attributed -- it reads 6 timers and 2 services where the source
+has 4 timers, 2 service servers and 2 service clients. The TOTAL happens to
+come out right, which is exactly why a hand-count is not evidence.)
+
+Gate: `just check entity-slot-costs`
+(`scripts/check-entity-slot-costs.py`). `EntityKind::callback_slots()` is a
+MIRROR -- the CLI is a host binary and `nros-node` is `no_std` and built for the
+target -- so it is held to the `next_entry_slot()` sites, the same way
+`ACTION_SERVER_QUERYABLES` is held to its creation sites. Five self-test
+mutations, including "a publisher started claiming a slot" in both the Rust and
+the C accounting.
+
+**An under-report cannot be silent, in three layers.**
+
+1. **Composition REFUSES on incomplete data.** One component in the image with
+   no `ENTITIES` and nothing is derived for the WHOLE image -- the same rule
+   `nros_derive_message_bound_knobs` holds when any type in the closure is
+   unbounded, and for the same reason. `ENTITIES NONE` is how a component that
+   really creates nothing says so, so ABSENCE always means "nobody said". An
+   `ENTITIES` list that is present and empty reads as absent too.
+2. **The derived value carries NO headroom**, deliberately. It is exactly the
+   declared demand, which makes the running image a checker of its own
+   declaration.
+3. **A short declaration is a NAMED boot failure.** Registration past the table
+   returns `NodeError::ExecutorFull`, which names the knob, and
+   `ComponentNode`'s `ok()` flag halts boot naming the failing node. This is
+   why `MAX_CBS` is the right FIRST consumer and the arena is not: an
+   under-sized arena halts DURING entity creation, before the first spin, which
+   is exactly why issue 0900 W1's advisory cannot cover it.
+
+**Precedence, unchanged from W8.** `NROS_EXECUTOR_MAX_CBS` moved from the plain
+`_nros_resolve_knob` to `_nros_resolve_derivable_knob` and its Kconfig default
+became the `-1` sentinel. Environment > Kconfig / board `.conf` > derived >
+crate default. Every image built before this wave declares no entities, so its
+inventory refuses, so it falls to rung 4 and the crate default of 4 -- exactly
+where it was.
+
+**Measured on the reference image**, the mr-canhubk344 island entry, over the
+`nros-metadata.json` its own board configure wrote (`build-board/`, 4 C++
+components):
+
+| | source | value |
+| --- | --- | ---: |
+| hand-set today | `boards/mr_canhubk3_s32k344.conf` | 36 |
+| the bring-up log's hand-count | `phase-3-canhubk344-real-silicon.md` | 33 |
+| DERIVED, entities declared | `NROS_ENTITY_INVENTORY_ENTITY_TOTAL` | 33 |
+| DERIVED, callback slots | `NROS_DERIVED_EXECUTOR_MAX_CBS` | **19** |
+
+Per component, as the fragment records it:
+
+| component | entities | slots |
+| --- | ---: | ---: |
+| `mrm_handler` | 15 | 10 |
+| `stop_mode_operator` | 8 | 4 |
+| `mrm_emergency_stop_operator` | 5 | 3 |
+| `mrm_comfortable_stop_operator` | 5 | 2 |
+| **total** | **33** | **19** |
+
+and by kind: 14 publishers, 11 subscriptions, 4 timers, 2 service servers, 2
+service clients, 0 actions, 0 guard conditions.
+
+Run against the SAME metadata with no declarations -- which is the island's
+tree as it stands -- the inventory refuses, names all four components, and
+publishes no number. That is the before/after: the refusal is the current
+state, and 19 is what the declaration buys.
+
+**What 17 slots are worth, and what is NOT claimed.** The arena is
+`max_cbs * (3 * SUBSCRIPTION_BUFFER_SIZE + 512) + 2048` when nothing pins it,
+so 36 -> 19 is 17 slots of arena the island stops reserving. The island PINS
+`CONFIG_NROS_EXECUTOR_ARENA_SIZE=40960`, so that saving is not automatic there
+and this wave does not claim it: the two knobs must move together, which is
+what W8's own Kconfig help already says. What IS claimed is the 17 slots'
+worth of `group_sched_table` (~168 B per slot, phase-409's measurement) and
+`entries`, which scale with `MAX_CBS` with no second knob to pin them.
+
+**Not measured on hardware.** The island was not flashed for this wave. The
+number is a DEFAULT under a `.conf` that still states 36, so adopting it is a
+deliberate act by whoever next brings the board up; the code claim -- that a
+publisher claims no slot -- is verified by reading all 24 registration sites
+and by the gate, not by a boot.
+
+**What W9 does NOT derive, and why it is not one more patch.** The arena and
+the zenoh payload classes need the two inventories JOINED per subscription:
+this wave's per-entity list against W8's per-type size. A total taken from
+either half alone is the same confident wrong number the campaign exists to
+remove, so the join is named as its own work rather than bolted onto either
+reader. `NROS_MAX_SUBSCRIBERS` / `NROS_MAX_PUBLISHERS` are a straight read of
+`NROS_ENTITY_COUNT_SUBSCRIPTION` / `_PUBLISHER` and were left out only for
+scope discipline -- one consumer, wired end to end, was the brief.
+
+Gate: `just check entity-inventory-knobs`
+(`tests/cmake-entity-inventory-tests.sh`, 24 assertions, `cmake -P` with a
+STUBBED CLI so it needs cmake and no cargo build) plus 19 unit tests in
+`nros_cli_core::entity_inventory` and `cmd::entity_inventory`, including the
+island case above.
+
 ## Relationship to phase-408 (PR #130)
 
 phase-408, "a C/C++ subscription sizes its buffer from its own message type",

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1153,6 +1153,73 @@ keeps `M` as a template parameter to the last call, in a header, and the arena
 owns the buffer there rather than the caller. The hand-written C API, which
 genuinely has no `M`, is the part that still needs a caller-supplied buffer.
 
+## Deriving the arena and the payload classes: the remaining steps
+
+Two inventories now exist and neither derives these on its own. W6/W8 price a
+TYPE; W9 lists an image's ENTITIES. The arena and the payload classes both need
+the two JOINED per subscription, and a total from either half alone is the same
+confident wrong number this campaign keeps removing.
+
+The two are NOT equally blocked, and the difference is worth stating because it
+sets the order.
+
+### Step 1 -- payload classes. Ready; no new input.
+
+A payload class is about ONE sample's size, so it needs only "which types are
+RECEIVED" times "their bound". W9 supplies the first by filtering its entity
+list to the receiving kinds; W6/W8 supply the second. Nothing else is required.
+
+The payoff is already measured on the island entry:
+
+| basis | SMALL | LARGE | total |
+| --- | ---: | ---: | ---: |
+| hand-set today | 49152 | 20480 | 69632 |
+| derived over the LINKED closure | 71808 | 0 | 71808 |
+| derived over the SUBSCRIBED set | 42240 | 0 | 42240 |
+
+W8 derives the middle row, which COSTS 2176 bytes: one
+`std_msgs/Float64MultiArray`, linked and never received, sets the small class
+for every subscription in the image. The join is exactly the difference between
+that row and the last one -- 27392 bytes.
+
+### Step 2 -- QoS depth in the declaration. Blocks the arena.
+
+The arena's per-subscription cost is
+`sizeof(entry) + buffered_region_size(depth, bound)`, and that region is
+`(depth + 1) * bound + (depth + 1) * 8`. **Depth is a multiplier on the bound**,
+measured on this island at ten subscriptions: 86108 bytes at the ROS default
+depth 10, 24516 at depth 1.
+
+W9's entity record carries `kind`, `type_name` and `name`. It does NOT carry
+depth, so a derived arena today would be wrong by up to 10x.
+
+Defaulting it is the worst option available. The ROS default IS 10, so assuming
+it inflates the arena tenfold on an image that states depth 1, and assuming 1
+UNDER-sizes an image that took the default -- the unsafe direction. Depth must be
+declared, on W9's own principle: the declaration supplies, the running image
+verifies.
+
+### Step 3 -- the arena. Last, because its failure cannot report itself.
+
+With depth present the arena is a straight sum: `arena_alloc` is a BUMP
+allocator, so the total IS the sum of the allocations. Two things are still
+needed:
+
+* **A probe per arena entry kind.** There are ten distinct entry types
+  (`SubBufferedRawCEntry`, `SrvRawEntry`, `TimerEntry`,
+  `ServiceClientRawArenaEntry`, the action entries, ...), each with its own size
+  and buffer terms. The existing size probe exports `RAW_SUBSCRIPTION_SIZE` and
+  friends, but those are the L1 POLLING handles, not these arena entries.
+* **The verification half**, which already exists: issue 0900 W1 landed
+  `arena_used()` and a first-spin advisory reporting what was actually claimed.
+
+**Why the arena is last.** An under-sized arena halts DURING entity creation --
+before the first spin -- so the advisory never prints. `MAX_CBS` was the right
+first consumer for the opposite reason: it fails AT registration with
+`ExecutorFull`, which names the knob. A derived arena is the one number whose
+failure mode cannot report itself, so it should land only once the inputs
+feeding it are themselves verified.
+
 ## Measurement, first not last
 
 Every wave here claims bytes, and this campaign has twice published a number

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1163,24 +1163,121 @@ confident wrong number this campaign keeps removing.
 The two are NOT equally blocked, and the difference is worth stating because it
 sets the order.
 
-### Step 1 -- payload classes. Ready; no new input.
+### Step 1 LANDED 2026-09-01 -- the payload classes are derived over the JOIN
 
-A payload class is about ONE sample's size, so it needs only "which types are
-RECEIVED" times "their bound". W9 supplies the first by filtering its entity
-list to the receiving kinds; W6/W8 supply the second. Nothing else is required.
+A payload class is about ONE sample's size, so it needs "which types are
+RECEIVED" times "their bound". W9 supplies the first; W6/W8 supply the second.
+`nros_derive_message_bound_knobs()` now takes an `ENTITY_INVENTORY` argument
+and `nros_find_interfaces()` passes W9's fragment, so the three payload-class
+knobs derive over the image's SUBSCRIPTIONS.
 
-The payoff is already measured on the island entry:
+**Measured on the reference island** -- the mr-canhubk344 entry, over the 84
+bounded types in the 11 `nros_message_bounds.cmake` fragments its own board
+configure wrote, joined against an entity declaration built from the island's
+published `docs/topic-contract.md`. Priced in `.bss` at that image's own
+`MAX_SUBSCRIBERS = 12` and `RING_DEPTH = 4`:
 
-| basis | SMALL | LARGE | total |
-| --- | ---: | ---: | ---: |
-| hand-set today | 49152 | 20480 | 69632 |
-| derived over the LINKED closure | 71808 | 0 | 71808 |
-| derived over the SUBSCRIBED set | 42240 | 0 | 42240 |
+| basis | small class | SMALL | LARGE | total |
+| --- | ---: | ---: | ---: | ---: |
+| hand-set today | 1024 | 49152 | 20480 | 69632 |
+| derived over the LINKED closure | 1496 | 71808 | 0 | 71808 |
+| derived over the SUBSCRIBED set | **880** | **42240** | 0 | **42240** |
 
-W8 derives the middle row, which COSTS 2176 bytes: one
-`std_msgs/Float64MultiArray`, linked and never received, sets the small class
-for every subscription in the image. The join is exactly the difference between
-that row and the last one -- 27392 bytes.
+**Which type sets the small class, before and after.** Before:
+`std_msgs/msg/Float64MultiArray` at 1496 B, which the island links and never
+receives. After: `nav_msgs/msg/Odometry` at 880 B, the largest of the ten
+topics the contract says it subscribes to. That is the whole finding, and it is
+worth 29,568 B against the middle row and 27,392 B against the hand-set one.
+
+Residual, stated: W9's declaration for this image reads `sub*7` on
+`mrm_handler` and the published topic contract names six of those seven, so the
+measurement above is over TEN subscriptions and not eleven. A missing
+subscription can only ADD a type, never remove one, so the answer can only move
+UP -- and only if that seventh type exceeds 880 B, which no type in the
+island's own closure does except the four `std_msgs` multi-arrays it links from
+`geometry_msgs`. Not measured on hardware; the board is the owner's.
+
+**Which kinds count as RECEIVING, and why it is two predicates.**
+`EntityKind::receives()` is the semantic set, read off the arena entry types
+rather than off the names, which mislead in both directions: a service SERVER
+receives requests (`SrvRawEntry` carries a `req_buffer`), a service CLIENT
+receives replies (`ServiceClientRawArenaEntry<REPLY_BUF>`), and an action
+server and an action client EACH carry three receive buffers
+(`GOAL_BUF`/`RESULT_BUF`/`FEEDBACK_BUF`). A publisher is not in it: it
+serialises into a per-call stack array, which is a transmit buffer.
+
+`EntityKind::receives_topic_sample()` is narrower -- subscriptions only -- and
+it is what the payload classes join on. That is MEASURED, not assumed: the
+pools `SMALL_PAYLOADS`/`LARGE_PAYLOADS` are reached through exactly one
+allocation, `alloc_payload_block(rx_buffer_hint)`, with exactly one caller, the
+`declare_subscriber` path. Including the other receiving kinds would not make
+the number safer; it would make it describe a pool those entities never
+allocate from. Both sets are published, because the arena (step 3) needs the
+wider one and a second derivation of it is how two green tools come to
+disagree.
+
+**The take buffer deliberately does NOT join.**
+`NROS_SUBSCRIPTION_BUFFER_SIZE` is not subscription-only whatever its name
+says: `nros-node/build.rs` turns it into `DEFAULT_RX_BUF_SIZE`, the default
+const generic for `RawSubscription`, `RawServiceServer`, `RawServiceClient`,
+`ActionServerCore` and `ActionClientCore`, and `executor/types.rs` then defines
+`DEFAULT_TX_BUF = DEFAULT_RX_BUF_SIZE`. A type this image only PUBLISHES still
+has to fit. Narrowing it to the subscribed set would size a buffer too small,
+which is the failure this campaign exists to remove, so it keeps the closure
+basis. `NROS_MESSAGE_BOUNDS_BASIS` records which set each number used.
+
+**The type-name spellings DO join, for messages, and cannot for anything
+else.** W9 records `pkg/msg/Name`, which is exactly what
+`TypeBoundEntry::type_name` is keyed on, so a subscription joins by string
+equality with no normalisation. Services and actions do NOT join and the
+reason is structural rather than a spelling problem:
+`BoundInventory::record_message` is called for `.msg` files and for nothing
+else in all four producers, so no `pkg/srv/Name_Request` and no
+`pkg/action/Name_Result` has an entry to join against, however well-formed the
+declaration is. That is why the join REFUSES on an unpriced type and names it,
+and why the refusal message says which of the two causes is likelier. Pricing
+the service and action sub-messages is its own work; nothing in step 1 needs
+them, because none of those entities allocates from the payload pools.
+
+**Refusal, and the one case that is not one.** With the entity fragment's own
+status `derived`, the payload classes are derived from the declaration or not
+at all: a subscribed set that did not resolve (a component declared no
+`ENTITIES`, or a subscription states no type), or a named type the bound
+inventory cannot price, REFUSES all three knobs and each keeps its configured
+value. No fall-back to the closure -- that publishes the middle row of the
+table above while every status still reads `derived`.
+
+The case that is NOT a refusal is the image that declared NOTHING: no fragment,
+or a fragment whose own status is `refused`. That is every image built before
+W9, and it keeps W8's closure answer byte for byte with
+`NROS_MESSAGE_BOUNDS_BASIS = closure`, a status line saying so, and a paragraph
+in the generated file saying what a declaration would buy. Refusing there would
+take those images from a derived over-approximation back to the hand-set
+numbers W8 exists to replace, which is a regression and not a safety property.
+A fragment from a STALE CLI is the same case with a warning, and deliberately
+not a `FATAL_ERROR`: the fragment's producer (`nano_ros_entry()`) runs LATER in
+the same configure than the reader does, so a fatal would abort before the
+stale fragment could ever be rewritten.
+
+**Schema.** `ENTITY_INVENTORY_SCHEMA_VERSION` 1 -> 2. Nothing moved; the
+fragment gained `NROS_ENTITY_SUBSCRIBED_TYPES` / `NROS_ENTITY_RECEIVED_TYPES`,
+each with its own status, and it still bumps -- a reader that took their
+absence for "this image receives nothing" would derive a payload class over an
+EMPTY set. Absence has to be distinguishable from zero here for the same reason
+`ENTITIES NONE` exists.
+
+**Ordering, same lag as W8's.** The entity fragment is composed by
+`nano_ros_entry()`, which runs later in a configure than `nros_find_interfaces()`
+does, so the fragment read is the one the PREVIOUS configure wrote. Closed the
+same way: `CMAKE_CONFIGURE_DEPENDS` on the fragment plus a write-if-changed
+producer, so ninja re-runs cmake by itself. An image whose declaration has just
+changed builds once at its old payload classes and again at the derived ones,
+never silently -- the status line names the basis.
+
+Gates: `just check message-bound-knobs` (80 assertions, up from 38 -- cases L,
+M and N are the join, its refusals and the back-compat), `just check
+entity-inventory-knobs` (27, up from 24) and 26 unit tests in
+`nros_cli_core::entity_inventory`.
 
 ### Step 2 -- QoS depth in the declaration. Blocks the arena.
 

--- a/just/check.just
+++ b/just/check.just
@@ -102,7 +102,7 @@ fast-serial: \
     ci-image-python-deps kconfig-overridden-values \
     platform-abi-mirror abi-bindings board-abi-mirror board-manifest-drift profile-board-mirror example-matrix \
     no-direct-kernel-alloc no-allow-multiple-def no-board-init weak-symbols \
-    infra-queryable-counts \
+    infra-queryable-counts entity-slot-costs \
     rmw-force-link-anchor rmw-required-slots rmw-slot-table board-tiers tier-priority-plan \
     subtree-guard \
     leaf-lockfiles submodule-pinned-locks msg-dep-is-path cargo-locked no-tracked-models no-tracked-workspace-roots host-platform-vocabulary posix-platform-purity orphan-generated-stamp generated-schema-coverage \
@@ -142,7 +142,7 @@ fast-serial: \
     interface-glob-configure-depends \
     wait-evidence-discarded \
     path-env-fingerprints retired-platform-clock-symbols \
-    cmake-support-library message-bound-knobs action-client-arena-budget \
+    cmake-support-library message-bound-knobs action-client-arena-budget entity-inventory-knobs \
     tests-can-fail
     # `_check-skip-reset` is shared skip-ledger infrastructure at the ROOT
     # (`run-gates-parallel.sh` calls it too), not a gate — and a module cannot
@@ -916,6 +916,27 @@ action-client-arena-budget:
         exit 0
     fi
     exit "$_rc"
+# phase-403 W9 (issue 0965) -- the READER for the ENTITY inventory, the second
+# source `NanoRosMessageBounds.cmake` says by name that it needs.
+#
+# The derivation itself is unit-tested in `nros_cli_core::entity_inventory`
+# (`cargo test -p nros-cli-core`), including the island's 33-entities /
+# 19-slots case. This gates what CMAKE owns: a refusal publishes NO number, an
+# unknown schema FATALs rather than being read field-by-field, a missing input
+# refuses rather than breaking a clean-tree configure, and a broken declaration
+# is fatal and names the component. The CLI is STUBBED, so this needs cmake and
+# nothing else -- no cargo build, which is what keeps it affordable on the fast
+# line beside its sibling above.
+entity-inventory-knobs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v cmake >/dev/null 2>&1; then
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip entity-inventory-knobs "missing host tool(s): cmake"
+        exit 0
+    fi
+    ./tests/cmake-entity-inventory-tests.sh
 
 abi-bindings:
     #!/usr/bin/env bash
@@ -3480,6 +3501,21 @@ zenoh:
 [private]
 infra-queryable-counts:
     @python3 scripts/check-infra-queryable-counts.py
+
+# phase-403 W9 (issue 0965) — the per-kind CALLBACK SLOT cost has ONE
+# definition, tied to the registration sites that actually claim a slot.
+#
+# `nros ws entity-inventory` derives NROS_EXECUTOR_MAX_CBS by summing
+# `EntityKind::callback_slots()`, and that function is a MIRROR: the CLI is a
+# host binary and nros-node is no_std and built for the target, so it restates
+# what `Executor::next_entry_slot()` decides. Same rule as the queryable counts
+# above — a mirror is acceptable only while something holds it to the
+# definition. The specific claim it defends is that a PUBLISHER claims no slot,
+# which is why the island's 33 declared entities want 19 and why the bring-up's
+# hand-count of "33 handles" over-sized by 14.
+[private]
+entity-slot-costs:
+    @python3 scripts/check-entity-slot-costs.py
 
 # phase-383 W10.c — an example workspace ROOT is generated, never tracked.
 #

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -1,0 +1,321 @@
+//! phase-403 W9 (issue 0965) -- `nros ws entity-inventory`, the verb that turns
+//! an image's component declarations into the three transports.
+//!
+//! Sibling of [`crate::cmd::entity_facts`], and deliberately shaped like it: one
+//! resolution, one implementation. The DIFFERENCE is which question it answers
+//! and where the answer comes from.
+//!
+//! `entity-facts` reads the resolved SystemModel and abstains on all 115 of
+//! them, because a launch file names a node and never says what that node
+//! wires. This verb reads `nros-metadata.json` -- the file
+//! `nano_ros_node_register()` already writes, one row per component -- and the
+//! `ENTITIES` the register call states. That is the one place in the build
+//! where the wiring is both KNOWN and available before the sizes it feeds are
+//! compiled; see [`crate::entity_inventory`] for why a link-section manifest
+//! cannot be.
+//!
+//! Reading METADATA and not the C++ sources is the same decision
+//! `codegen::entry::metadata` makes for `class` / `class_header`: the register
+//! call is the declaration, and a second parser for the same fact is how the
+//! two spellings drift.
+
+use std::path::PathBuf;
+
+use clap::Args as ClapArgs;
+use eyre::{Result, WrapErr, bail};
+use serde::Deserialize;
+
+use crate::entity_inventory::{
+    ComponentEntities, Declaration, ENTITY_INVENTORY_CMAKE_NAME, ENTITY_INVENTORY_JSON_NAME,
+    EntityDecl, EntityInventory,
+};
+
+/// The `components[]` fields this verb needs. Every other field the typed entry
+/// emitter reads is ignored here, exactly as that emitter ignores these.
+#[derive(Debug, Deserialize)]
+struct ComponentMeta {
+    name: String,
+    #[serde(default)]
+    pkg: Option<String>,
+    class: String,
+    /// phase-403 W9 -- `nano_ros_node_register(ENTITIES ...)`.
+    ///
+    /// `Option<Vec<_>>` and not `#[serde(default)]`: the whole design turns on
+    /// telling "declared nothing" from "did not declare", and a defaulted empty
+    /// vector collapses exactly those two.
+    #[serde(default)]
+    entities: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataDoc {
+    #[serde(default)]
+    components: Vec<ComponentMeta>,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct EntityInventoryArgs {
+    /// The `nros-metadata.json` an image's configure wrote. Defaults to
+    /// `nros-metadata.json` in the current directory, which is where
+    /// `_nros_metadata_emit()` puts it (`${CMAKE_BINARY_DIR}`).
+    #[arg(long, value_name = "PATH")]
+    pub metadata: Option<PathBuf>,
+
+    /// Write the canonical JSON artifact here.
+    #[arg(long = "output-json", value_name = "PATH")]
+    pub output_json: Option<PathBuf>,
+
+    /// Write the `include()`able CMake projection here.
+    #[arg(long = "output-cmake", value_name = "PATH")]
+    pub output_cmake: Option<PathBuf>,
+
+    /// Write both artifacts into this directory, under their canonical names.
+    #[arg(long = "output-dir", value_name = "DIR")]
+    pub output_dir: Option<PathBuf>,
+
+    /// Exit non-zero when the inventory REFUSES to derive.
+    ///
+    /// Off by default, and that is the load-bearing choice: a configure that has
+    /// not yet registered every component is a normal intermediate state, the
+    /// same one `nros_derive_message_bound_knobs` treats as "refused, every knob
+    /// keeps its configured value". A build that WANTS the number to exist asks
+    /// for it here.
+    #[arg(long)]
+    pub require_derived: bool,
+}
+
+/// Build the inventory from one parsed metadata document.
+///
+/// A pure function over the document, with file IO lifted out, for the reason
+/// `entity_facts::facts_from_model` is: a sizing rule verified by reading is how
+/// this campaign's other defects survived.
+fn inventory_from_metadata(source: &str, doc: &MetadataDoc) -> Result<EntityInventory> {
+    let mut inv = EntityInventory::new(source);
+    for c in &doc.components {
+        // Pre-RFC-0057 metadata carries no `pkg`; the retired L.4 convention
+        // (`pkg = class.split("::").next()`) is the same fallback
+        // `codegen::entry::metadata` keeps, restated rather than shared because
+        // that module's index is keyed for a different consumer.
+        let pkg = c
+            .pkg
+            .clone()
+            .or_else(|| c.class.split("::").next().map(str::to_string))
+            .unwrap_or_default();
+        let declaration = match &c.entities {
+            None => Declaration::Absent,
+            Some(specs) => {
+                let mut decls = Vec::new();
+                let mut said_none = false;
+                for spec in specs {
+                    let spec = spec.trim();
+                    if spec.is_empty() {
+                        continue;
+                    }
+                    if spec.eq_ignore_ascii_case("none") {
+                        said_none = true;
+                        continue;
+                    }
+                    decls.extend(EntityDecl::parse(spec).map_err(|e| {
+                        eyre::eyre!("component `{}::{}` declares `{spec}`: {e}", pkg, c.name)
+                    })?);
+                }
+                if !decls.is_empty() && said_none {
+                    bail!(
+                        "component `{}::{}` declares both NONE and {} entities. \
+                         NONE is an assertion that it creates none; the two cannot both hold.",
+                        pkg,
+                        c.name,
+                        decls.len()
+                    );
+                }
+                if decls.is_empty() && !said_none {
+                    // An `ENTITIES` list that is present and empty says nothing,
+                    // and "says nothing" must read as ABSENT so the refusal
+                    // fires. It must NOT read as zero.
+                    Declaration::Absent
+                } else if said_none {
+                    Declaration::None
+                } else {
+                    Declaration::Stated(decls)
+                }
+            }
+        };
+        inv.insert(ComponentEntities {
+            pkg,
+            component: c.name.clone(),
+            class: c.class.clone(),
+            declaration,
+        });
+    }
+    Ok(inv)
+}
+
+pub fn run(args: EntityInventoryArgs) -> Result<()> {
+    let metadata = args
+        .metadata
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("nros-metadata.json"));
+    let raw = std::fs::read_to_string(&metadata)
+        .wrap_err_with(|| format!("read metadata `{}`", metadata.display()))?;
+    let doc: MetadataDoc = serde_json::from_str(&raw)
+        .wrap_err_with(|| format!("parse metadata `{}`", metadata.display()))?;
+    let inv = inventory_from_metadata(&metadata.display().to_string(), &doc)?;
+
+    let (json_path, cmake_path) = match &args.output_dir {
+        Some(dir) => (
+            Some(
+                args.output_json
+                    .clone()
+                    .unwrap_or(dir.join(ENTITY_INVENTORY_JSON_NAME)),
+            ),
+            Some(
+                args.output_cmake
+                    .clone()
+                    .unwrap_or(dir.join(ENTITY_INVENTORY_CMAKE_NAME)),
+            ),
+        ),
+        None => (args.output_json.clone(), args.output_cmake.clone()),
+    };
+    if let Some(p) = &json_path {
+        write_if_changed(p, &inv.to_json())?;
+    }
+    if let Some(p) = &cmake_path {
+        write_if_changed(p, &inv.to_cmake())?;
+    }
+
+    // The env transport goes to stdout, which is what makes this verb
+    // interchangeable with `ws entity-facts` at a `corrosion_set_env_vars`
+    // call site. Empty on a refusal, so nothing is exported and the reading
+    // build script stays on its own default.
+    print!("{}", inv.to_env());
+
+    let derivation = inv.derive();
+    if let crate::entity_inventory::Derivation::Refused { reason } = &derivation {
+        if args.require_derived {
+            bail!("entity inventory REFUSED to derive:\n  {reason}");
+        }
+        eprintln!("nros: entity inventory not derived -- {reason}");
+    }
+    Ok(())
+}
+
+/// The one write discipline (issues 0498/0562): atomic, and WRITE-IF-CHANGED.
+///
+/// Write-if-changed is load-bearing rather than tidy here: the CMake consumer
+/// registers the fragment with `CMAKE_CONFIGURE_DEPENDS`, so rewriting it with
+/// identical bytes on every configure would re-arm a re-configure forever.
+/// Same reason `_nros_message_bounds_write_output` does it.
+fn write_if_changed(path: &std::path::Path, content: &str) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        if !dir.as_os_str().is_empty() {
+            std::fs::create_dir_all(dir).wrap_err_with(|| format!("create `{}`", dir.display()))?;
+        }
+    }
+    crate::atomic_file::atomic_write(path, content)
+        .wrap_err_with(|| format!("write `{}`", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: &str) -> EntityInventory {
+        let doc: MetadataDoc = serde_json::from_str(raw).expect("metadata parses");
+        inventory_from_metadata("test", &doc).expect("inventory builds")
+    }
+
+    /// The channel end to end: a register call's `ENTITIES` reaches the derived
+    /// knob through `nros-metadata.json` and nothing else.
+    #[test]
+    fn entities_travel_from_the_metadata_row_to_the_knob() {
+        let inv = parse(
+            r#"{"components": [
+                 {"name": "talker", "pkg": "demo", "class": "demo::Talker",
+                  "entities": ["pub:std_msgs/msg/Int32:/chatter", "timer"]},
+                 {"name": "listener", "pkg": "demo", "class": "demo::Listener",
+                  "entities": ["sub:std_msgs/msg/Int32:/chatter"]}
+               ]}"#,
+        );
+        let k = inv.derive().knobs().expect("derived").clone();
+        assert_eq!(k.entity_total, 3);
+        assert_eq!(k.max_cbs, 2, "the publisher claims no slot");
+        assert_eq!(inv.to_env(), "NROS_EXECUTOR_MAX_CBS=2\n");
+    }
+
+    /// A row with no `entities` KEY is the pre-W9 shape every existing
+    /// component still has, and it must refuse rather than count as zero.
+    #[test]
+    fn a_row_with_no_entities_key_is_absent_not_zero() {
+        let inv = parse(
+            r#"{"components": [
+                 {"name": "talker", "pkg": "demo", "class": "demo::Talker",
+                  "entities": ["timer"]},
+                 {"name": "legacy", "pkg": "demo", "class": "demo::Legacy"}
+               ]}"#,
+        );
+        match inv.derive() {
+            crate::entity_inventory::Derivation::Refused { reason } => {
+                assert!(reason.contains("demo::legacy"), "{reason}");
+            }
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
+    /// An `ENTITIES` list that is present and EMPTY says nothing. It reads as
+    /// absent, not as an assertion of zero -- `NONE` is that assertion.
+    #[test]
+    fn an_empty_entities_list_is_absent_and_none_is_an_answer() {
+        let empty = parse(
+            r#"{"components": [{"name": "n", "pkg": "p", "class": "p::N", "entities": []}]}"#,
+        );
+        assert!(matches!(
+            empty.derive(),
+            crate::entity_inventory::Derivation::Refused { .. }
+        ));
+        let none = parse(
+            r#"{"components": [{"name": "n", "pkg": "p", "class": "p::N", "entities": ["none"]}]}"#,
+        );
+        assert_eq!(none.derive().knobs().expect("derived").max_cbs, 0);
+    }
+
+    /// NONE beside real entities is a contradiction, and it is an ERROR rather
+    /// than a resolution in either direction. Picking one would make the other
+    /// spelling silently wrong.
+    #[test]
+    fn none_beside_entities_is_rejected() {
+        let doc: MetadataDoc = serde_json::from_str(
+            r#"{"components": [
+                 {"name": "n", "pkg": "p", "class": "p::N", "entities": ["none", "timer"]}]}"#,
+        )
+        .unwrap();
+        let err = inventory_from_metadata("test", &doc)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("both NONE"), "{err}");
+    }
+
+    /// A bad spelling names the component, not just the token: metadata is
+    /// machine-written and the user has to find the register call.
+    #[test]
+    fn a_bad_spelling_names_the_component() {
+        let doc: MetadataDoc = serde_json::from_str(
+            r#"{"components": [
+                 {"name": "n", "pkg": "p", "class": "p::N", "entities": ["publsher"]}]}"#,
+        )
+        .unwrap();
+        let err = inventory_from_metadata("test", &doc)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("p::n"), "{err}");
+        assert!(err.contains("publsher"), "{err}");
+    }
+
+    /// Pre-RFC-0057 metadata has no `pkg`; the fallback keeps such a row
+    /// identifiable in a refusal rather than dropping it.
+    #[test]
+    fn a_row_without_pkg_still_lands_in_the_inventory() {
+        let inv = parse(r#"{"components": [{"name": "n", "class": "old::N"}]}"#);
+        assert_eq!(inv.len(), 1);
+        assert_eq!(inv.components()[0].pkg, "old");
+    }
+}

--- a/packages/cli/nros-cli-core/src/cmd/mod.rs
+++ b/packages/cli/nros-cli-core/src/cmd/mod.rs
@@ -23,6 +23,7 @@ pub mod config;
 pub mod doctor;
 pub mod emit_package_xml;
 pub mod entity_facts;
+pub mod entity_inventory;
 pub mod explain;
 pub mod generate;
 pub mod generate_px4;

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -111,6 +111,25 @@ pub enum Sub {
     #[command(name = "entity-facts")]
     EntityFacts(crate::cmd::entity_facts::EntityFactsArgs),
 
+    /// phase-403 W9 (issue 0965) — compose this image's
+    /// `nano_ros_node_register(... ENTITIES …)` declarations into the ENTITY
+    /// inventory, and derive `NROS_EXECUTOR_MAX_CBS` from it.
+    ///
+    /// The sibling question to `entity-facts`, asked of a source that can
+    /// answer it. `entity-facts` reads the resolved SystemModel and abstains on
+    /// every one in this tree, because a launch file names a node and never
+    /// says what that node wires; the register call does.
+    ///
+    /// Prints the env transport (`KEY=VALUE`) on stdout — the same carrier and
+    /// the same reason as `board-facts` / `entity-facts` — and optionally
+    /// writes the canonical JSON and the `include()`able CMake projection.
+    ///
+    /// REFUSES, printing nothing, when any component in the image declared no
+    /// entities: a partial inventory derives a slot count smaller than the
+    /// image needs, and a short `MAX_CBS` fails entity creation at boot.
+    #[command(name = "entity-inventory")]
+    EntityInventory(crate::cmd::entity_inventory::EntityInventoryArgs),
+
     /// phase-348 W1 — list packages that announce a provision
     /// (`<export><nano_ros_provides kind="rmw" name="zenoh"/></export>`),
     /// across the search path: the nano-ros tree, then this workspace.
@@ -388,6 +407,7 @@ pub fn run(args: Args) -> Result<()> {
         Sub::CheckBoardProjections(a) => run_check_board_projections(a),
         Sub::BoardFacts(a) => crate::cmd::board_facts::run(a),
         Sub::EntityFacts(a) => crate::cmd::entity_facts::run(a),
+        Sub::EntityInventory(a) => crate::cmd::entity_inventory::run(a),
         Sub::Providers(a) => run_providers(a),
         Sub::Order(a) => run_order(a),
     }

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -20,6 +20,30 @@
 //!   is the same one `nros ws entity-facts` already publishes through
 //!   `corrosion_set_env_vars` (`cmake/NanoRosEntityFacts.cmake`).
 //!
+//! # The JOIN KEY (phase-403 step 1)
+//!
+//! Counting entities answers `NROS_EXECUTOR_MAX_CBS` and nothing else. The two
+//! SIZE consumers need which types are received, which is why every transport
+//! also carries [`EntityInventory::subscribed_types`] and
+//! [`EntityInventory::received_types`].
+//!
+//! They are two different sets on purpose. `subscribed_types` is what
+//! `nros_derive_message_bound_knobs` narrows the zenoh payload classes with,
+//! because those pools have exactly one allocation site and it is reached only
+//! from `declare_subscriber`. `received_types` is wider -- a service server, a
+//! service client and both action roles all carry receive buffers -- and it is
+//! what the executor arena needs. Collapsing them would either price a
+//! service's request against a pool it never allocates from, or leave the arena
+//! blind to four kinds. See [`EntityKind::receives`] for how each was read off
+//! the arena entry types rather than off the names.
+//!
+//! The spellings join because both inventories key on `pkg/msg/Name`. That is
+//! true for messages and cannot be true for services and actions:
+//! `BoundInventory::record_message` is called for `.msg` files and for nothing
+//! else, so `pkg/srv/Name_Request` and `pkg/action/Name_Result` have no bound
+//! entry to join against. A consumer that meets one must REFUSE, and the CMake
+//! reader does.
+//!
 //! # Where the declaration comes from, and why it is AUTHOR-STATED
 //!
 //! RFC-0043/0044 components create their entities in CONSTRUCTORS, at runtime.
@@ -88,7 +112,15 @@ use std::collections::BTreeMap;
 
 /// Bumped when the shape of the emitted inventory changes incompatibly.
 /// A consumer that does not recognise the version must refuse, never guess.
-pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 1;
+///
+/// **2** (phase-403 step 1): the fragment now also carries WHICH TYPES THE
+/// IMAGE RECEIVES -- `NROS_ENTITY_SUBSCRIBED_TYPES` and its wider sibling
+/// `NROS_ENTITY_RECEIVED_TYPES`, each with its own status. A version-1 fragment
+/// carries neither, and a reader that treated its absence as "no type is
+/// received" would derive a payload class over an EMPTY set and publish a
+/// number smaller than any real sample. That is an incompatible addition even
+/// though nothing moved, so it bumps.
+pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 2;
 
 /// Canonical artifact name.
 pub const ENTITY_INVENTORY_JSON_NAME: &str = "nros_entity_inventory.json";
@@ -163,6 +195,66 @@ impl EntityKind {
             | EntityKind::ActionClient
             | EntityKind::GuardCondition => 1,
         }
+    }
+
+    /// Does an entity of this kind RECEIVE a serialized payload?
+    ///
+    /// Read off the arena entry types in
+    /// `packages/core/nros-node/src/executor/arena.rs`, which is where a
+    /// receive buffer is actually spelled -- not off the names, which mislead
+    /// in both directions (a service CLIENT receives; an action CLIENT receives
+    /// three different things).
+    ///
+    /// * `Subscription` -- the topic sample. `SubBufferedRawCEntry` and its
+    ///   siblings.
+    /// * `ServiceServer` -- the REQUEST. `SrvRawEntry<REQ_BUF, REPLY_BUF>`
+    ///   carries a `req_buffer`.
+    /// * `ServiceClient` -- the REPLY. `ServiceClientRawArenaEntry<REPLY_BUF>`
+    ///   carries a `reply_buffer`.
+    /// * `ActionServer` -- three: the SendGoal request, the GetResult request
+    ///   and the CancelGoal request.
+    ///   `ActionServerRawArenaEntry<GOAL_BUF, RESULT_BUF, FEEDBACK_BUF, _>`.
+    /// * `ActionClient` -- three: the goal RESPONSE, the result RESPONSE and
+    ///   the feedback message. `ActionClientRawArenaEntry` has the same three
+    ///   const buffers, which is the clearest statement that "client" says
+    ///   nothing about direction.
+    /// * `Publisher` -- no. It SERIALIZES into a per-call stack array
+    ///   (`DEFAULT_TX_BUF` in `executor/types.rs`), which is a transmit buffer
+    ///   and a different question.
+    /// * `Timer`, `GuardCondition` -- no payload at all.
+    ///
+    /// This is the SEMANTIC predicate. It is deliberately wider than
+    /// [`Self::receives_topic_sample`], because the two answer different
+    /// questions and collapsing them is how a buffer gets sized too small.
+    pub fn receives(self) -> bool {
+        match self {
+            EntityKind::Subscription
+            | EntityKind::ServiceServer
+            | EntityKind::ServiceClient
+            | EntityKind::ActionServer
+            | EntityKind::ActionClient => true,
+            EntityKind::Publisher | EntityKind::Timer | EntityKind::GuardCondition => false,
+        }
+    }
+
+    /// Does an entity of this kind draw from the backend's TOPIC PAYLOAD
+    /// pools -- the two statically sized classes
+    /// `NROS_SUBSCRIBER_BUFFER_SIZE` / `NROS_SUBSCRIBER_LARGE_SIZE` size?
+    ///
+    /// Only a subscription, and that is MEASURED rather than assumed: in
+    /// `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs` the pools
+    /// `SMALL_PAYLOADS` / `LARGE_PAYLOADS` are reached through exactly one
+    /// allocation, `alloc_payload_block(rx_buffer_hint)`, and it has exactly
+    /// one caller -- the `declare_subscriber` path. A service server's request
+    /// buffer and an action client's feedback buffer are real receive buffers
+    /// and neither is one of these blocks; they are sized by other knobs.
+    ///
+    /// So narrowing the payload classes to subscriptions is not an
+    /// under-count. Including the other receiving kinds would not make the
+    /// number safer -- it would make it describe a pool those entities never
+    /// allocate from.
+    pub fn receives_topic_sample(self) -> bool {
+        matches!(self, EntityKind::Subscription)
     }
 
     /// Parse one declared kind.
@@ -357,6 +449,44 @@ impl Derivation {
     }
 }
 
+/// Which types an image RECEIVES, and how many entities receive each.
+///
+/// The count is per ENTITY and not per type, because the consumer that needs
+/// it counts blocks: `NROS_MAX_LARGE_SUBSCRIBERS` is how many large payload
+/// BLOCKS the backend reserves, and two subscriptions on one large type need
+/// two. Deduplicating to a type set would under-reserve by exactly the
+/// duplicates.
+///
+/// `Refused` carries prose and NO list, for the reason [`Derivation`] does: a
+/// consumer either reads a set this module resolved or reads nothing. An empty
+/// list is a legitimate ANSWER ("this image receives nothing of that shape")
+/// and must never be confused with "nobody said".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceivedTypes {
+    /// `(type_name, receiving entity count)`, sorted by `type_name` so the
+    /// artifact is byte-stable and a write-if-changed keeps mtimes still.
+    Resolved(Vec<(String, usize)>),
+    Refused {
+        reason: String,
+    },
+}
+
+impl ReceivedTypes {
+    pub fn tag(&self) -> &'static str {
+        match self {
+            ReceivedTypes::Resolved(_) => "resolved",
+            ReceivedTypes::Refused { .. } => "refused",
+        }
+    }
+
+    pub fn types(&self) -> Option<&[(String, usize)]> {
+        match self {
+            ReceivedTypes::Resolved(v) => Some(v),
+            ReceivedTypes::Refused { .. } => None,
+        }
+    }
+}
+
 impl EntityInventory {
     pub fn new(source: impl Into<String>) -> Self {
         Self {
@@ -464,6 +594,91 @@ impl EntityInventory {
         }))
     }
 
+    /// The types this image receives THROUGH THE TOPIC PAYLOAD POOLS -- the
+    /// join key for the zenoh payload classes (phase-403 step 1).
+    ///
+    /// Filters the declaration to [`EntityKind::receives_topic_sample`], which
+    /// is subscriptions, and counts one per ENTITY.
+    pub fn subscribed_types(&self) -> ReceivedTypes {
+        self.types_received_by(EntityKind::receives_topic_sample, "subscribed")
+    }
+
+    /// Every type this image receives, over every receiving kind
+    /// ([`EntityKind::receives`]).
+    ///
+    /// WIDER than [`Self::subscribed_types`] and published beside it because
+    /// the two consumers differ: the payload classes size a pool only
+    /// subscriptions allocate from, while the executor ARENA charges a receive
+    /// buffer for a service server, a service client and both action roles as
+    /// well. Emitting only the narrow set would leave the arena's derivation
+    /// (step 3) to re-derive it, and a second derivation is how two green
+    /// tools come to disagree.
+    pub fn received_types(&self) -> ReceivedTypes {
+        self.types_received_by(EntityKind::receives, "received")
+    }
+
+    /// The one implementation behind the two views above.
+    ///
+    /// REFUSES in two cases, and both are "the answer would be short":
+    ///
+    /// 1. The image's own composition refused -- some component declared no
+    ///    `ENTITIES` at all. Its subscriptions are then unknown, and a set
+    ///    composed over the components that DID answer is a subset of what the
+    ///    image receives.
+    /// 2. A matching entity carries no `type_name`. A count needs no type and
+    ///    `MAX_CBS` derives happily without one, but a SIZE does: an untyped
+    ///    receiving entity is a payload of unknown size, and pricing the rest
+    ///    would publish a maximum a real sample can exceed.
+    fn types_received_by(&self, matches: fn(EntityKind) -> bool, what: &str) -> ReceivedTypes {
+        if let Derivation::Refused { reason } = self.derive() {
+            return ReceivedTypes::Refused {
+                reason: format!(
+                    "the entity inventory itself did not compose, so the {what} type set would \
+                     be a subset of what this image receives:\n{reason}"
+                ),
+            };
+        }
+
+        let mut untyped: Vec<String> = Vec::new();
+        let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+        for c in self.components() {
+            for e in c.declaration.entities() {
+                if !matches(e.kind) {
+                    continue;
+                }
+                match &e.type_name {
+                    Some(t) => *counts.entry(t.clone()).or_insert(0) += 1,
+                    None => untyped.push(format!(
+                        "    {}::{} declares a `{}`{} with no type",
+                        c.pkg,
+                        c.component,
+                        e.kind.tag(),
+                        match &e.name {
+                            Some(n) => format!(" on `{n}`"),
+                            None => String::new(),
+                        }
+                    )),
+                }
+            }
+        }
+
+        if !untyped.is_empty() {
+            untyped.dedup();
+            return ReceivedTypes::Refused {
+                reason: format!(
+                    "{} receiving entities state no type, so the size of what they receive is \
+                     unknown:\n{}\nA count does not need the type and NROS_EXECUTOR_MAX_CBS still \
+                     derives; a payload SIZE does. State it as `<kind>:<pkg>/msg/<Name>[:<name>]` \
+                     in the component's `nano_ros_node_register(... ENTITIES ...)`.",
+                    untyped.len(),
+                    untyped.join("\n")
+                ),
+            };
+        }
+
+        ReceivedTypes::Resolved(counts.into_iter().collect())
+    }
+
     /// The canonical artifact.
     pub fn to_json(&self) -> String {
         let derivation = self.derive();
@@ -526,6 +741,34 @@ impl EntityInventory {
             Derivation::Refused { reason } => {
                 doc.insert("reason".into(), reason.clone().into());
             }
+        }
+        // The join key, on the canonical transport too. Same three states as
+        // the CMake projection: a `status` is always present and the list is
+        // present only when it resolved.
+        for (key, r) in [
+            ("subscribed_types", self.subscribed_types()),
+            ("received_types", self.received_types()),
+        ] {
+            let mut m = serde_json::Map::new();
+            m.insert("status".into(), r.tag().into());
+            match &r {
+                ReceivedTypes::Refused { reason } => {
+                    m.insert("reason".into(), reason.clone().into());
+                }
+                ReceivedTypes::Resolved(v) => {
+                    m.insert(
+                        "types".into(),
+                        serde_json::Value::Object(
+                            v.iter().map(|(t, n)| (t.clone(), (*n).into())).collect(),
+                        ),
+                    );
+                    m.insert(
+                        "entity_count".into(),
+                        v.iter().map(|(_, n)| *n).sum::<usize>().into(),
+                    );
+                }
+            }
+            doc.insert(key.into(), serde_json::Value::Object(m));
         }
         format!(
             "{}\n",
@@ -608,6 +851,31 @@ impl EntityInventory {
                 ));
             }
         }
+
+        // phase-403 step 1 -- the JOIN KEY. `nros_derive_message_bound_knobs`
+        // prices a type; these two say which types this image RECEIVES, which
+        // is the half it cannot know. Emitted in BOTH branches: a refusal here
+        // is a fact a reader must act on, and an absent variable would read as
+        // "no type is received" -- a payload class derived over an empty set.
+        s.push_str(&render_received(
+            "SUBSCRIBED",
+            "the types SUBSCRIPTIONS receive. These and only these allocate from the\n\
+             # backend's two topic payload classes (one `alloc_payload_block` call site,\n\
+             # reached only from `declare_subscriber`), so they are the join key for\n\
+             # NROS_SUBSCRIBER_BUFFER_SIZE / _LARGE_SIZE / NROS_MAX_LARGE_SUBSCRIBERS.\n\
+             # The count is per ENTITY, not per type: two subscriptions on one large type\n\
+             # need two blocks.",
+            &self.subscribed_types(),
+        ));
+        s.push_str(&render_received(
+            "RECEIVED",
+            "every type this image receives, over every receiving kind -- a service\n\
+             # SERVER receives requests, a service CLIENT receives replies, and an action\n\
+             # server and action client each receive three things. WIDER than the\n\
+             # subscribed set above; it is what the executor arena needs, not the payload\n\
+             # classes.",
+            &self.received_types(),
+        ));
         s
     }
 
@@ -622,6 +890,49 @@ impl EntityInventory {
             Derivation::Refused { .. } => String::new(),
         }
     }
+}
+
+/// One received-type view, as CMake.
+///
+/// `NROS_ENTITY_<WHAT>_TYPES_STATUS` is always set, so a reader can tell
+/// "resolved to nothing" from "refused" from "this fragment predates the
+/// field" -- three states that license three different actions and that an
+/// absent list collapses into one.
+fn render_received(what: &str, prose: &str, r: &ReceivedTypes) -> String {
+    let mut s = format!("# {prose}\n");
+    s.push_str(&format!(
+        "set(NROS_ENTITY_{what}_TYPES_STATUS \"{}\")\n",
+        r.tag()
+    ));
+    match r {
+        ReceivedTypes::Refused { reason } => {
+            s.push_str(&format!(
+                "set(NROS_ENTITY_{what}_TYPES_REASON \"{}\")\n",
+                cmake_escape(reason)
+            ));
+            s.push_str(&format!(
+                "# No {} type set. A consumer that needs one must REFUSE, never fall back\n\
+                 # to a wider set -- a wider set is a different question with a different\n\
+                 # answer.\n",
+                what.to_ascii_lowercase()
+            ));
+        }
+        ReceivedTypes::Resolved(v) => {
+            let names: Vec<&str> = v.iter().map(|(t, _)| t.as_str()).collect();
+            s.push_str(&format!(
+                "set(NROS_ENTITY_{what}_TYPES \"{}\")\n",
+                names.join(";")
+            ));
+            let pairs: Vec<String> = v.iter().map(|(t, n)| format!("{t}={n}")).collect();
+            s.push_str(&format!(
+                "set(NROS_ENTITY_{what}_TYPE_COUNTS \"{}\")\n",
+                pairs.join(";")
+            ));
+            let total: usize = v.iter().map(|(_, n)| *n).sum();
+            s.push_str(&format!("set(NROS_ENTITY_{what}_ENTITY_COUNT {total})\n"));
+        }
+    }
+    s
 }
 
 /// CMake `set(... "...")` is quote- and backslash-sensitive, and a refusal
@@ -752,7 +1063,9 @@ mod tests {
         assert!(c.contains("set(NROS_ENTITY_COUNT_PUBLISHER 4)"));
         assert!(c.contains("a::one = 7 entities, 3 slots"));
         assert!(
-            c.contains("set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)"),
+            c.contains(&format!(
+                "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION {ENTITY_INVENTORY_SCHEMA_VERSION})"
+            )),
             "a reader must be able to refuse an unrecognised schema"
         );
     }
@@ -824,6 +1137,214 @@ mod tests {
         b.insert(stated("z", "one", &["sub"]));
         assert_eq!(a.to_cmake(), b.to_cmake());
         assert_eq!(a.to_json(), b.to_json());
+    }
+
+    // -----------------------------------------------------------------
+    // phase-403 step 1 -- the JOIN KEY.
+    // -----------------------------------------------------------------
+
+    /// Which kinds RECEIVE is the decision this step turns on, and the two
+    /// predicates are deliberately different sets. Pinning both here is what
+    /// stops someone "simplifying" one into the other: widening
+    /// `receives_topic_sample` would price a service's request against a pool
+    /// it never allocates from, and narrowing `receives` would leave the arena
+    /// blind to four kinds that carry receive buffers.
+    #[test]
+    fn a_client_receives_and_a_publisher_does_not() {
+        for k in [
+            EntityKind::Subscription,
+            EntityKind::ServiceServer,
+            EntityKind::ServiceClient,
+            EntityKind::ActionServer,
+            EntityKind::ActionClient,
+        ] {
+            assert!(k.receives(), "{} receives a payload", k.tag());
+        }
+        for k in [
+            EntityKind::Publisher,
+            EntityKind::Timer,
+            EntityKind::GuardCondition,
+        ] {
+            assert!(!k.receives(), "{} receives nothing", k.tag());
+        }
+        // Only a subscription draws from the topic payload pools -- one
+        // `alloc_payload_block` call site, reached only from
+        // `declare_subscriber`.
+        for k in ALL_ENTITY_KINDS {
+            assert_eq!(
+                k.receives_topic_sample(),
+                *k == EntityKind::Subscription,
+                "{} and the payload pools",
+                k.tag()
+            );
+        }
+    }
+
+    /// The join key counts ENTITIES, not distinct types. Two subscriptions on
+    /// one large type need two large payload BLOCKS, and a deduplicated type
+    /// set would reserve one.
+    #[test]
+    fn the_subscribed_set_counts_entities_per_type() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated(
+            "a",
+            "one",
+            &[
+                "sub:std_msgs/msg/Int32:/a",
+                "sub:std_msgs/msg/Int32:/b",
+                "sub:nav_msgs/msg/Odometry:/c",
+                "pub:sensor_msgs/msg/Image:/d",
+                "timer",
+            ],
+        ));
+        let types = inv.subscribed_types();
+        assert_eq!(
+            types.types().expect("resolved"),
+            &[
+                ("nav_msgs/msg/Odometry".to_string(), 1),
+                ("std_msgs/msg/Int32".to_string(), 2),
+            ],
+            "two subscriptions on Int32, one on Odometry, and the PUBLISHED \
+             Image is not in the set"
+        );
+    }
+
+    /// A service SERVER receives requests and a service CLIENT receives
+    /// replies, so both are in the wider set -- and neither is in the payload
+    /// pools' set. The two views are what keep the arena (step 3) from
+    /// re-deriving this and disagreeing.
+    #[test]
+    fn the_received_set_is_wider_than_the_subscribed_one() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated(
+            "a",
+            "one",
+            &[
+                "sub:std_msgs/msg/Int32:/t",
+                "service_server:demo/srv/Op_Request:/s",
+                "service_client:demo/srv/Op_Response:/c",
+                "pub:std_msgs/msg/Bool:/p",
+            ],
+        ));
+        let sub: Vec<String> = inv
+            .subscribed_types()
+            .types()
+            .expect("resolved")
+            .iter()
+            .map(|(t, _)| t.clone())
+            .collect();
+        assert_eq!(sub, vec!["std_msgs/msg/Int32".to_string()]);
+        let recv: Vec<String> = inv
+            .received_types()
+            .types()
+            .expect("resolved")
+            .iter()
+            .map(|(t, _)| t.clone())
+            .collect();
+        assert_eq!(
+            recv,
+            vec![
+                "demo/srv/Op_Request".to_string(),
+                "demo/srv/Op_Response".to_string(),
+                "std_msgs/msg/Int32".to_string(),
+            ],
+            "a server's request and a client's reply are both received"
+        );
+        // And the publisher is in neither.
+        assert!(!recv.contains(&"std_msgs/msg/Bool".to_string()));
+    }
+
+    /// An untyped SUBSCRIPTION refuses the set rather than being skipped. A
+    /// skipped row is an under-report, and here it would size a payload class
+    /// from the types that happened to be annotated.
+    #[test]
+    fn an_untyped_subscription_refuses_the_set_but_not_the_slot_count() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["sub:std_msgs/msg/Int32:/t", "sub"]));
+        match inv.subscribed_types() {
+            ReceivedTypes::Refused { reason } => {
+                assert!(reason.contains("a::one"), "names the component: {reason}");
+                assert!(reason.contains("subscription"), "names the kind: {reason}");
+            }
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+        // MAX_CBS does not need the type, so it still derives -- the two
+        // questions have different inputs and different answers.
+        assert_eq!(inv.derive().knobs().expect("derived").max_cbs, 2);
+        // A timer has no type and that is not a refusal.
+        let mut ok = EntityInventory::new("test");
+        ok.insert(stated(
+            "a",
+            "one",
+            &["sub:std_msgs/msg/Int32:/t", "timer*3"],
+        ));
+        assert!(ok.subscribed_types().types().is_some());
+    }
+
+    /// An image whose composition refused has NO subscribed set either. The
+    /// un-annotated component's subscriptions are unknown, so a set composed
+    /// over the rest is a subset of what the image receives -- and a payload
+    /// class derived from a subset is too small.
+    #[test]
+    fn an_incomplete_image_has_no_subscribed_set() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["sub:std_msgs/msg/Int32:/t"]));
+        inv.insert(ComponentEntities {
+            pkg: "b".into(),
+            component: "two".into(),
+            class: "b::Two".into(),
+            declaration: Declaration::Absent,
+        });
+        assert!(matches!(
+            inv.subscribed_types(),
+            ReceivedTypes::Refused { .. }
+        ));
+        let c = inv.to_cmake();
+        assert!(c.contains("set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS \"refused\")"));
+        assert!(
+            !c.contains("set(NROS_ENTITY_SUBSCRIBED_TYPES "),
+            "a refusal must publish no set at all: {c}"
+        );
+    }
+
+    /// An image that declares entities and subscribes to NOTHING resolves to
+    /// an EMPTY set, which is an answer and not a refusal: its payload pools
+    /// are genuinely unused. The status is what tells the two apart, so the
+    /// fragment must always carry one.
+    #[test]
+    fn a_subscriber_less_image_resolves_to_an_empty_set() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["pub:std_msgs/msg/Bool:/p", "timer"]));
+        assert_eq!(inv.subscribed_types().types().expect("resolved").len(), 0);
+        let c = inv.to_cmake();
+        assert!(c.contains("set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS \"resolved\")"));
+        assert!(c.contains("set(NROS_ENTITY_SUBSCRIBED_TYPES \"\")"));
+        assert!(c.contains("set(NROS_ENTITY_SUBSCRIBED_ENTITY_COUNT 0)"));
+    }
+
+    /// The CMake projection carries the join key in the shape
+    /// `_nros_bounds_join_subscribed` parses: a `;` list of names and a
+    /// parallel `;` list of `type=count`.
+    #[test]
+    fn the_cmake_projection_carries_the_join_key() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated(
+            "a",
+            "one",
+            &[
+                "sub:nav_msgs/msg/Odometry:/k",
+                "sub:std_msgs/msg/Int32:/t",
+                "sub:std_msgs/msg/Int32:/u",
+            ],
+        ));
+        let c = inv.to_cmake();
+        assert!(c.contains(
+            "set(NROS_ENTITY_SUBSCRIBED_TYPES \"nav_msgs/msg/Odometry;std_msgs/msg/Int32\")"
+        ));
+        assert!(c.contains(
+            "set(NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS \"nav_msgs/msg/Odometry=1;std_msgs/msg/Int32=2\")"
+        ));
+        assert!(c.contains("set(NROS_ENTITY_SUBSCRIBED_ENTITY_COUNT 3)"));
     }
 
     /// The measured island. Its four components, exactly as their ctors read

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -1,0 +1,868 @@
+//! phase-403 W9 (issue 0965) -- WHICH ENTITIES AN IMAGE CREATES.
+//!
+//! The bound inventory (`rosidl_codegen::bounds`) prices a TYPE. It cannot say
+//! whether an image subscribes to that type, and three consumers need the
+//! second question answered: the zenoh payload class boundaries, the executor
+//! arena, and `NROS_EXECUTOR_MAX_CBS`. This module is the second source.
+//!
+//! It follows `bounds.rs`'s shape deliberately -- ONE data model, rendered into
+//! the transports the later stages already speak -- rather than inventing a
+//! second inventory mechanism:
+//!
+//! * [`EntityInventory::to_json`] -- canonical, `nros_entity_inventory.json`.
+//! * [`EntityInventory::to_cmake`] -- an `include()`able fragment for the
+//!   CMake/Kconfig lane, the same projection `nros_message_bounds.cmake` is.
+//! * [`EntityInventory::to_env`] -- `KEY=VALUE` lines, the carrier that reaches
+//!   a cargo invocation. `bounds.rs` uses a generated crate's `links` key for
+//!   this rung; an entity inventory has no generated crate of its own, and the
+//!   knob it feeds (`NROS_EXECUTOR_MAX_CBS`) is read from the ENVIRONMENT by
+//!   `nros-node/build.rs`. So the env line IS the cargo transport here, and it
+//!   is the same one `nros ws entity-facts` already publishes through
+//!   `corrosion_set_env_vars` (`cmake/NanoRosEntityFacts.cmake`).
+//!
+//! # Where the declaration comes from, and why it is AUTHOR-STATED
+//!
+//! RFC-0043/0044 components create their entities in CONSTRUCTORS, at runtime.
+//! The registration macros (`NROS_SUBSCRIBE`, `create_publisher`,
+//! `NROS_CREATE_TIMER`) do know the kind and the type `M` -- but anything they
+//! emit is a LINK-SECTION fact, and it exists only after linking. The numbers
+//! this inventory feeds are `const` sizes compiled INTO `nros-node`, which is
+//! built before a single component TU is compiled. A link-section manifest can
+//! therefore VERIFY a count and can never SUPPLY one; that is the direction of
+//! the build graph, not a gap in the tooling.
+//!
+//! So the declaration is stated where the component is already declared --
+//! `nano_ros_node_register(... ENTITIES ...)`, beside `CLASS`, `SHAPE` and
+//! `CALLBACK_GROUPS` -- and travels the channel that declaration already
+//! travels, `nros-metadata.json`.
+//!
+//! # An under-report can never be silent
+//!
+//! Three layers, in the order they fire:
+//!
+//! 1. **Composition refuses on INCOMPLETE data.** If any component in the image
+//!    states no `ENTITIES` at all, [`EntityInventory::derive`] refuses for the
+//!    WHOLE image and no knob is derived -- the same rule
+//!    `NanoRosMessageBounds.cmake` holds when any type in the closure is
+//!    unbounded. A component that really creates nothing says so explicitly
+//!    (`ENTITIES NONE`), so ABSENCE always means "nobody said", never "zero".
+//! 2. **The derived value carries NO headroom.** It is exactly the declared
+//!    slot demand. That is deliberate: it makes the running image a CHECKER of
+//!    its own manifest.
+//! 3. **A short manifest is a named boot failure.** Registration past the table
+//!    returns `NodeError::ExecutorFull`, which names the knob, and
+//!    `ComponentNode`'s `ok()` flag makes the entry halt boot naming the
+//!    failing node. `MAX_CBS` is the right FIRST consumer precisely because its
+//!    under-size failure is already loud: an under-sized ARENA halts during
+//!    entity creation, before the first spin, which is why issue 0900 W1's
+//!    advisory cannot cover it.
+//!
+//! # A publisher claims no callback slot, and that is MEASURED
+//!
+//! `NROS_EXECUTOR_MAX_CBS` sizes the executor's callback-entry table. Every
+//! registration site that claims one calls `Executor::next_entry_slot()`, and
+//! the 24 sites that do are subscriptions, timers, services, service clients,
+//! action servers, action clients and guard conditions. `create_publisher` is
+//! not among them -- on the C++ path it writes an `RmwPublisher` into
+//! caller-owned storage (`nros-cpp/src/publisher.rs`) and on the C path there
+//! is no `nros_executor_add_publisher` to increment `handle_count`.
+//!
+//! This matters because the mr-canhubk344 bring-up recorded "33 handles" for
+//! the island and set `MAX_CBS=36` from it. 33 is the ENTITY count; 14 of those
+//! are publishers, which claim no slot. Both numbers are in the inventory, and
+//! [`EntityKind::callback_slots`] is the only place the difference is spelled.
+//!
+//! # The infrastructure services are NOT a hidden term, and that was checked
+//!
+//! The obvious way for this derivation to be short is an entity the executor
+//! creates that no component declares. There are two candidates and neither
+//! claims a slot: `ParamState` is "stored outside the arena so it doesn't
+//! consume `MAX_CBS` slots" (`parameter_services.rs`), and the five REP-2002
+//! lifecycle servers go through `create_lc_srv`, which calls
+//! `session.create_service` directly and never
+//! `Executor::register_service_*`. So the declared application entities are the
+//! whole demand -- which is what makes rule 2 above (no headroom) a checkable
+//! claim rather than a hopeful one.
+
+use std::collections::BTreeMap;
+
+/// Bumped when the shape of the emitted inventory changes incompatibly.
+/// A consumer that does not recognise the version must refuse, never guess.
+pub const ENTITY_INVENTORY_SCHEMA_VERSION: u32 = 1;
+
+/// Canonical artifact name.
+pub const ENTITY_INVENTORY_JSON_NAME: &str = "nros_entity_inventory.json";
+
+/// CMake projection of [`ENTITY_INVENTORY_JSON_NAME`], beside it.
+pub const ENTITY_INVENTORY_CMAKE_NAME: &str = "nros_entity_inventory.cmake";
+
+/// A kind of entity a component creates.
+///
+/// The set is closed on purpose: an unrecognised spelling is a REFUSAL, never a
+/// row this module skips. A skipped row is exactly an under-report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EntityKind {
+    Publisher,
+    Subscription,
+    Timer,
+    ServiceServer,
+    ServiceClient,
+    ActionServer,
+    ActionClient,
+    GuardCondition,
+}
+
+/// Every kind, in emission order. The one list; a second one is how a kind
+/// silently stops being counted.
+pub const ALL_ENTITY_KINDS: &[EntityKind] = &[
+    EntityKind::Publisher,
+    EntityKind::Subscription,
+    EntityKind::Timer,
+    EntityKind::ServiceServer,
+    EntityKind::ServiceClient,
+    EntityKind::ActionServer,
+    EntityKind::ActionClient,
+    EntityKind::GuardCondition,
+];
+
+impl EntityKind {
+    /// The canonical spelling, used on every transport and in the declaration.
+    pub fn tag(self) -> &'static str {
+        match self {
+            EntityKind::Publisher => "publisher",
+            EntityKind::Subscription => "subscription",
+            EntityKind::Timer => "timer",
+            EntityKind::ServiceServer => "service_server",
+            EntityKind::ServiceClient => "service_client",
+            EntityKind::ActionServer => "action_server",
+            EntityKind::ActionClient => "action_client",
+            EntityKind::GuardCondition => "guard_condition",
+        }
+    }
+
+    /// How many `NROS_EXECUTOR_MAX_CBS` callback-entry slots ONE entity of this
+    /// kind claims.
+    ///
+    /// MIRROR of the `Executor::next_entry_slot()` call sites in
+    /// `packages/core/nros-node/src/executor/{spin,action}.rs`, held to them by
+    /// `scripts/check-entity-slot-costs.py`. The CLI cannot depend on
+    /// `nros-node` -- that crate is `no_std`, platform-gated and built for the
+    /// target, not the host -- so the mapping is restated here AND gated, which
+    /// is the difference between this and a comment that drifts.
+    ///
+    /// A publisher is 0. See the module docs: it is the number the island's
+    /// hand-count got wrong, and it is worth 14 slots on that image.
+    pub fn callback_slots(self) -> usize {
+        match self {
+            EntityKind::Publisher => 0,
+            EntityKind::Subscription
+            | EntityKind::Timer
+            | EntityKind::ServiceServer
+            | EntityKind::ServiceClient
+            | EntityKind::ActionServer
+            | EntityKind::ActionClient
+            | EntityKind::GuardCondition => 1,
+        }
+    }
+
+    /// Parse one declared kind.
+    ///
+    /// Accepts the canonical [`Self::tag`] plus the short spellings a human
+    /// writing a CMake argument reaches for. Anything else is an ERROR and not
+    /// a skipped row -- see the type docs.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let norm = s.trim().to_ascii_lowercase().replace('-', "_");
+        Ok(match norm.as_str() {
+            "publisher" | "pub" => EntityKind::Publisher,
+            "subscription" | "sub" | "subscriber" => EntityKind::Subscription,
+            "timer" | "tmr" => EntityKind::Timer,
+            "service_server" | "service" | "srv" | "server" => EntityKind::ServiceServer,
+            "service_client" | "client" => EntityKind::ServiceClient,
+            "action_server" => EntityKind::ActionServer,
+            "action_client" => EntityKind::ActionClient,
+            "guard_condition" | "guard" => EntityKind::GuardCondition,
+            _ => {
+                return Err(format!(
+                    "unknown entity kind `{s}` -- expected one of: {}",
+                    ALL_ENTITY_KINDS
+                        .iter()
+                        .map(|k| k.tag())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        })
+    }
+}
+
+/// One declared entity.
+///
+/// `type_name` is the ROS name the bound inventory prices (`pkg/msg/Name`) --
+/// the same spelling `TypeBoundEntry::type_name` uses, so the two inventories
+/// join without a second naming convention. It is OPTIONAL because a timer and
+/// a guard condition carry no type, and because a count is useful before every
+/// call site has been annotated. `name` is the topic / service / action name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityDecl {
+    pub kind: EntityKind,
+    pub type_name: Option<String>,
+    pub name: Option<String>,
+}
+
+impl EntityDecl {
+    /// Parse the declaration spelling: `<kind>[:<type>[:<name>]]`.
+    ///
+    /// `sub:nav_msgs/msg/Odometry:/localization/kinematic_state`, `timer`,
+    /// `publisher:autoware_vehicle_msgs/msg/GearCommand`.
+    ///
+    /// A `*N` suffix on the kind repeats it: `timer*3`. A repeat count is the
+    /// one concession to brevity, and it is on the KIND rather than a separate
+    /// argument so a row can never lose its multiplier in transit.
+    pub fn parse(spec: &str) -> Result<Vec<Self>, String> {
+        let spec = spec.trim();
+        if spec.is_empty() {
+            return Err("empty entity declaration".to_string());
+        }
+        let mut parts = spec.splitn(3, ':');
+        let kind_field = parts.next().unwrap_or("");
+        let type_name = parts.next().map(str::trim).filter(|s| !s.is_empty());
+        let name = parts.next().map(str::trim).filter(|s| !s.is_empty());
+
+        let (kind_str, repeat) = match kind_field.split_once('*') {
+            Some((k, n)) => {
+                let n: usize = n.trim().parse().map_err(|_| {
+                    format!("entity declaration `{spec}`: `{n}` is not a repeat count")
+                })?;
+                if n == 0 {
+                    return Err(format!(
+                        "entity declaration `{spec}`: a repeat count of 0 states nothing. \
+                         Omit the row, or declare the component `NONE`."
+                    ));
+                }
+                (k, n)
+            }
+            None => (kind_field, 1),
+        };
+        let kind = EntityKind::parse(kind_str).map_err(|e| format!("in `{spec}`: {e}"))?;
+        Ok((0..repeat)
+            .map(|_| EntityDecl {
+                kind,
+                type_name: type_name.map(str::to_string),
+                name: name.map(str::to_string),
+            })
+            .collect())
+    }
+}
+
+/// What one component said about its entities.
+///
+/// Three-valued for the reason [`rosidl_codegen::bounds::BoundState`] is:
+/// "it creates none" and "it did not say" license completely different actions,
+/// and collapsing them is exactly the under-report this module exists to make
+/// impossible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Declaration {
+    /// `ENTITIES <spec>...` -- the component named what it creates.
+    Stated(Vec<EntityDecl>),
+    /// `ENTITIES NONE` -- the component asserts it creates nothing.
+    None,
+    /// The register call carried no `ENTITIES` at all.
+    Absent,
+}
+
+impl Declaration {
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Declaration::Stated(_) => "stated",
+            Declaration::None => "none",
+            Declaration::Absent => "absent",
+        }
+    }
+
+    /// The declared entities; empty for both `None` and `Absent`. Callers must
+    /// distinguish those two through [`Declaration::tag`], never through the
+    /// length of this slice.
+    pub fn entities(&self) -> &[EntityDecl] {
+        match self {
+            Declaration::Stated(v) => v,
+            Declaration::None | Declaration::Absent => &[],
+        }
+    }
+}
+
+/// One component's row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentEntities {
+    /// ament package the component lives in.
+    pub pkg: String,
+    /// The `NAME` the register call gave it -- the launch `exec`.
+    pub component: String,
+    /// The qualified C++ class, so a refusal names something a user can grep.
+    pub class: String,
+    pub declaration: Declaration,
+}
+
+/// Every component in ONE image, with what each declared.
+///
+/// The unit is the IMAGE, not the package: `MAX_CBS` sizes one executor and an
+/// image has one. That is the same reason `nros_derive_message_bound_knobs`
+/// composes over the whole linked closure rather than per package.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EntityInventory {
+    /// Where this inventory came from, for the provenance line. Usually the
+    /// `nros-metadata.json` path.
+    pub source: String,
+    components: Vec<ComponentEntities>,
+}
+
+/// The knobs an entity inventory can answer, plus how it got there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedEntityKnobs {
+    /// `NROS_EXECUTOR_MAX_CBS` -- the total callback-entry slot demand.
+    pub max_cbs: usize,
+    /// Every declared entity, slot-claiming or not. NOT the knob: kept because
+    /// it is the number a human counts, and because the gap between the two is
+    /// the finding.
+    pub entity_total: usize,
+    /// Per-kind counts across the image, in [`ALL_ENTITY_KINDS`] order.
+    pub per_kind: BTreeMap<&'static str, usize>,
+    /// Per-component `(pkg, component, entities, slots)`, so the output records
+    /// which declaration contributed what.
+    pub per_component: Vec<(String, String, usize, usize)>,
+}
+
+/// The result of composing an image's declarations.
+///
+/// `Refused` carries prose and NO number: a consumer either reads a value this
+/// module derived or reads nothing at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Derivation {
+    Derived(Box<DerivedEntityKnobs>),
+    Refused { reason: String },
+}
+
+impl Derivation {
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Derivation::Derived(_) => "derived",
+            Derivation::Refused { .. } => "refused",
+        }
+    }
+
+    pub fn knobs(&self) -> Option<&DerivedEntityKnobs> {
+        match self {
+            Derivation::Derived(k) => Some(k),
+            Derivation::Refused { .. } => None,
+        }
+    }
+}
+
+impl EntityInventory {
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            components: Vec::new(),
+        }
+    }
+
+    /// Record one component. A later record for the same `(pkg, component)`
+    /// replaces the earlier one, so a configure that registers a component
+    /// twice cannot double-count it.
+    pub fn insert(&mut self, row: ComponentEntities) {
+        match self
+            .components
+            .iter_mut()
+            .find(|c| c.pkg == row.pkg && c.component == row.component)
+        {
+            Some(existing) => *existing = row,
+            None => self.components.push(row),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Rows in emission order: sorted by `(pkg, component)`, so the artifact is
+    /// byte-stable across runs and a write-if-changed keeps mtimes still.
+    pub fn components(&self) -> Vec<&ComponentEntities> {
+        let mut v: Vec<&ComponentEntities> = self.components.iter().collect();
+        v.sort_by(|a, b| (&a.pkg, &a.component).cmp(&(&b.pkg, &b.component)));
+        v
+    }
+
+    /// Compose the image's declarations into the knobs, or REFUSE.
+    ///
+    /// Refuses when the image has no components at all, and when ANY component
+    /// stated nothing. Partial data never yields a number: an image whose
+    /// fourth node has not been annotated would otherwise derive a total three
+    /// nodes' worth short, and a short `MAX_CBS` is a failed entity creation on
+    /// a board.
+    pub fn derive(&self) -> Derivation {
+        if self.components.is_empty() {
+            return Derivation::Refused {
+                reason: "no components were registered in this image, so there is nothing to \
+                         compose. `nano_ros_node_register()` is what puts a component here."
+                    .to_string(),
+            };
+        }
+
+        let undeclared: Vec<&ComponentEntities> = self
+            .components()
+            .into_iter()
+            .filter(|c| matches!(c.declaration, Declaration::Absent))
+            .collect();
+        if !undeclared.is_empty() {
+            let block = undeclared
+                .iter()
+                .map(|c| format!("    {}::{} ({})", c.pkg, c.component, c.class))
+                .collect::<Vec<_>>()
+                .join("\n");
+            return Derivation::Refused {
+                reason: format!(
+                    "{} of {} components in this image declare no entities:\n{block}\n\
+                     Deriving over only the components that did would publish a slot count \
+                     smaller than the image needs, and a short NROS_EXECUTOR_MAX_CBS fails \
+                     entity creation at boot. Add `ENTITIES ...` to each \
+                     `nano_ros_node_register()` above -- `ENTITIES NONE` for a component that \
+                     really creates none.",
+                    undeclared.len(),
+                    self.components.len()
+                ),
+            };
+        }
+
+        let mut per_kind: BTreeMap<&'static str, usize> = BTreeMap::new();
+        for k in ALL_ENTITY_KINDS {
+            per_kind.insert(k.tag(), 0);
+        }
+        let mut per_component = Vec::new();
+        let mut max_cbs = 0usize;
+        let mut entity_total = 0usize;
+        for c in self.components() {
+            let mut slots = 0usize;
+            let mut count = 0usize;
+            for e in c.declaration.entities() {
+                *per_kind.entry(e.kind.tag()).or_insert(0) += 1;
+                slots += e.kind.callback_slots();
+                count += 1;
+            }
+            max_cbs += slots;
+            entity_total += count;
+            per_component.push((c.pkg.clone(), c.component.clone(), count, slots));
+        }
+
+        Derivation::Derived(Box::new(DerivedEntityKnobs {
+            max_cbs,
+            entity_total,
+            per_kind,
+            per_component,
+        }))
+    }
+
+    /// The canonical artifact.
+    pub fn to_json(&self) -> String {
+        let derivation = self.derive();
+        let components: Vec<serde_json::Value> = self
+            .components()
+            .into_iter()
+            .map(|c| {
+                let mut m = serde_json::Map::new();
+                m.insert("pkg".into(), c.pkg.clone().into());
+                m.insert("component".into(), c.component.clone().into());
+                m.insert("class".into(), c.class.clone().into());
+                m.insert("declaration".into(), c.declaration.tag().into());
+                m.insert(
+                    "entities".into(),
+                    c.declaration
+                        .entities()
+                        .iter()
+                        .map(|e| {
+                            let mut r = serde_json::Map::new();
+                            r.insert("kind".into(), e.kind.tag().into());
+                            r.insert("callback_slots".into(), e.kind.callback_slots().into());
+                            if let Some(t) = &e.type_name {
+                                r.insert("type_name".into(), t.clone().into());
+                            }
+                            if let Some(n) = &e.name {
+                                r.insert("name".into(), n.clone().into());
+                            }
+                            serde_json::Value::Object(r)
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                );
+                serde_json::Value::Object(m)
+            })
+            .collect();
+
+        let mut doc = serde_json::Map::new();
+        doc.insert(
+            "schema_version".into(),
+            ENTITY_INVENTORY_SCHEMA_VERSION.into(),
+        );
+        doc.insert("producer".into(), "nros ws entity-inventory".into());
+        doc.insert("source".into(), self.source.clone().into());
+        doc.insert("status".into(), derivation.tag().into());
+        doc.insert("components".into(), components.into());
+        match &derivation {
+            Derivation::Derived(k) => {
+                doc.insert("entity_total".into(), k.entity_total.into());
+                doc.insert("max_cbs".into(), k.max_cbs.into());
+                doc.insert(
+                    "per_kind".into(),
+                    serde_json::Value::Object(
+                        k.per_kind
+                            .iter()
+                            .map(|(name, n)| ((*name).to_string(), (*n).into()))
+                            .collect(),
+                    ),
+                );
+            }
+            Derivation::Refused { reason } => {
+                doc.insert("reason".into(), reason.clone().into());
+            }
+        }
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&serde_json::Value::Object(doc)).unwrap_or_default()
+        )
+    }
+
+    /// The CMake/Kconfig projection.
+    ///
+    /// A REFUSAL sets a status and a reason and NO `NROS_DERIVED_*` variable, so
+    /// a consumer that reads a number reads one this module derived or reads
+    /// nothing -- the rule `nros_message_bounds.cmake` holds for a type with no
+    /// bound.
+    pub fn to_cmake(&self) -> String {
+        let derivation = self.derive();
+        let mut s = String::new();
+        s.push_str("# GENERATED by `nros ws entity-inventory` (phase-403 W9, issue 0965).\n");
+        s.push_str("# Do not edit.\n#\n");
+        s.push_str(
+            "# WHICH ENTITIES THIS IMAGE CREATES, composed from every\n\
+             # `nano_ros_node_register(... ENTITIES ...)` in it. The bound inventory\n\
+             # (`nros_message_bounds.cmake`) prices a TYPE; this one counts the entities,\n\
+             # which is the half `NROS_EXECUTOR_MAX_CBS` needs.\n#\n",
+        );
+        s.push_str(
+            "# The number is a DEFAULT. An environment value or a Kconfig / board `.conf`\n\
+             # value states a number and WINS; this only fills in what nobody stated.\n#\n",
+        );
+        s.push_str(
+            "# It carries NO headroom, deliberately: it is exactly the declared slot\n\
+             # demand, so a stale declaration makes the image fail entity creation with\n\
+             # `ExecutorFull` naming this knob, rather than being absorbed silently.\n",
+        );
+        s.push_str(&format!(
+            "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION {ENTITY_INVENTORY_SCHEMA_VERSION})\n"
+        ));
+        s.push_str(&format!(
+            "set(NROS_ENTITY_INVENTORY_SOURCE \"{}\")\n",
+            cmake_escape(&self.source)
+        ));
+        s.push_str(&format!(
+            "set(NROS_ENTITY_INVENTORY_STATUS \"{}\")\n",
+            derivation.tag()
+        ));
+        s.push_str(&format!(
+            "set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT {})\n",
+            self.components.len()
+        ));
+        match &derivation {
+            Derivation::Refused { reason } => {
+                s.push_str(&format!(
+                    "set(NROS_ENTITY_INVENTORY_REASON \"{}\")\n",
+                    cmake_escape(reason)
+                ));
+                s.push_str("# No knob is derived. Every one keeps its configured value.\n");
+            }
+            Derivation::Derived(k) => {
+                s.push_str(&format!(
+                    "set(NROS_ENTITY_INVENTORY_ENTITY_TOTAL {})\n",
+                    k.entity_total
+                ));
+                for (name, n) in &k.per_kind {
+                    let key = name.to_ascii_uppercase();
+                    s.push_str(&format!("set(NROS_ENTITY_COUNT_{key} {n})\n"));
+                }
+                s.push_str("# Where the slots came from -- pkg::component = entities/slots.\n");
+                for (pkg, comp, count, slots) in &k.per_component {
+                    s.push_str(&format!(
+                        "#   {pkg}::{comp} = {count} entities, {slots} slots\n"
+                    ));
+                }
+                s.push_str(
+                    "# A publisher claims NO callback slot (it writes an RmwPublisher into\n\
+                     # caller storage and never reaches Executor::next_entry_slot), so the\n\
+                     # entity total above is larger than the slot demand below.\n",
+                );
+                s.push_str(&format!(
+                    "set(NROS_DERIVED_EXECUTOR_MAX_CBS {})\n",
+                    k.max_cbs
+                ));
+            }
+        }
+        s
+    }
+
+    /// The environment projection -- the carrier that reaches a cargo build.
+    ///
+    /// One `KEY=VALUE` per line, and NOTHING when the derivation refused: an
+    /// absent variable leaves `nros-node/build.rs` on its own default, which is
+    /// rung 4 of the precedence ladder and the correct outcome for "no answer".
+    pub fn to_env(&self) -> String {
+        match self.derive() {
+            Derivation::Derived(k) => format!("NROS_EXECUTOR_MAX_CBS={}\n", k.max_cbs),
+            Derivation::Refused { .. } => String::new(),
+        }
+    }
+}
+
+/// CMake `set(... "...")` is quote- and backslash-sensitive, and a refusal
+/// reason is multi-line prose.
+fn cmake_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stated(pkg: &str, comp: &str, specs: &[&str]) -> ComponentEntities {
+        let mut decls = Vec::new();
+        for s in specs {
+            decls.extend(EntityDecl::parse(s).expect("spec parses"));
+        }
+        ComponentEntities {
+            pkg: pkg.to_string(),
+            component: comp.to_string(),
+            class: format!("{pkg}::{comp}"),
+            declaration: Declaration::Stated(decls),
+        }
+    }
+
+    /// The whole point: a publisher is declared, counted, and claims no slot.
+    /// The two numbers differ and both are reported.
+    #[test]
+    fn a_publisher_is_inventoried_and_claims_no_callback_slot() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("p", "n", &["pub*3", "sub", "timer"]));
+        let d = inv.derive();
+        let k = d.knobs().expect("derived");
+        assert_eq!(k.entity_total, 5);
+        assert_eq!(k.max_cbs, 2, "3 publishers claim no slot; sub + timer do");
+        assert_eq!(k.per_kind["publisher"], 3);
+    }
+
+    /// The refusal that makes an under-report impossible. One un-annotated
+    /// component and the WHOLE image derives nothing -- not a total three
+    /// components' worth short.
+    #[test]
+    fn one_undeclared_component_refuses_the_whole_image() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["sub", "timer"]));
+        inv.insert(ComponentEntities {
+            pkg: "b".into(),
+            component: "two".into(),
+            class: "b::Two".into(),
+            declaration: Declaration::Absent,
+        });
+        match inv.derive() {
+            Derivation::Refused { reason } => {
+                assert!(reason.contains("b::two"), "names the component: {reason}");
+                assert!(
+                    reason.contains("ENTITIES NONE"),
+                    "names the remedy: {reason}"
+                );
+            }
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+        // And no transport may carry a number.
+        assert!(!inv.to_cmake().contains("NROS_DERIVED_EXECUTOR_MAX_CBS"));
+        assert_eq!(inv.to_env(), "");
+    }
+
+    /// "Creates nothing" and "did not say" are different claims, and only the
+    /// first one lets the image derive.
+    #[test]
+    fn an_explicit_none_is_an_answer_and_absence_is_not() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["sub"]));
+        inv.insert(ComponentEntities {
+            pkg: "b".into(),
+            component: "two".into(),
+            class: "b::Two".into(),
+            declaration: Declaration::None,
+        });
+        let d = inv.derive();
+        assert_eq!(d.knobs().expect("derived").max_cbs, 1);
+    }
+
+    /// An image with no components is a refusal, not a zero. A zero would be a
+    /// perfectly plausible `MAX_CBS` and it would fail the first registration.
+    #[test]
+    fn an_empty_image_refuses_rather_than_deriving_zero() {
+        let inv = EntityInventory::new("test");
+        assert!(matches!(inv.derive(), Derivation::Refused { .. }));
+        assert!(!inv.to_json().contains("\"max_cbs\""));
+    }
+
+    /// An unknown kind is an ERROR at parse time, never a skipped row: a
+    /// skipped row is exactly an under-report wearing a typo.
+    #[test]
+    fn an_unknown_kind_is_rejected_rather_than_skipped() {
+        let err = EntityDecl::parse("subscribtion:std_msgs/msg/Int32").unwrap_err();
+        assert!(err.contains("unknown entity kind"), "{err}");
+        assert!(err.contains("subscription"), "names the legal set: {err}");
+    }
+
+    #[test]
+    fn a_declaration_carries_its_type_and_name() {
+        let d = EntityDecl::parse("sub:nav_msgs/msg/Odometry:/localization/kinematic_state")
+            .unwrap()
+            .remove(0);
+        assert_eq!(d.kind, EntityKind::Subscription);
+        assert_eq!(d.type_name.as_deref(), Some("nav_msgs/msg/Odometry"));
+        assert_eq!(d.name.as_deref(), Some("/localization/kinematic_state"));
+    }
+
+    #[test]
+    fn a_repeat_count_of_zero_is_rejected() {
+        assert!(EntityDecl::parse("timer*0").is_err());
+    }
+
+    /// The CMake projection is `include()`able and composes: it sets the knob
+    /// only when derived, and records the provenance either way.
+    #[test]
+    fn the_cmake_projection_sets_the_knob_only_when_derived() {
+        let mut inv = EntityInventory::new("build/nros-metadata.json");
+        inv.insert(stated("a", "one", &["sub*2", "pub*4", "timer"]));
+        let c = inv.to_cmake();
+        assert!(c.contains("set(NROS_ENTITY_INVENTORY_STATUS \"derived\")"));
+        assert!(c.contains("set(NROS_DERIVED_EXECUTOR_MAX_CBS 3)"));
+        assert!(c.contains("set(NROS_ENTITY_INVENTORY_ENTITY_TOTAL 7)"));
+        assert!(c.contains("set(NROS_ENTITY_COUNT_PUBLISHER 4)"));
+        assert!(c.contains("a::one = 7 entities, 3 slots"));
+        assert!(
+            c.contains("set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)"),
+            "a reader must be able to refuse an unrecognised schema"
+        );
+    }
+
+    /// A refusal reason is multi-line prose from `derive()`; a raw newline
+    /// inside `set(... "...")` is legal CMake but unreadable, and a stray quote
+    /// would end the string early.
+    #[test]
+    fn a_refusal_reason_is_escaped_for_cmake() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(ComponentEntities {
+            pkg: "b".into(),
+            component: "two".into(),
+            class: "b::\"Two\"".into(),
+            declaration: Declaration::Absent,
+        });
+        let c = inv.to_cmake();
+        let reason_line = c
+            .lines()
+            .find(|l| l.starts_with("set(NROS_ENTITY_INVENTORY_REASON"))
+            .expect("a reason is published");
+        assert!(!reason_line.contains("\\n\\n"), "no double escaping");
+        assert!(
+            reason_line.ends_with("\")"),
+            "the string closes: {reason_line}"
+        );
+        assert!(reason_line.contains("\\\""), "the class quote is escaped");
+    }
+
+    /// The env transport is the cargo carrier and it is EMPTY on a refusal:
+    /// an absent variable leaves `nros-node/build.rs` on its own default, which
+    /// is rung 4 of the ladder.
+    #[test]
+    fn the_env_transport_is_empty_on_a_refusal() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["sub", "timer", "service_server"]));
+        assert_eq!(inv.to_env(), "NROS_EXECUTOR_MAX_CBS=3\n");
+        inv.insert(ComponentEntities {
+            pkg: "b".into(),
+            component: "two".into(),
+            class: "b::Two".into(),
+            declaration: Declaration::Absent,
+        });
+        assert_eq!(inv.to_env(), "");
+    }
+
+    /// Registering the same component twice cannot double-count it: cmake
+    /// re-runs `nano_ros_node_register` on every configure, and a workspace
+    /// that reaches one package through two `add_subdirectory()` paths is a
+    /// shape this tree already has.
+    #[test]
+    fn a_component_recorded_twice_is_recorded_once() {
+        let mut inv = EntityInventory::new("test");
+        inv.insert(stated("a", "one", &["sub*3"]));
+        inv.insert(stated("a", "one", &["sub*3"]));
+        assert_eq!(inv.len(), 1);
+        assert_eq!(inv.derive().knobs().unwrap().max_cbs, 3);
+    }
+
+    /// Emission order is stable, so a write-if-changed consumer does not
+    /// re-arm a reconfigure on every run.
+    #[test]
+    fn emission_order_is_stable() {
+        let mut a = EntityInventory::new("test");
+        a.insert(stated("z", "one", &["sub"]));
+        a.insert(stated("a", "two", &["timer"]));
+        let mut b = EntityInventory::new("test");
+        b.insert(stated("a", "two", &["timer"]));
+        b.insert(stated("z", "one", &["sub"]));
+        assert_eq!(a.to_cmake(), b.to_cmake());
+        assert_eq!(a.to_json(), b.to_json());
+    }
+
+    /// The measured island. Its four components, exactly as their ctors read
+    /// today, and the two numbers the bring-up conflated.
+    ///
+    /// 33 entities is what a human counts and what
+    /// `docs/roadmap/phase-3-canhubk344-real-silicon.md` recorded; 19 is the
+    /// callback-slot demand, because the 14 publishers claim no slot. The board
+    /// `.conf` pins 36.
+    #[test]
+    fn the_island_derives_nineteen_slots_from_thirty_three_entities() {
+        let mut inv = EntityInventory::new("island");
+        inv.insert(stated(
+            "autoware_mrm_handler",
+            "mrm_handler",
+            &["sub*7", "pub*5", "service_client*2", "timer"],
+        ));
+        inv.insert(stated(
+            "autoware_stop_mode_operator",
+            "stop_mode_operator",
+            &["pub*4", "sub*3", "timer"],
+        ));
+        inv.insert(stated(
+            "autoware_mrm_comfortable_stop_operator",
+            "mrm_comfortable_stop_operator",
+            &["service_server", "pub*3", "timer"],
+        ));
+        inv.insert(stated(
+            "autoware_mrm_emergency_stop_operator",
+            "mrm_emergency_stop_operator",
+            &["sub", "service_server", "pub*2", "timer"],
+        ));
+        let k = inv.derive().knobs().expect("derived").clone();
+        assert_eq!(k.entity_total, 33);
+        assert_eq!(k.per_kind["publisher"], 14);
+        assert_eq!(k.per_kind["subscription"], 11);
+        assert_eq!(k.per_kind["timer"], 4);
+        assert_eq!(k.per_kind["service_server"], 2);
+        assert_eq!(k.per_kind["service_client"], 2);
+        assert_eq!(k.max_cbs, 19);
+    }
+}

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -19,6 +19,11 @@ pub mod builder;
 pub mod atomic_file;
 pub mod build_output;
 pub mod cmd;
+// phase-403 W9 (issue 0965) — the ENTITY inventory: WHICH entities an image
+// creates, the half the BOUND inventory (which prices a TYPE) cannot answer.
+// Shaped like `rosidl_codegen::bounds` — one data model, three transports —
+// rather than as a second inventory mechanism.
+pub mod entity_inventory;
 // Issue 0363 — the freshness predicate, shared verbatim with `build.rs` via
 // `include!`. One implementation: the build embeds a stamp, the runtime
 // recomputes it. Replaces the mtime comparison that fired on every rebase.

--- a/scripts/check-entity-slot-costs.py
+++ b/scripts/check-entity-slot-costs.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""phase-403 W9 (issue 0965) - the per-kind CALLBACK SLOT COST has one
+definition, and it matches the registration sites that actually claim a slot.
+
+`nros ws entity-inventory` derives `NROS_EXECUTOR_MAX_CBS` by summing
+`EntityKind::callback_slots()` over an image's declared entities. That function
+is a MIRROR: the CLI is a host binary and `nros-node` is `no_std` and built for
+the target, so it cannot read the executor's own accounting and has to restate
+it. A mirror is acceptable only while something holds it to the definition -
+which is the entire difference between this and a comment, and the reason
+`check-infra-queryable-counts` exists one lane over.
+
+The definition is `Executor::next_entry_slot()`. A registration that calls it
+claims one entry in the table `MAX_CBS` sizes; one that does not, does not.
+
+WHAT THIS GATE IS ACTUALLY DEFENDING. `create_publisher` never reaches
+`next_entry_slot` - on the C++ path it writes an `RmwPublisher` into
+caller-owned storage, and on the C path there is no `nros_executor_add_publisher`
+to increment `handle_count`. So a publisher costs ZERO slots, and the island's
+33 declared entities want 19. The mr-canhubk344 bring-up log recorded "33
+handles" and set `MAX_CBS=36` from it. If a later change makes a publisher claim
+a slot and this mirror is not moved with it, every image deriving its `MAX_CBS`
+under-sizes by its publisher count - which is the silent-wrong-number failure
+this whole campaign exists to remove.
+
+Python rather than shell, for the reason `check-infra-queryable-counts` gives:
+`check-gate-selftests`'s call detector requires parentheses, which a bash
+function call never has.
+"""
+
+import os
+import re
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+MODEL = "packages/cli/nros-cli-core/src/entity_inventory.rs"
+SPIN = "packages/core/nros-node/src/executor/spin.rs"
+ACTION = "packages/core/nros-node/src/executor/action.rs"
+C_API = "packages/api/nros-c/src/executor.rs"
+
+# fn-name fragment -> entity kind, IN ORDER. `service_client` must be tried
+# before `service`, and both action kinds before either, or a client is
+# classified as a server and the gate agrees with a mirror it never checked.
+CLASSIFY = [
+    ("action_server", "action_server"),
+    ("action_client", "action_client"),
+    ("service_client", "service_client"),
+    ("subscription", "subscription"),
+    ("timer", "timer"),
+    ("service", "service_server"),
+    ("guard", "guard_condition"),
+    ("publisher", "publisher"),
+]
+
+# Every kind the model knows. Restated here so a kind ADDED to the model with no
+# registration site behind it is caught too - the direction that over-sizes,
+# which is cheaper but still a number nothing backs.
+KINDS = [
+    "publisher",
+    "subscription",
+    "timer",
+    "service_server",
+    "service_client",
+    "action_server",
+    "action_client",
+    "guard_condition",
+]
+
+
+def read(root, rel):
+    with open(os.path.join(root, rel), encoding="utf8") as fh:
+        return fh.read()
+
+
+def declared_costs(text):
+    """`EntityKind::callback_slots()` -> {kind: slots}.
+
+    Parses the match arms rather than the whole file: the function is the one
+    definition, and reading it structurally is what makes an edit to it visible
+    here instead of only in a review.
+    """
+    m = re.search(
+        r"pub fn callback_slots\(self\) -> usize \{(.*?)\n    \}", text, re.S
+    )
+    if not m:
+        return None
+    body = m.group(1)
+    costs = {}
+    # Two arm shapes: `EntityKind::X => N,` and a `|`-joined group sharing one
+    # result. Both are normal Rust and both appear today.
+    for arm in re.finditer(r"((?:\s*(?:\|\s*)?EntityKind::\w+)+)\s*=>\s*(\d+)", body):
+        cost = int(arm.group(2))
+        for name in re.findall(r"EntityKind::(\w+)", arm.group(1)):
+            costs[camel_to_snake(name)] = cost
+    return costs
+
+
+def camel_to_snake(name):
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def claiming_fns(text):
+    """Every `fn` in `text` whose body reaches `next_entry_slot()`.
+
+    Attributes each call to the nearest preceding `fn`, which is how the module
+    is written (one claim per registration entry point, at the top of the body,
+    before the fallible work).
+    """
+    out = []
+    fns = [(m.start(), m.group(1)) for m in re.finditer(r"\n\s*(?:pub(?:\(crate\))? )?fn (\w+)", text)]
+    for m in re.finditer(r"next_entry_slot\(\)", text):
+        owner = None
+        for pos, name in fns:
+            if pos < m.start():
+                owner = name
+            else:
+                break
+        if owner:
+            out.append(owner)
+    return sorted(set(out))
+
+
+def classify(fn):
+    for frag, kind in CLASSIFY:
+        if frag in fn:
+            return kind
+    return None
+
+
+def check(root):
+    """Return a list of problem strings (empty == pass)."""
+    problems = []
+    try:
+        model = read(root, MODEL)
+    except OSError as e:
+        return [f"missing {MODEL}: {e}"]
+    costs = declared_costs(model)
+    if costs is None:
+        return [
+            f"`EntityKind::callback_slots` not found in {MODEL} - the per-kind "
+            f"cost must have exactly one definition, and this gate reads it. "
+            f"Fix the pattern; do not delete the check."
+        ]
+    missing = [k for k in KINDS if k not in costs]
+    if missing:
+        problems.append(
+            f"{MODEL}: callback_slots() states no cost for {', '.join(missing)}. "
+            f"Every kind needs one - an unstated kind is counted as zero by "
+            f"nothing and as one by nobody."
+        )
+
+    sites = []
+    for rel in (SPIN, ACTION):
+        try:
+            sites.extend(claiming_fns(read(root, rel)))
+        except OSError as e:
+            problems.append(f"cannot read {rel}: {e}")
+    if not sites:
+        return problems + [
+            f"no `next_entry_slot()` call sites found in {SPIN} / {ACTION} - the "
+            f"registration shape changed and this gate is now blind. Fix the "
+            f"pattern; do not delete the check."
+        ]
+
+    claiming = set()
+    for fn in sites:
+        kind = classify(fn)
+        if kind is None:
+            problems.append(
+                f"`{fn}` claims an executor callback slot and this gate cannot "
+                f"tell which entity kind it is. Add it to CLASSIFY in this "
+                f"script AND give the kind a cost in {MODEL} - a registration "
+                f"nobody counts is a MAX_CBS smaller than the image needs."
+            )
+            continue
+        claiming.add(kind)
+
+    for kind in sorted(claiming):
+        if costs.get(kind) == 0:
+            problems.append(
+                f"`{kind}` reaches Executor::next_entry_slot() but "
+                f"callback_slots() says it costs 0 slots. Every image deriving "
+                f"NROS_EXECUTOR_MAX_CBS is now short by its {kind} count, and "
+                f"the failure is a boot-time ExecutorFull rather than a build "
+                f"error."
+            )
+    for kind in KINDS:
+        if kind in claiming:
+            continue
+        if costs.get(kind, 0) != 0:
+            problems.append(
+                f"`{kind}` costs {costs[kind]} slot(s) in {MODEL} and no "
+                f"registration site in {SPIN} / {ACTION} claims one for it. "
+                f"That over-sizes every derived MAX_CBS by its count; if the "
+                f"kind really is free, say 0."
+            )
+
+    # The specific claim the island's measured 19-not-33 rests on, asserted
+    # separately from the loop above so its failure names the consequence.
+    if costs.get("publisher") != 0:
+        problems.append(
+            f"{MODEL} says a publisher costs {costs.get('publisher')} slot(s). "
+            f"If that became true, say so here AND in "
+            f"cmake/NanoRosEntityInventory.cmake and zephyr/Kconfig, both of "
+            f"which state that a publisher claims none."
+        )
+    if any("publisher" in fn for fn in sites):
+        problems.append(
+            f"a publisher registration now reaches next_entry_slot() "
+            f"({', '.join(fn for fn in sites if 'publisher' in fn)}). "
+            f"callback_slots() must charge it, and the three places that state "
+            f"'a publisher claims no slot' must be corrected with it."
+        )
+
+    # The C API keeps its own `handle_count`, capped at the same MAX_CBS. It is
+    # a second accounting of one table, so it is checked separately: a publisher
+    # that started incrementing it would under-size a C image while the Rust
+    # sites above still read clean.
+    try:
+        c_api = read(root, C_API)
+    except OSError:
+        pass  # the C API is an optional member of some trees
+    else:
+        incs = [m.start() for m in re.finditer(r"handle_count \+= 1", c_api)]
+        fns = [
+            (m.start(), m.group(1))
+            for m in re.finditer(r"\n\s*(?:pub )?(?:unsafe )?extern \"C\" fn (\w+)", c_api)
+        ]
+        if not incs:
+            problems.append(
+                f"no `handle_count += 1` sites found in {C_API} - the C API's "
+                f"own accounting changed and this gate is now blind. Fix the "
+                f"pattern; do not delete the check."
+            )
+        for pos in incs:
+            owner = None
+            for fpos, name in fns:
+                if fpos < pos:
+                    owner = name
+                else:
+                    break
+            if owner and "publisher" in owner:
+                problems.append(
+                    f"{C_API}: `{owner}` increments handle_count, so a publisher "
+                    f"DOES claim a slot on the C path. callback_slots() says 0."
+                )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Self-test. On the NORMAL path, not behind a flag: a negative control nobody
+# runs decays into a comment (`check-gate-selftests`).
+# ---------------------------------------------------------------------------
+
+MODEL_TMPL = """\
+impl EntityKind {{
+    pub fn callback_slots(self) -> usize {{
+        match self {{
+            EntityKind::Publisher => {pub_cost},
+            EntityKind::Subscription
+            | EntityKind::Timer
+            | EntityKind::ServiceServer
+            | EntityKind::ServiceClient
+            | EntityKind::ActionServer
+            | EntityKind::ActionClient
+            | EntityKind::GuardCondition => 1,
+        }}
+    }}
+}}
+"""
+
+SPIN_TMPL = """\
+impl Executor {{
+    pub fn register_subscription_buffered_on(&mut self) {{
+        let slot = self.next_entry_slot()?;
+    }}
+    pub fn register_timer(&mut self) {{
+        let slot = self.next_entry_slot()?;
+    }}
+    pub fn register_service_sized(&mut self) {{
+        let slot = self.next_entry_slot()?;
+    }}
+    pub fn register_service_client_raw_sized_inner(&mut self) {{
+        let slot = self.next_entry_slot()?;
+    }}
+    pub fn register_guard_condition(&mut self) {{
+        let slot = self.next_entry_slot()?;
+    }}
+{extra}
+}}
+"""
+
+ACTION_TMPL = """\
+impl Executor {
+    pub fn register_action_server_sized(&mut self) {
+        let slot = self.next_entry_slot()?;
+    }
+    pub fn register_action_client_core(&mut self) {
+        let slot = self.next_entry_slot()?;
+    }
+}
+"""
+
+C_TMPL = """\
+pub unsafe extern "C" fn nros_executor_add_subscription() {{
+    executor.handle_count += 1;
+}}
+{extra}
+"""
+
+
+def _write(root, pub_cost=0, spin_extra="", c_extra=""):
+    for rel, body in (
+        (MODEL, MODEL_TMPL.format(pub_cost=pub_cost)),
+        (SPIN, SPIN_TMPL.format(extra=spin_extra)),
+        (ACTION, ACTION_TMPL),
+        (C_API, C_TMPL.format(extra=c_extra)),
+    ):
+        path = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf8") as fh:
+            fh.write(body)
+
+
+def self_test():
+    pub_site = """
+    pub fn register_publisher_thing(&mut self) {
+        let slot = self.next_entry_slot()?;
+    }
+"""
+    unknown_site = """
+    pub fn register_wormhole(&mut self) {
+        let slot = self.next_entry_slot()?;
+    }
+"""
+    c_pub = """
+pub unsafe extern "C" fn nros_executor_add_publisher() {
+    executor.handle_count += 1;
+}
+"""
+    cases = [
+        ((0, "", ""), 0, "a publisher costs 0 and claims nothing"),
+        ((1, "", ""), 1, "the mirror started charging a publisher nothing charges"),
+        ((0, pub_site, ""), 1, "a publisher registration started claiming a slot"),
+        ((0, unknown_site, ""), 1, "an unclassifiable registration claims a slot"),
+        ((0, "", c_pub), 1, "the C API started counting a publisher as a handle"),
+    ]
+    failures = 0
+    tmp = tempfile.mkdtemp()
+    try:
+        for args, want, label in cases:
+            root = os.path.join(tmp, "t")
+            shutil.rmtree(root, ignore_errors=True)
+            _write(root, *args)
+            got = 1 if check(root) else 0
+            if got != want:
+                sys.stderr.write(f"  self-test FAIL: {label} - got {got}, want {want}\n")
+                failures += 1
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    if failures:
+        sys.stderr.write(f"check-entity-slot-costs self-test: FAILED ({failures})\n")
+        sys.exit(1)
+    print("check-entity-slot-costs self-test: OK")
+
+
+def main():
+    self_test()
+    if "--self-test" in sys.argv:
+        return
+    problems = check(ROOT)
+    if problems:
+        sys.stderr.write(
+            "check-entity-slot-costs: %d problem(s) - issue 0965:\n" % len(problems)
+        )
+        for p in problems:
+            sys.stderr.write(f"  - {p}\n")
+        sys.exit(1)
+    costs = declared_costs(read(ROOT, MODEL))
+    sites = claiming_fns(read(ROOT, SPIN)) + claiming_fns(read(ROOT, ACTION))
+    claiming = sorted({classify(f) for f in sites})
+    print(f"  ok    {len(sites)} registration site(s) claim a callback slot")
+    print(f"  ok    claiming kinds: {', '.join(claiming)}")
+    print(f"  ok    free kinds: {', '.join(k for k in KINDS if costs.get(k) == 0)}")
+    print("entity-slot-costs: callback_slots() agrees with next_entry_slot().")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cmake-entity-inventory-tests.sh
+++ b/tests/cmake-entity-inventory-tests.sh
@@ -52,6 +52,12 @@
 #      the whole point: "you have not declared" and "what you declared is
 #      wrong" license different actions.
 #
+#   A2. The JOIN KEY crosses the same boundary (phase-403 step 1). The
+#      subscribed-type set and the wider received set are what
+#      `nros_derive_message_bound_knobs` narrows the payload classes with, so
+#      an absent list is not "nothing published" -- it reads as "this image
+#      receives nothing" and derives a class over an empty set.
+#
 #   H. SEEDING. A refusal writes a placeholder fragment, because the consumer
 #      registers the path with CMAKE_CONFIGURE_DEPENDS and a ninja input with
 #      no producing rule is `missing and no known rule to make it` at LOAD,
@@ -127,7 +133,7 @@ chmod +x "$STUB"
 
 DERIVED_BODY="$TEST_TMPDIR/derived.cmake"
 cat > "$DERIVED_BODY" <<'EOF'
-set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 2)
 set(NROS_ENTITY_INVENTORY_SOURCE "meta.json")
 set(NROS_ENTITY_INVENTORY_STATUS "derived")
 set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4)
@@ -138,18 +144,34 @@ set(NROS_ENTITY_COUNT_TIMER 4)
 set(NROS_ENTITY_COUNT_SERVICE_SERVER 2)
 set(NROS_ENTITY_COUNT_SERVICE_CLIENT 2)
 set(NROS_DERIVED_EXECUTOR_MAX_CBS 19)
+set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")
+set(NROS_ENTITY_SUBSCRIBED_TYPES "nav_msgs/msg/Odometry;std_msgs/msg/Int32")
+set(NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS "nav_msgs/msg/Odometry=1;std_msgs/msg/Int32=2")
+set(NROS_ENTITY_SUBSCRIBED_ENTITY_COUNT 3)
+set(NROS_ENTITY_RECEIVED_TYPES_STATUS "resolved")
+set(NROS_ENTITY_RECEIVED_TYPES "demo/srv/Op_Request;nav_msgs/msg/Odometry;std_msgs/msg/Int32")
+set(NROS_ENTITY_RECEIVED_TYPE_COUNTS "demo/srv/Op_Request=1;nav_msgs/msg/Odometry=1;std_msgs/msg/Int32=2")
+set(NROS_ENTITY_RECEIVED_ENTITY_COUNT 4)
 EOF
 
 REFUSED_BODY="$TEST_TMPDIR/refused.cmake"
 cat > "$REFUSED_BODY" <<'EOF'
-set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 2)
 set(NROS_ENTITY_INVENTORY_STATUS "refused")
 set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4)
 set(NROS_ENTITY_INVENTORY_REASON "1 of 4 components in this image declare no entities:\n    demo::legacy (demo::Legacy)")
+set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "refused")
+set(NROS_ENTITY_SUBSCRIBED_TYPES_REASON "the entity inventory itself did not compose")
+set(NROS_ENTITY_RECEIVED_TYPES_STATUS "refused")
+set(NROS_ENTITY_RECEIVED_TYPES_REASON "the entity inventory itself did not compose")
 EOF
 
+# A schema this reader does NOT understand. Written as "one past supported"
+# rather than a literal, because the literal was `2` until phase-403 step 1
+# made 2 the supported version -- at which point the case silently stopped
+# testing anything it claimed to.
 BAD_SCHEMA_BODY="$TEST_TMPDIR/bad-schema.cmake"
-sed 's/SCHEMA_VERSION 1/SCHEMA_VERSION 2/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
+sed 's/SCHEMA_VERSION 2/SCHEMA_VERSION 3/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
 
 NO_SCHEMA_BODY="$TEST_TMPDIR/no-schema.cmake"
 grep -v SCHEMA_VERSION "$DERIVED_BODY" > "$NO_SCHEMA_BODY"
@@ -194,6 +216,24 @@ fi
 check
 if ! grep -q "publishers, which claim no callback slot" <<<"$OUT"; then
     fail "A: the status line does not say publishers claim no slot -- $OUT"
+fi
+# phase-403 step 1. The JOIN KEY has to cross the same function boundary the
+# counts do; it is the input `nros_derive_message_bound_knobs` narrows the
+# payload classes with, and an absent list there reads as "receives nothing".
+check
+if ! grep -q "NROS_ENTITY_SUBSCRIBED_TYPES_STATUS=resolved" <<<"$OUT"; then
+    fail "A: the subscribed-type status did not reach the caller's scope -- $OUT"
+fi
+check
+if ! grep -q "NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS=nav_msgs/msg/Odometry=1;std_msgs/msg/Int32=2" <<<"$OUT"; then
+    fail "A: the per-type ENTITY counts did not reach the caller's scope -- $OUT"
+fi
+# The two views are different sets and both travel. Collapsing them would
+# either price a service request against a pool it never allocates from, or
+# leave the arena blind to four receiving kinds.
+check
+if ! grep -q "NROS_ENTITY_RECEIVED_TYPES=demo/srv/Op_Request;" <<<"$OUT"; then
+    fail "A: the wider RECEIVED set did not reach the caller's scope -- $OUT"
 fi
 
 # ---------------------------------------------------------------------------
@@ -249,7 +289,7 @@ log_info "D. an unrecognised schema refuses to be read"
 flat() { tr '\n' ' ' | tr -s ' '; }
 OUT="$(derive "$BAD_SCHEMA_BODY" 0 "$META" "$TEST_TMPDIR/d1.cmake" | flat)"
 check
-if ! grep -q "states entity-inventory schema version 2" <<<"$OUT"; then
+if ! grep -q "states entity-inventory schema version 3" <<<"$OUT"; then
     fail "D: a future schema was read rather than refused -- $OUT"
 fi
 check

--- a/tests/cmake-entity-inventory-tests.sh
+++ b/tests/cmake-entity-inventory-tests.sh
@@ -1,0 +1,349 @@
+#!/bin/bash
+# tests/cmake-entity-inventory-tests.sh -- phase-403 W9 (issue 0965)
+#
+# Exercises the READER for the entity inventory: `cmake/NanoRosEntityInventory.
+# cmake`, driven in `cmake -P` script mode. Sibling of
+# `tests/cmake-message-bounds-tests.sh`, and shaped like it.
+#
+# THE CLI IS STUBBED, DELIBERATELY. The derivation itself -- the counting rule,
+# the per-kind slot cost, the refusal -- lives in
+# `nros_cli_core::entity_inventory` and is unit-tested there, including the
+# island's 33-entities-19-slots case. What CMAKE owns is a different set of
+# facts, and every one of them is a failure mode that has bitten this tree
+# before: does a refusal publish NO number, does an unknown schema FATAL instead
+# of being read field-by-field, does a missing input refuse rather than break a
+# clean-tree configure, and does the answer reach the CALLER's scope at all.
+# A stub that emits fragments lets each of those be a case; requiring a built
+# `nros` would make this gate need a cargo build, which is exactly what
+# `check-lane-contracts` forbids on an affordability lane.
+#
+# WHAT IS ASSERTED:
+#
+#   A. A DERIVED fragment reaches the caller's scope: status, component count,
+#      entity total, per-kind counts and NROS_DERIVED_EXECUTOR_MAX_CBS. The
+#      scope half is the one that reads as working while being broken --
+#      `include()` inside a function keeps its `set()`s in that frame, and
+#      publishing to one of the two scopes is the bug `_nros_bounds_publish`
+#      was written to prevent.
+#
+#   B. A REFUSED fragment publishes the reason and NO number. This is the
+#      wave's central requirement: a consumer either reads a value the
+#      inventory derived or reads nothing, because a slot count composed over
+#      part of an image is SMALLER than the image needs and a short MAX_CBS
+#      fails entity creation at boot.
+#
+#   C. A REFUSAL AFTER A DERIVATION leaves no stale number standing. The
+#      function is called twice in one script; the second call must clear what
+#      the first published, in both scopes.
+#
+#   D. An unknown SCHEMA VERSION is a FATAL_ERROR, and so is a fragment that
+#      states none. Reading fields that may have moved is how two green tools
+#      come to disagree.
+#
+#   E. A MISSING metadata file refuses rather than fataling -- an image that
+#      has registered no component is the state every build was in before this
+#      wave, and it is the permanent state of a launch-only image.
+#
+#   F. A MISSING CLI refuses rather than fataling, for the same reason.
+#
+#   G. A CLI that EXITS NON-ZERO is fatal. That is a broken declaration -- an
+#      unknown entity kind, a component claiming NONE beside real entities --
+#      and it names a component the user can fix. Distinguishing it from E/F is
+#      the whole point: "you have not declared" and "what you declared is
+#      wrong" license different actions.
+#
+#   H. SEEDING. A refusal writes a placeholder fragment, because the consumer
+#      registers the path with CMAKE_CONFIGURE_DEPENDS and a ninja input with
+#      no producing rule is `missing and no known rule to make it` at LOAD,
+#      before any rule runs. And seeding never overwrites an existing answer.
+#
+# PRECONDITIONS ARE HARD FAILURES. This script never prints-and-returns: a
+# green here is read as "the reader is sound". Skipping belongs in the `just`
+# recipe's check ledger, which is a different claim from "it passed".
+#
+# Usage: ./tests/cmake-entity-inventory-tests.sh
+# Exit:  0 all assertions held; 1 otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+MODULE="$PROJECT_ROOT/cmake/NanoRosEntityInventory.cmake"
+
+FAILURES=0
+CHECKS=0
+
+fail() {
+    log_error "$*"
+    FAILURES=$((FAILURES + 1))
+}
+
+check() {
+    CHECKS=$((CHECKS + 1))
+}
+
+if [ ! -f "$MODULE" ]; then
+    fail "module not found: $MODULE"
+    exit 1
+fi
+if ! command -v cmake >/dev/null 2>&1; then
+    fail "cmake is not on PATH -- this test cannot report a verdict without it"
+    exit 1
+fi
+
+init_test_tmpdir "nros-entity-inventory"
+trap 'cleanup_test_tmpdir' EXIT
+
+# ---------------------------------------------------------------------------
+# A stub `nros`. It writes the fragment named by --output-cmake, copying a body
+# this script supplies through NROS_STUB_BODY, and exits with NROS_STUB_RC.
+#
+# The bodies below are byte-for-byte the shape
+# `nros_cli_core::entity_inventory::EntityInventory::to_cmake` emits (see its
+# unit tests) -- if that emitter changes shape, these stop matching and this
+# test is where it is noticed.
+# ---------------------------------------------------------------------------
+STUB="$TEST_TMPDIR/nros-stub"
+cat > "$STUB" <<'STUB_EOF'
+#!/bin/bash
+out=""
+prev=""
+for a in "$@"; do
+    if [ "$prev" = "--output-cmake" ]; then out="$a"; fi
+    prev="$a"
+done
+if [ -n "${NROS_STUB_BODY:-}" ] && [ -n "$out" ]; then
+    mkdir -p "$(dirname "$out")"
+    cp "$NROS_STUB_BODY" "$out"
+fi
+if [ -n "${NROS_STUB_STDERR:-}" ]; then echo "$NROS_STUB_STDERR" >&2; fi
+exit "${NROS_STUB_RC:-0}"
+STUB_EOF
+chmod +x "$STUB"
+
+DERIVED_BODY="$TEST_TMPDIR/derived.cmake"
+cat > "$DERIVED_BODY" <<'EOF'
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)
+set(NROS_ENTITY_INVENTORY_SOURCE "meta.json")
+set(NROS_ENTITY_INVENTORY_STATUS "derived")
+set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4)
+set(NROS_ENTITY_INVENTORY_ENTITY_TOTAL 33)
+set(NROS_ENTITY_COUNT_PUBLISHER 14)
+set(NROS_ENTITY_COUNT_SUBSCRIPTION 11)
+set(NROS_ENTITY_COUNT_TIMER 4)
+set(NROS_ENTITY_COUNT_SERVICE_SERVER 2)
+set(NROS_ENTITY_COUNT_SERVICE_CLIENT 2)
+set(NROS_DERIVED_EXECUTOR_MAX_CBS 19)
+EOF
+
+REFUSED_BODY="$TEST_TMPDIR/refused.cmake"
+cat > "$REFUSED_BODY" <<'EOF'
+set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)
+set(NROS_ENTITY_INVENTORY_STATUS "refused")
+set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4)
+set(NROS_ENTITY_INVENTORY_REASON "1 of 4 components in this image declare no entities:\n    demo::legacy (demo::Legacy)")
+EOF
+
+BAD_SCHEMA_BODY="$TEST_TMPDIR/bad-schema.cmake"
+sed 's/SCHEMA_VERSION 1/SCHEMA_VERSION 2/' "$DERIVED_BODY" > "$BAD_SCHEMA_BODY"
+
+NO_SCHEMA_BODY="$TEST_TMPDIR/no-schema.cmake"
+grep -v SCHEMA_VERSION "$DERIVED_BODY" > "$NO_SCHEMA_BODY"
+
+META="$TEST_TMPDIR/nros-metadata.json"
+echo '{"components": []}' > "$META"
+
+# Run the derivation through the module's `cmake -P` entry point.
+#   derive <body-or-empty> <rc> <metadata> <output> [extra env]
+derive() {
+    local body="$1" rc="$2" meta="$3" out="$4" cli="${5:-$STUB}"
+    NROS_STUB_BODY="$body" NROS_STUB_RC="$rc" \
+        cmake -DNROS_ENTITY_CLI="$cli" \
+              -DNROS_ENTITY_METADATA="$meta" \
+              -DNROS_ENTITY_OUTPUT="$out" \
+              -P "$MODULE" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# A. A derived fragment reaches the caller's scope, with every field.
+# ---------------------------------------------------------------------------
+log_info "A. a derived inventory publishes its numbers"
+OUT="$(derive "$DERIVED_BODY" 0 "$META" "$TEST_TMPDIR/a.cmake")"
+check
+if ! grep -q "NROS_ENTITY_INVENTORY_STATUS=derived" <<<"$OUT"; then
+    fail "A: status not derived -- $OUT"
+fi
+check
+if ! grep -q "NROS_DERIVED_EXECUTOR_MAX_CBS=19" <<<"$OUT"; then
+    fail "A: MAX_CBS did not reach the caller's scope -- $OUT"
+fi
+check
+if ! grep -q "NROS_ENTITY_INVENTORY_ENTITY_TOTAL=33" <<<"$OUT"; then
+    fail "A: the entity total did not reach the caller's scope -- $OUT"
+fi
+check
+# The entity total and the slot demand are DIFFERENT numbers and both are
+# published. Collapsing them is the island's 33-vs-19 error.
+if ! grep -q "NROS_ENTITY_COUNT_PUBLISHER=14" <<<"$OUT"; then
+    fail "A: per-kind counts did not reach the caller's scope -- $OUT"
+fi
+check
+if ! grep -q "publishers, which claim no callback slot" <<<"$OUT"; then
+    fail "A: the status line does not say publishers claim no slot -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# B. A refusal publishes the reason and NO number.
+# ---------------------------------------------------------------------------
+log_info "B. a refusal publishes no number"
+OUT="$(derive "$REFUSED_BODY" 0 "$META" "$TEST_TMPDIR/b.cmake")"
+check
+if ! grep -q "NROS_ENTITY_INVENTORY_STATUS=refused" <<<"$OUT"; then
+    fail "B: status not refused -- $OUT"
+fi
+check
+if grep -q "NROS_DERIVED_EXECUTOR_MAX_CBS=" <<<"$OUT"; then
+    fail "B: a refusal published a MAX_CBS -- $OUT"
+fi
+check
+if ! grep -q "declare no entities" <<<"$OUT"; then
+    fail "B: the refusal reason did not reach the caller -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# C. A refusal AFTER a derivation leaves no stale number standing.
+# ---------------------------------------------------------------------------
+log_info "C. a second, refusing call clears the first call's answer"
+SEQ="$TEST_TMPDIR/seq.cmake"
+cat > "$SEQ" <<EOF
+include("$MODULE")
+nros_derive_entity_inventory_knobs(CLI "$STUB" METADATA "$META"
+    OUTPUT_FILE "$TEST_TMPDIR/c1.cmake" QUIET)
+message(STATUS "first=\${NROS_DERIVED_EXECUTOR_MAX_CBS}")
+set(ENV{NROS_STUB_BODY} "$REFUSED_BODY")
+nros_derive_entity_inventory_knobs(CLI "$STUB" METADATA "$META"
+    OUTPUT_FILE "$TEST_TMPDIR/c2.cmake" QUIET)
+message(STATUS "second=[\${NROS_DERIVED_EXECUTOR_MAX_CBS}]")
+EOF
+OUT="$(NROS_STUB_BODY="$DERIVED_BODY" cmake -P "$SEQ" 2>&1)"
+check
+if ! grep -q "first=19" <<<"$OUT"; then
+    fail "C: the first call did not publish -- $OUT"
+fi
+check
+if ! grep -q "second=\[\]" <<<"$OUT"; then
+    fail "C: a refusal left the previous number standing -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# D. An unrecognised schema is FATAL, both shapes.
+# ---------------------------------------------------------------------------
+log_info "D. an unrecognised schema refuses to be read"
+# cmake re-wraps a `message(FATAL_ERROR)` body at ~72 columns, so the phrases
+# below are matched against the output with newlines squashed. Grepping the raw
+# text passes only by accident of where the wrap lands.
+flat() { tr '\n' ' ' | tr -s ' '; }
+OUT="$(derive "$BAD_SCHEMA_BODY" 0 "$META" "$TEST_TMPDIR/d1.cmake" | flat)"
+check
+if ! grep -q "states entity-inventory schema version 2" <<<"$OUT"; then
+    fail "D: a future schema was read rather than refused -- $OUT"
+fi
+check
+if ! grep -qi "CMake Error" <<<"$OUT"; then
+    fail "D: a future schema did not raise a FATAL_ERROR -- $OUT"
+fi
+OUT="$(derive "$NO_SCHEMA_BODY" 0 "$META" "$TEST_TMPDIR/d2.cmake" | flat)"
+check
+if ! grep -q "sets no NROS_ENTITY_INVENTORY_SCHEMA_VERSION" <<<"$OUT"; then
+    fail "D: a fragment with no schema was read rather than refused -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# E. A missing metadata file refuses; it does not break the configure.
+# ---------------------------------------------------------------------------
+log_info "E. a missing metadata file refuses rather than fataling"
+OUT="$(derive "$DERIVED_BODY" 0 "$TEST_TMPDIR/absent.json" "$TEST_TMPDIR/e.cmake")"
+check
+if grep -qi "CMake Error" <<<"$OUT"; then
+    fail "E: a missing metadata file was fatal -- $OUT"
+fi
+check
+if ! grep -q "NROS_ENTITY_INVENTORY_STATUS=refused" <<<"$OUT"; then
+    fail "E: a missing metadata file did not refuse -- $OUT"
+fi
+check
+if ! grep -q "nothing in this image called nano_ros_node_register" <<<"$OUT"; then
+    fail "E: the refusal does not say what is missing -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# F. A missing CLI refuses too.
+# ---------------------------------------------------------------------------
+log_info "F. a missing CLI refuses rather than fataling"
+OUT="$(derive "$DERIVED_BODY" 0 "$META" "$TEST_TMPDIR/f.cmake" "$TEST_TMPDIR/no-such-nros")"
+check
+if grep -qi "CMake Error" <<<"$OUT"; then
+    fail "F: a missing CLI was fatal -- $OUT"
+fi
+check
+if ! grep -q "NROS_ENTITY_INVENTORY_STATUS=refused" <<<"$OUT"; then
+    fail "F: a missing CLI did not refuse -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# G. A CLI that fails is FATAL -- a broken declaration, not an absent one.
+# ---------------------------------------------------------------------------
+log_info "G. a broken declaration is fatal and names the fix"
+OUT="$(NROS_STUB_STDERR="component \`demo::n\` declares \`publsher\`" \
+       derive "" 1 "$META" "$TEST_TMPDIR/g.cmake")"
+check
+if ! grep -q "not readable" <<<"$OUT"; then
+    fail "G: a failing CLI was not fatal -- $OUT"
+fi
+check
+if ! grep -q "publsher" <<<"$OUT"; then
+    fail "G: the CLI's own message was swallowed -- $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# H. Seeding: a refusal leaves a well-formed fragment, and never clobbers one.
+# ---------------------------------------------------------------------------
+log_info "H. a refusal seeds a fragment, and seeding never clobbers an answer"
+SEED="$TEST_TMPDIR/h.cmake"
+derive "$DERIVED_BODY" 0 "$TEST_TMPDIR/absent.json" "$SEED" >/dev/null
+check
+if [ ! -f "$SEED" ]; then
+    fail "H: no fragment was seeded -- a CMAKE_CONFIGURE_DEPENDS input with no rule is a ninja load error"
+fi
+check
+if ! grep -q "NROS_ENTITY_INVENTORY_SCHEMA_VERSION" "$SEED"; then
+    fail "H: the seeded fragment states no schema version, so reading it later FATALs"
+fi
+check
+if ! grep -q 'NROS_ENTITY_INVENTORY_STATUS "refused"' "$SEED"; then
+    fail "H: the seeded fragment does not read as a refusal"
+fi
+KEEP="$TEST_TMPDIR/h-keep.cmake"
+cp "$DERIVED_BODY" "$KEEP"
+CMD="$TEST_TMPDIR/h-seed.cmake"
+cat > "$CMD" <<EOF
+include("$MODULE")
+nros_entity_inventory_seed_knobs_file("$KEEP")
+EOF
+cmake -P "$CMD" >/dev/null 2>&1
+check
+if ! grep -q "NROS_DERIVED_EXECUTOR_MAX_CBS 19" "$KEEP"; then
+    fail "H: seeding overwrote an existing answer"
+fi
+
+# ---------------------------------------------------------------------------
+if [ "$FAILURES" -eq 0 ]; then
+    log_success "cmake-entity-inventory: $CHECKS assertion(s) held"
+    exit 0
+fi
+log_error "cmake-entity-inventory: $FAILURES of $CHECKS assertion(s) failed"
+exit 1

--- a/tests/cmake-message-bounds-tests.sh
+++ b/tests/cmake-message-bounds-tests.sh
@@ -58,6 +58,29 @@
 #      called with none. Every other case passes fragments explicitly and would
 #      keep passing with the registry broken.
 #
+#   L. THE JOIN (phase-403 step 1). The three payload-class knobs derive over
+#      the types the image RECEIVES, not over everything it links. Asserted as
+#      a BEFORE/AFTER on one closure so the difference is the entity
+#      declaration and nothing else -- the island's own shape, where the small
+#      class is set by a `Float64MultiArray` that is linked and never received.
+#      Includes the take buffer NOT moving: it is also DEFAULT_TX_BUF and every
+#      raw entity's default buffer, so narrowing it would size a buffer too
+#      small, which is the failure this campaign exists to remove.
+#
+#   M. THE JOIN REFUSES rather than widening. Three shapes, all of them "the
+#      image DID declare and the join still cannot answer": the subscribed set
+#      itself refused, a named type the bound inventory does not price (which
+#      is every `pkg/srv/*` and `pkg/action/*` today -- the inventory records
+#      MESSAGES only), and a fragment that states the schema and not the field.
+#      None may fall back to the closure: that publishes a number derived over
+#      types the image never receives while the status still reads `derived`.
+#
+#   N. BACK-COMPAT. An image that declares nothing -- no fragment, or a
+#      fragment whose own status is `refused` -- keeps W8's closure answer
+#      byte for byte, labelled `basis = closure`. Refusing there would take
+#      every pre-W9 image from a derived number back to the hand-set ones.
+#      A fragment from a STALE CLI is the same case with a warning.
+#
 #   H. The OUTPUT FILE carries the answer AND the provenance, and is
 #      write-if-changed. The second is load-bearing rather than tidy: the
 #      consumer registers the file with CMAKE_CONFIGURE_DEPENDS, so rewriting
@@ -139,6 +162,34 @@ frag() {
 derive() {
     local frags="$1"; shift
     cmake -DNROS_BOUNDS_FRAGMENTS="$frags" "$@" -P "$MODULE" 2>&1
+}
+
+# phase-403 step 1. An ENTITY-inventory fragment, byte-for-byte the shape
+# `nros_cli_core::entity_inventory::EntityInventory::to_cmake` emits -- the same
+# contract-by-hand-written-fixture the `frag()` helper above is, and for the
+# same reason: a case like "the fragment is a schema behind" cannot exist if the
+# producer writes it.
+#
+#   entity_frag <path> <inventory-status> <subscribed-status> [<type>=<count>...]
+entity_frag() {
+    local path="$1" inv_status="$2" sub_status="$3"; shift 3
+    {
+        echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 2)"
+        echo "set(NROS_ENTITY_INVENTORY_STATUS \"$inv_status\")"
+        echo "set(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 1)"
+        echo "set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS \"$sub_status\")"
+        if [ "$sub_status" = "resolved" ]; then
+            local names="" pairs=""
+            for e in "$@"; do
+                names="${names:+$names;}${e%=*}"
+                pairs="${pairs:+$pairs;}$e"
+            done
+            echo "set(NROS_ENTITY_SUBSCRIBED_TYPES \"$names\")"
+            echo "set(NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS \"$pairs\")"
+        else
+            echo "set(NROS_ENTITY_SUBSCRIBED_TYPES_REASON \"a component declared no ENTITIES\")"
+        fi
+    } > "$path"
 }
 
 T="$TEST_TMPDIR"
@@ -483,18 +534,29 @@ function(first_include_from_a_frame)
 endfunction()
 first_include_from_a_frame()
 include("$MODULE")   # a no-op: the guard has already fired
-nros_derive_message_bound_knobs(FRAGMENTS "$T/a1.cmake" "$T/a2.cmake" QUIET)
+# The JOIN is the second consumer of a module-scope constant that a function
+# frame can eat: it resolves its sibling NanoRosEntityInventory.cmake through
+# \`_NROS_MESSAGE_BOUNDS_DIR\` to read that module's schema number, rather than
+# restating the number and drifting from it. An empty dir would make the
+# include silently fail and every joined image fall back to the closure.
+nros_derive_message_bound_knobs(
+    FRAGMENTS "$T/a1.cmake" "$T/a2.cmake"
+    ENTITY_INVENTORY "$T/k-ents.cmake" QUIET)
 file(WRITE "\${CMAKE_BINARY_DIR}/observed.txt"
-     "\${NROS_MESSAGE_BOUNDS_STATUS}|\${NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE}")
+     "\${NROS_MESSAGE_BOUNDS_STATUS}|\${NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE}|\${NROS_MESSAGE_BOUNDS_BASIS}|\${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE}")
 CMAKEEOF
+    # a1/a2's closure tops out at Odometry 880; subscribe only to the 114 B
+    # Control, so the joined small class must differ from the closure's.
+    entity_frag "$T/k-ents.cmake" derived resolved \
+        "autoware_control_msgs/msg/Control=1"
     KB="$T/kfn-build"
     check
     if ! cmake -G Ninja -S "$K" -B "$KB" > "$T/k.log" 2>&1; then
         fail "K: configure failed -- the module's constants did not survive a first include from a function frame:"; cat "$T/k.log"
     fi
     check
-    if [ "$(cat "$KB/observed.txt" 2>/dev/null)" != "derived|880" ]; then
-        fail "K: expected derived|880, got: $(cat "$KB/observed.txt" 2>/dev/null)"
+    if [ "$(cat "$KB/observed.txt" 2>/dev/null)" != "derived|880|subscribed|114" ]; then
+        fail "K: expected derived|880|subscribed|114 -- the take buffer on the closure, the small class on the join, both after a first include from a function frame. Got: $(cat "$KB/observed.txt" 2>/dev/null)"
     fi
 fi
 
@@ -547,6 +609,237 @@ CMAKEEOF
     if grep -q "set(NROS_DERIVED_" "$RB/knobs2.cmake"; then
         fail "J: the refusal file carries a value from the previous call:"; cat "$RB/knobs2.cmake"
     fi
+fi
+
+# ---------------------------------------------------------------------------
+# L. THE JOIN -- the reference island's shape, before and after.
+#
+# One closure, two runs, and the ONLY difference is whether an entity
+# declaration is present. `std_msgs/msg/Float64MultiArray` at 1496 B is linked
+# and never received; `nav_msgs/msg/Odometry` at 880 B is the largest that is.
+# These are the island's own derived bounds, and 1496 -> 880 is the measured
+# 71,808 -> 42,240 bytes of `SMALL_PAYLOADS` at its 12 subscribers x 4 ring
+# depth.
+# ---------------------------------------------------------------------------
+log_header "L -- the payload classes derive over what the image RECEIVES"
+frag "$T/l1.cmake" "island" <<'ROWS'
+std_msgs/msg/Float64MultiArray|bounded|1488|1496|
+nav_msgs/msg/Odometry|bounded|836|880|
+autoware_control_msgs/msg/Control|bounded|78|114|
+autoware_vehicle_msgs/msg/GearCommand|bounded|13|21|
+ROWS
+# The island subscribes to Odometry and Control; it PUBLISHES GearCommand and
+# neither publishes nor subscribes Float64MultiArray (a linked sibling type).
+entity_frag "$T/l-ents.cmake" derived resolved \
+    "nav_msgs/msg/Odometry=1" "autoware_control_msgs/msg/Control=1"
+
+OUT_BEFORE="$(derive "$T/l1.cmake")"
+OUT_AFTER="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/l-ents.cmake")"
+
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE=1496" <<< "$OUT_BEFORE"; then
+    fail "L: without a declaration the small class must still be the closure's 1496:"; echo "$OUT_BEFORE"
+fi
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_BASIS=closure" <<< "$OUT_BEFORE"; then
+    fail "L: the closure answer must be LABELLED as such:"; echo "$OUT_BEFORE"
+fi
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE=880" <<< "$OUT_AFTER"; then
+    fail "L: with a declaration the small class must be the largest SUBSCRIBED type (880, Odometry) -- a type the image links and never receives cannot set it:"; echo "$OUT_AFTER"
+fi
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_BASIS=subscribed" <<< "$OUT_AFTER"; then
+    fail "L: the joined answer must be labelled subscribed:"; echo "$OUT_AFTER"
+fi
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT=2" <<< "$OUT_AFTER"; then
+    fail "L: the joined answer must record how many subscriptions it saw:"; echo "$OUT_AFTER"
+fi
+# The take buffer does NOT narrow. It is also DEFAULT_TX_BUF and the default
+# buffer of every raw service/client/action entity, so a type this image only
+# publishes still has to fit. Narrowing it is the under-derivation.
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE=1496" <<< "$OUT_AFTER"; then
+    fail "L: the take buffer must stay on the CLOSURE basis (1496) -- it is DEFAULT_TX_BUF too:"; echo "$OUT_AFTER"
+fi
+
+# And the entity count, not the type count, drives the large class: two
+# subscriptions on one large type need two BLOCKS.
+log_header "L -- MAX_LARGE_SUBSCRIBERS counts blocks, so it counts ENTITIES"
+frag "$T/l2.cmake" "big" <<'ROWS'
+sensor_msgs/msg/JointState|bounded|4204|4208|
+std_msgs/msg/Int32|bounded|4|8|
+ROWS
+entity_frag "$T/l2-ents.cmake" derived resolved \
+    "sensor_msgs/msg/JointState=3" "std_msgs/msg/Int32=1"
+OUT="$(derive "$T/l2.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/l2-ents.cmake")"
+check
+if ! grep -q "NROS_DERIVED_MAX_LARGE_SUBSCRIBERS=3" <<< "$OUT"; then
+    fail "L: three subscriptions on one large type need three blocks, not one:"; echo "$OUT"
+fi
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIBER_LARGE_SIZE=4208" <<< "$OUT"; then
+    fail "L: the large class size is the largest RECEIVED type over the split:"; echo "$OUT"
+fi
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE=8" <<< "$OUT"; then
+    fail "L: the small class is the largest received type UNDER the split:"; echo "$OUT"
+fi
+
+# An image that declares entities and subscribes to nothing is an ANSWER, not
+# a refusal: its payload pools are genuinely unused, so zero blocks is right
+# and the small size is not derivable from an empty set.
+log_header "L -- an image that receives nothing answers ZERO blocks"
+entity_frag "$T/l3-ents.cmake" derived resolved
+OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/l3-ents.cmake")"
+check
+if ! grep -q "NROS_DERIVED_MAX_LARGE_SUBSCRIBERS=0" <<< "$OUT"; then
+    fail "L: an image with no subscriptions reserves no large blocks:"; echo "$OUT"
+fi
+check
+if grep -q "NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE=" <<< "$OUT"; then
+    fail "L: nothing is received, so the small class size is not derivable -- naming one would invent a number:"; echo "$OUT"
+fi
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS=derived" <<< "$OUT"; then
+    fail "L: an empty received set is an ANSWER, not a refusal:"; echo "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# M. THE JOIN REFUSES -- and never widens to the closure.
+# ---------------------------------------------------------------------------
+log_header "M -- a type the bound inventory cannot price REFUSES the classes"
+# Today this is structural rather than a typo: `BoundInventory::record_message`
+# is called for `.msg` files and for nothing else, so no `pkg/srv/*` or
+# `pkg/action/*` has an entry however well-formed the declaration is.
+entity_frag "$T/m1-ents.cmake" derived resolved \
+    "nav_msgs/msg/Odometry=1" "tier4_system_msgs/srv/OperateMrm_Request=1"
+OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/m1-ents.cmake")"
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS=refused" <<< "$OUT"; then
+    fail "M: an unpriced received type must refuse the payload classes:"; echo "$OUT"
+fi
+check
+if grep -qE "NROS_DERIVED_(SUBSCRIBER_BUFFER_SIZE|MAX_LARGE_SUBSCRIBERS|SUBSCRIBER_LARGE_SIZE)=" <<< "$OUT"; then
+    fail "M: a refusal published a payload-class number:"; echo "$OUT"
+fi
+check
+if grep -q "NROS_MESSAGE_BOUNDS_BASIS=" <<< "$OUT"; then
+    fail "M: a refusal must NOT widen to the closure -- that is the wrong row wearing a derived status:"; echo "$OUT"
+fi
+check
+if ! grep -q "OperateMrm_Request" <<< "$OUT"; then
+    fail "M: the refusal does not name the type it could not price:"; echo "$OUT"
+fi
+# The take buffer is a different question with a different basis, so it still
+# derives. A reader that collapsed the two statuses would lose it.
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE=1496" <<< "$OUT"; then
+    fail "M: the take buffer derives over the closure and must survive a payload-class refusal:"; echo "$OUT"
+fi
+
+log_header "M -- an unresolved subscribed set REFUSES the classes"
+entity_frag "$T/m2-ents.cmake" derived refused
+OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/m2-ents.cmake")"
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS=refused" <<< "$OUT"; then
+    fail "M: an unresolved subscribed set must refuse:"; echo "$OUT"
+fi
+check
+if grep -q "NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE=" <<< "$OUT"; then
+    fail "M: an unresolved subscribed set published a small class anyway:"; echo "$OUT"
+fi
+
+log_header "M -- a current schema that states no subscribed set REFUSES"
+{
+    echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 2)"
+    echo "set(NROS_ENTITY_INVENTORY_STATUS \"derived\")"
+} > "$T/m3-ents.cmake"
+OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/m3-ents.cmake")"
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS=refused" <<< "$OUT"; then
+    fail "M: a fragment claiming the current schema with no subscribed set must refuse, not read an absent list as an empty one:"; echo "$OUT"
+fi
+check
+if ! grep -q "malformed" <<< "$OUT"; then
+    fail "M: the refusal does not say the fragment is malformed:"; echo "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# N. BACK-COMPAT -- an image that declares nothing does not move.
+#
+# This is the requirement the join is easiest to get wrong on in the OTHER
+# direction: refusing here would take every image built before phase-403 W9
+# from a derived (over-approximate, safe) number back to the hand-set numbers
+# W8 exists to replace, which is a regression rather than a safety property.
+# ---------------------------------------------------------------------------
+log_header "N -- an image that declares nothing keeps W8's closure answer"
+# A fragment whose own status is `refused` -- the shape W9 writes when any
+# component in the image states no ENTITIES, which is every pre-W9 image.
+entity_frag "$T/n1-ents.cmake" refused refused
+OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/n1-ents.cmake")"
+check
+if [ "$OUT_BEFORE" != "$OUT" ]; then
+    fail "N: an image whose entity inventory refused must derive EXACTLY what it derives with no fragment at all. Diff:"
+    diff <(echo "$OUT_BEFORE") <(echo "$OUT") || true
+fi
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_BASIS=closure" <<< "$OUT"; then
+    fail "N: the unchanged answer must still be labelled closure:"; echo "$OUT"
+fi
+
+log_header "N -- a fragment from a STALE CLI warns and keeps the closure answer"
+# NOT a FATAL_ERROR, deliberately: the fragment's producer (`nano_ros_entry()`)
+# runs LATER in the same configure than this reader, so a fatal aborts before
+# the stale fragment can ever be rewritten and the build dir is stuck until
+# someone deletes the file by hand.
+{
+    echo "set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 1)"
+    echo "set(NROS_ENTITY_INVENTORY_STATUS \"derived\")"
+} > "$T/n2-ents.cmake"
+OUT="$(derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/n2-ents.cmake")"
+check
+if grep -qi "CMake Error" <<< "$OUT"; then
+    fail "N: a stale-schema fragment must not abort the configure -- its producer runs later in it:"; echo "$OUT"
+fi
+check
+if ! grep -q "IGNORED" <<< "$OUT"; then
+    fail "N: a stale-schema fragment must say loudly that it was not read:"; echo "$OUT"
+fi
+check
+if ! grep -q "NROS_MESSAGE_BOUNDS_BASIS=closure" <<< "$OUT"; then
+    fail "N: a stale-schema fragment must leave the closure answer standing:"; echo "$OUT"
+fi
+check
+if ! grep -q "NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE=1496" <<< "$OUT"; then
+    fail "N: a stale-schema fragment must not change any number:"; echo "$OUT"
+fi
+
+log_header "N -- the OUTPUT FILE records which basis each number used"
+derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/l-ents.cmake" \
+    -DNROS_BOUNDS_OUTPUT="$T/n3-knobs.cmake" >/dev/null
+check
+if ! grep -q 'set(NROS_MESSAGE_BOUNDS_BASIS "subscribed")' "$T/n3-knobs.cmake"; then
+    fail "N: the written answer does not record its basis:"; cat "$T/n3-knobs.cmake"
+fi
+check
+if ! grep -q "2 SUBSCRIPTIONS this image declares" "$T/n3-knobs.cmake"; then
+    fail "N: the written answer does not say what it was derived over:"; cat "$T/n3-knobs.cmake"
+fi
+derive "$T/l1.cmake" -DNROS_BOUNDS_ENTITY_INVENTORY="$T/m1-ents.cmake" \
+    -DNROS_BOUNDS_OUTPUT="$T/n4-knobs.cmake" >/dev/null 2>&1
+check
+if grep -q "set(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE" "$T/n4-knobs.cmake"; then
+    fail "N: a payload-class refusal wrote a class size into the answer file:"; cat "$T/n4-knobs.cmake"
+fi
+check
+if ! grep -q 'set(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS "refused")' "$T/n4-knobs.cmake"; then
+    fail "N: the answer file does not record the payload-class refusal:"; cat "$T/n4-knobs.cmake"
+fi
+check
+if ! grep -q "set(NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE 1496)" "$T/n4-knobs.cmake"; then
+    fail "N: the take buffer must still be written on a payload-class refusal:"; cat "$T/n4-knobs.cmake"
 fi
 
 # ---------------------------------------------------------------------------

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -938,21 +938,42 @@ endif # NROS_RMW_XRCE
 # =============================================================================
 
 config NROS_EXECUTOR_MAX_CBS
-    int "Maximum executor callback slots"
-    default 4
+    int "Maximum executor callback slots (-1 = derive)"
+    default -1
     help
       Maximum number of callback slots in the executor
-      (subscriptions + timers + services). Controls both Rust and C APIs.
+      (subscriptions + timers + services + service clients + action
+      entities + guard conditions). Controls both Rust and C APIs.
       Arena size is derived automatically from this value and the
       subscription buffer size.
 
-      Defaults to 4 to match nros-node/build.rs. This option was never
+      A PUBLISHER IS NOT ONE OF THEM. Every registration that claims a slot
+      calls Executor::next_entry_slot(); create_publisher does not — it writes
+      an RmwPublisher into caller-owned storage and there is no
+      nros_executor_add_publisher on the C path. The mr-canhubk344 bring-up
+      counted 33 "handles" for the island and set 36 here; 14 of those 33 are
+      publishers and the slot demand is 19.
+
+      -1 means DERIVE it from this image's ENTITY inventory (phase-403 W9 /
+      issue 0965): the sum of every `nano_ros_node_register(... ENTITIES ...)`
+      declaration in the image, counted by kind. It is derived only when EVERY
+      component declared; one that did not makes the whole image refuse, so a
+      partial answer can never be published as a whole one. Any value other
+      than -1 is yours and WINS; the crate default when nothing is stated and
+      nothing is derivable is 4.
+
+      The derived value carries NO headroom, which makes the running image a
+      checker of its own declaration: one entity past the table and
+      registration returns ExecutorFull naming this knob, and the entry halts
+      boot naming the node. Raise it deliberately if you want slack — the
+      arena scales with it.
+
+      4 is the crate default in nros-node/build.rs. This option was never
       forwarded to Cargo before issue 0316, so every Zephyr C image compiled
-      the crate default of 4 regardless of what was configured here; the old
-      default of 16 had therefore never been built. Honouring it as-is would
-      have grown a native_sim listener's .bss by 219 KB (+35%) as a side
-      effect of repairing the plumbing. Raise it deliberately — the arena
-      scales with it.
+      that default regardless of what was configured here; the old default of
+      16 had therefore never been built. Honouring it as-is would have grown a
+      native_sim listener's .bss by 219 KB (+35%) as a side effect of repairing
+      the plumbing.
 
 config NROS_SUBSCRIPTION_BUFFER_SIZE
     int "Per-subscription receive buffer size in bytes (-1 = derive)"

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -18,6 +18,11 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../packages/api/nros-c/cmake/nros-rtos-hel
 # reason, and here rather than via NanoRosCodegenCore.cmake because
 # `nros_resolve_knobs()` runs long before the interface generator is included.
 include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosMessageBounds.cmake")
+# phase-403 W9 (issue 0965) -- `nros_entity_inventory_knobs_file`, the same one
+# path for the ENTITY inventory beside it. Two inventories, two files, one
+# ladder: a bound inventory prices a TYPE and this one counts the ENTITIES, and
+# `NROS_EXECUTOR_MAX_CBS` is a question only the second can answer.
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/NanoRosEntityInventory.cmake")
 
 # =============================================================================
 # nros_detect_rust_target()
@@ -223,12 +228,59 @@ function(_nros_load_derived_message_bounds)
     endforeach()
 endfunction()
 
-# _nros_resolve_derivable_knob(<env_name> <kconfig_value> <derived_var>)
+# _nros_load_derived_entity_inventory()
+#
+# phase-403 W9 (issue 0965) -- the sibling of the loader above, for the ENTITY
+# inventory: WHICH entities the image creates, which is the half the bound
+# inventory cannot answer and `NROS_EXECUTOR_MAX_CBS` has always needed.
+#
+# Same ordering, same lag, same reason it is not silent. The producer here is
+# `nano_ros_entry()` rather than `nros_find_interfaces()` -- an entity count is
+# a property of the registered COMPONENTS, so it is composed at the point every
+# `nano_ros_node_register()` has run -- but from this module's seat both are
+# "later in this configure than I am", and the `CMAKE_CONFIGURE_DEPENDS` +
+# write-if-changed pair is what closes that.
+function(_nros_load_derived_entity_inventory)
+    nros_entity_inventory_knobs_file(_knobs)
+    if(NOT EXISTS "${_knobs}")
+        nros_entity_inventory_seed_knobs_file("${_knobs}")
+    endif()
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_knobs}")
+    include("${_knobs}")
+    foreach(_v
+        NROS_ENTITY_INVENTORY_STATUS
+        NROS_ENTITY_INVENTORY_REASON
+        NROS_ENTITY_INVENTORY_ENTITY_TOTAL
+        NROS_DERIVED_EXECUTOR_MAX_CBS)
+        if(DEFINED ${_v})
+            set(${_v} "${${_v}}" PARENT_SCOPE)
+        endif()
+    endforeach()
+endfunction()
+
+# _nros_resolve_derivable_knob(<env_name> <kconfig_value> <derived_var>
+#                              [<source-name> <reason-file>])
 #
 # `_nros_resolve_knob` plus rungs 3 and 4 of the ladder above. Use it for a knob
 # whose Kconfig option documents `-1` as "derive"; a plain knob keeps
 # `_nros_resolve_knob`.
+#
+# The two optional trailing arguments name WHICH inventory derived the value and
+# where its refusal reason is written. They default to the message-bound
+# inventory, which was the only one when this function was written; phase-403 W9
+# added the ENTITY inventory as a second producer on the same ladder. Naming the
+# source in the status line is not cosmetic -- "no value stated and none
+# derivable" pointing at the wrong file is a user reading a REASON that explains
+# a different refusal.
 function(_nros_resolve_derivable_knob env_name kconfig_value derived_var)
+    set(_src "message-bound inventory")
+    set(_reason_file "${CMAKE_BINARY_DIR}/nros/message_bound_knobs.cmake")
+    if(ARGC GREATER 3)
+        set(_src "${ARGV3}")
+    endif()
+    if(ARGC GREATER 4)
+        set(_reason_file "${ARGV4}")
+    endif()
     if(NOT "${kconfig_value}" STREQUAL "${NROS_KNOB_DERIVE_SENTINEL}")
         # Someone stated a number. It wins over the derivation, in both
         # directions and without comment: that is what "a derived value is a
@@ -246,8 +298,7 @@ function(_nros_resolve_derivable_knob env_name kconfig_value derived_var)
     if(DEFINED ${derived_var} AND NOT "${${derived_var}}" STREQUAL "")
         message(STATUS
             "nros: ${env_name}=${${derived_var}} DERIVED from this image's "
-            "message-bound inventory (nothing in Kconfig or the environment "
-            "states one)")
+            "${_src} (nothing in Kconfig or the environment states one)")
         _nros_resolve_knob(${env_name} "${${derived_var}}")
         return()
     endif()
@@ -256,8 +307,7 @@ function(_nros_resolve_derivable_knob env_name kconfig_value derived_var)
     # literal is written.
     message(STATUS
         "nros: ${env_name} left to its crate default -- no value stated and "
-        "none derivable (see NROS_MESSAGE_BOUNDS_REASON in "
-        "${CMAKE_BINARY_DIR}/nros/message_bound_knobs.cmake)")
+        "none derivable (see the refusal reason in ${_reason_file})")
 endfunction()
 
 # =============================================================================
@@ -280,6 +330,17 @@ function(nros_resolve_knobs)
         message(STATUS
             "nros: size knobs may derive from this image's message-bound "
             "inventory; a Kconfig or environment value still wins")
+    endif()
+
+    # phase-403 W9 (issue 0965) -- the COUNT knobs' rung-3 value, from the
+    # entity inventory. Same shape, same lag, different question.
+    _nros_load_derived_entity_inventory()
+    if(NROS_ENTITY_INVENTORY_STATUS STREQUAL "derived")
+        message(STATUS
+            "nros: NROS_EXECUTOR_MAX_CBS may derive from this image's entity "
+            "inventory (${NROS_ENTITY_INVENTORY_ENTITY_TOTAL} entities declared, "
+            "${NROS_DERIVED_EXECUTOR_MAX_CBS} of them claim a callback slot); "
+            "a Kconfig or environment value still wins")
     endif()
 
     # Zenoh transport tuning (zpico-sys build.rs + zpico.c defines)
@@ -434,7 +495,15 @@ function(nros_resolve_knobs)
 
     # Executor limits (nros-node build.rs, shared by both Rust and C APIs)
     # C API limits are derived from MAX_CBS via Cargo `links` metadata.
-    _nros_resolve_knob(NROS_EXECUTOR_MAX_CBS "${CONFIG_NROS_EXECUTOR_MAX_CBS}")
+    # phase-403 W9 (issue 0965) -- MAX_CBS moved from the plain resolver to the
+    # DERIVABLE one. Its Kconfig default is now the `-1` sentinel, so an image
+    # that states nothing gets the entity inventory's answer, and an image whose
+    # inventory refuses (any component that declared no ENTITIES -- which is
+    # every image built before this wave) falls through to rung 4 and the crate
+    # default of 4, exactly as it did before.
+    _nros_resolve_derivable_knob(NROS_EXECUTOR_MAX_CBS
+        "${CONFIG_NROS_EXECUTOR_MAX_CBS}" NROS_DERIVED_EXECUTOR_MAX_CBS
+        "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
     # Issue 0316's fix listed ONE of nros-node's six build.rs knobs; the other
     # five stayed unreachable on Zephyr (the curated cargo environment drops
     # any knob not resolved here, and shell exports do not survive it), so a


### PR DESCRIPTION
phase-403 step 1. Also carries W9 (#965), which has no PR of its own yet, so
this stacks: the join needs both inventories and only one of them was upstream.

## The problem

W8 derives the two zenoh payload classes over every type in the linked
interface closure, because a bound inventory is all it had. On the reference
island that is not a rounding error. It is the dominant term, and it points the
wrong way: one `std_msgs/Float64MultiArray`, linked through `geometry_msgs` and
never received, sets the small class for every subscription in the image at
1496 B. Letting W8 derive therefore COSTS that image 2176 bytes rather than
saving.

W9 landed the second inventory and the two were never joined. This is the join.

## Measured, mr-canhubk344 reference island

84 bounded types from the fragments its own board configure wrote, priced at its
`MAX_SUBSCRIBERS = 12` and `RING_DEPTH = 4`:

| basis | small class | SMALL | LARGE | total |
| --- | ---: | ---: | ---: | ---: |
| hand-set today | 1024 | 49152 | 20480 | 69632 |
| derived over the LINKED closure | 1496 | 71808 | 0 | 71808 |
| derived over the SUBSCRIBED set | **880** | **42240** | 0 | **42240** |

The type that sets the small class stops being `std_msgs/Float64MultiArray` and
becomes `nav_msgs/Odometry`, which is what the island's own topic contract says
it subscribes to. 27392 B against the hand-set row.

## Which kinds receive

Two predicates, and the difference is load-bearing.

`EntityKind::receives()` is the semantic set, read off the arena entry types in
`executor/arena.rs` rather than off the names, which mislead in both directions:

| kind | receives | what |
| --- | --- | --- |
| subscription | yes | the topic sample |
| service server | yes | the Request (`SrvRawEntry` has a `req_buffer`) |
| service client | yes | the Reply (`ServiceClientRawArenaEntry<REPLY_BUF>`) |
| action server | yes | three: goal, result, feedback |
| action client | yes | the same three |
| publisher | no | serialises into a per-call stack array, a transmit buffer |
| timer, guard condition | no | no payload |

`EntityKind::receives_topic_sample()` is narrower, subscriptions only, and it is
what the payload classes join on. That is measured, not assumed: `SMALL_PAYLOADS`
/ `LARGE_PAYLOADS` are reached through exactly one allocation,
`alloc_payload_block(rx_buffer_hint)`, with exactly one caller, the
`declare_subscriber` path. Widening the join to the other receiving kinds would
not make the number safer; it would make it describe a pool those entities never
allocate from.

Both sets are published, because the arena (step 3) needs the wider one, and a
second derivation of it is how two green tools come to disagree.

## The take buffer deliberately does NOT join

`NROS_SUBSCRIPTION_BUFFER_SIZE` is not subscription-only whatever its name says.
`nros-node/build.rs` turns it into `DEFAULT_RX_BUF_SIZE`, the default const
generic for `RawSubscription`, `RawServiceServer`, `RawServiceClient`,
`ActionServerCore` and `ActionClientCore`, and `executor/types.rs` then defines
`DEFAULT_TX_BUF = DEFAULT_RX_BUF_SIZE`. A type the image only PUBLISHES still has
to fit, so narrowing it would size a buffer too small, which is the exact failure
this campaign exists to remove. It keeps the closure basis, and every number now
records which basis produced it (`NROS_MESSAGE_BOUNDS_BASIS`).

## The spellings join for messages, and cannot for anything else

Structural, not a typo. `BoundInventory::record_message` is called for `.msg`
files and for nothing else in all four producers, so no `pkg/srv/Name_Request`
and no `pkg/action/Name_Result` has an entry to join against. The join REFUSES on
such a type, names it, and says which of the two causes is likelier. Nothing in
step 1 needs them, because none of those entities allocates from the payload
pools -- but it is a live gap for step 3, recorded as such.

## Refusal, and the one case that is not one

Once the entity fragment's own status is `derived`, the payload classes come from
the declaration or from nowhere: an unresolved subscribed set, or a named type
the bound inventory cannot price, refuses all three knobs and each keeps its
configured value. There is no fall-back to the closure, because that publishes
the middle row above while every status still reads `derived`.

An image that declares NO entities keeps W8's closure-derived answer byte for
byte, labelled `basis = closure`. Refusing there would take every pre-W9 image
from a derived over-approximation back to the hand-set numbers W8 exists to
replace, which is a regression rather than a safety property. Asserted as
identical to the no-fragment case.

A stale-CLI (schema 1) fragment warns and keeps the closure answer rather than
`FATAL_ERROR`, deliberately: its producer `nano_ros_entry()` runs LATER in the
same configure than the reader, so a fatal aborts before the stale fragment can
ever be rewritten, and the build dir then sticks until someone deletes it by
hand.

## Schema

`ENTITY_INVENTORY_SCHEMA_VERSION` 1 -> 2. Nothing moved; the fragment gained the
two type sets. It bumps because a reader taking their absence for "receives
nothing" would derive a class over an empty set, and absence must be
distinguishable from zero -- the same reason `ENTITIES NONE` exists.

One consequence: `tests/cmake-entity-inventory-tests.sh` used a literal `2` as
its "future schema" case, which would have silently stopped testing anything. It
is now `3`, with a comment saying why.

## Gates

Rebased onto `main` at e765ed959, clean.

* `just check message-bound-knobs` -- 80 assertions, was 38. New cases L (the
  join, before and after, entity-vs-type block counting, empty-set answer), M
  (three refusal shapes), N (back-compat, stale CLI, output-file provenance).
* `just check entity-inventory-knobs` -- 27, was 24.
* `just check entity-slot-costs` -- green.
* `just check emitter-just-spelling` -- green. It was RED on the base branch (2
  pre-existing hits in `NanoRosEntityInventory.cmake`); fixed rather than adding
  two more beside them.
* 26 unit tests in `nros_cli_core::entity_inventory`; clippy `-D warnings` clean.
* No goldens moved. `Cargo.lock` untouched. No hardware.

## Not closed, stated

1. W9's declaration reads `sub*7` on `mrm_handler` and the island's published
   contract names six of those seven, so the measurement is over TEN
   subscriptions. A missing subscription can only ADD a type, so the answer can
   only move up, and only if that type exceeds 880 B -- nothing in the island's
   closure does except the four `std_msgs` multi-arrays it links from
   `geometry_msgs`.
2. The island's `build-board/nros-metadata.json` predates W9 and carries no
   `entities` key, so the entity half of the fixture is built from
   `docs/topic-contract.md`. The bound half is the real artifact.
3. Not measured on silicon. These are DEFAULTS, and the board `.conf` still pins
   `MAX_LARGE_SUBSCRIBERS=2` and `SUBSCRIBER_LARGE_SIZE=2560`, so the 20480 B of
   large pool is only recovered once those two lines are deleted. Adopting it is
   a deliberate act by whoever next brings the board up.
4. Pre-existing W9 behaviour left alone: `nros_entity_inventory_seed_knobs_file`
   never overwrites, so if the `nros` CLI vanishes between configures a
   previously-derived fragment survives and would be joined against. In practice
   the CLI always rewrites it.
