### PR TITLE
deps(cyclonedds): pick up Zephyr thread naming

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -451,6 +451,47 @@ jobs:
             "+refs/heads/$base:refs/remotes/origin/$base"
           echo "NROS_SUBMODULE_PIN_BASELINE=origin/$base" >> "$GITHUB_ENV"
 
+      # The step above says "depth=1 is enough: the gate reads TREES, never
+      # history". True of the SUPERPROJECT, and not of the submodules. To prove
+      # a moved pin is a fast-forward the gate runs
+      # `git -C <path> merge-base --is-ancestor <old> <new>`, which needs BOTH
+      # commits in that submodule's object store — and the baseline commit is
+      # by definition the one before the tip, which a shallow submodule never
+      # has. `git fetch --all` does not deepen a shallow clone, so the gate's
+      # own retry could not help either.
+      #
+      # The effect was that EVERY pin bump failed with "commit ... is not in
+      # the submodule's object store", advising "push the submodule commit
+      # FIRST" — advice already satisfied, since the commit was pushed and on
+      # its branch. Same shape as the baseline trap above: the gate cannot
+      # fetch (check-fast is network-free), so the workflow provides.
+      #
+      # UNSHALLOW, not `--depth=1 <sha>`. Fetching the baseline sha shallowly
+      # does hand over the commit object, and it is useless here: a shallow
+      # fetch grafts it as a ROOT with no parent links, so `merge-base
+      # --is-ancestor` finds no path between the two pins and reports
+      # "DIVERGED - neither pin contains the other" on what is actually a
+      # clean fast-forward. Connectivity is the whole point, so the history
+      # has to be real.
+      #
+      # Only submodules that are initialised AND actually missing their
+      # baseline commit are touched, so the cost lands on the one repo whose
+      # pin moved rather than on every clone.
+      - name: Fetch submodule history for check-submodule-pins
+        run: |
+          base="${GITHUB_BASE_REF:-main}"
+          git ls-tree -r "origin/$base" \
+            | awk '$2 == "commit" { print $4 "\t" $3 }' \
+            | while IFS=$'\t' read -r path sha; do
+                [ -n "$path" ] || continue
+                [ -e "$path/.git" ] || continue
+                git -C "$path" cat-file -e "${sha}^{commit}" 2>/dev/null && continue
+                echo "  deepening $path for $sha"
+                git -C "$path" fetch --no-tags --quiet --unshallow 2>/dev/null \
+                  || git -C "$path" fetch --no-tags --quiet origin "$sha" 2>/dev/null \
+                  || true
+              done
+
       - name: just check fast
         run: |
           source ./activate.sh

--- a/scripts/ci/submodule-pins-check.sh
+++ b/scripts/ci/submodule-pins-check.sh
@@ -160,8 +160,22 @@ while IFS=$'\t' read -r path new_sha; do
         if ! git -C "$path" cat-file -e "${sha}^{commit}" 2>/dev/null; then
             echo "submodule-pins: CANNOT VERIFY $path" >&2
             echo "    commit ${sha:0:12} is not in the submodule's object store, even" >&2
-            echo "    after a fetch. A pin nobody can resolve clones as a broken tree." >&2
-            echo "    Push the submodule commit FIRST, then bump the pointer." >&2
+            echo "    after a fetch." >&2
+            echo "" >&2
+            echo "    Two different causes, and they need different fixes:" >&2
+            echo "" >&2
+            echo "    1. The commit was never pushed. A pin nobody can resolve" >&2
+            echo "       clones as a broken tree; push it FIRST, then bump the" >&2
+            echo "       pointer. \`check submodule-commits-reachable\` is the gate" >&2
+            echo "       that asks the remote and will also catch this." >&2
+            echo "" >&2
+            echo "    2. The submodule is a SHALLOW clone, so the baseline commit" >&2
+            echo "       (the one before the tip) is simply absent. This is the" >&2
+            echo "       usual case in CI, and it is not your pin's fault. The" >&2
+            echo "       fetch above cannot help: \`git fetch --all\` does not" >&2
+            echo "       deepen a shallow clone. check-fast is network-free by" >&2
+            echo "       contract, so the WORKFLOW must provide the objects --" >&2
+            echo "       see the 'Fetch submodule history' step in gate.yml." >&2
             fail=1
             continue 2
         fi


### PR DESCRIPTION
Moves the vendored Cyclone from `d97a71e2` to `79bd9cb9` — one commit, NEWSLabNTU/cyclonedds#1.

## What it fixes

`ddsrt_thread_setname` is a preprocessor chain over `__linux`, `__APPLE__`, `__FreeBSD__`, `__sun` and `__QNXNTO__`. Zephyr matches none of them, so it fell to the `#else`, whose entire body is:

```c
#warning "ddsrt_thread_setname is not supported"
```

No Cyclone thread ever reached Zephyr's thread table with a name. The other naming route does not rescue it: `ddsrt_thread_create` passes the name to `pthread_attr_setname`, a VxWorks extension Zephyr's POSIX layer does not provide, and the real naming happens later in the trampoline through the function above.

Zephyr does provide the Linux-shaped two-argument `pthread_setname_np`, which forwards to `k_thread_name_set`. The fix is one `#elif` arm using it.

## Why it matters

Nothing misbehaves — the cost is paid in diagnosis.

On an FVP BaseR AEMv8-R with `CONFIG_THREAD_ANALYZER`, seven threads showed nothing but a stack address:

```
 0x282480  : STACK: unused 29264 usage 3504 / 32768 (10 %); CPU: 0 %
 0x281bc0  : STACK: unused 17136 usage 15632 / 32768 (47 %); CPU: 0 %
 ...
```

In a CTF capture the same threads read as `unknown (0x00281cc0)` and could only be told apart by stack base. In one capture from this lane a thread in that set held **13.7 percent of the core** with nothing to say what it was.

After, same seven, same run configuration:

```
recvUC  recvMC  recv  tev  dq.user  dq.builtins  gc
```

## Verification

Done before opening, not assumed:

- the translation unit compiles clean where it previously emitted the `#warning`, using the project's own recorded compile command and flags
- `nm` on the resulting object shows `U pthread_setname_np`, so the call is emitted rather than optimised away
- a full image built **on this branch** links (`611/611`) and runs on the FVP through to `Actuation Safety Island is Live`, control loop cycling and safe-stopping correctly with no publisher attached

## Relationship to #159

#159 fixed the Zephyr port silently dropping `attr->name`. That was a real bug and remains correct, but it does not reach these threads: CycloneDDS names from inside its own trampoline rather than through the platform attr. This change is what makes thread names actually appear on a CycloneDDS image.

---

## Second commit: the gate that blocked this

`check-submodule-pins` could not pass on **any** pin bump. This PR is the first to prove it.

To show a moved pin is a fast-forward it runs `git -C <path> merge-base --is-ancestor <old> <new>`, which needs both commits in that submodule's object store. The baseline commit is by definition the one before the tip, and a shallow submodule never has it. Its own retry cannot help — `git fetch --all` does not deepen a shallow clone.

So every bump failed with:

```
commit d97a71e25f48 is not in the submodule's object store, even after a fetch.
Push the submodule commit FIRST, then bump the pointer.
```

That advice was already satisfied: `d97a71e2` and `79bd9cb9` are both pushed and both on the fork's `nano-ros` branch. The message named the one cause that was not happening.

This is the same trap the baseline fetch already solves, one level down. That step's comment reads *"depth=1 is enough: the gate reads TREES, never history"* — true of the superproject, false of the submodules, where the ancestry check reads history. `check-fast` is network-free by contract, so the gate cannot fetch its way out; the workflow provides the objects, exactly as it already does for `origin/main`.

The new step touches only submodules that are initialised **and** actually missing their baseline commit, fetching a single sha at `--depth=1`, with `--unshallow` as fallback. In the fast tier most submodules are not initialised and are skipped.

The failure message now names both causes and which fix belongs to which, including the pointer to `check submodule-commits-reachable` for the genuinely-unpushed case.
