### PR TITLE
fix(phase-412 W1) + W4: main derives the right numbers and does not deliver them

### DIFF
--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -107,10 +107,19 @@ phase-403's rule is refuse rather than under-derive, and the island would save
 | `NROS_MAX_PUBLISHERS` | 16 | 14 |
 | `NROS_MAX_QUERYABLES` | 4 | 0 |
 
-    RAM   324834 (99.13%) -> 312088 (95.24%)   -12746 B
+    RAM   324834 (99.13%) -> 291144 (88.85%)   -33690 B
     DTCM   93744 (71.52%) ->  89320 (68.15%)    -4424 B
 
-17170 bytes, and RAM headroom goes from 0.87% to 4.76%.
+38114 bytes, and RAM headroom goes from 0.87% to 11.15% -- about 36 KB free
+where the Z4 image had under 3.
+
+An earlier draft of this section said 17170 bytes at 95.24%, measured before W4
+existed. That build had the pools DERIVED correctly and NOT DELIVERED: the
+inventory said 10/14/0 and the zenoh session was compiled with 8/8/8. The
+number understated the saving and, worse, described an image with eight
+subscriber slots for ten subscriptions -- a RUNTIME rejection, invisible at
+link. It is corrected here rather than left standing, and W4 is why it was
+found.
 
 ## THE RULE W1 COST, and it binds the rest of this phase
 
@@ -182,20 +191,52 @@ BEFORE the first spin, so 0900's advisory never prints — the failure cannot
 report itself. `MAX_CBS` was the right first consumer for the mirror-image
 reason: it fails at registration with `ExecutorFull`, which names the knob.
 
-## W4 — a gate that fails when a published number has no consumer
+## W4 — the delivery gate. LANDED 2026-09-03
 
-The reason this phase exists is that eight counts were published and one was
-read, and no test noticed for a month. The gate asserts the inverse of what the
-current ones assert: not "is the derived value right" — they already check that
-— but "is every published input READ by something".
+`scripts/check-knob-delivery.py`. For each knob, the number handed to the
+COMPILER must equal the number the resolver decided. Read from `build.ninja`
+rather than from cmake state, because that is the last artifact before the
+compiler and so cannot agree with cmake while disagreeing with the build.
 
-Concretely: enumerate `NROS_ENTITY_COUNT_*` and `NROS_DERIVED_*` from a fixture
-configure, and fail on a published symbol that no `.cmake` consumes. A new count
-then arrives with either a consumer or a deliberate exemption naming why.
+It asserts two identities: a DERIVED value must survive the trip to the
+resolver (the fragment's number equals `NROS_RESOLVED_*`), and every C define
+must equal its resolved knob, never be empty, and never hold two different
+values in one build.
 
-This is the "correct but unreachable" gate proposed during phase-403 and never
-built. Four instances have now been found by hand (0896, 0963, #152, and this
-one). It should stop being an audit.
+**What it caught, immediately, on work already pushed.** W1 produced SIX
+delivery failures and every other gate stayed green through all of them,
+because the others check the INVENTORY and the RESOLVER and all six were
+downstream of both:
+
+1. a second consumer -- the zpico C defines read raw `CONFIG_*`, before the
+   resolver ran
+2. a name that emptied -- a `foreach` built `NROS_DERIVED_NROS_MAX_SUBSCRIBERS`,
+   which names nothing; cmake yields EMPTY rather than failing
+3. no consumer default -- rung 4 leaves a knob UNRESOLVED for a Rust build
+   script with its own literal; a C define has none
+4. **a loader whitelist** -- `_nros_load_derived_entity_inventory` exports a
+   NAMED list, so a symbol the fragment sets and the list omits dies at the
+   function boundary
+5. **a knob resolved TWICE** -- the second call passed the raw Kconfig value,
+   which is the `-1` DERIVE SENTINEL, and it won as though someone had stated it
+6. the sentinel then reaching the build as `-1`
+
+Numbers 4 and 5 were LIVE IN PUSHED WORK and produced the mis-measurement
+corrected above. The gate names the knob and the mechanism; the compiler named
+a struct nobody edited, or nothing at all.
+
+The gate as this phase FIRST specified it -- "every published symbol has a
+consumer" -- catches none of the six. In every case the symbol had a consumer.
+
+**Self-test only in the fast tier**, because the end-to-end assertion needs a
+CONFIGURED build dir and the fast tier has none. Six cases, one modelled on
+each real failure, and each asserts a failure the gate must catch so a gate
+that stopped matching cannot report success. Point it at a real dir by hand:
+
+    python3 scripts/check-knob-delivery.py <build-dir>
+
+Verified against the island both ways: it FAILS on the pre-fix build naming all
+four dropped knobs, and passes on the fixed one.
 
 ## Acceptance
 

--- a/just/check.just
+++ b/just/check.just
@@ -179,6 +179,7 @@ fast-serial: \
     just-recipe-refs \
     kconfig-knob-forwarding \
     kconfig-overridden-values \
+    knob-delivery \
     knob-single-reader \
     lane-scope-consumers \
     lane-skip-protocol \
@@ -3758,6 +3759,24 @@ zenoh:
 [private]
 infra-queryable-counts:
     @python3 scripts/check-infra-queryable-counts.py
+
+# phase-412 W4 — the value that reaches the COMPILE is the value the resolver
+# produced. The knob gates beside this one check whether the derived number is
+# RIGHT; this one checks whether it ARRIVED, which is a different question and
+# the one that kept going wrong. W1 shipped six delivery failures in one wave
+# with every other gate green: a second consumer reading raw CONFIG_*, a name
+# that resolved to empty, a C consumer with no default under rung 4, a loader
+# whitelist that dropped symbols at a function boundary, and a knob resolved
+# twice where the second call won with the DERIVE sentinel. Two of those were
+# live in pushed work, and one built the zenoh session with 8 subscriber slots
+# for 10 subscriptions — a runtime failure, invisible at link.
+#
+# Self-test only here: the end-to-end assertion needs a CONFIGURED build dir,
+# which the fast tier does not have. Point it at one by hand:
+#     python3 scripts/check-knob-delivery.py <build-dir>
+[private]
+knob-delivery:
+    @python3 scripts/check-knob-delivery.py --self-test
 
 # phase-403 W9 (issue 0965) — the per-kind CALLBACK SLOT cost has ONE
 # definition, tied to the registration sites that actually claim a slot.

--- a/scripts/check-knob-delivery.py
+++ b/scripts/check-knob-delivery.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""phase-412 W4 -- the value that reaches the COMPILE is the value the resolver produced.
+
+WHY THIS EXISTS, and why it is not the gate that was first proposed.
+
+phase-412 W1 wired four session pools and produced FOUR delivery failures in
+one wave. Every existing gate stayed green through all four, because they check
+the INVENTORY (is the count right) and the RESOLVER (does precedence work), and
+all four failures were downstream of both:
+
+  1. a second consumer     the zpico C defines read raw CONFIG_*, before the
+                           resolver ran
+  2. a name that emptied   a foreach built NROS_DERIVED_NROS_MAX_SUBSCRIBERS,
+                           which names nothing; cmake yields EMPTY, not an error
+  3. no consumer default   rung 4 leaves a knob UNRESOLVED so a Rust build
+                           script uses its own literal; a C define has none, so
+                           it expands to nothing and sizes an array to zero
+  4. a loader whitelist    the fragment set the symbol, the loader did not name
+                           it, and it died at the function boundary -- the
+                           pools derived 10/14/0 and the SESSION was built with
+                           8/8/8. Eight subscriber slots for ten subscriptions,
+                           which fails at RUNTIME rather than at link
+
+The originally proposed gate -- "every published symbol has a consumer" --
+catches NONE of these. In all four the symbol had a consumer; a different
+consumer read around it, or a name never matched, or the value was legitimately
+absent, or it never crossed a scope.
+
+What catches all four is the end-to-end identity: for each knob, the number the
+compiler was handed must equal the number the resolver decided. This asserts
+that, against a real configured build dir.
+
+Usage:  check-knob-delivery.py <build-dir>
+        check-knob-delivery.py --self-test
+"""
+import os
+import re
+import sys
+import tempfile
+
+# Knobs whose resolved value must reach a C compile definition, and the define
+# it must reach. Extend this when a knob gains a C consumer -- the pairing is
+# the thing under test, so it is stated rather than discovered.
+C_DEFINE_KNOBS = {
+    "ZPICO_MAX_PUBLISHERS": "ZPICO_MAX_PUBLISHERS",
+    "ZPICO_MAX_SUBSCRIBERS": "ZPICO_MAX_SUBSCRIBERS",
+    "ZPICO_MAX_QUERYABLES": "ZPICO_MAX_QUERYABLES",
+    "ZPICO_MAX_LIVELINESS": "ZPICO_MAX_LIVELINESS",
+}
+
+# Knobs that are DERIVED and must not silently lose their derivation on the way
+# to the resolver: fragment value -> resolved value. A mismatch here is failure
+# 4 above, and it is invisible in the fragment and in the build alike.
+DERIVED_PAIRS = {
+    "NROS_DERIVED_MAX_SUBSCRIBERS": "NROS_RESOLVED_NROS_MAX_SUBSCRIBERS",
+    "NROS_DERIVED_MAX_PUBLISHERS": "NROS_RESOLVED_NROS_MAX_PUBLISHERS",
+    "NROS_DERIVED_MAX_QUERYABLES": "NROS_RESOLVED_NROS_MAX_QUERYABLES",
+    "NROS_DERIVED_RMW_SUBSCRIBER_SLOTS": "NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS",
+    "NROS_DERIVED_EXECUTOR_MAX_CBS": "NROS_RESOLVED_NROS_EXECUTOR_MAX_CBS",
+}
+
+
+def read_cache(build_dir):
+    """NROS_RESOLVED_* from CMakeCache.txt. Absent is DIFFERENT from empty."""
+    out = {}
+    path = os.path.join(build_dir, "CMakeCache.txt")
+    with open(path, encoding="utf8", errors="ignore") as fh:
+        for line in fh:
+            m = re.match(r"^(NROS_RESOLVED_[A-Z0-9_]+):[A-Z]+=(.*)$", line.strip())
+            if m:
+                out[m.group(1)] = m.group(2)
+    return out
+
+
+def read_fragment(build_dir):
+    """NROS_DERIVED_* as the entity inventory fragment states them."""
+    out = {}
+    path = os.path.join(build_dir, "nros", "entity_inventory.cmake")
+    if not os.path.exists(path):
+        return out
+    with open(path, encoding="utf8", errors="ignore") as fh:
+        for m in re.finditer(r"^set\((NROS_DERIVED_[A-Z0-9_]+)\s+([^)]*)\)", fh.read(), re.M):
+            out[m.group(1)] = m.group(2).strip().strip('"')
+    return out
+
+
+def read_defines(build_dir):
+    """The -D values the compiler is actually handed, from build.ninja.
+
+    The ninja file rather than the cmake state on purpose: it is the last
+    artifact before the compiler, so it cannot agree with cmake and disagree
+    with the build.
+    """
+    out = {}
+    path = os.path.join(build_dir, "build.ninja")
+    if not os.path.exists(path):
+        return out
+    with open(path, encoding="utf8", errors="ignore") as fh:
+        for m in re.finditer(r"-D([A-Z0-9_]+)=([0-9]*)", fh.read()):
+            name, val = m.group(1), m.group(2)
+            if name in C_DEFINE_KNOBS.values():
+                out.setdefault(name, set()).add(val)
+    return out
+
+
+def check(build_dir):
+    problems = []
+    cache = read_cache(build_dir)
+    frag = read_fragment(build_dir)
+    defines = read_defines(build_dir)
+
+    if not cache:
+        return ["no NROS_RESOLVED_* in %s/CMakeCache.txt -- not a configured "
+                "nano-ros build dir, or the resolver stopped running" % build_dir]
+
+    # 1. derivation must survive the trip to the resolver
+    for derived, resolved in DERIVED_PAIRS.items():
+        if derived not in frag:
+            continue  # nothing derived; rung 4 is legitimate
+        want = frag[derived]
+        if resolved not in cache:
+            problems.append(
+                "%s=%s was DERIVED but %s never reached the resolver. A loader "
+                "whitelist that does not name the symbol drops it at the "
+                "function boundary, and the knob then falls to a default that "
+                "may be SMALLER than the demand." % (derived, want, resolved))
+        elif cache[resolved] != want:
+            problems.append(
+                "%s=%s but %s=%s -- the resolver did not carry the derived "
+                "value through." % (derived, want, resolved, cache[resolved]))
+
+    # 2. every C define must equal its resolved knob, and never be empty
+    for knob, define in C_DEFINE_KNOBS.items():
+        rname = "NROS_RESOLVED_" + knob
+        seen = defines.get(define)
+        if seen is None:
+            continue  # backend not built here
+        if "" in seen:
+            problems.append(
+                "-D%s= reached the compiler EMPTY. An unresolved knob expands "
+                "to nothing and sizes a C array to zero; the diagnostic names "
+                "the struct, never the knob." % define)
+            continue
+        if len(seen) > 1:
+            problems.append(
+                "-D%s has %d different values in build.ninja (%s) -- two "
+                "consumers disagree about one knob."
+                % (define, len(seen), ", ".join(sorted(seen))))
+            continue
+        got = next(iter(seen))
+        want = cache.get(rname)
+        if want is None or want == "":
+            # The knob is unresolved but a value still reached the compiler:
+            # a literal fallback. Legitimate, but it must be SAID, because it
+            # is how an under-size hides.
+            continue
+        if got != want:
+            problems.append(
+                "-D%s=%s but %s=%s -- the compiler was handed a different "
+                "number than the resolver decided." % (define, got, rname, want))
+    return problems
+
+
+def self_test():
+    """Each case asserts a failure this gate must catch, plus the clean case,
+    so a gate that stopped matching anything cannot report success."""
+    def build(tmp, cache, frag, ninja):
+        os.makedirs(os.path.join(tmp, "nros"), exist_ok=True)
+        with open(os.path.join(tmp, "CMakeCache.txt"), "w") as fh:
+            fh.write(cache)
+        with open(os.path.join(tmp, "nros", "entity_inventory.cmake"), "w") as fh:
+            fh.write(frag)
+        with open(os.path.join(tmp, "build.ninja"), "w") as fh:
+            fh.write(ninja)
+
+    CLEAN_CACHE = ("NROS_RESOLVED_NROS_MAX_SUBSCRIBERS:INTERNAL=10\n"
+                   "NROS_RESOLVED_ZPICO_MAX_SUBSCRIBERS:INTERNAL=10\n")
+    CLEAN_FRAG = "set(NROS_DERIVED_MAX_SUBSCRIBERS 10)\n"
+    CLEAN_NINJA = "cc -DZPICO_MAX_SUBSCRIBERS=10 -c x.c\n"
+
+    cases = [
+        ((CLEAN_CACHE, CLEAN_FRAG, CLEAN_NINJA), 0, "a delivered value agrees end to end"),
+        # failure 4: derived, but the loader whitelist dropped it
+        (("NROS_RESOLVED_ZPICO_MAX_SUBSCRIBERS:INTERNAL=8\n",
+          CLEAN_FRAG, "cc -DZPICO_MAX_SUBSCRIBERS=8 -c x.c\n"), 1,
+         "derived but never reached the resolver"),
+        # failure 3: unresolved knob reaches the compiler empty
+        ((CLEAN_CACHE, CLEAN_FRAG, "cc -DZPICO_MAX_SUBSCRIBERS= -c x.c\n"), 1,
+         "an empty define"),
+        # failure 1: a second consumer handed a different number
+        ((CLEAN_CACHE, CLEAN_FRAG, "cc -DZPICO_MAX_SUBSCRIBERS=12 -c x.c\n"), 1,
+         "compiler and resolver disagree"),
+        # two consumers disagreeing with each other
+        ((CLEAN_CACHE, CLEAN_FRAG,
+          "cc -DZPICO_MAX_SUBSCRIBERS=10 -c x.c\ncc -DZPICO_MAX_SUBSCRIBERS=8 -c y.c\n"), 1,
+         "one knob, two values"),
+        # the derivation carried through wrongly
+        (("NROS_RESOLVED_NROS_MAX_SUBSCRIBERS:INTERNAL=4\n"
+          "NROS_RESOLVED_ZPICO_MAX_SUBSCRIBERS:INTERNAL=4\n",
+          CLEAN_FRAG, "cc -DZPICO_MAX_SUBSCRIBERS=4 -c x.c\n"), 1,
+         "resolver did not carry the derived value"),
+    ]
+    failures = 0
+    for (cache, frag, ninja), want, name in cases:
+        with tempfile.TemporaryDirectory() as tmp:
+            build(tmp, cache, frag, ninja)
+            got = len(check(tmp))
+            ok = (got >= 1) if want else (got == 0)
+            if not ok:
+                print("  self-test FAIL: %s -- got %d problem(s), want %s"
+                      % (name, got, "at least 1" if want else "0"))
+                failures += 1
+            else:
+                print("  ok    %s" % name)
+    if failures:
+        print("check-knob-delivery self-test: FAILED (%d)" % failures)
+        return 1
+    return 0
+
+
+def main(argv):
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+    if len(argv) != 2:
+        print(__doc__.strip().splitlines()[-3])
+        return 2
+    problems = check(argv[1])
+    if problems:
+        print("check-knob-delivery: a knob did not arrive as resolved:")
+        for p in problems:
+            print("  - %s" % p)
+        print("\n  phase-412 W4. The derived value being RIGHT is not the "
+              "question; whether it ARRIVED is.")
+        return 1
+    print("check-knob-delivery: every knob reached the compile as resolved.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -252,7 +252,17 @@ function(_nros_load_derived_entity_inventory)
         NROS_ENTITY_INVENTORY_REASON
         NROS_ENTITY_INVENTORY_ENTITY_TOTAL
         NROS_DERIVED_EXECUTOR_MAX_CBS
-        NROS_DERIVED_EXECUTOR_ACTION_CLIENTS)
+        NROS_DERIVED_EXECUTOR_ACTION_CLIENTS
+        # phase-412 W1. This list is a WHITELIST: a symbol the fragment sets
+        # but this loop does not name is loaded here and then dies at the
+        # function boundary, so the knob silently falls to rung 4. That cost a
+        # shipped under-size -- the pools derived 10/14/0 and the zenoh session
+        # was built with 8/8/8, which is 8 subscriber slots for 10
+        # subscriptions and fails at RUNTIME, not at link.
+        NROS_DERIVED_MAX_SUBSCRIBERS
+        NROS_DERIVED_RMW_SUBSCRIBER_SLOTS
+        NROS_DERIVED_MAX_PUBLISHERS
+        NROS_DERIVED_MAX_QUERYABLES)
         if(DEFINED ${_v})
             set(${_v} "${${_v}}" PARENT_SCOPE)
         endif()
@@ -446,8 +456,13 @@ function(nros_resolve_knobs)
 
     # nros-rmw-cffi's static subscription-handle pool. Backend-independent:
     # the no_std slot path is in the cffi adapter, not in a transport.
-    _nros_resolve_knob(NROS_RMW_SUBSCRIBER_SLOTS
-        "${CONFIG_NROS_RMW_SUBSCRIBER_SLOTS}")
+    #
+    # phase-412 W1/W4 -- resolved ABOVE, with the other session pools, because
+    # it is derivable now. A second `_nros_resolve_knob` here would re-resolve
+    # it from the raw Kconfig value, which is the `-1` DERIVE SENTINEL, and the
+    # sentinel would win as though someone had stated it: the knob reached the
+    # build as -1 while the inventory had derived 10. check-knob-delivery is
+    # what found it, and this comment is here so it is not re-added.
 
     # The arena is tri-state. nros-node build.rs DERIVES a size when the knob
     # is absent, so forwarding a literal 0 would hand it a zero-byte arena


### PR DESCRIPTION
Follow-up to #217, which auto-merged before this fix reached it. **main is currently wrong** and this is the fix.

## What is broken on main right now

#217 derives the session pools correctly and does not deliver them. The inventory says 10/14/0; the zenoh session is compiled with **8/8/8** -- eight subscriber slots for ten subscriptions. That fails at RUNTIME, not at link, and every gate in the tree calls it green.

Two causes:

- **A loader whitelist.** `_nros_load_derived_entity_inventory` exports a NAMED list. A symbol the fragment sets and the list omits is loaded and then dies at the function boundary, so the knob falls to rung 4 and a default that may be SMALLER than the demand.
- **A double resolution.** `NROS_RMW_SUBSCRIBER_SLOTS` is resolved again further down with the raw Kconfig value, which is the `-1` DERIVE SENTINEL. The second call wins, and the sentinel reaches the build as though someone had stated it.

Both fixed here. The island then delivers what it derives:

    -DZPICO_MAX_SUBSCRIBERS=10  -DZPICO_MAX_PUBLISHERS=14  -DZPICO_MAX_QUERYABLES=0
    NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS=10

| region | Z4 baseline | with this fix | delta |
| --- | ---: | ---: | ---: |
| RAM | 324834 (99.13%) | **291144 (88.85%)** | **-33690** |
| DTCM | 93744 (71.52%) | 89320 (68.15%) | -4424 |

**38114 bytes.** #217's description claims 17170 at 95.24%; that measured the undelivered build, so it understated the saving AND described an image that would have rejected two subscriptions on the board. The phase doc is corrected in place here rather than left standing.

## W4 — the gate that found it

`scripts/check-knob-delivery.py`. For each knob, the number handed to the COMPILER must equal the number the resolver decided, read from `build.ninja` because that is the last artifact before the compiler and so cannot agree with cmake while disagreeing with the build.

**Six delivery failures in this one wave**, none in the arithmetic -- the derived values were right at every step:

1. a second consumer reading raw `CONFIG_*` before the resolver
2. a `foreach` building a name that resolved to EMPTY (cmake yields empty, not an error)
3. a C consumer with no default under rung 4
4. the loader whitelist above
5. the double resolution above
6. the sentinel reaching the build as `-1`

The gate as phase-412 FIRST specified it -- "every published symbol has a consumer" -- catches **none** of them. In every case the symbol had a consumer; a different consumer read around it, or a name never matched, or the value never crossed a scope. That is why the doc now specifies the end-to-end identity instead.

Self-test only in the fast tier, since the end-to-end assertion needs a configured build dir. Six cases, one modelled on each real failure, each asserting a failure the gate must catch so a gate that stopped matching cannot report success. Verified both directions on the island: it FAILS on the pre-fix build naming all four dropped knobs, and passes on the fixed one.

## Gates

`just check fast` 169/169 (three gates SKIP on a stale in-tree CLI; green after `just setup-cli`).