### PR TITLE
fix(#0992): nros build writes the missing facade itself — CI only ever gets one pass

### DIFF
--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -1096,7 +1096,7 @@ fn generate_entry(
         .join(coordinate(platform, image))
         .join(crate::builder::entry::package_name(image_id));
 
-    let spec = EntrySpec {
+    let mut spec = EntrySpec {
         image_id: image_id.to_string(),
         deploy: crate::builder::entry::macro_deploy_token(&candidates),
         launch,
@@ -1145,7 +1145,62 @@ fn generate_entry(
     // facade this build needed. Raising it earlier deadlocks a clone: sync
     // keys facades off the entry package, and this function is what writes it.
     if let Some(msg) = facade_missing_fatal {
-        eyre::bail!("{msg}");
+        // SELF-HEAL, because CI only ever gets one pass.
+        //
+        // Deferring the refusal until after the entry was written (the previous
+        // fix) made a DEVELOPER's tree recoverable: sync could finally see the
+        // entry package, so the next `nros build` succeeded. It did nothing for
+        // CI, and `host-tests` proved it — the run does
+        //
+        //     just _codegen        (sync: no entry yet, so no facade)
+        //     nros build           (writes the entry, then refuses)
+        //
+        // and there is no second sync, so the lane failed on the same message
+        // with the fix in place. A fresh checkout every run means the two-pass
+        // recovery never happens.
+        //
+        // But nothing here actually needs sync. `write_facade` wants the entry
+        // name, its directory, its manifest, the system and the facade root —
+        // and we hold all five, because we just generated the entry. The one
+        // input sync was missing is the thing this function produces.
+        //
+        // So: write the facade, then regenerate the entry with it. The second
+        // write is not optional — the first ran with `facade_dir = None`, so
+        // the entry carries no dependency on the facade crate, and a facade no
+        // entry depends on selects nothing (cargo feature unification is the
+        // whole mechanism). Two file writes, one build, no second invocation.
+        //
+        // Still fatal if the facade cannot be written: that is a real problem
+        // and the message already names it.
+        let facade_root = root.join("generated/nros-selection");
+        let entry_name = crate::builder::entry::package_name(image_id);
+        let healed = std::fs::read_to_string(bringup_dir.join("system.toml"))
+            .ok()
+            .and_then(|raw| {
+                toml::from_str::<crate::orchestration::cargo_metadata_schema::SystemToml>(&raw).ok()
+            })
+            .and_then(|sys| {
+                crate::orchestration::facade::write_facade(
+                    &entry_name,
+                    &dir,
+                    &dir.join("Cargo.toml"),
+                    &sys,
+                    &facade_root,
+                )
+                .ok()
+                .flatten()
+            });
+
+        let Some(_) = healed else {
+            eyre::bail!("{msg}");
+        };
+        eprintln!(
+            "nros build: wrote the missing selection facade for `{image_id}` from the entry \
+             just generated, and regenerated the entry against it."
+        );
+        spec.facade_dir = Some(facade_root.join(&entry_name));
+        crate::builder::entry::write(&spec, &facts, &parent)
+            .map_err(|e| eyre::eyre!("regenerating the entry for `{image_id}`: {e}"))?;
     }
 
     // phase-392 W5 — the ENTITY facts, from the SAME model resolved above.


### PR DESCRIPTION
`host-tests` failed on the **same message** with #291 in place. That fix was made against exactly this prediction and it was not enough.

```
Error: nros build: `native_rust_qos` needs a selection facade and there is none at …
```

## Why #291 was insufficient

It deferred the refusal until after the entry was written, so a **developer** recovers — sync can finally see the entry package and the next build succeeds. **CI never gets a next.** The fixture step is:

```
just _codegen     # sync — no entry yet, so no facade
nros build        # writes the entry, then refuses
```

There is no second sync in the run, and every checkout is fresh, so the two-pass recovery never happens and the lane fails identically forever.

## The fix

Nothing here actually needed sync. `write_facade` wants the entry name, its directory, its manifest, the system and the facade root — and this function **holds all five** at the point it was refusing, because the input sync was missing is the thing this function produces. So it writes the facade and carries on.

The entry is regenerated afterwards, and that second write is **not optional**: the first ran with `facade_dir = None`, so the entry carried no dependency on the facade crate — and a facade no entry depends on selects nothing, since cargo feature unification is the entire mechanism.

Two file writes, one build, no second invocation. Still fatal when the facade cannot be written; a system declaring no capabilities still only warns.

## Verified — the CI sequence, one pass, fresh-checkout state

```
nros build native_rust_qos   -> rc=0
  "wrote the missing selection facade for `native_rust_qos` from the entry
   just generated, and regenerated the entry against it"      (x4 images)

facade:  nros[lifecycle-services, param-services, ros-humble]
entry:   native_rust_qos_entry_nros_selection = { path = … }   <- the dep
rerun:   rc=0, zero self-heal messages (idempotent)
```

858 lib tests pass.

## Campaign note

Three commits were needed for one defect, and each was necessary: #260 turned a const-eval panic 400 lines from the cause into a message naming the facade; #291 stopped that message deadlocking a clone; this makes it unnecessary. The first two are what made the third findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)