### PR TITLE
ci(phase-413 W1): one l3 lane, not two — build-wide becomes dispatch-only

### DIFF
--- a/.github/workflows/build-wide.yml
+++ b/.github/workflows/build-wide.yml
@@ -13,25 +13,51 @@
 # "It compiles and links for every target" is the regression that hurts most and
 # costs least to catch. That is this lane.
 #
-# WHY push(main) AND NOT the merge queue
+# WHY THIS IS `workflow_dispatch` ONLY — phase-413 W1
 #
-# The queue's budget is the required `CI` context, deliberately cheap so ten
-# agents can land (phase-395). This runs AFTER a merge, where its job is to
-# bound how far a link regression travels — one commit, not one nightly.
+# This file used to run on `push` to main, and its header carried a "WHY
+# push(main) AND NOT the merge queue" rationale. That rationale was FALSE the
+# day it was written: `queue.yml`'s `l3` job already ran this exact lane on
+# `merge_group`. `just ci matrix build` dispatches to `_matrix-build`, whose
+# body is `l3` — the same recipe, on the same runner labels. Two phases added
+# it independently (395 W7 there, 410 W2 here) and neither saw the other.
 #
-# WHY cancel-in-progress IS correct here and is NOT correct for run-depth
+# The duplication was not free. The two jobs provisioned DIFFERENTLY, in
+# opposite directions: this one ran `just setup tier2` and no codegen, the
+# queue job ran codegen by hand and leaned on the runner's baked SDKs. So the
+# same recipe reported success in the queue and failure here, on the same four
+# commits, minutes apart (issue 0996):
 #
-# A newer commit's answer subsumes an older one's, and at well under a minute this run
-# FINISHES before the next merge arrives. A 20-minute run-depth lane under the
-# same setting starves: with ten agents landing through a queue that batches
-# four, each merge cancels the last and the tier completes never — a lane that
-# always cancels looks busy while reporting nothing. Run depth is on a clock,
-# in the `run-*` workflows.
+#   36c306405  queue success 16:25:49   build-wide FAILURE 16:26:23
+#   da0344af1  queue success 17:02:18   build-wide FAILURE 16:43:26
+#   ad5a8ecf9  queue success 17:06:55   build-wide FAILURE 17:22:19
+#   d2a8955c5  queue success 01:23:54   build-wide FAILURE 17:27:51
+#
+# A post-merge lane that is red for a day reports nothing: a regression landing
+# in it looks exactly like yesterday's failure. Worse, this lane gates nothing
+# by construction — the merge has already happened — and `CI` is the only
+# REQUIRED context, so the queue copy does not gate either. Two runs of an
+# ungating lane, one of them permanently red.
+#
+# So the lane lives in `queue.yml` alone: it runs BEFORE the merge, it is
+# measured at 27-46 s which the queue can afford, and `queue-notify.yml`
+# watches that workflow, so a failure comments on the pull request instead of
+# sitting in the Actions tab.
+#
+# What survives here is the on-demand entry point. The self-hosted runner is
+# the only place most people can cross-build every target, so `workflow_
+# dispatch` keeps that reachable without opening a pull request.
+#
+# CANCEL-IN-PROGRESS, on a dispatch-only lane
+#
+# Kept: two dispatches of the same ref mean the operator wants the newer
+# answer. The original note explained why this setting is right for build depth
+# and wrong for run depth — a 20-minute run-depth lane under the same setting
+# starves, because each merge cancels the last and the tier completes never.
+# That reasoning still governs the `run-*` workflows, which are on a clock.
 name: build-wide
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/just/ci.just
+++ b/just/ci.just
@@ -297,7 +297,9 @@ _matrix-run:
 # cover actually has a job. Change the lane here and CI follows, with no second
 # edit — that is the whole reason the selection is computed.
 # BUILD depth over the tier-2 breadth: cross build + link, no boot. This is
-# what `build-wide.yml` runs on every merge.
+# what `queue.yml` runs on every merge group (phase-413 W1 — it ran in two
+# places, `queue.yml` and `build-wide.yml`, with different provisioning and
+# opposite verdicts; the latter is dispatch-only now).
 #
 # It IS `l3` — build depth means build, link, AND verify the link, which is the
 # ELF symbol interrogation plus the heap-free gate that `l3` already does.

--- a/scripts/check-lane-contracts.py
+++ b/scripts/check-lane-contracts.py
@@ -66,8 +66,10 @@ LANES = {
     "ci::gate": "compile + unit, NO fixture build (CLAUDE.md)",
     # BUILD depth over the tier-2 breadth. Same affordability shape as the gate
     # — it must not resolve a fixture — for a different reason: it is the
-    # MANDATORY per-merge lane (build-wide.yml), so a fixture dependency here
-    # would make every merge pay a fixture build.
+    # per-merge lane, run by `queue.yml` on `merge_group`, so a fixture
+    # dependency here would make every merge pay a fixture build. (It used to
+    # name build-wide.yml, which ran the SAME recipe on push to main until
+    # phase-413 W1 collapsed the duplicate; that file is dispatch-only now.)
     "ci::_matrix-build": "cross build + link, NO fixture build (phase-410)",
     "check::fast": "buildless and source-only",
 }


### PR DESCRIPTION
phase-413 W1, first half. Issue 0996 measured the defect; this removes it.

## The lane ran twice and gated neither time

`just ci matrix build` dispatches to `_matrix-build`, whose body is `l3`. So `queue.yml` (`just ci l3`, on `merge_group`) and `build-wide.yml` (`just ci matrix build`, on `push` to main) ran the **same recipe on the same runner labels**. Two phases added it independently — 395 W7 there, 410 W2 here — and neither saw the other, so build-wide carried a `WHY push(main) AND NOT the merge queue` rationale that was false the day it was written.

The duplication was not free. The two jobs provisioned **differently, in opposite directions**: build-wide ran `just setup tier2` and no codegen; the queue job ran codegen by hand and leaned on the runner’s baked SDKs. Same recipe, same commits, minutes apart, opposite verdicts:

| commit | queue.yml | build-wide.yml |
| --- | --- | --- |
| `36c306405` | success 16:25:49 | **failure** 16:26:23 |
| `da0344af1` | success 17:02:18 | **failure** 16:43:26 |
| `ad5a8ecf9` | success 17:06:55 | **failure** 17:22:19 |
| `d2a8955c5` | success 01:23:54 | **failure** 17:27:51 |

## Why the queue copy is the one kept

- Measured at 27–46 s, which the queue can afford.
- It runs **before** the merge, where a gate belongs. A post-merge copy gates nothing by construction.
- `queue-notify.yml` watches that workflow, so a failure comments on the pull request instead of sitting in the Actions tab.

Worth stating plainly: `CI` is the **only** required context, so neither copy gates today. This was two runs of an ungating lane, one of them permanently red for a day — and a lane red for a day reports nothing, since a regression in it looks exactly like yesterday’s failure.

## What survives

`build-wide.yml` keeps `workflow_dispatch`. The self-hosted runner is the only place most people can cross-build every target, and that stays reachable without opening a pull request. Its `cancel-in-progress` note is rewritten for a dispatch lane, keeping the reasoning that still governs the `run-*` workflows.

Two comments naming build-wide as the per-merge lane are corrected (`just/ci.just`, `scripts/check-lane-contracts.py`). The gate’s LANES table is unchanged — only the prose saying which workflow runs `ci::_matrix-build`.

## Not in this PR

Deleting `queue.yml`’s four hand-rolled sync steps is the **rest** of W1 and waits on issue 0992 (#208). That boilerplate is load-bearing until the build verb does codegen itself — it is what hides 0992 from the queue while build-wide burns.

## Verification

Gates green: `check-lane-contracts`, `check-ci-no-verb-fallback`, `check-workflow-repo-env`, `check-required-contexts-reportable`, `check-doc-recipe-refs`. Workflow triggers verified by parsing the YAML (`workflow_dispatch` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)