### PR TITLE
ci(#0994): schedule the no-verdict sweep — the detector had no caller

### DIFF
--- a/.github/workflows/pr-verdicts.yml
+++ b/.github/workflows/pr-verdicts.yml
@@ -1,0 +1,59 @@
+# Issue 0994 — sweep for pull requests that can never merge because nothing
+# ever ran on them.
+#
+# `scripts/ci/pr-verdict-check.sh` answers this exactly, and has since PR #71
+# sat thirteen hours with auto-merge armed against a check that was never
+# requested. What it lacked was a caller: it is `just pr-verdicts`, in the
+# `setup` group, run only when a human thinks to ask. On 2026-09-02 PR #207 sat
+# silently ineligible — zero check suites for its head sha — and was found by
+# eye, with a working detector one command away.
+#
+# WHY A SCHEDULE AND NOT A GATE
+#
+# The script needs the network and an authenticated `gh`, so it cannot be a
+# gate: gates are buildless, offline and deterministic. It also asks a question
+# about OTHER pull requests, which is not a property of the diff under review.
+# A schedule is the right shape — the failure it looks for is silence, and
+# silence has no event to hook.
+#
+# WHY ITS OWN WORKFLOW RATHER THAN A JOB IN `nightly.yml`
+#
+# nightly is the L3/L4 cross-build matrix: it provisions SDKs and runs QEMU. A
+# 20-second `gh` sweep that must run whether or not that matrix is healthy does
+# not belong inside it — a red build there would take this with it, and this is
+# the check that notices when nothing is reporting.
+#
+# NOT A REQUIRED CHECK, deliberately. It runs on `schedule` and never on
+# `pull_request`, so it can never become a context a PR must satisfy. Adding a
+# scheduled job to the required set is the #0975 deadlock: a check that produces
+# no verdict for a PR blocks it forever.
+name: pr-verdicts
+
+on:
+  schedule:
+    # Twice daily. The failure mode is a PR sitting ineligible, which costs
+    # hours rather than minutes, so this does not need to be frequent — and
+    # each run is one `gh` call per open PR.
+    - cron: "0 9 * * *"
+    - cron: "0 21 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sweep for no-verdict pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # `--min-age 15`: a PR opened seconds ago legitimately has no checks
+        # yet. The script's own default is smaller; on a schedule there is no
+        # reason to be impatient, and a false "stuck" would teach people to
+        # ignore this.
+        run: bash scripts/ci/pr-verdict-check.sh --min-age 15

--- a/docs/issues/archived/0994-no-verdict-sweep-never-runs.md
+++ b/docs/issues/archived/0994-no-verdict-sweep-never-runs.md
@@ -1,0 +1,87 @@
+---
+id: 994
+title: "The detector for silently-ineligible pull requests exists and nothing
+  calls it — `pr-verdicts` runs only when a human thinks to ask"
+status: resolved
+type: tech-debt
+area: ci
+related: [issue-0975, issue-0196]
+resolved_in: "issue 0994 (this filing)"
+---
+
+## Symptom
+
+On 2026-09-02, PR #207 had **zero check suites for its head sha**. Not failing,
+not pending — no verdict at all, so it was ineligible to merge and would have
+stayed that way indefinitely. It was found by eye, from a `gh pr checks` line
+reading `no checks reported`.
+
+`scripts/ci/pr-verdict-check.sh` detects exactly this, and has since PR #71 sat
+thirteen hours in the same state with auto-merge armed against a check that was
+never requested. Run against the tree that day it answered correctly in seconds.
+
+**The detector was not missing. Its caller was.** It is `just pr-verdicts`, in
+the `setup` group, read-only, invoked only when someone already suspects the
+problem — which is the one situation where a detector adds least. The failure it
+looks for is SILENCE, and silence prompts nobody to run anything.
+
+## Why this is not a gate, and never can be
+
+The script needs the network and an authenticated `gh`. Gates here are
+buildless, offline and deterministic, and `check-lane-contracts` enforces that
+for merge-gating lanes. It also asks a question about OTHER pull requests, which
+is not a property of the diff under review.
+
+So the honest options were a schedule or nothing.
+
+## Third instance of the class
+
+| when | what | how it was found |
+| --- | --- | --- |
+| PR #71 | stacked PR; retarget emitted `pull_request.edited`, not a default dispatch type | by hand, 13 h later |
+| issue 0975 | a `merge_group`-only check on the required set — no PR could satisfy it, so no PR entered the queue, so the event that would run it never fired | by hand, 7 PRs stalled |
+| PR #207 | zero check suites for the head sha | by eye, 2026-09-02 |
+
+Each time the trigger was fixed. The DETECTION has depended on a person
+noticing an absence — and an absence is what people are worst at noticing.
+
+## Fix
+
+`.github/workflows/pr-verdicts.yml` — `schedule` (09:00 and 21:00 UTC) plus
+`workflow_dispatch`, running `scripts/ci/pr-verdict-check.sh --min-age 15`. The
+script already exits 1 when it finds a stuck PR, so it needed no change.
+
+Its own workflow rather than a job in `nightly.yml`: nightly is the L3/L4
+cross-build matrix that provisions SDKs and runs QEMU, and a 20-second `gh`
+sweep must run whether or not that matrix is healthy. Folding it in would mean a
+red cross-build takes down the check that notices when nothing is reporting.
+
+`--min-age 15` because a PR opened seconds ago legitimately has no checks yet.
+On a schedule there is no reason to be impatient, and a false "stuck" would
+teach people to ignore the alert — which is the failure mode this whole class
+already has.
+
+NOT a required check, and it runs on `schedule` only, never on `pull_request`.
+Adding a scheduled job to the required set is precisely issue 0975: a context
+that produces no verdict for a PR blocks it forever.
+
+## Verified
+
+* `bash scripts/ci/pr-verdict-check.sh --min-age 15` — the exact invocation the
+  workflow makes — returns `OK — 7 pull request(s) reporting, 0 too fresh to
+  judge, none stuck`, rc 0.
+* Before #207 was rebased the same script reported it stuck; after, it reports.
+  So the detector distinguishes the two states on real data, not just in
+  principle.
+* `check-workflow-repo-env` green over 12 workflows (was 11), 175 steps.
+
+## What this does not fix
+
+The sweep reports; it does not remedy. A stuck PR still needs a human to rebase
+(if conflicting — GitHub cannot build a merge ref, so nothing dispatches) or to
+re-fire the event (if not). The script already names WHICH of those two applies,
+because prescribing the wrong one is worse than prescribing nothing.
+
+Twice-daily is a latency of up to twelve hours. That is a deliberate trade
+against one `gh` call per open PR per run; if the class recurs faster than that,
+the cron is the thing to change.


### PR DESCRIPTION
PR #207 sat with **zero check suites for its head sha**: not failing, not pending, no verdict — ineligible to merge indefinitely. Found by eye, from a `gh pr checks` line reading `no checks reported`.

`scripts/ci/pr-verdict-check.sh` detects exactly this, and has since PR #71 sat thirteen hours in the same state with auto-merge armed against a check that was never requested.

**The detector was not missing. Its caller was.** It is `just pr-verdicts`, in the `setup` group, invoked only when someone already suspects the problem — the one situation where a detector adds least. What it looks for is *silence*, and silence prompts nobody to run anything.

## Third instance of the class

| | trigger | how it was found |
| --- | --- | --- |
| PR #71 | a retarget emits `pull_request.edited`, not a default dispatch type | by hand, 13 h later |
| issue 0975 | a `merge_group`-only check on the required set — no PR could satisfy it, so none entered the queue, so the event that would run it never fired | by hand, 7 PRs stalled |
| PR #207 | zero check suites for the head sha | by eye, 2026-09-02 |

Each time the **trigger** was fixed and detection stayed manual. An absence is what people are worst at noticing.

## Fix

`.github/workflows/pr-verdicts.yml` — `schedule` (09:00 and 21:00 UTC) plus `workflow_dispatch`, running `scripts/ci/pr-verdict-check.sh --min-age 15`. The script already exits 1 when it finds a stuck PR, so it needed no change.

**Not a gate, and cannot be:** it needs the network and an authenticated `gh`, and it asks a question about *other* pull requests, which is not a property of the diff under review. A schedule is the right shape for a failure whose signal is silence.

**Its own workflow, not a job in `nightly.yml`:** nightly is the L3/L4 cross-build matrix that provisions SDKs and runs QEMU. This must run whether or not that is healthy — folding it in means a red cross-build takes down the check that notices when nothing is reporting.

**`schedule` only, never `pull_request`**, so it can never become a required context. A scheduled job in the required set *is* issue 0975.

`--min-age 15` because a PR opened seconds ago legitimately has no checks yet. A false "stuck" would teach people to ignore the alert — the failure mode this class already has.

## Verified on real data

- The exact workflow invocation returns `OK — 7 pull request(s) reporting, 0 too fresh to judge, none stuck`, rc 0.
- Before #207 was rebased, the same script reported it **stuck**; after, it reports. So it distinguishes the two states on real data, not just in principle.
- `check-workflow-repo-env` green over 12 workflows (was 11), 175 steps.

## What this does not fix

It reports; it does not remedy. A stuck PR still needs a human to rebase (if conflicting — GitHub cannot build a merge ref, so nothing dispatches) or to re-fire the event. The script already names **which** of those applies, because prescribing the wrong one is worse than prescribing nothing.

Twice-daily is up to twelve hours' latency — a deliberate trade against one `gh` call per open PR per run. If the class recurs faster than that, the cron is the thing to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe