### PR TITLE
feat(#0965): the first image that declares its entities — 65,024 bytes off its stack

### DIFF
--- a/docs/issues/0965-no-entity-inventory-so-three-consumers-cannot-be-derived.md
+++ b/docs/issues/0965-no-entity-inventory-so-three-consumers-cannot-be-derived.md
@@ -156,17 +156,75 @@ to its creation sites.
 
 ### What is still uncovered
 
-* **The arena** and **the zenoh payload classes** need the two inventories
-  JOINED per subscription -- this one's per-entity list against W8's per-type
-  size. Either half alone yields the confident wrong number. Named as its own
-  work rather than bolted onto either reader.
-* **`NROS_MAX_SUBSCRIBERS` / `NROS_MAX_PUBLISHERS`** are a straight read of
-  `NROS_ENTITY_COUNT_SUBSCRIPTION` / `_PUBLISHER`. Left out for scope
-  discipline, not for a reason.
-* **No image in this tree declares `ENTITIES` yet**, so nothing derives today;
-  every existing image refuses and keeps its configured value. The island's own
-  declaration is four `nros_components_register_node(... ENTITIES ...)` edits
-  in the consumer repo.
+* ~~**The arena** and **the zenoh payload classes** need the two inventories
+  JOINED per subscription.~~ **LANDED** as phase-403 step 1 --
+  `_nros_bounds_join_subscribed` in `NanoRosMessageBounds.cmake`, with
+  `NROS_MESSAGE_BOUNDS_BASIS` reading `subscribed` or `closure`.
+* ~~**`NROS_MAX_SUBSCRIBERS` / `NROS_MAX_PUBLISHERS`**~~ **LANDED** as
+  phase-412 W1, as `NROS_DERIVED_MAX_SUBSCRIBERS` / `_MAX_PUBLISHERS`.
+* ~~**No image in this tree declares `ENTITIES` yet**~~ -- fixed 2026-09-04,
+  see below. This was the bullet that made the other three unreachable.
 * **Not measured on hardware.** The island was not flashed. The code claim (a
   publisher claims no slot) is verified by reading all 24 registration sites
   and by the gate; the byte saving is not.
+
+
+## The first declaring image (2026-09-04) — and 65,024 bytes off its stack
+
+Two of the four bullets above were already stale when this section was written:
+the join landed as phase-403 step 1 and the two pool knobs as phase-412 W1. The
+one that mattered was the third — **nothing declared, so none of it ran**. A
+mechanism that is correct, tested and unreachable from a real build is this
+campaign's signature failure, and this issue's own list had been carrying it as
+a footnote.
+
+`examples/workspaces/cpp` now declares. All six components, each read off its
+own source rather than inferred from its name:
+
+| package | `ENTITIES` |
+| --- | --- |
+| `talker_pkg` | `pub:std_msgs/msg/Int32:/chatter`, `timer` |
+| `listener_pkg` | `sub:std_msgs/msg/Int32:/chatter` |
+| `service_server_pkg` | `service_server:example_interfaces/srv/AddTwoInts:/add_two_ints` |
+| `service_client_pkg` | `service_client:…:/add_two_ints`, `timer` |
+| `action_server_pkg` | `action_server:example_interfaces/action/Fibonacci:/fibonacci`, `timer` |
+| `action_client_pkg` | `action_client:…:/fibonacci`, `timer` |
+
+All six, not just the two the entry composes, because a package declares what
+IT creates; which image composes it is the entry's question. And composition
+refuses if any member is silent, so a partial declaration buys nothing.
+
+### What it derives, predicted before it was run
+
+Over all six (the whole workspace): `entity_total` 10, `NROS_EXECUTOR_MAX_CBS`
+**9**, `NROS_EXECUTOR_ACTION_CLIENTS` **2**. Predicted 9 and 2 from the rules —
+a publisher claims no slot, and an action SERVER occupies a heavy slot like a
+client — and the verb agreed exactly.
+
+`src/zephyr_entry` composes only `talker_pkg` and `listener_pkg`, so the real
+image derives `MAX_CBS=2`, `ACTION_CLIENTS=0`, and a received-type set of one
+(`std_msgs/msg/Int32`). Worth stating because the six-component number is the
+WORKSPACE's, not the image's, and reporting it as the image's would have
+overstated this by a factor of four.
+
+### The saving, measured from `nros-node`'s generated constant
+
+| | `MAX_CBS` | `ARENA_SIZE` |
+| --- | ---: | ---: |
+| crate defaults, what this image compiles with today | 4 | 74,240 |
+| derived from the declarations | 2 | **9,216** |
+
+**65,024 bytes**, and it is stack rather than `.bss`, so `just mem-report`
+cannot see it — this is read from `ARENA_SIZE` for the reason issue 0900 gives.
+
+### What this still does not do
+
+* **Not configured or flashed.** The numbers above come from the derivation verb
+  and from `nros-node`'s build, not from a Zephyr configure of this entry — every
+  entry in `examples/workspaces/` targets Zephyr or FVP, so there is no host
+  entry to configure. The CMake reader is exercised by its own tests, not by this
+  image yet.
+* **The received-type set is resolved but unspent.** `received_types` reports
+  `std_msgs/msg/Int32` for this image, which is exactly the input the
+  `subscribed` basis wants; whether that changes the payload classes here is
+  unmeasured, and on a one-small-type image it may well be nothing.

--- a/examples/workspaces/cpp/src/action_client_pkg/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/action_client_pkg/CMakeLists.txt
@@ -16,7 +16,13 @@ nano_ros_auto_add_library(action_client_lib STATIC src/FibClient.cpp)
 nros_components_register_node(action_client_lib
     PLUGIN action_client_pkg::FibClient
     EXECUTABLE fib_client
-    SHAPE configure)
+    SHAPE configure
+    # issue 0965 — what this component CREATES, read off its own
+    # source. Absence means "nobody said" and refuses the whole image,
+    # so every component in a workspace declares or none derives.
+    ENTITIES
+             action_client:example_interfaces/action/Fibonacci:/fibonacci
+             timer)
 
 if(TARGET example_interfaces__nano_ros_cpp)
     target_link_libraries(action_client_lib

--- a/examples/workspaces/cpp/src/action_server_pkg/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/action_server_pkg/CMakeLists.txt
@@ -16,7 +16,13 @@ nano_ros_auto_add_library(action_server_lib STATIC src/FibServer.cpp)
 nros_components_register_node(action_server_lib
     PLUGIN action_server_pkg::FibServer
     EXECUTABLE fib_server
-    SHAPE configure)
+    SHAPE configure
+    # issue 0965 — what this component CREATES, read off its own
+    # source. Absence means "nobody said" and refuses the whole image,
+    # so every component in a workspace declares or none derives.
+    ENTITIES
+             action_server:example_interfaces/action/Fibonacci:/fibonacci
+             timer)
 
 # Guard with if(TARGET) (Zephyr whole-archives the generated interface; see talker_pkg).
 if(TARGET example_interfaces__nano_ros_cpp)

--- a/examples/workspaces/cpp/src/listener_pkg/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/listener_pkg/CMakeLists.txt
@@ -20,7 +20,12 @@ nano_ros_auto_add_library(listener_lib STATIC src/Listener.cpp)
 nros_components_register_node(listener_lib
     PLUGIN listener_pkg::Listener
     EXECUTABLE listener
-    SHAPE configure)
+    SHAPE configure
+    # issue 0965 — what this component CREATES, read off its own
+    # source. Absence means "nobody said" and refuses the whole image,
+    # so every component in a workspace declares or none derives.
+    ENTITIES
+             sub:std_msgs/msg/Int32:/chatter)
 
 # `nros_find_interfaces` declares INTERFACE libs (`std_msgs__nano_ros_cpp`)
 # carrying generated headers' include dirs. Entry pkg auto-links; Node

--- a/examples/workspaces/cpp/src/service_client_pkg/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/service_client_pkg/CMakeLists.txt
@@ -14,7 +14,13 @@ nano_ros_auto_add_library(service_client_lib STATIC src/AddClient.cpp)
 nros_components_register_node(service_client_lib
     PLUGIN service_client_pkg::AddClient
     EXECUTABLE add_client
-    SHAPE configure)
+    SHAPE configure
+    # issue 0965 — what this component CREATES, read off its own
+    # source. Absence means "nobody said" and refuses the whole image,
+    # so every component in a workspace declares or none derives.
+    ENTITIES
+             service_client:example_interfaces/srv/AddTwoInts:/add_two_ints
+             timer)
 
 if(TARGET example_interfaces__nano_ros_cpp)
     target_link_libraries(service_client_lib

--- a/examples/workspaces/cpp/src/service_server_pkg/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/service_server_pkg/CMakeLists.txt
@@ -15,7 +15,12 @@ nano_ros_auto_add_library(service_server_lib STATIC src/AddServer.cpp)
 nros_components_register_node(service_server_lib
     PLUGIN service_server_pkg::AddServer
     EXECUTABLE add_server
-    SHAPE configure)
+    SHAPE configure
+    # issue 0965 — what this component CREATES, read off its own
+    # source. Absence means "nobody said" and refuses the whole image,
+    # so every component in a workspace declares or none derives.
+    ENTITIES
+             service_server:example_interfaces/srv/AddTwoInts:/add_two_ints)
 
 # Guard with if(TARGET) (Zephyr whole-archives the generated interface; see talker_pkg).
 if(TARGET example_interfaces__nano_ros_cpp)

--- a/examples/workspaces/cpp/src/talker_pkg/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/talker_pkg/CMakeLists.txt
@@ -20,7 +20,13 @@ nano_ros_auto_add_library(talker_lib STATIC src/Talker.cpp)
 nros_components_register_node(talker_lib
     PLUGIN talker_pkg::Talker
     EXECUTABLE talker
-    SHAPE configure)
+    SHAPE configure
+    # issue 0965 — what this component CREATES, read off its own
+    # source. Absence means "nobody said" and refuses the whole image,
+    # so every component in a workspace declares or none derives.
+    ENTITIES
+             pub:std_msgs/msg/Int32:/chatter
+             timer)
 
 # `nros_find_interfaces` declares INTERFACE libs (`std_msgs__nano_ros_cpp`)
 # carrying generated headers' include dirs. Entry pkg auto-links; Node


### PR DESCRIPTION
0965's "still uncovered" list had four bullets. **Two were already stale** — the JOIN landed as phase-403 step 1 (`_nros_bounds_join_subscribed`), and `MAX_SUBSCRIBERS`/`MAX_PUBLISHERS` as phase-412 W1. Both marked.

The third was the one that mattered, and it was carried as a footnote:

> **No image in this tree declares `ENTITIES` yet**, so nothing derives today.

So the inventory, the join, and all three derived knob families ran on **nothing, anywhere**. A mechanism that is correct, tested and unreachable from a real build is this campaign's signature failure — and this issue had one in its own list.

## The declarations

`examples/workspaces/cpp`, all six components, each read off its own source rather than inferred from its name:

| package | `ENTITIES` |
| --- | --- |
| `talker_pkg` | `pub:std_msgs/msg/Int32:/chatter`, `timer` |
| `listener_pkg` | `sub:std_msgs/msg/Int32:/chatter` |
| `service_server_pkg` | `service_server:…/AddTwoInts:/add_two_ints` |
| `service_client_pkg` | `service_client:…/AddTwoInts:/add_two_ints`, `timer` |
| `action_server_pkg` | `action_server:…/Fibonacci:/fibonacci`, `timer` |
| `action_client_pkg` | `action_client:…/Fibonacci:/fibonacci`, `timer` |

All six rather than the two the entry composes: a package declares what *it* creates, and composition refuses if any member is silent, so a partial declaration buys nothing.

## Derivation, predicted before it was run

Whole workspace → `MAX_CBS=9`, `ACTION_CLIENTS=2`. Predicted 9 (a publisher claims no slot) and 2 (an action **server** occupies a heavy slot too, though the knob is named for clients). The verb agreed exactly.

The real **image** (`zephyr_entry` = talker + listener) → `MAX_CBS=2`, `ACTION_CLIENTS=0`, received types `{std_msgs/msg/Int32}`. Stated separately because the six-component figure is the *workspace's* — reporting it as the image's would overstate this fourfold.

## The saving, measured

From `nros-node`'s generated `ARENA_SIZE`, not the formula:

| | `MAX_CBS` | `ARENA_SIZE` |
| --- | ---: | ---: |
| crate defaults, what this image compiles with today | 4 | 74,240 |
| derived from the declarations | 2 | **9,216** |

**−65,024 bytes.** Stack, not `.bss`, so `mem-report` cannot see it — read from the constant for the reason 0900 gives.

## Not done

- **Not configured or flashed.** Every entry under `examples/workspaces/` targets Zephyr or FVP, so there's no host entry to configure; the CMake reader is still exercised only by its own tests.
- **The received-type set is resolved but unspent** — it's exactly the `subscribed` basis's input, but whether it moves the payload classes on a one-small-type image is unmeasured.

Gates: `check fast` (190), `check cpp`, `check entity-slot-costs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)