### PR TITLE
fix(ci): `just setup` must provision clang-format — every tier runs c-fmt

### DIFF
--- a/justfile
+++ b/justfile
@@ -3929,6 +3929,13 @@ _setup-common:
     # `rustup target add` is a no-op when the target is present.
     just workspace rust-targets
     just workspace install-corrosion
+    # `check fast` runs `c-fmt`/`cpp-fmt`, and EVERY tier runs `check fast`, so
+    # clang-format is a host fact every tier asserts — the same argument as the
+    # two above. Without it host-tests' `just ci tier1` reached the gate and
+    # died on "clang-format not found" after ~40 minutes of fixture builds.
+    # Idempotent: the recipe version-checks `build/clang-format/bin/clang-format`
+    # and exits early. Project-local, no install.
+    just setup-clang-format
 
 # Focused platform setup. Equivalent to `just <platform> setup`.
 [group("setup")]


### PR DESCRIPTION
host-tests run `33869867286` confirmed #365 fixed the three preconditions it was written for:

```
check-tier-preconditions: OK (submodules, CLI, leaf includes, build sources,
                              fixtures, build-output residue)
cli-fresh: OK — source-stamp: fresh
```

The lane then got past the gate that had been stopping it in ~2 minutes, ran both fixture builds, and failed ~40 minutes later inside `check fast`:

```
===== FAIL (c-fmt,   rc=1, 158ms) ===== clang-format not found.
===== FAIL (cpp-fmt, rc=1, 260ms) ===== clang-format not found.
check-fast (parallel): 2 of 197 gate(s) FAILED
```

**Same class, one step further in:** a tool the lane needs that `just setup <scope>` does not provision. `check fast` runs `c-fmt`/`cpp-fmt`, and *every* tier runs `check fast`, so clang-format is a host fact every tier asserts — the same argument that put `rust-targets` and `install-corrosion` into `_setup-common`. It goes in the same place.

`setup-clang-format` is idempotent (version-checks `build/clang-format/bin/clang-format` against `.clang-format-version`, exits early) and project-local, so this costs nothing on an already-provisioned host.

## Bounded, not guessed

Rather than fix one tool per CI round-trip, I enumerated the class: exactly **three** gates in the tree tell a user to run a setup recipe —

| recipe | status |
| --- | --- |
| `setup-cli` | already in `_setup-common` |
| `setup-nuttx` | platform-specific, not on the fast line |
| `setup-clang-format` | **the gap** |

Every other tool the fast-line gates probe (`cmake`, `bindgen`, `nm`, `parallel`, `arm-none-eabi-gcc`, …) is baked into the CI image or skip-guarded, and none of them failed in that run.

## Verification

`just check fast` — 197 gates ran, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)