### PR TITLE
feat(#1033): the XRCE subscriber cap joins the derivable ladder, and six leaves declare

### DIFF
--- a/book/src/reference/configuration-surface.md
+++ b/book/src/reference/configuration-surface.md
@@ -120,7 +120,7 @@ Read by compiled code or forwarded to a build script. On Zephyr the
 | `CONFIG_NROS_XRCE_BUFFER_SIZE` | `1024` | forwarded-to-cargo, cmake |
 | `CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS` | `4` | forwarded-to-cargo, cmake |
 | `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS` | `4` | forwarded-to-cargo, cmake |
-| `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | `8` | forwarded-to-cargo, cmake |
+| `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | `-1` | forwarded-to-cargo, cmake |
 | `CONFIG_NROS_XRCE_STREAM_HISTORY` | `16` | forwarded-to-cargo, cmake |
 | `CONFIG_NROS_XRCE_TRANSPORT_MTU` | `512` | forwarded-to-cargo, cmake, rust-source |
 | `CONFIG_NROS_ZENOH_AUTO_RECONNECT` | `y` | cmake |

--- a/docs/issues/1033-xrce-subscriber-slots-budget-eight-for-one.md
+++ b/docs/issues/1033-xrce-subscriber-slots-budget-eight-for-one.md
@@ -79,3 +79,58 @@ Raising `NROS_ZEPHYR_HEAP_SIZE` past 310 KB would make the three cells in
 image that reserves 86% of its session struct for entities it does not create.
 That is the shape this campaign exists to remove, and the boot failure is
 currently the only thing making it visible.
+
+
+## Option 2 taken, and it stops one step short (2026-09-04)
+
+The derivation is wired and the declarations are written; the composition step
+that joins them does not run for these leaves. All three facts are measured.
+
+**Wired.** `NROS_XRCE_MAX_SUBSCRIBERS` is on the derivable ladder
+(`_nros_resolve_derivable_knob`), reading the SAME
+`NROS_DERIVED_MAX_SUBSCRIBERS` the zenoh pools use. Reusing that value is the
+point rather than counting `sub:` entries again here: it already carries
+`ACTION_CLIENT_SUBSCRIPTIONS`, the multiplier `check-infra-queryable-counts`
+holds, so an action-carrying image is sized right. A second count would be a
+second derivation of one fact, and the copy that forgot the multiplier would
+under-size the image and fail at registration.
+
+Its Kconfig default becomes the `-1` DERIVE sentinel. Verified inert where
+nothing derives: the image still requests 309,696 bytes, because rung 4 leaves
+the knob unresolved and `build.rs` falls to the crate default of 8 — exactly
+what every image did before.
+
+**Declared.** All six `examples/zephyr/cpp/*` leaves now state `ENTITIES`, read
+off their own sources. The declaration reaches the metadata:
+
+```
+$ jq .components[].entities build-cpp-listener-xrce/nros-metadata.json
+["sub:std_msgs/msg/String:/chatter"]
+```
+
+**And the join does not happen.** The inventory reads:
+
+```
+set(NROS_ENTITY_INVENTORY_STATUS "refused")
+set(NROS_ENTITY_INVENTORY_REASON "no entity inventory composed yet")
+```
+
+`nros_derive_entity_inventory_knobs` has exactly ONE caller —
+`NanoRosEntry.cmake:890`, inside `nano_ros_entry()`. These zephyr examples are
+standalone Zephyr applications that register a node and never call it, so their
+declaration is captured and never composed. A second configure does not help;
+this is not issue 0991's one-configure lag, it is a step that never runs.
+
+### What that leaves
+
+The remaining work is to compose the inventory on the non-entry path, so a
+standalone leaf that declares can derive. That is a change to configure
+ORDERING — the composer must run after every registration, which is precisely
+why it lives in `nano_ros_entry()` today — and it belongs with whoever owns
+that seam rather than bolted on at the call site.
+
+Until then the two changes here are correct and dormant: the ladder is right,
+the declarations are right, and the image keeps the default it always had.
+Nothing regressed and nothing is yet saved.
+
+**Still do not raise the heap.** The reasoning above is unchanged.

--- a/examples/zephyr/cpp/action-client/CMakeLists.txt
+++ b/examples/zephyr/cpp/action-client/CMakeLists.txt
@@ -34,4 +34,9 @@ nros_components_register_node(fibonacci_action_client_lib
     PLUGIN zephyr_cpp_action_client::FibonacciClient
     EXECUTABLE fibonacci_action_client
     SHAPE configure
-    TYPED)
+    TYPED
+    # issue 1033 — what this image CREATES, read off its own source.
+    # The XRCE subscriber cap derives from this; absence means "nobody
+    # said" and the image keeps the 8-slot default.
+    ENTITIES
+             action_client:example_interfaces/action/Fibonacci:/fibonacci)

--- a/examples/zephyr/cpp/action-server/CMakeLists.txt
+++ b/examples/zephyr/cpp/action-server/CMakeLists.txt
@@ -34,4 +34,10 @@ nros_components_register_node(fibonacci_action_server_lib
     PLUGIN zephyr_cpp_action_server::FibonacciServer
     EXECUTABLE fibonacci_action_server
     SHAPE configure
-    TYPED)
+    TYPED
+    # issue 1033 — what this image CREATES, read off its own source.
+    # The XRCE subscriber cap derives from this; absence means "nobody
+    # said" and the image keeps the 8-slot default.
+    ENTITIES
+             action_server:example_interfaces/action/Fibonacci:/fibonacci
+             timer)

--- a/examples/zephyr/cpp/listener/CMakeLists.txt
+++ b/examples/zephyr/cpp/listener/CMakeLists.txt
@@ -47,4 +47,9 @@ nros_components_register_node(listener_lib
     PLUGIN zephyr_cpp_listener::Listener
     EXECUTABLE listener
     SHAPE configure
-    TYPED)
+    TYPED
+    # issue 1033 — what this image CREATES, read off its own source.
+    # The XRCE subscriber cap derives from this; absence means "nobody
+    # said" and the image keeps the 8-slot default.
+    ENTITIES
+             sub:std_msgs/msg/String:/chatter)

--- a/examples/zephyr/cpp/service-client/CMakeLists.txt
+++ b/examples/zephyr/cpp/service-client/CMakeLists.txt
@@ -46,4 +46,10 @@ nros_components_register_node(add_two_ints_client_lib
     PLUGIN zephyr_cpp_service_client::AddTwoIntsClient
     EXECUTABLE add_two_ints_client
     SHAPE configure
-    TYPED)
+    TYPED
+    # issue 1033 — what this image CREATES, read off its own source.
+    # The XRCE subscriber cap derives from this; absence means "nobody
+    # said" and the image keeps the 8-slot default.
+    ENTITIES
+             service_client:example_interfaces/srv/AddTwoInts:/add_two_ints
+             timer)

--- a/examples/zephyr/cpp/service-server/CMakeLists.txt
+++ b/examples/zephyr/cpp/service-server/CMakeLists.txt
@@ -46,4 +46,9 @@ nros_components_register_node(add_two_ints_server_lib
     PLUGIN zephyr_cpp_service_server::AddTwoIntsServer
     EXECUTABLE add_two_ints_server
     SHAPE configure
-    TYPED)
+    TYPED
+    # issue 1033 — what this image CREATES, read off its own source.
+    # The XRCE subscriber cap derives from this; absence means "nobody
+    # said" and the image keeps the 8-slot default.
+    ENTITIES
+             service_server:example_interfaces/srv/AddTwoInts:/add_two_ints)

--- a/examples/zephyr/cpp/talker/CMakeLists.txt
+++ b/examples/zephyr/cpp/talker/CMakeLists.txt
@@ -49,4 +49,10 @@ nros_components_register_node(talker_lib
     PLUGIN zephyr_cpp_talker::Talker
     EXECUTABLE talker
     SHAPE configure
-    TYPED)
+    TYPED
+    # issue 1033 — what this image CREATES, read off its own source.
+    # The XRCE subscriber cap derives from this; absence means "nobody
+    # said" and the image keeps the 8-slot default.
+    ENTITIES
+             pub:std_msgs/msg/String:/chatter
+             timer)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -943,10 +943,24 @@ config NROS_XRCE_TRANSPORT_MTU
 
 config NROS_XRCE_MAX_SUBSCRIBERS
     int "Maximum concurrent subscribers"
-    default 8
+    default -1
     help
       Maximum number of concurrent XRCE subscribers.
       Maps to XRCE_MAX_SUBSCRIBERS.
+
+      -1 means DERIVE: take the count from the image's entity inventory
+      (`nano_ros_node_register(... ENTITIES ...)`), the same
+      NROS_DERIVED_MAX_SUBSCRIBERS the zenoh pools use, so an action-carrying
+      image gets its action-client subscriptions counted too.
+
+      An image whose inventory refuses -- any component that declared no
+      ENTITIES -- falls through to the crate default of 8, which is what every
+      image did before issue 1033. Stating a number here still wins over both.
+
+      This is worth deriving: a slot is XRCE_SUBSCRIBER_RING_DEPTH x
+      XRCE_BUFFER_SIZE (32 x 1024) plus bookkeeping, so eight of them are
+      266,368 bytes of the session struct -- 86% of it on a one-subscriber
+      image, allocated from the Zephyr heap in a single request.
 
 config NROS_XRCE_MAX_SERVICE_SERVERS
     int "Maximum concurrent service servers"

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -635,8 +635,20 @@ function(nros_resolve_knobs)
         # The UDP MTU stayed at its 4096 default and the two per-session stream
         # buffers cost 2 x 4096 x 16 = 131072 bytes against a 65536-byte heap.
         _nros_resolve_knob(NROS_XRCE_TRANSPORT_MTU "${CONFIG_NROS_XRCE_TRANSPORT_MTU}")
-        _nros_resolve_knob(NROS_XRCE_MAX_SUBSCRIBERS
-            "${CONFIG_NROS_XRCE_MAX_SUBSCRIBERS}")
+        # issue 1033 — the subscriber cap joins the DERIVABLE ladder, on the
+        # SAME `NROS_DERIVED_MAX_SUBSCRIBERS` the zenoh pools use. Reusing that
+        # value rather than counting `sub:` entries here is the point: it
+        # already carries `ACTION_CLIENT_SUBSCRIPTIONS`, the multiplier held by
+        # `check-infra-queryable-counts`, so an action-carrying image is sized
+        # right. A second count here would be a second derivation of one fact,
+        # and the one that forgot the multiplier would under-size the image and
+        # fail at registration.
+        #
+        # This is 86% of `xrce_session_state_t`: 8 slots x 32-deep rings of
+        # 1024-byte buffers = 266,368 bytes on an image with one subscriber.
+        _nros_resolve_derivable_knob(NROS_XRCE_MAX_SUBSCRIBERS
+            "${CONFIG_NROS_XRCE_MAX_SUBSCRIBERS}" NROS_DERIVED_MAX_SUBSCRIBERS
+            "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
         _nros_resolve_knob(NROS_XRCE_MAX_SERVICE_SERVERS
             "${CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS}")
         _nros_resolve_knob(NROS_XRCE_MAX_SERVICE_CLIENTS


### PR DESCRIPTION
**Stacked on #324** (the MTU fix), so the diff shows both.

1033 offered two ways out and called the choice the campaign's. This takes **option 2 — derive** — because it reuses machinery that exists rather than planting twenty hand-picked numbers in the demos people copy (0827's objection). It gets two of the three steps; the third is measured, not assumed.

## Wired

`NROS_XRCE_MAX_SUBSCRIBERS` moves to `_nros_resolve_derivable_knob`, reading the **same** `NROS_DERIVED_MAX_SUBSCRIBERS` the zenoh pools use.

Reusing that value rather than counting `sub:` entries again is the point: it already carries `ACTION_CLIENT_SUBSCRIPTIONS`, the multiplier `check-infra-queryable-counts` holds. A second count here would be a second derivation of one fact, and the copy that forgot the multiplier would under-size the image and fail at registration.

Kconfig default becomes the `-1` DERIVE sentinel — **verified inert** where nothing derives: the image still requests 309,696 bytes, because rung 4 leaves it unresolved and `build.rs` falls to the crate default of 8. Safe here because the consumer supplies its own default, which is the rule phase-412 W1 cost.

## Declared

All six `examples/zephyr/cpp/*` leaves state `ENTITIES`, read off their own sources, and it reaches the metadata:

```
$ jq .components[].entities build-cpp-listener-xrce/nros-metadata.json
["sub:std_msgs/msg/String:/chatter"]
```

## And the join does not happen — the honest result

```
NROS_ENTITY_INVENTORY_STATUS  "refused"
NROS_ENTITY_INVENTORY_REASON  "no entity inventory composed yet"
```

`nros_derive_entity_inventory_knobs` has exactly **one** caller — `NanoRosEntry.cmake:890`, inside `nano_ros_entry()`. These zephyr examples are standalone applications that register a node and never call it, so the declaration is captured and never composed.

A second configure doesn't fix it: this is **not** issue 0991's one-configure lag, it's a step that never runs on this path. Composing on the non-entry path is a change to configure *ordering* — the composer must run after every registration, which is exactly why it lives in `nano_ros_entry()` — so it's recorded for whoever owns that seam rather than bolted on here.

## Net

**Nothing regressed and nothing is yet saved.** Both halves are correct and dormant, and the issue now names the missing step instead of implying the mechanism works.

Gates: `check fast` (190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)