### PR TITLE
test(#0976): an outside witness for the Cyclone action wire format — and it passes

### DIFF
--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -96,6 +96,55 @@ Then, and only then, one of two things becomes provable:
 Either way the answer comes from a test that has an outside witness, not from
 reading the adapters.
 
+## The witness exists now, and the answer is (1) — measured 2026-09-03
+
+`packages/testing/nros-tests/tests/ros2_action_e2e.rs`: a stock
+`ros2 action send_goal`, over `rmw_cyclonedds_cpp`, against the nano-ros action
+server (the `action-server` native Rust fixture built for Cyclone). Run against
+ROS 2 Humble on this host:
+
+```
+Goal accepted with ID: 297f46db62f840c38ff15c0a58b862c3
+Result:
+    sequence: [0, 1, 1, 2, 3, 5]
+Goal finished with status: SUCCEEDED
+```
+
+Discovery works too — `ros2 action info /fibonacci` reports `Action servers: 1`
+and names the node.
+
+**So the corrections are RIGHT.** A real ROS 2 client accepts the goal, receives
+feedback, and gets the correct sequence back, which is option 1 above: ROS 2
+interop passes WITH the adapters. They are not compensating for something that
+no longer exists, and they must not simply be deleted.
+
+The test asserts the RESULT CONTENT, not a zero exit: the adapters move bytes
+inside the goal and result messages, so a wrong shape surfaces as a wrong
+sequence or a goal never accepted. Checking only the exit status would pass on a
+server that accepted the goal and computed nothing.
+
+Mutation-tested rather than assumed — pointing it at an action nothing serves
+fails on the goal-accepted assertion, so the witness can go red.
+
+### What this unblocks, and what it does NOT settle
+
+`service.cpp`'s migration (issue 0970's service half, and the third site of
+issue 0969) now has something that would notice a wire-format change. That was
+the whole blocker: "blocked on there being any way to know whether it broke
+something".
+
+Not settled: **where** the corrections belong. Option 1 above says a passing
+interop test means migrating `service.cpp` requires moving each correction to
+the point where nano-ros SERIALIZES — a `uint8[16]` written with a length prefix
+is wrong for every backend, not only this one, and the message path already did
+exactly that (publisher.cpp's 233.6 comment records the Rust runtime being fixed
+to emit the fixed `octet[16]` and the matching strip being deleted from both
+sides). This test makes that move verifiable; it does not perform it.
+
+Also not covered: the reverse direction, an nros action CLIENT against a `ros2`
+action server. The adapters sit on both sides of the service path, and this
+witnesses one. That is the obvious next cell.
+
 ## Not to be confused with
 
 **#0970** (`0970-cyclone-rmw-should-own-its-sertype.md`, filed in PR #154 — not

--- a/packages/testing/nros-tests/tests/ros2_action_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros2_action_e2e.rs
@@ -1,0 +1,115 @@
+//! Issue 0976 — an OUTSIDE WITNESS for the Cyclone action wire format.
+//!
+//! `service.cpp` carries five per-action-type adapters that reshape CDR:
+//! `strip_goal_id_len_at` removes a 4-byte length prefix before a goal UUID,
+//! `strip_nested_cdr_at` removes a nested encapsulation header from inside a
+//! message, and three more special-case `_SendGoal_*` / `_GetResult_*`. Two of
+//! them DELETE BYTES — they correct a serialization that would otherwise be
+//! wrong on the wire.
+//!
+//! Until this file, the only thing exercising them was
+//! `test_native_cyclonedds_rust_action`, which is nano-ros server to nano-ros
+//! client. Both ends share whatever convention the adapters implement, so that
+//! test passes whether the bytes are ROS 2's or not — the single property the
+//! adapters exist to provide is the one property it cannot observe. The message
+//! and service paths already had witnesses (`ros2_pubsub_e2e`, `ros2_srv_e2e`);
+//! actions had none.
+//!
+//! This is that witness: a stock `ros2 action send_goal`, over
+//! `rmw_cyclonedds_cpp`, against the nano-ros action server. It is also what
+//! unblocks issue 0970's service half — migrating `service.cpp` to a blob
+//! sertype would change the action wire format, and nothing in the tree could
+//! tell.
+
+use std::process::Command;
+
+use nros_tests::{
+    fixtures,
+    ros_env::{HostRosEnv, Middleware, RosEnv},
+    ros2::{DEFAULT_ROS_DISTRO, require_ros2_cyclonedds},
+};
+
+/// A domain no concurrent copy of this test will pick.
+///
+/// Same scheme as the shell harnesses and `nros_tests::unique_ros_domain_id`:
+/// a fixed domain is a shared bus, and two overlapping runs discover each
+/// other's writers — which reads as a delivery bug rather than a collision
+/// (issue 0580).
+fn action_domain() -> u8 {
+    nros_tests::unique_ros_domain_id()
+}
+
+/// A real ROS 2 client drives a goal on the nano-ros action server.
+///
+/// Asserts the RESULT CONTENT, not merely that the call returned: the adapters
+/// move bytes around inside the goal and result messages, so a wrong shape
+/// shows up as a wrong sequence or a goal that is never accepted. Checking only
+/// for a zero exit would pass on a server that accepted the goal and computed
+/// nothing, which is the vacuous shape `check-no-vacuous-tests` exists for.
+#[test]
+fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
+    if !require_ros2_cyclonedds() {
+        nros_tests::skip!("ROS 2 + rmw_cyclonedds_cpp not available");
+    }
+
+    let server_bin = fixtures::build_native_rust_example_rmw(
+        "action-server",
+        "action-server",
+        fixtures::Rmw::Cyclonedds,
+    )
+    .unwrap_or_else(|e| {
+        nros_tests::skip!("native rust cyclonedds action-server fixture: {e}");
+    });
+
+    let domain = action_domain();
+    let mut server = Command::new(&server_bin)
+        .env("RMW_IMPLEMENTATION", "rmw_cyclonedds_cpp")
+        .env("ROS_DOMAIN_ID", domain.to_string())
+        .spawn()
+        .expect("start the nano-ros action server");
+
+    // Discovery over DDS multicast is not instant, and `send_goal` on an
+    // undiscovered action fails rather than waiting.
+    std::thread::sleep(std::time::Duration::from_secs(6));
+
+    // `RosEnv`, not a hand-rolled `source /opt/ros/...` (RFC-0058). A second
+    // spelling drifts from the first invisibly: the last one dropped the peer's
+    // ROS_DOMAIN_ID, and another hardcoded `humble` so every guarded test
+    // skipped forever on a jazzy host. `check-ros-env-spelling` caught this
+    // file doing exactly that.
+    let env = HostRosEnv::new(
+        DEFAULT_ROS_DISTRO,
+        Middleware::Cyclonedds { domain_id: domain },
+    );
+    let out = env
+        .run("timeout 60 ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci '{order: 5}'")
+        .expect("run ros2 action send_goal");
+
+    let _ = server.kill();
+    let _ = server.wait();
+
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        text.contains("Goal accepted"),
+        "a stock ROS 2 client must get the goal ACCEPTED — if the goal-id \
+         adapter reshapes the UUID wrongly the server never accepts.\n{text}"
+    );
+    assert!(
+        text.contains("SUCCEEDED"),
+        "the goal must reach SUCCEEDED, not merely be accepted.\n{text}"
+    );
+    // Fibonacci(5) — the result travels the `_GetResult_Response_` path, which
+    // is the one carrying the hand-built struct workaround (phase 171.0.b).
+    for n in ["0", "1", "2", "3", "5"] {
+        assert!(
+            text.contains(&format!("- {n}")),
+            "the result sequence must contain {n}; a reshaped result decodes \
+             to the wrong numbers rather than failing.\n{text}"
+        );
+    }
+}


### PR DESCRIPTION
0976's whole point: five CDR-reshaping adapters in `service.cpp` have **no test
that can observe the property they exist to provide**. The only thing exercising
them is nano-ros server ↔ nano-ros client, where both ends share whatever
convention the adapters implement — so it passes whether the bytes are ROS 2's or
not. The message and service paths have witnesses (`ros2_pubsub_e2e`,
`ros2_srv_e2e`); actions had none.

This is that witness: a stock `ros2 action send_goal` over `rmw_cyclonedds_cpp`
against the nano-ros action server. Against ROS 2 Humble:

```
Goal accepted with ID: 297f46db62f840c38ff15c0a58b862c3
Result: sequence: [0, 1, 1, 2, 3, 5]
Goal finished with status: SUCCEEDED
```

`ros2 action info /fibonacci` also reports `Action servers: 1`, so discovery
works as well as the goal round trip.

## The answer is 0976's option 1: the corrections are RIGHT

A real ROS 2 client accepts the goal, receives feedback, and gets the correct
sequence. The adapters are **not** compensating for something that no longer
exists, and must not simply be deleted.

## It can fail

- Asserts **result content**, not a zero exit — the adapters move bytes inside
  the goal and result messages, so a wrong shape shows up as a wrong sequence or
  a goal never accepted. Checking the exit status alone would pass on a server
  that accepted the goal and computed nothing.
- **Mutation-tested**: pointed at an action nothing serves, it fails on the
  goal-accepted assertion.
- Skips cleanly on a stale fixture (the guard fired on the first run).

## The gate caught my first version

It hand-rolled `source /opt/ros/<distro>/setup.bash`, and
`check-ros-env-spelling` refused the push — correctly. That's the second spelling
whose last instance dropped the peer's `ROS_DOMAIN_ID` and hardcoded `humble`. It
now goes through `nros_tests::ros_env::HostRosEnv` + `Middleware::Cyclonedds`
(RFC-0058), which is also how the domain reaches the *peer* and not just the
server.

## What this unblocks

`service.cpp`'s migration — issue **0970**'s service half, and the third site of
issue **0969** — now has something that would notice a wire-format change. That
was the stated blocker: *"blocked on there being any way to know whether it broke
something"*.

**Not settled:** *where* the corrections belong. A passing interop test means
migrating `service.cpp` requires moving each correction to the point where
nano-ros **serializes** — a `uint8[16]` with a length prefix is wrong for every
backend, and the message path already did exactly that. This makes the move
verifiable; it doesn't perform it. The reverse direction (nros action client → a
`ros2` action server) is uncovered and is the obvious next cell.

## One judgement call worth review

This builds a fixture directly rather than carrying an `interop::CELLS` row. It
mirrors `native_api.rs`'s `test_native_cyclonedds_rust_action`, which builds the
same fixture the same way and also carries no row; `matrix_fixture_coverage` is
green (10/10). If the convention is meant to bind ROS 2 witnesses to cells, this
and its sibling should move together.

`just check fast`: 168 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa