### PR TITLE
fix(ci): the scheduled gate builds the resolver its own steps need

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -665,9 +665,23 @@ jobs:
       # nothing about artifact preconditions — the helper was already built in
       # that tree. CI had no such tree and failed with
       # `nros-launch-resolve not built at … — run just setup-launch-resolve`.
-      - name: Build nros-launch-resolve (cli-tests' plan pipeline shells out to it)
+      # Two steps need it, on DISJOINT events, so the condition is the union of
+      # theirs: `just check cli-tests` on pull_request/merge_group, and
+      # `just generate-bindings` on schedule/workflow_dispatch — that one runs
+      # `nros sync`, which refuses to resolve a SystemModel without the
+      # resolver beside the `nros` binary.
+      #
+      # It was built for the first pair only, so every scheduled run since
+      # 2026-09-01 died in `generate-bindings` with "1 SystemModel(s) need
+      # resolving but `nros-launch-resolve` is not next to the `nros` binary".
+      # Same shape `check-lane-contracts` exists to forbid — a step resolving an
+      # artifact its own job never builds — but that gate only reaches
+      # merge-gating lanes, and its predicate is one level down (a RECIPE
+      # resolving an unbuilt stamp, not a STEP narrower than its consumers), so
+      # nothing watched this. Issue 1030 carries the gap.
+      - name: Build nros-launch-resolve (cli-tests and generate-bindings both shell out to it)
         if: >-
-          ${{ contains(fromJSON('["pull_request","merge_group"]'), github.event_name)
+          ${{ contains(fromJSON('["pull_request","merge_group","schedule","workflow_dispatch"]'), github.event_name)
               && !cancelled() }}
         run: |
           source ./activate.sh

--- a/docs/issues/1030-schedule-lane-producer-events.md
+++ b/docs/issues/1030-schedule-lane-producer-events.md
@@ -1,0 +1,79 @@
+---
+id: 1030
+title: "check-lane-contracts covers merge-gating lanes only, so a schedule-only step can consume an artifact no step on that event builds — the scheduled gate was red four days"
+status: open
+area: ci, testing
+severity: medium
+found: 2026-09-04
+related: [0876, 0878, 0196, 0993]
+---
+
+# A producer step narrower than its consumers, on a lane no gate reads
+
+## What happened
+
+`gate.yml`'s scheduled run failed on 2026-09-01, -02, -03 and -04 — every run
+since the step was added — with two failing steps that had one cause:
+
+```
+Error: sync: 1 SystemModel(s) need resolving but `nros-launch-resolve` is not next to the `nros` binary:
+  demo_bringup — .../examples/templates/c-and-cpp-mixed-workspace/build/nros/models/demo_bringup/system_model.yaml is missing (system.launch.xml)
+Build it:  ./scripts/bootstrap.sh   (contributors: just setup-launch-resolve)
+```
+
+and, in `just check build`'s one failing gate of 21:
+
+```
+thread 'fixture_workspace_plans_and_checks' panicked at nros-cli-core/tests/plan_pipeline_e2e.rs:228:5:
+nros-launch-resolve not built at .../packages/cli/nros-launch-resolve/target/release/nros-launch-resolve — run `just setup-launch-resolve`
+```
+
+`Build nros-launch-resolve` was conditioned on `pull_request`/`merge_group`,
+because it was added for `just check cli-tests`. Two later steps need the same
+binary on `schedule`/`workflow_dispatch` — `just generate-bindings` (via `nros
+sync`) and `just check build` — so on those events the producer was SKIPPED and
+both consumers failed.
+
+Fixed by widening that step's event set to the union of its consumers'.
+
+## Why the gate did not catch it
+
+`check-lane-contracts` exists for exactly this shape — "a gate in an
+affordability tier may only resolve artifacts the JOB ITSELF builds" — and it
+passes here, reporting `7 merge-gating CI lane invocation(s)`. Two reasons it
+cannot see this one:
+
+1. **Scope.** `GATING_EVENTS = {"pull_request", "merge_group"}`; a lane whose
+   events miss that set is skipped by construction
+   (`scripts/check-lane-contracts.py:589`). That is a deliberate,
+   documented severity call — a broken tier on `schedule` is a bad nightly, a
+   broken tier on `merge_group` is a repository nobody can merge into — and
+   this issue does not propose reversing it.
+
+2. **Predicate.** Even in scope, the gate asks whether a RECIPE's closure
+   resolves a stamp its job does not build. This defect is one level up: a
+   workflow STEP that builds a binary, whose `if:` event set is a strict subset
+   of the event sets of the steps that consume it. Nothing checks that
+   containment, on any lane.
+
+## Why it matters beyond the four days
+
+A lane red for four consecutive runs has no signal capacity — the same property
+issue 0876 rode in on. A regression landing in the scheduled gate would have
+looked exactly like 2026-09-01's failure, and `check build` + `no_std` +
+`generate-bindings` are the only place several gates run at all.
+
+## What a fix looks like
+
+A check that, per workflow job, every step producing a binary has an event set
+that is a SUPERSET of every step consuming it. The hard part is deriving
+consumption: `just check cli-tests` needs the resolver through a test that
+panics at runtime with a path, which is not statically visible from the recipe.
+An authored producer→consumer map would work and would also drift — the
+`rmw-api-parity` lesson — so it needs cross-checking against something
+observable, the way `check_against_vtable` does.
+
+Cheaper interim: assert that no step in a workflow job is conditioned on a
+STRICT SUBSET of the events of a step that appears after it and runs `just`,
+unless listed in a baseline. Noisy, but the baseline makes new ones loud, which
+is the property that was missing.


### PR DESCRIPTION
## The red

`gate.yml`'s scheduled run has failed **every night since 2026-09-01** — four consecutive runs (`371aca219`, `f6ab46fd2`, `f5dc050a2`, `d7b90a532`), two failing steps, one cause:

```
Error: sync: 1 SystemModel(s) need resolving but `nros-launch-resolve` is not next to the `nros` binary
```
```
thread 'fixture_workspace_plans_and_checks' panicked at nros-cli-core/tests/plan_pipeline_e2e.rs:228:5:
nros-launch-resolve not built at .../nros-launch-resolve — run `just setup-launch-resolve`
```

`Build nros-launch-resolve` was conditioned on `pull_request`/`merge_group`, because it was added for `just check cli-tests`. Two steps that run on `schedule`/`workflow_dispatch` need the same binary — `just generate-bindings` (drives `nros sync`) and `just check build` (its one failing gate of 21 was the plan-pipeline test). On those events the producer was **skipped** and both consumers failed.

## The fix

The step's event set becomes the union of its consumers'. A producer narrower than what consumes it is the defect, so the condition is now written from the consumers rather than from whichever one happened to be added first.

## Why no gate caught it

`check-lane-contracts` exists for this shape and **passes here**, reporting `7 merge-gating CI lane invocation(s)`. Two reasons, both filed as **issue 1030** rather than papered over:

1. Its scope is deliberately merge-gating only — a stated severity call in `scripts/check-lane-contracts.py:589`, which this PR does not reverse.
2. Its predicate is one level down: a *recipe* resolving a stamp its job doesn't build, not a *step* whose `if:` is a strict subset of its consumers'. Nothing checks that containment on any lane.

## Sweep

Enumerated every step in the workflow with its event set and command. `build compile-check fixtures` and its consumer `just check build` are both schedule/dispatch; no other producer is narrower than a consumer.

## Note

Four red runs is a lane with **no signal capacity** — a real regression in `check build`, `no_std` or `generate-bindings` would have looked exactly like 2026-09-01. That's how issue 0876 rode in.

Checks: `just check fast` (187 gates), `check issue-index`, `check lane-contracts`, YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)