### PR TITLE
phase-412 W1: the session pools derive from the entity inventory

### DIFF
--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -238,6 +238,8 @@ function(nros_derive_entity_inventory_knobs)
     _nros_entity_publish(NROS_ENTITY_INVENTORY_REASON "")
     _nros_entity_publish(NROS_ENTITY_INVENTORY_COMPONENT_COUNT 0)
     foreach(_v NROS_DERIVED_EXECUTOR_MAX_CBS NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
+               NROS_DERIVED_MAX_SUBSCRIBERS NROS_DERIVED_RMW_SUBSCRIBER_SLOTS
+               NROS_DERIVED_MAX_PUBLISHERS NROS_DERIVED_MAX_QUERYABLES
                NROS_ENTITY_INVENTORY_ENTITY_TOTAL)
         unset(${_v})
         unset(${_v} PARENT_SCOPE)
@@ -334,6 +336,15 @@ function(nros_derive_entity_inventory_knobs)
         _nros_entity_publish(NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
             "${NROS_DERIVED_EXECUTOR_ACTION_CLIENTS}")
     endif()
+    # phase-412 W1 -- the SESSION pools, republished on the same terms: present
+    # only when the whole image declared, absent otherwise, so a consumer reads
+    # a derived value or reads nothing.
+    foreach(_pool NROS_DERIVED_MAX_SUBSCRIBERS NROS_DERIVED_RMW_SUBSCRIBER_SLOTS
+                  NROS_DERIVED_MAX_PUBLISHERS NROS_DERIVED_MAX_QUERYABLES)
+        if(DEFINED ${_pool})
+            _nros_entity_publish(${_pool} "${${_pool}}")
+        endif()
+    endforeach()
     foreach(_kind PUBLISHER SUBSCRIPTION TIMER SERVICE_SERVER SERVICE_CLIENT
                   ACTION_SERVER ACTION_CLIENT GUARD_CONDITION)
         if(DEFINED NROS_ENTITY_COUNT_${_kind})
@@ -413,6 +424,10 @@ if(CMAKE_SCRIPT_MODE_FILE AND
         NROS_ENTITY_INVENTORY_ENTITY_TOTAL
         NROS_DERIVED_EXECUTOR_MAX_CBS
         NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
+        NROS_DERIVED_MAX_SUBSCRIBERS
+        NROS_DERIVED_RMW_SUBSCRIBER_SLOTS
+        NROS_DERIVED_MAX_PUBLISHERS
+        NROS_DERIVED_MAX_QUERYABLES
         NROS_ENTITY_COUNT_PUBLISHER
         NROS_ENTITY_COUNT_SUBSCRIPTION
         NROS_ENTITY_COUNT_TIMER

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -1,0 +1,152 @@
+# Phase 412 — every count and size the image can state about itself
+
+**Status (2026-09-02). Opened from the mr-canhubk344 island audit.** phase-403
+proved an image can derive its own buffer sizes; phase-409 proved the same for
+the `Executor` value. This phase is the campaign that finishes the job: no
+hand-picked count or size in a board `.conf` that the image already knows.
+
+## Why a campaign rather than another knob
+
+The island's board `.conf` was, until this week, twenty-odd numbers a person
+chose. Every one of them is a claim about the image, and every one can be wrong
+in two directions. Too small halts the board; too large costs RAM on a part
+that has 320 KiB. Neither failure names the knob that caused it, and none of the
+numbers carries the reasoning that produced it.
+
+Four of them now derive (phase-403 W8/W9). The audit that followed found the
+rest split cleanly into two groups, and the split is the point of this phase:
+
+* **The number is already computed and published, and nothing consumes it.**
+  Six knobs. No new arithmetic — a consumer and a precedence entry each.
+* **No derivation exists yet.** Six more, each blocked on something specific
+  and nameable.
+
+The first group is the recurring defect this repo keeps producing: a mechanism
+that is correct, tested, and unreachable from a real build. `rx_buffer_hint`
+sized nothing (0896). The bound inventory had no reader (0963). A cap could not
+reach codegen (#152). The entity inventory publishes eight per-kind counts and
+exactly one of them becomes a knob (this phase). Each was found by an audit, not
+by a gate, which is why W4 below exists.
+
+## Where the numbers already are
+
+`nros_entity_inventory_knobs_file` publishes, per configure, for the island:
+
+```
+NROS_ENTITY_INVENTORY_COMPONENT_COUNT 4
+NROS_ENTITY_INVENTORY_ENTITY_TOTAL   28
+NROS_ENTITY_COUNT_SUBSCRIPTION       10
+NROS_ENTITY_COUNT_PUBLISHER          14
+NROS_ENTITY_COUNT_TIMER               4
+NROS_ENTITY_COUNT_SERVICE_SERVER      0
+NROS_ENTITY_COUNT_SERVICE_CLIENT      0
+NROS_ENTITY_COUNT_ACTION_SERVER       0
+NROS_ENTITY_COUNT_ACTION_CLIENT       0
+NROS_ENTITY_COUNT_GUARD_CONDITION     0
+```
+
+Of these, one knob is derived: `NROS_DERIVED_EXECUTOR_MAX_CBS` (14 — the
+subscriptions, timers and service servers that claim a callback slot;
+publishers claim none).
+
+## W1 — wire the six
+
+Each is a `_nros_entity_publish` of a value that is already in the file, plus
+W8's precedence ladder (env > Kconfig/board > derived > crate default) and its
+refusal rule (derive nothing when the inventory's own status is not `derived`).
+
+| knob | island hand-set | published input | derives to |
+| --- | ---: | --- | ---: |
+| `NROS_MAX_SUBSCRIBERS` | 12 | `COUNT_SUBSCRIPTION` | 10 |
+| `NROS_RMW_SUBSCRIBER_SLOTS` | 12 | `COUNT_SUBSCRIPTION` | 10 |
+| `NROS_MAX_PUBLISHERS` | 16 | `COUNT_PUBLISHER` | 14 |
+| `NROS_MAX_QUERYABLES` | 4 | `COUNT_SERVICE_SERVER` | 0 |
+| `NROS_EXECUTOR_MAX_NODES` | 6 | `INVENTORY_COMPONENT_COUNT` | 4 |
+| `NROS_EXECUTOR_ACTION_CLIENTS` | 0 | `COUNT_ACTION_CLIENT` | 0 |
+
+**Two things to settle before wiring, not after.**
+
+`NROS_MAX_SUBSCRIBERS` and `NROS_MAX_QUERYABLES` are ZENOH SESSION limits, not
+executor ones. A session may declare entities the image never registers as
+callbacks — liveliness tokens, an internal queryable for the graph. Read the
+zenoh shim and count what it declares before equating the knob to
+`COUNT_SUBSCRIPTION`; if the shim adds any, the derivation is `count + shim`
+and the shim's contribution must come from the shim rather than from a constant
+written here. Getting this wrong under-counts, which halts the board.
+
+`NROS_EXECUTOR_MAX_NODES` is components, and a component is not always a node:
+a multi-node component would break the equality. Check `nros_components` before
+assuming `COMPONENT_COUNT` is the answer.
+
+**Derived values carry NO headroom, deliberately** (phase-403's rule). Exact
+demand makes the running image a checker of its own declaration: register past
+the table and `NodeError::ExecutorFull` names the knob. That property is only
+worth having if the count is right, which is why the two questions above are
+blocking rather than advisory.
+
+## W2 — the ones with no derivation, and what each is blocked on
+
+Named here so nobody re-audits them, with the blocker rather than a shrug.
+
+| knob | island | blocked on |
+| --- | ---: | --- |
+| `NROS_EXECUTOR_ARENA_SIZE` | 40960 | **phase-403 step 3**, which is blocked on step 2 (QoS depth). Depth MULTIPLIES the bound — 86108 B at depth 10 against 24516 at depth 1 for the same ten subscriptions — and the entity record carries `kind`, `type_name`, `name` and no depth. Defaulting is the worst option: ROS's default is 10, so assuming it inflates tenfold and assuming 1 under-sizes in the unsafe direction |
+| `CONFIG_MAIN_STACK_SIZE` | 16384 | needs frame analysis, not an inventory. **phase-409** established the method (`objdump`, summing every `sub`/`sub.w`/`subw sp`) and the numbers for one call chain; nothing turns that into a knob |
+| `NROS_ZEPHYR_HEAP_SIZE` | 94208 | runtime allocation. No static model, and the honest first step is a high-water reporter, not a derivation |
+| `NROS_GRAPH_CACHE_SIZE` | 4096 | sized by the PEER graph. Not a property of this image and probably never derivable from it |
+| `NROS_MAX_LIVELINESS` | 32 | same — remote peers |
+| `NROS_ZEPHYR_TASK_SLOTS`, `..._TASK_STACK_SIZE` | 5, 8192 | transport tasks, not entities. Derivable in principle from the transport's own declaration; nothing declares it today |
+
+`NROS_SUBSCRIBER_LARGE_SIZE` is a seventh case and a different one: it is
+DELIBERATELY not derived (see `NanoRosMessageBounds`), and on the island it now
+sizes nothing because `MAX_LARGE_SUBSCRIBERS` derives to 0. A number that sizes
+nothing should be deleted from a `.conf`, not derived.
+
+## W3 — the arena, once phase-403 step 2 lands
+
+The arena is the single largest hand-set number on the island (40960 B) and the
+last big one. It is listed here rather than duplicated: **phase-403 owns steps 2
+and 3**, and this phase consumes them. When depth reaches the entity record,
+W3 is the consumer that turns it into `NROS_DERIVED_EXECUTOR_ARENA_SIZE`.
+
+Ordering is not a preference. An under-sized arena halts during entity creation,
+BEFORE the first spin, so 0900's advisory never prints — the failure cannot
+report itself. `MAX_CBS` was the right first consumer for the mirror-image
+reason: it fails at registration with `ExecutorFull`, which names the knob.
+
+## W4 — a gate that fails when a published number has no consumer
+
+The reason this phase exists is that eight counts were published and one was
+read, and no test noticed for a month. The gate asserts the inverse of what the
+current ones assert: not "is the derived value right" — they already check that
+— but "is every published input READ by something".
+
+Concretely: enumerate `NROS_ENTITY_COUNT_*` and `NROS_DERIVED_*` from a fixture
+configure, and fail on a published symbol that no `.cmake` consumes. A new count
+then arrives with either a consumer or a deliberate exemption naming why.
+
+This is the "correct but unreachable" gate proposed during phase-403 and never
+built. Four instances have now been found by hand (0896, 0963, #152, and this
+one). It should stop being an audit.
+
+## Acceptance
+
+1. The island board `.conf` states no NROS count or size that W1 covers, and the
+   image builds and boots with every one of them derived.
+2. Each W1 knob's derived value is READ FROM THE BUILD and compared against the
+   hand-set number it replaces — the value, never the exit code. A cap or a join
+   that silently does nothing has misled this campaign twice already.
+3. W2's table is in the board `.conf` as a comment, so the next person reads the
+   blocker instead of re-deriving the audit.
+4. W4's gate fails on a deliberately unread published symbol, proving it can.
+
+## Known: the first configure derives the wrong basis
+
+`docs/issues/0991`. On a CLEAN build dir the payload classes derive over the
+linked closure, because W9's producer runs later in the configure than W8's
+reader. On the island that over-approximation overflows RAM by 103160 bytes at
+LINK. Every measurement in this phase must therefore be taken from a build that
+has configured at least twice, and W1's acceptance test must state which.
+
+Anything in this phase that adds a knob derived from the entity inventory
+inherits that lag. It is worth fixing before W1 multiplies it by six.

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -49,7 +49,7 @@ Of these, one knob is derived: `NROS_DERIVED_EXECUTOR_MAX_CBS` (14 — the
 subscriptions, timers and service servers that claim a callback slot;
 publishers claim none).
 
-## W1 — wire the six
+## W1 — wire the six. LANDED 2026-09-03, five of six
 
 Each is a `_nros_entity_publish` of a value that is already in the file, plus
 W8's precedence ladder (env > Kconfig/board > derived > crate default) and its
@@ -64,25 +64,92 @@ refusal rule (derive nothing when the inventory's own status is not `derived`).
 | `NROS_EXECUTOR_MAX_NODES` | 6 | `INVENTORY_COMPONENT_COUNT` | 4 |
 | `NROS_EXECUTOR_ACTION_CLIENTS` | 0 | `COUNT_ACTION_CLIENT` | 0 |
 
-**Two things to settle before wiring, not after.**
+**Both blocking questions, answered by reading the code.**
 
-`NROS_MAX_SUBSCRIBERS` and `NROS_MAX_QUERYABLES` are ZENOH SESSION limits, not
-executor ones. A session may declare entities the image never registers as
-callbacks — liveliness tokens, an internal queryable for the graph. Read the
-zenoh shim and count what it declares before equating the knob to
-`COUNT_SUBSCRIPTION`; if the shim adds any, the derivation is `count + shim`
-and the shim's contribution must come from the shim rather than from a constant
-written here. Getting this wrong under-counts, which halts the board.
+*Do the session pools need shim headroom?* No addend, verified rather than
+assumed: `ZenohSubscriber::new` has exactly ONE caller (`create_subscription`),
+and the two things that looked like they might share the pool do not -- the
+graph cache lives in its own `graph_cache.sub` field, liveliness tokens in
+`liveliness[ZPICO_MAX_LIVELINESS]`.
 
-`NROS_EXECUTOR_MAX_NODES` is components, and a component is not always a node:
-a multi-node component would break the equality. Check `nros_components` before
-assuming `COMPONENT_COUNT` is the answer.
+But the RAW per-kind count was still the wrong input, which is what made the
+question worth blocking on. A declared ACTION is one entity that costs several
+session slots:
 
-**Derived values carry NO headroom, deliberately** (phase-403's rule). Exact
-demand makes the running image a checker of its own declaration: register past
-the table and `NodeError::ExecutorFull` names the knob. That property is only
-worth having if the count is right, which is why the two questions above are
-blocking rather than advisory.
+    action server -> 3 queryables + 2 publishers
+    action client -> 1 subscription
+
+Wiring `MAX_QUERYABLES = COUNT_SERVICE_SERVER` would have under-sized every
+image with an action. The multipliers now live beside the calls that decide
+them (`ACTION_SERVER_QUERYABLES`, and new here `ACTION_SERVER_PUBLISHERS`,
+`ACTION_CLIENT_SUBSCRIPTIONS`), held there by `check-infra-queryable-counts`.
+
+Deliberately NOT counted: `PARAM_SERVICE_QUERYABLES` (6) and
+`LIFECYCLE_SERVICE_QUERYABLES` (5). A feature enables those and the inventory
+cannot see it, so counting them would guess. An image carrying either states
+the knob, which is what "the derived value is a DEFAULT" is for.
+
+*Is a component always a node?* One `ComponentNode` is one `Node::create` is
+one name, and the executor keys node slots by NAME -- "a repeated name must
+reuse its record". But `nros_create_node_on` (the bridge) creates TWO nodes per
+bridge, OUTSIDE the component model, so `COMPONENT_COUNT` is a lower bound.
+
+**So `NROS_EXECUTOR_MAX_NODES` is NOT wired.** Under-counting halts the board,
+phase-403's rule is refuse rather than under-derive, and the island would save
+6 -> 4. It moves to W2 with the bridge as its blocker.
+
+**Measured on the island**, both configures (issue 0991):
+
+| knob | hand-set | derived |
+| --- | ---: | ---: |
+| `NROS_MAX_SUBSCRIBERS` | 12 | 10 |
+| `NROS_RMW_SUBSCRIBER_SLOTS` | 12 | 10 |
+| `NROS_MAX_PUBLISHERS` | 16 | 14 |
+| `NROS_MAX_QUERYABLES` | 4 | 0 |
+
+    RAM   324834 (99.13%) -> 312088 (95.24%)   -12746 B
+    DTCM   93744 (71.52%) ->  89320 (68.15%)    -4424 B
+
+17170 bytes, and RAM headroom goes from 0.87% to 4.76%.
+
+## THE RULE W1 COST, and it binds the rest of this phase
+
+**The `-1` DERIVE sentinel is safe only where the consumer supplies its own
+default.** `_nros_resolve_derivable_knob`'s rung 4 deliberately leaves a knob
+UNRESOLVED so the reading build script falls to its own literal
+(`env_usize("ZPICO_MAX_SUBSCRIBERS", 8)`) -- "the one place that literal is
+written". A C compile definition has no such literal. An unresolved knob
+expands to nothing, `-DZPICO_MAX_SUBSCRIBERS=` reaches the compiler, and
+`zpico.c` reports `flexible array member not at end of struct` on a struct
+nobody edited.
+
+It only appears once a knob GAINS the sentinel, because before that Kconfig
+always carried a number. Every knob W2 converts must therefore be checked for a
+consumer with no default of its own, and that check belongs before the switch,
+not after.
+
+## THREE DELIVERY FAILURES, and what they say about W4
+
+W1's derived values were RIGHT at every step -- 10, 10, 14, 0 sat correctly in
+the fragment throughout. All three failures were in DELIVERY, and every gate
+stayed green through all three, because the gates check the inventory and the
+resolver and all three failures were downstream of both:
+
+1. **A second consumer.** The zpico C defines read raw `CONFIG_*`, bypassing the
+   resolver, and ran BEFORE it. Symptom: `size of array 'subscribers' is
+   negative`.
+2. **A name that resolved to empty.** A `foreach` building
+   `NROS_DERIVED_${_pool}` produced `NROS_DERIVED_NROS_MAX_SUBSCRIBERS`, which
+   names nothing; CMake yields EMPTY for an unknown name rather than failing.
+3. **A consumer with no default**, the rule above.
+
+W4 as first written -- "every published symbol has a consumer" -- would have
+caught NONE of them. The symbol had a consumer in all three cases; a different
+consumer was reading around it, or the name never matched, or the value was
+legitimately absent. **The gate that catches all three asserts, per knob, that
+the value reaching the COMPILE equals the value the resolver produced.** That is
+the form W4 should take, and it is now backed by three instances rather than by
+the argument that opened this phase.
 
 ## W2 — the ones with no derivation, and what each is blocked on
 
@@ -95,6 +162,7 @@ Named here so nobody re-audits them, with the blocker rather than a shrug.
 | `NROS_ZEPHYR_HEAP_SIZE` | 94208 | runtime allocation. No static model, and the honest first step is a high-water reporter, not a derivation |
 | `NROS_GRAPH_CACHE_SIZE` | 4096 | sized by the PEER graph. Not a property of this image and probably never derivable from it |
 | `NROS_MAX_LIVELINESS` | 32 | same — remote peers |
+| `NROS_EXECUTOR_MAX_NODES` | 6 | the BRIDGE creates two nodes per bridge outside the component model, so `COMPONENT_COUNT` is a lower bound. Needs the bridge to declare, or the derivation to refuse when one is present |
 | `NROS_ZEPHYR_TASK_SLOTS`, `..._TASK_STACK_SIZE` | 5, 8192 | transport tasks, not entities. Derivable in principle from the transport's own declaration; nothing declares it today |
 
 `NROS_SUBSCRIBER_LARGE_SIZE` is a seventh case and a different one: it is

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -407,6 +407,21 @@ pub struct EntityInventory {
     components: Vec<ComponentEntities>,
 }
 
+/// MIRRORS of the action multipliers in
+/// `nros_node::executor::action`. The CLI cannot depend on `nros-node`, so
+/// these are copies, and `check-infra-queryable-counts` holds each to the
+/// creation calls that decide it -- the same arrangement
+/// `ACTION_SERVER_QUERYABLES` already has in `cmd::entity_facts`.
+///
+/// They exist because a declared action is ONE entity that costs SEVERAL
+/// session slots. An author writing `ENTITIES action_server:...` declares one
+/// thing; the backend opens three queryables and two publishers for it. A pool
+/// sized from the raw per-kind count is short for every image with an action,
+/// and short halts the board.
+const ACTION_SERVER_QUERYABLES: usize = 3;
+const ACTION_SERVER_PUBLISHERS: usize = 2;
+const ACTION_CLIENT_SUBSCRIPTIONS: usize = 1;
+
 /// The knobs an entity inventory can answer, plus how it got there.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DerivedEntityKnobs {
@@ -431,6 +446,29 @@ pub struct DerivedEntityKnobs {
     /// it is the number a human counts, and because the gap between the two is
     /// the finding.
     pub entity_total: usize,
+    /// `NROS_MAX_SUBSCRIBERS` / `NROS_RMW_SUBSCRIBER_SLOTS` -- session
+    /// subscriber slots. Declared subscriptions PLUS the feedback subscription
+    /// each action client opens.
+    ///
+    /// Verified against the shim rather than assumed: `ZenohSubscriber::new`
+    /// has exactly one caller (`create_subscription`), and the two things that
+    /// looked like they might share the pool do not -- the graph cache lives in
+    /// its own `graph_cache.sub` field and liveliness tokens in
+    /// `liveliness[ZPICO_MAX_LIVELINESS]`. So there is no shim addend.
+    pub max_subscribers: usize,
+    /// `NROS_MAX_PUBLISHERS` -- declared publishers plus the feedback and
+    /// status topics each action server publishes.
+    pub max_publishers: usize,
+    /// `NROS_MAX_QUERYABLES` -- a service server IS a queryable, and an action
+    /// server is [`ACTION_SERVER_QUERYABLES`] of them.
+    ///
+    /// Does NOT include the parameter or lifecycle service families
+    /// (`PARAM_SERVICE_QUERYABLES` 6, `LIFECYCLE_SERVICE_QUERYABLES` 5): those
+    /// are per-image infrastructure enabled by a feature this inventory cannot
+    /// see, so counting them here would guess. An image carrying them must
+    /// still state the knob, and that is why this is a DEFAULT rather than a
+    /// ceiling.
+    pub max_queryables: usize,
     /// Per-kind counts across the image, in [`ALL_ENTITY_KINDS`] order.
     pub per_kind: BTreeMap<&'static str, usize>,
     /// Per-component `(pkg, component, entities, slots)`, so the output records
@@ -605,10 +643,25 @@ impl EntityInventory {
             per_component.push((c.pkg.clone(), c.component.clone(), count, slots));
         }
 
+        // phase-412 W1. A declared action is ONE entity that costs SEVERAL
+        // session slots, so the session pools are the per-kind count PLUS the
+        // multipliers held beside the calls that decide them. Reading the raw
+        // count would size every action-carrying image short.
+        let n = |tag: &str| per_kind.get(tag).copied().unwrap_or(0);
+        let max_subscribers = n(EntityKind::Subscription.tag())
+            + n(EntityKind::ActionClient.tag()) * ACTION_CLIENT_SUBSCRIPTIONS;
+        let max_publishers = n(EntityKind::Publisher.tag())
+            + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_PUBLISHERS;
+        let max_queryables = n(EntityKind::ServiceServer.tag())
+            + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_QUERYABLES;
+
         Derivation::Derived(Box::new(DerivedEntityKnobs {
             max_cbs,
             heavy_slots,
             entity_total,
+            max_subscribers,
+            max_publishers,
+            max_queryables,
             per_kind,
             per_component,
         }))
@@ -880,6 +933,29 @@ impl EntityInventory {
                 s.push_str(&format!(
                     "set(NROS_DERIVED_EXECUTOR_ACTION_CLIENTS {})\n",
                     k.heavy_slots
+                ));
+                // phase-412 W1 -- the SESSION pools. Separate from the slot
+                // demand above: a publisher claims no callback slot but does
+                // claim a session slot, and a declared action claims several
+                // of these for the one entity it declares.
+                s.push_str(
+                    "# Session pools. A declared action is ONE entity that costs\n                     # SEVERAL session slots: a server opens 3 queryables and 2\n                     # publishers, a client 1 subscription. The multipliers live\n                     # beside the calls that decide them and are held there by\n                     # check-infra-queryable-counts.\n                     # NOT included: the parameter (6) and lifecycle (5) service\n                     # families, which a feature enables and this inventory cannot\n                     # see. An image carrying them must state the knob -- which is\n                     # why these are DEFAULTS and not ceilings.\n",
+                );
+                s.push_str(&format!(
+                    "set(NROS_DERIVED_MAX_SUBSCRIBERS {})\n",
+                    k.max_subscribers
+                ));
+                s.push_str(&format!(
+                    "set(NROS_DERIVED_RMW_SUBSCRIBER_SLOTS {})\n",
+                    k.max_subscribers
+                ));
+                s.push_str(&format!(
+                    "set(NROS_DERIVED_MAX_PUBLISHERS {})\n",
+                    k.max_publishers
+                ));
+                s.push_str(&format!(
+                    "set(NROS_DERIVED_MAX_QUERYABLES {})\n",
+                    k.max_queryables
                 ));
             }
         }

--- a/packages/core/nros-node/src/executor/action.rs
+++ b/packages/core/nros-node/src/executor/action.rs
@@ -45,6 +45,27 @@ use super::{
 /// gate instead of silently under-sizing every image that declares an action.
 pub const ACTION_SERVER_QUERYABLES: usize = 3;
 
+/// Publishers an action SERVER creates, per action, beyond anything the author
+/// declares: the feedback topic and the status topic (`create_publisher` calls
+/// below). A consumer sizing the backend's publisher table from a declaration
+/// must add these, because an `ENTITIES action_server:...` spec declares ONE
+/// entity and costs two publisher slots.
+///
+/// Same rule as [`ACTION_SERVER_QUERYABLES`], and defined for the same reason:
+/// the number lives next to the calls that decide it, so it cannot drift from
+/// them without failing the gate that ties the two together.
+pub const ACTION_SERVER_PUBLISHERS: usize = 2;
+
+/// Subscriptions an action CLIENT creates, per action: the feedback topic.
+/// Status is polled through the result client rather than subscribed, so this
+/// is one and not two -- check the `create_subscription` calls below before
+/// changing it, not this comment.
+///
+/// The same under-sizing hazard as the two above: `ENTITIES action_client:...`
+/// is one declared entity and one subscriber slot that nothing else accounts
+/// for.
+pub const ACTION_CLIENT_SUBSCRIPTIONS: usize = 1;
+
 // ============================================================================
 // Raw action registration specs
 // ============================================================================

--- a/scripts/check-infra-queryable-counts.py
+++ b/scripts/check-infra-queryable-counts.py
@@ -61,6 +61,26 @@ def action_channels(text):
     return {m.group(1) for m in re.finditer(r"create_service\(&(\w+)_info", text)}
 
 
+def action_server_topics(text):
+    """The DISTINCT topics one action SERVER publishes: feedback and status.
+
+    Counted by the topic each `create_publisher` is handed, not by call sites,
+    for the same reason `action_channels` counts channels: the typed and raw
+    registration arms both appear, so a bare call count doubles.
+    """
+    return {m.group(1) for m in re.finditer(r"create_publisher\(&(\w+)_topic", text)}
+
+
+def action_client_topics(text):
+    """The DISTINCT topics one action CLIENT subscribes to: feedback.
+
+    Same counting rule. If status ever becomes a subscription rather than a
+    poll, this set grows and ACTION_CLIENT_SUBSCRIPTIONS must move with it --
+    which is the whole point of tying them.
+    """
+    return {m.group(1) for m in re.finditer(r"create_subscription\(&(\w+)_topic", text)}
+
+
 def declared(text, name):
     m = re.search(rf"^pub const {name}: usize = (\d+);", text, re.M)
     return int(m.group(1)) if m else None
@@ -220,6 +240,36 @@ def check(root, rmw_dir="packages/rmw"):
                     f"the constant, so the mirror is held here instead "
                     f"(phase-392 W5.d / W5.b2)."
                 )
+    # phase-412 W1 -- an action costs PUBLISHER and SUBSCRIBER slots too, and a
+    # consumer sizing those pools from a declaration has to add them. Same rule
+    # and same failure if they drift: an image declaring an action is sized
+    # short, and under-sizing halts the board rather than warning.
+    try:
+        action_src2 = read(root, ACTION)
+    except OSError as e:
+        problems.append(f"ACTION_SERVER_PUBLISHERS: cannot read {ACTION}: {e}")
+    else:
+        for const, fn in (("ACTION_SERVER_PUBLISHERS", action_server_topics),
+                          ("ACTION_CLIENT_SUBSCRIPTIONS", action_client_topics)):
+            topics = fn(action_src2)
+            want = declared(action_src2, const)
+            if want is None:
+                problems.append(
+                    f"{const} not found in {ACTION} — the count must have exactly "
+                    f"one definition, beside the calls it counts."
+                )
+            elif not topics:
+                problems.append(
+                    f"{const}: found no matching creation calls in {ACTION}; the "
+                    f"pattern this gate counts by has moved."
+                )
+            elif len(topics) != want:
+                problems.append(
+                    f"{const} says {want} but {ACTION} creates {len(topics)} "
+                    f"distinct topic(s): {sorted(topics)}. A pool sized from this "
+                    f"constant would be short for every image declaring an action."
+                )
+
     return problems
 
 
@@ -237,8 +287,17 @@ def _write(root, n_param, n_lc, c_param, c_lc, rmw_line, chans=3, c_action=3,
     # Written TWICE, as the real file does (typed + raw arms), so the probe
     # for "distinct channels, not call sites" is a real one.
     act = f"pub const ACTION_SERVER_QUERYABLES: usize = {c_action};\n"
+    # phase-412 W1 -- the publisher/subscriber multipliers live in the same
+    # file and are checked by the same run, so the fixture has to carry them
+    # or the clean case reports problems that belong to a missing fixture
+    # rather than to a drifted count.
+    act += "pub const ACTION_SERVER_PUBLISHERS: usize = 2;\n"
+    act += "pub const ACTION_CLIENT_SUBSCRIPTIONS: usize = 1;\n"
     for _ in range(2):
         act += "".join(f"    .create_service(&chan{i}_info, qos)\n" for i in range(chans))
+        act += "    .create_publisher(&feedback_topic, qos)\n"
+        act += "    .create_publisher(&status_topic, qos)\n"
+        act += "    .create_subscription(&feedback_topic, qos)\n"
     open(os.path.join(root, ACTION), "w").write(act)
     open(os.path.join(root, "packages/rmw/zenoh/x/src/service.rs"), "w").write(rmw_line + "\n")
     # The CLI mirror lives outside `packages/rmw`, so it is reached by a

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -650,25 +650,67 @@ config NROS_ZENOH_RAWETH_TRANSPORT
 # =============================================================================
 
 config NROS_MAX_PUBLISHERS
-    int "Maximum concurrent publishers"
-    default 8
+    int "Maximum concurrent publishers (-1 = derive)"
+    default -1
     help
       Maximum number of concurrent zenoh publishers in the shim layer.
       Maps to ZPICO_MAX_PUBLISHERS.
 
+      phase-412 W1 -- `-1` DERIVES this from the image's entity inventory
+      (`nano_ros_node_register(... ENTITIES ...)`). Stating a number here WINS
+      and suppresses the derivation, which is a fine thing to do deliberately
+      and a silent cost otherwise.
+
+      The derived value counts what the SESSION opens, which is not what the
+      author declares: a declared action server is one entity that costs three
+      queryables and two publishers, and an action client one subscription.
+      Those multipliers live beside the calls that decide them.
+
+      NOT counted, because a feature enables them and the inventory cannot see
+      it: the parameter (6) and lifecycle (5) service families. An image
+      carrying either must state this knob.
+
 config NROS_MAX_SUBSCRIBERS
-    int "Maximum concurrent subscribers"
-    default 8
+    int "Maximum concurrent subscribers (-1 = derive)"
+    default -1
     help
       Maximum number of concurrent zenoh subscribers in the shim layer.
       Maps to ZPICO_MAX_SUBSCRIBERS.
 
+      phase-412 W1 -- `-1` DERIVES this from the image's entity inventory
+      (`nano_ros_node_register(... ENTITIES ...)`). Stating a number here WINS
+      and suppresses the derivation, which is a fine thing to do deliberately
+      and a silent cost otherwise.
+
+      The derived value counts what the SESSION opens, which is not what the
+      author declares: a declared action server is one entity that costs three
+      queryables and two publishers, and an action client one subscription.
+      Those multipliers live beside the calls that decide them.
+
+      NOT counted, because a feature enables them and the inventory cannot see
+      it: the parameter (6) and lifecycle (5) service families. An image
+      carrying either must state this knob.
+
 config NROS_MAX_QUERYABLES
-    int "Maximum concurrent queryables"
-    default 8
+    int "Maximum concurrent queryables (-1 = derive)"
+    default -1
     help
       Maximum number of concurrent zenoh queryables (service servers) in the shim.
       Maps to ZPICO_MAX_QUERYABLES.
+
+      phase-412 W1 -- `-1` DERIVES this from the image's entity inventory
+      (`nano_ros_node_register(... ENTITIES ...)`). Stating a number here WINS
+      and suppresses the derivation, which is a fine thing to do deliberately
+      and a silent cost otherwise.
+
+      The derived value counts what the SESSION opens, which is not what the
+      author declares: a declared action server is one entity that costs three
+      queryables and two publishers, and an action client one subscription.
+      Those multipliers live beside the calls that decide them.
+
+      NOT counted, because a feature enables them and the inventory cannot see
+      it: the parameter (6) and lifecycle (5) service families. An image
+      carrying either must state this knob.
 
 config NROS_MAX_LIVELINESS
     int "Maximum concurrent liveliness tokens"
@@ -1045,8 +1087,8 @@ config NROS_PARAM_SERVICE_BUFFER_SIZE
       PARAM_SERVICE_BUFFER_SIZE).
 
 config NROS_RMW_SUBSCRIBER_SLOTS
-    int "Static subscription-handle slots (no_std targets)"
-    default 8
+    int "Static subscription-handle slots (no_std targets) (-1 = derive)"
+    default -1
     help
       nros-rmw-cffi keeps subscription handles in a static slot pool on
       no_std targets, since there is no allocator to Box them into. The
@@ -1054,6 +1096,20 @@ config NROS_RMW_SUBSCRIBER_SLOTS
       it as an opaque SubscriberCreationFailed, so this must be at least the
       number of subscriptions the image creates. Pool size is this x 1024
       bytes. Read by nros-rmw-cffi build.rs.
+
+      phase-412 W1 -- `-1` DERIVES this from the image's entity inventory
+      (`nano_ros_node_register(... ENTITIES ...)`). Stating a number here WINS
+      and suppresses the derivation, which is a fine thing to do deliberately
+      and a silent cost otherwise.
+
+      The derived value counts what the SESSION opens, which is not what the
+      author declares: a declared action server is one entity that costs three
+      queryables and two publishers, and an action client one subscription.
+      Those multipliers live beside the calls that decide them.
+
+      NOT counted, because a feature enables them and the inventory cannot see
+      it: the parameter (6) and lifecycle (5) service families. An image
+      carrying either must state this knob.
 
 config NROS_EXECUTOR_ACTION_CLIENTS
     int "Callback slots to budget at ActionClient size (-1 = derive)"

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -344,11 +344,49 @@ function(nros_resolve_knobs)
             "a Kconfig or environment value still wins")
     endif()
 
-    # Zenoh transport tuning (zpico-sys build.rs + zpico.c defines)
+    # phase-412 W1 -- the SESSION pools, on the same ladder and with the same
+    # fallback. These are what the ZENOH SESSION sizes its tables from, not what
+    # the executor sizes its slots from, so they count publishers (which claim
+    # no callback slot) and they add the entities a declared action opens
+    # without declaring.
+    #
+    # Verified against the shim before wiring, not assumed: ZenohSubscriber::new
+    # has exactly ONE caller, and the graph cache and liveliness tokens have
+    # their own storage rather than sharing the subscriber pool -- so there is
+    # no shim addend to carry here.
+    # Written out rather than looped: the knob is NROS_MAX_SUBSCRIBERS and the
+    # derived variable is NROS_DERIVED_MAX_SUBSCRIBERS, so a loop that builds
+    # `NROS_DERIVED_${_pool}` produces NROS_DERIVED_NROS_MAX_SUBSCRIBERS, which
+    # names nothing. It resolves EMPTY rather than failing, the empty reaches
+    # zpico.c, and the diagnostic is
+    #     error: flexible array member not at end of struct
+    # on a struct nobody edited. Spelling both names in full is the point.
+    _nros_resolve_derivable_knob(NROS_MAX_SUBSCRIBERS
+        "${CONFIG_NROS_MAX_SUBSCRIBERS}" NROS_DERIVED_MAX_SUBSCRIBERS
+        "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
+    _nros_resolve_derivable_knob(NROS_RMW_SUBSCRIBER_SLOTS
+        "${CONFIG_NROS_RMW_SUBSCRIBER_SLOTS}" NROS_DERIVED_RMW_SUBSCRIBER_SLOTS
+        "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
+    _nros_resolve_derivable_knob(NROS_MAX_PUBLISHERS
+        "${CONFIG_NROS_MAX_PUBLISHERS}" NROS_DERIVED_MAX_PUBLISHERS
+        "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
+    _nros_resolve_derivable_knob(NROS_MAX_QUERYABLES
+        "${CONFIG_NROS_MAX_QUERYABLES}" NROS_DERIVED_MAX_QUERYABLES
+        "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
+
+    # Zenoh transport tuning (zpico-sys build.rs + zpico.c defines).
+    #
+    # phase-412 W1 -- the three pool defines read NROS_RESOLVED_*, NOT the raw
+    # CONFIG_ value. Those knobs default to the `-1` DERIVE sentinel now, and a
+    # sentinel reaching zpico.c sizes a C array negative:
+    #     error: size of array 'subscribers' is negative
+    # which names neither the knob nor the sentinel. The resolution above must
+    # therefore stay ABOVE this block; it was written below it first, and this
+    # is what that cost.
     if(CONFIG_NROS_RMW_ZENOH)
-        _nros_resolve_knob(ZPICO_MAX_PUBLISHERS "${CONFIG_NROS_MAX_PUBLISHERS}")
-        _nros_resolve_knob(ZPICO_MAX_SUBSCRIBERS "${CONFIG_NROS_MAX_SUBSCRIBERS}")
-        _nros_resolve_knob(ZPICO_MAX_QUERYABLES "${CONFIG_NROS_MAX_QUERYABLES}")
+        _nros_resolve_knob(ZPICO_MAX_PUBLISHERS "${NROS_RESOLVED_NROS_MAX_PUBLISHERS}")
+        _nros_resolve_knob(ZPICO_MAX_SUBSCRIBERS "${NROS_RESOLVED_NROS_MAX_SUBSCRIBERS}")
+        _nros_resolve_knob(ZPICO_MAX_QUERYABLES "${NROS_RESOLVED_NROS_MAX_QUERYABLES}")
         _nros_resolve_knob(ZPICO_MAX_LIVELINESS "${CONFIG_NROS_MAX_LIVELINESS}")
         _nros_resolve_knob(ZPICO_MAX_PENDING_GETS "${CONFIG_NROS_MAX_PENDING_GETS}")
         _nros_resolve_knob(ZPICO_GET_REPLY_BUF_SIZE "${CONFIG_NROS_GET_REPLY_BUF_SIZE}")

--- a/zephyr/cmake/nros_rmw_zenoh.cmake
+++ b/zephyr/cmake/nros_rmw_zenoh.cmake
@@ -192,6 +192,29 @@ zephyr_include_directories(${NROS_REPO_DIR}/packages/rmw/zenoh/zpico-zephyr/incl
 # value the cargo build got. Reading CONFIG_* here would reintroduce issue 0135:
 # an environment override would reach the Rust side only, and the two would
 # disagree about a struct's size with no diagnostic (issue 0316).
+# phase-412 W1 -- a C define has NO default of its own, unlike a Rust build
+# script. `_nros_resolve_derivable_knob`'s rung 4 deliberately leaves a knob
+# UNRESOLVED so the reading build script falls to its own literal
+# (`env_usize("ZPICO_MAX_SUBSCRIBERS", 8)`), which is the one place that literal
+# is written. That contract does not reach here: an unresolved knob expands to
+# nothing, `-DZPICO_MAX_SUBSCRIBERS=` reaches the compiler, and zpico.c reports
+#     error: flexible array member not at end of struct
+# on a struct nobody edited.
+#
+# It only bites since these knobs gained the `-1` DERIVE sentinel: before that
+# Kconfig always carried a number. So the sentinel is safe only where the
+# consumer supplies a default, and this consumer is the exception.
+foreach(_zp MAX_PUBLISHERS MAX_SUBSCRIBERS MAX_QUERYABLES)
+    if(NOT DEFINED NROS_RESOLVED_ZPICO_${_zp} OR
+       "${NROS_RESOLVED_ZPICO_${_zp}}" STREQUAL "")
+        set(NROS_RESOLVED_ZPICO_${_zp} 8)
+        message(STATUS
+            "nros: ZPICO_${_zp} left at the zpico literal default 8 -- nothing "
+            "stated it and the entity inventory derived nothing (a first "
+            "configure on a clean build dir always lands here, issue 0991)")
+    endif()
+endforeach()
+
 zephyr_compile_definitions(
     ZPICO_MAX_PUBLISHERS=${NROS_RESOLVED_ZPICO_MAX_PUBLISHERS}
     ZPICO_MAX_SUBSCRIBERS=${NROS_RESOLVED_ZPICO_MAX_SUBSCRIBERS}


### PR DESCRIPTION
Supersedes #214 (the phase doc), which is folded in here as the first commit.

The entity inventory published eight per-kind counts every configure and exactly ONE became a knob. This wires four more.

| knob | island hand-set | derived |
| --- | ---: | ---: |
| `NROS_MAX_SUBSCRIBERS` | 12 | 10 |
| `NROS_RMW_SUBSCRIBER_SLOTS` | 12 | 10 |
| `NROS_MAX_PUBLISHERS` | 16 | 14 |
| `NROS_MAX_QUERYABLES` | 4 | 0 |

    RAM   324834 (99.13%) -> 312088 (95.24%)   -12746 B
    DTCM   93744 (71.52%) ->  89320 (68.15%)    -4424 B

17170 bytes, and RAM headroom goes from 0.87% to 4.76%. Every derived value matches an independent enumeration of the four components' sources.

## Both blocking questions were answered by reading the code first

**No shim addend.** `ZenohSubscriber::new` has exactly one caller (`create_subscription`); the graph cache lives in its own `graph_cache.sub` field and liveliness tokens in `liveliness[ZPICO_MAX_LIVELINESS]`, so neither shares the subscriber pool.

**But the raw per-kind count was still the wrong input**, which is why the question was worth blocking on. A declared action is ONE entity that costs several session slots -- a server 3 queryables and 2 publishers, a client 1 subscription. `ACTION_SERVER_PUBLISHERS` and `ACTION_CLIENT_SUBSCRIPTIONS` join `ACTION_SERVER_QUERYABLES` beside the calls that decide them, and `check-infra-queryable-counts` now holds all three. I verified the new checks can FAIL rather than pass silently: setting `ACTION_SERVER_PUBLISHERS` to 3 reports the drift, and restoring it goes green.

**`NROS_EXECUTOR_MAX_NODES` is deliberately NOT wired.** A component is one node, but the bridge creates TWO nodes per bridge outside the component model, so `COMPONENT_COUNT` is a lower bound. Under-counting halts the board; it moves to W2 with that blocker named.

## The rule this cost

**The `-1` DERIVE sentinel is safe only where the consumer supplies its own default.** Rung 4 deliberately leaves a knob UNRESOLVED so a Rust build script falls to its own literal -- "the one place that literal is written". A C compile definition has none, so the unresolved knob expands to nothing and `zpico.c` reports `flexible array member not at end of struct` on a struct nobody edited. W2 converts five more knobs onto that sentinel, so the rule is in the phase doc.

## Three delivery failures, none in the arithmetic

The derived values were right at every step -- 10, 10, 14, 0 sat correctly in the fragment throughout -- and **every gate stayed green through all three**, because the gates check the inventory and the resolver and all three were downstream of both:

1. **A second consumer** -- the zpico C defines read raw `CONFIG_*`, bypassing the resolver, and ran before it.
2. **A name that resolved to empty** -- a `foreach` built `NROS_DERIVED_NROS_MAX_SUBSCRIBERS`, which names nothing; CMake yields EMPTY rather than failing.
3. **A consumer with no default** -- the rule above.

W4 as first written ("every published symbol has a consumer") catches NONE of them. The doc now specifies the form that does: assert per knob that the value reaching the COMPILE equals the value the resolver produced. Three instances, not an argument.

## Gates

`just check fast` 168/168. Pushed with hooks enabled -- and the pre-push guard caught a stale `zenoh-pico` submodule pin rewind that `git add -A` had swept in, which is exactly what it is for.

Note the island needs TWO configures (issue #0991); every measurement above is from the second.