### PR TITLE
docs(#1038): the zenohd hypothesis is confirmed — the CI image has no zenoh at all

### DIFF
--- a/docs/issues/1038-nightly-job-does-not-provision-its-lane.md
+++ b/docs/issues/1038-nightly-job-does-not-provision-its-lane.md
@@ -141,13 +141,47 @@ question to answer, not this issue's.
   platforms share is `zenohd_unavailable_reason()`. Both jobs do
   `source /opt/ros/humble/setup.bash`.
 
-  **UNCONFIRMED**: the leading hypothesis is that the humble CI image lacks
-  `ros-humble-rmw-zenoh-cpp` — RFC-0075 says we ship no router, and
-  `rmw_zenohd` is invisible to `command -v` even when installed. Settle it by
-  checking the image for that package, or by running the cell with
-  `NROS_RMW_ZENOHD` set. Every other `require_e2e` branch for these two names
-  env or directories the build step already proved present. This is filed as a
-  hypothesis, not a diagnosis.
+  **CONFIRMED 2026-09-04** — the image has NO zenoh packages at all. The
+  hypothesis was that it lacks `ros-humble-rmw-zenoh-cpp`; it does, and the
+  chain is now closed rather than merely plausible:
+
+  * `ci/docker/ci-base/Dockerfile` builds `FROM ros:humble-ros-base`, which does
+    not carry that package, and its apt list adds `ros-humble-example-interfaces`
+    and nothing else ROS-side.
+  * Queried a built image (`nros-ci-test:humble`, 2026-08-28, from this
+    Dockerfile): `dpkg -l | grep -i zenoh` returns NOTHING. The only RMW
+    implementation present is `ros-humble-rmw-fastrtps-cpp`.
+    `/opt/ros/humble/lib/rmw_zenoh_cpp/` does not exist, and a `find` over
+    `/opt/ros` for `rmw_zenohd` or `libzenohc*` returns nothing.
+
+  So: no router -> `zenohd_unavailable_reason()` returns `Some` ->
+  `require_e2e()` fails -> all 9 cases `skip!` -> `_check-skip-budget` reports
+  "this lane verified nothing". Every language and variant, both platforms,
+  which is the uniformity that pointed at a shared precondition rather than a
+  code fault.
+
+  (Scope of the check: the Dockerfile is the SSoT for what the image contains,
+  and a local build of it agrees. The PUBLISHED `ghcr.io/newslabntu/nano-ros-ci:humble`
+  was not pulled — 5.7 GB — so the claim rests on the recipe plus a build of it,
+  not on the exact published layer.)
+
+  **The fix is TWO changes, not one, and the Dockerfile already predicts the
+  second.** Installing `ros-humble-rmw-zenoh-cpp` makes the router RESOLVE but
+  not necessarily RUN. That image sets `AMENT_PREFIX_PATH` / `LD_LIBRARY_PATH`
+  as static `ENV` — a snapshot of what sourcing `setup.bash` produced for the
+  CURRENT package set — instead of sourcing it. `rmw_zenoh_cpp` installs into
+  `<prefix>/opt/zenoh_cpp_vendor/lib`, which that snapshot does not name, and a
+  router paired with the wrong `libzenohc.so` SEGVs mid-startup rather than
+  failing to load. That is issue 0774 exactly, and the Dockerfile's own comment
+  names it: *"a ROS package that installs to a DIFFERENT prefix ... would need
+  this block updated -- `ros-humble-rmw-zenoh-cpp` adding
+  `<prefix>/opt/zenoh_cpp_vendor/lib` to `LD_LIBRARY_PATH` is the case issue
+  0774 is about. Re-run the capture command above after changing the ROS package
+  set rather than assuming."*
+
+  Read in hindsight, that comment was the tell: it names the package
+  HYPOTHETICALLY, as something that WOULD need handling — which is only how you
+  write it when the package is not installed.
 
   Worth noting separately: a skip message that carries the remedy is useless if
   the transport truncates it. Both artifacts cut it at the colon.

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -107,9 +107,20 @@ conversion can be verified in a lane that is already red.
    report `Real failures: 0 / 0` with all 9 e2e cases skipped on one shared
    precondition (`_check-skip-budget` correctly refusing to call that a pass),
    and `tier 2 nightly` is runner state (three fixture families missing
-   `.inputsig`). The `freertos`/`threadx_linux` skip reason is TRUNCATED in both
-   the log and the junit, so the cause is a hypothesis, not a diagnosis — see
-   1038 before acting on it.
+   `.inputsig`).
+
+   The `freertos`/`threadx_linux` cause is **CONFIRMED** (2026-09-04): the CI
+   image carries NO zenoh packages — `FROM ros:humble-ros-base` plus an apt list
+   whose only ROS entry is `example-interfaces`; a built image has no
+   `rmw_zenoh_cpp` prefix, no `rmw_zenohd`, no `libzenohc*`, and
+   `rmw-fastrtps-cpp` as its sole RMW. No router, so
+   `zenohd_unavailable_reason()` fails `require_e2e()` and all 9 cases skip.
+   **Fixing it takes TWO changes**: install `ros-humble-rmw-zenoh-cpp`, AND
+   re-capture the image's static `AMENT_PREFIX_PATH`/`LD_LIBRARY_PATH` `ENV`
+   block, which will not name `<prefix>/opt/zenoh_cpp_vendor/lib` — a router
+   paired with the wrong `libzenohc.so` SEGVs mid-startup (issue 0774). The
+   Dockerfile's own comment already says to re-run its capture command after
+   changing the ROS package set. Detail in issue 1038.
 4. **`build-wide`** — expected to go green with W1/0992; if it does not, its
    remaining failure is now visible rather than buried under the include
    preflight.


### PR DESCRIPTION
Issue 1038 filed the `freertos`/`threadx_linux` cause as a **hypothesis with the check that would settle it**, because the skip reason is truncated at the same column in both the log and the junit. Ran the check.

## The image carries no zenoh packages

- `ci/docker/ci-base/Dockerfile` builds `FROM ros:humble-ros-base` — which doesn't carry `ros-humble-rmw-zenoh-cpp` — and its apt list adds `ros-humble-example-interfaces` and nothing else ROS-side.
- A built image from that Dockerfile: `dpkg -l | grep -i zenoh` returns **nothing**; the only RMW implementation is `rmw-fastrtps-cpp`; `/opt/ros/humble/lib/rmw_zenoh_cpp/` doesn't exist; a `find` over `/opt/ros` for `rmw_zenohd` or `libzenohc*` returns nothing.

Chain closed: no router → `zenohd_unavailable_reason()` returns `Some` → `require_e2e()` fails → all 9 cases `skip!` at `rtos_e2e.rs:514` → `_check-skip-budget` reports *"this lane verified nothing."* Both platforms, every language and variant — the uniformity that pointed at a shared precondition rather than a code fault.

**Scope of the check, stated rather than glossed:** the published `ghcr.io` image wasn't pulled (5.7 GB), so this rests on the Dockerfile — the SSoT for what the image contains — plus a local build of it.

## The fix is two changes, not one

Installing the package makes the router **resolve** but not necessarily **run**. The image sets `AMENT_PREFIX_PATH`/`LD_LIBRARY_PATH` as a static `ENV` snapshot instead of sourcing `setup.bash`, and `rmw_zenoh_cpp` installs into `<prefix>/opt/zenoh_cpp_vendor/lib`, which that snapshot doesn't name. A router paired with the wrong `libzenohc.so` **SEGVs mid-startup** rather than failing to load — issue 0774 exactly.

The Dockerfile already predicted this, and in hindsight its comment was the tell — it names the package *hypothetically*, as one that **would** need the ENV block updated:

> a ROS package that installs to a DIFFERENT prefix … would need this block updated — `ros-humble-rmw-zenoh-cpp` adding `<prefix>/opt/zenoh_cpp_vendor/lib` to `LD_LIBRARY_PATH` is the case issue 0774 is about. Re-run the capture command above after changing the ROS package set rather than assuming.

That's only how you write it when the package isn't installed.

Docs only — issue 1038 and the phase-413 W2 note that carried the same hypothesis. `just check fast` 197/197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)