### PR TITLE
ci(gate): cache the launch-resolver's target dir — 11% of every merge group

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -406,11 +406,28 @@ jobs:
       # this saves 79 s of a ~5 min gate, and `check-fast` is buildless and
       # source-free by construction (its CLI-touching gates skip gracefully
       # when the CLI is absent).
+      # BOTH target dirs — phase-413.
+      #
+      # `nros-launch-resolve` is its OWN cargo workspace (deliberately: the
+      # justfile comment says its dependency graph stays separate from the main
+      # CLI's), so it builds into `packages/cli/nros-launch-resolve/target` and
+      # this cache — pointed only at `packages/cli/target` — never saw it. It
+      # was recompiled from scratch on every merge group.
+      #
+      # MEASURED on run 33834957224, a successful `merge_group` gate totalling
+      # 20.4 min: "Build nros-launch-resolve" was 2.22 min of it, 11%, spent
+      # rebuilding something whose sources had not changed. It exists solely so
+      # `check cli-tests` can shell out to it.
+      #
+      # The key already hashes `packages/cli/**`, which covers this crate's
+      # sources, so a change to it still invalidates the entry.
       - name: Cache CLI build (compile tier)
         if: ${{ contains(fromJSON('["pull_request","merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
         uses: actions/cache@v4
         with:
-          path: packages/cli/target
+          path: |
+            packages/cli/target
+            packages/cli/nros-launch-resolve/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
           restore-keys: |
             nros-cli-${{ runner.os }}-


### PR DESCRIPTION
You are right that `gate` should be fast — it is the merge-blocking lane and the only one everyone pays. Measured first.

## Where the 20 minutes go

`gate` on `merge_group`: **20.0 min median** (n=16, 12.1–20.9). Run `33834957224`, a successful one totalling 20.4 min:

```
6.50m  just check cli-tests
3.52m  just check fast
3.47m  just test-unit
2.22m  Build nros-launch-resolve      <-- this PR
1.52m  Build nros CLI + provision
1.17m  Initialize containers
0.78m  just check submodule-commits-reachable
```

(For contrast: `nightly`, `queue` and `build-wide` are long **by design** — they build and run. `gate` only checks.)

## This change

`nros-launch-resolve` is its **own cargo workspace** — deliberately, so its dependency graph stays separate from the CLI — so it builds into `packages/cli/nros-launch-resolve/target`. The cache pointed only at `packages/cli/target` and never saw it, so the crate was recompiled from scratch on every merge group, for sources that had not changed. It exists solely so `check cli-tests` can shell out to it.

The cache key already hashes `packages/cli/**`, which covers this crate, so editing it still invalidates the entry. No coverage change — the same step runs, it just stops paying for a rebuild it does not need.

## The bigger number, deliberately not in this PR

`cli-tests` **+ this build = 8.7 min of 20.4, 43% of the gate** — and every step runs **sequentially in one job**. Splitting `cli-tests` into a parallel job would make wall-clock roughly `max(component) + setup` instead of the sum, plausibly ~11 min.

That changes the shape of the required check, and a required context that stops reporting **freezes the queue** — issue 0975, which deadlocked this repo for exactly that reason. It wants its own change and its own review rather than being smuggled in behind a cache fix.

Gates green: workflow-repo-env, ci-no-verb-fallback, required-contexts-reportable, workflow-indexed-apt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)