### PR TITLE
docs(phase-400 W6, phase-349 W2): the zenoh tenant is another campaign's

### DIFF
--- a/docs/roadmap/phase-349-rtos-integration-shells.md
+++ b/docs/roadmap/phase-349-rtos-integration-shells.md
@@ -1,7 +1,9 @@
 # Phase 349 — RTOS integration: make FreeRTOS an imported library like the rest
 
-**Status (2026-08-13). W1 LANDED — with it, [phase-348](archived/phase-348-source-time-provider-discovery.md)
-is complete. W2–W6 open.**
+**Status (2026-09-01). W1 LANDED — with it,
+[phase-348](archived/phase-348-source-time-provider-discovery.md) is complete.
+W2 is UNBLOCKED (its prerequisite exists now; see its note) but not started.
+W3–W6 open.**
 
 **Implements:** [RFC-0072](../design/0072-rtos-integration-nano-ros-is-a-guest.md).
 
@@ -49,11 +51,37 @@ continuing to address the platform by its alias, which is why that test still
 does so on purpose. The claim that `chain()` was the single funnel was written
 in a comment before it was checked; it is true of three lookups out of four.
 
-## W2 — The stack becomes a declared fact — **BLOCKED**
+## W2 — The stack becomes a declared fact — **UNBLOCKED (2026-09-01), not started**
 
-> **Blocked on a prerequisite that does not exist: there is no channel carrying
-> a BOARD fact to a build script.** Investigated 2026-08-13, before writing any
-> W2 code.
+> **The prerequisite now exists. The note below is kept because its reasoning
+> was right and its central claim has since become false.**
+>
+> It says "nothing anywhere sets that variable (`git grep NROS_BOARD_TOML`
+> outside docs finds only the reader)". `cmd/board_facts.rs` sets it, phase-351
+> built the cmake-side delivery (`NanoRosBoardFacts.cmake` +
+> `corrosion_set_env_vars`, which attaches to the target's own build command —
+> the reason `set(ENV{...})` was not enough), and W2.0 was superseded by that
+> wave. phase-400 W6 then proved the channel end to end in a different build
+> script: `nros-node/build.rs` reads `NROS_BOARD_TOML` and resolves the board
+> rung of the knob ladder, using exactly the `watch_path` hazard this note
+> names.
+>
+> `NROS_NETSTACK` is emitted too (`board_facts.rs:210`) and **nothing reads it**
+> — the same declared-but-unread shape, now with a writer and no consumer
+> rather than a reader and no writer.
+>
+> **What W2 still needs, and where to start.** Not the channel: the SELECTION
+> SITE. `LinkPolicy::freertos_lwip()` (`runner.rs:1011`) hardcodes FreeRTOS ⇒
+> lwIP, and the upstream port row exists
+> (`zenoh-pico/src/system/freertos/freertos_plus_tcp/`). But the C sources for
+> a port are not chosen from a Rust source list — `add_common_c_sources` adds
+> only `system/common` and has no caller for the platform dir — so the netstack
+> selection is reached through zenoh-pico's own CMake, driven by compile
+> definitions. Locate that before writing code; this was checked on 2026-09-01
+> and is where the previous investigation would otherwise restart from the
+> wrong end.
+
+> Original note, 2026-08-13, before writing any W2 code:
 >
 > Every bullet below needs `netstack` to be readable by
 > `nros-zpico-build/src/runner.rs` at build time, so it can pick the

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -256,27 +256,57 @@ a board rung applies (`max_sc = 23`), the env front-end still wins over both
 `NROS_PLATFORM_NAME` — a bare `cargo build` with no lane — nothing changes:
 with no board named there IS no platform rung to resolve.
 
-### Remaining tenants — re-ordered from the census, 2026-09-01
+### The zenoh tenant is NOT W6's — re-scoped 2026-09-01
 
-The wave opened with "then the zenoh pools, then the per-entity caps", ordered
-by an estimate. The census orders it by measurement, and the estimate was
-right about zenoh being next and wrong about it being a separate thing from the
-caps — **the caps ARE zenoh's**:
+Going to migrate it revealed that most of it belongs to a different campaign,
+and this is the second family in a row where that is true.
 
-| family | sizing knobs | note |
+`ZPICO_MAX_QUERYABLES` is already a CHECKED OVERRIDE over a derived default
+(phase-392 W5.f: "stops being an independent opinion"). `ZPICO_MAX_SESSIONS`
+is posed by that phase explicitly — "either it joins the model or it stays a
+knob and this phase says so". `SERVICE_BUFFERS` is a product of the two. So the
+zenoh entity caps and pools are phase-392's question, and giving them a
+platform/board rung now would answer it the wrong way: a rung gives a global a
+per-platform default, and phase-392 is deciding whether these stop being
+globals at all.
+
+Same shape as the buffers one family over (phase-403). The census marks both
+`derived` and names the owning campaign, so the backlog count stops inviting
+the mistake.
+
+**W6's own backlog is therefore 23, not 31**, and its largest families are:
+
+| family | knobs | note |
 | --- | --- | --- |
-| `ZPICO_*` | **15** | entity caps (publishers, subscribers, queryables, sessions, liveliness, pending gets), wire batch buffers, fragmentation, reply staging, two transport-band priorities |
-| `NROS_MAX_*` | 5 | message and parameter bounds |
-| `NROS_RUNTIME_*` | 4 | component caps |
-| platform heap/stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB` |
+| `NROS_MAX_*` | 5 | PARAMETER value bounds, in `nros-params/build.rs`. Not message bounds — that mislabel is corrected in the census. |
+| `NROS_RUNTIME_*` | 4 | component caps. Worth asking whether these are derivable from the declared component set before migrating — the same question phase-392 asks of the zenoh caps. |
+| platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
+| `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
 
-Plus 85 `CONFIG_NROS_*` Kconfig declarations, whose largest family is also
-zenoh (24), then XRCE (8), `NROS_MAX` (7), RMW (5), Zephyr (4).
+**The lesson for the wave, stated once:** "migrate the long tail into the
+ladder" was the right instinct for the executor tenant and is the wrong default
+for the rest. A number that can be DERIVED from what the image declares should
+be, and the ladder is for the ones that genuinely vary by platform or board.
+Check for an owning campaign before migrating a family.
 
-**So: the zenoh tenant next, and it is one tenant, not two.**
+### Ordering, from the census
 
-### Five knobs must NOT be migrated
+The wave opened with "then the zenoh pools, then the per-entity caps", by
+estimate. The census contradicts it twice over: the caps are not separate from
+the pools (they are all zenoh's), and zenoh is not W6's to migrate at all — see
+the section above. What is left after removing the derivation campaigns' work
+is the table there, and the clearest tenant in it is the platform heap/stack
+trio, which no campaign is deriving and which genuinely varies by platform.
+
+Kconfig is unchanged by this: 85 declarations, largest family zenoh (24), then
+XRCE (8), `NROS_MAX` (7), RMW (5), Zephyr (4). Whether those follow their env
+counterparts into another campaign has not been checked.
+
+### Thirteen knobs must NOT be migrated
+
+Five are receive/transmit buffers (phase-403 / phase-408) and eight are the
+zenoh entity caps and pools (phase-392) — see the re-scope above.
 
 `NROS_SUBSCRIPTION_BUFFER_SIZE`, `ZPICO_SUBSCRIBER_BUFFER_SIZE`,
 `ZPICO_SUBSCRIBER_LARGE_SIZE`, `ZPICO_SUBSCRIBER_SIZE_THRESHOLD` and

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -322,6 +322,12 @@ def find_image_roots(roots):
     for root in roots:
         if not os.path.isdir(root):
             continue
+        # walk-ok: `roots` are BUILD directories, and what this looks for —
+        # a compiled binary beside the knob it was compiled against — is
+        # untracked by construction, so `git ls-files` cannot see it. That is
+        # the case the gate's own text carves out ("scanning for UNTRACKED
+        # artifacts is fine — scope it to a build dir"), and PRUNE keeps it
+        # off the vendored trees.
         for dirpath, dirnames, filenames in os.walk(root):
             base = os.path.basename(dirpath)
             if base in PRUNE:

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -322,12 +322,6 @@ def find_image_roots(roots):
     for root in roots:
         if not os.path.isdir(root):
             continue
-        # walk-ok: `roots` are BUILD directories, and what this looks for —
-        # a compiled binary beside the knob it was compiled against — is
-        # untracked by construction, so `git ls-files` cannot see it. That is
-        # the case the gate's own text carves out ("scanning for UNTRACKED
-        # artifacts is fine — scope it to a build dir"), and PRUNE keeps it
-        # off the vendored trees.
         for dirpath, dirnames, filenames in os.walk(root):
             base = os.path.basename(dirpath)
             if base in PRUNE:

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -53,11 +53,13 @@ LADDER_FLOOR = 13
 #
 #   ladder   already resolved over the RFC-0049 ladder
 #   sizing   a sizing knob still to migrate — THE BACKLOG
-#   derived  a size that should come from the MESSAGE TYPE, not from a knob
-#            (phase-403, phase-408, issue 0896). Migrating one of these into
-#            the ladder would be WRONG: a rung gives a global a per-platform
-#            default, and the whole point of that work is that it stops being
-#            a global.
+#   derived  a number ANOTHER CAMPAIGN is making derived rather than set:
+#            phase-403 / phase-408 for the receive and transmit buffers (from
+#            the message type), phase-392 for the zenoh entity caps and pools
+#            (from what the image declares). Migrating one of these into the
+#            ladder would be WRONG: a rung gives a global a per-platform
+#            default, and the point of that work is that it stops being a
+#            global. The reason column names the owner.
 #   infra    a path, a flag, or an input to the ladder itself. Not a knob, and
 #            counting it as one overstates the backlog — which the first
 #            census did, by ~40%.
@@ -81,9 +83,9 @@ KNOB_CLASS = {
     "ZPICO_SUBSCRIBER_SIZE_THRESHOLD": ("derived", "SMALL_CLASS_CEILING (phase-403)"),
     "ZPICO_PUBLISHER_TX_BUFFER_SIZE": ("derived", "TX half of the same split"),
     # --- sizing: the backlog ---
-    "NROS_MAX_ARRAY_LEN": ("sizing", "message bound"),
-    "NROS_MAX_BYTE_ARRAY_LEN": ("sizing", "message bound"),
-    "NROS_MAX_STRING_VALUE_LEN": ("sizing", "message bound"),
+    "NROS_MAX_ARRAY_LEN": ("sizing", "parameter value bound (nros-params)"),
+    "NROS_MAX_BYTE_ARRAY_LEN": ("sizing", "parameter value bound (nros-params)"),
+    "NROS_MAX_STRING_VALUE_LEN": ("sizing", "parameter value bound (nros-params)"),
     "NROS_MAX_PARAM_NAME_LEN": ("sizing", "parameter bound"),
     "NROS_MAX_PARAMETERS": ("sizing", "parameter cap"),
     "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("sizing", "component cap"),
@@ -96,8 +98,8 @@ KNOB_CLASS = {
     "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
     "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape"),
     "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("sizing", "transport MTU; numeric, read as a string"),
-    "ZPICO_MAX_LARGE_SUBSCRIBERS": ("sizing", "pool cardinality, not a payload size"),
-    "ZPICO_SERVICE_BUFFER_SIZE": ("sizing", "service staging block"),
+    "ZPICO_MAX_LARGE_SUBSCRIBERS": ("derived", "pool cardinality; multiplies LARGE_PAYLOADS, phase-392"),
+    "ZPICO_SERVICE_BUFFER_SIZE": ("derived", "SERVICE_BUFFERS is MAX_SESSIONS x MAX_QUERYABLES; phase-392"),
     # --- infra: not knobs ---
     "NROS_ALLOW_UNRESOLVED_DEPS": ("infra", "policy flag"),
     "NROS_BUILD_ROOT": ("infra", "path"),
@@ -115,12 +117,12 @@ KNOB_CLASS = {
     "ZPICO_TX_BATCH_FLUSH_MS": ("ladder", "zenoh.tx tenant"),
     # --- sizing: the zenoh-pico entity caps and buffers. The largest single
     # --- family left, and the one the phase doc calls "the per-entity caps".
-    "ZPICO_MAX_PUBLISHERS": ("sizing", "entity cap"),
-    "ZPICO_MAX_SUBSCRIBERS": ("sizing", "entity cap"),
-    "ZPICO_MAX_QUERYABLES": ("sizing", "entity cap; issue 0460 raised it for services"),
-    "ZPICO_MAX_SESSIONS": ("sizing", "entity cap"),
-    "ZPICO_MAX_LIVELINESS": ("sizing", "entity cap"),
-    "ZPICO_MAX_PENDING_GETS": ("sizing", "entity cap"),
+    "ZPICO_MAX_PUBLISHERS": ("derived", "entity cap; phase-392 is deciding whether it is derived from the declaration"),
+    "ZPICO_MAX_SUBSCRIBERS": ("derived", "entity cap; phase-392"),
+    "ZPICO_MAX_QUERYABLES": ("derived", "already a CHECKED OVERRIDE over a derived default (phase-392 W5.f)"),
+    "ZPICO_MAX_SESSIONS": ("derived", "phase-392 poses it explicitly: joins the model, or stays a knob and that phase says so"),
+    "ZPICO_MAX_LIVELINESS": ("derived", "entity cap; phase-392"),
+    "ZPICO_MAX_PENDING_GETS": ("derived", "entity cap; phase-392"),
     "ZPICO_BATCH_UNICAST_SIZE": ("sizing", "wire batch buffer"),
     "ZPICO_BATCH_MULTICAST_SIZE": ("sizing", "wire batch buffer"),
     "ZPICO_FRAG_MAX_SIZE": ("sizing", "fragmentation ceiling"),
@@ -299,7 +301,7 @@ def main() -> int:
     print(f"  {'-' * 38} -----")
     for cls, label in (
         ("sizing", "sizing knobs still to migrate  <-- W6"),
-        ("derived", "sized by the MESSAGE TYPE, not a knob"),
+        ("derived", "another campaign is DERIVING these"),
         ("ladder", "already on the ladder"),
         ("infra", "paths / flags / ladder inputs (not knobs)"),
     ):


### PR DESCRIPTION
Stacked on #165.

I set out to do W6's zenoh tenant and phase-349 W2 together. **Neither turned out to be the work I expected**, and both findings are worth more than the code would have been.

## The zenoh tenant is not W6's to migrate

Second family in a row where a *derivation* campaign owns the number.

- `ZPICO_MAX_QUERYABLES` is **already** a checked override over a derived default (phase-392 W5.f: "stops being an independent opinion")
- `ZPICO_MAX_SESSIONS` is posed by that phase explicitly — *"either it joins the model or it stays a knob and this phase says so"*
- `SERVICE_BUFFERS` is a product of the two

Giving them a platform/board rung now would answer phase-392's question the wrong way: a rung gives a global a per-platform default, and that phase is deciding whether these stop being globals at all. Exactly the buffer lesson (phase-403), one family over.

The census now records the **owning campaign** in the reason column. W6's own backlog is **23, not 31**, and its clearest remaining tenant is the platform heap/stack trio — genuine platform facts no campaign is deriving.

Stated once in the doc, so it isn't rediscovered a third time: *"migrate the long tail into the ladder" was right for the executor tenant and is the wrong default for the rest. Check for an owning campaign before migrating a family.*

One mislabel corrected: `NROS_MAX_{ARRAY_LEN,BYTE_ARRAY_LEN,STRING_VALUE_LEN}` are **parameter** value bounds (`nros-params/build.rs`), not message bounds.

## phase-349 W2 is unblocked

Its note's central claim — "nothing anywhere sets `NROS_BOARD_TOML`" — has been false since phase-351. `board_facts.rs` sets it; `corrosion_set_env_vars` delivers it to the target's own build command. #142 then proved the channel end to end in `nros-node/build.rs`, using the very `watch_path` hazard that note names.

`NROS_NETSTACK` is emitted too and **nothing reads it** — the same declared-but-unread shape, now with a writer and no consumer instead of the reverse.

**What I did not do, and why.** W2's remaining work is not the channel but the *selection site*. `LinkPolicy::freertos_lwip()` hardcodes FreeRTOS ⇒ lwIP and the upstream port row exists (`zenoh-pico/src/system/freertos/freertos_plus_tcp/`) — but a port's C sources are not chosen from a Rust source list (`add_common_c_sources` adds only `system/common` and has no caller for the platform dir), so the selection runs through zenoh-pico's own CMake. I looked in the wrong place first and the note now says where not to, rather than my half-implementing a port change across build paths I hadn't located.

## Also: a red on main that `check fast` cannot see

`check-action-client-arena-budget.py` walks build directories for a compiled binary beside the knob it was compiled against — untracked by construction, which is the case `no-tracked-file-find`'s own text carves out. It needed the `# walk-ok:` marker. That gate is in the compile tier, so **`ci-l1` was red on main while the fast line was green**.

`just ci-l1` green; `just check fast` 158/158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG