### PR TITLE
fix(#1038): the central patch file gets a producer, and threadx_riscv64 calls it

### DIFF
--- a/just/threadx-riscv64.just
+++ b/just/threadx-riscv64.just
@@ -118,6 +118,15 @@ build: build-examples
     @echo "ThreadX RISC-V 64 examples built."
 
 # Build ThreadX QEMU RISC-V 64 examples
+#
+# issue 1038 — `nros_ensure_central_patch` FIRST. Every Rust leaf here reaches the
+# universal-trio patches through `include = ["…/nros-patch.toml"]`, and that
+# file is written by `nros sync`, which needs a workspace. This lane builds only
+# standalone leaves, so nothing here ever wrote it: the nightly cell died on
+# `failed to load config include ../../../../../nros-patch.toml` at MANIFEST
+# PARSE, before any compilation. Every other platform lane runs
+# `workspace-fixtures-build.sh` somewhere and got the file by side effect, which
+# is why the identical config resolved for them and not here.
 [group("main")]
 build-examples:
     #!/usr/bin/env bash
@@ -128,6 +137,8 @@ build-examples:
     source scripts/build/lane-skip.sh
     nros_lane_skip_reset threadx-riscv64
     source scripts/build/cargo.sh
+    # issue 1038 — before ANY cargo invocation in this lane (see the header).
+    nros_ensure_central_patch
     cargo_profile_args="$(nros_cargo_profile_arg_string)"
     if [ ! -d "$THREADX_DIR/common/inc" ] || [ ! -d "$NETX_DIR/common/inc" ]; then
         nros_lane_skip_note threadx-riscv64 "Skipping ThreadX QEMU RISC-V examples (ThreadX/NetX not found). Run: just threadx-linux setup"
@@ -191,6 +202,12 @@ build-fixture-extras:
     set -e
     source scripts/build/cargo.sh
     source scripts/build/fixture-matrix.sh
+    # issue 1038 — this is where the Rust leaves are actually built (the
+    # phase-369 cmake path), so it is where the nightly died at manifest parse.
+    # Also called in `build-examples`, which runs first under `build-fixtures`;
+    # the call is idempotent, and repeating it means running THIS recipe alone
+    # works too.
+    nros_ensure_central_patch
     cargo_profile_args="$(nros_cargo_profile_arg_string)"
     export cargo_profile_args
     cargo_frontends="$(nros_cargo_frontend_jobs)"

--- a/justfile
+++ b/justfile
@@ -1870,6 +1870,33 @@ _require-leaf-includes:
     fi
     python3 scripts/build/leaf-config-includes.py
 
+# issue 1038 — WRITE the central `nros-patch.toml` that 47 tracked leaf
+# `.cargo/config.toml` files `include`. The PRODUCER for the dependency the
+# preflight above only checks.
+#
+# Only `nros sync` wrote that file, and sync needs a WORKSPACE. A lane building
+# standalone leaves has no workspace to sync, so it got the file as a SIDE
+# EFFECT of whichever neighbouring lane ran `workspace-fixtures-build.sh` first.
+# Six lanes do (esp32, threadx-linux, native, nuttx, zephyr-ci, freertos);
+# `threadx-riscv64` does not, which is why it is the one whose leaves died at
+# manifest parse with
+#
+#   failed to load config include `../../../../../nros-patch.toml`
+#
+# while the identical config in a freertos leaf resolved. The lanes that worked
+# were working by accident.
+#
+# `nros ws central-patch` is the SAME writer `sync` calls, not a second spelling
+# of the content — the table must agree with sync's byte for byte or two leaves
+# resolve against different crates. Idempotent (skip-write when unchanged), so a
+# lane that already has the file pays one process spawn.
+[private]
+_ensure-central-patch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/build/cargo.sh
+    nros_ensure_central_patch
+
 # The codegen stage of the build verb (issue 0992).
 #
 # `colcon build` generates messages, which is why a ROS user never types a

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -67,6 +67,27 @@ pub enum Sub {
     /// `package.xml`, stale patch blocks. Mirrors the sync detection.
     Doctor(DoctorArgs),
 
+    /// Write the central `<checkout>/nros-patch.toml` and nothing else
+    /// (issue 1038).
+    ///
+    /// 47 tracked leaf `.cargo/config.toml` files reach the universal-trio
+    /// patches through one `include = ["…/nros-patch.toml"]` line, and a
+    /// missing `include` target is a HARD cargo error during MANIFEST PARSE —
+    /// four frames deep, naming neither the leaf nor `nros sync`. Until now the
+    /// only thing that wrote that file was a full `nros sync`, which needs a
+    /// workspace; a lane building only STANDALONE leaves has no workspace to
+    /// sync, so it got the file by side effect from whichever neighbouring lane
+    /// happened to build workspace fixtures first. `threadx-riscv64` is the one
+    /// lane with no such neighbour, which is why it is the one that failed.
+    ///
+    /// This is the same writer `sync` calls, not a second spelling of the
+    /// content: the patch table must agree with sync's byte for byte or the
+    /// leaves resolve against different crates.
+    ///
+    /// Hidden: a build-system seam, like `model-dims`.
+    #[command(name = "central-patch", hide = true)]
+    CentralPatch(CentralPatchArgs),
+
     /// Print the `execution.tiers` dim keys a committed SystemModel declares,
     /// one per line, sorted (issue 0380).
     ///
@@ -404,6 +425,7 @@ pub fn run(args: Args) -> Result<()> {
         Sub::Clean(a) => run_clean(a),
         Sub::Doctor(a) => run_doctor(a),
         Sub::ModelDims(a) => run_model_dims(a),
+        Sub::CentralPatch(a) => run_central_patch(a),
         Sub::CheckBoardProjections(a) => run_check_board_projections(a),
         Sub::BoardFacts(a) => crate::cmd::board_facts::run(a),
         Sub::EntityFacts(a) => crate::cmd::entity_facts::run(a),
@@ -3195,6 +3217,27 @@ fn warn_if_cargo_predates_config_include(ws_root: &Path) {
             line.trim(),
         );
     }
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct CentralPatchArgs {
+    /// nano-ros checkout to write into. Defaults to `NROS_REPO_DIR`, then cwd.
+    #[arg(long)]
+    pub nano_ros_path: Option<PathBuf>,
+}
+
+/// issue 1038 — write the central patch file, with no workspace and no codegen.
+fn run_central_patch(args: CentralPatchArgs) -> Result<()> {
+    let root = match args.nano_ros_path {
+        Some(p) => p,
+        None => match std::env::var_os("NROS_REPO_DIR") {
+            Some(v) => PathBuf::from(v),
+            None => std::env::current_dir()?,
+        },
+    };
+    let dst = write_central_patch_file(&root)?;
+    println!("{}", dst.display());
+    Ok(())
 }
 
 fn write_central_patch_file(nano_ros_path: &Path) -> Result<PathBuf> {

--- a/scripts/build/cargo.sh
+++ b/scripts/build/cargo.sh
@@ -456,3 +456,26 @@ nros_cargo_fetch_standalone_manifests() {
         fi
     done < "$list"
 }
+
+# issue 1038 — ensure the central `nros-patch.toml` exists.
+#
+# 47 tracked leaf `.cargo/config.toml` files reach the universal-trio patches
+# through `include = ["…/nros-patch.toml"]`, and a missing include target is a
+# HARD cargo error during MANIFEST PARSE — before any compilation, four frames
+# deep, naming neither the leaf nor `nros sync`.
+#
+# Only `nros sync` wrote that file, and sync needs a WORKSPACE. A lane building
+# standalone leaves has no workspace to sync, so it got the file as a SIDE
+# EFFECT of whichever neighbouring lane ran `workspace-fixtures-build.sh` first.
+# Six lanes do; `threadx-riscv64` does not, which is why its leaves were the
+# ones that failed while an identical config in a freertos leaf resolved.
+#
+# `nros ws central-patch` is the SAME writer sync calls, so the table cannot
+# drift from sync's. Idempotent — skip-write when unchanged.
+#
+# A shell function rather than a `just` recipe because `just` MODULES cannot
+# depend on a root-level recipe, and the alternative was spelling these two
+# lines once per platform module.
+nros_ensure_central_patch() {
+    NROS_REPO_DIR="${NROS_REPO_DIR:-$PWD}" "$(nros_cli_bin)" ws central-patch >/dev/null
+}


### PR DESCRIPTION
The nightly `threadx_riscv64` cell died **before compiling anything**:

```
error: failed to parse manifest at .../qemu-riscv64-threadx/rust/talker/Cargo.toml
Caused by: could not load Cargo configuration
Caused by: failed to load config include `../../../../../nros-patch.toml`
```

47 tracked leaf `.cargo/config.toml` files reach the universal-trio patches through that one `include`, and a missing include target is a hard cargo error during **manifest parse** — four frames deep, naming neither the leaf nor the thing that writes the file.

## Why only this lane

The file has exactly one writer, `write_central_patch_file`, reached from exactly one caller: `run_sync`. And `nros sync` needs a **workspace**. A lane building only *standalone* leaves has no workspace to sync, so it inherited the file as a **side effect** of whichever neighbouring lane ran `workspace-fixtures-build.sh` first.

Six lanes do that — `esp32`, `threadx-linux`, `native`, `nuttx`, `zephyr-ci`, `freertos`. `threadx-riscv64` does not. That's the whole difference, and it's why an identical config resolved in a freertos leaf and failed here. **The lanes that worked were working by accident.**

## A wrong first reproduction, recorded

`cargo metadata --manifest-path <leaf>` from the repo root **succeeds** with the file absent. Cargo discovers config from the **CWD**, not the manifest path — the failure only appears with `cd <leaf>`, which is how the build invokes it. `rc=0` vs `rc=101` on the same tree.

## Both halves

**Structural** — the dependency gets a producer. `nros ws central-patch` writes the file and nothing else: no workspace, no codegen. It calls the *same* writer sync calls rather than restating the table (two spellings = two sets of crates for leaves to resolve against); verified byte-identical to what sync had written. `nros_ensure_central_patch` in `scripts/build/cargo.sh` is the shell entry point — a function, not a `just` recipe, because `just` **modules cannot depend on a root-level recipe**.

**Narrow** — `threadx-riscv64` calls it in `build-examples` (first under `build-fixtures`, so `build-all` is covered) and again in `build-fixture-extras`, where its Rust leaves are actually built via the phase-369 cmake path and where CI died.

## Verification

Deleted `nros-patch.toml`, then ran `just threadx_riscv64 build-fixture-extras` alone: the file came back and **the lane completed, exit 0**, leaves compiled — the exact recipe that previously failed at manifest parse. Output matches sync's byte for byte.

`just check fast` 197/197, `just check cli-tests` green.

## Not claimed

The other five lanes still get the file by side effect. They work, and wiring each is a change to five modules with no failing lane to justify it — recorded in #1038 rather than done blind.

Split from #374 (the `nuttx` one-liner), which is already queued and whose branch is push-protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)