### PR TITLE
feat(phase-421 W5): a custom format costs no codegen, and D7 is amended to what the schema can do

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nros-serdes-packed"
+version = "0.5.0"
+dependencies = [
+ "nros-serdes",
+]
+
+[[package]]
 name = "nros-sizes-build"
 version = "0.5.0"
 dependencies = [
@@ -2183,6 +2190,7 @@ dependencies = [
  "nros-rmw",
  "nros-rmw-zenoh",
  "nros-serdes",
+ "nros-serdes-packed",
  "nros-std-msgs-diag",
  "nvidia-ivc",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ members = [
     "packages/api/nros",
     "packages/core/nros-core",
     "packages/core/nros-serdes",
+    # phase-421 W5 — the schema-driven reference serdes provider. A path dep of
+    # a member inside the workspace dir is a member anyway; listed because every
+    # other crate here is, and an implicit member is the kind of thing a reader
+    # concludes is missing.
+    "packages/core/nros-serdes-packed",
     "packages/core/nros-macros",
     "packages/core/nros-params",
     "packages/core/nros-rmw",

--- a/docs/design/0088-serialization-format-is-a-compile-time-provider.md
+++ b/docs/design/0088-serialization-format-is-a-compile-time-provider.md
@@ -290,15 +290,47 @@ a vendor package it `<depend>`s on (RFC-0087 D5).
 
 ```rust
 pub trait SchemaSerializer {
-    fn serialize(msg: *const u8, schema: &'static [Field], out: &mut [u8])
-        -> Result<usize, SerdesError>;
-    fn deserialize(bytes: &[u8], schema: &'static [Field], msg: *mut u8)
-        -> Result<(), SerdesError>;
+    const FORMAT_NAME: &'static str;   // cross-image identity (D2)
+    const FORMAT_ID:   u8;             // image-local discriminant
+    fn serialize(msg: &mut CdrReader<'_>, type_name: &str,
+                 schema: &'static [Field], out: &mut [u8]) -> Result<usize, SchemaError>;
+    fn deserialize(bytes: &[u8], type_name: &str,
+                   schema: &'static [Field], msg: &mut CdrWriter<'_>) -> Result<usize, SchemaError>;
 }
 ```
 
 A provider implements this once and works for every message, with no codegen
-plugin and no generated code. It is slower than the per-type `serialize` we emit
+plugin and no generated code.
+
+**Amended 2026-09-04 from implementation (W5): the message side is the CDR byte
+stream, not a `*const u8`.** This RFC first specified a raw pointer to the
+message struct, and that is not implementable over today's schema, for three
+independent measured reasons:
+
+1. **A `String` member's host type is `heapless::String<N>` and the schema
+   carries no `N`.** Codegen emits `FieldType::String`, the IDL type;
+   `BoundedString(n)` is the IDL bound, a *different* number from the host
+   capacity.
+2. **`heapless::String` / `heapless::Vec` are `repr(Rust)`.** `Field::offset`
+   soundly reaches the *start* of the container and nothing inside it.
+3. **`NestedType` records `type_name` and `fields` but no size**, so
+   `Array(N, Nested(..))` and sequences of structs have no stride.
+
+So `impl = "schema"` is a **transcoder** strategy in v1: CDR bytes in, the
+provider's bytes out. That is a smaller claim than "reads the message struct
+directly", and it is the claim the schema can actually support. The walk
+therefore lives in `nros-serdes` (`walk::{SchemaSink, SchemaSource}`) rather
+than being re-implemented per provider, and `type_name` is a parameter because a
+`&'static [Field]` slice has no name of its own.
+
+Making the pointer form implementable is a change to the *schema*, not to this
+trait: it needs the host capacity, a stable container layout, and a nested
+type's size. That is worth doing when a provider needs to skip the CDR hop, and
+it is not free.
+
+**One hole the walk inherits rather than introduces:** `WString` /
+`BoundedWString` return `Unsupported`, because `CdrReader`/`CdrWriter` have no
+wide-string primitive in either direction. Nothing in tree uses a `wstring`. It is slower than the per-type `serialize` we emit
 for CDR, and that trade is deliberate for v1: adequate for a control topic,
 inadequate for a high-rate sensor stream. `impl = "codegen"` is the answer when
 someone hits the wall, and it is the point at which a codegen plugin ABI must
@@ -349,6 +381,11 @@ format is decided at compile time and the description never leaves Rust.
 
 ## Changelog
 
+- 2026-09-04 — D7 amended from implementation (phase-421 W5): the schema-driven
+  strategy transcodes from the CDR byte stream rather than reading the message
+  struct through a `*const u8`. The schema carries neither the host string
+  capacity, nor a stable container layout, nor a nested type's size, so the
+  pointer form cannot be written against it today.
 - 2026-09-04 — D6 amended from implementation (phase-421 W4): the per-target key
   is `[image.<t>].serdes`, not `[deploy.<t>].serdes`. The upstream `DeployBlock`
   denies unknown fields, so the specified key would have been a parse error.

--- a/docs/roadmap/phase-421-serialization-format-provider.md
+++ b/docs/roadmap/phase-421-serialization-format-provider.md
@@ -1,6 +1,6 @@
 # Phase 421 — serialization format as a compile-time provider
 
-**Status (2026-09-04). W1–W4 landed; W5–W6 open.**
+**Status (2026-09-04). W1–W5 landed; W6 open.**
 Implements [RFC-0088](../design/0088-serialization-format-is-a-compile-time-provider.md).
 Depends on **[phase-420](phase-420-package-identity-and-provider-format.md) W1
 only** (the `<nano_ros_uses>` general consumption tag) — and only from W4 onward;
@@ -92,15 +92,46 @@ The mechanism is compile-time, not runtime: ROS 2 uses format strings because
         the fix changes discovery for every family and belongs in its own
         change.
 
-- [ ] **W5 — the schema-driven strategy, with a reference provider.**
-      `SchemaSerializer` over the `&'static [Field]` schema codegen already
-      emits. Ship one in-tree non-CDR reference provider so the path has a test
-      subject that is not uORB (uORB's wire is a struct, so it cannot exercise a
-      schema walk).
-      **Acceptance:** the reference format round-trips every message in
-      `packages/interfaces/*` through the schema walk with no generated code, and
-      a native matrix cell covers it. **No new matrix coordinate** — one cell, not
-      an axis (RFC-0088 non-goals).
+- [x] **W5 — the schema-driven strategy, with a reference provider.**
+      (landed 2026-09-04) `nros_serdes::walk` carries `SchemaSerializer` plus the
+      reusable walk (`SchemaSink` / `SchemaSource`, `encode_from_cdr` /
+      `decode_to_cdr`). `packages/core/nros-serdes-packed/` is the reference
+      provider: family `serdes`, `impl = "schema"`, `format_id = 3`,
+      `<build_type>nros_cargo</build_type>`.
+      **Acceptance, met with one signature amendment (below).** All 76 committed
+      generated messages in `packages/interfaces/*` round-trip through the walk
+      in BOTH CDR encodings — 152 (type, encoding) pairs, zero refusals, zero
+      failures — using nothing but `&'static [Field]`
+      (`nros-tests/tests/schema_serializer_round_trip.rs`). `corpus_is_exhaustive`
+      re-counts `impl ::nros_serdes::Message` out of the sources at run time, so a
+      message added later cannot sit outside the sweep. **No matrix cell was
+      added** — see "What landed differently".
+
+      Three findings recorded rather than worked around:
+
+      - **D7's `*const u8` signature cannot be implemented over today's schema.**
+        A `String` member's host type is `heapless::String<N>` and the schema
+        carries no `N` (`FieldType::String` is the IDL type, and
+        `BoundedString(n)` is the IDL bound, a different number); `heapless`'
+        containers are `repr(Rust)`, so their interior layout is not a fact this
+        crate may assume; and `NestedType` records no SIZE, so an
+        `Array(N, Nested(..))` has no stride. `Field::offset` is sound — it only
+        reaches the START of a container. The message side of both methods is
+        therefore a `CdrReader` / `CdrWriter`, which makes `impl = "schema"` a
+        **transcoder** strategy in v1 and is why the walk lives in `nros-serdes`
+        rather than in each provider. Full reasoning in `walk.rs`'s module docs.
+      - **A second parameter, `type_name`.** A `&'static [Field]` slice has no
+        name — `Message::TYPE_NAME` is a separate const and nested members carry
+        theirs in `NestedType` — so without it the top-level struct is the one
+        node a self-describing format cannot name.
+        `serialize_message::<M>` / `deserialize_message::<M>` supply both from a
+        type.
+      - **`wstring` reaches `SchemaError::Unsupported`, by name.** Not a limit of
+        the walk: `CdrReader` / `CdrWriter` have no wide-string primitive in
+        either direction, so there is nothing to transcode from. No message in
+        `packages/interfaces/*` has one, so the sweep refuses nothing today — and
+        the test treats a refusal as a FAILURE rather than a skip, so the first
+        one that appears is read rather than tolerated.
 
 - [ ] **W6 — C and C++ assert at compile time.** `NROS_SERIALIZATION_FORMAT_ID` /
       `NROS_SERIALIZATION_FORMAT` in the generated config; a per-message
@@ -136,6 +167,35 @@ The mechanism is compile-time, not runtime: ROS 2 uses format strings because
   from the single image constant, so `PubSubBridge::new` cannot fail in a real
   image until a bridge image links two backends. The error rendering is tested;
   the end-to-end case waits on W4/W5.
+
+- **W5 amended D7's signature and added no matrix cell.** The `*const u8`
+  message pointer is not usable over today's schema (three measured reasons,
+  above), so `SchemaSerializer` pivots on the CDR byte stream. And a
+  `matrix::CELLS` row is FIXTURE-BACKED — `matrix_fixture_coverage.rs` G1–G4
+  require a matching `examples/fixtures.toml` row — so a cell means an image.
+  There is nothing yet to put in one: no backend declares `packed`, so the image
+  would link a provider nothing calls, and the cell would answer "does dead code
+  link" rather than "does the format work". The coordinate the walk varies over
+  is the MESSAGE SHAPE, not platform × language × rmw × kind, and the sweep
+  covers all 76 of those on the host with no fixture — so it runs in
+  `just ci gate`'s `test-unit`, on every merge-queue batch, at no matrix cost.
+  This is the RFC-0088 non-goal honoured rather than dodged: the axis stays at
+  four, and a cell is the right answer only once a backend SPEAKS a second
+  format (the uORB bridge, phase-325), which is where W3's runtime path becomes
+  reachable too.
+- **The reference format is `packed`, and it is a test vehicle, not interop.**
+  Little-endian, no alignment padding, `u32` byte-length strings with no NUL, no
+  DHEADER, `u32`-counted sequences. Every one of those differs from CDR
+  deliberately: a walk that inherits CDR's padding, its `len + 1` string prefix,
+  or its per-struct DHEADER fails the round trip instead of passing by
+  coincidence. Nothing else speaks `packed` and nothing should.
+- **`packed` gets no `SerializationFormatId` variant, on purpose.**
+  `check-serdes-descriptors` S3 tolerates a `format_id` the enum does not name —
+  it constrains descriptors that USE a reserved name or value and never demands
+  one exist — so `format.rs` needed no edit. A variant would assert `packed` is a
+  wire a BACKEND speaks, and none does. `SchemaSerializer::FORMAT_ID` is a raw
+  `u8` for exactly that reason, which is also what RFC-0088 D2 says an
+  image-local discriminant is.
 
 ## Sequencing
 

--- a/packages/core/nros-serdes-packed/Cargo.toml
+++ b/packages/core/nros-serdes-packed/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nros-serdes-packed"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Reference schema-driven serialization provider for nano-ros (RFC-0088 D7)"
+authors.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme = "README.md"
+keywords = ["ros2", "serialization", "no-std", "embedded"]
+categories = ["embedded", "no-std", "encoding"]
+
+[dependencies]
+# The ONLY dependency, and that is the point: a schema-driven provider needs
+# the walk and the schema, and nothing else. No codegen plugin, no per-message
+# generated code, no third-party codec.
+nros-serdes = { path = "../nros-serdes" }
+
+[lints]
+workspace = true

--- a/packages/core/nros-serdes-packed/README.md
+++ b/packages/core/nros-serdes-packed/README.md
@@ -1,0 +1,29 @@
+# nros-serdes-packed
+
+The reference **schema-driven** serialization provider (RFC-0088 D7,
+phase-421 W5). Family `serdes` under RFC-0087.
+
+`packed` is a **test vehicle, not an interop claim.** Nothing else speaks it and
+no backend selects it. It exists so the `impl = "schema"` strategy has a subject
+that actually exercises the schema walk: uORB's wire is the PX4 struct verbatim
+so it walks nothing, and CDR is the `impl = "codegen"` case this strategy is the
+alternative to.
+
+The whole implementation is one `SchemaSink` and one `SchemaSource` — roughly
+150 lines of primitive encode/decode with no recursion and no type knowledge.
+The walk over `&'static [Field]` lives in `nros_serdes::walk`, once. That is the
+claim D7 makes and this package is the measurement of it: **a custom format
+costs no codegen work.**
+
+## Wire
+
+Little-endian, byte-packed, no padding. `u32` length prefix on strings (no NUL)
+and sequences; fixed arrays carry no count; structs carry nothing around their
+fields. Every one of those differs from CDR, deliberately — see the table in
+`src/lib.rs`.
+
+## Round-trip coverage
+
+`packages/testing/nros-tests/tests/schema_serializer_round_trip.rs` transcodes
+every committed generated message in `packages/interfaces/*` through this
+provider and back, in both CDR encodings, and asserts byte equality.

--- a/packages/core/nros-serdes-packed/nros-serdes.toml
+++ b/packages/core/nros-serdes-packed/nros-serdes.toml
@@ -1,0 +1,24 @@
+# nano-ros serialization-format descriptor — RFC-0088 D6, phase-421 W5.
+#
+# The provider announces its NAME in `package.xml`; this file carries only the
+# two facts no convention can derive (RFC-0087 D4).
+[serdes]
+
+# The strategy this provider exists to demonstrate: ONE implementation over the
+# `&'static [Field]` schema codegen already emits, covering every message with
+# no codegen work (RFC-0088 D7). Contrast `nros-serdes/nros-serdes.toml`, which
+# is `"codegen"` because CDR gets a per-type serializer emitted for it.
+impl = "schema"
+
+# Image-local discriminant (RFC-0088 D2). **This number means nothing outside
+# the image that assigned it** — the NAME is what crosses an image boundary.
+#
+# 3 is the next free value after the two `SerializationFormatId` reserves
+# (1 = cdr, 2 = uorb). `check-serdes-descriptors` S3 tolerates a value the enum
+# does not name — it constrains descriptors that USE a reserved name or value,
+# and never demands one exist — so this provider needs no edit to `format.rs`.
+# It does NOT get a `SerializationFormatId` variant, and that is the honest
+# reading of D2: a variant would assert `packed` is an in-tree wire format that
+# a backend speaks, and no backend speaks it. `SchemaSerializer::FORMAT_ID` is a
+# raw `u8` for exactly this reason.
+format_id = 3

--- a/packages/core/nros-serdes-packed/package.xml
+++ b/packages/core/nros-serdes-packed/package.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>nros_serdes_packed</name>
+  <version>0.0.0</version>
+  <description>
+    The reference schema-driven serialization provider (RFC-0088 D7,
+    phase-421 W5).
+
+    `packed` is a TEST VEHICLE, not an interop claim. Nothing else speaks it:
+    it exists so the `impl = "schema"` path has a subject that actually
+    exercises the schema walk. uORB cannot serve — its wire is the PX4 struct
+    verbatim (RFC-0011), so a uORB "serializer" walks nothing — and CDR cannot
+    either, because CDR is the `impl = "codegen"` case this strategy is the
+    alternative to.
+
+    The wire is deliberately the simplest thing that is still DIFFERENT from
+    CDR in every structural way a walk could get wrong: little-endian with no
+    alignment padding, a u32 length prefix on strings and sequences, no NUL
+    terminator, and no DHEADER. A transcode that got any of those wrong would
+    not round-trip.
+
+    See src/lib.rs for the wire spec.
+  </description>
+  <maintainer email="dev@example.com">Developer</maintainer>
+  <license>Apache-2.0</license>
+
+  <depend>nros_serdes</depend>
+
+  <export>
+    <build_type>nros_cargo</build_type>
+    <!--
+      Provision (RFC-0087 D3): this package IS the `packed` serializer. A
+      consumer selects it with `<nano_ros_uses kind="serdes" name="packed"/>`
+      or `[image.<t>] serdes = "packed"`.
+
+      `impl` and `format_id` are in the sibling nros-serdes.toml, because
+      neither can be derived from the name.
+    -->
+    <nano_ros_provides kind="serdes" name="packed"/>
+  </export>
+</package>

--- a/packages/core/nros-serdes-packed/src/lib.rs
+++ b/packages/core/nros-serdes-packed/src/lib.rs
@@ -1,0 +1,434 @@
+//! `packed` — the reference schema-driven serialization provider (RFC-0088 D7,
+//! phase-421 W5).
+//!
+//! # Why this format, and what it is not
+//!
+//! `packed` is a **test vehicle**. It makes no interop claim, nothing else
+//! speaks it, and no backend selects it. It exists because the `impl =
+//! "schema"` strategy needed a subject, and the two formats already in the tree
+//! cannot be one:
+//!
+//! * **uORB** is the PX4 struct verbatim (RFC-0011). A "serializer" for it
+//!   copies bytes and walks no schema at all, so it would prove nothing about
+//!   the walk.
+//! * **CDR** is the `impl = "codegen"` case — the strategy schema-driven
+//!   serialization is the ALTERNATIVE to. Transcoding CDR to CDR would let a
+//!   walk that mishandles alignment still pass.
+//!
+//! So the wire is the simplest thing that still differs from CDR in every
+//! structural way a walk could get wrong. Each difference is a defect the
+//! round-trip would surface:
+//!
+//! | `packed` | CDR | what a bug here would look like |
+//! | --- | --- | --- |
+//! | no alignment padding | pad to natural alignment (capped at 4 under XCDR2) | field values shift after the first odd-width member |
+//! | `u32` byte length, no NUL | `u32` of `len + 1`, then the NUL | strings gain or lose a trailing byte per field |
+//! | nothing per struct | a DHEADER per struct under XCDR2 | a nested struct swallows its parent's next field |
+//! | `u32` count then elements | same | — (the one place they agree) |
+//!
+//! # Wire format
+//!
+//! Little-endian throughout, byte-packed, no padding anywhere.
+//!
+//! ```text
+//! bool          1 byte, 0 or 1
+//! u8 / i8       1 byte
+//! u16 / i16     2 bytes LE
+//! u32 / i32     4 bytes LE
+//! u64 / i64     8 bytes LE
+//! f32 / f64     4 / 8 bytes, IEEE-754 LE bit pattern
+//! string        u32 LE byte count, then that many UTF-8 bytes. No NUL.
+//! array<T, N>   N encodings of T, back to back. No count: N is in the schema.
+//! sequence<T>   u32 LE element count, then that many encodings of T.
+//! struct        its fields in declaration order. Nothing around them.
+//! ```
+//!
+//! There is no self-description: the schema on both sides says what comes next.
+//! That is the whole economy of `impl = "schema"` — the description already
+//! exists in `.rodata`, so the wire does not have to carry it.
+//!
+//! # What it does not encode
+//!
+//! `wstring` / `bounded wstring`. Not a limitation of this format — the CDR
+//! codec has no wide-string primitive in either direction, so there is nothing
+//! to transcode from. The walk refuses those by name
+//! (`SchemaError::Unsupported`); no message in `packages/interfaces/*` has one.
+
+#![no_std]
+
+use nros_serdes::{
+    cdr::{CdrReader, CdrWriter},
+    schema::Field,
+    walk::{
+        SchemaError, SchemaSerializer, SchemaSink, SchemaSource, decode_to_cdr, encode_from_cdr,
+    },
+};
+
+/// Cross-image identity (RFC-0088 D2). Must equal the `name` in `package.xml`.
+pub const FORMAT_NAME: &str = "packed";
+
+/// Image-local discriminant. Must equal `format_id` in `nros-serdes.toml`.
+///
+/// A raw `u8`, not a `SerializationFormatId` variant: the enum reserves values
+/// for formats a BACKEND speaks, and none speaks this one.
+pub const FORMAT_ID: u8 = 3;
+
+/// The `packed` format, as a type.
+pub struct Packed;
+
+/// Encoder: appends `packed` values into a caller-owned buffer.
+pub struct PackedSink<'a> {
+    out: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> PackedSink<'a> {
+    /// A sink writing into `out` from byte 0.
+    pub fn new(out: &'a mut [u8]) -> Self {
+        Self { out, pos: 0 }
+    }
+
+    /// Bytes written so far.
+    pub fn position(&self) -> usize {
+        self.pos
+    }
+
+    fn raw(&mut self, bytes: &[u8]) -> Result<(), SchemaError> {
+        let end = self
+            .pos
+            .checked_add(bytes.len())
+            .ok_or(SchemaError::BufferTooSmall)?;
+        if end > self.out.len() {
+            return Err(SchemaError::BufferTooSmall);
+        }
+        self.out[self.pos..end].copy_from_slice(bytes);
+        self.pos = end;
+        Ok(())
+    }
+
+    fn len_prefix(&mut self, n: usize) -> Result<(), SchemaError> {
+        let n = u32::try_from(n).map_err(|_| SchemaError::Malformed)?;
+        self.raw(&n.to_le_bytes())
+    }
+}
+
+impl SchemaSink for PackedSink<'_> {
+    fn seq_begin(&mut self, len: usize) -> Result<(), SchemaError> {
+        self.len_prefix(len)
+    }
+    fn put_bool(&mut self, v: bool) -> Result<(), SchemaError> {
+        self.raw(&[u8::from(v)])
+    }
+    fn put_u8(&mut self, v: u8) -> Result<(), SchemaError> {
+        self.raw(&[v])
+    }
+    fn put_i8(&mut self, v: i8) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_u16(&mut self, v: u16) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_i16(&mut self, v: i16) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_u32(&mut self, v: u32) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_i32(&mut self, v: i32) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_u64(&mut self, v: u64) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_i64(&mut self, v: i64) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_f32(&mut self, v: f32) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_f64(&mut self, v: f64) -> Result<(), SchemaError> {
+        self.raw(&v.to_le_bytes())
+    }
+    fn put_str(&mut self, v: &str) -> Result<(), SchemaError> {
+        self.len_prefix(v.len())?;
+        self.raw(v.as_bytes())
+    }
+}
+
+/// Decoder: reads `packed` values out of a borrowed buffer.
+pub struct PackedSource<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> PackedSource<'a> {
+    /// A source reading `bytes` from byte 0.
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    /// Bytes consumed so far.
+    pub fn position(&self) -> usize {
+        self.pos
+    }
+
+    fn raw(&mut self, n: usize) -> Result<&'a [u8], SchemaError> {
+        let end = self.pos.checked_add(n).ok_or(SchemaError::Truncated)?;
+        if end > self.bytes.len() {
+            return Err(SchemaError::Truncated);
+        }
+        let out = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn fixed<const N: usize>(&mut self) -> Result<[u8; N], SchemaError> {
+        let s = self.raw(N)?;
+        let mut buf = [0u8; N];
+        buf.copy_from_slice(s);
+        Ok(buf)
+    }
+
+    fn len_prefix(&mut self) -> Result<usize, SchemaError> {
+        Ok(u32::from_le_bytes(self.fixed::<4>()?) as usize)
+    }
+}
+
+impl SchemaSource for PackedSource<'_> {
+    fn seq_begin(&mut self) -> Result<usize, SchemaError> {
+        let n = self.len_prefix()?;
+        // A count larger than the bytes that remain cannot be honoured, and
+        // believing it would mean a `for 0..n` that fails one element at a
+        // time. Each element is at least one byte, so this is a sound floor.
+        if n > self.bytes.len() - self.pos {
+            return Err(SchemaError::Truncated);
+        }
+        Ok(n)
+    }
+    fn take_bool(&mut self) -> Result<bool, SchemaError> {
+        match self.fixed::<1>()?[0] {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(SchemaError::Malformed),
+        }
+    }
+    fn take_u8(&mut self) -> Result<u8, SchemaError> {
+        Ok(self.fixed::<1>()?[0])
+    }
+    fn take_i8(&mut self) -> Result<i8, SchemaError> {
+        Ok(i8::from_le_bytes(self.fixed::<1>()?))
+    }
+    fn take_u16(&mut self) -> Result<u16, SchemaError> {
+        Ok(u16::from_le_bytes(self.fixed::<2>()?))
+    }
+    fn take_i16(&mut self) -> Result<i16, SchemaError> {
+        Ok(i16::from_le_bytes(self.fixed::<2>()?))
+    }
+    fn take_u32(&mut self) -> Result<u32, SchemaError> {
+        Ok(u32::from_le_bytes(self.fixed::<4>()?))
+    }
+    fn take_i32(&mut self) -> Result<i32, SchemaError> {
+        Ok(i32::from_le_bytes(self.fixed::<4>()?))
+    }
+    fn take_u64(&mut self) -> Result<u64, SchemaError> {
+        Ok(u64::from_le_bytes(self.fixed::<8>()?))
+    }
+    fn take_i64(&mut self) -> Result<i64, SchemaError> {
+        Ok(i64::from_le_bytes(self.fixed::<8>()?))
+    }
+    fn take_f32(&mut self) -> Result<f32, SchemaError> {
+        Ok(f32::from_le_bytes(self.fixed::<4>()?))
+    }
+    fn take_f64(&mut self) -> Result<f64, SchemaError> {
+        Ok(f64::from_le_bytes(self.fixed::<8>()?))
+    }
+    fn take_str(&mut self) -> Result<&str, SchemaError> {
+        let n = self.len_prefix()?;
+        let bytes = self.raw(n)?;
+        core::str::from_utf8(bytes).map_err(|_| SchemaError::Malformed)
+    }
+}
+
+impl SchemaSerializer for Packed {
+    const FORMAT_NAME: &'static str = FORMAT_NAME;
+    const FORMAT_ID: u8 = FORMAT_ID;
+
+    fn serialize(
+        msg: &mut CdrReader<'_>,
+        type_name: &str,
+        schema: &'static [Field],
+        out: &mut [u8],
+    ) -> Result<usize, SchemaError> {
+        let mut sink = PackedSink::new(out);
+        encode_from_cdr(msg, type_name, schema, &mut sink)?;
+        Ok(sink.position())
+    }
+
+    fn deserialize(
+        bytes: &[u8],
+        type_name: &str,
+        schema: &'static [Field],
+        msg: &mut CdrWriter<'_>,
+    ) -> Result<usize, SchemaError> {
+        let mut source = PackedSource::new(bytes);
+        decode_to_cdr(&mut source, type_name, schema, msg)?;
+        Ok(source.position())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nros_serdes::schema::{FieldType, NestedType};
+
+    const TIME_FIELDS: &[Field] = &[
+        Field {
+            name: "sec",
+            ty: FieldType::Int32,
+            offset: 0,
+        },
+        Field {
+            name: "nanosec",
+            ty: FieldType::Uint32,
+            offset: 4,
+        },
+    ];
+    const TIME: NestedType = NestedType {
+        type_name: "builtin_interfaces/msg/Time",
+        fields: TIME_FIELDS,
+    };
+
+    /// `u8` then `i64`: CDR pads seven bytes to reach 8-byte alignment,
+    /// `packed` does not. If the walk ever inherited CDR's padding rule this
+    /// assertion is the one that fails.
+    #[test]
+    fn packed_has_no_alignment_padding_where_cdr_does() {
+        const FIELDS: &[Field] = &[
+            Field {
+                name: "tag",
+                ty: FieldType::Uint8,
+                offset: 0,
+            },
+            Field {
+                name: "value",
+                ty: FieldType::Int64,
+                offset: 8,
+            },
+        ];
+
+        let mut cdr = [0u8; 64];
+        let cdr_len = {
+            let mut w = CdrWriter::new(&mut cdr);
+            w.write_u8(0xAA).unwrap();
+            w.write_i64(-1).unwrap();
+            w.position()
+        };
+        assert_eq!(cdr_len, 16, "1 byte + 7 pad + 8");
+
+        let mut out = [0u8; 64];
+        let mut r = CdrReader::new(&cdr[..cdr_len]);
+        let n = Packed::serialize(&mut r, "t/msg/M", FIELDS, &mut out).unwrap();
+        assert_eq!(n, 9, "packed writes 1 + 8 with nothing between");
+        assert_eq!(
+            &out[..9],
+            &[0xAA, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+        );
+    }
+
+    /// A string is `len` bytes with no NUL, where CDR writes `len + 1` and one.
+    #[test]
+    fn a_string_carries_no_nul_and_no_off_by_one() {
+        const FIELDS: &[Field] = &[Field {
+            name: "text",
+            ty: FieldType::String,
+            offset: 0,
+        }];
+
+        let mut cdr = [0u8; 64];
+        let cdr_len = {
+            let mut w = CdrWriter::new(&mut cdr);
+            w.write_string("hi").unwrap();
+            w.position()
+        };
+        assert_eq!(cdr_len, 4 + 3, "CDR: u32 len+1, 'hi', NUL");
+
+        let mut out = [0u8; 64];
+        let mut r = CdrReader::new(&cdr[..cdr_len]);
+        let n = Packed::serialize(&mut r, "t/msg/S", FIELDS, &mut out).unwrap();
+        assert_eq!(&out[..n], &[2, 0, 0, 0, b'h', b'i']);
+    }
+
+    /// Nested structs are transparent: no DHEADER, no delimiter, nothing.
+    #[test]
+    fn a_nested_struct_adds_nothing_to_the_wire() {
+        const FIELDS: &[Field] = &[Field {
+            name: "stamp",
+            ty: FieldType::Nested(&TIME),
+            offset: 0,
+        }];
+
+        let mut cdr = [0u8; 64];
+        let cdr_len = {
+            // XCDR2, so the CDR side genuinely carries two DHEADERs the packed
+            // side must drop.
+            let mut w = CdrWriter::new_with_header_xcdr2(&mut cdr).unwrap();
+            let outer = w.begin_dheader().unwrap();
+            let inner = w.begin_dheader().unwrap();
+            w.write_i32(1).unwrap();
+            w.write_u32(2).unwrap();
+            w.end_dheader(inner).unwrap();
+            w.end_dheader(outer).unwrap();
+            w.position()
+        };
+
+        let mut out = [0u8; 64];
+        let mut r = CdrReader::new_with_header(&cdr[..cdr_len]).unwrap();
+        let n = Packed::serialize(&mut r, "t/msg/N", FIELDS, &mut out).unwrap();
+        assert_eq!(&out[..n], &[1, 0, 0, 0, 2, 0, 0, 0], "8 bytes, no headers");
+    }
+
+    #[test]
+    fn a_short_output_buffer_errs_rather_than_truncating() {
+        const FIELDS: &[Field] = &[Field {
+            name: "value",
+            ty: FieldType::Uint64,
+            offset: 0,
+        }];
+        let mut cdr = [0u8; 16];
+        let cdr_len = {
+            let mut w = CdrWriter::new(&mut cdr);
+            w.write_u64(7).unwrap();
+            w.position()
+        };
+        let mut out = [0u8; 4];
+        let mut r = CdrReader::new(&cdr[..cdr_len]);
+        assert_eq!(
+            Packed::serialize(&mut r, "t/msg/U", FIELDS, &mut out),
+            Err(SchemaError::BufferTooSmall)
+        );
+    }
+
+    #[test]
+    fn a_truncated_input_errs_rather_than_reading_zero() {
+        const FIELDS: &[Field] = &[Field {
+            name: "value",
+            ty: FieldType::Uint64,
+            offset: 0,
+        }];
+        let mut cdr = [0u8; 32];
+        let mut w = CdrWriter::new(&mut cdr);
+        assert_eq!(
+            Packed::deserialize(&[1, 2, 3], "t/msg/U", FIELDS, &mut w),
+            Err(SchemaError::Truncated)
+        );
+    }
+
+    #[test]
+    fn the_declared_identity_matches_the_descriptor() {
+        // The three spellings of one fact: this crate's consts, the trait
+        // impl, and `nros-serdes.toml`. The first two are checked here; the
+        // third by `check-serdes-descriptors` reading the announcement.
+        assert_eq!(<Packed as SchemaSerializer>::FORMAT_NAME, "packed");
+        assert_eq!(<Packed as SchemaSerializer>::FORMAT_ID, 3);
+    }
+}

--- a/packages/core/nros-serdes/src/lib.rs
+++ b/packages/core/nros-serdes/src/lib.rs
@@ -40,6 +40,7 @@ pub mod primitives;
 pub mod schema;
 pub mod size;
 pub mod traits;
+pub mod walk;
 
 #[cfg(test)]
 mod compat_tests;
@@ -50,6 +51,9 @@ pub use cdr::{
 pub use error::{DeserError, SerError};
 pub use schema::{Field, FieldType, Message, NestedType};
 pub use traits::{Deserialize, DeserializeView, Serialize};
+pub use walk::{
+    SchemaError, SchemaSerializer, SchemaSink, SchemaSource, decode_to_cdr, encode_from_cdr,
+};
 
 /// Length of the CDR encapsulation header (representation identifier + options).
 pub const CDR_HEADER_LEN: usize = 4;

--- a/packages/core/nros-serdes/src/walk.rs
+++ b/packages/core/nros-serdes/src/walk.rs
@@ -1,0 +1,671 @@
+//! phase-421 W5 — the schema-driven serialization strategy (RFC-0088 D7).
+//!
+//! A provider that declares `impl = "schema"` in its `nros-serdes.toml` writes
+//! ONE implementation and gets every message, with no codegen plugin and no
+//! generated code per type. This module is the machinery that makes that true:
+//! the walk over [`crate::schema::Field`] lives here, once, and a provider
+//! supplies only the primitive encode/decode operations of its own wire.
+//!
+//! # The signature RFC-0088 D7 sketched cannot be implemented
+//!
+//! D7 wrote:
+//!
+//! ```text
+//! fn serialize(msg: *const u8, schema: &'static [Field], out: &mut [u8]) -> …
+//! ```
+//!
+//! That takes the HOST STRUCT as a pointer and reads fields at `Field::offset`.
+//! Measured against the schemas codegen actually emits, it stops at the first
+//! variable-length field, and it does so for three independent reasons:
+//!
+//! * **A `String` field's host type is `heapless::String<N>` and the schema
+//!   does not carry `N`.** `nros generate-rust` emits
+//!   `FieldType::String` — the IDL type — for a member whose Rust storage is a
+//!   fixed-capacity buffer. `BoundedString(n)` is the IDL bound, not the host
+//!   capacity, and the two are different numbers.
+//! * **`heapless::String` / `heapless::Vec` are `repr(Rust)`.** Their field
+//!   order and padding are unspecified, so "the length is at offset 0" is not a
+//!   fact this crate is allowed to assume. `Field::offset` is well defined —
+//!   `offset_of!` works on a `repr(Rust)` struct — but it only gets you to the
+//!   START of the container, and the container's own interior is opaque.
+//! * **A nested type's SIZE is not in the schema.** [`crate::schema::NestedType`]
+//!   carries `type_name` and `fields`; striding an `Array(N, Nested(..))` or a
+//!   sequence of structs needs `size_of` of the element, and the largest
+//!   `offset` in a `repr(Rust)` child does not determine it.
+//!
+//! Extending the schema to carry host layout would change what codegen must
+//! emit for every committed generated message, which is a different change from
+//! this one. So the pivot moves: the value access a schema-driven provider has
+//! today is **the CDR byte stream**, which nano-ros already produces for every
+//! message from generated code. `impl = "schema"` is therefore a TRANSCODER
+//! strategy in v1 — CDR in, foreign wire out, and back — and that is precisely
+//! why the walk belongs here rather than in each provider.
+//!
+//! The cost is the one D7 already accepted: schema-driven is slower than the
+//! per-type serializer we emit for CDR, and `impl = "codegen"` is the answer
+//! when someone hits the wall.
+//!
+//! # What the walk does not cover
+//!
+//! `FieldType::WString` / `FieldType::BoundedWString` reach
+//! [`SchemaError::Unsupported`], because [`crate::cdr::CdrReader`] has no
+//! wide-string primitive to read them WITH — there is no `read_wstring`, in
+//! either direction. No message in `packages/interfaces/*` uses one, so this is
+//! a hole in the CDR codec that the schema walk inherits rather than one it
+//! introduces.
+
+use crate::{
+    cdr::{CdrReader, CdrWriter},
+    error::{DeserError, SerError},
+    schema::{Field, FieldType, Message},
+};
+
+/// What can go wrong in a schema-driven encode or decode.
+///
+/// Deliberately separate from [`SerError`] / [`DeserError`]: those describe the
+/// CDR side of a transcode, and a provider's own wire has failure modes CDR
+/// does not (a truncated foreign buffer, a length prefix that disagrees with
+/// the schema).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaError {
+    /// The CDR side failed while reading.
+    CdrRead(DeserError),
+    /// The CDR side failed while writing.
+    CdrWrite(SerError),
+    /// The foreign buffer is too small to hold the encoding.
+    BufferTooSmall,
+    /// The foreign buffer ended in the middle of a value.
+    Truncated,
+    /// The foreign buffer disagrees with the schema — a length prefix past a
+    /// declared bound, a bool that is not 0 or 1, invalid UTF-8.
+    Malformed,
+    /// A schema shape this walk cannot express, with the reason.
+    ///
+    /// Never a silent skip: a field that cannot be walked ends the encode,
+    /// because a partial message on the wire is worse than no message.
+    Unsupported(&'static str),
+}
+
+impl From<DeserError> for SchemaError {
+    fn from(e: DeserError) -> Self {
+        SchemaError::CdrRead(e)
+    }
+}
+
+impl From<SerError> for SchemaError {
+    fn from(e: SerError) -> Self {
+        SchemaError::CdrWrite(e)
+    }
+}
+
+impl core::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SchemaError::CdrRead(e) => write!(f, "cdr read: {e}"),
+            SchemaError::CdrWrite(e) => write!(f, "cdr write: {e}"),
+            SchemaError::BufferTooSmall => write!(f, "output buffer too small"),
+            SchemaError::Truncated => write!(f, "input ended mid-value"),
+            SchemaError::Malformed => write!(f, "input disagrees with the schema"),
+            SchemaError::Unsupported(why) => write!(f, "unsupported schema shape: {why}"),
+        }
+    }
+}
+
+/// The encode half of a schema-driven format: the walk pushes typed values in,
+/// the implementor writes its wire.
+///
+/// Every structural hook has a no-op default, so a flat format like the
+/// reference `packed` provider implements only the primitives. A self-describing
+/// format (one that writes field names, or a per-struct length) overrides the
+/// hooks it needs.
+pub trait SchemaSink {
+    /// Entering a struct — the top-level message, or a nested member.
+    fn struct_begin(&mut self, type_name: &str) -> Result<(), SchemaError> {
+        let _ = type_name;
+        Ok(())
+    }
+    /// Leaving the struct opened by the matching [`Self::struct_begin`].
+    fn struct_end(&mut self) -> Result<(), SchemaError> {
+        Ok(())
+    }
+    /// Entering one field. Carries the whole [`Field`], so a format that writes
+    /// names or types has them without a second lookup.
+    fn field_begin(&mut self, field: &'static Field) -> Result<(), SchemaError> {
+        let _ = field;
+        Ok(())
+    }
+    /// Leaving the field opened by the matching [`Self::field_begin`].
+    fn field_end(&mut self, field: &'static Field) -> Result<(), SchemaError> {
+        let _ = field;
+        Ok(())
+    }
+    /// A fixed-size array of `len` elements is about to be written. No length
+    /// is on the wire unless the format chooses to put one there — `len` comes
+    /// from the schema on both sides.
+    fn array_begin(&mut self, len: usize) -> Result<(), SchemaError> {
+        let _ = len;
+        Ok(())
+    }
+    /// Leaving the array opened by the matching [`Self::array_begin`].
+    fn array_end(&mut self) -> Result<(), SchemaError> {
+        Ok(())
+    }
+    /// A sequence of `len` elements is about to be written. Unlike an array
+    /// this length is DATA, so a format must record it.
+    fn seq_begin(&mut self, len: usize) -> Result<(), SchemaError>;
+    /// Leaving the sequence opened by the matching [`Self::seq_begin`].
+    fn seq_end(&mut self) -> Result<(), SchemaError> {
+        Ok(())
+    }
+
+    /// Write an IDL `boolean`.
+    fn put_bool(&mut self, v: bool) -> Result<(), SchemaError>;
+    /// Write an IDL `octet` / `uint8`.
+    fn put_u8(&mut self, v: u8) -> Result<(), SchemaError>;
+    /// Write an IDL `int8`.
+    fn put_i8(&mut self, v: i8) -> Result<(), SchemaError>;
+    /// Write an IDL `uint16`.
+    fn put_u16(&mut self, v: u16) -> Result<(), SchemaError>;
+    /// Write an IDL `int16`.
+    fn put_i16(&mut self, v: i16) -> Result<(), SchemaError>;
+    /// Write an IDL `uint32`.
+    fn put_u32(&mut self, v: u32) -> Result<(), SchemaError>;
+    /// Write an IDL `int32`.
+    fn put_i32(&mut self, v: i32) -> Result<(), SchemaError>;
+    /// Write an IDL `uint64`.
+    fn put_u64(&mut self, v: u64) -> Result<(), SchemaError>;
+    /// Write an IDL `int64`.
+    fn put_i64(&mut self, v: i64) -> Result<(), SchemaError>;
+    /// Write an IDL `float`.
+    fn put_f32(&mut self, v: f32) -> Result<(), SchemaError>;
+    /// Write an IDL `double`.
+    fn put_f64(&mut self, v: f64) -> Result<(), SchemaError>;
+    /// Write an IDL narrow `string`. The NUL CDR appends is a CDR concern and
+    /// is already stripped — `v` is the payload.
+    fn put_str(&mut self, v: &str) -> Result<(), SchemaError>;
+}
+
+/// The decode half: the walk pulls typed values out, in schema order.
+///
+/// Exactly dual to [`SchemaSink`]. The walk knows what comes next from the
+/// schema, so the implementor never has to parse a type tag it did not write.
+pub trait SchemaSource {
+    /// Entering a struct — the top-level message, or a nested member.
+    fn struct_begin(&mut self, type_name: &str) -> Result<(), SchemaError> {
+        let _ = type_name;
+        Ok(())
+    }
+    /// Leaving the struct opened by the matching [`Self::struct_begin`].
+    fn struct_end(&mut self) -> Result<(), SchemaError> {
+        Ok(())
+    }
+    /// Entering one field.
+    fn field_begin(&mut self, field: &'static Field) -> Result<(), SchemaError> {
+        let _ = field;
+        Ok(())
+    }
+    /// Leaving the field opened by the matching [`Self::field_begin`].
+    fn field_end(&mut self, field: &'static Field) -> Result<(), SchemaError> {
+        let _ = field;
+        Ok(())
+    }
+    /// A fixed-size array of `len` elements follows; `len` is from the schema.
+    fn array_begin(&mut self, len: usize) -> Result<(), SchemaError> {
+        let _ = len;
+        Ok(())
+    }
+    /// Leaving the array opened by the matching [`Self::array_begin`].
+    fn array_end(&mut self) -> Result<(), SchemaError> {
+        Ok(())
+    }
+    /// Read the element count of a sequence off the wire.
+    fn seq_begin(&mut self) -> Result<usize, SchemaError>;
+    /// Leaving the sequence opened by the matching [`Self::seq_begin`].
+    fn seq_end(&mut self) -> Result<(), SchemaError> {
+        Ok(())
+    }
+
+    /// Read an IDL `boolean`.
+    fn take_bool(&mut self) -> Result<bool, SchemaError>;
+    /// Read an IDL `octet` / `uint8`.
+    fn take_u8(&mut self) -> Result<u8, SchemaError>;
+    /// Read an IDL `int8`.
+    fn take_i8(&mut self) -> Result<i8, SchemaError>;
+    /// Read an IDL `uint16`.
+    fn take_u16(&mut self) -> Result<u16, SchemaError>;
+    /// Read an IDL `int16`.
+    fn take_i16(&mut self) -> Result<i16, SchemaError>;
+    /// Read an IDL `uint32`.
+    fn take_u32(&mut self) -> Result<u32, SchemaError>;
+    /// Read an IDL `int32`.
+    fn take_i32(&mut self) -> Result<i32, SchemaError>;
+    /// Read an IDL `uint64`.
+    fn take_u64(&mut self) -> Result<u64, SchemaError>;
+    /// Read an IDL `int64`.
+    fn take_i64(&mut self) -> Result<i64, SchemaError>;
+    /// Read an IDL `float`.
+    fn take_f32(&mut self) -> Result<f32, SchemaError>;
+    /// Read an IDL `double`.
+    fn take_f64(&mut self) -> Result<f64, SchemaError>;
+    /// Read an IDL narrow `string`, borrowed out of the source buffer.
+    fn take_str(&mut self) -> Result<&str, SchemaError>;
+}
+
+/// Walk `schema`, reading CDR and pushing each value into `sink`.
+///
+/// `reader` must be positioned at the start of the struct's members (past the
+/// encapsulation header). The DHEADER handling mirrors a generated `serialize`
+/// exactly: one per struct, top-level AND nested, a no-op under XCDR1 — the
+/// same rule `crate::size` was written against.
+pub fn encode_from_cdr<S: SchemaSink + ?Sized>(
+    reader: &mut CdrReader<'_>,
+    type_name: &str,
+    schema: &'static [Field],
+    sink: &mut S,
+) -> Result<(), SchemaError> {
+    let scope = reader.begin_dheader()?;
+    sink.struct_begin(type_name)?;
+    for field in schema {
+        sink.field_begin(field)?;
+        encode_one(reader, &field.ty, sink)?;
+        sink.field_end(field)?;
+    }
+    sink.struct_end()?;
+    reader.end_dheader(scope)?;
+    Ok(())
+}
+
+fn encode_one<S: SchemaSink + ?Sized>(
+    r: &mut CdrReader<'_>,
+    ty: &'static FieldType,
+    sink: &mut S,
+) -> Result<(), SchemaError> {
+    match ty {
+        FieldType::Bool => sink.put_bool(r.read_bool()?),
+        FieldType::Uint8 => sink.put_u8(r.read_u8()?),
+        FieldType::Int8 => sink.put_i8(r.read_i8()?),
+        FieldType::Uint16 => sink.put_u16(r.read_u16()?),
+        FieldType::Int16 => sink.put_i16(r.read_i16()?),
+        FieldType::Uint32 => sink.put_u32(r.read_u32()?),
+        FieldType::Int32 => sink.put_i32(r.read_i32()?),
+        FieldType::Uint64 => sink.put_u64(r.read_u64()?),
+        FieldType::Int64 => sink.put_i64(r.read_i64()?),
+        FieldType::Float32 => sink.put_f32(r.read_f32()?),
+        FieldType::Float64 => sink.put_f64(r.read_f64()?),
+        FieldType::String => sink.put_str(r.read_string()?),
+        FieldType::BoundedString(n) => {
+            let s = r.read_string()?;
+            // The bound is an IDL fact the peer may have violated; refusing
+            // here is what stops it becoming the provider's problem.
+            if s.len() > *n {
+                return Err(SchemaError::Malformed);
+            }
+            sink.put_str(s)
+        }
+        FieldType::WString | FieldType::BoundedWString(_) => Err(SchemaError::Unsupported(
+            "wstring: CdrReader has no wide-string primitive to transcode from",
+        )),
+        FieldType::Nested(nested) => encode_from_cdr(r, nested.type_name, nested.fields, sink),
+        FieldType::Array(n, inner) => {
+            sink.array_begin(*n)?;
+            for _ in 0..*n {
+                encode_one(r, inner, sink)?;
+            }
+            sink.array_end()
+        }
+        FieldType::Sequence(inner) => {
+            let n = r.read_sequence_len()?;
+            sink.seq_begin(n)?;
+            for _ in 0..n {
+                encode_one(r, inner, sink)?;
+            }
+            sink.seq_end()
+        }
+        FieldType::BoundedSequence(cap, inner) => {
+            let n = r.read_sequence_len()?;
+            if n > *cap {
+                return Err(SchemaError::Malformed);
+            }
+            sink.seq_begin(n)?;
+            for _ in 0..n {
+                encode_one(r, inner, sink)?;
+            }
+            sink.seq_end()
+        }
+    }
+}
+
+/// Walk `schema`, pulling each value from `source` and writing CDR.
+///
+/// The exact inverse of [`encode_from_cdr`], including the per-struct DHEADER,
+/// so a value that survives one survives the pair byte-for-byte.
+pub fn decode_to_cdr<S: SchemaSource + ?Sized>(
+    source: &mut S,
+    type_name: &str,
+    schema: &'static [Field],
+    writer: &mut CdrWriter<'_>,
+) -> Result<(), SchemaError> {
+    let mark = writer.begin_dheader()?;
+    source.struct_begin(type_name)?;
+    for field in schema {
+        source.field_begin(field)?;
+        decode_one(source, &field.ty, writer)?;
+        source.field_end(field)?;
+    }
+    source.struct_end()?;
+    writer.end_dheader(mark)?;
+    Ok(())
+}
+
+fn decode_one<S: SchemaSource + ?Sized>(
+    source: &mut S,
+    ty: &'static FieldType,
+    w: &mut CdrWriter<'_>,
+) -> Result<(), SchemaError> {
+    match ty {
+        FieldType::Bool => w.write_bool(source.take_bool()?)?,
+        FieldType::Uint8 => w.write_u8(source.take_u8()?)?,
+        FieldType::Int8 => w.write_i8(source.take_i8()?)?,
+        FieldType::Uint16 => w.write_u16(source.take_u16()?)?,
+        FieldType::Int16 => w.write_i16(source.take_i16()?)?,
+        FieldType::Uint32 => w.write_u32(source.take_u32()?)?,
+        FieldType::Int32 => w.write_i32(source.take_i32()?)?,
+        FieldType::Uint64 => w.write_u64(source.take_u64()?)?,
+        FieldType::Int64 => w.write_i64(source.take_i64()?)?,
+        FieldType::Float32 => w.write_f32(source.take_f32()?)?,
+        FieldType::Float64 => w.write_f64(source.take_f64()?)?,
+        FieldType::String => {
+            let s = source.take_str()?;
+            w.write_string(s)?;
+        }
+        FieldType::BoundedString(n) => {
+            let s = source.take_str()?;
+            if s.len() > *n {
+                return Err(SchemaError::Malformed);
+            }
+            w.write_string(s)?;
+        }
+        FieldType::WString | FieldType::BoundedWString(_) => {
+            return Err(SchemaError::Unsupported(
+                "wstring: CdrWriter has no wide-string primitive to transcode into",
+            ));
+        }
+        FieldType::Nested(nested) => {
+            decode_to_cdr(source, nested.type_name, nested.fields, w)?;
+        }
+        FieldType::Array(n, inner) => {
+            source.array_begin(*n)?;
+            for _ in 0..*n {
+                decode_one(source, inner, w)?;
+            }
+            source.array_end()?;
+        }
+        FieldType::Sequence(inner) => {
+            let n = source.seq_begin()?;
+            w.write_sequence_len(n)?;
+            for _ in 0..n {
+                decode_one(source, inner, w)?;
+            }
+            source.seq_end()?;
+        }
+        FieldType::BoundedSequence(cap, inner) => {
+            let n = source.seq_begin()?;
+            if n > *cap {
+                return Err(SchemaError::Malformed);
+            }
+            w.write_sequence_len(n)?;
+            for _ in 0..n {
+                decode_one(source, inner, w)?;
+            }
+            source.seq_end()?;
+        }
+    }
+    Ok(())
+}
+
+/// A serialization format implemented once, by walking the schema (RFC-0088 D7).
+///
+/// # How this differs from the D7 sketch, and why
+///
+/// D7 wrote `serialize(msg: *const u8, schema, out)`. The host struct pointer
+/// is not usable — see the module docs for the three measured reasons — so the
+/// message side of both methods is the CDR byte stream instead: a
+/// [`CdrReader`] positioned at the members on the way out, a [`CdrWriter`] on
+/// the way back. Everything else survives: one implementation, every message,
+/// no generated code, the schema as the only description.
+///
+/// The second added parameter is `type_name`. A `&'static [Field]` slice has no
+/// name of its own — [`Message::TYPE_NAME`] is a separate const, and nested
+/// members carry theirs in [`crate::schema::NestedType`] — so without it the
+/// top-level struct would be the one node a self-describing format could not
+/// name. Use [`SchemaSerializer::serialize_message`] to supply both from a type.
+pub trait SchemaSerializer {
+    /// Cross-image identity (RFC-0088 D2). The string, never the number, is
+    /// what crosses an image boundary.
+    const FORMAT_NAME: &'static str;
+
+    /// Image-local discriminant, as a raw `u8` rather than a
+    /// [`crate::format::SerializationFormatId`]: the enum reserves values for
+    /// in-tree formats, and a third-party provider is assigned one by the build
+    /// from the set of formats its image declares. A provider that becomes
+    /// in-tree gains a variant; one that does not still has a number here.
+    const FORMAT_ID: u8;
+
+    /// Encode one message from its CDR form into `out`, returning bytes written.
+    fn serialize(
+        msg: &mut CdrReader<'_>,
+        type_name: &str,
+        schema: &'static [Field],
+        out: &mut [u8],
+    ) -> Result<usize, SchemaError>;
+
+    /// Decode one message from `bytes` into CDR, returning bytes consumed.
+    fn deserialize(
+        bytes: &[u8],
+        type_name: &str,
+        schema: &'static [Field],
+        msg: &mut CdrWriter<'_>,
+    ) -> Result<usize, SchemaError>;
+
+    /// [`Self::serialize`] with the name and schema taken from the type.
+    fn serialize_message<M: Message>(
+        msg: &mut CdrReader<'_>,
+        out: &mut [u8],
+    ) -> Result<usize, SchemaError>
+    where
+        Self: Sized,
+    {
+        Self::serialize(msg, M::TYPE_NAME, M::FIELDS, out)
+    }
+
+    /// [`Self::deserialize`] with the name and schema taken from the type.
+    fn deserialize_message<M: Message>(
+        bytes: &[u8],
+        msg: &mut CdrWriter<'_>,
+    ) -> Result<usize, SchemaError>
+    where
+        Self: Sized,
+    {
+        Self::deserialize(bytes, M::TYPE_NAME, M::FIELDS, msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::NestedType;
+
+    /// A sink that records the walk as text, so the ORDER of the callbacks is
+    /// asserted rather than assumed. It writes no wire at all — the point is
+    /// that a provider sees the structure, not just a flat value stream.
+    #[derive(Default)]
+    struct Trace {
+        out: heapless::String<512>,
+    }
+
+    impl Trace {
+        fn push(&mut self, s: &str) -> Result<(), SchemaError> {
+            self.out
+                .push_str(s)
+                .map_err(|_| SchemaError::BufferTooSmall)
+        }
+    }
+
+    impl SchemaSink for Trace {
+        fn struct_begin(&mut self, type_name: &str) -> Result<(), SchemaError> {
+            self.push("{")?;
+            self.push(type_name)
+        }
+        fn struct_end(&mut self) -> Result<(), SchemaError> {
+            self.push("}")
+        }
+        fn field_begin(&mut self, field: &'static Field) -> Result<(), SchemaError> {
+            self.push(" ")?;
+            self.push(field.name)?;
+            self.push("=")
+        }
+        fn seq_begin(&mut self, len: usize) -> Result<(), SchemaError> {
+            self.push(if len == 0 { "[0" } else { "[n" })
+        }
+        fn seq_end(&mut self) -> Result<(), SchemaError> {
+            self.push("]")
+        }
+        fn put_bool(&mut self, _: bool) -> Result<(), SchemaError> {
+            self.push("b")
+        }
+        fn put_u8(&mut self, _: u8) -> Result<(), SchemaError> {
+            self.push("u8")
+        }
+        fn put_i8(&mut self, _: i8) -> Result<(), SchemaError> {
+            self.push("i8")
+        }
+        fn put_u16(&mut self, _: u16) -> Result<(), SchemaError> {
+            self.push("u16")
+        }
+        fn put_i16(&mut self, _: i16) -> Result<(), SchemaError> {
+            self.push("i16")
+        }
+        fn put_u32(&mut self, _: u32) -> Result<(), SchemaError> {
+            self.push("u32")
+        }
+        fn put_i32(&mut self, _: i32) -> Result<(), SchemaError> {
+            self.push("i32")
+        }
+        fn put_u64(&mut self, _: u64) -> Result<(), SchemaError> {
+            self.push("u64")
+        }
+        fn put_i64(&mut self, _: i64) -> Result<(), SchemaError> {
+            self.push("i64")
+        }
+        fn put_f32(&mut self, _: f32) -> Result<(), SchemaError> {
+            self.push("f32")
+        }
+        fn put_f64(&mut self, _: f64) -> Result<(), SchemaError> {
+            self.push("f64")
+        }
+        fn put_str(&mut self, v: &str) -> Result<(), SchemaError> {
+            self.push("\"")?;
+            self.push(v)?;
+            self.push("\"")
+        }
+    }
+
+    const TIME_FIELDS: &[Field] = &[
+        Field {
+            name: "sec",
+            ty: FieldType::Int32,
+            offset: 0,
+        },
+        Field {
+            name: "nanosec",
+            ty: FieldType::Uint32,
+            offset: 4,
+        },
+    ];
+    const TIME: NestedType = NestedType {
+        type_name: "builtin_interfaces/msg/Time",
+        fields: TIME_FIELDS,
+    };
+    const HEADER_FIELDS: &[Field] = &[
+        Field {
+            name: "stamp",
+            ty: FieldType::Nested(&TIME),
+            offset: 0,
+        },
+        Field {
+            name: "frame_id",
+            ty: FieldType::String,
+            offset: 8,
+        },
+    ];
+
+    fn header_cdr(buf: &mut [u8]) -> usize {
+        let mut w = CdrWriter::new(buf);
+        let dh = w.begin_dheader().unwrap();
+        let inner = w.begin_dheader().unwrap();
+        w.write_i32(7).unwrap();
+        w.write_u32(8).unwrap();
+        w.end_dheader(inner).unwrap();
+        w.write_string("map").unwrap();
+        w.end_dheader(dh).unwrap();
+        w.position()
+    }
+
+    #[test]
+    fn the_walk_visits_nested_structs_in_declaration_order() {
+        let mut buf = [0u8; 64];
+        let len = header_cdr(&mut buf);
+        let mut r = CdrReader::new(&buf[..len]);
+        let mut trace = Trace::default();
+        encode_from_cdr(&mut r, "std_msgs/msg/Header", HEADER_FIELDS, &mut trace).unwrap();
+        assert_eq!(
+            trace.out.as_str(),
+            "{std_msgs/msg/Header stamp={builtin_interfaces/msg/Time sec=i32 nanosec=u32} \
+             frame_id=\"map\"}"
+        );
+    }
+
+    #[test]
+    fn a_wstring_is_refused_by_name_rather_than_skipped() {
+        const WIDE: &[Field] = &[Field {
+            name: "text",
+            ty: FieldType::WString,
+            offset: 0,
+        }];
+        let buf = [0u8; 16];
+        let mut r = CdrReader::new(&buf);
+        let mut trace = Trace::default();
+        let err = encode_from_cdr(&mut r, "t/msg/W", WIDE, &mut trace).unwrap_err();
+        match err {
+            SchemaError::Unsupported(why) => assert!(why.contains("wstring"), "got {why:?}"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_bounded_sequence_past_its_bound_is_malformed_not_accepted() {
+        const ELEM: FieldType = FieldType::Uint8;
+        const FIELDS: &[Field] = &[Field {
+            name: "data",
+            ty: FieldType::BoundedSequence(2, &ELEM),
+            offset: 0,
+        }];
+        let mut buf = [0u8; 32];
+        let len = {
+            let mut w = CdrWriter::new(&mut buf);
+            let dh = w.begin_dheader().unwrap();
+            w.write_sequence_len(5).unwrap();
+            for _ in 0..5 {
+                w.write_u8(1).unwrap();
+            }
+            w.end_dheader(dh).unwrap();
+            w.position()
+        };
+        let mut r = CdrReader::new(&buf[..len]);
+        let mut trace = Trace::default();
+        assert_eq!(
+            encode_from_cdr(&mut r, "t/msg/B", FIELDS, &mut trace),
+            Err(SchemaError::Malformed)
+        );
+    }
+}

--- a/packages/testing/nros-tests/Cargo.toml
+++ b/packages/testing/nros-tests/Cargo.toml
@@ -529,4 +529,9 @@ nros-lifecycle-msgs = { path = "../../interfaces/lifecycle-msgs/generated/humble
 nros-std-msgs-diag = { path = "../../interfaces/diagnostic-msgs/generated/humble/nros-std-msgs-diag" }
 nros-diagnostic-msgs = { path = "../../interfaces/diagnostic-msgs/generated/humble/nros-diagnostic-msgs" }
 nros-builtin-interfaces-diag = { path = "../../interfaces/diagnostic-msgs/generated/humble/nros-builtin-interfaces-diag" }
+# phase-421 W5 — the reference schema-driven serdes provider (RFC-0088 D7).
+# `schema_serializer_round_trip` transcodes every generated message above
+# through it and back. A dev-dep, like the generated crates it is exercised
+# against: nothing downstream links `packed`, and no backend speaks it.
+nros-serdes-packed = { path = "../../core/nros-serdes-packed" }
 

--- a/packages/testing/nros-tests/bins/action-client-multigoal/package.xml
+++ b/packages/testing/nros-tests/bins/action-client-multigoal/package.xml
@@ -14,6 +14,6 @@
   <depend>example_interfaces</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/action-raw-goal-probe/package.xml
+++ b/packages/testing/nros-tests/bins/action-raw-goal-probe/package.xml
@@ -11,7 +11,7 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cmake</build_type>
     <nano_ros deploy="native"/>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/action-server-concurrent/package.xml
+++ b/packages/testing/nros-tests/bins/action-server-concurrent/package.xml
@@ -14,6 +14,6 @@
   <depend>example_interfaces</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/cdr-roundtrip-qemu/package.xml
+++ b/packages/testing/nros-tests/bins/cdr-roundtrip-qemu/package.xml
@@ -7,6 +7,6 @@
   <license>MIT OR Apache-2.0</license>
   <depend>std_msgs</depend>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/declarative-safety-listener/package.xml
+++ b/packages/testing/nros-tests/bins/declarative-safety-listener/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/entry-poc/package.xml
+++ b/packages/testing/nros-tests/bins/entry-poc/package.xml
@@ -8,6 +8,6 @@
   <license>MIT OR Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/graph-probe/package.xml
+++ b/packages/testing/nros-tests/bins/graph-probe/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/header-chatter-talker/package.xml
+++ b/packages/testing/nros-tests/bins/header-chatter-talker/package.xml
@@ -15,6 +15,6 @@
   <depend>builtin_interfaces</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/int32-sink/package.xml
+++ b/packages/testing/nros-tests/bins/int32-sink/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/message-info-observer/package.xml
+++ b/packages/testing/nros-tests/bins/message-info-observer/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/param-chatter-talker/package.xml
+++ b/packages/testing/nros-tests/bins/param-chatter-talker/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/qemu-baremetal-main-e2e/package.xml
+++ b/packages/testing/nros-tests/bins/qemu-baremetal-main-e2e/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/ros-edition-pose-pub/package.xml
+++ b/packages/testing/nros-tests/bins/ros-edition-pose-pub/package.xml
@@ -12,4 +12,7 @@
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <depend>geometry_msgs</depend>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/bins/rtic-run-plan-e2e/package.xml
+++ b/packages/testing/nros-tests/bins/rtic-run-plan-e2e/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/safety-chatter-listener/package.xml
+++ b/packages/testing/nros-tests/bins/safety-chatter-listener/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/bins/safety-chatter-talker/package.xml
+++ b/packages/testing/nros-tests/bins/safety-chatter-talker/package.xml
@@ -14,6 +14,6 @@
   <depend>std_msgs</depend>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/board_import_fvp/package.xml
+++ b/packages/testing/nros-tests/fixtures/board_import_fvp/package.xml
@@ -5,5 +5,5 @@
   <description>Phase 215.E.1 fixture — minimal ASI-shaped Zephyr consumer that imports a nano-ros board crate via nano_ros_use_board().</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>Apache-2.0</license>
-  <export><build_type>ament_nros</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_cpp/src/demo_entry/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_cpp/src/demo_entry/package.xml
@@ -6,5 +6,5 @@
   <license>MIT</license>
   <exec_depend>talker_pkg</exec_depend>
   <exec_depend>listener_pkg</exec_depend>
-  <export><build_type>ament_nros</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_cpp/src/listener_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_cpp/src/listener_pkg/package.xml
@@ -4,5 +4,5 @@
   <description>Phase 212.D pure-cpp fixture — listener component.</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>MIT</license>
-  <export><build_type>ament_cmake</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_cpp/src/talker_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_cpp/src/talker_pkg/package.xml
@@ -4,5 +4,5 @@
   <description>Phase 212.D pure-cpp fixture — talker component.</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>MIT</license>
-  <export><build_type>ament_cmake</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_esp_idf/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_esp_idf/demo_bringup/package.xml
@@ -7,5 +7,5 @@
   <license>MIT</license>
   <exec_depend>talker_pkg</exec_depend>
   <exec_depend>listener_pkg</exec_depend>
-  <export><build_type>ament_nros</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/demo_bringup/package.xml
@@ -9,6 +9,6 @@
   <exec_depend>talker_pkg</exec_depend>
   <exec_depend>listener_pkg</exec_depend>
   <export>
-    <build_type>nros_bringup</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/firmware/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/firmware/package.xml
@@ -12,6 +12,6 @@
   <exec_depend>talker_pkg</exec_depend>
   <exec_depend>listener_pkg</exec_depend>
   <export>
-    <build_type>nros_entry</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/listener_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/listener_pkg/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/talker_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_freertos/src/talker_pkg/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_mixed/src/listener_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_mixed/src/listener_pkg/package.xml
@@ -4,5 +4,5 @@
   <description>Phase 212.D mixed fixture — listener component.</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>MIT</license>
-  <export><build_type>ament_cmake</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_mixed/src/talker_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_mixed/src/talker_pkg/package.xml
@@ -4,5 +4,5 @@
   <description>Phase 212.D mixed fixture — Rust talker component.</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>MIT</license>
-  <export><build_type>ament_cargo</build_type></export>
+  <export><build_type>nros_cargo</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_nuttx/src/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_nuttx/src/demo_bringup/package.xml
@@ -6,5 +6,5 @@
   <license>MIT</license>
   <exec_depend>talker_pkg</exec_depend>
   <exec_depend>listener_pkg</exec_depend>
-  <export><build_type>ament_nros</build_type></export>
+  <export><build_type>nros_cargo</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_px4/brake_arbiter_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_px4/brake_arbiter_pkg/package.xml
@@ -4,5 +4,5 @@
   <description>Phase 212.H.7 PX4 fixture — brake_arbiter component.</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>MIT</license>
-  <export><build_type>ament_cmake</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_px4/talker_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_px4/talker_pkg/package.xml
@@ -4,5 +4,5 @@
   <description>Phase 212.H.7 PX4 fixture — talker component.</description>
   <maintainer email="noreply@example.com">nano-ros</maintainer>
   <license>MIT</license>
-  <export><build_type>ament_cmake</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/multi_pkg_workspace_zephyr/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/multi_pkg_workspace_zephyr/demo_bringup/package.xml
@@ -7,5 +7,5 @@
   <license>MIT</license>
   <exec_depend>talker_pkg</exec_depend>
   <exec_depend>listener_pkg</exec_depend>
-  <export><build_type>ament_nros</build_type></export>
+  <export><build_type>nros_cmake</build_type></export>
 </package>

--- a/packages/testing/nros-tests/fixtures/n9_workspace/src/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/n9_workspace/src/demo_bringup/package.xml
@@ -7,6 +7,6 @@
   <license>MIT OR Apache-2.0</license>
   <exec_depend>talker_pkg</exec_depend>
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/n9_workspace/src/demo_entry/package.xml
+++ b/packages/testing/nros-tests/fixtures/n9_workspace/src/demo_entry/package.xml
@@ -7,6 +7,6 @@
   <license>MIT OR Apache-2.0</license>
   <exec_depend>demo_bringup</exec_depend>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/n9_workspace/src/talker_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/n9_workspace/src/talker_pkg/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.com">Developer</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/freertos_entry/package.xml
+++ b/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/freertos_entry/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/posix_entry/package.xml
+++ b/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/posix_entry/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/shared_node_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/n_board_agnostic_run_plan/src/shared_node_pkg/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/demo_entry/package.xml
+++ b/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/demo_entry/package.xml
@@ -7,6 +7,6 @@
   <license>MIT OR Apache-2.0</license>
   <exec_depend>demo_bringup</exec_depend>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/node_a/package.xml
+++ b/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/node_a/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.com">Developer</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/node_b/package.xml
+++ b/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/node_b/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.com">Developer</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/node_c/package.xml
+++ b/packages/testing/nros-tests/fixtures/o4_pkg_index_workspace/src/node_c/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.com">Developer</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o5_nav2_compat_smoke/src/demo_entry/package.xml
+++ b/packages/testing/nros-tests/fixtures/o5_nav2_compat_smoke/src/demo_entry/package.xml
@@ -8,6 +8,6 @@
   <exec_depend>primary_node</exec_depend>
   <exec_depend>secondary_node</exec_depend>
   <export>
-    <build_type>nros_entry</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o5_nav2_compat_smoke/src/primary_node/package.xml
+++ b/packages/testing/nros-tests/fixtures/o5_nav2_compat_smoke/src/primary_node/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/o5_nav2_compat_smoke/src/secondary_node/package.xml
+++ b/packages/testing/nros-tests/fixtures/o5_nav2_compat_smoke/src/secondary_node/package.xml
@@ -6,6 +6,6 @@
   <maintainer email="dev@example.org">nano-ros tests</maintainer>
   <license>MIT OR Apache-2.0</license>
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_composable/demo_container_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_composable/demo_container_bringup/package.xml
@@ -10,6 +10,6 @@
   <exec_depend>demo_container</exec_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_composable/src/demo_container/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_composable/src/demo_container/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_conditionals/demo_cond_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_conditionals/demo_cond_bringup/package.xml
@@ -10,6 +10,6 @@
   <exec_depend>demo_cond</exec_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_conditionals/src/demo_cond/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_conditionals/src/demo_cond/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_e2e/demo_pkg_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_e2e/demo_pkg_bringup/package.xml
@@ -10,6 +10,6 @@
   <exec_depend>demo_pkg</exec_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_e2e/src/demo_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_e2e/src/demo_pkg/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_includes/demo_inc_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_includes/demo_inc_bringup/package.xml
@@ -10,6 +10,6 @@
   <exec_depend>demo_inc</exec_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_includes/src/demo_inc/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_includes/src/demo_inc/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_set_remap_env/demo_se_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_set_remap_env/demo_se_bringup/package.xml
@@ -10,6 +10,6 @@
   <exec_depend>demo_se</exec_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_set_remap_env/src/demo_se/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_set_remap_env/src/demo_se/package.xml
@@ -8,6 +8,6 @@
   <license>Apache-2.0</license>
 
   <export>
-    <build_type>ament_cargo</build_type>
+    <build_type>nros_cargo</build_type>
   </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_tiers_freertos/src/ctrl_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_tiers_freertos/src/ctrl_pkg/package.xml
@@ -5,4 +5,7 @@
   <description>Phase 228.E.2 fixture node</description>
   <maintainer email="dev@example.com">dev</maintainer>
   <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_tiers_freertos/src/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_tiers_freertos/src/demo_bringup/package.xml
@@ -5,4 +5,7 @@
   <description>Phase 228.E.2 multi-tier freertos bringup</description>
   <maintainer email="dev@example.com">dev</maintainer>
   <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_tiers_freertos/src/telem_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_tiers_freertos/src/telem_pkg/package.xml
@@ -5,4 +5,7 @@
   <description>Phase 228.E.2 fixture node</description>
   <maintainer email="dev@example.com">dev</maintainer>
   <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_tiers_native/src/ctrl_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_tiers_native/src/ctrl_pkg/package.xml
@@ -5,4 +5,7 @@
   <description>Phase 228.G fixture control node</description>
   <maintainer email="dev@example.com">dev</maintainer>
   <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_tiers_native/src/demo_bringup/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_tiers_native/src/demo_bringup/package.xml
@@ -5,4 +5,7 @@
   <description>Phase 228.G fixture multi-tier bringup</description>
   <maintainer email="dev@example.com">dev</maintainer>
   <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/fixtures/orchestration_tiers_native/src/telem_pkg/package.xml
+++ b/packages/testing/nros-tests/fixtures/orchestration_tiers_native/src/telem_pkg/package.xml
@@ -5,4 +5,7 @@
   <description>Phase 228.G fixture telemetry node</description>
   <maintainer email="dev@example.com">dev</maintainer>
   <license>Apache-2.0</license>
+  <export>
+    <build_type>nros_cargo</build_type>
+  </export>
 </package>

--- a/packages/testing/nros-tests/tests/schema_serializer_round_trip.rs
+++ b/packages/testing/nros-tests/tests/schema_serializer_round_trip.rs
@@ -1,0 +1,504 @@
+//! phase-421 W5 — the schema-driven strategy round-trips every generated
+//! message, with no generated code (RFC-0088 D7).
+//!
+//! The claim `impl = "schema"` makes is that a provider writes ONE
+//! implementation and gets every message. That claim is only worth anything if
+//! it is measured against the messages the tree actually has, so this sweeps
+//! all of `packages/interfaces/*` — every `impl ::nros_serdes::Message`, and
+//! `corpus_is_exhaustive` counts them out of the sources so a message added
+//! later cannot silently sit outside the sweep.
+//!
+//! # Why the message never becomes a Rust value here
+//!
+//! Not laziness — the schema does not permit it. `SchemaSerializer` takes a
+//! `CdrReader`, not the `*const u8` RFC-0088 D7 sketched, because a
+//! `String` field's host type is `heapless::String<N>` with `N` absent from the
+//! schema, `heapless`' containers are `repr(Rust)`, and a nested type's size is
+//! not recorded. `nros_serdes::walk`'s module docs carry the full finding. So
+//! the walk transcodes CDR to `packed` and back, and what this file asserts is
+//! that the two CDR streams are IDENTICAL — a lossless walk, byte for byte.
+//!
+//! Driving the CDR side from the schema rather than from 76 hand-written
+//! literals is the same trade `serialized_size_bound.rs` made in phase-380: the
+//! literals would rot, and rotted literals silently shrink coverage.
+//! `a_real_generated_message_survives_the_round_trip` pins the other end — a
+//! real value through the type's OWN generated `serialize`/`deserialize` — so
+//! the synthetic writer cannot drift from what a publisher runs.
+//!
+//! Both encodings, because a walk that mishandles the XCDR2 DHEADER passes an
+//! XCDR1-only suite.
+
+use std::fs;
+
+use nros_serdes::{
+    cdr::{CdrReader, CdrWriter, EncodingVersion},
+    schema::{Field, FieldType, Message},
+    walk::{SchemaError, SchemaSerializer},
+};
+use nros_serdes_packed::Packed;
+
+/// One corpus row: a label for failure messages, the ROS type name, the schema.
+type Row = (&'static str, &'static str, &'static [Field]);
+
+macro_rules! entry {
+    ($t:ty) => {
+        (
+            stringify!($t),
+            <$t as Message>::TYPE_NAME,
+            <$t as Message>::FIELDS,
+        )
+    };
+}
+
+/// Every committed generated message in `packages/interfaces/*`.
+///
+/// Generated once from the sources and pinned by `corpus_is_exhaustive`, which
+/// re-counts them at run time — so this list cannot fall behind the tree
+/// without a red test naming the difference.
+fn corpus() -> Vec<Row> {
+    vec![
+        entry!(nros_builtin_interfaces::msg::Duration),
+        entry!(nros_builtin_interfaces::msg::Time),
+        entry!(nros_builtin_interfaces_diag::msg::Duration),
+        entry!(nros_builtin_interfaces_diag::msg::Time),
+        entry!(nros_diagnostic_msgs::msg::DiagnosticArray),
+        entry!(nros_diagnostic_msgs::msg::DiagnosticStatus),
+        entry!(nros_diagnostic_msgs::msg::KeyValue),
+        entry!(nros_diagnostic_msgs::srv::AddDiagnosticsRequest),
+        entry!(nros_diagnostic_msgs::srv::AddDiagnosticsResponse),
+        entry!(nros_diagnostic_msgs::srv::SelfTestRequest),
+        entry!(nros_diagnostic_msgs::srv::SelfTestResponse),
+        entry!(nros_lifecycle_msgs::msg::State),
+        entry!(nros_lifecycle_msgs::msg::Transition),
+        entry!(nros_lifecycle_msgs::msg::TransitionDescription),
+        entry!(nros_lifecycle_msgs::msg::TransitionEvent),
+        entry!(nros_lifecycle_msgs::srv::ChangeStateRequest),
+        entry!(nros_lifecycle_msgs::srv::ChangeStateResponse),
+        entry!(nros_lifecycle_msgs::srv::GetAvailableStatesRequest),
+        entry!(nros_lifecycle_msgs::srv::GetAvailableStatesResponse),
+        entry!(nros_lifecycle_msgs::srv::GetAvailableTransitionsRequest),
+        entry!(nros_lifecycle_msgs::srv::GetAvailableTransitionsResponse),
+        entry!(nros_lifecycle_msgs::srv::GetStateRequest),
+        entry!(nros_lifecycle_msgs::srv::GetStateResponse),
+        entry!(nros_rcl_interfaces::msg::FloatingPointRange),
+        entry!(nros_rcl_interfaces::msg::IntegerRange),
+        entry!(nros_rcl_interfaces::msg::ListParametersResult),
+        entry!(nros_rcl_interfaces::msg::Log),
+        entry!(nros_rcl_interfaces::msg::Parameter),
+        entry!(nros_rcl_interfaces::msg::ParameterDescriptor),
+        entry!(nros_rcl_interfaces::msg::ParameterEvent),
+        entry!(nros_rcl_interfaces::msg::ParameterEventDescriptors),
+        entry!(nros_rcl_interfaces::msg::ParameterType),
+        entry!(nros_rcl_interfaces::msg::ParameterValue),
+        entry!(nros_rcl_interfaces::msg::SetParametersResult),
+        entry!(nros_rcl_interfaces::srv::DescribeParametersRequest),
+        entry!(nros_rcl_interfaces::srv::DescribeParametersResponse),
+        entry!(nros_rcl_interfaces::srv::GetParameterTypesRequest),
+        entry!(nros_rcl_interfaces::srv::GetParameterTypesResponse),
+        entry!(nros_rcl_interfaces::srv::GetParametersRequest),
+        entry!(nros_rcl_interfaces::srv::GetParametersResponse),
+        entry!(nros_rcl_interfaces::srv::ListParametersRequest),
+        entry!(nros_rcl_interfaces::srv::ListParametersResponse),
+        entry!(nros_rcl_interfaces::srv::SetParametersAtomicallyRequest),
+        entry!(nros_rcl_interfaces::srv::SetParametersAtomicallyResponse),
+        entry!(nros_rcl_interfaces::srv::SetParametersRequest),
+        entry!(nros_rcl_interfaces::srv::SetParametersResponse),
+        entry!(nros_std_msgs_diag::msg::Bool),
+        entry!(nros_std_msgs_diag::msg::Byte),
+        entry!(nros_std_msgs_diag::msg::ByteMultiArray),
+        entry!(nros_std_msgs_diag::msg::Char),
+        entry!(nros_std_msgs_diag::msg::ColorRGBA),
+        entry!(nros_std_msgs_diag::msg::Empty),
+        entry!(nros_std_msgs_diag::msg::Float32),
+        entry!(nros_std_msgs_diag::msg::Float32MultiArray),
+        entry!(nros_std_msgs_diag::msg::Float64),
+        entry!(nros_std_msgs_diag::msg::Float64MultiArray),
+        entry!(nros_std_msgs_diag::msg::Header),
+        entry!(nros_std_msgs_diag::msg::Int16),
+        entry!(nros_std_msgs_diag::msg::Int16MultiArray),
+        entry!(nros_std_msgs_diag::msg::Int32),
+        entry!(nros_std_msgs_diag::msg::Int32MultiArray),
+        entry!(nros_std_msgs_diag::msg::Int64),
+        entry!(nros_std_msgs_diag::msg::Int64MultiArray),
+        entry!(nros_std_msgs_diag::msg::Int8),
+        entry!(nros_std_msgs_diag::msg::Int8MultiArray),
+        entry!(nros_std_msgs_diag::msg::MultiArrayDimension),
+        entry!(nros_std_msgs_diag::msg::MultiArrayLayout),
+        entry!(nros_std_msgs_diag::msg::String),
+        entry!(nros_std_msgs_diag::msg::UInt16),
+        entry!(nros_std_msgs_diag::msg::UInt16MultiArray),
+        entry!(nros_std_msgs_diag::msg::UInt32),
+        entry!(nros_std_msgs_diag::msg::UInt32MultiArray),
+        entry!(nros_std_msgs_diag::msg::UInt64),
+        entry!(nros_std_msgs_diag::msg::UInt64MultiArray),
+        entry!(nros_std_msgs_diag::msg::UInt8),
+        entry!(nros_std_msgs_diag::msg::UInt8MultiArray),
+    ]
+}
+
+// ── A populated CDR instance, written from the schema ────────────────────────
+
+/// How many elements a variable-length member gets.
+///
+/// Two, not one: a stride bug in the walk (reading an element and then
+/// re-reading it, or skipping one) is invisible at length 1. Two also stays
+/// inside every `heapless` capacity codegen emits, which matters for
+/// `a_real_generated_message_survives_the_round_trip`.
+const SEQ_LEN: usize = 2;
+
+/// Values vary with a counter so a walk that visits fields out of order, or
+/// reuses a value, produces a different byte stream. A constant filler would
+/// make a field-swap bug invisible.
+struct Counter(u64);
+
+impl Counter {
+    fn next(&mut self) -> u64 {
+        // A small LCG. Deterministic, so a failure reproduces exactly.
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        self.0
+    }
+}
+
+/// Write a populated instance of `fields`, or `None` when the schema holds a
+/// shape the CDR codec cannot write.
+fn write_populated(
+    fields: &[Field],
+    version: EncodingVersion,
+    buf: &mut [u8],
+) -> Option<(usize, &'static str)> {
+    let mut w = match version {
+        EncodingVersion::Xcdr1 => CdrWriter::new_with_header(buf).ok()?,
+        EncodingVersion::Xcdr2 => CdrWriter::new_with_header_xcdr2(buf).ok()?,
+    };
+    let mut c = Counter(0x5eed);
+    let dh = w.begin_dheader().ok()?;
+    let unsupported = write_fields(&mut w, fields, &mut c)?;
+    w.end_dheader(dh).ok()?;
+    Some((w.position(), unsupported))
+}
+
+/// `Some("")` on success; `Some(reason)` when a shape was refused. `None` only
+/// for a writer error, which is a bug in this file (buffer too small).
+fn write_fields(w: &mut CdrWriter<'_>, fields: &[Field], c: &mut Counter) -> Option<&'static str> {
+    for f in fields {
+        let refused = write_one(w, &f.ty, c)?;
+        if !refused.is_empty() {
+            return Some(refused);
+        }
+    }
+    Some("")
+}
+
+fn write_one(w: &mut CdrWriter<'_>, ty: &FieldType, c: &mut Counter) -> Option<&'static str> {
+    let n = c.next();
+    match ty {
+        FieldType::Bool => w.write_bool(n & 1 == 1).ok()?,
+        FieldType::Uint8 => w.write_u8(n as u8).ok()?,
+        FieldType::Int8 => w.write_i8(n as i8).ok()?,
+        FieldType::Uint16 => w.write_u16(n as u16).ok()?,
+        FieldType::Int16 => w.write_i16(n as i16).ok()?,
+        FieldType::Uint32 => w.write_u32(n as u32).ok()?,
+        FieldType::Int32 => w.write_i32(n as i32).ok()?,
+        FieldType::Uint64 => w.write_u64(n).ok()?,
+        FieldType::Int64 => w.write_i64(n as i64).ok()?,
+        // Finite and exactly representable, so a bit-pattern comparison is a
+        // fair test of the codec rather than of float formatting.
+        FieldType::Float32 => w.write_f32((n % 1000) as f32 * 0.5).ok()?,
+        FieldType::Float64 => w.write_f64((n % 1000) as f64 * 0.25).ok()?,
+        FieldType::String => w.write_string(&"xy".repeat(1 + (n % 3) as usize)).ok()?,
+        FieldType::BoundedString(cap) => {
+            let len = (*cap).min(4);
+            w.write_string(&"z".repeat(len)).ok()?
+        }
+        FieldType::WString | FieldType::BoundedWString(_) => {
+            return Some("wstring: the CDR codec has no wide-string primitive");
+        }
+        FieldType::Nested(nested) => {
+            let dh = w.begin_dheader().ok()?;
+            let refused = write_fields(w, nested.fields, c)?;
+            if !refused.is_empty() {
+                return Some(refused);
+            }
+            w.end_dheader(dh).ok()?
+        }
+        FieldType::Array(len, inner) => {
+            for _ in 0..*len {
+                let refused = write_one(w, inner, c)?;
+                if !refused.is_empty() {
+                    return Some(refused);
+                }
+            }
+        }
+        FieldType::Sequence(inner) => {
+            w.write_sequence_len(SEQ_LEN).ok()?;
+            for _ in 0..SEQ_LEN {
+                let refused = write_one(w, inner, c)?;
+                if !refused.is_empty() {
+                    return Some(refused);
+                }
+            }
+        }
+        FieldType::BoundedSequence(cap, inner) => {
+            let len = (*cap).min(SEQ_LEN);
+            w.write_sequence_len(len).ok()?;
+            for _ in 0..len {
+                let refused = write_one(w, inner, c)?;
+                if !refused.is_empty() {
+                    return Some(refused);
+                }
+            }
+        }
+    }
+    Some("")
+}
+
+// ── The sweep ────────────────────────────────────────────────────────────────
+
+/// THE property: CDR -> `packed` -> CDR is the identity, for every generated
+/// message, in both encodings, using nothing but the `&'static [Field]` schema.
+#[test]
+fn every_generated_message_round_trips_through_the_schema_walk() {
+    let mut cdr_in = vec![0u8; 1 << 16];
+    let mut foreign = vec![0u8; 1 << 16];
+    let mut cdr_out = vec![0u8; 1 << 16];
+
+    let mut checked = 0usize;
+    let mut refused: Vec<String> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+
+    for (label, type_name, fields) in corpus() {
+        for version in [EncodingVersion::Xcdr1, EncodingVersion::Xcdr2] {
+            let (in_len, why) = write_populated(fields, version, &mut cdr_in)
+                .unwrap_or_else(|| panic!("{label} {version:?}: could not write a CDR instance"));
+            if !why.is_empty() {
+                refused.push(format!("{label} {version:?}: {why}"));
+                continue;
+            }
+
+            // Out: the payload past the encapsulation header is what a
+            // publisher hands the transport, and what the walk consumes.
+            let mut reader = CdrReader::new_with_header(&cdr_in[..in_len]).unwrap();
+            let packed_len = match Packed::serialize(&mut reader, type_name, fields, &mut foreign) {
+                Ok(n) => n,
+                Err(SchemaError::Unsupported(why)) => {
+                    refused.push(format!("{label} {version:?}: {why}"));
+                    continue;
+                }
+                Err(e) => {
+                    failures.push(format!("{label} {version:?}: serialize failed: {e}"));
+                    continue;
+                }
+            };
+
+            // The transcode must consume the whole message and nothing more.
+            if reader.remaining() != 0 {
+                failures.push(format!(
+                    "{label} {version:?}: the walk left {} CDR byte(s) unread — it \
+                     read a different shape than the writer wrote",
+                    reader.remaining()
+                ));
+                continue;
+            }
+
+            // Back.
+            let mut w = match version {
+                EncodingVersion::Xcdr1 => CdrWriter::new_with_header(&mut cdr_out).unwrap(),
+                EncodingVersion::Xcdr2 => CdrWriter::new_with_header_xcdr2(&mut cdr_out).unwrap(),
+            };
+            let consumed =
+                match Packed::deserialize(&foreign[..packed_len], type_name, fields, &mut w) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        failures.push(format!("{label} {version:?}: deserialize failed: {e}"));
+                        continue;
+                    }
+                };
+            let out_len = w.position();
+
+            if consumed != packed_len {
+                failures.push(format!(
+                    "{label} {version:?}: decode consumed {consumed} of {packed_len} \
+                     packed byte(s) — the two halves disagree about the wire"
+                ));
+                continue;
+            }
+            if cdr_in[..in_len] != cdr_out[..out_len] {
+                failures.push(format!(
+                    "{label} {version:?}: round trip changed the CDR ({in_len} -> \
+                     {out_len} bytes)"
+                ));
+                continue;
+            }
+            checked += 1;
+        }
+    }
+
+    // Preconditions, not decoration. An empty corpus, or one where every row
+    // was refused, would make the assertion below vacuous.
+    assert!(
+        checked >= 150,
+        "expected at least 150 (type, encoding) pairs to round-trip — 76 types \
+         times two encodings, minus any refused shape — got {checked}, refused \
+         {}. The corpus or the walk has silently stopped covering things.",
+        refused.len()
+    );
+    assert!(
+        failures.is_empty(),
+        "{} round-trip failure(s):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+    // A refusal is a FINDING, not a pass: nothing in packages/interfaces uses a
+    // wstring, so anything refused here is new information and must be read.
+    assert!(
+        refused.is_empty(),
+        "{} shape(s) the schema walk could not express — this is a finding \
+         about the schema, not a tolerated skip:\n{}",
+        refused.len(),
+        refused.join("\n")
+    );
+    eprintln!("schema walk: {checked} (type, encoding) pair(s) round-tripped");
+}
+
+/// The corpus above is a hand-maintained list, and a hand-maintained list of
+/// what to test is exactly the thing that goes stale. Count the real ones.
+#[test]
+fn corpus_is_exhaustive() {
+    let root = nros_tests::project_root().join("packages/interfaces");
+    assert!(
+        root.is_dir(),
+        "packages/interfaces missing at {} — this test cannot answer its \
+         question without the sources",
+        root.display()
+    );
+
+    let mut found: Vec<String> = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        for e in fs::read_dir(&dir).expect("read_dir") {
+            let p = e.expect("dir entry").path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().is_some_and(|x| x == "rs") {
+                let text = fs::read_to_string(&p).expect("read source");
+                for line in text.lines() {
+                    if let Some(rest) = line.strip_prefix("impl ::nros_serdes::Message for ") {
+                        let ty = rest.trim_end_matches(" {").trim();
+                        found.push(format!("{ty} ({})", p.display()));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        !found.is_empty(),
+        "no `impl ::nros_serdes::Message` found under packages/interfaces — the \
+         probe is broken, and a broken probe would make this test vacuous"
+    );
+    assert_eq!(
+        found.len(),
+        corpus().len(),
+        "the corpus has {} row(s) but packages/interfaces defines {} \
+         `impl ::nros_serdes::Message`. Regenerate the corpus — a message \
+         outside it is a message the round-trip sweep never sees.\nFound:\n{}",
+        corpus().len(),
+        found.len(),
+        found.join("\n")
+    );
+}
+
+/// The other end of the trade the sweep makes: a REAL value, through the type's
+/// own generated `serialize` / `deserialize`, so the synthetic CDR writer above
+/// cannot drift from what a publisher actually runs.
+///
+/// `DiagnosticStatus` is the shape that exercises everything at once — three
+/// strings, a sequence of a nested struct that itself holds two strings.
+#[test]
+fn a_real_generated_message_survives_the_round_trip() {
+    use nros_diagnostic_msgs::msg::{DiagnosticStatus, KeyValue};
+    use nros_serdes::traits::{Deserialize, Serialize};
+
+    // Built through `Default` + `push_str` rather than by naming
+    // `heapless::String` — this crate does not depend on `heapless`, and a
+    // test is not a reason to grow the dependency graph.
+    let mut original = DiagnosticStatus {
+        level: 2,
+        ..Default::default()
+    };
+    original.name.push_str("motor_left").unwrap();
+    original.message.push_str("over temperature").unwrap();
+    original.hardware_id.push_str("mcu-7").unwrap();
+    for (k, v) in [("temp_c", "91.5"), ("rpm", "0")] {
+        let mut kv = KeyValue::default();
+        kv.key.push_str(k).unwrap();
+        kv.value.push_str(v).unwrap();
+        original.values.push(kv).unwrap();
+    }
+
+    let mut cdr = [0u8; 1024];
+    let mut w = CdrWriter::new_with_header(&mut cdr).unwrap();
+    original.serialize(&mut w).unwrap();
+    let cdr_len = w.position();
+
+    let mut foreign = [0u8; 1024];
+    let mut r = CdrReader::new_with_header(&cdr[..cdr_len]).unwrap();
+    let packed_len = Packed::serialize_message::<DiagnosticStatus>(&mut r, &mut foreign).unwrap();
+
+    // The wire really is different — otherwise this test would pass on a
+    // transcoder that copied its input.
+    assert_ne!(
+        &foreign[..packed_len],
+        &cdr[..cdr_len],
+        "packed and CDR must not coincide, or nothing here is being tested"
+    );
+
+    let mut back = [0u8; 1024];
+    let mut w2 = CdrWriter::new_with_header(&mut back).unwrap();
+    Packed::deserialize_message::<DiagnosticStatus>(&foreign[..packed_len], &mut w2).unwrap();
+    let back_len = w2.position();
+
+    assert_eq!(
+        &cdr[..cdr_len],
+        &back[..back_len],
+        "CDR bytes must be identical"
+    );
+
+    let mut r2 = CdrReader::new_with_header(&back[..back_len]).unwrap();
+    let decoded = DiagnosticStatus::deserialize(&mut r2).unwrap();
+    assert_eq!(
+        decoded, original,
+        "the value must survive, not just the bytes"
+    );
+}
+
+/// A provider gets the schema, and the schema alone. If `nros_serdes_packed`
+/// ever needed a generated per-message item, this would stop compiling — the
+/// only thing named here is the trait and the two `&'static` consts.
+#[test]
+fn the_provider_needs_no_generated_code() {
+    fn transcode<M: Message>(cdr: &[u8], out: &mut [u8]) -> Result<usize, SchemaError> {
+        let mut r = CdrReader::new_with_header(cdr).unwrap();
+        Packed::serialize(&mut r, M::TYPE_NAME, M::FIELDS, out)
+    }
+
+    let mut cdr = [0u8; 64];
+    let mut w = CdrWriter::new_with_header(&mut cdr).unwrap();
+    nros_serdes::traits::Serialize::serialize(
+        &nros_builtin_interfaces::msg::Time {
+            sec: -3,
+            nanosec: 7,
+        },
+        &mut w,
+    )
+    .unwrap();
+    let len = w.position();
+
+    let mut out = [0u8; 64];
+    let n = transcode::<nros_builtin_interfaces::msg::Time>(&cdr[..len], &mut out).unwrap();
+    assert_eq!(
+        &out[..n],
+        &[0xFD, 0xFF, 0xFF, 0xFF, 7, 0, 0, 0],
+        "two little-endian words, no padding, no header"
+    );
+}


### PR DESCRIPTION
RFC-0088 D7. `nros_serdes::walk` carries the schema walk once — `SchemaSink`/`SchemaSource`, structural hooks defaulted to no-ops, driven by `encode_from_cdr`/`decode_to_cdr` — so a provider implements primitives and gets every message. `nros-serdes-packed` proves it.

## D7's `*const u8` is not implementable, and the RFC is amended rather than the finding buried

Three independent reasons, each measured against the real schema:

1. A `String` member's host type is `heapless::String<N>` and **the schema carries no `N`**. Codegen emits `FieldType::String` (the IDL type); `BoundedString(n)` is the IDL bound, a *different* number from the host capacity.
2. `heapless::String`/`heapless::Vec` are `repr(Rust)` — `Field::offset` soundly reaches the **start** of the container and nothing inside it.
3. `NestedType` records `type_name` and `fields` but **no size**, so `Array(N, Nested(..))` and sequences of structs have no stride.

So `impl = "schema"` is a **transcoder** in v1: CDR bytes in, the provider's bytes out. Smaller than "reads the struct directly", and the claim the schema can actually support. Making the pointer form work is a change to the **schema** — host capacity, stable container layout, nested size — worth doing when a provider needs to skip the CDR hop, and not free.

One hole the walk **inherits** rather than introduces: `WString`/`BoundedWString` return `Unsupported`, because `CdrReader`/`CdrWriter` have no wide-string primitive in either direction. Nothing in tree uses one.

## The reference format is deliberately hostile to a walk that cheats

LE, **no alignment padding**, `u32` byte-length strings with **no NUL**, **no DHEADER**, `u32`-counted sequences, uncounted arrays. Each differs from CDR on purpose: a walk that inherited CDR's padding, its `len + 1` string prefix, or its per-struct DHEADER **fails** the round trip instead of passing by coincidence. Test vehicle, not an interop claim — its README says so.

uORB could not serve as the subject (its wire is the struct, so it walks nothing); CDR could not (that is the `impl = "codegen"` case).

## Proof

**All 76 committed generated messages** in `packages/interfaces/*`, both CDR encodings: **152/152 pairs round-trip byte-identically, 0 refused.** A refusal is asserted as a *failure*, not a skip, and `corpus_is_exhaustive` re-counts `impl ::nros_serdes::Message` out of the sources at run time so the list cannot fall behind the tree. Negative control: mutating `take_u16` by +1 turns the sweep red.

## No matrix cell, deliberately

A `matrix::CELLS` row is fixture-backed, so a cell means an **image** — and no backend declares `packed`, so that image would link a provider nothing calls and the cell would answer *"does dead code link"*. The coordinate this varies over is **message shape**, not platform × language × rmw × kind, and all 76 run on the host with no fixture inside `just ci gate`'s `test-unit`. A cell becomes right when a backend actually speaks a second format — which is also when W3's runtime path becomes reachable.

## No `format.rs` patch

`check-serdes-descriptors` S3 tolerates a `format_id` the enum does not name, and a `SerializationFormatId::Packed` variant would assert `packed` is a wire some *backend* speaks, which none does. `FORMAT_ID` is a raw `u8` — which is what D2 says an image-local discriminant is.

## Verification

`cargo test -p nros-serdes` 80 · `-p nros-serdes-packed` 6 · round-trip sweep 4 (152 pairs) · clippy `-D warnings` clean · `just check serdes-descriptors` (2 descriptors, 2 discriminants) · `generated-schema-coverage` 64/64 · `no-vacuous-tests` · `leaf-lockfiles` · builds for `thumbv7em-none-eabihf`.

`Cargo.lock` moves by 8 additive lines for the new member; the crate is also listed explicitly in the root `Cargo.toml`, since path-dep auto-membership already covered it but every other crate is listed and an implicit member reads as an omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV