### PR TITLE
ci(phase-413 W1b): queue.yml sheds its hand-rolled codegen; post-submit stops discarding work in flight

### DIFF
--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -43,7 +43,32 @@ concurrency:
   # Superseding is correct HERE and wrong in the queue: post-submit asks "is
   # main good NOW", so a newer commit's answer subsumes an older one's.
   group: post-submit-${{ github.ref }}
-  cancel-in-progress: true
+  # ...but supersede the PENDING run, never the RUNNING one — phase-413.
+  #
+  # MEASURED 2026-09-03: 10 of the last 30 runs of this lane were CANCELLED.
+  # `dep-chain` is 158 s and merges through a batching queue sometimes arrive
+  # inside that, so the header's own class — "a lane that always cancels looks
+  # busy while reporting nothing" — still bit the lane phase-410 left behind.
+  #
+  # `cancel-in-progress: false` is NOT "let them all pile up". GitHub keeps at
+  # most one run in progress per group and ONE pending: when a run is queued
+  # behind an in-progress one, any PREVIOUSLY pending run in the same group is
+  # cancelled. So this setting is a debounce, and it changes WHICH run is
+  # discarded — the pending one, which has consumed no runner, instead of the
+  # in-flight one, which has already spent its minutes and is thrown away with
+  # nothing to show.
+  #
+  # The cost is honest and small: the verdict in flight is for a slightly older
+  # commit, and the newest pending run covers the newest one. A cancelled run
+  # gives NO verdict at all, which is the failure mode this repo keeps meeting
+  # (issue 0996: four of six lanes carrying no signal). Trading a little
+  # freshness for a verdict that exists is the right way round for a lane whose
+  # whole job is to bound how far a regression travels.
+  #
+  # `cancel-in-progress: true` stays right where a run is SHORT relative to the
+  # merge interval, or where an operator asked for the newest answer on demand
+  # (`build-wide.yml`, dispatch-only since W1).
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -68,90 +68,53 @@ jobs:
       # lands on the author's change looking like a code failure. Assert first.
       - name: Verify this runner's labels are true
         run: ./scripts/ci/runner-doctor.sh nros-sdk-zephyr,nros-big
-      # L3 cross-builds three example leaves, and every one of them carries a
-      # `.cargo/config.toml` whose `include` names the GITIGNORED
-      # `nros-patch.toml` that only `nros sync` writes. Cargo treats a missing
-      # include as a HARD error during manifest parse (issue 0463), so without
-      # this the lane dies before compiling anything:
+      # phase-411 W4 — a CI job is `just setup <scope>` then one command a
+      # developer can type. Nothing here is CI-only orchestration.
+      #
+      # WHAT THIS REPLACES, AND WHY IT WAS HERE
+      #
+      # Four hand-rolled steps stood here until phase-413 W1b: `just setup-cli`,
+      # `just setup-launch-resolve`, `nros sync` on the rust workspace, and a
+      # loop syncing the three leaves L3 cross-builds. They existed because the
+      # leaves carry a `.cargo/config.toml` whose `include` names the GITIGNORED
+      # `nros-patch.toml` that only `nros sync` writes, and cargo treats a
+      # missing include as a HARD error during manifest parse (issue 0463):
       #
       #   error: 54 unresolved `include` target(s) across 54 of 73 tracked
       #          .cargo/config.toml files
       #
-      # That is what this job had been failing on since it was enabled — NOT the
-      # Zephyr SDK. The doctor step above passes; `ac0c8cd96` fixed the SDK
-      # lookup, and the red simply moved one step later, which is easy to read
-      # as "the runner is still broken".
+      # That is issue 0992: the codegen stage was mandatory and reachable from
+      # no verb, so this lane did it by hand. The workaround was LOAD-BEARING —
+      # it is what kept the queue green while `build-wide.yml`, running the same
+      # recipe without it, failed on that exact error for a day (issue 0996).
       #
-      # `nros sync` needs the CLI built and `nros-launch-resolve` sitting BESIDE
-      # it (issues 0285 / 0797 — resolved by absolute path, never $PATH, and
-      # `--bin nros` does not build it). Same chain `host-tests.yml` and
-      # `nightly.yml` already run, for the same reason.
-      - name: Build nros CLI (nros sync needs it)
+      # `just setup <scope>` now runs `_setup-common` (the guarded play_launch
+      # submodule init, the CLI, the launch resolver) and the build verb runs
+      # `_codegen` for every scope, in dependency order. The steps are gone
+      # because the toolchain does the work, not because the work stopped
+      # mattering — and that is the point of the phase: a hand-rolled step in a
+      # workflow is a claim the toolchain cannot do the thing itself, and each
+      # true one is a defect nobody is looking at.
+      #
+      # NROS_SKIP_LEAF_INCLUDE_CHECK went with them. It skipped
+      # `_require-leaf-includes`, never the sync itself, and post-0992 the sync
+      # happens inside `_codegen` regardless — so the variable would now
+      # suppress only the ASSERT that the codegen this lane just ran produced a
+      # resolvable tree. That is the one thing worth keeping.
+      - name: just setup tier2
         run: |
-          git submodule update --init --depth 1 packages/cli/third-party/play_launch
           source ./activate.sh
-          just setup-cli
+          just setup tier2
 
-      - name: Build nros-launch-resolve (nros sync shells out to it)
+      # `ci matrix build` — the (breadth, depth) pair, not a lane letter.
+      # phase-410 W4: `l3` survives as the implementation; this spelling says
+      # WHICH breadth at WHICH depth, which is what the file is for. It is the
+      # same recipe (`_matrix-build`'s body IS `l3`), now with one spelling
+      # across the repo instead of two.
+      - name: just ci matrix build
         run: |
           source ./activate.sh
-          just setup-launch-resolve
-
-      # Run from a WORKSPACE, not the repo root. `nros sync` at the root fails —
-      #
-      #   Error: sync: no `src/<pkg>/package.xml` and no `package.xml` at root
-      #          … expected colcon-style workspace or single-pkg dir
-      #
-      # — which is what the first attempt at this step did, because the remedy
-      # the leaf-include gate prints is `nros sync` with no directory. The
-      # CENTRAL patch is written to `<checkout>/nros-patch.toml` by ANY
-      # workspace's sync (`ws.rs` CENTRAL_PATCH_FILE), so one workspace suffices
-      # and every one of the 54 leaves then resolves its include.
-      #
-      # Verified locally: with the root file deleted, `cd examples/workspaces/
-      # rust && nros sync` recreated it BYTE-IDENTICAL to the committed-era one,
-      # `leaf-config-includes.py` went green, and no tracked file changed.
-      - name: nros sync (writes the central `nros-patch.toml` the leaves include)
-        run: |
-          source ./activate.sh
-          cd examples/workspaces/rust
-          nros sync
-
-      # ...and the THREE leaves this lane actually cross-builds. Each example
-      # leaf is its own consumer: its manifest path-deps `generated/<msg pkg>`,
-      # which `nros sync` produces per leaf and `.gitignore` excludes, so a
-      # clone has none of them.
-      - name: nros sync the leaves L3 builds
-        run: |
-          source ./activate.sh
-          for leaf in examples/qemu-arm-freertos/rust/talker \
-                      examples/qemu-arm-nuttx/rust/talker \
-                      examples/threadx-linux/rust/talker; do
-            nros sync "$leaf"
-          done
-
-      # NROS_SKIP_LEAF_INCLUDE_CHECK, deliberately and narrowly.
-      #
-      # `_require-leaf-includes` is a REPO-WIDE precondition: it walks all 73
-      # tracked `.cargo/config.toml` and 110 manifests and fails if ANY leaf
-      # lacks its gitignored `generated/`. That is right for `just format` and
-      # `build-test-fixtures`, which touch the whole tree (issues 0463/0474).
-      #
-      # L3 cross-builds THREE leaves. Demanding a fully-synced tree to link
-      # three talkers means syncing ~108 unrelated leaves per merge group, and
-      # the guard's whole purpose — turning a cryptic cargo manifest-parse error
-      # into a sentence naming sync — is already served for the leaves that
-      # matter by the step above, which syncs exactly them.
-      #
-      # So the scope of the check is wrong for this lane, not the check. If L3
-      # ever reaches a leaf outside that list, the raw cargo error is the cost,
-      # which is what the bypass documents.
-      - name: just ci l3
-        env:
-          NROS_SKIP_LEAF_INCLUDE_CHECK: "1"
-        run: |
-          source ./activate.sh
-          just ci l3
+          just ci matrix build
       - name: Upload logs and size reports
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Two commits: the rest of phase-413 W1, and the cancellation waste.

## W1b — delete the four hand-rolled steps

`queue.yml`s L3 job carried `just setup-cli`, `just setup-launch-resolve`, `nros sync` on the rust workspace, and a loop syncing the three leaves L3 cross-builds. They existed because those leaves reach the gitignored `nros-patch.toml` through an `include`, and cargo treats a missing include as a **hard manifest-parse error** (issue 0463).

That workaround was **load-bearing** — it is what kept this lane green while `build-wide.yml`, the same recipe without it, failed on `54 unresolved include target(s)` for a day (issue 0996). Issue 0992 (#208, merged `c98918979`) made the claim false: `just setup <scope>` runs `_setup-common` and the build verb runs `_codegen` for every scope. The job is now `just setup tier2` then one command — the phase-411 W4 shape.

`NROS_SKIP_LEAF_INCLUDE_CHECK` went with them: it skipped the *check*, never the sync, and post-0992 the sync happens inside `_codegen` regardless — so it would now suppress only the assert that the codegen this lane just ran produced a resolvable tree.

## Cancellation waste

Measured: **10 of the last 30 `post-submit` runs were cancelled.** The lane is `dep-chain` at 158 s and merges sometimes arrive inside that.

`cancel-in-progress: false` here is a **debounce, not a pile-up** — GitHub documents it:

> At most one job or workflow run can be `pending` in the concurrency group. When a new job or workflow run is queued, any existing `pending` job or workflow run in the same group is canceled and replaced.

So the group holds one running + one pending. The setting only changes **which run is discarded**: the pending one, which has consumed no runner — instead of the in-flight one, which has already spent its minutes and is thrown away with nothing to show.

This matches the published guidance for default branches (never `cancel-in-progress: true` on `main`; let default-branch runs finish). `true` stays right for short lanes and for on-demand dispatch (`build-wide.yml`, dispatch-only since #249).

## Deliberately not done

Cancelling a queue lane when its batch is destroyed. The community pattern keys on a `merge_group.destroyed` event; GitHubs reference says only `checks_requested` is supported, so that workaround cannot be written today.

Gates: `lane-contracts`, `ci-no-verb-fallback`, `workflow-repo-env`, `required-contexts-reportable`, `gate-visibility`, `doc-recipe-refs` — all green.

Stacked on #249 conceptually but independent in content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)