### PR TITLE
fix(ci): host-tests never provisioned the preconditions its tier asserts

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -166,47 +166,30 @@ jobs:
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
 
-      - name: Provision workspace sources via nros
+      # phase-413 W5 — provision with the SCOPE VERB, not four hand-rolled
+      # steps. `just setup native` is what a user runs, and it expands to the
+      # same sequence this lane spelled out: `nros setup --build-sources` (the
+      # union of vendored sources), `just ci provision-zenohd`, and the qemu /
+      # xrce-agent / play_launch_parser tools.
+      #
+      # It also runs `_setup-common`, which builds the CLI and
+      # `nros-launch-resolve` AND provisions the two host facts every tier
+      # asserts — cross Rust targets and pinned corrosion. That is what this
+      # lane was missing: `just ci tier1` failed on three unmet preconditions
+      # that no step here provisioned, so the tier never started.
+      - name: just setup native
         run: |
           source ./activate.sh
-          nros setup --source px4-rs --source zenoh-pico --source mbedtls \
-                     --source micro-cdr --source micro-xrce-dds-client \
-                     --source cyclonedds-src --source nuttx-libc
+          just setup native
 
-      # `test-integration` spawns zenohd to back the Phase 211/212 host tests.
-      - name: just ci provision-zenohd
+      # CI-only: export the provisioned play_launch_parser for later steps.
+      # `just setup native` installs it into the store; a container job still
+      # has to put it on PATH, and it stays best-effort (workspace-entry
+      # fixtures SKIP without it, every other fixture builds).
+      - name: Export play_launch_parser on PATH
         run: |
-          source ./activate.sh
-          just ci provision-zenohd
-
-      # Test prerequisites the way a user gets them — via `nros setup` (#25): the
-      # patched qemu-system-arm (build/qemu/), the prebuilt Micro-XRCE-DDS Agent
-      # (nros store), and play_launch_parser (launch-graph tool; best-effort).
-      - name: Provision QEMU + XRCE agent + play_launch_parser (nros setup --tool)
-        run: |
-          source ./activate.sh
-          nros setup --tool qemu --prefix "$GITHUB_WORKSPACE/build/qemu" --index nros-sdk-index.toml
-          nros setup --tool xrce-agent --index nros-sdk-index.toml
-          nros setup --tool play_launch_parser --index nros-sdk-index.toml \
-            || echo "play_launch_parser unavailable — workspace-entry fixtures [SKIPPED]"
           plp_bin="$(dirname "$(find "$HOME/.nros/sdk/play_launch_parser" -type f -name play_launch_parser -path '*/bin/*' 2>/dev/null | head -1)")"
           [ -n "$plp_bin" ] && echo "$plp_bin" >> "$GITHUB_PATH" || true
-
-      # `nros sync` resolves SystemModels by shelling out to `nros-launch-resolve`,
-      # which it looks for NEXT TO the `nros` binary (issue 0285 — absolute path,
-      # never $PATH). Without it every fixture build dies at the sync step:
-      #
-      #   Error: sync: 9 SystemModel(s) need resolving but `nros-launch-resolve`
-      #          is not next to the `nros` binary
-      #
-      # Only `nightly.yml` provisioned it, so this lane had been red for at least
-      # ten consecutive runs — both fixture builds failing, both failures
-      # swallowed (see below), and 296 tests then skipping for fixtures that were
-      # never built.
-      - name: Build nros-launch-resolve (nros sync needs it beside the CLI)
-        run: |
-          source ./activate.sh
-          just setup-launch-resolve
 
       # The native integration tests spawn PREBUILT example binaries via
       # `require_prebuilt_binary`. Stage them by building the fixtures the way a
@@ -280,6 +263,18 @@ jobs:
       - name: just ci tier1
         env:
           CARGO_BUILD_JOBS: "2"
+          # This lane builds a DELIBERATE SUBSET of the native fixtures --
+          # `build-fixture-rust-core` + `build-workspace-fixtures`, with the
+          # ~52 GB extras omitted so test-integration does not hit ENOSPC (see
+          # the steps above). So it cannot honestly claim the `lane=native`
+          # coverage that `_require-fixtures` checks for, and writing that
+          # stamp would be a lie rather than a fix.
+          #
+          # The documented bypass is exactly this case ("built them another
+          # way?"). It only skips the PRE-FLIGHT: a missing in-lane fixture is
+          # still a hard failure at test time via `check-skip-budget` (issue
+          # 0584), so nothing is laundered into a skip.
+          NROS_SKIP_FIXTURE_CHECK: "1"
         run: |
           source ./activate.sh
           mkdir -p build/ci-logs

--- a/ci/docker/ci-base/Dockerfile
+++ b/ci/docker/ci-base/Dockerfile
@@ -138,6 +138,21 @@ RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-
         riscv32imc-unknown-none-elf riscv64imac-unknown-none-elf riscv64gc-unknown-none-elf \
     && cargo install cargo-nextest --locked
 
+# ...and then every target the tree DECLARES, read from the SSoT rather than
+# hand-listed. Issue 0833 split this list into `config/rust-targets.txt`
+# because two hand-written copies had drifted; this image was a THIRD copy and
+# had drifted the same way -- it never gained `armv8r-none-eabihf`, so
+# `check-tier-preconditions` failed on every container job that ran a tier.
+#
+# Additive on purpose: the list above carries targets the SSoT does not
+# declare, and dropping them here would be a silent capability loss. The rows
+# below can only add. `scripts/lib/rust-targets.sh` is the one parser (it
+# locates the list relative to itself, hence the mirrored paths).
+COPY scripts/lib/rust-targets.sh /opt/nros-ssot/scripts/lib/rust-targets.sh
+COPY config/rust-targets.txt     /opt/nros-ssot/config/rust-targets.txt
+RUN . /opt/nros-ssot/scripts/lib/rust-targets.sh \
+    && nros_rust_targets rustup | xargs -r rustup target add
+
 # sccache — the compiler cache the justfile ALREADY wires: `RUSTC_WRAPPER` is
 # `command -v sccache || true`, so every `just` recipe picks it up the moment
 # the binary is on PATH, and no workflow needs to opt in.
@@ -185,7 +200,9 @@ RUN rustup toolchain install nightly-2026-04-11 --profile minimal \
     && rustup +nightly-2026-04-11 target add \
         x86_64-unknown-none armv7a-none-eabi armv7r-none-eabihf aarch64-unknown-none \
         thumbv7m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf \
-        riscv32imc-unknown-none-elf riscv64imac-unknown-none-elf
+        riscv32imc-unknown-none-elf riscv64imac-unknown-none-elf \
+    && . /opt/nros-ssot/scripts/lib/rust-targets.sh \
+    && nros_rust_targets rustup | xargs -r rustup +nightly-2026-04-11 target add
 
 # git-as-root in CI containers: avoid "dubious ownership" on the checkout + the
 # source submodules `nros setup` provisions.

--- a/justfile
+++ b/justfile
@@ -3917,6 +3917,18 @@ _setup-common:
     fi
     just setup-cli
     just setup-launch-resolve
+    # Host-provisioning facts that `check-tier-preconditions` asserts for EVERY
+    # tier, so every `just setup <scope>` must satisfy them — otherwise the
+    # documented `setup -> build -> test` chain does not clear the checks its
+    # own test step runs, which is how host-tests sat red on three unmet
+    # preconditions it had no step to provision.
+    #
+    # AFTER `setup-cli`: `install-corrosion` resolves its prefix with
+    # `nros sdk-path corrosion`, so it needs the binary to exist.
+    # Both are idempotent -- corrosion short-circuits on its version stamp,
+    # `rustup target add` is a no-op when the target is present.
+    just workspace rust-targets
+    just workspace install-corrosion
 
 # Focused platform setup. Equivalent to `just <platform> setup`.
 [group("setup")]


### PR DESCRIPTION
`just ci tier1` in host-tests failed before running a single test:

```
  [x] cross Rust target(s) declared by this tree are not installed
        missing rust target(s): armv8r-none-eabihf
  [x] test fixtures not ready for this lane (missing, or stale under the stamp)
  [x] corrosion in the SDK store is not at the pinned version
```

None of these is a test bug. All three are provisioning, and the lane had no step that provisioned any of them — because **`just setup <scope>` does not provision them either**. Corrosion and the cross targets live in `just workspace setup`, which neither the platform arm nor the preset arm of the `setup` dispatcher chains. So the documented `setup → build → test` chain does not clear the checks its own test step runs, for *every* scope. host-tests is just where it surfaced.

## Three causes, three fixes

**1. `_setup-common` now provisions the two host facts every tier asserts.** It runs on every `just setup <scope>` path, so the scope verb now satisfies `check-tier-preconditions`. Both additions are idempotent (corrosion short-circuits on its version stamp; `rustup target add` is a no-op when present) and both run *after* `setup-cli`, because `install-corrosion` resolves its prefix via `nros sdk-path corrosion`.

**2. The CI image was a third copy of the target list.** This is the issue-0833 drift class one level further out: `config/rust-targets.txt` exists precisely because two hand-written copies of that list had drifted, and `ci/docker/ci-base/Dockerfile` was a **third** — it never gained `armv8r-none-eabihf`. It now also installs every target the SSoT declares, read through `scripts/lib/rust-targets.sh` (the one parser), for both the stable and pinned-nightly toolchains.

Additive on purpose: the baked list carries targets the SSoT does not declare (`x86_64-unknown-none`, `aarch64-unknown-none`, …), and dropping those here would be a silent capability loss.

**3. Four hand-rolled provisioning steps collapse to `just setup native`** — the same sequence a user runs (`nros setup --build-sources`, `just ci provision-zenohd`, the qemu / xrce-agent / play_launch_parser tools), plus the CLI and resolver via `_setup-common`. The play_launch_parser PATH export stays as a CI-only step.

## The fixture precondition is bypassed, not satisfied — deliberately

This lane builds a **subset** of the native fixtures: the ~52 GB extras are omitted so `test-integration` does not hit ENOSPC on the shared disk. Writing the lane stamp would assert coverage it does not have, which is a lie rather than a fix. `NROS_SKIP_FIXTURE_CHECK=1` skips only the pre-flight — a missing in-lane fixture is still a hard failure at test time via `check-skip-budget` (issue 0584), so nothing is laundered into a skip.

## Verification

- `just workspace install-corrosion` turned out to be missing on my host too, and installed `0.6.1-nros1` — the gap is not CI-specific.
- `check-tier-preconditions` no longer lists either the cross targets or corrosion.
- `just check fast` — 196 gates ran, 0 failures.
- Workflow YAML re-parsed after editing: both jobs intact (unit 6 steps, integration 10).

Note the runtime fix (1) makes host-tests green **without** waiting for the image rebuild in (2); the image change removes the per-run cost and the drift class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)