### PR TITLE
fix(#1011): NrosCdrBlob is an aggregate again, and one TU pins C++11 to keep it one

### DIFF
--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/nros_sertype.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/nros_sertype.hpp
@@ -51,9 +51,25 @@ namespace nros_rmw_cyclonedds {
 ///
 /// `dds_write(writer, &blob)` reaches `from_sample`, which copies the span into
 /// a serdata. The span only has to outlive that call.
+///
+/// **No default member initialisers, deliberately (issue 1011).** A class with
+/// NSDMIs is not an aggregate in C++11 -- C++14 relaxed exactly that rule -- and
+/// the Zephyr lane compiles this TU with `-std=c++11`. With `{nullptr}` / `{0}`
+/// here, `NrosCdrBlob{data, len}` stops being aggregate initialisation there and
+/// the compiler looks for a two-argument constructor that does not exist:
+///
+///     publisher.cpp:287: error: no matching function for call to
+///       'nros_rmw_cyclonedds::NrosCdrBlob::NrosCdrBlob(<brace-enclosed initializer list>)'
+///
+/// Every use site either brace-initialises both members or casts from `void*`;
+/// nothing default-constructs one, so the initialisers bought nothing and cost
+/// the whole Zephyr Cyclone lane. Keeping them out also keeps the type
+/// trivially default-constructible on top of trivially copyable, which is what
+/// `sertype_zero_samples` / `sertype_realloc_samples` rely on when they `memset`
+/// and `dds_realloc` this as raw storage.
 struct NrosCdrBlob {
-    const uint8_t* data{nullptr};
-    size_t size{0};
+    const uint8_t* data;
+    size_t size;
 };
 
 /// Build a sertype for @p desc's type name, to be handed to

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
@@ -645,3 +645,45 @@ else()
         "no in-build `ddsc` target, so cyclone's internal addrset headers are not "
         "reachable (issue 0496 regression cover is NOT running in this configuration)")
 endif()
+
+# Issue 1011 — the ONLY C++11 translation unit in the tree, deliberately.
+#
+# The Zephyr lane builds this backend with `-std=c++11`, where a class carrying
+# default member initialisers is not an aggregate (C++14 relaxed that). Two such
+# initialisers on `NrosCdrBlob` broke `NrosCdrBlob{data, len}` in publisher.cpp
+# and service.cpp, failing six zephyr cyclonedds leaves while every other lane —
+# all C++14 or later — stayed green.
+#
+# Pinning C++11 here is the whole point: nothing else in a normal `just check`
+# compiles this header at that standard, so without this target a re-added
+# initialiser is invisible until a Zephyr fixture build fails. Header-only, so
+# it links the backend only to inherit CycloneDDS' include dirs — the header
+# pulls in `dds/dds.h`, so it is not standalone.
+#
+# Only THIS target is C++11; the backend it links stays on its own standard,
+# which is the point: the test proves the header is consumable at C++11 without
+# dragging the rest of the tree back to it.
+add_executable(nros_rmw_cyclonedds_sertype_sample_cxx11 sertype_sample_cxx11.cpp)
+set_target_properties(nros_rmw_cyclonedds_sertype_sample_cxx11 PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF)
+target_link_libraries(nros_rmw_cyclonedds_sertype_sample_cxx11
+    PRIVATE nros_rmw_cyclonedds)
+target_include_directories(nros_rmw_cyclonedds_sertype_sample_cxx11
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+# `nros_sertype.hpp` reaches INTERNAL Cyclone headers (`dds/ddsi/ddsi_sertype.h`),
+# which the backend adds PRIVATE — so they do not propagate to a consumer and
+# have to be mirrored here. Same condition the backend guards them with.
+if(NROS_CYCLONEDDS_PROVENANCE STREQUAL "source")
+    target_include_directories(nros_rmw_cyclonedds_sertype_sample_cxx11 PRIVATE
+        "${CYCLONEDDS_SOURCE_DIR}/src/core/ddsi/include"
+        "${CYCLONEDDS_SOURCE_DIR}/src/core/ddsc/include"
+        "${CYCLONEDDS_SOURCE_DIR}/src/ddsrt/include"
+        "${NROS_CYCLONEDDS_SOURCE_BUILD_DIR}/src/ddsrt/include")
+endif()
+
+add_test(
+    NAME nros_rmw_cyclonedds_sertype_sample_cxx11
+    COMMAND nros_rmw_cyclonedds_sertype_sample_cxx11
+)

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/sertype_sample_cxx11.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/sertype_sample_cxx11.cpp
@@ -1,0 +1,67 @@
+/* Issue 1011 — `NrosCdrBlob` must stay a C++11 AGGREGATE.
+ *
+ * The Zephyr lane compiles the backend with `-std=c++11`, and a class with
+ * default member initialisers is not an aggregate before C++14 — C++14 relaxed
+ * exactly that rule. So two NSDMIs that read as harmless defaults turned
+ * `NrosCdrBlob{data, len}` in `publisher.cpp` and `service.cpp` into a call to
+ * a two-argument constructor that does not exist:
+ *
+ *     error: no matching function for call to
+ *       'nros_rmw_cyclonedds::NrosCdrBlob::NrosCdrBlob(<brace-enclosed initializer list>)'
+ *
+ * Every other lane builds this TU at C++14 or later and was fine, which is why
+ * it was invisible for as long as it was: six zephyr cyclonedds leaves failed
+ * to build and nothing else did.
+ *
+ * This TU is compiled AS C++11 on purpose (see tests/CMakeLists.txt). It is the
+ * only place in the tree that pins that standard, so it is the only thing that
+ * can catch a re-added initialiser before the Zephyr lane does.
+ *
+ * The static_asserts guard the other half: `sertype_zero_samples` memsets these
+ * and `sertype_realloc_samples` hands them to `dds_realloc`, both of which treat
+ * the sample as raw storage. Trivial copyability is what makes that defined;
+ * standard layout is what makes the `static_cast` from `void*` defined.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#include "nros_sertype.hpp"
+
+using nros_rmw_cyclonedds::NrosCdrBlob;
+
+static_assert(std::is_trivially_copyable<NrosCdrBlob>::value,
+              "sertype_zero_samples memsets this and sertype_realloc_samples "
+              "dds_reallocs it; both need trivial copyability");
+static_assert(std::is_standard_layout<NrosCdrBlob>::value,
+              "the sertype callbacks static_cast this from void*");
+static_assert(std::is_trivially_default_constructible<NrosCdrBlob>::value,
+              "raw storage: a default member initialiser would break this AND "
+              "aggregate initialisation under C++11 (issue 1011)");
+
+int main() {
+    /* The exact shape publisher.cpp:287 and service.cpp:506 use. Under C++11
+     * this only compiles while the type is an aggregate. */
+    const uint8_t bytes[4] = {0, 1, 2, 3};
+    const NrosCdrBlob blob{bytes, sizeof(bytes)};
+    if (blob.data != bytes || blob.size != sizeof(bytes)) {
+        return 1;
+    }
+
+    /* Value-initialisation still zeroes without the initialisers. */
+    NrosCdrBlob zeroed{};
+    if (zeroed.data != nullptr || zeroed.size != 0) {
+        return 1;
+    }
+
+    /* And the raw-storage path the sertype callbacks take. */
+    NrosCdrBlob samples[2];
+    std::memset(samples, 0, sizeof(NrosCdrBlob) * 2);
+    if (samples[1].size != 0) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
phase-416 W1. Six `rust-*-cyclonedds` zephyr leaves fail to build, all identically:

```
publisher.cpp:287:37: error: no matching function for call to
  'nros_rmw_cyclonedds::NrosCdrBlob::NrosCdrBlob(<brace-enclosed initializer list>)'
```

## Cause

The Zephyr lane compiles this TU with **`-std=c++11`**, and a class carrying default member initialisers is **not an aggregate** before C++14 — C++14 relaxed exactly that rule. So `NrosCdrBlob{data, len}` stopped being aggregate initialisation and the compiler went looking for a two-argument constructor that does not exist. Every other lane builds at C++14 or later, which is why only Zephyr ever saw it.

## Fix

Drop the two initialisers. Minimal, and it is also the better type: no site default-constructs one — all five are brace-init or a `static_cast` from `void*` — so they bought nothing, and removing them restores trivial **default constructibility** on top of trivial copyability. `sertype_zero_samples` memsets these and `sertype_realloc_samples` hands them to `dds_realloc`; that code's comment already called the sample "a trivially copyable two-word struct", which was only half true before this PR.

The alternative, adding a two-argument constructor, was rejected: it keeps trivial copyability but costs aggregate status *and* trivial default construction, for a type DDS treats as raw storage.

## The gate is the point, not a footnote

`tests/sertype_sample_cxx11.cpp` is the **only C++11 translation unit in the tree**. Nothing else in `just check` compiles this header at that standard, so without it a re-added initialiser stays invisible until a Zephyr fixture build fails — which is exactly how this survived.

It builds the **real header**, not a copy of the struct; a copy would be the same two-spellings defect one level down. It asserts the three properties the sertype callbacks depend on (trivially copyable, standard layout, trivially default constructible) and exercises the `publisher.cpp` / `service.cpp` shape.

It links the backend only to inherit CycloneDDS' include dirs — the header reaches *internal* Cyclone headers (`dds/ddsi/ddsi_sertype.h`) which the backend adds `PRIVATE`, so they do not propagate and are mirrored under the same provenance guard. Only this target is C++11; the rest of the tree keeps its own standard.

## Verified

- `just check rmw-cyclonedds` — **24/24 pass**, including the new test and both ROS 2 e2e cells. `just check cpp` OK.
- **Non-vacuous by mutation.** Restoring the initialisers fails the build with *both* the triviality `static_assert` and the production error verbatim, then passes again when reverted.
- Standard sweep on the isolated shape: old shape **fails at C++11, compiles at C++14** — the asymmetry that hid it; new shape compiles at C++11/14/17.

## Not verified

The six zephyr cyclonedds leaves themselves. Their west build dir fails to **configure** for an unrelated, pre-existing reason:

```
CMake Error at NrosRmwCycloneddsTypeSupport.cmake:700 (message):
  nros_rmw_cyclonedds_generate_from_msg: PKG_NAME, PKG_DIR, and INTERFACES are required.
```

That is a stale cached invocation in the build dir; a header change can neither cause nor fix a configure failure. The compile-level proof above is direct, but leaf-level confirmation needs that configure sorted first — it looks like the shape of #1007 one platform over and is worth its own look.

Issue #1011's file is not archived here: it lives on the unmerged #318, so archiving belongs with that merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
