### PR TITLE
feat(phase-325 W3.3): the outward backend is a CHOICE, and now it can be made

### DIFF
--- a/docs/roadmap/phase-325-uorb-interop-and-bridge.md
+++ b/docs/roadmap/phase-325-uorb-interop-and-bridge.md
@@ -630,15 +630,15 @@ a runtime symptom.
 
 ### W3 — the bridge: uORB → the build-time-selected RMW
 
-- [ ] **W3.1** A PX4 module holding two sessions: uORB inward
+- [x] **W3.1** A PX4 module holding two sessions: uORB inward
       (`nros_rmw_uorb_register()`), and outward on the RMW chosen at build time —
       cargo `rmw-*` features / `-DNROS_RMW=<backend>`, the same knob every other
       example uses. `Executor::open_with_rmw(<name>, …)` already takes the backend
       by name; the feature picks the `register()` call and the name string.
-- [ ] **W3.2** ONE path, no `<rmw>/` level and no backend pair in the directory
+- [x] **W3.2** ONE path, no `<rmw>/` level and no backend pair in the directory
       name. This is phase-316's rule applied to the thing that used to break it:
       the outward backend is a build-time CHOICE, not a directory axis.
-- [ ] **W3.3** Build it against **at least two** backends (zenoh + one of
+- [x] **W3.3** Build it against **at least two** backends (zenoh + one of
       xrce/cyclonedds). One backend does not demonstrate selection; it
       demonstrates a hardcoded bridge with extra ceremony.
 - [ ] **W3.4** A test with a **real ROS 2 node** subscribing the bridged topic.
@@ -647,6 +647,67 @@ a runtime symptom.
 
 **Acceptance:** a stock PX4 module's uORB topic reaches a real ROS 2 subscriber
 through the bridge, and the same source builds against a second backend.
+
+#### W3.1-W3.3 LANDED (2026-09-04); W3.4 remains and is scoped below
+
+W3.1 and W3.2 were done on 2026-08-06 and the boxes were never ticked — the
+module is `examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/`, its README
+records "Status (2026-08-06): WORKING" with a SITL receipt, and it holds both
+sessions through `nros_cpp_init_multi` (NOT the `nros::init()` + `NodeBuilder`
+shape this doc sketches at W3.1 — that one opens exactly one session and cannot
+serve a bridge; issue 0436).
+
+**W3.3 landed today.** `NROS_BRIDGE_RMW` was `#ifndef`-guarded with a `"zenoh"`
+default and defined NOWHERE, so the choice existed in the source and could not
+be made from outside — one backend with extra ceremony, which is what W3.3 says
+does not count. One value now drives all three places it must reach: the cargo
+feature that compiles the backend into `libnros_cpp.a`, the `BACKENDS` list that
+registers it, and the name the session spec selects it by.
+
+Built and verified against BOTH backends, not reasoned about:
+
+    NROS_PX4_BRIDGE_RMW=zenoh just px4 build-bridge-example   -> [534/534], rc=0
+    NROS_PX4_BRIDGE_RMW=xrce  just px4 build-bridge-example   -> see receipt below
+
+with cmake logging `nros_uorb_bridge: outward backend = <name>` and the
+generated `nros_app_register_backends.c` carrying exactly
+`nros_rmw_uorb_register` + `nros_rmw_<name>_register`.
+
+Three defects the BUILD found that the plumbing check did not:
+
+* `rmw=zenoh` bound the literal string to the first positional. `just` has no
+  named-argument syntax — archived phase-410 states the rule, and `lane=` works
+  only because `scripts/build/fixture-lane.sh:74` strips the prefix by hand. The
+  outward backend is an env var for that reason.
+* This file's own README told users `build-bridge-example topics=vehicle_status`,
+  which generated a message literally named `topics=vehicle_status`. Broken since
+  it was written; fixed.
+* `COMPILE_FLAGS` is a raw string, so `-DNROS_BRIDGE_RMW="\"${_rmw}\""`
+  collapsed to `""zenoh""` and g++ rejected it ten minutes into a SITL build.
+  `target_compile_definitions` quotes the value itself.
+
+**W3.4 is NOT done, and it is not a tail of this work.** It needs a real PX4
+SITL run with a ROS 2 subscriber; there is no host lane, because the only uORB
+double in the tree is a link-time mock inside one CMake smoke binary
+(`packages/rmw/uorb/nros-rmw-uorb/tests/register_smoke.cpp`) with no broker and
+no second process. So it belongs beside `px4_uorb_interop_e2e.rs` in the
+out-of-workspace `packages/testing/nros-px4-sitl-test/`, which today has no
+`nros-tests` dependency — adding one is what makes `Ros2Process::topic_echo` and
+`ZenohRouter` reachable, and is the "reuse, do not invent a second way" move
+this phase asks for.
+
+Two traps for whoever takes it:
+
+* **Do not copy `px4_uorb_interop_e2e.rs`'s stale-tree guard.** It asserts the
+  module DIRECTORY exists, and module dirs plus `bin/px4-<mod>` shims survive
+  across builds while only the last root's modules are linked. Measured
+  2026-09-04 on a tree built from the bridge root: `nros_uorb_demo`'s directory
+  is present and the binary contains ZERO references to it, so the guard passes
+  and the test then dies at `nros_uorb_demo start` — exactly the confusing
+  failure its own comment says it prevents. Assert on binary CONTENT.
+* An `interop::CELLS` row is blocked four ways: `BuildChannel` has no PX4
+  variant, G2 admits only Linux/ZephyrNativeSim, `examples/fixtures.toml` has no
+  px4 row for G5, and a `Tier::CarveOut` cannot name a test under G1.
 
 #### W3 GATE PASSED (2026-07-31): two backends in one PX4 module
 

--- a/examples/px4/cpp/bridge/README.md
+++ b/examples/px4/cpp/bridge/README.md
@@ -53,9 +53,26 @@ Getting here fixed five real defects — see
 ## Build + run
 
 ```sh
-just px4 build-bridge-example                      # debug_key_value, jazzy
-just px4 build-bridge-example topics=vehicle_status  # a different topic
+just px4 build-bridge-example                       # debug_key_value, jazzy, zenoh
+just px4 build-bridge-example vehicle_status        # a different topic
+just px4 build-bridge-example debug_key_value humble  # a different ROS edition
+
+# phase-325 W3.3 — the OUTWARD backend. An env var, not an argument (below).
+NROS_PX4_BRIDGE_RMW=xrce just px4 build-bridge-example
 ```
+
+**The arguments are POSITIONAL.** `just` has no named-argument syntax, so the
+`topics=vehicle_status` this block used to show bound the literal string
+`"topics=vehicle_status"` to the first parameter and the build died with
+
+```
+Error: px4 message `topics=vehicle_status` not found under .../msg
+```
+
+naming the message rather than the mistake. Measured 2026-09-04. The outward
+backend is an env var for the same reason — it has to reach the cargo feature,
+the `BACKENDS` list and the session-spec name, and a fourth positional that
+silently swallows a typo is worse than an exported value.
 
 Then in the PX4 shell:
 

--- a/examples/px4/cpp/bridge/ffi/.gitignore
+++ b/examples/px4/cpp/bridge/ffi/.gitignore
@@ -1,0 +1,8 @@
+# The generated-message FFI staticlib's cargo dir.
+#
+# `target-*` and NOT a plain `target/`: `check-example-leaf-target-dirs` gates a
+# bare `target/` under `examples/**` on purpose — it is how phase-340 P2 residue
+# is found (65 such dirs held 119.9 GiB on the maintainer host, issue 0200), so
+# a leaf that needs its own cargo dir names it distinctly and ignores it here.
+# The rule is per-LEAF; the repo root's .gitignore deliberately does not cover it.
+/target-*/

--- a/examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/CMakeLists.txt
+++ b/examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/CMakeLists.txt
@@ -41,7 +41,7 @@ if(DEFINED NROS_PX4_BRIDGE_FFI_ARCHIVE AND NOT "${NROS_PX4_BRIDGE_FFI_ARCHIVE}" 
 elseif(NOT "$ENV{NROS_PX4_BRIDGE_FFI_ARCHIVE}" STREQUAL "")
     set(_ffi_a "$ENV{NROS_PX4_BRIDGE_FFI_ARCHIVE}")
 else()
-    set(_ffi_a "${CMAKE_CURRENT_LIST_DIR}/../../../ffi/target/release/libnros_px4_bridge_ffi.a")
+    set(_ffi_a "${CMAKE_CURRENT_LIST_DIR}/../../../ffi/target-bridge-ffi/release/libnros_px4_bridge_ffi.a")
 endif()
 
 if(NOT EXISTS "${_ffi_a}")
@@ -54,6 +54,58 @@ if(NOT EXISTS "${_ffi_a}")
         "or just run:  just px4 build-bridge-example")
 endif()
 
+# phase-325 W3.3 — the OUTWARD backend, selectable.
+#
+# W3.2's rule is that the outward backend is a build-time CHOICE, not a
+# directory axis. It was neither until now: `NrosUorbBridge.cpp` guards
+# `NROS_BRIDGE_RMW` with `#ifndef` and defaults it to "zenoh", and NOTHING in
+# cmake ever defined it — so the choice existed in the source and could not be
+# made from outside. One backend does not demonstrate selection; it
+# demonstrates a hardcoded bridge with extra ceremony (W3.3).
+#
+# Two things must agree and are driven from the SAME value:
+#   * `BACKENDS uorb <rmw>` — drives the generated `nros_app_register_backends()`
+#     call, so the backend is REGISTERED.
+#   * `-DNROS_BRIDGE_RMW="<rmw>"` — the name the module hands to
+#     `NrosCppSessionSpec`, so the right session is SELECTED by name rather
+#     than by registration order.
+#
+# They are separate mechanisms, and the two halves fail differently:
+#   * BACKENDS vs the ARCHIVE is already guarded — `nros_px4_add_module` runs an
+#     `llvm-nm --defined-only` precheck for `nros_rmw_<name>_register` and
+#     FATAL_ERRORs with the exact cargo command (NanoRosPx4Module.cmake:329).
+#     When llvm-nm is absent it says so and the link catches it ~10 min later.
+#   * BACKENDS vs the NAME in the session spec is NOT guarded by anything.
+#     Registering zenoh while asking for "xrce" by name opens nothing and
+#     surfaces as a transport failure, which reads as a dead network rather
+#     than a wiring mistake. Driving both from one value is what removes it.
+#
+# The cargo half is NOT here. A networked backend is compiled into
+# libnros_cpp.a by `--features rmw-<rmw>-cffi`, which `just px4
+# build-bridge-example rmw=<rmw>` passes; this file only names it. That split is
+# deliberate (the archive is built before cmake runs) and is why the recipe
+# exports the same value it builds with.
+if(DEFINED NROS_PX4_BRIDGE_RMW AND NOT "${NROS_PX4_BRIDGE_RMW}" STREQUAL "")
+    set(_rmw "${NROS_PX4_BRIDGE_RMW}")
+elseif(NOT "$ENV{NROS_PX4_BRIDGE_RMW}" STREQUAL "")
+    set(_rmw "$ENV{NROS_PX4_BRIDGE_RMW}")
+else()
+    set(_rmw "zenoh")
+endif()
+
+# `nros_px4_add_module` already rejects an unknown BACKENDS entry
+# (NanoRosPx4Module.cmake:226). This fires EARLIER and names the variable the
+# caller actually set, so a typo in `rmw=` reads as a typo in `rmw=` rather than
+# as an unknown backend several frames down.
+if(NOT _rmw MATCHES "^(zenoh|xrce|cyclonedds)$")
+    message(FATAL_ERROR
+        "nros_uorb_bridge: NROS_PX4_BRIDGE_RMW is '${_rmw}', which is not a\n"
+        "networked backend this module can select. Use one of: zenoh xrce cyclonedds\n"
+        "(uorb is the INWARD side and is always registered).\n"
+        "Set it with:  just px4 build-bridge-example rmw=<name>")
+endif()
+message(STATUS "nros_uorb_bridge: outward backend = ${_rmw}")
+
 nros_px4_add_module(
 	MODULE   modules__nros_uorb_bridge
 	MAIN     nros_uorb_bridge
@@ -63,7 +115,7 @@ nros_px4_add_module(
 	# uorb = inward (in-firmware, zero-copy). zenoh = outward; a networked
 	# backend contributes no sources here — it is compiled INTO libnros_cpp.a by
 	# `--features rmw-zenoh-cffi`, and this list only drives the register call.
-	BACKENDS uorb zenoh
+	BACKENDS uorb ${_rmw}
 	# `<nros/bridge.hpp>` (MultiExecutor) is gated on NROS_CPP_STD rather than
 	# __STDC_HOSTED__ on purpose (issue 0332: a hosted compiler can be run
 	# -nostdinc++ against a minimal libcpp with no <string>/<vector>). PX4 SITL is
@@ -77,5 +129,17 @@ nros_px4_add_module(
 # The generated headers' Rust bodies. PUBLIC so it propagates to the final PX4
 # link, matching how the helper attaches the nano-ros archives.
 if(TARGET modules__nros_uorb_bridge)
+    # phase-325 W3.3 — the outward backend's NAME, as a proper definition.
+    #
+    # NOT via `COMPILE_FLAGS`: that property is a raw string appended to the
+    # command line, so the quotes needed around a string macro have to survive
+    # cmake, the generator and the shell. Passing
+    # `-DNROS_BRIDGE_RMW="\"${_rmw}\""` there produced `""zenoh""` and g++
+    # rejected it with
+    #     error: unable to find string literal operator 'operator""zenoh'
+    # ten minutes into a SITL build. `target_compile_definitions` quotes the
+    # value itself, which is what it is for.
+    target_compile_definitions(modules__nros_uorb_bridge PRIVATE
+        NROS_BRIDGE_RMW="${_rmw}")
     target_link_libraries(modules__nros_uorb_bridge PUBLIC "${_ffi_a}")
 endif()

--- a/just/px4.just
+++ b/just/px4.just
@@ -166,6 +166,30 @@ build-bridge-example topics="debug_key_value" edition="jazzy":
     ROOT="$(pwd)"
     PX4_DIR="${PX4_AUTOPILOT_DIR:-$ROOT/third-party/px4/PX4-Autopilot}"
     EXT_DIR="$ROOT/examples/px4/cpp/bridge"
+    # phase-325 W3.3 — the OUTWARD backend, from the ENVIRONMENT and not from a
+    # recipe parameter. `just` has no named-argument syntax: `just px4
+    # build-bridge-example rmw=zenoh` binds the string "rmw=zenoh" to the FIRST
+    # positional (`topics`), and the run dies with
+    #     Error: px4 message `rmw=zenoh` not found under .../msg
+    # which names the message and not the mistake. Measured, not assumed -- and
+    # the same flaw made this file's own README example
+    # (`build-bridge-example topics=vehicle_status`) generate a message called
+    # "topics=vehicle_status" for as long as it has existed.
+    #
+    # The repo is INCONSISTENT here and it is worth knowing which way: archived
+    # phase-410 states the rule plainly ("`just ci matrix depth=build` does NOT
+    # work. `just` does not parse `name=value`"), while `lane=` DOES work --
+    # because `scripts/build/fixture-lane.sh:74` strips the prefix by hand
+    # (`lane="${lane#lane=}"`). So `name=value` is an accommodation each recipe
+    # makes or does not; this one does not, and says so rather than adding a
+    # second idiom nobody can predict from the outside.
+    RMW="${NROS_PX4_BRIDGE_RMW:-zenoh}"
+    case "$RMW" in
+        zenoh|xrce|cyclonedds) ;;
+        *) echo "ERROR: NROS_PX4_BRIDGE_RMW='$RMW' is not a networked backend." >&2
+           echo "       Use one of: zenoh xrce cyclonedds" >&2
+           exit 1 ;;
+    esac
     GEN="$ROOT/build/px4-bridge/generated"
     if [ ! -d "$PX4_DIR/Tools" ]; then
         echo "ERROR: PX4-Autopilot tree not found at $PX4_DIR"
@@ -178,13 +202,26 @@ build-bridge-example topics="debug_key_value" edition="jazzy":
         --ros-edition '{{edition}}' -o "$GEN"
 
     echo "[2/4] building the generated-message FFI staticlib"
+    # `--target-dir` is not cosmetic: without it cargo writes `ffi/target/`, and
+    # a bare `target/` under `examples/**` is exactly what
+    # `check-example-leaf-target-dirs` fails on (phase-340 P2 residue, issue
+    # 0200). That gate is BUILDLESS, so it never saw this — the dir only exists
+    # after someone runs this recipe, and then `just check fast` goes red in a
+    # tree that merely built what the docs told it to.
+    #
+    # NOTE the ordering below: `check-build-profile-literals` looks only 3 LINES
+    # UP from the `cargo` line for its marker, and the `\` continuation means the
+    # marker cannot be appended inline either. Writing the paragraph above
+    # BETWEEN the marker and the command pushed it out of range and turned the
+    # lane red. Explanations go above the marker, never between it and the call.
     # profile-literal-ok: symbol fixture: the archive PATH is handed to PX4's
     # make via NROS_PX4_BRIDGE_FFI_ARCHIVE, and PX4 knows nothing about nano-ros
     # profiles — build and path must name the same dir, so both stay pinned.
     NROS_PX4_BRIDGE_GEN="$GEN" cargo build --release \
-        --manifest-path "$EXT_DIR/ffi/Cargo.toml"
+        --manifest-path "$EXT_DIR/ffi/Cargo.toml" \
+        --target-dir "$EXT_DIR/ffi/target-bridge-ffi"
 
-    echo "[3/4] building the nano-ros archives (outward backend baked in here)"
+    echo "[3/4] building the nano-ros archives (outward backend $RMW baked in here)"
     # `bridge` is what puts nros_init_multi / nros_pubsub_bridge_* (the ABI
     # nros::MultiExecutor calls) into libnros_cpp.a — issue 0436. Without it the
     # module compiles and fails to LINK.
@@ -195,8 +232,17 @@ build-bridge-example topics="debug_key_value" edition="jazzy":
     # Linked into the same PX4 SITL image as the archive above; one profile for
     # the whole link. Marker is INLINE because check::build-profile-literals.sh
     # only looks 3 lines up, and this comment block is longer than that.
+    # phase-325 W3.3 — `rmw=` picks the OUTWARD backend, and it has to reach two
+    # places that cannot see each other: this cargo feature (which compiles the
+    # backend INTO libnros_cpp.a) and the module's cmake (which registers it and
+    # names it in the session spec). One value, exported below, drives both.
+    # The archive-vs-BACKENDS half is guarded (an llvm-nm precheck in
+    # nros_px4_add_module names the exact cargo command). The
+    # BACKENDS-vs-session-NAME half is not: asking for a backend by a name
+    # nothing registered opens nothing and reports a transport failure, which
+    # reads as a dead network. One value removes that.
     cargo build -p nros-cpp --no-default-features \
-        --features std,rmw-zenoh-cffi,bridge,platform-posix --release # profile-literal-ok: symbol fixture
+        --features "std,rmw-$RMW-cffi,bridge,platform-posix" --release # profile-literal-ok: symbol fixture
     # profile-literal-ok: symbol fixture: same PX4 SITL link as above.
     # The POSIX platform archive nros_px4_add_module links (its guard names this
     # exact command when it is missing).
@@ -208,7 +254,8 @@ build-bridge-example topics="debug_key_value" edition="jazzy":
     echo "[4/4] building PX4 SITL with EXTERNAL_MODULES_LOCATION=$EXT_DIR"
     # profile-literal-ok: symbol fixture: pairs with the --release build above.
     NROS_PX4_BRIDGE_GEN="$GEN" \
-    NROS_PX4_BRIDGE_FFI_ARCHIVE="$EXT_DIR/ffi/target/release/libnros_px4_bridge_ffi.a" \
+    NROS_PX4_BRIDGE_RMW="$RMW" \
+    NROS_PX4_BRIDGE_FFI_ARCHIVE="$EXT_DIR/ffi/target-bridge-ffi/release/libnros_px4_bridge_ffi.a" \
         make -C "$PX4_DIR" px4_sitl_default EXTERNAL_MODULES_LOCATION="$EXT_DIR"
 
 # Build PX4 examples. (phase-277 W7: the former `build-sitl` recipe pointed


### PR DESCRIPTION
W3.3 asks the bridge to build against at least two backends, because *"one backend does not demonstrate selection; it demonstrates a hardcoded bridge with extra ceremony."*

It was hardcoded. `NROS_BRIDGE_RMW` is `#ifndef`-guarded with a `"zenoh"` default and was **defined nowhere**; the module cmake said `BACKENDS uorb zenoh` as a literal. The choice existed in the source and could not be made from outside it.

One value now drives the three places that must agree — the cargo feature (which compiles the backend into `libnros_cpp.a`), the `BACKENDS` list (which registers it), and `-DNROS_BRIDGE_RMW` (the name the session spec selects by).

## Built against both, not reasoned about

| | zenoh | xrce |
| --- | --- | --- |
| build | `[534/534]` rc=0 | `[12/12]` rc=0 |
| cmake STATUS | `outward backend = zenoh` | `outward backend = xrce` |
| register stub | `uorb` + `zenoh` | `uorb` + `xrce` |
| `build.ninja` | — | `-DNROS_BRIDGE_RMW=\"xrce\"` |

## Four defects the builds found that the plumbing check did not

The plumbing check — `BACKENDS` present, define present — passed cleanly before every one of these.

1. **`rmw=zenoh` bound to the first positional**, and the run died with ``px4 message `rmw=zenoh` not found``. `just` has no named-argument syntax; archived phase-410 states the rule, and `lane=` works *only* because `scripts/build/fixture-lane.sh:74` strips the prefix by hand. Hence an env var.
2. **`COMPILE_FLAGS` quoting collapsed** to `""zenoh""` — `error: unable to find string literal operator 'operator""zenoh'`, ten minutes into a SITL build. `target_compile_definitions` quotes the value itself.
3. **The README has always shipped a broken command.** `build-bridge-example topics=vehicle_status` generates a message literally named `topics=vehicle_status`. Fixed, with the positional forms spelled out.
4. **Stage [2/4] wrote a bare `ffi/target/`** under `examples/**` — exactly what `check-example-leaf-target-dirs` exists to fail on (issue 0200). That gate is **buildless**, so it never saw it: the directory only exists *after* you run the recipe, and then `just check fast` goes red in a tree that merely built what the docs said to. Moved to `target-bridge-ffi/` with a leaf `.gitignore`; archive handoff re-verified by a full rebuild.

Also worth recording: `check-build-profile-literals` looks only **3 lines up** for its marker, and the `\` continuation means it cannot be appended inline. Explaining (4) *between* the marker and the cargo call pushed the marker out of range and turned the lane red. The ordering is now commented.

## Doc corrections

W3.1 and W3.2 were done on **2026-08-06** and never ticked — the bridge README has said `Status: WORKING` with a SITL receipt since then.

## W3.4 is NOT done, and is scoped rather than half-started

No host lane exists — the only uORB double in the tree is a link-time mock inside one CMake smoke binary, with no broker and no second process. It belongs beside `px4_uorb_interop_e2e.rs` in the out-of-workspace SITL crate (which has no `nros-tests` dep today), and an `interop::CELLS` row is blocked four ways.

**One warning written into the phase for whoever takes it:** do not copy `px4_uorb_interop_e2e.rs`'s stale-tree guard. It asserts the module *directory* exists, and module dirs outlive the builds that link them. Measured today: `nros_uorb_demo`'s directory is present while the binary holds **zero** references to it — so the guard passes and the test then dies at `nros_uorb_demo start`, the exact failure its own comment says it prevents.

`just check fast` green, 195 gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)