### PR TITLE
fix(#0984): one archive, two authored source lists, and #0970 updated only one

### DIFF
--- a/docs/issues/0985-cpp-config-header-never-written-to-the-shared-target-dir.md
+++ b/docs/issues/0985-cpp-config-header-never-written-to-the-shared-target-dir.md
@@ -1,0 +1,120 @@
+---
+id: 985
+title: "The C++ side never writes `nros_config_generated.h` to the shared target
+  dir, so issue 0978's mirror falls back to the leaf copy every time — and the
+  leaf copy is a museum"
+status: open
+type: bug
+area: cmake, build
+severity: high
+found: 2026-09-02
+related: [issue-0978, issue-0805, issue-0834, issue-0369, issue-0088]
+---
+
+## Symptom
+
+`just build native` fails linking `c_listener` (`fixture-linux-c-zenoh`), with
+issue 0369's size anchor and the SAME hash issue 0978 was filed for:
+
+```
+/usr/bin/ld: CMakeFiles/c_listener.dir/src/main.c.o:(.data.rel.ro+0x0):
+  undefined reference to `nros_config_variant_sz_f3c40eb64e98fb7d'
+/usr/bin/ld: libstd_msgs__nano_ros_c.a(std_msgs_msg_string.c.o):(.data.rel.ro+0x0):
+  undefined reference to `nros_config_variant_sz_f3c40eb64e98fb7d'
+```
+
+**This is not 0978 regressing.** 0978's fix is present and working — it is
+visible working in the measurement below. This is the case its fallback arm
+cannot help with.
+
+## Measured
+
+`examples/native/c/listener/build-zenoh` holds FOUR copies of
+`nros_config_generated.h` with THREE different size anchors:
+
+| copy | anchor | mtime |
+| --- | --- | --- |
+| `nros-c/include/nros/…` | `sz_9a3e918900c9d46d` | **2026-09-02 03:12:42** |
+| `nros-cpp/include/nros/…` | `sz_f3c40eb64e98fb7d` | **2026-09-02 03:12:43** |
+| `nros-c/…` | `sz_cd6bc387c5d734f9` | 2026-09-01 04:02 |
+| `nros-cpp/…` | `sz_f3c40eb64e98fb7d` | 2026-08-26 20:22 |
+
+Both `include/nros/` copies were written **by the same build, one second
+apart**. The C one is current; the C++ one carries the 2026-08-26 generation.
+The archives and every shared copy agree on the current `sz_9a3e918900c9d46d`:
+
+```
+libnros_c.a      nros_config_variant_sz_9a3e918900c9d46d
+libnros_cpp.a    nros_config_variant_sz_9a3e918900c9d46d
+build/corrosion-cargo/native/*/nros-c-generated/nros/nros_config_generated.h   sz_9a3e918900c9d46d
+```
+
+## Root cause: the C++ side has no shared copy of THAT file to prefer
+
+Issue 0978 made `mirror-generated-header.sh` prefer the leaf-independent copy at
+`$CARGO_TARGET_DIR/nros-{c,cpp}-generated/nros/<name>` and fall back to the
+leaf's own corrosion dir. For `nros-c` the shared copy exists, so the mirror
+takes it and the C header is current — 0978 working.
+
+For `nros-cpp` it does not exist. Every native shared dir holds:
+
+```
+$ ls build/corrosion-cargo/native/*/nano-ros_1147c/nros-cpp-generated/nros/
+nros_cpp_config_generated.h
+nros_cpp_config_generated.h.stamp
+```
+
+`nros_cpp_config_generated.h` — a DIFFERENT file — and no
+`nros_config_generated.h`. So candidate (2) is absent for this name on the C++
+side, the fallback fires **every time by construction**, and it resolves to the
+leaf's own copy, which nothing has rewritten since 2026-08-26.
+
+0978's premise was "the shared copy is refreshed by ANY leaf's run, so it is
+never staler". True — where it is written at all. `write_header_to_target_dir`
+writes the C++ package's OWN header there and not the shared
+`nros_config_generated.h`, so for that one name the guarantee does not hold and
+the fallback is not a fallback: it is the only arm.
+
+## Not issue 0834
+
+0834's signature is "a `.stamp` with no `.h` beside it", absorbing, repairable
+only by `rm -rf`. Here the stamp's own header IS present; a *different* header
+is missing, and the state is explainable and fixable without a wipe. Worth
+separating, because the directory listing looks superficially like 0834's.
+
+## Why the C link picks up the C++ copy
+
+`main.c.o` and `std_msgs_msg_string.c.o` both reference `sz_f3c40eb64e98fb7d`,
+which is only in the two `nros-cpp` copies — so `c_listener`'s include path
+reaches `nros-cpp/include/nros/` for this header. Whether that is intended
+(nros-c's public headers include nros-cpp's) or an include-order accident is NOT
+yet established and should be answered before fixing: if a C target should never
+resolve this header from the C++ package, that ordering is a second defect
+sitting behind this one.
+
+## Direction
+
+1. Establish whether `nros_config_generated.h` should be written to the shared
+   target dir by the C++ side too, or whether the C++ mirror should read the C
+   side's shared copy (they are the same generated content — the sizes header —
+   which is what makes four copies possible at all).
+2. Answer the include-path question above before choosing, since it decides
+   whether the C++ copy needs to be current or needs to not be reachable.
+3. Whichever: the invariant worth gating is that **no two
+   `nros_config_generated.h` under one build dir may disagree**. That is
+   checkable directly, cheaply, and would have caught 0088, 0114, 0122, 0123,
+   0245, 0268, 0978 and this — the whole family — at the point of divergence
+   rather than as a link error naming a hash.
+
+## How it was found
+
+Three deep. Issue 0978 unblocked the C/C++ link stage; issue 0979 unblocked the
+Rust build-script stage; issue 0984 unblocked the Rust link stage; this is what
+the lane reached next. Each was invisible until the one in front of it was
+fixed.
+
+## Acceptance
+
+* `just build native` links `fixture-linux-c-zenoh`.
+* No two copies of `nros_config_generated.h` under one build dir disagree, and
+  a gate says so.

--- a/docs/issues/archived/0984-cyclone-backend-source-list-drifts-between-cmake-and-cargo.md
+++ b/docs/issues/archived/0984-cyclone-backend-source-list-drifts-between-cmake-and-cargo.md
@@ -1,0 +1,114 @@
+---
+id: 984
+title: "One archive, two authored source lists — `nros_sertype.cpp` reached the
+  cmake target and not the cargo one, so every Rust fixture failed to link"
+status: resolved
+type: bug
+area: rmw, build
+severity: high
+found: 2026-09-02
+related: [issue-0970, issue-0979, issue-0088, issue-0475]
+---
+
+## Symptom
+
+`just build native` fails at `fixture-0018`
+(`bridge-zenoh-to-cyclonedds-fwd`):
+
+```
+rust-lld: error: undefined symbol: nros_rmw_cyclonedds::create_nros_sertype(dds_topic_descriptor const*)
+  >>> referenced by publisher.cpp:148
+  >>>   115f693ad0506440-publisher.o:(nros_rmw_cyclonedds::publisher_create(...))
+  >>>   in archive .../out/libnros_rmw_cyclonedds.a
+```
+
+The reference comes from INSIDE the archive: a TU compiled against a
+declaration whose definition was never compiled in beside it.
+
+## Not a stale archive
+
+Worth stating, because the shape (`-Wl,--whole-archive -lnros_rmw_cyclonedds`,
+a raw link flag) is issue 0475's, and 0475's remedy is a rebuild edge. It is
+not that. The archive was written minutes earlier by the run that failed, and
+its member list settles it:
+
+```
+$ ar t libnros_rmw_cyclonedds.a | grep -E 'sertype|publisher'
+115f693ad0506440-publisher.o
+115f693ad0506440-subscriber.o
+115f693ad0506440-sertype_min.o          <- and no nros_sertype.o
+$ nm -C libnros_rmw_cyclonedds.a | grep -c 'T .*create_nros_sertype'
+0
+```
+
+Fresh archive, missing member. Nothing was stale; a source was never compiled.
+
+## Root cause: the archive has TWO authored source lists
+
+`libnros_rmw_cyclonedds.a` is built two ways, and each names its sources by
+hand:
+
+| built by | list | linked by |
+| --- | --- | --- |
+| cmake | `nros-rmw-cyclonedds/CMakeLists.txt` `target_sources` | C/C++ examples |
+| cargo | `nros-rmw-cyclonedds-sys/build.rs` `let cpp_files` | Rust fixtures |
+
+`b4858f941` (`feat(#0970): the Cyclone backend registers its own sertype`) added
+`src/nros_sertype.cpp` to the CMake list — one `+1` line in its diffstat — and
+not to `cpp_files`. So every C/C++ example kept linking and every Rust fixture
+could not, which is why it looked like nothing was wrong.
+
+`build.rs` was already carrying the warning, eight lines below the list:
+
+> The CMake target adds these too (see `nros-rmw-cyclonedds/CMakeLists.txt:95`);
+> without them the vendored cargo build leaves the symbols undefined.
+
+A comment is not a check. This is the third instance of "one derivation, two
+spellings" found in two days, after issue 0978 (the generated-header mirror) and
+issue 0981 (the RX size-bound rule) — and like 0981, the commit that broke it
+had a note explaining precisely the hazard it then walked into.
+
+## Why it surfaced only now
+
+It did not surface when `b4858f941` landed because the Rust fixture stage was
+already dying earlier, in `nros-node`'s build script (issue 0979). Fixing 0979
+let the lane reach LINKING for the first time since, and this was waiting there
+— the same way 0978's fix uncovered 0979. Three failures deep in one lane, each
+hidden by the one in front of it.
+
+## Fix
+
+`nros_sertype.cpp` added to `cpp_files`.
+
+Gate: `just check cyclone-backend-sources` →
+`scripts/check-cyclone-backend-sources.py`, on the fast line. It extracts the
+`src/*.cpp` set from the cmake target and the `let cpp_files` array from
+`build.rs` and requires them equal, naming the direction of any difference and
+what it will break. Pure text, no build.
+
+The `bridge/` list is deliberately not compared: those TUs are only in the cargo
+build, and `build.rs` says so.
+
+Proven non-vacuous: against the pre-fix tree it reports
+
+```
+check-cyclone-backend-sources: the two lists that build libnros_rmw_cyclonedds.a disagree.
+  only in CMakeLists.txt: nros_sertype.cpp
+      -> a RUST fixture will fail to link against symbols this TU defines,
+         while every C/C++ example keeps working (issue 0984).
+```
+
+The script runs its own selftest on the normal path, per
+`check-gate-selftests`.
+
+## Sweep
+
+Build scripts carrying a C++ source list mirrored by a CMake target: this is the
+only one in the tree (`git grep -l '\.cpp"' -- '*/build.rs'` yields this crate
+and one CLI source file that merely shares the filename).
+
+## Acceptance
+
+* [x] `cpp_files` and the cmake target name the same backend TUs.
+* [x] A gate that fails on the pre-fix tree and passes after.
+* [x] `just build native` links `fixture-0018`.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -78,5 +78,6 @@ fails if this block drifts.
 - **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it See `0971-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
+- **#0985** (cmake, build) — The C++ side never writes `nros_config_generated.h` to the shared target dir, so issue 0978's mirror falls back to the leaf copy every time — and the leaf copy is a museum See `0985-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/just/check.just
+++ b/just/check.just
@@ -142,6 +142,7 @@ fast-serial: \
     cpp-fmt \
     cpp-freestanding-includes \
     cpp-no-std-stdio \
+    cyclone-backend-sources \
     cyclone-domain-not-pinned \
     deploy-board-resolves \
     doc-recipe-refs \
@@ -504,6 +505,18 @@ codegen-size-bound-golden:
     @cargo test --manifest-path packages/cli/Cargo.toml -p rosidl-codegen \
         --test codegen_golden --test message_size_bound_parity --quiet
     @echo "codegen size-bound golden + C/C++/Rust parity: OK"
+
+# Issue 0984 — `libnros_rmw_cyclonedds.a` is built from TWO authored source
+# lists (the cmake target, and `let cpp_files` in the sys crate's build.rs), and
+# #0970 added `nros_sertype.cpp` to only one. The cmake path kept linking, so
+# nothing looked wrong; every RUST fixture that reached the link stage died on
+# an undefined `create_nros_sertype` referenced from inside the archive.
+#
+# `build.rs` already carried a comment warning about this exact drift. A comment
+# is not a check.
+[private]
+cyclone-backend-sources:
+    @python3 scripts/check-cyclone-backend-sources.py
 
 [private]
 cli-tests:

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds-sys/build.rs
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds-sys/build.rs
@@ -124,6 +124,10 @@ fn vendored_build() {
         "graph.cpp",
         "qos.cpp",
         "sertype_min.cpp",
+        // issue 0984 — added by #0970 to the CMake list and NOT to this one, so
+        // the cmake path linked and the cargo path did not. `check-cyclone-backend-sources`
+        // now compares the two.
+        "nros_sertype.cpp",
     ];
     // Phase 212.K.7.7 — bridge TUs that define the C++ entry points called
     // by the Rust `nros-rmw-cyclonedds` crate (descriptor builder + type

--- a/scripts/check-cyclone-backend-sources.py
+++ b/scripts/check-cyclone-backend-sources.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""One archive, two source lists — assert they agree. Issue 0984.
+
+`libnros_rmw_cyclonedds.a` is built two ways, and both lists are AUTHORED:
+
+  * `packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt` — the cmake
+    target, which is what a C/C++ example links.
+  * `packages/rmw/cyclonedds/nros-rmw-cyclonedds-sys/build.rs` — the vendored
+    cargo build, which is what a RUST fixture links.
+
+Issue 0970 added `nros_sertype.cpp` to the first and not the second. The cmake
+path kept working, so nothing looked wrong; every Rust fixture that reached the
+link stage died on
+
+    rust-lld: error: undefined symbol: nros_rmw_cyclonedds::create_nros_sertype(...)
+
+referenced from `publisher.o` INSIDE the archive — a TU that was compiled
+against a declaration whose definition was never compiled in beside it.
+
+`build.rs` already carried a comment warning about exactly this ("The CMake
+target adds these too [...]; without them the vendored cargo build leaves the
+symbols undefined"). A comment is not a check. This is the check.
+
+The `bridge/` list is deliberately NOT compared: those TUs are only in the
+cargo build (cmake reaches them another way), and the comment above them says
+so. Only the backend `src/*.cpp` set has to match.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CMAKE = REPO / "packages/rmw/cyclonedds/nros-rmw-cyclonedds/CMakeLists.txt"
+BUILD_RS = REPO / "packages/rmw/cyclonedds/nros-rmw-cyclonedds-sys/build.rs"
+
+# `    src/foo.cpp` inside the target's source list.
+_CMAKE_SRC = re.compile(r"^\s*src/([A-Za-z0-9_]+\.cpp)\s*$", re.M)
+# The `let cpp_files = [ ... ];` array, then the quoted names inside it.
+_RS_BLOCK = re.compile(r"let\s+cpp_files\s*=\s*\[(.*?)\];", re.S)
+_RS_NAME = re.compile(r'"([A-Za-z0-9_]+\.cpp)"')
+
+
+def cmake_sources(text: str) -> set[str]:
+    return set(_CMAKE_SRC.findall(text))
+
+
+def build_rs_sources(text: str) -> set[str]:
+    block = _RS_BLOCK.search(text)
+    if block is None:
+        raise SystemExit(
+            "check-cyclone-backend-sources: no `let cpp_files = [...]` in "
+            f"{BUILD_RS.relative_to(REPO)} — the parser and the file have "
+            "drifted; fix the parser rather than deleting the gate."
+        )
+    return set(_RS_NAME.findall(block.group(1)))
+
+
+def self_test() -> None:
+    """Runs on the NORMAL path (`check-gate-selftests`): a negative control
+    nobody runs decays into a comment."""
+    cm = cmake_sources("target_sources(x PRIVATE\n    src/a.cpp\n    src/b.cpp\n)\n")
+    assert cm == {"a.cpp", "b.cpp"}, cm
+    rs = build_rs_sources('let cpp_files = [\n "a.cpp",\n // c.cpp\n "b.cpp",\n];\n')
+    assert rs == {"a.cpp", "b.cpp", "c.cpp"} or rs == {"a.cpp", "b.cpp"}, rs
+    # The regression: cmake gains a file, build.rs does not.
+    cm2 = cmake_sources("    src/a.cpp\n    src/new.cpp\n")
+    rs2 = build_rs_sources('let cpp_files = [\n "a.cpp",\n];\n')
+    assert cm2 - rs2 == {"new.cpp"}, (cm2, rs2)
+    # ...and it must not fire when they agree.
+    assert cmake_sources("    src/a.cpp\n") ^ build_rs_sources(
+        'let cpp_files = [\n "a.cpp",\n];\n'
+    ) == set()
+
+
+def main() -> int:
+    self_test()
+
+    cm = cmake_sources(CMAKE.read_text(encoding="utf-8"))
+    rs = build_rs_sources(BUILD_RS.read_text(encoding="utf-8"))
+
+    if not cm:
+        print("check-cyclone-backend-sources: no src/*.cpp found in "
+              f"{CMAKE.relative_to(REPO)} — parser drift.", file=sys.stderr)
+        return 1
+
+    only_cmake = sorted(cm - rs)
+    only_cargo = sorted(rs - cm)
+    if not only_cmake and not only_cargo:
+        print(f"check-cyclone-backend-sources: OK — {len(cm)} backend TU(s), "
+              "cmake and cargo agree.")
+        return 0
+
+    print("check-cyclone-backend-sources: the two lists that build "
+          "libnros_rmw_cyclonedds.a disagree.", file=sys.stderr)
+    for f in only_cmake:
+        print(f"  only in CMakeLists.txt: {f}", file=sys.stderr)
+        print("      -> a RUST fixture will fail to link against symbols this TU "
+              "defines,", file=sys.stderr)
+        print("         while every C/C++ example keeps working (issue 0984).",
+              file=sys.stderr)
+    for f in only_cargo:
+        print(f"  only in build.rs: {f}", file=sys.stderr)
+        print("      -> the mirror of the same defect, one direction over.",
+              file=sys.stderr)
+    print("", file=sys.stderr)
+    print(f"  cmake:  {CMAKE.relative_to(REPO)}", file=sys.stderr)
+    print(f"  cargo:  {BUILD_RS.relative_to(REPO)} (`let cpp_files`)",
+          file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #0984. Also files #0985 (investigated, deliberately not fixed — see below).

## The bug

`just build native` dies linking `fixture-0018`:

```
rust-lld: error: undefined symbol: nros_rmw_cyclonedds::create_nros_sertype(...)
  >>> referenced by publisher.cpp:148
  >>>   ...-publisher.o: in archive .../libnros_rmw_cyclonedds.a
```

The reference comes from **inside** the archive — a TU compiled against a declaration whose definition was never compiled in beside it.

## Not a stale archive

Worth stating, because the shape (`-Wl,--whole-archive -lnros_rmw_cyclonedds`, a raw link flag) is issue 0475's, and 0475's remedy is a rebuild edge. It is not that:

```
$ ar t libnros_rmw_cyclonedds.a | grep -E 'sertype|publisher'
...-publisher.o
...-subscriber.o
...-sertype_min.o          <- and no nros_sertype.o
$ nm -C libnros_rmw_cyclonedds.a | grep -c 'T .*create_nros_sertype'
0
```

Fresh archive (written by the run that failed, minutes earlier), missing member. Nothing was stale; a source was never compiled. So no `rm -rf`, and the rebuild-edge remedy would have been the wrong tool.

## Root cause: the archive has TWO authored source lists

| built by | list | linked by |
| --- | --- | --- |
| cmake | `nros-rmw-cyclonedds/CMakeLists.txt` `target_sources` | C/C++ examples |
| cargo | `nros-rmw-cyclonedds-sys/build.rs` `let cpp_files` | Rust fixtures |

`b4858f941` (`feat(#0970)`) added `src/nros_sertype.cpp` to the first — one `+1` line in its diffstat — and not to the second. Every C/C++ example kept linking, which is why nothing looked wrong.

`build.rs` was already carrying the warning, eight lines below the list:

> The CMake target adds these too (see `.../CMakeLists.txt:95`); without them the vendored cargo build leaves the symbols undefined.

A comment is not a check. Third instance of "one derivation, two spellings" in two days after #0978 (the generated-header mirror) and #0981 (the RX size-bound rule) — and like #0981, the commit that broke it had a note describing exactly the hazard it then walked into.

## Why it surfaced only now

The Rust fixture stage was already dying earlier, in `nros-node`'s build script (#0979). Fixing that let the lane reach **linking** for the first time since — the same way #0978's fix uncovered #0979. Three failures deep in one lane, each masked by the one in front of it.

## Fix

`nros_sertype.cpp` added to `cpp_files`.

Gate: `just check cyclone-backend-sources` → `scripts/check-cyclone-backend-sources.py`, fast line, pure text and no build. It compares the two lists as sets and names the direction of any difference and what it will break. `bridge/` is deliberately not compared — those TUs are cargo-only, and build.rs says so. The script runs its own selftest on the normal path, per `check-gate-selftests`.

Non-vacuous — against the pre-fix tree:

```
check-cyclone-backend-sources: the two lists that build libnros_rmw_cyclonedds.a disagree.
  only in CMakeLists.txt: nros_sertype.cpp
      -> a RUST fixture will fail to link against symbols this TU defines,
         while every C/C++ example keeps working (issue 0984).
```

## Sweep

Build scripts carrying a C++ source list mirrored by a cmake target: this is the only one in the tree (`git grep -l '\.cpp"' -- '*/build.rs'` yields this crate and one CLI source file that merely shares the filename).

## Also in this PR: #0985 filed, not fixed

With #0979 and #0984 both applied, `just build native` gets one stage further and fails in `build-fixture-extras` with #0369's size anchor. **#0978 is not regressing — it is visibly working in the same measurement.** Four copies of `nros_config_generated.h` in one build dir, three anchors; the two `include/nros/` copies were written by the same build one second apart, the C one current and the C++ one carrying the 08-26 generation. Cause: the shared target dir holds `nros_cpp_config_generated.h` and no `nros_config_generated.h`, so #0978's fallback arm is the *only* arm on the C++ side and it lands on a museum leaf copy.

Filed rather than fixed because one question decides the fix and is unanswered: a C target's include path reaches `nros-cpp/include/nros/` for this header, and whether that is intended or an include-order accident decides whether the C++ copy must be made *current* or made *unreachable*. Guessing would repeat #0978's own mistake one level up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSuM4yABT9i6XzprmNn1op