### PR TITLE
test(#1016): a filtered run can no longer report skips as failures

### DIFF
--- a/justfile
+++ b/justfile
@@ -903,6 +903,78 @@ test-unit verbose="":
     just _check-skip-budget
     echo "All failures were [SKIPPED] preconditions — treating as pass."
 
+# Run an ARBITRARY nextest filter with honest skip accounting (issue 1016).
+#
+# `nros_tests::skip!` panics with `[SKIPPED]`, and nextest has no native skip —
+# so a bare `cargo nextest run -E ...` reports every unmet precondition as a
+# FAILURE. The summary line for "six cells were never built" is then
+# character-for-character the summary line for "six cells ran and failed":
+#
+#     Summary [295.800s] 9 tests run: 0 passed, 9 failed, 45 skipped
+#
+# `test-all` and `test-integration` already rewrite those to `<skipped>` before
+# tallying, but both carry a FIXED filter, so anyone running a subset by hand
+# got the raw count. That is not hypothetical: it produced a wrong reading in
+# issue 0968 — six of nine zephyr cells reported as failures when they were
+# out-of-lane skips, and only the panic frame distinguished them.
+#
+#     just test-select 'test(/example_e2e::case_(19|2[0-7])_xrce_/)'
+#     just test-select 'binary(rtos_e2e) and test(Platform__Nuttx)'
+#
+# Deliberately NOT calling `_check-skip-budget`: that guard exists so a full
+# sweep cannot report green having run nothing, and its budget is a property of
+# the sweep. A filtered run may legitimately skip everything it selected (every
+# cell out of lane is the normal case), so applying it here would fail correct
+# runs. The skip REASONS are printed instead — read them.
+test-select filter verbose="":
+    #!/usr/bin/env bash
+    set -e
+    source scripts/build/cargo.sh
+    source scripts/test/nextest-profile.sh
+    cargo_nextest_args=($(nros_cargo_nextest_args))
+    args=(-E '{{filter}}')
+    if [ -n "{{verbose}}" ]; then args+=(--no-capture); fi
+    nros_nextest_junit_reset
+    set +e
+    cargo nextest run "${cargo_nextest_args[@]}" "${args[@]}"
+    rc=$?
+    set -e
+    junit="$(nros_nextest_junit_path)"
+    just _rewrite-skipped-junit "$junit" || true
+    [ $rc -eq 0 ] && exit 0
+    # Same refusal as `test-all`: a build/setup failure emits no junit cases and
+    # would otherwise tally as "0 real failures" (issue #29).
+    # Exit 4 is nextest's "no tests to run" — the filter matched nothing. That
+    # is a distinct failure from a broken build and deserves its own sentence:
+    # a filter selecting nothing is the hazard phase-373 names, because it looks
+    # exactly like a lane with nothing to do.
+    if [ "$rc" -eq 4 ]; then
+        echo "ERROR: the filter selected NO tests — nothing ran."
+        echo "       '{{filter}}' matched none of the test names in this tree."
+        echo "       This is not a pass. Check the expression against \`cargo nextest list\`."
+        exit 1
+    fi
+    if [ "$rc" -ne 100 ] || [ ! -f "$junit" ]; then
+        echo "ERROR: nextest build/setup failed (nextest exit $rc) — not a [SKIPPED] precondition."
+        exit 1
+    fi
+    real="$(just _count-real-failures "$junit")"
+    just _test-summary "$junit" || true
+    if [ "$real" -ne 0 ]; then
+        echo "ERROR: $real real (non-[SKIPPED]) test failure(s):"
+        just _name-real-failures "$junit" || true
+        exit 1
+    fi
+    # Say the number outright. `_test-summary` counts `<failure>` elements, and
+    # the rewrite has just turned these into `<skipped>` — so it correctly
+    # reports "Real failures: 0 / 0", which on its own reads as "nothing
+    # happened" rather than "nine cells declined to run".
+    skipped="$(grep -c '<skipped' "$junit" 2>/dev/null || echo 0)"
+    echo "All failures were [SKIPPED] preconditions — treating as pass."
+    echo "  $skipped selected test(s) SKIPPED, 0 ran. A filtered run that skips"
+    echo "  everything is legitimate (out-of-lane is the normal case) — but it is"
+    echo "  NOT evidence about the code. Reasons are in the [SKIPPED] lines above."
+
 # nros-tests integration tests, skipping heavy cross-compile / QEMU groups.
 # Filters mirror the `test` recipe's `-E` predicate, just scoped to
 # `package(nros-tests)` so the workspace unit tests aren't re-run.


### PR DESCRIPTION
**Rescoped.** This PR previously also carried the #1039 NuttX `stdbool` workaround and its issue. Both are dropped: **#1035 on main is the same defect, already resolved**, and its fix corrects zenoh-pico's `#if ... == true` at the source, where mine force-included a conforming `true`/`false` ahead of every TU to paper over NuttX's header. Theirs is the better fix and it landed first. Main carries no workaround of mine, and needs none.

What remains is the part nothing on main duplicates.

## A filtered run can no longer report skips as failures

`nros_tests::skip!` panics with `[SKIPPED]`, and nextest has no native skip — so a bare `cargo nextest run -E ...` reports every unmet precondition as a FAILURE. The summary line for "six cells were never built" is character-for-character the line for "six cells ran and failed":

```
Summary [295.800s] 9 tests run: 0 passed, 9 failed, 45 skipped
```

`test-all` and `test-integration` already rewrite those to `<skipped>` before tallying, but both carry a **fixed filter**, so anyone running a subset by hand got the raw count. That is not hypothetical: it produced six phantom results in issue #0968, where only the panic frame distinguished them from real failures.

`just test-select '<nextest filter>'` runs an arbitrary filter through the same rewrite and real-failure accounting, then says the number outright:

```
9 selected test(s) SKIPPED, 0 ran. A filtered run that skips
everything is legitimate (out-of-lane is the normal case) — but it is
NOT evidence about the code. Reasons are in the [SKIPPED] lines above.
```

`_test-summary` cannot say that: it counts `<failure>` elements, and after the rewrite it correctly reports `Real failures: 0 / 0` — which on its own reads as "nothing happened" rather than "nine cells declined to run".

## Two deliberate differences from `test-all`

- **No `_check-skip-budget`.** That guard exists so a full sweep cannot report green having run nothing, and its budget is a property of the sweep. A filtered run may legitimately skip everything it selected, so applying it here would fail correct runs.
- **Exit 4 gets its own sentence.** nextest's "no tests to run" means the filter matched nothing — the hazard phase-373 names, because it looks exactly like a lane with nothing to do. Reporting it as "build/setup failed" would misdirect.

## Verified

| path | command | result |
| --- | --- | --- |
| all skipped | `test(/example_e2e::case_(19\|2[0-7])_xrce_/)` under tier-2 coords | rc 0, "9 selected test(s) SKIPPED, 0 ran", per-cell reasons above it |
| no match | `test(nonexistent_xyzzy)` | rc 1, "the filter selected NO tests" |
| passing | `test(cross_libc)` | rc 0, "1 test run: 1 passed" |

Re-verified on current main after the rescope: the justfile parses and the no-match path still reports correctly.

**Not verified:** the real-failure branch. It is copied verbatim from `test-all`'s and needs a genuinely failing test to exercise, which I did not manufacture.

## Note on #1016's own text

Its premise — that `lane=tier2` does not build the zephyr rust/c west leaves — is **wrong**, and the issue on main still says it. `lane-coords tier2` contains exactly one zephyr coordinate (`zephyr,cpp,xrce`), so those leaves are legitimately out of lane and the run skips them correctly. They did not skip in my original measurement because I ran `cargo nextest` directly without `NROS_TEST_COORDS`, so the guard was inactive. The surviving half is the summary-level conflation this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
