### PR TITLE
fix(#0980): the doctor looked for the Zephyr SDK where actions/checkout deletes it

### DIFF
--- a/docs/issues/0981-codegen-golden-not-regenerated-for-the-real-cpp-bound.md
+++ b/docs/issues/0981-codegen-golden-not-regenerated-for-the-real-cpp-bound.md
@@ -1,0 +1,102 @@
+---
+id: 981
+title: "`codegen_golden` has been red on `main` since 5f3c08545 — the C++ pack's
+  REAL bound moved `RX_MAX_SERIALIZED_SIZE` by 3 and the golden was not
+  regenerated"
+status: open
+type: bug
+area: codegen, ci
+severity: medium
+found: 2026-09-01
+related: [phase-408, issue-0896, issue-0952]
+---
+
+## Symptom
+
+`just ci gate` fails at step 3 of 6 (`check::build`, via `check-cli-tests`):
+
+```
+CHANGED configured/Capped.hpp:
+  line 66:
+    golden:     static constexpr size_t RX_MAX_SERIALIZED_SIZE = 157;
+    now   :     static constexpr size_t RX_MAX_SERIALIZED_SIZE = 160;
+
+CHANGED inline/Bounded.hpp:
+  line 70:
+    golden:     static constexpr size_t RX_MAX_SERIALIZED_SIZE = 133;
+    now   :     static constexpr size_t RX_MAX_SERIALIZED_SIZE = 136;
+
+failures:
+    generated_output_matches_the_committed_golden
+```
+
+Three files, every one of them `RX_MAX_SERIALIZED_SIZE`, every one +3.
+
+## Measured, on `main`, in a pristine worktree
+
+Not a local-state artefact. Reproduced in a `git worktree` freshly checked out
+at `6662869d2` (`origin/main`) with nothing else in it:
+
+```
+6662869d2  test result: FAILED. 1 passed; 1 failed
+```
+
+Bisected by running that one test at each revision, again in the clean
+worktree:
+
+```
+0744e8ba1  ok       (ec63d4ed9^)
+ec63d4ed9  ok       fix: a receive buffer is sized for what the transport DELIVERS
+07748a644  ok       feat(phase-408 W5b): the info and validated C subscriptions size their arena
+5f3c08545  FAILED   feat(phase-408, #0896): the C++ pack emits the REAL bound, and spends it
+6ef2c2281  FAILED   fix(phase-408): ledger the three C++ items the parity gate had no row for
+```
+
+`07748a644` is `5f3c08545`'s parent, so **`5f3c08545` is the first bad
+commit** — adjacent revisions, no interval left to search.
+
+Its own subject says the +3 is the intended behaviour ("the C++ pack emits the
+REAL bound, and spends it on the receive buffer"). It touched
+`packages/cli/rosidl-codegen/tests/` in the same commit, so the golden was not
+forgotten wholesale — the three `RX_MAX_SERIALIZED_SIZE` lines were just not
+regenerated with it.
+
+**Not yet established:** whether the generator's new number is right in all
+three cases, or whether one of them is a real sizing bug wearing the same +3.
+That is why this is filed rather than fixed with `NROS_UPDATE_GOLDEN=1` — the
+test's own remedy line says to read the resulting diff before committing, and
+nobody has.
+
+## Why nobody noticed for a day
+
+`codegen_golden` runs in `check-cli-tests`, which is on `check::build`. Per
+CLAUDE.md, `check-build` is `schedule` / `workflow_dispatch` only:
+
+> `check-build` is now `schedule`/`workflow_dispatch` only — it was on the merge
+> group and could never pass there
+
+So no pull request and no merge group runs this test. The required `CI` context
+is `check-fast` + `test-unit`, and both are green on the commit that broke it.
+A red that no merge-gating lane can see is a red that lands.
+
+This is the second half of issue 0952's point about a lane that stops at its
+first failure: `check::build` is the only step where the C/C++ backends compile,
+and it has been withdrawing every step after it — `check::api-parity`,
+`test-unit`, `test-lane-contracts` — for anyone running the local tier since
+2026-08-31 19:12Z.
+
+## Direction
+
+1. Regenerate (`NROS_UPDATE_GOLDEN=1 cargo test -p rosidl-codegen --test
+   codegen_golden`) and READ the diff: confirm each +3 is the encapsulation
+   allowance `5f3c08545` intended and not an off-by-one that happens to be the
+   same size in all three.
+2. Separately: `check-cli-tests` gates nothing on a PR. Either it belongs on a
+   lane that merge-gates, or the fact that it does not should be said where
+   someone reads it — a golden test nobody runs before merging is a golden test
+   that records history rather than enforcing it.
+
+## Acceptance
+
+* `just ci gate` reaches step 6 on a pristine `main`.
+* The three regenerated numbers each have a stated reason, not just a new value.

--- a/docs/issues/archived/0980-runner-doctor-locates-zephyr-sdk-in-the-git-cleaned-checkout.md
+++ b/docs/issues/archived/0980-runner-doctor-locates-zephyr-sdk-in-the-git-cleaned-checkout.md
@@ -1,0 +1,192 @@
+---
+id: 980
+title: "`runner-doctor` locates the Zephyr SDK in the job checkout, which
+  `actions/checkout` git-cleans — so it fails every self-hosted runner whose SDK
+  is where it has to be"
+status: resolved
+type: bug
+area: ci
+severity: high
+found: 2026-09-01
+related: [issue-0975, issue-0654, issue-0833, phase-395, phase-405]
+---
+
+## Symptom
+
+Every `merge_group` run of the `queue` workflow goes red in `L3 (cross build +
+link)`, before any build starts, at the first step:
+
+```
+=== nros-sdk-zephyr ===
+  [OK] west: West version: v1.5.0
+  [OK] Zephyr workspace: /mnt/evo/<user>/nano-ros/zephyr-workspace
+  [MISSING] Zephyr SDK 0.16.8 is not at /home/<user>/actions-runner/_work/nano-ros/nano-ros/scripts/zephyr/sdk/zephyr-sdk-0.16.8
+            this workspace's zephyr/SDK_VERSION demands exactly 0.16.8.
+  [MISSING] no arm-zephyr-eabi-gcc under /home/<user>/actions-runner/_work/nano-ros/nano-ros/scripts/zephyr/sdk/zephyr-sdk-0.16.8
+            the SDK directory exists but its toolchains are not unpacked —
+            an interrupted install leaves exactly this state.
+  [OK] Zephyr SDK 0.16.8 registered with cmake (/mnt/evo/<user>/nano-ros/scripts/zephyr/sdk/zephyr-sdk-0.16.8/cmake)
+runner-doctor: FAIL — at least one label claims something this host does not have.
+```
+
+`just queue-triage` reports `queue` failing across **8 different pull
+requests**, which is its INFRA verdict: the same check failing on unrelated
+changes is not a property of any of them.
+
+Read the four lines together. The function calls the SDK missing from one path
+and then prints `[OK]` naming a *different* path where it is. One fact, two
+derivations, and the disagreement is reported as a diagnosis rather than
+noticed. The second `[MISSING]` is worse than useless — "the SDK directory
+exists but its toolchains are not unpacked" was printed unconditionally, so the
+commonest case (no SDK at that path at all) was reported as a half-unpacked
+install, aiming the reader at the wrong remedy.
+
+## Not a regression — the lane had never actually run
+
+`queue` looks like it broke on 2026-08-31 at 18:57Z: green before, red after.
+It is not a code regression. In every green run the job was **skipped**:
+
+```
+33423643227  success  2026-08-31T18:11:32Z   L3 (cross build + link) :: skipped
+33427914059  failure  2026-08-31T18:57:50Z   L3 (cross build + link) :: failure
+```
+
+`l3` is gated on `vars.NROS_SELF_HOSTED_READY`. It flipped true at 18:57Z, the
+job ran for the first time, and it failed at once — first on the workspace, then
+(after the operator set `NROS_ZEPHYR_WORKSPACE`) on the SDK. The green history
+is the interlock working, not the check passing. This is the same day, and the
+same flip, as issue 0975.
+
+## Root cause: the doctor's location is not the build's location
+
+`runner-doctor.sh` derived the SDK from the checkout —
+`<root>/scripts/zephyr/sdk/zephyr-sdk-<ver>`, where `scripts/zephyr/setup.sh`
+puts it on a dev box — with `ZEPHYR_SDK_INSTALL_DIR` as the only override.
+
+**That path cannot be right on a self-hosted runner.** `scripts/zephyr/sdk/` is
+gitignored (`scripts/zephyr/.gitignore:3`), so is `/zephyr-workspace`
+(`.gitignore:25`), and `actions/checkout@v4` defaults to `clean: true`, which is
+`git clean -ffdx` — **`-x` removes ignored files**. Anything provisioned inside
+the job checkout is deleted at the top of the next job. A runner's 9.2 GB SDK
+has to live outside the checkout, and this operator's does.
+
+Meanwhile the tree already documents where the build looks, in
+`scripts/build/zephyr-toolchain.sh`:
+
+> With `ZEPHYR_SDK_INSTALL_DIR` still unset the lookup takes the same `else()`
+> search branch as before, and the in-tree SDK is found the way it always was —
+> **through the CMake user package registry (`~/.cmake/packages/Zephyr-sdk/*`,
+> written by `scripts/zephyr/setup.sh`)**, not through the hard-coded
+> `/usr /opt $HOME` list, which never contained it.
+
+So the registry is the normal answer for every SDK-toolchain board in this tree,
+and `runner-doctor` was the only place resolving the SDK any other way. Worse,
+its own registration check three blocks down was *already reading the registry*
+— it had the true path in hand and printed it in an `[OK]` line.
+
+The doctor's header names this exact failure mode as the thing it exists to
+prevent:
+
+> a doctor telling a working host it is broken is the failure mode a doctor
+> exists to prevent (issue 0654)
+
+and it committed it, because the remedy it offers (`ZEPHYR_SDK_INSTALL_DIR`) is
+one `scripts/build/zephyr-toolchain.sh` explicitly tells you not to use for the
+build.
+
+## Fix
+
+`_nros_runner_zephyr_sdk_path <want> <root>` is now the single resolver, and its
+precedence mirrors `FindZephyr-sdk.cmake`:
+
+1. `ZEPHYR_SDK_INSTALL_DIR` — both spellings (the SDK, or its parent);
+2. the CMake user package registry, via
+   `_nros_runner_zephyr_sdk_registry_path`;
+3. `<root>/scripts/zephyr/sdk/zephyr-sdk-<ver>` — the dev-box default, kept as
+   the fallback for a host with neither of the above.
+
+Every sub-check now reads that one answer, and each `[OK]`/`[MISSING]` line
+names the ORIGIN (`via cmake package registry`) so the next reader can see why
+that path and not another.
+
+Three smaller defects in the same function, all of the same "named is not
+present" shape, went with it:
+
+* the registration check grepped the registry file's TEXT and never checked that
+  the directory it names exists, so a stale entry outliving its SDK reported
+  `[OK]`. It now distinguishes registered-and-present from
+  registered-and-gone, and says which.
+* a registry entry whose directory is missing no longer shadows a live entry for
+  the same version, whatever order the glob yields them in.
+* the "interrupted install" remedy is printed only when the directory is
+  actually there.
+
+## Gate
+
+`just check runner-doctor-sdk-resolution` → `runner-doctor.sh --self-test`, on
+the fast line. Temp dirs only: no SDK, no cmake, no cargo, no network. Nine
+cases — the three registry-resolution cases, the wrong-version case, the
+dev-box default, both `ZEPHYR_SDK_INSTALL_DIR` spellings, and two end-to-end
+runs of the whole `nros-sdk-zephyr` check against a host shaped like the runner
+that failed.
+
+Proven non-vacuous: restoring the old precedence fails exactly four cases and
+passes the other five —
+
+```
+FAIL an SDK outside the checkout is found via the cmake registry
+FAIL a live registry entry beats a stale one
+FAIL a stale-only entry is reported, not silently discarded
+ok   an entry for another SDK version is ignored
+ok   with no env and no registry the checkout default is used
+ok   ZEPHYR_SDK_INSTALL_DIR naming the SDK beats the registry
+ok   ZEPHYR_SDK_INSTALL_DIR naming the parent appends the version
+FAIL a runner with its SDK outside the checkout verifies clean
+ok   a host with no SDK at all still fails
+```
+
+The last of those is the one that keeps the gate honest: the check must still be
+able to go red.
+
+## Verified
+
+A replica of the runner's layout — workspace and SDK outside the checkout,
+registry pointing at the SDK, `ZEPHYR_SDK_INSTALL_DIR` unset — reproduces the
+production output line for line before the fix, and after it:
+
+```
+  [OK] Zephyr SDK 0.16.8 unpacked: .../elsewhere/zephyr-sdk-0.16.8 (via cmake package registry)
+  [OK] arm-zephyr-eabi toolchain present (SDK is unpacked, not just downloaded)
+  [OK] Zephyr SDK 0.16.8 registered with cmake (.../elsewhere/zephyr-sdk-0.16.8/cmake)
+runner-doctor: OK — all 1 label(s) verified.
+```
+
+**What this does NOT prove.** The fix removes a red that was WRONG; it cannot
+make an SDK exist. The runner's registry names
+`/mnt/evo/<user>/nano-ros/scripts/zephyr/sdk/zephyr-sdk-0.16.8` — if that tree has
+since been deleted or was never fully unpacked, `L3` stays red, now saying so
+truthfully (`cmake's registry names <path>, but nothing is there`, or `no
+arm-zephyr-eabi-gcc under <path>`). The next `queue` run is the measurement, and
+nobody with access to that host has confirmed the SDK is intact.
+
+## Sibling of the same class, left open
+
+`_nros_runner_check_qemu` locates the patched QEMU at `<root>/build/qemu/bin/
+qemu-system-arm`. `build/` is gitignored (`.gitignore:22`), so it is wiped by
+the same `git clean -ffdx` on every self-hosted job. It does not currently
+produce a false red, because it falls back to `qemu-system-arm` on PATH and
+checks the >= 7.2 rule there — but a runner provisioned with only the
+project-local build will be told it has no QEMU. It is deliberately NOT fixed
+here: unlike the SDK, QEMU has no registry to consult, so the checkout-
+independent location would have to be invented rather than adopted, and that is
+a decision rather than a repair. It bites when the `nros-qemu` label is asserted
+by a self-hosted lane — `nightly.yml` and `run-matrix.yml` both do.
+
+## Acceptance
+
+* [x] `runner-doctor` resolves the SDK the way the build does, and every
+      sub-check reads one answer.
+* [x] A gate that fails if the precedence is restored, and can still fail on a
+      genuinely broken host.
+* [ ] `queue`'s `L3` job green on the merge group — depends on the runner's
+      SDK actually being intact, which this change cannot establish.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -80,5 +80,6 @@ fails if this block drifts.
 - **#0975** (ci) — `--self-hosted-ready` requires a merge_group-only check, so no PR can enter the queue See `0975-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
+- **#0981** (codegen, ci) — `codegen_golden` has been red on `main` since 5f3c08545 — the C++ pack's REAL bound moved `RX_MAX_SERIALIZED_SIZE` by 3 and the golden was not regenerated See `0981-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/just/check.just
+++ b/just/check.just
@@ -227,6 +227,7 @@ fast-serial: \
     rmw-vtable-order \
     roadmap-status \
     ros-env-spelling \
+    runner-doctor-sdk-resolution \
     rust-stdio-on-zephyr \
     rust-targets-covered \
     scope-namespace \
@@ -988,6 +989,21 @@ platform-abi-mirror:
 [private]
 mirror-header-precedence:
     @bash scripts/build/mirror-generated-header.sh --self-test
+
+
+# Issue 0980 — `runner-doctor` answered "where is the Zephyr SDK?" from the job
+# CHECKOUT while the build answers it from the CMake user package registry.
+# `scripts/zephyr/sdk/` is gitignored and `actions/checkout` runs
+# `git clean -ffdx`, so a self-hosted runner's SDK is necessarily somewhere
+# else — which made the derived path wrong by construction and failed every
+# merge-group `L3` job on a host that builds fine.
+#
+# Same shape as the gate above, for the same reason: the self-test lives in the
+# script so the rule and its cases cannot drift apart, and it stages temp dirs
+# only (no SDK, no cmake, no network), so it belongs on the fast line.
+[private]
+runner-doctor-sdk-resolution:
+    @bash scripts/ci/runner-doctor.sh --self-test
 
 
 # RFC-0054 (phase-299 W3) — the committed bindgen output must match a fresh

--- a/scripts/ci/runner-doctor.sh
+++ b/scripts/ci/runner-doctor.sh
@@ -134,6 +134,70 @@ _nros_runner_fix()     { printf '            %s\n' "$*" >&2; }
 #   4. a toolchain binary is actually THERE. A half-unpacked or interrupted
 #      download leaves the directory and the registration behind, so checking
 #      for the directory alone is the check that passes on the broken case.
+# Where cmake says the Zephyr SDK for <want> is — issue 0980.
+#
+# `find_package(Zephyr-sdk)` consults the CMake USER PACKAGE REGISTRY,
+# `~/.cmake/packages/Zephyr-sdk/<hash>`, each file holding the directory that
+# contains `Zephyr-sdkConfig.cmake` — i.e. `<sdk>/cmake`. `scripts/zephyr/
+# setup.sh` writes it, and per `scripts/build/zephyr-toolchain.sh` it is the
+# branch every SDK-toolchain board in this tree actually takes.
+#
+# Prints the SDK ROOT (the `cmake` component stripped) for an entry naming
+# `zephyr-sdk-<want>`, or nothing. An entry whose directory EXISTS wins over one
+# whose does not, so a stale registration left behind by a deleted SDK cannot
+# shadow a live one — while a stale entry alone is still printed, because the
+# caller reports that as its own diagnosis rather than as "unregistered".
+_nros_runner_zephyr_sdk_registry_path() {
+    local want="$1" reg dir best="" stale=""
+    for reg in "$HOME"/.cmake/packages/Zephyr-sdk/*; do
+        [ -f "$reg" ] || continue
+        dir="$(tr -d '\r\n' < "$reg" 2>/dev/null || true)"
+        [ -n "$dir" ] || continue
+        case "$dir" in *"zephyr-sdk-$want"*) ;; *) continue ;; esac
+        # The registry records `<sdk>/cmake`; tolerate an entry that records the
+        # SDK root itself, which older setup scripts wrote.
+        [ "$(basename "$dir")" = "cmake" ] && dir="$(dirname "$dir")"
+        if [ -d "$dir" ]; then
+            best="$dir"
+            break
+        fi
+        [ -n "$stale" ] || stale="$dir"
+    done
+    printf '%s' "${best:-$stale}"
+}
+
+# Where THIS host's Zephyr SDK <want> is, and what said so.
+#
+# Prints `<path><TAB><origin>`. Precedence mirrors `FindZephyr-sdk.cmake`:
+# the explicit env var, then the cmake user package registry, then the
+# checkout-relative location `scripts/zephyr/setup.sh` uses on a dev box.
+#
+# The last of those is a FALLBACK and nothing more. It cannot be the primary:
+# see the long note in `_nros_runner_check_sdk_zephyr` — `actions/checkout`
+# git-cleans ignored files, so a self-hosted runner's SDK is necessarily
+# outside the checkout.
+_nros_runner_zephyr_sdk_path() {
+    local want="$1" root="$2" from_registry=""
+
+    if [ -n "${ZEPHYR_SDK_INSTALL_DIR:-}" ]; then
+        # Both spellings are in the wild: the SDK itself, or its parent.
+        case "$(basename "$ZEPHYR_SDK_INSTALL_DIR")" in
+            zephyr-sdk-*) printf '%s\tZEPHYR_SDK_INSTALL_DIR' "$ZEPHYR_SDK_INSTALL_DIR" ;;
+            *)            printf '%s/zephyr-sdk-%s\tZEPHYR_SDK_INSTALL_DIR' \
+                              "${ZEPHYR_SDK_INSTALL_DIR%/}" "$want" ;;
+        esac
+        return 0
+    fi
+
+    from_registry="$(_nros_runner_zephyr_sdk_registry_path "$want")"
+    if [ -n "$from_registry" ]; then
+        printf '%s\tcmake package registry' "$from_registry"
+        return 0
+    fi
+
+    printf '%s/scripts/zephyr/sdk/zephyr-sdk-%s\tcheckout default' "$root" "$want"
+}
+
 _nros_runner_check_sdk_zephyr() {
     local root fail=0
     root="$(_nros_runner_repo_root)"
@@ -195,25 +259,51 @@ _nros_runner_check_sdk_zephyr() {
         return 1
     fi
 
-    # Where the SDK was unpacked. `scripts/zephyr/setup.sh` puts it at
-    # `<repo>/scripts/zephyr/sdk/zephyr-sdk-<ver>`; an operator who exported
-    # ZEPHYR_SDK_INSTALL_DIR may have pointed it at either the SDK itself or its
-    # parent, and both spellings are in the wild, so accept both.
-    local sdk_parent="$root/scripts/zephyr/sdk" sdk_path=""
-    if [ -n "${ZEPHYR_SDK_INSTALL_DIR:-}" ]; then
-        case "$(basename "$ZEPHYR_SDK_INSTALL_DIR")" in
-            zephyr-sdk-*) sdk_path="$ZEPHYR_SDK_INSTALL_DIR"
-                          sdk_parent="$(dirname "$ZEPHYR_SDK_INSTALL_DIR")" ;;
-            *)            sdk_parent="$ZEPHYR_SDK_INSTALL_DIR" ;;
-        esac
-    fi
-    [ -n "$sdk_path" ] || sdk_path="$sdk_parent/zephyr-sdk-$want"
+    # Where the SDK is, resolved the way the BUILD resolves it — issue 0980.
+    #
+    # This used to be a path derived from the checkout
+    # (`<root>/scripts/zephyr/sdk/zephyr-sdk-<ver>`, where `scripts/zephyr/
+    # setup.sh` puts it on a dev box) with `ZEPHYR_SDK_INSTALL_DIR` as the only
+    # override. That is not where a self-hosted runner's SDK can be. Both
+    # `scripts/zephyr/sdk/` and `/zephyr-workspace` are gitignored, and
+    # `actions/checkout` defaults to `git clean -ffdx` — `-x` removes IGNORED
+    # files — so anything provisioned inside the job checkout is deleted at the
+    # top of the next job. A runner's 9.2 GB SDK must live outside the checkout,
+    # which made the derived path wrong by construction and the doctor failed a
+    # host that builds fine. That is the exact failure mode this file's header
+    # says it exists to prevent (issue 0654).
+    #
+    # `scripts/build/zephyr-toolchain.sh` already states where the build looks:
+    #
+    #   With `ZEPHYR_SDK_INSTALL_DIR` still unset the lookup takes the same
+    #   `else()` search branch as before, and the in-tree SDK is found the way
+    #   it always was — through the CMake user package registry
+    #   (`~/.cmake/packages/Zephyr-sdk/*`, written by `scripts/zephyr/setup.sh`)
+    #
+    # So the registry is not a fallback here, it is the normal answer, and this
+    # function's own registration check three blocks down was already reading
+    # it — printing the true path in an `[OK]` line while the checks above
+    # called the SDK missing from a path nothing uses. One fact, two
+    # derivations, and the disagreement reported as a diagnosis.
+    #
+    # Precedence mirrors `FindZephyr-sdk.cmake`: the env var first, then the
+    # registry, then the checkout default for a plain dev box with neither.
+    local resolved sdk_path sdk_origin
+    resolved="$(_nros_runner_zephyr_sdk_path "$want" "$root")"
+    sdk_path="${resolved%%	*}"
+    sdk_origin="${resolved#*	}"
 
     if [ -d "$sdk_path" ]; then
-        _nros_runner_ok "Zephyr SDK $want unpacked: $sdk_path"
+        _nros_runner_ok "Zephyr SDK $want unpacked: $sdk_path (via $sdk_origin)"
     else
-        _nros_runner_missing "Zephyr SDK $want is not at $sdk_path"
+        _nros_runner_missing "Zephyr SDK $want is not at $sdk_path (via $sdk_origin)"
         _nros_runner_fix "this workspace's zephyr/SDK_VERSION demands exactly $want."
+        if [ "$sdk_origin" = "checkout default" ]; then
+            _nros_runner_fix "nothing points anywhere else: ZEPHYR_SDK_INSTALL_DIR is unset and"
+            _nros_runner_fix "no ~/.cmake/packages/Zephyr-sdk/ entry names zephyr-sdk-$want."
+            _nros_runner_fix "On a self-hosted runner the SDK must live OUTSIDE the job checkout —"
+            _nros_runner_fix "actions/checkout git-cleans ignored files, and scripts/zephyr/sdk/ is one."
+        fi
         _nros_runner_fix "scripts/ci/runner-provision.sh nros-sdk-zephyr"
         fail=1
     fi
@@ -226,23 +316,36 @@ _nros_runner_check_sdk_zephyr() {
         _nros_runner_ok "arm-zephyr-eabi toolchain present (SDK is unpacked, not just downloaded)"
     else
         _nros_runner_missing "no arm-zephyr-eabi-gcc under $sdk_path"
-        _nros_runner_fix "the SDK directory exists but its toolchains are not unpacked —"
-        _nros_runner_fix "an interrupted install leaves exactly this state."
+        # Only claim the interrupted-install story when the directory is
+        # actually there. It was printed unconditionally, so the commonest case
+        # — no SDK at that path at all — was reported as a half-unpacked one,
+        # which sends the reader to the wrong remedy.
+        if [ -d "$sdk_path" ]; then
+            _nros_runner_fix "the SDK directory exists but its toolchains are not unpacked —"
+            _nros_runner_fix "an interrupted install leaves exactly this state."
+        else
+            _nros_runner_fix "there is no SDK at that path — see the line above."
+        fi
         _nros_runner_fix "scripts/ci/runner-provision.sh nros-sdk-zephyr"
         fail=1
     fi
 
     # Registration is what cmake actually consults. Unregistered = a configure
     # failure that names neither the version nor the remedy.
-    local reg have=""
-    for reg in "$HOME"/.cmake/packages/Zephyr-sdk/*; do
-        [ -f "$reg" ] || continue
-        case "$(cat "$reg" 2>/dev/null || true)" in
-            *"zephyr-sdk-$want"*) have="$(cat "$reg" 2>/dev/null || true)" ;;
-        esac
-    done
-    if [ -n "$have" ]; then
-        _nros_runner_ok "Zephyr SDK $want registered with cmake ($have)"
+    #
+    # The registered path must EXIST, not merely be named. A registry entry
+    # outlives the SDK it points at (the directory is deleted, the entry is
+    # not), and grepping the file's text alone reports `[OK]` for an SDK that
+    # is gone — the same "named is not present" mistake one layer up.
+    local have=""
+    have="$(_nros_runner_zephyr_sdk_registry_path "$want")"
+    if [ -n "$have" ] && [ -d "$have" ]; then
+        _nros_runner_ok "Zephyr SDK $want registered with cmake ($have/cmake)"
+    elif [ -n "$have" ]; then
+        _nros_runner_missing "cmake's registry names $have for SDK $want, but nothing is there"
+        _nros_runner_fix "a stale ~/.cmake/packages/Zephyr-sdk/ entry outlived its SDK."
+        _nros_runner_fix "Re-register from the SDK that IS installed:  (cd <sdk> && ./setup.sh -h -c)"
+        fail=1
     else
         _nros_runner_missing "Zephyr SDK $want is not registered with cmake"
         _nros_runner_fix "find_package(Zephyr-sdk) reads ~/.cmake/packages/Zephyr-sdk/;"
@@ -561,6 +664,152 @@ nros_runner_doctor() {
     return 0
 }
 
+# --- self-test ---------------------------------------------------------------
+#
+# Issue 0980. The SDK resolver is the one part of this file that can be checked
+# without a provisioned host, and it is the part that was wrong: it answered
+# "where is the SDK?" from the checkout while the build answers it from the
+# cmake user package registry, so a runner whose SDK lives outside the checkout
+# — which is every self-hosted runner, since `actions/checkout` git-cleans
+# ignored files — was told it was broken while building fine.
+#
+# Temp dirs only: no cmake, no cargo, no SDK, no network. `just check
+# runner-doctor-sdk-resolution` runs it on the fast line.
+_nros_runner_self_test() {
+    local tmp fails=0 saved_home="${HOME}" saved_env="${ZEPHYR_SDK_INSTALL_DIR:-}"
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'; HOME='$saved_home'" RETURN
+
+    _st_ok()  { printf '  ok   %s\n' "$1"; }
+    _st_bad() { printf '  FAIL %s: %s\n' "$1" "$2" >&2; fails=$((fails + 1)); }
+
+    # <case> -> a HOME with a registry, and a checkout root, both empty.
+    _st_stage() {
+        local d="$tmp/$1"
+        mkdir -p "$d/home/.cmake/packages/Zephyr-sdk" "$d/root/scripts/zephyr/sdk"
+        printf '%s' "$d"
+    }
+    # _st_register <case-dir> <entry-name> <sdk-dir> <create|absent>
+    _st_register() {
+        [ "$4" = "create" ] && mkdir -p "$3/cmake"
+        printf '%s\n' "$3/cmake" > "$1/home/.cmake/packages/Zephyr-sdk/$2"
+    }
+    # _st_resolve <case-dir> -> "<path>\t<origin>"
+    _st_resolve() { HOME="$1/home" _nros_runner_zephyr_sdk_path 0.16.8 "$1/root"; }
+    _st_expect() { # <label> <got> <want>
+        [ "$2" = "$3" ] && _st_ok "$1" || _st_bad "$1" "got '$2'"
+    }
+
+    unset ZEPHYR_SDK_INSTALL_DIR
+
+    # Issue 0980 — the regression. The SDK is outside the checkout and only the
+    # registry knows where; the checkout path must NOT win merely by being the
+    # default. This is the case that failed every merge-group L3 job.
+    local d got
+    d="$(_st_stage outside)"
+    _st_register "$d" aaa "$tmp/elsewhere/zephyr-sdk-0.16.8" create
+    got="$(_st_resolve "$d")"
+    _st_expect "an SDK outside the checkout is found via the cmake registry" \
+        "$got" "$tmp/elsewhere/zephyr-sdk-0.16.8	cmake package registry"
+
+    # A live entry beats a stale one whatever order the glob yields them in —
+    # `aaa` sorts first and points at nothing.
+    d="$(_st_stage stale_and_live)"
+    _st_register "$d" aaa "$tmp/gone/zephyr-sdk-0.16.8" absent
+    _st_register "$d" bbb "$tmp/live/zephyr-sdk-0.16.8" create
+    got="$(_st_resolve "$d")"
+    _st_expect "a live registry entry beats a stale one" \
+        "$got" "$tmp/live/zephyr-sdk-0.16.8	cmake package registry"
+
+    # A stale entry ALONE is still returned, so the caller can report "cmake
+    # names this path and nothing is there" instead of the misleading
+    # "not registered with cmake".
+    d="$(_st_stage stale_only)"
+    _st_register "$d" aaa "$tmp/gone2/zephyr-sdk-0.16.8" absent
+    got="$(_st_resolve "$d")"
+    _st_expect "a stale-only entry is reported, not silently discarded" \
+        "$got" "$tmp/gone2/zephyr-sdk-0.16.8	cmake package registry"
+
+    # An entry for a DIFFERENT version must not be mistaken for this one —
+    # `zephyr/SDK_VERSION` demands an exact version.
+    d="$(_st_stage wrong_version)"
+    _st_register "$d" aaa "$tmp/other/zephyr-sdk-0.17.4" create
+    got="$(_st_resolve "$d")"
+    _st_expect "an entry for another SDK version is ignored" \
+        "$got" "$d/root/scripts/zephyr/sdk/zephyr-sdk-0.16.8	checkout default"
+
+    # Neither env nor registry: the dev-box default, preserved.
+    d="$(_st_stage bare)"
+    got="$(_st_resolve "$d")"
+    _st_expect "with no env and no registry the checkout default is used" \
+        "$got" "$d/root/scripts/zephyr/sdk/zephyr-sdk-0.16.8	checkout default"
+
+    # The explicit override wins over the registry, in both spellings.
+    d="$(_st_stage env_sdk)"
+    _st_register "$d" aaa "$tmp/live/zephyr-sdk-0.16.8" create
+    got="$(ZEPHYR_SDK_INSTALL_DIR="$tmp/chosen/zephyr-sdk-0.16.8" _st_resolve "$d")"
+    _st_expect "ZEPHYR_SDK_INSTALL_DIR naming the SDK beats the registry" \
+        "$got" "$tmp/chosen/zephyr-sdk-0.16.8	ZEPHYR_SDK_INSTALL_DIR"
+
+    d="$(_st_stage env_parent)"
+    _st_register "$d" aaa "$tmp/live/zephyr-sdk-0.16.8" create
+    got="$(ZEPHYR_SDK_INSTALL_DIR="$tmp/parent" _st_resolve "$d")"
+    _st_expect "ZEPHYR_SDK_INSTALL_DIR naming the parent appends the version" \
+        "$got" "$tmp/parent/zephyr-sdk-0.16.8	ZEPHYR_SDK_INSTALL_DIR"
+
+
+    # The whole zephyr check, on a host shaped like the runner that failed:
+    # workspace and SDK outside the checkout, registry pointing at the SDK,
+    # ZEPHYR_SDK_INSTALL_DIR unset. Every sub-check must agree. Before the fix
+    # this printed two `[MISSING]` lines and an `[OK]` naming the very path it
+    # had just called missing — one fact, two derivations, the disagreement
+    # reported as a diagnosis.
+    local self e2e out
+    self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+    e2e="$tmp/e2e"
+    mkdir -p "$e2e"/{home/.cmake/packages/Zephyr-sdk,root,ws/zephyr,bin} \
+             "$e2e"/sdk/zephyr-sdk-0.16.8/{cmake,arm-zephyr-eabi/bin}
+    printf '0.16.8\n' > "$e2e/ws/zephyr/SDK_VERSION"
+    printf '#!/bin/sh\necho "West version: v1.5.0"\n' > "$e2e/bin/west"
+    printf '#!/bin/sh\nexit 0\n' > "$e2e/sdk/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc"
+    chmod +x "$e2e/bin/west" "$e2e/sdk/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc"
+    printf '%s\n' "$e2e/sdk/zephyr-sdk-0.16.8/cmake" > "$e2e/home/.cmake/packages/Zephyr-sdk/aaa"
+
+    _st_doctor() { # <home> -> runs the label check in a clean environment
+        PATH="$e2e/bin:$PATH" HOME="$1" NROS_RUNNER_REPO_ROOT="$e2e/root" \
+        NROS_ZEPHYR_WORKSPACE="$e2e/ws" NROS_RUNNER_NO_ACTIVATE=1 \
+        ZEPHYR_SDK_INSTALL_DIR= bash "$self" nros-sdk-zephyr 2>&1
+    }
+
+    if out="$(_st_doctor "$e2e/home")" && ! printf '%s' "$out" | grep -q MISSING; then
+        _st_ok "a runner with its SDK outside the checkout verifies clean"
+    else
+        _st_bad "a runner with its SDK outside the checkout verifies clean" \
+            "$(printf '%s' "$out" | grep -E 'MISSING|FAIL' | head -2 | tr '\n' ';')"
+    fi
+
+    # ...and it can still FAIL. With no registry entry and no SDK anywhere, the
+    # check must go red — a doctor that cannot fail is the vacuous gate this
+    # file's header is about.
+    mkdir -p "$e2e/empty-home/.cmake/packages/Zephyr-sdk"
+    if _st_doctor "$e2e/empty-home" >/dev/null 2>&1; then
+        _st_bad "a host with no SDK at all still fails" "exited 0"
+    else
+        _st_ok "a host with no SDK at all still fails"
+    fi
+
+    [ -n "$saved_env" ] && export ZEPHYR_SDK_INSTALL_DIR="$saved_env"
+    HOME="$saved_home"
+
+    if [ "$fails" -ne 0 ]; then
+        echo "runner-doctor self-test: FAIL ($fails)" >&2
+        return 1
+    fi
+    echo "runner-doctor self-test OK"
+    return 0
+}
+
 # --- standalone entry point --------------------------------------------------
 #
 # Guarded so `. scripts/ci/runner-doctor.sh` defines the functions and runs
@@ -579,9 +828,15 @@ _nros_runner_doctor_main() {
                 # runner scripts take the same one.
                 ;;
             --quiet) NROS_RUNNER_QUIET=1 ;;
+            --self-test)
+                # Probes nothing on this host; see `_nros_runner_self_test`.
+                _nros_runner_self_test
+                return $?
+                ;;
             -h|--help)
                 cat <<EOF
 usage: scripts/ci/runner-doctor.sh <labels> [--check] [--quiet]
+       scripts/ci/runner-doctor.sh --self-test
 
   <labels>   comma- or space-separated, e.g. nros-qemu,nros-sdk-zephyr,nros-big
              GitHub's own labels (self-hosted, linux, X64) are accepted and
@@ -589,6 +844,9 @@ usage: scripts/ci/runner-doctor.sh <labels> [--check] [--quiet]
 
   --check    accepted and inert — this script never changes anything.
   --quiet    print only failures.
+
+  --self-test  check this file's own SDK-location resolver against temp dirs.
+               Probes nothing on this host; needs no SDK. Issue 0980.
 
 Known labels: $NROS_RUNNER_LABELS
 

--- a/scripts/ci/runner-doctor.sh
+++ b/scripts/ci/runner-doctor.sh
@@ -638,12 +638,36 @@ nros_runner_labels_split() {
 # machine wants the whole list of what is missing, not the first item; the
 # one-at-a-time shape is what makes provisioning a machine an afternoon of
 # round trips. Same reasoning as `just doctor`'s `set +e`.
+# Run this file's own selftest on the NORMAL path, not only behind
+# `--self-test` — `check-gate-selftests`, and the reason it gives: a negative
+# control nobody runs decays into a comment.
+#
+# Output is DISCARDED on success. An operator ran this to be told about the
+# HOST, and nine `ok` lines about temp directories would bury that. On failure
+# it is printed in full and the run STOPS: a broken SDK resolver means every
+# verdict below it is about a path nobody uses, which is issue 0980 itself.
+#
+# Costs ~50 ms (temp dirs and two re-invocations of this script; the child skips
+# this guard via `_NROS_RUNNER_SELFTEST_CHILD`, or it would recurse forever).
+_nros_runner_selftest_guard() {
+    [ "${_NROS_RUNNER_SELFTEST_CHILD:-0}" = "1" ] && return 0
+    local out
+    if ! out="$(_nros_runner_self_test 2>&1)"; then
+        printf '%s\n' "$out" >&2
+        echo "runner-doctor: its OWN selftest failed, so the SDK resolver is broken —" >&2
+        echo "  nothing this run would report about the host can be trusted." >&2
+        return 1
+    fi
+    return 0
+}
+
 nros_runner_doctor() {
     local labels="$1" label fail=0 n=0
     if [ -z "$labels" ]; then
         echo "runner-doctor: no labels given" >&2
         return 2
     fi
+    _nros_runner_selftest_guard || return 1
     _nros_runner_activate
     while read -r label; do
         [ -n "$label" ] || continue
@@ -765,7 +789,7 @@ _nros_runner_self_test() {
     # this printed two `[MISSING]` lines and an `[OK]` naming the very path it
     # had just called missing — one fact, two derivations, the disagreement
     # reported as a diagnosis.
-    local self e2e out
+    local self e2e out st
     self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
     e2e="$tmp/e2e"
     mkdir -p "$e2e"/{home/.cmake/packages/Zephyr-sdk,root,ws/zephyr,bin} \
@@ -777,12 +801,23 @@ _nros_runner_self_test() {
     printf '%s\n' "$e2e/sdk/zephyr-sdk-0.16.8/cmake" > "$e2e/home/.cmake/packages/Zephyr-sdk/aaa"
 
     _st_doctor() { # <home> -> runs the label check in a clean environment
+        # `_NROS_RUNNER_SELFTEST_CHILD` stops the child re-entering the
+        # normal-path selftest that invoked it — this case IS that selftest.
         PATH="$e2e/bin:$PATH" HOME="$1" NROS_RUNNER_REPO_ROOT="$e2e/root" \
         NROS_ZEPHYR_WORKSPACE="$e2e/ws" NROS_RUNNER_NO_ACTIVATE=1 \
+        _NROS_RUNNER_SELFTEST_CHILD=1 \
         ZEPHYR_SDK_INSTALL_DIR= bash "$self" nros-sdk-zephyr 2>&1
     }
 
-    if out="$(_st_doctor "$e2e/home")" && ! printf '%s' "$out" | grep -q MISSING; then
+    # A `case` glob, not `grep -q` — issue 0726: a forked grep that fails to
+    # START is exit >= 2, indistinguishable from "no match" to `grep -q`, and
+    # this runs under a 32-way gate fan-out. Bash pattern matching forks
+    # nothing and cannot fail this way.
+    out="$(_st_doctor "$e2e/home")" && st=0 || st=1
+    case "$st$out" in
+        0*MISSING*) st=1 ;;
+    esac
+    if [ "$st" -eq 0 ]; then
         _st_ok "a runner with its SDK outside the checkout verifies clean"
     else
         _st_bad "a runner with its SDK outside the checkout verifies clean" \


### PR DESCRIPTION
Fixes #0980 (`docs/issues/archived/0980-*`). Files #0981.

## The bug

`runner-doctor.sh` resolved the Zephyr SDK from the job **checkout** —
`<root>/scripts/zephyr/sdk/zephyr-sdk-<ver>`, where `scripts/zephyr/setup.sh`
puts it on a dev box — with `ZEPHYR_SDK_INSTALL_DIR` as the only override.

That path cannot be right on a self-hosted runner. `scripts/zephyr/sdk/` is
gitignored, so is `/zephyr-workspace`, and `actions/checkout@v4` defaults to
`clean: true` = `git clean -ffdx` — **`-x` removes ignored files** — so anything
provisioned inside the checkout is deleted at the top of the next job. A
runner's 9.2 GB SDK has to live outside the checkout, and this one's does.

`scripts/build/zephyr-toolchain.sh` already states where the build looks:

> With `ZEPHYR_SDK_INSTALL_DIR` still unset the lookup takes the same `else()`
> search branch as before, and the in-tree SDK is found the way it always was —
> through the CMake user package registry (`~/.cmake/packages/Zephyr-sdk/*`)

So the registry is the normal answer for every SDK-toolchain board in this tree,
and the doctor was the only place resolving the SDK any other way. Its own
registration check three blocks down was **already reading that registry** — it
had the true path in hand and printed it in an `[OK]` line while the checks
above called the SDK missing from a path nothing uses:

```
[MISSING] Zephyr SDK 0.16.8 is not at <checkout>/scripts/zephyr/sdk/zephyr-sdk-0.16.8
[MISSING] no arm-zephyr-eabi-gcc under <checkout>/scripts/zephyr/sdk/zephyr-sdk-0.16.8
          the SDK directory exists but its toolchains are not unpacked
[OK]      Zephyr SDK 0.16.8 registered with cmake (/mnt/evo/.../zephyr-sdk-0.16.8/cmake)
```

One fact, two derivations, the disagreement reported as a diagnosis. The second
remedy is actively wrong — printed unconditionally, so the commonest case (no
SDK at that path at all) reads as a half-unpacked install.

## Not a regression

`queue`'s `L3` job was **skipped** in every green run. It is interlocked on
`vars.NROS_SELF_HOSTED_READY`, which flipped true at 18:57Z on 2026-08-31; the
job ran for the first time and failed at once, on 8 different PRs since
(`just queue-triage` classifies it INFRA). The green history was the interlock
working, not the check passing. Same flip, same day, as #0975.

## The fix

`_nros_runner_zephyr_sdk_path` is the single resolver, precedence mirroring
`FindZephyr-sdk.cmake`:

1. `ZEPHYR_SDK_INSTALL_DIR` (both spellings — the SDK, or its parent)
2. the CMake user package registry
3. `<root>/scripts/zephyr/sdk/zephyr-sdk-<ver>` — the dev-box fallback

Every sub-check reads that one answer and names the ORIGIN it came from
(`via cmake package registry`). Three smaller defects of the same
"named is not present" shape went with it:

- the registration check required only that a registry file's TEXT match; it now
  requires the directory it names to EXIST, and distinguishes
  registered-and-present from registered-and-gone;
- a stale entry no longer shadows a live one for the same version, whatever
  order the glob yields them in;
- the interrupted-install remedy prints only when the directory is there.

## Gate

`just check runner-doctor-sdk-resolution` → `runner-doctor.sh --self-test`, on
the fast line. Temp dirs only: no SDK, no cmake, no cargo, no network. Nine
cases.

Proven non-vacuous — restoring the old precedence fails exactly four and passes
the five that encode preserved behaviour:

```
FAIL an SDK outside the checkout is found via the cmake registry
FAIL a live registry entry beats a stale one
FAIL a stale-only entry is reported, not silently discarded
ok   an entry for another SDK version is ignored
ok   with no env and no registry the checkout default is used
ok   ZEPHYR_SDK_INSTALL_DIR naming the SDK beats the registry
ok   ZEPHYR_SDK_INSTALL_DIR naming the parent appends the version
FAIL a runner with its SDK outside the checkout verifies clean
ok   a host with no SDK at all still fails
```

That last one is what keeps the doctor able to go red.

## Verified

A replica of the runner's layout (workspace and SDK outside the checkout,
registry pointing at the SDK, `ZEPHYR_SDK_INSTALL_DIR` unset) reproduces the
production output line for line before the change, and after it:

```
[OK] Zephyr SDK 0.16.8 unpacked: .../zephyr-sdk-0.16.8 (via cmake package registry)
[OK] arm-zephyr-eabi toolchain present (SDK is unpacked, not just downloaded)
runner-doctor: OK — all 1 label(s) verified.
```

**What this does NOT prove.** It removes a red that was WRONG; it cannot make an
SDK exist. If the runner's SDK tree has since been deleted or was never fully
unpacked, `L3` stays red — now saying so truthfully. The next `queue` run is the
measurement.

## Tier run

`check::cli-fresh` ok · `check::fast` **164 gates OK** · `check::api-parity` ok ·
`test-unit` **1051 passed, 1 skipped** (ZPICO_MAX_SESSIONS precondition) ·
`test-lane-contracts` **17/17**.

`check::build` fails — **and it fails on clean `main` too**, which is #0981 filed
in this PR. I ran the steps it withdrew individually rather than report a
blocked lane as a verdict (issue 0952).

## Left open, recorded in the issue

`_nros_runner_check_qemu` locates the patched QEMU at `<root>/build/qemu/`, also
gitignored, also wiped by the same clean. It produces no false red today because
it falls back to PATH — and unlike the SDK it has no registry to adopt, so the
checkout-independent location would have to be invented rather than adopted.
That is a decision, not a repair. It bites when `nros-qemu` is asserted by a
self-hosted lane; `nightly.yml` and `run-matrix.yml` both do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSuM4yABT9i6XzprmNn1op