### PR TITLE
feat(phase-403 step 3): the arena sums over what the image declares

### DIFF
--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -33,7 +33,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | knob | default | read by |
 | --- | ---: | --- |
 | `NROS_EXECUTOR_ACTION_CLIENTS` | computed — see `packages/core/nros-node/build.rs:105` | `packages/core/nros-node` |
-| `NROS_EXECUTOR_ARENA_SIZE` | computed — see `packages/core/nros-node/build.rs:161` | `packages/core/nros-node` |
+| `NROS_EXECUTOR_ARENA_SIZE` | computed — see `packages/core/nros-node/build.rs:242` | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_CBS` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_NODES` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SC` | 8 | `packages/core/nros-node` |
@@ -60,6 +60,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_MAX_SOCKETS` | 1 | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SMOLTCP_MAX_UDP_SOCKETS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:26` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
+| `NROS_SUBSCRIBER_BUFFER_SIZE` | computed — see `packages/core/nros-node/build.rs:171` | `packages/core/nros-node` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
 | `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:488` | `packages/rmw/zenoh/nros-zpico-build` |

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -138,11 +138,92 @@ fn main() {
     let action_client_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
         + ACTION_CLIENT_FEEDBACK_SUBS * rx_buf_size
         + ACTION_CLIENT_SUB_OVERHEAD;
-    let pubsub_entry = PUBSUB_SUB_BUFS * rx_buf_size + PUBSUB_ENTRY_OVERHEAD;
-    let derived_arena = (action_clients * action_client_entry
-        + max_cbs.saturating_sub(action_clients) * pubsub_entry
-        + ARENA_BASE_OVERHEAD)
-        .max(ARENA_FLOOR);
+    // phase-403 step 3 -- a SUBSCRIPTION's arena buffer is sized by what it
+    // RECEIVES, which is not the knob this term used.
+    //
+    // `NROS_SUBSCRIPTION_BUFFER_SIZE` is also `DEFAULT_TX_BUF` and every raw
+    // entity's default buffer, so it is derived over the whole LINKED closure
+    // -- a type this image only publishes still has to fit. The arena's
+    // receive region is not that: `register_subscription_buffered_*` sizes it
+    // from the type's own bound, and the SUBSCRIBER payload class is the
+    // maximum over subscribed types, so it is a tight upper bound for every
+    // subscription and the closure figure is not.
+    //
+    // On the reference island that is 880 against 1496, and the difference is
+    // 3 * 616 per subscription -- 18,480 bytes over ten of them, which is why
+    // that image's hand-set 40,960 sits BELOW the modelled 52,304.
+    //
+    // Falls back to the closure knob when the payload class is absent, which
+    // is larger and therefore the safe direction.
+    // NOT WIRED YET, and the fallback is deliberate. The receive class is
+    // resolved into the cargo env as `ZPICO_SUBSCRIBER_BUFFER_SIZE` -- a
+    // BACKEND name, which this backend-agnostic crate must not read -- so
+    // `NROS_SUBSCRIBER_BUFFER_SIZE` is absent here and this falls back to the
+    // closure knob. Measured on the reference island: the arena derives 52,304
+    // against a hand-set 40,960, and the whole 11,344-byte difference is this
+    // term using 1,496 where the receive class is 880.
+    //
+    // Giving it a backend-agnostic spelling is a DESIGN choice with two bad
+    // options -- have this crate read a ZPICO_ name, or resolve one value
+    // under two names and invite the drift that three separate double
+    // resolutions have already caused in this file's sibling. It is named in
+    // phase-403 step 3 rather than guessed at here.
+    let rx_recv_size = env_usize("NROS_SUBSCRIBER_BUFFER_SIZE", rx_buf_size);
+    let pubsub_entry = PUBSUB_SUB_BUFS * rx_recv_size + PUBSUB_ENTRY_OVERHEAD;
+
+    // phase-403 step 3 -- SUM OVER WHAT THE IMAGE DECLARES, when it declares.
+    //
+    // The arithmetic below this comment charges EVERY callback slot at the
+    // pub/sub entry size. That is a worst case over `max_cbs`, and on an image
+    // that declares its entities it is wrong in a measurable direction: a
+    // TIMER claims 32 bytes of arena (measured, `report_arena_costs`) and this
+    // model bills it `3 * rx_buf + 512` -- 5,000 bytes at the reference
+    // island's derived rx_buf of 1,496. Ten subscriptions and four timers cost
+    // 72,048 modelled against ~50,000 actually claimed, which is why that
+    // image pins the knob by hand.
+    //
+    // So when phase-403 W9's entity inventory reaches this lane, the sum runs
+    // per KIND instead. Absence is not zero: a count that is missing means
+    // "nobody declared", and the whole per-kind path is skipped rather than
+    // summing zeros into a too-small arena.
+    //
+    // TIMER_ENTRY is measured, not modelled. `report_arena_costs` reports 32
+    // on x86_64; entry structs hold pointers, so this is rounded UP to a
+    // pointer-generous 64 rather than pinned to the host figure -- the one
+    // direction that cannot under-size a 32-bit target.
+    const TIMER_ENTRY: usize = 64;
+    let declared_subs = env_opt_usize("NROS_ENTITY_COUNT_SUBSCRIPTION");
+    let declared_timers = env_opt_usize("NROS_ENTITY_COUNT_TIMER");
+    let declared_services = env_opt_usize("NROS_ENTITY_COUNT_SERVICE_SERVER");
+    let declared_action_clients = env_opt_usize("NROS_ENTITY_COUNT_ACTION_CLIENT");
+    let declared_action_servers = env_opt_usize("NROS_ENTITY_COUNT_ACTION_SERVER");
+
+    let derived_arena = match (
+        declared_subs,
+        declared_timers,
+        declared_services,
+        declared_action_clients,
+        declared_action_servers,
+    ) {
+        (Some(subs), Some(timers), Some(services), Some(acl), Some(asv)) => {
+            // A service server carries a request AND a reply buffer, so it is
+            // billed at the pub/sub entry plus one more buffer rather than
+            // being folded into the pub/sub term.
+            let service_entry = pubsub_entry + rx_buf_size;
+            (subs * pubsub_entry
+                + timers * TIMER_ENTRY
+                + services * service_entry
+                + (acl + asv) * action_client_entry
+                + ARENA_BASE_OVERHEAD)
+                .max(ARENA_FLOOR)
+        }
+        // Nobody declared, or declared only partly: keep the pre-step-3
+        // arithmetic byte for byte, so no existing image moves.
+        _ => (action_clients * action_client_entry
+            + max_cbs.saturating_sub(action_clients) * pubsub_entry
+            + ARENA_BASE_OVERHEAD)
+            .max(ARENA_FLOOR),
+    };
     // `0` is the Kconfig SENTINEL for "derive it" (zephyr/Kconfig:
     // NROS_EXECUTOR_ARENA_SIZE, "0 = derive"), and it has to be honoured HERE,
     // where the value is consumed.
@@ -251,6 +332,27 @@ fn rung_value(
         "param_service_buffer_size" => rungs.param_service_buffer_size,
         _ => None,
     }
+}
+
+/// A DECLARED entity count, or `None` when nobody declared one.
+///
+/// phase-403 step 3. Deliberately NOT `env_usize` with a default: absence and
+/// zero are different answers here. `Some(0)` means "this image declares no
+/// timers"; `None` means "no entity inventory reached this lane", and summing
+/// a missing count as zero would produce an arena too small for entities that
+/// exist. The caller therefore requires EVERY count before using the per-kind
+/// sum, and otherwise keeps the pre-step-3 worst case.
+///
+/// Reads the same two places `env_usize` does and in the same order, so an
+/// operator override still wins: the cargo env, then `$DOTCONFIG` (issue 0460
+/// -- knobs reach the Zephyr Rust lane only through the dotconfig, because
+/// `set(ENV{...})` at configure time does not survive into the cargo build).
+fn env_opt_usize(name: &str) -> Option<usize> {
+    println!("cargo:rerun-if-env-changed={name}");
+    if let Some(v) = std::env::var(name).ok().and_then(|v| v.trim().parse().ok()) {
+        return Some(v);
+    }
+    nros_zephyr_build::dotconfig_usize(&format!("CONFIG_{name}"))
 }
 
 /// One executor knob: env → Kconfig → board → platform → built-in default.

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -5501,3 +5501,185 @@ fn a_deferred_goal_reaches_the_accepted_callback_exactly_once() {
         "still only the first goal"
     );
 }
+
+// ====================================================================
+// Phase 403 step 3 -- the ARENA COST OF ONE ENTITY, MEASURED
+//
+// Step 3 derives the arena as a sum over what the entity inventory says
+// the image creates, so it needs a per-kind cost. These MEASURE it:
+// `arena_alloc` is a BUMP allocator, so an `arena_used()` delta across
+// exactly one registration IS that entity's arena footprint, including
+// alignment padding at the region boundary and the trailing buffer that
+// `arena_alloc_with_trailing` places after the entry.
+//
+// Measured, never modelled. A table derived by reading `size_of` on the
+// entry structs would agree with the allocator right up until an
+// alignment or a trailing term moved, and this campaign has produced six
+// mechanisms that were arithmetically right and did not reach the thing
+// they sized. The derivation must be checked against what the allocator
+// ACTUALLY claims, which is what these deltas are.
+//
+// WHY THIS MATTERS MORE THAN THE OTHER KNOBS. An under-sized arena halts
+// DURING entity creation, before the first spin, so issue 0900's advisory
+// never prints. `MAX_CBS` fails at registration with `ExecutorFull` and
+// `MAX_NODES` with `NodeTableFull`, both naming their knob; the arena is
+// the one number whose failure mode cannot report itself. So its inputs
+// are measured before anything derives from them.
+// ====================================================================
+
+/// The arena cost of one TIMER, which carries no payload buffer and so is
+/// the floor every other kind is measured against.
+fn arena_cost_timer(executor: &mut Executor<'_>) -> usize {
+    let before = executor.arena_used();
+    executor
+        .register_timer(TimerDuration::from_millis(1000), || {})
+        .expect("timer registration must succeed");
+    executor.arena_used() - before
+}
+
+/// The arena cost of one SERVICE SERVER. A service carries TWO payload
+/// buffers (request and reply), so it is the kind whose cost is least
+/// predictable from a subscription's.
+fn arena_cost_service(executor: &mut Executor<'_>, name: &str) -> usize {
+    let before = executor.arena_used();
+    executor
+        .register_service_sized::<TestService, _, 512, 512>(name, |req: &TestServiceRequest| {
+            TestServiceReply { sum: req.a }
+        })
+        .expect("service registration must succeed");
+    executor.arena_used() - before
+}
+
+#[test]
+fn a_service_server_costs_a_measurable_and_constant_arena_slice() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let first = arena_cost_service(&mut executor, "/svc_a");
+    assert!(
+        first > 0,
+        "a service server must claim arena; a zero delta means the probe is \
+         not measuring the allocation it names"
+    );
+    let second = arena_cost_service(&mut executor, "/svc_b");
+    assert_eq!(
+        first, second,
+        "two service servers must cost the same; step 3 sums a per-kind \
+         constant over the declared count, which is only valid if it IS \
+         constant"
+    );
+}
+
+#[test]
+fn an_unbounded_subscription_costs_more_than_a_bounded_one() {
+    // Measured 2316 bounded against 5356 unbounded on x86_64 -- 2.3x. This is
+    // why step 3 must REFUSE when a subscribed type is unbounded rather than
+    // budgeting the fallback: the fallback is the expensive arm, so an image
+    // that silently took it would be sized for a number nobody chose.
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let nid = executor
+        .node_builder("bounded_vs_not")
+        .build()
+        .expect("node");
+    let bounded = arena_delta(&mut executor, nid, "/b", qos_with_depth(1), true);
+    let unbounded = arena_delta(&mut executor, nid, "/u", qos_with_depth(1), false);
+    assert!(
+        unbounded > bounded,
+        "the unbounded fallback must cost MORE than a derived bound \
+         (got {unbounded} vs {bounded}); if it were cheaper, refusing to \
+         derive would be the conservative choice and it is not"
+    );
+}
+
+/// The per-kind arena cost table, as a MEASUREMENT PROBE.
+///
+///     cargo test -p nros-node --features std --lib report_arena_costs -- --ignored
+///
+/// Reports through `panic!` rather than `println!` deliberately: this crate is
+/// `#![no_std]`, `std::println!` is banned in its `src/` (issue 0589 -- it
+/// SIGSEGVs a Zephyr native_sim image), and the panic payload is the one
+/// output channel that needs no stdio. `#[ignore]` because it is a tool for a
+/// human, not a verdict; the assertions below are the verdicts and they run
+/// every time.
+///
+/// HOST NUMBERS. The entry structs hold pointers, so a 32-bit target's table
+/// differs. Step 3 must compute per target and may never copy these.
+///
+/// Measured 2026-09-03, x86_64:
+///     timer=32  sub_d1=2316  sub_d10=2504  sub_unbounded=5356
+///     service_512_512=3496  per_depth=20
+///
+/// The d1->d10 delta of 188 does NOT match
+/// `(depth + 1) * bound + (depth + 1) * 8` exactly for any plausible bound of
+/// `TestMsg` (a bound of 12 predicts 180), so the region carries alignment or
+/// padding terms that formula omits. That gap is the whole reason step 3
+/// derives against THIS probe rather than against the formula.
+#[test]
+#[ignore = "measurement probe: run with --ignored to read the table"]
+fn report_arena_costs() {
+    // One executor PER measurement. The default MAX_CBS is 4, and this probe
+    // registers more entities than that -- the first version died with
+    // `ExecutorFull`, which is the knob naming itself and is exactly the
+    // failure mode the arena does NOT have. A bump allocator's deltas are
+    // independent, so per-kind executors measure the same thing.
+    let timer = {
+        let mut e: Executor = executor_with_clock(MockSession::new());
+        arena_cost_timer(&mut e)
+    };
+    let (d1, d10, unb) = {
+        let mut e: Executor = executor_with_clock(MockSession::new());
+        let nid = e.node_builder("arena_report").build().expect("node");
+        let a = arena_delta(&mut e, nid, "/r1", qos_with_depth(1), true);
+        let b = arena_delta(&mut e, nid, "/r10", qos_with_depth(10), true);
+        let c = arena_delta(&mut e, nid, "/ru", qos_with_depth(1), false);
+        (a, b, c)
+    };
+    let svc = {
+        let mut e: Executor = executor_with_clock(MockSession::new());
+        arena_cost_service(&mut e, "/rsvc")
+    };
+    panic!(
+        "ARENA timer={timer} sub_d1={d1} sub_d10={d10} sub_unbounded={unb} \
+         service_512_512={svc} per_depth={}",
+        (d10 as isize - d1 as isize) / 9
+    );
+}
+
+#[test]
+fn a_timer_costs_a_measurable_and_depth_independent_arena_slice() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let first = arena_cost_timer(&mut executor);
+    assert!(
+        first > 0,
+        "a timer must claim arena; a zero delta means the probe is not \
+         measuring the allocation it names"
+    );
+
+    // A second timer costs the same: the per-kind cost is a CONSTANT the
+    // derivation may multiply by a declared count. If this ever differs,
+    // the arena is not a straight sum and step 3's premise is wrong.
+    let second = arena_cost_timer(&mut executor);
+    assert_eq!(
+        first, second,
+        "two timers must cost the same; step 3 sums a per-kind constant \
+         over the declared count, which is only valid if it IS constant"
+    );
+}
+
+#[test]
+fn a_subscriptions_arena_cost_scales_with_declared_depth() {
+    // The whole reason step 2 had to land first. Depth is a MULTIPLIER on
+    // the bound -- `buffered_region_size(depth, bound)` is
+    // `(depth + 1) * bound + (depth + 1) * 8` -- so a derivation that
+    // ignores it is wrong by up to 10x, in whichever direction hurts.
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let nid = executor.node_builder("arena_probe").build().expect("node");
+
+    let d1 = arena_delta(&mut executor, nid, "/d1", qos_with_depth(1), true);
+    let d10 = arena_delta(&mut executor, nid, "/d10", qos_with_depth(10), true);
+
+    assert!(
+        d10 > d1,
+        "depth 10 must claim more arena than depth 1 (got {d10} vs {d1}); \
+         if these are equal the buffered region is not depth-scaled and \
+         the arena cannot be derived from a declared depth"
+    );
+}

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -159,6 +159,21 @@ KNOB_CLASS = {
     #
     # The board descriptor's facts: identity and paths the CLI hands the build,
     # which are what the ladder RESOLVES AGAINST rather than knobs it resolves.
+    # phase-403 step 3 -- the entity inventory's per-kind counts. INFRA, not
+    # sizing: nobody tunes these, they are what the image DECLARED, and the
+    # arena derivation sums bytes over them. Same category as a board
+    # descriptor fact -- something the ladder resolves AGAINST rather than a
+    # knob it resolves.
+    "NROS_ENTITY_COUNT_SUBSCRIPTION": ("infra", "declared entity count"),
+    "NROS_ENTITY_COUNT_TIMER": ("infra", "declared entity count"),
+    "NROS_ENTITY_COUNT_SERVICE_SERVER": ("infra", "declared entity count"),
+    "NROS_ENTITY_COUNT_ACTION_CLIENT": ("infra", "declared entity count"),
+    "NROS_ENTITY_COUNT_ACTION_SERVER": ("infra", "declared entity count"),
+    # The receive payload class. DERIVED -- it is the largest bound among the
+    # types this image subscribes to, which phase-403 W8 computes exactly. Read
+    # here so the arena stops billing a subscription at the CLOSURE buffer,
+    # which is also DEFAULT_TX_BUF and therefore larger.
+    "NROS_SUBSCRIBER_BUFFER_SIZE": ("derived", "receive payload class"),
     "NROS_BOARD_ZEPHYR_ID": ("infra", "board descriptor fact"),
     "NROS_BOARD_TOOLCHAIN": ("infra", "board descriptor fact"),
     "NROS_BOARD_RUNNER": ("infra", "board descriptor fact"),
@@ -286,6 +301,10 @@ def kconfig_symbols():
 # and a callee in neither is a FAILURE: the same "a new knob forces a decision"
 # rule this file already applies to knobs, applied to the idioms that read them.
 READ_CALLEES = {
+    # phase-403 step 3. Reads the environment like `env_usize`, but returns
+    # Option: for an entity COUNT, absence and zero are different answers and
+    # a default would erase the difference.
+    "env_opt_usize",
     "env", "env_get", "env_bool", "env_usize", "env_usize_min",
     "env_usize_compat", "env_or_repo_path", "env_path_or", "flag", "knob",
     "knob_usize", "knob_bool", "req", "list", "var", "var_os",

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -285,7 +285,17 @@ function(_nros_load_derived_entity_inventory)
         NROS_DERIVED_RMW_SUBSCRIBER_SLOTS
         NROS_DERIVED_MAX_PUBLISHERS
         NROS_DERIVED_MAX_QUERYABLES
-        NROS_DERIVED_EXECUTOR_MAX_NODES)
+        NROS_DERIVED_EXECUTOR_MAX_NODES
+        # phase-403 step 3 -- the per-kind COUNTS, for the arena sum. Third
+        # time this whitelist has dropped a symbol the fragment publishes: it
+        # is a NAMED list, so anything not spelled here loads and then dies at
+        # the function boundary, silently, and the consumer falls back to a
+        # default that looks deliberate.
+        NROS_ENTITY_COUNT_SUBSCRIPTION
+        NROS_ENTITY_COUNT_TIMER
+        NROS_ENTITY_COUNT_SERVICE_SERVER
+        NROS_ENTITY_COUNT_ACTION_CLIENT
+        NROS_ENTITY_COUNT_ACTION_SERVER)
         if(DEFINED ${_v})
             set(${_v} "${${_v}}" PARENT_SCOPE)
         endif()
@@ -410,6 +420,38 @@ function(nros_resolve_knobs)
     # bridge, whose two nodes are runtime strings declared nowhere; that path
     # now names this knob when the table fills, which is what makes deriving it
     # safe rather than hopeful.
+    # phase-403 step 3 -- the ARENA sums over what the image DECLARES, and the
+    # byte arithmetic lives in nros-node's build.rs (it knows rx_buf and the
+    # target's pointer width; this file knows neither). So the COUNTS travel
+    # and the bytes stay put.
+    #
+    # These are not Kconfig symbols, so `$DOTCONFIG` cannot carry them and the
+    # cargo env is the only route -- `nros_set_cargo_env_from_kconfig` exports
+    # every name in NROS_RESOLVED_KNOBS, so resolving them here is what makes
+    # them reachable. Forwarding a count the inventory did not publish would be
+    # WORSE than not forwarding it: build.rs treats a missing count as "nobody
+    # declared" and keeps the old worst case, while a zero would sum an arena
+    # too small for entities that exist.
+    # Spelled out, not looped. A computed name (`NROS_ENTITY_COUNT_${_kind}`)
+    # is invisible to `check-kconfig-knob-forwarding`, which reads this file
+    # statically: it saw the literal prefix as a forwarded knob no build script
+    # reads, and failed. It is the same lesson a computed `NROS_DERIVED_${_pool}`
+    # taught one wave earlier, where cmake resolved the built-up name to EMPTY
+    # and the knob silently took a default. Knob names are written in full.
+    if(DEFINED NROS_ENTITY_COUNT_SUBSCRIPTION AND
+       NOT "${NROS_ENTITY_COUNT_SUBSCRIPTION}" STREQUAL "")
+        _nros_resolve_knob(NROS_ENTITY_COUNT_SUBSCRIPTION
+            "${NROS_ENTITY_COUNT_SUBSCRIPTION}")
+        _nros_resolve_knob(NROS_ENTITY_COUNT_TIMER
+            "${NROS_ENTITY_COUNT_TIMER}")
+        _nros_resolve_knob(NROS_ENTITY_COUNT_SERVICE_SERVER
+            "${NROS_ENTITY_COUNT_SERVICE_SERVER}")
+        _nros_resolve_knob(NROS_ENTITY_COUNT_ACTION_CLIENT
+            "${NROS_ENTITY_COUNT_ACTION_CLIENT}")
+        _nros_resolve_knob(NROS_ENTITY_COUNT_ACTION_SERVER
+            "${NROS_ENTITY_COUNT_ACTION_SERVER}")
+    endif()
+
     _nros_resolve_derivable_knob(NROS_EXECUTOR_MAX_NODES
         "${CONFIG_NROS_EXECUTOR_MAX_NODES}" NROS_DERIVED_EXECUTOR_MAX_NODES
         "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")


### PR DESCRIPTION
**Stacked on #239** (step 2), which is stacked on #223 and #225. Two commits of its own: the measurement probe, then the derivation.

## The probe, first -- because the formula turned out to be incomplete

Step 3 sums per-kind costs, so it needs those costs. They are MEASURED, not modelled: `arena_alloc` is a bump allocator, so an `arena_used()` delta across exactly one registration IS that entity's footprint, alignment and trailing buffer included.

x86_64:

| entity | arena bytes |
| --- | ---: |
| timer | 32 |
| subscription, bounded, depth 1 | 2316 |
| subscription, bounded, depth 10 | 2504 |
| subscription, **unbounded** | 5356 |
| service server (512/512) | 3496 |

**phase-403's own formula does not predict this.** It models the region as `(depth + 1) * bound + (depth + 1) * 8`; the measured d1->d10 delta is **188**, and that formula gives 180 at the largest plausible bound for `TestMsg`. Terms it omits exist. A derivation built on the formula alone would be quietly wrong -- which is exactly why the phase ordered the probe first.

**The unbounded arm costs 2.3x a bounded one** (5356 vs 2316), so a subscribed type with no bound must make the derivation REFUSE rather than budget the fallback.

Four assertions run every time (non-zero, constant per kind, depth-scaling, unbounded-costs-more). The table itself is `#[ignore]`d and reports via `panic!` because `std::println!` is banned in this `no_std` crate (issue 0589).

## The derivation

The old model billed EVERY callback slot at the pub/sub entry size. On the island that is 14 slots x 5,000, and four of them are timers -- measured at 32 bytes. The sum now runs per kind.

**Absence is not zero.** `env_opt_usize` returns Option; the per-kind path runs only when EVERY count is present. A missing count means "no inventory reached this lane", and summing it as zero would produce an arena too small for entities that exist. Partial declaration keeps the old arithmetic byte for byte.

## What this does NOT ship, and why

**The island keeps its hand-set arena.** With the derivation live it computes **52,304** against the hand-set **40,960** -- it would GROW the image by 11,344 bytes. I restored the pin rather than land a saving that costs bytes.

The cause is the step-1 distinction: the pub/sub term multiplies by `NROS_SUBSCRIPTION_BUFFER_SIZE` (**1496**, the closure basis -- correct for that knob, which is also `DEFAULT_TX_BUF`). But a subscription's arena region is sized by what it RECEIVES, and the receive class is **880**. That is `3 * 616 * 10` = 18,480 bytes of over-charge, and it means **the hand-set 40,960 was an operator hand-correcting for a defect nobody had named.**

Not fixed here because it is not mechanical: the receive class reaches the cargo env as `ZPICO_SUBSCRIBER_BUFFER_SIZE`, a BACKEND name this backend-agnostic crate must not read, and resolving one value under a second name invites the drift that three separate double-resolutions have already caused in the sibling file. Documented at the fallback; named as the next step.

## Two gates caught real mistakes in this change

`check-kconfig-knob-forwarding` rejected a `foreach` that BUILT knob names -- invisible to a static scan, so it read as a forwarded knob nobody reads. Same lesson a computed `NROS_DERIVED_${_pool}` taught one wave earlier, where cmake resolved the built-up name to EMPTY and the knob silently took a default. Names spelled out.

`check-config-knob-census` refused six unclassified env names, forcing the decision it exists to force: counts are `infra` (declared facts, not tunables), the receive class is `derived`.

Also fixes the loader whitelist for the **third** time -- the five counts are published by the fragment and were dropped at the function boundary, silently, which is how the first attempt derived nothing while looking like it worked.

## Gates

`just check fast` 170/170. The island image links with the derivation live (RAM 88.85%); the arena value was read from the build script's output, not inferred from the image.