### PR TITLE
fix(#1007, #1026, #1027): NuttX locators, the arch precondition, and the waits that could not fail

### DIFF
--- a/docs/issues/1007-nuttx-arch-export-snapshot-vs-shared-tree.md
+++ b/docs/issues/1007-nuttx-arch-export-snapshot-vs-shared-tree.md
@@ -84,3 +84,128 @@ cell runnable, and the message printed when it is not says what that command is.
 
 Running the phase-414 W3 experiment for issue 0870. It cost one forced kernel
 build plus a second full fixture rebuild before any measurement could be taken.
+
+## Fix (2026-09-04, branch `fix/1007-1026-1027-followups`)
+
+**Direction 2, plus Direction 3.** The test precondition now reads the per-arch
+EXPORT SNAPSHOT — `$NUTTX_DIR/nros-nuttx-export-<arch>` — which is exactly what
+`build-nuttx.sh` guarantees, so the build contract and the test precondition
+stop disagreeing about which artifact is authoritative.
+
+### Why direction 2 and not direction 1
+
+The issue rejected direction 2 with "the snapshot is not what an image links
+against". MEASURED, that is inverted — since phase-339 the snapshot is the ONLY
+thing an image links against:
+
+* the arm cells boot the FIXTURE binary (`QemuProcess::start_nuttx_virt`), never
+  `$NUTTX_DIR/nuttx`. Both callers of `nuttx_kernel_path_for` (`rtos_e2e.rs:267`,
+  `logging_smoke.rs:124`) use it as a PRECONDITION and discard the path;
+* the fixture links `nros-nuttx-export-<arch>/{libs,startup,scripts}` and
+  compiles against its `include/` — `nros_board_common::nuttx_export`,
+  `nros_build_paths::nuttx_include_root`, `cmake/platform/nano-ros-nuttx.cmake`
+  — and `check-nuttx-links-snapshot.sh` exists precisely to keep consumers off
+  the live tree;
+* MEASURED in a built fixture's dep-info
+  (`…/nros-minsizerel/talker.d`): 7 NuttX inputs, 6 under
+  `nros-nuttx-export-arm/`, and the one shared-tree entry is
+  `include/nuttx/config.h` — an issue-0477 candidate WATCH (invalidate if the
+  fallback ever becomes live), not a compile input.
+
+So `nuttx_kernel_path_for` was the last consumer keyed on the shared tree, and
+it was checking an artifact nothing on its own path consumes.
+
+Direction 1 (make the short-circuit validate the SHARED TREE) is the one to
+avoid: the tree holds one `.config`, so demanding it hold arm forces a full
+reconfigure + kernel rebuild on every lane alternation — which is what issue
+0433 removed, and what the short-circuit's own comment calls "not just slow but
+pointless". It also breaks the riscv lane symmetrically, one lane at a time,
+forever.
+
+### What changed
+
+`packages/testing/nros-tests/src/fixtures/binaries/nuttx.rs`:
+
+* `nuttx_kernel_path_for(arch)` resolves `nros-nuttx-export-<snapshot_id>` and
+  returns its ROOT. `NuttxArch::snapshot_id()` is new and names the CONFIG dir
+  (`arm`/`riscv`), matching `build-nuttx.sh`'s `NUTTX_CONFIG_ID` key.
+* `snapshot_for_arch(root, arch)` is the predicate, split out so it is testable
+  without a provisioned tree — the arm half of issue 0743 was untestable for
+  exactly that reason, and the reason was the env lookup, not the rule. It
+  requires `<root>/libs` and, when `<root>/startup/crt0.o` is readable, checks
+  its `e_machine`. Issue 0743's "ask the file, never the name" survives; the
+  per-arch directories make the last-build-wins ambiguity structurally
+  impossible, so an unreadable probe is accepted rather than failing a host
+  whose export is fine.
+* **Direction 3, the message.** "no NuttX Arm kernel export at <path> — this
+  lane's images link `<export>/libs` and nothing has built it. Run: just nuttx
+  build-fixtures-arm", plus a NOTE, emitted only on a mismatch, saying the
+  shared tree holds the other arch and that this is expected and is not the
+  problem. That note is the one thing the old message got most wrong: it sent
+  the reader to the tree.
+
+Five unit tests cover the predicate and the note (both directions of the note,
+missing export, wrong-arch export, unreadable probe).
+
+### Sweep
+
+After the change, `grep -rn 'join("nuttx")'` over `packages/` + `scripts/` and
+`grep -rnE '\$\{?NUTTX_DIR\}?/nuttx([^-a-zA-Z_/]|$)'` over the tree find only:
+the diagnostic NOTE and its unit test, and `build-nuttx.sh`'s own prints (it is
+the PRODUCER). No consumer reads the shared tree's kernel any more.
+
+No new gate was added: the class is down to one deliberate diagnostic site,
+and a gate forbidding `$NUTTX_DIR/nuttx` would need a self-exemption for it.
+
+## Measured — the acceptance, on a riscv-configured tree
+
+The tree was ARM-configured, so it was deliberately put back to riscv and
+recovered.
+
+1. Forced a riscv reconfigure (`nros-nuttx-export-riscv/.nros-export-key` moved
+   aside, `NUTTX_DEFCONFIG=…/riscv/defconfig NUTTX_BOARD_MAKEDEFS=… NUTTX_CROSS=
+   riscv-none-elf-gcc bash scripts/nuttx/build-nuttx.sh`). Result:
+   `.config` `CONFIG_ARCH_BOARD="rv-virt"`, `$NUTTX_DIR/nuttx` `e_machine`
+   `0xf3`. That is issue 1007's exact starting state: the OLD predicate compares
+   `0xf3` against `0x28` and skips every arm cell.
+2. Ran an arm Rust cell WITHOUT rebuilding anything. The arch precondition
+   PASSED (no `[SKIPPED] nuttx: … is a RiscV image`). The cell instead reported
+   the honest, actionable
+
+       Test fixture is STALE …
+         binary: …/nros-minsizerel/talker
+         newer:  …/third-party/nuttx/nuttx/include/nuttx/config.h
+
+   — the shared tree's `config.h` that the reconfigure regenerated, which the
+   fixtures carry as a candidate watch (above). This is the issue's step 2, and
+   it is now the ONLY thing standing between a riscv tree and a running arm
+   cell.
+3. Ran the ONE documented command, `just nuttx build-fixtures-arm`. Its C/C++
+   half self-provisions through `build-nuttx.sh`, which short-circuits on the
+   arm snapshot (leaving the tree riscv-configured, which is now fine), and its
+   Rust half rebuilds the stale fixtures.
+4. Re-ran the arm Rust cells: **3 passed, 0 failed** (pubsub / service /
+   action), on a tree still configured for rv-virt. `just nuttx
+   build-fixtures-arm` took 2 min 03 s (warm sccache), and its log carries the
+   1007 symptom lines verbatim — `NuttX arm export up-to-date
+   (nros-nuttx-export-arm) — skipping build/export.` followed by `NOTE: the
+   shared tree stays configured for "rv-virt", not "qemu-armv7a".` — which is
+   now a true statement about a state that works, rather than a trap.
+
+Direction 3 demonstrated separately: with `nros-nuttx-export-arm` moved aside,
+an arm cell prints
+
+    [SKIPPED] nuttx: no NuttX Arm kernel export at
+    …/third-party/nuttx/nuttx/nros-nuttx-export-arm — this lane's images link
+    `<export>/libs` and nothing has built it. Run: just nuttx build-fixtures-arm
+      (The shared tree at …/third-party/nuttx/nuttx/nuttx currently holds a
+      RiscV kernel. That is expected and is NOT the problem: since phase-339
+      every consumer links the per-arch export snapshot, not the tree.)
+
+So: from a riscv-configured tree, ONE command makes an arm cell runnable, and
+the message printed when it is not names that command — both halves of the
+acceptance.
+
+**End state of this worktree:** the shared NuttX tree is left RISCV-configured
+with fresh arm fixtures. That is deliberate: it is the state the issue says
+should be OK, and after this fix it is.

--- a/docs/issues/1026-wait-for-output-aimed-at-free-running-nodes.md
+++ b/docs/issues/1026-wait-for-output-aimed-at-free-running-nodes.md
@@ -98,3 +98,125 @@ For each site: either it waits on a condition rather than a lifetime, or it
 states in a comment what it cannot observe and why that is acceptable.
 `services.rs:212` must be able to FAIL — demonstrated by a mutation, not by
 inspection.
+
+<!-- BEGIN: services.rs wave (2026-09-04) -->
+## Fixed — `tests/services.rs` (both sites), 2026-09-04
+
+Scope of this block: `packages/testing/nros-tests/tests/services.rs` ONLY. The
+other seven sites in the table above are untouched.
+
+### What the test is actually for, and what the client really prints
+
+MEASURED, by running the fixture (`native/rust/service-client`, zenoh, against a
+`zenohd_unique` router with no server):
+
+```
+PROBE n=1 at 1.021163202s why=None seen_count=1
+PROBE n=2 at 2.020642364s why=None seen_count=1
+PROBE n=3 at 3.014332016s why=None seen_count=1
+PROBE n=4 at 4.018483002s why=None seen_count=1
+PROBE n=5 at 5.013361215s why=None seen_count=1
+PROBE n=6 at 6.01650743s  why=None seen_count=1
+```
+
+The client prints `[INFO] Service call failed, retrying: Runtime` — the `Err`
+arm of `call_for_name` in `examples/native/rust/service-client/src/lib.rs` —
+once per 1 s timer tick, from ~1 s after spawn, **forever**. It never exits
+(`spin = "forever"`, issue 0274) and it never prints anything resembling
+`Timed out waiting`. The only producer of that wording in the tree is the
+unrelated `service-client-callback` example, which spells it
+`Timed out waiting for reply to {} + {}`. So the greped pattern was dead in
+both tests.
+
+A fourth defect, on top of the three the issue listed: `or_else` **discards the
+first wait's output**. The 12 s window collected ~12 failure lines, the `Err`
+carried them into a formatted message, and `or_else` threw the whole thing
+away — so the assertion only ever saw the ~2 s the fallback re-collected. The
+original run printed two lines where twelve had happened.
+
+The property both tests are for, restated:
+
+* `test_service_client_starts_without_server` — the error path is REACHABLE:
+  the first call fails and says so, promptly, without the client dying.
+* `test_service_client_timeout` — it STAYS reachable: every attempt fails and
+  is reported at the timer cadence, no reply is ever manufactured, and the
+  client survives its own timeouts.
+
+Both now wait with `ManagedProcess::collect_until_count` (the `ManagedProcess`
+sibling of the `QemuProcess` primitive the issue names; it returns as soon as
+the count is reached and, unlike `wait_for_output`/`wait_for_all_output`, kills
+NOTHING on timeout). The tests own the lifetime and call `client.kill()`
+themselves. Assertions: `>= 3` failure markers within 20 s (1 Hz ⇒ ~3 s),
+`!output.contains(SERVICE_RESULT_PREFIX)`, and `is_running()` sampled BEFORE
+the kill.
+
+Stated bound, per acceptance: neither test observes whether the client would
+eventually give up (it has no such contract) nor that a call succeeds once a
+server appears (that is `test_service_multiple_sequential_calls`).
+
+### Mutation evidence
+
+**The old test passes with a fully working server present** — the sharpest
+statement of the defect. Same file, only the mutation added (spawn the server
+the test is supposed to be missing):
+
+```
+running 1 test
+Timeout test output:
+
+test test_service_client_timeout ... ok
+        PASS [  14.315s] nros-tests::services test_service_client_timeout
+```
+
+Note `Timeout test output:` is EMPTY: the assertion ran against `""` and passed
+on `!client.is_running()` alone, which the fallback's kill had just made true.
+
+**New test, same mutation (server present) — RED:**
+
+```
+a client with no server must report a failed call on every attempt: expected >= 3
+`Service call failed, retrying:` within 20s, saw 0:
+...
+[INFO] Result of add_two_ints: 5
+        FAIL [  20.316s] nros-tests::services test_service_client_timeout
+```
+
+**New test, SUT silenced** (stand in a client build whose `Err` arm prints
+nothing and never exits — the pre-phase-338 `Err(_) => {}` shape) — RED:
+
+```
+expected >= 3 `Service call failed, retrying:` within 20s, saw 0:
+...
+[INFO] Waiting for service requests
+        FAIL [  20.313s] nros-tests::services test_service_client_timeout
+```
+
+Same mutation against the sibling `test_service_client_starts_without_server` —
+also RED (`FAIL [ 15.315s]`).
+
+**Restored, GREEN**, whole file:
+
+```
+        PASS [   1.321s] nros-tests::services test_service_client_starts_without_server
+        PASS [   3.322s] nros-tests::services test_service_client_timeout
+     Summary [  10.681s] 5 tests run: 5 passed, 0 skipped
+```
+
+Wall clock also improves: the two tests were 14.3 s + 12 s of pure deadline;
+they are now 1.3 s + 3.3 s of real waiting.
+
+### Follow-ups this wave did not take
+
+* `SERVICE_CALL_FAILED_MARKER` is a file-local `const` in `services.rs`, not a
+  `nros_tests::output` constant, because this wave owned one file. It belongs
+  beside `SERVICE_RESULT_PREFIX` — every Rust group copy of the client
+  (`qemu-arm-nuttx`, `qemu-arm-freertos`, `threadx-linux`) prints the same
+  wording, and the C/C++ copies print a different one (`Service call failed
+  with error %d`), which is worth a second constant.
+* On the issue's point 3 (a gate for unfalsifiable assertions): the shape that
+  made this one unfalsifiable is *a disjunct the test's own preceding call
+  makes true* — here `!is_running()` after a helper that kills. That is
+  narrower than "unfalsifiable" in general and might be greppable: an
+  `is_running()`/`try_wait()` disjunct in an `assert!` that follows a
+  `wait_for_all_output`/`wait_for_output` in the same body. Not attempted here.
+<!-- END: services.rs wave (2026-09-04) -->

--- a/docs/issues/1026-wait-for-output-aimed-at-free-running-nodes.md
+++ b/docs/issues/1026-wait-for-output-aimed-at-free-running-nodes.md
@@ -220,3 +220,175 @@ they are now 1.3 s + 3.3 s of real waiting.
   `is_running()`/`try_wait()` disjunct in an `assert!` that follows a
   `wait_for_all_output`/`wait_for_output` in the same body. Not attempted here.
 <!-- END: services.rs wave (2026-09-04) -->
+
+<!-- BEGIN: remaining-sites wave (2026-09-04) -->
+## Fixed — the other seven sites + the two helper layers, 2026-09-04
+
+Scope of this block: everything in the table above EXCEPT `services.rs` (which
+the wave above owns). Files touched:
+`src/{ros2.rs,ros_env.rs,zephyr.rs}`,
+`tests/{interop_e2e.rs,native_api.rs,ros_editions_e2e.rs,native_async_roundtrip_e2e.rs,zephyr.rs}`.
+
+Note on one path in the issue's sweep: the three `zephyr.rs:886/977/1681` sites
+are in **`tests/zephyr.rs`**, not `src/zephyr.rs` (which is 1428 lines and has
+no such call). `src/zephyr.rs` gained a doc warning instead — see below.
+
+### The helper layer first, because six of the seven sites needed it
+
+`RosPeer` (`src/ros_env.rs`) had exactly one wait, `wait_for_output`, and it is
+`ros2::wait_child_output` — a terminal drain that kills the process group at
+the deadline and reads stdout only. There was nothing else to call, so every
+`ros_editions_e2e` cell used it, and the issue's "no doc warning" note
+understates it: the warning was missing because the alternative was missing.
+
+* `ros2::wait_child_output` and the new `ros2::collect_child_until` are now one
+  loop (`collect_child_inner`) parameterised by an `Option<(pattern, count)>`
+  stop condition. `None` = the historical terminal drain, byte-for-byte;
+  `Some` = return at the n-th occurrence, **kill nothing**, and hand the stream
+  back so a later wait resumes.
+* `RosPeer::collect_until{,_count}` expose it, mirroring
+  `ManagedProcess::collect_until` and `QemuProcess::collect_until`.
+* `RosPeer::wait_for_output` now carries the warning (what it kills, what a
+  `spin = "forever"` node makes of the timeout, and that it is stdout-only —
+  which is safe here only because `nano_node_cmd*` bakes `2>&1`).
+* `ZephyrProcess::wait_for_output` (`src/zephyr.rs`) got the same warning. It
+  is the worst of the three: *every* return path passes through
+  `kill_process_group`, and its only early-outs are four hard-coded terminal
+  markers no cell asserts. `wait_for_pattern` was already the condition-shaped
+  sibling; nothing pointed at it.
+* `ros2.rs:673 collect_ros2_output` — DELETED (dead, zero callers).
+
+### `Ros2Process::topic_echo` — the baked `timeout --foreground 10`
+
+Two facts, and the second is why the horizon could not simply be raised:
+
+1. The baked timeout is a HORIZON, not an implementation detail. A caller
+   waiting longer than it gets a truncated transcript and a failure that reads
+   like "no delivery". It is now a parameter — `topic_echo_for(…, window)`,
+   with `topic_echo` delegating at the named `DEFAULT_ECHO_WINDOW` (10 s) — so
+   the peer's lifetime and the caller's wait are one decision at one site.
+2. **The baked timeout was doubling as the flush mechanism.** `ros2 topic echo`
+   is a Python entry point, so with stdout on a pipe its `print`s sit in a
+   block buffer until the process exits. That is why every caller had to drain
+   to completion: a count wait would have seen nothing and timed out. The
+   command now sets `PYTHONUNBUFFERED=1`, which is what makes a condition wait
+   possible at all here. MEASURED: case 1 below returns in ~1 s against a 25 s
+   window, so the echo is streaming, not flushing at exit.
+
+`Ros2Process::topic_echo` has exactly one caller (`interop_e2e` case 1), which
+is why it could be changed here. The four `Ros2DdsProcess::topic_echo*`
+siblings behind the bridge/xrce tests were deliberately LEFT as they are: their
+callers are files this wave does not own, they still drain to completion (so
+the buffered-until-exit behaviour is load-bearing for them), and giving them
+`PYTHONUNBUFFERED=1` would change delivery timing under tests nobody here can
+run. They are the same horizon and still unstated — the remaining piece of this
+row.
+
+### Site-by-site
+
+| site | now | stated bound |
+| --- | --- | --- |
+| `interop_e2e.rs` case 1 (nano→ros2 echo) | `wait_for_output_count("data:", 1, 20s)` over a 25 s echo window | FIRST delivery only |
+| `interop_e2e.rs` case 5 (ros2 server ↔ nano client) | `collect_until(SERVICE_RESULT_PREFIX, 15s)` | the demo client is SINGLE-SHOT (`State::done` latches, then it idles), so one result is all it will ever print — no count >1 exists to assert |
+| `native_api.rs` action body | client: `collect_until(ACTION_RESULT_PREFIX, 20s)`; server: `collect_until(ACTION_EXECUTING_MARKER, 5s)` | one goal; nothing after it |
+| `ros_editions_e2e.rs` ×3 | `RosPeer::collect_until` on the marker each cell already asserts | first delivery / one reply / one result |
+| `tests/zephyr.rs` 886, 1681 | `ManagedProcess::collect_until` on the listener sample line | first cross-process delivery |
+| `tests/zephyr.rs` 977 | `ZephyrProcess::wait_for_pattern` on the sample line | first delivery |
+| `native_async_roundtrip_e2e.rs` ×2 | wait for the client's TERMINAL line, and assert it | see below |
+
+`native_async_roundtrip_e2e` was the one whose ASSERTION had to change, not
+just its wait. It asserted `ACTION_GOAL_ACCEPTED_MARKER`, which the client
+prints in the middle of its run: acceptance, then a feedback stream, then an
+awaited `get_result`. A stall in either of the last two printed the accepted
+line and reported PASS. It now waits for and asserts `ACTION_RESULT_PREFIX`
+too, with acceptance kept as the earlier of two assertions so a rejection and a
+post-acceptance stall stay distinguishable.
+
+### Class sweep in the same files
+
+`native_api.rs` had eight more copies of
+`wait_for_output_pattern(M, t).or_else(|_| wait_for_all_output(2s)).unwrap_or_default()`.
+That idiom destroys its own evidence twice — the strict wait has already
+collected the transcript into an `Err` the `or_else` drops, and the fallback
+then KILLS the client to gather the two seconds that remain — so a failing cell
+reports the tail of a run it truncated. All eight are now `collect_until`.
+Sweep command:
+
+```
+rg -n 'or_else\(\|_\| .*wait_for_all_output' packages/testing
+```
+
+Two survivors, both outside this wave's files: `tests/services.rs` (the wave
+above) and `tests/action_multigoal.rs:76`. **`action_multigoal.rs:76` is an
+eighth site of this class that the issue's original table does not list.**
+
+One `wait_for_all_output` was deliberately KEPT, with the reason written at the
+call site: `native_api.rs`'s `native_rust_service_interop` drains the server
+purely to `eprintln!` it — nothing asserts on that string, and the kill is the
+teardown the test wanted anyway. Per acceptance, a stated bound is the answer
+there, not a rewrite.
+
+### Evidence
+
+MEASURED on this host (ROS 2 humble with `rmw_zenoh_cpp`; `cargo test`, not
+nextest, so `skip!` panics show as failures):
+
+| lane | result |
+| --- | --- |
+| `--test interop_e2e` (whole file) | **10 passed, 0 failed** (36.0 s) |
+| `--test interop_e2e` cases 1+5, 3 repeats | 2 passed ×3 (3.45 / 3.50 / 3.50 s) |
+| `--test native_async_roundtrip_e2e` ×3 | 2 passed ×3 (1.53 s) |
+| `--test zephyr` (the three e2e cells) ×3 | 3 passed ×3 (5.0 s solo / 14.9 s together) |
+| `--test native_api` (whole file) | **32 passed, 4 failed** — see the pre-existing red below |
+
+Wall-clock, since a blind window is also a bill: the two zephyr pubsub cells
+were 40 s each of pure deadline and now finish the pair in 10 s; the workspace
+Entry cell was 40 s and is 5 s; interop cases 1+5 were ≥23 s of deadline and
+are 3.5 s together.
+
+**Mutation evidence** (the acceptance asks for it on `services.rs`; doing it
+here too, since two of these assertions changed meaning):
+
+* async action, wait+assert pointed at a marker the client never prints:
+  `FAILED` in 1.32 s with `accepted the goal but never resolved its awaited
+  RESULT` — and note the GOAL-ACCEPTANCE assertion still passed in that run,
+  which is exactly the blind spot the old cell had.
+* `interop_e2e` case 1 with the talker killed before it can publish: `FAILED`,
+  and the failure reads
+  `[wait data:] … printed 'data:' fewer than 1 time(s) within 20s`.
+  The wait diagnostic goes on a SEPARATE channel from the asserted string
+  (issue 0670): the error text names the pattern `data:`, so folding it into
+  the output would have made `count_pattern(&out, "data:")` match the complaint
+  about the missing samples and pass. This was the first thing tried and it did
+  silently pass; the two-channel shape is what caught it.
+
+**NOT RUN, and why:**
+
+* `ros_editions_e2e` — every cell `skip!`s here: `example <x> not built for
+  jazzy — run 'just ros_editions build-e2e-fixtures jazzy'` (the per-edition
+  docker fixture set is not on this host). Compile- and clippy-clean only.
+* `native_api`'s 4 reds are `test_threadx_linux_cyclonedds_{talker,cpp_talker,
+  service,action}`, all **pre-existing and unrelated**: they fail identically
+  with and without `NROS_SKIP_FIXTURE_CHECK=1`, their bodies (lines 1103–1291)
+  contain none of this wave's hunks, and the failure is a cyclone delivery
+  failure on `lo` (`selected interface "lo" is not multicast-capable:
+  disabling multicast`, listener saw 0 of 2).
+* The C/C++ native and zephyr fixtures were STALE by mtime on this host (a
+  rebase refreshed `nros-zpico-build/src/lib.rs` at 02:31 while the binaries
+  were built at 01:46; the file's content last changed 2026-08-31, i.e. before
+  the build). The `native_api` and `interop_e2e` runs used
+  `NROS_SKIP_FIXTURE_CHECK=1` for that reason. The three zephyr images were
+  built properly (`NROS_ZEPHYR_FIXTURE_FILTER='build-rust-(talker|listener)-zenoh'`
+  and `'build-ws-rs-entry-zenoh'`), so those runs are on fresh binaries.
+
+### On the issue's point 3, a gate
+
+Nothing added. The other wave's note is the sharper lead (a disjunct the test's
+own preceding call makes true). For THIS half of the class the greppable shape
+is different and probably worth more: a *terminal drain used as an observation*
+— `wait_for_output` / `wait_for_all_output` / `wait_child_output` whose result
+is bound and then asserted on, in a body that never kills the process itself.
+The three types now each have a condition-shaped sibling
+(`collect_until`/`collect_until_count`/`wait_for_pattern`), so such a gate would
+have a remedy to name, which is the precondition for adding one.
+<!-- END: remaining-sites wave (2026-09-04) -->

--- a/docs/issues/1027-nuttx-rust-fixture-probes-leaf-not-shared-cargo-dir.md
+++ b/docs/issues/1027-nuttx-rust-fixture-probes-leaf-not-shared-cargo-dir.md
@@ -98,9 +98,12 @@ So NuttX has FOUR sites and FreeRTOS one, and fixing only the reported line
 would leave the fallback arm looking in the same wrong place — which is how the
 warning would keep firing for the wrong reason.
 
-FreeRTOS is not currently RED here only because those fixtures happen to build
-into the leaf on this tree; that is a property of which lane last ran, not of the
-locator being right. It should move with the others.
+**CORRECTION (2026-09-04): that sentence was wrong.** FreeRTOS fixtures do NOT
+land in the leaf — `freertos` IS in `NROS_FIXTURE_SHARED_PLATFORMS` and its
+artifacts are in `build/cargo-fixtures/freertos/`. It was green because it
+happened to spell the CARVE-OUT profile directly, which is the one on disk. So
+it was one profile spelling away from the same failure, not one directory away.
+Fixed with the others.
 
 (`cache_key.rs`'s `target/nros-*` paths are a different thing — a scratch dir
 under the project root, not a fixture artifact. Leave them.)
@@ -109,3 +112,74 @@ under the project root, not a fixture artifact. Leave them.)
 
 Zephyr and ThreadX locators, which resolve differently (west leaves,
 `librustapp.d`) and were not part of this sweep.
+
+## Fix (2026-09-04, branch `fix/1007-1026-1027-followups`)
+
+All five sites in the sweep are addressed, and the two NuttX literals the issue
+flagged (the leaf `target/` prefix, and "the carve-out is the profile on disk")
+are both gone.
+
+**One derivation added.** `binaries/mod.rs::row_profile_dir(row)` — the profile
+DIRECTORY a row's platform builds into, from `nros_cargo_profile::
+platform_profile(row.coord.0)` (the Rust twin of `nros_cargo_platform_profile`).
+It is deliberately the same derivation `rel_at_row_profile` already applies
+inside the row-keyed chokepoint, exposed so a resolver can ask "which profile is
+on disk?" BEFORE it hands a path over — which the NuttX carve-out/ambient choice
+needs.
+
+**`binaries/nuttx.rs`** — `build_rust_example` (sites `:201`/`:227`) is DELETED.
+It was dead (`#[allow(dead_code)]`, kept alive only by a `_keep_` shim) and it
+was a second spelling of the same artifact path, which is how the fallback arm
+came to look in a place nothing writes. `require_entry_binary` (sites
+`:308`/`:313`) is now the one resolver, and it asks the manifest:
+`groups::select_sole_row(dir)` → `groups::row_resolved_dir(row)` for the artifact
+ROOT (leaf or group, decided by the row's own `shared`/`slug`) and
+`row_profile_dir(row)` for the PROFILE. The only literal left is the target
+triple, which no `GroupRow` carries.
+
+**The miscompile warning is kept and now means what it says.** Its condition is
+three-part: the platform's carve-out differs from the ambient profile, the
+carve-out artifact is ABSENT, and the ambient artifact is PRESENT. "Carve-out
+absent" alone is also what an unbuilt tree looks like — warning about a codegen
+bug there is the cry-wolf this issue measured. The ambient arm resolves through
+the PATH route on purpose: `rel_at_row_profile` rewrites a rel's profile
+component to the carve-out, which is exactly what that arm must not do, while
+`groups::resolved` redirects the artifact root only.
+
+**`binaries/freertos.rs`** (site `:106`) moved with them, to
+`select_sole_row` + `require_prebuilt_row_binary_fresh` + `row_profile_dir`.
+Note the issue's reading of why FreeRTOS was green is inverted: MEASURED, its
+artifacts are NOT in the leaf — `freertos` is in
+`NROS_FIXTURE_SHARED_PLATFORMS` and they are under
+`build/cargo-fixtures/freertos/thumbv7m-none-eabi/nros-minsizerel/`. It reached
+them because it spelled the carve-out profile DIRECTLY and let the path route's
+root redirect do the rest. So it was one profile spelling away from the NuttX
+failure, not one lane away.
+
+## Measured
+
+Same tree, same fixtures, `just nuttx build-fixtures-arm` already run:
+
+| | before | after |
+| --- | --- | --- |
+| `rtos_e2e` NuttX Rust cells (pubsub/service/action) | 0 passed, 3 failed | **3 passed, 0 failed** |
+| `rtos_e2e` FreeRTOS Rust cells | 3 passed | 3 passed (no regression) |
+
+The three failures all read
+`not prebuilt: build/cargo-fixtures/nuttx-<slug>/armv7a-nuttx-eabihf/nros-relwithdebinfo/<bin>`
+— the root redirect had already worked; only the profile component was wrong.
+
+**The warning was demonstrated, not asserted.** A real ambient-profile build
+(`NROS_CARGO_PROFILE=nros-relwithdebinfo bash scripts/build/fixtures-build.sh
+nuttx rust`) was run, then the carve-out `talker`/`listener` were moved aside so
+the ambient artifact was the only one present. The cell resolved and ran, with:
+
+    [nros-tests] WARNING: NuttX Rust fixture `talker` is present at the ambient
+    `nros-relwithdebinfo` profile but NOT at the `nros-minsizerel` carve-out
+    (…/armv7a-nuttx-eabihf/nros-minsizerel/talker); running the ambient build,
+    which hits the 177.8.c armv7a-nuttx-eabihf codegen bug …
+
+The carve-out artifacts and the ambient build output were both restored/removed
+afterwards. (Incidentally: that ambient image PASSED the pubsub cell on this
+host — the 177.8.c miscompile is non-deterministic, which is why the warning
+rather than a hard refusal.)

--- a/packages/testing/nros-tests/src/fixtures/binaries/freertos.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/freertos.rs
@@ -72,22 +72,30 @@ static FREERTOS_ACTION_CLIENT_BINARY: OnceCell<PathBuf> = OnceCell::new();
 /// locator is how a test stops noticing that a fixture moved, which is #393's
 /// shape and the reason build, probe and resolver have to move together.
 ///
-/// Goes through [`super::require_prebuilt_binary_fresh`], so the leaf path is
-/// rewritten onto the row's shared cargo group when the platform is migrated
-/// (phase-340 B2/B3) — callers never spell the group dir.
+/// Goes through the row-keyed chokepoint
+/// [`super::require_prebuilt_row_binary_fresh`], so the artifact ROOT (leaf or
+/// shared cargo group) and the PROFILE both come from the manifest row —
+/// callers never spell the group dir and never name a profile constant.
 pub fn require_entry_binary(name: &str) -> TestResult<PathBuf> {
     build_rust_example(name, name)
 }
+
+/// The target triple these fixtures are built for. The row authors it too
+/// (`target = "thumbv7m-none-eabi"`), but `GroupRow` does not carry it, so this
+/// is the one component of the relative path that is still spelled here — the
+/// artifact root and the profile are asked, not assumed (issue 1027).
+const FREERTOS_QEMU_TARGET: &str = "thumbv7m-none-eabi";
 
 fn build_rust_example(name: &str, binary_name: &str) -> TestResult<PathBuf> {
     // Issue #181 — the role crates are lib-only Component pkgs since 212.L
     // (same as NuttX, see nuttx.rs `require_entry_binary`): the runnable
     // firmware is the sibling `<role>-entry` image `build-examples` prebuilds
-    // at --release. The old path probed a `qemu-freertos-<role>` bin the role
-    // crate can no longer produce, so the lane looked permanently unbuilt.
+    // at the FreeRTOS-QEMU carve-out. The old path probed a
+    // `qemu-freertos-<role>` bin the role crate can no longer produce, so the
+    // lane looked permanently unbuilt.
     let _ = binary_name;
-    let root = project_root();
-    let example_dir = root.join(format!("examples/qemu-arm-freertos/rust/{}", name));
+    let dir_rel = format!("examples/qemu-arm-freertos/rust/{name}");
+    let example_dir = project_root().join(&dir_rel);
 
     if !example_dir.exists() {
         return Err(TestError::BuildFailed(format!(
@@ -97,16 +105,24 @@ fn build_rust_example(name: &str, binary_name: &str) -> TestResult<PathBuf> {
     }
 
     // phase-338 W2 — collapsed package, short `[[bin]]` name (native convention).
-    let bin = name.to_string();
-    // phase-336 — the carve-out profile these Entry demos are prebuilt at (the
-    // emulated Cortex-M3 misses zenoh-pico's handshake window below it). Same
-    // constant the `just freertos build-fixtures` recipe uses, so the locator
-    // cannot look somewhere the builder never wrote.
-    let profile_dir = nros_cargo_profile::target_dir(nros_cargo_profile::FREERTOS_QEMU_PROFILE);
-    let binary_path = example_dir.join(format!("target/thumbv7m-none-eabi/{profile_dir}/{bin}"));
+    let bin = name;
+    // Issue 1027 — the row, not a literal. `<leaf>/target/…` was correct only
+    // for as long as `freertos` stayed out of `NROS_FIXTURE_SHARED_PLATFORMS`;
+    // it is in that list today and the artifacts are under
+    // `build/cargo-fixtures/freertos/`, so this site was one root redirect away
+    // from the NuttX failure and reached the right file only because it spelled
+    // the carve-out profile directly. Both halves now come from the row:
+    // `row_resolved_dir` (inside the chokepoint) for the root,
+    // `row_profile_dir` for the carve-out the emulated Cortex-M3 needs (it
+    // misses zenoh-pico's handshake window below it).
+    let row = crate::fixtures::groups::select_sole_row(&dir_rel)?;
+    let rel = PathBuf::from(format!(
+        "{FREERTOS_QEMU_TARGET}/{}/{bin}",
+        super::row_profile_dir(row)
+    ));
 
     // Tests must not compile fixtures — run `just build-test-fixtures` first.
-    super::require_prebuilt_binary_fresh(&binary_path)
+    super::require_prebuilt_row_binary_fresh(row, &rel)
 }
 
 pub fn build_freertos_talker() -> TestResult<&'static Path> {

--- a/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/mod.rs
@@ -884,6 +884,30 @@ pub(crate) fn cargo_target_profile_dir() -> String {
     nros_cargo_profile::target_dir(&cargo_profile_name())
 }
 
+/// The `target/` profile DIRECTORY a row's platform builds its cargo fixtures
+/// into — the platform's carve-out when it has one, the ambient profile
+/// otherwise.
+///
+/// Issue 1027 / issue 0608. A resolver that already holds its manifest row has
+/// no reason to name a profile constant: the row carries the coordinate, and
+/// `nros_cargo_profile::platform_profile` is THE platform→profile derivation
+/// (its shell twin is `nros_cargo_platform_profile`). Naming
+/// `NUTTX_RUST_PROFILE` at a call site is the same defect one level down — it
+/// hardcodes an answer that a table already gives, so a platform whose carve-out
+/// changes leaves the resolver looking in a directory the builder stopped
+/// writing.
+///
+/// This is deliberately the SAME derivation [`rel_at_row_profile`] applies to a
+/// caller-built `rel`, exposed so a resolver can ask "which profile is on disk?"
+/// BEFORE it hands a path over — which is what the NuttX carve-out/ambient
+/// choice needs.
+pub(crate) fn row_profile_dir(row: &crate::fixtures::groups::GroupRow) -> String {
+    let (platform, _lang, _rmw) = &row.coord;
+    nros_cargo_profile::platform_profile(platform)
+        .map(nros_cargo_profile::target_dir)
+        .unwrap_or_else(cargo_target_profile_dir)
+}
+
 fn cargo_build_args() -> Vec<String> {
     let mut args = vec!["build".to_string()];
     args.extend(nros_cargo_profile::build_args(&cargo_profile_name()));

--- a/packages/testing/nros-tests/src/fixtures/binaries/nuttx.rs
+++ b/packages/testing/nros-tests/src/fixtures/binaries/nuttx.rs
@@ -3,7 +3,7 @@
 //! Cached `OnceCell<PathBuf>` fixtures for the NuttX Rust / C / C++
 //! examples. Moved out of `tests/nuttx_qemu.rs` (Phase 85.5).
 
-use crate::{TestError, TestResult, project_root};
+use crate::{TestError, TestResult, fixtures::groups, project_root};
 use once_cell::sync::OnceCell;
 use std::{
     path::{Path, PathBuf},
@@ -80,6 +80,21 @@ impl NuttxArch {
         }
     }
 
+    /// The export-snapshot directory this arch's images link, relative to
+    /// `$NUTTX_DIR` — `build-nuttx.sh`'s `nros-nuttx-export-<config-id>`.
+    ///
+    /// Keyed on the CONFIG id, which today equals the arch for both live
+    /// configurations (`nuttx-config/arm/`, `nuttx-config/riscv/`). A second
+    /// config of one arch (`arm-smp`) gets its own directory and would need its
+    /// own token here; the `e_machine` probe below cannot tell two configs of
+    /// one arch apart, which `build-nuttx.sh` says in as many words.
+    fn snapshot_id(self) -> &'static str {
+        match self {
+            NuttxArch::Arm => "arm",
+            NuttxArch::RiscV => "riscv",
+        }
+    }
+
     fn rebuild_hint(self) -> &'static str {
         match self {
             NuttxArch::Arm => "just nuttx build-fixtures-arm",
@@ -114,48 +129,127 @@ fn elf_machine(path: &Path) -> Option<u16> {
     })
 }
 
-/// Path to a pre-built NuttX kernel image **for `arch`**.
+/// Root of the pre-built NuttX kernel export **for `arch`** — the artifact this
+/// lane's images actually link.
 ///
-/// Issue 0743. The predicate is "is there a kernel, and is it the architecture
-/// you asked for" — never bare `.exists()`. On 2026-08-21 a sweep died with
-/// "qemu-system-arm: … The image is from incompatible architecture" because the
-/// old resolver answered the first question and not the second: the tree had
-/// been reconfigured for riscv five days earlier, and every arm consumer was
-/// still being handed that image.
+/// # Why this reads the SNAPSHOT and not `$NUTTX_DIR/nuttx` (issue 1007)
 ///
-/// The `Err` is a ready-to-print reason naming the rebuild, because "no kernel"
-/// and "the wrong kernel" want different actions from whoever reads it.
+/// It used to read the shared tree's `nuttx` ELF. That made the build contract
+/// and the test precondition disagree about which artifact is authoritative,
+/// and the disagreement had a name: `build-nuttx.sh`'s snapshot short-circuit
+/// says outright that it "guarantees the snapshot, not `$NUTTX_DIR`", so a
+/// clean `just nuttx build-fixtures-arm` on a riscv-configured tree exited 0
+/// while every arm cell skipped — and the skip named that same command as the
+/// remedy.
+///
+/// The disagreement was resolvable in one direction only, because
+/// `$NUTTX_DIR/nuttx` is consumed by NOTHING on the path this precondition
+/// guards:
+///
+/// * the arm cells boot the FIXTURE binary (`QemuProcess::start_nuttx_virt`),
+///   never the shared tree's kernel ELF;
+/// * that fixture links `nros-nuttx-export-<arch>/{libs,startup,scripts}` and
+///   compiles against its `include/` — phase-339's build-once-link-many
+///   snapshot (`nros_board_common::nuttx_export`,
+///   `nros_build_paths::nuttx_include_root`, `nano-ros-nuttx.cmake`), with
+///   `check-nuttx-links-snapshot.sh` gating that no consumer reaches back into
+///   the live tree.
+///
+/// So this was the last consumer still keyed on the shared tree, checking an
+/// artifact no image links. Making the SHORT-CIRCUIT validate the shared tree
+/// instead (the other candidate direction) would have reverted issue 0433: the
+/// tree holds one `.config`, so demanding it hold arm forces a full
+/// reconfigure + kernel rebuild on every lane alternation, which is exactly
+/// what the snapshot exists to stop — and it would break the riscv lane
+/// symmetrically, one lane at a time, forever.
+///
+/// With this, ONE command — `just nuttx build-fixtures-arm` — makes an arm cell
+/// runnable from any tree state, because that command's C/C++ half
+/// self-provisions through `build-nuttx.sh`, whose short-circuit guarantees
+/// precisely the snapshot checked here.
+///
+/// # Still content-checked (issue 0743)
+///
+/// The predicate stays "is there a kernel export, and is it the architecture
+/// you asked for" — never bare `.exists()`. The snapshot dirs are per-arch, so
+/// the 0743 failure (one filename, two arches, last build wins) cannot recur
+/// structurally; the `e_machine` probe on `startup/crt0.o` is kept anyway
+/// because a mis-keyed or half-moved snapshot is still possible and asking the
+/// file costs one read.
+///
+/// The `Err` is a ready-to-print reason naming the rebuild, because "no export"
+/// and "the wrong export" want different actions from whoever reads it.
 pub fn nuttx_kernel_path_for(arch: NuttxArch) -> Result<PathBuf, String> {
     let dir = std::env::var("NUTTX_DIR").map_err(|_| "NUTTX_DIR not set".to_string())?;
-    let kernel = Path::new(&dir).join("nuttx");
-    if !kernel.exists() {
+    let snapshot = Path::new(&dir).join(format!("nros-nuttx-export-{}", arch.snapshot_id()));
+    snapshot_for_arch(&snapshot, arch).map_err(|why| {
+        format!(
+            "{why} Run: {}{}",
+            arch.rebuild_hint(),
+            shared_tree_note(&dir, arch)
+        )
+    })?;
+    Ok(snapshot)
+}
+
+/// Is `snapshot` a usable kernel export for `arch`?
+///
+/// Split out from [`nuttx_kernel_path_for`] so the decision is testable without
+/// a provisioned NuttX tree — the arm half of issue 0743 was untestable for
+/// exactly that reason, and the reason is the environment lookup, not the rule.
+/// The returned string is a sentence; the caller appends the remedy.
+fn snapshot_for_arch(snapshot: &Path, arch: NuttxArch) -> Result<(), String> {
+    if !snapshot.join("libs").is_dir() {
         return Err(format!(
-            "NuttX kernel not built ({}) — run: {}",
-            kernel.display(),
-            arch.rebuild_hint()
+            "no NuttX {arch:?} kernel export at {} — this lane's images link \
+             `<export>/libs` and nothing has built it.",
+            snapshot.display(),
         ));
     }
-    match elf_machine(&kernel) {
-        Some(m) if m == arch.elf_machine() => Ok(kernel),
+    // `make export` ships the startup objects; `crt0.o` is present for both
+    // configurations. When it is not, the export's own presence is the whole
+    // contract: the directory is arch-KEYED, so there is no last-build-wins
+    // ambiguity left to resolve, and refusing here would fail a host whose
+    // export is fine.
+    let probe = snapshot.join("startup/crt0.o");
+    match elf_machine(&probe) {
+        None => Ok(()),
+        Some(m) if m == arch.elf_machine() => Ok(()),
         Some(m) => {
             let found = match NuttxArch::from_elf_machine(m) {
-                Some(a) => format!("a {a:?} image"),
-                None => format!("an unknown image (e_machine {m:#x})"),
+                Some(a) => format!("a {a:?} export"),
+                None => format!("an unknown export (e_machine {m:#x})"),
             };
             Err(format!(
-                "the NuttX kernel at {} is {found}, but this lane needs {:?} ({}). The arm and \
-                 riscv configurations share that ONE filename and each `make` reconfigures the \
-                 tree (issue 0743), so the last build wins. Reconfigure and rebuild: {}",
-                kernel.display(),
-                arch,
+                "the NuttX kernel export at {} is {found}, but this lane needs {arch:?} ({}) — \
+                 the per-arch snapshot holds the wrong architecture, which means it was written \
+                 by a build whose defconfig disagrees with its directory.",
+                snapshot.display(),
                 arch.board(),
-                arch.rebuild_hint(),
             ))
         }
-        None => Err(format!(
-            "{} is not an ELF file — the NuttX build did not produce a kernel",
-            kernel.display()
-        )),
+    }
+}
+
+/// A one-line note about the shared tree, for the reader who is about to check
+/// it and be misled.
+///
+/// Issue 1007's whole cost was a diagnostic that pointed at the shared tree. It
+/// is genuinely normal for `$NUTTX_DIR` to hold the OTHER architecture — the
+/// tree carries one `.config`, and since phase-339 nothing links it — so say so
+/// rather than leaving the next reader to rediscover it. Empty when the tree
+/// holds this arch (or no kernel at all), so the message stays short in the
+/// common case.
+fn shared_tree_note(nuttx_dir: &str, arch: NuttxArch) -> String {
+    let kernel = Path::new(nuttx_dir).join("nuttx");
+    match elf_machine(&kernel).and_then(NuttxArch::from_elf_machine) {
+        Some(held) if held != arch => format!(
+            "\n  (The shared tree at {} currently holds a {held:?} kernel. That is expected and \
+             is NOT the problem: since phase-339 every consumer links the per-arch export \
+             snapshot, not the tree.)",
+            kernel.display(),
+        ),
+        _ => String::new(),
     }
 }
 
@@ -179,69 +273,28 @@ static NUTTX_SERVICE_CLIENT_BINARY: OnceCell<PathBuf> = OnceCell::new();
 static NUTTX_ACTION_SERVER_BINARY: OnceCell<PathBuf> = OnceCell::new();
 static NUTTX_ACTION_CLIENT_BINARY: OnceCell<PathBuf> = OnceCell::new();
 
-fn build_rust_example(name: &str, binary_name: &str) -> TestResult<PathBuf> {
-    let root = project_root();
-    let example_dir = root.join(format!("examples/qemu-arm-nuttx/rust/{}", name));
-
-    if !example_dir.exists() {
-        return Err(TestError::BuildFailed(format!(
-            "NuttX example directory not found: {}",
-            example_dir.display()
-        )));
-    }
-
-    // Phase 177.8.c — NuttX Rust fixtures are built at the carve-out profile
-    // (`nros_cargo_profile::NUTTX_RUST_PROFILE`, fat LTO) to dodge the
-    // armv7a-nuttx-eabihf cross-CGU codegen miscompile that any `lto = "off"`
-    // profile hits. Prefer that artifact; fall back to the ambient profile only
-    // if it is all that is present (a fresh carve-out build always wins over a
-    // stale broken one).
-    let carve_out = nros_cargo_profile::target_dir(nros_cargo_profile::NUTTX_RUST_PROFILE);
-    let release_binary_path = example_dir.join(format!(
-        "target/armv7a-nuttx-eabihf/{}/{}",
-        carve_out, binary_name
-    ));
-    let binary_path = if release_binary_path.exists() {
-        release_binary_path
-    } else {
-        // Phase 177 / G4 — an image built at the ambient (lto=off) profile hits
-        // the 177.8.c CGU miscompile: reboot loop before `main`, zero console
-        // output, surfacing as "readiness pattern never observed" with no
-        // diagnostics. Warn loudly so a stale/partial local build is recognised
-        // instead of silently exercising the known-broken profile. CI builds the
-        // carve-out via `just nuttx build-fixtures`, so this is local-dev only.
-        let ambient = super::cargo_target_profile_dir();
-        eprintln!(
-            "[nros-tests] WARNING: no `{}` build of NuttX Rust fixture `{}` \
-             found at {}; falling back to the `{}` profile, which hits the \
-             177.8.c armv7a-nuttx-eabihf codegen bug (reboot loop before main → \
-             no output → boot-readiness failure). Run `just nuttx \
-             build-fixtures` to produce the `{}` build.",
-            carve_out,
-            binary_name,
-            release_binary_path.display(),
-            ambient,
-            carve_out,
-        );
-        example_dir.join(format!(
-            "target/armv7a-nuttx-eabihf/{}/{}",
-            ambient, binary_name
-        ))
-    };
-    super::require_prebuilt_binary_fresh(&binary_path)
-}
-
 // #132 — the role crates (`talker`, `listener`, …) have been LIB-ONLY since
-// Phase 212.L.1 ("Component pkg shape — lib only, no [[bin]]"), so
+// Phase 212.L.1 ("Component pkg shape — lib only, no [[bin]]"), so the old
 // `build_rust_example` resolved a `[[bin]]` that no longer exists and every
 // nuttx-rust rtos_e2e case silently fixture-skipped. The bootable images are
-// now the `<role>_entry` ELFs (ffi-linked, locator baked to the NUTTX 7452
-// port table by their `[[fixture]]` env). Resolve those instead. `build_rust_example`
-// is retained for any caller that still wants the raw staticlib path.
-#[allow(dead_code)]
-fn _keep_build_rust_example() {
-    let _ = build_rust_example;
-}
+// now the `<role>` ELFs (ffi-linked, locator baked to the NUTTX 7452 port table
+// by their `[[fixture]]` env), resolved by [`require_entry_binary`].
+//
+// Issue 1027 deleted `build_rust_example`. It was dead (`#[allow(dead_code)]`,
+// kept alive only by a `_keep_` shim) and it was a SECOND spelling of the same
+// artifact path, so the leaf-`target/` defect had to be fixed in two places
+// that nothing kept in agreement — which is exactly how the fallback arm ended
+// up looking in the wrong directory. One resolver, one spelling.
+
+/// The target triple the NuttX **arm** Rust fixtures are built for.
+///
+/// Not a profile and not an artifact root: it is the `--target` cargo was
+/// given, and it is the one component of a fixture's relative path that no
+/// manifest row carries — `GroupRow` holds the row's artifact root, platform,
+/// group and coordinate, while the triple lives in the leaf's
+/// `.cargo/config.toml` (and, for the sibling platforms, in the row's `target`
+/// key). Everything else below is asked, not spelled.
+const NUTTX_ARM_TARGET: &str = "armv7a-nuttx-eabihf";
 
 pub fn build_nuttx_talker() -> TestResult<&'static Path> {
     NUTTX_TALKER_BINARY
@@ -283,38 +336,93 @@ pub fn build_nuttx_action_client() -> TestResult<&'static Path> {
 // #127 — per-role Entry-pkg demos (build-assert).
 // =============================================================================
 
-/// Resolve a prebuilt NuttX `<role>_entry` bootable ELF.
+/// Resolve a prebuilt NuttX `<role>` bootable ELF.
 ///
 /// Prebuilt by the `[[fixture]]` rows in `examples/fixtures.toml` (built via
-/// `just nuttx build-examples` → `fixtures-build.sh nuttx rust` at the
-/// `release` profile — the 177.8.c CGU-miscompile dodge — which runs
+/// `just nuttx build-examples` → `fixtures-build.sh nuttx rust` at the NuttX
+/// carve-out profile — the 177.8.c CGU-miscompile dodge — which runs
 /// `nros sync` + cargo; the board-centric image link needs `NUTTX_DIR`).
 /// `role` is hyphenated (`"service-server"`); since phase-338 W2 collapsed the
 /// `-entry` package into the role package, `bin` is that same short name.
-/// Mirrors [`build_rust_example`]'s
-/// release-first profile resolution.
+///
+/// # Why this asks the manifest instead of building a path (issue 1027)
+///
+/// It used to probe `<leaf>/target/<triple>/<carve-out>/<bin>` and, when that
+/// missed, `<leaf>/target/<triple>/<ambient>/<bin>`. Phase-340 moved the NuttX
+/// build into a shared cargo group dir, so under a clean
+/// `just nuttx build-fixtures-arm` NEITHER leaf path exists — MEASURED: no
+/// `examples/qemu-arm-nuttx/rust/talker/target` at all, while
+/// `build/cargo-fixtures/nuttx-*/armv7a-nuttx-eabihf/nros-minsizerel/talker`
+/// was freshly built. The first `.exists()` therefore always missed, the
+/// ambient arm always won, and the path route's root redirect then reported the
+/// binary missing at the AMBIENT profile — a working image, one directory over,
+/// reported as not prebuilt, with the miscompile warning firing for a reason
+/// that had nothing to do with the profile.
+///
+/// So the row answers both questions the literals were guessing at:
+/// [`groups::select_sole_row`] + [`groups::row_resolved_dir`] give the artifact
+/// ROOT (leaf or group, decided by the row's own `shared`/`slug`), and
+/// [`super::row_profile_dir`] gives the PROFILE from the row's coordinate. The
+/// only literal left is the target triple, which no row carries.
+///
+/// The miscompile warning is KEPT and now means what it says: the artifact is
+/// at the WRONG PROFILE — the ambient one is on disk and the carve-out is not —
+/// rather than "the artifact is not where I looked".
 pub fn require_entry_binary(role: &str, bin: &str) -> TestResult<PathBuf> {
-    let dir = project_root().join(format!("examples/qemu-arm-nuttx/rust/{role}"));
+    let dir_rel = format!("examples/qemu-arm-nuttx/rust/{role}");
+    let dir = project_root().join(&dir_rel);
     if !dir.exists() {
         return Err(TestError::BuildFailed(format!(
             "NuttX entry example not found: {}",
             dir.display()
         )));
     }
-    // Same carve-out as `require_example_binary` above — prefer the profile the
-    // builder forces, fall back to the ambient one with the artifact that a
-    // local hand-build would have left.
-    let carve_out = nros_cargo_profile::target_dir(nros_cargo_profile::NUTTX_RUST_PROFILE);
-    let forced = dir.join(format!("target/armv7a-nuttx-eabihf/{carve_out}/{bin}"));
-    let bin_path = if forced.exists() {
-        forced
-    } else {
-        dir.join(format!(
-            "target/armv7a-nuttx-eabihf/{}/{bin}",
-            super::cargo_target_profile_dir()
-        ))
-    };
-    super::require_prebuilt_binary_fresh(&bin_path)
+    let row = groups::select_sole_row(&dir_rel)?;
+    let rel = |profile: &str| PathBuf::from(format!("{NUTTX_ARM_TARGET}/{profile}/{bin}"));
+
+    // Phase 177.8.c — NuttX Rust fixtures are built at the carve-out profile
+    // (`nros_cargo_profile::platform_profile("nuttx")`, fat LTO) to dodge the
+    // armv7a-nuttx-eabihf cross-CGU codegen miscompile that any `lto = "off"`
+    // profile hits.
+    let carve_out = super::row_profile_dir(row);
+    let ambient = super::cargo_target_profile_dir();
+    let root = groups::row_resolved_dir(row);
+
+    if carve_out != ambient
+        && !root.join(rel(&carve_out)).exists()
+        && root.join(rel(&ambient)).exists()
+    {
+        // Phase 177 / G4 — an image built at the ambient (lto=off) profile hits
+        // the 177.8.c CGU miscompile: reboot loop before `main`, zero console
+        // output, surfacing as "readiness pattern never observed" with no
+        // diagnostics. Warn loudly so a local hand-build at the ambient profile
+        // is recognised instead of silently exercising the known-broken one. CI
+        // builds the carve-out via `just nuttx build-fixtures`, so this is
+        // local-dev only.
+        //
+        // The condition is now three-part on purpose: the ambient artifact must
+        // actually BE there. "Carve-out absent" alone is also what an unbuilt
+        // fixture looks like, and warning about a codegen bug on a tree that
+        // simply has not been built is the cry-wolf issue 1027 measured.
+        eprintln!(
+            "[nros-tests] WARNING: NuttX Rust fixture `{bin}` is present at the \
+             ambient `{ambient}` profile but NOT at the `{carve_out}` carve-out \
+             ({}); running the ambient build, which hits the 177.8.c \
+             armv7a-nuttx-eabihf codegen bug (reboot loop before main → no \
+             output → boot-readiness failure). Run `just nuttx build-fixtures` \
+             to produce the `{carve_out}` build.",
+            root.join(rel(&carve_out)).display(),
+        );
+        // The PATH route for this arm, not the row route: `rel_at_row_profile`
+        // rewrites a rel's profile component to the platform's carve-out, which
+        // is exactly what this arm must NOT do. `groups::resolved` redirects the
+        // artifact ROOT only, so the ambient profile survives — and the row's
+        // own `artifact_root` is what the lane narrowing attributes by.
+        return super::require_prebuilt_binary_fresh(
+            &project_root().join(&row.artifact_root).join(rel(&ambient)),
+        );
+    }
+    super::require_prebuilt_row_binary_fresh(row, &rel(&carve_out))
 }
 
 // =============================================================================
@@ -480,6 +588,74 @@ mod tests {
             "EI_DATA=2 is ELFDATA2MSB — reading e_machine little-endian there \
              yields 0x2800 and would call an arm kernel unknown"
         );
+    }
+
+    /// A snapshot dir for issue 1007's tests: `libs/` plus an optional
+    /// `startup/crt0.o` of a chosen machine.
+    fn snapshot(name: &str, libs: bool, crt0: Option<u16>) -> PathBuf {
+        let root = std::env::temp_dir().join(format!("nros-nuttx-export-test-{name}"));
+        let _ = std::fs::remove_dir_all(&root);
+        if libs {
+            std::fs::create_dir_all(root.join("libs")).expect("libs");
+        } else {
+            std::fs::create_dir_all(&root).expect("root");
+        }
+        if let Some(m) = crt0 {
+            std::fs::create_dir_all(root.join("startup")).expect("startup");
+            std::fs::write(root.join("startup/crt0.o"), elf_header(1, m)).expect("crt0");
+        }
+        root
+    }
+
+    /// Issue 1007 — the precondition now asks the artifact the images link.
+    /// A riscv-configured SHARED tree is irrelevant to it, which is the whole
+    /// point: that state used to skip every arm cell while naming as the remedy
+    /// the command that had just short-circuited.
+    #[test]
+    fn a_present_export_satisfies_its_own_arch() {
+        let arm = snapshot("arm-ok", true, Some(0x28));
+        assert!(snapshot_for_arch(&arm, NuttxArch::Arm).is_ok());
+        let riscv = snapshot("riscv-ok", true, Some(0xF3));
+        assert!(snapshot_for_arch(&riscv, NuttxArch::RiscV).is_ok());
+    }
+
+    #[test]
+    fn a_missing_export_names_the_export_not_the_tree() {
+        let none = snapshot("absent", false, None);
+        let why = snapshot_for_arch(&none, NuttxArch::Arm).expect_err("no libs ⇒ no export");
+        assert!(
+            why.contains("kernel export") && why.contains("libs"),
+            "the message must point at the export the images link, not at \
+             $NUTTX_DIR/nuttx: {why}"
+        );
+    }
+
+    #[test]
+    fn a_wrong_arch_export_is_still_caught() {
+        let mismatched = snapshot("arm-holding-riscv", true, Some(0xF3));
+        let why = snapshot_for_arch(&mismatched, NuttxArch::Arm).expect_err("riscv crt0 in arm/");
+        assert!(why.contains("RiscV"), "must name what it found: {why}");
+    }
+
+    /// The export's PRESENCE is the contract when no startup object can be
+    /// read — the directory is arch-keyed, so there is no last-build-wins
+    /// ambiguity left, and failing here would fail a host whose export is fine.
+    #[test]
+    fn an_export_without_a_startup_probe_is_accepted() {
+        let no_probe = snapshot("no-crt0", true, None);
+        assert!(snapshot_for_arch(&no_probe, NuttxArch::Arm).is_ok());
+    }
+
+    /// The shared tree's architecture is a NOTE, never the verdict — and it is
+    /// silent when it agrees, so the common failure stays one line.
+    #[test]
+    fn the_shared_tree_note_fires_only_on_a_mismatch() {
+        let tree = std::env::temp_dir().join("nros-nuttx-shared-tree-note");
+        std::fs::create_dir_all(&tree).expect("tree");
+        std::fs::write(tree.join("nuttx"), elf_header(1, 0xF3)).expect("kernel");
+        let dir = tree.to_str().expect("utf8");
+        assert!(shared_tree_note(dir, NuttxArch::Arm).contains("RiscV"));
+        assert_eq!(shared_tree_note(dir, NuttxArch::RiscV), "");
     }
 
     #[test]

--- a/packages/testing/nros-tests/src/ros2.rs
+++ b/packages/testing/nros-tests/src/ros2.rs
@@ -12,6 +12,11 @@ use std::{
 /// Default ROS 2 distro to use
 pub const DEFAULT_ROS_DISTRO: &str = "humble";
 
+/// How long a `ros2 topic echo` peer lives when the caller does not say
+/// (issue 1026) — the historical baked `timeout --foreground 10`, now named so
+/// a caller can compare its own wait against it instead of guessing.
+pub const DEFAULT_ECHO_WINDOW: Duration = Duration::from_secs(10);
+
 /// phase-304 W4 — is a specific ROS 2 distro installed under `/opt/ros/<distro>`?
 /// Distro-parametric so an edition lane (RFC-0056) can require iron/jazzy/rolling
 /// and `skip!` when absent, instead of everything assuming humble. Returns false
@@ -347,7 +352,8 @@ impl Ros2Process {
         })
     }
 
-    /// Start a ROS 2 topic echo subscriber
+    /// Start a ROS 2 topic echo subscriber that lives for
+    /// [`DEFAULT_ECHO_WINDOW`].
     ///
     /// # Arguments
     /// * `topic` - Topic name (e.g., "/chatter")
@@ -360,9 +366,34 @@ impl Ros2Process {
         locator: &str,
         distro: &str,
     ) -> TestResult<Self> {
+        Self::topic_echo_for(topic, msg_type, locator, distro, DEFAULT_ECHO_WINDOW)
+    }
+
+    /// [`Self::topic_echo`] with the subscriber's LIFETIME named by the caller
+    /// (issue 1026).
+    ///
+    /// The `timeout --foreground` is a horizon, not an implementation detail:
+    /// it is the hard cap on what the echo can ever observe, so a caller whose
+    /// own wait is longer than it silently gets a truncated transcript and a
+    /// failure that reads like "no delivery". Passing the window makes the two
+    /// numbers one decision at one site.
+    ///
+    /// `PYTHONUNBUFFERED=1` is what makes a CONDITION wait possible here at
+    /// all: `ros2 topic echo` is a Python entry point, so with stdout on a pipe
+    /// its `print`s sit in a block buffer until the process exits — which is
+    /// how the baked timeout came to double as the flush mechanism, and why
+    /// every caller used to have to drain to completion.
+    pub fn topic_echo_for(
+        topic: &str,
+        msg_type: &str,
+        locator: &str,
+        distro: &str,
+        window: Duration,
+    ) -> TestResult<Self> {
         let (env_setup, config_dir) = ros2_env_setup_with_locator(distro, locator);
+        let secs = window.as_secs().max(1);
         let cmd = format!(
-            "{env_setup} && timeout --foreground 10 ros2 topic echo {topic} {msg_type} --qos-reliability best_effort"
+            "{env_setup} && PYTHONUNBUFFERED=1 timeout --foreground {secs} ros2 topic echo {topic} {msg_type} --qos-reliability best_effort"
         );
 
         Self::spawn_bash(&cmd, format!("ros2 topic echo {topic}"), Some(config_dir))
@@ -668,18 +699,57 @@ impl Drop for Ros2Process {
     }
 }
 
-/// Helper to collect output from a process with timeout
-pub fn collect_ros2_output(process: &mut Ros2Process, timeout: Duration) -> String {
-    process.wait_for_output(timeout).unwrap_or_default()
-}
-
 /// Read everything a spawned child prints on stdout within `timeout`, without
 /// blocking forever. Shared by [`Ros2Process`] and [`crate::ros_env::RosPeer`]
 /// (phase-309) so both peer wrappers use identical non-blocking drain logic.
+///
+/// **A terminal drain, not a wait-for-readiness (issue 1026).** There is no
+/// stop condition, so a process that keeps running ALWAYS reaches the deadline
+/// — and reaching it kills the process group. Pointed at a `spin = "forever"`
+/// node the timeout is therefore the node's LIFETIME, and whatever the node
+/// would have done afterwards is unobservable by construction. To wait on a
+/// CONDITION and keep the peer alive, use [`collect_child_until`].
 pub fn wait_child_output(handle: &mut Child, name: &str, timeout: Duration) -> TestResult<String> {
+    collect_child_inner(handle, name, None, timeout)
+}
+
+/// Collect a child's stdout, returning as soon as `pattern` has appeared
+/// `expected` times — the CONDITION sibling of [`wait_child_output`], and the
+/// wait to use for a free-running node (issue 1026).
+///
+/// Never kills: the caller (or [`crate::ros_env::RosPeer`]'s `Drop`) decides
+/// when the peer dies, so a test that wants to keep observing after the marker
+/// still can. Returns whatever was printed whether or not the condition was
+/// met — the caller asserts on the content and wants the transcript in its own
+/// failure message, exactly as with
+/// [`crate::process::ManagedProcess::collect_until`].
+pub fn collect_child_until(
+    handle: &mut Child,
+    name: &str,
+    pattern: &str,
+    expected: usize,
+    timeout: Duration,
+) -> TestResult<String> {
+    collect_child_inner(handle, name, Some((pattern, expected)), timeout)
+}
+
+/// The shared drain loop. `stop` is `None` for the terminal drain (run to the
+/// deadline, then kill) and `Some((pattern, n))` for the condition wait (return
+/// at the n-th occurrence, kill nothing).
+fn collect_child_inner(
+    handle: &mut Child,
+    name: &str,
+    stop: Option<(&str, usize)>,
+    timeout: Duration,
+) -> TestResult<String> {
     use std::io::Read;
     #[cfg(unix)]
     use std::os::unix::io::AsRawFd;
+
+    let satisfied = |out: &str| match stop {
+        Some((pattern, expected)) => out.matches(pattern).count() >= expected,
+        None => false,
+    };
 
     let start = std::time::Instant::now();
     let mut output = String::new();
@@ -701,8 +771,22 @@ pub fn wait_child_output(handle: &mut Child, name: &str, timeout: Duration) -> T
 
     let mut buffer = [0u8; 4096];
     loop {
+        if satisfied(&output) {
+            // Condition met — hand the stream back so a later call keeps
+            // reading where this one stopped, and leave the peer RUNNING.
+            handle.stdout = Some(stdout);
+            return Ok(output);
+        }
         if start.elapsed() > timeout {
-            kill_process_group(handle);
+            // Only the terminal drain kills. A condition wait that misses its
+            // deadline leaves the peer alive: the caller asserts on the output
+            // and may still want to look at (or keep) the process.
+            if stop.is_none() {
+                kill_process_group(handle);
+            } else {
+                handle.stdout = Some(stdout);
+                return Ok(output);
+            }
             if output.is_empty() {
                 return Err(TestError::Timeout);
             }
@@ -729,6 +813,12 @@ pub fn wait_child_output(handle: &mut Child, name: &str, timeout: Duration) -> T
             },
             Err(_) => break,
         }
+    }
+    if stop.is_some() {
+        // Process exited (or the stream broke) before the condition was met.
+        // Give the stream back regardless; the caller decides what the missing
+        // marker means.
+        handle.stdout = Some(stdout);
     }
     Ok(output)
 }

--- a/packages/testing/nros-tests/src/ros_env.rs
+++ b/packages/testing/nros-tests/src/ros_env.rs
@@ -170,9 +170,60 @@ pub struct RosPeer {
 }
 
 impl RosPeer {
-    /// Best-effort read of everything the peer printed within `timeout`.
+    /// Drain the peer's stdout until it exits or `timeout` elapses, then KILL
+    /// it.
+    ///
+    /// **A terminal drain, not a wait-for-readiness — issue 1026.** There is no
+    /// stop condition, so a peer that keeps running always reaches the deadline
+    /// and reaching it kills its process group. Aimed at a `spin = "forever"`
+    /// nano-ros node the timeout is therefore that node's LIFETIME, not a
+    /// deadline: the test observes exactly one window and reports PASS on the
+    /// first marker inside it, whatever the node would have done next. That is
+    /// the shape issue 1013 measured — a 15 s window ended a 1 Hz talker after
+    /// twelve publishes and hid a lease defect that broke delivery in
+    /// production.
+    ///
+    /// It also reads STDOUT ONLY. Peers spawned through
+    /// [`nano_node_cmd`]/[`nano_node_cmd_rmw`] redirect `2>&1` so their
+    /// `env_logger` lines land here; a peer spawned any other way that logs to
+    /// stderr looks silent.
+    ///
+    /// Use [`Self::collect_until`] when the test is really waiting for a
+    /// CONDITION — which is nearly always.
     pub fn wait_for_output(&mut self, timeout: std::time::Duration) -> TestResult<String> {
         crate::ros2::wait_child_output(&mut self.handle, &self.name, timeout)
+    }
+
+    /// Collect the peer's stdout, returning as soon as `pattern` has appeared
+    /// `expected` times — the CONDITION wait (issue 1026).
+    ///
+    /// Kills nothing: the peer stays alive (its `Drop` still tears it down), so
+    /// the timeout bounds the WAIT rather than the node. Returns whatever was
+    /// printed whether or not the condition was met, so the caller's own
+    /// assertion carries the transcript; a harness-level failure (stdout
+    /// already taken) is rendered INTO the returned text rather than dropped,
+    /// matching [`crate::qemu::QemuProcess::collect_until`].
+    pub fn collect_until_count(
+        &mut self,
+        pattern: &str,
+        expected: usize,
+        timeout: std::time::Duration,
+    ) -> String {
+        match crate::ros2::collect_child_until(
+            &mut self.handle,
+            &self.name,
+            pattern,
+            expected,
+            timeout,
+        ) {
+            Ok(out) => out,
+            Err(e) => format!("<no output collected: {e}>"),
+        }
+    }
+
+    /// [`Self::collect_until_count`] for the single-occurrence case.
+    pub fn collect_until(&mut self, pattern: &str, timeout: std::time::Duration) -> String {
+        self.collect_until_count(pattern, 1, timeout)
     }
 
     /// Still running?

--- a/packages/testing/nros-tests/src/zephyr.rs
+++ b/packages/testing/nros-tests/src/zephyr.rs
@@ -565,11 +565,25 @@ impl ZephyrProcess {
         self.platform
     }
 
-    /// Wait for output with timeout
+    /// Wait for output with timeout, then KILL the image.
     ///
     /// Collects stdout from the process. Since Zephyr native_sim processes
     /// typically output everything quickly and then wait indefinitely,
     /// this uses a thread to avoid blocking on read().
+    ///
+    /// **A terminal drain, not a wait-for-readiness — issue 1026.** The only
+    /// early-outs are four hard-coded terminal markers
+    /// (`SUCCESS`/`COMPLETE`/`session error`/`Failed to create context`), so an
+    /// image that keeps spinning always runs to the deadline, and the deadline
+    /// kills it *unconditionally* — every return path here passes through
+    /// `kill_process_group`. Aimed at a `spin_blocking` node the timeout is
+    /// that node's LIFETIME, and whatever it would have printed afterwards is
+    /// unobservable by construction (issue 1013 measured the cost of exactly
+    /// this on the RTOS pubsub cell).
+    ///
+    /// Use [`Self::wait_for_pattern`] when the test is waiting for a
+    /// CONDITION: it returns at the marker, returns the output either way, and
+    /// leaves the image running for the next wait.
     ///
     /// # Arguments
     /// * `timeout` - Maximum time to wait

--- a/packages/testing/nros-tests/tests/interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/interop_e2e.rs
@@ -303,15 +303,37 @@ fn interop(#[case] cell: Cell) {
         Scenario::ZenohPubsubNanoToRos2 => {
             let router = start_zenoh_router();
             let locator = router.locator();
-            let mut ros2 =
-                match Ros2Process::topic_echo(TOPIC, STRING_MSG, &locator, DEFAULT_ROS_DISTRO) {
-                    Ok(p) => p,
-                    Err(e) => skip!("ROS 2 topic echo could not start: {e}"),
-                };
+            // issue 1026 — the echo peer's LIFETIME and the wait are one
+            // decision, made here. `ECHO_WINDOW` is the `timeout --foreground`
+            // baked into the peer; the wait is shorter so a missed sample is
+            // reported as "no delivery" rather than as the peer vanishing
+            // mid-read. The wait itself is a CONDITION (one `data:` line), so
+            // the common path returns as soon as delivery happens.
+            const ECHO_WINDOW: Duration = Duration::from_secs(25);
+            const ECHO_WAIT: Duration = Duration::from_secs(20);
+            let mut ros2 = match Ros2Process::topic_echo_for(
+                TOPIC,
+                STRING_MSG,
+                &locator,
+                DEFAULT_ROS_DISTRO,
+                ECHO_WINDOW,
+            ) {
+                Ok(p) => p,
+                Err(e) => skip!("ROS 2 topic echo could not start: {e}"),
+            };
             let mut talker = spawn_nano_zenoh(&talker_binary(), "native-rs-talker", &locator);
-            let out = ros2
-                .wait_for_output(Duration::from_secs(8))
-                .unwrap_or_default();
+            // Bound stated: this cell asserts FIRST delivery only. It cannot
+            // see a session that dies after the first sample — that is the
+            // continuity assertion, and it lives on the pubsub cells that
+            // count samples over a lease interval (issue 1013).
+            // The asserted string and the diagnostic go on DIFFERENT channels
+            // (issue 0670): the error text names the pattern it waited for, so
+            // folding it into `out` would make `count_pattern(&out, "data:")`
+            // match the complaint about the missing samples.
+            let (out, why) = match ros2.wait_for_output_count("data:", 1, ECHO_WAIT) {
+                Ok(o) => (o, String::new()),
+                Err(e) => (String::new(), format!("\n[wait data:] {e}")),
+            };
             talker.kill();
 
             let n = count_pattern(&out, "data:");
@@ -325,7 +347,7 @@ fn interop(#[case] cell: Cell) {
                  conventions carry no version of their own, so the zenoh numbers are \
                  the closest available proxy; the ROS PACKAGE version is not — it is a \
                  wrapper version and says nothing about the zenoh inside it.)\n\
-                 ROS 2 output:\n{out}",
+                 ROS 2 output:\n{out}{why}",
                 cell.note,
                 nros_tests::process::zenoh_pairing_versions()
             );
@@ -479,9 +501,20 @@ fn interop(#[case] cell: Cell) {
                 "native-rs-service-client",
                 &locator,
             );
-            let out = client
-                .wait_for_all_output(Duration::from_secs(15))
-                .unwrap_or_default();
+            // issue 1026 — was `wait_for_all_output(15s)`, which KILLS at the
+            // deadline: the SUT's whole life was the wait window, so the cell
+            // could only ever mean "did it answer within 15 s of birth".
+            // `collect_until` waits on the CONDITION instead and leaves the
+            // client running.
+            //
+            // Bound stated: the demo client is SINGLE-SHOT — `State::done`
+            // latches on the first reply and it then idles forever — so one
+            // result is everything it will ever print, and no count above 1 is
+            // available to assert here. What this cell therefore cannot see is
+            // whether the session survives past that first call; that is the
+            // continuity question, and it belongs to a cell whose SUT keeps
+            // issuing requests.
+            let out = client.collect_until(output::SERVICE_RESULT_PREFIX, Duration::from_secs(15));
             ros2_server.kill();
 
             // The nano client prints the demo `Result of add_two_ints:` line.

--- a/packages/testing/nros-tests/tests/native_api.rs
+++ b/packages/testing/nros-tests/tests/native_api.rs
@@ -322,10 +322,21 @@ fn test_native_service_communication_callback(
 
     let mut client = spawn_native(&client_bin, lang, "service-client-callback", &locator);
 
-    let client_output = client
-        .wait_for_output_pattern(SERVICE_RESULT_PREFIX, Duration::from_secs(15))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    // issue 1026 — every client wait in this file used to read
+    // `wait_for_output_pattern(M, t).or_else(|_| wait_for_all_output(2s))
+    //  .unwrap_or_default()`, which destroys its own evidence twice: the strict
+    // wait had already collected the transcript into an `Err` the `or_else`
+    // drops, and the fallback then KILLS the client to gather the two seconds
+    // that remain — so a failing cell reports the tail of a run it truncated.
+    // `collect_until` is the primitive for "assert on the content yourself":
+    // it returns at the marker, returns everything printed when the marker
+    // never comes, and kills nothing.
+    //
+    // Bound stated (all of these): a single request/goal, asserted on its
+    // terminal line. Nothing here observes what the SUT does after that.
+    // Swept with:
+    //   rg -n 'or_else\(\|_\| client\.wait_for_all_output' packages/testing
+    let client_output = client.collect_until(SERVICE_RESULT_PREFIX, Duration::from_secs(15));
 
     server.kill();
 
@@ -373,10 +384,7 @@ fn service_callback_interop_body(
         .expect("service server did not become ready");
 
     let mut client = spawn_native(client_bin, client_lang, "service-client-callback", locator);
-    let client_output = client
-        .wait_for_output_pattern(SERVICE_RESULT_PREFIX, Duration::from_secs(15))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(SERVICE_RESULT_PREFIX, Duration::from_secs(15));
     server.kill();
 
     eprintln!("cross-lang callback client output:\n{}", client_output);
@@ -452,10 +460,7 @@ fn rust_callback_interop_body(locator: &str, server_bin: &Path, server_lang: Lan
         .expect("service server did not become ready");
 
     let mut client = spawn_rust_callback_client(&client_bin, locator);
-    let client_output = client
-        .wait_for_output_pattern(SERVICE_RESULT_PREFIX, Duration::from_secs(20))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(SERVICE_RESULT_PREFIX, Duration::from_secs(20));
     server.kill();
 
     eprintln!(
@@ -514,14 +519,24 @@ fn native_action_communication_body(lang: Language, locator: &str) {
     let mut client = spawn_native(&client_bin, lang, "action-client", locator);
 
     // Both clients end with the demo terminal line `Result received: [...]`.
-    let client_output = client
-        .wait_for_output_pattern(ACTION_RESULT_PREFIX, Duration::from_secs(20))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    //
+    // issue 1026 — the `.or_else(wait_for_all_output).unwrap_or_default()`
+    // idiom this replaces destroyed its own evidence twice over: the strict
+    // wait had already consumed the transcript into an `Err` the `or_else`
+    // dropped, and the fallback then KILLED the client to collect the two
+    // seconds that remained. `collect_until` returns at the marker, returns
+    // everything printed when it does not appear, and kills nothing.
+    let client_output = client.collect_until(ACTION_RESULT_PREFIX, Duration::from_secs(20));
 
-    let server_output = server
-        .wait_for_all_output(Duration::from_secs(2))
-        .unwrap_or_default();
+    // The server is free-running (`spin = "forever"`), so there is no drain
+    // that ends by itself. Wait for the marker the assertion below names — by
+    // now the goal has already completed on the client side, so this normally
+    // returns immediately from what is already buffered.
+    //
+    // Bound stated: this observes the server only up to the FIRST goal it
+    // executed. A server that wedges after one goal, or whose session lapses
+    // later, is outside what this cell can see — it drives exactly one goal.
+    let server_output = server.collect_until(ACTION_EXECUTING_MARKER, Duration::from_secs(5));
     server.kill();
 
     eprintln!(
@@ -606,10 +621,7 @@ fn test_cpp_action_communication_callback(zenohd_unique: ZenohRouter) {
         &locator,
     );
 
-    let client_output = client
-        .wait_for_output_pattern(ACTION_RESULT_PREFIX, Duration::from_secs(25))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(ACTION_RESULT_PREFIX, Duration::from_secs(25));
 
     server.kill();
 
@@ -675,10 +687,7 @@ fn test_action_callback_interop_cpp_client_c_server(zenohd_unique: ZenohRouter) 
         &locator,
     );
 
-    let client_output = client
-        .wait_for_output_pattern(ACTION_RESULT_PREFIX, Duration::from_secs(25))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(ACTION_RESULT_PREFIX, Duration::from_secs(25));
     server.kill();
 
     eprintln!(
@@ -726,10 +735,7 @@ fn test_action_callback_interop_c_client_cpp_server(zenohd_unique: ZenohRouter) 
         .expect("C++ action server did not become ready");
     let mut client = spawn_native(&client_bin, Language::C, "action-client", &locator);
 
-    let client_output = client
-        .wait_for_output_pattern(ACTION_RESULT_PREFIX, Duration::from_secs(25))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(ACTION_RESULT_PREFIX, Duration::from_secs(25));
     server.kill();
 
     eprintln!(
@@ -778,10 +784,7 @@ fn test_cpp_action_goal_rejection(zenohd_unique: ZenohRouter) {
     let mut client = ManagedProcess::spawn_command(client_cmd, "cpp-action-client")
         .expect("Failed to start cpp-action-client");
 
-    let client_output = client
-        .wait_for_output_pattern(ACTION_GOAL_REJECTED_PREFIX, Duration::from_secs(20))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(ACTION_GOAL_REJECTED_PREFIX, Duration::from_secs(20));
 
     server.kill();
     eprintln!("C++ action client output:\n{}", client_output);
@@ -1308,11 +1311,14 @@ fn native_rust_service_interop(lang: Language, locator: &str) {
     let mut client = ManagedProcess::spawn_command(client_cmd, "rust-service-client")
         .expect("Failed to start Rust service client");
 
-    let client_output = client
-        .wait_for_output_pattern(SERVICE_RESULT_PREFIX, Duration::from_secs(30))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    let client_output = client.collect_until(SERVICE_RESULT_PREFIX, Duration::from_secs(30));
 
+    // issue 1026 — a DIAGNOSTIC drain, and deliberately left as one: nothing
+    // below asserts on `server_output`, it is only `eprintln!`ed beside the
+    // client's, and by this point the client has already printed its result so
+    // the server's side of the exchange is in the pipe. The 2 s is therefore a
+    // bound on the PRINTOUT, not on anything observed. The kill it performs is
+    // the teardown this test wanted anyway.
     let server_output = server
         .wait_for_all_output(Duration::from_secs(2))
         .unwrap_or_default();

--- a/packages/testing/nros-tests/tests/native_async_roundtrip_e2e.rs
+++ b/packages/testing/nros-tests/tests/native_async_roundtrip_e2e.rs
@@ -56,10 +56,16 @@ fn native_async_service_client_awaits_reply(zenohd_unique: ZenohRouter) {
     });
 
     // Async client runs once, awaits the reply, logs it, exits.
+    //
+    // issue 1026 — the reply line is this client's TERMINAL event, so wait for
+    // it rather than draining 30 s and killing whatever is left. Same
+    // assertion, but it now returns the moment the awaited Promise resolves
+    // and the failure carries the full transcript instead of the last window.
     let mut cli = spawn(&client, &locator, "async-service-client");
-    let out = cli
-        .wait_for_all_output(Duration::from_secs(30))
-        .unwrap_or_default();
+    let out = cli.collect_until(
+        nros_tests::output::SERVICE_RESULT_PREFIX,
+        Duration::from_secs(30),
+    );
     srv.kill();
 
     assert!(
@@ -94,15 +100,35 @@ fn native_async_action_client_awaits_goal_and_result(zenohd_unique: ZenohRouter)
         panic!("action server never became ready")
     });
 
+    // issue 1026 — this waited 40 s, killed the client, and then asserted only
+    // GOAL ACCEPTANCE, which is a MID-RUN marker: the client awaits acceptance,
+    // then streams feedback, then awaits the result. A hang anywhere after
+    // acceptance — a feedback stream that never yields, a `get_result` Promise
+    // that never resolves — printed the accepted line and reported PASS.
+    //
+    // So the wait and the assertion now name the client's TERMINAL event, the
+    // result line, and acceptance is asserted on the way there.
+    //
+    // Bound stated: one goal. Feedback CONTENT is not asserted here (the
+    // Fibonacci sequence is checked by the sync action cells); what this adds
+    // is that the async `.await` path reaches its end, not just its middle.
     let mut cli = spawn(&client, &locator, "async-action-client");
-    let out = cli
-        .wait_for_all_output(Duration::from_secs(40))
-        .unwrap_or_default();
+    let out = cli.collect_until(
+        nros_tests::output::ACTION_RESULT_PREFIX,
+        Duration::from_secs(40),
+    );
     srv.kill();
 
     assert!(
         out.contains(nros_tests::output::ACTION_GOAL_ACCEPTED_MARKER),
         "async action client never resolved its awaited goal acceptance — the \
          tokio spin_async + .await path did not complete against the server.\n{out}"
+    );
+    assert!(
+        out.contains(nros_tests::output::ACTION_RESULT_PREFIX),
+        "async action client accepted the goal but never resolved its awaited \
+         RESULT — the .await path stalled after acceptance (feedback stream or \
+         get_result), which the old goal-acceptance-only assertion reported as \
+         a pass.\n{out}"
     );
 }

--- a/packages/testing/nros-tests/tests/ros_editions_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros_editions_e2e.rs
@@ -186,14 +186,21 @@ fn ros_edition_interop(#[case] rmw: Rmw, #[case] workload: Workload, #[case] dir
                 .expect("spawn ros2 topic pub");
             let mut listener = ros_env::spawn_process(lane.nano_cmd(&[]), "nano-listener")
                 .expect("spawn nano listener");
-            let out = listener
-                .wait_for_output(Duration::from_secs(45))
-                .unwrap_or_default();
+            // issue 1026 — wait on the SAMPLE, not on 45 s of the listener's
+            // life. `wait_for_output` had no stop condition, so it always ran
+            // the full window and killed the node at the end; a cell that
+            // asserts first delivery paid 45 s for it and, worse, could not
+            // have observed anything past it anyway.
+            //
+            // Bound stated: FIRST delivery only. Nothing here can see a
+            // session that lapses after the first sample — the edition axis is
+            // about type_hash + keyexpr compatibility, and one matched sample
+            // settles that; continuity belongs to the pubsub cells that count
+            // samples across a lease interval (issue 1013).
+            let marker = format!("{} [hello]", nros_tests::output::LISTENER_LOG_PREFIX);
+            let out = listener.collect_until(&marker, Duration::from_secs(45));
             assert!(
-                out.contains(&format!(
-                    "{} [hello]",
-                    nros_tests::output::LISTENER_LOG_PREFIX
-                )),
+                out.contains(&marker),
                 "nano-ros listener did not receive the ROS String on /chatter ({rmw:?}):\n{out}"
             );
         }
@@ -205,11 +212,16 @@ fn ros_edition_interop(#[case] rmw: Rmw, #[case] workload: Workload, #[case] dir
                 .expect("spawn rclpy server");
             let mut client = ros_env::spawn_process(lane.nano_cmd(&[]), "nano-srv-client")
                 .expect("spawn nano client");
-            let out = client
-                .wait_for_output(Duration::from_secs(45))
-                .unwrap_or_default();
+            // issue 1026 — wait on the REPLY, not on 45 s of the client's life.
+            //
+            // Bound stated: the demo service client is single-shot (it latches
+            // `done` after the first reply and idles), so one result is all it
+            // will ever print; this cell says nothing about the session after
+            // that call.
+            let expected = nros_tests::output::service_result_line(5);
+            let out = client.collect_until(&expected, Duration::from_secs(45));
             assert!(
-                out.contains(&nros_tests::output::service_result_line(5)),
+                out.contains(&expected),
                 "nano-ros service-client did not get sum 5 from the ROS server ({rmw:?}):\n{out}"
             );
         }
@@ -233,9 +245,13 @@ fn ros_edition_interop(#[case] rmw: Rmw, #[case] workload: Workload, #[case] dir
                 .expect("spawn rclpy action server");
             let mut client = ros_env::spawn_process(lane.nano_cmd(&[]), "nano-action-client")
                 .expect("spawn nano client");
-            let out = client
-                .wait_for_output(Duration::from_secs(60))
-                .unwrap_or_default();
+            // issue 1026 — wait on the RESULT, not on 60 s of the client's
+            // life. The result line is terminal for this client, so the wait
+            // and the assertion now name the same event.
+            //
+            // Bound stated: one goal, one result. Feedback ordering and what
+            // the client does after the result are not observed here.
+            let out = client.collect_until("Result received:", Duration::from_secs(60));
             assert!(
                 out.contains("Result received:") && out.contains("34"),
                 "nano-ros action-client did not get the Fibonacci result from the ROS server ({rmw:?}):\n{out}"

--- a/packages/testing/nros-tests/tests/services.rs
+++ b/packages/testing/nros-tests/tests/services.rs
@@ -18,6 +18,31 @@ use nros_tests::{
 use rstest::rstest;
 use std::{path::PathBuf, process::Command, time::Duration};
 
+/// The native Rust service client's per-attempt FAILURE marker.
+///
+/// `examples/native/rust/service-client/src/lib.rs` logs
+/// `Service call failed, retrying: {:?}` from the `Err` arm of
+/// `call_for_name` — the same wording every Rust group copy uses
+/// (`examples/{qemu-arm-nuttx,qemu-arm-freertos,threadx-linux}/rust/
+/// service-client`). MEASURED at 1 Hz, the timer period, starting ~1 s after
+/// spawn.
+///
+/// Issue 1026: the two tests below used to grep `"Timed out waiting"`, a
+/// string NOTHING in this tree prints for `/add_two_ints` — the only producer
+/// of that wording is the unrelated `service-client-callback` example, and it
+/// spells it `Timed out waiting for reply to {} + {}`. Both waits therefore
+/// always hit their deadline; the timeout test's third disjunct
+/// (`!client.is_running()`) then made it true by construction, because the
+/// `wait_for_all_output` fallback had just killed the process.
+///
+/// Not in `nros_tests::output` only because this wave owns one file; promoting
+/// it there (beside `SERVICE_RESULT_PREFIX`) is the right follow-up.
+const SERVICE_CALL_FAILED_MARKER: &str = "Service call failed, retrying:";
+
+/// How many consecutive failures prove the client is RETRYING rather than
+/// reporting once and wedging. At the measured 1 Hz this is reached in ~3 s.
+const SERVICE_RETRY_EVIDENCE: usize = 3;
+
 // =============================================================================
 // (Phase 182.3) `test_service_{server,client}_builds` removed — they only
 // asserted the service fixtures compiled, covered by `build-all` + the service
@@ -92,21 +117,38 @@ fn test_service_client_starts_without_server(
     let mut client = ManagedProcess::spawn_command(cmd, "native-rs-service-client")
         .expect("Failed to start service client");
 
-    // Without a server the client must report a failure (and exit non-zero)
-    // rather than hanging or crashing: either the wait-for-service timeout,
-    // or — on backends whose readiness probe is optimistic (the CFFI zenoh
-    // path has no liveliness probe) — the per-call timeout.
-    let output = client
-        .wait_for_output_pattern("Timed out waiting", Duration::from_secs(10))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    // Without a server the very first call must FAIL and SAY SO. That is the
+    // whole property here: the error path is reachable and audible.
+    //
+    // Issue 1026 — this waits on the CONDITION, not on a lifetime. The client
+    // is `spin = "forever"` (issue 0274) and never exits, so the old
+    // `wait_for_output_pattern(dead pattern) → wait_for_all_output` pair spent
+    // 12 s and then KILLED it; worse, the `or_else` threw away the 10 s of
+    // output the first wait had collected, so the assertion only ever saw the
+    // last 2 s.
+    let (output, why) =
+        client.collect_until_count(SERVICE_CALL_FAILED_MARKER, 1, Duration::from_secs(15));
+    let alive = client.is_running();
+    // We own the lifetime; nothing above kills it.
+    client.kill();
 
     eprintln!("Client output (no server):\n{}", output);
 
     assert!(
-        output.contains("Timed out waiting for /add_two_ints service")
-            || output.contains("Service call failed"),
-        "client without a server should report the wait-for-service or call timeout"
+        output.contains(SERVICE_CALL_FAILED_MARKER),
+        "client without a server must report the failed call (`{SERVICE_CALL_FAILED_MARKER}`); \
+         got:\n{output}{}",
+        why.unwrap_or_default()
+    );
+    assert!(
+        !output.contains(SERVICE_RESULT_PREFIX),
+        "no server is running, so no reply can exist — yet the client printed \
+         `{SERVICE_RESULT_PREFIX}`:\n{output}"
+    );
+    assert!(
+        alive,
+        "the client must REPORT the failure and keep retrying, not die on it; \
+         it had exited by the time the first failure was observed:\n{output}"
     );
 }
 
@@ -206,20 +248,54 @@ fn test_service_client_timeout(zenohd_unique: ZenohRouter, service_client_binary
     let mut client = ManagedProcess::spawn_command(client_cmd, "service-client-timeout")
         .expect("Failed to start service client");
 
-    // Wait for client to report the wait-for-service/call timeout or exit
-    let output = client
-        .wait_for_output_pattern("Timed out waiting", Duration::from_secs(12))
-        .or_else(|_| client.wait_for_all_output(Duration::from_secs(2)))
-        .unwrap_or_default();
+    // What this test is FOR, restated after issue 1026: a client with no server
+    // must time out EVERY attempt and keep saying so at the timer cadence —
+    // not report once and wedge, not fall silent, and never manufacture a
+    // reply. The sibling above proves the error path is reachable at all; this
+    // one proves it stays reachable.
+    //
+    // The old shape could not fail on any build: it greped a string nothing
+    // prints, so the `or_else` fallback always ran, `wait_for_all_output`
+    // killed the process when ITS window closed, and the assertion's third
+    // disjunct `!client.is_running()` was therefore TRUE BY CONSTRUCTION.
+    //
+    // `collect_until_count` returns as soon as the count is reached and KILLS
+    // NOTHING on timeout (unlike `wait_for_output`/`wait_for_all_output`), so
+    // the 20 s here is a deadline, not the node's lifetime. MEASURED: the
+    // marker arrives at 1 Hz from ~1 s, so the wait returns in ~3 s.
+    let (output, why) = client.collect_until_count(
+        SERVICE_CALL_FAILED_MARKER,
+        SERVICE_RETRY_EVIDENCE,
+        Duration::from_secs(20),
+    );
+    let failures = count_pattern(&output, SERVICE_CALL_FAILED_MARKER);
+    let alive = client.is_running();
+    client.kill();
 
-    eprintln!("Timeout test output:\n{}", output);
+    eprintln!("Timeout test output ({failures} failures):\n{output}");
 
     assert!(
-        output.contains("Timed out waiting for /add_two_ints service")
-            || output.contains("Service call failed")
-            || !client.is_running(),
-        "client without a server should report the timeout (or exit)"
+        failures >= SERVICE_RETRY_EVIDENCE,
+        "a client with no server must report a failed call on every attempt: \
+         expected >= {SERVICE_RETRY_EVIDENCE} `{SERVICE_CALL_FAILED_MARKER}` within 20s, \
+         saw {failures}:\n{output}{}",
+        why.unwrap_or_default()
     );
+    assert!(
+        !output.contains(SERVICE_RESULT_PREFIX),
+        "no server is running, so every call must fail — yet the client printed \
+         `{SERVICE_RESULT_PREFIX}`:\n{output}"
+    );
+    assert!(
+        alive,
+        "the client must survive its own timeouts and keep retrying; it had \
+         exited after {failures} failures:\n{output}"
+    );
+
+    // Not observed here (stated per issue 1026's acceptance): whether the
+    // client would EVENTUALLY give up, and whether a call succeeds once a
+    // server appears. The first is not a contract the client has; the second
+    // is `test_service_multiple_sequential_calls` above.
 }
 
 // =============================================================================

--- a/packages/testing/nros-tests/tests/zephyr.rs
+++ b/packages/testing/nros-tests/tests/zephyr.rs
@@ -877,14 +877,24 @@ fn test_zephyr_to_native_e2e() {
     // Wait for communication
     eprintln!("Waiting for Zephyr → Native communication...");
 
-    // Wait for listener output (use wait_for_all_output to capture stderr where env_logger logs).
-    // 40 s: on a slow native_sim host the Zephyr talker's zenoh-pico session
-    // setup + first publish lands ~20 s after boot (issue #17). The wait always
-    // runs the full duration (listener never self-exits), so this caps
-    // wall-time, not the success path.
-    let listener_output = listener
-        .wait_for_all_output(Duration::from_secs(40))
-        .expect("Listener timed out");
+    // Wait for the listener's first SAMPLE line — `collect_until` reads stderr
+    // too (where env_logger writes), returns as soon as the marker lands, and
+    // kills nothing.
+    //
+    // issue 1026 — this was `wait_for_all_output(40s)`, which has no stop
+    // condition and KILLS at the deadline, so it always ran the full 40 s and
+    // the window was the listener's lifetime rather than a bound on the wait.
+    // 40 s is still the right cap: on a slow native_sim host the Zephyr
+    // talker's zenoh-pico session setup + first publish lands ~20 s after boot
+    // (issue #17).
+    //
+    // Bound stated: FIRST delivery only. This cell cannot see a session that
+    // lapses after the first sample — for that, count samples across a lease
+    // interval, which is what issue 1013 put on the RTOS pubsub cell.
+    let listener_output = listener.collect_until(
+        nros_tests::output::LISTENER_LOG_PREFIX,
+        Duration::from_secs(40),
+    );
 
     // Get Zephyr output for debugging
     let zephyr_output = zephyr
@@ -970,12 +980,23 @@ fn test_native_to_zephyr_e2e() {
     // Wait for communication
     eprintln!("Waiting for Native → Zephyr communication...");
 
-    // Wait for Zephyr output. 40 s: the Zephyr listener's zenoh-pico
+    // Wait for the Zephyr listener's first SAMPLE line. 40 s: its zenoh-pico
     // subscription setup is slow on a slow native_sim host (issue #17); the
     // fast native talker only delivers once the subscriber is declared.
-    let zephyr_output = zephyr
-        .wait_for_output(Duration::from_secs(40))
-        .unwrap_or_default();
+    //
+    // issue 1026 — `wait_for_output` here was a terminal drain that killed the
+    // image at the deadline, so the timeout was the guest's lifetime; on the
+    // failure path it also short-circuited on markers this cell never asserts.
+    // `wait_for_pattern` waits on the CONDITION, returns the accumulated
+    // output either way, and leaves the image running for the `zephyr.kill()`
+    // below.
+    //
+    // Bound stated: FIRST delivery only — nothing after the first received
+    // sample is observed (issue 1013 is the counting shape).
+    let zephyr_output = zephyr.wait_for_pattern(
+        nros_tests::output::LISTENER_LOG_PREFIX,
+        Duration::from_secs(40),
+    );
 
     // Get native talker output for debugging
     let talker_output = talker
@@ -1674,12 +1695,20 @@ fn test_zephyr_workspace_entry_native_sim_e2e() {
     // The external listener must log at least one real sample line.
     // Timeout is generous: on a slow native_sim host the Entry's zenoh-pico
     // session setup + first publish lands ~20 s after boot (steady-state
-    // cadence then tracks the ~2.5 s lease keepalive). `wait_for_all_output`
-    // always runs the full duration (the listener `spin_blocking`s and never
-    // self-exits), so this bounds the test wall-time, not its success path.
-    let listener_output = listener
-        .wait_for_all_output(Duration::from_secs(40))
-        .expect("Listener timed out");
+    // cadence then tracks the ~2.5 s lease keepalive).
+    //
+    // issue 1026 — was `wait_for_all_output(40s)`, which has no stop condition
+    // and kills at the deadline, so the window WAS the listener's lifetime and
+    // the cell always paid the full 40 s. `collect_until` waits on the sample
+    // line the assertion names.
+    //
+    // Bound stated: FIRST cross-process delivery only. Whether the Entry keeps
+    // publishing past that (the lease-lapse question of issue 1013) is not
+    // observed here.
+    let listener_output = listener.collect_until(
+        nros_tests::output::INT32_LISTENER_LOG_PREFIX,
+        Duration::from_secs(40),
+    );
     let entry_output = entry
         .wait_for_output(Duration::from_secs(1))
         .unwrap_or_default();


### PR DESCRIPTION
**Stacked on #305** — carries its commits too, so merge that first.

Fixes #1007, #1026 and #1027, the three issues left from phase-414's spun-out set.

## #1027 — NuttX Rust cells were 0/3, now 3/3

I re-ran them myself rather than taking the report: pubsub, service and action all green, 92 s. NuttX all languages 9/9; FreeRTOS Rust 3/3, no regression.

All three "before" failures read `not prebuilt: build/cargo-fixtures/nuttx-<slug>/armv7a-nuttx-eabihf/**nros-relwithdebinfo**/<bin>`. The root redirect had *already* worked — only the **profile** component was wrong.

Fixed as a class across all five swept sites. `row_profile_dir(row)` derives the profile from the row's platform, the same derivation `rel_at_row_profile` applies inside the chokepoint, exposed so a resolver can ask *before* handing a path over. Two of the sites are **deleted**: `build_rust_example` was dead code kept alive by a `_keep_` shim, and a second spelling of the same path — which is how the fallback arm came to look where nothing writes.

The 177.8.c miscompile warning is kept and now means what it says. Demonstrated with a real ambient build, not asserted.

**A correction to my own issue text:** I wrote that FreeRTOS was green because its fixtures land in the leaf. Wrong — `freertos` *is* in `NROS_FIXTURE_SHARED_PLATFORMS`. It was green because it happened to spell the carve-out profile directly. One profile spelling from the same failure, not one directory.

## #1007 — one command recovers an arm lane, demonstrated on a riscv tree

`nuttx_kernel_path_for` now resolves the per-arch **export snapshot**, checking `crt0.o`'s `e_machine` where readable.

The issue objected that "the snapshot is not what an image links against". That is **inverted since phase-339**: measured in `talker.d`, 6 of 7 NuttX inputs are under `nros-nuttx-export-arm/`; the arm cells boot the fixture, never `$NUTTX_DIR/nuttx`; and both callers use the path purely as a precondition and discard it.

Acceptance demonstrated on a genuinely riscv-configured tree, put back for the purpose: forced riscv reconfigure → arm precondition passes and reports an honest STALE → **one command** (2m03s) → arm Rust cells 3/0, tree still rv-virt.

## #1026 — both halves

**`services.rs` could not fail on any build.** The sharpest evidence is the old test passing *with a working server present*:

```
Timeout test output:

test test_service_client_timeout ... ok
PASS [ 14.315s]
```

Empty output — it asserted on `""` and passed on `!client.is_running()`, which the fallback's own kill had just made true. Nothing prints the greped string; the only source of that wording is an unrelated example. **A fourth defect** the issue hadn't listed: `or_else` *discards* the first wait's output, so 12 s of evidence was thrown away. 5 tests now run in 3.3 s, down from ~26 s.

**The remaining six sites** wait on a condition or state their bound.

Two findings worth reading:

1. **The baked `timeout --foreground 10` was doubling as the flush mechanism.** `ros2 topic echo` is a Python entry point, so piped prints block-buffer until exit — a count wait would have seen *nothing*. `PYTHONUNBUFFERED=1` is what makes a condition wait possible at all.
2. **`native_async_roundtrip_e2e` needed its assertion changed, not just its wait** — it asserted goal *acceptance*, a mid-run marker, so a stall in feedback or `get_result` passed. Mutation-proved.

A trap recorded rather than silently avoided: folding the wait's error text into the collected output made `count_pattern(&out, "data:")` match the *complaint* and pass silently (issue 0670's shape). The two-channel form caught it.

## Verification

`just check fast`: **192 gates OK**. `interop_e2e` **10/10 with no staleness override**; `native_async_roundtrip_e2e` 2/2; NuttX Rust `rtos_e2e` 3/3 — all re-run by me. fmt and clippy clean.

**Not run, and said so rather than implied:** `ros_editions_e2e`'s three sites skip here (per-edition fixtures need docker) — compile- and clippy-clean only. `native_api`'s C/C++ cells read STALE by mtime because this session's own counterfactual experiments touched `nros-zpico-build/src/lib.rs`; content is unchanged.

Named for follow-up, not fixed: `tests/action_multigoal.rs:76` is an **eighth** site of the `or_else` class the original table missed, and `Ros2DdsProcess::topic_echo*` still bakes the same unstated horizon behind four callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
