### PR TITLE
docs(#0961): where the stack check can live — scoped, not implemented

### DIFF
--- a/docs/issues/0961-executor-open-in-needs-more-than-32k-of-caller-stack.md
+++ b/docs/issues/0961-executor-open-in-needs-more-than-32k-of-caller-stack.md
@@ -159,3 +159,40 @@ Two things this did NOT do, and they are why the issue stays open:
    unnamed, and that is the half of this issue that cost four bring-up sessions.
 
 `ZenohSession::names_and_types_filtered` (19840 bytes) is untouched.
+
+## Where the "state the number" check can and cannot live (2026-09-03)
+
+Scoped but NOT implemented. Recording the constraints, because the obvious two
+placements are both wrong and finding that out costs a build each.
+
+**It cannot go inside `Executor::open_in`.** The overflow happens in that
+function's PROLOGUE — `sub.w sp, sp, #16000` before phase-409, and the named
+fault above points at `__aeabi_memclr8` with `lr = open_in`. Any check written
+in the body runs after the stack has already been claimed, so it cannot fire on
+the image it is meant to protect. The same argument rules out `nros_cpp_init`,
+which is the other half of the same call chain and commits its own frame first.
+A runtime check has to sit in the CALLER, before the call — which means the
+board's entry, per platform.
+
+**The configure-time route needs a probe that does not exist yet.** The heap
+gate this issue asks to imitate works because both of its numbers are knobs
+resolved at configure. The stack requirement is not: it derives from
+`size_of::<Executor>()`, which is only knowable by compiling the crate. There IS
+a probe of that shape — `nros-build-helpers::c` reads a compiled rlib and emits
+`EXECUTOR_OPAQUE_U64S` — but that constant is `size_of::<ExecutorInlineStorage>()`,
+the executor value PLUS its carved backing. The backing is not on the stack, so
+reusing it would overstate the requirement, and on a part where the overstatement
+is a build error that is not a safe direction to be wrong in.
+
+So the work is: add a probe for `size_of::<Executor>()` alone, emit it beside
+the existing macros, and compare `2 x` it (the issue's own "one value, moved
+twice" finding) against `CONFIG_MAIN_STACK_SIZE` — as a NECESSARY condition, not
+a sufficient one. The frames hold locals besides the executor: measured on
+x86_64 after phase-409, `open_in` is 3368 and `nros_cpp_init` 1816 against a
+1016-byte `Executor`, so `2 x size_of` is a floor and roughly a third of the
+real cost.
+
+Being explicit about that ratio matters: a gate that claims to state THE number
+while checking a third of it is the shape this campaign keeps finding — a value
+that reads as applied and is not. Either it says "necessary minimum" in its own
+message, or it waits for a measured frame budget.


### PR DESCRIPTION
0961's remaining half is *"nothing STATES the number"*. I scoped it and **did not
implement it**. This records the constraints, because the two obvious placements
are both wrong and finding that out costs a build each.

## It cannot go inside `Executor::open_in`

The overflow is in that function's **prologue** — `sub.w sp, sp, #16000`, and the
issue's own named fault points at `__aeabi_memclr8` with `lr = open_in`. A check
in the body runs *after* the stack is claimed, so it cannot fire on the image it
exists to protect. Same argument rules out `nros_cpp_init`, the other half of the
chain. A runtime check must sit in the **caller**, before the call — which makes
it per-platform.

## The configure-time route needs a probe that doesn't exist

The heap gate this issue asks to imitate works because both its numbers are knobs
resolved at configure. This one derives from `size_of::<Executor>()`, knowable
only by compiling.

The nearest existing probe emits `EXECUTOR_OPAQUE_U64S` — but that is
`size_of::<ExecutorInlineStorage>()`, the executor value **plus its carved
backing**. The backing is not on the stack, so reusing it overstates the
requirement; and where the overstatement is a build error, that is the wrong
direction to be wrong in.

## So the work is

A `size_of::<Executor>()` probe of its own, compared as `2 ×` against
`CONFIG_MAIN_STACK_SIZE` (this issue's "one value, moved twice" finding), stated
as a **necessary minimum**, not the requirement.

Measured on x86_64 after phase-409: `open_in` 3368 and `nros_cpp_init` 1816
against a 1016-byte `Executor` — so `2 × size_of` is roughly **a third** of the
real cost.

## Why that ratio makes this a doc commit

A check that claims to state *the* number while testing a third of it is the
shape this campaign keeps finding: a value that reads as applied and is not. It
either says "necessary minimum" in its own message, or waits for a measured frame
budget — and choosing between those is worth doing deliberately rather than at
the end of a long session.

The issue's other half, booting on `mr_canhubk3/s32k344`, needs the part, which
is not in this tree.

No behaviour change. `just check fast`: 168 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa