### PR TITLE
fix(phase-392 W5.g): deliver the entity facts to every cargo root, not one

### DIFF
--- a/cmake/NanoRosEntityFacts.cmake
+++ b/cmake/NanoRosEntityFacts.cmake
@@ -96,6 +96,64 @@ function(nros_record_entity_facts _model)
     endif()
 endfunction()
 
+# nros_entity_facts_env_deferred(<target>)
+#
+# Schedule `nros_entity_facts_env` for the END of the top-level scope, once per
+# target. Use this from anywhere that imports a Corrosion crate; call the
+# immediate form only if you can prove every `nano_ros_add_entry()` has already
+# run, which almost nothing can.
+#
+# WHY DEFERRED (phase-392 W5.g). The facts are accumulated by
+# `nros_record_entity_facts`, which runs inside `nano_ros_add_entry()` — and an
+# entry is declared LAST in a configure by design ("the first point guaranteed
+# to be AFTER every nano_ros_node_register()"). Every caller that applies the env
+# inline therefore reads an EMPTY accumulator. Traced on
+# `examples/workspaces/mixed`: the consumer logged `seen=<empty>` before all
+# seven producers, so the mechanism had never delivered anything anywhere.
+#
+# WHY EVERY CORROSION TARGET AND NOT JUST THE UMBRELLA (phase-392 W5.g follow-up).
+# `zpico-sys` is compiled once per CARGO ROOT, and a workspace has two: the
+# synthesised umbrella (`nros_ws_runtime`) and the repo root that
+# `nros_cpp-static` / `nros_c-static` import from. Measured on `mixed`: 6
+# `zpico-sys` units, and only the 1 under the umbrella could ever see the env.
+# A pure-C/C++ workspace is worse — `nros_synth_runtime_umbrella` returns early
+# for it, so the umbrella call site does not exist and NO unit was reachable.
+#
+# The DEFER target is the TOP-LEVEL scope, for the reason
+# `_nano_ros_support_schedule_flush` states one module over: deferring to the
+# CURRENT directory fires at the end of whichever package called first, which is
+# the bug rather than a smaller version of it.
+# The target list travels through a GLOBAL property and the deferred call takes
+# NO arguments, which is the shape `_nano_ros_support_flush` uses one module
+# over. That is not a style preference: passing the name as a deferred CALL
+# argument was tried first and the callee received an EMPTY string, so the
+# mapper resolved nothing and `corrosion_set_env_vars` was invoked with one
+# argument ("incorrect arguments for function named"). A global carries the
+# value across the scope boundary intact.
+function(nros_entity_facts_env_deferred _target)
+    get_property(_queued GLOBAL PROPERTY NROS_ENTITY_FACTS_TARGETS)
+    if("${_target}" IN_LIST _queued)
+        return()
+    endif()
+    set_property(GLOBAL APPEND PROPERTY NROS_ENTITY_FACTS_TARGETS "${_target}")
+    get_property(_scheduled GLOBAL PROPERTY NROS_ENTITY_FACTS_FLUSH_SCHEDULED)
+    if(_scheduled)
+        return()
+    endif()
+    set_property(GLOBAL PROPERTY NROS_ENTITY_FACTS_FLUSH_SCHEDULED TRUE)
+    cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
+        CALL _nros_entity_facts_flush)
+endfunction()
+
+function(_nros_entity_facts_flush)
+    get_property(_targets GLOBAL PROPERTY NROS_ENTITY_FACTS_TARGETS)
+    foreach(_t IN LISTS _targets)
+        if(TARGET "${_t}")
+            nros_entity_facts_env("${_t}")
+        endif()
+    endforeach()
+endfunction()
+
 # nros_entity_facts_env(<target>)
 #
 # Attach this configure's accumulated entity facts to a Corrosion target's cargo

--- a/cmake/NanoRosRuntimeCrate.cmake
+++ b/cmake/NanoRosRuntimeCrate.cmake
@@ -327,8 +327,7 @@ nros_armv8r_cflags_env(nros_ws_runtime-static)
     # current one would fire at the end of whichever scope called first, which
     # is the bug rather than a smaller version of it.
     include("${NANO_ROS_ROOT}/cmake/NanoRosEntityFacts.cmake")
-    cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
-        CALL nros_entity_facts_env nros_ws_runtime-static)
+    nros_entity_facts_env_deferred(nros_ws_runtime-static)
     if(NOT TARGET nros_ws_runtime-static)
         message(FATAL_ERROR
             "nros_synth_runtime_umbrella: Corrosion did not create "

--- a/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
+++ b/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
@@ -24,7 +24,57 @@ Measured on the island entry: 11 inventories, 84 types, 60 bounded.
 
 ## What consumes it
 
-Nothing.
+**Nothing, when this was filed. That is no longer true — measured 2026-09-02.**
+
+`nros_cargo_build.cmake` loads the fragments (`_nros_load_derived_message_bounds`)
+and resolves `NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE`, `..._SUBSCRIBER_LARGE_SIZE`,
+`..._MAX_LARGE_SUBSCRIBERS` and `..._SUBSCRIPTION_BUFFER_SIZE` through
+`_nros_resolve_derivable_knob`, the same ladder `NROS_EXECUTOR_MAX_CBS` uses.
+phase-403 W8/W9 built that while this issue stayed open.
+
+**The transport works end to end.** On `examples/workspaces/mixed`, after a full
+build, a reconfigure finds 10 `nros_message_bounds.cmake` fragments and reads
+them. The one-configure lag the fragments carry ("still a build-time output ...
+the numbers apply from the next configure") RESOLVES; it is not a permanent
+stall.
+
+## The blocker moved: the data refuses, and the refusal is right
+
+What the consumer now prints on that workspace is not silence but a reasoned
+abstention:
+
+```
+nros: message-bound sizing REFUSED -- every size knob keeps its configured value.
+  16 of 35 types in the linked interface closure carry no bound:
+    action_msgs/msg/GoalStatusArray (unbounded): status_list (sequence<T>)
+    example_interfaces/msg/String (unbounded): data (string)
+    example_interfaces/msg/*MultiArray (unbounded): layout.dim, data
+    ... 16 total
+  Deriving a class size over only the bounded types would publish a maximum a
+  real sample can exceed, which is a SILENT BufferTooSmall drop on the C/C++
+  arena dispatch path.
+```
+
+Fifteen of the sixteen are `example_interfaces` — the `*MultiArray` family,
+`String`, `WString`, `MultiArrayDimension`, `MultiArrayLayout` — plus
+`action_msgs/GoalStatusArray`. These are unbounded in their own `.msg`
+definitions, so no amount of wiring fixes them.
+
+**So the next action is not "wire a consumer".** It is one of:
+
+* **bound them** in `nros-codegen.toml` (RFC-0033 `cap`), which runs into
+  [issue 0962](0962-nested-bounded-sequences-cost-the-product-of-their-caps.md):
+  a bound over nested bounded sequences is the PRODUCT of the caps, so a uniform
+  cap does not terminate at a usable number;
+* **narrow the closure**, so an image pays only for the types it actually links
+  rather than everything `example_interfaces` ships — the `mixed` workspace uses
+  a handful of these and the closure carries all sixteen;
+* or **accept the refusal** for images with unbounded types and let the knobs
+  stay hand-set there, which is what happens today and is at least honest.
+
+Whoever takes it should re-read this section rather than the one above: the
+"nothing consumes it" framing sent this issue's severity to `high` and is now
+the wrong problem.
 
 ## What that costs, measured rather than argued
 

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1115,7 +1115,7 @@ The line now prints on `mixed`:
     nano-ros: queryable table sized from the declaration — infrastructure none,
     application count undeclared (no model here describes wiring)
 
-**Delivery is PARTIAL, and that is not a saving yet.** After a full rebuild the
+**Delivery is PARTIAL, and NO SAVING IS MEASURED.** After a full rebuild the
 `ZPICO_MAX_QUERYABLES` the units actually compiled are:
 
 | cargo root | value |
@@ -1124,7 +1124,13 @@ The line now prints on `mixed`:
 | `nros_ws_runtime_*` (a second unit) | 32 |
 | `nano-ros_*` (repo-root dir, 4 units) | 32 |
 
-So one unit fell 32 -> 8 slots and five did not. The env reaches the umbrella's
+So one unit sits at 8 and five at 32. **Whether the 8 is the env's doing is NOT
+established** — 8 is also the non-hosted default, and the attempted before/after
+build measured the same configuration twice (the revert silently did not apply,
+so both halves ran WITH the fix and both reported `SERVICE_BUFFERS` = 36,032).
+The causal claim is withdrawn rather than repaired here; what IS verified is that
+the status line was absent on every configure before the fix and present after,
+which is the ordering defect itself. The env reaches the umbrella's
 `zpico-sys` and not the other instantiations, which are separate cargo units
 under a different workspace root (issue 0616's shape: a `--target-dir` serves one
 root, and `-C metadata` keys a unit by the path it was reached by). Sizing one of

--- a/packages/api/nros-c/CMakeLists.txt
+++ b/packages/api/nros-c/CMakeLists.txt
@@ -145,6 +145,26 @@ nros_riscv64_rustflags_env(nros_c-static)
 # phase-372 W1 — the cortex-r52 FPU cflags, same class one arch over.
 nros_armv8r_cflags_env(nros_c-static)
 
+# phase-392 W5.g follow-up — the entity figures the RMW sizes its queryable
+# table and payload classes from.
+#
+# HERE, and not only on the workspace umbrella, because `zpico-sys` is compiled
+# once per CARGO ROOT and this staticlib imports from the REPO ROOT while the
+# umbrella imports from its own synthesised one. Measured on
+# `examples/workspaces/mixed`: 6 `zpico-sys` units, of which only the umbrella's
+# could ever see the env. A pure-C/C++ workspace never even reaches the umbrella
+# call site (`nros_synth_runtime_umbrella` returns early for it), so no unit was
+# reachable at all — which is why W5.g found the delivery missing in every
+# workspace it checked.
+#
+# DEFERRED: the accumulator is filled by `nano_ros_add_entry()`, which runs long
+# after this file. Applying it inline reads an empty set, which is the W5.g
+# defect itself.
+# Relative to THIS file, not ${NANO_ROS_ROOT} — see the note above.
+include("${CMAKE_CURRENT_LIST_DIR}/../../../cmake/NanoRosEntityFacts.cmake")
+nros_entity_facts_env_deferred(nros_c-static)
+
+
 # ---- In-tree variant header (Phase 137) ----
 # `nros-c`'s build.rs writes the per-build `nros_config_generated.h` to
 # `${CORROSION_BUILD_DIR}/nros_config_generated.h` (== this file's

--- a/packages/api/nros-cpp/CMakeLists.txt
+++ b/packages/api/nros-cpp/CMakeLists.txt
@@ -70,6 +70,26 @@ nros_riscv64_rustflags_env(nros_cpp-static)
 # phase-372 W1 — the cortex-r52 FPU cflags, same class one arch over.
 nros_armv8r_cflags_env(nros_cpp-static)
 
+# phase-392 W5.g follow-up — the entity figures the RMW sizes its queryable
+# table and payload classes from.
+#
+# HERE, and not only on the workspace umbrella, because `zpico-sys` is compiled
+# once per CARGO ROOT and this staticlib imports from the REPO ROOT while the
+# umbrella imports from its own synthesised one. Measured on
+# `examples/workspaces/mixed`: 6 `zpico-sys` units, of which only the umbrella's
+# could ever see the env. A pure-C/C++ workspace never even reaches the umbrella
+# call site (`nros_synth_runtime_umbrella` returns early for it), so no unit was
+# reachable at all — which is why W5.g found the delivery missing in every
+# workspace it checked.
+#
+# DEFERRED: the accumulator is filled by `nano_ros_add_entry()`, which runs long
+# after this file. Applying it inline reads an empty set, which is the W5.g
+# defect itself.
+# Relative to THIS file, not ${NANO_ROS_ROOT} — see the note above.
+include("${CMAKE_CURRENT_LIST_DIR}/../../../cmake/NanoRosEntityFacts.cmake")
+nros_entity_facts_env_deferred(nros_cpp-static)
+
+
 # ---- Header-only C++ interface library ----
 add_library(nros-cpp-headers INTERFACE)
 add_library(NanoRos::NanoRosCpp ALIAS nros-cpp-headers)


### PR DESCRIPTION
W5.g fixed the **ordering** (consumer ran before its producers) but left the env
reaching a single Corrosion target.

`zpico-sys` is compiled once per **cargo root**, and a workspace has two: the
synthesised umbrella, and the repo root that `nros_cpp-static` / `nros_c-static`
import from. Only the umbrella was fed.

A pure-C/C++ workspace was worse — `nros_synth_runtime_umbrella` returns early
for it, so the single call site did not exist and **no** unit was reachable. That
is W5.g's "c/cpp are by construction" row, and it was not by construction; it was
one missing call.

## Change

`nros_entity_facts_env_deferred(<target>)` is now the one spelling, used at all
three import sites.

Measured on `examples/workspaces/mixed`:

- status line: **1 occurrence → 3**
- every live `zpico-sys` unit compiles `ZPICO_MAX_QUERYABLES = 8`
- the linked entry carries `SERVICE_BUFFERS` = **36,032 B** = 8 × 4504 — sized
  from the declaration, not the 32-slot budget

On a hosted build that reading is unambiguous: an undelivered hosted unit takes
32, a delivered one takes `UNDECLARED_HEADROOM` = 8.

## Two findings worth the next reader's time

**The deferred call must take no arguments.** Passing the target as
`cmake_language(DEFER ... CALL fn "${_target}")` delivered an **empty string** to
the callee, so the mapper resolved nothing and `corrosion_set_env_vars` failed
with *"incorrect arguments for function named"*. The name now travels through a
global property — the shape `_nano_ros_support_flush` already uses one module
over.

**"Five of six units are uncovered" was a stale-artifact reading** — W5.g's own
finding, and the reason this work item existed. The three units still reporting
32 are dated **2026-08-28**, five days before this build. Every unit the current
graph compiles is at 8. Checking mtimes before believing a number is this repo's
own rule (four issues were retracted for skipping it), and it applies to
build-script output, not only to test binaries.

## Not claimed

A byte delta. Establishing one needs a from-scratch build of both configurations,
and the earlier attempt at exactly that measured the same configuration twice.
What is verified here is the delivery and the resulting constant.

`just check fast`: 168 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa