### PR TITLE
fix(rtos-e2e): the skip named the gate, not the missing tool

### DIFF
--- a/packages/testing/nros-tests/src/process.rs
+++ b/packages/testing/nros-tests/src/process.rs
@@ -1473,9 +1473,28 @@ pub fn is_local_tcp_listener_available() -> bool {
 /// }
 /// ```
 pub fn require_zenohd() -> bool {
+    match zenohd_unavailable_reason() {
+        Some(why) => {
+            eprintln!("Skipping test: {why}");
+            false
+        }
+        None => true,
+    }
+}
+
+/// Why the zenoh router is unusable here, or `None` if it is usable.
+///
+/// The reason-returning half of [`require_zenohd`], added for issue 0982: a
+/// caller that turns "unavailable" into a SKIP must be able to put the cause in
+/// the skip message. `require_zenohd`'s `eprintln!` goes to stderr, which
+/// nextest suppresses under `--failure-output never` — so the CI log recorded
+/// that a precondition was unmet and never which one.
+///
+/// `require_zenohd` keeps its `bool` signature: it has ~190 call sites, and the
+/// ones that merely gate an early return do not need the text.
+pub fn zenohd_unavailable_reason() -> Option<String> {
     if !is_local_tcp_listener_available() {
-        eprintln!("Skipping test: local TCP listeners unavailable in this environment");
-        return false;
+        return Some("local TCP listeners unavailable in this environment".to_string());
     }
 
     if !is_zenohd_available() {
@@ -1483,17 +1502,18 @@ pub fn require_zenohd() -> bool {
         // package but an unsourced one, and `rmw_zenohd` is invisible to
         // `command -v` even when present, so "is it installed?" is the question
         // a reader cannot answer from the shell.
-        eprintln!(
-            "Skipping test: no ROS zenoh router. Source your ROS setup \
+        // Names SOURCING first (issue 0653) — see above.
+        return Some(
+            "no ROS zenoh router. Source your ROS setup \
              (`source /opt/ros/<distro>/setup.bash`) — that exports \
              AMENT_PREFIX_PATH, which is how the router is found; note \
              `rmw_zenohd` is NOT on PATH even when installed. Otherwise install \
              `ros-<distro>-rmw-zenoh-cpp`, or set NROS_RMW_ZENOHD to its path. \
              No ROS on this host? `--rmw cyclonedds` needs no router (phase-362)"
+                .to_string(),
         );
-        return false;
     }
-    true
+    None
 }
 
 /// Check if cmake is available in PATH

--- a/packages/testing/nros-tests/tests/rtos_e2e.rs
+++ b/packages/testing/nros-tests/tests/rtos_e2e.rs
@@ -14,7 +14,7 @@ use nros_tests::{
     TestError, TestResult, count_pattern,
     fixtures::{
         QemuProcess, ZenohRouter, freertos, is_qemu_available, is_qemu_riscv64_available, nuttx,
-        require_zenohd, threadx_linux, threadx_riscv64,
+        threadx_linux, threadx_riscv64, zenohd_unavailable_reason,
     },
     platform,
     process::{ManagedProcess, kill_process_group},
@@ -172,90 +172,82 @@ impl Platform {
         }
     }
 
-    fn require_e2e(self) -> bool {
+    /// `Ok(())` when this platform can run an e2e test here, else the reason.
+    ///
+    /// Issue 0982 — this returned `bool` and printed the reason with
+    /// `eprintln!`. nextest runs these lanes with `--failure-output never`, so
+    /// stderr is suppressed and the CI log said only `require_e2e check failed
+    /// for freertos`: the gate, never the missing tool. Five nightly cells
+    /// reported that for nine tests each. The messages were always here; they
+    /// just could not reach the skip.
+    fn require_e2e(self) -> Result<(), String> {
         match self {
             Platform::Freertos => {
                 if !freertos::is_freertos_available() {
-                    eprintln!("Skipping test: FREERTOS_DIR not set or invalid");
-                    return false;
+                    return Err("FREERTOS_DIR not set or invalid".to_string());
                 }
                 if !freertos::is_lwip_available() {
-                    eprintln!("Skipping test: LWIP_DIR not set or invalid");
-                    return false;
+                    return Err("LWIP_DIR not set or invalid".to_string());
                 }
                 if !freertos::is_arm_gcc_available() {
-                    eprintln!("Skipping test: arm-none-eabi-gcc not found");
-                    return false;
+                    return Err("arm-none-eabi-gcc not found".to_string());
                 }
                 if !is_qemu_available() {
-                    eprintln!("Skipping test: qemu-system-arm not found");
-                    return false;
+                    return Err("qemu-system-arm not found".to_string());
                 }
-                require_zenohd()
+                zenohd_unavailable_reason().map_or(Ok(()), Err)
             }
             Platform::Nuttx => {
                 if !nuttx::is_nuttx_available() {
-                    eprintln!("Skipping test: NUTTX_DIR not set or invalid");
-                    return false;
+                    return Err("NUTTX_DIR not set or invalid".to_string());
                 }
                 if !nuttx::is_nuttx_configured() {
-                    eprintln!("Skipping test: NuttX not configured");
-                    return false;
+                    return Err("NuttX not configured".to_string());
                 }
                 if !nuttx::is_arm_gcc_available() {
-                    eprintln!("Skipping test: arm-none-eabi-gcc not found");
-                    return false;
+                    return Err("arm-none-eabi-gcc not found".to_string());
                 }
                 if !nuttx::is_nuttx_toolchain_available() {
-                    eprintln!(
-                        "Skipping test: nightly toolchain missing rust-src for armv7a-nuttx-eabihf"
+                    return Err(
+                        "nightly toolchain missing rust-src for armv7a-nuttx-eabihf".to_string()
                     );
-                    return false;
                 }
                 // Issue 0743 — ask for the ARM kernel specifically. The old
                 // `.is_none()` check passed on a riscv image, because the two
                 // configurations share the one filename.
                 if let Err(why) = nuttx::nuttx_kernel_path_for(nuttx::NuttxArch::Arm) {
-                    eprintln!("Skipping test: {why}");
-                    return false;
+                    return Err(why.to_string());
                 }
                 if !is_qemu_available() {
-                    eprintln!("Skipping test: qemu-system-arm not found");
-                    return false;
+                    return Err("qemu-system-arm not found".to_string());
                 }
-                require_zenohd()
+                zenohd_unavailable_reason().map_or(Ok(()), Err)
             }
             Platform::ThreadxLinux => {
                 if !threadx_linux::is_threadx_available() {
-                    eprintln!("Skipping test: THREADX_DIR not set or invalid");
-                    return false;
+                    return Err("THREADX_DIR not set or invalid".to_string());
                 }
                 if !threadx_linux::is_nsos_netx_available() {
-                    eprintln!(
-                        "Skipping test: nsos-netx not found at packages/drivers/net/nsos-netx/"
+                    return Err(
+                        "nsos-netx not found at packages/drivers/net/nsos-netx/".to_string()
                     );
-                    return false;
                 }
-                require_zenohd()
+                zenohd_unavailable_reason().map_or(Ok(()), Err)
             }
             Platform::ThreadxRiscv64 => {
                 if !threadx_riscv64::is_threadx_available() {
-                    eprintln!("Skipping test: THREADX_DIR not set or invalid");
-                    return false;
+                    return Err("THREADX_DIR not set or invalid".to_string());
                 }
                 if !threadx_riscv64::is_netx_available() {
-                    eprintln!("Skipping test: NETX_DIR not set or invalid");
-                    return false;
+                    return Err("NETX_DIR not set or invalid".to_string());
                 }
                 if !threadx_riscv64::is_riscv_gcc_available() {
-                    eprintln!("Skipping test: riscv64-unknown-elf-gcc not found");
-                    return false;
+                    return Err("riscv64-unknown-elf-gcc not found".to_string());
                 }
                 if !is_qemu_riscv64_available() {
-                    eprintln!("Skipping test: qemu-system-riscv64 not found");
-                    return false;
+                    return Err("qemu-system-riscv64 not found".to_string());
                 }
-                require_zenohd()
+                zenohd_unavailable_reason().map_or(Ok(()), Err)
             }
         }
     }
@@ -512,8 +504,14 @@ fn maybe_skip(platform: Platform, lang: Lang, variant: Variant) -> bool {
         eprintln!("[SKIP] {} {} {:?}: {}", platform, lang, variant, reason);
         return true;
     }
-    if !platform.require_e2e() {
-        nros_tests::skip!("require_e2e check failed for {}", platform);
+    if let Err(why) = platform.require_e2e() {
+        // The site's OWN text, unchanged — those messages already name the
+        // remedy, and rewording here would put the remedy in two places.
+        // `<platform>: <reason>` rather than `<platform> needs <reason>`: the
+        // reasons are a mix of noun phrases ("arm-none-eabi-gcc not found") and
+        // full sentences ("the NuttX kernel at … is a RiscV image, but this
+        // lane needs Arm"), and only the colon reads correctly for both.
+        nros_tests::skip!("{}: {}", platform, why);
     }
     false
 }


### PR DESCRIPTION
Five nightly cells report `require_e2e check failed for <platform>`, nine times each, and that sentence contains nothing anyone can act on.

**The reasons were always there.** `require_e2e` runs up to six checks per platform, each with its own message naming the remedy — and threw all of them away:

```rust
if !freertos::is_arm_gcc_available() {
    eprintln!("Skipping test: arm-none-eabi-gcc not found");
    return false;                       // <- the text stops here
}
```

`eprintln!` goes to stderr, and these lanes run under `--failure-output never`, so nextest suppresses it — `Skipping test:` appears **zero** times in the freertos job log. A `bool` can't carry a reason, so the skip site could only name the function that said no.

## The fix

`require_e2e` now returns `Result<(), String>`, and each check returns its own text **unchanged** — those messages already name the remedy, and rewording them at the skip site would put the remedy in two places.

Measured on this host, the same test before and after:

```
[SKIPPED] require_e2e check failed for nuttx

[SKIPPED] nuttx: the NuttX kernel at …/third-party/nuttx/nuttx/nuttx is a
          RiscV image, but this lane needs Arm (qemu-armv7a). The arm and riscv
          configurations share that ONE filename and each `make` reconfigures
          the tree (issue 0743), so the last build wins.
          Reconfigure and rebuild: just nuttx build-fixtures-arm
```

`<platform>: <reason>` rather than `<platform> needs <reason>` — the reasons are a mix of noun phrases (`arm-none-eabi-gcc not found`) and full sentences, and only the colon reads correctly for both. I tried the other way first and got *"nuttx needs the NuttX kernel at … is a RiscV image"*.

## `require_zenohd` keeps its signature

It has ~190 call sites and most only gate an early return, so changing it would be a large blast radius for no benefit. The reason-returning half is a new sibling, `zenohd_unavailable_reason() -> Option<String>`, which `require_zenohd` delegates to — so the router's long remedy text (issue 0653: name **sourcing** first, because `rmw_zenohd` is invisible to `command -v` even when installed) has exactly one copy.

## Knock-on

This makes `check-skip-budget`'s reason grouping useful for these lanes for the first time. It groups by the `[SKIPPED]` text, and until now every platform's nine skips collapsed into one bucket that said nothing.

## Verification

`cargo check -p nros-tests --all-targets` clean; `just check fast` 158 gates, 4 host-precondition skips. The message above is a real run on this host, not a constructed example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB