### PR TITLE
feat(phase-400 W6): classify the census, and find the zenoh surface is 4x bigger

### DIFF
--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -256,87 +256,52 @@ a board rung applies (`max_sc = 23`), the env front-end still wins over both
 `NROS_PLATFORM_NAME` — a bare `cargo build` with no lane — nothing changes:
 with no board named there IS no platform rung to resolve.
 
-### Remaining tenants
+### Remaining tenants — re-ordered from the census, 2026-09-01
 
-The zenoh pools, then the per-entity caps.
+The wave opened with "then the zenoh pools, then the per-entity caps", ordered
+by an estimate. The census orders it by measurement, and the estimate was
+right about zenoh being next and wrong about it being a separate thing from the
+caps — **the caps ARE zenoh's**:
 
----
+| family | sizing knobs | note |
+| --- | --- | --- |
+| `ZPICO_*` | **15** | entity caps (publishers, subscribers, queryables, sessions, liveliness, pending gets), wire batch buffers, fragmentation, reply staging, two transport-band priorities |
+| `NROS_MAX_*` | 5 | message and parameter bounds |
+| `NROS_RUNTIME_*` | 4 | component caps |
+| platform heap/stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB` |
+| singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
 
-## W7 — core's exclusive features — DONE, and the premise was wrong
+Plus 85 `CONFIG_NROS_*` Kconfig declarations, whose largest family is also
+zenoh (24), then XRCE (8), `NROS_MAX` (7), RMW (5), Zephyr (4).
 
-**Audited 2026-08-30. No work outstanding.** This wave was scoped from a claim
-that did not survive checking, and the correction is recorded here rather than
-quietly dropped.
+**So: the zenoh tenant next, and it is one tenant, not two.**
 
-The claim: `nros-node`'s `scheduler-fifo` / `-edf` / `-bucketed` / `-sporadic`
-is a pick-one family expressed in an additive mechanism, guarded by five
-`compile_error!` calls standing in for the constraint Cargo cannot express.
+### Five knobs must NOT be migrated
 
-What the tree actually says, three lines above those declarations:
+`NROS_SUBSCRIPTION_BUFFER_SIZE`, `ZPICO_SUBSCRIBER_BUFFER_SIZE`,
+`ZPICO_SUBSCRIBER_LARGE_SIZE`, `ZPICO_SUBSCRIBER_SIZE_THRESHOLD` and
+`ZPICO_PUBLISHER_TX_BUFFER_SIZE` are receive/transmit buffer sizes that
+[phase-403](phase-403-type-bound-rx-sizing.md) and
+[phase-408](phase-408-cpp-message-derived-buffers.md) are making **derived from
+the message type**. A ladder rung would give each a per-platform default —
+entrenching the global those phases exist to remove. The census classifies them
+`derived` so nobody migrates one by following the backlog count.
 
-> Each flag is independent; multiple may be on simultaneously when runtime
-> selection across classes is needed.
+`NROS_SUBSCRIPTION_BUFFER_SIZE` is the awkward one: it is ALREADY on the
+ladder, from this wave's executor tenant, and that is fine — it stays as the
+fallback for a type with no declared bound. It just must not be treated as
+finished business.
 
-The `cfg` sites agree — they gate scheduler classes in, additively. The five
-`compile_error!` guards are feature IMPLICATIONS (`param-services` needs
-`alloc`), not exclusivity. Every `cfg(not(feature = …))` in core is the correct
-no_std shape. And `packages/api/nros/src/lib.rs` records that a platform
-mutual-exclusion `compile_error!` was deliberately *removed* — the tree has
-already learned this lesson.
+### Two corrections to earlier numbers here
 
-The error was inferring exclusivity from a naming family without reading the
-comment above it.
-
-**What survives.** RFC-0086 D5's rule stands on its own footing: Cargo features
-are additive by contract, so they cannot express "off over an on-default",
-which RFC-0049 requires of a front-end. That is a constraint on new knobs,
-enforced at review. It simply has no backlog attached.
-
-**Gate.** Satisfied on audit: no `compile_error!` in core stands in for an
-exclusivity constraint, and no core feature encodes a negative.
-
----
-
-## W8 — retire the old paths
-
-Retirement is a wave, not a side effect, because a mechanism that still
-resolves is a mechanism people still use.
-
-* A migrated knob's old reader is **deleted**, not left as a fallback. A
-  fallback that silently wins is how issue 0135/0316 happened: two consumers
-  disagreeing about one value with no diagnostic.
-* Env vars that were the *only* home for a knob before nano-ros #0749/#0752
-  keep their names as front-ends. Env vars that duplicated a ladder knob are
-  removed.
-* `config/<name>/nros-platform.toml` stops being read after W1's grace period.
-* A gate asserts no knob has two readers.
-
-**Gate.** For every migrated knob, exactly one reader exists, and
-`nros config explain` is the only way to learn its value.
-
----
-
-## Risks, and the ones already realised
-
-* **A fallback left in place wins silently.** Realised twice: issue 0135 and
-  issue 0316, both "two consumers disagreed about a struct's size with no
-  diagnostic". W8's one-reader gate exists for this.
-* **A drift test that mirrors nothing.** RFC-0049's mirror test is only as good
-  as its coverage; W5 must extend it to the new `depends on`, or the Kconfig
-  projection silently diverges.
-* **Migrating a knob without its coupling.** A sizing knob moved into the
-  ladder with its implications left in a `.conf` file is worse than not moving
-  it — the value looks authoritative and is not. Move the rule with the knob.
-* **`implies` implemented as `select`.** The single most likely wrong turn, and
-  the one the surveyed prior art most clearly warns against.
-
-## What this phase does NOT do
-
-* It does not change the four-rung ladder or its order. RFC-0049's precedence
-  is correct.
-* It does not touch the runtime seam (`nros_rmw_vtable_t`, RFC-0035).
-* It does not introduce a constraint solver. `requires` validates and `implies`
-  enforces; picking a satisfying assignment reintroduces the opacity W4 exists
-  to prevent.
-* It does not migrate RFC-0045's boot-config resolution, which is the runtime
-  half of the same story and lands separately.
+* **The census scanned only `build.rs`.** A build script that grew past a few
+  lines moved its body into a helper crate and the knobs went with it: 21
+  `ZPICO_*` names live in `nros-zpico-build/src/`. Both this doc's original
+  "`ZPICO_*` env | 9" and the census's first "6" undercounted the zenoh surface
+  roughly fourfold. It now scans `*-build` crates and `packages/tooling/` too.
+* **The env row counted things that are not knobs.** 19 of the 64 names are
+  paths, flags, or the ladder's own inputs — including `NROS_PLATFORM_NAME`,
+  which this wave ADDED, so the raw count rose while the backlog fell. Names
+  are classified explicitly now, and an unclassified name FAILS the gate: a new
+  knob has to be decided about (ladder? derived? infra?) rather than guessed at
+  by a heuristic, which is how a backlog number stops meaning anything.

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -46,6 +46,101 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # reported, never gated. Raise this when a tenant lands.
 LADDER_FLOOR = 13
 
+# Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
+# gate rather than landing in a bucket by heuristic — the first version of this
+# analysis split by read idiom (`env_usize` vs `env::var`) and misfiled three
+# knobs that are numeric but read as strings and handed to a C `#define`.
+#
+#   ladder   already resolved over the RFC-0049 ladder
+#   sizing   a sizing knob still to migrate — THE BACKLOG
+#   derived  a size that should come from the MESSAGE TYPE, not from a knob
+#            (phase-403, phase-408, issue 0896). Migrating one of these into
+#            the ladder would be WRONG: a rung gives a global a per-platform
+#            default, and the whole point of that work is that it stops being
+#            a global.
+#   infra    a path, a flag, or an input to the ladder itself. Not a knob, and
+#            counting it as one overstates the backlog — which the first
+#            census did, by ~40%.
+KNOB_CLASS = {
+    # --- ladder (phase-400 W6) ---
+    "NROS_EXECUTOR_MAX_CBS": ("ladder", "executor tenant"),
+    "NROS_EXECUTOR_MAX_SC": ("ladder", "executor tenant"),
+    "NROS_EXECUTOR_MAX_NODES": ("ladder", "executor tenant"),
+    "NROS_EXECUTOR_MAX_SHUTDOWN_CBS": ("ladder", "executor tenant"),
+    "NROS_EXECUTOR_ACTION_CLIENTS": ("ladder", "executor tenant"),
+    "NROS_EXECUTOR_ARENA_SIZE": ("ladder", "executor tenant; 0 = derive"),
+    "NROS_PARAM_SERVICE_BUFFER_SIZE": ("ladder", "executor tenant"),
+    # --- derived: the message type should size these ---
+    "NROS_SUBSCRIPTION_BUFFER_SIZE": (
+        "derived",
+        "the runtime-owned take buffer. phase-403 makes it per-type; it is in "
+        "the ladder today as the fallback for a type with no bound",
+    ),
+    "ZPICO_SUBSCRIBER_BUFFER_SIZE": ("derived", "SMALL_PAYLOADS class (phase-403)"),
+    "ZPICO_SUBSCRIBER_LARGE_SIZE": ("derived", "LARGE_PAYLOADS class (phase-403)"),
+    "ZPICO_SUBSCRIBER_SIZE_THRESHOLD": ("derived", "SMALL_CLASS_CEILING (phase-403)"),
+    "ZPICO_PUBLISHER_TX_BUFFER_SIZE": ("derived", "TX half of the same split"),
+    # --- sizing: the backlog ---
+    "NROS_MAX_ARRAY_LEN": ("sizing", "message bound"),
+    "NROS_MAX_BYTE_ARRAY_LEN": ("sizing", "message bound"),
+    "NROS_MAX_STRING_VALUE_LEN": ("sizing", "message bound"),
+    "NROS_MAX_PARAM_NAME_LEN": ("sizing", "parameter bound"),
+    "NROS_MAX_PARAMETERS": ("sizing", "parameter cap"),
+    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("sizing", "component cap"),
+    "NROS_RUNTIME_MAX_CELL_ENTITIES": ("sizing", "component cap"),
+    "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("sizing", "component cap"),
+    "NROS_RUNTIME_MAX_COMPONENTS": ("sizing", "component cap"),
+    "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "platform heap"),
+    "NROS_FREERTOS_HEAP_KB": ("sizing", "platform heap; numeric, read as a string"),
+    "NROS_FREERTOS_APP_STACK_KB": ("sizing", "platform stack; numeric, read as a string"),
+    "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
+    "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape"),
+    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("sizing", "transport MTU; numeric, read as a string"),
+    "ZPICO_MAX_LARGE_SUBSCRIBERS": ("sizing", "pool cardinality, not a payload size"),
+    "ZPICO_SERVICE_BUFFER_SIZE": ("sizing", "service staging block"),
+    # --- infra: not knobs ---
+    "NROS_ALLOW_UNRESOLVED_DEPS": ("infra", "policy flag"),
+    "NROS_BUILD_ROOT": ("infra", "path"),
+    "NROS_CARGO_FLAGS": ("infra", "the --locked shim"),
+    "NROS_LINK_IP": ("infra", "link toggle"),
+    "NROS_PLATFORMS_DIR": ("infra", "the ladder's own search path"),
+    "NROS_PLATFORM_NAME": ("infra", "the ladder's own platform rung input"),
+    "NROS_PX4_BRIDGE_GEN": ("infra", "codegen toggle"),
+    "NROS_REPO_DIR": ("infra", "path"),
+    "NROS_TRACE": ("infra", "debug flag"),
+    "NROS_ZEPHYR_WORKSPACE": ("infra", "path"),
+    # --- ladder: the zenoh tx tenant (phase-282), read in the build HELPER ---
+    "ZPICO_TX_BATCH": ("ladder", "zenoh.tx tenant"),
+    "ZPICO_TX_SPLIT_LOCK": ("ladder", "zenoh.tx tenant"),
+    "ZPICO_TX_BATCH_FLUSH_MS": ("ladder", "zenoh.tx tenant"),
+    # --- sizing: the zenoh-pico entity caps and buffers. The largest single
+    # --- family left, and the one the phase doc calls "the per-entity caps".
+    "ZPICO_MAX_PUBLISHERS": ("sizing", "entity cap"),
+    "ZPICO_MAX_SUBSCRIBERS": ("sizing", "entity cap"),
+    "ZPICO_MAX_QUERYABLES": ("sizing", "entity cap; issue 0460 raised it for services"),
+    "ZPICO_MAX_SESSIONS": ("sizing", "entity cap"),
+    "ZPICO_MAX_LIVELINESS": ("sizing", "entity cap"),
+    "ZPICO_MAX_PENDING_GETS": ("sizing", "entity cap"),
+    "ZPICO_BATCH_UNICAST_SIZE": ("sizing", "wire batch buffer"),
+    "ZPICO_BATCH_MULTICAST_SIZE": ("sizing", "wire batch buffer"),
+    "ZPICO_FRAG_MAX_SIZE": ("sizing", "fragmentation ceiling"),
+    "ZPICO_GET_REPLY_BUF_SIZE": ("sizing", "reply staging block"),
+    "ZPICO_GET_POLL_INTERVAL_MS": ("sizing", "a poll interval, not a size; same ladder shape"),
+    "ZPICO_READ_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
+    "ZPICO_LEASE_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
+    "NROS_LET_BUFFER_SIZE": ("sizing", "logical-execution-time buffer"),
+    # --- infra ---
+    "NROS_DECLARED_INFRA_QUERYABLES": ("infra", "a COUNT the resolver passes down, not a knob"),
+    "NROS_DECLARED_SERVICE_SERVERS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    "NROS_PICOLIBC_SYSROOT": ("infra", "path"),
+    "NROS_RISCV64_PREFIX": ("infra", "toolchain prefix"),
+    "NROS_SDK_STORE": ("infra", "path"),
+    "NROS_SIZES_PROBE_TARGET_DIR": ("infra", "path"),
+    "NROS_ZPICO_DEBUG": ("infra", "debug flag"),
+    "ZPICO_NO_SMOLTCP": ("infra", "link toggle"),
+    "ZPICO_PLATFORMS_TOML": ("infra", "the ladder's own platform file pointer"),
+}
+
 
 def tracked(*globs):
     out = subprocess.check_output(
@@ -109,10 +204,28 @@ def _env_names_in(txt, prefix):
     )
 
 
+def build_env_sources():
+    """Files that run at BUILD time and may read a knob.
+
+    Not just `build.rs`: a build script that grew past a few lines moved its
+    body into a helper crate, and the knobs moved with it. 21 `ZPICO_*` names
+    live in `nros-zpico-build/src/`, and a census that scanned only `build.rs`
+    reported six — so both this file's first number and the phase doc's
+    original table undercounted the zenoh surface by a factor of four.
+
+    The convention is the crate NAME: `*-build` crates and everything under
+    `packages/tooling/` are build-time by construction.
+    """
+    out = list(tracked("*build.rs"))
+    out += [p for p in tracked("packages/*/*-build/src/*.rs", "packages/*/*/*-build/src/*.rs")]
+    out += list(tracked("packages/tooling/*/src/*.rs"))
+    return sorted(set(out))
+
+
 def build_script_env(prefix):
-    """`<PREFIX>_*` names a build.rs reads from the environment."""
+    """`<PREFIX>_*` names a build-time source reads from the environment."""
     names = set()
-    for p in tracked("*build.rs"):
+    for p in build_env_sources():
         names |= _env_names_in(read(p), prefix)
     return names
 
@@ -163,16 +276,57 @@ def main() -> int:
     nros_env = build_script_env("NROS")
     zpico_env = build_script_env("ZPICO")
 
+    seen = sorted(nros_env | zpico_env)
+    by_class = {}
+    unclassified = []
+    for n in seen:
+        cls = KNOB_CLASS.get(n)
+        if cls is None:
+            unclassified.append(n)
+        else:
+            by_class.setdefault(cls[0], []).append(n)
+
     print("phase-400 config census")
     print()
-    print(f"  {'where configuration lives':<34} count")
-    print(f"  {'-' * 34} -----")
-    print(f"  {'knobs in the RFC-0049 ladder':<34} {n_ladder}")
+    print(f"  {'where configuration lives':<38} count")
+    print(f"  {'-' * 38} -----")
+    print(f"  {'knobs in the RFC-0049 ladder':<38} {n_ladder}")
     for struct, fields in sorted(ladder.items()):
-        print(f"      {struct:<30} {len(fields)}")
-    print(f"  {'Kconfig CONFIG_NROS_* declarations':<34} {len(kconfig)}")
-    print(f"  {'NROS_* env read by a build.rs':<34} {len(nros_env)}")
-    print(f"  {'ZPICO_* env read by a build.rs':<34} {len(zpico_env)}")
+        print(f"      {struct:<34} {len(fields)}")
+    print(f"  {'Kconfig CONFIG_NROS_* declarations':<38} {len(kconfig)}")
+    print()
+    print(f"  build-script env names, by what they ARE ({len(seen)} total)")
+    print(f"  {'-' * 38} -----")
+    for cls, label in (
+        ("sizing", "sizing knobs still to migrate  <-- W6"),
+        ("derived", "sized by the MESSAGE TYPE, not a knob"),
+        ("ladder", "already on the ladder"),
+        ("infra", "paths / flags / ladder inputs (not knobs)"),
+    ):
+        print(f"  {label:<38} {len(by_class.get(cls, []))}")
+
+    if "--verbose" in sys.argv:
+        print()
+        for cls in ("sizing", "derived", "ladder", "infra"):
+            print(f"  {cls}:")
+            for n in by_class.get(cls, []):
+                print(f"    {n:<36} {KNOB_CLASS[n][1]}")
+
+    if unclassified:
+        sys.stderr.write(
+            "config-knob-census: FAILED — build scripts read env name(s) that "
+            "KNOB_CLASS does not classify:\n"
+        )
+        for n in unclassified:
+            sys.stderr.write(f"    {n}\n")
+        sys.stderr.write(
+            "  Classify each in scripts/check/config-knob-census.py. The point\n"
+            "  is that a new knob forces a DECISION — is it a sizing knob for\n"
+            "  the ladder, a size the message type should derive (phase-403),\n"
+            "  or infrastructure? A heuristic would guess, and guessing is how\n"
+            "  the backlog number stops meaning anything.\n"
+        )
+        return 1
 
     if "--check" in sys.argv and n_ladder < LADDER_FLOOR:
         sys.stderr.write(
@@ -184,16 +338,6 @@ def main() -> int:
         )
         return 1
 
-    if "--verbose" in sys.argv:
-        print()
-        for label, items in (
-            ("Kconfig", kconfig),
-            ("NROS_* env", nros_env),
-            ("ZPICO_* env", zpico_env),
-        ):
-            print(f"  {label}:")
-            for n in sorted(items):
-                print(f"    {n}")
     return 0
 
 


### PR DESCRIPTION
Stacked on #142.

Two defects in the census that wave shipped, both of which made its number mean less than it looked.

## It scanned only `build.rs`

A build script that grows past a few lines moves its body into a helper crate, and the knobs go with it — **21 `ZPICO_*` names live in `nros-zpico-build/src/`**. So the census reported 6 zenoh env knobs, the phase doc's original table reported 9, and the real figure is ~27. A fourfold undercount, in the family that turns out to be the largest remaining.

Now scans `*-build` crates and `packages/tooling/` too.

## The env row counted things that are not knobs

19 of 64 names are paths, flags, or inputs to the ladder itself — including `NROS_PLATFORM_NAME`, which the previous commit **added**, so the raw count rose while the backlog fell. That was the number people were meant to act on.

Names are classified explicitly now — `ladder` / `sizing` / `derived` / `infra` — and an **unclassified name fails the gate**. Deliberately not a heuristic: the first cut of this analysis split by read idiom (`env_usize` vs `env::var`) and misfiled three knobs that are numeric but read as strings and handed to a C `#define`.

```
build-script env names, by what they ARE (64 total)
  sizing knobs still to migrate  <-- W6      31
  sized by the MESSAGE TYPE, not a knob       5
  already on the ladder                       9
  paths / flags / ladder inputs (not knobs)  19
```

## Five knobs must NOT be migrated

`NROS_SUBSCRIPTION_BUFFER_SIZE`, `ZPICO_SUBSCRIBER_{BUFFER_SIZE,LARGE_SIZE,SIZE_THRESHOLD}` and `ZPICO_PUBLISHER_TX_BUFFER_SIZE` are the receive/transmit buffers that **phase-403** and **phase-408** are making derived from the message type. A ladder rung would give each a per-platform default — entrenching the global those phases exist to remove.

`NROS_SUBSCRIPTION_BUFFER_SIZE` is the awkward one: already on the ladder from the executor tenant, which is fine (it stays as the fallback for a type with no declared bound), but it is not finished business. The `derived` class is what stops someone migrating one by following the backlog count.

## The remaining tenants, re-ordered from the measurement

The wave opened with "then the zenoh pools, then the per-entity caps", by estimate. The estimate was right that zenoh is next and **wrong that the caps are a separate thing**: 15 of the 31 sizing knobs are `ZPICO_*`, and the entity caps (publishers, subscribers, queryables, sessions, liveliness, pending gets) *are* zenoh's. One tenant, not two. Kconfig agrees — its largest family is also zenoh, 24 of 85.

`just ci-l1` green; `just check fast` 157/157; census self-test and its negative control both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG