### PR TITLE
ci(queue): sync the leaves L3 builds, and scope the repo-wide guard off it

### DIFF
--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -117,7 +117,38 @@ jobs:
           cd examples/workspaces/rust
           nros sync
 
+      # ...and the THREE leaves this lane actually cross-builds. Each example
+      # leaf is its own consumer: its manifest path-deps `generated/<msg pkg>`,
+      # which `nros sync` produces per leaf and `.gitignore` excludes, so a
+      # clone has none of them.
+      - name: nros sync the leaves L3 builds
+        run: |
+          source ./activate.sh
+          for leaf in examples/qemu-arm-freertos/rust/talker \
+                      examples/qemu-arm-nuttx/rust/talker \
+                      examples/threadx-linux/rust/talker; do
+            nros sync "$leaf"
+          done
+
+      # NROS_SKIP_LEAF_INCLUDE_CHECK, deliberately and narrowly.
+      #
+      # `_require-leaf-includes` is a REPO-WIDE precondition: it walks all 73
+      # tracked `.cargo/config.toml` and 110 manifests and fails if ANY leaf
+      # lacks its gitignored `generated/`. That is right for `just format` and
+      # `build-test-fixtures`, which touch the whole tree (issues 0463/0474).
+      #
+      # L3 cross-builds THREE leaves. Demanding a fully-synced tree to link
+      # three talkers means syncing ~108 unrelated leaves per merge group, and
+      # the guard's whole purpose — turning a cryptic cargo manifest-parse error
+      # into a sentence naming sync — is already served for the leaves that
+      # matter by the step above, which syncs exactly them.
+      #
+      # So the scope of the check is wrong for this lane, not the check. If L3
+      # ever reaches a leaf outside that list, the raw cargo error is the cost,
+      # which is what the bypass documents.
       - name: just ci l3
+        env:
+          NROS_SKIP_LEAF_INCLUDE_CHECK: "1"
         run: |
           source ./activate.sh
           just ci l3


### PR DESCRIPTION
Iteration four on the self-hosted lane. It now reaches its own work.

| step | result |
| --- | --- |
| Verify runner labels | **pass** — `ac0c8cd96` fixed the SDK lookup; the host was fine |
| Build nros CLI | **pass** |
| Build nros-launch-resolve | **pass** |
| nros sync | **pass** — once run from a workspace, not the root (#209) |
| just ci l3 | fails: 108 leaves lack their gitignored `generated/` |

Two things here, and only one is a missing step.

**A missing step.** Each example leaf is its own consumer: its manifest path-deps `generated/<msg pkg>`, produced per leaf by `nros sync` and gitignored, so a clone has none. The three leaves L3 cross-builds are now synced explicitly (verified locally — all three sync clean).

**A scope mismatch.** The other 105 are not missing provisioning. `_require-leaf-includes` is *repo-wide*: it walks all 73 tracked `.cargo/config.toml` and 110 manifests and fails if **any** leaf lacks `generated/`. Correct for `just format` and `build-test-fixtures`, which touch the whole tree (issues 0463/0474). L3 links **three talkers**. Demanding a fully-synced tree for that means syncing ~108 unrelated leaves per merge group — and the guard's purpose, turning a cryptic cargo manifest-parse error into a sentence naming sync, is already served for the leaves that matter by the step that syncs exactly them.

So `NROS_SKIP_LEAF_INCLUDE_CHECK=1` on that one step, narrowly, with the reason in the file. If L3 ever reaches a leaf outside the three, the raw cargo error is the cost — which is what the bypass documents.

**Still not claiming L3 passes.** It needs the freertos / nuttx / threadx cross toolchains, which the `nros-sdk-zephyr,nros-big` labels do not assert, and the merge group is the only place this executes — I can't run it from here.

`just check fast`: 168/168.