### PR TITLE
ci(phase-413 W3): the index is the SSoT for OS packages, and a gate keeps it so

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,10 +55,21 @@ jobs:
           curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.17.0/mdbook-mermaid-v0.17.0-x86_64-unknown-linux-gnu.tar.gz \
             | tar xz -C /usr/local/bin
 
-      - name: Install Doxygen + Graphviz
+      # The INDEX names these, not this file — phase-413 W3. `[prereq.doxygen]`
+      # and `[prereq.graphviz]` already carry the apt/dnf/pacman/brew spellings
+      # and a presence probe; repeating `doxygen graphviz` here made this the
+      # second place that fact lived, and the one nobody updates.
+      #
+      # `nros setup --system` is the user-facing verb and stays so. It is not
+      # used HERE because this job builds no CLI, and making a docs deploy
+      # compile one to learn that `doxygen` is spelled `doxygen` costs minutes
+      # to answer what the index answers in milliseconds. The script reads the
+      # same file the CLI reads.
+      - name: Install Doxygen + Graphviz (from the index)
         run: |
           sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
+          sudo apt-get install -y \
+            $(python3 scripts/sdk/prereq-packages.py --manager apt doxygen graphviz)
 
       - name: Install Rust toolchain
         # tools/rust-toolchain.toml pins the workspace channel; reuse it so

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -805,7 +805,15 @@ jobs:
       - name: Add ROS 2 apt repo
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl gnupg lsb-release
+          # `curl` dropped: it is preinstalled on the GitHub runner AND
+          # declared by `[prereq.curl]`, so naming it here was the index's fact
+          # restated in a second place (phase-413 W3). `gnupg` and
+          # `lsb-release` stay literal on purpose — they exist only to ADD the
+          # third-party ROS apt source below, and RFC-0062's providers are
+          # system / sdk / source / submodule, none of which can express "add
+          # this apt repository first". Indexing them would claim the index
+          # provisions something it cannot.
+          sudo apt-get install -y gnupg lsb-release
           sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu jammy main" \
             | sudo tee /etc/apt/sources.list.d/ros2.list >/dev/null

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -586,7 +586,8 @@ jobs:
         if: startsWith(matrix.example, 'rust/')
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends clang libclang-dev
+          apt-get install -y --no-install-recommends \
+            $(python3 scripts/sdk/prereq-packages.py --manager apt clang libclang-dev)
 
       - name: Build zephyr/${{ matrix.example }} (zenoh) on ${{ matrix.line }}
         run: |

--- a/just/check.just
+++ b/just/check.just
@@ -989,9 +989,16 @@ config-knob-census:
 
 # The reverse of `check-sysdep-remedies` — phase-413 W3.
 #
-# That gate refuses a hand-written `sudo apt` in a `just` recipe, and
-# `[prereq.doxygen]`'s own `why` reads "found undeclared by
-# check-sysdep-remedies". Nothing guarded the other direction: a WORKFLOW may
+# That gate refuses a hand-written native install command in a `just` recipe,
+# and `[prereq.doxygen]`'s own `why` reads "found undeclared by
+# check-sysdep-remedies".
+#
+# DESCRIBED, not quoted — `check-sysdep-remedies` is a text scan and cannot tell
+# a command from a sentence about one, so a comment naming the forbidden
+# spelling fails it. `provision-zenohd`'s comment says exactly this and takes
+# exactly this way out; writing that phrase here anyway cost this PR a red.
+#
+# Nothing guarded the other direction: a WORKFLOW may
 # not restate a package `[prereq.*]` already declares. Three did — doxygen and
 # graphviz in `docs.yml`, clang and libclang-dev in `nightly.yml` — each with
 # its dnf/pacman/brew spellings and a presence probe sitting in the index.

--- a/just/check.just
+++ b/just/check.just
@@ -279,6 +279,7 @@ fast-serial: \
     version-lockstep \
     wait-evidence-discarded \
     weak-symbols \
+    workflow-indexed-apt \
     workflow-repo-env \
     workflow-runner-isolation \
     workspace-build-output \
@@ -985,6 +986,20 @@ knob-single-reader:
 # this existed, because the phase doc recorded a table and no method.
 config-knob-census:
     @python3 scripts/check/config-knob-census.py --check
+
+# The reverse of `check-sysdep-remedies` — phase-413 W3.
+#
+# That gate refuses a hand-written `sudo apt` in a `just` recipe, and
+# `[prereq.doxygen]`'s own `why` reads "found undeclared by
+# check-sysdep-remedies". Nothing guarded the other direction: a WORKFLOW may
+# not restate a package `[prereq.*]` already declares. Three did — doxygen and
+# graphviz in `docs.yml`, clang and libclang-dev in `nightly.yml` — each with
+# its dnf/pacman/brew spellings and a presence probe sitting in the index.
+#
+# Buildless and source-only, so it belongs on the fast line.
+[group("main")]
+workflow-indexed-apt:
+    @python3 scripts/check-workflow-indexed-apt.py
 
 # issue 0933 — a CI step that invokes `just`/`nros`/`west` must source the repo
 # environment. `activate.sh` is what exports `nano_ros_ROOT`, and that is how

--- a/scripts/check-workflow-indexed-apt.py
+++ b/scripts/check-workflow-indexed-apt.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""A workflow must not install a package the index already declares — W3.
+
+phase-413 W3, from the audit in issue 0996.
+
+## The asymmetry this closes
+
+`check-sysdep-remedies` already refuses a hand-written `sudo apt` in a `just`
+recipe, and `[prereq.doxygen]`'s own `why` field reads "found undeclared by
+check-sysdep-remedies" — so the index-side gap is guarded. The REVERSE was not:
+nothing stopped a workflow apt-installing a package `[prereq.*]` already names,
+and three did. `docs.yml` installed doxygen and graphviz, `nightly.yml` installed
+clang and libclang-dev, and all four were in the index with their dnf/pacman/brew
+spellings and a presence probe beside them.
+
+That is not a style violation. It is the same fact in two places, and the copy in
+YAML is the one nobody updates when the index moves — the drift RFC-0062 exists
+to delete.
+
+## What is checked
+
+Inside a workflow `run:` block, an `apt-get install` / `apt install` line may not
+name a package that appears in any `[prereq.*].apt` list.
+
+## What is deliberately allowed
+
+* A package the index does NOT declare. This gate says "do not restate the
+  index", not "never apt-get". `gnupg` and `lsb-release` in `gate.yml` exist to
+  add a third-party apt source, and RFC-0062's providers are system / sdk /
+  source / submodule — none of which can express "add this repository first", so
+  indexing them would claim a capability the index does not have.
+* `ros-humble-*`. Same reason: they come from packages.ros.org, which has to be
+  added first, and the `ci-base` image is the right home for a ROS stack.
+* Comment lines and heredoc bodies, for the reason `check-workflow-repo-env`
+  documents: a gate that cannot tell a command from a sentence about a command is
+  worse than no gate.
+* A `$(...)` substitution — that IS the fix, and it must not read as a violation.
+
+Run: python3 scripts/check-workflow-indexed-apt.py [--self-test]
+"""
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
+
+INSTALL = re.compile(r"\bapt(?:-get)?\s+install\b([^\n]*)")
+HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def indexed_apt_packages(path=INDEX):
+    try:
+        import tomllib as toml
+    except ModuleNotFoundError:
+        import tomli as toml
+    with open(path, "rb") as fh:
+        index = toml.load(fh)
+    out = {}
+    for key, entry in (index.get("prereq") or {}).items():
+        for pkg in entry.get("apt") or []:
+            out.setdefault(pkg, key)
+    return out
+
+
+def command_lines(run):
+    """Lines of a `run:` body that are commands — not comments, not heredocs."""
+    out, terminator = [], None
+    for line in (run or "").split("\n"):
+        if terminator is not None:
+            if line.strip() == terminator:
+                terminator = None
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.append(line)
+        m = HEREDOC.search(line)
+        if m:
+            terminator = m.group(2)
+    return out
+
+
+def named_packages(run):
+    """(package, line) for every literal package an apt install line names.
+
+    Continuations are joined first: the install list is routinely one package
+    per line ending in `\\`, and reading line-by-line would see none of them.
+    """
+    joined, buf = [], ""
+    for line in command_lines(run):
+        buf += line.rstrip()
+        if buf.endswith("\\"):
+            buf = buf[:-1] + " "
+            continue
+        joined.append(buf)
+        buf = ""
+    if buf:
+        joined.append(buf)
+
+    found = []
+    for line in joined:
+        m = INSTALL.search(line)
+        if not m:
+            continue
+        rest = m.group(1)
+        # A command substitution is the REMEDY. Do not read its contents as
+        # literal package names.
+        rest = re.sub(r"\$\([^)]*\)", " ", rest)
+        for tok in rest.split():
+            if tok.startswith("-") or tok.startswith("$"):
+                continue
+            if re.fullmatch(r"[a-z0-9][a-z0-9.+-]*", tok):
+                found.append((tok, line.strip()))
+    return found
+
+
+def load_workflows():
+    import yaml
+
+    docs = []
+    for name in sorted(os.listdir(WORKFLOWS)):
+        if not name.endswith(".yml"):
+            continue
+        path = os.path.join(WORKFLOWS, name)
+        with open(path) as fh:
+            docs.append((name, yaml.safe_load(fh)))
+    return docs
+
+
+def offenders(docs, indexed):
+    bad = []
+    for name, doc in docs:
+        for job_name, job in (doc.get("jobs") or {}).items():
+            for step in job.get("steps", []) or []:
+                for pkg, line in named_packages(step.get("run") or ""):
+                    if pkg in indexed:
+                        bad.append((name, job_name, pkg, indexed[pkg], line))
+    return bad
+
+
+def self_test():
+    indexed = {"doxygen": "doxygen", "graphviz": "graphviz", "curl": "curl"}
+    cases = [
+        ("sudo apt-get install -y doxygen graphviz", ["doxygen", "graphviz"]),
+        ("apt-get install -y --no-install-recommends curl", ["curl"]),
+        # the remedy must not read as a violation
+        ("sudo apt-get install -y $(python3 scripts/sdk/prereq-packages.py doxygen)", []),
+        # an unindexed package is allowed
+        ("sudo apt-get install -y gnupg lsb-release", []),
+        ("echo doxygen", []),
+    ]
+    failures = 0
+    for run, want in cases:
+        got = [p for p, _ in named_packages(run) if p in indexed]
+        if got != want:
+            print(f"  self-test FAIL: {run!r} -> {got}, want {want}")
+            failures += 1
+
+    # continuations: one package per line is the common spelling
+    multi = "sudo apt-get install -y \\\n  doxygen \\\n  graphviz"
+    if [p for p, _ in named_packages(multi) if p in indexed] != ["doxygen", "graphviz"]:
+        print("  self-test FAIL: line continuations not joined")
+        failures += 1
+
+    if command_lines("# apt-get install doxygen\napt-get install curl\n") != [
+        "apt-get install curl"
+    ]:
+        print("  self-test FAIL: comment read as a command")
+        failures += 1
+    if command_lines("cat <<EOF\napt-get install doxygen\nEOF\n") != ["cat <<EOF"]:
+        print("  self-test FAIL: heredoc body read as commands")
+        failures += 1
+
+    if failures:
+        print(f"check-workflow-indexed-apt self-test: {failures} case(s) FAILED")
+        return 1
+    print(f"check-workflow-indexed-apt self-test: OK ({len(cases)} cases + extraction)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    indexed = indexed_apt_packages()
+    docs = load_workflows()
+    bad = offenders(docs, indexed)
+    if bad:
+        print("check-workflow-indexed-apt: workflow(s) install a package the index declares:")
+        for name, job, pkg, key, line in bad:
+            print(f"  {name}  [{job}]  {pkg}  — declared by [prereq.{key}]")
+            print(f"      {line[:100]}")
+        print()
+        print("  The index carries the apt/dnf/pacman/brew spellings and a presence")
+        print("  probe. Restating one here is the same fact in two places, and this")
+        print("  is the copy that goes stale. Use:")
+        print("      $(python3 scripts/sdk/prereq-packages.py --manager apt <key>…)")
+        print("  or `nros setup --system` in a job that already builds the CLI.")
+        return 1
+
+    print(
+        f"check-workflow-indexed-apt: OK — {len(docs)} workflow(s), "
+        f"{len(indexed)} indexed apt package(s), none restated."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sdk/prereq-packages.py
+++ b/scripts/sdk/prereq-packages.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Print the OS packages `[prereq.*]` declares for a manager — phase-413 W3.
+
+WHY A SCRIPT AND NOT `nros setup --system`
+
+`nros setup --system` is the user-facing verb and stays so. This exists for the
+jobs that need two packages and nothing else from the toolchain: making a docs
+deploy build the `nros` CLI to learn that `doxygen` is spelled `doxygen` costs
+minutes to answer a question the index answers in milliseconds.
+
+It is not a second source of truth. It reads `nros-sdk-index.toml`, the same
+file the CLI reads, exactly as `check-dist-runtime-deps.py` already does — the
+SSoT is the index, not any one consumer of it.
+
+WHY IT REFUSES UNKNOWN KEYS
+
+Silently printing nothing for a typo would install nothing and fail later at the
+compiler, which is the shape RFC-0062 exists to delete. An unknown key is an
+error naming the key, the same rung the `<depend>` ladder ends on.
+
+Usage:
+    prereq-packages.py --manager apt doxygen graphviz
+    prereq-packages.py --self-test
+"""
+
+import argparse
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
+MANAGERS = ("apt", "dnf", "pacman", "brew")
+
+
+def load(path=INDEX):
+    try:
+        import tomllib as toml
+    except ModuleNotFoundError:  # py<3.11
+        import tomli as toml
+    with open(path, "rb") as fh:
+        return toml.load(fh)
+
+
+def packages_for(index, manager, keys):
+    """The manager's packages for `keys`, in the order given, deduped.
+
+    Raises on an unknown key, or on a key the index declares for no package
+    under this manager — "declared but not for your OS" is a real answer and a
+    silent empty string is not.
+    """
+    prereq = index.get("prereq", {})
+    out, seen, missing, unmapped = [], set(), [], []
+    for k in keys:
+        entry = prereq.get(k)
+        if entry is None:
+            missing.append(k)
+            continue
+        pkgs = entry.get(manager) or []
+        if not pkgs:
+            unmapped.append(k)
+            continue
+        for p in pkgs:
+            if p not in seen:
+                seen.add(p)
+                out.append(p)
+    if missing:
+        raise SystemExit(
+            f"prereq-packages: no [prereq.{missing[0]}] in nros-sdk-index.toml"
+            + (f" (and {len(missing) - 1} more)" if len(missing) > 1 else "")
+            + "\n  Declare it there — the index is the SSoT (RFC-0062)."
+        )
+    if unmapped:
+        raise SystemExit(
+            f"prereq-packages: [prereq.{unmapped[0]}] declares no `{manager}` package"
+            + (f" (and {len(unmapped) - 1} more)" if len(unmapped) > 1 else "")
+            + f"\n  Add the `{manager} = [..]` line to that entry."
+        )
+    return out
+
+
+def self_test():
+    index = {
+        "prereq": {
+            "doxygen": {"apt": ["doxygen"], "dnf": ["doxygen"]},
+            "graphviz": {"apt": ["graphviz"]},
+            "dup": {"apt": ["doxygen"]},
+        }
+    }
+    failures = 0
+
+    got = packages_for(index, "apt", ["doxygen", "graphviz"])
+    if got != ["doxygen", "graphviz"]:
+        print(f"  FAIL: order/content {got}")
+        failures += 1
+
+    # A package named by two keys is emitted once — the caller pastes this into
+    # one `apt-get install` line.
+    if packages_for(index, "apt", ["doxygen", "dup"]) != ["doxygen"]:
+        print("  FAIL: duplicate package not deduped")
+        failures += 1
+
+    for keys, why in ((["nope"], "unknown key"), (["graphviz"], "unmapped manager")):
+        manager = "apt" if why == "unknown key" else "dnf"
+        try:
+            packages_for(index, manager, keys)
+        except SystemExit:
+            pass
+        else:
+            print(f"  FAIL: {why} did not raise")
+            failures += 1
+
+    if failures:
+        print(f"prereq-packages self-test: {failures} case(s) FAILED")
+        return 1
+    print("prereq-packages self-test: OK")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manager", default="apt", choices=MANAGERS)
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("keys", nargs="*")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.keys:
+        ap.error("name at least one [prereq.*] key")
+    print(" ".join(packages_for(load(), args.manager, args.keys)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Item 4 of the maintainer-ordered list, first piece: the CI workflows stop restating what the provisioning system already knows.

## The asymmetry

`check-sysdep-remedies` refuses a hand-written `sudo apt` in a `just` recipe — `[prereq.doxygen]`s own `why` field literally reads *"found undeclared by check-sysdep-remedies"*. The **reverse was unguarded**, and three workflows walked through it:

| workflow | installed | already declared |
| --- | --- | --- |
| `docs.yml` | doxygen, graphviz | yes, with dnf/pacman/brew + a probe |
| `nightly.yml` | clang, libclang-dev | yes |
| `gate.yml` | curl | yes (and preinstalled on the runner) |

Same fact in two places — and the YAML copy is the one nobody updates when the index moves.

## What changed

**`scripts/sdk/prereq-packages.py`** prints the OS packages `[prereq.*]` declares for a manager. Not a second SSoT — it reads `nros-sdk-index.toml`, the same file the CLI reads, exactly as `check-dist-runtime-deps.py` already does. It refuses an unknown key, and refuses a key that declares nothing for the requested manager: *"declared but not for your OS"* is a real answer and a silent empty string is not.

Why not `nros setup --system`: that stays the user-facing verb for jobs that already build the CLI. `docs.yml` builds none, and making a docs deploy compile one to learn that `doxygen` is spelled `doxygen` costs minutes to answer what the index answers in milliseconds.

**`gate.yml`** drops `curl`. `gnupg` and `lsb-release` stay literal **on purpose**: they exist only to add the third-party ROS apt source, and RFC-0062s providers are system / sdk / source / submodule — none can express "add this repository first". Indexing them would claim a capability the index does not have.

**`check-workflow-indexed-apt`** — the gate, on the fast line (buildless, source-only). Self-testing, and mutation-checked by restoring the pre-fix spelling in `docs.yml`: it names the package, workflow, job and the `[prereq.*]` key that declares it.

It allows what it should — an unindexed package (this says *do not restate the index*, not *never apt-get*), `$(...)` substitutions (which **are** the fix and must not read as violations), and comments/heredoc bodies. Line continuations are joined first, since one-package-per-line is the common spelling and reading line-by-line would see none of them.

## Not done here

colcon-parity still apt-installs a ROS 2 Humble stack instead of using `container: ghcr.io/newslabntu/nano-ros-ci:humble` — which `images.yml` builds, describes as the base container for exactly these lanes, and which only `nightly.yml` uses today. That needs the image verified to carry colcon and the msg packages, and this job feeds the required `CI` aggregator, so it wants its own change rather than a guess.

Gates green: gate-lists (212), gate-visibility, ci-no-verb-fallback, workflow-repo-env, doc-recipe-refs, lane-contracts, required-contexts-reportable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)