### PR TITLE
fix(#1033): NROS_RMW_SUBSCRIBER_SLOTS admits zero too — the second floor the same question found

### DIFF
--- a/packages/rmw/cffi/build.rs
+++ b/packages/rmw/cffi/build.rs
@@ -90,9 +90,21 @@ fn emit_subscriber_slots() {
     // builtin and takes its platform answer from the derivation instead.
     let parsed = knob("NROS_RMW_SUBSCRIBER_SLOTS", None, 8);
 
-    if !(1..=128).contains(&parsed) {
+    // issue 1033 — ZERO is in range. A pub-only image derives 0 subscriptions
+    // from the entity inventory, and 0 slots is the honest answer: `[T; 0]` is
+    // ordinary Rust (no zero-length-array question as in C), and the only
+    // access is `for index in 0..SLOT_COUNT`, which at 0 does not run.
+    //
+    // The floor was 1 while the derivation could never produce 0 — every image
+    // refused for want of a declaration, so the knob fell to its default of 8
+    // and the bound was never exercised. Making the derivation reachable turned
+    // that latent disagreement into a build failure on the zephyr cpp talker,
+    // which is the first image ever to derive 0 here. Refusing it would clamp,
+    // and clamping is what issue 0827 forbids: it "reserved the memory anyway
+    // while reading as though the knob had been honoured".
+    if !(0..=128).contains(&parsed) {
         panic!(
-            "NROS_RMW_SUBSCRIBER_SLOTS={parsed} out of range [1, 128]. Each \
+            "NROS_RMW_SUBSCRIBER_SLOTS={parsed} out of range [0, 128]. Each \
              slot is a 1 KiB static; bump the upper bound only with the \
              memory budget in hand."
         );


### PR DESCRIPTION
Making the entity derivation reachable (#332) broke four zephyr cpp images:

```
NROS_RMW_SUBSCRIBER_SLOTS=0 out of range [1, 128]
```

A **different crate with the same defensive floor**. It had never been exercised: until the composition fix, every image refused for want of a declaration and the knob fell to its default of 8, so nothing could ever produce 0. The zephyr cpp **talker** — a publisher and a timer, no subscriptions — is the first image in this tree to derive it, and the bound was wrong the moment the derivation started working.

## Zero is right, and more plainly than in the C case

- `[T; 0]` is ordinary Rust — no zero-length-array question at all.
- The only access is `for index in 0..SLOT_COUNT`, which at 0 doesn't run.
- Refusing it would clamp to 1, and clamping is what issue 0827 forbids in as many words: *"reserved the memory anyway while reading as though the knob had been honoured."*

Range becomes `[0, 128]`.

## Result

All six zephyr cpp xrce images build, and **every one now fits its 66,048-byte heap** — where all six previously requested 427,968:

| image | `sizeof(xrce_session_state_t)` |
| --- | ---: |
| talker | 25,792 |
| service-client | 25,792 |
| service-server | 30,176 |
| action-server | 38,944 |
| listener | 59,088 |
| action-client | 59,088 |

## The multipliers are visibly doing their job

`action-server` derives `SERVICE_SERVERS=3` (`ACTION_SERVER_QUERYABLES`) and `action-client` derives `SUBSCRIBERS=1` (`ACTION_CLIENT_SUBSCRIPTIONS`). A raw per-kind count would have given 0 for both and under-sized them — which is exactly why #332 reused the audited aggregates instead of counting entries again.

Gates: `check fast` (195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)