### PR TITLE
fix(#1015): a derived pool that sizes a C array has a floor of ONE

### DIFF
--- a/docs/issues/1015-a-derived-pool-of-zero-silences-the-board.md
+++ b/docs/issues/1015-a-derived-pool-of-zero-silences-the-board.md
@@ -1,0 +1,85 @@
+---
+id: 1015
+title: "A derived session pool of ZERO silences the board, with no diagnostic"
+status: open
+area: cmake
+severity: high
+related: [1002, 0991, 0940, 0965, phase-403, phase-412]
+---
+
+# Zero is not a smaller pool, it is a different kind of object
+
+## Measured
+
+Same image, same derived knobs, one variable changed:
+
+| `ZPICO_MAX_QUERYABLES` | serial output in 15 s |
+| ---: | ---: |
+| 0 (derived) | **0 bytes** |
+| 4 (floored) | **110 bytes** |
+
+At zero the board transmits NOTHING. No panic, no log line, no fault -- the
+core sits in WFI and the ROS graph shows nothing. The Z4-verified image
+(everything hand-set) transmits 108 bytes on the same board, cable and router,
+so nothing outside the image is implicated.
+
+## Cause
+
+phase-412 W1 derives
+
+    MAX_QUERYABLES = COUNT_SERVICE_SERVER + actions * ACTION_SERVER_QUERYABLES
+
+The reference island declares no service servers and no actions, so it derives
+exactly 0. In `zpico.c`:
+
+    queryable_entry_t queryables[ZPICO_MAX_QUERYABLES];   // line 435
+
+A zero-length array, and NOT the last member of the struct. It is a GNU
+extension that compiles silently and changes what the struct is.
+
+## The rule that was missing
+
+phase-403 states the derived value carries NO headroom, deliberately: it is
+exactly the declared demand, which makes the running image a checker of its own
+declaration. That is right for a table the executor INDEXES -- registration
+past the end returns `ExecutorFull`, which names the knob.
+
+It is wrong when the number backs a FIXED-SIZE C ARRAY. There, zero is not a
+smaller pool; it is a different kind of object, and the failure is a layout
+change rather than a bounds check.
+
+**A derived pool that backs a C array has a floor of 1.**
+
+## Why every gate was green
+
+This is the seventh delivery-class defect of the campaign and the first that
+produced NO diagnostic at all:
+
+* the image links;
+* `check-knob-delivery` confirms the value ARRIVED, because it did -- 0 was
+  delivered faithfully, it was simply the wrong answer;
+* `check-knob-fixpoint` converges, because 0 is stable;
+* the fast tier is green, because nothing here is a host-testable property.
+
+Every check in the tree asks whether the number the image was built with is the
+number that was derived. None asks whether the number is USABLE.
+
+## Options
+
+1. **Floor it in the derivation** (done in the fix commit): any pool backing a C
+   array derives `max(1, demand)`. Cheapest, and it cannot regress a
+   correctly-declared image because 0 was never a legal size for these arrays.
+2. **Floor it in C**, `#if ZPICO_MAX_X < 1 #error`. Louder, and it fails at
+   BUILD rather than at silence -- worth having as well, since a floor in one
+   producer does not bind another.
+3. **Make zero legal**, giving each pool a `[1]` placeholder. Rejected: it
+   spends a slot on every image to make an illegal value representable.
+
+## Not covered
+
+Nothing asserts a derived knob is USABLE, only that it is faithfully delivered.
+A gate that knows which knobs back fixed C arrays and requires them positive
+would have caught this at configure time, and is cheap. The wider question --
+what other derived value has an illegal special case at some boundary -- is
+open, and 0 is the obvious one to check first for every pool this campaign has
+touched.

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -848,12 +848,37 @@ impl EntityInventory {
         // multipliers held beside the calls that decide them. Reading the raw
         // count would size every action-carrying image short.
         let n = |tag: &str| per_kind.get(tag).copied().unwrap_or(0);
-        let max_subscribers = n(EntityKind::Subscription.tag())
-            + n(EntityKind::ActionClient.tag()) * ACTION_CLIENT_SUBSCRIPTIONS;
-        let max_publishers = n(EntityKind::Publisher.tag())
-            + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_PUBLISHERS;
-        let max_queryables = n(EntityKind::ServiceServer.tag())
-            + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_QUERYABLES;
+        let floor1 = |v: usize| v.max(1);
+        let max_subscribers = floor1(
+            n(EntityKind::Subscription.tag())
+                + n(EntityKind::ActionClient.tag()) * ACTION_CLIENT_SUBSCRIPTIONS,
+        );
+        let max_publishers = floor1(
+            n(EntityKind::Publisher.tag())
+                + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_PUBLISHERS,
+        );
+        // Issue 1015 -- FLOOR OF ONE on any pool that backs a fixed C array.
+        //
+        // phase-403's rule is that a derived value carries NO headroom: it is
+        // exactly the declared demand, so the running image checks its own
+        // declaration. That is right for a table the executor INDEXES, where
+        // registering past the end returns `ExecutorFull` and names the knob.
+        //
+        // It is wrong here. These three size C arrays in `zpico.c`
+        // (`queryable_entry_t queryables[ZPICO_MAX_QUERYABLES]` and its
+        // siblings), and a zero-length array is not a smaller pool -- it is a
+        // different kind of object, and it is not the last member of that
+        // struct. Measured on the reference island, which declares no service
+        // servers and so derived exactly 0: the board transmitted NOTHING in
+        // 15 seconds, no panic, no log, core in WFI. The same image with the
+        // pool at 4 transmitted 110 bytes. Every gate was green either way,
+        // because 0 was derived correctly and delivered faithfully.
+        //
+        // One slot costs a handful of bytes. A zero costs the whole image.
+        let max_queryables = floor1(
+            n(EntityKind::ServiceServer.tag())
+                + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_QUERYABLES,
+        );
         let max_nodes = self.components().len();
 
         Derivation::Derived(Box::new(DerivedEntityKnobs {

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -350,6 +350,27 @@ typedef struct {
 // Static slots for non-blocking z_get operations
 // ZPICO_MAX_PENDING_GETS is provided via -D compiler flag from build.rs,
 // with a default fallback above for non-Cargo build paths.
+/* Issue 1015 -- these three pools are FIXED C ARRAYS, so zero is not a smaller
+ * pool: a zero-length array is a GNU extension that compiles silently, and
+ * none of these is the last member of its struct. A derived 0 (an image that
+ * declares no service servers derives exactly that) produced a board that
+ * transmitted NOTHING -- no panic, no log, core in WFI -- while every gate
+ * stayed green, because the value was derived correctly and delivered
+ * faithfully. It was simply not a usable size.
+ *
+ * The derivation floors these at 1 (nros-cli-core entity_inventory.rs). This
+ * is the second line, here rather than there because a floor in one producer
+ * does not bind another, and this is where the array actually is. */
+#if ZPICO_MAX_QUERYABLES < 1
+#error "ZPICO_MAX_QUERYABLES must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#if ZPICO_MAX_SUBSCRIBERS < 1
+#error "ZPICO_MAX_SUBSCRIBERS must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#if ZPICO_MAX_PUBLISHERS < 1
+#error "ZPICO_MAX_PUBLISHERS must be >= 1: it sizes a C array (issue 1015)"
+#endif
+
 typedef struct {
     get_reply_ctx_t ctx;
     bool in_use;


### PR DESCRIPTION
## MERGE ORDER: this should go FIRST, ahead of the queued stack

#217 is merged and its `MAX_QUERYABLES` derivation is what ships the zero. **Any image that declares no service servers, built from current `main`, is silent** -- and stacked PRs #223/#225/#239/#244/#251/#258 all sit on top of that. This PR is small, verified on hardware, and unblocks the rest.

It is stacked on #258 for context, but the two-line derivation change plus the C guards are independent of everything above #217 and can be cherry-picked if the stack needs to move separately.

## Measured, same image, one variable

| `ZPICO_MAX_QUERYABLES` | serial output in 15 s |
| ---: | ---: |
| 0 (derived) | **0 bytes** |
| 4 (hand-pinned probe) | 110 bytes |
| **1 (derived + floor)** | **110 bytes** |

At zero the board says NOTHING -- no panic, no log, no fault, core in WFI, ROS graph empty. The Z4-verified image transmits 108 bytes on the same board, cable and router, so nothing outside the image is implicated.

The third row is the one that matters: the island declares no service servers, so it is the exact configuration that derived 0, and with the floor it derives **1** (not the C-side fallback of 8, which was checked separately) and the board transmits.

## Cause

phase-412 W1 derives `MAX_QUERYABLES = service servers + actions * 3`. This image declares neither, so it derived exactly 0, and in `zpico.c`:

```c
queryable_entry_t queryables[ZPICO_MAX_QUERYABLES];   /* line 435 */
```

becomes a zero-length array that is **not the last member of its struct** -- a GNU extension that compiles silently and changes what the struct is.

## The rule that was missing

phase-403 states the derived value carries no headroom, deliberately: exactly the declared demand, so the running image checks its own declaration. **That is right for a table the executor INDEXES** -- registering past the end returns `ExecutorFull`, which names the knob.

It is wrong where the number sizes a fixed C array. There, zero is not a smaller pool; it is a different kind of object.

**A derived pool that backs a C array has a floor of 1.**

## Fixed for the class, not the site

Floored for all three pools that back C arrays, not only the one that bit: `MAX_SUBSCRIBERS` and `MAX_PUBLISHERS` carry the identical hazard for an image with no subscriptions or no publishers.

Also guarded in C with `#error`, beside the arrays. A floor in one producer does not bind another -- a hand-set `.conf`, an env override or another backend's cmake can still reach zero -- and it turns a silent board into a build failure naming the knob and the issue.

## Why every gate was green

Seventh delivery-class defect of this campaign, and the first with **no diagnostic at all**:

- the image links;
- `check-knob-delivery` confirms the value ARRIVED, because it did -- 0 was derived correctly and delivered faithfully;
- `check-knob-fixpoint` converges, because 0 is stable;
- the fast tier is green, because nothing here is a host-testable property.

Every check in the tree asks whether the number the image was built with is the number that was derived. **None asks whether it is usable.** Issue #1015 names that gap and the cheap gate that closes it.

## Gates

`nros-cli-core` 852 passed; `just check fast` 172/172; verified on hardware rather than inferred.