### PR TITLE
test(#0976): the reverse cell — an nros action client against a stock ROS 2 server

### DIFF
--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -141,9 +141,41 @@ exactly that (publisher.cpp's 233.6 comment records the Rust runtime being fixed
 to emit the fixed `octet[16]` and the matching strip being deleted from both
 sides). This test makes that move verifiable; it does not perform it.
 
-Also not covered: the reverse direction, an nros action CLIENT against a `ros2`
-action server. The adapters sit on both sides of the service path, and this
-witnesses one. That is the obvious next cell.
+### The reverse cell, added the same day — both directions now witnessed
+
+`the_nano_ros_action_client_drives_a_stock_ros2_server`: the nano-ros action
+client against `examples_rclcpp_minimal_action_server`, which serves the same
+`/fibonacci` over `example_interfaces/action/Fibonacci`.
+
+```
+[INFO] Sending goal
+[INFO] Goal accepted by server, waiting for result
+[INFO] Next number in sequence received: [0, 1, 1]
+...
+[INFO] Result received: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+```
+
+and on the ROS 2 side, ten `Publish Feedback` lines and `Goal Succeeded`.
+
+**Not redundant with the forward cell.** The adapters sit on BOTH sides. Sending
+a goal exercises `strip_goal_id_len_at` and `strip_nested_cdr_at` on what
+nano-ros WRITES; receiving feedback and a result exercises the take path against
+bytes a real ROS 2 server produced. One direction passing says nothing about the
+other, which is precisely why a nano-ros-to-nano-ros test could not settle this.
+
+So option 1 holds in both directions: the corrections are right, and ROS 2
+interop passes with them.
+
+**One defect in the test itself, worth recording.** The first version ran the
+client with `Command::output()` and no deadline. The client BLOCKS waiting for a
+server it has not discovered, so a slow discovery did not fail — it hung for ten
+minutes. It now runs under `timeout 60` inside the ROS env. A test that cannot
+fail in bounded time is not a test, and an e2e that spawns a peer is exactly
+where that goes unnoticed.
+
+Both cells are mutation-tested: the forward one pointed at an action nothing
+serves, the reverse one with the server replaced by `sleep 300`. Both go red on
+the goal-accepted assertion.
 
 ## Not to be confused with
 

--- a/packages/testing/nros-tests/tests/ros2_action_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros2_action_e2e.rs
@@ -39,6 +39,15 @@ fn action_domain() -> u8 {
     nros_tests::unique_ros_domain_id()
 }
 
+/// Single-quote a path for the shell `RosEnv::run` builds.
+///
+/// The fixture path comes from the build tree, so it is ours rather than a
+/// user's — but quoting it is one line and an unquoted path with a space
+/// fails as "command not found", which reads as a missing fixture.
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
 /// A real ROS 2 client drives a goal on the nano-ros action server.
 ///
 /// Asserts the RESULT CONTENT, not merely that the call returned: the adapters
@@ -112,4 +121,88 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
              to the wrong numbers rather than failing.\n{text}"
         );
     }
+}
+
+/// The nano-ros action CLIENT drives a stock ROS 2 action server.
+///
+/// The reverse of the cell above, and not redundant with it: the adapters sit
+/// on BOTH sides of the service path. Sending a goal exercises
+/// `strip_goal_id_len_at` and `strip_nested_cdr_at` on what nano-ros WRITES;
+/// receiving feedback and a result exercises the take path against bytes a real
+/// ROS 2 server produced. One direction passing says nothing about the other —
+/// which is the whole reason a nano-ros-to-nano-ros test could not settle this.
+///
+/// The peer is `examples_rclcpp_minimal_action_server`, which serves
+/// `/fibonacci` over `example_interfaces/action/Fibonacci` — the same action and
+/// type the nano-ros client targets.
+#[test]
+fn the_nano_ros_action_client_drives_a_stock_ros2_server() {
+    if !require_ros2_cyclonedds() {
+        nros_tests::skip!("ROS 2 + rmw_cyclonedds_cpp not available");
+    }
+
+    let client_bin = fixtures::build_native_rust_example_rmw(
+        "action-client",
+        "action-client",
+        fixtures::Rmw::Cyclonedds,
+    )
+    .unwrap_or_else(|e| {
+        nros_tests::skip!("native rust cyclonedds action-client fixture: {e}");
+    });
+
+    let domain = action_domain();
+    let env = HostRosEnv::new(
+        DEFAULT_ROS_DISTRO,
+        Middleware::Cyclonedds { domain_id: domain },
+    );
+
+    // `RosPeer` kills the whole process group on drop, so a failed assertion
+    // below cannot leave a `ros2` server behind to collide with the next run —
+    // the orphan-peer shape that makes a later test fail for an earlier test's
+    // reason.
+    let _server = env
+        .spawn(
+            "minimal_action_server",
+            "ros2 run examples_rclcpp_minimal_action_server action_server_member_functions",
+        )
+        .expect("start the stock ROS 2 action server");
+
+    std::thread::sleep(std::time::Duration::from_secs(6));
+
+    // Through the ROS env with an explicit `timeout`, NOT a bare
+    // `Command::output()`. The client blocks waiting for a server it has not
+    // discovered, and `output()` has no deadline — the first version of this
+    // test hung for ten minutes instead of failing in one. A test that cannot
+    // fail in bounded time is not a test.
+    let out = env
+        .run(&format!(
+            "timeout 60 {}",
+            shell_escape(&client_bin.to_string_lossy())
+        ))
+        .expect("run the nano-ros action client");
+
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        text.contains("Goal accepted"),
+        "a real ROS 2 server must ACCEPT the goal nano-ros wrote — this is the \
+         side `strip_goal_id_len_at` and `strip_nested_cdr_at` reshape.\n{text}"
+    );
+    // Fibonacci(10). Asserted as the whole sequence: a reshaped result decodes
+    // to wrong numbers rather than failing, so a substring like "Result" would
+    // pass on garbage.
+    assert!(
+        text.contains("Result received: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]"),
+        "the result from a stock server must decode to Fibonacci(10).\n{text}"
+    );
+    // Feedback travels a different message than the result, and only the
+    // feedback path exercises the server's own periodic publish.
+    assert!(
+        text.contains("Next number in sequence received"),
+        "feedback from a stock server must reach the nano-ros client.\n{text}"
+    );
 }


### PR DESCRIPTION
Follows #227, which witnessed a ROS 2 client driving the nano-ros action server.
This is the other direction, and it is **not redundant**: the five adapters sit
on **both** sides of the service path.

Sending a goal exercises `strip_goal_id_len_at` / `strip_nested_cdr_at` on what
nano-ros **writes**; receiving feedback and a result exercises the take path
against bytes a real ROS 2 server produced. One direction passing says nothing
about the other — which is exactly why a nano-ros-to-nano-ros test could never
settle this issue.

Peer is `examples_rclcpp_minimal_action_server`, serving the same `/fibonacci`
over `example_interfaces/action/Fibonacci`:

```
[INFO] Goal accepted by server, waiting for result
[INFO] Result received: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
```

with ten `Publish Feedback` lines and `Goal Succeeded` on the ROS 2 side. So
0976's **option 1 holds in both directions** — the corrections are right.

## A defect in my own test, fixed and recorded

The first version ran the client with `Command::output()` and **no deadline**.
The client blocks waiting for a server it hasn't discovered, so slow discovery
didn't fail — it **hung for ten minutes** under the default parallel run. It now
goes through the ROS env under `timeout 60`.

A test that cannot fail in bounded time is not a test, and an e2e that spawns a
peer is exactly where that goes unnoticed.

## Verification

- 2 passed **serially** (73 s)
- 2 passed under the **default parallel run** (67 s) — how CI executes them
- peer is a `RosPeer`, so a failed assertion kills the process group rather than
  orphaning a `ros2` server for the next test to trip over
- **mutation-tested**: server replaced by `sleep 300` → fails on the
  goal-accepted assertion

`just check fast`: 168 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa