### PR TITLE
fix(#0991): a clean build of an entity-declaring image derives the wrong payload basis

### DIFF
--- a/cmake/NanoRosMessageBounds.cmake
+++ b/cmake/NanoRosMessageBounds.cmake
@@ -718,6 +718,30 @@ function(_nros_bounds_join_subscribed _frag _ceiling
     # The image registered components but at least one declared no `ENTITIES`,
     # so W9 refused for the whole image. Nothing was declared that this join can
     # narrow to; the pre-W9 state, and it keeps the pre-W9 answer.
+    #
+    # Issue 0991 -- SAY SO when the refusal is the FIRST-CONFIGURE placeholder
+    # rather than a real one. The producer (`nano_ros_entry()`) runs later in
+    # this configure than this reader, so on a clean build dir the fragment is
+    # always the placeholder and the basis is always `closure`. That is a safe
+    # over-approximation for correctness and NOT safe for a part that is nearly
+    # full: on the mr-canhubk344 island it sets the small class from a linked-
+    # only type and the image overflows RAM by 103160 bytes at LINK, naming a
+    # byte count and no knob. The recovery is one more configure, which no
+    # error message used to state.
+    if(NOT NROS_ENTITY_INVENTORY_STATUS STREQUAL "derived"
+       AND DEFINED NROS_ENTITY_INVENTORY_REASON
+       AND NROS_ENTITY_INVENTORY_REASON STREQUAL "no entity inventory composed yet")
+        message(STATUS
+            "nros: the entity inventory has not been composed in this build dir "
+            "yet, so the payload classes derive over the LINKED CLOSURE this "
+            "pass -- an over-approximation.\n"
+            "  This is expected on a CLEAN build dir and resolves itself: the "
+            "fragment is written at the end of this configure and the NEXT "
+            "configure derives over the SUBSCRIBED set instead.\n"
+            "  If this image is memory-tight, that first over-approximation can "
+            "fail to LINK (issue 0991). Configure again before reading a link "
+            "error as a sizing problem.")
+    endif()
     if(NOT NROS_ENTITY_INVENTORY_STATUS STREQUAL "derived")
         set(${_o_basis} "closure" PARENT_SCOPE)
         return()

--- a/docs/issues/0991-a-clean-build-of-an-entity-declaring-image-does-not-link.md
+++ b/docs/issues/0991-a-clean-build-of-an-entity-declaring-image-does-not-link.md
@@ -1,0 +1,97 @@
+---
+id: 991
+title: "A clean build of an entity-declaring image derives the WRONG payload basis and does not link"
+status: open
+area: cmake
+severity: high
+related: [0965, 0940, phase-403]
+---
+
+# The first configure always answers `closure`, and on a small part that does not fit
+
+## What happens
+
+phase-403 W9's producer (`nano_ros_entry()`) runs LATER in a configure than
+W8's reader (`nros_derive_message_bound_knobs`, reached from
+`nros_find_interfaces`). The reader therefore reads the fragment the PREVIOUS
+configure wrote. On a clean build dir there is no previous configure, so it
+reads the placeholder:
+
+    set(NROS_ENTITY_INVENTORY_STATUS "refused")
+    set(NROS_ENTITY_INVENTORY_REASON "no entity inventory composed yet")
+
+and falls back to `NROS_MESSAGE_BOUNDS_BASIS "closure"`.
+
+`NanoRosMessageBounds.cmake` calls that fallback an over-approximation "in the
+safe direction". It is safe for CORRECTNESS. It is not safe for a part that is
+nearly full, and that is the case the whole derivation exists to serve.
+
+## Measured, mr-canhubk344 island
+
+Reproduced in TWO independent, freshly created build dirs. Identical byte count
+both times:
+
+    ld.bfd: region `RAM' overflowed by 103160 bytes
+
+Because the closure basis sets the small payload class from a
+`std_msgs/Float64MultiArray` the image links through `geometry_msgs` and never
+receives:
+
+| configure | basis | small class | result |
+| --- | --- | ---: | --- |
+| 1st (clean build dir) | `closure` | 1496 | RAM overflow by 103160 B, no link |
+| 2nd (same dir) | `subscribed` | 880 | links; RAM 98.83%, DTCM 68.15% |
+
+The image declares 28 entities across four components and the fragment resolves
+correctly -- `NROS_ENTITY_INVENTORY_STATUS "derived"`,
+`NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved"`, 9 subscribed types,
+`NROS_DERIVED_EXECUTOR_MAX_CBS 14`. Nothing is wrong with the declaration. The
+first configure simply cannot see it.
+
+## Why the documented recovery does not fire
+
+The module says the fragment's rewrite "re-runs cmake". Empirically a single
+`west build` on a clean dir does NOT reach a second configure before linking:
+it configures once, writes the real fragment at the end of that configure, then
+runs ninja, which builds and fails at link. A later explicit configure over the
+same dir does flip the basis and the image links.
+
+So the lag closes eventually, but not within the build that first needs it.
+
+## Why it is worse than a slow convergence
+
+1. It fails at LINK, far from the cause, naming a byte count and no knob. The
+   phase-403 message chain -- "a bound must EXIST before a buffer can be sized
+   from it" -- does not appear, because every bound does exist. Only the BASIS
+   is wrong.
+2. The failure is order-dependent, so it reproduces for a new contributor and
+   for CI (both start clean) and NOT for anyone with a warm build dir. That is
+   the worst distribution for a bug.
+3. It punishes exactly the images the feature targets. An image with slack in
+   RAM never notices; an image tight enough to need derived payload classes
+   cannot build.
+
+## Options
+
+1. **Compose the entity inventory before the bound reader runs.** Removes the
+   lag rather than tolerating it. Biggest change; the producer currently has to
+   run after every `nano_ros_node_register()`.
+2. **Make the producer force a reconfigure when the fragment's answer CHANGES**,
+   so the pass that first learns the subscribed set is followed by one that uses
+   it, inside the same `west build`.
+3. **Refuse rather than over-approximate when the fragment is a placeholder AND
+   the image declares entities.** A clear "configure again" beats a link error
+   naming 103160 bytes. Cheapest, and honest, but leaves two passes as the
+   contract.
+
+Option 3 is the smallest correct step and option 2 is what a user would want.
+Whichever lands, the acceptance test is a CLEAN build dir: build once, from
+nothing, and require a link.
+
+## Not covered
+
+No gate builds an entity-declaring image from a clean build dir and asserts it
+links. The existing knob gates assert the DERIVED VALUES, which are right --
+they are read after the fragment exists. This is the same shape as 0963 and
+0896: a mechanism that is correct and, on the path a real user takes, not
+reached.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -79,5 +79,7 @@ fails if this block drifts.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0988** (tooling) — No gate runs a hook the way git runs it — with `GIT_DIR` set — so a script that corrupts the caller's repository passes every check See `0988-*`.
+- **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
+- **#0991** (cmake) — A clean build of an entity-declaring image derives the WRONG payload basis and does not link See `0991-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -79,8 +79,6 @@ fails if this block drifts.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0988** (tooling) — No gate runs a hook the way git runs it — with `GIT_DIR` set — so a script that corrupts the caller's repository passes every check See `0988-*`.
-- **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
-- **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0991** (cmake) — A clean build of an entity-declaring image derives the WRONG payload basis and does not link See `0991-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -80,6 +80,7 @@ fails if this block drifts.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0988** (tooling) — No gate runs a hook the way git runs it — with `GIT_DIR` set — so a script that corrupts the caller's repository passes every check See `0988-*`.
 - **#0979** (build, boards) — `just build native`'s Rust stage panics `unknown platform \\`posix\\`: no /posix/nros-platform.toml` — the descriptor root resolves EMPTY, and only under the fixture lane See `0979-*`.
+- **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0991** (cmake) — A clean build of an entity-declaring image derives the WRONG payload basis and does not link See `0991-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
Two commits. #0991 is the subject; #0986 is cherry-picked from PR #196 because without it this branch cannot be pushed with hooks enabled (the hook corrupts the repo it guards, and it reproduced live while preparing this).

## The defect

phase-403 W9's producer (`nano_ros_entry()`) runs LATER in a configure than W8's reader, so on a CLEAN build dir the reader always sees the placeholder fragment and falls back to the closure basis. `NanoRosMessageBounds` calls that an over-approximation "in the safe direction". It is safe for CORRECTNESS and not safe for a part that is nearly full -- which is the case the derivation exists to serve.

Measured on the mr-canhubk344 island, in TWO independent freshly created build dirs, identical byte count both times:

    ld.bfd: region `RAM' overflowed by 103160 bytes

| configure | basis | small class | result |
| --- | --- | ---: | --- |
| 1st (clean dir) | closure | 1496 | RAM overflow by 103160 B, no link |
| 2nd (same dir) | subscribed | 880 | links; RAM 98.83%, DTCM 68.15% |

The small class comes from a `std_msgs/Float64MultiArray` the image links through `geometry_msgs` and never receives. Nothing is wrong with the declaration: 28 entities across four components, status `derived`, 9 subscribed types, `NROS_DERIVED_EXECUTOR_MAX_CBS 14`. The first configure cannot see it.

## Why it is worse than slow convergence

It fails at LINK, far from the cause, naming a byte count and no knob -- the phase-403 message chain never fires, because every bound DOES exist and only the BASIS is wrong.

It reproduces for a new contributor and for CI, both of which start clean, and never for anyone with a warm build dir. That is the worst possible distribution.

And it punishes exactly the memory-tight images the feature targets. An image with RAM to spare never notices.

## What this changes

The smallest correct step, not the whole fix. The reader now distinguishes the FIRST-CONFIGURE placeholder from a real refusal (a component that declared no `ENTITIES`) and states the remedy, so an operator reads "configure again" instead of a 103160-byte link error.

Verified on a clean build -- the message prints immediately above the sizing lines that produce the overflow:

    -- nros: the entity inventory has not been composed in this build dir yet, so
       the payload classes derive over the LINKED CLOSURE this pass ...
       If this image is memory-tight, that first over-approximation can fail to
       LINK (issue 0991). Configure again before reading a link error as a
       sizing problem.
    -- nros:   small payload class 1496 B -> NROS_SUBSCRIBER_BUFFER_SIZE

## Deliberately not attempted

Composing the inventory before the reader runs, or forcing a reconfigure when the fragment's answer changes. Both are real changes to configure ordering and belong with someone measuring them rather than reasoning about them. docs/issues/0991 carries both, plus the acceptance test either needs: a CLEAN build dir, built once, required to link.

No gate does that today. The existing knob gates assert the derived VALUES, which are right -- they run after the fragment exists. Same shape as 0963 and 0896: a mechanism that is correct and, on the path a real user takes, not reached.

## Gates

`message-bound-knobs` 80 assertions, `entity-inventory-knobs` 27. Pushed with hooks ENABLED and green.