### PR TITLE
docs(#0973): endpoint wiring is AUTHORED — and the issue was never landed

### DIFF
--- a/docs/design/0060-launch-toolchain-three-layers.md
+++ b/docs/design/0060-launch-toolchain-three-layers.md
@@ -213,6 +213,30 @@ directly, so the proc-macro path stays light.
   cannot recur by construction.
 - play_launch gets smaller and its purpose becomes statable in one line.
 
+## Endpoint wiring is AUTHORED, not derived (issue 0973)
+
+A resolved `SystemModel`'s `structure` carries `scopes` and `nodes` from the
+launch tree. It carries `topics`, `services` and `actions` ONLY when a
+`<stem>.contract.yaml` sits beside the launch file: `model_builder` fills those
+three from a `ManifestIndex`, and `manifest_loader` builds that index by reading
+contract files. Nothing derives endpoints from launch XML, because a launch file
+names nodes and does not say what they publish or serve.
+
+Measured in this repo: **93 `*.launch.xml`, 0 `*.contract.yaml`.** So every
+resolved model here describes no wiring, and a consumer asking "how many service
+servers does this system have?" gets an ABSTENTION — which is the designed
+answer, not a failure.
+
+This is written down because the empty maps read exactly like a resolver bug,
+and one instance genuinely was (the loader silently dropped `actions:`, fixed by
+R1-P2). Anyone who finds them empty again should check for contract files before
+searching the resolver.
+
+Consumers that need per-image entity counts without asking users to author 93
+contract files should use the component SIDECAR instead, which records the
+entities a component declares — including action and service clients. That is
+the route issue 0900 took.
+
 ## Invariants to preserve
 
 Two properties, both learned by violating them this week:

--- a/docs/issues/0973-resolved-models-describe-no-endpoint-wiring.md
+++ b/docs/issues/0973-resolved-models-describe-no-endpoint-wiring.md
@@ -1,0 +1,122 @@
+---
+id: 973
+title: "No resolved SystemModel describes endpoint wiring — 0 of 119 carry topics, services or actions"
+status: open
+area: orchestration
+severity: medium
+found: 2026-09-01
+related: [0900, RFC-0060, RFC-0063]
+---
+
+# `structure` carries placement, never endpoints
+
+Measured across every resolved model in the tree:
+
+```
+resolved models        : 119
+describe ANY wiring    :   0
+have an actions block  :   0
+have an action CLIENT  :   0
+```
+
+Every model's `structure` holds `scopes` and `nodes` and nothing else. The
+schema has room for more — `ros_launch_manifest_model`'s `Structure` declares
+`topics: BTreeMap<String, TopicWiring>`, `services` and `actions` (both
+`ServiceWiring`, which carries `server` AND `client` lists) — and all three are
+empty everywhere.
+
+The sharp case: `examples/workspaces/rust/build/nros/models/demo_bringup/
+action_client_model.yaml` resolves `action_client.launch.xml`, whose single node
+`/fibonacci_client` IS an action client. Its `structure` names the scope and the
+node, and has no `actions` block at all.
+
+## Why this is not obviously a bug
+
+`entity_facts.rs` already anticipates it. `describes_wiring()` tests
+`!structure.topics.is_empty() || !services.is_empty() || !actions.is_empty()`,
+and `a_model_that_describes_no_wiring_abstains_on_the_app_count` asserts that a
+model without wiring makes the consumer ABSTAIN rather than report a zero. So
+the code is correct for this state; the question is whether the state is
+intended.
+
+Two readings, and the difference matters:
+
+* **Intended** — a launch file declares nodes, and endpoint wiring is a
+  different layer that only some resolves produce. Then the abstain path is the
+  permanent normal case, and anything wanting endpoint counts must get them
+  elsewhere (the per-component sidecar, which issue 0900 extended for exactly
+  this reason).
+* **A gap** — the resolver can derive wiring and does not, or does and drops it
+  somewhere between layer 2 and the written model. Then `describes_wiring` is
+  guarding a bug rather than a design.
+
+Nothing in the tree distinguishes these, which is itself the problem: a
+consumer cannot tell "this system has no services" from "this model does not
+say".
+
+## What it currently costs
+
+Issue 0900 wanted the action-client count to size the executor arena — 74,240
+bytes against 16,384, ~56.5 KiB of TASK STACK per image. The model is the
+natural source and abstains on all 119, so that path delivers nothing today. The
+fallbacks are a per-component sidecar (which cannot cover cross-compiled
+components — they are unprobeable by construction) and a post-link `nm` gate
+(landed, and reporting 181 over-budgeted images).
+
+More generally, any future sizing that wants "how many X does this image have"
+meets the same wall.
+
+## ANSWERED 2026-09-03 — reading 1. Wiring is AUTHORED, and nobody authors it
+
+Traced through the resolver rather than inferred from the models.
+
+`model_builder.rs` DOES populate `structure.topics` and `structure.services`
+(and, since R1-P2, `structure.actions`). It fills them from `ManifestIndex`,
+which `manifest_loader` builds by reading a **`<stem>.contract.yaml` sitting
+beside each launch file**. Endpoint wiring is a separate authored artifact, not
+something derived from the launch XML.
+
+Counted in this tree:
+
+```
+*.launch.xml            : 93
+*.contract.yaml         :  0
+```
+
+So the models are empty because **nothing declares wiring**, not because the
+resolver drops it. `describes_wiring()` is guarding a design, and the abstain
+path is the permanent normal case until someone authors contracts.
+
+**Reading 2 was true once and is already fixed.** `manifest_loader.rs:255`
+records it: "Previously the loader silently dropped `actions:` — the model's
+`structure.actions` was always empty." That is the exact bug this issue
+suspected, found and repaired by R1-P2 before this issue was filed. Looking for
+it again would have been a second search for a closed defect — which is why this
+was traced to the loader instead of stopping at the empty models.
+
+### What that means for the consumers
+
+Any sizing that wants "how many X does this image have" from the MODEL needs
+contract files to exist first. That is a product decision — 93 of them, hand
+written, describing endpoints that the component sidecar already records — and
+issue 0900 took the other route for exactly this reason: the per-component
+sidecar now carries action and service CLIENTS, and it needs no contract.
+
+So the recommended action is item 3 below (write the design down), NOT item 2.
+Item 2 is struck.
+
+## Work
+
+1. ~~Decide which reading is right.~~ **Done: reading 1, evidenced above.**
+2. ~~If wiring IS meant to be produced: find where it is lost.~~ **Struck.**
+   Nothing is lost; the input does not exist. The one real instance of this
+   (dropped `actions:`) was fixed by R1-P2.
+3. **This is the action.** Say so in RFC-0060 and in `describes_wiring`'s doc
+   comment, so the abstain path reads as the designed outcome rather than as a
+   symptom, and consumers stop being written against it. Name the input a user
+   would have to author (`<stem>.contract.yaml`) so "the model does not say" is
+   actionable rather than merely true.
+
+Found while implementing issue 0900. Filed rather than pursued: the answer
+changes the resolver's contract, and 0900 had already been mis-scoped three
+times by inferring one level too shallow.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -76,6 +76,7 @@ fails if this block drifts.
 - **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a decode, an encode and two heap allocations per take See `0969-*`.
 - **#0970** ([rmw]) — The Cyclone backend borrows Cyclone's generated sertype instead of registering its own, and that — not an upstream gap — is what forces the CDR round trip on publish See `0970-*`.
 - **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it See `0971-*`.
+- **#0973** (orchestration) — No resolved SystemModel describes endpoint wiring — 0 of 119 carry topics, services or actions See `0973-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0988** (tooling) — No gate runs a hook the way git runs it — with `GIT_DIR` set — so a script that corrupts the caller's repository passes every check See `0988-*`.

--- a/packages/cli/nros-cli-core/src/cmd/entity_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_facts.rs
@@ -108,6 +108,20 @@ pub fn facts_from_model(model: &SystemModel) -> BTreeMap<String, String> {
 /// The discriminator is whether ANY wiring was described. If it was, an empty
 /// `services` map is a real zero. If nothing was, the question is unanswered
 /// and this verb says nothing rather than guessing.
+///
+/// **Abstaining is the DESIGNED outcome here, not a symptom (issue 0973).**
+/// Endpoint wiring is AUTHORED, not derived: `model_builder` fills
+/// `structure.{topics,services,actions}` from a `ManifestIndex`, which
+/// `manifest_loader` builds by reading a `<stem>.contract.yaml` beside each
+/// launch file. This tree has 93 `*.launch.xml` and 0 `*.contract.yaml`, so the
+/// maps are empty everywhere and always will be until someone authors contracts.
+///
+/// So a caller must not read the abstain as "the resolver lost something".
+/// Nothing is lost; the input does not exist. (There WAS one real instance of
+/// loss — the loader silently dropped `actions:` — and R1-P2 fixed it.) A
+/// consumer that wants per-image entity counts should use the component
+/// SIDECAR, which records action and service clients and needs no contract
+/// file; that is the route issue 0900 took.
 fn describes_wiring(model: &SystemModel) -> bool {
     !model.structure.topics.is_empty()
         || !model.structure.services.is_empty()


### PR DESCRIPTION
Two things, one of which is embarrassing.

## The issue does not exist on main

0973 was written on 2026-09-01 in `02d7b2093`, on branch `campaign/0900-finding`,
and **that branch never merged**. The other four commits' content reached main by
other PRs, so nothing looked missing. Three docs already cite 0973 by number and
until now pointed at nothing.

Recovered here unchanged, apart from the answer below.

## The substance: it is a design, not a bug

0973 asked whether empty `structure.{topics,services,actions}` is a design or a
bug, and said the answer belonged to whoever owns the resolver seam. Traced, so
it no longer needs anyone to guess.

`model_builder` **does** populate all three — from `ManifestIndex`, which
`manifest_loader` builds by reading a **`<stem>.contract.yaml` beside each launch
file**. Endpoint wiring is an authored artifact; nothing derives it from launch
XML, because a launch file names nodes and never says what they publish or serve.

```
*.launch.xml    : 93
*.contract.yaml :  0
```

The models are empty because nothing declares wiring — not because anything is
lost. `describes_wiring()` guards a design, and the abstain path is permanent
until contracts exist.

## The other reading was true once, and is already fixed

`manifest_loader.rs:255` records it: the loader silently dropped `actions:`, so
`structure.actions` was always empty — repaired by R1-P2 *before* 0973 was filed.

Searching for it again is exactly what "the models are empty" invites, which is
why this was traced to the loader rather than stopped at the models.

## What lands

- Work item 2 **struck** — nothing is lost; the input does not exist.
- Work item 3 **done**: RFC-0060 gains an *"Endpoint wiring is AUTHORED, not
  derived"* section, and `describes_wiring`'s doc comment says the abstain is the
  designed outcome and **names the file a user would have to write**, so "the
  model does not say" becomes actionable rather than merely true.
- Both point a consumer wanting per-image entity counts at the component
  **sidecar**, which needs no contract file — the route issue 0900 took.

No behaviour change. `just check fast`: 168 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa