### PR TITLE
feat(phase-412): the image writes a boot self-report into RAM

### DIFF
--- a/docs/issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md
+++ b/docs/issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md
@@ -1,0 +1,94 @@
+---
+id: 1036
+title: "Arena exhaustion was half silent, and on the island it was wholly
+  unreachable -- the two diagnostics written to explain it go to a sink that
+  does not exist"
+status: open
+type: bug
+area: core, boards, testing
+severity: high
+found: 2026-09-04
+related: [issue-0900, issue-0589, phase-412, phase-403, phase-409]
+---
+
+## What happens
+
+Two separate defects that compose into one blind spot, both found while
+building phase-412's boot self-report.
+
+**Half of arena exhaustion reported nothing.** `Executor::arena_alloc` has
+called `report_arena_exhausted` since issue 0900 -- it names the knob and the
+shortfall, because `NodeError::BufferTooSmall` is what a dozen other paths
+return and a bare return code cannot distinguish them. Its sibling
+`arena_alloc_with_trailing` returned the same error and said nothing:
+
+```rust
+let new_used = trailing_offset + trailing_bytes;
+if new_used > self.arena.len() {
+    return Err(NodeError::BufferTooSmall);   // <- and that was all of it
+}
+```
+
+The split is not random. `arena_alloc_with_trailing` is the path for the
+BUFFERED subscription entries and the action entries -- `spin.rs:3949`,
+`spin.rs:4124`, `spin.rs:4348`, `action.rs:1454`. Those are what an island
+image actually allocates, so the silent half is the half that matters on the
+board that hit it.
+
+**And on that board, the loud half is silent too.** Both diagnostics go through
+`nros_log`. On the MR-CANHUBK344 the console is on `lpuart0`, which is not
+wired; `lpuart2` carries the zenoh serial transport and cannot take a second
+protocol. So the two messages written specifically to explain an arena failure
+reach nothing, on the one board where the arena was being derived.
+
+## Why it was not caught
+
+Every hosted test has a sink, so the message is asserted and passes
+(`executor_arena_advisory.rs` does exactly that). The gap is only visible on a
+target with no sink, and there is no cell for that -- the assertion is "the
+advisory reaches a sink", which is untestable where the answer is "there is no
+sink".
+
+The `_with_trailing` half is worse: no test asserts anything about it, because
+it produced no output to assert on. It is the shape issue 0196 names -- a
+diagnostic nobody can observe is indistinguishable from one that was never
+written.
+
+## Measured
+
+Reading `git grep arena_alloc` across `packages/core/nros-node/src`: 20 call
+sites, of which 8 go through `arena_alloc_with_trailing`. Those 8 covered every
+buffered subscription and every action entry.
+
+On the island, the practical consequence is recorded in phase-412: the derived
+configuration produced a degraded ROS graph, the node count gave 4, 0, 0, 4, 4
+across five runs of one unchanged config, and no channel could say why. RTT was
+tried and could not discriminate -- a working image and a derived image both
+printed only the Zephyr banner, and a deliberate positive control (`MAX_CBS=1`)
+produced nothing at all.
+
+## Fixed here, one half of it
+
+`arena_alloc_with_trailing` now calls `report_arena_exhausted`, so both halves
+name the knob. That closes the asymmetry but not the reachability: on a board
+with no sink the message still goes nowhere.
+
+For the reachability half, phase-412 landed `boot_report` -- a fixed 60-byte
+RAM record read back with a debugger rather than a log stream, because the
+failure halts before any stream could carry it. `note_alloc_failed` records the
+first failing allocation and its shortfall, so a dump names the number to add.
+
+## Not fixed, and this issue stays open for it
+
+**No cell exercises the target-side path.** The record is unit-tested on the
+host (`boot_report::tests`), and `check-boot-report-layout` keeps the decoder
+in step with the struct, but nothing yet builds an image with
+`CONFIG_NROS_BOOT_REPORT=y`, exhausts its arena on purpose, and asserts the
+dump names the shortfall. Until that exists, the instrument is verified in
+every part except the one that runs on silicon -- which is the same shape as
+the defect it was built to find.
+
+**The sibling question is unswept.** `report_arena_exhausted` and
+`report_arena_headroom` are two of an unknown number of diagnostics that assume
+a sink. Nothing has enumerated which other `nros_log` call sites are reachable
+only on a target that cannot carry one.

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -285,6 +285,83 @@ that stopped matching cannot report success. Point it at a real dir by hand:
 Verified against the island both ways: it FAILS on the pre-fix build naming all
 four dropped knobs, and passes on the fixed one.
 
+## W5 -- the instrument, because the campaign ran out of oracle. LANDED 2026-09-04
+
+W1 through W4 all assume a way to tell a correct image from a broken one. On
+the island there is not one.
+
+The six derived knobs were unpinned, the graph came up degraded, and the
+bisect that followed could not converge because the signal itself was not
+reliable: **one unchanged configuration produced 4, 0, 0, 4, 4 nodes across
+five runs.** Three hypotheses were raised and each disproved by measurement --
+the arena (the 40,960 image failed identically), `MAX_CBS` (the restore trial
+gave 0 after giving 4), and a printk sink of my own (removing it changed
+nothing). None of those retractions was cheap, and all three were caused by
+reasoning against a 60%-reliable instrument rather than by reasoning badly.
+
+So the board `.conf` is currently pinned back to hand-set values with that
+evidence recorded in comments, and **acceptance 1 below is NOT met.** That is
+the honest state: the numbers derive, and nobody can say whether the derived
+image is right.
+
+### Why every stream was already disqualified
+
+| channel | why not |
+| --- | --- |
+| console UART | `lpuart0`, not wired on the MR-CANHUBK344 |
+| second UART | `lpuart2` carries the zenoh serial transport |
+| `nros_log` | therefore reaches nothing -- including BOTH of issue 0900's arena diagnostics |
+| SEGGER RTT | tried; could not discriminate. Working and derived images both printed only the Zephyr banner, and a deliberate positive control produced nothing |
+| semihosting | halts the core until a probe answers, and FAULTS with none attached, so the image cannot run standalone |
+
+What those share is that they are STREAMS: they need the board still running,
+and somebody attached at the moment the interesting thing happens. The failure
+this phase is chasing is the opposite shape -- an under-sized arena halts
+DURING entity creation, before the first spin, so the advisory that would
+explain it never runs. **W3 is blocked on this and not on arithmetic**, which
+is why it is still open with its derivation already written.
+
+### What landed
+
+`packages/core/nros-node/src/boot_report.rs` -- a fixed 60-byte record in RAM,
+not a stream. Fifteen `AtomicU32`s: the header, the stage boot reached, the
+knobs the image was COMPILED with, and the arena allocation that did not fit.
+Read back by halting the core and dumping memory, with the address resolved
+from the ELF's own symbol table so a relinked image cannot be read at a stale
+one:
+
+    python3 scripts/read-boot-report.py build/zephyr/zephyr.elf dump.bin
+
+A PARTIAL record is the useful case rather than a lost one, which is the whole
+difference from a log: the last stage reached and the failed allocation are
+exactly what names the knob to change.
+
+Opt-in (`NROS_BOOT_REPORT=1`, Zephyr `CONFIG_NROS_BOOT_REPORT=y`), so an image
+that does not enable it is byte-identical -- the rule issue 0900's arena knob
+and phase-403's `rx_buffer_from_type()` both keep.
+
+**The compile-time half is the part this phase needed most.** W4's
+`check-knob-delivery.py` asserts that the number reaching the compiler equals
+the number the resolver decided, read from `build.ninja`. The record asserts
+the same identity one step further along -- from the silicon. Six delivery
+failures reached `main` before W4 existed; this is the arm that would catch a
+seventh that survives the build system entirely.
+
+### Found while building it
+
+[#1036](../issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md):
+`arena_alloc_with_trailing` reported NOTHING on failure while its sibling
+`arena_alloc` has named the knob since issue 0900. Half of arena exhaustion was
+silent -- and it is the half carrying buffered subscriptions and action
+entries, which is what an island image actually allocates. Fixed with W5.
+
+### What W5 does NOT settle
+
+No cell builds an image with the record on, exhausts its arena on purpose, and
+asserts the dump names the shortfall. The instrument is verified in every part
+except the one that runs on silicon, which is the same shape as the defect it
+exists to find. Filed in #1036 rather than claimed here.
+
 ## Acceptance
 
 1. The island board `.conf` states no NROS count or size that W1 covers, and the

--- a/just/check.just
+++ b/just/check.just
@@ -131,6 +131,7 @@ fast-serial: \
     board-vocabulary \
     book-links \
     book-no-just \
+    boot-report-layout \
     box-sync-covers-tracked-source \
     build-profile-literals \
     build-root \
@@ -599,7 +600,14 @@ codegen-size-bound-golden:
 # correct one, and stamped it with a new mtime — so ninja found the mirror's
 # OUTPUT newer than its trigger and skipped the command that would have fixed
 # it. A repair for drift that caused drift and suppressed its own fix.
-#
+
+# phase-412 -- the boot self-report is decoded POSITIONALLY out of a memory
+# dump, so a field reordered on one side and not the other does not fail: it
+# decodes, and prints an arena size that is really a callback count.
+[private]
+boot-report-layout:
+    @python3 scripts/check-boot-report-layout.py
+
 # Static, no build. The whole 0088 -> 0114 -> 0122 -> 0123 -> 0245 -> 0268 ->
 # 0978 -> 0985 family is one shape: two ways to answer "which bytes are the
 # current sizes header".

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -21,6 +21,15 @@ fn main() {
     // this presence cfg.
     println!("cargo:rustc-check-cfg=cfg(rmw_needs_type_descriptors)");
 
+    // The boot self-report (`src/boot_report.rs`) is OPT-IN, so an image that
+    // does not ask for it is byte-identical to one built before it existed.
+    // Set NROS_BOOT_REPORT=1 (Zephyr: CONFIG_NROS_BOOT_REPORT=y) to enable.
+    println!("cargo:rustc-check-cfg=cfg(nros_boot_report)");
+    println!("cargo:rerun-if-env-changed=NROS_BOOT_REPORT");
+    if env::var("NROS_BOOT_REPORT").is_ok_and(|v| !v.is_empty() && v != "0" && v != "n") {
+        println!("cargo:rustc-cfg=nros_boot_report");
+    }
+
     // Emit `has_rmw` when an RMW seam is compiled in.
     //
     // phase-347 W1 — this used to test four features:

--- a/packages/core/nros-node/src/boot_report.rs
+++ b/packages/core/nros-node/src/boot_report.rs
@@ -1,0 +1,444 @@
+//! A fixed RAM record the image writes about itself, for targets where no log
+//! sink reaches a human.
+//!
+//! # Why this exists
+//!
+//! phase-412 derived six pool counts and the executor arena for the
+//! mr-canhubk344 island, and then could not tell whether the derived image was
+//! correct. The only available signal was the ROS graph's node count, and one
+//! unchanged configuration produced 4, 0, 0, 4, 4 across five runs. Every other
+//! channel was already disqualified for that board:
+//!
+//! * The console is on `lpuart0`, which is not wired on the MR-CANHUBK344.
+//!   `lpuart2` is the zenoh serial transport and cannot carry a second protocol.
+//! * `nros_log` therefore reaches nothing. Both arena diagnostics (issue 0900)
+//!   go through it, so the two messages written specifically to explain an
+//!   arena failure are invisible on the one board that needed them.
+//! * SEGGER RTT was tried and could not discriminate: a working image and a
+//!   derived image both emitted only the Zephyr banner, and a deliberate
+//!   positive control produced nothing at all.
+//! * Semihosting halts the core until a probe answers and FAULTS with no probe
+//!   attached, so an image carrying it cannot run standalone.
+//!
+//! What all of those share is that they are STREAMS: they need the board to
+//! still be running, and they need somebody attached at the moment the
+//! interesting thing happens. The failure this campaign is trying to see is the
+//! opposite shape. An under-sized arena halts DURING entity creation, before
+//! the first spin, so issue 0900's advisory never prints -- the failure cannot
+//! report itself through any stream.
+//!
+//! So this is not a stream. It is a fixed-size record in RAM that the image
+//! keeps up to date as it boots, read out AFTERWARDS by halting the core and
+//! dumping memory. It survives the halt because it does not depend on anything
+//! still running, and a PARTIAL record is the useful case rather than a lost
+//! one: the last stage reached and the allocation that did not fit are exactly
+//! what names the knob to change.
+//!
+//! # Reading it
+//!
+//! The record is a `#[no_mangle]` static, so it has a symbol in the ELF and a
+//! debugger can find it without the address being wired in anywhere:
+//!
+//! ```text
+//! pyocd commander -t s32k344 -c "halt" -c "savemem <addr> <len> report.bin"
+//! python3 scripts/read-boot-report.py <elf> report.bin
+//! ```
+//!
+//! [`MAGIC`] distinguishes a written record from uninitialised RAM, and
+//! [`BootReport::struct_size`] lets a reader refuse a layout it does not know
+//! rather than decode it wrongly.
+//!
+//! # Cost, and why it is opt-in
+//!
+//! Enabled by setting `NROS_BOOT_REPORT=1` at build time (Zephyr:
+//! `CONFIG_NROS_BOOT_REPORT=y`), which makes `nros-node`'s build script emit
+//! `cfg(nros_boot_report)`. With the cfg absent every function here is an empty
+//! `#[inline(always)]` body and the static does not exist, so an image that
+//! does not opt in is byte-identical to one built before this module -- the
+//! same rule issue 0900's arena knob and phase-403's `rx_buffer_from_type()`
+//! both keep.
+//!
+//! Enabled, it costs [`BootReport::struct_size`] bytes of `.bss` (60 on a
+//! 32-bit target) and a handful of relaxed atomic stores on paths that run once
+//! per entity at registration. Nothing here is on the spin path.
+
+#![allow(clippy::module_name_repetitions)]
+
+/// `"NRSR"` -- nano-ros self report. Written LAST, so a reader that finds it
+/// knows every field before it is already valid.
+pub const MAGIC: u32 = 0x4e52_5352;
+
+/// Layout version. Bump on any field change; a reader refuses what it does not
+/// know rather than decoding a record it would misread.
+pub const VERSION: u32 = 1;
+
+/// How far boot got. Monotonic, and the single most useful field: an arena
+/// failure halts during entity creation, so the stage that was NOT reached
+/// names the phase to look at.
+///
+/// Values are stable across versions -- a new stage is appended, never
+/// inserted, so a stage number in an old dump keeps its meaning.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum Stage {
+    /// RAM as the loader left it. Never stored; a reader seeing this with a
+    /// valid magic has found a record that was reset but not re-entered.
+    Untouched = 0,
+    /// The record itself is initialised and the compile-time knobs are in it.
+    /// Reaching only here means the image died before the executor existed.
+    ReportReady = 1,
+    /// An `Executor` has bound its arena, so [`BootReport::arena_capacity`]
+    /// is the real slice length rather than the compiled constant.
+    ExecutorReady = 2,
+    /// Entity registration has begun. The interval between this and
+    /// [`Stage::EntitiesReady`] is where an under-sized arena halts.
+    RegisteringEntities = 3,
+    /// Every entity the image declares was registered successfully.
+    EntitiesReady = 4,
+    /// The first `spin_once` was entered, which is where issue 0900's
+    /// headroom advisory would have printed had a sink existed.
+    FirstSpin = 5,
+}
+
+#[cfg(nros_boot_report)]
+pub use enabled::*;
+
+#[cfg(nros_boot_report)]
+mod enabled {
+    use super::{MAGIC, Stage, VERSION};
+    use portable_atomic::{AtomicU32, Ordering};
+
+    /// The record. One per image, in `.bss`.
+    ///
+    /// `#[repr(C)]` with every field an `AtomicU32` -- which is
+    /// `repr(transparent)` over `u32` -- so the layout is exactly the sequence
+    /// of 32-bit words the reader script decodes, on every target this crate
+    /// builds for.
+    ///
+    /// Atomics rather than a `static mut` because the record is written from
+    /// registration paths that an application may reach from more than one
+    /// thread. `Relaxed` throughout: there is no ordering relationship to
+    /// establish with any other data, and the reader is a debugger that has
+    /// already halted the core.
+    #[repr(C)]
+    pub struct BootReport {
+        magic: AtomicU32,
+        version: AtomicU32,
+        struct_size: AtomicU32,
+        stage: AtomicU32,
+
+        // Compile-time, so that comparing these against what the build system
+        // BELIEVES it delivered turns a "derived value did not arrive" defect
+        // into a measurement. `scripts/check-knob-delivery.py` asserts the same
+        // identity one step earlier, at `build.ninja`; this is the same
+        // assertion made by the silicon.
+        arena_size: AtomicU32,
+        max_cbs: AtomicU32,
+        max_sc: AtomicU32,
+        max_nodes: AtomicU32,
+        default_rx_buf_size: AtomicU32,
+
+        // Runtime.
+        arena_capacity: AtomicU32,
+        arena_used: AtomicU32,
+        alloc_count: AtomicU32,
+        last_alloc_size: AtomicU32,
+        /// Bytes the allocation that FAILED asked for, or 0 if none has.
+        failed_alloc_size: AtomicU32,
+        /// Bytes by which that allocation overran the arena. This is the
+        /// number to add to `NROS_EXECUTOR_ARENA_SIZE`, which is why it is
+        /// stored rather than left to be recomputed from the two above.
+        failed_alloc_shortfall: AtomicU32,
+    }
+
+    impl BootReport {
+        const fn new() -> Self {
+            Self {
+                magic: AtomicU32::new(0),
+                version: AtomicU32::new(0),
+                struct_size: AtomicU32::new(0),
+                stage: AtomicU32::new(0),
+                arena_size: AtomicU32::new(0),
+                max_cbs: AtomicU32::new(0),
+                max_sc: AtomicU32::new(0),
+                max_nodes: AtomicU32::new(0),
+                default_rx_buf_size: AtomicU32::new(0),
+                arena_capacity: AtomicU32::new(0),
+                arena_used: AtomicU32::new(0),
+                alloc_count: AtomicU32::new(0),
+                last_alloc_size: AtomicU32::new(0),
+                failed_alloc_size: AtomicU32::new(0),
+                failed_alloc_shortfall: AtomicU32::new(0),
+            }
+        }
+
+        /// Size of the record in bytes, as the reader must expect it.
+        ///
+        /// ASKED OF THE COMPILER, not counted by hand. A hand-written word
+        /// count is a second statement of the field list that drifts the first
+        /// time a field is added, and it would drift SILENTLY -- the reader
+        /// would accept the record and decode one field short. This whole
+        /// campaign is about not hand-picking numbers the build already knows.
+        #[must_use]
+        pub const fn struct_size() -> u32 {
+            // The record is all `AtomicU32`, so this is exact on every target
+            // and there is no padding for the cast to lose.
+            core::mem::size_of::<Self>() as u32
+        }
+    }
+
+    /// A plain-value copy of the record.
+    ///
+    /// Field-for-field with [`BootReport`] and in the SAME ORDER, because
+    /// `scripts/read-boot-report.py` decodes that order out of a memory dump.
+    /// A test that reads through this therefore exercises the same layout the
+    /// script assumes, which is the only thing keeping the two in step.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub struct Snapshot {
+        pub magic: u32,
+        pub version: u32,
+        pub struct_size: u32,
+        pub stage: u32,
+        pub arena_size: u32,
+        pub max_cbs: u32,
+        pub max_sc: u32,
+        pub max_nodes: u32,
+        pub default_rx_buf_size: u32,
+        pub arena_capacity: u32,
+        pub arena_used: u32,
+        pub alloc_count: u32,
+        pub last_alloc_size: u32,
+        pub failed_alloc_size: u32,
+        pub failed_alloc_shortfall: u32,
+    }
+
+    /// Read the record.
+    #[must_use]
+    pub fn snapshot() -> Snapshot {
+        let r = &NROS_BOOT_REPORT;
+        let g = |f: &AtomicU32| f.load(Ordering::Relaxed);
+        Snapshot {
+            magic: g(&r.magic),
+            version: g(&r.version),
+            struct_size: g(&r.struct_size),
+            stage: g(&r.stage),
+            arena_size: g(&r.arena_size),
+            max_cbs: g(&r.max_cbs),
+            max_sc: g(&r.max_sc),
+            max_nodes: g(&r.max_nodes),
+            default_rx_buf_size: g(&r.default_rx_buf_size),
+            arena_capacity: g(&r.arena_capacity),
+            arena_used: g(&r.arena_used),
+            alloc_count: g(&r.alloc_count),
+            last_alloc_size: g(&r.last_alloc_size),
+            failed_alloc_size: g(&r.failed_alloc_size),
+            failed_alloc_shortfall: g(&r.failed_alloc_shortfall),
+        }
+    }
+
+    /// The record, findable by symbol name from a debugger.
+    ///
+    /// `#[used]` because nothing in a minimal image necessarily reads it, and a
+    /// static whose only writes are through this module's functions is exactly
+    /// what a linker is entitled to discard.
+    #[unsafe(no_mangle)]
+    #[used]
+    pub static NROS_BOOT_REPORT: BootReport = BootReport::new();
+
+    /// Stamp the header and the compile-time knobs.
+    ///
+    /// Idempotent, and safe to call from more than one place -- an image with
+    /// two executors should not have to decide which one owns the record.
+    /// MAGIC is stored LAST so a reader that finds it knows the rest is there.
+    pub fn init() {
+        let r = &NROS_BOOT_REPORT;
+        r.version.store(VERSION, Ordering::Relaxed);
+        r.struct_size
+            .store(BootReport::struct_size(), Ordering::Relaxed);
+        r.arena_size
+            .store(saturate(crate::config::ARENA_SIZE), Ordering::Relaxed);
+        r.max_cbs
+            .store(saturate(crate::config::MAX_CBS), Ordering::Relaxed);
+        r.max_sc
+            .store(saturate(crate::config::MAX_SC), Ordering::Relaxed);
+        r.max_nodes
+            .store(saturate(crate::config::MAX_NODES), Ordering::Relaxed);
+        r.default_rx_buf_size.store(
+            saturate(crate::config::DEFAULT_RX_BUF_SIZE),
+            Ordering::Relaxed,
+        );
+        r.magic.store(MAGIC, Ordering::Relaxed);
+        checkpoint(Stage::ReportReady);
+    }
+
+    /// Record that boot reached `stage`.
+    ///
+    /// MONOTONIC: a lower stage never overwrites a higher one, so a late call
+    /// on a re-entered path cannot make the record claim less progress than was
+    /// actually made. That matters because the field's whole purpose is to be
+    /// believed about a boot that did not finish.
+    pub fn checkpoint(stage: Stage) {
+        let want = stage as u32;
+        let r = &NROS_BOOT_REPORT;
+        let mut cur = r.stage.load(Ordering::Relaxed);
+        while want > cur {
+            match r
+                .stage
+                .compare_exchange_weak(cur, want, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    /// Record the arena slice an `Executor` actually bound.
+    ///
+    /// Not the same number as `ARENA_SIZE`, and the difference is a finding
+    /// rather than noise: the arena's placement is the caller's choice
+    /// (issue 0900), so an image can compile one size and hand the executor
+    /// another. Both are in the record so a dump can say which happened.
+    pub fn note_arena_capacity(capacity: usize) {
+        NROS_BOOT_REPORT
+            .arena_capacity
+            .store(saturate(capacity), Ordering::Relaxed);
+    }
+
+    /// Record a successful arena allocation.
+    pub fn note_alloc(size: usize, used_after: usize) {
+        let r = &NROS_BOOT_REPORT;
+        r.alloc_count.fetch_add(1, Ordering::Relaxed);
+        r.last_alloc_size.store(saturate(size), Ordering::Relaxed);
+        r.arena_used.store(saturate(used_after), Ordering::Relaxed);
+    }
+
+    /// Record the arena allocation that did not fit.
+    ///
+    /// FIRST writer wins, on the same reasoning as [`checkpoint`]: the first
+    /// failure is the one that explains the boot, and any later one is a
+    /// consequence of it.
+    pub fn note_alloc_failed(size: usize, shortfall: usize) {
+        let r = &NROS_BOOT_REPORT;
+        if r.failed_alloc_size
+            .compare_exchange(0, saturate(size), Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            r.failed_alloc_shortfall
+                .store(saturate(shortfall), Ordering::Relaxed);
+        }
+    }
+
+    /// `usize` -> `u32`, saturating.
+    ///
+    /// Every field is a `u32` so the record's layout does not change between a
+    /// 32-bit board and a 64-bit host running the same tests. Saturating rather
+    /// than truncating because a value too large to represent should read as
+    /// "enormous", not as its low half -- a truncated 4 GiB reads as 0, which
+    /// is the one wrong answer that looks like a normal one.
+    fn saturate(v: usize) -> u32 {
+        u32::try_from(v).unwrap_or(u32::MAX)
+    }
+}
+
+#[cfg(not(nros_boot_report))]
+pub use disabled::*;
+
+/// No-op stubs, so call sites need no `cfg` of their own and an image that does
+/// not opt in is byte-identical.
+#[cfg(not(nros_boot_report))]
+mod disabled {
+    use super::Stage;
+
+    #[inline(always)]
+    pub fn init() {}
+
+    #[inline(always)]
+    pub fn checkpoint(_stage: Stage) {}
+
+    #[inline(always)]
+    pub fn note_arena_capacity(_capacity: usize) {}
+
+    #[inline(always)]
+    pub fn note_alloc(_size: usize, _used_after: usize) {}
+
+    #[inline(always)]
+    pub fn note_alloc_failed(_size: usize, _shortfall: usize) {}
+}
+
+#[cfg(all(test, nros_boot_report))]
+mod tests {
+    use super::*;
+
+    /// The reader decodes fifteen u32s positionally, so the record must be
+    /// exactly that and nothing else -- no padding, no reordering.
+    ///
+    /// `size_of` on the TARGET, which is the half `check-boot-report-layout.py`
+    /// cannot see: that gate compares two source files, and this compares the
+    /// source against what the compiler actually laid out.
+    #[test]
+    fn the_record_is_fifteen_packed_u32s() {
+        assert_eq!(BootReport::struct_size(), 15 * 4);
+        assert_eq!(
+            core::mem::size_of::<BootReport>(),
+            15 * core::mem::size_of::<u32>(),
+            "the record grew padding; the reader decodes positionally"
+        );
+        assert_eq!(core::mem::align_of::<BootReport>(), 4);
+    }
+
+    /// The magic is written LAST, so finding it means the rest is valid.
+    ///
+    /// The reader leans on this to tell "the image died before it had an
+    /// executor" apart from "the dump is at the wrong address", and it can
+    /// only do so if the ordering actually holds.
+    #[test]
+    fn init_stamps_the_header_and_the_compiled_knobs() {
+        init();
+        let s = snapshot();
+        assert_eq!(s.magic, MAGIC);
+        assert_eq!(s.version, VERSION);
+        assert_eq!(s.struct_size, BootReport::struct_size());
+        assert_eq!(s.arena_size, crate::config::ARENA_SIZE as u32);
+        assert_eq!(s.max_cbs, crate::config::MAX_CBS as u32);
+        assert_eq!(s.max_nodes, crate::config::MAX_NODES as u32);
+        assert!(s.stage >= Stage::ReportReady as u32);
+    }
+
+    /// A late call on a re-entered path must not make the record claim LESS
+    /// progress than was actually made. The field's whole purpose is to be
+    /// believed about a boot that did not finish.
+    #[test]
+    fn a_checkpoint_never_goes_backwards() {
+        init();
+        checkpoint(Stage::FirstSpin);
+        assert_eq!(snapshot().stage, Stage::FirstSpin as u32);
+        checkpoint(Stage::ExecutorReady);
+        assert_eq!(
+            snapshot().stage,
+            Stage::FirstSpin as u32,
+            "an earlier stage overwrote a later one"
+        );
+    }
+
+    /// The FIRST failure is the one that explains the boot; a later one is a
+    /// consequence of it and must not overwrite the cause.
+    #[test]
+    fn the_first_alloc_failure_wins() {
+        init();
+        note_alloc_failed(100, 8);
+        note_alloc_failed(999, 512);
+        let s = snapshot();
+        assert_eq!(s.failed_alloc_size, 100);
+        assert_eq!(s.failed_alloc_shortfall, 8);
+    }
+
+    /// A value too large for the field must read as enormous, not as its low
+    /// half. A truncated 4 GiB reads as 0, which is the one wrong answer that
+    /// looks like a normal one.
+    #[test]
+    fn an_unrepresentable_size_saturates_rather_than_truncating() {
+        init();
+        note_arena_capacity(usize::MAX);
+        assert_eq!(snapshot().arena_capacity, u32::MAX);
+    }
+}

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1503,6 +1503,15 @@ impl<'s> Executor<'s> {
         if let Some(slot0) = sched_contexts.first_mut() {
             *slot0 = Some(super::sched_context::SchedContext::default());
         }
+        // phase-412 -- stamp the self-report before anything can fail. `init`
+        // is idempotent, so an image with two executors need not decide which
+        // one owns the record, and `note_arena_capacity` records the slice this
+        // executor was actually handed rather than the compiled constant: the
+        // arena's placement is the caller's choice (issue 0900), so the two can
+        // legitimately differ and the difference is worth seeing.
+        crate::boot_report::init();
+        crate::boot_report::note_arena_capacity(arena.len());
+        crate::boot_report::checkpoint(crate::boot_report::Stage::ExecutorReady);
         Self {
             // `assemble` is reached from session-only entry points that have no
             // config, so 0 is the floor rather than a choice; `open_in` and any
@@ -3953,9 +3962,11 @@ impl<'s> Executor<'s> {
                 self.arena_used,
                 self.arena.len(),
             );
+            crate::boot_report::note_alloc_failed(size, new_used - self.arena.len());
             return Err(NodeError::BufferTooSmall);
         }
         self.arena_used = new_used;
+        crate::boot_report::note_alloc(size, new_used);
         Ok(aligned_offset)
     }
 
@@ -3975,9 +3986,24 @@ impl<'s> Executor<'s> {
             (entry_offset + entry_size).next_multiple_of(core::mem::align_of::<u64>());
         let new_used = trailing_offset + trailing_bytes;
         if new_used > self.arena.len() {
+            // This path reported NOTHING until phase-412's self-report went in,
+            // while its sibling `arena_alloc` has named the knob since issue
+            // 0900. Half of arena exhaustion was therefore silent -- and it is
+            // the half carrying buffered subscriptions and action entries,
+            // which is what an island image actually allocates.
+            super::arena::report_arena_exhausted(
+                new_used - self.arena.len(),
+                self.arena_used,
+                self.arena.len(),
+            );
+            crate::boot_report::note_alloc_failed(
+                new_used - entry_offset,
+                new_used - self.arena.len(),
+            );
             return Err(NodeError::BufferTooSmall);
         }
         self.arena_used = new_used;
+        crate::boot_report::note_alloc(new_used - entry_offset, new_used);
         Ok((entry_offset, trailing_offset))
     }
 
@@ -6024,6 +6050,11 @@ impl<'s> Executor<'s> {
         // registered. First spin rather than "end of registration", because
         // there is no such point: an app may register lazily.
         super::arena::maybe_report_arena_headroom(self.arena_used, self.arena.len());
+
+        // phase-412 -- the same moment, recorded where a board with no log sink
+        // can still be asked. Reaching this stage is the positive result the
+        // advisory above cannot deliver on the island: registration completed.
+        crate::boot_report::checkpoint(crate::boot_report::Stage::FirstSpin);
 
         // Phase 110.0 — cap against the backend's next internal-event
         // deadline (lease keepalive, heartbeat, ACK-NACK timeout, ...).

--- a/packages/core/nros-node/src/lib.rs
+++ b/packages/core/nros-node/src/lib.rs
@@ -84,6 +84,8 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+/// phase-412 -- the boot self-report, for boards with no reachable log sink.
+pub mod boot_report;
 pub mod c_waker;
 pub mod config;
 /// RFC-0088 / phase-421 W1 — the compile-time message-format check.

--- a/scripts/check-boot-report-layout.py
+++ b/scripts/check-boot-report-layout.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""The boot report's Rust layout and its Python decoder must agree.
+
+phase-412. `scripts/read-boot-report.py` decodes a memory dump positionally --
+fifteen little-endian u32s in a fixed order. Nothing in either language forces
+that order to match `BootReport` in
+`packages/core/nros-node/src/boot_report.rs`, and a mismatch does not fail: it
+DECODES, and prints an arena size that is really a callback count.
+
+That is the failure mode this gate exists for. A wrong number that looks like a
+number is worse than no number, and this record's whole purpose is to be
+believed about a board that cannot otherwise be asked.
+
+Checked here:
+
+* the struct's field order equals the script's `FIELDS`
+* `Snapshot`, which the Rust tests read through, has the same order again --
+  so a test asserting on the record exercises the layout the script assumes
+* `MAGIC` and `VERSION` are the same constants on both sides
+
+Not checked here: the size the RECORD reports at runtime. That comes from
+`size_of` on the target and is asserted by the Rust test, which is the only
+side that can see it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RUST = REPO / "packages/core/nros-node/src/boot_report.rs"
+PY = REPO / "scripts/read-boot-report.py"
+
+
+def fail(msg: str) -> int:
+    print(f"check-boot-report-layout: {msg}", file=sys.stderr)
+    return 1
+
+
+def rust_struct_fields(text: str, name: str, ty: str) -> list[str]:
+    """Field names of `struct <name>`, in declaration order."""
+    m = re.search(rf"\n\s*pub struct {name} \{{\n(.*?)\n\s*\}}\n", text, re.S)
+    if not m:
+        raise SystemExit(f"{RUST}: no `pub struct {name}` found")
+    fields = []
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("//") or line.startswith("///"):
+            continue
+        fm = re.match(rf"(?:pub )?([a-z_][a-z0-9_]*): {re.escape(ty)},", line)
+        if fm:
+            fields.append(fm.group(1))
+    return fields
+
+
+def py_fields(text: str) -> list[str]:
+    m = re.search(r"\nFIELDS = \(\n(.*?)\n\)\n", text, re.S)
+    if not m:
+        raise SystemExit(f"{PY}: no `FIELDS` tuple found")
+    return re.findall(r'"([a-z_][a-z0-9_]*)"', m.group(1))
+
+
+def const_u32(text: str, name: str) -> int:
+    m = re.search(rf"\npub const {name}: u32 = (0x[0-9a-fA-F_]+|\d+);", text)
+    if not m:
+        raise SystemExit(f"{RUST}: no `pub const {name}: u32` found")
+    return int(m.group(1).replace("_", ""), 0)
+
+
+def py_const(text: str, name: str) -> int:
+    m = re.search(rf"\n{name} = (0x[0-9a-fA-F]+|\d+)\n", text)
+    if not m:
+        raise SystemExit(f"{PY}: no `{name}` found")
+    return int(m.group(1), 0)
+
+
+def diff(
+    label: str,
+    a: list[str],
+    b: list[str],
+    a_name: str,
+    b_name: str,
+    quiet: bool = False,
+) -> int:
+    """Compare two field orders. `quiet` suppresses the report, for the
+    selftest's deliberate mismatches -- printing those on a PASSING run
+    would train a reader to skip exactly the output that matters."""
+    if a == b:
+        return 0
+    if quiet:
+        return 1
+    rc = fail(f"{label}: {a_name} and {b_name} disagree")
+    for i, (x, y) in enumerate(zip(a, b)):
+        if x != y:
+            print(f"  word {i}: {a_name} has `{x}`, {b_name} has `{y}`", file=sys.stderr)
+    if len(a) != len(b):
+        print(
+            f"  {a_name} has {len(a)} fields, {b_name} has {len(b)}: "
+            f"extra {sorted(set(a) ^ set(b))}",
+            file=sys.stderr,
+        )
+    return rc
+
+
+def main() -> int:
+    rust = RUST.read_text()
+    py = PY.read_text()
+
+    record = rust_struct_fields(rust, "BootReport", "AtomicU32")
+    snapshot = rust_struct_fields(rust, "Snapshot", "u32")
+    script = py_fields(py)
+
+    if not record:
+        return fail("parsed zero fields out of `BootReport` -- the gate is blind")
+
+    rc = 0
+    rc |= diff("record vs decoder", record, script, "BootReport", "read-boot-report.py")
+    rc |= diff("record vs snapshot", record, snapshot, "BootReport", "Snapshot")
+
+    for name, py_name in (("MAGIC", "MAGIC"), ("VERSION", "KNOWN_VERSION")):
+        r = const_u32(rust, name)
+        p = py_const(py, py_name)
+        if r != p:
+            rc |= fail(f"{name}: boot_report.rs has {r:#x}, read-boot-report.py has {p:#x}")
+
+    if rc == 0:
+        print(
+            f"check-boot-report-layout: OK ({len(record)} fields, "
+            f"{len(record) * 4} bytes, agreed by BootReport, Snapshot and the decoder)"
+        )
+    return rc
+
+
+def self_test() -> int:
+    """Negative controls: the gate must FAIL on each drift it exists to catch.
+
+    Run on the normal path, not behind a flag. A gate that only ever sees the
+    agreeing case reports OK for both reasons -- because the files agree, and
+    because it stopped being able to tell.
+    """
+    ok = True
+
+    def expect(name: str, got, want) -> None:
+        nonlocal ok
+        if got != want:
+            ok = False
+            print(f"  self-test FAIL {name}: {got!r} != {want!r}")
+
+    rust = RUST.read_text()
+    py = PY.read_text()
+    record = rust_struct_fields(rust, "BootReport", "AtomicU32")
+    snapshot = rust_struct_fields(rust, "Snapshot", "u32")
+    script = py_fields(py)
+
+    # The parsers must actually find something. A regex that silently matches
+    # nothing turns every comparison below into `[] == []`, which passes.
+    expect("parses the record", len(record) > 5, True)
+    expect("parses the snapshot", len(snapshot) > 5, True)
+    expect("parses the decoder", len(script) > 5, True)
+
+    # Reordering two words is the drift that DECODES rather than failing, and
+    # so is the whole reason this gate exists.
+    swapped = list(script)
+    swapped[0], swapped[1] = swapped[1], swapped[0]
+    expect("catches a reorder", diff("t", record, swapped, "a", "b", quiet=True) != 0, True)
+
+    # A field added on one side only.
+    expect("catches a missing field", diff("t", record, script[:-1], "a", "b", quiet=True) != 0, True)
+
+    # And the agreeing case must still pass, or the gate fails everything.
+    expect("passes when they agree", diff("t", record, script, "a", "b", quiet=True), 0)
+
+    print("check-boot-report-layout --self-test: " + ("OK" if ok else "FAILED"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    # The selftest runs on the NORMAL path -- a negative control nobody runs
+    # decays into a comment, which is what `check-gate-selftests` enforces.
+    rc = self_test()
+    sys.exit(rc if rc or "--self-test" in sys.argv else main())

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -91,6 +91,7 @@ KNOB_CLASS = {
     # "unresolved" hatch would make one variable mean two different
     # judgements, and a user silencing one would silence the other.
     "NROS_ALLOW_INFRA_DEPS": ("infra", "policy flag"),
+    "NROS_BOOT_REPORT": ("infra", "diagnostic toggle; a bool, so it has no rung"),
     "NROS_BUILD_ROOT": ("infra", "path"),
     "NROS_CARGO_FLAGS": ("infra", "the --locked shim"),
     "NROS_LINK_IP": ("infra", "link toggle"),

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Decode the nano-ros boot self-report out of a target memory dump.
+
+phase-412. The image writes a fixed record about itself into RAM
+(`packages/core/nros-node/src/boot_report.rs`); this reads it back after the
+core has been halted. See that module for WHY the record is not a log stream:
+the failure it exists to catch halts the board during entity creation, before
+any advisory can print, on a board whose console UART is not wired.
+
+Two inputs, and the ELF is not optional: the record's address is resolved from
+the image's own symbol table rather than hard-coded, so a relinked image cannot
+be read at a stale address and silently decode as garbage.
+
+    pyocd commander -t s32k344 -c halt -c "savemem ADDR LEN report.bin"
+    python3 scripts/read-boot-report.py build/zephyr/zephyr.elf report.bin
+
+`--addr-only` prints the address and length for that savemem line, so the two
+steps can be scripted without anyone copying a hex number by hand:
+
+    read $(python3 scripts/read-boot-report.py --addr-only build/zephyr/zephyr.elf)
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+SYMBOL = "NROS_BOOT_REPORT"
+
+# "NRSR". Must match boot_report.rs MAGIC.
+MAGIC = 0x4E525352
+# Layout this script knows how to decode. Must match boot_report.rs VERSION.
+KNOWN_VERSION = 1
+
+# Field order, matching `BootReport` and `Snapshot` in boot_report.rs. Every
+# field is a u32; the record is all `AtomicU32`, which is repr(transparent).
+FIELDS = (
+    "magic",
+    "version",
+    "struct_size",
+    "stage",
+    "arena_size",
+    "max_cbs",
+    "max_sc",
+    "max_nodes",
+    "default_rx_buf_size",
+    "arena_capacity",
+    "arena_used",
+    "alloc_count",
+    "last_alloc_size",
+    "failed_alloc_size",
+    "failed_alloc_shortfall",
+)
+
+STAGES = {
+    0: "Untouched -- the image never reached boot_report::init()",
+    1: "ReportReady -- record stamped; executor not constructed",
+    2: "ExecutorReady -- arena bound",
+    3: "RegisteringEntities -- entity creation begun, NOT finished",
+    4: "EntitiesReady -- every declared entity registered",
+    5: "FirstSpin -- registration complete and spinning",
+}
+
+
+def resolve_symbol(elf: Path) -> tuple[int, int]:
+    """Address and size of the record, from the ELF's symbol table.
+
+    `nm` rather than a parser, because every toolchain that produced one of
+    these images ships one, and the alternative is another dependency on the
+    host side of a debugging tool.
+    """
+    for tool in ("nm", "arm-zephyr-eabi-nm", "arm-none-eabi-nm", "llvm-nm"):
+        try:
+            out = subprocess.run(
+                [tool, "-S", "--defined-only", str(elf)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            continue
+        if out.returncode != 0:
+            continue
+        for line in out.stdout.splitlines():
+            parts = line.split()
+            # "<addr> <size> <type> <name>" -- the size column is why -S.
+            if len(parts) == 4 and parts[3] == SYMBOL:
+                return int(parts[0], 16), int(parts[1], 16)
+        # The tool worked and the symbol is not there. Say so rather than
+        # trying the next tool and blaming its absence.
+        raise SystemExit(
+            f"{elf}: no `{SYMBOL}` symbol.\n"
+            "The image was built WITHOUT the boot report. Rebuild with\n"
+            "  NROS_BOOT_REPORT=1        (Zephyr: CONFIG_NROS_BOOT_REPORT=y)"
+        )
+    raise SystemExit("no usable `nm` found (tried nm, arm-zephyr-eabi-nm, llvm-nm)")
+
+
+def decode(blob: bytes) -> dict[str, int]:
+    want = len(FIELDS) * 4
+    if len(blob) < want:
+        raise SystemExit(
+            f"dump is {len(blob)} bytes, need at least {want} for one record"
+        )
+    values = struct.unpack_from(f"<{len(FIELDS)}I", blob, 0)
+    return dict(zip(FIELDS, values, strict=True))
+
+
+def report(rec: dict[str, int]) -> int:
+    """Print the record. Returns the process exit code."""
+    if rec["magic"] != MAGIC:
+        print(
+            f"NO RECORD: magic is 0x{rec['magic']:08x}, expected 0x{MAGIC:08x}.\n"
+            "\n"
+            "The magic is written LAST by boot_report::init(), so this means the\n"
+            "image did not get as far as constructing an Executor -- not that the\n"
+            "dump is at the wrong address, which the ELF lookup already ruled out.\n"
+            "An image that halted even earlier than that is itself the finding.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if rec["version"] != KNOWN_VERSION:
+        print(
+            f"record version {rec['version']}, this script decodes {KNOWN_VERSION}.\n"
+            "Refusing to decode rather than misreading it -- update this script.",
+            file=sys.stderr,
+        )
+        return 2
+
+    expect = len(FIELDS) * 4
+    if rec["struct_size"] != expect:
+        print(
+            f"record says {rec['struct_size']} bytes, this script expects {expect}.\n"
+            "Same version, different layout: one side changed a field without\n"
+            "bumping VERSION.",
+            file=sys.stderr,
+        )
+        return 2
+
+    stage = rec["stage"]
+    print(f"stage      {stage}  {STAGES.get(stage, 'UNKNOWN -- newer image than this script')}")
+    print()
+    print("compiled in (compare against what the build believed it delivered):")
+    print(f"  NROS_EXECUTOR_ARENA_SIZE      {rec['arena_size']}")
+    print(f"  NROS_EXECUTOR_MAX_CBS         {rec['max_cbs']}")
+    print(f"  NROS_EXECUTOR_MAX_SC          {rec['max_sc']}")
+    print(f"  NROS_EXECUTOR_MAX_NODES       {rec['max_nodes']}")
+    print(f"  NROS_SUBSCRIPTION_BUFFER_SIZE {rec['default_rx_buf_size']}")
+    print()
+    print("measured on the board:")
+    cap = rec["arena_capacity"]
+    used = rec["arena_used"]
+    print(f"  arena capacity                {cap}")
+    print(f"  arena used                    {used}", end="")
+    if cap:
+        print(f"   ({100.0 * used / cap:.1f}%)")
+    else:
+        print()
+    print(f"  arena allocations             {rec['alloc_count']}")
+    print(f"  last allocation               {rec['last_alloc_size']} bytes")
+
+    if cap and cap != rec["arena_size"]:
+        print()
+        print(
+            f"  NOTE: the executor was handed {cap} bytes but the image compiled\n"
+            f"  {rec['arena_size']}. Both are legitimate -- the arena's placement is the\n"
+            "  caller's choice (issue 0900) -- but size against the one in use."
+        )
+
+    if rec["failed_alloc_size"]:
+        print()
+        print(
+            f"ARENA EXHAUSTED: an allocation of {rec['failed_alloc_size']} bytes did not fit,\n"
+            f"short by {rec['failed_alloc_shortfall']} bytes.\n"
+            "\n"
+            f"  set NROS_EXECUTOR_ARENA_SIZE >= {cap + rec['failed_alloc_shortfall']}\n"
+            "  (Zephyr: CONFIG_NROS_EXECUTOR_ARENA_SIZE)\n"
+            "\n"
+            "That is the FIRST failure, which is the one that explains the boot;\n"
+            "later allocations may also have failed as a consequence."
+        )
+        return 1
+
+    if stage < 4:
+        print()
+        print(
+            "Registration did NOT complete, and the arena is not why.\n"
+            "Look for a pool count instead: a full pool fails at registration\n"
+            "with ExecutorFull rather than in the arena."
+        )
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Decode the nano-ros boot self-report out of a target memory dump."
+    )
+    ap.add_argument("elf", type=Path, help="the image the board is running")
+    ap.add_argument("dump", type=Path, nargs="?", help="memory dumped from the target")
+    ap.add_argument(
+        "--addr-only",
+        action="store_true",
+        help="print '<addr> <len>' for a pyocd savemem line, and exit",
+    )
+    args = ap.parse_args()
+
+    if not args.elf.is_file():
+        raise SystemExit(f"{args.elf}: not a file")
+
+    addr, size = resolve_symbol(args.elf)
+    if args.addr_only:
+        print(f"0x{addr:08x} {size}")
+        return 0
+
+    if args.dump is None:
+        ap.error("a dump is required unless --addr-only is given")
+    if not args.dump.is_file():
+        raise SystemExit(f"{args.dump}: not a file")
+
+    return report(decode(args.dump.read_bytes()))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1075,6 +1075,29 @@ config NROS_SUBSCRIPTION_BUFFER_SIZE
       NROS_EXECUTOR_ARENA_SIZE must move the two together; leaving both to
       derive is the shape that cannot disagree.
 
+config NROS_BOOT_REPORT
+    bool "Write a boot self-report into RAM"
+    default n
+    help
+      The image keeps a fixed 60-byte record in RAM describing itself: the
+      knobs it was COMPILED with, how far boot got, and the arena allocation
+      that did not fit. Read it back with a debugger after halting the core:
+
+        python3 scripts/read-boot-report.py build/zephyr/zephyr.elf dump.bin
+
+      For boards where no log sink reaches a human. On the MR-CANHUBK344 the
+      console UART is not wired and the second UART carries the zenoh serial
+      transport, so both of issue 0900's arena diagnostics -- the two messages
+      written specifically to explain an arena failure -- go nowhere.
+
+      Unlike a log, this survives the failure it reports. An under-sized arena
+      halts DURING entity creation, before the first spin, so the advisory
+      never prints; the record's last stage and failed allocation are still
+      there to be read.
+
+      OFF by default: an image that does not enable it is byte-identical to one
+      built before the feature existed.
+
 config NROS_EXECUTOR_MAX_SC
     int "Maximum scheduling-context slots per executor"
     default 8

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -721,6 +721,17 @@ function(nros_set_cargo_env_from_kconfig)
         set(ENV{${_knob}} "${NROS_RESOLVED_${_knob}}")
     endforeach()
 
+    # phase-412 -- the boot self-report. A BOOL, so it is exported directly
+    # rather than through the resolve ladder above: that machinery exists to
+    # carry a tri-state (env > Kconfig > derived, with -1 and 0 as sentinels for
+    # "derive it"), and a bool has no derive state to represent. Passing it
+    # through would mean inventing a third meaning for a sentinel, which is the
+    # shape that has already produced three double-resolution defects in this
+    # file.
+    if(CONFIG_NROS_BOOT_REPORT)
+        set(ENV{NROS_BOOT_REPORT} "1")
+    endif()
+
     if(CONFIG_NROS_RMW_ZENOH)
         # zpico-sys build.rs needs the nros-platform-cffi header dir. In-tree dev
         # gets it from .env/direnv; set it from the known module path so a


### PR DESCRIPTION
phase-412 derived six pool counts and the executor arena for the mr-canhubk344
island, and then could not tell whether the derived image was correct. The only
signal was the ROS graph's node count, and one unchanged configuration produced
4, 0, 0, 4, 4 across five runs. Three hypotheses were raised during the bisect
and each disproved by measurement -- the arena, MAX_CBS, and a printk sink of
my own. None of those retractions was caused by reasoning badly; they were
caused by reasoning against a 60% instrument.

## Why not a log

Every other channel on that board was already out:

| channel | why not |
| --- | --- |
| console UART | lpuart0, not wired on the MR-CANHUBK344 |
| second UART | lpuart2 carries the zenoh serial transport |
| nros_log | therefore reaches nothing, including BOTH of issue 0900's arena diagnostics |
| SEGGER RTT | tried; could not discriminate. Working and derived images both printed only the Zephyr banner, and a deliberate positive control produced nothing |
| semihosting | halts the core until a probe answers, and faults with none attached |

Those are all STREAMS: they need the board still running and somebody attached
when the interesting thing happens. The failure being chased is the opposite
shape -- an under-sized arena halts DURING entity creation, before the first
spin, so the advisory that would explain it never runs.

## What this is

A fixed 60-byte record in RAM. Fifteen AtomicU32s: the header, the stage boot
reached, the knobs the image was COMPILED with, and the arena allocation that
did not fit. Read back by halting the core and dumping memory, with the address
resolved from the ELF's symbol table so a relinked image cannot be read at a
stale one.

    NROS_BOOT_REPORT=1        (Zephyr: CONFIG_NROS_BOOT_REPORT=y)
    python3 scripts/read-boot-report.py build/zephyr/zephyr.elf dump.bin

A PARTIAL record is the useful case rather than a lost one. That is the whole
difference from a log.

The compile-time half is what the campaign needed most: W4's
check-knob-delivery.py asserts the number reaching the compiler equals the
number the resolver decided, read from build.ninja. This asserts the same
identity one step further along, from the silicon.

Opt-in, so an image that does not enable it is byte-identical to one built
before this existed -- the rule issue 0900's arena knob keeps.

## Found on the way

Issue 1036. `arena_alloc_with_trailing` reported NOTHING on failure, while its
sibling `arena_alloc` has named the knob since issue 0900. Half of arena
exhaustion was silent, and it is the half carrying buffered subscriptions and
action entries -- what an island image actually allocates. Fixed here.

## Verification

- 191/191 fast gates green, including the new `boot-report-layout`
- 5 unit tests under the cfg: layout is 15 packed u32s with no padding, init
  stamps the compiled knobs, a checkpoint never goes backwards, the first alloc
  failure wins, an unrepresentable size saturates rather than truncating
- the new gate runs its own negative controls on the normal path, and was
  confirmed to exit 1 on a field reorder and on a drifted MAGIC

## What this does NOT settle

No cell builds an image with the record on, exhausts its arena on purpose, and
asserts the dump names the shortfall. The instrument is verified in every part
except the one that runs on silicon, which is the same shape as the defect it
exists to find. Filed in issue 1036 rather than claimed here.

The island .conf stays pinned to hand-set values. This PR is the instrument;
unpinning against it is the next wave.