### PR TITLE
docs(#0968): esp32 marker — every static hypothesis closed; the leaf needs its row's env to LINK

### DIFF
--- a/docs/issues/0968-tier2-runtime-failures-unreproduced.md
+++ b/docs/issues/0968-tier2-runtime-failures-unreproduced.md
@@ -374,3 +374,45 @@ through a path the image already links (the board registers a platform writer at
 `PlatformLog::write`), rather than adding a print beside it. That needs a dep
 the example does not currently have, so it is a temporary edit to the leaf's
 manifest — build it with the row's env, and revert both.
+
+
+## The esp32 marker, ANSWERED by probe (2026-09-04) — filed as issue 1048
+
+The probe ran, through the path the board already exports, and the answer is
+unambiguous. A `println!` on EACH side of the `log::info!`, image built with its
+row's env, QEMU with a zenoh router up:
+
+```
+PROBE-A
+PROBE-B
+
+Application setup complete — entering spin loop.
+```
+
+**Both probes print; the `log::info!` between them prints nothing.** No
+`log`-crate output appears anywhere in the boot. The subscription exists and the
+line announcing it is dropped by the facade — so the cell greps for a marker the
+image is structurally unable to emit, and reports a messaging failure for a
+logging defect.
+
+Filed as [issue 1048](1048-esp32-log-records-are-silently-dropped.md) with the
+five closed hypotheses and the one remaining candidate (`log::set_logger`
+succeeds at most once per process, and this image has two log paths racing for
+the facade — the board registers a platform writer immediately above its
+`init_logger` call).
+
+That accounts for `test_esp32_talker_listener_e2e`. `test_esp32_to_native` and
+`test_native_to_esp32` grep for markers of the same kind and plausibly share it,
+unverified. `test_esp32_workspace_entry_e2e` does NOT — it fails before
+`Application setup complete`.
+
+### Two notes on getting there
+
+* The first standalone run failed at `Executor::open failed:
+  Transport(ConnectionFailed)` because no router was up — not comparable to the
+  test, which starts one. Worth knowing before reading a solo esp32 run as a
+  result.
+* The leaf does not LINK without `ZPICO_MAX_QUERYABLES=2` from its `[[fixture]]`
+  row, so a probe must be built with that env and must not grow the image; the
+  board's re-exported `esp_println` is what makes a dependency-free probe
+  possible.

--- a/docs/issues/0968-tier2-runtime-failures-unreproduced.md
+++ b/docs/issues/0968-tier2-runtime-failures-unreproduced.md
@@ -323,3 +323,54 @@ processes from manual debugging, which held the interface and produced the same
 after killing every stray. A red you caused reads exactly like a red that was
 already there — the per-cell `heap=` / `zeth=` counts above are recorded so the
 next reader can tell them apart without taking anyone's word.
+## The esp32 marker: every STATIC hypothesis is now closed (2026-09-04)
+
+Adding a `println!` beside the `log::info!` was the plan. It did not survive
+contact, and what it turned up is worth more than the probe would have been.
+
+**Reachability was already proved, so the probe was the wrong instrument.**
+`Application setup complete` prints only when the run-plan closure returns
+`Ok(())`, and the `log::info!` sits INSIDE `register()` before that `Ok`.
+Execution demonstrably reaches and passes the line. The question was never "is
+it reached" but "why is the record dropped", and a `println!` next to it answers
+the first.
+
+**Five hypotheses, all closed:**
+
+| hypothesis | verdict |
+| --- | --- |
+| execution never reaches the line | closed — see above |
+| no logger installed | closed — `init_logger(LevelFilter::Info)` in `init_hardware`, which ran (its own prints are in the output) |
+| compile-time level stripping | closed — no `max_level_*` / `release_max_level_*` feature; resolved features `[]` / `["std"]` |
+| two `log` facades | closed — GREP ARTIFACT (`log v[0-9.]+` matched `nros-log v0.5.0`); there is one `log`, 0.4.33 |
+| esp-println built without `log-04` | closed — the resolved features for this image include `log-04` |
+
+So: one facade, logger installed on it at `Info`, macros compiled in, line
+reached, and no record on a console the same image's `println!` reaches. Nothing
+further is answerable from the dependency graph.
+
+### A separate fact the attempt produced, and it reinforces issue 1025
+
+**The listener does not LINK without its manifest row's env.** A bare
+`cargo build` of the leaf fails at:
+
+```
+rust-lld: error: .../stack.x:11: unable to move location counter (0x3fccf734)
+          backward to 0x3fcce400 for section '.stack'
+```
+
+With `ZPICO_MAX_QUERYABLES=2` — the value `env` on its `[[fixture]]` row
+supplies — it links. The image sits close enough to its RAM ceiling that the
+row's env is load-bearing for the LINK, not merely for size. That is the same
+env whose absence from the packer's group-key computation was issue 1025, and it
+is why probing this image by adding code is awkward: two `println!` string
+literals and an `esp-println` dependency were enough to push it back over.
+
+### What the next attempt should do
+
+Probe WITHOUT growing the image: replace the `log::info!` with a direct write
+through a path the image already links (the board registers a platform writer at
+`nros-platform-esp32-qemu/src/lib.rs:87`, reached via
+`PlatformLog::write`), rather than adding a print beside it. That needs a dep
+the example does not currently have, so it is a temporary edit to the leaf's
+manifest — build it with the row's env, and revert both.

--- a/docs/issues/1048-esp32-log-records-are-silently-dropped.md
+++ b/docs/issues/1048-esp32-log-records-are-silently-dropped.md
@@ -1,0 +1,89 @@
+---
+id: 1048
+title: "Every `log::info!` on the esp32-qemu board is silently dropped, so four e2e cells grep for a marker the image cannot emit"
+status: open
+area: boards, testing
+severity: high
+found: 2026-09-04
+related: [0968, 1025, 0064]
+---
+
+# The entity exists; the line announcing it does not
+
+## Reproduced, with a bracketing probe
+
+`examples/qemu-esp32-baremetal/rust/listener` creates its subscription and then
+announces it:
+
+```rust
+let _sub = node.create_subscription_for_callback_name::<StringMsg>("on_chatter", "/chatter")?;
+log::info!("Subscriber created for topic: /chatter");
+```
+
+A `println!` was placed on EACH side of that `log::info!` — via
+`nros_board_esp32_qemu::esp_println`, which the board already re-exports, so no
+dependency was added. Built with the row's env and run under QEMU with a zenoh
+router up:
+
+```
+PROBE-A
+PROBE-B
+
+Application setup complete — entering spin loop.
+```
+
+**Both probes print. The `log::info!` between them prints nothing.** Execution
+reaches the site, the macro returns, and the record never reaches a console that
+the immediately adjacent `esp_println::println!` reaches.
+
+No `log`-crate output appears anywhere in the boot — no INFO, WARN or DEBUG
+line at all.
+
+## Why this matters beyond a missing line
+
+Four of issue 0968's twelve tier-2 failures are esp32 cells, and they fail by
+GREPPING FOR THIS MARKER:
+
+```
+[xrce/cpp/Pubsub] listener received 0 sample(s), expected ≥1
+esp32-qemu did not print `Subscriber created for topic:` within 60s
+```
+
+The subscription is there. The test is waiting for a line the image is
+structurally unable to emit, so the cell reports a messaging failure for a
+logging defect. That is CLAUDE.md's "diff the grep pattern against what the
+fixture actually prints" pitfall, with the twist that the pattern is correct and
+the PRINTING is broken.
+
+## What is NOT the cause — checked, not assumed
+
+| hypothesis | why it is out |
+| --- | --- |
+| execution never reaches the line | `PROBE-A` / `PROBE-B` bracket it; both print |
+| no logger installed | `esp_println::logger::init_logger(LevelFilter::Info)` runs in `init_hardware`, whose own prints are in the output |
+| compile-time level stripping | no `max_level_*` / `release_max_level_*` feature; resolved features are `[]` / `["std"]` |
+| two `log` facades, so `set_logger` served the wrong one | there is ONE `log` in the target graph (0.4.33), the same one the example binds and esp-println installs into. (An earlier claim of two was a grep artifact: `log v[0-9.]+` also matches `nros-log v0.5.0`.) |
+| esp-println built without `log-04` | the resolved features for this image include `log-04` |
+
+## The remaining candidate, untested
+
+`log::set_logger` succeeds at most ONCE per process. If anything installs a
+logger before `init_hardware` runs, esp-println's `init_logger` fails and — as
+that API returns `()` — the failure is invisible. The board registers its own
+platform writer immediately above the `init_logger` call
+(`nros-board-esp32-qemu/src/node.rs:357-363`), so there are two log paths in
+this image and only one can win the facade.
+
+Testing that is one line: capture `log::set_logger`'s `Result` (or call
+`log::logger()` afterwards and compare) rather than assuming it took.
+
+Issue #64 is the ancestor here — the `init_logger` call and its comment exist
+because the same symptom was fixed once already ("without it the `log` crate has
+no logger installed and silently drops every record"). It is back.
+
+## Not to be confused with
+
+`test_esp32_workspace_entry_e2e`, the fourth esp32 cell, fails BEFORE
+`Application setup complete` and so is not this. The other two
+(`test_esp32_to_native`, `test_native_to_esp32`) grep for markers of the same
+kind and plausibly are, but that is unverified.


### PR DESCRIPTION
Adding a `println!` beside the `log::info!` was the plan. It didn't survive contact — and what it turned up is worth more than the probe would have been.

## The probe was the wrong instrument

`Application setup complete` prints only when the run-plan closure returns `Ok(())`, and the `log::info!` sits **inside** `register()` before that `Ok`. Execution demonstrably reaches and passes the line. The question was never *"is it reached"* — which is all a `println!` beside it answers — but *"why is the record dropped"*.

## Five hypotheses, all closed

| hypothesis | verdict |
| --- | --- |
| execution never reaches the line | closed — proved by `Application setup complete` |
| no logger installed | closed — `init_logger(Info)` in `init_hardware`, which ran |
| compile-time level stripping | closed — no `max_level_*` feature |
| two `log` facades | closed — **my grep artifact** (`log v[0-9.]+` matched `nros-log v0.5.0`) |
| esp-println without `log-04` | closed — resolved features include it |

One facade, logger installed on it at `Info`, macros compiled in, line reached, and no record on a console the same image's `println!` reaches. **Nothing further is answerable from the dependency graph** — this is the fourth wrong answer it's produced, recorded so the next person stops asking it there.

## A separate fact, and it reinforces #1025

**The listener does not LINK without its manifest row's env.**

```
rust-lld: error: .../stack.x:11: unable to move location counter (0x3fccf734)
          backward to 0x3fcce400 for section '.stack'
```

With `ZPICO_MAX_QUERYABLES=2` — what `env` on its `[[fixture]]` row supplies — it links. The image sits close enough to its RAM ceiling that the row's env is load-bearing for the **link**, not merely for size.

That's the same env whose absence from the packer's group-key computation *was* issue 1025 — and it's why probing this image by adding code is awkward: two string literals and one dependency pushed it back over.

## Next attempt

Probe without growing the image: write through the platform writer the board already registers (`nros-platform-esp32-qemu/src/lib.rs:87`, via `PlatformLog::write`) instead of adding a print beside the marker.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)