### PR TITLE
docs: the dangling issue references — one recovered, one that never existed

### DIFF
--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -1,0 +1,14 @@
+# Prose references to an issue id with no file on disk.
+#
+# A RATCHET, not an allowlist: this file may only shrink. Each row is
+# `<path>:<id>`. The legitimate reason to be here is an IN-FLIGHT issue —
+# the citing doc is on main, its issue file is in another open PR — where
+# deleting the correct citation would be the wrong fix.
+#
+# Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline
+book/src/getting-started/zephyr.md:0940
+cmake/NanoRosCodegenCore.cmake:0940
+cmake/NanoRosGenerateInterfaces.cmake:0940
+cmake/NanoRosMessageBounds.cmake:0940
+cmake/NanoRosWorkspace.cmake:0949
+just/check.just:0940

--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -6,9 +6,5 @@
 # deleting the correct citation would be the wrong fix.
 #
 # Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline
-book/src/getting-started/zephyr.md:0940
-cmake/NanoRosCodegenCore.cmake:0940
-cmake/NanoRosGenerateInterfaces.cmake:0940
-cmake/NanoRosMessageBounds.cmake:0940
-cmake/NanoRosWorkspace.cmake:0949
-just/check.just:0940
+just/check.just:1039
+scripts/check-zenoh-platform-macros.py:1039

--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -6,5 +6,6 @@
 # deleting the correct citation would be the wrong fix.
 #
 # Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline
-just/check.just:1039
-scripts/check-zenoh-platform-macros.py:1039
+docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
+just/check/docs.just:1110
+scripts/build/rustdoc-set.sh:1110

--- a/.config/prose-issue-ref-baseline.txt
+++ b/.config/prose-issue-ref-baseline.txt
@@ -6,6 +6,33 @@
 # deleting the correct citation would be the wrong fix.
 #
 # Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline
+#
+# CLASSIFIED 2026-09-08, because "in flight" is only true of some of these:
+#
+#   1099  IN FLIGHT — `docs/issues/1099-cpp-trigger-transition-crosses-
+#         lifecycle-ids.md` exists on `origin/design/context-init-shape`.
+#         The citation is correct and the file is coming.
+#
+#   9999  NEGATION — the citation is deliberately unresolvable. Issue 1092
+#         describes a mutation test whose control is "a gap reason naming
+#         issue 9999, which DOES NOT EXIST". Filing 9999 would destroy the
+#         control; deleting the sentence would delete the test's description.
+#         The same class `check-doc-recipe-refs` calls NEGATION.
+#
+#   0417  RESERVED, NEVER WRITTEN. `refs/issue-ids/0417` exists on origin, so
+#   1080  the id was claimed with `just issue-new` and no file was ever
+#         committed — issue 0999's shape ("the id was reserved, the fix
+#         landed, the file never got written"). The citations are honest and
+#         point at nothing, and the fix is to write the file, which needs
+#         whoever claimed the id. Not deleted: a reference removed is a
+#         record lost, and the id is not free either.
+#
+docs/issues/1092-rmw-shape-gate-licenses-deviation-without-pinning-it.md:9999
 docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md:1110
+docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md:1080
+docs/issues/1186-executor-backing-latch-test-races-siblings.md:0417
+docs/roadmap/phase-428-api-porting-principle-sweep.md:1099
+docs/roadmap/phase-432-codegen-one-producer-many-packs.md:1080
 just/check/docs.just:1110
+just/check/lanes.just:1099
 scripts/build/rustdoc-set.sh:1110

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,7 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
   reach its own guard** — `metadata-mode` carried an unreachable `compile_error!` for two phases.
   And where a consumer GETS `std` is not uniform (`examples/native/rust/*` inherit it from
   `nros-board-linux`; `nros-tests/bins/*` must name it), so a manifest-READING sweep looks complete
-  while half the tree is red — build the candidates. → issues 0632, 0640.
+  while half the tree is red — build the candidates.
 - **Messages are generated** (`nros generate-rust` from `package.xml`) — never hand-write. Detail
   → RFC-0023 + [docs/guides/message-generation.md](docs/guides/message-generation.md).
 - Unused vars: `_name` + comment, or `#[allow(dead_code)]` for test struct fields.

--- a/docs/issues/archived/0883-generated-issue-index-serialises-every-pr.md
+++ b/docs/issues/archived/0883-generated-issue-index-serialises-every-pr.md
@@ -1,0 +1,130 @@
+---
+id: 883
+title: "`docs/issues/README.md` is generated, committed, and touched by nearly every
+  PR — so one merge ejects all the others from the queue"
+status: resolved
+type: tech-debt
+area: ci
+related: [phase-396, issue-0871, issue-0884]
+resolved_in: "issue 0884"
+---
+
+## Resolved — recovered 2026-09-02
+
+This file was written but never reached `main`: the commit carrying it
+(`bda4a5478`) was not merged, while the FIX it argues for was landed separately
+under issue 0884. So the defect was fixed and its analysis was lost, leaving
+`CLAUDE.md` and `docs/issues/README.md` citing "issues 0883/0884" with only one
+of them on disk.
+
+Recovered rather than deleted, because the two issues say different things:
+0884 records the ledger conflicting on concurrent filings; THIS one records why
+the conflict serialises the QUEUE — one merge ejecting every other entry — which
+is the argument for `merge=union` on a generated list rather than for a tidier
+list. The 0884 fix (move the generated rows out of the authored `README.md` into
+`docs/issues/open.md`, `merge=union`) is what closes both.
+
+Verified on main: `docs/issues/README.md` carries 0 generated rows,
+`.gitattributes` marks `docs/issues/open.md merge=union`, and five concurrent
+rebases on 2026-09-02 produced no conflict in that file.
+
+
+## Problem
+
+`docs/issues/README.md` is **generated** by `scripts/gen-issue-index.py` from the
+frontmatter of every issue file, and it is **committed**. Almost every pull
+request in this repository files, resolves or archives an issue, so almost every
+pull request rewrites it — and two pull requests that both rewrite it conflict,
+even when their actual changes are unrelated.
+
+Measured 2026-08-29, test-merging each open branch against `main` in an isolated
+worktree:
+
+```
+fix/0865-nuttx-qemu-throttling      CONFLICT: docs/issues/README.md
+fix/0819-xrce-fragmented-receive    CONFLICT: docs/issues/README.md
+fix/0871-ci-compile-check-fixtures  CONFLICT: docs/issues/README.md
+fix/heap-free-tier-gate             merges CLEAN
+fix/0831                            merges CLEAN
+```
+
+Three of five, and `docs/issues/README.md` is the **only** conflicting path in
+each. Nothing else disagrees.
+
+## What it costs
+
+It serialises the merge queue. On 2026-08-29, seven pull requests were rebased
+onto `main`, gated green and armed with auto-merge. `#9` — a two-line issue
+resolution — merged. That single merge conflicted the index in the other six,
+which were ejected from the queue with their auto-merge cancelled, and needed a
+full rebase round to get back.
+
+So the throughput of a queue that now works correctly is capped at **one
+doc-touching pull request per rebase round**, and essentially every pull request
+is doc-touching. This is the bottleneck that remains after phase-396 fixed the
+required check.
+
+## Why the obvious fixes do not work
+
+**A custom merge driver does not help.** `.gitattributes` plus
+`merge.<driver>.driver = python3 scripts/gen-issue-index.py` would resolve this
+perfectly on a developer's machine — the file is a pure function of the issue
+files, so regenerating IS the correct merge. But GitHub's merge queue performs
+its rebase **server-side**, where custom merge drivers do not run. It would fix
+local rebases and leave the queue exactly as it is, which is the half that hurts.
+
+**`merge=union` is wrong.** The index is a sorted, structured table with a
+counted header; union merge produces duplicate rows and a count that disagrees
+with them, and `check-issue-index` fails on the result — correctly.
+
+**Sorting differently does not help either.** The rows are already ordered by
+id, so two pull requests filing adjacent ids touch adjacent lines. And today's
+conflicts were mostly *removals* (issues resolved and archived), which conflict
+regardless of ordering.
+
+## Options, with what each gives up
+
+1. **Stop committing it.** Gitignore the file, generate on demand
+   (`just issues-index`), and publish it from CI rather than from the tree. Ends
+   the conflict class outright. Gives up the browsable index on GitHub, which is
+   most of why the file exists — and `check-issue-index` becomes a check with
+   nothing to compare against.
+2. **Commit it, but regenerate on `main` after each merge.** A `post-submit` job
+   regenerates and pushes. Ends the conflicts; costs a bot commit per merge, and
+   collides with `required_linear_history` plus the PR-only rule — the bot needs
+   a bypass actor, and `bypass_actors` is deliberately empty.
+3. **Shrink the file to what does not churn.** Keep a stable index that names
+   only the issue *files* (which are append-only) and move the volatile columns —
+   status, title, area — out of the committed artifact. Smaller conflict surface
+   without losing navigability. Most design work of the three.
+4. **Accept it**, and make the cost explicit: batch doc changes, and expect one
+   rebase round per merge.
+
+Not decided. Option 1 is the smallest change and the biggest loss; option 3 is
+the one that keeps what the file is for.
+
+## Reproduce
+
+```
+W=$(mktemp -d); git worktree add -q --detach "$W" origin/main
+cd "$W"
+for b in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -v HEAD); do
+    git checkout -q --detach origin/main
+    git merge --no-commit --no-ff "$b" >/dev/null 2>&1 \
+        && echo "$b: clean" \
+        || echo "$b: CONFLICT $(git diff --name-only --diff-filter=U | tr '\n' ' ')"
+    git merge --abort 2>/dev/null
+done
+```
+
+Note `git merge-tree --write-tree` is NOT available on this host's git; an
+earlier version of this measurement used it and reported "CONFLICT" for every
+branch, which was the command failing rather than a merge result. Use a real
+worktree merge.
+
+## Acceptance
+
+- Two pull requests that each file an issue, and touch nothing else in common,
+  can both merge without a rebase round between them.
+- `check-issue-index` still fails when the index disagrees with the issue files,
+  whatever form the index takes.

--- a/docs/issues/archived/0989-prose-issue-references-unchecked.md
+++ b/docs/issues/archived/0989-prose-issue-references-unchecked.md
@@ -1,0 +1,87 @@
+---
+id: 989
+title: "A prose `issue NNNN` reference resolves to nothing and no gate notices —
+  `check-doc-refs` validates paths, not the form people actually write"
+status: resolved
+type: tech-debt
+area: build
+related: [issue-0883, issue-0196]
+resolved_in: "issue 0989 (this filing)"
+---
+
+## Symptom
+
+`CLAUDE.md` — loaded into every agent session — pointed at three issues that do
+not exist on `main`, and every gate was green:
+
+| ref | cited in | what it was |
+| --- | --- | --- |
+| 0883 | `CLAUDE.md`, `docs/issues/README.md` | file written, never merged |
+| 0632 | `CLAUDE.md` | no file, on any branch, ever |
+| 0640 | `CLAUDE.md` | no file, on any branch, ever |
+
+A pointer in CLAUDE.md is an instruction to go read something. When the
+something is absent the reader cannot tell whether the document was lost or
+their search was bad — and 0883 was the expensive shape: the analysis existed,
+was never merged, and the fix landed under a different id, so the tree said
+"see 0883" about a file that had never been on main.
+
+## Why `check-doc-refs` did not catch it
+
+That gate checks **paths** — `docs/issues/NNNN-slug.md` written into prose, into
+cmake strings, into frontmatter. It exists because a renumbered RFC left a stale
+path in a cmake error message, and it is the right check for a path.
+
+Prose does not contain a path. It contains an id with a word in front of it, and
+there is nothing for a path-checker to resolve. The two gates are complements.
+
+## Fix
+
+`scripts/check-prose-issue-refs.py`, on the fast line as `just check
+prose-issue-refs`. Buildless, milliseconds.
+
+It matches a 4-digit id preceded by `issue`/`issues`, with an optional `#`, and
+follows a comma- or slash-separated tail so a cited pair is two references
+rather than one. Deliberately narrow: bare 4-digit numbers are everywhere in
+this tree (ports, sizes, buffer bounds) and matching them would drown the gate
+in noise.
+
+**A RATCHET against a tracked baseline, not a hard zero.** A doc on `main` can
+correctly cite an issue whose file is still in another open PR — six references
+are in exactly that state today (0940 and 0949, both filed in PR #151). Failing
+those would push someone to delete a correct citation, which is worse than the
+dangling ref. New violations fail; a row that stops dangling must leave the
+baseline, so the debt can only shrink.
+
+## Two false-positive classes, both found by running it
+
+Recorded because both were *plausible* regexes that produced wrong answers, and
+the audit is what settled it — the first draft reported 12 violations of which
+half were fictional.
+
+1. **A date reads as a second id.** `issue 0364, 2026-07-31` is one reference
+   and a date, but the comma-tail rule took `2026` as its pair — inventing a
+   dangling reference to "issue 2026". Fixed with a `(?!-\d)` guard; a real id
+   is never followed by `-<digit>`.
+2. **The gate flags itself.** Its own docstring must name the ids that motivated
+   it, and its `just` recipe comment wanted to quote an example. Both tripped
+   it. The script is exempt by path, and the recipe comment paraphrases instead
+   — `check-doc-refs` records hitting the same thing and solving it the second
+   way.
+
+## Verified
+
+* Negative control: injecting `issue 9123` into `docs/design/ARCHITECTURE.md`
+  fails the gate and names the file and id; removing it passes.
+* Self-test on the normal path (phase-395), seven cases — the bare form, a
+  slashed pair, a comma pair, the hyphenated `issue-NNNN` spelling, a `#`
+  prefix, and two negatives that must NOT match (a bare number, and a 5-digit
+  run).
+* The scan that found the original three now reports only the in-flight rows.
+
+## Not covered
+
+Only `issue`-prefixed references. A doc that says "see 0640" with no such word
+is invisible to this, and deliberately so — the alternative is matching every
+4-digit number in the repo. If that shape ever appears in practice it is a
+different gate, not a wider regex here.

--- a/just/check/docs.just
+++ b/just/check/docs.just
@@ -365,3 +365,19 @@ archived-issue-status:
 [group("ci")]
 std-census:
     @python3 scripts/check-std-census.py
+
+# Issue 0989 — `check-doc-refs` validates a PATH (`docs/issues/NNNN-slug.md`);
+# this validates the form people actually write in prose (an `issue NNNN`
+# mention, or a comma/slash-separated pair of them). It was green while
+# CLAUDE.md — loaded into every agent session — cited three ids with no file on
+# main.
+#
+# The examples are PARAPHRASED, not quoted: a literal dead id in this comment is
+# a reference like any other and the gate flags it. `check-doc-refs` records
+# hitting the same thing.
+#
+# A RATCHET, not a hard zero: a doc on main can correctly cite an issue whose
+# file is still in another open PR, and deleting that citation would be the
+# wrong fix. Buildless, milliseconds, self-testing.
+prose-issue-refs:
+    @python3 scripts/check-prose-issue-refs.py

--- a/scripts/check-prose-issue-refs.py
+++ b/scripts/check-prose-issue-refs.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Issue 0989 — a prose reference to an issue id must resolve to a file.
+
+WHY `check-doc-refs` DOES NOT COVER THIS
+
+That gate checks PATHS: `docs/issues/NNNN-slug.md` written into prose, cmake
+strings, frontmatter. It was built for a renumbered RFC whose stale path sat in
+a cmake error message. It is the right check for a path, and it cannot see the
+form people actually write in prose:
+
+    (issues 0883/0884)          → issues 0632, 0640.          see issue 0940
+
+No path, no link, nothing for a path-checker to resolve. Measured 2026-09-02:
+`check-doc-refs` was GREEN while `CLAUDE.md` cited three ids with no file on
+main — 0883 (written, never merged), 0632 and 0640 (no file on any branch,
+ever). The two gates are complements, not duplicates.
+
+WHY IT MATTERS MORE THAN A BROKEN LINK
+
+CLAUDE.md is loaded into every agent session. A pointer there is an instruction
+to go read something, and when the something does not exist the reader cannot
+tell whether they are looking at a lost document or their own bad search. The
+0883 case was the expensive shape: the analysis existed, was never merged, and
+the fix landed under a different id — so the tree said "see 0883" for four days
+about a file that had never been on main.
+
+WHAT COUNTS AS A REFERENCE
+
+A 4-digit id preceded by `issue`/`issues`, optionally `#`-prefixed and
+hyphen- or space-separated. Deliberately narrow: bare 4-digit numbers appear
+everywhere (ports, sizes, years, sha prefixes) and matching them would make this
+gate noise. `issue-0196` and `issues 0883/0884` are the spellings in this tree.
+
+WHAT IS EXEMPT, AND WHY
+
+  * `docs/issues/archived/**` — an archived issue legitimately cites its
+    contemporaries, some of which may since have been renumbered or dropped.
+    Rewriting history to satisfy a gate is worse than the dangling ref.
+  * A `related:` / `resolved_in:` frontmatter list — those are already the
+    business of `check-issue-ids`, and duplicating that check here would give
+    two error messages for one defect.
+  * An id whose file is ADDED IN THE WORKING TREE but not yet committed: the
+    gate reads the filesystem, so a new issue and the doc that cites it can land
+    in one commit. That is the normal flow and must not be blocked.
+
+The last one is the reason this reads the filesystem rather than `git ls-files`:
+a gate that forced you to commit the issue before you could cite it would push
+people to cite nothing.
+
+IN-FLIGHT REFERENCES ARE THE HARD CASE
+
+An id can be cited correctly by a doc whose issue file is in ANOTHER open PR —
+`book/src/getting-started/zephyr.md` cites 0940, whose file is in PR #151. On
+that branch the gate is green; on main it would be red, and the "fix" (deleting
+a correct citation) is wrong.
+
+So violations are a RATCHET against a tracked baseline, not a hard zero. A new
+dangling reference fails; the known in-flight ones are listed and disappear from
+the baseline when their issue lands. Same shape as
+`.config/gate-selftest-baseline.txt`.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASELINE = os.path.join(ROOT, ".config", "prose-issue-ref-baseline.txt")
+
+# `issue 0883`, `issues 0883/0884`, `issue-0196`, `issue #0883`
+REF = re.compile(r"issues?[-\s]#?(\d{4})(?!-\d)\b", re.I)
+# A second id after a separator: `issues 0883/0884`, `issues 0632, 0640`
+# `(?!-\d)` rejects a DATE. `issue 0364, 2026-07-31` is one id and a date, not
+# a pair — without this the year is read as a second issue and the gate invents
+# a dangling reference to issue 2026. Found by running the audit on this tree.
+TAIL = re.compile(r"\s*[/,]\s*#?(\d{4})(?!-\d)\b")
+
+SEARCH_ROOTS = ("docs", "book/src", "cmake", "scripts", "just")
+SEARCH_FILES = ("CLAUDE.md", "AGENTS.md", "README.md")
+EXEMPT_DIRS = (os.path.join("docs", "issues", "archived"),)
+# This gate's own source. Its docstring must name the ids that motivated it,
+# and a gate that flags itself for documenting its own cases is unusable —
+# `check-doc-refs` records hitting exactly this and solved it by paraphrasing;
+# an explicit exemption is clearer than prose contorted to avoid a regex.
+EXEMPT_FILES = ("scripts/check-prose-issue-refs.py",)
+
+
+def existing_ids():
+    """Every issue id with a file on disk, open or archived."""
+    ids = set()
+    for d in (os.path.join(ROOT, "docs", "issues"),
+              os.path.join(ROOT, "docs", "issues", "archived")):
+        if not os.path.isdir(d):
+            continue
+        for name in os.listdir(d):
+            m = re.match(r"(\d{4})-", name)
+            if m:
+                ids.add(m.group(1))
+    return ids
+
+
+def candidate_files():
+    out = []
+    for f in SEARCH_FILES:
+        p = os.path.join(ROOT, f)
+        if os.path.isfile(p):
+            out.append(f)
+    for root in SEARCH_ROOTS:
+        base = os.path.join(ROOT, root)
+        for dirpath, dirnames, filenames in os.walk(base):
+            rel = os.path.relpath(dirpath, ROOT)
+            if any(rel == e or rel.startswith(e + os.sep) for e in EXEMPT_DIRS):
+                dirnames[:] = []
+                continue
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+            for name in filenames:
+                if name.endswith((".md", ".sh", ".py", ".cmake", ".just", ".txt")):
+                    out.append(os.path.relpath(os.path.join(dirpath, name), ROOT))
+    return sorted(set(out))
+
+
+def refs_in(text):
+    """Every id referenced, including the tail of `issues A/B` and `A, B`."""
+    found = set()
+    for m in REF.finditer(text):
+        found.add(m.group(1))
+        pos = m.end()
+        while True:
+            t = TAIL.match(text, pos)
+            if not t:
+                break
+            found.add(t.group(1))
+            pos = t.end()
+    return found
+
+
+def scan():
+    """{ 'file:id' } for every reference with no file on disk."""
+    have = existing_ids()
+    bad = set()
+    for rel in candidate_files():
+        if rel in EXEMPT_FILES:
+            continue
+        path = os.path.join(ROOT, rel)
+        try:
+            with open(path, encoding="utf8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        # Frontmatter `related:` / `resolved_in:` belong to check-issue-ids.
+        text = re.sub(r"^(related|resolved_in):.*$", "", text, flags=re.M)
+        for n in refs_in(text):
+            if n not in have:
+                bad.add(f"{rel}:{n}")
+    return bad
+
+
+def load_baseline():
+    if not os.path.exists(BASELINE):
+        raise SystemExit(
+            f"check-prose-issue-refs: baseline missing at {BASELINE}.\n"
+            "  It is tracked, so its absence is a PATH bug, not an empty ratchet.\n"
+            "  Regenerate deliberately with --write-baseline."
+        )
+    with open(BASELINE, encoding="utf8") as fh:
+        return {l.strip() for l in fh if l.strip() and not l.startswith("#")}
+
+
+def write_baseline(bad):
+    os.makedirs(os.path.dirname(BASELINE), exist_ok=True)
+    with open(BASELINE, "w", encoding="utf8") as fh:
+        fh.write(
+            "# Prose references to an issue id with no file on disk.\n"
+            "#\n"
+            "# A RATCHET, not an allowlist: this file may only shrink. Each row is\n"
+            "# `<path>:<id>`. The legitimate reason to be here is an IN-FLIGHT issue —\n"
+            "# the citing doc is on main, its issue file is in another open PR — where\n"
+            "# deleting the correct citation would be the wrong fix.\n"
+            "#\n"
+            "# Regenerate: python3 scripts/check-prose-issue-refs.py --write-baseline\n"
+        )
+        for row in sorted(bad):
+            fh.write(row + "\n")
+    print(f"wrote {BASELINE} — {len(bad)} known dangling reference(s)")
+
+
+def self_test():
+    """The gate's own failure path, run on the normal path (phase-395)."""
+    fails = 0
+
+    def case(name, text, want):
+        nonlocal fails
+        got = refs_in(text)
+        if got != want:
+            print(f"  [FAIL] {name}: got {sorted(got)}, want {sorted(want)}", file=sys.stderr)
+            fails += 1
+
+    case("bare", "see issue 0883 for detail", {"0883"})
+    case("slashed pair", "(issues 0883/0884) — the ledger", {"0883", "0884"})
+    case("comma pair", "→ issues 0632, 0640.", {"0632", "0640"})
+    case("hyphenated", "the issue-0196 rule", {"0196"})
+    case("hash", "issue #0975 deadlocked the queue", {"0975"})
+    # A bare number is NOT a reference — this is what keeps the gate quiet.
+    case("bare number ignored", "port 7447 and 0640 bytes", set())
+    case("word boundary", "issue 09755 is not an id", set())
+
+    if fails:
+        print(f"check-prose-issue-refs: self-test FAILED ({fails} case(s))", file=sys.stderr)
+        return False
+    return True
+
+
+def main():
+    if not self_test():
+        return 1
+
+    bad = scan()
+
+    if "--write-baseline" in sys.argv:
+        write_baseline(bad)
+        return 0
+
+    if "--audit" in sys.argv:
+        print(f"{len(bad)} dangling prose reference(s):")
+        for row in sorted(bad):
+            print(f"  {row}")
+        return 0
+
+    baseline = load_baseline()
+    new = bad - baseline
+    fixed = baseline - bad
+
+    if new:
+        print("check-prose-issue-refs: FAIL — reference(s) to an issue with no file:", file=sys.stderr)
+        for row in sorted(new):
+            path, n = row.rsplit(":", 1)
+            print(f"    {path} cites issue {n}, and docs/issues/{n}-*.md does not exist", file=sys.stderr)
+        print(file=sys.stderr)
+        print("  Either the issue was never filed, or its file is in another open PR.", file=sys.stderr)
+        print("  If it is in flight, add the row to the baseline and say which PR:", file=sys.stderr)
+        print("    python3 scripts/check-prose-issue-refs.py --write-baseline", file=sys.stderr)
+        print("  Otherwise fix the citation — or file the issue it points at.", file=sys.stderr)
+        return 1
+
+    if fixed:
+        print("check-prose-issue-refs: FAIL — the baseline is STALE.", file=sys.stderr)
+        print("  These no longer dangle (their issue landed, or the citation went):", file=sys.stderr)
+        for row in sorted(fixed):
+            print(f"    {row}", file=sys.stderr)
+        print("  A ratchet that does not tighten stops being one. Regenerate:", file=sys.stderr)
+        print("    python3 scripts/check-prose-issue-refs.py --write-baseline", file=sys.stderr)
+        return 1
+
+    print(f"check-prose-issue-refs: OK ({len(baseline)} known in-flight, no new dangling reference)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-prose-issue-refs.py
+++ b/scripts/check-prose-issue-refs.py
@@ -107,6 +107,10 @@ def candidate_files():
             out.append(f)
     for root in SEARCH_ROOTS:
         base = os.path.join(ROOT, root)
+        # walk-ok: must see files added in the working tree but not yet
+        # committed (see module docstring, "WHAT IS EXEMPT" — an id and the
+        # doc citing it can land in one commit), so `git ls-files` is the
+        # wrong index here.
         for dirpath, dirnames, filenames in os.walk(base):
             rel = os.path.relpath(dirpath, ROOT)
             if any(rel == e or rel.startswith(e + os.sep) for e in EXEMPT_DIRS):


### PR DESCRIPTION
Three issue IDs were cited in authored docs with no file on `main`:

| ref | cited in | status |
| --- | --- | --- |
| **0883** | `CLAUDE.md:558`, `docs/issues/README.md` | file written, never merged |
| **0632** | `CLAUDE.md:358` | no file, ever |
| **0640** | `CLAUDE.md:358` | no file, ever |

`check-doc-refs` does not catch these — it validates **link paths** (`docs/issues/NNNN-slug.md`), not prose references of the form "issue 0883".

## 0883 — recovered, not deleted

Its file exists on `bda4a5478`, a commit that never reached main, while the **fix it argues for landed separately as 0884**. So the defect was fixed and its analysis was lost.

The two issues say different things and both are worth having:

- **0884** — the ledger *conflicting* on concurrent filings.
- **0883** — why that conflict *serialises the queue*: one merge ejects every other entry. That is the argument for `merge=union` on a generated list, rather than merely for a tidier list.

Restored to `archived/` as `status: resolved`, `resolved_in: issue 0884`, with a section recording the recovery and the evidence that it **is** resolved on main: `docs/issues/README.md` carries 0 generated rows, `.gitattributes` marks `docs/issues/open.md merge=union`, and five concurrent rebases on 2026-09-02 produced no conflict in that file.

## 0632 / 0640 — pointer dropped

Both ids are reserved on origin, but no file has ever existed on any branch:

```
git log --all -S"id: 632" -- docs/issues/   ->  nothing
```

The citation pointed at nothing and always had. The paragraph it hung off already carries the substance — a manifest-reading sweep looks complete while half the tree is red, so build the candidates — and loses nothing without the reference.

## Deliberately not touched

`book/src/getting-started/zephyr.md` cites **0940**, whose file is in open PR #151 and resolves when that merges. Removing a citation because its issue is still in flight would be the wrong fix.

## Verification

The scan now reports **1** dangling ref (the in-flight 0940) where it reported 4. `check-issue-index`, `check-issue-ids` (959 issues) and `check-doc-refs` all green.

Reusable scan: match `issues?[- ]#?(\d{4})` in `CLAUDE.md`, `AGENTS.md`, `docs/**` and `book/**`; compare against filenames in `docs/issues/` and `archived/`.

## Still open

The gap that allowed this is not closed: no gate checks prose issue references. The scan above is the basis for one, left unfiled here rather than bundled into a docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe