### PR TITLE
feat(phase-400 W1): a workspace's own platform packages join the search path

### DIFF
--- a/docs/roadmap/phase-400-unified-configuration.md
+++ b/docs/roadmap/phase-400-unified-configuration.md
@@ -1,7 +1,7 @@
 # Phase 400 — the unified config system: build it, migrate onto it, retire the rest
 
-**Status (2026-09-01): W2-W5, W7 and W8 done; W6's `executor`, `transport`,
-`zenoh.tx`, `memory`, `params` and `rmw` tenants done, its remaining tenants and W1
+**Status (2026-09-04): W1-W5, W7 and W8 done; W6's `executor`, `transport`,
+`zenoh.tx`, `memory`, `params` and `rmw` tenants done, its remaining tenants
 outstanding.** Design is
 [RFC-0086](../design/0086-unified-configuration-transport-tenant-and-coupling.md),
 which amends RFC-0049 (Stable) and adopts RFC-0071 D8. Nothing here proposes a
@@ -54,7 +54,7 @@ them. When W3 lands that file is a transport stanza and nothing else.
 
 | | What | Gate | State |
 | --- | --- | --- | --- |
-| **W1** | Platform axis resolves like rmw: descriptor beside its crate, by name over a search path | a platform outside the tree builds without forking `config/` | |
+| **W1** | Platform axis resolves like rmw: descriptor beside its crate, by name over a search path | a platform outside the tree builds without forking `config/` | **done** |
 | **W2** | De-name the platform sections — `[build.<rmw>]`, `[knobs.<rmw>.tx]` | a second backend receives platform knobs with neither side naming the other | **done** |
 | **W3** | `transport` tenant + `requires` / `implies` / `exactly-one-of` in the resolver | serial-only image builds with no hand-written link or driver lines | **done** |
 | **W4** | Provenance: `explain` reports implied and overridden | every knob prints rung, rule, and override | **done** |
@@ -71,25 +71,53 @@ those knobs are scattered, not wrong.
 
 ## W1 — the platform axis resolves like the others
 
-RFC-0049 opens by rejecting a central file, then implements one. rmw and board
-descriptors live in their packages; platform descriptors live in
+**Done.** The move landed 2026-08-30 in `3164c93a7`; the discovery half landed
+2026-09-04 (below). This section is kept because the shape it argues for is now
+the shape the tree has, and because two descriptors deliberately did not move.
+
+RFC-0049 opens by rejecting a central file, then implemented one. rmw and board
+descriptors live in their packages; platform descriptors lived in
 `config/<name>/` behind a single `--platforms-dir` root.
 
 * Move `config/<name>/nros-platform.toml` →
-  `packages/platform/nros-platform-<name>/nros-platform.toml`.
-* Resolve by name over a search path of workspaces, reusing RFC-0071 D5's
-  resolver rather than writing a second one.
+  `packages/platform/nros-platform-<name>/nros-platform.toml`. **Done for the
+  five platforms that HAVE a crate** — `posix`, `zephyr`, `freertos`, `nuttx`,
+  `threadx`. `bare-metal` and `generic` stay in `config/`, and that is not
+  residue: neither names a crate to sit beside, because neither is a port. They
+  are the fallbacks a board selects when no port applies, so `config/` is their
+  correct home until something owns them.
+* Resolve by name over a search path. **Done.** The loader keys each descriptor
+  on `names.first()`, falling back to the directory, so a package resolves under
+  the name it declares rather than the name of the folder someone cloned it
+  into.
 * Keep `--platforms-dir` / `$NROS_PLATFORMS_DIR` as an explicit single-root
-  override. It stops being the only way in.
+  override. It stops being the only way in. **Done** — but this was the half
+  that lagged, and it lagged silently. The search path was two fixed in-tree
+  directories plus the override, so an out-of-tree platform package resolved
+  ONLY if a human exported the variable; without it the build fell through to
+  the builtins with a `cargo:warning`, which reads as a working build. Nothing
+  derived the path from the workspace.
+
+  `nros ws board-facts` now does, because it is already the seam that knows
+  the workspace and already hands down `NROS_PLATFORM_NAME` and
+  `NROS_BOARD_TOML`. It scans the workspace for `<root>/<pkg>/nros-platform.toml`
+  and puts each `<root>` on `NROS_PLATFORMS_DIR`, after any value the caller
+  set — an explicit override still outranks discovery. Build outputs
+  (`build/`, `install/`, `log/`, `target/`) are skipped by name: they hold
+  COPIES of the very descriptors being looked for, and a copy resolving as a
+  platform is worse than not finding one.
 
 **Trap.** `config/` also holds `git-settings.txt`, `rust-targets.txt` and a
-README. This wave moves the platform descriptors only; `config/` does not
+README. This wave moved the platform descriptors only; `config/` does not
 disappear.
 
 **Gate.** A platform package outside the tree resolves and builds with
-`config/` untouched.
-
----
+`config/` untouched. **Met, and measured end to end**: a workspace holding
+`src/nros-platform-acme/nros-platform.toml` (`names = ["acme"]`,
+`[knobs.params] max_parameters = 77`) emits
+`NROS_PLATFORMS_DIR=<ws>/src` from `board-facts` with nothing exported, and a
+build resolving `acme` over that path compiles
+`pub const MAX_PARAMETERS: usize = 77;` — `config/` untouched throughout.
 
 ## W2 — de-name the platform sections
 
@@ -492,7 +520,11 @@ resolves is a mechanism people still use.
 * Env vars that were the *only* home for a knob before nano-ros #0749/#0752
   keep their names as front-ends. Env vars that duplicated a ladder knob are
   removed.
-* `config/<name>/nros-platform.toml` stops being read after W1's grace period.
+* `config/<name>/nros-platform.toml` stops being read after W1's grace period
+  — **for the five platforms W1 moved**. `config/bare-metal` and
+  `config/generic` are not a grace period and must keep resolving: neither has
+  a crate to live beside (see W1), so `config/` remains a legitimate rung of
+  the search path rather than the old central file.
 * A gate asserts no knob has two readers.
 
 **Gate.** For every migrated knob, exactly one reader exists, and

--- a/packages/cli/nros-cli-core/src/cmd/board_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/board_facts.rs
@@ -94,11 +94,45 @@ pub fn resolve(
             differing.join(", ")
         ));
     }
-    resolved
+    let mut out = resolved
         .into_iter()
         .next()
         .map(|(_, f)| f)
-        .ok_or_else(|| eyre!("{}: no [deploy.*] blocks", ws.display()))
+        .ok_or_else(|| eyre!("{}: no [deploy.*] blocks", ws.display()))?;
+    // phase-400 W1 — platform packages in the USER's workspace.
+    //
+    // W1 says resolution is by name over a search path and that
+    // `$NROS_PLATFORMS_DIR` "stops being the only way in". For an in-tree
+    // platform it did: `default_search_path` carries `packages/platform`. For a
+    // platform package in the user's own workspace it did NOT — nothing derived
+    // the search path from the workspace, so such a package resolved only if a
+    // human exported the variable by hand, and otherwise fell through to the
+    // builtins with a warning.
+    //
+    // This is the seam that knows the workspace, so it is where the answer
+    // belongs — the same way `NROS_BOARD_TOML` and `NROS_PLATFORM_NAME` are
+    // handed down rather than rediscovered by every build script.
+    //
+    // A caller's own value comes FIRST: an explicit `--platforms-dir` is an
+    // override and must keep outranking discovery.
+    let mut roots: Vec<String> = env("NROS_PLATFORMS_DIR")
+        .map(|v| {
+            v.split(':')
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    for dir in workspace_platform_roots(ws) {
+        let d = dir.display().to_string();
+        if !roots.contains(&d) {
+            roots.push(d);
+        }
+    }
+    if !roots.is_empty() {
+        out.insert("NROS_PLATFORMS_DIR".into(), roots.join(":"));
+    }
+    Ok(out)
 }
 
 /// Do two spellings name the SAME board?
@@ -506,6 +540,72 @@ netstack = "lwip"
 sdk = { freertos = "{env:FREERTOS_DIR}", lwip = "{env:LWIP_DIR}" }
 "#;
 
+    /// phase-400 W1 — a platform package in the USER's workspace is found
+    /// WITHOUT anyone exporting `NROS_PLATFORMS_DIR`.
+    ///
+    /// The assertion is on the emitted search path rather than on a built
+    /// artifact because this seam's job ends at handing the path down; that the
+    /// resolver then honours it is `platform_config`'s own coverage.
+    #[test]
+    fn workspace_platform_package_joins_the_search_path() {
+        let ws = ws_with(FREERTOS_WS);
+        let pkg = ws.path().join("src/nros-platform-acme");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join(PLATFORM_CONFIG_FILENAME), "names = [\"acme\"]\n").unwrap();
+
+        let env = |k: &str| match k {
+            "FREERTOS_DIR" => Some("/opt/freertos".to_string()),
+            "LWIP_DIR" => Some("/opt/lwip".to_string()),
+            _ => None,
+        };
+        let facts = resolve(ws.path(), &repo_root(), None, None, &env).expect("resolves");
+        let path = facts
+            .get("NROS_PLATFORMS_DIR")
+            .expect("workspace platform packages put a root on the search path");
+        let want = ws.path().join("src").display().to_string();
+        assert!(
+            path.split(':').any(|p| p == want),
+            "search path {path} is missing the workspace root {want}"
+        );
+    }
+
+    /// A caller's own value stays AHEAD of what discovery found — the override
+    /// is still an override.
+    #[test]
+    fn explicit_platforms_dir_outranks_discovery() {
+        let ws = ws_with(FREERTOS_WS);
+        let pkg = ws.path().join("src/nros-platform-acme");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join(PLATFORM_CONFIG_FILENAME), "names = [\"acme\"]\n").unwrap();
+
+        let env = |k: &str| match k {
+            "FREERTOS_DIR" => Some("/opt/freertos".to_string()),
+            "LWIP_DIR" => Some("/opt/lwip".to_string()),
+            "NROS_PLATFORMS_DIR" => Some("/opt/mine".to_string()),
+            _ => None,
+        };
+        let facts = resolve(ws.path(), &repo_root(), None, None, &env).expect("resolves");
+        let path = facts.get("NROS_PLATFORMS_DIR").expect("set");
+        assert!(
+            path.starts_with("/opt/mine:"),
+            "explicit root must come first, got {path}"
+        );
+    }
+
+    /// A workspace with no platform package of its own emits nothing — the
+    /// in-tree default search path is not something this seam should restate.
+    #[test]
+    fn plain_workspace_adds_no_search_path() {
+        let ws = ws_with(FREERTOS_WS);
+        let env = |k: &str| match k {
+            "FREERTOS_DIR" => Some("/opt/freertos".to_string()),
+            "LWIP_DIR" => Some("/opt/lwip".to_string()),
+            _ => None,
+        };
+        let facts = resolve(ws.path(), &repo_root(), None, None, &env).expect("resolves");
+        assert_eq!(facts.get("NROS_PLATFORMS_DIR"), None);
+    }
+
     /// The whole point of the wave: one call, both halves, in the shape a
     /// cargo invoker can export.
     #[test]
@@ -823,4 +923,51 @@ sdk = { freertos = "/opt/freertos" }
         );
         assert!(resolve_board(&catalog, "no-such-board").is_none());
     }
+}
+
+use nros_board_common::platform_config::PLATFORM_CONFIG_FILENAME;
+
+/// Directories in `ws` that CONTAIN platform packages.
+///
+/// A platform descriptor lives at `<root>/<pkg>/nros-platform.toml`, so what
+/// the search path wants is `<root>` — the same shape `packages/platform` has
+/// in the tree.
+///
+/// Bounded and source-time (RFC-0071 D5): three levels is enough for
+/// `<ws>/src/<pkg>/` and `<ws>/<pkg>/`, and the build outputs are skipped by
+/// name because scanning them is pure cost — a workspace's `build/` and
+/// `install/` hold copies of the very files this is looking for, and a copy
+/// resolving as a platform is worse than not finding one.
+fn workspace_platform_roots(ws: &Path) -> Vec<std::path::PathBuf> {
+    const SKIP: &[&str] = &["build", "install", "log", "target", ".git"];
+    let mut out = Vec::new();
+    let mut stack = vec![(ws.to_path_buf(), 0u32)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > 3 {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        let mut holds_platform = false;
+        for e in entries.flatten() {
+            let p = e.path();
+            if !p.is_dir() {
+                continue;
+            }
+            let name = p.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+            if SKIP.contains(&name) || name.starts_with('.') {
+                continue;
+            }
+            if p.join(PLATFORM_CONFIG_FILENAME).is_file() {
+                holds_platform = true;
+            }
+            stack.push((p, depth + 1));
+        }
+        if holds_platform && !out.contains(&dir) {
+            out.push(dir);
+        }
+    }
+    out.sort();
+    out
 }


### PR DESCRIPTION
## What

W1's third bullet said `$NROS_PLATFORMS_DIR` "stops being the only way in". For an in-tree platform it already had — `default_search_path` carries `packages/platform` — but for a platform package in the **user's own workspace** it had not: nothing derived the search path from the workspace, so such a package resolved only if a human exported the variable by hand. Without it the build fell through to the builtin knobs with a `cargo:warning`, which reads as a working build.

`nros ws board-facts` is the seam that already knows the workspace and already hands down `NROS_PLATFORM_NAME` and `NROS_BOARD_TOML` rather than letting every build script rediscover them, so the answer belongs there. It now scans the workspace for `<root>/<pkg>/nros-platform.toml` and puts each `<root>` on `NROS_PLATFORMS_DIR`.

Two properties the tests pin:

- A caller's own value comes **first** — an explicit `--platforms-dir` still outranks discovery.
- Build outputs (`build/`, `install/`, `log/`, `target/`) are skipped by name. They hold *copies* of the very descriptors being looked for, and a copy resolving as a platform is worse than not finding one.

## Gate

W1's gate is "a platform package outside the tree resolves and builds with `config/` untouched". Measured end to end: a workspace holding `src/nros-platform-acme/` with `names = ["acme"]` and `[knobs.params] max_parameters = 77` emits `NROS_PLATFORMS_DIR=<ws>/src` with nothing exported, and a build resolving `acme` over that path compiles `pub const MAX_PARAMETERS: usize = 77;` — `config/` untouched throughout.

## Tests

Three, going through `resolve()` itself rather than calling the scanner directly. Mutation-checked by making the scanner return empty: both discovery tests fail, and the absence test correctly stays green.

## Doc

W1's move landed 2026-08-30 in `3164c93a7` and the status line still called W1 outstanding. Also records why `config/bare-metal` and `config/generic` deliberately did not move and must keep resolving — neither is a port, so neither has a crate to sit beside — which narrows W8's "config stops being read" to the five platforms that do.

## Checks

`just check fast` (187 gates), `board-cargo-config-applied`, `provider-index`, `workspace-order`, `doc-recipe-refs`, `cargo test -p nros-cli-core --lib board_facts` (14 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)