### PR TITLE
docs(#0976): the write-side strips are dead — measured in Rust, C and C++

### DIFF
--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -218,11 +218,26 @@ Running the client directly is what produced the table above.
 Licensed: deleting the two write-side strips, and the `type_ends_with` branches
 that call them.
 
-NOT licensed yet: the same claim for the C and C++ action paths. This measured
-the RUST runtime. `nros-c`/`nros-cpp` action entries reach `write_typed` through
-the same C ABI but serialize through their own generated code, and nothing here
-observed them. The same probe against a C/C++ action entry is the remaining
-check, and it is cheap now that the witness exists.
+### The C and C++ paths agree — all three languages measured
+
+The gap named above is closed. Same probe, same stock ROS 2 server, the
+`build-cyclonedds` action clients of each language:
+
+| client | `strip_goal_id_len_at` | `strip_nested_cdr_at` | result |
+| --- | --- | --- | --- |
+| Rust | declined x2 | declined | `[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]` |
+| C | declined x2 | declined | same |
+| C++ | declined x2 | declined | same |
+
+Identical in all three, including the decline COUNTS — two goal-id sites
+(`_SendGoal_Request_` and `_GetResult_Request_`) and one nested-header site. The
+C and C++ entries serialize through their own generated code and reach
+`write_typed` through the C ABI, so this is three independent producers agreeing
+that neither correction has anything to correct.
+
+**The deletion is now licensed for the write path in every language nano-ros
+ships**, which is what the ROS 2-compatibility-belongs-to-nano-ros call asks for:
+the correction lives at the serializer, and the backend copy is dead.
 
 Also untouched: the three RECEIVE-side adapters
 (`take_fibonacci_get_result_response_wire` and the two `_SendGoal_*` /

--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -177,6 +177,59 @@ Both cells are mutation-tested: the forward one pointed at an action nothing
 serves, the reverse one with the server replaced by `sleep 300`. Both go red on
 the goal-accepted assertion.
 
+## MEASURED with the witness: the two write-side strips are DEAD (2026-09-03)
+
+The design call — if a correction is about ROS 2 compatibility and correctness,
+nano-ros should own it, not one backend — turns out to be already SATISFIED on
+the write path, and the backend code is vestigial.
+
+Instrumented both branches of `write_typed` and rebuilt the native fixtures
+(`strings` confirms 4 probe literals in each binary, so the instrumentation is
+linked rather than assumed). Then ran the nano-ros action client against the
+stock ROS 2 server:
+
+```
+2  PROBE strip_goal_id_len_at declined
+1  PROBE strip_nested_cdr_at(SendGoal) declined
+1  [INFO] Result received: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+```
+
+They are REACHED and they DECLINE — every time — while the round trip succeeds
+against a real ROS 2 peer. Their guards test for the `[16,0,0,0]` length prefix
+and a nested encapsulation header, and neither is present: the Rust runtime
+already emits the fixed `octet[16]` (publisher.cpp's 233.6 note records that
+fix), so there is nothing left to strip.
+
+**So nano-ros already owns this correction.** The bytes are right at the source,
+which is where a ROS 2-compatibility fix belongs, and
+`strip_goal_id_len_at` / `strip_nested_cdr_at` are dead code on the write path.
+
+### One measurement error worth recording
+
+The first run of this reported "no probe fired at all", which would have meant
+`write_typed` was off the action path entirely. Wrong, and wrong in the
+convenient direction: the reverse cell CAPTURES the client's output into the
+assertion string, so the probe lines went into the capture rather than the
+terminal. Absence of evidence was an artifact of where the evidence was sent.
+Running the client directly is what produced the table above.
+
+### What this licenses, and what it does not
+
+Licensed: deleting the two write-side strips, and the `type_ends_with` branches
+that call them.
+
+NOT licensed yet: the same claim for the C and C++ action paths. This measured
+the RUST runtime. `nros-c`/`nros-cpp` action entries reach `write_typed` through
+the same C ABI but serialize through their own generated code, and nothing here
+observed them. The same probe against a C/C++ action entry is the remaining
+check, and it is cheap now that the witness exists.
+
+Also untouched: the three RECEIVE-side adapters
+(`take_fibonacci_get_result_response_wire` and the two `_SendGoal_*` /
+`_GetResult_Request_` memcpy branches). Those are a different question — issue
+0969 argues a `dds_takecdr` rewrite removes the need for them rather than
+correcting them.
+
 ## Not to be confused with
 
 **#0970** (`0970-cyclone-rmw-should-own-its-sertype.md`, filed in PR #154 — not


### PR DESCRIPTION
Supersedes #236 (same first commit, plus the C/C++ result that closes the gap
that PR named). Close #236 in favour of this.

The design call — *a correction about ROS 2 compatibility and correctness belongs
to nano-ros, not one backend* — is **already satisfied** on the write path. The
backend code is vestigial, and now measured as such in every language nano-ros
ships.

## Measured

Instrumented both branches of `write_typed`, then ran each language's
`build-cyclonedds` action client against the stock ROS 2 server:

| client | `strip_goal_id_len_at` | `strip_nested_cdr_at` | result |
| --- | --- | --- | --- |
| Rust | declined ×2 | declined | `[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]` |
| C | declined ×2 | declined | same |
| C++ | declined ×2 | declined | same |

Identical in all three, **including the decline counts** — two goal-id sites
(`_SendGoal_Request_`, `_GetResult_Request_`) and one nested-header site. C and
C++ serialize through their own generated code and reach `write_typed` via the C
ABI, so these are three independent producers agreeing that neither correction
has anything left to correct.

The guards look for a `[16,0,0,0]` length prefix and a nested encapsulation
header. Neither is present, because the runtime already emits the fixed
`octet[16]` (publisher.cpp's 233.6 note records that fix). The bytes are right
**at the source**.

No rebuild was needed for the C/C++ round: the earlier `lane=native` build had
carried the instrumentation into every action client, which `strings` confirms (4
probe literals each). Checking that first saved ~25 minutes.

## One measurement error, recorded because it pointed the convenient way

The first run reported *no* probe firing at all — which would have meant
`write_typed` was off the action path entirely. Artifact: the reverse cell
**captures** the client's output into its assertion string, so the probe lines
went into the capture rather than the terminal. Running the client directly gave
the real table.

## What this licenses

**Licensed:** deleting the two write-side strips and the `type_ends_with`
branches that call them — the write path, all three languages.

**Still out of scope:** the three receive-side adapters. Issue 0969 argues a
`dds_takecdr` rewrite removes the need for those rather than correcting them.

No behaviour change; instrumentation reverted. `just check fast`: 188 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa