### PR TITLE
fix(phase-392 W5.g): the entity facts were read before anything produced them

### DIFF
--- a/cmake/NanoRosRuntimeCrate.cmake
+++ b/cmake/NanoRosRuntimeCrate.cmake
@@ -306,11 +306,29 @@ nros_armv8r_cflags_env(nros_ws_runtime-static)
     # cargo from the workspace root).
     nros_board_facts_env(nros_ws_runtime-static)
     # phase-392 W5.c — and the entity figures the RMW sizes its queryable table
-    # from. Applied HERE, once, because this staticlib is shared by every entry
-    # in the configure and the accumulation is complete only after the SUBDIRS
-    # loop above has processed them all.
+    # from.
+    #
+    # DEFERRED to the end of the TOP-LEVEL scope (phase-392 W5.g), because the
+    # comment this replaced was wrong about the ordering and the mechanism has
+    # therefore never run anywhere. It said the accumulation "is complete only
+    # after the SUBDIRS loop above has processed them all" — true of the NODE
+    # packages, false of the ENTRY, which `nano_ros_add_entry` declares LAST by
+    # design ("the first point in a configure that is guaranteed to be AFTER
+    # every nano_ros_node_register()"). `nros_record_entity_facts` runs there.
+    #
+    # MEASURED on `examples/workspaces/mixed`: the consumer logged
+    # `seen=<empty>` at configure line 17 and the seven models were recorded at
+    # lines 19-85. It read the accumulator before anything filled it, every
+    # time, in every workspace — which is why W5.g found no status line in any
+    # of the three it checked and could not explain `mixed`.
+    #
+    # Same fix and same reasoning as `_nano_ros_support_schedule_flush`: DEFER
+    # to `CMAKE_SOURCE_DIR`, not to the current directory. Deferring to the
+    # current one would fire at the end of whichever scope called first, which
+    # is the bug rather than a smaller version of it.
     include("${NANO_ROS_ROOT}/cmake/NanoRosEntityFacts.cmake")
-    nros_entity_facts_env(nros_ws_runtime-static)
+    cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
+        CALL nros_entity_facts_env nros_ws_runtime-static)
     if(NOT TARGET nros_ws_runtime-static)
         message(FATAL_ERROR
             "nros_synth_runtime_umbrella: Corrosion did not create "

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1079,9 +1079,65 @@ the same function. It still prints nothing. Either the call is not reached for
 a reason not yet found, or the status line is suppressed. **Not diagnosed;
 recorded as the next action rather than guessed at.**
 
+### W5.g DIAGNOSED AND FIXED 2026-09-02 — an ORDERING inversion, not a workspace quirk
+
+`mixed` is explained, and the explanation covers all three rows: the consumer ran
+BEFORE any producer, everywhere.
+
+`nros_synth_runtime_umbrella` called `nros_entity_facts_env` inline, under a
+comment asserting "the accumulation is complete only after the SUBDIRS loop
+above has processed them all". That is true of the NODE packages and false of the
+ENTRY, which `nano_ros_add_entry` declares LAST by design — `NanoRosEntry.cmake`
+says so in its own words, "the first point in a configure that is guaranteed to
+be AFTER every `nano_ros_node_register()`". `nros_record_entity_facts` runs
+there.
+
+Measured by tracing a `mixed` reconfigure:
+
+```
+line 17:  facts_env(nros_ws_runtime-static) seen=<empty>   <- consumer
+lines 19-85: model OK: system_model.yaml, ... (7 models)   <- producers
+```
+
+The accumulator was read before anything filled it, on every configure. No
+workspace could ever have printed the status line, which is why W5.g found none
+in three and could not explain the third.
+
+**Fixed** by deferring to the top-level scope —
+`cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL nros_entity_facts_env
+…)` — the same idiom and the same reasoning as
+`_nano_ros_support_schedule_flush` one module over, including its warning that
+deferring to the CURRENT directory would fire at the end of whichever scope
+called first and so be the bug rather than a smaller version of it.
+
+The line now prints on `mixed`:
+
+    nano-ros: queryable table sized from the declaration — infrastructure none,
+    application count undeclared (no model here describes wiring)
+
+**Delivery is PARTIAL, and that is not a saving yet.** After a full rebuild the
+`ZPICO_MAX_QUERYABLES` the units actually compiled are:
+
+| cargo root | value |
+| --- | ---: |
+| `nros_ws_runtime_*` (the unit that got the env) | **8** |
+| `nros_ws_runtime_*` (a second unit) | 32 |
+| `nano-ros_*` (repo-root dir, 4 units) | 32 |
+
+So one unit fell 32 -> 8 slots and five did not. The env reaches the umbrella's
+`zpico-sys` and not the other instantiations, which are separate cargo units
+under a different workspace root (issue 0616's shape: a `--target-dir` serves one
+root, and `-C metadata` keys a unit by the path it was reached by). Sizing one of
+six is not a shipped number, and no byte figure is claimed from it.
+
+**And the application half is still absent** — "application count undeclared (no
+model here describes wiring)" is issue 0973: `describes_wiring()` is false for
+every resolved model in the tree, so only the INFRA figure is ever delivered.
+
 **So the honest state of W5:** the sizing logic, the exhaustion diagnostic and
-the checked override all landed and are unit-tested, and the figure they consume
-reaches no image that was checked. The 143,456 B in W5.d remains a measurement
+the checked override all landed and are unit-tested; the figure they consume now
+REACHES a build for the first time, on one of six compiled units, carrying the
+infra half only. The 143,456 B in W5.d remains a measurement
 of what the mechanism WOULD save, on a leaf where the mechanism does not run.
 Nothing in this wave should be quoted as a shipped saving until the `mixed` case
 is explained and a before/after `mem-report` exists.


### PR DESCRIPTION
W5.g found no `"queryable table sized from the declaration"` line in any of three
workspaces, and could not explain why `mixed` was silent when its umbrella was
demonstrably created.

One ordering inversion explains all three rows: **the consumer ran before every
producer, on every configure.**

## Cause

`nros_synth_runtime_umbrella` called `nros_entity_facts_env` inline, under a
comment asserting the accumulation *"is complete only after the SUBDIRS loop
above has processed them all"*. True of the **node** packages. False of the
**entry**, which `nano_ros_add_entry` declares last by design —
`NanoRosEntry.cmake` says so in its own words, *"the first point in a configure
that is guaranteed to be AFTER every `nano_ros_node_register()`"* — and that is
where `nros_record_entity_facts` runs.

Traced on a `mixed` reconfigure rather than reasoned about:

```
line 17:     facts_env(nros_ws_runtime-static) seen=<empty>   <- consumer
lines 19-85: model OK: system_model.yaml, ... (7 models)      <- producers
```

## Fix

Defer to the **top-level** scope — the same idiom and reasoning as
`_nano_ros_support_schedule_flush` one module over, including its warning that
deferring to the *current* directory fires at the end of whichever scope called
first, and so is the bug rather than a smaller version of it.

The line now prints on `mixed`, and one `zpico-sys` unit compiles
`ZPICO_MAX_QUERYABLES = 8` where it was 32.

## Delivery is PARTIAL — no saving claimed

After a full rebuild:

| cargo root | value |
| --- | ---: |
| `nros_ws_runtime_*` (got the env) | **8** |
| `nros_ws_runtime_*` (second unit) | 32 |
| `nano-ros_*` (repo-root, 4 units) | 32 |

One of six units took it. The others are separate cargo units under a different
workspace root — issue 0616's shape, where `-C metadata` keys a unit by the path
it was reached by. **Sizing one of six is not a number to quote**, so this
reports slots and measures no bytes.

The application half also remains absent — *"application count undeclared (no
model here describes wiring)"* is issue **0973**: only the infra figure is ever
delivered while no model describes wiring.

## Verification

`just check fast`: 167 gates OK. The status line was confirmed present after the
fix and absent before, on a real reconfigure of `examples/workspaces/mixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa