### PR TITLE
ci(queue): L3 needs `nros sync` — the runner was fine, the lane was not

### DIFF
--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -68,6 +68,40 @@ jobs:
       # lands on the author's change looking like a code failure. Assert first.
       - name: Verify this runner's labels are true
         run: ./scripts/ci/runner-doctor.sh nros-sdk-zephyr,nros-big
+      # L3 cross-builds three example leaves, and every one of them carries a
+      # `.cargo/config.toml` whose `include` names the GITIGNORED
+      # `nros-patch.toml` that only `nros sync` writes. Cargo treats a missing
+      # include as a HARD error during manifest parse (issue 0463), so without
+      # this the lane dies before compiling anything:
+      #
+      #   error: 54 unresolved `include` target(s) across 54 of 73 tracked
+      #          .cargo/config.toml files
+      #
+      # That is what this job had been failing on since it was enabled — NOT the
+      # Zephyr SDK. The doctor step above passes; `ac0c8cd96` fixed the SDK
+      # lookup, and the red simply moved one step later, which is easy to read
+      # as "the runner is still broken".
+      #
+      # `nros sync` needs the CLI built and `nros-launch-resolve` sitting BESIDE
+      # it (issues 0285 / 0797 — resolved by absolute path, never $PATH, and
+      # `--bin nros` does not build it). Same chain `host-tests.yml` and
+      # `nightly.yml` already run, for the same reason.
+      - name: Build nros CLI (nros sync needs it)
+        run: |
+          git submodule update --init --depth 1 packages/cli/third-party/play_launch
+          source ./activate.sh
+          just setup-cli
+
+      - name: Build nros-launch-resolve (nros sync shells out to it)
+        run: |
+          source ./activate.sh
+          just setup-launch-resolve
+
+      - name: nros sync (writes the leaf `nros-patch.toml` includes)
+        run: |
+          source ./activate.sh
+          nros sync
+
       - name: just ci l3
         run: |
           source ./activate.sh


### PR DESCRIPTION
**The runner is already provisioned. The failure moved and kept looking the same.**

I went to provision `nros-sdk-zephyr` and found the host fixed: `ac0c8cd96` ("the doctor looked for the Zephyr SDK where `actions/checkout` deletes it") landed today, and the **"Verify this runner's labels are true" step now passes**. What is still red is the next step, with a message that reads nothing like a cargo-config problem:

```
error: 54 unresolved `include` target(s) across 54 of 73 tracked .cargo/config.toml files
  examples/qemu-arm-baremetal/rust/listener/.cargo/config.toml
      include -> ../../../../../nros-patch.toml  (absent)
```

L3 cross-builds three example leaves, and every leaf's `.cargo/config.toml` includes the **gitignored** `nros-patch.toml` that only `nros sync` writes. Cargo treats a missing include as a hard error during manifest **parse** (issue 0463), so the lane dies before compiling anything — in a job called "cross build + link".

## The gap

The job was `checkout → doctor → just ci l3`. No CLI build, no resolver, no sync.

It now runs the chain `host-tests.yml` and `nightly.yml` already run, for the same documented reasons: `nros sync` needs the CLI built and `nros-launch-resolve` sitting **beside** it (issues 0285 / 0797 — resolved by absolute path never `$PATH`, and `--bin nros` does not build it).

## What this does not claim

That L3 now passes. **I cannot run it** — the runner is a different machine (this box is `newslab-server243`; the runner has `/mnt/evo` and an `actions-runner` tree, neither of which exists here), so the merge group is the only place this executes. This fixes the failure that is actually present and will reveal the next one if there is one: `just ci l3` also needs the freertos / nuttx / threadx cross toolchains, which the `nros-sdk-zephyr,nros-big` labels do not assert.

Safe to land either way — `queue` failing does not block merges, as every PR merged today demonstrates.

## Verification

- `just check fast` — 167/167
- `check-workflow-repo-env` and `check-workflow-runner-isolation` — OK
