### PR TITLE
docs(#0976): correct a cross-reference that outlived its own claim

### DIFF
--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -270,7 +270,7 @@ correcting them.
 
 ## Not to be confused with
 
-**#0970** (`archived/0970-cyclone-rmw-should-own-its-sertype.md`, RESOLVED 2026-09-03 — not
-linked because it has not landed on `main` yet) — the sertype migration
-itself, whose message half has landed. This is the reason its service half has
-not.
+[**#0970**](archived/0970-cyclone-rmw-should-own-its-sertype.md) — the sertype
+migration itself. RESOLVED 2026-09-03: this issue's witnesses are what unblocked
+its service half, and that half then removed the three receive-side adapters
+listed at the top of this issue. Both halves are on `main`.


### PR DESCRIPTION
0976's closing note said #0970 was *"not linked because it has not landed on main yet"* and that *"its service half has not"* landed. Both are now false — the service half landed 2026-09-03, and **0976's own witnesses are what unblocked it**.

The line mattered because it stated the dependency backwards for anyone reading 0976 for what to do next: it presented 0970 as blocked, when 0976 had already unblocked it and 0970 had then removed the three receive-side adapters this issue lists at the top.

Docs only. `check-doc-refs` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa