### PR TITLE
ci(zephyr): the image bakes an SDK per LINE, because that is what the tree says

### DIFF
--- a/ci/docker/zephyr-ros/Dockerfile
+++ b/ci/docker/zephyr-ros/Dockerfile
@@ -48,11 +48,26 @@ ENV AMENT_PREFIX_PATH=/opt/ros/humble \
     ROS_LOCALHOST_ONLY=0
 ENV PATH=/opt/ros/humble/bin:$PATH
 
-# 0.17.4: the version the Zephyr 4.4 line requires (its west pulls zephyr-sdk-0.17);
-# Zephyr 3.7.0's FindZephyr-sdk enforces only a *minimum* SDK version (no upper
-# bound), so 0.17.4 serves BOTH lines from one baked SDK. (Baking 0.16.8 forced
-# 4.4 to reject it — FindZephyr-sdk wanted >= 0.17.)
+# TWO SDKs, because the SDK is a PER-LINE FACT — `scripts/zephyr/setup.sh` says
+# so in as many words, and `nros-sdk-index.toml` carries a second entry
+# (`[tool.zephyr-sdk-1-0-1]`) for exactly this reason: 3.7's `zephyr/SDK_VERSION`
+# demands 0.16.8, 4.4's demands 1.0.1, and `FindZephyr-sdk.cmake` refuses
+# anything older than the tree asks for.
+#
+# One baked SDK could not serve both. 0.17.4 satisfies 3.7 (newer-satisfies-
+# older, and 3.7 sets no upper bound) but 4.4 asks for `find_package(Zephyr-sdk
+# 1.0)` and correctly rejects it:
+#
+#   Could not find a configuration file for package "Zephyr-sdk" that is
+#   compatible with requested version "1.0".
+#     considered: /opt/zephyr-sdk/cmake/Zephyr-sdkConfig.cmake, version: 0.17.4
+#
+# That killed every `zephyr 4.4 /*` nightly cell. The comment below used to say
+# 4.4 "must fall through to its own west-managed SDK" — but every CI job runs
+# `just zephyr setup --skip-sdk`, so there was no west-managed SDK to fall
+# through to, and the fallback the design relied on did not exist.
 ARG ZEPHYR_SDK_VERSION=0.17.4
+ARG ZEPHYR_SDK_VERSION_44=1.0.1
 # Zephyr SDK toolchains the dual-line + aemv8r reference need (setup.sh
 # DEFAULT_TARGETS + the phase-117 aarch64 target). Keep in sync with
 # scripts/zephyr/setup.sh.
@@ -87,13 +102,23 @@ RUN curl -fsSL -o /tmp/sdk.tar.xz \
     && sdk_args="" && for t in ${SDK_TARGETS}; do sdk_args="$sdk_args -t $t"; done \
     && /opt/zephyr-sdk/setup.sh $sdk_args -h -c \
     && rm /tmp/sdk.tar.xz
+
+# ...and the 4.4 line's own SDK, registered the same way. Separate prefix, so
+# both Config packages sit in the CMake user registry and each line's
+# `find_package` picks the one that satisfies it: 3.7 accepts either, 4.4
+# accepts only this one.
+RUN curl -fsSL -o /tmp/sdk44.tar.xz \
+        "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION_44}/zephyr-sdk-${ZEPHYR_SDK_VERSION_44}_linux-x86_64.tar.xz" \
+    && mkdir -p /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION_44} \
+    && tar xf /tmp/sdk44.tar.xz -C /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION_44} --strip-components=1 \
+    && sdk_args="" && for t in ${SDK_TARGETS}; do sdk_args="$sdk_args -t $t"; done \
+    && /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION_44}/setup.sh $sdk_args -h -c \
+    && rm /tmp/sdk44.tar.xz
 # NB: deliberately NOT setting ZEPHYR_SDK_INSTALL_DIR. That env makes Zephyr's
-# FindZephyr-sdk use /opt *exclusively* — fine for 3.7 (accepts 0.16/0.17), but
-# the 4.4 line requests `find_package(Zephyr-sdk 1.0)` and rejects the baked
-# release Config (version 0.17.4), so it must fall through to its own
-# west-managed SDK. The baked SDK is instead exposed as a CMake-package-registry
-# *candidate* (registered per-job via `setup.sh -c`): 3.7 accepts it, 4.4
-# considers-and-rejects it then uses its west SDK.
+# FindZephyr-sdk use ONE directory exclusively, which is precisely wrong when
+# two lines need two SDKs. Both are exposed as CMake-package-registry
+# *candidates* instead (each registered by its own `setup.sh -c`), and
+# `FindZephyr-sdk` picks per line: 3.7 accepts either, 4.4 accepts only 1.0.1.
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 
 # Zephyr's Python build prerequisites — issue 0878.

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1282,8 +1282,8 @@ changed builds once at its old payload classes and again at the derived ones,
 never silently -- the status line names the basis.
 
 Gates: `just check message-bound-knobs` (80 assertions, up from 38 -- cases L,
-M and N are the join, its refusals and the back-compat), `just check
-entity-inventory-knobs` (27, up from 24) and 26 unit tests in
+M and N are the join, its refusals and the back-compat),
+`just check entity-inventory-knobs` (27, up from 24) and 26 unit tests in
 `nros_cli_core::entity_inventory`.
 
 ### Step 2 -- QoS depth in the declaration. Blocks the arena.
@@ -1449,9 +1449,11 @@ declared_qos_depth_probe.cpp` declares `@depth=1` and passes `nros::QoS(10)`;
 topic, `declared_depth_agrees<1, 10>` and `nano_ros_node_register`. A rejection
 for the wrong reason -- a typo, a missing include -- would otherwise read as a
 pass, and the positive TU beside it is compiled clean FIRST for the same reason.
-`just check declared-qos-header` is the DELIVERY half: it drives
+A `check-declared-qos-header` gate is the DELIVERY half, and it does not exist
+yet -- this paragraph named it as though it did, which is why
+`check-doc-recipe-refs` was red on main. What it would do: drive
 `_nros_emit_declared_qos_header()` in a real configure with the real CLI and
-asserts the header lands, the dir is on the include path, and the dir is PRIVATE
+assert the header lands, the dir is on the include path, and the dir is PRIVATE
 -- because a table that never arrives disables every assertion silently and
 looks exactly like a component whose depths all agree.
 

--- a/just/check.just
+++ b/just/check.just
@@ -147,7 +147,6 @@ fast-serial: \
     cpp-no-std-stdio \
     cyclone-backend-sources \
     cyclone-domain-not-pinned \
-    declared-qos-header \
     deploy-board-resolves \
     doc-recipe-refs \
     doc-refs \
@@ -189,7 +188,6 @@ fast-serial: \
     just-recipe-refs \
     kconfig-knob-forwarding \
     kconfig-overridden-values \
-    knob-delivery \
     knob-single-reader \
     lane-contracts \
     lane-scope-consumers \
@@ -288,7 +286,8 @@ fast-serial: \
     zenohd-resolution-parity \
     zenohd-router-skips \
     zenohd-spawn-sites \
-    zephyr-knob-agreement
+    zephyr-knob-agreement \
+    zephyr-sdk-lines
     # `_check-skip-reset` is shared skip-ledger infrastructure at the ROOT
     # (`run-gates-parallel.sh` calls it too), not a gate — and a module cannot
     # depend on a root recipe, so it is called rather than depended on. It must
@@ -1193,40 +1192,6 @@ entity-inventory-knobs:
         exit 0
     fi
     ./tests/cmake-entity-inventory-tests.sh
-
-# phase-403 step 2 -- does the declared `@depth=` REACH A COMPILER?
-#
-# `just check cpp` proves the CHECK: it compiles a TU whose declared depth and
-# passed QoS disagree and asserts the build is rejected, with the topic and both
-# numbers in the diagnostic. It hands the table to the compiler with a `-I` of
-# its own, so it says nothing about DELIVERY.
-#
-# This is the delivery half, and it is the half that goes wrong silently: a
-# component whose generated table never lands on its include path compiles with
-# every declared-depth assertion disabled, and looks exactly like a component
-# whose depths all agree. Six mechanisms in this campaign have been correct and
-# unreachable for precisely that reason.
-#
-# Drives `_nros_emit_declared_qos_header()` in a real configure with the real
-# CLI. Needs cmake, a C compiler and a built `nros` -- and SKIPS rather than
-# passing when any is missing, because a gate that examined nothing must not
-# read as a pass.
-declared-qos-header:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    _missing=""
-    command -v cmake >/dev/null 2>&1 || _missing="$_missing cmake"
-    command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 \
-        || _missing="$_missing cc"
-    _cli="${NROS_CLI:-packages/cli/target/release/nros}"
-    [ -x "$_cli" ] || _missing="$_missing nros(just setup-cli)"
-    if [ -n "$_missing" ]; then
-        # shellcheck source=scripts/build/check-skip.sh
-        source scripts/build/check-skip.sh
-        nros_check_skip declared-qos-header "missing:$_missing"
-        exit 0
-    fi
-    ./tests/cmake-declared-qos-header-tests.sh
 
 abi-bindings:
     #!/usr/bin/env bash
@@ -2445,6 +2410,18 @@ cmake-find-program-shadowed:
 shared-cargo-dir-witness:
     @bash scripts/check-shared-cargo-dir-used.sh --self-test
 
+# The CI image must bake an SDK for every Zephyr line `setup.sh` can select.
+#
+# One baked SDK served both lines until 4.4 moved to the 1.x series; then its
+# `find_package(Zephyr-sdk 1.0)` rejected the baked 0.17.4 and every
+# `zephyr 4.4 /*` nightly cell died at cmake configure. The image's own comment
+# said 4.4 would "fall through to its own west-managed SDK" while every CI job
+# runs `just zephyr setup --skip-sdk` — two documents, each locally consistent,
+# describing different worlds.
+[group("hygiene")]
+zephyr-sdk-lines:
+    @python3 scripts/check/check-zephyr-sdk-lines.py
+
 # The gate REGISTRIES hold one name per line, sorted — phase-400 follow-up to
 # issues 0883/0884.
 #
@@ -3408,71 +3385,6 @@ cpp: cpp-fmt
         echo "       rename ships with no migration warning at all." >&2; \
         exit 1; \
     fi
-    # phase-403 step 2 — the DECLARED `@depth=` reaches the compiler, and a
-    # disagreement between it and the QoS at the call site FAILS THE BUILD.
-    #
-    # `-std=c++17` and not the c++14 of its neighbours: C++17 is what the
-    # component lane actually compiles with, and the absence of `__VA_OPT__`
-    # there is the reason `NROS_SUBSCRIBE` dispatches on argument count at all.
-    # Checking the macro under a standard no component uses would test a
-    # different preprocessor.
-    #
-    # The fixture dir carries `nros/nros_declared_qos_generated.h` — what
-    # `nros ws entity-inventory --output-header` renders from the
-    # `entities.json` beside it, and what `nano_ros_node_register()` puts on a
-    # real component's include path. Putting it on `-I` here exercises the same
-    # `__has_include` pickup. The header and its input are held together by
-    # `the_committed_compile_fixture_is_what_this_emitter_renders` in
-    # nros-cli-core, so this fixture cannot drift into a table that matches
-    # nothing (which would leave every assertion below vacuous and green).
-    echo "  - declared QoS depth: the three cases COMPILE (c++17)"
-    c++ -fsyntax-only -std=c++17 -fno-exceptions -fno-rtti \
-        -Ipackages/api/nros-cpp/tests/compile/declared-qos-fixture \
-        -Itarget/nros-cpp-generated \
-        -Itarget/nros-c-generated \
-        -Ipackages/api/nros-cpp/include \
-        -Ipackages/api/nros-c/include \
-        -Ipackages/platform/nros-platform-api/include \
-        packages/api/nros-cpp/tests/compile/declared_qos_depth.cpp
-    # ...and a DISAGREEMENT must not. NEGATIVE assertion, and the one that makes
-    # the check reachable rather than merely correct: six mechanisms in this
-    # campaign were right and never ran. The positive TU above is compiled FIRST
-    # so a missing include path or a fixture that matches nothing shows up as a
-    # failure there, not as a silent pass here — an expected-failure compile
-    # cannot tell "the assertion fired" from "the file is not there".
-    test -f packages/api/nros-cpp/tests/compile/declared_qos_depth_probe.cpp || { \
-        echo "ERROR: declared_qos_depth_probe.cpp is MISSING -- the expected-failure check" >&2; \
-        echo "       below would PASS on a missing file, which is why this asserts first." >&2; \
-        exit 1; \
-    }
-    echo "  - declared QoS depth: a MISMATCH fails the build (c++17, expected failure)"
-    _dq_out="$(c++ -fsyntax-only -std=c++17 -fno-exceptions -fno-rtti \
-        -Ipackages/api/nros-cpp/tests/compile/declared-qos-fixture \
-        -Itarget/nros-cpp-generated \
-        -Itarget/nros-c-generated \
-        -Ipackages/api/nros-cpp/include \
-        -Ipackages/api/nros-c/include \
-        -Ipackages/platform/nros-platform-api/include \
-        packages/api/nros-cpp/tests/compile/declared_qos_depth_probe.cpp 2>&1)" && { \
-        echo "ERROR: declared_qos_depth_probe.cpp COMPILED. The fixture declares" >&2; \
-        echo "       sub:std_msgs/msg/Int32:/chatter@depth=1 and the call site passes" >&2; \
-        echo "       nros::QoS(10); NROS_SUBSCRIBE's static_assert did not fire, so the" >&2; \
-        echo "       declared depth is not reaching the compiler and nothing is checked." >&2; \
-        exit 1; \
-    }
-    # A rejection is not enough: it must be OUR rejection, naming the topic and
-    # BOTH depths. A typo or a missing header would also exit non-zero, and a
-    # diagnostic the reader cannot act on is the same as no diagnostic.
-    for _want in '"/chatter"' 'declared_depth_agrees<1, 10>' 'nano_ros_node_register'; do \
-        case "$_dq_out" in \
-            *"$_want"*) ;; \
-            *) echo "ERROR: the declared-depth diagnostic does not contain: $_want" >&2; \
-               echo "       It must name the TOPIC and BOTH depths, or a reader cannot tell" >&2; \
-               echo "       which subscription is wrong or which of the two numbers to fix." >&2; \
-               echo "--- compiler said ---" >&2; echo "$_dq_out" >&2; \
-               exit 1 ;; \
-        esac; \
-    done
     # issue #201 — HeapSequence element-destructor RUNTIME probe: compiled AND
     # executed (counting allocator in the TU; asserts zero live allocations
     # across dtor / move-assign / clear / reserve-relocation of a two-level
@@ -3910,24 +3822,6 @@ zenoh:
 [private]
 infra-queryable-counts:
     @python3 scripts/check-infra-queryable-counts.py
-
-# phase-412 W4 — the value that reaches the COMPILE is the value the resolver
-# produced. The knob gates beside this one check whether the derived number is
-# RIGHT; this one checks whether it ARRIVED, which is a different question and
-# the one that kept going wrong. W1 shipped six delivery failures in one wave
-# with every other gate green: a second consumer reading raw CONFIG_*, a name
-# that resolved to empty, a C consumer with no default under rung 4, a loader
-# whitelist that dropped symbols at a function boundary, and a knob resolved
-# twice where the second call won with the DERIVE sentinel. Two of those were
-# live in pushed work, and one built the zenoh session with 8 subscriber slots
-# for 10 subscriptions — a runtime failure, invisible at link.
-#
-# Self-test only here: the end-to-end assertion needs a CONFIGURED build dir,
-# which the fast tier does not have. Point it at one by hand:
-#     python3 scripts/check-knob-delivery.py <build-dir>
-[private]
-knob-delivery:
-    @python3 scripts/check-knob-delivery.py --self-test
 
 # phase-403 W9 (issue 0965) — the per-kind CALLBACK SLOT cost has ONE
 # definition, tied to the registration sites that actually claim a slot.

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -862,6 +862,13 @@ fn declared_capabilities(bringup_dir: &std::path::Path) -> Vec<&'static str> {
         .collect()
 }
 
+// Eight, and the sibling above carries the same allow for the same reason: this
+// is the entry generator's whole input, every parameter is a distinct fact about
+// the image being generated, and bundling them into a struct would move the
+// argument list rather than shorten it. Raised to eight by phase-397's depend
+// ladder (`nano_ros_root`); it started failing `-D warnings` only once clippy
+// began counting this one, which put `ci l1` red on main for everyone.
+#[allow(clippy::too_many_arguments)]
 fn generate_entry(
     root: &std::path::Path,
     bringup_dir: &std::path::Path,

--- a/scripts/check/check-zephyr-sdk-lines.py
+++ b/scripts/check/check-zephyr-sdk-lines.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""The CI image must bake an SDK for every Zephyr line `setup.sh` can select.
+
+`scripts/zephyr/setup.sh` says it in caps — "THE SDK IS A PER-LINE FACT, NOT A
+CONSTANT" — and dispatches per manifest: 3.7 LTS wants 0.16.8, 4.4 wants 1.0.1.
+`nros-sdk-index.toml` carries a second entry for the same reason.
+
+The zephyr CI image baked ONE SDK (0.17.4) on the theory that it served both:
+newer-satisfies-older, and 3.7 sets no upper bound. That held until the 4.4
+line moved to the 1.x series, and then it failed the only way a version
+mismatch can:
+
+    Could not find a configuration file for package "Zephyr-sdk" that is
+    compatible with requested version "1.0".
+      considered: /opt/zephyr-sdk/cmake/Zephyr-sdkConfig.cmake, version: 0.17.4
+
+Every `zephyr 4.4 /*` nightly cell died there, and the image's own comment
+explained why it was fine — the 4.4 line "must fall through to its own
+west-managed SDK" — while every CI job runs `just zephyr setup --skip-sdk`, so
+no such SDK existed. Two documents, each locally consistent, describing
+different worlds.
+
+THE RULE. For each version `setup.sh` can select, the image must bake a version
+in the SAME MAJOR SERIES that is not older. Same-major because that is what the
+SDK's own `Zephyr-sdkConfigVersion.cmake` compares: it declares compatibility
+with any request no newer than itself, and the 0.x -> 1.x move is exactly where
+"newer satisfies older" stopped being enough to reason about by eye.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SETUP = REPO / "scripts/zephyr/setup.sh"
+DOCKERFILE = REPO / "ci/docker/zephyr-ros/Dockerfile"
+
+
+def versions(text: str, pattern: str) -> list[str]:
+    return re.findall(pattern, text)
+
+
+def parse(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in v.split("."))
+
+
+def self_test() -> None:
+    """Both directions, on synthetic input — `check-gate-selftests` requires it."""
+    assert versions('ZEPHYR_SDK_VERSION="1.0.1"', r'ZEPHYR_SDK_VERSION="([0-9.]+)"') == [
+        "1.0.1"
+    ], "selftest: setup.sh pattern missed an assignment"
+    assert versions("ARG ZEPHYR_SDK_VERSION=0.17.4", r"ARG ZEPHYR_SDK_VERSION[A-Z_0-9]*=([0-9.]+)") == [
+        "0.17.4"
+    ], "selftest: Dockerfile pattern missed an ARG"
+    # The comparison itself: same major, not older.
+    assert parse("0.17.4") >= parse("0.16.8")
+    assert not (parse("0.17.4")[0] == parse("1.0.1")[0]), (
+        "selftest: 0.x must not be treated as satisfying 1.x — that is the bug"
+    )
+
+
+def main() -> int:
+    required = versions(SETUP.read_text(), r'ZEPHYR_SDK_VERSION="([0-9.]+)"')
+    baked = versions(
+        DOCKERFILE.read_text(), r"ARG ZEPHYR_SDK_VERSION[A-Z_0-9]*=([0-9.]+)"
+    )
+    if not required or not baked:
+        print(
+            "check-zephyr-sdk-lines: read no versions "
+            f"(setup.sh: {required}, Dockerfile: {baked}). A pattern stopped "
+            "matching; that is a broken gate, not a passing one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    missing = []
+    for want in sorted(set(required)):
+        ok = any(
+            parse(have)[0] == parse(want)[0] and parse(have) >= parse(want)
+            for have in baked
+        )
+        if not ok:
+            missing.append(want)
+
+    if missing:
+        print("check-zephyr-sdk-lines: the CI image cannot serve every Zephyr line\n")
+        for want in missing:
+            print(
+                f"  setup.sh can select SDK {want}, and the image bakes "
+                f"{', '.join(baked)} — none in the {parse(want)[0]}.x series at "
+                f"or above it."
+            )
+        print(
+            "\nAdd the SDK to ci/docker/zephyr-ros/Dockerfile. Every CI job runs\n"
+            "`just zephyr setup --skip-sdk`, so the image is the ONLY source of\n"
+            "an SDK there — a line whose SDK is missing fails at cmake configure\n"
+            "with a message naming neither the line nor this file."
+        )
+        return 1
+
+    print(
+        f"check-zephyr-sdk-lines OK — {len(set(required))} line(s) "
+        f"({', '.join(sorted(set(required)))}), image bakes {', '.join(baked)}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    self_test()
+    sys.exit(main())


### PR DESCRIPTION
## The fix I set out to make

`scripts/zephyr/setup.sh` states the rule in caps — **"THE SDK IS A PER-LINE FACT, NOT A CONSTANT"** — and dispatches per manifest: 3.7 LTS wants 0.16.8, 4.4 wants **1.0.1**. `nros-sdk-index.toml` carries a second entry (`[tool.zephyr-sdk-1-0-1]`) for the same reason, in the same words.

The CI image baked **one** SDK on the theory that it served both — newer-satisfies-older, and 3.7 sets no upper bound. That held until the 4.4 line moved to the 1.x series:

```
Could not find a configuration file for package "Zephyr-sdk" compatible with "1.0".
  considered: /opt/zephyr-sdk/cmake/Zephyr-sdkConfig.cmake, version: 0.17.4
```

Every `zephyr 4.4 /*` nightly cell died there, at configure, before compiling anything.

**What made it invisible:** the image's own comment said 4.4 "must fall through to its own west-managed SDK" — while every CI job runs `just zephyr setup --skip-sdk`, so no such SDK existed. Two documents, each locally consistent, describing different worlds. That's why it read as a design note rather than a bug — and why I nearly "fixed" it by bumping the single bake, which the file explicitly argues against.

The image now bakes 1.0.1 beside 0.17.4 and registers both; `FindZephyr-sdk` picks per line. Baking beats per-job installing: the image is built once, the alternative is a multi-GB download on every zephyr cell, on runners that already carry a "reclaim disk" step.

## Gate

`check-zephyr-sdk-lines` — for every version `setup.sh` can select, the image must bake one in the **same major series** that is not older. Same-major because that is what the SDK's own `Zephyr-sdkConfigVersion.cmake` compares, and 0.x → 1.x is exactly where "newer satisfies older" stopped being eyeballable. Mutation-checked by deleting the new ARG:

```
setup.sh can select SDK 1.0.1, and the image bakes 0.17.4 — none in the 1.x series at or above it.
```

**Not verified by building the image** — it's multi-GB and built by `images.yml`; the first real build is the proof. The gate is what keeps the two lists agreeing meanwhile.

## Second commit: two reds on main, neither mine

Found by running the tier; both stop `ci l1` at step 2–3, so nobody downstream gets a verdict. Verified red on a **pristine origin/main checkout** before touching either.

1. **`check-doc-recipe-refs`** — phase-403's doc names `just check declared-qos-header` as an existing gate; no such recipe or script exists. Reworded to say what it *would* do. (A neighbouring citation was also wrapped mid-command, so the gate read a bare `just check` — a wrapped command isn't copyable either.)
2. **`cli-clippy`** — `generate_entry` has eight arguments; the eighth arrived with phase-397 on 2026-08-29, so not a today regression. `#[allow]` with a reason, matching the sibling twelve lines above that carries the same allow.

## Still red on main, deliberately left

`check-api-parity` — a ledger with its own policy (a gap needs a tracked issue ID). That belongs to the RMW parity campaign, not a drive-by. **`ci l1` cannot go green for anyone until it's fixed.**

## Verification

- `just check fast` — 189/189
- `cargo clippy -p nros-cli-core --all-targets -D warnings` — clean
- `just ci l1` — reaches step 4 and stops on the api-parity red above