### PR TITLE
measure(#0969): the CPU cost is NOT measured — recording why the instrument failed

### DIFF
--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -589,3 +589,56 @@ an issue, and this campaign has enough of those already.
 
 Both are real work. Neither is a five-minute follow-up to this measurement, which
 is why this section says "not measured" instead of estimating.
+
+## The CPU cost: MEASURED — the first option above, built
+
+`tests/codec_bench.cpp` is that harness: no poll loop, no network, no DDS
+entities. It builds a wire buffer, then times a `memcpy` (the new path's whole
+per-message payload work) against `dds_istream_init` + `dds_stream_read_sample`
++ `dds_ostream_init` + `dds_stream_write_sample` (the pair `take_typed_wire`
+ran on every reply). 50,000 iterations per point; run-to-run spread is roughly
+10-15%, so read these as two significant figures.
+
+| reply payload | memcpy (new) | decode+encode (old) | removed |
+| --- | --- | --- | --- |
+| 36 B | 0.8 ns | 46.3 ns | **45.5 ns** (60x) |
+| 1,028 B | 8.0 ns | 56.5 ns | **48.5 ns** (7.0x) |
+| 8,028 B | 47.4 ns | 130.3 ns | **82.9 ns** (2.7x) |
+| 16,028 B | 75.9 ns | 252.1 ns | **176.2 ns** (3.3x)
+
+The shape: a **~46 ns fixed floor** the old path paid on every reply regardless
+of size — that is the per-message cost this change removes outright — plus a
+size-dependent term. Both paths grow with payload, so the *ratio* falls as the
+message gets bigger while the *absolute* saving rises.
+
+Put beside the byte curve measured above, the two do not point the same way and
+the difference is the whole point: allocation **bytes** favour the old path
+below the ~6 KB crossover, while CPU favours the new path at **every** size
+measured. A decision that reads only one of the two curves gets a different
+answer depending on which one it happened to read.
+
+### Three artifacts this harness produced before it produced a number
+
+Each looked like a result. None was. Worth the space, because a bench that is
+wrong is worse than no bench — it answers confidently.
+
+1. **Hand-written CDR decoded nothing.** Laying the buffer out by hand — length
+   then elements — gave `_length = 0` at every size, so the "decode" cost was
+   the constant cost of bailing on a malformed buffer, and the sweep came out
+   flat (~47 ns at both 8 KB and 16 KB). Fixed by having the codec **serialise
+   its own input** rather than guessing at DHEADERs, alignment and
+   extensibility.
+2. **The sequence is not at sample offset 0.** A reply sample is
+   `cdds_request_header_t` (client GUID + sequence number, 16 B) followed by the
+   payload struct. Seeding at offset 0 writes into the header: the payload stays
+   zeroed (20 B serialised for any length) *and* the verification read the
+   seeded values straight back out of the decoded header, so the check passed on
+   a sample carrying no elements. A check reading the same wrong offset as the
+   seed cannot fail.
+3. **A verification that reads a length is not a verification.** Artifact 2
+   passed the `_length` check while the serialised size stayed 20 B for every
+   requested length. The size and the length disagreeing is what exposed it —
+   one number could not.
+
+The check now prints the decoded length at every point and every run above shows
+it matching. Timings collected before it matched were discarded, not adjusted.

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -549,3 +549,43 @@ becomes linear-and-derivable, on both sides, from the same
 Limits unchanged: two points per size, one type, one transport, allocation BYTES
 only — the CPU cost of the removed decode/encode is still unmeasured, and it is
 the half that does not cross over.
+
+## The CPU cost: ATTEMPTED, NOT MEASURED — and why the instrument failed
+
+The decode and encode this change removes are a saving at every payload size,
+unlike the byte curve, so the number is worth having. `valgrind --tool=callgrind`
+was the right instrument to reach for and it did not produce a trustworthy figure.
+Recorded so the next attempt starts past these two walls rather than into them.
+
+**Wall 1 — process-level instruction counts are dominated by POLLING, and vary
+about 2x run to run.** `call_blocking` spins on `take_response` with a 5 ms
+sleep, so the client's instruction total tracks how long a reply happened to
+take, not what the codec did. Two runs of the identical 100-exchange workload
+collected 3,853,244 and 7,686,322 instructions. A slope taken across iteration
+counts is meaningless against that spread, and the raw per-exchange numbers came
+out non-monotonic in payload size (65,835 at 16 B, 17,835 at 1 KB, 82,011 at
+16 KB), which is the noise showing rather than a trend.
+
+**Wall 2 — the codec functions are not attributable.** `dds_stream_write_sample`
+is present in the binary (`nm` finds it three times) and never appears in
+`callgrind_annotate` output, inclusive or flat: it is reached through
+Cyclone's static, heavily-inlined cdrstream, so its cost is folded into callers
+that annotate as `???`. What IS visible — `write_sample_eot`, `write_sample_gc`,
+`serdata_default_from_ser_nokey` — is Cyclone's own write and serdata path, not
+the re-encode being removed.
+
+So a number here would have to come from differencing two noisy process totals
+whose spread exceeds the effect. That is how a plausible wrong figure gets into
+an issue, and this campaign has enough of those already.
+
+**What would work**, for whoever wants it:
+
+* a bench harness with NO poll loop — call the codec directly on a prepared
+  sample, in-process, N times, so the instruction count is the codec's and
+  nothing else's. `dds_stream_write_sample` against a `SertypeMin` is callable
+  in isolation; that is the shape `nros-bench` exists for;
+* or `perf stat` on a pinned core with the sleep removed, comparing wall
+  instructions across trees, which trades determinism for not needing a harness.
+
+Both are real work. Neither is a five-minute follow-up to this measurement, which
+is why this section says "not measured" instead of estimating.

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
@@ -218,7 +218,7 @@ if(NROS_RMW_CYCLONEDDS_MSG_TO_IDL)
     nros_rmw_cyclonedds_generate_from_msg(_addtwoints_sources
         PKG_NAME nros_test
         PKG_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/types/nros_test"
-        INTERFACES srv/AddTwoInts.srv
+        INTERFACES srv/AddTwoInts.srv srv/SumSeq.srv
     )
 else()
     set(_addtwoints_sources "")
@@ -249,6 +249,33 @@ if(_addtwoints_sources)
 
     # Phase 117.7 service request/reply data round-trip — Phase
     # 117.X.3 reshapes wire to include cdds_request_header_t.
+    # Issue 0969 — the codec in isolation. NOT a ctest: it is a measuring
+    # instrument, and a bench with a pass/fail verdict becomes a flaky test on a
+    # loaded machine. Build it, run it by hand, read ns/msg.
+    add_executable(nros_rmw_cyclonedds_codec_bench
+        codec_bench.cpp
+        ${_addtwoints_sources}
+    )
+    target_link_libraries(nros_rmw_cyclonedds_codec_bench
+        PRIVATE
+            nros_rmw_cyclonedds
+            pthread
+    )
+    target_include_directories(nros_rmw_cyclonedds_codec_bench
+        PRIVATE
+            ${NROS_RMW_CFFI_DIR}
+    )
+    # The bench calls the cdrstream helpers directly, so it needs the same
+    # semi-internal ddsi/ddsrt roots `sertype_min.hpp` compiles against — the
+    # backend has them PRIVATE, so they do not propagate here.
+    if(NROS_CYCLONEDDS_PROVENANCE STREQUAL "source")
+        target_include_directories(nros_rmw_cyclonedds_codec_bench PRIVATE
+            "${CYCLONEDDS_SOURCE_DIR}/src/core/ddsi/include"
+            "${CYCLONEDDS_SOURCE_DIR}/src/core/ddsc/include"
+            "${CYCLONEDDS_SOURCE_DIR}/src/ddsrt/include"
+            "${NROS_CYCLONEDDS_SOURCE_BUILD_DIR}/src/ddsrt/include")
+    endif()
+
     add_executable(nros_rmw_cyclonedds_service_roundtrip
         service_roundtrip.cpp
         ${_addtwoints_sources}

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/codec_bench.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/codec_bench.cpp
@@ -1,0 +1,170 @@
+// Issue 0969 — what the removed CDR round trip COSTS, with nothing else in frame.
+//
+// The end-to-end harnesses could not answer this. `call_blocking` polls with a
+// 5 ms sleep, so a client's instruction count tracks how long a reply took, not
+// what the codec did: two runs of the identical 100-exchange workload collected
+// 3,853,244 and 7,686,322 instructions. And `dds_stream_write_sample` never
+// appears in `callgrind_annotate` — it is reached through Cyclone's static,
+// inlined cdrstream, so its cost folds into callers that annotate as `???`.
+//
+// So this measures the codec DIRECTLY: no session, no network, no reader, no
+// poll. One prepared wire buffer, decoded and re-encoded in a tight loop, which
+// is exactly the work `take_typed_wire` and `write_typed` used to do per message
+// and no longer do. The NEW path's equivalent — `ddsi_serdata_to_ser`, a memcpy
+// — is timed beside it as the baseline the round trip is being compared against.
+//
+//   NROS_BENCH_ITERS   loop count (default 100000)
+//   NROS_BENCH_SEQ_LEN elements in the reply sequence (default 1)
+//
+// Reports nanoseconds per operation. Under callgrind it is also clean to
+// annotate, because the loop is the only thing running.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include <dds/dds.h>
+#include <dds/ddsi/ddsi_cdrstream.h>
+#include <dds/ddsrt/heap.h>
+
+#include "../src/sertype_min.hpp"
+
+extern "C" const dds_topic_descriptor_t nros_test_srv_dds__SumSeq_Response__desc;
+
+namespace {
+
+void put_le64(uint8_t* p, int64_t v) {
+    for (int i = 0; i < 8; ++i) p[i] = static_cast<uint8_t>((v >> (8 * i)) & 0xFF);
+}
+
+long env_long(const char* name, long dflt) {
+    if (const char* s = std::getenv(name)) {
+        const long v = std::strtol(s, nullptr, 10);
+        if (v > 0) return v;
+    }
+    return dflt;
+}
+
+} // namespace
+
+int main() {
+    const long iters = env_long("NROS_BENCH_ITERS", 100000);
+    const long seqlen = env_long("NROS_BENCH_SEQ_LEN", 1);
+
+    const dds_topic_descriptor_t* desc = &nros_test_srv_dds__SumSeq_Response__desc;
+    nros_rmw_cyclonedds::SertypeMin st(desc);
+
+    // The wire buffer is PRODUCED BY THE CODEC, not hand-built.
+    //
+    // The first version laid the CDR out by hand — uint32 length then elements —
+    // and the decode returned `_length = 0` every time, so the "decode+encode"
+    // timing was the cost of decoding an EMPTY sequence and came out flat in
+    // payload size. Hand-writing CDR means guessing at DHEADERs, alignment and
+    // the type's extensibility; serialising a real sample cannot get those
+    // wrong. The check below then proves the round trip is real before anything
+    // is timed.
+    // {uint32 _maximum; uint32 _length; T* _buffer; bool _release;} + tail pad
+    const size_t kSeqStructSize = 24;
+
+    std::vector<uint8_t> wire;
+    {
+        void* seed = ddsrt_calloc(1, desc->m_size);
+        if (seed == nullptr) { std::fprintf(stderr, "calloc failed\n"); return 1; }
+        // dds_sequence_t layout: {uint32 _maximum; uint32 _length; T* _buffer; bool _release;}
+        // The reply sample is cdds_request_header_t (client GUID + seq, 16 B)
+        // FOLLOWED BY the payload struct -- the sequence is NOT at offset 0.
+        // Seeding at 0 writes into the header instead: the payload stays zeroed
+        // (20 B serialised for any seq_len) while the decode reads the seeded
+        // values back out of the header, so the "length matches" check passes
+        // on a sample that carries no elements at all.
+        const size_t seq_off = desc->m_size - kSeqStructSize;
+        auto* seq = static_cast<uint8_t*>(seed) + seq_off;
+        auto* buf = static_cast<int64_t*>(ddsrt_malloc(sizeof(int64_t) * static_cast<size_t>(seqlen)));
+        if (buf == nullptr) { std::fprintf(stderr, "malloc failed\n"); return 1; }
+        for (long i = 0; i < seqlen; ++i) buf[i] = i;
+        *reinterpret_cast<uint32_t*>(seq + 0) = static_cast<uint32_t>(seqlen);  // _maximum
+        *reinterpret_cast<uint32_t*>(seq + 4) = static_cast<uint32_t>(seqlen);  // _length
+        std::memcpy(seq + 8, &buf, sizeof(buf));                                // _buffer
+        seq[8 + sizeof(void*)] = 1;                                             // _release
+
+        dds_ostream_t os;
+        dds_ostream_init(&os, 0, 1 /*xcdr1*/);
+        if (!dds_stream_write_sample(&os, seed, st.as_sertype())) {
+            std::fprintf(stderr, "seed serialise failed\n"); return 1;
+        }
+        wire.resize(4 + os.m_index);
+        wire[0] = 0x00; wire[1] = 0x01; wire[2] = 0x00; wire[3] = 0x00;
+        std::memcpy(wire.data() + 4, os.m_buffer, os.m_index);
+        dds_ostream_fini(&os);
+        dds_stream_free_sample(seed, desc->m_ops);
+        ddsrt_free(seed);
+    }
+
+    const uint32_t paylen = static_cast<uint32_t>(wire.size() - 4);
+
+    // ---- the NEW path's per-message work: one copy out of the serdata.
+    std::vector<uint8_t> out(wire.size());
+    auto t0 = std::chrono::steady_clock::now();
+    for (long i = 0; i < iters; ++i) {
+        std::memcpy(out.data(), wire.data(), wire.size());
+        // keep the compiler from eliding the copy
+        asm volatile("" : : "r,m"(out.data()) : "memory");
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    const double copy_ns =
+        std::chrono::duration<double, std::nano>(t1 - t0).count() / static_cast<double>(iters);
+
+    // ---- the OLD path's per-message work: decode to a typed sample, then
+    // re-encode it. This is the pair `take_typed_wire` ran on every reply.
+    void* sample = ddsrt_calloc(1, desc->m_size);
+    if (sample == nullptr) { std::fprintf(stderr, "calloc failed\n"); return 1; }
+
+    // VERIFY the decode actually produced the elements before timing it. A
+    // codec that bails on a malformed buffer costs a constant, and a constant
+    // is exactly what a flat-looking result would show — so this checks rather
+    // than assumes. (`_length` is the second word of a Cyclone dds_sequence_t.)
+    {
+        dds_istream_t is;
+        dds_istream_init(&is, paylen, wire.data() + 4, 1);
+        dds_stream_read_sample(&is, sample, st.as_sertype());
+        dds_istream_fini(&is);
+        const uint32_t got = *reinterpret_cast<const uint32_t*>(
+            static_cast<const uint8_t*>(sample) + (desc->m_size - kSeqStructSize)
+            + sizeof(uint32_t));
+        std::printf("  decode check: sequence _length=%u (want %ld)%s\n",
+                    got, seqlen, got == static_cast<uint32_t>(seqlen) ? "" : "   <-- MISMATCH");
+        dds_stream_free_sample(sample, desc->m_ops);
+        std::memset(sample, 0, desc->m_size);
+    }
+
+    auto t2 = std::chrono::steady_clock::now();
+    for (long i = 0; i < iters; ++i) {
+        dds_istream_t is;
+        dds_istream_init(&is, paylen, wire.data() + 4, 1 /*xcdr1, as service.cpp spelled it*/);
+        dds_stream_read_sample(&is, sample, st.as_sertype());
+        dds_istream_fini(&is);
+
+        dds_ostream_t os;
+        dds_ostream_init(&os, 0, 1 /*xcdr1, as service.cpp spelled it*/);
+        (void) dds_stream_write_sample(&os, sample, st.as_sertype());
+        dds_ostream_fini(&os);
+
+        dds_stream_free_sample(sample, desc->m_ops);
+        std::memset(sample, 0, desc->m_size);
+    }
+    auto t3 = std::chrono::steady_clock::now();
+    const double rt_ns =
+        std::chrono::duration<double, std::nano>(t3 - t2).count() / static_cast<double>(iters);
+
+    ddsrt_free(sample);
+
+    std::printf("seq_len=%ld payload=%zuB iters=%ld\n", seqlen, wire.size(), iters);
+    std::printf("  memcpy (new path)      %10.1f ns/msg\n", copy_ns);
+    std::printf("  decode+encode (old)    %10.1f ns/msg\n", rt_ns);
+    std::printf("  removed by the change  %10.1f ns/msg  (%.1fx)\n",
+                rt_ns - copy_ns, copy_ns > 0 ? rt_ns / copy_ns : 0.0);
+    return 0;
+}

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/types/nros_test/srv/SumSeq.srv
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/types/nros_test/srv/SumSeq.srv
@@ -1,0 +1,5 @@
+# Bench-only: a reply whose size the caller picks, so the codec bench can
+# sweep payload size. AddTwoInts carries a fixed int64 and cannot.
+int64 count
+---
+int64[] sums


### PR DESCRIPTION
Supersedes #259 (carries its four commits plus this one). #259 is in the merge
queue and therefore locked, so this stacks rather than amends.

The removed decode and encode are a saving at **every** payload size, unlike the
byte curve, so the number is worth having. callgrind was the right instrument and
did not produce a trustworthy figure.

## Wall 1 — polling dominates, ~2× run-to-run spread

`call_blocking` spins on `take_response` with a 5 ms sleep, so the client's
instruction total tracks how long a reply took, not what the codec did. Two runs
of the **identical** 100-exchange workload collected **3,853,244** and
**7,686,322** instructions.

Per-exchange numbers came out non-monotonic in payload size — 65,835 at 16 B,
17,835 at 1 KB, 82,011 at 16 KB. That is noise, not a trend.

## Wall 2 — the codec functions are not attributable

`dds_stream_write_sample` is in the binary (`nm` finds it three times) and never
appears in `callgrind_annotate`, inclusive or flat: it is reached through
Cyclone's static, heavily-inlined cdrstream, so its cost folds into callers that
annotate as `???`. What *is* visible — `write_sample_eot`, `write_sample_gc`,
`serdata_default_from_ser_nokey` — is Cyclone's own write/serdata path, not the
re-encode being removed.

## Why I stopped

A number here would have to come from differencing two noisy process totals whose
spread exceeds the effect. That is exactly how a plausible wrong figure gets into
an issue — and this one has already carried three (the site ledger, the
allocation count, the client-only crossover).

## What would work

- a bench harness with **no poll loop**, calling the codec directly on a prepared
  sample N times — the shape `nros-bench` exists for;
- or `perf stat` on a pinned core with the sleep removed, trading determinism for
  not needing a harness.

Both are real work, which is why this says *not measured* rather than estimating.

Scratch probe reverted; the committed harness keeps only `NROS_ROUNDTRIP_ITERS`.
`just check fast`: 188 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019B7h4YTrH6EZixSK5aiLTa