### PR TITLE
feat(phase-400 W8): the ladder's membership decides what the one-reader gate checks

### DIFF
--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -62,9 +62,9 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:482` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:481` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:480` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:488` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:487` | `packages/rmw/zenoh/nros-zpico-build` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:486` | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -82,5 +82,3 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_SUBSCRIBER_LARGE_SIZE` | 16384 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_RING_DEPTH` | 4 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_SIZE_THRESHOLD` | 2048 | `packages/rmw/zenoh/nros-rmw-zenoh` |
-| `ZPICO_TX_BATCH` | 0 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_TX_BATCH_FLUSH_MS` | 50 | `packages/rmw/zenoh/nros-zpico-build` |

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -371,6 +371,50 @@ pub fn executor_env_only(knob: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+/// The zenoh tx tenant with NO platform rung — the env front-end over the
+/// builtins, and honest about which one answered.
+///
+/// phase-400 W8. `nros-zpico-build` had its own copy of this for the case where
+/// no platform name resolves, which made three migrated knobs have two readers
+/// that could disagree — the shape `check-knob-single-reader` exists to catch,
+/// and the shape issues 0135 and 0316 both were.
+///
+/// That copy also reported `KnobSource::Env` for a value that came from a
+/// BUILTIN, so `nros config explain` would have named the wrong rung. Here the
+/// source is whichever actually answered.
+///
+/// Same role as [`executor_env_only`], and the same reasoning: a caller that
+/// cannot reach a platform tree still honours an operator's override, through
+/// one implementation rather than its own.
+#[must_use]
+pub fn tx_env_only(env: &dyn Fn(&str) -> Option<String>) -> ResolvedTxKnobs {
+    let flag =
+        |name: &str, builtin: bool| match env(name).and_then(|v| v.trim().parse::<u64>().ok()) {
+            Some(n) => Resolved {
+                value: n != 0,
+                source: KnobSource::Env,
+            },
+            None => Resolved {
+                value: builtin,
+                source: KnobSource::Builtin,
+            },
+        };
+    ResolvedTxKnobs {
+        batch: flag("ZPICO_TX_BATCH", BUILTIN_TX_BATCH),
+        split_lock: flag("ZPICO_TX_SPLIT_LOCK", BUILTIN_TX_SPLIT_LOCK),
+        flush_ms: match env("ZPICO_TX_BATCH_FLUSH_MS").and_then(|v| v.trim().parse::<u64>().ok()) {
+            Some(n) => Resolved {
+                value: n,
+                source: KnobSource::Env,
+            },
+            None => Resolved {
+                value: BUILTIN_TX_FLUSH_MS,
+                source: KnobSource::Builtin,
+            },
+        },
+    }
+}
+
 /// `[knobs.executor]` — phase-400 W6. All optional; `None` defers to the rung
 /// below, and the built-in defaults stay in `nros-node/build.rs` so an absent
 /// tree changes nothing.

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -452,8 +452,14 @@ fn shim_config_from_env() -> ShimConfig {
         max_sessions: env_usize("ZPICO_MAX_SESSIONS", 1),
         get_reply_buf_size: env_usize("ZPICO_GET_REPLY_BUF_SIZE", 4096),
         get_poll_interval_ms: env_usize("ZPICO_GET_POLL_INTERVAL_MS", 10),
-        tx_batch: env_usize("ZPICO_TX_BATCH", 0) != 0,
-        tx_batch_flush_ms: env_usize("ZPICO_TX_BATCH_FLUSH_MS", 50),
+        // phase-400 W8 — the BUILTINS, not a second env read. These two are
+        // ladder knobs, and the resolved values overwrite them below (search
+        // `shim_config.tx_batch =`), so reading the environment here was dead
+        // work that only looked authoritative. It is exactly the second reader
+        // `check-knob-single-reader` forbids: harmless while the overwrite
+        // stays put, a silent disagreement the moment it moves.
+        tx_batch: platform_config::BUILTIN_TX_BATCH,
+        tx_batch_flush_ms: platform_config::BUILTIN_TX_FLUSH_MS as usize,
         // Defaults MIRROR the `#define` fallbacks in
         // `zpico-sys/c/zpico/zpico.c` (16 / 16). A different number here would
         // not be a tuning choice, it would be the two lanes disagreeing.
@@ -958,28 +964,15 @@ pub fn run() {
             tx
         }
         _ => {
-            // Legacy / unknown-platform fallback: env-only ladder.
-            let b = env_get("ZPICO_TX_BATCH")
-                .and_then(|v| v.parse::<u64>().ok())
-                .map(|n| n != 0);
-            let sl = env_get("ZPICO_TX_SPLIT_LOCK")
-                .and_then(|v| v.parse::<u64>().ok())
-                .map(|n| n != 0);
-            let fm = env_get("ZPICO_TX_BATCH_FLUSH_MS").and_then(|v| v.parse::<u64>().ok());
-            platform_config::ResolvedTxKnobs {
-                batch: platform_config::Resolved {
-                    value: b.unwrap_or(platform_config::BUILTIN_TX_BATCH),
-                    source: platform_config::KnobSource::Env,
-                },
-                split_lock: platform_config::Resolved {
-                    value: sl.unwrap_or(platform_config::BUILTIN_TX_SPLIT_LOCK),
-                    source: platform_config::KnobSource::Env,
-                },
-                flush_ms: platform_config::Resolved {
-                    value: fm.unwrap_or(platform_config::BUILTIN_TX_FLUSH_MS),
-                    source: platform_config::KnobSource::Env,
-                },
-            }
+            // Legacy / unknown-platform fallback: the env front-end over the
+            // builtins, resolved by the ONE implementation of that rule.
+            //
+            // phase-400 W8 — this used to re-read the three knobs here, which
+            // made each of them have two readers that could disagree, and
+            // reported `KnobSource::Env` even for a value that came from a
+            // builtin. `check-knob-single-reader` now derives its list from the
+            // census, which is how the pair was found.
+            platform_config::tx_env_only(&env_get)
         }
     };
 

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -31,21 +31,76 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 
-# Knobs migrated into the ladder, with the crate that legitimately reads each.
-# Adding a row here is the second half of migrating a knob; a knob that is in
-# the ladder but not here is simply unchecked, which is why W6 and W8 move
-# together.
-MIGRATED: dict[str, str] = {
+# Knobs migrated into the ladder, with the file that legitimately reads each.
+#
+# phase-400 W8 — the LIST is no longer maintained here. Which knobs are in the
+# ladder is the census's answer (`KNOB_CLASS`, class `ladder`), and this file
+# supplies only the OWNER. That coupling is the point: the previous version
+# said so itself — "a knob that is in the ladder but not here is simply
+# unchecked, which is why W6 and W8 move together" — and then relied on
+# whoever migrated a knob remembering to add a row. Two of them did not, and
+# the memory tenant's pair would have been three.
+#
+# Now a knob that reaches the ladder with no owner here FAILS, so the second
+# half of migrating a knob cannot be skipped, only done or deliberately
+# excused.
+OWNERS: dict[str, str] = {
     "NROS_EXECUTOR_MAX_CBS": "packages/core/nros-node/build.rs",
     "NROS_EXECUTOR_MAX_SC": "packages/core/nros-node/build.rs",
     "NROS_EXECUTOR_MAX_NODES": "packages/core/nros-node/build.rs",
     "NROS_EXECUTOR_MAX_SHUTDOWN_CBS": "packages/core/nros-node/build.rs",
     "NROS_EXECUTOR_ACTION_CLIENTS": "packages/core/nros-node/build.rs",
     "NROS_EXECUTOR_ARENA_SIZE": "packages/core/nros-node/build.rs",
+    # Classed `derived` by the census (phase-403 makes it per-type) but still
+    # ON the ladder as the fallback for a type with no declared bound, so it
+    # keeps a single owner. Listed here deliberately: it is checked, and the
+    # membership check below skips it because the census does not call it
+    # `ladder`.
     "NROS_SUBSCRIPTION_BUFFER_SIZE": "packages/core/nros-node/build.rs",
     "NROS_PARAM_SERVICE_BUFFER_SIZE": "packages/core/nros-node/build.rs",
+    # The memory tenant (phase-400 W6). The stack is read inside the crate that
+    # owns the ladder; the heap by the board crate that sizes `ucHeap`.
+    "NROS_FREERTOS_APP_STACK_KB": "packages/boards/nros-board-common/src/freertos_build.rs",
+    "NROS_FREERTOS_HEAP_KB": "packages/boards/nros-board-freertos/build.rs",
+    # The transport and zenoh-tx tenants resolve inside the ladder itself, so
+    # the resolver IS the owner. `nros-zpico-build` re-read the tx trio for its
+    # no-platform case until W8 replaced that with `tx_env_only`.
+    "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
+    "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
+    "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",
+    "ZPICO_TX_SPLIT_LOCK": "packages/boards/nros-board-common/src/platform_config.rs",
+    "ZPICO_TX_BATCH_FLUSH_MS": "packages/boards/nros-board-common/src/platform_config.rs",
 }
 
+
+def census_class(classes: tuple[str, ...]) -> set[str]:
+    """The env names the census puts in any of `classes`."""
+    import importlib.util
+
+    census = REPO / "scripts" / "check" / "config-knob-census.py"
+    spec = importlib.util.spec_from_file_location("config_knob_census", census)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return {n for n, (cls, _) in mod.KNOB_CLASS.items() if cls in classes}
+
+
+def ladder_knobs_from_census() -> set[str]:
+    """The env names the census classifies as `ladder`.
+
+    Imported rather than restated: two hand-kept lists of "what is in the
+    ladder" is the same duplicate-fact shape the ladder itself exists to
+    remove, and the census is already the file a new knob has to be added to
+    (its gate fails on an unclassified name).
+    """
+    import importlib.util
+
+    census = REPO / "scripts" / "check" / "config-knob-census.py"
+    spec = importlib.util.spec_from_file_location("config_knob_census", census)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return census_class(("ladder",))
 # The resolver itself names every knob in its front-end table; that is the map,
 # not a second reader.
 EXEMPT = {
@@ -123,6 +178,17 @@ def self_test() -> None:
 
 
 def main() -> int:
+    # The ladder's membership comes from the census; the owner comes from here.
+    # A knob in one and not the other is the drift this pairing removes.
+    ladder = ladder_knobs_from_census()
+    unowned = sorted(ladder - OWNERS.keys())
+    # A `derived` knob may legitimately keep an owner: it is on the ladder as a
+    # fallback while another campaign takes over its value. What must not
+    # happen is an owner for a knob the census does not know at all.
+    derived = census_class(("derived",))
+    stale = sorted(OWNERS.keys() - ladder - derived)
+    MIGRATED = {k: v for k, v in OWNERS.items() if k in ladder}
+
     # Single pass over the sources: read each file once and test every knob
     # against it. The naive shape (a pass per knob) re-reads several thousand
     # files eight times and takes minutes, which is a gate nobody will run.
@@ -158,6 +224,24 @@ def main() -> int:
             if readers_in(text, knob):
                 readers[knob].add(rel)
 
+    # Drift between the two halves, reported before the reader check so the
+    # message names the cause rather than a symptom.
+    if unowned or stale:
+        print("check-knob-single-reader: the ladder and its owners disagree\n")
+        for knob in unowned:
+            print(
+                f"  {knob}: in the ladder (census class `ladder`) and names no\n"
+                f"      owning reader here. Migrating a knob has TWO halves — the\n"
+                f"      rung, and the single reader. Add it to OWNERS."
+            )
+        for knob in stale:
+            print(
+                f"  {knob}: names an owner here, but the census no longer classes\n"
+                f"      it `ladder`. If it left the ladder, drop the row; if it was\n"
+                f"      reclassified, the reason column there should say why."
+            )
+        return 1
+
     failures = []
     for knob, owner in sorted(MIGRATED.items()):
         extra = sorted(readers[knob] - {owner})
@@ -174,7 +258,7 @@ def main() -> int:
             "A second reader is not a fallback, it is a disagreement waiting to\n"
             "happen: the two can resolve different values and nothing reports it\n"
             "(issues 0135, 0316). Delete the second reader, or -- if it is the\n"
-            "legitimate owner -- update MIGRATED in this script."
+            "legitimate owner -- update OWNERS in this script."
         )
         return 1
 


### PR DESCRIPTION
Stacked on #174.

W8's gate is *"for every migrated knob, exactly one reader"*. It existed and passed — over a **hand-kept list of eight, while the ladder held fifteen**. Its own docstring named the hole:

> a knob that is in the ladder but not here is simply unchecked, which is why W6 and W8 move together

…and then relied on whoever migrated a knob remembering to add a row. Three waves didn't.

So the list is no longer kept there. It comes from the census's `ladder` class; this file supplies only the **owner**, and a knob reaching the ladder without one now fails. Two hand-kept lists of "what's in the ladder" is the same duplicate-fact shape the ladder exists to remove.

## It found real work immediately

Seven unowned knobs, and in two of them a **second reader**:

- **`nros-zpico-build`'s no-platform fallback re-read the tx trio.** Three migrated knobs with two readers that could resolve different values — precisely issues 0135 and 0316. It also reported `KnobSource::Env` for values that came from **builtins**, so provenance was wrong in the one place provenance *is* the product. Replaced by `platform_config::tx_env_only`, the same role `executor_env_only` already had.
- **`shim_config_from_env` read `ZPICO_TX_BATCH` and `_FLUSH_MS`** — and had them overwritten eleven lines later by the resolved values. Dead work that looked authoritative: harmless while the overwrite stays put, a silent disagreement the moment it moves.

A `derived` knob may still keep an owner — `NROS_SUBSCRIPTION_BUFFER_SIZE` is on the ladder as the fallback for a type with no declared bound while phase-403 takes over its value. What the gate refuses is an owner for a knob the census doesn't know at all.

**14 migrated knobs, one reader each.**

## Correcting myself

I said this gate "would have caught the duplicate I created". **It would not** — that duplicate was the env-*pointer* dance (`NROS_PLATFORM_NAME`, `NROS_BOARD_TOML`), which are infra, not migrated knobs. This gate catches duplicate readers of ladder *values*, a narrower thing. The argument for doing W8 first was weaker than I made it; the wave earned its place on what it actually found.

`just ci-l1` green; `just check fast` 158/158. Pool inventory regenerated (line drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQbCR532JTsPvwhsY5JuG