### PR TITLE
measure(#0900): the arena saving is 56.5 KiB — and 42.4 KiB for action images too

### DIFF
--- a/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -500,3 +500,42 @@ So the two are complements, not alternatives:
 * **3** — a checked manual knob where it cannot.
 
 Neither alone is both safe and useful across the tree.
+
+## The saving, MEASURED (2026-09-04) — and the default is wrong for action images too
+
+Everything above is mechanism. This is what it delivers, read from
+`nros-node`'s generated `ARENA_SIZE` rather than argued from the formula. The
+arena is inline on the task stack, so `just mem-report` cannot see it; the
+generated constant is the number that sizes the reservation.
+
+Isolated `CARGO_TARGET_DIR` per run, one variable, defaults otherwise
+(`MAX_CBS=4`, `DEFAULT_RX_BUF_SIZE=1024`):
+
+| `NROS_EXECUTOR_ACTION_CLIENTS` | `ARENA_SIZE` | saved vs default |
+| --- | ---: | ---: |
+| unset (= `MAX_CBS`, today's default) | 74,240 | — |
+| 1 | 30,848 | **43,392 B (42.4 KiB)** |
+| 0 | 16,384 | **57,856 B (56.5 KiB)** |
+
+The 56.5 KiB this issue has claimed throughout is confirmed to the byte.
+
+**What is new is the middle row, and it changes who this is for.** This issue is
+written as though the saving belongs to pub/sub images — "every pub/sub image
+56.5 KiB smaller" is how option 2 is phrased. But an image with ONE action
+client, which is what an action-client image typically has, still saves
+**43,392 bytes**, because the default budgets ALL FOUR slots at the action-client
+size rather than the one that needs it. The default is not merely conservative
+for images with no action client; it is wrong by 42 KiB for the images it was
+chosen to protect.
+
+That also removes the sharpest edge from option 2's objection. Flipping the
+default to 0 was rejected for breaking "every action-client image at
+REGISTRATION". The derivation makes that moot where it runs — an action-client
+image derives 1, not 0 — and the gate (W3) catches `knob == 0` with an action
+entity linked. The remaining exposure is an image that is neither derived nor
+gated, which is the same set the tri-state already falls back to worst-case for.
+
+Not measured here: an end-to-end image build showing the stack reservation
+shrink. The constant is what sizes it, and no image in the tree currently
+derives a non-default value, so that measurement needs an image built through
+the CMake seam with a declaring `nano_ros_node_register`.

--- a/packages/cli/nros-cli-core/src/orchestration/model_ingest.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/model_ingest.rs
@@ -381,8 +381,15 @@ pub fn load_workspace_metadata(ws_root: &Path) -> Vec<JsonValue> {
 ///   timer counts ZERO in the model and ONE in the recorder — the exact hole
 ///   issue 0257 documented;
 /// - the recorder only sees what `Component::register` declares as an entity,
-///   and service/action CLIENTS are not recorded as node entities, while the
-///   model's wiring names them.
+///   while the model's wiring names things the recorder never runs to see.
+///
+/// That second bullet used to read "service/action CLIENTS are not recorded as
+/// node entities". That is no longer true (issue 0900): the recorder always
+/// captured them and the SIDECAR WRITER dropped them on the way out, which is
+/// fixed — `action_clients` and `service_clients` are emitted arrays now. The
+/// max rule still holds, for the reason above and for the timer hole below; it
+/// no longer holds for the client reason, and a stale rationale is how the next
+/// reader concludes the sidecar cannot answer a question it now can.
 ///
 /// Taking the max per node is monotone (never below today's model bound, so no
 /// existing build regresses) and never over-counts a node by mixing the two


### PR DESCRIPTION
0900 has carried its 56.5 KiB figure since it was opened, derived from the formula. Measured now.

Read from `nros-node`'s generated `ARENA_SIZE`, not `mem-report` — the arena is inline on the task stack, so `mem-report` cannot see it at all. Isolated `CARGO_TARGET_DIR` per run, one variable, defaults otherwise (`MAX_CBS=4`, `RX_BUF=1024`):

| `NROS_EXECUTOR_ACTION_CLIENTS` | `ARENA_SIZE` | saved |
| --- | ---: | ---: |
| unset (= `MAX_CBS`, today's default) | 74,240 | — |
| 1 | 30,848 | **43,392 B (42.4 KiB)** |
| 0 | 16,384 | **57,856 B (56.5 KiB)** |

The 56.5 KiB is confirmed to the byte.

## The middle row changes who this is for

The issue is written as though the saving belongs to pub/sub images — option 2 is phrased "every pub/sub image 56.5 KiB smaller". But an image with **one** action client, which is what an action-client image typically has, still saves **43,392 bytes** — the default budgets all four slots at the action-client size instead of the one slot that needs it.

So the default is not merely conservative for images without an action client. **It is wrong by 42 KiB for the images it was chosen to protect.**

That also blunts option 2's objection: flipping the default to 0 was rejected for breaking "every action-client image at REGISTRATION". Where the derivation runs, an action-client image derives 1, not 0; and W3's gate catches `knob == 0` with an action entity linked.

## A stale claim of my own, corrected

`count_callbacks_with_metadata` justified its max rule partly with *"service/action CLIENTS are not recorded as node entities"*. They are — and since my earlier 0900 commit they reach the sidecar too. The max rule still holds on its other two grounds (the timer hole; wiring the recorder never runs to see), just not that one.

A stale rationale is how the next reader concludes the sidecar cannot answer a question it now can. That is this campaign's recurring shape, and worse when the staleness is mine.

## Not measured

An end-to-end image build showing the stack reservation shrink. The constant is what sizes it, and no image in the tree currently derives a non-default value — that needs an image built through the CMake seam with a declaring `nano_ros_node_register`.

No behaviour change. Gates: `check fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)