### PR TITLE
fix: a receive buffer is sized for what the transport delivers, not what the message measures

### DIFF
--- a/packages/cli/rosidl-codegen/src/bounds.rs
+++ b/packages/cli/rosidl-codegen/src/bounds.rs
@@ -64,8 +64,14 @@ pub const INVENTORY_CMAKE_NAME: &str = "nros_message_bounds.cmake";
 ///
 /// The two encodings are kept apart because they genuinely differ: XCDR2 adds a
 /// 4-byte DHEADER and aligns 8-byte primitives to 4 instead of 8. `tx` is the
-/// XCDR1 number because this stack WRITES XCDR1; `rx` is the larger of the two
-/// because a receive buffer must hold either.
+/// XCDR1 number because this stack WRITES XCDR1; `rx` is the larger of the two,
+/// because a receive buffer must hold either, rounded up by
+/// [`transport_framed`], because what a transport DELIVERS can exceed the
+/// message by its own framing alignment.
+///
+/// So `rx >= tx` always, and `rx` is not "the message under some encoding" — it
+/// is "what a buffer has to be able to accept". Anything sizing a receive buffer
+/// wants `rx`; anything reporting how big the message is wants `tx`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BoundState {
     /// A bound exists. Bytes, encapsulation header included.
@@ -80,17 +86,61 @@ pub enum BoundState {
     Unresolved { reason: String },
 }
 
+/// Round a serialized size up to the 4-byte multiple a receive buffer must be
+/// able to hold.
+///
+/// The message is `n` bytes. What a transport DELIVERS can be up to three bytes
+/// more, and a receive buffer sized to `n` exactly will refuse those bytes
+/// rather than truncate them — correctly, and with the message lost.
+///
+/// Measured, not assumed. A 25-byte `std_msgs/String` published by ROS 2 Humble
+/// over stock `rmw_cyclonedds` arrives at the nano-ros Cyclone backend as:
+///
+/// ```text
+/// WIRE=len:28 hdr:00010000 cdr:25
+/// ```
+///
+/// The three extra bytes are the RTPS submessage's own 4-byte alignment, added
+/// by the SENDER; the encapsulation options read `0000` rather than `0003`, so
+/// the pad is not even discoverable from the header. The backend adds nothing —
+/// it hands back exactly what the wire gave it (issues 0969 / 0970) — which is
+/// precisely why the pad now reaches the buffer sizing instead of being absorbed
+/// by a re-encode.
+///
+/// This is deliberately NOT folded into the type's own bound. `MAX_SERIALIZED_SIZE`
+/// answers "how big is this message", and issue 0964 exists because that number
+/// had been fudged before; the answer stays exact. Framing is a property of the
+/// transport, so it is applied where a RECEIVE BUFFER is sized and nowhere else.
+/// TX keeps the exact figure: we write what we serialise.
+///
+/// Four is not a Cyclone number. RTPS aligns submessages to 4, and CDR itself
+/// aligns to at most 8 within a 4-aligned encapsulation, so 4 is the alignment
+/// any DDS peer can impose. A transport that framed more coarsely would need its
+/// own allowance, which is why this is a named function and not a `+ 3`.
+///
+/// The Rust runtime applies the same rounding in
+/// `nros_node::rmw_type_registry::subscription_rx_bytes`; both are cited from
+/// each other so the two cannot drift into disagreeing.
+pub const fn transport_framed(bound: usize) -> usize {
+    bound.next_multiple_of(4)
+}
+
 impl BoundState {
     /// The one place the two per-encoding answers become a TX/RX pair.
     ///
     /// The C header emitter (`generator::msg`) calls this too, so the constants
     /// in a generated header and the numbers in the inventory cannot drift into
     /// disagreeing about which encoding feeds which direction.
+    ///
+    /// RX takes the larger of the two encodings AND rounds it up to a 4-byte
+    /// multiple — see [`transport_framed`] for why that rounding is not padding
+    /// anyone chose. TX stays exact: we write what we serialise, and the framing
+    /// underneath is the transport's business.
     pub fn classify(xcdr1: &TypeBound, xcdr2: &TypeBound) -> Self {
         match (xcdr1, xcdr2) {
             (TypeBound::Bounded(a), TypeBound::Bounded(b)) => BoundState::Bounded {
                 tx: *a,
-                rx: *a.max(b),
+                rx: transport_framed(*a.max(b)),
             },
             // Unbounded wins over Unresolved when both appear: "there is no
             // bound" is a fact about the message, and it stays true however the
@@ -689,6 +739,44 @@ mod tests {
             .unwrap()
             .clone();
         assert_eq!(e.bound, BoundState::Bounded { tx: 12, rx: 16 });
+    }
+
+    /// RX carries the transport's framing allowance and TX does not.
+    ///
+    /// `classify` is a pure function of the two encoding bounds, so this pins
+    /// the rule directly rather than hunting a corpus type whose bound happens
+    /// to be misaligned. The numbers are chosen so every case is visible: 13
+    /// rounds to 16, 16 stays 16, and TX is 13 either way — we write what we
+    /// serialise.
+    #[test]
+    fn rx_allows_for_transport_framing_and_tx_does_not() {
+        assert_eq!(
+            BoundState::classify(&TypeBound::Bounded(13), &TypeBound::Bounded(13)),
+            BoundState::Bounded { tx: 13, rx: 16 },
+            "a 13-byte message can arrive as 16 — see `transport_framed`"
+        );
+        assert_eq!(
+            BoundState::classify(&TypeBound::Bounded(16), &TypeBound::Bounded(16)),
+            BoundState::Bounded { tx: 16, rx: 16 },
+            "an already-aligned bound must not be inflated"
+        );
+        // The larger encoding still wins, and THEN gets the allowance.
+        assert_eq!(
+            BoundState::classify(&TypeBound::Bounded(13), &TypeBound::Bounded(17)),
+            BoundState::Bounded { tx: 13, rx: 20 },
+            "RX is max(xcdr1, xcdr2) framed, not max(framed, framed) of one"
+        );
+    }
+
+    /// A 25-byte message is the one this was measured on: ROS 2 Humble over
+    /// stock `rmw_cyclonedds` delivers it as 28 bytes (`WIRE=len:28 cdr:25`),
+    /// and a buffer sized to 25 refuses it.
+    #[test]
+    fn the_measured_case_is_covered() {
+        assert_eq!(transport_framed(25), 28);
+        assert_eq!(transport_framed(28), 28);
+        assert_eq!(transport_framed(0), 0);
+        assert_eq!(transport_framed(1), 4);
     }
 
     /// The whole point of the wave: an unbounded type is a MARKER plus the

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.h
@@ -89,7 +89,7 @@ const nros_message_type_t* fingerprint_corpus_msg_bounded_get_type_support(void)
 /// publish helper below uses that one; a RECEIVE buffer must hold either, so a
 /// subscription wants the larger.
 #define FINGERPRINT_CORPUS_MSG_BOUNDED_TX_MAX_SERIALIZED_SIZE 133
-#define FINGERPRINT_CORPUS_MSG_BOUNDED_RX_MAX_SERIALIZED_SIZE 133
+#define FINGERPRINT_CORPUS_MSG_BOUNDED_RX_MAX_SERIALIZED_SIZE 136
 
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.h
@@ -85,7 +85,7 @@ const nros_message_type_t* fingerprint_corpus_msg_capped_get_type_support(void);
 /// publish helper below uses that one; a RECEIVE buffer must hold either, so a
 /// subscription wants the larger.
 #define FINGERPRINT_CORPUS_MSG_CAPPED_TX_MAX_SERIALIZED_SIZE 157
-#define FINGERPRINT_CORPUS_MSG_CAPPED_RX_MAX_SERIALIZED_SIZE 157
+#define FINGERPRINT_CORPUS_MSG_CAPPED_RX_MAX_SERIALIZED_SIZE 160
 
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.h
@@ -89,7 +89,7 @@ const nros_message_type_t* fingerprint_corpus_msg_bounded_get_type_support(void)
 /// publish helper below uses that one; a RECEIVE buffer must hold either, so a
 /// subscription wants the larger.
 #define FINGERPRINT_CORPUS_MSG_BOUNDED_TX_MAX_SERIALIZED_SIZE 133
-#define FINGERPRINT_CORPUS_MSG_BOUNDED_RX_MAX_SERIALIZED_SIZE 133
+#define FINGERPRINT_CORPUS_MSG_BOUNDED_RX_MAX_SERIALIZED_SIZE 136
 
 
 /// Typed publish helper. Serializes `msg` into a stack buffer sized from the

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -354,6 +354,61 @@ fn an_unbounded_type_yields_no_receive_buffer_size() {
     );
 }
 
+/// A message whose bound is NOT a multiple of 4 — one `int8`, so 4 bytes of
+/// encapsulation plus 1.
+///
+/// `TestMsg` cannot test the framing allowance: a single `i32` bounds at 8,
+/// which is already aligned, so rounding is a no-op and the assertion passes
+/// whether or not the code rounds. This fixture exists so the test can fail.
+/// Only `schema::Message` — `subscription_rx_bytes` asks for nothing else, and
+/// the bound is a property of the schema rather than of the transport traits.
+struct OddBoundTestMsg;
+
+impl nros_serdes::schema::Message for OddBoundTestMsg {
+    const TYPE_NAME: &'static str = "test/msg/OddBoundTestMsg";
+    const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
+        name: "data",
+        ty: nros_serdes::schema::FieldType::Int8,
+        offset: 0,
+    }];
+}
+
+/// The receive buffer carries the transport's framing allowance, so it is the
+/// bound rounded UP to 4 rather than the bound itself.
+///
+/// Measured, not assumed: a 25-byte message published by ROS 2 Humble over stock
+/// `rmw_cyclonedds` reaches the Cyclone backend as 28 bytes — the RTPS
+/// submessage's own alignment, applied by the sender. A buffer sized to the
+/// exact bound refuses it, correctly and with the message lost. See
+/// `rmw_type_registry::transport_framed`.
+#[test]
+fn the_receive_buffer_allows_for_transport_framing() {
+    let bound = nros_serdes::size::max_serialized_bound::<OddBoundTestMsg>().unwrap();
+    assert_ne!(
+        bound % 4,
+        0,
+        "this fixture only proves anything while its bound is misaligned"
+    );
+    assert_eq!(
+        crate::rmw_type_registry::subscription_rx_bytes::<OddBoundTestMsg>(
+            crate::config::DEFAULT_RX_BUF_SIZE
+        ),
+        Some(bound.next_multiple_of(4)),
+        "the receive buffer must hold what the transport delivers, not just what \
+         the message measures"
+    );
+
+    // An already-aligned type must not be inflated.
+    let aligned = nros_serdes::size::max_serialized_bound::<TestMsg>().unwrap();
+    assert_eq!(aligned % 4, 0, "TestMsg is the aligned control case");
+    assert_eq!(
+        crate::rmw_type_registry::subscription_rx_bytes::<TestMsg>(
+            crate::config::DEFAULT_RX_BUF_SIZE
+        ),
+        Some(aligned),
+    );
+}
+
 /// A type whose bound EXCEEDS the ceiling keeps the ceiling. Growing here would
 /// spend arena the caller never budgeted.
 #[test]

--- a/packages/core/nros-node/src/rmw_type_registry.rs
+++ b/packages/core/nros-node/src/rmw_type_registry.rs
@@ -223,10 +223,43 @@ pub const fn subscription_rx_bytes<M: nros_serdes::schema::Message>(
     rx_buf: usize,
 ) -> Option<usize> {
     match nros_serdes::size::max_serialized_bound::<M>() {
-        Some(bound) if bound < rx_buf => Some(bound),
-        Some(_) => Some(rx_buf),
+        Some(bound) => {
+            let framed = transport_framed(bound);
+            Some(if framed < rx_buf { framed } else { rx_buf })
+        }
         None => None,
     }
+}
+
+/// Round a serialized size up to the 4-byte multiple a receive buffer must be
+/// able to hold.
+///
+/// The message is `bound` bytes. What a transport DELIVERS can be up to three
+/// bytes more, and a buffer sized to `bound` exactly refuses those bytes rather
+/// than truncating them — correctly, and with the message lost.
+///
+/// Measured, not assumed. A 25-byte `std_msgs/String` published by ROS 2 Humble
+/// over stock `rmw_cyclonedds` arrives at the Cyclone backend as
+/// `len:28 hdr:00010000 cdr:25` — three bytes of RTPS submessage alignment added
+/// by the SENDER, with the encapsulation options reading `0000` rather than
+/// `0003`, so the pad is not discoverable from the header either. The backend
+/// hands back exactly what the wire gave it (issues 0969 / 0970), which is why
+/// the pad reaches buffer sizing now instead of being absorbed by a re-encode.
+///
+/// Deliberately NOT folded into `max_serialized_bound`. That answers "how big is
+/// this message", and issue 0964 exists because that number had been fudged
+/// before — it stays exact. Framing is the transport's, so it is applied where a
+/// RECEIVE BUFFER is sized and nowhere else.
+///
+/// Four is not a Cyclone number: RTPS aligns submessages to 4, so it is the
+/// alignment any DDS peer can impose. A transport that framed more coarsely
+/// would need its own allowance, which is why this is a named function and not
+/// a `+ 3`.
+///
+/// `rosidl_codegen::bounds::transport_framed` is the same rule for the C and C++
+/// constants; the two cite each other so they cannot drift apart.
+const fn transport_framed(bound: usize) -> usize {
+    bound.next_multiple_of(4)
 }
 
 /// Phase 380 W4 — can a default-sized receive buffer hold every message of `M`?


### PR DESCRIPTION
**Should land before #162.** That PR makes the derived bound exact (fixes #964); this makes sure an exactly-bound-sized receive buffer can still hold what a peer actually sends.

## The measurement

A 25-byte message published by ROS 2 Humble over stock `rmw_cyclonedds` reaches the nano-ros Cyclone backend as **28 bytes**:

```
WIRE=len:28 hdr:00010000 cdr:25
```

Three bytes of the RTPS submessage's own 4-byte alignment, applied by the **sender**. The encapsulation options read `0000`, not `0003`, so the pad isn't discoverable from the header either. A buffer sized to the exact bound refuses that message — correctly, by the take contract, and with the message lost.

## This is newly reachable, and it is my own doing

Before #0969/#0970 the Cyclone take re-serialised the sample, which produced an unpadded length that fit an exactly-sized buffer. Handing back the wire bytes hands back the wire's framing with them. It stays latent only while the bound is an over-estimate — which is exactly what #162 removes.

## The fix

Applied where a **receive buffer** is sized, and deliberately nowhere else. `MAX_SERIALIZED_SIZE` answers "how big is this message", and #964 exists because that number had been fudged before — it stays exact, and TX stays exact with it, because we write what we serialise.

Two mirrored sites already carried the "RX needs more than TX" idea and now carry this too:

- `rosidl-codegen` `bounds::classify` → `{PREFIX}_RX_MAX_SERIALIZED_SIZE` for C/C++, plus the JSON/CMake inventory.
- `nros-node` `rmw_type_registry::subscription_rx_bytes` → the arena.

Each cites the other so they can't drift. Four is not a Cyclone number — RTPS aligns submessages to 4, so it's the alignment any DDS peer can impose — and it's a named function rather than a `+ 3` so a coarser transport can be given its own allowance later.

Golden headers move exactly as intended and only on RX: **133 → 136**, **157 → 160**.

## The test needed a fixture to be worth anything

My first version asserted against `TestMsg`, whose bound is 8 — already aligned, so rounding is a no-op and **it passed with the fix neutered**. `OddBoundTestMsg` exists so the test can fail, and it does: `Some(9)` vs `Some(12)` with the allowance removed. `TestMsg` stays as the aligned control case, so an over-eager future change that inflates every buffer is caught too.

The codegen side pins `classify` directly — 13→16, 16→16, and `max(13,17)` → 20, so "RX is max-then-frame" rather than "frame-then-max".

## Testing

- `cargo test -p nros-node --lib --features std` — 292 passed.
- `rosidl-codegen` — all suites green; golden regenerated via `NROS_UPDATE_GOLDEN=1`.
- `just check` — 2 of 158 gates fail (`kconfig-overridden-values`, `fixtures-manifest`), the same two that fail on a clean tree: `nros: command not found` in a fresh worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
