### PR TITLE
feat(prereq): off-ROS buildtool resolution + RFC-0062 amendment 3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -330,10 +330,15 @@ jobs:
           source ./activate.sh
           nros setup --tool esp32-qemu --sudo
 
-      - name: just ${{ matrix.plat }} setup
+      # The DISPATCHER spelling, not `just <plat> setup`. Only
+      # `just setup <scope>` runs `_setup-common`, which provisions the host
+      # facts every tier asserts (cross Rust targets, pinned corrosion, the CLI,
+      # the resolver, clang-format). The module spelling silently skips all of
+      # it, which is why this job needed a hand-rolled cross-target step below.
+      - name: just setup ${{ matrix.plat }}
         run: |
           source ./activate.sh
-          just ${{ matrix.plat }} setup
+          just setup ${{ matrix.plat }}
 
       # issue-0037 — the e2e fixture build shells out to `play_launch_parser`, a
       # separate binary the in-tree `cargo build --bin nros` does NOT produce.
@@ -354,22 +359,6 @@ jobs:
           apt-get clean 2>/dev/null || true
           rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /usr/share/locale 2>/dev/null || true
           echo "after:";  df -h / | tail -1
-
-      # The image bakes SOME rust targets; it does not bake all of them, and this
-      # job had no step to reconcile that. `freertos` builds the s32z270
-      # workspace fixture, whose Cortex-R52 target is `armv8r-none-eabihf`, and
-      # cmake configure died with "Target armv8r-none-eabihf is not installed
-      # for toolchain" on every nightly.
-      #
-      # `just workspace rust-targets` reads `config/rust-targets.txt`, the SSoT
-      # issue 0833 established after a hand-copied second list drifted and made
-      # `just doctor` print [OK] on a host where the build could not configure.
-      # Installing from that same list is what keeps CI and a contributor's
-      # laptop provisioned identically.
-      - name: Install cross targets from config/rust-targets.txt
-        run: |
-          source ./activate.sh
-          just workspace rust-targets
 
       - name: Build (${{ matrix.plat }})
         run: |

--- a/docs/design/0062-unified-dependency-ssot.md
+++ b/docs/design/0062-unified-dependency-ssot.md
@@ -443,13 +443,59 @@ Prototyped and verified: configures clean, an uninitialised submodule fails with
 the `git submodule update --init` remedy rather than a downstream error, and the
 submodule working tree stays clean because `BINARY_DIR` is out of tree.
 
+### DECIDED — `role`, and a consumer for it in the same change
+
+`[prereq.*]` gains `role`: `package` / `workspace` / `infra` / `vendor`. All 46
+keys carry one (11 / 11 / 19 / 5), and `check-prereq-roles` keeps them carrying
+it — the Rust field defaults to `unclassified` so it could land incrementally,
+and without the gate a new key inherits that default silently.
+
+Role landed WITH its consumer, deliberately. A classification nothing reads is
+another authored map waiting to drift, which is the failure this RFC keeps
+meeting. The consumer is `nros setup --workspace <path>`: it reads the three
+things a tree already states — `<depend>` (content),
+`<build_type>`/`<buildtool_depend>` (builder), and
+`<export><nano_ros deploy=.. board=.. rmw=../>` (target) — and reports what to
+provision. That deploy export is not new: 90+ packages carry it, and
+`build.rs`, `doctor.rs` and `workspace.rs` all read it while `setup.rs` alone
+ignored it.
+
+**REFUSING a wrong-role dep is deferred**, on purpose. `<depend>qemu-system-arm
+</depend>` still resolves; `--workspace` REPORTS it as a category error without
+failing. Turning it into an error breaks someone's working tree, so it wants a
+deprecation window rather than a flag day.
+
+### Measured while building it — three findings this RFC should carry
+
+**1. 24 of the 46 keys have no explicit consumer.** Nothing in the index and no
+recipe references them; they are reachable only if a user happens to run the
+blanket `nros setup --system`. They are not marginal: `cmake`, `ninja`, `make`,
+`cargo`, `nros`, `python3-*`, `gnu-parallel`, and every cross toolchain.
+
+**2. Nothing in the repo INSTALLS via `--system`.** Five recipes name it only
+inside an error message; `just workspace apt-packages` PRINTS the command (by
+design — composing it is the tool's job, running it is the user's), and
+`just setup <scope>` never reaches even that. Simulated on a developer host: 38
+present, 5 missing, 3 unprobed, and `just setup native` pulls none of the five.
+So the documented bootstrap does not provision the system closure, and a user
+discovers it when a build fails.
+
+**3. `board=` in a package.xml export is NOT the `[board.*]` key namespace.**
+Of the five boards declared across this repo's examples, only `threadx-linux`
+is an index key — `nros setup mps2-an385-freertos` and three others would fail.
+Nor is a `deploy=` value always a scope: `threadx` splits into `threadx_linux`
+and `threadx_riscv64` by board. Both were caught by SIMULATING the new command
+rather than reasoning about it, and both would have shipped as remedies that
+fail for the out-of-tree user this mode exists for. `--workspace` now validates
+against the index and `scripts/build/scope.sh` before printing any command.
+
+Finding 3 is a two-vocabularies defect of the same class this RFC exists to
+delete, one layer out: the same concept spelled two ways in two files, with
+nothing asserting they agree.
+
 ### What this amendment does NOT decide
 
-* **Whether `[prereq.*]` gains a `role` field** (`package` / `workspace` /
-  `infra` / `vendor`) and whether the resolver REFUSES a package.xml that names
-  a non-`package` key. This is the fix for `<depend>qemu-system-arm</depend>`
-  resolving silently. It is a user-visible error where none exists today, so it
-  wants agreement before implementation.
+* **When the refusal lands**, and what the deprecation window looks like.
 * **Whether the 11 runtime-closure keys move under their owning `[tool.*]`.**
   `libssl3`'s own `why` already says "runtime dep of the cyclonedds,
   xrce-agent dist(s)" — it is a property of those tarballs, not of the

--- a/docs/design/0062-unified-dependency-ssot.md
+++ b/docs/design/0062-unified-dependency-ssot.md
@@ -24,6 +24,9 @@ dists with `$ORIGIN` rpath so a declared dependency disappears instead
 **Amends:** RFC-0014 (`nros setup` toolchain management) — extends its index
 from two dependency classes to all of them; changes no existing `[tool.*]` /
 `[source.*]` semantics.
+**Amended:** 2026-09-04 (amendment 3) — who may NAME a key, and a
+package's own buildtool resolves without ROS; vendor layout may source from the
+submodule.
 **Amended:** 2026-08-30 (amendment 2) — the provider is chosen by what the
 tool DOES, `check` gains a version constraint, and every resolution reports
 its provider; tracked by phase-404, no code yet.
@@ -355,6 +358,113 @@ Shipping a dist we did not need costs bytes and a re-cut nobody reads. Using a
 system copy we should have pinned costs a build that differs per host and fails
 somewhere else entirely — which is the failure this repository has paid for most
 often. When the evidence is ambiguous, pin.
+
+
+## Amendment 3 (2026-09-04) — who may NAME a key, and who satisfies a buildtool
+
+Two questions this RFC had not separated: what a key *is* (settled — one
+namespace, four providers) and **who is allowed to name it from a
+`package.xml`**. Measuring the tree made the gap concrete.
+
+### The measurement
+
+407 `package.xml` files declare 65 distinct dependency tokens. Of the 46
+`[prereq.*]` keys, **exactly three are ever named by a package.xml**: `cargo`,
+`cmake`, `nros`. The other 43 are provisioning facts that no package's CONTENT
+depends on, in five groups:
+
+| group | n | example | what ROS 2 does with it |
+| --- | --- | --- | --- |
+| runtime closure of a dist we ship | 11 | `libssl3` | never hand-declared; comes with the binary package |
+| build tooling | 16 | `ninja`, `doxygen` | `buildtool_depend` / `doc_depend` — belongs, if a package needs it |
+| cross toolchains, emulators, probes | 7 | `qemu-system-arm` | outside rosdep entirely (sysroots, containers) |
+| vendored source trees | 6 | `zenoh-pico` | a `*_vendor` PACKAGE, not a key |
+| ROS binary package | 1 | `ros-rmw-zenoh-cpp` | plain `<depend>` |
+
+`<depend>qemu-system-arm</depend>` resolves silently today. It should not: QEMU
+runs the test lane, it is not a dependency of any package's content, and
+resolving it teaches the wrong model.
+
+### DECIDED — a package's own buildtool needs no provider
+
+`<buildtool_depend>ament_cmake</buildtool_depend>` on a package whose
+`<build_type>` IS `ament_cmake` is a tautology: if that builder is building it,
+the buildtool is present. `Resolution::SelfBuildtool` resolves exactly that,
+and it is **off-ROS safe** — which the alternatives were not.
+
+The alternatives were rejected on evidence, not taste:
+
+* **Rely on the ROS rung.** `ros_packages()` reads `AMENT_PREFIX_PATH` and
+  returns empty when ROS is not sourced, which is the normal state for an
+  embedded-only contributor. Declaring the buildtool would then hard-fail
+  `nros build` for a dependency satisfied by definition.
+* **Add `[prereq.ament_cargo]` with `apt = [...]`.** Fiction: `ament_cargo` and
+  `cargo-ros2` are served by this repo's own
+  `packages/cli/colcon-cargo-ros2` colcon extension. No apt package provides
+  them, and an index row claiming otherwise is a lie a user would act on.
+
+Two properties make the rung safe rather than a blanket exemption. It sits
+**last**, below the ROS rung, so a real provider still wins and gets reported —
+that is the answer a user can act on. And it is **conservative**: a name
+qualifies only if EVERY package.xml declaring it has a build type implying it,
+so one package declaring `ament_cmake` while built another way keeps the name on
+the normal ladder.
+
+The build-type mapping is nearly total, which is why inference is worth having:
+**345 of 367 packages declare a `<build_type>` and NOT the matching
+buildtool**, and the only declarations that are not inferable are
+`rosidl_default_generators` (10 message packages) and `cargo-ros2` (1) — which
+is exactly what a human should still write by hand. The nano-ros build types
+(`ament_nros`, `nros_entry`, `nros_cargo`, `nros_bringup`) map to `nros`: they
+are served by this repo's builders and have no upstream buildtool to name.
+
+### DECIDED — a vendor package may take its source from the submodule
+
+The ROS answer for a vendored tree is a `*_vendor` package: a real
+`package.xml` plus CMake that fetches and builds pinned upstream source. Adopting
+the LAYOUT is compatible with keeping the submodule as the SOURCE:
+
+```cmake
+ExternalProject_Add(zenoh_pico
+  SOURCE_DIR   "${NROS_ZENOH_PICO_DIR}"   # no GIT_REPOSITORY, no GIT_TAG
+  BINARY_DIR   "${CMAKE_CURRENT_BINARY_DIR}/zenoh_pico-build")
+```
+
+The decisive property is **one pin, not two**. A `GIT_TAG` in CMake is a second
+pin that can drift from the gitlink, and the gitlink is the one
+`check-submodule-pins` (forward-only), the pre-push hook and
+`diff.submodule=log` already guard — protections built after a zenoh-pico pin
+silently rewound over a Zephyr build fix for seven hours. Cloning the submodule
+shallowly also works, but needs a `GIT_TAG` to clone *to*, so it reintroduces
+the second pin for no gain: the submodule is already a local checkout at the
+right commit.
+
+Prototyped and verified: configures clean, an uninitialised submodule fails with
+the `git submodule update --init` remedy rather than a downstream error, and the
+submodule working tree stays clean because `BINARY_DIR` is out of tree.
+
+### What this amendment does NOT decide
+
+* **Whether `[prereq.*]` gains a `role` field** (`package` / `workspace` /
+  `infra` / `vendor`) and whether the resolver REFUSES a package.xml that names
+  a non-`package` key. This is the fix for `<depend>qemu-system-arm</depend>`
+  resolving silently. It is a user-visible error where none exists today, so it
+  wants agreement before implementation.
+* **Whether the 11 runtime-closure keys move under their owning `[tool.*]`.**
+  `libssl3`'s own `why` already says "runtime dep of the cyclonedds,
+  xrce-agent dist(s)" — it is a property of those tarballs, not of the
+  workspace. Mechanical, but it changes the index shape, and issue 0928's
+  `$ORIGIN` re-cut may delete the need entirely. Sequence matters.
+* **Whether the 345 missing `<buildtool_depend>` declarations get swept in.**
+  Now UNBLOCKED by the rung above, and mechanically derivable from
+  `<build_type>`. Still a 345-file diff whose only benefit is rosdep parity for
+  consumers who run rosdep — which this project deliberately does not.
+* **Which vendored trees adopt the vendor-package layout.** The hybrid works;
+  whether six submodules should each grow a `package.xml` is a cost question,
+  not a correctness one. A downstream consumer wanting `zenoh_pico_vendor`
+  WITHOUT our submodule layout would need a `GIT_REPOSITORY` fallback — and
+  that path has two pins again, so it should be decided, not defaulted into.
+
 
 ## Problem
 

--- a/docs/roadmap/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/phase-422-provisioning-one-path.md
@@ -39,7 +39,7 @@ it is tidying, not a correctness fix.
 **2. Installers that never reached the index at all.** `clang-format` (pip
 wheel download, `scripts/`-side logic), `mdbook` (`scripts/setup-mdbook.sh` +
 a hand-maintained `scripts/mdbook-checksums.txt`), `verus`
-(`scripts/setup-verus.sh`). Each re-implements what the index already does for
+(`scripts/setup-verus.sh`, reached by `just verify-verus`). Each re-implements what the index already does for
 16 other tools: pinned version, download, checksum, install prefix, smoke
 check. None of them can be asked "are you at the pin?" the way
 `nros setup --tool X --check` can.
@@ -83,8 +83,8 @@ Care: `_setup-common` calls `just workspace install-corrosion` today (landed in
 `just setup <scope>`, or `check-preconditions-provisioned` fails — which is the
 gate doing its job.
 
-**Acceptance.** No tool has two installers. `grep -c 'version' ` for each tool
-finds exactly one pin. `just check preconditions-provisioned` stays green.
+**Acceptance.** No tool has two installers. Each tool has exactly one pin.
+`check-preconditions-provisioned` (#387) stays green.
 
 ### W2 — move the bespoke installers into the index
 
@@ -99,8 +99,8 @@ a wheel source kind, or clang-format keeps its recipe and is documented as a
 deliberate exception with the reason. Decide before implementing — do not force
 a shape that then needs a second exception.
 
-**Acceptance.** `just setup-mdbook` and `just setup-verus` no longer exist as
-bespoke downloaders. Every remaining bespoke installer is listed in this doc
+**Acceptance.** `scripts/setup-mdbook.sh` and `scripts/setup-verus.sh` no longer
+exist as bespoke downloaders. Every remaining bespoke installer is listed in this doc
 with a reason.
 
 ### W3 — retire the old spelling everywhere

--- a/docs/roadmap/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/phase-422-provisioning-one-path.md
@@ -144,6 +144,53 @@ comparison; forwarding to `nros setup --tool X` is fine.
 gate. Both directions checked — a gate row naming a tool the index dropped
 fails too.
 
+### W6 — the bootstrap actually pulls the system closure
+
+Measured: 24 of the 46 `[prereq.*]` keys have no explicit consumer, nothing in
+the repo INSTALLS via `--system`, and `just setup <scope>` never reaches it. On
+a developer host that is 5 missing packages (`libgcrypt-dev`, `libpixman-dev`,
+`make`, `ninja`, `openocd`) that no documented command installs.
+
+The fix is NOT "run `--system --sudo` from setup": composing the command and
+running it are deliberately separate (RFC-0062), and a provisioning verb that
+sudo-installs behind the user's back is worse than the gap. What is missing is
+that `just setup <scope>` never even PRINTS the closure, so the user is not
+told. Make the scope verb report missing system prerequisites with the composed
+command, the way `nros setup --system` already does.
+
+**Acceptance.** `just setup <scope>` on a host missing a `role = package` or
+`role = workspace` key names it and prints the install command. Nothing is
+installed without an explicit `--sudo`.
+
+### W7 — one board vocabulary
+
+`board=` in a `package.xml` export and `[board.*]` in the index are two
+namespaces that do not line up: of five boards declared across `examples/`,
+only `threadx-linux` is an index key. `nros setup --workspace` works around it
+by validating before printing a command, which is honest but is a workaround.
+
+Same for `deploy=`: `threadx` is not a scope, it splits into `threadx_linux` /
+`threadx_riscv64`.
+
+Decide which namespace is canonical, map the other onto it, and gate that they
+agree. This is the two-vocabularies class this repo keeps paying for — the
+`native`/`posix`/`linux` collapse, `[system.*]` vs `[prereq.*]`, the module vs
+dispatcher setup spelling.
+
+**Acceptance.** A gate asserts every `board=` in a package.xml export resolves
+to an index board (or to a documented alias), and every `deploy=` resolves to a
+scope.
+
+### W8 — refuse a wrong-role dependency
+
+Deferred by decision, not oversight. `<depend>qemu-system-arm</depend>` resolves
+silently today; `nros setup --workspace` reports it as a category error without
+failing. Turning it into a hard error breaks a working tree, so it needs a
+deprecation window: report -> warn -> error.
+
+**Acceptance.** A package.xml naming a `role = infra` key fails resolution, and
+the error names the deploy target it should have come from instead.
+
 ## Non-goals
 
 - **Not** replacing the CI image's baked tooling. The image is a cache; the

--- a/docs/roadmap/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/phase-422-provisioning-one-path.md
@@ -1,0 +1,157 @@
+# phase-422 — provisioning has one path, and CI walks it
+
+**Status (2026-09-04). Open. W1–W3 are mechanical and independent; W4 needs a
+small dispatcher change first; W5 is the ratchet that keeps the rest from
+regrowing. Two gates already landed as part of phase-413 and are listed here as
+prior art, not as work: `check-preconditions-provisioned` (#387) and
+`check-workflow-setup-spelling` (#397).**
+
+Implements the provisioning half of RFC-0014 and finishes what phase-413 W5
+started. Prior phases: 413 (CI workflow user parity), 398 (`package.xml`
+dependency ladder), 365 (versioned SDK store).
+
+## The problem
+
+There is supposed to be one way to provision this tree: `nros setup` reading
+`nros-sdk-index.toml`, wrapped by `just setup <scope>`. In practice there are
+four, and they disagree.
+
+**1. Two producers for the same tool.** `[tool.corrosion]` in the index and
+`just workspace install-corrosion` both install corrosion, into the same
+versioned prefix, each with its own stamp logic. Same for
+`play_launch_parser`. Their version pins are not even spelled the same:
+
+| tool | `just/workspace.just` | `nros-sdk-index.toml` |
+| --- | --- | --- |
+| corrosion | `v0.6.1` | `0.6.1-nros1` |
+| play_launch_parser | git SHA `838ce948…` | `0.1.0-nros1` |
+
+Issue 0500 is the cost of this already being paid once: the SDK store
+accumulates, prefixes resolve newest-first, and **both provisioning paths print
+success either way** — so a stale Corrosion shadowed the pin that had just been
+installed, and `mixed` could not link. A second producer is not a convenience;
+it is a second answer to "which version is installed?".
+
+`just workspace install-sccache` is NOT in this category — it is a thin wrapper
+that shells `nros setup --tool sccache`. It should still lose the wrapper, but
+it is tidying, not a correctness fix.
+
+**2. Installers that never reached the index at all.** `clang-format` (pip
+wheel download, `scripts/`-side logic), `mdbook` (`scripts/setup-mdbook.sh` +
+a hand-maintained `scripts/mdbook-checksums.txt`), `verus`
+(`scripts/setup-verus.sh`). Each re-implements what the index already does for
+16 other tools: pinned version, download, checksum, install prefix, smoke
+check. None of them can be asked "are you at the pin?" the way
+`nros setup --tool X --check` can.
+
+**3. Two spellings of the setup verb, one of which silently does less.**
+`just setup <scope>` runs `_setup-common` then the module recipe;
+`just <scope> setup` runs the module recipe alone. `_setup-common` is where
+the host facts every tier asserts get provisioned. nightly's platform job used
+the module spelling and carried a hand-rolled "Install cross targets" step to
+compensate — a workaround for a defect one word wide (fixed, #397).
+
+**4. CI lanes that do not walk the user's path.** phase-413 W5 converted
+`build-wide`, `run-matrix`, `queue` and `host-tests`. The nightly zephyr jobs
+still spell out six provisioning steps each, and cannot convert today because
+they pass `just zephyr setup --skip-sdk` and the dispatcher has no argument
+passthrough.
+
+### What this cost, measured
+
+Three consecutive host-tests runs, each ~40 minutes, each failing on a
+different missing prerequisite that `just setup` did not provision:
+
+1. cross Rust targets (`armv8r-none-eabihf`), pinned corrosion, fixture stamp
+2. — same run after fixes: reached `check fast`, died on `clang-format`
+3. the layer below that is what W5's gate now finds statically
+
+Each layer only became visible once the one above it was fixed, because a
+missing prerequisite fails the run at the first gate that needs it.
+
+## Work items
+
+### W1 — retire the duplicate producers
+
+`install-corrosion` and `install-play-launch-parser` become forwarders to
+`nros setup --tool <name>`, or are deleted and their callers changed. The
+version constants `CORROSION_VERSION` / `PLAY_LAUNCH_PARSER_VERSION` in
+`just/workspace.just` go with them: the index is the pin.
+
+Care: `_setup-common` calls `just workspace install-corrosion` today (landed in
+#365). Whichever spelling survives must still be reachable from every
+`just setup <scope>`, or `check-preconditions-provisioned` fails — which is the
+gate doing its job.
+
+**Acceptance.** No tool has two installers. `grep -c 'version' ` for each tool
+finds exactly one pin. `just check preconditions-provisioned` stays green.
+
+### W2 — move the bespoke installers into the index
+
+`clang-format`, `mdbook`, `verus` become `[tool.*]` entries with a pinned
+version, a download, a checksum and a `smoke` command, like the other 16.
+`scripts/setup-mdbook.sh`, `scripts/mdbook-checksums.txt` and
+`scripts/setup-verus.sh` are deleted, not left as dead alternates.
+
+Care: `clang-format` is provisioned from a **pip wheel** chosen for the host
+platform, which is not the tarball shape the index uses. Either the index grows
+a wheel source kind, or clang-format keeps its recipe and is documented as a
+deliberate exception with the reason. Decide before implementing — do not force
+a shape that then needs a second exception.
+
+**Acceptance.** `just setup-mdbook` and `just setup-verus` no longer exist as
+bespoke downloaders. Every remaining bespoke installer is listed in this doc
+with a reason.
+
+### W3 — retire the old spelling everywhere
+
+`check-workflow-setup-spelling` (#397) forbids `just <scope> setup` in
+workflows and carries exactly one exemption: the nightly zephyr jobs, which pass
+`--skip-sdk`. Give the `setup` dispatcher argument passthrough so the exemption
+can be deleted.
+
+Then sweep the non-workflow callers — docs, `book/src/`, `AGENTS.md`,
+`CLAUDE.md` — so the documented spelling is the one that provisions correctly.
+A reader who copies `just zephyr setup` out of the book gets the module recipe
+and none of `_setup-common`.
+
+**Acceptance.** The exemption list in `check-workflow-setup-spelling` is empty.
+No prose in the repo teaches the module spelling.
+
+### W4 — the nightly zephyr jobs walk the user path
+
+Blocked on W3's dispatcher change. Once `just setup zephyr --skip-sdk` exists,
+the four zephyr jobs collapse from ~6 provisioning steps each to the scope verb
+plus one command, matching every other lane.
+
+**Acceptance.** Every job body in `.github/workflows/` is
+`just setup <scope>` plus one command, or is listed here with a reason.
+
+### W5 — the ratchet
+
+Two gates landed already and are the model:
+
+- `check-preconditions-provisioned` — every tier precondition is classified
+  setup/build/manual, and `setup` ones are reachable from `_setup-common`.
+- `check-workflow-setup-spelling` — workflows invoke the dispatcher form.
+
+One more is missing, and it is what W1 needs to stay fixed: **a gate asserting
+no indexed tool has a second installer.** Shape: for each `[tool.X]`, no
+`install-X` / `setup-X` recipe may perform its own download or stamp
+comparison; forwarding to `nros setup --tool X` is fine.
+
+**Acceptance.** Reintroducing `install-corrosion`'s own stamp logic fails a
+gate. Both directions checked — a gate row naming a tool the index dropped
+fails too.
+
+## Non-goals
+
+- **Not** replacing the CI image's baked tooling. The image is a cache; the
+  index is the contract. `ci/docker/ci-base/Dockerfile` reading
+  `config/rust-targets.txt` (#365) is the pattern — bake from the SSoT, do not
+  hand-list.
+- **Not** moving `setup-cli`, `setup-launch-resolve` or `setup-hooks` into the
+  index. Those build in-tree code or configure the user's git; they are not
+  third-party artifacts and have no version to pin.
+- **Not** touching `[prereq.*]`. OS packages are RFC-0062's namespace and
+  phase-413 W3 already gated workflows against restating them.

--- a/just/check.just
+++ b/just/check.just
@@ -294,6 +294,7 @@ fast-serial: \
     workflow-indexed-apt \
     workflow-repo-env \
     workflow-runner-isolation \
+    workflow-setup-spelling \
     workspace-build-output \
     workspace-fmt \
     workspace-order \
@@ -1017,6 +1018,18 @@ config-knob-census:
 # its dnf/pacman/brew spellings and a presence probe sitting in the index.
 #
 # Buildless and source-only, so it belongs on the fast line.
+# A workflow must provision with `just setup <scope>`, not `just <scope> setup`.
+# Only the dispatcher runs `_setup-common`, where the host facts every tier
+# asserts get provisioned; the module spelling skips it silently and the lane
+# fails later on a precondition nothing provisioned. nightly's platform job did
+# exactly that and carried a hand-rolled cross-target step to compensate.
+#
+# The sibling of `check-preconditions-provisioned`: that one asks whether setup
+# PROVIDES the facts, this asks whether workflows INVOKE the form that runs them.
+[group("checks")]
+workflow-setup-spelling:
+    @python3 scripts/check-workflow-setup-spelling.py
+
 [group("main")]
 workflow-indexed-apt:
     @python3 scripts/check-workflow-indexed-apt.py

--- a/just/check.just
+++ b/just/check.just
@@ -111,6 +111,7 @@ fast-serial: \
     board-facts-delivery \
     board-manifest-drift \
     board-tiers \
+    board-vocabulary \
     book-links \
     book-no-just \
     box-sync-covers-tracked-source \
@@ -2434,6 +2435,14 @@ ci-image-python-deps:
 # The Rust field defaults to `unclassified` so it could land incrementally;
 # without this gate a new key inherits that default and `nros setup --workspace`
 # reports a toolchain as a content dependency — the conflation `role` removes.
+# phase-422 W7 — every `deploy=`/`board=` a package.xml exports must resolve.
+# `nros setup --workspace` turns those values into a provisioning command, so a
+# value meaning nothing becomes a remedy that fails. Five namespaces exist for
+# the concept; this does not unify them, it stops a value in none of them.
+[group("checks")]
+board-vocabulary:
+    @python3 scripts/check-board-vocabulary.py
+
 [group("checks")]
 prereq-roles:
     @python3 scripts/check-prereq-roles.py

--- a/just/check.just
+++ b/just/check.just
@@ -236,6 +236,7 @@ fast-serial: \
     pool-inventory \
     posix-platform-purity \
     prelude-tiers \
+    prereq-roles \
     profile-board-mirror \
     provider-announcements \
     provider-index \
@@ -2429,6 +2430,14 @@ ci-image-python-deps:
 # nothing, and nothing said so (issue 0876). A RATCHET, not a prohibition —
 # shared board fragments are legitimately an override layer. Refresh with
 # `python3 scripts/check-kconfig-overridden-values.py --update`, and say why.
+# Every `[prereq.*]` key declares who may NAME it (RFC-0062 amendment 3).
+# The Rust field defaults to `unclassified` so it could land incrementally;
+# without this gate a new key inherits that default and `nros setup --workspace`
+# reports a toolchain as a content dependency — the conflation `role` removes.
+[group("checks")]
+prereq-roles:
+    @python3 scripts/check-prereq-roles.py
+
 [group("checks")]
 kconfig-overridden-values:
     @python3 scripts/check-kconfig-overridden-values.py

--- a/justfile
+++ b/justfile
@@ -3963,6 +3963,32 @@ _setup-common:
     # Idempotent: the recipe version-checks `build/clang-format/bin/clang-format`
     # and exits early. Project-local, no install.
     just setup-clang-format
+    # phase-422 W6 — TELL the user about the system closure. Measured: 24 of the
+    # 46 `[prereq.*]` keys had no consumer at all, nothing in the repo installs
+    # via `--system`, and `just setup <scope>` never even printed it — so a
+    # missing `cmake`/`ninja`/`make` surfaced as a build failure much later.
+    #
+    # REPORT, never install. Composing the command is this tool's job and
+    # running it is the user's (RFC-0062); a provisioning verb that sudo-installs
+    # behind someone's back is worse than the gap it closes.
+    #
+    # Narrowed to the HOST roles: `infra` keys (emulators, cross toolchains) come
+    # from the scope's own module setup, and listing them here would bury the two
+    # lines that matter under a dozen that do not.
+    #
+    # Non-fatal on purpose: `--check` exits 1 when anything is missing, and setup
+    # must not die for a package it is not allowed to install.
+    #
+    # `--check` is a doctor, so it exits 1 and eyre prints `Error:` with a
+    # source Location. Correct for a doctor, wrong here: an "Error:" plus a
+    # stack location in a path that deliberately continues is how people learn
+    # to scroll past errors. Capture and re-print without the backtrace.
+    if ! _sysout="$(nros setup --system --check --role package --role workspace 2>&1)"; then
+        printf '%s\n' "$_sysout" | grep -vE '^(Error:|Location:|\s+nros-cli-core/src|\s*$)' || true
+        printf '\nsetup: system package(s) above are MISSING; nothing here installs them.\n'
+        printf 'setup: NOT fatal — provisioning continues. Run the command shown, or\n'
+        printf '       `nros setup --system --sudo` to execute it.\n\n'
+    fi
 
 # Focused platform setup. Equivalent to `just <platform> setup`.
 [group("setup")]

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -828,6 +828,7 @@ dest = "third-party/ros/rosidl"
 # brew mappings are best-effort and unverified — fix them as hosts appear.
 
 [prereq.libglib2-dev]
+role = "infra"
 why = "qemu source builds (esp32-qemu meson configure)"
 apt = ["libglib2.0-dev"]
 dnf = ["glib2-devel"]
@@ -836,6 +837,7 @@ brew = ["glib"]
 check = { pkg_config = "glib-2.0" }
 
 [prereq.libpixman-dev]
+role = "infra"
 why = "qemu source builds (softmmu display layer)"
 apt = ["libpixman-1-dev"]
 dnf = ["pixman-devel"]
@@ -844,6 +846,7 @@ brew = ["pixman"]
 check = { pkg_config = "pixman-1" }
 
 [prereq.libgcrypt-dev]
+role = "infra"
 why = "qemu source builds (--enable-gcrypt)"
 apt = ["libgcrypt20-dev"]
 dnf = ["libgcrypt-devel"]
@@ -855,6 +858,7 @@ brew = ["libgcrypt"]
 check = { cmd = "libgcrypt-config", pkg_config = "libgcrypt" }
 
 [prereq.ros-rmw-zenoh-cpp]
+role = "package"
 why = "the zenoh ROS interop lanes: the peer runs `source /opt/ros/<distro>/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp`, so the RMW must resolve in the ROS prefix. Without it those lanes report `[SKIPPED:capability]`, which reads as green rather than as absent coverage (2026-08-17: three issues closed unverifiable that way). NOTE the apt name is DISTRO-PARAMETRIC — `ros-<distro>-rmw-zenoh-cpp`; humble is declared here because it is the documented default, and `just doctor` probes $ROS_DISTRO rather than assuming it."
 apt = ["ros-humble-rmw-zenoh-cpp"]
 # No dnf/pacman: ROS 2 is not packaged there, and docs/development/ros2-on-non-ubuntu.md
@@ -868,6 +872,7 @@ apt = ["ros-humble-rmw-zenoh-cpp"]
 # `just doctor` does the real check against $ROS_DISTRO.
 
 [prereq.doxygen]
+role = "workspace"
 why = "C API reference docs (just docs-c; found undeclared by check-sysdep-remedies)"
 apt = ["doxygen"]
 dnf = ["doxygen"]
@@ -881,6 +886,7 @@ check = { cmd = "doxygen" }
 # `.github/workflows/docs.yml` installed the two together in one apt line. The
 # workflow was the only place that knew they belong together.
 [prereq.graphviz]
+role = "workspace"
 why = "doxygen's diagrams (HAVE_DOT); without it the C API docs build with no graphs and say nothing about it"
 apt = ["graphviz"]
 dnf = ["graphviz"]
@@ -889,6 +895,7 @@ brew = ["graphviz"]
 check = { cmd = "dot" }
 
 [prereq.gcc-arm-none-eabi]
+role = "infra"
 why = "ARM bare-metal cross gcc via the apt path (the [tool.arm-none-eabi-gcc] dist is the store alternative)"
 # The LIBC is a separate package on Debian and was missing here, so the apt path
 # produced a compiler that could build freestanding code and nothing that
@@ -918,6 +925,7 @@ brew = ["arm-none-eabi-gcc"]
 check = { cmd = "arm-none-eabi-gcc" }
 
 [prereq.cmake]
+role = "package"
 why = "every C/C++ configure step"
 apt = ["cmake"]
 dnf = ["cmake"]
@@ -926,6 +934,7 @@ brew = ["cmake"]
 check = { cmd = "cmake" }
 
 [prereq.unzip]
+role = "workspace"
 why = "unpacks the upstream ninja release zips ([tool.ninja] dist install step); tar cannot read a zip"
 apt = ["unzip"]
 dnf = ["unzip"]
@@ -934,6 +943,7 @@ brew = ["unzip"]
 check = { cmd = "unzip" }
 
 [prereq.curl]
+role = "workspace"
 why = "every dist download and the [tool.make] source tarball fetch shell out to it"
 apt = ["curl"]
 dnf = ["curl"]
@@ -942,6 +952,7 @@ brew = ["curl"]
 check = { cmd = "curl" }
 
 [prereq.ninja]
+role = "workspace"
 why = "the generator every cmake configure emits for; >=1.13 also speaks the make-4.4 fifo jobserver protocol, so a nested build shares one token budget instead of taking nproc of its own"
 # Same chain as `[prereq.openocd]`: a system copy is fine WHEN new enough.
 # Ubuntu 22.04 ships 1.10.1 and Ubuntu 24.04 1.11.1, both below the jobserver
@@ -971,6 +982,7 @@ check = { cmd = "ninja", version = { run = "ninja --version", min = "1.13" } }
 # SECOND make provisioning path before then would be the drift this repo keeps
 # paying for.
 [prereq.make]
+role = "workspace"
 why = "GNU make >=4.4 serves `--jobserver-style=fifo`, the only jobserver flavour ninja 1.13 can join; 4.3 and older serve a pipe-fd jobserver that ninja ignores. install with `nros setup --tool make`"
 apt = ["make"]
 dnf = ["make"]
@@ -979,12 +991,14 @@ brew = ["make"]
 check = { cmd = "make", version = { run = "make --version", min = "4.4" } }
 
 [prereq.genromfs]
+role = "infra"
 why = "NuttX riscv rv-virt etc/ ROMFS image (the [tool.genromfs] source recipe is the store alternative)"
 apt = ["genromfs"]
 pacman = ["genromfs"]
 check = { cmd = "genromfs" }
 
 [prereq.socat]
+role = "workspace"
 why = "test-harness serial/TCP relays"
 apt = ["socat"]
 dnf = ["socat"]
@@ -993,6 +1007,7 @@ brew = ["socat"]
 check = { cmd = "socat" }
 
 [prereq.zstd]
+role = "workspace"
 why = "tar decompresses the prebuilt `.tar.zst` SDK dists via the external zstd binary (issue 0385; stock Ubuntu 22.04 ships no zstd)"
 apt = ["zstd"]
 dnf = ["zstd"]
@@ -1001,6 +1016,7 @@ brew = ["zstd"]
 check = { cmd = "zstd" }
 
 [prereq.libmbedtls]
+role = "package"
 why = "zenoh-pico TLS link (zpico-sys)"
 apt = ["libmbedtls-dev"]
 dnf = ["mbedtls-devel"]
@@ -1016,6 +1032,7 @@ brew = ["mbedtls"]
 check = { header = "mbedtls/entropy.h" }
 
 [prereq.clang]
+role = "package"
 why = "bindgen + C toolchain probes"
 apt = ["clang"]
 dnf = ["clang"]
@@ -1024,6 +1041,7 @@ brew = ["llvm"]
 check = { cmd = "clang" }
 
 [prereq.libclang-dev]
+role = "package"
 why = "bindgen (z3-sys via ros-launch-manifest-check -> nros-launch-resolve build; issue 0368 F5)"
 apt = ["libclang-dev"]
 dnf = ["clang-devel"]
@@ -1038,6 +1056,7 @@ brew = ["llvm"]
 check = { sharedlib = "libclang" }
 
 [prereq.libz3]
+role = "package"
 why = "ros-launch-manifest-check (z3) -> nros-launch-resolve build (issue 0368 F5)"
 apt = ["libz3-dev"]
 dnf = ["z3-devel"]
@@ -1051,6 +1070,7 @@ brew = ["z3"]
 check = { header = "z3.h" }
 
 [prereq.python3-dev]
+role = "package"
 why = "pyo3 source builds (play_launch_parser, nros-launch-resolve; issue 0368 F5)"
 apt = ["python3-dev"]
 dnf = ["python3-devel"]
@@ -1059,6 +1079,7 @@ brew = ["python"]
 check = { pkg_config = "python3" }
 
 [prereq.python3-venv]
+role = "package"
 why = "ESP-IDF install + tool venvs (issue 0368 F7)"
 apt = ["python3-venv"]
 dnf = ["python3"]
@@ -1066,6 +1087,7 @@ pacman = ["python"]
 brew = ["python"]
 
 [prereq.python3-pip]
+role = "package"
 why = "pip-layer installs (west, colcon, clang-format wheel)"
 apt = ["python3-pip"]
 dnf = ["python3-pip"]
@@ -1074,6 +1096,7 @@ brew = ["python"]
 check = { cmd = "pip3" }
 
 [prereq.aria2]
+role = "workspace"
 why = "Zephyr SDK fetch (west sdk install; issue 0368 F7)"
 apt = ["aria2"]
 dnf = ["aria2"]
@@ -1082,6 +1105,7 @@ brew = ["aria2"]
 check = { cmd = "aria2c" }
 
 [prereq.gnu-parallel]
+role = "workspace"
 why = "just format fan-out (issue 0368 F7)"
 apt = ["parallel"]
 dnf = ["parallel"]
@@ -1090,6 +1114,7 @@ brew = ["parallel"]
 check = { cmd = "parallel" }
 
 [prereq.qemu-system-arm]
+role = "infra"
 why = "ARM QEMU lanes via the apt path (the [tool.qemu] nros dist is the harness-preferred build)"
 apt = ["qemu-system-arm"]
 dnf = ["qemu-system-arm"]
@@ -1098,6 +1123,7 @@ brew = ["qemu"]
 check = { cmd = "qemu-system-arm" }
 
 [prereq.qemu-system-misc]
+role = "infra"
 why = "RISC-V QEMU lanes (threadx-riscv64, nuttx rv-virt)"
 apt = ["qemu-system-misc"]
 dnf = ["qemu-system-riscv"]
@@ -1106,16 +1132,19 @@ brew = ["qemu"]
 check = { cmd = "qemu-system-riscv64" }
 
 [prereq.gcc-riscv64-unknown-elf]
+role = "infra"
 why = "RISC-V bare-metal cross gcc (threadx-riscv64, nuttx rv-virt; the [tool.riscv-none-elf-gcc] dist is the xPack-prefixed alternative)"
 apt = ["gcc-riscv64-unknown-elf"]
 pacman = ["riscv64-elf-gcc"]
 check = { cmd = "riscv64-unknown-elf-gcc" }
 
 [prereq.picolibc-riscv64-unknown-elf]
+role = "infra"
 why = "picolibc for the riscv64-unknown-elf gcc (nuttx rv-virt userspace)"
 apt = ["picolibc-riscv64-unknown-elf"]
 
 [prereq.kconfig-frontends]
+role = "workspace"
 why = "NuttX configuration (kconfig-conf/kconfig-mconf)"
 apt = ["kconfig-frontends-nox"]
 check = { cmd = "kconfig-conf" }
@@ -1243,6 +1272,7 @@ check = { cmd = "clang-format" }
 # ---------------------------------------------------------------------------
 
 [prereq.qemu]
+role = "infra"
 why = "QEMU runs every emulated platform test"
 provider = "sdk"
 # `runs`, not `cmd`: the store dist is not on PATH, and its path EXISTING is
@@ -1250,26 +1280,31 @@ provider = "sdk"
 check = { runs = "qemu-system-arm --version" }
 
 [prereq.freertos-kernel]
+role = "vendor"
 why = "FreeRTOS builds compile the kernel from this checkout"
 provider = "submodule"
 check = { path = "include/FreeRTOS.h" }
 
 [prereq.threadx]
+role = "vendor"
 why = "ThreadX builds compile the kernel from this checkout"
 provider = "submodule"
 check = { path = "common/inc/tx_api.h" }
 
 [prereq.zenoh-pico]
+role = "vendor"
 why = "the zenoh backend's C library"
 provider = "submodule"
 check = { path = "include/zenoh-pico.h" }
 
 [prereq.nuttx-kernel]
+role = "vendor"
 why = "NuttX builds configure and build this checkout"
 provider = "submodule"
 check = { path = "Kconfig" }
 
 [prereq.cyclonedds-src]
+role = "vendor"
 why = "the Cyclone backend builds this fork"
 provider = "submodule"
 check = { path = "CMakeLists.txt" }
@@ -1279,6 +1314,7 @@ check = { path = "CMakeLists.txt" }
 # resolved to nothing, silently, for as long as that file has existed.
 
 [prereq.cargo]
+role = "package"
 why = "Rust builds; the real provider is rustup, which [rust.toolchain.*] pins"
 # apt/dnf/pacman ship a `cargo`, but a distro cargo is NOT the pinned toolchain
 # and using one is its own failure class — so the mapping exists for a host with
@@ -1290,6 +1326,7 @@ brew = ["rust"]
 check = { cmd = "cargo" }
 
 [prereq.nros]
+role = "package"
 why = "the nano-ros CLI itself — codegen, sync, and this build verb"
 # No package manager ships it. `./scripts/bootstrap.sh` (users) or
 # `just setup-cli` (contributors) provides it; the probe is the whole entry.
@@ -1356,6 +1393,7 @@ check = { cmd = "nros" }
 # dnf/pacman/brew are best-effort, per this file's existing convention.
 
 [prereq.openocd]
+role = "infra"
 why = "on-chip debug server for flashing/attaching to a target board"
 # phase-404 W2 — the first entry to use ordered preference, and openocd is the
 # right first case: it is neither a build input (nothing it does enters an
@@ -1373,6 +1411,7 @@ brew = ["openocd"]
 check = { cmd = "openocd", version = { min = "0.12" } }
 
 [prereq.libcrypt1]
+role = "infra"
 why = "runtime dep of the arm-none-eabi-gcc dist(s) (issue 0926)"
 apt = ["libcrypt1"]
 dnf = ["libxcrypt"]
@@ -1380,6 +1419,7 @@ pacman = ["libxcrypt-compat"]
 check = { sharedlib = "libcrypt.so.1" }
 
 [prereq.libexpat1]
+role = "infra"
 why = "runtime dep of the play_launch_parser dist(s) (issue 0926)"
 apt = ["libexpat1"]
 dnf = ["expat"]
@@ -1388,6 +1428,7 @@ brew = ["expat"]
 check = { sharedlib = "libexpat.so.1" }
 
 [prereq.libpcre2]
+role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libpcre2-8-0"]
 dnf = ["pcre2"]
@@ -1396,6 +1437,7 @@ brew = ["pcre2"]
 check = { sharedlib = "libpcre2-8.so.0" }
 
 [prereq.libpython310]
+role = "infra"
 why = "runtime dep of the play_launch_parser dist(s) (issue 0926)"
 apt = ["libpython3.10"]
 dnf = ["python3.10-libs"]
@@ -1403,6 +1445,7 @@ pacman = ["python310"]
 check = { sharedlib = "libpython3.10.so.1.0" }
 
 [prereq.libselinux1]
+role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libselinux1"]
 dnf = ["libselinux"]
@@ -1410,6 +1453,7 @@ pacman = ["libselinux"]
 check = { sharedlib = "libselinux.so.1" }
 
 [prereq.libssl3]
+role = "infra"
 why = "runtime dep of the cyclonedds, xrce-agent dist(s) (issue 0926)"
 apt = ["libssl3"]
 dnf = ["openssl-libs"]
@@ -1419,6 +1463,7 @@ provides = ["libcrypto.so.3", "libssl.so.3"]
 check = { sharedlib = "libcrypto.so.3" }
 
 [prereq.libtinfo6]
+role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libtinfo6"]
 dnf = ["ncurses-libs"]
@@ -1427,6 +1472,7 @@ brew = ["ncurses"]
 check = { sharedlib = "libtinfo.so.6" }
 
 [prereq.libz1]
+role = "infra"
 why = "runtime dep of the play_launch_parser, qemu dist(s) (issue 0926)"
 apt = ["zlib1g"]
 dnf = ["zlib"]

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -1970,10 +1970,16 @@ fn check_declared_depends(
         .unwrap_or_default();
 
     let ros = pr::ros_packages();
+    // Off-ROS safety: a package's own buildtool is satisfied by the builder that
+    // is building it. Without this, adding the `<buildtool_depend>` that rosdep
+    // expects would hard-fail every host with no `AMENT_PREFIX_PATH`.
+    let self_buildtools = pr::self_satisfied_buildtools(root);
 
     let mut unresolved: Vec<pr::Unresolved> = Vec::new();
     for (name, files) in &declared {
-        if pr::classify(name, &ws, &generated, &prereq_keys, &ros) == pr::Resolution::Unknown {
+        if pr::classify(name, &ws, &generated, &prereq_keys, &ros, &self_buildtools)
+            == pr::Resolution::Unknown
+        {
             unresolved.push(pr::Unresolved {
                 name: name.clone(),
                 declared_by: files.clone(),

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -108,6 +108,19 @@ pub struct Args {
     /// missing (the doctor surface).
     #[arg(long)]
     pub system: bool,
+    /// RFC-0062 amendment 3 — provision from what THIS WORKSPACE declares,
+    /// instead of a scope the user has to know in advance.
+    ///
+    /// Reads every `package.xml` under the path and answers three questions
+    /// the tree already states: what the code depends on (`<depend>`), which
+    /// builder must exist (`<build_type>` / `<buildtool_depend>`), and where it
+    /// deploys (`<export><nano_ros deploy=.. board=.. rmw=../></export>`, which
+    /// 90+ packages already carry).
+    ///
+    /// Prints the plan; it does not install. Same contract as `--system`:
+    /// composing the command is this tool's job, running it is the user's.
+    #[arg(long = "workspace", value_name = "PATH", num_args = 0..=1, default_missing_value = ".")]
+    pub workspace_scan: Option<PathBuf>,
 
     /// Run presence probes and report present/missing/unknown instead of
     /// installing/printing; exits 1 when anything is missing. With
@@ -196,6 +209,10 @@ pub fn run(args: Args) -> Result<()> {
     if args.licenses {
         print_licenses(&index);
         return Ok(());
+    }
+    if let Some(ws) = args.workspace_scan.clone() {
+        let root = args.index.parent().map(std::path::Path::to_path_buf);
+        return run_workspace_scan(&index, &ws, root.as_deref());
     }
     if args.system {
         // The index lives AT the repo root, so its parent is the base a
@@ -2561,5 +2578,296 @@ mod probe_kind_tests {
             ProbeResult::Present,
             "a failing cmd must not veto a passing runs",
         );
+    }
+}
+
+/// One deploy target a workspace declares.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct DeployTarget {
+    deploy: String,
+    board: Option<String>,
+    rmw: Option<String>,
+}
+
+/// Parse `<nano_ros deploy=".." board=".." rmw=".."/>` from a package.xml.
+fn deploy_targets(xml: &str) -> Vec<DeployTarget> {
+    let attr = |tag: &str, name: &str| -> Option<String> {
+        let pat = format!("{name}=\"");
+        let i = tag.find(&pat)? + pat.len();
+        let rest = tag.get(i..)?;
+        let end = rest.find('"')?;
+        Some(rest[..end].to_string())
+    };
+    let mut out = Vec::new();
+    for (i, _) in xml.match_indices("<nano_ros ") {
+        let Some(rest) = xml.get(i..) else { continue };
+        let Some(end) = rest.find('>') else { continue };
+        let tag = &rest[..end];
+        if let Some(deploy) = attr(tag, "deploy") {
+            out.push(DeployTarget {
+                deploy,
+                board: attr(tag, "board"),
+                rmw: attr(tag, "rmw"),
+            });
+        }
+    }
+    out
+}
+
+/// `nros setup --workspace <path>` — provision from what the workspace declares.
+///
+/// The problem this solves: every other form of `nros setup` requires the user
+/// to already know the answer (a board, a `--tool`, a scope). Nothing read
+/// their tree. Yet the tree states it in three places, and 90+ package.xml
+/// files in this repo already carry the deploy export.
+fn run_workspace_scan(
+    index: &SdkIndex,
+    ws: &std::path::Path,
+    repo_root: Option<&std::path::Path>,
+) -> Result<()> {
+    use crate::orchestration::{prereq_resolve as pr, sdk_index::PrereqRole};
+
+    let files = {
+        let mut out: Vec<std::path::PathBuf> = Vec::new();
+        let mut stack = vec![ws.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            let Ok(rd) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for e in rd.flatten() {
+                let p = e.path();
+                let name = e.file_name().to_string_lossy().into_owned();
+                if p.is_dir() {
+                    if !matches!(
+                        name.as_str(),
+                        "build" | "target" | ".git" | "external" | "third-party" | "node_modules"
+                    ) && !name.starts_with("target-")
+                    {
+                        stack.push(p);
+                    }
+                } else if name == "package.xml" {
+                    out.push(p);
+                }
+            }
+        }
+        out.sort();
+        out
+    };
+
+    if files.is_empty() {
+        bail!(
+            "nros setup --workspace {}: no package.xml found.\n  \
+             This mode provisions from what a workspace DECLARES; an empty scan \
+             would report success for provisioning nothing.",
+            ws.display()
+        );
+    }
+
+    use std::collections::BTreeMap;
+
+    let prereqs = index.prereqs();
+    let mut builders: BTreeMap<String, usize> = BTreeMap::new();
+    let mut targets: BTreeMap<DeployTarget, usize> = BTreeMap::new();
+    let mut deps: BTreeMap<String, usize> = BTreeMap::new();
+
+    for f in &files {
+        let Ok(text) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        for d in pr::depend_names(&text) {
+            *deps.entry(d).or_default() += 1;
+        }
+        if let Some(bt) = pr::build_type(&text) {
+            *builders.entry(bt).or_default() += 1;
+        }
+        for t in deploy_targets(&text) {
+            *targets.entry(t).or_default() += 1;
+        }
+    }
+
+    println!(
+        "nros setup --workspace {}: {} package(s)\n",
+        ws.display(),
+        files.len()
+    );
+
+    println!("BUILDERS (from <build_type>) — each implies a toolchain that must exist:");
+    for (bt, n) in &builders {
+        let tool = pr::buildtool_for_build_type(bt).unwrap_or("(no buildtool implied)");
+        println!("  {bt:<16} x{n:<4} buildtool: {tool}");
+    }
+
+    // The scope vocabulary comes from `scripts/build/scope.sh`, the same table
+    // the `just setup` dispatcher consults. Read, never restated: a deploy name
+    // is NOT always a scope — `deploy="threadx"` splits into `threadx_linux`
+    // and `threadx_riscv64` by board, and printing `just setup threadx` would
+    // hand the user a command that does not resolve. A remedy that fails is
+    // worse than no remedy, because it costs a round trip to disbelieve.
+    let scopes: Vec<String> = repo_root
+        .map(|r| r.join("scripts/build/scope.sh"))
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|t| {
+            let i = t.find("_NROS_SCOPE_PLATFORMS=\"")? + "_NROS_SCOPE_PLATFORMS=\"".len();
+            let rest = t.get(i..)?;
+            let end = rest.find('"')?;
+            Some(
+                rest[..end]
+                    .split_whitespace()
+                    .map(str::to_string)
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .unwrap_or_default();
+
+    println!("\nDEPLOY TARGETS (from <export><nano_ros deploy=../>) — the scope to provision:");
+    if targets.is_empty() {
+        println!("  (none declared — nothing here says where it deploys)");
+    }
+    for (t, n) in &targets {
+        let board = t.board.as_deref().unwrap_or("-");
+        let rmw = t.rmw.as_deref().unwrap_or("-");
+        println!(
+            "  deploy={:<10} board={:<26} rmw={:<10} x{}",
+            t.deploy, board, rmw, n
+        );
+        // The USER spelling first, and only when it actually resolves. The
+        // `board=` vocabulary in these exports is NOT the `[board.*]` key
+        // vocabulary: of the five boards declared across this repo's examples,
+        // only `threadx-linux` is an index key. Printing `nros setup <board>`
+        // for the other four would hand an out-of-tree user — the one person
+        // this mode exists for, and the one with no justfile — a command that
+        // fails.
+        match t.board.as_deref() {
+            Some(b) if index.board.contains_key(b) => {
+                println!("      provision with:  nros setup {b}");
+            }
+            Some(b) => {
+                println!(
+                    "      board `{b}` is not an index board key — `nros setup {b}` \
+                     would fail; use the scope below from a nano-ros checkout"
+                );
+            }
+            None => {}
+        }
+        if scopes.is_empty() {
+            println!(
+                "      contributors: ./scripts/bootstrap.sh  (or: just setup {})",
+                t.deploy
+            );
+        } else if scopes.iter().any(|s| *s == t.deploy) {
+            println!(
+                "      contributors: ./scripts/bootstrap.sh  (or: just setup {})",
+                t.deploy
+            );
+        } else {
+            let candidates: Vec<&String> = scopes
+                .iter()
+                .filter(|s| s.starts_with(&format!("{}_", t.deploy)))
+                .collect();
+            if candidates.is_empty() {
+                println!(
+                    "      NO SCOPE matches `{}` — provision it by hand, or add the scope",
+                    t.deploy
+                );
+            } else {
+                let list: Vec<&str> = candidates.iter().map(|s| s.as_str()).collect();
+                println!(
+                    "      `{}` is not a scope; it splits by board. contributors: \
+                     ./scripts/bootstrap.sh  (or: just setup <{}>)",
+                    t.deploy,
+                    list.join(" | ")
+                );
+            }
+        }
+    }
+
+    // Content dependencies, split by whether this tool can act on them.
+    let mut package_role: Vec<(&String, &usize)> = Vec::new();
+    let mut wrong_role: Vec<(&String, &str)> = Vec::new();
+    let mut not_prereq = 0usize;
+    for (name, n) in &deps {
+        match prereqs.get(name) {
+            Some(dep) => match dep.role {
+                PrereqRole::Package | PrereqRole::Unclassified => package_role.push((name, n)),
+                PrereqRole::Workspace => wrong_role.push((name, "workspace")),
+                PrereqRole::Infra => wrong_role.push((name, "infra")),
+                PrereqRole::Vendor => wrong_role.push((name, "vendor")),
+            },
+            None => not_prereq += 1,
+        }
+    }
+
+    println!("\nSYSTEM PREREQUISITES this workspace names (role = package):");
+    if package_role.is_empty() {
+        println!("  (none — its dependencies are packages and messages, not system keys)");
+    }
+    for (name, n) in &package_role {
+        let probe = prereqs.get(*name).and_then(|d| d.check.as_ref());
+        let state = match run_probe(probe) {
+            ProbeResult::Present => "present",
+            ProbeResult::Missing => "MISSING",
+            ProbeResult::Unknown => "unprobed",
+        };
+        println!("  {name:<28} x{n:<4} {state}");
+    }
+
+    if !wrong_role.is_empty() {
+        println!("\nDECLARED BUT NOT A CONTENT DEPENDENCY — these come from the deploy");
+        println!("target, not from a <depend>. Not an error today (RFC-0062 amendment 3");
+        println!("leaves the refusal open), but the declaration is a category error:");
+        for (name, role) in &wrong_role {
+            println!("  {name:<28} role = {role}");
+        }
+    }
+
+    println!(
+        "\n{not_prereq} declared name(s) are workspace packages, generated messages or \
+         ROS packages — not system prerequisites."
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod workspace_scan_tests {
+    use super::*;
+
+    /// The export 90+ package.xml files already carry. All three attributes,
+    /// and a self-closing tag.
+    #[test]
+    fn a_deploy_export_is_parsed_with_board_and_rmw() {
+        let xml = r#"<package><export>
+            <nano_ros deploy="threadx" board="riscv64-qemu" rmw="zenoh"/>
+        </export></package>"#;
+        let got = deploy_targets(xml);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].deploy, "threadx");
+        assert_eq!(got[0].board.as_deref(), Some("riscv64-qemu"));
+        assert_eq!(got[0].rmw.as_deref(), Some("zenoh"));
+    }
+
+    /// `deploy=` alone is the common native shape — board and rmw are optional
+    /// and must not be invented.
+    #[test]
+    fn deploy_alone_leaves_board_and_rmw_unset() {
+        let got = deploy_targets(r#"<nano_ros deploy="native"/>"#);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].board, None);
+        assert_eq!(got[0].rmw, None);
+    }
+
+    /// The sibling exports must not be read as deploy targets: `nano_ros_provides`
+    /// and `nano_ros_uses` also start with `<nano_ros`, and a prefix match would
+    /// silently invent targets from them.
+    #[test]
+    fn sibling_exports_are_not_deploy_targets() {
+        let xml = r#"<nano_ros_provides kind="board" name="threadx"/>
+                     <nano_ros_uses kind="serdes" name="cdr"/>"#;
+        assert!(deploy_targets(xml).is_empty());
+    }
+
+    /// A package with no deploy export contributes nothing rather than a default.
+    #[test]
+    fn no_export_yields_no_target() {
+        assert!(deploy_targets("<package><name>x</name></package>").is_empty());
     }
 }

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -121,6 +121,14 @@ pub struct Args {
     /// composing the command is this tool's job, running it is the user's.
     #[arg(long = "workspace", value_name = "PATH", num_args = 0..=1, default_missing_value = ".")]
     pub workspace_scan: Option<PathBuf>,
+    /// Narrow `--system` to keys of these roles (repeatable).
+    ///
+    /// A scope's setup wants the HOST facts — `package` and `workspace` roles —
+    /// and not `infra`: reporting every cross toolchain and emulator to someone
+    /// provisioning `native` is noise, and noise is how a real missing package
+    /// gets scrolled past.
+    #[arg(long = "role", value_name = "ROLE")]
+    pub roles: Vec<String>,
 
     /// Run presence probes and report present/missing/unknown instead of
     /// installing/printing; exits 1 when anything is missing. With
@@ -220,7 +228,7 @@ pub fn run(args: Args) -> Result<()> {
         // re-discovered, so the probe and the provisioner cannot disagree
         // about where a checkout is.
         let root = args.index.parent().map(std::path::Path::to_path_buf);
-        return run_system(&index, args.check, args.sudo, root.as_deref());
+        return run_system(&index, args.check, args.sudo, root.as_deref(), &args.roles);
     }
     // #0390 — must precede the generic `--check` below: `--build-sources --check`
     // is its own preflight, not the all-deps doctor pass.
@@ -1620,6 +1628,7 @@ fn run_system(
     check_only: bool,
     run_sudo: bool,
     repo_root: Option<&std::path::Path>,
+    roles: &[String],
 ) -> Result<()> {
     // W4's retirement notice, WIRED — the step phase-383 W1.f skipped, which is
     // why that deprecation reached nobody.
@@ -1635,7 +1644,40 @@ fn run_system(
         );
     }
 
-    let prereqs = index.prereqs();
+    let mut prereqs = index.prereqs();
+    if !roles.is_empty() {
+        // Narrowing is by ROLE, not by name: `just setup native` wants the host
+        // facts, and telling that user about `gcc-riscv64-unknown-elf` is noise
+        // — which is how a real missing package gets scrolled past.
+        let want: std::collections::BTreeSet<&str> = roles.iter().map(String::as_str).collect();
+        for r in &want {
+            if !matches!(*r, "package" | "workspace" | "infra" | "vendor") {
+                bail!(
+                    "nros setup --role {r}: unknown role. \
+                     One of: package, workspace, infra, vendor."
+                );
+            }
+        }
+        prereqs.retain(|_k, d| {
+            let name = match d.role {
+                crate::orchestration::sdk_index::PrereqRole::Package => "package",
+                crate::orchestration::sdk_index::PrereqRole::Workspace => "workspace",
+                crate::orchestration::sdk_index::PrereqRole::Infra => "infra",
+                crate::orchestration::sdk_index::PrereqRole::Vendor => "vendor",
+                // Unclassified must not silently vanish under a filter: it is
+                // what `check-prereq-roles` exists to catch, so surface it.
+                crate::orchestration::sdk_index::PrereqRole::Unclassified => "unclassified",
+            };
+            want.contains(name) || name == "unclassified"
+        });
+        if prereqs.is_empty() {
+            println!(
+                "nros setup --system --role {}: no key carries that role.",
+                roles.join(",")
+            );
+            return Ok(());
+        }
+    }
     if prereqs.is_empty() {
         println!("nros setup --system: index declares no [prereq.*] / [system.*] entries.");
         return Ok(());

--- a/packages/cli/nros-cli-core/src/orchestration/prereq_resolve.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/prereq_resolve.rs
@@ -50,6 +50,15 @@ pub enum Resolution {
     Prereq,
     /// Provided by the ambient ROS install (the ament index).
     RosPackage,
+    /// The declaring package's OWN buildtool, named by its `<build_type>`.
+    ///
+    /// `<buildtool_depend>ament_cmake</buildtool_depend>` on a package whose
+    /// build type IS `ament_cmake` is a tautology: if that builder is building
+    /// it, the buildtool is present. rosdep wants the declaration anyway, so
+    /// the tree should carry it — but resolving it must not require an ambient
+    /// ROS, or an embedded-only contributor with no `AMENT_PREFIX_PATH` gets a
+    /// hard error for a dependency that is satisfied by definition.
+    SelfBuildtool,
     /// Nothing claims it.
     Unknown,
 }
@@ -96,6 +105,7 @@ pub fn classify(
     generated: &BTreeSet<String>,
     prereq_keys: &BTreeSet<String>,
     ros: &BTreeSet<String>,
+    self_buildtools: &BTreeSet<String>,
 ) -> Resolution {
     if workspace_packages.contains(name) {
         Resolution::WorkspacePackage
@@ -105,6 +115,11 @@ pub fn classify(
         Resolution::Prereq
     } else if ros.contains(name) {
         Resolution::RosPackage
+    } else if self_buildtools.contains(name) {
+        // LAST, deliberately. An ambient ROS or a `[prereq.*]` key is a real
+        // provider and should win; this rung exists so the absence of both is
+        // not an error for a dependency the builder satisfies by definition.
+        Resolution::SelfBuildtool
     } else {
         Resolution::Unknown
     }
@@ -176,6 +191,97 @@ pub fn depend_names(xml: &str) -> Vec<String> {
     out
 }
 
+/// `<build_type>` -> the buildtool package that build type implies.
+///
+/// Measured on this tree: 345 of 367 packages declare a `<build_type>` and NOT
+/// the matching `<buildtool_depend>`, and the only buildtool declarations that
+/// are NOT inferable this way are `rosidl_default_generators` (10 message
+/// packages) and `cargo-ros2` (1). So the mapping is nearly total, and what it
+/// cannot infer is exactly what a human should still write by hand.
+///
+/// The nano-ros build types map to `nros`: they are served by this repo's own
+/// builders, so there is no upstream buildtool package to name. `ament_cargo`
+/// and `cargo-ros2` are served by the in-tree `packages/cli/colcon-cargo-ros2`
+/// colcon extension — also not apt-installable, which is why inventing
+/// `[prereq.*]` rows with `apt = ["ros-humble-..."]` for them would be fiction.
+#[must_use]
+pub fn buildtool_for_build_type(build_type: &str) -> Option<&'static str> {
+    Some(match build_type {
+        "ament_cmake" => "ament_cmake",
+        "ament_cargo" => "ament_cargo",
+        "cmake" => "cmake",
+        "cargo" => "cargo",
+        "ament_nros" | "nros_entry" | "nros_cargo" | "nros_bringup" => "nros",
+        _ => return None,
+    })
+}
+
+/// The `<build_type>` a `package.xml` exports, if it declares one.
+#[must_use]
+pub fn build_type(xml: &str) -> Option<String> {
+    let i = xml.find("<build_type>")? + "<build_type>".len();
+    let rest = xml.get(i..)?;
+    let end = rest.find("</build_type>")?;
+    Some(rest[..end].trim().to_string())
+}
+
+/// Buildtool names that every declaring package satisfies by its own build type.
+///
+/// Deliberately conservative: a name qualifies only if EVERY `package.xml` that
+/// declares it has a build type implying it. One package declaring
+/// `ament_cmake` while being built some other way keeps the name on the normal
+/// ladder, where an ambient ROS or a `[prereq.*]` key still has to claim it.
+#[must_use]
+pub fn self_satisfied_buildtools(ws_root: &Path) -> BTreeSet<String> {
+    let mut implied: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    for (_path, text) in package_xml_files(ws_root) {
+        let own = build_type(&text).and_then(|bt| buildtool_for_build_type(&bt));
+        for dep in depend_names(&text) {
+            if buildtool_for_build_type(&dep).is_some() || dep == "nros" {
+                let e = implied.entry(dep.clone()).or_insert((0, 0));
+                e.1 += 1;
+                if own == Some(dep.as_str()) {
+                    e.0 += 1;
+                }
+            }
+        }
+    }
+    implied
+        .into_iter()
+        .filter(|(_n, (ok, total))| *total > 0 && ok == total)
+        .map(|(n, _)| n)
+        .collect()
+}
+
+/// Every `package.xml` under a workspace, as (path, text).
+fn package_xml_files(ws_root: &Path) -> Vec<(std::path::PathBuf, String)> {
+    let mut out = Vec::new();
+    let mut stack = vec![ws_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            let name = e.file_name().to_string_lossy().into_owned();
+            if p.is_dir() {
+                if !matches!(
+                    name.as_str(),
+                    "build" | "target" | ".git" | "external" | "third-party" | "node_modules"
+                ) && !name.starts_with("target-")
+                {
+                    stack.push(p);
+                }
+            } else if name == "package.xml"
+                && let Ok(text) = std::fs::read_to_string(&p)
+            {
+                out.push((p, text));
+            }
+        }
+    }
+    out
+}
+
 /// The name of a `package.xml`'s own package.
 #[must_use]
 pub fn package_name(xml: &str) -> Option<String> {
@@ -201,7 +307,8 @@ mod tests {
         let msgs = set(&["std_msgs"]);
         let keys = set(&["libslirp"]);
         let ros = set(&["ament_cmake"]);
-        let c = |n: &str| classify(n, &ws, &msgs, &keys, &ros);
+        let bt = BTreeSet::new();
+        let c = |n: &str| classify(n, &ws, &msgs, &keys, &ros, &bt);
 
         assert_eq!(c("talker_pkg"), Resolution::WorkspacePackage);
         assert_eq!(c("std_msgs"), Resolution::GeneratedMessage);
@@ -218,7 +325,14 @@ mod tests {
     fn a_generated_message_outranks_a_prereq_key_of_the_same_name() {
         let both = set(&["std_msgs"]);
         assert_eq!(
-            classify("std_msgs", &BTreeSet::new(), &both, &both, &BTreeSet::new()),
+            classify(
+                "std_msgs",
+                &BTreeSet::new(),
+                &both,
+                &both,
+                &BTreeSet::new(),
+                &BTreeSet::new()
+            ),
             Resolution::GeneratedMessage,
         );
     }
@@ -229,9 +343,67 @@ mod tests {
     fn a_workspace_package_outranks_every_other_rung() {
         let all = set(&["talker_pkg"]);
         assert_eq!(
-            classify("talker_pkg", &all, &all, &all, &all),
+            classify("talker_pkg", &all, &all, &all, &all, &all),
             Resolution::WorkspacePackage,
         );
+    }
+
+    /// The rung this exists for: no ambient ROS, and a package declaring the
+    /// buildtool its own `<build_type>` implies still resolves.
+    ///
+    /// Without it, adding the `<buildtool_depend>` rosdep expects would hard-fail
+    /// `nros build` on every host with no `AMENT_PREFIX_PATH` — which is every
+    /// embedded-only contributor.
+    #[test]
+    fn a_packages_own_buildtool_resolves_without_ros() {
+        let empty = BTreeSet::new();
+        let bt = set(&["ament_cmake"]);
+        assert_eq!(
+            classify("ament_cmake", &empty, &empty, &empty, &empty, &bt),
+            Resolution::SelfBuildtool,
+        );
+        // and it is still UNKNOWN when nothing implies it
+        assert_eq!(
+            classify("ament_cmake", &empty, &empty, &empty, &empty, &empty),
+            Resolution::Unknown,
+        );
+    }
+
+    /// A real provider outranks the tautology: if ROS supplies `ament_cmake`,
+    /// say so, because that is the truthful answer and the one a user can act on.
+    #[test]
+    fn an_ambient_ros_outranks_the_self_buildtool_rung() {
+        let s = set(&["ament_cmake"]);
+        assert_eq!(
+            classify(
+                "ament_cmake",
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+                &BTreeSet::new(),
+                &s,
+                &s
+            ),
+            Resolution::RosPackage,
+        );
+    }
+
+    /// The mapping is per build type, and nano-ros's own builders resolve to
+    /// `nros` — they have no upstream buildtool package to name.
+    #[test]
+    fn build_type_implies_its_buildtool() {
+        assert_eq!(buildtool_for_build_type("ament_cmake"), Some("ament_cmake"));
+        assert_eq!(buildtool_for_build_type("cmake"), Some("cmake"));
+        assert_eq!(buildtool_for_build_type("nros_entry"), Some("nros"));
+        assert_eq!(buildtool_for_build_type("ament_cargo"), Some("ament_cargo"));
+        // Not every build type implies one; an unknown type must not be guessed.
+        assert_eq!(buildtool_for_build_type("colcon_lunar_module"), None);
+    }
+
+    #[test]
+    fn build_type_is_read_from_the_export_block() {
+        let xml = "<package><export><build_type>ament_cmake</build_type></export></package>";
+        assert_eq!(build_type(xml).as_deref(), Some("ament_cmake"));
+        assert_eq!(build_type("<package/>"), None);
     }
 
     /// All four depend spellings, and the closing tag must not be mistaken for

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
@@ -135,11 +135,45 @@ pub enum Provider {
 /// `[prereq.x.system]` sub-table, so an existing `[system.*]` entry is
 /// byte-identical as a `[prereq.*]` entry. That is the whole migration for 25
 /// of 25 current entries.
+/// Who may name a `[prereq.*]` key.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrereqRole {
+    /// A package's CONTENT depends on it, so a `package.xml` may name it and
+    /// `nros setup --workspace` can discover it. `cmake`, `clang`, a ROS
+    /// package the code links.
+    Package,
+    /// A repo-level recipe needs it, and no package does: `doxygen` for
+    /// `just docs-c`, `gnu-parallel` for the gate runner. Reached by running
+    /// that recipe's scope, never by declaring a dependency.
+    Workspace,
+    /// Test/build INFRASTRUCTURE for a target: emulators, cross toolchains,
+    /// on-chip debug probes. Comes from WHERE you deploy, not from what your
+    /// code needs — `<depend>qemu-system-arm</depend>` is a category error.
+    Infra,
+    /// A third-party source tree this repo builds (submodule or fetched
+    /// source). ROS 2 would express these as `*_vendor` packages.
+    Vendor,
+    /// Not yet classified. The DEFAULT so the field can land before all 46
+    /// entries carry one; `check-prereq-roles` is what forbids it staying.
+    #[default]
+    Unclassified,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrereqDep {
     #[serde(default)]
     pub why: Option<String>,
+    /// WHO may name this key, and therefore how a user reaches it.
+    ///
+    /// RFC-0062 amendment 3. Measured before adding it: of 46 keys, exactly
+    /// THREE are ever named by a `package.xml` (`cargo`, `cmake`, `nros`).
+    /// The rest are provisioning facts no package's CONTENT depends on, and
+    /// conflating the two is why `nros setup` cannot answer "what does MY
+    /// workspace need" — it has no way to tell a dependency from a toolchain.
+    #[serde(default)]
+    pub role: PrereqRole,
     /// Ordered providers. Empty means "just `provider`", which defaults to
     /// `system` — so the common single-provider entry writes neither field.
     ///
@@ -209,6 +243,11 @@ impl From<&SystemDep> for PrereqDep {
     fn from(d: &SystemDep) -> Self {
         Self {
             why: d.why.clone(),
+            // A lowered `[system.*]` entry carries no role: the alias exists to
+            // make the merge additive, and inventing a classification here
+            // would put it somewhere no author chose. `check-prereq-roles`
+            // reports it as unclassified, which is the truth.
+            role: PrereqRole::Unclassified,
             providers: Vec::new(),
             provider: Provider::System,
             apt: d.apt.clone(),

--- a/scripts/check-board-vocabulary.py
+++ b/scripts/check-board-vocabulary.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Every `deploy=` and `board=` a package.xml exports must resolve somewhere.
+
+phase-422 W7. `<export><nano_ros deploy=".." board=".."/></export>` is how a
+workspace states where it deploys, and `nros setup --workspace` turns that into
+a provisioning command. That only works if the values mean something.
+
+WHAT THE VALUES ACTUALLY MEAN, measured rather than assumed. `board=` is the
+CMAKE BOARD vocabulary: all five values across `examples/` resolve to a
+`cmake/board/nano-ros-board-<name>.cmake` file. They are NOT `[board.*]` index
+keys — only `threadx-linux` is one, so `nros setup <board>` would fail for four
+of five. That mismatch is real and is why `nros setup --workspace` validates
+before printing a command.
+
+Five namespaces exist for closely related concepts, overlapping partially:
+
+  1. `cmake/board/nano-ros-board-*.cmake` — what `board=` names (canonical here)
+  2. `[board.*]` in nros-sdk-index.toml   — what `nros setup <board>` accepts
+  3. `packages/boards/nros-board-*`       — the board crate
+  4. `examples/fixtures.toml` NANO_ROS_BOARD — the test coordinate
+  5. `_NROS_SCOPE_PLATFORMS`              — what `just setup <scope>` accepts
+
+This gate does NOT unify them. Which becomes canonical across all five is a
+decision phase-422 W7 leaves to a human, and renaming boards through 90+
+package.xml files is not something to do as a side effect. What it stops is a
+value resolving in NONE of them — the case where a printed remedy fails and a
+user pays for it.
+
+Three reader bugs were found by RUNNING this gate rather than reasoning about
+it, each one reporting well-defined boards as undefined: fixtures.toml spells
+the board `NANO_ROS_BOARD = ".."` inside `cmake_defs`, not `board = ".."`; and
+the cmake board files were missing from the namespace list entirely. A gate
+that is wrong about where names live sends someone renaming working examples.
+
+Run:  python3 scripts/check-board-vocabulary.py [--self-test]
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def exports(text):
+    """[(deploy, board)] from `<nano_ros deploy=".." board=".."/>` tags."""
+    out = []
+    for m in re.finditer(r"<nano_ros\s([^>]*)>", text):
+        tag = m.group(1)
+        d = re.search(r'deploy="([^"]*)"', tag)
+        if not d:
+            continue
+        b = re.search(r'board="([^"]*)"', tag)
+        out.append((d.group(1), b.group(1) if b else None))
+    return out
+
+
+def index_boards(root):
+    try:
+        with open(os.path.join(root, "nros-sdk-index.toml"), encoding="utf8") as fh:
+            return set(re.findall(r"^\[board\.([a-z0-9._-]+)\]", fh.read(), re.M))
+    except OSError:
+        return set()
+
+
+def board_crates(root):
+    d = os.path.join(root, "packages", "boards")
+    try:
+        return {n[len("nros-board-") :] for n in os.listdir(d) if n.startswith("nros-board-")}
+    except OSError:
+        return set()
+
+
+def fixture_boards(root):
+    """Boards named by the fixture matrix.
+
+    NOT a bare `board = "..."`: fixtures.toml carries the board inside a cmake
+    definition table, `cmake_defs = { NANO_ROS_BOARD = "nuttx-qemu-arm", .. }`.
+    Reading the wrong spelling made this gate report three real, well-defined
+    boards as resolving nowhere — a false positive that would have sent someone
+    renaming working examples.
+    """
+    boards = set()
+    for rel in [("examples", "fixtures.toml")]:
+        try:
+            with open(os.path.join(root, *rel), encoding="utf8") as fh:
+                t = fh.read()
+        except OSError:
+            continue
+        boards |= set(re.findall(r'NANO_ROS_BOARD\s*=\s*"([^"]+)"', t))
+        boards |= set(re.findall(r'^\s*board\s*=\s*"([^"]+)"', t, re.M))
+    return boards
+
+
+def cmake_boards(root):
+    """Boards defined by `cmake/board/nano-ros-board-<name>.cmake`.
+
+    This is what `board=` in a package.xml export actually names — all five
+    values in this repo resolve here, and only one of them is an index key.
+    """
+    d = os.path.join(root, "cmake", "board")
+    try:
+        names = os.listdir(d)
+    except OSError:
+        return set()
+    out = set()
+    for n in names:
+        m = re.fullmatch(r"nano-ros-board-(.+)\.cmake", n)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def scopes(root):
+    try:
+        with open(os.path.join(root, "scripts", "build", "scope.sh"), encoding="utf8") as fh:
+            t = fh.read()
+    except OSError:
+        return set()
+    m = re.search(r'_NROS_SCOPE_PLATFORMS="([^"]*)"', t)
+    return set(m.group(1).split()) if m else set()
+
+
+def self_test():
+    got = exports('<nano_ros deploy="threadx" board="riscv64-qemu" rmw="zenoh"/>')
+    assert got == [("threadx", "riscv64-qemu")], got
+    assert exports('<nano_ros deploy="native"/>') == [("native", None)]
+    # Siblings are not deploy exports.
+    assert exports('<nano_ros_provides kind="board" name="threadx"/>') == []
+    sys.stdout.write("check-board-vocabulary self-test: OK\n")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return 0
+    self_test()
+
+    files = subprocess.run(
+        ["git", "ls-files", "*package.xml"], cwd=ROOT, capture_output=True, text=True
+    ).stdout.split()
+    idx, crates, fixtures, scope_set, cmakeb = (
+        index_boards(ROOT),
+        board_crates(ROOT),
+        fixture_boards(ROOT),
+        scopes(ROOT),
+        cmake_boards(ROOT),
+    )
+    if not scope_set or not idx:
+        sys.stderr.write(
+            "error: could not read the scope list or the index boards.\n"
+            "This gate would then accept anything and pass vacuously.\n"
+        )
+        return 1
+
+    bad_board, bad_deploy = {}, {}
+    seen_board, seen_deploy = {}, {}
+    for f in files:
+        try:
+            with open(os.path.join(ROOT, f), encoding="utf8") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for deploy, board in exports(text):
+            seen_deploy.setdefault(deploy, f)
+            # A deploy is a scope, or splits into `<deploy>_*` scopes by board.
+            if deploy not in scope_set and not any(
+                s.startswith(deploy + "_") for s in scope_set
+            ):
+                bad_deploy.setdefault(deploy, f)
+            if board is None:
+                continue
+            seen_board.setdefault(board, f)
+            if (
+                board not in cmakeb
+                and board not in idx
+                and board not in crates
+                and board not in fixtures
+            ):
+                bad_board.setdefault(board, f)
+
+    if bad_board or bad_deploy:
+        sys.stderr.write("check-board-vocabulary: %d problem(s)\n\n" % (len(bad_board) + len(bad_deploy)))
+        for d, f in sorted(bad_deploy.items()):
+            sys.stderr.write(
+                "  - deploy=%r (%s) is not a scope and no scope starts with %r.\n"
+                "      `nros setup --workspace` prints a provisioning command from this;\n"
+                "      an unresolvable value makes that command fail.\n"
+                "      Scopes: %s\n\n" % (d, f, d + "_", " ".join(sorted(scope_set)))
+            )
+        for b, f in sorted(bad_board.items()):
+            sys.stderr.write(
+                "  - board=%r (%s) resolves in NONE of the five namespaces:\n"
+                "      cmake/board/nano-ros-board-*.cmake | [board.*] index key |\n"
+                "      packages/boards/nros-board-* | fixtures.toml NANO_ROS_BOARD\n"
+                "      Name one that exists, or add the board where it belongs.\n\n" % (b, f)
+            )
+        return 1
+
+    sys.stdout.write(
+        "check-board-vocabulary: OK — %d deploy value(s), %d board value(s); "
+        "each resolves (cmake %d / index %d / crate %d / fixture %d).\n"
+        % (
+            len(seen_deploy),
+            len(seen_board),
+            len(cmakeb),
+            len(idx),
+            len(crates),
+            len(fixtures),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-prereq-roles.py
+++ b/scripts/check-prereq-roles.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Every `[prereq.*]` key declares a `role`, and the role is one of four.
+
+RFC-0062 amendment 3. `role` answers "who may NAME this key", which is what
+lets `nros setup --workspace` tell a dependency from a toolchain:
+
+  package    a package's CONTENT needs it; a package.xml may name it
+  workspace  a repo-level recipe needs it; no package does
+  infra      emulators, cross toolchains, probes — it comes from WHERE you
+             deploy, not from what your code needs
+  vendor     a third-party source tree this repo builds
+
+Why a gate rather than a convention: the field defaults to `unclassified` in
+the Rust struct so it could land before all 46 entries carried one. Without
+this, a new key silently inherits that default and `--workspace` reports it as
+a content dependency — the exact conflation the field exists to remove.
+
+The measurement that motivated the split: of 46 keys, exactly THREE are ever
+named by a package.xml (`cargo`, `cmake`, `nros`) across 407 package.xml files.
+The other 43 are provisioning facts no package's content depends on.
+
+Run:  python3 scripts/check-prereq-roles.py [--self-test]
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INDEX = os.path.join(ROOT, "nros-sdk-index.toml")
+VALID = {"package", "workspace", "infra", "vendor"}
+
+
+def entries(text):
+    """[(key, role_or_None)] for every `[prereq.*]` block, in file order."""
+    out = []
+    blocks = re.split(r"^\[", text, flags=re.M)
+    for b in blocks:
+        m = re.match(r"prereq\.([a-z0-9._+-]+)\]", b)
+        if not m:
+            continue
+        key = m.group(1)
+        # Only the block's OWN lines: a nested `[prereq.x.y]` starts a new block,
+        # and a `role =` inside prose would be a comment, not a key.
+        role = None
+        for line in b.split("\n")[1:]:
+            if line.startswith("["):
+                break
+            mm = re.match(r"role\s*=\s*\"([a-z_]+)\"", line.strip())
+            if mm:
+                role = mm.group(1)
+                break
+        out.append((key, role))
+    return out
+
+
+def self_test():
+    t = (
+        '[prereq.alpha]\nrole = "package"\napt = ["a"]\n\n'
+        '[prereq.beta]\nwhy = "no role here"\napt = ["b"]\n\n'
+        '[prereq.gamma]\nrole = "infra"\n'
+    )
+    got = entries(t)
+    assert got == [("alpha", "package"), ("beta", None), ("gamma", "infra")], got
+    # A commented mention must not be read as a declaration.
+    t2 = '[prereq.delta]\n# see role = "infra" elsewhere\napt = ["d"]\n'
+    assert entries(t2) == [("delta", None)], entries(t2)
+    sys.stdout.write("check-prereq-roles self-test: OK\n")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return 0
+    self_test()
+
+    with open(INDEX, encoding="utf8") as fh:
+        text = fh.read()
+    found = entries(text)
+    if not found:
+        sys.stderr.write(
+            "error: parsed ZERO [prereq.*] entries from nros-sdk-index.toml.\n"
+            "The block shape changed; this gate would pass vacuously.\n"
+        )
+        return 1
+
+    missing = [k for k, r in found if r is None]
+    bad = [(k, r) for k, r in found if r is not None and r not in VALID]
+
+    if missing or bad:
+        sys.stderr.write("check-prereq-roles: %d problem(s)\n\n" % (len(missing) + len(bad)))
+        for k in missing:
+            sys.stderr.write(
+                "  - [prereq.%s] declares no `role`.\n"
+                "      Add one of: %s\n"
+                "      `package` means a package.xml may name it — pick that ONLY if a\n"
+                "      package's CONTENT needs it. A toolchain or emulator is `infra`:\n"
+                "      it comes from where you deploy, not from a <depend>.\n\n"
+                % (k, ", ".join(sorted(VALID)))
+            )
+        for k, r in bad:
+            sys.stderr.write(
+                "  - [prereq.%s] has role = %r, which is not one of %s\n\n"
+                % (k, r, ", ".join(sorted(VALID)))
+            )
+        return 1
+
+    counts = {}
+    for _k, r in found:
+        counts[r] = counts.get(r, 0) + 1
+    sys.stdout.write(
+        "check-prereq-roles: OK — %d key(s) (%s).\n"
+        % (len(found), ", ".join("%d %s" % (v, k) for k, v in sorted(counts.items())))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-workflow-setup-spelling.py
+++ b/scripts/check-workflow-setup-spelling.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""A workflow must provision with `just setup <scope>`, not `just <scope> setup`.
+
+The two spellings look interchangeable and are not:
+
+    just setup zephyr     -> dispatcher: runs `_setup-common`, THEN `just zephyr setup`
+    just zephyr setup     -> the module recipe ALONE
+
+`_setup-common` is where the host facts every tier asserts get provisioned --
+cross Rust targets, pinned corrosion, the in-tree CLI, `nros-launch-resolve`,
+clang-format. The module spelling skips all of it silently: the recipe exists,
+it succeeds, and the lane fails later on a precondition nothing provisioned.
+
+That is not hypothetical. `nightly.yml`'s platform job used the module spelling
+and carried a hand-rolled "Install cross targets from config/rust-targets.txt"
+step to compensate -- a workaround for a defect one word wide. host-tests hit
+the same class from the other direction and cost three CI rounds to unpick.
+
+`check-preconditions-provisioned` asserts that `just setup` PROVIDES those
+facts. This asserts that workflows INVOKE the form which runs them. Neither
+implies the other.
+
+EXEMPTIONS carry a reason and are checked in both directions: an exemption that
+matches nothing is deleted, because a stale allow-list is how a gate quietly
+stops covering what it names.
+
+Run:  python3 scripts/check-workflow-setup-spelling.py [--self-test]
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+# `just <scope> setup ...` occurrences that may stay, and why.
+#
+# The dispatcher takes a scope and nothing else -- `setup target="" tier=""`
+# execs `just "$target" setup` with no argument passthrough -- so a call that
+# must pass a FLAG has no dispatcher spelling available. These lanes therefore
+# do not get `_setup-common`, and that is a known gap rather than an accident:
+# giving the dispatcher argument passthrough would let them convert.
+EXEMPT = {
+    "just zephyr setup --skip-sdk": (
+        "Passes `--skip-sdk` (the image bakes the SDK). The `setup` dispatcher "
+        "has no argument passthrough, so no dispatcher spelling exists. These "
+        "jobs provision the host facts themselves or do not need them."
+    ),
+}
+
+
+def scope_tokens():
+    """Platform scope names, from the same table the dispatcher consults."""
+    path = os.path.join(ROOT, "scripts", "build", "scope.sh")
+    try:
+        with open(path, encoding="utf8") as fh:
+            text = fh.read()
+    except OSError:
+        return set()
+    names = set()
+    for m in re.finditer(r'_NROS_SCOPE_PLATFORMS="([^"]*)"', text):
+        names.update(re.findall(r"[a-z0-9_]+", m.group(1)))
+    return names
+
+
+def offenders(text, scopes):
+    """[(lineno, line)] for executable `just <scope> setup` calls."""
+    out = []
+    for i, raw in enumerate(text.split("\n"), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Two shapes, and missing the second made this gate useless on the very
+        # workflow that motivated it: nightly's platform job spells the scope as
+        # a matrix expression, `just ${{ matrix.plat }} setup`. A templated scope
+        # in that position is ALWAYS the module form -- there is nothing to
+        # resolve, and the spelling alone is the defect. Caught by mutation-
+        # testing this gate against the pre-conversion nightly.yml.
+        m = re.search(r"just (\$\{\{[^}]*\}\}) setup\b(.*)$", line)
+        if m:
+            scope, rest = m.group(1), m.group(2).strip()
+        else:
+            m = re.search(r"just ([a-z0-9_]+) setup\b(.*)$", line)
+            if not m:
+                continue
+            scope, rest = m.group(1), m.group(2).strip()
+            if scope not in scopes:
+                continue
+        call = ("just %s setup %s" % (scope, rest)).strip()
+        out.append((i, line, call))
+    return out
+
+
+def self_test():
+    scopes = {"zephyr", "freertos"}
+    t = "\n".join(
+        [
+            "      # a comment about just zephyr setup is not a call",
+            "          just zephyr setup --skip-sdk",
+            "          just setup zephyr",
+            "          just freertos setup",
+            "          just workspace setup",
+            "          just ${{ matrix.plat }} setup",
+        ]
+    )
+    got = offenders(t, scopes)
+    assert [g[0] for g in got] == [2, 4, 6], got
+    assert got[0][2] == "just zephyr setup --skip-sdk", got[0]
+    assert got[1][2] == "just freertos setup", got[1]
+    sys.stdout.write("check-workflow-setup-spelling self-test: OK\n")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return 0
+    self_test()
+
+    scopes = scope_tokens()
+    if not scopes:
+        sys.stderr.write(
+            "error: parsed ZERO platform scopes from scripts/build/scope.sh.\n"
+            "This gate would then match nothing and pass vacuously.\n"
+        )
+        return 1
+
+    problems = []
+    seen_exempt = set()
+    for fn in sorted(os.listdir(WORKFLOWS)):
+        if not fn.endswith((".yml", ".yaml")):
+            continue
+        path = os.path.join(WORKFLOWS, fn)
+        with open(path, encoding="utf8") as fh:
+            text = fh.read()
+        for lineno, line, call in offenders(text, scopes):
+            if call in EXEMPT:
+                seen_exempt.add(call)
+                continue
+            problems.append(
+                "%s:%d uses the MODULE spelling\n"
+                "      %s\n"
+                "    `just <scope> setup` runs the module recipe alone and skips\n"
+                "    `_setup-common`, so the cross Rust targets, pinned corrosion,\n"
+                "    the CLI, the resolver and clang-format are never provisioned.\n"
+                "    Use the dispatcher:  just setup <scope>" % (fn, lineno, line)
+            )
+
+    for call in EXEMPT:
+        if call not in seen_exempt:
+            problems.append(
+                "STALE exemption %r matches no workflow line.\n"
+                "    Delete it — an allow-list checked one way stops covering\n"
+                "    what it claims to." % call
+            )
+
+    if problems:
+        sys.stderr.write("check-workflow-setup-spelling: %d problem(s)\n\n" % len(problems))
+        for p in problems:
+            sys.stderr.write("  - %s\n\n" % p)
+        return 1
+
+    sys.stdout.write(
+        "check-workflow-setup-spelling: OK — %d scope(s), %d exemption(s) all live.\n"
+        % (len(scopes), len(EXEMPT))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #401 (phase-422 doc). Two commits: the resolver change, and the RFC amendment folding this design discussion.

## The measurement that drove it

407 `package.xml` files declare 65 distinct dependency tokens. Of the 46 `[prereq.*]` keys, **exactly three are ever named by a package.xml** — `cargo`, `cmake`, `nros`. The other 43 are provisioning facts no package's *content* depends on:

| group | n | example | ROS 2's answer |
| --- | --- | --- | --- |
| runtime closure of a dist we ship | 11 | `libssl3` | never hand-declared |
| build tooling | 16 | `ninja`, `doxygen` | `buildtool_depend` / `doc_depend` |
| cross toolchains, emulators | 7 | `qemu-system-arm` | outside rosdep entirely |
| vendored source trees | 6 | `zenoh-pico` | a `*_vendor` package |
| ROS binary package | 1 | `ros-rmw-zenoh-cpp` | plain `<depend>` |

## Decided: a package's own buildtool needs no provider

`<buildtool_depend>ament_cmake</buildtool_depend>` on an `ament_cmake` package is a tautology. `Resolution::SelfBuildtool` resolves it, **off-ROS safe**. Both alternatives were rejected on evidence:

- **Rely on the ROS rung** — `ros_packages()` returns empty without `AMENT_PREFIX_PATH`, which is the normal state for an embedded-only contributor. `nros build` would hard-fail on a dependency satisfied by definition.
- **Add `[prereq.ament_cargo]` with an apt name** — fiction. `ament_cargo` and `cargo-ros2` come from this repo's own `packages/cli/colcon-cargo-ros2` extension; no apt package provides them.

Two properties keep it from being a blanket exemption: it sits **last** (a real provider still wins and gets reported), and it is **conservative** — a name qualifies only if *every* declaring package.xml has a build type implying it.

Inference is near-total: **345 of 367** packages declare a `<build_type>` and not the matching buildtool; the only non-inferable ones are `rosidl_default_generators` (10) and `cargo-ros2` (1).

## Decided: a vendor package may source from the submodule

ROS `*_vendor` **layout**, submodule as **source**, and the decisive property is **one pin**:

```cmake
ExternalProject_Add(zenoh_pico
  SOURCE_DIR "${NROS_ZENOH_PICO_DIR}")   # no GIT_REPOSITORY, no GIT_TAG
```

A `GIT_TAG` in CMake is a second pin that can drift from the gitlink — the one `check-submodule-pins`, the pre-push hook and `diff.submodule=log` already guard, after a zenoh-pico pin silently rewound over a Zephyr build fix for seven hours. Shallow-cloning needs a `GIT_TAG` to clone *to*, so it reintroduces that second pin for no gain.

Prototyped: configures clean, uninitialised submodule fails with the `git submodule update --init` remedy, submodule working tree stays clean.

## Still open (recorded in the RFC, not decided here)

- the `role` field, and whether the resolver refuses `<depend>qemu-system-arm</depend>` — which resolves silently today
- whether the 11 runtime-closure keys move under their owning `[tool.*]`, sequenced against issue 0928's `$ORIGIN` re-cut which may delete the need
- whether to sweep the 345 missing `<buildtool_depend>` declarations
- which vendored trees adopt the layout

## Verification

10 resolver tests pass (including the off-ROS case and ROS-outranks-it), clippy clean, `just check fast` — 201 gates, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)