### PR TITLE
fix(sdk): esp32-qemu declares its real runtime sonames; files the configure gap

### DIFF
--- a/docs/issues/1006-esp32-qemu-configure-nondeterministic-deps.md
+++ b/docs/issues/1006-esp32-qemu-configure-nondeterministic-deps.md
@@ -1,0 +1,72 @@
+---
+id: 1006
+title: "esp32-qemu's configure does not disable the backends it never uses, so its
+  runtime dependency set is a property of the machine that built it"
+status: open
+type: bug
+area: tooling, build
+related: [0926, 0500]
+---
+
+`[tool.esp32-qemu]` is **source-built with no dist** — every user runs the
+recipe. Its `configure` disables gtk, vnc, sdl and docs, and says nothing about
+audio, curl or tools. qemu's configure AUTO-DETECTS those, so the binary links
+whatever backends the build host happened to have dev headers for.
+
+`check-dist-runtime-deps` against a source build of this recipe found **69
+sonames no `[prereq.*]` declares**, essentially all of them backends the
+emulator never uses:
+
+    audio   libasound, libpulse, libpulsecommon, libFLAC, libvorbis,
+            libvorbisenc, libsndfile, libsndio, libasyncns, libogg
+    X11     libX11, libX11-xcb, libxcb, libXau, libXdmcp, libxkbcommon
+    net/misc libcurl, libssh, librtmp, libsasl2, libpsl, libsystemd,
+            libudev, libusb-1.0, libdbus-1, libapparmor, …
+
+Compare the control, same upstream project, same index:
+
+| tool | configure disables | `system = [..]` |
+| --- | --- | ---: |
+| `qemu` | gtk, vnc, sdl, spice, docs, tools | 2 |
+| `esp32-qemu` | gtk, vnc, sdl, docs | 3 (now 8) |
+
+## Why this is not "declare the 69"
+
+The set is not a property of the recipe. It is a property of the machine that
+ran it: a lean container yields a short list, a developer desktop with ALSA,
+PulseAudio and X11 headers yields this one. Writing those 69 into the index
+would record one host's accident as though it were the recipe's contract, and
+the next builder on a different host would fail the same gate with a different
+list.
+
+The five entries added alongside this issue are the opposite case and are
+therefore safe: zlib, pcre2, selinux, tinfo and openssl are reached through
+glib and qemu's block layer on any build, so they belong in `system = [..]`
+whatever the host.
+
+## The fix, and why it is not done here
+
+Pin the link surface in `configure` — `--audio-drv-list=` (empty), plus the
+`--disable-*` this recipe is missing relative to `[tool.qemu.source]` — so the
+dependency set is decided by the recipe rather than the host. Then declare what
+remains, which should be close to qemu's two.
+
+Not done in this commit because it needs a REBUILD to verify, and a wrong flag
+breaks the esp32 lane rather than failing loudly:
+
+* `--enable-gcrypt` and `--enable-slirp` are deliberate (secure-boot crypto and
+  user-mode networking) and must survive.
+* `--target-list=riscv32-softmmu` is the whole point of the fork.
+* Whether upstream's esp-develop branch accepts every flag `[tool.qemu.source]`
+  passes is unverified — the fork is pinned at an older base, which is also why
+  it carries `--disable-werror` (see the comment above `configure`).
+
+## How to verify a fix
+
+Rebuild via `nros setup --tool esp32-qemu` and re-run
+`python3 scripts/check-dist-runtime-deps.py`. The gate needs a provisioned
+store, is in no registry, and SKIPS loudly without one — so it is only
+observable on a host that has actually built this tool. That is why the gap sat
+unnoticed: CI never provisions esp32-qemu (it is nightly-only), and a developer
+who has built it sees a 75-line failure that looks like index rot rather than a
+configure problem.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -77,6 +77,7 @@ fails if this block drifts.
 - **#1000** ([rmw, third-party]) — Vendored Cyclone: `handle_xevk_spdp`'s early returns orphan the PERIODIC spdp event — it leaves the heap, is never re-armed, and the participant goes silent forever See `1000-*`.
 - **#1001** (tooling, ci) — `check-action-client-arena-budget` walks the whole repo, so `check fast` costs minutes on a cold page cache — the pre-push gate is where that is felt See `1001-*`.
 - **#1005** (testing, build) — A zenoh constant that lives in `nros-zpico-build` is invisible to the fixture staleness probe, so a fixture baked before a fix reports FRESH See `1005-*`.
+- **#1006** (tooling, build) — esp32-qemu's configure does not disable the backends it never uses, so its runtime dependency set is a property of the machine that built it See `1006-*`.
 - **#1007** (testing, build) — `just nuttx build-fixtures-arm` can leave every arm cell unrunnable, and the remedy it prints is the command that just short-circuited See `1007-*`.
 - **#1009** (testing, ci) — Our DDS interop tests share a bus with the whole LAN, so a foreign peer on another host can fail them — and `ROS_LOCALHOST_ONLY=1` alone does NOT fix it See `1009-*`.
 - **#1013** (testing) — `test_rtos_pubsub_e2e` SIGKILLs its talker after ~12 publishes, so the cell exercises twelve seconds of a free-running publisher See `1013-*`.

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -374,10 +374,27 @@ install = "cmake --build build --parallel $(nproc) --target install"
 # only (not hosted) — `just esp32 setup` → `nros setup --tool esp32-qemu`.
 [tool.esp32-qemu]
 version = "esp-develop-nros1"
-# Source-built (no dist): these are BUILD deps of qemu's meson configure —
-# found undeclared when the configure died on glib-2.0 (phase-327 W4 applied
-# to source recipes; probed BEFORE the build so the failure names packages).
-system = ["libglib2-dev", "libpixman-dev", "libgcrypt-dev"]
+# Source-built (no dist): the first three are BUILD deps of qemu's meson
+# configure — found undeclared when the configure died on glib-2.0 (phase-327 W4
+# applied to source recipes; probed BEFORE the build so the failure names
+# packages).
+#
+# The rest are RUNTIME sonames the built binary links unconditionally, found by
+# `check-dist-runtime-deps` against a source build of this very recipe. Each was
+# already a `[prereq.*]` key; only this list was missing them, which is the
+# hand-authored half issue 0926 named. They are core (zlib, pcre2, selinux,
+# tinfo, openssl via glib and qemu's block layer), not optional backends, so
+# they hold for any build of this recipe on any host.
+system = [
+    "libglib2-dev",
+    "libpixman-dev",
+    "libgcrypt-dev",
+    "libssl3",
+    "libpcre2",
+    "libselinux1",
+    "libtinfo6",
+    "libz1",
+]
 upstream = "esp-develop"
 [tool.esp32-qemu.source]
 git = "https://github.com/espressif/qemu"


### PR DESCRIPTION
Work on the maintainer-ordered list: **complete the sys dep index**. Two commits.

## First, the correction that matters

Items 1 and 2 of that list — "finish the package.xml dep SSoT" and "complete the rosdep-like resolver" — **are already done**, and my phase-413 W6 framing of them as design work was wrong.

- **RFC-0062 is Stable**, and its 2026-08-29 amendment settles every question I listed as open: `[prereq.*]` is the user-facing namespace across four providers, the index owns the mapping, and **rosdep is deliberately not consulted** (it answers for one provider of four, cannot carry a `check` probe, and a host-dependent resolver is exactly the drift the RFC deletes) — while keeping rosdep KEY NAMES so porting a list stays mechanical.
- **phase-398 is COMPLETE and archived.** The ladder is live in `cmd/build.rs check_declared_depends`: workspace package → generated message crate → `[prereq.*]` key → ROS/ament → **error**, failing by default, with `NROS_ALLOW_UNRESOLVED_DEPS=1` as a named escape hatch. Its first run over the tree found three stale `<exec_depend>` entries in workspaces that built green.

## What was actually incomplete

`check-dist-runtime-deps` reports six sonames `[tool.esp32-qemu] system = [..]` did not name, each already a `[prereq.*]` key: `libcrypto`/`libssl` → `libssl3`, `libpcre2-8` → `libpcre2`, `libselinux` → `libselinux1`, `libtinfo` → `libtinfo6`, `libz` → `libz1`. That is the hand-authored half issue 0926 named. **Now 0 of that kind.**

These five are safe to declare because they are core — zlib, pcre2, selinux, tinfo and openssl reached through glib and qemu block layer on any build.

## What I did NOT declare, and why (issue 1006)

The other **69 sonames** are audio and X11 backends the emulator never uses. esp32-qemu is source-built with no dist, and its configure disables gtk/vnc/sdl/docs but says nothing about audio, curl or tools — so qemu auto-detects whatever dev headers the build host has.

| tool | configure disables | system |
| --- | --- | ---: |
| `qemu` | gtk, vnc, sdl, spice, docs, tools | 2 |
| `esp32-qemu` | gtk, vnc, sdl, docs | 3 → 8 |

So the set is a property of the machine that ran the recipe, not of the recipe. Declaring the 69 would write one hosts accident into the index, and the next builder would fail the same gate with a different list. The fix is to pin the link surface in `configure` — which needs a rebuild to verify, must keep `--enable-gcrypt` / `--enable-slirp` / `--target-list=riscv32-softmmu`, and is unverified against the older pinned esp-develop base (the recipe already carries `--disable-werror` for that reason). Filed rather than guessed.

## Why nobody saw it

The gate is in no registry, needs a provisioned store, and skips loudly without one — so only a host that has actually built esp32-qemu observes it, and CI never provisions it (nightly-only).

Index validated; `nros setup --system --check` unchanged at 38 present / 5 missing / 3 unprobed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)