### PR TITLE
fix(#0896): the C++ RX bound is FRAMED — two artifacts that missed their parent's change

### DIFF
--- a/packages/cli/rosidl-codegen/tests/codegen_golden.rs
+++ b/packages/cli/rosidl-codegen/tests/codegen_golden.rs
@@ -208,3 +208,118 @@ fn corpus_emits_every_language_and_entity() {
         assert!(!v.trim().is_empty(), "{k} emitted an empty artifact");
     }
 }
+
+/// The COMMITTED goldens must agree across languages about one type's bound.
+///
+/// This is the check whose absence let issue 0896's own regression ship. The C
+/// and C++ packs share one derivation (`generator::common::derive_message_bound`)
+/// precisely so a bound cannot differ by language — the sizes-header mirror
+/// class, 0088 → 0114 → 0122 → 0123 → 0245 → 0268, wearing a language axis. But
+/// nothing compared the two GOLDEN FILES:
+///
+/// * `message_size_bound_parity.rs` cross-checks C, C++ and Rust — by
+///   GENERATING headers. It passed, because the generator was right.
+/// * `generated_output_matches_the_committed_golden` compares generated against
+///   committed, per file. It failed, correctly — but only in `cli-tests`, which
+///   is in `check-build` and not on the required set, so the red landed on main
+///   and sat there.
+///
+/// So the C++ goldens were captured before the emitter learned to tell RX from
+/// TX and never re-captured: three of them stated `RX == TX` while the C golden
+/// beside them said `RX == TX + 3`. `Bounded.msg` exists to make exactly that
+/// visible — "the XCDR1/XCDR2 numbers must DIFFER here, so a regression that
+/// emits one value for both is visible in the golden diff" — and the golden
+/// diff did show it. Nothing was comparing the pair.
+///
+/// Reading the committed files rather than the emitter is the point: a stale
+/// capture is invisible to any check that regenerates first.
+#[test]
+fn the_committed_c_and_cpp_goldens_state_the_same_bound() {
+    /// `..._TX_MAX_SERIALIZED_SIZE 133` in a C header → ("TX", 133).
+    fn c_bounds(src: &str) -> Vec<(String, String)> {
+        src.lines()
+            .filter_map(|l| {
+                let (head, val) = l.rsplit_once(' ')?;
+                let which = if head.ends_with("_TX_MAX_SERIALIZED_SIZE") {
+                    "TX"
+                } else if head.ends_with("_RX_MAX_SERIALIZED_SIZE") {
+                    "RX"
+                } else {
+                    return None;
+                };
+                if !head.starts_with("#define") {
+                    return None;
+                }
+                val.trim().parse::<usize>().ok()?;
+                Some((which.to_string(), val.trim().to_string()))
+            })
+            .collect()
+    }
+
+    /// `static constexpr size_t RX_MAX_SERIALIZED_SIZE = 136;` → ("RX", 136).
+    fn cpp_bounds(src: &str) -> Vec<(String, String)> {
+        src.lines()
+            .filter_map(|l| {
+                let l = l.trim();
+                let rest = l.strip_prefix("static constexpr size_t ")?;
+                let (name, val) = rest.split_once(" = ")?;
+                let which = match name {
+                    "TX_MAX_SERIALIZED_SIZE" => "TX",
+                    "RX_MAX_SERIALIZED_SIZE" => "RX",
+                    _ => return None,
+                };
+                let val = val.trim_end_matches(';').trim();
+                val.parse::<usize>().ok()?;
+                Some((which.to_string(), val.to_string()))
+            })
+            .collect()
+    }
+
+    let mut compared = 0;
+    let mut problems = Vec::new();
+    for h in walk(&golden_dir()).expect("walk goldens") {
+        if h.extension().and_then(|e| e.to_str()) != Some("h") {
+            continue;
+        }
+        let hpp = h.with_extension("hpp");
+        if !hpp.exists() {
+            continue;
+        }
+        let (c_src, cpp_src) = (
+            std::fs::read_to_string(&h).expect("read C golden"),
+            std::fs::read_to_string(&hpp).expect("read C++ golden"),
+        );
+        let cpp = cpp_bounds(&cpp_src);
+        for (which, c_val) in c_bounds(&c_src) {
+            let Some((_, cpp_val)) = cpp.iter().find(|(w, _)| *w == which) else {
+                problems.push(format!(
+                    "{}: C states {which}_MAX_SERIALIZED_SIZE {c_val}, the C++ golden states none",
+                    h.file_name().unwrap().to_string_lossy()
+                ));
+                continue;
+            };
+            compared += 1;
+            if *cpp_val != c_val {
+                problems.push(format!(
+                    "{}: {which}_MAX_SERIALIZED_SIZE — C golden {c_val}, C++ golden {cpp_val}",
+                    h.file_name().unwrap().to_string_lossy()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        compared > 0,
+        "compared no bounds at all — the corpus lost its bounded types, or the \
+         patterns stopped matching. A cross-check that silently examines nothing \
+         is the vacuous-test shape this repo gates against."
+    );
+    assert!(
+        problems.is_empty(),
+        "the committed goldens disagree across languages about a bound derived \
+         in ONE place:\n  {}\n\nRegenerate with NROS_UPDATE_GOLDEN=1 and read the \
+         diff: if the two languages really do differ, the shared derivation is \
+         broken, not the golden.",
+        problems.join("\n  ")
+    );
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
@@ -67,7 +67,7 @@ struct Bounded {
     /// so a transmit buffer wants TX; a RECEIVE buffer must hold whichever
     /// encoding a peer negotiated, so it wants RX.
     static constexpr size_t TX_MAX_SERIALIZED_SIZE = 133;
-    static constexpr size_t RX_MAX_SERIALIZED_SIZE = 133;
+    static constexpr size_t RX_MAX_SERIALIZED_SIZE = 136;
 
     /// The two constants above, reachable UNIFORMLY across bounded and unbounded
     /// types — see the unbounded arm, where these are the poison. A generic
@@ -75,7 +75,7 @@ struct Bounded {
     /// one spelling works for every message type and a type with no bound
     /// reports so at the point the number is actually needed.
     template <class = void> struct tx_size_bound { static constexpr size_t value = 133; };
-    template <class = void> struct rx_size_bound { static constexpr size_t value = 133; };
+    template <class = void> struct rx_size_bound { static constexpr size_t value = 136; };
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
@@ -63,7 +63,7 @@ struct Capped {
     /// so a transmit buffer wants TX; a RECEIVE buffer must hold whichever
     /// encoding a peer negotiated, so it wants RX.
     static constexpr size_t TX_MAX_SERIALIZED_SIZE = 157;
-    static constexpr size_t RX_MAX_SERIALIZED_SIZE = 157;
+    static constexpr size_t RX_MAX_SERIALIZED_SIZE = 160;
 
     /// The two constants above, reachable UNIFORMLY across bounded and unbounded
     /// types — see the unbounded arm, where these are the poison. A generic
@@ -71,7 +71,7 @@ struct Capped {
     /// one spelling works for every message type and a type with no bound
     /// reports so at the point the number is actually needed.
     template <class = void> struct tx_size_bound { static constexpr size_t value = 157; };
-    template <class = void> struct rx_size_bound { static constexpr size_t value = 157; };
+    template <class = void> struct rx_size_bound { static constexpr size_t value = 160; };
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
@@ -67,7 +67,7 @@ struct Bounded {
     /// so a transmit buffer wants TX; a RECEIVE buffer must hold whichever
     /// encoding a peer negotiated, so it wants RX.
     static constexpr size_t TX_MAX_SERIALIZED_SIZE = 133;
-    static constexpr size_t RX_MAX_SERIALIZED_SIZE = 133;
+    static constexpr size_t RX_MAX_SERIALIZED_SIZE = 136;
 
     /// The two constants above, reachable UNIFORMLY across bounded and unbounded
     /// types — see the unbounded arm, where these are the poison. A generic
@@ -75,7 +75,7 @@ struct Bounded {
     /// one spelling works for every message type and a type with no bound
     /// reports so at the point the number is actually needed.
     template <class = void> struct tx_size_bound { static constexpr size_t value = 133; };
-    template <class = void> struct rx_size_bound { static constexpr size_t value = 133; };
+    template <class = void> struct rx_size_bound { static constexpr size_t value = 136; };
 
     /// Publish via FFI (called by Publisher<M>::publish)
     static int ffi_publish(void* handle, const void* msg) {

--- a/packages/cli/rosidl-codegen/tests/message_size_bound_parity.rs
+++ b/packages/cli/rosidl-codegen/tests/message_size_bound_parity.rs
@@ -126,10 +126,23 @@ fn the_cpp_header_states_the_same_bound_as_the_c_header_and_the_rust_const() {
             let lookup: &MsgLookup<'_> = &corpus_lookup;
 
             let (x1, x2) = rust_consts(name, &msg, &caps, lookup);
-            // TX writes XCDR1; RX must hold whichever encoding arrives.
+            // TX writes XCDR1, exactly: we write what we serialise.
             let want_tx = x1;
+            // RX must hold whichever encoding arrives, AND the framing the
+            // transport adds on top of it — `transport_framed`, which is the
+            // sender's RTPS 4-byte submessage alignment (issues 0969/0970), not
+            // padding anyone chose.
+            //
+            // Called, not restated. This expectation was written as a bare
+            // `a.max(b)` one commit AFTER `ec63d4ed9` introduced the framing, so
+            // it asserted the pre-framing number and went red the moment the C++
+            // pack started emitting a bound at all. An open-coded `+ 4` here
+            // would be a THIRD implementation of the same rounding — there are
+            // already two, `rosidl_codegen::bounds::transport_framed` and
+            // `nros_node::rmw_type_registry::transport_framed`, which cite each
+            // other precisely so they cannot drift.
             let want_rx = match (x1, x2) {
-                (Some(a), Some(b)) => Some(a.max(b)),
+                (Some(a), Some(b)) => Some(rosidl_codegen::bounds::transport_framed(a.max(b))),
                 _ => None,
             };
 

--- a/scripts/check-cyclone-domain-not-pinned.py
+++ b/scripts/check-cyclone-domain-not-pinned.py
@@ -121,4 +121,9 @@ def self_test() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(self_test() if "--self-test" in sys.argv else main())
+    # The selftest runs on the NORMAL path, not only behind the flag: a negative
+    # control nobody runs decays into a comment, which is what
+    # `check-gate-selftests` enforces. `--self-test` stays as a way to run ONLY
+    # the control.
+    rc = self_test()
+    sys.exit(rc if rc or "--self-test" in sys.argv else main())


### PR DESCRIPTION
`main` was red in **two** rosidl-codegen tests, and they disagreed about the truth — which is why this needed a measurement, not a regeneration.

```
codegen_golden      C++ golden says RX 133, the emitter says 136
size_bound_parity   the emitter says 136, this test wants 133
```

Regenerating the goldens would have blessed 136; "fixing" the emitter would have blessed 133. Only one of those is right.

## The emitter is right

`BoundState::classify` sets `rx: transport_framed(max(x1, x2))`. `transport_framed` rounds up to 4 because **RTPS aligns a submessage to 4 and the *sender* adds that pad** — the backend hands back exactly what the wire gave it (issues 0969/0970), so the pad reaches the receive buffer instead of being absorbed by a re-encode. A buffer sized to the exact bound refuses those bytes. TX stays exact: we write what we serialise.

**Measured, not assumed.** I probed both size implementations directly:

```
Xcdr1: codegen=Bounded(133) runtime=Some(133)
Xcdr2: codegen=Bounded(129) runtime=Some(129)
```

Codegen's `bound_message` and the runtime's `nros_serdes::size::max_serialized_size` agree per-encoding, so the +3 is **not** drift between them — it's the framing applied on top of `max(133, 129)`. The runtime applies the same rounding in `subscription_rx_bytes`, so C, C++ and Rust all size 136; only the two test artifacts were stale.

## The sequence explains both reds

`ec63d4ed9` introduced the framing. `5f3c08545` — the very next commit — added the C++ emitter, captured its goldens, and wrote the parity expectation, **all three without it**. Two artifacts forgot a change their parent had just made.

- The three C++ goldens now state the framed RX (133 → 136, 157 → 160). TX untouched; the C goldens beside them already said 136.
- The parity expectation now **calls** `bounds::transport_framed` instead of restating the rounding. An open-coded `+ 4` would be a third implementation of it — there are already two, and they cite each other so they cannot drift.

## Why nothing caught it

- `message_size_bound_parity` cross-checks C, C++ and Rust by **generating** headers — it never reads a golden.
- `codegen_golden` compares generated against committed **per file** — it never compares two goldens to each other.

So the C golden said 136 and the C++ golden beside it said 133 *for the same type*, and no test was looking at that pair. `the_committed_c_and_cpp_goldens_state_the_same_bound` now does, reading the **committed files** rather than the emitter — a stale capture is invisible to any check that regenerates first.

Mutation-checked: reverting one golden to 133 fails it by name —

```
the committed goldens disagree across languages about a bound derived in ONE place:
  Bounded.h: RX_MAX_SERIALIZED_SIZE — C golden 136, C++ golden 133
```

— and it refuses to pass vacuously if the corpus ever loses its bounded types.

## Also in here

`check-cyclone-domain-not-pinned` (landed today in `47003cc1e`) ran its selftest only behind `--self-test`, which `check-gate-selftests` rejects — a third red blocking `ci l1` for everyone. It now runs on the normal path.

## Verification

- `just ci l1` — **PASSED**, the first fully green tier 1 in several days
- `just check fast` — 164/164
- Whole `packages/cli` test suite green
