### PR TITLE
ci(phase-413 W4+W5): the PR gate's promise matches what it runs; `native` gains a setup verb

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -704,6 +704,28 @@ jobs:
 
       # Aspirational umbrella-decoupling guard — EXPECTED TO FAIL until the
       # Phase 104.A migration completes. Advisory only. (Build tier, non-push.)
+      # NOT ON `pull_request`, deliberately — "PR cheap, batch thorough".
+      #
+      # phase-395 (197eef4fa) narrowed this from `github.event_name != 'push'`,
+      # which DID include pull requests, to the list below. The paragraph that
+      # follows predates that change and described the wider set; it is kept for
+      # the fixture reasoning, which still holds, but read the CONDITION for
+      # what runs. A comment that outlived its code is what sent phase-413 W4
+      # looking for a regression that was never there — and it is the same shape
+      # as `build-wide.yml`'s "WHY push(main) AND NOT the merge queue", which was
+      # false the day it was written (issue 0996).
+      #
+      # Cost, measured 2026-09-03 across three merge-group runs: 3:30, 3:17,
+      # 3:22. Per batch that is cheap; per PR push, on a queue that batches, it
+      # is the difference the phase-395 split exists to make.
+      #
+      # CONSEQUENCE, and it is worth stating where someone will read it: a green
+      # required `CI` on a pull request does NOT mean the unit tests passed. It
+      # means the source gates and the compile smoke held. Nothing broken lands
+      # — the queue runs them before merging — but the feedback arrives as a
+      # queue ejection (`queue-notify.yml` comments on the PR) rather than on the
+      # PR itself. `just ci gate` locally is the same lane, sooner.
+      #
       # Phase-395 W4 — this job already runs `check-fast` (push) and `check`
       # (PR). Adding `test-unit` makes the PR gate exactly L1, the lane an agent
       # is told to run before pushing (CLAUDE.md, AGENTS.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,13 +96,21 @@ to — `net/` `serial/` `ipc/` `sys/` — documented in `packages/drivers/README
     not prebuilt")`. A gate in an affordability tier may resolve a COMPILE-stage
     stamp only if the lane BUILDS it (~13 s); a runtime fixture is banned
     outright.
-    **CI runs a SUBSET of it, deliberately** (phase-396/399): the required `CI`
-    context is `check-fast` + `test-unit` + `check-cli-tests` (the last added
+    **CI runs a SUBSET of it, deliberately, and the subset DIFFERS BY EVENT**
+    (phase-395 "PR cheap, batch thorough"; phase-396/399). On `pull_request` the
+    required `CI` context is `check-fast` + `check-submodule-commits-reachable` +
+    `check-compile-smoke` + `check-cli-tests`. **`test-unit` is NOT in it** — it
+    runs on `merge_group` (and schedule/dispatch), where it costs a measured
+    ~3.5 min per batch instead of per PR push. So a green `CI` on a pull request
+    means "it compiles and the source gates hold", NOT "the unit tests pass";
+    nothing broken lands, because the queue runs them before the merge, but the
+    feedback arrives at the queue and an ejection is how you hear about it
+    (`queue-notify.yml` comments on the PR). Run `just ci gate` locally if you
+    want that answer sooner — it is the same lane. (`check-cli-tests` was added
     2026-09-02 — it lived only in `check-build`, which no merge-gating event
-    runs, so issue 0896's two reds landed and stayed; no fixture/SDK/ROS, on
-    `pull_request` AND `merge_group`, ~2 min warm / ~8 min cold, including
-    the `nros-launch-resolve` it must build first); `ci-l1` also runs `check-build` +
-    `check-api-parity`. Your local tier is STRONGER than the gate, so you catch
+    runs, so issue 0896's two reds landed and stayed; no fixture/SDK/ROS, ~2 min
+    warm / ~8 min cold, including the `nros-launch-resolve` it must build
+    first.) `ci-l1` also runs `check-build` + `check-api-parity`. Your local tier is STRONGER than the gate, so you catch
     compile-tier breakage before the queue does and the queue stays cheap and
     always-satisfiable. `check-build` is now `schedule`/`workflow_dispatch` only —
     it was on the merge group and could never pass there (it needs generated

--- a/just/native.just
+++ b/just/native.just
@@ -162,6 +162,40 @@ build-fixtures: build-fixture-rust build-fixture-extras build-workspace-fixtures
     @bash scripts/dev/deprecated-scope-alias.sh native build-fixtures "just build native"
     @echo "Native test fixtures built."
 
+# Provision what the NATIVE lane needs — phase-413 W5.
+#
+# `just setup native` expands to the modules of the `native` preset, which is
+# `[native]` — and this module had NO `setup` recipe, so the verb ran the common
+# preamble (submodule init, CLI, launch resolver) and then printed "native has no
+# `setup` recipe — nothing to provision". Meanwhile `host-tests.yml` provisioned
+# the native lane in five hand-rolled steps, because the verb genuinely did not
+# do it. That is the gap issue 0996 measured as "provisioning verbs `just setup`
+# cannot reach".
+#
+# SOURCES COME FROM THE INDEX, NOT A LIST HERE. `--build-sources` resolves the
+# top-level `build_sources` union — which is byte for byte the seven sources the
+# workflow was naming by hand (zenoh-pico, mbedtls, cyclonedds-src,
+# micro-xrce-dds-client, micro-cdr, px4-rs, nuttx-libc). Restating it here would
+# reintroduce the second copy W3 just deleted one level down.
+#
+# `--prefix build/qemu` is not a CI detail: `nros setup --help` documents it as
+# where the test harness already looks for the emulator.
+[group("setup")]
+setup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nros setup --build-sources
+    just ci provision-zenohd
+    nros setup --tool qemu --prefix build/qemu --index nros-sdk-index.toml
+    nros setup --tool xrce-agent --index nros-sdk-index.toml
+    # OPTIONAL, and it says so. The workspace-entry fixtures skip without it;
+    # every other native fixture builds. `|| echo` is the "continue past a
+    # known-optional command" form — a decision that is visible in the log,
+    # not a fallback between two verbs.
+    nros setup --tool play_launch_parser --index nros-sdk-index.toml \
+        || echo "native setup: play_launch_parser unavailable — workspace-entry fixtures will SKIP"
+    echo "native lane provisioned."
+
 # Build native workspace fixtures from examples/fixtures.toml.
 #
 # CODEGEN FIRST — phase-413 W2, and it is issue 0992 in a second place.


### PR DESCRIPTION
## W4 — the doc moves, not the trigger

`test-unit` does not run on `pull_request`, and CLAUDE.md said the required `CI` context included it. **I went looking for the regression and there is not one.** Commit `197eef4fa` — *"ci(phase-395): the required check does different work per event — PR cheap, batch thorough"* — deliberately narrowed the condition from `github.event_name != 'push'` (which **did** include pull requests) to the current merge_group/schedule/dispatch list.

Reversing another phase deliberate decision is not a doc fix, so the doc is what changed.

What misled me is worth fixing too: the comment above the step still describes the wider set — *"Adding `test-unit` makes the PR gate exactly L1"* — and predates the narrowing. Same shape as `build-wide.yml`s *"WHY push(main) AND NOT the merge queue"*, false the day it was written (issue 0996). A comment that outlives its code sends the next reader hunting a regression that was never there.

Both now state the consequence where someone will read it: **a green required `CI` on a pull request does not mean the unit tests passed.** Nothing broken lands — the queue runs them — but feedback arrives as a queue ejection rather than on the PR, and `just ci gate` locally is the same lane, sooner.

Cost, measured across three merge-group runs: 3:30, 3:17, 3:22.

## W5 — `just setup native` provisioned nothing

The `native` preset expands to `[native]`, and that module had **no `setup` recipe** — so the verb ran the common preamble and printed *"native has no `setup` recipe — nothing to provision"*, while `host-tests.yml` provisioned the same lane in five hand-rolled steps. That is issue 0996s "provisioning verbs `just setup` cannot reach", and `just ci provision-zenohd` was one of them.

`native::setup` now does it, and takes the **sources from the index**: `nros setup --build-sources` resolves the top-level `build_sources` union, which is byte for byte the seven the workflow named by hand (zenoh-pico, mbedtls, cyclonedds-src, micro-xrce-dds-client, micro-cdr, px4-rs, nuttx-libc). Listing them again would reintroduce the second copy #265 just deleted one level down.

## Not converting host-tests yet, deliberately

That lane is red and #260 is in flight fixing it. Adding a second change to a lane under repair means neither can be verified — my own "W2 gates the rest" rule. It converts once host-tests is green.

Gates: doc-recipe-refs, gate-lists, ci-no-verb-fallback green; `just setup native` verified to reach `native::setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)