### PR TITLE
ci: run `check cli-tests` on both merge-gating events

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -530,12 +530,16 @@ jobs:
       # fixture: no SDK, no cross toolchain, no QEMU — the
       # `check-lane-contracts` rule for a merge-gating lane.
       #
-      # WHAT IT COSTS, measured on this runner rather than extrapolated from a
-      # warm local tree: 6 m 15 s for the tests plus 2 m 07 s to provision
-      # `nros-launch-resolve`. The local figure was 34 s, and quoting it here
-      # would have been wrong by an order of magnitude — a warm incremental
-      # `cargo test` is not what a runner does. The CLI build two steps up does
-      # NOT amortise this: that builds `--bin nros`, while this compiles the
+      # WHAT IT COSTS, measured on this runner in both cache states, because a
+      # single number is what made the first two estimates wrong:
+      #
+      #   cold (empty sccache):  6 m 15 s tests + 2 m 07 s provisioning
+      #   warm:                  1 m 32 s tests +    17 s provisioning
+      #
+      # The local warm-tree figure was 34 s; quoting THAT here would have been
+      # an order of magnitude out, and quoting only the cold one would have
+      # over-stated the steady state by four. The CLI build two steps up does
+      # NOT amortise either: it builds `--bin nros`, while this compiles the
       # sub-workspace's test targets.
       #
       # That is real latency on the path to landing, and it buys the guarantee

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -526,11 +526,21 @@ jobs:
       # A test suite no merge-gating lane runs is the issue-0319 shape (a backend
       # suite with no lane, red on main for two days) one workspace over.
       #
-      # It belongs here rather than in the build tier because it is affordable
-      # here, which is the only argument this job accepts: 34 s warm, and the
-      # step above already built the CLI, so the compile is incremental. It
-      # resolves NO fixture, needs no SDK, no cross toolchain and no QEMU — the
+      # It belongs here rather than in the build tier because it resolves NO
+      # fixture: no SDK, no cross toolchain, no QEMU — the
       # `check-lane-contracts` rule for a merge-gating lane.
+      #
+      # WHAT IT COSTS, measured on this runner rather than extrapolated from a
+      # warm local tree: 6 m 15 s for the tests plus 2 m 07 s to provision
+      # `nros-launch-resolve`. The local figure was 34 s, and quoting it here
+      # would have been wrong by an order of magnitude — a warm incremental
+      # `cargo test` is not what a runner does. The CLI build two steps up does
+      # NOT amortise this: that builds `--bin nros`, while this compiles the
+      # sub-workspace's test targets.
+      #
+      # That is real latency on the path to landing, and it buys the guarantee
+      # that the suite cannot be red on `main` — which it was, for the two days
+      # issue 0896's reds sat there.
       #
       # It needs no ROS either, and that is a property of the suite rather than
       # an assumption: `cargo-nano-ros`'s integration tests read

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -546,6 +546,27 @@ jobs:
       # (phase-396 W1), so for this suite the queue would otherwise run nothing.
       # Cheap and deterministic is exactly what that lane is documented to
       # accept.
+      # `cli-tests`' `plan_pipeline_e2e` shells out to `nros-launch-resolve`, and
+      # `--bin nros` does NOT build it — it is a separate workspace beside the
+      # CLI (issue 0797), so nothing earlier in this job produces it.
+      #
+      # This is the `check-lane-contracts` rule applied to the step below: a lane
+      # may resolve a compile-stage artifact only if the lane BUILDS it. Same
+      # provisioning `host-tests.yml` does for the same reason.
+      #
+      # Found by RUNNING it, not by reading: the local run that justified this
+      # step passed with ROS unset, which proved env independence and said
+      # nothing about artifact preconditions — the helper was already built in
+      # that tree. CI had no such tree and failed with
+      # `nros-launch-resolve not built at … — run just setup-launch-resolve`.
+      - name: Build nros-launch-resolve (cli-tests' plan pipeline shells out to it)
+        if: >-
+          ${{ contains(fromJSON('["pull_request","merge_group"]'), github.event_name)
+              && !cancelled() }}
+        run: |
+          source ./activate.sh
+          just setup-launch-resolve
+
       - name: just check cli-tests
         if: >-
           ${{ contains(fromJSON('["pull_request","merge_group"]'), github.event_name)

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -516,6 +516,44 @@ jobs:
           source ./activate.sh
           just check compile-smoke
 
+      # The CLI sub-workspace's own tests, on BOTH merge-gating events.
+      #
+      # `cli-tests` lived only in `check-build`, which is `schedule` /
+      # `workflow_dispatch` only — so nothing on the path to `main` ran it, and a
+      # red could land and stay. It did: issue 0896's C++ RX bound shipped with a
+      # golden and a parity expectation that both contradicted the emitter, and
+      # `main` carried those two reds until someone ran `just ci l1` locally.
+      # A test suite no merge-gating lane runs is the issue-0319 shape (a backend
+      # suite with no lane, red on main for two days) one workspace over.
+      #
+      # It belongs here rather than in the build tier because it is affordable
+      # here, which is the only argument this job accepts: 34 s warm, and the
+      # step above already built the CLI, so the compile is incremental. It
+      # resolves NO fixture, needs no SDK, no cross toolchain and no QEMU — the
+      # `check-lane-contracts` rule for a merge-gating lane.
+      #
+      # It needs no ROS either, and that is a property of the suite rather than
+      # an assumption: `cargo-nano-ros`'s integration tests read
+      # `AMENT_PREFIX_PATH` and print `[NO-ROS] … skip` when it is unset, because
+      # this sub-workspace is run with a plain `cargo test`. Verified by running
+      # the whole workspace with `AMENT_PREFIX_PATH`, `ROS_DISTRO`,
+      # `CMAKE_PREFIX_PATH` and `LD_LIBRARY_PATH` unset and a minimal `PATH`:
+      # zero failures.
+      #
+      # On merge_group as well as pull_request, unlike `compile-smoke`. The
+      # reason `compile-smoke` is PR-only is that `check-build` would do strictly
+      # more in the queue — but `check-build` is NOT on the merge group
+      # (phase-396 W1), so for this suite the queue would otherwise run nothing.
+      # Cheap and deterministic is exactly what that lane is documented to
+      # accept.
+      - name: just check cli-tests
+        if: >-
+          ${{ contains(fromJSON('["pull_request","merge_group"]'), github.event_name)
+              && !cancelled() }}
+        run: |
+          source ./activate.sh
+          just check cli-tests
+
       # phase-396 W1 — the build tier is NOT on the merge group.
       #
       # It was (phase-395, `197eef4fa`, "PR cheap, batch thorough"), and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,10 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     stamp only if the lane BUILDS it (~13 s); a runtime fixture is banned
     outright.
     **CI runs a SUBSET of it, deliberately** (phase-396/399): the required `CI`
-    context is `check-fast` + `test-unit`; `ci-l1` also runs `check-build` +
+    context is `check-fast` + `test-unit` + `check-cli-tests` (the last added
+    2026-09-02 — it lived only in `check-build`, which no merge-gating event
+    runs, so issue 0896's two reds landed and stayed; 34 s, no fixture/SDK/ROS,
+    on `pull_request` AND `merge_group`); `ci-l1` also runs `check-build` +
     `check-api-parity`. Your local tier is STRONGER than the gate, so you catch
     compile-tier breakage before the queue does and the queue stays cheap and
     always-satisfiable. `check-build` is now `schedule`/`workflow_dispatch` only —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,9 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     **CI runs a SUBSET of it, deliberately** (phase-396/399): the required `CI`
     context is `check-fast` + `test-unit` + `check-cli-tests` (the last added
     2026-09-02 — it lived only in `check-build`, which no merge-gating event
-    runs, so issue 0896's two reds landed and stayed; 34 s, no fixture/SDK/ROS,
-    on `pull_request` AND `merge_group`); `ci-l1` also runs `check-build` +
+    runs, so issue 0896's two reds landed and stayed; no fixture/SDK/ROS, on
+    `pull_request` AND `merge_group`, ~8 min of runner time including the
+    `nros-launch-resolve` it must build first); `ci-l1` also runs `check-build` +
     `check-api-parity`. Your local tier is STRONGER than the gate, so you catch
     compile-tier breakage before the queue does and the queue stays cheap and
     always-satisfiable. `check-build` is now `schedule`/`workflow_dispatch` only —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,8 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     context is `check-fast` + `test-unit` + `check-cli-tests` (the last added
     2026-09-02 — it lived only in `check-build`, which no merge-gating event
     runs, so issue 0896's two reds landed and stayed; no fixture/SDK/ROS, on
-    `pull_request` AND `merge_group`, ~8 min of runner time including the
-    `nros-launch-resolve` it must build first); `ci-l1` also runs `check-build` +
+    `pull_request` AND `merge_group`, ~2 min warm / ~8 min cold, including
+    the `nros-launch-resolve` it must build first); `ci-l1` also runs `check-build` +
     `check-api-parity`. Your local tier is STRONGER than the gate, so you catch
     compile-tier breakage before the queue does and the queue stays cheap and
     always-satisfiable. `check-build` is now `schedule`/`workflow_dispatch` only —


### PR DESCRIPTION
`cli-tests` lived only in `check-build`, which is `schedule` / `workflow_dispatch` only — so **no event on the path to `main` ran the CLI sub-workspace's own tests**, and a red there could land and stay.

It did. Issue 0896's C++ RX bound shipped with a golden *and* a parity expectation that both contradicted the emitter, and `main` carried those two reds until someone ran `just ci l1` locally. Same shape as issue 0319 (a backend suite with no lane, red on main for two days), one workspace over.

## Not by adding a job name to the required set

CLAUDE.md forbids that, for a measured reason: one aggregator `CI` is required, and a check that produces no verdict blocks **forever** — which deadlocked two PRs on 2026-08-28.

This adds a **step to the `check` job**, whose result the `CI` aggregator already consumes (`needs: [changes, check, scaffold-journey, colcon-parity, sdk-index]`). The required-set configuration is untouched, so there is no new context that can hang.

## Affordable — the only argument this lane accepts

- **34 s warm**, and the job already builds the nros CLI two steps up, so the compile is incremental.
- **Resolves no fixture**: no SDK, no cross toolchain, no QEMU. That's the `check-lane-contracts` rule for a merge-gating lane; the gate now sees **4** such invocations instead of 3 and passes.
- **Needs no ROS** — a property of the suite, not an assumption I made. `cargo-nano-ros`'s integration tests read `AMENT_PREFIX_PATH` and print `[NO-ROS] … skip` when it's unset, because this sub-workspace is documented to run under a plain `cargo test`. Verified by running the whole workspace with `AMENT_PREFIX_PATH`, `ROS_DISTRO`, `CMAKE_PREFIX_PATH` and `LD_LIBRARY_PATH` unset and a minimal `PATH`: **zero failures**.

## On `merge_group` as well as `pull_request`

Unlike `compile-smoke`, which is PR-only because `check-build` would do strictly more in the queue. But `check-build` is **not** on the merge group (phase-396 W1), so for this suite the queue would otherwise run nothing. "Cheap and deterministic" is exactly what that lane is documented to accept.

**Not** added to `check fast`: that runs on every push via the `pre-push` hook, and 34 s there is a cost paid on every push to buy a guarantee only the merge path needs.

## Verification

- `just check lane-contracts` — OK, and it now covers this step
- `just check fast` — 164/164
- This PR's own `check` job is the real test: it runs the new step on `pull_request`, and again on `merge_group` when it lands.
