### PR TITLE
docs(#971): close it — the pending-status fix is in on both paths, verified

### DIFF
--- a/docs/issues/archived/0971-take-sequence-cannot-say-why-it-stopped.md
+++ b/docs/issues/archived/0971-take-sequence-cannot-say-why-it-stopped.md
@@ -1,7 +1,7 @@
 ---
 id: 971
 title: "`take_sequence` cannot say why a drain stopped, and its two implementations disagree about it"
-status: open
+status: resolved
 area: [rmw, api]
 severity: high
 related: [0969, 0773, phase-124, phase-376, phase-384]
@@ -214,3 +214,64 @@ named this issue as the place the question belongs.
 [#0964](0964-two-different-sizes-for-the-same-type.md) — how big a receive
 buffer should be. That is about picking `per_msg_cap`; this is about what
 happens when the pick is wrong.
+
+## Resolution — implemented as specified, on both paths, 2026-09-03
+
+Verified against the code rather than the text; the fix had landed and only this
+file was open.
+
+**Cyclone** (`subscriber.cpp`). `SubState::pending_too_small`, set in the drain
+loop when a sample does not fit and delivered at the top of the NEXT call:
+
+* `subscription_take_sequence_count` returns
+  `-static_cast<int32_t>(NROS_RMW_RET_BUFFER_TOO_SMALL)` — negated, per issue
+  0773, because this entry point's success value is a count;
+* `subscription_take` returns it unnegated, because it can return a status
+  inline. Both check, so a caller that mixes the two entry points hears it
+  either way — which is the case the fix would have missed if only the sequence
+  path had the check.
+
+**Runtime fallback** (`CffiSubscriber`, `cffi/src/lib.rs`).
+`pending_status: Option<TransportError>`, with the rule the issue asked for:
+
+```rust
+Err(e) => {
+    if count == 0 { return Err(e); }   // nothing delivered — no count to protect
+    self.pending_status = Some(e);     // park it; the slots already written are real
+    break;
+}
+```
+
+and `pending_status.take()` before any new take. So both paths now emit the same
+SEQUENCE of answers, which is what makes `rmw_vtable.h`'s "identical observable
+behaviour" claim true instead of something to delete.
+
+## Tests, and the mutation that proves they measure
+
+* `nros-rmw-cyclonedds/tests/take_sequence_pending_status.cpp`
+* `nros-rmw-cffi/tests/try_recv_sequence.rs` — six cases, four of them 0971's:
+  two messages then an oversized sample then empty; the fallback loop with a
+  backend whose third take does not fit; the parked status delivered next call;
+  and the `count == 0` arm that returns immediately.
+
+Reverting the fallback's `Err` arm to the pre-0971 `return Err(e)` — the shape
+that discarded the count — fails
+`try_recv_sequence_fallback_parks_the_status` and nothing else. The tests
+distinguish the fix from its absence rather than merely compiling against it.
+
+## What this issue is worth remembering for
+
+Not the flag, which is small, but the two corrections it made to itself while
+open:
+
+1. It first claimed `subscription_take` (single) had the same defect. It does
+   not. Consume-then-refuse is the DESIGN — live zenoh does the identical thing
+   deliberately, and `nros-verification`'s `no_silent_truncation` proves the
+   invariant is "no stuck subscription and no silent truncation", not "the
+   message survives".
+2. The dead `err < 0` branch it found was ALSO the wrong fix. Making it
+   reachable would have traded a silent drop for a contract violation, since
+   erroring out of a partial drain is exactly what `rmw_vtable.h` forbids.
+
+Both corrections narrowed the issue before anyone implemented it. That is the
+issue working as intended.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -73,7 +73,6 @@ fails if this block drifts.
 - **#0965** (codegen, memory, build) — Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set See `0965-*`.
 - **#0968** (testing) — Tier 2 has ~12 runtime e2e failures on main, unreproduced — nobody has run the tier in a long time See `0968-*`.
 - **#0969** ([rmw, memory]) — The Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a decode, an encode and two heap allocations per take See `0969-*`.
-- **#0971** ([rmw, api]) — `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it See `0971-*`.
 - **#0973** (orchestration) — No resolved SystemModel describes endpoint wiring — 0 of 119 carry topics, services or actions See `0973-*`.
 - **#0976** ([rmw, testing]) — Five action adapters in the Cyclone service path reshape the CDR to match ROS 2, and the only thing that exercises them is nano-ros talking to itself See `0976-*`.
 - **#0986** (tooling) — The pre-push hook writes into the repository it is guarding See `0986-*`.


### PR DESCRIPTION
## What

Closes **#0971**. No code — the fix was already in on both paths; this verifies
it against the tree and records what the issue is worth remembering for.

## Verified, not reimplemented

I started this intending to implement the fix and found it landed. Both halves
match the issue's spec exactly:

**Cyclone** (`subscriber.cpp`) — `SubState::pending_too_small`, set in the drain
loop when a sample does not fit, delivered at the top of the NEXT call:

* `subscription_take_sequence_count` returns
  `-static_cast<int32_t>(NROS_RMW_RET_BUFFER_TOO_SMALL)` — negated per issue
  0773, because this entry point's success value is a count;
* `subscription_take` returns it unnegated, because it *can* return a status
  inline. Both check, so a caller mixing the two entry points hears it either
  way — the case a sequence-only fix would have missed.

**Runtime fallback** (`CffiSubscriber`) — `pending_status: Option<TransportError>`:

```rust
Err(e) => {
    if count == 0 { return Err(e); }   // nothing delivered — no count to protect
    self.pending_status = Some(e);     // park it; the slots already written are real
    break;
}
```

with `pending_status.take()` before any new take. Both paths now emit the same
SEQUENCE of answers, which is what makes `rmw_vtable.h`'s "identical observable
behaviour" claim true rather than something to delete.

## The mutation that proves the tests measure

Reverting the fallback's `Err` arm to the pre-0971 `return Err(e)` — the shape
that discarded the count — fails `try_recv_sequence_fallback_parks_the_status`
and nothing else. Restored and re-verified green.

Tests: `nros-rmw-cyclonedds/tests/take_sequence_pending_status.cpp`, and four of
the six cases in `nros-rmw-cffi/tests/try_recv_sequence.rs`.

## What the issue is worth remembering for

Not the flag, which is small, but the two corrections it made to ITSELF while
open:

1. It first claimed single `subscription_take` shared the defect. It does not.
   Consume-then-refuse is the DESIGN — live zenoh does the identical thing
   deliberately, and `nros-verification`'s `no_silent_truncation` proves the
   invariant is "no stuck subscription and no silent truncation", not "the
   message survives".
2. The dead `err < 0` branch it found was ALSO the wrong fix. Making it
   reachable would have traded a silent drop for a contract violation, since
   erroring out of a partial drain is exactly what `rmw_vtable.h` forbids.

Both narrowed the issue before anyone implemented it.

## Verification

`just ci gate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP
