### PR TITLE
fix(#0972, #0974): respect the ROS domain cap, and stop the tooling pinning the cyclone domain

### DIFF
--- a/book/src/getting-started/zephyr.md
+++ b/book/src/getting-started/zephyr.md
@@ -185,7 +185,6 @@ dynamic threads, `NET_TCP`, …) are `select`ed automatically by
 CONFIG_NROS=y
 CONFIG_NROS_RMW_CYCLONEDDS=y
 CONFIG_CPP=y
-CONFIG_NROS_CYCLONE_DOMAIN_ID=0
 CONFIG_POSIX_API=y
 CONFIG_NET_IPV4_IGMP=y                  # RTPS SPDP uses UDP multicast
 CONFIG_MAIN_STACK_SIZE=524288

--- a/changelog.d/0974.fix.md
+++ b/changelog.d/0974.fix.md
@@ -1,0 +1,1 @@
+generated cyclonedds projects no longer pin the Cyclone domain to 0, which silently split it from CONFIG_NROS_DOMAIN_ID

--- a/docs/issues/archived/0974-cyclone-domain-literal-pinned-by-the-tooling.md
+++ b/docs/issues/archived/0974-cyclone-domain-literal-pinned-by-the-tooling.md
@@ -1,0 +1,77 @@
+---
+id: 974
+title: "`nros new` and the book both pinned `CONFIG_NROS_CYCLONE_DOMAIN_ID=0`, the one thing CLAUDE.md says never to do"
+status: resolved
+type: bug
+area: cli, docs, rmw-cyclonedds
+related: [issue-0161, issue-0972, issue-0801]
+---
+
+## What was wrong
+
+`zephyr/Kconfig:209` declares the knob carefully:
+
+```kconfig
+config NROS_CYCLONE_DOMAIN_ID
+    int "DDS domain ID"
+    default NROS_DOMAIN_ID
+    range 0 232
+```
+
+`default NROS_DOMAIN_ID` is the whole safety property: the Cyclone domain
+TRACKS the generic one unless somebody deliberately separates them. `range 0
+232` already respects the ROS spec.
+
+Two places wrote a literal over that default:
+
+* `packages/cli/nros-cli-core/src/cmd/new_entry.rs:612` — the `nros new`
+  template for the cyclonedds backend, so **every generated project** carried
+  `CONFIG_NROS_CYCLONE_DOMAIN_ID=0`;
+* `book/src/getting-started/zephyr.md:188` — the getting-started conf, so the
+  documentation taught the pattern.
+
+A user who then sets `CONFIG_NROS_DOMAIN_ID=5` gets an image running Cyclone on
+0. Nothing reports an error, because the domain is just the first element of
+every discovery key — the peer simply never appears (issue 0801). That is
+phase-180's split-brain (issue 0161) reintroduced by the tooling, and CLAUDE.md
+has carried *"never pin it to a literal in confs"* ever since.
+
+## Why a document was not enough
+
+The rule existed, was correct, and was written in the two files agents read
+most. It still got re-broken — by a code generator and a tutorial, neither of
+which anybody re-reads while editing the other. **A convention that only lives
+in prose is re-broken by tooling.**
+
+## Fix
+
+Both literals removed, so the Kconfig default does what it was written to do.
+Nothing else changes: an image that genuinely wants a separate Cyclone domain
+still sets it, and the ASI consumer the knob exists for is unaffected.
+
+Gated by `check-cyclone-domain-not-pinned.py` on the fast line. It allows the
+declaration in `zephyr/Kconfig` and prose in `docs/`, `CLAUDE.md` and
+`AGENTS.md`, and takes a `nros-allow-cyclone-domain-pin` marker for an image
+that deliberately separates the two — so the escape hatch is explicit rather
+than a guess about intent.
+
+Verified non-vacuous: run against the pre-fix tree it names both sites; after
+the fix it passes. Self-test covers the match, the spacing variant, a bare
+mention, the Kconfig declaration, and the allow-list boundaries.
+
+## Not done: the knob itself
+
+The knob was called cumbersome, and there is something to that — it is a second
+spelling of "which domain am I on", kept safe by a default rather than by
+construction. But removing it is not this issue's call: `main.hpp:320` selects
+it over the generic knob specifically to match an out-of-tree consumer (ASI),
+and nothing here measures what that consumer needs. What this fix does is remove
+the way it silently goes wrong. Whether one knob can replace two is a separate
+question, and it wants that consumer in the room.
+
+## Acceptance
+
+* ~~No tracked conf or template pins the Cyclone domain to a literal.~~ Met.
+* ~~The default in `zephyr/Kconfig` is what generated projects get.~~ Met.
+* ~~The rule is enforced rather than documented.~~ Met, and the gate is proven
+  against the defect it was written for.

--- a/just/check.just
+++ b/just/check.just
@@ -100,7 +100,6 @@ fast:
 [group("main")]
 fast-serial: \
     abi-bindings \
-    cyclone-domain-not-pinned \
     absolute-paths \
     action-client-arena-budget \
     activate-shells \
@@ -142,6 +141,7 @@ fast-serial: \
     cpp-fmt \
     cpp-freestanding-includes \
     cpp-no-std-stdio \
+    cyclone-domain-not-pinned \
     deploy-board-resolves \
     doc-recipe-refs \
     doc-refs \

--- a/just/check.just
+++ b/just/check.just
@@ -100,6 +100,7 @@ fast:
 [group("main")]
 fast-serial: \
     abi-bindings \
+    cyclone-domain-not-pinned \
     absolute-paths \
     action-client-arena-budget \
     activate-shells \
@@ -2199,6 +2200,16 @@ feature-contract:
 [group("ci")]
 no-std-stdio:
     @python3 scripts/check-no-std-stdio.py
+
+# issue 0974 — `CONFIG_NROS_CYCLONE_DOMAIN_ID` defaults to `NROS_DOMAIN_ID` so
+# the two knobs cannot split; pinning a literal breaks that link silently, which
+# is phase-180's split-brain (issue 0161). Both `nros new`'s template and the
+# Zephyr getting-started page were emitting the pin, so every generated
+# cyclonedds project started split-brained and the book taught the pattern.
+[group("check")]
+cyclone-domain-not-pinned:
+    @python3 scripts/check-cyclone-domain-not-pinned.py --self-test
+    @python3 scripts/check-cyclone-domain-not-pinned.py
 
 # issue 0942 — the C++ twin of the rule above. `std::fprintf` in a TU that is
 # cross-compiled for a board's own toolchain depends on a guarantee freestanding

--- a/packages/api/nros-c/src/node.rs
+++ b/packages/api/nros-c/src/node.rs
@@ -29,10 +29,29 @@ use crate::{
 ///
 /// Keeping the decode in one place is the point: this was the same mistake at
 /// two call sites, and a third would have made it three.
-fn resolve_domain_from_c_abi(raw: u8, session_domain: u32) -> u32 {
+fn resolve_domain_from_c_abi(raw: u8, session_domain: u32) -> Option<u32> {
     match nros_node::baked_domain_from_c_abi(raw) {
-        Some(explicit) => explicit,
-        None => session_domain,
+        None => Some(session_domain),
+        // The ROS domain space caps at 232 (`DOMAIN_ID_MAX`). `baked_domain_
+        // from_c_abi` deliberately does NOT range-check — its docstring defers
+        // that to `ExecutorConfig::try_resolve`, which is right for the boot
+        // path but not for here: this resolver feeds entity keyexprs directly
+        // and never goes through `try_resolve`, so 233..=254 would be ASSIGNED
+        // as a domain. An out-of-spec domain is not a smaller problem than a
+        // wrong one — it is unroutable, and silent, because a domain is just
+        // the first element of the discovery key (issue 0801).
+        Some(d) if d > nros_node::DOMAIN_ID_MAX => {
+            nros_log::nros_error!(
+                nros_log::get_logger("nros-c"),
+                "domain id {} exceeds the ROS maximum of {}; refusing to create \
+                 the entity rather than keying it on an unroutable domain \
+                 (issue 0972)",
+                d,
+                nros_node::DOMAIN_ID_MAX
+            );
+            None
+        }
+        Some(explicit) => Some(explicit),
     }
 }
 
@@ -743,7 +762,7 @@ pub(crate) unsafe fn resolve_session_and_domain(
             node.domain_id_override
         } else if !support_ptr.is_null() {
             // issue 0972 — decode, do not read the raw byte.
-            resolve_domain_from_c_abi((*support_ptr).domain_id, session.domain_id())
+            resolve_domain_from_c_abi((*support_ptr).domain_id, session.domain_id())?
         } else {
             session.domain_id()
         };
@@ -765,7 +784,7 @@ pub(crate) unsafe fn resolve_session_and_domain(
         let raw_domain = support_mut.domain_id;
         let session = support_mut.get_session_mut()?;
         // issue 0972 — decode, do not read the raw byte.
-        let domain_id = resolve_domain_from_c_abi(raw_domain, session.domain_id());
+        let domain_id = resolve_domain_from_c_abi(raw_domain, session.domain_id())?;
         Some((session, domain_id))
     }
 }
@@ -787,7 +806,7 @@ mod node_ref_tests {
         // The session is on a different domain, so a fallback would be visible.
         assert_eq!(
             resolve_domain_from_c_abi(crate::support::NROS_DOMAIN_ID_EXPLICIT_ZERO, 7),
-            0,
+            Some(0),
             "explicit-zero must mean domain 0, not the sentinel's own value"
         );
     }
@@ -797,15 +816,44 @@ mod node_ref_tests {
     /// meanings back together.
     #[test]
     fn unset_defers_to_the_session_domain() {
-        assert_eq!(resolve_domain_from_c_abi(0, 7), 7);
-        assert_eq!(resolve_domain_from_c_abi(0, 0), 0);
+        assert_eq!(resolve_domain_from_c_abi(0, 7), Some(7));
+        assert_eq!(resolve_domain_from_c_abi(0, 0), Some(0));
     }
 
     /// An ordinary domain passes through unchanged.
     #[test]
     fn an_explicit_domain_wins_over_the_session() {
-        assert_eq!(resolve_domain_from_c_abi(5, 7), 5);
-        assert_eq!(resolve_domain_from_c_abi(232, 7), 232);
+        assert_eq!(resolve_domain_from_c_abi(5, 7), Some(5));
+        assert_eq!(resolve_domain_from_c_abi(232, 7), Some(232));
+    }
+
+    /// issue 0972 follow-up — the ROS domain space caps at 232, so a byte above
+    /// it is not a domain and must not become one.
+    ///
+    /// `baked_domain_from_c_abi` deliberately does not range-check (its
+    /// docstring defers that to `ExecutorConfig::try_resolve`), and this
+    /// resolver does not go through `try_resolve` — it feeds entity keyexprs
+    /// directly. Without this guard 233..=254 were ASSIGNED as domains:
+    /// unroutable, and silent, because the domain is just the first element of
+    /// the discovery key (issue 0801). Refusing is the loud option available
+    /// here; the caller turns `None` into a failed entity creation.
+    #[test]
+    fn a_domain_above_the_ros_maximum_is_refused_not_assigned() {
+        for raw in [233u8, 240, 254] {
+            assert_eq!(
+                resolve_domain_from_c_abi(raw, 7),
+                None,
+                "domain {raw} exceeds the ROS maximum and must not be assigned"
+            );
+        }
+        // The boundary itself is legal and must still pass.
+        assert_eq!(resolve_domain_from_c_abi(232, 7), Some(232));
+        // 255 is the explicit-zero SENTINEL, not an out-of-range domain — it
+        // must keep decoding to 0 rather than being caught by the range guard.
+        assert_eq!(
+            resolve_domain_from_c_abi(crate::support::NROS_DOMAIN_ID_EXPLICIT_ZERO, 7),
+            Some(0)
+        );
     }
 
     /// The two meanings of "zero" are distinguishable — which is the whole

--- a/packages/cli/nros-cli-core/src/cmd/new_entry.rs
+++ b/packages/cli/nros-cli-core/src/cmd/new_entry.rs
@@ -607,9 +607,16 @@ CONFIG_NROS_XRCE_AGENT_LOCATOR="udp/127.0.0.1:2018"
 CONFIG_MAX_PTHREAD_MUTEX_COUNT=16
 "#
         .to_string(),
+        // issue 0974 — do NOT emit `CONFIG_NROS_CYCLONE_DOMAIN_ID` here.
+        // Its Kconfig default is `NROS_DOMAIN_ID`, which is what keeps the two
+        // knobs from splitting; pinning a literal is what phase-180 did, and it
+        // silently ran every cyclone image on domain 0 while the generic knob
+        // said otherwise (issue 0161). A generated project is the worst place
+        // for that: the user sets `CONFIG_NROS_DOMAIN_ID=5`, cyclone stays on 0,
+        // and discovery just never matches. Leave it unset and let the default
+        // track.
         "cyclonedds" => r#"# Cyclone DDS backend.
 CONFIG_NROS_RMW_CYCLONEDDS=y
-CONFIG_NROS_CYCLONE_DOMAIN_ID=0
 CONFIG_MAX_PTHREAD_MUTEX_COUNT=64
 "#
         .to_string(),

--- a/scripts/check-cyclone-domain-not-pinned.py
+++ b/scripts/check-cyclone-domain-not-pinned.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""`CONFIG_NROS_CYCLONE_DOMAIN_ID` must never be pinned to a literal.
+
+Issue 0974. The knob exists so a Cyclone image can run on a domain of its own,
+and its Kconfig carries `default NROS_DOMAIN_ID` precisely so that it TRACKS the
+generic knob unless someone deliberately separates them. Writing a literal into
+a `prj.conf` breaks that link silently:
+
+    CONFIG_NROS_DOMAIN_ID=5          # what the user set
+    CONFIG_NROS_CYCLONE_DOMAIN_ID=0  # what the image actually uses
+
+Nothing reports an error, because the domain is just the first element of every
+discovery key — the peer simply never appears. That is phase-180's split-brain
+(issue 0161), and CLAUDE.md has carried "never pin it to a literal in confs"
+ever since.
+
+A rule that lives only in a document gets re-broken by tooling that nobody
+re-reads. Both `nros new`'s cyclonedds template and the Zephyr getting-started
+page emitted `CONFIG_NROS_CYCLONE_DOMAIN_ID=0`, so every generated cyclonedds
+project started split-brained and the book taught the pattern.
+
+## What is allowed
+
+* `zephyr/Kconfig` — the DECLARATION, which is where the default lives.
+* Documentation that quotes the hazard in order to warn about it: `docs/`,
+  `CLAUDE.md`, `AGENTS.md`.
+* A conf that genuinely wants a separate domain can still do it — by setting the
+  value through Kconfig with a comment saying why, which this gate asks for via
+  an explicit marker rather than by guessing intent.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PATTERN = re.compile(r"CONFIG_NROS_CYCLONE_DOMAIN_ID\s*=\s*\d")
+MARKER = "nros-allow-cyclone-domain-pin"
+
+# Paths that may legitimately contain the string.
+ALLOWED_PREFIXES = ("docs/", "book/src/reference/")
+ALLOWED_EXACT = {"CLAUDE.md", "AGENTS.md", "zephyr/Kconfig",
+                 "scripts/check-cyclone-domain-not-pinned.py"}
+
+
+def tracked():
+    out = subprocess.run(["git", "ls-files", "-z"], cwd=REPO,
+                         capture_output=True, text=True, check=True).stdout
+    return [n for n in out.split("\0") if n]
+
+
+def allowed(rel: str) -> bool:
+    return rel in ALLOWED_EXACT or rel.startswith(ALLOWED_PREFIXES)
+
+
+def main() -> int:
+    bad = []
+    for rel in tracked():
+        if allowed(rel):
+            continue
+        p = REPO / rel
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except (OSError, IsADirectoryError):
+            continue
+        if "CONFIG_NROS_CYCLONE_DOMAIN_ID" not in text:
+            continue
+        lines = text.splitlines()
+        for i, line in enumerate(lines, start=1):
+            if not PATTERN.search(line):
+                continue
+            if MARKER in line or (i >= 2 and MARKER in lines[i - 2]):
+                continue
+            bad.append((rel, i, line.strip()))
+
+    if not bad:
+        print("check-cyclone-domain-not-pinned: OK "
+              "(no conf pins the cyclone domain to a literal)")
+        return 0
+
+    print("check-cyclone-domain-not-pinned: FAIL\n")
+    for rel, i, line in bad:
+        print(f"  {rel}:{i}: {line}")
+    print(
+        "\n`CONFIG_NROS_CYCLONE_DOMAIN_ID` defaults to `NROS_DOMAIN_ID` in\n"
+        "`zephyr/Kconfig` so the two cannot split. Pinning a literal breaks that\n"
+        "link SILENTLY — the image runs on the pinned domain while the generic\n"
+        "knob says otherwise, and discovery simply never matches because the\n"
+        "domain is the first element of every key (issues 0161, 0974).\n\n"
+        "Drop the line and let the default track. If an image genuinely needs a\n"
+        f"separate Cyclone domain, mark the line `{MARKER}` and say why."
+    )
+    return 1
+
+
+def self_test() -> int:
+    ok = True
+
+    def expect(name, got, want):
+        nonlocal ok
+        if got != want:
+            ok = False
+            print(f"  self-test FAIL {name}: {got!r} != {want!r}")
+
+    expect("matches a pin", bool(PATTERN.search("CONFIG_NROS_CYCLONE_DOMAIN_ID=0")), True)
+    expect("matches spaced", bool(PATTERN.search("CONFIG_NROS_CYCLONE_DOMAIN_ID = 12")), True)
+    expect("ignores a mention", bool(PATTERN.search("see CONFIG_NROS_CYCLONE_DOMAIN_ID for why")), False)
+    expect("ignores the Kconfig decl", bool(PATTERN.search("config NROS_CYCLONE_DOMAIN_ID")), False)
+    expect("docs allowed", allowed("docs/issues/archived/0161-zephyr-cyclonedds-nextest-group-serialized.md"), True)
+    expect("kconfig allowed", allowed("zephyr/Kconfig"), True)
+    expect("cli template NOT allowed",
+           allowed("packages/cli/nros-cli-core/src/cmd/new_entry.rs"), False)
+    expect("book getting-started NOT allowed",
+           allowed("book/src/getting-started/zephyr.md"), False)
+
+    print("check-cyclone-domain-not-pinned --self-test: " + ("OK" if ok else "FAILED"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(self_test() if "--self-test" in sys.argv else main())


### PR DESCRIPTION
Two things, both from the same review point: the domain must obey the ROS spec,
and the second cyclone knob is easy to get wrong.

#0972 FOLLOW-UP — AN OUT-OF-SPEC DOMAIN WAS BEING ASSIGNED. My fix decoded the
C ABI byte correctly but did not range-check it. `baked_domain_from_c_abi`
deliberately does NOT validate — its docstring defers that to
`ExecutorConfig::try_resolve` — and that is right for the boot path, but this
resolver never goes through `try_resolve`: it feeds entity keyexprs directly.
So 233..=254 were used AS domains, above the ROS maximum of 232.

`resolve_domain_from_c_abi` now returns `Option<u32>` and refuses anything above
`DOMAIN_ID_MAX`, logging through `nros_log` and failing the entity creation
rather than keying it on an unroutable domain. 255 still decodes to explicit
zero — it is the sentinel, not an out-of-range domain, and a test pins that
distinction so the guard cannot swallow it.

#0974 — AND THE TOOLING WAS PINNING THE CYCLONE DOMAIN TO A LITERAL, which is
the one thing CLAUDE.md says never to do. `zephyr/Kconfig` declares
`default NROS_DOMAIN_ID` (and `range 0 232`, already spec-correct) so the two
knobs cannot split. Two places overwrote that default:

  packages/cli/nros-cli-core/src/cmd/new_entry.rs:612   the `nros new` template
  book/src/getting-started/zephyr.md:188                the getting-started conf

So EVERY generated cyclonedds project shipped `CONFIG_NROS_CYCLONE_DOMAIN_ID=0`,
and the book taught it. A user who then sets `CONFIG_NROS_DOMAIN_ID=5` gets an
image running Cyclone on 0 with no error, because the domain is just the first
element of every discovery key (#0801) — phase-180's split-brain (#0161)
reintroduced by the tooling.

Both literals removed; the Kconfig default now does what it was written to do.
Gated by `check-cyclone-domain-not-pinned.py` on the fast line, which allows the
declaration and prose that warns about the hazard, and takes an explicit marker
for an image that deliberately separates the two. Proven against the pre-fix
tree: it names both sites, and passes after.

The rule already existed, was correct, and lived in the two files agents read
most — and was still re-broken by a code generator and a tutorial, neither of
which anyone re-reads while editing the other. A convention that only lives in
prose is re-broken by tooling; that is why this is a gate and not a doc edit.

NOT DONE, and deliberately: removing the knob. It was called cumbersome and
there is something to that — it is a second spelling of "which domain am I on",
kept safe by a default rather than by construction. But `main.hpp:320` selects it
over the generic knob to match an out-of-tree consumer (ASI), and nothing here
measures what that consumer needs. This removes the way it silently goes wrong;
whether one knob can replace two wants that consumer in the room.

159/159 fast gates.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2tZGAEZ8rWab5YcDVpFKk