### PR TITLE
ci(queue): sync from a WORKSPACE — the root is not one

### DIFF
--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -97,9 +97,24 @@ jobs:
           source ./activate.sh
           just setup-launch-resolve
 
-      - name: nros sync (writes the leaf `nros-patch.toml` includes)
+      # Run from a WORKSPACE, not the repo root. `nros sync` at the root fails —
+      #
+      #   Error: sync: no `src/<pkg>/package.xml` and no `package.xml` at root
+      #          … expected colcon-style workspace or single-pkg dir
+      #
+      # — which is what the first attempt at this step did, because the remedy
+      # the leaf-include gate prints is `nros sync` with no directory. The
+      # CENTRAL patch is written to `<checkout>/nros-patch.toml` by ANY
+      # workspace's sync (`ws.rs` CENTRAL_PATCH_FILE), so one workspace suffices
+      # and every one of the 54 leaves then resolves its include.
+      #
+      # Verified locally: with the root file deleted, `cd examples/workspaces/
+      # rust && nros sync` recreated it BYTE-IDENTICAL to the committed-era one,
+      # `leaf-config-includes.py` went green, and no tracked file changed.
+      - name: nros sync (writes the central `nros-patch.toml` the leaves include)
         run: |
           source ./activate.sh
+          cd examples/workspaces/rust
           nros sync
 
       - name: just ci l3


### PR DESCRIPTION
Follow-up to #204, which merged before I could correct it.

The merge group ran #204 and moved the failure two steps on. Doctor, CLI build and resolver build all pass; `nros sync` fails:

```
Error: sync: no `src/<pkg>/package.xml` and no `package.xml` at root
       … expected colcon-style workspace or single-pkg dir
```

I wrote `nros sync` bare because that is the remedy the leaf-include gate prints — and that remedy assumes you are standing in a workspace. The repo root is not one.

The **central** patch is written to `<checkout>/nros-patch.toml` by *any* workspace's sync (`ws.rs` `CENTRAL_PATCH_FILE`), so one workspace suffices and all 54 leaves then resolve their include.

**Verified locally rather than guessed:** with the root file moved away, `cd examples/workspaces/rust && nros sync` recreated it **byte-identical** to the one that had sat there since July, `leaf-config-includes.py` went green, and `git status` showed no tracked file changed.

Progress on the runner lane, for the record:

| step | before #204 | now |
| --- | --- | --- |
| Verify runner labels | pass | pass |
| Build nros CLI | — | pass |
| Build nros-launch-resolve | — | pass |
| nros sync | — | **this PR** |
| just ci l3 | fail (leaf includes) | not yet reached |

Still not claiming L3 passes: `just ci l3` needs the freertos / nuttx / threadx cross toolchains, which the `nros-sdk-zephyr,nros-big` labels do not assert, and I cannot run it from here — the runner is a different machine.