### PR TITLE
feat(phase-400 W6): the `runtime` tenant — four component pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -50,10 +50,10 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_RMW_MAX_NODES` | 4 | `packages/rmw/cffi` |
 | `NROS_RMW_MESSAGE_INFO_SLOTS` | 64 | `packages/rmw/cffi` |
 | `NROS_RMW_SUBSCRIBER_SLOTS` | 8 | `packages/rmw/cffi` |
-| `NROS_RUNTIME_COMPONENT_SLOT_BYTES` | 512 | `packages/api/nros` |
-| `NROS_RUNTIME_MAX_CELL_ENTITIES` | 8 | `packages/api/nros` |
-| `NROS_RUNTIME_MAX_CLASS_INSTANCES` | 2 | `packages/api/nros` |
-| `NROS_RUNTIME_MAX_COMPONENTS` | 4 | `packages/api/nros` |
+| `NROS_RUNTIME_COMPONENT_SLOT_BYTES` | computed — see `packages/api/nros/build.rs:47` | `packages/api/nros` |
+| `NROS_RUNTIME_MAX_CELL_ENTITIES` | computed — see `packages/api/nros/build.rs:70` | `packages/api/nros` |
+| `NROS_RUNTIME_MAX_CLASS_INSTANCES` | computed — see `packages/api/nros/build.rs:58` | `packages/api/nros` |
+| `NROS_RUNTIME_MAX_COMPONENTS` | computed — see `packages/api/nros/build.rs:41` | `packages/api/nros` |
 | `NROS_SERVICE_TIMEOUT_MS` | 30000 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `NROS_SMOLTCP_BUFFER_SIZE` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:57` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SMOLTCP_CONNECT_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:62` | `packages/drivers/net/nros-smoltcp` |

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-01): W2-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params`, `rmw` and `net` tenants done, its remaining tenants and W1
+`zenoh.tx`, `memory`, `params`, `rmw`, `net` and `runtime` tenants done, its remaining tenants and W1
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -312,6 +312,29 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `runtime` tenant — done
+
+The four static pools the component runtime is carved from —
+`NROS_RUNTIME_MAX_COMPONENTS`, `..._COMPONENT_SLOT_BYTES`,
+`..._MAX_CLASS_INSTANCES`, `..._MAX_CELL_ENTITIES` — now resolve through the
+ladder: `RuntimeKnobs`, `[knobs.runtime]`, `BuildRungs::runtime_rungs()`, and
+one reader in `packages/api/nros/build.rs`.
+
+**phase-391 is a CONSUMER, not the owner.** It emits `config::MAX_COMPONENTS`
+and friends from these numbers and sizes the arena from them; it never decided
+their values. That is the same relationship `nros-node/build.rs` had with the
+executor knobs before this wave, and it is why the ownership check cleared:
+reading a knob is not owning it. phase-412 does not claim them either — its W1
+six and its W2 blocked-list both name other things.
+
+Verified against the emitted constants:
+
+    builtin        4 / 512 / 2 / 8
+    platform rung  9 / 256 / 5 / 3
+    env wins       MAX_COMPONENTS=12, the rest keep the rung
+
+Backlog after this: **15**, from 19.
 
 ### The `net` tenant — done, and the reason the reader moved
 

--- a/packages/api/nros/Cargo.toml
+++ b/packages/api/nros/Cargo.toml
@@ -17,6 +17,10 @@ readme = "README.md"
 # issue 0460 — the shared Kconfig-via-$DOTCONFIG knob fallback, so a Zephyr Rust
 # image reads the knobs Kconfig set rather than this crate's defaults.
 nros-zephyr-build = { path = "../../tooling/nros-zephyr-build" }
+# phase-400 W6 — the `[knobs.runtime]` platform/board rungs, from the LEAF
+# ladder crate (a board crate would be a cycle for anything the platform layer
+# reaches; see `nros-platform-config`).
+nros-platform-config = { path = "../../tooling/nros-platform-config" }
 
 [features]
 # phase-361 W3 / issue 0591 — EMPTY; `std` is opt-in per dep-site.

--- a/packages/api/nros/build.rs
+++ b/packages/api/nros/build.rs
@@ -23,25 +23,43 @@ use std::{env, path::Path};
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    // phase-400 W6 — the `[knobs.runtime]` platform/board rungs, resolved once.
+    // `None` when no lane named a platform, and the builtins below then stand.
+    //
+    // phase-391 emits the consts from these numbers and sizes the arena from
+    // them; it does not decide their VALUES. This is where a platform or board
+    // gets to, without an env var on the shell that happened to run the build.
+    let rungs = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.runtime_rungs())
+        .unwrap_or_default();
+
     // Component pool slots. `register_node::<C>()` is a runtime call so the
     // COUNT is not known at compile time, but the BOUND is — which is all a
     // static pool needs. Mirrors `NROS_EXECUTOR_MAX_NODES` (default 4) one
     // layer down; 4 leaves room for the multi-component entries codegen emits
     // without charging a single-node image for slots it never fills.
-    let max_components = env_usize("NROS_RUNTIME_MAX_COMPONENTS", 4);
+    let max_components = env_usize("NROS_RUNTIME_MAX_COMPONENTS", rungs.max_components, 4);
 
     // Per-slot byte budget for the type-erased `TypedSlot<C>`. A BYTE budget
     // rather than a type, because the pool is heterogeneous (`TypedSlot<C>` is
     // generic over `C`) and the FFI seam cannot name a generic. A component
     // whose slot does not fit is a registration error, not a compile error.
-    let component_slot_bytes = env_usize("NROS_RUNTIME_COMPONENT_SLOT_BYTES", 512);
+    let component_slot_bytes = env_usize(
+        "NROS_RUNTIME_COMPONENT_SLOT_BYTES",
+        rungs.component_slot_bytes,
+        512,
+    );
 
     // phase-391 W5.3b — instances of ONE component class the macro-emitted
     // per-class store can hold. Multi-instance is real: the launch path bakes
     // one identity per plan node and can name the same class twice. 2 covers
     // the pair case without charging every class for more; install past the
     // cap is a Full-style registration error, not silent reuse.
-    let max_class_instances = env_usize("NROS_RUNTIME_MAX_CLASS_INSTANCES", 2);
+    let max_class_instances = env_usize(
+        "NROS_RUNTIME_MAX_CLASS_INSTANCES",
+        rungs.max_class_instances,
+        2,
+    );
 
     // phase-391 W5 regression fix — entity-registry slots per COMPONENT CELL.
     // The first heapless conversion borrowed the metadata twin's 32, which is
@@ -49,7 +67,7 @@ fn main() {
     // ~152 B) — 4 components ate ~80 KiB of the 128 KiB bare-metal arena.
     // 8 is per-component-shaped (a component declaring more than 8 entities of
     // ONE KIND is rare and gets a loud registration error + this knob).
-    let max_cell_entities = env_usize("NROS_RUNTIME_MAX_CELL_ENTITIES", 8);
+    let max_cell_entities = env_usize("NROS_RUNTIME_MAX_CELL_ENTITIES", rungs.max_cell_entities, 8);
 
     let contents = format!(
         "/// Component pool slots (set via `NROS_RUNTIME_MAX_COMPONENTS`, default 4).\n\
@@ -73,6 +91,10 @@ fn main() {
     std::fs::write(Path::new(&out_dir).join("nros_runtime_config.rs"), contents).unwrap();
 }
 
-fn env_usize(name: &str, default: usize) -> usize {
-    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), default)
+/// phase-400 W6 — `rung` is the platform/board answer from `[knobs.runtime]`,
+/// and it sits between the Kconfig rung and the crate builtin. Passing it as
+/// `knob_usize`'s default is what places it there: env and `$DOTCONFIG` still
+/// win above it, and the builtin applies only where no descriptor spoke.
+fn env_usize(name: &str, rung: Option<usize>, default: usize) -> usize {
+    nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), rung.unwrap_or(default))
 }

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/cli/nros-cli-core/src/cmd/config.rs
+++ b/packages/cli/nros-cli-core/src/cmd/config.rs
@@ -264,6 +264,32 @@ fn explain(args: ExplainArgs) -> Result<()> {
         );
     }
 
+    // phase-400 W6 — the component-runtime tenant. Defaults mirror
+    // `packages/api/nros/build.rs`, which stays the authority on them.
+    let runtime_defaults: &[(&str, usize)] = &[
+        ("max_components", 4),
+        ("component_slot_bytes", 512),
+        ("max_class_instances", 2),
+        ("max_cell_entities", 8),
+    ];
+    for (name, r) in tree
+        .resolve_runtime(
+            &args.platform,
+            board.as_ref().map(|b| &b.knobs.runtime),
+            &env_get,
+            runtime_defaults,
+        )
+        .map_err(|e| eyre!("{e}"))?
+    {
+        println!(
+            "{:<34} {:<10} {}  [{}]",
+            format!("runtime.{name}"),
+            r.value,
+            r.source.as_str(),
+            r.env_key
+        );
+    }
+
     // phase-400 W6 — the smoltcp net tenant. Defaults mirror
     // `packages/drivers/net/nros-smoltcp/build.rs`, which stays the authority.
     // `max_udp_sockets` shows 1 here: its builtin is FEATURE-derived (4 with

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-serdes",
  "nros-zephyr-build",

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-serdes",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "nros-node",
  "nros-params",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-serdes",

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -171,6 +171,9 @@ pub struct Knobs {
     /// phase-400 W6 — the smoltcp net tenant. See [`NetKnobs`].
     #[serde(default)]
     pub net: NetKnobs,
+    /// phase-400 W6 — the component-runtime tenant. See [`RuntimeKnobs`].
+    #[serde(default)]
+    pub runtime: RuntimeKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -419,6 +422,24 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.runtime]` RUNGS for this build — platform merged with board,
+    /// board winning. See [`Self::rmw_rungs`].
+    pub fn runtime_rungs(&self) -> RuntimeKnobs {
+        let plat = self.tree.platform_runtime_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("runtime", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.runtime.clone())
+            .unwrap_or_default();
+        RuntimeKnobs {
+            max_components: b.max_components.or(plat.max_components),
+            component_slot_bytes: b.component_slot_bytes.or(plat.component_slot_bytes),
+            max_class_instances: b.max_class_instances.or(plat.max_class_instances),
+            max_cell_entities: b.max_cell_entities.or(plat.max_cell_entities),
+        }
+    }
+
     /// The `[knobs.net]` RUNGS for this build — platform merged with board,
     /// board winning. See [`Self::rmw_rungs`].
     pub fn net_rungs(&self) -> NetKnobs {
@@ -591,6 +612,49 @@ pub struct NetKnobs {
     pub connect_timeout_ms: Option<usize>,
     #[serde(default)]
     pub socket_timeout_ms: Option<usize>,
+}
+
+/// phase-400 W6 — the component-runtime tenant.
+///
+/// The four static pools `packages/api/nros/build.rs` carves the component
+/// runtime from: how many components an image may register, how big each one's
+/// slot is, how many instances of a class, and how many entities per cell.
+///
+/// phase-391 CONSUMES these (it emits `config::MAX_COMPONENTS` and friends and
+/// sizes the arena from them); it does not own their VALUES, which is the same
+/// relationship `nros-node/build.rs` had with the executor knobs before this
+/// wave. So the rungs are the ladder's to give and the consts stay phase-391's
+/// to emit.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeKnobs {
+    #[serde(default)]
+    pub max_components: Option<usize>,
+    #[serde(default)]
+    pub component_slot_bytes: Option<usize>,
+    #[serde(default)]
+    pub max_class_instances: Option<usize>,
+    #[serde(default)]
+    pub max_cell_entities: Option<usize>,
+}
+
+/// Every runtime knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const RUNTIME_KNOBS: &[&str] = &[
+    "max_components",
+    "component_slot_bytes",
+    "max_class_instances",
+    "max_cell_entities",
+];
+
+/// The env front-end for a runtime knob — the EXISTING names, verbatim.
+pub fn runtime_env_key(knob: &str) -> &'static str {
+    match knob {
+        "max_components" => "NROS_RUNTIME_MAX_COMPONENTS",
+        "component_slot_bytes" => "NROS_RUNTIME_COMPONENT_SLOT_BYTES",
+        "max_class_instances" => "NROS_RUNTIME_MAX_CLASS_INSTANCES",
+        "max_cell_entities" => "NROS_RUNTIME_MAX_CELL_ENTITIES",
+        other => panic!("unknown runtime knob `{other}`"),
+    }
 }
 
 /// Every net knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -1455,6 +1519,73 @@ impl PlatformsTree {
                     *dst = src;
                 }
             }
+        }
+        Ok(out)
+    }
+
+    fn platform_runtime_knobs(&self, name: &str) -> Result<RuntimeKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = RuntimeKnobs::default();
+        for file in chain.iter().rev() {
+            let r = &file.knobs.runtime;
+            for (dst, src) in [
+                (&mut out.max_components, r.max_components),
+                (&mut out.component_slot_bytes, r.component_slot_bytes),
+                (&mut out.max_class_instances, r.max_class_instances),
+                (&mut out.max_cell_entities, r.max_cell_entities),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.runtime]` rungs for a platform, inherits chain applied.
+    pub fn platform_runtime_rungs(&self, platform: &str) -> Result<RuntimeKnobs, ConfigError> {
+        self.platform_runtime_knobs(platform)
+    }
+
+    /// phase-400 W6 — resolve the runtime tenant over the RFC-0049 ladder.
+    pub fn resolve_runtime(
+        &self,
+        platform: &str,
+        board: Option<&RuntimeKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_runtime_knobs(platform)?;
+        let pick = |k: &RuntimeKnobs, name: &str| match name {
+            "max_components" => k.max_components,
+            "component_slot_bytes" => k.component_slot_bytes,
+            "max_class_instances" => k.max_class_instances,
+            "max_cell_entities" => k.max_cell_entities,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = runtime_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
         }
         Ok(out)
     }

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -85,6 +85,12 @@ OWNERS: dict[str, str] = {
     "NROS_SMOLTCP_BUFFER_SIZE": "packages/drivers/net/nros-smoltcp/build.rs",
     "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": "packages/drivers/net/nros-smoltcp/build.rs",
     "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": "packages/drivers/net/nros-smoltcp/build.rs",
+    # The component-runtime tenant (phase-400 W6). phase-391 emits the consts
+    # from these; the ladder decides their values.
+    "NROS_RUNTIME_MAX_COMPONENTS": "packages/api/nros/build.rs",
+    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": "packages/api/nros/build.rs",
+    "NROS_RUNTIME_MAX_CLASS_INSTANCES": "packages/api/nros/build.rs",
+    "NROS_RUNTIME_MAX_CELL_ENTITIES": "packages/api/nros/build.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 28
+LADDER_FLOOR = 32
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -88,10 +88,10 @@ KNOB_CLASS = {
     "NROS_MAX_STRING_VALUE_LEN": ("ladder", "params tenant"),
     "NROS_MAX_PARAM_NAME_LEN": ("ladder", "params tenant"),
     "NROS_MAX_PARAMETERS": ("ladder", "params tenant"),
-    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("sizing", "component cap"),
-    "NROS_RUNTIME_MAX_CELL_ENTITIES": ("sizing", "component cap"),
-    "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("sizing", "component cap"),
-    "NROS_RUNTIME_MAX_COMPONENTS": ("sizing", "component cap"),
+    "NROS_RUNTIME_COMPONENT_SLOT_BYTES": ("ladder", "runtime tenant"),
+    "NROS_RUNTIME_MAX_CELL_ENTITIES": ("ladder", "runtime tenant"),
+    "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("ladder", "runtime tenant"),
+    "NROS_RUNTIME_MAX_COMPONENTS": ("ladder", "runtime tenant"),
     "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
@@ -258,6 +258,7 @@ def ladder_knobs():
         "ParamKnobs",
         "RmwKnobs",
         "NetKnobs",
+        "RuntimeKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:


### PR DESCRIPTION
Stacked on #278 — this PR's own diff is the single commit on top of it.

The four static pools the component runtime is carved from — `NROS_RUNTIME_MAX_COMPONENTS`, `..._COMPONENT_SLOT_BYTES`, `..._MAX_CLASS_INSTANCES`, `..._MAX_CELL_ENTITIES` — now resolve through the RFC-0049 ladder: `RuntimeKnobs`, `[knobs.runtime]`, `BuildRungs::runtime_rungs()`, and **one** reader in `packages/api/nros/build.rs` composing env → Kconfig → rung → builtin.

## phase-391 is a consumer, not the owner

That distinction is the entire ownership check. phase-391 emits `config::MAX_COMPONENTS` and friends from these numbers and sizes the arena from them — it never decided their **values**. Same relationship `nros-node/build.rs` had with the executor knobs before this wave: **reading a knob is not owning it.**

phase-412 doesn't claim them either — its W1 six and its W2 blocked-list both name other things. So unlike three of the last five families, this one is genuinely W6's.

## Verified against the emitted constants

```
builtin        4 / 512 / 2 / 8
platform rung  9 / 256 / 5 / 3
env wins       MAX_COMPONENTS=12, the rest keep the rung
```

Observed in the generated config, not inferred from reading the code. `nros config explain` prints the tenant beside the others.

## Census

| | before | after |
| --- | ---: | ---: |
| sizing backlog (W6) | 19 | **15** |
| on the ladder | 27 | 31 |

## Verification

- `just check fast` — 190/190
- `just ci l1` — passed
- `just check submodule-pins` — OK, 0 pins moved
