### PR TITLE
fix(activate): prepend the in-tree CLI dir even before the binary exists

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -232,8 +232,29 @@ esac
 # trees. This is the sole source: the pre-218 `~/.nros/bin/nros` curl
 # install (`scripts/install-nros.sh`) is retired, and the standalone
 # `NEWSLabNTU/nros-cli` repo was merged in-tree at `packages/cli/`.
+# Prepend UNCONDITIONALLY, whether or not the binary is there yet.
+#
+# This used to be `if [ -x <the binary> ]`, which loses the race a CI job runs
+# every time: `source ./activate.sh` happens BEFORE `just setup <scope>` builds
+# the CLI, so on a fresh checkout the directory was empty, the prepend was
+# skipped, and PATH stayed fixed for the rest of the step. `setup-cli` then
+# built the CLI into a directory that was not on PATH, and `nros` kept
+# resolving to whatever else the host had — on the self-hosted runner, a
+# DIFFERENT checkout at /mnt/evo/aeon/nano-ros. That CLI was stale against its
+# own sources, so `just setup tier2` died with
+#
+#     Error: in-tree nros CLI is STALE — its sources changed since it was built
+#
+# blaming this checkout for another one's state. `build-wide` failed this way on
+# every run once the runner was provisioned.
+#
+# Prepending a not-yet-populated directory is harmless — nothing resolves from
+# it until the build lands — and it makes "this checkout's CLI wins" true
+# regardless of the order the two steps run in. The hint below still fires
+# correctly: `command -v nros` cannot find anything in an empty directory.
+export PATH="$_nros_root/packages/cli/target/release:$PATH"
 if [ -x "$_nros_root/packages/cli/target/release/nros" ]; then
-    export PATH="$_nros_root/packages/cli/target/release:$PATH"
+    :
 elif [ -z "${NROS_QUIET_ACTIVATE:-}" ] && ! command -v nros >/dev/null 2>&1; then
     # Phase 222.F.1 — first-run hint. The checkout has no built CLI AND
     # `nros` is not resolvable from any other PATH entry (e.g. ~/.nros/bin).


### PR DESCRIPTION
`build-wide` has failed on **every run** since the runner was provisioned, now at `just setup tier2`:

```
[setup-cli] WARNING: `which nros` -> /mnt/evo/aeon/nano-ros/packages/cli/target/release/nros
[setup-cli]   This shadows the in-tree CLI we just built (…/actions-runner/_work/nano-ros/…)
Error: in-tree nros CLI is STALE — its sources changed since it was built
```

The message blames this checkout for a **different checkout's** state. What actually happens is an ordering race CI runs every time and a developer never does:

```bash
source ./activate.sh     # fresh checkout: no CLI yet
just setup tier2         # `setup-cli` builds it — too late
```

The prepend was guarded by `if [ -x <the binary> ]`. On a fresh checkout that directory is empty, so `activate.sh` skipped it and PATH stayed fixed for the rest of the step. `setup-cli` then built the CLI into a directory **not on PATH**, and `nros` kept resolving to whatever else the host had — on the self-hosted runner, another checkout at `/mnt/evo/aeon/nano-ros`, whose CLI was stale against *its* sources.

**A developer never sees this** because their checkout already has a built CLI, so the guard is true and the prepend happens. The guard only fails in exactly the situation CI is always in.

Prepending a not-yet-populated directory is harmless — nothing resolves from it until the build lands — and it makes "this checkout's CLI wins" true regardless of the order the two steps run in.

## Verified by reproducing it

Fresh worktree, no built CLI, a foreign `nros` first on PATH, in CI's order (source, **then** build):

| | `command -v nros` |
| --- | --- |
| before | `…/scratchpad/foreign/nros` |
| after | `…/fresh/packages/cli/target/release/nros` |

The first-run hint is unchanged: it still fires when no CLI is resolvable anywhere (`command -v` finds nothing in an empty directory) and stays quiet when one exists — both checked.

`just check fast` 163 gates, 4 host-precondition skips.

> Note: the earlier `runner-doctor` failure on this lane **is resolved** — the runner now has the Zephyr SDK and passes label verification. This is the next blocker behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2zFRQS5rDsPBNWH85JjJB