### PR TITLE
fix(#0987): the newest shared candidate, not the first — glob order is by name

### DIFF
--- a/docs/issues/archived/0987-mirror-glob-takes-first-candidate-not-newest.md
+++ b/docs/issues/archived/0987-mirror-glob-takes-first-candidate-not-newest.md
@@ -1,0 +1,109 @@
+---
+id: 987
+title: "The mirror's `cargo/*/` glob took the FIRST candidate, not the newest,
+  so a six-week-old residue target dir shadowed the current one"
+status: resolved
+type: bug
+area: cmake, build
+severity: high
+found: 2026-09-02
+related: [issue-0978, issue-0985, issue-0500, issue-0488, issue-0369]
+---
+
+## Symptom
+
+`just build native` fails linking `action_raw_goal_probe` on issue 0369's size
+anchor:
+
+```
+undefined reference to `nros_config_variant_sz_886681abade04db2'
+```
+
+The direction is the OPPOSITE of issue 0985: the mirrored HEADER is old and
+every archive is current.
+
+## Measured
+
+Two cargo target dirs under one leaf
+(`packages/testing/nros-tests/bins/action-raw-goal-probe/build-zenoh`):
+
+| path | mtime | anchor |
+| --- | --- | --- |
+| `cargo/build/nros-c-generated/…` | **2026-08-19 06:48** | `sz_886681abade04db2` |
+| `cargo/nano-ros_1147c/nros-c-generated/…` | 2026-09-02 14:00 | `sz_9a3e918900c9d46d` |
+
+The mirror wrote the 2026-08-19 one into the include dirs; every archive the
+link consumes was `sz_9a3e918900c9d46d`.
+
+## Root cause: first-match, and glob order is by NAME
+
+```sh
+for cand in "$build_dir"/cargo/*/"$gen_subdir"/nros/"$name"; do
+    [ -f "$cand" ] && { src="$cand"; break; }
+done
+```
+
+`break` takes the first candidate and glob expansion is sorted, so
+`cargo/build/` beats `cargo/nano-ros_1147c/` whatever their dates.
+`cargo/build/` is residue from the pre-phase-340 target-dir layout (issue
+0488's class); nothing rewrites it, so it is frozen and shadowed the live store
+on every run.
+
+Issue 0978's premise — "refreshed by ANY leaf's run, so it is always at least
+as fresh as (1), never staler" — is true of THE shared copy. The glob can match
+several, and the selection rule was never stated: it was inherited from a
+comment reading "one entry in practice", which stopped being true silently,
+because first-match still returns A file and the failure lands a layer down as
+a link error naming a hash and no path.
+
+Same shape as issue 0500, whose remedy is the rule missing here: a store that
+ACCUMULATES needs an ordering. There the SDK prefixes are enumerated
+newest-VERSION-first because `find_package` takes the first that resolves; here
+the residue is not distinguishable by name, so the order is by MTIME.
+
+## Fix
+
+Pick the newest candidate by mtime (`stat -c %Y`, BSD `stat -f %m` second, 0 if
+neither answers so an unreadable mtime cannot win over a known one).
+
+Self-test case `the newest shared copy wins, not the first by name`: two shared
+dirs where the stale one sorts FIRST by name (`aaa_old` before `zzz_new`) and is
+older by mtime — issue 0987's tree in miniature. Proven non-vacuous: under the
+old first-match selection exactly that case fails (`got OLD`) and the other five
+pass, #0978's included.
+
+## Verified, and one attribution corrected
+
+The resolver, run against the real leaf, returns `sz_9a3e918900c9d46d` where it
+used to return `sz_886681abade04db2`.
+
+`action_raw_goal_probe` then linked — but **not because of this fix**, and the
+distinction is worth recording. Its `main.c.o` resolves the header from the
+*nros-cpp* include dir, which in this leaf happened to be current; the nros-c
+copy was still stale. The clean attribution is to force the mirror edge itself:
+
+```
+BEFORE  nros-c/include/nros/nros_config_generated.h   sz_886681abade04db2
+$ rm  <that file>
+$ ninja -C <leaf> nros_c_config_header
+AFTER   nros-c/include/nros/nros_config_generated.h   sz_9a3e918900c9d46d
+```
+
+That is this change, through the real cmake path rather than a direct probe.
+
+## Left open
+
+**An already-drifted `nros-c` copy does not self-heal.** Its mirror is an
+`add_custom_command` whose OUTPUT is compared against
+`$<TARGET_FILE:nros_c-static>`; when the two share a timestamp — which they do,
+being written by the same build — ninja treats the output as up to date and
+skips it, so a copy that is stale for some *other* reason stays stale until the
+crate rebuilds. Issue 0985 gave `nros-cpp` a configure-time heal that now runs
+this same resolver; `nros-c` has no equivalent. Adding one is a behaviour change
+in a second file and belongs in its own change, not here.
+
+## Acceptance
+
+* [x] When the glob matches several candidates the newest wins, with a
+      self-test case that fails under first-match ordering.
+* [x] The mirror edge writes the current header for the leaf that failed.

--- a/scripts/build/mirror-generated-header.sh
+++ b/scripts/build/mirror-generated-header.sh
@@ -44,6 +44,19 @@ if [ "${1:-}" = "--self-test" ]; then
     ok() { printf '  ok   %s\n' "$1"; }
     bad() { printf '  FAIL %s: %s\n' "$1" "$2" >&2; fails=$((fails + 1)); }
 
+    # Two shared candidates: `aaa_old` sorts BEFORE `zzz_new` by name and is
+    # OLDER by mtime, so first-match picks the stale one and newest-match picks
+    # the current one. That is issue 0987's tree in miniature.
+    _st_stage_two() {
+        d="$tmp/two$RANDOM$RANDOM"
+        mkdir -p "$d/cargo/aaa_old/gen/nros" "$d/cargo/zzz_new/gen/nros" "$d/leaf"
+        printf 'OLD\n' > "$d/cargo/aaa_old/gen/nros/h.h"
+        printf 'NEW\n' > "$d/cargo/zzz_new/gen/nros/h.h"
+        touch -d '2020-01-01 00:00:00' "$d/cargo/aaa_old/gen/nros/h.h"
+        printf 'LEAF\n' > "$d/leaf/h.h"
+        echo "$d"
+    }
+
     stage() { # <shared-content|-> <leaf-content|->  -> echoes the build dir
         d="$tmp/case$RANDOM$RANDOM"
         mkdir -p "$d/cargo/ws_abc/gen/nros" "$d/leaf"
@@ -60,6 +73,15 @@ if [ "${1:-}" = "--self-test" ]; then
     [ "$(cat "$d/dest.h")" = "NEW" ] \
         && ok "a stale leaf copy loses to the shared one" \
         || bad "a stale leaf copy loses to the shared one" "got $(cat "$d/dest.h")"
+
+    # Issue 0987 — the glob can match SEVERAL shared dirs, and the stale one
+    # sorts FIRST by name here, exactly as `cargo/build/` sorts before
+    # `cargo/nano-ros_1147c/` in the tree. Name order must not decide it.
+    d="$(_st_stage_two)"
+    bash "$self" "$d/leaf/h.h" "$d" gen h.h "$d/dest.h" >/dev/null
+    [ "$(cat "$d/dest.h")" = "NEW" ] \
+        && ok "the newest shared copy wins, not the first by name" \
+        || bad "the newest shared copy wins, not the first by name" "got $(cat "$d/dest.h")"
 
     # Issue 0805's original case, still handled: a leaf whose build script never
     # ran has no copy at all.
@@ -108,9 +130,47 @@ leaf_src="$1"; build_dir="$2"; gen_subdir="$3"; name="$4"; dest="$5"
 # `<build>/cargo/<workspace>_<hash>/...` — one entry in practice; the glob
 # avoids hardcoding Corrosion's hash, and this path is identical whether
 # `cargo` is a real directory or the shared-store symlink.
+# Issue 0987 — the NEWEST candidate, not the first.
+#
+# This used to `break` on the first match, and glob expansion is SORTED, so the
+# winner was decided by name. Measured 2026-09-02 in
+# `packages/testing/nros-tests/bins/action-raw-goal-probe/build-zenoh`, which
+# carries two:
+#
+#   cargo/build/...            2026-08-19  sz_886681abade04db2   <- won, by name
+#   cargo/nano-ros_1147c/...   2026-09-02  sz_9a3e918900c9d46d
+#
+# `cargo/build/` is residue from the pre-phase-340 target-dir layout (issue
+# 0488's class). Nothing rewrites it, so it is frozen and shadowed the live
+# store on every run, and `action_raw_goal_probe` failed to link on issue 0369's
+# size anchor against archives that were all current.
+#
+# Issue 0978's premise — "refreshed by ANY leaf's run, so it is always at least
+# as fresh as (1), never staler" — is true of THE shared copy. The glob can
+# match several, and the selection rule was never stated: it was inherited from
+# a comment reading "one entry in practice", which stopped being true silently,
+# because first-match still returns A file and the failure lands one layer down
+# as a link error naming a hash and no path.
+#
+# Same shape as issue 0500, whose remedy is the rule missing here: a store that
+# ACCUMULATES needs an ordering. There the SDK prefixes are enumerated
+# newest-VERSION-first because `find_package` takes the first that resolves;
+# here the residue is not distinguishable by name, so the order is by MTIME.
 src=""
+# -1, not 0: a candidate whose mtime cannot be read scores 0, and it must still
+# beat "no candidate at all" — otherwise an unreadable stat would silently
+# demote a real shared copy to the leaf fallback, which is the staleness this
+# whole family is about.
+_newest=-1
 for cand in "$build_dir"/cargo/*/"$gen_subdir"/nros/"$name"; do
-    [ -f "$cand" ] && { src="$cand"; break; }
+    [ -f "$cand" ] || continue
+    # GNU first, BSD/macOS second, and 0 if neither answers — an unreadable
+    # mtime must not silently win over a candidate whose mtime we know.
+    _m="$(stat -c %Y "$cand" 2>/dev/null || stat -f %m "$cand" 2>/dev/null || echo 0)"
+    if [ "$_m" -gt "$_newest" ]; then
+        _newest="$_m"
+        src="$cand"
+    fi
 done
 
 if [ -z "$src" ]; then


### PR DESCRIPTION
Fixes #0987. With this, #0985 and #0979, **`just build native` completes (EXIT=0)** — the first green native lane this session.

## The bug

`just build native` failed linking `action_raw_goal_probe` on issue 0369's size anchor, in the **opposite** direction from #0985: the mirrored *header* was old and every archive current.

Two cargo target dirs under one leaf:

| path | mtime | anchor |
| --- | --- | --- |
| `cargo/build/nros-c-generated/…` | **2026-08-19 06:48** | `sz_886681abade04db2` |
| `cargo/nano-ros_1147c/nros-c-generated/…` | 2026-09-02 14:00 | `sz_9a3e918900c9d46d` |

## Root cause: first-match, and glob order is by NAME

```sh
for cand in "$build_dir"/cargo/*/"$gen_subdir"/nros/"$name"; do
    [ -f "$cand" ] && { src="$cand"; break; }
done
```

`break` takes the first candidate and glob expansion is sorted, so `cargo/build/` beats `cargo/nano-ros_1147c/` whatever their dates. `cargo/build/` is residue from the pre-phase-340 layout (issue 0488's class); nothing rewrites it, so it is frozen and shadowed the live store on every run.

#0978's premise — *"refreshed by ANY leaf's run, so it is always at least as fresh as (1), never staler"* — is true of **the** shared copy. The glob can match several, and the selection rule was never stated: it was inherited from a comment reading *"one entry in practice"*, which stopped being true silently, because first-match still returns *a* file and the failure lands a layer down as a link error naming a hash and no path.

Same shape as **issue 0500**, whose remedy is the rule missing here: a store that ACCUMULATES needs an ordering. There the SDK prefixes are enumerated newest-*version*-first because `find_package` takes the first that resolves; here the residue is not distinguishable by name, so the order is by **mtime**.

## Fix

Newest candidate by mtime — GNU `stat -c %Y`, BSD `stat -f %m` second, `0` if neither answers. The accumulator starts at **`-1`, not `0`**: a candidate whose mtime cannot be read scores 0 and must still beat *no candidate at all*, or an unreadable `stat` would silently demote a real shared copy to the leaf fallback — which is the staleness this whole family is about. (I wrote `0` first; caught it while verifying.)

Self-test case `the newest shared copy wins, not the first by name`: two shared dirs where the stale one sorts **first** by name (`aaa_old` before `zzz_new`) and is older by mtime — #0987's tree in miniature. Non-vacuous: under first-match exactly that case fails (`got OLD`) and the other five pass, #0978's included.

## Verified, with one attribution corrected

The resolver run against the real leaf returns `sz_9a3e918900c9d46d` where it used to return `sz_886681abade04db2`.

`action_raw_goal_probe` then linked — **but not because of this fix**, and the distinction is worth recording. Its `main.c.o` resolves the header from the *nros-cpp* include dir, which in that leaf happened to be current; the nros-c copy was still stale. The clean attribution is to force the mirror edge itself:

```
BEFORE  nros-c/include/nros/nros_config_generated.h   sz_886681abade04db2
$ rm <that file> && ninja -C <leaf> nros_c_config_header
AFTER   nros-c/include/nros/nros_config_generated.h   sz_9a3e918900c9d46d
```

That is this change, through the real cmake path rather than a direct probe.

## Left open, recorded in the issue

**An already-drifted `nros-c` copy does not self-heal.** Its mirror's `OUTPUT` is compared against `$<TARGET_FILE:nros_c-static>`, and the two share a timestamp when written by the same build, so ninja skips it — a copy stale for some *other* reason stays stale until the crate rebuilds. #0985 gives `nros-cpp` a configure-time heal that runs this same resolver; `nros-c` has none. Adding one is a behaviour change in a second file and belongs in its own change.

Also seen once and not yet filed: `build-workspace-fixtures` hit a **race** where the issue-0740 stamp step ran before the mirror produced its output under parallel `gmake`. Re-running the same build succeeds (100%, rc=0), which is what distinguishes a race from a deterministic failure. A missing dependency edge; worth its own issue once characterised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSuM4yABT9i6XzprmNn1op