### PR TITLE
fix(#1025): pack the ESP32 flash image from the row the build actually wrote

### DIFF
--- a/docs/issues/1065-esp32-build-qemu-recipe-has-no-lane.md
+++ b/docs/issues/1065-esp32-build-qemu-recipe-has-no-lane.md
@@ -1,0 +1,69 @@
+---
+id: 1065
+title: "`just esp32 build-qemu` is run by no lane, so it can be wholly broken with every test green"
+status: open
+area: testing
+severity: medium
+related: [1025, 0196, 0883]
+---
+
+## What
+
+`just esp32 build-qemu` is the documented way to produce the ESP32 QEMU flash
+images, and **nothing in CI runs it**. Grepping the whole tree for callers finds
+only `just docker build-qemu` (a different recipe, in the Docker module) and
+prose references.
+
+The ESP32 e2e tests do not use it. `packages/testing/nros-tests/tests/
+esp32_emulator.rs` resolves the ELF through the fixture resolver and packs its
+own image:
+
+```rust
+let elf = build_esp32_qemu_talker().expect("Failed to build esp32-qemu-talker");
+let flash_image = nros_tests::build_dir(nros_tests::kind::ESP32_QEMU, &[])
+    .join("esp32-qemu-talker.bin");
+create_esp32_flash_image(elf, &flash_image).expect("Failed to create flash image");
+```
+
+So the tests exercise a SECOND packing path that happens to be correct, and the
+recipe a human is told to run is exercised by nobody.
+
+## Evidence that this is not theoretical
+
+Issue 1025: the recipe's ELF lookup passed `"" ""` for the row's cargo args and
+env, so it read `build/cargo-fixtures/qemu-esp32-baremetal/` while the build
+wrote `qemu-esp32-baremetal-4118800323`. **No flash image could be packed at
+all**, and it stayed that way through many green CI runs, because the only
+consumer of the broken path is a person at a terminal.
+
+It also hid a second time: on a developer machine that had built those rows
+before they gained an `env`, a stale ELF sits at the bare path and the recipe
+works. The failure is invisible in CI (never run) and intermittent locally
+(depends on build residue) — issue 0828's shape exactly.
+
+## Why the nightly does not cover it
+
+`nightly.yml` has an `esp32` path filter and an esp32 lane module, so ESP32 looks
+covered. It is — for the MATRIX, which builds fixtures through
+`build-test-fixtures` and tests through the resolver. Neither route calls this
+recipe. "The platform is covered" and "this recipe is covered" are different
+claims, and only the first is true.
+
+## Fix
+
+Run it. It needs no ROS, no SDK beyond the esp32 toolchain the lane already
+provisions, and it is a build, so it belongs wherever the ESP32 compile work
+already happens — the nightly esp32 module, gated on the same path filter.
+
+Assert the artifacts, not the exit code: the recipe's own history is of exiting
+0 while producing nothing (issue #181, which is why the "ERROR: … is missing"
+guard exists). The check is that `build/esp32-qemu/esp32-qemu-{talker,listener}
+.bin` exist and are non-empty afterwards.
+
+## The general shape, worth stating once
+
+A user-facing recipe whose output is also produced by a second, test-internal
+path has no coverage from those tests, however green they are. The test proves
+the SECOND path. Any recipe the book or `just --list` offers a human should have
+one lane that invokes it the way a human would — otherwise its correctness is
+asserted only by the last person who happened to run it.

--- a/docs/issues/1065-esp32-build-qemu-recipe-has-no-lane.md
+++ b/docs/issues/1065-esp32-build-qemu-recipe-has-no-lane.md
@@ -60,6 +60,28 @@ Assert the artifacts, not the exit code: the recipe's own history is of exiting
 guard exists). The check is that `build/esp32-qemu/esp32-qemu-{talker,listener}
 .bin` exist and are non-empty afterwards.
 
+## Direction: this recipe should move onto RFC-0062 provisioning
+
+Adding a lane is the interim step, not the destination. The recipe currently
+hand-rolls its own dependency resolution — six `command -v` probes across
+`just/esp32.just` for `espflash` and `qemu-system-riscv32`, each with its own
+message and its own opinion about whether a miss is fatal (issue 0486 already
+had to convert one from a warn-and-continue into a failure, precisely because a
+skip read as green).
+
+RFC-0062 is the SSoT for exactly this: `[prereq.*]`, one declaration namespace
+over four providers, rosdep no longer consulted (phase-327 / phase-398 landed
+it; phase-404 carries amendment 2, where the provider is chosen by what the tool
+DOES and every resolution reports its provider). `[tool.esp32-qemu]` already
+declares its build deps there — issue 1038 wired that up — so the recipe is the
+part that has not moved.
+
+Doing so replaces the six probes with a declaration, and gives the lane a
+provisioning step that fails with a reason instead of a recipe that decides for
+itself what to do about a missing tool. Sequence it after the lane exists: the
+lane is what proves the move did not break the recipe, and adding a lane to an
+unprovisioned recipe is how a "skip" becomes the CI answer.
+
 ## The general shape, worth stating once
 
 A user-facing recipe whose output is also produced by a second, test-internal

--- a/docs/issues/archived/1025-esp32-flash-image-consumer-drops-the-row-variant.md
+++ b/docs/issues/archived/1025-esp32-flash-image-consumer-drops-the-row-variant.md
@@ -1,7 +1,7 @@
 ---
 id: 1025
 title: "ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using"
-status: open
+status: resolved
 area: build, testing
 severity: high
 found: 2026-09-04
@@ -129,3 +129,53 @@ tests' failures. Confirming it means fixing this, rebuilding, and re-running the
 five. Recorded that way deliberately — 0968 exists because four issues were
 filed here from a sweep and all four retracted, two carrying confident wrong
 root causes.
+
+
+## RESOLVED 2026-09-04
+
+**`nros_fixture_row_artifact_dir_by_id <row-id> <platform>`** — the row's args
+and env come from the manifest, which is the one place they are written. The
+four-argument form stays for callers that genuinely hold them (the build
+itself). Both ESP32 packers now name the row id they are packing, which is the
+same id the build loop above each already passes to `fixtures-build.sh --id`.
+
+**Acceptance is the build, as the helper's own docstring demands:**
+
+```
+$ just esp32 build-qemu
+  build/esp32-qemu/esp32-qemu-talker.bin      Image successfully saved!
+  build/esp32-qemu/esp32-qemu-listener.bin    Image successfully saved!
+$ just esp32 build-logging-smoke
+  …/logging-smoke-esp32-qemu.bin              Image successfully saved!
+```
+
+### The class, swept — and two of the five flags were the GATE being wrong
+
+`check-fixture-artifact-dir-inputs` (fast line) forbids a packer of a
+lane-built artifact from supplying empty args or env on a shared platform. Its
+first version flagged six sites. Only the two ESP32 ones were defects.
+
+The other four — `freertos`, `nuttx`, `qemu-arm-baremetal`, `threadx-linux`,
+`threadx-riscv64` run-example recipes — **build the artifact themselves**, and
+pass the very same empty arguments to `nros_fixture_target_dir_flag`. Their two
+halves therefore agree with each other: they write and read the same unhashed
+dir. Measured, not assumed — `nuttx` and `threadx-riscv64` DO diverge from the
+fixture lane's key (`nuttx-2965781523` vs `nuttx`), which is what makes them look
+like defects, and they are not, because nothing in those recipes reads what the
+lane built.
+
+Shipping that first version would have reported a five-site bug that does not
+exist. The gate now exempts a call whose recipe also calls
+`nros_fixture_target_dir_flag` — a gate wider than the rule it enforces is issue
+0196's audit finding, and this one was about to repeat it.
+
+**Mutation-tested on the normal path**, per `check-gate-selftests`: the gate
+runs three controls every time — the real 1025 defect (must flag), the by-id fix
+(must not), and a self-consistent build-it-yourself recipe (must not). The third
+is what pins the narrowing, so a future edit cannot quietly widen it back.
+
+### What it does NOT establish
+
+Whether the five esp32 tests in [issue 0968](0968-tier2-runtime-failures-unreproduced.md)
+pass now. They could not run at all before this; that they CAN run is not the
+same as their passing, and running them is 0968's work.

--- a/just/check.just
+++ b/just/check.just
@@ -168,6 +168,7 @@ fast-serial: \
     feature-contract \
     feature-set-ssot \
     ffi-struct-mirrors \
+    fixture-artifact-dir-inputs \
     fixture-binary-names \
     fixture-groups \
     fixture-id-guard \
@@ -4029,6 +4030,15 @@ rmw-descriptors:
 [private]
 serdes-descriptors:
     @python3 scripts/check-serdes-descriptors.py
+
+# Issue 1025 -- a packer must not invent the row's cargo args or env. The shared
+# cargo group key is a function of (platform, args, env); a consumer supplying
+# two of the three gets a directory the build never wrote to, and only once that
+# row gains a variant. Silent until then, which is how every ESP32 QEMU flash
+# image stopped being packable without a single lane going red.
+[group("check")]
+fixture-artifact-dir-inputs:
+    @python3 scripts/check-fixture-artifact-dir-inputs.py
 
 [private]
 fixture-groups:

--- a/just/esp32.just
+++ b/just/esp32.just
@@ -136,8 +136,16 @@ build-qemu:
         # live under `build/cargo-fixtures/<group>/`; the helper returns the
         # leaf's own `target/` for any platform that has not migrated, so this
         # line is correct on both sides of a migration.
-        artifact_dir="$(nros_fixture_row_artifact_dir \
-            "examples/qemu-esp32-baremetal/rust/$ex" qemu-esp32-baremetal "" "")"
+        #
+        # Issue 1025 — BY ROW ID, not by leaf-plus-two-empty-strings. The group
+        # key is a function of (platform, cargo args, env); this used to pass
+        # `"" ""` for the last two, so the moment these rows gained
+        # `env = { ZPICO_MAX_QUERYABLES = "2" }` the build wrote
+        # `qemu-esp32-baremetal-4118800323` and this line kept reading
+        # `qemu-esp32-baremetal`. No flash image could be packed at all. The id
+        # is the same one passed to `fixtures-build.sh --id` four lines up.
+        artifact_dir="$(nros_fixture_row_artifact_dir_by_id \
+            "qemu-esp32-baremetal-$ex" qemu-esp32-baremetal)"
         elf="$artifact_dir/riscv32imc-unknown-none-elf/$target_profile_dir/$elf_name"
         out="$esp32_qemu_dir/esp32-qemu-$ex.bin"
         # Issue 0439 — the build loop above is lane-narrowable, so under a lane
@@ -190,8 +198,11 @@ build-logging-smoke:
     echo "Creating logging-smoke-esp32-qemu flash image..."
     fixture=packages/testing/nros-tests/bins/logging-smoke-esp32-qemu
     # Same migration-aware derivation as `build-qemu` — this row is
-    # `qemu-esp32-baremetal` too, so it moved with the platform.
-    artifact_dir="$(nros_fixture_row_artifact_dir "$fixture" qemu-esp32-baremetal "" "")"
+    # `qemu-esp32-baremetal` too, so it moved with the platform. Issue 1025:
+    # by ROW ID, because this row carries `env` as well and the two-empty-string
+    # form derives a group dir the build never wrote to.
+    artifact_dir="$(nros_fixture_row_artifact_dir_by_id \
+        qemu-esp32-baremetal-logging-smoke qemu-esp32-baremetal)"
     elf="$artifact_dir/riscv32imc-unknown-none-elf/$target_profile_dir/logging-smoke-esp32-qemu"
     bin="$elf.bin"
     # Issue 0439 — same shape as `build-qemu` above: a lane-narrowable `--id`

--- a/scripts/build/fixtures-target-dir.sh
+++ b/scripts/build/fixtures-target-dir.sh
@@ -298,6 +298,48 @@ nros_fixture_row_artifact_dir() {
     fi
 }
 
+# nros_fixture_row_artifact_dir_by_id <row-id> <platform>
+#
+# WHERE the row with this id actually landed, with the row's OWN cargo args and
+# env — read from the manifest, not supplied by the caller.
+#
+# Issue 1025. `nros_fixture_row_artifact_dir` made the FORMULA single; its
+# INPUTS were still derived twice, and that is where the two sides diverged.
+# The group key is a function of (platform, cargo args, env), so a consumer that
+# passes `"" ""` for two of the three asks a different question with the same
+# function and gets an answer that is wrong exactly when a row has a variant:
+#
+#   producer  nros_fixture_group_slug qemu-esp32-baremetal "" "ZPICO_MAX_QUERYABLES=2"
+#             -> qemu-esp32-baremetal-4118800323
+#   consumer  nros_fixture_group_slug qemu-esp32-baremetal "" ""
+#             -> qemu-esp32-baremetal
+#
+# That is what stopped every ESP32 QEMU flash image from being packed the moment
+# those rows gained an `env` (41a7d8de7). The manifest is the one place the
+# row's args and env are written, so the fix is to read them there rather than
+# to spell them a third time at the call site.
+#
+# A packer names the ROW it is packing — an id it already has, since the build
+# loop above it passes the same id to `fixtures-build.sh --id`. Anything that
+# post-processes a fixture artifact should call THIS, not the four-argument
+# form; the four-argument form remains for callers that genuinely hold the
+# row's args and env already (the build itself).
+nros_fixture_row_artifact_dir_by_id() {
+    local row_id="$1" platform="$2"
+    local record dir envstr args
+    record="$(python3 scripts/build/fixtures-manifest.py list --id "$row_id")" || return 1
+    # Exactly one row, or the id is not an id. Refuse rather than take the
+    # first: a prefix that matched two rows would pack one row's ELF under
+    # another row's name, silently.
+    if [ "$(printf '%s\n' "$record" | grep -c .)" != "1" ]; then
+        printf 'nros_fixture_row_artifact_dir_by_id: %s matched %s manifest row(s), expected 1\n' \
+            "$row_id" "$(printf '%s\n' "$record" | grep -c .)" >&2
+        return 1
+    fi
+    IFS=$'\x1f' read -r dir envstr args <<< "$record"
+    nros_fixture_row_artifact_dir "$dir" "$platform" "$args" "$envstr"
+}
+
 # nros_example_build_target_dir_flag <leaf-dir> [<platform>]
 #
 # issue 0635 — the `--target-dir` for a walk that builds example leaves for

--- a/scripts/check-fixture-artifact-dir-inputs.py
+++ b/scripts/check-fixture-artifact-dir-inputs.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Issue 1025 — a consumer must not invent a row's cargo args or env.
+
+`nros_fixture_row_artifact_dir <leaf> <platform> <args> <env>` derives the
+shared cargo group dir, and the key is a function of ALL THREE of platform,
+cargo args and env. A packer that passes empty literals for the last two asks a
+different question with the same function, and gets an answer that is wrong
+exactly when the row has a variant.
+
+That is not hypothetical: it stranded every ESP32 QEMU flash image the moment
+`41a7d8de7` gave those rows an `env`, and nothing noticed because no CI lane
+builds fixtures. The formula was already single (phase-340 item 7 made it so);
+the INPUTS were still derived twice.
+
+So on a SHARED platform, a call site must use `nros_fixture_row_artifact_dir_by_id
+<row-id> <platform>`, which reads the row's args and env from the manifest.
+
+An UNSHARED platform is exempt and stays that way on purpose: it resolves to the
+leaf's own `target/` whatever the variant says, so the empty literals are
+harmless there — and flagging them would be a gate wider than the rule it
+enforces, which this repo has audited itself for before (issue 0196).
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CALL = re.compile(r'nros_fixture_row_artifact_dir\s+(.+?)\)"', re.S)
+
+
+def shared_platforms():
+    """The list, read from the shell that owns it — never a second copy here."""
+    src = (ROOT / "scripts/build/fixtures-target-dir.sh").read_text()
+    m = re.search(r'NROS_FIXTURE_SHARED_PLATFORMS="\$\{NROS_FIXTURE_SHARED_PLATFORMS:-([^}]*)\}"', src)
+    if not m:
+        sys.exit("check-fixture-artifact-dir-inputs: cannot find NROS_FIXTURE_SHARED_PLATFORMS")
+    return set(m.group(1).split())
+
+
+def selftest() -> None:
+    """The negative control, on the NORMAL path — a gate that cannot fail is a comment.
+
+    Modelled on the real defect: a packer that reads a lane-built artifact and
+    supplies the row's args and env itself. `_flag` is the exempting sibling, so
+    the pair also pins the NARROWING — without it this gate flagged five
+    self-consistent run-example recipes, which is a gate wider than its rule.
+    """
+    import tempfile
+
+    bug = ('  artifact_dir="$(nros_fixture_row_artifact_dir '
+           '"examples/qemu-esp32-baremetal/rust/$ex" qemu-esp32-baremetal "" "")"\n')
+    ok = ('  artifact_dir="$(nros_fixture_row_artifact_dir_by_id '
+          '"qemu-esp32-baremetal-$ex" qemu-esp32-baremetal)"\n')
+    self_consistent = ('  flag="$(nros_fixture_target_dir_flag nuttx "" "")"\n'
+                       '  d="$(nros_fixture_row_artifact_dir "$L" nuttx "" "")"\n')
+
+    for name, body, want in (("the 1025 defect", bug, 1),
+                             ("the by-id fix", ok, 0),
+                             ("a recipe that builds it itself", self_consistent, 0)):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "just"
+            d.mkdir()
+            (d / "probe.just").write_text("recipe:\n" + body)
+            got = len(_scan(d))
+            if (got > 0) != (want > 0):
+                sys.exit(f"check-fixture-artifact-dir-inputs SELFTEST FAILED: "
+                         f"{name} -> {got} finding(s), expected {'>=1' if want else '0'}")
+
+
+def _scan(just_dir: Path):
+    """The finder, over an arbitrary directory — shared by main and the selftest."""
+    shared = shared_platforms()
+    bad = []
+    for path in sorted(just_dir.glob("*.just")):
+        text = path.read_text()
+        lines = text.splitlines()
+        for m in CALL.finditer(text):
+            call = " ".join(m.group(1).split())
+            words = call.split()
+            plat = next((w for w in words if w in shared), None)
+            if plat is None or not re.findall(r'""(?=\s|$)', call):
+                continue
+            line = text[: m.start()].count("\n") + 1
+            window = "\n".join(lines[max(0, line - 25) : line + 5])
+            if "nros_fixture_target_dir_flag" in window:
+                continue
+            bad.append((path.name, line, plat,
+                        len(re.findall(r'""(?=\s|$)', call)), call[:90]))
+    return bad
+
+
+def main() -> int:
+    selftest()
+    shared = shared_platforms()
+    bad = [(ROOT.joinpath("just", n).relative_to(ROOT), l, p_, e, c)
+           for n, l, p_, e, c in _scan(ROOT / "just")]
+
+    if not bad:
+        print(f"check-fixture-artifact-dir-inputs: OK "
+              f"({len(shared)} shared platform(s); every packer of a lane-built "
+              f"artifact derives its row's args and env from the manifest)")
+        return 0
+
+    print("check-fixture-artifact-dir-inputs: a consumer is inventing a row's variant.\n")
+    for path, line, plat, empties, call in bad:
+        print(f"  {path}:{line}  platform={plat}  {empties} empty argument(s)")
+        print(f"      {call}")
+    print("""
+  The group key is (platform, cargo args, env). Passing "" for args or env asks a
+  DIFFERENT question with the same function, and the answer diverges the moment
+  that row gains a variant — which is issue 1025, where every ESP32 QEMU flash
+  image stopped being packable and no lane noticed.
+
+  Fix: use `nros_fixture_row_artifact_dir_by_id <row-id> <platform>`, which reads
+  the row's args and env from the manifest. The row id is the one the build loop
+  above already passes to `fixtures-build.sh --id`.""")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
No ESP32 QEMU flash image could be packed **at all**. The ELF built fine; the packer read `build/cargo-fixtures/qemu-esp32-baremetal/` while the build wrote `qemu-esp32-baremetal-4118800323`.

The shared cargo group key is a function of **(platform, cargo args, env)**, and the packer passed the last two **empty** — one function, two questions, diverging exactly when a row has a variant. Live since `41a7d8de7`, a *correct* DRAM fix whose `env = { ZPICO_MAX_QUERYABLES = "2" }` gave those rows their first variant.

**A recurrence at the site the preventing helper was written for.** `nros_fixture_row_artifact_dir`'s docstring is about `just esp32 build-qemu` hand-spelling this path: *"a post-processing step that spells the artifact path by hand is a second derivation of the group key; this makes it one."* The call site was duly converted — phase-340 item 7 made the **formula** single, and the **inputs** were still derived twice.

## Fix

`nros_fixture_row_artifact_dir_by_id <row-id> <platform>` reads the row's args and env from the manifest — the one place they're written. Both packers now name the row id they pack, the same id the build loop above each already passes to `fixtures-build.sh --id`.

**Acceptance is the build**, which the helper's docstring demands and which a gate is what passed last time:

```
just esp32 build-qemu           → esp32-qemu-talker.bin, esp32-qemu-listener.bin
just esp32 build-logging-smoke  → logging-smoke-esp32-qemu.bin
```

## The sweep — and two of the five other flags were the gate being wrong

`check-fixture-artifact-dir-inputs`'s first version flagged six sites. **Only the two ESP32 ones were defects.** The freertos / nuttx / qemu-arm-baremetal / threadx-linux / threadx-riscv64 run-example recipes *build the artifact themselves* and pass the same empty arguments to `nros_fixture_target_dir_flag`, so their halves agree — they write and read the same unhashed dir.

Measured rather than argued: `nuttx` and `threadx-riscv64` genuinely diverge from the fixture lane's key (`nuttx-2965781523` vs `nuttx`), which is what makes them *look* like defects — and nothing in those recipes reads what the lane built.

Shipping that version would have reported a five-site bug that does not exist: a gate wider than the rule it enforces, which is issue 0196's audit finding, about to be repeated. The gate now exempts a call whose recipe also calls `nros_fixture_target_dir_flag`, and its **selftest runs three controls on the normal path** — the 1025 defect must flag, the by-id fix must not, a build-it-yourself recipe must not. The third pins the narrowing so a later edit can't quietly widen it back.

Sweep command: `python3 scripts/check-fixture-artifact-dir-inputs.py`

## What this does not establish

Whether issue 0968's five esp32 tests **pass**. They could not run at all before this; can-run is not passes. Running them is 0968's work.

Gates: `check fast` (191, including the new one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)