### PR TITLE
feat(phase-400 W6): the memory tenant, one reader for the build rungs, and two of my own mistakes

### DIFF
--- a/docs/roadmap/phase-349-rtos-integration-shells.md
+++ b/docs/roadmap/phase-349-rtos-integration-shells.md
@@ -1,7 +1,9 @@
 # Phase 349 — RTOS integration: make FreeRTOS an imported library like the rest
 
-**Status (2026-08-13). W1 LANDED — with it, [phase-348](archived/phase-348-source-time-provider-discovery.md)
-is complete. W2–W6 open.**
+**Status (2026-09-01). W1 LANDED — with it,
+[phase-348](archived/phase-348-source-time-provider-discovery.md) is complete.
+W2 is UNBLOCKED (its prerequisite exists now; see its note) but not started.
+W3–W6 open.**
 
 **Implements:** [RFC-0072](../design/0072-rtos-integration-nano-ros-is-a-guest.md).
 
@@ -49,11 +51,37 @@ continuing to address the platform by its alias, which is why that test still
 does so on purpose. The claim that `chain()` was the single funnel was written
 in a comment before it was checked; it is true of three lookups out of four.
 
-## W2 — The stack becomes a declared fact — **BLOCKED**
+## W2 — The stack becomes a declared fact — **UNBLOCKED (2026-09-01), not started**
 
-> **Blocked on a prerequisite that does not exist: there is no channel carrying
-> a BOARD fact to a build script.** Investigated 2026-08-13, before writing any
-> W2 code.
+> **The prerequisite now exists. The note below is kept because its reasoning
+> was right and its central claim has since become false.**
+>
+> It says "nothing anywhere sets that variable (`git grep NROS_BOARD_TOML`
+> outside docs finds only the reader)". `cmd/board_facts.rs` sets it, phase-351
+> built the cmake-side delivery (`NanoRosBoardFacts.cmake` +
+> `corrosion_set_env_vars`, which attaches to the target's own build command —
+> the reason `set(ENV{...})` was not enough), and W2.0 was superseded by that
+> wave. phase-400 W6 then proved the channel end to end in a different build
+> script: `nros-node/build.rs` reads `NROS_BOARD_TOML` and resolves the board
+> rung of the knob ladder, using exactly the `watch_path` hazard this note
+> names.
+>
+> `NROS_NETSTACK` is emitted too (`board_facts.rs:210`) and **nothing reads it**
+> — the same declared-but-unread shape, now with a writer and no consumer
+> rather than a reader and no writer.
+>
+> **What W2 still needs, and where to start.** Not the channel: the SELECTION
+> SITE. `LinkPolicy::freertos_lwip()` (`runner.rs:1011`) hardcodes FreeRTOS ⇒
+> lwIP, and the upstream port row exists
+> (`zenoh-pico/src/system/freertos/freertos_plus_tcp/`). But the C sources for
+> a port are not chosen from a Rust source list — `add_common_c_sources` adds
+> only `system/common` and has no caller for the platform dir — so the netstack
+> selection is reached through zenoh-pico's own CMake, driven by compile
+> definitions. Locate that before writing code; this was checked on 2026-09-01
+> and is where the previous investigation would otherwise restart from the
+> wrong end.
+
+> Original note, 2026-08-13, before writing any W2 code:
 >
 > Every bullet below needs `netstack` to be readable by
 > `nros-zpico-build/src/runner.rs` at build time, so it can pick the

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -362,3 +362,89 @@ finished business.
   are classified explicitly now, and an unclassified name FAILS the gate: a new
   knob has to be decided about (ladder? derived? infra?) rather than guessed at
   by a heuristic, which is how a backlog number stops meaning anything.
+
+---
+
+<!-- Restored 2026-09-01. W7, W8 and the scope note below were deleted by
+     accident in the phase-400 W6 census commit: a section replacement anchored
+     on "### Remaining tenants" ran to END OF FILE and took everything after it.
+     Recovered verbatim from caa634aff~1. -->
+
+## W7 — core's exclusive features — DONE, and the premise was wrong
+
+**Audited 2026-08-30. No work outstanding.** This wave was scoped from a claim
+that did not survive checking, and the correction is recorded here rather than
+quietly dropped.
+
+The claim: `nros-node`'s `scheduler-fifo` / `-edf` / `-bucketed` / `-sporadic`
+is a pick-one family expressed in an additive mechanism, guarded by five
+`compile_error!` calls standing in for the constraint Cargo cannot express.
+
+What the tree actually says, three lines above those declarations:
+
+> Each flag is independent; multiple may be on simultaneously when runtime
+> selection across classes is needed.
+
+The `cfg` sites agree — they gate scheduler classes in, additively. The five
+`compile_error!` guards are feature IMPLICATIONS (`param-services` needs
+`alloc`), not exclusivity. Every `cfg(not(feature = …))` in core is the correct
+no_std shape. And `packages/api/nros/src/lib.rs` records that a platform
+mutual-exclusion `compile_error!` was deliberately *removed* — the tree has
+already learned this lesson.
+
+The error was inferring exclusivity from a naming family without reading the
+comment above it.
+
+**What survives.** RFC-0086 D5's rule stands on its own footing: Cargo features
+are additive by contract, so they cannot express "off over an on-default",
+which RFC-0049 requires of a front-end. That is a constraint on new knobs,
+enforced at review. It simply has no backlog attached.
+
+**Gate.** Satisfied on audit: no `compile_error!` in core stands in for an
+exclusivity constraint, and no core feature encodes a negative.
+
+---
+
+## W8 — retire the old paths
+
+Retirement is a wave, not a side effect, because a mechanism that still
+resolves is a mechanism people still use.
+
+* A migrated knob's old reader is **deleted**, not left as a fallback. A
+  fallback that silently wins is how issue 0135/0316 happened: two consumers
+  disagreeing about one value with no diagnostic.
+* Env vars that were the *only* home for a knob before nano-ros #0749/#0752
+  keep their names as front-ends. Env vars that duplicated a ladder knob are
+  removed.
+* `config/<name>/nros-platform.toml` stops being read after W1's grace period.
+* A gate asserts no knob has two readers.
+
+**Gate.** For every migrated knob, exactly one reader exists, and
+`nros config explain` is the only way to learn its value.
+
+---
+
+## Risks, and the ones already realised
+
+* **A fallback left in place wins silently.** Realised twice: issue 0135 and
+  issue 0316, both "two consumers disagreed about a struct's size with no
+  diagnostic". W8's one-reader gate exists for this.
+* **A drift test that mirrors nothing.** RFC-0049's mirror test is only as good
+  as its coverage; W5 must extend it to the new `depends on`, or the Kconfig
+  projection silently diverges.
+* **Migrating a knob without its coupling.** A sizing knob moved into the
+  ladder with its implications left in a `.conf` file is worse than not moving
+  it — the value looks authoritative and is not. Move the rule with the knob.
+* **`implies` implemented as `select`.** The single most likely wrong turn, and
+  the one the surveyed prior art most clearly warns against.
+
+## What this phase does NOT do
+
+* It does not change the four-rung ladder or its order. RFC-0049's precedence
+  is correct.
+* It does not touch the runtime seam (`nros_rmw_vtable_t`, RFC-0035).
+* It does not introduce a constraint solver. `requires` validates and `implies`
+  enforces; picking a satisfying assignment reintroduces the opacity W4 exists
+  to prevent.
+* It does not migrate RFC-0045's boot-config resolution, which is the runtime
+  half of the same story and lands separately.

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -256,27 +256,57 @@ a board rung applies (`max_sc = 23`), the env front-end still wins over both
 `NROS_PLATFORM_NAME` — a bare `cargo build` with no lane — nothing changes:
 with no board named there IS no platform rung to resolve.
 
-### Remaining tenants — re-ordered from the census, 2026-09-01
+### The zenoh tenant is NOT W6's — re-scoped 2026-09-01
 
-The wave opened with "then the zenoh pools, then the per-entity caps", ordered
-by an estimate. The census orders it by measurement, and the estimate was
-right about zenoh being next and wrong about it being a separate thing from the
-caps — **the caps ARE zenoh's**:
+Going to migrate it revealed that most of it belongs to a different campaign,
+and this is the second family in a row where that is true.
 
-| family | sizing knobs | note |
+`ZPICO_MAX_QUERYABLES` is already a CHECKED OVERRIDE over a derived default
+(phase-392 W5.f: "stops being an independent opinion"). `ZPICO_MAX_SESSIONS`
+is posed by that phase explicitly — "either it joins the model or it stays a
+knob and this phase says so". `SERVICE_BUFFERS` is a product of the two. So the
+zenoh entity caps and pools are phase-392's question, and giving them a
+platform/board rung now would answer it the wrong way: a rung gives a global a
+per-platform default, and phase-392 is deciding whether these stop being
+globals at all.
+
+Same shape as the buffers one family over (phase-403). The census marks both
+`derived` and names the owning campaign, so the backlog count stops inviting
+the mistake.
+
+**W6's own backlog is therefore 23, not 31**, and its largest families are:
+
+| family | knobs | note |
 | --- | --- | --- |
-| `ZPICO_*` | **15** | entity caps (publishers, subscribers, queryables, sessions, liveliness, pending gets), wire batch buffers, fragmentation, reply staging, two transport-band priorities |
-| `NROS_MAX_*` | 5 | message and parameter bounds |
-| `NROS_RUNTIME_*` | 4 | component caps |
-| platform heap/stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB` |
+| `NROS_MAX_*` | 5 | PARAMETER value bounds, in `nros-params/build.rs`. Not message bounds — that mislabel is corrected in the census. |
+| `NROS_RUNTIME_*` | 4 | component caps. Worth asking whether these are derivable from the declared component set before migrating — the same question phase-392 asks of the zenoh caps. |
+| platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
+| `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
 
-Plus 85 `CONFIG_NROS_*` Kconfig declarations, whose largest family is also
-zenoh (24), then XRCE (8), `NROS_MAX` (7), RMW (5), Zephyr (4).
+**The lesson for the wave, stated once:** "migrate the long tail into the
+ladder" was the right instinct for the executor tenant and is the wrong default
+for the rest. A number that can be DERIVED from what the image declares should
+be, and the ladder is for the ones that genuinely vary by platform or board.
+Check for an owning campaign before migrating a family.
 
-**So: the zenoh tenant next, and it is one tenant, not two.**
+### Ordering, from the census
 
-### Five knobs must NOT be migrated
+The wave opened with "then the zenoh pools, then the per-entity caps", by
+estimate. The census contradicts it twice over: the caps are not separate from
+the pools (they are all zenoh's), and zenoh is not W6's to migrate at all — see
+the section above. What is left after removing the derivation campaigns' work
+is the table there, and the clearest tenant in it is the platform heap/stack
+trio, which no campaign is deriving and which genuinely varies by platform.
+
+Kconfig is unchanged by this: 85 declarations, largest family zenoh (24), then
+XRCE (8), `NROS_MAX` (7), RMW (5), Zephyr (4). Whether those follow their env
+counterparts into another campaign has not been checked.
+
+### Thirteen knobs must NOT be migrated
+
+Five are receive/transmit buffers (phase-403 / phase-408) and eight are the
+zenoh entity caps and pools (phase-392) — see the re-scope above.
 
 `NROS_SUBSCRIPTION_BUFFER_SIZE`, `ZPICO_SUBSCRIBER_BUFFER_SIZE`,
 `ZPICO_SUBSCRIBER_LARGE_SIZE`, `ZPICO_SUBSCRIBER_SIZE_THRESHOLD` and

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -256,6 +256,33 @@ a board rung applies (`max_sc = 23`), the env front-end still wins over both
 `NROS_PLATFORM_NAME` — a bare `cargo build` with no lane — nothing changes:
 with no board named there IS no platform rung to resolve.
 
+### `[knobs.memory]` — the platform heap and stack — DONE (2 of 3)
+
+The tenant the re-scope below identified as the clearest one left: numbers that
+genuinely vary by platform and board, that no derivation campaign owns.
+
+`NROS_FREERTOS_HEAP_KB` and `NROS_FREERTOS_APP_STACK_KB` now resolve over the
+full ladder and print in `nros config explain`. `NROS_ZEPHYR_HEAP_SIZE` is the
+third and is NOT done — it is read by `option_env!` in `nros-platform`'s
+source with its own build-script resolver, so it needs that crate to take the
+`nros-board-common` build-dep first, the same decision phase-400 W6 already
+made for `nros-node`.
+
+**Stored in BYTES, always.** The front-ends disagree about units — the FreeRTOS
+pair is KiB, Zephyr's is bytes — and a table where "heap" means one thing on
+one platform and another elsewhere is a unit bug waiting to be written. The
+env names keep their spellings and the rung converts, in one place.
+
+The env-pointer dance is now written ONCE, as
+`platform_config::BuildRungs::from_build_env()`. `nros-node/build.rs` grew its
+own copy when the executor tenant landed; two build scripts resolving the same
+rungs differently is precisely the drift `check-knob-single-reader` exists to
+catch one level up, so the shared version is the one to use and that copy
+should adopt it.
+
+Verified against the running tool: builtin, platform rung, and the env
+front-end converting KiB to bytes (`NROS_FREERTOS_HEAP_KB=4096` → 4194304).
+
 ### The zenoh tenant is NOT W6's — re-scoped 2026-09-01
 
 Going to migrate it revealed that most of it belongs to a different campaign,

--- a/packages/boards/nros-board-common/src/freertos_build.rs
+++ b/packages/boards/nros-board-common/src/freertos_build.rs
@@ -129,7 +129,14 @@ pub fn add_lwip_includes(build: &mut cc::Build, lwip_dir: &Path) {
 /// `NROS_FREERTOS_APP_STACK_KB`. Emits the `rerun-if-env-changed` line.
 pub fn app_stack_bytes_from_build_env() -> u32 {
     println!("cargo:rerun-if-env-changed=NROS_FREERTOS_APP_STACK_KB");
-    app_stack_bytes(env::var("NROS_FREERTOS_APP_STACK_KB").ok().as_deref())
+    let builtin = app_stack_bytes(None);
+    // phase-400 W6 — the platform and board rungs, beneath the env front-end
+    // that still wins. `None` when no lane named a platform, which is a bare
+    // `cargo build`: then this is exactly the env-or-default it always was.
+    match crate::platform_config::BuildRungs::from_build_env() {
+        Some(rungs) => rungs.memory_value("app_stack_bytes", builtin as usize) as u32,
+        None => app_stack_bytes(env::var("NROS_FREERTOS_APP_STACK_KB").ok().as_deref()),
+    }
 }
 
 /// Write the board's `NROS_APP_CONFIG` definition into `out_dir` and return the

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -159,6 +159,9 @@ pub struct Knobs {
     /// and board rung, and makes them visible to `nros config explain`.
     #[serde(default)]
     pub executor: ExecutorKnobs,
+    /// phase-400 W6 — the platform memory tenant (RTOS heap, app stack).
+    #[serde(default)]
+    pub memory: MemoryKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -222,6 +225,87 @@ pub const EXECUTOR_KNOBS: &[&str] = &[
     "param_service_buffer_size",
 ];
 
+/// The platform and board rungs a BUILD SCRIPT can reach, resolved once.
+///
+/// phase-400 W6. A build script learns its platform and board the way every
+/// other build-time fact travels here: the lane exports a value and a POINTER,
+/// and the script reads the file. `nros ws board-facts` emits
+/// `NROS_PLATFORM_NAME` and `NROS_BOARD_TOML`, and `corrosion_set_env_vars`
+/// attaches them to the target's own build command — which is what actually
+/// runs cargo, unlike cmake's `set(ENV{...})` (issue 0460).
+///
+/// Absent pointer (a bare `cargo build` with no lane) → `None`, and the
+/// caller's own front-end and default decide, exactly as before. With no board
+/// named there IS no platform rung to resolve.
+///
+/// Every failure here is FATAL rather than a fall-through to defaults: a
+/// silently empty tree resolves every knob to a builtin and produces a wrong
+/// image with no diagnostic, which is the failure the ladder exists to remove.
+/// It lives HERE so the env-pointer dance has ONE spelling — two build scripts
+/// resolving the same rungs differently is the drift
+/// `check-knob-single-reader` exists to catch, one level up.
+pub struct BuildRungs {
+    pub platform: String,
+    pub tree: PlatformsTree,
+    pub board: Option<BoardKnobsFile>,
+}
+
+impl BuildRungs {
+    /// Resolve from the environment the lane exports, or `None` when no lane
+    /// named a platform.
+    pub fn from_build_env() -> Option<Self> {
+        let platform = std::env::var("NROS_PLATFORM_NAME")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        println!("cargo:rerun-if-env-changed=NROS_PLATFORM_NAME");
+
+        let board = std::env::var("NROS_BOARD_TOML")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|raw| {
+                // issue 0491 — fingerprint the file's CONTENT. A
+                // `rerun-if-env-changed` on a variable naming a PATH compares
+                // the spelling, and one directory has three spellings here.
+                println!("cargo:rerun-if-changed={raw}");
+                BoardKnobsFile::load(Path::new(&raw))
+                    .unwrap_or_else(|e| panic!("NROS_BOARD_TOML={raw}: {e}"))
+            });
+
+        let search = PlatformsTree::default_search_path(
+            &std::env::current_dir().unwrap_or_default(),
+            std::env::var("NROS_PLATFORMS_DIR").ok().as_deref(),
+        );
+        let tree = PlatformsTree::load_search_path(&search)
+            .unwrap_or_else(|e| panic!("platform search path {search:?}: {e}"));
+        Some(Self {
+            platform,
+            tree,
+            board,
+        })
+    }
+
+    /// The memory tenant for this build, over the full ladder.
+    pub fn memory(&self, defaults: &[(&'static str, usize)]) -> Vec<(&'static str, ResolvedUsize)> {
+        self.tree
+            .resolve_memory(
+                &self.platform,
+                self.board.as_ref().map(|b| &b.knobs.memory),
+                &|k| std::env::var(k).ok(),
+                defaults,
+            )
+            .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={}: {e}", self.platform))
+    }
+
+    /// One resolved memory knob, by name.
+    pub fn memory_value(&self, knob: &'static str, default: usize) -> usize {
+        self.memory(&[(knob, default)])
+            .into_iter()
+            .next()
+            .map(|(_, r)| r.value)
+            .unwrap_or(default)
+    }
+}
+
 /// The env front-end name for an executor knob. These are the EXISTING names
 /// `nros-node/build.rs` already reads, kept verbatim: migrating a knob into the
 /// ladder must not change how anyone sets it.
@@ -269,6 +353,52 @@ pub struct ExecutorKnobs {
     pub arena_size: Option<usize>,
     pub subscription_buffer_size: Option<usize>,
     pub param_service_buffer_size: Option<usize>,
+}
+
+/// `[knobs.memory]` — phase-400 W6, the platform memory tenant.
+///
+/// The RTOS heap and the application task's stack: two numbers that genuinely
+/// vary by PLATFORM and BOARD and that no derivation campaign owns, which is
+/// what makes them the ladder's business rather than phase-392's or
+/// phase-403's.
+///
+/// **Stored in BYTES, always.** Their env front-ends disagree about units —
+/// `NROS_FREERTOS_HEAP_KB` and `NROS_FREERTOS_APP_STACK_KB` are KiB,
+/// `NROS_ZEPHYR_HEAP_SIZE` is bytes — and a table where "heap" means one thing
+/// on one platform and another elsewhere is a unit bug waiting to be written.
+/// The front-ends keep their spellings and convert; the ladder has one unit.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryKnobs {
+    /// The RTOS heap this platform sizes, in bytes.
+    #[serde(default)]
+    pub heap_bytes: Option<usize>,
+    /// The application task's stack, in bytes.
+    #[serde(default)]
+    pub app_stack_bytes: Option<usize>,
+}
+
+/// Every memory knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const MEMORY_KNOBS: &[&str] = &["heap_bytes", "app_stack_bytes"];
+
+/// The env front-end for a memory knob. As with the executor tenant these are
+/// the EXISTING names, kept verbatim — migrating a knob into the ladder must
+/// not change how anyone sets it.
+///
+/// The FreeRTOS pair is the platform that sizes both today; Zephyr's heap has
+/// its own spelling and is resolved by `nros-platform`'s build script.
+pub fn memory_env_key(knob: &str) -> &'static str {
+    match knob {
+        "heap_bytes" => "NROS_FREERTOS_HEAP_KB",
+        "app_stack_bytes" => "NROS_FREERTOS_APP_STACK_KB",
+        other => panic!("unknown memory knob `{other}`"),
+    }
+}
+
+/// Whether a memory knob's env front-end is spelled in KiB rather than bytes.
+/// The ladder stores bytes; this is the one place the difference lives.
+pub fn memory_env_is_kib(knob: &str) -> bool {
+    matches!(knob, "heap_bytes" | "app_stack_bytes")
 }
 
 /// One resolved executor knob: value, rung, and the env name that is still its
@@ -850,6 +980,78 @@ impl PlatformsTree {
     ///
     /// Each knob keeps its existing env name, so migrating a knob changes no
     /// call site — it only adds the two rungs it never had.
+    /// The `[knobs.memory]` a platform's chain declares, merged nearest-wins.
+    fn platform_memory_knobs(&self, name: &str) -> Result<MemoryKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = MemoryKnobs::default();
+        for file in chain.iter().rev() {
+            let m = &file.knobs.memory;
+            if m.heap_bytes.is_some() {
+                out.heap_bytes = m.heap_bytes;
+            }
+            if m.app_stack_bytes.is_some() {
+                out.app_stack_bytes = m.app_stack_bytes;
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.memory]` rungs, without resolution — for a build script that
+    /// owns the defaults and its own env/Kconfig front-end. Same shape as
+    /// [`Self::platform_executor_rungs`], and the same reason.
+    pub fn platform_memory_rungs(&self, platform: &str) -> Result<MemoryKnobs, ConfigError> {
+        self.platform_memory_knobs(platform)
+    }
+
+    /// phase-400 W6 — resolve the memory tenant over the RFC-0049 ladder:
+    /// builtin < platform toml < board toml < env front-end.
+    ///
+    /// `defaults` are passed in, as for the executor tenant: the built-in for
+    /// a FreeRTOS heap lives in the board crate that sizes it, and an absent
+    /// platform tree must change nothing.
+    pub fn resolve_memory(
+        &self,
+        platform: &str,
+        board: Option<&MemoryKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_memory_knobs(platform)?;
+        let pick = |k: &MemoryKnobs, name: &str| match name {
+            "heap_bytes" => k.heap_bytes,
+            "app_stack_bytes" => k.app_stack_bytes,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = memory_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                // The front-ends disagree about units and the ladder does not:
+                // a KiB spelling is multiplied here, once, beside the table
+                // that records which spelling each knob has.
+                value = if memory_env_is_kib(name) { n * 1024 } else { n };
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
+        }
+        Ok(out)
+    }
+
     /// The `[knobs.executor]` a platform's chain declares, merged nearest-wins.
     ///
     /// Public because a BUILD SCRIPT needs the rungs without the resolution:

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -284,6 +284,38 @@ impl BuildRungs {
         })
     }
 
+    /// The `[knobs.executor]` RUNGS for this build — platform merged with
+    /// board, board winning — with NO env rung and no defaults.
+    ///
+    /// Deliberately not the full ladder: `nros-node/build.rs` composes
+    /// env → Kconfig → these → its own builtin, and the Kconfig rung sits
+    /// between the front-end and the descriptors. What it needed shared was
+    /// the ENV-POINTER DANCE above, not the composition, and pretending
+    /// otherwise would have quietly dropped its Kconfig rung.
+    pub fn executor_rungs(&self) -> ExecutorKnobs {
+        let plat = self
+            .tree
+            .platform_executor_rungs(&self.platform)
+            .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={}: {e}", self.platform));
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.executor.clone())
+            .unwrap_or_default();
+        ExecutorKnobs {
+            max_cbs: b.max_cbs.or(plat.max_cbs),
+            max_sc: b.max_sc.or(plat.max_sc),
+            max_nodes: b.max_nodes.or(plat.max_nodes),
+            max_shutdown_cbs: b.max_shutdown_cbs.or(plat.max_shutdown_cbs),
+            action_clients: b.action_clients.or(plat.action_clients),
+            arena_size: b.arena_size.or(plat.arena_size),
+            subscription_buffer_size: b.subscription_buffer_size.or(plat.subscription_buffer_size),
+            param_service_buffer_size: b
+                .param_service_buffer_size
+                .or(plat.param_service_buffer_size),
+        }
+    }
+
     /// The memory tenant for this build, over the full ladder.
     pub fn memory(&self, defaults: &[(&'static str, usize)]) -> Vec<(&'static str, ResolvedUsize)> {
         self.tree
@@ -388,17 +420,42 @@ pub const MEMORY_KNOBS: &[&str] = &["heap_bytes", "app_stack_bytes"];
 /// The FreeRTOS pair is the platform that sizes both today; Zephyr's heap has
 /// its own spelling and is resolved by `nros-platform`'s build script.
 pub fn memory_env_key(knob: &str) -> &'static str {
-    match knob {
-        "heap_bytes" => "NROS_FREERTOS_HEAP_KB",
-        "app_stack_bytes" => "NROS_FREERTOS_APP_STACK_KB",
-        other => panic!("unknown memory knob `{other}`"),
+    memory_env_key_for("freertos", knob)
+}
+
+/// The env front-end for a memory knob ON A GIVEN PLATFORM.
+///
+/// The same knob has different front-end spellings per platform — a heap is
+/// `NROS_FREERTOS_HEAP_KB` on FreeRTOS and `NROS_ZEPHYR_HEAP_SIZE` on Zephyr —
+/// because those names predate the ladder and migrating a knob must not change
+/// how anyone sets it. The RUNG is one knob; only its front-end differs, so
+/// this is where the difference lives rather than in two knob names.
+///
+/// Without this, `nros config explain --platform zephyr` would print the
+/// FreeRTOS variable beside the Zephyr heap — telling a reader to set something
+/// that does nothing, in the report whose whole job is to say where a value
+/// came from.
+pub fn memory_env_key_for(platform: &str, knob: &str) -> &'static str {
+    match (platform, knob) {
+        ("zephyr", "heap_bytes") => "NROS_ZEPHYR_HEAP_SIZE",
+        (_, "heap_bytes") => "NROS_FREERTOS_HEAP_KB",
+        (_, "app_stack_bytes") => "NROS_FREERTOS_APP_STACK_KB",
+        (_, other) => panic!("unknown memory knob `{other}`"),
     }
 }
 
 /// Whether a memory knob's env front-end is spelled in KiB rather than bytes.
 /// The ladder stores bytes; this is the one place the difference lives.
 pub fn memory_env_is_kib(knob: &str) -> bool {
-    matches!(knob, "heap_bytes" | "app_stack_bytes")
+    memory_env_is_kib_for("freertos", knob)
+}
+
+/// Whether a memory knob's front-end is KiB on this platform. The unit travels
+/// with the SPELLING, not with the knob: `NROS_FREERTOS_HEAP_KB` is KiB and
+/// `NROS_ZEPHYR_HEAP_SIZE` is bytes, for the same `heap_bytes` rung.
+pub fn memory_env_is_kib_for(platform: &str, knob: &str) -> bool {
+    !matches!((platform, knob), ("zephyr", "heap_bytes"))
+        && matches!(knob, "heap_bytes" | "app_stack_bytes")
 }
 
 /// One resolved executor knob: value, rung, and the env name that is still its
@@ -1030,14 +1087,18 @@ impl PlatformsTree {
                     (None, Some(v)) => (v, KnobSource::Platform),
                     (None, None) => (*builtin, KnobSource::Builtin),
                 };
-            let env_key = memory_env_key(name);
+            let env_key = memory_env_key_for(platform, name);
             if let Some(raw) = env(env_key)
                 && let Ok(n) = raw.trim().parse::<usize>()
             {
                 // The front-ends disagree about units and the ladder does not:
                 // a KiB spelling is multiplied here, once, beside the table
                 // that records which spelling each knob has.
-                value = if memory_env_is_kib(name) { n * 1024 } else { n };
+                value = if memory_env_is_kib_for(platform, name) {
+                    n * 1024
+                } else {
+                    n
+                };
                 source = KnobSource::Env;
             }
             out.push((

--- a/packages/boards/nros-board-freertos/build.rs
+++ b/packages/boards/nros-board-freertos/build.rs
@@ -108,11 +108,27 @@ fn main() {
     //      below the cyclone DDS-discovery default; cyclone/xrce don't enable
     //      this feature on the base crate, so they keep the 3 MiB default; tune
     //      via the env (`xPortGetMinimumEverFreeHeapSize()` high-water).
-    let heap_kb = env::var("NROS_FREERTOS_HEAP_KB")
-        .ok()
-        .or_else(|| (env::var("CARGO_FEATURE_RMW_ZENOH").is_ok()).then(|| "2048".to_string()));
+    // phase-400 W6 — the platform and board rungs sit UNDER the two overrides
+    // this already had, and the env front-end still wins over all of them.
+    //
+    // The knob keeps its KiB spelling at the front end and the ladder stores
+    // bytes, so the define is converted back here: FreeRTOSConfig.h reads KiB.
+    let zenoh_default_kb =
+        (env::var("CARGO_FEATURE_RMW_ZENOH").is_ok()).then(|| 2048_usize);
+    let heap_kb = match nros_board_common::platform_config::BuildRungs::from_build_env() {
+        Some(rungs) => {
+            // No lane default means "leave FreeRTOSConfig.h's 3 MiB alone",
+            // which is not a number this can invent — so only ask the ladder
+            // when something below it has an opinion.
+            zenoh_default_kb.map(|kb| rungs.memory_value("heap_bytes", kb * 1024) / 1024)
+        }
+        None => env::var("NROS_FREERTOS_HEAP_KB")
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .or(zenoh_default_kb),
+    };
     if let Some(kb) = heap_kb {
-        freertos.define("NROS_FREERTOS_HEAP_KB", kb.as_str());
+        freertos.define("NROS_FREERTOS_HEAP_KB", kb.to_string().as_str());
     }
     println!("cargo:rerun-if-env-changed=NROS_FREERTOS_HEAP_KB");
     for src in &[

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -264,6 +264,30 @@ fn explain(args: ExplainArgs) -> Result<()> {
         );
     }
 
+    // phase-400 W6 — the platform memory tenant. Defaults mirror the board
+    // crate that sizes each: FreeRTOS heap_4 `ucHeap` at the `rmw-zenoh` 2 MiB,
+    // and the `nros_app` task stack. Both in BYTES, which is the ladder's unit;
+    // their env front-ends are KiB and convert at the rung.
+    let mem_defaults: &[(&str, usize)] =
+        &[("heap_bytes", 2048 * 1024), ("app_stack_bytes", 384 * 1024)];
+    for (name, r) in tree
+        .resolve_memory(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.memory),
+            &env_get,
+            mem_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?
+    {
+        println!(
+            "{:<34} {:<10} {}  [{}]",
+            format!("memory.{name}"),
+            r.value,
+            r.source.as_str(),
+            r.env_key
+        );
+    }
+
     for w in tree
         .transport_warnings(&args.platform, &transport)
         .map_err(|e| eyre!("{e}"))?

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -208,92 +208,23 @@ fn main() {
     println!("cargo:rx_buf_size={rx_buf_size}");
 }
 
-/// Read a usize knob: explicit env var, else Zephyr Kconfig, else `default`.
-///
-/// issue 0460 — a Zephyr RUST image never sees the `set(ENV{...})` knob exports
-/// that `nros_cargo_build.cmake` writes, so every one of these compiled its
-/// crate default whatever Kconfig said (measured: `.config` said
-/// `CONFIG_NROS_EXECUTOR_MAX_CBS=16`, zero occurrences in `build.ninja`, crate
-/// compiled 4). `nros_zephyr_build::knob_usize` is the ONE spelling of the
-/// `$DOTCONFIG` fallback — the zenoh shim's knobs go through the same helper.
-/// This crate's env names are the Kconfig names minus `CONFIG_`, so the pair is
-/// derived rather than tabulated.
-/// The platform and board rungs of the RFC-0049 ladder for `[knobs.executor]`,
-/// resolved once.
+/// The platform and board rungs of the RFC-0049 ladder for `[knobs.executor]`.
 ///
 /// phase-400 W6. This crate deliberately has NO `platform-*` cargo feature
 /// (phase-248 C2: the core executor is platform-agnostic and reaches the
 /// platform through the vtable), so the build script cannot know its platform
-/// from a `cfg`. It learns it the way every other build-script fact travels
-/// here: the lane exports a value, and a POINTER to the file that carries the
-/// rest. `nros ws board-facts` emits `NROS_PLATFORM_NAME` and
-/// `NROS_BOARD_TOML`, and `corrosion_set_env_vars` attaches them to the
-/// target's own build command — which is what actually runs cargo, unlike
-/// cmake's `set(ENV{...})` (issue 0460).
+/// from a `cfg`. `BuildRungs` learns it the way every other build-script fact
+/// travels here — the lane exports a value and a POINTER, and the script reads
+/// the file — and it is SHARED: this function grew its own copy of that dance
+/// first, and two build scripts resolving the same rungs differently is the
+/// drift `check-knob-single-reader` exists to catch one level up.
 ///
-/// Absent pointer (a bare `cargo build` with no lane, an out-of-tree consumer)
-/// → every rung is `None` and the front-end below decides, exactly as before.
-/// With no board named there IS no platform rung to resolve, so that is the
-/// right answer rather than a degradation.
+/// Absent pointer (a bare `cargo build` with no lane) → every rung is `None`
+/// and the front-end below decides, exactly as before.
 fn executor_rungs() -> nros_board_common::platform_config::ExecutorKnobs {
-    use nros_board_common::platform_config as pc;
-
-    let empty = pc::ExecutorKnobs::default();
-    let Some(platform) = std::env::var("NROS_PLATFORM_NAME")
-        .ok()
-        .filter(|s| !s.is_empty())
-    else {
-        return empty;
-    };
-    println!("cargo:rerun-if-env-changed=NROS_PLATFORM_NAME");
-
-    // The board rung. `watch_path` fingerprints the file's CONTENT — issue
-    // 0491: `rerun-if-env-changed` on a variable naming a PATH compares the
-    // spelling, and one directory has three spellings here.
-    // Every failure below is FATAL, never a fall-through to defaults.
-    //
-    // A silently empty tree resolves every knob to a builtin and produces a
-    // wrong image with no diagnostic — `nros-zpico-build` says exactly this
-    // about the same tree, and it is not a hypothetical: the first version of
-    // this function used `.ok()`, and a platform file with one rejected key
-    // compiled at the crate defaults while reporting success. The lane named a
-    // platform; being unable to honour it is an error.
-    let board = nros_build_paths::env_path("NROS_BOARD_TOML").map(|p| {
-        nros_build_paths::watch_path(&p);
-        pc::BoardKnobsFile::load(&p)
-            .unwrap_or_else(|e| panic!("NROS_BOARD_TOML={}: {e}", p.display()))
-            .knobs
-            .executor
-    });
-
-    let search = pc::PlatformsTree::default_search_path(
-        &nros_build_paths::repo_root(),
-        std::env::var("NROS_PLATFORMS_DIR").ok().as_deref(),
-    );
-    for dir in &search {
-        nros_build_paths::watch_path(dir);
-    }
-    let tree = pc::PlatformsTree::load_search_path(&search)
-        .unwrap_or_else(|e| panic!("platform search path {search:?}: {e}"));
-    let plat = tree
-        .platform_executor_rungs(&platform)
-        .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={platform}: {e}"));
-
-    // Board over platform, per RFC-0049. `None` at both leaves the front-end
-    // and the built-in default in charge.
-    let b = board.unwrap_or_default();
-    pc::ExecutorKnobs {
-        max_cbs: b.max_cbs.or(plat.max_cbs),
-        max_sc: b.max_sc.or(plat.max_sc),
-        max_nodes: b.max_nodes.or(plat.max_nodes),
-        max_shutdown_cbs: b.max_shutdown_cbs.or(plat.max_shutdown_cbs),
-        action_clients: b.action_clients.or(plat.action_clients),
-        arena_size: b.arena_size.or(plat.arena_size),
-        subscription_buffer_size: b.subscription_buffer_size.or(plat.subscription_buffer_size),
-        param_service_buffer_size: b
-            .param_service_buffer_size
-            .or(plat.param_service_buffer_size),
-    }
+    nros_board_common::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.executor_rungs())
+        .unwrap_or_default()
 }
 
 /// The knob a front-end env name belongs to, derived from the one table that

--- a/packages/platform/nros-platform/build.rs
+++ b/packages/platform/nros-platform/build.rs
@@ -25,6 +25,21 @@
 const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
 
 fn main() {
+    // phase-400 W6 — this knob does NOT get the `[knobs.memory]` platform and
+    // board rungs, and the reason is structural rather than a decision.
+    //
+    // `nros-board-common` owns the ladder and depends on THIS crate, so a
+    // build-dependency the other way is a cycle — cargo rejects it outright.
+    // That is the difference from `nros-node`, which board-common does not
+    // depend on and which therefore could take it.
+    //
+    // Nothing is lost in practice: on Zephyr the rung those tables would
+    // provide is already served by Kconfig, which `knob_usize` reads from
+    // `$DOTCONFIG` (issue 0460). The platform states the value where a Zephyr
+    // image already looks for it.
+    //
+    // Giving it the toml rungs would need the ladder types in a crate BELOW
+    // both — a real refactor, not a dependency line.
     let size = nros_zephyr_build::knob_usize(
         "NROS_ZEPHYR_HEAP_SIZE",
         "CONFIG_NROS_ZEPHYR_HEAP_SIZE",

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -322,6 +322,12 @@ def find_image_roots(roots):
     for root in roots:
         if not os.path.isdir(root):
             continue
+        # walk-ok: `roots` are BUILD directories, and what this looks for —
+        # a compiled binary beside the knob it was compiled against — is
+        # untracked by construction, so `git ls-files` cannot see it. That is
+        # the case the gate's own text carves out ("scanning for UNTRACKED
+        # artifacts is fine — scope it to a build dir"), and PRUNE keeps it
+        # off the vendored trees.
         for dirpath, dirnames, filenames in os.walk(root):
             base = os.path.basename(dirpath)
             if base in PRUNE:

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -322,12 +322,6 @@ def find_image_roots(roots):
     for root in roots:
         if not os.path.isdir(root):
             continue
-        # walk-ok: `roots` are BUILD directories, and what this looks for —
-        # a compiled binary beside the knob it was compiled against — is
-        # untracked by construction, so `git ls-files` cannot see it. That is
-        # the case the gate's own text carves out ("scanning for UNTRACKED
-        # artifacts is fine — scope it to a build dir"), and PRUNE keeps it
-        # off the vendored trees.
         for dirpath, dirnames, filenames in os.walk(root):
             base = os.path.basename(dirpath)
             if base in PRUNE:

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -53,11 +53,13 @@ LADDER_FLOOR = 13
 #
 #   ladder   already resolved over the RFC-0049 ladder
 #   sizing   a sizing knob still to migrate — THE BACKLOG
-#   derived  a size that should come from the MESSAGE TYPE, not from a knob
-#            (phase-403, phase-408, issue 0896). Migrating one of these into
-#            the ladder would be WRONG: a rung gives a global a per-platform
-#            default, and the whole point of that work is that it stops being
-#            a global.
+#   derived  a number ANOTHER CAMPAIGN is making derived rather than set:
+#            phase-403 / phase-408 for the receive and transmit buffers (from
+#            the message type), phase-392 for the zenoh entity caps and pools
+#            (from what the image declares). Migrating one of these into the
+#            ladder would be WRONG: a rung gives a global a per-platform
+#            default, and the point of that work is that it stops being a
+#            global. The reason column names the owner.
 #   infra    a path, a flag, or an input to the ladder itself. Not a knob, and
 #            counting it as one overstates the backlog — which the first
 #            census did, by ~40%.
@@ -81,9 +83,9 @@ KNOB_CLASS = {
     "ZPICO_SUBSCRIBER_SIZE_THRESHOLD": ("derived", "SMALL_CLASS_CEILING (phase-403)"),
     "ZPICO_PUBLISHER_TX_BUFFER_SIZE": ("derived", "TX half of the same split"),
     # --- sizing: the backlog ---
-    "NROS_MAX_ARRAY_LEN": ("sizing", "message bound"),
-    "NROS_MAX_BYTE_ARRAY_LEN": ("sizing", "message bound"),
-    "NROS_MAX_STRING_VALUE_LEN": ("sizing", "message bound"),
+    "NROS_MAX_ARRAY_LEN": ("sizing", "parameter value bound (nros-params)"),
+    "NROS_MAX_BYTE_ARRAY_LEN": ("sizing", "parameter value bound (nros-params)"),
+    "NROS_MAX_STRING_VALUE_LEN": ("sizing", "parameter value bound (nros-params)"),
     "NROS_MAX_PARAM_NAME_LEN": ("sizing", "parameter bound"),
     "NROS_MAX_PARAMETERS": ("sizing", "parameter cap"),
     "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("sizing", "component cap"),
@@ -96,8 +98,8 @@ KNOB_CLASS = {
     "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
     "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape"),
     "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("sizing", "transport MTU; numeric, read as a string"),
-    "ZPICO_MAX_LARGE_SUBSCRIBERS": ("sizing", "pool cardinality, not a payload size"),
-    "ZPICO_SERVICE_BUFFER_SIZE": ("sizing", "service staging block"),
+    "ZPICO_MAX_LARGE_SUBSCRIBERS": ("derived", "pool cardinality; multiplies LARGE_PAYLOADS, phase-392"),
+    "ZPICO_SERVICE_BUFFER_SIZE": ("derived", "SERVICE_BUFFERS is MAX_SESSIONS x MAX_QUERYABLES; phase-392"),
     # --- infra: not knobs ---
     "NROS_ALLOW_UNRESOLVED_DEPS": ("infra", "policy flag"),
     "NROS_BUILD_ROOT": ("infra", "path"),
@@ -115,12 +117,12 @@ KNOB_CLASS = {
     "ZPICO_TX_BATCH_FLUSH_MS": ("ladder", "zenoh.tx tenant"),
     # --- sizing: the zenoh-pico entity caps and buffers. The largest single
     # --- family left, and the one the phase doc calls "the per-entity caps".
-    "ZPICO_MAX_PUBLISHERS": ("sizing", "entity cap"),
-    "ZPICO_MAX_SUBSCRIBERS": ("sizing", "entity cap"),
-    "ZPICO_MAX_QUERYABLES": ("sizing", "entity cap; issue 0460 raised it for services"),
-    "ZPICO_MAX_SESSIONS": ("sizing", "entity cap"),
-    "ZPICO_MAX_LIVELINESS": ("sizing", "entity cap"),
-    "ZPICO_MAX_PENDING_GETS": ("sizing", "entity cap"),
+    "ZPICO_MAX_PUBLISHERS": ("derived", "entity cap; phase-392 is deciding whether it is derived from the declaration"),
+    "ZPICO_MAX_SUBSCRIBERS": ("derived", "entity cap; phase-392"),
+    "ZPICO_MAX_QUERYABLES": ("derived", "already a CHECKED OVERRIDE over a derived default (phase-392 W5.f)"),
+    "ZPICO_MAX_SESSIONS": ("derived", "phase-392 poses it explicitly: joins the model, or stays a knob and that phase says so"),
+    "ZPICO_MAX_LIVELINESS": ("derived", "entity cap; phase-392"),
+    "ZPICO_MAX_PENDING_GETS": ("derived", "entity cap; phase-392"),
     "ZPICO_BATCH_UNICAST_SIZE": ("sizing", "wire batch buffer"),
     "ZPICO_BATCH_MULTICAST_SIZE": ("sizing", "wire batch buffer"),
     "ZPICO_FRAG_MAX_SIZE": ("sizing", "fragmentation ceiling"),
@@ -299,7 +301,7 @@ def main() -> int:
     print(f"  {'-' * 38} -----")
     for cls, label in (
         ("sizing", "sizing knobs still to migrate  <-- W6"),
-        ("derived", "sized by the MESSAGE TYPE, not a knob"),
+        ("derived", "another campaign is DERIVING these"),
         ("ladder", "already on the ladder"),
         ("infra", "paths / flags / ladder inputs (not knobs)"),
     ):

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -92,7 +92,7 @@ KNOB_CLASS = {
     "NROS_RUNTIME_MAX_CELL_ENTITIES": ("sizing", "component cap"),
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("sizing", "component cap"),
     "NROS_RUNTIME_MAX_COMPONENTS": ("sizing", "component cap"),
-    "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "platform heap"),
+    "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
@@ -141,6 +141,31 @@ KNOB_CLASS = {
     "NROS_ZPICO_DEBUG": ("infra", "debug flag"),
     "ZPICO_NO_SMOLTCP": ("infra", "link toggle"),
     "ZPICO_PLATFORMS_TOML": ("infra", "the ladder's own platform file pointer"),
+    # --- found once the scan followed the `build-helpers` feature ---
+    "NROS_CYCLONEDDS_MAX_TYPES": (
+        "derived",
+        "already DERIVED from the SystemModel (msg=1/srv=2/action=8+3, next_pow2) "
+        "and forwarded; the env is the override, not the source",
+    ),
+    "NROS_TRANSPORT_KIND": ("ladder", "transport tenant front-end"),
+    "NROS_TRANSPORT_ENDPOINT": ("ladder", "transport tenant front-end"),
+    "NROS_ENTRY_SPIN_MS": ("sizing", "entry spin period; a duration, same ladder shape"),
+    # --- infra: pointers, flags and orchestration inputs ---
+    "NROS_BOARD_TOML": ("infra", "the ladder's own board rung pointer"),
+    "NROS_EXTRA_BOARD_PATH": ("infra", "extra board search roots"),
+    "NROS_HOME": ("infra", "path"),
+    "NROS_MODEL_DIR": ("infra", "path"),
+    "NROS_WORKSPACE": ("infra", "path"),
+    "NROS_WORKSPACE_ROOT": ("infra", "path"),
+    "NROS_LAUNCH_RESOLVE": ("infra", "resolver binary path"),
+    "NROS_METADATA_PROBE_CACHE": ("infra", "cache path"),
+    "NROS_RMW": ("infra", "the selected backend, not a size"),
+    "NROS_OFFLINE": ("infra", "policy flag"),
+    "NROS_NO_AUTO_SETUP": ("infra", "policy flag"),
+    "NROS_SKIP_STALE_CHECK": ("infra", "policy flag"),
+    "NROS_SUPPRESS_DEPRECATION": ("infra", "policy flag"),
+    "NROS_DEBUG_BRINGUP_RESOLVER": ("infra", "debug flag"),
+    "NROS_TRACE_ABI_GUARD": ("infra", "debug flag"),
 }
 
 
@@ -215,12 +240,24 @@ def build_env_sources():
     reported six — so both this file's first number and the phase doc's
     original table undercounted the zenoh surface by a factor of four.
 
-    The convention is the crate NAME: `*-build` crates and everything under
-    `packages/tooling/` are build-time by construction.
+    Two conventions find them. The crate NAME (`*-build`, and everything under
+    `packages/tooling/`), and — because a crate can be a build helper without
+    saying so in its name — a declared `build-helpers` FEATURE. The second was
+    added after a refactor moved the env-pointer reads out of a `build.rs` and
+    into `nros-board-common`, whose name says "board" and whose
+    `build-helpers` feature says what it actually is: the census lost sight of
+    a knob because the code moved, which is the failure mode a name-based scan
+    always has.
     """
     out = list(tracked("*build.rs"))
     out += [p for p in tracked("packages/*/*-build/src/*.rs", "packages/*/*/*-build/src/*.rs")]
     out += list(tracked("packages/tooling/*/src/*.rs"))
+    for manifest in tracked("packages/*/*/Cargo.toml", "packages/*/Cargo.toml"):
+        if "build-helpers" not in read(manifest):
+            continue
+        crate = os.path.dirname(manifest)
+        rel = os.path.relpath(crate, ROOT)
+        out += [str(q) for q in tracked(f"{rel}/src/*.rs")]
     return sorted(set(out))
 
 

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 13
+LADDER_FLOOR = 15
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -93,8 +93,8 @@ KNOB_CLASS = {
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("sizing", "component cap"),
     "NROS_RUNTIME_MAX_COMPONENTS": ("sizing", "component cap"),
     "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "platform heap"),
-    "NROS_FREERTOS_HEAP_KB": ("sizing", "platform heap; numeric, read as a string"),
-    "NROS_FREERTOS_APP_STACK_KB": ("sizing", "platform stack; numeric, read as a string"),
+    "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
+    "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
     "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape"),
     "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("sizing", "transport MTU; numeric, read as a string"),
@@ -173,7 +173,7 @@ def ladder_knobs():
     """Fields on the typed `[knobs.*]` structs — the migrated knobs."""
     src = read(os.path.join(ROOT, "packages/boards/nros-board-common/src/platform_config.rs"))
     total = {}
-    for struct in ("TxKnobs", "ExecutorKnobs", "TransportKnobs"):
+    for struct in ("TxKnobs", "ExecutorKnobs", "TransportKnobs", "MemoryKnobs"):
         fields = _struct_fields(src, struct)
         if fields:
             total[struct] = fields


### PR DESCRIPTION
Supersedes #168 and #170 — both are contained here, rebased onto main.

## `[knobs.memory]` — the platform heap and stack

The tenant with no derivation campaign competing for it. `NROS_FREERTOS_HEAP_KB` and `NROS_FREERTOS_APP_STACK_KB` resolve builtin < platform < board < env and print in `nros config explain`.

**Stored in bytes, always** — front-ends disagree (FreeRTOS KiB, Zephyr bytes), and a table where "heap" means different things per platform is a unit bug waiting to happen. Verified: `NROS_FREERTOS_HEAP_KB=4096` → `4194304 env`; a platform file's `heap_bytes` → `1234567 platform`.

The front-end **spelling is per-platform**: without `memory_env_key_for`, `explain --platform zephyr` would print the FreeRTOS variable beside the Zephyr heap — telling a reader to set something that does nothing, in the report whose job is to say where a value came from.

## One reader for the build rungs

`nros-node/build.rs` grew its own copy of the env-pointer dance when the executor tenant landed; `BuildRungs` arrived a wave later for memory. Two build scripts resolving the same rungs differently is what `check-knob-single-reader` catches one level up, so `nros-node` delegates now.

Only the **dance** is shared, not the composition — `nros-node` composes env → Kconfig → rungs → builtin, and the Kconfig rung sits between the front-end and the descriptors. Sharing the full ladder would have silently dropped it. Verified through the generated header: platform rung 11, env 77, no lane 4.

## The Zephyr heap is blocked, structurally

I said this would be "the same decision as `nros-node`". It isn't a decision at all — `nros-board-common` owns the ladder and **depends on** `nros-platform`, so the build-dep the other way is a cycle and cargo refuses it. Nothing is lost in practice: on Zephyr, Kconfig via `$DOTCONFIG` already serves the rung. Recorded as blocked backlog, not done, not dropped.

## Two mistakes of mine

**I deleted W7, W8 and the scope note from the phase doc** in #165 — a section replacement anchored on `s[s.index('### Remaining tenants'):]`, which runs to end of file. It landed on main. Nothing caught it: no gate reads a wave list, and the table at the top still named W8, so the file contradicted itself in a way only someone looking for W8 would notice. I was that reader, one wave later. Restored verbatim from `caa634aff~1`, diffed byte-for-byte.

**My own revert undid #169 on rebase.** When the walk-ok fix moved to its own PR I reverted it here to "main as it stood then" — without the marker. #169 merged, the rebase replayed the revert on top of the real fix, and removed it again. A revert pinned to *main as of now* is a time bomb across a rebase.

## The census follows the code now

Moving those reads into `nros-board-common` made them invisible to the census — a name-based scan loses sight of a knob when the code moves, which it did, immediately, to me. It now also follows the declared `build-helpers` **feature**, which is what that crate is regardless of its name. That found 19 more env names, and the gate failed until each was classified — the gate working.

84 names: 22 sizing, 14 derived, 14 ladder, 34 infra. Ladder 13 → 15.

`just ci-l1` green (tier's own exit); `just check fast` 158/158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG