### PR TITLE
docs(#0976): correct three claims the witness commit made, and the stale blocker

### DIFF
--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -113,9 +113,18 @@ Goal finished with status: SUCCEEDED
 Discovery works too — `ros2 action info /fibonacci` reports `Action servers: 1`
 and names the node.
 
-**So the corrections are RIGHT.** A real ROS 2 client accepts the goal, receives
-feedback, and gets the correct sequence back, which is option 1 above: ROS 2
-interop passes WITH the adapters. They are not compensating for something that
+**So the corrections are RIGHT.** A real ROS 2 client accepts the goal and gets
+the correct sequence back, which is option 1 above: ROS 2 interop passes WITH
+the adapters.
+
+(This paragraph said "receives feedback" until 2026-09-03. It does not: the
+command in `ros2_action_e2e.rs:85` carries no `--feedback`, so feedback is
+neither printed nor asserted. A `--feedback` helper exists at
+`packages/testing/nros-tests/src/ros_env.rs:651`, but on `DockerRosEnv`, not the
+`HostRosEnv` this test uses. The transcript quoted above is also a PARAPHRASE —
+`ros2 action send_goal` prints a YAML block list, `sequence:` then `- 0`, `- 1`,
+…, which is what the test's `contains("- {n}")` assertions match. The
+assertions were right; the prose describing them was not.) They are not compensating for something that
 no longer exists, and they must not simply be deleted.
 
 The test asserts the RESULT CONTENT, not a zero exit: the adapters move bytes

--- a/docs/reference/cyclonedds-known-limitations.md
+++ b/docs/reference/cyclonedds-known-limitations.md
@@ -57,8 +57,23 @@ consequences that are not obvious:
   rounded up to 4 (`rosidl_codegen::bounds::transport_framed`).
 
 **Still round-tripping:** `src/service.cpp`, which is why `sertype_min.{hpp,cpp}`
-still exists. Blocked, and not on effort — see
-[#0976](../issues/0976-service-action-adapters-tested-only-against-ourselves.md).
+still exists.
+
+It was "blocked, and not on effort" on #0976 — nothing could observe whether the
+five CDR-reshaping adapters produce ROS 2's bytes, so converting the path risked
+breaking a wire format with no witness. **That blocker is lifted in one
+direction**: `6ec8c4d21` added `ros2_action_e2e.rs`, a stock `ros2 action
+send_goal` against the nano-ros action server, and it passes.
+
+The remaining work is effort, not a blocker, with one caveat: the witness covers
+nano-ros in the SERVER role only. `strip_goal_id_len_at` and
+`take_fibonacci_get_result_response_wire` fire only when nano-ros is the CLIENT,
+so they are still unobserved — see
+[#0976](../issues/0976-service-action-adapters-tested-only-against-ourselves.md),
+which stays open for that reason, and
+[#0969](../issues/0969-cyclone-take-cdr-round-trip.md), which argues the
+conversion would DELETE most of these adapters rather than have to preserve
+them (recorded there as not yet verified).
 
 ## Phase 108 status events: NULL slots
 
@@ -261,7 +276,10 @@ per-message cost as a slope. The claim that "the smoke tests don't measure
 allocation pressure" is no longer true, which is why it is no longer here.
 
 **Still allocating per message:** `src/service.cpp` — three sites, one per
-request and two per reply. See
+request and two per reply. The take side is
+[#0969](../issues/0969-cyclone-take-cdr-round-trip.md)'s third site
+(`take_typed_wire`, which re-encodes XCDR1 native-endian — a correctness
+question, not only a cost one); the witness situation is
 [#0976](../issues/0976-service-action-adapters-tested-only-against-ourselves.md).
 
 ## Boards

--- a/packages/testing/nros-tests/tests/ros2_action_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros2_action_e2e.rs
@@ -96,8 +96,13 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
 
     assert!(
         text.contains("Goal accepted"),
-        "a stock ROS 2 client must get the goal ACCEPTED — if the goal-id \
-         adapter reshapes the UUID wrongly the server never accepts.\n{text}"
+        "a stock ROS 2 client must get the goal ACCEPTED — the server has to \
+         read a real ROS 2 SendGoal request, UUID and all.\n\
+         NOTE this does NOT exercise `strip_goal_id_len_at` (issue 0976): that \
+         adapter fires only when nano-ros WRITES a SendGoal/GetResult request, \
+         and here `ros2` writes them. What guards the server's receive side is \
+         `split_wire_header`'s deliberate non-insertion (service.cpp:589-599, \
+         issue #68).\n{text}"
     );
     assert!(
         text.contains("SUCCEEDED"),


### PR DESCRIPTION
`6ec8c4d21` landed a real outside witness for the Cyclone action wire format — a stock `ros2 action send_goal` against the nano-ros action server — and it passes. That is genuine progress. Three things it asserts are not true of the code, and the reference doc now says the opposite of what it should.

## 1. The test misattributes its own assertion

`ros2_action_e2e.rs:99` said *"if the goal-id adapter reshapes the UUID wrongly the server never accepts."*

`strip_goal_id_len_at` fires only when nano-ros **writes** a SendGoal/GetResult request (`service.cpp:615-620`). Here `ros2` writes them, so it never runs. What actually guards the server's receive side is `split_wire_header`'s deliberate non-insertion (`service.cpp:589-599`, issue #68).

The message now says what the test proves and names what it does not.

## 2. "Receives feedback" — it does not

The command at `ros2_action_e2e.rs:85` carries no `--feedback`, so feedback is neither printed nor asserted. (Verified: no occurrence of `feedback` anywhere in the test.) A `--feedback` helper exists at `ros_env.rs:651`, but on `DockerRosEnv`, not the `HostRosEnv` this test uses.

## 3. The quoted transcript is a paraphrase

#0976 shows `sequence: [0, 1, 1, 2, 3, 5]`. `ros2 action send_goal` prints a YAML **block** list — `sequence:` then `- 0`, `- 1`, … — which is what the test's `contains("- {n}")` assertions match. The assertions were right; the prose describing them was not.

None of these change the verdict — the adapters **are** producing ROS 2's bytes in the server direction. They change what a reader believes is covered, which is the thing #0976 exists to keep honest.

## And the blocker text now misleads the other way

`cyclonedds-known-limitations.md:61` still calls `service.cpp` *"Blocked, and not on effort — see #0976."*

The blocker was "nothing can observe the wire format". That is now **false in the server direction**. Rewritten to say the blocker is lifted there, that the remaining work is effort rather than a blocker, and that the **client** direction (`strip_goal_id_len_at`, `take_fibonacci_get_result_response_wire`) is still unobserved — which is why #0976 stays open.

The allocation entry at `:265` now points at #0969's third site by name, including that its XCDR1 native-endian re-encode is a **correctness** question and not only a cost one.

## Verified

`cargo check -p nros-tests --tests` clean; `doc-refs`, `issue-index`, `issue-ids` green. Each claim was checked against the source (grep for `feedback`, read of the assertion and of `service.cpp:615-620`) rather than taken from a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012U3DRNkVwmKGFi6KCCkmhe