### PR TITLE
phase-408 W5a: the info/validated C++ subscriptions stop dropping their receive hint

### DIFF
--- a/docs/issues/archived/0841-subscriber-size-class-gap-below-threshold.md
+++ b/docs/issues/archived/0841-subscriber-size-class-gap-below-threshold.md
@@ -3,10 +3,10 @@ id: 841
 title: "A subscription whose hint lands between the small block size and the size
   threshold gets a block that cannot hold it — and the build error's own remedy
   puts it there"
-status: open
+status: resolved
 type: bug
 area: rmw
-related: [phase-392, issue-0757, issue-0776, rfc-0038]
+related: [phase-392, phase-403, issue-0757, issue-0776, rfc-0038]
 ---
 
 ## Problem
@@ -123,3 +123,35 @@ needs a consumer-side packet capture to attribute (which is exactly what the
 
 Raising `ZPICO_MAX_LARGE_SUBSCRIBERS`, or `ZPICO_SUBSCRIBER_BUFFER_SIZE` so the
 type fits the small class, are both valid answers; the inventory prices each.
+
+## Resolution — fixed, and the top end closed with it
+
+`alloc_payload_block` no longer routes on the threshold alone. It routes on
+`SMALL_CLASS_CEILING`, the `min` of the two knobs:
+
+```rust
+const SMALL_CLASS_CEILING: usize = if SUBSCRIBER_SIZE_THRESHOLD < SUBSCRIBER_BUFFER_SIZE {
+    SUBSCRIBER_SIZE_THRESHOLD
+} else {
+    SUBSCRIBER_BUFFER_SIZE
+};
+```
+
+`min`, not a replacement: setting the threshold BELOW the block size stays a
+legitimate way to push borderline topics into the large class early. What can no
+longer happen is a hint small-classed into a block that cannot hold it, which
+was the 1,025..=2,048 window this issue reported and the one the build error's
+own remedy walked you into.
+
+**Phase-403 W4 then closed the same defect one class up**, which this issue left
+open: a hint above `SUBSCRIBER_LARGE_SIZE` used to route large into a block too
+small for it and drop every sample identically. It is now refused at create time
+via `LARGEST_PAYLOAD_CLASS`, so the image fails where the person who set the
+knobs is standing. That is also what makes `MAX_LARGE_SUBSCRIBERS == 0` legal:
+with no large class, a hint past the small block has nowhere legal to go.
+
+Both ends carry tests in `shim/subscriber.rs` — every block handed out can hold
+the hint that routed to it, and the top-end refusal.
+
+Closed 2026-09-01 after verifying against the code rather than the issue text;
+the fix had landed and only the issue was left open.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -39,7 +39,6 @@ fails if this block drifts.
 - **#0830** (boards) — A QEMU net hub with only a NIC and a tap never delivers host->guest frames — OUR lan9118 can_receive patch deadlocks before the guest enables RX See `0830-*`.
 - **#0831** (build) — `[image.<id>].rmw` configures nothing on the cargo driver — and a workspace fixture row's `rmw` does not either, so two tier-2 coordinates test zenoh while claiming cyclonedds and XRCE See `0831-*`.
 - **#0835** (testing) — The cmake and rust fixture families re-stale each other, so `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails ~190 tests on every run See `0835-*`.
-- **#0841** (rmw) — A subscription whose hint lands between the small block size and the size threshold gets a block that cannot hold it — and the build error's own remedy puts it there See `0841-*`.
 - **#0847** (rmw) — An XRCE publisher outliving `executor.close()` segfaults in its own Drop: the entity destructor dereferences the session state that close already freed See `0847-*`.
 - **#0849** (cli) — `nros sync` bakes the invocation's path SPELLING into every leaf patch table, so working through a symlink to the checkout makes cargo see two copies of every core crate and refuse the build on `links` See `0849-*`.
 - **#0852** (rmw, platform) — the zenoh read task inherits the executor's priority on Zephyr — the declared priority is discarded by the port, so a 20 ms timeslice starves the polled serial RX and it overruns See `0852-*`.

--- a/docs/roadmap/phase-408-cpp-message-derived-buffers.md
+++ b/docs/roadmap/phase-408-cpp-message-derived-buffers.md
@@ -156,8 +156,34 @@ Acceptance: a C example subscribing to a bounded type shows a smaller arena in
 `mem-report --baseline` **without its source being edited**, beyond switching to
 the generated helper.
 
-**W5 — `_with_info` stops discarding the hint.** Small, and it is the variant a
-component with `MessageInfo` uses.
+**W5 — `_with_info` stops discarding the hint.** ~~Small~~ — it is TWO things,
+and only one of them is small. Split after reading the entries.
+
+The plain C path was already migrated to a runtime-sized `BufferStrategy` over
+trailing arena bytes. The info and validated paths were NOT: their entries store
+a real `[u8; RX_BUF]` —
+
+```rust
+type Entry<const N: usize> = SubBufferedRawInfoCEntry<N>;
+buffer: [0u8; RX_BUF],
+```
+
+— which is exactly the case W3 says to leave const. So "pass the hint" means two
+different jobs on this path:
+
+* **W5a — the hint reaches the BACKEND. LANDED 2026-09-01.** The two executor
+  entry points take `rx_buffer_hint` and set `topic.with_rx_buffer_hint(...)`,
+  so zenoh-pico's payload size-class routing sees it. The two C++ sites stop
+  destructuring it into `_rx_buffer_hint` and dropping it. This is the half the
+  size-class cluster is actually about, and it needs no entry change.
+* **W5b — the hint sizes the ARENA. OPEN.** Requires migrating
+  `SubBufferedRawInfoCEntry` and the validated sibling off `[u8; N]` onto the
+  same `BufferStrategy` the plain path uses. Real work, not a parameter.
+
+Until W5b, an info-callback subscription routes to the right payload class and
+still charges `DEFAULT_RX_BUF_SIZE` of arena. Both numbers matter and they are
+not the same number — the distinction this phase's status section already had to
+make once.
 
 ## Explicitly out of scope
 

--- a/docs/roadmap/phase-408-cpp-message-derived-buffers.md
+++ b/docs/roadmap/phase-408-cpp-message-derived-buffers.md
@@ -1,6 +1,39 @@
 # Phase 408 — a C/C++ subscription sizes its buffer from its own message type
 
-**Status (2026-08-31). Opened from a design review; survey done, no code yet.**
+**Status (2026-09-01). W1, W2 and W4 are LANDED on the C pack — by other work,
+not by this phase.** Re-measured against the tree rather than read off this
+file, which said "no code yet" and sent the next reader looking in the wrong
+place. What that reader found:
+
+| wave | state | evidence |
+| --- | --- | --- |
+| W1 emit the constant | **done (C)** | `packs/c/message.h.jinja` emits `_TX_/_RX_MAX_SERIALIZED_SIZE`, comment cites 0896 |
+| W2 retarget publish helper | **done** | bounded types get `_TX_MAX_SERIALIZED_SIZE`; `NROS_PUB_BUFFER_SIZE` survives only as the unbounded fallback, which is the honest answer |
+| W3 runtime `RX_BUF` | **open** | `add_arena_subscription_c_callback<const RX_BUF: usize>` and five siblings |
+| W4 deliver at the call site | **done (C)** | `<Type>_subscribe` passes the constant; an unbounded type gets a POISONED macro naming the costing member |
+| W5 `_with_info` keeps the hint | **open** | `subscription.rs:353` and `:470` destructure `_rx_buffer_hint` and fall back to `DEFAULT_RX_BUF_SIZE` |
+| C++ pack | **open, and not what it looks like** | see below |
+
+**The C++ pack is the part with a trap in it.** It emits a single
+`SERIALIZED_SIZE_MAX` from `types::compute_serialized_size_max`, and that number
+must NOT be reused as the receive hint. `bounds.rs` says why, in its own words:
+
+> It is deliberately NOT `crate::types::compute_serialized_size_max` … That
+> function ESTIMATES: it charges a flat 512 bytes per nested message and a flat
+> default capacity per string, and it always returns a value, so it can never
+> report "unbounded". A flat 512 for a nested type whose own bound exceeds 512
+> is an UNDER-estimate, which is the direction that matters.
+
+Wiring the existing C++ constant into `rx_buffer_hint` would ship an UNDER-sized
+receive buffer — the drop-every-sample failure this whole cluster is about,
+reintroduced by reusing a number that was already there. The C++ work is
+*emit the real bound from `bounds.rs`*, not *use the number in the header*.
+
+**Two numbers, not one — the distinction W3 turns on.** The C path already
+carries a runtime hint to the BACKEND for payload-class routing (phase-402,
+`subscription.rs:301`). What is still fixed at `DEFAULT_RX_BUF_SIZE` is the
+const that sizes the EXECUTOR ARENA's trailing region. W3 is about the second;
+the first is done for one of the three variants.
 Scope is the C and C++ path only. The other obstacles to
 [phase 392](phase-392-static-memory-space-campaign.md)'s "W3 remainder" — Rust
 being opt-in (W3c), Cyclone not consuming the hint (W3f), unbounded diagnostics

--- a/packages/api/nros-c/src/executor.rs
+++ b/packages/api/nros-c/src/executor.rs
@@ -1571,6 +1571,12 @@ pub unsafe extern "C" fn nros_executor_add_subscription_raw_with_info(
             qos_settings,
             cb,
             context,
+            // phase-408 W5a — this entry point predates the options struct and
+            // has no hint to forward, so it states none. 0 is "no opinion", not
+            // a claim of zero bytes: the subscription keeps the small payload
+            // class it has always taken. A C caller that wants the derived size
+            // goes through the options-carrying registration.
+            0,
         );
         match result {
             Ok(_handle_id) => {

--- a/packages/api/nros-cpp/src/subscription.rs
+++ b/packages/api/nros-cpp/src/subscription.rs
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn nros_cpp_subscription_register_with_info(
     options: *const nros_cpp_subscription_options_t,
 ) -> nros_cpp_ret_t {
     // phase-402 — these two could not take a callback group at all before.
-    let (sched_context, callback_group, _rx_buffer_hint) =
+    let (sched_context, callback_group, rx_buffer_hint) =
         unsafe { read_subscription_options(options) };
     let _ = callback_group;
     if node.is_null()
@@ -405,6 +405,9 @@ pub unsafe extern "C" fn nros_cpp_subscription_register_with_info(
         qos.to_qos_settings(),
         callback,
         context,
+        // phase-408 W5a — the hint reaches the backend's payload
+        // classing instead of being destructured and dropped.
+        rx_buffer_hint as usize,
     );
 
     match result {
@@ -467,7 +470,7 @@ pub unsafe extern "C" fn nros_cpp_subscription_register_validated(
     options: *const nros_cpp_subscription_options_t,
 ) -> nros_cpp_ret_t {
     // phase-402 — these two could not take a callback group at all before.
-    let (sched_context, callback_group, _rx_buffer_hint) =
+    let (sched_context, callback_group, rx_buffer_hint) =
         unsafe { read_subscription_options(options) };
     let _ = callback_group;
     if node.is_null()
@@ -524,6 +527,9 @@ pub unsafe extern "C" fn nros_cpp_subscription_register_validated(
             qos.to_qos_settings(),
             callback,
             context,
+            // phase-408 W5a — the hint reaches the backend's payload
+            // classing instead of being destructured and dropped.
+            rx_buffer_hint as usize,
         );
 
     match result {

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -5011,6 +5011,13 @@ impl<'s> Executor<'s> {
         qos: QoSProfile,
         callback: RawSubscriptionInfoCallback,
         context: *mut core::ffi::c_void,
+        // phase-408 W5a — bytes the caller expects to receive; 0 = no opinion.
+        // Reaches the BACKEND, which routes the payload size class on it. The
+        // ARENA slot for this variant is still `RX_BUF`: its entry stores a real
+        // `[u8; N]`, so shrinking that needs the runtime-sized `BufferStrategy`
+        // the plain C path already uses, which is W5b. Routing is the half that
+        // does not need it, and it is the half the size-class cluster is about.
+        rx_buffer_hint: usize,
     ) -> Result<HandleId, NodeError> {
         type Entry<const N: usize> = SubBufferedRawInfoCEntry<N>;
 
@@ -5030,6 +5037,12 @@ impl<'s> Executor<'s> {
             .with_namespace(&ns);
         if !node_name.is_empty() {
             topic = topic.with_node_name(&node_name);
+        }
+        // phase-408 W5a — only when the caller actually stated one:
+        // `with_rx_buffer_hint(0)` would be a claim of "zero bytes", not
+        // "no opinion".
+        if rx_buffer_hint != 0 {
+            topic = topic.with_rx_buffer_hint(rx_buffer_hint);
         }
         let handle = {
             let session = self
@@ -5093,6 +5106,13 @@ impl<'s> Executor<'s> {
         qos: QoSProfile,
         callback: super::types::RawSubscriptionSafetyCallback,
         context: *mut core::ffi::c_void,
+        // phase-408 W5a — bytes the caller expects to receive; 0 = no opinion.
+        // Reaches the BACKEND, which routes the payload size class on it. The
+        // ARENA slot for this variant is still `RX_BUF`: its entry stores a real
+        // `[u8; N]`, so shrinking that needs the runtime-sized `BufferStrategy`
+        // the plain C path already uses, which is W5b. Routing is the half that
+        // does not need it, and it is the half the size-class cluster is about.
+        rx_buffer_hint: usize,
     ) -> Result<HandleId, NodeError> {
         use super::arena::{
             SubBufferedRawSafetyCEntry, sub_buffered_raw_safety_c_has_data,
@@ -5116,6 +5136,12 @@ impl<'s> Executor<'s> {
             .with_namespace(&ns);
         if !node_name.is_empty() {
             topic = topic.with_node_name(&node_name);
+        }
+        // phase-408 W5a — only when the caller actually stated one:
+        // `with_rx_buffer_hint(0)` would be a claim of "zero bytes", not
+        // "no opinion".
+        if rx_buffer_hint != 0 {
+            topic = topic.with_rx_buffer_hint(rx_buffer_hint);
         }
         let handle = {
             let session = self

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -2527,6 +2527,7 @@ fn test_raw_subscription_info_callback() {
             QoSProfile::default().keep_last(1),
             info_cb,
             core::ptr::null_mut(),
+            0, // phase-408 W5a — no hint stated
         )
         .unwrap();
 


### PR DESCRIPTION
## What

Work on the size-class cluster (#0896 / #0841 / #0827). Most of it turned out to
be already built, so this PR is one real code change plus the reconciliation
that found it.

### phase-408 W5a — the info and validated C++ subscriptions stop dropping their hint

`nros_cpp_subscription_register_with_info` and its validated sibling
destructured the caller's receive hint into `_rx_buffer_hint` and threw it away,
falling back to `DEFAULT_RX_BUF_SIZE`. Every C++ subscription that wants
`MessageInfo` therefore took the SMALL payload class whatever its message type —
issue 0896's defect, on the two variants phase-402 did not reach.

Both executor entry points now take `rx_buffer_hint` and set
`topic.with_rx_buffer_hint(...)` when non-zero, exactly as the plain C path has
since phase-402. Zero stays "no opinion", not a claim of zero bytes.

**W5 was recorded as "small" and it is two things.** Reading the entries split
it. The plain C path was already migrated to a runtime-sized `BufferStrategy`
over trailing arena bytes; the info and validated paths were not — they hold a
real `[u8; RX_BUF]`, which is the case W3 explicitly says to leave const.

    W5a  the hint reaches the BACKEND for payload-class routing   <- here
    W5b  the hint sizes the ARENA                                 <- needs the
         entries migrated off [u8; N]; real work, still open

Two numbers, and only the first moves. An info-callback subscription now routes
to the right payload class and still charges `DEFAULT_RX_BUF_SIZE` of arena.

### #0841 closed — verified against the code, not the text

`alloc_payload_block` routes on `SMALL_CLASS_CEILING`, the `min` of the two
knobs, so the 1,025..=2,048 window is gone — the window the build error's own
remedy walked you into. Phase-403 W4 then closed the same defect one class up.
Both ends carry tests. Only the issue was left open.

### phase-408 reconciled with the tree

Its status said "survey done, no code yet". Three of five waves were done on the
C pack, landed by phase-402/403, and W3's substance too — the arena already
sizes from the hint when one is given. The stale line sent me looking for code
that was already written.

The doc now also records **a trap I nearly walked into**: the C++ pack emits
`SERIALIZED_SIZE_MAX` from `types::compute_serialized_size_max`, and `bounds.rs`
is explicit that this ESTIMATES — a flat 512 B per nested message, so a nested
type whose own bound exceeds 512 is UNDER-estimated. Wiring that number into
`rx_buffer_hint` would ship an under-sized receive buffer: the drop-every-sample
failure this cluster exists to fix, reintroduced by reusing a number that
happened to be lying around. The C++ work is to emit the real bound.

### A caller sweep I should not have needed

Adding the parameter broke `nros-c` and an executor test, because I fixed the
C++ sites and discovered the rest one compiler error at a time. Both now pass
`0`. Sweep in the commit message.

## Verification

`just ci gate` green. Beyond it: `just check c`, `check cpp`,
`check rmw-cyclonedds` all green.

`cargo check --all-targets -p nros-node` reports 247 errors WITH OR WITHOUT this
change — a pre-existing feature-gating artifact of checking a `no_std` crate's
tests without its `std` feature, confirmed against a stashed tree.

Not claimed: no `mem-report` delta. W5a changes payload-class ROUTING, not arena
size, so the number this cluster is eventually judged on does not move until
W5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP
