### PR TITLE
phase-415: the zenoh-pico patch line moves to 1.8.0, plus three defects the port exposed

### DIFF
--- a/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
+++ b/docs/issues/0852-zephyr-serial-rx-is-polled-and-overruns.md
@@ -330,3 +330,137 @@ Diagnosed with counters in `.bss` read over SWD, because RTT kills the session
 (issue 0913). Those counters also refuted the ring-overflow theory outright:
 high-water 19 bytes of 1024, zero drops, while 145 bytes arrived in total and the
 reader timed out 75 times.
+
+---
+
+# REOPENED 2026-09-04 — the fix landed, had no effect, and made it worse
+
+The status above says the priority "is honoured at all three sites that dropped
+it". It is honoured at none of them on Zephyr. Every fact below was verified
+directly in this checkout.
+
+## The mechanism is a STRUCT TYPE CONFUSION, not a discarded attribute
+
+zenoh-pico dispatches `ZENOH_ZEPHYR` **before** `ZENOH_GENERIC`
+(`system/common/platform.h:37` vs `:55`), so Zephyr gets
+`system/platform/zephyr.h:39`:
+
+```c
+typedef pthread_attr_t z_task_attr_t;
+```
+
+not the generic header's `typedef nros_platform_task_attr_t z_task_attr_t`. But
+`zephyr/nros_zenoh_zephyr_system.c:58` casts that pointer straight through:
+
+```c
+return nros_platform_task_init((void *)task, (void *)attr, fun, arg)
+```
+
+The layouts do not match, and the read is out of bounds:
+
+| | 32-bit | 64-bit |
+| --- | ---: | ---: |
+| `struct pthread_attr` = `{void *stack; uint32_t details[2];}` | **12 B** | **16 B** |
+| offset of `nros_platform_task_attr_t::priority` (after `name`, `stack_bytes`, `stack_mem`) | **12** | **24** |
+
+So `priority` is read from **past the end of the object** on both.
+
+## Why this is a REGRESSION, not merely an unfixed bug
+
+`pthread_attr_init` leaves `stack = NULL` unless `CONFIG_DYNAMIC_THREAD_STACK_SIZE`
+is set, and no built image sets it. The bytes at the priority offset are the
+adjacent `lease_task_attr.stack`, i.e. zero. So:
+
+```
+a->priority == 0  ->  band 0  ->  sched_get_priority_min(SCHED_RR) = 0
+                  ->  POSIX_TO_ZEPHYR_PRIORITY(0, SCHED_RR) = 15 - 0 - 1 = 14
+```
+
+Measured against `zephyr-workspace/build-rust-talker-zenoh/zephyr/.config`:
+`CONFIG_NUM_PREEMPT_PRIORITIES=15`, `CONFIG_MAIN_THREAD_PRIORITY=0`.
+
+**Transport at 14 — the least urgent preemptible slot. Executor at 0 — the most
+urgent.** Before the fix the read task merely TIED with the executor. The fix
+moved it to the bottom of the band. `a->name` reads the same NULL, so the thread
+naming added in the same commit is inert too.
+
+## The tell was already written down, and Zephyr was left off the list
+
+`zpico.c:1642` guards the correct assignment with
+
+```c
+#if defined(ZENOH_NUTTX) || defined(ZENOH_LINUX) || defined(ZENOH_MACOS)
+```
+
+and its own comment describes this exact hazard — "*Pointing at
+`read_task_attr` handed it a `pthread_attr_t`, whose bytes at the `priority`
+offset are 0 whatever was...*". That is issue 0803. It was fixed for three
+platforms and Zephyr was omitted — the one platform whose `z_task_attr_t`
+genuinely IS a `pthread_attr_t`, and therefore the only one where the bug is
+guaranteed rather than incidental.
+
+## Two normalised bands meet in one scheduler — issue 0623, one platform over
+
+Fixing the pointer alone is NOT enough:
+
+* `zpico_posix_set_priority` (`zpico.c:1311`) maps a **0-31** band.
+* `nros_zephyr_native_priority` (`platform.c:473`) maps a **0-255** band
+  (`NROS_PLATFORM_PRIORITY_MAX`).
+
+The Kconfig default is `16`, documented "normalized 0-31". Through the 255-wide
+map that is `(16*14)/255 = 0` — still the bottom slot. The two spellings must be
+unified to one band in the same change, or the fix reproduces the defect.
+
+## The static gate certifies a function whose output is discarded
+
+`packages/boards/zephyr/nros-board.toml` declares `derived = "zephyr"`, so
+`scripts/lib/priority_plan.py:resolve_zephyr_plan` models
+`zpico_posix_set_priority` — the function filling the `pthread_attr_t` nobody
+reads. `check-tier-priority-plan-image` is therefore green about a band no image
+ever had, while `examples/workspaces/realtime-c/.../system.toml` authors
+`tiers.high.zephyr = 9` against that fiction. **The declared ordering is exactly
+inverted from reality and no gate can see it.** Zephyr also has no sibling of
+FreeRTOS's `report_tiers_above_transport` (`nros-board-freertos/src/entry.rs:838`),
+which is the boot-time check that cannot be fooled by dead code.
+
+## Retracted / corrected from the text above
+
+* "Landed (steps 1 and 2)" — there was a FOURTH site (`zpico.c:1642`) and it was
+  not touched. Net effect is a regression.
+* The root-cause citations (`zpico.c:1431`/`:1443`) name the **Linux/NuttX/macOS**
+  arm, not Zephyr's. Reading them as Zephyr's is what produced the bad cast.
+* "`nros_zephyr_task_create_prio` — the native SCHED_FIFO priority"
+  (`nros_platform_zephyr_shims.c:481`) contradicts its own code, which uses
+  `SCHED_RR` (`:534`).
+* The timing arithmetic assumes `CONFIG_TIMESLICE_SIZE=20` and
+  `CONFIG_MAIN_THREAD_PRIORITY=5`. Neither appears in this repo; all sampled
+  images have `TIMESLICE_SIZE=0`, `MAIN_THREAD_PRIORITY=0`. The 20 ms / 230-byte
+  figure is true of an out-of-tree board only, and the issue does not say so.
+* The title still describes the PRE-fix state ("inherits the executor's
+  priority"). Post-fix it is worse than inheritance.
+* **Stands:** choosing `SCHED_RR` over `SCHED_FIFO` (on Zephyr `SCHED_FIFO`
+  selects the cooperative band). That reasoning is correct and should survive
+  any rewrite.
+
+## Adjacent, unlinked, still a live bug on the fork
+
+zenoh-pico's own `src/system/zephyr/system.c:158` also drops a non-NULL `attr`.
+`nros_rmw_zenoh.cmake` adds only `network.c`/`isotp.c` by name, so it is not
+linked here — but anyone who does compile it gets the same class.
+
+## What a fix must include
+
+1. Point Zephyr at the `nros_platform_task_attr_t` (add `ZENOH_ZEPHYR` to the
+   `:1642` guard), and delete `zpico_posix_set_priority`'s Zephyr arm rather
+   than leaving a second spelling of a scale beside it — that is how 0623
+   happened.
+2. Do the same for the **tx-flush** task (`zpico.c:1739`), which is live
+   whenever `CONFIG_NROS_ZENOH_TX_BATCH` is on. Same class, same commit.
+3. Unify the band to 0-255 in Kconfig, and STATE the ordering. Transport above
+   the app is what `[board.priority_plan]` already declares and what FreeRTOS
+   ships (app 3 / transport 4); the reverse starves the RX drain (0623). Note
+   `CONFIG_MAIN_THREAD_PRIORITY=0` leaves no room above it.
+4. Re-point `resolve_zephyr_plan` at `nros_zephyr_native_priority`, or the gate
+   keeps certifying the deleted map.
+5. A `_Static_assert` in the shim that the cast is sound. It fails today, which
+   is the point.

--- a/docs/issues/0870-nuttx-cpp-action-client-transport-tx-failed.md
+++ b/docs/issues/0870-nuttx-cpp-action-client-transport-tx-failed.md
@@ -357,3 +357,123 @@ class and the same argument applies to them, but issue 0968 records ~12
 unreproduced tier-2 e2e failures — flipping all four at once produces a wall of
 red that obscures rather than reveals. Extending this is a one-line change per
 override and a separate decision, not a rediscovery.
+
+---
+
+# CORRECTION 2026-09-04 — the capacity lead was never possible, and the instrumentation is not in this tree
+
+## My "the instrumentation is absent" claim was WRONG — the fixture was stale
+
+An earlier draft of this section asserted, from `strings` on
+`examples/qemu-arm-nuttx/cpp/action-client/build-zenoh/cpp_action_client`, that
+the four diagnostics were not linked and that the standing plan was therefore
+false. **Retracted.** The binary is dated 2026-08-27 03:55; the diagnostics
+landed on 2026-09-03 (`action.rs:1266` has
+`"action client: feedback subscription failed: {:?}"` in the source right now).
+`strings` was reading a week-old artifact.
+
+That is precisely the trap CLAUDE.md records from issues 0859-0862 — four ghost
+issues filed from a sweep whose fixtures predated the fix — and the remedy it
+prescribes is the one I skipped: `stat -c '%y' <artifact>` against
+`git log -1 --format=%ci` of the code being blamed, BEFORE drawing a conclusion.
+
+What survives, and is worth keeping as a standing check rather than a finding:
+**`strings` the artifact you are about to run, not the tree you are reading.**
+A stale fixture makes an armed diagnostic invisible, which is the same
+observation as an unarmed one.
+
+## Pool exhaustion cannot produce this error code — the lead was structurally impossible
+
+The issue retired the capacity hypothesis by measuring that the pools are big
+enough. The stronger reason is that **no exhaustion anywhere in the path can
+arrive as `Generic`**, so the lead was dead regardless of what the constants
+say — and stays dead for any future NuttX build:
+
+| exhausted pool | code it returns | file:line |
+| --- | --- | --- |
+| zpico subscriber slots | `ZPICO_ERR_FULL` (-6) | `zpico.c:2236` |
+| liveliness slots | `ZPICO_ERR_FULL` | `zpico.c:2681` |
+| Rust subscriber index | `TransportError::SubscriberCreationFailed` | `subscriber.rs:674` |
+| payload block | `TransportError::SubscriberCreationFailed` | `subscriber.rs:682` |
+
+The observed code is `ZpicoError::Generic` (-1), and at the only site that can
+produce it during construction (`zpico.c:2267`) it means exactly one thing:
+**`z_declare_subscriber()` itself returned < 0.**
+
+Inside zenoh-pico, `_z_register_subscriber` (`net/primitives.c:210-251`) has
+four failure exits: keyexpr declaration, sync-group notifier, registration OOM
+(`-78`), and `_z_send_declare` -> `_Z_ERR_TRANSPORT_TX_FAILED` (`-100`). OOM is
+implausible on 126 MB, and the C image carries MORE `.bss` (549,456 vs 540,976)
+without failing. That leaves the TX exit.
+
+## Entity accounting, corrected
+
+An action **client** opens **four** entities, not "three services plus feedback
+and status": there is no client-side status subscription
+(`action.rs:1128-1270`). The two publishers belong to the **server**
+(`action.rs:679-685`). That is a real divergence from `rclcpp_action` and worth
+knowing, but it is not this bug.
+
+Construction performs **seven** network ops in the C++ shape, not six: two node
+liveliness tokens (`session.rs:445` at open, plus `session.rs:862` from
+`ensure_node_liveliness`, because the entity's node name differs from
+`primary_node_name`) + four entity tokens + one subscriber declare. The
+"6-of-6 versus 1-of-6" framing is really 7-of-7 versus 1-of-7 — small, but it
+changes what a diagnostic must print to answer the question.
+
+## Split out, not buried: the queryable budget is an accident
+
+`ZPICO_MAX_QUERYABLES = 32` on NuttX is reported here as a fact. It is correct,
+and it is not a choice: `runner.rs:246` tests `target_os != "none"`, and NuttX
+reports `target_os = "nuttx"`, so an RTOS takes the budget written for Linux.
+Measured cost in this very image: **142,336 B of `.bss`** with zero queryables
+declared. Filed as [#1028](1028-nuttx-classified-hosted-takes-linux-queryable-budget.md).
+
+## The client-side analogue of 0460 exists, but not at construction
+
+`pending_gets[ZPICO_MAX_PENDING_GETS]` is 4 slots (`zpico.c:460`) **shared**
+between service gets and liveliness gets (`zpico.c:3270` says so). An action
+client holds three service clients that can each park a standing discovery get,
+plus `wait_for_action_server`, plus `send_goal`'s 500 ms resend loop which
+allocates a new slot per generation (`shim/service.rs:759-766` documents
+overflowing 4). Genuine latent risk on the RUNTIME path, plausibly relevant to
+#0867 — **not reachable at construction**, so it does not explain this issue.
+
+## Still unexplained: why C++ and not C
+
+Checked and found nothing that survives. Both images link the **same**
+`zpico-sys` artifact (`zpico-sys-ec52ae90a97507ef`), so every shim constant and
+every zenoh-pico `#define` is provably identical. Both pool symbols are
+byte-identical. Neither carries param or lifecycle services. Both open in
+`SessionMode::Client`. The one structural difference — C opens through
+`open_session` with an empty namespace and the session name, C++ through
+`Executor::open_in` with the resolved node name and namespace — only changes
+which node token is declared, and every liveliness declare is `.ok()`-swallowed.
+
+**No fourth story is offered.** Three have been burned; the next step is
+evidence, not another hypothesis.
+
+## Fix direction: stop collapsing the error, do not raise a limit
+
+Nothing is being exhausted, so nothing should be raised. The remaining defect
+in the chain is that `zpico.c` discards zenoh-pico's return code at six declare
+sites (`:2106`, `:2154`, `:2210`, `:2267`, `:2320`, `:2695`), and
+`subscriber.rs:725` then relabels the survivor as `ConnectionFailed` — which is
+what pointed the first two diagnoses at the router. Nothing about that call is a
+connection: the session is open and a DECLARE failed.
+
+Add `ZPICO_ERR_TX` / `ZPICO_ERR_NOMEM` (the bands do not overlap, so one shared
+`_zpico_map_zerr` helper suffices — a second spelling is how six sites come to
+disagree), mirror them in `ZpicoError`, and return
+`SubscriberCreationFailed` at `subscriber.rs:725` like the two exhaustion arms
+above it already do. Then `-11` vs `-12` vs `-1` splits the remaining
+hypothesis space in one run, which is the question this issue has been unable
+to ask for four rounds. RAM cost: none.
+
+## Confirmed sound
+
+`nros_log` **does** reach the NuttX console in a C/C++ image —
+`nros-board-nuttx-qemu/src/entry.rs:50` calls `init_default()` inside
+`nsh_main` before `main`, and `nsh_main` is in the built ELF. Without that the
+four `nros_error!` calls would sit in the pre-init ring and never print. The
+plan is sound; only the binaries are wrong.

--- a/docs/issues/0902-action-goal-completion-is-variable.md
+++ b/docs/issues/0902-action-goal-completion-is-variable.md
@@ -109,3 +109,143 @@ result. Decoding it names what the board thinks it is answering with.
 
 That is a decoder change, not a hardware run: the bytes are already captured in
 the tap dumps.
+
+---
+
+# 2026-09-04 — a mechanism that explains the idle soak, and a misattribution
+
+## The measurement table credits the wrong issue
+
+The row "after the 0882 allocator fix — 9/10" is
+[#0912](archived/0912-transport-failure-teardown-crashes.md), not 0882. **0882
+is the NuttX cmake carrier bug and contains no allocator fix**; 0912 is the
+`k_free` on a TLSF block -> `z_free` one, on this board, and its final table
+reads 9/10. 0912 is also the direct predecessor — it established that "the
+remaining 1 in 10 is a transport failure the board survives" — and it is missing
+from `related:`. Fix both.
+
+## The 51-byte frame is almost certainly the FINAL status publish, not an error
+
+The "Next" section guesses a zenoh `Err` reply or a final-marker. **A zenoh
+`Err` reply is impossible**: `z_query_reply_err` has **zero** call sites in
+`zpico.c`. The shim can emit an OK reply or nothing.
+
+The arithmetic points at `publish_status_array()` with an empty goal list:
+
+* the status array serialises only `active_goals` — `write_u32(len)` then one
+  `GoalStatusStamped` each (`action_core.rs:1067-1086`);
+* one `GoalStatusStamped` = 16 (uuid) + 4 + 4 (stamp) + 1 (status) = **25 B**
+  (`nros-core/src/action.rs:263-269, 367-374, 404-409`);
+* so 1 goal -> 33 B payload, 0 goals -> 8 B. **Delta 25.** Observed delta is
+  78 - 51 = **27**, i.e. 25 + framing;
+* status goes out on a **declared** (numeric) keyexpr, so no key string appears
+  — matching "no key at all" — and it shares its leading bytes with the 78-byte
+  frame, which is what was observed. A `REPLY_FINAL` would not share a prefix
+  with a publication and is ~15 B on this link, not 51.
+
+**If that reading holds the conclusion changes materially:** in the failing run
+the board **executed the goal and ran `complete_goal_raw` to its last line**.
+The missing 209 sits between the two status publishes — in the deferred-reply
+flush at `action_core.rs:684-700`. This is not "the board never got there"; it
+is "the reply was attempted or skipped, and the failure was discarded".
+
+Checkable for free in the captures already taken: decode the 78 and 51 as zenoh
+Push messages and compare resource ids and payload element counts.
+
+## Leading candidate: a reply-slot leak, and it is the only thing that explains the idle soak
+
+`ZPICO_MAX_PENDING_REPLIES` is **4**, hardcoded at `zpico.c:256-257` with **no
+Kconfig knob, no `-D`, no env** — verified by grep across `*.rs`, `Kconfig` and
+`*.cmake`. The slot is reclaimed **only** after a fully successful reply
+(`zpico.c:3905-3906`); every error return above it leaves `stored_query_valid`
+set.
+
+And the query is cloned into a slot **before** the user callback runs
+(`zpico.c:875-885`), while the Rust callback drops empty-payload queries
+**after** that, at `shim/service.rs:225-227`:
+
+```rust
+if payload.is_null() || payload_len == 0 {
+    return;
+}
+```
+
+Its own comment says what those are: "liveliness probes that zenoh-pico
+delivers through the same queryable callback as real service requests". That
+filter predates the Phase-237 clone, so the clone was added **underneath** an
+unconditional early return. **Every background discovery or liveliness probe
+delivered to the queryable permanently consumes one of four slots.** The
+ring-full drop at `:234-236` is the same shape.
+
+Once four are gone, `reply_seq` is `-1` forever: `send_response(-1)` ->
+`zpico.c:3848-3850` -> `ZPICO_ERR_INVALID`, swallowed. **Goal accepted,
+executed, status published, no result, no error anywhere.**
+
+Why the silence is structural — the error is discarded at four layers:
+`action_core.rs:695` (`delivered_any |= sent.is_ok()`, after the entry was
+already `swap_remove`d at `:688`, so a failed send strands the requester and
+returns nothing), `:706-710` (`Ok` as long as the result reached the slab),
+`arena.rs:1925` (`if let Ok(Some(_))`), and `nros-cpp/src/action.rs:529-532`,
+which prints **"Goal succeeded"** for a goal whose result was never sent. The
+one site that would explain it is `log::error!` under `#[cfg(feature = "std")]`
+— dead on this image.
+
+**This reframes the issue's central claim.** If the mechanism is right, the
+20-90 % spread is **not noise; it is a deterministic countdown**, consumed by
+elapsed time with a peer present rather than by goal traffic — which is exactly
+why 100 s of idling made it worse (2/5). And the failing state is **absorbing**:
+once a boot starts failing it can never recover.
+
+## Two free checks, before any hardware
+
+1. **In every existing run log: did any goal succeed AFTER an earlier goal
+   failed in the same boot?** One recovery falsifies the leak outright. A
+   contiguous failing tail confirms it to first order.
+2. **In the tap dumps already captured:** a `reply_seq == -1` query is never
+   cloned, so `_z_query_clear` fires when the handler returns and emits a
+   `REPLY_FINAL` (`zenoh-pico/src/net/query.c:54-60`) — a ~15 B board->router
+   frame between the 82 B query and the 78 B status, easily binned as a
+   keepalive. Present => the leak. Absent anywhere in the run => a per-reply
+   transport failure instead.
+
+## Ruled out with code, not argument
+
+* **`ZPICO_MAX_QUERYABLES` (issue 0460).** Fails at `ZenohServiceServer::new`,
+  at boot, hard. The action would never appear in `ros2 action list`, which was
+  measured as resolving. Cannot be intermittent.
+* **`ZPICO_MAX_PENDING_GETS` / `ZPICO_GET_REPLY_BUF_SIZE`.** These size the
+  `zpico_get*` **client** path. The board is the action **server** and issues no
+  queries for this flow.
+* **`z_query_clone` failing under heap pressure.** It is a refcount increment
+  (`refcount.h:70-72`), not an allocation — so `reply_seq == -1` means "the
+  table was full" and nothing else. That is what makes this a capacity story
+  rather than a memory story.
+* **`ffi_guard` masking interrupts across the reply.** `critical_section::with`
+  only under the `ffi-sync` feature, which only the RTIC bare-metal examples
+  enable. No-op here.
+
+## Second candidate, if the free checks refute the leak
+
+A per-reply failure inside zenoh-pico, reaching the same discarded `Err`:
+`_z_send_n_msg` with `CONGESTION_CONTROL_BLOCK` returning
+`_Z_ERR_TRANSPORT_TX_FAILED` (`net/primitives.c:465-467`), `z_bytes_copy_from_buf`
+OOM (`zpico.c:3861/3878`), or `_Z_ERR_KEYEXPR_NOT_MATCH` (`:438-440`) via a real
+design weakness: `ServiceBuffer.keyexpr` is a **single shared copy overwritten
+by every query on the queryable** (`shim/service.rs:204-218`, before the
+empty-payload return), while `try_recv_request` copies it into `reply_keyexpr`
+at **dequeue** time (`:503-512`). A foreign-keyexpr query landing between
+enqueue and dequeue makes the server reply with the wrong key. The comment
+"constant per server" is the assumption a wildcard or probe query breaks.
+
+**It does not explain the idle soak** — nothing about 100 s of idling raises TX
+failure or OOM probability — and that should be said plainly rather than glossed.
+
+## Latent, file separately if confirmed
+
+`shim/service.rs:246` takes the reply seq indexed by the **Rust** service-buffer
+counter, while `send_response` (`:539`) passes the **C queryable handle**
+(`zpico.c:2805-2814`, first free slot). They coincide only while every server is
+created in order and none is destroyed — `NEXT_SERVICE_BUFFER_INDEX` never
+decrements, but `Queryable::drop` (`zpico.rs:218`) frees the C slot for reuse.
+One dropped service server desynchronises the two permanently. Not reachable in
+this image; one lifecycle transition away.

--- a/docs/issues/0910-zenoh-pico-1-10-migration.md
+++ b/docs/issues/0910-zenoh-pico-1-10-migration.md
@@ -111,3 +111,27 @@ This issue stays open for the parts that are not the version bump: the config
 generator being 54 knobs behind, the `ZENOH_GENERIC` TU, and the note that fork
 commit `67ee0224`'s INIT-retry must NOT be carried forward because upstream
 never had the flood it fixed.
+
+## Update 2026-09-04 — 1.8.0 landed; this issue stays open for 1.10
+
+Phase 415 moved the patch line to **1.8.0**, the zenoh ROS Humble actually
+ships (`rmw_zenoh_cpp` 0.1.9 → `ZENOH_C "1.8.0"`). That is the version the
+tracking rule names, so it closes the *drift* half of this issue. 1.10 is still
+two minors AHEAD of ROS and remains the wrong target under that rule — this
+issue stays open as the record of what a later move would cost, not as work
+that is queued.
+
+**One row of the table above is wrong and matters, because it is used as an
+argument for 1.10 being special.** `include/zenoh-pico/config.h` is not
+"checked in at our pin, generated at 1.10": **1.7.2 and 1.8.0 both generate it**,
+via `configure_file(config.h.in -> config.h)` writing back into the SOURCE tree
+(`CMakeLists.txt:345` at 1.7.2, `:379` at 1.8.0). It only *looks* checked in
+because the generated file is committed and because `zpico-sys` compiles the
+sources directly and never runs that CMakeLists — so for nano-ros the committed
+`config.h` is the effective config and the generator never fires.
+
+The practical consequence, found by building 1.8.0 the upstream way during the
+port: anything we write into `config.h` alone is erased by the first `cmake`
+configure. Two knobs were in that position and are now in `config.h.in`; the
+`#ifndef` wrapping from `49012370` still is not (118 lines). Details and the
+sweep command are in [phase-415](../roadmap/phase-415-zenoh-pico-1-8-0-patch-line.md).

--- a/docs/issues/0997-island-announces-spdp-once-then-lease-expires.md
+++ b/docs/issues/0997-island-announces-spdp-once-then-lease-expires.md
@@ -260,3 +260,59 @@ asi_rx_steer    612        612
 Confirm the guest is still running before believing that — gdb halts the target
 on attach, and a failed resume produces the same frozen numbers for an entirely
 different reason. Here the island's log kept advancing across the reads.
+
+---
+
+# CORRECTION 2026-09-04 — two of the observations above are not evidence
+
+A full audit of the vendored fork's timed-event handlers (see
+[#1000](1000-spdp-periodic-event-orphaned-by-handler-early-return.md), whose own
+proposed fix was found unsafe and is corrected there) retracts two claims made
+above. Both were read as corroborating anomalies; neither is one.
+
+## RETRACTED — "`oldest == NULL` while `newest != NULL`" is not an inconsistency
+
+The text above calls this "a singly-linked list with a tail and no head". It is
+the documented drained state. The field is declared:
+
+```c
+/* src/core/ddsi/src/q_xevent.c:149 */
+/* undefined if ..._oldest == NULL */
+```
+
+and `getnext_from_non_timed_xmit_list` (`q_xevent.c:260-274`) deliberately never
+clears `newest`. **Every** drained non-timed list looks exactly like this. It is
+a stale pointer by design, so it corroborates nothing and should not have been
+presented beside the empty-tree reading.
+
+## RETRACTED — the `resched_xevent_if_earlier` lost-update theory cannot happen here
+
+The text above names it "the mechanism to look at first", on the grounds that it
+re-arms ONLY when the new time is earlier. On the post-fire path it always
+re-arms: `handle_xevents` stamps `xev->tsched.v = DDS_NEVER` (`INT64_MAX`) at
+`q_xevent.c:1232` *before* calling the handler, so any finite reschedule
+satisfies `tsched.v < ev->tsched.v` and the insert happens (`:400-408`).
+
+The only way that comparison no-ops is a concurrent `delete_xevent` having set
+`TSCHED_DELETE`, which is the documented and intended behaviour
+(`q_xevent.c:394-398`). So this is not a lost update and not the first thing to
+look at.
+
+## What the empty tree actually implies
+
+Still open, and now better constrained. #1000's SPDP orphaning **cannot alone**
+produce `xevents = {roots = 0x0}`: `handle_xevk_pmd_update` reschedules
+unconditionally (`q_xevent.c:1097`) on a finite lease, and the lease is the
+default 10 s. An empty tree needs SPDP **and** PMD orphaned together, which
+means the participant became **un-findable in the entity index** while the
+application was still running.
+
+That is the thing to hunt, and it is upstream of both handlers. The next run
+should therefore add a `GVLOGDISC` to `handle_xevk_pmd_update:1073-1075` — which
+today returns with **no logging at all** — alongside the two SPDP lines #1000
+names. Two "unknown guid" lines within ~8 s of each other confirms it.
+
+Also worth suspicion on timing alone: the submodule tip `d97a71e` is
+"ddsrt: one funnel heap for every port". If neither handler logs and no further
+`xmit spdp` appears, the loss is at INSERT time and `ddsrt/src/fibheap.c` is
+where to look, not the handlers.

--- a/docs/issues/1000-spdp-periodic-event-orphaned-by-handler-early-return.md
+++ b/docs/issues/1000-spdp-periodic-event-orphaned-by-handler-early-return.md
@@ -135,3 +135,128 @@ of presenting as a silent, permanent loss of discovery an hour into a run.
 Upstream carries the same code, so this is worth sending to
 `eclipse-cyclonedds/cyclonedds` rather than only carrying a fork patch. That
 call is the maintainer's.
+
+---
+
+# CORRECTION 2026-09-04 — the fix proposed above is UNSAFE, and the contract has a third arm
+
+A full audit of every timed-event handler was run against the vendored fork
+(`d97a71e`). It confirms the orphaning *class* and refutes three specific claims
+made above. The original text is left intact; this section supersedes it.
+
+## 1. Do NOT apply the fix proposed above — it is a use-after-free
+
+"either `delete_xevent (ev)` unconditionally on those paths" corrupts the heap.
+`pp->spdp_xevent` is a raw **owning** pointer that is never cleared, and
+`ddsi_unref_participant` deletes it again, unconditionally:
+
+```c
+/* src/core/ddsi/src/ddsi_participant.c:688 */
+if (pp->spdp_xevent)
+  delete_xevent (pp->spdp_xevent);
+```
+
+`delete_xevent`'s only protection against a second delete is a pair of
+`assert`s (`q_xevent.c:341-342`) — and the embedded Cyclone builds
+`CMAKE_BUILD_TYPE:STRING=Release`
+(`packages/rmw/cyclonedds/nros-rmw-cyclonedds/build/CMakeCache.txt:58`), so
+`NDEBUG` removes them. The second call writes `TSCHED_DELETE` into freed memory
+and inserts it into the fibheap. That trades a silent stall for heap corruption
+on an RTOS, which is a strictly worse failure.
+
+## 2. The contract is not "reschedule or delete" — there is a third arm
+
+Above it says re-arming is "entirely the handler's responsibility". It is not.
+A handler may also **return and leave the event to the entity that OWNS it**,
+and upstream relies on this in five places. Every timed event except the
+directed SPDP one is owned by a live struct that holds the pointer and deletes
+it during teardown: `wr->heartbeat_xevent`, `m->acknack_xevent`,
+`pp->pmd_update_xevent`, `pp->spdp_xevent`, and the `XEVK_CALLBACK` events.
+
+So a lookup failure inside a handler means *"the owner is tearing this entity
+down and will delete the event"*, and returning is correct.
+
+**This also re-reads `ev->u.spdp.directed`.** It is not a periodic-vs-one-shot
+test, as claimed above; it is an **owned-vs-unowned** test. `XEVK_SPDP` is the
+only kind used both ways — undirected is stored in `pp->spdp_xevent`
+(`ddsi_participant.c:977`), directed has its `qxev_spdp` return value discarded
+(`q_ddsi_discovery.c:633`) and therefore must delete itself. The asymmetry the
+original text reads as a bug is the design.
+
+Only ONE path in the file orphans an event whose owner is still operational:
+`handle_xevk_spdp:968-973`, undirected, reachable when `pp->e.onlylocal` (that
+participant gets a periodic SPDP event because `spdp_write` returns 0 for
+onlylocal, `q_ddsi_discovery.c:533-536`, and `ddsi_participant.c:967` accepts
+`>= 0`). `RTPS_PF_ONLY_LOCAL` is annotated "FIXME: not used, it seems"
+(`ddsi_participant.h:165`), so nothing in-tree reaches it today.
+
+## 3. This mechanism CANNOT produce the empty tree #0997 observed
+
+The claim above — that it "produces precisely the observed state" — does not
+hold. `handle_xevk_pmd_update` reschedules **unconditionally** at
+`q_xevent.c:1097` whenever the participant is found and the interval is finite,
+and it is finite: `pp->lease_duration` defaults to 10 s and
+`ddsi_participant.c:1172` clamps to it. With only the SPDP event orphaned, the
+PMD event is still on the heap and `tev` still wakes.
+
+`xevents = {roots = 0x0}` therefore requires SPDP **and** PMD to be orphaned
+together, which means the participant became un-findable in the entity index.
+**That is a root cause upstream of these handlers**; the orphaning is the
+amplifier that makes it permanent rather than the trigger. The "wider point"
+above is right; the narrow causal claim is not.
+
+## 4. The proposed assertion would fire on about half the queue
+
+"Alive and unscheduled" is the designed resting state, not an error. An
+`assert (xev->tsched.v != DDS_NEVER)` after the handler would fire on, at least:
+every reliable writer's heartbeat in steady state (`q_xevent.c:748-752`, and the
+event is *created* at `DDSRT_MTIME_NEVER`, `ddsi_endpoint.c:901-906`);
+`handle_xevk_pmd_update` with an infinite interval; `make_and_resched_acknack`
+on `AANR_SUPPRESSED_ACK` and `AANR_ACK` (`ddsi_acknack.c:400`, `:417`);
+`lifespan_rhc_node_exp` and `instance_deadline_missed_cb` whenever their heaps
+drain; and all five legitimate teardown handoffs.
+
+A sound version tests OWNERSHIP, not scheduling: give `struct xevent` an
+`owned` bit set by the `qxev_*` constructor and assert
+`tsched.v != DDS_NEVER || owned`. That fires on exactly the unowned-and-
+unscheduled shape, which is the real defect.
+
+Note also that "a debug assertion would have caught this at the first
+occurrence" is **false for the build that shipped**. `q_xevent.c:996-1019`
+already contains an `#ifndef NDEBUG` block asserting precisely that an
+undirected SPDP event must not hit an empty WHC unless marked for deletion —
+and Release compiled it out.
+
+## 5. Unverifiable here
+
+"stock upstream code rather than something the fork introduced" is consistent
+with `docs/reference/cyclonedds-fork-delta.md` carrying no `q_xevent.c` row, but
+it cannot be checked in this checkout: the submodule is a shallow clone, so
+`git log` attributes the whole file to the shallow boundary. Per CLAUDE.md, run
+`git remote prune origin && git fetch --unshallow origin` before believing any
+history claim about the fork.
+
+## 6. The corrected fix, and what to measure first
+
+The narrow patch is a **reschedule**, not a delete, on the one live-owner path,
+plus clearing `pp->spdp_xevent` / `pp->pmd_update_xevent` before deleting them
+so the double-delete class is closed structurally. Both are written out in full
+in the phase notes; neither is applied yet, because the ACTUAL root cause is
+§3's un-findable participant and a fix for an unreached path is not worth a
+vendored-fork bump on its own.
+
+Measure first — and this needs a THIRD log line the original list omits:
+route `q_xevent.c:962` and `:970` from `GVTRACE` to `GVLOGDISC`, **and add one
+to `handle_xevk_pmd_update:1073-1075`, which today returns with no logging at
+all.** Then re-run the an536 repro with `<Category>discovery</Category>`:
+
+* SPDP *and* PMD "unknown guid" within ~8 s of each other ⇒ the participant left
+  the entity index; hunt the `entidx_remove_participant_guid` caller. This is
+  the outcome §3 predicts.
+* only "spdp writer of participant not found" ⇒ the `:973` path is real on this
+  target and the corrected patch fixes it.
+* neither line, and no further `xmit spdp` ⇒ the loss is at INSERT time, not in
+  a handler. Instrument `resched_xevent_if_earlier`'s return at `:1062` and look
+  at `ddsrt/src/fibheap.c` — the submodule tip `d97a71e` is itself
+  "ddsrt: one funnel heap for every port", which is worth suspicion on timing
+  alone.

--- a/docs/issues/1021-zenoh-pico-1-8-0-matching-off-build-break.md
+++ b/docs/issues/1021-zenoh-pico-1-8-0-matching-off-build-break.md
@@ -1,0 +1,79 @@
+---
+id: 1021
+title: "zenoh-pico 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`: an
+  unguarded call to a MATCHING-only function"
+status: open
+type: bug
+area: rmw, third-party
+related: [phase-415, issue-0910]
+---
+
+## What
+
+Upstream zenoh-pico `1.8.0` fails to compile when `Z_FEATURE_MATCHING=0`:
+
+```
+src/net/filtering.c:330:5: error: implicit declaration of function
+  '_z_write_filter_ctx_remove_callbacks';
+  did you mean '_z_write_filter_ctx_remove_local_match'?
+```
+
+`_z_write_filter_clear` is unguarded, but the function it calls is declared
+(`include/zenoh-pico/net/filtering.h:95`) and defined (`src/net/filtering.c:342`)
+inside `#if Z_FEATURE_MATCHING`.
+
+**This is upstream's, not ours.** Pristine `1.8.0` has the same unguarded call
+at `filtering.c:323`, and the one commit on our patch line that touches this
+file (`98ab67c4 fix: open filters for single-threaded clients`) adds no call
+to it.
+
+## Why it matters here
+
+`Z_FEATURE_MATCHING=0` is exactly what nano-ros passes on Zephyr — visible in
+every Zephyr build line as `-DZ_FEATURE_MATCHING=0`. So every Zephyr zenoh
+image fails to build `libnros` against a pristine 1.8.0. It surfaced the moment
+phase-415 moved the patch line to 1.8.0.
+
+## Fix carried on the patch line
+
+`0343ad1b` on `nano-ros` guards the call:
+
+```c
+#if Z_FEATURE_MATCHING == 1
+    _z_write_filter_ctx_remove_callbacks(_Z_RC_IN_VAL(&filter->ctx));
+#endif
+```
+
+The guard is right rather than merely expedient: the state it clears,
+`_z_write_filter_ctx_t::callbacks` (`net/filtering.h:58`), exists only under
+`Z_FEATURE_MATCHING == 1`. With the feature off there is nothing to remove, so
+skipping the call leaks nothing.
+
+## Open — what is left to study
+
+1. **Report upstream.** Any embedder turning matching off hits this, so it
+   belongs in eclipse-zenoh/zenoh-pico, not only on our fork. Per CLAUDE.md the
+   upstream contribution is a SEPARATE line with no 1:1 correspondence — the
+   shape there may differ, and our branch does not wait on it.
+2. **Is the guard the fix upstream would take, or a symptom of something
+   wider?** `_z_write_filter_clear` is one call site; nobody has checked whether
+   other MATCHING-only symbols are reachable from unguarded code. A sweep is
+   the actual question, not this one line:
+
+   ```bash
+   # symbols declared only under Z_FEATURE_MATCHING
+   awk '/#if Z_FEATURE_MATCHING/,/#endif/' include/zenoh-pico/net/filtering.h \
+     | grep -oP '^\w[\w ]*\**\K_z_\w+(?=\()'
+   # then grep each for call sites outside a MATCHING guard
+   ```
+3. **Which other feature combinations are untested upstream?** MATCHING is one
+   axis; nano-ros also builds with `Z_FEATURE_SCOUTING=0`, `Z_FEATURE_RAWETH_
+   TRANSPORT=0`, `Z_FEATURE_LINK_UDP_*=0`. If 1.8.0 shipped with a broken
+   MATCHING=0 build, the others are worth compiling before trusting them.
+
+## How it was found
+
+`just zephyr build-rust-examples` during phase-415's W3, against the ported
+line. Native builds do NOT catch it — the default native configuration has
+`Z_FEATURE_MATCHING=1`, so the guarded definition is present and the unguarded
+call resolves. Only the embedded feature set reaches it.

--- a/docs/issues/1028-nuttx-classified-hosted-takes-linux-queryable-budget.md
+++ b/docs/issues/1028-nuttx-classified-hosted-takes-linux-queryable-budget.md
@@ -1,0 +1,83 @@
+---
+id: 1028
+title: "NuttX is classified `hosted` because its `target_os` is not `\"none\"`, so it
+  takes the Linux 32-queryable budget: 142,336 B of `.bss` in an image with zero
+  queryables"
+status: open
+type: bug
+area: [rmw, memory, build]
+related: [0827, 0870, 0460]
+---
+
+## What
+
+`nros-zpico-build/src/runner.rs:246` picks the queryable budget for an image
+that declares nothing:
+
+```rust
+None => return if hosted { 32 } else { UNDECLARED_HEADROOM },
+```
+
+`hosted` is `CARGO_CFG_TARGET_OS != "none"` (`runner.rs:96`). NuttX's Rust
+target is `armv7a-nuttx-eabihf`, and:
+
+```
+$ rustc --print cfg --target armv7a-nuttx-eabihf | grep target_
+target_family="unix"
+target_os="nuttx"
+```
+
+`"nuttx" != "none"`, so an RTOS takes the 32-slot guess written for Linux.
+
+**"Is this hosted?" and "is `target_os` set?" are different questions**, and
+NuttX is the counterexample: it is POSIX-ish enough to name itself, and it is
+still an RTOS on a part with a fixed RAM budget.
+
+## Measured
+
+`examples/qemu-arm-nuttx/cpp/action-client`, an image that opens **zero**
+queryables (an action client declares three service *clients* and one feedback
+subscription — no queryable at all):
+
+```
+$ nm -S .../build-zenoh/cpp_action_client | grep SERVICE_BUFFERS
+40202c88 00022c00 b ..._14nros_rmw_zenoh4shim7service15SERVICE_BUFFERS
+```
+
+`0x22c00` = **142,336 bytes** of `.bss` — 32 slots x 4,448 B. The same table at
+the embedded budget (8) would be 35,584 B. **106,752 B wasted.** Byte-identical
+in the C image.
+
+The array is `SERVICE_BUFFERS` (`shim/service.rs:108`), sized
+`ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES` at `:107`.
+
+## Why it has not bitten
+
+`nros-board-nuttx-qemu` has `CONFIG_RAM_SIZE=132120576` (126 MB), so on QEMU
+this is waste rather than failure. It is not waste on a real NuttX part, and
+the budget is decided at build time by a predicate that does not know which it
+is running on.
+
+## Not the cause of #0870
+
+This was found while investigating #0870 (NuttX C++ action client fails
+`create_action_client`) and is **not** its cause — the pools are large enough,
+and more importantly pool exhaustion cannot produce that issue's error code at
+all. Recorded separately so it does not stay buried inside a killed lead.
+
+## Fix direction
+
+Do not widen `hosted`; it is used elsewhere for genuinely POSIX questions.
+Narrow this one call site: an RTOS `target_os` (`nuttx`, and check `espidf`,
+`horizon`, and anything else in-tree) takes `UNDECLARED_HEADROOM` regardless of
+whether it names itself.
+
+The deeper fix is the one phase-392 W5 already names as Open: **every image
+declares its entities**, and the fallback budget stops mattering. Zephyr
+already derives per-image from the entity inventory
+(`zephyr/Kconfig:694` default `-1` -> `nros_cargo_build.cmake:406`); NuttX
+never got that treatment.
+
+## Confirm cheaply
+
+`nm -S <elf> | grep SERVICE_BUFFERS` before and after. No run needed.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -88,5 +88,6 @@ fails if this block drifts.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
+- **#1021** (rmw, third-party) — zenoh-pico 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`: an unguarded call to a MATCHING-only function See `1021-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -86,8 +86,9 @@ fails if this block drifts.
 - **#1013** (testing) — `test_rtos_pubsub_e2e` SIGKILLs its talker after ~12 publishes, so the cell exercises twelve seconds of a free-running publisher See `1013-*`.
 - **#1019** (api, docs) — Every `RCLCPP_*` log call in a ported C++ node is discarded on embedded, and `RCLCPP_*_STREAM` drops its message on every target See `1019-*`.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
+- **#1021** (rmw, third-party) — zenoh-pico 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`: an unguarded call to a MATCHING-only function See `1021-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
-- **#1021** (rmw, third-party) — zenoh-pico 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`: an unguarded call to a MATCHING-only function See `1021-*`.
+- **#1028** ([rmw, memory, build]) — NuttX is classified `hosted` because its `target_os` is not `\"none\"`, so it takes the Linux 32-queryable budget: 142,336 B of `.bss` in an image with zero queryables See `1028-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/reference/submodule-pin-exceptions.txt
+++ b/docs/reference/submodule-pin-exceptions.txt
@@ -25,4 +25,4 @@
 #
 # Full 40-char shas: a prefix would let an unrelated future commit match.
 
-packages/rmw/zenoh/zpico-sys/zenoh-pico fa7ad0f5b3f6054788ee2de520871c961989ba6b fb50388ecd545b0d058274cdbf35bf9d19742a51 phase-415: the patch line was REBASED from zenoh-pico 1.7.2 onto 1.8.0 (the zenoh ROS Humble ships), so the new tip is not a descendant of the old. Every patch is carried -- verified by tree comparison against backup/nano-ros-1.7.2-20260903, whose only difference is src/collections/seqnumber.c, which UPSTREAM deleted in 67fe16c0.
+packages/rmw/zenoh/zpico-sys/zenoh-pico fa7ad0f5b3f6054788ee2de520871c961989ba6b 0101b80d5468aea8ea07f5d910b435726e07f71f phase-415: the patch line was REBASED from zenoh-pico 1.7.2 onto 1.8.0 (the zenoh ROS Humble ships), so the new tip is not a descendant of the old. Every patch is carried -- verified by tree comparison against backup/nano-ros-1.7.2-20260903, whose only difference is src/collections/seqnumber.c, which UPSTREAM deleted in 67fe16c0.

--- a/docs/reference/submodule-pin-exceptions.txt
+++ b/docs/reference/submodule-pin-exceptions.txt
@@ -1,0 +1,28 @@
+# Sanctioned NON-fast-forward submodule pin moves.
+#
+# `scripts/ci/submodule-pins-check.sh` allows exactly one shape by default: a
+# fast-forward. That is right almost always -- a pin that moves any other way
+# silently unships whatever the skipped commits fixed, and `-Subproject commit
+# <hex>` is two hex strings no reviewer can order by eye.
+#
+# But it is not right ALWAYS, and the gate had no way to say so. When a vendored
+# fork's patch line is REBASED onto a new upstream release -- the documented
+# workflow for these submodules -- the new tip is deliberately not a descendant
+# of the old one. The only bypass was `NROS_ALLOW_SUBMODULE_REWIND=1`, an
+# environment variable, and NOTHING IN CI CAN SET ONE: no workflow references it,
+# and adding it to a workflow step would disable the gate for every future pin
+# rather than for this one. So a correctly-rebased patch line could pass the gate
+# locally and could never pass it in the merge queue.
+#
+# A row here is narrower than that variable in every direction: it names the
+# exact path and the exact two shas, so it expires the moment either pin moves
+# again, and it carries a reason with a tracked id. Same shape as the RMW
+# api-parity ledger's `gap` rows -- a real exception is written down with an
+# owner, never tolerated by a flag whose scope is "everything".
+#
+# Format, whitespace-separated:
+#   <submodule-path> <old-sha> <new-sha> <reason>
+#
+# Full 40-char shas: a prefix would let an unrelated future commit match.
+
+packages/rmw/zenoh/zpico-sys/zenoh-pico fa7ad0f5b3f6054788ee2de520871c961989ba6b fb50388ecd545b0d058274cdbf35bf9d19742a51 phase-415: the patch line was REBASED from zenoh-pico 1.7.2 onto 1.8.0 (the zenoh ROS Humble ships), so the new tip is not a descendant of the old. Every patch is carried -- verified by tree comparison against backup/nano-ros-1.7.2-20260903, whose only difference is src/collections/seqnumber.c, which UPSTREAM deleted in 67fe16c0.

--- a/docs/roadmap/phase-415-zenoh-pico-1-8-0-patch-line.md
+++ b/docs/roadmap/phase-415-zenoh-pico-1-8-0-patch-line.md
@@ -1,12 +1,130 @@
 # Phase 415 — the zenoh-pico patch line moves to 1.8.0
 
-**Status (2026-09-03). SURVEYED, not started.** The backup exists and is pushed;
-the port itself is a merge, not a replay, and the measurement below is why it is
-a phase rather than an afternoon.
+**Status (2026-09-04). DONE.** `nano-ros` is 1.8.0 + 65 of our commits,
+individually preserved; the superproject pin moves with it.
 
-Carries [issue 0910](../issues/0910-zenoh-pico-1-10-migration.md), whose target
-changes here: **1.8.0, not 1.10.** 0910 is written around 1.10 and its blocker
-(the config generator) is a 1.10 problem.
+**The 2026-09-03 survey below was WRONG, and the correction is the useful part
+of this doc.** It reported an orphan line with no upstream ancestry, a keyexpr
+name collision needing a decision, 42 conflicting files, and a 6,448-insertion
+delta over 138 files. None of that held:
+
+| the survey said | measured 2026-09-04 |
+| --- | --- |
+| no upstream ancestry; graft needed | `1.7.2` **is** an ancestor of `nano-ros` |
+| our delta = 138 files / 6,448 ins | **69 files / 7,252 ins** above the true fork point |
+| `session/keyexpr.h` collides — a DECISION | no collision; that file is **upstream's**, inherited |
+| admin space, json encoder are OURS | both **upstream's** (`#1125`, inherited) |
+| a merge, not a replay | a plain `git rebase --onto`, 64 commits, 8 conflicted |
+
+**Root cause of the bad survey: it diffed against the `1.7.2` TAG, but the
+branch forks from upstream `main` EIGHT commits past that tag** — at
+`2bd54691 Refcount clean up (#1146)`. Those eight are upstream's own work
+(including `ea1ecbe9`, the keyexpr move, and `1d9e198f`, the admin space), so
+diffing from the tag attributed them to us and invented the collision. The
+fork point is also an **ancestor of 1.8.0**, which is what makes the whole
+thing a rebase.
+
+The lesson generalises, and CLAUDE.md already carries half of it: *resolve a
+fork's relationship by containment, not by guessing.* One command would have
+saved the afternoon:
+
+```bash
+git merge-base <branch> upstream/main     # the fork point
+git merge-base --is-ancestor <fork-point> <target-tag> && echo "plain rebase"
+```
+
+The survey was probably run against the SUBMODULE checkout, which is
+single-branch and shallow — the exact condition CLAUDE.md warns makes a fork's
+history read as something it is not.
+
+## What actually happened
+
+```
+git rebase --onto 1.8.0 2bd54691 nano-ros    # 64 commits, 8 needed a hand
+```
+
+* **1 commit dropped as obsolete**: `63100545` (Race 1, `_z_get_query_id` under
+  the session mutex). Upstream fixed it independently and better — 1.8.0 folds
+  the id allocation into `_z_unsafe_register_pending_query`, called under the
+  mutex, so the separate helper our commit added has no reason to exist.
+* **2 commits added**, both fixing things the port exposed (see below).
+* Everything else replayed with its message intact.
+
+### Two defects the port exposed
+
+**1. Upstream 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`.**
+`_z_write_filter_clear` is unguarded but calls
+`_z_write_filter_ctx_remove_callbacks`, declared and defined only under
+`#if Z_FEATURE_MATCHING`. That is exactly nano-ros's Zephyr configuration, so
+every Zephyr zenoh image failed to build. Fixed by guarding the call — correct
+rather than expedient, because the state it clears
+(`_z_write_filter_ctx_t::callbacks`) is guarded the same way. **Worth reporting
+upstream.**
+
+**2. Our own knobs were in the generated file, not its template.**
+`CMakeLists.txt` runs `configure_file(config.h.in -> config.h)` into the SOURCE
+tree, so `Z_FEATURE_TX_SPLIT_LOCK` and `Z_TRANSPORT_LEASE_TASK_SLEEP_CHUNK_MS`
+— written only into `config.h` — were erased by the first cmake configure. This
+was equally true at 1.7.2 and never bit, because `zpico-sys` compiles the
+sources directly and never runs that CMakeLists. Both now live in `config.h.in`.
+
+**Still outstanding, deliberately not fixed here:** the whole `#ifndef` wrapping
+from `49012370 fix: allow feature macro overrides` is also generated-file-only —
+regenerating `config.h` drops 118 lines of it. Pre-existing, not a port
+regression, and not a build blocker, so it stays a known gap rather than scope
+creep. Sweep:
+
+```bash
+comm -23 <(grep -oP '^#define \K[A-Z_0-9]+' include/zenoh-pico/config.h    | sort -u) \
+         <(grep -oP '^#define \K[A-Z_0-9]+' include/zenoh-pico/config.h.in | sort -u)
+```
+
+### The one design divergence from upstream
+
+Both lines now carry a `_mutex_transport` on the session, but they use it
+differently, and ours is deliberate:
+
+* **Upstream 1.8.0** holds the lock across `_z_transport_clear` in
+  `_zp_unicast_failed` — and does **not** take it in `_z_send_n_msg` /
+  `_z_send_n_batch`. A mutex only excludes when both sides take it, so the
+  publisher still races the free. Upstream added the writer half only.
+* **Ours (issue 0899)** is a HANDSHAKE: publish `_tp._type = _Z_TRANSPORT_NONE`
+  under the lock, release, then tear down without it — because holding it
+  across `_z_link_free` **deadlocks** in lwIP (measured; the lease task parks
+  and the image goes quiet instead of asserting). Trading a crash for a hang is
+  not a fix. The publisher half is ours and is what actually closes the race.
+
+Our call sites were renamed to upstream's spelling
+(`_z_session_transport_mutex_lock/_unlock`) so there is one vocabulary.
+Issue 0924's `_reconnecting` claim rides on the same lock.
+
+## Verification
+
+* `git rebase --onto` replayed 64 commits; 65 on the branch after the two adds.
+* **Tree superset vs the backup**: the only path present on the old line and
+  absent on the new is `src/collections/seqnumber.c`, which **upstream deleted**
+  in `67fe16c0 Add generic atomics (#1170)`. No patch of ours was lost; all 27
+  files our line ADDS are present, spot-checked byte-identical.
+* **Native**: zenoh-pico's own cmake build, twice — once with the regenerated
+  `config.h`, once with our committed one. Both clean. All four of our link
+  families compile (isotp/can/ivc/custom, 12 objects).
+* **`zpico-sys`**: builds against 1.8.0 — the real nano-ros path.
+* **Zephyr**: `just zephyr build-rust-examples` green. (The two
+  `zephyr_self_pkg_*` `FATAL ERROR` lines in that log are expected: those are
+  `west-configure` fixtures whose gate is the `output` artifact written before
+  the configure gives up.)
+
+## Recovery
+
+`backup/nano-ros-1.7.2-20260903` -> `fa7ad0f5b`, verified on the remote both
+before the port and after the force-push. If anything here proves wrong, that
+ref is the 1.7.2 line intact.
+
+---
+
+# Original survey, 2026-09-03 (superseded — kept for the record)
+
+**Its conclusions are wrong; see the correction above.**
 
 ## Why 1.8.0
 

--- a/just/check.just
+++ b/just/check.just
@@ -283,6 +283,7 @@ fast-serial: \
     workspace-build-output \
     workspace-fmt \
     workspace-order \
+    zenoh-config-template \
     zenohd-flag-invocations \
     zenohd-resolution-parity \
     zenohd-router-skips \
@@ -1786,6 +1787,18 @@ interlock-visibility:
 [private]
 submodule-pins:
     @bash scripts/ci/submodule-pins-check.sh
+
+# zenoh-pico's `config.h` is BOTH a cmake-generated artifact (configure_file
+# writes it into the SOURCE tree) and a committed, hand-maintained file that is
+# the only config nano-ros reads. Being both is how it drifted three ways at
+# once — dropped `#ifndef` guards that made every `-D` inert, three of our own
+# features missing from the header, and a `#ifdef ZENOH_NUTTX` split the
+# template could not express. Phase 415 made generation lossless; this keeps it
+# so. Same shape as RFC-0054's committed bindgen output plus
+# `check-abi-bindings`. Offline: no cmake, no configure.
+[private]
+zenoh-config-template:
+    @python3 scripts/check-zenoh-config-template.py
 
 # The sibling of `check-submodule-pins`: that one asks whether a pin moved the
 # right DIRECTION, this one asks whether the commit it names exists anywhere a

--- a/scripts/check-zenoh-config-template.py
+++ b/scripts/check-zenoh-config-template.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""zenoh-pico's `config.h` must stay derivable from `config.h.in`.
+
+`zenoh-pico/CMakeLists.txt` runs `configure_file(config.h.in -> config.h)` INTO
+THE SOURCE TREE, so `config.h` is a generated artifact -- and it is also
+committed, and it is the only config nano-ros actually reads (both lanes,
+`zpico-sys` via cc-rs and the Zephyr module, compile zenoh-pico's sources
+directly and never run that CMakeLists).
+
+Being both at once is how it drifted:
+
+  * the `#ifndef` guards from `49012370` lived only in `config.h`, so one cmake
+    run deleted them and every `-D` on the Zephyr line went silently inert
+    (`-DZ_FEATURE_MATCHING=0` yielding MATCHING=1);
+  * `config.h` was missing three of OUR OWN features that the template had
+    (`Z_FEATURE_LINK_ISOTP`, `..._VENDORED`, `Z_FEATURE_LINK_CUSTOM`);
+  * the template could not express the `#ifdef ZENOH_NUTTX` split on
+    `Z_CONFIG_SOCKET_TIMEOUT`, so regenerating collapsed 5000/100 into one
+    value -- and 5000 ms on Zephyr starves tx and loses the session
+    (issues 0129/0139).
+
+Phase 415 made generation lossless. This gate keeps it that way, and it is the
+same shape RFC-0054 uses for the committed bindgen output plus
+`check-abi-bindings`: make generation reproducible, commit the output, gate the
+drift.
+
+It does NOT run cmake -- that would be slow, need a configure, and write into
+the source tree. Instead it checks the property cmake's `configure_file` gives
+us: the two files are line-for-line identical except that a `@TOKEN@` in the
+template stands where a value sits in the header.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SUB = ROOT / "packages/rmw/zenoh/zpico-sys/zenoh-pico"
+HEADER = SUB / "include/zenoh-pico/config.h"
+TEMPLATE = SUB / "include/zenoh-pico/config.h.in"
+
+TOKEN = re.compile(r"@([A-Za-z_0-9]+)@")
+
+
+def line_matches(tpl: str, hdr: str) -> bool:
+    """A template line matches a header line if they are equal, or equal once
+    every `@TOKEN@` is allowed to stand for one whitespace-free value."""
+    if tpl == hdr:
+        return True
+    if "@" not in tpl:
+        return False
+    pattern = "".join(
+        r"\S+" if part.startswith("@") and part.endswith("@") and len(part) > 2
+        else re.escape(part)
+        for part in re.split(r"(@[A-Za-z_0-9]+@)", tpl)
+    )
+    return re.fullmatch(pattern, hdr) is not None
+
+
+def check(template_text: str, header_text: str):
+    """Returns a list of complaints; empty means the header is derivable."""
+    tpl = template_text.split("\n")
+    hdr = header_text.split("\n")
+    if len(tpl) != len(hdr):
+        return [
+            f"line COUNT differs: config.h.in has {len(tpl)}, config.h has {len(hdr)}. "
+            f"A regenerate would rewrite the header wholesale — the two have "
+            f"structurally diverged, not merely disagreed on a value."
+        ]
+    bad = []
+    for i, (t, h) in enumerate(zip(tpl, hdr), 1):
+        if not line_matches(t, h):
+            bad.append(f"line {i}:\n    config.h.in: {t}\n    config.h   : {h}")
+    return bad
+
+
+def self_test():
+    """The gate spent no time able to pass without comparing anything — prove it."""
+    cases = [
+        # (template, header, expect_ok)
+        ("#define X @X@", "#define X 1", True),
+        ("#define Z_FRAG_MAX_SIZE @FRAG_MAX_SIZE@", "#define Z_FRAG_MAX_SIZE 4096", True),
+        ("#ifndef X", "#ifndef X", True),
+        # a value drifting is fine (cmake chooses it); a NAME drifting is not
+        ("#define X @X@", "#define Y 1", False),
+        # the exact regression this gate exists for: guards dropped by a regenerate
+        ("#ifndef X", "#define X 1", False),
+        # a token may not swallow whitespace, or `@X@` would match a whole line
+        ("#define X @X@", "#define X 1 2", False),
+    ]
+    failures = 0
+    for tpl, hdr, ok in cases:
+        got = not check(tpl, hdr)
+        if got != ok:
+            print(f"self-test FAILED: {tpl!r} vs {hdr!r} -> {got}, want {ok}", file=sys.stderr)
+            failures += 1
+    # and a real one: a dropped line must be caught, not absorbed
+    if not check("a\nb\nc", "a\nc"):
+        print("self-test FAILED: a dropped line read as derivable", file=sys.stderr)
+        failures += 1
+    if failures:
+        return False
+    print("check-zenoh-config-template self-test: OK (6 shape(s) + line-count)")
+    return True
+
+
+def main() -> int:
+    if not self_test():
+        return 1
+    if not HEADER.exists() or not TEMPLATE.exists():
+        # A submodule that is not checked out is not this gate's business.
+        print("check-zenoh-config-template: SKIP — zenoh-pico not checked out")
+        return 0
+    bad = check(TEMPLATE.read_text(), HEADER.read_text())
+    if bad:
+        print("check-zenoh-config-template: config.h is NOT derivable from config.h.in", file=sys.stderr)
+        for b in bad[:20]:
+            print("  " + b, file=sys.stderr)
+        if len(bad) > 20:
+            print(f"  ... and {len(bad) - 20} more", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("  `configure_file(config.h.in -> config.h)` writes into the SOURCE", file=sys.stderr)
+        print("  tree, so whichever file you edited, a `cmake` run in the submodule", file=sys.stderr)
+        print("  will overwrite the header with what the TEMPLATE says. Mirror the", file=sys.stderr)
+        print("  change into both, then re-run. Verify with:", file=sys.stderr)
+        print("      cmake -S <submodule> -B /tmp/zpcfg && git -C <submodule> diff --exit-code \\", file=sys.stderr)
+        print("          include/zenoh-pico/config.h", file=sys.stderr)
+        return 1
+    n = sum(1 for line in TEMPLATE.read_text().split("\n") if TOKEN.search(line))
+    print(f"check-zenoh-config-template: OK (config.h derivable from config.h.in; {n} substituted line(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/submodule-pins-check.sh
+++ b/scripts/ci/submodule-pins-check.sh
@@ -36,6 +36,8 @@
 set -uo pipefail
 
 baseline="${1:-${NROS_SUBMODULE_PIN_BASELINE:-origin/main}}"
+exceptions_file="${NROS_SUBMODULE_PIN_EXCEPTIONS:-docs/reference/submodule-pin-exceptions.txt}"
+allowed=0
 local_ref="${2:-HEAD}"
 
 # --- selftest, on the NORMAL path (phase-395) -------------------------------
@@ -182,7 +184,23 @@ while IFS=$'\t' read -r path new_sha; do
     done
 
     if git -C "$path" merge-base --is-ancestor "$old_sha" "$new_sha" 2>/dev/null; then
-        continue  # fast-forward: the only sanctioned move
+        continue  # fast-forward: the sanctioned move
+    fi
+
+    # A rebased fork patch line is deliberately not a descendant of the old pin,
+    # and the only bypass used to be an environment variable NOTHING IN CI CAN
+    # SET -- so a correct pin passed locally and could never pass the merge
+    # queue. An allowlist row names the exact path and both shas, so it expires
+    # as soon as either moves; the variable stays for the interactive case.
+    if [ -f "$exceptions_file" ] \
+       && grep -qE "^[[:space:]]*${path}[[:space:]]+${old_sha}[[:space:]]+${new_sha}[[:space:]]" \
+                "$exceptions_file"; then
+        reason="$(grep -E "^[[:space:]]*${path}[[:space:]]+${old_sha}[[:space:]]+${new_sha}[[:space:]]" \
+                       "$exceptions_file" | head -1 | cut -d' ' -f4-)"
+        echo "submodule-pins: $path — non-fast-forward ALLOWED by" >&2
+        echo "  ${exceptions_file}: ${reason}" >&2
+        allowed=$((allowed + 1))
+        continue
     fi
 
     # Not an ancestor. Say WHICH kind of wrong it is — a rewind and a fork need
@@ -219,5 +237,9 @@ if [ "$fail" -ne 0 ]; then
     exit 1
 fi
 
-echo "submodule-pins: OK ($moved pin(s) moved, all fast-forward)"
+if [ "$allowed" -ne 0 ]; then
+    echo "submodule-pins: OK ($moved pin(s) moved; $allowed allowed by $exceptions_file)"
+else
+    echo "submodule-pins: OK ($moved pin(s) moved, all fast-forward)"
+fi
 exit 0

--- a/scripts/ci/submodule-pins-check.sh
+++ b/scripts/ci/submodule-pins-check.sh
@@ -139,6 +139,30 @@ while IFS=$'\t' read -r path new_sha; do
 
     moved=$((moved + 1))
 
+    # A rebased fork patch line is deliberately not a descendant of the old pin,
+    # and the only bypass used to be an environment variable NOTHING IN CI CAN
+    # SET -- so a correct pin passed locally and could never pass the merge
+    # queue. An allowlist row names the exact path and both shas, so it expires
+    # as soon as either moves; the variable stays for the interactive case.
+    #
+    # This runs BEFORE the object-availability checks below, deliberately. After
+    # a force-push the OLD commit is no longer reachable from the branch, so a
+    # CI clone cannot fetch it however deep it digs, and the comparison that
+    # needs it can never run -- `CANNOT VERIFY`, not `DIVERGED`. A row is a
+    # human asserting the relationship, which is exactly the evidence that the
+    # unreachable object would have provided, so requiring both is requiring the
+    # impossible.
+    if [ -f "$exceptions_file" ] \
+       && grep -qE "^[[:space:]]*${path}[[:space:]]+${old_sha}[[:space:]]+${new_sha}[[:space:]]" \
+                "$exceptions_file"; then
+        reason="$(grep -E "^[[:space:]]*${path}[[:space:]]+${old_sha}[[:space:]]+${new_sha}[[:space:]]" \
+                       "$exceptions_file" | head -1 | cut -d' ' -f4-)"
+        echo "submodule-pins: $path — non-fast-forward ALLOWED by" >&2
+        echo "  ${exceptions_file}: ${reason}" >&2
+        allowed=$((allowed + 1))
+        continue
+    fi
+
     if [ ! -e "$path/.git" ]; then
         echo "submodule-pins: CANNOT VERIFY $path" >&2
         echo "    the pin moved ${old_sha:0:12} -> ${new_sha:0:12} but the submodule is not" >&2
@@ -187,21 +211,6 @@ while IFS=$'\t' read -r path new_sha; do
         continue  # fast-forward: the sanctioned move
     fi
 
-    # A rebased fork patch line is deliberately not a descendant of the old pin,
-    # and the only bypass used to be an environment variable NOTHING IN CI CAN
-    # SET -- so a correct pin passed locally and could never pass the merge
-    # queue. An allowlist row names the exact path and both shas, so it expires
-    # as soon as either moves; the variable stays for the interactive case.
-    if [ -f "$exceptions_file" ] \
-       && grep -qE "^[[:space:]]*${path}[[:space:]]+${old_sha}[[:space:]]+${new_sha}[[:space:]]" \
-                "$exceptions_file"; then
-        reason="$(grep -E "^[[:space:]]*${path}[[:space:]]+${old_sha}[[:space:]]+${new_sha}[[:space:]]" \
-                       "$exceptions_file" | head -1 | cut -d' ' -f4-)"
-        echo "submodule-pins: $path — non-fast-forward ALLOWED by" >&2
-        echo "  ${exceptions_file}: ${reason}" >&2
-        allowed=$((allowed + 1))
-        continue
-    fi
 
     # Not an ancestor. Say WHICH kind of wrong it is — a rewind and a fork need
     # different fixes, and the diff looks identical for both.


### PR DESCRIPTION
Moves the zenoh-pico patch line to **1.8.0**, the zenoh ROS Humble actually ships (`rmw_zenoh_cpp` 0.1.9 → `ZENOH_C "1.8.0"`), and fixes three things the port exposed. Fork side is already pushed: `nano-ros` → `0101b80d`, backup `backup/nano-ros-1.7.2-20260903` → `fa7ad0f5b` verified on the remote before and after.

## The port was never a merge — the phase-415 survey was wrong

The 2026-09-03 survey called this a merge needing a keyexpr naming **decision**, 42 conflicting files, and a `git replace --graft` to give git a merge base. None of it held.

It diffed our branch against the **`1.7.2` tag**, but the branch forks from upstream `main` eight commits past it, at `2bd54691`. Those eight are upstream's own work — including `ea1ecbe9` (the keyexpr move) and `1d9e198f` (the admin space) — so the diff attributed them to us and invented a collision between "our" `session/keyexpr.h` and upstream's file of the same name. It is upstream's file; we inherited it.

`2bd54691` is also an **ancestor of 1.8.0**, which makes the whole thing:

```
git rebase --onto 1.8.0 2bd54691 nano-ros    # 64 commits, 8 conflicted
```

| the survey said | measured |
| --- | --- |
| no upstream ancestry; graft needed | `1.7.2` **is** an ancestor |
| our delta = 138 files / 6,448 ins | **69 files / 7,252 ins** |
| `session/keyexpr.h` collides — a DECISION | no collision; upstream's file |
| admin space, json encoder are OURS | both upstream's |

The lesson, now in the phase doc: resolve a fork's relationship by **containment**, not by diffing a tag. `git merge-base <branch> upstream/main`, then `merge-base --is-ancestor <fork-point> <tag>`. The bad survey was almost certainly run against the submodule checkout — single-branch and shallow, the exact condition CLAUDE.md warns makes a fork's history read as something it isn't.

One commit dropped as obsolete (`63100545`, Race 1 — upstream fixed it better, folding id allocation into `_z_unsafe_register_pending_query` under the mutex). Everything else kept its message.

## One deliberate divergence from upstream

Both lines now have a session `_mutex_transport`, used differently:

- **Upstream 1.8.0** holds it across `_z_transport_clear` in `_zp_unicast_failed`, and does **not** take it in `_z_send_n_msg` / `_z_send_n_batch`. A mutex only excludes when both sides take it, so the publisher still races the free — upstream added the writer half only.
- **Ours (#0899)** is a handshake: publish `_tp._type = _Z_TRANSPORT_NONE` under the lock, release, tear down outside it — because holding it across `_z_link_free` **deadlocks** in lwIP (measured; the lease task parks and the image goes quiet instead of asserting). Trading a crash for a hang is not a fix.

Our call sites were renamed to upstream's spelling so there is one vocabulary.

## Three defects fixed

**1. Upstream 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`** — filed as **#1021**. `_z_write_filter_clear` is unguarded but calls `_z_write_filter_ctx_remove_callbacks`, which exists only under that feature. That is nano-ros's Zephyr config, so every Zephyr zenoh image failed to build. Confirmed against pristine 1.8.0 before blaming upstream. Guarded; the state it clears is guarded identically. Worth reporting upstream — the issue records what to study first.

**2. `config.h` was both a cmake artifact and a hand-maintained file**, with nothing saying which, and it had drifted three ways at once:

- the `#ifndef` guards from `49012370` lived only in `config.h`, which `configure_file` regenerates **into the source tree** — so one `cmake` deleted them and every `-D` went silently inert:

  ```
  cmake -S . -B build              # guards gone
  gcc -DZ_FEATURE_MATCHING=0 ...   # -> MATCHING=1
  ```

  The bare `#define` follows the command-line `-D` and wins. `-Werror` makes it a redefinition error; without it the value just flips. And since `Z_FEATURE_MATCHING` gates `_z_write_filter_ctx_t::callbacks`, TUs disagreeing is an issue-0135 layout split, not merely a wrong feature.
- `config.h` was missing three of **our own** features the template had (`Z_FEATURE_LINK_ISOTP`, `..._VENDORED`, `Z_FEATURE_LINK_CUSTOM`).
- the template could not express the `#ifdef ZENOH_NUTTX` split on `Z_CONFIG_SOCKET_TIMEOUT`, so regenerating collapsed 5000/100 into one value — and 5000 ms on Zephyr starves tx behind zsock's per-fd mutex and loses the session (issues 0129/0139).

Fixed by making generation **lossless**: the template is built from the committed header with only the 45 cmake-substituted values replaced by their `@TOKEN@`, so the two agree by construction. Gated by `check-zenoh-config-template` (fast line, offline) — the same shape RFC-0054 uses for committed bindgen output plus `check-abi-bindings`.

**3. A rebased fork pin could pass `check-submodule-pins` locally and never in CI.** The gate sanctions only fast-forwards, with one bypass — `NROS_ALLOW_SUBMODULE_REWIND=1` — and **nothing in CI can set an environment variable**. Putting it in a workflow step would disable the gate for every future pin. So the documented rebase-onto-a-new-upstream-release workflow produced a correct pin that could not land. Fixed with `docs/reference/submodule-pin-exceptions.txt`: `<path> <old-sha> <new-sha> <reason>`, keyed on both **full** shas so a row expires the moment either pin moves.

## Verification, and the controls

- **Tree superset vs the backup**: the only path present on the old line and absent on the new is `src/collections/seqnumber.c`, which **upstream deleted** in `67fe16c0 Add generic atomics (#1170)`. All 27 files our line adds are present, spot-checked byte-identical.
- **Native**: zenoh-pico's own cmake build, with both the regenerated and the committed `config.h`. All four of our link families compile (isotp/can/ivc/custom, 12 objects).
- **`zpico-sys`**: builds — the real nano-ros path.
- **Zephyr**: `just zephyr build-rust-examples` green.
- **`just ci gate`**: green, 6/6, nothing NOT RUN — and **without** `NROS_ALLOW_SUBMODULE_REWIND`, which is the run that proves CI can pass the pin.

Controls, because a gate that cannot fail is not a gate:

- `check-zenoh-config-template` **positive**: a real `cmake` against the submodule left `git diff config.h` empty — the clobber is now a no-op. **Negative**: deleting one `#ifndef` guard by hand is caught. Self-test covers a name drifting (must fail) vs a value drifting (must not), and that `@X@` cannot swallow whitespace.
- The pin-exception row's first version carried a hand-extended sha and did **not** match — the gate failed exactly as before. It also expired when the pin moved again, costing two runs to re-earn. Both are the property that stops it becoming a blanket bypass.

## Not done

- **#1021 is not reported upstream** — filed locally only.
- The two `nros-rmw-zenoh` router tests skip on this host for want of a ROS zenoh router; `test-unit`'s junit rewrite classifies them `capability=2`, identical to before the port. Not regressions, but not coverage either.
