### PR TITLE
fix(#1034): give .bss its own program header — 294.8 s of NuttX arm e2e becomes 134.1 s

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -477,6 +477,40 @@ jobs:
       # Only submodules that are initialised AND actually missing their
       # baseline commit are touched, so the cost lands on the one repo whose
       # pin moved rather than on every clone.
+      # An UNINITIALISED submodule whose pin moved is the same trap one step
+      # earlier, and it is the one that bites hardest: this job initialises
+      # exactly `packages/cli/third-party/play_launch`, so a bump to any OTHER
+      # submodule reaches the gate with no object store to read and fails
+      # `CANNOT VERIFY ... not initialised here`. That is unconditional — no
+      # amount of pushing, rebasing or re-running clears it, because nothing
+      # in the lane was ever going to provide the objects. Measured on the
+      # nuttx `.bss` pin bump (issue 1034), which could not pass CI at all
+      # while passing `just check fast` locally, where the submodule exists.
+      #
+      # `--filter=tree:0`: the gate needs COMMITS (for `merge-base
+      # --is-ancestor`) and nothing else, so trees and blobs stay on the
+      # server. Not `--depth`, for the reason spelled out above — a shallow
+      # commit is grafted as a root and destroys the connectivity the check
+      # is about. Only submodules whose pin actually MOVED are touched, so a
+      # PR that moves none pays nothing.
+      - name: Init submodules whose pin moved (commits only)
+        run: |
+          base="${GITHUB_BASE_REF:-main}"
+          git ls-tree -r "origin/$base" \
+            | awk '$2 == "commit" { print $4 "\t" $3 }' \
+            | while IFS=$'\t' read -r path base_sha; do
+                [ -n "$path" ] || continue
+                head_sha="$(git ls-tree -r HEAD -- "$path" \
+                            | awk '$2 == "commit" { print $3 }')"
+                [ -n "$head_sha" ] || continue
+                [ "$head_sha" != "$base_sha" ] || continue
+                [ ! -e "$path/.git" ] || continue
+                echo "  pin moved in $path (${base_sha:0:12} -> ${head_sha:0:12}); initialising"
+                git submodule update --init --filter=tree:0 "$path" \
+                  || git submodule update --init "$path" \
+                  || true
+              done
+
       - name: Fetch submodule history for check-submodule-pins
         run: |
           base="${GITHUB_BASE_REF:-main}"

--- a/docs/issues/1034-qemu11-elf-bss-zero-fill-stalls-nuttx-boot.md
+++ b/docs/issues/1034-qemu11-elf-bss-zero-fill-stalls-nuttx-boot.md
@@ -142,3 +142,103 @@ line introduced.
 
     # the discriminator
     arm-none-eabi-readelf -l <image> | grep '^  LOAD'
+
+---
+
+## FIXED 2026-09-04 — direction 1, in the NuttX fork's board linker script
+
+**Landing is blocked on one push.** The change is a commit on the `nuttx` fork's
+`nano-ros` branch (`aea00d73`, on top of the pinned `c3fa5dfb`, forward-only).
+Per AGENTS.md the agent does not push fork remotes, so the commit is local and
+the superproject pin cannot advance until a maintainer pushes it. Everything
+below is measured against that commit applied.
+
+### The change
+
+`boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld`:
+
+```
+-  .bss : {
++  .bss ALIGN(ADDR(.noinit) + SIZEOF(.noinit) + 1, 16) :
++       AT (LOADADDR(.noinit) + SIZEOF(.noinit)) {
+```
+
+Both halves are load-bearing:
+
+* the **ALIGN** forces `.bss`'s VMA off the end of the preceding section. `ld`
+  opens a new segment only when the next section's VMA is not contiguous, and
+  the `+ 1` before rounding makes that unconditional — an already-aligned
+  `.data` still moves. Cost: at most 15 bytes of RAM.
+* the **AT** keeps `.bss`'s LMA on the ROM run. Without it `ld` assigns
+  `LMA == VMA` in RAM, which splits the segment correctly and **breaks the
+  image** (see below).
+
+The result is byte-for-byte the layout the two naturally-split images already
+had: three `PT_LOAD`s, `.bss` at `p_filesz == 0` with an LMA in flash.
+
+### Measured
+
+All twelve NuttX arm C/C++ images, on `11.0.0-nros2`:
+
+| | before | after |
+| --- | --- | --- |
+| `PT_LOAD` count | 2 (ten images), 3 (two) | **3 (all twelve)** |
+| time to first console byte | 19.5–20.1 s (ten), 0.05 s (two) | **0.05–0.10 s (all twelve)** |
+
+`rtos_e2e`, the six NuttX C/C++ cells, `--retries 0`, same host, back to back:
+
+| cell | before | after |
+| --- | ---: | ---: |
+| action C | 25.7 s | 6.0 s |
+| action C++ | 45.7 s | 4.8 s |
+| pubsub C | 81.4 s | 61.1 s |
+| pubsub C++ | 79.6 s | 60.6 s |
+| service C | 20.9 s | 0.7 s |
+| service C++ | 41.3 s | 0.8 s |
+| **wall clock** | **294.8 s** | **134.1 s** |
+
+**6 of 6 passed before and after** — this is a latency change, not a behaviour
+change. The pubsub cells stay near 61 s because that is their deliberate
+60-sample window, which no longer has ~20 s of emulator stall in front of it.
+
+### Two variants that were wrong, and are worth not re-trying
+
+* **`. = . + 16;` between `.noinit` and `.bss` does nothing.** Both sections are
+  placed with `> RAM`, and a region-assigned output section takes its address
+  from the region's allocation pointer, so the bare dot assignment is ignored.
+  Verified in the generated script — the text was present and `.bss` still
+  started at `.data`'s end.
+* **`AT > RAM`, and an explicit ALIGN with no AT, both split the segment and
+  both break the image.** The image boots and prints its banner, then fails at
+  session open with `zpico Session -> ConnectionFailed`. Confirmed as an A/B
+  against a control built from the pristine script on the same tree, with a
+  working router, control re-run afterwards to rule out drift. The shift size is
+  not the variable: a 16-byte move fails exactly like a 0x250 one. The variable
+  is the LMA — flash works, RAM does not.
+
+  **Why an LMA in RAM breaks the network stack is NOT explained.** Nothing in
+  the boot path should read `.bss`'s load address. Recorded rather than guessed
+  at; anyone changing this section again should treat it as a live hazard.
+
+### Found on the way: two linker scripts, two sources, one link
+
+`nros-nuttx-ffi` preprocesses `$NUTTX_DIR/boards/arm/qemu/qemu-armv7a/scripts/
+dramboot.ld` — the LIVE tree — while `nros-board-nuttx-qemu` preprocesses
+`nros-nuttx-export-<arch>/scripts/dramboot.ld` — the SNAPSHOT. Both emit a
+`dramboot.ld` into their own `OUT_DIR`; only the `nros-nuttx-ffi` one reaches
+the link. Editing the snapshot alone therefore changes nothing while looking
+like it should, which cost a build cycle here. phase-339's rule is that
+consumers link the snapshot, so the `nros-nuttx-ffi` path is the odd one out.
+Not fixed here — it is a separate change with its own blast radius.
+
+### Still open in this issue
+
+The mechanism section above is still INFERRED: `third-party/qemu/qemu` is not
+initialised, so `hw/core/loader.c` was not read, and no stock upstream QEMU 11
+was available to say whether this is upstream behaviour or something our patch
+line introduced. The fix does not depend on that answer — it removes the
+zero-fill rather than changing how it is performed — but the answer is still
+worth having, because any other board whose `.data` is `AT > ROM` has the same
+exposure.
+
+Direction 3 (print which emulator resolved) is also not done.

--- a/docs/issues/1034-qemu11-elf-bss-zero-fill-stalls-nuttx-boot.md
+++ b/docs/issues/1034-qemu11-elf-bss-zero-fill-stalls-nuttx-boot.md
@@ -147,11 +147,13 @@ line introduced.
 
 ## FIXED 2026-09-04 — direction 1, in the NuttX fork's board linker script
 
-**Landing is blocked on one push.** The change is a commit on the `nuttx` fork's
-`nano-ros` branch (`aea00d73`, on top of the pinned `c3fa5dfb`, forward-only).
-Per AGENTS.md the agent does not push fork remotes, so the commit is local and
-the superproject pin cannot advance until a maintainer pushes it. Everything
-below is measured against that commit applied.
+The change is one commit on the `nuttx` fork's patch branch — `aea00d73` on
+`nano-ros`, a fast-forward over the previously pinned `c3fa5dfb` (0 behind,
+1 ahead) — pushed on the owner's instruction, with the superproject pin bumped
+to it in the same PR. Reading the fork's branches needed `git ls-remote`: the
+submodule is a single-branch clone (`+refs/heads/master:refs/remotes/origin/
+master`), so `git branch -a` showed only `master` and the `nano-ros` branch
+`.gitmodules` names looked as though it did not exist.
 
 ### The change
 

--- a/docs/issues/1043-pin-gate-cannot-verify-uninitialised-submodule.md
+++ b/docs/issues/1043-pin-gate-cannot-verify-uninitialised-submodule.md
@@ -1,0 +1,74 @@
+---
+id: 1043
+title: "`check-submodule-pins` fails CLOSED on any submodule CI does not
+  initialise, so a whole class of pin bump could never pass the required lane"
+status: open
+type: bug
+area: ci, tooling
+severity: high
+found: 2026-09-04
+related: [issue-0996, issue-1034, phase-395]
+---
+
+## What happened
+
+The nuttx pin bump in issue 1034 passed `just check fast` locally (197 gates OK)
+and failed the required `CI` context with:
+
+    ===== FAIL (submodule-pins, rc=1, 459ms) =====
+    submodule-pins: CANNOT VERIFY third-party/nuttx/nuttx
+        the pin moved c3fa5dfb0673 -> aea00d736d69 but the submodule is not
+        initialised here, so its history cannot be read.
+        Run: git submodule update --init third-party/nuttx/nuttx
+
+The remedy it prints is addressed to a developer with a checkout. In CI nobody
+can act on it: the `check` job initialises exactly one submodule
+(`packages/cli/third-party/play_launch`), plus the `-sys` sources `nros setup`
+provisions on the compile tier. `third-party/nuttx/nuttx` is in neither set, so
+the objects the gate needs were never going to exist.
+
+**So the failure is unconditional.** Re-running, rebasing, or pushing the
+submodule commit first — which was already done — changes nothing. Any pin bump
+to any submodule outside that small set is unmergeable through the required
+lane, and the gate reports it as if it were the author's mistake.
+
+## Why the existing machinery did not cover it
+
+`gate.yml` already has a step for the SHALLOW version of this trap ("Fetch
+submodule history for check-submodule-pins"), whose own comment says the gate
+"cannot fetch (check-fast is network-free), so the workflow provides". That step
+is guarded by `[ -e "$path/.git" ] || continue` — it deepens submodules that
+exist and skips the ones that do not, which is exactly the case that cannot
+recover on its own.
+
+The class is the one CLAUDE.md names for `check-lane-contracts`: a gate in an
+affordability tier may only resolve artifacts the job itself provides.
+`check-lane-contracts` enforces that for fixture STAMPS; a submodule object
+store is the same kind of dependency and is not covered.
+
+## Fixed here (the workflow half)
+
+A step ahead of the existing one initialises, commits-only, any submodule whose
+pin differs between the base and the head:
+
+    git submodule update --init --filter=tree:0 "$path"
+
+`--filter=tree:0` because `merge-base --is-ancestor` needs commits and nothing
+else. NOT `--depth`: the neighbouring comment already records that a shallow
+fetch grafts the commit as a root with no parent links, so the ancestry check
+then reports `DIVERGED` on a clean fast-forward. Only pins that actually moved
+are touched, so a PR that moves none pays nothing — and a pin that moved is
+precisely the one the gate is about to need.
+
+## Still open
+
+* **The gate's own message is wrong in CI.** It names a command the runner
+  cannot usefully run and reads as author error. It should distinguish "you have
+  no checkout of this submodule" from "this lane never provides one", the way
+  the shallow arm below it already distinguishes its two causes.
+* **`check-lane-contracts` does not cover submodule object stores**, only
+  fixture stamps. The rule it encodes is the right one; its coverage is narrower
+  than the rule, which is the issue-0196 shape.
+* Nothing tests this. The failure was found by a pin bump, and the next class
+  member — a submodule that is initialised but whose *history* the workflow's
+  deepening step cannot reach — would be found the same way.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -95,5 +95,6 @@ fails if this block drifts.
 - **#1029** (ci, testing) — The Zephyr dual-line nightly has its own 05:00 cron and every scheduled run SKIPS it, so the lane it exists to watch has produced no verdict for days See `1029-*`.
 - **#1034** (testing, tooling) — The provisioned QEMU 11 spends ~19.6 s materialising a NuttX image's `.bss` before the guest runs, and that stall is the whole C-vs-C++ asymmetry in issue 0870 See `1034-*`.
 - **#1038** (ci, build, testing) — nightly triage (phase-413 W2.3): three of six cell failures are one class — the platform job builds a lane whose prerequisites its own setup never installs; none is a product regression See `1038-*`.
+- **#1043** (ci, tooling) — `check-submodule-pins` fails CLOSED on any submodule CI does not initialise, so a whole class of pin bump could never pass the required lane See `1043-*`.
 
 <!-- END GENERATED open-issue list -->


### PR DESCRIPTION
Issue 1034, direction 1. One linker-script line in the `nuttx` fork gives `.bss`
its own program header, so an ELF loader has no ~600 KB of zeros to materialise
into the board's flash aperture.

The fork commit is pushed (`aea00d73` on `nano-ros`, a fast-forward over the
previously pinned `c3fa5dfb` — 0 behind, 1 ahead) and **this PR bumps the
superproject pin to it**, so merging lands the change. Reading the fork's
branches needed `git ls-remote`: the submodule is a single-branch clone, so
`git branch -a` showed only `master` and the `nano-ros` branch `.gitmodules`
names looked as though it did not exist.

```
-  .bss : {
+  .bss ALIGN(ADDR(.noinit) + SIZEOF(.noinit) + 1, 16) :
+       AT (LOADADDR(.noinit) + SIZEOF(.noinit)) {
```

| | before | after |
| --- | --- | --- |
| `PT_LOAD` count, 12 NuttX arm C/C++ images | 2 (ten), 3 (two) | **3 (all twelve)** |
| time to first console byte | 19.5–20.1 s (ten) | **0.05–0.10 s (all twelve)** |
| six `rtos_e2e` NuttX C/C++ cells, wall clock | **294.8 s** | **134.1 s** |

6/6 passed before and after — latency only, no behaviour change.

Both halves of the change are load-bearing. The `ALIGN` forces the VMA gap that
makes `ld` open a new segment (the `+ 1` makes it unconditional, ≤15 bytes of
RAM); the `AT` keeps the LMA on the ROM run. **Without the `AT`, the segment
splits correctly and the image breaks** — it boots, prints its banner, then
fails session open with `zpico Session -> ConnectionFailed`. A/B'd against a
control built from the pristine script, control re-run afterwards to rule out
drift; a 16-byte shift fails exactly like a 0x250 one, so the variable is the
LMA, not the distance. *Why* an LMA in RAM breaks the network stack is not
explained, and the issue says so rather than guessing.

Two things worth knowing that this turned up:

- a bare `. = . + 16;` between the sections **does nothing** — a region-assigned
  output section takes its address from the region pointer, so the dot
  assignment is ignored. Verified in the generated script.
- `nros-nuttx-ffi` preprocesses the **live tree's** linker script while
  `nros-board-nuttx-qemu` preprocesses the export **snapshot**, and only the
  former reaches the link. Editing the snapshot alone changes nothing while
  looking like it should. phase-339's rule is that consumers link the snapshot,
  so the `nros-nuttx-ffi` path is the odd one out — not fixed here.

`just check fast`: 195 gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
