### PR TITLE
feat(phase-400 W6): the `zenoh.wire` tenant — five sizes, two priorities left out

### DIFF
--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -38,6 +38,8 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_EXECUTOR_MAX_NODES` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SC` | 8 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SHUTDOWN_CBS` | 2 | `packages/core/nros-node` |
+| `NROS_FREERTOS_APP_STACK_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:851` | `packages/tooling/nros-platform-config` |
+| `NROS_FREERTOS_HEAP_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:850` | `packages/tooling/nros-platform-config` |
 | `NROS_KEYEXPR_STRING_SIZE` | 256 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `NROS_LET_BUFFER_SIZE` | 512 | `packages/tooling/nros-build-helpers` |
 | `NROS_MAX_ARRAY_LEN` | 32 | `packages/core/nros-params` |
@@ -62,11 +64,12 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:67` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:488` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:487` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/rmw/zenoh/nros-zpico-build/src/runner.rs:486` | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_GET_POLL_INTERVAL_MS` | 10 | `packages/rmw/zenoh/nros-zpico-build` |
-| `ZPICO_GET_REPLY_BUF_SIZE` | 4096 | `packages/rmw/zenoh/nros-zpico-build` |
+| `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:849` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:977` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:976` | `packages/tooling/nros-platform-config` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:978` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_POLL_INTERVAL_MS` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:980` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_REPLY_BUF_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:979` | `packages/tooling/nros-platform-config` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_LARGE_SUBSCRIBERS` | 2 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-01): W2-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params`, `rmw`, `net` and `runtime` tenants done, its remaining tenants and W1
+`zenoh.tx`, `memory`, `params`, `rmw`, `net`, `runtime` and `zenoh.wire` tenants done, its remaining tenants and W1
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -312,6 +312,39 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The `zenoh.wire` tenant — done, and the two priorities left out
+
+Five wire sizes — the unicast and multicast batch buffers, the fragmentation
+ceiling, the get-reply staging block and its poll interval — now resolve through
+the ladder as `[knobs.zenoh.wire]`, beside the existing `[knobs.zenoh.tx]`.
+
+This does NOT contradict "the zenoh tenant is not W6's" above. That re-scope was
+about the entity CAPS and pools — `ZPICO_MAX_QUERYABLES`, `ZPICO_MAX_SESSIONS`,
+`SERVICE_BUFFERS` — which phase-392 is deciding the shape of. These five are
+sizes of the wire itself, and the same re-scope listed them as W6's remainder.
+
+**The two transport-band priorities are deliberately NOT here.**
+`ZPICO_READ_TASK_PRIORITY` and `ZPICO_LEASE_TASK_PRIORITY` look like the rest of
+the family and are not: the build script's defaults MIRROR the `#define`
+fallbacks in `zpico-sys/c/zpico/zpico.c`, and `FreertosScheduling` already
+carries a per-board `zenoh_read_priority` / `zenoh_lease_priority` in raw
+FreeRTOS units. A ladder rung would be a THIRD path to one number, which is the
+drift `check-knob-single-reader` exists to prevent. Their real question is
+ORDERING against the app tiers (issue 0623), which is a policy the board already
+expresses — not a size a platform defaults.
+
+The builtins stay the CALLER's: `nros-zpico-build` computes a batch and
+fragmentation size from the platform's transport before any descriptor is read,
+so `resolve_wire` takes them as its `defaults` and applies the rungs above them.
+
+Verification note, stated plainly: the resolver is pinned by a unit test over
+all four rungs. The build script's half is five straight-line assignments
+mirroring the tx trio two lines above them, and it is NOT verified by an
+emitted-artifact probe — the header it writes is produced inside example build
+trees, and every probe I wrote observed the wrong tree.
+
+Backlog after this: **10**, from 15.
 
 ### The `runtime` tenant — done
 

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -450,8 +450,12 @@ fn shim_config_from_env() -> ShimConfig {
         max_liveliness: env_usize("ZPICO_MAX_LIVELINESS", 16),
         max_pending_gets: env_usize("ZPICO_MAX_PENDING_GETS", 4),
         max_sessions: env_usize("ZPICO_MAX_SESSIONS", 1),
-        get_reply_buf_size: env_usize("ZPICO_GET_REPLY_BUF_SIZE", 4096),
-        get_poll_interval_ms: env_usize("ZPICO_GET_POLL_INTERVAL_MS", 10),
+        // phase-400 W6 — BUILTINS, like the tx pair below: these five are
+        // ladder knobs now, and `resolve_wire` overwrites them where the rungs
+        // are known (search `shim_config.get_reply_buf_size =`). Reading the
+        // environment twice is what `check-knob-single-reader` forbids.
+        get_reply_buf_size: 4096,
+        get_poll_interval_ms: 10,
         // phase-400 W8 — the BUILTINS, not a second env read. These two are
         // ladder knobs, and the resolved values overwrite them below (search
         // `shim_config.tx_batch =`), so reading the environment here was dead
@@ -483,9 +487,13 @@ fn zenoh_buffer_config_from_env(posix: bool) -> ZenohBufferConfig {
     };
 
     ZenohBufferConfig {
-        frag_max_size: env_usize("ZPICO_FRAG_MAX_SIZE", default_frag),
-        batch_unicast_size: env_usize("ZPICO_BATCH_UNICAST_SIZE", default_batch_uni),
-        batch_multicast_size: env_usize("ZPICO_BATCH_MULTICAST_SIZE", default_batch_multi),
+        // phase-400 W6 — the computed per-platform BUILTINS. `resolve_wire`
+        // takes them as its `defaults` and applies the rungs above them, so the
+        // transport still picks the starting number and a descriptor can still
+        // override it.
+        frag_max_size: default_frag,
+        batch_unicast_size: default_batch_uni,
+        batch_multicast_size: default_batch_multi,
     }
 }
 
@@ -941,13 +949,17 @@ pub fn run() {
     // issue 0460 — the same env-or-Kconfig ladder the sized knobs use, so the
     // tx trio is not one more thing a Zephyr RUST image reads as "unset".
     let env_get = |name: &str| kconfig_fallback_str(name);
+    // phase-400 W6 — loaded ONCE and shared by both zenoh tenants (`tx` and
+    // `wire`). It used to live inside the tx arm; a second `load` for the wire
+    // knobs would parse the same file twice and could disagree with itself if
+    // one call site ever grew an option the other did not.
+    let board_knobs = env_get("NROS_BOARD_TOML").map(|path| {
+        let p = PathBuf::from(&path);
+        println!("cargo:rerun-if-changed={}", p.display());
+        platform_config::BoardKnobsFile::load(&p).unwrap_or_else(|e| panic!("{path}: {e}"))
+    });
     let tx_knobs = match (&platforms_tree, platform_name) {
         (Some(tree), Some(name)) => {
-            let board_knobs = env_get("NROS_BOARD_TOML").map(|path| {
-                let p = PathBuf::from(&path);
-                println!("cargo:rerun-if-changed={}", p.display());
-                platform_config::BoardKnobsFile::load(&p).unwrap_or_else(|e| panic!("{path}: {e}"))
-            });
             let mut tx = tree
                 .resolve_tx(
                     name,
@@ -979,7 +991,7 @@ pub fn run() {
     // Read buffer config with platform-appropriate defaults
     // NuttX is POSIX-compatible, use same defaults as posix.
     // ThreadX uses NetX Duo BSD sockets, treat as posix-like for buffer defaults.
-    let buf_config = zenoh_buffer_config_from_env(use_posix || use_nuttx || use_threadx);
+    let mut buf_config = zenoh_buffer_config_from_env(use_posix || use_nuttx || use_threadx);
 
     // Read shim slot counts from ZPICO_MAX_* env vars and generate Rust consts
     let mut shim_config = shim_config_from_env();
@@ -987,6 +999,68 @@ pub fn run() {
     // top-rung values; overwrite the tx pair with the ladder-resolved ones.
     shim_config.tx_batch = tx_knobs.batch.value;
     shim_config.tx_batch_flush_ms = tx_knobs.flush_ms.value as usize;
+    // phase-400 W6 — the zenoh WIRE sizes, same ladder. The builtins are the
+    // values `shim_config_from_env` just computed from the platform's
+    // transport, so a board that says nothing keeps the transport-appropriate
+    // number and a board that speaks outranks it.
+    {
+        let wire_defaults: [(&'static str, usize); 5] = [
+            ("batch_unicast_size", buf_config.batch_unicast_size),
+            ("batch_multicast_size", buf_config.batch_multicast_size),
+            ("frag_max_size", buf_config.frag_max_size),
+            ("get_reply_buf_size", shim_config.get_reply_buf_size),
+            ("get_poll_interval_ms", shim_config.get_poll_interval_ms),
+        ];
+        for key in platform_config::WIRE_KNOBS {
+            println!(
+                "cargo:rerun-if-env-changed={}",
+                platform_config::wire_env_key(key)
+            );
+        }
+        let resolved = match (&platforms_tree, platform_name) {
+            (Some(tree), Some(name)) => tree
+                .resolve_wire(
+                    name,
+                    board_knobs.as_ref().map(|b| &b.knobs.zenoh.wire),
+                    &env_get,
+                    &wire_defaults,
+                )
+                .unwrap_or_else(|e| panic!("nros-platform.toml: {e}")),
+            // No platform named: the env front-end over the computed builtins,
+            // which is what an out-of-tree consumer and a plain `cargo build`
+            // get.
+            _ => wire_defaults
+                .iter()
+                .map(|(name, builtin)| {
+                    let key = platform_config::wire_env_key(name);
+                    let value = env_get(key)
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                        .unwrap_or(*builtin);
+                    (*name, value)
+                })
+                .map(|(name, value)| {
+                    (
+                        name,
+                        platform_config::ResolvedUsize {
+                            value,
+                            source: platform_config::KnobSource::Builtin,
+                            env_key: platform_config::wire_env_key(name),
+                        },
+                    )
+                })
+                .collect(),
+        };
+        for (name, r) in resolved {
+            match name {
+                "batch_unicast_size" => buf_config.batch_unicast_size = r.value,
+                "batch_multicast_size" => buf_config.batch_multicast_size = r.value,
+                "frag_max_size" => buf_config.frag_max_size = r.value,
+                "get_reply_buf_size" => shim_config.get_reply_buf_size = r.value,
+                "get_poll_interval_ms" => shim_config.get_poll_interval_ms = r.value,
+                other => unreachable!("unknown wire knob `{other}`"),
+            }
+        }
+    }
     std::fs::write(out_dir.join("shim_constants.rs"), shim_config.rust_consts()).unwrap();
 
     // Phase 134.3 — `zenoh_generic_config.h` is the single source of

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -422,6 +422,25 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.zenoh.wire]` RUNGS for this build — platform merged with
+    /// board, board winning. See [`Self::rmw_rungs`].
+    pub fn wire_rungs(&self) -> WireKnobs {
+        let plat = self.tree.platform_wire_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("zenoh.wire", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.zenoh.wire.clone())
+            .unwrap_or_default();
+        WireKnobs {
+            batch_unicast_size: b.batch_unicast_size.or(plat.batch_unicast_size),
+            batch_multicast_size: b.batch_multicast_size.or(plat.batch_multicast_size),
+            frag_max_size: b.frag_max_size.or(plat.frag_max_size),
+            get_reply_buf_size: b.get_reply_buf_size.or(plat.get_reply_buf_size),
+            get_poll_interval_ms: b.get_poll_interval_ms.or(plat.get_poll_interval_ms),
+        }
+    }
+
     /// The `[knobs.runtime]` RUNGS for this build — platform merged with board,
     /// board winning. See [`Self::rmw_rungs`].
     pub fn runtime_rungs(&self) -> RuntimeKnobs {
@@ -914,6 +933,53 @@ pub struct ResolvedTransport {
 pub struct ZenohKnobs {
     #[serde(default)]
     pub tx: TxKnobs,
+    /// phase-400 W6 — the WIRE sizes: batch buffers, the fragmentation
+    /// ceiling, the get-reply staging block and its poll interval.
+    ///
+    /// Deliberately NOT the entity caps. `ZPICO_MAX_QUERYABLES`,
+    /// `ZPICO_MAX_SESSIONS` and `SERVICE_BUFFERS` are phase-392's question —
+    /// that phase is deciding whether they stop being globals at all, and a
+    /// per-platform rung would answer it the wrong way. These five are sizes of
+    /// the wire itself, which no campaign derives.
+    #[serde(default)]
+    pub wire: WireKnobs,
+}
+
+/// phase-400 W6 — the zenoh WIRE sizes, read by `nros-zpico-build`.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireKnobs {
+    #[serde(default)]
+    pub batch_unicast_size: Option<usize>,
+    #[serde(default)]
+    pub batch_multicast_size: Option<usize>,
+    #[serde(default)]
+    pub frag_max_size: Option<usize>,
+    #[serde(default)]
+    pub get_reply_buf_size: Option<usize>,
+    #[serde(default)]
+    pub get_poll_interval_ms: Option<usize>,
+}
+
+/// Every wire knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const WIRE_KNOBS: &[&str] = &[
+    "batch_unicast_size",
+    "batch_multicast_size",
+    "frag_max_size",
+    "get_reply_buf_size",
+    "get_poll_interval_ms",
+];
+
+/// The env front-end for a wire knob — the EXISTING `ZPICO_*` names.
+pub fn wire_env_key(knob: &str) -> &'static str {
+    match knob {
+        "batch_unicast_size" => "ZPICO_BATCH_UNICAST_SIZE",
+        "batch_multicast_size" => "ZPICO_BATCH_MULTICAST_SIZE",
+        "frag_max_size" => "ZPICO_FRAG_MAX_SIZE",
+        "get_reply_buf_size" => "ZPICO_GET_REPLY_BUF_SIZE",
+        "get_poll_interval_ms" => "ZPICO_GET_POLL_INTERVAL_MS",
+        other => panic!("unknown wire knob `{other}`"),
+    }
 }
 
 /// The phase-282 TX levers. All optional — `None` means "defer to the
@@ -1542,6 +1608,80 @@ impl PlatformsTree {
         Ok(out)
     }
 
+    fn platform_wire_knobs(&self, name: &str) -> Result<WireKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = WireKnobs::default();
+        for file in chain.iter().rev() {
+            let w = &file.knobs.zenoh.wire;
+            for (dst, src) in [
+                (&mut out.batch_unicast_size, w.batch_unicast_size),
+                (&mut out.batch_multicast_size, w.batch_multicast_size),
+                (&mut out.frag_max_size, w.frag_max_size),
+                (&mut out.get_reply_buf_size, w.get_reply_buf_size),
+                (&mut out.get_poll_interval_ms, w.get_poll_interval_ms),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// phase-400 W6 — resolve the zenoh WIRE tenant over the RFC-0049 ladder.
+    ///
+    /// `defaults` carries the CALLER's builtins because they are computed, not
+    /// constant: `nros-zpico-build` picks a batch and fragmentation size from
+    /// the platform's transport before any descriptor is consulted. The ladder
+    /// still owns the rungs above them.
+    pub fn resolve_wire(
+        &self,
+        platform: &str,
+        board: Option<&WireKnobs>,
+        env: &dyn Fn(&str) -> Option<String>,
+        defaults: &[(&'static str, usize)],
+    ) -> Result<Vec<(&'static str, ResolvedUsize)>, ConfigError> {
+        let plat = self.platform_wire_knobs(platform)?;
+        let pick = |k: &WireKnobs, name: &str| match name {
+            "batch_unicast_size" => k.batch_unicast_size,
+            "batch_multicast_size" => k.batch_multicast_size,
+            "frag_max_size" => k.frag_max_size,
+            "get_reply_buf_size" => k.get_reply_buf_size,
+            "get_poll_interval_ms" => k.get_poll_interval_ms,
+            _ => None,
+        };
+        let mut out = Vec::new();
+        for (name, builtin) in defaults {
+            let (mut value, mut source) =
+                match (board.and_then(|b| pick(b, name)), pick(&plat, name)) {
+                    (Some(v), _) => (v, KnobSource::Board),
+                    (None, Some(v)) => (v, KnobSource::Platform),
+                    (None, None) => (*builtin, KnobSource::Builtin),
+                };
+            let env_key = wire_env_key(name);
+            if let Some(raw) = env(env_key)
+                && let Ok(n) = raw.trim().parse::<usize>()
+            {
+                value = n;
+                source = KnobSource::Env;
+            }
+            out.push((
+                *name,
+                ResolvedUsize {
+                    value,
+                    source,
+                    env_key,
+                },
+            ));
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.zenoh.wire]` rungs for a platform, inherits chain applied.
+    pub fn platform_wire_rungs(&self, platform: &str) -> Result<WireKnobs, ConfigError> {
+        self.platform_wire_knobs(platform)
+    }
+
     /// The `[knobs.runtime]` rungs for a platform, inherits chain applied.
     pub fn platform_runtime_rungs(&self, platform: &str) -> Result<RuntimeKnobs, ConfigError> {
         self.platform_runtime_knobs(platform)
@@ -2160,6 +2300,68 @@ impl BoardKnobsFile {
 
 #[cfg(test)]
 mod tests {
+    /// The zenoh WIRE ladder: builtin < platform < board < env.
+    ///
+    /// The `nros-zpico-build` side of this tenant writes a C header from an
+    /// example build tree, which made an end-to-end probe unreliable to observe
+    /// — so the RESOLVER is pinned here instead, and the build script's job is
+    /// reduced to five straight-line assignments that mirror the tx trio two
+    /// lines above them.
+    #[test]
+    fn the_wire_ladder_resolves_builtin_platform_board_and_env() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("posix")).unwrap();
+        std::fs::write(
+            dir.path().join("posix/nros-platform.toml"),
+            "[knobs.zenoh.wire]\nfrag_max_size = 777\nget_reply_buf_size = 1234\n",
+        )
+        .unwrap();
+        let tree = PlatformsTree::load_search_path(&[dir.path().to_path_buf()]).expect("tree");
+        let defaults = [
+            ("frag_max_size", 2048usize),
+            ("get_reply_buf_size", 4096),
+            ("get_poll_interval_ms", 10),
+        ];
+
+        // platform rung over the caller's computed builtins
+        let got = tree
+            .resolve_wire("posix", None, &|_| None, &defaults)
+            .expect("resolve");
+        let by = |n: &str| got.iter().find(|(k, _)| *k == n).unwrap().1.clone();
+        assert_eq!(by("frag_max_size").value, 777);
+        assert_eq!(by("frag_max_size").source, KnobSource::Platform);
+        // a knob the platform does not name keeps the CALLER's builtin, which is
+        // the whole reason `defaults` is a parameter: it is computed per
+        // transport, not a constant.
+        assert_eq!(by("get_poll_interval_ms").value, 10);
+        assert_eq!(by("get_poll_interval_ms").source, KnobSource::Builtin);
+
+        // board outranks platform
+        let board = WireKnobs {
+            frag_max_size: Some(99),
+            ..Default::default()
+        };
+        let got = tree
+            .resolve_wire("posix", Some(&board), &|_| None, &defaults)
+            .expect("resolve");
+        let hit = got.iter().find(|(k, _)| *k == "frag_max_size").unwrap();
+        assert_eq!(hit.1.value, 99);
+        assert_eq!(hit.1.source, KnobSource::Board);
+
+        // env outranks both
+        let got = tree
+            .resolve_wire(
+                "posix",
+                Some(&board),
+                &|k| (k == "ZPICO_FRAG_MAX_SIZE").then(|| "555".to_string()),
+                &defaults,
+            )
+            .expect("resolve");
+        let hit = got.iter().find(|(k, _)| *k == "frag_max_size").unwrap();
+        assert_eq!(hit.1.value, 555);
+        assert_eq!(hit.1.source, KnobSource::Env);
+    }
+
     /// A platform with NO descriptor resolves to builtins; a BROKEN one does not.
     ///
     /// The phase-400 W6 regression this pins killed every image of the three

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -91,6 +91,15 @@ OWNERS: dict[str, str] = {
     "NROS_RUNTIME_COMPONENT_SLOT_BYTES": "packages/api/nros/build.rs",
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": "packages/api/nros/build.rs",
     "NROS_RUNTIME_MAX_CELL_ENTITIES": "packages/api/nros/build.rs",
+    # The zenoh WIRE tenant (phase-400 W6). The two transport-band PRIORITIES
+    # are deliberately absent: `ZPICO_READ_TASK_PRIORITY` mirrors a C `#define`
+    # and `FreertosScheduling` already carries a per-board `zenoh_read_priority`
+    # in raw FreeRTOS units, so a rung would be a THIRD path to one number.
+    "ZPICO_BATCH_UNICAST_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_BATCH_MULTICAST_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_FRAG_MAX_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_GET_REPLY_BUF_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    "ZPICO_GET_POLL_INTERVAL_MS": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 32
+LADDER_FLOOR = 37
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -123,11 +123,11 @@ KNOB_CLASS = {
     "ZPICO_MAX_SESSIONS": ("derived", "phase-392 poses it explicitly: joins the model, or stays a knob and that phase says so"),
     "ZPICO_MAX_LIVELINESS": ("derived", "entity cap; phase-392"),
     "ZPICO_MAX_PENDING_GETS": ("derived", "entity cap; phase-392"),
-    "ZPICO_BATCH_UNICAST_SIZE": ("sizing", "wire batch buffer"),
-    "ZPICO_BATCH_MULTICAST_SIZE": ("sizing", "wire batch buffer"),
-    "ZPICO_FRAG_MAX_SIZE": ("sizing", "fragmentation ceiling"),
-    "ZPICO_GET_REPLY_BUF_SIZE": ("sizing", "reply staging block"),
-    "ZPICO_GET_POLL_INTERVAL_MS": ("sizing", "a poll interval, not a size; same ladder shape"),
+    "ZPICO_BATCH_UNICAST_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_BATCH_MULTICAST_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_FRAG_MAX_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_GET_REPLY_BUF_SIZE": ("ladder", "zenoh.wire tenant"),
+    "ZPICO_GET_POLL_INTERVAL_MS": ("ladder", "zenoh.wire tenant"),
     "ZPICO_READ_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
     "ZPICO_LEASE_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
     "NROS_LET_BUFFER_SIZE": ("sizing", "logical-execution-time buffer"),
@@ -259,6 +259,7 @@ def ladder_knobs():
         "RmwKnobs",
         "NetKnobs",
         "RuntimeKnobs",
+        "WireKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:

--- a/scripts/gen-pool-inventory.py
+++ b/scripts/gen-pool-inventory.py
@@ -116,6 +116,26 @@ def crate_of(rel):
 # silently dropped by a literal-only regex.
 KNOB_ANY = re.compile(r'\b(?:env_usize(?:_compat|_min)?|knob)\(\s*"([A-Z0-9_]+)"')
 
+# A knob whose FRONT-END NAME lives in a ladder mapping rather than a call.
+#
+# phase-400 W6 moves a knob's resolution out of its build script and into the
+# RFC-0049 ladder. The build script then reads no environment at all — the
+# ladder does, through `<tenant>_env_key`, whose body is a match from field name
+# to env name:
+#
+#     "frag_max_size" => "ZPICO_FRAG_MAX_SIZE",
+#
+# The call-shaped patterns above cannot see that, so migrating a tenant DELETED
+# its knobs from this table: five vanished with the `zenoh.wire` tenant, three
+# with `params` before that. A knob nobody can enumerate is a knob nobody sets
+# (issue 0271), and "it moved to the ladder" is not a reason to stop listing it
+# — the ladder is where a user sets it.
+#
+# Their default is deliberately recorded as COMPUTED: a ladder knob's builtin
+# may be per-platform (`nros-zpico-build` picks a batch size from the
+# transport), so a single number here would be a claim this file cannot make.
+LADDER_ENV_KEY = re.compile(r'=>\s*"([A-Z][A-Z0-9_]+)"\s*,')
+
 
 def scan(files=None):
     """(knobs, pools) — knobs: name -> (default, file, line); pools: list."""
@@ -145,6 +165,12 @@ def scan(files=None):
                 # None default = computed expression; render says so rather
                 # than dropping the row.
                 knobs.setdefault(name, (None, rel, line, False))
+        if "_env_key" in text:
+            for m in LADDER_ENV_KEY.finditer(text):
+                name = m.group(1)
+                if name not in knobs:
+                    line = text[: m.start()].count("\n") + 1
+                    knobs.setdefault(name, (None, rel, line, False))
         for m in POOL_ANNOT.finditer(text):
             expr = m.group(2).replace("\\", " ").strip()
             pools.append((m.group(1), expr, rel, text[: m.start()].count("\n") + 1))


### PR DESCRIPTION
Stacked on #278. Five zenoh **wire sizes** — the unicast and multicast batch buffers, the fragmentation ceiling, the get-reply staging block and its poll interval — now resolve through the ladder as `[knobs.zenoh.wire]`, beside the existing `[knobs.zenoh.tx]`.

This does **not** contradict *"the zenoh tenant is not W6's"*. That re-scope was about the entity **caps** (`ZPICO_MAX_QUERYABLES`, `ZPICO_MAX_SESSIONS`, `SERVICE_BUFFERS`) which phase-392 is deciding the shape of — and it listed these five as W6's remainder in the same table.

## The two priorities are deliberately left out

`ZPICO_READ_TASK_PRIORITY` and `ZPICO_LEASE_TASK_PRIORITY` sit three lines from the others and look identical. They aren't:

- the build script's defaults **mirror the `#define` fallbacks** in `zpico-sys/c/zpico/zpico.c` — *"a different number here would not be a tuning choice, it would be the two lanes disagreeing"*
- `FreertosScheduling` **already** carries a per-board `zenoh_read_priority` / `zenoh_lease_priority` in raw FreeRTOS units

A rung would be a **third** path to one number. Their real question is *ordering* against the app tiers (issue 0623) — a policy the board already expresses, not a size a platform defaults.

## The builtins stay the caller's

`nros-zpico-build` computes a batch and fragmentation size from the platform's transport before any descriptor is read, so `resolve_wire` takes them as its `defaults` and applies the rungs above them. A board that says nothing keeps the transport-appropriate number.

`board_knobs` is now loaded **once** and shared by both zenoh tenants; a second `load` would parse the same file twice and could disagree with itself.

## Two regressions I caused and caught

Both from one cause — *a knob that stops being read by a call becomes invisible to tools that scan for calls*:

- **the census** stopped seeing the five names. Expected: the ladder reads them through `wire_env_key`, and the ladder count comes from the struct fields, so the backlog stays right.
- **`gen-pool-inventory` deleted five rows** from the published inventory. That one matters — *"a knob nobody can enumerate is a knob nobody sets"* is issue 0271, which cost ~145 KB. The generator now also reads ladder env-key mappings, and recovered **eight** rows: these five plus three the `memory` tenant had silently dropped earlier and nobody noticed.

## Verification, and its limit

`resolve_wire` is pinned by a unit test over all four rungs (builtin → platform → board → env).

The build script's half is five straight-line assignments mirroring the tx trio two lines above them, and it is **not** verified by an emitted-artifact probe — the header it writes is produced inside example build trees, and every probe I wrote observed the wrong tree. Saying so rather than implying coverage I don't have.

- `just check fast` — 190/190
- `just ci l1` — passed
- `just check submodule-pins` — 0 pins moved

Census: backlog **15 → 10**.
