### PR TITLE
fix(nightly): a `||` chain turned a failed build into a smaller one that passed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -329,11 +329,29 @@ jobs:
           # Disk lever: push/PR get the lighter `build-examples` smoke; the heavy
           # `build-all` fixtures matrix (what QEMU e2e consumes) only on schedule /
           # dispatch-with-run_e2e.
+          #
+          # ONE VERB PER PATH, no `||` fallback — phase-411.
+          #
+          # This used to read `build-all || build-examples || build`. Every
+          # platform module defines all four verbs, so the fallbacks could never
+          # fire for a MISSING recipe; they fired only when the previous verb
+          # FAILED. The step then built something smaller and reported success,
+          # which is the "skip and report success" shape phase-411 exists to
+          # remove — expressed in shell rather than in a skip helper.
+          #
+          # It defeated the mechanism that was working: nightly sets no
+          # `NROS_LANE_INCLUDED`, so every platform here is NAMED, and a named
+          # platform whose prerequisite is missing already fails loudly
+          # (`NROS_LANE_NAMED_FAIL`). The chain caught that failure and
+          # downgraded it. The prerequisite then surfaced two stages later as
+          # nine skipped tests and a `_check-skip-budget` red — twenty minutes
+          # after the point of decision, naming the gate instead of the missing
+          # tool, which is exactly what phase-411's acceptance rules out.
           if [ "${{ github.event_name }}" = "schedule" ] || \
              { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.run_e2e }}" = "true" ]; }; then
-            just ${{ matrix.plat }} build-all || just ${{ matrix.plat }} build-examples || just ${{ matrix.plat }} build
+            just ${{ matrix.plat }} build-all
           else
-            just ${{ matrix.plat }} build-examples || just ${{ matrix.plat }} build
+            just ${{ matrix.plat }} build-examples
           fi
 
       - name: Test / e2e (${{ matrix.plat }})

--- a/just/check.just
+++ b/just/check.just
@@ -126,7 +126,7 @@ fast-serial: \
     lane-skip-protocol named-lane-fails skip-marker-matching scope-namespace \
     package-xml-comments provider-announcements provider-index \
     zephyr-knob-agreement site-config lane-scope-consumers \
-    interlock-visibility fixture-stamp-honesty ci-no-fixture-tolerance sdk-guard-can-fire \
+    interlock-visibility fixture-stamp-honesty ci-no-fixture-tolerance ci-no-verb-fallback sdk-guard-can-fire \
     tier-has-ci-owner \
     board-facts-delivery deploy-board-resolves \
     opaque-storage-guards cpp-ffi-error-mapping submodule-pins \
@@ -794,6 +794,16 @@ workflow-repo-env:
 [private]
 doc-recipe-refs:
     @python3 scripts/check-doc-recipe-refs.py
+
+# phase-411 — a CI step must not fall back from one `just` verb to another.
+# `build-all || build-examples || build` made a FAILED verb build something
+# smaller and report success, which is the "skip and report success" shape
+# phase-411 removes, written in shell instead of a skip helper. Buildless: YAML
+# plus a regex, and it skips comments and heredocs for the reason
+# `check-workflow-repo-env` documents.
+[private]
+ci-no-verb-fallback:
+    @python3 scripts/check-ci-no-verb-fallback.py
 
 # issues 0320 / 0334 — no build-host absolute paths in tracked code/config.
 # A pure grep, so it belongs in the source-free tier (see #337 for what happens

--- a/scripts/check-ci-no-verb-fallback.py
+++ b/scripts/check-ci-no-verb-fallback.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""A CI step must not fall back from one `just` verb to another.
+
+phase-411 — "named must work; unnamed may skip, and is reported."
+
+## The shape
+
+`nightly.yml` ran, for every platform cell:
+
+    just <plat> build-all || just <plat> build-examples || just <plat> build
+
+Every platform module defines all four verbs, so the fallbacks could never fire
+for a MISSING recipe. They fired only when the previous verb FAILED — and the
+step then built something smaller and reported success.
+
+That is the "skip and report success" defect phase-411 exists to remove,
+expressed in shell instead of in a skip helper. It defeated the mechanism that
+was already working: nightly sets no `NROS_LANE_INCLUDED`, so its platforms are
+NAMED, and a named platform whose prerequisite is missing fails loudly with
+`NROS_LANE_NAMED_FAIL`. The `||` chain caught that failure and downgraded it.
+The missing prerequisite surfaced two stages later as nine skipped tests and a
+`_check-skip-budget` red — twenty minutes after the point of decision, naming
+the gate rather than the missing tool.
+
+## What is checked
+
+Inside a workflow `run:` block, a command whose head is `just` must not be the
+left operand of `||` where the right operand is also a `just` command.
+
+## What is deliberately allowed
+
+* `just … || echo "…"` and `just … || true` — a step choosing to CONTINUE past a
+  known-optional command, which is a different decision and is visible in the
+  log. `report-interlock-coverage.sh` exists for the cases where that needs
+  saying out loud.
+* `cmd || just …` where the left side is not `just` — a fallback INTO the
+  toolchain, not between two of its verbs.
+* `&&` chains — sequencing, not fallback.
+* Comment lines and heredoc bodies, for the reason `check-workflow-repo-env`
+  documents: a gate that cannot tell a command from a sentence about a command
+  is worse than no gate.
+
+Run: python3 scripts/check-ci-no-verb-fallback.py [--self-test]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO / ".github" / "workflows"
+
+# `just …` on the left of `||`, with another `just` as the right operand.
+# `[^|]*` keeps the match inside one command rather than spanning a pipeline.
+FALLBACK = re.compile(r"\bjust\s[^|]*\|\|\s*just\s")
+
+HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def command_lines(run: str):
+    """Lines of a `run:` body that are commands — not comments, not heredocs."""
+    out, terminator = [], None
+    for line in (run or "").split("\n"):
+        if terminator is not None:
+            if line.strip() == terminator:
+                terminator = None
+            continue
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        out.append(line)
+        m = HEREDOC.search(line)
+        if m:
+            terminator = m.group(2)
+    return out
+
+
+def offenders(docs):
+    bad = []
+    for path, doc in docs:
+        for job_name, job in (doc.get("jobs") or {}).items():
+            for step in job.get("steps", []) or []:
+                for line in command_lines(step.get("run") or ""):
+                    if FALLBACK.search(line):
+                        bad.append(
+                            (path, job_name, step.get("name") or "(unnamed)", line.strip())
+                        )
+    return bad
+
+
+def load():
+    import yaml
+
+    return [
+        (p.relative_to(REPO), yaml.safe_load(p.read_text()))
+        for p in sorted(WORKFLOWS.glob("*.yml"))
+    ]
+
+
+def self_test() -> int:
+    cases = [
+        ("just a build-all || just a build-examples", True),
+        ("just a build-all || just a build-examples || just a build", True),
+        # continuing past a known-optional command is a different decision
+        ('just a setup || echo "optional"', False),
+        ("just a setup || true", False),
+        # a fallback INTO just, not between its verbs
+        ("cmake --build . || just a build", False),
+        # sequencing
+        ("just a setup && just a build", False),
+        ("just a build", False),
+    ]
+    failures = 0
+    for text, want in cases:
+        got = bool(FALLBACK.search(text))
+        if got != want:
+            print(f"  self-test FAIL: {text!r} -> {got}, want {want}")
+            failures += 1
+
+    # comments and heredocs are not commands
+    if command_lines("# just a || just b\njust c\n") != ["just c"]:
+        print("  self-test FAIL: comment line was read as a command")
+        failures += 1
+    if command_lines("cat <<EOF\njust a || just b\nEOF\njust c\n") != ["cat <<EOF", "just c"]:
+        print("  self-test FAIL: heredoc body was read as commands")
+        failures += 1
+
+    if failures:
+        print(f"check-ci-no-verb-fallback self-test: {failures} case(s) FAILED")
+        return 1
+    print(f"check-ci-no-verb-fallback self-test: OK ({len(cases)} cases + extraction)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    docs = load()
+    bad = offenders(docs)
+    if bad:
+        print("check-ci-no-verb-fallback: CI step(s) fall back from one `just` verb to another:")
+        for path, job, step, line in bad:
+            print(f"  {path}  [{job}] {step}")
+            print(f"      {line[:100]}")
+        print()
+        print("  A fallback makes a FAILED verb build something smaller and report")
+        print("  success — the shape phase-411 removes. Name one verb per path.")
+        print("  To continue past a known-optional command, say so: `|| echo …`.")
+        return 1
+
+    steps = sum(len(j.get("steps", []) or []) for _, d in docs for j in (d.get("jobs") or {}).values())
+    print(
+        f"check-ci-no-verb-fallback: OK — {len(docs)} workflow(s), {steps} step(s); "
+        "no `just` verb falls back to another."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
phase-411's rule is *"named must work; unnamed may skip, and is reported"*, and **the mechanism for it already worked**: nightly sets no `NROS_LANE_INCLUDED`, so every platform in its matrix is NAMED, and a named platform whose prerequisite is missing fails loudly with `NROS_LANE_NAMED_FAIL`.

The Build step then caught that failure and threw it away:

```bash
just <plat> build-all || just <plat> build-examples || just <plat> build
just <plat> build-examples || just <plat> build          # the else branch
```

Every platform module defines **all four verbs** — checked, all five modules — so the fallbacks could never fire for a *missing* recipe. They fired only when the previous verb **failed**. The step built something smaller and reported success.

That's the "skip and report success" shape phase-411 exists to remove, written in shell rather than in a skip helper — and it explains the five red platform cells exactly:

```
success  just freertos setup
success  Build (freertos)
failure  Test / e2e (freertos)   <- 9 tests skip, _check-skip-budget red
```

Twenty minutes after the point of decision, naming the gate (`require_e2e check failed for freertos`) instead of the missing tool. phase-411's acceptance rules out precisely that ordering. `FREERTOS_DIR` appears **zero** times in that job's log.

**One verb per path now**: `build-all` for the e2e path, `build-examples` otherwise. The disk-lever intent the surrounding comment describes is unchanged; only the masking goes.

## Gated so it cannot return

`check-ci-no-verb-fallback`, buildless, on the fast line. It allows what is a different *decision* rather than a fallback:

- `just … || echo …` and `|| true` — continuing past a known-optional command, visible in the log
- `cmd || just …` — a fallback *into* the toolchain, not between its verbs
- `&&` — sequencing

It skips comments and heredoc bodies for the reason `check-workflow-repo-env` documents: a gate that can't tell a command from a sentence about a command is worse than no gate.

**Mutation-checked**: reinstating a two-verb chain makes it exit 1 and name the step; removing it returns 0. The sweep found these two sites and no others across 11 workflows and 168 steps.

## Verification

`just check fast` — 158 gates, 1 skipped.

Worth noting: two gates (`kconfig-overridden-values`, `fixtures-manifest`) were failing here and I nearly reported main as red. Both were one cause — a **stale in-tree `nros`** whose parser rejected `nros-sdk-index.toml`, which parses fine as TOML. `just setup-cli` cleared both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB