### PR TITLE
feat(phase-421 W4): a serialization format is a provider, found by package name

### DIFF
--- a/docs/design/0088-serialization-format-is-a-compile-time-provider.md
+++ b/docs/design/0088-serialization-format-is-a-compile-time-provider.md
@@ -263,12 +263,25 @@ Consumption uses the general form, so no parser learns a new attribute:
 <nano_ros_uses kind="serdes" name="flatbuf"/>
 ```
 
-and `system.toml` may set it per deploy:
+and the system config may set it per image:
 
 ```toml
-[deploy.orin-spe]
+[image.orin-spe]
 serdes = "flatbuf"
 ```
+
+**Amended 2026-09-04 from implementation (W4).** This RFC first specified
+`[deploy.<t>] serdes = "…"`, and that key cannot exist: `DeployBlock` comes from
+the upstream `ros-launch-manifest` crate (a git-tag dependency) and carries
+`deny_unknown_fields`, so an unknown key in a deploy block is a parse *error*,
+not an ignored line. Adding it would need an upstream release and a dependency
+bump. The ladder therefore mirrors `rmw`'s, minus that rung: CLI override →
+`[image.<t>]` folded over `[image_defaults]` → `[system]` → `"cdr"`, with
+`[package.metadata.nros.deploy.<t>].serdes` — the deploy block nano-ros *does*
+own — carried into the synthesized image block exactly as `rmw` already is.
+`rmw` on `[deploy.*]` is itself deprecated (`image::DEPRECATED_DEPLOY_FIELDS`,
+RFC-0065 D6 / issue 0951), so the rung this loses is one the tree is already
+retiring.
 
 A custom format that wraps a C codec is two ordinary packages: the provider, and
 a vendor package it `<depend>`s on (RFC-0087 D5).
@@ -336,6 +349,9 @@ format is decided at compile time and the description never leaves Rust.
 
 ## Changelog
 
+- 2026-09-04 — D6 amended from implementation (phase-421 W4): the per-target key
+  is `[image.<t>].serdes`, not `[deploy.<t>].serdes`. The upstream `DeployBlock`
+  denies unknown fields, so the specified key would have been a parse error.
 - 2026-09-04 — D1 amended from implementation (phase-421 W1–W3): the message's
   format is a **defaulted const on `nros_core::RosMessage`**, not an associated
   type on `nros_serdes::schema::Message` — the schema is required only under

--- a/docs/issues/1054-provider-scan-prunes-the-nano-ros-root.md
+++ b/docs/issues/1054-provider-scan-prunes-the-nano-ros-root.md
@@ -1,0 +1,80 @@
+---
+id: 1054
+title: "`provider_scan` reads `.nros-ignore` on the root it was handed, so scanning the nano-ros tree finds ZERO providers of any family — the marker's own header says it must not"
+status: open
+type: bug
+area: cli, tooling
+severity: high
+found: 2026-09-04
+related: [0621, 0809, phase-348, phase-420, phase-421]
+---
+
+# The marker prunes the tree it was written to protect
+
+`walk_packages` checks the ignore markers on every directory it pops, starting
+with the root it was given:
+
+```rust
+let mut stack = vec![root.to_path_buf()];
+while let Some(dir) = stack.pop() {
+    if IGNORE_MARKERS.iter().any(|m| dir.join(m).exists()) {
+        continue;
+    }
+```
+
+The repository root carries `.nros-ignore`. So `scan_roots(&[<nano-ros root>])`
+returns **zero packages**, and therefore zero providers — not just serdes:
+`rmw`, `board` and `platform` are pruned identically.
+
+## The contract says the opposite, in the marker file itself
+
+`.nros-ignore`'s header (issue 0621):
+
+> This marker prunes the whole tree from any walk that starts ABOVE it. It does
+> NOT affect nano-ros's own discovery: `build_pkg_index` exempts the root it was
+> given (`entry.depth() == 0` returns true before any marker is read), so when
+> nano-ros IS the workspace root this file is never consulted, and when it is
+> nested it prunes at depth 1.
+
+`nros-pkg-index` honours that. `provider_scan` does not.
+
+## How it got here
+
+Issue 0809 taught `provider_scan` the `.nros-ignore` spelling — the repo root's
+own marker had been written for `nros-pkg-index`, and `provider_scan` did not
+recognise it. The spelling was carried across; the **depth-0 exemption that
+makes the spelling safe was not**. Two walks, one marker vocabulary, two
+different meanings for the root.
+
+## Why nothing has failed yet
+
+`default_search_path` returns `[nano-ros root, user workspace]`, and every
+consumer today resolves providers through the generated compile-time tables
+(`rmw_table.rs`, and now `serdes_table.rs`), which `build.rs` produces by
+globbing descriptor paths directly rather than by scanning. The scan's answer is
+consumed for workspace discovery, where the caller passes the *workspace* root,
+not the nano-ros root. So root 0 of the search path has been contributing
+nothing, silently, since 0809.
+
+phase-421 W4's `resolve_serdes_in` is the first caller to ask the search path
+for an in-tree provider by name, which is how this surfaced.
+
+## Reproduction
+
+`cargo test -p cargo-nano-ros --lib
+serdes_resolver::tests::the_nano_ros_root_is_pruned_by_its_own_nros_ignore`
+pins the behaviour as it is today, and says in its body what changes when this
+is fixed. It passes *because* the bug exists; it is a characterization test, not
+an endorsement.
+
+## Fix
+
+Exempt depth 0 in `walk_packages`, the way `build_pkg_index` does — check the
+markers on descendants only. That is the smallest change that makes the two
+walks agree with the marker's stated contract.
+
+It changes discovery for **every** provider family, so it wants its own change
+and its own verification rather than riding a serdes wave: after the fix, a scan
+of the nano-ros root starts returning ~272 packages where it returned none, and
+every caller that passes that root needs to be checked for whether it wanted
+them. The characterization test above becomes the assertion that it does.

--- a/docs/roadmap/phase-421-serialization-format-provider.md
+++ b/docs/roadmap/phase-421-serialization-format-provider.md
@@ -1,6 +1,6 @@
 # Phase 421 — serialization format as a compile-time provider
 
-**Status (2026-09-04). W1–W3 landed; W4–W6 open.**
+**Status (2026-09-04). W1–W4 landed; W5–W6 open.**
 Implements [RFC-0088](../design/0088-serialization-format-is-a-compile-time-provider.md).
 Depends on **[phase-420](phase-420-package-identity-and-provider-format.md) W1
 only** (the `<nano_ros_uses>` general consumption tag) — and only from W4 onward;
@@ -63,15 +63,34 @@ The mechanism is compile-time, not runtime: ROS 2 uses format strings because
       `declarative_bridge_zenoh_to_{cyclonedds,xrce}` cells stay green; the
       comparison is one byte, at construction, not per sample.
 
-- [ ] **W4 — the `serdes` provider family.** One `FAMILIES` row in
+- [x] **W4 — the `serdes` provider family.** (landed 2026-09-04) One `FAMILIES` row in
       `check-provider-announcements.py`; `nros-serdes.toml` whose only field is
       `impl = "schema" | "codegen"` (absent file means `schema` and all
       defaults); `<nano_ros_provides kind="serdes" name="…"/>`; consumption via
       `<nano_ros_uses kind="serdes" name="…"/>` (phase-420 W1) and a
       `[deploy.<t>] serdes = "…"` key; `check-serdes-descriptors` covering S1–S4
       plus discriminant allocation.
-      **Acceptance:** a provider package outside the repo is selected by name and
-      reaches the build; no parser learns a new attribute to make that work.
+      **Acceptance, partly met.** A provider in the USER WORKSPACE root — a
+      directory outside this repo — is selected by name and resolves
+      (`a_provider_in_the_user_workspace_reaches_the_default_search_path`). A
+      provider at a *third* location is not reachable: `default_search_path`
+      still returns two roots, which is phase-420 W6. No parser learned a new
+      attribute, which is the half W1 of phase-420 bought.
+
+      Two findings recorded rather than worked around:
+
+      - **`[deploy.<t>].serdes` cannot exist.** `DeployBlock` is upstream
+        (`ros-launch-manifest`, git tag) with `deny_unknown_fields`, so the key
+        RFC-0088 D6 specified is a parse error, and adding it needs an upstream
+        release plus a dependency bump. The ladder mirrors `rmw`'s minus that
+        rung — and `rmw` on `[deploy.*]` is itself deprecated (issue 0951). D6 is
+        amended to match.
+      - **Issue 1054**: `provider_scan` reads `.nros-ignore` on the root it is
+        handed, so scanning the nano-ros tree returns zero providers of ANY
+        family. The marker's own header says the opposite is the contract, and
+        `nros-pkg-index` honours it. Pinned by a characterization test here;
+        the fix changes discovery for every family and belongs in its own
+        change.
 
 - [ ] **W5 — the schema-driven strategy, with a reference provider.**
       `SchemaSerializer` over the `&'static [Field]` schema codegen already

--- a/just/check.just
+++ b/just/check.just
@@ -262,6 +262,7 @@ fast-serial: \
     scope-namespace \
     sdk-guard-can-fire \
     sdk-store-not-enumerated \
+    serdes-descriptors \
     shared-cargo-dir-witness \
     single-rust-staticlib \
     site-config \
@@ -3895,6 +3896,21 @@ build-root:
 rmw-descriptors:
     @python3 scripts/check-rmw-descriptors.py
 
+# phase-421 W4 / RFC-0088 — the `serdes` provider descriptors. Catches: an
+# `impl` that is not "schema"/"codegen"; a `format_id` that is missing, not an
+# integer, or outside 1..=255; an unknown key under `[serdes]`, which lowers to
+# nothing while reading like a decision; two providers claiming one name or —
+# the wire-visible one — one `format_id`; a descriptor whose reserved
+# discriminant disagrees with `nros_serdes::format::SerializationFormatId`
+# (`cdr = 1`, `uorb = 2` are written in both places, and this is what stops them
+# diverging), in EITHER direction; and a package announcing
+# `<nano_ros_provides kind="serdes"/>` with no descriptor beside it, whose
+# symptom is otherwise a defaulted `impl` nobody chose. Runs its own selftest on
+# the normal path. Buildless: TOML plus a regex over one Rust file.
+[private]
+serdes-descriptors:
+    @python3 scripts/check-serdes-descriptors.py
+
 [private]
 fixture-groups:
     @python3 scripts/check-fixture-groups.py
@@ -4123,6 +4139,14 @@ cargo-target-spelling:
 # lowers to (its descriptor). Nothing structural keeps the two name lists equal,
 # so compare them. ONE gate for every provider family: a copy of the rule beside
 # each family's descriptors is the second-spelling antipattern (#282 -> #326).
+#
+# Catches: a descriptor with no `<nano_ros_provides>` beside it (invisible to
+# the phase-348 scan while looking migrated); a name list that disagrees with
+# the descriptor's, or is in the wrong order, for the three families whose
+# descriptors still carry `names`; and, for a family whose descriptor carries
+# none (`serdes`, RFC-0087 D4 — the announcement is the only spelling), two
+# providers announcing one name. phase-421 W4 added that fourth family as one
+# FAMILIES row, not a second script.
 [private]
 provider-announcements:
     @python3 scripts/check-provider-announcements.py

--- a/packages/cli/cargo-nano-ros/build.rs
+++ b/packages/cli/cargo-nano-ros/build.rs
@@ -22,6 +22,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
+// phase-421 W4 — the descriptor parser + the derivations, shared VERBATIM with
+// the library rather than re-implemented here. See the module's own header for
+// why it is std-only.
+include!("src/serdes_descriptor.rs");
+
 fn main() {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     // packages/cli/cargo-nano-ros -> packages
@@ -30,6 +35,8 @@ fn main() {
         .nth(2)
         .expect("cargo-nano-ros lives at packages/cli/cargo-nano-ros")
         .to_path_buf();
+    println!("cargo:rerun-if-changed=src/serdes_descriptor.rs");
+    generate_serdes_table(&packages);
     let rmw_root = packages.join("rmw");
 
     let mut descriptors: Vec<(String, Descriptor)> = Vec::new();
@@ -215,6 +222,195 @@ fn render(ds: &[(String, Descriptor)]) -> String {
             d.needs_cxx_linker,
             d.per_message_hook,
             caps = caps,
+        ));
+    }
+    out.push_str("];\n");
+    out
+}
+
+// ===========================================================================
+// phase-421 W4 — the serdes table (RFC-0088 D6)
+// ===========================================================================
+
+/// One in-tree serdes provider, as the generated table sees it.
+struct SerdesEntry {
+    names: Vec<String>,
+    crate_name: String,
+    descriptor: SerdesDescriptor,
+    descriptor_path: String,
+}
+
+/// Emit `serdes_table.rs` from `packages/*/*/nros-serdes.toml`.
+///
+/// Same shape as the RMW table above and for the same reasons — the descriptors
+/// are the source, nothing central enumerates providers, and the resolver's
+/// answers are `'static` for free. One difference, and it is the RFC-0087 D4
+/// point: **the NAMES are not in the descriptor.** They come from the sibling
+/// `package.xml`'s `<nano_ros_provides kind="serdes" …/>`, because the
+/// announcement already carries them and a second spelling drifts.
+///
+/// Same honest cost too: only IN-TREE providers are found here. An out-of-repo
+/// provider is resolved at selection time over the provider search path — see
+/// `serdes_resolver::resolve_serdes_in`.
+fn generate_serdes_table(packages: &Path) {
+    let mut entries: Vec<SerdesEntry> = Vec::new();
+
+    let mut families: Vec<PathBuf> = fs::read_dir(packages)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", packages.display()))
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    families.sort();
+    for family in families {
+        let Ok(pkgs) = fs::read_dir(&family) else {
+            continue;
+        };
+        let mut ps: Vec<PathBuf> = pkgs.flatten().map(|e| e.path()).collect();
+        ps.sort();
+        for pkg in ps {
+            let toml_path = pkg.join("nros-serdes.toml");
+            if !toml_path.is_file() {
+                continue;
+            }
+            println!("cargo:rerun-if-changed={}", toml_path.display());
+            entries.push(read_serdes_provider(&pkg, &toml_path));
+        }
+        // A new provider DIRECTORY must re-run this script, not just a changed
+        // file — same rule the RMW root gets below.
+        println!("cargo:rerun-if-changed={}", family.display());
+    }
+    println!("cargo:rerun-if-changed={}", packages.display());
+
+    if entries.is_empty() {
+        panic!(
+            "no nros-serdes.toml found under {} — refusing to generate an EMPTY \
+             serdes table, which would make every `serdes = ...` unresolvable \
+             (including the `cdr` default) while looking like a working build \
+             (phase-421 W4)",
+            packages.display()
+        );
+    }
+
+    // Two providers claiming one format name is ambiguous resolution; fail
+    // loudly rather than taking whichever sorted first.
+    let mut seen: Vec<(String, String)> = Vec::new();
+    for e in &entries {
+        for n in &e.names {
+            if let Some((_, other)) = seen.iter().find(|(name, _)| name == n) {
+                panic!(
+                    "two packages announce serdes name `{n}`: {other} and {}",
+                    e.descriptor_path
+                );
+            }
+            seen.push((n.clone(), e.descriptor_path.clone()));
+        }
+    }
+
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("serdes_table.rs");
+    fs::write(&out, render_serdes(&entries)).expect("write serdes_table.rs");
+}
+
+/// Read one provider: the announcement (names), the manifest (crate) and the
+/// descriptor (the two non-derivable fields).
+fn read_serdes_provider(pkg: &Path, toml_path: &Path) -> SerdesEntry {
+    let origin = toml_path.display().to_string();
+
+    let manifest = pkg.join("package.xml");
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    let xml = fs::read_to_string(&manifest).unwrap_or_else(|e| {
+        panic!(
+            "{origin} has no readable sibling package.xml ({}): {e} — a descriptor \
+             is read only for the provider that was SELECTED, and selection goes \
+             through the <nano_ros_provides kind=\"serdes\"/> announcement, so a \
+             descriptor with no announcement can never be reached (RFC-0087 D4)",
+            manifest.display()
+        )
+    });
+    let names = package_xml_provides(&xml, "serdes");
+    if names.is_empty() {
+        panic!(
+            "{} announces no <nano_ros_provides kind=\"serdes\" name=\"…\"/>, but \
+             {origin} exists beside it — the descriptor carries no `names` on \
+             purpose (RFC-0087 D4), so nothing could resolve to this provider",
+            manifest.display()
+        );
+    }
+
+    let cargo_toml = pkg.join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", cargo_toml.display());
+    let crate_name = fs::read_to_string(&cargo_toml)
+        .ok()
+        .as_deref()
+        .and_then(cargo_package_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "{}: no [package] name — the serdes `crate` is DERIVED from the \
+                 sibling Cargo.toml and there is nothing to derive it from",
+                cargo_toml.display()
+            )
+        });
+
+    let text = fs::read_to_string(toml_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", toml_path.display()));
+    let descriptor = parse_serdes_descriptor(&text, &origin).unwrap_or_else(|e| panic!("{e}"));
+
+    SerdesEntry {
+        names,
+        crate_name,
+        descriptor,
+        descriptor_path: origin,
+    }
+}
+
+fn render_serdes(entries: &[SerdesEntry]) -> String {
+    let mut out = String::from(
+        "// @generated by build.rs from packages/*/*/nros-serdes.toml plus each\n\
+         // provider's <nano_ros_provides kind=\"serdes\"/> — DO NOT EDIT.\n\
+         // phase-421 W4: the announcement is the source of the NAMES, the\n\
+         // descriptor of what cannot be derived, and everything else is derived.\n\n",
+    );
+    out.push_str(
+        "pub(crate) struct SerdesRow {\n    \
+         pub declared: &'static str,\n    \
+         pub names: &'static [&'static str],\n    \
+         pub crate_name: &'static str,\n    \
+         pub cargo_feature: &'static str,\n    \
+         pub cmake_value: &'static str,\n    \
+         pub c_define_token: &'static str,\n    \
+         pub impl_strategy: &'static str,\n    \
+         pub format_id: Option<u8>,\n\
+         }\n\n",
+    );
+    out.push_str("pub(crate) static SERDES_ROWS: &[SerdesRow] = &[\n");
+    for e in entries {
+        let declared = &e.names[0];
+        let names = e
+            .names
+            .iter()
+            .map(|n| format!("{n:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let format_id = match e.descriptor.format_id {
+            Some(id) => format!("Some({id})"),
+            None => "None".to_string(),
+        };
+        out.push_str(&format!(
+            "    SerdesRow {{\n        \
+             declared: {:?},\n        \
+             names: &[{names}],\n        \
+             crate_name: {:?},\n        \
+             cargo_feature: {:?},\n        \
+             cmake_value: {:?},\n        \
+             c_define_token: {:?},\n        \
+             impl_strategy: {:?},\n        \
+             format_id: {format_id},\n    \
+             }},\n",
+            declared,
+            e.crate_name,
+            serdes_cargo_feature(declared),
+            serdes_cmake_value(declared),
+            serdes_c_define_token(declared),
+            e.descriptor.impl_strategy,
         ));
     }
     out.push_str("];\n");

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -50,6 +50,16 @@ pub mod package_xml;
 pub mod provider_scan;
 pub mod rmw_resolver;
 pub mod scaffold;
+/// The `nros-serdes.toml` descriptor and the derivations that make it almost
+/// empty (phase-421 W4, RFC-0088 D6 / RFC-0087 D4).
+///
+/// `include!`d by `build.rs` as well as compiled here, so that the table in
+/// `OUT_DIR` and the out-of-repo selection path share ONE parser. Its own file
+/// header carries the rest of the rationale — as plain `//` comments rather
+/// than `//!`, because an inner doc comment cannot appear mid-file in the
+/// build script that includes it.
+pub mod serdes_descriptor;
+pub mod serdes_resolver;
 pub mod workflow;
 pub mod workspace_scaffold;
 

--- a/packages/cli/cargo-nano-ros/src/serdes_descriptor.rs
+++ b/packages/cli/cargo-nano-ros/src/serdes_descriptor.rs
@@ -1,0 +1,233 @@
+// phase-421 W4 — the `nros-serdes.toml` descriptor, and the derivations that
+// mean it carries almost nothing (RFC-0088 D6, RFC-0087 D4).
+//
+// **This module is `include!`d by `build.rs`** as well as compiled into the
+// library, so it is deliberately std-only: `build.rs` may not use `toml` or
+// `quick-xml`, which are ordinary dependencies rather than build-dependencies,
+// and adding a build-dependency would move `Cargo.lock`.
+//
+// One parser, two callers, on purpose. The table in `OUT_DIR` is generated at
+// build time (in-tree providers) while an out-of-repo provider's descriptor is
+// read at selection time (`serdes_resolver::resolve_serdes_in`); two parsers
+// for one file format is the drift class this repo keeps paying for
+// (the sizes-header mirror, the FFI struct mirrors, the parity map).
+//
+// The `package.xml` reader below is the one exception, and it is the SMALL
+// half: `build.rs` needs the `<nano_ros_provides kind="serdes"/>` names and
+// cannot reach [`crate::package_xml::PackageXml`]'s quick-xml parser. It is
+// cross-checked against the real parser by
+// `serdes_resolver::tests::generated_names_match_the_real_package_xml_parser`,
+// because two readers of one file that nobody compares is how the RMW parity
+// map came to disagree with the vtable by 25 symbols.
+
+/// What a provider's `nros-serdes.toml` says that no convention can produce.
+///
+/// Everything else about a serdes provider is DERIVED (RFC-0087 D4): the name
+/// from the `package.xml` announcement, the crate from the sibling
+/// `Cargo.toml`, and the cargo feature / cmake value / C token from the name.
+/// A second spelling of a derivable fact drifts, so the descriptor does not
+/// offer one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerdesDescriptor {
+    /// `"schema"` | `"codegen"` — how the serializer is produced (RFC-0088 D7).
+    /// Not derivable: a property of the implementation, not of the name.
+    pub impl_strategy: String,
+    /// Image-local `u8` discriminant (RFC-0088 D2). `None` means the provider
+    /// states none and the build assigns one from the set of formats its image
+    /// declares — **the NAME is the cross-image identity, never this number.**
+    pub format_id: Option<u8>,
+}
+
+/// The strategy a provider gets when it ships no descriptor at all.
+///
+/// RFC-0088 D7: schema-driven is the default, because it costs a provider no
+/// codegen work. `nros-serdes` itself declares `codegen` precisely because CDR
+/// is the exception.
+pub const DEFAULT_SERDES_IMPL: &str = "schema";
+
+/// The serialization format a build gets when nothing declares one.
+///
+/// RFC-0088: a build that declares no format must behave exactly as it does
+/// today, and today is CDR everywhere.
+pub const DEFAULT_SERDES_NAME: &str = "cdr";
+
+/// The strategies [`SerdesDescriptor::impl_strategy`] may name.
+pub const SERDES_IMPL_STRATEGIES: &[&str] = &["schema", "codegen"];
+
+/// The cargo feature a serdes name lowers to — `serdes-<name>`.
+#[must_use]
+pub fn serdes_cargo_feature(name: &str) -> String {
+    format!("serdes-{name}")
+}
+
+/// The `-DNANO_ROS_SERDES` cmake value — the canonical name, verbatim.
+///
+/// A function rather than the caller writing `name.to_string()` so the
+/// derivation has ONE site: the RMW descriptor authored `cmake_value` by hand
+/// and it is `zenoh` for `zenoh` in every row, which is a field that only ever
+/// restates its key.
+#[must_use]
+pub fn serdes_cmake_value(name: &str) -> String {
+    name.to_string()
+}
+
+/// The C `#define` token — `UPPER(name)`.
+///
+/// `-` becomes `_` because a hyphen cannot appear in a preprocessor identifier
+/// and a provider named `flat-buf` is legal (the announcement's `name=` is an
+/// open vocabulary; see [`crate::package_xml::Provision`]).
+#[must_use]
+pub fn serdes_c_define_token(name: &str) -> String {
+    name.to_uppercase().replace(['-', '.'], "_")
+}
+
+/// Parse an `nros-serdes.toml`.
+///
+/// Line-oriented, matching `build.rs`'s existing `nros-rmw.toml` reader and
+/// `NanoRosCapabilities.cmake`'s `file(STRINGS … REGEX …)` — the descriptor
+/// shape is flat `key = value` under one table, and it is ours.
+///
+/// Errors rather than defaulting on a value it does not understand: a typo'd
+/// `impl = "codgen"` that silently became `schema` would produce a working
+/// build with the wrong serializer.
+pub fn parse_serdes_descriptor(text: &str, origin: &str) -> Result<SerdesDescriptor, String> {
+    let mut section = String::new();
+    let mut impl_strategy: Option<String> = None;
+    let mut format_id: Option<u8> = None;
+
+    for raw in text.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            section = name.to_string();
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let (key, value) = (key.trim(), value.trim());
+        match (section.as_str(), key) {
+            ("serdes", "impl") => impl_strategy = Some(value.trim_matches('"').to_string()),
+            ("serdes", "format_id") => {
+                let parsed = value.trim_matches('"').parse::<u8>().map_err(|e| {
+                    format!("{origin}: [serdes].format_id = {value} is not a u8 ({e})")
+                })?;
+                if parsed == 0 {
+                    return Err(format!(
+                        "{origin}: [serdes].format_id = 0 is reserved for \"no format\" — \
+                         in-tree formats hold low values from 1 (RFC-0088 D2)"
+                    ));
+                }
+                format_id = Some(parsed);
+            }
+            _ => {}
+        }
+    }
+
+    let impl_strategy = impl_strategy.unwrap_or_else(|| DEFAULT_SERDES_IMPL.to_string());
+    if !SERDES_IMPL_STRATEGIES.contains(&impl_strategy.as_str()) {
+        return Err(format!(
+            "{origin}: [serdes].impl = {impl_strategy:?} is not a strategy (known: {})",
+            SERDES_IMPL_STRATEGIES.join(", ")
+        ));
+    }
+
+    Ok(SerdesDescriptor {
+        impl_strategy,
+        format_id,
+    })
+}
+
+/// The `[package] name` of a `Cargo.toml`, for the `crate` derivation.
+///
+/// Std-only for the same reason as the descriptor parser. Only the `[package]`
+/// table is consulted, so a `name =` under `[dependencies.…]` cannot be
+/// mistaken for the crate's own.
+#[must_use]
+pub fn cargo_package_name(text: &str) -> Option<String> {
+    let mut in_package = false;
+    for raw in text.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if let Some(section) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            in_package = section == "package";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=')
+            && key.trim() == "name"
+        {
+            return Some(value.trim().trim_matches('"').to_string());
+        }
+    }
+    None
+}
+
+/// The `name=`s of every `<nano_ros_provides kind="<kind>" …/>` in a
+/// `package.xml`, in declaration order.
+///
+/// The `build.rs` half of the "two readers of one file" note at the top of this
+/// module. Comments are stripped first, because a commented-out announcement is
+/// not an announcement — `package_xml::tests::commented_out_provision_is_ignored`
+/// asserts exactly that of the real parser, and a second reader that disagreed
+/// would announce a name no scan can find.
+#[must_use]
+pub fn package_xml_provides(text: &str, kind: &str) -> Vec<String> {
+    let stripped = strip_xml_comments(text);
+    let mut out = Vec::new();
+    let mut rest = stripped.as_str();
+    while let Some(at) = rest.find("<nano_ros_provides") {
+        rest = &rest[at + "<nano_ros_provides".len()..];
+        let Some(end) = rest.find('>') else { break };
+        let (tag, after) = rest.split_at(end);
+        rest = after;
+        if xml_attr(tag, "kind").as_deref() == Some(kind)
+            && let Some(name) = xml_attr(tag, "name")
+            && !name.is_empty()
+        {
+            out.push(name);
+        }
+    }
+    out
+}
+
+fn strip_xml_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find("<!--") {
+        out.push_str(&rest[..at]);
+        match rest[at..].find("-->") {
+            Some(end) => rest = &rest[at + end + 3..],
+            // Unterminated comment: everything after it is commented out.
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn xml_attr(tag: &str, attr: &str) -> Option<String> {
+    let mut rest = tag;
+    while let Some(at) = rest.find(attr) {
+        let before_ok = at == 0
+            || rest[..at]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+        let after = &rest[at + attr.len()..];
+        let after_trimmed = after.trim_start();
+        if before_ok && let Some(v) = after_trimmed.strip_prefix('=') {
+            let v = v.trim_start();
+            let quote = v.chars().next()?;
+            if quote == '"' || quote == '\'' {
+                let body = &v[1..];
+                return body.find(quote).map(|e| body[..e].to_string());
+            }
+        }
+        rest = &rest[at + attr.len()..];
+    }
+    None
+}

--- a/packages/cli/cargo-nano-ros/src/serdes_resolver.rs
+++ b/packages/cli/cargo-nano-ros/src/serdes_resolver.rs
@@ -1,0 +1,817 @@
+//! Serialization-format selection lowering — phase-421 W4, RFC-0088 D6.
+//!
+//! The sibling of [`crate::rmw_resolver`], and deliberately its shape: a
+//! declared name is validated and **lowered** to each language's build
+//! mechanism — a cargo feature, a CMake value, a C `#define` token — and an
+//! unknown name is an error that lists what IS available.
+//!
+//! Two differences from the RMW resolver, both consequences of RFC-0087 D4 and
+//! RFC-0088 D6:
+//!
+//! * **The names live in the announcement, not the descriptor.** A provider
+//!   says `<nano_ros_provides kind="serdes" name="cdr"/>` in its `package.xml`;
+//!   `nros-serdes.toml` carries only `impl` and `format_id`, the two facts no
+//!   convention can produce. Everything else is derived — see
+//!   [`crate::serdes_descriptor`].
+//! * **There is an out-of-repo path.** [`resolve_serdes`] answers from the
+//!   generated in-tree table (no I/O, `'static`); [`resolve_serdes_in`] answers
+//!   from a provider scan over the search path, which is what makes a provider
+//!   package living outside this repo selectable by name.
+//!
+//! The default is `cdr` ([`DEFAULT_SERDES_NAME`]): a build that declares no
+//! format behaves exactly as it does today.
+
+use std::{fmt, path::PathBuf};
+
+use crate::{
+    package_xml::PackageXml,
+    provider_scan::{ResolveError, ScanResult, resolve_unique},
+    serdes_descriptor::{
+        DEFAULT_SERDES_NAME, cargo_package_name, parse_serdes_descriptor, serdes_c_define_token,
+        serdes_cargo_feature, serdes_cmake_value,
+    },
+};
+
+include!(concat!(env!("OUT_DIR"), "/serdes_table.rs"));
+
+/// The provider family name — the `kind=` of the announcement and the `<kind>`
+/// of `nros-<kind>.toml`. One constant so the string is not retyped at each of
+/// the three sites that must agree.
+pub const SERDES_KIND: &str = "serdes";
+
+/// The serialization formats THIS CHECKOUT provides, derived from the in-tree
+/// descriptors plus their announcements.
+///
+/// Not the whole answer: a provider in the user's workspace or anywhere else on
+/// the search path is found by [`resolve_serdes_in`] and does not appear here.
+/// This is "what nano-ros ships", used for the default and for error text when
+/// no scan is available.
+#[must_use]
+pub fn known_serdes() -> Vec<&'static str> {
+    SERDES_ROWS.iter().map(|r| r.declared).collect()
+}
+
+/// A declared serdes value lowered to its per-language build forms.
+///
+/// Owned `String`s rather than `&'static str` (the RMW resolver's choice)
+/// because an out-of-repo provider's name is read from a file at selection
+/// time and cannot be `'static`. The RMW resolver could stay `'static` only
+/// because it has no out-of-tree path at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSerdes {
+    /// The canonical declared name, e.g. `"cdr"`.
+    pub declared: String,
+    /// The crate that implements it — DERIVED from the provider's `Cargo.toml`.
+    pub crate_name: String,
+    /// The cargo feature the selection lowers to, `serdes-<name>`.
+    pub cargo_feature: String,
+    /// The `-DNANO_ROS_SERDES` CMake value — the canonical name.
+    pub cmake_value: String,
+    /// The `#define NROS_SERIALIZATION_FORMAT_<TOKEN>` token, `UPPER(name)`.
+    pub c_define_token: String,
+    /// `"schema"` | `"codegen"` (RFC-0088 D7). From the descriptor.
+    pub impl_strategy: String,
+    /// The image-local `u8` discriminant, when the provider states one
+    /// (RFC-0088 D2). `None` ⇒ the build assigns it from the set of formats the
+    /// image declares. **Never an identity across images** — the name is.
+    pub format_id: Option<u8>,
+    /// Where the provider package was found. `None` for a row that came from
+    /// the compiled-in table, which records no path.
+    pub package_dir: Option<PathBuf>,
+}
+
+/// A declared serdes value no provider claims.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownSerdes {
+    pub declared: String,
+    /// The names that ARE claimed, sorted — an unknown name is usually a typo,
+    /// and the list is the fix.
+    pub available: Vec<String>,
+}
+
+impl fmt::Display for UnknownSerdes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown serdes `{}`", self.declared)?;
+        if self.available.is_empty() {
+            write!(f, " — no serdes providers were discovered at all")
+        } else {
+            write!(f, " (known: {})", self.available.join(", "))
+        }
+    }
+}
+
+impl std::error::Error for UnknownSerdes {}
+
+/// Why a search-path resolution did not produce exactly one provider.
+#[derive(Debug)]
+pub enum SerdesResolveError {
+    /// The scan claims no such name, or two packages in one root claim it.
+    Scan(ResolveError),
+    /// The provider was found but could not be lowered — an unreadable or
+    /// malformed descriptor, or a missing `Cargo.toml` to derive the crate
+    /// from. A provider that cannot be lowered is not a provider.
+    Provider { dir: PathBuf, message: String },
+}
+
+impl fmt::Display for SerdesResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SerdesResolveError::Scan(e) => write!(f, "{e}"),
+            SerdesResolveError::Provider { dir, message } => {
+                write!(f, "serdes provider at {}: {message}", dir.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for SerdesResolveError {}
+
+/// The canonical serdes name from any announced spelling. `None` for unknown.
+#[must_use]
+pub fn canonical_serdes(input: &str) -> Option<&'static str> {
+    SERDES_ROWS
+        .iter()
+        .find(|r| r.names.contains(&input))
+        .map(|r| r.declared)
+}
+
+/// Lower a declared serdes string against the IN-TREE table.
+///
+/// The no-I/O answer, for callers with no provider scan in hand. An out-of-repo
+/// provider is invisible here by construction — use [`resolve_serdes_in`].
+pub fn resolve_serdes(declared: &str) -> Result<ResolvedSerdes, UnknownSerdes> {
+    SERDES_ROWS
+        .iter()
+        .find(|r| r.names.contains(&declared))
+        .map(|r| ResolvedSerdes {
+            declared: r.declared.to_string(),
+            crate_name: r.crate_name.to_string(),
+            cargo_feature: r.cargo_feature.to_string(),
+            cmake_value: r.cmake_value.to_string(),
+            c_define_token: r.c_define_token.to_string(),
+            impl_strategy: r.impl_strategy.to_string(),
+            format_id: r.format_id,
+            package_dir: None,
+        })
+        .ok_or_else(|| UnknownSerdes {
+            declared: declared.to_string(),
+            available: known_serdes().iter().map(|s| (*s).to_string()).collect(),
+        })
+}
+
+/// Lower a declared serdes string against a PROVIDER SCAN.
+///
+/// This is the path RFC-0088 D6 is about: the scan walks the search path, and
+/// the nano-ros tree is simply its first root, so an in-tree provider and one
+/// in the user's workspace — or any other root a caller puts on the path — are
+/// found by the same code. A later root overlays an earlier one
+/// ([`resolve_unique`]), so a user's `cdr` shadows ours rather than colliding
+/// with it.
+///
+/// The descriptor is read HERE and only here: the scan reads `package.xml`
+/// alone, so one cheap parse per package and one detailed parse per build.
+/// A provider with no `nros-serdes.toml` at all is legal and gets every default
+/// (RFC-0088 D6: "optional; absent means every default applies").
+pub fn resolve_serdes_in(
+    scan: &ScanResult,
+    declared: &str,
+) -> Result<ResolvedSerdes, SerdesResolveError> {
+    let resolution =
+        resolve_unique(scan, SERDES_KIND, declared).map_err(SerdesResolveError::Scan)?;
+    let pkg = resolution.winner;
+
+    // The CANONICAL name is the provider's first `serdes` announcement, not the
+    // string the consumer typed: a provider announcing `cdr` and `ros-cdr` has
+    // one canonical spelling, and the lowering must not depend on which alias
+    // the consumer reached it by.
+    let canonical = pkg
+        .provides
+        .iter()
+        .find(|p| p.kind == SERDES_KIND)
+        .map(|p| p.name.clone())
+        .ok_or_else(|| SerdesResolveError::Provider {
+            dir: pkg.dir.clone(),
+            message: "resolved as a serdes provider but announces no serdes provision".to_string(),
+        })?;
+
+    let fail = |message: String| SerdesResolveError::Provider {
+        dir: pkg.dir.clone(),
+        message,
+    };
+
+    let descriptor_path = pkg.descriptor_path(SERDES_KIND);
+    let descriptor = if descriptor_path.is_file() {
+        let text = std::fs::read_to_string(&descriptor_path)
+            .map_err(|e| fail(format!("read {}: {e}", descriptor_path.display())))?;
+        parse_serdes_descriptor(&text, &descriptor_path.display().to_string()).map_err(fail)?
+    } else {
+        // RFC-0088 D6 — a provider with nothing non-derivable to say needs no
+        // descriptor. `impl` defaults to `schema`, `format_id` to unassigned.
+        parse_serdes_descriptor("", &descriptor_path.display().to_string())
+            .expect("the empty descriptor is the default descriptor")
+    };
+
+    let manifest = pkg.dir.join("Cargo.toml");
+    let crate_name = std::fs::read_to_string(&manifest)
+        .map_err(|e| {
+            fail(format!(
+                "read {}: {e} — the serdes `crate` is DERIVED from the provider's \
+                 Cargo.toml (RFC-0087 D4), so a provider without one cannot be linked",
+                manifest.display()
+            ))
+        })
+        .and_then(|text| {
+            cargo_package_name(&text)
+                .ok_or_else(|| fail(format!("{}: no [package] name", manifest.display())))
+        })?;
+
+    Ok(ResolvedSerdes {
+        cargo_feature: serdes_cargo_feature(&canonical),
+        cmake_value: serdes_cmake_value(&canonical),
+        c_define_token: serdes_c_define_token(&canonical),
+        declared: canonical,
+        crate_name,
+        impl_strategy: descriptor.impl_strategy,
+        format_id: descriptor.format_id,
+        package_dir: Some(pkg.dir),
+    })
+}
+
+/// The serdes a package declares FOR ITSELF, from
+/// `<nano_ros_uses kind="serdes" name="…"/>` (phase-420 W1).
+///
+/// The first one wins if a package writes several: ROS 2's semantic is one
+/// image, one encoding (RFC-0088), so several selections is an authoring error
+/// rather than a set — and it is [`crate::rmw_resolver`]'s situation exactly,
+/// where no package declares two backends either.
+#[must_use]
+pub fn package_declared_serdes(pkg: &PackageXml) -> Option<&str> {
+    pkg.uses_of_kind(SERDES_KIND)
+        .next()
+        .map(|u| u.name.as_str())
+}
+
+/// The declared serdes name for one package in one system, or the default.
+///
+/// **The ladder, and where it comes from.** `rmw`'s is `--rmw`, then
+/// `[image.<t>]`, then the deprecated `[deploy.<t>]`, then `[system]`, then a
+/// built-in default (`SystemToml::resolved_rmw`). This mirrors it, with the
+/// package's own `<nano_ros_uses>` between the CLI flag and the system answer:
+///
+/// 1. an explicit CLI override;
+/// 2. the package's own `<nano_ros_uses kind="serdes"/>`;
+/// 3. the system-level answer (`SystemToml::resolved_serdes`, which is itself
+///    image > deploy > system);
+/// 4. [`DEFAULT_SERDES_NAME`].
+///
+/// Rung 2 sits above rung 3 on the same principle that puts `[image.<t>]` above
+/// `[system]` in the RMW ladder: the more specific declaration wins. RFC-0088
+/// orders neither against the other, so this states the choice rather than
+/// leaving it to whichever caller asks first.
+#[must_use]
+pub fn declared_serdes(
+    cli: Option<&str>,
+    package: Option<&PackageXml>,
+    system: Option<&str>,
+) -> String {
+    cli.map(str::to_string)
+        .or_else(|| {
+            package
+                .and_then(package_declared_serdes)
+                .map(str::to_string)
+        })
+        .or_else(|| system.map(str::to_string))
+        .unwrap_or_else(|| DEFAULT_SERDES_NAME.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_scan::{default_search_path, scan_roots};
+    use std::{fs, path::Path};
+
+    fn repo_root() -> PathBuf {
+        // CARGO_MANIFEST_DIR = packages/cli/cargo-nano-ros
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .canonicalize()
+            .expect("the repo root is reachable from the manifest dir")
+    }
+
+    #[test]
+    fn cdr_is_in_the_table_and_lowers_to_each_language() {
+        let r = resolve_serdes("cdr").expect("cdr is provided in-tree");
+        assert_eq!(r.declared, "cdr");
+        assert_eq!(r.cargo_feature, "serdes-cdr");
+        assert_eq!(r.cmake_value, "cdr");
+        assert_eq!(r.c_define_token, "CDR");
+        assert_eq!(r.crate_name, "nros-serdes");
+        // Non-derivable, so they come from the descriptor and nowhere else.
+        assert_eq!(r.impl_strategy, "codegen");
+        assert_eq!(r.format_id, Some(1));
+    }
+
+    #[test]
+    fn the_default_is_cdr_and_it_resolves() {
+        assert_eq!(DEFAULT_SERDES_NAME, "cdr");
+        assert!(
+            resolve_serdes(DEFAULT_SERDES_NAME).is_ok(),
+            "a build that declares nothing must still resolve"
+        );
+    }
+
+    #[test]
+    fn every_known_serdes_resolves() {
+        let known = known_serdes();
+        assert!(
+            !known.is_empty(),
+            "the generated table is empty — build.rs must refuse that"
+        );
+        for name in known {
+            assert!(resolve_serdes(name).is_ok(), "{name} should resolve");
+        }
+    }
+
+    #[test]
+    fn unknown_serdes_is_rejected_and_names_what_is_available() {
+        let err = resolve_serdes("flatbuf").expect_err("flatbuf is not in-tree");
+        assert_eq!(err.declared, "flatbuf");
+        let msg = err.to_string();
+        assert!(msg.contains("flatbuf"), "{msg}");
+        assert!(
+            msg.contains("cdr"),
+            "the error must list what IS known: {msg}"
+        );
+    }
+
+    #[test]
+    fn every_lowering_is_derived_from_the_name() {
+        for name in known_serdes() {
+            let r = resolve_serdes(name).unwrap();
+            assert_eq!(r.cargo_feature, format!("serdes-{name}"));
+            assert_eq!(r.cmake_value, name);
+            assert_eq!(r.c_define_token, name.to_uppercase());
+        }
+    }
+
+    /// The two readers of `package.xml` must agree.
+    ///
+    /// `build.rs` cannot reach [`PackageXml`]'s quick-xml parser, so
+    /// [`crate::serdes_descriptor::package_xml_provides`] is a second, smaller
+    /// reader. Two readers of one file that nobody compares is how the RMW
+    /// parity map came to disagree with the vtable by 25 symbols, so they are
+    /// compared here, against the real tree.
+    #[test]
+    fn generated_names_match_the_real_package_xml_parser() {
+        let root = repo_root();
+        let mut checked = 0;
+        for row in SERDES_ROWS {
+            // Find the provider by crate name under packages/*/*.
+            let mut found = None;
+            for family in fs::read_dir(root.join("packages")).expect("packages/ is readable") {
+                let family = family.expect("readable entry").path();
+                let Ok(pkgs) = fs::read_dir(&family) else {
+                    continue;
+                };
+                for pkg in pkgs.flatten() {
+                    let dir = pkg.path();
+                    if dir.join("nros-serdes.toml").is_file() && dir.join("package.xml").is_file() {
+                        let parsed = PackageXml::parse(&dir.join("package.xml"))
+                            .expect("an in-tree provider's package.xml parses");
+                        let names: Vec<String> = parsed
+                            .provides_of_kind(SERDES_KIND)
+                            .map(|p| p.name.clone())
+                            .collect();
+                        if names.first().map(String::as_str) == Some(row.declared) {
+                            found = Some(names);
+                        }
+                    }
+                }
+            }
+            let names = found.unwrap_or_else(|| {
+                panic!(
+                    "the generated table claims serdes `{}` but no in-tree package.xml \
+                     announces it — the two package.xml readers disagree",
+                    row.declared
+                )
+            });
+            assert_eq!(
+                names,
+                row.names
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect::<Vec<_>>(),
+                "generated names for `{}` differ from the quick-xml parser's",
+                row.declared
+            );
+            checked += 1;
+        }
+        assert!(checked > 0, "no rows were cross-checked");
+    }
+
+    #[test]
+    fn canonical_serdes_maps_every_announced_spelling_to_one_name() {
+        assert_eq!(canonical_serdes("cdr"), Some("cdr"));
+        assert_eq!(canonical_serdes("CDR"), None, "names are not case-folded");
+        assert_eq!(canonical_serdes("flatbuf"), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // The shared descriptor parser — `build.rs` depends on exactly this code
+    // -----------------------------------------------------------------------
+
+    use crate::serdes_descriptor::{
+        DEFAULT_SERDES_IMPL, package_xml_provides, serdes_c_define_token,
+    };
+
+    #[test]
+    fn an_empty_descriptor_is_the_default_descriptor() {
+        let d = parse_serdes_descriptor("", "test").expect("empty parses");
+        assert_eq!(d.impl_strategy, DEFAULT_SERDES_IMPL);
+        assert_eq!(d.format_id, None);
+    }
+
+    #[test]
+    fn the_shipped_cdr_descriptor_parses_to_what_the_table_says() {
+        let text =
+            std::fs::read_to_string(repo_root().join("packages/core/nros-serdes/nros-serdes.toml"))
+                .expect("the in-tree descriptor is readable");
+        let d = parse_serdes_descriptor(&text, "nros-serdes.toml").expect("parses");
+        assert_eq!(d.impl_strategy, "codegen");
+        assert_eq!(d.format_id, Some(1));
+    }
+
+    #[test]
+    fn format_id_zero_is_rejected() {
+        // RFC-0088 D2 — in-tree formats hold low values FROM 1, and 0 is the
+        // "no format" hole a `#[repr(u8)]` enum leaves. Accepting it would let
+        // an image assign a discriminant that means "absent" elsewhere.
+        let err = parse_serdes_descriptor("[serdes]\nformat_id = 0\n", "t")
+            .expect_err("0 must be rejected");
+        assert!(err.contains("format_id"), "{err}");
+    }
+
+    #[test]
+    fn a_non_numeric_format_id_is_an_error() {
+        let err =
+            parse_serdes_descriptor("[serdes]\nformat_id = \"one\"\n", "t").expect_err("not a u8");
+        assert!(err.contains("u8"), "{err}");
+    }
+
+    #[test]
+    fn keys_outside_the_serdes_table_are_not_read() {
+        let d = parse_serdes_descriptor("[other]\nimpl = \"codegen\"\n", "t").expect("parses");
+        assert_eq!(
+            d.impl_strategy, DEFAULT_SERDES_IMPL,
+            "a key under the wrong table must not decide the strategy"
+        );
+    }
+
+    #[test]
+    fn cargo_package_name_reads_only_the_package_table() {
+        let manifest = "[package]\nname = \"the-crate\"\n\n\
+                        [dependencies.serde]\nname = \"not-this\"\n";
+        assert_eq!(cargo_package_name(manifest).as_deref(), Some("the-crate"));
+        assert_eq!(cargo_package_name("[dependencies]\nname = \"x\"\n"), None);
+    }
+
+    #[test]
+    fn the_build_script_xml_reader_ignores_commented_out_announcements() {
+        // The real parser asserts this too
+        // (`package_xml::tests::commented_out_provision_is_ignored`); the two
+        // must agree, which is the point of the cross-check test above.
+        let xml = r#"<export>
+  <!-- <nano_ros_provides kind="serdes" name="ghost"/> -->
+  <nano_ros_provides kind="serdes" name="real"/>
+  <nano_ros_provides kind="rmw" name="zenoh"/>
+</export>"#;
+        assert_eq!(
+            package_xml_provides(xml, "serdes"),
+            vec!["real".to_string()]
+        );
+        assert_eq!(package_xml_provides(xml, "rmw"), vec!["zenoh".to_string()]);
+        assert!(package_xml_provides(xml, "board").is_empty());
+    }
+
+    #[test]
+    fn the_c_token_survives_a_hyphenated_name() {
+        // `name=` is an open vocabulary, and a hyphen cannot appear in a
+        // preprocessor identifier.
+        assert_eq!(serdes_c_define_token("flat-buf"), "FLAT_BUF");
+    }
+
+    // -----------------------------------------------------------------------
+    // Search-path resolution — the RFC-0088 D6 acceptance
+    // -----------------------------------------------------------------------
+
+    /// Write a provider package into `dir`. `descriptor` of `None` exercises
+    /// "absent means every default applies".
+    fn write_provider(dir: &Path, pkg_name: &str, serdes_name: &str, descriptor: Option<&str>) {
+        fs::create_dir_all(dir).expect("create provider dir");
+        fs::write(
+            dir.join("package.xml"),
+            format!(
+                r#"<?xml version="1.0"?>
+<package format="3">
+  <name>{pkg_name}</name>
+  <version>0.0.0</version>
+  <description>test serdes provider</description>
+  <maintainer email="d@example.com">D</maintainer>
+  <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+    <nano_ros_provides kind="serdes" name="{serdes_name}"/>
+  </export>
+</package>
+"#
+            ),
+        )
+        .expect("write package.xml");
+        fs::write(
+            dir.join("Cargo.toml"),
+            format!("[package]\nname = \"{pkg_name}\"\nversion = \"0.0.0\"\nedition = \"2021\"\n"),
+        )
+        .expect("write Cargo.toml");
+        if let Some(d) = descriptor {
+            fs::write(dir.join("nros-serdes.toml"), d).expect("write descriptor");
+        }
+    }
+
+    #[test]
+    fn a_provider_outside_the_repo_is_selected_by_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("vendor_ws");
+        write_provider(
+            &root.join("flatbuf_serdes"),
+            "flatbuf-serdes",
+            "flatbuf",
+            Some("[serdes]\nimpl = \"schema\"\nformat_id = 7\n"),
+        );
+
+        // A root that is NOT the nano-ros tree — this is the whole point.
+        let scan = scan_roots(std::slice::from_ref(&root)).expect("scan the vendor root");
+        assert!(
+            scan.errors.is_empty(),
+            "scan reported errors: {:?}",
+            scan.errors
+        );
+
+        let r = resolve_serdes_in(&scan, "flatbuf").expect("the out-of-repo provider resolves");
+        assert_eq!(r.declared, "flatbuf");
+        assert_eq!(r.crate_name, "flatbuf-serdes");
+        assert_eq!(r.cargo_feature, "serdes-flatbuf");
+        assert_eq!(r.cmake_value, "flatbuf");
+        assert_eq!(r.c_define_token, "FLATBUF");
+        assert_eq!(r.impl_strategy, "schema");
+        assert_eq!(r.format_id, Some(7));
+        assert_eq!(
+            r.package_dir.as_deref(),
+            Some(root.join("flatbuf_serdes").as_path())
+        );
+
+        // And it is invisible to the in-tree table, which is the honest cost of
+        // a compile-time table (the same one `rmw_resolver` documents).
+        assert!(resolve_serdes("flatbuf").is_err());
+    }
+
+    /// The acceptance case, through the SHIPPED search path rather than a
+    /// hand-built root list.
+    ///
+    /// `default_search_path` is `[nano-ros tree, user workspace]`, and the user
+    /// workspace is a directory outside this repo. So a provider package the
+    /// user drops into their own workspace IS selected by name today; it is not
+    /// waiting on phase-420 W6, which widens the path beyond those two roots.
+    /// A provider at a third location that is neither root is not reachable
+    /// yet, and that is W6's job rather than this wave's.
+    #[test]
+    fn a_provider_in_the_user_workspace_reaches_the_default_search_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("robot_ws");
+        write_provider(
+            &workspace.join("src/flatbuf_serdes"),
+            "flatbuf-serdes",
+            "flatbuf",
+            Some("[serdes]\nimpl = \"schema\"\nformat_id = 9\n"),
+        );
+
+        let nano_ros = repo_root();
+        let roots = default_search_path(Some(&nano_ros), &workspace);
+        assert_eq!(
+            roots.len(),
+            2,
+            "the user workspace is outside the nano-ros tree, so it is its own root: {roots:?}"
+        );
+
+        let scan = scan_roots(&roots).expect("scan the default search path");
+        let r = resolve_serdes_in(&scan, "flatbuf").expect("the user's provider resolves");
+        assert_eq!(r.crate_name, "flatbuf-serdes");
+        assert_eq!(r.cargo_feature, "serdes-flatbuf");
+        assert_eq!(r.format_id, Some(9));
+    }
+
+    /// MEASURED, and it surprised this wave: **root 0 of the default search
+    /// path contributes nothing in this repository.**
+    ///
+    /// The nano-ros root carries its own `.nros-ignore` (issue 0621, so a
+    /// vendored checkout stops polluting a consumer's package graph), and
+    /// [`crate::provider_scan`] reads `IGNORE_MARKERS` on every directory
+    /// INCLUDING the root it was handed. `nros-pkg-index` does not — its walk
+    /// exempts depth 0, which the marker file's own header states as the
+    /// contract ("It does NOT affect nano-ros's own discovery"). Issue 0809
+    /// taught `provider_scan` the `.nros-ignore` spelling and did not carry the
+    /// depth-0 exemption across with it, so the two walks agree on the marker
+    /// and disagree on the root.
+    ///
+    /// This test pins the CURRENT behaviour so the day it changes is visible.
+    /// It is not a claim that the behaviour is right — a fix belongs with
+    /// `provider_scan`, whose rmw/board/platform families are affected exactly
+    /// as serdes is, and not with the wave that happened to notice.
+    #[test]
+    fn the_nano_ros_root_is_pruned_by_its_own_nros_ignore() {
+        let root = repo_root();
+        assert!(
+            root.join(".nros-ignore").is_file(),
+            "this test is about that marker; if it is gone, the finding is stale"
+        );
+
+        let scan = scan_roots(&[root]).expect("scan the nano-ros root");
+        assert!(
+            scan.providers.is_empty(),
+            "root 0 is pruned at depth 0 — if this now finds providers, the \
+             depth-0 exemption landed and `resolve_serdes_in` gains the in-tree \
+             providers through the default search path for free: {:?}",
+            scan.providers
+                .iter()
+                .map(|p| &p.package)
+                .collect::<Vec<_>>()
+        );
+        // Which is why the in-tree cross-check above scans `packages/core`
+        // directly: below the marker, the same walk finds the same provider.
+    }
+
+    #[test]
+    fn a_provider_with_no_descriptor_gets_every_default() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("ws");
+        write_provider(&root.join("bare"), "bare-serdes", "bare", None);
+
+        let scan = scan_roots(&[root]).expect("scan");
+        let r = resolve_serdes_in(&scan, "bare").expect("resolves with no descriptor");
+        assert_eq!(r.impl_strategy, "schema", "RFC-0088 D7 default");
+        assert_eq!(
+            r.format_id, None,
+            "an unstated discriminant is assigned by the build, not defaulted here"
+        );
+    }
+
+    #[test]
+    fn the_in_tree_provider_resolves_through_the_scan_too() {
+        // The nano-ros tree is root 0 of the default search path, not a
+        // builtin reached by a different code path (provider_scan's premise).
+        let scan = scan_roots(&[repo_root().join("packages/core")]).expect("scan packages/core");
+        let r = resolve_serdes_in(&scan, "cdr").expect("cdr resolves through the scan");
+        let table = resolve_serdes("cdr").expect("and through the table");
+        assert_eq!(r.declared, table.declared);
+        assert_eq!(r.crate_name, table.crate_name);
+        assert_eq!(r.cargo_feature, table.cargo_feature);
+        assert_eq!(r.c_define_token, table.c_define_token);
+        assert_eq!(r.impl_strategy, table.impl_strategy);
+        assert_eq!(r.format_id, table.format_id);
+    }
+
+    #[test]
+    fn a_later_root_overlays_an_earlier_one() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let under = tmp.path().join("underlay");
+        let over = tmp.path().join("overlay");
+        write_provider(
+            &under.join("cdr_pkg"),
+            "nros-serdes",
+            "cdr",
+            Some("[serdes]\nimpl = \"codegen\"\nformat_id = 1\n"),
+        );
+        write_provider(
+            &over.join("cdr_pkg"),
+            "my-patched-cdr",
+            "cdr",
+            Some("[serdes]\nimpl = \"schema\"\nformat_id = 1\n"),
+        );
+
+        let scan = scan_roots(&[under, over.clone()]).expect("scan both roots");
+        let r = resolve_serdes_in(&scan, "cdr").expect("resolves");
+        assert_eq!(
+            r.crate_name, "my-patched-cdr",
+            "the LATER root must win (provider_scan::resolve_unique)"
+        );
+        assert_eq!(
+            r.package_dir.as_deref(),
+            Some(over.join("cdr_pkg").as_path())
+        );
+    }
+
+    #[test]
+    fn an_unknown_name_in_a_scan_lists_what_is_available() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("ws");
+        write_provider(&root.join("flatbuf"), "flatbuf-serdes", "flatbuf", None);
+
+        let scan = scan_roots(&[root]).expect("scan");
+        let err = resolve_serdes_in(&scan, "flatbüf").expect_err("typo must not resolve");
+        let msg = err.to_string();
+        assert!(msg.contains("flatbüf"), "{msg}");
+        assert!(
+            msg.contains("flatbuf"),
+            "must name the available format: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_provider_without_a_cargo_toml_cannot_be_lowered() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("ws");
+        let dir = root.join("no_crate");
+        write_provider(&dir, "no-crate", "nocrate", None);
+        fs::remove_file(dir.join("Cargo.toml")).expect("remove Cargo.toml");
+
+        let scan = scan_roots(&[root]).expect("scan");
+        let err = resolve_serdes_in(&scan, "nocrate").expect_err("no crate to derive");
+        assert!(
+            err.to_string().contains("Cargo.toml"),
+            "the error must name what is missing: {err}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_descriptor_is_an_error_not_a_default() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("ws");
+        write_provider(
+            &root.join("typo"),
+            "typo-serdes",
+            "typo",
+            Some("[serdes]\nimpl = \"codgen\"\n"),
+        );
+
+        let scan = scan_roots(&[root]).expect("scan");
+        let err = resolve_serdes_in(&scan, "typo").expect_err("a typo'd impl must not default");
+        assert!(err.to_string().contains("codgen"), "{err}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Consumption
+    // -----------------------------------------------------------------------
+
+    fn uses_xml(body: &str) -> String {
+        format!(
+            r#"<?xml version="1.0"?>
+<package format="3">
+  <name>consumer</name>
+  <version>0.0.0</version>
+  <description>d</description>
+  <maintainer email="d@example.com">D</maintainer>
+  <license>Apache-2.0</license>
+  <export>
+{body}
+  </export>
+</package>
+"#
+        )
+    }
+
+    #[test]
+    fn a_package_selects_a_serdes_with_nano_ros_uses() {
+        let pkg = PackageXml::parse_str(&uses_xml(
+            r#"    <nano_ros_uses kind="serdes" name="flatbuf"/>"#,
+        ))
+        .expect("parses");
+        assert_eq!(package_declared_serdes(&pkg), Some("flatbuf"));
+    }
+
+    #[test]
+    fn a_package_selecting_nothing_declares_nothing() {
+        let pkg =
+            PackageXml::parse_str(&uses_xml(r#"    <nano_ros_uses kind="rmw" name="zenoh"/>"#))
+                .expect("parses");
+        assert_eq!(
+            package_declared_serdes(&pkg),
+            None,
+            "an rmw selection is not a serdes selection"
+        );
+    }
+
+    #[test]
+    fn the_ladder_prefers_the_more_specific_declaration() {
+        let pkg = PackageXml::parse_str(&uses_xml(
+            r#"    <nano_ros_uses kind="serdes" name="flatbuf"/>"#,
+        ))
+        .expect("parses");
+
+        assert_eq!(declared_serdes(None, None, None), "cdr");
+        assert_eq!(declared_serdes(None, None, Some("uorb")), "uorb");
+        assert_eq!(declared_serdes(None, Some(&pkg), Some("uorb")), "flatbuf");
+        assert_eq!(
+            declared_serdes(Some("cdr"), Some(&pkg), Some("uorb")),
+            "cdr"
+        );
+    }
+}

--- a/packages/cli/nros-cli-core/src/cmd/new_system.rs
+++ b/packages/cli/nros-cli-core/src/cmd/new_system.rs
@@ -365,6 +365,10 @@ fn render_system_toml(pkg_name: &str, components: &[String]) -> Result<String> {
             name: system_name,
             rmw: "zenoh".to_string(),
             domain_id: 0,
+            // phase-421 W4 — omitted from the scaffold on purpose: absent means
+            // `cdr`, which is what the image builds anyway, and a scaffold that
+            // states a default teaches the reader it is a choice they made.
+            serdes: None,
             // Omitted from the scaffold → the humble default (RFC-0056); a user
             // adds `ros_edition = "iron"|"jazzy"|…` when targeting a newer distro.
             ros_edition: None,

--- a/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
@@ -412,6 +412,16 @@ pub struct DeployTargetMetadata {
     /// RMW backend (`zenoh` / `xrce` / `cyclonedds`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rmw: Option<String>,
+    /// Serialization format, by PROVIDER NAME (phase-421 W4, RFC-0088 D6).
+    ///
+    /// The Cargo-native deploy block is the one `[deploy.<t>]` nano-ros OWNS.
+    /// The `system.toml` one is `ros_launch_manifest_model::DeployBlock`, an
+    /// upstream `deny_unknown_fields` struct that declares `rmw` and not
+    /// `serdes` — so the system.toml rung of RFC-0088 D6's
+    /// `[deploy.<t>] serdes = "…"` needs a spec release, and the live home for
+    /// the key is `[image.<id>].serdes` (where `rmw` itself moved, RFC-0065 D6).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serdes: Option<String>,
     /// Baked ROS_DOMAIN_ID — embedded targets bake at build time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub domain_id: Option<u32>,
@@ -1122,6 +1132,44 @@ impl SystemToml {
         }
     }
 
+    /// The serialization format for `target`, by provider name — phase-421 W4,
+    /// RFC-0088 D6.
+    ///
+    /// **The ladder mirrors [`Self::resolved_rmw`]'s, rung for rung**, because
+    /// serdes is the same kind of fact: one declared, language-agnostic value
+    /// that decides what gets compiled. CLI flag, then `[image.<target>].serdes`
+    /// (folded over `[image_defaults]`), then `[system].serdes`, then `"cdr"`.
+    ///
+    /// **One rung of `rmw`'s is absent, and that is a finding rather than a
+    /// choice.** `rmw` also reads `[deploy.<target>].rmw` — the DEPRECATED rung
+    /// (see `image::DEPRECATED_DEPLOY_FIELDS`) — and `[deploy.*]` in
+    /// `system.toml` is `ros_launch_manifest_model::system_config::DeployBlock`,
+    /// an UPSTREAM struct with `deny_unknown_fields`. `serdes` cannot be added
+    /// to it from this repo, so RFC-0088 D6's `[deploy.<t>] serdes = "…"`
+    /// spelling needs a `ros-launch-manifest` release before it can parse at
+    /// all. Nothing is lost by its absence: `[image.*]` is where every build
+    /// field moved (RFC-0065 D6, issue 0951), a deploy rung would be born
+    /// deprecated, and the Cargo-native deploy block nano-ros DOES own carries
+    /// the key ([`DeployTargetMetadata::serdes`]), projected here as an image.
+    ///
+    /// The default is `cdr` and not, say, the first provider found: a build
+    /// that declares no format must behave exactly as it does today.
+    #[must_use]
+    pub fn resolved_serdes(&self, target: Option<&str>, cli: Option<&str>) -> String {
+        if let Some(c) = cli {
+            return c.to_string();
+        }
+        if let Some(t) = target
+            && let Some(s) = self.image_for(t).and_then(|img| img.serdes)
+        {
+            return s;
+        }
+        self.system
+            .serdes
+            .clone()
+            .unwrap_or_else(|| cargo_nano_ros::serdes_descriptor::DEFAULT_SERDES_NAME.to_string())
+    }
+
     /// Phase 255 Wave 5 — the multi-RMW link set a single binary needs when it
     /// hosts cross-RMW `[[bridge]]`s. A single binary must link the **union** of
     /// every bridged session's RMW so it can speak both sides. Returned in
@@ -1207,6 +1255,15 @@ pub struct SystemHeader {
     /// invocation would be an expensive way to learn the default.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub default_images: Vec<String>,
+    /// System-wide serialization format, by PROVIDER NAME (phase-421 W4,
+    /// RFC-0088 D6). Absent ⇒ `cdr`, which is what every image builds today.
+    ///
+    /// Optional where [`Self::rmw`] is mandatory, deliberately: making it
+    /// mandatory would mean editing every `system.toml` in the tree to restate
+    /// the value they already have, and RFC-0088's rule is that a build
+    /// declaring no format behaves exactly as it does now.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serdes: Option<String>,
     /// Phase 261 W4 — generic capability axes by declared name, e.g.
     /// `features = ["safety", "param_services"]`. Each entry must resolve via
     /// `capability_resolver::capability(name)` (unknown ⇒ hard error, typo guard);
@@ -1910,6 +1967,72 @@ board = "native"
         let bare: SystemToml =
             toml::from_str("[system]\nname=\"d\"\nrmw=\"\"\ndomain_id=0\n").unwrap();
         assert_eq!(bare.resolved_rmw(None, None), "zenoh");
+    }
+
+    /// phase-421 W4 — `resolved_serdes` mirrors `resolved_rmw`'s ladder:
+    /// `--serdes` > `[image.<t>].serdes` (over `[image_defaults]`) >
+    /// `[system].serdes` > `cdr`.
+    #[test]
+    fn resolved_serdes_precedence_ladder() {
+        let sys: SystemToml = toml::from_str(
+            r#"
+[system]
+name = "d"
+rmw = "zenoh"
+domain_id = 0
+serdes = "uorb"
+
+[image.gw]
+board = "native"
+serdes = "flatbuf"
+
+[image.plain]
+board = "native"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(sys.resolved_serdes(Some("gw"), Some("cdr")), "cdr");
+        assert_eq!(sys.resolved_serdes(Some("gw"), None), "flatbuf");
+        assert_eq!(sys.resolved_serdes(Some("plain"), None), "uorb");
+        assert_eq!(sys.resolved_serdes(Some("nope"), None), "uorb");
+        assert_eq!(sys.resolved_serdes(None, None), "uorb");
+
+        // `[image_defaults]` is the base, exactly as it is for rmw.
+        let defaults: SystemToml = toml::from_str(
+            r#"
+[system]
+name = "d"
+rmw = "zenoh"
+domain_id = 0
+
+[image_defaults]
+serdes = "flatbuf"
+
+[image.gw]
+board = "native"
+"#,
+        )
+        .unwrap();
+        assert_eq!(defaults.resolved_serdes(Some("gw"), None), "flatbuf");
+    }
+
+    /// A system.toml that never mentions a serialization format must resolve to
+    /// CDR — RFC-0088's rule that declaring nothing changes nothing.
+    #[test]
+    fn a_system_declaring_no_serdes_is_cdr_everywhere() {
+        let bare: SystemToml = toml::from_str(
+            "[system]\nname=\"d\"\nrmw=\"zenoh\"\ndomain_id=0\n[image.gw]\nboard=\"native\"\n",
+        )
+        .unwrap();
+        assert_eq!(bare.resolved_serdes(None, None), "cdr");
+        assert_eq!(bare.resolved_serdes(Some("gw"), None), "cdr");
+        // And the answer is a name the resolver can actually lower.
+        assert!(
+            cargo_nano_ros::serdes_resolver::resolve_serdes(&bare.resolved_serdes(None, None))
+                .is_ok(),
+            "the default must be a provider this checkout ships"
+        );
     }
 
     /// Phase 256 / issue 0951 — `resolve_image`: `--image` → the sole image

--- a/packages/cli/nros-cli-core/src/orchestration/image.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/image.rs
@@ -86,6 +86,16 @@ pub struct ImageBlock {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rmw: Option<String>,
 
+    /// Serialization format for this image, by PROVIDER NAME (phase-421 W4,
+    /// RFC-0088 D6). Absent ⇒ the system header's `serdes`, then `cdr`.
+    ///
+    /// Per IMAGE and not per topic or per publisher: ROS 2's semantic is one
+    /// middleware, one encoding, and RFC-0088 keeps it. The name is resolved
+    /// against the provider search path — an in-tree format and one from a
+    /// package outside this repo are selected the same way.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serdes: Option<String>,
+
     /// ROS edition. Absent ⇒ the system header's `ros_edition`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ros_edition: Option<String>,
@@ -158,6 +168,7 @@ impl ImageBlock {
             },
             panic: pick(&self.panic, &base.panic),
             rmw: pick(&self.rmw, &base.rmw),
+            serdes: pick(&self.serdes, &base.serdes),
             ros_edition: pick(&self.ros_edition, &base.ros_edition),
             profile: pick(&self.profile, &base.profile),
             variant: pick(&self.variant, &base.variant),

--- a/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
@@ -569,6 +569,10 @@ fn synthesise_self_bringup(comp: &ComponentPackageEntry) -> BringupPackageEntry 
             .clone()
             .unwrap_or_else(|| "zenoh".to_string()),
         domain_id: first_deploy.domain_id.unwrap_or(0),
+        // phase-421 W4 — carry the Cargo-native `[..deploy.<t>].serdes`
+        // projection into the synthesized header, the same way `rmw` above
+        // comes from the first deploy block. Absent ⇒ `cdr` at resolve time.
+        serdes: first_deploy.serdes.clone(),
         // Self-bringup synthesized from component deploy metadata, which carries
         // no edition today → humble default (RFC-0056; phase-304 W2 follow-up:
         // thread a component-declared edition here if one is added).
@@ -669,6 +673,12 @@ fn synthesise_self_bringup(comp: &ComponentPackageEntry) -> BringupPackageEntry 
                 crate::orchestration::image::ImageBlock {
                     board: dt.board.clone(),
                     rmw: dt.rmw.clone(),
+                    // phase-421 W4 — the Cargo-native deploy block is the one
+                    // `[deploy.<t>]` nano-ros owns, and it is where a
+                    // `serdes = "…"` key can live at all (system.toml's block
+                    // is upstream's `deny_unknown_fields` struct). Projected as
+                    // an image so `resolved_serdes`'s image rung sees it.
+                    serdes: dt.serdes.clone(),
                     ..Default::default()
                 },
             )

--- a/packages/core/nros-serdes/nros-serdes.toml
+++ b/packages/core/nros-serdes/nros-serdes.toml
@@ -1,0 +1,44 @@
+# nano-ros serialization-format descriptor — RFC-0088 D6, phase-421 W4.
+#
+# The provider announces its NAME in `package.xml`; this file carries only what
+# no convention can produce (RFC-0087 D4). Everything else is derived:
+#
+#   crate          the sibling Cargo.toml's [package] name
+#   cargo feature  serdes-<name>
+#   cmake value    the canonical name
+#   C define token UPPER(name)
+#
+# A provider with nothing non-derivable to say needs no descriptor at all; the
+# defaults apply. This one exists because `impl` and `format_id` cannot be
+# guessed.
+[serdes]
+
+# How this format is produced. Not derivable: it is a property of the
+# implementation, not of the name.
+#
+#   "codegen"  a per-type serializer emitted by `nros generate-rust` — fast,
+#              and what CDR uses (the generated `serialize`/`deserialize`).
+#   "schema"   one implementation walking the `&'static [Field]` schema codegen
+#              already emits for every message. Slower, and costs a provider no
+#              codegen work at all (RFC-0088 D7).
+impl = "codegen"
+
+# Image-local discriminant (RFC-0088 D2).
+#
+# **This number means nothing outside the image that assigned it.** nano-ros
+# cannot allocate a globally unique `u8` to a third-party format, so the NAME is
+# the identity that crosses image boundaries — the bridge config, tooling
+# output, and the `get_serialization_format` vtable slot all carry the string.
+#
+# In-tree formats hold low reserved values for readability, and only for that:
+#   1  cdr    (this file)
+#   2  uorb   (declared by the uORB RMW backend, whose wire is the PX4 struct —
+#              a backend property, not a serialization library, so it has no
+#              provider package of its own)
+# A third-party provider that states none is assigned one by the build from the
+# set of formats its image declares.
+#
+# `check-serdes-descriptors` S3 parses `SerializationFormatId` out of
+# `packages/core/nros-serdes/src/format.rs` and asserts the two spellings of
+# this number agree, in both directions.
+format_id = 1

--- a/packages/core/nros-serdes/package.xml
+++ b/packages/core/nros-serdes/package.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>nros_serdes</name>
+  <version>0.0.0</version>
+  <description>
+    CDR serialization for nano-ros — and, since phase-421 W4, the package that
+    ANNOUNCES it.
+
+    RFC-0087 D1: a package is a directory with a package.xml, so this file is
+    what makes the crate discoverable at all. RFC-0088 D6: the `serdes` family
+    joins `rmw`, `board` and `platform`, and the `nano_ros_provides` export
+    below is what a source-time scan reads. What it lowers to is declared in the
+    sibling `nros-serdes.toml` descriptor, read only when this provider is the
+    one selected.
+
+    The descriptor sits beside the crate that implements the format rather than
+    in a metadata-only package: a provider that announces a format nothing here
+    implements would be a name with no code behind it.
+  </description>
+  <maintainer email="dev@example.com">Developer</maintainer>
+  <license>Apache-2.0</license>
+
+  <export>
+    <build_type>nros_cargo</build_type>
+    <!--
+      Provision, NOT consumption: this package IS the CDR serializer, rather
+      than selecting one. A consumer selects it with
+      `<nano_ros_uses kind="serdes" name="cdr"/>` (phase-420 W1) or
+      `[deploy.<t>] serdes = "cdr"`.
+
+      Must equal the descriptor's declared names, canonical first —
+      `check-provider-announcements.py` compares them, because two spellings of
+      one fact drift.
+    -->
+    <nano_ros_provides kind="serdes" name="cdr"/>
+  </export>
+</package>

--- a/scripts/check-provider-announcements.py
+++ b/scripts/check-provider-announcements.py
@@ -10,7 +10,27 @@ them.
   A1  a package.xml sitting beside a descriptor announces provisions of that
       kind — otherwise it is invisible to the scan while looking migrated;
   A2  its provision names equal the descriptor's declared names EXACTLY and in
-      order, canonical first, since names[0] is what error messages list.
+      order, canonical first, since names[0] is what error messages list;
+  A3  for a family whose descriptors carry no names at all, the announced names
+      are UNIQUE across the family — see "Two shapes of family" below.
+
+**Two shapes of family, and A2 exists only for one of them.** `rmw`, `board` and
+`platform` predate RFC-0087 D4: their descriptors repeat the provider's names, so
+there are two spellings of one fact and A2 is what keeps them equal. D4 removed
+`names` from NEW descriptors — a descriptor now carries only what no convention
+can produce, and the announcement is the ONLY place a name is written. For such a
+family A2 has nothing to compare against and cannot be written honestly, so the
+row declares `extract=None` and the check becomes A1 + A3: the descriptor must
+still be announced (or it is invisible to the scan), and since the announcement
+is the sole spelling, the one thing that can still go wrong is two providers
+claiming one name.
+
+Do NOT "fix" a nameless family back into an A2 comparison by adding `names` to
+its descriptor: that re-creates the second spelling D4 deleted, and A2 would then
+be checking the descriptor against a copy of itself — the cannot-fail gate
+`check-rmw-descriptors` retired its own S-checks over (see its docstring).
+Equally, do not delete A2 from the three families that DO have `names`; their
+duplication is real and unchecked otherwise.
 
 **One gate for every family, not one per family.** This started as S5 inside
 `check-rmw-descriptors.py`, covering rmw alone. Extending the rule to boards by
@@ -39,7 +59,8 @@ except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# kind -> (descriptor glob, how to pull the declared names out of it).
+# kind -> (descriptor glob, how to pull the declared names out of it — or None
+# for a family whose descriptors carry no names, see A3 above).
 #
 # The two families disagree in shape and that is not an accident: an rmw
 # descriptor is ONE backend (`[rmw]`), while a board descriptor is an ARRAY
@@ -64,6 +85,17 @@ FAMILIES = {
         "config/*/nros-platform.toml",
         lambda d: list(d.get("names", [])),
     ),
+    # phase-421 W4 / RFC-0088 D6. The first family born after RFC-0087 D4, so
+    # its descriptor has NO `names` key and never will: `nros-serdes.toml`
+    # carries `impl` and `format_id`, the two facts no convention can derive,
+    # and the `<nano_ros_provides>` announcement is the name. `None` selects
+    # A1 + A3 instead of A1 + A2 (see the module docstring).
+    #
+    # Everything serdes-SPECIFIC — descriptor well-formedness, the `format_id`
+    # discriminant, and the descriptor a package announcing `serdes` must have —
+    # lives in `scripts/check-serdes-descriptors.py`, the same split that keeps
+    # this gate one gate for every family rather than one per family.
+    "serdes": ("packages/*/*/nros-serdes.toml", None),
 }
 
 PROVIDES_RE = r'<nano_ros_provides\s+kind="{kind}"\s+name="([^"]+)"\s*/?>'
@@ -86,6 +118,7 @@ def main():
     problems = []
     checked = 0
     announced = 0
+    claimed = {}  # (kind, name) -> package.xml that announced it (A3)
 
     for kind, (pattern, extract) in sorted(FAMILIES.items()):
         paths = sorted(glob.glob(os.path.join(ROOT, pattern)))
@@ -112,8 +145,8 @@ def main():
                 except Exception as e:  # noqa: BLE001 — report, do not raise
                     problems.append(f"{desc_rel}: not valid TOML: {e}")
                     continue
-            names = extract(data)
-            if not names:
+            names = None if extract is None else extract(data)
+            if extract is not None and not names:
                 problems.append(
                     f"{desc_rel}: declares no names — nothing could resolve to it"
                 )
@@ -122,12 +155,28 @@ def main():
             found = declared_provisions(pkg_xml, kind)
             announced += len(found)
             if not found:
+                # A1 — true for both shapes of family.
                 problems.append(
                     f'{rel}: sits beside a {kind} descriptor but announces no '
                     f'<nano_ros_provides kind="{kind}"/> — it would be invisible '
                     f"to the phase-348 scan"
                 )
+            elif names is None:
+                # A3 — a nameless-descriptor family (RFC-0087 D4). There is no
+                # second spelling to compare against, so the only failure left
+                # is two providers answering to one name.
+                for n in found:
+                    prior = claimed.get((kind, n))
+                    if prior is not None and prior != rel:
+                        problems.append(
+                            f"{rel}: announces {kind} name {n!r}, already announced "
+                            f"by {prior} — a name resolves to one provider, and "
+                            f"for this family the announcement is the ONLY place "
+                            f"it is written"
+                        )
+                    claimed[(kind, n)] = rel
             elif found != names:
+                # A2 — a family whose descriptor repeats the names.
                 problems.append(
                     f"{rel}: provides {found} but {desc_rel} declares {names} — "
                     f"discovery and resolution must claim the same names, "
@@ -140,10 +189,13 @@ def main():
             sys.stderr.write(f"  {p}\n")
         return 1
 
+    nameless = sum(1 for _, e in FAMILIES.values() if e is None)
     print(
         f"provider announcements: OK ({checked} migrated provider(s) across "
-        f"{len(FAMILIES)} famil(ies), {announced} name(s) announced, all matching "
-        f"their descriptor)"
+        f"{len(FAMILIES)} famil(ies), {announced} name(s) announced; "
+        f"{len(FAMILIES) - nameless} famil(ies) matched name-for-name against "
+        f"their descriptor, {nameless} nameless-descriptor famil(ies) checked "
+        f"for announcement + uniqueness)"
     )
     return 0
 

--- a/scripts/check-serdes-descriptors.py
+++ b/scripts/check-serdes-descriptors.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""phase-421 W4 — the serdes descriptors are well-formed and unambiguous.
+
+Family `serdes` (RFC-0088 D6) is the first provider family born after RFC-0087
+D4, so its descriptor is SMALL by construction: the `<nano_ros_provides>`
+announcement carries the name, and `nros-serdes.toml` carries only the two facts
+no convention can derive — how the format is produced (`impl`) and the
+image-local discriminant (`format_id`). A provider with nothing non-derivable to
+say needs no descriptor at all.
+
+That shape decides what this gate can honestly assert. Its sibling
+`check-rmw-descriptors.py` learned the hard way that **a gate that cannot fail
+is worse than no gate** — it began as an agreement check and had to be rewritten
+once the descriptors became the source, because comparing a generated table to
+its own input is comparing a thing to itself. So this file never compares the
+descriptor to something derived from it. It checks what can still go wrong:
+
+  S1  every descriptor is well-formed: `impl` is exactly "schema" or "codegen",
+      `format_id` is an integer in 1..=255, and there are no unknown keys under
+      `[serdes]` — an unknown key is a typo, and a typo silently lowers to
+      nothing while reading like a decision;
+  S2  no two providers claim one name, and no two claim one `format_id`. The
+      discriminant half is the one that matters: an ambiguous `u8` is a
+      wire-visible bug with a compile-time-looking cause (RFC-0088 D2);
+  S3  the in-tree reserved discriminants agree with
+      `nros_serdes::format::SerializationFormatId`. `cdr = 1` and `uorb = 2` are
+      written twice — once in the Rust enum, once in a descriptor — and this is
+      the only thing stopping them diverging. The pairs are PARSED out of
+      `format.rs`, never hardcoded here: a copy in this file would be a third
+      spelling of the same fact and would agree with neither;
+  S4  a descriptor exists for every package announcing `kind="serdes"`, so
+      adding a provider and forgetting the descriptor fails here rather than at
+      a consumer, where the symptom is a defaulted `impl` nobody chose.
+
+Why S3 checks BOTH directions. A reserved name must hold its reserved value
+(`cdr` may not become 7), and a reserved value must not be taken under another
+name (`flatbuf = 2` would collide with uORB inside any image that links both).
+Only the first direction is obvious, and only the second is the wire bug.
+
+Note that uORB has NO serdes provider package: its wire is the PX4 struct, a
+property of that backend rather than a serialization library (RFC-0011). It is a
+reserved name with no descriptor, which S3 tolerates by design — it constrains
+descriptors that USE a reserved name or value, and never demands one exist.
+
+`kind="serdes"` announcement agreement — "a package.xml beside a descriptor
+announces its family, and no two announce one name" — is NOT here. It lives in
+`scripts/check-provider-announcements.py`, one gate covering every family, which
+is where S5 moved when boards needed the same rule (#282 → #326). What stays
+here is what is serdes-SPECIFIC. The name-uniqueness pass below is the belt to
+that gate's braces and covers a strictly larger set: this one sees providers
+whose descriptor is missing (S4) or whose package.xml the other gate skips.
+
+Buildless — TOML plus a regex over one Rust file. No cargo, no cmake.
+
+Usage:
+    scripts/check-serdes-descriptors.py
+    scripts/check-serdes-descriptors.py --self-test
+"""
+
+import glob
+import importlib.util
+import os
+import re
+import sys
+
+try:
+    import tomllib  # 3.11+
+except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
+    import tomli as tomllib
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+FORMAT_RS = os.path.join(ROOT, "packages/core/nros-serdes/src/format.rs")
+
+# `impl` values the toolchain knows how to lower (RFC-0088 D7). A third value is
+# a provider asking for a strategy that does not exist.
+IMPLS = {"schema", "codegen"}
+
+# Every key `[serdes]` may carry. Anything else is a typo: the reader takes its
+# default and the authored line has no effect, which is the failure mode this
+# repo keeps paying for in Kconfig fragments (issue 0876).
+KNOWN_KEYS = {"impl", "format_id"}
+
+
+def _load(name, path):
+    """Import a sibling gate by file path (hyphens are not module names)."""
+    spec = importlib.util.spec_from_file_location(name, os.path.join(ROOT, path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ANN = _load("_announcements", "scripts/check-provider-announcements.py")
+
+# ONE spelling of "where serdes descriptors live" and of "how a package.xml
+# announces a provision", shared with the family gate rather than re-written.
+DESCRIPTOR_GLOB = _ANN.FAMILIES["serdes"][0]
+declared_provisions = _ANN.declared_provisions
+
+# Where a package.xml may announce `serdes` from. Wider than DESCRIPTOR_GLOB on
+# purpose: S4's whole job is the package that announces and has no descriptor,
+# so it cannot search only where descriptors already are.
+PACKAGE_XML_GLOB = "packages/*/*/package.xml"
+
+ENUM_RE = re.compile(r"pub enum SerializationFormatId\s*\{(.*?)\n\}", re.DOTALL)
+VARIANT_RE = re.compile(r"^\s*([A-Z][A-Za-z0-9]*)\s*=\s*(\d+)\s*,", re.MULTILINE)
+AS_STR_RE = re.compile(r"pub const fn as_str\(self\)[^{]*\{(.*?)\n    \}", re.DOTALL)
+ARM_RE = re.compile(r"Self::([A-Za-z0-9]+)\s*=>\s*\"([^\"]+)\"")
+
+
+def reserved_formats(text):
+    """{name: discriminant} parsed out of `format.rs`.
+
+    Two independent readings that must agree: the enum body gives variant ->
+    number, `as_str` gives variant -> string. Requiring both means the enum
+    cannot grow a variant with no cross-image name, which is the identity that
+    actually crosses an image boundary (RFC-0088 D2).
+
+    Returns (mapping, problems).
+    """
+    problems = []
+    body = ENUM_RE.search(text)
+    if not body:
+        return {}, ["could not find `pub enum SerializationFormatId` — did it move?"]
+    variants = {m.group(1): int(m.group(2)) for m in VARIANT_RE.finditer(body.group(1))}
+    if not variants:
+        return {}, ["`SerializationFormatId` parsed with no explicit discriminants"]
+
+    arms_src = AS_STR_RE.search(text)
+    if not arms_src:
+        return {}, ["could not find `SerializationFormatId::as_str` — did it move?"]
+    arms = dict(ARM_RE.findall(arms_src.group(1)))
+
+    mapping = {}
+    for variant, value in sorted(variants.items(), key=lambda kv: kv[1]):
+        name = arms.get(variant)
+        if name is None:
+            problems.append(
+                f"SerializationFormatId::{variant} has no `as_str` arm — the "
+                f"string, not the number, is the cross-image identity"
+            )
+            continue
+        mapping[name] = value
+    return mapping, problems
+
+
+def read_format_rs():
+    """(reserved mapping, problems) — never raises.
+
+    A missing or moved `format.rs` is a real failure mode (the crate is
+    reorganised, this gate is not) and must READ as one, not as a traceback: a
+    stack trace on a gate reads as "the gate is broken" and gets ignored.
+    """
+    try:
+        with open(FORMAT_RS, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as e:  # report, do not raise
+        return {}, [f"cannot read {os.path.relpath(FORMAT_RS, ROOT)}: {e}"]
+    return reserved_formats(text)
+
+
+def read_descriptor(path):
+    """([serdes] table, problems) for one descriptor."""
+    rel = os.path.relpath(path, ROOT)
+    with open(path, "rb") as fh:
+        try:
+            data = tomllib.load(fh)
+        except Exception as e:  # noqa: BLE001 — report, do not raise
+            return None, [f"{rel}: not valid TOML: {e}"]
+    table = data.get("serdes")
+    if table is None:
+        return None, [f"{rel}: no [serdes] table"]
+    if not isinstance(table, dict):
+        return None, [f"{rel}: [serdes] is not a table"]
+    return table, []
+
+
+def check_descriptor(rel, table):
+    """S1 for one descriptor: impl, format_id, no unknown keys."""
+    problems = []
+
+    unknown = sorted(set(table) - KNOWN_KEYS)
+    if unknown:
+        problems.append(
+            f"{rel}: unknown key(s) under [serdes]: {unknown} — known keys are "
+            f"{sorted(KNOWN_KEYS)}; an unrecognised key lowers to nothing while "
+            f"reading like a decision"
+        )
+
+    impl = table.get("impl")
+    if impl is None:
+        problems.append(
+            f"{rel}: [serdes].impl is missing — write \"codegen\" or \"schema\" "
+            f"(RFC-0088 D7); a descriptor that has nothing to say should not exist"
+        )
+    elif impl not in IMPLS:
+        problems.append(
+            f"{rel}: [serdes].impl is {impl!r}, not one of {sorted(IMPLS)}"
+        )
+
+    fid = table.get("format_id")
+    if fid is None:
+        problems.append(f"{rel}: [serdes].format_id is missing")
+    elif isinstance(fid, bool) or not isinstance(fid, int):
+        problems.append(
+            f"{rel}: [serdes].format_id is {fid!r} — must be an integer, since it "
+            f"lowers to a u8 discriminant"
+        )
+    elif not 1 <= fid <= 255:
+        problems.append(
+            f"{rel}: [serdes].format_id is {fid} — must be in 1..=255 (0 is "
+            f"reserved for 'unset' and the discriminant is a u8)"
+        )
+    return problems
+
+
+def scan():
+    """Every serdes provider found in the tree.
+
+    Returns (providers, problems) where a provider is
+    (package dir rel, descriptor rel or None, announced names, [serdes] table).
+    """
+    problems = []
+    by_dir = {}
+
+    for desc in sorted(glob.glob(os.path.join(ROOT, DESCRIPTOR_GLOB))):
+        d = os.path.dirname(desc)
+        table, probs = read_descriptor(desc)
+        problems += probs
+        by_dir[d] = [os.path.relpath(desc, ROOT), [], table]
+
+    for pkg_xml in sorted(glob.glob(os.path.join(ROOT, PACKAGE_XML_GLOB))):
+        names = declared_provisions(pkg_xml, "serdes")
+        if not names:
+            continue
+        d = os.path.dirname(pkg_xml)
+        by_dir.setdefault(d, [None, [], None])[1] = names
+
+    providers = [
+        (os.path.relpath(d, ROOT), desc, names, table)
+        for d, (desc, names, table) in sorted(by_dir.items())
+    ]
+    return providers, problems
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+
+    # phase-395: a negative control nobody runs decays into a comment, so the
+    # selftest runs on the NORMAL path too — quietly when it passes. The flag
+    # above is only the verbose entry point.
+    rc = self_test(quiet=True)
+    if rc:
+        return rc
+
+    providers, problems = scan()
+    if not providers:
+        sys.exit(
+            "check-serdes-descriptors: no serdes provider found — refusing to "
+            "pass on an empty set (the gate would be vacuous)"
+        )
+
+    reserved, probs = read_format_rs()
+    problems += [f"packages/core/nros-serdes/src/format.rs: {p}" for p in probs]
+    reserved_by_id = {v: k for k, v in reserved.items()}
+
+    by_name = {}
+    by_id = {}
+    descriptors = 0
+
+    for pkg, desc_rel, names, table in providers:
+        # S4 — announced, but no descriptor beside the announcement.
+        if desc_rel is None:
+            problems.append(
+                f"{pkg}: announces serdes name(s) {names} but ships no "
+                f"nros-serdes.toml — `impl` and `format_id` cannot be derived "
+                f"from a name, so a consumer would silently get the defaults"
+            )
+            continue
+        if table is None:
+            continue  # already reported by read_descriptor
+        descriptors += 1
+        problems += check_descriptor(desc_rel, table)
+
+        # S2 — one name, one provider; one discriminant, one format.
+        for n in names:
+            if n in by_name:
+                problems.append(
+                    f"two providers claim serdes name {n!r}: {by_name[n]} and "
+                    f"{desc_rel} — a name resolves to exactly one provider"
+                )
+            by_name[n] = desc_rel
+        fid = table.get("format_id")
+        if isinstance(fid, int) and not isinstance(fid, bool):
+            if fid in by_id:
+                problems.append(
+                    f"two providers claim format_id {fid}: {by_id[fid]} and "
+                    f"{desc_rel} — an ambiguous discriminant is a wire-visible "
+                    f"bug with a compile-time-looking cause (RFC-0088 D2)"
+                )
+            by_id[fid] = desc_rel
+
+            # S3 — both directions against the Rust enum.
+            for n in names:
+                if n in reserved and reserved[n] != fid:
+                    problems.append(
+                        f"{desc_rel}: format_id {fid} for {n!r}, but "
+                        f"SerializationFormatId reserves {reserved[n]} for it — "
+                        f"the enum and the descriptor are two spellings of one "
+                        f"number and must agree"
+                    )
+            holder = reserved_by_id.get(fid)
+            if holder is not None and holder not in names:
+                problems.append(
+                    f"{desc_rel}: format_id {fid} is reserved for {holder!r} by "
+                    f"SerializationFormatId, but this provider announces {names} "
+                    f"— a reserved discriminant may not be taken under another "
+                    f"name"
+                )
+
+    if problems:
+        sys.stderr.write("check-serdes-descriptors: FAILED\n")
+        for p in problems:
+            sys.stderr.write(f"  {p}\n")
+        return 1
+
+    print(
+        f"serdes descriptors: OK ({descriptors} descriptor(s), "
+        f"{len(by_name)} name(s) claimed, {len(by_id)} discriminant(s), no "
+        f"duplicates; {len(reserved)} reserved format(s) in format.rs agree)"
+    )
+    return 0
+
+
+def self_test(quiet=False):
+    """Exercise each check against a synthetic input, both directions."""
+    bad = []
+
+    def expect(label, problems, want):
+        """`want` is a substring of the message this case must produce."""
+        if want is None:
+            if problems:
+                bad.append(f"{label}: expected clean, got {problems}")
+        elif not any(want in p for p in problems):
+            bad.append(f"{label}: expected a problem containing {want!r}, got {problems}")
+
+    # S1
+    good = {"impl": "codegen", "format_id": 1}
+    expect("S1 well-formed", check_descriptor("d", good), None)
+    expect("S1 bad impl", check_descriptor("d", {"impl": "cdr", "format_id": 1}), "not one of")
+    expect("S1 missing impl", check_descriptor("d", {"format_id": 1}), "impl is missing")
+    expect("S1 typo key", check_descriptor("d", dict(good, imp1="codegen")), "unknown key")
+    expect("S1 id 0", check_descriptor("d", {"impl": "schema", "format_id": 0}), "1..=255")
+    expect("S1 id 256", check_descriptor("d", {"impl": "schema", "format_id": 256}), "1..=255")
+    expect(
+        "S1 id not an int",
+        check_descriptor("d", {"impl": "schema", "format_id": "1"}),
+        "must be an integer",
+    )
+    # A TOML bool is an int in Python; it must not read as a discriminant.
+    expect(
+        "S1 id is a bool",
+        check_descriptor("d", {"impl": "schema", "format_id": True}),
+        "must be an integer",
+    )
+
+    # S3 — the enum parser, against a miniature format.rs and its failure modes.
+    src = (
+        "pub enum SerializationFormatId {\n    /// doc\n    Cdr = 1,\n    Uorb = 2,\n}\n"
+        "impl SerializationFormatId {\n"
+        "    pub const fn as_str(self) -> &'static str {\n"
+        "        match self {\n"
+        "            Self::Cdr => \"cdr\",\n"
+        "            Self::Uorb => \"uorb\",\n"
+        "        }\n"
+        "    }\n"
+    )
+    mapping, probs = reserved_formats(src)
+    if mapping != {"cdr": 1, "uorb": 2} or probs:
+        bad.append(f"S3 enum parse: got {mapping} / {probs}")
+    _, probs = reserved_formats(src.replace("Self::Uorb => \"uorb\",\n", ""))
+    if not any("no `as_str` arm" in p for p in probs):
+        bad.append("S3 a variant with no string arm was accepted")
+    _, probs = reserved_formats("fn unrelated() {}")
+    if not probs:
+        bad.append("S3 a format.rs with no enum was accepted")
+
+    # The real file must parse, and must still reserve what the descriptors use.
+    live, probs = read_format_rs()
+    if probs or not live:
+        bad.append(f"S3 live format.rs did not parse: {probs}")
+
+    # S2/S4 depend on the tree, so the self-test asserts only that the scan
+    # sees something — a green run over an empty scan is the vacuous gate.
+    providers, _ = scan()
+    if not providers:
+        bad.append("S2/S4 scan found no serdes provider at all")
+
+    if bad:
+        for b in bad:
+            sys.stderr.write("check-serdes-descriptors --self-test: " + b + "\n")
+        return 2
+    if not quiet:
+        print(
+            f"check-serdes-descriptors --self-test: OK (13 case(s), "
+            f"{len(providers)} provider(s) visible)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
RFC-0088 D6 over RFC-0087's provider machinery. `serdes` becomes the fourth family beside `rmw`, `board` and `platform`.

```xml
<nano_ros_provides kind="serdes" name="cdr"/>
```

```toml
[serdes]
impl = "codegen"   # "schema" | "codegen"
format_id = 1      # image-local
```

**Two fields, because they are the only two no convention can produce.** Crate name, cargo feature, cmake value and C define token are derived (RFC-0087 D4), and `names` is absent by design — the announcement is the only spelling, so the two cannot disagree.

**Consumption needed no new attribute anywhere.** `<nano_ros_uses kind="serdes" name="…"/>` already parses in both readers — that was phase-420 W1's whole purpose, now cashed in.

## Two findings recorded rather than worked around

**`[deploy.<t>].serdes` cannot exist.** `DeployBlock` is upstream (`ros-launch-manifest`, git tag) with `deny_unknown_fields`, so the key D6 specified is a parse *error*, and adding it needs an upstream release plus a dependency bump. The ladder mirrors `resolved_rmw`'s rung for rung minus that one — CLI → `[image.<t>]` over `[image_defaults]` → `[system]` → `cdr` — with `[package.metadata.nros.deploy.<t>].serdes` (the deploy block nano-ros *does* own) carried into the synthesized image block exactly as `rmw` already is. The lost rung is one the tree is already retiring (`rmw` on `[deploy.*]` is in `DEPRECATED_DEPLOY_FIELDS`, issue 0951). **D6 amended to match.**

**Issue 1054 — `provider_scan` prunes the nano-ros root.** `walk_packages` reads ignore markers on the root it is handed; the repo root carries `.nros-ignore`; so scanning this tree returns **zero providers of any family** — rmw and board included. The marker file's own header states the opposite contract, and `nros-pkg-index` honours it with a depth-0 exemption that issue 0809 did not carry across when it taught `provider_scan` the spelling.

Nothing failed before because every consumer resolves through the generated compile-time tables; W4's `resolve_serdes_in` is the first caller to ask the *search path* for an in-tree provider by name. Pinned by a characterization test that states what changes when it is fixed. The fix moves discovery for every family, so it belongs in its own change.

So the acceptance is **partly met, honestly**: a provider in the user-workspace root — outside this repo — resolves by name, proven by a test that writes one into a temp directory. A provider at a *third* location needs phase-420 W6.

## Implementation notes

`serdes_descriptor.rs` is `include!`d by `build.rs` **and** compiled into the lib, so the compile-time table and the runtime out-of-repo path share one parser rather than two that drift. `build.rs` cannot reach quick-xml, so that module carries a small comment-stripping XML reader — and `generated_names_match_the_real_package_xml_parser` cross-checks it against `PackageXml::parse` over the real tree, because *two green tools disagreeing* is the failure mode the RMW parity map already taught us.

## Gates

`check-serdes-descriptors` — S1 well-formedness (including unknown keys, which lower to nothing while reading like a decision); S2 duplicate names **and** duplicate discriminants; S3 the descriptor agrees with `SerializationFormatId` **in both directions**, by parsing the enum out of `format.rs` rather than hardcoding pairs; S4 an announcement with no descriptor.

`check-provider-announcements` grew a second family **shape**, not a second script: a nameless-descriptor family cannot run the name-for-name comparison, so it runs announcement-presence + uniqueness instead — with the reason written down so nobody restores `names` to make the old check apply, which would re-create the second spelling D4 deleted.

## Verification

`cargo test -p cargo-nano-ros --lib` 142 pass · `-p nros-cli-core --lib` 863 pass · clippy `-D warnings` clean.

`just check fast` — 3 of 199 fail, all pre-existing on this host: `cpp-fmt` under clang-format 14 where 17.0.6 is pinned, `fixtures-manifest` and `kconfig-overridden-values` on `nros: command not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV