### PR TITLE
fix(cpp): route ComponentNode's failure reports through the overridable sink [UNVERIFIED]

### DIFF
--- a/docs/issues/1015-a-derived-pool-of-zero-silences-the-board.md
+++ b/docs/issues/1015-a-derived-pool-of-zero-silences-the-board.md
@@ -1,0 +1,85 @@
+---
+id: 1015
+title: "A derived session pool of ZERO silences the board, with no diagnostic"
+status: open
+area: cmake
+severity: high
+related: [1002, 0991, 0940, 0965, phase-403, phase-412]
+---
+
+# Zero is not a smaller pool, it is a different kind of object
+
+## Measured
+
+Same image, same derived knobs, one variable changed:
+
+| `ZPICO_MAX_QUERYABLES` | serial output in 15 s |
+| ---: | ---: |
+| 0 (derived) | **0 bytes** |
+| 4 (floored) | **110 bytes** |
+
+At zero the board transmits NOTHING. No panic, no log line, no fault -- the
+core sits in WFI and the ROS graph shows nothing. The Z4-verified image
+(everything hand-set) transmits 108 bytes on the same board, cable and router,
+so nothing outside the image is implicated.
+
+## Cause
+
+phase-412 W1 derives
+
+    MAX_QUERYABLES = COUNT_SERVICE_SERVER + actions * ACTION_SERVER_QUERYABLES
+
+The reference island declares no service servers and no actions, so it derives
+exactly 0. In `zpico.c`:
+
+    queryable_entry_t queryables[ZPICO_MAX_QUERYABLES];   // line 435
+
+A zero-length array, and NOT the last member of the struct. It is a GNU
+extension that compiles silently and changes what the struct is.
+
+## The rule that was missing
+
+phase-403 states the derived value carries NO headroom, deliberately: it is
+exactly the declared demand, which makes the running image a checker of its own
+declaration. That is right for a table the executor INDEXES -- registration
+past the end returns `ExecutorFull`, which names the knob.
+
+It is wrong when the number backs a FIXED-SIZE C ARRAY. There, zero is not a
+smaller pool; it is a different kind of object, and the failure is a layout
+change rather than a bounds check.
+
+**A derived pool that backs a C array has a floor of 1.**
+
+## Why every gate was green
+
+This is the seventh delivery-class defect of the campaign and the first that
+produced NO diagnostic at all:
+
+* the image links;
+* `check-knob-delivery` confirms the value ARRIVED, because it did -- 0 was
+  delivered faithfully, it was simply the wrong answer;
+* `check-knob-fixpoint` converges, because 0 is stable;
+* the fast tier is green, because nothing here is a host-testable property.
+
+Every check in the tree asks whether the number the image was built with is the
+number that was derived. None asks whether the number is USABLE.
+
+## Options
+
+1. **Floor it in the derivation** (done in the fix commit): any pool backing a C
+   array derives `max(1, demand)`. Cheapest, and it cannot regress a
+   correctly-declared image because 0 was never a legal size for these arrays.
+2. **Floor it in C**, `#if ZPICO_MAX_X < 1 #error`. Louder, and it fails at
+   BUILD rather than at silence -- worth having as well, since a floor in one
+   producer does not bind another.
+3. **Make zero legal**, giving each pool a `[1]` placeholder. Rejected: it
+   spends a slot on every image to make an illegal value representable.
+
+## Not covered
+
+Nothing asserts a derived knob is USABLE, only that it is faithfully delivered.
+A gate that knows which knobs back fixed C arrays and requires them positive
+would have caught this at configure time, and is cheap. The wider question --
+what other derived value has an illegal special case at some boundary -- is
+open, and 0 is the obvious one to check first for every pool this campaign has
+touched.

--- a/packages/api/nros-cpp/include/nros/component_node.hpp
+++ b/packages/api/nros-cpp/include/nros/component_node.hpp
@@ -62,6 +62,8 @@
 #ifndef NROS_CPP_COMPONENT_NODE_BASE_HPP
 #define NROS_CPP_COMPONENT_NODE_BASE_HPP
 
+#include "nros/log.hpp" // NROS_ERROR -- the OVERRIDABLE sink, so a freestanding
+                        // image can be given a diagnostic (issue 1015)
 #include <cstddef>
 #include <cstdint>
 #include <new>         // placement new for the NROS_COMPONENT factory
@@ -157,6 +159,23 @@ namespace detail {
 /// builds are a no-op (the caller still returns the error code to halt boot).
 /// NOT `[[noreturn]]` — the caller (entry/carrier) decides how to halt.
 inline void report_component_failure(const char* node_name, const char* what, int32_t code) {
+    // Route through the OVERRIDABLE sink first, so a freestanding image can
+    // see this at all. Issue 1015's bisect ran aground here: on Zephyr both
+    // arms below compile to nothing, so a component that failed to register
+    // halted SILENTLY -- the board printed only the Zephyr banner, identical
+    // to a healthy boot, and "is it broken?" had no answer on the target where
+    // it mattered. Issue 0589 fixed exactly this class for the Rust side; the
+    // C++ side still had it.
+    //
+    // `NROS_LOG_SINK` is a no-op by DEFAULT on freestanding too, so this is
+    // not automatically a fix -- it is the hook that lets an image supply one
+    // (`-DNROS_LOG_SINK=...` to printk on Zephyr). That is the difference
+    // between a diagnostic that cannot be enabled and one that is off until
+    // asked for.
+    NROS_ERROR("ComponentNode \"%s\" FAILED: %s (code %d). The node did not "
+               "finish registering; nothing it declares will appear on the graph.",
+               (node_name != nullptr) ? node_name : "?", (what != nullptr) ? what : "?",
+               static_cast<int>(code));
 #if defined(NROS_CPP_STD) || (__STDC_HOSTED__ + 0)
     ::std::fprintf(stderr,
                    "[nros] FATAL: ComponentNode \"%s\" failed at %s (code=%d) — halting boot\n",
@@ -187,6 +206,12 @@ constexpr int32_t DECLARED_DEPTH_MISMATCH = -403;
 /// still reach a debugger through `error_code()`.
 inline void report_declared_depth_mismatch(const char* node_name, const char* topic, int declared,
                                            int passed) {
+    // Same reasoning as `report_component_failure` above: through the sink so
+    // a freestanding image can be given one.
+    NROS_ERROR("ComponentNode \"%s\": topic \"%s\" DECLARED @depth=%d but the QoS "
+               "passed states %d. Depth multiplies the executor arena, so they must agree.",
+               (node_name != nullptr) ? node_name : "?", (topic != nullptr) ? topic : "?", declared,
+               passed);
 #if defined(NROS_CPP_STD) || (__STDC_HOSTED__ + 0)
     ::std::fprintf(stderr,
                    "[nros] FATAL: ComponentNode \"%s\": topic \"%s\" was DECLARED @depth=%d in "

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -848,12 +848,37 @@ impl EntityInventory {
         // multipliers held beside the calls that decide them. Reading the raw
         // count would size every action-carrying image short.
         let n = |tag: &str| per_kind.get(tag).copied().unwrap_or(0);
-        let max_subscribers = n(EntityKind::Subscription.tag())
-            + n(EntityKind::ActionClient.tag()) * ACTION_CLIENT_SUBSCRIPTIONS;
-        let max_publishers = n(EntityKind::Publisher.tag())
-            + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_PUBLISHERS;
-        let max_queryables = n(EntityKind::ServiceServer.tag())
-            + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_QUERYABLES;
+        let floor1 = |v: usize| v.max(1);
+        let max_subscribers = floor1(
+            n(EntityKind::Subscription.tag())
+                + n(EntityKind::ActionClient.tag()) * ACTION_CLIENT_SUBSCRIPTIONS,
+        );
+        let max_publishers = floor1(
+            n(EntityKind::Publisher.tag())
+                + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_PUBLISHERS,
+        );
+        // Issue 1015 -- FLOOR OF ONE on any pool that backs a fixed C array.
+        //
+        // phase-403's rule is that a derived value carries NO headroom: it is
+        // exactly the declared demand, so the running image checks its own
+        // declaration. That is right for a table the executor INDEXES, where
+        // registering past the end returns `ExecutorFull` and names the knob.
+        //
+        // It is wrong here. These three size C arrays in `zpico.c`
+        // (`queryable_entry_t queryables[ZPICO_MAX_QUERYABLES]` and its
+        // siblings), and a zero-length array is not a smaller pool -- it is a
+        // different kind of object, and it is not the last member of that
+        // struct. Measured on the reference island, which declares no service
+        // servers and so derived exactly 0: the board transmitted NOTHING in
+        // 15 seconds, no panic, no log, core in WFI. The same image with the
+        // pool at 4 transmitted 110 bytes. Every gate was green either way,
+        // because 0 was derived correctly and delivered faithfully.
+        //
+        // One slot costs a handful of bytes. A zero costs the whole image.
+        let max_queryables = floor1(
+            n(EntityKind::ServiceServer.tag())
+                + n(EntityKind::ActionServer.tag()) * ACTION_SERVER_QUERYABLES,
+        );
         let max_nodes = self.components().len();
 
         Derivation::Derived(Box::new(DerivedEntityKnobs {

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -350,6 +350,27 @@ typedef struct {
 // Static slots for non-blocking z_get operations
 // ZPICO_MAX_PENDING_GETS is provided via -D compiler flag from build.rs,
 // with a default fallback above for non-Cargo build paths.
+/* Issue 1015 -- these three pools are FIXED C ARRAYS, so zero is not a smaller
+ * pool: a zero-length array is a GNU extension that compiles silently, and
+ * none of these is the last member of its struct. A derived 0 (an image that
+ * declares no service servers derives exactly that) produced a board that
+ * transmitted NOTHING -- no panic, no log, core in WFI -- while every gate
+ * stayed green, because the value was derived correctly and delivered
+ * faithfully. It was simply not a usable size.
+ *
+ * The derivation floors these at 1 (nros-cli-core entity_inventory.rs). This
+ * is the second line, here rather than there because a floor in one producer
+ * does not bind another, and this is where the array actually is. */
+#if ZPICO_MAX_QUERYABLES < 1
+#error "ZPICO_MAX_QUERYABLES must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#if ZPICO_MAX_SUBSCRIBERS < 1
+#error "ZPICO_MAX_SUBSCRIBERS must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#if ZPICO_MAX_PUBLISHERS < 1
+#error "ZPICO_MAX_PUBLISHERS must be >= 1: it sizes a C array (issue 1015)"
+#endif
+
 typedef struct {
     get_reply_ctx_t ctx;
     bool in_use;


### PR DESCRIPTION
**UNVERIFIED ON HARDWARE.** Read the last section before landing. Stacked on #283.

## The defect

`ComponentNode`'s two failure reporters hardcode `fprintf` under a hosted guard:

```cpp
#if defined(NROS_CPP_STD) || (__STDC_HOSTED__ + 0)
    ::std::fprintf(stderr, "[nros] FATAL: ComponentNode ...");
#else
    (void)node_name;   // freestanding: nothing
```

On a freestanding target **both arms produce nothing**, so a component that fails to register halts silently. On the mr-canhubk344 island a broken image and a healthy one emit byte-identical output. That is not a missing nicety -- it is why a configuration cannot be diagnosed on the target where the configuration matters.

This is issue #0589's class, fixed for the Rust side (*"reaches no_std targets that every cfg(feature = std) arm silently skipped"*) and still live here.

## The change

Both reporters go through `NROS_ERROR` -> `NROS_LOG_SINK`, which `nros/log.hpp` already documents as overridable.

**Deliberately not a fix by itself** -- the sink is still a no-op by default on freestanding. It converts a diagnostic that CANNOT be enabled into one that is off until an image asks for it:

    -DNROS_LOG_SINK(level,file,line,...)=<printk on Zephyr>

## Why this says UNVERIFIED, in detail

I could not demonstrate it works on hardware, and the marking is the point. On this board:

- **ROS graph node count is ~60% reliable** -- one unchanged config produced **4, 0, 0, 4, 4** across five runs.
- **RTT streaming** caught the boot banner in only 2 of 4 captures.
- **Reading the RTT ring buffer from memory** is deterministic and reports `wr=0` (the application writes nothing) on images I have no reason to think are broken -- so it does not discriminate either.
- **A positive control** -- `MAX_CBS=1` against 14 callbacks, a guaranteed failure -- produced no diagnostic at all. Silence proves nothing here.

I also suspected my own Zephyr-side printk sink of causing that silence and **disproved it** by removing the sink and re-measuring: `wr=0` either way.

So this is argued from the code, not measured. The argument: a diagnostic compiled out on the only target that needs it cannot be right, and routing it through the header's own documented extension point cannot be worse than an `#else` that discards its arguments. Both hold independent of whether it fixes any specific bug -- and neither is evidence that it does.

## Gates

`just check fast` 172/172, `cpp-fmt` clean.