### PR TITLE
fix(#0971): the trait default discarded the count its own doc comment protects

### DIFF
--- a/packages/core/nros-rmw/src/traits.rs
+++ b/packages/core/nros-rmw/src/traits.rs
@@ -1967,12 +1967,36 @@ pub trait Subscription {
         let mut count = 0;
         for i in 0..limit {
             let slot = &mut buf[i * per_msg_cap..(i + 1) * per_msg_cap];
-            match self.try_recv_raw(slot)? {
-                Some(len) => {
+            // Issue 0971 — NOT `try_recv_raw(slot)?`. The `?` propagates the
+            // error and DISCARDS `count`, which is precisely what the doc
+            // comment above forbids ("Partial drains MUST report the count, not
+            // error out") and what `c3af8c1d1` removed from the two concrete
+            // implementations. A backend that does not override this body got
+            // the original defect back through the default.
+            //
+            // The shape is the one that fix established: a drain that has
+            // already taken messages reports the COUNT, and the error is
+            // delivered by the NEXT call — the caller sees every message it was
+            // handed, then the reason the drain stopped. With nothing taken
+            // there is no count to protect, so the error goes out immediately.
+            //
+            // Parking is per-implementation state, which a default body has no
+            // place to keep. So it does the half it can do correctly: it
+            // returns the partial count and lets the error surface on the
+            // caller's next `try_recv_raw`, which is where an unconsumed
+            // backend error still sits.
+            match self.try_recv_raw(slot) {
+                Ok(Some(len)) => {
                     out_lens[i] = len;
                     count += 1;
                 }
-                None => break,
+                Ok(None) => break,
+                Err(e) => {
+                    if count == 0 {
+                        return Err(e);
+                    }
+                    break;
+                }
             }
         }
         Ok(count)
@@ -2684,6 +2708,73 @@ pub trait Rmw {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue 0971 — the DEFAULT `try_recv_sequence` body must report a partial
+    /// count rather than discard it, which is what its own doc comment says and
+    /// what `?` did not do.
+    ///
+    /// This is the default's negative control: a backend that takes two
+    /// messages and then errors must hand the caller those two. Before the fix
+    /// the `?` threw them away and the caller could not tell two messages had
+    /// been consumed — they were gone from the queue and absent from the
+    /// result.
+    mod try_recv_sequence_default {
+        use super::*;
+
+        #[derive(Debug, PartialEq)]
+        struct Boom;
+
+        /// Yields `n` one-byte messages, then errors forever.
+        struct ThenErrors {
+            left: usize,
+        }
+
+        impl Subscription for ThenErrors {
+            type Error = Boom;
+
+            fn try_recv_raw(&mut self, buf: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+                if self.left == 0 {
+                    return Err(Boom);
+                }
+                self.left -= 1;
+                buf[0] = 0xAB;
+                Ok(Some(1))
+            }
+
+            fn deserialization_error(&self) -> Self::Error {
+                Boom
+            }
+        }
+
+        #[test]
+        fn a_partial_drain_reports_its_count_instead_of_the_error() {
+            let mut sub = ThenErrors { left: 2 };
+            let mut buf = [0u8; 4 * 8];
+            let mut lens = [0usize; 4];
+
+            // Two messages are available, the third call errors.
+            let got = sub.try_recv_sequence(&mut buf, 8, 4, &mut lens);
+
+            assert_eq!(
+                got,
+                Ok(2),
+                "a drain that took messages must report them; `?` discarded the \
+                 count and the caller lost two consumed messages"
+            );
+            assert_eq!(&lens[..2], &[1, 1]);
+        }
+
+        #[test]
+        fn an_error_with_nothing_taken_is_returned_immediately() {
+            let mut sub = ThenErrors { left: 0 };
+            let mut buf = [0u8; 4 * 8];
+            let mut lens = [0usize; 4];
+
+            // No count to protect, so the caller should see the error itself
+            // rather than an ambiguous `Ok(0)`.
+            assert_eq!(sub.try_recv_sequence(&mut buf, 8, 4, &mut lens), Err(Boom));
+        }
+    }
 
     #[test]
     fn test_topic_info() {


### PR DESCRIPTION
`c3af8c1d1` fixed the two implementations issue #0971 named — the Cyclone native batch and the CFFI runtime fallback. Investigating the issue turned up **four** sites, not two. This is the third, and it is the one that hands the defect to every backend that does not override.

## The defect

`Subscription::try_recv_sequence`'s default body:

```rust
match self.try_recv_raw(slot)? {   // <- the `?`
```

The `?` propagates the error and **discards `count`** — twenty lines below its own doc comment:

> Partial drains MUST report the count, not error out.

A backend inheriting the default consumes messages from its queue, throws them away, and returns an error saying nothing about how many were lost. It is the exact shape `c3af8c1d1` removed from the two concrete implementations, still live in the body they fall back to.

## The fix

The shape `c3af8c1d1` established, as far as a default body can carry it:

- a drain that has already taken messages returns the **count**;
- an error with **nothing** taken is returned immediately — there is no count to protect.

Parking the status for delivery on the next call is per-implementation state a default body has nowhere to keep, so the error surfaces on the caller's next `try_recv_raw`, where an unconsumed backend error still sits. That is stated in the code rather than left implicit.

## Verified as a control, not just a pass

| test | old `?` body | new body |
| --- | --- | --- |
| `a_partial_drain_reports_its_count_instead_of_the_error` | **FAILS** | passes |
| `an_error_with_nothing_taken_is_returned_immediately` | passes | passes |

The second passing both ways is what makes the first one evidence rather than decoration.

## Not fixed here — why #0971 should stay open

Zenoh's `try_recv_sequence` (`shim/subscriber.rs:1307`, drop-and-continue at `:1331-1337`) silently drops an oversized message and keeps draining. That is verbatim the option #0971 rejects: *"delivers more, still destroys the message with no signal."* Zenoh's **single** take does the right thing at `:1019-1022`, so its two entry points contradict each other.

Fixing it needs a `pending_status` on `ZenohSubscriber` and a decision on break-vs-continue — Cyclone breaks, zenoh continues, so the **counts** differ too, not only the status. That is a backend change with no test today and belongs in its own commit.

Also worth noting: `book/src/reference/rmw-feature-matrix.md:35` reports batch receive as "wired" for both backends, which hides this divergence — `gen-rmw-feature-matrix.py:72` only greps for `fn try_recv_sequence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe