### PR TITLE
fix(api-parity): ledger `cpp::declared_depth`, the one unledgered row on main

### DIFF
--- a/docs/reference/api-parity-ledger/other.json
+++ b/docs/reference/api-parity-ledger/other.json
@@ -215,6 +215,10 @@
     "verdict": "declined",
     "why": "see `cpp:add_will_overflow`."
   },
+  "cpp:declared_depth": {
+    "verdict": "extension",
+    "why": "the declared depth for `(type, topic)`, or `DECLARED_DEPTH_UNDECLARED`. `constexpr`, so it answers inside a `static_assert` when the topic is a string literal -- which is every call site in this tree -- and an ordinary call for the boot-time fallback in `ComponentNode::create_subscription` when the topic is only known at run time. One implementation, two evaluation times. It reads the build-time table a component's own declaration emits (phase-403 step 2), so a subscription that passes a QoS disagreeing with the declaration is rejected where it is written rather than at run time. rclcpp has no counterpart: there a depth is a runtime argument to `create_subscription` and nothing records what the component declared, so nothing can compare the two. The mechanism exists because a receive buffer is sized from the declared depth (phase-403), and a number the image sizes memory from must be checkable at the point it is stated."
+  },
   "cpp:get_c_string": {
     "verdict": "divergence",
     "why": "rclcpp's `std::string` -> `const char*` adapter, which exists because rclcpp's API takes `std::string` and rcl takes `const char*`. Our C++ has no such boundary: `nros-cpp` is freestanding with `-fno-exceptions` (RFC-0018) and gates every `<string>` include on `NROS_CPP_STD` (issue 0112), so the API takes `const char*` throughout and there is nothing to adapt."


### PR DESCRIPTION
`check-api-parity` was red on `main`, and the gate said exactly why:

```
+ declared_depth      UNLEDGERED   ours-only
1 item(s) differ with no ledger entry.
```

phase-403 step 2 added `nros::declared_depth` — the C++ half of the declared-QoS table — and every item where our user API doesn't correspond to rclcpp must carry a **written** verdict. This one had none, so the gate did its job.

## The verdict, from the source

`extension`. It's `constexpr`, so it answers inside a `static_assert` when the topic is a string literal (every call site in this tree), and is an ordinary call for the boot-time fallback in `ComponentNode::create_subscription` when the topic is only known at run time — one implementation, two evaluation times. It reads the build-time table a component's own declaration emits.

rclcpp has no counterpart: a depth there is a runtime argument to `create_subscription`, and nothing records what the component declared, so nothing can compare the two.

## Two things the gate told me

**My first placement was wrong.** I filed it under `qos.json` because the symbol is about QoS depth. The gate replied:

```
1 ledger row(s) sit in the wrong topic shard (all listed; the move is mechanical):
  cpp:declared_depth  is in qos.json, belongs in other.json
```

It derives the shard rather than trusting the author — the only reason a 17-shard ledger stays navigable.

**My first write reformatted three neighbouring rows.** `json.dumps(..., ensure_ascii=False)` unescaped their `—`. Caught it in the diff, reverted, rewrote with the file's own escaping. The diff is now four lines and nothing else moved.

## Verification

- `just check api-parity` — passes (was red on pristine `main`)
- `just check api-parity-ledger` — self-test, 0 checks failed

**Not green here yet:** `just ci l1` still stops at `cli-clippy`, which **#267** fixes (`generate_entry`'s eighth argument). This PR removes one of the two remaining reds on main; that one removes the other. Together they should restore a green tier 1 for everyone.