### PR TITLE
fix(#0963): the join checks its own set — and "narrow the closure" is blocked by ordering

### DIFF
--- a/cmake/NanoRosMessageBounds.cmake
+++ b/cmake/NanoRosMessageBounds.cmake
@@ -789,6 +789,24 @@ function(_nros_bounds_join_subscribed _frag _ceiling
             list(APPEND _unpriced "${_t}")
             continue()
         endif()
+        # A subscribed type that is `unbounded`/`unresolved` has no `_RX` worth
+        # reading, and reading one anyway would size a payload class from a
+        # blank or a placeholder -- the silent BufferTooSmall this module exists
+        # to prevent.
+        #
+        # Today this cannot fire: the closure-wide open-type check above
+        # `return()`s before this function is called, and the subscribed set is
+        # a SUBSET of the closure. That is exactly why the check belongs here.
+        # The invariant lives in another block, thirty lines up, and nothing
+        # states the dependency -- so the first person to make the payload
+        # classes derivable on an image whose CLOSURE has an unbounded type
+        # (issue 0963's "narrow the closure" remedy, which is the whole point of
+        # this join) removes the guard without knowing it was one.
+        if(NOT NROS_MESSAGE_BOUND_${_key}_STATE STREQUAL "bounded")
+            list(APPEND _open_subscribed
+                 "${_t} (${NROS_MESSAGE_BOUND_${_key}_STATE})")
+            continue()
+        endif()
         set(_rx "${NROS_MESSAGE_BOUND_${_key}_RX}")
         if(_rx GREATER _ceiling)
             list(APPEND _large_types "${_t}=${_rx}")
@@ -807,6 +825,20 @@ function(_nros_bounds_join_subscribed _frag _ceiling
     # (`BoundInventory::record_message` is called for `.msg` and for nothing
     # else), so a `pkg/srv/Name_Request` or a `pkg/action/Name_Result` has no
     # entry however well-formed the declaration is.
+    # Checked BEFORE `_unpriced` because it is the more specific answer: a type
+    # this image receives and this tree cannot bound is a different problem from
+    # one the inventory has never heard of, and saying "not in the inventory"
+    # about a type that IS in it would send the reader looking for a typo.
+    if(_open_subscribed)
+        list(LENGTH _open_subscribed _open_sub_count)
+        string(REPLACE ";" "\n    " _open_sub_block "${_open_subscribed}")
+        set(${_o_status} "refused" PARENT_SCOPE)
+        set(${_o_why}
+            "${_open_sub_count} type(s) this image RECEIVES carry no derived bound, so their payload class cannot be sized:\n    ${_open_sub_block}\n  Bound the member in its `.msg` (`string<=64`) or cap it `inline` in the package's `nros-codegen.toml` (RFC-0033). Narrowing to the subscribed set does not help here -- these are in it."
+            PARENT_SCOPE)
+        return()
+    endif()
+
     if(_unpriced)
         list(LENGTH _unpriced _unpriced_count)
         string(REPLACE ";" "\n    " _unpriced_block "${_unpriced}")

--- a/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
+++ b/docs/issues/0963-the-exported-bound-inventory-has-no-consumer.md
@@ -186,3 +186,76 @@ for a different reason than "no entity inventory exists": both need the two
 inventories JOINED per subscription -- W8's per-type size against W9's
 per-entity list. A total from either half alone is the same plausible wrong
 number, so the join is its own work.
+
+
+## The join landed — and "narrow the closure" is still unreachable, by ORDERING (2026-09-04)
+
+Items 2 and 3 above are marked "both need the two inventories JOINED". **That
+join exists**: `_nros_bounds_join_subscribed` in `NanoRosMessageBounds.cmake`,
+phase-403 step 1, with `NROS_MESSAGE_BOUNDS_BASIS` reading `subscribed` or
+`closure`. And `examples/workspaces/cpp` now declares `ENTITIES` (issue 0965),
+so for the first time there is an image that can drive it.
+
+It does not lift this issue's blocker, and the reason is ordering rather than
+data. Driving the reader directly over that image's fragments, both ways:
+
+| basis | entity inventory | result |
+| --- | --- | --- |
+| closure | absent | `refused` — 16 unbounded types in the closure |
+| subscribed | present, `std_msgs/msg/Int32` only | **`refused`, identically** |
+
+`NROS_MESSAGE_BOUNDS_BASIS` comes back EMPTY in the second run, which is the
+tell: the join never executed. `nros_derive_message_bound_knobs` evaluates the
+closure-wide open-type check and `return()`s at
+`NanoRosMessageBounds.cmake:481`; the join is called at :512.
+
+So an image whose every SUBSCRIBED type is bounded still refuses, because
+something it merely links is not. That is exactly this issue's second remedy —
+"narrow the closure, so an image pays only for the types it actually links
+rather than everything `example_interfaces` ships" — being unavailable through
+the mechanism built to provide it.
+
+**It is not a simple reorder, and the module is not wrong today.** Its header
+states the rule deliberately ("it names a type that is `unbounded`/`unresolved`
+-> the whole derivation already refused"), and the two knob families genuinely
+differ: the take buffer `NROS_SUBSCRIPTION_BUFFER_SIZE` is also `DEFAULT_TX_BUF`
+and every raw entity's default, so a type the image only PUBLISHES must fit it,
+and it must keep refusing on the closure. Only the three payload-class knobs are
+a fact about subscriptions.
+
+### The fix, scoped
+
+1. Run the join BEFORE the closure-wide refusal.
+2. On a closure that has open types: refuse the take buffer as today, but
+   publish the payload classes if the join derived them. The output format
+   already carries `NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS` separately — it is only
+   written inside the `derived` branch.
+3. Check the consumer: `nros_cargo_build.cmake` gates on the OVERALL status, so
+   a "take buffer refused, payload classes derived" answer needs the consumer to
+   read the payload status too, or it will ignore values that are present.
+
+Not done here. It changes a documented refusal contract on a path whose failure
+mode is a silent `BufferTooSmall`, and it needs the consumer change in the same
+commit.
+
+### What IS done: the join no longer trusts an invariant it cannot see
+
+The join reads `NROS_MESSAGE_BOUND_<t>_RX` without ever checking `_STATE`. It is
+safe **only** because the closure refusal above it guarantees every type is
+bounded — an invariant that lives thirty lines away, in the block step 1 above
+proposes to move. The first person to make the payload classes derivable on an
+image with an unbounded closure type removes the guard without knowing it was
+one, and the failure is a payload class sized from a blank `_RX`.
+
+So the join now checks boundedness itself and refuses naming the offending type,
+distinct from the "not in the inventory" refusal beside it (a type this tree
+cannot bound is a different problem from one it has never heard of).
+
+**It cannot fire through the public entry point today** — that is the point of
+it — so it is tested by calling the join directly: case O in
+`tests/cmake-message-bounds-tests.sh`, one assertion that a fully bounded
+subscribed set still derives and two that an unbounded one refuses and names the
+type. A check that has never executed is indistinguishable from one that does
+not work, and the first version of this test passed for the wrong reason: the
+join iterates `TYPE_COUNTS`, not `TYPES`, so a fixture listing the unbounded type
+in only the latter never visited it.

--- a/tests/cmake-message-bounds-tests.sh
+++ b/tests/cmake-message-bounds-tests.sh
@@ -843,6 +843,62 @@ if ! grep -q "set(NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE 1496)" "$T/n4-knobs.cmak
 fi
 
 # ---------------------------------------------------------------------------
+log_header "O -- the join refuses a subscribed type that carries no bound"
+# ---------------------------------------------------------------------------
+#
+# issue 0963. This guard CANNOT fire through `nros_derive_message_bound_knobs`
+# today: the closure-wide open-type check returns before the join runs, and the
+# subscribed set is a subset of the closure. It is tested by calling the join
+# DIRECTLY, because a check that has never executed is indistinguishable from
+# one that does not work -- and the thing that makes this one reachable is
+# exactly the change 0963 asks for (deriving the payload classes on an image
+# whose closure has an unbounded type it never receives).
+cat > "$T/o-join.cmake" <<EOF
+include("$MODULE")
+set(NROS_MESSAGE_BOUND_std_msgs_msg_Int32_STATE "bounded")
+set(NROS_MESSAGE_BOUND_std_msgs_msg_Int32_RX 12)
+set(NROS_MESSAGE_BOUND_demo_msg_Open_STATE "unbounded")
+set(NROS_MESSAGE_BOUND_demo_msg_Open_RX "")
+_nros_bounds_join_subscribed("\${FRAG}" 2048 b st why cnt small ltypes lmax lcount)
+message(STATUS "basis=\${b} status=\${st} why=\${why}")
+EOF
+# The join iterates TYPE_COUNTS (it needs each type's count), NOT TYPES -- so a
+# fixture that lists a type only in TYPES is never visited and the case passes
+# for the wrong reason. It did, on the first run of this test.
+_o_frag() {
+    {
+        printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 3)\n'
+        printf 'set(NROS_ENTITY_INVENTORY_STATUS "derived")\n'
+        printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")\n'
+        printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES "%s")\n' "$1"
+        printf 'set(NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS "%s")\n' "$2"
+        printf 'set(NROS_ENTITY_SUBSCRIBED_ENTITY_COUNT 1)\n'
+    } > "$3"
+}
+_o_frag "std_msgs/msg/Int32" "std_msgs/msg/Int32=1" "$T/o-ok.cmake"
+_o_frag "std_msgs/msg/Int32;demo/msg/Open" \
+        "std_msgs/msg/Int32=1;demo/msg/Open=1" "$T/o-bad.cmake"
+
+_o_out=$(cmake -DFRAG="$T/o-ok.cmake" -P "$T/o-join.cmake" 2>&1)
+if ! printf '%s' "$_o_out" | grep -q "status=derived"; then
+    fail "O: every subscribed type is bounded and the join still refused:"
+    printf '%s\n' "$_o_out"
+fi
+check
+_o_out=$(cmake -DFRAG="$T/o-bad.cmake" -P "$T/o-join.cmake" 2>&1)
+if ! printf '%s' "$_o_out" | grep -q "status=refused"; then
+    fail "O: a subscribed type with no bound did NOT refuse -- a payload class \
+would be sized from a blank _RX:"
+    printf '%s\n' "$_o_out"
+fi
+check
+if ! printf '%s' "$_o_out" | grep -q "demo/msg/Open"; then
+    fail "O: the refusal does not name the offending type:"
+    printf '%s\n' "$_o_out"
+fi
+check
+
+# ---------------------------------------------------------------------------
 log_header "Summary"
 if [ "$FAILURES" -eq 0 ]; then
     log_success "$CHECKS assertions held"


### PR DESCRIPTION
0963's items 2 and 3 both read "needs the two inventories JOINED". The join exists (`_nros_bounds_join_subscribed`, phase-403 step 1), and since #289 there's an image that declares `ENTITIES` and can drive it — so it was worth asking whether the blocker had moved.

## It hasn't, and the reason is ordering, not data

Driving the reader over `examples/workspaces/cpp`'s fragments both ways:

| basis | entity inventory | result |
| --- | --- | --- |
| closure | absent | `refused` — 16 unbounded types in the closure |
| subscribed | present, `std_msgs/msg/Int32` only | **`refused`, identically** |

`NROS_MESSAGE_BOUNDS_BASIS` comes back **empty** on the second — the join never ran. `nros_derive_message_bound_knobs` returns on the closure-wide open-type check at `:481`; the join is at `:512`.

So an image whose every **subscribed** type is bounded refuses because something it merely **links** isn't. That is precisely 0963's own second remedy — *"narrow the closure, so an image pays only for the types it actually links"* — being unavailable through the mechanism built to provide it.

## Not fixed here, deliberately

The two knob families genuinely differ: the take buffer is also `DEFAULT_TX_BUF` and every raw entity's default, so a type the image only *publishes* must fit it — it must keep refusing on the closure. Only the three payload-class knobs are a fact about subscriptions.

Changing it means touching a documented refusal contract on a path whose failure is a silent `BufferTooSmall`, plus `nros_cargo_build.cmake` (it gates on the *overall* status, so "take buffer refused, payload classes derived" would be ignored). Three steps scoped in the issue.

## What IS fixed — the hazard that scoping found

The join reads `NROS_MESSAGE_BOUND_<t>_RX` and **never checks `_STATE`**. It's safe only because the refusal above it guarantees boundedness — an invariant living thirty lines away, in the very block step 1 proposes to move. Whoever makes the payload classes derivable removes that guard without knowing it was one, and gets a payload class sized from a blank `_RX`.

The join now checks boundedness itself and refuses naming the type, kept distinct from the "not in the inventory" refusal beside it — a type this tree *cannot bound* is a different problem from one it *has never heard of*, and saying the wrong one sends the reader hunting a typo.

## Proving a guard that cannot fire

It's unreachable through the public entry point today — that's the point of it — so case O calls the join directly: one assertion that a fully bounded subscribed set still derives, two that an unbounded one refuses and names the type.

**Its first version passed for the wrong reason.** The join iterates `TYPE_COUNTS`, not `TYPES`, so a fixture listing the unbounded type only in the latter never visited it. Fixed, and noted in the test.

Gates: `just check message-bound-knobs` (83 assertions, was 80), `check fast` (190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)