### PR TITLE
docs(#1052): the fault is reached from ZenohSession::create_publisher — and my bisect was measuring a stale image

### DIFF
--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -282,6 +282,53 @@ resolving `0x42051d70` cannot name the caller — it is a frame of the panic
 printer, not of the faulting code. Step 1 is a dead end by construction; steps 2
 and 3 are unaffected.
 
+## gdb names the frame (2026-09-04): `ZenohSession::create_publisher`
+
+`riscv32-esp-elf-gdb` against QEMU's gdbstub, with the router CONFIRMED serving
+on :9800 first. Break at the handler, dump the stack, resolve every code address
+on it:
+
+```
+0x42017ec8  <nros_rmw_zenoh::shim::session::ZenohSession as nros_rmw::traits::Session>::create_publisher
+0x420531ca  esp_hal::interrupt::riscv::vectored::enable_on_cpu
+0x4205334c  <riscv_rt::TrapFrame as core::fmt::Debug>::fmt
+0x4205e950  <i32 as core::fmt::Display>::fmt
+```
+
+Everything but the first is the exception handler printing itself. **The only
+application frame on the faulting stack is `ZenohSession::create_publisher`.**
+
+At the handler: `sp` is in `.bss` near `nros_smoltcp::TCP_RX_BUFFER_0`, and `ra`
+resolves to `core::panicking::assert_failed_inner+2` — a mid-symbol offset, so
+treat that as nearest-preceding resolution and NOT as proof of a panic frame.
+The `a0`/`a2` strings are the handler's own format literals
+(`"Exception '...' mepc=0x..."`), not an assertion message; an earlier reading of
+them as one would have been wrong.
+
+### It fits the leaf split — and CONTRADICTS the empty-register result
+
+A publisher is what the talker creates and the listener does not, so the frame
+explains the split immediately. But variants E, F and H registered NOTHING and
+faulted identically, and with an empty `register` no publisher is created.
+
+Both cannot be true. Either:
+
+* the empty-`register` images were not actually rebuilt before packing — the
+  pack step may have used a cached ELF, which would make E/F/H measurements of
+  the ORIGINAL image; or
+* something creates a publisher during session setup regardless of what the node
+  registers (liveliness, the graph, an internal token), in which case the frame
+  is reached on every image and the leaf split has a different cause.
+
+**Resolve that before acting on either.** The check is cheap: rebuild an
+empty-`register` talker, confirm the string `Hello World` is ABSENT from the ELF
+(it only exists in the publishing path), and re-run. If it faults with the
+publisher genuinely gone, the second explanation holds.
+
+This is the same class as the four retracted issues 0859-0862: a measurement
+whose artifact provenance was never checked. My E/F/H runs did not verify that
+the packed image contained the edit.
+
 ## STATIC ANALYSIS 2026-09-04 — the registers say it is a RETURN, and the backtrace frame is a ghost
 
 No build was run for this section. Everything below is either arithmetic on the

--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -615,3 +615,59 @@ rather than a line of code.
   from that capture is recorded here. Two instruction-access faults are not
   necessarily the same fault, and the pre-fix build had no `nros_log` record
   path in the leaves.
+
+## RESOLVED, both halves: the frame is real and the bisect was stale (2026-09-04)
+
+Ran the check the section above asked for, and it settles both.
+
+An empty-`register` talker, **with the artifact verified this time** — the
+`create_publisher` symbol count in the freshly built ELF is **0**, so the
+publisher is genuinely gone. (`Hello World` is a BAD probe and stays present:
+the string lives in the callback body, which still compiles. Symbol count is the
+probe that discriminates.) Run against the same router, same QEMU arguments as
+the harness (`-M esp32c3 -icount 3 -nic user,model=open_eth`), with the ORIGINAL
+image kept as a matched control in the same session:
+
+| image | `create_publisher` in ELF | faults in 60 s |
+| --- | --- | --- |
+| empty `register` | 0 | **0** |
+| full talker (control) | present | **2** |
+
+So `register` decides it, `ZenohSession::create_publisher` on the stack is real,
+and **variants E, F and H are RETRACTED** — they measured the original image.
+
+### Why they were stale: this issue's own sibling, #1025
+
+`just esp32 build-qemu` resolved the ELF with
+
+```
+nros_fixture_row_artifact_dir "<leaf>" qemu-esp32-baremetal "" ""
+```
+
+— empty `cargo_args` and empty `envstr`, INVENTED at the call site rather than
+read from the row. The talker row carries the variant `ZPICO_MAX_QUERYABLES=2`,
+so cargo writes to the group dir `qemu-esp32-baremetal-4118800323` while the
+packer looks in the bare `qemu-esp32-baremetal`. During E/F/H a stale ELF sat at
+the bare path, so every "rebuild" packed the SAME original image, and three
+variants agreed because they were one binary.
+
+That is issue **#1025** exactly, and its fix (the by-id helper, which reads the
+row instead of inventing its inputs) is in open PR **#303** — unmerged, which is
+why the broken spelling is still on `main` and why the trap was still armed
+today. It now fails LOUD (`is missing, and nothing narrowed this build`) rather
+than packing a stale image, because #700 landed in between; that is the only
+reason this was catchable at all.
+
+### What is actually established
+
+The fault is reached from `ZenohSession::create_publisher`, on the connected
+path, in the talker only. The listener creates a subscription and does not
+fault. Next step is that function, not another bisect.
+
+### Method note
+
+Every wrong turn in this issue has one shape: a measurement whose artifact
+provenance was never checked — the ASCII lead, the "fault is on the CONNECTED
+path" claim, and now E/F/H. The control that caught it costs one command
+(`nm | grep -c <symbol>` on the ELF you are about to run) and would have caught
+all three.


### PR DESCRIPTION
Two commits. The first records what gdb found; the second runs the check that first commit asked for, and it corrects me.

## gdb names the frame

`riscv32-esp-elf-gdb` against QEMU's gdbstub, router **confirmed serving on :9800 first**. Break at the handler, resolve every code address on the stack:

```
0x42017ec8  <ZenohSession as Session>::create_publisher
0x420531ca  esp_hal::interrupt::riscv::vectored::enable_on_cpu
0x4205334c  <riscv_rt::TrapFrame as Debug>::fmt
0x4205e950  <i32 as Display>::fmt
```

Everything but the first is the exception handler printing itself. Two readings I deliberately did *not* take: `ra` → `assert_failed_inner+2` is a **mid-symbol** offset (nearest-preceding resolution, not a panic frame), and `a0`/`a2` are the handler's own format literals, not an assert message. I over-read registers once already in this issue.

## The check that settles it

Empty-`register` talker, **artifact verified this time** — `create_publisher` symbol count in the fresh ELF is **0**. (`Hello World` is a bad probe and survives; it's in the callback body. The symbol count discriminates.) Same router, same harness QEMU args, original image kept as a matched control in the same session:

| image | `create_publisher` in ELF | faults in 60 s |
|---|---|---|
| empty `register` | 0 | **0** |
| full talker (control) | present | **2** |

`register` decides it. The frame is real. **Variants E, F and H are retracted** — they measured the original image.

## Why they were stale: this issue's own sibling, #1025

`just esp32 build-qemu` resolved the ELF with

```sh
nros_fixture_row_artifact_dir "<leaf>" qemu-esp32-baremetal "" ""
```

— empty `cargo_args`/`envstr`, **invented at the call site** instead of read from the row. The talker row carries the variant `ZPICO_MAX_QUERYABLES=2`, so cargo writes to `qemu-esp32-baremetal-4118800323` while the packer looks in bare `qemu-esp32-baremetal`. A stale ELF sat at the bare path, so every "rebuild" packed the same binary and three variants agreed because **they were one image**.

That's #1025 exactly. Its fix — the by-id helper, which reads the row rather than inventing its inputs — is in open PR #303, still unmerged, which is why the trap was armed today. It now fails loud rather than packing stale, but only because #700 landed in between.

## Established

The fault is reached from `ZenohSession::create_publisher`, on the connected path, talker only. The listener creates a subscription and doesn't fault. Next step is that function, not another bisect.

## Method note

Every wrong turn in this issue has one shape: a measurement whose artifact provenance was never checked — the ASCII lead, the "fault is on the connected path" claim, now E/F/H. The control costs one command (`nm | grep -c <symbol>` on the ELF you're about to run) and would have caught all three.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)