### PR TITLE
ci(zephyr): the 4.4 SDK download 404'd — sdk-ng repackaged at 1.0

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -117,6 +117,13 @@ jobs:
       # r3 (#0878): baked Zephyr's pinned Python build prereqs (west, pyelftools,
       # PyYAML, pykwalify, packaging) — without them every nightly cell failed at
       # `just zephyr setup` before any build.
+      # r4: the SECOND Zephyr SDK (1.0.1, for the 4.4 line) actually lands. The
+      # commit that added it (e569d9a55) left the tag at r3, and its image build
+      # 404'd on the download, so the registry kept serving one-SDK content under
+      # r3 while the tree said two — and every `zephyr 4.4 /*` cell went on
+      # failing `find_package(Zephyr-sdk 1.0)` against 0.17.4. Bumped because the
+      # published content changes, which is what `-rN` is for; r3 stays valid for
+      # anything still pinned to it.
       #
       # ORDERING, because this tag is hand-bumped rather than content-derived:
       # `nightly.yml` is moved to r3 in the SAME commit, and r3 does not exist in
@@ -126,7 +133,7 @@ jobs:
       # slack. If the image build fails, fix it before the next nightly rather
       # than reverting the consumers.
       IMAGE: ghcr.io/newslabntu/nano-ros-zephyr-ci
-      TAG: humble-sdk0.17.4-r3
+      TAG: humble-sdk0.17.4-r4
     steps:
       - uses: actions/checkout@v4
       - name: Log in to GHCR

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -470,7 +470,7 @@ jobs:
       group: nightly-zephyr-matrix-${{ matrix.line }}-${{ matrix.example }}-${{ github.ref }}-${{ github.event_name }}
       cancel-in-progress: false
     container:
-      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r3
+      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -607,7 +607,7 @@ jobs:
       group: nightly-zephyr-summary-${{ github.ref }}-${{ github.event_name }}
       cancel-in-progress: false
     container:
-      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r3
+      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -705,7 +705,7 @@ jobs:
       group: nightly-zephyr-copyout-${{ github.ref }}-${{ github.event_name }}
       cancel-in-progress: false
     container:
-      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r3
+      image: ghcr.io/newslabntu/nano-ros-zephyr-ci:humble-sdk0.17.4-r4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/docker/zephyr-ros/Dockerfile
+++ b/ci/docker/zephyr-ros/Dockerfile
@@ -107,8 +107,29 @@ RUN curl -fsSL -o /tmp/sdk.tar.xz \
 # both Config packages sit in the CMake user registry and each line's
 # `find_package` picks the one that satisfies it: 3.7 accepts either, 4.4
 # accepts only this one.
+#
+# `_gnu`, and the suffix is NOT optional — sdk-ng REPACKAGED at 1.0.
+#
+# The 0.x line ships one bundle per host, `zephyr-sdk-<ver>_linux-x86_64.tar.xz`.
+# The 1.x line splits it by toolchain flavour, so the same name without a
+# suffix simply does not exist and the build 404'd on its first run:
+#
+#   curl: (22) The requested URL returned error: 404
+#   ERROR: failed to build: process "/bin/sh -c curl -fsSL -o /tmp/sdk44.tar.xz …"
+#
+# Measured against the release API rather than guessed — v1.0.1 offers
+# `_gnu` (2033 MiB), `_llvm` (319 MiB) and `_minimal` (67 MiB), and no
+# unsuffixed bundle at all. `_gnu` is the one that corresponds to 0.17.4's
+# 1907 MiB bundle and carries the GNU toolchains `SDK_TARGETS` registers below;
+# `_minimal` is host tools only and would need a per-target download each.
+#
+# That 404 is why this image was never published with the second SDK: the
+# `images.yml` run for the commit that added it failed here, so the registry
+# kept serving the previous `-r3` content and every `zephyr 4.4 /*` nightly cell
+# went on failing `find_package(Zephyr-sdk 1.0)` against 0.17.4 — the exact
+# symptom the comment above says this block exists to fix.
 RUN curl -fsSL -o /tmp/sdk44.tar.xz \
-        "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION_44}/zephyr-sdk-${ZEPHYR_SDK_VERSION_44}_linux-x86_64.tar.xz" \
+        "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION_44}/zephyr-sdk-${ZEPHYR_SDK_VERSION_44}_linux-x86_64_gnu.tar.xz" \
     && mkdir -p /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION_44} \
     && tar xf /tmp/sdk44.tar.xz -C /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION_44} --strip-components=1 \
     && sdk_args="" && for t in ${SDK_TARGETS}; do sdk_args="$sdk_args -t $t"; done \


### PR DESCRIPTION
The last non-code blocker from the phase-413 W2 diagnosis.

## What was actually wrong

The `zephyr 4.4 /*` nightly cells fail `find_package(Zephyr-sdk 1.0)` against 0.17.4. **The tree already fixes that** — `e569d9a55` (09-03 10:58) bakes a second SDK and its comment quotes the exact CMake error.

The image never shipped it. The `images.yml` run for that commit, 20 minutes later, **failed**:

```
curl: (22) The requested URL returned error: 404
ERROR: failed to build: process "/bin/sh -c curl -fsSL -o /tmp/sdk44.tar.xz …"
```

## Why

**sdk-ng repackaged at 1.0.** The 0.x line ships one bundle per host, `zephyr-sdk-<ver>_linux-x86_64.tar.xz`. The 1.x line splits it by toolchain flavour, so the unsuffixed name does not exist at all.

Measured against the release API rather than guessed — v1.0.1 offers `_gnu` (2033 MiB), `_llvm` (319 MiB), `_minimal` (67 MiB), and nothing unsuffixed. Verified by request:

```
0.17.4/zephyr-sdk-0.17.4_linux-x86_64.tar.xz        HTTP 200
1.0.1/zephyr-sdk-1.0.1_linux-x86_64.tar.xz          HTTP 404   <- was used
1.0.1/zephyr-sdk-1.0.1_linux-x86_64_gnu.tar.xz      HTTP 200
```

`_gnu` corresponds to 0.17.4s 1907 MiB bundle and carries the GNU toolchains `SDK_TARGETS` registers; `_minimal` is host tools only and would need a per-target download each. The 0.x URL is untouched — correct for its line.

## Tag

Bumped to **r4**, with `nightly.yml`s three `container:` refs moved in the same commit — the ordering `images.yml` documents.

r3 in the registry is **pre-two-SDK** content, because the run that would have replaced it is the one that 404d. So this is a content change relative to what is published, which is what `-rN` is for. r3 stays valid for anything still pinned to it.

This also follows that files own instruction for exactly this case: *"If the image build fails, fix it before the next nightly rather than reverting the consumers."*

`images.yml` triggers on `ci/docker/zephyr-ros/**`, so merging rebuilds and publishes r4; nightly is daily, which is the slack the comment relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)