### PR TITLE
docs: four phase status lines that outlived what they described

### DIFF
--- a/docs/roadmap/archived/phase-356-test-evidence-and-measurement-trust.md
+++ b/docs/roadmap/archived/phase-356-test-evidence-and-measurement-trust.md
@@ -1,7 +1,14 @@
 # Phase 356 — Test evidence: a sweep you can read afterwards, and numbers you can believe
 
-**Status (2026-08-17). W1 and W2 DONE; W3's available half DONE, its remainder
-unblocked and specified.** Three issues about the same failure: a test run that
+**Status (2026-09-04). W1, W2 and W3 all DONE — the phase is complete.** The
+2026-08-17 line described W3 as having a remainder "unblocked and specified";
+that remainder has since landed. Issue 0260 is `status: resolved` and archived
+(`d97b79484` — "the SMP core-pin arm RUNS and is observed"), which was exactly
+the fixture question this doc identified when it corrected its own
+phase-162 blocker claim. Nothing here is owed.
+
+**Previously (2026-08-17): W1 and W2 DONE; W3's available half DONE, its
+remainder unblocked and specified.** Three issues about the same failure: a test run that
 reports something which cannot be checked, or which is not what it appears to
 be.
 

--- a/docs/roadmap/phase-209-cpp-port-friction-reduction.md
+++ b/docs/roadmap/phase-209-cpp-port-friction-reduction.md
@@ -16,7 +16,18 @@ glue + one or two `#include`s**, not by rewriting the source. The three survey
 candidates (`autoware_external_cmd_selector`, `topic_state_monitor`,
 `autoware_steer_offset_estimator`) are concrete fixtures to validate against.
 
-**Status.** **MVP RUNS AGAIN — issue 0465 fixed 2026-08-07.** The rclcpp shim was
+**Status (2026-09-04). MVP RUNS, and the acceptance is now EXECUTED — the
+"STILL OPEN" clause below is stale.** It said "none of this phase's three port
+templates is in any fixture row, test or recipe". Measured today: `examples/
+fixtures.toml` carries **nine** template rows (issue 0469 — the block is
+commented there as phase 209's acceptance), and
+`packages/testing/nros-tests/tests/port_templates_e2e.rs` RUNS the publisher
+rather than only building it, which is the distinction that clause called for
+("a build-only row would not have caught this"). The gap that let 0465 hide for
+ten weeks is closed; what follows is the record of it, kept because the reason
+it stayed hidden is the reusable part.
+
+**Previously (2026-08-07): MVP RUNS AGAIN — issue 0465 fixed.** The rclcpp shim was
 opening a SECOND RMW session (`rclcpp::init()` builds the global executor, then
 `rclcpp::Node` created its own); a non-bridge app has exactly one, and the second
 open exhausted the default 1-entry pool and surfaced as `Transport(ConnectionFailed)`.

--- a/docs/roadmap/phase-296-system-model-consumption.md
+++ b/docs/roadmap/phase-296-system-model-consumption.md
@@ -1,10 +1,27 @@
 # Phase 296 — SystemModel consumption: bake the model into embedded images
 
-**Status.** IN PROGRESS — but LAST RECORDED 2026-07-23, so treat the figures
-below as stale until re-audited. W1–W4 + W3b.1–.5 landed (2026-07-20) incl. the
-cross-runtime parity fixture; the R2/R4 migration was mid-flight with a holdout
-inventory of **17 CMake + 7 Rust** entries. Migration state for C/C++ lives in
-the CMake `LAUNCH`/`MODEL` keyword, not the source.
+**Status (2026-09-04). W1-W4 + W3b.1-.5 LANDED; W5 design-only; the R2/R4
+migration is SUPERSEDED, not unfinished — phase-330 W7 reversed its direction.**
+
+The 2026-07-23 line below reported "**17 CMake + 7 Rust** holdouts" and read as
+migration debt for six weeks. It is not debt, and re-counting it is the wrong
+repair. Its classifier counts entries whose non-comment lines still carry
+`LAUNCH "…"` / `launch = "…"`, because R4's target was to move every entry ONTO
+`MODEL`/`model =`. [phase-330](phase-330-system-model-as-build-artifact.md) W7
+— *"Input-addressed entries: `launch =` replaces `model =`"* (2026-08-03) —
+reversed exactly that: entries name their INPUT, SystemModels are build
+artifacts, and `model =`/`MODEL` are now DEPRECATED expert overrides (CLAUDE.md
+states this rule). phase-330 W7's own text names "the `nros::main!(launch = …)`
+form that phase-296 R4 removed".
+
+So the holdouts became the REQUIRED form. Measured 2026-09-04 on anchored
+patterns (an unanchored grep matches this doc's own prose, which is how the
+first re-count went wrong): **0** real `MODEL` keywords and **0** real
+`nros::main!(model = …)` invocations in `examples/`, against 13 `LAUNCH` and 23
+`launch =`. The tree is fully on phase-330's form.
+
+Read every R2/R4 section below as HISTORY of a direction that was abandoned.
+W5 remains design-only, and its prereqs (a) and (b) are done.
 
 Implements RFC-0050 (consumer half) + RFC-0052 (the RTOS mapper).
 Producer side is DONE (play_launch phase 43: `resolve` emits the model,

--- a/docs/roadmap/phase-357-wcet-as-declared-data.md
+++ b/docs/roadmap/phase-357-wcet-as-declared-data.md
@@ -1,7 +1,22 @@
 # Phase 357 — WCET as declared data: making derived scheduling mean something
 
-**Status (2026-08-18). W3 DONE; W1's RFC LANDED (RFC-0078) with its type/validator
-still to come; W2 blocked behind that.** [phase-356](phase-356-test-evidence-and-measurement-trust.md)
+**Status (2026-09-04). W3 DONE; W1 DONE — RFC-0078 landed AND its type and
+validator are in the tree; W2 is the only open strand, and it is blocked on
+model INPUTS rather than on W1.** The 2026-08-18 line said the type and
+validator were "still to come" and W2 was "blocked behind that"; both halves
+were overtaken. `packages/core/nros-orchestration-ir/src/wcet.rs` carries
+`WcetProfile`, its `clock_hz` field and the validator (including the
+`clock_hz is 0` rejection and the cycles-to-milliseconds conversion), so W2 is
+not waiting on W1 for anything.
+
+W2's two remaining derivations and their real blockers are stated below and are
+unchanged: `placement` needs an interference model on top of `SchedCaps.n_cores`
+(which now EXISTS), and `non_preempt` needs per-callback priorities within a
+tier, which is a MODEL change scoped in issue 0259. Note the inputs those would
+consume are still SYNTHETIC — RFC-0078's worked example says so, because QEMU
+cannot measure cycles and there is no hardware lane.
+
+**Previously (2026-08-18):** [phase-356](phase-356-test-evidence-and-measurement-trust.md)
 W2 landed the artifact (#403 resolved), which was the only thing holding W1.
 Three orchestration issues that are one dependency chain, not three tasks.
 


### PR DESCRIPTION
Surveying the 53 pre-400 phases for one worth continuing, **five of the most promising turned out to be already done** — the work had landed and only the header still said otherwise. Four are corrected here; phase-403 was fixed separately in #298. Each was verified against the tree, not against the doc.

| Phase | Header claimed | Tree says |
| --- | --- | --- |
| **296** | "IN PROGRESS — 17 CMake + 7 Rust holdouts" | superseded, direction reversed |
| **209** | "STILL OPEN: none of the templates is in any fixture row, test or recipe" | 9 fixture rows + a test that runs them |
| **357** | W1's "type/validator still to come; W2 blocked behind that" | `wcet.rs` has both; W2 blocked elsewhere |
| **356** | W3 remainder "unblocked and specified" | landed; issue 0260 resolved → archived |

## phase-296 is the interesting one, and it is NOT "migration complete"

Its status reported 17 + 7 holdouts and read as migration debt for six weeks. The classifier counts entries still carrying `LAUNCH`/`launch = `, because R4's target was to move everything **onto** `MODEL`/`model = `.

[phase-330](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/roadmap/phase-330-system-model-as-build-artifact.md) W7 — *"Input-addressed entries: `launch =` replaces `model =`"* (2026-08-03) — **reversed that**, and its own text names "the `nros::main!(launch = …)` form that phase-296 R4 removed". SystemModels became build artifacts; `model =`/`MODEL` became deprecated expert overrides, which is the rule CLAUDE.md now states.

So the holdouts became the *required* form. Measured on anchored patterns: **0** real `MODEL` keywords, **0** real `nros::main!(model = …)`, against 13 `LAUNCH` and 23 `launch =`. The R2/R4 sections are now history of an abandoned direction, and re-counting them would have been the wrong repair.

## A grep trap worth recording

My first re-count of 296 said "0 holdouts, migration complete" and was wrong in the other direction — `grep 'MODEL '` matches the phase doc's **own prose** ("RFC-0052 R2: MODEL path") and doc-comments in example sources. Count with `^\s*MODEL\s` and exclude `//` lines, or the doc measures itself.

## Not touched, deliberately

phase-357 W2 keeps its real blockers — an interference model for `placement`, per-callback priorities for `non_preempt` (issue 0259). Only the false claim that it was waiting on W1 is removed.

`just check fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742