### PR TITLE
docs(0996 + phase-413): CI audit and the phase to close it

### DIFF
--- a/docs/issues/0996-ci-workflow-audit-tier-promises.md
+++ b/docs/issues/0996-ci-workflow-audit-tier-promises.md
@@ -179,6 +179,13 @@ Worth recording, because it is the part that works and should not be undone:
 * `report-interlock-coverage.sh` turns "this self-hosted lane did not run" into
   a stated outcome instead of silence — the fix for the no-verdict class.
 
+## Where the work is tracked
+
+phase-413 (`docs/roadmap/phase-413-ci-workflow-user-parity.md`) carries the work
+items. W6 — `package.xml` as the dependency SSoT — is DESIGN, not
+implementation: it changes what a `package.xml` means here, so its deliverable
+is an RFC, and no code should be written against it first.
+
 ## Order to fix
 
 1. Land 0992, then delete `queue.yml`'s four hand-rolled sync steps and decide

--- a/docs/issues/0996-ci-workflow-audit-tier-promises.md
+++ b/docs/issues/0996-ci-workflow-audit-tier-promises.md
@@ -1,0 +1,192 @@
+---
+id: 996
+title: "CI audit: the same lane passes in the queue and fails after merge, four of
+  six lanes carry no signal, and the provisioning system is bypassed by hand"
+status: open
+type: bug
+area: ci, tooling
+related: [0992, 0876, 0883]
+---
+
+Audit of all 11 workflows against the four properties they are supposed to have:
+a workflow reads as a user session; provisioning goes through `nros setup`; each
+tier delivers the promise it advertises; and a missing prerequisite fails rather
+than skips.
+
+## 1. The same lane passes in the queue and fails after merge
+
+`just ci matrix build` dispatches to `_matrix-build`, whose entire body is `l3`.
+So `queue.yml` (`just ci l3`, on `merge_group`) and `build-wide.yml`
+(`just ci matrix build`, on `push` to main) run **the same recipe on the same
+runner labels**. Their verdicts, on the same commits, minutes apart:
+
+| commit | queue.yml (merge_group) | build-wide.yml (push main) |
+| --- | --- | --- |
+| `36c306405` (pr-216) | success 16:25:49 | **failure** 16:26:23 |
+| `da0344af1` (pr-219) | success 17:02:18 | **failure** 16:43:26 |
+| `ad5a8ecf9` (pr-217) | success 17:06:55 | **failure** 17:22:19 |
+| `d2a8955c5` (pr-220) | success 01:23:54 | **failure** 17:27:51 |
+
+Five queue successes, four post-merge failures, one lane. The difference is not
+the code — it is that `queue.yml` hand-rolls the codegen step:
+
+```yaml
+- name: Build nros CLI (nros sync needs it)
+- name: Build nros-launch-resolve (nros sync shells out to it)
+- name: nros sync (writes the central `nros-patch.toml` the leaves include)
+- name: nros sync the leaves L3 builds        # a for-loop over three leaves
+```
+
+while `build-wide.yml` runs `just setup tier2` and trusts the build verb to do
+it. It did not — that is issue 0992, and this table is its proof in the wild.
+**The boilerplate is load-bearing**: it is exactly what keeps the defect
+invisible to the queue while the post-merge lane burns.
+
+Two consequences, and the second is the expensive one:
+
+* The same self-hosted lane is paid for twice per change, once in the queue and
+  again after the merge it already gated.
+* A gate that has already passed in the queue cannot fail differently after the
+  merge unless the two spellings have diverged — so a red `build-wide` reads as
+  noise, and stayed red for a day.
+
+Once 0992 lands, those four steps are dead weight and `queue.yml`'s job body
+should be the same two lines `build-wide.yml` has. Better still: **decide
+whether this lane belongs in the queue or after it, and run it once.**
+
+## 2. Four of six verification lanes carry no signal
+
+| workflow | last 5 conclusions |
+| --- | --- |
+| `gate.yml` | green (the required `CI`) |
+| `post-submit.yml` | success, cancelled, success, success, success |
+| `build-wide.yml` | failure ×4 |
+| `run-matrix.yml` | failure ×2 |
+| `nightly.yml` | failure ×4 |
+| `host-tests.yml` | failure ×4, cancelled |
+
+CLAUDE.md already names this class outright: *"A uniformly-red lane has NO
+signal capacity: a regression landing in it looks exactly like yesterday's
+failure."* That is the state of every lane above the merge gate. The tiers
+promise coverage they are not delivering — not because the tier is wrong, but
+because nobody can tell a new failure from the standing one.
+
+`host-tests` is the honest case and worth keeping: it dies in **Build workspace
+fixtures**, a fixture step that fails loudly instead of laundering the failure
+into a skip. That is the policy working. It still needs fixing.
+
+## 3. Provisioning is bypassed by hand, for packages the index already declares
+
+`nros setup --system` resolves the `[prereq.*]` closure for the detected package
+manager (RFC-0062 / phase-327). On this host it reports **38 present, 5 missing,
+3 unprobed** — the mechanism works. Yet:
+
+| workflow | does | already declared? |
+| --- | --- | --- |
+| `docs.yml` | `sudo apt-get install -y doxygen graphviz` | **yes** — `[prereq.doxygen]`, `[prereq.graphviz]` |
+| `nightly.yml` | `apt-get install -y clang libclang-dev` | **yes** — both in the index |
+| `gate.yml` (colcon-parity) | adds the ROS apt repo, installs `ros-humble-ros-base`, `colcon`, then curl-installs `just` | `colcon` **yes**; ROS no |
+
+`[prereq.doxygen]`'s own `why` field reads *"found undeclared by
+check-sysdep-remedies"* — so a gate already exists that finds sysdeps missing
+from the index. **Nothing checks the reverse**: that a workflow does not
+apt-install what the index already knows. That is the gate this audit asks for.
+
+`gate.yml`'s colcon-parity job is the sharpest case. `images.yml` builds
+`ghcr.io/newslabntu/nano-ros-ci:humble` — described in its own header as *"ROS 2
+Humble + host tools, the base `container:` for the check / …"* — and **only
+`nightly.yml` ever uses it**. colcon-parity installs a ROS 2 desktop stack by
+apt on every run instead of declaring `container: ci-base`.
+
+## 4. `nros setup` is index-driven, not `package.xml`-driven
+
+The intent is the rosdep experience: deps are written in `package.xml`, the tool
+scans the packages and installs accordingly. Today the two halves do not meet.
+
+* **406 tracked `package.xml` files.** Their entire dependency vocabulary is ROS
+  message and build-tool keys — `std_msgs` (177), `example_interfaces` (106),
+  `ament_cmake` (19), `rosidl_default_*` (27), and workspace-local node
+  packages. Not one names a system dependency.
+* Those declarations are consumed **only by codegen** — which msg packages to
+  generate. No provisioning path reads them.
+* Provisioning reads `nros-sdk-index.toml` instead: `[prereq.*]`, `[rust.*]`,
+  `[python.*]`, `[source.*]`, `[tool.*]`. Hand-maintained, repo-global.
+
+So a `package.xml` cannot express "this package needs libssl-dev", and there is
+no `nros setup <workspace>` that walks a workspace's manifests and resolves
+their closure. The nearest thing, `nros setup --build-sources`, provisions a
+repo-global union from the index, not a per-workspace scan.
+
+This is the gap between "we have a provisioning system" and "we have rosdep".
+Closing it means: a `package.xml` dep key resolves through the index's
+`[prereq.*]` table the way a rosdep key resolves through the rosdep DB, and
+`nros setup` takes a workspace path.
+
+## 5. Tier promises vs what the critical path actually runs
+
+`just ci gate` promises *"compile + unit; no fixtures were built or needed"* and
+runs `check::cli-fresh check::fast check::build check::api-parity test-unit
+test-lane-contracts`. What the required `CI` context runs, per event:
+
+| step | pull_request | merge_group | schedule/dispatch |
+| --- | --- | --- | --- |
+| `check fast` (168 gates) | ✓ | ✓ | ✓ |
+| `check submodule-commits-reachable` | ✓ | ✓ | ✓ |
+| `check compile-smoke` | ✓ | — | — |
+| `check cli-tests` | ✓ | ✓ | — |
+| `check build` + `no-std` | — | — | ✓ |
+| `generate-bindings`, compile-check fixtures | — | — | ✓ |
+| **`test-unit`** | **—** | ✓ | ✓ |
+
+**`test-unit` does not run on `pull_request`.** A PR shows a green required `CI`
+having never run a unit test; they run first in the merge queue. Nothing broken
+lands (the queue is the real gate, and `queue-notify.yml` exists to comment on
+ejections), but CLAUDE.md states the required context *is* `check-fast` +
+`test-unit` + `check-cli-tests`, which is true only in the queue. Either the
+doc or the trigger list should move.
+
+`check::api-parity` looked absent from every workflow and is not: its members
+(`rmw-api-parity`, `rmw-abi-shape`, `api-parity-ledger`) are in the
+`fast-serial` registry, so `check fast` runs them on every PR. No gap — recorded
+because the grep says otherwise and the next reader will run it.
+
+## 6. One scope vocabulary, five spellings
+
+phase-411 W4 says a CI job is `just setup <scope>` then one command a developer
+can type. Three lanes do this; the rest predate it:
+
+| workflow | provisioning | work |
+| --- | --- | --- |
+| `build-wide` | `just setup tier2` | `just ci matrix build` |
+| `run-matrix` | `just setup tier2` | `just ci matrix` |
+| `nightly` (matrix) | `just setup tier2-nightly` | `just ci matrix-nightly` |
+| `host-tests` | 5 hand-rolled steps (`nros setup --source ×6`, 3× `--tool`, `provision-zenohd`, `setup-launch-resolve`) | `just native build-fixture-rust-core`, `just native build-workspace-fixtures`, `just ci tier1` |
+| `queue` | 4 hand-rolled steps (§1) | `just ci l3` |
+| `nightly` (platform) | `just <plat> setup` + 6 more steps | `just <plat> test` |
+
+`nightly.yml` repeats a 22-line "Build nros CLI from packages/cli/" block in
+four jobs verbatim.
+
+## What the skip policy got right
+
+Worth recording, because it is the part that works and should not be undone:
+
+* `host-tests`' fixture steps `exit 1` on failure. The comment above them
+  records the ten runs where a green step sat over a failed build.
+* `gate.yml`'s `ci-ok` refuses a vacuous pass: a skipped `check` is accepted
+  only for a `pull_request` that `changes` proved touched no code, and any other
+  skip is a hard failure.
+* `report-interlock-coverage.sh` turns "this self-hosted lane did not run" into
+  a stated outcome instead of silence — the fix for the no-verdict class.
+
+## Order to fix
+
+1. Land 0992, then delete `queue.yml`'s four hand-rolled sync steps and decide
+   whether l3 runs in the queue or after it — **once**, not both.
+2. Get `host-tests` green (workspace fixtures), then `run-matrix`, then
+   `nightly`. Until a lane is green once it cannot report anything.
+3. Gate: no workflow may `apt-get install` a package the index declares.
+   Convert `docs.yml`, `nightly.yml`'s clang step, and colcon-parity (to
+   `container: ci-base`).
+4. Decide the `package.xml`-vs-index question in an RFC before writing code —
+   it changes what a `package.xml` in this repo means.

--- a/docs/issues/1001-arena-budget-walks-whole-repo.md
+++ b/docs/issues/1001-arena-budget-walks-whole-repo.md
@@ -1,0 +1,113 @@
+---
+id: 1001
+title: "`check-action-client-arena-budget` walks the whole repo, so `check fast`
+  costs minutes on a cold page cache — the pre-push gate is where that is felt"
+status: open
+type: bug
+area: tooling, ci
+related: [0900, 0981, 0996]
+---
+
+`check fast` promises BUILDLESS and SOURCE-FREE, green in ~23 s. It is what a
+contributor runs before every push, and the `pre-push` hook runs it alone. One
+gate on that line traverses the entire repository.
+
+## What it does
+
+`check-action-client-arena-budget` answers a POST-LINK question — `nm` over
+built cross ELFs — so it cannot use `git ls-files`: the artifacts it needs are
+untracked by construction, which its own text carves out ("scanning for
+UNTRACKED artifacts is fine — scope it to a build dir"). But the call site does
+not scope it to a build dir:
+
+```python
+build_root = os.environ.get("NROS_BUILD_ROOT") or os.path.join(ROOT, "build")
+roots = [ROOT]                     # ← the whole checkout
+```
+
+`PRUNE` drops `.git`, `.fingerprint`, `incremental`, `deps`, `third-party` and a
+few others — but not cargo `target*/` dirs, not `zephyr-workspace/`, not `tmp/`.
+So the walk is the repo.
+
+## The cost is I/O, not CPU — which is why it hides
+
+Measured on one developer tree (`build/` 79,523 dirs, `target/` 44,382,
+`zephyr-workspace/` more than 120 s merely to *count*):
+
+| subtree | dirs traversed | cold | warm |
+| --- | ---: | ---: | ---: |
+| `examples/` | 98,617 | >60 s (capped) | 0.6 s |
+| `zephyr-workspace/` | 49,943 | 60 s (capped) | 0.3 s |
+| `build/` | 27,807 | 4.4 s | — |
+| `tmp/` | 3,232 | 10.3 s | — |
+| `esp-idf-workspace/` | 4,192 | 6.9 s | — |
+
+**The same traversal is 100× apart cold vs warm.** Warm, the whole gate runs in
+3.4 s and is unremarkable. Cold — the first `check fast` after boot, or after
+another workload has evicted the page cache — it is minutes. On the host this
+was found on, with an unrelated build at load 26, the gate did not finish in
+600 s.
+
+That is exactly the condition a contributor hits: `check fast` is often the
+first thing touching these trees in a session.
+
+It also reports on scratch: a run on this tree printed `[not examined]` lines
+for `tmp/scaftest/…`, `tmp/wsx/…`, `tmp/wsx2/…`.
+
+## Two fixes were tried and are WRONG — do not repeat them
+
+**1. Move the gate to the build tier.** Rejected by `check-gate-visibility`,
+correctly:
+
+```
+action-client-arena-budget: in a lane no pull_request or merge_group job runs
+A gate no pull request runs is a gate that rots (issue 0981)
+if it passes with no build artifacts it does not belong in the build tier at all
+```
+
+The gate SKIPS cleanly (rc 78) when there is no built image, so it passes in a
+pristine worktree — which is precisely the test that gate names, and it means
+the fast line is its correct home. Relocation is not available.
+
+**2. Prune non-`out` children of `build/<pkg>-<hash>/`.** The anchor is only
+ever recorded for a dir named `out` whose grandparent is `build`, so pruning
+siblings looked provably free, and it cut `examples/` from 98,617 to 77,387
+dirs. It **silently dropped 159 of 410 findings**. The predicate fires on ANY
+directory whose parent is named `build` — including the top-level `build/`
+shared cargo group dirs (phase-340), amputating whole target trees. Caught only
+by diffing a full `--verbose` run against a captured baseline.
+
+Anyone touching this must capture `--verbose` output before and after and diff
+it. The gate reports the same *shape* while examining a smaller set, so a
+smoke test cannot see the difference.
+
+## Also measured, and NOT a defect
+
+`config-knob-census` and `check-feature-contract` were first blamed at 74 s and
+93 s. Both figures were contention artifacts — they were timed underneath a
+`-P24` fast-line run on a loaded host. Clean, they are **1.2 s** and **0.43 s**,
+and both are index-based (`git ls-files`) and source-only. Recorded because
+those wrong numbers are what a careless re-measurement reproduces.
+
+## The design question
+
+Scoping `roots` to discovered cargo target dirs instead of `[ROOT]`, without
+losing an image the gate currently finds. Open questions:
+
+1. **What is the root set?** Target dirs here are `<repo>/target`, per-leaf
+   `examples/**/target*`, the phase-340 shared group dirs under `build/`, west
+   build dirs under `zephyr-workspace/build-*`, and `esp-idf-workspace/`. Is
+   that set derivable (from `fixtures.toml` coordinates / `nros_fixture_row_
+   artifact_dir`) or does it become a second hand-maintained list that drifts?
+2. **Does enumerating them cost what walking them costs?** The dirs are found
+   by walking; the saving comes from not descending their interiors, and the
+   interiors are where the anchor lives. The win may be smaller than it looks
+   and should be MEASURED cold, not assumed.
+3. **Should `tmp/` and `test-logs/` be pruned?** Cheap and removes noise, but it
+   is a semantic narrowing: an image built in `tmp/` stops being checked.
+4. **Is a cold-cache cost acceptable at all on the pre-push line?** The
+   alternative framing is that any gate reading untracked artifacts is
+   inherently cache-hostile, and the fast line's "buildless and source-free"
+   claim (asserted by `check-lane-contracts`) is already false for it.
+
+Tracked as phase-413 W7.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -79,9 +79,9 @@ fails if this block drifts.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.
 - **#0988** (tooling) — No gate runs a hook the way git runs it — with `GIT_DIR` set — so a script that corrupts the caller's repository passes every check See `0988-*`.
 - **#0991** (cmake) — A clean build of an entity-declaring image derives the WRONG payload basis and does not link See `0991-*`.
+- **#0996** (ci, tooling) — CI audit: the same lane passes in the queue and fails after merge, four of six lanes carry no signal, and the provisioning system is bypassed by hand See `0996-*`.
 - **#0997** ([rmw, platform, embedded]) — The timed-event tree empties itself on FreeRTOS: the SPDP resend is scheduled, never lands in the queue, and every peer expires the participant's lease See `0997-*`.
 - **#1000** ([rmw, third-party]) — Vendored Cyclone: `handle_xevk_spdp`'s early returns orphan the PERIODIC spdp event — it leaves the heap, is never re-armed, and the participant goes silent forever See `1000-*`.
-- **#0996** (ci, tooling) — CI audit: the same lane passes in the queue and fails after merge, four of six lanes carry no signal, and the provisioning system is bypassed by hand See `0996-*`.
 - **#1001** (tooling, ci) — `check-action-client-arena-budget` walks the whole repo, so `check fast` costs minutes on a cold page cache — the pre-push gate is where that is felt See `1001-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -81,5 +81,6 @@ fails if this block drifts.
 - **#0991** (cmake) — A clean build of an entity-declaring image derives the WRONG payload basis and does not link See `0991-*`.
 - **#0997** ([rmw, platform, embedded]) — The timed-event tree empties itself on FreeRTOS: the SPDP resend is scheduled, never lands in the queue, and every peer expires the participant's lease See `0997-*`.
 - **#1000** ([rmw, third-party]) — Vendored Cyclone: `handle_xevk_spdp`'s early returns orphan the PERIODIC spdp event — it leaves the heap, is never re-armed, and the participant goes silent forever See `1000-*`.
+- **#0996** (ci, tooling) — CI audit: the same lane passes in the queue and fails after merge, four of six lanes carry no signal, and the provisioning system is bypassed by hand See `0996-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -82,5 +82,6 @@ fails if this block drifts.
 - **#0997** ([rmw, platform, embedded]) — The timed-event tree empties itself on FreeRTOS: the SPDP resend is scheduled, never lands in the queue, and every peer expires the participant's lease See `0997-*`.
 - **#1000** ([rmw, third-party]) — Vendored Cyclone: `handle_xevk_spdp`'s early returns orphan the PERIODIC spdp event — it leaves the heap, is never re-armed, and the participant goes silent forever See `1000-*`.
 - **#0996** (ci, tooling) — CI audit: the same lane passes in the queue and fails after merge, four of six lanes carry no signal, and the provisioning system is bypassed by hand See `0996-*`.
+- **#1001** (tooling, ci) — `check-action-client-arena-budget` walks the whole repo, so `check fast` costs minutes on a cold page cache — the pre-push gate is where that is felt See `1001-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -210,6 +210,39 @@ Questions the RFC has to answer, none of which have obvious answers:
 Deliverable for W6 is **an RFC in `docs/design/`**, not code. Only once it is
 `Draft` and reviewed does an implementation work item get opened.
 
+## W7 — DESIGN: scope the arena-budget walk (issue 1001)
+
+Found while doing W1, and it is the fast line's own promise at stake.
+
+`check fast` is BUILDLESS and SOURCE-FREE, ~23 s, and the `pre-push` hook runs
+it alone. `check-action-client-arena-budget` walks the ENTIRE repository — its
+call site passes `roots = [ROOT]`, and `PRUNE` covers neither cargo `target*/`
+nor `zephyr-workspace/` nor `tmp/`.
+
+The cost is **I/O, not CPU**, which is why it went unnoticed: the same
+traversal is 0.6 s warm and over 60 s cold, and the whole gate is 3.4 s warm but
+did not finish in 600 s on a host whose page cache another build had evicted.
+Cold is exactly the case a contributor hits, because `check fast` is often the
+first thing in a session to touch these trees.
+
+**Two fixes were tried and are wrong; issue 1001 records both so they are not
+repeated.** Moving it to the build tier is refused by `check-gate-visibility`
+for a good reason (a gate no pull request runs rots — issue 0981), and it skips
+cleanly with no artifacts, which is that gate's own test for belonging on the
+fast line. Pruning non-`out` siblings under `build/<pkg>-<hash>/` looked
+provably free and silently dropped 159 of 410 findings, because the predicate
+also matches the top-level `build/` shared cargo group dirs from phase-340.
+
+So this is **design work, not a patch**: scoping `roots` to discovered cargo
+target dirs without losing an image, and deciding whether a gate that reads
+untracked artifacts can honour a "buildless and source-free" claim at all —
+`check-lane-contracts` asserts that claim today and it is already false for this
+gate. Issue 1001 carries the four open questions.
+
+**Whoever takes it: capture `--verbose` before and after and diff.** The gate
+prints the same shape while examining a smaller set, so a smoke test cannot see
+a regression — that is how attempt 2 passed inspection.
+
 ## Acceptance for the phase
 
 * One spelling of the l3 lane, running once per change (W1).
@@ -220,6 +253,8 @@ Deliverable for W6 is **an RFC in `docs/design/`**, not code. Only once it is
 * Every job body is `just setup <scope>` + one command (W5).
 * An RFC for `package.xml`-driven provisioning, reviewed, with an implementation
   work item opened against it (W6).
+* The arena-budget walk scoped, or a recorded decision that its cold cost is
+  accepted and the fast line's claim amended to match (W7).
 
 ## What the audit found working, and this phase must not undo
 

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -1,0 +1,236 @@
+# Phase 413 — make CI run the process a user runs
+
+**Status (2026-09-03). Opened from the workflow audit in issue 0996.** The
+workflows are meant to read as a transcript of a user session: `just setup
+<scope>`, then one command a developer can type (phase-411 W4). Six of eleven
+still hand-roll the middle. The audit measured what that costs, and the cost is
+not tidiness — it is a lane that passes in the merge queue and fails after the
+merge, on the same commit, running the same recipe.
+
+## The finding that orders this phase
+
+`just ci matrix build` dispatches to `_matrix-build`, whose body is `l3`. So
+`queue.yml` (`just ci l3`, on `merge_group`) and `build-wide.yml` (`just ci
+matrix build`, on `push` to main) run the **same recipe on the same runner
+labels**. Their verdicts on the same four commits, minutes apart:
+
+| commit | queue.yml | build-wide.yml |
+| --- | --- | --- |
+| `36c306405` | success 16:25:49 | **failure** 16:26:23 |
+| `da0344af1` | success 17:02:18 | **failure** 16:43:26 |
+| `ad5a8ecf9` | success 17:06:55 | **failure** 17:22:19 |
+| `d2a8955c5` | success 01:23:54 | **failure** 17:27:51 |
+
+The code is identical. The difference is that `queue.yml` carries four
+hand-rolled steps — `setup-cli`, `setup-launch-resolve`, `nros sync` on the rust
+workspace, and a loop syncing the three leaves L3 builds — which `build-wide.yml`
+does not, because it trusts `just setup tier2` and the build verb.
+
+**The boilerplate is load-bearing.** It is not clutter around a working system;
+it is what hides issue 0992 from the queue while the post-merge lane burns. That
+is the general shape this phase is about: every hand-rolled step in a workflow is
+a claim that the toolchain cannot do the thing itself, and each one that is true
+is a defect nobody is looking at.
+
+## The state to fix from
+
+| workflow | last 5 conclusions | shape |
+| --- | --- | --- |
+| `gate.yml` | green (the required `CI`) | — |
+| `post-submit.yml` | success ×4, cancelled | — |
+| `build-wide.yml` | failure ×4 | `just setup tier2` + one command |
+| `run-matrix.yml` | failure ×2 | `just setup tier2` + one command |
+| `nightly.yml` | failure ×4 | mixed |
+| `host-tests.yml` | failure ×4, cancelled | 5 provisioning steps hand-rolled |
+
+Four of six verification lanes carry no signal. CLAUDE.md names the class: *"A
+uniformly-red lane has NO signal capacity: a regression landing in it looks
+exactly like yesterday's failure."* Until a lane is green once, nothing it says
+counts, so **W2 gates most of the rest of this phase** — there is no way to prove
+a conversion did not break something in a lane that was already red.
+
+---
+
+## W1 — collapse the duplicated `l3` lane
+
+Blocked on issue 0992 (PR #208) landing; that is what lets `build-wide` provision
+through the verb instead of by hand.
+
+Then: delete `queue.yml`'s four sync steps, and **decide whether this lane runs
+in the queue or after it — once, not both.** Today the same self-hosted lane is
+paid for twice per change, and a gate that already passed in the queue cannot
+fail differently after the merge unless the two spellings have diverged. Which is
+exactly what happened.
+
+Recommendation: keep it on `merge_group` (a gate belongs before the merge, not
+after) and retire `build-wide.yml`, or reduce it to the scheduled/dispatch entry
+point it also serves. Whichever way, one spelling.
+
+Acceptance: `grep -c 'nros sync' .github/workflows/queue.yml` is 0; exactly one
+workflow runs the l3 lane; a full change cycle shows the lane running once.
+
+## W2 — get each red lane green, in dependency order
+
+Not a conversion task — a debugging one, and it comes first because no
+conversion can be verified in a lane that is already red.
+
+1. **`host-tests`** — dies in *Build workspace fixtures*. This is the honest
+   failure: the step `exit 1`s instead of laundering into a skip, which is the
+   policy working. Fix the fixture build.
+2. **`run-matrix`** — tier-2 run depth, one step, exit 1 with no further
+   detail in the log summary. Needs a real diagnosis before it can be trusted.
+3. **`nightly`** — failure ×4. `just nightly-triage` classifies by which STEP
+   failed and flags cells red across a window; use it rather than reading runs.
+4. **`build-wide`** — expected to go green with W1/0992; if it does not, its
+   remaining failure is now visible rather than buried under the include
+   preflight.
+
+Acceptance: each lane green at least once, and the date recorded here. A lane
+that cannot be made green is a finding, not a skip — file it.
+
+## W3 — a gate: no workflow installs what the index already declares
+
+`nros setup --system` resolves the `[prereq.*]` closure for the detected package
+manager (RFC-0062 / phase-327). Measured on a dev host: 38 present, 5 missing, 3
+unprobed. The mechanism works. Yet:
+
+| site | installs | already declared |
+| --- | --- | --- |
+| `docs.yml` | `doxygen`, `graphviz` | **both** |
+| `nightly.yml` | `clang`, `libclang-dev` | **both** |
+| `gate.yml` colcon-parity | ROS apt repo, `ros-humble-ros-base`, `colcon`, curl-installs `just` | `colcon` yes; ROS no |
+
+`[prereq.doxygen]`'s own `why` field reads *"found undeclared by
+check-sysdep-remedies"* — so a gate already exists for the index-side gap. **The
+reverse is unchecked**: nothing stops a workflow apt-installing what the index
+knows. That asymmetry is why these three survived.
+
+Two halves:
+
+* **The gate.** A workflow `run:` block may not `apt-get install` / `pip install`
+  a package name the index declares. Self-testing, on the fast line. It must skip
+  comment lines and heredoc bodies, for the reason `check-workflow-repo-env`
+  documents: a gate that cannot tell a command from a sentence about a command is
+  worse than no gate.
+* **The conversions.** `docs.yml` and `nightly.yml`'s clang step become
+  `nros setup --system --sudo` (or a narrower `--tool`). colcon-parity becomes
+  `container: ghcr.io/newslabntu/nano-ros-ci:humble` — `images.yml` builds that
+  image and describes it as *"ROS 2 Humble + host tools, the base `container:`
+  for the check / …"*, and **only `nightly.yml` uses it today**. A ROS desktop
+  stack is installed by apt on every colcon-parity run for want of one line.
+
+Acceptance: the gate reproduces each of the three sites before the fix and passes
+after; no workflow apt-installs an indexed package.
+
+## W4 — decide what the required check promises on a pull request
+
+`test-unit` does not run on `pull_request` — only on `merge_group`, `schedule`
+and `workflow_dispatch`. So a PR shows a green required `CI` having never run a
+unit test; they run first in the merge queue.
+
+Nothing broken lands, because the queue is the real gate and `queue-notify.yml`
+exists to comment on ejections. But CLAUDE.md states the required context *is*
+`check-fast` + `test-unit` + `check-cli-tests`, which is true only in the queue.
+Either the trigger list gains `pull_request` (cost: unit tests on every push to
+every PR) or the doc stops claiming it. **Pick one and write down why** — the
+value of this line is that a contributor can predict what green means.
+
+Acceptance: the doc and the trigger list agree, and the reasoning is recorded
+next to whichever moved.
+
+## W5 — one scope vocabulary
+
+phase-411 W4: a CI job is `just setup <scope>` then one command a developer can
+type. Three lanes do this; three do not.
+
+| workflow | provisioning | work |
+| --- | --- | --- |
+| `build-wide` | `just setup tier2` | `just ci matrix build` |
+| `run-matrix` | `just setup tier2` | `just ci matrix` |
+| `nightly` (matrix) | `just setup tier2-nightly` | `just ci matrix-nightly` |
+| `host-tests` | `nros setup --source` ×6, `--tool` ×3, `provision-zenohd`, `setup-launch-resolve` | `just native build-fixture-rust-core`, `just native build-workspace-fixtures`, `just ci tier1` |
+| `queue` | 4 hand-rolled steps (W1) | `just ci l3` |
+| `nightly` (platform) | `just <plat> setup` + 6 more steps | `just <plat> test` |
+
+`nightly.yml` also repeats a 22-line *"Build nros CLI from packages/cli/"* block
+verbatim in four jobs.
+
+The conversion is only safe once the target verbs actually provision what the
+lane needs — which is what 0992's `_setup-common` starts and what W3 finishes for
+OS packages. Two provisioning verbs are still unreachable from `just setup`:
+`just ci provision-zenohd` and (before 0992) `setup-launch-resolve`. Absorb the
+first.
+
+Acceptance: every job body is `just setup <scope>` plus one command; the repeated
+CLI-build block exists once; `just ci provision-zenohd` is reachable from
+`just setup`.
+
+## W6 — DESIGN REQUIRED: `package.xml` as the dependency SSoT (rosdep parity)
+
+**This one is not an implementation task and must not be started as one.** It
+changes what a `package.xml` means in this repo, so it needs an RFC first.
+
+The intent is the rosdep experience: dependencies are written in `package.xml`,
+the tool scans the packages, and installs accordingly. The two halves do not
+meet today:
+
+* **406 tracked `package.xml` files.** Their entire dependency vocabulary is ROS
+  message and build-tool keys — `std_msgs` (177), `example_interfaces` (106),
+  `ament_cmake` (19), `rosidl_default_*` (27), plus workspace-local node
+  packages. **Not one names a system dependency.**
+* Those declarations are consumed **only by codegen** — which msg packages to
+  generate. No provisioning path reads them.
+* Provisioning reads `nros-sdk-index.toml`: `[prereq.*]`, `[rust.*]`,
+  `[python.*]`, `[source.*]`, `[tool.*]`. Hand-maintained and repo-global.
+
+So a `package.xml` cannot express "this package needs libssl-dev", and there is
+no `nros setup <workspace>` that walks a workspace's manifests and resolves their
+closure. The nearest thing, `nros setup --build-sources`, provisions a
+repo-global union from the index — not a per-workspace scan.
+
+Questions the RFC has to answer, none of which have obvious answers:
+
+1. **What is the key namespace?** rosdep keys are a curated global database
+   (`libssl-dev` → per-distro package names). Do we adopt rosdep keys, our own
+   `[prereq.*]` names, or accept both? A `package.xml` that only our tool can
+   read is a divergence from ROS, which is the thing the analogy exists to avoid.
+2. **Who owns the mapping?** Today `[prereq.*]` carries `apt`/`dnf`/`pacman`/
+   `brew` plus a `check` probe. That is a rosdep rules file in TOML. Does the
+   index stay the mapping and `package.xml` become the *declaration*, or do we
+   consume the real rosdep database where present?
+3. **What about the 406 existing files?** They declare message deps that must
+   keep meaning what they mean to codegen. A second meaning for the same tag is
+   how a file ends up with two readers that disagree.
+4. **Scope resolution.** `nros setup <workspace>` implies a workspace scope for
+   provisioning, which the phase-411 scope vocabulary does not currently have —
+   its scopes are platforms and lanes.
+5. **Does this subsume `--build-sources`?** If a workspace's manifests can state
+   their own needs, the repo-global union is a fallback, not the SSoT.
+
+Deliverable for W6 is **an RFC in `docs/design/`**, not code. Only once it is
+`Draft` and reviewed does an implementation work item get opened.
+
+## Acceptance for the phase
+
+* One spelling of the l3 lane, running once per change (W1).
+* Every verification lane green at least once, with the date recorded (W2).
+* A gate that fails when a workflow installs an indexed package, plus the three
+  conversions (W3).
+* The required check's promise and its trigger list agree (W4).
+* Every job body is `just setup <scope>` + one command (W5).
+* An RFC for `package.xml`-driven provisioning, reviewed, with an implementation
+  work item opened against it (W6).
+
+## What the audit found working, and this phase must not undo
+
+Recorded because a cleanup pass is exactly where these get deleted by accident:
+
+* `host-tests`' fixture steps `exit 1` on failure. The comment above them records
+  the ten runs where a green step sat over a failed build.
+* `gate.yml`'s `ci-ok` refuses a vacuous pass: a skipped `check` is accepted only
+  for a `pull_request` that `changes` proved touched no code; any other skip is a
+  hard failure.
+* `report-interlock-coverage.sh` turns "this self-hosted lane did not run" into a
+  stated outcome instead of silence.
+* `check-ci-no-verb-fallback` forbids one `just` verb falling back to another
+  with `||` — the shell spelling of skip-and-report-success.


### PR DESCRIPTION
Audit of all 11 workflows (issue 0996) plus the phase that carries the work items (phase-413).

## The finding that orders the phase

`just ci matrix build` dispatches to `_matrix-build`, whose body is `l3`. So `queue.yml` and `build-wide.yml` run the **same recipe on the same runner labels** — and disagree:

| commit | queue.yml (merge_group) | build-wide.yml (push main) |
| --- | --- | --- |
| `36c306405` | success 16:25:49 | **failure** 16:26:23 |
| `da0344af1` | success 17:02:18 | **failure** 16:43:26 |
| `ad5a8ecf9` | success 17:06:55 | **failure** 17:22:19 |
| `d2a8955c5` | success 01:23:54 | **failure** 17:27:51 |

The difference is four hand-rolled steps in `queue.yml`. **That boilerplate is load-bearing** — it is what hides issue 0992 from the queue while build-wide burns, and it means the same self-hosted lane is paid for twice per change.

## Work items

- **W1** collapse the duplicated l3 lane — blocked on 0992 (#208); then one spelling, running once.
- **W2** get each red lane green, in order. **Gates most of the rest**: four of six verification lanes are uniformly red, so no conversion can be verified in them.
- **W3** a gate that fails when a workflow installs an indexed package, plus three conversions (`doxygen`/`graphviz`, `clang`/`libclang-dev`, colcon-parity to `container: ci-base`).
- **W4** decide what the required check promises on a PR — `test-unit` does not run there, and the doc says it does.
- **W5** one scope vocabulary: every job body `just setup <scope>` + one command.
- **W6** **DESIGN REQUIRED** — `package.xml` as the dependency SSoT (rosdep parity). Deliverable is an **RFC, not code**.

## Why W6 is design work

It changes what a `package.xml` means here. All 406 tracked files declare only message and build-tool keys, consumed by codegen and by no provisioning path; provisioning reads `nros-sdk-index.toml` instead. The doc records the five questions an RFC must answer — key namespace, who owns the mapping, the existing files gaining a second meaning, workspace scope, and whether it subsumes `--build-sources` — rather than assuming any of them.

The phase also records what the audit found **working**, because a cleanup pass is where those get deleted by accident: the fixture steps that `exit 1` instead of laundering into a skip, `ci-ok`s refusal of a vacuous pass, `report-interlock-coverage`, and `check-ci-no-verb-fallback`.

Docs only. `just check fast`: 167 gates green (1 skipped — no bindgen-cli on this host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)