### PR TITLE
docs(roadmap): every open issue gets a home phase — 36 had none

### DIFF
--- a/docs/roadmap/phase-296-system-model-consumption.md
+++ b/docs/roadmap/phase-296-system-model-consumption.md
@@ -1117,3 +1117,15 @@ swap its entries, rebuild its fixtures, run its e2e), so each step stays
 green. When the R3 deprecation warning fires in zero fixture builds, R4's
 code removal (require `--model`, delete the `launch` arm + `launch_synth`)
 becomes a mergeable, test-green change.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0760](../issues/0760-ingress-declaration-schema-belongs-to-ros-launch-manifest.md) | RFC-0074's `ingress` declaration is a ros-launch-manifest schema change, not a nano-ros one — it gates what the model can carry |
+

--- a/docs/roadmap/phase-355-dependency-and-fork-debt.md
+++ b/docs/roadmap/phase-355-dependency-and-fork-debt.md
@@ -145,3 +145,15 @@ the lockfiles:
 * **No fork rebase as part of this phase.** W2 decides what to upstream; the
   mechanical rebase is separate work under the vendored-fork branch workflow in
   CLAUDE.md (fork branch pushed FIRST, then the superproject pointer).
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0910](../issues/0910-zenoh-pico-1-10-migration.md) | migrating to zenoh-pico 1.10: the serial layer moved and `config.h` is no longer generated the same way — carried-fork debt coming due |
+

--- a/docs/roadmap/phase-356-test-evidence-and-measurement-trust.md
+++ b/docs/roadmap/phase-356-test-evidence-and-measurement-trust.md
@@ -410,3 +410,18 @@ prints the assertion; wiring `sched_dims_applied_e2e` to run it is the next step
 * **Not chasing flakes.** Full-sweep QEMU lanes flake under load (287-W7), and a
   solo red can be a stale-build artifact (issue 0268). That is a known,
   documented confounder, not this phase's subject.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0820](../issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md) | a NuttX e2e that failed on a MUSEUM BINARY — the seam had no freshness probe, so the run reported on a tree that no longer existed |
+| [#0835](../issues/0835-fixture-staleness-probe-families-restale-each-other.md) | the cmake and rust fixture families re-stale each other, so a sweep can never be simultaneously fresh |
+| [#0930](../issues/0930-built-qemu-can-be-stale-against-its-pin.md) | the built QEMU can be older than the commit `third-party/qemu/qemu` pins, and nothing says so — every timing number is then about an unknown binary |
+| [#0968](../issues/0968-tier2-runtime-failures-unreproduced.md) | tier 2 has ~12 runtime e2e failures on main, UNREPRODUCED: nobody has run the tier in a long time, which is this phase's subject one tier up |
+

--- a/docs/roadmap/phase-358-embedded-runtime-under-load.md
+++ b/docs/roadmap/phase-358-embedded-runtime-under-load.md
@@ -445,3 +445,17 @@ debt this uncovered.
 * **Not touching #532** (platform clock resolution). Phase 352 is COMPLETE and
   its title claims exactly that scope; #532 should be checked for staleness
   against it rather than re-planned here.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0902](../issues/0902-action-goal-completion-is-variable.md) | action goals complete between 20 % and 90 % of the time on the same build — a load-dependent success rate, which is this phase's subject |
+| [#0913](../issues/0913-the-debugger-is-not-a-passive-instrument.md) | attaching pyocd RTT kills the zenoh session: the debugger perturbs the thing being measured |
+| [#0917](../issues/0917-an536-fragmented-sample-never-syncs.md) | the emulated LAN9118 RX FIFO cannot hold an 8-fragment RTPS burst — an overrun with a known cause |
+

--- a/docs/roadmap/phase-359-drop-std-campaign.md
+++ b/docs/roadmap/phase-359-drop-std-campaign.md
@@ -1314,3 +1314,15 @@ at all: seven `std`-gated `nros-node` tests that no lane ran, one of which had
 NEVER passed (issue 0577), and the extra-session wake install that was `std`-only
 on the dynamic path with no no_std multi-RMW test to catch it. Budget for that
 rather than treating each as a surprise.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0736](../issues/0736-realtime-tiers-timer-overrun-red-on-main.md) | `realtime_tiers` nuttx-arm/rust: the fast tier outruns the slow one. Mentioned in passing here; making it a work item so it has an owner |
+

--- a/docs/roadmap/phase-364-platform-abi-ask-do-not-assume.md
+++ b/docs/roadmap/phase-364-platform-abi-ask-do-not-assume.md
@@ -244,3 +244,16 @@ the Rust ports through the generator rather than by hand.
 * **No out-of-tree ports are known**, so the `attr` break has no external cost
   today; `attr_init` is what keeps later additions source-compatible if that
   stops being true.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0758](../issues/0758-platform-sntp-epoch-source.md) | no platform wall-clock epoch source, so embedded consumers hand-roll one — the ABI does not state a fact it owns |
+| [#0954](../issues/0954-nuttx-fallback-sizes-header-has-no-gate.md) | the committed NuttX fallback sizes header is a hand-maintained twin with no gate, and went stale. A size the platform should state, restated by hand |
+

--- a/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
+++ b/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
@@ -650,3 +650,17 @@ repo keeps re-learning.
   each pair and writes the ledger row.
 * `--show all` prints matching rows too, which is the fastest way to check
   whether a name you are about to add already correlates.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0783](../issues/0783-rust-facade-hides-the-error-vocabulary.md) | `RclReturnCode` exists and is unreachable, and RFC-0036 documents a Rust surface we do not export |
+| [#0784](../issues/0784-nros-facade-node-surface-is-three-audiences.md) | `nros::` publishes three different audiences under one namespace — parity is unreadable until the surface is separable |
+| [#0829](../issues/0829-two-system-default-qos-presets-disagree-on-depth.md) | two `SYSTEM_DEFAULT` QoS presets ship under one meaning and disagree on it |
+

--- a/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
+++ b/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
@@ -282,3 +282,15 @@ that there is no other thread to do the work.
 the lifecycle state machine over the wire while the node's own code cannot read
 it in-process in any language. The table is already `const`. That is a local
 accessor, not a graph query, and could land any time.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0788](../issues/0788-api-verbs-disagree-across-our-three-languages.md) | the same API verb is spelled differently in our C, C++ and Rust — the sweep this phase's lane choice depends on |
+

--- a/docs/roadmap/phase-382-unified-parameter-store-caller-owned.md
+++ b/docs/roadmap/phase-382-unified-parameter-store-caller-owned.md
@@ -403,3 +403,17 @@ producer question. The `EnvRung` asymmetry noted there belongs in RFC-0045.
 store-vs-wire mismatch (`MAX_ARRAY_LEN=32` against wire 64) is issue 0323's live
 behaviour. Streaming makes it moot for the handlers; unification does **not**
 remove it.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0793](../issues/0793-c-params-declared-via-legacy-store-invisible-to-ros2.md) | C ships two disjoint parameter stores; this phase must say which one survives |
+| [#0794](../issues/0794-baked-boot-config-is-one-field-deep-in-c.md) | the baked boot config carries four fields and the C/C++ emitter sets one |
+| [#0865](../issues/0865-no-example-registers-parameter-services.md) | parameter services are implemented and tested but undiscoverable: no docs, no example. A store nobody can find is not a store |
+

--- a/docs/roadmap/phase-383-colcon-like-builder.md
+++ b/docs/roadmap/phase-383-colcon-like-builder.md
@@ -872,3 +872,21 @@ migration.
 - **The phase is large.** W1–W7 is a builder; W8–W10 is a migration. If it must
   be cut, W1–W3 plus W8.a is a coherent shippable subset (Rust workspaces only,
   proven against a hostile tree); W4–W7 then follow per language.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0798](../issues/0798-c-freertos-entry-hardcodes-board-while-root-routes-s32z270.md) | `examples/workspaces/c`'s root routes `s32z270-freertos` to an entry that cannot serve it |
+| [#0809](../issues/0809-two-walks-honour-different-nros-ignore-spellings.md) | `provider_scan` honours `NROS_IGNORE` while `nros-pkg-index` does not — two discovery paths, one vocabulary |
+| [#0831](../issues/0831-per-image-rmw-is-inert-on-the-cargo-driver.md) | `[image.<id>].rmw` configures nothing on the cargo driver, so a declared RMW is silently inert |
+| [#0849](../issues/0849-nros-sync-bakes-the-invocation-path-spelling.md) | `nros sync` bakes the invocation's path SPELLING into every leaf patch, so a moved checkout resolves wrong |
+| [#0914](../issues/0914-resolver-shipped-pair-untested.md) | nothing exercises the SHIPPED resolver + `pyexec` pair, so a resolver that cannot load is indistinguishable from one that works |
+| [#0939](../issues/0939-probe-links-node-name-not-component-lib.md) | the metadata probe links the node NAME, which is not a target |
+| [#0953](../issues/0953-pyexec-panic-crosses-c-abi.md) | a panic in the Python half crosses `extern "C"` and ABORTS the resolver — the builder's own subprocess boundary |
+

--- a/docs/roadmap/phase-385-mps3-an536-freertos-board.md
+++ b/docs/roadmap/phase-385-mps3-an536-freertos-board.md
@@ -268,3 +268,16 @@ now has a working implementation of both to copy.
 * Replacing the S32Z270 bundle. This board proves the ARMv8-R SOFTWARE stack;
   NETC, PBcfg, the licensed `GCC/ARM_CR52_GIC` port and flash/boot stay
   hardware-gated there.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0772](../issues/0772-freertos-lwip-wall-clock-epoch.md) | FreeRTOS/lwIP has no wall-clock epoch — the same gap issue 0758 states for the platform ABI, on this board |
+| [#0830](../issues/0830-qemu-hub-two-port-tap-rx.md) | a QEMU net hub with only a NIC and a tap never delivers host->guest frames |
+

--- a/docs/roadmap/phase-391-allocation-unification-and-tier-model.md
+++ b/docs/roadmap/phase-391-allocation-unification-and-tier-model.md
@@ -850,3 +850,17 @@ probes have already passed that gate vacuously at `symbols read: 1`.
 - Whether `heap` survives as a storage mode at all. Payload buffers staying
   static means no payload field needs it; the question is whether infrastructure
   use justifies keeping a mode nobody applies to messages.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0816](../issues/0816-no-alloc-claimed-but-unenforced.md) | the book promises no-alloc integrations and nothing checks the linked image |
+| [#0827](../issues/0827-unused-rmw-pools-dominate-static-ram.md) | static RAM is a property of the RMW, not of the node |
+| [#0857](../issues/0857-cell-registry-inline-capacity-heap-regression.md) | ComponentCell's inline registries cost worst-case x biggest-payload heap per component |
+

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1148,3 +1148,16 @@ of what the mechanism WOULD save, on a leaf where the mechanism does not run.
 Nothing in this wave should be quoted as a shipped saving until the `mixed` case
 is explained and a before/after `mem-report` exists.
 
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md) | the zenoh read task inherits the executor's priority on Zephyr |
+| [#0880](../issues/0880-tcm-unused-while-sram-exhausted.md) | 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted |
+| [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a full round trip |
+

--- a/docs/roadmap/phase-393-rmw-contract-remainder.md
+++ b/docs/roadmap/phase-393-rmw-contract-remainder.md
@@ -161,3 +161,17 @@ phase-376 (issue 0800), it caught issue 0785's enclave grouping, and it caught
 `set_log_severity`, which shipped with a slot, a dispatcher and stub tests and
 no backend body for two phases. Before claiming any symbol here, run
 `check-rmw-slot-producers` and look at which column it lands in.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0970](../issues/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip |
+| [#0971](../issues/0971-take-sequence-cannot-say-why-it-stopped.md) | `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it |
+| [#0976](../issues/0976-service-action-adapters-tested-only-against-ourselves.md) | five action adapters in the Cyclone service path reshape the CDR to match ROS 2, exercised only by nano-ros talking to itself. This is the VERIFICATION remainder W3 names |
+

--- a/docs/roadmap/phase-395-dev-workflow-migration.md
+++ b/docs/roadmap/phase-395-dev-workflow-migration.md
@@ -872,3 +872,19 @@ Stated so this is falsifiable rather than a one-way door:
 - If batch reds are more often flakes than defects, W5 failed; stop batching.
 - If the self-hosted runner becomes a single point of failure for landing,
   move L3 back to hosted and accept a narrower L3.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0895](../issues/0895-format-walks-unbuilt-colcon-workspace-leaves.md) | `just format` is red or green depending on whether a migrated colcon workspace has been BUILT |
+| [#0925](../issues/0925-box-sync-copies-generated-manifests.md) | `ros2-box-sync.sh` copies the GENERATED workspace manifests, so the box and the host disagree |
+| [#0957](../issues/0957-format-blocked-by-unexcluded-workspace-leaf.md) | `just format` fails whole-tree — a workspace leaf is in neither the root members nor the excludes |
+| [#0986](../issues/0986-pre-push-hook-corrupts-the-repo-it-guards.md) | the pre-push hook writes into the repository it is guarding |
+| [#0988](../issues/0988-hook-scripts-never-exercised-under-a-hook-environment.md) | no gate runs a hook the way git runs it — with `GIT_DIR` set — so a hook can pass every check and still fail in git's hands |
+

--- a/docs/roadmap/phase-396-merge-queue-throughput-policy.md
+++ b/docs/roadmap/phase-396-merge-queue-throughput-policy.md
@@ -204,3 +204,17 @@ then green again with W1 restored. 17 self-test assertions, on the normal path.
 - [Merge queue best practices — Graphite](https://graphite.com/guides/merge-queue-best-practices)
 - [GitHub Merge Queue in 2026 — Tenki](https://tenki.cloud/blog/github-merge-queue-setup)
 - [Pre and post-merge tests using a merge queue — Aviator](https://www.aviator.co/blog/pre-and-post-merge-tests-using-a-merge-queue/)
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0871](../issues/0871-ci-check-build-asserts-fixtures-it-never-builds.md) | every PR red on a fixture CI never builds, and `main` cannot see it because the required gate does not run on push |
+| [#0872](../issues/0872-pr-arm-example-check-needs-nros-sync.md) | the PR/nightly check arm has never run to completion — each fix exposes the next environment gap. The pattern this phase keeps meeting |
+| [#0874](../issues/0874-sccache-ghac-v1-sunset-breaks-every-rustc.md) | sccache 0.8.2 speaks a GitHub cache API that no longer exists, so the compile tier pays full cost on every run |
+

--- a/docs/roadmap/phase-400-rust-dependency-weight-audit.md
+++ b/docs/roadmap/phase-400-rust-dependency-weight-audit.md
@@ -1551,3 +1551,15 @@ no measurement in this phase has touched.
   does not drop their `#[no_mangle]` exports. Machete cannot see `extern crate`
   force-links. Its output needs per-row triage against that pattern before any of
   it is acted on; W1 is the one row confirmed by reading the source.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0945](../issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | the shared-cargo-dir campaign rests on five unsupported build-system assumptions — the exposure register, made a work item |
+

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -218,3 +218,15 @@ has configured at least twice, and W1's acceptance test must state which.
 
 Anything in this phase that adds a knob derived from the entity inventory
 inherits that lag. It is worth fixing before W1 multiplies it by six.
+
+## Issues homed here (survey 2026-09-03)
+Every open issue was checked for a home phase; these had none, or were
+mentioned here only in passing. A mention is not an owner — an issue with
+no work item is an issue nobody is accountable for, which is the same shape
+as a gate sitting in a lane no CI job runs. Each row is a work item: the issue
+holds the evidence, the item is *close it*.
+
+| issue | why it belongs here |
+| --- | --- |
+| [#0991](../issues/0991-a-clean-build-of-an-entity-declaring-image-does-not-link.md) | a clean build of an entity-declaring image derives the WRONG payload basis and does not link |
+

--- a/docs/roadmap/phase-414-rtos-runtime-correctness.md
+++ b/docs/roadmap/phase-414-rtos-runtime-correctness.md
@@ -1,0 +1,66 @@
+# Phase 414 — RTOS runtime correctness: the e2e failures that reproduce SOLO
+
+**Status (2026-09-03). Opened as a HOME, not as a plan.** Five open issues had
+no phase that could hold them, and the survey that found that is the whole
+reason this doc exists — an issue with no home is an issue nobody is
+accountable for, the same shape as a gate that sits in a lane no CI job runs.
+No work item here has been started.
+
+## Why these five are one phase, and why the two neighbours could not take them
+
+They are RUNTIME failures on a real RTOS: the image builds, links and boots, and
+then does the wrong thing. That is a different activity from either neighbour:
+
+* **[phase-349](phase-349-rtos-integration-shells.md)** is BUILD integration —
+  "make FreeRTOS an imported library like the rest". It is about how the RTOS
+  enters the build, not about what the image does afterwards.
+* **[phase-358](phase-358-embedded-runtime-under-load.md)** is footprint,
+  overrun and overload — failures that appear when you PUSH the runtime. These
+  five fail at rest.
+
+The distinguishing property, and the reason they are worth grouping: **each
+reproduces SOLO.** CLAUDE.md's standing advice for a QEMU red is to retest it
+alone before believing it, because full-sweep lanes flake under load. These
+already survive that test, so they are not the flake class — they are defects
+with a stable reproduction and no owner.
+
+## Work items
+
+Each is an existing issue. The item is "close it"; the issue holds the evidence.
+
+* **W1 — [issue 0877](../issues/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md),
+  FreeRTOS pubsub delivers NOTHING under the test.** The most severe: a
+  transport that hand-delivers and then delivers nothing at all. Start here —
+  a platform that cannot pass its own pubsub e2e makes every other FreeRTOS
+  result unreadable.
+* **W2 — [issue 0867](../issues/0867-nuttx-c-action-goal-send-times-out.md),
+  `test_rtos_action_e2e` nuttx/C fails 3/3 SOLO.** Explicitly not the load
+  flake; three of three alone.
+* **W3 — [issue 0870](../issues/0870-nuttx-cpp-action-client-transport-tx-failed.md),
+  NuttX C++ `create_action_client` fails.** Likely shares a cause with W2 —
+  same platform, same entity family, different language binding. Do them
+  adjacently and say whether the cause was shared; if it was, that is one fix
+  and the phase shrinks.
+* **W4 — [issue 0847](../issues/0847-xrce-entity-drop-after-session-close.md), an XRCE
+  publisher outliving `executor.close()` segfaults in its own Drop.** A
+  lifetime/ordering defect, not a transport one. It is the only one here whose
+  fix is likely in our own Rust rather than in a vendored stack.
+* **W5 — [issue 0741](../issues/0741-xrce-service-reply-history-payload-too-small.md),
+  `test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the
+  request.** INTEROP with a real ROS 2 peer, so it may belong with
+  [phase-303](phase-303-xcdr2-interop.md) instead; it sits here because it is
+  an XRCE service failure like W4's neighbourhood and because 303 is about
+  XCDR2 encoding specifically. **Move it if the cause turns out to be
+  encoding.**
+
+## Acceptance
+
+* Each of the five is resolved, or reassigned to a phase that fits better with
+  the reason recorded.
+* For W2/W3, an explicit statement of whether the cause was shared — that
+  answer is worth more than either fix.
+
+## What this phase deliberately does NOT do
+
+It does not add tests, lanes or gates. Every one of these already has a failing
+test; the problem is that nothing was accountable for making them pass.


### PR DESCRIPTION
Docs only. No code, no gates, no CI changes.

## What the survey found

All 66 open issues, checked against the 70 active phase docs:

| | count |
| --- | ---: |
| open issues | 66 |
| already a work item in an active phase | 14 |
| mentioned by a phase, but only **in passing** | 16 |
| mentioned by **no** active phase at all | 36 |

The middle row is the interesting one. Being "homed" mostly meant a phase said the issue's number somewhere in prose. `phase-392` genuinely says *"W2 IS issue 0900"* — that's an owner. *"Filed as issue 0736"* is a footnote. **A mention is not an owner: an issue with no work item is an issue nobody is accountable for.**

## What this adds

Each target phase gains one `## Issues homed here (survey 2026-09-03)` section — a table of (issue, why it belongs here), one row per work item. Batched per phase rather than 47 edits scattered through them, so it reads as one deliberate act and reverts as one.

```
phase-356 test evidence          0820 0835 0930 0968
phase-396 merge queue            0871 0872 0874
phase-393 rmw contract remainder 0970 0971 0976
phase-358 runtime under load     0902 0913 0917
phase-395 dev workflow           0895 0925 0957 0986 0988
phase-383 colcon-like builder    0798 0809 0831 0849 0914 0939 0953
phase-379 api parity             0783 0784 0829
phase-382 parameter store        0793 0794 0865
phase-391 allocation/tier model  0816 0827 0857
phase-392 static memory          0852 0880 0969
phase-385 mps3-an536 board       0772 0830
phase-364 platform ABI           0758 0954
phase-355 dependency/fork debt   0910
phase-359 drop-std               0736
phase-381 graph queries          0788
phase-296 system model           0760
phase-400 dependency weight      0945
phase-412 derived counts         0991
```

## Only one new phase

The instruction was "create home phases if there is no open one". The honest answer turned out to be that nearly every orphan **did** have a plausible home, matched by topic rather than by existing mention — creating six cluster phases would have duplicated `phase-356`, `phase-396`, `phase-393` and others that already scope exactly that work.

**`phase-414` — RTOS runtime correctness** (0741, 0847, 0867, 0870, 0877) is the one cluster with no home, and the doc states why the neighbours can't take it: `phase-349` is *build* integration, `phase-358` is footprint and overload. These five fail **at rest**, and each reproduces **solo** — so they are not the load-flake class CLAUDE.md warns about, they are defects with a stable reproduction and no owner. Opened as a home, not a plan; no work started.

**Result: 0 of 66 open issues now lack an active phase that names them.**

## A claim I had to retract

An earlier draft of this commit said 16 links in the phase docs were broken because their issues had been archived, and that *"nothing checks that a link into `docs/issues/` still resolves after an archive"*.

**Both halves were wrong.** `check-doc-refs` checks exactly that and understands archive redirection — which is why those 16 pass and my own naive scan was the thing at fault. The gate then caught the one genuinely dangling reference in this change: a link to `archived/0993-…`, an issue this branch does not create. Removed, along with its prose mentions, so the branch stands alone on `main`.

All 47 links added here resolve. `check-doc-refs` and the fast line are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSuM4yABT9i6XzprmNn1op