### PR TITLE
measure(#0969): codec bench — the removed decode+encode costs ~46 ns/reply

### DIFF
--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -92,6 +92,14 @@ reads the CDR the serdata is already holding.
 full encode. On a Cortex-R safety MCU this sits directly in the receive path of a
 control loop.
 
+> **Now measured** (`tests/codec_bench.cpp`, section "The CPU cost: MEASURED"
+> below). The decode+encode pair costs a **~46 ns floor on every message**
+> regardless of size, rising to 176 ns at a 16 KB payload; the new path's whole
+> per-message payload work is a `memcpy` at 0.8-76 ns over the same range. The
+> allocations are the NULL RESULT below — count unchanged, bytes crossing over
+> at ~6 KB. So of the three costs asserted here, the CPU one is real at every
+> size and the allocation one is a trade, not a win.
+
 **Real-time bound.** [phase 391](../roadmap/phase-391-allocation-unification-and-tier-model.md) argues
 the heap holds infrastructure while payload buffers stay static, and derives a
 Robson bound from that. Every Cyclone take allocates a *payload-sized* block, and

--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -266,7 +266,10 @@ Also untouched: the three RECEIVE-side adapters
 (`take_fibonacci_get_result_response_wire` and the two `_SendGoal_*` /
 `_GetResult_Request_` memcpy branches). Those are a different question — issue
 0969 argues a `dds_takecdr` rewrite removes the need for them rather than
-correcting them.
+correcting them. **That rewrite has since landed, and its cost is measured**: the
+decode+encode it removes was a ~46 ns floor per message (176 ns at 16 KB), while
+the allocation count it was also expected to cut did not move. See 0969's
+"The CPU cost: MEASURED" section.
 
 ## Not to be confused with
 

--- a/docs/issues/archived/0970-cyclone-rmw-should-own-its-sertype.md
+++ b/docs/issues/archived/0970-cyclone-rmw-should-own-its-sertype.md
@@ -135,8 +135,21 @@ work around.
     cyclonedds steady-state sites   2 -> 1
 
 The survivor is `serdata_alloc`, the one copy a caller-owns-the-buffer contract
-cannot avoid. Per-message allocation on the service and action data path is
-otherwise gone.
+cannot avoid.
+
+**Read that as what it is: a count of allocation SOURCE SITES, not of runtime
+allocations.** This section first went on to say per-message allocation was
+"otherwise gone" from the service and action data path. The ledger does not
+support that claim and the runtime measurement contradicts it — see
+[#0969](../0969-cyclone-take-cdr-round-trip.md), where the allocation COUNT comes
+out unchanged before and after, and the BYTES cross over at ~6 KB rather than
+falling. A site disappearing from a ledger is not a call disappearing at runtime.
+
+**What the change does remove at runtime, measured** (bench in
+`tests/codec_bench.cpp`, numbers in 0969): the decode+encode pair, worth a
+**~46 ns floor per message** at any size and 176 ns at a 16 KB payload, against
+a `memcpy` of 0.8-76 ns over the same range. That is the win this migration
+actually buys, and unlike the byte curve it holds at every payload size.
 
 `check-rmw-alloc-sites` is what caught the leftovers: it failed with "DECLARED
 names a steady-state site that is gone", which is how `write_fibonacci_get_result_

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1160,4 +1160,5 @@ holds the evidence, the item is *close it*.
 | [#0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md) | the zenoh read task inherits the executor's priority on Zephyr |
 | [#0880](../issues/0880-tcm-unused-while-sram-exhausted.md) | 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted |
 | [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `take_serialized` costs a full round trip |
+| [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a full round trip. **Round trip removed; cost measured** — ~46 ns/message floor (176 ns at 16 KB). The allocation saving this row assumed did NOT appear: count unchanged, bytes a crossover at ~6 KB. Remaining: the third site, per 0976 |
 

--- a/docs/roadmap/phase-393-rmw-contract-remainder.md
+++ b/docs/roadmap/phase-393-rmw-contract-remainder.md
@@ -171,7 +171,7 @@ holds the evidence, the item is *close it*.
 
 | issue | why it belongs here |
 | --- | --- |
-| [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip |
+| [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip. **RESOLVED**; the removed decode+encode is worth ~46 ns/message (176 ns at 16 KB), measured in 0969. Its allocation-site ledger reads 2 -> 1, which is SITES and not runtime calls — the runtime count did not move |
 | [#0971](../issues/0971-take-sequence-cannot-say-why-it-stopped.md) | `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it |
 | [#0976](../issues/0976-service-action-adapters-tested-only-against-ourselves.md) | five action adapters in the Cyclone service path reshape the CDR to match ROS 2, exercised only by nano-ros talking to itself. This is the VERIFICATION remainder W3 names |
 


### PR DESCRIPTION
Builds the harness the previous 0969 commit named but did not write: no poll loop, codec called directly in-process, so the number is the codec's rather than the polling loop's.

## Result

| reply payload | memcpy (new) | decode+encode (old) | removed |
| --- | --- | --- | --- |
| 36 B | 0.8 ns | 46.3 ns | **45.5 ns** (60x) |
| 1,028 B | 8.0 ns | 56.5 ns | **48.5 ns** (7.0x) |
| 8,028 B | 47.4 ns | 130.3 ns | **82.9 ns** (2.7x) |
| 16,028 B | 75.9 ns | 252.1 ns | **176.2 ns** (3.3x) |

A **~46 ns fixed floor** removed from every reply, plus a size-dependent term.

This closes the one quantity the callgrind attempt could not produce (polling noise ~2x run-to-run; the cdrstream functions inline and annotate as `???`).

## Why it matters that both curves exist

CPU favours the new path at **every** size. Allocation **bytes** favour the old path **below ~6 KB**. They disagree, so a decision reading only one gets a different answer depending which.

## Notes for review

- **Not a ctest.** A bench with a pass/fail verdict becomes a flaky test on a loaded machine.
- **`AddTwoInts.srv` is restored**, not changed. It was mutated in place while developing this (it carries a fixed `int64` and cannot sweep size); the bench now has its own bench-only `srv/SumSeq.srv`.
- **Three artifacts were caught and discarded before any number was kept** — a hand-written CDR buffer that decoded to zero elements; a seed written into the 16-byte `cdds_request_header_t` instead of the payload; and a length check reading the same wrong offset as the seed, which therefore could not fail. Written up in the issue: each looked like a result, and a bench that is wrong answers confidently.

The decode check now prints the decoded element count at every point. Timings collected before it matched were discarded, not adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)