### PR TITLE
fix: the two nightly cell prerequisites — build-std targets and jsonschema

### DIFF
--- a/ci/docker/zephyr-ros/Dockerfile
+++ b/ci/docker/zephyr-ros/Dockerfile
@@ -131,7 +131,8 @@ RUN pip3 install --no-cache-dir \
         PyYAML==6.0.2 \
         pykwalify==1.8.0 \
         packaging==24.2 \
-    && python3 -c 'import west, elftools, yaml, pykwalify, packaging' \
+        jsonschema==4.23.0 \
+    && python3 -c 'import west, elftools, yaml, pykwalify, packaging, jsonschema' \
     && west --version
 
 # uv (Python 3.12 for the Zephyr 4.4 line) + just (recipe runner). Both via

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -317,6 +317,50 @@ impl BuildRungs {
         })
     }
 
+    /// A platform with NO `nros-platform.toml` has no rungs, and that is a
+    /// normal state — not an error.
+    ///
+    /// phase-400 W6 REGRESSION, and this is the second half of issue 0979.
+    /// `nros-node/build.rs` resolved the platform with `.ok()` before the rungs
+    /// moved here; the move turned an absent descriptor into a `panic!`. Three
+    /// of the platforms this tree builds — `threadx-linux`, `esp32`,
+    /// `zephyr` — have never had a descriptor, so every one of their images
+    /// died in a build script:
+    ///
+    /// ```text
+    /// NROS_PLATFORM_NAME=threadx-linux: unknown platform `threadx-linux`:
+    ///   no …/packages/platform/threadx-linux/nros-platform.toml
+    /// ```
+    ///
+    /// 0979 fixed the ROOT being empty, which is why the message now names a
+    /// real path. It did not fix this: a correct root still has no file for a
+    /// platform that declares none.
+    ///
+    /// What stays fatal is a descriptor that EXISTS and is broken — `Io`,
+    /// `Parse`, `Manifest`, a cycle, an arch conflict. Those are a wrong
+    /// answer; an absent file is no answer, and no answer means the builtin
+    /// defaults every knob already carries. The warning keeps it visible, so a
+    /// TYPO in `NROS_PLATFORM_NAME` still shows up rather than silently
+    /// selecting builtins — which is the one thing the panic was buying.
+    ///
+    /// One helper, not three call sites with three spellings: the panic existed
+    /// three times over (executor, params, memory) and would have been fixed
+    /// once and left twice.
+    fn or_builtin_rungs<T: Default>(&self, what: &str, r: Result<T, ConfigError>) -> T {
+        match r {
+            Ok(v) => v,
+            Err(ConfigError::UnknownPlatform { .. }) => {
+                println!(
+                    "cargo:warning=NROS_PLATFORM_NAME={}: no nros-platform.toml, \
+                     so the {what} knobs fall through to their builtin defaults",
+                    self.platform
+                );
+                T::default()
+            }
+            Err(e) => panic!("NROS_PLATFORM_NAME={}: {e}", self.platform),
+        }
+    }
+
     /// The `[knobs.executor]` RUNGS for this build — platform merged with
     /// board, board winning — with NO env rung and no defaults.
     ///
@@ -326,10 +370,8 @@ impl BuildRungs {
     /// the ENV-POINTER DANCE above, not the composition, and pretending
     /// otherwise would have quietly dropped its Kconfig rung.
     pub fn executor_rungs(&self) -> ExecutorKnobs {
-        let plat = self
-            .tree
-            .platform_executor_rungs(&self.platform)
-            .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={}: {e}", self.platform));
+        let plat = self.tree.platform_executor_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("executor", plat);
         let b = self
             .board
             .as_ref()
@@ -355,10 +397,8 @@ impl BuildRungs {
     /// builtin, and the Kconfig rung sits between the front-end and the
     /// descriptors.
     pub fn param_rungs(&self) -> ParamKnobs {
-        let plat = self
-            .tree
-            .platform_param_rungs(&self.platform)
-            .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={}: {e}", self.platform));
+        let plat = self.tree.platform_param_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("params", plat);
         let b = self
             .board
             .as_ref()
@@ -375,14 +415,15 @@ impl BuildRungs {
 
     /// The memory tenant for this build, over the full ladder.
     pub fn memory(&self, defaults: &[(&'static str, usize)]) -> Vec<(&'static str, ResolvedUsize)> {
-        self.tree
-            .resolve_memory(
-                &self.platform,
-                self.board.as_ref().map(|b| &b.knobs.memory),
-                &|k| std::env::var(k).ok(),
-                defaults,
-            )
-            .unwrap_or_else(|e| panic!("NROS_PLATFORM_NAME={}: {e}", self.platform))
+        let plat = self.tree.platform_memory_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("memory", plat);
+        self.tree.resolve_memory_from(
+            &self.platform,
+            &plat,
+            self.board.as_ref().map(|b| &b.knobs.memory),
+            &|k| std::env::var(k).ok(),
+            defaults,
+        )
     }
 
     /// One resolved memory knob, by name.
@@ -1323,6 +1364,24 @@ impl PlatformsTree {
         defaults: &[(&'static str, usize)],
     ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
         let plat = self.platform_memory_knobs(platform)?;
+        Ok(self.resolve_memory_from(platform, &plat, board, env, defaults))
+    }
+
+    /// The memory ladder over an ALREADY-RESOLVED platform rung.
+    ///
+    /// Split out so the build side can supply an empty rung for a platform that
+    /// declares no descriptor (see `BuildRungs::or_builtin_rungs`) without
+    /// re-implementing the ladder, while `nros config explain` keeps the strict
+    /// lookup above — a typo in `--platform` should still be an error there,
+    /// and silently printing builtins for it would be the wrong answer.
+    pub fn resolve_memory_from(
+        &self,
+        platform: &str,
+        plat: &MemoryKnobs,
+        board: Option<&MemoryKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Vec<(&'static str, ResolvedUsize)> {
         let pick = |k: &MemoryKnobs, name: &str| match name {
             "heap_bytes" => k.heap_bytes,
             "app_stack_bytes" => k.app_stack_bytes,
@@ -1331,7 +1390,7 @@ impl PlatformsTree {
         let mut out = Vec::new();
         for (name, builtin) in defaults {
             let (mut value, mut source) =
-                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                match (board.and_then(|b| pick(b, name)), pick(plat, name)) {
                     (Some(v), _) => (v, KnobSource::Board),
                     (None, Some(v)) => (v, KnobSource::Platform),
                     (None, None) => (*builtin, KnobSource::Builtin),
@@ -1359,7 +1418,7 @@ impl PlatformsTree {
                 },
             ));
         }
-        Ok(out)
+        out
     }
 
     /// The `[knobs.executor]` a platform's chain declares, merged nearest-wins.
@@ -1691,6 +1750,61 @@ impl BoardKnobsFile {
 
 #[cfg(test)]
 mod tests {
+    /// A platform with NO descriptor resolves to builtins; a BROKEN one does not.
+    ///
+    /// The phase-400 W6 regression this pins killed every image of the three
+    /// platforms that declare no `nros-platform.toml` — `threadx-linux`,
+    /// `esp32`, `zephyr` — by panicking in a build script. Issue 0979 fixed the
+    /// search ROOT being empty; this is the other half, and the two look
+    /// identical in a log (`unknown platform \`x\`: no <root>/x/…`), which is
+    /// why the second one survived the first fix.
+    ///
+    /// Both directions, because the tolerant arm must not swallow a real error:
+    /// an absent file is NO answer (builtins are correct), a malformed file is
+    /// a WRONG answer (still fatal).
+    #[test]
+    fn an_absent_descriptor_is_unknown_platform_and_a_broken_one_is_not() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+
+        let tree = PlatformsTree::load_search_path(&[root.to_path_buf()])
+            .expect("an empty but EXISTING root is a valid tree");
+
+        // Absent: the variant `or_builtin_rungs` keys its tolerant arm on.
+        match tree.platform_param_rungs("threadx-linux") {
+            Err(ConfigError::UnknownPlatform { name, .. }) => {
+                assert_eq!(name, "threadx-linux");
+            }
+            other => panic!("expected UnknownPlatform, got {other:?}"),
+        }
+
+        // ...and with no platform rung, the ladder still answers with builtins
+        // rather than dropping the knob.
+        let resolved = tree.resolve_memory_from(
+            "threadx-linux",
+            &MemoryKnobs::default(),
+            None,
+            &|_| None,
+            &[("heap_bytes", 4096)],
+        );
+        assert_eq!(resolved.len(), 1, "an absent rung must not drop the knob");
+        assert_eq!(resolved[0].1.value, 4096);
+
+        // Present but malformed: NOT UnknownPlatform, so it stays fatal.
+        std::fs::create_dir_all(root.join("brokenplat")).expect("mkdir");
+        std::fs::write(
+            root.join("brokenplat/nros-platform.toml"),
+            "[knobs.executor]\nmax_cbs = \"not a number\"\n",
+        )
+        .expect("write");
+        let reloaded = PlatformsTree::load_search_path(&[root.to_path_buf()]);
+        assert!(
+            !matches!(reloaded, Err(ConfigError::UnknownPlatform { .. })),
+            "a malformed descriptor must not be reported as an absent one — \
+             the tolerant arm would then silently substitute builtins"
+        );
+    }
+
     use super::*;
 
     fn write_tree(files: &[(&str, &str)]) -> tempfile::TempDir {

--- a/packages/cli/nros-cli-core/src/builder/preflight.rs
+++ b/packages/cli/nros-cli-core/src/builder/preflight.rs
@@ -50,13 +50,41 @@ pub fn check(board: &BoardDescriptor, root: &Path) -> Vec<Missing> {
 
     // The rustc target triple. A cross board that pins one needs it installed,
     // and `cargo build --target` fails deep in the build otherwise.
-    if let Some(target) = board.target.as_deref()
-        && !rust_target_installed(target)
-    {
-        out.push(Missing {
-            what: format!("Rust target `{target}` (board `{}`)", board.names[0]),
-            remedy: format!("rustup target add {target}"),
-        });
+    if let Some(target) = board.target.as_deref() {
+        match target_provisioning(root, target) {
+            // A prebuilt `rust-std` exists, so "is it installed" is the right
+            // question and `rustup target add` is the answer.
+            Provisioning::Rustup => {
+                if !rust_target_installed(target) {
+                    out.push(Missing {
+                        what: format!("Rust target `{target}` (board `{}`)", board.names[0]),
+                        remedy: format!("rustup target add {target}"),
+                    });
+                }
+            }
+            // Tier 3 / custom JSON: there is NOTHING to install, and this used
+            // to say `rustup target add armv7a-nuttx-eabihf` — a command that
+            // cannot succeed. `config/rust-targets.txt` says so in as many
+            // words: "There is nothing to install, so neither the installer nor
+            // the doctor touches these rows."
+            //
+            // It cost the nightly's `nuttx` and `esp32` cells, which failed
+            // preflight before compiling anything, with a remedy that would
+            // have failed too. The requirement these targets DO have is the
+            // `rust-src` component, because the leaf builds them with
+            // `-Zbuild-std`.
+            Provisioning::BuildStd => {
+                if !rust_component_installed("rust-src") {
+                    out.push(Missing {
+                        what: format!(
+                            "`rust-src` for build-std target `{target}` (board `{}`)",
+                            board.names[0]
+                        ),
+                        remedy: "rustup component add rust-src".to_string(),
+                    });
+                }
+            }
+        }
     }
 
     // A workspace that has never been synced has no generated message crates,
@@ -79,6 +107,57 @@ pub fn check(board: &BoardDescriptor, root: &Path) -> Vec<Missing> {
     }
 
     out
+}
+
+/// How `config/rust-targets.txt` says a triple is provided.
+///
+/// Column 2 of the ONE list (issue 0833). Unknown or unreadable ⇒ `Rustup`,
+/// which is the pre-existing behaviour: a triple nobody declared is more likely
+/// a normal target than a custom JSON one, and preflight must never refuse a
+/// build the compiler would have accepted.
+#[derive(Debug, PartialEq, Eq)]
+enum Provisioning {
+    Rustup,
+    BuildStd,
+}
+
+fn target_provisioning(root: &Path, target: &str) -> Provisioning {
+    let Ok(text) = std::fs::read_to_string(root.join("config/rust-targets.txt")) else {
+        return Provisioning::Rustup;
+    };
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut cols = line.split_whitespace();
+        if cols.next() == Some(target) {
+            return match cols.next() {
+                Some("build-std") => Provisioning::BuildStd,
+                _ => Provisioning::Rustup,
+            };
+        }
+    }
+    Provisioning::Rustup
+}
+
+/// Whether `rustup` reports a COMPONENT as installed.
+///
+/// Same false-negative-is-safe rule as [`rust_target_installed`]: no rustup ⇒
+/// report installed and let the build speak.
+fn rust_component_installed(component: &str) -> bool {
+    let Ok(out) = std::process::Command::new("rustup")
+        .args(["component", "list", "--installed"])
+        .output()
+    else {
+        return true;
+    };
+    if !out.status.success() {
+        return true;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .any(|l| l.trim() == component || l.trim().starts_with(&format!("{component}-")))
 }
 
 /// Whether `rustup` reports `target` as installed.
@@ -146,6 +225,43 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let m = check(&board(""), tmp.path());
         assert!(!m.iter().any(|m| m.what.contains("Rust target")), "{m:?}");
+    }
+
+    /// A `build-std` target must NOT be reported as an uninstallable rustup one.
+    ///
+    /// `config/rust-targets.txt` marks `armv7a-nuttx-eabihf` and
+    /// `riscv32imac-unknown-nuttx-elf` as `build-std`: Tier 3, no prebuilt
+    /// `rust-std`, provided by `-Zbuild-std` from the leaf. Preflight demanded
+    /// `rustup target add` for them anyway — a prerequisite that can never be
+    /// satisfied — and the nightly's `nuttx` and `esp32` cells died at stage 3
+    /// with a remedy that would also have failed.
+    ///
+    /// Reads the REAL list rather than a fixture: the point of issue 0833's one
+    /// list is that a second copy drifts, and a test asserting against its own
+    /// private copy would be exactly that.
+    #[test]
+    fn the_provisioning_column_decides_which_prerequisite_is_checked() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .find(|p| p.join("config/rust-targets.txt").is_file())
+            .expect("the repo's rust-targets list");
+
+        assert_eq!(
+            target_provisioning(root, "armv7a-nuttx-eabihf"),
+            Provisioning::BuildStd,
+            "a NuttX target is build-std; demanding `rustup target add` for it \
+             names a command that cannot succeed"
+        );
+        assert_eq!(
+            target_provisioning(root, "thumbv7m-none-eabi"),
+            Provisioning::Rustup,
+            "a target with a prebuilt rust-std keeps the rustup check"
+        );
+        // A triple nobody declared falls back to the pre-existing behaviour.
+        assert_eq!(
+            target_provisioning(root, "nros-not-a-declared-triple"),
+            Provisioning::Rustup
+        );
     }
 
     #[test]

--- a/scripts/check-python-deps.py
+++ b/scripts/check-python-deps.py
@@ -73,6 +73,15 @@ GROUPS = {
             ("yaml", "PyYAML"),
             ("pykwalify", "pykwalify"),
             ("packaging", "packaging"),
+            # Zephyr 4.4 validates module `zephyr/module.yml` against a JSON
+            # schema during CMake configure. Absent, west stops with
+            # `Missing jsonschema dependency` and the build never starts — which
+            # is how the nightly's `zephyr copy-out check (4.4)` and
+            # `zephyr ci-both` cells died before compiling anything. 3.7 does
+            # not import it, so this group grew a member the older line does not
+            # need; that is the group's own rule — it lists what OUR lanes
+            # import, and one of them now imports this.
+            ("jsonschema", "jsonschema"),
         ],
     ),
     "west": (

--- a/scripts/zephyr/provision-py312-venv.sh
+++ b/scripts/zephyr/provision-py312-venv.sh
@@ -44,12 +44,12 @@ remedy() {
   nano-ros does not create this venv. Either of these makes one:
 
       uv venv --python 3.12 "$VENV"
-      "$VENV/bin/python" -m pip install west pyelftools PyYAML pykwalify packaging
+      "$VENV/bin/python" -m pip install west pyelftools PyYAML pykwalify packaging jsonschema
 
   or, with a python3.12 already on PATH:
 
       python3.12 -m venv "$VENV"
-      "$VENV/bin/python" -m pip install west pyelftools PyYAML pykwalify packaging
+      "$VENV/bin/python" -m pip install west pyelftools PyYAML pykwalify packaging jsonschema
 
   4.4 builds run west THROUGH it:
       $VENV/bin/python -m west build ...    (or prepend $VENV/bin to PATH)


### PR DESCRIPTION
Both from the dispatched nightly. Two commits, two independent causes.

## 1. A `build-std` target has nothing to install — **not a CI-only bug**

`nros build`'s stage-3 preflight demanded `rustup target add` for **every** board target, including Tier 3 / custom-JSON ones. `config/rust-targets.txt` says what those need, in as many words:

> `build-std`  No prebuilt std (Tier 3 / custom JSON target) … **There is nothing to install**, so neither the installer nor the doctor touches these rows.

So every NuttX build failed before compiling anything, with a remedy that cannot succeed:

```
- Rust target `armv7a-nuttx-eabihf` (board `nuttx`)
    run: rustup target add armv7a-nuttx-eabihf
```

I first read this as "the container is missing a target". It isn't: `rustup target list --installed` has no such triple on **this** box either — it cannot — so the check refused a build that works. The nightly's `nuttx` and `esp32` cells are only where it was visible.

Preflight now reads the **provisioning column** of that one list and checks what the row actually requires: `rustup target add` for a `rustup` row, the **`rust-src` component** for a `build-std` one, since that is what `-Zbuild-std` needs. An undeclared triple keeps the old behaviour; an absent rustup still reports installed — preflight exists to give a better message than the compiler, never to refuse a build the compiler would accept.

The test reads the **real** list, not a fixture: issue 0833's point is that a second copy drifts, and a test asserting against its own private copy would be that copy.

Verified end to end — `nros build --dry-run` in `examples/workspaces/c` now resolves `demo_bringup:nuttx` instead of bailing at stage 3.

## 2. jsonschema is a west-build dependency our 4.4 lane imports

Zephyr 4.4 validates `zephyr/module.yml` against a JSON schema at CMake configure. Without it:

```
Missing jsonschema dependency
FATAL ERROR: command exited with status 1: /usr/bin/cmake …
```

That killed `zephyr copy-out check (4.4)` and `zephyr ci-both (3.7 + 4.4)`. 3.7 does not import it, and its cells passed in the same run.

Added to the **one list** (`check-python-deps.py` `zephyr-build`), which the 4.4 venv provisioner reads — *"never a second copy in this file or in YAML"*. Three places move together because issue 0878 built a gate saying so: the list, the image's **pinned** `pip3 install`, and the image's import-check line. `check-ci-image-python-deps` reports 6 modules instead of 5 and passes.

The provisioner's own `remedy()` heredoc held a hand-typed copy of that package list — the exact shape its neighbouring comment warns against — and drifted the moment this landed. Updated; it's prose, so no gate can catch it, which is worth knowing.

## Verification

- `just check fast` — 168/168
- `just ci l1` — passed
- `just check ci-image-python-deps` — OK, 6 modules, pinned

## Not fixed here

The other three nightly causes are host-side on a machine I can't reach: qemu-system-arm **6.2 < 7.2** (`nros-qemu` label), `threadx_riscv64`'s missing C++ headers for the cross cyclonedds build, and `freertos`'s `error: no tests to run` (a nextest filter selecting nothing — that one is in-repo and worth a separate look).