### PR TITLE
feat(phase-400 W6): the `rmw` tenant — three of four, because phase-412 owns the fourth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-01): W2-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory` and `params` tenants done, its remaining tenants and W1
+`zenoh.tx`, `memory`, `params` and `rmw` tenants done, its remaining tenants and W1
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -312,6 +312,36 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `rmw` tenant — done, minus the one phase-412 took
+
+Three static pools the CFFI registry and node table are carved from —
+`NROS_RMW_MAX_BACKENDS`, `NROS_RMW_MAX_NODES`, `NROS_RMW_MESSAGE_INFO_SLOTS` —
+now resolve through the ladder: `RmwKnobs`, `[knobs.rmw]`,
+`BuildRungs::rmw_rungs()`, and one reader in `packages/rmw/cffi/build.rs`. The
+build script keeps its RANGE checks, which belong to the array it carves rather
+than to the ladder.
+
+**`NROS_RMW_SUBSCRIBER_SLOTS` was in this family and is NOT in this tenant.** It
+sits in the same build script, three lines away, and looks identical — but
+phase-412 W1 landed on 2026-09-03 deriving it from the entity inventory
+(`COUNT_SUBSCRIPTION`). A knob two campaigns resolve is exactly the drift issue
+0938 cost, so it stays on env -> Kconfig -> builtin and takes its platform
+answer from the derivation. The census now classes it `derived` and names the
+owner.
+
+That check is the third time it has changed the plan: the zenoh tenant belonged
+to phase-392/403, the buffers to phase-403/408, and now a quarter of the `rmw`
+family to phase-412. **Checking for an owning campaign is not a formality in
+this repo — it has been right more often than the plan was.**
+
+phase-412 also derives two knobs THIS wave already migrated
+(`NROS_EXECUTOR_MAX_NODES`, `NROS_EXECUTOR_ACTION_CLIENTS`). That is not a
+conflict: its precedence is env > Kconfig/board > derived > crate default, so
+the ladder's rungs still win and the derivation fills the builtin slot. Worth
+knowing before someone reads the two docs and assumes one must be wrong.
+
+Backlog after this: **24**, from 28.
 
 ### The `params` tenant — done
 

--- a/packages/boards/nros-board-common/src/platform_config.rs
+++ b/packages/boards/nros-board-common/src/platform_config.rs
@@ -165,6 +165,9 @@ pub struct Knobs {
     /// phase-400 W6 — the parameter-storage tenant.
     #[serde(default)]
     pub params: ParamKnobs,
+    /// phase-400 W6 — the RMW static-pool tenant. See [`RmwKnobs`].
+    #[serde(default)]
+    pub rmw: RmwKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -413,6 +416,27 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.rmw]` RUNGS for this build — platform merged with board,
+    /// board winning — with no env rung and no defaults.
+    ///
+    /// Same shape as [`Self::param_rungs`]: the consuming build script composes
+    /// env -> Kconfig -> these -> its own builtin, and keeps its RANGE checks,
+    /// which are a property of the array it carves and not of the ladder.
+    pub fn rmw_rungs(&self) -> RmwKnobs {
+        let plat = self.tree.platform_rmw_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("rmw", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.rmw.clone())
+            .unwrap_or_default();
+        RmwKnobs {
+            max_backends: b.max_backends.or(plat.max_backends),
+            max_nodes: b.max_nodes.or(plat.max_nodes),
+            message_info_slots: b.message_info_slots.or(plat.message_info_slots),
+        }
+    }
+
     /// The memory tenant for this build, over the full ladder.
     pub fn memory(&self, defaults: &[(&'static str, usize)]) -> Vec<(&'static str, ResolvedUsize)> {
         let plat = self.tree.platform_memory_rungs(&self.platform);
@@ -488,6 +512,42 @@ pub struct ParamKnobs {
     pub max_array_len: Option<usize>,
     #[serde(default)]
     pub max_byte_array_len: Option<usize>,
+}
+
+/// phase-400 W6 — the RMW static-pool tenant.
+///
+/// Three fixed-size arrays the CFFI registry and node table are carved from,
+/// read by `packages/rmw/cffi/build.rs`. They are a PLATFORM fact: an embedded
+/// image links one backend and runs a handful of nodes, a host build links
+/// several and may run many, and until now the only way to say so was an env
+/// var on the shell that happened to run the build.
+///
+/// `NROS_RMW_SUBSCRIBER_SLOTS` is deliberately NOT here. It sits in the same
+/// build script and looks identical, but phase-412 W1 derives it from the
+/// entity inventory (`COUNT_SUBSCRIPTION`), and a knob two campaigns resolve is
+/// the drift issue 0938 cost. Checked before writing this rather than after.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RmwKnobs {
+    #[serde(default)]
+    pub max_backends: Option<usize>,
+    #[serde(default)]
+    pub max_nodes: Option<usize>,
+    #[serde(default)]
+    pub message_info_slots: Option<usize>,
+}
+
+/// Every RMW knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const RMW_KNOBS: &[&str] = &["max_backends", "max_nodes", "message_info_slots"];
+
+/// The env front-end for an RMW knob — the EXISTING names, verbatim.
+pub fn rmw_env_key(knob: &str) -> &'static str {
+    match knob {
+        "max_backends" => "NROS_RMW_MAX_BACKENDS",
+        "max_nodes" => "NROS_RMW_MAX_NODES",
+        "message_info_slots" => "NROS_RMW_MESSAGE_INFO_SLOTS",
+        other => panic!("unknown rmw knob `{other}`"),
+    }
 }
 
 /// Every parameter knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -1279,8 +1339,76 @@ impl PlatformsTree {
 
     /// The `[knobs.params]` rungs, without resolution — for a build script that
     /// owns the defaults and its own env/Kconfig front-end.
+    fn platform_rmw_knobs(&self, name: &str) -> Result<RmwKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = RmwKnobs::default();
+        for file in chain.iter().rev() {
+            let r = &file.knobs.rmw;
+            for (dst, src) in [
+                (&mut out.max_backends, r.max_backends),
+                (&mut out.max_nodes, r.max_nodes),
+                (&mut out.message_info_slots, r.message_info_slots),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.rmw]` rungs for a platform, inherits chain applied.
+    pub fn platform_rmw_rungs(&self, platform: &str) -> Result<RmwKnobs, ConfigError> {
+        self.platform_rmw_knobs(platform)
+    }
+
     pub fn platform_param_rungs(&self, platform: &str) -> Result<ParamKnobs, ConfigError> {
         self.platform_param_knobs(platform)
+    }
+
+    /// phase-400 W6 — resolve the RMW tenant over the RFC-0049 ladder.
+    ///
+    /// Mirrors [`Self::resolve_params`]; the build script keeps its own range
+    /// checks, which belong to the array it carves rather than to the ladder.
+    pub fn resolve_rmw(
+        &self,
+        platform: &str,
+        board: Option<&RmwKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_rmw_knobs(platform)?;
+        let pick = |k: &RmwKnobs, name: &str| match name {
+            "max_backends" => k.max_backends,
+            "max_nodes" => k.max_nodes,
+            "message_info_slots" => k.message_info_slots,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = rmw_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
+        }
+        Ok(out)
     }
 
     /// phase-400 W6 — resolve the parameter tenant over the RFC-0049 ladder.

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -428,6 +428,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -505,6 +505,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -373,6 +373,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -360,6 +360,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -415,6 +415,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -415,6 +415,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -373,6 +373,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -370,6 +370,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -384,6 +384,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -264,6 +264,32 @@ fn explain(args: ExplainArgs) -> Result<()> {
         );
     }
 
+    // phase-400 W6 — the RMW static-pool tenant. Defaults mirror
+    // `packages/rmw/cffi/build.rs`, which stays the authority on them.
+    // `NROS_RMW_SUBSCRIBER_SLOTS` is absent on purpose: phase-412 W1 derives it.
+    let rmw_defaults: &[(&str, usize)] = &[
+        ("max_backends", 8),
+        ("max_nodes", 4),
+        ("message_info_slots", 64),
+    ];
+    for (name, r) in tree
+        .resolve_rmw(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.rmw),
+            &env_get,
+            rmw_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?
+    {
+        println!(
+            "{:<34} {:<10} {}  [{}]",
+            format!("rmw.{name}"),
+            r.value,
+            r.source.as_str(),
+            r.env_key
+        );
+    }
+
     // phase-400 W6 — the parameter-storage tenant. Defaults mirror
     // `nros-params/build.rs`, which stays the authority on them.
     let param_defaults: &[(&str, usize)] = &[

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -472,6 +472,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -504,6 +504,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/rmw/cffi/Cargo.toml
+++ b/packages/rmw/cffi/Cargo.toml
@@ -35,6 +35,12 @@ portable-atomic = { version = "1", default-features = false }
 # an env a Zephyr Rust image never receives. Same helper `nros-node` and
 # `nros-params` use; gated by `check-kconfig-knob-forwarding`.
 nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }
+# phase-400 W6 — the `[knobs.rmw]` platform/board rungs. Build-only, like the
+# helper above; `default-features = false` keeps the board crate's runtime half
+# out of a build script.
+nros-board-common = { path = "../../boards/nros-board-common", features = [
+    "build-helpers",
+], default-features = false }
 # Phase 115.G.4 — compiles the second-language smoke-test stubs in
 # `tests/c_stubs/*.c` into a small static lib that the integration
 # tests link against. Only used during `cargo build`/`cargo test`;

--- a/packages/rmw/cffi/build.rs
+++ b/packages/rmw/cffi/build.rs
@@ -14,10 +14,19 @@
 //!    `nros-rmw-cffi` that vendor it without a C toolchain on the
 //!    build host aren't forced through the cc invocation.
 
+use nros_board_common::platform_config::{BuildRungs, RmwKnobs};
+
 fn main() {
-    emit_max_backends();
+    // phase-400 W6 — the platform/board rungs for `[knobs.rmw]`, resolved once.
+    // `None` when no lane named a platform, which is every out-of-tree consumer
+    // and every plain `cargo build` here; the builtins then stand.
+    let rungs = BuildRungs::from_build_env()
+        .map(|r| r.rmw_rungs())
+        .unwrap_or_default();
+
+    emit_max_backends(&rungs);
     emit_subscriber_slots();
-    emit_message_info_slots();
+    emit_message_info_slots(&rungs);
     maybe_build_c_stub();
 }
 
@@ -34,12 +43,16 @@ fn main() {
 /// an unparseable value as absent and falls through to the default. The RANGE
 /// checks below are kept, since they are the ones that catch a plausible-looking
 /// wrong number.
-fn knob(name: &str, default: usize) -> usize {
-    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), default)
+/// phase-400 W6 — `rung` is the platform/board answer from `[knobs.rmw]`, and
+/// it sits between the Kconfig rung and the crate builtin. Passing it as
+/// `knob_usize`'s default is what places it there: env and `$DOTCONFIG` still
+/// win above it, and the builtin only applies when no descriptor said anything.
+fn knob(name: &str, rung: Option<usize>, default: usize) -> usize {
+    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), rung.unwrap_or(default))
 }
 
-fn emit_max_backends() {
-    let parsed = knob("NROS_RMW_MAX_BACKENDS", 8);
+fn emit_max_backends(rungs: &RmwKnobs) {
+    let parsed = knob("NROS_RMW_MAX_BACKENDS", rungs.max_backends, 8);
 
     if !(1..=64).contains(&parsed) {
         panic!(
@@ -54,7 +67,7 @@ fn emit_max_backends() {
     // Phase 376 W5/B1 — distinct `(name, namespace)` pairs one session hosts.
     // Default 4, matching `nros-node`'s `NROS_EXECUTOR_MAX_NODES`: the shim
     // cannot see more nodes than the executor will register.
-    let nodes = knob("NROS_RMW_MAX_NODES", 4);
+    let nodes = knob("NROS_RMW_MAX_NODES", rungs.max_nodes, 4);
     if !(1..=64).contains(&nodes) {
         panic!(
             "NROS_RMW_MAX_NODES={nodes} out of range [1, 64]. Bump \
@@ -71,7 +84,11 @@ fn emit_max_backends() {
 /// the fifth `create_subscription` returned BAD_ALLOC, which the
 /// executor then surfaced as an opaque `SubscriberCreationFailed`.
 fn emit_subscriber_slots() {
-    let parsed = knob("NROS_RMW_SUBSCRIBER_SLOTS", 8);
+    // NO ladder rung, deliberately: phase-412 W1 derives this from the
+    // entity inventory (`COUNT_SUBSCRIPTION`). Two campaigns resolving one
+    // knob is the drift issue 0938 cost, so this one keeps env -> Kconfig ->
+    // builtin and takes its platform answer from the derivation instead.
+    let parsed = knob("NROS_RMW_SUBSCRIBER_SLOTS", None, 8);
 
     if !(1..=128).contains(&parsed) {
         panic!(
@@ -91,8 +108,8 @@ fn emit_subscriber_slots() {
 /// never used: measured 3,136 bytes of live BTCM on the Orin SPE at 4
 /// subscribers. The table is keyed by backend handle, so the useful bound is
 /// the session's subscription count, not a fixed 64.
-fn emit_message_info_slots() {
-    let parsed = knob("NROS_RMW_MESSAGE_INFO_SLOTS", 64);
+fn emit_message_info_slots(rungs: &RmwKnobs) {
+    let parsed = knob("NROS_RMW_MESSAGE_INFO_SLOTS", rungs.message_info_slots, 64);
 
     if !(1..=256).contains(&parsed) {
         panic!(

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -423,6 +423,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -365,6 +365,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -376,6 +376,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -346,6 +346,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -346,6 +346,7 @@ name = "nros-rmw-cffi"
 version = "0.5.0"
 dependencies = [
  "cc",
+ "nros-board-common",
  "nros-cc-flags",
  "nros-log",
  "nros-rmw",

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -71,6 +71,13 @@ OWNERS: dict[str, str] = {
     "NROS_MAX_STRING_VALUE_LEN": "packages/core/nros-params/build.rs",
     "NROS_MAX_ARRAY_LEN": "packages/core/nros-params/build.rs",
     "NROS_MAX_BYTE_ARRAY_LEN": "packages/core/nros-params/build.rs",
+    # The RMW static-pool tenant (phase-400 W6). `NROS_RMW_SUBSCRIBER_SLOTS`
+    # is NOT here: it lives in the same build script and looks identical, but
+    # phase-412 W1 derives it from the entity inventory, so the census classes
+    # it `derived` and this gate leaves it alone.
+    "NROS_RMW_MAX_BACKENDS": "packages/rmw/cffi/build.rs",
+    "NROS_RMW_MAX_NODES": "packages/rmw/cffi/build.rs",
+    "NROS_RMW_MESSAGE_INFO_SLOTS": "packages/rmw/cffi/build.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 20
+LADDER_FLOOR = 23
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -183,10 +183,15 @@ KNOB_CLASS = {
     # overflow; the dependency-weight audit names the RMW cap as a knob cmake
     # never resolves). Both are arguments FOR a board rung, the same shape the
     # ASI consumer's `NROS_MAX_PARAMETERS=256` had.
-    "NROS_RMW_MAX_BACKENDS": ("sizing", "static pool; candidate rmw tenant"),
-    "NROS_RMW_MAX_NODES": ("sizing", "static pool; candidate rmw tenant"),
-    "NROS_RMW_SUBSCRIBER_SLOTS": ("sizing", "static pool; candidate rmw tenant"),
-    "NROS_RMW_MESSAGE_INFO_SLOTS": ("sizing", "static pool; candidate rmw tenant"),
+    # A RUNTIME trace toggle, not a build-time size — presence-tested with
+    # `var_os` in `cffi/src/lib.rs`, never parsed. It became visible to this
+    # census only when `nros-rmw-cffi` gained a `build-helpers` dependency and
+    # its sources entered the scan; it configures nothing about the image.
+    "NROS_RMW_TRACE_OPEN": ("infra", "runtime trace toggle, not a size"),
+    "NROS_RMW_MAX_BACKENDS": ("ladder", "rmw tenant"),
+    "NROS_RMW_MAX_NODES": ("ladder", "rmw tenant"),
+    "NROS_RMW_SUBSCRIBER_SLOTS": ("derived", "phase-412 W1 — COUNT_SUBSCRIPTION"),
+    "NROS_RMW_MESSAGE_INFO_SLOTS": ("ladder", "rmw tenant"),
     "NROS_SMOLTCP_MAX_SOCKETS": ("sizing", "driver pool; candidate net tenant"),
     "NROS_SMOLTCP_MAX_UDP_SOCKETS": ("sizing", "driver pool; candidate net tenant"),
     "NROS_SMOLTCP_BUFFER_SIZE": ("sizing", "driver buffer; candidate net tenant"),
@@ -246,6 +251,7 @@ def ladder_knobs():
         "TransportKnobs",
         "MemoryKnobs",
         "ParamKnobs",
+        "RmwKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:


### PR DESCRIPTION
Three static pools the CFFI registry and node table are carved from — `NROS_RMW_MAX_BACKENDS`, `NROS_RMW_MAX_NODES`, `NROS_RMW_MESSAGE_INFO_SLOTS` — now resolve through the RFC-0049 ladder: `RmwKnobs`, `[knobs.rmw]`, `BuildRungs::rmw_rungs()`, and **one** reader in `packages/rmw/cffi/build.rs` composing env → Kconfig → rung → builtin.

The build script keeps its **range checks**: those belong to the array it carves, not to the ladder.

## The fourth one isn't mine

`NROS_RMW_SUBSCRIBER_SLOTS` was in the family I proposed. It sits in the same build script *three lines away* and looks identical — but **phase-412 W1 landed the same day**, deriving it from the entity inventory (`COUNT_SUBSCRIPTION`). A knob two campaigns resolve is the drift issue 0938 cost, so it keeps env → Kconfig → builtin and takes its platform answer from the derivation. The census classes it `derived` and names the owner; the build script says so where the rung would have gone.

**That check has now changed the plan three times** — zenoh belonged to phase-392/403, the buffers to phase-403/408, and a quarter of this family to phase-412. It has been right more often than the plan was.

phase-412 also derives two knobs this wave already migrated (`NROS_EXECUTOR_MAX_NODES`, `NROS_EXECUTOR_ACTION_CLIENTS`). **Not a conflict** — its precedence is env > Kconfig/board > derived > crate default, so the ladder's rungs win and the derivation fills the builtin slot. Recorded so nobody reads the two docs and assumes one must be wrong.

## Verified through the build script's own output

Not by reading code — that is the mistake that shipped a no-op "fix" twice this week:

```
builtin        MAX_BACKENDS=8  MAX_NODES=4  MESSAGE_INFO_SLOTS=64
platform rung  MAX_BACKENDS=3  MAX_NODES=2  MESSAGE_INFO_SLOTS=8
env wins       MAX_BACKENDS=7  MAX_NODES=2  MESSAGE_INFO_SLOTS=8
```

`nros config explain` prints the tenant beside the others, and an env override shows as `env`.

## Census

| | before | after |
| --- | ---: | ---: |
| sizing backlog (W6) | 28 | **24** |
| on the ladder | 19 | 22 |
| another campaign deriving | 14 | 15 |

`NROS_RMW_TRACE_OPEN` became visible when this crate gained a `build-helpers` dep; classed `infra` — a runtime `var_os` presence test, not a size.

17 leaf locks refreshed for the new build-dep edge; diff reviewed — `+ "nros-board-common",` and nothing else.

## Verification

- `just check fast` — 188/188
- `just ci l1` — passed
- `just check knob-single-reader` — 22 migrated, one reader each