### PR TITLE
fix(phase-413 W2): the nightly tier-2 job checks its labels AFTER provisioning

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -844,12 +844,32 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
-      - name: Verify this runner's labels are true
-        run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
       - name: just setup tier2-nightly
         run: |
           source ./activate.sh
           just setup tier2-nightly
+      # AFTER `setup` — phase-413 W2, same as run-matrix (#279), queue (#253)
+      # and build-wide (#249).
+      #
+      # `runner-doctor.sh` checks `$root/build/qemu/bin/qemu-system-arm` FIRST
+      # ("the project-local patched build is the PRIMARY path (phase-143) … a
+      # host with it needs nothing from the system") and falls back to the
+      # system qemu only when that is absent. That path is inside the CHECKOUT,
+      # and `just setup tier2-nightly` creates it — the lane expands to
+      # `esp32 freertos native nuttx qemu threadx_linux threadx_riscv64 zephyr`,
+      # and the `qemu` module's `setup` ends in `just qemu setup-qemu`.
+      #
+      # Asserting before provisioning asks the host for something the next step
+      # supplies. This job carries the same `nros-qemu` label on the same runner
+      # class as `run-matrix`, where it failed at step 2 against a system qemu
+      # 6.2 in every run — provisioning nothing, testing nothing, and reporting
+      # it as a host that needs `runner-provision.sh`.
+      #
+      # A genuinely mislabeled runner still fails, one step later, and `setup`
+      # would have failed on it first.
+      - name: Verify this runner's labels are true
+        run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
+
       - name: just ci matrix-nightly
         run: |
           source ./activate.sh


### PR DESCRIPTION
Fourth and final site of the ordering defect. `run-matrix.yml` (#279), `queue.yml` (#253) and `build-wide.yml` (#249) carry the same fix; this job was missed because it lives inside `nightly.yml` rather than in a lane file of its own.

## The defect

`runner-doctor.sh` checks `$root/build/qemu/bin/qemu-system-arm` **first** — *"the project-local patched build is the PRIMARY path (phase-143) … a host with it needs nothing from the system"* — and falls back to the system qemu only when that is absent.

That path is inside the **checkout**, and `just setup tier2-nightly` creates it: the lane expands to `esp32 freertos native nuttx qemu threadx_linux threadx_riscv64 zephyr`, and the `qemu` module's `setup` ends in `just qemu setup-qemu`.

This job carries the same `nros-qemu` label on the same runner class as `run-matrix`, and failed identically in **all five** nightly runs examined:

```
[MISSING] qemu-system-arm is 6.2 — the RTOS multi-instance cells need >= 7.2
runner-doctor: FAIL — at least one label claims something this host does not have.
```

Step 2 of 5 — so the lane provisioned nothing and tested nothing, and the failure was reported as a host needing `runner-provision.sh nros-qemu` rather than as a workflow asking the host for what the next step supplies.

## After this

All four copies of this job agree on when the check runs. Fail-fast is not lost: a genuinely mislabeled runner still fails, one step later, and `setup` would have failed on it first.

This was the headline red in **both** `run-matrix` and nightly tier-2. With the four fixes in, the remaining genuine W2 blockers are issue 1014 (the `<memory>`/`<string>` freestanding defect, needs a RISC-V toolchain) and the Zephyr 4.4 container SDK.

Gates green: workflow-repo-env, ci-no-verb-fallback, required-contexts-reportable, lane-contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)