### PR TITLE
fix(#1031): the cxx-syntax lane generates the headers it compiles against

### DIFF
--- a/docs/issues/archived/1031-cxx-syntax-config-header-never-generated.md
+++ b/docs/issues/archived/1031-cxx-syntax-config-header-never-generated.md
@@ -1,0 +1,84 @@
+---
+id: 1031
+title: "the cxx-syntax lane's config-header generation selects no RMW backend, so the probe returns 0, both build scripts decline to write, and three snippets compile against the committed stub — passing locally only on residue"
+status: resolved
+area: build, testing
+severity: medium
+found: 2026-09-04
+resolved: 2026-09-04
+related: [0834, 0464, 0475, 0088, 1030]
+---
+
+# A build that exits 0 having generated nothing
+
+## Symptom
+
+Every scheduled `gate.yml` run, three `cxx-syntax` compile-check fixtures failed:
+
+```
+== generating nros-cpp / nros-c config headers for cxx-syntax ==
+== cxx-syntax: rclcpp_node_options ==
+.../nros_config_generated.h:37:2: error: #error "nros_config_generated.h must be supplied per-build by the build system; see this stub for guidance."
+.../nros_cpp_config_generated.h:59:2: error: #error "nros_cpp_config_generated.h must be supplied per-build ..."
+.../polling_action_server.hpp:231:44: error: 'NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S' was not declared in this scope
+   cxx-syntax FAILED for rclcpp_node_options (no stamp; consuming test will report)
+```
+
+Same for `subscription_with_info` and `spin_until_future_complete` — the three
+snippets that reach `nros.hpp`. The step itself exited 0.
+
+## Root cause
+
+`scripts/build/compile-check-fixtures.sh` generated the per-build headers with
+
+```
+cargo build -q -p nros-cpp -p nros-c --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble
+```
+
+which selects **no RMW backend**. Both build scripts take their sizes from
+`probe_nros_sizes`, which builds `nros` with the features this command resolves;
+with no backend the probe returns `EXECUTOR_SIZE = 0`, and both scripts then
+take the documented early return — "no RMW backend means no executor sizes to
+ship" — writing neither header. The build succeeds, so the script's
+`|| echo "...generation build failed"` never fires.
+
+Adding `nros-cpp/rmw-zenoh-cffi` makes the probe yield real sizes and both
+headers appear.
+
+## Why it looked like a CI-only fault
+
+It is not. Reproduced on a developer machine — but only after deleting
+`target/nros-{c,cpp}-generated/`. Those directories are normally left over from
+some other build that DID select a backend, so the lane passes on **residue**.
+Before the second fix below, deleting them did not even restore them: the
+headers are a build-script byproduct that nothing declared as an input, so
+cargo considered the crates fresh and never re-ran the scripts. The
+`drop_stamp_without_header` doc comment already described that state — "cargo
+considers the crate up to date, so the byproduct is not re-emitted" — and noted
+that `write_header_if_absent_or_verify` "already self-heals an absent header
+when it RUNS". The missing half was making it run.
+
+## Fix
+
+1. `nros-cpp/rmw-zenoh-cffi` added to the generation command, with the reason
+   at the call site.
+2. `cargo:rerun-if-changed` on the generated header and its stamp, from both
+   the writer and the declining path. Cargo now says
+   `Dirty nros-cpp: the file target/nros-c-generated/nros/nros_config_generated.h is missing`
+   and regenerates. Verified no rebuild loop: three consecutive builds report
+   1, 0, 0 dirty units. Same discipline as the `rerun-if-changed` on the
+   cbindgen output one function over, and issue 0475's shape one layer down.
+3. A build that exits 0 having written no header now says so, instead of
+   letting the failure surface twenty frames into a header as the stub's
+   `#error`.
+
+Verified: from a cleared `target/nros-{c,cpp}-generated/`, all three snippets
+stamp `.compile-ok`.
+
+## What stays open
+
+The step exits 0 while three of its fixtures fail — by design ("no stamp;
+consuming test will report"), but the consuming test does not run in that lane,
+so nothing reported it for as long as it was broken. Changing that exit
+semantics affects every compile-check lane and is not done here. It is the same
+lane-visibility problem as issue 1030.

--- a/packages/tooling/nros-build-helpers/src/shared.rs
+++ b/packages/tooling/nros-build-helpers/src/shared.rs
@@ -613,6 +613,31 @@ pub fn write_header_if_absent_or_verify(relative: &[&str], contents: &str, label
     let Some(dest) = target_dir_path(relative) else {
         return;
     };
+    // The edge that makes this function's self-healing REACHABLE.
+    //
+    // This header is a build-script byproduct that nothing declares as an
+    // input, so cargo's freshness never considered it: delete it and the crate
+    // is still up to date, the script does not run, and the header does not
+    // come back. `drop_stamp_without_header`'s doc already describes that state
+    // ("cargo considers the crate up to date, so the byproduct is not
+    // re-emitted") and says this function "already self-heals an absent header
+    // when it RUNS" — the missing half was making it run.
+    //
+    // Cost of not having it, measured on gate.yml's scheduled lane: three
+    // `cxx-syntax` snippets failed every night with the committed stub's
+    // `#error` and `*_OPAQUE_U64S was not declared`, because the generation
+    // step's `cargo build` was up to date and emitted nothing.
+    //
+    // Same shape as the `rerun-if-changed` on the cbindgen output above, and as
+    // issue 0475 one layer down: a file with no edge is a file the build cannot
+    // notice. No rebuild loop — the writers below are conditional, so a steady
+    // state rewrites neither file and the mtimes stay behind the script's own
+    // output stamp.
+    println!("cargo:rerun-if-changed={}", dest.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        dest.with_extension("h.stamp").display()
+    );
     // Sidecar rather than a `#define` inside the header: the two writers build
     // `contents` from different sources (nros-c from a `.template`, nros-cpp
     // from an inline string), so a stamp define would have to be added to both
@@ -688,6 +713,11 @@ pub fn drop_stamp_without_header(relative: &[&str]) {
         return;
     };
     let stamp_path = dest.with_extension("h.stamp");
+    // Same edge as the writer's. A declining run must watch these too, or the
+    // build that would START emitting them (a later run whose probe finally
+    // yields sizes) is one cargo considers unnecessary.
+    println!("cargo:rerun-if-changed={}", dest.display());
+    println!("cargo:rerun-if-changed={}", stamp_path.display());
     if !dest.exists() && stamp_path.exists() {
         // Best-effort: a build script must not fail because a cleanup could
         // not run. The gate (`check-orphan-generated-stamp`) still catches the

--- a/scripts/build/compile-check-fixtures.sh
+++ b/scripts/build/compile-check-fixtures.sh
@@ -665,9 +665,35 @@ if command -v "${CXX:-c++}" >/dev/null 2>&1; then
     # build is `no_std` and dies on `#[panic_handler]` / "unwinding panics are
     # not supported without std". It failed into the `|| echo` below, which
     # loses the headers silently — the exact shape issue 0464 is about.
+    #
+    # The RMW backend is load-bearing, not decoration. Both build scripts get
+    # their sizes from `probe_nros_sizes`, which builds `nros` with the features
+    # this command resolves; with no backend selected the probe returns
+    # `EXECUTOR_SIZE = 0` and BOTH scripts then decline to write the header at
+    # all ("no RMW backend means no executor sizes to ship"). The build still
+    # exits 0, so the `|| echo` below never fires, and the three snippets that
+    # reach `nros.hpp` fail against the committed stub:
+    #
+    #   nros_config_generated.h:37:2: error: #error "must be supplied per-build"
+    #   polling_action_server.hpp:231:44: error: NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S was not declared
+    #
+    # That was every scheduled run's `rclcpp_node_options`,
+    # `subscription_with_info` and `spin_until_future_complete`. It read as a
+    # CI-only fault and was not: on a developer machine the headers are left
+    # over from some other build that DID select a backend, so the lane passes
+    # on residue. Issue 1031.
     ( cd "$repo_root" && cargo build -q -p nros-cpp -p nros-c \
-        --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble ) \
+        --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble,nros-cpp/rmw-zenoh-cffi ) \
         || echo "cxx-syntax: config-header generation build failed (snippets needing them will skip)" >&2
+    # A build that exits 0 having written nothing is the case the `||` above
+    # cannot see. Say so — the snippets fail either way, but their error is
+    # `#error "must be supplied per-build"` twenty frames into a header, which
+    # names the stub rather than the step that was supposed to replace it.
+    for _h in target/nros-cpp-generated/nros/nros_cpp_config_generated.h \
+              target/nros-c-generated/nros/nros_config_generated.h; do
+        [ -f "$repo_root/$_h" ] || echo "cxx-syntax: config-header generation produced NO $_h \
+(the build succeeded) — snippets including it will fail against the committed stub" >&2
+    done
     while IFS=$'\x1f' read -r id builder dir pkg mdir target profiles output; do
         [ -n "$id" ] || continue
         run_fixture "$out_root/$id" "$id" "$builder" cxx_syntax_check "$id"


### PR DESCRIPTION
## Symptom

Three `cxx-syntax` compile-check snippets — `rclcpp_node_options`, `subscription_with_info`, `spin_until_future_complete`, the ones that reach `nros.hpp` — failed in **every** scheduled run against the committed stub:

```
nros_config_generated.h:37:2: error: #error "nros_config_generated.h must be supplied per-build by the build system"
polling_action_server.hpp:231:44: error: 'NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S' was not declared in this scope
   cxx-syntax FAILED for rclcpp_node_options (no stamp; consuming test will report)
```

## Root cause

The generation step ran and reported nothing wrong, because nothing was wrong with what it ran:

```
cargo build -q -p nros-cpp -p nros-c --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble
```

**No RMW backend.** Both build scripts take their sizes from `probe_nros_sizes`, which builds `nros` with the features this command resolves; with no backend the probe returns `EXECUTOR_SIZE = 0` and both take the documented early return — *"no RMW backend means no executor sizes to ship"* — writing neither header. The build exits 0, so the `|| echo` guarding that line never fires.

## It was not a CI-only fault

On a developer machine `target/nros-{c,cpp}-generated/` is left over from some other build that *did* select a backend, so the lane passes on **residue**. This lane's green on my tree was a museum artifact; deleting those directories reproduced CI exactly.

Deleting them also did not restore them — the second defect. The headers are a build-script byproduct nothing declared as an input, so cargo considered the crates fresh and never re-ran the scripts. `drop_stamp_without_header`'s own doc already described that state ("cargo considers the crate up to date, so the byproduct is not re-emitted") and noted that `write_header_if_absent_or_verify` "already self-heals an absent header when it RUNS". The missing half was making it run.

## Fix

1. `nros-cpp/rmw-zenoh-cffi` on the generation command, with the reason at the call site.
2. `cargo:rerun-if-changed` on the header and its stamp, from both the writer and the declining path. Cargo now reports `Dirty nros-cpp: the file target/nros-c-generated/nros/nros_config_generated.h is missing` and regenerates. Same discipline as the `rerun-if-changed` on the cbindgen output one function over, which already names issue 0475's shape.
3. A build that exits 0 having written no header now says so, rather than letting the failure surface twenty frames into a header as the stub's `#error`.

## Verification

- From a cleared `target/nros-{c,cpp}-generated/`, all three snippets stamp `.compile-ok`.
- Three consecutive builds report **1, 0, 0** dirty units — the new edge does not loop.
- `just check fast` 190/190.

## Left open

The step exits 0 while three of its fixtures fail. That's by design ("no stamp; consuming test will report") — but the consuming test doesn't run in this lane, so nothing reported it for as long as it was broken. Changing that affects every compile-check lane, so it's recorded in the issue alongside #1030 rather than done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)