### PR TITLE
feat(phase-420 W1): a provider family costs the package.xml readers nothing

### DIFF
--- a/cmake/NanoRosPackageXml.cmake
+++ b/cmake/NanoRosPackageXml.cmake
@@ -64,13 +64,31 @@ endfunction()
 # ---------------------------------------------------------------------------
 # nano_ros_read_package_export([PACKAGE_XML <path>])
 #
-# Parse the `<export><nano_ros deploy= board= rmw=/></export>` tuple from a
-# package.xml (default `${CMAKE_CURRENT_SOURCE_DIR}/package.xml`). Sets, in the
-# caller's scope:
+# Parse a package.xml's consumption exports (default
+# `${CMAKE_CURRENT_SOURCE_DIR}/package.xml`). Sets, in the caller's scope:
 #   NANO_ROS_EXPORT_DEPLOY   — deploy attr verbatim (e.g. native / freertos), or ""
 #   NANO_ROS_EXPORT_BOARD    — board attr, or ""
 #   NANO_ROS_EXPORT_RMW      — rmw attr, or ""
 #   NANO_ROS_EXPORT_FOUND    — TRUE iff a <nano_ros …/> element was present
+#   NANO_ROS_EXPORT_USES_KINDS      — every selected family, declaration order
+#   NANO_ROS_EXPORT_USES_<KIND>     — the name selected for that family
+#
+# RFC-0087 D3 / phase-420 W1 — two spellings, one meaning:
+#
+#   <nano_ros deploy="freertos" board="mps2-an385-freertos" rmw="zenoh"/>
+#   <nano_ros_uses kind="serdes" name="flatbuf"/>
+#
+# `board=` and `rmw=` are provider selections and desugar into
+# `NANO_ROS_EXPORT_USES_{BOARD,RMW}` alongside their legacy variables, so the
+# two spellings are indistinguishable to a consumer. `deploy=` does NOT: it
+# names a `[deploy.*]` block in system.toml (mapped to the NANO_ROS_PLATFORM
+# axis below), not a provider, and folding it in would invent a family with no
+# descriptor behind it.
+#
+# The point of the general form is that **a new provider family costs this
+# reader nothing** — selecting a serializer needs no fourth attribute here and
+# no new special case in `cargo-nano-ros`'s parser.
+#
 # A package with no `<nano_ros>` element (or no package.xml) leaves FOUND FALSE
 # and the strings empty — callers fall back to their prior defaults.
 # ---------------------------------------------------------------------------
@@ -84,24 +102,59 @@ function(nano_ros_read_package_export)
     set(NANO_ROS_EXPORT_BOARD  "" PARENT_SCOPE)
     set(NANO_ROS_EXPORT_RMW    "" PARENT_SCOPE)
     set(NANO_ROS_EXPORT_FOUND  FALSE PARENT_SCOPE)
+    set(NANO_ROS_EXPORT_USES_KINDS "" PARENT_SCOPE)
 
     if(NOT EXISTS "${_NRP_PACKAGE_XML}")
         return()
     endif()
     nros_read_package_xml_body("${_NRP_PACKAGE_XML}" _body)
 
-    # Isolate the <nano_ros …/> element (self-closing or paired). Attribute order
-    # is free, so pull each attribute independently rather than positionally.
-    if(NOT _body MATCHES "<nano_ros[ \t\r\n]+([^>]*)/?>")
-        return()
-    endif()
-    set(_attrs "${CMAKE_MATCH_1}")
-    set(NANO_ROS_EXPORT_FOUND TRUE PARENT_SCOPE)
+    set(_kinds "")
 
-    foreach(_key deploy board rmw)
-        if(_attrs MATCHES "${_key}[ \t]*=[ \t]*\"([^\"]*)\"")
-            string(TOUPPER "${_key}" _KEY)
-            set(NANO_ROS_EXPORT_${_KEY} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    # The general form first, in declaration order. MATCHALL because a package
+    # may select several families; `<nano_ros_uses` cannot be confused with
+    # `<nano_ros ` (no whitespace follows the shared prefix) or with
+    # `<nano_ros_provides`, which is the opposite direction and read elsewhere.
+    string(REGEX MATCHALL "<nano_ros_uses[ \t\r\n]+[^>]*/?>" _uses "${_body}")
+    foreach(_use IN LISTS _uses)
+        set(_kind "")
+        set(_name "")
+        if(_use MATCHES "kind[ \t]*=[ \t]*\"([^\"]*)\"")
+            set(_kind "${CMAKE_MATCH_1}")
         endif()
+        if(_use MATCHES "name[ \t]*=[ \t]*\"([^\"]*)\"")
+            set(_name "${CMAKE_MATCH_1}")
+        endif()
+        if(_kind STREQUAL "" OR _name STREQUAL "")
+            message(FATAL_ERROR
+                "${_NRP_PACKAGE_XML}: <nano_ros_uses> needs non-empty kind= and name= "
+                "(got kind=\"${_kind}\", name=\"${_name}\")")
+        endif()
+        string(TOUPPER "${_kind}" _KIND)
+        set(NANO_ROS_EXPORT_USES_${_KIND} "${_name}" PARENT_SCOPE)
+        list(APPEND _kinds "${_kind}")
     endforeach()
+
+    # Then the sugar. Isolate the <nano_ros …/> element (self-closing or
+    # paired). Attribute order is free, so pull each attribute independently
+    # rather than positionally.
+    if(_body MATCHES "<nano_ros[ \t\r\n]+([^>]*)/?>")
+        set(_attrs "${CMAKE_MATCH_1}")
+        set(NANO_ROS_EXPORT_FOUND TRUE PARENT_SCOPE)
+
+        foreach(_key deploy board rmw)
+            if(_attrs MATCHES "${_key}[ \t]*=[ \t]*\"([^\"]*)\"")
+                string(TOUPPER "${_key}" _KEY)
+                set(NANO_ROS_EXPORT_${_KEY} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+                # board= and rmw= ARE provider selections; deploy= is not.
+                if(NOT _key STREQUAL "deploy" AND NOT CMAKE_MATCH_1 STREQUAL "")
+                    set(NANO_ROS_EXPORT_USES_${_KEY} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+                    list(APPEND _kinds "${_key}")
+                endif()
+            endif()
+        endforeach()
+    endif()
+
+    list(REMOVE_DUPLICATES _kinds)
+    set(NANO_ROS_EXPORT_USES_KINDS "${_kinds}" PARENT_SCOPE)
 endfunction()

--- a/docs/roadmap/phase-420-package-identity-and-provider-format.md
+++ b/docs/roadmap/phase-420-package-identity-and-provider-format.md
@@ -1,6 +1,6 @@
 # Phase 420 — package identity and the provider format
 
-**Status (2026-09-04). Planning.** No work item started. Implements
+**Status (2026-09-04). W1 landed; W2–W9 open.** Implements
 [RFC-0087](../design/0087-package-identity-and-provider-format.md). Sequenced
 with [phase-421](phase-421-serialization-format-provider.md), which implements
 RFC-0088 and needs **W1 of this phase only** — the rest of this phase can land
@@ -36,17 +36,27 @@ is one road.
 
 ## Work items
 
-- [ ] **W1 — `<nano_ros_uses kind= name=/>` and one parser for three tags.**
+- [x] **W1 — `<nano_ros_uses kind= name=/>` and one parser for three tags.** (landed 2026-09-04)
       Add the general consumption form; define `board=` / `rmw=` on the bare
       `<nano_ros …/>` tag as sugar for it; leave `deploy=` an attribute, because
       it names a `[deploy.*]` block and is not a provider kind. Implement the
       shared rule set once (must sit inside `<export>`, non-empty `kind`/`name`,
       comments stripped) and have both the Rust parser and
       `NanoRosPackageXml.cmake` consume that one implementation.
-      **Acceptance:** a package selecting a provider of a family that has no
-      bespoke attribute builds with no change to either parser; the two
-      reader-confusion tests still pass, plus a new one asserting sugar and
-      general form resolve identically. **This is what phase-421 W4 needs.**
+      **Acceptance, met:** a package selecting `kind="serdes"` resolves in both
+      readers with no new attribute in either; the two reader-confusion tests
+      still pass; `the_sugar_and_the_general_form_resolve_identically` asserts
+      the equivalence in Rust and `check-package-xml-uses` asserts it in cmake.
+      **This is what phase-421 W4 needs.**
+
+      Landed as: one `read_announcement` helper serving both announcement tags
+      in `package_xml.rs` (the two readers that confused the directions each
+      implemented the rule separately — one match arm cannot disagree with
+      itself); `PackageXml::{uses, deploy}` with `uses_of_kind()`;
+      `NANO_ROS_EXPORT_USES_<KIND>` plus `NANO_ROS_EXPORT_USES_KINDS` in
+      `NanoRosPackageXml.cmake`, fed by both spellings; and a buildless
+      `cmake -P` gate. `deploy=` stays an attribute in both, and a
+      `<nano_ros_uses kind="deploy" …/>` is not invented to carry it.
 
 - [ ] **W2 — `nros_cmake` / `nros_cargo` build types.** Teach the reader both old
       and new, mapping `ament_cargo|ament_nros → nros_cargo` with a deprecation

--- a/just/check.just
+++ b/just/check.just
@@ -223,6 +223,7 @@ fast-serial: \
     opaque-storage-guards \
     orphan-generated-stamp \
     package-xml-comments \
+    package-xml-uses \
     path-env-fingerprints \
     peer-sweep-lanes \
     platform-abi-mirror \
@@ -4170,6 +4171,15 @@ provider-index:
 [private]
 package-xml-comments:
     @bash packages/testing/nros-tests/tests/package_xml_comment_stripping.sh
+
+# RFC-0087 D3 / phase-420 W1 — `<nano_ros_uses kind= name=/>` and the
+# `<nano_ros deploy= board= rmw=/>` sugar must mean the same thing to the cmake
+# reader, and `deploy=` must NOT become a selection (it names a system.toml
+# block, not a provider). Divergence between the two spellings would be
+# invisible: both still configure, against different values. Buildless.
+[private]
+package-xml-uses:
+    @bash packages/testing/nros-tests/tests/package_xml_uses_general_form.sh
 
 # issue 0762 — a killed build launcher must take its whole subtree with it.
 # Drives real process trees and asserts on `ps`: the orphan bug is silent by

--- a/packages/cli/cargo-nano-ros/src/package_xml.rs
+++ b/packages/cli/cargo-nano-ros/src/package_xml.rs
@@ -8,31 +8,41 @@ use eyre::{Result, WrapErr, eyre};
 use quick_xml::{Reader, events::Event};
 use std::{collections::HashSet, path::Path};
 
-/// A provision export — phase-348 W1 / RFC-0071 D5.
+/// A `(kind, name)` announcement — phase-348 W1 / RFC-0071 D5, generalised by
+/// RFC-0087 D3.
+///
+/// One shape, two directions, two tags:
 ///
 /// ```xml
 /// <export>
-///   <nano_ros_provides kind="rmw" name="zenoh"/>
+///   <nano_ros_provides kind="rmw"    name="zenoh"/>   <!-- "I am"           -->
+///   <nano_ros_uses     kind="serdes" name="flatbuf"/> <!-- "build me against" -->
 /// </export>
 /// ```
 ///
-/// Deliberately a DIFFERENT tag from the consumption export
-/// `<nano_ros deploy= board= rmw=/>` (`cmake/NanoRosPackageXml.cmake`), which
-/// says "this is what I consume". The two would be confused on sight if
-/// provision were spelled as another attribute of the same element, and they
-/// mean opposite things: one selects a backend, the other IS one.
+/// The directions stay two tags deliberately. They mean opposite things, and
+/// spelling one as an attribute of the other is how two independent readers
+/// came to confuse them: this module's own test message ("`<nano_ros rmw=…>`
+/// says what this package CONSUMES") and `cmake/NanoRosPackageXml.cmake`'s
+/// comment about having "reported the file as consuming `rmw=zenoh`".
 ///
 /// `kind` is an open vocabulary. The scan does not validate it, because the
 /// kinds that exist are a property of what descriptors exist
-/// (`nros-{rmw,board,platform}.toml`), not of this parser — a new provider
-/// family must not require editing the XML reader.
+/// (`nros-{rmw,board,platform,serdes}.toml`), not of this parser — a new
+/// provider family must not require editing the XML reader. That is the whole
+/// point of `<nano_ros_uses>`: selecting a serializer costs no new attribute in
+/// this parser or in the cmake one.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct Provision {
-    /// What family this package provides: `rmw`, `board`, `platform`, …
+    /// What family this announcement names: `rmw`, `board`, `platform`, …
     pub kind: String,
     /// The name a consumer selects it by (`rmw = "zenoh"`).
     pub name: String,
 }
+
+/// A consumption announcement. Same shape as [`Provision`], opposite direction
+/// — see that type's docs for why they are not one tag.
+pub type Selection = Provision;
 
 /// Parsed package.xml metadata
 #[derive(Debug, Clone)]
@@ -47,6 +57,66 @@ pub struct PackageXml {
     /// Empty for every package that is not a provider, which is almost all of
     /// them — this is the cheap parse the scan does per package.
     pub provides: Vec<Provision>,
+    /// `<export><nano_ros_uses …/></export>` entries, plus the `board=` / `rmw=`
+    /// attributes of the `<nano_ros …/>` sugar desugared into the same list
+    /// (RFC-0087 D3). Declaration order, sugar last.
+    pub uses: Vec<Selection>,
+    /// The `deploy=` attribute of `<nano_ros …/>`, verbatim.
+    ///
+    /// NOT desugared into [`Self::uses`], because `deploy` is **not a provider
+    /// kind**: it names a `[deploy.*]` block in `system.toml`, which
+    /// `NanoRosPackageXml.cmake` maps to the `NANO_ROS_PLATFORM` axis. Folding
+    /// it in would invent a family that has no descriptor and no provider.
+    pub deploy: Option<String>,
+}
+
+/// Read a `(kind, name)` announcement from either announcement tag.
+///
+/// ONE rule set for `<nano_ros_provides>` and `<nano_ros_uses>` (RFC-0087 D3):
+/// inside `<export>`, both attributes present and non-empty, no others allowed.
+/// The tag name is carried only so the error text names the element the author
+/// actually wrote.
+fn read_announcement(
+    e: &quick_xml::events::BytesStart<'_>,
+    tag: &str,
+    in_export: bool,
+) -> Result<Provision> {
+    if !in_export {
+        return Err(eyre!(
+            "<{tag}> outside <export> — an announcement is only read from the \
+             export block, so this one would never be discovered"
+        ));
+    }
+    let mut kind = None;
+    let mut name = None;
+    for attr in e.attributes() {
+        let attr = attr.map_err(|e| eyre!("bad attribute: {e}"))?;
+        let value = attr
+            .unescape_value()
+            .map_err(|e| eyre!("bad attribute value: {e}"))?
+            .to_string();
+        match attr.key.as_ref() {
+            b"kind" => kind = Some(value),
+            b"name" => name = Some(value),
+            other => {
+                return Err(eyre!(
+                    "<{tag}> has unknown attribute {:?} — expected only kind= and name=",
+                    String::from_utf8_lossy(other)
+                ));
+            }
+        }
+    }
+    // Both are load-bearing and neither has a defensible default: an
+    // announcement with no name cannot be selected, and one with no kind names
+    // no descriptor.
+    match (kind, name) {
+        (Some(k), Some(n)) if !k.is_empty() && !n.is_empty() => Ok(Provision { kind: k, name: n }),
+        (k, n) => Err(eyre!(
+            "<{tag}> needs non-empty kind= and name= (got kind={:?}, name={:?})",
+            k.unwrap_or_default(),
+            n.unwrap_or_default()
+        )),
+    }
 }
 
 impl PackageXml {
@@ -67,6 +137,9 @@ impl PackageXml {
         let mut version = None;
         let mut dependencies = HashSet::new();
         let mut provides = Vec::new();
+        let mut uses: Vec<Selection> = Vec::new();
+        let mut sugar: Vec<Selection> = Vec::new();
+        let mut deploy = None;
 
         let mut current_tag = String::new();
         let mut in_export = false;
@@ -78,51 +151,67 @@ impl PackageXml {
                 // catch-all — so a provision written self-closing (the natural
                 // spelling, and the one the docs show) would have been silently
                 // invisible.
+                // `Empty` is the self-closing form. Before phase-348 this arm
+                // did not exist at all — every `<tag/>` fell through the `_`
+                // catch-all — so a provision written self-closing (the natural
+                // spelling, and the one the docs show) would have been silently
+                // invisible.
+                //
+                // RFC-0087 D3 — both announcement tags are read here, by ONE
+                // rule set. Two readers implementing the rule separately is
+                // exactly how provision and consumption came to be confused;
+                // one match arm cannot disagree with itself.
                 Ok(Event::Start(e) | Event::Empty(e))
-                    if e.name().as_ref() == b"nano_ros_provides" =>
+                    if matches!(e.name().as_ref(), b"nano_ros_provides" | b"nano_ros_uses") =>
                 {
+                    let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    let announcement = read_announcement(&e, &tag, in_export)?;
+                    if tag == "nano_ros_provides" {
+                        provides.push(announcement);
+                    } else {
+                        uses.push(announcement);
+                    }
+                }
+                // The `<nano_ros deploy= board= rmw=/>` sugar (91 packages).
+                // `board=` and `rmw=` ARE provider selections and desugar into
+                // `uses`; `deploy=` is not a kind and stays an attribute.
+                Ok(Event::Start(e) | Event::Empty(e)) if e.name().as_ref() == b"nano_ros" => {
                     if !in_export {
                         return Err(eyre!(
-                            "<nano_ros_provides> outside <export> — a provision \
-                             is only read from the export block, so this one \
-                             would never be discovered"
+                            "<nano_ros> outside <export> — the consumption tuple is \
+                             only read from the export block, so this one would \
+                             never be seen"
                         ));
                     }
-                    let mut kind = None;
-                    let mut pname = None;
                     for attr in e.attributes() {
                         let attr = attr.map_err(|e| eyre!("bad attribute: {e}"))?;
                         let value = attr
                             .unescape_value()
                             .map_err(|e| eyre!("bad attribute value: {e}"))?
                             .to_string();
+                        if value.is_empty() {
+                            continue;
+                        }
                         match attr.key.as_ref() {
-                            b"kind" => kind = Some(value),
-                            b"name" => pname = Some(value),
+                            b"deploy" => deploy = Some(value),
+                            b"board" => sugar.push(Selection {
+                                kind: "board".to_string(),
+                                name: value,
+                            }),
+                            b"rmw" => sugar.push(Selection {
+                                kind: "rmw".to_string(),
+                                name: value,
+                            }),
                             other => {
                                 return Err(eyre!(
-                                    "<nano_ros_provides> has unknown attribute {:?} \
-                                     — expected only kind= and name=",
+                                    "<nano_ros> has unknown attribute {:?} — the sugar \
+                                     carries deploy=, board= and rmw=; anything else is \
+                                     a <nano_ros_uses kind= name=/>",
                                     String::from_utf8_lossy(other)
                                 ));
                             }
                         }
                     }
-                    // Both are load-bearing and neither has a defensible
-                    // default: a provision with no name cannot be selected, and
-                    // one with no kind names no descriptor.
-                    let (kind, pname) = match (kind, pname) {
-                        (Some(k), Some(n)) if !k.is_empty() && !n.is_empty() => (k, n),
-                        (k, n) => {
-                            return Err(eyre!(
-                                "<nano_ros_provides> needs non-empty kind= and name= \
-                                 (got kind={:?}, name={:?})",
-                                k.unwrap_or_default(),
-                                n.unwrap_or_default()
-                            ));
-                        }
-                    };
-                    provides.push(Provision { kind, name: pname });
                 }
                 Ok(Event::Start(e)) => {
                     current_tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
@@ -162,6 +251,11 @@ impl PackageXml {
             version: version.unwrap_or_else(|| "0.0.0".to_string()),
             dependencies,
             provides,
+            uses: {
+                uses.extend(sugar);
+                uses
+            },
+            deploy,
         })
     }
 
@@ -173,6 +267,13 @@ impl PackageXml {
     /// Provisions of one kind, in declaration order.
     pub fn provides_of_kind(&self, kind: &str) -> impl Iterator<Item = &Provision> {
         self.provides.iter().filter(move |p| p.kind == kind)
+    }
+
+    /// Selections of one kind, in declaration order — the general form and the
+    /// `<nano_ros …/>` sugar together, which is what makes them equivalent to a
+    /// consumer.
+    pub fn uses_of_kind(&self, kind: &str) -> impl Iterator<Item = &Selection> {
+        self.uses.iter().filter(move |u| u.kind == kind)
     }
 }
 
@@ -362,5 +463,131 @@ mod tests {
         assert_eq!(pkg.name, "minimal");
         assert_eq!(pkg.version, "0.0.0");
         assert!(pkg.dependencies.is_empty());
+    }
+    // ── RFC-0087 D3 / phase-420 W1 — the general consumption form ─────────
+
+    /// The acceptance criterion: a family with no bespoke attribute is
+    /// selectable, and this parser learned nothing to make that true.
+    #[test]
+    fn a_family_with_no_attribute_is_selectable() {
+        let pkg = PackageXml::parse_str(&provider_xml(
+            r#"    <nano_ros_uses kind="serdes" name="flatbuf"/>"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            pkg.uses_of_kind("serdes").collect::<Vec<_>>(),
+            vec![&Selection {
+                kind: "serdes".to_string(),
+                name: "flatbuf".to_string(),
+            }]
+        );
+        // And it is NOT a provision: this package consumes flatbuf, it is not
+        // flatbuf. That confusion has cost two readers already.
+        assert!(pkg.provides.is_empty());
+    }
+
+    /// Sugar and general form must be indistinguishable to a consumer, or the
+    /// 91 packages using the tuple would mean something subtly different from
+    /// the packages using the general form.
+    #[test]
+    fn the_sugar_and_the_general_form_resolve_identically() {
+        let sugar = PackageXml::parse_str(&provider_xml(
+            r#"    <nano_ros deploy="freertos" board="mps2-an385-freertos" rmw="zenoh"/>"#,
+        ))
+        .unwrap();
+        let general = PackageXml::parse_str(&provider_xml(
+            r#"    <nano_ros deploy="freertos"/>
+    <nano_ros_uses kind="board" name="mps2-an385-freertos"/>
+    <nano_ros_uses kind="rmw" name="zenoh"/>"#,
+        ))
+        .unwrap();
+
+        for kind in ["board", "rmw"] {
+            assert_eq!(
+                sugar.uses_of_kind(kind).collect::<Vec<_>>(),
+                general.uses_of_kind(kind).collect::<Vec<_>>(),
+                "{kind} differs between the sugar and the general form"
+            );
+        }
+        assert_eq!(sugar.deploy.as_deref(), Some("freertos"));
+        assert_eq!(general.deploy.as_deref(), Some("freertos"));
+    }
+
+    /// `deploy` names a `[deploy.*]` block in system.toml, not a provider, so
+    /// it must not appear as a selection of kind `deploy` — a family with no
+    /// descriptor and no provider behind it.
+    #[test]
+    fn deploy_is_not_a_provider_kind() {
+        let pkg =
+            PackageXml::parse_str(&provider_xml(r#"    <nano_ros deploy="native"/>"#)).unwrap();
+        assert_eq!(pkg.deploy.as_deref(), Some("native"));
+        assert!(
+            pkg.uses.is_empty(),
+            "deploy must not desugar into a selection"
+        );
+        assert_eq!(pkg.uses_of_kind("deploy").count(), 0);
+    }
+
+    /// The same rule set as `<nano_ros_provides>`, because it is literally the
+    /// same code path — asserted here so a future split shows up as a failure.
+    #[test]
+    fn a_selection_obeys_the_provision_rules() {
+        // outside <export>
+        let err = PackageXml::parse_str(
+            r#"<?xml version="1.0"?>
+<package format="3">
+  <name>p</name>
+  <version>0.0.0</version>
+  <nano_ros_uses kind="serdes" name="flatbuf"/>
+</package>"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("nano_ros_uses"),
+            "the error must name the tag the author wrote: {err}"
+        );
+
+        // unknown attribute
+        let err = PackageXml::parse_str(&provider_xml(
+            r#"    <nano_ros_uses kind="serdes" name="flatbuf" versoin="2"/>"#,
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("versoin"), "{err}");
+
+        // empty name
+        let err = PackageXml::parse_str(&provider_xml(
+            r#"    <nano_ros_uses kind="serdes" name=""/>"#,
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("non-empty"), "{err}");
+    }
+
+    /// issue 0516 — a documented example is not a declaration, and the strip
+    /// covers the new tag because it covers the file, not a tag list.
+    #[test]
+    fn a_commented_out_selection_is_not_a_selection() {
+        let pkg = PackageXml::parse_str(&provider_xml(
+            r#"    <!-- <nano_ros_uses kind="serdes" name="ghost"/> -->
+    <nano_ros_uses kind="serdes" name="real"/>"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            pkg.uses_of_kind("serdes")
+                .map(|u| u.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["real"]
+        );
+    }
+
+    /// An unknown attribute on the sugar is a typo, not a new axis — the
+    /// general form is where a new family goes.
+    #[test]
+    fn the_sugar_rejects_an_unknown_attribute() {
+        let err = PackageXml::parse_str(&provider_xml(
+            r#"    <nano_ros deploy="native" serdes="flatbuf"/>"#,
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("serdes"), "{err}");
+        assert!(err.to_string().contains("nano_ros_uses"), "{err}");
     }
 }

--- a/packages/testing/nros-tests/tests/package_xml_uses_general_form.sh
+++ b/packages/testing/nros-tests/tests/package_xml_uses_general_form.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# RFC-0087 D3 / phase-420 W1 — `<nano_ros_uses kind= name=/>`, the general
+# consumption form, as the cmake reader sees it.
+#
+# THE PROPERTY
+#
+# A consumption export has two spellings and they must mean the same thing:
+#
+#   <nano_ros deploy="freertos" board="mps2-an385-freertos" rmw="zenoh"/>
+#   <nano_ros_uses kind="board" name="mps2-an385-freertos"/>
+#
+# 91 packages use the sugar, so it is not going away; the general form exists so
+# that a NEW provider family — a serializer, phase-421 W4 — costs this reader no
+# fourth attribute and costs `cargo-nano-ros`'s parser no new special case. If
+# the two spellings ever diverged, that promise would be false and the divergence
+# would be invisible: both would still configure, just against different values.
+#
+# Cases:
+#
+#   T1  the general form sets NANO_ROS_EXPORT_USES_<KIND> for a family this
+#       reader has never heard of;
+#   T2  the sugar desugars into the SAME variables (board/rmw), so a consumer
+#       cannot tell which spelling was used;
+#   T3  `deploy=` does NOT become a selection. It names a `[deploy.*]` block in
+#       system.toml, not a provider, and inventing a `deploy` family would give
+#       it a descriptor lookup that must always fail;
+#   T4  a commented-out selection is not a selection (issue 0516, re-asserted
+#       for the new tag because the strip covers the FILE, not a tag list);
+#   T5  a selection missing `name=` is a hard error, not a silent skip — the
+#       same rule `<nano_ros_provides>` has always had.
+#
+# Buildless: `cmake -P`, no compiler, no cargo, no fixtures.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+MODULE="$ROOT/cmake/NanoRosPackageXml.cmake"
+
+# shellcheck source=../../../../scripts/lib/grep-q.sh
+. "$ROOT/scripts/lib/grep-q.sh"
+
+[ -f "$MODULE" ] || {
+    echo "FAIL: module not found at $MODULE" >&2
+    exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# T1 — a family with no bespoke attribute anywhere in this reader.
+cat >"$WORK/general.xml" <<'XML'
+<?xml version="1.0"?>
+<package format="3">
+  <name>general</name>
+  <export>
+    <nano_ros deploy="freertos"/>
+    <nano_ros_uses kind="board" name="mps2-an385-freertos"/>
+    <nano_ros_uses kind="rmw" name="zenoh"/>
+    <nano_ros_uses kind="serdes" name="flatbuf"/>
+  </export>
+</package>
+XML
+
+# T2 — the same selection, written as the sugar.
+cat >"$WORK/sugar.xml" <<'XML'
+<?xml version="1.0"?>
+<package format="3">
+  <name>sugar</name>
+  <export>
+    <nano_ros deploy="freertos" board="mps2-an385-freertos" rmw="zenoh"/>
+  </export>
+</package>
+XML
+
+# T4 — a documented example beside a real one.
+cat >"$WORK/commented.xml" <<'XML'
+<?xml version="1.0"?>
+<package format="3">
+  <name>commented</name>
+  <export>
+    <!-- example: <nano_ros_uses kind="serdes" name="ghost"/> -->
+    <nano_ros_uses kind="serdes" name="real"/>
+  </export>
+</package>
+XML
+
+cat >"$WORK/run.cmake" <<CMAKE
+include("$MODULE")
+foreach(_case general sugar commented)
+    nano_ros_read_package_export(PACKAGE_XML "$WORK/\${_case}.xml")
+    message(STATUS "RESULT \${_case} kinds=[\${NANO_ROS_EXPORT_USES_KINDS}] board=\${NANO_ROS_EXPORT_USES_BOARD} rmw=\${NANO_ROS_EXPORT_USES_RMW} serdes=\${NANO_ROS_EXPORT_USES_SERDES} deploy=\${NANO_ROS_EXPORT_DEPLOY} usesdeploy=[\${NANO_ROS_EXPORT_USES_DEPLOY}]")
+endforeach()
+CMAKE
+
+OUT="$(cmake -P "$WORK/run.cmake" 2>&1)" || {
+    echo "FAIL: cmake -P errored" >&2
+    echo "$OUT" >&2
+    exit 1
+}
+
+fail=0
+expect() {
+    local label="$1" want="$2"
+    local got grc
+    # Issue 0726 — a `grep … || true` would map "no RESULT line" and "grep did
+    # not run" onto the same empty string, and the empty string is reported
+    # below as a claim about the cmake loop. Split the statuses by hand.
+    if got="$(grep -E "RESULT $label " <<<"$OUT")"; then :; else
+        grc=$?
+        [ "$grc" -eq 1 ] || {
+            echo "FATAL: grep failed (rc=$grc) selecting the RESULT line for" >&2
+            echo "       '$label'. A tool failure, not a finding (issue 0726)." >&2
+            exit 2
+        }
+        got=""
+    fi
+    if [ -z "$got" ]; then
+        echo "FAIL[$label]: no RESULT line — the case never ran" >&2
+        fail=1
+        return
+    fi
+    if ! nros_grep_q -F -- "$want" <<<"$got"; then
+        echo "FAIL[$label]: expected to contain '$want'" >&2
+        echo "  got: ${got#*-- }" >&2
+        fail=1
+    fi
+}
+
+# T1 — an unknown family resolves, and the known ones come along.
+expect general "serdes=flatbuf"
+expect general "board=mps2-an385-freertos"
+expect general "rmw=zenoh"
+
+# T2 — the sugar lands in the SAME variables. This is the equivalence.
+expect sugar "board=mps2-an385-freertos"
+expect sugar "rmw=zenoh"
+expect sugar "kinds=[board;rmw]"
+
+# T3 — deploy is read, and is not a selection, in EITHER spelling.
+expect general "deploy=freertos"
+expect general "usesdeploy=[]"
+expect sugar "deploy=freertos"
+expect sugar "usesdeploy=[]"
+
+# T4 — the comment declares nothing; the real one survives.
+expect commented "serdes=real"
+
+# T5 — a malformed selection must FAIL the configure rather than be skipped.
+cat >"$WORK/broken.xml" <<'XML'
+<?xml version="1.0"?>
+<package format="3">
+  <name>broken</name>
+  <export>
+    <nano_ros_uses kind="serdes"/>
+  </export>
+</package>
+XML
+cat >"$WORK/broken.cmake" <<CMAKE
+include("$MODULE")
+nano_ros_read_package_export(PACKAGE_XML "$WORK/broken.xml")
+message(STATUS "RESULT broken REACHED")
+CMAKE
+
+if BROKEN_OUT="$(cmake -P "$WORK/broken.cmake" 2>&1)"; then
+    echo "FAIL[broken]: a <nano_ros_uses> with no name= configured successfully" >&2
+    echo "  got: $BROKEN_OUT" >&2
+    fail=1
+# cmake wraps a long `message(FATAL_ERROR …)` across lines, so match a fragment
+# that survives the wrap rather than the whole sentence.
+elif ! nros_grep_q -F -- "needs non-empty kind=" <<<"$BROKEN_OUT"; then
+    echo "FAIL[broken]: failed for the wrong reason" >&2
+    echo "  got: $BROKEN_OUT" >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "check-package-xml-uses: FAILED" >&2
+    exit 1
+fi
+
+echo "check-package-xml-uses: OK (general form, sugar equivalence, deploy, comments, malformed)"


### PR DESCRIPTION
Implements [RFC-0087](docs/design/0087-package-identity-and-provider-format.md) D3. Unblocks phase-421 W4.

`<nano_ros_uses kind= name=/>` joins `<nano_ros_provides>` as the general consumption form; the `<nano_ros deploy= board= rmw=/>` sugar (91 packages) is defined as `board=`/`rmw=` desugaring into it.

**The point is what does *not* change when a family is added.** Selecting a serializer becomes `<nano_ros_uses kind="serdes" name="…"/>` — no fourth attribute in `NanoRosPackageXml.cmake`, no new special case in `cargo-nano-ros`'s parser. An attribute per family means teaching both readers, once per family, forever.

## `deploy=` deliberately does not desugar

It names a `[deploy.*]` block in system.toml — mapped to the `NANO_ROS_PLATFORM` axis — **not a provider**. Folding it in would invent a family whose descriptor lookup could only ever fail. Both readers keep it an attribute; both test suites assert it stays out of the selection list.

## The directions stay two tags

They mean opposite things, and the tree has scars proving it matters:

- `package_xml.rs` carries a test whose message is *"`<nano_ros rmw=…>` says what this package CONSUMES; reading it as a [provision]…"*
- `NanoRosPackageXml.cmake` records a reader bug that *"reported the file as consuming `rmw=zenoh`. The file was correct; the reader…"*

What is unified is the **shape and the code**: one `read_announcement` helper now serves both announcement tags — inside `<export>`, both attributes non-empty, no others. Two readers implementing one rule separately is how both of those bugs happened; one match arm cannot disagree with itself.

## Surface

| Side | Added |
|---|---|
| cmake | `NANO_ROS_EXPORT_USES_<KIND>`, `NANO_ROS_EXPORT_USES_KINDS`, fed by **both** spellings |
| Rust | `PackageXml::{uses, deploy}`, `uses_of_kind()`, `Selection` |

## Tests

Six new Rust cases, notably `the_sugar_and_the_general_form_resolve_identically` (the equivalence) and `a_family_with_no_attribute_is_selectable` — asserted with `serdes`, a family that does not exist yet, which is the whole claim.

New buildless `cmake -P` gate `check-package-xml-uses`: the same equivalence on the cmake side, plus comment stripping and a hard error on a malformed selection. The malformed case matches a fragment rather than the whole sentence — cmake wraps a long `FATAL_ERROR` across lines, and the first version of that assertion failed on the wrap rather than on the behaviour.

## Verification

`cargo test -p cargo-nano-ros --lib` — 115 pass. clippy `-D warnings` clean.

`just check fast` — 4 of 198 fail, none this change: `cpp-fmt` reports pre-existing violations under clang-format 14 where 17.0.6 is pinned; `fixtures-manifest` and `kconfig-overridden-values` exit 127 on `nros: command not found` (CLI not built on this host). `cli-fmt` **did** fail on this change and is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV