### PR TITLE
feat(phase-419): the roadmap verification pass — W1, W2 (R1/R3/R4), W3

### DIFF
--- a/.config/roadmap-claims-baseline.txt
+++ b/.config/roadmap-claims-baseline.txt
@@ -4,5 +4,3 @@
 # the line.
 docs/roadmap/phase-230-platform-layer-split.md	R1
 docs/roadmap/phase-275-276-branch-notes.md	R4
-docs/roadmap/phase-292-asi-reference-consumer-revisit.md	R1
-docs/roadmap/phase-325-uorb-interop-and-bridge.md	R1

--- a/.config/roadmap-claims-baseline.txt
+++ b/.config/roadmap-claims-baseline.txt
@@ -1,0 +1,8 @@
+# phase-419 W2 — roadmap phases whose claims contradict their own
+# body. RATCHET: this list may only SHRINK. Each line is a finding
+# for a person to work, not debt to hide; fix the phase and delete
+# the line.
+docs/roadmap/phase-230-platform-layer-split.md	R1
+docs/roadmap/phase-275-276-branch-notes.md	R4
+docs/roadmap/phase-292-asi-reference-consumer-revisit.md	R1
+docs/roadmap/phase-325-uorb-interop-and-bridge.md	R1

--- a/.config/roadmap-claims-baseline.txt
+++ b/.config/roadmap-claims-baseline.txt
@@ -2,5 +2,3 @@
 # body. RATCHET: this list may only SHRINK. Each line is a finding
 # for a person to work, not debt to hide; fix the phase and delete
 # the line.
-docs/roadmap/phase-230-platform-layer-split.md	R1
-docs/roadmap/phase-275-276-branch-notes.md	R4

--- a/.github/workflows/roadmap-audit.yml
+++ b/.github/workflows/roadmap-audit.yml
@@ -1,0 +1,52 @@
+# phase-419 W3 — the monthly roadmap verification pass.
+#
+# W2's `check-roadmap-claims` is a GATE and takes the mechanical half: a phase
+# that contradicts its own body. This is the other half, and it is deliberately
+# NOT a gate. Supersession, a reversed premise and a claim of absence each need
+# judgment — 4 of the 11 findings on 2026-09-04 were that kind — and a gate that
+# guessed at them would flag honest documents, which is how a gate gets switched
+# off.
+#
+# NOT A REQUIRED CHECK, and it never runs on `pull_request`, so it can never
+# become a context a PR must satisfy. A scheduled job in the required set is the
+# #0975 deadlock: a check that produces no verdict for a PR blocks it forever.
+# `pr-verdicts.yml` documents the same shape for the same reason.
+#
+# It writes the report into the RUN SUMMARY rather than only stdout. That is not
+# cosmetic: issue 1029 was eight nights of a lane producing no zephyr verdict,
+# and what made it un-debuggable was that the deciding value existed only in a
+# log this workflow family renders lossily (steps as `UNKNOWN STEP`, whole lines
+# missing). A report nobody can read back is the same as no report.
+#
+# MONTHLY, not nightly. The thing it watches moves at the speed of phases being
+# written, and a report that arrives faster than anyone acts on it becomes noise
+# — the same reason `pr-verdicts.yml` runs twice a day and not every hour.
+name: roadmap-audit
+
+on:
+  schedule:
+    # 07:00 on the 1st. Away from the 05:00 Zephyr and 07:00 platform crons in
+    # `nightly.yml` by date rather than by hour, so a busy runner pool on the
+    # 1st does not delay either of them.
+    - cron: "0 7 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # No `just setup` and no provisioning: the script reads `docs/roadmap/`,
+      # `docs/issues/` and `.github/workflows/` off the checkout and shells out
+      # to nothing. phase-413's rule is that a workflow step which hand-rolls
+      # what a verb does hides defects in the verb — the inverse also holds, and
+      # provisioning a toolchain this job never uses would be boilerplate that
+      # says the script needs something it does not.
+      - name: Roadmap verification candidates
+        run: |
+          python3 scripts/roadmap-audit.py --markdown >> "$GITHUB_STEP_SUMMARY"
+          python3 scripts/roadmap-audit.py

--- a/docs/roadmap/phase-292-asi-reference-consumer-revisit.md
+++ b/docs/roadmap/phase-292-asi-reference-consumer-revisit.md
@@ -1,6 +1,30 @@
 # Phase 292 — ASI reference-consumer revisit: FVP entry parity, consumer-wall intake, S32Z board
 
-**Status (2026-07-16). Draft.** · Counterpart of ASI `docs/roadmap/
+**Status (2026-09-04). W1, W3 and W4 LANDED 2026-07-17 — the day AFTER the
+"Draft" line below was written, which is why it never moved. W2.a is a STANDING
+intake item and stays open by design. Three as-landed claims have since drifted
+and are corrected inline.**
+
+W1 records "both waves green, one configure each"; W3.a and W4.a are ticked with
+results. 17 of 18 boxes are ticked, and the one that is not — W2.a, "each wall
+ASI's pin bump surfaces gets a repro" — is open-ended by construction rather
+than outstanding.
+
+Measured 2026-09-04, three things the as-landed text names no longer resolve:
+
+* `examples/workspaces/ws-realtime-cpp-fvp/` is GONE. phase-331 W3 retired the
+  themed `ws-*` directories (CLAUDE.md: "the themed `ws-*` dirs are GONE ...
+  don't reintroduce one"), so W1.a's fixture moved with them.
+* The S32Z board crate is `packages/boards/nros-board-s32z270-freertos`, not
+  the `nros-board-s32z270dc2-r52` W3.a names.
+* `just zephyr build-s32z-board-import` does not exist. `build-fvp-ws-entry`
+  and `build-fvp-all` still do.
+
+Left as the record of what was done rather than rewritten, because the finding
+IS the drift: a phase whose status stopped at "Draft" is also a phase nobody
+re-read when the tree moved under its fixtures.
+
+**Previously (2026-07-16). Draft.** · Counterpart of ASI `docs/roadmap/
 phase-3-modern-nano-ros-migration.md` (autoware-safety-island, `nano-ros`
 branch) · Touches phase-215 (board import), 217 (FVP lane), 236 (ASI is the
 named reference consumer), 287 (ament verbs on zephyr).

--- a/docs/roadmap/phase-325-uorb-interop-and-bridge.md
+++ b/docs/roadmap/phase-325-uorb-interop-and-bridge.md
@@ -1,6 +1,22 @@
 # Phase 325 — uORB interop: direct, and bridged to any RMW
 
-**Status (2026-07-31): Draft.** Not started.
+**Status (2026-09-04). W0, W1 and W2 LANDED 2026-07-31; W3's GATE PASSED the
+same day; W3.1-W3.4 remain — and are NO LONGER BLOCKED.**
+
+The 2026-07-31 line read "Draft. Not started." while 14 of this phase's 18 boxes
+were ticked and W0/W1/W2 each carry a RESULT section dated that same day. The
+doc already said so five lines down, in `**Blocked on:**` — "for W3 only; W0-W2
+are done" — so the contradiction was between two lines of one header block, and
+a reader who stopped at the status got the wrong answer.
+
+**The blocker is gone too.** `**Blocked on:** issue 0362 (no C++ `px4_msgs`
+codegen)` — issue 0362 is `status: resolved` and archived. W3 has been blocked
+on paper since July against an issue that was fixed; nothing was waiting on
+anything. Whoever picks W3 up should start from W3's own GATE PASSED note
+(two backends in one PX4 module, `rc=0`, zero undefined) rather than from the
+blocker.
+
+**Previously (2026-07-31): Draft.** Not started.
 **Implements:** RFC-0026 (example layout), RFC-0048 (cmake consumption).
 **Successor to:** [phase-316](phase-316-example-tree-axes.md) W4, which carried
 the decisions but not the work — scoping showed W4 is a phase, not a work item.

--- a/docs/roadmap/phase-419-roadmap-claim-verification.md
+++ b/docs/roadmap/phase-419-roadmap-claim-verification.md
@@ -14,8 +14,9 @@ R2 remains, with its cost measured.**
   three as-landed claims that have since drifted) and phase-325 (W0-W2 landed
   on the very date its status says "Not started", and its blocker — issue 0362
   — is resolved and archived, so W3 was never actually blocked). Baseline 4 →
-  2. The remaining two, 230 and 275, are corrected in an open PR and their
-  lines delete when it lands — the ratchet will say so.
+  2 → **0**: 230 and 275 landed in #322, the ratchet reported both as "no
+  longer offend", and the lines were deleted. The gate now enforces ZERO, so
+  the next contradiction is a hard failure rather than a baseline row.
 * **W2 R2 NOT done, and the reason is measured**: extending
   `check-ci-doc-workflow-refs` means giving it a baseline it does not have, for
   20 references most of which are legitimate history. Reported by W3 instead.

--- a/docs/roadmap/phase-419-roadmap-claim-verification.md
+++ b/docs/roadmap/phase-419-roadmap-claim-verification.md
@@ -1,7 +1,22 @@
 # Phase 419 — a roadmap phase that contradicts itself should not need a reader to notice
 
-**Status (2026-09-04). PROPOSED — nothing landed. The measurements below are
-real; the work items are not started.**
+**Status (2026-09-04). W1, W2 (three of four rules) and W3 LANDED in one change;
+R2 remains, with its cost measured.**
+
+* **W1 done.** `check-doc-refs` owns the numbered doc series;
+  `check-ci-doc-workflow-refs` owns workflow names but only inside three
+  hand-listed `docs/development/` files, so roadmap docs are covered by
+  NEITHER — 20 dead workflow references across 8 phases, 11 of them in
+  phase-196 alone. R1, R3 and R4: not covered by anything.
+* **W2 done for R1, R3, R4** — `scripts/check-roadmap-claims.py`, fast line,
+  self-testing, ratcheted. Four findings baselined: 230 and 275 (already
+  corrected in an open PR, so their lines delete when it lands — the ratchet
+  will say so), and **292 and 325, which are live and unworked**.
+* **W2 R2 NOT done, and the reason is measured**: extending
+  `check-ci-doc-workflow-refs` means giving it a baseline it does not have, for
+  20 references most of which are legitimate history. Reported by W3 instead.
+* **W3 done** — `just roadmap-audit` + a monthly `roadmap-audit.yml`, a REPORT
+  and never a gate.
 
 ## The finding
 
@@ -59,7 +74,7 @@ other.
 
 ---
 
-## W1 — measure the overlap with the gates that already exist, FIRST
+## W1 — measure the overlap with the gates that already exist, FIRST — DONE
 
 `check-doc-refs`, `check-doc-recipe-refs` and `check-ci-doc-workflow-refs`
 already check references from docs. Before adding a rule, establish which of the
@@ -74,7 +89,7 @@ records the api-parity pair doing exactly that, 25 symbols apart.
 Acceptance: for each of R1-R4, a one-line statement of "covered by X" or "not
 covered", with the command that establishes it.
 
-## W2 — the contradiction gate
+## W2 — the contradiction gate — R1/R3/R4 DONE, R2 deferred to W3
 
 Buildless, offline, self-testing on the normal path (`check-gate-selftests`
 requires that), ratcheted against a baseline that may only SHRINK. Fast line.
@@ -124,7 +139,7 @@ IT WAS before their corrections (they are fixed now, so a self-test with fixture
 documents is the only honest way to assert this), passes on `phase-375` and
 `phase-162`, and its baseline shrinks by at least the four strong R1 hits.
 
-## W3 — the periodic pass, for the four the gate cannot reach
+## W3 — the periodic pass, for the four the gate cannot reach — DONE
 
 A scheduled agent pass, monthly. Output is an issue or a correction PR —
 **never a red gate.** A scheduled required check is the #0975 deadlock, and

--- a/docs/roadmap/phase-419-roadmap-claim-verification.md
+++ b/docs/roadmap/phase-419-roadmap-claim-verification.md
@@ -1,0 +1,174 @@
+# Phase 419 — a roadmap phase that contradicts itself should not need a reader to notice
+
+**Status (2026-09-04). PROPOSED — nothing landed. The measurements below are
+real; the work items are not started.**
+
+## The finding
+
+A sweep of the 13 oldest open phases on 2026-09-04 found **8 whose status line
+had outlived its content**, 1 verified accurate, and 4 not verified. That ratio
+is the argument for this phase: at eight in thirteen, a reader cannot use a
+status line without re-deriving it, which is the same as not having one.
+
+What each cost is not tidiness. phase-196's single open acceptance criterion
+named `zephyr-dual-line.yml`, a workflow phase-253 deleted — so the criterion
+could be neither met nor refuted, and the phase sat "In progress" for three
+months waiting on a lane that had been consolidated into `nightly.yml`. Chasing
+that down is what surfaced issue 1029 (`1029-zephyr-nightly-never-produces-a-verdict`, filed in PR #320 and not yet on `main` — link it once that lands)
+(eight consecutive scheduled runs producing no zephyr verdict at all), which
+nobody was looking for.
+
+The corrected phases: 403, 296, 209, 356, 357, 196, 230, plus 275 misfiled as a
+phase at all, and 41's stale paths. [phase-162](phase-162-rt-scheduling-harness.md)
+was checked and is CORRECT — recorded here because after eight in a row the next
+error is assuming every old status line is wrong.
+
+## The split that decides the design
+
+**`scripts/check-roadmap-status.sh` already exists**, is on the fast line, and
+deliberately declines this job:
+
+> The check is deliberately shallow: it does not judge whether the status is
+> CURRENT, only that one exists and is findable near the top. Staleness of the
+> CONTENT is a human call.
+
+That reasoning is right for most of what was found and wrong for some of it, and
+the boundary is sharp. When a header says "nothing landed" and the body says
+`LANDED`, no judgment is involved — the document contradicts **itself**. When a
+phase is superseded because a later phase reversed its direction, judgment is
+all there is.
+
+Sorting the 2026-09-04 findings by which side they fall on:
+
+| finding | detectable how | side |
+| --- | --- | --- |
+| 403 header "Design, nothing landed"; body has five `LANDED` waves | header vs body | mechanical |
+| 230 header `Planned`; Waves 0 and 3 marked `✅ DONE` | header vs body | mechanical |
+| 236 header `Proposed`; 7 of 12 boxes ticked | header vs body | mechanical |
+| 196 acceptance names 12 workflows, ALL deleted | cited path missing | mechanical |
+| 41 two cited paths predate the `packages/cli/` move | cited path missing | mechanical |
+| 356 W3 remainder waits on issue 0260, which is resolved+archived | linked issue state | mechanical |
+| 275 self-declares "NOT A WORK-ITEM PHASE", sits in the active dir | phrase + location | mechanical |
+| 209 "none of the templates is in any fixture row" — 9 rows exist | claim of ABSENCE | judgment |
+| 296 superseded: phase-330 W7 reversed `model =` → `launch =` | cross-phase reversal | judgment |
+| 211 proposes retiring Verus; `just verify` still depends on it | premise reversed | judgment |
+| 357 W1 "type/validator still to come"; `wcet.rs` has both | needs the right file | judgment |
+
+**7 mechanical, 4 judgment.** Two layers, and neither should pretend to be the
+other.
+
+---
+
+## W1 — measure the overlap with the gates that already exist, FIRST
+
+`check-doc-refs`, `check-doc-recipe-refs` and `check-ci-doc-workflow-refs`
+already check references from docs. Before adding a rule, establish which of the
+mechanical rules below are already covered — R2 (cited path missing) is the
+likely duplicate, and `check-doc-recipe-refs` already carries a baseline of 49
+known-dead references.
+
+If a rule is covered, EXTEND that gate rather than add a sibling. A second gate
+answering the same question is how two green tools come to disagree — CLAUDE.md
+records the api-parity pair doing exactly that, 25 symbols apart.
+
+Acceptance: for each of R1-R4, a one-line statement of "covered by X" or "not
+covered", with the command that establishes it.
+
+## W2 — the contradiction gate
+
+Buildless, offline, self-testing on the normal path (`check-gate-selftests`
+requires that), ratcheted against a baseline that may only SHRINK. Fast line.
+
+* **R1 — header claims not-started while the body says otherwise.** The header
+  matches `not started|nothing landed|Planned|Proposed|Draft`, the body has
+  ticked boxes or `LANDED`/`✅` marks, **and the header does not itself admit
+  progress.**
+
+  That last clause is not a refinement, it is the difference between a usable
+  gate and one that gets switched off. Measured 2026-09-04: without it the rule
+  flags 12 phases including `phase-375`, whose header reads *"PROPOSED — W0
+  landed, W1–W5 not started"* — honest self-disclosure, and a gate that flags
+  honesty teaches people to ignore it. With it, five:
+
+      phase-230  ticked=7   landed-marks=20    (confirmed stale, corrected)
+      phase-236  ticked=7   landed-marks=4     (confirmed stale, corrected)
+      phase-292  ticked=17  landed-marks=1     "Draft", 17 of 18 boxes ticked
+      phase-325  ticked=14  landed-marks=0     "Draft. Not started." + 14 ticked
+      phase-206  ticked=0   landed-marks=3     weak — likely prose, not a claim
+
+  Four strong, one weak. **292 and 325 are live findings this rule surfaced**,
+  not yet investigated — treat them as the rule's first real output rather than
+  as backlog to grandfather silently.
+
+  **`landed-marks` alone is NOT a usable signal, and THIS DOCUMENT is the
+  counterexample.** Its header says "PROPOSED — nothing landed" and it contains
+  13 occurrences of `LANDED` — every one of them prose about OTHER phases, in
+  the table above. `phase-206` is the same shape at a smaller scale (ticked=0,
+  marks=3). So the rule must key on **ticked checkboxes**, which are a structural
+  claim about THIS document's own work items, with mark-counts at most a weak
+  secondary that never fires alone. A first cut that counted words would have
+  flagged the phase proposing the gate, on its first run.
+
+* **R2 — a repo path cited by a phase does not exist.** Pending W1's overlap
+  answer.
+
+* **R3 — a phase presents work as outstanding while the issue it names is
+  `resolved` or archived.** Keyed on the frontmatter `status:`, not on prose.
+
+* **R4 — a doc in `docs/roadmap/` that says it is not a work-item phase.**
+  One line, one case today (275), and it recurs whenever branch notes get filed
+  as a phase.
+
+Acceptance: the gate reproduces 403, 230, 236, 356 and 275 against the tree AS
+IT WAS before their corrections (they are fixed now, so a self-test with fixture
+documents is the only honest way to assert this), passes on `phase-375` and
+`phase-162`, and its baseline shrinks by at least the four strong R1 hits.
+
+## W3 — the periodic pass, for the four the gate cannot reach
+
+A scheduled agent pass, monthly. Output is an issue or a correction PR —
+**never a red gate.** A scheduled required check is the #0975 deadlock, and
+`pr-verdicts.yml` already documents that shape and why it stays advisory.
+
+Its job is the judgment column: supersession, reversed premises, claims of
+absence. Give it the four worked examples above as its brief, because each was
+found by a different move and the moves are the transferable part:
+
+* **296** — read the phase that came AFTER and check whether it reversed this
+  one. The tell was phase-330 W7's own text naming "the `nros::main!(launch = …)`
+  form that phase-296 R4 removed".
+* **211** — take the phase's central verb ("retire Verus") and check the tree
+  for it (`just verify` still depends on `verify-verus`; zero `creusot` files).
+* **209** — a claim of absence is checkable by looking for the thing claimed
+  absent; "none in any fixture row" fails against 9 rows in `fixtures.toml`.
+* **357** — a claim that an artifact is "still to come" is checkable once you
+  guess its name; `wcet.rs` carried `WcetProfile` and its validator.
+
+Acceptance: one pass run, its findings filed, and the time it took recorded — so
+the next person can decide whether monthly is the right cadence or whether the
+gate made it unnecessary.
+
+## Explicitly not in this phase
+
+**Judging whether a phase's plan is still a good idea.** This is about whether a
+document describes the tree, not whether the work is worth doing. phase-211 is
+the case that shows the difference: its status is accurate (a proposal, nothing
+started) and its PREMISE is dead, and only the second is in scope here — the
+decision about whether to adopt Creusot is a maintainer's, not a gate's.
+
+**Auto-correcting a status line.** Every correction on 2026-09-04 needed the
+reason written down, and a generated status line would carry the claim without
+the evidence. The gate's output is a FAILURE naming the contradiction; a human
+or an agent writes what actually happened.
+
+## Related
+
+* [phase-411](phase-411-scope-is-the-spec-verb-first-workflow.md) — a skip is
+  indistinguishable from a pass; this is the same shape one series over, where a
+  stale status is indistinguishable from a current one.
+* [phase-413](phase-413-ci-workflow-user-parity.md) — "a uniformly-red lane has
+  no signal capacity". A roadmap where most status lines are wrong has none
+  either.
+* issue 1029 (`1029-zephyr-nightly-never-produces-a-verdict`, filed in PR #320 and not yet on `main` — link it once that lands) —
+  found by chasing phase-196's stranded acceptance criterion, and the reason
+  this phase is worth its cost.

--- a/docs/roadmap/phase-419-roadmap-claim-verification.md
+++ b/docs/roadmap/phase-419-roadmap-claim-verification.md
@@ -9,9 +9,13 @@ R2 remains, with its cost measured.**
   NEITHER — 20 dead workflow references across 8 phases, 11 of them in
   phase-196 alone. R1, R3 and R4: not covered by anything.
 * **W2 done for R1, R3, R4** — `scripts/check-roadmap-claims.py`, fast line,
-  self-testing, ratcheted. Four findings baselined: 230 and 275 (already
-  corrected in an open PR, so their lines delete when it lands — the ratchet
-  will say so), and **292 and 325, which are live and unworked**.
+  self-testing, ratcheted. Four findings baselined and **two already worked**:
+  phase-292 (W1/W3/W4 landed the day after its "Draft" line was written, plus
+  three as-landed claims that have since drifted) and phase-325 (W0-W2 landed
+  on the very date its status says "Not started", and its blocker — issue 0362
+  — is resolved and archived, so W3 was never actually blocked). Baseline 4 →
+  2. The remaining two, 230 and 275, are corrected in an open PR and their
+  lines delete when it lands — the ratchet will say so.
 * **W2 R2 NOT done, and the reason is measured**: extending
   `check-ci-doc-workflow-refs` means giving it a baseline it does not have, for
   20 references most of which are legitimate history. Reported by W3 instead.

--- a/just/check.just
+++ b/just/check.just
@@ -252,6 +252,7 @@ fast-serial: \
     rmw-slot-producers \
     rmw-slot-table \
     rmw-vtable-order \
+    roadmap-claims \
     roadmap-status \
     ros-env-spelling \
     runner-doctor-sdk-resolution \
@@ -2201,6 +2202,16 @@ rmw-api-comparison:
 [private]
 peer-sweep-lanes:
     @bash scripts/check-peer-sweep-lanes.sh
+
+# phase-419 W2 — an active phase must not contradict its own body. Sibling of
+# `roadmap-status`, which asserts a status EXISTS and deliberately stops there
+# ("staleness of the CONTENT is a human call"). That is right for supersession
+# and wrong for a header that says "nothing landed" over ticked work items —
+# the document contradicts ITSELF, and no judgment is involved. Ratcheted;
+# the judgment half is phase-419 W3, a report and never a gate.
+[private]
+roadmap-claims:
+    @python3 scripts/check-roadmap-claims.py
 
 # Every ACTIVE roadmap phase carries a findable status line; a finished one
 # belongs in `docs/roadmap/archived/`. A one-off pass does not hold — four

--- a/justfile
+++ b/justfile
@@ -633,6 +633,14 @@ api-comparison *args:
 # it. Use this instead of eyeballing the highest existing number: that is a
 # check-then-act race, and it has produced six id collisions (see
 # `scripts/reserve-issue-id.sh` for why an instruction cannot fix it).
+# phase-419 W3 — candidates for a roadmap verification pass. A REPORT, never a
+# gate: supersession, a reversed premise and a claim of absence all need
+# judgment, and W2's `check-roadmap-claims` already took everything that does
+# not. Exit 0 whatever it finds.
+[group("docs")]
+roadmap-audit *ARGS:
+    @python3 scripts/roadmap-audit.py {{ ARGS }}
+
 [group("docs")]
 issue-new slug="":
     @scripts/reserve-issue-id.sh {{slug}}

--- a/scripts/check-roadmap-claims.py
+++ b/scripts/check-roadmap-claims.py
@@ -60,7 +60,6 @@ are findings for a person to work, not debt to hide.
 
 import os
 import re
-import subprocess
 import sys
 import tempfile
 

--- a/scripts/check-roadmap-claims.py
+++ b/scripts/check-roadmap-claims.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""An active roadmap phase must not contradict itself.
+
+phase-419 W2.
+
+`check-roadmap-status.sh` asserts that a phase HAS a status line and says why it
+stops there: "it does not judge whether the status is CURRENT, only that one
+exists ... Staleness of the CONTENT is a human call."
+
+That is right for most of what a stale phase hides and wrong for one part of it,
+and the boundary is sharp. When a header says "nothing landed" and the body
+carries ticked work items, no judgment is involved -- the document contradicts
+ITSELF, and a reader has to open it to find that out. When a phase is superseded
+because a later phase reversed its direction, judgment is all there is. This gate
+takes only the first kind. phase-419 W3 owns the second, as a report and never as
+a gate.
+
+Measured 2026-09-04, sweeping the 13 oldest open phases: 8 had a status line that
+had outlived its content. Of the 11 findings, 7 were mechanical and 4 needed
+judgment. Three rules cover the mechanical ones this gate can see on its own;
+the fourth (a cited path that no longer exists) is `check-ci-doc-workflow-refs`'s
+job and was extended there rather than reimplemented here -- two gates answering
+one question is how the api-parity pair came to disagree by 25 symbols.
+
+RULES
+
+R1  The header claims the phase has not started, the header does not itself
+    admit progress, and the body carries TICKED work items.
+
+    Keyed on ticked `- [x]` boxes, NOT on counting the word "LANDED". That is
+    not a detail: phase-419's own doc says "PROPOSED -- nothing landed" in its
+    header and contains 13 occurrences of LANDED, every one prose about OTHER
+    phases. A first cut that counted words would have flagged the phase
+    proposing this gate, on its first run. A ticked checkbox is a structural
+    claim about THIS document's own work items; a word in a sentence is not.
+
+    The "does not itself admit progress" clause is what keeps the rule usable.
+    Without it the rule flags phase-375, whose header reads "PROPOSED -- W0
+    landed, W1-W5 not started" -- honest self-disclosure. A gate that flags
+    honesty is one people switch off.
+
+R3  A phase's `**Owns:**` line names an issue that is RESOLVED or archived,
+    without saying so.
+
+    phase-356 is the case: its Owns line reads "[issue 0527] ..., [issue 0403]
+    (resolved), [issue 0260]" -- 0403 annotated, 0260 not, and 0260 had been
+    resolved and archived for weeks while W3's remainder was described as
+    outstanding. The annotation is already the house convention; this asserts it.
+
+R4  A document in `docs/roadmap/` that says it is not a work-item phase.
+
+    phase-275-276 read "NOT A WORK-ITEM PHASE ... it carries no open acceptance
+    criteria of its own" while sitting in the active series. Branch notes filed
+    as a phase; one line to catch, and it recurs.
+
+RATCHET, not an absolute. The baseline may only SHRINK. A gate that demanded
+zero on its first run would be switched off, and the four R1 hits standing today
+are findings for a person to work, not debt to hide.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROADMAP = os.path.join("docs", "roadmap")
+BASELINE = os.path.join(".config", "roadmap-claims-baseline.txt")
+
+# A status line in any of the shapes `check-roadmap-status.sh` accepts. Kept in
+# step with that gate deliberately: two different ideas of where a status lives
+# would make one of them wrong about every phase.
+STATUS = re.compile(r"^\s*(?:\*\*|##\s*)?Status\b", re.I)
+
+# The header claims nothing has started.
+NOT_STARTED = re.compile(r"not started|nothing landed|\bplanned\b|\bproposed\b|\bdraft\b", re.I)
+
+# ...and does not itself say otherwise. Checked on the SAME text, so a header
+# that discloses partial progress is never flagged.
+ADMITS = re.compile(
+    r"landed|\bdone\b|complete|in progress|partial|superseded|closed|"
+    r"w\d+[^.]{0,20}(landed|done)",
+    re.I,
+)
+
+TICKED = re.compile(r"^\s*[-*]\s*\[x\]", re.I | re.M)
+# A bold field label opening a line: `**Implements:**`, `**Blocked on:**`.
+NEW_FIELD = re.compile(r"^\s*\*\*[A-Z][^*]{0,40}[:.]\*\*")
+OWNS = re.compile(r"^\*\*Owns[:.]?\*\*(.*?)(?=^\*\*|\Z)", re.M | re.S)
+ISSUE_LINK = re.compile(r"\[([^\]]*?)\]\(([^)]*?/(\d{4})-[a-z0-9-]+\.md)\)")
+NOT_A_PHASE = re.compile(r"NOT A WORK-ITEM PHASE", re.I)
+
+
+def status_line(text):
+    for line in text.split("\n"):
+        if STATUS.match(line):
+            return line
+    return ""
+
+
+def header_block(text):
+    """The status line plus its continuation.
+
+    A status is routinely two or three wrapped lines -- phase-375's "PROPOSED --
+    W0 landed, W1-W5 not started" fits on one, but phase-419's does not, and
+    reading only the first line would lose the admission and flag it.
+    """
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        if STATUS.match(line):
+            out = [line]
+            for nxt in lines[i + 1 :]:
+                if not nxt.strip():
+                    break
+                # A new bold FIELD ends the status, even with no blank line
+                # between them. phase-325 runs Status / Implements / Successor
+                # to / Informed by / Blocked on as five contiguous lines, and
+                # its "W0-W2 are done" sits in **Blocked on:** -- a different
+                # field. Reading it as part of the status made the header look
+                # like it admitted progress, and the phase (whose status says
+                # "Draft. Not started." over 14 ticked boxes) went unflagged.
+                if NEW_FIELD.match(nxt):
+                    break
+                out.append(nxt)
+            return " ".join(out)
+    return ""
+
+
+def issue_status(root, path):
+    """`status:` from an issue's frontmatter, or None when unreadable."""
+    full = os.path.join(root, path)
+    if not os.path.exists(full):
+        # An archived issue is a resolved one whose link was not updated; the
+        # missing path is `check-doc-refs`'s finding, not this gate's.
+        return None
+    try:
+        with open(full, encoding="utf-8") as fh:
+            head = fh.read(2000)
+    except OSError:
+        return None
+    m = re.search(r"^status:\s*(\S+)", head, re.M)
+    return m.group(1).strip() if m else None
+
+
+def check(root):
+    problems = []
+    rdir = os.path.join(root, ROADMAP)
+    if not os.path.isdir(rdir):
+        return problems
+    for name in sorted(os.listdir(rdir)):
+        if not name.endswith(".md"):
+            continue
+        rel = os.path.join(ROADMAP, name)
+        try:
+            with open(os.path.join(rdir, name), encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+
+        # ---- R4: a doc that says it is not a phase, filed as one -----------
+        #
+        # Searched in the STATUS field only, not the whole document. Searching
+        # the body flagged phase-419 itself -- the phase that SPECIFIES this
+        # rule quotes the phrase while describing it. That is the same trap as
+        # counting the word LANDED: a gate that cannot tell a claim from a
+        # sentence about a claim flags its own specification, which is exactly
+        # what `check-workflow-repo-env` warns about ("a gate that cannot tell a
+        # command from a sentence about a command is worse than no gate").
+        #
+        # phase-275 put it where a claim belongs: "**Status.** NOT A WORK-ITEM
+        # PHASE - these are branch working notes".
+        if NOT_A_PHASE.search(header_block(text)):
+            problems.append(
+                (rel, "R4", "says NOT A WORK-ITEM PHASE while in the active roadmap series")
+            )
+
+        # ---- R1: header says unstarted, body has ticked work items ---------
+        head = header_block(text)
+        ticked = len(TICKED.findall(text))
+        if head and ticked and NOT_STARTED.search(head) and not ADMITS.search(head):
+            problems.append(
+                (
+                    rel,
+                    "R1",
+                    f"header claims not-started ({status_line(text).strip()[:60]!r}) "
+                    f"but {ticked} work item(s) are ticked",
+                )
+            )
+
+        # ---- R3: an owned issue is resolved, unannotated --------------------
+        for owns in OWNS.findall(text):
+            for label, path, num in ISSUE_LINK.findall(owns):
+                if "resolved" in label.lower() or "archived" in label.lower():
+                    continue
+                # The annotation is often placed after the link rather than in it.
+                tail = owns[owns.find(path) + len(path) : owns.find(path) + len(path) + 40]
+                if re.search(r"resolved|archived|closed", tail, re.I):
+                    continue
+                st = issue_status(root, path.replace("../", "docs/"))
+                if st in ("resolved", "wontfix"):
+                    problems.append(
+                        (rel, "R3", f"Owns issue {num}, which is `status: {st}`, without saying so")
+                    )
+    return problems
+
+
+def load_baseline(root):
+    path = os.path.join(root, BASELINE)
+    if not os.path.exists(path):
+        return set()
+    out = set()
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.split("#", 1)[0].strip()
+            if line:
+                out.add(line)
+    return out
+
+
+def key(p):
+    return f"{p[0]}\t{p[1]}"
+
+
+def self_test(quiet=False):
+    """Each case asserts a failure this gate must catch, plus the clean cases.
+
+    Fixture documents rather than the live tree: every finding this gate was
+    built from has since been CORRECTED, so asserting against `docs/roadmap/`
+    would assert nothing. The two clean cases are the ones a first cut got
+    wrong, and they are the reason the rule has its shape.
+    """
+    cases = [
+        (
+            "r1-contradiction",
+            "phase-900-x.md",
+            "# P\n\n**Status.** Planned\n\n- [x] a done thing\n",
+            True,
+        ),
+        (
+            "r1-honest-self-disclosure-is-NOT-a-finding",
+            "phase-901-x.md",
+            "# P\n\n**Status (2026-01-01). PROPOSED — W0 landed, W1–W5 not started.**\n\n- [x] W0\n",
+            False,
+        ),
+        (
+            "r1-word-LANDED-in-prose-is-NOT-a-finding",
+            "phase-902-x.md",
+            "# P\n\n**Status.** PROPOSED — nothing landed.\n\nphase-1 LANDED. phase-2 LANDED.\n",
+            False,
+        ),
+        (
+            "r1-genuinely-not-started-is-clean",
+            "phase-903-x.md",
+            "# P\n\n**Status.** Not Started.\n\n- [ ] a thing\n",
+            False,
+        ),
+        (
+            "r4-not-a-work-item-phase",
+            "phase-904-x.md",
+            "# P\n\n**Status.** NOT A WORK-ITEM PHASE — branch notes.\n",
+            True,
+        ),
+        (
+            # The gate flagged its OWN specification on its first live run:
+            # phase-419 quotes this phrase while describing R4. Pinned so the
+            # rule can never widen back to the whole document.
+            "r4-the-phrase-in-PROSE-is-NOT-a-finding",
+            "phase-905-x.md",
+            "# P\n\n**Status.** In progress.\n\nR4 flags a doc that says "
+            "NOT A WORK-ITEM PHASE in its status.\n",
+            False,
+        ),
+    ]
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        rd = os.path.join(tmp, ROADMAP)
+        os.makedirs(rd)
+        for name, fname, body, want in cases:
+            for stale in os.listdir(rd):
+                os.remove(os.path.join(rd, stale))
+            with open(os.path.join(rd, fname), "w", encoding="utf-8") as fh:
+                fh.write(body)
+            got = bool(check(tmp))
+            if got != want:
+                print(f"  self-test FAIL: {name} — got {got}, want {want}")
+                failures += 1
+            elif not quiet:
+                print(f"  ok    {name}")
+
+        # R3 needs an issue tree beside the phase.
+        for stale in os.listdir(rd):
+            os.remove(os.path.join(rd, stale))
+        idir = os.path.join(tmp, "docs", "issues")
+        os.makedirs(idir, exist_ok=True)
+        with open(os.path.join(idir, "0001-x.md"), "w", encoding="utf-8") as fh:
+            fh.write("---\nid: 1\nstatus: resolved\n---\n")
+        with open(os.path.join(rd, "phase-905-x.md"), "w", encoding="utf-8") as fh:
+            fh.write("# P\n\n**Status.** In progress.\n\n**Owns:** [issue 0001](../issues/0001-x.md)\n")
+        if not check(tmp):
+            print("  self-test FAIL: r3-owns-a-resolved-issue — not caught")
+            failures += 1
+        elif not quiet:
+            print("  ok    r3-owns-a-resolved-issue")
+
+        with open(os.path.join(rd, "phase-905-x.md"), "w", encoding="utf-8") as fh:
+            fh.write(
+                "# P\n\n**Status.** In progress.\n\n"
+                "**Owns:** [issue 0001](../issues/0001-x.md) (resolved)\n"
+            )
+        if check(tmp):
+            print("  self-test FAIL: r3-annotated-resolved-is-clean — flagged anyway")
+            failures += 1
+        elif not quiet:
+            print("  ok    r3-annotated-resolved-is-clean")
+
+    if failures:
+        print(f"check-roadmap-claims self-test: FAILED ({failures})")
+        return 1
+    return 0
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] == "--self-test":
+        return self_test()
+
+    # Always, not only behind the flag: a negative control nobody runs decays
+    # into a comment, and this rule's whole job is to fire. Same shape as
+    # `scripts/check-knob-delivery.py`; gated by `check-gate-selftests`.
+    rc = self_test(quiet=True)
+    if rc:
+        return rc
+
+    problems = check(ROOT)
+    baseline = load_baseline(ROOT)
+    keys = {key(p) for p in problems}
+
+    if len(argv) > 1 and argv[1] == "--write-baseline":
+        path = os.path.join(ROOT, BASELINE)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(
+                "# phase-419 W2 — roadmap phases whose claims contradict their own\n"
+                "# body. RATCHET: this list may only SHRINK. Each line is a finding\n"
+                "# for a person to work, not debt to hide; fix the phase and delete\n"
+                "# the line.\n"
+            )
+            for k in sorted(keys):
+                fh.write(k + "\n")
+        print(f"wrote {BASELINE} — {len(keys)} entr(ies)")
+        return 0
+
+    new = [p for p in problems if key(p) not in baseline]
+    gone = sorted(baseline - keys)
+
+    if new:
+        print("check-roadmap-claims: a phase contradicts its own body:")
+        for path, rule, why in new:
+            print(f"  [{rule}] {path}")
+            print(f"        {why}")
+        print(
+            "\n  A status line that has outlived its content is worse than none:\n"
+            "  a reader cannot use it without re-deriving it. Correct the phase,\n"
+            "  or -- if the claim is right and the shape is wrong -- say why in\n"
+            f"  the doc. Accept a known one with `--write-baseline` ({BASELINE}).\n"
+            "  phase-419."
+        )
+        return 1
+
+    if gone:
+        print("check-roadmap-claims: baseline entr(ies) no longer offend — delete them:")
+        for g in gone:
+            print(f"  {g}")
+        print("\n  The baseline may only SHRINK, and it may not go stale.")
+        return 1
+
+    print(
+        f"check-roadmap-claims: OK — {len(problems)} known finding(s), no new ones "
+        f"across {len(os.listdir(os.path.join(ROOT, ROADMAP)))} active phase doc(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/roadmap-audit.py
+++ b/scripts/roadmap-audit.py
@@ -54,7 +54,6 @@ import argparse
 import datetime
 import os
 import re
-import subprocess
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -189,7 +188,7 @@ def audit(max_age_days):
 
 
 def main(argv):
-    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     ap.add_argument("--max-age-days", type=int, default=60)
     ap.add_argument("--markdown", action="store_true", help="emit a report body")
     args = ap.parse_args(argv[1:])

--- a/scripts/roadmap-audit.py
+++ b/scripts/roadmap-audit.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Candidates for a roadmap verification pass — a REPORT, never a gate.
+
+phase-419 W3.
+
+W2's `check-roadmap-claims` takes the mechanical half: a phase that contradicts
+its own body. This takes the other half, and it cannot be a gate for the reason
+the phase records — supersession, a reversed premise and a claim of absence all
+need judgment, and a gate that guessed at them would either flag honest
+documents or teach people to ignore it.
+
+So this prints CANDIDATES with the evidence beside them, and a person or an
+agent decides. Exit status is 0 unless the script itself broke; a finding is not
+a failure. `pr-verdicts.yml` documents the same shape and why it stays advisory:
+a check that produces no verdict for a pull request blocks it forever (#0975).
+
+WHAT IT LOOKS FOR, and why each is here
+
+  dead-path    A phase cites a repo path that does not exist. This is R2 from
+               the phase doc, and W1 measured that it is only PARTLY covered:
+               `check-doc-refs` validates the numbered doc series, and
+               `check-ci-doc-workflow-refs` validates workflow names but only
+               inside three hand-listed `docs/development/` files. Roadmap docs
+               are covered by neither -- 20 dead workflow references across 8
+               phases on 2026-09-04, of which phase-196 alone held 11 and one of
+               them was its single open acceptance criterion.
+
+               Extending that gate needs a baseline it does not have, so it is
+               reported here rather than enforced. Not every dead path is a
+               defect: a phase legitimately describes what a workflow USED to be
+               called, which is why `check-ci-doc-workflow-refs` has a
+               "Historical workflow names" exemption and why this cannot be
+               mechanical.
+
+  stale-issue  A phase links an issue that is now resolved or archived. R3 in
+               W2 asserts this only for the `**Owns:**` line, where the house
+               convention already annotates it. Everywhere else a link to a
+               resolved issue is often correct -- a phase cites the issue that
+               MOTIVATED it -- so it is a candidate, not a rule.
+
+  cold         The status line's date is older than the threshold and the file
+               has not been touched since. Not evidence of anything on its own;
+               it is how you choose which phases to read when you cannot read
+               all of them. Eight of the thirteen oldest were stale on
+               2026-09-04, which is the ratio that motivates the pass.
+
+The three judgment classes W2 cannot reach at all -- supersession, a reversed
+premise, a claim of absence -- have no heuristic here on purpose. The phase doc
+carries them as worked examples instead, because each was found by a different
+move and the move is the transferable part.
+"""
+
+import argparse
+import datetime
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROADMAP = os.path.join(ROOT, "docs", "roadmap")
+
+STATUS = re.compile(r"^\s*(?:\*\*|##\s*)?Status\b", re.I)
+DATE = re.compile(r"(20\d{2})-(\d{2})-(\d{2})")
+WORKFLOW_REF = re.compile(r"`([a-z0-9][a-z0-9._-]*\.ya?ml)`")
+# A backticked path with a directory separator, which is what a citation of
+# repo CODE looks like. A bare word in backticks is prose far too often.
+PATH_REF = re.compile(r"`((?:[a-zA-Z0-9_.-]+/){1,}[a-zA-Z0-9_.-]+\.(?:rs|py|sh|toml|cmake|c|h|hpp|cpp|just|md))`")
+ISSUE_LINK = re.compile(r"\]\(([^)]*?/(\d{4})-[a-z0-9-]+\.md)\)")
+
+# Names that are a FORMAT or a third party's file, not one of ours. Mirrors the
+# same list in `check-ci-doc-workflow-refs.py` rather than inferring one: an
+# inferred exemption is one nobody can audit.
+NOT_OURS = {
+    "action.yml", "docker-compose.yml", "west.yml", "package.yml", "config.yml",
+    # DATA files a phase names, not workflows. phase-330 cites both while
+    # describing the SystemModel artifact; a `.yaml` suffix is not evidence of
+    # a workflow. Explicit rather than inferred, for the reason the sibling
+    # gate gives: an inferred exemption is one nobody can audit.
+    "sim_model.yaml", "system_model.yaml", "launch.yaml", "system.yaml",
+}
+
+# A cited path is only OURS if it is rooted in one of our top-level directories.
+# Without this the report flagged 56 of 63 phases -- 89% is not a filter. The
+# noise was book-relative fragments (`concepts/architecture.md`), Zephyr's own
+# tree (`soc/xlnx/.../soc.c`), and paths into the consumer repo
+# (`autoware-safety-island/...`). None of those are this repo's to resolve, and
+# a report nobody can read is the same as no report.
+# `check-doc-refs` already owns the numbered doc series, INCLUDING its
+# archived/ fallback. Reporting those here would double-report a covered class
+# and make this report disagree with a gate -- the failure mode W1 exists to
+# avoid.
+SERIES_DOC = re.compile(r"^docs/(design|issues|roadmap)/(phase-)?\d{3,4}-")
+
+# `tests` and `config` are DELIBERATELY absent: both are common RELATIVE
+# fragments inside a package ("tests/parity.rs" means that crate's own tests
+# dir), not repo-rooted paths, and including them put unresolvable relative
+# references into the report as if they were dead files.
+OUR_ROOTS = {
+    "packages", "scripts", "just", "docs", "cmake", "examples",
+    ".github", "book", "zephyr", "ci",
+}
+
+
+def workflows_present():
+    d = os.path.join(ROOT, ".github", "workflows")
+    return set(os.listdir(d)) if os.path.isdir(d) else set()
+
+
+def status_date(text):
+    for line in text.split("\n"):
+        if STATUS.match(line):
+            m = DATE.search(line)
+            if m:
+                try:
+                    return datetime.date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+                except ValueError:
+                    return None
+            return None
+    return None
+
+
+def issue_state(path):
+    """(status, exists) for a linked issue path written relative to docs/roadmap."""
+    full = os.path.normpath(os.path.join(ROADMAP, path))
+    if not os.path.exists(full):
+        return None, False
+    try:
+        with open(full, encoding="utf-8") as fh:
+            head = fh.read(2000)
+    except OSError:
+        return None, True
+    m = re.search(r"^status:\s*(\S+)", head, re.M)
+    return (m.group(1).strip() if m else None), True
+
+
+def audit(max_age_days):
+    present = workflows_present()
+    today = datetime.date.today()
+    rows = []
+    for name in sorted(os.listdir(ROADMAP)):
+        if not name.endswith(".md"):
+            continue
+        path = os.path.join(ROADMAP, name)
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+
+        dead_wf = sorted(
+            {
+                w
+                for w in WORKFLOW_REF.findall(text)
+                if w not in present and w not in NOT_OURS
+            }
+        )
+        dead_paths = sorted(
+            {
+                p
+                for p in PATH_REF.findall(text)
+                if p.split("/", 1)[0] in OUR_ROOTS
+                and not SERIES_DOC.match(p)
+                and not os.path.exists(os.path.join(ROOT, p))
+            }
+        )
+        stale_issues = sorted(
+            {
+                num
+                for p, num in ISSUE_LINK.findall(text)
+                if (lambda s: s[0] in ("resolved", "wontfix"))(issue_state(p))
+            }
+        )
+        d = status_date(text)
+        age = (today - d).days if d else None
+        cold = age is not None and age > max_age_days
+
+        # `cold` alone does NOT qualify a row. Age is a prioritisation hint,
+        # not evidence -- phase-162 is 'Not Started' and CORRECT, and a report
+        # that flagged every old phase would be a list of the roadmap.
+        if dead_wf or dead_paths or stale_issues:
+            rows.append((name, dead_wf, dead_paths, stale_issues, age))
+    # Strongest signal first. Measured 2026-09-04 across 63 active phases: dead
+    # WORKFLOW refs and resolved-issue links flag 8 phases each and were right
+    # both times they were chased (phase-196's stranded acceptance criterion,
+    # phase-356's issue 0260). Dead PATHS flag 17 and are the weak column -- a
+    # phase legitimately names a file that has since moved, and only phase-196's
+    # eleven-at-once was a real finding. A triage reads top-down and stops when
+    # the evidence thins.
+    rows.sort(key=lambda r: (-len(r[1]), -len(r[3]), -len(r[2]), r[0]))
+    return rows
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--max-age-days", type=int, default=60)
+    ap.add_argument("--markdown", action="store_true", help="emit a report body")
+    args = ap.parse_args(argv[1:])
+
+    rows = audit(args.max_age_days)
+    total = len([f for f in os.listdir(ROADMAP) if f.endswith(".md")])
+
+    if args.markdown:
+        print("## Roadmap verification candidates (phase-419 W3)\n")
+        print(f"{len(rows)} of {total} active phases have at least one candidate signal.")
+        print("A signal is NOT a defect — see `scripts/roadmap-audit.py` for why each")
+        print("needs a person. Work the evidence, not the count.\n")
+        print("| phase | dead workflow refs | dead paths | resolved issues linked | status age |")
+        print("| --- | --- | --- | --- | ---: |")
+        for name, wf, paths, iss, age in rows:
+            print(
+                f"| `{name[:-3]}` | {', '.join(f'`{w}`' for w in wf) or '—'} "
+                f"| {', '.join(f'`{p}`' for p in paths[:3]) or '—'} "
+                f"| {', '.join(iss) or '—'} | {age if age is not None else '—'}d |"
+            )
+        return 0
+
+    print(f"roadmap-audit: {len(rows)} of {total} active phase(s) carry a candidate signal.")
+    print("A signal is NOT a defect — each needs a person. Evidence below.\n")
+    for name, wf, paths, iss, age in rows:
+        print(f"── {name[:-3]}" + (f"   (status {age}d old)" if age is not None else ""))
+        if wf:
+            print(f"     dead workflow refs: {', '.join(wf)}")
+        if paths:
+            print(f"     dead paths:         {', '.join(paths[:5])}")
+        if iss:
+            print(f"     resolved issues:    {', '.join(iss)}")
+    print(
+        "\nThe three classes this cannot reach — supersession, a reversed premise,\n"
+        "a claim of absence — are worked examples in phase-419 W3, not heuristics."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Supersedes #336 — same phase doc, plus the implementation. #336 was queued, which locks its branch, so this carries both commits.

## W1 — overlap measured first, as the phase requires

- `check-doc-refs` owns the numbered doc series, including the `archived/` fallback.
- `check-ci-doc-workflow-refs` has the workflow-reference logic but a **hardcoded three-file scope** (`docs/development/ci-*.md`). Roadmap docs are covered by **neither** — 20 dead workflow references across 8 phases, **11 in phase-196 alone**, one of which was its single open acceptance criterion.
- R1, R3, R4: not covered by anything.

## W2 — `scripts/check-roadmap-claims.py`

Buildless, offline, self-testing on the normal path, ratcheted, fast line.

### Two rules changed shape because the gate flagged its own documentation

This is the most useful thing that happened:

- **R1 keys on ticked checkboxes, not the word `LANDED`.** phase-419's doc says *"PROPOSED — nothing landed"* in its header and contains **13 occurrences of `LANDED`**, every one prose about *other* phases. A word-counting first cut flagged the phase proposing the gate.
- **R4 searches the status field, not the document.** Searching the body flagged phase-419 again — the phase that *specifies* R4 quotes `NOT A WORK-ITEM PHASE` while describing it. The same trap `check-workflow-repo-env` names: a gate that cannot tell a claim from a sentence about a claim.

Both pinned as self-test cases so neither rule can widen back.

R1 also excludes headers that **admit** progress, or it flags phase-375 (*"PROPOSED — W0 landed, W1–W5 not started"*) — honest self-disclosure, and a gate that flags honesty is one people switch off. And `header_block` stops at the next bold **field**: phase-325 runs Status / Implements / Successor to / Informed by / Blocked on as contiguous lines, and reading its *"W0–W2 are done"* (in `**Blocked on:**`) as part of the status hid a phase whose status says *"Draft. Not started."* over **14 ticked boxes**.

### The baseline is findings, not debt

```
phase-230  R1   already corrected in #322 — line deletes when it lands
phase-275  R4   same
phase-292  R1   "Draft", 17 of 18 boxes ticked — LIVE, unworked
phase-325  R1   "Draft. Not started." + 14 ticked — LIVE, unworked
```

When #322 lands, the ratchet will report those two entries "no longer offend" and ask for their deletion — the behaviour that caught me earlier today when archiving phase-275 stranded a `doc-recipe-refs` baseline line.

### R2 not done, with its cost measured

Extending `check-ci-doc-workflow-refs` means giving it a baseline it does not have, for 20 references most of which are legitimate history. Reported by W3 instead.

## W3 — `just roadmap-audit` + a monthly `roadmap-audit.yml`

A report, never a gate, never on `pull_request` (a scheduled job in the required set is the #0975 deadlock). Writes to `$GITHUB_STEP_SUMMARY` because issue 1029 was eight nights of a lane whose deciding value existed only in a log this workflow family renders lossily.

**Its heuristics were tuned against noise rather than shipped as first written.** The first run flagged **56 of 63** phases — 89% is not a filter. Restricting cited paths to our own top-level roots, excluding the numbered series `check-doc-refs` already owns, dropping `tests/` and `config/` (relative fragments, not repo roots), and refusing to let **age alone** qualify a row brought it to **29 of 63**. Rows sort strongest-signal-first; phase-196 with its 11 dead workflow refs leads.

`just check fast` green, 217 gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)