### PR TITLE
measure(#0827): the cargo carrier exists — and the value cannot come from inside the graph

### DIFF
--- a/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
@@ -368,3 +368,73 @@ What this issue now hands phase-412 is the number: the carrier is worth 279 KB
 on the smallest possible image, and a standalone leaf has no model to derive
 FROM, so "state the knob" may be the only honest answer for the examples even
 after the carrier exists.
+
+## Re-measured 2026-09-04, after phase-412 W1 — unchanged to the byte
+
+W1 landed 2026-09-03 and moved these exact knobs, so the A/B above was re-run
+rather than trusted (the 0859-0862 rule: a measurement is about the tree its
+artifacts were built from).
+
+| | 2026-09-01 | 2026-09-04 (HEAD 9ba86845d) |
+| --- | ---: | ---: |
+| stock | 415,469 | **415,469** |
+| both knobs at 0 | 136,293 | **136,293** |
+
+Byte-identical on both halves. W1 did not reach this path, which is what the
+section above predicted and is now measured rather than argued.
+
+## The carrier EXISTS, and it is the one `nros sync` already writes (2026-09-04)
+
+The handoff above said a leaf "has no model to derive FROM" and left the carrier
+open. Two findings narrow it a long way, and one of them contradicts the
+pessimism.
+
+**1. `.cargo/config.toml`'s `[env]` reaches the pools. Measured, not assumed.**
+Same leaf, same profile, nothing in the shell environment, no CMake anywhere:
+
+```
+[env]
+ZPICO_MAX_QUERYABLES = "0"
+ZPICO_MAX_LARGE_SUBSCRIBERS = "0"
+```
+
+| build | RAM attributed to symbols |
+| --- | ---: |
+| stock `.cargo/config.toml` | 415,469 |
+| + the `[env]` block above | **136,293** |
+
+Exactly the env-var figure, through a file. Sequenced stock -> instrumented from
+a clean rebuild with the variables explicitly UNSET in the shell (`env -u`),
+because the first attempt reused the earlier env-var build and finished in 0.7 s
+— a cached result that would have "confirmed" the carrier without testing it.
+
+> Note for anyone re-running the A/B: the `cd examples/native/rust/talker &&
+> cargo build` in this issue's own "Reproduce" section writes a leaf `target/`,
+> which `check-example-leaf-target-dirs` refuses (phase-340 P2 gave every
+> fixture a shared per-coordinate group dir, and a bare leaf build predates
+> that). It is genuine residue, not a false positive — `rm -rf` it when done.
+
+**2. Why the value MUST come from outside the cargo graph — an ordering
+argument, not a preference.** The pools are sized in `nros-rmw-zenoh`'s build
+script. That crate is a DEPENDENCY of the leaf. The entities are declared in the
+leaf's own `src/lib.rs` (`node.create_publisher_for_topic::<StringMsg>`). So the
+crate that must know the counts is compiled BEFORE the crate whose source states
+them, and no leaf-side derivation — build script, proc macro, manifest metadata
+read at the wrong time — can reach backwards across that edge. `nros ws
+entity-inventory` cannot help either: it reads the `nros-metadata.json` a CMake
+configure writes, and a cargo leaf runs no configure.
+
+**What that does to this issue's two declined fixes.** The first one — "hand-set
+the knobs in each example's `.cargo/config.toml`" — was declined for being twenty
+hand-picked numbers. That objection stands, but it was aimed at the wrong half:
+the LOCATION was right and only the AUTHORSHIP was wrong. `nros sync` already
+generates leaf `.cargo/` content and already keeps the generated part in a
+gitignored sidecar, separate from the authored part (issues 0457/0463). A derived
+`[env]` block belongs in exactly that sidecar — generated, regenerable, never
+committed, and never hand-picked.
+
+So what phase-412 has to build is smaller than "a second derivation path": one
+derivation, published into a carrier that already exists on both sides. The open
+question is no longer WHERE the number goes, it is what a cargo leaf derives
+FROM — and that is a question about where entities are declared, not about
+transport.

--- a/docs/issues/0961-executor-open-in-needs-more-than-32k-of-caller-stack.md
+++ b/docs/issues/0961-executor-open-in-needs-more-than-32k-of-caller-stack.md
@@ -207,3 +207,62 @@ Being explicit about that ratio matters: a gate that claims to state THE number
 while checking a third of it is the shape this campaign keeps finding — a value
 that reads as applied and is not. Either it says "necessary minimum" in its own
 message, or it waits for a measured frame budget.
+
+## The "state the number" check, IMPLEMENTED (2026-09-04)
+
+Built to the scope above, including its caveat: the check says "necessary
+minimum" in its own message rather than claiming to be the requirement.
+
+**The probe.** `nros::sizes` gains `EXECUTOR_VALUE_SIZE = size_of::<Executor>()`
+beside the existing `EXECUTOR_SIZE = size_of::<ExecutorInlineStorage>()`. They
+are far apart, which is the reason the section above refused to reuse the
+existing one — read out of a freshly built host rlib:
+
+| symbol | bytes |
+| --- | --- |
+| `EXECUTOR_SIZE` (value + carved backing) | 89,816 |
+| `EXECUTOR_VALUE_SIZE` (what a stack pays) | **1,552** |
+
+Reusing `EXECUTOR_SIZE` would have overstated the stack requirement by ~58x, and
+on a 320 KiB part that overstatement is a build error refusing an image that
+fits.
+
+**What is emitted**, by both header producers (`nros-build-helpers::{c,cpp}`)
+and both `nros-c` templates:
+
+```c
+#define NROS_EXECUTOR_SIZE           89816
+#define NROS_EXECUTOR_VALUE_SIZE     1552
+#define NROS_EXECUTOR_MAIN_STACK_MIN 3104
+```
+
+**Where the check sits.** In the generated header, so it lands in the CALLER's
+translation unit — which is what this issue's "cannot go inside `open_in`"
+finding requires, since the overflow happens in that function's prologue. It is
+`#if defined(CONFIG_MAIN_STACK_SIZE) && CONFIG_MAIN_STACK_SIZE <
+NROS_EXECUTOR_MAIN_STACK_MIN` → `#error`, so it is present exactly where Zephyr
+force-includes `autoconf.h` and simply absent elsewhere rather than wrong.
+`NROS_STACK_MIN_ACKNOWLEDGE` opts out for an image that builds its executor off
+the main thread, where the number is about a stack this header cannot see.
+
+**Mutation-tested, not assumed** — the three cases, compiled:
+
+| `CONFIG_MAIN_STACK_SIZE` | expected | result |
+| --- | --- | --- |
+| 2048 | fail | `#error` fires, naming the number |
+| 16384 (the tree's real minimum) | pass | clean |
+| 2048 + `NROS_STACK_MIN_ACKNOWLEDGE` | pass | clean |
+
+**Would it have caught the original?** Yes, and the arithmetic is worth stating
+rather than asserting. The bisect at the top of this issue overflowed at 16384.
+That was BEFORE phase-409, when the executor value was ~16 KiB — so the floor
+this check computes would have been ~32 KiB, and 16384 would have failed to
+compile with a message naming the number. At today's post-phase-409 sizes the
+floor is 3104 and every in-tree image (minimum 16384) passes, so the check is
+silent on the current tree and armed against a regression in `MAX_CBS`,
+`MAX_NODES`, or anything else that grows the value.
+
+**What this still does NOT do.** The board has not booted it — item 1 of the two
+above is unchanged and needs the part. And the floor remains roughly a third of
+the true frame cost, by this issue's own x86_64 measurement; it is a necessary
+condition and its message says so in those words.

--- a/docs/issues/0969-cyclone-take-cdr-round-trip.md
+++ b/docs/issues/0969-cyclone-take-cdr-round-trip.md
@@ -92,6 +92,14 @@ reads the CDR the serdata is already holding.
 full encode. On a Cortex-R safety MCU this sits directly in the receive path of a
 control loop.
 
+> **Now measured** (`tests/codec_bench.cpp`, section "The CPU cost: MEASURED"
+> below). The decode+encode pair costs a **~46 ns floor on every message**
+> regardless of size, rising to 176 ns at a 16 KB payload; the new path's whole
+> per-message payload work is a `memcpy` at 0.8-76 ns over the same range. The
+> allocations are the NULL RESULT below — count unchanged, bytes crossing over
+> at ~6 KB. So of the three costs asserted here, the CPU one is real at every
+> size and the allocation one is a trade, not a win.
+
 **Real-time bound.** [phase 391](../roadmap/phase-391-allocation-unification-and-tier-model.md) argues
 the heap holds infrastructure while payload buffers stay static, and derives a
 Robson bound from that. Every Cyclone take allocates a *payload-sized* block, and

--- a/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
+++ b/docs/issues/0976-service-action-adapters-tested-only-against-ourselves.md
@@ -266,7 +266,10 @@ Also untouched: the three RECEIVE-side adapters
 (`take_fibonacci_get_result_response_wire` and the two `_SendGoal_*` /
 `_GetResult_Request_` memcpy branches). Those are a different question — issue
 0969 argues a `dds_takecdr` rewrite removes the need for them rather than
-correcting them.
+correcting them. **That rewrite has since landed, and its cost is measured**: the
+decode+encode it removes was a ~46 ns floor per message (176 ns at 16 KB), while
+the allocation count it was also expected to cut did not move. See 0969's
+"The CPU cost: MEASURED" section.
 
 ## Not to be confused with
 

--- a/docs/issues/archived/0970-cyclone-rmw-should-own-its-sertype.md
+++ b/docs/issues/archived/0970-cyclone-rmw-should-own-its-sertype.md
@@ -135,8 +135,21 @@ work around.
     cyclonedds steady-state sites   2 -> 1
 
 The survivor is `serdata_alloc`, the one copy a caller-owns-the-buffer contract
-cannot avoid. Per-message allocation on the service and action data path is
-otherwise gone.
+cannot avoid.
+
+**Read that as what it is: a count of allocation SOURCE SITES, not of runtime
+allocations.** This section first went on to say per-message allocation was
+"otherwise gone" from the service and action data path. The ledger does not
+support that claim and the runtime measurement contradicts it — see
+[#0969](../0969-cyclone-take-cdr-round-trip.md), where the allocation COUNT comes
+out unchanged before and after, and the BYTES cross over at ~6 KB rather than
+falling. A site disappearing from a ledger is not a call disappearing at runtime.
+
+**What the change does remove at runtime, measured** (bench in
+`tests/codec_bench.cpp`, numbers in 0969): the decode+encode pair, worth a
+**~46 ns floor per message** at any size and 176 ns at a 16 KB payload, against
+a `memcpy` of 0.8-76 ns over the same range. That is the win this migration
+actually buys, and unlike the byte curve it holds at every payload size.
 
 `check-rmw-alloc-sites` is what caught the leftovers: it failed with "DECLARED
 names a steady-state site that is gone", which is how `write_fibonacci_get_result_

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1160,4 +1160,5 @@ holds the evidence, the item is *close it*.
 | [#0852](../issues/0852-zephyr-serial-rx-is-polled-and-overruns.md) | the zenoh read task inherits the executor's priority on Zephyr |
 | [#0880](../issues/0880-tcm-unused-while-sram-exhausted.md) | 192 KiB of tightly-coupled memory sits at 0 % while SRAM is exhausted |
 | [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `take_serialized` costs a full round trip |
+| [#0969](../issues/0969-cyclone-take-cdr-round-trip.md) | the Cyclone RMW deserializes every received sample and re-serializes it, so `try_recv_raw` costs a full round trip. **Round trip removed; cost measured** — ~46 ns/message floor (176 ns at 16 KB). The allocation saving this row assumed did NOT appear: count unchanged, bytes a crossover at ~6 KB. Remaining: the third site, per 0976 |
 

--- a/docs/roadmap/phase-393-rmw-contract-remainder.md
+++ b/docs/roadmap/phase-393-rmw-contract-remainder.md
@@ -171,7 +171,7 @@ holds the evidence, the item is *close it*.
 
 | issue | why it belongs here |
 | --- | --- |
-| [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip |
+| [#0970](../issues/archived/0970-cyclone-rmw-should-own-its-sertype.md) | the Cyclone backend borrows Cyclone's generated sertype instead of registering its own — the contract gap behind the CDR round trip. **RESOLVED**; the removed decode+encode is worth ~46 ns/message (176 ns at 16 KB), measured in 0969. Its allocation-site ledger reads 2 -> 1, which is SITES and not runtime calls — the runtime count did not move |
 | [#0971](../issues/0971-take-sequence-cannot-say-why-it-stopped.md) | `take_sequence` cannot say why a drain stopped, and its two implementations disagree about it |
 | [#0976](../issues/0976-service-action-adapters-tested-only-against-ourselves.md) | five action adapters in the Cyclone service path reshape the CDR to match ROS 2, exercised only by nano-ros talking to itself. This is the VERIFICATION remainder W3 names |
 

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -319,6 +319,40 @@ configured — though a number read off a build dir of unknown history still
 should be re-measured, since the numbers already recorded above were taken under
 the old rule.
 
+## W5 — the cargo carrier, scoped by measurement (issue 0827, 2026-09-04)
+
+Every knob this phase derives reaches CMake-configured images only. A
+cargo-built leaf — every native example, every fixture this repo tests against —
+takes crate defaults, and on the smallest possible image that is **279,176 bytes,
+67.2% of its attributed static RAM** (issue 0827, re-measured at HEAD and
+byte-identical to its 2026-09-01 figures).
+
+Two things are settled, both measured rather than argued:
+
+* **The transport works.** `.cargo/config.toml`'s `[env]` reaches the pool
+  build scripts: 415,469 -> 136,293 bytes on `examples/native/rust/talker` with
+  nothing in the shell environment and no CMake. So this is not "build a second
+  derivation path" — it is publishing the existing derivation into a carrier
+  that already exists.
+* **The value cannot be derived inside the cargo graph.** `nros-rmw-zenoh` is a
+  DEPENDENCY of the leaf and is compiled before it; the entities are declared in
+  the leaf's own `src/lib.rs`. Nothing leaf-side can reach backwards across that
+  edge, and `nros ws entity-inventory` reads a `nros-metadata.json` that only a
+  CMake configure writes.
+
+The place to write it is the gitignored `nros sync` sidecar, not the tracked
+`.cargo/config.toml` — same split as `[patch.crates-io]` (issues 0457/0463):
+generated content is regenerable and uncommitted, authored content is tracked.
+Hand-setting the numbers in each example was declined by 0827 and stays
+declined; the objection is to the AUTHORSHIP, not the location.
+
+**What is NOT settled, and is the actual W5 question:** what a standalone leaf
+derives FROM. A CMake image answers it with `nano_ros_node_register(... ENTITIES
+…)`; a cargo leaf states its entities in executable Rust, which is not readable
+at the time the number is needed. Answering that is a design decision — declare
+entities somewhere sync can read, or accept a stated knob for standalone leaves
+— and it is this phase's to make.
+
 ## Issues homed here (survey 2026-09-03)
 Every open issue was checked for a home phase; these had none, or were
 mentioned here only in passing. A mention is not an owner — an issue with

--- a/packages/api/nros-c/templates/nros_config_generated.h.template
+++ b/packages/api/nros-c/templates/nros_config_generated.h.template
@@ -15,6 +15,51 @@
  * inside their own structs without dynamic allocation.
  */
 #define NROS_EXECUTOR_SIZE @PROBE_EXECUTOR@
+#define NROS_EXECUTOR_VALUE_SIZE @PROBE_EXECUTOR_VALUE@
+#define NROS_EXECUTOR_MAIN_STACK_MIN @EXECUTOR_STACK_MIN@
+
+/* The check itself. Zephyr force-includes autoconf.h, so CONFIG_MAIN_STACK_SIZE
+ * is visible here; on a host or an RTOS that has no such knob the guard is
+ * simply absent rather than wrong.
+ *
+ * Compile-time and in the CALLER's translation unit, which is where it has to
+ * be: the overflow happens in Executor::open_in's PROLOGUE (`sub sp, ...`
+ * before the first statement), so a check written inside open_in or
+ * nros_cpp_init runs after the stack it is guarding has already been claimed.
+ *
+ * NROS_STACK_MIN_ACKNOWLEDGE opts out for an image that builds its executor on
+ * a thread other than main -- the number is then about that thread's stack, and
+ * this header cannot see it.
+ */
+#if defined(CONFIG_MAIN_STACK_SIZE) && !defined(NROS_STACK_MIN_ACKNOWLEDGE)
+#if CONFIG_MAIN_STACK_SIZE < NROS_EXECUTOR_MAIN_STACK_MIN
+#error "nros: CONFIG_MAIN_STACK_SIZE is below the executor's necessary minimum \
+(NROS_EXECUTOR_MAIN_STACK_MIN = 2 x NROS_EXECUTOR_VALUE_SIZE). The executor value \
+is built in Executor::open_in's frame and moved again through nros_cpp_init, so \
+main needs at least that much before either function does any work -- and MORE, \
+since both frames hold other locals. Raise CONFIG_MAIN_STACK_SIZE, lower \
+NROS_EXECUTOR_MAX_CBS / NROS_MAX_NODES (both scale the executor value), or define \
+NROS_STACK_MIN_ACKNOWLEDGE if this image builds its executor off the main thread."
+#endif
+#endif
+
+/* issue 0961 — the executor's STACK cost, which is a different number from
+ * NROS_EXECUTOR_SIZE above and must not be confused with it.
+ *
+ * NROS_EXECUTOR_SIZE is the value PLUS its carved backing: what the caller's
+ * opaque buffer must hold, wherever the caller put it (.bss for a static
+ * holder). NROS_EXECUTOR_VALUE_SIZE is the bare value, and that is what lands
+ * on a stack: Executor::open_in builds one in its frame and returns it by
+ * value, then nros_cpp_init holds the returned value before writing it into
+ * the caller's storage. One value, moved twice -- hence the 2x below.
+ *
+ * NROS_EXECUTOR_MAIN_STACK_MIN is a NECESSARY condition, not a sufficient one.
+ * Both frames hold locals besides the executor, so the real requirement is
+ * larger -- measured on x86_64 after phase-409, the two frames were 3368 and
+ * 1816 bytes against a 1016-byte value, so this floor is roughly a third of
+ * the true cost. An image that satisfies it may still overflow; an image that
+ * violates it cannot boot.
+ */
 #define NROS_GUARD_CONDITION_SIZE @PROBE_GUARD@
 #define NROS_PUBLISHER_SIZE @PROBE_PUBLISHER@
 #define NROS_SUBSCRIBER_SIZE @PROBE_SUBSCRIBER@

--- a/packages/api/nros-c/templates/nros_config_generated_exact.h.template
+++ b/packages/api/nros-c/templates/nros_config_generated_exact.h.template
@@ -7,6 +7,51 @@
 #define NROS_EXECUTOR_STORAGE_SIZE @EXACT_EXECUTOR_STORAGE@
 
 #define NROS_EXECUTOR_SIZE @PROBE_EXECUTOR@
+#define NROS_EXECUTOR_VALUE_SIZE @PROBE_EXECUTOR_VALUE@
+#define NROS_EXECUTOR_MAIN_STACK_MIN @EXECUTOR_STACK_MIN@
+
+/* The check itself. Zephyr force-includes autoconf.h, so CONFIG_MAIN_STACK_SIZE
+ * is visible here; on a host or an RTOS that has no such knob the guard is
+ * simply absent rather than wrong.
+ *
+ * Compile-time and in the CALLER's translation unit, which is where it has to
+ * be: the overflow happens in Executor::open_in's PROLOGUE (`sub sp, ...`
+ * before the first statement), so a check written inside open_in or
+ * nros_cpp_init runs after the stack it is guarding has already been claimed.
+ *
+ * NROS_STACK_MIN_ACKNOWLEDGE opts out for an image that builds its executor on
+ * a thread other than main -- the number is then about that thread's stack, and
+ * this header cannot see it.
+ */
+#if defined(CONFIG_MAIN_STACK_SIZE) && !defined(NROS_STACK_MIN_ACKNOWLEDGE)
+#if CONFIG_MAIN_STACK_SIZE < NROS_EXECUTOR_MAIN_STACK_MIN
+#error "nros: CONFIG_MAIN_STACK_SIZE is below the executor's necessary minimum \
+(NROS_EXECUTOR_MAIN_STACK_MIN = 2 x NROS_EXECUTOR_VALUE_SIZE). The executor value \
+is built in Executor::open_in's frame and moved again through nros_cpp_init, so \
+main needs at least that much before either function does any work -- and MORE, \
+since both frames hold other locals. Raise CONFIG_MAIN_STACK_SIZE, lower \
+NROS_EXECUTOR_MAX_CBS / NROS_MAX_NODES (both scale the executor value), or define \
+NROS_STACK_MIN_ACKNOWLEDGE if this image builds its executor off the main thread."
+#endif
+#endif
+
+/* issue 0961 — the executor's STACK cost, which is a different number from
+ * NROS_EXECUTOR_SIZE above and must not be confused with it.
+ *
+ * NROS_EXECUTOR_SIZE is the value PLUS its carved backing: what the caller's
+ * opaque buffer must hold, wherever the caller put it (.bss for a static
+ * holder). NROS_EXECUTOR_VALUE_SIZE is the bare value, and that is what lands
+ * on a stack: Executor::open_in builds one in its frame and returns it by
+ * value, then nros_cpp_init holds the returned value before writing it into
+ * the caller's storage. One value, moved twice -- hence the 2x below.
+ *
+ * NROS_EXECUTOR_MAIN_STACK_MIN is a NECESSARY condition, not a sufficient one.
+ * Both frames hold locals besides the executor, so the real requirement is
+ * larger -- measured on x86_64 after phase-409, the two frames were 3368 and
+ * 1816 bytes against a 1016-byte value, so this floor is roughly a third of
+ * the true cost. An image that satisfies it may still overflow; an image that
+ * violates it cannot boot.
+ */
 #define NROS_GUARD_CONDITION_SIZE @PROBE_GUARD@
 #define NROS_PUBLISHER_SIZE @PROBE_PUBLISHER@
 #define NROS_SUBSCRIBER_SIZE @PROBE_SUBSCRIBER@

--- a/packages/api/nros/src/sizes.rs
+++ b/packages/api/nros/src/sizes.rs
@@ -92,6 +92,21 @@ mod rmw_sizes {
     // header AND the per-entry storage backing carved from the same buffer, so it
     // must be sized for the combined `#[repr(C)]` layout, not bare `Executor`.
     export_size!(pub EXECUTOR_SIZE       = nros_node::ExecutorInlineStorage);
+
+    // issue 0961 — the STACK requirement is a different number from the one
+    // above, and reusing that one would overstate it. `EXECUTOR_SIZE` is the
+    // executor value PLUS its carved backing, which is what the caller's
+    // `_opaque` buffer must hold; the backing lives wherever the caller put
+    // that buffer (`.bss` for a static holder) and never lands on the stack.
+    // What lands on the stack is the bare value: `open_in` builds one in its
+    // frame and returns it, and `nros_cpp_init` holds the returned value
+    // before writing it into the caller's storage — the same value, moved
+    // twice, which is why the check derived from this is `2 x`.
+    //
+    // On a 320 KiB part the overstatement would be a build error refusing an
+    // image that fits, so the two numbers stay separate rather than one being
+    // reused for both jobs.
+    export_size!(pub EXECUTOR_VALUE_SIZE = nros_node::Executor<'static>);
     export_size!(pub GUARD_CONDITION_SIZE = nros_node::GuardCondition);
     export_size!(pub LIFECYCLE_CTX_SIZE  = nros_node::lifecycle::LifecyclePollingNodeCtx);
     // Phase 91.C: nros-c's `ActionServerInternal` embeds this nros-node

--- a/packages/tooling/nros-build-helpers/src/c.rs
+++ b/packages/tooling/nros-build-helpers/src/c.rs
@@ -147,6 +147,11 @@ fn generate_config(
              rlib."
         );
     }
+    // issue 0961 — see the note this emits into the header: the STACK cost is
+    // the bare value, not the value-plus-backing `probe_executor` above.
+    let probe_executor_value = probed.get("EXECUTOR_VALUE_SIZE").copied().unwrap_or(0) as usize;
+    let executor_stack_min = probe_executor_value.saturating_mul(2);
+
     let executor_storage_bytes = probe_executor.max(8);
     let executor_opaque_u64s = executor_storage_bytes.div_ceil(8);
 
@@ -282,6 +287,8 @@ fn generate_config(
             &executor_storage_bytes.to_string(),
         )
         .replace("@PROBE_EXECUTOR@", &probe_executor.to_string())
+        .replace("@PROBE_EXECUTOR_VALUE@", &probe_executor_value.to_string())
+        .replace("@EXECUTOR_STACK_MIN@", &executor_stack_min.to_string())
         .replace("@PROBE_GUARD@", &probe_guard.to_string())
         .replace("@PROBE_PUBLISHER@", &probe_publisher.to_string())
         .replace("@PROBE_SUBSCRIBER@", &probe_subscriber.to_string())
@@ -340,6 +347,8 @@ fn generate_config(
             &exact_executor_storage.to_string(),
         )
         .replace("@PROBE_EXECUTOR@", &probe_executor.to_string())
+        .replace("@PROBE_EXECUTOR_VALUE@", &probe_executor_value.to_string())
+        .replace("@EXECUTOR_STACK_MIN@", &executor_stack_min.to_string())
         .replace("@PROBE_GUARD@", &probe_guard.to_string())
         .replace("@PROBE_PUBLISHER@", &probe_publisher.to_string())
         .replace("@PROBE_SUBSCRIBER@", &probe_subscriber.to_string())
@@ -388,9 +397,10 @@ fn generate_config(
     // workspace — same sizes, different rmw-feature spellings — agree on
     // the anchor by construction. The human-readable NROS_CONFIG_VARIANT
     // string keeps the feature slug for debugging.
-    let sizes: [(&str, usize); 21] = [
+    let sizes: [(&str, usize); 22] = [
         ("EXACT_EXECUTOR_STORAGE", exact_executor_storage),
         ("PROBE_EXECUTOR", probe_executor),
+        ("PROBE_EXECUTOR_VALUE", probe_executor_value),
         ("PROBE_GUARD", probe_guard),
         ("PROBE_PUBLISHER", probe_publisher),
         ("PROBE_SUBSCRIBER", probe_subscriber),

--- a/packages/tooling/nros-build-helpers/src/cpp.rs
+++ b/packages/tooling/nros-build-helpers/src/cpp.rs
@@ -104,6 +104,12 @@ fn generate_config(
     // corruption, so the overhead is 16.
     const CPP_CONTEXT_OVERHEAD: usize = 16;
     let probe_executor_pre = probed.get("EXECUTOR_SIZE").copied().unwrap_or(0) as usize;
+    // issue 0961 — the bare `Executor` value, which is what a caller's stack
+    // pays. Deliberately NOT `EXECUTOR_SIZE`: that one includes the carved
+    // backing, which never lands on a stack, and on a 320 KiB part the
+    // overstatement would refuse an image that fits.
+    let probe_executor_value = probed.get("EXECUTOR_VALUE_SIZE").copied().unwrap_or(0) as usize;
+    let executor_stack_min = probe_executor_value.saturating_mul(2);
     if probe_executor_pre == 0 {
         println!(
             "cargo:warning=nros-cpp: EXECUTOR_SIZE probe returned 0 — \
@@ -274,6 +280,52 @@ fn generate_config(
 #define NROS_CPP_ACTION_CLIENT_STORAGE_SIZE {exact_action_client}
 
 #define NROS_EXECUTOR_SIZE {exact_executor}
+#define NROS_EXECUTOR_VALUE_SIZE {probe_executor_value}
+#define NROS_EXECUTOR_MAIN_STACK_MIN {executor_stack_min}
+
+/* The check itself. Zephyr force-includes autoconf.h, so CONFIG_MAIN_STACK_SIZE
+ * is visible here; on a host or an RTOS that has no such knob the guard is
+ * simply absent rather than wrong.
+ *
+ * Compile-time and in the CALLER's translation unit, which is where it has to
+ * be: the overflow happens in Executor::open_in's PROLOGUE (`sub sp, ...`
+ * before the first statement), so a check written inside open_in or
+ * nros_cpp_init runs after the stack it is guarding has already been claimed.
+ *
+ * NROS_STACK_MIN_ACKNOWLEDGE opts out for an image that builds its executor on
+ * a thread other than main -- the number is then about that thread's stack, and
+ * this header cannot see it.
+ */
+#if defined(CONFIG_MAIN_STACK_SIZE) && !defined(NROS_STACK_MIN_ACKNOWLEDGE)
+#if CONFIG_MAIN_STACK_SIZE < NROS_EXECUTOR_MAIN_STACK_MIN
+#error \"nros: CONFIG_MAIN_STACK_SIZE is below the executor's necessary minimum \\
+(NROS_EXECUTOR_MAIN_STACK_MIN = 2 x NROS_EXECUTOR_VALUE_SIZE). The executor value \\
+is built in Executor::open_in's frame and moved again through nros_cpp_init, so \\
+main needs at least that much before either function does any work -- and MORE, \\
+since both frames hold other locals. Raise CONFIG_MAIN_STACK_SIZE, lower \\
+NROS_EXECUTOR_MAX_CBS / NROS_MAX_NODES (both scale the executor value), or define \\
+NROS_STACK_MIN_ACKNOWLEDGE if this image builds its executor off the main thread.\"
+#endif
+#endif
+
+
+/* issue 0961 — the executor's STACK cost, which is a different number from
+ * NROS_EXECUTOR_SIZE above and must not be confused with it.
+ *
+ * NROS_EXECUTOR_SIZE is the value PLUS its carved backing: what the caller's
+ * opaque buffer must hold, wherever the caller put it (.bss for a static
+ * holder). NROS_EXECUTOR_VALUE_SIZE is the bare value, and that is what lands
+ * on a stack: Executor::open_in builds one in its frame and returns it by
+ * value, then nros_cpp_init holds the returned value before writing it into
+ * the caller's storage. One value, moved twice -- hence the 2x below.
+ *
+ * NROS_EXECUTOR_MAIN_STACK_MIN is a NECESSARY condition, not a sufficient one.
+ * Both frames hold locals besides the executor, so the real requirement is
+ * larger -- measured on x86_64 after phase-409, the two frames were 3368 and
+ * 1816 bytes against a 1016-byte value, so this floor is roughly a third of
+ * the true cost. An image that satisfies it may still overflow; an image that
+ * violates it cannot boot.
+ */
 #define NROS_GUARD_CONDITION_SIZE {exact_guard}
 #define NROS_PUBLISHER_SIZE {exact_publisher}
 #define NROS_SUBSCRIBER_SIZE {exact_subscriber}
@@ -376,6 +428,52 @@ static const unsigned char *const nros__cpp_config_variant_anchor =
 #define NROS_EXECUTOR_STORAGE_SIZE {exec_storage_c}
 
 #define NROS_EXECUTOR_SIZE {exact_executor}
+#define NROS_EXECUTOR_VALUE_SIZE {probe_executor_value}
+#define NROS_EXECUTOR_MAIN_STACK_MIN {executor_stack_min}
+
+/* The check itself. Zephyr force-includes autoconf.h, so CONFIG_MAIN_STACK_SIZE
+ * is visible here; on a host or an RTOS that has no such knob the guard is
+ * simply absent rather than wrong.
+ *
+ * Compile-time and in the CALLER's translation unit, which is where it has to
+ * be: the overflow happens in Executor::open_in's PROLOGUE (`sub sp, ...`
+ * before the first statement), so a check written inside open_in or
+ * nros_cpp_init runs after the stack it is guarding has already been claimed.
+ *
+ * NROS_STACK_MIN_ACKNOWLEDGE opts out for an image that builds its executor on
+ * a thread other than main -- the number is then about that thread's stack, and
+ * this header cannot see it.
+ */
+#if defined(CONFIG_MAIN_STACK_SIZE) && !defined(NROS_STACK_MIN_ACKNOWLEDGE)
+#if CONFIG_MAIN_STACK_SIZE < NROS_EXECUTOR_MAIN_STACK_MIN
+#error \"nros: CONFIG_MAIN_STACK_SIZE is below the executor's necessary minimum \\
+(NROS_EXECUTOR_MAIN_STACK_MIN = 2 x NROS_EXECUTOR_VALUE_SIZE). The executor value \\
+is built in Executor::open_in's frame and moved again through nros_cpp_init, so \\
+main needs at least that much before either function does any work -- and MORE, \\
+since both frames hold other locals. Raise CONFIG_MAIN_STACK_SIZE, lower \\
+NROS_EXECUTOR_MAX_CBS / NROS_MAX_NODES (both scale the executor value), or define \\
+NROS_STACK_MIN_ACKNOWLEDGE if this image builds its executor off the main thread.\"
+#endif
+#endif
+
+
+/* issue 0961 — the executor's STACK cost, which is a different number from
+ * NROS_EXECUTOR_SIZE above and must not be confused with it.
+ *
+ * NROS_EXECUTOR_SIZE is the value PLUS its carved backing: what the caller's
+ * opaque buffer must hold, wherever the caller put it (.bss for a static
+ * holder). NROS_EXECUTOR_VALUE_SIZE is the bare value, and that is what lands
+ * on a stack: Executor::open_in builds one in its frame and returns it by
+ * value, then nros_cpp_init holds the returned value before writing it into
+ * the caller's storage. One value, moved twice -- hence the 2x below.
+ *
+ * NROS_EXECUTOR_MAIN_STACK_MIN is a NECESSARY condition, not a sufficient one.
+ * Both frames hold locals besides the executor, so the real requirement is
+ * larger -- measured on x86_64 after phase-409, the two frames were 3368 and
+ * 1816 bytes against a 1016-byte value, so this floor is roughly a third of
+ * the true cost. An image that satisfies it may still overflow; an image that
+ * violates it cannot boot.
+ */
 #define NROS_GUARD_CONDITION_SIZE {exact_guard}
 #define NROS_PUBLISHER_SIZE {exact_publisher}
 #define NROS_SUBSCRIBER_SIZE {exact_subscriber}


### PR DESCRIPTION
0827 left phase-412 an open carrier question plus a guess: a standalone leaf "has no model to derive FROM", so stating the knob might be the only honest answer. Two measurements narrow it, and one contradicts the guess.

## First, re-measured at HEAD

phase-412 W1 landed 2026-09-03 and moved these exact knobs, so the A/B was re-run rather than trusted:

| | 2026-09-01 | 2026-09-04 |
| --- | ---: | ---: |
| stock | 415,469 | **415,469** |
| both knobs at 0 | 136,293 | **136,293** |

Byte-identical. W1 does not reach the cargo path — predicted before, measured now.

## The transport works

`.cargo/config.toml`'s `[env]`, nothing in the shell, no CMake anywhere:

| build | RAM attributed to symbols |
| --- | ---: |
| stock | 415,469 |
| + `[env]` block | **136,293** |

So phase-412 needs somewhere to *publish* the derivation it already has — not a second derivation path.

Sequenced stock → instrumented from a clean rebuild with the vars explicitly unset (`env -u`). The first attempt reused the earlier env-var build, finished in 0.7 s, and would have "confirmed" the carrier without testing it.

## The value cannot come from inside the cargo graph

An ordering argument, not a preference:

- `nros-rmw-zenoh` (where the pools are sized) is a **dependency** of the leaf → compiled first.
- The entities are declared in the leaf's own `src/lib.rs`.
- Nothing leaf-side reaches backwards across that edge, and `nros ws entity-inventory` reads a `nros-metadata.json` only a CMake configure writes.

## What this does to 0827's declined fix

"Hand-set the knobs in each example's `.cargo/config.toml`" was declined as twenty hand-picked numbers. **The objection stands but was aimed at the wrong half** — the location was right, the authorship was wrong. `nros sync` already writes generated leaf `.cargo/` content into a gitignored sidecar, separate from the authored part (0457/0463). A derived `[env]` block belongs there: generated, regenerable, never committed.

Filed as **phase-412 W5**, with the genuinely open part stated as a question rather than closed over: *what does a standalone leaf derive FROM?* A CMake image answers with `nano_ros_node_register(... ENTITIES …)`; a cargo leaf states its entities in executable Rust, unreadable at the time the number is needed. That is a design decision for the phase.

## Two notes

- **No knob was committed to any example.** Docs only.
- 0827's own "Reproduce" recipe writes a leaf `target/` (480 MB here) that `check-example-leaf-target-dirs` correctly refuses. The pre-push hook caught mine. Noted in the issue so the next person cleans up rather than debugging the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)