### PR TITLE
fix(#0870): no retries on the NuttX e2e cells — a flaky guarantee is a failed one

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -534,7 +534,32 @@ retries = 1
 filter = "binary(rtos_e2e) and test(Platform__Nuttx)"
 test-group = "qemu-nuttx"
 slow-timeout = { period = "120s", terminate-after = 3 }
-retries = 2
+# Issue 0870 — NO RETRIES, and this is a policy statement rather than a tuning
+# choice. These cells exist to show an RTOS meeting its obligations, including
+# under load; that is the property being tested. A cell that fails once and
+# passes on the third attempt has NOT demonstrated it — it has demonstrated
+# that the guarantee is probabilistic, which is the failure. Retrying converts
+# that finding into a green.
+#
+# It cost this: 0870 (nuttx C++ `create_action_client` -> -100) failed roughly
+# two runs in three for weeks and was reported FLAKY, so it passed CI on its
+# third try and nobody looked. Meanwhile the one instrument that would explain
+# it did not exist — NuttX had no `printk` arm, so every shim diagnostic
+# compiled away. Both halves are fixed now: the diagnostics are linked in
+# (verified by `strings`), `rtos_e2e.rs:963-965` already prints server and
+# client output on every run, and a failure will name which of the four
+# declarations failed plus zenoh-pico's raw return code.
+#
+# So a red here is INFORMATION, not noise. If concurrency is what makes a cell
+# fail, the fix is the test-group and port routing above — configuring the
+# concurrency correctly — not re-rolling the dice.
+#
+# The other three RTOS e2e overrides still carry `retries = 2`
+# (Platform__Freertos, Platform__Threadx*, ThreadxLinux). They mask the same
+# class and are deliberately left for a separate decision: issue 0968 records
+# ~12 unreproduced tier-2 e2e failures, so flipping all four at once would
+# produce a wall of red that obscures rather than reveals.
+retries = 0
 
 # ThreadX QEMU RISC-V — allocator window 9400+. Match only the RV64 rtos_e2e
 # slice, not `ThreadxLinux`, by using the trailing-underscore-free

--- a/docs/issues/0870-nuttx-cpp-action-client-transport-tx-failed.md
+++ b/docs/issues/0870-nuttx-cpp-action-client-transport-tx-failed.md
@@ -315,3 +315,45 @@ A failing run. Since it will not fail on demand here, the cheapest honest option
 is to leave the instrumentation in place and catch it in a sweep — the cell is
 reported FLAKY by nextest retries, so the CI history already knows when it fails
 even though no one has read a failing run since the diagnostics landed.
+
+## 2026-09-04 — policy: NO RETRIES on this cell
+
+Owner decision, and it reframes what the cell is for. These e2e cells exist to
+show an RTOS meeting its obligations **including under load** — that is the
+property under test. A cell that fails once and passes on the third attempt has
+not demonstrated it; it has demonstrated that the guarantee is PROBABILISTIC,
+which is the failure. Retrying converts that finding into a green.
+
+`retries = 2` -> `retries = 0` for `binary(rtos_e2e) and test(Platform__Nuttx)`.
+
+That retry is what kept this issue unreadable for weeks: the cell failed roughly
+two runs in three, was reported FLAKY, passed CI on its third try, and nobody
+looked. Both halves of the blindness are now gone:
+
+* the shim diagnostics are linked in (verified by `strings`, absent from the
+  Aug-21 binaries) — the NuttX `printk` arm exists now;
+* `rtos_e2e.rs` already prints server boot, server post-boot and client output
+  on EVERY run, so a failure carries them;
+* the action assertion now names the question its own output answers.
+
+**A red here is information, not noise.** And if concurrency is what makes a
+cell fail, the fix is the `test-group` and port routing — configuring the
+concurrency correctly — not re-rolling the dice.
+
+### What a failing run will now settle
+
+The one remaining unknown: **six of six, or one of six?** Construction performs
+five liveliness declares plus the feedback subscriber. If all six failed, the
+session's declare/TX path is dead at that moment and `ConnectionFailed` was
+accidentally the right family. If only the subscriber failed, it is
+subscriber-specific and zenoh-pico's raw code names it. Nobody has ever seen
+that, because nobody has read a failing run since the diagnostics landed.
+
+### Deliberately NOT done
+
+The other three RTOS e2e overrides still carry `retries = 2`:
+`Platform__Freertos`, `Platform__Threadx*`, `ThreadxLinux`. They mask the same
+class and the same argument applies to them, but issue 0968 records ~12
+unreproduced tier-2 e2e failures — flipping all four at once produces a wall of
+red that obscures rather than reveals. Extending this is a one-line change per
+override and a separate decision, not a rediscovery.

--- a/packages/testing/nros-tests/tests/rtos_e2e.rs
+++ b/packages/testing/nros-tests/tests/rtos_e2e.rs
@@ -967,9 +967,22 @@ fn test_rtos_action_e2e(
     let goal_accepted = client_out.contains("Goal accepted");
     let completed = client_out.contains(nros_tests::output::ACTION_RESULT_PREFIX);
 
+    // Issue 0870 — a failure here is now ANSWERABLE from the output above, and
+    // said so, because for weeks it was not: NuttX had no `printk` arm so every
+    // shim diagnostic compiled away, and retries reported the cell FLAKY so
+    // nobody read the one run that had anything to say.
     assert!(
         goal_accepted && completed,
-        "{} {} action E2E failed: accepted={}, completed={}",
+        "{} {} action E2E failed: accepted={}, completed={}\n\
+         \n\
+         If the client never reached `Sending goal`, construction failed. Read \
+         the client output above for `action client: <which> failed` and for \
+         zenoh-pico's raw code (`zpico: z_declare_subscriber (ring) failed: <n>` \
+         / `z_liveliness_declare_token failed: <n>`). THE QUESTION IT ANSWERS: \
+         did ALL SIX network operations fail (5 liveliness declares + the \
+         feedback subscriber -- the session's declare/TX path is dead), or ONLY \
+         the subscriber (a subscriber-specific fault)? That distinction is \
+         issue 0870's whole remaining unknown.",
         platform,
         lang,
         goal_accepted,


### PR DESCRIPTION
phase-414 W3, option B. **Policy, not tuning.**

These e2e cells exist to show an RTOS meeting its obligations **including under load** — that is the property under test. A cell that fails once and passes on the third attempt has not demonstrated it; it has demonstrated that the guarantee is *probabilistic*, which is the failure. Retrying converts that finding into a green.

`retries = 2` → `retries = 0` for `binary(rtos_e2e) and test(Platform__Nuttx)`. The setting had no stated rationale — the comment above it is about a deleted binary.

## Why this is the fix for 0870 rather than more hunting

That retry is precisely what kept the issue unreadable. The cell failed ~2 runs in 3 for weeks, was reported **FLAKY**, passed CI on its third try, and nobody looked. Meanwhile the one instrument that would explain it did not exist: NuttX had no `printk` arm, so every shim diagnostic compiled away.

Both halves are now gone:

- the shim diagnostics are linked in — verified by `strings`, **absent from the Aug-21 binaries**;
- `rtos_e2e.rs:963-965` already prints server boot, server post-boot and client output on *every* run;
- the action assertion now names the question its own output answers.

So the expensive part of this bug was never reproducing it — it was that a failure told you nothing. That is fixed, which makes waiting for a real red strictly better value than forcing one.

## What a failing run will now settle

**Six of six, or one of six?** Construction performs five liveliness declares plus the feedback subscriber. All six failing means the session's declare/TX path is dead at that moment and `ConnectionFailed` was accidentally the right family; only the subscriber failing means it is subscriber-specific, and zenoh-pico's raw code names it.

Nobody has ever seen that answer, because nobody has read a failing run since the diagnostics landed.

## And if it fails for concurrency reasons

Then the fix is the `test-group` and port routing already in that override — configuring the concurrency correctly — not re-rolling the dice.

## Deliberately not done

The other three RTOS e2e overrides still carry `retries = 2`: `Platform__Freertos`, `Platform__Threadx*`, `ThreadxLinux`. The same argument applies to them, but **issue 0968 records ~12 unreproduced tier-2 e2e failures**, so flipping all four at once produces a wall of red that obscures rather than reveals. They are named in the config so extending this is a one-line decision per override rather than a rediscovery.

## Verification

`cargo nextest list` still parses the config — a malformed filter kills *every* run in the repo, which the comment two lines above warns about. `just check fast`: 190 gates OK. `cargo check -p nros-tests --tests`: clean.

The behavioural change is only visible on a red, so there is nothing to demonstrate green here beyond the config parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
