### PR TITLE
docs(#1038, phase-413 W2.3): nightly triage — three cells, one class, no regressions

### DIFF
--- a/docs/issues/1038-nightly-job-does-not-provision-its-lane.md
+++ b/docs/issues/1038-nightly-job-does-not-provision-its-lane.md
@@ -1,0 +1,158 @@
+---
+id: 1038
+title: "nightly triage (phase-413 W2.3): three of six cell failures are one class — the platform job builds a lane whose prerequisites its own setup never installs; none is a product regression"
+status: open
+area: ci, build, testing
+severity: medium
+found: 2026-09-04
+related: [1030, 0463, 0937, 1006, 1007, 0996, phase-413, RFC-0062]
+---
+
+# The job does not provide what its own lane consumes
+
+**Filed under phase-413 W2 item 3**, which owns exactly this — *"`nightly` —
+failure ×4 … use `just nightly-triage`"* — and whose acceptance says *"A lane
+that cannot be made green is a finding, not a skip — file it."* This is that
+finding. Nothing here proposes a new mechanism; each instance maps to a wave
+that already owns its fix.
+
+Triage of nightly run `33831829557` (dispatched 2026-09-04T03:04Z against a
+current tree, deliberately — the previous run predated #245 and its `nuttx`
+cell was reproducing a fixed bug). Six failing jobs, **zero product
+regressions**. Three share one cause.
+
+## The class
+
+`nightly.yml`'s `platform` job runs, in order:
+
+    just ${{ matrix.plat }} setup
+    nros setup --source px4-rs --source nuttx-libc
+    just ${{ matrix.plat }} build-all
+
+`build-all` reaches artifacts that neither `setup` step installs. Each instance
+then fails in the vocabulary of whatever it reached first, which is why they
+read as three unrelated bugs.
+
+### 1. `nuttx` — a cross toolchain
+
+```
+NROS_LANE_NAMED_FAIL: nuttx: riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)
+error: you named `nuttx`, so this is a FAILURE, not a skip.
+```
+
+The arm leaves built; the riscv ones need a toolchain `just nuttx setup` does
+not install. **The lane behaved correctly** — phase-411's named-platform rule
+fired exactly as designed, loudly and at the point of decision. The defect is
+upstream of it.
+
+### 2. `threadx_riscv64` — a generated cargo config
+
+```
+error: failed to parse manifest at `examples/qemu-riscv64-threadx/rust/talker/Cargo.toml`
+Caused by: could not load Cargo configuration
+Caused by: failed to load config include `../../../../../nros-patch.toml`
+```
+
+Issue 0463 verbatim, and worth restating because it does not look like a
+provisioning failure: the leaf's TRACKED `.cargo/config.toml` includes the
+central `nros-patch.toml`, which is generated and gitignored. A missing
+`include` target is a hard cargo error during MANIFEST PARSE, four frames deep,
+naming neither `nros sync` nor the leaf. The job never runs sync or `_codegen`.
+
+The same job logged the softer form of the same gap dozens of times:
+
+```
+nros build: warning: no selection facade at .../generated/nros-selection/nuttx_entry
+  — building `nuttx` without its RMW and ROS edition. Run `nros sync` first (issue 0937).
+```
+
+A warning where the leaf tolerates it, a hard parse error where it does not.
+
+### 3. `esp32` — apt packages for a source build
+
+```
+nros setup: 1 package(s) have no prebuilt for linux-x86_64 — BUILDING FROM SOURCE: esp32-qemu
+Error: nros setup --tool esp32-qemu: needs 3 system package(s) this host is
+missing: libglib2-dev, libpixman-dev, libgcrypt-dev.
+```
+
+Adjacent to issue 1006 but not the same: 1006 is about esp32-qemu's RUNTIME
+dependency set being a property of the machine that built it; this is a BUILD
+prerequisite absent from the container image. Related work is in flight
+(phase-413 W3 — the index as SSoT for OS packages).
+
+## Where each fix already lives
+
+**esp32 is not a missing mechanism — it is W3's conversion, unapplied.** The
+index ALREADY declares all three packages, twice over: as `[prereq.libglib2-dev]`
+/ `[prereq.libpixman-dev]` / `[prereq.libgcrypt-dev]` with apt mappings and
+`pkg_config` probes, and in `[tool.esp32-qemu]`'s own `system = [...]` list. The
+error names them *because the index knows them*. `nros setup --system` resolves
+that closure (RFC-0062 / phase-327; measured 38 present, 5 missing on a dev
+host). The nightly job never runs it.
+
+Phase-413 W3 is written as *"no workflow installs what the index already
+declares"* and converts `docs.yml` and `nightly.yml`'s clang step to
+`nros setup --system --sudo`. This is the same conversion, one step over: the
+workflow installs nothing, and the thing it does not install is indexed.
+
+**Checked against the gate as IMPLEMENTED, not as specified**
+(`scripts/check-workflow-indexed-apt.py`, landed 2026-09-04): it matches
+`apt(-get)? install` lines and refuses one that names a `[prereq.*].apt`
+package. That is duplication — a workflow restating the index — and it is the
+right rule. It has no way to express the opposite, and this site apt-installs
+nothing at all, so the gate is silent here by construction. Widening W3's
+acceptance to cover omission is a separate decision for whoever owns the wave.
+
+**nuttx and threadx_riscv64 are W2's "fix the lane" work**, and both are one
+missing invocation rather than a design gap: `nros setup qemu-riscv-nuttx` for
+the toolchain (the failure text names the exact command), and a sync/`_codegen`
+step for the leaves whose tracked `.cargo/config.toml` includes a generated file.
+
+**None of this is W6.** W6 (rosdep parity — `package.xml` as the dependency SSoT)
+is explicitly RFC-first and *"must not be started as an implementation task"*.
+It is the right long-term home for "a workspace states its own needs", and it
+would subsume the per-lane knowledge these three failures encode. It does not
+need to land for any of the three to be fixed, and none of them should be used
+to justify starting it early.
+
+## The gate boundary, stated
+
+Issue 1030 gated the adjacent shape — a workflow step whose events do not cover
+its consumers' — by reading the justfile's own dependency ORDER
+(`_codegen: setup-launch-resolve generate-bindings …`). None of the three above
+is declared that way: they are `nros setup --tool` / `--system` invocations and a
+missing sync, and the justfile orders none of them before `build-all`. That rule
+reports how little it covers (1 invocation today), which is what makes this
+boundary measurable rather than a surprise. Widening it is a candidate, not a
+proposal — `required_producers` already reads a recipe's hard-failing remediation
+text, and `run: nros setup qemu-riscv-nuttx` is exactly that shape in a different
+spelling. Whether that belongs here or inside W6's scope resolution is W6's
+question to answer, not this issue's.
+
+## The other three failures, for completeness
+
+* **`freertos`** and **`threadx_linux`**: `Real failures: 0 / 0`. All 9 e2e
+  cases skipped on an unmet precondition, and `_check-skip-budget` correctly
+  refused to call that a pass ("This lane verified nothing"). The skip reason is
+  TRUNCATED at the same column in both the log and the junit
+  (`[SKIPPED] freertos:`), so it was traced in source instead: all nine skip at
+  `rtos_e2e.rs:514` via `require_e2e()`, and the only precondition the two
+  platforms share is `zenohd_unavailable_reason()`. Both jobs do
+  `source /opt/ros/humble/setup.bash`.
+
+  **UNCONFIRMED**: the leading hypothesis is that the humble CI image lacks
+  `ros-humble-rmw-zenoh-cpp` — RFC-0075 says we ship no router, and
+  `rmw_zenohd` is invisible to `command -v` even when installed. Settle it by
+  checking the image for that package, or by running the cell with
+  `NROS_RMW_ZENOHD` set. Every other `require_e2e` branch for these two names
+  env or directories the build step already proved present. This is filed as a
+  hypothesis, not a diagnosis.
+
+  Worth noting separately: a skip message that carries the remedy is useless if
+  the transport truncates it. Both artifacts cut it at the colon.
+
+* **`tier 2 nightly`**: three fixture families missing `.inputsig` on the
+  self-hosted runner; `_lane-gate` refused. Runner state, not code. It did get
+  PAST `runner-doctor` this run — the label failure that killed it on
+  2026-09-03 is gone.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -92,5 +92,6 @@ fails if this block drifts.
 - **#1025** (build, testing) — ESP32 flash images can never be built: the packer asks for the group dir with the row's env stripped, so it looks in a directory the build stopped using See `1025-*`.
 - **#1028** ([rmw, memory, build]) — NuttX is classified `hosted` because its `target_os` is not `\"none\"`, so it takes the Linux 32-queryable budget: 142,336 B of `.bss` in an image with zero queryables See `1028-*`.
 - **#1034** (testing, tooling) — The provisioned QEMU 11 spends ~19.6 s materialising a NuttX image's `.bss` before the guest runs, and that stall is the whole C-vs-C++ asymmetry in issue 0870 See `1034-*`.
+- **#1038** (ci, build, testing) — nightly triage (phase-413 W2.3): three of six cell failures are one class — the platform job builds a lane whose prerequisites its own setup never installs; none is a product regression See `1038-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -81,6 +81,35 @@ conversion can be verified in a lane that is already red.
    detail in the log summary. Needs a real diagnosis before it can be trusted.
 3. **`nightly`** — failure ×4. `just nightly-triage` classifies by which STEP
    failed and flags cells red across a window; use it rather than reading runs.
+
+   **Triaged 2026-09-04 against run `33831829557`** (dispatched deliberately —
+   the scheduled run predated #245 and its `nuttx` cell was reproducing a fixed
+   bug, which is the issue-0859 trap). Six failing jobs, **zero product
+   regressions**; details in issue 1038. Three are one class — the job builds a
+   lane whose prerequisites its own `setup` never installs:
+
+   | cell | first thing it reached | owner |
+   | --- | --- | --- |
+   | `nuttx` | `riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)` | this wave |
+   | `threadx_riscv64` | cargo manifest-parse: missing `include` of the generated `nros-patch.toml` (issue 0463) | this wave |
+   | `esp32` | `esp32-qemu` source build needs `libglib2-dev`, `libpixman-dev`, `libgcrypt-dev` | **W3** |
+
+   `esp32` is W3's conversion unapplied rather than a missing mechanism: the
+   index declares all three as `[prereq.*]` AND in `[tool.esp32-qemu]`'s own
+   `system = [...]`, so `nros setup --system` already resolves them. Checked
+   against the gate as IMPLEMENTED (`check-workflow-indexed-apt.py`), not as
+   specified: it matches `apt(-get)? install` lines naming a `[prereq.*].apt`
+   package, which is duplication and is the right rule — but this site installs
+   nothing at all, so the gate is silent here by construction. Whether W3's
+   acceptance should also cover OMISSION is a decision for this wave's owner.
+
+   The other three cells are not conversions: `freertos` and `threadx_linux`
+   report `Real failures: 0 / 0` with all 9 e2e cases skipped on one shared
+   precondition (`_check-skip-budget` correctly refusing to call that a pass),
+   and `tier 2 nightly` is runner state (three fixture families missing
+   `.inputsig`). The `freertos`/`threadx_linux` skip reason is TRUNCATED in both
+   the log and the junit, so the cause is a hypothesis, not a diagnosis — see
+   1038 before acting on it.
 4. **`build-wide`** — expected to go green with W1/0992; if it does not, its
    remaining failure is now visible rather than buried under the include
    preflight.


### PR DESCRIPTION
Phase-413 W2 item 3 asks for `nightly` to be diagnosed, and its acceptance says *"a lane that cannot be made green is a finding, not a skip — file it."* This is that finding, filed under the wave that owns it rather than as a new class claim.

## Method note

Triaged against run `33831829557`, **dispatched deliberately**. The scheduled run predated #245 by 1h46m and its `nuttx` cell was reproducing a bug that fix had already closed — the issue-0859 trap. Six failing jobs, **zero product regressions**.

## Three cells, one class

The platform job runs `just <plat> setup`, then `build-all` reaches artifacts neither setup step installs. Each fails in the vocabulary of whatever it hit first, which is why they read as three unrelated bugs.

| cell | first thing it reached | owner |
| --- | --- | --- |
| `nuttx` | `riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)` | W2 |
| `threadx_riscv64` | manifest-parse failure on a missing `include` of the generated `nros-patch.toml` (issue 0463) | W2 |
| `esp32` | `esp32-qemu` source build needs `libglib2-dev`, `libpixman-dev`, `libgcrypt-dev` | **W3** |

`nuttx` is worth stating precisely: **the lane behaved correctly.** phase-411's named-platform rule fired exactly as designed. The defect is upstream of it.

## esp32 reframes a W3 acceptance gap

Not a missing mechanism — W3's conversion unapplied. The index declares all three packages **twice**: as `[prereq.*]` with apt mappings and `pkg_config` probes, and in `[tool.esp32-qemu]`'s own `system = [...]`. `nros setup --system` already resolves that closure (RFC-0062 / phase-327). The error names them *because the index knows them*.

So W3's gate as specified would **not** catch this: it's written as "no workflow installs what the index already declares", and this site installs nothing at all. It catches duplication, not omission. Recorded in W3.

## Explicitly not W6

Rosdep parity is the right long-term home for "a workspace states its own needs", but W6 is RFC-first and says it must not be started as an implementation task. None of these three needs it to be fixed, and none should be used to justify starting it early.

## The other three

`freertos` and `threadx_linux`: `Real failures: 0 / 0`, all 9 e2e cases skipped on one shared precondition — `_check-skip-budget` correctly refusing to call that a pass. `tier 2 nightly`: runner state (three fixture families missing `.inputsig`); it got **past** `runner-doctor` this run, so 2026-09-03's label failure is gone.

The `freertos`/`threadx_linux` skip reason is truncated at the same column in **both** the log and the junit, so it was traced in source: all nine skip at `rtos_e2e.rs:514` via `require_e2e()`, and the only precondition those two platforms share is `zenohd_unavailable_reason()`. The leading hypothesis — the humble CI image lacking `ros-humble-rmw-zenoh-cpp` — is filed as a **hypothesis with the check that settles it**, not a diagnosis.

Side finding: a skip message that carries its own remedy is useless if the transport truncates it. Both artifacts cut it at the colon.

Docs only. `just check fast` 190/190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)