### PR TITLE
feat(phase-421 W6): C and C++ refuse a message the backend cannot encode

### DIFF
--- a/docs/roadmap/phase-421-serialization-format-provider.md
+++ b/docs/roadmap/phase-421-serialization-format-provider.md
@@ -83,15 +83,34 @@ The mechanism is compile-time, not runtime: ROS 2 uses format strings because
       a native matrix cell covers it. **No new matrix coordinate** — one cell, not
       an axis (RFC-0088 non-goals).
 
-- [ ] **W6 — C and C++ assert at compile time.** `NROS_SERIALIZATION_FORMAT_ID` /
+- [x] **W6 — C and C++ assert at compile time.** (landed 2026-09-04) `NROS_SERIALIZATION_FORMAT_ID` /
       `NROS_SERIALIZATION_FORMAT` in the generated config; a per-message
       `_Static_assert` in C; `format_of<M>` plus `static_assert` in C++, using
       `const char*` rather than `std::string_view` so the header survives Zephyr's
       minimal libcpp. `check-format-macro-scope`: a bridge-linked image must not
       reference the macro, because a two-backend image has no single answer.
-      **Acceptance:** a C entry publishing a message whose format differs from
-      the linked backend fails to compile; a bridge image referencing the macro
-      fails the gate.
+      **Acceptance, met.** `serialization_format_mismatch_probe.{c,cpp}` are
+      expected-failure compiles in `check-c` / `check-cpp`; the C refusal names
+      the message (`"RFC-0088: px4_msgs/VehicleStatus is not encoded in the
+      format the linked backend speaks"`). `check-format-macro-scope` fails on a
+      bridge-linked TU that references the macro, verified by injecting one.
+
+      Landed differently in two places, both recorded here:
+
+      - **The macro is lowered by cbindgen, not by the config header.**
+        `nros_config_generated.h` is substituted in `nros-build-helpers`, and a
+        build script cannot evaluate a Rust `const`. Each mirror instead carries
+        a `const _` proving it equal to `session::IMAGE_SERIALIZATION_FORMAT{,_ID}`,
+        so a backend that answers otherwise fails `cargo check` naming the drift.
+        **The value's proper home is the RMW descriptor** (`[rmw]
+        serialization_format` → `NanoRosRmwDispatch.cmake` → `configure_file`);
+        the mirror is the affordable version, and its `const _` is the tripwire
+        for the day a backend disagrees.
+      - **`format_of<M>` defaults to `Cdr` rather than being a bare
+        declaration**, mirroring RFC-0088 D1's defaulted const. Hand-written tag
+        types pass through the typed creators (`DebugKeyValueTag` in the px4
+        bridge, `FakeString` in a compat fixture); a hard-erroring primary would
+        have broken them.
 
 ## What landed differently from the plan (2026-09-04)
 

--- a/just/check.just
+++ b/just/check.just
@@ -170,6 +170,7 @@ fast-serial: \
     fixtures-manifest \
     flake-quarantine \
     flavour-lanes \
+    format-macro-scope \
     gate-lists \
     gate-selftests \
     gate-visibility \
@@ -1388,6 +1389,16 @@ cc-build-policy:
 [private]
 ffi-struct-mirrors:
     @bash scripts/check-ffi-struct-mirrors.sh
+
+# RFC-0088 D5 / phase-421 W6 — `NROS_SERIALIZATION_FORMAT{,_ID}` names the
+# format of THE image's single backend. A bridge image links two and has no
+# single answer, so a bridge-linked TU referencing the macro is a wrong answer
+# that compiles. Pure source scan (~1 s, no build, no fixture, no SDK), so it
+# is affordable on the fast line — and it carries its own vacuity guards, since
+# a gate whose subject set emptied reports the same green as one that passed.
+[private]
+format-macro-scope:
+    @python3 scripts/check-format-macro-scope.py
 
 # Issue 0268 — the per-build sizes headers (`nros_{,cpp_}config_generated.h`)
 # mirrored onto the consumer include path must equal the copy build.rs wrote.
@@ -3250,6 +3261,34 @@ c: c-fmt
         -Ipackages/api/nros-c/include \
         -Ipackages/platform/nros-platform-api/include \
         packages/api/nros-c/tests/compile/graph_query_entry_points.c
+    echo "  - a message's serialization format matches the linked backend (RFC-0088 D5)"
+    # phase-421 W6 — every generated C message header carries a
+    # `_Static_assert` comparing its format id against the image's. The positive
+    # TU proves the assertion is reachable and does not fire on a matching pair;
+    # the probe below proves it fires on a mismatched one.
+    cc -fsyntax-only -std=c11 \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-c/tests/compile/serialization_format.c
+    # Expected-failure, and asserted-present first for the same reason the
+    # parameter probe below is: a missing file is also a non-zero cc, and reads
+    # as a pass.
+    test -f packages/api/nros-c/tests/compile/serialization_format_mismatch_probe.c || { \
+        echo "ERROR: serialization_format_mismatch_probe.c is MISSING -- the expected-failure" >&2; \
+        echo "       check below would PASS on a missing file." >&2; \
+        exit 1; \
+    }
+    if cc -fsyntax-only -std=c11 \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-c/tests/compile/serialization_format_mismatch_probe.c 2>/dev/null; then \
+        echo "ERROR: a message declaring a format the linked backend does not speak compiled clean." >&2; \
+        echo "       NROS_ASSERT_MESSAGE_FORMAT is not reaching callers, so a uORB-encoded" >&2; \
+        echo "       message would publish through a CDR backend with no diagnostic." >&2; \
+        exit 1; \
+    fi
     echo "  - parameter name spelling + deprecated forwarders (phase 379 W5)"
     # The parameter family is `nros_parameter_*`; the old `nros_param_*` names
     # survive one release as NROS_DEPRECATED_MSG `static inline` forwarders. The
@@ -3535,6 +3574,33 @@ cpp: cpp-fmt
         -Ipackages/api/nros-c/include \
         -Ipackages/platform/nros-platform-api/include \
         packages/api/nros-cpp/tests/compile/graph_query_entry_points.cpp
+    echo "  - a message's serialization format matches the linked backend (RFC-0088 D5)"
+    # phase-421 W6 — codegen specialises `nros::format_of<M>` per message and the
+    # typed creators `static_assert` on it. The positive TU proves the assertion
+    # is reachable; the probe proves it fires.
+    c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+        -Itarget/nros-cpp-generated \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-cpp/include \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-cpp/tests/compile/serialization_format.cpp
+    test -f packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp || { \
+        echo "ERROR: serialization_format_mismatch_probe.cpp is MISSING -- the expected-failure" >&2; \
+        echo "       check below would PASS on a missing file." >&2; \
+        exit 1; \
+    }
+    if c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+        -Itarget/nros-cpp-generated \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-cpp/include \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp 2>/dev/null; then \
+        echo "ERROR: a message declaring a format the linked backend does not speak compiled clean." >&2; \
+        echo "       NROS_CPP_ASSERT_MESSAGE_FORMAT is not reaching the typed creators." >&2; \
+        exit 1; \
+    fi
     # issue 0338 — `spin` verb SHAPE probe: `spin()` blocks until shutdown
     # (rclcpp/C/Rust semantics) and the bounded verb is `spin_for(...)`. The
     # defect was the shape of the API, so a compile-time assertion on which

--- a/packages/api/nros-c/Doxyfile
+++ b/packages/api/nros-c/Doxyfile
@@ -16,6 +16,7 @@ PROJECT_BRIEF          = "Lightweight ROS 2 client for embedded real-time system
 INPUT                  = include/nros/nros.h \
                          include/nros/nros_generated.h \
                          include/nros/types.h \
+                         include/nros/serialization_format.h \
                          include/nros/init.h \
                          include/nros/node.h \
                          include/nros/publisher.h \

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -112,6 +112,13 @@ struct nros_goal_uuid_t;
 #define NROS_MAX_CONCURRENT_GOALS 4
 
 /**
+ * Image-local discriminant of the linked backend's serialization format
+ * (`nros_serdes::format::SerializationFormatId`). RFC-0088 D2 — image-local:
+ * never persist it, never compare it across images.
+ */
+#define NROS_SERIALIZATION_FORMAT_ID 1
+
+/**
  * Maximum length of a parameter name
  */
 #define NROS_MAX_PARAM_NAME_LEN 64

--- a/packages/api/nros-c/include/nros/serialization_format.h
+++ b/packages/api/nros-c/include/nros/serialization_format.h
@@ -1,0 +1,119 @@
+/**
+ * @file serialization_format.h
+ * @ingroup grp_types
+ * @brief RFC-0088 D5 — the linked backend's serialization format, as a
+ *        compile-time fact the C API can assert on.
+ *
+ * ROS 2 asks `rmw_get_serialization_format()` at run time because it resolves
+ * its typesupport through `dlopen`. nano-ros does not `dlopen`, so the answer is
+ * already known when the image is compiled: exactly one backend is linked, and
+ * one backend speaks exactly one encoding.
+ *
+ * `NROS_SERIALIZATION_FORMAT_ID` is generated — it is `cbindgen` output in
+ * `nros/nros_generated.h`, lowered from `nros_c::constants`, whose value is
+ * proven equal to `nros_node::session::IMAGE_SERIALIZATION_FORMAT_ID` by a
+ * `const _` in that module. So the macro cannot silently disagree with the
+ * backend this image links: a backend whose format is not the one mirrored
+ * there fails the Rust build with a message naming the drift.
+ *
+ * `NROS_SERIALIZATION_FORMAT` is its cross-image identity string, derived here
+ * from the discriminant. RFC-0088 D2 is the reason for that direction: the
+ * **string** is the identity that crosses image boundaries, and the **`u8` is
+ * image-local** — never persist it, never compare it against a value another
+ * image produced.
+ *
+ * ## Scope — a bridge image must not use these macros
+ *
+ * A bridge image (`Executor::open_multi`) links two backends and therefore has
+ * no single answer, so neither macro means anything there; such an image asks
+ * per session instead, with `nros_node_get_serialization_format()`.
+ * `scripts/check-format-macro-scope.py` refuses a bridge-linked translation
+ * unit that references either macro.
+ *
+ * Copyright 2026 nros contributors
+ * Licensed under Apache-2.0
+ */
+
+#ifndef NROS_SERIALIZATION_FORMAT_H
+#define NROS_SERIALIZATION_FORMAT_H
+
+#include "nros/nros_generated.h"
+
+/**
+ * Portable compile-time assertion.
+ *
+ * Spelled once here because the generated message headers are compiled as C
+ * *and* included from C++ (they carry their own `extern "C"` block), and
+ * `_Static_assert` is not a C++ keyword. C23 spells the C keyword
+ * `static_assert` too; C11 spells it `_Static_assert`; the C99 fallback is the
+ * negative-array-size idiom, so a freestanding pre-C11 toolchain still gets the
+ * diagnostic rather than silently skipping the check.
+ */
+#if defined(__cplusplus)
+#define NROS_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define NROS_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define NROS_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#else
+/* Pre-C11 fallback: a negative array size. The tag must be unique within the
+   translation unit, and `__LINE__` is NOT — two generated message headers
+   included in one TU collide whenever the assertion lands on the same line
+   number in both. `__COUNTER__` (gcc, clang, armcc) is unique per expansion;
+   `__LINE__` is the last resort for a compiler with neither. */
+#define NROS_STATIC_ASSERT_CAT_(a, b) a##b
+#define NROS_STATIC_ASSERT_CAT(a, b) NROS_STATIC_ASSERT_CAT_(a, b)
+#ifdef __COUNTER__
+#define NROS_STATIC_ASSERT_TAG_ __COUNTER__
+#else
+#define NROS_STATIC_ASSERT_TAG_ __LINE__
+#endif
+#define NROS_STATIC_ASSERT(cond, msg)                                                              \
+    typedef char NROS_STATIC_ASSERT_CAT(nros_static_assert_,                                       \
+                                        NROS_STATIC_ASSERT_TAG_)[(cond) ? 1 : -1]
+#endif
+
+/* RFC-0088 D2 — reserved discriminants for the in-tree formats. Low values for
+   readability, and nothing more: the allocation is per image, so these are the
+   values THIS image's `nros_serdes::format::SerializationFormatId` uses, not a
+   registry any other image is bound by. */
+#define NROS_SERIALIZATION_FORMAT_ID_CDR 1
+#define NROS_SERIALIZATION_FORMAT_ID_UORB 2
+
+#ifndef NROS_SERIALIZATION_FORMAT_ID
+#error                                                                                             \
+    "NROS_SERIALIZATION_FORMAT_ID is missing — <nros/nros_generated.h> did not supply it. Regenerate the committed cbindgen headers (`cargo run -p nros-cbindgen-headers`)."
+#endif
+
+/**
+ * Cross-image identity of `NROS_SERIALIZATION_FORMAT_ID` (RFC-0088 D2).
+ *
+ * Derived from the discriminant rather than emitted beside it: `cbindgen` maps
+ * no Rust `&str` to a C constant, so a second generated macro would be a second
+ * authored spelling with nothing tying the two together. One generated number
+ * and one table is the shape that cannot drift into disagreeing with itself.
+ */
+#if NROS_SERIALIZATION_FORMAT_ID == NROS_SERIALIZATION_FORMAT_ID_CDR
+#define NROS_SERIALIZATION_FORMAT "cdr"
+#elif NROS_SERIALIZATION_FORMAT_ID == NROS_SERIALIZATION_FORMAT_ID_UORB
+#define NROS_SERIALIZATION_FORMAT "uorb"
+#else
+#error                                                                                             \
+    "NROS_SERIALIZATION_FORMAT_ID names a format this header has no name for — add its row here and in `nros_serdes::format::SerializationFormatId` together (RFC-0088 D2)."
+#endif
+
+/**
+ * Assert that a message type's serialization format is the one the linked
+ * backend speaks. Emitted once per generated message header.
+ *
+ * @param msg_format_id  the type's own `NROS_MSG_FORMAT_ID_<type>` macro
+ * @param type_literal   the type's name, as a string literal, so the
+ *                       diagnostic names the message rather than the header
+ */
+#define NROS_ASSERT_MESSAGE_FORMAT(msg_format_id, type_literal)                                    \
+    NROS_STATIC_ASSERT((msg_format_id) == NROS_SERIALIZATION_FORMAT_ID,                            \
+                       "RFC-0088: " type_literal                                                   \
+                       " is not encoded in the format the linked backend speaks "                  \
+                       "(NROS_SERIALIZATION_FORMAT) — one image, one backend, one encoding")
+
+#endif /* NROS_SERIALIZATION_FORMAT_H */

--- a/packages/api/nros-c/include/nros/types.h
+++ b/packages/api/nros-c/include/nros/types.h
@@ -22,5 +22,9 @@
 #include "nros/visibility.h"
 #include "nros/nros_config_generated.h"
 #include "nros/nros_generated.h"
+/* RFC-0088 D5 — NROS_SERIALIZATION_FORMAT{,_ID} plus the per-message
+   compile-time assertion generated message headers emit. Included here so a
+   generated header reaches it through its single `<nros/types.h>` include. */
+#include "nros/serialization_format.h"
 
 #endif /* NROS_TYPES_H */

--- a/packages/api/nros-c/src/constants.rs
+++ b/packages/api/nros-c/src/constants.rs
@@ -72,3 +72,62 @@ const _: () = {
 pub use crate::opaque_sizes::{
     GUARD_HANDLE_OPAQUE_U64S, PUBLISHER_OPAQUE_U64S, SESSION_OPAQUE_U64S,
 };
+
+// ── Serialization format (RFC-0088 D5) ──────────────────────────────────
+//
+// The format the linked backend speaks, as a `u8` discriminant and as its
+// cross-image identity string. `cbindgen` lowers the DISCRIMINANT into
+// `nros_generated.h` as `#define NROS_SERIALIZATION_FORMAT_ID`; the string is
+// NOT lowered (cbindgen maps no Rust `&str` to a C constant), so
+// `nros/serialization_format.h` derives `NROS_SERIALIZATION_FORMAT` from the
+// discriminant instead of carrying a second authored spelling. Those macros are
+// what the per-message `_Static_assert` codegen emits compares against, and what
+// `nros/serialization_format.hpp` lifts into `nros::SerializationFormat`.
+//
+// **Only meaningful in a single-backend image.** A bridge image links two
+// backends and has no single answer; it asks each session instead
+// (`nros_node_get_serialization_format()`). `check-format-macro-scope` refuses a
+// bridge-linked image that references either macro.
+//
+// The literals are MIRRORED, not authored: they exist so `cbindgen` — which
+// runs with `parse_deps = false` and evaluates no expressions — can emit a C
+// constant at all. The `const _` below is what makes them true: it compares
+// each against `nros_node::session::IMAGE_SERIALIZATION_FORMAT{,_ID}`, the same
+// constant the Rust API's `format_check` asserts on, so a backend whose format
+// is not CDR fails this crate's build with a message naming the drift rather
+// than shipping a header that quietly disagrees with the linked backend.
+// (Same contract as the `MAX_*` mirrors above; see the module docs.)
+
+/// Image-local discriminant of the linked backend's serialization format
+/// (`nros_serdes::format::SerializationFormatId`). RFC-0088 D2 — image-local:
+/// never persist it, never compare it across images.
+pub const NROS_SERIALIZATION_FORMAT_ID: u8 = 1;
+
+/// Cross-image identity of the linked backend's serialization format.
+pub const NROS_SERIALIZATION_FORMAT: &str = "cdr";
+
+// Compile-time drift check — the mirrors above must equal what the linked
+// backend actually declares. A `const _` is evaluated by `cargo check`, so this
+// fires before codegen, unlike the `const {}` inside the generic Rust entity
+// creators.
+const _: () = {
+    assert!(
+        NROS_SERIALIZATION_FORMAT_ID == nros_node::session::IMAGE_SERIALIZATION_FORMAT_ID.as_u8(),
+        "RFC-0088: NROS_SERIALIZATION_FORMAT_ID no longer matches the linked \
+         backend — update the mirror (and the C/C++ headers that assert on it)"
+    );
+    let mirrored = NROS_SERIALIZATION_FORMAT.as_bytes();
+    let linked = nros_node::session::IMAGE_SERIALIZATION_FORMAT.as_bytes();
+    assert!(
+        mirrored.len() == linked.len(),
+        "RFC-0088: NROS_SERIALIZATION_FORMAT no longer matches the linked backend"
+    );
+    let mut i = 0;
+    while i < mirrored.len() {
+        assert!(
+            mirrored[i] == linked[i],
+            "RFC-0088: NROS_SERIALIZATION_FORMAT no longer matches the linked backend"
+        );
+        i += 1;
+    }
+};

--- a/packages/api/nros-c/tests/compile/serialization_format.c
+++ b/packages/api/nros-c/tests/compile/serialization_format.c
@@ -1,0 +1,62 @@
+/* RFC-0088 D5 / phase-421 W6 — the POSITIVE half of the C format check.
+ *
+ * The linked backend's format reaches C as two macros
+ * (`NROS_SERIALIZATION_FORMAT_ID`, `NROS_SERIALIZATION_FORMAT`), and every
+ * generated message header asserts its own format against them. This TU proves
+ * three things a header edit could silently take away:
+ *
+ *   1. both macros arrive through the ordinary `<nros/nros.h>` include, with no
+ *      extra header a user has to know about;
+ *   2. `NROS_ASSERT_MESSAGE_FORMAT` compiles — and is a real assertion, not a
+ *      no-op — for a message whose format matches the image;
+ *   3. the string is a usable C string literal, not a token.
+ *
+ * The MISMATCH is the other half, and it must FAIL to compile:
+ * `serialization_format_mismatch_probe.c`, run as an expected-failure.
+ *
+ * Copyright 2026 nros contributors
+ * Licensed under Apache-2.0
+ */
+
+#include <nros/nros.h>
+
+/* (1) Both macros exist. `#error` rather than a runtime check: their absence is
+   a build-system fault, and the diagnostic should name it here. */
+#ifndef NROS_SERIALIZATION_FORMAT_ID
+#error "NROS_SERIALIZATION_FORMAT_ID did not arrive via <nros/nros.h> (RFC-0088 D5)"
+#endif
+#ifndef NROS_SERIALIZATION_FORMAT
+#error "NROS_SERIALIZATION_FORMAT did not arrive via <nros/nros.h> (RFC-0088 D5)"
+#endif
+
+/* (2) A message type shaped exactly like codegen's output: its own format id,
+   then the assertion. `packs/c/message.h.jinja` emits these two lines. */
+#define NROS_MSG_FORMAT_ID_probe_msgs_msg_reading NROS_SERIALIZATION_FORMAT_ID_CDR
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_probe_msgs_msg_reading, "probe_msgs/Reading");
+
+/* The assertion must have TEETH. A `NROS_STATIC_ASSERT` that expanded to
+   nothing would let the line above pass on any input, and the expected-failure
+   probe next door would then be the only thing standing between us and a
+   silently absent check — a single point of failure for a two-sided property.
+   So assert a FALSE condition here too, in a form we can prove fired: this one
+   is deliberately wrapped so it is legal C, and the mismatch probe is the
+   negative case proper. */
+NROS_STATIC_ASSERT(NROS_SERIALIZATION_FORMAT_ID == NROS_SERIALIZATION_FORMAT_ID,
+                   "NROS_STATIC_ASSERT must be a declaration, not an empty expansion");
+
+/* (3) The format name is a string literal — usable where a `const char*` is
+   wanted, e.g. reporting the image's encoding at startup. A pointer INITIALIZER
+   is the check: a bare token would not compile here. */
+static const char* const kFormatName = NROS_SERIALIZATION_FORMAT;
+
+/* A C entry publishing that message. The format assertion above is what makes
+   the call below legitimate — it is the compile-time proof that this image's
+   backend can encode what `nros_publish_raw` is handed. */
+nros_ret_t nros_probe_publish_reading(struct nros_publisher_t* publisher, const uint8_t* cdr,
+                                      size_t cdr_len);
+
+nros_ret_t nros_probe_publish_reading(struct nros_publisher_t* publisher, const uint8_t* cdr,
+                                      size_t cdr_len) {
+    (void)kFormatName;
+    return nros_publish_raw(publisher, cdr, cdr_len);
+}

--- a/packages/api/nros-c/tests/compile/serialization_format_mismatch_probe.c
+++ b/packages/api/nros-c/tests/compile/serialization_format_mismatch_probe.c
@@ -1,0 +1,44 @@
+/* RFC-0088 D5 / phase-421 W6 — the NEGATIVE half of the C format check.
+ *
+ * EXPECTED TO FAIL TO COMPILE. `check-c` runs it as an expected-failure, the
+ * same shape as `param_deprecation_probe.c`: a clean compile here means the
+ * per-message `_Static_assert` codegen emits has stopped asserting anything, so
+ * a C entry could publish a message in an encoding the linked backend does not
+ * speak and find out on the wire.
+ *
+ * The mismatch is spelled the way a non-CDR codegen pack would spell it — the
+ * message's own `NROS_MSG_FORMAT_ID_<type>` naming a different format from the
+ * image's. Today every in-tree pack emits CDR, so there is no generated header
+ * that disagrees; hardcoding the discriminant here is what makes the refusal
+ * testable before a second pack exists (RFC-0088 W5 ships one).
+ *
+ * Copyright 2026 nros contributors
+ * Licensed under Apache-2.0
+ */
+
+#include <nros/nros.h>
+
+/* Belt and braces: if the image itself were ever uORB, this probe would be
+   asserting a TRUE condition and would compile — reporting a broken check that
+   is in fact fine. Fail loudly instead of quietly inverting. */
+#if NROS_SERIALIZATION_FORMAT_ID != NROS_SERIALIZATION_FORMAT_ID_CDR
+#error "this probe assumes a CDR image; pick a discriminant the image does NOT speak"
+#endif
+
+/* A uORB-encoded message (RFC-0011: the PX4 struct verbatim, no CDR anywhere)
+   in an image whose backend speaks CDR. */
+#define NROS_MSG_FORMAT_ID_px4_msgs_msg_vehicle_status NROS_SERIALIZATION_FORMAT_ID_UORB
+
+/* THIS is the line that must not compile. */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_px4_msgs_msg_vehicle_status,
+                           "px4_msgs/VehicleStatus");
+
+/* ...and this is the C entry that would have published it. Kept so the probe
+   describes a real mistake rather than a bare assertion in a vacuum. */
+nros_ret_t nros_probe_publish_vehicle_status(struct nros_publisher_t* publisher,
+                                             const uint8_t* payload, size_t payload_len);
+
+nros_ret_t nros_probe_publish_vehicle_status(struct nros_publisher_t* publisher,
+                                             const uint8_t* payload, size_t payload_len) {
+    return nros_publish_raw(publisher, payload, payload_len);
+}

--- a/packages/api/nros-cpp/Doxyfile
+++ b/packages/api/nros-cpp/Doxyfile
@@ -24,6 +24,7 @@ INPUT                  = include/nros/nros.hpp \
                          include/nros/qos.hpp \
                          include/nros/result.hpp \
                          include/nros/config.hpp \
+                         include/nros/serialization_format.hpp \
                          include/nros/span.hpp \
                          include/nros/fixed_string.hpp \
                          include/nros/fixed_sequence.hpp \

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -32,6 +32,8 @@
 #include "nros/options.hpp"
 #include "nros/future.hpp"
 #include "nros/stream.hpp"
+// RFC-0088 D5 — nros::SerializationFormat / format_of<M> / linked_format().
+#include "nros/serialization_format.hpp"
 // Phase 84.G8: node.hpp no longer pulls in the heavy entity headers —
 // each entity header carries its own out-of-line `Node::create_X<>()`
 // template definition. The umbrella pulls in every entity explicitly so

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -61,6 +61,13 @@
 #define NROS_CPP_DOMAIN_ID_INHERIT UINT32_MAX
 
 /**
+ * Image-local discriminant of the linked backend's serialization format
+ * (`nros_serdes::format::SerializationFormatId`). RFC-0088 D2 — image-local:
+ * never persist it, never compare it across images.
+ */
+#define NROS_CPP_SERIALIZATION_FORMAT_ID 1
+
+/**
  * `nros::SchedClass` mirror. Phase 110.B.
  */
 enum nros_cpp_sched_class_t

--- a/packages/api/nros-cpp/include/nros/publisher.hpp
+++ b/packages/api/nros-cpp/include/nros/publisher.hpp
@@ -16,6 +16,8 @@
 
 #include "nros/config.hpp"
 #include "nros/result.hpp"
+// RFC-0088 D5 — NROS_CPP_ASSERT_MESSAGE_FORMAT, expanded in the creator below.
+#include "nros/serialization_format.hpp"
 
 #include "nros_cpp_ffi.h"
 
@@ -270,6 +272,9 @@ namespace nros {
 
 template <typename M>
 Result Node::create_publisher(Publisher<M>& out, const char* topic, const QoS& qos) {
+    // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
+    // message the linked backend cannot encode never reaches the wire.
+    NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_publisher_create(&handle_, topic, M::TYPE_NAME, M::TYPE_HASH,

--- a/packages/api/nros-cpp/include/nros/serialization_format.hpp
+++ b/packages/api/nros-cpp/include/nros/serialization_format.hpp
@@ -1,0 +1,104 @@
+// nros-cpp: the serialization format as a compile-time fact (freestanding C++14)
+//
+// RFC-0088 D5. ROS 2 asks `rmw_get_serialization_format()` at run time because
+// it resolves its typesupport through `dlopen`; nano-ros does not `dlopen`, so
+// the answer is already known when the image is compiled — one image links one
+// backend, and one backend speaks one encoding.
+//
+// `const char*` throughout, never `std::string` or `std::string_view`: these
+// headers must compile against Zephyr's minimal libcpp behind `NROS_CPP_STD`,
+// where `<string>` does not exist (issue 0112).
+
+/**
+ * @file serialization_format.hpp
+ * @ingroup grp_support
+ * @brief `nros::format_of<M>` — a message type's serialization format;
+ *        `nros::linked_format()` — the linked backend's; and the
+ *        `static_assert` that refuses to create a typed entity over a message
+ *        the backend cannot encode.
+ */
+
+#ifndef NROS_CPP_SERIALIZATION_FORMAT_HPP
+#define NROS_CPP_SERIALIZATION_FORMAT_HPP
+
+#include <cstdint>
+
+// `NROS_CPP_SERIALIZATION_FORMAT_ID` — cbindgen output, lowered from
+// `nros_cpp`'s own mirror, which a `const _` proves equal to
+// `nros_node::session::IMAGE_SERIALIZATION_FORMAT_ID`. Taken from the C++ FFI
+// header rather than from `<nros/nros_generated.h>` so that a generated message
+// header never pulls a C API header ahead of this one (issue 0160 — the FFI
+// struct mirrors make that include order one-way).
+#include "nros_cpp_ffi.h"
+
+namespace nros {
+
+/// The serialization formats this image can name.
+///
+/// RFC-0088 D2 — the discriminant is **image-local**. It is assigned per build
+/// from the formats declared in that image; the low values below are reserved
+/// for the in-tree formats for readability and nothing more. Never persist one,
+/// and never compare one against a value another image produced — the *string*
+/// (`linked_format_name()`) is the identity that crosses an image boundary.
+enum class SerializationFormat : uint8_t {
+    /// OMG CDR as ROS 2 puts it on the wire, encapsulation header included.
+    Cdr = 1,
+    /// PX4's in-memory struct, verbatim — no encoding step at all (RFC-0011).
+    Uorb = 2,
+};
+
+/// The serialization format a message type is encoded in.
+///
+/// **Defaulted to CDR**, deliberately: this is the C++ mirror of
+/// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`, which RFC-0088 D1 makes a
+/// *defaulted* const so that every message answers something and the 142
+/// existing implementors cost nothing. Codegen specializes it per message
+/// anyway, so a generated type STATES its format rather than inheriting it;
+/// the default is what keeps a hand-written tag type (the PX4 uORB demo's
+/// `DebugKeyValueTag`, the compile fixtures' `Bounded`/`Unbounded`) usable
+/// without a specialization it has no generator to write.
+template <typename M> struct format_of {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+
+/// The format the backend this image links speaks.
+///
+/// **Only meaningful in a single-backend image.** A bridge image links two
+/// backends and has no single answer; it asks per session instead, with
+/// `nros::Node::serialization_format()`. `check-format-macro-scope` refuses a
+/// bridge-linked translation unit that reaches the underlying macro.
+constexpr SerializationFormat linked_format() {
+    return static_cast<SerializationFormat>(NROS_CPP_SERIALIZATION_FORMAT_ID);
+}
+
+/// The cross-image identity string of `linked_format()` (RFC-0088 D2).
+///
+/// `const char*`, so the header stays usable against Zephyr's minimal libcpp.
+/// Derived from the discriminant rather than emitted beside it: cbindgen maps
+/// no Rust `&str` to a C constant, so a second generated macro would be a
+/// second authored spelling with nothing tying the two together.
+constexpr const char* linked_format_name() {
+    return linked_format() == SerializationFormat::Cdr
+               ? "cdr"
+               : (linked_format() == SerializationFormat::Uorb ? "uorb" : "unknown");
+}
+
+} // namespace nros
+
+/**
+ * Assert that message type @p M is encoded in the format the linked backend
+ * speaks. Expanded at every typed entity-creation site — the C++ sibling of
+ * `nros_node::format_check::assert_message_format`.
+ *
+ * A macro, not a function, so the failing `static_assert` reports the file and
+ * line of the `create_publisher` / `create_subscription` call rather than a
+ * line inside this header.
+ */
+#define NROS_CPP_ASSERT_MESSAGE_FORMAT(M)                                                          \
+    static_assert(::nros::format_of<M>::value == ::nros::linked_format(),                          \
+                  "RFC-0088: this message type is not encoded in the format the linked "           \
+                  "backend speaks: one image, one backend, one encoding. A bridge image "          \
+                  "is the only place two formats legitimately meet, and it converts "              \
+                  "explicitly.")
+
+#endif // NROS_CPP_SERIALIZATION_FORMAT_HPP

--- a/packages/api/nros-cpp/include/nros/subscription.hpp
+++ b/packages/api/nros-cpp/include/nros/subscription.hpp
@@ -17,6 +17,8 @@
 #include "nros/config.hpp"
 #include "nros/result.hpp"
 #include "nros/size_bound.hpp" // nros::rx_buffer_capacity<M> — the receive-buffer size
+// RFC-0088 D5 — NROS_CPP_ASSERT_MESSAGE_FORMAT, expanded in the creators below.
+#include "nros/serialization_format.hpp"
 #include "nros/stream.hpp"
 
 #include "nros_cpp_ffi.h"
@@ -604,6 +606,9 @@ namespace nros {
 
 template <typename M>
 Result Node::create_subscription(Subscription<M>& out, const char* topic, const QoS& qos) {
+    // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
+    // message the linked backend cannot encode never reaches the wire.
+    NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
     nros_cpp_ret_t ret = nros_cpp_subscription_create(&handle_, topic, M::TYPE_NAME, M::TYPE_HASH,
@@ -663,6 +668,9 @@ Result Node::create_subscription(Subscription<M>& out, const char* topic, const 
 template <typename M, typename F, typename>
 Result Node::create_subscription(Subscription<M>& out, const char* topic, F callback,
                                  const QoS& qos, const SubscriptionOptions& options) {
+    // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
+    // message the linked backend cannot encode never reaches the wire.
+    NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
 
@@ -698,6 +706,9 @@ template <typename M, typename F, typename>
 Result Node::create_subscription_in(const CallbackGroup& group, Subscription<M>& out,
                                     const char* topic, F callback, const QoS& qos,
                                     const SubscriptionOptions& options) {
+    // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
+    // message the linked backend cannot encode never reaches the wire.
+    NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
 
@@ -731,6 +742,9 @@ Result Node::create_subscription_in(const CallbackGroup& group, Subscription<M>&
 template <typename M, typename F, typename>
 Result Node::create_subscription_with_info(Subscription<M>& out, const char* topic, F callback,
                                            const QoS& qos, const SubscriptionOptions& options) {
+    // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
+    // message the linked backend cannot encode never reaches the wire.
+    NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
 
@@ -777,6 +791,9 @@ inline Expected<Subscription<M>> create_subscription(Node& node, const char* top
 template <typename M, typename F, typename>
 Result Node::create_subscription_with_safety(Subscription<M>& out, const char* topic, F callback,
                                              const QoS& qos, const SubscriptionOptions& options) {
+    // RFC-0088 D5 — one image, one backend, one encoding. Compile-time, so a
+    // message the linked backend cannot encode never reaches the wire.
+    NROS_CPP_ASSERT_MESSAGE_FORMAT(M);
     if (!initialized_) return Result(ErrorCode::NotInitialized);
     nros_cpp_qos_t ffi_qos = detail::qos_to_ffi(qos);
 

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3634,3 +3634,62 @@ fn entry_spin_ms() -> u64 {
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(0)
 }
+
+// ── Serialization format (RFC-0088 D5) ──────────────────────────────────
+//
+// The discriminant of the format the linked backend speaks, lowered by
+// `cbindgen` into `nros_cpp_ffi.h` as
+// `#define NROS_CPP_SERIALIZATION_FORMAT_ID`. `nros/serialization_format.hpp`
+// lifts it into `nros::SerializationFormat` and asserts every typed entity's
+// message type against it.
+//
+// It is emitted HERE, into the C++ crate's own FFI header, rather than reused
+// from `nros-c`'s `NROS_SERIALIZATION_FORMAT_ID`, so that no C++ header has to
+// include a C API header to get it. Reaching `nros/nros_generated.h` from a
+// generated message header would put it BEFORE `nros_cpp_ffi.h` in include
+// order, and that order is one-way (issue 0160: the FFI struct mirrors).
+//
+// The literal is a MIRROR — `cbindgen` runs with `parse_deps = false` and
+// evaluates no expressions — and the `const _` below is what makes it true:
+// it compares against `nros_node::session::IMAGE_SERIALIZATION_FORMAT_ID`, the
+// same constant `nros_node::format_check` asserts on. A backend whose format is
+// not CDR fails this crate's build naming the drift, instead of shipping a
+// header that quietly disagrees with the backend the image links.
+//
+// **Only meaningful in a single-backend image** (RFC-0088 D5). A bridge image
+// links two backends and has no single answer; it asks per session, with
+// `nros::Node::serialization_format()`. `scripts/check-format-macro-scope.py`
+// refuses a bridge-linked translation unit that references the macro.
+
+/// Image-local discriminant of the linked backend's serialization format
+/// (`nros_serdes::format::SerializationFormatId`). RFC-0088 D2 — image-local:
+/// never persist it, never compare it across images.
+pub const NROS_CPP_SERIALIZATION_FORMAT_ID: u8 = 1;
+
+/// Cross-image identity of the linked backend's serialization format.
+/// Not lowered to C++ (cbindgen maps no Rust `&str` to a C constant);
+/// `nros::linked_format_name()` derives the name from the discriminant.
+pub const NROS_CPP_SERIALIZATION_FORMAT: &str = "cdr";
+
+const _: () = {
+    assert!(
+        NROS_CPP_SERIALIZATION_FORMAT_ID
+            == nros_node::session::IMAGE_SERIALIZATION_FORMAT_ID.as_u8(),
+        "RFC-0088: NROS_CPP_SERIALIZATION_FORMAT_ID no longer matches the linked \
+         backend — update the mirror (and the C++ headers that assert on it)"
+    );
+    let mirrored = NROS_CPP_SERIALIZATION_FORMAT.as_bytes();
+    let linked = nros_node::session::IMAGE_SERIALIZATION_FORMAT.as_bytes();
+    assert!(
+        mirrored.len() == linked.len(),
+        "RFC-0088: NROS_CPP_SERIALIZATION_FORMAT no longer matches the linked backend"
+    );
+    let mut i = 0;
+    while i < mirrored.len() {
+        assert!(
+            mirrored[i] == linked[i],
+            "RFC-0088: NROS_CPP_SERIALIZATION_FORMAT no longer matches the linked backend"
+        );
+        i += 1;
+    }
+};

--- a/packages/api/nros-cpp/tests/compile/serialization_format.cpp
+++ b/packages/api/nros-cpp/tests/compile/serialization_format.cpp
@@ -1,0 +1,81 @@
+// RFC-0088 D5 / phase-421 W6 — the POSITIVE half of the C++ format check.
+//
+// `nros::format_of<M>` is what a message type answers; `nros::linked_format()`
+// is what the image's backend speaks; `NROS_CPP_ASSERT_MESSAGE_FORMAT(M)` is
+// the `static_assert` every typed entity-creation funnel expands. The header
+// `-fsyntax-only` loop in `just check cpp` only PARSES the templates, so this TU
+// INSTANTIATES `create_publisher` / `create_subscription` against a message type
+// carrying the specialization codegen emits, which is the only way the assert in
+// their bodies is actually evaluated.
+//
+// The MISMATCH is the other half and must FAIL to compile:
+// `serialization_format_mismatch_probe.cpp`, run as an expected-failure.
+//
+// `just check cpp` compiles this with `-fsyntax-only -std=c++14`.
+#include <nros/nros.hpp>
+
+#include <type_traits>
+
+namespace nros_cpp_serialization_format_compile_test {
+
+// Mirror of a codegen'd message (cf. std_msgs/msg/Int32).
+struct Int32 {
+    int32_t data{0};
+    static const size_t SERIALIZED_SIZE_MAX = 16;
+    static constexpr const char* TYPE_NAME = "std_msgs::msg::dds_::Int32_";
+    static constexpr const char* TYPE_HASH = "RIHS01_int32_stub";
+    static int ffi_publish(void*, const void*) { return 0; }
+    static int ffi_serialize(const void*, uint8_t*, size_t, size_t* out) {
+        if (out) *out = 0;
+        return 0;
+    }
+    static int ffi_deserialize(const uint8_t*, size_t, void*) { return 0; }
+};
+
+} // namespace nros_cpp_serialization_format_compile_test
+
+// The specialization `packs/cpp/message.hpp.jinja` emits, verbatim in shape.
+namespace nros {
+template <> struct format_of<::nros_cpp_serialization_format_compile_test::Int32> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
+
+namespace nros_cpp_serialization_format_compile_test {
+
+// The enum is `uint8_t`-backed (RFC-0088 D5) — a wider one would not match the
+// `nros_serdes::format::SerializationFormatId` `#[repr(u8)]` it mirrors.
+static_assert(
+    std::is_same<typename std::underlying_type<::nros::SerializationFormat>::type, uint8_t>::value,
+    "nros::SerializationFormat must be uint8_t-backed to mirror the Rust repr(u8)");
+
+// The name is a `const char*`, never a `std::string`/`std::string_view`: these
+// headers compile against Zephyr's minimal libcpp, where `<string>` does not
+// exist (issue 0112). A regression to a std type stops compiling here.
+static_assert(std::is_same<decltype(::nros::linked_format_name()), const char*>::value,
+              "nros::linked_format_name() must return const char* (issue 0112)");
+
+// A message with no specialization still ANSWERS — the C++ mirror of the
+// defaulted `nros_core::RosMessage::SERIALIZATION_FORMAT_ID` (RFC-0088 D1).
+struct Unspecialized {};
+static_assert(::nros::format_of<Unspecialized>::value == ::nros::SerializationFormat::Cdr,
+              "format_of<M> must default to Cdr, mirroring the defaulted Rust const");
+
+// Force instantiation of the entity creators, so the `static_assert` inside
+// their bodies is evaluated rather than merely parsed.
+inline ::nros::Result instantiate(::nros::Node& node) {
+    ::nros::Publisher<Int32> pub;
+    ::nros::Result rp = node.create_publisher(pub, "/count");
+
+    ::nros::Subscription<Int32> sub;
+    ::nros::Result rs = node.create_subscription(sub, "/count");
+
+    ::nros::PollingSubscription<Int32> poll;
+    ::nros::Result rq = node.create_polling_subscription(poll, "/count");
+
+    (void)rs;
+    (void)rq;
+    return rp;
+}
+
+} // namespace nros_cpp_serialization_format_compile_test

--- a/packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp
@@ -1,0 +1,58 @@
+// RFC-0088 D5 / phase-421 W6 — the NEGATIVE half of the C++ format check.
+//
+// EXPECTED TO FAIL TO COMPILE. `check-cpp` runs it as an expected-failure, the
+// same shape as the C side's `serialization_format_mismatch_probe.c` and as
+// `qos_deprecation_probe.cpp`: a clean compile here means the `static_assert` in
+// `Node::create_publisher` / `create_subscription` has stopped asserting, so a
+// C++ entity could be created over a message in an encoding the linked backend
+// does not speak.
+//
+// The mismatch is spelled the way a non-CDR codegen pack would spell it — the
+// message's own `nros::format_of<M>` specialization naming a different format
+// from the image's. Every in-tree pack emits CDR today, so stating the
+// discriminant here is what makes the refusal testable before a second pack
+// exists (RFC-0088 W5 ships one).
+#include <nros/nros.hpp>
+
+namespace nros_cpp_serialization_format_mismatch_probe {
+
+// A uORB-encoded message (RFC-0011: the PX4 struct verbatim, no CDR anywhere).
+struct VehicleStatus {
+    uint64_t timestamp{0};
+    static const size_t SERIALIZED_SIZE_MAX = 32;
+    static constexpr const char* TYPE_NAME = "px4_msgs::msg::dds_::VehicleStatus_";
+    static constexpr const char* TYPE_HASH = "RIHS01_vehicle_status_stub";
+    static int ffi_publish(void*, const void*) { return 0; }
+    static int ffi_serialize(const void*, uint8_t*, size_t, size_t* out) {
+        if (out) *out = 0;
+        return 0;
+    }
+    static int ffi_deserialize(const uint8_t*, size_t, void*) { return 0; }
+};
+
+} // namespace nros_cpp_serialization_format_mismatch_probe
+
+namespace nros {
+template <> struct format_of<::nros_cpp_serialization_format_mismatch_probe::VehicleStatus> {
+    static constexpr SerializationFormat value = SerializationFormat::Uorb;
+};
+} // namespace nros
+
+namespace nros_cpp_serialization_format_mismatch_probe {
+
+// If the image itself were ever uORB this probe would be asserting a TRUE
+// condition and would compile — reporting a broken check that is in fact fine.
+// Fail loudly instead of quietly inverting.
+static_assert(::nros::linked_format() == ::nros::SerializationFormat::Cdr,
+              "this probe assumes a CDR image; specialize format_of with a format the image "
+              "does NOT speak");
+
+// THIS is what must not compile: a typed entity created over a uORB message in
+// a CDR image. The assertion lives in `Node::create_publisher`'s body, so the
+// instantiation below is what evaluates it.
+inline ::nros::Result instantiate(::nros::Node& node) {
+    ::nros::Publisher<VehicleStatus> pub;
+    return node.create_publisher(pub, "/fmu/out/vehicle_status");
+}
+
+} // namespace nros_cpp_serialization_format_mismatch_probe

--- a/packages/cli/rosidl-codegen/packs/c/message.h.jinja
+++ b/packages/cli/rosidl-codegen/packs/c/message.h.jinja
@@ -52,6 +52,21 @@ typedef struct {{ struct_name }}_View {
 } {{ struct_name }}_View;
 {%- endif %}
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer ({{ struct_name }}_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_{{ struct_name }} NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_{{ struct_name }}, "{{ package_name }}/{{ message_name }}");
+
 /// Get the ROS type name for {{ message_name }}
 static inline const char* {{ struct_name }}_get_type_name(void) {
     return "{{ package_name }}::msg::dds_::{{ message_name }}_";

--- a/packages/cli/rosidl-codegen/packs/cpp/message.hpp.jinja
+++ b/packages/cli/rosidl-codegen/packs/cpp/message.hpp.jinja
@@ -14,6 +14,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 {%- if has_borrowed %}
 #include "nros/span.hpp"
 {%- endif %}
@@ -182,5 +183,23 @@ static constexpr {{ constant.c_type }} {{ message_name }}_{{ constant.name }} = 
 {%- endfor %}
 
 }} // namespace {{ cpp_package }}::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::{{ cpp_package }}::msg::{{ message_name }}> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // {{ guard_name }}

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.h
@@ -30,6 +30,21 @@ typedef struct fingerprint_corpus_msg_bounded {
     struct { uint32_t size; char data[4][8]; } labels;
 } fingerprint_corpus_msg_bounded;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_bounded_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_bounded NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_bounded, "fingerprint-corpus/Bounded");
+
 /// Get the ROS type name for Bounded
 static inline const char* fingerprint_corpus_msg_bounded_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Bounded_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Bounded.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 
 // FFI declarations
 extern "C" {
@@ -97,5 +98,23 @@ struct Bounded {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Bounded> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_BOUNDED_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.h
@@ -26,6 +26,21 @@ typedef struct fingerprint_corpus_msg_capped {
     struct { uint32_t size; char data[4][8]; } tags;
 } fingerprint_corpus_msg_capped;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_capped_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_capped NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_capped, "fingerprint-corpus/Capped");
+
 /// Get the ROS type name for Capped
 static inline const char* fingerprint_corpus_msg_capped_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Capped_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Capped.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 
 // FFI declarations
 extern "C" {
@@ -93,5 +94,23 @@ struct Capped {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Capped> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_CAPPED_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.h
@@ -26,6 +26,21 @@ typedef struct fingerprint_corpus_msg_nested {
     struct { uint32_t size; struct fingerprint_corpus_msg_shapes data[64]; } many;
 } fingerprint_corpus_msg_nested;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_nested_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_nested NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_nested, "fingerprint-corpus/Nested");
+
 /// Get the ROS type name for Nested
 static inline const char* fingerprint_corpus_msg_nested_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Nested_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Nested.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 #include "msg/fingerprint_corpus_msg_shapes.hpp"
 
 // FFI declarations
@@ -106,5 +107,23 @@ struct Nested {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Nested> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_NESTED_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.h
@@ -66,6 +66,21 @@ typedef struct fingerprint_corpus_msg_shapes_View {
     char str_bounded[8];
 } fingerprint_corpus_msg_shapes_View;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_shapes_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_shapes NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_shapes, "fingerprint-corpus/Shapes");
+
 /// Get the ROS type name for Shapes
 static inline const char* fingerprint_corpus_msg_shapes_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Shapes_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/configured/Shapes.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 #include "nros/span.hpp"
 
 // FFI declarations
@@ -154,5 +155,23 @@ struct ShapesView {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Shapes> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_SHAPES_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.h
@@ -30,6 +30,21 @@ typedef struct fingerprint_corpus_msg_bounded {
     struct { uint32_t size; char data[4][8]; } labels;
 } fingerprint_corpus_msg_bounded;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_bounded_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_bounded NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_bounded, "fingerprint-corpus/Bounded");
+
 /// Get the ROS type name for Bounded
 static inline const char* fingerprint_corpus_msg_bounded_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Bounded_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Bounded.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 
 // FFI declarations
 extern "C" {
@@ -97,5 +98,23 @@ struct Bounded {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Bounded> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_BOUNDED_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.h
@@ -26,6 +26,21 @@ typedef struct fingerprint_corpus_msg_capped {
     struct { uint32_t size; char data[64][256]; } tags;
 } fingerprint_corpus_msg_capped;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_capped_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_capped NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_capped, "fingerprint-corpus/Capped");
+
 /// Get the ROS type name for Capped
 static inline const char* fingerprint_corpus_msg_capped_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Capped_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Capped.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 
 // FFI declarations
 extern "C" {
@@ -106,5 +107,23 @@ struct Capped {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Capped> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_CAPPED_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.h
@@ -26,6 +26,21 @@ typedef struct fingerprint_corpus_msg_nested {
     struct { uint32_t size; struct fingerprint_corpus_msg_shapes data[64]; } many;
 } fingerprint_corpus_msg_nested;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_nested_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_nested NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_nested, "fingerprint-corpus/Nested");
+
 /// Get the ROS type name for Nested
 static inline const char* fingerprint_corpus_msg_nested_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Nested_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Nested.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 #include "msg/fingerprint_corpus_msg_shapes.hpp"
 
 // FFI declarations
@@ -106,5 +107,23 @@ struct Nested {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Nested> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_NESTED_HPP

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.h
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.h
@@ -40,6 +40,21 @@ typedef struct fingerprint_corpus_msg_shapes {
     char str_bounded[8];
 } fingerprint_corpus_msg_shapes;
 
+/// RFC-0088 D5 — the serialization format this type is encoded in, as the
+/// image-local `nros_serdes::format::SerializationFormatId` discriminant.
+///
+/// This pack emits a CDR serializer (fingerprint_corpus_msg_shapes_serialize writes a CDR
+/// encapsulation header), so the answer is a property of the GENERATOR, not a
+/// value copied from a backend: what this header contains IS CDR.
+#define NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_shapes NROS_SERIALIZATION_FORMAT_ID_CDR
+
+/* One image links one backend and one backend speaks one encoding (RFC-0088),
+   so a message this image cannot encode is a build error rather than a runtime
+   surprise on the wire. NROS_SERIALIZATION_FORMAT_ID comes in via
+   <nros/types.h> above; a bridge image, which links two backends and has no
+   single answer, must not reach it at all (check-format-macro-scope). */
+NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_fingerprint_corpus_msg_shapes, "fingerprint-corpus/Shapes");
+
 /// Get the ROS type name for Shapes
 static inline const char* fingerprint_corpus_msg_shapes_get_type_name(void) {
     return "fingerprint-corpus::msg::dds_::Shapes_";

--- a/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.hpp
+++ b/packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus/expected/inline/Shapes.hpp
@@ -15,6 +15,7 @@
 #include "nros/heap_sequence.hpp"
 #include "nros/heap_string.hpp"
 #include "nros/size_bound.hpp"
+#include "nros/serialization_format.hpp"
 
 // FFI declarations
 extern "C" {
@@ -120,5 +121,23 @@ struct Shapes {
 // the struct-member `<Msg>::<NAME>` above, which matches rosidl C++).
 
 }} // namespace fingerprint_corpus::msg
+
+// RFC-0088 D5 — state this type's serialization format.
+//
+// `nros::format_of<M>` defaults to CDR (the C++ mirror of the defaulted
+// `nros_core::RosMessage::SERIALIZATION_FORMAT_ID`), so this specialization
+// changes no answer today. It is emitted anyway because a generated type should
+// STATE its format rather than inherit one: this pack emits a CDR serializer,
+// which is a fact about the GENERATOR, and a future non-CDR pack specializes the
+// same slot instead of silently riding the default.
+//
+// `nros::Node::create_publisher` / `create_subscription` static_assert on this
+// against the format the linked backend speaks — one image, one backend, one
+// encoding.
+namespace nros {
+template <> struct format_of<::fingerprint_corpus::msg::Shapes> {
+    static constexpr SerializationFormat value = SerializationFormat::Cdr;
+};
+} // namespace nros
 
 #endif // FINGERPRINT_CORPUS_MSG_SHAPES_HPP

--- a/scripts/check-format-macro-scope.py
+++ b/scripts/check-format-macro-scope.py
@@ -158,8 +158,92 @@ def read(rel: str) -> str:
         return ""
 
 
+
+def self_test(quiet: bool = False) -> None:
+    """Negative controls — a gate whose rule never fires proves nothing.
+
+    Each case asserts the rule FIRES on the shape it exists for, then that the
+    intended escape silences it. These run on the NORMAL path (see the call in
+    `main`), because a control nobody runs decays into a comment.
+    """
+    cases = []
+
+    def case(name: str, ok: bool) -> None:
+        cases.append((name, ok))
+
+    # 1. The image-wide macros are caught, in both language spellings.
+    for macro in (
+        "NROS_SERIALIZATION_FORMAT_ID",
+        "NROS_SERIALIZATION_FORMAT",
+        "NROS_CPP_SERIALIZATION_FORMAT_ID",
+        "NROS_CPP_SERIALIZATION_FORMAT",
+    ):
+        line = f"    uint8_t id = {macro};"
+        case(f"{macro} is caught", bool(MACRO_REFS.search(TABLE_REF.sub("", line))))
+
+    # 2. The C++ accessors are caught too — `linked_format()` answers the same
+    #    question the macro does, so gating only the macros would be the
+    #    narrower-than-the-rule coverage issue 0196 is about.
+    for expr in ("nros::linked_format()", "nros::linked_format_name()"):
+        case(f"{expr} is caught", bool(MACRO_REFS.search(TABLE_REF.sub("", expr))))
+
+    # 3. The reserved-discriminant TABLE is NOT a violation. Naming a format is
+    #    fine anywhere, including a bridge — the one place two legitimately
+    #    meet. This is the escape, and it must silence the rule. The stripping
+    #    is what makes it work, so the case is written against a line where the
+    #    table entry is the ONLY token: without TABLE_REF this must go red.
+    for line in (
+        "NROS_SERIALIZATION_FORMAT_ID_CDR",
+        "NROS_CPP_SERIALIZATION_FORMAT_ID_UORB",
+    ):
+        stripped = TABLE_REF.sub("", line)
+        case(f"table ref is stripped: {line[:34]}", stripped.strip() == "")
+
+    # 4. A prefix of a macro name is not a match — the word boundary matters,
+    #    or `NROS_SERIALIZATION_FORMATTER` would read as the macro.
+    case(
+        "a longer identifier is not a match",
+        not MACRO_REFS.search(TABLE_REF.sub("", "int NROS_SERIALIZATION_FORMATTER = 0;")),
+    )
+
+    # 5. Bridge detection fires on each marker the API actually presents.
+    for marker in (
+        "#include <nros/bridge.h>",
+        '#include "nros/bridge.hpp"',
+        "    nros_pubsub_bridge_create(exec, &src, &dst);",
+        "    nros_bridge_endpoint_t src;",
+        "    nros::MultiExecutor exec;",
+    ):
+        case(f"bridge marker: {marker.strip()[:34]}", bool(BRIDGE_MARKERS.search(marker)))
+
+    # 6. And does NOT fire on a plain nano-ros TU, or every image would be
+    #    treated as a bridge and the gate would fail the whole tree.
+    case(
+        "a plain TU is not a bridge",
+        not BRIDGE_MARKERS.search("#include <nros/nros.h>\n    nros_init();"),
+    )
+
+    failed = [n for n, ok in cases if not ok]
+    if failed:
+        print("check-format-macro-scope SELFTEST FAILED:")
+        for n in failed:
+            print(f"  - {n}")
+        sys.exit(2)
+    if not quiet:
+        print(f"check-format-macro-scope self-test: OK ({len(cases)} case(s))")
+
+
 def main() -> int:
     want_list = "--list" in sys.argv[1:]
+
+    # The negative controls run on the NORMAL path. `check-gate-selftests`
+    # requires that: a control reachable only behind a flag is a comment, and
+    # this gate's whole value is that its two regexes fire on the right shapes
+    # and stay silent on the reserved-discriminant table.
+    verbose_selftest = "--self" in " ".join(sys.argv[1:])
+    self_test(quiet=not verbose_selftest)
+    if verbose_selftest:
+        return 0
 
     # Vacuity guard 1 — the macros still exist where this gate thinks they do.
     missing = []

--- a/scripts/check-format-macro-scope.py
+++ b/scripts/check-format-macro-scope.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""RFC-0088 D5 — a bridge-linked image must not reference the format macros.
+
+`NROS_SERIALIZATION_FORMAT_ID` / `NROS_SERIALIZATION_FORMAT` (and their
+`NROS_CPP_`-prefixed C++ FFI siblings, and the `nros::linked_format()` /
+`nros::linked_format_name()` accessors that lift them) answer ONE question:
+*what encoding does the backend this image links speak?* That question has an
+answer exactly when the image links one backend — which is the ordinary case,
+and the reason the whole check is compile-time rather than a `dlopen`-resolved
+string the way ROS 2 does it.
+
+A **bridge image is the exception, structurally**. `Executor::open_multi` opens
+two sessions on two backends in one process (RFC-0088 D3); the format stops
+being a property of the image and becomes a property of the session. There the
+macro is not merely useless, it is *actively wrong*: it names one of the two
+backends, silently, with no diagnostic — a subtle wrong answer where the whole
+point of the design was to make a mismatch loud. A bridge asks per session
+instead:
+
+    C    nros_node_get_serialization_format(node)
+    C++  node.serialization_format()
+    Rust session.serialization_format()  /  RawSubscription::format()
+
+## What this gate can and cannot see
+
+"Image" is a LINK-time notion and this is a SOURCE-time gate, so the predicate
+is a documented approximation, deliberately conservative in the direction that
+matters:
+
+  * a translation unit is **bridge-linked** when it names the bridge API
+    (`<nros/bridge.h>`, `<nros/bridge.hpp>`, `nros_pubsub_bridge_create`,
+    `nros::bridge::`, `nros::MultiExecutor`), or when any sibling source under
+    the same *entry root* does — an entry root being the nearest ancestor
+    directory holding a `CMakeLists.txt`, `package.xml` or `Cargo.toml`, i.e.
+    the unit that becomes one image;
+  * it therefore over-approximates (every TU of a bridge entry is treated as
+    bridge-linked, even one that only ever touches a single backend) and cannot
+    catch an image assembled entirely outside the tree.
+
+Over-approximating is the right error to make: the cost is a diagnostic on a
+line that could have stayed, and the fix — ask the session — is correct in both
+cases anyway.
+
+## Not vacuous
+
+Two guards, because a gate whose subject set has silently emptied reports the
+same green as a gate that passed:
+
+  * the macros must still EXIST at their defining sites. A rename that this
+    file did not follow fails here rather than making every scan trivially
+    clean;
+  * at least one bridge-linked TU must be found. If the bridge API is renamed
+    and the patterns above stop matching, the gate says so.
+
+Usage:
+    python3 scripts/check-format-macro-scope.py [--list]
+
+`--list` prints the classification (bridge-linked TUs, macro references) and
+exits 0 — for working out why a file was picked up.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+C_LIKE = {".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx", ".inc"}
+
+# ── The macros, and every spelling of the same fact ──────────────────────────
+#
+# The RFC names the two C macros. The C++ FFI header carries its own
+# `NROS_CPP_`-prefixed copy (emitted there so no C++ header has to include a C
+# API header — issue 0160's one-way include order), and `serialization_format.hpp`
+# lifts both into `nros::linked_format()`. All four answer "what does THIS image
+# speak", so all four are wrong in a bridge; gating only the two the RFC spells
+# would be the narrower-than-the-rule coverage issue 0196 is about.
+MACRO_REFS = re.compile(
+    r"\b(?:"
+    r"NROS_SERIALIZATION_FORMAT_ID"
+    r"|NROS_SERIALIZATION_FORMAT"
+    r"|NROS_CPP_SERIALIZATION_FORMAT_ID"
+    r"|NROS_CPP_SERIALIZATION_FORMAT"
+    r"|linked_format_name"
+    r"|linked_format"
+    r")\b"
+)
+
+# `NROS_SERIALIZATION_FORMAT_ID_CDR` / `_UORB` are the reserved-discriminant
+# TABLE, not the image's answer — naming a format is fine anywhere, including a
+# bridge, which is the one place two of them legitimately meet.
+TABLE_REF = re.compile(r"\bNROS_(?:CPP_)?SERIALIZATION_FORMAT_ID_[A-Z]+\b")
+
+BRIDGE_MARKERS = re.compile(
+    r"(?:"
+    r"#\s*include\s*[<\"]nros/bridge\.h(?:pp)?[>\"]"
+    r"|\bnros_pubsub_bridge_create\b"
+    r"|\bnros_bridge_endpoint_t\b"
+    r"|\bnros::bridge::"
+    r"|\bnros::MultiExecutor\b"
+    r")"
+)
+
+# ── Where the macros are DEFINED / derived. These are the API, not an image ──
+#
+# Each entry is (path, the token that must appear in it). The token half is the
+# vacuity guard: if a rename moves the macro and nobody updates this file, the
+# gate fails loudly instead of scanning for a string that no longer exists.
+DEFINITION_SITES = [
+    ("packages/api/nros-c/include/nros/serialization_format.h", "NROS_SERIALIZATION_FORMAT_ID"),
+    ("packages/api/nros-c/include/nros/nros_generated.h", "NROS_SERIALIZATION_FORMAT_ID"),
+    ("packages/api/nros-cpp/include/nros/serialization_format.hpp", "linked_format"),
+    ("packages/api/nros-cpp/include/nros/nros_cpp_ffi.h", "NROS_CPP_SERIALIZATION_FORMAT_ID"),
+]
+
+# Files exempt from the "must not reference" rule: the API that defines the
+# macros, the compile probes that exist to prove the assertion has teeth, and
+# `bridge.{h,hpp}` itself (its prose explains why a bridge does not use them).
+EXEMPT_PREFIXES = (
+    "packages/api/nros-c/include/nros/",
+    "packages/api/nros-cpp/include/nros/",
+    "packages/api/nros-c/tests/compile/",
+    "packages/api/nros-cpp/tests/compile/",
+)
+
+ENTRY_ROOT_MARKERS = ("CMakeLists.txt", "package.xml", "Cargo.toml")
+
+
+def tracked_files():
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [p for p in out.split("\0") if p]
+
+
+def entry_root(rel: str) -> str:
+    """Nearest ancestor directory that becomes one image, as a repo-relative path."""
+    d = (ROOT / rel).parent
+    while True:
+        if any((d / m).exists() for m in ENTRY_ROOT_MARKERS):
+            return str(d.relative_to(ROOT))
+        if d == ROOT:
+            return "."
+        d = d.parent
+
+
+def is_exempt(rel: str) -> bool:
+    return rel.startswith(EXEMPT_PREFIXES)
+
+
+def read(rel: str) -> str:
+    try:
+        return (ROOT / rel).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def main() -> int:
+    want_list = "--list" in sys.argv[1:]
+
+    # Vacuity guard 1 — the macros still exist where this gate thinks they do.
+    missing = []
+    for path, token in DEFINITION_SITES:
+        body = read(path)
+        if not body:
+            missing.append(f"{path} (file not found)")
+        elif token not in body:
+            missing.append(f"{path} (no `{token}`)")
+    if missing:
+        print("check-format-macro-scope: FAIL — the macros this gate polices are not")
+        print("       where it expects them, so every scan below would be vacuous:")
+        for m in missing:
+            print(f"         {m}")
+        print()
+        print("       Either the definition moved (update DEFINITION_SITES and")
+        print("       MACRO_REFS together) or the cbindgen headers are unregenerated")
+        print("       (`cargo run -p nros-cbindgen-headers`).")
+        return 1
+
+    sources = [p for p in tracked_files() if Path(p).suffix in C_LIKE]
+
+    # Pass 1 — which entry roots contain bridge code, and which TUs name it.
+    bridge_tus = []
+    bridge_roots = set()
+    for rel in sources:
+        if BRIDGE_MARKERS.search(read(rel)):
+            bridge_tus.append(rel)
+            if not is_exempt(rel):
+                bridge_roots.add(entry_root(rel))
+
+    # Vacuity guard 2 — the bridge API is still recognisable.
+    if not bridge_tus:
+        print("check-format-macro-scope: FAIL — no bridge-linked source found at all.")
+        print("       The bridge API was renamed and BRIDGE_MARKERS no longer matches,")
+        print("       so this gate has no subject and would pass on anything.")
+        return 1
+
+    # Pass 2 — a bridge-linked TU must not reference the image-wide answer.
+    violations = []
+    for rel in sources:
+        if is_exempt(rel):
+            continue
+        root = entry_root(rel)
+        direct = rel in bridge_tus
+        if not direct and root not in bridge_roots:
+            continue
+        body = read(rel)
+        for n, line in enumerate(body.splitlines(), 1):
+            # Strip the reserved-discriminant table before looking for the
+            # image's answer — `..._ID_CDR` contains `..._ID` as a prefix.
+            probe = TABLE_REF.sub("", line)
+            if MACRO_REFS.search(probe):
+                violations.append((rel, n, line.strip(), root, direct))
+
+    if want_list:
+        print("bridge-linked translation units:")
+        for rel in sorted(bridge_tus):
+            print(f"  {rel}")
+        print()
+        print("entry roots treated as bridge images:")
+        for r in sorted(bridge_roots):
+            print(f"  {r}")
+        print()
+        print(f"macro references inside them: {len(violations)}")
+        for rel, n, line, _root, _direct in violations:
+            print(f"  {rel}:{n}: {line}")
+        return 0
+
+    if violations:
+        print("check-format-macro-scope: FAIL — a bridge-linked image references the")
+        print("       image-wide serialization format (RFC-0088 D5). A bridge links two")
+        print("       backends, so there is no single answer and the macro silently")
+        print("       names one of them:")
+        print()
+        for rel, n, line, root, direct in violations:
+            why = "names the bridge API" if direct else f"shares entry root `{root}` with bridge code"
+            print(f"         {rel}:{n}  ({why})")
+            print(f"           {line}")
+        print()
+        print("       Ask the SESSION instead — that is the one place the answer is")
+        print("       per-backend and therefore true:")
+        print("         C    nros_node_get_serialization_format(node)")
+        print("         C++  node.serialization_format()")
+        print("         Rust session.serialization_format() / RawSubscription::format()")
+        return 1
+
+    print(
+        f"check-format-macro-scope: OK ({len(sources)} C/C++ source(s); "
+        f"{len(bridge_tus)} bridge-linked, {len(bridge_roots)} bridge entry root(s); "
+        "none reaches the image-wide format macro)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
RFC-0088 D5. Rust has had this check since W1 — an inline `const {}` comparing the message's format against the image's. C and C++ now have the same one, at the same moment: compile time, no runtime branch, no new call.

**C**, per generated message header:

```c
#define NROS_MSG_FORMAT_ID_std_msgs_msg_string NROS_SERIALIZATION_FORMAT_ID_CDR
NROS_ASSERT_MESSAGE_FORMAT(NROS_MSG_FORMAT_ID_std_msgs_msg_string, "std_msgs/String");
```

`NROS_STATIC_ASSERT` is `_Static_assert` on C11, `static_assert` on C++/C23, and a `__COUNTER__`-tagged negative-array typedef before that — these headers compile as C *and* get included from C++, where `_Static_assert` is not a keyword.

**C++** gets `enum class SerializationFormat : uint8_t`, a codegen-specialised `format_of<M>`, and a `static_assert` in the seven typed-creator funnels. `const char*` throughout — never `std::string`/`string_view`, since the headers must survive Zephyr's minimal libcpp (archived issue 0112) — with a `static_assert` in the compile test pinning the return type so a regression to a std type stops compiling.

## Two deliberate departures from the D5 sketch

**The macro is lowered by cbindgen, not written into `nros_config_generated.h`.** That header is substituted in `nros-build-helpers`, and a build script cannot evaluate a Rust `const`. Each mirror instead carries a `const _` proving it equal to `session::IMAGE_SERIALIZATION_FORMAT{,_ID}` — the same constant `format_check` asserts on — so a backend whose format differs fails `cargo check` naming the drift rather than shipping a header that quietly disagrees.

The properly-derived path is `[rmw] serialization_format` in each backend descriptor → `NanoRosRmwDispatch.cmake` → `configure_file`. That is four files in other waves' territory; this is the affordable version, and the `const _` is the tripwire for the day a backend answers something else.

**`format_of<M>` is defined and defaults to `Cdr`**, not a bare declaration — mirroring D1's defaulted `RosMessage::SERIALIZATION_FORMAT_ID`. Load-bearing: hand-written tag types pass through these creators (`DebugKeyValueTag` in the px4 bridge, `FakeString` in a compat fixture), and a hard-erroring primary would have broken them.

## The negative case is proven, with the harness that already exists

The `param_deprecation_probe.c` shape — assert the probe file is present **first**, because a missing file is also a non-zero `cc` and reads as a pass. The C refusal names the type:

```
error: static assertion failed: "RFC-0088: px4_msgs/VehicleStatus is not encoded
in the format the linked backend speaks — one image, one backend, one encoding"
```

Refused across `-std=c99/c11/c17` and C++14; the positive TUs compile.

Caveat stated in the probes: every in-tree pack emits CDR, so no *generated* header disagrees yet — the probes spell the mismatch the way a non-CDR pack would. W5's reference provider makes it a generated case.

## `check-format-macro-scope`

A bridge image links two backends and has no single answer, so a bridge-linked TU referencing `NROS_SERIALIZATION_FORMAT{,_ID}` is a wrong answer that compiles. Two vacuity guards: the macros must still exist at their defining sites, and at least one bridge-linked TU must be found — a gate whose subject set emptied reports the same green as one that passed.

## Verified

Golden corpus re-recorded with `NROS_UPDATE_GOLDEN=1` (16 files) · cbindgen headers regenerated, `--check` green · clippy `-D warnings` clean on nros-c and nros-cpp · `just check gate-lists` / `gate-visibility` / `format-macro-scope` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV