### PR TITLE
fix(#1039): NuttX defines ZENOH_LINUX in the manifest too, so the unix layer is not defined twice

### DIFF
--- a/packages/platform/nros-platform-nuttx/nros-platform.toml
+++ b/packages/platform/nros-platform-nuttx/nros-platform.toml
@@ -19,7 +19,7 @@ names = ["nuttx"]
 ip_stack = true    # posix sockets, named in [build]
 
 [build.zenoh]
-defines = ["ZENOH_GENERIC", "ZENOH_NUTTX"]
+defines = ["ZENOH_GENERIC", "ZENOH_NUTTX", "ZENOH_LINUX"]
 defines_kv = { ZENOH_DEBUG = "0", Z_FEATURE_MULTI_THREAD = "1", Z_CONFIG_SOCKET_TIMEOUT = "5000" }
 include = ["system/common"]
 # Phase 156 Sub-bug B (NuttX) — `system/common/platform.h` routes


### PR DESCRIPTION
One line. It makes the NuttX arm zenoh lane link.

## The defect: two authored copies of "what NuttX defines"

`src/system/common/platform.c:135` defines a fallback `_z_socket_get_endpoints` under

```c
#if !defined(ZENOH_WINDOWS) && !defined(ZENOH_LINUX) && !defined(ZENOH_MACOS) \
    && !defined(ZENOH_BSD) && !defined(ZENOH_ZEPHYR)
```

and the unix layer defines the real one. Without `ZENOH_LINUX`, **both** compile — six `multiple definition` link errors, every NuttX zenoh fixture dead.

`runner.rs`'s size probe already defines both `ZENOH_NUTTX` and `ZENOH_LINUX`, with a comment explaining at length why the second is essential:

> Keep it. NuttX ships `<sys/random.h>` and `getrandom()`, so the Linux arm compiles and works, while the NuttX arm it shadows opens `/dev/urandom` — a device node a NuttX configuration is not obliged to provide. Dropping this define would silently move every NuttX image onto six code paths nothing here has ever exercised.

`nros-platform-nuttx/nros-platform.toml` defined only `ZENOH_NUTTX`. So the size probe and the library build compiled zenoh-pico with **different defines**, and nothing compared them. This makes the manifest say what the probe already said.

## Measured, with a control

Same tree, same command:

| | result |
| --- | --- |
| baseline, no `ZENOH_LINUX` | `EXIT=2`, 6× `multiple definition of _z_socket_get_endpoints` |
| with `ZENOH_LINUX` | **`EXIT=0`, 0 errors** |

Leaves relinked: `cpp_action_client` 18:48:43, `c_talker` 18:47:52.

## Why this could not be measured until now

The identical experiment yesterday returned **byte-identical output**, and I read it as refuted. It had never run: the watch loop reconstructed `root/<name>/nros-platform.toml` while a platform package directory is `nros-platform-<name>`, so this manifest was not a build input at all. An edit to it changed nothing until an unrelated rebuild.

Proof the build script genuinely re-ran this time — the thing yesterday's attempt could not show — is that the generated `nros_nuttx_stdbool_fixup.h` mtimes moved `18:46:11 → 18:47:20`.

**Depends on #363** (`fix/platform-manifest-build-input`) to be *testable*, though not to be *correct*. Without it, this edit reaches nothing until something else forces a rebuild.

## Third and last layer of the NuttX lane

Each was hidden behind the one before it:

| layer | where |
| --- | --- |
| preflight refusing a build-std target | #0999, already on main |
| NuttX's non-conforming `stdbool.h` vs zenoh-pico's new keyexpr template | #1039 workaround, PR #343 |
| the unix layer compiled twice | **this** |

## Not claimed

Only that the **arm** lane links. `riscv` NuttX was not built, and nothing here says anything about runtime behaviour — the lane produces images again, which is a precondition for a verdict, not a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
