### PR TITLE
feat(phase-400 W6): the singletons, and the Zephyr heap whose blocker had already gone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,7 @@ dependencies = [
  "cc",
  "nros-build-paths",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-sizes-build",
 ]
 
@@ -2076,6 +2077,7 @@ version = "0.5.0"
 dependencies = [
  "cc",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-rmw-cffi",
  "nros-zephyr-build",
 ]
@@ -2100,6 +2102,7 @@ dependencies = [
  "nros-ghost-types",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-tests",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-platform-esp32-qemu",
  "nros-platform-mps2-an385",
  "nros-platform-stm32f4",

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -21,9 +21,9 @@ moves with it.
 
 | pool | bytes at default | formula | declared in |
 | --- | ---: | --- | --- |
-| `LARGE_PAYLOADS` | 131,072 | `ZPICO_MAX_LARGE_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:200` |
+| `LARGE_PAYLOADS` | — (knob `ZPICO_SUBSCRIBER_RING_DEPTH` has a computed default) | `ZPICO_MAX_LARGE_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:200` |
 | `SLOTS` | 8,192 | `NROS_RMW_SUBSCRIBER_SLOTS * 1024` | `packages/rmw/cffi/src/rust_adapter.rs:111` |
-| `SMALL_PAYLOADS` | 32,768 | `ZPICO_MAX_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_BUFFER_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:199` |
+| `SMALL_PAYLOADS` | — (knob `ZPICO_SUBSCRIBER_RING_DEPTH` has a computed default) | `ZPICO_MAX_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_BUFFER_SIZE` | `packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs:199` |
 
 ## Every sizing knob
 
@@ -38,10 +38,10 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_EXECUTOR_MAX_NODES` | 4 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SC` | 8 | `packages/core/nros-node` |
 | `NROS_EXECUTOR_MAX_SHUTDOWN_CBS` | 2 | `packages/core/nros-node` |
-| `NROS_FREERTOS_APP_STACK_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:851` | `packages/tooling/nros-platform-config` |
-| `NROS_FREERTOS_HEAP_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:850` | `packages/tooling/nros-platform-config` |
-| `NROS_KEYEXPR_STRING_SIZE` | 256 | `packages/rmw/zenoh/nros-rmw-zenoh` |
-| `NROS_LET_BUFFER_SIZE` | 512 | `packages/tooling/nros-build-helpers` |
+| `NROS_FREERTOS_APP_STACK_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:893` | `packages/tooling/nros-platform-config` |
+| `NROS_FREERTOS_HEAP_KB` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:892` | `packages/tooling/nros-platform-config` |
+| `NROS_KEYEXPR_STRING_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1061` | `packages/tooling/nros-platform-config` |
+| `NROS_LET_BUFFER_SIZE` | computed — see `packages/tooling/nros-build-helpers/src/c.rs:116` | `packages/tooling/nros-build-helpers` |
 | `NROS_MAX_ARRAY_LEN` | 32 | `packages/core/nros-params` |
 | `NROS_MAX_BYTE_ARRAY_LEN` | 256 | `packages/core/nros-params` |
 | `NROS_MAX_PARAMETERS` | 32 | `packages/core/nros-params` |
@@ -64,13 +64,14 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:67` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIBER_BUFFER_SIZE` | computed — see `packages/core/nros-node/build.rs:171` | `packages/core/nros-node` |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
-| `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:259` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
-| `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:849` | `packages/tooling/nros-platform-config` |
-| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:977` | `packages/tooling/nros-platform-config` |
-| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:976` | `packages/tooling/nros-platform-config` |
-| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:978` | `packages/tooling/nros-platform-config` |
-| `ZPICO_GET_POLL_INTERVAL_MS` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:980` | `packages/tooling/nros-platform-config` |
-| `ZPICO_GET_REPLY_BUF_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:979` | `packages/tooling/nros-platform-config` |
+| `NROS_XRCE_CUSTOM_TRANSPORT_MTU` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:406` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
+| `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:264` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
+| `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:891` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1081` | `packages/tooling/nros-platform-config` |
+| `ZPICO_BATCH_UNICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1080` | `packages/tooling/nros-platform-config` |
+| `ZPICO_FRAG_MAX_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1082` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_POLL_INTERVAL_MS` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1084` | `packages/tooling/nros-platform-config` |
+| `ZPICO_GET_REPLY_BUF_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1083` | `packages/tooling/nros-platform-config` |
 | `ZPICO_LEASE_TASK_PRIORITY` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
 | `ZPICO_MAX_LARGE_SUBSCRIBERS` | 2 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_MAX_LIVELINESS` | 16 | `packages/rmw/zenoh/nros-zpico-build` |
@@ -84,5 +85,5 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `ZPICO_SERVICE_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_BUFFER_SIZE` | 1024 | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_LARGE_SIZE` | 16384 | `packages/rmw/zenoh/nros-rmw-zenoh` |
-| `ZPICO_SUBSCRIBER_RING_DEPTH` | 4 | `packages/rmw/zenoh/nros-rmw-zenoh` |
+| `ZPICO_SUBSCRIBER_RING_DEPTH` | computed — see `packages/rmw/zenoh/nros-rmw-zenoh/build.rs:50` | `packages/rmw/zenoh/nros-rmw-zenoh` |
 | `ZPICO_SUBSCRIBER_SIZE_THRESHOLD` | 2048 | `packages/rmw/zenoh/nros-rmw-zenoh` |

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
 **Status (2026-09-01): W2-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params`, `rmw`, `net`, `runtime` and `zenoh.wire` tenants done, its remaining tenants and W1
+`zenoh.tx`, `memory`, `params`, `rmw`, `net`, `runtime`, `zenoh.wire`, `xrce` and `zenoh.limits` tenants done, its remaining tenants and W1
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -312,6 +312,32 @@ census fix below), and its largest families are:
 | platform heap / stack | 3 | `NROS_ZEPHYR_HEAP_SIZE`, `NROS_FREERTOS_HEAP_KB`, `NROS_FREERTOS_APP_STACK_KB`. Genuine platform facts with no derivation candidate — **the clearest W6 tenant left.** |
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
+
+### The singletons — five migrated, three with reasons not to
+
+`[knobs.xrce]` (`custom_transport_mtu`, `stream_history`),
+`[knobs.zenoh.limits]` (`keyexpr_string_size`, `subscriber_ring_depth`) and the
+LET buffer folded into `[knobs.runtime]`.
+
+**Three did NOT migrate, and each refusal is the interesting part.**
+
+`NROS_SERVICE_TIMEOUT_MS` has TWO readers by design — `nros-rmw-zenoh/build.rs`
+emits a Rust const and `nros-build-helpers`'s C emitter emits a `#define`, and a
+comment asked the next editor to keep the defaults equal. I migrated it, and
+`check-knob-single-reader` refused: a migrated knob gets exactly one reader, and
+that rule is precisely what stops the pair drifting. Both would have resolved
+through the same ladder and so could not disagree — but the gate cannot know
+that, and weakening it to say so trades a checked invariant for a comment.
+Migrating this knob means giving the pair ONE emission point first, which is a
+change to where the value is emitted rather than to the ladder.
+
+`NROS_ENTRY_SPIN_MS` is read by a proc macro, the C++ library and a C header.
+Same shape, three readers, and no single build script to own it.
+
+The two transport-band priorities stay out for the reasons in the `zenoh.wire`
+section above.
+
+Backlog after this: **5**, from 10.
 
 ### The `zenoh.wire` tenant — done, and the two priorities left out
 

--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -313,6 +313,28 @@ census fix below), and its largest families are:
 | `ZPICO_*` remainder | 7 | wire batch, fragmentation, reply staging, two transport-band priorities |
 | singletons | 4 | keyexpr bound, LET buffer, service timeout, XRCE MTU |
 
+### `NROS_ZEPHYR_HEAP_SIZE` — the blocker was gone and the note still said it was
+
+The census had carried, for two waves: *"BLOCKED: the ladder crate depends on
+`nros-platform`, so the rungs are a cycle away."* `nros-platform/build.rs` said
+the same in its own words — *"giving it the toml rungs would need the ladder
+types in a crate BELOW both — a real refactor, not a dependency line."*
+
+That refactor is `nros-platform-config`, extracted for the `net` tenant. Both
+notes went stale the moment it landed and neither was updated, because nothing
+re-reads a reason once it is written.
+
+The `memory` tenant had ALREADY mapped this knob —
+`("zephyr", "heap_bytes") => "NROS_ZEPHYR_HEAP_SIZE"` — so the ladder modelled
+it while its only reader could not consult it: a mechanism that was correct,
+tested, and unreachable, which is the shape phase-412 opened to clean up. The
+build script now resolves through `memory_value`, composing env, Kconfig via
+`$DOTCONFIG`, the platform/board rung, and the builtin.
+
+Verified: builtin 65536, platform rung 131072, env override 4096.
+
+Backlog: **4**.
+
 ### The singletons — five migrated, three with reasons not to
 
 `[knobs.xrce]` (`custom_transport_mtu`, `stream_history`),

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -401,6 +401,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -462,6 +462,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-platform-mps2-an385",
  "nros-zephyr-build",
 ]

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -530,6 +530,7 @@ version = "0.5.0"
 dependencies = [
  "cc",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-rmw-cffi",
  "nros-zephyr-build",
 ]
@@ -543,6 +544,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -346,6 +346,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -333,6 +333,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "cc",
  "nros-build-paths",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-sizes-build",
 ]
 
@@ -443,6 +444,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-ffi/Cargo.lock
@@ -389,6 +389,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "cc",
  "nros-build-paths",
  "nros-cc-flags",
+ "nros-platform-config",
  "nros-sizes-build",
 ]
 
@@ -443,6 +444,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/nros-nuttx-riscv-ffi/Cargo.lock
@@ -389,6 +389,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -346,6 +346,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -343,6 +343,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -350,6 +350,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/platform/nros-platform/Cargo.toml
+++ b/packages/platform/nros-platform/Cargo.toml
@@ -204,6 +204,10 @@ nros-platform-esp32-qemu = { version = "0.4.0", path = "../../platform/nros-plat
 workspace = true
 
 [build-dependencies]
+# phase-400 W6 — the `[knobs.memory]` rungs, from the LEAF ladder crate. This
+# dependency was impossible before the reader was extracted: `nros-board-common`
+# reaches back to this crate.
+nros-platform-config = { path = "../../tooling/nros-platform-config" }
 # issue 0460 — the shared Kconfig-via-$DOTCONFIG knob fallback. A Zephyr RUST
 # image inherits none of the cmake `set(ENV{...})` knob exports, so a bare
 # environment read compiles the crate default whatever Kconfig says. Needed

--- a/packages/platform/nros-platform/build.rs
+++ b/packages/platform/nros-platform/build.rs
@@ -38,13 +38,26 @@ fn main() {
     // `$DOTCONFIG` (issue 0460). The platform states the value where a Zephyr
     // image already looks for it.
     //
-    // Giving it the toml rungs would need the ladder types in a crate BELOW
-    // both — a real refactor, not a dependency line.
-    let size = nros_zephyr_build::knob_usize(
-        "NROS_ZEPHYR_HEAP_SIZE",
-        "CONFIG_NROS_ZEPHYR_HEAP_SIZE",
-        DEFAULT_HEAP_SIZE,
-    );
+    // phase-400 W6 — and it NOW HAS the toml rungs. This comment used to end
+    // "giving it the toml rungs would need the ladder types in a crate BELOW
+    // both — a real refactor, not a dependency line", and that refactor
+    // happened: `nros-platform-config` is exactly that crate, extracted so the
+    // reader could reach crates `nros-board-common` cannot.
+    //
+    // The `memory` tenant already mapped this knob — `("zephyr", "heap_bytes")
+    // => "NROS_ZEPHYR_HEAP_SIZE"` — so the ladder modelled it while the only
+    // reader could not consult it. `memory_value` composes the whole ladder:
+    // env, then Kconfig via `$DOTCONFIG`, then the platform/board rung, then
+    // the builtin below.
+    let size = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.memory_value("heap_bytes", DEFAULT_HEAP_SIZE))
+        .unwrap_or_else(|| {
+            nros_zephyr_build::knob_usize(
+                "NROS_ZEPHYR_HEAP_SIZE",
+                "CONFIG_NROS_ZEPHYR_HEAP_SIZE",
+                DEFAULT_HEAP_SIZE,
+            )
+        });
 
     // `zephyr_heap.rs` keeps its `option_env!` read; this simply makes the
     // value it sees the RESOLVED one rather than whatever happened to be in

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/reference/stm32f4-porting/polling/Cargo.lock
+++ b/packages/reference/stm32f4-porting/polling/Cargo.lock
@@ -453,6 +453,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/reference/stm32f4-porting/rtic/Cargo.lock
+++ b/packages/reference/stm32f4-porting/rtic/Cargo.lock
@@ -485,6 +485,7 @@ name = "nros-platform"
 version = "0.5.0"
 dependencies = [
  "nros-platform-api",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/Cargo.toml
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/Cargo.toml
@@ -57,6 +57,8 @@ host-only-reason = "XRCE C FFI surface, built per-platform by cmake"
 nros-rmw-cffi = { version = "0.5.0", path = "../../cffi", default-features = false }
 
 [build-dependencies]
+# phase-400 W6 — the ladder rungs, from the LEAF crate.
+nros-platform-config = { path = "../../../tooling/nros-platform-config" }
 cc = "1"
 # issue 0383 — strict C diagnostics (implicit-function-declaration,
 # int-conversion) as ERRORS at every `cc::Build` below. One shared spelling.

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
@@ -256,7 +256,14 @@ fn main() {
     // targets that don't run server-side action callbacks can drop
     // from the default 16 (= 64 KiB per-session output buffer) to 8
     // or 4. `internal.h` enforces `>= 4`.
-    if let Some(v) = knob("NROS_XRCE_STREAM_HISTORY") {
+    // phase-400 W6 — the `[knobs.xrce]` rungs sit under the env front-end and
+    // above the builtins below.
+    let xrce_rungs = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.xrce_rungs())
+        .unwrap_or_default();
+    if let Some(v) = knob("NROS_XRCE_STREAM_HISTORY")
+        .or_else(|| xrce_rungs.stream_history.map(|n| n.to_string()))
+    {
         let n: u32 = v
             .parse()
             .unwrap_or_else(|_| panic!("NROS_XRCE_STREAM_HISTORY='{}' is not a number", v));
@@ -392,8 +399,17 @@ fn generate_uxr_config(
             // CUSTOM_TRANSPORT_MTU × STREAM_HISTORY`) by an order of
             // magnitude. Min 128 (smaller breaks the framing/header
             // assumptions); default tracks XRCE_TRANSPORT_MTU_DEFAULT.
-            &env::var("NROS_XRCE_CUSTOM_TRANSPORT_MTU")
-                .unwrap_or_else(|_| XRCE_TRANSPORT_MTU_DEFAULT.into()),
+            // phase-400 W6 — env, then the `[knobs.xrce]` rung, then the
+            // default. `knob` rather than a bare `env::var` so the Kconfig
+            // front-end reaches this the way it reaches the pool sizes above
+            // (issue 0460).
+            &knob("NROS_XRCE_CUSTOM_TRANSPORT_MTU")
+                .or_else(|| {
+                    nros_platform_config::platform_config::BuildRungs::from_build_env()
+                        .and_then(|r| r.xrce_rungs().custom_transport_mtu)
+                        .map(|n| n.to_string())
+                })
+                .unwrap_or_else(|| XRCE_TRANSPORT_MTU_DEFAULT.into()),
         )
         .replace("@UCLIENT_SHARED_MEMORY_MAX_ENTITIES@", "4")
         .replace("@UCLIENT_SHARED_MEMORY_STATIC_MEM_SIZE@", "10")

--- a/packages/rmw/zenoh/nros-rmw-zenoh/Cargo.toml
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/Cargo.toml
@@ -152,6 +152,8 @@ log = { workspace = true, optional = true }
 critical-section = { version = "1.2", optional = true }
 
 [build-dependencies]
+# phase-400 W6 — the ladder rungs, from the LEAF crate.
+nros-platform-config = { path = "../../../tooling/nros-platform-config" }
 # issue 0460 — `ZPICO_{SUBSCRIBER,SERVICE}_BUFFER_SIZE` are Kconfig knobs on
 # Zephyr, and the Rust lane never sees the cmake `set(ENV{...})` exports. One
 # spelling of the `$DOTCONFIG` fallback, shared with `nros-zpico-build`.

--- a/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
@@ -29,12 +29,29 @@ fn main() {
     // Bumping to 30 s covers the common slow-Zephyr action window; fast
     // services on POSIX still return in milliseconds so the wider cap
     // only matters when something is genuinely slow.
+    // phase-400 W6 — the `[knobs.zenoh.limits]` rungs. `None` when no lane named
+    // a platform, and the builtins below then stand.
+    let limits = nros_platform_config::platform_config::BuildRungs::from_build_env()
+        .map(|r| r.zenoh_limit_rungs())
+        .unwrap_or_default();
+    // NOT a ladder knob, deliberately: this value is read HERE and in
+    // `nros-build-helpers`'s C emitter, because two artifacts embed it (a Rust
+    // const and a C define). `check-knob-single-reader` allows a migrated knob
+    // exactly one reader, and that invariant is what stops the pair drifting —
+    // so migrating this one needs the two readers to share a single resolution
+    // point first, which is a change to where the value is EMITTED, not to the
+    // ladder.
     let service_timeout_ms: usize = env_usize("NROS_SERVICE_TIMEOUT_MS", 30_000);
-    let keyexpr_string_size: usize = env_usize("NROS_KEYEXPR_STRING_SIZE", 256);
+    let keyexpr_string_size: usize =
+        env_usize_rung("NROS_KEYEXPR_STRING_SIZE", limits.keyexpr_string_size, 256);
     // Phase 124.D.3.c — SPSC ring depth per subscriber. Default 4
     // keeps the static-RAM bump small (4 × SUBSCRIBER_BUFFER_SIZE
     // per subscriber); raise for burst-heavy topics. Must be ≥ 1.
-    let ring_depth: usize = env_usize_min("ZPICO_SUBSCRIBER_RING_DEPTH", 4, 1);
+    let ring_depth: usize = env_usize_min(
+        "ZPICO_SUBSCRIBER_RING_DEPTH",
+        limits.subscriber_ring_depth.unwrap_or(4),
+        1,
+    );
     // Phase 231 (RFC-0038) — size-class receive buffers. `SUBSCRIBER_BUFFER_SIZE`
     // above is the `small` class slot size; the `large` class is for big
     // messages (images, point clouds). A subscription routes to `large` when its
@@ -181,4 +198,14 @@ fn env_usize(name: &str, default: usize) -> usize {
             .and_then(|v| v.parse().ok())
             .unwrap_or(default),
     }
+}
+
+/// phase-400 W6 — env, then the platform/board rung, then the builtin.
+///
+/// A thin sibling of `env_usize` rather than a change to it: the other callers
+/// of that helper are knobs with no tenant, and giving them a rung parameter
+/// they always pass `None` for would say the ladder reaches further than it
+/// does.
+fn env_usize_rung(name: &str, rung: Option<usize>, default: usize) -> usize {
+    env_usize(name, rung.unwrap_or(default))
 }

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -393,6 +393,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
+++ b/packages/testing/nros-tests/bins/contract-monitor/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -338,6 +338,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -349,6 +349,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -317,6 +317,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
+++ b/packages/testing/nros-tests/bins/qos-override-pubsub/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -317,6 +317,7 @@ version = "0.5.0"
 dependencies = [
  "nros-platform-api",
  "nros-platform-cffi",
+ "nros-platform-config",
  "nros-zephyr-build",
 ]
 

--- a/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
+++ b/packages/testing/nros-tests/bins/ros2-string-interop/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "nros-core",
  "nros-log",
  "nros-platform",
+ "nros-platform-config",
  "nros-rmw",
  "nros-rmw-cffi",
  "nros-zephyr-build",

--- a/packages/tooling/nros-build-helpers/Cargo.toml
+++ b/packages/tooling/nros-build-helpers/Cargo.toml
@@ -37,6 +37,9 @@ default = []
 cbindgen-drift-check = ["dep:cbindgen"]
 
 [dependencies]
+# phase-400 W6 — the ladder rungs. A regular dependency, not a build one:
+# this crate IS the helper a build script calls.
+nros-platform-config = { path = "../nros-platform-config" }
 cbindgen = { workspace = true, optional = true }
 cc = "1"
 # issue 0383 — strict C diagnostics (implicit-function-declaration,
@@ -55,3 +58,4 @@ nros-sizes-build = { workspace = true }
 
 [lints]
 workspace = true
+

--- a/packages/tooling/nros-build-helpers/src/c.rs
+++ b/packages/tooling/nros-build-helpers/src/c.rs
@@ -105,7 +105,21 @@ fn generate_config(
     let message_buffer_size = dep_usize("DEP_NROS_NODE_RX_BUF_SIZE");
 
     // --- C API knobs (nros-c only, not shared with nros-node) ---
-    let let_buffer_size = env_usize("NROS_LET_BUFFER_SIZE", 512);
+    // phase-400 W6 — the `[knobs.runtime]` rungs for the LET buffer.
+    //
+    // `NROS_SERVICE_TIMEOUT_MS` below is deliberately NOT on the ladder: it is
+    // read here and in `nros-rmw-zenoh/build.rs` because two artifacts embed
+    // it, and a migrated knob may have exactly one reader
+    // (`check-knob-single-reader`). Migrating it means giving the pair one
+    // emission point first.
+    let rungs = nros_platform_config::platform_config::BuildRungs::from_build_env();
+    let let_buffer_size = env_usize(
+        "NROS_LET_BUFFER_SIZE",
+        rungs
+            .as_ref()
+            .and_then(|r| r.runtime_rungs().let_buffer_size)
+            .unwrap_or(512),
+    );
     // Phase 192.4 — default service-client RPC timeout. Read the same env var
     // and use the same default (30000) as the zenoh backend
     // (`nros-rmw-zenoh/build.rs`) so the two paths agree.

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -174,6 +174,9 @@ pub struct Knobs {
     /// phase-400 W6 — the component-runtime tenant. See [`RuntimeKnobs`].
     #[serde(default)]
     pub runtime: RuntimeKnobs,
+    /// phase-400 W6 — the XRCE transport tenant. See [`XrceKnobs`].
+    #[serde(default)]
+    pub xrce: XrceKnobs,
     /// phase-400 W3 / RFC-0086 D1 — the transport tenant.
     ///
     /// The first knob that crosses all three descriptor axes: the backend knows
@@ -422,6 +425,37 @@ impl BuildRungs {
         }
     }
 
+    /// The `[knobs.xrce]` RUNGS for this build. See [`Self::rmw_rungs`].
+    pub fn xrce_rungs(&self) -> XrceKnobs {
+        let plat = self.tree.platform_xrce_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("xrce", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.xrce.clone())
+            .unwrap_or_default();
+        XrceKnobs {
+            custom_transport_mtu: b.custom_transport_mtu.or(plat.custom_transport_mtu),
+            stream_history: b.stream_history.or(plat.stream_history),
+        }
+    }
+
+    /// The `[knobs.zenoh.limits]` RUNGS for this build. See [`Self::rmw_rungs`].
+    pub fn zenoh_limit_rungs(&self) -> ZenohLimitKnobs {
+        let plat = self.tree.platform_zenoh_limit_rungs(&self.platform);
+        let plat = self.or_builtin_rungs("zenoh.limits", plat);
+        let b = self
+            .board
+            .as_ref()
+            .map(|f| f.knobs.zenoh.limits.clone())
+            .unwrap_or_default();
+        ZenohLimitKnobs {
+            keyexpr_string_size: b.keyexpr_string_size.or(plat.keyexpr_string_size),
+            service_timeout_ms: b.service_timeout_ms.or(plat.service_timeout_ms),
+            subscriber_ring_depth: b.subscriber_ring_depth.or(plat.subscriber_ring_depth),
+        }
+    }
+
     /// The `[knobs.zenoh.wire]` RUNGS for this build — platform merged with
     /// board, board winning. See [`Self::rmw_rungs`].
     pub fn wire_rungs(&self) -> WireKnobs {
@@ -456,6 +490,7 @@ impl BuildRungs {
             component_slot_bytes: b.component_slot_bytes.or(plat.component_slot_bytes),
             max_class_instances: b.max_class_instances.or(plat.max_class_instances),
             max_cell_entities: b.max_cell_entities.or(plat.max_cell_entities),
+            let_buffer_size: b.let_buffer_size.or(plat.let_buffer_size),
         }
     }
 
@@ -655,6 +690,11 @@ pub struct RuntimeKnobs {
     pub max_class_instances: Option<usize>,
     #[serde(default)]
     pub max_cell_entities: Option<usize>,
+    /// The logical-execution-time staging buffer, read by
+    /// `nros-build-helpers`'s C emitter. Grouped here because LET is an
+    /// execution-model buffer, not a wire or transport size.
+    #[serde(default)]
+    pub let_buffer_size: Option<usize>,
 }
 
 /// Every runtime knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -663,6 +703,7 @@ pub const RUNTIME_KNOBS: &[&str] = &[
     "component_slot_bytes",
     "max_class_instances",
     "max_cell_entities",
+    "let_buffer_size",
 ];
 
 /// The env front-end for a runtime knob — the EXISTING names, verbatim.
@@ -672,6 +713,7 @@ pub fn runtime_env_key(knob: &str) -> &'static str {
         "component_slot_bytes" => "NROS_RUNTIME_COMPONENT_SLOT_BYTES",
         "max_class_instances" => "NROS_RUNTIME_MAX_CLASS_INSTANCES",
         "max_cell_entities" => "NROS_RUNTIME_MAX_CELL_ENTITIES",
+        "let_buffer_size" => "NROS_LET_BUFFER_SIZE",
         other => panic!("unknown runtime knob `{other}`"),
     }
 }
@@ -943,6 +985,9 @@ pub struct ZenohKnobs {
     /// the wire itself, which no campaign derives.
     #[serde(default)]
     pub wire: WireKnobs,
+    /// phase-400 W6 — zenoh runtime limits. See [`ZenohLimitKnobs`].
+    #[serde(default)]
+    pub limits: ZenohLimitKnobs,
 }
 
 /// phase-400 W6 — the zenoh WIRE sizes, read by `nros-zpico-build`.
@@ -959,6 +1004,65 @@ pub struct WireKnobs {
     pub get_reply_buf_size: Option<usize>,
     #[serde(default)]
     pub get_poll_interval_ms: Option<usize>,
+}
+
+/// phase-400 W6 — the XRCE transport tenant, read by `nros-rmw-xrce-cffi`.
+///
+/// The MTU is a TRANSPORT fact (a serial link's frame budget differs from
+/// UDP's) and the stream history is the reliable-stream depth the agent
+/// negotiates against. Both are per-platform in practice and were env-only.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct XrceKnobs {
+    #[serde(default)]
+    pub custom_transport_mtu: Option<usize>,
+    #[serde(default)]
+    pub stream_history: Option<usize>,
+}
+
+/// Every XRCE knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
+pub const XRCE_KNOBS: &[&str] = &["custom_transport_mtu", "stream_history"];
+
+/// The env front-end for an XRCE knob — the EXISTING names, verbatim.
+pub fn xrce_env_key(knob: &str) -> &'static str {
+    match knob {
+        "custom_transport_mtu" => "NROS_XRCE_CUSTOM_TRANSPORT_MTU",
+        "stream_history" => "NROS_XRCE_STREAM_HISTORY",
+        other => panic!("unknown xrce knob `{other}`"),
+    }
+}
+
+/// phase-400 W6 — zenoh RUNTIME limits, read by `nros-rmw-zenoh`.
+///
+/// Separate from [`WireKnobs`] on purpose: those size the WIRE (batching,
+/// fragmentation), these bound what a session holds — the key-expression
+/// string, the default RPC timeout, and the per-subscriber SPSC ring.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZenohLimitKnobs {
+    #[serde(default)]
+    pub keyexpr_string_size: Option<usize>,
+    #[serde(default)]
+    pub service_timeout_ms: Option<usize>,
+    #[serde(default)]
+    pub subscriber_ring_depth: Option<usize>,
+}
+
+/// Every zenoh limit knob, in a stable order.
+pub const ZENOH_LIMIT_KNOBS: &[&str] = &[
+    "keyexpr_string_size",
+    "service_timeout_ms",
+    "subscriber_ring_depth",
+];
+
+/// The env front-end for a zenoh limit knob — the EXISTING names, verbatim.
+pub fn zenoh_limit_env_key(knob: &str) -> &'static str {
+    match knob {
+        "keyexpr_string_size" => "NROS_KEYEXPR_STRING_SIZE",
+        "service_timeout_ms" => "NROS_SERVICE_TIMEOUT_MS",
+        "subscriber_ring_depth" => "ZPICO_SUBSCRIBER_RING_DEPTH",
+        other => panic!("unknown zenoh limit knob `{other}`"),
+    }
 }
 
 /// Every wire knob, in a stable order. Same reason as [`EXECUTOR_KNOBS`].
@@ -1599,6 +1703,7 @@ impl PlatformsTree {
                 (&mut out.component_slot_bytes, r.component_slot_bytes),
                 (&mut out.max_class_instances, r.max_class_instances),
                 (&mut out.max_cell_entities, r.max_cell_entities),
+                (&mut out.let_buffer_size, r.let_buffer_size),
             ] {
                 if src.is_some() {
                     *dst = src;
@@ -1677,6 +1782,54 @@ impl PlatformsTree {
         Ok(out)
     }
 
+    fn platform_xrce_knobs(&self, name: &str) -> Result<XrceKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = XrceKnobs::default();
+        for file in chain.iter().rev() {
+            let x = &file.knobs.xrce;
+            for (dst, src) in [
+                (&mut out.custom_transport_mtu, x.custom_transport_mtu),
+                (&mut out.stream_history, x.stream_history),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.xrce]` rungs for a platform, inherits chain applied.
+    pub fn platform_xrce_rungs(&self, platform: &str) -> Result<XrceKnobs, ConfigError> {
+        self.platform_xrce_knobs(platform)
+    }
+
+    fn platform_zenoh_limit_knobs(&self, name: &str) -> Result<ZenohLimitKnobs, ConfigError> {
+        let chain = self.chain(name)?;
+        let mut out = ZenohLimitKnobs::default();
+        for file in chain.iter().rev() {
+            let z = &file.knobs.zenoh.limits;
+            for (dst, src) in [
+                (&mut out.keyexpr_string_size, z.keyexpr_string_size),
+                (&mut out.service_timeout_ms, z.service_timeout_ms),
+                (&mut out.subscriber_ring_depth, z.subscriber_ring_depth),
+            ] {
+                if src.is_some() {
+                    *dst = src;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The `[knobs.zenoh.limits]` rungs for a platform, inherits chain applied.
+    pub fn platform_zenoh_limit_rungs(
+        &self,
+        platform: &str,
+    ) -> Result<ZenohLimitKnobs, ConfigError> {
+        self.platform_zenoh_limit_knobs(platform)
+    }
+
     /// The `[knobs.zenoh.wire]` rungs for a platform, inherits chain applied.
     pub fn platform_wire_rungs(&self, platform: &str) -> Result<WireKnobs, ConfigError> {
         self.platform_wire_knobs(platform)
@@ -1701,6 +1854,7 @@ impl PlatformsTree {
             "component_slot_bytes" => k.component_slot_bytes,
             "max_class_instances" => k.max_class_instances,
             "max_cell_entities" => k.max_cell_entities,
+            "let_buffer_size" => k.let_buffer_size,
             _ => None,
         };
         let mut out = Vec::new();

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -61,6 +61,10 @@ OWNERS: dict[str, str] = {
     # The memory tenant (phase-400 W6). The stack is read inside the crate that
     # owns the ladder; the heap by the board crate that sizes `ucHeap`.
     "NROS_FREERTOS_APP_STACK_KB": "packages/boards/nros-board-common/src/freertos_build.rs",
+    # The Zephyr heap joined the memory tenant once `nros-platform` could reach
+    # the ladder — it could not while the reader lived in `nros-board-common`,
+    # which depends on `nros-platform`.
+    "NROS_ZEPHYR_HEAP_SIZE": "packages/platform/nros-platform/build.rs",
     "NROS_FREERTOS_HEAP_KB": "packages/boards/nros-board-freertos/build.rs",
     # The transport and zenoh-tx tenants resolve inside the ladder itself, so
     # the resolver IS the owner. `nros-zpico-build` re-read the tx trio for its

--- a/scripts/check/check-knob-single-reader.py
+++ b/scripts/check/check-knob-single-reader.py
@@ -100,6 +100,15 @@ OWNERS: dict[str, str] = {
     "ZPICO_FRAG_MAX_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
     "ZPICO_GET_REPLY_BUF_SIZE": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
     "ZPICO_GET_POLL_INTERVAL_MS": "packages/rmw/zenoh/nros-zpico-build/src/runner.rs",
+    # The zenoh limits + xrce tenants, and the LET buffer (phase-400 W6).
+    # `NROS_SERVICE_TIMEOUT_MS` is NOT here: it has two readers by design (a
+    # Rust const and a C define), and this gate's one-reader rule is what keeps
+    # them equal. Migrating it needs a single emission point first.
+    "NROS_KEYEXPR_STRING_SIZE": "packages/rmw/zenoh/nros-rmw-zenoh/build.rs",
+    "ZPICO_SUBSCRIBER_RING_DEPTH": "packages/rmw/zenoh/nros-rmw-zenoh/build.rs",
+    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": "packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs",
+    "NROS_XRCE_STREAM_HISTORY": "packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs",
+    "NROS_LET_BUFFER_SIZE": "packages/tooling/nros-build-helpers/src/c.rs",
     "NROS_TRANSPORT_KIND": "packages/boards/nros-board-common/src/platform_config.rs",
     "NROS_TRANSPORT_ENDPOINT": "packages/boards/nros-board-common/src/platform_config.rs",
     "ZPICO_TX_BATCH": "packages/boards/nros-board-common/src/platform_config.rs",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -92,7 +92,7 @@ KNOB_CLASS = {
     "NROS_RUNTIME_MAX_CELL_ENTITIES": ("ladder", "runtime tenant"),
     "NROS_RUNTIME_MAX_CLASS_INSTANCES": ("ladder", "runtime tenant"),
     "NROS_RUNTIME_MAX_COMPONENTS": ("ladder", "runtime tenant"),
-    "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
+    "NROS_ZEPHYR_HEAP_SIZE": ("ladder", "memory tenant — unblocked when the reader moved to a leaf crate"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_KEYEXPR_STRING_SIZE": ("ladder", "zenoh.limits tenant"),

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -44,7 +44,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # only ever rises is enforceable where a count that "should fall" is not: an
 # env name legitimately SURVIVES migration as the front-end, so the env rows are
 # reported, never gated. Raise this when a tenant lands.
-LADDER_FLOOR = 37
+LADDER_FLOOR = 42
 
 # Every build-script env name, and WHAT IT IS. An unclassified name FAILS the
 # gate rather than landing in a bucket by heuristic — the first version of this
@@ -95,9 +95,9 @@ KNOB_CLASS = {
     "NROS_ZEPHYR_HEAP_SIZE": ("sizing", "BLOCKED: the ladder crate depends on nros-platform, so the rungs are a cycle away. Kconfig already serves the rung on Zephyr"),
     "NROS_FREERTOS_HEAP_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
     "NROS_FREERTOS_APP_STACK_KB": ("ladder", "memory tenant; KiB front-end over a bytes rung"),
-    "NROS_KEYEXPR_STRING_SIZE": ("sizing", "keyexpr bound"),
-    "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape"),
-    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("sizing", "transport MTU; numeric, read as a string"),
+    "NROS_KEYEXPR_STRING_SIZE": ("ladder", "zenoh.limits tenant"),
+    "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape. TWO readers (zenoh build + the C emitter), so it needs one emission point before a rung"),
+    "NROS_XRCE_CUSTOM_TRANSPORT_MTU": ("ladder", "xrce tenant"),
     "ZPICO_MAX_LARGE_SUBSCRIBERS": ("derived", "pool cardinality; multiplies LARGE_PAYLOADS, phase-392"),
     "ZPICO_SERVICE_BUFFER_SIZE": ("derived", "SERVICE_BUFFERS is MAX_SESSIONS x MAX_QUERYABLES; phase-392"),
     # --- infra: not knobs ---
@@ -130,7 +130,7 @@ KNOB_CLASS = {
     "ZPICO_GET_POLL_INTERVAL_MS": ("ladder", "zenoh.wire tenant"),
     "ZPICO_READ_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
     "ZPICO_LEASE_TASK_PRIORITY": ("sizing", "transport-band priority (issue 0623)"),
-    "NROS_LET_BUFFER_SIZE": ("sizing", "logical-execution-time buffer"),
+    "NROS_LET_BUFFER_SIZE": ("ladder", "runtime tenant"),
     # --- infra ---
     "NROS_DECLARED_INFRA_QUERYABLES": ("infra", "a COUNT the resolver passes down, not a knob"),
     "NROS_DECLARED_SERVICE_SERVERS": ("infra", "a COUNT the resolver passes down, not a knob"),
@@ -212,8 +212,8 @@ KNOB_CLASS = {
     "NROS_SMOLTCP_BUFFER_SIZE": ("ladder", "net tenant"),
     "NROS_SMOLTCP_SOCKET_TIMEOUT_MS": ("ladder", "net tenant"),
     "NROS_SMOLTCP_CONNECT_TIMEOUT_MS": ("ladder", "net tenant"),
-    "NROS_XRCE_STREAM_HISTORY": ("sizing", "xrce stream depth; candidate rmw tenant"),
-    "ZPICO_SUBSCRIBER_RING_DEPTH": ("sizing", "SPSC ring depth (count, not a byte size)"),
+    "NROS_XRCE_STREAM_HISTORY": ("ladder", "xrce tenant"),
+    "ZPICO_SUBSCRIBER_RING_DEPTH": ("ladder", "zenoh.limits tenant"),
     "NROS_EXTRA_BOARD_PATH": ("infra", "extra board search roots"),
     "NROS_HOME": ("infra", "path"),
     "NROS_MODEL_DIR": ("infra", "path"),
@@ -275,6 +275,8 @@ def ladder_knobs():
         "NetKnobs",
         "RuntimeKnobs",
         "WireKnobs",
+        "XrceKnobs",
+        "ZenohLimitKnobs",
     ):
         fields = _struct_fields(src, struct)
         if fields:
@@ -308,6 +310,9 @@ READ_CALLEES = {
     # Option: for an entity COUNT, absence and zero are different answers and
     # a default would erase the difference.
     "env_opt_usize",
+    # phase-400 W6. `env_usize` with a ladder rung between the env and the
+    # builtin.
+    "env_usize_rung",
     "env", "env_get", "env_bool", "env_usize", "env_usize_min",
     "env_usize_compat", "env_or_repo_path", "env_path_or", "flag", "knob",
     "knob_usize", "knob_bool", "req", "list", "var", "var_os",


### PR DESCRIPTION
Stacked on #278. Five singleton knobs migrated across three crates; three deliberately not.

**Migrated:** `[knobs.xrce]` (`custom_transport_mtu`, `stream_history`), `[knobs.zenoh.limits]` (`keyexpr_string_size`, `subscriber_ring_depth`), and the LET buffer folded into `[knobs.runtime]`. Each had exactly one reader and no owning campaign.

## The three refusals are the substance

**`NROS_SERVICE_TIMEOUT_MS` has two readers by design.** `nros-rmw-zenoh/build.rs` emits a Rust const; `nros-build-helpers`'s C emitter emits a `#define`; a comment asks the next editor to keep the defaults equal.

I migrated it, and **`check-knob-single-reader` refused** — a migrated knob gets exactly one reader, and that rule is what stops the pair drifting. Both would have resolved through the same ladder and *could not* have disagreed, but the gate can't know that, and weakening it to say so trades a checked invariant for a comment. Migrating this knob means giving the pair **one emission point** first: a change to where the value is emitted, not to the ladder. Reverted, with the reason written at both sites.

**`NROS_ENTRY_SPIN_MS`** — read by a proc macro, the C++ library and a C header. Same shape, three readers, no single build script to own it.

**The two transport-band priorities** stay out for the reasons recorded with the `zenoh.wire` tenant.

## Verified against the emitted constants

```
builtin        KEYEXPR 256 / RING 4
platform rung  KEYEXPR 321 / RING 7
env wins       KEYEXPR 99, the rung still holding the rest
```

## The census caught my own helper

`env_usize_rung` was an idiom it didn't know, so it failed with *"a helper in neither list is counted as nothing"* — the gate I added this morning, working on the person who added it. Classified as a reader.

## Census

| | before | after |
| --- | ---: | ---: |
| sizing backlog (W6) | 10 | **5** |
| ladder struct fields | 37 | 42 |

## Verification

- `just check fast` — 190/190
- `just ci l1` — passed
- `just check submodule-pins` — 0 moved, checked deliberately and staged by explicit path rather than `git add -u`
