### PR TITLE
docs(phase-422): provisioning has four paths that disagree — one campaign to fix it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -330,10 +330,15 @@ jobs:
           source ./activate.sh
           nros setup --tool esp32-qemu --sudo
 
-      - name: just ${{ matrix.plat }} setup
+      # The DISPATCHER spelling, not `just <plat> setup`. Only
+      # `just setup <scope>` runs `_setup-common`, which provisions the host
+      # facts every tier asserts (cross Rust targets, pinned corrosion, the CLI,
+      # the resolver, clang-format). The module spelling silently skips all of
+      # it, which is why this job needed a hand-rolled cross-target step below.
+      - name: just setup ${{ matrix.plat }}
         run: |
           source ./activate.sh
-          just ${{ matrix.plat }} setup
+          just setup ${{ matrix.plat }}
 
       # issue-0037 — the e2e fixture build shells out to `play_launch_parser`, a
       # separate binary the in-tree `cargo build --bin nros` does NOT produce.
@@ -354,22 +359,6 @@ jobs:
           apt-get clean 2>/dev/null || true
           rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /usr/share/locale 2>/dev/null || true
           echo "after:";  df -h / | tail -1
-
-      # The image bakes SOME rust targets; it does not bake all of them, and this
-      # job had no step to reconcile that. `freertos` builds the s32z270
-      # workspace fixture, whose Cortex-R52 target is `armv8r-none-eabihf`, and
-      # cmake configure died with "Target armv8r-none-eabihf is not installed
-      # for toolchain" on every nightly.
-      #
-      # `just workspace rust-targets` reads `config/rust-targets.txt`, the SSoT
-      # issue 0833 established after a hand-copied second list drifted and made
-      # `just doctor` print [OK] on a host where the build could not configure.
-      # Installing from that same list is what keeps CI and a contributor's
-      # laptop provisioned identically.
-      - name: Install cross targets from config/rust-targets.txt
-        run: |
-          source ./activate.sh
-          just workspace rust-targets
 
       - name: Build (${{ matrix.plat }})
         run: |

--- a/docs/roadmap/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/phase-422-provisioning-one-path.md
@@ -1,0 +1,157 @@
+# phase-422 — provisioning has one path, and CI walks it
+
+**Status (2026-09-04). Open. W1–W3 are mechanical and independent; W4 needs a
+small dispatcher change first; W5 is the ratchet that keeps the rest from
+regrowing. Two gates already landed as part of phase-413 and are listed here as
+prior art, not as work: `check-preconditions-provisioned` (#387) and
+`check-workflow-setup-spelling` (#397).**
+
+Implements the provisioning half of RFC-0014 and finishes what phase-413 W5
+started. Prior phases: 413 (CI workflow user parity), 398 (`package.xml`
+dependency ladder), 365 (versioned SDK store).
+
+## The problem
+
+There is supposed to be one way to provision this tree: `nros setup` reading
+`nros-sdk-index.toml`, wrapped by `just setup <scope>`. In practice there are
+four, and they disagree.
+
+**1. Two producers for the same tool.** `[tool.corrosion]` in the index and
+`just workspace install-corrosion` both install corrosion, into the same
+versioned prefix, each with its own stamp logic. Same for
+`play_launch_parser`. Their version pins are not even spelled the same:
+
+| tool | `just/workspace.just` | `nros-sdk-index.toml` |
+| --- | --- | --- |
+| corrosion | `v0.6.1` | `0.6.1-nros1` |
+| play_launch_parser | git SHA `838ce948…` | `0.1.0-nros1` |
+
+Issue 0500 is the cost of this already being paid once: the SDK store
+accumulates, prefixes resolve newest-first, and **both provisioning paths print
+success either way** — so a stale Corrosion shadowed the pin that had just been
+installed, and `mixed` could not link. A second producer is not a convenience;
+it is a second answer to "which version is installed?".
+
+`just workspace install-sccache` is NOT in this category — it is a thin wrapper
+that shells `nros setup --tool sccache`. It should still lose the wrapper, but
+it is tidying, not a correctness fix.
+
+**2. Installers that never reached the index at all.** `clang-format` (pip
+wheel download, `scripts/`-side logic), `mdbook` (`scripts/setup-mdbook.sh` +
+a hand-maintained `scripts/mdbook-checksums.txt`), `verus`
+(`scripts/setup-verus.sh`). Each re-implements what the index already does for
+16 other tools: pinned version, download, checksum, install prefix, smoke
+check. None of them can be asked "are you at the pin?" the way
+`nros setup --tool X --check` can.
+
+**3. Two spellings of the setup verb, one of which silently does less.**
+`just setup <scope>` runs `_setup-common` then the module recipe;
+`just <scope> setup` runs the module recipe alone. `_setup-common` is where
+the host facts every tier asserts get provisioned. nightly's platform job used
+the module spelling and carried a hand-rolled "Install cross targets" step to
+compensate — a workaround for a defect one word wide (fixed, #397).
+
+**4. CI lanes that do not walk the user's path.** phase-413 W5 converted
+`build-wide`, `run-matrix`, `queue` and `host-tests`. The nightly zephyr jobs
+still spell out six provisioning steps each, and cannot convert today because
+they pass `just zephyr setup --skip-sdk` and the dispatcher has no argument
+passthrough.
+
+### What this cost, measured
+
+Three consecutive host-tests runs, each ~40 minutes, each failing on a
+different missing prerequisite that `just setup` did not provision:
+
+1. cross Rust targets (`armv8r-none-eabihf`), pinned corrosion, fixture stamp
+2. — same run after fixes: reached `check fast`, died on `clang-format`
+3. the layer below that is what W5's gate now finds statically
+
+Each layer only became visible once the one above it was fixed, because a
+missing prerequisite fails the run at the first gate that needs it.
+
+## Work items
+
+### W1 — retire the duplicate producers
+
+`install-corrosion` and `install-play-launch-parser` become forwarders to
+`nros setup --tool <name>`, or are deleted and their callers changed. The
+version constants `CORROSION_VERSION` / `PLAY_LAUNCH_PARSER_VERSION` in
+`just/workspace.just` go with them: the index is the pin.
+
+Care: `_setup-common` calls `just workspace install-corrosion` today (landed in
+#365). Whichever spelling survives must still be reachable from every
+`just setup <scope>`, or `check-preconditions-provisioned` fails — which is the
+gate doing its job.
+
+**Acceptance.** No tool has two installers. `grep -c 'version' ` for each tool
+finds exactly one pin. `just check preconditions-provisioned` stays green.
+
+### W2 — move the bespoke installers into the index
+
+`clang-format`, `mdbook`, `verus` become `[tool.*]` entries with a pinned
+version, a download, a checksum and a `smoke` command, like the other 16.
+`scripts/setup-mdbook.sh`, `scripts/mdbook-checksums.txt` and
+`scripts/setup-verus.sh` are deleted, not left as dead alternates.
+
+Care: `clang-format` is provisioned from a **pip wheel** chosen for the host
+platform, which is not the tarball shape the index uses. Either the index grows
+a wheel source kind, or clang-format keeps its recipe and is documented as a
+deliberate exception with the reason. Decide before implementing — do not force
+a shape that then needs a second exception.
+
+**Acceptance.** `just setup-mdbook` and `just setup-verus` no longer exist as
+bespoke downloaders. Every remaining bespoke installer is listed in this doc
+with a reason.
+
+### W3 — retire the old spelling everywhere
+
+`check-workflow-setup-spelling` (#397) forbids `just <scope> setup` in
+workflows and carries exactly one exemption: the nightly zephyr jobs, which pass
+`--skip-sdk`. Give the `setup` dispatcher argument passthrough so the exemption
+can be deleted.
+
+Then sweep the non-workflow callers — docs, `book/src/`, `AGENTS.md`,
+`CLAUDE.md` — so the documented spelling is the one that provisions correctly.
+A reader who copies `just zephyr setup` out of the book gets the module recipe
+and none of `_setup-common`.
+
+**Acceptance.** The exemption list in `check-workflow-setup-spelling` is empty.
+No prose in the repo teaches the module spelling.
+
+### W4 — the nightly zephyr jobs walk the user path
+
+Blocked on W3's dispatcher change. Once `just setup zephyr --skip-sdk` exists,
+the four zephyr jobs collapse from ~6 provisioning steps each to the scope verb
+plus one command, matching every other lane.
+
+**Acceptance.** Every job body in `.github/workflows/` is
+`just setup <scope>` plus one command, or is listed here with a reason.
+
+### W5 — the ratchet
+
+Two gates landed already and are the model:
+
+- `check-preconditions-provisioned` — every tier precondition is classified
+  setup/build/manual, and `setup` ones are reachable from `_setup-common`.
+- `check-workflow-setup-spelling` — workflows invoke the dispatcher form.
+
+One more is missing, and it is what W1 needs to stay fixed: **a gate asserting
+no indexed tool has a second installer.** Shape: for each `[tool.X]`, no
+`install-X` / `setup-X` recipe may perform its own download or stamp
+comparison; forwarding to `nros setup --tool X` is fine.
+
+**Acceptance.** Reintroducing `install-corrosion`'s own stamp logic fails a
+gate. Both directions checked — a gate row naming a tool the index dropped
+fails too.
+
+## Non-goals
+
+- **Not** replacing the CI image's baked tooling. The image is a cache; the
+  index is the contract. `ci/docker/ci-base/Dockerfile` reading
+  `config/rust-targets.txt` (#365) is the pattern — bake from the SSoT, do not
+  hand-list.
+- **Not** moving `setup-cli`, `setup-launch-resolve` or `setup-hooks` into the
+  index. Those build in-tree code or configure the user's git; they are not
+  third-party artifacts and have no version to pin.
+- **Not** touching `[prereq.*]`. OS packages are RFC-0062's namespace and
+  phase-413 W3 already gated workflows against restating them.

--- a/just/check.just
+++ b/just/check.just
@@ -294,6 +294,7 @@ fast-serial: \
     workflow-indexed-apt \
     workflow-repo-env \
     workflow-runner-isolation \
+    workflow-setup-spelling \
     workspace-build-output \
     workspace-fmt \
     workspace-order \
@@ -1017,6 +1018,18 @@ config-knob-census:
 # its dnf/pacman/brew spellings and a presence probe sitting in the index.
 #
 # Buildless and source-only, so it belongs on the fast line.
+# A workflow must provision with `just setup <scope>`, not `just <scope> setup`.
+# Only the dispatcher runs `_setup-common`, where the host facts every tier
+# asserts get provisioned; the module spelling skips it silently and the lane
+# fails later on a precondition nothing provisioned. nightly's platform job did
+# exactly that and carried a hand-rolled cross-target step to compensate.
+#
+# The sibling of `check-preconditions-provisioned`: that one asks whether setup
+# PROVIDES the facts, this asks whether workflows INVOKE the form that runs them.
+[group("checks")]
+workflow-setup-spelling:
+    @python3 scripts/check-workflow-setup-spelling.py
+
 [group("main")]
 workflow-indexed-apt:
     @python3 scripts/check-workflow-indexed-apt.py

--- a/scripts/check-workflow-setup-spelling.py
+++ b/scripts/check-workflow-setup-spelling.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""A workflow must provision with `just setup <scope>`, not `just <scope> setup`.
+
+The two spellings look interchangeable and are not:
+
+    just setup zephyr     -> dispatcher: runs `_setup-common`, THEN `just zephyr setup`
+    just zephyr setup     -> the module recipe ALONE
+
+`_setup-common` is where the host facts every tier asserts get provisioned --
+cross Rust targets, pinned corrosion, the in-tree CLI, `nros-launch-resolve`,
+clang-format. The module spelling skips all of it silently: the recipe exists,
+it succeeds, and the lane fails later on a precondition nothing provisioned.
+
+That is not hypothetical. `nightly.yml`'s platform job used the module spelling
+and carried a hand-rolled "Install cross targets from config/rust-targets.txt"
+step to compensate -- a workaround for a defect one word wide. host-tests hit
+the same class from the other direction and cost three CI rounds to unpick.
+
+`check-preconditions-provisioned` asserts that `just setup` PROVIDES those
+facts. This asserts that workflows INVOKE the form which runs them. Neither
+implies the other.
+
+EXEMPTIONS carry a reason and are checked in both directions: an exemption that
+matches nothing is deleted, because a stale allow-list is how a gate quietly
+stops covering what it names.
+
+Run:  python3 scripts/check-workflow-setup-spelling.py [--self-test]
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+# `just <scope> setup ...` occurrences that may stay, and why.
+#
+# The dispatcher takes a scope and nothing else -- `setup target="" tier=""`
+# execs `just "$target" setup` with no argument passthrough -- so a call that
+# must pass a FLAG has no dispatcher spelling available. These lanes therefore
+# do not get `_setup-common`, and that is a known gap rather than an accident:
+# giving the dispatcher argument passthrough would let them convert.
+EXEMPT = {
+    "just zephyr setup --skip-sdk": (
+        "Passes `--skip-sdk` (the image bakes the SDK). The `setup` dispatcher "
+        "has no argument passthrough, so no dispatcher spelling exists. These "
+        "jobs provision the host facts themselves or do not need them."
+    ),
+}
+
+
+def scope_tokens():
+    """Platform scope names, from the same table the dispatcher consults."""
+    path = os.path.join(ROOT, "scripts", "build", "scope.sh")
+    try:
+        with open(path, encoding="utf8") as fh:
+            text = fh.read()
+    except OSError:
+        return set()
+    names = set()
+    for m in re.finditer(r'_NROS_SCOPE_PLATFORMS="([^"]*)"', text):
+        names.update(re.findall(r"[a-z0-9_]+", m.group(1)))
+    return names
+
+
+def offenders(text, scopes):
+    """[(lineno, line)] for executable `just <scope> setup` calls."""
+    out = []
+    for i, raw in enumerate(text.split("\n"), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Two shapes, and missing the second made this gate useless on the very
+        # workflow that motivated it: nightly's platform job spells the scope as
+        # a matrix expression, `just ${{ matrix.plat }} setup`. A templated scope
+        # in that position is ALWAYS the module form -- there is nothing to
+        # resolve, and the spelling alone is the defect. Caught by mutation-
+        # testing this gate against the pre-conversion nightly.yml.
+        m = re.search(r"just (\$\{\{[^}]*\}\}) setup\b(.*)$", line)
+        if m:
+            scope, rest = m.group(1), m.group(2).strip()
+        else:
+            m = re.search(r"just ([a-z0-9_]+) setup\b(.*)$", line)
+            if not m:
+                continue
+            scope, rest = m.group(1), m.group(2).strip()
+            if scope not in scopes:
+                continue
+        call = ("just %s setup %s" % (scope, rest)).strip()
+        out.append((i, line, call))
+    return out
+
+
+def self_test():
+    scopes = {"zephyr", "freertos"}
+    t = "\n".join(
+        [
+            "      # a comment about just zephyr setup is not a call",
+            "          just zephyr setup --skip-sdk",
+            "          just setup zephyr",
+            "          just freertos setup",
+            "          just workspace setup",
+            "          just ${{ matrix.plat }} setup",
+        ]
+    )
+    got = offenders(t, scopes)
+    assert [g[0] for g in got] == [2, 4, 6], got
+    assert got[0][2] == "just zephyr setup --skip-sdk", got[0]
+    assert got[1][2] == "just freertos setup", got[1]
+    sys.stdout.write("check-workflow-setup-spelling self-test: OK\n")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return 0
+    self_test()
+
+    scopes = scope_tokens()
+    if not scopes:
+        sys.stderr.write(
+            "error: parsed ZERO platform scopes from scripts/build/scope.sh.\n"
+            "This gate would then match nothing and pass vacuously.\n"
+        )
+        return 1
+
+    problems = []
+    seen_exempt = set()
+    for fn in sorted(os.listdir(WORKFLOWS)):
+        if not fn.endswith((".yml", ".yaml")):
+            continue
+        path = os.path.join(WORKFLOWS, fn)
+        with open(path, encoding="utf8") as fh:
+            text = fh.read()
+        for lineno, line, call in offenders(text, scopes):
+            if call in EXEMPT:
+                seen_exempt.add(call)
+                continue
+            problems.append(
+                "%s:%d uses the MODULE spelling\n"
+                "      %s\n"
+                "    `just <scope> setup` runs the module recipe alone and skips\n"
+                "    `_setup-common`, so the cross Rust targets, pinned corrosion,\n"
+                "    the CLI, the resolver and clang-format are never provisioned.\n"
+                "    Use the dispatcher:  just setup <scope>" % (fn, lineno, line)
+            )
+
+    for call in EXEMPT:
+        if call not in seen_exempt:
+            problems.append(
+                "STALE exemption %r matches no workflow line.\n"
+                "    Delete it — an allow-list checked one way stops covering\n"
+                "    what it claims to." % call
+            )
+
+    if problems:
+        sys.stderr.write("check-workflow-setup-spelling: %d problem(s)\n\n" % len(problems))
+        for p in problems:
+            sys.stderr.write("  - %s\n\n" % p)
+        return 1
+
+    sys.stdout.write(
+        "check-workflow-setup-spelling: OK — %d scope(s), %d exemption(s) all live.\n"
+        % (len(scopes), len(EXEMPT))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Opens the campaign to tidy the provisioning system, grounded in what phase-413 actually turned up rather than written from intent.

## What I found

**1. Two producers for the same tool.** `[tool.corrosion]` and `just workspace install-corrosion` both install corrosion into the same versioned prefix, each with its own stamp logic. Same for `play_launch_parser`. Their pins are not even spelled alike:

| tool | `just/workspace.just` | `nros-sdk-index.toml` |
| --- | --- | --- |
| corrosion | `v0.6.1` | `0.6.1-nros1` |
| play_launch_parser | git SHA `838ce948…` | `0.1.0-nros1` |

Issue 0500 already paid for this once: the store accumulates, prefixes resolve newest-first, and **both paths print success either way** — so a stale Corrosion shadowed the pin just installed and `mixed` could not link.

I checked before asserting: `install-sccache` is **not** in this category — it forwards to `nros setup --tool sccache`. The doc says so, and marks it tidying rather than a correctness fix.

**2. Installers that never reached the index.** `clang-format` (pip wheel), `mdbook` (script + hand-maintained checksum file), `verus` (script). Each re-implements pin/download/checksum/prefix/smoke that the index does for 16 other tools, and none can answer `--check`.

**3. Two spellings of the setup verb**, one of which silently does less — `just <scope> setup` skips `_setup-common`.

**4. CI lanes that don't walk the user's path** — the nightly zephyr jobs, blocked on the dispatcher being unable to forward `--skip-sdk`.

## The measured cost

Three consecutive ~40-minute host-tests runs, each failing on a different missing prerequisite, each only visible once the one above was fixed.

## Shape

W1–W3 mechanical and independent. W4 blocked on a dispatcher change in W3. W5 is the ratchet and names the one gate still missing — *no indexed tool may have a second installer* — alongside the two that already landed (#387, #397).

**Two decisions deliberately left open** rather than guessed: whether the index grows a wheel source kind for clang-format or clang-format stays a documented exception; and which spelling survives W1, given `_setup-common` calls `install-corrosion` today.

## Verification

- `just check roadmap-status` — OK, 61 active phases carry a status line
- `just check fast` — 201 gates, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)