### PR TITLE
docs(#0877, #1005): W1 verified — the cell is green, and #268's attribution to 0906 is refuted

### DIFF
--- a/docs/issues/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md
+++ b/docs/issues/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md
@@ -162,3 +162,79 @@ pin is well past it.
 If green: close this as fixed by 0906 and file the `wait_for_output` talker-kill
 separately. If still red: raise `talker_window` to 60 s, which separates
 "delivery is broken" from "the publisher was killed first" in one run.
+
+## VERIFIED 2026-09-03: the cell is GREEN — and my attribution above is WRONG
+
+Rebuilt via the sanctioned `just build freertos` (exit 0), bake verified BEFORE
+running anything, then `test_rtos_pubsub_e2e` FreeRTOS solo,
+`--test-threads 1 --retries 0`, 3 rounds x 3 languages.
+
+**9 of 9 PASS.** C, C++ and Rust, 12 published / 12 heard every run, ~35.4 s
+each, zero message loss, no STALE verdict, no panic. **0877's symptom does not
+reproduce.**
+
+The bake, measured before and after:
+
+| | before | after |
+| --- | --- | --- |
+| C++ fixtures | `10000` x12, mtime **2026-08-20 22:31** | `60000` x12, 19:08 |
+| Rust fixtures | `10000`, mtime **2026-08-20 21:53** | `60000`, 19:02 |
+
+So issue 1005 is confirmed independently: every live FreeRTOS zenoh fixture was
+baked ten days before the 0906 fix and the probe never said so. (The `10000`
+copies still on disk are dead fingerprint dirs from Aug 20; nothing links them.)
+
+### RETRACTION: this is NOT attributable to 0906
+
+The section above says the report "probably predates its own fix" and names
+0906. **The green is real; that attribution is refuted**, and by measurement
+rather than by doubt.
+
+Counterfactual run: `Z_TRANSPORT_LEASE_MS` put back to `10_000`, fixtures
+rebuilt, bake verified to read `10000`, C and C++ run 3x each.
+
+    6 of 6 PASS, 12 published / 12 heard — identical to the fixed build.
+
+The lease constant is **invisible to this cell**, and the arithmetic says why:
+
+    listener t=0 -> stabilization_delay 20 s -> talker t=20
+    -> wait_for_output(15 s) SIGKILLs it at t~35
+
+The talker emits exactly **12** publishes at 1 Hz before it dies. The first
+lease lapse is at ~20 s of session life. **The window closes before the lapse
+can happen.**
+
+So the rebuild fixed it and 0906 did not. Something else in the twenty days
+between Aug 20 and Sep 3 is the real cause. Candidates, INFERRED and untested —
+`7cb213c43 feat(lan9118): drive RX from the interrupt, not a 5 ms poll (#0917)`
+is the best fit for "delivers by hand, nothing under the harness", with
+`5e147bee3` (#0899/#0906 lease task freeing the transport under the publisher),
+`34d0a22de` (#0924) and the lwIP FULLDUPLEX / per-task netconn changes behind
+it. Bisecting is separate work and is NOT done.
+
+### A corollary that outlives this issue
+
+**This cell can never regression-test 0906.** It kills the publisher before the
+lease can lapse, so the constant it was supposed to protect is unobservable
+here. Whatever gate guards that fix, it is not this one — and nothing currently
+does.
+
+### The talker kill, now quantified
+
+Real and independent of 0877. The 15 s `wait_for_output` window
+(`rtos_e2e.rs:725`, `qemu.rs:448` `kill_process_group`) truncates the talker at
+exactly 12 messages, every run, all three languages: the cell exercises twelve
+seconds of a free-running publisher. It was not raised here — that escalation
+was conditioned on the cell failing, and it passed.
+
+**Correction to the timeline in the section above:** the predicted `verdict
+t~65` no longer holds. Every run finished in 35.4 s. The ~65 s in the original
+report is not what this cell does today.
+
+### Disposition
+
+The symptom is gone and the cell is green, but the CAUSE is unidentified, so
+this is not being closed on "it passes now" — that is precisely the reasoning
+that let the stale-binary story stand. It stays open pending either a bisect
+across the Aug-20..Sep-3 range or a decision that a green cell with an
+unattributed fix is acceptable to close.

--- a/docs/issues/1005-zpico-build-constants-outside-staleness-inputs.md
+++ b/docs/issues/1005-zpico-build-constants-outside-staleness-inputs.md
@@ -83,6 +83,20 @@ Not settled, and worth choosing rather than patching the one constant:
 Whichever lands, the acceptance is the case above: change
 `Z_TRANSPORT_LEASE_MS`, do not rebuild, and require the probe to report STALE.
 
+## Confirmed independently 2026-09-03
+
+A sanctioned `just build freertos` flipped every live FreeRTOS zenoh fixture
+from `10000` to `60000`. The binaries it replaced were dated **2026-08-20**, ten
+days before the fix that changed the constant, and the probe reported FRESH for
+all of them. Measured, not inferred.
+
+**And a second gap found while verifying it:** the cell that would notice the
+old value cannot. `test_rtos_pubsub_e2e` FreeRTOS kills its talker after 15 s,
+so it emits 12 publishes and the first lease lapse (~20 s of session life) never
+arrives — a build baked at `10000` passes it 6 of 6. So the constant is
+unprotected in BOTH directions: the probe cannot see it change, and the cell
+cannot see it be wrong. Fixing the probe alone leaves the second half open.
+
 ## Not covered
 
 Whether other build-script dependency crates feed other fixture families the

--- a/docs/roadmap/phase-414-rtos-runtime-correctness.md
+++ b/docs/roadmap/phase-414-rtos-runtime-correctness.md
@@ -58,8 +58,21 @@ Each is an existing issue. The item is "close it"; the issue holds the evidence.
   30 s listener wait is the reported ~65 s exactly. The service and action
   shapes use `collect_until` and let the server live, which is why they pass on
   the same host.
-  **Next: rebuild the FreeRTOS pubsub fixtures, confirm the bake reads 60000,
-  re-run the cell.** Do not trust a FRESH verdict from the probe here.
+  **VERIFIED 2026-09-03: rebuilt, bake confirmed 60000, cell is GREEN — 9 of 9
+  across all three languages, 12 published / 12 heard, ~35.4 s each.** The
+  symptom does not reproduce.
+  **But the attribution to 0906 is REFUTED, by counterfactual rather than by
+  doubt.** Putting the lease back to 10000 and rebuilding still passes 6 of 6.
+  The cell kills its talker 15 s in, so it emits 12 publishes and the first
+  lease lapse (~20 s of session life) never arrives — the constant is invisible
+  here. The rebuild fixed it; 0906 did not. The real cause is somewhere in the
+  twenty days Aug 20 -> Sep 3 and is NOT identified (best untested candidate:
+  `7cb213c43`, lan9118 RX driven from the interrupt, which fits "delivers by
+  hand, nothing under the harness").
+  **Corollary that outlives the issue: this cell can never regression-test
+  0906**, and nothing else currently does.
+  NOT closed on "it passes now" — that is the reasoning that let the
+  stale-binary story stand in the first place.
   The `queue.c:1673` assert this issue also records is **issue 0899, already
   resolved** — the same 0906 session churn one layer down.
 * **W2 — [issue 0867](../issues/archived/0867-nuttx-c-action-goal-send-times-out.md).
@@ -169,11 +182,12 @@ server ordering cannot reach it. The phase does not shrink.
 Three of the five were unreadable rather than unfixed:
 
 * W2 was fixed on 2026-08-28 and nobody closed it.
-* W1's evidence predates issue 0906's fix by one day, and every built FreeRTOS
-  fixture still bakes the pre-fix `Z_TRANSPORT_LEASE 10000` while the source
-  says 60000 — with a staleness probe that reports FRESH, because the constant
-  lives in a build-script DEPENDENCY crate that never enters
-  `cargo:rerun-if-changed`.
+* W1's fixtures were baked 2026-08-20 and the staleness probe reported FRESH
+  for all of them, because the constant lives in a build-script DEPENDENCY
+  crate that never enters `cargo:rerun-if-changed` (#1005). A rebuild makes the
+  cell green — though NOT, as first written here, because of issue 0906: the
+  counterfactual passes too, so the fix is real and unattributed. And the cell
+  cannot see that constant in either direction, which is the sharper half.
 * W3 could not be read at all: NuttX had no `printk` arm, so every shim
   diagnostic compiled away.
 * W5's own mitigation had been unreachable for nine days behind a


### PR DESCRIPTION
Follow-up to #268 (phase-414), which merged while this verification was running. W1's result arrived after that branch entered the merge queue and could no longer be updated.

## The cell is green

Rebuilt via the sanctioned `just build freertos` (exit 0), bake verified to read `60000` **before** running anything, then `test_rtos_pubsub_e2e` FreeRTOS solo, `--test-threads 1 --retries 0`, 3 rounds × 3 languages:

**9 of 9 PASS** — C, C++ and Rust, 12 published / 12 heard every run, ~35.4 s each, zero loss, no STALE verdict. Issue 0877's symptom does not reproduce.

**Issue #1005 confirmed independently:** every live FreeRTOS zenoh fixture was baked **2026-08-20**, ten days before the constant changed, and the staleness probe reported FRESH for all of them.

| | before | after |
| --- | --- | --- |
| C++ fixtures | `10000` ×12, mtime **2026-08-20 22:31** | `60000` ×12 |
| Rust fixtures | `10000`, mtime **2026-08-20 21:53** | `60000` |

## And the attribution in #268 is wrong

#268 said 0877 "probably predates its own fix" and named issue 0906. The green is real; **that attribution is refuted — by counterfactual, not by doubt.**

Put `Z_TRANSPORT_LEASE_MS` back to `10_000`, rebuild, verify the bake reads `10000`, run C and C++ 3× each:

> **6 of 6 PASS, 12 published / 12 heard — identical to the fixed build.**

The arithmetic says why. The cell kills its talker 15 s in (`wait_for_output`, a run-to-completion wait aimed at a free-running 1 Hz publisher), so it emits exactly **12** publishes; the first lease lapse is at ~20 s of session life. The window closes before the lapse. **The constant is invisible to this cell.**

So the rebuild fixed it and 0906 did not. The real cause is somewhere in Aug 20 → Sep 3 and is **not identified**. Best untested candidate: `7cb213c43` (lan9118 RX driven from the interrupt rather than a 5 ms poll), which fits "delivers by hand, nothing under the harness". Bisecting is separate work.

## The corollary, which outlives both issues

**This cell can never regression-test 0906**, and nothing else does. The constant is unprotected in *both* directions — the probe cannot see it change (#1005), and the cell cannot see it be wrong. Fixing the probe alone leaves half the gap open. Recorded on both issues.

## Not closed

0877 stays open. The symptom is gone but the cause is unidentified, and "it passes now" is precisely the reasoning that let the stale-binary story stand in the first place.

Also corrected: the `verdict t~65` timeline #268 predicted does not hold — every run finished in 35.4 s.

Docs only. `just check fast`: 186 gates, 3 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
