### PR TITLE
fix(#1038): `just nuttx setup` provisions the RISC-V board its build-all builds

### DIFF
--- a/just/nuttx.just
+++ b/just/nuttx.just
@@ -548,7 +548,7 @@ check-libc-struct-sizes:
     @python3 {{ justfile_directory() }}/scripts/check-nuttx-libc-struct-sizes.py
 
 # Install NuttX prerequisites. Phase 197.4 — provisioning delegated to
-# `nros setup qemu-arm-nuttx` (toolchain + sources); the NuttX-specific
+# `nros setup qemu-{arm,riscv}-nuttx` (toolchains + sources); the NuttX-specific
 # external-app staging stays here.
 [group("setup")]
 setup:
@@ -559,6 +559,19 @@ setup:
     # SDK index; the host-env helper handles rustup. Kernel build + external-app
     # staging stay below (NuttX-specific). `source setup.bash` to PATH the tools.
     nros setup qemu-arm-nuttx
+    # ...and the RISC-V board, because `build-all` builds BOTH. Issue 1038: this
+    # recipe provisioned only the Arm board while `build-fixtures-riscv` builds
+    # riscv leaves, so the nightly `nuttx` cell died every run on
+    #
+    #   NROS_LANE_NAMED_FAIL: nuttx: riscv-none-elf-gcc not found
+    #     (run: nros setup qemu-riscv-nuttx)
+    #   error: you named `nuttx`, so this is a FAILURE, not a skip.
+    #
+    # The lane was behaving correctly — phase-411's named-platform rule firing
+    # at the point of decision, naming the remedy. The defect was that setup did
+    # not run it. `nros setup` is idempotent, so this costs nothing on a host
+    # that already has the toolchain.
+    nros setup qemu-riscv-nuttx
     "{{justfile_directory()}}/tools/host-env.sh" nuttx
     # Phase 194.4 — the NuttX export is self-provisioned by the example build
     # (`nros_nuttx_build_example` runs `make export` before the cargo link), so


### PR DESCRIPTION
## The failure

The nightly `nuttx` cell failed every run at:

```
NROS_LANE_NAMED_FAIL: nuttx: riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)
error: you named `nuttx`, so this is a FAILURE, not a skip.
```

`setup` provisioned `qemu-arm-nuttx` and nothing else, while `build-all` builds **both** architectures — it died in `build-fixtures-riscv` → `build-riscv-c`, after the Arm leaves had built fine.

## What was not broken

**The lane behaved correctly.** phase-411's named-platform rule fired at the point of decision and printed the exact remedy, which is why this took one grep to place. The defect was that setup never ran that remedy.

## Verification

`nros setup qemu-riscv-nuttx --dry-run` resolves the board and its plan names **`riscv-none-elf-gcc`** — so the board id is right and the CI-only symptom is a store that lacks the toolchain, not a typo'd name.

`nros setup` is idempotent, so this is free where the toolchain already exists. It does pull `genromfs` as a source build where no prebuilt exists (minutes on a cold runner) — flagged rather than discovered later.

`just check fast` 197/197.

## Scope

One of three cells in issue 1038's provisioning class. The other two are **deliberately not bundled**, because neither is a one-liner:

- `threadx_riscv64` — needs whatever writes the central `nros-patch.toml` to run before its leaves are read. Their tracked `.cargo/config.toml` includes it, and a missing `include` target is a hard cargo error during *manifest parse* (issue 0463), four frames deep, naming neither the leaf nor `nros sync`.
- `esp32` — phase-413 W3's `nros setup --system` conversion, for packages the index already declares as `[prereq.*]` and in `[tool.esp32-qemu]`'s own `system = [...]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)