### PR TITLE
docs(#0958, #0976): close 0958 at the ignore site, and record what actually blocks service.cpp

### DIFF
--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -1,0 +1,104 @@
+---
+id: 976
+title: "Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself"
+status: open
+area: [rmw, testing]
+severity: high
+related: [0970, 0969, 0234, phase-171]
+---
+
+# The bytes they exist to correct are the one thing nothing checks
+
+## What is in the service path
+
+`packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/service.cpp` carries five
+per-action-type special cases in front of its generic typed path:
+
+| adapter | what it does |
+| --- | --- |
+| `strip_goal_id_len_at` | removes a 4-byte `[16,0,0,0]` length prefix before the goal UUID |
+| `strip_nested_cdr_at` | removes a nested `00 01 00 00` encapsulation header from INSIDE a message |
+| `write_typed`'s `_SendGoal_*` / `_GetResult_Request_` branch | skips the CDR stream entirely and `memcpy`s the payload onto the typed struct |
+| `write_fibonacci_get_result_response` | hand-builds the generated C struct, because `dds_stream_read_sample` crashes on that type (phase 171.0.b) |
+| `take_fibonacci_get_result_response_wire` | the receive-side mirror of the above |
+
+The first two are not "make cdrstream happy" adjustments. They **delete bytes**.
+A `uint8[16]` UUID has no length prefix in CDR, and a CDR message has exactly one
+encapsulation header — at the top, not before a nested member. So these correct a
+serialization that would otherwise be wrong on the wire, and the correction lives
+in the backend rather than at the source.
+
+## What exercises them
+
+Measured, by instrumenting every entry to `write_typed` and `take_typed_wire`
+and running the backend's whole ctest suite:
+
+```
+7 PROBE take_typed_wire type=nros_test::srv::dds_::AddTwoInts_Response_
+3 PROBE write_typed     type=nros_test::srv::dds_::AddTwoInts_Request_ len=40
+3 PROBE write_typed     type=nros_test::srv::dds_::AddTwoInts_Response_ len=28
+3 PROBE take_typed_wire type=nros_test::srv::dds_::AddTwoInts_Request_
+```
+
+`AddTwoInts` and nothing else. Not one action type reaches this file in 22 tests,
+and both strip helpers fired **zero** times.
+
+They are not dead code, though — `examples/fixtures.toml` carries a Cyclone
+action pair (issue 0234), consumed by
+`packages/testing/nros-tests/tests/native_api.rs::test_native_cyclonedds_rust_action`,
+which drives an order-10 Fibonacci goal end to end. That lane runs the adapters.
+
+**It is nano-ros server to nano-ros client.** Both ends share whatever convention
+the adapters implement, so the test passes whether the bytes are ROS 2's or not.
+The single property these five exist to provide — that an action's wire format
+matches what a ROS 2 peer expects — is the one property no test can observe.
+
+Compare the non-action paths, which do have an outside witness:
+`ros2_pubsub_e2e` and `ros2_srv_e2e` run against stock `rmw_cyclonedds`. There is
+no `ros2_action_e2e`.
+
+## Why this surfaced now
+
+**#0970** moved the message publisher
+and subscriber onto a sertype whose sample is CDR, so neither direction decodes.
+Its scope note left `service.cpp` alone, saying its request/reply path "reads
+typed samples for several action types, and moving it belongs with the work that
+retires those adapters".
+
+That framing was incomplete. Two of the five do not merely read the typed
+sample — they change what goes on the wire, and a blob sertype has nowhere to
+change it. So migrating `service.cpp` would alter the action wire format, and by
+the paragraph above **nothing in the tree could tell**.
+
+So the migration is blocked, and not on effort. It is blocked on there being any
+way to know whether it broke something.
+
+## What unblocks it
+
+A ROS 2 action interop test, in the shape the two existing ones already have:
+`ros2_srv_e2e` spawns a real `ros2` process against an nros entity and compares.
+The action equivalent — `ros2 action send_goal` against the nros action server,
+and an nros action client against a `ros2` action server — turns the adapters'
+whole purpose into something observable.
+
+Then, and only then, one of two things becomes provable:
+
+1. The corrections are right, ROS 2 interop passes with them, and migrating
+   `service.cpp` requires moving each correction to the point where nano-ros
+   SERIALIZES — which is where it belonged, since a `uint8[16]` written with a
+   length prefix is wrong for every backend, not only this one. Note the message
+   path already did exactly this: publisher.cpp's 233.6 comment records the Rust
+   runtime being fixed to emit the fixed `octet[16]`, and the matching strip
+   being deleted from both sides.
+2. They are compensating for something that no longer exists, ROS 2 interop
+   passes without them, and they are deleted.
+
+Either way the answer comes from a test that has an outside witness, not from
+reading the adapters.
+
+## Not to be confused with
+
+**#0970** (`0970-cyclone-rmw-should-own-its-sertype.md`, filed in PR #154 — not
+linked because it has not landed on `main` yet) — the sertype migration
+itself, whose message half has landed. This is the reason its service half has
+not.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -76,5 +76,6 @@ fails if this block drifts.
 - **#0964** (codegen) — The C++ header states an ESTIMATED size for every type, including types that have no bound See `0964-*`.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
+- **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/sertype_min.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/sertype_min.hpp
@@ -46,9 +46,15 @@
 //     Issue 0970 does the same in `nros_sertype.{hpp,cpp}`; the message
 //     publisher and subscriber now use it and neither builds a typed sample.
 //
-// `service.cpp` is what still uses this builder. Its request/reply path reads
-// typed samples for several action types, and moving it belongs with the work
-// that retires those adapters rather than with the data-path change.
+// `service.cpp` is what still uses this builder, and issue 0976 is why it has
+// not followed. Two of its five action adapters do not merely read the typed
+// sample — `strip_goal_id_len_at` and `strip_nested_cdr_at` DELETE BYTES, so a
+// blob sertype would put an action's uncorrected CDR on the wire. Measured, the
+// only thing exercising them is nano-ros talking to nano-ros
+// (`test_native_cyclonedds_rust_action`), where both ends share whatever
+// convention the adapters implement — so the one property they exist to provide
+// is the one no test can observe. The migration is blocked on a ROS 2 action
+// interop test, not on effort.
 // --------------------------------------------------------------------------
 
 #include <dds/dds.h>

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/subscriber.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/subscriber.cpp
@@ -76,10 +76,37 @@ inline SubState* as_state(const rmw_subscription_t* s) {
 
 } // namespace
 
+/// `options` is unused, and issue 0958 is why that is a decision rather than an
+/// omission.
+///
+/// `rmw_subscription_options_t::rx_buffer_hint` tells a backend how many bytes a
+/// receive buffer needs for this type, so a size-classing backend (zenoh-pico)
+/// can pick a class. This backend has no receive buffer to class:
+///
+///   * the sample arrives in a serdata, sized by the sample and allocated by
+///     `nros_sertype.cpp` at the moment it arrives;
+///   * the destination is the CALLER's buffer, whose capacity arrives on every
+///     `take` and is authoritative there.
+///
+/// Before issue 0969 there was exactly one candidate consumer: the `dds_ostream`
+/// that re-serialised the typed sample grew by `realloc`, and an initial size
+/// would have saved those reallocs. That ostream went with the round trip, and
+/// with it the last thing a hint could have sized.
+///
+/// So the field is INAPPLICABLE here rather than unimplemented, and the
+/// difference matters to anyone measuring: a Cyclone consumer can set the hint,
+/// do everything the sizing campaign asks, and correctly observe nothing change
+/// in this backend. What DOES change is the executor's arena, which nano-ros
+/// sizes itself from the same bound — measure the arena, not the backend.
+///
+/// The ABI declares the field advisory and says a backend MAY ignore it
+/// (`rmw_entity.h`). What it may not do is ignore it silently, which is the state
+/// issue 0958 opened against: the parameter was discarded at a bare
+/// `/*options*/` with nothing for a reader to find.
 rmw_ret_t subscription_create(const rmw_node_t* node, const rmw_message_type_support_t* type_support,
                                 const char* topic_name,
                                  uint32_t /*domain_id*/, const rmw_qos_profile_t* qos,
-                                 const rmw_subscription_options_t* /*options*/,
+                                 const rmw_subscription_options_t* /*options — see above*/,
                                  rmw_subscription_t* out) {
     /* phase-406 W1 — one argument in, two locals out, so the body below is
        unchanged. A NULL type support is INVALID_ARGUMENT rather than an


### PR DESCRIPTION
Stacked on #156 (base `fix/cyclone-take-cdr`). Two follow-ups from that work: one closes, one turns out to be blocked for a reason nobody had stated.

## #0958 — closed where the field is ignored

The issue asked that a backend ignoring a shared-ABI field say so **at the point it ignores it**. `subscription_create`'s `options` parameter now does.

The hint is **inapplicable** here, not unimplemented, and the difference matters to anyone measuring. This backend has no receive buffer to size: the sample arrives in a serdata sized by the sample, and the destination is the caller's buffer whose capacity arrives on every `take`. The one candidate consumer — the `dds_ostream` that re-serialised the typed sample and grew by `realloc` — went with the round trip in #0969.

So a Cyclone consumer can set the hint, do everything the sizing campaign asks, and correctly observe nothing change here. What *does* change is the executor arena, which nano-ros sizes itself. Measure the arena, not the backend.

## #0976 — service.cpp is blocked, and not on effort

#0970's scope note said `service.cpp`'s request/reply path "reads typed samples for several action types", implying the migration becomes mechanical once those are retired. **That was incomplete.**

`strip_goal_id_len_at` and `strip_nested_cdr_at` don't read the typed sample — they **delete bytes**: a 4-byte length prefix before a `uint8[16]` UUID, and a nested `00 01 00 00` encapsulation header *inside* a message. Neither belongs in CDR. They are wire-format corrections, and a blob sertype has nowhere to apply them. Migrating would change the action wire format.

**Which would be fine if anything could tell.** Instrumenting every entry to `write_typed` / `take_typed_wire` and running the whole suite:

```
7 PROBE take_typed_wire type=nros_test::srv::dds_::AddTwoInts_Response_
3 PROBE write_typed     type=nros_test::srv::dds_::AddTwoInts_Request_ len=40
3 PROBE write_typed     type=nros_test::srv::dds_::AddTwoInts_Response_ len=28
3 PROBE take_typed_wire type=nros_test::srv::dds_::AddTwoInts_Request_
```

`AddTwoInts` and nothing else — not one action type reaches this file in 22 tests, and both strip helpers fire **zero** times.

They aren't dead: `examples/fixtures.toml`'s Cyclone action pair (issue 0234) drives them via `test_native_cyclonedds_rust_action`. But that is **nano-ros server to nano-ros client**, where both ends share whatever convention the adapters implement. The single property these five exist to provide — that an action's wire format is what a ROS 2 peer expects — is the one property no test can observe. `ros2_pubsub_e2e` and `ros2_srv_e2e` have an outside witness; there is no `ros2_action_e2e`.

So the blocker is: **there is no way to know whether the migration broke something.** The unblock is a ROS 2 action interop test in the shape the two existing ones already have. Then either the corrections are right and belong at the point nano-ros serialises (which is what the *message* path already did — publisher.cpp's 233.6 note records the Rust runtime being fixed to emit the fixed `octet[16]` and the strip deleted from both sides), or they compensate for something gone and get deleted.

`sertype_min.hpp`'s amendment now says this rather than the weaker "belongs with the work that retires those adapters".

## Testing

`just cyclonedds ci` — 23/23. `just check` — 2 of 156 gates fail (`kconfig-overridden-values`, `fixtures-manifest`), the same two that fail on a clean tree.

The instrumentation was temporary and is not in the diff; the numbers above are what it produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
