### PR TITLE
docs(#0963): the inventory IS consumed now — the blocker is unbounded types

### DIFF
--- a/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
+++ b/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
@@ -24,7 +24,57 @@ Measured on the island entry: 11 inventories, 84 types, 60 bounded.
 
 ## What consumes it
 
-Nothing.
+**Nothing, when this was filed. That is no longer true — measured 2026-09-02.**
+
+`nros_cargo_build.cmake` loads the fragments (`_nros_load_derived_message_bounds`)
+and resolves `NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE`, `..._SUBSCRIBER_LARGE_SIZE`,
+`..._MAX_LARGE_SUBSCRIBERS` and `..._SUBSCRIPTION_BUFFER_SIZE` through
+`_nros_resolve_derivable_knob`, the same ladder `NROS_EXECUTOR_MAX_CBS` uses.
+phase-403 W8/W9 built that while this issue stayed open.
+
+**The transport works end to end.** On `examples/workspaces/mixed`, after a full
+build, a reconfigure finds 10 `nros_message_bounds.cmake` fragments and reads
+them. The one-configure lag the fragments carry ("still a build-time output ...
+the numbers apply from the next configure") RESOLVES; it is not a permanent
+stall.
+
+## The blocker moved: the data refuses, and the refusal is right
+
+What the consumer now prints on that workspace is not silence but a reasoned
+abstention:
+
+```
+nros: message-bound sizing REFUSED -- every size knob keeps its configured value.
+  16 of 35 types in the linked interface closure carry no bound:
+    action_msgs/msg/GoalStatusArray (unbounded): status_list (sequence<T>)
+    example_interfaces/msg/String (unbounded): data (string)
+    example_interfaces/msg/*MultiArray (unbounded): layout.dim, data
+    ... 16 total
+  Deriving a class size over only the bounded types would publish a maximum a
+  real sample can exceed, which is a SILENT BufferTooSmall drop on the C/C++
+  arena dispatch path.
+```
+
+Fifteen of the sixteen are `example_interfaces` — the `*MultiArray` family,
+`String`, `WString`, `MultiArrayDimension`, `MultiArrayLayout` — plus
+`action_msgs/GoalStatusArray`. These are unbounded in their own `.msg`
+definitions, so no amount of wiring fixes them.
+
+**So the next action is not "wire a consumer".** It is one of:
+
+* **bound them** in `nros-codegen.toml` (RFC-0033 `cap`), which runs into
+  [issue 0962](0962-nested-bounded-sequences-cost-the-product-of-their-caps.md):
+  a bound over nested bounded sequences is the PRODUCT of the caps, so a uniform
+  cap does not terminate at a usable number;
+* **narrow the closure**, so an image pays only for the types it actually links
+  rather than everything `example_interfaces` ships — the `mixed` workspace uses
+  a handful of these and the closure carries all sixteen;
+* or **accept the refusal** for images with unbounded types and let the knobs
+  stay hand-set there, which is what happens today and is at least honest.
+
+Whoever takes it should re-read this section rather than the one above: the
+"nothing consumes it" framing sent this issue's severity to `high` and is now
+the wrong problem.
 
 ## What that costs, measured rather than argued
 

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1115,7 +1115,7 @@ The line now prints on `mixed`:
     nano-ros: queryable table sized from the declaration — infrastructure none,
     application count undeclared (no model here describes wiring)
 
-**Delivery is PARTIAL, and that is not a saving yet.** After a full rebuild the
+**Delivery is PARTIAL, and NO SAVING IS MEASURED.** After a full rebuild the
 `ZPICO_MAX_QUERYABLES` the units actually compiled are:
 
 | cargo root | value |
@@ -1124,7 +1124,13 @@ The line now prints on `mixed`:
 | `nros_ws_runtime_*` (a second unit) | 32 |
 | `nano-ros_*` (repo-root dir, 4 units) | 32 |
 
-So one unit fell 32 -> 8 slots and five did not. The env reaches the umbrella's
+So one unit sits at 8 and five at 32. **Whether the 8 is the env's doing is NOT
+established** — 8 is also the non-hosted default, and the attempted before/after
+build measured the same configuration twice (the revert silently did not apply,
+so both halves ran WITH the fix and both reported `SERVICE_BUFFERS` = 36,032).
+The causal claim is withdrawn rather than repaired here; what IS verified is that
+the status line was absent on every configure before the fix and present after,
+which is the ordering defect itself. The env reaches the umbrella's
 `zpico-sys` and not the other instantiations, which are separate cargo units
 under a different workspace root (issue 0616's shape: a `--target-dir` serves one
 root, and `-C metadata` keys a unit by the path it was reached by). Sizing one of


### PR DESCRIPTION
0963 says **"What consumes it: Nothing"** and carries severity `high` on that
basis. True when filed; not true now. phase-403 W8/W9 built the consumers while
the issue stayed open.

`nros_cargo_build.cmake` loads the fragments (`_nros_load_derived_message_bounds`)
and resolves four size knobs through `_nros_resolve_derivable_knob` — the same
ladder `NROS_EXECUTOR_MAX_CBS` uses.

## The transport works end to end

Measured on `examples/workspaces/mixed`, not read: after a full build, a
reconfigure finds **10** `nros_message_bounds.cmake` fragments and reads them.
The one-configure lag they carry — *"still a build-time output … the numbers
apply from the next configure"* — **resolves** rather than stalling.

Worth checking specifically after W5.g, where a consumer that ran before its
producer meant an export never arrived anywhere. This one is not that.

## The blocker moved: the data refuses, and the refusal is correct

```
nros: message-bound sizing REFUSED -- every size knob keeps its configured value.
  16 of 35 types in the linked interface closure carry no bound:
    action_msgs/msg/GoalStatusArray (unbounded): status_list (sequence<T>)
    example_interfaces/msg/String (unbounded): data (string)
    example_interfaces/msg/*MultiArray (unbounded): layout.dim, data
  Deriving a class size over only the bounded types would publish a maximum a
  real sample can exceed — a SILENT BufferTooSmall on the C/C++ arena path.
```

Fifteen of sixteen are `example_interfaces`; one is `action_msgs`. All are
unbounded in their own `.msg` definitions, so **no amount of wiring fixes them**.

## Next action is one of three, and it is a real choice

- **Bound them** via `nros-codegen.toml` (RFC-0033 `cap`) — runs into issue
  **0962**: nested bounded sequences cost the *product* of their caps, so a
  uniform cap does not terminate at a usable number.
- **Narrow the closure**, so an image pays only for the types it links rather
  than everything `example_interfaces` ships.
- **Accept the refusal** and leave those knobs hand-set — which is today's
  behaviour, and at least honest.

Recorded as three options rather than picked.

## Scope

Documentation only, no code change. The issue's framing aims at a problem that
has since been solved, which is worse than a plain open issue: it sends the next
person to wire something already wired.

`just check fast`: 168 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa