### PR TITLE
feat(#0259): derive performance placement, now that something counts the cores

### DIFF
--- a/docs/issues/0259-realizer-placement-nonpreempt-not-derived.md
+++ b/docs/issues/0259-realizer-placement-nonpreempt-not-derived.md
@@ -422,3 +422,71 @@ may be unrepresentable at runtime — in which case the honest realization is
 tier-level with a Degrade record ("ceiling applied at tier granularity;
 group-level non-preemption not enforced"). Decide group-granular vs
 tier-granular before implementing step 1.
+
+## `placement` DERIVED 2026-09-04 — the performance half, now that a core count exists
+
+The section above closed with "what placement needs first: a core count in the
+board descriptor, reaching `SchedCaps`". `n_cores` landed the same day, and this
+is the derivation it unblocked. `realize_rtos` now assigns `RealizedNode.core`
+and sets `placement_real = Native`.
+
+**Only the PERFORMANCE half**, which is the half finding 2 said must be derived
+rather than declared. Hardware locality is untouched: it names a DEVICE and
+resolves against the board, and this tree has no device vocabulary to name one
+with. Chain colocation is untouched too — it needs the interference model
+finding 2 describes, not just a count, and inventing one is the same
+fabricated-hardware failure as an invented WCET.
+
+Worst-fit decreasing: largest utilisation first, each onto the least-loaded
+core. Worst-fit rather than first-fit because the goal is to SPREAD load;
+first-fit packs cores tight, which maximises interference on the ones it fills.
+Ties break on node name, so two identical bakes produce identical placements
+rather than a diff nobody can explain.
+
+### Four preconditions, each refusing rather than guessing
+
+1. **`affinity`** — the board must have the mechanism.
+2. **`n_cores >= 2`** — on a uniprocessor every node lands on core 0, which
+   satisfies "a dim is derived" while saying nothing. That is exactly the
+   tautology this issue rejected for `preempt_threshold`, and it is no better
+   here.
+3. **Every PERIODIC node measured.** One unmeasured node and the whole
+   derivation refuses: a bin-pack over a taskset it cannot see is the same
+   fabrication as an invented WCET. Aperiodic nodes contribute no utilisation
+   and are left unpinned rather than counted as zero.
+4. **The packing must FIT** — see below.
+
+### The finding the aggregate utilisation check cannot make
+
+Three tasks at `U=0.6` on two cores total **1.80** against a capacity of
+**2.00**, so the system-wide utilisation check is correctly silent. Yet no core
+can hold two of them: partitioned fixed-priority scheduling runs a task on ONE
+core, so total headroom does not imply a feasible partition.
+
+That case is now a `Degradation { dim: "placement" }` carrying its inputs, and
+NO node is pinned — an infeasible packing assigns nothing rather than a best
+effort. It rides the existing `sched_warnings` route into `nros-plan.json` and
+`nros explain`, so it needed no new plumbing.
+
+### Verified
+
+Five tests, and the partition one proven by SABOTAGE rather than assumed:
+relaxing the fit guard to `worst > 99.0` makes
+`a_taskset_that_fits_in_total_but_in_no_partition_is_reported` fail, so it is
+testing the guard and not merely passing beside it. Its first assertion pins the
+premise — that the utilisation check stays silent on that taskset — so the test
+cannot quietly stop exercising the partition case. 100 lib tests green,
+`just check fast` green.
+
+## Still open after this
+
+* **`non_preempt`** — unchanged, and still not a realizer change. It needs
+  per-callback priorities within a tier, carried through `RealizedNode` and the
+  emitted `TierDef`, plus a runtime dispatch that honours them. Its own work
+  item, as recorded above.
+* **The inputs are SYNTHETIC.** RFC-0078's worked example says so: QEMU cannot
+  measure cycles and there is no hardware lane, so no run has produced a real
+  `nros.wcet.measurements/1` artifact. The placement machinery is correct and
+  will stay silent until something declares a WCET — which is the honest state,
+  not a defect, but it means this derivation has never run on measured numbers.
+* **Hardware locality** and **chain colocation**, as above.

--- a/packages/core/nros-orchestration-ir/src/rtos_realizer.rs
+++ b/packages/core/nros-orchestration-ir/src/rtos_realizer.rs
@@ -535,6 +535,102 @@ pub fn realize_rtos(ranked: &RankedPlan, input: &MapperInput, caps: &SchedCaps) 
         }
     }
 
+    // ---- issue 0259: derived PERFORMANCE placement --------------------------
+    //
+    // The issue's finding 2 is that `placement` is a MECHANISM, not a
+    // requirement: "pin to core N" implies nothing on its own, so the question
+    // is not "which contract fact means core-pin?" but "what does the realizer
+    // need in order to DECIDE?". The answer was an interference model over a
+    // core count — and the count did not exist. `SchedCaps.n_cores` supplies it
+    // now, so the decision is finally computable rather than blocked.
+    //
+    // This derives the PERFORMANCE half only: spread the measured load so no
+    // core is over-subscribed. Hardware locality ("this callback services the
+    // IMU whose IRQ lands on core 0") is the other half and is NOT derived
+    // here — it names a DEVICE and resolves against the board, which needs a
+    // device vocabulary this tree does not have. Chain colocation is likewise
+    // out: it needs an interference model, not just a count, and guessing one
+    // is the fabricated-hardware failure again.
+    //
+    // FOUR preconditions, each refusing rather than guessing:
+    //
+    //  1. `affinity` — the board must actually have the mechanism.
+    //  2. `n_cores >= 2` — on a uniprocessor every node lands on core 0, which
+    //     satisfies "a dim is derived" while saying nothing. That is exactly
+    //     the tautology this issue rejected for `preempt_threshold`, and it is
+    //     no better here.
+    //  3. Every PERIODIC node measured. One unmeasured node makes the packing a
+    //     statement about a taskset we cannot see; a bin-pack over unknowns is
+    //     the same fabrication as an invented WCET. Nodes with no period are
+    //     aperiodic, contribute no utilisation, and are left unpinned rather
+    //     than counted as zero.
+    //  4. The packing must FIT. See below — this is the part that finds
+    //     something the utilisation check cannot.
+    if let (true, Some(cores)) = (caps.affinity, caps.n_cores.filter(|c| *c >= 2)) {
+        let mut measured: Vec<(usize, f64)> = Vec::new();
+        let mut unmeasured = 0usize;
+        for (i, n) in nodes.iter().enumerate() {
+            match (n.budget_us, n.period_us) {
+                (Some(c), Some(t)) if t > 0 => measured.push((i, (c as f64) / (t as f64))),
+                (_, Some(_)) => unmeasured += 1,
+                _ => {}
+            }
+        }
+        if unmeasured == 0 && !measured.is_empty() {
+            // Worst-fit decreasing: largest utilisation first, each onto the
+            // least-loaded core. Worst-fit rather than first-fit because the
+            // goal is to SPREAD load — first-fit packs cores tight, which
+            // maximises interference on the ones it fills.
+            //
+            // Ties break on node name so the assignment is deterministic; a
+            // placement that moved between two identical bakes would make every
+            // downstream artifact diff noisily for no reason.
+            measured.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(core::cmp::Ordering::Equal)
+                    .then_with(|| nodes[a.0].name.cmp(&nodes[b.0].name))
+            });
+            let mut load = vec![0.0_f64; cores as usize];
+            let mut assign: Vec<(usize, usize)> = Vec::new();
+            for (idx, u) in &measured {
+                let core = load
+                    .iter()
+                    .enumerate()
+                    .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(core::cmp::Ordering::Equal))
+                    .map(|(c, _)| c)
+                    .unwrap_or(0);
+                load[core] += *u;
+                assign.push((*idx, core));
+            }
+            // The packing check the aggregate utilisation cannot make. Three
+            // tasks at U=0.6 on two cores total 1.8 against a capacity of 2.0,
+            // so the system-wide check is silent — yet no core can hold two of
+            // them. Partitioned fixed-priority scheduling assigns each task to
+            // one core, so a per-core overflow is infeasible however much total
+            // headroom exists.
+            let worst = load.iter().cloned().fold(0.0_f64, f64::max);
+            if worst > 1.0 {
+                degradations.push(Degradation {
+                    node: "<system>".to_string(),
+                    dim: "placement",
+                    reason: format!(
+                        "no assignment of the {} measured periodic node(s) to {cores} core(s) \
+                         fits: the least-loaded packing still demands {:.2} of one processor. \
+                         Total utilisation can fit while no PARTITION does, because a task \
+                         runs on one core (issue 0259).",
+                        measured.len(),
+                        worst
+                    ),
+                });
+            } else {
+                for (idx, core) in assign {
+                    nodes[idx].core = Some(core as u32);
+                    nodes[idx].placement_real = DimRealization::Native;
+                }
+            }
+        }
+    }
+
     RtosPlan {
         nodes,
         degradations,
@@ -1093,6 +1189,131 @@ mod tests {
             "{}",
             u.reason
         );
+    }
+
+    /// SMP caps: the mechanism exists AND the count is declared. `caps_cores`
+    /// leaves `affinity` false, which is why the utilisation tests above never
+    /// trip the placement derivation.
+    fn caps_smp(cores: Option<u16>) -> SchedCaps {
+        SchedCaps {
+            n_cores: cores,
+            affinity: true,
+            ..caps(false, false, false)
+        }
+    }
+
+    /// Two light nodes on two cores are SPREAD, not stacked. Worst-fit puts the
+    /// second on the empty core rather than beside the first.
+    #[test]
+    fn measured_nodes_are_spread_across_the_declared_cores() {
+        let input = MapperInput {
+            nodes: vec![
+                node_with_rate("/a", 100.0, 1.0),
+                node_with_rate("/b", 100.0, 1.0),
+            ],
+            legacy: None,
+            chains: vec![],
+        };
+        let ranked = chain_aware_rank(&input);
+        let plan = realize_rtos(&ranked, &input, &caps_smp(Some(2)));
+        let mut cores: Vec<u32> = plan.nodes.iter().filter_map(|n| n.core).collect();
+        cores.sort_unstable();
+        assert_eq!(cores, vec![0, 1], "both pinned, one per core");
+        assert!(
+            plan.nodes
+                .iter()
+                .all(|n| n.placement_real == DimRealization::Native)
+        );
+    }
+
+    /// The finding the aggregate utilisation check CANNOT make: three tasks at
+    /// U=0.6 total 1.80 against a capacity of 2.00, so the system-wide check is
+    /// silent — yet no core can hold two of them. A task runs on ONE core, so
+    /// total headroom does not imply a feasible partition.
+    #[test]
+    fn a_taskset_that_fits_in_total_but_in_no_partition_is_reported() {
+        let input = MapperInput {
+            nodes: vec![
+                node_with_rate("/a", 100.0, 6.0),
+                node_with_rate("/b", 100.0, 6.0),
+                node_with_rate("/c", 100.0, 6.0),
+            ],
+            legacy: None,
+            chains: vec![],
+        };
+        let ranked = chain_aware_rank(&input);
+        let plan = realize_rtos(&ranked, &input, &caps_smp(Some(2)));
+        assert!(
+            !plan.degradations.iter().any(|d| d.dim == "utilization"),
+            "1.80 of 2.00 fits in aggregate, so that check must stay silent — \
+             otherwise this test is not exercising the partition case"
+        );
+        let p = plan
+            .degradations
+            .iter()
+            .find(|d| d.dim == "placement")
+            .expect("no partition of 3x0.60 onto 2 cores fits");
+        assert!(p.reason.contains("1.20"), "{}", p.reason);
+        assert!(
+            plan.nodes.iter().all(|n| n.core.is_none()),
+            "an infeasible packing must assign NOTHING, not a best effort"
+        );
+    }
+
+    /// One unmeasured periodic node and the whole derivation refuses. A
+    /// bin-pack over a taskset it cannot see is the same fabrication as an
+    /// invented WCET.
+    #[test]
+    fn one_unmeasured_periodic_node_blocks_the_whole_placement() {
+        let mut silent = node_with_rate("/silent", 100.0, 0.0);
+        silent.paths[0].exec_ms = None;
+        let input = MapperInput {
+            nodes: vec![node_with_rate("/a", 100.0, 1.0), silent],
+            legacy: None,
+            chains: vec![],
+        };
+        let ranked = chain_aware_rank(&input);
+        let plan = realize_rtos(&ranked, &input, &caps_smp(Some(2)));
+        assert!(
+            plan.nodes.iter().all(|n| n.core.is_none()),
+            "one unmeasured node must silence placement for all of them"
+        );
+    }
+
+    /// A uniprocessor gets NOTHING. Pinning every node to core 0 would satisfy
+    /// "the dim is derived" while saying nothing — the same tautology this
+    /// issue rejected for `preempt_threshold`.
+    #[test]
+    fn a_uniprocessor_gets_no_derived_placement() {
+        let input = MapperInput {
+            nodes: vec![node_with_rate("/a", 100.0, 1.0)],
+            legacy: None,
+            chains: vec![],
+        };
+        let ranked = chain_aware_rank(&input);
+        let plan = realize_rtos(&ranked, &input, &caps_smp(Some(1)));
+        assert!(plan.nodes.iter().all(|n| n.core.is_none()));
+        assert!(
+            plan.nodes
+                .iter()
+                .all(|n| n.placement_real == DimRealization::NotRequested)
+        );
+    }
+
+    /// No affinity mechanism, no placement — however many cores are declared.
+    #[test]
+    fn a_board_without_affinity_gets_no_derived_placement() {
+        let input = MapperInput {
+            nodes: vec![
+                node_with_rate("/a", 100.0, 1.0),
+                node_with_rate("/b", 100.0, 1.0),
+            ],
+            legacy: None,
+            chains: vec![],
+        };
+        let ranked = chain_aware_rank(&input);
+        let plan = realize_rtos(&ranked, &input, &caps_cores(Some(4)));
+        assert!(plan.nodes.iter().all(|n| n.core.is_none()));
     }
 
     fn node_with_rate(name: &str, rate_hz: f64, exec_ms: f64) -> MapperNode {


### PR DESCRIPTION
Issue 0259 — the repo's oldest open issue — closed its placement section with *"what placement needs first: a core count in the board descriptor, reaching `SchedCaps`"*. `n_cores` landed the same day and nothing consumed it. This is the derivation it unblocked: `realize_rtos` now assigns `RealizedNode.core` and sets `placement_real = Native`.

## Scope: the performance half only

Finding 2 of the issue splits placement in two, and is explicit that only one half is derivable:

- **Performance placement** (spread load) *"must be a DERIVED allocation output — from per-core utilization and chain structure — never a declared field; the user cannot state it correctly because it depends on the whole taskset."* ← this PR
- **Hardware locality** ("the IMU whose IRQ lands on core 0") is a legitimate *declared* fact, but it names a **device**, and this tree has no device vocabulary to name one with. Untouched.
- **Chain colocation** needs finding 2's interference model, not just a count. Untouched.

Worst-fit decreasing: largest utilisation first, each onto the least-loaded core. Worst-fit rather than first-fit because the goal is to **spread** load — first-fit packs cores tight, which maximises interference on the ones it fills. Ties break on node name, so two identical bakes place identically.

## Four preconditions, each refusing rather than guessing

1. **`affinity`** — the board must have the mechanism.
2. **`n_cores >= 2`** — on a uniprocessor every node lands on core 0, which satisfies "a dim is derived" while saying nothing. That is exactly the tautology this issue rejected for `preempt_threshold`, and it is no better here.
3. **Every periodic node measured.** One unmeasured node and the whole derivation refuses: a bin-pack over a taskset it cannot see is the same fabrication as an invented WCET. Aperiodic nodes are left unpinned, not counted as zero.
4. **The packing must fit.**

## (4) finds something the utilisation check cannot

Three tasks at `U=0.6` on two cores total **1.80** against a capacity of **2.00** — so the existing system-wide check is correctly *silent*. Yet no core can hold two of them, because partitioned fixed-priority scheduling runs a task on **one** core. **Total headroom does not imply a feasible partition.**

That case is now a `Degradation { dim: "placement" }` carrying its inputs, with **no node pinned** — an infeasible packing assigns nothing rather than a best effort. It rides the existing `sched_warnings` route into `nros-plan.json` and `nros explain`, so it needed no new plumbing.

## Verified by sabotage, not assumed

Relaxing the fit guard to `worst > 99.0` makes `a_taskset_that_fits_in_total_but_in_no_partition_is_reported` **fail** — so it tests the guard rather than passing beside it. That test's first assertion also pins its own premise (that the utilisation check stays silent on this taskset), so it cannot quietly stop exercising the partition case.

Five new tests; 100 lib tests green; `just check fast` green.

## What this does NOT do

- **`non_preempt` is unchanged.** Still not a realizer change: it needs per-callback priorities within a tier, carried through `RealizedNode` and the emitted `TierDef`, plus a runtime dispatch that honours them. Its own work item, as the issue already scoped.
- **The inputs are synthetic.** RFC-0078's worked example says so — QEMU cannot measure cycles and there is no hardware lane, so no run has ever produced a real `nros.wcet.measurements/1` artifact. This machinery stays silent until something declares a WCET. That is the honest state rather than a defect, but it means the derivation has never run on measured numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742