### PR TITLE
fix(phase-413 W2): the tier-2 lanes never built their fixtures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -871,6 +871,34 @@ jobs:
       - name: Verify this runner's labels are true
         run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
 
+      # THE MISSING MIDDLE — phase-413 W2.
+      #
+      # The documented chain is `setup` -> `build` -> `test` (phase-411 W4), and
+      # this job went straight from setup to the test lane. `ci matrix-nightly`
+      # opens with `_lane-gate tier2-nightly`, which runs `check-fixtures-stale.sh` — a
+      # FRESHNESS GATE, not a build. So the lane asked "are the fixtures fresh?"
+      # of a tree that had never built them.
+      #
+      # On a self-hosted runner with a persistent workspace that can look like it
+      # works, because a previous run left artifacts behind. It stops looking
+      # like it works the moment the per-leaf `generated/` msg crates are absent,
+      # and then the gate cannot even build a fixture to judge it:
+      #
+      #   ERROR: 104 rust fixture(s) could NOT be built by the staleness probe:
+      #     examples/native/rust/talker
+      #         error: failed to load manifest for dependency `std_msgs`
+      #     examples/native/rust/service-client
+      #         error: failed to load manifest for dependency `example_interfaces`
+      #
+      # `just build <scope>` is the stage that produces them: it runs `_codegen`
+      # (issue 0992) and then the lane's fixtures. Naming the SAME scope as
+      # setup and test keeps one vocabulary across the three steps, which is the
+      # property phase-411 exists to give.
+      - name: just build tier2-nightly
+        run: |
+          source ./activate.sh
+          just build tier2-nightly
+
       - name: just ci matrix-nightly
         run: |
           source ./activate.sh

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -90,6 +90,34 @@ jobs:
       # and `setup` would have failed on it first anyway.
       - name: Verify this runner's labels are true
         run: ./scripts/ci/runner-doctor.sh nros-qemu,nros-sdk-zephyr,nros-big
+
+      # THE MISSING MIDDLE — phase-413 W2.
+      #
+      # The documented chain is `setup` -> `build` -> `test` (phase-411 W4), and
+      # this job went straight from setup to the test lane. `ci matrix`
+      # opens with `_lane-gate tier2`, which runs `check-fixtures-stale.sh` — a
+      # FRESHNESS GATE, not a build. So the lane asked "are the fixtures fresh?"
+      # of a tree that had never built them.
+      #
+      # On a self-hosted runner with a persistent workspace that can look like it
+      # works, because a previous run left artifacts behind. It stops looking
+      # like it works the moment the per-leaf `generated/` msg crates are absent,
+      # and then the gate cannot even build a fixture to judge it:
+      #
+      #   ERROR: 104 rust fixture(s) could NOT be built by the staleness probe:
+      #     examples/native/rust/talker
+      #         error: failed to load manifest for dependency `std_msgs`
+      #     examples/native/rust/service-client
+      #         error: failed to load manifest for dependency `example_interfaces`
+      #
+      # `just build <scope>` is the stage that produces them: it runs `_codegen`
+      # (issue 0992) and then the lane's fixtures. Naming the SAME scope as
+      # setup and test keeps one vocabulary across the three steps, which is the
+      # property phase-411 exists to give.
+      - name: just build tier2
+        run: |
+          source ./activate.sh
+          just build tier2
       # `just ci matrix`, NOT `just test tier2`. phase-411 W4 briefly used the
       # latter and that was a COVERAGE REGRESSION caught by
       # check-tier-has-ci-owner: the tier recipe is `_lane-gate` + `check` +


### PR DESCRIPTION
The first real verdict `nightly` tier-2 has produced — and it exposed a missing stage.

## What the run showed

Nightly `33831829557` is the first to get **past** the runner-doctor ordering fix (#282). Instead of dying at step 2 with a no-verdict, it ran and reported:

```
ERROR: 104 rust fixture(s) could NOT be built by the staleness probe:
  examples/native/rust/talker
      error: failed to load manifest for dependency `std_msgs`
  examples/native/rust/service-client
      error: failed to load manifest for dependency `example_interfaces`
```

## The defect

Both tier-2 jobs went **setup → test**, skipping the middle stage of the documented chain (`setup` → `build` → `test`, phase-411 W4).

`ci matrix` and `ci matrix-nightly` open with `_lane-gate`, which runs `check-fixtures-stale.sh` — a **freshness gate, not a build**. So each lane asked *"are the fixtures fresh?"* of a tree that had never built them.

On a self-hosted runner with a persistent workspace that can pass, because an earlier run left artifacts behind. It stops passing the moment the per-leaf `generated/` message crates are absent — and then the gate cannot even build a fixture in order to judge it.

## The fix

`just build <scope>` is the stage that produces them: it runs `_codegen` (issue 0992) and then the lane fixtures. Added to both jobs, naming the **same scope** its `setup` and its `ci` lane already name, so one vocabulary spans the three steps.

This is the same defect as the `host-tests` codegen gap one lane over — a build path reachable without the codegen it depends on. There it was a recipe missing `_codegen`; here it is a workflow missing the build verb entirely.

Order is now **checkout → setup → verify labels → build → test**. The label check stays after setup for the reason #279/#282 record (it probes `build/qemu`, which setup creates) and before build, so a mislabeled runner fails ahead of the expensive stage rather than after it.

## Verified

Both scope tokens resolve: `just build tier2` and `just build tier2-nightly` map to `build-test-fixtures lane=<scope>`. Gates green: workflow-repo-env, ci-no-verb-fallback, required-contexts-reportable, lane-contracts, workflow-indexed-apt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)