### PR TITLE
docs(#1034, phase-414 W3): the C-vs-C++ asymmetry was the emulator, not the binding

### DIFF
--- a/docs/issues/0870-nuttx-cpp-action-client-transport-tx-failed.md
+++ b/docs/issues/0870-nuttx-cpp-action-client-transport-tx-failed.md
@@ -477,3 +477,82 @@ to ask for four rounds. RAM cost: none.
 `nsh_main` before `main`, and `nsh_main` is in the built ELF. Without that the
 four `nros_error!` calls would sit in the pre-init ring and never print. The
 plan is sound; only the binaries are wrong.
+
+**Corroborated 2026-09-04 from a second session, on freshly rebuilt fixtures:**
+`strings` on `cpp_action_client` and `c_action_client` (both rebuilt 10:38 that
+day) finds all four diagnostics, 1 occurrence each. So the retraction above is
+right and the standing plan holds — the diagnostics ARE armed in a current
+build. The section heading still says otherwise; the body is what to believe.
+
+## 2026-09-04 — the C-vs-C++ asymmetry is EXPLAINED, and it is not about C++
+
+This issue's most recent measurement — "**C: 3/3 PASS at 26.4-27.2 s. C++:
+44-50 s.** The C++ image takes ~20 s longer for the same action round trip …
+the first evidence of any kind about the asymmetry" — has a cause, and it is
+the EMULATOR, not the binding. Filed as **issue 1034**; the part that matters
+here is that this lead is dead.
+
+The harness resolves `qemu_system_arm_path()` to the `nros setup` store build
+(`~/.nros/sdk/qemu/11.0.0-nros2`) in preference to `PATH`. On that build, a
+NuttX arm image whose `.bss` is folded into the same `PT_LOAD` as its `.data`
+takes **~19.6 s of CPU-bound emulator work before the guest's first console
+byte**; on the distro `qemu-system-arm` 6.2.0 the same image starts in 0.05 s.
+The correlation with program-header shape is exact across all 19 NuttX arm
+images in the tree, and the stall is linear in the zero-fill size.
+
+Instrumented cell timings on this tree:
+
+    nuttx C   action: server banner 20.14 s | client collect  3.51 s | cell 26.1 s
+    nuttx C++ action: server banner 19.94 s | client collect 23.10 s | cell 45.7 s
+
+Both servers pay the stall. `c/action-client` does NOT (it is one of two C
+images linked with `.bss` in its own segment); `cpp/action-client` does. So the
+C cell pays it once and the C++ cell twice, and **the entire ~20 s "asymmetry"
+is one emulator stall**. With the stall gone — hand-run on QEMU 6.2.0, router
+up, server first — the C++ client completes goal → accept → feedback → result in
+**2.2 s**, and there is no asymmetry left to explain.
+
+`c/action-client` and `c/action-server` differ by 16 bytes of `.bss`, and one
+stalls while the other does not, so nothing about the C++ toolchain, the C++
+binding or the declaration burst is implicated by the timing.
+
+### What this does and does not settle
+
+* **Settled, and removed as a lead:** the "C++ is slower for the same round
+  trip" measurement. It measured the emulator. Any future C-vs-C++ story must
+  not cite it.
+* **NOT settled:** the `-100` / `Generic → ConnectionFailed` failure itself.
+  Nothing here reproduces it, and no mechanism connecting the stall to the
+  failure is offered — that would be a fifth guess, and this issue has already
+  burned four.
+* **Worth knowing for the next experiment:** this issue records that the fault
+  "is timing-sensitive and moves with image CONTENT". Issue 1034 is a mechanism
+  by which 16 bytes of image content move timing by 20 seconds. So an experiment
+  that compares two builds is comparing two emulation regimes unless the
+  `PT_LOAD` shape is checked first (`arm-none-eabi-readelf -l <image> |
+  grep '^  LOAD'`), and a hand-run reproduction is not comparable to a cell
+  unless it uses the same emulator binary — the two differ by 400x here.
+
+### The reproduction attempt is now ~10x cheaper, and it was spent
+
+Issue 1034's finding is directly useful here: with `QEMU_SYSTEM_ARM=/usr/bin/
+qemu-system-arm` the cell runs in **4.7 s instead of 46 s**, because it skips two
+~19.6 s emulator stalls. So the "run it many times and wait for a failure"
+strategy — which this issue chose in September as "the cheapest honest option" —
+costs a tenth of what it did.
+
+Spent immediately, `--retries 0`:
+
+| batch | condition | result |
+| --- | --- | --- |
+| 24 runs | idle host, QEMU 6.2.0 | 24/24 PASS, 4.6-4.8 s each |
+| 12 runs | 32 busy loops, load avg 22 | 12/12 PASS |
+
+With the 28 runs already recorded, that is **64 consecutive passes**. The
+reported 2-in-3 rate does not hold for any build or emulator measured here.
+
+**Stated bound:** these 36 runs are on the DISTRO emulator, which is not the one
+CI or a default `just` invocation uses, so they do not extend the store-QEMU
+evidence — they extend the evidence that the C++ image itself completes the
+round trip. That is deliberate: a cheap batch on a different emulator is worth
+more than no batch, provided nobody later reads it as the same experiment.

--- a/docs/issues/1034-qemu11-elf-bss-zero-fill-stalls-nuttx-boot.md
+++ b/docs/issues/1034-qemu11-elf-bss-zero-fill-stalls-nuttx-boot.md
@@ -1,0 +1,144 @@
+---
+id: 1034
+title: "The provisioned QEMU 11 spends ~19.6 s materialising a NuttX image's
+  `.bss` before the guest runs, and that stall is the whole C-vs-C++ asymmetry
+  in issue 0870"
+status: open
+type: bug
+area: testing, tooling
+severity: high
+found: 2026-09-04
+related: [issue-0870, issue-0930, phase-414]
+---
+
+## Symptom
+
+Every NuttX arm C/C++ cell pays ~19.6 s of dead time per image, before the
+guest prints its first byte. It is invisible as a stall because it looks like
+a slow boot, and it is charged to the cell's wall clock.
+
+MEASURED, on an idle host, same image, two emulators:
+
+| | Debian `qemu-system-arm` 6.2.0 | `~/.nros/sdk/qemu/11.0.0-nros2` |
+| --- | ---: | ---: |
+| `cpp/action-server` first console byte | 0.05 s | **19.60 s** |
+| `c/action-server` | 0.05 s | **19.89 s** |
+| `c/action-client` | 0.05 s | 0.05 s |
+
+The harness uses the second one: `qemu_system_arm_path()` prefers the `nros
+setup` store over `PATH`, so a developer timing an image by hand with
+`qemu-system-arm` measures a different emulator than the test does. That is how
+this went unnoticed — the hand-run and the cell disagree by 400x and neither
+says which binary it used.
+
+During the stall QEMU burns a full core (`utime+stime` tracks wall clock 1:1
+across the whole 19.6 s), so it is emulation/device work, not a wait.
+
+## What it explains: issue 0870's C-vs-C++ asymmetry, quantitatively
+
+Issue 0870 recorded "C: 26.4-27.2 s, C++: 44-50 s -- a measurement, not a
+mechanism", and treated the ~20 s gap as evidence about the C++ binding. It is
+not about the binding at all. Instrumented cell timings, this tree:
+
+    nuttx C   action: server banner 20.14 s | client collect  3.51 s | cell 26.1 s
+    nuttx C++ action: server banner 19.94 s | client collect 23.10 s | cell 45.7 s
+
+Both servers stall. The C **client** does not; the C++ client does. So the C
+cell pays the stall once and the C++ cell pays it twice, and the difference is
+one stall: **20 s, matching the reported 18-23 s gap.** With the stall removed
+the round trips are the same length -- hand-run on QEMU 6.2.0, C++ completes
+goal -> accept -> feedback -> result in **2.2 s**.
+
+`nros-tests` charges this to the cell either way, which is why the asymmetry
+looked like a property of the C++ image.
+
+## The discriminator is the ELF program headers, and the correlation is exact
+
+19 of 19 NuttX arm images, both emulators:
+
+| shape | images | QEMU 6.2.0 | QEMU 11.0.0-nros2 |
+| --- | --- | ---: | ---: |
+| 2 `PT_LOAD`, second has `memsz` >> `filesz` (`.bss` folded in with `.data`) | 10 | 0.05 s | **19.5-19.9 s** |
+| 3+ `PT_LOAD`, `.bss` in its own `filesz == 0` segment | 9 | 0.05 s | 0.05 s |
+
+    c/action-server    2 LOADs   0x00db0/0x97000   -> 19.89 s
+    cpp/talker         2 LOADs   0x00ed0/0x95000   -> 19.65 s
+    c/action-client    3 LOADs   0x00db8/0x00db8   ->  0.05 s
+    rust:*/talker      3 LOADs   0x00d88/0x00d88   ->  0.05 s
+
+Every Rust NuttX image is in the fast set (they link with `.bss` split out), and
+so are exactly two C ones -- `c/action-client` and `c/service-client`. Nothing
+else about those two is special: `c/action-client` and `c/action-server` differ
+by **16 bytes of `.bss` and 8 bytes of `.data`**, and one boots in 0.05 s while
+the other takes 19.9 s.
+
+**And the cost is linear in the zero-fill size**, which is the second
+independent check:
+
+| merged segment `memsz` | stall |
+| ---: | ---: |
+| 0x97000 (618 496) | 19.89 s |
+| 0x96000 (614 400) | 19.64 / 19.69 / 19.74 s |
+| 0x95000 (610 304) | 19.50-19.65 s (mean 19.56) |
+
+618496/610304 = 1.0134 against 19.89/19.56 = 1.0169. The implied rate is
+**~31 KB/s**.
+
+## Hypothesis for the mechanism, and how to settle it
+
+NuttX's `virt` images are linked to run from the machine's FLASH aperture
+(`0x0-0x08000000`): the text segment sits at paddr `0x00600000` and the data
+segment at paddr `0x00688000`, with `.bss` folded into it in the slow images.
+QEMU's `-kernel` ELF loader zero-pads a `PT_LOAD` out to `memsz` and writes the
+whole thing at the segment's **paddr** -- so on the slow images it pushes ~600 KB
+of zeros into the pflash device, and ~31 KB/s is the shape of a device write
+path that invalidates translated code per store. A `filesz == 0` segment gives
+the loader nothing to load, which is why the split-`.bss` images escape entirely.
+
+That last step is INFERRED: `third-party/qemu/qemu` is not initialised in this
+checkout, so `hw/core/loader.c` was not read. Settle it by initialising the
+submodule and checking how `load_elf_ram_sym` treats `p_filesz == 0` and where it
+routes the padded write; or by comparing against a stock upstream QEMU 11, which
+would also answer whether this is a regression from 6.2.0 or something our patch
+line introduced.
+
+## Why it is worth fixing rather than tolerating
+
+* It costs ~20 s per affected image. 10 of the 12 NuttX arm C/C++ fixtures are
+  affected, and a full NuttX arm C/C++ e2e sweep boots twelve of them: **~3.3
+  minutes of pure emulator overhead per sweep**.
+* It makes hand-runs and cells disagree by 400x on the same image, which is a
+  trap for exactly the timing-sensitive investigations that keep landing on
+  NuttX (0870, 0891, 0902).
+* Issue 0870 says its fault "is timing-sensitive and moves with image CONTENT".
+  This is a mechanism by which image content moves timing by 20 s -- 16 bytes of
+  `.bss` decide it. That does not prove it is 0870's cause and is not offered as
+  one; it does mean any 0870 experiment that compares two builds is comparing two
+  different emulation regimes unless the segment shape is checked.
+
+## Directions
+
+1. **Split `.bss` into its own `PT_LOAD` in the NuttX arm link.** Nine images
+   already have this shape, so it is a linker-script/`--no-rosegment`-class
+   change, not a new capability, and it removes the cost outright.
+2. **Fix or drop the provisioned QEMU for this board.** 6.2.0 does not have the
+   problem. Note the store QEMU is patched for other boards (mps2/an536, lan9118)
+   so it cannot simply be discarded -- and issue 0930 already records that
+   nothing checks the built QEMU against the pin.
+3. **Say which emulator ran.** A one-line print of the resolved
+   `qemu_system_arm_path()` in the cell's output would have made this visible the
+   first time anyone compared a hand-run against a cell.
+
+## Reproduce
+
+    # slow (2 PT_LOADs) vs fast (3 PT_LOADs), same emulator
+    ~/.nros/sdk/qemu/11.0.0-nros2/bin/qemu-system-arm -M virt -cpu cortex-a7 \
+      -nographic -kernel examples/qemu-arm-nuttx/cpp/action-server/build-zenoh/cpp_action_server
+    ~/.nros/sdk/qemu/11.0.0-nros2/bin/qemu-system-arm -M virt -cpu cortex-a7 \
+      -nographic -kernel examples/qemu-arm-nuttx/c/action-client/build-zenoh/c_action_client
+
+    # the same two on the distro emulator: both immediate
+    /usr/bin/qemu-system-arm -M virt -cpu cortex-a7 -nographic -kernel <same>
+
+    # the discriminator
+    arm-none-eabi-readelf -l <image> | grep '^  LOAD'

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -91,5 +91,6 @@ fails if this block drifts.
 - **#1023** (rmw, build) — `nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target See `1023-*`.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
 - **#1028** ([rmw, memory, build]) — NuttX is classified `hosted` because its `target_os` is not `\"none\"`, so it takes the Linux 32-queryable budget: 142,336 B of `.bss` in an image with zero queryables See `1028-*`.
+- **#1034** (testing, tooling) — The provisioned QEMU 11 spends ~19.6 s materialising a NuttX image's `.bss` before the guest runs, and that stall is the whole C-vs-C++ asymmetry in issue 0870 See `1034-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-414-rtos-runtime-correctness.md
+++ b/docs/roadmap/phase-414-rtos-runtime-correctness.md
@@ -1,6 +1,6 @@
 # Phase 414 — RTOS runtime correctness: the e2e failures that reproduce SOLO
 
-**Status (2026-09-03). W2 and W4 CLOSED, W3 advanced, W1 rediagnosed.** Opened
+**Status (2026-09-04). W1/W2/W4/W5 CLOSED. W3 is the only item left, and its timing lead is withdrawn (issue 1034).** Opened
 as a HOME, not as a plan: five open issues had no phase that could hold them,
 and the survey that found that is the whole reason this doc exists — an issue
 with no home is an issue nobody is accountable for, the same shape as a gate
@@ -113,6 +113,22 @@ Each is an existing issue. The item is "close it"; the issue holds the evidence.
   Also: the Aug-21 binaries in this tree predate the Aug-29 instrumentation that
   produced this issue's quoted output, so "it passes now" is not a delta against
   "it failed then" — different images, not diffable.
+  **2026-09-04: the asymmetry is EXPLAINED and withdrawn as a lead — issue
+  1034.** It measured the EMULATOR. The harness prefers the `nros setup` store
+  QEMU (`11.0.0-nros2`) over `PATH`, and on that build a NuttX arm image whose
+  `.bss` shares a `PT_LOAD` with its `.data` burns **~19.6 s of CPU before the
+  guest's first console byte**; on the distro QEMU 6.2.0 it starts in 0.05 s.
+  Correlation with program-header shape is exact over all 19 NuttX arm images,
+  and the cost is linear in the zero-fill size (~31 KB/s). Instrumented: both
+  action SERVERS stall, `cpp/action-client` stalls, `c/action-client` does not —
+  so the C cell pays one stall (26.1 s) and the C++ cell two (45.7 s), and the
+  difference IS the stall. Hand-run on 6.2.0 the C++ round trip is **2.2 s**.
+  `c/action-client` and `c/action-server` differ by 16 bytes of `.bss`.
+  The `-100` failure is UNTOUCHED by this — no mechanism connecting stall to
+  failure is offered. What changes is method: this issue says the fault "moves
+  with image CONTENT", and 1034 is a way 16 bytes of content move timing by 20 s,
+  so a two-build comparison must check the `PT_LOAD` shape, and a hand-run is not
+  comparable to a cell unless it runs the same emulator binary.
 * **W4 — [issue 0847](../issues/archived/0847-xrce-entity-drop-after-session-close.md).
   CLOSED.** The fix is a refcount (`live_entities` + `session_closed`), applied
   to all four entity destructors, with each checking `xrce_session_is_closed`
@@ -126,6 +142,10 @@ Each is an existing issue. The item is "close it"; the issue holds the evidence.
   contrast is what settled the shape.
   Gated by `tests/entity_lifetime.c` under `just check rmw-xrce`, asserting the
   EXIT STATUS as the issue required, and mutation-checked.
+* **W5 — [issue 0741](../issues/archived/0741-xrce-service-reply-history-payload-too-small.md),
+  RESOLVED 2026-09-03 — the 28-byte sample is a FOREIGN peer's, on another
+  host.** Everything below is the investigation that got there, kept because
+  four of its steps were dead ends worth not repeating.
 * **W5 — [issue 0741](../issues/0741-xrce-service-reply-history-payload-too-small.md),
   `test_xrce_service_ros2_client` fails on main — Fast-DDS refuses the
   request.** INTEROP with a real ROS 2 peer.
@@ -176,6 +196,16 @@ Each is an existing issue. The item is "close it"; the issue holds the evidence.
 
 **Progress 2026-09-03.** W2 and W4 closed; W5's routing decided (stays);
 W1 and W3 rediagnosed with their standing guesses killed by measurement.
+
+**Progress 2026-09-04. W5 is CLOSED** — issue 0741 resolved: the 28-byte sample
+on the reply topic belongs to a FOREIGN peer on another host, which is also what
+issue 1009 fixed (the interop bus is now pinned to loopback on both sides). The
+inference this phase recorded about the Agent mis-slicing a SampleIdentity stays
+refuted; the sample was never ours to explain.
+
+**W3 is the phase's only open item.** Its C-vs-C++ asymmetry is now explained
+and withdrawn (issue 1034, above); its `-100` failure still needs a failing run,
+and the instrumentation for that is armed and linked.
 
 The shared-cause answer: **NO.** W2 was harness ordering and is already fixed;
 W3 fails inside construction, before any interaction with the server exists, so


### PR DESCRIPTION
Phase-414 W3. Issue 0870's only hard evidence about the C-vs-C++ asymmetry —
"C: 26.4-27.2 s, C++: 44-50 s" — measured the **emulator**, not the binding.

`qemu_system_arm_path()` prefers the `nros setup` store build
(`~/.nros/sdk/qemu/11.0.0-nros2`) over `PATH`. On that build a NuttX arm image
whose `.bss` is folded into the same `PT_LOAD` as its `.data` burns **~19.6 s of
CPU-bound emulator work before the guest's first console byte**; on the distro
`qemu-system-arm` 6.2.0 the same image starts in 0.05 s. So a developer timing an
image by hand and the cell timing it are 400x apart, and neither prints which
binary it used.

**Correlation is exact over all 19 NuttX arm images:**

| shape | images | 6.2.0 | 11.0.0-nros2 |
| --- | --- | ---: | ---: |
| 2 `PT_LOAD`, second `memsz` >> `filesz` | 10 | 0.05 s | 19.5–19.9 s |
| 3+ `PT_LOAD`, `.bss` in its own `filesz == 0` segment | 9 | 0.05 s | 0.05 s |

and the cost is linear in the zero-fill size (~31 KB/s), which is a second
independent check: `0x97000` → 19.89 s against `0x95000` → 19.56 s is 1.0134 vs
1.0169.

**The asymmetry is one stall.** Both action servers pay it; `cpp/action-client`
pays it, `c/action-client` does not — so the C cell pays once (26.1 s) and the C++
cell twice (45.7 s). `c/action-client` and `c/action-server` differ by **16 bytes
of `.bss`**. Hand-run on 6.2.0 the C++ round trip is 2.2 s.

The `-100` failure is **untouched** — no mechanism connecting the stall to it is
offered, and 0870 has already burned four guesses. What changes is method: a
two-build comparison must check the `PT_LOAD` shape first, and a hand-run is not
comparable to a cell unless it runs the same emulator.

The finding paid for itself: the cell runs in 4.7 s instead of 46 s on the distro
emulator, so 36 more reproduction runs (24 idle, 12 under load avg 22,
`--retries 0`) cost ~5 minutes. All passed — 64 consecutive. Bound stated in the
issue: those are on the distro emulator and do not extend the store-QEMU evidence.

Also: phase-414 W5 marked closed (issue 0741 resolved — the 28-byte sample is a
foreign peer's), leaving W3 as the phase's only open item.

Docs only. `just check fast`: 192 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
