### PR TITLE
feat(phase-400 W6): the params tenant, and a census that had been under-counting by 29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless 0.8.0",
+ "nros-board-common",
  "nros-ghost-types",
  "nros-zephyr-build",
 ]

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,8 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
-**Status (2026-08-31): W2-W5 and W7 done; W6's first and largest tenant
-(`NROS_EXECUTOR_*`) done, its remaining tenants and W1 / W8 outstanding.** Design is
+**Status (2026-09-01): W2-W5, W7 and W8 done; W6's `executor`, `transport`,
+`zenoh.tx`, `memory` and `params` tenants done, its remaining tenants and W1
+outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
 new mechanism — the ladder and `nros config explain` already exist and work.
@@ -301,15 +302,60 @@ Same shape as the buffers one family over (phase-403). The census marks both
 `derived` and names the owning campaign, so the backlog count stops inviting
 the mistake.
 
-**W6's own backlog is therefore 23, not 31**, and its largest families are:
+**W6's own backlog is therefore 23, not 31** (re-measured at 28 after the
+census fix below), and its largest families are:
 
 | family | knobs | note |
 | --- | --- | --- |
-| `NROS_MAX_*` | 5 | PARAMETER value bounds, in `nros-params/build.rs`. Not message bounds — that mislabel is corrected in the census. |
+| `NROS_MAX_*` | 5 | **DONE** — the `params` tenant, below. |
 | `NROS_RUNTIME_*` | 4 | component caps. Worth asking whether these are derivable from the declared component set before migrating — the same question phase-392 asks of the zenoh caps. |
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `params` tenant — done
+
+The five `NROS_MAX_*` PARAMETER value bounds (not message bounds — that mislabel
+is corrected in the census) now resolve through the ladder: `ParamKnobs`,
+`[knobs.params]` in a platform or board toml, `BuildRungs::param_rungs()`, and a
+single reader in `nros-params/build.rs` composing env -> Kconfig -> rung ->
+builtin. `nros config explain` prints them beside the executor and memory
+tenants.
+
+No campaign owns these; the only doc hit was
+`phase-292-asi-reference-consumer-revisit.md`, and it is a usage RECORD —
+"consumer-side knobs that made it fit: `NROS_MAX_PARAMETERS=256`" — living in a
+consumer's `build.sh`. That is the argument FOR a rung, not against one: a
+consumer discovering a platform-appropriate value and having nowhere to put it
+is the gap the ladder closes.
+
+### The census had been under-counting by 29
+
+Wiring this tenant's gate turned up a defect in the measuring instrument. The
+census found readers by matching a fixed list of helper NAMES
+(`env_usize`, `env::var`, ...), so `nros-params/build.rs` wrapping its rungs in
+a local `knob()` took its five knobs out of the count while `--check` stayed
+green — the gate only fails on a name it SEES and cannot classify.
+
+Matching any call instead is the opposite error: `.define("ZPICO_X", ..)` emits
+a C macro and `.with_env(..)` sets a CHILD's environment, and counting those
+added 67 phantom names. So the matcher now carries `READ_CALLEES` and
+`NON_READ_CALLEES`, and a callee in NEITHER is a failure — the same "a new knob
+forces a decision" rule this census already applies to knobs, applied to the
+idioms that read them.
+
+That surfaced 29 names read through `req` / `list` / `env_get` / `flag`, which
+the fixed list never knew: 18 infra (board descriptor facts, include and source
+dirs) and **11 sizing** — the RMW static pools, the smoltcp driver pools and
+timeouts, the XRCE stream depth, and the zpico subscriber ring depth. So W6's
+backlog is **28, not 17**; it went up because the instrument stopped lying. Two
+candidate tenants fall out of it, an `rmw` one and a `net` one, neither owned by
+another campaign.
+
+**The lesson, and it is not the same one as below:** a counting gate that
+under-counts silently is worse than no gate, because a wrong baseline looks
+measured. Both of this census's counters now have negative controls on synthetic
+input for exactly that reason.
 
 **The lesson for the wave, stated once:** "migrate the long tail into the
 ladder" was the right instinct for the executor tenant and is the wrong default

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -162,6 +162,9 @@ pub struct Knobs {
     /// phase-400 W6 — the platform memory tenant (RTOS heap, app stack).
     #[serde(default)]
     pub memory: MemoryKnobs,
+    /// phase-400 W6 — the parameter-storage tenant.
+    #[serde(default)]
+    pub params: ParamKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -346,6 +349,30 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.params]` RUNGS for this build — platform merged with board,
+    /// board winning, no env rung. Same reason as [`Self::executor_rungs`]:
+    /// `nros-params`'s build script composes env → Kconfig → these → its own
+    /// builtin, and the Kconfig rung sits between the front-end and the
+    /// descriptors.
+    pub fn param_rungs(&self) -> ParamKnobs {
+        let plat = self
+            .tree
+            .platform_param_rungs(&self.platform)
+            .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={}: {e}", self.platform));
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.params.clone())
+            .unwrap_or_default();
+        ParamKnobs {
+            max_parameters: b.max_parameters.or(plat.max_parameters),
+            max_param_name_len: b.max_param_name_len.or(plat.max_param_name_len),
+            max_string_value_len: b.max_string_value_len.or(plat.max_string_value_len),
+            max_array_len: b.max_array_len.or(plat.max_array_len),
+            max_byte_array_len: b.max_byte_array_len.or(plat.max_byte_array_len),
+        }
+    }
+
     /// The memory tenant for this build, over the full ladder.
     pub fn memory(&self, defaults: &[(&'static str, usize)]) -> Vec<(&'static str, ResolvedUsize)> {
         self.tree
@@ -399,6 +426,48 @@ pub fn executor_env_only(knob: &str, default: usize) -> usize {
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .unwrap_or(default)
+}
+
+/// `[knobs.params]` — phase-400 W6, the parameter-storage tenant.
+///
+/// Five bounds on what a parameter server can hold. They vary by BOARD in
+/// practice and the tree records a case: phase-292's ASI consumer needed
+/// `NROS_MAX_PARAMETERS=256` and set it in a `build.sh`, which is a board fact
+/// living in a shell script because there was nowhere to declare it.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParamKnobs {
+    #[serde(default)]
+    pub max_parameters: Option<usize>,
+    #[serde(default)]
+    pub max_param_name_len: Option<usize>,
+    #[serde(default)]
+    pub max_string_value_len: Option<usize>,
+    #[serde(default)]
+    pub max_array_len: Option<usize>,
+    #[serde(default)]
+    pub max_byte_array_len: Option<usize>,
+}
+
+/// Every parameter knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const PARAM_KNOBS: &[&str] = &[
+    "max_parameters",
+    "max_param_name_len",
+    "max_string_value_len",
+    "max_array_len",
+    "max_byte_array_len",
+];
+
+/// The env front-end for a parameter knob — the EXISTING names, verbatim.
+pub fn param_env_key(knob: &str) -> &'static str {
+    match knob {
+        "max_parameters" => "NROS_MAX_PARAMETERS",
+        "max_param_name_len" => "NROS_MAX_PARAM_NAME_LEN",
+        "max_string_value_len" => "NROS_MAX_STRING_VALUE_LEN",
+        "max_array_len" => "NROS_MAX_ARRAY_LEN",
+        "max_byte_array_len" => "NROS_MAX_BYTE_ARRAY_LEN",
+        other => panic!("unknown param knob `{other}`"),
+    }
 }
 
 /// The zenoh tx tenant with NO platform rung — the env front-end over the
@@ -1146,6 +1215,77 @@ impl PlatformsTree {
     ///
     /// Each knob keeps its existing env name, so migrating a knob changes no
     /// call site — it only adds the two rungs it never had.
+    /// The `[knobs.params]` a platform's chain declares, merged nearest-wins.
+    fn platform_param_knobs(&self, name: &str) -> Result<ParamKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = ParamKnobs::default();
+        for file in chain.iter().rev() {
+            let p = &file.knobs.params;
+            for (dst, src) in [
+                (&mut out.max_parameters, p.max_parameters),
+                (&mut out.max_param_name_len, p.max_param_name_len),
+                (&mut out.max_string_value_len, p.max_string_value_len),
+                (&mut out.max_array_len, p.max_array_len),
+                (&mut out.max_byte_array_len, p.max_byte_array_len),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.params]` rungs, without resolution — for a build script that
+    /// owns the defaults and its own env/Kconfig front-end.
+    pub fn platform_param_rungs(&self, platform: &str) -> Result<ParamKnobs, ConfigError> {
+        self.platform_param_knobs(platform)
+    }
+
+    /// phase-400 W6 — resolve the parameter tenant over the RFC-0049 ladder.
+    pub fn resolve_params(
+        &self,
+        platform: &str,
+        board: Option<&ParamKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_param_knobs(platform)?;
+        let pick = |k: &ParamKnobs, name: &str| match name {
+            "max_parameters" => k.max_parameters,
+            "max_param_name_len" => k.max_param_name_len,
+            "max_string_value_len" => k.max_string_value_len,
+            "max_array_len" => k.max_array_len,
+            "max_byte_array_len" => k.max_byte_array_len,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = param_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
+        }
+        Ok(out)
+    }
+
     /// The `[knobs.memory]` a platform's chain declares, merged nearest-wins.
     fn platform_memory_knobs(&self, name: &str) -> Result<MemoryKnobs, ConfigError> {
         let chain = self.chain(name)?;

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -378,6 +378,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -439,6 +439,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -323,6 +323,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -310,6 +310,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -365,6 +365,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -365,6 +365,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -323,6 +323,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -320,6 +320,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -327,6 +327,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -264,6 +264,33 @@ fn explain(args: ExplainArgs) -> Result<()> {
         );
     }
 
+    // phase-400 W6 — the parameter-storage tenant. Defaults mirror
+    // `nros-params/build.rs`, which stays the authority on them.
+    let param_defaults: &[(&str, usize)] = &[
+        ("max_parameters", 32),
+        ("max_param_name_len", 64),
+        ("max_string_value_len", 256),
+        ("max_array_len", 32),
+        ("max_byte_array_len", 256),
+    ];
+    for (name, r) in tree
+        .resolve_params(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.params),
+            &env_get,
+            param_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?
+    {
+        println!(
+            "{:<34} {:<10} {}  [{}]",
+            format!("params.{name}"),
+            r.value,
+            r.source.as_str(),
+            r.env_key
+        );
+    }
+
     // phase-400 W6 — the platform memory tenant. Defaults mirror the board
     // crate that sizes each: FreeRTOS heap_4 `ucHeap` at the `rmw-zenoh` 2 MiB,
     // and the `nros_app` task stack. Both in BYTES, which is the ladder's unit;

--- a/packages/core/nros-params/Cargo.toml
+++ b/packages/core/nros-params/Cargo.toml
@@ -35,3 +35,10 @@ workspace = true
 
 [build-dependencies]
 nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }
+
+# phase-400 W6 — the RFC-0049 knob ladder, so the five parameter bounds get
+# their platform and board rungs. Host-only (`build-helpers` gates serde/toml)
+# and build-only; no cycle, `nros-board-common` does not depend on this crate.
+nros-board-common = { path = "../../boards/nros-board-common", features = [
+    "build-helpers",
+], default-features = false }

--- a/packages/core/nros-params/build.rs
+++ b/packages/core/nros-params/build.rs
@@ -8,11 +8,22 @@ use std::{env, path::Path};
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    let max_parameters = env_usize("NROS_MAX_PARAMETERS", 32);
-    let max_param_name_len = env_usize("NROS_MAX_PARAM_NAME_LEN", 64);
-    let max_string_value_len = env_usize("NROS_MAX_STRING_VALUE_LEN", 256);
-    let max_array_len = env_usize("NROS_MAX_ARRAY_LEN", 32);
-    let max_byte_array_len = env_usize("NROS_MAX_BYTE_ARRAY_LEN", 256);
+    // phase-400 W6 — the platform and board rungs sit under the env/Kconfig
+    // front-end each of these already had. phase-292's ASI consumer needed
+    // `NROS_MAX_PARAMETERS=256` and set it in a `build.sh`: a board fact living
+    // in a shell script because there was nowhere to declare it.
+    //
+    // `None` when no lane names a platform (a bare `cargo build`), and then
+    // every knob below is exactly the env-or-default it always was.
+    let rungs = nros_board_common::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.param_rungs())
+        .unwrap_or_default();
+
+    let max_parameters = knob("NROS_MAX_PARAMETERS", rungs.max_parameters, 32);
+    let max_param_name_len = knob("NROS_MAX_PARAM_NAME_LEN", rungs.max_param_name_len, 64);
+    let max_string_value_len = knob("NROS_MAX_STRING_VALUE_LEN", rungs.max_string_value_len, 256);
+    let max_array_len = knob("NROS_MAX_ARRAY_LEN", rungs.max_array_len, 32);
+    let max_byte_array_len = knob("NROS_MAX_BYTE_ARRAY_LEN", rungs.max_byte_array_len, 256);
 
     let contents = format!(
         "/// Maximum number of parameters the server can store \
@@ -39,22 +50,17 @@ fn main() {
     std::fs::write(Path::new(&out_dir).join("nros_params_config.rs"), contents).unwrap();
 }
 
-/// Read a usize from an environment variable, falling back to a default.
-/// Resolve a sizing knob the way every other nros build script does.
+/// One parameter knob: env → Kconfig → the descriptor rung → built-in default.
 ///
-/// Issue 0460 — a Zephyr RUST image inherits NONE of cmake's `set(ENV{...})`
-/// knob exports: that call only touches the configure-time process, the C lane
-/// re-bakes them into its own command, and zephyr-lang-rust's
-/// `rust_cargo_application` builds a fresh one that inherits nothing. So a plain
-/// `env::var` here reads the crate DEFAULT on Zephyr no matter what Kconfig
-/// says, and the two lanes then disagree about a compile-time constant — an
-/// 0135-class ABI split, silently.
-///
-/// `knob_usize` reads `$DOTCONFIG` for `CONFIG_<name>` and falls back to the
-/// environment, which is what `nros-node`'s identical helper does. Gated by
-/// `check-kconfig-knob-forwarding`, which went red when #0749 taught
-/// `zephyr/cmake/nros_cargo_build.cmake` to forward `NROS_MAX_PARAMETERS` while
-/// this crate — its only reader — still used the env-only form.
-fn env_usize(name: &str, default: usize) -> usize {
-    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), default)
+/// The front-end keeps winning. Migrating a knob into the ladder must not take
+/// an operator's override away, which is half of this wave's own gate.
+fn knob(name: &str, rung: Option<usize>, default: usize) -> usize {
+    println!("cargo:rerun-if-env-changed={name}");
+    if let Some(v) = env::var(name).ok().and_then(|v| v.trim().parse().ok()) {
+        return v;
+    }
+    if let Some(v) = nros_zephyr_build::dotconfig_usize(&format!("CONFIG_{name}")) {
+        return v;
+    }
+    rung.unwrap_or(default)
 }

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -442,6 +442,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -474,6 +474,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -381,6 +381,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -315,6 +315,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -326,6 +326,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -305,6 +305,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -305,6 +305,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/packages/verification/nros-verification/Cargo.lock
+++ b/packages/verification/nros-verification/Cargo.lock
@@ -181,6 +181,7 @@ name = "nros-params"
 version = "0.5.0"
 dependencies = [
  "heapless",
+ "nros-board-common",
  "nros-zephyr-build",
 ]
 

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -65,6 +65,12 @@ OWNERS: dict[str, str] = {
     # The transport and zenoh-tx tenants resolve inside the ladder itself, so
     # the resolver IS the owner. `nros-zpico-build` re-read the tx trio for its
     # no-platform case until W8 replaced that with `tx_env_only`.
+    # The parameter tenant (phase-400 W6).
+    "NROS_MAX_PARAMETERS": "packages/core/nros-params/build.rs",
+    "NROS_MAX_PARAM_NAME_LEN": "packages/core/nros-params/build.rs",
+    "NROS_MAX_STRING_VALUE_LEN": "packages/core/nros-params/build.rs",
+    "NROS_MAX_ARRAY_LEN": "packages/core/nros-params/build.rs",
+    "NROS_MAX_BYTE_ARRAY_LEN": "packages/core/nros-params/build.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 15
+LADDER_FLOOR = 20
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -83,11 +83,11 @@ KNOB_CLASS = {
     "ZPICO_SUBSCRIBER_SIZE_THRESHOLD": ("derived", "SMALL_CLASS_CEILING (phase-403)"),
     "ZPICO_PUBLISHER_TX_BUFFER_SIZE": ("derived", "TX half of the same split"),
     # --- sizing: the backlog ---
-    "NROS_MAX_ARRAY_LEN": ("sizing", "parameter value bound (nros-params)"),
-    "NROS_MAX_BYTE_ARRAY_LEN": ("sizing", "parameter value bound (nros-params)"),
-    "NROS_MAX_STRING_VALUE_LEN": ("sizing", "parameter value bound (nros-params)"),
-    "NROS_MAX_PARAM_NAME_LEN": ("sizing", "parameter bound"),
-    "NROS_MAX_PARAMETERS": ("sizing", "parameter cap"),
+    "NROS_MAX_ARRAY_LEN": ("ladder", "params tenant"),
+    "NROS_MAX_BYTE_ARRAY_LEN": ("ladder", "params tenant"),
+    "NROS_MAX_STRING_VALUE_LEN": ("ladder", "params tenant"),
+    "NROS_MAX_PARAM_NAME_LEN": ("ladder", "params tenant"),
+    "NROS_MAX_PARAMETERS": ("ladder", "params tenant"),
     "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("sizing", "component cap"),
     "NROS_RUNTIME_MAX_CELL_ENTITIES": ("sizing", "component cap"),
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("sizing", "component cap"),
@@ -152,6 +152,48 @@ KNOB_CLASS = {
     "NROS_ENTRY_SPIN_MS": ("sizing", "entry spin period; a duration, same ladder shape"),
     # --- infra: pointers, flags and orchestration inputs ---
     "NROS_BOARD_TOML": ("infra", "the ladder's own board rung pointer"),
+    # Surfaced when the reader matcher stopped enumerating helper names
+    # (READ_CALLEES). These are read through `req`/`list`/`env_get`/`flag`,
+    # which the old fixed list did not know, so the census had never counted
+    # them and the W6 backlog was measured 29 names short.
+    #
+    # The board descriptor's facts: identity and paths the CLI hands the build,
+    # which are what the ladder RESOLVES AGAINST rather than knobs it resolves.
+    "NROS_BOARD_ZEPHYR_ID": ("infra", "board descriptor fact"),
+    "NROS_BOARD_TOOLCHAIN": ("infra", "board descriptor fact"),
+    "NROS_BOARD_RUNNER": ("infra", "board descriptor fact"),
+    "NROS_BOARD_RUST_TARGETS": ("infra", "board descriptor fact"),
+    "NROS_BOARD_GATED_PKGS": ("infra", "board descriptor fact"),
+    "NROS_BOARD_PRJ_CONF": ("infra", "board descriptor path"),
+    "NROS_BOARD_BOARD_CONF": ("infra", "board descriptor path"),
+    "NROS_BOARD_BOARD_OVERLAY": ("infra", "board descriptor path"),
+    "NROS_BOARD_DEFAULT_RMW": ("infra", "board descriptor default, not a size"),
+    "NROS_BOARD_DEFAULT_TRANSPORT": ("infra", "board descriptor default, not a size"),
+    # Source and include directories.
+    "NROS_C_INCLUDE": ("infra", "include dir"),
+    "NROS_CPP_INCLUDE": ("infra", "include dir"),
+    "NROS_PLATFORM_CFFI_INCLUDE": ("infra", "include dir"),
+    "NROS_PLATFORM_POSIX_SRC": ("infra", "platform source dir"),
+    "NROS_PLATFORM_FREERTOS_SRC": ("infra", "platform source dir"),
+    "NROS_PLATFORM_THREADX_SRC": ("infra", "platform source dir"),
+    "NROS_LAN9118_LWIP_DIR": ("infra", "driver source dir"),
+    "NROS_VIRTIO_NET_NETX_DIR": ("infra", "driver source dir"),
+    # Sizes, and none of them owned by another campaign: the only live doc
+    # hits are usage records (phase-358 records `=8` as what recovered #271's
+    # overflow; the dependency-weight audit names the RMW cap as a knob cmake
+    # never resolves). Both are arguments FOR a board rung, the same shape the
+    # ASI consumer's `NROS_MAX_PARAMETERS=256` had.
+    "NROS_RMW_MAX_BACKENDS": ("sizing", "static pool; candidate rmw tenant"),
+    "NROS_RMW_MAX_NODES": ("sizing", "static pool; candidate rmw tenant"),
+    "NROS_RMW_SUBSCRIBER_SLOTS": ("sizing", "static pool; candidate rmw tenant"),
+    "NROS_RMW_MESSAGE_INFO_SLOTS": ("sizing", "static pool; candidate rmw tenant"),
+    "NROS_SMOLTCP_MAX_SOCKETS": ("sizing", "driver pool; candidate net tenant"),
+    "NROS_SMOLTCP_MAX_UDP_SOCKETS": ("sizing", "driver pool; candidate net tenant"),
+    "NROS_SMOLTCP_BUFFER_SIZE": ("sizing", "driver buffer; candidate net tenant"),
+    "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": ("sizing", "driver timeout; candidate net tenant"),
+    "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": ("sizing", "driver timeout; candidate net tenant"),
+    "NROS_XRCE_STREAM_HISTORY": ("sizing", "xrce stream depth; candidate rmw tenant"),
+    "ZPICO_SUBSCRIBER_RING_DEPTH": ("sizing", "SPSC ring depth (count, not a byte size)"),
     "NROS_EXTRA_BOARD_PATH": ("infra", "extra board search roots"),
     "NROS_HOME": ("infra", "path"),
     "NROS_MODEL_DIR": ("infra", "path"),
@@ -198,7 +240,13 @@ def ladder_knobs():
     """Fields on the typed `[knobs.*]` structs — the migrated knobs."""
     src = read(os.path.join(ROOT, "packages/boards/nros-board-common/src/platform_config.rs"))
     total = {}
-    for struct in ("TxKnobs", "ExecutorKnobs", "TransportKnobs", "MemoryKnobs"):
+    for struct in (
+        "TxKnobs",
+        "ExecutorKnobs",
+        "TransportKnobs",
+        "MemoryKnobs",
+        "ParamKnobs",
+    ):
         fields = _struct_fields(src, struct)
         if fields:
             total[struct] = fields
@@ -213,22 +261,70 @@ def kconfig_symbols():
     return syms
 
 
-def _env_names_in(txt, prefix):
-    """`<PREFIX>_*` names READ from the environment in one source string.
+# How a build script READS a knob, and how it does everything else with one.
+#
+# The census used to carry only the first list, and matching nothing else meant
+# a build script that introduced a helper of its own silently dropped its knobs
+# from the count: `nros-params/build.rs` wrapped its rungs in a local `knob()`
+# and five names vanished while `--check` still passed, because the gate only
+# fails on a name it SEES and cannot classify.
+#
+# Matching ANY call instead is the opposite error -- `.define("ZPICO_X", ..)`
+# emits a C macro and `.with_env("NROS_X", ..)` sets a CHILD's environment;
+# counting those as readers added 67 phantom names. So both lists are explicit
+# and a callee in neither is a FAILURE: the same "a new knob forces a decision"
+# rule this file already applies to knobs, applied to the idioms that read them.
+READ_CALLEES = {
+    "env", "env_get", "env_bool", "env_usize", "env_usize_min",
+    "env_usize_compat", "env_or_repo_path", "env_path_or", "flag", "knob",
+    "knob_usize", "knob_bool", "req", "list", "var", "var_os",
+}
+
+# Not reads. Named rather than ignored by default, so the failure below stays
+# meaningful.
+NON_READ_CALLEES = {
+    "define",          # emits a C preprocessor macro
+    "set_var", "remove_var", "with_env",  # WRITES an environment
+    "push", "insert",  # builds a list / a fact map
+    "get", "contains", "contains_key", "starts_with",  # inspects one
+}
+
+_CALL_RE = r'([A-Za-z_][A-Za-z0-9_:]*)\s*\(\s*&?"({prefix}_[A-Z0-9_]+)"'
+
+
+def _calls_in(txt, prefix):
+    """(callee, name) for every call taking a `<PREFIX>_*` literal first.
 
     Comments are stripped first: a knob named in a comment is documentation,
     not a reader, and counting it inflates the number this gate exists to
-    track. Factored out so the selftest drives it on synthetic input.
+    track. Macros are excluded by the absence of `!` from the callee pattern,
+    which keeps `panic!("NROS_X unset")` and friends out.
     """
     stripped = re.sub(r"(?m)^\s*(///|//).*$", "", txt)
-    return set(
-        m.group(1)
-        for m in re.finditer(
-            r'(?:env::var|env::var_os|env|env_usize|env_bool|knob_usize|knob_bool)'
-            r'\s*\(\s*&?"(' + prefix + r'_[A-Z0-9_]+)"',
-            stripped,
-        )
-    )
+    return [
+        (m.group(1).rsplit("::", 1)[-1], m.group(2))
+        for m in re.finditer(_CALL_RE.format(prefix=prefix), stripped)
+    ]
+
+
+def _env_names_in(txt, prefix):
+    """`<PREFIX>_*` names READ from the environment in one source string.
+
+    Factored out so the selftest drives it on synthetic input.
+    """
+    return {n for callee, n in _calls_in(txt, prefix) if callee in READ_CALLEES}
+
+
+def unknown_idioms(sources, prefixes):
+    """Callees that neither read nor demonstrably-don't. See READ_CALLEES."""
+    out = {}
+    for path in sources:
+        txt = read(path)
+        for prefix in prefixes:
+            for callee, name in _calls_in(txt, prefix):
+                if callee not in READ_CALLEES and callee not in NON_READ_CALLEES:
+                    out.setdefault(callee, set()).add(name)
+    return out
 
 
 def build_env_sources():
@@ -290,8 +386,21 @@ def self_test() -> None:
         '// NROS_EXECUTOR_MAX_CBS was read here once',
         'println!("set NROS_THING");',
         'let n = env_usize("ZPICO_TX_BATCH", 0);',
+        # ...including the shapes that TOUCH a knob without reading one.
+        'cfg.define("NROS_THING", "1");',
+        'cmd.with_env("NROS_THING", "");',
+        'flags.push("NROS_THING");',
     ):
         assert not _env_names_in(src, "NROS"), f"selftest: false positive on {src!r}"
+
+    # An idiom in NEITHER list must be reported rather than silently dropped:
+    # that silent drop is exactly what hid five knobs behind a local `knob()`.
+    assert _calls_in('let n = brand_new_helper("NROS_THING", 4);', "NROS") == [
+        ("brand_new_helper", "NROS_THING")
+    ], "selftest: the call matcher missed an unknown idiom"
+    assert not _env_names_in('let n = brand_new_helper("NROS_THING", 4);', "NROS"), (
+        "selftest: an unknown idiom was counted as a read"
+    )
 
     # The ladder counter reads STRUCT FIELDS, so it must not count a doc
     # comment, a non-`pub` field, or a field of a struct it was not asked for.
@@ -350,6 +459,25 @@ def main() -> int:
             print(f"  {cls}:")
             for n in by_class.get(cls, []):
                 print(f"    {n:<36} {KNOB_CLASS[n][1]}")
+
+    unknown = unknown_idioms(build_env_sources(), ("NROS", "ZPICO"))
+    if unknown:
+        sys.stderr.write(
+            "config-knob-census: FAILED — build script(s) touch a knob name "
+            "through an idiom this census does not know:\n"
+        )
+        for callee, names in sorted(unknown.items()):
+            sample = ", ".join(sorted(names)[:3])
+            sys.stderr.write(f"    {callee}(...)  e.g. {sample}\n")
+        sys.stderr.write(
+            "  Add it to READ_CALLEES if it READS the environment, or to\n"
+            "  NON_READ_CALLEES if it does something else with the name (emits\n"
+            "  a C macro, sets a child's env, builds a list). Neither list may\n"
+            "  be skipped: a helper in neither is counted as nothing, which is\n"
+            "  how a local `knob()` wrapper took five migrated knobs out of\n"
+            "  this census while the gate stayed green.\n"
+        )
+        return 1
 
     if unclassified:
         sys.stderr.write(

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -70,6 +70,20 @@ KNOB_PATTERNS = [
     # figures for BOTH payload pools -- the `SLOTS` regression this list already
     # records, one wrapper later.
     re.compile(r'\benv_usize_min\(\s*"([A-Z0-9_]+)"\s*,\s*([0-9_]+)\s*,\s*[0-9_]+\s*\)'),
+    # `knob("NAME", rung, 32)` — the LADDER shape (phase-400 W6): env, then
+    # Kconfig, then the platform/board rung, then the builtin LAST. So the
+    # figure this table wants is the third argument, where every other spelling
+    # puts it second.
+    #
+    # Third entry in this list added for the same reason as the two above it,
+    # which is the point: a crate that grows a resolution rule wraps its reads,
+    # and the wrapper is invisible here until someone notices a knob went
+    # missing. The params tenant's five knobs rendered as "computed — see
+    # build.rs:25" -- a line number in a generated table, churning on every
+    # edit, in place of the default it exists to publish.
+    re.compile(
+        r'\bknob\(\s*"([A-Z0-9_]+)"\s*,\s*[A-Za-z0-9_.]+\s*,\s*([0-9_]+)\s*\)'
+    ),
 ]
 
 # `// nros-pool: NAME = KNOB * KNOB * 4` — products of knobs and integers only.
@@ -240,6 +254,8 @@ def self_test():
         'let y = env_usize_min("NROS_PROBE_DEPTH", 3, 1);\n'
         '// nros-pool: P = NROS_PROBE_SLOTS * 8\n'
         '// nros-pool: Q = NROS_PROBE_DEPTH * NROS_PROBE_SLOTS\n'
+        'let z = knob("NROS_PROBE_LADDER", rungs.thing, 9);\n'
+        'let w = knob("NROS_PROBE_PLAIN", 7);\n'
     )
     tmp = os.path.join(ROOT, "tmp")
     os.makedirs(tmp, exist_ok=True)
@@ -252,6 +268,14 @@ def self_test():
     assert k.get("NROS_PROBE_DEPTH", (None,))[0] == 3, (
         "env_usize_min knob not scanned — its DEFAULT is the reported figure, "
         "not its floor (issue 0827)"
+    )
+    assert k.get("NROS_PROBE_LADDER", (None,))[0] == 9, (
+        "ladder knob not scanned — `knob(name, rung, builtin)` puts the "
+        "builtin THIRD, and reading the second argument yields a rung "
+        "expression, not a figure (phase-400 W6)"
+    )
+    assert k.get("NROS_PROBE_PLAIN", (None,))[0] == 7, (
+        "the two-argument `knob(name, default)` spelling must still scan"
     )
     by_name = {name: expr for name, expr, *_ in pl}
     assert "P" in by_name, "pool annotation not scanned"


### PR DESCRIPTION
Stacked on #177 — review that first; this PR's own diff is the single commit `1ba14271b`.

## The `params` tenant

The five `NROS_MAX_*` **parameter-storage** bounds (not message bounds — that mislabel is corrected in the census) move onto the RFC-0049 ladder: `ParamKnobs`, `[knobs.params]` in a platform or board toml, `BuildRungs::param_rungs()`, and one reader in `nros-params/build.rs` composing env → Kconfig → rung → builtin.

```
$ nros config explain --platform zephyr
params.max_parameters              32         builtin  [NROS_MAX_PARAMETERS]
...
$ NROS_MAX_PARAMETERS=77 nros config explain --platform zephyr
params.max_parameters              77         env      [NROS_MAX_PARAMETERS]
```

Checked for an owning campaign first, per the lesson that has bitten this wave twice. The only doc hit is a usage *record* — the ASI consumer's `NROS_MAX_PARAMETERS=256` living in its own `build.sh` — which is the argument **for** a rung, not against one.

## The census had been under-counting by 29

Wiring the gate exposed a defect in the measuring instrument, and it is the more important half of this PR.

The census found readers by matching a fixed list of helper **names** (`env_usize`, `env::var`, …). Wrapping these five reads in a local `knob()` took them out of the count **while `--check` stayed green** — the gate only fails on a name it *sees* and cannot classify.

Matching *any* call is the opposite error: `.define("ZPICO_X", ..)` emits a C macro and `.with_env(..)` sets a **child's** environment; counting those added 67 phantom names. So the matcher now carries `READ_CALLEES` and `NON_READ_CALLEES` and **fails on a callee in neither** — the same "a new knob forces a decision" rule this census already applied to knobs, applied to the idioms that read them.

That surfaced **29 names** read through `req` / `list` / `env_get` / `flag`:

| | count | |
| --- | --- | --- |
| infra | 18 | board descriptor facts, include and source dirs |
| **sizing** | **11** | RMW static pools, smoltcp driver pools + timeouts, XRCE stream depth, zpico ring depth |

**W6's backlog is 28, not 17.** It went up because the instrument stopped lying. Two candidate tenants fall out of it — an `rmw` one and a `net` one — neither owned by another campaign.

## `gen-pool-inventory` had the same blind spot

Same cause, one tool over: it rendered the five defaults as `computed — see build.rs:25`, a churning line number in place of the figure the table exists to publish. Its own comments already record this regression twice (`knob`, then `env_usize_min`). The ladder shape puts the builtin **third**, so it needs a third pattern; both `knob` spellings now have selftest probes.

## Verification

- `just check fast` — 158/158 OK
- `just ci l1` — passed (compile + unit)
- `just check pool-inventory` / `config-knob-census` / `knob-single-reader` / `gate-selftests` — OK
- 18 leaf locks regenerated via `just lock-update` for the new build-dep edge; diff reviewed — `+ "nros-board-common",` and nothing else, no registry packages.
