### PR TITLE
fix(#0968): the XRCE transport MTU knob was dead — 118,272 bytes per session

### DIFF
--- a/book/src/reference/configuration-surface.md
+++ b/book/src/reference/configuration-surface.md
@@ -122,7 +122,7 @@ Read by compiled code or forwarded to a build script. On Zephyr the
 | `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS` | `4` | forwarded-to-cargo, cmake |
 | `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | `8` | forwarded-to-cargo, cmake |
 | `CONFIG_NROS_XRCE_STREAM_HISTORY` | `16` | forwarded-to-cargo, cmake |
-| `CONFIG_NROS_XRCE_TRANSPORT_MTU` | `512` | forwarded-to-cargo, cmake |
+| `CONFIG_NROS_XRCE_TRANSPORT_MTU` | `512` | forwarded-to-cargo, cmake, rust-source |
 | `CONFIG_NROS_ZENOH_AUTO_RECONNECT` | `y` | cmake |
 | `CONFIG_NROS_ZENOH_LEASE_FACTOR` | `3` | c-define, cmake |
 | `CONFIG_NROS_ZENOH_LEASE_MS` | `10000` | c-define, cmake |

--- a/book/src/reference/static-pool-inventory.md
+++ b/book/src/reference/static-pool-inventory.md
@@ -64,7 +64,7 @@ its byte cost yet. Absence of a figure is not a claim that it is free.
 | `NROS_SMOLTCP_SOCKET_TIMEOUT_MS` | computed — see `packages/drivers/net/nros-smoltcp/build.rs:67` | `packages/drivers/net/nros-smoltcp` |
 | `NROS_SUBSCRIBER_BUFFER_SIZE` | computed — see `packages/core/nros-node/build.rs:171` | `packages/core/nros-node` **(conflicting defaults — see below)** |
 | `NROS_SUBSCRIPTION_BUFFER_SIZE` | 1024 | `packages/core/nros-node` |
-| `NROS_XRCE_CUSTOM_TRANSPORT_MTU` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:406` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
+| `NROS_XRCE_CUSTOM_TRANSPORT_MTU` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:433` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
 | `NROS_XRCE_STREAM_HISTORY` | computed — see `packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs:264` | `packages/rmw/xrce/nros-rmw-xrce-cffi` |
 | `NROS_ZEPHYR_HEAP_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:891` | `packages/tooling/nros-platform-config` |
 | `ZPICO_BATCH_MULTICAST_SIZE` | computed — see `packages/tooling/nros-platform-config/src/platform_config.rs:1081` | `packages/tooling/nros-platform-config` |

--- a/docs/issues/1033-xrce-subscriber-slots-budget-eight-for-one.md
+++ b/docs/issues/1033-xrce-subscriber-slots-budget-eight-for-one.md
@@ -1,0 +1,81 @@
+---
+id: 1033
+title: "The XRCE session budgets eight 32-deep subscriber rings, so a one-subscriber image pays 266,368 bytes for seven it will never use"
+status: open
+area: rmw, memory
+severity: high
+found: 2026-09-04
+related: [0968, 0827, 0900, 0965, 0460, phase-392, phase-412]
+---
+
+# 62% of the XRCE session struct is slots the image does not have
+
+## Measured
+
+`sizeof(xrce_session_state_t)` on the zephyr cpp-listener-xrce image, read from
+its own DWARF, after the MTU fix in issue 0968 took it from 427,968:
+
+| member | bytes | share |
+| --- | ---: | ---: |
+| `subscriber_slots[8]` @ 33,296 | **266,368** | 86% |
+| `service_server_slots[4]` @ 4,384 | 17,536 | 6% |
+| `output` + `input_reliable_buf` @ 8,192 | 16,384 | 5% |
+| `service_client_slots[4]` @ 1,040 | 4,160 | 1% |
+| rest | 5,248 | 2% |
+| **total** | **309,696** | |
+
+Against a `CONFIG_NROS_ZEPHYR_HEAP_SIZE` of 65,536. The image is a LISTENER: it
+has **one** subscriber, no service server and no service client.
+
+A slot is `XRCE_SUBSCRIBER_RING_DEPTH` (32) x `XRCE_BUFFER_SIZE` (1024) plus 528
+bytes of bookkeeping. So the image reserves 32 buffered samples for each of
+eight subscriptions, having declared one.
+
+## This is issue 0827's class, one backend over
+
+0827 is "unused RMW pools dominate static RAM" for zenoh — `SERVICE_BUFFERS` and
+`LARGE_PAYLOADS` sized for entities a talker does not have. This is the same
+shape on XRCE, and it is worse in one respect: zenoh's pools are `.bss` that
+`just mem-report` can see, while this is a single heap allocation that only
+shows up as a boot-time failure.
+
+## The knobs exist and are honoured — nothing sets them
+
+`NROS_XRCE_MAX_SUBSCRIBERS`, `NROS_XRCE_MAX_SERVICE_SERVERS`,
+`NROS_XRCE_MAX_SERVICE_CLIENTS` and `NROS_XRCE_SUBSCRIBER_RING_DEPTH` all reach
+`build.rs` and all have a minimum of 1. `internal.h`'s own header comment says
+what they buy:
+
+> The default `xrce_session_state_t` is ~390 KB; a pub-only bare-metal node can
+> drop it well below 32 KB by setting subscribers/services to 0 and smaller
+> per-entity buffers.
+
+So this is not a defect in the mechanism. It is that every Zephyr XRCE example
+ships the 8/4/4 defaults, and those defaults are sized for a workload none of
+them run.
+
+`CONFIG_NROS_XRCE_SUBSCRIBER_RING_DEPTH` is the exception worth checking: the
+other three have Kconfig entries and this one appears not to, so on a Zephyr
+image the ring depth may not be settable at all.
+
+## Two ways to fix it, and the choice is the campaign's
+
+1. **State the caps per example.** Correct immediately, and it is the twenty
+   hand-picked numbers issue 0827 declined — planted in the demos people copy.
+2. **Derive them**, from the entity inventory issue 0965 built. A C++ component
+   image CAN declare `ENTITIES`, and `examples/workspaces/cpp` now does; these
+   zephyr example leaves do not. The count of `sub:` entries IS
+   `XRCE_MAX_SUBSCRIBERS`, exactly as `NROS_DERIVED_MAX_SUBSCRIBERS` already
+   works for the zenoh pools (phase-412 W1).
+
+(2) is the campaign's answer and reuses machinery that exists. What it needs is
+the zephyr example leaves to declare, plus the XRCE caps joining the derivable
+ladder beside the zenoh ones.
+
+## Do not just raise the heap
+
+Raising `NROS_ZEPHYR_HEAP_SIZE` past 310 KB would make the three cells in
+[issue 0968](0968-tier2-runtime-failures-unreproduced.md) pass while leaving an
+image that reserves 86% of its session struct for entities it does not create.
+That is the shape this campaign exists to remove, and the boot failure is
+currently the only thing making it visible.

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -195,9 +195,27 @@ void *nros_platform_alloc(size_t size) {
          * spinlock is released for the same reason -- never call into
          * anything reentrant while holding the funnel's lock. */
         extern size_t nros_zephyr_heap_capacity(void);
-        printk("nros: HEAP EXHAUSTED: request %zu bytes, arena %zu bytes "
-               "(raise CONFIG_NROS_ZEPHYR_HEAP_SIZE / NROS_ZEPHYR_HEAP_SIZE)\n",
-               size, nros_zephyr_heap_capacity());
+        /* issue 0968 — and WHO asked. The size alone is not actionable: three
+         * zephyr xrce-cpp cells died on a byte-identical 427968-byte request
+         * and nothing in the image, the Kconfig or the generated sizes header
+         * accounted for it, so the only move left was to raise the knob until
+         * it booted -- which buries the question instead of answering it.
+         *
+         * The return address costs nothing at runtime and turns the message
+         * into a lead:
+         *     arm-none-eabi-addr2line -f -e build/zephyr/zephyr.elf <caller>
+         *
+         * `__builtin_return_address(0)` is the immediate caller, which on this
+         * path is the allocator shim rather than the code that wanted the
+         * memory. That is still one frame closer than nothing, and it names
+         * the SHIM so the reader knows which allocator to look behind. */
+        printk("nros: HEAP EXHAUSTED: request %zu bytes, arena %zu bytes, "
+               "caller %p\n"
+               "      (addr2line -f -e zephyr.elf %p to name it; raise "
+               "CONFIG_NROS_ZEPHYR_HEAP_SIZE / NROS_ZEPHYR_HEAP_SIZE only once "
+               "you know what asked)\n",
+               size, nros_zephyr_heap_capacity(),
+               __builtin_return_address(0), __builtin_return_address(0));
     }
     return out;
 }

--- a/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
+++ b/packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
@@ -274,6 +274,7 @@ fn main() {
     }
     println!("cargo:rerun-if-env-changed=NROS_XRCE_STREAM_HISTORY");
     println!("cargo:rerun-if-env-changed=NROS_XRCE_CUSTOM_TRANSPORT_MTU");
+    println!("cargo:rerun-if-env-changed=NROS_XRCE_TRANSPORT_MTU");
 
     // Phase 207.6 — per-session pool sizes. A pub-only bare-metal node
     // can drop `MAX_SUBSCRIBERS` to 1 (zero-length arrays aren't
@@ -375,6 +376,26 @@ fn generate_uxr_config(
 ) {
     let template = fs::read_to_string(microxrce.join("include/uxr/client/config.h.in"))
         .expect("read uxr config.h.in");
+    // issue 0968 — the general transport MTU, min-guarded like CUSTOM's.
+    //
+    // `knob_usize`, NOT `env::var`: a Zephyr RUST image inherits none of cmake's
+    // `set(ENV{...})` exports, so a bare read yields the crate default whatever
+    // Kconfig says (issue 0460). `check-kconfig-knob-forwarding` caught exactly
+    // that in the first version of this fix, which would have repaired the C
+    // lane and left the Rust one on 4096 — half-fixing the thing this change is
+    // about.
+    let xrce_transport_mtu = nros_zephyr_build::knob_usize(
+        "NROS_XRCE_TRANSPORT_MTU",
+        "CONFIG_NROS_XRCE_TRANSPORT_MTU",
+        XRCE_TRANSPORT_MTU_DEFAULT
+            .parse()
+            .expect("XRCE_TRANSPORT_MTU_DEFAULT is a number"),
+    );
+    if xrce_transport_mtu < 128 {
+        panic!("NROS_XRCE_TRANSPORT_MTU={xrce_transport_mtu} too small (minimum 128)");
+    }
+    let xrce_transport_mtu = xrce_transport_mtu.to_string();
+
     // Substitute @TOKEN@ placeholders.
     let mut h = template
         .replace("@PROJECT_VERSION_MAJOR@", "2")
@@ -389,8 +410,14 @@ fn generate_uxr_config(
         .replace("@UCLIENT_MIN_SESSION_CONNECTION_INTERVAL@", "1000")
         .replace("@UCLIENT_MIN_HEARTBEAT_TIME_INTERVAL@", "100")
         // Phase 214.C.2 — MTU defaults from named consts at file top.
-        .replace("@UCLIENT_UDP_TRANSPORT_MTU@", XRCE_TRANSPORT_MTU_DEFAULT)
-        .replace("@UCLIENT_TCP_TRANSPORT_MTU@", XRCE_TRANSPORT_MTU_DEFAULT)
+        // issue 0968 — UDP and TCP honour `NROS_XRCE_TRANSPORT_MTU` too. Only
+        // CUSTOM was tunable, so a UDP image (which every Zephyr XRCE example
+        // is — it dials an agent at `CONFIG_NROS_XRCE_AGENT_ADDR:PORT`) was
+        // pinned to 4096 whatever Kconfig said. `STREAM_BUFFER_SIZE = MTU x
+        // STREAM_HISTORY` twice per session, so the default cost 131072 bytes
+        // where the configured 512 costs 16384.
+        .replace("@UCLIENT_UDP_TRANSPORT_MTU@", &xrce_transport_mtu)
+        .replace("@UCLIENT_TCP_TRANSPORT_MTU@", &xrce_transport_mtu)
         .replace("@UCLIENT_SERIAL_TRANSPORT_MTU@", XRCE_SERIAL_MTU_DEFAULT)
         .replace(
             "@UCLIENT_CUSTOM_TRANSPORT_MTU@",

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -77,6 +77,11 @@ KNOB_CLASS = {
     "ZPICO_PUBLISHER_TX_BUFFER_SIZE": ("derived", "TX half of the same split"),
     # --- sizing: the backlog ---
     "NROS_SERVICE_TIMEOUT_MS": ("sizing", "a timeout, not a size, but the same ladder shape. TWO readers (zenoh build + the C emitter), so it needs one emission point before a rung"),
+    # issue 0968 — the UDP/TCP twin of the line above. Documented in the book and
+    # in Kconfig with a 512 default, resolved by cmake under the UNPREFIXED name
+    # that no build script reads, and hardcoded to 4096 on the UDP path anyway —
+    # so every Zephyr XRCE image paid 2 x 4096 x 16 for its stream buffers.
+    "NROS_XRCE_TRANSPORT_MTU": ("sizing", "transport MTU (UDP/TCP); numeric"),
     "ZPICO_MAX_LARGE_SUBSCRIBERS": ("derived", "pool cardinality; multiplies LARGE_PAYLOADS, phase-392"),
     "ZPICO_SERVICE_BUFFER_SIZE": ("derived", "SERVICE_BUFFERS is MAX_SESSIONS x MAX_QUERYABLES; phase-392"),
     # --- infra: not knobs ---

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -612,7 +612,14 @@ function(nros_resolve_knobs)
     # nothing read them and five menuconfig options were inert (issue 0316
     # defect 2). The C defaults in nros-rmw-xrce/src/internal.h always won.
     if(CONFIG_NROS_RMW_XRCE)
-        _nros_resolve_knob(XRCE_TRANSPORT_MTU "${CONFIG_NROS_XRCE_TRANSPORT_MTU}")
+        # issue 0968 — PREFIXED, like every sibling below it. Issue 0316 defect 2
+        # is the comment directly above, and this line was the one site its sweep
+        # missed: it kept exporting the unprefixed `XRCE_TRANSPORT_MTU`, which no
+        # build script reads, so `CONFIG_NROS_XRCE_TRANSPORT_MTU` was documented
+        # in the book, defined in Kconfig, resolved here, and consumed by nobody.
+        # The UDP MTU stayed at its 4096 default and the two per-session stream
+        # buffers cost 2 x 4096 x 16 = 131072 bytes against a 65536-byte heap.
+        _nros_resolve_knob(NROS_XRCE_TRANSPORT_MTU "${CONFIG_NROS_XRCE_TRANSPORT_MTU}")
         _nros_resolve_knob(NROS_XRCE_MAX_SUBSCRIBERS
             "${CONFIG_NROS_XRCE_MAX_SUBSCRIBERS}")
         _nros_resolve_knob(NROS_XRCE_MAX_SERVICE_SERVERS


### PR DESCRIPTION
Three zephyr xrce-cpp cells die at boot on a byte-identical `HEAP EXHAUSTED: request 427968 bytes, arena 66048 bytes`. This attributes that request and fixes the largest thing in it.

## First, the diagnostic couldn't be acted on

It named a size and no caller — so the only move left was raising the knob until it booted, which buries the question. `nros_platform_alloc` now prints `__builtin_return_address(0)` plus the addr2line command. That's how the rest was found:

```
caller 0x42b99c → nros_xrce_calloc (internal.h:62), from xrce_session_create
```

So the whole request is one `sizeof(xrce_session_state_t)`. Composition, from the image's own DWARF:

| member | bytes |
| --- | ---: |
| `subscriber_slots[8]` @ 33,296 | 266,368 |
| `output` + `input_reliable_buf` @ 65,536 | 131,072 |
| service server/client slots | 21,696 |
| rest | 8,832 |
| **total** | **427,968** ✓ exact |

## The dead knob

`65536 = 16 × 4096`, but the image sets `CONFIG_NROS_XRCE_TRANSPORT_MTU=512`, which would give 8,192. It's dead twice over:

1. **`nros_cargo_build.cmake` exported it unprefixed.** The comment three lines above that call describes issue 0316 defect 2 — *"this bridge previously exported the UNPREFIXED names, so nothing read them and five menuconfig options were inert"* — and this was the one site that sweep missed, while every sibling beneath it is prefixed.
2. **`build.rs` made only CUSTOM tunable** and hardcoded UDP/TCP to 4096. Every Zephyr XRCE example dials its agent over UDP, so the configurable path was the one nothing used.

Both fixed. Measured on the rebuilt image: **427,968 → 309,696**, and the generated `uxr/client/config.h` now carries `UDP_TRANSPORT_MTU 512`.

## A gate caught my first attempt

`check-kconfig-knob-forwarding` rejected the bare `env::var` version: a Zephyr **Rust** image inherits none of cmake's `set(ENV{...})` exports (issue 0460), so it would have repaired the C lane and left the Rust one on 4096 — half-fixing the exact thing this change is about. It resolves through `nros_zephyr_build::knob_usize` now.

## Not sufficient — said plainly

309,696 still exceeds the 66,048 heap, so the three cells still fail. What remains is `subscriber_slots[8]` = 266,368 on an image with **one** subscriber. That's issue 0827's class on the XRCE backend, and it's configuration-or-derivation rather than a defect — filed as **#1033** rather than hand-set here.

Gates: `check fast` (190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)