### PR TITLE
fix(#0741, #1009): the 28-byte sample belongs to a foreign peer on another host

### DIFF
--- a/docs/issues/1009-interop-bus-is-not-isolated-from-the-lan.md
+++ b/docs/issues/1009-interop-bus-is-not-isolated-from-the-lan.md
@@ -1,0 +1,107 @@
+---
+id: 1009
+title: "Our DDS interop tests share a bus with the whole LAN, so a foreign peer
+  on another host can fail them — and `ROS_LOCALHOST_ONLY=1` alone does NOT fix it"
+status: open
+type: bug
+area: testing, ci
+severity: high
+found: 2026-09-03
+related: [issue-0741, issue-0707, issue-0927, phase-414]
+---
+
+## What happened
+
+Issue 0741 spent fifteen sections and four wrong diagnoses on a 28-byte DDS
+reply that Fast-DDS refused into a 15-byte reader history. The sample was not
+ours. It came from **a CycloneDDS `add_two_ints_server` on a different host**
+(`arm-a100`, 10.2.15.142; this host is 10.2.15.118), which is squatting **35 ROS
+domains** — 1, 2, 3, 4, 5, 10, 12, 20, 27, 29, 31, 36, 40, 42, 46, 47, 49, 59,
+65, 67, 68, 69, 70, 72, 81, 82, 83, 84, 85, 86, 89, 90, 93, 99 — one participant
+each, all announcing `__ProcessName=add_two_ints_server`,
+`__Hostname=arm-a100`, CycloneDDS 0.10.5.
+
+**The repro 0741 never had, and it needs none of our code:**
+
+    $ ROS_DOMAIN_ID=1 ros2 service call /add_two_ints \
+        example_interfaces/srv/AddTwoInts "{a: 5, b: 3}"
+    [RTPS_READER_HISTORY Error] Change payload size of '28' bytes is larger than
+    the history payload size of '15' bytes and cannot be resized.
+
+3 of 3 here, 5 of 5 in the original measurement. No nano-ros process, no XRCE
+agent, nothing of ours running. Domain 9 is empty and is the control.
+
+The 28 bytes are the **rmw_cyclonedds** request/reply mapping
+(`[client GUID 8][seq 8][response 8]`): the Cyclone server read a Fast-DDS
+request — which carries only the payload, with the identity in inline QoS
+`PID 0x800f RELATED_SAMPLE_IDENTITY` — as its own header, giving
+`guid=5, seq=3, sum=0`. The two service mappings are not interoperable. Bytes
+measured; that interpretation inferred.
+
+## Why this is OUR issue and not just someone else's stray process
+
+Killing those 35 orphans fixes today. It does not fix the class: **our interop
+tests discover on whatever multicast the host can reach**, so any DDS
+participant on the LAN — a colleague's laptop, a robot, a CI runner — is a
+peer. This has now cost one issue weeks of misdirected work, and the same shape
+already appeared in issue 0927 (a probe alone on a domain enumerating itself)
+and issue 0707 (stepping off a busy SPDP port).
+
+**And the intermittency was never randomness.** `dds_bus_snapshot`
+(`packages/testing/nros-tests/src/ros2.rs:2037`) runs `ros2 node list` /
+`service list` / `topic list` WITHOUT `--no-daemon`, unlike its three siblings
+at lines 762/775/948. Every failing run therefore leaves a ros2 daemon on that
+domain; `domain_discovery_port_busy` then reads the port as busy and the next
+run steps to the NEXT domain. After two failures the run lands on a domain with
+no foreign peer and can never fail again. That is exactly the 1-fail-then-45-
+green pattern 0741 recorded and could not explain.
+
+## `ROS_LOCALHOST_ONLY=1` IS NOT THE FIX — measured
+
+| batch | condition | domain | pass / fail |
+| --- | --- | ---: | ---: |
+| D | per-run daemon kill, UDP-only profile | 1 | 12 / **3** |
+| F | `ROS_LOCALHOST_ONLY=1` alone | 1 | **0 / 15** |
+| G | Fast-DDS `interfaceWhiteList 127.0.0.1`, BOTH processes | 1 | **15 / 15** |
+
+`ROS_LOCALHOST_ONLY=1` alone gives 0 of 15 — empty client output, no history
+error at all — because **the XRCE Agent is a bare Fast-DDS application, not a
+ROS process**, so it ignores the variable and the two stop discovering each
+other. A variable that isolates one side of a pair is worse than none: it turns
+a wrong answer into no answer.
+
+What is measured to work is a `FASTRTPS_DEFAULT_PROFILES_FILE` whose transport
+declares `<interfaceWhiteList><address>127.0.0.1</address></interfaceWhiteList>`,
+exported so BOTH the peer and the Agent use it: 15 of 15 on the poisoned domain.
+
+Note also that a custom `userTransports` profile DEFEATS `ROS_LOCALHOST_ONLY`,
+so the two must not be combined naively (batch E: 9/6, confounded).
+
+Cyclone lanes need the `CYCLONEDDS_URI` equivalent; that is not yet written.
+
+## Direction
+
+1. **Isolate the interop bus to loopback, for every DDS lane and for the Agent
+   too.** The profile route above is measured; the Cyclone equivalent is not.
+   This is the fix that survives the LAN.
+2. **`dds_bus_snapshot` must pass `--no-daemon`** like its siblings. Worth doing
+   regardless — but note it could never have caught this anyway: `ros2 service
+   list` collapses a service to one NAME however many servers offer it, and the
+   helper's own comment pre-explains an empty `[nodes]` as normal, which is
+   exactly where `/add_two_ints_server` would have appeared.
+3. **`domain_discovery_port_busy` is local-only by design** — its doc-comment
+   says so — and is therefore structurally blind to a REMOTE squatter. Worth
+   stating in issue 0707's terms rather than changing: a local port probe cannot
+   answer a question about the LAN.
+
+## Acceptance
+
+With the 35 foreign participants still live, the XRCE service interop cell
+passes on a poisoned domain (1 or 5), repeatedly, with no per-run domain
+walking.
+
+## Not covered
+
+The orphans themselves. `arm-a100` is a different machine and clearing it needs
+access to that host; it is the direct cause of today's failures and none of the
+fix above depends on it.

--- a/docs/issues/archived/0741-xrce-service-reply-history-payload-too-small.md
+++ b/docs/issues/archived/0741-xrce-service-reply-history-payload-too-small.md
@@ -2,7 +2,7 @@
 id: 741
 title: "`test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the
   28-byte reply into a 15-byte history payload"
-status: open
+status: resolved
 type: bug
 area: rmw, testing
 related: [issue-0736, issue-0776]
@@ -1222,3 +1222,88 @@ Non-root alternative worth trying first: force the client's reply reader to
 `PREALLOCATED_WITH_REALLOC` via `FASTRTPS_DEFAULT_PROFILES_FILE` +
 `RMW_FASTRTPS_USE_QOS_FROM_XML=1`, so the sample is accepted and its CONTENT
 becomes visible. Caveat: it changes the client's QoS and may mask the failure.
+
+## RESOLVED 2026-09-03 — the 28-byte sample is a FOREIGN peer's, on another host
+
+**It was never our defect.** Not the agent pin, not Fast-CDR skew, not type
+registration, not the missing size advertisement, not the reply framing. The
+15-byte reader history is correct, our reply is 12 bytes, and the 28-byte
+sample comes from a machine this repo does not run on.
+
+### The repro this issue never had, and it uses none of our code
+
+    $ ROS_DOMAIN_ID=1 ros2 service call /add_two_ints \
+        example_interfaces/srv/AddTwoInts "{a: 5, b: 3}"
+    [RTPS_READER_HISTORY Error] Change payload size of '28' bytes is larger than
+    the history payload size of '15' bytes and cannot be resized.
+
+3 of 3 on re-verification here, 5 of 5 in the original measurement. **No
+nano-ros process, no XRCE agent, nothing of ours running.** Domain 9 is empty
+and is the control.
+
+### The writer, identified
+
+A CycloneDDS `add_two_ints_server` on **`arm-a100` = 10.2.15.142** (this host is
+10.2.15.118), squatting **35 ROS domains** including 1-5. Writer GUID
+`0110ba9bee88c773100c4688.00001503` — `0110` is the Cyclone vendor id — peer
+`10.2.15.142:52724`, topic `rr/add_two_intsReply`, payload 28 B:
+
+    00010000 | 0500000000000000 0300000000000000 0000000000000000
+
+That is the **rmw_cyclonedds** request/reply mapping `[client GUID 8][seq 8]
+[response 8]`. The Cyclone server read our Fast-DDS request — which carries only
+`a=5, b=3` in the payload, with the identity in inline QoS `PID 0x800f
+RELATED_SAMPLE_IDENTITY` — as its own header, hence `guid=5, seq=3, sum=0`. The
+two service mappings are not interoperable. Bytes measured; that reading
+inferred.
+
+Captured without root: `tshark`/`dumpcap` are absent and `tcpdump` has no
+capabilities, so an `LD_PRELOAD` interposer on `sendto`/`recvfrom` logged the
+RTPS datagrams instead, plus a passive SPDP scanner that binds the discovery
+multicast ports and sends nothing.
+
+### It also explains the intermittency — which was never randomness
+
+Request-side, from the wire: a PASSING run writes the request to BOTH
+`127.0.0.1:7661` (our Agent) and `10.2.15.142:58782`. A FAILING run writes it
+**only** to the foreign peer. That is the `read_fn=0 / write=0` agent trace from
+the section above, confirmed from outside the agent.
+
+`wait_for_service` is satisfied by whichever server is seen first; when our
+Agent's replier is not yet matched at request-write time (RELIABLE + VOLATILE),
+only the foreign reader gets it.
+
+And the "1 fail then 45 green" shape has a mechanism: `dds_bus_snapshot` ran
+`ros2 node list` etc. WITHOUT `--no-daemon`, so every failing run left a ros2
+daemon on that domain, `domain_discovery_port_busy` read the port as busy, and
+the next run stepped to the NEXT domain — walking the test off the poisoned
+domains onto domain 9, which has no foreign peer and can never fail. A
+reproduction of that walk went 1 -> 5 -> 9 exactly.
+
+**So every measurement in this issue, mine included, was taken on a bus whose
+occupants nobody had enumerated.**
+
+### What is being FIXED, and what is not
+
+Fixed here: `dds_bus_snapshot` now passes `--no-daemon` like its three siblings,
+so a failing run stops walking itself off the evidence. Necessary, not
+sufficient — that probe could not have caught this anyway, because `ros2 service
+list` collapses a service to one NAME however many servers offer it, so the
+"SECOND `/add_two_ints`" its own comment hopes for never appears as a row.
+
+Filed as **issue 1009**: our interop bus is not isolated from the LAN, and
+`ROS_LOCALHOST_ONLY=1` alone is measured NOT to fix it — 0 of 15, because the
+XRCE Agent is a bare Fast-DDS application and ignores the variable, so the two
+sides stop discovering each other. A `FASTRTPS_DEFAULT_PROFILES_FILE` with an
+`interfaceWhiteList` of `127.0.0.1`, exported for BOTH processes, is measured at
+15 of 15 on a poisoned domain.
+
+Not covered: the 35 orphans on `arm-a100`, which need access to that host.
+
+### For the record, the wrong diagnoses this issue accumulated
+
+Five, including one of mine. The reply-framing story (`28 = 4 + 24`, the Agent
+mis-slicing a SampleIdentity) was mine, and it was refuted twice — first by the
+agent trace showing it wrote nothing, then by this, showing it was never asked
+to. Every one of the five was reached by reading code and return codes. The
+thing that settled it was asking who else was on the wire.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -18,7 +18,6 @@ fails if this block drifts.
 - **#0259** (orchestration) — Derived scheduling is quantitatively inert — no WCET in the model, so blocking is unmodelled and budget/placement/non_preempt can't be derived See `0259-*`.
 - **#0506** (embedded) — Transport tasks above application tiers is the right default but has no budget — inbound overload preempts every tier for ~200 ms bursts See `0506-*`.
 - **#0736** (core, platform, testing) — `realtime_tiers` nuttx-arm/rust: the fast tier now outruns the slow one but only ~2.4x against a 3x bar — was a 10x inversion, now a marginal shortfall See `0736-*`.
-- **#0741** (rmw, testing) — `test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the 28-byte reply into a 15-byte history payload See `0741-*`.
 - **#0758** (core, boards) — No platform wall-clock epoch source — embedded consumers hand-roll SNTP before boot, and stamped messages are wrong until they do See `0758-*`.
 - **#0760** (orchestration, rmw) — RFC-0074's `ingress` declaration is a ros-launch-manifest schema change, not a nano-ros one — park it until that discussion happens See `0760-*`.
 - **#0772** (platform, boards) — FreeRTOS/lwIP has no wall-clock epoch — the same consumer that drove the Zephyr one runs a FreeRTOS board too See `0772-*`.
@@ -82,5 +81,6 @@ fails if this block drifts.
 - **#1001** (tooling, ci) — `check-action-client-arena-budget` walks the whole repo, so `check fast` costs minutes on a cold page cache — the pre-push gate is where that is felt See `1001-*`.
 - **#1005** (testing, build) — A zenoh constant that lives in `nros-zpico-build` is invisible to the fixture staleness probe, so a fixture baked before a fix reports FRESH See `1005-*`.
 - **#1007** (testing, build) — `just nuttx build-fixtures-arm` can leave every arm cell unrunnable, and the remedy it prints is the command that just short-circuited See `1007-*`.
+- **#1009** (testing, ci) — Our DDS interop tests share a bus with the whole LAN, so a foreign peer on another host can fail them — and `ROS_LOCALHOST_ONLY=1` alone does NOT fix it See `1009-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/packages/testing/nros-tests/src/ros2.rs
+++ b/packages/testing/nros-tests/src/ros2.rs
@@ -2045,12 +2045,29 @@ pub fn dds_bus_snapshot(distro: &str, domain_id: u8) -> String {
     // agent creates DDS participants on behalf of its clients, and those are not
     // ROS nodes. `services` and `topics` are where a foreign endpoint shows up —
     // a SECOND `/add_two_ints`, or a reply topic nobody in this test created.
+    //
+    // Issue 1009 — `--no-daemon` on every one, like the three sibling probes at
+    // the top of this file. Without it each call STARTS a ros2 daemon on this
+    // domain and leaves it running; `domain_discovery_port_busy` then reads the
+    // port as busy and the next run steps to the NEXT domain. That is not a
+    // tidiness point: it silently walks a failing test off the domain that made
+    // it fail, so a real, reproducible failure presents as "one red then dozens
+    // of greens" — which is exactly the pattern issue 0741 recorded and could
+    // not explain, while a foreign CycloneDDS server sat on domains 1 and 5.
+    //
+    // Note this probe could not have caught 0741 even so: `ros2 service list`
+    // collapses a service to one NAME however many servers offer it, so the
+    // "SECOND /add_two_ints" the comment above hopes for never appears as a
+    // second row. Fixing the daemon leak is necessary, not sufficient.
     for (label, sub) in [
-        ("nodes", "node list"),
-        ("services", "service list -t"),
+        ("nodes", "node list --no-daemon"),
+        ("services", "service list -t --no-daemon"),
         // Hidden topics included: a service's request/reply pair is hidden, and
         // hiding them is precisely what would keep a foreign endpoint invisible.
-        ("topics", "topic list -t --include-hidden-topics"),
+        (
+            "topics",
+            "topic list -t --include-hidden-topics --no-daemon",
+        ),
     ] {
         let out = std::process::Command::new("bash")
             .args(["-c", &format!("{env} && timeout 10 ros2 {sub} 2>&1")])


### PR DESCRIPTION
Closes #0741. Files #1009.

**Issue 0741 was never our defect.** Not the agent pin, not Fast-CDR skew, not type registration, not the missing size advertisement, not the reply framing. The 15-byte reader history is correct, our reply is 12 bytes, and the 28-byte sample comes from a machine this repo does not run on.

## The repro the issue never had — and it uses none of our code

```
ROS_DOMAIN_ID=1 ros2 service call /add_two_ints \
    example_interfaces/srv/AddTwoInts "{a: 5, b: 3}"

[RTPS_READER_HISTORY Error] Change payload size of '28' bytes is larger than
the history payload size of '15' bytes and cannot be resized.
```

3 of 3 on re-verification, 5 of 5 originally. **No nano-ros process, no XRCE agent, nothing of ours running.** Domain 9 is empty and is the control.

## The writer

A CycloneDDS `add_two_ints_server` on **`arm-a100` (10.2.15.142)**; this host is 10.2.15.118. It squats **35 ROS domains** including 1–5. Writer GUID `0110ba9bee88c773100c4688.00001503` — `0110` is the Cyclone vendor id.

The 28 bytes are the **rmw_cyclonedds** request/reply mapping `[client GUID 8][seq 8][response 8]`. The Cyclone server read a Fast-DDS request — payload only, identity in inline QoS `PID 0x800f` — as its own header, giving `guid=5, seq=3, sum=0`. The two service mappings are not interoperable. Bytes measured; that reading inferred.

Captured **without root** (tshark/dumpcap absent, tcpdump has no capabilities): an `LD_PRELOAD` interposer on `sendto`/`recvfrom`, plus a passive SPDP scanner that binds the discovery ports and sends nothing.

## It also explains the intermittency, which was never randomness

From the wire: a **passing** run writes the request to *both* `127.0.0.1:7661` (our Agent) and `10.2.15.142:58782`. A **failing** run writes it *only* to the foreign peer. That is the `read_fn=0 / write=0` agent trace, confirmed from outside the agent.

## What this PR fixes

`dds_bus_snapshot` ran `ros2 node list` / `service list` / `topic list` **without `--no-daemon`**, unlike its three siblings at `ros2.rs:762/775/948`. Every failing run therefore left a ros2 daemon on that domain; `domain_discovery_port_busy` read the port as busy, and the next run stepped to the **next** domain — walking the test off the poisoned domains onto domain 9, which has no foreign peer and can never fail.

That is exactly the *"1 fail then 45 green"* shape 0741 recorded and could not explain. A reproduction of the walk went 1 → 5 → 9.

**Necessary, not sufficient**, and the comment says so: that probe could not have caught this anyway, because `ros2 service list` collapses a service to one *name* however many servers offer it — so the "SECOND `/add_two_ints`" its own comment hopes for never appears as a row.

## #1009 — the real remaining work

Our interop bus is not isolated from the LAN. **`ROS_LOCALHOST_ONLY=1` alone is measured NOT to fix it — 0 of 15**, because the XRCE Agent is a bare Fast-DDS application, not a ROS process, so it ignores the variable and the two sides stop discovering each other. A variable that isolates one half of a pair turns a wrong answer into no answer.

| condition | domain | pass / fail |
| --- | ---: | ---: |
| per-run daemon kill, UDP-only profile | 1 | 12 / **3** |
| `ROS_LOCALHOST_ONLY=1` alone | 1 | **0 / 15** |
| Fast-DDS `interfaceWhiteList 127.0.0.1`, **both** processes | 1 | **15 / 15** |

## Five wrong diagnoses, one of them mine

0741 accumulated five, including my own `28 = 4 + 24` reply-framing story — refuted twice, first by the agent trace showing it wrote nothing, then by this, showing it was never asked to. Every one was reached by reading code and return codes. What settled it was asking who else was on the wire.

`just check fast`: 189 gates OK. `cargo check -p nros-tests --tests`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
