### PR TITLE
feat(sched): measure release jitter, the thing #515 said was invisible

### DIFF
--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1390,6 +1390,33 @@ pub struct Executor<'s> {
     /// Saturating. Without this a never-drained (or slowly-drained)
     /// image silently reports a stale prefix of its faults.
     pub(crate) monitor_violations_dropped: u32,
+    /// Release jitter: worst observed lateness of a `spin_period` wake
+    /// against its own nominal schedule, in microseconds.
+    ///
+    /// Issue #515 added a STATIC audit for one cause of cadence error --
+    /// a period that is not a multiple of the spin period. Nothing measured
+    /// the actual release instants, and `audit_spin_quantization` says so in
+    /// as many words: "the rate is preserved and no activation is dropped,
+    /// so every runtime rule is (correctly) silent -- the jitter stays
+    /// invisible until someone measures cadence on target."
+    ///
+    /// This is that measurement, and it is the one `cyclictest` exists to
+    /// report: the deviation between a timer's programmed wake-up and the
+    /// instant the task actually resumed, whose MAXIMUM is the figure of
+    /// merit for a real-time system.
+    ///
+    /// `spin_period` already holds both numbers -- `next_us` is the nominal
+    /// deadline and `now_us()` the actual -- and when the loop is late it
+    /// skips the sleep and discards the difference. That difference is the
+    /// jitter.
+    pub(crate) max_release_jitter_us: u64,
+    /// Wakes that were already past their nominal deadline, and wakes total.
+    ///
+    /// The maximum alone cannot distinguish one bad wake from a loop that is
+    /// late every single cycle, and those are different faults: the first is
+    /// a glitch, the second means the period cannot be met at all.
+    pub(crate) late_wakes: u32,
+    pub(crate) total_wakes: u32,
     /// Issue #514 — log every violation as it is detected. On by
     /// default: each rule pushed verdicts into a ring that nothing
     /// consumed in a real image, so a violated contract and a met one
@@ -1548,6 +1575,9 @@ impl<'s> Executor<'s> {
             fault_fn: None,
             spin_quantization_checked: false,
             monitor_violations_dropped: 0,
+            max_release_jitter_us: 0,
+            late_wakes: 0,
+            total_wakes: 0,
             report_violations: true,
             monitor_violations,
             // Issue 0790 — both phase tables start empty. An image that
@@ -2109,6 +2139,33 @@ impl<'s> Executor<'s> {
     /// W3b.5 — install the `DeadlineAction::Fault` hook. Without one a
     /// fault-class deadline miss panics (watchdog-visible stop on
     /// embedded targets).
+    /// Release-jitter statistics from `spin_period`: worst lateness in
+    /// microseconds, the number of wakes that were already late, and the
+    /// number of wakes total.
+    ///
+    /// The maximum is the figure of merit, and the ratio is what tells the
+    /// two failures apart: one late wake in ten thousand is a glitch, ten
+    /// thousand in ten thousand means the period cannot be met at all.
+    ///
+    /// Zero on a build with no clock -- `spin_period` refuses to run at all
+    /// there (issue 0709), so there is nothing to have measured.
+    pub fn release_jitter(&self) -> (u64, u32, u32) {
+        (
+            self.max_release_jitter_us,
+            self.late_wakes,
+            self.total_wakes,
+        )
+    }
+
+    /// Reset the release-jitter statistics. For monitoring code that logs
+    /// and clears per window, so a single early outlier does not pin the
+    /// maximum for the life of the process.
+    pub fn clear_release_jitter_stats(&mut self) {
+        self.max_release_jitter_us = 0;
+        self.late_wakes = 0;
+        self.total_wakes = 0;
+    }
+
     pub fn set_fault_handler(&mut self, f: fn(&super::monitor::Violation)) {
         self.fault_fn = Some(f);
     }
@@ -7569,10 +7626,25 @@ impl<'s> Executor<'s> {
             self.spin_once(period);
 
             if let Some(next) = next_us {
-                if let Some(now) = self.now_us()
-                    && now < next
-                {
-                    platform_sleep(core::time::Duration::from_micros(next - now));
+                if let Some(now) = self.now_us() {
+                    self.total_wakes = self.total_wakes.saturating_add(1);
+                    if now < next {
+                        platform_sleep(core::time::Duration::from_micros(next - now));
+                    } else {
+                        // Already past the nominal deadline: there is no sleep
+                        // to take, and `now - next` is the release jitter. The
+                        // loop used to skip straight to the accumulate below,
+                        // which is why lateness was invisible -- drift
+                        // compensation HIDES it, by design. Rate is preserved
+                        // and no activation is dropped, so no existing rule
+                        // fires; the cadence is simply wrong in a way nothing
+                        // reported.
+                        let late = now - next;
+                        self.late_wakes = self.late_wakes.saturating_add(1);
+                        if late > self.max_release_jitter_us {
+                            self.max_release_jitter_us = late;
+                        }
+                    }
                 }
                 // Accumulate to prevent drift (not = now + period)
                 next_us = Some(next + period_us);

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -5683,3 +5683,50 @@ fn a_subscriptions_arena_cost_scales_with_declared_depth() {
          the arena cannot be derived from a declared depth"
     );
 }
+
+/// Issue #515's audit is STATIC: it warns when a declared period is not a
+/// multiple of the spin period, and says in its own comment that "the jitter
+/// stays invisible until someone measures cadence on target". These cover the
+/// measurement that makes it visible.
+#[test]
+fn release_jitter_starts_empty_and_clears() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    assert_eq!(
+        executor.release_jitter(),
+        (0, 0, 0),
+        "nothing has been measured yet, so it must report nothing rather than \
+         a confident zero-jitter"
+    );
+    executor.clear_release_jitter_stats();
+    assert_eq!(executor.release_jitter(), (0, 0, 0));
+}
+
+/// `spin_period` must actually COUNT its wakes. Before this, `next_us` and
+/// `now_us()` were both in hand every cycle and the difference was discarded,
+/// so a loop that never met its period looked identical to one that always did.
+#[test]
+fn spin_period_counts_its_wakes_and_keeps_late_within_total() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let flag = executor.halt_flag();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        flag.store(true, portable_atomic::Ordering::SeqCst);
+    });
+    executor
+        .spin_period(core::time::Duration::from_millis(2))
+        .expect("a clock is installed, so spin_period must run");
+
+    let (max_us, late, total) = executor.release_jitter();
+    assert!(total > 0, "the loop ran, so wakes must have been counted");
+    assert!(
+        late <= total,
+        "late wakes ({late}) cannot exceed total wakes ({total})"
+    );
+    // Deliberately NOT asserting max_us > 0: a host that always meets a 2 ms
+    // period is a legitimate outcome, and a test that demanded lateness would
+    // fail on the machine behaving best.
+    assert!(
+        max_us == 0 || late > 0,
+        "a non-zero maximum ({max_us} us) with zero late wakes is contradictory"
+    );
+}


### PR DESCRIPTION
## Problem

Issue #515 added a **static** audit for one cause of cadence error: a period that is not an integer multiple of the executor's spin period lands on the spin grid instead of the declared cadence (a 33 ms timer on a 5 ms spin alternates 35/30, mean 33.0). Its own comment names what it could not do:

> the rate is preserved and no activation is dropped, so every runtime rule is (correctly) silent — **the jitter stays invisible until someone measures cadence on target.**

Nothing measured actual release instants.

## Change

`spin_period` already held both numbers — `next_us` is the nominal deadline, `now_us()` the actual. When the loop is late it skips the sleep and drops the difference:

```rust
if let Some(now) = self.now_us() && now < next {
    platform_sleep(...);
}
next_us = Some(next + period_us);   // lateness discarded here
```

Drift compensation **hides** lateness by design, which is exactly why nothing reported it. That difference is the jitter, and it is now recorded.

This is also the most established probe in real-time practice: `cyclictest` exists to report one thing — the deviation between a timer's programmed wake-up and the instant the task actually resumed — and its **maximum** is the figure of merit.

### Three fields, not one

`max_release_jitter_us`, `late_wakes`, `total_wakes`.

A maximum alone cannot tell two different faults apart. One late wake in ten thousand is a glitch; ten thousand in ten thousand means the period cannot be met at all. Both show the same maximum.

### Readable

`release_jitter()` returns all three; `clear_release_jitter_stats()` resets them for monitoring code that logs per window.

Both public deliberately. A statistic nothing can read is the defect this repo already carries in Zephyr's `tracing_packet_drop_num` — every dropped trace packet is counted into a `static` with no accessor, no shell command, and no reader anywhere in the tree.

## Cost

A comparison and two saturating adds, on a path that already reads the clock twice. Zero on a build without a clock, where `spin_period` refuses to run at all (issue 0709) — so there is nothing to have measured, and the fields say so rather than reporting a confident zero.

## Tests

- empty-start and clear contract
- `spin_period` actually counts its wakes, with `late <= total`

Deliberately **not** asserting that lateness occurs. A host that always meets a 2 ms period is a legitimate outcome, and a test demanding jitter would fail on the machine behaving best.

## Verification

```
cargo test -p nros-node --features std
  test result: ok. 300 passed; 0 failed
  test result: ok. 5 passed; 0 failed
```

Builds clean on default (no_std) and `alloc`.

Same note as #308: `cargo test -p nros-node` with default features does not compile, on this branch and on main alike — `elapse_then_spin_once` in `tests.rs` is `#[cfg(feature = "alloc")]` while its callers are not. `--features std` is the working invocation. Predates both PRs.

## Relationship to #308

Independent. #308 records worst *execution* time so `budget_us` can be sized; this records worst *release* lateness so the cadence itself can be judged. Both were values the executor already computed and discarded. No overlapping edits.
