### PR TITLE
docs(#0877, #1013): accept W1 green with the cause unattributed, and file the talker-kill defect

### DIFF
--- a/docs/issues/1013-pubsub-cell-kills-its-talker-after-12-publishes.md
+++ b/docs/issues/1013-pubsub-cell-kills-its-talker-after-12-publishes.md
@@ -1,0 +1,63 @@
+---
+id: 1013
+title: "`test_rtos_pubsub_e2e` SIGKILLs its talker after ~12 publishes, so the
+  cell exercises twelve seconds of a free-running publisher"
+status: open
+type: bug
+area: testing
+severity: medium
+found: 2026-09-03
+related: [issue-0877, issue-0906, issue-1005, phase-414]
+---
+
+## What happens
+
+`wait_for_output` is a RUN-TO-COMPLETION wait — its own doc-comment says "wait
+for QEMU to produce output *and exit*" — and `rtos_e2e.rs:729` aims it at a
+free-running 1 Hz publisher with a 15 s window (`:725`). When the window
+expires, `qemu.rs:448` `kill_process_group`s the guest.
+
+    listener t=0 -> stabilization_delay 20 s -> talker t=20
+    -> SIGKILL t~35 -> verdict t~35
+
+MEASURED, all three languages, every run: the talker emits exactly **12**
+publishes and is then killed. The service and action shapes do not do this —
+they use `collect_until` and let the long-lived server run the whole window.
+
+## Why it matters
+
+**It silently bounds what the cell can observe.** Anything whose period exceeds
+~12 s of session life is invisible to it, and the cell reports PASS regardless.
+
+That is not hypothetical. Issue 0906 fixed `Z_TRANSPORT_LEASE` 10 s -> 60 s
+because a 10 s lease against a 30 s router keep-alive expired every session.
+Measured while accepting issue 0877: **rebuilding with the OLD 10 s lease still
+passes this cell 6 of 6**, because the first lapse is at ~20 s of session life
+and the window closes first.
+
+So this cell cannot regression-test 0906, and nothing else does. Issue 1005 is
+the other half — the staleness probe cannot see that constant change either, so
+it is unprotected in both directions.
+
+## Direction
+
+Not settled; the choice is about what the cell is FOR.
+
+1. **Use the shape the sibling cells use.** `collect_until` with a predicate on
+   messages received, letting the publisher run, is what service and action do
+   and why they are not subject to this.
+2. **Raise the window** past the longest period the cell must be able to see.
+   Cheapest, and it needs a stated number rather than a guess — the lease is 60 s,
+   so a window under that keeps 0906 invisible.
+3. **Leave the window and state the bound.** Legitimate if the cell is only ever
+   meant to prove first-delivery, but then something else must cover session
+   lifetime, and today nothing does.
+
+Whichever lands, the acceptance is the counterfactual: build with
+`Z_TRANSPORT_LEASE_MS = 10_000` and require the cell to FAIL.
+
+## Not covered
+
+Whether the same run-to-completion shape is aimed at other free-running
+producers elsewhere in the harness. `wait_for_output` has other callers and they
+have not been swept.

--- a/docs/issues/archived/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md
+++ b/docs/issues/archived/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md
@@ -2,10 +2,10 @@
 id: 877
 title: "FreeRTOS pubsub delivers by hand and delivers NOTHING under the test
   harness — and the talker trips a FreeRTOS queue assert"
-status: open
+status: resolved
 type: bug
 area: testing, boards
-related: [issue-0891, issue-0830, issue-0387, issue-0906, issue-0899, issue-1005]
+related: [issue-0891, issue-0830, issue-0387, issue-0906, issue-0899, issue-1005, issue-1013]
 ---
 
 ## Symptom
@@ -238,3 +238,44 @@ this is not being closed on "it passes now" — that is precisely the reasoning
 that let the stale-binary story stand. It stays open pending either a bisect
 across the Aug-20..Sep-3 range or a decision that a green cell with an
 unattributed fix is acceptable to close.
+
+## CLOSED 2026-09-04 — accepted green, with the cause UNATTRIBUTED
+
+Owner decision, and the reason it is a decision rather than a conclusion: the
+symptom is gone and reproducibly so, but **nothing here identifies what fixed
+it**.
+
+What is established:
+
+* The cell passes 9 of 9, three languages, `--retries 0`, 12 published / 12
+  heard, ~35 s each.
+* The fixtures that produced this report were baked 2026-08-20 and the staleness
+  probe called them FRESH (issue 1005).
+* It is **not** issue 0906. The counterfactual — rebuild with the old 10 s lease
+  — also passes 6 of 6.
+
+What is NOT established, and is being accepted as unknown rather than quietly
+dropped: **which change between 2026-08-20 and 2026-09-03 actually fixed it.**
+The best untested candidate is `7cb213c43` (lan9118 RX driven from the
+interrupt rather than a 5 ms poll), which fits "delivers by hand, nothing under
+the harness". Nobody bisected the range.
+
+### What that costs, stated plainly
+
+If the real fix is later reverted or refactored, this symptom returns and this
+issue will not be the thing that catches it — because the cell that would notice
+is bounded (issue 1013) and the probe that would notice is blind (issue 1005).
+Closing this is a judgement that the residual risk is acceptable, not a claim
+that the risk is zero.
+
+### The two findings that outlive it, filed so they do not close with it
+
+* **Issue 1013** — the cell SIGKILLs its talker after ~12 publishes, so it can
+  never see anything with a period beyond ~12 s of session life. That is what
+  makes 0906 invisible to it.
+* **Issue 1005** — the staleness probe cannot see a constant that lives in a
+  build-script dependency crate. Together these leave `Z_TRANSPORT_LEASE`
+  unprotected in both directions.
+
+Reopen if the symptom returns; the bisect over Aug 20 -> Sep 3 is the first
+thing to do if it does.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -47,7 +47,6 @@ fails if this block drifts.
 - **#0871** (ci, testing) — Every PR is red on a fixture CI never builds — and `main` cannot see it, because the required gate does not run on push See `0871-*`.
 - **#0872** (ci) — The PR/nightly check arm has never run to completion — each fix exposes the next environment gap See `0872-*`.
 - **#0874** (ci, tooling) — sccache 0.8.2 speaks a GitHub cache API that no longer exists — and because it is the `RUSTC_WRAPPER`, that fails every `rustc` See `0874-*`.
-- **#0877** (testing, boards) — FreeRTOS pubsub delivers by hand and delivers NOTHING under the test harness — and the talker trips a FreeRTOS queue assert See `0877-*`.
 - **#0880** (platform, embedded) — 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted — the Zephyr images place nothing in ITCM or DTCM See `0880-*`.
 - **#0895** (build) — `just format` is red or green depending on whether a migrated colcon workspace has been BUILT See `0895-*`.
 - **#0900** (core, memory) — Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use See `0900-*`.
@@ -81,5 +80,6 @@ fails if this block drifts.
 - **#1005** (testing, build) — A zenoh constant that lives in `nros-zpico-build` is invisible to the fixture staleness probe, so a fixture baked before a fix reports FRESH See `1005-*`.
 - **#1007** (testing, build) — `just nuttx build-fixtures-arm` can leave every arm cell unrunnable, and the remedy it prints is the command that just short-circuited See `1007-*`.
 - **#1009** (testing, ci) — Our DDS interop tests share a bus with the whole LAN, so a foreign peer on another host can fail them — and `ROS_LOCALHOST_ONLY=1` alone does NOT fix it See `1009-*`.
+- **#1013** (testing) — `test_rtos_pubsub_e2e` SIGKILLs its talker after ~12 publishes, so the cell exercises twelve seconds of a free-running publisher See `1013-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-414-rtos-runtime-correctness.md
+++ b/docs/roadmap/phase-414-rtos-runtime-correctness.md
@@ -38,7 +38,7 @@ with a stable reproduction and no owner.
 
 Each is an existing issue. The item is "close it"; the issue holds the evidence.
 
-* **W1 — [issue 0877](../issues/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md),
+* **W1 — [issue 0877](../issues/archived/0877-freertos-pubsub-passes-by-hand-fails-under-harness.md),
   FreeRTOS pubsub delivers NOTHING under the test. REDIAGNOSED, not yet
   closed.** The issue's evidence is dated 2026-08-29; issue **0906** (every
   zenoh-pico session dropping every ~20 s because `Z_TRANSPORT_LEASE` was 10 s
@@ -71,8 +71,11 @@ Each is an existing issue. The item is "close it"; the issue holds the evidence.
   hand, nothing under the harness").
   **Corollary that outlives the issue: this cell can never regression-test
   0906**, and nothing else currently does.
-  NOT closed on "it passes now" — that is the reasoning that let the
-  stale-binary story stand in the first place.
+  **CLOSED 2026-09-04, accepted green with the cause UNATTRIBUTED** — an
+  owner decision, not a conclusion. The residual risk is stated in the issue:
+  if the real fix is later reverted, this symptom returns and neither the cell
+  (bounded, issue 1013) nor the probe (blind, issue 1005) will catch it. The
+  bisect over Aug 20 -> Sep 3 is the first thing to do if it does.
   The `queue.c:1673` assert this issue also records is **issue 0899, already
   resolved** — the same 0906 session churn one layer down.
 * **W2 — [issue 0867](../issues/archived/0867-nuttx-c-action-goal-send-times-out.md).


### PR DESCRIPTION
Closes #0877 (accepted green). Files #1013.

## W1 accepted, with the cause unattributed

The FreeRTOS pubsub cell passes **9 of 9** — three languages, `--retries 0`, 12 published / 12 heard, ~35 s each. The symptom is gone and reproducibly so.

This is recorded as a **decision, not a conclusion**, because nothing identifies what fixed it:

- **Established** — 9/9 green; the fixtures that produced the original report were baked 2026-08-20 and the staleness probe called them FRESH (#1005).
- **Not established** — which change between Aug 20 and Sep 3 is the fix. It is **not** issue 0906: the counterfactual, rebuilt with the old 10 s lease, also passes 6 of 6. Best untested candidate is `7cb213c43` (lan9118 RX driven from the interrupt rather than a 5 ms poll). Nobody bisected the range.

The cost is stated in the issue rather than left implicit: **if the real fix is later reverted or refactored, this symptom returns and 0877 will not catch it** — because the cell that would notice is bounded (#1013) and the probe that would notice is blind (#1005). Accepting is a judgement that the residual risk is tolerable, not a claim that it is zero. The bisect is the first thing to do if it recurs.

## #1013 — and filing it is the point of this PR

The talker-kill defect was recorded *on* 0877. Archiving 0877 would have buried it: a real, measured finding closing with the issue that happened to surface it.

`wait_for_output` is a **run-to-completion** wait — its own doc-comment says "wait for QEMU to produce output *and exit*" — aimed at a free-running 1 Hz publisher with a 15 s window. Measured, every run, all three languages: **the talker emits exactly 12 publishes and is then killed.** The service and action shapes use `collect_until` and let the server run, which is why they are not subject to it.

That is precisely what makes 0906 invisible here. A build carrying the **old 10 s lease passes this cell 6 of 6**, because the first lapse is at ~20 s of session life and the window closes first.

Combined with #1005 — the staleness probe cannot see that constant change either, since it lives in a build-script *dependency* crate that never enters `cargo:rerun-if-changed` — `Z_TRANSPORT_LEASE` is unprotected in **both** directions. #1013's acceptance criterion is the counterfactual: build at `10_000` and require the cell to **fail**.

Docs only. `just check fast`: 190 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
