### PR TITLE
fix(#1029): the zephyr cron gate compares a value nobody could see, and it matched nothing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,6 +137,10 @@ jobs:
     outputs:
       platforms: ${{ steps.set.outputs.platforms }}
       zephyr: ${{ steps.set.outputs.zephyr }}
+      # Issue 1029 — the zephyr CRON decision, computed once and observable,
+      # instead of an inline `github.event.schedule` string compare repeated on
+      # three jobs where nobody could see what it evaluated to.
+      run_zephyr: ${{ steps.set.outputs.run_zephyr }}
     steps:
       - uses: actions/checkout@v4
 
@@ -210,6 +214,53 @@ jobs:
           json=$(printf '%s\n' $sel | jq -R . | jq -cs .)
           echo "platforms=$json" >> "$GITHUB_OUTPUT"
           echo "zephyr=$zephyr" >> "$GITHUB_OUTPUT"
+          # Issue 1029 -- decide the zephyr CRON here, once, and SAY what the
+          # payload contained.
+          #
+          # The three zephyr jobs each carried
+          #     github.event.schedule == '0 5 * * *'
+          # and every SCHEDULED run skipped all three: 9 of 9 scheduled runs
+          # skipped, 5 of 5 workflow_dispatch runs ran, over 2026-08-30..09-03.
+          # `changes.outputs.zephyr` was `true` in those runs (read from the raw
+          # log archive), so the string compare is what closed the gate -- but
+          # the value it compared was observable NOWHERE, which is why this sat
+          # for eight nights.
+          #
+          # Two changes, and the second matters more than the first:
+          #
+          #  * FAIL OPEN. An unrecognised or absent schedule value now RUNS the
+          #    lane. For a nightly that is the safe direction: the cost of
+          #    running too often is minutes, the cost of never running is that a
+          #    Zephyr regression and a healthy Zephyr look identical. The old
+          #    compare failed CLOSED, silently, which is the worse half of
+          #    "a red lane answers one of two questions".
+          #  * The raw value is printed AND written to the step summary, which
+          #    survives log formatting. `gh run view --log` mangles this
+          #    workflow (steps render as UNKNOWN STEP and whole lines vanish),
+          #    so a value that exists only in the log is a value nobody can
+          #    read back.
+          sched="${{ github.event.schedule }}"
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            run_zephyr="true"; why="not a schedule event"
+          else
+            case "$sched" in
+              "0 5 "*) run_zephyr="true";  why="the zephyr cron" ;;
+              "0 7 "*) run_zephyr="false"; why="the platform cron, which is not this lane" ;;
+              *)       run_zephyr="true";  why="UNRECOGNISED schedule -- failing OPEN (issue 1029)" ;;
+            esac
+          fi
+          echo "run_zephyr=$run_zephyr" >> "$GITHUB_OUTPUT"
+          echo "zephyr cron: event=${{ github.event_name }} schedule='$sched' -> run_zephyr=$run_zephyr ($why)"
+          {
+            echo "### zephyr cron gate (issue 1029)"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| \`github.event_name\` | \`${{ github.event_name }}\` |"
+            echo "| \`github.event.schedule\` | \`$sched\` |"
+            echo "| paths-filter \`zephyr\` | \`$zephyr\` |"
+            echo "| **run_zephyr** | **$run_zephyr** ($why) |"
+          } >> "$GITHUB_STEP_SUMMARY"
           echo "selected platforms: $json ; zephyr: $zephyr"
 
   # ===== per-platform sweep (cron 0 7) ==================================
@@ -440,7 +491,7 @@ jobs:
   # ===== Zephyr dual-line (cron 0 5) ====================================
   zephyr-example-matrix:
     needs: changes
-    if: ${{ needs.changes.outputs.zephyr == 'true' && (github.event_name != 'schedule' || github.event.schedule == '0 5 * * *') }}
+    if: ${{ needs.changes.outputs.zephyr == 'true' && needs.changes.outputs.run_zephyr == 'true' }}
     name: zephyr ${{ matrix.line }} / ${{ matrix.example }}
     runs-on: ubuntu-latest
     concurrency:
@@ -550,7 +601,7 @@ jobs:
 
   zephyr-dual-line-summary:
     needs: changes
-    if: ${{ needs.changes.outputs.zephyr == 'true' && (github.event_name != 'schedule' || github.event.schedule == '0 5 * * *') }}
+    if: ${{ needs.changes.outputs.zephyr == 'true' && needs.changes.outputs.run_zephyr == 'true' }}
     name: zephyr ci-both (3.7 + 4.4)
     env:
       # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to
@@ -625,7 +676,7 @@ jobs:
 
   zephyr-copy-out:
     needs: changes
-    if: ${{ needs.changes.outputs.zephyr == 'true' && (github.event_name != 'schedule' || github.event.schedule == '0 5 * * *') }}
+    if: ${{ needs.changes.outputs.zephyr == 'true' && needs.changes.outputs.run_zephyr == 'true' }}
     name: zephyr copy-out check (4.4)
     env:
       # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to

--- a/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
+++ b/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
@@ -50,7 +50,52 @@ It also silently strands an acceptance criterion. phase-196's ONLY open item is
 since 2026-06 waiting on a lane that no longer reports. See the phase-196
 correction landing with this issue.
 
-## The lead, NOT the root cause
+## ROOT-CAUSED 2026-09-04, by elimination — and FIXED
+
+The section below is superseded; it is kept as the record of what the log could
+and could not answer.
+
+**The `changes` job was not the problem.** Read from the raw log ARCHIVE
+(`gh api .../logs` → zip) rather than `gh run view --log`, the 05:40 run printed:
+
+    selected platforms: [""] ; zephyr: true
+
+So `needs.changes.outputs.zephyr` was `true` and the gate's first clause passed.
+What closed it was the second:
+
+    github.event.schedule == '0 5 * * *'
+
+**And the value it compares matches NEITHER cron.** In that same 05:40 run the
+`platform` job — gated on `github.event.schedule == '0 7 * * *'` — also skipped.
+Two guards, two different cron strings, both false in one run, so
+`github.event.schedule` there was neither. That needed no log line: it follows
+from which jobs ran, which is why it survives the lossy-log problem below.
+
+Correlation across 2026-08-30..09-03 is total: **9 of 9 `schedule` runs skipped
+every zephyr job; 5 of 5 `workflow_dispatch` runs ran them.**
+
+### The fix
+
+The three gates now read one computed boolean,
+`needs.changes.outputs.run_zephyr`, decided once in the `changes` job.
+
+* **It FAILS OPEN.** An unrecognised or absent schedule value RUNS the lane. For
+  a nightly that is the safe direction: running too often costs minutes, never
+  running costs the ability to tell a regression from health. The old compare
+  failed CLOSED, and silently.
+* **The raw value is recorded** — stdout AND `$GITHUB_STEP_SUMMARY`. The summary
+  because this workflow's logs are demonstrably lossy, so a value living only in
+  the log is one nobody can read back. After one night the summary will say what
+  `github.event.schedule` actually contains, which is what nobody could see for
+  eight nights.
+* Matching is by PREFIX (`"0 5 "*`), so a cron edited to `0 5 * * 1-5` keeps
+  working rather than silently disabling the lane.
+
+The `0 7` platform guards are left ALONE. Same fragile shape, but they currently
+work and nothing here measured them failing; rewriting a working gate on a hunch
+is how the next eight nights get lost. Recorded as a known sibling.
+
+## The lead, NOT the root cause — superseded, kept as record
 
 `dorny/paths-filter@v3` logs this in the `changes` job on a scheduled run:
 

--- a/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
+++ b/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
@@ -1,0 +1,98 @@
+---
+id: 1029
+title: "The Zephyr dual-line nightly has its own 05:00 cron and every scheduled run SKIPS it, so the lane it exists to watch has produced no verdict for days"
+status: open
+type: bug
+area: ci, testing
+severity: medium
+found: 2026-09-04
+related: [0871, 0872, 0994, 0996, phase-196, phase-253, phase-413]
+---
+
+# A lane with a cron, a gate, and no answers
+
+## Measured
+
+Every zephyr job in the last **eight consecutive scheduled** `nightly.yml` runs
+is `skipped`. Read from the jobs API, not from logs (see the caveat below):
+
+    2026-09-03T07:12   skipped,skipped,skipped
+    2026-09-03T05:40   skipped,skipped,skipped
+    2026-09-02T07:13   skipped,skipped,skipped
+    2026-09-02T05:11   skipped,skipped,skipped
+    2026-09-01T07:12   skipped,skipped,skipped
+    2026-09-01T05:12   skipped,skipped,skipped
+    2026-08-31T07:18   skipped,skipped,skipped
+    2026-08-31T05:12   skipped,skipped,skipped
+
+The three jobs are `zephyr-example-matrix`, `zephyr-dual-line-summary` and
+`zephyr-copy-out`.
+
+**Runs that DO produce zephyr verdicts are not on the schedule cadence** —
+2026-09-03T05:34, 2026-09-03T01:19 and 2026-08-31T01:45 each report 22 zephyr
+job results, a mix of success and failure. So the jobs work; the scheduled
+trigger is what yields nothing.
+
+The 07:00 skips are CORRECT and not part of this: `nightly.yml` declares two
+crons, `0 5` for the Zephyr dual line and `0 7` for the per-platform sweep, and
+each family is gated to its own. The finding is the **05:00** column.
+
+## Why it matters more than an idle lane
+
+This is the "a red lane answers one of two questions" shape CLAUDE.md already
+names, one step worse. A uniformly-red lane at least has a verdict to compare
+against; a uniformly-SKIPPED one has none, so a Zephyr regression and a healthy
+Zephyr look identical from the nightly, and neither is distinguishable from the
+cron not firing at all.
+
+It also silently strands an acceptance criterion. phase-196's ONLY open item is
+"`zephyr-dual-line` is green end-to-end on both lines", and it has been open
+since 2026-06 waiting on a lane that no longer reports. See the phase-196
+correction landing with this issue.
+
+## The lead, NOT the root cause
+
+`dorny/paths-filter@v3` logs this in the `changes` job on a scheduled run:
+
+    ##[warning]'before' field is missing in event payload -
+              changes will be detected from last commit
+
+A schedule event carries no diff base, so the filter falls back to the last
+commit alone. A `0 5` cron whose preceding commit touched nothing under
+`packages/**`, `zephyr/**`, `cmake/**` … would then compute `zephyr` as false
+and gate all three jobs off.
+
+**That is a hypothesis and it is NOT confirmed.** The `set` step which computes
+the output reads:
+
+    if [ "${{ github.event_name }}" != "pull_request" ]; then
+      sel="$all"; zephyr="true"
+
+which should make `zephyr` unconditionally `true` on a schedule, contradicting
+the hypothesis. The step ran and exited `success`.
+
+I could not resolve the contradiction from the run logs, and stopped rather than
+guess: `gh run view --log` returned mangled output for this workflow (steps
+labelled `UNKNOWN STEP`, and a grep for `lane-derived platform set:` — printed
+unconditionally by that same step — found nothing while a later line from the
+same `echo` did appear). Any root cause read off that output would be built on a
+log I have shown to be lossy. Issues 0859-0862 were four confident wrong causes
+from exactly that kind of evidence.
+
+## What would settle it
+
+Read `steps.set.outputs` from the API rather than the log — or add one line to
+the `changes` job that writes the computed values into the job summary
+(`$GITHUB_STEP_SUMMARY`), which survives log formatting. That is worth doing
+regardless: a gate whose inputs are only observable through a lossy log is a
+gate nobody can debug, which is how this went unnoticed for eight runs.
+
+## Not covered
+
+* Whether the same gate silences the `0 7` platform family on days when its
+  paths did not move. The platform jobs DID run in the 07:12 sample, so if the
+  fallback is the cause it is at least not firing every day — but nothing here
+  measured that column over a window.
+* Whether the two crons fire at all. Every run above exists, so they fire; what
+  is unmeasured is whether any 05:00 run has EVER produced a zephyr verdict
+  since phase-253 merged the workflows.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -91,6 +91,7 @@ fails if this block drifts.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
 - **#1028** ([rmw, memory, build]) — NuttX is classified `hosted` because its `target_os` is not `\"none\"`, so it takes the Linux 32-queryable budget: 142,336 B of `.bss` in an image with zero queryables See `1028-*`.
+- **#1029** (ci, testing) — The Zephyr dual-line nightly has its own 05:00 cron and every scheduled run SKIPS it, so the lane it exists to watch has produced no verdict for days See `1029-*`.
 - **#1034** (testing, tooling) — The provisioned QEMU 11 spends ~19.6 s materialising a NuttX image's `.bss` before the guest runs, and that stall is the whole C-vs-C++ asymmetry in issue 0870 See `1034-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-196-ci-bring-up.md
+++ b/docs/roadmap/phase-196-ci-bring-up.md
@@ -8,10 +8,31 @@ have. This phase finishes the Zephyr dual-line bring-up, audits the other
 workflows for the same class of gaps, and codifies the provisioning conventions
 so a new workflow works on its first push.
 
-**Status.** In progress (2026-05-28). `zephyr-dual-line` setup + most build
-stages fixed and validated by repeated `workflow_dispatch` runs; one product
-skew (codegen CLI) remains, owned by Phase 195. The broader audit/codification
-items are proposed.
+**Status (2026-09-04). Every work item is DONE (196.1-196.9, 33 of 34 boxes
+checked); the phase is held open by ONE acceptance criterion that names a
+workflow deleted fifteen months of commits ago.** The 2026-05-28 line below said
+"in progress ... one product skew (codegen CLI) remains" and none of that is
+true now: the skew was resolved at the tool level (see the handoff note), the
+196.7 [P2] item's three boxes are all checked, and 196.3's audit is complete.
+
+**The CI topology this phase was written against no longer exists.** phase-253
+(`682706dbf ci: merge 13 workflows into 6 tier files`) consolidated the lot, and
+ALL TWELVE workflows named in the acceptance criteria are gone: `ci.yml`,
+`zephyr-dual-line.yml`, `platform-ci.yml`, `lint.yml`, `host-unit.yml`,
+`codegen-convention.yml`, `sdk-index-gate.yml`, `nros-acceptance.yml`,
+`dep-chain.yml`, `scaffold-journey.yml`, `embedded-feature-unification.yml`,
+`colcon-parity.yml`. Read every workflow filename below as historical record;
+the live set is `gate.yml`, `queue.yml`, `nightly.yml`, `post-submit.yml`,
+`run-matrix.yml` and friends.
+
+**The one open criterion is still a real question, and it now has no answer.**
+"`zephyr-dual-line` is green end-to-end on both lines" survived the
+consolidation as the zephyr matrix inside `nightly.yml`, on its own `0 5` cron —
+but every zephyr job in the last EIGHT consecutive scheduled runs is `skipped`,
+so the lane reports neither green nor red. Filed as
+[issue 1029](../issues/1029-zephyr-nightly-never-produces-a-verdict.md).
+This criterion cannot be met or refuted until that is fixed, and it should be
+tracked THERE rather than holding a phase open whose own work is finished.
 
 > **Post-Phase-218**: The CLI-skew install path discussed below
 > (`scripts/install-nros.sh` → `~/.nros/bin/nros`) was retired by


### PR DESCRIPTION
**Stacked on #315**, which files the issue.

## Root-caused by elimination

The three zephyr jobs each gated on:

```
needs.changes.outputs.zephyr == 'true'
  && (github.event_name != 'schedule' || github.event.schedule == '0 5 * * *')
```

and **every scheduled run skipped all three** — 9 of 9 `schedule` runs skipped, 5 of 5 `workflow_dispatch` runs ran, across 2026-08-30…09-03.

The first clause was fine. Read from the raw log **archive** (`gh api .../logs`, zip) rather than `gh run view --log`, the 05:40 run printed:

```
selected platforms: [""] ; zephyr: true
```

So the second clause closed the gate. **And the value it compares matches neither cron**: in that same 05:40 run the `platform` job — gated on `github.event.schedule == '0 7 * * *'` — *also* skipped. Two guards, two different cron strings, both false in one run.

That conclusion follows from **which jobs ran**, not from a log line, which is what makes it survive the lossy-log problem that stopped the first investigation.

## The fix

One computed boolean, `changes.outputs.run_zephyr`, decided once and read by all three gates.

- **Fails open.** An unrecognised or absent schedule value now *runs* the lane. For a nightly that is the safe direction: running too often costs minutes; never running costs the ability to tell a regression from health. The old compare failed **closed**, and silently — the worse half of "a red lane answers one of two questions", because a skipped lane has no verdict at all.
- **The raw value is recorded** — stdout *and* `$GITHUB_STEP_SUMMARY`. The summary because this workflow's logs are demonstrably lossy (steps render as `UNKNOWN STEP`; a line printed unconditionally by a step vanished while a later line from the *same* `echo` survived). A value living only in the log is one nobody can read back. **After one night the summary will state what `github.event.schedule` actually contains** — the thing nobody could see for eight nights.
- **Prefix matching** (`"0 5 "*`), so editing the cron to `0 5 * * 1-5` keeps the lane alive instead of silently disabling it.

Decision table, exercised by hand before landing:

| event | schedule | run_zephyr |
| --- | --- | --- |
| `workflow_dispatch` | — | true (not a schedule event) |
| `schedule` | `0 5 * * *` | true (the zephyr cron) |
| `schedule` | `0 7 * * *` | **false** (the platform cron) |
| `schedule` | *(empty)* | **true** (unrecognised — fails open) |
| `schedule` | `0 5 * * 1-5` | true (prefix match) |
| `push` | — | true |

## Not touched

The `0 7` platform guards. Same fragile shape, but they currently work and nothing here measured them failing. Rewriting a working gate on a hunch is how the next eight nights get lost — recorded in the issue as a known sibling.

`just check fast` green; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)