### PR TITLE
feat(phase-410 W1): rename pr-checks.yml → gate.yml — probed first, and it found three silent breaks

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -15,7 +15,7 @@
 #
 # NOT folded here: the heavy test/build lanes (host-tests, nightly), release,
 # images, docs.
-name: pr-checks
+name: gate
 
 on:
   push:
@@ -36,7 +36,7 @@ on:
       - "rustfmt.toml"
       - "nros-sdk-index.toml"
       - ".gitmodules"
-      - ".github/workflows/pr-checks.yml"
+      - ".github/workflows/gate.yml"
   pull_request:
     # NO `branches:` filter and NO `paths:` filter. Both are load-bearing rather
     # than oversights, and they are the same trap on two different axes.
@@ -111,7 +111,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pr-checks-${{ github.ref }}-${{ github.event_name }}
+  group: gate-${{ github.ref }}-${{ github.event_name }}
   # NEVER cancel a merge-queue run. Cancelling one makes the batch fail with no
   # verdict, and GitHub then ejects pull requests that were never actually
   # tested — the opposite of what the queue is for. Superseding is right

--- a/.github/workflows/queue-notify.yml
+++ b/.github/workflows/queue-notify.yml
@@ -20,7 +20,10 @@ name: queue-notify
 
 on:
   workflow_run:
-    workflows: ["pr-checks", "queue"]
+    # phase-410 W1 — `gate`, renamed from `pr-checks`. This is a
+    # workflow_run trigger keyed on the workflow NAME, so it breaks
+    # SILENTLY on a rename: the notifier simply stops firing.
+    workflows: ["gate", "queue"]
     types: [completed]
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ separate `NEWSLabNTU/nano-ros-sdk` repo's Releases (referenced by URL, not a sub
   the `third-party/qemu` submodule build. `just <tool> build` still source-builds for devs.
 - ESP32 = **ESP32-C3 (RISC-V)** (`riscv32imc-unknown-none-elf` via rustup + build-std, espflash,
   Espressif `qemu-system-riscv32` fork). Needs no index host-tool.
-- CI gate: the `sdk-index` job in `.github/workflows/pr-checks.yml` sha256-verifies any index `dist` change. Bump a
+- CI gate: the `sdk-index` job in `.github/workflows/gate.yml` sha256-verifies any index `dist` change. Bump a
   tool's `-nros<N>` suffix when rebuilding the same upstream version with different config.
 
 ## C/C++ Integration Shape

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nano-ros
 
-[![CI](https://github.com/NEWSLabNTU/nano-ros/actions/workflows/pr-checks.yml/badge.svg)](https://github.com/NEWSLabNTU/nano-ros/actions/workflows/pr-checks.yml)
+[![CI](https://github.com/NEWSLabNTU/nano-ros/actions/workflows/gate.yml/badge.svg)](https://github.com/NEWSLabNTU/nano-ros/actions/workflows/gate.yml)
 [![Book](https://img.shields.io/badge/docs-book-blue)](https://newslabntu.github.io/nano-ros-book/)
 ![no_std](https://img.shields.io/badge/no__std-yes-success)
 ![Rust](https://img.shields.io/badge/rust-edition%202024-orange)

--- a/docs/development/ci-conventions.md
+++ b/docs/development/ci-conventions.md
@@ -180,7 +180,7 @@ per-workflow minutes low and failures isolated to one platform:
 
 | Workflow | What it shows |
 |----------|---------------|
-| `pr-checks.yml` | the fast gate: path-filtered jobs, container image + credentials, build-CLI-from-source, `nros setup --source` provisioning |
+| `gate.yml` | the fast gate: path-filtered jobs, container image + credentials, build-CLI-from-source, `nros setup --source` provisioning |
 | `host-tests.yml` | ROS on the runner, and installing a package rather than assuming it |
 | `nightly.yml` | the broad matrix, and lanes too expensive to gate a merge |
 | `queue.yml` | `merge_group`, `cancel-in-progress: false`, and a self-hosted job interlocked on a repo variable |
@@ -194,9 +194,9 @@ lessons were learned from them; do not go looking for them.
 
 | Historical | Replaced by |
 |------------|-------------|
-| `ci.yml` | `pr-checks.yml` (fast gate) + `nightly.yml` (matrix) — phase-253 |
+| `ci.yml` | `gate.yml` (fast gate) + `nightly.yml` (matrix) — phase-253 |
 | `dep-chain.yml` | `nightly.yml`; the check itself is `scripts/ci/dep-chain-check.sh` |
 | `zephyr-dual-line.yml` | `nightly.yml` |
-| `codegen-convention.yml` | `pr-checks.yml`; the lint is `scripts/ci/codegen-invocation-check.sh` |
-| `sdk-index-gate.yml` | `pr-checks.yml`, job `sdk-index` |
+| `codegen-convention.yml` | `gate.yml`; the lint is `scripts/ci/codegen-invocation-check.sh` |
+| `sdk-index-gate.yml` | `gate.yml`, job `sdk-index` |
 | `host-integration-tests.yml` | `host-tests.yml` |

--- a/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
+++ b/docs/roadmap/phase-410-ci-breadth-depth-restructure.md
@@ -1,6 +1,6 @@
 # phase-410 — CI is BREADTH × DEPTH, and only depth is expensive
 
-**Status (2026-08-31). W2, W3 and W4 landed; W1 deferred with reasons.**
+**Status (2026-09-01). W1–W4 landed. The phase is complete.**
 
 Restructures the CI workflows so a tier's file keeps the promise the tier makes.
 Consumes phase-411 (`just <verb> <scope>`) and phase-395 (the event design);
@@ -16,7 +16,7 @@ under load.
 `host-tests.yml`, tier 2 in `post-submit.yml`, tier-2-nightly in `nightly.yml`,
 tier 3 nowhere. "Where does tier 2 run?" needed a gate to answer.
 
-**2. `pr-checks.yml` does different work for five events in 850 lines.**
+**2. `gate.yml` does different work for five events in 850 lines.**
 Deliberate (phase-395's economics) and unreadable: a developer cannot answer
 "what runs on my PR?" without reading all of it. `nightly.yml` is another 851.
 
@@ -68,7 +68,7 @@ finishes.
 
 ## Caching is a REPOSITORY-wide budget, not a per-job one
 
-`pr-checks.yml` already records why sccache is used over caching `target/`, and
+`gate.yml` already records why sccache is used over caching `target/`, and
 the constraint that matters here: **the GitHub Actions Cache limit is 10 GB per
 REPOSITORY**, and GitHub evicts entries "created and deleted at a high
 frequency" (hence `SCCACHE_CACHE_SIZE=2G`).
@@ -109,7 +109,7 @@ perpetually superseded.
 ## THE MIGRATION CONSTRAINT — read before touching anything
 
 The required status check is the job **named `CI`** (`ci-ok` in
-`pr-checks.yml`), and CLAUDE.md records that a required check producing no
+`gate.yml`), and CLAUDE.md records that a required check producing no
 verdict **deadlocked two pull requests**: a check that never reports blocks
 forever rather than failing.
 
@@ -123,23 +123,41 @@ else moves.
 
 ## Work items
 
-**W1 — DEFERRED, deliberately. `pr-checks.yml` keeps its name for now.**
+**W1 LANDED — the inference was right, and PROBING it found three things it
+would have broken.**
 
-The plan was to rename it `gate.yml`. The inference that this is safe is
-strong: the ruleset requires the bare context `CI`, which cannot come from the
-file name or from the workflow's `name: pr-checks` — so GitHub is matching the
-JOB name, `ci-ok`'s `name: CI`, and a rename preserves it.
+The rename was deferred because the required status check is the context `CI`,
+and CLAUDE.md records a required check with no verdict DEADLOCKING two pull
+requests. The inference — that GitHub matches the JOB name, so a rename
+preserves it — was strong but not observable from a shell: `gh pr checks`
+reports no contexts for a branch even when a run has succeeded.
 
-Strong is not verified. `gh pr checks` reports no contexts for this branch even
-though a `pr-checks` run succeeded, so the association cannot be observed from
-here. CLAUDE.md records that a required check producing no verdict DEADLOCKED
-two pull requests — with ten agents landing through a merge queue, that blocks
-everyone, and the benefit on offer is a better filename.
+So it was tested rather than reasoned about. A throwaway branch, a real PR, and
+a look:
 
-So the rename is its own change, made when someone can watch the context report
-on a real PR. W2 and W3 add NEW files and touch no required context; they carry
-the substance of this phase — the breadth/depth split, the starvation fix and
-the cache rule — without betting the queue on an inference.
+```
+CI     pass   4s
+check  pass   8m42s
+```
+
+The context survives. Filename and workflow `name:` moved together, because a
+partial rename leaves the workflow name matching and proves nothing.
+
+**Three load-bearing references would have broken silently**, and none of them
+is prose:
+
+* the workflow's own `paths:` filter listed `.github/workflows/pr-checks.yml`,
+  so after the rename it would have stopped triggering on edits to ITSELF;
+* `check-ros-env-spelling.py` keys its allow-list on the path, so the renamed
+  file would have lost its exemption and gone red for an unrelated reason;
+* `queue-notify.yml` triggers on `workflow_run` with
+  `workflows: ["pr-checks", "queue"]` — keyed on the workflow NAME, so the
+  notifier would simply have stopped firing, with nothing to notice.
+
+The third is the one that justifies the whole exercise: a `workflow_run`
+trigger that no longer matches produces no error, no red, and no runs. It is
+the same silent-skip class this phase and phase-407 spent their time on, and it
+was one grep away from shipping.
 
 **W2 — `build-wide.yml`.** The mandatory build+link lane on `push(main)`.
 

--- a/just/check.just
+++ b/just/check.just
@@ -226,7 +226,7 @@ build: \
 # AND no `cargo tree`/metadata (which would need the workspace — i.e. every `-sys`
 # source submodule — to resolve). So it needs neither the nros CLI nor any
 # provisioned source, finishes in ~1 min, and survives the per-push cadence. This
-# is the per-push CI gate (`pr-checks.yml`).
+# is the per-push CI gate (`gate.yml`).
 #
 # That description is now TRUE, and was not (issue 0466): `check-cli-fresh` and
 # `check-test-targets` both lived here and both needed what the paragraph says
@@ -276,7 +276,7 @@ workspace-fmt:
 #
 # Issue 0466 — this is a check-BUILD gate, and used to sit in `check-fast`.
 # Compiling the workspace needs the `-sys` SOURCE submodules, which the push
-# lane deliberately does not provision (pr-checks.yml gates that on
+# lane deliberately does not provision (gate.yml gates that on
 # `event_name != 'push'`), so on every push it died:
 #
 #     error: failed to run custom build command for `zpico-sys`
@@ -2406,7 +2406,7 @@ no-std:
     echo "no-std OK."
 
 # Verify nros-sdk-index.toml + the QEMU configure flags
-# (the `sdk-index` job in .github/workflows/pr-checks.yml). Buildless + fast.
+# (the `sdk-index` job in .github/workflows/gate.yml). Buildless + fast.
 [group("ci")]
 sdk-index:
     python3 scripts/sdk/verify-index.py nros-sdk-index.toml

--- a/scripts/check-decoupling.sh
+++ b/scripts/check-decoupling.sh
@@ -43,7 +43,7 @@ check_manifest() {
     #
     # on every run: a FAILING verdict whose stated reason was false, about a
     # crate that was never checked at all. The guard is advisory
-    # (`continue-on-error` in pr-checks.yml, and deliberately outside
+    # (`continue-on-error` in gate.yml, and deliberately outside
     # `just check` since RFC-0031 superseded the goal it guards), so nothing was
     # gated on the lie — it just made the one output nobody could trust.
     #

--- a/scripts/check-leaf-lockfiles.sh
+++ b/scripts/check-leaf-lockfiles.sh
@@ -206,7 +206,7 @@ if [ ${#unsynced[@]} -gt 0 ]; then
     #
     # Issue 0466 — this used to `exit 1` either way, which made the gate
     # unrunnable in the very lane it lives in. `check-fast` is documented
-    # BUILDLESS *and* SOURCE-FREE, and pr-checks.yml deliberately does NOT
+    # BUILDLESS *and* SOURCE-FREE, and gate.yml deliberately does NOT
     # provision the CLI or run `nros sync` on a push; so on every push this gate
     # met two leaves it could not resolve and failed. Per-push CI was red
     # CONTINUOUSLY for over a day on exactly this, which also buried every other

--- a/scripts/check-ros-env-spelling.py
+++ b/scripts/check-ros-env-spelling.py
@@ -104,7 +104,7 @@ ALLOWLIST = {
         "distro is the image pin, not a test's choice",
     ".github/workflows/nightly.yml":
         "CI job bootstrap, as host-tests.yml",
-    ".github/workflows/pr-checks.yml":
+    ".github/workflows/gate.yml":
         "CI job bootstrap, as host-tests.yml",
 
     # --- developer environment SSoT ------------------------------------------

--- a/scripts/ci/enable-merge-queue.sh
+++ b/scripts/ci/enable-merge-queue.sh
@@ -68,7 +68,7 @@ RULESET="${NROS_QUEUE_RULESET:-main-rules}"
 # that cannot REPORT is the same freeze as one that cannot START.
 #
 # So `check (fast on push; full on PR/nightly)` is NOT here despite being the
-# obvious candidate: `pr-checks.yml` triggers on push/pull_request/schedule and
+# obvious candidate: `gate.yml` triggers on push/pull_request/schedule and
 # NOT on merge_group. It still runs on every PR and its failures are still
 # visible; it just cannot be the thing that gates a queue. `just ci-l1` covers
 # the same ground inside the queue (check-fast + check-build + test-unit).
@@ -167,7 +167,7 @@ if [ "$READINESS" = 1 ]; then
     # observation: five dispatches fired to measure a flake showed up here as
     # `absent,absent,cancelled`.
     runs=""; _seen=0
-    for _rid in $(gh run list --workflow pr-checks.yml --branch "$BRANCH" --limit 12 \
+    for _rid in $(gh run list --workflow gate.yml --branch "$BRANCH" --limit 12 \
                     --json databaseId --jq '.[].databaseId' 2>/dev/null); do
         [ "$_seen" -ge 5 ] && break
         _c="$(gh run view "$_rid" --json jobs --jq \

--- a/scripts/ci/pr-verdict-check.sh
+++ b/scripts/ci/pr-verdict-check.sh
@@ -27,7 +27,7 @@
 # undispatched one creates nothing at all.
 #
 # PR #71 sat this way for thirteen hours. It was STACKED — opened against
-# another PR's branch — and `pr-checks.yml` filtered `pull_request` on
+# another PR's branch — and `gate.yml` filtered `pull_request` on
 # `branches: [main]`, so its `opened` and `synchronize` events were dropped.
 # Retargeting it to main afterwards emitted `pull_request.edited`, which is not
 # one of the default event types, so that dispatched nothing either. The filter

--- a/scripts/ci/submodule-pins-check.sh
+++ b/scripts/ci/submodule-pins-check.sh
@@ -88,7 +88,7 @@ if ! git rev-parse --verify --quiet "$baseline^{commit}" >/dev/null; then
     # had existed. Measured: a real play_launch pin rewind reached a pushed
     # branch and was caught only by a LOCAL run.
     #
-    # pr-checks.yml already documents this exact trap for a sibling check:
+    # gate.yml already documents this exact trap for a sibling check:
     # "the base ref is usually absent and the diff would fail — which the
     # fail-safe would turn into code=true forever, i.e. safe but never actually
     # firing". Same trap, different gate.


### PR DESCRIPTION
**The probe succeeded, so this is now the real change.** Completes phase-410.

## The probe, and why there was one

The required status check on `main` is the context `CI`, produced by the job named `CI` in this workflow. CLAUDE.md records that a required check producing no verdict **deadlocked two pull requests** — it stays *pending* forever rather than failing, which with ten agents landing blocks everyone.

The inference was that GitHub matches the **job** name, so a rename preserves it. Strong, but not observable from a shell: `gh pr checks` reports no contexts for a branch even when a run has succeeded.

So it was tested on this throwaway branch rather than argued about:

```
CI     pass   4s
check  pass   8m42s
```

The context survives. Filename and workflow `name:` moved together — a partial rename leaves the workflow name matching and proves nothing.

## Three load-bearing references would have broken silently

None of them is prose:

1. **the workflow's own `paths:` filter** listed `.github/workflows/pr-checks.yml`, so after the rename it would have stopped triggering on edits to *itself*;
2. **`check-ros-env-spelling.py`** keys its allow-list on the path — the renamed file loses its exemption and the gate goes red for an unrelated reason;
3. **`queue-notify.yml`** fires on `workflow_run` with `workflows: ["pr-checks", "queue"]` — keyed on the workflow **name**.

The third justifies the whole exercise. A `workflow_run` trigger that no longer matches produces **no error, no red, and no runs** — the notifier just stops, and nothing says so. Same silent-skip class phase-407 and phase-410 spent their time on, one grep from shipping. It now carries a comment saying the trigger is name-keyed, so the next rename doesn't rediscover it.

## Also here

The remaining ~11 references (comments, `AGENTS.md`, `README.md`, `ci-conventions.md`, gate prose) updated in the same pass, so the tree stops describing a file that no longer exists.

`just check fast`: 157 gates OK. Job name `CI` untouched — that is the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa