### PR TITLE
fix(freertos): the lane selected a target with nothing runnable in it

### DIFF
--- a/just/freertos.just
+++ b/just/freertos.just
@@ -320,7 +320,30 @@ test verbose="": build-fixtures
         echo "ERROR: lwIP not found at $LWIP_DIR. Run: just setup-freertos"
         exit 1
     fi
-    just _nextest-platform freertos_qemu '{{verbose}}'
+    # `rtos_e2e`'s `Platform__Freertos` cells, NOT the `freertos_qemu` target.
+    #
+    # That target holds exactly two tests and BOTH are `#[ignore]`d — the
+    # cyclonedds fixtures they drove were retired in phase 220.C path B and
+    # phase 214.P, and their own header says where the coverage went: "The
+    # per-role binaries are consumed by the `rtos_e2e` Platform__Freertos
+    # tests." So this lane selected a binary with nothing runnable in it and
+    # nextest ended the job:
+    #
+    #     Starting 0 tests across 1 binary (2 tests skipped)
+    #     error: no tests to run
+    #
+    # It had been VACUOUS since those ignores landed and only became visible
+    # when nextest started treating an empty selection as an error rather than
+    # a silent pass — which is the better default, and is what surfaced this.
+    # A lane that runs nothing while reporting success is the shape this repo
+    # gates against everywhere else.
+    #
+    # Same move the NuttX lane already made, for the same reason and in the
+    # same words (`_nextest-platform`'s `filter` parameter exists for it): the
+    # per-platform target was subsumed by the shared matrix, so select the
+    # platform's cells out of `rtos_e2e` instead. `test(Freertos)` selects 9 —
+    # action / pubsub / service, each in Rust, C and C++.
+    just _nextest-platform rtos_e2e '{{verbose}}' '' 'test(Freertos)'
 
 # Run all FreeRTOS tests including networked E2E
 [group("full-matrix")]

--- a/packages/testing/nros-tests/tests/cross_libc_precedence_gate.rs
+++ b/packages/testing/nros-tests/tests/cross_libc_precedence_gate.rs
@@ -166,13 +166,13 @@ fn cross_libc_two_set_precedence_holds() {
 ///   * SDK store (`~/.nros/sdk/arm-none-eabi-gcc/13.2-nros1`, newlib 13.2.1):
 ///     newlib's own `stdlib.h` is reached FIRST, so the stub's is a
 ///     redefinition —
-///         error: conflicting declaration 'typedef struct div_s div_t'
+///     error: conflicting declaration 'typedef struct div_s div_t'
 ///
 ///   * the CI container's apt cross (newlib 10.3.1): the stub's `stdlib.h` is
 ///     reached INSTEAD of newlib's, so newlib's `<cstdlib>` finds nothing to
 ///     re-export —
-///         /usr/include/newlib/c++/10.3.1/bits/std_abs.h:52:11:
-///             error: 'abs' has not been declared in '::'
+///     /usr/include/newlib/c++/10.3.1/bits/std_abs.h:52:11:
+///     error: 'abs' has not been declared in '::'
 ///
 /// Both are the stub shadowing the real libc; only the first was modelled, so
 /// the gate failed on the container with "fix the gate fixture" — correctly


### PR DESCRIPTION
```
Starting 0 tests across 1 binary (2 tests skipped)
error: no tests to run
```

`just freertos test` ran `_nextest-platform freertos_qemu`, and **both** tests in that target are `#[ignore]`d — the cyclonedds fixtures they drove were retired in phase 220.C path B and phase 214.P. The lane could never run anything, and had been vacuous since those ignores landed.

It only became **visible** when nextest started treating an empty selection as an error rather than a silent pass. That is the better default and it is what surfaced this: a lane reporting success while running nothing is the shape this repo gates against everywhere else, and here it was the test step of an entire platform cell.

## The fix is a move this tree already made

`_nextest-platform`'s `filter` parameter exists for exactly this, and its comment describes the NuttX case in the same words. The retired target's own header says where the coverage went:

> The per-role binaries are consumed by the `rtos_e2e` Platform__Freertos tests.

So select those cells. **Measured: `test(Freertos)` selects nine** — action, pubsub and service, each in Rust, C and C++ — against zero before. The same file's networked-E2E recipe already spells this filter, so the lane is now consistent with its neighbour rather than novel.

## Sweep

A class fixed at one site is fixed nowhere, so every `_nextest-platform` caller, by runnable (non-ignored) count:

| target | runnable |
| --- | --- |
| `freertos_qemu` | **0** ← this lane, repointed |
| `threadx_riscv64_qemu` | 4 |
| `esp32_emulator` | 5 |
| `rtos_e2e` | nuttx and threadx-linux already select from it |

One member. **No gate added**: nextest's own `no tests to run` *is* the detector now, and it fired. A second regex-based one would be a lower-fidelity duplicate of a check the tool already performs exactly.

Reproduced locally before and after, identical to the nightly's output.

## Second commit: an unrelated red on main

`892e507cc` (issue 0995, today) added a compiler-transcript excerpt indented 8 and 12 spaces under a doc bullet. rust-1.96 clippy's `doc_overindented_list_items` rejects it, `check::build` runs clippy with `-D warnings`, and `nros-tests` stopped compiling — so **`just ci l1` was red on main for everyone**, on three lines of prose. Re-indented; the transcript reads the same.

## Verification

- `just ci l1` — passed (red before the second commit)
- `just check fast` — 185/185
- `just check nextest-binary-filters` — OK, 520 test targets known