### PR TITLE
refactor(phase-383 W10.e): retire `resolve_target` — `target` is the rustc triple

### DIFF
--- a/docs/roadmap/phase-383-colcon-like-builder.md
+++ b/docs/roadmap/phase-383-colcon-like-builder.md
@@ -700,7 +700,7 @@ found only because these trees are not uniform the way ours are.
       | "a `[deploy.<n>.nros]` site layer — 30 `sdk` + 17 `netstack` — with no `[image.*]` counterpart" | 24 `[board_config.<board>]` blocks. The 30 held 3 distinct value-sets; keying on the board removed 25 duplicates. |
       | "`board_facts.rs` hard-ERRORS when `.board` is absent" | It selects candidates from `[image.*] ∪ [deploy.*]` and matches `--board` through the board catalog. |
       | "`check-deploy-board-resolves.py` errors if it finds zero deploy values" | It reads `[image.*]` and `[image_defaults]` too. Run today: `deploy boards resolve: OK (20 distinct value(s))`. |
-      | "13 production reader sites … the build fields are NOT inert" | Every one migrated to `[image.*]`-first with a deploy fallback: `resolve_target`, `derive_target_rtos`, `schema_build_json`, the `codegen_system` launch fallback, `doctor`, `board_facts`, and `synthesise_self_bringup`. |
+      | "13 production reader sites … the build fields are NOT inert" | Every one migrated to `[image.*]`-first with a deploy fallback: `resolve_target` (now `resolve_image`, W10.e), `derive_target_rtos`, `schema_build_json`, the `codegen_system` launch fallback, `doctor`, `board_facts`, and `synthesise_self_bringup`. |
       | "`nros build --dry-run` cannot see any of this" | Still true, and it is why 0951 verified with regenerated SystemModels plus `nros codegen entry` before/after, not with dry-runs. |
 
       The one claim that stands is the first: `[deploy.*]` is upstream's type
@@ -742,6 +742,35 @@ found only because these trees are not uniform the way ours are.
       tracks. The gate matches exactly one level below `examples/workspaces/`,
       so package manifests are untouched, and it runs its own negative control
       on every invocation (2 shapes that must flag, 5 that must not).
+- [x] **W10.e** Retire `resolve_target` — the last identifier asserting the
+      concept 0951 removed.
+
+      **Done.** `[system].default_target` was already retired and `--target`
+      already only an alias, but the resolver was still called
+      `resolve_target` while returning an IMAGE id, and the field it flowed
+      through was `PlanOptions.target`. That is the shape issue 0938 cost:
+      `nros build` resolving RMW from `[image.*]` while `plan` read
+      `[deploy.<t>]`, because "target" and "image" read as synonyms.
+
+      `resolve_target` → `resolve_image`, `PlanOptions.target` → `.image`,
+      `plan::Args.target` → `.image`, and the planner's `selected_target` /
+      `cli_target` → `selected_image` / `cli_image`. The names converge on what
+      `build.rs` and `image.rs` already spelled. **`target` now means the rustc
+      triple, and nothing else** — `plan.build.target` still does, which is why
+      the field rename mattered: the two sat one struct apart under one word.
+
+      The rename was driven by the COMPILER, not by sed, and that was load-
+      bearing: `target: None` appears in several unrelated option structs where
+      it IS the triple, so a textual pass would have renamed the wrong ones.
+      The compiler named all 21 sites across 9 files, in four rounds — and the
+      lines it did NOT name are the proof, being `target: None` in structs
+      where target is the triple.
+
+      No behaviour change: `--image` and its `--target` alias parse as before,
+      and the deprecated `[deploy.*]` sole-block rung stays (it retires with the
+      rest of the table at 0.6.0, W10.b) — now with a comment saying it is
+      unreachable for anything this tree authors and why.
+
 - [x] **W10.d** Book sweep: `examples/workspaces/*/README.md` still print the
       six-command ritual this phase deletes.
 

--- a/packages/cli/nros-build/src/lib.rs
+++ b/packages/cli/nros-build/src/lib.rs
@@ -244,7 +244,7 @@ pub fn generate_run_plan_with(opts: &Options) -> Result<PathBuf> {
         // Phase 255 — RMW resolved from the bringup's `system.toml`; build.rs has
         // no `--rmw` override.
         rmw: None,
-        target: None,
+        image: None,
     };
     let planning = plan_system(plan_options).wrap_err("nros-build: planner failed")?;
     println!("cargo:rerun-if-changed={}", model_path.display());

--- a/packages/cli/nros-cli-core/src/cmd/plan.rs
+++ b/packages/cli/nros-cli-core/src/cmd/plan.rs
@@ -77,9 +77,11 @@ pub struct Args {
     /// deprecated `[deploy.<t>]` → target-agnostic.
     ///
     /// `--target` is kept as an ALIAS, not a second flag: it named the deploy
-    /// era's concept, and the value callers pass is now an image id.
+    /// era's concept, and the value callers pass is now an image id. The FIELD
+    /// is `image` for the same reason `PlanOptions`' is — `target` in this tree
+    /// is the rustc triple, and the flag has been `--image` since 0951.
     #[arg(long = "image", alias = "target")]
-    pub target: Option<String>,
+    pub image: Option<String>,
 
     /// nano-ros checkout holding `packages/boards`, used to derive the selected
     /// image's rustc triple from its board descriptor. Defaults to
@@ -166,7 +168,7 @@ pub fn run(args: Args) -> Result<()> {
             manifest_files: args.manifests,
             launch_args: args.launch_args,
             rmw: args.rmw,
-            target: args.target,
+            image: args.image,
         })?;
         drop(tmp);
         eprintln!(
@@ -215,7 +217,7 @@ pub fn run(args: Args) -> Result<()> {
             manifest_files: args.manifests,
             launch_args: args.launch_args,
             rmw: args.rmw,
-            target: args.target,
+            image: args.image,
         })?;
         drop(tmp);
         eprintln!(
@@ -256,7 +258,7 @@ pub fn run(args: Args) -> Result<()> {
         manifest_files: args.manifests,
         launch_args: args.launch_args,
         rmw: args.rmw,
-        target: args.target,
+        image: args.image,
     })?;
 
     eprintln!(

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -2170,7 +2170,7 @@ fn generate_bridge_configs(
                 manifest_files: Vec::new(),
                 launch_args: Vec::new(),
                 rmw: None,
-                target: None,
+                image: None,
                 // Issue 0951 — this bridge plan runs inside the user's
                 // workspace, not a nano-ros checkout, so the resolver's own
                 // ladder (NROS_REPO_DIR, then an autodetect walk) is the right

--- a/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
@@ -896,11 +896,20 @@ impl SystemToml {
         blocks
     }
 
-    /// Phase 256 / issue 0951 — which per-target block a target-agnostic caller
-    /// (the planner) resolves values against when none was named:
+    /// Which IMAGE a caller that was given no image resolves values against:
     /// `cli` (`--image`, alias `--target`) → the sole image
     /// [`select_default_images`] picks → the sole DEPRECATED `[deploy.<t>]` →
     /// `None`.
+    ///
+    /// Phase 256 / issue 0951. It was `resolve_target` until the name was the
+    /// last thing here still asserting the retired concept: what it returns is
+    /// an image id, `[system].default_target` no longer decides anything, and
+    /// `--target` survives only as an alias. A function whose name says
+    /// "target" and whose body says "image" is how the two came to be read as
+    /// synonyms, which is what issue 0938 cost — `nros build` resolving RMW
+    /// from `[image.*]` while `plan` read `[deploy.<t>]`. The tree already
+    /// spelled it `selected_image` / `cli_image` in `build.rs` and `image.rs`;
+    /// this is the last holdout adopting the vocabulary its callers use.
     ///
     /// The image rung DELEGATES to `select_default_images` rather than
     /// reimplementing "explicit list, else the only one". That function is what
@@ -923,7 +932,7 @@ impl SystemToml {
     /// `deny_unknown_fields`, so deleting it would turn an unused key into a
     /// hard parse error for an out-of-tree user — and
     /// [`Self::deprecated_default_target_warning`] is what tells them.
-    pub fn resolve_target(&self, cli: Option<&str>) -> Option<String> {
+    pub fn resolve_image(&self, cli: Option<&str>) -> Option<String> {
         if let Some(c) = cli {
             return Some(c.to_string());
         }
@@ -933,6 +942,14 @@ impl SystemToml {
         {
             return Some(only.clone());
         }
+        // The DEPRECATED rung, and the only one left that reads `[deploy.*]`.
+        // Unreachable for anything this tree authors — 0951 left zero deploy
+        // blocks in any `system.toml`, and a synthesised bringup now projects
+        // an image for the same row, so the image rung above answers first
+        // (`nros_config.rs`'s synthesis test pins exactly that). It stays for
+        // an out-of-tree workspace written before 0951, and retires with the
+        // rest of `[deploy.*]` parsing at 0.6.0 — phase-383 W10.b, which is
+        // waiting on the version boundary, not on this.
         if self.deploy.len() == 1 {
             return self.deploy.keys().next().cloned();
         }
@@ -941,9 +958,9 @@ impl SystemToml {
 
     /// `default_images` names only declared images, or say which it does not.
     ///
-    /// [`Self::resolve_target`] must return an `Option`, so it can only IGNORE
+    /// [`Self::resolve_image`] must return an `Option`, so it can only IGNORE
     /// a bad `default_images` — and ignoring it means a typo silently
-    /// downgrades a plan to target-agnostic instead of failing. Callers with an
+    /// downgrades a plan to image-agnostic instead of failing. Callers with an
     /// error channel call this first; `select_default_images` is the one
     /// implementation of the rule, so this cannot drift from what
     /// `nros build` enforces.
@@ -1895,10 +1912,10 @@ board = "native"
         assert_eq!(bare.resolved_rmw(None, None), "zenoh");
     }
 
-    /// Phase 256 / issue 0951 — `resolve_target`: `--image` → the sole image
+    /// Phase 256 / issue 0951 — `resolve_image`: `--image` → the sole image
     /// `default_images` picks → the sole `[deploy.<t>]` → `None`.
     #[test]
-    fn resolve_target_precedence() {
+    fn resolve_image_precedence() {
         // CLI flag wins.
         let two: SystemToml = toml::from_str(
             "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n\
@@ -1906,9 +1923,9 @@ board = "native"
              [image.native]\nboard=\"native\"\n[image.qemu]\nboard=\"native\"\n",
         )
         .unwrap();
-        assert_eq!(two.resolve_target(Some("qemu")).as_deref(), Some("qemu"));
+        assert_eq!(two.resolve_image(Some("qemu")).as_deref(), Some("qemu"));
         // No flag → the one image `default_images` names.
-        assert_eq!(two.resolve_target(None).as_deref(), Some("native"));
+        assert_eq!(two.resolve_image(None).as_deref(), Some("native"));
 
         // `default_images` naming SEVERAL is not an answer to "which one".
         // A bringup that builds three images has no single "the" target, and
@@ -1920,7 +1937,7 @@ board = "native"
              [image.a]\nboard=\"native\"\n[image.b]\nboard=\"native\"\n",
         )
         .unwrap();
-        assert_eq!(many.resolve_target(None), None);
+        assert_eq!(many.resolve_image(None), None);
 
         // `[system].default_target` is RETIRED — it named the deploy era's
         // concept. The field still parses (deleting it from a
@@ -1932,7 +1949,7 @@ board = "native"
              [image.a]\nboard=\"native\"\n[image.b]\nboard=\"native\"\n",
         )
         .unwrap();
-        assert_eq!(retired.resolve_target(None), None, "it must not decide");
+        assert_eq!(retired.resolve_image(None), None, "it must not decide");
         let w = retired
             .deprecated_default_target_warning()
             .expect("set, so warned");
@@ -1951,14 +1968,14 @@ board = "native"
              [deploy.a]\nkind=\"self\"\n[deploy.b]\nkind=\"self\"\n",
         )
         .unwrap();
-        assert_eq!(ambiguous.resolve_target(None), None);
+        assert_eq!(ambiguous.resolve_image(None), None);
 
         // Sole deploy → that one (the deprecated rung, still live).
         let sole: SystemToml = toml::from_str(
             "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n[deploy.only]\nkind=\"self\"\n",
         )
         .unwrap();
-        assert_eq!(sole.resolve_target(None).as_deref(), Some("only"));
+        assert_eq!(sole.resolve_image(None).as_deref(), Some("only"));
 
         // Issue 0951 — the sole IMAGE resolves the same way, so a workspace
         // that has finished migrating off `[deploy.*]` still has a target.
@@ -1969,7 +1986,7 @@ board = "native"
              [image.firmware]\nboard=\"mps2-an385-freertos\"\n",
         )
         .unwrap();
-        assert_eq!(sole_image.resolve_target(None).as_deref(), Some("firmware"));
+        assert_eq!(sole_image.resolve_image(None).as_deref(), Some("firmware"));
 
         // Two images are as ambiguous as two deploys.
         let two_images: SystemToml = toml::from_str(
@@ -1977,7 +1994,7 @@ board = "native"
              [image.a]\nboard=\"native\"\n[image.b]\nboard=\"native\"\n",
         )
         .unwrap();
-        assert_eq!(two_images.resolve_target(None), None);
+        assert_eq!(two_images.resolve_image(None), None);
 
         // Mid-migration: one image and one deploy. The IMAGE is the half that
         // survives, so it decides — picking the deploy would resolve to a name
@@ -1987,7 +2004,7 @@ board = "native"
              [image.firmware]\nboard=\"native\"\n[deploy.legacy]\nkind=\"self\"\n",
         )
         .unwrap();
-        assert_eq!(both.resolve_target(None).as_deref(), Some("firmware"));
+        assert_eq!(both.resolve_image(None).as_deref(), Some("firmware"));
     }
 
     /// `image_for` folds `[image_defaults]` under the block. Forgetting the

--- a/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
@@ -657,7 +657,7 @@ fn synthesise_self_bringup(comp: &ComponentPackageEntry) -> BringupPackageEntry 
         );
     }
 
-    // Issue 0951 — project the same rows as images. `resolve_target`'s image
+    // Issue 0951 — project the same rows as images. `resolve_image`'s image
     // rung and every `image_for` reader see a synthesised bringup exactly as
     // they see an authored one.
     let image: BTreeMap<String, crate::orchestration::image::ImageBlock> = nros
@@ -1052,7 +1052,7 @@ locator = "tcp/127.0.0.1:7447"
         assert_eq!(img.board.as_deref(), Some("native_sim/native/64"));
         // Placement stays on the deploy side — an image has no `kind`.
         assert_eq!(
-            entry.system.resolve_target(None).as_deref(),
+            entry.system.resolve_image(None).as_deref(),
             Some("native"),
             "the sole image resolves the target"
         );

--- a/packages/cli/nros-cli-core/src/orchestration/planner.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/planner.rs
@@ -36,8 +36,12 @@ pub struct PlanOptions {
     /// `[image.<id>]` the planner resolves per-target values against (RMW
     /// override, build tuning). `None` ⇒ the sole image `default_images` picks
     /// → the sole deprecated `[deploy.<t>]` → target-agnostic. See
-    /// `SystemToml::resolve_target`.
-    pub target: Option<String>,
+    /// `SystemToml::resolve_image`.
+    ///
+    /// Named `image`, not `target`: in this tree `target` is the rustc triple
+    /// (`plan.build.target`), and this field selects an `[image.<id>]`. The two
+    /// sat one struct apart under one word.
+    pub image: Option<String>,
     /// nano-ros checkout holding `packages/boards`, for deriving the selected
     /// image's rustc triple from its board descriptor.
     ///
@@ -202,7 +206,7 @@ pub fn plan_system(options: PlanOptions) -> Result<PlanningOutput> {
     let build_json = schema_build_json(
         system_toml_path.as_deref(),
         options.rmw.as_deref(),
-        options.target.as_deref(),
+        options.image.as_deref(),
         catalog.as_ref(),
     )?;
     let build: PlanBuildOptions = serde_json::from_value(build_json.clone())
@@ -739,7 +743,7 @@ fn schema_plan_json(
 fn schema_build_json(
     system_toml: Option<&Path>,
     cli_rmw: Option<&str>,
-    cli_target: Option<&str>,
+    cli_image: Option<&str>,
     catalog: Option<&super::board_descriptor::BoardCatalog>,
 ) -> Result<Value> {
     let mut build = json!({
@@ -753,7 +757,7 @@ fn schema_build_json(
     });
     let obj = build.as_object_mut().expect("build is an object");
     // Phase 255/256 — `[system].rmw` (resolved) is the SSoT; `--rmw` tops the
-    // ladder. The planner resolves the selected target (`--image`, alias
+    // ladder. The planner resolves the selected IMAGE (`--image`, alias
     // `--target` → the sole image `default_images` picks → the sole deprecated
     // `[deploy.<t>]`) and feeds it to `resolved_rmw`. With no system.toml,
     // `--rmw` alone still drives the plan.
@@ -761,15 +765,15 @@ fn schema_build_json(
         .and_then(|p| std::fs::read_to_string(p).ok())
         .and_then(|s| toml::from_str::<super::cargo_metadata_schema::SystemToml>(&s).ok());
     // A bad `default_images` must FAIL, not quietly downgrade the plan to
-    // target-agnostic. `resolve_target` returns an `Option` and can only ignore
+    // image-agnostic. `resolve_image` returns an `Option` and can only ignore
     // it; this is the rung with an error channel.
     if let Some(s) = &sys {
         s.validate_default_images().map_err(|e| eyre!("{e}"))?;
     }
-    // The selected deploy target (phase-256 W3a): shared by RMW + build-tuning.
-    let selected_target = sys.as_ref().and_then(|s| s.resolve_target(cli_target));
+    // The selected image (phase-256 W3a): shared by RMW + build-tuning.
+    let selected_image = sys.as_ref().and_then(|s| s.resolve_image(cli_image));
     let resolved_rmw = match &sys {
-        Some(s) => Some(s.resolved_rmw(selected_target.as_deref(), cli_rmw)),
+        Some(s) => Some(s.resolved_rmw(selected_image.as_deref(), cli_rmw)),
         None => cli_rmw.map(str::to_string),
     };
     if let Some(rmw) = resolved_rmw {
@@ -794,7 +798,7 @@ fn schema_build_json(
     // and is authored NOWHERE in this tree — zero occurrences across every
     // `system.toml` — so it is carried for the deploy path only rather than
     // given a new home it has no user for.
-    if let Some(t) = selected_target.as_deref()
+    if let Some(t) = selected_image.as_deref()
         && let Some(s) = sys.as_ref()
     {
         let img = s.image_for(t);
@@ -3938,7 +3942,7 @@ mod tests {
 
     /// A `default_images` naming no declared image must FAIL the plan.
     ///
-    /// `resolve_target` returns an `Option`, so it can only ignore the bad
+    /// `resolve_image` returns an `Option`, so it can only ignore the bad
     /// value — and ignoring it downgrades the plan to target-agnostic, which
     /// looks like success and silently drops every per-image value. That is the
     /// silent-skip shape, so the rung with an error channel refuses it.
@@ -4140,7 +4144,7 @@ mod tests {
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -4205,7 +4209,7 @@ mod tests {
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -4631,7 +4635,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -4787,7 +4791,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -5020,7 +5024,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -5136,7 +5140,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -5237,7 +5241,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let raw = fs::read_to_string(output.plan_path).unwrap();
@@ -5302,7 +5306,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -5387,7 +5391,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let raw = fs::read_to_string(output.plan_path).unwrap();
@@ -5466,7 +5470,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
         .unwrap();
         let plan: Value =
@@ -5669,7 +5673,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
     }
 
@@ -5702,7 +5706,7 @@ topics:
             manifest_files: vec![],
             launch_args: vec![],
             rmw: None,
-            target: None,
+            image: None,
         })
     }
 

--- a/packages/cli/nros-cli-core/tests/orchestration_cli.rs
+++ b/packages/cli/nros-cli-core/tests/orchestration_cli.rs
@@ -42,7 +42,7 @@ fn orchestration_metadata_plan_check_commands_share_artifacts() {
         manifests: vec![root.join("manifest.launch.yaml")],
         launch_args: Vec::new(),
         rmw: None,
-        target: None,
+        image: None,
     })
     .expect("plan command consumes preserved metadata");
 

--- a/packages/cli/nros-cli-core/tests/orchestration_self_bringup_cargo_metadata.rs
+++ b/packages/cli/nros-cli-core/tests/orchestration_self_bringup_cargo_metadata.rs
@@ -151,7 +151,7 @@ fn plan_system_succeeds_with_cargo_metadata_alpha_bridge() {
         manifest_files: Vec::new(),
         launch_args: Vec::new(),
         rmw: None,
-        target: None,
+        image: None,
     })
     .expect("plan_system configures against cargo-metadata-only workspace");
 
@@ -269,7 +269,7 @@ domain_id = 0
         manifest_files: Vec::new(),
         launch_args: Vec::new(),
         rmw: None,
-        target: None,
+        image: None,
     })
     .expect_err("plan_system rejects pkg with no metadata source");
     let msg = format!("{err:#}");

--- a/packages/cli/nros-cli-core/tests/plan_pipeline_e2e.rs
+++ b/packages/cli/nros-cli-core/tests/plan_pipeline_e2e.rs
@@ -90,7 +90,7 @@ fn fixture_workspace_plans_and_checks() {
         manifests: vec![demo_pkg.join("manifest/system.launch.yaml")],
         launch_args: Vec::new(),
         rmw: None,
-        target: None,
+        image: None,
     })
     .expect("plan command parses launch and writes checked artifacts");
 


### PR DESCRIPTION
Step 2 of the `[deploy.*]` retirement: the last identifier still asserting the concept issue 0951 removed.

## The problem

0951 retired `[system].default_target` and reduced `--target` to an alias — but the resolver was still called **`resolve_target` while returning an IMAGE id**, and the field it flowed through was `PlanOptions.target`.

That is exactly the shape **issue 0938** cost: `nros build` resolved RMW from `[image.*]` while `plan` read `[deploy.<t>]`, because "target" and "image" read as synonyms.

In this tree the collision is sharper than a synonym — **`target` IS the rustc triple** (`plan.build.target`). It sat one struct apart from an image id, under one word.

## The change

```
resolve_target      -> resolve_image
PlanOptions.target  -> PlanOptions.image
plan::Args.target   -> plan::Args.image
selected_target     -> selected_image
cli_target          -> cli_image
```

The names converge on what `build.rs` and `image.rs` **already spelled** — this was the last holdout, not a new convention.

## Why the compiler drove it

`target: None` appears in several unrelated option structs where it *is* the triple, so a textual pass would have renamed the wrong ones. Renaming the field first and letting rustc find the callers named **all 21 sites across 9 files, in four rounds** — and the lines it did *not* name are the proof the hazard was real.

## No behaviour change

- `--image` and its `--target` alias parse exactly as before (checked against the built CLI).
- The deprecated `[deploy.*]` sole-block rung **stays** — it retires with the rest of the table at 0.6.0 (W10.b, waiting on the version boundary, not on this). It now carries a comment recording that it is unreachable for anything this tree authors: 0951 left zero deploy blocks in any `system.toml`, and a synthesised bringup projects an image for the same row, which `nros_config.rs`'s synthesis test already pins.

## Verification

- Whole `packages/cli` workspace test suite passes — 838 lib tests plus every integration binary
- `just check fast` — **162/162 OK**
- `just ci l1` fails **only** on a pre-existing red on `main`: the `rosidl-codegen` golden `RX_MAX_SERIALIZED_SIZE` 133 vs 136. It reproduces on a pristine `origin/main` checkout and is untouched here (this PR contains no codegen change). Last regenerated by `5f3c08545` with nothing landing after it in `rosidl-*` — it merged with goldens not matching its own generator, invisible to the merge gate because `check-build` is not on the required set. Still worth someone owning; it is PR #162's live area.
