### PR TITLE
fix(#1005, #1009, #1013): phase-414's spun-out issues, and a gate that ran nowhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,18 +701,21 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   eleven slots before the app declares anything, against `ZPICO_MAX_QUERYABLES` = 8 embedded.
   Raise `CONFIG_NROS_MAX_QUERYABLES`; the table is a static array, so the default stays small.
   → issue 0460.
-- **The interop DDS bus is pinned to LOOPBACK by the harness, not by a variable you
-  export** (issue 1009) — `FASTRTPS_DEFAULT_PROFILES_FILE` + `CYCLONEDDS_URI` from
-  `nros_tests::ros2::apply_dds_loopback_env`, applied at the CHOKE POINT
-  (`ManagedProcess::spawn_command`) plus every `ros2_env_setup_*` and the XRCE Agent's
-  own `Command`. `ROS_LOCALHOST_ONLY=1` is NOT this and does not work: it reaches ROS
-  processes only, so it isolates one side of a pair and measures **0/15** — the Agent is
-  a bare Fast-DDS app and ignores it. **Pin both sides or neither; half is no discovery**
-  (3/3 both, 3/3 neither, 0/3 one side). `useBuiltinTransports` must stay FALSE —
+- **The interop DDS bus is pinned to LOOPBACK by a profile FILE the harness writes, not
+  by a variable you export** (issue 1009) — `nros_tests::dds_isolation` generates the
+  Fast-DDS / Cyclone profiles into a per-PROCESS dir and hands them out as
+  `FASTRTPS_DEFAULT_PROFILES_FILE` / `CYCLONEDDS_URI`, through
+  `env_exports_for_rmw()` in every `ros2_env_setup_*` and `apply_fastdds_profile()` on
+  the XRCE Agent's own `Command`. `ROS_LOCALHOST_ONLY=1` is NOT this and does not work:
+  it reaches ROS processes only, so it isolates one side of a pair and measures **0/15**
+  with EMPTY output — the Agent is a bare Fast-DDS app and ignores it. **Pin both sides
+  or neither; half is no discovery**, and a whitelist profile on both is 15/15. Never
+  combine the two: a custom `userTransports` profile DEFEATS `ROS_LOCALHOST_ONLY`, which
+  is what confounded the issue's batch E. `useBuiltinTransports` must stay FALSE —
   `userTransports` ADDS to the builtin set, so leaving it true keeps the unrestricted
   transport beside the whitelisted one and isolates nothing while reading as if it does.
   Without the pin a foreign `add_two_ints_server` on ANOTHER HOST failed our XRCE service
-  cell 4 of 15 and cost issue 0741 five wrong diagnoses. Opt out: `NROS_TEST_DDS_ALLOW_LAN=1`.
+  cell 4 of 15 and cost issue 0741 five wrong diagnoses. Opt out: `NROS_DDS_ALLOW_LAN=1`.
 - **Manual native_sim pair repros need distinct `--seed`** — unseeded processes share the test
   entropy source → identical GUIDs/ports → discovery sees the peer as itself → false-negative
   "no delivery". The test harness seeds automatically; hand-run repros must too. → issue 0157

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,6 +701,18 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   eleven slots before the app declares anything, against `ZPICO_MAX_QUERYABLES` = 8 embedded.
   Raise `CONFIG_NROS_MAX_QUERYABLES`; the table is a static array, so the default stays small.
   → issue 0460.
+- **The interop DDS bus is pinned to LOOPBACK by the harness, not by a variable you
+  export** (issue 1009) — `FASTRTPS_DEFAULT_PROFILES_FILE` + `CYCLONEDDS_URI` from
+  `nros_tests::ros2::apply_dds_loopback_env`, applied at the CHOKE POINT
+  (`ManagedProcess::spawn_command`) plus every `ros2_env_setup_*` and the XRCE Agent's
+  own `Command`. `ROS_LOCALHOST_ONLY=1` is NOT this and does not work: it reaches ROS
+  processes only, so it isolates one side of a pair and measures **0/15** — the Agent is
+  a bare Fast-DDS app and ignores it. **Pin both sides or neither; half is no discovery**
+  (3/3 both, 3/3 neither, 0/3 one side). `useBuiltinTransports` must stay FALSE —
+  `userTransports` ADDS to the builtin set, so leaving it true keeps the unrestricted
+  transport beside the whitelisted one and isolates nothing while reading as if it does.
+  Without the pin a foreign `add_two_ints_server` on ANOTHER HOST failed our XRCE service
+  cell 4 of 15 and cost issue 0741 five wrong diagnoses. Opt out: `NROS_TEST_DDS_ALLOW_LAN=1`.
 - **Manual native_sim pair repros need distinct `--seed`** — unseeded processes share the test
   entropy source → identical GUIDs/ports → discovery sees the peer as itself → false-negative
   "no delivery". The test harness seeds automatically; hand-run repros must too. → issue 0157

--- a/docs/issues/1005-zpico-build-constants-outside-staleness-inputs.md
+++ b/docs/issues/1005-zpico-build-constants-outside-staleness-inputs.md
@@ -7,16 +7,16 @@ type: bug
 area: testing, build
 severity: high
 found: 2026-09-03
-related: [issue-0877, issue-0906, issue-0196, issue-0911, phase-414]
+related: [issue-0877, issue-0906, issue-0196, issue-0911, issue-0627, issue-0442, phase-340, phase-363, phase-414]
 ---
 
 ## What happens
 
 The zenoh fixture staleness arm resolves its inputs from the
 `cargo:rerun-if-changed` lines that `zpico-sys`'s build script RECORDED
-(`packages/testing/nros-tests/src/fixtures/binaries/mod.rs:1240-1250`). Dumping
-the recorded set for the FreeRTOS C talker gives 41 entries, and **none of them
-is under `packages/rmw/zenoh/nros-zpico-build/`**.
+(`packages/testing/nros-tests/src/fixtures/binaries/mod.rs`). Dumping the
+recorded set for the FreeRTOS C talker gives 28 in-repo entries, and **none of
+them is under `packages/rmw/zenoh/nros-zpico-build/`**.
 
 That crate is a build-script DEPENDENCY. Cargo tracks it correctly through its
 own unit graph — change it and cargo rebuilds — but it never appears as a
@@ -27,7 +27,7 @@ constant that lives there is outside everything the probe examines.
 
 `Z_TRANSPORT_LEASE_MS = 60_000` at
 `packages/rmw/zenoh/nros-zpico-build/src/lib.rs:289` (issue 0906's fix,
-2026-08-30). Every built FreeRTOS fixture in the tree still bakes the old value:
+2026-08-30). Every built FreeRTOS fixture in the tree still baked the old value:
 
     examples/qemu-arm-freertos/{c,cpp}/*/build-zenoh/cargo/.../zpico-sys-*/out/
         zenoh-config/zenoh_generic_config.h
@@ -35,18 +35,19 @@ constant that lives there is outside everything the probe examines.
 
     examples/qemu-arm-freertos/c/talker/build-zenoh/c_talker   mtime 2026-08-21
 
-Source says 60000. Binaries say 10000. The probe reports FRESH.
+Source said 60000. Binaries said 10000. The probe reported FRESH.
 
 ## Why it matters more than a stale binary
 
 Issue 0906 measured what the old value costs on exactly these images: **19 heard
 of 77** before, **77 of 77** after, because a 10 s lease against a router
-keep-alive on a 30 s cadence expires deterministically. So the probe is reporting
-FRESH on binaries that carry a known, measured, delivery-breaking defect.
+keep-alive on a 30 s cadence expires deterministically. So the probe was
+reporting FRESH on binaries that carry a known, measured, delivery-breaking
+defect.
 
 Found while rediagnosing issue 0877 (phase-414 W1), whose "0 messages received"
 is very likely this: the report is dated one day before 0906's fix, and the
-fixtures on disk have not moved since.
+fixtures on disk had not moved since.
 
 **This is the shape CLAUDE.md already names**: "Build-side stale probes must
 watch the same inputs as test-side gates — a probe that misses `generated/**`
@@ -62,27 +63,6 @@ input class: not a generated tree, but a build-script dependency crate.
 * A STALE verdict is absorbing and loud; a FRESH verdict is silent. This is the
   silent direction, which is the worse one.
 
-## Direction
-
-Not settled, and worth choosing rather than patching the one constant:
-
-1. **Walk the build-script dependency closure.** `zpico-sys`'s build script
-   depends on `nros-zpico-build`; the probe could resolve that from cargo
-   metadata rather than from recorded paths. Closest to correct, and the same
-   answer as `packages/cli/cli-source-dirs.txt` reached for the CLI's own
-   freshness closure (issue 0627) — that one is GENERATED for exactly this
-   reason, after a textual walk was found wrong in both directions.
-2. **Have `nros-zpico-build` emit its own sources as `rerun-if-changed`** from
-   the consuming build script, so the recorded list becomes complete. Cheapest;
-   relies on every future build-script dependency remembering to do it, which is
-   the property that failed here.
-3. **Hash the generated `zenoh_generic_config.h` into the probe's input set.**
-   Watches the OUTPUT rather than the inputs, so it cannot miss an input class —
-   but it only covers what that header carries.
-
-Whichever lands, the acceptance is the case above: change
-`Z_TRANSPORT_LEASE_MS`, do not rebuild, and require the probe to report STALE.
-
 ## Confirmed independently 2026-09-03
 
 A sanctioned `just build freertos` flipped every live FreeRTOS zenoh fixture
@@ -97,58 +77,144 @@ arrives — a build baked at `10000` passes it 6 of 6. So the constant is
 unprotected in BOTH directions: the probe cannot see it change, and the cell
 cannot see it be wrong. Fixing the probe alone leaves the second half open.
 
-## Not covered
+---
 
-Whether other build-script dependency crates feed other fixture families the
-same way. `nros-zpico-build` is the one measured; the class is "a build-script
-dependency crate", and nothing has swept for siblings.
+# Fixed, probe half — 2026-09-04
 
-## Landed 2026-09-04 — the crate declares itself, and it is MEASURED to reach the probe
+## Which direction, and why
 
-`nros_zpico_build::runner::run()` now emits its own sources as an input:
+Direction (1) — **ask cargo for the build closure** — but resolved from what
+cargo already wrote on disk rather than from `cargo metadata` or a generated
+list.
+
+The recorded-path arm answers "what did the build script READ". The missing
+class is "what was the build script COMPILED FROM", and no amount of emitting
+fixes that in general, because the closure is TRANSITIVE: `nros-zpico-build`
+itself build-depends on `nros-cc-flags`, `nros-board-common`,
+`nros-build-paths` and `nros-zephyr-build`, and a constant in any of those has
+the identical defect. Direction (2) would need each consuming build script to
+enumerate a closure a build script cannot compute — `cargo metadata` inside a
+build script takes the package-cache lock cargo is already holding, the exact
+constraint issue 0627 records. Direction (3) watches one generated header and
+nothing else.
+
+Cargo's dep-info for the corrosion staticlib carries the whole thing.
+Measured on `examples/qemu-arm-freertos/c/talker/build-zenoh` (2026-09-04),
+`<group>/<triple>/<profile>/libnros_c.d` lists **236 in-repo inputs**: the
+target-side crates (`packages/core/**`, 65), the C shim the `cc` crate compiled
+(`zpico-sys/c/**`, 14), and the build-script closure —
+`nros-zpico-build/src/lib.rs`, `nros-board-common/src/*`,
+`nros-cc-flags/src/lib.rs`, `nros-build-paths/src/lib.rs`.
+
+So this is phase-363's "ask the tool that owns the graph" one level up, read
+through the same `.d` reader the pure-cargo and Zephyr arms already use. It is
+DERIVED, not authored: nothing enumerates a crate, so a build script that gains
+a dependency tomorrow is covered without anyone remembering. That is why it
+needs no generated list plus a drift gate the way issue 0627's CLI closure did
+— there is no authored artifact here to keep honest.
+
+`deps/*.d` is deliberately NOT read: those name paths relative to the cargo
+invocation's cwd, which is the issue-0696 trap. The staticlib `.d` beside the
+`.a` is absolute and is already their union.
+
+## The self-declaration fix landed separately, and is kept
+
+A narrower fix for the same issue reached `main` first (commit `50819ce`,
+direction 2): `nros_zpico_build::runner::run()` emits its own sources as an
+input,
 
     println!("cargo:rerun-if-changed={}/src", env!("CARGO_MANIFEST_DIR"));
 
-Verified end to end rather than reasoned about — a real `cargo build -p zpico-sys`,
-then reading the file the probe actually reads:
+measured to raise the recorded set from 28 entries to 29, with
+`packages/rmw/zenoh/nros-zpico-build/src` among them. It is emitted from the
+DEPENDENCY rather than from each consumer, so a future consumer inherits it.
 
-    target/debug/build/zpico-sys-e43b33ac44297a9a/output
-      29 rerun-if-changed entries (was 28, none under nros-zpico-build)
-      cargo:rerun-if-changed=<root>/packages/rmw/zenoh/nros-zpico-build/src
+That line is untouched here and stays. It is subsumed by the dep-info arm above
+-- which covers the TRANSITIVE closure the self-declaration cannot reach -- but
+it costs nothing and it keeps the recorded-path arm honest for the one crate it
+names. The dep-info arm is what the acceptance below exercises.
 
-That path is absolute and in-repo, so it survives `zpico_recorded_inputs`'
-canonicalize-and-filter, and `zpico_c_inputs` expands a recorded DIRECTORY
-through `collect_source_files` already.
+## A second defect found on the way, and fixed with it
 
-**Emitted from the DEPENDENCY, not from each consumer** — which is stronger than
-direction 2 as written above. The objection to direction 2 was that it "relies on
-every future build-script dependency remembering to do it". Here the whole
-build-script implementation lives in this crate (`zpico-sys/build.rs` is a
-three-line shim calling `run()`), so a future consumer inherits the declaration
-instead of having to remember it. `env!` binds THIS crate's manifest dir at its
-own compile time, so the path is right whoever calls `run()`.
+`find_build_script_outputs` walked with `DirEntry::file_type()`, which LSTATs.
+Since the phase-340 shared cargo group dir landed, a cross-compiled leaf's
+`build-<rmw>/cargo` is a **symlink** into
+`build/corrosion-cargo/<platform>/<hash>/`, so the walk answered "not a
+directory" and stopped there. Measured 2026-09-04: `zpico_recorded_inputs`
+returned **0 entries** for every FreeRTOS / NuttX / ThreadX fixture (28 once the
+walk STATs instead), so the probe had silently been running the hand-authored
+bootstrap walk that its own doc comment calls unreachable — across the entire
+cross-compiled half of the tree.
 
-Direction 1 (walk the build-script dependency closure from cargo metadata) is
-still the more general answer and is NOT done. This is the cheap half that closes
-the measured defect.
+The bootstrap arm announces itself through `staleness::probe_accounting()`,
+which is rendered only inside a STALE message. On the FRESH path — the
+direction that matters — it said nothing at all. That asymmetry is still open
+(see below).
 
-## Still open after this
+## Acceptance, run 2026-09-04
 
-* **The second gap is untouched.** `test_rtos_pubsub_e2e` FreeRTOS kills its
-  talker after 15 s, so the first lease lapse (~20 s of session life) never
-  arrives and a build baked at `10000` passes 6 of 6. The probe can now see the
-  constant change; the cell still cannot see it be wrong.
-* **The class is unswept.** The rule is "an in-repo build-script dependency
-  crate is an input the recorded path list does not name", and `nros-zpico-build`
-  is the one measured. A sweep of `[build-dependencies]` with a `path =` across
-  the tree finds these other helper crates, none of which declares itself:
+The counterfactual from this issue, on
+`examples/qemu-arm-freertos/c/talker/build-zenoh/c_talker`. The artifact's
+mtime was first advanced so the probe had a clean FRESH baseline (the tree
+carried an unrelated `zpico.c` mtime bump); everything was restored afterwards,
+binary byte-identical.
 
-      nros-board-common     (9 consumers: every freertos/nuttx/threadx board)
-      nros-cc-flags         (5 consumers)
-      nros-build-paths      (4 consumers)
-      nros-zephyr-build     (packages/api/nros)
-      nros-board-threadx-port-riscv64
+    1. constant unchanged                      -> FRESH
+    2. Z_TRANSPORT_LEASE_MS 60_000 -> 45_000,
+       NO rebuild                              -> STALE packages/rmw/zenoh/nros-zpico-build/src/lib.rs
+    3. same edit, cargo arm disabled
+       (pre-fix behaviour)                     -> FRESH
 
-  Whether each MATTERS depends on whether a staleness probe arm reads that
-  consumer's recorded inputs — the zenoh arm does, and the others have not been
-  checked. Not fixed here, and worth doing as one change rather than five.
+Membership, measured on the same fixture: the pre-fix arms walk 1777 candidates
+and `nros-zpico-build/src/lib.rs` is in none of them; the new arm walks 271 and
+it is there.
+
+Regression tests (`packages/testing/nros-tests/src/fixtures/binaries/mod.rs`),
+all hermetic, all verified to FAIL with the fix reverted:
+
+* `a_build_script_dependency_crate_is_a_staleness_input`
+* `the_cmake_probe_consults_the_cargo_input_arm` (the wiring, per issue 0196 —
+  the arm being right does not mean the probe calls it)
+* `the_build_script_record_is_found_across_a_symlinked_cargo_dir`
+
+## Sibling sweep — the class is "a build-script dependency crate"
+
+Measured across all four freshness entry points:
+
+| arm | input source | sees build-script deps? |
+| --- | --- | --- |
+| `require_prebuilt_binary_fresh` / `_row_` | `<binary>.d` | YES — `talker.d` lists `nros-zpico-build/src/{lib,runner}.rs` |
+| `require_prebuilt_binary_fresh_zephyr` | `librustapp.d` | YES — 209 in-repo inputs incl. `nros-zpico-build`, `nros-cc-flags`, `nros-build-paths`, `nros-zephyr-build` |
+| `require_prebuilt_binary_fresh_cmake` | `ninja -t deps` + recorded `rerun-if-changed` | **NO** — this issue |
+
+Cargo folds the build-script closure into the dep-info of any unit it emits
+one for, so the three arms that read a `.d` were never blind. The cmake arm
+read neither, because corrosion is one opaque ninja edge. One affected family,
+and it is the one measured.
+
+The other in-repo build-dependency crates — `nros-board-common`,
+`nros-cc-flags`, `nros-build-paths`, `nros-zephyr-build`,
+`nros-build-helpers`, `nros-board-threadx-port-riscv64` — are consumed by ~20
+crates and are now covered by the same arm, because the fix names none of them.
+
+## Consequence worth stating
+
+A C/C++ cmake fixture now watches the whole Rust closure it links (~140–410
+in-repo files depending on the leaf), not just its C surface. That is correct —
+those sources are IN the binary — and it was silently unwatched before. It also
+means a real edit to a core crate will make every C/C++ cmake fixture report
+STALE. Measured 2026-09-04 across all 101 cmake fixture binaries: at the mtime
+level the pre-existing arms already flagged 101 of 101, so the new arm adds no
+verdict today; the difference it makes is at the CONTENT level, where the
+candidate set is what decides.
+
+## Remaining — this issue stays open
+
+The second half is untouched: `test_rtos_pubsub_e2e` FreeRTOS still cannot
+observe a wrong lease, because it kills its talker before the first lapse. The
+probe can now see the constant change; no cell can see it be wrong.
+
+Also open, found here: `staleness::probe_accounting()` — which carries the
+"INPUT SET UNMEASURED" announcement — is rendered only in a STALE message, so a
+degraded probe is invisible on the FRESH path. That is what let the symlink
+defect run for the whole cross-compiled tree unnoticed.

--- a/docs/issues/1013-pubsub-cell-kills-its-talker-after-12-publishes.md
+++ b/docs/issues/1013-pubsub-cell-kills-its-talker-after-12-publishes.md
@@ -56,8 +56,166 @@ Not settled; the choice is about what the cell is FOR.
 Whichever lands, the acceptance is the counterfactual: build with
 `Z_TRANSPORT_LEASE_MS = 10_000` and require the cell to FAIL.
 
-## Not covered
+## Fixed in the worktree — direction 1, plus a second instrument the counterfactual forced
 
-Whether the same run-to-completion shape is aimed at other free-running
-producers elsewhere in the harness. `wait_for_output` has other callers and they
-have not been swept.
+> Frontmatter deliberately still says `status: open`. The fix and its acceptance
+> are below and were run; what has NOT happened is the integration, and closing
+> an issue here means three edits in ONE commit — flip the status, `git mv` this
+> file to `archived/`, and add its `Recently resolved` row to
+> `docs/issues/README.md` (then `python3 scripts/gen-issue-index.py`).
+> `check-issue-index` enforces exactly that set, and README.md is the shared
+> registry two sessions collide in, so it belongs to whoever integrates.
+
+**Direction 1 (the sibling shape), with direction 2's stated number folded into
+it.** `wait_for_output` is gone from the pub/sub cell. Both nodes now run free
+and the cell waits on a COUNT of delivered samples
+(`RtosProcess::collect_until_count`, backed by a new `QemuProcess::
+collect_until_count` over the existing `collect_until_pred`), killing nothing
+until the count is in — which is exactly why the service and action cells were
+never subject to this.
+
+Direction 3 was not available: nothing else covers session lifetime, which is
+the premise it needs.
+
+### The number: 60 samples, and it is derived
+
+Every talker in the matrix runs a 1 Hz timer, so N samples == N seconds of
+session life.
+
+* `_zp_unicast_lease_task` arms `next_lease = lease`, and the FIRST expiry only
+  consumes the `_received` the handshake set — a session whose peer stays silent
+  closes at **2 x lease**. 0906's 10 s lease lapsed at 19.5 s on the wire.
+* The peer is `rmw_zenohd`, whose shipped config announces `lease: 60000,
+  keep_alive: 2` — an idle router speaks every **30 s**.
+* So `L >= 30 s` holds a session forever and `L < 30 s` closes at `2L < 60 s`.
+
+60 samples is the frontier between those two sets: every client lease that
+cannot hold a session against the ROS router is inside the window, and no lease
+that can hold one is asked to prove more. Cost, measured: 82 s per FreeRTOS cell
+(was ~35 s), 62 s per ThreadX-Linux cell.
+
+**The bound it does not cover, stated:** a defect whose first symptom is past
+60 s of session life — the shipped 60 s lease's own lapse would be at 120 s.
+That wants a soak, not a bigger per-cell budget.
+
+## The counterfactual, and what it changed about this issue
+
+Both halves, FreeRTOS x {rust, c, cpp}, `just build freertos` between them, bake
+verified per rebuild (17 freshly written `zenoh_generic_config.h`, all agreeing):
+
+| build | delivery | router sessions | verdict |
+| --- | --- | --- | --- |
+| `Z_TRANSPORT_LEASE_MS = 60_000` | 60 published / 60 heard | 2 (one per node) | PASS 3/3 |
+| `Z_TRANSPORT_LEASE_MS = 10_000` | **60 published / 60 heard** | **5** | FAIL 3/3 |
+
+**The delivery count does not discriminate, and that is a finding, not a
+detail.** This issue (and 0906's own measurement of 77 published / 19 heard)
+assumed a lapse still costs messages. On this tree it does not: rebuilt with the
+10 s lease, delivery is *perfect* — because the defects that turned a lapse into
+lost samples (issues 0899, 0924, and the board's `LWIP_NETCONN_FULLDUPLEX`) have
+since been fixed. The reopen now completes in ~15 ms, and a 1 Hz publisher
+almost never has a sample in flight during one. A delivery assertion would catch
+that build a few runs in a thousand.
+
+So no window length, at any cost, makes the delivery assertion fail on the build
+this issue names. What the bad build still does — every 2 x lease, exactly as
+0906 measured on the wire — is re-handshake:
+
+    18:30:03  New transport opened ... 676725ea…      <- listener
+    18:30:23  New transport opened ... 676725ea…      <- again, 20 s later
+    18:30:23  New transport opened ... 1d0e5e56…      <- talker
+    18:30:43  New transport opened ... 1d0e5e56…
+    18:31:03  New transport opened ... 676725ea…
+
+That is visible from this side of the link for free: the router's own log. So
+the cell gained a second assertion, `assert_no_session_churn` — **at most 3
+transports opened for two nodes** (measured: exactly 2 on a healthy build, on
+FreeRTOS and ThreadX-Linux, all languages; the third slot is slack for one
+genuine re-open). It is 0906's stated acceptance ("ONE session for at least five
+lease periods, proven by a capture showing no second handshake"), automated from
+the router log instead of a packet capture, and it is the half that fails on the
+bad build.
+
+Two notes on that instrument:
+
+* The marker is `New transport opened`, not `Accepted TCP connection`. A healthy
+  FreeRTOS pair produces THREE accepts and two transports — the first dial is
+  abandoned before the handshake. Sessions are the thing being asserted anyway.
+* The marker is third-party text (RFC-0075: the router is whatever ROS ships), so
+  "fewer than two of these in the log" is a FAILURE naming the constant to fix,
+  never zero reconnects. A rename upstream must not turn this into a cell that
+  silently stopped checking.
+
+## Verified on
+
+* FreeRTOS (QEMU mps2-an385) rust / c / cpp — PASS 3/3 on 60_000, FAIL 3/3 on
+  10_000, both halves re-run against the final code.
+* ThreadX-Linux rust / c / cpp — PASS 3/3, 60/60, 2 sessions, 62 s per cell.
+  This is also the only coverage of `collect_until_count`'s `ManagedProcess`
+  arm.
+* NuttX c / cpp — PASS, 60/60, 2 sessions, 81-84 s per cell: a cold arm-virt
+  boot does fit `pubsub_window`, and its bring-up does not re-dial.
+* NuttX **rust** — could not be run, for a reason that predates this work and
+  has nothing to do with it (see below).
+* ThreadX-RISCV64 — not run; its fixtures were not built here. The bar is
+  protocol-level rather than platform-level, so it should hold, but that is an
+  inference, not a measurement.
+
+## Found on the way, unrelated, NOT fixed here
+
+The NuttX **Rust** rtos_e2e cells cannot resolve their fixtures on a machine
+using the phase-340 shared cargo dirs. `binaries/nuttx.rs::build_rust_example`
+picks the 177.8.c carve-out profile with a LEAF-path probe —
+
+    example_dir.join("target/armv7a-nuttx-eabihf/nros-minsizerel/<bin>").exists()
+
+— but the builder writes into `build/cargo-fixtures/nuttx-<hash>/...` and the
+leaf has no `target/` at all, so that probe is always false. The lane then falls
+back to the ambient profile and reports
+
+    Test fixture binary not prebuilt: .../nros-relwithdebinfo/talker
+
+naming a profile nothing builds, while `.../nros-minsizerel/talker` sits there
+freshly built. The `eprintln!` that explains the fallback is swallowed by
+nextest failure-output settings (issue 0982's shape), so only the misleading
+line survives. This is #393's rule — move the test-side locator in the SAME
+commit as the build — with the probe left behind: `require_prebuilt_binary_fresh`
+was migrated to the shared dir, the `.exists()` above it was not. Reproduced
+after a clean `just nuttx build-fixtures-arm`, so it is not a half-built tree.
+It belongs to whoever owns `fixtures/binaries/`.
+
+## Still open
+
+* **`MAX_ROUTER_SESSIONS` is a count, not a rate.** A lease in the 15-30 s band
+  costs only 1-2 re-opens inside a 60 s window and can sit under the limit.
+  Closing that means asserting the INTERVAL between opens, or a longer window.
+* Issue 1005 is still the other half: the staleness probe does not watch
+  `Z_TRANSPORT_LEASE_MS`, so a leaf can carry an old bake with a FRESH verdict.
+  Every rebuild in this acceptance was verified by reading the generated header,
+  not by trusting the probe.
+
+## Not covered — swept, and it is a class
+
+`wait_for_output` and its five siblings (`ManagedProcess::wait_for_output` /
+`wait_for_all_output`, `Ros2Process`, `Ros2DdsProcess`, `ZephyrProcess`, and
+`RosPeer::wait_for_output` in `src/ros_env.rs`, which carries no doc warning)
+are all run-to-completion-then-kill. Aimed at a free-running node, every one of
+them turns its timeout into that node's lifetime. Sites found, none fixed here:
+
+* `services.rs:212` — the worst: its primary wait greps a string no producer
+  prints, so the 2 s fallback always runs, and the assertion's third disjunct is
+  `!client.is_running()`, which the fallback's own kill makes true. That test
+  **cannot fail**, on any build.
+* `services.rs:101`, `interop_e2e.rs:483`, `native_api.rs:523` — window is the
+  SUT's whole life AND carries the assertion.
+* `ros_editions_e2e.rs:190/209/237`, `zephyr.rs:886/977/1681` — blind-collect at
+  a `spin=forever` node, asserting only the first event; two of them document
+  "the wait always runs the full duration" without drawing the conclusion.
+* `native_async_roundtrip_e2e.rs:99` — asserts a MID-RUN marker, so a client that
+  hangs after goal acceptance is killed at 40 s and reported PASS.
+* `Ros2Process::topic_echo`'s baked `timeout --foreground 10` is the same 10 s
+  horizon one layer down, behind four bridge/interop sites.
+* `ros2.rs:673` `collect_ros2_output` — dead wrapper, no callers.
+
+Each wants the same treatment this cell got: name what the producer must do,
+wait for THAT, and kill only afterwards.

--- a/docs/issues/1026-wait-for-output-aimed-at-free-running-nodes.md
+++ b/docs/issues/1026-wait-for-output-aimed-at-free-running-nodes.md
@@ -1,0 +1,100 @@
+---
+id: 1026
+title: "Six run-to-completion waits are aimed at free-running nodes, turning a
+  timeout into the node's lifetime — and one test cannot fail on any build"
+status: open
+type: bug
+area: testing
+severity: high
+found: 2026-09-04
+related: [issue-1013, issue-0906, phase-414]
+---
+
+## The class
+
+`wait_for_output` and its siblings are RUN-TO-COMPLETION waits — "wait for the
+process to produce output **and exit**". Aimed at a node that never exits, the
+timeout stops being a deadline and becomes **the node's lifetime**: the helper
+kills it when the window closes.
+
+Issue 1013 was one instance, now fixed — `test_rtos_pubsub_e2e` SIGKILLed its
+talker after exactly 12 publishes, which is why a build carrying the pre-0906
+`Z_TRANSPORT_LEASE = 10000` passed it. Six more share the shape. Found while
+fixing 1013; **none of them is fixed**.
+
+Note `RosPeer::wait_for_output` (`src/ros_env.rs:174`) carries no doc warning at
+all, unlike `QemuProcess`'s, so the hazard is invisible at that call site.
+
+## The one that cannot fail — `tests/services.rs:212`
+
+Worst first, and it is worse than a bounded window:
+
+```rust
+let output = client
+    .wait_for_output_pattern("Timed out waiting", Duration::from_secs(12))
+    .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
+    .unwrap_or_default();
+
+assert!(
+    output.contains("Timed out waiting for /add_two_ints service")
+        || output.contains("Service call failed")
+        || !client.is_running(),
+    ...
+);
+```
+
+Three defects compounding:
+
+1. The primary wait greps a string **nothing prints**, so it always times out.
+2. The `or_else` fallback therefore always runs — and `wait_for_all_output`
+   calls `kill_process_group` when ITS window closes (verified in
+   `process.rs`).
+3. The assertion's third disjunct is `!client.is_running()`, and
+   `is_running()` is `matches!(try_wait(), Ok(None))`. The fallback just killed
+   the process, so that disjunct is **true by construction**.
+
+**This test passes on every build, including one where the client never times
+out at all.** It is not caught by `check-no-vacuous-tests`, because that gate
+keys on "a body whose only effects are PRINTS" and this body has a real
+`assert!`. The assertion is simply unfalsifiable.
+
+## The rest
+
+| site | shape |
+| --- | --- |
+| `services.rs:101`, `interop_e2e.rs:483`, `native_api.rs:523` | the window IS the SUT's whole life, and it carries the assertion |
+| `ros_editions_e2e.rs:190/209/237`, `zephyr.rs:886/977/1681` | blind-collect against `spin=forever` nodes asserting only the FIRST event; two even document "always runs the full duration" |
+| `native_async_roundtrip_e2e.rs:99` | asserts a mid-run marker, so a hang AFTER goal acceptance reports PASS |
+| `Ros2Process::topic_echo` | a baked `timeout --foreground 10` — the same horizon one layer down, behind four bridge/interop sites |
+
+`ros2.rs:673 collect_ros2_output` is dead and can go.
+
+## Why it matters beyond tidiness
+
+A bounded window silently bounds what a cell can OBSERVE, and the cell reports
+PASS regardless. Issue 1013 measured the cost concretely: the pubsub cell could
+not see a lease defect that broke delivery in production, because it killed the
+publisher before the lease could lapse. Each site above has its own version of
+that blind spot, and none of them states it.
+
+## Direction
+
+The shared primitive now exists: `QemuProcess::collect_until_count` (added by
+1013), built on `collect_until_pred`. Wait on a COUNT or a predicate, let the
+node run, kill nothing until the condition is met.
+
+1. **`services.rs:212` first, and separately** — it is not a bounded-window
+   problem, it is an unfalsifiable assertion, and it should be fixed even if
+   nothing else here is. Decide what that test is actually for and assert that.
+2. **Migrate the rest to the count/predicate shape**, each with a stated bound
+   for what it can still not see.
+3. **Consider a gate.** `check-no-vacuous-tests` cannot catch an assertion that
+   is merely unfalsifiable; whether that is checkable at all is an open
+   question worth a few minutes before anyone tries.
+
+## Acceptance
+
+For each site: either it waits on a condition rather than a lifetime, or it
+states in a comment what it cannot observe and why that is acceptable.
+`services.rs:212` must be able to FAIL — demonstrated by a mutation, not by
+inspection.

--- a/docs/issues/1027-nuttx-rust-fixture-probes-leaf-not-shared-cargo-dir.md
+++ b/docs/issues/1027-nuttx-rust-fixture-probes-leaf-not-shared-cargo-dir.md
@@ -1,0 +1,111 @@
+---
+id: 1027
+title: "NuttX Rust fixtures resolve at a LEAF `target/` that phase-340 moved, so
+  a freshly built image reports `not prebuilt`"
+status: open
+type: bug
+area: testing, build
+severity: high
+found: 2026-09-04
+related: [issue-0393, issue-0488, phase-340, phase-414]
+---
+
+## What happens
+
+`binaries/nuttx.rs::build_rust_example` probes the carve-out profile at a LEAF
+path:
+
+```rust
+let carve_out = nros_cargo_profile::target_dir(nros_cargo_profile::NUTTX_RUST_PROFILE);
+let release_binary_path = example_dir.join(format!(
+    "target/armv7a-nuttx-eabihf/{}/{}", carve_out, binary_name
+));
+```
+
+Under phase-340's shared cargo dirs that path does not exist. MEASURED on this
+tree, after a clean `just nuttx build-fixtures-arm`:
+
+    examples/qemu-arm-nuttx/rust/talker/target        <- ABSENT
+    build/cargo-fixtures/nuttx-2162892711/armv7a-nuttx-eabihf/
+        nros-minsizerel/talker                        <- freshly built
+
+The probe misses, falls through to the ambient-profile arm, and the cell
+reports `not prebuilt: .../nros-relwithdebinfo/talker` while the real artifact
+sits beside it under a different profile directory.
+
+## Why it is worse than a missing file
+
+The fallback exists to warn about the **phase-177.8.c CGU miscompile** — an
+`lto = "off"` NuttX Rust image reboot-loops before `main` with zero console
+output. So the branch that fires here is the one whose whole job is to say "you
+are about to exercise the known-broken profile". It now fires for a reason that
+has nothing to do with the profile, on a tree where the correct artifact was
+just built. A warning that cries wolf about a real miscompile is worse than no
+warning.
+
+## The class
+
+CLAUDE.md states the rule this broke, in its phase-340 entry:
+
+> Give such a build a row (preferred) or derive its dir from
+> `nros_fixture_target_dir_flag` + `nros_fixture_row_artifact_dir` — **never a
+> literal, and move the test-side locator in the SAME commit** (#393).
+
+The build side moved to the shared group dir; this locator did not. Same shape
+as issue 0393, and a cousin of 0488 (a platform's fixture profile must be read
+through `nros_cargo_platform_profile`, or the probe looks in a second profile
+dir and reports permanent false-STALE).
+
+Two literals are involved and both are suspect: the leaf `target/` prefix, and
+the assumption that the carve-out profile is the one on disk. The artifact
+found here is at `nros-minsizerel`, while the probe's fallback message names
+`nros-relwithdebinfo`.
+
+## Direction
+
+Resolve the path the way the manifest already knows how, rather than
+constructing it:
+
+1. `nros_fixture_row_artifact_dir` / `row_artifact_root()` — the same helper the
+   lane resolver uses to attribute an artifact back to its manifest row. That
+   makes build-set and run-set one predicate on one coordinate file, which is
+   the property #393 was fixed to have.
+2. Read the platform's profile through `nros_cargo_platform_profile` rather than
+   assuming the carve-out, so the 0488 half cannot recur.
+
+Keep the miscompile warning — it is guarding a real defect — but make it fire on
+"the artifact is at the wrong PROFILE", which is what it means, rather than on
+"the artifact is not where I looked".
+
+## Acceptance
+
+After `just nuttx build-fixtures-arm`, the NuttX Rust `rtos_e2e` cells resolve
+their fixtures and run. A deliberately ambient-profile build still triggers the
+miscompile warning.
+
+## The sweep, done — it is a class, not a site
+
+`rg '"target/' packages/testing/nros-tests/src/fixtures/`:
+
+| site | note |
+| --- | --- |
+| `binaries/nuttx.rs:201` | the measured one (carve-out probe) |
+| `binaries/nuttx.rs:227` | the ambient fallback — same leaf prefix, so BOTH arms miss |
+| `binaries/nuttx.rs:308`, `:313` | a second pair, same shape |
+| `binaries/freertos.rs:106` | `target/thumbv7m-none-eabi/{profile}/{bin}` — the same leaf assumption on another platform |
+
+So NuttX has FOUR sites and FreeRTOS one, and fixing only the reported line
+would leave the fallback arm looking in the same wrong place — which is how the
+warning would keep firing for the wrong reason.
+
+FreeRTOS is not currently RED here only because those fixtures happen to build
+into the leaf on this tree; that is a property of which lane last ran, not of the
+locator being right. It should move with the others.
+
+(`cache_key.rs`'s `target/nros-*` paths are a different thing — a scratch dir
+under the project root, not a fixture artifact. Leave them.)
+
+## Not covered
+
+Zephyr and ThreadX locators, which resolve differently (west leaves,
+`librustapp.d`) and were not part of this sweep.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -90,6 +90,8 @@ fails if this block drifts.
 - **#1021** (rmw, third-party) — zenoh-pico 1.8.0 does not compile with `Z_FEATURE_MATCHING=0`: an unguarded call to a MATCHING-only function See `1021-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
+- **#1026** (testing) — Six run-to-completion waits are aimed at free-running nodes, turning a timeout into the node's lifetime — and one test cannot fail on any build See `1026-*`.
+- **#1027** (testing, build) — NuttX Rust fixtures resolve at a LEAF `target/` that phase-340 moved, so a freshly built image reports `not prebuilt` See `1027-*`.
 - **#1028** ([rmw, memory, build]) — NuttX is classified `hosted` because its `target_os` is not `\"none\"`, so it takes the Linux 32-queryable budget: 142,336 B of `.bss` in an image with zero queryables See `1028-*`.
 - **#1034** (testing, tooling) — The provisioned QEMU 11 spends ~19.6 s materialising a NuttX image's `.bss` before the guest runs, and that stall is the whole C-vs-C++ asymmetry in issue 0870 See `1034-*`.
 - **#1038** (ci, build, testing) — nightly triage (phase-413 W2.3): three of six cell failures are one class — the platform job builds a lane whose prerequisites its own setup never installs; none is a product regression See `1038-*`.

--- a/just/check.just
+++ b/just/check.just
@@ -1311,40 +1311,6 @@ reconfigure-on-change:
         exit 0
     fi
     ./tests/cmake-reconfigure-tests.sh
-# phase-403 step 2 -- does the declared `@depth=` REACH A COMPILER?
-#
-# `just check cpp` proves the CHECK: it compiles a TU whose declared depth and
-# passed QoS disagree and asserts the build is rejected, with the topic and both
-# numbers in the diagnostic. It hands the table to the compiler with a `-I` of
-# its own, so it says nothing about DELIVERY.
-#
-# This is the delivery half, and it is the half that goes wrong silently: a
-# component whose generated table never lands on its include path compiles with
-# every declared-depth assertion disabled, and looks exactly like a component
-# whose depths all agree. Six mechanisms in this campaign have been correct and
-# unreachable for precisely that reason.
-#
-# Drives `_nros_emit_declared_qos_header()` in a real configure with the real
-# CLI. Needs cmake, a C compiler and a built `nros` -- and SKIPS rather than
-# passing when any is missing, because a gate that examined nothing must not
-# read as a pass.
-declared-qos-header:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    _missing=""
-    command -v cmake >/dev/null 2>&1 || _missing="$_missing cmake"
-    command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 \
-        || _missing="$_missing cc"
-    _cli="${NROS_CLI:-packages/cli/target/release/nros}"
-    [ -x "$_cli" ] || _missing="$_missing nros(just setup-cli)"
-    if [ -n "$_missing" ]; then
-        # shellcheck source=scripts/build/check-skip.sh
-        source scripts/build/check-skip.sh
-        nros_check_skip declared-qos-header "missing:$_missing"
-        exit 0
-    fi
-    ./tests/cmake-declared-qos-header-tests.sh
-
 abi-bindings:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/just/check.just
+++ b/just/check.just
@@ -276,6 +276,7 @@ fast-serial: \
     subtree-guard \
     sysdep-remedies \
     test-domain-assignment \
+    test-scripts-have-callers \
     tests-can-fail \
     tier-has-ci-owner \
     tier-priority-plan \
@@ -1237,6 +1238,65 @@ entity-inventory-knobs:
 #
 # cmake + ninja only: `project(... NONE)`, no compiler, no nano-ros build, no
 # codegen, ~2 s. Fast line, beside the two readers it protects.
+# Issue 0870's neighbour, found while restoring `declared-qos-header` above: a
+# test script with NO CALLER is a test that runs nowhere, and nothing detected
+# it. `e569d9a55` -- a commit about which Zephyr SDK the CI image bakes --
+# deleted that recipe and its lane entry, its message mentioning neither, and
+# `tests/cmake-declared-qos-header-tests.sh` sat tracked and unreachable for a
+# day while guarding phase-403 step 2's delivery half.
+#
+# The repo's recurring class one level up: a mechanism that is correct and
+# unreachable. Every previous instance (0896, 0963, the flag-only selftest, the
+# NuttX printk arm, `just xrce setup`'s short-circuit) was found by a human
+# noticing, which is not a control.
+#
+# Pure `git ls-files` + line scan, no build, ~0.2 s -- fast line.
+test-scripts-have-callers:
+    python3 scripts/check-test-scripts-have-callers.py
+
+# RESTORED (2026-09-04). This recipe and its fast-lane list entry were deleted
+# by `e569d9a55`, a commit about which Zephyr SDK the CI image bakes, whose
+# message does not mention them -- an accidental loss in a rebase, not a
+# decision. For a day the test script sat tracked with NO caller anywhere in
+# `just/`, `justfile` or `.github/`: a gate that runs nowhere, guarding the
+# delivery half of phase-403 step 2, which had merged hours earlier.
+#
+# `check-test-scripts-have-callers` now catches that class -- it was written
+# from this incident and fires on exactly this state.
+# phase-403 step 2 -- does the declared `@depth=` REACH A COMPILER?
+#
+# `just check cpp` proves the CHECK: it compiles a TU whose declared depth and
+# passed QoS disagree and asserts the build is rejected, with the topic and both
+# numbers in the diagnostic. It hands the table to the compiler with a `-I` of
+# its own, so it says nothing about DELIVERY.
+#
+# This is the delivery half, and it is the half that goes wrong silently: a
+# component whose generated table never lands on its include path compiles with
+# every declared-depth assertion disabled, and looks exactly like a component
+# whose depths all agree. Six mechanisms in this campaign have been correct and
+# unreachable for precisely that reason.
+#
+# Drives `_nros_emit_declared_qos_header()` in a real configure with the real
+# CLI. Needs cmake, a C compiler and a built `nros` -- and SKIPS rather than
+# passing when any is missing, because a gate that examined nothing must not
+# read as a pass.
+declared-qos-header:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    _missing=""
+    command -v cmake >/dev/null 2>&1 || _missing="$_missing cmake"
+    command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 \
+        || _missing="$_missing cc"
+    _cli="${NROS_CLI:-packages/cli/target/release/nros}"
+    [ -x "$_cli" ] || _missing="$_missing nros(just setup-cli)"
+    if [ -n "$_missing" ]; then
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip declared-qos-header "missing:$_missing"
+        exit 0
+    fi
+    ./tests/cmake-declared-qos-header-tests.sh
+
 reconfigure-on-change:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -1149,6 +1149,34 @@ fn cmake_dep_info_newer_source(binary_path: &Path) -> Option<PathBuf> {
     candidates.extend(zpico_candidates);
     let newer = newer.or(zpico_newer);
 
+    // issue 1005 — the arm above asks the BUILD SCRIPT what it READ. That is a
+    // different question from what the build script was COMPILED FROM, and the
+    // second question has no `rerun-if-changed` answer at all: a build-script
+    // DEPENDENCY crate is tracked by cargo through its unit graph, never as a
+    // recorded path. `Z_TRANSPORT_LEASE_MS` lives in `nros-zpico-build`, which
+    // appears in none of the 41 entries `zpico-sys` records, so every FreeRTOS
+    // zenoh fixture read FRESH for ten days while baking a lease value issue
+    // 0906 had measured as delivery-breaking (19 of 77 heard vs 77 of 77).
+    //
+    // Cargo already wrote the complete answer next to the artifact: the
+    // corrosion staticlib's own dep-info (`<profile>/libnros_c.d`), which lists
+    // EVERY rustc input for that unit — the target-side crates, the C shim the
+    // `cc` crate compiled, AND the whole build-script closure
+    // (`nros-zpico-build`, `nros-board-common`, `nros-cc-flags`,
+    // `nros-build-paths`). So this is the same "ask the tool that owns the
+    // graph" move phase-363 made for the `cc` inputs, one level up, read
+    // through the SAME `.d` helper the pure-cargo and Zephyr arms already use.
+    //
+    // Derived, not authored: nothing here enumerates a crate, so a build script
+    // that gains a dependency tomorrow is covered without anyone remembering.
+    // That is what direction (2) in the issue could not promise, and it is why
+    // this needs no generated list + gate the way issue 0627's CLI closure did
+    // — that one had to be authored because `source_stamp.rs` cannot shell
+    // `cargo metadata`; here cargo has already left its resolve on disk.
+    let (cargo_newer, cargo_candidates) = cargo_rust_inputs(build_dir, bin_mtime);
+    candidates.extend(cargo_candidates);
+    let newer = newer.or(cargo_newer);
+
     // issue 0764 — the CONTENT decides, through the same shared helper the
     // cargo dep-info arm (`dep_info_newer_source`) and the zephyr arm already
     // use. Before this, THIS arm compared raw mtimes while the build compared
@@ -1312,7 +1340,17 @@ fn find_build_script_outputs(dir: &Path, prefix: &str, depth: usize) -> Vec<Path
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        // issue 1005 — `is_dir()` (which STATS, following symlinks), never
+        // `entry.file_type()` (which LSTATS). Since the phase-340 shared cargo
+        // group dir landed, a cross-platform leaf's `build-<rmw>/cargo` is a
+        // SYMLINK into `build/corrosion-cargo/<platform>/<hash>/`, so an
+        // lstat-based walk stopped at it and this returned EMPTY for every
+        // FreeRTOS / NuttX / ThreadX fixture. The caller then fell through to
+        // its hand-authored bootstrap walk — the arm whose doc comment says it
+        // should be unreachable for a built fixture, announcing itself via
+        // `note_unmeasured_input_set()`. It had been running for the whole
+        // cross-compiled half of the tree.
+        if !path.is_dir() {
             continue;
         }
         let name = entry.file_name();
@@ -1325,6 +1363,142 @@ fn find_build_script_outputs(dir: &Path, prefix: &str, depth: usize) -> Vec<Path
             continue;
         }
         found.extend(find_build_script_outputs(&path, prefix, depth + 1));
+    }
+    found
+}
+
+/// issue 1005 — the cargo-side input closure of a cmake/corrosion fixture,
+/// read from the dep-info cargo wrote for the staticlib it links.
+///
+/// The Rust half of a C/C++ fixture is one opaque `cargo` custom command as far
+/// as ninja is concerned, so [`cmake_dep_info_newer_source`]'s ninja arm never
+/// sees a single `.rs`. `zpico_c_inputs` closes part of that by replaying what
+/// `zpico-sys`'s build script RECORDED, but a recorded `rerun-if-changed` path
+/// can only ever name what a build script READ — never the crates the build
+/// script itself was COMPILED FROM. That is the class issue 1005 measured:
+/// `nros-zpico-build` is a build-DEPENDENCY, tracked correctly by cargo's unit
+/// graph and absent from every recorded path.
+///
+/// Cargo's own dep-info for the staticlib carries both halves. Measured on
+/// `examples/qemu-arm-freertos/c/talker/build-zenoh` (2026-09-04),
+/// `libnros_c.d` lists 236 in-repo inputs including `packages/core/**` (65),
+/// `zpico-sys/c/**` (14) and the build-script closure
+/// (`nros-zpico-build/src/lib.rs`, `nros-board-common/src/*`,
+/// `nros-cc-flags/src/lib.rs`, `nros-build-paths/src/lib.rs`).
+///
+/// Returns BOTH halves of one resolution — first newer input, and the whole
+/// candidate set to content-hash — for the same reason `zpico_c_inputs` does:
+/// two functions resolving one input set is issue 0442.
+///
+/// Empty when no cargo profile dir is found (a fixture with no Rust half, or a
+/// layout this cannot recognise): "nothing was measured", never "nothing
+/// changed" — and the arms above still apply.
+fn cargo_rust_inputs(
+    build_dir: &Path,
+    bin_mtime: std::time::SystemTime,
+) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let mut newer: Option<PathBuf> = None;
+    for dep_file in cargo_unit_dep_files(build_dir) {
+        // issue 0764's rule, and the reason this does NOT call
+        // `dep_file_newer_than_for`: that helper RETURNS at the first newer
+        // entry, so its `walked` list is truncated there. The ninja arm above
+        // deliberately gathers the WHOLE set before deciding, because the
+        // content helper must be called once with every input — measured here
+        // at 139 of 236 in-repo inputs surviving the early return, with
+        // `nros-zpico-build/src/lib.rs` among the 97 that did not.
+        for dep_path in staleness::dep_file_paths(&dep_file) {
+            if staleness::note_candidate(&dep_path) {
+                continue;
+            }
+            if candidates.contains(&dep_path) {
+                continue; // `libnros_c.d` and `libnros_cpp.d` overlap heavily
+            }
+            if newer.is_none()
+                && let Ok(dep_mtime) = fs::metadata(&dep_path).and_then(|m| m.modified())
+                && dep_mtime > bin_mtime
+            {
+                newer = Some(dep_path.clone());
+            }
+            candidates.push(dep_path);
+        }
+    }
+    (newer, candidates)
+}
+
+/// The per-unit `.d` files cargo left at the top level of each profile dir
+/// under a cmake build dir (`<group>/<triple>/<profile>/libnros_c.d`).
+///
+/// The cargo target dir is a phase-340 group dir — usually a symlink to
+/// `build/corrosion-cargo/<platform>/<hash>/<group>` shared by every leaf of
+/// the family, which is correct here: those leaves link the SAME staticlib, so
+/// they have the same Rust input closure.
+///
+/// Only the top level of a profile dir is read. `deps/*.d` holds one file per
+/// intermediate unit, with paths written RELATIVE to the cargo invocation's
+/// cwd — the shape issue 0696 records as resolving against the nextest CWD and
+/// flagging the wrong file. The staticlib `.d` beside the `.a` is absolute and
+/// is already the union of those units.
+fn cargo_unit_dep_files(build_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for profile in find_cargo_profile_dirs(build_dir, 0) {
+        let Ok(entries) = fs::read_dir(&profile) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("d") && path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// Directories that look like a cargo profile output dir — i.e. that contain a
+/// `deps/` child. Bounded like [`find_build_script_outputs`], and it does not
+/// descend into cargo's own bulk subtrees, so this stays a handful of
+/// `read_dir`s rather than a walk of a cmake tree.
+fn find_cargo_profile_dirs(dir: &Path, depth: usize) -> Vec<PathBuf> {
+    const MAX_DEPTH: usize = 8;
+    let mut found = Vec::new();
+    if depth > MAX_DEPTH {
+        return found;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return found;
+    };
+    let mut children: Vec<PathBuf> = Vec::new();
+    let mut is_profile = false;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Stat, not lstat: `build-<rmw>/cargo` is a symlink to the phase-340
+        // shared group dir on every cross-compiled leaf (see
+        // `find_build_script_outputs`). MAX_DEPTH bounds a symlink cycle.
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name == "deps" {
+            is_profile = true;
+            continue;
+        }
+        // cargo's bulk subtrees and cmake's own: nothing under them is a
+        // profile dir, and `.fingerprint` alone is thousands of entries.
+        if matches!(
+            name.as_ref(),
+            ".fingerprint" | "build" | "incremental" | "examples" | "CMakeFiles" | "_deps"
+        ) {
+            continue;
+        }
+        children.push(path);
+    }
+    if is_profile {
+        found.push(dir.to_path_buf());
+    }
+    for child in children {
+        found.extend(find_cargo_profile_dirs(&child, depth + 1));
     }
     found
 }
@@ -6598,5 +6772,190 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// issue 1005 — a build-script DEPENDENCY crate is an input of a cmake
+    /// fixture, and the probe must be able to see it.
+    ///
+    /// `Z_TRANSPORT_LEASE_MS` lives in `nros-zpico-build`, which `zpico-sys`
+    /// build-depends on. Cargo tracks that through its unit graph and never
+    /// through a `rerun-if-changed` path, so the arm that replays recorded
+    /// paths is blind to it BY CONSTRUCTION — measured on the FreeRTOS C
+    /// talker, whose recorded set names 28 in-repo inputs and none of them
+    /// there. Ten days of FreeRTOS zenoh fixtures therefore read FRESH while
+    /// baking the 10 s lease issue 0906 measured at 19 heard of 77.
+    ///
+    /// Hermetic: a synthetic corrosion layout plus a `.d` in the shape cargo
+    /// writes, so this asserts the search and the parse rather than the state
+    /// of anybody's build tree.
+    #[test]
+    fn a_build_script_dependency_crate_is_a_staleness_input() {
+        let root = project_root();
+        let tmp = root.join("tmp/issue-1005-probe");
+        let _ = fs::remove_dir_all(&tmp);
+
+        // The layout corrosion produces, measured on
+        // `examples/qemu-arm-freertos/c/talker/build-zenoh` (2026-09-04):
+        //   cargo/<pkg>_<hash>/<triple>/<profile>/{deps/,libnros_c.d,libnros_c.a}
+        let profile = tmp.join("cargo/nano-ros_0b88c/thumbv7m-none-eabi/release");
+        fs::create_dir_all(profile.join("deps")).unwrap();
+
+        // The build-script dependency crate that issue 1005 measured.
+        let build_dep = root.join("packages/rmw/zenoh/nros-zpico-build/src/lib.rs");
+        assert!(
+            build_dep.is_file(),
+            "the crate this probes moved; re-point the test, do not delete it"
+        );
+        fs::write(
+            profile.join("libnros_c.d"),
+            format!(
+                "{}: {} /usr/include/stdio.h\n",
+                profile.join("libnros_c.a").display(),
+                build_dep.display(),
+            ),
+        )
+        .unwrap();
+        // `deps/*.d` must NOT be read: those name paths RELATIVE to the cargo
+        // invocation's cwd, and a nextest process resolving one against ITS cwd
+        // is issue 0696 — one wrong file, always the same one. The staticlib
+        // `.d` beside the `.a` is absolute and is already their union.
+        fs::write(
+            profile.join("deps/nros_zpico_build-dead.d"),
+            "x: src/lib.rs\n",
+        )
+        .unwrap();
+
+        let long_ago = std::time::SystemTime::UNIX_EPOCH;
+        let (newer, candidates) = cargo_rust_inputs(&tmp, long_ago);
+        assert_eq!(
+            newer.as_deref(),
+            Some(build_dep.as_path()),
+            "the build-script dependency must be reported: {candidates:?}"
+        );
+        assert!(
+            !candidates
+                .iter()
+                .any(|p| p.ends_with("src/lib.rs") && p.is_relative()),
+            "a relative `deps/*.d` entry must not enter the set (issue 0696): {candidates:?}"
+        );
+
+        // …and this is not a probe that simply always fires.
+        let far_future = std::time::SystemTime::now() + std::time::Duration::from_secs(86_400);
+        assert!(
+            cargo_rust_inputs(&tmp, far_future).0.is_none(),
+            "nothing is newer than a future artifact"
+        );
+
+        // The point of the arm: the RECORDED-path arm cannot express this. Its
+        // set is what a build script READ, never what it was COMPILED FROM.
+        let recorded = zpico_recorded_inputs(&tmp);
+        assert!(
+            !recorded.contains(&build_dep),
+            "if the recorded set ever names it, this test is vacuous"
+        );
+
+        fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    /// issue 1005 — …and the PROBE must actually consult that arm.
+    ///
+    /// The test above drives `cargo_rust_inputs` directly, so it passes with
+    /// the arm unwired. That is the gap this codebase keeps finding in gates
+    /// (issue 0196): the rule is right and the wiring is not checked. So drive
+    /// `cmake_dep_info_newer_source` end to end over a synthetic build dir and
+    /// assert it reports the cargo-side input.
+    ///
+    /// The synthetic input is given a FUTURE mtime and the artifact a present
+    /// one, so every other arm is quiet by construction: `ninja -t deps` has no
+    /// graph to answer from, and the zpico bootstrap walk sees a real
+    /// `zpico-sys/c` tree that is older than the artifact. Whatever this
+    /// reports therefore came from the cargo arm and nowhere else.
+    #[test]
+    fn the_cmake_probe_consults_the_cargo_input_arm() {
+        let root = project_root();
+        let tmp = root.join("tmp/issue-1005-wiring");
+        let _ = fs::remove_dir_all(&tmp);
+        let build_dir = tmp.join("build-zenoh");
+        let profile = build_dir.join("cargo/nano-ros_0b88c/thumbv7m-none-eabi/release");
+        fs::create_dir_all(profile.join("deps")).unwrap();
+        // Present, but unanswerable: `ninja_dep_paths` requires the log to
+        // exist and yields nothing when the query fails.
+        fs::write(build_dir.join(".ninja_deps"), b"").unwrap();
+
+        let input = tmp.join("synthetic_input.rs");
+        fs::write(&input, "// issue 1005 wiring probe\n").unwrap();
+        fs::write(
+            profile.join("libnros_c.d"),
+            format!(
+                "{}: {}\n",
+                profile.join("libnros_c.a").display(),
+                input.display()
+            ),
+        )
+        .unwrap();
+
+        let binary = build_dir.join("c_talker");
+        fs::write(&binary, b"\x7fELF not really\n").unwrap();
+        let day = std::time::Duration::from_secs(86_400);
+        fs::File::options()
+            .write(true)
+            .open(&input)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(std::time::SystemTime::now() + day))
+            .unwrap();
+
+        let verdict = cmake_dep_info_newer_source(&binary);
+        assert_eq!(
+            verdict.as_deref(),
+            Some(input.as_path()),
+            "the cmake probe must reach the cargo dep-info arm; without it the \
+             fixture reports FRESH against an input cargo itself recorded"
+        );
+
+        fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    /// issue 1005, second half — the build-script record lives across a SYMLINK.
+    ///
+    /// Since the phase-340 shared cargo group dir, a cross-compiled leaf's
+    /// `build-<rmw>/cargo` is a symlink into `build/corrosion-cargo/<platform>/
+    /// <hash>/`. `DirEntry::file_type()` LSTATs, so it answers "not a
+    /// directory" for that symlink and the walk stopped dead: measured
+    /// 2026-09-04, `zpico_recorded_inputs` returned 0 entries for every
+    /// FreeRTOS / NuttX / ThreadX fixture, and the probe silently ran the
+    /// hand-authored bootstrap walk that
+    /// `falling_back_to_a_hand_authored_input_set_is_reported` calls
+    /// unreachable. It reported 28 entries once the walk STATted instead.
+    ///
+    /// The fallback announces itself only through `probe_accounting()`, which
+    /// is rendered inside a STALE message — so on the FRESH path, the direction
+    /// that matters, it said nothing at all.
+    #[test]
+    fn the_build_script_record_is_found_across_a_symlinked_cargo_dir() {
+        let root = project_root();
+        let tmp = root.join("tmp/issue-1005-symlink");
+        let _ = fs::remove_dir_all(&tmp);
+
+        let build_dir = tmp.join("build-zenoh");
+        fs::create_dir_all(&build_dir).unwrap();
+        let group = tmp.join("corrosion-cargo/freertos/2e024fb928e1");
+        let bs = group.join("thumbv7m-none-eabi/release/build/zpico-sys-deadbeef");
+        fs::create_dir_all(&bs).unwrap();
+        let in_repo_file = root.join("packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c");
+        fs::write(
+            bs.join("output"),
+            format!("cargo:rerun-if-changed={}\n", in_repo_file.display()),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&group, build_dir.join("cargo")).unwrap();
+
+        let found = zpico_recorded_inputs(&build_dir);
+        assert!(
+            found.contains(&in_repo_file.canonicalize().unwrap()),
+            "the walk must cross the group-dir symlink, or every cross-compiled \
+             fixture silently falls back to the hand-authored input set: {found:?}"
+        );
+
+        fs::remove_dir_all(&tmp).unwrap();
     }
 }

--- a/packages/testing/nros-tests/src/qemu.rs
+++ b/packages/testing/nros-tests/src/qemu.rs
@@ -579,6 +579,33 @@ impl QemuProcess {
         self.collect_until_pred(|out| out.contains(pattern), timeout)
     }
 
+    /// Collect output, stopping early once `pattern` has appeared `expected`
+    /// times — the COUNTING sibling of [`Self::collect_until`], lenient in
+    /// exactly the same way.
+    ///
+    /// This is the wait for a FREE-RUNNING producer, which is the one shape
+    /// [`Self::wait_for_output`] cannot serve: that call is run-to-completion
+    /// (it kills the guest at the deadline), so pointing it at a node with no
+    /// terminal state silently makes the timeout the node's LIFETIME —
+    /// issue 1013, where a 15 s window ended a 1 Hz talker after twelve
+    /// publishes and the cell still reported PASS. A count says what such a
+    /// test actually means: "keep it alive until it has produced this much".
+    ///
+    /// Returns whatever was printed, count reached or not, so the caller can
+    /// assert on the count itself and put the real transcript in its own
+    /// failure message.
+    pub fn collect_until_count(
+        &mut self,
+        pattern: &str,
+        expected: usize,
+        timeout: Duration,
+    ) -> String {
+        match self.collect_until_pred(|out| out.matches(pattern).count() >= expected, timeout) {
+            Ok(out) => out,
+            Err(e) => format!("<no output collected: {e}>"),
+        }
+    }
+
     /// The general form: collect until `done` accepts the accumulated output,
     /// or the deadline passes.
     ///

--- a/packages/testing/nros-tests/tests/rtos_e2e.rs
+++ b/packages/testing/nros-tests/tests/rtos_e2e.rs
@@ -20,7 +20,11 @@ use nros_tests::{
     process::{ManagedProcess, kill_process_group},
 };
 use rstest::rstest;
-use std::{fmt, path::Path, time::Duration};
+use std::{
+    fmt,
+    path::Path,
+    time::{Duration, Instant},
+};
 
 // =============================================================================
 // Parameter enums
@@ -90,6 +94,51 @@ impl RtosProcess {
         match self {
             RtosProcess::Qemu(p) => p.collect_until(pattern, timeout),
             RtosProcess::Managed(p) => p.collect_until(pattern, timeout),
+        }
+    }
+
+    /// Collect output until `pattern` has appeared `expected` times, or the
+    /// deadline passes — the COUNTING sibling of [`Self::collect_until`], and
+    /// lenient the same way: it returns what was printed either way, so the
+    /// caller asserts on the count and reports the real transcript.
+    ///
+    /// Issue 1013 — this is what a wait on a FREE-RUNNING node has to be. The
+    /// pub/sub cell used to end its talker with `wait_for_output`, a
+    /// run-to-completion wait ("wait for QEMU to produce output *and exit*")
+    /// aimed at a node that never exits; the timeout became the talker's
+    /// lifetime instead.
+    fn collect_until_count(&mut self, pattern: &str, expected: usize, timeout: Duration) -> String {
+        match self {
+            RtosProcess::Qemu(p) => p.collect_until_count(pattern, expected, timeout),
+            // `ManagedProcess::collect_until_count` splits an unmet count into
+            // an EMPTY string plus a diagnostic (issue 0670's rule: never let
+            // an assertion match the complaint about its own pattern). Correct
+            // there, wrong here — this call site asserts on the COUNT, so an
+            // empty string would report 0 samples where the process printed 19,
+            // and the number is the whole finding. So build the count wait out
+            // of the single-match wait: each call returns at the next
+            // occurrence, N calls cost N lines, and the accumulated text is the
+            // honest transcript.
+            RtosProcess::Managed(p) => {
+                let deadline = Instant::now() + timeout;
+                let mut out = String::new();
+                while count_pattern(&out, pattern) < expected {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        break;
+                    }
+                    let chunk = p.collect_until(pattern, remaining);
+                    if chunk.is_empty() {
+                        // Nothing read before the deadline, or the process is
+                        // gone. Either way another lap would only spin.
+                        if !p.is_running() {
+                            break;
+                        }
+                    }
+                    out.push_str(&chunk);
+                }
+                out
+            }
         }
     }
 
@@ -601,6 +650,176 @@ fn boot_budget(platform: Platform) -> Duration {
     }
 }
 
+/// How many delivered samples the pub/sub cell requires before it is satisfied.
+///
+/// Every talker example in the matrix runs a **1 Hz** timer (`TimerDuration::
+/// from_millis(1000)` in the Rust ones, `nros_timer_init(..., 1000000000ULL,
+/// ...)` in the C/C++ ones), so this number is also *how many seconds of
+/// SESSION LIFE the cell observes* — the property issue 1013 says a 15 s
+/// run-to-completion window did not have.
+///
+/// **60 is derived, not chosen.** zenoh-pico's client lease task
+/// (`_zp_unicast_lease_task`, `src/transport/unicast/lease.c`) arms
+/// `next_lease = lease` and, at the first expiry, consumes the `_received` flag
+/// the handshake set; only the SECOND expiry with nothing received closes the
+/// session. A session whose peer never speaks therefore dies at **2 x lease** —
+/// issue 0906's 10 s lease lapsed at 19.5 s on the wire, measured.
+///
+/// The peer is `rmw_zenohd`, and its shipped
+/// `DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5` announces `lease: 60000` with
+/// `keep_alive: 2`, i.e. an idle router speaks every **30 s**. zenoh-pico takes
+/// `min(peer_lease, Z_TRANSPORT_LEASE)`. So the lease values split cleanly:
+///
+/// * `L >= 30 s` — the router is heard before the deadline; the session holds
+///   indefinitely. The shipped 60 s is in this set.
+/// * `L < 30 s` — it cannot be heard in time, and the session closes at
+///   `2L < 60 s`. Issue 0906's 10 s is in this set.
+///
+/// 60 samples is exactly the frontier between those two: **every** client-lease
+/// configuration that cannot hold a session against the ROS router fails this
+/// cell, and no configuration that can hold one is asked to prove more than
+/// that. A shorter window would readmit part of the broken half (a 40 s window
+/// passes any `L >= 20 s`); a longer one costs wall clock to prove nothing new
+/// about this class.
+///
+/// **The bound this does NOT cover, stated:** a defect whose first symptom is
+/// beyond 60 s of session life stays invisible here — the shipped 60 s lease's
+/// own lapse would be at 120 s, and a slow leak or a drift that needs minutes
+/// is out of reach of any per-cell window. Nothing in the suite covers that
+/// today; it wants a soak, not a bigger e2e budget.
+const PUBSUB_MIN_SAMPLES: usize = 60;
+
+/// How long the pub/sub cell will wait for [`PUBSUB_MIN_SAMPLES`] samples.
+///
+/// The wait starts when the talker is spawned, so it has to cover that image's
+/// boot, its network wait and its session open BEFORE the first of the 60
+/// seconds of publishing — which is what the old talker window measured at
+/// ">15 s" on QEMU, and NuttX's cold arm-virt boot makes worse. Keyed on
+/// platform for the same reason [`boot_budget`] is: every term in that list is
+/// a property of the emulator and the board, not of the language.
+fn pubsub_window(platform: Platform) -> Duration {
+    match platform {
+        // Cold arm-virt boot + slirp; the pre-1013 cell already gave this
+        // platform 3x the others.
+        Platform::Nuttx => Duration::from_secs(150),
+        // A native process — no emulator, no cold boot to absorb.
+        Platform::ThreadxLinux => Duration::from_secs(90),
+        _ => Duration::from_secs(120),
+    }
+}
+
+/// The zenoh router's per-SESSION DEBUG line, and the only evidence a test on
+/// this side of the link has that a peer re-dialled it.
+///
+/// Deliberately the transport line and not `"Accepted TCP connection"`: a
+/// healthy FreeRTOS pair produces THREE accepts and two sessions, because the
+/// first dial is abandoned before the handshake (measured: accept at t=0.0 with
+/// no transport, then one transport each at t=2.0 and t=22.0). Counting accepts
+/// would have to carry that boot artefact as slack, on every platform, forever.
+/// Sessions are the thing being asserted anyway.
+///
+/// It is third-party text (RFC-0075: the router is whatever ROS ships), so
+/// [`assert_no_session_churn`] treats "not one of these in the whole log" as a
+/// FAILURE rather than as zero reconnects — a rename upstream must show up as a
+/// red naming this constant, never as a cell that silently stops checking.
+const ROUTER_SESSION_MARKER: &str = "New transport opened";
+
+/// Router log filter for [`ROUTER_SESSION_MARKER`]. Scoped to the crate that
+/// emits it — a whole-router `debug` writes ~46 KB per cell to say the same
+/// thing.
+const ROUTER_SESSION_LOG_FILTER: &str = "zenoh_transport=debug";
+
+/// How many sessions the router may open during one pub/sub cell.
+///
+/// TWO is the invariant — one per node, held for the whole run. Measured on the
+/// shipped 60 s lease: exactly 2, on all three FreeRTOS languages, every run.
+/// The third slot is slack for ONE genuine re-open (a link that drops once, a
+/// platform whose bring-up re-dials); a lapse on a TIMER cannot hide under it,
+/// because a lease of `L` costs one re-open per node per `2L` and issue 0906's
+/// 10 s lease measured FIVE in this cell's window.
+const MAX_ROUTER_SESSIONS: usize = 3;
+
+/// Turn on the router's accept log for this test process.
+///
+/// SAFETY / why an env var: `ZenohRouter` reads `ZENOHD_LOG` when it SPAWNS the
+/// router, and there is no per-call switch. nextest runs each case as its own
+/// process, so this write happens once, before this cell's router exists and
+/// before any thread that could read the environment concurrently. An operator
+/// value is left alone — `ZENOHD_LOG=trace` is someone debugging, and its log
+/// is a superset of what this needs.
+fn enable_router_session_log() {
+    if std::env::var_os("ZENOHD_LOG").is_none() {
+        // SAFETY: single-threaded, once, at the top of the test.
+        unsafe { std::env::set_var("ZENOHD_LOG", ROUTER_SESSION_LOG_FILTER) };
+    }
+}
+
+/// The pub/sub cell's SECOND question: did the two nodes hold ONE session each,
+/// or did they re-dial the router on a timer?
+///
+/// Issue 1013 asked for a delivery window long enough to see issue 0906's 10 s
+/// `Z_TRANSPORT_LEASE` fail. Measured on this tree, a 60 s delivery window does
+/// NOT see it: rebuilt with the 10 s lease, FreeRTOS delivered **60 published /
+/// 60 heard** on all three languages. The defects that turned a lapse into lost
+/// messages (issues 0899, 0924, and the board's `LWIP_NETCONN_FULLDUPLEX`) have
+/// since been fixed, so the reopen now completes in ~15 ms and a 1 Hz publisher
+/// almost never has a sample in flight during one. "Almost never" is the whole
+/// problem: a delivery assertion would catch that build a few runs in a
+/// thousand, which is worse than not claiming to catch it.
+///
+/// What that build still does is re-handshake every `2 x lease`, exactly as 0906
+/// measured on the wire — and the router logs each one. So this is 0906's own
+/// acceptance ("ONE session for at least five lease periods, proven by a capture
+/// showing no second handshake"), automated from the router's own log instead of
+/// a packet capture. It is the half that actually fails on that build: **5
+/// sessions against a limit of 3, 3 languages out of 3**, while delivery reads
+/// perfect.
+fn assert_no_session_churn(platform: Platform, lang: Lang, port: u16, window: Duration) {
+    let log_path = nros_tests::fixtures::fixture_log_path(&format!("zenohd-{port}"));
+    let log = std::fs::read_to_string(&log_path).unwrap_or_else(|e| {
+        panic!(
+            "{platform} {lang} pubsub E2E: cannot read the router log at {} ({e}).\n\
+             This cell asserts on it, so an unreadable log is a failure, not a pass. \
+             `enable_router_session_log` sets ZENOHD_LOG before the router starts; \
+             if that no longer reaches `ZenohRouter`, this is where it shows.",
+            log_path.display()
+        )
+    });
+    let sessions = count_pattern(&log, ROUTER_SESSION_MARKER);
+    eprintln!(
+        "[{} {}] router sessions opened: {} (max {})",
+        platform, lang, sessions, MAX_ROUTER_SESSIONS
+    );
+    assert!(
+        sessions >= 2,
+        "{platform} {lang} pubsub E2E: the router log records fewer than two \
+         `{ROUTER_SESSION_MARKER}` lines, yet both nodes demonstrably talked to it — so \
+         this cell's session-churn check just measured nothing.\n\
+         That line is third-party text (RFC-0075: the router is whatever ROS ships). \
+         Either the filter `{ROUTER_SESSION_LOG_FILTER}` no longer selects it or this \
+         zenoh renamed it; fix ROUTER_SESSION_MARKER / ROUTER_SESSION_LOG_FILTER in this \
+         file. Log: {}",
+        log_path.display(),
+    );
+    assert!(
+        sessions <= MAX_ROUTER_SESSIONS,
+        "{platform} {lang} pubsub E2E: the router opened {sessions} sessions in {window:?} \
+         for TWO nodes — they are re-dialling on a timer, not holding one session each.\n\
+         That is issue 0906's signature: zenoh-pico closes a session after 2 x \
+         `Z_TRANSPORT_LEASE` of silence, and `rmw_zenohd` speaks only every 30 s \
+         (`lease: 60000, keep_alive: 2`), so any client lease under 30 s lapses \
+         deterministically. Note delivery can look PERFECT while this fails — the reopen \
+         is fast now, which is exactly why the count is what this asserts on. Check \
+         `Z_TRANSPORT_LEASE_MS` in `packages/rmw/zenoh/nros-zpico-build/src/lib.rs` \
+         (60_000) and what the leaf actually BAKED — issue 1005: the staleness probe does \
+         not watch that constant, so a stale image can carry an old value. Sessions:\n{}",
+        log.lines()
+            .filter(|l| l.contains(ROUTER_SESSION_MARKER))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+}
+
 fn ensure_ready(output: &str, readiness_pattern: &str, platform: Platform) {
     if output.contains(readiness_pattern) {
         return;
@@ -637,8 +856,15 @@ fn ensure_ready(output: &str, readiness_pattern: &str, platform: Platform) {
 
 /// End-to-end pub/sub across Rust, C, and C++ on all four RTOS
 /// platforms. First node is the talker; second node is the listener.
-/// We wait for the listener to reach "Waiting for messages" before
-/// killing both, and assert that at least one "Received" line appeared.
+///
+/// We wait for the listener's readiness banner, then let BOTH nodes run until
+/// the listener has heard [`PUBSUB_MIN_SAMPLES`] samples — 60 at 1 Hz, so 60
+/// seconds of session life, the number derived at that constant. Neither node
+/// is killed before the count is in.
+///
+/// The old shape asserted `received > 0` after killing the talker at 15 s
+/// (issue 1013): it proved a sample could be delivered, never that the session
+/// survived long enough to keep delivering them.
 #[rstest]
 fn test_rtos_pubsub_e2e(
     #[values(
@@ -656,7 +882,12 @@ fn test_rtos_pubsub_e2e(
 
     let (talker_bin, listener_bin) = build_pair(platform, lang, Variant::Pubsub);
 
-    let _zenohd = platform
+    // Ask the router to record its TCP accepts BEFORE starting it — that log is
+    // this cell's only window onto session CONTINUITY (see
+    // `assert_no_session_churn`), and `ZenohRouter` decides whether to keep one
+    // at spawn time.
+    enable_router_session_log();
+    let zenohd = platform
         .zenoh_router_start(Variant::Pubsub, lang)
         .expect("Failed to start zenohd");
 
@@ -718,29 +949,50 @@ fn test_rtos_pubsub_e2e(
     let listener_boot = listener.collect_until(ready_marker, boot_budget(platform));
     ensure_ready(&listener_boot, ready_marker, platform);
 
-    // Let the talker run a bit and drain its output to avoid pipe back-pressure.
-    // NuttX C needs a longer window: cold QEMU boot + 5s app sleep + session
-    // open can eat >15 s before the first publish, and parallel retries from
-    // earlier flaky tests load the host further.
-    let talker_window = match platform {
-        Platform::Nuttx => Duration::from_secs(45),
-        _ => Duration::from_secs(15),
-    };
-    let talker_out = talker.wait_for_output(talker_window).unwrap_or_default();
-
-    // Phase 182.6 — early-exit on the first delivered sample instead of
-    // blind-collecting for the whole window. `wait_for_output_pattern` returns
-    // as soon as "Received" appears (typically a few seconds) yet still waits up
-    // to `listener_window` before giving up, so it both de-flakes (less host
-    // saturation from tests that used to burn the full 30 s / 90 s every run)
-    // and keeps the same failure deadline. The assert only needs ≥1 sample.
-    let listener_window = match platform {
-        Platform::Nuttx => Duration::from_secs(90),
-        _ => Duration::from_secs(30),
-    };
-    let final_out =
-        listener.collect_until(nros_tests::output::LISTENER_LOG_PREFIX, listener_window);
+    // ⚠️ The talker is FREE-RUNNING and nothing here may cut it short. ⚠️
+    //
+    // Issue 1013 — what stood here was
+    //
+    //     let talker_out = talker.wait_for_output(15s).unwrap_or_default();
+    //
+    // and `wait_for_output` is a RUN-TO-COMPLETION wait: its own doc says "wait
+    // for QEMU to produce output *and exit*", and at the deadline it
+    // `kill_process_group`s the guest. Pointed at a 1 Hz publisher — a node
+    // with no terminal state — the timeout silently became the talker's
+    // LIFETIME. Measured: exactly 12 publishes, every run, all three languages,
+    // whole cell in ~35 s. The assertion below was `received > 0`, so every
+    // defect whose first symptom lands after the twelfth publish was invisible
+    // AND the cell said PASS: a build carrying issue 0906's 10 s
+    // `Z_TRANSPORT_LEASE` — a session that provably dies at ~20 s — passed it
+    // 6 runs out of 6.
+    //
+    // The service and action cells never had this: they let the long-lived
+    // server run and wait on the CLIENT's terminal line. Pub/sub has no
+    // terminal line, so the wait is on a COUNT of delivered samples, and the
+    // talker is killed only after the count is in.
+    //
+    // Both processes now run undrained for the length of the wait. That is
+    // sound at these volumes and not by luck: an mps2 talker prints its boot
+    // banner plus one ~40-byte line per second, so a 90 s wait leaves single-
+    // digit kilobytes against a 64 KiB pipe buffer. A node that logs per-sample
+    // at any real rate would need this drained in slices.
+    let listener_window = pubsub_window(platform);
+    let already_heard = count_pattern(&listener_boot, nros_tests::output::LISTENER_LOG_PREFIX);
+    let final_out = listener.collect_until_count(
+        nros_tests::output::LISTENER_LOG_PREFIX,
+        PUBSUB_MIN_SAMPLES.saturating_sub(already_heard),
+        listener_window,
+    );
     let full_listener = format!("{}{}", listener_boot, final_out);
+
+    // The talker has been publishing the whole time; scrape its transcript for
+    // the log now that the listener's count is in. Bounded and NON-killing (the
+    // kill is two lines down either way) — this is a read, not a wait.
+    let talker_out = talker.collect_until_count(
+        nros_tests::output::TALKER_PAYLOAD_PREFIX,
+        PUBSUB_MIN_SAMPLES,
+        Duration::from_secs(5),
+    );
 
     talker.kill();
     listener.kill();
@@ -748,14 +1000,39 @@ fn test_rtos_pubsub_e2e(
     eprintln!("Talker output:\n{}", talker_out);
     eprintln!("Listener output:\n{}", full_listener);
 
+    // TALKER_PAYLOAD_PREFIX, not TALKER_LOG_PREFIX: only the opening payload
+    // quote separates a real publish line from setup prose containing the word
+    // "Publishing" (phase-295 W2).
+    let published = count_pattern(&talker_out, nros_tests::output::TALKER_PAYLOAD_PREFIX);
     let received = count_pattern(&full_listener, nros_tests::output::LISTENER_LOG_PREFIX);
-    eprintln!("[{} {}] messages received: {}", platform, lang, received);
-    assert!(
-        received > 0,
-        "{} {} pubsub E2E failed — 0 messages received",
-        platform,
-        lang
+    // Published vs heard is the shape issue 0906 was measured in ("77
+    // published, 19 heard"), so print both: a shortfall says the session
+    // stopped delivering, not that the talker stopped publishing.
+    eprintln!(
+        "[{} {}] messages published: {}, received: {} (need {})",
+        platform, lang, published, received, PUBSUB_MIN_SAMPLES
     );
+    assert!(
+        received >= PUBSUB_MIN_SAMPLES,
+        "{} {} pubsub E2E failed — heard {} of the {} samples this cell requires \
+         (talker printed {} publish lines) within {:?}.\n\
+         {} samples at 1 Hz is {} SECONDS of session life: a shortfall means \
+         delivery stopped part-way, which is what a session that expires looks \
+         like from here (issue 0906/1013). Listener output:\n{}",
+        platform,
+        lang,
+        received,
+        PUBSUB_MIN_SAMPLES,
+        published,
+        listener_window,
+        PUBSUB_MIN_SAMPLES,
+        PUBSUB_MIN_SAMPLES,
+        full_listener,
+    );
+    // Delivery is only half of it — see this function's header for why a build
+    // that lapses every 20 s can still deliver 60 of 60.
+    assert_no_session_churn(platform, lang, zenohd.port(), listener_window);
+
     eprintln!(
         "[PASS] {} {} pubsub E2E: {} messages",
         platform, lang, received

--- a/scripts/check-test-scripts-have-callers.py
+++ b/scripts/check-test-scripts-have-callers.py
@@ -48,34 +48,44 @@ CALLER_FILES = ["justfile"]
 def _files_under(root):
     """TRACKED files in the caller roots.
 
-    `git ls-files`, not `os.walk`, and the reason is measured: `scripts/`
-    carries 7.8 GB across 60,533 files of build output on a working tree, and
-    walking it read-line-by-line hangs this gate for minutes. The first version
-    used `grep -rl`, which was fast only because it is C and short-circuits.
+    `git ls-files`, not `os.walk`, and there is NO walk fallback -- the repo
+    has a gate against exactly that (`check-no-tracked-file-find`), which
+    measured 7m36s -> 0.8s for the same 232 paths and notes that pruning does
+    not help because find still stats every directory it considers pruning. The
+    first version of this file walked `scripts/`, which carries 7.8 GB across
+    60,533 files of build output on a working tree, and hung for minutes.
 
-    Tracked-only is also the correct SEMANTIC rather than just the fast one: a
-    caller that is not committed cannot run the script for anybody else.
+    Tracked-only is also the correct SEMANTIC rather than merely the fast one:
+    a caller that is not committed cannot run the script for anybody else.
     """
     r = subprocess.run(
         ["git", "-C", root, "ls-files", "--"] + CALLER_DIRS + CALLER_FILES,
         capture_output=True, text=True, check=False,
     )
-    if r.returncode == 0:
-        for rel in r.stdout.splitlines():
-            if rel.strip():
-                yield os.path.join(root, rel)
-        return
-    # Not a git tree (the self-test's tmpdir is one such): fall back to a walk,
-    # which is safe there because the fixture is three files.
-    targets = [os.path.join(root, d) for d in CALLER_DIRS]
-    targets += [os.path.join(root, f) for f in CALLER_FILES]
-    for t in targets:
-        if os.path.isfile(t):
-            yield t
-        elif os.path.isdir(t):
-            for dirpath, _dirs, files in os.walk(t):
-                for fn in files:
-                    yield os.path.join(dirpath, fn)
+    if r.returncode != 0:
+        raise SystemExit(
+            f"check-test-scripts-have-callers: `git ls-files` failed in {root}.\n"
+            f"  {r.stderr.strip()}\n"
+            "  This gate reads the INDEX on purpose and has no filesystem-walk\n"
+            "  fallback -- see `check-no-tracked-file-find`, and the 7m36s -> 0.8s\n"
+            "  it measured. The self-test builds a real git tree for the same\n"
+            "  reason."
+        )
+    me = os.path.relpath(os.path.abspath(__file__), ROOT)
+    for rel in r.stdout.splitlines():
+        rel = rel.strip()
+        if not rel:
+            continue
+        # THIS FILE IS NEVER A CALLER. It names the scripts it reports on -- in
+        # the failure message below, on a non-comment line -- so without this it
+        # is its own caller and can never report anything. That is the second
+        # time this gate defeated itself with its own prose: the first was
+        # counting comments, caught by the mutation test; this one was caught by
+        # the same test after the comment fix, which is the argument for keeping
+        # a mutation test rather than trusting a green.
+        if rel == me:
+            continue
+        yield os.path.join(root, rel)
 
 
 def callers_of(name, root):
@@ -130,7 +140,18 @@ def self_test(quiet=False):
     Runs on the NORMAL path, not behind a flag -- a control nobody runs decays
     into a comment, and `check-gate-selftests` holds this file to that.
     """
+    def git(tmp, *args):
+        subprocess.run(["git", "-C", tmp, *args], check=True,
+                       capture_output=True, text=True)
+
+    def stage(tmp):
+        """`git ls-files` reads the INDEX, so the fixture has to be staged."""
+        git(tmp, "add", "-A")
+
     with tempfile.TemporaryDirectory() as tmp:
+        # A real git tree, because the gate reads the index and deliberately has
+        # no walk fallback. Cheap: three files.
+        git(tmp, "init", "-q")
         os.makedirs(os.path.join(tmp, "tests"))
         os.makedirs(os.path.join(tmp, "just"))
         called = os.path.join(tmp, "tests", "called-tests.sh")
@@ -140,6 +161,7 @@ def self_test(quiet=False):
         open(os.path.join(tmp, "just", "check.just"), "w").write(
             "a-gate:\n    ./tests/called-tests.sh\n"
         )
+        stage(tmp)
 
         stranded, checked = scan(tmp)
         assert checked == 2, f"expected to check 2 scripts, checked {checked}"
@@ -152,6 +174,7 @@ def self_test(quiet=False):
         open(os.path.join(tmp, "just", "check.just"), "a").write(
             "# orphan-tests.sh is mentioned here in prose only\n"
         )
+        stage(tmp)
         stranded, _ = scan(tmp)
         assert stranded == ["orphan-tests.sh"], \
             f"a comment mentioning a script must not count as a caller; got {stranded}"
@@ -160,6 +183,7 @@ def self_test(quiet=False):
         open(os.path.join(tmp, "just", "check.just"), "a").write(
             "another:\n    ./tests/orphan-tests.sh\n"
         )
+        stage(tmp)
         stranded, _ = scan(tmp)
         assert stranded == [], f"an invoked script must not be reported; got {stranded}"
 

--- a/scripts/check-test-scripts-have-callers.py
+++ b/scripts/check-test-scripts-have-callers.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""A test script with no caller is a test that runs nowhere.
+
+WHY THIS EXISTS. On 2026-09-03, `e569d9a55` -- a commit about which Zephyr SDK
+the CI image bakes -- deleted the `declared-qos-header` recipe and its fast-lane
+entry from `just/check.just`. Its message says nothing about either; it was an
+accidental loss in a rebase. `tests/cmake-declared-qos-header-tests.sh` then sat
+TRACKED, passing, and reachable by nobody, guarding the delivery half of
+phase-403 step 2 which had merged hours earlier.
+
+Nothing caught it. Every gate we have asks whether some rule holds in the code;
+none asks whether a test still has a way to run. A stranded script is invisible
+in the worst possible way -- it looks exactly like a test that passes, because
+running it by hand still passes.
+
+This is the repo's own recurring class one level up: a mechanism that is correct
+and unreachable. The instances so far -- `rx_buffer_hint` sizing nothing (0896),
+the bound inventory with no reader (0963), the knob-delivery selftest behind a
+flag, the NuttX `printk` arm, `just xrce setup`'s short-circuit -- were each
+found by a human noticing, which is not a control.
+
+WHAT IT CHECKS. Every `tests/*.sh` must be INVOKED -- named on a non-comment
+line -- by a justfile, a CI workflow, or another script. Comments do not count;
+see `callers_of` for why that is the whole gate rather than a detail.
+
+Still deliberately weak in one way, and worth knowing: being invoked from a
+recipe is not the same as that recipe being REACHED, so a script called only by
+a recipe nobody runs still passes here. `check-lane-contracts` and
+`check-gate-selftests` cover other parts of the same question. A weak check that
+runs beats a strong one nobody wrote.
+
+Exit 0 when every script has a caller, 1 otherwise.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Where a caller may live. A script named ONLY inside `tests/` does not count:
+# tests calling each other is not a route from CI or from a developer's `just`.
+CALLER_DIRS = ["just", ".github", "scripts"]
+CALLER_FILES = ["justfile"]
+
+
+def _files_under(root):
+    """TRACKED files in the caller roots.
+
+    `git ls-files`, not `os.walk`, and the reason is measured: `scripts/`
+    carries 7.8 GB across 60,533 files of build output on a working tree, and
+    walking it read-line-by-line hangs this gate for minutes. The first version
+    used `grep -rl`, which was fast only because it is C and short-circuits.
+
+    Tracked-only is also the correct SEMANTIC rather than just the fast one: a
+    caller that is not committed cannot run the script for anybody else.
+    """
+    r = subprocess.run(
+        ["git", "-C", root, "ls-files", "--"] + CALLER_DIRS + CALLER_FILES,
+        capture_output=True, text=True, check=False,
+    )
+    if r.returncode == 0:
+        for rel in r.stdout.splitlines():
+            if rel.strip():
+                yield os.path.join(root, rel)
+        return
+    # Not a git tree (the self-test's tmpdir is one such): fall back to a walk,
+    # which is safe there because the fixture is three files.
+    targets = [os.path.join(root, d) for d in CALLER_DIRS]
+    targets += [os.path.join(root, f) for f in CALLER_FILES]
+    for t in targets:
+        if os.path.isfile(t):
+            yield t
+        elif os.path.isdir(t):
+            for dirpath, _dirs, files in os.walk(t):
+                for fn in files:
+                    yield os.path.join(dirpath, fn)
+
+
+def callers_of(name, root):
+    """Files that name `name` on a line that is NOT a comment.
+
+    COMMENTS DO NOT COUNT, and that distinction is the whole gate. The first
+    version of this file matched any mention, and its own mutation test proved
+    it useless: the restored recipe's comment names the script, and so does THIS
+    file's docstring -- so `cmake-declared-qos-header-tests.sh` would have had a
+    permanent "caller" made entirely of prose about it being uncalled. A gate
+    that its own explanation satisfies is not a gate.
+
+    Line-based and deliberately crude: a `#`-leading line is a comment in every
+    language in the caller roots (just, bash, YAML, Python). A trailing comment
+    on a real command line still counts as a caller, which is correct -- the
+    command is there.
+    """
+    hits = []
+    for path in _files_under(root):
+        try:
+            with open(path, encoding="utf8", errors="replace") as fh:
+                for line in fh:
+                    if name not in line:
+                        continue
+                    if line.lstrip().startswith("#"):
+                        continue
+                    hits.append(path)
+                    break
+        except OSError:
+            continue
+    return hits
+
+
+def scan(root):
+    """(stranded, checked) for `tests/*.sh` under `root`."""
+    tests_dir = os.path.join(root, "tests")
+    if not os.path.isdir(tests_dir):
+        return [], 0
+    stranded, checked = [], 0
+    for fn in sorted(os.listdir(tests_dir)):
+        if not fn.endswith(".sh"):
+            continue
+        checked += 1
+        if not callers_of(fn, root):
+            stranded.append(fn)
+    return stranded, checked
+
+
+def self_test(quiet=False):
+    """Negative control: the rule must FIRE on a stranded script.
+
+    Runs on the NORMAL path, not behind a flag -- a control nobody runs decays
+    into a comment, and `check-gate-selftests` holds this file to that.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        os.makedirs(os.path.join(tmp, "tests"))
+        os.makedirs(os.path.join(tmp, "just"))
+        called = os.path.join(tmp, "tests", "called-tests.sh")
+        orphan = os.path.join(tmp, "tests", "orphan-tests.sh")
+        open(called, "w").write("#!/bin/sh\n")
+        open(orphan, "w").write("#!/bin/sh\n")
+        open(os.path.join(tmp, "just", "check.just"), "w").write(
+            "a-gate:\n    ./tests/called-tests.sh\n"
+        )
+
+        stranded, checked = scan(tmp)
+        assert checked == 2, f"expected to check 2 scripts, checked {checked}"
+        assert stranded == ["orphan-tests.sh"], \
+            f"the rule must name the uncalled script and only it; got {stranded}"
+
+        # A COMMENT naming it must NOT silence the rule. This case is the one
+        # that matters: the first version of this gate failed it, and failed it
+        # against its own docstring.
+        open(os.path.join(tmp, "just", "check.just"), "a").write(
+            "# orphan-tests.sh is mentioned here in prose only\n"
+        )
+        stranded, _ = scan(tmp)
+        assert stranded == ["orphan-tests.sh"], \
+            f"a comment mentioning a script must not count as a caller; got {stranded}"
+
+        # And the intended escape: actually INVOKING it silences the rule.
+        open(os.path.join(tmp, "just", "check.just"), "a").write(
+            "another:\n    ./tests/orphan-tests.sh\n"
+        )
+        stranded, _ = scan(tmp)
+        assert stranded == [], f"an invoked script must not be reported; got {stranded}"
+
+    if not quiet:
+        print("check-test-scripts-have-callers self-test: OK")
+    return 0
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    # Always, not only behind the flag. See `scripts/check-board-tiers.py`.
+    rc = self_test(quiet=True)
+    if rc:
+        return rc
+
+    stranded, checked = scan(ROOT)
+    if stranded:
+        print("check-test-scripts-have-callers: test script(s) nothing can run:")
+        for fn in stranded:
+            print(f"  - tests/{fn}")
+        print(
+            "\n  Nothing in just/, justfile, .github/ or scripts/ names these.\n"
+            "  A tracked test with no caller reads exactly like a passing test,\n"
+            "  because running it by hand still passes -- which is how\n"
+            "  `cmake-declared-qos-header-tests.sh` sat unreachable for a day\n"
+            "  after a rebase dropped its recipe (2026-09-04).\n"
+            "\n  Give it a recipe, or delete it if it is genuinely obsolete."
+        )
+        return 1
+    print(f"check-test-scripts-have-callers: OK ({checked} script(s), all reachable)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
The four issues phase-414 spun out, plus a stranded gate found while fixing them. Seven commits.

| | |
| --- | --- |
| **#1005** | staleness probe blind to the build-script closure — **fixed** |
| **#1009** | interop bus not isolated from the LAN — **fixed** |
| **#1013** | pubsub cell kills its talker after 12 publishes — **fixed** |
| `declared-qos-header` | stranded gate — **restored**, plus a gate for the class |
| **#1026, #1027** | two defects found en route — **filed** |

## #1013 — the counterfactual changed the issue

This is the one worth reading. Measured on FreeRTOS × {rust, c, cpp}, rebuilt between halves, bake verified per rebuild:

| build | delivery | router sessions | verdict |
| --- | --- | ---: | --- |
| `60_000` | 60 published / 60 heard | 2 | **PASS 3/3** |
| `10_000` | **60 published / 60 heard** | **5** | **FAIL 3/3** |

**A delivery count alone cannot fail on the bad build.** The issue's own premise — and 0906's "77 published, 19 heard" — no longer holds: rebuilt at 10 s, delivery is *perfect*, because the defects that turned a lapse into lost samples (0899, 0924, `LWIP_NETCONN_FULLDUPLEX`) have since been fixed. The reopen takes ~15 ms now. No window length fixes that.

What the bad build still does every 2 × lease is **re-handshake**, and the router logs it. So the cell asserts session continuity: at most 3 transports for two nodes. That is 0906's own acceptance automated from the router log instead of a packet capture — and it is the half that fails.

The window is derived, not guessed: 60 samples = 60 s, the frontier where `L ≥ 30 s` holds forever and `L < 30 s` closes at `2L`.

## #1009 — the bus is pinned by the harness, not by a variable

On poisoned domain 1 with the foreign squatter live, `--retries 0`: **11/4 before → 15/0 after**. The `28 bytes … 15 bytes` error appears in 0 of 30 post-fix logs.

Two non-obvious halves, both encoded as tests: `useBuiltinTransports` must be **false** (`userTransports` *adds* to the builtin set, so leaving it true isolates nothing while reading as if it does), and **a partial rollout is no discovery** — 3/3 both sides, 3/3 neither, **0/3 one side**. Hence a choke point, guarded by a test that fails if the call disappears.

Honest limit: the Cyclone half is verified *accepted and working*, not verified to *fix a failure* — this squatter doesn't break the Cyclone cell, because it is also an `add_two_ints_server` returning `sum=8`.

## #1005 — and a worse defect found with it

Counterfactual passes: edit the constant without rebuilding → `STALE`, naming the right file; with the new arm disabled → `FRESH`.

En route: `find_build_script_outputs` used **`lstat`**, so it stopped at the symlink phase-340 introduced. `zpico_recorded_inputs` returned **zero entries for every cross-compiled fixture**, and the probe had been running a bootstrap walk its own doc comment calls unreachable — announced only inside a STALE message, so the FRESH path said nothing.

## The stranded gate, and three self-inflicted bugs

`e569d9a55` — a commit about Zephyr SDK selection — deleted the `declared-qos-header` recipe and its lane entry, mentioning neither. Restored verbatim and mutation-checked.

Then a gate for the class. It took three tries, and the failures are the point:

1. It **violated `check-no-tracked-file-find`** — the `os.walk` I added is what that gate forbids. Removed rather than annotated around.
2. It counted **comments** as callers, so the restored recipe's comment and its own docstring "called" the script.
3. With comments excluded it *still* passed, because its own **failure message** names the scripts it reports on, on a non-comment line. A gate cannot be its own caller.

All three passed a green run. None was visible without deliberately breaking the thing the gate exists to catch.

## Filed, not fixed

**#1026** — six run-to-completion waits aimed at free-running nodes, one of which (`services.rs:212`) **cannot fail on any build**: the fallback kills the process and the assertion's third disjunct is `!is_running()`. Verified in `process.rs`, not taken on report. `check-no-vacuous-tests` cannot catch it — that gate keys on "prints only", and this has a real `assert!`.

**#1027** — NuttX Rust fixtures resolve at a leaf `target/` phase-340 moved. The sweep says it is a class: **four** NuttX sites including the fallback arm, plus FreeRTOS.

## Verification

`just check fast`: **192 gates OK** (190 + the restored gate + the new one). `cargo check -p nros-tests --tests` clean, clippy clean, fmt clean.

Not a tier claim — no `just ci`. Three agents shared this worktree and the fixture treadmill made a full tier-1 run unwise; each change states what it verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
