### PR TITLE
measure(#0969): the service path's allocation count did NOT move — and that corrects me

### DIFF
--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -346,3 +346,69 @@ a regression is the shape this repo keeps retracting.
    (`tests/data_roundtrip.cpp`, `NROS_ROUNDTRIP_ITERS`) — the message path went
    9.93 → 2.00 allocations/message and this path still carries three sites, one
    per request and two per reply.
+
+## The allocation measurement, done 2026-09-03 — and it is a NULL RESULT
+
+Step 3 of the order above said "re-run the allocation harness". Done, both ways,
+and the answer corrects something I wrote when the migration landed.
+
+`service_roundtrip.cpp` and the `ros2_srv_{client,server}` pair gained
+`NROS_ROUNDTRIP_ITERS`, the same knob and the same slope method
+`data_roundtrip.cpp` uses — deliberately the same, because a service number
+measured a different way would not be comparable to the message path's
+9.93 -> 2.00.
+
+**Single process (client and server in one, the loopback case):**
+
+| | iters=1 | iters=200 | per exchange |
+| --- | ---: | ---: | ---: |
+| before the migration | 1,200 | 1,996 | **4.00** |
+| after | 1,178 | 1,974 | **4.00** |
+
+**Two processes (the case a control loop actually runs), CLIENT half only:**
+
+| | iters=1 | iters=200 | per exchange |
+| --- | ---: | ---: | ---: |
+| before | 1,445 | 2,269 | **4.14** |
+| after | 1,429 | 2,255 | **4.15** |
+
+**The migration did not change measured per-exchange allocations.** Not in
+loopback, not across processes.
+
+### What that corrects
+
+The commit that landed the sertype migration said "per-message allocation is
+otherwise off the service and action data path". That is NOT supported. What was
+measured then was `check-rmw-alloc-sites` going 2 -> 1 — a count of SOURCE
+SITES, not of runtime allocations. Letting a static ledger stand in for a runtime
+number is the substitution this campaign catches elsewhere, and it happened here.
+
+What the migration did do, and these still hold:
+
+* removed a decode and an encode per message on the service path (structural,
+  visible in the source);
+* removed one steady-state allocation SITE, gated;
+* removed five per-type adapters that existed only to work around the round trip.
+
+What it did not do is reduce the allocation COUNT.
+
+### The loopback harness under-reports, which is worth keeping
+
+The two-process CLIENT HALF ALONE costs 4.15, while the single-process run
+measuring BOTH halves costs 4.00. So a same-process harness prices roughly half
+of what a deployment pays — Cyclone can hand a sample to a local reader by
+reference, and the write path may never fully serialise. Any future service or
+action number should come from the two-process pair.
+
+Note the message path's 9.93 -> 2.00 was itself a single-process measurement, so
+it carries the same caveat about absolute value. It is still good evidence that
+the METHOD detects real change: the same harness style that moved by 7.93 there
+moves by 0.01 here, so this null result is not the instrument failing to see.
+
+### Not explained
+
+4.00-4.15 per exchange is fewer than the old path's sites predict (a typed sample
+and an ostream on each of request and reply, plus serdata). Something is either
+absorbing those or they are not on the measured path. Recorded as an open
+question rather than guessed at — the number is what it is, and the explanation
+is a separate piece of work.

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -448,3 +448,58 @@ So the honest statement is narrower than either "no saving" or "a saving":
 sequence long enough to force ostream growth. That is where a service-path number
 comparable to 9.93 -> 2.00 would come from, and this harness's payload cannot
 produce one.
+
+## The size sweep — the migration is a CROSSOVER at ~8 KB, measured 2026-09-03
+
+Allocation COUNT is neutral at every size (4.14 -> 4.15 at 12 B, 4.20 -> 4.26 at
+16 KB), so counting allocations was the wrong instrument. BYTES is where the
+behaviour lives. Client half, two-process, bytes allocated per exchange:
+
+| reply payload | before | after | delta |
+| ---: | ---: | ---: | ---: |
+| 16 B | 8,329 | 270 | **-8,059** |
+| 104 B | 8,329 | 276 | -8,054 |
+| 488 B | 8,428 | 844 | -7,584 |
+| 1,008 B | 8,347 | 1,186 | -7,161 |
+| 2,008 B | 8,350 | 2,260 | -6,089 |
+| 4,008 B | 8,354 | 4,342 | -4,011 |
+| **8,008 B** | 8,325 | 8,219 | **-106** |
+| 16,008 B | 8,444 | 16,260 | **+7,816** |
+
+**The old path is FLAT — ~8,350 bytes per exchange whatever the payload, from
+16 bytes to 16 KB.** It pays a fixed cost for a typed sample plus a re-encode
+buffer, and a one-field reply costs the same as a 2,000-element sequence.
+
+**The new path is LINEAR — about 1.02x the payload, on a ~260-byte floor.** The
+sample IS the bytes, so what it allocates is what the message weighs.
+
+So the migration is neither a win nor a regression; it is a change of SHAPE, and
+the two curves cross at roughly **8 KB of reply payload**:
+
+* below it, the saving is large and grows as the message shrinks — **30x fewer
+  bytes** on a small reply, which is the regime a control loop actually runs in;
+* above it, the new path allocates more, and the gap widens linearly.
+
+### Why this matters beyond a number
+
+Flat-versus-linear is the more useful half. A fixed ~8.4 KB per exchange is easy
+to bound and impossible to shrink; a payload-proportional cost is the opposite.
+For [phase 391](../roadmap/phase-391-allocation-unification-and-tier-model.md)'s
+Robson bound the linear one is the better shape — it is derivable from the type's
+own `MAX_SERIALIZED_SIZE`, which is exactly what issue 0896 makes available —
+whereas the old constant was a number nobody could attribute.
+
+But a service whose replies routinely exceed 8 KB now allocates MORE, and nothing
+warns about it. That is worth knowing before someone quotes the round-trip
+removal as an unconditional improvement, which is what the migration commit did
+and what this measurement corrects.
+
+### Method and limits
+
+`NROS_PROBE_SEQ_LEN` was a SCRATCH change (an `int64[] sums` reply on
+`AddTwoInts`) used to sweep payload size, and it is reverted — the committed
+harness keeps only `NROS_ROUNDTRIP_ITERS`. Two points per size (n=1, n=50), slope
+over 49 exchanges, client half only. The server half and the CPU cost of the
+removed decode/encode are not measured. The 8 KB crossover is where these two
+curves meet on THIS type and this transport; treat it as an order of magnitude,
+not a threshold to encode.

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -503,3 +503,49 @@ over 49 exchanges, client half only. The server half and the CPU cost of the
 removed decode/encode are not measured. The 8 KB crossover is where these two
 curves meet on THIS type and this transport; treat it as an order of magnitude,
 not a threshold to encode.
+
+## The SERVER half, and the whole exchange — measured 2026-09-03
+
+The sweep above was the client. The server, same method (valgrind on the server
+process, client untraced), bytes allocated per exchange:
+
+| reply payload | SERVER before | after | delta | CLIENT before | after | delta |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 16 B | 4,328 | 299 | -4,030 | 8,329 | 270 | -8,059 |
+| 1,008 B | 4,223 | 1,299 | -2,924 | 8,347 | 1,186 | -7,161 |
+| 8,008 B | 4,307 | 8,284 | **+3,977** | 8,325 | 8,219 | -106 |
+| 16,008 B | 4,232 | 16,282 | +12,051 | 8,444 | 16,260 | +7,816 |
+
+**The server's old cost is flat too, but at HALF the client's** — ~4,270 versus
+~8,350 bytes per exchange. Both are payload-independent; they differ by a factor
+of two, which is what the two directions cost asymmetrically in the old typed
+path. The new cost is the same on both sides, ~1.02x payload, because both now
+allocate exactly the message.
+
+**Combined, per exchange:**
+
+| reply | before | after | delta |
+| ---: | ---: | ---: | ---: |
+| 16 B | 12,657 | 569 | **-12,089** |
+| 1,008 B | 12,570 | 2,485 | -10,085 |
+| 8,008 B | 12,632 | 16,503 | +3,871 |
+| 16,008 B | 12,676 | 32,542 | +19,867 |
+
+**So the WHOLE-EXCHANGE crossover is ~6 KB of reply, not the ~8 KB the client
+half alone suggested.** Measuring one side and doubling would have put it in the
+wrong place: the server's flat cost is half the client's, so the combined old
+curve sits at ~12,635 rather than ~16,700.
+
+Corrected summary of the migration, both halves, whole exchange:
+
+* **a 22x reduction** on a small reply (12,657 -> 569 bytes);
+* break-even at **~6 KB**;
+* **2.6x more** at 16 KB, growing linearly beyond it.
+
+The shape argument stands and is stronger with both halves: flat-and-unattributable
+becomes linear-and-derivable, on both sides, from the same
+`MAX_SERIALIZED_SIZE` issue 0896 exposes.
+
+Limits unchanged: two points per size, one type, one transport, allocation BYTES
+only — the CPU cost of the removed decode/encode is still unmeasured, and it is
+the half that does not cross over.

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -405,10 +405,46 @@ it carries the same caveat about absolute value. It is still good evidence that
 the METHOD detects real change: the same harness style that moved by 7.93 there
 moves by 0.01 here, so this null result is not the instrument failing to see.
 
-### Not explained
+### EXPLAINED, by DHAT — the harness payload is too small to show the defect
 
-4.00-4.15 per exchange is fewer than the old path's sites predict (a typed sample
-and an ostream on each of request and reply, plus serdata). Something is either
-absorbing those or they are not on the measured path. Recorded as an open
-question rather than guessed at — the number is what it is, and the explanation
-is a separate piece of work.
+`valgrind --tool=dhat` at both counts, differenced, attributes every growing
+allocation:
+
+| allocation | before | after |
+| --- | ---: | ---: |
+| our typed sample, write path (`maybe_flush_request`) | 1.01 | — |
+| our typed sample, take path (`take_typed_wire`) | 1.01 | — |
+| our serdata x2 (`serdata_from_sample` / `serdata_from_ser`) | — | 2.02 |
+| Cyclone `ddsrt_malloc` payload x2 | 1.99 | 2.02 |
+| **total** | **4.01** | **4.15** |
+
+**The migration SUBSTITUTED allocations rather than removing them.** Before, we
+allocated a typed sample per direction and Cyclone allocated the serdata; after,
+we allocate the serdata and there is no typed sample. One for one.
+
+**And the count was never going to move on THIS payload.** The prediction that
+the old path cost more assumed the `dds_ostream_t` allocated separately from the
+typed sample. It does not, for a small message: `dds_ostream_init(&os, 0, ...)`
+starts empty and the first write allocates once — for a 12-byte `AddTwoInts`
+reply it never reallocs, so the entire re-encode costs ONE allocation, the same
+one the new path spends on a serdata.
+
+That is what this issue already recorded about the message path, read from the
+other end: **9.93 was NON-INTEGRAL because the ostream grew by realloc, so its
+allocation count depended on the sample.** A 12-byte reply produces no growth, so
+it produces no delta. The harness exchanges `req[20]` and `reply[12]`, sizes
+chosen for an interop assertion rather than for this measurement.
+
+So the honest statement is narrower than either "no saving" or "a saving":
+
+* on a SMALL fixed-size type the migration is allocation-neutral (measured);
+* the saving the round-trip removal buys lives in the REALLOC TAIL, which appears
+  only once a payload outgrows the ostream's first block — the regime where the
+  message path measured 9.93 and where the count stops being an integer;
+* what it removes unconditionally is a decode and an encode of CPU work, plus the
+  per-type adapters. Those hold at any payload size.
+
+**Next measurement**: the same slope with a large, variable-length reply — a
+sequence long enough to force ostream growth. That is where a service-path number
+comparable to 9.93 -> 2.00 would come from, and this harness's payload cannot
+produce one.

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_srv_client.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_srv_client.cpp
@@ -117,7 +117,30 @@ int main() {
     put_le64(req + 12, 31);
     uint8_t rep[64] = {};
     size_t n = 0;
-    rmw_ret_t call_rc = call_blocking(&cli, req, sizeof(req), rep, sizeof(rep), &n);
+
+    // Issue 0969 — `NROS_ROUNDTRIP_ITERS` repeats the CALL so the client half of
+    // the service data path can be priced by slope, the same method and the same
+    // variable name `data_roundtrip.cpp` uses.
+    //
+    // Why here and not only in `service_roundtrip.cpp`: that harness puts client
+    // and server in ONE process, so Cyclone can hand the sample to the local
+    // reader by reference and the write path may never serialise. A number
+    // measured there can therefore under-report what a real deployment pays.
+    // This binary talks to a SEPARATE server process, which is the case a
+    // control loop actually runs.
+    //
+    // Default 1, so the interop test this binary exists for is unchanged.
+    long iters = 1;
+    if (const char *e = std::getenv("NROS_ROUNDTRIP_ITERS")) {
+        const long parsed = std::strtol(e, nullptr, 10);
+        if (parsed > 0) iters = parsed;
+    }
+    rmw_ret_t call_rc = NROS_RMW_RET_OK;
+    for (long it = 0; it < iters; ++it) {
+        n = 0;
+        call_rc = call_blocking(&cli, req, sizeof(req), rep, sizeof(rep), &n);
+        if (call_rc != NROS_RMW_RET_OK || n == 0) break;
+    }
     if (call_rc != NROS_RMW_RET_OK || n == 0) {
         std::fprintf(stderr, "call_blocking failed rc=%d len=%zu\n", (int) call_rc, n);
         g_vt->destroy_client(&cli);

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_srv_server.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/ros2_srv_server.cpp
@@ -73,7 +73,14 @@ int main() {
     }
 
     const auto deadline = std::chrono::steady_clock::now() +
-                          std::chrono::seconds(30);
+                          std::chrono::seconds(600);
+    long iters = 1;
+    if (const char *e = std::getenv("NROS_ROUNDTRIP_ITERS")) {
+        const long parsed = std::strtol(e, nullptr, 10);
+        if (parsed > 0) iters = parsed;
+    }
+    long served = 0;
+
     while (std::chrono::steady_clock::now() < deadline) {
         bool has_r = false;
         /* Phase 376 W3.d step A — flag out, status returned. */
@@ -100,9 +107,16 @@ int main() {
                             static_cast<long long>(b),
                             static_cast<long long>(a + b));
                 std::fflush(stdout);
-                g_vt->destroy_service(&srv);
-                (void) g_vt->destroy_session(&s);
-                return 0;
+                // Issue 0969 — serve `NROS_ROUNDTRIP_ITERS` requests, not one,
+                // so a client measuring its data path by slope has a peer for
+                // every iteration. Default 1 keeps the interop test's meaning:
+                // one call, one reply, exit.
+                if (++served >= iters) {
+                    g_vt->destroy_service(&srv);
+                    (void) g_vt->destroy_session(&s);
+                    return 0;
+                }
+                continue;
             }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(20));


### PR DESCRIPTION
0969's own order ended *"re-run the allocation harness"*. Done, two ways, and the
answer is a **null result** that corrects the commit which landed the migration.

`service_roundtrip.cpp` and the `ros2_srv_{client,server}` pair gain
`NROS_ROUNDTRIP_ITERS` — the same knob and slope method `data_roundtrip.cpp`
uses, deliberately, so the number compares to the message path's 9.93 → 2.00.

## Measured

| configuration | before | after |
| --- | ---: | ---: |
| single process (loopback), per exchange | **4.00** | **4.00** |
| two processes, **client half only** | **4.14** | **4.15** |

**The migration did not change per-exchange allocations.** Not in loopback, not
across processes.

## What this corrects

The sertype-migration commit said *"per-message allocation is otherwise off the
service and action data path"*. **Not supported.** What I measured then was
`check-rmw-alloc-sites` going 2 → 1 — a count of **source sites**, not runtime
allocations. I let a static ledger stand for a runtime number, which is exactly
the substitution this campaign catches elsewhere.

What the migration *did* do still holds: a decode and an encode removed per
message, one steady-state site removed, five per-type adapters deleted. What it
did not do is reduce the allocation **count** — and the issue now says so.

## The more useful finding: the loopback harness under-reports

The two-process **client half alone** costs 4.15, while the single-process run
measuring **both halves** costs 4.00. A same-process harness prices roughly half
of what a deployment pays — Cyclone is free to hand a sample to a local reader by
reference, so the write path may never fully serialise.

Future service/action numbers should come from the two-process pair. The message
path's 9.93 → 2.00 was itself single-process and carries the same caveat on
absolute value.

**The null is not the instrument failing to see:** the same method moved by 7.93
on the message path and by 0.01 here.

## Not explained

4.00–4.15 is *fewer* allocations than the old path's sites predict (typed sample
+ ostream on each of request and reply, plus serdata). Something absorbs them, or
they are not on the measured path. Recorded as an open question rather than
guessed at.

## Scope

Defaults are 1 everywhere, so `ros2_srv_e2e` and `service_roundtrip` keep their
meaning; the server's deadline widened to cover an iterated run under valgrind.

Backend ctest **23/23**, `just check fast` **188 gates**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa