### PR TITLE
docs(#0968): the tier-2 fixture build fails twice before any test runs — #1023, #1025

### DIFF
--- a/docs/issues/0968-tier2-runtime-failures-unreproduced.md
+++ b/docs/issues/0968-tier2-runtime-failures-unreproduced.md
@@ -83,3 +83,43 @@ next person at a dead end.
    `stat -c '%y'` on the artifact against `git log -1 --format=%ci`, per the
    0859-0862 rule.
 4. File per cause, once reproduced. Not before.
+
+## Step 1 attempted 2026-09-04 — and it found TWO build failures before any test ran
+
+`just build-test-fixtures lane=tier2` on `a1c6d0d22`. Seven of eight modules
+built (zephyr, native, qemu, freertos, nuttx, threadx_linux). The other two are
+new findings, both COMPILE/BUILD failures rather than runtime ones, and both are
+this issue's own thesis arriving one stage earlier than it predicted:
+
+* **[#1023](1023-sertype-hosted-includes-break-freestanding.md)** —
+  `threadx_riscv64` cannot compile `nros_sertype.cpp`: it includes `<memory>`
+  and `<string>` and the target is freestanding. The file is new in issue 0970's
+  commit, and `examples/fixtures.toml:3146` declares the coordinate, so this is
+  a supported cell that has been unbuildable since it landed.
+* **[#1025](1025-esp32-flash-image-consumer-drops-the-row-variant.md)** — ESP32
+  QEMU flash images cannot be packed. The ELF builds fine; the packer looks in
+  `build/cargo-fixtures/qemu-esp32-baremetal/` while the build writes to
+  `qemu-esp32-baremetal-4118800323`, because the packer asks
+  `nros_fixture_row_artifact_dir` for the group dir with the row's env stripped
+  (`"" ""`). Live since `41a7d8de7` on 2026-08-31 — hours before this issue was
+  filed.
+
+**1025 bears directly on this issue's list and does not close any of it.** Five
+of the twelve are esp32 and all five need a flash image that cannot be produced.
+That is a plausible single cause for the whole esp32 cluster; it is NOT
+established as their cause, because what was reproduced is the BUILD failing,
+not those tests failing for that reason. Establishing it means fixing 1025,
+rebuilding, and re-running the five. Written this way on purpose — 0859-0862
+were four issues filed from a sweep in this repo and all four retracted, two
+carrying confident wrong root causes.
+
+**Status of the twelve: still unreproduced.** The seven non-esp32 ones
+(qemu-rtic 1, threadx_linux 3, zephyr xrce-cpp 3) have their modules built and
+are ready to run; the five esp32 ones are blocked on 1025.
+
+**Method note for whoever continues.** Run each candidate SOLO, not in a sweep —
+CLAUDE.md's rule for QEMU reds, and this issue's list came out of a sweep. And
+`cargo nextest` reports a `nros_tests::skip!` panic as a FAILURE while a filter
+matching nothing exits 0, so a re-run needs four verdicts (pass / fail /
+skipped-precondition / not-found), not two. A two-verdict harness would report
+an unmet precondition as a regression and a renamed test as a pass.

--- a/docs/issues/1023-sertype-hosted-includes-break-freestanding.md
+++ b/docs/issues/1023-sertype-hosted-includes-break-freestanding.md
@@ -1,0 +1,102 @@
+---
+id: 1023
+title: "`nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target"
+status: open
+area: rmw, build
+severity: high
+found: 2026-09-04
+related: [0970, 0968, 0942, 0112, phase-393]
+---
+
+# The sertype the CDR-blob path needs is written in hosted C++
+
+## What happened
+
+`just build-test-fixtures lane=tier2`, on a tree at `a1c6d0d22`:
+
+```
+== threadx_riscv64 == FAILED (rc=2)
+FAILED: nros_rmw_cyclonedds.dir/src/nros_sertype.cpp.obj
+/mnt/evo/aeon/nano-ros/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/nros_sertype.cpp:23:10:
+    fatal error: memory: No such file or directory
+```
+
+The other seven modules of that lane built: zephyr, native, qemu, freertos,
+nuttx, threadx_linux — this is one module, and it is a COMPILE failure, not a
+runtime one.
+
+## It is a declared coordinate, not an unsupported one
+
+`examples/fixtures.toml:3146` pairs threadx_riscv64 with cyclonedds for
+`test_threadx_riscv64_cyclonedds_two_qemu_pubsub`. So this is a cell the tree
+says it supports, and it cannot be built.
+
+## Provenance: issue 0970, and the file fixed ONE include of this class already
+
+`nros_sertype.cpp` is new in `b4858f941` ("feat(#0970): the Cyclone backend
+registers its own sertype"). Before it, the Cyclone path used Cyclone's
+generated sertype and this TU did not exist, so the coordinate built.
+
+The file already carries a note about exactly this class, for a different
+include:
+
+```c
+// Issue 0942 — `<cstdio>` is only required to declare these in `std`, and a
+// freestanding libstdc++ does the reverse, so a board toolchain can fail on
+// `std::snprintf` where every hosted target passed. Unqualified, from
+// `<stdio.h>`, as `descriptors.cpp` does.
+#include <stdio.h>
+```
+
+So the class was known HERE, and fixed at the reported site only — which is
+CLAUDE.md's "fix the CLASS, not the reported site" verbatim. The remaining two
+hosted includes are three lines below that comment.
+
+## What is actually used, so the fix is not an include deletion
+
+* `<memory>` — `std::unique_ptr<NrosSerdata>` at three sites
+  (`serdata_from_ser`, and its two siblings), each `new (std::nothrow)` with
+  early returns on failure.
+* `<string>` — `NrosSertype::type_name`, used four ways: `==` between two
+  sertypes (`:335`), a char loop for the hash (`:343`), assignment from
+  `desc->m_typename` (`:391`), and `.c_str()` into `ddsi_sertype_init_flags`
+  (`:392`).
+* `<new>` and `<cstring>` are fine: `<new>` is a freestanding header, and
+  `<cstring>` resolved on this toolchain (the compiler stopped at `<memory>`,
+  which is three lines later).
+
+## The fix, scoped — and the part that needs a decision
+
+`std::unique_ptr` is mechanical: a ten-line local RAII holder, or explicit
+`delete` on each early return. Prefer the holder — the manual version needs
+every return path audited and this is a serdata allocation path.
+
+`std::string` is NOT mechanical, and the reason is lifetime.
+`st->type_name = desc->m_typename` currently COPIES. Replacing it with a
+`const char*` stores a pointer into the caller's descriptor, and whether that
+outlives the sertype is not established here — `create_nros_sertype(desc)`'s
+callers would each have to be checked. The safe shape is `ddsrt_strdup` freed in
+the sertype's free op, which also keeps the "ddsrt heap, not libc heap" rule the
+file already states for its buffers (Phase 177.26.RX.2: on ThreadX and FreeRTOS
+the libc heap is separate from the ddsrt heap, so `new[]` can return null for
+every message on a board where `ddsrt_malloc` works).
+
+**Not attempted here.** A memory-lifetime change in a serdata path is not
+something to land unverified, and the coordinate that would verify it is the one
+that cannot build.
+
+## Why nobody noticed
+
+Issue 0968's thesis, showing up as a BUILD break rather than a test one:
+`post-submit`'s tier-2 job has never run (interlocked on an unset
+`vars.NROS_SELF_HOSTED_READY`), and `host-tests` has been red on issue 0967. So
+no fixture-backed lane has built this coordinate since 0970 landed.
+
+Found while doing 0968's step 1 — "rebuild tier-2 fixtures, nothing here is
+currently reproducible" — which is the first tier-2 fixture build in some time.
+
+## Not blocking 0968's own work
+
+None of 0968's twelve runtime failures are on threadx_riscv64: they are esp32
+(5), threadx_linux (3), zephyr xrce-cpp (3) and one qemu-rtic. Those modules
+built. This issue is a separate finding from the same run.

--- a/docs/issues/1023-sertype-hosted-includes-break-freestanding.md
+++ b/docs/issues/1023-sertype-hosted-includes-break-freestanding.md
@@ -17,7 +17,7 @@ related: [0970, 0968, 0942, 0112, phase-393]
 ```
 == threadx_riscv64 == FAILED (rc=2)
 FAILED: nros_rmw_cyclonedds.dir/src/nros_sertype.cpp.obj
-/mnt/evo/aeon/nano-ros/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/nros_sertype.cpp:23:10:
+packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/nros_sertype.cpp:23:10:
     fatal error: memory: No such file or directory
 ```
 

--- a/docs/issues/1025-esp32-flash-image-consumer-drops-the-row-variant.md
+++ b/docs/issues/1025-esp32-flash-image-consumer-drops-the-row-variant.md
@@ -1,0 +1,131 @@
+---
+id: 1025
+title: "ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using"
+status: open
+area: build, testing
+severity: high
+found: 2026-09-04
+related: [0968, 0535, 0439, phase-340, 0393, 0181]
+---
+
+# The producer writes to a hashed group dir; the consumer asks for the unhashed one
+
+## Reproduced
+
+```
+$ just esp32 build-qemu
+Building ESP32 QEMU fixtures (from examples/fixtures.toml)...
+  → examples/qemu-esp32-baremetal/rust/talker
+  → examples/qemu-esp32-baremetal/rust/listener
+
+Creating flash images...
+ERROR: build/cargo-fixtures/qemu-esp32-baremetal/riscv32imc-unknown-none-elf/
+       nros-relwithdebinfo/esp32_qemu_talker is missing, and nothing narrowed
+       this build.
+```
+
+**The ELF is not missing.** It is one directory over, and the build had just
+written it:
+
+```
+build/cargo-fixtures/qemu-esp32-baremetal-4118800323/riscv32imc-unknown-none-elf/
+    nros-relwithdebinfo/esp32_qemu_talker      <- produced
+build/cargo-fixtures/qemu-esp32-baremetal/…/esp32_qemu_talker  <- sought
+```
+
+So no ESP32 QEMU flash image can be produced, and every test that consumes one
+fails for a reason that has nothing to do with the code under test.
+
+## The mechanism
+
+`nros_fixture_group_slug` keys the shared cargo target dir on the row's VARIANT
+— its cargo args plus its env. A row with no variant gets the bare platform
+name; a row with one gets `<platform>-<cksum>`.
+
+`just esp32 build-qemu` packs the ELF, and asks where it landed:
+
+```sh
+artifact_dir="$(nros_fixture_row_artifact_dir \
+    "examples/qemu-esp32-baremetal/rust/$ex" qemu-esp32-baremetal "" "")"
+```
+
+The last two arguments are the cargo args and the env — passed EMPTY. The
+producer passes the row's real ones. Same function, two different keys.
+
+## What made it live: a fix-the-class commit, one class down
+
+`41a7d8de7` (2026-08-31 02:31 UTC), *"fix(esp32): the DRAM fix landed on one row;
+its three siblings kept overflowing"*, added to the three esp32 rows:
+
+```toml
+env = { ZPICO_MAX_QUERYABLES = "2" }
+```
+
+That is a correct fix for a real DRAM overflow, and its commit message is about
+applying a fix to a whole class rather than one reported site. But env IS the
+variant signature, so adding it moved the producer from `qemu-esp32-baremetal`
+to `qemu-esp32-baremetal-4118800323` — and the consumer, which names no env,
+stayed where it was. Before that commit both sides agreed on the bare name and
+the packer worked.
+
+## It is a RECURRENCE, and the helper that exists to prevent it names this site
+
+`nros_fixture_row_artifact_dir`'s own docstring is about this exact failure at
+this exact call site:
+
+> phase-340 item 7 — this exists because `just esp32 build-qemu` hand-wrote
+> `examples/qemu-esp32-baremetal/rust/$ex/target/...` to find the ELF it packs
+> into a flash image. Migrating the platform redirected the BUILD and left that
+> path pointing at nothing […] Every gate passed while that happened, which is
+> #393's failure mode […] A post-processing step that spells the artifact path
+> by hand is a second derivation of the group key; this makes it one.
+
+The call site was duly converted to the helper. Passing `"" ""` re-creates the
+second derivation anyway — the key is a function of (platform, args, env), and
+supplying two of the three constants a different answer. The helper made the
+FORMULA single; the INPUTS are still derived twice, and that is where it
+diverged.
+
+## Why nothing caught it
+
+Same reason as [issue 0968](0968-tier2-runtime-failures-unreproduced.md), whose
+step 1 is what surfaced this: tier-2 fixture builds do not run in CI
+(`post-submit`'s job is interlocked on an unset `vars.NROS_SELF_HOSTED_READY`,
+and `host-tests` has been red on 0967). This is a BUILD failure that a build
+lane would have caught on the day.
+
+The `skip` arm cannot mask it and correctly did not: issue 0439 already made the
+"absent ELF" case loud unless `NROS_FIXTURE_COORDS` narrowed the build, which is
+why this reports rather than exits 0.
+
+## The fix, scoped
+
+Do NOT hardcode `ZPICO_MAX_QUERYABLES=2` at the call site — that is a THIRD
+derivation of the row's variant and would break again the next time a row's env
+moves.
+
+The consumer should ask the MANIFEST for the row it is packing, by row id
+(`qemu-esp32-baremetal-talker` / `-listener`, which the build loop directly
+above already names). `scripts/build/fixtures-manifest.py` already owns "THE
+single computation of a row's artifact root" in `row_artifact_root`, but it
+returns the leaf-relative `<dir>/<target_dir or "target">` rather than the
+shared group dir, so it needs to learn the group case before it can answer this.
+That is the change, and it belongs with a test that builds the image.
+
+**Acceptance is a BUILD, never a gate** — the helper's own docstring says so
+about this same site, and a gate is what passed last time.
+
+## Bearing on issue 0968
+
+0968 lists twelve unreproduced tier-2 runtime failures; FIVE are esp32
+(`test_esp32_talker_listener_e2e`, `test_esp32_workspace_entry_e2e`,
+`test_esp32_to_native`, `test_native_to_esp32`, and
+`logging_smoke_esp32_qemu_emits_every_severity`). All five need a flash image
+that cannot currently be produced.
+
+That is a plausible single cause for the esp32 cluster and it is NOT yet
+established as their cause: this issue reproduces the BUILD failure, not those
+tests' failures. Confirming it means fixing this, rebuilding, and re-running the
+five. Recorded that way deliberately — 0968 exists because four issues were
+filed here from a sweep and all four retracted, two carrying confident wrong
+root causes.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -86,5 +86,6 @@ fails if this block drifts.
 - **#1019** (api, docs) — Every `RCLCPP_*` log call in a ported C++ node is discarded on embedded, and `RCLCPP_*_STREAM` drops its message on every target See `1019-*`.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
+- **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -85,5 +85,6 @@ fails if this block drifts.
 - **#1013** (testing) — `test_rtos_pubsub_e2e` SIGKILLs its talker after ~12 publishes, so the cell exercises twelve seconds of a free-running publisher See `1013-*`.
 - **#1019** (api, docs) — Every `RCLCPP_*` log call in a ported C++ node is discarded on embedded, and `RCLCPP_*_STREAM` drops its message on every target See `1019-*`.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
+- **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
Issue 0968's step 1 is *"rebuild tier-2 fixtures and re-run the 12 — nothing here is currently reproducible."* Doing that found **two build failures**, so the twelve runtime failures remain unreproduced. This records what stands in the way.

Seven of eight modules built: zephyr, native, qemu, freertos, nuttx, threadx_linux.

## #1025 — ESP32 flash images cannot be packed

The ELF builds fine. The packer looks in `build/cargo-fixtures/qemu-esp32-baremetal/`; the build writes to `qemu-esp32-baremetal-4118800323`.

The group key is a function of **(platform, cargo args, env)**, and the packer calls `nros_fixture_row_artifact_dir` with the last two **empty** — so both sides call one function and get different keys.

**Live since `41a7d8de7` (2026-08-31 02:31)** — *"fix(esp32): the DRAM fix landed on one row; its three siblings kept overflowing"*. That commit is a correct fix for a real overflow; adding `env = { ZPICO_MAX_QUERYABLES = "2" }` gave those rows a variant, and the variant is the key. Before it, both sides agreed on the bare platform name.

**It's a recurrence at the exact site the preventing helper was written for.** `nros_fixture_row_artifact_dir`'s docstring is about `just esp32 build-qemu` hand-writing this path, and ends: *"a post-processing step that spells the artifact path by hand is a second derivation of the group key; this makes it one."* The call site was duly converted — passing `"" ""` re-creates the second derivation through the **inputs** rather than the formula.

## #1023 — threadx_riscv64 cannot compile the sertype

`nros_sertype.cpp` includes `<memory>` and `<string>` against a freestanding target. New in issue 0970's commit, on a coordinate `examples/fixtures.toml:3146` declares — so a supported cell has been unbuildable since it landed. The file already carries an issue-0942 note fixing *one* include of this class three lines above the two that remain.

**Filed, not fixed**, for a specific reason: `std::string type_name` currently **copies** from `desc->m_typename`; a `const char*` stores a pointer whose lifetime relative to the sertype nobody has established. The safe shape is `ddsrt_strdup` freed in the free op — a memory-lifetime change in a serdata path, on the one coordinate that can't build to verify it.

## What this does and does not establish

**#1025 closes none of 0968's twelve.** Five are esp32 and all five need an image that cannot be produced. That makes it a *plausible* single cause for the esp32 cluster and **not an established one** — what reproduced is the build failing, not those tests failing for that reason.

Written that way deliberately: 0859–0862 were four issues filed from a sweep in this repo and all four retracted, two carrying confident wrong root causes.

Both failures are 0968's own thesis arriving a stage earlier than it predicted — no fixture-backed lane runs in CI, so a build break survives as easily as a test one.

Gates: `check fast` (190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)