### PR TITLE
feat(phase-400 W6): five tenants — net, runtime, zenoh.wire, xrce, zenoh.limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,7 @@ dependencies = [
  "cc",
  "nros-build-paths",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-sizes-build",
 ]
 
@@ -2076,6 +2077,7 @@ version = "0.5.0"
 dependencies = [
  "cc",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-rmw-cffi",
  "nros-zephyr-build",
 ]
@@ -2100,6 +2102,7 @@ dependencies = [
  "nros-ghost-types",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-tests",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-platform-esp32-qemu",
  "nros-platform-mps2-an385",
  "nros-platform-stm32f4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -50,10 +50,10 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_RMW_MAX_NODES` | 4 | `packages/rmw/cffi` |
 | `NROS_RMW_MESSAGE_INFO_SLOTS` | 64 | `packages/rmw/cffi` |
 | `NROS_RMW_SUBSCRIBER_SLOTS` | 8 | `packages/rmw/cffi` |
-| `NROS_RUNTIME_COMPONENT_SLOT_BYTES` | 512 | `packages/api/nros` |
-| `NROS_RUNTIME_MAX_CELL_ENTITIES` | 8 | `packages/api/nros` |
-| `NROS_RUNTIME_MAX_CLASS_INSTANCES` | 2 | `packages/api/nros` |
-| `NROS_RUNTIME_MAX_COMPONENTS` | 4 | `packages/api/nros` |
+| `NROS_RUNTIME_COMPONENT_SLOT_BYTES` | computed — see `packages/api/nros/build.rs:47` | `packages/api/nros` |
+| `NROS_RUNTIME_MAX_CELL_ENTITIES` | computed — see `packages/api/nros/build.rs:70` | `packages/api/nros` |
+| `NROS_RUNTIME_MAX_CLASS_INSTANCES` | computed — see `packages/api/nros/build.rs:58` | `packages/api/nros` |
+| `NROS_RUNTIME_MAX_COMPONENTS` | computed — see `packages/api/nros/build.rs:41` | `packages/api/nros` |
 | `NROS_SERVICE_TIMEOUT_MS` | 30000 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `NROS_SMOLTCP_BUFFER_SIZE` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:57` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SMOLTCP_CONNECT_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:62` | `packages/drivers/net/nros-smoltcp` |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -38,6 +38,8 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_EXECUTOR_MAX_NODES` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SC` | 8 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SHUTDOWN_CBS` | 2 | `packages/core/nros-node` |
+| `NROS_FREERTOS_APP_STACK_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:851` | `packages/tooling/nros-platform-config` |
+| `NROS_FREERTOS_HEAP_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:850` | `packages/tooling/nros-platform-config` |
 | `NROS_KEYEXPR_STRING_SIZE` | 256 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `NROS_LET_BUFFER_SIZE` | 512 | `packages/tooling/nros-build-helpers` |
 | `NROS_MAX_ARRAY_LEN` | 32 | `packages/core/nros-params` |
@@ -63,11 +65,12 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SUBSCRIBER_BUFFER_SIZE` | computed — see `packages/core/nros-node/build.rs:171` | `packages/core/nros-node` **(conflicting defaults — see below)** |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:488` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:487` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:486` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
+| `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:849` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:977` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:976` | `packages/tooling/nros-platform-config` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:978` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_POLL_INTERVAL_MS` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:980` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_REPLY_BUF_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:979` | `packages/tooling/nros-platform-config` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_LARGE_SUBSCRIBERS` | 2 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -55,11 +55,11 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_RUNTIME_MAX_CLASS_INSTANCES` | 2 | `packages/api/nros` |
 | `NROS_RUNTIME_MAX_COMPONENTS` | 4 | `packages/api/nros` |
 | `NROS_SERVICE_TIMEOUT_MS` | 30000 | `packages/rmw/zenoh/nros-rmw-zenoh` |
-| `NROS_SMOLTCP_BUFFER_SIZE` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:31` | `packages/drivers/net/nros-smoltcp` |
-| `NROS_SMOLTCP_CONNECT_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:36` | `packages/drivers/net/nros-smoltcp` |
-| `NROS_SMOLTCP_MAX_SOCKETS` | 1 | `packages/drivers/net/nros-smoltcp` |
-| `NROS_SMOLTCP_MAX_UDP_SOCKETS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:26` | `packages/drivers/net/nros-smoltcp` |
-| `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:41` | `packages/drivers/net/nros-smoltcp` |
+| `NROS_SMOLTCP_BUFFER_SIZE` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:57` | `packages/drivers/net/nros-smoltcp` |
+| `NROS_SMOLTCP_CONNECT_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:62` | `packages/drivers/net/nros-smoltcp` |
+| `NROS_SMOLTCP_MAX_SOCKETS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:44` | `packages/drivers/net/nros-smoltcp` |
+| `NROS_SMOLTCP_MAX_UDP_SOCKETS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:52` | `packages/drivers/net/nros-smoltcp` |
+| `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:67` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIBER_BUFFER_SIZE` | computed — see `packages/core/nros-node/build.rs:171` | `packages/core/nros-node` **(conflicting defaults — see below)** |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -21,9 +21,9 @@ moves with it.
 
 | pool | bytes at default | formula | declared in |
 | --- | ---: | --- | --- |
-| `LARGE_PAYLOADS` | 131,072 | `ZPICO_MAX_LARGE_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:200` |
+| `LARGE_PAYLOADS` | — (knob `ZPICO_SUBSCRIBER_RING_DEPTH` has a computed default) | `ZPICO_MAX_LARGE_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:200` |
 | `SLOTS` | 8,192 | `NROS_RMW_SUBSCRIBER_SLOTS * 1024` | `packages/rmw/cffi/src/rust_adapter.rs:111` |
-| `SMALL_PAYLOADS` | — (knob `NROS_SUBSCRIBER_BUFFER_SIZE` has a computed default) | `ZPICO_MAX_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * NROS_SUBSCRIBER_BUFFER_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:199` |
+| `SMALL_PAYLOADS` | — (knob `ZPICO_SUBSCRIBER_RING_DEPTH` has a computed default) | `ZPICO_MAX_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * NROS_SUBSCRIBER_BUFFER_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:199` |
 
 ## Every sizing knob
 
@@ -38,10 +38,10 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_EXECUTOR_MAX_NODES` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SC` | 8 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SHUTDOWN_CBS` | 2 | `packages/core/nros-node` |
-| `NROS_FREERTOS_APP_STACK_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:851` | `packages/tooling/nros-platform-config` |
-| `NROS_FREERTOS_HEAP_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:850` | `packages/tooling/nros-platform-config` |
-| `NROS_KEYEXPR_STRING_SIZE` | 256 | `packages/rmw/zenoh/nros-rmw-zenoh` |
-| `NROS_LET_BUFFER_SIZE` | 512 | `packages/tooling/nros-build-helpers` |
+| `NROS_FREERTOS_APP_STACK_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:893` | `packages/tooling/nros-platform-config` |
+| `NROS_FREERTOS_HEAP_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:892` | `packages/tooling/nros-platform-config` |
+| `NROS_KEYEXPR_STRING_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1061` | `packages/tooling/nros-platform-config` |
+| `NROS_LET_BUFFER_SIZE` | computed — see `packages/tooling/nros-build-helpers/src/c.rs:116` | `packages/tooling/nros-build-helpers` |
 | `NROS_MAX_ARRAY_LEN` | 32 | `packages/core/nros-params` |
 | `NROS_MAX_BYTE_ARRAY_LEN` | 256 | `packages/core/nros-params` |
 | `NROS_MAX_PARAMETERS` | 32 | `packages/core/nros-params` |
@@ -64,13 +64,14 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:67` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIBER_BUFFER_SIZE` | computed — see `packages/core/nros-node/build.rs:171` | `packages/core/nros-node` **(conflicting defaults — see below)** |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
-| `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:849` | `packages/tooling/nros-platform-config` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:977` | `packages/tooling/nros-platform-config` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:976` | `packages/tooling/nros-platform-config` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:978` | `packages/tooling/nros-platform-config` |
-| `ZPICO_GET_POLL_INTERVAL_MS` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:980` | `packages/tooling/nros-platform-config` |
-| `ZPICO_GET_REPLY_BUF_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:979` | `packages/tooling/nros-platform-config` |
+| `NROS_XRCE_CUSTOM_TRANSPORT_MTU` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:406` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
+| `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:264` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
+| `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:891` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1081` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1080` | `packages/tooling/nros-platform-config` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1082` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_POLL_INTERVAL_MS` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1084` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_REPLY_BUF_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1083` | `packages/tooling/nros-platform-config` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_LARGE_SUBSCRIBERS` | 2 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -83,7 +84,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_READ_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_SERVICE_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_LARGE_SIZE` | 16384 | `packages/rmw/zenoh/nros-rmw-zenoh` |
-| `ZPICO_SUBSCRIBER_RING_DEPTH` | 4 | `packages/rmw/zenoh/nros-rmw-zenoh` |
+| `ZPICO_SUBSCRIBER_RING_DEPTH` | computed — see `packages/rmw/zenoh/nros-rmw-zenoh/build.rs:50` | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_SIZE_THRESHOLD` | 2048 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 
 ## Conflicting defaults

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-04): W1-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params`, `rmw`, `net`, `runtime` and `zenoh.wire` tenants done, its remaining tenants
+`zenoh.tx`, `memory`, `params`, `rmw`, `net`, `runtime`, `zenoh.wire`, `xrce` and `zenoh.limits` tenants done, its remaining tenants
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -340,6 +340,32 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The singletons — five migrated, three with reasons not to
+
+`[knobs.xrce]` (`custom_transport_mtu`, `stream_history`),
+`[knobs.zenoh.limits]` (`keyexpr_string_size`, `subscriber_ring_depth`) and the
+LET buffer folded into `[knobs.runtime]`.
+
+**Three did NOT migrate, and each refusal is the interesting part.**
+
+`NROS_SERVICE_TIMEOUT_MS` has TWO readers by design — `nros-rmw-zenoh/build.rs`
+emits a Rust const and `nros-build-helpers`'s C emitter emits a `#define`, and a
+comment asked the next editor to keep the defaults equal. I migrated it, and
+`check-knob-single-reader` refused: a migrated knob gets exactly one reader, and
+that rule is precisely what stops the pair drifting. Both would have resolved
+through the same ladder and so could not disagree — but the gate cannot know
+that, and weakening it to say so trades a checked invariant for a comment.
+Migrating this knob means giving the pair ONE emission point first, which is a
+change to where the value is emitted rather than to the ladder.
+
+`NROS_ENTRY_SPIN_MS` is read by a proc macro, the C++ library and a C header.
+Same shape, three readers, and no single build script to own it.
+
+The two transport-band priorities stay out for the reasons in the `zenoh.wire`
+section above.
+
+Backlog after this: **5**, from 10.
 
 ### The `zenoh.wire` tenant — done, and the two priorities left out
 

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-04): W1-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params`, `rmw`, `net` and `runtime` tenants done, its remaining tenants
+`zenoh.tx`, `memory`, `params`, `rmw`, `net`, `runtime` and `zenoh.wire` tenants done, its remaining tenants
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -340,6 +340,39 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `zenoh.wire` tenant — done, and the two priorities left out
+
+Five wire sizes — the unicast and multicast batch buffers, the fragmentation
+ceiling, the get-reply staging block and its poll interval — now resolve through
+the ladder as `[knobs.zenoh.wire]`, beside the existing `[knobs.zenoh.tx]`.
+
+This does NOT contradict "the zenoh tenant is not W6's" above. That re-scope was
+about the entity CAPS and pools — `ZPICO_MAX_QUERYABLES`, `ZPICO_MAX_SESSIONS`,
+`SERVICE_BUFFERS` — which phase-392 is deciding the shape of. These five are
+sizes of the wire itself, and the same re-scope listed them as W6's remainder.
+
+**The two transport-band priorities are deliberately NOT here.**
+`ZPICO_READ_TASK_PRIORITY` and `ZPICO_LEASE_TASK_PRIORITY` look like the rest of
+the family and are not: the build script's defaults MIRROR the `#define`
+fallbacks in `zpico-sys/c/zpico/zpico.c`, and `FreertosScheduling` already
+carries a per-board `zenoh_read_priority` / `zenoh_lease_priority` in raw
+FreeRTOS units. A ladder rung would be a THIRD path to one number, which is the
+drift `check-knob-single-reader` exists to prevent. Their real question is
+ORDERING against the app tiers (issue 0623), which is a policy the board already
+expresses — not a size a platform defaults.
+
+The builtins stay the CALLER's: `nros-zpico-build` computes a batch and
+fragmentation size from the platform's transport before any descriptor is read,
+so `resolve_wire` takes them as its `defaults` and applies the rungs above them.
+
+Verification note, stated plainly: the resolver is pinned by a unit test over
+all four rungs. The build script's half is five straight-line assignments
+mirroring the tx trio two lines above them, and it is NOT verified by an
+emitted-artifact probe — the header it writes is produced inside example build
+trees, and every probe I wrote observed the wrong tree.
+
+Backlog after this: **10**, from 15.
 
 ### The `runtime` tenant — done
 

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-04): W1-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params` and `rmw` tenants done, its remaining tenants
+`zenoh.tx`, `memory`, `params`, `rmw` and `net` tenants done, its remaining tenants
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -340,6 +340,35 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `net` tenant — done, and the reason the reader moved
+
+Five smoltcp knobs — the TCP and UDP socket pools, the per-socket buffer, and
+the connect/socket timeouts — now resolve through the ladder: `NetKnobs`,
+`[knobs.net]`, `BuildRungs::net_rungs()`, and one reader in
+`packages/drivers/net/nros-smoltcp/build.rs`.
+
+**This tenant is why `nros-platform-config` exists.** `nros-smoltcp` could not
+depend on `nros-board-common`: cargo counts an optional dependency when it looks
+for cycles, and the board crate reaches back through `nros-platform ->
+nros-platform-esp32-qemu -> nros-smoltcp`. Every driver was locked out of the
+ladder. The reader moved to a leaf crate, and this is the first tenant to use it.
+
+Two things the rung does NOT flatten. `max_udp_sockets`'s builtin is
+FEATURE-derived (1 brokered, 4 with `rtps`), and it stays that way — a
+descriptor naming the knob outranks it, but a board that says nothing still gets
+the feature-appropriate number rather than a constant. And the deprecated
+`ZPICO_SMOLTCP_*` spellings rank WITH env, above the rungs, which is what a
+deprecated front-end should do.
+
+Verified against the build script's own emitted constants:
+
+    builtin        1 / 1 / 2048 / 10000
+    platform rung  3 / 2 /  512 /   250
+    env wins       MAX_SOCKETS=4, the rest keep the rung
+    legacy alias   ZPICO_SMOLTCP_BUFFER_SIZE=99 also outranks the rung
+
+Backlog after this: **19**, from 24.
 
 ### The `rmw` tenant — done, minus the one phase-412 took
 

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -341,6 +341,28 @@ census fix below), and its largest families are:
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
 
+### `NROS_ZEPHYR_HEAP_SIZE` — the blocker was gone and the note still said it was
+
+The census had carried, for two waves: *"BLOCKED: the ladder crate depends on
+`nros-platform`, so the rungs are a cycle away."* `nros-platform/build.rs` said
+the same in its own words — *"giving it the toml rungs would need the ladder
+types in a crate BELOW both — a real refactor, not a dependency line."*
+
+That refactor is `nros-platform-config`, extracted for the `net` tenant. Both
+notes went stale the moment it landed and neither was updated, because nothing
+re-reads a reason once it is written.
+
+The `memory` tenant had ALREADY mapped this knob —
+`("zephyr", "heap_bytes") => "NROS_ZEPHYR_HEAP_SIZE"` — so the ladder modelled
+it while its only reader could not consult it: a mechanism that was correct,
+tested, and unreachable, which is the shape phase-412 opened to clean up. The
+build script now resolves through `memory_value`, composing env, Kconfig via
+`$DOTCONFIG`, the platform/board rung, and the builtin.
+
+Verified: builtin 65536, platform rung 131072, env override 4096.
+
+Backlog: **4**.
+
 ### The singletons — five migrated, three with reasons not to
 
 `[knobs.xrce]` (`custom_transport_mtu`, `stream_history`),

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-04): W1-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params`, `rmw` and `net` tenants done, its remaining tenants
+`zenoh.tx`, `memory`, `params`, `rmw`, `net` and `runtime` tenants done, its remaining tenants
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -340,6 +340,29 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `runtime` tenant — done
+
+The four static pools the component runtime is carved from —
+`NROS_RUNTIME_MAX_COMPONENTS`, `..._COMPONENT_SLOT_BYTES`,
+`..._MAX_CLASS_INSTANCES`, `..._MAX_CELL_ENTITIES` — now resolve through the
+ladder: `RuntimeKnobs`, `[knobs.runtime]`, `BuildRungs::runtime_rungs()`, and
+one reader in `packages/api/nros/build.rs`.
+
+**phase-391 is a CONSUMER, not the owner.** It emits `config::MAX_COMPONENTS`
+and friends from these numbers and sizes the arena from them; it never decided
+their values. That is the same relationship `nros-node/build.rs` had with the
+executor knobs before this wave, and it is why the ownership check cleared:
+reading a knob is not owning it. phase-412 does not claim them either — its W1
+six and its W2 blocked-list both name other things.
+
+Verified against the emitted constants:
+
+    builtin        4 / 512 / 2 / 8
+    platform rung  9 / 256 / 5 / 3
+    env wins       MAX_COMPONENTS=12, the rest keep the rung
+
+Backlog after this: **15**, from 19.
 
 ### The `net` tenant — done, and the reason the reader moved
 

--- a/packages/api/nros/Cargo.toml
+++ b/packages/api/nros/Cargo.toml
@@ -17,6 +17,10 @@ readme = "README.md"
 # issue 0460 — the shared Kconfig-via-$DOTCONFIG knob fallback, so a Zephyr Rust
 # image reads the knobs Kconfig set rather than this crate's defaults.
 nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }
+# phase-400 W6 — the `[knobs.runtime]` platform/board rungs, from the LEAF
+# ladder crate (a board crate would be a cycle for anything the platform layer
+# reaches; see `nros-platform-config`).
+nros-platform-config = { path = "../../tooling/nros-platform-config" }
 
 [features]
 # phase-361 W3 / issue 0591 — EMPTY; `std` is opt-in per dep-site.

--- a/packages/api/nros/build.rs
+++ b/packages/api/nros/build.rs
@@ -23,25 +23,43 @@ use std::{env, path::Path};
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    // phase-400 W6 — the `[knobs.runtime]` platform/board rungs, resolved once.
+    // `None` when no lane named a platform, and the builtins below then stand.
+    //
+    // phase-391 emits the consts from these numbers and sizes the arena from
+    // them; it does not decide their VALUES. This is where a platform or board
+    // gets to, without an env var on the shell that happened to run the build.
+    let rungs = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.runtime_rungs())
+        .unwrap_or_default();
+
     // Component pool slots. `register_node::<C>()` is a runtime call so the
     // COUNT is not known at compile time, but the BOUND is — which is all a
     // static pool needs. Mirrors `NROS_EXECUTOR_MAX_NODES` (default 4) one
     // layer down; 4 leaves room for the multi-component entries codegen emits
     // without charging a single-node image for slots it never fills.
-    let max_components = env_usize("NROS_RUNTIME_MAX_COMPONENTS", 4);
+    let max_components = env_usize("NROS_RUNTIME_MAX_COMPONENTS", rungs.max_components, 4);
 
     // Per-slot byte budget for the type-erased `TypedSlot<C>`. A BYTE budget
     // rather than a type, because the pool is heterogeneous (`TypedSlot<C>` is
     // generic over `C`) and the FFI seam cannot name a generic. A component
     // whose slot does not fit is a registration error, not a compile error.
-    let component_slot_bytes = env_usize("NROS_RUNTIME_COMPONENT_SLOT_BYTES", 512);
+    let component_slot_bytes = env_usize(
+        "NROS_RUNTIME_COMPONENT_SLOT_BYTES",
+        rungs.component_slot_bytes,
+        512,
+    );
 
     // phase-391 W5.3b — instances of ONE component class the macro-emitted
     // per-class store can hold. Multi-instance is real: the launch path bakes
     // one identity per plan node and can name the same class twice. 2 covers
     // the pair case without charging every class for more; install past the
     // cap is a Full-style registration error, not silent reuse.
-    let max_class_instances = env_usize("NROS_RUNTIME_MAX_CLASS_INSTANCES", 2);
+    let max_class_instances = env_usize(
+        "NROS_RUNTIME_MAX_CLASS_INSTANCES",
+        rungs.max_class_instances,
+        2,
+    );
 
     // phase-391 W5 regression fix — entity-registry slots per COMPONENT CELL.
     // The first heapless conversion borrowed the metadata twin's 32, which is
@@ -49,7 +67,7 @@ fn main() {
     // ~152 B) — 4 components ate ~80 KiB of the 128 KiB bare-metal arena.
     // 8 is per-component-shaped (a component declaring more than 8 entities of
     // ONE KIND is rare and gets a loud registration error + this knob).
-    let max_cell_entities = env_usize("NROS_RUNTIME_MAX_CELL_ENTITIES", 8);
+    let max_cell_entities = env_usize("NROS_RUNTIME_MAX_CELL_ENTITIES", rungs.max_cell_entities, 8);
 
     let contents = format!(
         "/// Component pool slots (set via `NROS_RUNTIME_MAX_COMPONENTS`, default 4).\n\
@@ -73,6 +91,10 @@ fn main() {
     std::fs::write(Path::new(&out_dir).join("nros_runtime_config.rs"), contents).unwrap();
 }
 
-fn env_usize(name: &str, default: usize) -> usize {
-    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), default)
+/// phase-400 W6 — `rung` is the platform/board answer from `[knobs.runtime]`,
+/// and it sits between the Kconfig rung and the crate builtin. Passing it as
+/// `knob_usize`'s default is what places it there: env and `$DOTCONFIG` still
+/// win above it, and the builtin applies only where no descriptor spoke.
+fn env_usize(name: &str, rung: Option<usize>, default: usize) -> usize {
+    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), rung.unwrap_or(default))
 }

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -401,6 +401,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -474,6 +474,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -561,6 +561,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -462,6 +462,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-platform-mps2-an385",
  "nros-zephyr-build",
 ]

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -530,6 +530,7 @@ version = "0.5.0"
 dependencies = [
  "cc",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-rmw-cffi",
  "nros-zephyr-build",
 ]
@@ -543,6 +544,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -419,6 +419,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -346,6 +346,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -333,6 +333,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -406,6 +406,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "cc",
  "nros-build-paths",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-sizes-build",
 ]
 
@@ -443,6 +444,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -389,6 +389,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -471,6 +471,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "cc",
  "nros-build-paths",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-sizes-build",
 ]
 
@@ -443,6 +444,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -389,6 +389,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -471,6 +471,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -419,6 +419,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -346,6 +346,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -416,6 +416,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -343,6 +343,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -430,6 +430,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -350,6 +350,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -264,6 +264,32 @@ fn explain(args: ExplainArgs) -> Result<()> {
         );
     }
 
+    // phase-400 W6 — the component-runtime tenant. Defaults mirror
+    // `packages/api/nros/build.rs`, which stays the authority on them.
+    let runtime_defaults: &[(&str, usize)] = &[
+        ("max_components", 4),
+        ("component_slot_bytes", 512),
+        ("max_class_instances", 2),
+        ("max_cell_entities", 8),
+    ];
+    for (name, r) in tree
+        .resolve_runtime(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.runtime),
+            &env_get,
+            runtime_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?
+    {
+        println!(
+            "{:<34} {:<10} {}  [{}]",
+            format!("runtime.{name}"),
+            r.value,
+            r.source.as_str(),
+            r.env_key
+        );
+    }
+
     // phase-400 W6 — the smoltcp net tenant. Defaults mirror
     // `packages/drivers/net/nros-smoltcp/build.rs`, which stays the authority.
     // `max_udp_sockets` shows 1 here: its builtin is FEATURE-derived (4 with

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -264,6 +264,35 @@ fn explain(args: ExplainArgs) -> Result<()> {
         );
     }
 
+    // phase-400 W6 — the smoltcp net tenant. Defaults mirror
+    // `packages/drivers/net/nros-smoltcp/build.rs`, which stays the authority.
+    // `max_udp_sockets` shows 1 here: its builtin is FEATURE-derived (4 with
+    // `rtps`), and a cargo feature is not a fact this command can see.
+    let net_defaults: &[(&str, usize)] = &[
+        ("max_sockets", 1),
+        ("max_udp_sockets", 1),
+        ("buffer_size", 2048),
+        ("connect_timeout_ms", 30_000),
+        ("socket_timeout_ms", 10_000),
+    ];
+    for (name, r) in tree
+        .resolve_net(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.net),
+            &env_get,
+            net_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?
+    {
+        println!(
+            "{:<34} {:<10} {}  [{}]",
+            format!("net.{name}"),
+            r.value,
+            r.source.as_str(),
+            r.env_key
+        );
+    }
+
     // phase-400 W6 — the RMW static-pool tenant. Defaults mirror
     // `packages/rmw/cffi/build.rs`, which stays the authority on them.
     // `NROS_RMW_SUBSCRIBER_SLOTS` is absent on purpose: phase-412 W1 derives it.

--- a/packages/drivers/net/nros-smoltcp/Cargo.lock
+++ b/packages/drivers/net/nros-smoltcp/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +43,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -49,10 +61,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nb"
@@ -61,8 +89,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nros-build-paths"
+version = "0.5.0"
+
+[[package]]
 name = "nros-platform-api"
 version = "0.5.0"
+
+[[package]]
+name = "nros-platform-config"
+version = "0.5.0"
+dependencies = [
+ "nros-build-paths",
+ "serde",
+ "toml",
+]
 
 [[package]]
 name = "nros-smoltcp"
@@ -71,6 +112,7 @@ dependencies = [
  "embedded-nal",
  "nb",
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]
@@ -80,6 +122,63 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smoltcp"
@@ -99,3 +198,70 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]

--- a/packages/drivers/net/nros-smoltcp/Cargo.toml
+++ b/packages/drivers/net/nros-smoltcp/Cargo.toml
@@ -74,3 +74,9 @@ portable-atomic = { version = "1", default-features = false }
 # disables interrupts, which a hosted OS will not permit.
 [target.'cfg(all(target_os = "none", not(target_has_atomic = "ptr")))'.dependencies]
 portable-atomic = { version = "1", default-features = false, features = ["unsafe-assume-single-core"] }
+
+[build-dependencies]
+# phase-400 W6 — the `[knobs.net]` platform/board rungs. The LEAF ladder crate,
+# not `nros-board-common`: that one reaches back here through `nros-platform ->
+# nros-platform-esp32-qemu -> nros-smoltcp`, which cargo rejects as a cycle.
+nros-platform-config = { path = "../../../tooling/nros-platform-config" }

--- a/packages/drivers/net/nros-smoltcp/build.rs
+++ b/packages/drivers/net/nros-smoltcp/build.rs
@@ -22,26 +22,52 @@ fn main() {
     // to 4 (3 RTPS sockets/participant — default-unicast + metatraffic-unicast
     // + metatraffic-multicast — plus one spare) without anyone setting an env.
     let rtps = env::var_os("CARGO_FEATURE_RTPS").is_some();
-    let max_sockets = env_usize_compat("NROS_SMOLTCP_MAX_SOCKETS", "ZPICO_SMOLTCP_MAX_SOCKETS", 1);
+
+    // phase-400 W6 — the `[knobs.net]` platform/board rungs, resolved once.
+    // `None` when no lane named a platform (every out-of-tree consumer and every
+    // plain `cargo build`), and the builtins below then stand.
+    //
+    // Each rung is passed as `env_usize_compat`'s DEFAULT, which is what puts it
+    // in the right place on the ladder: `NROS_SMOLTCP_*` and its deprecated
+    // `ZPICO_SMOLTCP_*` alias still win above it, and a builtin applies only
+    // where no descriptor said anything.
+    //
+    // This crate reads the ladder from `nros-platform-config` rather than
+    // `nros-board-common`: the board crate reaches back here through
+    // `nros-platform -> nros-platform-esp32-qemu -> nros-smoltcp`, and cargo
+    // counts that as a cycle. The reader was moved to a leaf crate FOR this
+    // tenant.
+    let rungs = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.net_rungs())
+        .unwrap_or_default();
+
+    let max_sockets = env_usize_compat(
+        "NROS_SMOLTCP_MAX_SOCKETS",
+        "ZPICO_SMOLTCP_MAX_SOCKETS",
+        rungs.max_sockets.unwrap_or(1),
+    );
+    // The builtin here is FEATURE-derived, and a rung outranks it: a board that
+    // names the knob has said something specific, while `rtps` is a default good
+    // enough for a board that has not.
     let max_udp_sockets = env_usize_compat(
         "NROS_SMOLTCP_MAX_UDP_SOCKETS",
         "ZPICO_SMOLTCP_MAX_UDP_SOCKETS",
-        if rtps { 4 } else { 1 },
+        rungs.max_udp_sockets.unwrap_or(if rtps { 4 } else { 1 }),
     );
     let buffer_size = env_usize_compat(
         "NROS_SMOLTCP_BUFFER_SIZE",
         "ZPICO_SMOLTCP_BUFFER_SIZE",
-        2048,
+        rungs.buffer_size.unwrap_or(2048),
     );
     let connect_timeout_ms = env_usize_compat(
         "NROS_SMOLTCP_CONNECT_TIMEOUT_MS",
         "ZPICO_SMOLTCP_CONNECT_TIMEOUT_MS",
-        30_000,
+        rungs.connect_timeout_ms.unwrap_or(30_000),
     );
     let socket_timeout_ms = env_usize_compat(
         "NROS_SMOLTCP_SOCKET_TIMEOUT_MS",
         "ZPICO_SMOLTCP_SOCKET_TIMEOUT_MS",
-        10_000,
+        rungs.socket_timeout_ms.unwrap_or(10_000),
     );
 
     if max_sockets > 4 {

--- a/packages/drivers/serial/cmsdk-uart/Cargo.lock
+++ b/packages/drivers/serial/cmsdk-uart/Cargo.lock
@@ -137,6 +137,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/drivers/serial/stm32f4-usart/Cargo.lock
+++ b/packages/drivers/serial/stm32f4-usart/Cargo.lock
@@ -130,6 +130,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/platform/nros-platform/Cargo.toml
+++ b/packages/platform/nros-platform/Cargo.toml
@@ -204,6 +204,10 @@ nros-platform-esp32-qemu = { version = "0.4.0", path = "../../platform/nros-plat
 workspace = true
 
 [build-dependencies]
+# phase-400 W6 — the `[knobs.memory]` rungs, from the LEAF ladder crate. This
+# dependency was impossible before the reader was extracted: `nros-board-common`
+# reaches back to this crate.
+nros-platform-config = { path = "../../tooling/nros-platform-config" }
 # issue 0460 — the shared Kconfig-via-$DOTCONFIG knob fallback. A Zephyr RUST
 # image inherits none of the cmake `set(ENV{...})` knob exports, so a bare
 # environment read compiles the crate default whatever Kconfig says. Needed

--- a/packages/platform/nros-platform/build.rs
+++ b/packages/platform/nros-platform/build.rs
@@ -38,13 +38,26 @@ fn main() {
     // `$DOTCONFIG` (issue 0460). The platform states the value where a Zephyr
     // image already looks for it.
     //
-    // Giving it the toml rungs would need the ladder types in a crate BELOW
-    // both — a real refactor, not a dependency line.
-    let size = nros_zephyr_build::knob_usize(
-        "NROS_ZEPHYR_HEAP_SIZE",
-        "CONFIG_NROS_ZEPHYR_HEAP_SIZE",
-        DEFAULT_HEAP_SIZE,
-    );
+    // phase-400 W6 — and it NOW HAS the toml rungs. This comment used to end
+    // "giving it the toml rungs would need the ladder types in a crate BELOW
+    // both — a real refactor, not a dependency line", and that refactor
+    // happened: `nros-platform-config` is exactly that crate, extracted so the
+    // reader could reach crates `nros-board-common` cannot.
+    //
+    // The `memory` tenant already mapped this knob — `("zephyr", "heap_bytes")
+    // => "NROS_ZEPHYR_HEAP_SIZE"` — so the ladder modelled it while the only
+    // reader could not consult it. `memory_value` composes the whole ladder:
+    // env, then Kconfig via `$DOTCONFIG`, then the platform/board rung, then
+    // the builtin below.
+    let size = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.memory_value("heap_bytes", DEFAULT_HEAP_SIZE))
+        .unwrap_or_else(|| {
+            nros_zephyr_build::knob_usize(
+                "NROS_ZEPHYR_HEAP_SIZE",
+                "CONFIG_NROS_ZEPHYR_HEAP_SIZE",
+                DEFAULT_HEAP_SIZE,
+            )
+        });
 
     // `zephyr_heap.rs` keeps its `option_env!` read; this simply makes the
     // value it sees the RESOLVED one rather than whatever happened to be in

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-serdes",
  "nros-zephyr-build",

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -518,6 +518,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -453,6 +453,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -550,6 +550,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -485,6 +485,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-serdes",
  "nros-zephyr-build",

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/Cargo.toml
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/Cargo.toml
@@ -57,6 +57,8 @@ host-only-reason = "XRCE C FFI surface, built per-platform by cmake"
 nros-rmw-cffi = { version = "0.5.0", path = "../../cffi", default-features = false }
 
 [build-dependencies]
+# phase-400 W6 — the ladder rungs, from the LEAF crate.
+nros-platform-config = { path = "../../../tooling/nros-platform-config" }
 cc = "1"
 # issue 0383 — strict C diagnostics (implicit-function-declaration,
 # int-conversion) as ERRORS at every `cc::Build` below. One shared spelling.

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
@@ -256,7 +256,14 @@ fn main() {
     // targets that don't run server-side action callbacks can drop
     // from the default 16 (= 64 KiB per-session output buffer) to 8
     // or 4. `internal.h` enforces `>= 4`.
-    if let Some(v) = knob("NROS_XRCE_STREAM_HISTORY") {
+    // phase-400 W6 — the `[knobs.xrce]` rungs sit under the env front-end and
+    // above the builtins below.
+    let xrce_rungs = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.xrce_rungs())
+        .unwrap_or_default();
+    if let Some(v) = knob("NROS_XRCE_STREAM_HISTORY")
+        .or_else(|| xrce_rungs.stream_history.map(|n| n.to_string()))
+    {
         let n: u32 = v
             .parse()
             .unwrap_or_else(|_| panic!("NROS_XRCE_STREAM_HISTORY='{}' is not a number", v));
@@ -392,8 +399,17 @@ fn generate_uxr_config(
             // CUSTOM_TRANSPORT_MTU × STREAM_HISTORY`) by an order of
             // magnitude. Min 128 (smaller breaks the framing/header
             // assumptions); default tracks XRCE_TRANSPORT_MTU_DEFAULT.
-            &env::var("NROS_XRCE_CUSTOM_TRANSPORT_MTU")
-                .unwrap_or_else(|_| XRCE_TRANSPORT_MTU_DEFAULT.into()),
+            // phase-400 W6 — env, then the `[knobs.xrce]` rung, then the
+            // default. `knob` rather than a bare `env::var` so the Kconfig
+            // front-end reaches this the way it reaches the pool sizes above
+            // (issue 0460).
+            &knob("NROS_XRCE_CUSTOM_TRANSPORT_MTU")
+                .or_else(|| {
+                    nros_platform_config::platform_config::BuildRungs::from_build_env()
+                        .and_then(|r| r.xrce_rungs().custom_transport_mtu)
+                        .map(|n| n.to_string())
+                })
+                .unwrap_or_else(|| XRCE_TRANSPORT_MTU_DEFAULT.into()),
         )
         .replace("@UCLIENT_SHARED_MEMORY_MAX_ENTITIES@", "4")
         .replace("@UCLIENT_SHARED_MEMORY_STATIC_MEM_SIZE@", "10")

--- a/packages/rmw/zenoh/nros-rmw-zenoh/Cargo.toml
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/Cargo.toml
@@ -152,6 +152,8 @@ log = { workspace = true, optional = true }
 critical-section = { version = "1.2", optional = true }
 
 [build-dependencies]
+# phase-400 W6 — the ladder rungs, from the LEAF crate.
+nros-platform-config = { path = "../../../tooling/nros-platform-config" }
 # issue 0460 — `ZPICO_{SUBSCRIBER,SERVICE}_BUFFER_SIZE` are Kconfig knobs on
 # Zephyr, and the Rust lane never sees the cmake `set(ENV{...})` exports. One
 # spelling of the `$DOTCONFIG` fallback, shared with `nros-zpico-build`.

--- a/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
@@ -29,12 +29,29 @@ fn main() {
     // Bumping to 30 s covers the common slow-Zephyr action window; fast
     // services on POSIX still return in milliseconds so the wider cap
     // only matters when something is genuinely slow.
+    // phase-400 W6 — the `[knobs.zenoh.limits]` rungs. `None` when no lane named
+    // a platform, and the builtins below then stand.
+    let limits = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.zenoh_limit_rungs())
+        .unwrap_or_default();
+    // NOT a ladder knob, deliberately: this value is read HERE and in
+    // `nros-build-helpers`'s C emitter, because two artifacts embed it (a Rust
+    // const and a C define). `check-knob-single-reader` allows a migrated knob
+    // exactly one reader, and that invariant is what stops the pair drifting —
+    // so migrating this one needs the two readers to share a single resolution
+    // point first, which is a change to where the value is EMITTED, not to the
+    // ladder.
     let service_timeout_ms: usize = env_usize("NROS_SERVICE_TIMEOUT_MS", 30_000);
-    let keyexpr_string_size: usize = env_usize("NROS_KEYEXPR_STRING_SIZE", 256);
+    let keyexpr_string_size: usize =
+        env_usize_rung("NROS_KEYEXPR_STRING_SIZE", limits.keyexpr_string_size, 256);
     // Phase 124.D.3.c — SPSC ring depth per subscriber. Default 4
     // keeps the static-RAM bump small (4 × SUBSCRIBER_BUFFER_SIZE
     // per subscriber); raise for burst-heavy topics. Must be ≥ 1.
-    let ring_depth: usize = env_usize_min("ZPICO_SUBSCRIBER_RING_DEPTH", 4, 1);
+    let ring_depth: usize = env_usize_min(
+        "ZPICO_SUBSCRIBER_RING_DEPTH",
+        limits.subscriber_ring_depth.unwrap_or(4),
+        1,
+    );
     // Phase 231 (RFC-0038) — size-class receive buffers. `SUBSCRIBER_BUFFER_SIZE`
     // above is the `small` class slot size; the `large` class is for big
     // messages (images, point clouds). A subscription routes to `large` when its
@@ -181,4 +198,14 @@ fn env_usize(name: &str, default: usize) -> usize {
             .and_then(|v| v.parse().ok())
             .unwrap_or(default),
     }
+}
+
+/// phase-400 W6 — env, then the platform/board rung, then the builtin.
+///
+/// A thin sibling of `env_usize` rather than a change to it: the other callers
+/// of that helper are knobs with no tenant, and giving them a rung parameter
+/// they always pass `None` for would say the ladder reaches further than it
+/// does.
+fn env_usize_rung(name: &str, rung: Option<usize>, default: usize) -> usize {
+    env_usize(name, rung.unwrap_or(default))
 }

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -450,8 +450,12 @@ fn shim_config_from_env() -> ShimConfig {
         max_liveliness: env_usize("ZPICO_MAX_LIVELINESS", 16),
         max_pending_gets: env_usize("ZPICO_MAX_PENDING_GETS", 4),
         max_sessions: env_usize("ZPICO_MAX_SESSIONS", 1),
-        get_reply_buf_size: env_usize("ZPICO_GET_REPLY_BUF_SIZE", 4096),
-        get_poll_interval_ms: env_usize("ZPICO_GET_POLL_INTERVAL_MS", 10),
+        // phase-400 W6 — BUILTINS, like the tx pair below: these five are
+        // ladder knobs now, and `resolve_wire` overwrites them where the rungs
+        // are known (search `shim_config.get_reply_buf_size =`). Reading the
+        // environment twice is what `check-knob-single-reader` forbids.
+        get_reply_buf_size: 4096,
+        get_poll_interval_ms: 10,
         // phase-400 W8 — the BUILTINS, not a second env read. These two are
         // ladder knobs, and the resolved values overwrite them below (search
         // `shim_config.tx_batch =`), so reading the environment here was dead
@@ -483,9 +487,13 @@ fn zenoh_buffer_config_from_env(posix: bool) -> ZenohBufferConfig {
     };
 
     ZenohBufferConfig {
-        frag_max_size: env_usize("ZPICO_FRAG_MAX_SIZE", default_frag),
-        batch_unicast_size: env_usize("ZPICO_BATCH_UNICAST_SIZE", default_batch_uni),
-        batch_multicast_size: env_usize("ZPICO_BATCH_MULTICAST_SIZE", default_batch_multi),
+        // phase-400 W6 — the computed per-platform BUILTINS. `resolve_wire`
+        // takes them as its `defaults` and applies the rungs above them, so the
+        // transport still picks the starting number and a descriptor can still
+        // override it.
+        frag_max_size: default_frag,
+        batch_unicast_size: default_batch_uni,
+        batch_multicast_size: default_batch_multi,
     }
 }
 
@@ -965,13 +973,17 @@ pub fn run() {
     // issue 0460 — the same env-or-Kconfig ladder the sized knobs use, so the
     // tx trio is not one more thing a Zephyr RUST image reads as "unset".
     let env_get = |name: &str| kconfig_fallback_str(name);
+    // phase-400 W6 — loaded ONCE and shared by both zenoh tenants (`tx` and
+    // `wire`). It used to live inside the tx arm; a second `load` for the wire
+    // knobs would parse the same file twice and could disagree with itself if
+    // one call site ever grew an option the other did not.
+    let board_knobs = env_get("NROS_BOARD_TOML").map(|path| {
+        let p = PathBuf::from(&path);
+        println!("cargo:rerun-if-changed={}", p.display());
+        platform_config::BoardKnobsFile::load(&p).unwrap_or_else(|e| panic!("{path}: {e}"))
+    });
     let tx_knobs = match (&platforms_tree, platform_name) {
         (Some(tree), Some(name)) => {
-            let board_knobs = env_get("NROS_BOARD_TOML").map(|path| {
-                let p = PathBuf::from(&path);
-                println!("cargo:rerun-if-changed={}", p.display());
-                platform_config::BoardKnobsFile::load(&p).unwrap_or_else(|e| panic!("{path}: {e}"))
-            });
             let mut tx = tree
                 .resolve_tx(
                     name,
@@ -1003,7 +1015,7 @@ pub fn run() {
     // Read buffer config with platform-appropriate defaults
     // NuttX is POSIX-compatible, use same defaults as posix.
     // ThreadX uses NetX Duo BSD sockets, treat as posix-like for buffer defaults.
-    let buf_config = zenoh_buffer_config_from_env(use_posix || use_nuttx || use_threadx);
+    let mut buf_config = zenoh_buffer_config_from_env(use_posix || use_nuttx || use_threadx);
 
     // Read shim slot counts from ZPICO_MAX_* env vars and generate Rust consts
     let mut shim_config = shim_config_from_env();
@@ -1011,6 +1023,68 @@ pub fn run() {
     // top-rung values; overwrite the tx pair with the ladder-resolved ones.
     shim_config.tx_batch = tx_knobs.batch.value;
     shim_config.tx_batch_flush_ms = tx_knobs.flush_ms.value as usize;
+    // phase-400 W6 — the zenoh WIRE sizes, same ladder. The builtins are the
+    // values `shim_config_from_env` just computed from the platform's
+    // transport, so a board that says nothing keeps the transport-appropriate
+    // number and a board that speaks outranks it.
+    {
+        let wire_defaults: [(&'static str, usize); 5] = [
+            ("batch_unicast_size", buf_config.batch_unicast_size),
+            ("batch_multicast_size", buf_config.batch_multicast_size),
+            ("frag_max_size", buf_config.frag_max_size),
+            ("get_reply_buf_size", shim_config.get_reply_buf_size),
+            ("get_poll_interval_ms", shim_config.get_poll_interval_ms),
+        ];
+        for key in platform_config::WIRE_KNOBS {
+            println!(
+                "cargo:rerun-if-env-changed={}",
+                platform_config::wire_env_key(key)
+            );
+        }
+        let resolved = match (&platforms_tree, platform_name) {
+            (Some(tree), Some(name)) => tree
+                .resolve_wire(
+                    name,
+                    board_knobs.as_ref().map(|b| &b.knobs.zenoh.wire),
+                    &env_get,
+                    &wire_defaults,
+                )
+                .unwrap_or_else(|e| panic!("nros-platform.toml: {e}")),
+            // No platform named: the env front-end over the computed builtins,
+            // which is what an out-of-tree consumer and a plain `cargo build`
+            // get.
+            _ => wire_defaults
+                .iter()
+                .map(|(name, builtin)| {
+                    let key = platform_config::wire_env_key(name);
+                    let value = env_get(key)
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                        .unwrap_or(*builtin);
+                    (*name, value)
+                })
+                .map(|(name, value)| {
+                    (
+                        name,
+                        platform_config::ResolvedUsize {
+                            value,
+                            source: platform_config::KnobSource::Builtin,
+                            env_key: platform_config::wire_env_key(name),
+                        },
+                    )
+                })
+                .collect(),
+        };
+        for (name, r) in resolved {
+            match name {
+                "batch_unicast_size" => buf_config.batch_unicast_size = r.value,
+                "batch_multicast_size" => buf_config.batch_multicast_size = r.value,
+                "frag_max_size" => buf_config.frag_max_size = r.value,
+                "get_reply_buf_size" => shim_config.get_reply_buf_size = r.value,
+                "get_poll_interval_ms" => shim_config.get_poll_interval_ms = r.value,
+                other => unreachable!("unknown wire knob `{other}`"),
+            }
+        }
+    }
     std::fs::write(out_dir.join("shim_constants.rs"), shim_config.rust_consts()).unwrap();
 
     // Phase 134.3 — `zenoh_generic_config.h` is the single source of

--- a/packages/rmw/zenoh/zpico-serial/Cargo.lock
+++ b/packages/rmw/zenoh/zpico-serial/Cargo.lock
@@ -130,6 +130,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -393,6 +393,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -470,6 +470,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -338,6 +338,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -422,6 +422,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -349,6 +349,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -317,6 +317,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -393,6 +393,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -317,6 +317,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -393,6 +393,7 @@ name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/qemu-smoltcp-bridge/Cargo.lock
+++ b/packages/testing/qemu-smoltcp-bridge/Cargo.lock
@@ -58,6 +58,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +86,16 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -88,6 +110,12 @@ name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nb"
@@ -105,14 +133,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nros-build-paths"
+version = "0.5.0"
+
+[[package]]
 name = "nros-platform-api"
 version = "0.5.0"
+
+[[package]]
+name = "nros-platform-config"
+version = "0.5.0"
+dependencies = [
+ "nros-build-paths",
+ "serde",
+ "toml",
+]
 
 [[package]]
 name = "nros-smoltcp"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "portable-atomic",
  "smoltcp",
 ]
@@ -124,6 +166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "qemu-rs-common"
 version = "0.4.0"
 dependencies = [
@@ -131,6 +182,15 @@ dependencies = [
  "lan9118-smoltcp",
  "nros-smoltcp",
  "smoltcp",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -158,6 +218,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "smoltcp"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +274,64 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vcell"
@@ -195,4 +352,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]

--- a/packages/tooling/nros-build-helpers/Cargo.toml
+++ b/packages/tooling/nros-build-helpers/Cargo.toml
@@ -37,6 +37,9 @@ default = []
 cbindgen-drift-check = ["dep:cbindgen"]
 
 [dependencies]
+# phase-400 W6 — the ladder rungs. A regular dependency, not a build one:
+# this crate IS the helper a build script calls.
+nros-platform-config = { path = "../nros-platform-config" }
 cbindgen = { workspace = true, optional = true }
 cc = "1"
 # issue 0383 — strict C diagnostics (implicit-function-declaration,
@@ -55,3 +58,4 @@ nros-sizes-build = { workspace = true }
 
 [lints]
 workspace = true
+

--- a/packages/tooling/nros-build-helpers/src/c.rs
+++ b/packages/tooling/nros-build-helpers/src/c.rs
@@ -105,7 +105,21 @@ fn generate_config(
     let message_buffer_size = dep_usize("DEP_NROS_NODE_RX_BUF_SIZE");
 
     // --- C API knobs (nros-c only, not shared with nros-node) ---
-    let let_buffer_size = env_usize("NROS_LET_BUFFER_SIZE", 512);
+    // phase-400 W6 — the `[knobs.runtime]` rungs for the LET buffer.
+    //
+    // `NROS_SERVICE_TIMEOUT_MS` below is deliberately NOT on the ladder: it is
+    // read here and in `nros-rmw-zenoh/build.rs` because two artifacts embed
+    // it, and a migrated knob may have exactly one reader
+    // (`check-knob-single-reader`). Migrating it means giving the pair one
+    // emission point first.
+    let rungs = nros_platform_config::platform_config::BuildRungs::from_build_env();
+    let let_buffer_size = env_usize(
+        "NROS_LET_BUFFER_SIZE",
+        rungs
+            .as_ref()
+            .and_then(|r| r.runtime_rungs().let_buffer_size)
+            .unwrap_or(512),
+    );
     // Phase 192.4 — default service-client RPC timeout. Read the same env var
     // and use the same default (30000) as the zenoh backend
     // (`nros-rmw-zenoh/build.rs`) so the two paths agree.

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -168,6 +168,9 @@ pub struct Knobs {
     /// phase-400 W6 — the RMW static-pool tenant. See [`RmwKnobs`].
     #[serde(default)]
     pub rmw: RmwKnobs,
+    /// phase-400 W6 — the smoltcp net tenant. See [`NetKnobs`].
+    #[serde(default)]
+    pub net: NetKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -416,6 +419,25 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.net]` RUNGS for this build — platform merged with board,
+    /// board winning. See [`Self::rmw_rungs`].
+    pub fn net_rungs(&self) -> NetKnobs {
+        let plat = self.tree.platform_net_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("net", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.net.clone())
+            .unwrap_or_default();
+        NetKnobs {
+            max_sockets: b.max_sockets.or(plat.max_sockets),
+            max_udp_sockets: b.max_udp_sockets.or(plat.max_udp_sockets),
+            buffer_size: b.buffer_size.or(plat.buffer_size),
+            connect_timeout_ms: b.connect_timeout_ms.or(plat.connect_timeout_ms),
+            socket_timeout_ms: b.socket_timeout_ms.or(plat.socket_timeout_ms),
+        }
+    }
+
     /// The `[knobs.rmw]` RUNGS for this build — platform merged with board,
     /// board winning — with no env rung and no defaults.
     ///
@@ -535,6 +557,66 @@ pub struct RmwKnobs {
     pub max_nodes: Option<usize>,
     #[serde(default)]
     pub message_info_slots: Option<usize>,
+}
+
+/// phase-400 W6 — the smoltcp (bare-metal net) tenant.
+///
+/// Socket pools, the per-socket buffer, and the two timeouts, read by
+/// `packages/drivers/net/nros-smoltcp/build.rs`. Every one is a PLATFORM fact:
+/// a brokered bare-metal client needs one TCP and one UDP socket, an RTPS one
+/// needs four, and until now the only way to say so was an env var on the shell
+/// that happened to run the build.
+///
+/// THIS TENANT IS WHY THE READER IS A LEAF CRATE. `nros-smoltcp` could not
+/// depend on `nros-board-common` — cargo counts an optional dependency when it
+/// looks for cycles, and the board crate reaches back through `nros-platform ->
+/// nros-platform-esp32-qemu -> nros-smoltcp`. Every driver was locked out of
+/// the ladder until the reader moved here.
+///
+/// Note what the rung does NOT replace: the crate's default for
+/// `max_udp_sockets` is FEATURE-derived (1 brokered, 4 with `rtps`), and that
+/// stays the builtin. A descriptor naming the knob outranks it — an explicit
+/// declaration beats a heuristic — but a board that says nothing still gets the
+/// feature-appropriate number rather than a constant.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetKnobs {
+    #[serde(default)]
+    pub max_sockets: Option<usize>,
+    #[serde(default)]
+    pub max_udp_sockets: Option<usize>,
+    #[serde(default)]
+    pub buffer_size: Option<usize>,
+    #[serde(default)]
+    pub connect_timeout_ms: Option<usize>,
+    #[serde(default)]
+    pub socket_timeout_ms: Option<usize>,
+}
+
+/// Every net knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const NET_KNOBS: &[&str] = &[
+    "max_sockets",
+    "max_udp_sockets",
+    "buffer_size",
+    "connect_timeout_ms",
+    "socket_timeout_ms",
+];
+
+/// The env front-end for a net knob — the EXISTING `NROS_SMOLTCP_*` names.
+///
+/// The `ZPICO_SMOLTCP_*` spellings the build script also accepts are a
+/// DEPRECATED alias, not a second front-end: they rank WITH env, above this
+/// tenant's rungs, and are not listed here because nothing should start using
+/// them.
+pub fn net_env_key(knob: &str) -> &'static str {
+    match knob {
+        "max_sockets" => "NROS_SMOLTCP_MAX_SOCKETS",
+        "max_udp_sockets" => "NROS_SMOLTCP_MAX_UDP_SOCKETS",
+        "buffer_size" => "NROS_SMOLTCP_BUFFER_SIZE",
+        "connect_timeout_ms" => "NROS_SMOLTCP_CONNECT_TIMEOUT_MS",
+        "socket_timeout_ms" => "NROS_SMOLTCP_SOCKET_TIMEOUT_MS",
+        other => panic!("unknown net knob `{other}`"),
+    }
 }
 
 /// Every RMW knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -1353,6 +1435,75 @@ impl PlatformsTree {
                     *dst = src;
                 }
             }
+        }
+        Ok(out)
+    }
+
+    fn platform_net_knobs(&self, name: &str) -> Result<NetKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = NetKnobs::default();
+        for file in chain.iter().rev() {
+            let n = &file.knobs.net;
+            for (dst, src) in [
+                (&mut out.max_sockets, n.max_sockets),
+                (&mut out.max_udp_sockets, n.max_udp_sockets),
+                (&mut out.buffer_size, n.buffer_size),
+                (&mut out.connect_timeout_ms, n.connect_timeout_ms),
+                (&mut out.socket_timeout_ms, n.socket_timeout_ms),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.net]` rungs for a platform, inherits chain applied.
+    pub fn platform_net_rungs(&self, platform: &str) -> Result<NetKnobs, ConfigError> {
+        self.platform_net_knobs(platform)
+    }
+
+    /// phase-400 W6 — resolve the net tenant over the RFC-0049 ladder.
+    pub fn resolve_net(
+        &self,
+        platform: &str,
+        board: Option<&NetKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_net_knobs(platform)?;
+        let pick = |k: &NetKnobs, name: &str| match name {
+            "max_sockets" => k.max_sockets,
+            "max_udp_sockets" => k.max_udp_sockets,
+            "buffer_size" => k.buffer_size,
+            "connect_timeout_ms" => k.connect_timeout_ms,
+            "socket_timeout_ms" => k.socket_timeout_ms,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = net_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
         }
         Ok(out)
     }

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -422,6 +422,25 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.zenoh.wire]` RUNGS for this build — platform merged with
+    /// board, board winning. See [`Self::rmw_rungs`].
+    pub fn wire_rungs(&self) -> WireKnobs {
+        let plat = self.tree.platform_wire_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("zenoh.wire", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.zenoh.wire.clone())
+            .unwrap_or_default();
+        WireKnobs {
+            batch_unicast_size: b.batch_unicast_size.or(plat.batch_unicast_size),
+            batch_multicast_size: b.batch_multicast_size.or(plat.batch_multicast_size),
+            frag_max_size: b.frag_max_size.or(plat.frag_max_size),
+            get_reply_buf_size: b.get_reply_buf_size.or(plat.get_reply_buf_size),
+            get_poll_interval_ms: b.get_poll_interval_ms.or(plat.get_poll_interval_ms),
+        }
+    }
+
     /// The `[knobs.runtime]` RUNGS for this build — platform merged with board,
     /// board winning. See [`Self::rmw_rungs`].
     pub fn runtime_rungs(&self) -> RuntimeKnobs {
@@ -914,6 +933,53 @@ pub struct ResolvedTransport {
 pub struct ZenohKnobs {
     #[serde(default)]
     pub tx: TxKnobs,
+    /// phase-400 W6 — the WIRE sizes: batch buffers, the fragmentation
+    /// ceiling, the get-reply staging block and its poll interval.
+    ///
+    /// Deliberately NOT the entity caps. `ZPICO_MAX_QUERYABLES`,
+    /// `ZPICO_MAX_SESSIONS` and `SERVICE_BUFFERS` are phase-392's question —
+    /// that phase is deciding whether they stop being globals at all, and a
+    /// per-platform rung would answer it the wrong way. These five are sizes of
+    /// the wire itself, which no campaign derives.
+    #[serde(default)]
+    pub wire: WireKnobs,
+}
+
+/// phase-400 W6 — the zenoh WIRE sizes, read by `nros-zpico-build`.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireKnobs {
+    #[serde(default)]
+    pub batch_unicast_size: Option<usize>,
+    #[serde(default)]
+    pub batch_multicast_size: Option<usize>,
+    #[serde(default)]
+    pub frag_max_size: Option<usize>,
+    #[serde(default)]
+    pub get_reply_buf_size: Option<usize>,
+    #[serde(default)]
+    pub get_poll_interval_ms: Option<usize>,
+}
+
+/// Every wire knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const WIRE_KNOBS: &[&str] = &[
+    "batch_unicast_size",
+    "batch_multicast_size",
+    "frag_max_size",
+    "get_reply_buf_size",
+    "get_poll_interval_ms",
+];
+
+/// The env front-end for a wire knob — the EXISTING `ZPICO_*` names.
+pub fn wire_env_key(knob: &str) -> &'static str {
+    match knob {
+        "batch_unicast_size" => "ZPICO_BATCH_UNICAST_SIZE",
+        "batch_multicast_size" => "ZPICO_BATCH_MULTICAST_SIZE",
+        "frag_max_size" => "ZPICO_FRAG_MAX_SIZE",
+        "get_reply_buf_size" => "ZPICO_GET_REPLY_BUF_SIZE",
+        "get_poll_interval_ms" => "ZPICO_GET_POLL_INTERVAL_MS",
+        other => panic!("unknown wire knob `{other}`"),
+    }
 }
 
 /// The phase-282 TX levers. All optional — `None` means "defer to the
@@ -1542,6 +1608,80 @@ impl PlatformsTree {
         Ok(out)
     }
 
+    fn platform_wire_knobs(&self, name: &str) -> Result<WireKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = WireKnobs::default();
+        for file in chain.iter().rev() {
+            let w = &file.knobs.zenoh.wire;
+            for (dst, src) in [
+                (&mut out.batch_unicast_size, w.batch_unicast_size),
+                (&mut out.batch_multicast_size, w.batch_multicast_size),
+                (&mut out.frag_max_size, w.frag_max_size),
+                (&mut out.get_reply_buf_size, w.get_reply_buf_size),
+                (&mut out.get_poll_interval_ms, w.get_poll_interval_ms),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// phase-400 W6 — resolve the zenoh WIRE tenant over the RFC-0049 ladder.
+    ///
+    /// `defaults` carries the CALLER's builtins because they are computed, not
+    /// constant: `nros-zpico-build` picks a batch and fragmentation size from
+    /// the platform's transport before any descriptor is consulted. The ladder
+    /// still owns the rungs above them.
+    pub fn resolve_wire(
+        &self,
+        platform: &str,
+        board: Option<&WireKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_wire_knobs(platform)?;
+        let pick = |k: &WireKnobs, name: &str| match name {
+            "batch_unicast_size" => k.batch_unicast_size,
+            "batch_multicast_size" => k.batch_multicast_size,
+            "frag_max_size" => k.frag_max_size,
+            "get_reply_buf_size" => k.get_reply_buf_size,
+            "get_poll_interval_ms" => k.get_poll_interval_ms,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = wire_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.zenoh.wire]` rungs for a platform, inherits chain applied.
+    pub fn platform_wire_rungs(&self, platform: &str) -> Result<WireKnobs, ConfigError> {
+        self.platform_wire_knobs(platform)
+    }
+
     /// The `[knobs.runtime]` rungs for a platform, inherits chain applied.
     pub fn platform_runtime_rungs(&self, platform: &str) -> Result<RuntimeKnobs, ConfigError> {
         self.platform_runtime_knobs(platform)
@@ -2160,6 +2300,68 @@ impl BoardKnobsFile {
 
 #[cfg(test)]
 mod tests {
+    /// The zenoh WIRE ladder: builtin < platform < board < env.
+    ///
+    /// The `nros-zpico-build` side of this tenant writes a C header from an
+    /// example build tree, which made an end-to-end probe unreliable to observe
+    /// — so the RESOLVER is pinned here instead, and the build script's job is
+    /// reduced to five straight-line assignments that mirror the tx trio two
+    /// lines above them.
+    #[test]
+    fn the_wire_ladder_resolves_builtin_platform_board_and_env() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("posix")).unwrap();
+        std::fs::write(
+            dir.path().join("posix/nros-platform.toml"),
+            "[knobs.zenoh.wire]\nfrag_max_size = 777\nget_reply_buf_size = 1234\n",
+        )
+        .unwrap();
+        let tree = PlatformsTree::load_search_path(&[dir.path().to_path_buf()]).expect("tree");
+        let defaults = [
+            ("frag_max_size", 2048usize),
+            ("get_reply_buf_size", 4096),
+            ("get_poll_interval_ms", 10),
+        ];
+
+        // platform rung over the caller's computed builtins
+        let got = tree
+            .resolve_wire("posix", None, &|_| None, &defaults)
+            .expect("resolve");
+        let by = |n: &str| got.iter().find(|(k, _)| *k == n).unwrap().1.clone();
+        assert_eq!(by("frag_max_size").value, 777);
+        assert_eq!(by("frag_max_size").source, KnobSource::Platform);
+        // a knob the platform does not name keeps the CALLER's builtin, which is
+        // the whole reason `defaults` is a parameter: it is computed per
+        // transport, not a constant.
+        assert_eq!(by("get_poll_interval_ms").value, 10);
+        assert_eq!(by("get_poll_interval_ms").source, KnobSource::Builtin);
+
+        // board outranks platform
+        let board = WireKnobs {
+            frag_max_size: Some(99),
+            ..Default::default()
+        };
+        let got = tree
+            .resolve_wire("posix", Some(&board), &|_| None, &defaults)
+            .expect("resolve");
+        let hit = got.iter().find(|(k, _)| *k == "frag_max_size").unwrap();
+        assert_eq!(hit.1.value, 99);
+        assert_eq!(hit.1.source, KnobSource::Board);
+
+        // env outranks both
+        let got = tree
+            .resolve_wire(
+                "posix",
+                Some(&board),
+                &|k| (k == "ZPICO_FRAG_MAX_SIZE").then(|| "555".to_string()),
+                &defaults,
+            )
+            .expect("resolve");
+        let hit = got.iter().find(|(k, _)| *k == "frag_max_size").unwrap();
+        assert_eq!(hit.1.value, 555);
+        assert_eq!(hit.1.source, KnobSource::Env);
+    }
+
     /// A platform with NO descriptor resolves to builtins; a BROKEN one does not.
     ///
     /// The phase-400 W6 regression this pins killed every image of the three

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -171,6 +171,9 @@ pub struct Knobs {
     /// phase-400 W6 — the smoltcp net tenant. See [`NetKnobs`].
     #[serde(default)]
     pub net: NetKnobs,
+    /// phase-400 W6 — the component-runtime tenant. See [`RuntimeKnobs`].
+    #[serde(default)]
+    pub runtime: RuntimeKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -419,6 +422,24 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.runtime]` RUNGS for this build — platform merged with board,
+    /// board winning. See [`Self::rmw_rungs`].
+    pub fn runtime_rungs(&self) -> RuntimeKnobs {
+        let plat = self.tree.platform_runtime_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("runtime", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.runtime.clone())
+            .unwrap_or_default();
+        RuntimeKnobs {
+            max_components: b.max_components.or(plat.max_components),
+            component_slot_bytes: b.component_slot_bytes.or(plat.component_slot_bytes),
+            max_class_instances: b.max_class_instances.or(plat.max_class_instances),
+            max_cell_entities: b.max_cell_entities.or(plat.max_cell_entities),
+        }
+    }
+
     /// The `[knobs.net]` RUNGS for this build — platform merged with board,
     /// board winning. See [`Self::rmw_rungs`].
     pub fn net_rungs(&self) -> NetKnobs {
@@ -591,6 +612,49 @@ pub struct NetKnobs {
     pub connect_timeout_ms: Option<usize>,
     #[serde(default)]
     pub socket_timeout_ms: Option<usize>,
+}
+
+/// phase-400 W6 — the component-runtime tenant.
+///
+/// The four static pools `packages/api/nros/build.rs` carves the component
+/// runtime from: how many components an image may register, how big each one's
+/// slot is, how many instances of a class, and how many entities per cell.
+///
+/// phase-391 CONSUMES these (it emits `config::MAX_COMPONENTS` and friends and
+/// sizes the arena from them); it does not own their VALUES, which is the same
+/// relationship `nros-node/build.rs` had with the executor knobs before this
+/// wave. So the rungs are the ladder's to give and the consts stay phase-391's
+/// to emit.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeKnobs {
+    #[serde(default)]
+    pub max_components: Option<usize>,
+    #[serde(default)]
+    pub component_slot_bytes: Option<usize>,
+    #[serde(default)]
+    pub max_class_instances: Option<usize>,
+    #[serde(default)]
+    pub max_cell_entities: Option<usize>,
+}
+
+/// Every runtime knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const RUNTIME_KNOBS: &[&str] = &[
+    "max_components",
+    "component_slot_bytes",
+    "max_class_instances",
+    "max_cell_entities",
+];
+
+/// The env front-end for a runtime knob — the EXISTING names, verbatim.
+pub fn runtime_env_key(knob: &str) -> &'static str {
+    match knob {
+        "max_components" => "NROS_RUNTIME_MAX_COMPONENTS",
+        "component_slot_bytes" => "NROS_RUNTIME_COMPONENT_SLOT_BYTES",
+        "max_class_instances" => "NROS_RUNTIME_MAX_CLASS_INSTANCES",
+        "max_cell_entities" => "NROS_RUNTIME_MAX_CELL_ENTITIES",
+        other => panic!("unknown runtime knob `{other}`"),
+    }
 }
 
 /// Every net knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -1455,6 +1519,73 @@ impl PlatformsTree {
                     *dst = src;
                 }
             }
+        }
+        Ok(out)
+    }
+
+    fn platform_runtime_knobs(&self, name: &str) -> Result<RuntimeKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = RuntimeKnobs::default();
+        for file in chain.iter().rev() {
+            let r = &file.knobs.runtime;
+            for (dst, src) in [
+                (&mut out.max_components, r.max_components),
+                (&mut out.component_slot_bytes, r.component_slot_bytes),
+                (&mut out.max_class_instances, r.max_class_instances),
+                (&mut out.max_cell_entities, r.max_cell_entities),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.runtime]` rungs for a platform, inherits chain applied.
+    pub fn platform_runtime_rungs(&self, platform: &str) -> Result<RuntimeKnobs, ConfigError> {
+        self.platform_runtime_knobs(platform)
+    }
+
+    /// phase-400 W6 — resolve the runtime tenant over the RFC-0049 ladder.
+    pub fn resolve_runtime(
+        &self,
+        platform: &str,
+        board: Option<&RuntimeKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_runtime_knobs(platform)?;
+        let pick = |k: &RuntimeKnobs, name: &str| match name {
+            "max_components" => k.max_components,
+            "component_slot_bytes" => k.component_slot_bytes,
+            "max_class_instances" => k.max_class_instances,
+            "max_cell_entities" => k.max_cell_entities,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = runtime_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
         }
         Ok(out)
     }

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -174,6 +174,9 @@ pub struct Knobs {
     /// phase-400 W6 — the component-runtime tenant. See [`RuntimeKnobs`].
     #[serde(default)]
     pub runtime: RuntimeKnobs,
+    /// phase-400 W6 — the XRCE transport tenant. See [`XrceKnobs`].
+    #[serde(default)]
+    pub xrce: XrceKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -422,6 +425,37 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.xrce]` RUNGS for this build. See [`Self::rmw_rungs`].
+    pub fn xrce_rungs(&self) -> XrceKnobs {
+        let plat = self.tree.platform_xrce_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("xrce", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.xrce.clone())
+            .unwrap_or_default();
+        XrceKnobs {
+            custom_transport_mtu: b.custom_transport_mtu.or(plat.custom_transport_mtu),
+            stream_history: b.stream_history.or(plat.stream_history),
+        }
+    }
+
+    /// The `[knobs.zenoh.limits]` RUNGS for this build. See [`Self::rmw_rungs`].
+    pub fn zenoh_limit_rungs(&self) -> ZenohLimitKnobs {
+        let plat = self.tree.platform_zenoh_limit_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("zenoh.limits", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.zenoh.limits.clone())
+            .unwrap_or_default();
+        ZenohLimitKnobs {
+            keyexpr_string_size: b.keyexpr_string_size.or(plat.keyexpr_string_size),
+            service_timeout_ms: b.service_timeout_ms.or(plat.service_timeout_ms),
+            subscriber_ring_depth: b.subscriber_ring_depth.or(plat.subscriber_ring_depth),
+        }
+    }
+
     /// The `[knobs.zenoh.wire]` RUNGS for this build — platform merged with
     /// board, board winning. See [`Self::rmw_rungs`].
     pub fn wire_rungs(&self) -> WireKnobs {
@@ -456,6 +490,7 @@ impl BuildRungs {
             component_slot_bytes: b.component_slot_bytes.or(plat.component_slot_bytes),
             max_class_instances: b.max_class_instances.or(plat.max_class_instances),
             max_cell_entities: b.max_cell_entities.or(plat.max_cell_entities),
+            let_buffer_size: b.let_buffer_size.or(plat.let_buffer_size),
         }
     }
 
@@ -655,6 +690,11 @@ pub struct RuntimeKnobs {
     pub max_class_instances: Option<usize>,
     #[serde(default)]
     pub max_cell_entities: Option<usize>,
+    /// The logical-execution-time staging buffer, read by
+    /// `nros-build-helpers`'s C emitter. Grouped here because LET is an
+    /// execution-model buffer, not a wire or transport size.
+    #[serde(default)]
+    pub let_buffer_size: Option<usize>,
 }
 
 /// Every runtime knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -663,6 +703,7 @@ pub const RUNTIME_KNOBS: &[&str] = &[
     "component_slot_bytes",
     "max_class_instances",
     "max_cell_entities",
+    "let_buffer_size",
 ];
 
 /// The env front-end for a runtime knob — the EXISTING names, verbatim.
@@ -672,6 +713,7 @@ pub fn runtime_env_key(knob: &str) -> &'static str {
         "component_slot_bytes" => "NROS_RUNTIME_COMPONENT_SLOT_BYTES",
         "max_class_instances" => "NROS_RUNTIME_MAX_CLASS_INSTANCES",
         "max_cell_entities" => "NROS_RUNTIME_MAX_CELL_ENTITIES",
+        "let_buffer_size" => "NROS_LET_BUFFER_SIZE",
         other => panic!("unknown runtime knob `{other}`"),
     }
 }
@@ -943,6 +985,9 @@ pub struct ZenohKnobs {
     /// the wire itself, which no campaign derives.
     #[serde(default)]
     pub wire: WireKnobs,
+    /// phase-400 W6 — zenoh runtime limits. See [`ZenohLimitKnobs`].
+    #[serde(default)]
+    pub limits: ZenohLimitKnobs,
 }
 
 /// phase-400 W6 — the zenoh WIRE sizes, read by `nros-zpico-build`.
@@ -959,6 +1004,65 @@ pub struct WireKnobs {
     pub get_reply_buf_size: Option<usize>,
     #[serde(default)]
     pub get_poll_interval_ms: Option<usize>,
+}
+
+/// phase-400 W6 — the XRCE transport tenant, read by `nros-rmw-xrce-cffi`.
+///
+/// The MTU is a TRANSPORT fact (a serial link's frame budget differs from
+/// UDP's) and the stream history is the reliable-stream depth the agent
+/// negotiates against. Both are per-platform in practice and were env-only.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct XrceKnobs {
+    #[serde(default)]
+    pub custom_transport_mtu: Option<usize>,
+    #[serde(default)]
+    pub stream_history: Option<usize>,
+}
+
+/// Every XRCE knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const XRCE_KNOBS: &[&str] = &["custom_transport_mtu", "stream_history"];
+
+/// The env front-end for an XRCE knob — the EXISTING names, verbatim.
+pub fn xrce_env_key(knob: &str) -> &'static str {
+    match knob {
+        "custom_transport_mtu" => "NROS_XRCE_CUSTOM_TRANSPORT_MTU",
+        "stream_history" => "NROS_XRCE_STREAM_HISTORY",
+        other => panic!("unknown xrce knob `{other}`"),
+    }
+}
+
+/// phase-400 W6 — zenoh RUNTIME limits, read by `nros-rmw-zenoh`.
+///
+/// Separate from [`WireKnobs`] on purpose: those size the WIRE (batching,
+/// fragmentation), these bound what a session holds — the key-expression
+/// string, the default RPC timeout, and the per-subscriber SPSC ring.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZenohLimitKnobs {
+    #[serde(default)]
+    pub keyexpr_string_size: Option<usize>,
+    #[serde(default)]
+    pub service_timeout_ms: Option<usize>,
+    #[serde(default)]
+    pub subscriber_ring_depth: Option<usize>,
+}
+
+/// Every zenoh limit knob, in a stable order.
+pub const ZENOH_LIMIT_KNOBS: &[&str] = &[
+    "keyexpr_string_size",
+    "service_timeout_ms",
+    "subscriber_ring_depth",
+];
+
+/// The env front-end for a zenoh limit knob — the EXISTING names, verbatim.
+pub fn zenoh_limit_env_key(knob: &str) -> &'static str {
+    match knob {
+        "keyexpr_string_size" => "NROS_KEYEXPR_STRING_SIZE",
+        "service_timeout_ms" => "NROS_SERVICE_TIMEOUT_MS",
+        "subscriber_ring_depth" => "ZPICO_SUBSCRIBER_RING_DEPTH",
+        other => panic!("unknown zenoh limit knob `{other}`"),
+    }
 }
 
 /// Every wire knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -1599,6 +1703,7 @@ impl PlatformsTree {
                 (&mut out.component_slot_bytes, r.component_slot_bytes),
                 (&mut out.max_class_instances, r.max_class_instances),
                 (&mut out.max_cell_entities, r.max_cell_entities),
+                (&mut out.let_buffer_size, r.let_buffer_size),
             ] {
                 if src.is_some() {
                     *dst = src;
@@ -1677,6 +1782,54 @@ impl PlatformsTree {
         Ok(out)
     }
 
+    fn platform_xrce_knobs(&self, name: &str) -> Result<XrceKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = XrceKnobs::default();
+        for file in chain.iter().rev() {
+            let x = &file.knobs.xrce;
+            for (dst, src) in [
+                (&mut out.custom_transport_mtu, x.custom_transport_mtu),
+                (&mut out.stream_history, x.stream_history),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.xrce]` rungs for a platform, inherits chain applied.
+    pub fn platform_xrce_rungs(&self, platform: &str) -> Result<XrceKnobs, ConfigError> {
+        self.platform_xrce_knobs(platform)
+    }
+
+    fn platform_zenoh_limit_knobs(&self, name: &str) -> Result<ZenohLimitKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = ZenohLimitKnobs::default();
+        for file in chain.iter().rev() {
+            let z = &file.knobs.zenoh.limits;
+            for (dst, src) in [
+                (&mut out.keyexpr_string_size, z.keyexpr_string_size),
+                (&mut out.service_timeout_ms, z.service_timeout_ms),
+                (&mut out.subscriber_ring_depth, z.subscriber_ring_depth),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.zenoh.limits]` rungs for a platform, inherits chain applied.
+    pub fn platform_zenoh_limit_rungs(
+        &self,
+        platform: &str,
+    ) -> Result<ZenohLimitKnobs, ConfigError> {
+        self.platform_zenoh_limit_knobs(platform)
+    }
+
     /// The `[knobs.zenoh.wire]` rungs for a platform, inherits chain applied.
     pub fn platform_wire_rungs(&self, platform: &str) -> Result<WireKnobs, ConfigError> {
         self.platform_wire_knobs(platform)
@@ -1701,6 +1854,7 @@ impl PlatformsTree {
             "component_slot_bytes" => k.component_slot_bytes,
             "max_class_instances" => k.max_class_instances,
             "max_cell_entities" => k.max_cell_entities,
+            "let_buffer_size" => k.let_buffer_size,
             _ => None,
         };
         let mut out = Vec::new();

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -61,6 +61,10 @@ OWNERS: dict[str, str] = {
     # The memory tenant (phase-400 W6). The stack is read inside the crate that
     # owns the ladder; the heap by the board crate that sizes `ucHeap`.
     "NROS_FREERTOS_APP_STACK_KB": "packages/boards/nros-board-common/src/freertos_build.rs",
+    # The Zephyr heap joined the memory tenant once `nros-platform` could reach
+    # the ladder — it could not while the reader lived in `nros-board-common`,
+    # which depends on `nros-platform`.
+    "NROS_ZEPHYR_HEAP_SIZE": "packages/platform/nros-platform/build.rs",
     "NROS_FREERTOS_HEAP_KB": "packages/boards/nros-board-freertos/build.rs",
     # The transport and zenoh-tx tenants resolve inside the ladder itself, so
     # the resolver IS the owner. `nros-zpico-build` re-read the tx trio for its

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -85,6 +85,12 @@ OWNERS: dict[str, str] = {
     "NROS_SMOLTCP_BUFFER_SIZE": "packages/drivers/net/nros-smoltcp/build.rs",
     "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": "packages/drivers/net/nros-smoltcp/build.rs",
     "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": "packages/drivers/net/nros-smoltcp/build.rs",
+    # The component-runtime tenant (phase-400 W6). phase-391 emits the consts
+    # from these; the ladder decides their values.
+    "NROS_RUNTIME_MAX_COMPONENTS": "packages/api/nros/build.rs",
+    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": "packages/api/nros/build.rs",
+    "NROS_RUNTIME_MAX_CLASS_INSTANCES": "packages/api/nros/build.rs",
+    "NROS_RUNTIME_MAX_CELL_ENTITIES": "packages/api/nros/build.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -100,6 +100,15 @@ OWNERS: dict[str, str] = {
     "ZPICO_FRAG_MAX_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
     "ZPICO_GET_REPLY_BUF_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
     "ZPICO_GET_POLL_INTERVAL_MS": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    # The zenoh limits + xrce tenants, and the LET buffer (phase-400 W6).
+    # `NROS_SERVICE_TIMEOUT_MS` is NOT here: it has two readers by design (a
+    # Rust const and a C define), and this gate's one-reader rule is what keeps
+    # them equal. Migrating it needs a single emission point first.
+    "NROS_KEYEXPR_STRING_SIZE": "packages/rmw/zenoh/nros-rmw-zenoh/build.rs",
+    "ZPICO_SUBSCRIBER_RING_DEPTH": "packages/rmw/zenoh/nros-rmw-zenoh/build.rs",
+    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": "packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs",
+    "NROS_XRCE_STREAM_HISTORY": "packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs",
+    "NROS_LET_BUFFER_SIZE": "packages/tooling/nros-build-helpers/src/c.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -91,6 +91,15 @@ OWNERS: dict[str, str] = {
     "NROS_RUNTIME_COMPONENT_SLOT_BYTES": "packages/api/nros/build.rs",
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": "packages/api/nros/build.rs",
     "NROS_RUNTIME_MAX_CELL_ENTITIES": "packages/api/nros/build.rs",
+    # The zenoh WIRE tenant (phase-400 W6). The two transport-band PRIORITIES
+    # are deliberately absent: `ZPICO_READ_TASK_PRIORITY` mirrors a C `#define`
+    # and `FreertosScheduling` already carries a per-board `zenoh_read_priority`
+    # in raw FreeRTOS units, so a rung would be a THIRD path to one number.
+    "ZPICO_BATCH_UNICAST_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_BATCH_MULTICAST_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_FRAG_MAX_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_GET_REPLY_BUF_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_GET_POLL_INTERVAL_MS": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -78,6 +78,13 @@ OWNERS: dict[str, str] = {
     "NROS_RMW_MAX_BACKENDS": "packages/rmw/cffi/build.rs",
     "NROS_RMW_MAX_NODES": "packages/rmw/cffi/build.rs",
     "NROS_RMW_MESSAGE_INFO_SLOTS": "packages/rmw/cffi/build.rs",
+    # The smoltcp net tenant (phase-400 W6). The driver reads the ladder from
+    # the LEAF crate; it cannot see `nros-board-common` without a cycle.
+    "NROS_SMOLTCP_MAX_SOCKETS": "packages/drivers/net/nros-smoltcp/build.rs",
+    "NROS_SMOLTCP_MAX_UDP_SOCKETS": "packages/drivers/net/nros-smoltcp/build.rs",
+    "NROS_SMOLTCP_BUFFER_SIZE": "packages/drivers/net/nros-smoltcp/build.rs",
+    "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": "packages/drivers/net/nros-smoltcp/build.rs",
+    "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": "packages/drivers/net/nros-smoltcp/build.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -92,7 +92,7 @@ KNOB_CLASS = {
     "NROS_RUNTIME_MAX_CELL_ENTITIES": ("ladder", "runtime tenant"),
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("ladder", "runtime tenant"),
     "NROS_RUNTIME_MAX_COMPONENTS": ("ladder", "runtime tenant"),
-    "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
+    "NROS_ZEPHYR_HEAP_SIZE": ("ladder", "memory tenant — unblocked when the reader moved to a leaf crate"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_KEYEXPR_STRING_SIZE": ("ladder", "zenoh.limits tenant"),

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 32
+LADDER_FLOOR = 37
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -123,11 +123,11 @@ KNOB_CLASS = {
     "ZPICO_MAX_SESSIONS": ("derived", "phase-392 poses it explicitly: joins the model, or stays a knob and that phase says so"),
     "ZPICO_MAX_LIVELINESS": ("derived", "entity cap; phase-392"),
     "ZPICO_MAX_PENDING_GETS": ("derived", "entity cap; phase-392"),
-    "ZPICO_BATCH_UNICAST_SIZE": ("sizing", "wire batch buffer"),
-    "ZPICO_BATCH_MULTICAST_SIZE": ("sizing", "wire batch buffer"),
-    "ZPICO_FRAG_MAX_SIZE": ("sizing", "fragmentation ceiling"),
-    "ZPICO_GET_REPLY_BUF_SIZE": ("sizing", "reply staging block"),
-    "ZPICO_GET_POLL_INTERVAL_MS": ("sizing", "a poll interval, not a size; same ladder shape"),
+    "ZPICO_BATCH_UNICAST_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_BATCH_MULTICAST_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_FRAG_MAX_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_GET_REPLY_BUF_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_GET_POLL_INTERVAL_MS": ("ladder", "zenoh.wire tenant"),
     "ZPICO_READ_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
     "ZPICO_LEASE_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
     "NROS_LET_BUFFER_SIZE": ("sizing", "logical-execution-time buffer"),
@@ -274,6 +274,7 @@ def ladder_knobs():
         "RmwKnobs",
         "NetKnobs",
         "RuntimeKnobs",
+        "WireKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 23
+LADDER_FLOOR = 28
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -207,11 +207,11 @@ KNOB_CLASS = {
     "NROS_RMW_MAX_NODES": ("ladder", "rmw tenant"),
     "NROS_RMW_SUBSCRIBER_SLOTS": ("derived", "phase-412 W1 — COUNT_SUBSCRIPTION"),
     "NROS_RMW_MESSAGE_INFO_SLOTS": ("ladder", "rmw tenant"),
-    "NROS_SMOLTCP_MAX_SOCKETS": ("sizing", "driver pool; candidate net tenant"),
-    "NROS_SMOLTCP_MAX_UDP_SOCKETS": ("sizing", "driver pool; candidate net tenant"),
-    "NROS_SMOLTCP_BUFFER_SIZE": ("sizing", "driver buffer; candidate net tenant"),
-    "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": ("sizing", "driver timeout; candidate net tenant"),
-    "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": ("sizing", "driver timeout; candidate net tenant"),
+    "NROS_SMOLTCP_MAX_SOCKETS": ("ladder", "net tenant"),
+    "NROS_SMOLTCP_MAX_UDP_SOCKETS": ("ladder", "net tenant"),
+    "NROS_SMOLTCP_BUFFER_SIZE": ("ladder", "net tenant"),
+    "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": ("ladder", "net tenant"),
+    "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": ("ladder", "net tenant"),
     "NROS_XRCE_STREAM_HISTORY": ("sizing", "xrce stream depth; candidate rmw tenant"),
     "ZPICO_SUBSCRIBER_RING_DEPTH": ("sizing", "SPSC ring depth (count, not a byte size)"),
     "NROS_EXTRA_BOARD_PATH": ("infra", "extra board search roots"),
@@ -272,6 +272,7 @@ def ladder_knobs():
         "MemoryKnobs",
         "ParamKnobs",
         "RmwKnobs",
+        "NetKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 37
+LADDER_FLOOR = 42
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -95,9 +95,9 @@ KNOB_CLASS = {
     "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
-    "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
-    "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape"),
-    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("sizing", "transport MTU; numeric, read as a string"),
+    "NROS_KEYEXPR_STRING_SIZE": ("ladder", "zenoh.limits tenant"),
+    "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape. TWO readers (zenoh build + the C emitter), so it needs one emission point before a rung"),
+    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("ladder", "xrce tenant"),
     "ZPICO_MAX_LARGE_SUBSCRIBERS": ("derived", "pool cardinality; multiplies LARGE_PAYLOADS, phase-392"),
     "ZPICO_SERVICE_BUFFER_SIZE": ("derived", "SERVICE_BUFFERS is MAX_SESSIONS x MAX_QUERYABLES; phase-392"),
     # --- infra: not knobs ---
@@ -130,7 +130,7 @@ KNOB_CLASS = {
     "ZPICO_GET_POLL_INTERVAL_MS": ("ladder", "zenoh.wire tenant"),
     "ZPICO_READ_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
     "ZPICO_LEASE_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
-    "NROS_LET_BUFFER_SIZE": ("sizing", "logical-execution-time buffer"),
+    "NROS_LET_BUFFER_SIZE": ("ladder", "runtime tenant"),
     # --- infra ---
     "NROS_DECLARED_INFRA_QUERYABLES": ("infra", "a COUNT the resolver passes down, not a knob"),
     "NROS_DECLARED_SERVICE_SERVERS": ("infra", "a COUNT the resolver passes down, not a knob"),
@@ -212,8 +212,8 @@ KNOB_CLASS = {
     "NROS_SMOLTCP_BUFFER_SIZE": ("ladder", "net tenant"),
     "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": ("ladder", "net tenant"),
     "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": ("ladder", "net tenant"),
-    "NROS_XRCE_STREAM_HISTORY": ("sizing", "xrce stream depth; candidate rmw tenant"),
-    "ZPICO_SUBSCRIBER_RING_DEPTH": ("sizing", "SPSC ring depth (count, not a byte size)"),
+    "NROS_XRCE_STREAM_HISTORY": ("ladder", "xrce tenant"),
+    "ZPICO_SUBSCRIBER_RING_DEPTH": ("ladder", "zenoh.limits tenant"),
     "NROS_EXTRA_BOARD_PATH": ("infra", "extra board search roots"),
     "NROS_HOME": ("infra", "path"),
     "NROS_MODEL_DIR": ("infra", "path"),
@@ -275,6 +275,8 @@ def ladder_knobs():
         "NetKnobs",
         "RuntimeKnobs",
         "WireKnobs",
+        "XrceKnobs",
+        "ZenohLimitKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:
@@ -308,6 +310,9 @@ READ_CALLEES = {
     # Option: for an entity COUNT, absence and zero are different answers and
     # a default would erase the difference.
     "env_opt_usize",
+    # phase-400 W6. `env_usize` with a ladder rung between the env and the
+    # builtin.
+    "env_usize_rung",
     "env", "env_get", "env_bool", "env_usize", "env_usize_min",
     "env_usize_compat", "env_or_repo_path", "env_path_or", "flag", "knob",
     "knob_usize", "knob_bool", "req", "list", "var", "var_os",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 28
+LADDER_FLOOR = 32
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -88,10 +88,10 @@ KNOB_CLASS = {
     "NROS_MAX_STRING_VALUE_LEN": ("ladder", "params tenant"),
     "NROS_MAX_PARAM_NAME_LEN": ("ladder", "params tenant"),
     "NROS_MAX_PARAMETERS": ("ladder", "params tenant"),
-    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("sizing", "component cap"),
-    "NROS_RUNTIME_MAX_CELL_ENTITIES": ("sizing", "component cap"),
-    "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("sizing", "component cap"),
-    "NROS_RUNTIME_MAX_COMPONENTS": ("sizing", "component cap"),
+    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("ladder", "runtime tenant"),
+    "NROS_RUNTIME_MAX_CELL_ENTITIES": ("ladder", "runtime tenant"),
+    "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("ladder", "runtime tenant"),
+    "NROS_RUNTIME_MAX_COMPONENTS": ("ladder", "runtime tenant"),
     "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
@@ -273,6 +273,7 @@ def ladder_knobs():
         "ParamKnobs",
         "RmwKnobs",
         "NetKnobs",
+        "RuntimeKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -116,6 +116,26 @@ def crate_of(rel):
 # silently dropped by a literal-only regex.
 KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat|_min)?|knob)\(\s*"([A-Z0-9_]+)"')
 
+# A knob whose FRONT-END NAME lives in a ladder mapping rather than a call.
+#
+# phase-400 W6 moves a knob's resolution out of its build script and into the
+# RFC-0049 ladder. The build script then reads no environment at all — the
+# ladder does, through `<tenant>_env_key`, whose body is a match from field name
+# to env name:
+#
+#     "frag_max_size" => "ZPICO_FRAG_MAX_SIZE",
+#
+# The call-shaped patterns above cannot see that, so migrating a tenant DELETED
+# its knobs from this table: five vanished with the `zenoh.wire` tenant, three
+# with `params` before that. A knob nobody can enumerate is a knob nobody sets
+# (issue 0271), and "it moved to the ladder" is not a reason to stop listing it
+# — the ladder is where a user sets it.
+#
+# Their default is deliberately recorded as COMPUTED: a ladder knob's builtin
+# may be per-platform (`nros-zpico-build` picks a batch size from the
+# transport), so a single number here would be a claim this file cannot make.
+LADDER_ENV_KEY = re.compile(r'=>\s*"([A-Z][A-Z0-9_]+)"\s*,')
+
 
 def scan(files=None):
     """(knobs, pools) — knobs: name -> (default, file, line); pools: list."""
@@ -145,6 +165,12 @@ def scan(files=None):
                 # None default = computed expression; render says so rather
                 # than dropping the row.
                 knobs.setdefault(name, (None, rel, line, False))
+        if "_env_key" in text:
+            for m in LADDER_ENV_KEY.finditer(text):
+                name = m.group(1)
+                if name not in knobs:
+                    line = text[: m.start()].count("\n") + 1
+                    knobs.setdefault(name, (None, rel, line, False))
         for m in POOL_ANNOT.finditer(text):
             expr = m.group(2).replace("\\", " ").strip()
             pools.append((m.group(1), expr, rel, text[: m.start()].count("\n") + 1))


### PR DESCRIPTION
Five smoltcp knobs — the TCP and UDP socket pools, the per-socket buffer, and the connect/socket timeouts — now resolve through the RFC-0049 ladder: `NetKnobs`, `[knobs.net]`, `BuildRungs::net_rungs()`, and **one** reader in `packages/drivers/net/nros-smoltcp/build.rs`.

## This tenant is why the reader moved

`nros-smoltcp` could not depend on `nros-board-common` — cargo counts an optional dependency when it looks for cycles, and the board crate reaches back through `nros-platform → nros-platform-esp32-qemu → nros-smoltcp`. **Every driver was locked out of the ladder.** #261 extracted the reader to `nros-platform-config` for exactly this; this is the first tenant to use it, and the build script says so where it names the crate.

## Two things the rung deliberately does not flatten

**`max_udp_sockets`'s builtin is feature-derived** — 1 brokered, 4 with `rtps` — and stays that way. A descriptor naming the knob outranks it (an explicit declaration beats a heuristic), but a board that says nothing still gets the feature-appropriate number rather than a constant.

**The deprecated `ZPICO_SMOLTCP_*` spellings rank *with* env**, above the rungs. That's what a deprecated front-end should do — it's still a user override — and it's why `net_env_key` lists only the `NROS_` names: nothing should start using the old ones.

## Verified against the build script's own emitted constants

```
builtin        1 / 1 / 2048 / 10000
platform rung  3 / 2 /  512 /   250
env wins       MAX_SOCKETS=4, the rest keep the rung
legacy alias   ZPICO_SMOLTCP_BUFFER_SIZE=99 also outranks the rung
```

Four rungs, each observed in `nros_smoltcp_config.rs` — not inferred from reading the code. `nros config explain` prints the tenant beside the others, and an env override shows as `env`.

## Census

| | before | after |
| --- | ---: | ---: |
| sizing backlog (W6) | 24 | **19** |
| on the ladder | 22 | 27 |

**Ownership checked first, as always:** `NROS_SMOLTCP_*` appears in no live roadmap or design doc — only four archived phases. Unclaimed, unlike three of the last four families I looked at.

Two leaf locks gain the serde/toml **build-dependency** closure — host-side only, and the same price `nros-params` and `nros-rmw-cffi` already pay to read the ladder.

## Verification

- `just check fast` — 190/190
- `just ci l1` — **passed** (first fully green tier 1 since #267 and #270 cleared main's reds)
