### PR TITLE
ci(phase-413 W5): the CLI-build block existed four times; now once

### DIFF
--- a/.github/actions/setup-nros-cli/action.yml
+++ b/.github/actions/setup-nros-cli/action.yml
@@ -1,0 +1,49 @@
+name: Build the in-tree nros CLI
+description: >
+  phase-413 W5 — build `packages/cli/target/release/nros` and put it on
+  `$GITHUB_PATH`, plus the `nros-launch-resolve` helper the CLI refuses to work
+  without.
+
+  This body was copied VERBATIM in four `nightly.yml` jobs (platform,
+  zephyr-example-matrix, zephyr-dual-line-summary, zephyr-copy-out). Four
+  copies of a 24-line block is four places to update when the CLI's build
+  changes, and the phase's own finding is that a workflow which hand-rolls what
+  a verb does hides defects in the verb — issue 0992 was invisible to the queue
+  for exactly that reason.
+
+  DELIBERATELY NOT `just _setup-common`, which already does all three of these
+  steps and is what `just setup <tier>` calls. The only delta is `--depth 1` on
+  the submodule init: `_setup-common` clones play_launch in full. Routing
+  through the verb is the RIGHT end state and is what W5 asks for, but it
+  changes clone cost in a lane that is currently red, and a behaviour change
+  landed into a lane with no signal cannot be verified. So this step is a
+  faithful de-duplication with no behavioural delta, and the verb conversion is
+  left as its own change once W2 gets the lane green.
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        source ./activate.sh
+        git submodule update --init --depth 1 packages/cli/third-party/play_launch
+        cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
+        echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
+        # issue 0797 — `--bin nros` does NOT build `nros-launch-resolve`: the
+        # helper is its own cargo workspace (RFC-0060 layer 2). Without it
+        # `nros sync` refuses any workspace with an unresolved SystemModel,
+        # which aborted five of eight nightly jobs in 2-5 s — nightly looked
+        # like it exercised six platforms and exercised one.
+        #
+        # The refusal is CORRECT and must not be loosened: issue 0409 records
+        # that proceeding without a resolver let a stale one silently drop
+        # every `params` projection from 22 models.
+        #
+        # No copying needed. `nros` finds it by walking up from its own path
+        # (ws.rs `resolver_from`, arm 3: `<repo>/packages/cli/
+        # nros-launch-resolve/target/release/`), which is exactly where this
+        # recipe builds — `nros` lands in `packages/cli/target/release`, four
+        # ancestors below the repo root. Verified against that code, because
+        # the error message says "next to the `nros` binary" (arm 2) and that
+        # phrasing would send you to copy the binary instead.
+        just setup-launch-resolve

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -253,30 +253,7 @@ jobs:
             nros-cli-${{ runner.os }}-
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
-        run: |
-          source ./activate.sh
-          git submodule update --init --depth 1 packages/cli/third-party/play_launch
-          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
-          echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
-          # issue 0797 — `--bin nros` does NOT build `nros-launch-resolve`: the
-          # helper is its own cargo workspace (RFC-0060 layer 2). Without it
-          # `nros sync` refuses any workspace with an unresolved SystemModel,
-          # which aborted five of eight nightly jobs in 2-5 s — nightly looked
-          # like it exercised six platforms and exercised one.
-          #
-          # The refusal is CORRECT and must not be loosened: issue 0409 records
-          # that proceeding without a resolver let a stale one silently drop
-          # every `params` projection from 22 models.
-          #
-          # No copying needed. `nros` finds it by walking up from its own path
-          # (ws.rs `resolver_from`, arm 3: `<repo>/packages/cli/
-          # nros-launch-resolve/target/release/`), which is exactly where this
-          # recipe builds — `nros` lands in `packages/cli/target/release`, four
-          # ancestors below the repo root. Verified against that code, because
-          # the error message says "next to the `nros` binary" (arm 2) and that
-          # phrasing would send you to copy the binary instead.
-          just setup-launch-resolve
-
+        uses: ./.github/actions/setup-nros-cli
       - name: just ${{ matrix.plat }} setup
         run: |
           source ./activate.sh
@@ -511,30 +488,7 @@ jobs:
             nros-cli-${{ runner.os }}-
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
-        run: |
-          source ./activate.sh
-          git submodule update --init --depth 1 packages/cli/third-party/play_launch
-          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
-          echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
-          # issue 0797 — `--bin nros` does NOT build `nros-launch-resolve`: the
-          # helper is its own cargo workspace (RFC-0060 layer 2). Without it
-          # `nros sync` refuses any workspace with an unresolved SystemModel,
-          # which aborted five of eight nightly jobs in 2-5 s — nightly looked
-          # like it exercised six platforms and exercised one.
-          #
-          # The refusal is CORRECT and must not be loosened: issue 0409 records
-          # that proceeding without a resolver let a stale one silently drop
-          # every `params` projection from 22 models.
-          #
-          # No copying needed. `nros` finds it by walking up from its own path
-          # (ws.rs `resolver_from`, arm 3: `<repo>/packages/cli/
-          # nros-launch-resolve/target/release/`), which is exactly where this
-          # recipe builds — `nros` lands in `packages/cli/target/release`, four
-          # ancestors below the repo root. Verified against that code, because
-          # the error message says "next to the `nros` binary" (arm 2) and that
-          # phrasing would send you to copy the binary instead.
-          just setup-launch-resolve
-
+        uses: ./.github/actions/setup-nros-cli
       - name: Provision Zephyr sources via nros
         run: |
           source ./activate.sh
@@ -628,30 +582,7 @@ jobs:
             nros-cli-${{ runner.os }}-
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
-        run: |
-          source ./activate.sh
-          git submodule update --init --depth 1 packages/cli/third-party/play_launch
-          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
-          echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
-          # issue 0797 — `--bin nros` does NOT build `nros-launch-resolve`: the
-          # helper is its own cargo workspace (RFC-0060 layer 2). Without it
-          # `nros sync` refuses any workspace with an unresolved SystemModel,
-          # which aborted five of eight nightly jobs in 2-5 s — nightly looked
-          # like it exercised six platforms and exercised one.
-          #
-          # The refusal is CORRECT and must not be loosened: issue 0409 records
-          # that proceeding without a resolver let a stale one silently drop
-          # every `params` projection from 22 models.
-          #
-          # No copying needed. `nros` finds it by walking up from its own path
-          # (ws.rs `resolver_from`, arm 3: `<repo>/packages/cli/
-          # nros-launch-resolve/target/release/`), which is exactly where this
-          # recipe builds — `nros` lands in `packages/cli/target/release`, four
-          # ancestors below the repo root. Verified against that code, because
-          # the error message says "next to the `nros` binary" (arm 2) and that
-          # phrasing would send you to copy the binary instead.
-          just setup-launch-resolve
-
+        uses: ./.github/actions/setup-nros-cli
       - name: Provision Zephyr sources via nros
         run: |
           source ./activate.sh
@@ -726,30 +657,7 @@ jobs:
             nros-cli-${{ runner.os }}-
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
-        run: |
-          source ./activate.sh
-          git submodule update --init --depth 1 packages/cli/third-party/play_launch
-          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
-          echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
-          # issue 0797 — `--bin nros` does NOT build `nros-launch-resolve`: the
-          # helper is its own cargo workspace (RFC-0060 layer 2). Without it
-          # `nros sync` refuses any workspace with an unresolved SystemModel,
-          # which aborted five of eight nightly jobs in 2-5 s — nightly looked
-          # like it exercised six platforms and exercised one.
-          #
-          # The refusal is CORRECT and must not be loosened: issue 0409 records
-          # that proceeding without a resolver let a stale one silently drop
-          # every `params` projection from 22 models.
-          #
-          # No copying needed. `nros` finds it by walking up from its own path
-          # (ws.rs `resolver_from`, arm 3: `<repo>/packages/cli/
-          # nros-launch-resolve/target/release/`), which is exactly where this
-          # recipe builds — `nros` lands in `packages/cli/target/release`, four
-          # ancestors below the repo root. Verified against that code, because
-          # the error message says "next to the `nros` binary" (arm 2) and that
-          # phrasing would send you to copy the binary instead.
-          just setup-launch-resolve
-
+        uses: ./.github/actions/setup-nros-cli
       - name: Provision Zephyr sources via nros
         run: |
           source ./activate.sh


### PR DESCRIPTION
`nightly.yml` carried a 24-line *"Build nros CLI from packages/cli/"* step **verbatim in four jobs** — `platform`, `zephyr-example-matrix`, `zephyr-dual-line-summary`, `zephyr-copy-out`. W5's acceptance asks for one.

Extracted to `.github/actions/setup-nros-cli`, following the precedent already in the tree (`.github/actions/setup-qemu-patched`). **96 lines removed, 4 added**; `nightly.yml` goes 889 → 798.

The step body is preserved **byte-for-byte**, asserted rather than eyeballed: the extracted `run:` string compares equal to the original block with its indent stripped. Every removed line belongs to those four blocks — the only removals not matching the block's own text are the four `run: |` lines the `uses:` replaces.

## Deliberately NOT routed through `just _setup-common`

That verb already does all three steps (submodule init, `setup-cli`, `setup-launch-resolve`) and is what `just setup <tier>` calls. It is the **right end state**, and it is literally what W5 asks for — *"every job body is `just setup <scope>` plus one command"*. Two reasons it is not this commit:

- The one behavioural delta is `--depth 1`: `_setup-common` clones `play_launch` in **full**. That is a clone-cost change in the nightly.
- **`nightly.yml` is currently red** (failure ×3 in the last window), and phase-413 W2 says it plainly: *no conversion can be verified in a lane that is already red.* A behaviour change landed into a lane with no signal cannot be distinguished from the failure already there.

So this is a faithful de-duplication with no behavioural delta; the verb conversion is its own change once W2 gets the lane green. The reasoning is recorded in the action's own description so the next person does not re-derive it.

## A finding for W5's remaining scope

`_setup-common` is reachable **only** from the root `setup` recipe (4 call sites in `justfile`). **`just <plat> setup` does not reach it** — which is exactly why these four blocks exist. They are compensating for a verb that does not provision the CLI.

That is the defect phase-413's thesis predicts: *"every hand-rolled step in a workflow is a claim that the toolchain cannot do the thing itself, and each one that is true is a defect nobody is looking at."* Here the claim is true, and the fix is a **verb** change, not a workflow one.

`just check fast` green (195 gates); both YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)