### PR TITLE
docs: three more old phase headers, and one that was right

### DIFF
--- a/docs/roadmap/phase-211-proof-carrying-code.md
+++ b/docs/roadmap/phase-211-proof-carrying-code.md
@@ -8,7 +8,27 @@ Rust verifier (Frama-C/WP for C). Extract the registry tooling into a
 standalone Why3 Component Registry (`wcr`) and deliver a Sentinel-style
 safety-island demonstrator with an end-to-end GSN safety case.
 
-**Status:** Proposed (2026-05-31).
+**Status (2026-09-04). Still a PROPOSAL, nothing started — and the tree has
+since committed the other way, so this needs RE-DECIDING rather than picking
+up.** Zero checkboxes and zero DONE markers in 478 lines, which is honest; what
+is stale is the premise.
+
+This phase says "Retire Verus in favour of Creusot as the single Rust verifier".
+Measured 2026-09-04:
+
+* **Verus was not retired.** `just verify-verus` exists (`justfile:3125`) and
+  `just verify` DEPENDS on it (`verify: verify-kani verify-verus`,
+  `justfile:3171`). CLAUDE.md documents Kani + Verus as the verification stack.
+* **Creusot is not in the tree at all** — `git ls-files '*creusot*'` returns
+  zero files.
+
+So the retirement half is not merely unstarted, it is contradicted by fifteen
+months of practice. Anyone picking this up should first re-argue the Verus →
+Creusot swap against a stack that now has Verus proofs in it, rather than treat
+it as agreed and outstanding. Kept OPEN because the Frama-C / C half is
+untouched by that, and no decision has been recorded either way.
+
+**Previously:** Proposed (2026-05-31).
 
 > **Post-Phase-218**: References to `scripts/install-nros.sh` + the
 > external `github.com/NEWSLabNTU/nros-cli` repo below predate the

--- a/docs/roadmap/phase-236-cpp-entry-embedded-runtime.md
+++ b/docs/roadmap/phase-236-cpp-entry-embedded-runtime.md
@@ -18,7 +18,16 @@ record-only:
   follow-up"). The register sequence is dispatched but instantiates
   nothing.
 
-**Status.** Proposed (2026-06-11). Driven by Autoware Safety Island
+**Status (2026-09-04). NOT "Proposed" — 7 of its 12 checkboxes are ticked and
+13 items carry a DONE/LANDED marker; 5 boxes remain.** The C++ entry surface
+this phase describes as a gap now exists in the tree: `NROS_MAIN` is documented
+and implemented in `packages/api/nros-cpp/include/nros/main.hpp`, and
+`nano_ros_entry(...)` appears in 9 example `CMakeLists.txt`.
+
+Not re-verified item by item, so the 5 open boxes stand as written — this
+corrects the HEADER, which said the whole phase was unstarted.
+
+**Previously.** Proposed (2026-06-11). Driven by Autoware Safety Island
 (ASI) as the reference embedded consumer — ASI already has a *working*
 imperative Zephyr + Cyclone runtime (`actuation_module`'s
 `common/node` shim over `nros::Node` + direct `create_publisher` /

--- a/docs/roadmap/phase-41-iron-type-hash-support.md
+++ b/docs/roadmap/phase-41-iron-type-hash-support.md
@@ -2,9 +2,11 @@
 
 **Status: Substantially complete (2026-07-26).** The RIHS01 machinery is built,
 wired, and verified end to end for iron + jazzy:
-- **Computation** — `rosidl-codegen/src/rihs.rs` (`build_type_description` +
+- **Computation** — `packages/cli/rosidl-resolve/src/rihs.rs` (the path below
+  read `rosidl-codegen/src/rihs.rs`, which predates the codegen move into
+  `packages/cli/`; the file is there, under a crate that was renamed) (`build_type_description` +
   `rihs01`, message/service/action) computes REP-2011 hashes; proven
-  `engine == fixture == live Jazzy` by `rosidl-bindgen/tests/edition_hash_oracle.rs`.
+  `engine == fixture == live Jazzy` by `packages/cli/rosidl-bindgen/tests/edition_hash_oracle.rs`.
 - **Codegen** — `nros generate-rust --ros-edition {iron,jazzy}` emits the real
   per-message `const TYPE_HASH` (verified: `std_msgs/Int32` →
   `RIHS01_b6578ded3c58c626cfe8d1a6fb6e04f706f97e9f03d2727c9ff4e74b1cef0deb`,


### PR DESCRIPTION
Finished the sweep of the oldest open phases. Three corrected — and one worth naming because it was **accurate**.

## phase-211 (proof-carrying code) — the premise, not the progress

Still a proposal with zero checkboxes in 478 lines, which is honest. What is stale is what it proposes: *"Retire Verus in favour of Creusot as the single Rust verifier."* The tree committed the other way.

```
just verify-verus                      exists (justfile:3125)
just verify: verify-kani verify-verus  (justfile:3171)
git ls-files "*creusot*"            -> 0 files
```

So the retirement is not merely unstarted — it is contradicted by fifteen months of practice, and CLAUDE.md documents Kani + Verus as the stack. Anyone picking this up must **re-argue** the swap against a stack that now has Verus proofs in it, rather than treat it as agreed-and-outstanding.

Left **open**: the Frama-C / C half is untouched by that, and no decision is recorded either way.

## phase-236 (C++ entry embedded runtime) — "Proposed" understated it

7 of 12 boxes ticked, 13 DONE/LANDED markers. The surface it describes as a gap exists: `NROS_MAIN` is implemented and documented in `packages/api/nros-cpp/include/nros/main.hpp`, and `nano_ros_entry(...)` appears in 9 example `CMakeLists.txt`.

Header corrected only — the 5 open boxes stand as written, since I did not re-verify item by item.

## phase-41 (Iron type hash) — stale paths, sound substance

Two cited paths predate the codegen move into `packages/cli/`: `rosidl-codegen/src/rihs.rs` is now `packages/cli/rosidl-resolve/src/rihs.rs`, and the oracle test lives under `packages/cli/`. Paths fixed; status untouched.

## phase-162 is CORRECT and left alone

"Not Started" — 0 checked, 25 unchecked, no DONE markers anywhere.

I am recording this deliberately. **Eight consecutive phases in this sweep had headers that outlived their content**, and the easy next mistake is to assume every old status line is wrong. This one is not, and treating it as suspect would waste the next reader's time in the opposite direction.

## Not verified, deliberately

188, 201, 206, 216, 292 — untouched. 215 and 217 are FVP-gated and unverifiable on this host (`FVP_BaseR_AEMv8R` absent). 216 reads partial and *is* partial (14 of 33 boxes), so its header is not misleading even if the work has moved.

`just check fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)