### PR TITLE
feat(#0900): derive the arena's heavy-slot count from the entity inventory

### DIFF
--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -237,7 +237,8 @@ function(nros_derive_entity_inventory_knobs)
     _nros_entity_publish(NROS_ENTITY_INVENTORY_STATUS "refused")
     _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "")
     _nros_entity_publish(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 0)
-    foreach(_v NROS_DERIVED_EXECUTOR_MAX_CBS NROS_ENTITY_INVENTORY_ENTITY_TOTAL)
+    foreach(_v NROS_DERIVED_EXECUTOR_MAX_CBS NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
+               NROS_ENTITY_INVENTORY_ENTITY_TOTAL)
         unset(${_v})
         unset(${_v} PARENT_SCOPE)
     endforeach()
@@ -326,6 +327,13 @@ function(nros_derive_entity_inventory_knobs)
         _nros_entity_publish(NROS_DERIVED_EXECUTOR_MAX_CBS
             "${NROS_DERIVED_EXECUTOR_MAX_CBS}")
     endif()
+    # Issue 0900 — how many of those slots the arena budgets at the ACTION
+    # entry size. Published beside MAX_CBS because the two are only meaningful
+    # together: build.rs clamps this to that.
+    if(DEFINED NROS_DERIVED_EXECUTOR_ACTION_CLIENTS)
+        _nros_entity_publish(NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
+            "${NROS_DERIVED_EXECUTOR_ACTION_CLIENTS}")
+    endif()
     foreach(_kind PUBLISHER SUBSCRIPTION TIMER SERVICE_SERVER SERVICE_CLIENT
                   ACTION_SERVER ACTION_CLIENT GUARD_CONDITION)
         if(DEFINED NROS_ENTITY_COUNT_${_kind})
@@ -356,7 +364,9 @@ function(nros_derive_entity_inventory_knobs)
             "${NROS_ENTITY_INVENTORY_COMPONENT_COUNT} components -- "
             "${NROS_ENTITY_INVENTORY_ENTITY_TOTAL} entities, "
             "${NROS_DERIVED_EXECUTOR_MAX_CBS} executor callback slots "
-            "-> NROS_EXECUTOR_MAX_CBS")
+            "-> NROS_EXECUTOR_MAX_CBS, "
+            "${NROS_DERIVED_EXECUTOR_ACTION_CLIENTS} of them action-sized "
+            "-> NROS_EXECUTOR_ACTION_CLIENTS")
         if(DEFINED NROS_ENTITY_COUNT_PUBLISHER AND
            NROS_ENTITY_COUNT_PUBLISHER GREATER 0)
             message(STATUS
@@ -402,6 +412,7 @@ if(CMAKE_SCRIPT_MODE_FILE AND
         NROS_ENTITY_INVENTORY_COMPONENT_COUNT
         NROS_ENTITY_INVENTORY_ENTITY_TOTAL
         NROS_DERIVED_EXECUTOR_MAX_CBS
+        NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
         NROS_ENTITY_COUNT_PUBLISHER
         NROS_ENTITY_COUNT_SUBSCRIPTION
         NROS_ENTITY_COUNT_TIMER

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -239,7 +239,12 @@ mod tests {
         let k = inv.derive().knobs().expect("derived").clone();
         assert_eq!(k.entity_total, 3);
         assert_eq!(k.max_cbs, 2, "the publisher claims no slot");
-        assert_eq!(inv.to_env(), "NROS_EXECUTOR_MAX_CBS=2\n");
+        // Issue 0900 — `NROS_EXECUTOR_ACTION_CLIENTS` rides the same carrier,
+        // clamped by build.rs to the MAX_CBS emitted beside it.
+        assert_eq!(
+            inv.to_env(),
+            "NROS_EXECUTOR_MAX_CBS=2\nNROS_EXECUTOR_ACTION_CLIENTS=0\n"
+        );
     }
 
     /// A row with no `entities` KEY is the pre-W9 shape every existing

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -412,6 +412,21 @@ pub struct EntityInventory {
 pub struct DerivedEntityKnobs {
     /// `NROS_EXECUTOR_MAX_CBS` -- the total callback-entry slot demand.
     pub max_cbs: usize,
+    /// `NROS_EXECUTOR_ACTION_CLIENTS` (issue 0900) -- how many of those slots
+    /// the arena must budget at the HEAVY entry size rather than the pub/sub
+    /// one. At the defaults that is 18,048 bytes against 3,584, and the arena
+    /// is inline on the TASK STACK, so budgeting every slot heavy is 74,240
+    /// bytes where a talker needs 16,384.
+    ///
+    /// Counts action SERVERS as well as clients, though the knob is named for
+    /// clients. The knob's real meaning is "slots budgeted at the worst case",
+    /// and `build.rs` picked the action client as that worst case when nothing
+    /// else was measured. It is not the worst case: the arena demonstrably
+    /// stores `ActionServerArenaEntry`, so an action-server image occupies
+    /// heavy slots too, and counting only clients would advise it into exactly
+    /// the `BufferTooSmall` this derivation exists to avoid. Counting both is
+    /// conservative in the safe direction.
+    pub heavy_slots: usize,
     /// Every declared entity, slot-claiming or not. NOT the knob: kept because
     /// it is the number a human counts, and because the gap between the two is
     /// the finding.
@@ -572,6 +587,7 @@ impl EntityInventory {
         }
         let mut per_component = Vec::new();
         let mut max_cbs = 0usize;
+        let mut heavy_slots = 0usize;
         let mut entity_total = 0usize;
         for c in self.components() {
             let mut slots = 0usize;
@@ -579,6 +595,9 @@ impl EntityInventory {
             for e in c.declaration.entities() {
                 *per_kind.entry(e.kind.tag()).or_insert(0) += 1;
                 slots += e.kind.callback_slots();
+                if matches!(e.kind, EntityKind::ActionClient | EntityKind::ActionServer) {
+                    heavy_slots += e.kind.callback_slots();
+                }
                 count += 1;
             }
             max_cbs += slots;
@@ -588,6 +607,7 @@ impl EntityInventory {
 
         Derivation::Derived(Box::new(DerivedEntityKnobs {
             max_cbs,
+            heavy_slots,
             entity_total,
             per_kind,
             per_component,
@@ -849,6 +869,18 @@ impl EntityInventory {
                     "set(NROS_DERIVED_EXECUTOR_MAX_CBS {})\n",
                     k.max_cbs
                 ));
+                // Issue 0900 -- of those slots, how many the arena must budget
+                // at the ACTION entry size (18,048 B at the defaults) rather
+                // than the pub/sub one (3,584 B). A talker derives 0 here and
+                // stops carrying 74,240 bytes of task stack for an entity it
+                // never constructs.
+                s.push_str(
+                    "# Action clients AND action servers: the knob is named for\n                     # clients because build.rs picked one as the worst case, but\n                     # the arena stores ActionServerArenaEntry too (issue 0900).\n",
+                );
+                s.push_str(&format!(
+                    "set(NROS_DERIVED_EXECUTOR_ACTION_CLIENTS {})\n",
+                    k.heavy_slots
+                ));
             }
         }
 
@@ -886,7 +918,14 @@ impl EntityInventory {
     /// rung 4 of the precedence ladder and the correct outcome for "no answer".
     pub fn to_env(&self) -> String {
         match self.derive() {
-            Derivation::Derived(k) => format!("NROS_EXECUTOR_MAX_CBS={}\n", k.max_cbs),
+            // Issue 0900 -- both, or neither. `NROS_EXECUTOR_ACTION_CLIENTS`
+            // is only meaningful against the `MAX_CBS` it is clamped to, and
+            // emitting one without the other would size an arena against a
+            // slot count from a different rung.
+            Derivation::Derived(k) => format!(
+                "NROS_EXECUTOR_MAX_CBS={}\nNROS_EXECUTOR_ACTION_CLIENTS={}\n",
+                k.max_cbs, k.heavy_slots
+            ),
             Derivation::Refused { .. } => String::new(),
         }
     }
@@ -1001,6 +1040,46 @@ mod tests {
         assert_eq!(inv.to_env(), "");
     }
 
+    /// Issue 0900 — the heavy-slot count is what stops a talker carrying an
+    /// arena sized for an entity it does not have.
+    ///
+    /// Asserted through `to_env`, not just the struct field: the env projection
+    /// is the only thing a build ever reads, and the derivation was correct for
+    /// two phases while nothing lowered it.
+    #[test]
+    fn only_action_entities_claim_a_heavy_arena_slot() {
+        // A talker: publisher (no slot at all) + timer. Nothing heavy.
+        let mut talker = EntityInventory::new("test");
+        talker.insert(stated("a", "talker", &["publisher", "timer"]));
+        assert_eq!(
+            talker.to_env(),
+            "NROS_EXECUTOR_MAX_CBS=1\nNROS_EXECUTOR_ACTION_CLIENTS=0\n",
+            "a pub/sub-only image must budget no slot at the action size"
+        );
+
+        // An action CLIENT is heavy.
+        let mut client = EntityInventory::new("test");
+        client.insert(stated("a", "client", &["timer", "action_client"]));
+        assert_eq!(client.derive().knobs().expect("derived").heavy_slots, 1);
+
+        // So is an action SERVER, though the knob is named for clients: the
+        // arena stores `ActionServerArenaEntry`, so advising a server image to
+        // zero the knob would trade the saving for `BufferTooSmall`.
+        let mut server = EntityInventory::new("test");
+        server.insert(stated("a", "server", &["action_server"]));
+        assert_eq!(
+            server.derive().knobs().expect("derived").heavy_slots,
+            1,
+            "an action server occupies a heavy slot too"
+        );
+
+        // A service client/server is NOT heavy — the nearest miss, and the one
+        // a name-based rule would get wrong.
+        let mut svc = EntityInventory::new("test");
+        svc.insert(stated("a", "svc", &["service_client", "service_server"]));
+        assert_eq!(svc.derive().knobs().expect("derived").heavy_slots, 0);
+    }
+
     /// "Creates nothing" and "did not say" are different claims, and only the
     /// first one lets the image derive.
     #[test]
@@ -1102,7 +1181,12 @@ mod tests {
     fn the_env_transport_is_empty_on_a_refusal() {
         let mut inv = EntityInventory::new("test");
         inv.insert(stated("a", "one", &["sub", "timer", "service_server"]));
-        assert_eq!(inv.to_env(), "NROS_EXECUTOR_MAX_CBS=3\n");
+        // Issue 0900 — both knobs travel together; none of these three kinds
+        // is heavy, so the arena budgets no slot at the action size.
+        assert_eq!(
+            inv.to_env(),
+            "NROS_EXECUTOR_MAX_CBS=3\nNROS_EXECUTOR_ACTION_CLIENTS=0\n"
+        );
         inv.insert(ComponentEntities {
             pkg: "b".into(),
             component: "two".into(),

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1056,13 +1056,22 @@ config NROS_RMW_SUBSCRIBER_SLOTS
       bytes. Read by nros-rmw-cffi build.rs.
 
 config NROS_EXECUTOR_ACTION_CLIENTS
-    int "Callback slots to budget at ActionClient size"
-    default 4
+    int "Callback slots to budget at ActionClient size (-1 = derive)"
+    default -1
     help
       How many of NROS_EXECUTOR_MAX_CBS slots the arena derivation budgets at
       ACTION CLIENT size (~18 KiB each) rather than pub/sub size (~3.5 KiB).
-      Defaults to MAX_CBS, which reproduces the historical arithmetic exactly,
-      so leaving it alone changes nothing.
+
+      -1 DERIVES it from the image's entity inventory, the same way MAX_CBS is
+      derived: the count is the action clients AND action servers the image's
+      components declare. An image whose inventory refuses -- any component
+      that declared no ENTITIES -- falls through to MAX_CBS, which reproduces
+      the historical arithmetic exactly, so nothing built before this moves.
+
+      Action SERVERS count too, though the option is named for clients: the
+      arena stores ActionServerArenaEntry, so a server image occupies the same
+      heavy slots and zeroing this on one would trade the saving for a runtime
+      BufferTooSmall.
 
       Set it to 0 on an image with no action client: at the defaults that takes
       the arena from 74240 bytes to 16384. The arena is INLINE ON THE TASK

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -251,7 +251,8 @@ function(_nros_load_derived_entity_inventory)
         NROS_ENTITY_INVENTORY_STATUS
         NROS_ENTITY_INVENTORY_REASON
         NROS_ENTITY_INVENTORY_ENTITY_TOTAL
-        NROS_DERIVED_EXECUTOR_MAX_CBS)
+        NROS_DERIVED_EXECUTOR_MAX_CBS
+        NROS_DERIVED_EXECUTOR_ACTION_CLIENTS)
         if(DEFINED ${_v})
             set(${_v} "${${_v}}" PARENT_SCOPE)
         endif()
@@ -504,6 +505,13 @@ function(nros_resolve_knobs)
     _nros_resolve_derivable_knob(NROS_EXECUTOR_MAX_CBS
         "${CONFIG_NROS_EXECUTOR_MAX_CBS}" NROS_DERIVED_EXECUTOR_MAX_CBS
         "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
+    # Issue 0900 -- the same inventory answers how many of those slots must be
+    # budgeted at the ACTION entry size. Derivable for the same reason and with
+    # the same fallback: an image whose inventory refuses gets MAX_CBS, which is
+    # the historical arithmetic, so no existing image moves.
+    _nros_resolve_derivable_knob(NROS_EXECUTOR_ACTION_CLIENTS
+        "${CONFIG_NROS_EXECUTOR_ACTION_CLIENTS}" NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
+        "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
     # Issue 0316's fix listed ONE of nros-node's six build.rs knobs; the other
     # five stayed unreachable on Zephyr (the curated cargo environment drops
     # any knob not resolved here, and shell exports do not survive it), so a
@@ -523,11 +531,6 @@ function(nros_resolve_knobs)
     _nros_resolve_derivable_knob(NROS_SUBSCRIPTION_BUFFER_SIZE
         "${CONFIG_NROS_SUBSCRIPTION_BUFFER_SIZE}"
         NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE)
-    # issue 0900 — how many slots the arena derivation charges at ActionClient
-    # size. Read by nros-node/build.rs through the derived CONFIG_<name> lookup,
-    # like its siblings above.
-    _nros_resolve_knob(NROS_EXECUTOR_ACTION_CLIENTS
-        "${CONFIG_NROS_EXECUTOR_ACTION_CLIENTS}")
     _nros_resolve_knob(NROS_EXECUTOR_MAX_SC "${CONFIG_NROS_EXECUTOR_MAX_SC}")
     _nros_resolve_knob(NROS_EXECUTOR_MAX_NODES "${CONFIG_NROS_EXECUTOR_MAX_NODES}")
     # issue 0790 — shutdown-hook slots per phase. Read by nros-node/build.rs


### PR DESCRIPTION
`NROS_EXECUTOR_ACTION_CLIENTS` has existed since W2 and **nothing set it**, so
every image budgeted all four slots at the ActionClient size: 74,240 bytes of
arena, *inline on the task stack*, on a talker that owns no action client.

It now derives.

## The issue's "not expressible" was true of the wrong thing

0900 concluded the count could not be derived — correctly, about
`SourceMetadata`'s model wiring, which `describes_wiring()` reports absent for
every resolved model in the tree (issue 0973).

It is not true of the **entity inventory**, composed from the
`nano_ros_node_register()` calls an image actually makes, which already carries
`EntityKind::ActionClient` in `per_kind`. The number was one field away; what was
missing was lowering it.

## Changes

- `DerivedEntityKnobs::heavy_slots`
- both projections carry it — `to_env()` (cargo) and
  `set(NROS_DERIVED_EXECUTOR_ACTION_CLIENTS …)` (cmake), emitted **beside**
  `MAX_CBS` and never without it, since build.rs clamps one to the other
- Zephyr Kconfig default → the `-1` derive sentinel; the knob moves to
  `_nros_resolve_derivable_knob`, matching what phase-403 W9 did for `MAX_CBS`

**Action servers count too**, though the knob is named for clients. Its real
meaning is "slots budgeted at the worst case", and build.rs picked the client as
that worst case without measuring. The arena demonstrably stores
`ActionServerArenaEntry`, so zeroing the knob on a server image would trade the
saving for a runtime `BufferTooSmall`. Counting both errs safely.

## Nothing existing moves

An image whose inventory **refuses** — any component that declared no
`ENTITIES`, i.e. every image built before phase-403 W9 — falls through to
`MAX_CBS`, which is the historical arithmetic exactly.

## Why here and not at the entry — the thin-wrapper principle

C/C++ inherit this for free. `EXECUTOR_OPAQUE_U64S` is generated per build from
`ExecutorSizing::DEFAULT`, and `nros_generated.h` declares `uint64_t
_opaque[EXECUTOR_OPAQUE_U64S]`. The arena is **83%** of it:

| `action_clients` | arena | C `_opaque` |
| ---: | ---: | ---: |
| 4 (today) | 74,240 B | 89,680 B |
| 0 (a talker) | 16,384 B | **31,824 B** |

No C-side change, no second mechanism. Sizing the arena from `ENTITY_BOUNDS` at
the entry instead would have been Rust-only and would not have shrunk the C
struct at all — a thick wrapper for less saving.

## Also removed

A **duplicate** `_nros_resolve_knob(NROS_EXECUTOR_ACTION_CLIENTS)` sitting beside
the new derivable one. Two resolvers for one knob, last-wins, is how a derivation
gets silently overridden by the rung it was meant to replace.

## Verification

`only_action_entities_claim_a_heavy_arena_slot` covers a talker (0), an action
client (1), an action server (1 — the case a name-based rule gets wrong) and a
service client/server pair (0 — the nearest miss). Asserted through `to_env`: the
derivation was already correct for two phases while nothing lowered it, so the
projection is the part worth pinning.

- `cargo test -p nros-cli-core`: green
- `just check kconfig-knob-forwarding`: 28 knobs, each read by the Rust lane
- `just check fast`: 166 gates OK

## Not claimed

A built image's measured delta. That needs a fixture rebuild, and this repo's
rule is that no wave claims a saving it did not measure — the table above is
build.rs's formula, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa