### PR TITLE
docs(phase-201, RFC-0013): archived unstarted — RFC-0087 deletes the question

### DIFF
--- a/docs/design/0013-custom-board-provisioning.md
+++ b/docs/design/0013-custom-board-provisioning.md
@@ -1,13 +1,34 @@
 ---
 rfc: 0013
 title: "Custom-board provisioning — out-of-tree boards self-describe their deps"
-status: Stable
+status: Superseded
 since: 2026-05
-last-reviewed: 2026-05
+last-reviewed: 2026-09
 implements-tracked-by: []
 supersedes: []
-superseded-by: null
+superseded-by: [0087, 0062]
 ---
+
+> **SUPERSEDED 2026-09-04 by RFC-0087 + RFC-0062.** This RFC answers "how does a
+> board crate tell `nros setup` what to provision?" — a question RFC-0087
+> **deletes** rather than answers. There, *"a package is a directory containing
+> `package.xml`, and nothing else identifies one"*, and *"there is no builtin
+> road"*: a board is an ordinary package, its dependencies are its `<depend>`
+> entries, and `provider_scan` finds an out-of-tree one the same way it finds
+> `packages/boards/*`. Nothing needs to learn a board-specific descriptor
+> because nothing is looking one up.
+>
+> | what this RFC proposed | where it went |
+> | --- | --- |
+> | `[[board.source]]` / `[[board.tool]]` / `[[board.gated]]` in `nros-board.toml` | RFC-0087 (`<depend>` + `provider_scan`); external trees become **vendor packages**, phase-420 W8 |
+> | a `cargo_install` tool kind | RFC-0062 `[prereq.*]` — one key namespace, ordered `providers` |
+> | out-of-tree discovery / `--board-manifest` | phase-420 W6 — `[workspace] package_paths` + `NROS_PACKAGE_PATH`, shadowing **reported** |
+> | a board scaffolder | **shipped** as `nros new board <name>` (phase-290 W4.b) |
+>
+> Kept in place rather than deleted: the real-board survey and the simulated
+> walkthrough below are the evidence for what a third-party board actually
+> needs, and RFC-0087 inherits that requirement without restating it. Read this
+> for the problem, not for the mechanism. Tracked by [phase-201](../roadmap/archived/phase-201-custom-board-provisioning.md), archived unstarted.
 
 # Custom-board provisioning — out-of-tree boards self-describe their deps
 

--- a/docs/design/0049-hierarchical-platform-board-config.md
+++ b/docs/design/0049-hierarchical-platform-board-config.md
@@ -106,8 +106,12 @@ Per RFC-0004's rule this is a **fixed, short precedence ladder, not an open
 merge**. The chain is explicit: the app names its board (deploy key, as
 today) → the board toml names its platform → the loader follows that
 two-hop chain. Out-of-tree board/platform directories resolve through the
-existing RFC-0014 / phase-201 board-provisioning mechanism — no second
-resolver, no cross-package walk-ups.
+existing RFC-0014 board-provisioning mechanism — no second resolver, no
+cross-package walk-ups. (This named phase-201 as the out-of-tree half; that
+phase was archived unstarted 2026-09-04 and the resolution moves to phase-420
+W6's search path — `[workspace] package_paths` + `NROS_PACKAGE_PATH`. The
+"no second resolver" rule is what survives, and W6 honours it: one search
+path for every package kind, not a board-specific fallback.)
 
 Resolved values are emitted into the one generated config header /
 `-D` set the shim build already produces, preserving the issue-0135
@@ -200,7 +204,9 @@ for non-express topics.
   RFC is the BUILD-time sibling and does not touch `system.toml`).
 - RFC-0042 (`nros-board.toml` board descriptor + `[board.capabilities]` —
   this RFC extends that file, not a new one).
-- RFC-0014 / phase-201 (out-of-tree board/platform dir resolution).
+- RFC-0014 (out-of-tree board/platform dir resolution). Was RFC-0014 /
+  phase-201; phase-201 archived unstarted 2026-09-04, superseded by RFC-0087 —
+  the search path is phase-420 W6.
 - RFC-0033 (config-file precedent: `deny_unknown_fields`, deep-merge
   mechanics, discovery — note codegen capacity config remains its own
   file/system; message capacities are app-scoped, not platform-scoped).
@@ -219,7 +225,10 @@ for non-express topics.
    via the `NROS_BOARD_TOML` env hook (works from any lane that can set
    an env var, which all cmake lanes do); automatic export from the
    phase-201 registry is deferred until an in-tree board carries a
-   `[knobs]` delta.
+   `[knobs]` delta. **There is no phase-201 registry and there will not be**
+   (archived unstarted 2026-09-04): under RFC-0087 a board is an ordinary
+   package, so the automatic export, if it is ever wanted, comes off
+   phase-420 W6's search path. The env hook is unaffected.
 
 ## Changelog
 

--- a/docs/design/0064-board-support-organization.md
+++ b/docs/design/0064-board-support-organization.md
@@ -315,6 +315,11 @@ Three ways not to add an entry, in increasing cost:
    Precedent exists in a sibling verb: `nros setup board <name>
    --zephyr-workspace` already reads the *board package's* provisioning contract
    rather than the index.
+   **Both superseded 2026-09-04** (phase-201 archived unstarted, RFC-0013 marked
+   Superseded): RFC-0087 makes a board an ordinary `package.xml` package whose
+   deps are its `<depend>` entries, so there is no index lookup left to extend
+   and no board-specific descriptor to read. The `--zephyr-workspace` precedent
+   still stands as evidence the pull was real — it is that shape, board-scoped.
 
 **Proposed fix:** re-key the table as `[profile.<arch>-<ecosystem>]` and make
 `[board.*]` an optional alias pointing at a profile. One `cortex-m-freertos`
@@ -933,7 +938,7 @@ vendor reads. Fix regardless of everything else here.
 | Keep low-tier boards in-tree | phase-320 W3.d | Do not relocate anything; shells add nothing to relocate |
 | Tier is metadata, not layout | phase-320 W3 | No tier or vendor directories |
 | Board crate merges 27 → 19 | phase-322 (deferred) | Orthogonal |
-| Out-of-tree boards self-describe deps | RFC-0013 / phase-201 (deferred) | The revival case |
+| Out-of-tree boards self-describe deps | RFC-0087 / phase-420 W6+W8 (RFC-0013 + phase-201 superseded 2026-09-04) | The revival case — answered generally, not per-board |
 
 ## Sequencing
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -74,7 +74,7 @@ Each RFC carries frontmatter: `rfc`, `title`, `status`, `since`, `last-reviewed`
 | RFC | Doc | Status | One-liner |
 | --- | --- | --- | --- |
 | 0012 | [board-bsp-integration-architecture](0012-board-bsp-integration-architecture.md) | Stable | vendor BSP × board × SDK-variant integration shape |
-| 0013 | [custom-board-provisioning](0013-custom-board-provisioning.md) | Stable | out-of-tree boards self-describe deps to `nros setup` |
+| 0013 | [custom-board-provisioning](0013-custom-board-provisioning.md) | Superseded by RFC-0087 / RFC-0062 | out-of-tree boards self-describe deps to `nros setup` — the question is deleted rather than answered: under RFC-0087 a board is an ordinary `package.xml` package and there is no index lookup to extend |
 | 0014 | [nros-setup-toolchain-management](0014-nros-setup-toolchain-management.md) | Stable | `nros setup` as single toolchain entrypoint |
 | 0015 | [rtos-orchestration](0015-rtos-orchestration.md) | Stable | launch tree + manifest codegen across RTOSes |
 | 0016 | [rtos-scheduling-features](0016-rtos-scheduling-features.md) | Stable | per-RTOS scheduling feature survey |

--- a/docs/roadmap/archived/phase-201-custom-board-provisioning.md
+++ b/docs/roadmap/archived/phase-201-custom-board-provisioning.md
@@ -4,7 +4,43 @@
 `nros-board.toml` so `nros setup <custom-board>` provisions them out-of-tree —
 without an entry in the maintainer-owned central `nros-sdk-index.toml`.
 
-**Status.** Deferred (proposed 2026-05-29). Design complete; implementation
+**Status (2026-09-04). SUPERSEDED — archived unstarted.** Deferred as proposed
+2026-05-29 and never picked up; in the 97 days since, the architecture moved
+underneath it and the question this phase exists to answer no longer has a place
+to be asked.
+
+**RFC-0087 deletes the lookup rather than extending it.** This phase's whole
+shape is "on a central-index MISS, fall back to reading the board crate" — one
+more branch in a resolver. RFC-0087's premise is that there is no resolver to
+branch: *"a package is a directory containing `package.xml`, and nothing else
+identifies one"*, and *"there is no builtin road"*. A user's board is found by
+`provider_scan` exactly as `packages/boards/*` are, and its dependencies are its
+`<depend>` entries. Nothing has to miss first.
+
+Every work item has a successor, verified against `main` 2026-09-04:
+
+| item | successor |
+| --- | --- |
+| **201.1** dep schema + resolver branch | RFC-0087 (`<depend>` + `provider_scan`); external trees become **vendor packages** reached by package name — phase-420 **W8**, which deletes the `[source.*]` row in the same commit |
+| **201.2** `cargo_install` tool kind | RFC-0062 **`[prereq.*]`** — one key namespace over four providers, ordered `providers` list. (Note the name: nano-ros builds its own rosdep-shaped thing; rosdep itself is deliberately no longer consulted, and the fallback was deleted.) |
+| **201.3** out-of-tree discovery / `--board-manifest` | phase-420 **W6** — `[workspace] package_paths` in `nros.toml` + `NROS_PACKAGE_PATH`, nano-ros tree first, shadowing **reported** by `nros ws packages` rather than silently won |
+| **201.4** `nros new --board` scaffolder | **SHIPPED**, by phase-290 W4.b — `nros new board <name>` (`cmd/new.rs:36`). Not by this phase |
+| **201.5** fresh-machine acceptance lane | phase-420 W6 / W8 acceptance |
+
+**The premise is still literally true, which is why this needs saying out loud.**
+`resolve_packages` (`packages/cli/nros-cli-core/src/cmd/setup.rs:1067`) still
+bails with *"Add a `[board.<name>]` entry to `nros-sdk-index.toml`"*. Anyone
+reading only the code would conclude this phase is still the answer. It is not:
+the gap closes when boards stop being things the index knows about.
+
+**And one narrow instance already shipped, in the direction this phase wanted.**
+`nros setup board <name> --zephyr-workspace` reads the board's own provisioning
+contract (`board.cmake`) out of the crate directory rather than the index
+(phase-215.J.2, `setup.rs:429-467`). That is 201.1's shape, board-scoped and
+Zephyr-only — evidence that the pull was real, not that this phase should be
+revived.
+
+*Original status, 2026-05-29:* Deferred. Design complete; implementation
 parked. Pick up after the active Phase 200 line.
 
 **Priority.** P3 — no nano-ros-internal board needs it; it's the enabler for
@@ -16,7 +52,10 @@ index kinds; builds consume nros-store tools), Phase 197.5 (nros-0.3.1 index sch
 + the deny-unknown-fields lesson — schema additions must be released).
 
 **Design.** Full exploration + real-board survey + simulated walkthrough in
-[`docs/design/0013-custom-board-provisioning.md`](../design/0013-custom-board-provisioning.md).
+[`docs/design/0013-custom-board-provisioning.md`](../design/0013-custom-board-provisioning.md)
+— **also marked Superseded (2026-09-04)**, and kept for the survey rather than
+the mechanism: it is the evidence for what a third-party board actually needs,
+which RFC-0087 inherits without restating.
 Builds on [`docs/design/0012-board-bsp-integration-architecture.md`](../design/0012-board-bsp-integration-architecture.md)
 (the build-side / overlay-crate model).
 


### PR DESCRIPTION
phase-201 — *"out-of-tree boards self-describe their deps so `nros setup` can
provision them"* — was proposed 2026-05-29, deferred, and never picked up. Its
whole shape is **one more branch in a resolver**: on a central-index MISS, fall
back to reading the board crate's `nros-board.toml`.

**RFC-0087 removes the thing being missed.** *"A package is a directory
containing `package.xml`, and nothing else identifies one"*; *"there is no
builtin road."* A user's board is found by `provider_scan` exactly as
`packages/boards/*` are, and its dependencies are its `<depend>` entries.
Nothing has to miss first, because nothing is looking a board up.

## Every work item has a successor

| item | successor |
| --- | --- |
| **201.1** dep schema + resolver branch | RFC-0087; external trees become **vendor packages** — phase-420 **W8**, which deletes the `[source.*]` row in the same commit |
| **201.2** `cargo_install` tool kind | RFC-0062 **`[prereq.*]`**, ordered `providers` list |
| **201.3** out-of-tree discovery / `--board-manifest` | phase-420 **W6** search path; shadowing **reported** by `nros ws packages`, not silently won |
| **201.4** board scaffolder | **already shipped** by phase-290 W4.b — `nros new board <name>` (`cmd/new.rs:36`) |
| **201.5** acceptance lane | phase-420 W6/W8 acceptance |

## Two things recorded because they would otherwise mislead

**The premise is still literally true.** `resolve_packages`
(`nros-cli-core/src/cmd/setup.rs:1067`) still bails with *"Add a
`[board.<name>]` entry to `nros-sdk-index.toml`"*. Reading only the code, this
phase looks live — so the archival note says why it isn't.

**A narrow instance already shipped, in the direction the phase wanted.**
`nros setup board <name> --zephyr-workspace` reads the board's own provisioning
contract out of the crate directory rather than the index (phase-215.J.2,
`setup.rs:429-467`). That is 201.1's shape, board-scoped and Zephyr-only —
evidence the pull was real, not that the phase should be revived.

## RFC-0013

Marked `Superseded` (by 0087, 0062) rather than deleted. Its real-board survey
and simulated walkthrough are the evidence for *what a third-party board
actually needs*, which RFC-0087 inherits without restating. Read it for the
problem, not the mechanism.

## The inbound sweep

Four pointers in two **active** RFCs (0049 ×3, 0064 ×2) named phase-201 as the
live mechanism. Each now names phase-420 W6 or RFC-0087.

`check-doc-refs` would not have caught these — they are **prose references, not
links**, so the gate has nothing to resolve. Archived-doc references
(phase-290, issue 0944) are left as history.

## Verification

    check-doc-refs        OK
    check-book-links      OK — 706 relative links in 123 pages
    check-roadmap-claims  OK — 0 findings, 63 active phase docs

Active phases 61 → 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
