### PR TITLE
fix(#1050): build-sitl-example builds the archive it links, instead of inheriting one

### DIFF
--- a/docs/issues/1050-px4-demo-links-whatever-archive-was-built-last.md
+++ b/docs/issues/1050-px4-demo-links-whatever-archive-was-built-last.md
@@ -1,0 +1,121 @@
+---
+id: 1050
+title: "`just px4 build-sitl-example` links whatever `libnros_cpp.a` was built last, so a uORB-only module fails at `nros::init()` because a backend it never declared won slot 0"
+status: open
+type: bug
+area: build, testing
+severity: high
+found: 2026-09-04
+related: [1046, 0436, phase-325, 0616]
+---
+
+# Same source, same recipe, same command — different result
+
+## Reproduced, by changing exactly one variable
+
+`nros_uorb_demo start` on a correctly-built SITL tree:
+
+    ERROR [nros_uorb_demo] nros::init() failed
+    ERROR [nros_uorb_demo] Task start failed (-1)
+
+`task_spawn` returns `PX4_ERROR` when `init()` fails, and the PX4 shell reports
+that as status **255** — which is what `px4_uorb_interop_e2e.rs` dies with.
+
+Rebuild `libnros_cpp.a` without zenoh, rebuild the module, change nothing else:
+
+    $ ./bin/px4-nros_uorb_demo start      # (silent — success)
+    $ ./bin/px4-nros_uorb_demo status
+    INFO  [nros_uorb_demo] published: 0  received: 0
+
+Both `nros_rmw_uorb_register_topic` calls succeed in both cases; the failure is
+the session open.
+
+## The mechanism
+
+`just px4 build-sitl-example` (`just/px4.just`) is four lines: it checks for the
+PX4 tree and runs `make px4_sitl_default`. **It does not build `libnros_cpp.a`,
+and does not check which one is there.** It links against whatever the last
+`cargo build -p nros-cpp` left in `target/release/`.
+
+The module's own generated stub registers exactly what it declared:
+
+```c
+/* Backends registered: uorb */
+extern int nros_rmw_uorb_register(void);
+void nros_app_register_backends(void) { (void)nros_rmw_uorb_register(); }
+```
+
+But a zenoh-enabled archive **also** registers zenoh, through the `.init_array`
+constructor that survives on hosted Rust backends
+(`packages/rmw/zenoh/nros-rmw-zenoh/src/lib.rs`). PX4 SITL is hosted POSIX, so
+that ctor runs **before `main`** — therefore before `nros_app_register_backends()`
+is ever called. zenoh lands in slot 0.
+
+`nros::init()` opens the DEFAULT slot. It gets zenoh, dials the default
+`tcp/127.0.0.1:7447`, finds no router (the one running on this host was on
+`:32823`), and fails.
+
+**A uORB-only module, broken by a backend it never declared, winning a race it
+should not have been in.**
+
+## The coupling is circular, which is why it also breaks the LINK
+
+The generated header the module compiles against
+(`target/nros-cpp-generated/nros_cpp_config_generated.h`) comes from that same
+ambient archive, so the module's expected feature VARIANT is decided by whatever
+someone built previously. Building the bridge and then the demo produces:
+
+    undefined reference to `nros_cpp_config_variant_alloc_env_platform_posix_
+        rmw_cffi_rmw_zenoh_cffi_ros_humble_std'
+
+i.e. the demo compiled expecting an archive it is not being linked against. The
+anchor is doing its job; the recipe is what put it in that position.
+
+## FIXED 2026-09-04 (defect 1 only) — proven from the broken state
+
+`build-sitl-example` now builds the archive it links, with `rmw-cffi` (uORB is
+this module's outward side), the way `build-bridge-example` always has for the
+opposite reason.
+
+Verified by starting from the FAILING condition rather than a good tree — the
+weaker direction would have passed before the fix too, which is how issue 1046's
+guard survived:
+
+    archive poisoned with rmw-zenoh-cffi   -> 3 nros_rmw_zenoh_register
+    just px4 build-sitl-example            -> archive rebuilt, 0 zenoh_register
+    ./bin/px4-nros_uorb_demo start         -> silent (success; was status 255)
+    ./bin/px4-nros_uorb_demo status        -> published: 0  received: 0
+
+## Three separable defects
+
+1. **A recipe consumes a shared artifact it neither builds nor verifies.**
+   `build-bridge-example` builds its own archive (stage [3/4]) precisely because
+   the outward backend is chosen there; `build-sitl-example` never got the same
+   treatment. This is issue 1046's class one layer up — an artifact standing in
+   for a fact, outliving the fact.
+2. **`.init_array` registration races the explicit stub.** `BACKENDS uorb` reads
+   as "this image registers uorb", and on a hosted target it does not mean that:
+   any backend compiled into the archive registers itself first. The keyword's
+   own docs in `NanoRosPx4Module.cmake` describe the generated stub as the
+   registration mechanism, which is true on RTOS targets and incomplete on POSIX.
+3. **`nros::init()` takes slot 0**, so the race above silently decides the
+   transport. A module that wants uORB has no way to say so through `nros::init()`
+   — `Executor::open_with_rmw("uorb", …)` exists, but the C++ one-liner the
+   examples use does not reach it.
+
+Only (1) is fixed here. (2) and (3) are design questions: (2) would mean either
+suppressing the ctor path when a stub is generated, or making `BACKENDS` an
+assertion rather than a hint; (3) would mean the examples naming their backend.
+Both change behaviour for every consumer, so they want an owner and a decision,
+not a drive-by.
+
+## Not covered
+
+* Whether `build-sitl-cpp` (the register-check gate) has the same exposure. Its
+  comments quote the `cargo build -p nros-cpp --features std,rmw-cffi` command,
+  but whether the recipe RUNS it was not checked.
+* Whether any non-PX4 lane links `libnros_cpp.a` ambiently the same way.
+* Whether the 1046 guard should also assert the archive's feature variant. It
+  currently answers "is this module linked", not "was it linked against the
+  right archive" — a strictly harder question, and arguably the anchor symbol
+  already answers it at link time.

--- a/docs/issues/open.md
+++ b/docs/issues/open.md
@@ -92,5 +92,6 @@ fails if this block drifts.
 - **#1043** (ci, tooling) — `check-submodule-pins` fails CLOSED on any submodule CI does not initialise, so a whole class of pin bump could never pass the required lane See `1043-*`.
 - **#1044** (testing) — The run-to-completion wait class is not finished: an eighth site, four bridge callers with an unstated horizon, and an assertion that counts re-opens instead of rating them See `1044-*`.
 - **#1045** (testing, build) — Two unswept corners of fixture resolution: the Zephyr and ThreadX locators, and a staleness probe that announces its own degradation only on the STALE path See `1045-*`.
+- **#1050** (build, testing) — `just px4 build-sitl-example` links whatever `libnros_cpp.a` was built last, so a uORB-only module fails at `nros::init()` because a backend it never declared won slot 0 See `1050-*`.
 
 <!-- END GENERATED open-issue list -->

--- a/just/px4.just
+++ b/just/px4.just
@@ -139,6 +139,39 @@ build-sitl-example:
         echo "Run: just px4 setup"
         exit 1
     fi
+    # Issue 1050 -- build the archive this links, instead of inheriting one.
+    #
+    # This recipe used to be `make` alone, linking whatever `cargo build -p
+    # nros-cpp` last left in `target/release/`. That is not a tidiness point:
+    # the demo declares `BACKENDS uorb`, but a zenoh-enabled archive ALSO
+    # registers zenoh through the `.init_array` ctor that survives on hosted
+    # Rust backends -- and on POSIX that ctor runs BEFORE main, hence before the
+    # generated `nros_app_register_backends()`. zenoh takes slot 0, `nros::init()`
+    # opens the default slot, dials tcp/127.0.0.1:7447, finds nothing, and the
+    # module dies with `nros::init() failed` -> PX4_ERROR -> status 255.
+    #
+    # A uORB-only module, broken by a backend it never declared.
+    #
+    # The coupling is circular too: the generated header the module compiles
+    # against comes from the same ambient archive, so building the BRIDGE and
+    # then this produced `undefined reference to
+    # nros_cpp_config_variant_..._rmw_zenoh_cffi_...` -- the module compiled for
+    # an archive it was not linked against.
+    #
+    # `rmw-cffi` and NOT `rmw-zenoh-cffi`: this module's outward side IS uORB.
+    # `build-bridge-example` does the same thing for the opposite reason (it
+    # picks a NETWORKED backend), which is why that recipe never had this bug.
+    echo "Building the nano-ros archive this module links (uORB only)"
+    # profile-literal-ok: symbol fixture: the PX4 link and this build must name
+    # the same profile dir, and PX4 knows nothing about nano-ros profiles.
+    cargo build -p nros-cpp --no-default-features \
+        --features std,rmw-cffi,platform-posix --release
+    # nros-cmake-prefix-exempt: the POSIX platform's C archive -- no Rust target
+    # in that project, so no Corrosion to resolve.
+    cmake -S "$(pwd)/packages/platform/nros-platform-posix" \
+        -B "$(pwd)/build/nros-platform-posix" >/dev/null
+    cmake --build "$(pwd)/build/nros-platform-posix" >/dev/null
+
     echo "Building PX4 SITL with EXTERNAL_MODULES_LOCATION=$EXT_DIR"
     make -C "$PX4_DIR" px4_sitl_default EXTERNAL_MODULES_LOCATION="$EXT_DIR"
 


### PR DESCRIPTION
The 255 from #1046's newly-passing guard, root-caused.

`just px4 build-sitl-example` was four lines: check the PX4 tree, run `make`. It linked whatever `cargo build -p nros-cpp` last left in `target/release/`, and never checked which.

## Why that breaks a uORB-only module

The demo declares `BACKENDS uorb`, and its generated stub registers exactly that:

```c
/* Backends registered: uorb */
void nros_app_register_backends(void) { (void)nros_rmw_uorb_register(); }
```

But a zenoh-enabled archive **also** registers zenoh, via the `.init_array` ctor that survives on hosted Rust backends — and on POSIX that ctor runs **before `main`**, therefore before the stub. zenoh takes slot 0, `nros::init()` opens the **default** slot, dials `tcp/127.0.0.1:7447`, finds nothing:

```
ERROR [nros_uorb_demo] nros::init() failed
ERROR [nros_uorb_demo] Task start failed (-1)
```

→ `PX4_ERROR` → **status 255**, which is what `px4_uorb_interop_e2e.rs` dies with.

**A uORB-only module, broken by a backend it never declared, winning a race it should not have been in.**

The coupling is circular, which is why it also broke the *link*: the generated header the module compiles against comes from that same ambient archive, so building the bridge then the demo gave `undefined reference to nros_cpp_config_variant_..._rmw_zenoh_cffi_...`. The anchor did its job; the recipe put it in that position.

## Proven from the broken state

Not from a good tree — the weak direction would have passed before the fix too, which is exactly how #1046's guard survived for so long:

```
archive poisoned with rmw-zenoh-cffi  ->  3 nros_rmw_zenoh_register
just px4 build-sitl-example           ->  archive rebuilt, 0 zenoh_register
./bin/px4-nros_uorb_demo start        ->  silent (success; was 255)
./bin/px4-nros_uorb_demo status       ->  published: 0  received: 0
```

`rmw-cffi`, not `rmw-zenoh-cffi` — this module's outward side *is* uORB. `build-bridge-example` has always built its own archive for the mirror-image reason (it picks a **networked** backend), which is why that recipe never had this bug.

## Only defect 1 is fixed

The issue records two more and deliberately leaves them:

- **`.init_array` races the explicit stub**, so `BACKENDS uorb` does not constrain what registers on a hosted target — the keyword's own docs describe the stub as *the* mechanism, which is true on RTOS and incomplete on POSIX.
- **`nros::init()` takes slot 0**, letting that race silently choose the transport.

Both change behaviour for every consumer and want an owner, not a drive-by. Three unchecked things are listed too, including whether `build-sitl-cpp` has the same exposure.

`just check fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)