### PR TITLE
phase-409 acceptance 3, and the pre-push hook stops corrupting the repo it guards

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,6 +22,21 @@
 
 set -euo pipefail
 
+# git runs a hook with GIT_DIR set (and, in a worktree or submodule, often
+# GIT_WORK_TREE / GIT_INDEX_FILE too). Those override BOTH a path argument and
+# `git -C`, so every command this hook invokes -- the gate tier, the selftests
+# that build throwaway repositories -- gets silently redirected at the repo
+# being pushed. Observed: `git init <tmp>` rewrote this repo's config with
+# core.bare=true, which then broke `rev-parse --show-toplevel` below for every
+# later push, and `update-index --add --cacheinfo 160000,...` staged a bogus
+# submodule pin into this repo's index -- from the hook whose job is to refuse
+# bogus submodule pins (issue 0986).
+#
+# Everything below resolves from the working tree, so clear them here. This is
+# also why running this hook by hand never reproduced the failure: an
+# interactive shell has no GIT_DIR.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
 repo_root="$(git rev-parse --show-toplevel)"
 check="$repo_root/scripts/ci/issue-ids-check.sh"
 

--- a/docs/issues/0986-pre-push-hook-corrupts-the-repo-it-guards.md
+++ b/docs/issues/0986-pre-push-hook-corrupts-the-repo-it-guards.md
@@ -1,0 +1,76 @@
+---
+id: 986
+title: "The pre-push hook writes into the repository it is guarding"
+status: open
+area: tooling
+severity: high
+related: [0840, 0966]
+---
+
+# A selftest that runs against the caller's repo
+
+## What happens
+
+Git sets `GIT_DIR` in a hook's environment. Three scripts reachable from
+`.githooks/pre-push` build throwaway repositories, and an inherited `GIT_DIR`
+overrides BOTH a path argument and `git -C`:
+
+* `scripts/ci/submodule-commits-reachable.sh` (`git init -q "$tmp/work"`,
+  `git init -q "$tmp/super"`, then `git -C "$tmp/super" update-index --add`)
+* `scripts/check-source-manifest.sh` (`git init -q .` in two places)
+* `scripts/reserve-claim.sh` (four `git init` calls in its selftest)
+
+So the selftests do not run against a temp repo. They run against the caller's.
+
+## Measured, on this checkout
+
+Two distinct kinds of damage, both observed:
+
+1. **Config.** `git init -q "$tmp/work"` with `GIT_DIR` set writes
+   `core.bare = true` into `GIT_DIR`'s config. Every later
+   `git rev-parse --show-toplevel` then fails with "fatal: this operation must
+   be run in a work tree" -- including the one on line 25 of the hook itself.
+   The push aborts, the config stays broken, and the next push repeats it.
+   Reproduced against a scratch repo shaped like a submodule (separate gitdir,
+   `core.worktree` set, no `bare` key):
+
+       before: bare=unset
+       git init -q "$tmp/work"   # with GIT_DIR set
+       after:  bare=true
+
+2. **Index.** `git -C "$tmp/super" update-index --add --cacheinfo "160000,$1,dep"`
+   staged a gitlink named `dep` into the CALLER's index, carrying the selftest's
+   deliberately invalid sha:
+
+       AD dep
+       Submodule dep 000000000...012345678 (new submodule)
+
+   That is a bogus submodule pin staged into a working repo by the hook whose
+   stated job is to refuse bad submodule pins. Had it been committed by an
+   unrelated `git commit -a`, the hook would have been the source of exactly the
+   failure it exists to prevent.
+
+## Why it went unseen
+
+The selftests redirect to `/dev/null` and return a status, so the damage is
+silent. And the hook is only exercised with `GIT_DIR` set when git itself runs
+it -- running `bash .githooks/pre-push` by hand does NOT reproduce it, because
+an interactive shell has no `GIT_DIR`. A hand-run hook passes and the real one
+corrupts.
+
+Worse, it is self-masking: run 1 sets `core.bare=true`, and from run 2 onward
+the hook dies at `rev-parse --show-toplevel` BEFORE reaching the selftests, so
+the symptom presents as a broken repository rather than as a bad script.
+
+## Fix
+
+`unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY` at the top of
+each of the three scripts. Every git invocation in them already names its target
+explicitly, so nothing else changes.
+
+## Not covered
+
+No gate runs a hook under a hook's environment. A gate that exports `GIT_DIR`,
+runs the hook, and asserts the repo's config and index are untouched afterwards
+would have caught this on the day it landed. Related to 0840: hooks that are
+installed but never exercised as git exercises them.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -79,7 +79,6 @@ fails if this block drifts.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
 - **#0985** (cmake, build) — The C++ side never writes `nros_config_generated.h` to the shared target dir, so issue 0978's mirror falls back to the leaf copy every time — and the leaf copy is a museum See `0985-*`.
-- **#0972** (api-c, rmw) — ROS domain 0 is both a legal domain and the `unset` marker, so asking for domain 0 explicitly is silently overridden See `0972-*`.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -79,5 +79,7 @@ fails if this block drifts.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
 - **#0985** (cmake, build) — The C++ side never writes `nros_config_generated.h` to the shared target dir, so issue 0978's mirror falls back to the leaf copy every time — and the leaf copy is a museum See `0985-*`.
+- **#0972** (api-c, rmw) — ROS domain 0 is both a legal domain and the `unset` marker, so asking for domain 0 explicitly is silently overridden See `0972-*`.
+- **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-409-executor-inline-storage.md
+++ b/docs/roadmap/phase-409-executor-inline-storage.md
@@ -1,4 +1,4 @@
-# Phase 405 — finish phase-271: every knob-scaled member leaves the `Executor` value
+# Phase 409 — finish phase-271: every knob-scaled member leaves the `Executor` value
 
 **Status (2026-08-31). Opened from issue 0961.** phase-271 externalised SIX
 sized arrays and said so deliberately: "`Executor` keeps every field except the
@@ -167,9 +167,57 @@ fallback snapshots (`nros_config_generated_nuttx.h`,
 `nros_cpp_config_generated_nuttx.h`) are hand-maintained UPPER BOUNDS at 98296
 and still cover the new value; they were deliberately left alone.
 
-### Not done here
+### Acceptance 3 -- MET on silicon (2026-09-01)
 
-Acceptance 3 -- the island boot on `mr_canhubk3/s32k344` -- needs the board, which
-this work did not have. `ZenohSession::names_and_types_filtered` (19840 bytes,
-the largest frame in the image and larger than `open_in` ever was) is untouched;
-it is not on the boot path, and issue 0961 files it separately.
+The board arrived after the section above was written. All three acceptance
+criteria now hold, and 2 has been re-measured on the target rather than inferred
+from an x86_64 ratio.
+
+**Acceptance 2, on Cortex-M.** Frames read with `arm-zephyr-eabi-objdump -d` from
+the linked island image (`build-z4rtt/zephyr/zephyr.elf`), against the numbers
+issue 0961 reported for the same two functions before the carve:
+
+| function | 0961, before | island image, after |
+| --- | ---: | ---: |
+| `Executor::open_in` | 16000 | 2244 |
+| `nros_cpp_init` | 15104 | 1396 |
+
+31104 bytes of prologue on that call chain becomes 3640. The x86_64 table above
+predicted the ratio; this is the part number the phase was actually opened for.
+
+A parser note, because it cost a wrong answer before it cost a right one: on
+Thumb-2 the wide form is `subw sp, sp, #N`, which does NOT match a pattern
+written for `sub.w`. A scan that misses it reports a frame of ZERO for a function
+that has a real 2244-byte one, and zero reads as success. Match all three of
+`sub`, `sub.w` and `subw`.
+
+**Acceptance 3.** The island entry boots on `mr_canhubk3/s32k344` with
+`CONFIG_MAIN_STACK_SIZE=16384`, half the 32768 that was the smallest workable
+value before the carve, and every value in that board `.conf` is now traceable to
+a failure the board produced. Recorded in the superproject at commit 8d586b2,
+"feat(island): the configuration that boots, measured on silicon": four MRM nodes
+and 22 topics visible from a stock ROS 2 Humble graph over zenoh-pico on serial.
+Final image RAM 99.16%, DTCM 71.52%, FLASH 9.82%.
+
+phase-271 is finished. Every knob-scaled member is charged to the backing, and
+the value no longer scales with a knob at either the defaults or the island's.
+
+### Residual, not this phase
+
+`ZenohSession::names_and_types_filtered` measures 19876 bytes on the island image
+(19840 on x86_64) and is still the largest frame there, larger than `open_in`
+ever was. Not on the boot path; issue 0961 files it separately.
+
+Two frames the carve did not touch, surfaced by the same scan and worth a look
+before anyone enables actions on a small part:
+
+| function | island image |
+| --- | ---: |
+| `Executor::register_action_server_raw` | 11764 |
+| `Executor::register_action_client_raw` | 9036 |
+
+The island sets `NROS_EXECUTOR_ACTION_CLIENTS=0` and registers no action entity,
+so neither is on its boot path today. They are per-entity registration frames
+rather than knob-scaled `Executor` members, so they are a different shape of
+problem from the one this phase solved, and they should be measured before they
+are assumed to be one.

--- a/scripts/check-source-manifest.sh
+++ b/scripts/check-source-manifest.sh
@@ -21,6 +21,18 @@
 # failure here can never leave the real worktree dirty.
 set -uo pipefail
 
+# A hook runs with GIT_DIR (and sometimes GIT_WORK_TREE / GIT_INDEX_FILE) set by
+# git, and those override BOTH a path argument and `git -C`. This script builds
+# throwaway repositories, so an inherited GIT_DIR silently redirects that work
+# into the CALLER'S repository: `git init <tmp>` rewrites the caller's config
+# (setting core.bare=true, which then breaks `rev-parse --show-toplevel` for
+# everything downstream), and `git -C <tmp> update-index --add` stages entries
+# into the caller's index. Observed as a pre-push hook that corrupted the repo
+# it was guarding. The variables are cleared here because every git invocation
+# below names its target explicitly.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/build/source-manifest.sh
 source "$repo_root/scripts/build/source-manifest.sh"

--- a/scripts/ci/submodule-commits-reachable.sh
+++ b/scripts/ci/submodule-commits-reachable.sh
@@ -49,6 +49,18 @@
 #       2 the network is unavailable and the check could not be performed.
 set -uo pipefail
 
+# A hook runs with GIT_DIR (and sometimes GIT_WORK_TREE / GIT_INDEX_FILE) set by
+# git, and those override BOTH a path argument and `git -C`. This script builds
+# throwaway repositories, so an inherited GIT_DIR silently redirects that work
+# into the CALLER'S repository: `git init <tmp>` rewrites the caller's config
+# (setting core.bare=true, which then breaks `rev-parse --show-toplevel` for
+# everything downstream), and `git -C <tmp> update-index --add` stages entries
+# into the caller's index. Observed as a pre-push hook that corrupted the repo
+# it was guarding. The variables are cleared here because every git invocation
+# below names its target explicitly.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+
+
 # Prove the two verdicts on every run, against a LOCAL remote.
 #
 # `check-gate-selftests` requires this and is right to: the whole value here is

--- a/scripts/reserve-claim.sh
+++ b/scripts/reserve-claim.sh
@@ -80,6 +80,18 @@
 
 set -euo pipefail
 
+# A hook runs with GIT_DIR (and sometimes GIT_WORK_TREE / GIT_INDEX_FILE) set by
+# git, and those override BOTH a path argument and `git -C`. This script builds
+# throwaway repositories, so an inherited GIT_DIR silently redirects that work
+# into the CALLER'S repository: `git init <tmp>` rewrites the caller's config
+# (setting core.bare=true, which then breaks `rev-parse --show-toplevel` for
+# everything downstream), and `git -C <tmp> update-index --add` stages entries
+# into the caller's index. Observed as a pre-push hook that corrupted the repo
+# it was guarding. The variables are cleared here because every git invocation
+# below names its target explicitly.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+
+
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 cd "${NROS_CLAIM_REPO:-$(dirname "$SELF")/..}"
 


### PR DESCRIPTION
Two commits. The first finishes phase-271; the second fixes a hook bug the first one ran into.

## phase-409 acceptance 3 (commit 1)

phase-271 externalised six sized arrays and left nine knob-scaled members in the `Executor` value. phase-409 carved those nine into the same backing and landed with acceptance 1 and 2 measured on x86_64, and acceptance 3 open because that work did not have the board.

The board is here. Both remaining claims are now measured on silicon.

Acceptance 2, on Cortex-M, read with `arm-zephyr-eabi-objdump` from the linked island image, against the frames issue 0961 reported before the carve:

| function | before | after |
| --- | ---: | ---: |
| `Executor::open_in` | 16000 | 2244 |
| `nros_cpp_init` | 15104 | 1396 |

31104 bytes of prologue on that call chain becomes 3640.

Acceptance 3: the island boots on `mr_canhubk3/s32k344` with `CONFIG_MAIN_STACK_SIZE=16384`, half the smallest workable value before the carve. So phase-271 is finished.

A parser note is in the doc because it cost a wrong answer first. On Thumb-2 the wide form is `subw sp, sp, #N`, which does not match a pattern written for `sub.w`. My first scan missed it and reported a frame of ZERO for `open_in` -- and zero reads as success rather than as a broken pattern.

Residual, recorded and NOT fixed: `register_action_server_raw` at 11764 bytes and `register_action_client_raw` at 9036. Not on the island's boot path, and a different shape of problem from the one this phase solved.

## The hook bug, issue 0986 (commit 2)

Found while trying to push commit 1.

Git runs a hook with `GIT_DIR` set, and that overrides both a path argument and `git -C`. Scripts reachable from `.githooks/pre-push` build throwaway repositories in their selftests, so with `GIT_DIR` set those selftests do not run against a temp repo. They run against the caller's. Two kinds of damage, both observed on a real checkout:

`git init -q "$tmp/work"` wrote `core.bare = true` into this repo's config, after which every `git rev-parse --show-toplevel` failed with "fatal: this operation must be run in a work tree" -- including the one in the hook itself.

`git -C "$tmp/super" update-index --add --cacheinfo "160000,$sha,dep"` staged a gitlink named `dep` into this repo's index, carrying the selftest's deliberately invalid sha. A bogus submodule pin, staged by the hook whose job is to refuse bogus submodule pins.

Fixed at the boundary where the variable enters (the hook clears the inherited variables), plus the same hardening in the three scripts so they are safe when invoked directly.

Two properties are why it survived, and both are in the commit message: it does not reproduce by hand, because an interactive shell has no `GIT_DIR`; and it is self-masking, because run 1 sets `core.bare` and from run 2 the hook dies before reaching the code that caused it.

Issue 0986 also names the gate that does not exist: nothing runs a hook under a hook's environment and asserts the repo is untouched afterwards.

## Verification

Pushed with the hook ENABLED and green -- no `--no-verify`. `just check fast` 156/156, which is what the hook itself ran.