### PR TITLE
fix(#1032): a snippet that will not compile is reported by someone

### DIFF
--- a/docs/issues/archived/1031-cxx-syntax-config-header-never-generated.md
+++ b/docs/issues/archived/1031-cxx-syntax-config-header-never-generated.md
@@ -1,0 +1,84 @@
+---
+id: 1031
+title: "the cxx-syntax lane's config-header generation selects no RMW backend, so the probe returns 0, both build scripts decline to write, and three snippets compile against the committed stub — passing locally only on residue"
+status: resolved
+area: build, testing
+severity: medium
+found: 2026-09-04
+resolved: 2026-09-04
+related: [0834, 0464, 0475, 0088, 1030]
+---
+
+# A build that exits 0 having generated nothing
+
+## Symptom
+
+Every scheduled `gate.yml` run, three `cxx-syntax` compile-check fixtures failed:
+
+```
+== generating nros-cpp / nros-c config headers for cxx-syntax ==
+== cxx-syntax: rclcpp_node_options ==
+.../nros_config_generated.h:37:2: error: #error "nros_config_generated.h must be supplied per-build by the build system; see this stub for guidance."
+.../nros_cpp_config_generated.h:59:2: error: #error "nros_cpp_config_generated.h must be supplied per-build ..."
+.../polling_action_server.hpp:231:44: error: 'NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S' was not declared in this scope
+   cxx-syntax FAILED for rclcpp_node_options (no stamp; consuming test will report)
+```
+
+Same for `subscription_with_info` and `spin_until_future_complete` — the three
+snippets that reach `nros.hpp`. The step itself exited 0.
+
+## Root cause
+
+`scripts/build/compile-check-fixtures.sh` generated the per-build headers with
+
+```
+cargo build -q -p nros-cpp -p nros-c --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble
+```
+
+which selects **no RMW backend**. Both build scripts take their sizes from
+`probe_nros_sizes`, which builds `nros` with the features this command resolves;
+with no backend the probe returns `EXECUTOR_SIZE = 0`, and both scripts then
+take the documented early return — "no RMW backend means no executor sizes to
+ship" — writing neither header. The build succeeds, so the script's
+`|| echo "...generation build failed"` never fires.
+
+Adding `nros-cpp/rmw-zenoh-cffi` makes the probe yield real sizes and both
+headers appear.
+
+## Why it looked like a CI-only fault
+
+It is not. Reproduced on a developer machine — but only after deleting
+`target/nros-{c,cpp}-generated/`. Those directories are normally left over from
+some other build that DID select a backend, so the lane passes on **residue**.
+Before the second fix below, deleting them did not even restore them: the
+headers are a build-script byproduct that nothing declared as an input, so
+cargo considered the crates fresh and never re-ran the scripts. The
+`drop_stamp_without_header` doc comment already described that state — "cargo
+considers the crate up to date, so the byproduct is not re-emitted" — and noted
+that `write_header_if_absent_or_verify` "already self-heals an absent header
+when it RUNS". The missing half was making it run.
+
+## Fix
+
+1. `nros-cpp/rmw-zenoh-cffi` added to the generation command, with the reason
+   at the call site.
+2. `cargo:rerun-if-changed` on the generated header and its stamp, from both
+   the writer and the declining path. Cargo now says
+   `Dirty nros-cpp: the file target/nros-c-generated/nros/nros_config_generated.h is missing`
+   and regenerates. Verified no rebuild loop: three consecutive builds report
+   1, 0, 0 dirty units. Same discipline as the `rerun-if-changed` on the
+   cbindgen output one function over, and issue 0475's shape one layer down.
+3. A build that exits 0 having written no header now says so, instead of
+   letting the failure surface twenty frames into a header as the stub's
+   `#error`.
+
+Verified: from a cleared `target/nros-{c,cpp}-generated/`, all three snippets
+stamp `.compile-ok`.
+
+## What stays open
+
+The step exits 0 while three of its fixtures fail — by design ("no stamp;
+consuming test will report"), but the consuming test does not run in that lane,
+so nothing reported it for as long as it was broken. Changing that exit
+semantics affects every compile-check lane and is not done here. It is the same
+lane-visibility problem as issue 1030.

--- a/docs/issues/archived/1032-cpp-snippet-stamp-reported-nowhere.md
+++ b/docs/issues/archived/1032-cpp-snippet-stamp-reported-nowhere.md
@@ -1,0 +1,76 @@
+---
+id: 1032
+title: "a compile-check snippet's failure was reported at neither end: the build stage defers to the consuming test, the consuming test skipped unconditionally, and one snippet had no consumer at all"
+status: resolved
+area: testing, build
+severity: medium
+found: 2026-09-04
+resolved: 2026-09-04
+related: [1031, 1030, 0034, 0309]
+---
+
+# "Does not fail here because it fails there" — failing nowhere
+
+## The chain
+
+Three `cxx-syntax` snippets failed in every scheduled `gate.yml` run from at
+least 2026-09-01 (issue 1031 is why they failed). Nothing went red, at either
+end of a two-step handoff:
+
+1. **Build stage** — `cxx_syntax_check` on a failed compile echoes
+   `cxx-syntax FAILED for <id> (no stamp; consuming test will report)` and
+   returns. The step exits 0. This is deliberate: a snippet that will not
+   compile must not block `build-test-fixtures`. Its comment states the
+   contract — "the consuming test reports the gap per tier (hard-fail full /
+   [SKIPPED] light)".
+
+2. **Consuming test** — `cpp_api_drift.rs`'s `assert_snippet_compiled` caught
+   `Err(_)` from `require_compile_check` and called `nros_tests::skip!`
+   **unconditionally**. A skip is not a failure. No tier logic, despite the
+   claim above.
+
+So step 1 deferred to step 2, and step 2 reported nothing.
+
+The tier policy the build script described was not missing from the codebase —
+it lives in `require_compile_check`, which is tier-aware (hard-fail in the full
+tier, `[SKIPPED]` under `NROS_FIXTURES_OPTIONAL=1`). `cpp_api_drift.rs` threw it
+away by catching the error. The sibling consumer,
+`platform_header_compile.rs`, has always used `?` and has always failed
+correctly.
+
+## The third snippet
+
+`spin_until_future_complete` was asserted by **nothing**. A search for its id
+across the test tree found only the fixture file. It was one of the three
+failing nightly and the one no consumer could ever have reported — a step worse
+than a skip that says nothing.
+
+## Stale justification
+
+The skip cited issue 0034 as tracked pre-existing drift. 0034 was resolved and
+archived on 2026-06-12. Its named cause here — "`rclcpp_node_options` needs
+generated config headers" — was issue 1031, fixed the same day as this. The
+excuse outlived the defect by three months, and the module doc still described
+the snippets as currently failing.
+
+## Fix
+
+* `assert_snippet_compiled` propagates with `?`, restoring the tier policy
+  rather than writing a second one.
+* `spin_until_future_complete_compiles` added.
+* The build script's comment no longer asserts what another file does without
+  qualification; it says the deferral is only safe while a consumer exists.
+* **Structural**: `fixtures-manifest.py validate-compile-checks` now rejects a
+  `cxx-syntax` row whose id no test names. It runs in the fast tier via
+  `check fixtures-manifest`, so a snippet added without an assertion cannot
+  land. All 12 current rows pass with no baseline.
+
+## Verified
+
+* All four tests pass with the stamps present.
+* Removing `spin_until_future_complete`'s stamp turns the test RED (it was
+  silently green before).
+* Under `NROS_FIXTURES_OPTIONAL=1` the same missing stamp yields `[SKIPPED]`,
+  so the light tier is unchanged.
+* Mutation on the new gate: repointing the new test at another id makes
+  `validate-compile-checks` fail naming `spin_until_future_complete`.

--- a/packages/testing/nros-tests/tests/cpp_api_drift.rs
+++ b/packages/testing/nros-tests/tests/cpp_api_drift.rs
@@ -10,13 +10,14 @@
 //!     compilation inside tests", these compile in the **build stage** — the
 //!     `cpp_compat_snippets/*.cpp` fixtures are `c++ -fsyntax-only`'d by
 //!     `compile-check-fixtures.sh` (run by `build-test-fixtures`), which stamps
-//!     `.compile-ok`. The tests assert the stamps. (The snippets currently fail
-//!     to compile — a pre-existing drift: `declared_node`'s `create_subscription`
-//!     call is stale vs the current signature, and `rclcpp_node_options` needs
-//!     generated config headers; both are tracked in issue 0034 for the C++ API
-//!     owner. Until fixed, the build stage leaves no stamp and these report the
-//!     gap per tier — they do NOT block `build-test-fixtures`.)
+//!     `.compile-ok`. The tests assert the stamps, and a missing stamp is a
+//!     FAILURE in the full tier (`[SKIPPED]` only under
+//!     `NROS_FIXTURES_OPTIONAL=1`) — see `assert_snippet_compiled`. The build
+//!     stage still does not block `build-test-fixtures` on a snippet that will
+//!     not compile; reporting it is this file's job, and until issue 1032 it
+//!     was not being done.
 
+use nros_tests::TestResult;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -104,19 +105,37 @@ fn examples_cpp_have_no_retired_symbols() {
     );
 }
 
-/// Assert a cpp-compat-snippet's build-stage `.compile-ok` stamp. The snippet's
-/// compile is a tracked pre-existing drift (issue 0034) — when the build stage
-/// couldn't compile it, skip with a pointer rather than hard-fail (the compile
-/// error is in the build-test-fixtures log; the fix is the C++ API owner's).
-fn assert_snippet_compiled(id: &str) {
-    match nros_tests::fixtures::require_compile_check(id) {
-        Ok(stamp) => assert!(stamp.exists(), "stamp missing: {}", stamp.display()),
-        Err(_) => nros_tests::skip!(
-            "cpp compat snippet `{id}` not built — pre-existing C++ API drift / \
-             missing generated headers (issue 0034); run `just build-test-fixtures` \
-             and see its log for the compile error"
-        ),
-    }
+/// Assert a cpp-compat-snippet's build-stage `.compile-ok` stamp.
+///
+/// issue 1032 — this used to catch `Err(_)` and `skip!` UNCONDITIONALLY, which
+/// made a broken snippet green at both ends: the build stage already declines
+/// to fail (`cxx-syntax FAILED for <id> (no stamp; consuming test will
+/// report)`) on the understanding that the consuming test reports it, and the
+/// consuming test then reported nothing. Three snippets failed every scheduled
+/// run from at least 2026-09-01 and no lane went red.
+///
+/// The skip cited issue 0034 as a tracked pre-existing drift. 0034 was resolved
+/// and archived on 2026-06-12, and its named cause here — "needs generated
+/// config headers" — was issue 1031, fixed. The excuse outlived the defect by
+/// three months.
+///
+/// `?` rather than a bare `assert!`, because the tier policy the old code threw
+/// away already lives in `require_compile_check`: hard-fail in the full tier,
+/// `[SKIPPED]` under `NROS_FIXTURES_OPTIONAL=1`. This restores that policy
+/// instead of writing a second one — the sibling consumer
+/// (`platform_header_compile.rs`) has always done it this way.
+fn assert_snippet_compiled(id: &str) -> TestResult<()> {
+    let stamp = nros_tests::fixtures::require_compile_check(id)?;
+    assert!(
+        stamp.exists(),
+        "compile-ok stamp missing for `{id}`: {}\n\
+         The snippet did not compile at the build stage. Run \
+         `just build-test-fixtures` and read its log for the compile error — \
+         these snippets are the only compile coverage for the public \
+         `nros.hpp` surface.",
+        stamp.display()
+    );
+    Ok(())
 }
 
 // Phase-257 Stage-3b — the `declared_node_typed_helpers` snippet exercised the
@@ -125,8 +144,8 @@ fn assert_snippet_compiled(id: &str) {
 // (`configure(Node&)` + `Publisher<M>` + `bind_timer`).
 
 #[test]
-fn rclcpp_node_options_and_component_factory_compile() {
-    assert_snippet_compiled("rclcpp_node_options");
+fn rclcpp_node_options_and_component_factory_compile() -> TestResult<()> {
+    assert_snippet_compiled("rclcpp_node_options")
 }
 
 /// phase-277 W5 — the callback-style subscription-with-attachment path
@@ -134,6 +153,19 @@ fn rclcpp_node_options_and_component_factory_compile() {
 /// dedicated snippet; it used to live as an `if (false)` block inside the
 /// `examples/native/cpp/listener` example (examples stay demo-only).
 #[test]
-fn create_subscription_with_info_compiles() {
-    assert_snippet_compiled("subscription_with_info");
+fn create_subscription_with_info_compiles() -> TestResult<()> {
+    assert_snippet_compiled("subscription_with_info")
+}
+
+/// issue 1032 — `spin_until_future_complete.cpp` was compiled by the build
+/// stage and asserted by NOTHING. Not even the unconditional skip above reached
+/// it: a grep for its id across the test tree found only the fixture file.
+///
+/// It was one of the three snippets failing in every scheduled run, and it was
+/// the one no consumer could ever have reported, which is a step worse than a
+/// skip that says nothing — a fixture with no consumer is build cost that
+/// cannot answer a question.
+#[test]
+fn spin_until_future_complete_compiles() -> TestResult<()> {
+    assert_snippet_compiled("spin_until_future_complete")
 }

--- a/packages/tooling/nros-build-helpers/src/shared.rs
+++ b/packages/tooling/nros-build-helpers/src/shared.rs
@@ -613,6 +613,31 @@ pub fn write_header_if_absent_or_verify(relative: &[&str], contents: &str, label
     let Some(dest) = target_dir_path(relative) else {
         return;
     };
+    // The edge that makes this function's self-healing REACHABLE.
+    //
+    // This header is a build-script byproduct that nothing declares as an
+    // input, so cargo's freshness never considered it: delete it and the crate
+    // is still up to date, the script does not run, and the header does not
+    // come back. `drop_stamp_without_header`'s doc already describes that state
+    // ("cargo considers the crate up to date, so the byproduct is not
+    // re-emitted") and says this function "already self-heals an absent header
+    // when it RUNS" — the missing half was making it run.
+    //
+    // Cost of not having it, measured on gate.yml's scheduled lane: three
+    // `cxx-syntax` snippets failed every night with the committed stub's
+    // `#error` and `*_OPAQUE_U64S was not declared`, because the generation
+    // step's `cargo build` was up to date and emitted nothing.
+    //
+    // Same shape as the `rerun-if-changed` on the cbindgen output above, and as
+    // issue 0475 one layer down: a file with no edge is a file the build cannot
+    // notice. No rebuild loop — the writers below are conditional, so a steady
+    // state rewrites neither file and the mtimes stay behind the script's own
+    // output stamp.
+    println!("cargo:rerun-if-changed={}", dest.display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        dest.with_extension("h.stamp").display()
+    );
     // Sidecar rather than a `#define` inside the header: the two writers build
     // `contents` from different sources (nros-c from a `.template`, nros-cpp
     // from an inline string), so a stamp define would have to be added to both
@@ -688,6 +713,11 @@ pub fn drop_stamp_without_header(relative: &[&str]) {
         return;
     };
     let stamp_path = dest.with_extension("h.stamp");
+    // Same edge as the writer's. A declining run must watch these too, or the
+    // build that would START emitting them (a later run whose probe finally
+    // yields sizes) is one cargo considers unnecessary.
+    println!("cargo:rerun-if-changed={}", dest.display());
+    println!("cargo:rerun-if-changed={}", stamp_path.display());
     if !dest.exists() && stamp_path.exists() {
         // Best-effort: a build script must not fail because a cleanup could
         // not run. The gate (`check-orphan-generated-stamp`) still catches the

--- a/scripts/build/compile-check-fixtures.sh
+++ b/scripts/build/compile-check-fixtures.sh
@@ -665,9 +665,35 @@ if command -v "${CXX:-c++}" >/dev/null 2>&1; then
     # build is `no_std` and dies on `#[panic_handler]` / "unwinding panics are
     # not supported without std". It failed into the `|| echo` below, which
     # loses the headers silently — the exact shape issue 0464 is about.
+    #
+    # The RMW backend is load-bearing, not decoration. Both build scripts get
+    # their sizes from `probe_nros_sizes`, which builds `nros` with the features
+    # this command resolves; with no backend selected the probe returns
+    # `EXECUTOR_SIZE = 0` and BOTH scripts then decline to write the header at
+    # all ("no RMW backend means no executor sizes to ship"). The build still
+    # exits 0, so the `|| echo` below never fires, and the three snippets that
+    # reach `nros.hpp` fail against the committed stub:
+    #
+    #   nros_config_generated.h:37:2: error: #error "must be supplied per-build"
+    #   polling_action_server.hpp:231:44: error: NROS_CPP_RAW_ACTION_SERVER_OPAQUE_U64S was not declared
+    #
+    # That was every scheduled run's `rclcpp_node_options`,
+    # `subscription_with_info` and `spin_until_future_complete`. It read as a
+    # CI-only fault and was not: on a developer machine the headers are left
+    # over from some other build that DID select a backend, so the lane passes
+    # on residue. Issue 1031.
     ( cd "$repo_root" && cargo build -q -p nros-cpp -p nros-c \
-        --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble ) \
+        --features nros-cpp/std,nros-c/std,nros-cpp/ros-humble,nros-cpp/rmw-zenoh-cffi ) \
         || echo "cxx-syntax: config-header generation build failed (snippets needing them will skip)" >&2
+    # A build that exits 0 having written nothing is the case the `||` above
+    # cannot see. Say so — the snippets fail either way, but their error is
+    # `#error "must be supplied per-build"` twenty frames into a header, which
+    # names the stub rather than the step that was supposed to replace it.
+    for _h in target/nros-cpp-generated/nros/nros_cpp_config_generated.h \
+              target/nros-c-generated/nros/nros_config_generated.h; do
+        [ -f "$repo_root/$_h" ] || echo "cxx-syntax: config-header generation produced NO $_h \
+(the build succeeded) — snippets including it will fail against the committed stub" >&2
+    done
     while IFS=$'\x1f' read -r id builder dir pkg mdir target profiles output; do
         [ -n "$id" ] || continue
         run_fixture "$out_root/$id" "$id" "$builder" cxx_syntax_check "$id"

--- a/scripts/build/compile-check-fixtures.sh
+++ b/scripts/build/compile-check-fixtures.sh
@@ -619,6 +619,13 @@ cxx_syntax_check() {
     # missing generated header) does NOT fail build-test-fixtures — it just
     # leaves no `.compile-ok`, so the consuming test reports the gap per tier
     # (hard-fail full / [SKIPPED] light). The compile error is in this log.
+    #
+    # issue 1032 — that sentence was an ASSERTION ABOUT ANOTHER FILE, and it was
+    # false for three snippets. `cpp_api_drift.rs` caught the error and skipped
+    # unconditionally, and `spin_until_future_complete` had no consumer at all,
+    # so "does not fail here because it fails there" failed NOWHERE. Deferring a
+    # report is only safe while something is on the other end; if you add a
+    # snippet, add its assertion in the same commit.
     # phase-363 W4 — `-MD -MF` so the compiler records which headers it actually
     # read. Without it these rows had NO measured closure: their signature was
     # the snippet plus two hand-named include TREES, so a header reached through

--- a/scripts/build/fixtures-manifest.py
+++ b/scripts/build/fixtures-manifest.py
@@ -206,6 +206,51 @@ def validate_compile_check_fixture(entry):
             _fail(entry, f"missing required key 'output' for builder {builder!r}")
 
 
+# Where a `cxx-syntax` row's stamp is asserted. One directory, because these
+# are all `nros-tests` integration tests.
+CXX_CONSUMER_DIR = SCRIPT_ROOT / "packages/testing/nros-tests/tests"
+
+
+def _cxx_rows_without_a_consumer(entries):
+    """`cxx-syntax` ids no test names — issue 1032.
+
+    The build stage deliberately does NOT fail on a snippet that will not
+    compile: it leaves no `.compile-ok` and defers the report to the consuming
+    test. That contract is only safe while a consumer EXISTS, and for
+    `spin_until_future_complete` none ever did — it was compiled every run,
+    failed every run since at least 2026-09-01, and could not be reported by
+    anyone. A snippet with no consumer is build cost that cannot answer a
+    question.
+
+    A text search for the quoted id, not an import graph: the two consumers
+    spell it differently (a literal argument in `cpp_api_drift.rs`, a `const`
+    array in `platform_header_compile.rs`) and both are found this way.
+    """
+    if not CXX_CONSUMER_DIR.is_dir():
+        return []
+    # `git ls-files`, not a walk: these are tracked sources, and the repo's
+    # `check-no-tracked-file-find` forbids the walk for the reason
+    # `regenerate-bindings.sh` records — an index lookup instead of a
+    # filesystem traversal.
+    listed = subprocess.run(
+        ["git", "ls-files", "-z", "--", str(CXX_CONSUMER_DIR)],
+        cwd=SCRIPT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    hay = "\n".join(
+        (SCRIPT_ROOT / rel).read_text(encoding="utf-8", errors="replace")
+        for rel in listed.split("\0")
+        if rel.endswith(".rs")
+    )
+    return [
+        e["id"]
+        for e in entries
+        if e.get("builder") == "cxx-syntax" and f'"{e["id"]}"' not in hay
+    ]
+
+
 def validate_compile_check_fixtures(entries):
     seen = {}
     for e in entries:
@@ -214,6 +259,17 @@ def validate_compile_check_fixtures(entries):
         if fid in seen:
             _fail(e, f"duplicate compile-check fixture id {fid!r}")
         seen[fid] = True
+    orphans = _cxx_rows_without_a_consumer(entries)
+    if orphans:
+        raise ValueError(
+            "cxx-syntax row(s) whose `.compile-ok` no test asserts: "
+            + ", ".join(sorted(orphans))
+            + f"\nThe build stage does not fail on a snippet that will not compile — "
+            f"it defers the report to a consuming test (issue 1032). With no "
+            f"consumer, nothing reports it at all.\nAdd an assertion under "
+            f"{CXX_CONSUMER_DIR.relative_to(SCRIPT_ROOT)}/ that calls "
+            f"`nros_tests::fixtures::require_compile_check(\"<id>\")`."
+        )
     return len(seen)
 
 


### PR DESCRIPTION
> **Stacked on #321.** Without that fix these snippets don't compile at all, so the tests this PR sharpens would be red on their own. Base retargets to `main` when #321 merges.

## The chain

Three `cxx-syntax` snippets failed in every scheduled run from at least 2026-09-01 (#1031 is *why*). Nothing went red, at either end of a two-step handoff:

1. **Build stage** — echoes `cxx-syntax FAILED for <id> (no stamp; consuming test will report)` and exits 0. Deliberate: a snippet that won't compile must not block `build-test-fixtures`.
2. **Consuming test** — `cpp_api_drift.rs` caught `Err(_)` from `require_compile_check` and called `skip!` **unconditionally**.

Step 1 deferred to step 2. Step 2 reported nothing.

## The policy was never missing

The build script's comment claimed the consumer reports "per tier (hard-fail full / [SKIPPED] light)". That policy lives in `require_compile_check` and is real — `cpp_api_drift.rs` threw it away by catching the error. The sibling consumer `platform_header_compile.rs` has always used `?` and always failed correctly.

So the fix is `?`, not a new policy.

## The third snippet had no consumer at all

`spin_until_future_complete` was asserted by **nothing** — a search for its id across the test tree found only the fixture file. One of the three failing nightly, and the one nobody could ever have reported. It has a test now.

## Stale justification

The skip cited issue 0034 as tracked pre-existing drift. **0034 was resolved and archived 2026-06-12**, and its named cause here ("`rclcpp_node_options` needs generated config headers") was #1031, fixed today. The excuse outlived the defect by three months; the module doc still described these snippets as currently failing. Both corrected.

## Structural half

`validate-compile-checks` now rejects a `cxx-syntax` row whose id no test names — fast tier via `check fixtures-manifest`, so a snippet added without an assertion cannot land. All 12 current rows pass, no baseline. Lookup is `git ls-files`, not a walk: `check-no-tracked-file-find` caught my first version, for the reason `regenerate-bindings.sh` records.

## Verified

- Four tests pass with stamps present.
- Removing `spin_until_future_complete`'s stamp turns it **RED** — silently green before.
- Under `NROS_FIXTURES_OPTIONAL=1` the same missing stamp yields `[SKIPPED]` — light tier unchanged.
- Mutation on the new gate: repointing the new test at another id makes `validate-compile-checks` fail, naming the orphan.
- `just check fast` 190/190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)