### PR TITLE
docs(phase-314, phase-315): both finished a month ago — by phase-323

### DIFF
--- a/docs/roadmap/archived/phase-314-feature-set-ssot.md
+++ b/docs/roadmap/archived/phase-314-feature-set-ssot.md
@@ -1,9 +1,12 @@
 # Phase 314 — one feature-set SSoT for every language
 
-**Status (2026-07-28): W1–W5 landed; issue 0311 closes. ONE acceptance item
-open** — the Rust path still hand-lists capability features (see Acceptance). Fixes issue 0311. Unblocks multi-edition ROS
-support and image-level selectable capabilities (`param-services`,
-`lifecycle-services`, `safety-e2e`).
+**Status (2026-09-04): COMPLETE.** W1–W5 landed 2026-07-28 and issue 0311
+closed then; the last acceptance item — the Rust path hand-listing capability
+features — was closed by **phase-315 W1/W2**, and the "Known deviation" below by
+**phase-323 W2**. Both landed before 2026-08-01; this doc simply never recorded
+it. Verified against `main` 2026-09-04, see the two entries for the evidence.
+Fixes issue 0311. Unblocks multi-edition ROS support and image-level selectable
+capabilities (`param-services`, `lifecycle-services`, `safety-e2e`).
 
 ## Problem
 
@@ -224,10 +227,27 @@ recording: a gate whose heuristics are wrong teaches people to ignore it.
 - [x] Exactly one feature-list computation, with the threadx board split intact.
 - [x] No Rust leaf names a `ros-*` feature; the scaffold does not emit one
       (`scaffold_rust` already takes the edition as a parameter). *(gate-enforced)*
-- [ ] A capability declared in `system.toml` enables its feature on the C, C++
-      **and Rust** paths alike.
-      **C and C++ done. Rust: the silent-failure half is closed, the
-      derivation half is not.** A Rust entry still hand-lists
+- [x] A capability declared in `system.toml` enables its feature on the C, C++
+      **and Rust** paths alike. **CLOSED by phase-315 W1/W2** (verified on
+      `main` 2026-09-04). `nros sync` generates a selection facade crate per
+      entry, and `orchestration/facade.rs:204-223` walks
+      `capability_resolver::CAPABILITIES`, testing each against
+      `sys.capability_enabled(cap.declared)` — the declaration in `system.toml`
+      is what puts `param-services` on the entry's `nros` dep, through cargo
+      feature unification. The entries stopped restating it: the two params
+      entries name the facade and no capability
+      (`examples/workspaces/features/src/zephyr_rust_params_entry/Cargo.toml`,
+      whose comment says so — "This entry names none of them: the declaration is
+      the SSoT"). The one remaining hand-list is the NODE pkg
+      (`rust_param_talker_pkg`), and it is deliberate and documented in place:
+      `ctx.parameter::<T>()` is gated on the feature, so the node declares it to
+      compile standalone rather than only when an Entry unifies it in. That is
+      the same "reason to stay written down" resolution phase-315's last
+      acceptance item uses for its three surviving paths.
+
+      *Original wording, kept because it is the record of what was true on
+      2026-07-28:* C and C++ done; Rust's silent-failure half closed, the
+      derivation half not. A Rust entry still hand-listed
       `param-services` in its own `Cargo.toml`
       (`examples/workspaces/ws-params-rust/src/native_entry`), so declaring
       `[param_services]` in `system.toml` does not enable the cargo feature —
@@ -255,12 +275,20 @@ recording: a gate whose heuristics are wrong teaches people to ignore it.
 - [x] A gate in `just check` fails when the paths disagree.
 - [x] Issue 0311 closes.
 
-## Known deviation
+## Known deviation — RESOLVED by phase-323 W2
 
-The `posix` special case is KEPT rather than removed. On hosted builds
-`param-services` / `lifecycle-services` stay always-on, because the C++ executor
-headers call the gated C entry points and an example using them must link
-whether or not the system declared the axis. It is now a SUPERSET of the
-declared set rather than the only source, so nothing regresses — but the
-original acceptance wording ("the posix-only special case is gone") is not met.
-Removing it needs every hosted example audited first.
+**Resolved 2026-07-31, recorded here 2026-09-04.** phase-323 W2 is titled
+"delete the `posix` always-on" and did exactly that; `main` carries no
+unconditional capability append, and `cmake/NanoRosRuntimeCrate.cmake:226-234`
+now carries the removal's reasoning in place of the code. The audit this
+deviation said was needed ahead of removal is phase-323's own W2 measurement
+round.
+
+*What the deviation said, kept as the record:* the `posix` special case was
+KEPT rather than removed. On hosted builds `param-services` /
+`lifecycle-services` stayed always-on, because the C++ executor headers call
+the gated C entry points and an example using them must link whether or not the
+system declared the axis. It was a SUPERSET of the declared set rather than the
+only source, so nothing regressed — but the original acceptance wording ("the
+posix-only special case is gone") was not met, and removing it needed every
+hosted example audited first.

--- a/docs/roadmap/archived/phase-315-declaration-drives-rust-selection.md
+++ b/docs/roadmap/archived/phase-315-declaration-drives-rust-selection.md
@@ -1,6 +1,10 @@
 # Phase 315 — `system.toml` drives Rust selection too
 
-**Status (2026-07-30): W1, W2, W3, W5 landed and verified; W4 has ONE open decision.** Finishes what phase-314 started: the RMW, the
+**Status (2026-09-04): COMPLETE.** W1, W2, W3, W5 landed and verified
+2026-07-30; W4's one open decision — the `posix` always-on — was taken by
+**phase-323 W2** on 2026-07-31, whose workstream is titled "delete the `posix`
+always-on". This doc never recorded it. Verified against `main` 2026-09-04, see
+the acceptance item for the evidence. Finishes what phase-314 started: the RMW, the
 ROS edition and the capability list are declared once, in `system.toml`, for
 **every** language. Closes phase-314's last open acceptance item and retires the
 hand-written Rust selection it was working around.
@@ -351,8 +355,8 @@ scoped to the deps the facade owns, with comments stripped.
       `--no-default-features`** — verified on `examples/native/rust/talker`, and
       verified in the negative: restoring the old default reproduces
       `error: ros-{humble,iron,jazzy} are mutually exclusive`.
-- [ ] **Retired paths removed, or their reason to stay written down** — 3 of 4
-      resolved, all by evidence rather than inspection:
+- [x] **Retired paths removed, or their reason to stay written down** — all
+      four resolved, all by evidence rather than inspection:
       - `PARAM_SERVICES_ENABLED` **stays** — the facade only covers workspace
         entries; a standalone entry has no `system.toml`, so the assert remains
         the only guard there.
@@ -360,12 +364,33 @@ scoped to the deps the facade owns, with comments stripped.
         in `examples/native/{c,cpp}/safety-listener`. It is the standalone
         capability selector, the C/C++ twin of W3's Rust edition selector.
       - the zephyr local `default` **stays**, per the exception above.
-      - **OPEN:** the `posix` always-on `param_services lifecycle` in
-        `NanoRosRuntimeCrate.cmake`. 9 workspaces declare a capability; ~26
-        receive these two without asking. The 9 that need them already declare
-        them, so it looks removable — but the failure mode is a capability
-        silently missing from an image, not a build error, so it needs a fixture
-        sweep to decide. That sweep is the blocker.
+      - the `posix` always-on `param_services lifecycle` in
+        `NanoRosRuntimeCrate.cmake` is **REMOVED** — by phase-323 W2
+        (2026-07-31, "delete the `posix` always-on"), not by this phase.
+        Confirmed on `main` 2026-09-04: no unconditional capability append
+        survives, and `cmake/NanoRosRuntimeCrate.cmake:226-234` carries the
+        removal's reasoning where the code used to be — *"posix used to get
+        `param_services` + `lifecycle` unconditionally … W1 made
+        `nano_ros_workspace()` resolve the axes from `SYSTEM` before the import,
+        so the declaration now arrives on its own and this can go."*
+
+        The blocker named here — "the failure mode is a capability silently
+        missing from an image, not a build error, so it needs a fixture sweep to
+        decide" — was dissolved rather than paid: phase-323 W4 gated it, and the
+        failure is no longer silent in either direction. A system that declares
+        `[param_services]` against an entry that lacks the feature is a
+        const-eval panic from `nros::main!`
+        (`nros-macros/src/main_macro.rs:1228`, phase-314's guard), and a missing
+        facade is now fatal at `nros build` rather than a warning
+        (`nros-cli-core/src/cmd/build.rs`, phase-413 W2). phase-323 did run the
+        measurement round this item asked for — "All measured on real
+        workspaces, with the posix always-on removed".
+
+        *Original wording, kept as the record of what was true on 2026-07-30:*
+        OPEN. 9 workspaces declare a capability; ~26 received these two without
+        asking. The 9 that need them already declare them, so it looked
+        removable — but the failure mode was a capability silently missing from
+        an image, not a build error, so it needed a fixture sweep to decide.
 - [x] **The gate rejects an entry that restates a declared axis** — W5 rule 5,
       brace-balanced over facade-owned dep specs, comments stripped.
 


### PR DESCRIPTION
Two phases sat open on acceptance items that a **later phase had already
closed**. Neither was work; both were an unrecorded handoff. Found by
`scripts/roadmap-audit.py` (phase-419 W3) plus a box count over
`docs/roadmap/` — 314 and 315 were the only two active phases with exactly
one unticked acceptance box.

## phase-314's last item — closed by phase-315 W1/W2

> A capability declared in `system.toml` enables its feature on the C, C++
> **and Rust** paths alike.

The doc deferred the Rust derivation to phase-315, which built it.
`nros sync` writes a selection facade crate per entry, and
`orchestration/facade.rs:204-223` walks `capability_resolver::CAPABILITIES`,
testing each against `sys.capability_enabled(cap.declared)` — the declaration
is what puts `param-services` on the entry's `nros` dep, through cargo feature
unification.

The entries stopped restating it. `zephyr_rust_params_entry/Cargo.toml` says so
itself: *"This entry names none of them: the declaration is the SSoT."*

The one surviving hand-list is the **node** pkg (`rust_param_talker_pkg`), and
it is deliberate and documented in place — `ctx.parameter::<T>()` is gated on
the feature, so the node declares it to compile standalone rather than only when
an Entry unifies it in. Same "reason to stay written down" resolution phase-315's
own last item uses for its three surviving paths.

The doc's cited counter-example, `ws-params-rust/src/native_entry`, was deleted
by **phase-331 W3**. The evidence for the open claim had not existed for a month
either.

## phase-314's "Known deviation" and phase-315's open W4 decision are the same item — closed by phase-323 W2

phase-323 W2 is titled **"delete the `posix` always-on"** and landed 2026-07-31.
`main` carries no unconditional capability append;
`cmake/NanoRosRuntimeCrate.cmake:226-234` now holds the removal's reasoning
where the code used to be:

> posix used to get `param_services` + `lifecycle` unconditionally … W1 made
> `nano_ros_workspace()` resolve the axes from `SYSTEM` before the import, so the
> declaration now arrives on its own and this can go.

phase-323's own header states the relationship: *"Implements the premise
phase-314 and phase-315 established and did not finish."*

## The blocker phase-315 named was dissolved, not paid

> the failure mode is a capability silently missing from an image, not a build
> error, so it needs a fixture sweep to decide. That sweep is the blocker.

It is loud in both directions now:

* a system declaring `[param_services]` against an entry without the feature is a
  const-eval panic from `nros::main!` (`main_macro.rs:1228` — phase-314's own guard);
* a missing facade is **fatal** at `nros build` rather than a warning (phase-413 W2).

And phase-323 did run the measurement round this item asked for — *"All measured
on real workspaces, with the posix always-on removed."*

## What this PR does

Marks both COMPLETE, archives them, and keeps the original wordings inline as
the record of what was true on 2026-07-28 / 2026-07-30 — a phase doc is a living
record, not a status field.

Docs only; no code changes.

## Verification

    check-doc-refs        OK (every referenced design/issue/roadmap document exists)
    check-roadmap-claims  OK — 0 known finding(s), no new ones across 65 active phase doc(s)
    roadmap-audit         active phases 64 -> 62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
