### PR TITLE
fix(#1038, phase-413 W3): --sudo reaches a tool's own system deps, and esp32 uses it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -305,6 +305,31 @@ jobs:
 
       - name: Build nros CLI from packages/cli/ (Phase 218)
         uses: ./.github/actions/setup-nros-cli
+      # issue 1038 — provision `[tool.esp32-qemu]`'s declared BUILD deps before
+      # the lane asks for the tool.
+      #
+      # The Espressif QEMU fork has no prebuilt for linux-x86_64, so `nros setup
+      # --tool esp32-qemu` builds it from source, and qemu's meson needs glib,
+      # pixman and gcrypt. The index declares all three — as `[prereq.*]` with
+      # apt names and probes, AND in `[tool.esp32-qemu] system = [..]` — so the
+      # tool can install them itself. That is why this is NOT an `apt-get
+      # install` line: restating what the index already declares is exactly what
+      # phase-413 W3's gate forbids, and the packages are indexed.
+      #
+      # `--sudo` because a CI container is where executing a package install is
+      # appropriate; the default still refuses and prints the command, which is
+      # the right behaviour on a developer's machine.
+      #
+      # NOT the cause of this cell's RED — that is issue 1025 (#303), where the
+      # flash packer looks in a directory the build stopped using. This step
+      # stops the ESP32 e2e from SKIPPING for want of a QEMU that knows
+      # `esp32c3`, which is a coverage hole that reads as green.
+      - name: Provision esp32-qemu's declared system deps (issue 1038)
+        if: matrix.plat == 'esp32'
+        run: |
+          source ./activate.sh
+          nros setup --tool esp32-qemu --sudo
+
       - name: just ${{ matrix.plat }} setup
         run: |
           source ./activate.sh

--- a/docs/issues/1038-nightly-job-does-not-provision-its-lane.md
+++ b/docs/issues/1038-nightly-job-does-not-provision-its-lane.md
@@ -70,6 +70,27 @@ A warning where the leaf tolerates it, a hard parse error where it does not.
 
 ### 3. `esp32` — apt packages for a source build
 
+**CORRECTION (2026-09-04).** This cell has TWO independent faults and the
+triage above attributed its RED to the wrong one. The missing packages are real,
+but `just esp32 setup` tolerates that failure by design —
+`nros setup --tool esp32-qemu || echo "esp32-qemu unavailable (e2e will skip);
+build unaffected"` — so it does not fail the job. What fails the job is one step
+later:
+
+```
+Creating flash images...
+ERROR: .../qemu-esp32-baremetal/riscv32imc-unknown-none-elf/nros-relwithdebinfo/esp32_qemu_talker
+       is missing, and nothing narrowed this build.
+error: recipe `build-qemu` failed with exit code 1
+```
+
+That is **issue 1025**, already owned by PR #303 — the flash packer asking for a
+directory the build stopped using. The packages are a COVERAGE hole (the ESP32
+e2e skips for want of a QEMU that knows `esp32c3`, which reads as green), not
+the red. Both are worth fixing; only one of them turns this cell green, and it
+is not this one.
+
+
 ```
 nros setup: 1 package(s) have no prebuilt for linux-x86_64 — BUILDING FROM SOURCE: esp32-qemu
 Error: nros setup --tool esp32-qemu: needs 3 system package(s) this host is

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -92,9 +92,13 @@ conversion can be verified in a lane that is already red.
    | --- | --- | --- |
    | `nuttx` | `riscv-none-elf-gcc not found (run: nros setup qemu-riscv-nuttx)` | this wave |
    | `threadx_riscv64` | cargo manifest-parse: missing `include` of the generated `nros-patch.toml` (issue 0463) | this wave |
-   | `esp32` | `esp32-qemu` source build needs `libglib2-dev`, `libpixman-dev`, `libgcrypt-dev` | **W3** |
+   | `esp32` | RED is issue 1025 (#303); the missing `libglib2-dev`/`libpixman-dev`/`libgcrypt-dev` are a separate COVERAGE hole | **W3** |
 
-   `esp32` is W3's conversion unapplied rather than a missing mechanism: the
+   `esp32` needed a correction after the fact: its RED is issue 1025 (the flash
+   packer looking in a directory the build stopped using, PR #303), NOT the
+   packages — `just esp32 setup` tolerates that failure by design, so it costs
+   the e2e SKIP rather than the build. The package half is still W3's
+   conversion unapplied rather than a missing mechanism: the
    index declares all three as `[prereq.*]` AND in `[tool.esp32-qemu]`'s own
    `system = [...]`, so `nros setup --system` already resolves them. Checked
    against the gate as IMPLEMENTED (`check-workflow-indexed-apt.py`), not as

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -120,6 +120,10 @@ pub struct Args {
 
     /// With `--system`: EXECUTE the composed native install command (which
     /// invokes sudo where the manager needs it) instead of printing it.
+    ///
+    /// issue 1038 — ALSO applies to `--tool`: a tool declaring its own
+    /// `[tool.<name>] system = [..]` build deps installs them instead of
+    /// bailing with a line for a human to copy.
     #[arg(long, requires = "system", conflicts_with = "check")]
     pub sudo: bool,
 }
@@ -224,7 +228,13 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if let Some(tool) = args.tool.as_deref() {
-        return install_single_tool(&index, tool, args.prefix.as_deref(), args.dry_run);
+        return install_single_tool(
+            &index,
+            tool,
+            args.prefix.as_deref(),
+            args.dry_run,
+            args.sudo,
+        );
     }
 
     if !args.sources.is_empty() {
@@ -628,6 +638,7 @@ fn install_single_tool(
     name: &str,
     prefix_override: Option<&Path>,
     dry_run: bool,
+    run_sudo: bool,
 ) -> Result<()> {
     let host = host_key();
     let tool = index
@@ -678,13 +689,48 @@ fn install_single_tool(
         let hint = detect_package_manager()
             .map(|mgr| native_install_command(mgr, &compose_packages(&entries, mgr)))
             .unwrap_or_else(|| "<no supported package manager detected>".to_string());
-        bail!(
-            "nros setup --tool {name}: needs {} system package(s) this host is \
-             missing: {}.\n  Install with:  {hint}\n  \
-             (declared as [tool.{name}] system = [..]; probes via [system.*].check)",
-            missing_sys.len(),
-            missing_sys.join(", "),
-        );
+        // issue 1038 — `--sudo` INSTALLS them, exactly as it does for
+        // `--system`. Without this the flag reached only the global
+        // `[system.*]` closure, so a tool whose deps live in its own
+        // `[tool.<name>] system = [..]` could be DIAGNOSED and never
+        // provisioned: `esp32-qemu` needs glib/pixman/gcrypt for qemu's meson
+        // build, they are declared in the index, and the only way to act on
+        // that was for a human to copy the printed line. A workflow's remaining
+        // option was to `apt-get install` them itself — which is the
+        // index-restating that phase-413 W3 exists to forbid.
+        //
+        // Default is unchanged and stays safe for a developer tree: without
+        // `--sudo` this still bails with the command to run, because installing
+        // system packages behind someone's back is not a thing a build tool
+        // should do uninvited.
+        if run_sudo {
+            let Some(mgr) = detect_package_manager() else {
+                bail!(
+                    "nros setup --tool {name} --sudo: {} system package(s) missing ({}) \
+                     and no supported package manager detected",
+                    missing_sys.len(),
+                    missing_sys.join(", "),
+                );
+            };
+            let cmd = native_install_command(mgr, &compose_packages(&entries, mgr));
+            println!("nros setup --tool {name} --sudo: running:\n  {cmd}");
+            let status = std::process::Command::new("sh")
+                .args(["-c", &cmd])
+                .status()
+                .wrap_err("spawn the native package manager")?;
+            if !status.success() {
+                bail!("system package install for [tool.{name}] failed ({status})");
+            }
+        } else {
+            bail!(
+                "nros setup --tool {name}: needs {} system package(s) this host is \
+                 missing: {}.\n  Install with:  {hint}\n  \
+                 (or re-run with --sudo)\n  \
+                 (declared as [tool.{name}] system = [..]; probes via [system.*].check)",
+                missing_sys.len(),
+                missing_sys.join(", "),
+            );
+        }
     }
     match action {
         InstallAction::Present => {}


### PR DESCRIPTION
## The gap

`nros setup --tool esp32-qemu` could **diagnose** its missing build deps and never provision them:

```
Error: nros setup --tool esp32-qemu: needs 3 system package(s) this host is missing:
libglib2-dev, libpixman-dev, libgcrypt-dev.
```

`--sudo` reached only the global `[system.*]` closure, so a tool whose deps live in its own `[tool.<name>] system = [..]` had no path from *"the index declares these"* to *"they are installed"* except a human copying the printed line.

A workflow's remaining option was to `apt-get install` them itself — precisely the index-restating that **W3's gate forbids**, and all three are indexed. That's the shape of the acceptance gap I flagged when filing #1038: W3 catches *duplication*, not *omission*.

## The change

`--sudo` now installs them, composing through the **same** `native_install_command(compose_packages(..))` that `--system --sudo` uses, so the two cannot disagree about a package name.

The default is unchanged and still refuses — installing system packages behind someone's back isn't a thing a build tool should do uninvited, and a developer tree is where that matters. The nightly's esp32 cell opts in; `sudo` is present and the job is root (checked in the image, not assumed).

## A correction — the more useful half

My triage in #1038 attributed this cell's **red** to those packages. **It doesn't.** `just esp32 setup` tolerates that failure by design:

```
nros setup --tool esp32-qemu || echo "esp32-qemu unavailable (e2e will skip); build unaffected"
```

The job dies one step later in `build-qemu`:

```
ERROR: .../nros-relwithdebinfo/esp32_qemu_talker is missing, and nothing narrowed this build.
```

That's **issue 1025**, already owned by **#303**. The packages are a *coverage hole* — the ESP32 e2e skips for want of a QEMU that knows `esp32c3`, and a skip reads as green — not the red. Both are worth fixing; only #303 turns the cell green. Corrected in #1038 and the phase-413 W2 note, because a wrong cause in a triage document aims the next person at a dead end.

## Verification

`check workflow-indexed-apt` green (this adds no apt line), `check fast` 200/200, `check cli-tests` green, YAML parses.

**Not verified locally, and worth saying:** this host *has* the three packages, so the missing-package branch never executed here — the default path went straight to a real source build. That branch is reached only where the packages are absent, i.e. the CI container. Its correctness rests on review and on the shared composer, not on a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)