### PR TITLE
fix: mark the arena-budget build-dir walk, so `ci-l1` is green on main again

### DIFF
--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -322,6 +322,12 @@ def find_image_roots(roots):
     for root in roots:
         if not os.path.isdir(root):
             continue
+        # walk-ok: `roots` are BUILD directories, and what this looks for —
+        # a compiled binary beside the knob it was compiled against — is
+        # untracked by construction, so `git ls-files` cannot see it. That is
+        # the case the gate's own text carves out ("scanning for UNTRACKED
+        # artifacts is fine — scope it to a build dir"), and PRUNE keeps it
+        # off the vendored trees.
         for dirpath, dirnames, filenames in os.walk(root):
             base = os.path.basename(dirpath)
             if base in PRUNE:


### PR DESCRIPTION
`check-no-tracked-file-find` has been failing on main since `84211fd97`.

`check-action-client-arena-budget.py` walks **build** directories looking for a compiled binary beside the knob it was compiled against — untracked by construction, so `git ls-files` cannot see it. That is precisely the case the gate's own text carves out ("scanning for UNTRACKED artifacts is fine — scope it to a build dir"), and `PRUNE` already keeps it off the vendored trees. It needed the `# walk-ok:` marker and nothing else.

**Why it went unnoticed:** the gate is in the compile tier, and the push lane runs `check fast` alone. On main, `just check fast` is green and `just check build` is not — the same asymmetry CLAUDE.md records for `ci-l1`.

Verified on a clean `origin/main` checkout: `just check build` fails with exactly this one recipe, and passes with the marker.

Split out of #168 so a one-line unblock doesn't wait behind a doc re-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG