### PR TITLE
docs(#1000): the vendored Cyclone drops a fired event when its handler returns without re-arming

### DIFF
--- a/docs/issues/1000-spdp-periodic-event-orphaned-by-handler-early-return.md
+++ b/docs/issues/1000-spdp-periodic-event-orphaned-by-handler-early-return.md
@@ -1,0 +1,137 @@
+---
+id: 1000
+title: "Vendored Cyclone: `handle_xevk_spdp`'s early returns orphan the PERIODIC spdp event — it leaves the heap, is never re-armed, and the participant goes silent forever"
+status: open
+area: [rmw, third-party]
+severity: high
+related: [0997]
+---
+
+# An event that fires is off the heap until its handler puts it back
+
+**This is a defect in the vendored CycloneDDS fork**
+(`third-party/dds/cyclonedds`, `NEWSLabNTU/cyclonedds` @ `d97a71e`), not in
+nano-ros code, and it is stock upstream code rather than something the fork
+introduced. It is filed here because this is the repository that consumes the
+fork and the fork has issues disabled.
+
+It is the mechanism behind [#0997](0997-island-announces-spdp-once-then-lease-expires.md),
+where an an536 island stops announcing itself and every DDS peer expires its
+lease and deletes it.
+
+## The contract
+
+`handle_xevents` (`src/core/ddsi/src/q_xevent.c:1219`) takes an event OFF the
+heap before running it, and marks it unscheduled:
+
+```c
+while (earliest_in_xeventq(xevq).v <= tnow.v)
+{
+  struct xevent *xev = ddsrt_fibheap_extract_min (&evq_xevents_fhdef, &xevq->xevents);
+  if (xev->tsched.v == TSCHED_DELETE)
+    free_xevent (xevq, xev);
+  else
+  {
+    /* event rescheduling functions look at xev->tsched to
+       determine whether it is currently on the heap or not (i.e.,
+       scheduled or not), so set to TSCHED_NEVER to indicate it
+       currently isn't. */
+    xev->tsched.v = DDS_NEVER;
+    handle_timed_xevent (thrst, xev, xp, tnow);
+  }
+}
+```
+
+So between `extract_min` and the handler's own `resched_xevent_if_earlier`, the
+event exists but is scheduled nowhere. **Re-arming is entirely the handler's
+responsibility, and nothing checks that it happened.** A handler that returns
+without rescheduling leaks the event out of the queue while leaving it
+allocated — no assertion, no warning, no trace.
+
+## The two paths that do exactly that
+
+`handle_xevk_spdp` (`q_xevent.c:951`):
+
+```c
+if ((pp = entidx_lookup_participant_guid (gv->entity_index, &ev->u.spdp.pp_guid)) == NULL)
+{
+  GVTRACE ("handle_xevk_spdp "PGUIDFMT" - unknown guid\n", PGUID (ev->u.spdp.pp_guid));
+  if (ev->u.spdp.directed)
+    delete_xevent (ev);
+  return;
+}
+
+if ((spdp_wr = ddsi_get_builtin_writer (pp, NN_ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER)) == NULL)
+{
+  GVTRACE ("handle_xevk_spdp "PGUIDFMT" - spdp writer of participant not found\n", ...);
+  if (ev->u.spdp.directed)
+    delete_xevent (ev);
+  return;
+}
+```
+
+For a **directed** event (a one-shot reply to someone else's SPDP) this is
+correct: `delete_xevent` disposes of it properly.
+
+For the **periodic** event — the one that keeps the participant alive — both
+paths simply `return`. The event has already been extracted and stamped
+`DDS_NEVER`, so it is now:
+
+* not on the heap,
+* not marked for deletion,
+* not freed,
+* and referenced by nothing that will ever reschedule it.
+
+Permanently orphaned, on the one event whose whole purpose is to repeat.
+
+## Why this is not merely theoretical
+
+[#0997](0997-island-announces-spdp-once-then-lease-expires.md) observed exactly
+the end state this produces, read live over gdb on a stalled island:
+
+```
+xevents                    = {roots = 0x0}     <- timed-event tree EMPTY
+non_timed_xmit_list_oldest = 0x0
+non_timed_xmit_list_newest = 0x2170b228        <- tail with no head
+terminate                  = 0
+cond.tasks                 = {len = 10, cnt = 1}
+```
+
+The last SPDP handler logged `(resched 8s)`, and eight seconds later nothing
+fired. `tev` then waited with `portMAX_DELAY` — correctly, because the queue was
+empty — and the peer expired the lease 10 s after the final announcement.
+
+## What is NOT yet proven, and how to close it cheaply
+
+**That these early returns are the path actually taken.** The mechanism exists,
+and it produces precisely the observed state, but no trace line confirms it fired
+— because both early exits log through `GVTRACE`, which is the `trace` category, and
+the island run used `discovery`. The `trace` firehose over semihosted stdout is
+slow enough to perturb the timing of the thing being measured, which is why it
+was not simply enabled.
+
+Cheapest confirmation, in order:
+
+1. Route those two `GVTRACE` calls to `GVLOGDISC` (as #0997's investigation
+   already did for the "xmit spdp" line) and re-run with `<Category>discovery`.
+   A single `handle_xevk_spdp … - unknown guid` line settles it.
+2. If neither fires, the orphaning is happening elsewhere and the same audit
+   should be run across every `handle_xevk_*`: the contract above says each one
+   MUST reschedule or delete on every path, and that is a property nothing
+   currently enforces.
+
+## The fix, and the wider point
+
+Narrowly: the periodic event must be disposed of rather than dropped — either
+`delete_xevent (ev)` unconditionally on those paths, or reschedule it so a
+participant that reappears resumes announcing.
+
+Wider, and worth more: the invariant "a fired event is off the heap until its
+handler re-arms or deletes it" is enforced by nothing. A debug assertion at the
+bottom of `handle_timed_xevent` — that `tsched` is no longer `DDS_NEVER` unless
+the event was deleted — would have caught this at the first occurrence instead
+of presenting as a silent, permanent loss of discovery an hour into a run.
+
+Upstream carries the same code, so this is worth sending to
+`eclipse-cyclonedds/cyclonedds` rather than only carrying a fork patch. That
+call is the maintainer's.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -82,5 +82,6 @@ fails if this block drifts.
 - **#0988** (tooling) — No gate runs a hook the way git runs it — with `GIT_DIR` set — so a script that corrupts the caller's repository passes every check See `0988-*`.
 - **#0991** (cmake) — A clean build of an entity-declaring image derives the WRONG payload basis and does not link See `0991-*`.
 - **#0997** ([rmw, platform, embedded]) — The timed-event tree empties itself on FreeRTOS: the SPDP resend is scheduled, never lands in the queue, and every peer expires the participant's lease See `0997-*`.
+- **#1000** ([rmw, third-party]) — Vendored Cyclone: `handle_xevk_spdp`'s early returns orphan the PERIODIC spdp event — it leaves the heap, is never re-armed, and the participant goes silent forever See `1000-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
The mechanism behind #0997, isolated. **This is a defect in the vendored CycloneDDS fork** (`NEWSLabNTU/cyclonedds` @ `d97a71e`), not in nano-ros code — filed here because that repo has issues disabled and this is where the fork is consumed.

## The contract nothing enforces

`handle_xevents` (`q_xevent.c:1219`) takes an event **off** the fibheap before running it and stamps it unscheduled:

```c
struct xevent *xev = ddsrt_fibheap_extract_min (&evq_xevents_fhdef, &xevq->xevents);
...
/* event rescheduling functions look at xev->tsched to
   determine whether it is currently on the heap or not … */
xev->tsched.v = DDS_NEVER;
handle_timed_xevent (thrst, xev, xp, tnow);
```

So re-arming is entirely the handler's job, and **nothing checks that it happened**. A handler that returns early leaks the event out of the queue while leaving it allocated — no assertion, no warning, no trace.

## The two paths that do it

`handle_xevk_spdp` calls `delete_xevent` **only when the event is directed**:

```c
if ((pp = entidx_lookup_participant_guid (…)) == NULL) {
  GVTRACE ("handle_xevk_spdp … - unknown guid\n");
  if (ev->u.spdp.directed) delete_xevent (ev);
  return;
}
```

For the one-shot directed reply that's correct. For the **periodic** event — the one whose whole purpose is to repeat, and which keeps the participant alive — it just returns. The event is then off the heap, not marked for deletion, not freed, and referenced by nothing that will ever reschedule it.

## Which is exactly what was observed

#0997 read this live over gdb on a stalled island, ten seconds before the peer expired the lease:

```
xevents                    = {roots = 0x0}     ← timed-event tree EMPTY
non_timed_xmit_list_oldest = 0x0
non_timed_xmit_list_newest = 0x2170b228        ← tail with no head
terminate                  = 0
cond.tasks                 = {len = 10, cnt = 1}
```

The last handler logged `(resched 8s)`; eight seconds later nothing fired.

## What is not proven

No trace line confirms these early returns fired. Both log through `GVTRACE` (the `trace` category) while the island run used `discovery`, and the `trace` firehose over semihosted stdout is slow enough to perturb the timing being measured. The cheap confirmation is routing those two calls to `GVLOGDISC`, exactly as #0997's investigation did for the "xmit spdp" line. If neither fires, the same audit should run across every `handle_xevk_*`.

## The wider point

Worth more than the narrow fix: *"a fired event is off the heap until its handler re-arms or deletes it"* is an invariant nothing enforces. An assertion at the bottom of `handle_timed_xevent` would have caught this at the first occurrence, instead of as a silent permanent loss of discovery an hour into a run.

The code is stock upstream, so this is worth sending to `eclipse-cyclonedds/cyclonedds` rather than only carrying a fork patch — that call is the maintainer's.

## Testing

Docs only. `just check` — 2 of 188 gates fail (`kconfig-overridden-values`, `fixtures-manifest`), the same two that fail on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
