### PR TITLE
fix(#1005): the build-script helper crate declares itself, so the probe can see it

### DIFF
--- a/docs/issues/1005-zpico-build-constants-outside-staleness-inputs.md
+++ b/docs/issues/1005-zpico-build-constants-outside-staleness-inputs.md
@@ -102,3 +102,53 @@ cannot see it be wrong. Fixing the probe alone leaves the second half open.
 Whether other build-script dependency crates feed other fixture families the
 same way. `nros-zpico-build` is the one measured; the class is "a build-script
 dependency crate", and nothing has swept for siblings.
+
+## Landed 2026-09-04 — the crate declares itself, and it is MEASURED to reach the probe
+
+`nros_zpico_build::runner::run()` now emits its own sources as an input:
+
+    println!("cargo:rerun-if-changed={}/src", env!("CARGO_MANIFEST_DIR"));
+
+Verified end to end rather than reasoned about — a real `cargo build -p zpico-sys`,
+then reading the file the probe actually reads:
+
+    target/debug/build/zpico-sys-e43b33ac44297a9a/output
+      29 rerun-if-changed entries (was 28, none under nros-zpico-build)
+      cargo:rerun-if-changed=<root>/packages/rmw/zenoh/nros-zpico-build/src
+
+That path is absolute and in-repo, so it survives `zpico_recorded_inputs`'
+canonicalize-and-filter, and `zpico_c_inputs` expands a recorded DIRECTORY
+through `collect_source_files` already.
+
+**Emitted from the DEPENDENCY, not from each consumer** — which is stronger than
+direction 2 as written above. The objection to direction 2 was that it "relies on
+every future build-script dependency remembering to do it". Here the whole
+build-script implementation lives in this crate (`zpico-sys/build.rs` is a
+three-line shim calling `run()`), so a future consumer inherits the declaration
+instead of having to remember it. `env!` binds THIS crate's manifest dir at its
+own compile time, so the path is right whoever calls `run()`.
+
+Direction 1 (walk the build-script dependency closure from cargo metadata) is
+still the more general answer and is NOT done. This is the cheap half that closes
+the measured defect.
+
+## Still open after this
+
+* **The second gap is untouched.** `test_rtos_pubsub_e2e` FreeRTOS kills its
+  talker after 15 s, so the first lease lapse (~20 s of session life) never
+  arrives and a build baked at `10000` passes 6 of 6. The probe can now see the
+  constant change; the cell still cannot see it be wrong.
+* **The class is unswept.** The rule is "an in-repo build-script dependency
+  crate is an input the recorded path list does not name", and `nros-zpico-build`
+  is the one measured. A sweep of `[build-dependencies]` with a `path =` across
+  the tree finds these other helper crates, none of which declares itself:
+
+      nros-board-common     (9 consumers: every freertos/nuttx/threadx board)
+      nros-cc-flags         (5 consumers)
+      nros-build-paths      (4 consumers)
+      nros-zephyr-build     (packages/api/nros)
+      nros-board-threadx-port-riscv64
+
+  Whether each MATTERS depends on whether a staleness probe arm reads that
+  consumer's recorded inputs — the zenoh arm does, and the others have not been
+  checked. Not fixed here, and worth doing as one change rather than five.

--- a/docs/issues/1009-interop-bus-is-not-isolated-from-the-lan.md
+++ b/docs/issues/1009-interop-bus-is-not-isolated-from-the-lan.md
@@ -105,3 +105,15 @@ walking.
 The orphans themselves. `arm-a100` is a different machine and clearing it needs
 access to that host; it is the direct cause of today's failures and none of the
 fix above depends on it.
+
+## Direction 2 was already landed — verified 2026-09-04
+
+`dds_bus_snapshot` passes `--no-daemon` on all three sub-commands
+(`packages/testing/nros-tests/src/ros2.rs`), with a comment citing this issue and
+recording both halves: that the daemon leak is what walked a failing run onto a
+clean domain, and that fixing it could not have caught 0741 anyway because
+`ros2 service list` collapses a service to one NAME however many servers offer
+it. Nothing to do here.
+
+Directions 1 (loopback isolation for every DDS lane AND the Agent) and 3 (state
+0707's local-probe blindness) remain open, and 1 is the one that survives the LAN.

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1,6 +1,10 @@
 # Phase 403 — the type's bound sizes every receive buffer, and third parties can say what they need
 
-**Status (2026-08-30). Design, nothing landed.** Opened because
+**Status (2026-09-04). W1, W4 (one half), W6, W7, W7b, W8, W9 and steps 1-3
+are LANDED; W0, W2, W3 and W5 remain.** The 2026-08-30 line said "design,
+nothing landed" and outlived that by five days and eleven commits -- the body
+below had been recording `LANDED` per wave the whole time, so the phase read as
+unstarted to anyone who stopped at the header. Opened because
 [phase 402](phase-402-c-subscription-options-struct.md) delivered the PLUMBING
 for a per-type receive hint and stopped there: the hint now reaches the backend
 and changes nothing's size. Depends on
@@ -1286,7 +1290,7 @@ M and N are the join, its refusals and the back-compat),
 `just check entity-inventory-knobs` (27, up from 24) and 26 unit tests in
 `nros_cli_core::entity_inventory`.
 
-### Step 2 -- QoS depth in the declaration. Blocks the arena.
+### Step 2 LANDED 2026-09-02 -- QoS depth in the declaration. Blocks the arena.
 
 The arena's per-subscription cost is
 `sizeof(entry) + buffered_region_size(depth, bound)`, and that region is
@@ -1462,7 +1466,7 @@ side is not in the table -- keyed `(type, topic)`, a publisher and a
 subscription on one pair would be two rows with one key, and nothing consults a
 publisher's depth today.
 
-### Step 3 -- the arena. Last, because its failure cannot report itself.
+### Step 3 LANDED 2026-09-03 -- the arena. Last, because its failure cannot report itself.
 
 With depth present the arena is a straight sum: `arena_alloc` is a BUMP
 allocator, so the total IS the sum of the allocations. Two things are still

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -602,6 +602,30 @@ fn generate_config_header(
 }
 
 pub fn run() {
+    // Issue 1005 — THIS crate's sources are an input to every build that calls
+    // `run()`, and until now nothing said so. Cargo tracks the dependency
+    // correctly through its own unit graph, so an edit here does rebuild the
+    // consumer; what was missing is a `rerun-if-changed` PATH, and the fixture
+    // staleness probe reads exactly that recorded path list
+    // (`zpico_recorded_inputs`). The consequence was measured: `Z_TRANSPORT_LEASE_MS`
+    // moved 10_000 -> 60_000 on 2026-08-30 (issue 0906) and every FreeRTOS
+    // fixture in the tree still baked 10000 ten days later while the probe
+    // reported FRESH -- a known, measured, delivery-breaking value behind a
+    // green verdict.
+    //
+    // Emitted HERE and not from each consuming `build.rs` on purpose. The whole
+    // build-script implementation lives in this crate (`zpico-sys/build.rs` is
+    // a three-line shim), so a future consumer inherits the input declaration
+    // instead of having to remember it -- and "every consumer remembers" is the
+    // property that already failed.
+    //
+    // `env!` binds THIS crate's manifest dir at ITS compile time, which is what
+    // makes the path right no matter who calls `run()`. Watching a PATH is the
+    // safe direction: cargo reads a `rerun-if-changed` back from the stored
+    // output and never re-resolves it, unlike `rerun-if-env-changed` on a path
+    // VALUE (issue 0491).
+    println!("cargo:rerun-if-changed={}/src", env!("CARGO_MANIFEST_DIR"));
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let target = env::var("TARGET").unwrap_or_default();


### PR DESCRIPTION
## #1005 — a build-script dependency crate is an input nothing named

`nros-zpico-build` is a build-script dependency of `zpico-sys`. Cargo tracks it through its own unit graph, so editing it rebuilds the consumer — but it never appeared as a `rerun-if-changed` **path**, and the fixture staleness probe reads exactly that recorded path list (`zpico_recorded_inputs`). A constant living there was outside everything the probe examined.

Measured consequence, from the issue: `Z_TRANSPORT_LEASE_MS` moved 10_000 → 60_000 on 2026-08-30 (issue 0906) and every FreeRTOS fixture still baked 10000 ten days later while the probe reported FRESH. 0906 measured what the old value costs on those images — **19 heard of 77 before, 77 of 77 after**.

### The fix, and why it is in the dependency

```rust
println!("cargo:rerun-if-changed={}/src", env!("CARGO_MANIFEST_DIR"));
```

Emitted from the **dependency**, not from each consuming `build.rs` — which is stronger than the issue's own direction 2. That direction's stated weakness was that it "relies on every future build-script dependency remembering to do it". Here the entire build-script implementation lives in this crate (`zpico-sys/build.rs` is a three-line shim calling `run()`), so a consumer inherits the declaration instead of remembering it. `env!` binds *this* crate's manifest dir at its own compile time, so the path is right whoever calls `run()`.

Watching a **path** is the safe direction: cargo reads a `rerun-if-changed` back from the stored output and never re-resolves it, unlike `rerun-if-env-changed` on a path *value* (issue 0491).

### Verified, not reasoned about

A real `cargo build -p zpico-sys`, then reading the file the probe reads:

```
target/debug/build/zpico-sys-e43b33ac44297a9a/output
  29 rerun-if-changed entries  (was 28, none under nros-zpico-build)
  cargo:rerun-if-changed=<root>/packages/rmw/zenoh/nros-zpico-build/src
```

Absolute and in-repo, so it survives the canonicalize-and-filter, and `zpico_c_inputs` already expands a recorded directory through `collect_source_files`.

### What this does NOT fix — written into the issue, not left implied

- **The second gap.** `test_rtos_pubsub_e2e` FreeRTOS kills its talker after 15 s, so the first lease lapse (~20 s of session life) never arrives and a build baked at `10000` passes 6 of 6. The probe can now see the constant change; the cell still cannot see it be wrong.
- **The class.** Five other in-repo build-script helper crates declare themselves no better — `nros-board-common` (9 consumers), `nros-cc-flags` (5), `nros-build-paths` (4), `nros-zephyr-build`, `nros-board-threadx-port-riscv64`. Whether each matters depends on whether a staleness probe arm reads that consumer's recorded inputs; the zenoh arm does, the others are unchecked. Worth doing as one change rather than five, so it is not done here.

Sweep command is in the commit message.

## Also here

**docs(#1009)** — direction 2 was **already landed**. `dds_bus_snapshot` passes `--no-daemon` on all three sub-commands with a comment citing the issue. Recorded so the next reader does not redo it; directions 1 (loopback isolation, the one that survives the LAN) and 3 stay open.

**docs(phase-403)** — the status line read *"Design, nothing landed"* and had outlived that by five days and eleven commits, while the body below it recorded `LANDED` per wave the whole time. The phase read as unstarted to anyone who stopped at the header. Now states what landed (W1, W4 one half, W6, W7, W7b, W8, W9, steps 1–3) and what remains (W0, W2, W3, W5); the step 2 and 3 headings say LANDED like step 1 and the W-waves already did.

`just check fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742