### PR TITLE
docs(#1029, phase-196): the Zephyr nightly reports nothing, and a phase waits on it

### DIFF
--- a/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
+++ b/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
@@ -1,0 +1,98 @@
+---
+id: 1029
+title: "The Zephyr dual-line nightly has its own 05:00 cron and every scheduled run SKIPS it, so the lane it exists to watch has produced no verdict for days"
+status: open
+type: bug
+area: ci, testing
+severity: medium
+found: 2026-09-04
+related: [0871, 0872, 0994, 0996, phase-196, phase-253, phase-413]
+---
+
+# A lane with a cron, a gate, and no answers
+
+## Measured
+
+Every zephyr job in the last **eight consecutive scheduled** `nightly.yml` runs
+is `skipped`. Read from the jobs API, not from logs (see the caveat below):
+
+    2026-09-03T07:12   skipped,skipped,skipped
+    2026-09-03T05:40   skipped,skipped,skipped
+    2026-09-02T07:13   skipped,skipped,skipped
+    2026-09-02T05:11   skipped,skipped,skipped
+    2026-09-01T07:12   skipped,skipped,skipped
+    2026-09-01T05:12   skipped,skipped,skipped
+    2026-08-31T07:18   skipped,skipped,skipped
+    2026-08-31T05:12   skipped,skipped,skipped
+
+The three jobs are `zephyr-example-matrix`, `zephyr-dual-line-summary` and
+`zephyr-copy-out`.
+
+**Runs that DO produce zephyr verdicts are not on the schedule cadence** —
+2026-09-03T05:34, 2026-09-03T01:19 and 2026-08-31T01:45 each report 22 zephyr
+job results, a mix of success and failure. So the jobs work; the scheduled
+trigger is what yields nothing.
+
+The 07:00 skips are CORRECT and not part of this: `nightly.yml` declares two
+crons, `0 5` for the Zephyr dual line and `0 7` for the per-platform sweep, and
+each family is gated to its own. The finding is the **05:00** column.
+
+## Why it matters more than an idle lane
+
+This is the "a red lane answers one of two questions" shape CLAUDE.md already
+names, one step worse. A uniformly-red lane at least has a verdict to compare
+against; a uniformly-SKIPPED one has none, so a Zephyr regression and a healthy
+Zephyr look identical from the nightly, and neither is distinguishable from the
+cron not firing at all.
+
+It also silently strands an acceptance criterion. phase-196's ONLY open item is
+"`zephyr-dual-line` is green end-to-end on both lines", and it has been open
+since 2026-06 waiting on a lane that no longer reports. See the phase-196
+correction landing with this issue.
+
+## The lead, NOT the root cause
+
+`dorny/paths-filter@v3` logs this in the `changes` job on a scheduled run:
+
+    ##[warning]'before' field is missing in event payload -
+              changes will be detected from last commit
+
+A schedule event carries no diff base, so the filter falls back to the last
+commit alone. A `0 5` cron whose preceding commit touched nothing under
+`packages/**`, `zephyr/**`, `cmake/**` … would then compute `zephyr` as false
+and gate all three jobs off.
+
+**That is a hypothesis and it is NOT confirmed.** The `set` step which computes
+the output reads:
+
+    if [ "${{ github.event_name }}" != "pull_request" ]; then
+      sel="$all"; zephyr="true"
+
+which should make `zephyr` unconditionally `true` on a schedule, contradicting
+the hypothesis. The step ran and exited `success`.
+
+I could not resolve the contradiction from the run logs, and stopped rather than
+guess: `gh run view --log` returned mangled output for this workflow (steps
+labelled `UNKNOWN STEP`, and a grep for `lane-derived platform set:` — printed
+unconditionally by that same step — found nothing while a later line from the
+same `echo` did appear). Any root cause read off that output would be built on a
+log I have shown to be lossy. Issues 0859-0862 were four confident wrong causes
+from exactly that kind of evidence.
+
+## What would settle it
+
+Read `steps.set.outputs` from the API rather than the log — or add one line to
+the `changes` job that writes the computed values into the job summary
+(`$GITHUB_STEP_SUMMARY`), which survives log formatting. That is worth doing
+regardless: a gate whose inputs are only observable through a lossy log is a
+gate nobody can debug, which is how this went unnoticed for eight runs.
+
+## Not covered
+
+* Whether the same gate silences the `0 7` platform family on days when its
+  paths did not move. The platform jobs DID run in the 07:12 sample, so if the
+  fallback is the cause it is at least not firing every day — but nothing here
+  measured that column over a window.
+* Whether the two crons fire at all. Every run above exists, so they fire; what
+  is unmeasured is whether any 05:00 run has EVER produced a zephyr verdict
+  since phase-253 merged the workflows.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -88,5 +88,6 @@ fails if this block drifts.
 - **#1020** (docs, api) — The C++ parity lane measures the NATIVE API against rclcpp and cannot see `rclcpp_compat.hpp` — 589 lines whose entire purpose is the thing being measured See `1020-*`.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
+- **#1029** (ci, testing) — The Zephyr dual-line nightly has its own 05:00 cron and every scheduled run SKIPS it, so the lane it exists to watch has produced no verdict for days See `1029-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-196-ci-bring-up.md
+++ b/docs/roadmap/phase-196-ci-bring-up.md
@@ -8,10 +8,31 @@ have. This phase finishes the Zephyr dual-line bring-up, audits the other
 workflows for the same class of gaps, and codifies the provisioning conventions
 so a new workflow works on its first push.
 
-**Status.** In progress (2026-05-28). `zephyr-dual-line` setup + most build
-stages fixed and validated by repeated `workflow_dispatch` runs; one product
-skew (codegen CLI) remains, owned by Phase 195. The broader audit/codification
-items are proposed.
+**Status (2026-09-04). Every work item is DONE (196.1-196.9, 33 of 34 boxes
+checked); the phase is held open by ONE acceptance criterion that names a
+workflow deleted fifteen months of commits ago.** The 2026-05-28 line below said
+"in progress ... one product skew (codegen CLI) remains" and none of that is
+true now: the skew was resolved at the tool level (see the handoff note), the
+196.7 [P2] item's three boxes are all checked, and 196.3's audit is complete.
+
+**The CI topology this phase was written against no longer exists.** phase-253
+(`682706dbf ci: merge 13 workflows into 6 tier files`) consolidated the lot, and
+ALL TWELVE workflows named in the acceptance criteria are gone: `ci.yml`,
+`zephyr-dual-line.yml`, `platform-ci.yml`, `lint.yml`, `host-unit.yml`,
+`codegen-convention.yml`, `sdk-index-gate.yml`, `nros-acceptance.yml`,
+`dep-chain.yml`, `scaffold-journey.yml`, `embedded-feature-unification.yml`,
+`colcon-parity.yml`. Read every workflow filename below as historical record;
+the live set is `gate.yml`, `queue.yml`, `nightly.yml`, `post-submit.yml`,
+`run-matrix.yml` and friends.
+
+**The one open criterion is still a real question, and it now has no answer.**
+"`zephyr-dual-line` is green end-to-end on both lines" survived the
+consolidation as the zephyr matrix inside `nightly.yml`, on its own `0 5` cron —
+but every zephyr job in the last EIGHT consecutive scheduled runs is `skipped`,
+so the lane reports neither green nor red. Filed as
+[issue 1029](../issues/1029-zephyr-nightly-never-produces-a-verdict.md).
+This criterion cannot be met or refuted until that is fixed, and it should be
+tracked THERE rather than holding a phase open whose own work is finished.
 
 > **Post-Phase-218**: The CLI-skew install path discussed below
 > (`scripts/install-nros.sh` → `~/.nros/bin/nros`) was retired by


### PR DESCRIPTION
Picked up **phase-196** (CI bring-up, "In progress" since 2026-05-28) to check it, and it turned into a live finding.

## The phase's work is done; a deleted workflow holds it open

33 of 34 boxes are checked, 196.1–196.9 all marked, and the 196.7 `[P2]` item's three boxes are all `[x]`. What holds it open is **one acceptance criterion naming a workflow that no longer exists.**

phase-253 (`682706dbf ci: merge 13 workflows into 6 tier files`) consolidated the CI topology this phase was written against. **All twelve** workflows named in its acceptance are gone — `ci.yml`, `zephyr-dual-line.yml`, `platform-ci.yml`, `lint.yml`, `host-unit.yml`, `codegen-convention.yml`, `sdk-index-gate.yml`, `nros-acceptance.yml`, `dep-chain.yml`, `scaffold-journey.yml`, `embedded-feature-unification.yml`, `colcon-parity.yml`.

## The criterion survived — but it reports nothing

"`zephyr-dual-line` is green end-to-end on both lines" is now the zephyr matrix in `nightly.yml`, on its own `0 5` cron. Every zephyr job in the last **eight consecutive scheduled runs** is `skipped`:

```
09-03T07:12  09-03T05:40  09-02T07:13  09-02T05:11
09-01T07:12  09-01T05:12  08-31T07:18  08-31T05:12
```

all `skipped,skipped,skipped`. Runs that **do** produce zephyr verdicts (05:34, 01:19, 01:45) are off the schedule cadence and report 22 job results each — so the jobs work, and the scheduled trigger is what yields nothing.

The 07:00 skips are correct by design: two crons, `0 5` Zephyr and `0 7` platforms, each gated to its own family. The finding is the **05:00** column.

This is worse than a red lane, and it is the shape CLAUDE.md already names. A red lane has a verdict to compare against; a uniformly **skipped** one makes a Zephyr regression and a healthy Zephyr indistinguishable — and neither distinguishable from the cron not firing.

## Filed WITHOUT a root cause, deliberately

`dorny/paths-filter` warns on schedule that *"'before' field is missing in event payload — changes will be detected from last commit"*, which would explain the gate closing. **But** the `set` step assigns `zephyr="true"` unconditionally for any non-`pull_request` event, which contradicts that, and the step exited `success`.

I could not resolve the contradiction, because `gh run view --log` returns mangled output for this workflow — steps labelled `UNKNOWN STEP`, and a grep for a line that step prints *unconditionally* found nothing while a later line from the **same** `echo` did appear. A cause read off a log I have shown to be lossy is issues 0859–0862 all over again, so I stopped.

Issue **1029** records the measurement, the lead, and what would settle it — read `steps.set.outputs` from the API, or have the `changes` job write its computed values to `$GITHUB_STEP_SUMMARY`, which survives log formatting. That is worth doing regardless: a gate whose inputs are only observable through a lossy log is a gate nobody can debug, which is how this went unnoticed for eight runs.

`just check fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742