### PR TITLE
feat(phase-392 W4): a serial image without the network stack — 38,334 B, measured

### DIFF
--- a/cmake/zephyr/mps2-an385-serial.conf
+++ b/cmake/zephyr/mps2-an385-serial.conf
@@ -1,0 +1,45 @@
+# mps2/an385, zenoh over SERIAL. phase-392 W4.
+#
+# A DELTA ON `mps2-an385.conf`, NOT A REPLACEMENT FOR IT. A serial fixture row
+# lists BOTH, this one last:
+#
+#     conf_files = ["prj.conf", "prj-zenoh.conf",
+#                   "cmake/zephyr/mps2-an385.conf",
+#                   "cmake/zephyr/mps2-an385-serial.conf"]
+#
+# The first draft of this file was a replacement, and the measurement it
+# produced was worthless: omitting the board fragment also dropped
+# `MAIN_STACK_SIZE` (131072 -> 16384), `HW_STACK_PROTECTION`, `MPU_STACK_GUARD`
+# and the POSIX settings, so the image shrank 613,034 bytes and only ~29,000 of
+# that was networking. A "saving" measured against a differently-configured
+# image is not a saving. Keeping this a delta is what makes the number
+# attributable.
+#
+# WHY A BOARD FRAGMENT AND NOT A LEAF CONF
+#
+# W4's triage said "the fix is conf-level: a serial image should not enable
+# NETWORKING/NET_TCP/NET_PKT_*/NET_BUF_*". True, but it cannot be written in the
+# leaf: Zephyr merges LAST-WINS and `mps2-an385.conf` is appended after every
+# leaf conf, setting `CONFIG_NET_NATIVE=y` / `NET_DRIVERS=y` /
+# `NET_CONFIG_SETTINGS=y` unconditionally. A `CONFIG_NETWORKING=n` in the leaf
+# is DEAD and looks like it should work — issue 0876 exactly. Only a fragment
+# merged after the board's can turn it off.
+
+# The transport. `NROS_ZENOH_LINK_SERIAL` has no networking dependency, unlike
+# `NROS_RMW_XRCE`'s `depends on NET_SOCKETS`.
+CONFIG_NROS_TRANSPORT_SERIAL=y
+
+# The wave's whole point. Explicit `n`, not omission: the leaf sets
+# `CONFIG_NET_TCP=y`, which selects NETWORKING, so leaving this out left the
+# probe build with `CONFIG_NETWORKING=y` and every native-IP symbol behind it.
+# Omission only works when nothing else asserts the value.
+CONFIG_NETWORKING=n
+
+# What the net stack was providing IMPLICITLY, now named. Both were found by
+# LINKING, not by reading: the image COMPILED clean — settling W4's open caveat
+# that zenoh-pico's unguarded `#include <zephyr/net/net_if.h>` would still build
+# with networking off, which it does — and then failed at link on `ring_buf_get`
+# (zenoh-pico `src/system/zephyr/network.c:941`, the serial link) and
+# `z_impl_sys_rand_get` (`zpico.c`).
+CONFIG_RING_BUFFER=y
+CONFIG_TEST_RANDOM_GENERATOR=y

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -609,6 +609,52 @@ hold — but it is not proven here, and if it does not hold the remedy is guardi
 that include in zenoh-pico, which is VENDORED and must be reported rather than
 patched in place.
 
+### MEASURED 2026-09-02 — 38,334 B on mps2/an385, and the caveat is settled
+
+Two images built from one tree, differing ONLY in networking:
+
+| | `.bss`+`.data` | FLASH |
+| --- | ---: | ---: |
+| zenoh over TCP (`mps2-an385.conf`) | 1,212,854 B | 362,956 B |
+| zenoh over serial (`+ mps2-an385-serial.conf`) | 1,174,520 B | 284,260 B |
+| **saving** | **38,334 B** | 78,696 B |
+
+103 symbols disappear (38,917 B); the serial path adds 1,080 B back
+(`_z_serial_rx_storage` and its ring). The config diff outside networking is two
+lines, `CONFIG_PIPES` and `CONFIG_POSIX_HOST_NAME_MAX`, both selected BY
+networking.
+
+**Larger than this wave's own estimates** — 27,760 B reported for mr_canhubk3,
+22,580 B cross-checked here — because those counted symbols matching `net_*`
+patterns. The stack also drags in `work_q_stack` (4,160), `rx_stack` (1,600),
+`mgmt_stack` (896) and `contexts` (2,752), which no `net_` grep finds.
+
+**The open caveat is settled, favourably.** zenoh-pico's unguarded
+`#include <zephyr/net/net_if.h>` COMPILES cleanly with `CONFIG_NETWORKING=n` —
+the headers are declaration-only, as predicted. **No vendored change is needed.**
+What the image does need is two symbols the net stack was supplying implicitly,
+found by LINKING rather than reading: `ring_buf_get` (zenoh-pico
+`src/system/zephyr/network.c:941`) and `z_impl_sys_rand_get` (`zpico.c`), so the
+fragment names `CONFIG_RING_BUFFER` and `CONFIG_TEST_RANDOM_GENERATOR`.
+
+**The fix is a BOARD fragment, not a leaf conf — the triage above is wrong on
+that point.** Zephyr merges last-wins and `mps2-an385.conf` is appended after
+every leaf conf while setting `CONFIG_NET_NATIVE=y` / `NET_DRIVERS=y` /
+`NET_CONFIG_SETTINGS=y` unconditionally, so a `CONFIG_NETWORKING=n` written in
+the leaf is DEAD and looks like it should work. Issue 0876 exactly, one wave
+over. `cmake/zephyr/mps2-an385-serial.conf` is a DELTA listed after the board
+fragment, never in place of it.
+
+**One wrong measurement, recorded so it is not repeated.** The first version of
+that fragment REPLACED the board conf instead of delta-ing it, which also
+dropped `MAIN_STACK_SIZE` (131072 -> 16384), `HW_STACK_PROTECTION` and
+`MPU_STACK_GUARD`. It reported a 613,034-byte "saving" of which ~29,000 was
+networking. A saving measured against a differently-configured image is not a
+saving.
+
+**Still not measured:** the mr_canhubk3 board itself, for the reason below. The
+38,334 B is mps2/an385 with a C talker, and it is this wave's number.
+
 **NOT MEASURED, and deliberately not guessed.** The mr_canhubk3/s32k344 board is
 not in this tree — no board directory, no conf, no `build-board/` — so its image
 cannot be built or measured here. `scripts/nros-mem-report.py` and


### PR DESCRIPTION
W4 triaged this in August and could not measure it — the mr_canhubk3 board it
was reported on is not in this tree. It **is** measurable on mps2/an385, and the
number is larger than either estimate.

## Measured

Two images from one tree, differing only in networking:

| | `.bss`+`.data` | FLASH |
| --- | ---: | ---: |
| zenoh over TCP | 1,212,854 B | 362,956 B |
| zenoh over serial | 1,174,520 B | 284,260 B |
| **saving** | **38,334 B** | 78,696 B |

103 symbols disappear (38,917 B); the serial path adds 1,080 B back
(`_z_serial_rx_storage` + ring). Outside networking the config diff is two lines,
`CONFIG_PIPES` and `CONFIG_POSIX_HOST_NAME_MAX` — both selected *by* networking.

Larger than the 27,760 B reported and 22,580 B cross-checked, because those
counted `net_*`-matching symbols. The stack also drags in `work_q_stack` (4,160),
`rx_stack` (1,600), `mgmt_stack` (896), `contexts` (2,752) — none of which a
`net_` grep finds.

## The open caveat is settled, favourably

zenoh-pico's unguarded `#include <zephyr/net/net_if.h>` **compiles cleanly** with
`CONFIG_NETWORKING=n`. The headers are declaration-only, as W4 predicted but
could not prove. **No vendored change needed.**

What the image *does* need is two symbols the net stack supplied implicitly —
found by **linking**, not reading: `ring_buf_get` (zenoh-pico
`src/system/zephyr/network.c:941`) and `z_impl_sys_rand_get` (`zpico.c`).

## The triage was wrong about where the fix goes

It said "conf-level: a serial image should not enable
NETWORKING/NET_TCP/NET_PKT_*/NET_BUF_*". True — and **undoable in the leaf**.
Zephyr merges last-wins and `mps2-an385.conf` is appended *after* every leaf conf
while setting `CONFIG_NET_NATIVE=y` / `NET_DRIVERS=y` / `NET_CONFIG_SETTINGS=y`
unconditionally. A `CONFIG_NETWORKING=n` in the leaf is **dead**, and looks like
it should work — issue 0876, one wave over.

Hence a board fragment merged after the board's own, and hence an explicit `n`
rather than omission: the leaf's `CONFIG_NET_TCP=y` selects NETWORKING, so
leaving it out left the first probe at `CONFIG_NETWORKING=y`.

## One wrong measurement, recorded rather than discarded

The first version of the fragment **replaced** the board conf instead of
delta-ing it, so it also dropped `MAIN_STACK_SIZE` (131072→16384),
`HW_STACK_PROTECTION` and `MPU_STACK_GUARD` — and reported a 613,034-byte
"saving" of which ~29,000 was networking. A saving measured against a
differently-configured image is not a saving. The delta shape is what makes the
number attributable, and the wrong version is in the file's comment so nobody
repeats it.

## Scope

Adds the fragment and the measurement, **not a lane**. No fixture row — a serial
coordinate deserves its own decision.

`just check fast`: 167 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa