### PR TITLE
feat(phase-420 W5): a descriptor carries only what convention cannot produce

### DIFF
--- a/docs/design/0087-package-identity-and-provider-format.md
+++ b/docs/design/0087-package-identity-and-provider-format.md
@@ -190,7 +190,23 @@ Derived by convention, never authored in a new descriptor:
 | cmake value | the canonical name |
 | C define token | `UPPER(name)` |
 | cffi feature | `<cargo_feature>-cffi` |
-| crate | the package's `Cargo.toml` |
+
+**Amended 2026-09-04 from implementation (phase-420 W5): `crate` is NOT
+derivable, and this table said it was.** "The package's `Cargo.toml`" holds for
+one and a half of the four RMW backends. `nros-rmw-xrce` ships **no
+`Cargo.toml`** at all and its `[rmw.provides.cargo].crate` names a *sibling*
+(`nros-rmw-xrce-cffi`); `nros-rmw-cyclonedds` states `sys_crate =
+"cyclonedds-sys"`, also not its own. A convention with exceptions is not a
+convention, so `crate` stays authored and xrce is the derivation ratchet's one
+grandfathered row.
+
+**Names are derivable per family, not universally.** They come from the
+announcement for `rmw` and `serdes`. They cannot for `board`:
+`nros-board-nuttx-qemu` declares **two** `[[board]]` entries and announces seven
+names in one flat list, and `<nano_ros_provides>` carries no boundary that could
+attribute a name to an entry. `board` therefore stays a *named* family, and the
+FAMILIES shape phase-421 W4 introduced (`extract=None` meaning "nameless") is
+per family rather than a migration every family completes.
 
 **A stated derivable field must equal its derived value** — a ratchet, so the
 existing rmw/board/platform descriptors are grandfathered where history forces a
@@ -300,6 +316,11 @@ semantics, over the topological order `provider_scan` already computes.
 
 ## Changelog
 
+- 2026-09-04 — D4 amended from implementation (phase-420 W5): `crate` is not
+  derivable (xrce ships no `Cargo.toml` and names a sibling; cyclonedds names a
+  sys crate), and `names` is derivable per family — `board` cannot, because one
+  package declares two board entries and announces seven names with no boundary
+  between them.
 - 2026-09-04 — initial draft. Folds the packaging discussion: one recognition
   rule, `nros_cmake`/`nros_cargo`, three export tags with `<nano_ros_uses>` as
   the general consumption form, derived descriptor fields, vendor packages as

--- a/just/check.just
+++ b/just/check.just
@@ -150,6 +150,7 @@ fast-serial: \
     cyclone-domain-not-pinned \
     declared-qos-header \
     deploy-board-resolves \
+    derived-descriptor-fields \
     doc-recipe-refs \
     doc-refs \
     emitter-just-spelling \
@@ -1789,6 +1790,17 @@ generated-schema-coverage:
     @python3 scripts/check-generated-schema-coverage.py
 
 # `nros sync` skips the leaf with a count instead of a name. Buildless.
+# RFC-0087 D4 / phase-420 W5 — a descriptor carries only what no convention can
+# produce, so a field it DOES state must equal the value convention derives.
+# Six of eleven rmw fields were convention written longhand; five are now gone
+# and this keeps the rest honest. A ratchet: `crate` is grandfathered for
+# `nros-rmw-xrce`, which ships no Cargo.toml and names a sibling — the
+# measurement that showed D4's own table was wrong about `crate` being
+# derivable. Buildless, ~0.2 s.
+[private]
+derived-descriptor-fields:
+    @python3 scripts/check-derived-descriptor-fields.py
+
 [private]
 deploy-board-resolves:
     @python3 scripts/check-deploy-board-resolves.py

--- a/packages/cli/cargo-nano-ros/build.rs
+++ b/packages/cli/cargo-nano-ros/build.rs
@@ -53,6 +53,11 @@ mod derived_descriptor;
 /// The provider kind this script lowers. `cargo_feature` is `<kind>-<name>`.
 const KIND: &str = "rmw";
 
+// phase-421 W4 — the descriptor parser + the derivations, shared VERBATIM with
+// the library rather than re-implemented here. See the module's own header for
+// why it is std-only.
+include!("src/serdes_descriptor.rs");
+
 fn main() {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     // packages/cli/cargo-nano-ros -> packages
@@ -61,6 +66,8 @@ fn main() {
         .nth(2)
         .expect("cargo-nano-ros lives at packages/cli/cargo-nano-ros")
         .to_path_buf();
+    println!("cargo:rerun-if-changed=src/serdes_descriptor.rs");
+    generate_serdes_table(&packages);
     let rmw_root = packages.join("rmw");
 
     let mut descriptors: Vec<(String, Descriptor)> = Vec::new();
@@ -324,6 +331,194 @@ fn render(ds: &[(String, Descriptor)]) -> String {
             d.needs_cxx_linker,
             d.per_message_hook,
             caps = caps,
+        ));
+    }
+    out.push_str("];\n");
+    out
+}
+
+// phase-421 W4 — the serdes table (RFC-0088 D6)
+// ===========================================================================
+
+/// One in-tree serdes provider, as the generated table sees it.
+struct SerdesEntry {
+    names: Vec<String>,
+    crate_name: String,
+    descriptor: SerdesDescriptor,
+    descriptor_path: String,
+}
+
+/// Emit `serdes_table.rs` from `packages/*/*/nros-serdes.toml`.
+///
+/// Same shape as the RMW table above and for the same reasons — the descriptors
+/// are the source, nothing central enumerates providers, and the resolver's
+/// answers are `'static` for free. One difference, and it is the RFC-0087 D4
+/// point: **the NAMES are not in the descriptor.** They come from the sibling
+/// `package.xml`'s `<nano_ros_provides kind="serdes" …/>`, because the
+/// announcement already carries them and a second spelling drifts.
+///
+/// Same honest cost too: only IN-TREE providers are found here. An out-of-repo
+/// provider is resolved at selection time over the provider search path — see
+/// `serdes_resolver::resolve_serdes_in`.
+fn generate_serdes_table(packages: &Path) {
+    let mut entries: Vec<SerdesEntry> = Vec::new();
+
+    let mut families: Vec<PathBuf> = fs::read_dir(packages)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", packages.display()))
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    families.sort();
+    for family in families {
+        let Ok(pkgs) = fs::read_dir(&family) else {
+            continue;
+        };
+        let mut ps: Vec<PathBuf> = pkgs.flatten().map(|e| e.path()).collect();
+        ps.sort();
+        for pkg in ps {
+            let toml_path = pkg.join("nros-serdes.toml");
+            if !toml_path.is_file() {
+                continue;
+            }
+            println!("cargo:rerun-if-changed={}", toml_path.display());
+            entries.push(read_serdes_provider(&pkg, &toml_path));
+        }
+        // A new provider DIRECTORY must re-run this script, not just a changed
+        // file — same rule the RMW root gets below.
+        println!("cargo:rerun-if-changed={}", family.display());
+    }
+    println!("cargo:rerun-if-changed={}", packages.display());
+
+    if entries.is_empty() {
+        panic!(
+            "no nros-serdes.toml found under {} — refusing to generate an EMPTY \
+             serdes table, which would make every `serdes = ...` unresolvable \
+             (including the `cdr` default) while looking like a working build \
+             (phase-421 W4)",
+            packages.display()
+        );
+    }
+
+    // Two providers claiming one format name is ambiguous resolution; fail
+    // loudly rather than taking whichever sorted first.
+    let mut seen: Vec<(String, String)> = Vec::new();
+    for e in &entries {
+        for n in &e.names {
+            if let Some((_, other)) = seen.iter().find(|(name, _)| name == n) {
+                panic!(
+                    "two packages announce serdes name `{n}`: {other} and {}",
+                    e.descriptor_path
+                );
+            }
+            seen.push((n.clone(), e.descriptor_path.clone()));
+        }
+    }
+
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("serdes_table.rs");
+    fs::write(&out, render_serdes(&entries)).expect("write serdes_table.rs");
+}
+
+/// Read one provider: the announcement (names), the manifest (crate) and the
+/// descriptor (the two non-derivable fields).
+fn read_serdes_provider(pkg: &Path, toml_path: &Path) -> SerdesEntry {
+    let origin = toml_path.display().to_string();
+
+    let manifest = pkg.join("package.xml");
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    let xml = fs::read_to_string(&manifest).unwrap_or_else(|e| {
+        panic!(
+            "{origin} has no readable sibling package.xml ({}): {e} — a descriptor \
+             is read only for the provider that was SELECTED, and selection goes \
+             through the <nano_ros_provides kind=\"serdes\"/> announcement, so a \
+             descriptor with no announcement can never be reached (RFC-0087 D4)",
+            manifest.display()
+        )
+    });
+    let names = package_xml_provides(&xml, "serdes");
+    if names.is_empty() {
+        panic!(
+            "{} announces no <nano_ros_provides kind=\"serdes\" name=\"…\"/>, but \
+             {origin} exists beside it — the descriptor carries no `names` on \
+             purpose (RFC-0087 D4), so nothing could resolve to this provider",
+            manifest.display()
+        );
+    }
+
+    let cargo_toml = pkg.join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", cargo_toml.display());
+    let crate_name = fs::read_to_string(&cargo_toml)
+        .ok()
+        .as_deref()
+        .and_then(cargo_package_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "{}: no [package] name — the serdes `crate` is DERIVED from the \
+                 sibling Cargo.toml and there is nothing to derive it from",
+                cargo_toml.display()
+            )
+        });
+
+    let text = fs::read_to_string(toml_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", toml_path.display()));
+    let descriptor = parse_serdes_descriptor(&text, &origin).unwrap_or_else(|e| panic!("{e}"));
+
+    SerdesEntry {
+        names,
+        crate_name,
+        descriptor,
+        descriptor_path: origin,
+    }
+}
+
+fn render_serdes(entries: &[SerdesEntry]) -> String {
+    let mut out = String::from(
+        "// @generated by build.rs from packages/*/*/nros-serdes.toml plus each\n\
+         // provider's <nano_ros_provides kind=\"serdes\"/> — DO NOT EDIT.\n\
+         // phase-421 W4: the announcement is the source of the NAMES, the\n\
+         // descriptor of what cannot be derived, and everything else is derived.\n\n",
+    );
+    out.push_str(
+        "pub(crate) struct SerdesRow {\n    \
+         pub declared: &'static str,\n    \
+         pub names: &'static [&'static str],\n    \
+         pub crate_name: &'static str,\n    \
+         pub cargo_feature: &'static str,\n    \
+         pub cmake_value: &'static str,\n    \
+         pub c_define_token: &'static str,\n    \
+         pub impl_strategy: &'static str,\n    \
+         pub format_id: Option<u8>,\n\
+         }\n\n",
+    );
+    out.push_str("pub(crate) static SERDES_ROWS: &[SerdesRow] = &[\n");
+    for e in entries {
+        let declared = &e.names[0];
+        let names = e
+            .names
+            .iter()
+            .map(|n| format!("{n:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let format_id = match e.descriptor.format_id {
+            Some(id) => format!("Some({id})"),
+            None => "None".to_string(),
+        };
+        out.push_str(&format!(
+            "    SerdesRow {{\n        \
+             declared: {:?},\n        \
+             names: &[{names}],\n        \
+             crate_name: {:?},\n        \
+             cargo_feature: {:?},\n        \
+             cmake_value: {:?},\n        \
+             c_define_token: {:?},\n        \
+             impl_strategy: {:?},\n        \
+             format_id: {format_id},\n    \
+             }},\n",
+            declared,
+            e.crate_name,
+            serdes_cargo_feature(declared),
+            serdes_cmake_value(declared),
+            serdes_c_define_token(declared),
+            e.descriptor.impl_strategy,
         ));
     }
     out.push_str("];\n");

--- a/packages/cli/cargo-nano-ros/build.rs
+++ b/packages/cli/cargo-nano-ros/build.rs
@@ -16,16 +16,42 @@
 //! The cost is the honest one: **only IN-TREE backends are found here.** An
 //! out-of-tree backend needs runtime discovery over a workspace search path,
 //! which is phase-348 and deliberately not this wave.
+//!
+//! ## phase-420 W5 — the descriptor carries only what convention cannot produce
+//!
+//! RFC-0087 D4. Five of the fields this script used to READ were convention
+//! written longhand: `names` restated the `<nano_ros_provides>` announcements
+//! next door, and `cargo_feature` / `cmake_value` / `c_define_token` /
+//! `cffi_feature` restated `rmw-<name>` / `<name>` / `UPPER(<name>)` /
+//! `<cargo_feature>-cffi`. They are now DERIVED here, from
+//! `src/derived_descriptor.rs` — the same file the library compiles, so the
+//! generator and any other reader cannot disagree.
+//!
+//! A descriptor may still STATE one (an out-of-tree backend written against
+//! the old shape), and then it must equal what the convention produces: the
+//! script panics on a disagreement rather than silently preferring one, which
+//! is the belt to `check-derived-descriptor-fields`'s braces. So deleting a
+//! derivable field from a descriptor cannot change the generated table, which
+//! is exactly W5's acceptance.
+//!
+//! `cpp_define` is NOT derived and stays authored: its spellings are
+//! inconsistent across backends by history (`_CFFI` on two, bare on two) and
+//! consumers `#if` on them.
 
 use std::{
     env, fs,
     path::{Path, PathBuf},
 };
 
-// phase-421 W4 — the descriptor parser + the derivations, shared VERBATIM with
-// the library rather than re-implemented here. See the module's own header for
-// why it is std-only.
-include!("src/serdes_descriptor.rs");
+// One implementation of the conventions, shared with the library (which
+// declares the same file as `pub mod derived_descriptor`). A build script
+// cannot depend on its own crate, and a second copy of `format!("{kind}-{name}")`
+// is exactly the second spelling this wave exists to delete.
+#[path = "src/derived_descriptor.rs"]
+mod derived_descriptor;
+
+/// The provider kind this script lowers. `cargo_feature` is `<kind>-<name>`.
+const KIND: &str = "rmw";
 
 fn main() {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -35,8 +61,6 @@ fn main() {
         .nth(2)
         .expect("cargo-nano-ros lives at packages/cli/cargo-nano-ros")
         .to_path_buf();
-    println!("cargo:rerun-if-changed=src/serdes_descriptor.rs");
-    generate_serdes_table(&packages);
     let rmw_root = packages.join("rmw");
 
     let mut descriptors: Vec<(String, Descriptor)> = Vec::new();
@@ -53,7 +77,14 @@ fn main() {
                 let toml_path = pkg.join("nros-rmw.toml");
                 if toml_path.is_file() {
                     println!("cargo:rerun-if-changed={}", toml_path.display());
-                    descriptors.push((toml_path.display().to_string(), parse(&toml_path)));
+                    // phase-420 W5 — the sibling `package.xml` is now an INPUT:
+                    // it announces the provider's names. Watch it, or adding an
+                    // alias would leave a stale table behind a cargo that
+                    // thinks it is up to date.
+                    let pkg_xml = pkg.join("package.xml");
+                    println!("cargo:rerun-if-changed={}", pkg_xml.display());
+                    descriptors
+                        .push((toml_path.display().to_string(), parse(&toml_path, &pkg_xml)));
                 }
             }
         }
@@ -115,7 +146,11 @@ struct Descriptor {
 /// Only the `[rmw]` and `[rmw.link]` tables are read; `[rmw.capabilities]`,
 /// `[rmw.provides.*]` and `[rmw.codegen]` are for later waves and are ignored
 /// here rather than half-parsed.
-fn parse(path: &Path) -> Descriptor {
+///
+/// phase-420 W5: what the file STATES is read here; what convention DERIVES is
+/// filled in by [`derive_fields`] afterwards, and a stated value that
+/// disagrees with the derived one is fatal.
+fn parse(path: &Path, pkg_xml: &Path) -> Descriptor {
     let text = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     let mut section = String::new();
     let mut d = Descriptor {
@@ -174,13 +209,80 @@ fn parse(path: &Path) -> Descriptor {
             _ => {}
         }
     }
-    if d.names.is_empty() {
+    derive_fields(path, pkg_xml, &mut d);
+    d
+}
+
+/// Fill in the five convention fields, and refuse a stated value that
+/// disagrees with the convention (RFC-0087 D4).
+///
+/// The order of evidence for `names` is the RFC's: the `<nano_ros_provides>`
+/// announcements next to the descriptor are the source. A descriptor with no
+/// `package.xml` beside it falls back to a stated `names`, because
+/// `check-provider-announcements` deliberately skips such a provider — the
+/// migration proceeds one provider at a time and an unmigrated one must keep
+/// building.
+fn derive_fields(path: &Path, pkg_xml: &Path, d: &mut Descriptor) {
+    let announced = fs::read_to_string(pkg_xml)
+        .map(|xml| derived_descriptor::announced_names(&xml, KIND))
+        .unwrap_or_default();
+
+    if !announced.is_empty() {
+        agree(path, "names", &d.names.join(","), &announced.join(","));
+        d.names = announced;
+    } else if d.names.is_empty() {
         panic!(
-            "{}: [rmw].names is empty — nothing could resolve to it",
+            "{}: no <nano_ros_provides kind=\"{KIND}\"/> in {} and no [rmw].names \
+             — nothing could resolve to it",
+            path.display(),
+            pkg_xml.display()
+        );
+    }
+
+    let canonical = d.names[0].clone();
+    let cargo_feature = derived_descriptor::cargo_feature(KIND, &canonical);
+    agree(path, "cargo_feature", &d.cargo_feature, &cargo_feature);
+    d.cargo_feature = cargo_feature;
+
+    let cmake_value = derived_descriptor::cmake_value(&canonical);
+    agree(path, "cmake_value", &d.cmake_value, &cmake_value);
+    d.cmake_value = cmake_value;
+
+    let token = derived_descriptor::c_define_token(&canonical);
+    agree(path, "c_define_token", &d.c_define_token, &token);
+    d.c_define_token = token;
+
+    let cffi = derived_descriptor::cffi_feature(&d.cargo_feature);
+    agree(path, "cffi_feature", &d.cffi_feature, &cffi);
+    d.cffi_feature = cffi;
+
+    if d.cpp_define.is_empty() {
+        // Not derivable — see the module header. An absent one would lower to
+        // an empty `#define`, which compiles and means nothing.
+        panic!(
+            "{}: [rmw].cpp_define is missing — it is the one non-derivable \
+             lowering (spellings are inconsistent across backends by history \
+             and consumers `#if` on them), so it must be authored",
             path.display()
         );
     }
-    d
+}
+
+/// A descriptor may restate a derivable field; it may not disagree with it.
+///
+/// Empty means "not stated" — the field's whole point after W5 is to be
+/// absent. `check-derived-descriptor-fields` is the buildless form of this
+/// same rule, with a ratchet for the rows history has pinned; this is the
+/// copy that fires for anyone who builds.
+fn agree(path: &Path, field: &str, stated: &str, derived: &str) {
+    if !stated.is_empty() && stated != derived {
+        panic!(
+            "{}: [rmw].{field} states {stated:?} but convention derives \
+             {derived:?} (RFC-0087 D4). Delete the field — it is derived from \
+             the provider's announced name — or fix the name it disagrees with.",
+            path.display()
+        );
+    }
 }
 
 fn render(ds: &[(String, Descriptor)]) -> String {
@@ -222,195 +324,6 @@ fn render(ds: &[(String, Descriptor)]) -> String {
             d.needs_cxx_linker,
             d.per_message_hook,
             caps = caps,
-        ));
-    }
-    out.push_str("];\n");
-    out
-}
-
-// ===========================================================================
-// phase-421 W4 — the serdes table (RFC-0088 D6)
-// ===========================================================================
-
-/// One in-tree serdes provider, as the generated table sees it.
-struct SerdesEntry {
-    names: Vec<String>,
-    crate_name: String,
-    descriptor: SerdesDescriptor,
-    descriptor_path: String,
-}
-
-/// Emit `serdes_table.rs` from `packages/*/*/nros-serdes.toml`.
-///
-/// Same shape as the RMW table above and for the same reasons — the descriptors
-/// are the source, nothing central enumerates providers, and the resolver's
-/// answers are `'static` for free. One difference, and it is the RFC-0087 D4
-/// point: **the NAMES are not in the descriptor.** They come from the sibling
-/// `package.xml`'s `<nano_ros_provides kind="serdes" …/>`, because the
-/// announcement already carries them and a second spelling drifts.
-///
-/// Same honest cost too: only IN-TREE providers are found here. An out-of-repo
-/// provider is resolved at selection time over the provider search path — see
-/// `serdes_resolver::resolve_serdes_in`.
-fn generate_serdes_table(packages: &Path) {
-    let mut entries: Vec<SerdesEntry> = Vec::new();
-
-    let mut families: Vec<PathBuf> = fs::read_dir(packages)
-        .unwrap_or_else(|e| panic!("read_dir {}: {e}", packages.display()))
-        .flatten()
-        .map(|e| e.path())
-        .collect();
-    families.sort();
-    for family in families {
-        let Ok(pkgs) = fs::read_dir(&family) else {
-            continue;
-        };
-        let mut ps: Vec<PathBuf> = pkgs.flatten().map(|e| e.path()).collect();
-        ps.sort();
-        for pkg in ps {
-            let toml_path = pkg.join("nros-serdes.toml");
-            if !toml_path.is_file() {
-                continue;
-            }
-            println!("cargo:rerun-if-changed={}", toml_path.display());
-            entries.push(read_serdes_provider(&pkg, &toml_path));
-        }
-        // A new provider DIRECTORY must re-run this script, not just a changed
-        // file — same rule the RMW root gets below.
-        println!("cargo:rerun-if-changed={}", family.display());
-    }
-    println!("cargo:rerun-if-changed={}", packages.display());
-
-    if entries.is_empty() {
-        panic!(
-            "no nros-serdes.toml found under {} — refusing to generate an EMPTY \
-             serdes table, which would make every `serdes = ...` unresolvable \
-             (including the `cdr` default) while looking like a working build \
-             (phase-421 W4)",
-            packages.display()
-        );
-    }
-
-    // Two providers claiming one format name is ambiguous resolution; fail
-    // loudly rather than taking whichever sorted first.
-    let mut seen: Vec<(String, String)> = Vec::new();
-    for e in &entries {
-        for n in &e.names {
-            if let Some((_, other)) = seen.iter().find(|(name, _)| name == n) {
-                panic!(
-                    "two packages announce serdes name `{n}`: {other} and {}",
-                    e.descriptor_path
-                );
-            }
-            seen.push((n.clone(), e.descriptor_path.clone()));
-        }
-    }
-
-    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("serdes_table.rs");
-    fs::write(&out, render_serdes(&entries)).expect("write serdes_table.rs");
-}
-
-/// Read one provider: the announcement (names), the manifest (crate) and the
-/// descriptor (the two non-derivable fields).
-fn read_serdes_provider(pkg: &Path, toml_path: &Path) -> SerdesEntry {
-    let origin = toml_path.display().to_string();
-
-    let manifest = pkg.join("package.xml");
-    println!("cargo:rerun-if-changed={}", manifest.display());
-    let xml = fs::read_to_string(&manifest).unwrap_or_else(|e| {
-        panic!(
-            "{origin} has no readable sibling package.xml ({}): {e} — a descriptor \
-             is read only for the provider that was SELECTED, and selection goes \
-             through the <nano_ros_provides kind=\"serdes\"/> announcement, so a \
-             descriptor with no announcement can never be reached (RFC-0087 D4)",
-            manifest.display()
-        )
-    });
-    let names = package_xml_provides(&xml, "serdes");
-    if names.is_empty() {
-        panic!(
-            "{} announces no <nano_ros_provides kind=\"serdes\" name=\"…\"/>, but \
-             {origin} exists beside it — the descriptor carries no `names` on \
-             purpose (RFC-0087 D4), so nothing could resolve to this provider",
-            manifest.display()
-        );
-    }
-
-    let cargo_toml = pkg.join("Cargo.toml");
-    println!("cargo:rerun-if-changed={}", cargo_toml.display());
-    let crate_name = fs::read_to_string(&cargo_toml)
-        .ok()
-        .as_deref()
-        .and_then(cargo_package_name)
-        .unwrap_or_else(|| {
-            panic!(
-                "{}: no [package] name — the serdes `crate` is DERIVED from the \
-                 sibling Cargo.toml and there is nothing to derive it from",
-                cargo_toml.display()
-            )
-        });
-
-    let text = fs::read_to_string(toml_path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", toml_path.display()));
-    let descriptor = parse_serdes_descriptor(&text, &origin).unwrap_or_else(|e| panic!("{e}"));
-
-    SerdesEntry {
-        names,
-        crate_name,
-        descriptor,
-        descriptor_path: origin,
-    }
-}
-
-fn render_serdes(entries: &[SerdesEntry]) -> String {
-    let mut out = String::from(
-        "// @generated by build.rs from packages/*/*/nros-serdes.toml plus each\n\
-         // provider's <nano_ros_provides kind=\"serdes\"/> — DO NOT EDIT.\n\
-         // phase-421 W4: the announcement is the source of the NAMES, the\n\
-         // descriptor of what cannot be derived, and everything else is derived.\n\n",
-    );
-    out.push_str(
-        "pub(crate) struct SerdesRow {\n    \
-         pub declared: &'static str,\n    \
-         pub names: &'static [&'static str],\n    \
-         pub crate_name: &'static str,\n    \
-         pub cargo_feature: &'static str,\n    \
-         pub cmake_value: &'static str,\n    \
-         pub c_define_token: &'static str,\n    \
-         pub impl_strategy: &'static str,\n    \
-         pub format_id: Option<u8>,\n\
-         }\n\n",
-    );
-    out.push_str("pub(crate) static SERDES_ROWS: &[SerdesRow] = &[\n");
-    for e in entries {
-        let declared = &e.names[0];
-        let names = e
-            .names
-            .iter()
-            .map(|n| format!("{n:?}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let format_id = match e.descriptor.format_id {
-            Some(id) => format!("Some({id})"),
-            None => "None".to_string(),
-        };
-        out.push_str(&format!(
-            "    SerdesRow {{\n        \
-             declared: {:?},\n        \
-             names: &[{names}],\n        \
-             crate_name: {:?},\n        \
-             cargo_feature: {:?},\n        \
-             cmake_value: {:?},\n        \
-             c_define_token: {:?},\n        \
-             impl_strategy: {:?},\n        \
-             format_id: {format_id},\n    \
-             }},\n",
-            declared,
-            e.crate_name,
-            serdes_cargo_feature(declared),
-            serdes_cmake_value(declared),
-            serdes_c_define_token(declared),
-            e.descriptor.impl_strategy,
         ));
     }
     out.push_str("];\n");

--- a/packages/cli/cargo-nano-ros/src/derived_descriptor.rs
+++ b/packages/cli/cargo-nano-ros/src/derived_descriptor.rs
@@ -1,0 +1,199 @@
+//! RFC-0087 D4 / phase-420 W5 — the convention half of a provider descriptor.
+//!
+//! A provider descriptor carries only what no convention can produce. Six of
+//! the eleven fields in `nros-rmw-zenoh/nros-rmw.toml` were convention written
+//! longhand, and a field written twice is a field that can disagree with
+//! itself. This module is the ONE implementation of those conventions:
+//!
+//! | field | derived from |
+//! | --- | --- |
+//! | the provider's names | the `<nano_ros_provides>` announcements, in order |
+//! | cargo feature | `<kind>-<name>` |
+//! | cmake value | the canonical name |
+//! | C define token | `UPPER(name)` |
+//! | cffi feature | `<cargo_feature>-cffi` |
+//!
+//! (`crate` is the sixth in the RFC's table. It is NOT here, and phase-420 W5
+//! measured why: `nros-rmw-xrce` ships no `Cargo.toml` at all and its
+//! `[rmw.provides.cargo].crate` names a SIBLING package,
+//! `nros-rmw-xrce-cffi`; `nros-rmw-cyclonedds` names `cyclonedds-sys`, not its
+//! own crate. "The package's `Cargo.toml`" is the right answer for two of four
+//! backends, which makes it a convention with exceptions rather than a
+//! convention. It stays authored, and `check-derived-descriptor-fields`
+//! grandfathers the divergence rather than pretending it is derivable.)
+//!
+//! **`build.rs` and the library share this file**, the former through
+//! `#[path = "src/derived_descriptor.rs"]`. That is the point: the generator
+//! and anything that later wants to answer "what would this field be?" cannot
+//! be two spellings of one rule. `scripts/check-derived-descriptor-fields.py`
+//! is a third reader by necessity (it is Python and buildless), and it is a
+//! CHECKER of the same rule rather than a producer — the sibling gates take
+//! the same shape for the same reason.
+//!
+//! No dependencies, deliberately: a build script may not pull one in without
+//! moving `Cargo.lock`, which this repo only permits through
+//! `just lock-update`.
+
+/// The cargo feature a provider of `kind` named `name` lowers to.
+///
+/// `rmw` + `zenoh` -> `rmw-zenoh`. Phase 248 C5b: this is the BOARD crate's
+/// feature, not an `nros/rmw-X` one — the board self-links and registers the
+/// concrete backend.
+pub fn cargo_feature(kind: &str, name: &str) -> String {
+    format!("{kind}-{name}")
+}
+
+/// The `-DNANO_ROS_RMW` (and family equivalent) CMake value: the canonical
+/// name, unchanged. A separate field only ever recorded the identity function.
+pub fn cmake_value(name: &str) -> String {
+    name.to_string()
+}
+
+/// The C `#define NROS_SYSTEM_RMW_<TOKEN>` token: `UPPER(name)`.
+///
+/// Anything that cannot appear in a C identifier becomes `_`, so a name like
+/// `native_sim/native/64` lowers to something a preprocessor accepts rather
+/// than to a token that fails at the use site. No in-tree rmw name needs the
+/// substitution today (`cyclonedds` -> `CYCLONEDDS`); it exists so the rule is
+/// total.
+pub fn c_define_token(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// The `nros-c` / `nros-cpp` umbrella feature that bundles and force-links a
+/// backend: the cargo feature plus `-cffi`.
+pub fn cffi_feature(cargo_feature: &str) -> String {
+    format!("{cargo_feature}-cffi")
+}
+
+/// The `<nano_ros_provides kind="..." name="..."/>` names a `package.xml`
+/// announces, in file order.
+///
+/// **The announcement is the only spelling of a provider's names.** RFC-0087
+/// D4: a descriptor that also lists them is a second spelling policed by a
+/// gate, which is the shape CLAUDE.md warns about.
+///
+/// Comments are stripped first, and that is not optional (issue 0516): every
+/// provider `package.xml` in this tree documents the tag in a comment above
+/// the real one, and a scanner that cannot tell the two apart reads the
+/// example as a claim. `check-provider-announcements.py` and
+/// `nros_read_package_xml_body` in `NanoRosPackageXml.cmake` carry the
+/// identical strip for the identical reason.
+///
+/// This is a scanner, not a parser: it does not validate the document, and
+/// `package_xml::PackageXml` (quick-xml, the library's real reader) stays the
+/// authority. `rmw_resolver`'s `descriptor_names_match_the_package_xml_reader`
+/// asserts the two agree on every in-tree provider, so this cheap form cannot
+/// drift from the expensive one.
+pub fn announced_names(package_xml: &str, kind: &str) -> Vec<String> {
+    let body = strip_xml_comments(package_xml);
+    let needle = format!("kind=\"{kind}\"");
+    let mut out = Vec::new();
+    for tag in body.split("<nano_ros_provides").skip(1) {
+        let Some(end) = tag.find('>') else { continue };
+        let attrs = &tag[..end];
+        if !attrs.contains(&needle) {
+            continue;
+        }
+        if let Some(name) = attr_value(attrs, "name") {
+            out.push(name);
+        }
+    }
+    out
+}
+
+/// `<!-- ... -->` removed. An XML comment body cannot contain `--`, so the
+/// scan is exact rather than heuristic.
+fn strip_xml_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("<!--") {
+        out.push_str(&rest[..start]);
+        match rest[start..].find("-->") {
+            Some(end) => rest = &rest[start + end + 3..],
+            // An unterminated comment swallows the remainder, which is what a
+            // real XML reader does too.
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn attr_value(attrs: &str, key: &str) -> Option<String> {
+    let at = attrs.find(&format!("{key}=\""))? + key.len() + 2;
+    let rest = &attrs[at..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_four_scalar_conventions() {
+        assert_eq!(cargo_feature("rmw", "zenoh"), "rmw-zenoh");
+        assert_eq!(cargo_feature("serdes", "flatbuf"), "serdes-flatbuf");
+        assert_eq!(cmake_value("cyclonedds"), "cyclonedds");
+        assert_eq!(c_define_token("cyclonedds"), "CYCLONEDDS");
+        assert_eq!(cffi_feature("rmw-xrce"), "rmw-xrce-cffi");
+    }
+
+    #[test]
+    fn c_define_token_is_total() {
+        // A name is not constrained to C identifier characters — the zephyr
+        // board announces `native_sim/native/64`. The token must still be one.
+        assert_eq!(
+            c_define_token("native_sim/native/64"),
+            "NATIVE_SIM_NATIVE_64"
+        );
+        assert_eq!(c_define_token("bare-metal"), "BARE_METAL");
+    }
+
+    #[test]
+    fn announcements_are_read_in_file_order() {
+        let xml = r#"<package format="3"><name>p</name>
+  <export>
+    <build_type>nros_cargo</build_type>
+    <nano_ros_provides kind="rmw" name="zenoh"/>
+    <nano_ros_provides kind="rmw" name="rmw-zenoh"/>
+    <nano_ros_provides kind="board" name="not-an-rmw"/>
+    <nano_ros_provides kind="rmw" name="rmw-zenoh-cffi"/>
+  </export>
+</package>"#;
+        assert_eq!(
+            announced_names(xml, "rmw"),
+            ["zenoh", "rmw-zenoh", "rmw-zenoh-cffi"]
+        );
+        assert_eq!(announced_names(xml, "board"), ["not-an-rmw"]);
+        assert!(announced_names(xml, "serdes").is_empty());
+    }
+
+    #[test]
+    fn a_commented_out_announcement_is_not_a_claim() {
+        // Issue 0516. Every provider package.xml in this tree documents the
+        // tag in a comment; counting one is how a doc example becomes a name.
+        let xml = r#"<export>
+    <!-- <nano_ros_provides kind="rmw" name="example"/> -->
+    <nano_ros_provides kind="rmw" name="real"/>
+  </export>"#;
+        assert_eq!(announced_names(xml, "rmw"), ["real"]);
+    }
+
+    #[test]
+    fn an_unterminated_comment_does_not_leak_its_body() {
+        let xml = r#"<export>
+    <!-- <nano_ros_provides kind="rmw" name="example"/>
+  </export>"#;
+        assert!(announced_names(xml, "rmw").is_empty());
+    }
+}

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -55,6 +55,16 @@ pub mod package_xml;
 pub mod provider_scan;
 pub mod rmw_resolver;
 pub mod scaffold;
+/// The `nros-serdes.toml` descriptor and the derivations that make it almost
+/// empty (phase-421 W4, RFC-0088 D6 / RFC-0087 D4).
+///
+/// `include!`d by `build.rs` as well as compiled here, so that the table in
+/// `OUT_DIR` and the out-of-repo selection path share ONE parser. Its own file
+/// header carries the rest of the rationale — as plain `//` comments rather
+/// than `//!`, because an inner doc comment cannot appear mid-file in the
+/// build script that includes it.
+pub mod serdes_descriptor;
+pub mod serdes_resolver;
 pub mod workflow;
 pub mod workspace_scaffold;
 

--- a/packages/cli/cargo-nano-ros/src/lib.rs
+++ b/packages/cli/cargo-nano-ros/src/lib.rs
@@ -45,21 +45,16 @@ pub mod config_patcher;
 // `nros codegen cyclonedds-descriptors` verb (K.4) still emits
 // host-side descriptor C and lives in `nros-cli-core`.
 pub mod dependency_parser;
+// RFC-0087 D4 / phase-420 W5 — the convention half of a provider descriptor
+// (names from the announcement, cargo feature, cmake value, C define token,
+// cffi feature). `build.rs` shares this exact file via `#[path]`, so the
+// generator and the library cannot be two spellings of one rule.
+pub mod derived_descriptor;
 pub mod package_discovery;
 pub mod package_xml;
 pub mod provider_scan;
 pub mod rmw_resolver;
 pub mod scaffold;
-/// The `nros-serdes.toml` descriptor and the derivations that make it almost
-/// empty (phase-421 W4, RFC-0088 D6 / RFC-0087 D4).
-///
-/// `include!`d by `build.rs` as well as compiled here, so that the table in
-/// `OUT_DIR` and the out-of-repo selection path share ONE parser. Its own file
-/// header carries the rest of the rationale — as plain `//` comments rather
-/// than `//!`, because an inner doc comment cannot appear mid-file in the
-/// build script that includes it.
-pub mod serdes_descriptor;
-pub mod serdes_resolver;
 pub mod workflow;
 pub mod workspace_scaffold;
 

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw.toml
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/nros-rmw.toml
@@ -7,11 +7,19 @@
 # and `check-rmw-descriptors` asserts this file agrees with them row for row.
 # W3 inverts that — the descriptor becomes the source and the closed lists go.
 [rmw]
-names = ["cyclonedds", "rmw-cyclonedds", "rmw-cyclonedds-cffi"]
-cargo_feature = "rmw-cyclonedds"
-cmake_value = "cyclonedds"
-c_define_token = "CYCLONEDDS"
-cffi_feature = "rmw-cyclonedds-cffi"
+# phase-420 W5 / RFC-0087 D4 — this table used to open with five more lines:
+#
+#   names = [...]            the `<nano_ros_provides>` announcements, restated
+#   cargo_feature = "..."    `<kind>-<name>`
+#   cmake_value = "..."      the canonical name
+#   c_define_token = "..."   `UPPER(name)`
+#   cffi_feature = "..."     `<cargo_feature>-cffi`
+#
+# All five are DERIVED now (`cargo-nano-ros/src/derived_descriptor.rs`, shared
+# by `build.rs` and the library). The names come from `package.xml`, which is
+# the only place a provider should spell them; the other four are convention.
+# `check-derived-descriptor-fields` refuses a restatement that disagrees, and
+# `build.rs` panics on one too.
 
 # The C++ define `nros-cpp` puts on its INTERFACE for this backend. Spellings
 # are INCONSISTENT across backends by history (`_CFFI` on two, bare on two) and

--- a/packages/rmw/uorb/nros-rmw-uorb/nros-rmw.toml
+++ b/packages/rmw/uorb/nros-rmw-uorb/nros-rmw.toml
@@ -7,11 +7,19 @@
 # and `check-rmw-descriptors` asserts this file agrees with them row for row.
 # W3 inverts that — the descriptor becomes the source and the closed lists go.
 [rmw]
-names = ["uorb", "rmw-uorb"]
-cargo_feature = "rmw-uorb"
-cmake_value = "uorb"
-c_define_token = "UORB"
-cffi_feature = "rmw-uorb-cffi"
+# phase-420 W5 / RFC-0087 D4 — this table used to open with five more lines:
+#
+#   names = [...]            the `<nano_ros_provides>` announcements, restated
+#   cargo_feature = "..."    `<kind>-<name>`
+#   cmake_value = "..."      the canonical name
+#   c_define_token = "..."   `UPPER(name)`
+#   cffi_feature = "..."     `<cargo_feature>-cffi`
+#
+# All five are DERIVED now (`cargo-nano-ros/src/derived_descriptor.rs`, shared
+# by `build.rs` and the library). The names come from `package.xml`, which is
+# the only place a provider should spell them; the other four are convention.
+# `check-derived-descriptor-fields` refuses a restatement that disagrees, and
+# `build.rs` panics on one too.
 
 # The C++ define `nros-cpp` puts on its INTERFACE for this backend. Spellings
 # are INCONSISTENT across backends by history (`_CFFI` on two, bare on two) and

--- a/packages/rmw/xrce/nros-rmw-xrce/nros-rmw.toml
+++ b/packages/rmw/xrce/nros-rmw-xrce/nros-rmw.toml
@@ -7,11 +7,19 @@
 # and `check-rmw-descriptors` asserts this file agrees with them row for row.
 # W3 inverts that — the descriptor becomes the source and the closed lists go.
 [rmw]
-names = ["xrce", "rmw-xrce", "rmw-xrce-cffi"]
-cargo_feature = "rmw-xrce"
-cmake_value = "xrce"
-c_define_token = "XRCE"
-cffi_feature = "rmw-xrce-cffi"
+# phase-420 W5 / RFC-0087 D4 — this table used to open with five more lines:
+#
+#   names = [...]            the `<nano_ros_provides>` announcements, restated
+#   cargo_feature = "..."    `<kind>-<name>`
+#   cmake_value = "..."      the canonical name
+#   c_define_token = "..."   `UPPER(name)`
+#   cffi_feature = "..."     `<cargo_feature>-cffi`
+#
+# All five are DERIVED now (`cargo-nano-ros/src/derived_descriptor.rs`, shared
+# by `build.rs` and the library). The names come from `package.xml`, which is
+# the only place a provider should spell them; the other four are convention.
+# `check-derived-descriptor-fields` refuses a restatement that disagrees, and
+# `build.rs` panics on one too.
 
 # The C++ define `nros-cpp` puts on its INTERFACE for this backend. Spellings
 # are INCONSISTENT across backends by history (`_CFFI` on two, bare on two) and

--- a/packages/rmw/zenoh/nros-rmw-zenoh/nros-rmw.toml
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/nros-rmw.toml
@@ -7,11 +7,19 @@
 # and `check-rmw-descriptors` asserts this file agrees with them row for row.
 # W3 inverts that — the descriptor becomes the source and the closed lists go.
 [rmw]
-names = ["zenoh", "rmw-zenoh", "rmw-zenoh-cffi"]
-cargo_feature = "rmw-zenoh"        # the BOARD crate's feature (RFC-0031, phase-248 C5b)
-cmake_value = "zenoh"
-c_define_token = "ZENOH"
-cffi_feature = "rmw-zenoh-cffi"
+# phase-420 W5 / RFC-0087 D4 — this table used to open with five more lines:
+#
+#   names = [...]            the `<nano_ros_provides>` announcements, restated
+#   cargo_feature = "..."    `<kind>-<name>`
+#   cmake_value = "..."      the canonical name
+#   c_define_token = "..."   `UPPER(name)`
+#   cffi_feature = "..."     `<cargo_feature>-cffi`
+#
+# All five are DERIVED now (`cargo-nano-ros/src/derived_descriptor.rs`, shared
+# by `build.rs` and the library). The names come from `package.xml`, which is
+# the only place a provider should spell them; the other four are convention.
+# `check-derived-descriptor-fields` refuses a restatement that disagrees, and
+# `build.rs` panics on one too.
 
 # The C++ define `nros-cpp` puts on its INTERFACE for this backend. Spellings
 # are INCONSISTENT across backends by history (`_CFFI` on two, bare on two) and

--- a/scripts/check-derived-descriptor-fields.py
+++ b/scripts/check-derived-descriptor-fields.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""RFC-0087 D4 / phase-420 W5 — a stated derivable field equals its derived value.
+
+A provider descriptor carries only what no convention can produce. Measured on
+`nros-rmw-zenoh/nros-rmw.toml` on 2026-09-04, six of eleven fields were
+convention written longhand:
+
+    names          the `<nano_ros_provides>` announcements, restated
+    cargo_feature  `<kind>-<name>`
+    cmake_value    the canonical name
+    c_define_token `UPPER(name)`
+    cffi_feature   `<cargo_feature>-cffi`
+    crate          the package's own `Cargo.toml`
+
+W5 deleted the first five from the rmw descriptors and made
+`cargo-nano-ros/src/derived_descriptor.rs` produce them. This gate is what
+keeps them from coming back WRONG: a descriptor may still state one — an
+out-of-tree provider written against the old shape, or a family whose reader
+has not moved yet — and then it must equal what the convention produces.
+
+## The rules
+
+  D1  a stated derivable field equals its derived value;
+  D2  a stated field whose derivation is UNAVAILABLE here (no `package.xml` to
+      announce, no `Cargo.toml` to name a crate) is a claim nothing can check,
+      and must be grandfathered rather than assumed right;
+  D3  the baseline only shrinks: a row whose divergence is gone is REPORTED as
+      improved, and a row naming a descriptor that no longer exists is an
+      error, because a stale exemption is how a rule gets reclaimed by
+      accident;
+  D4  no family is vacuous — a glob that matches nothing, or a scan that
+      checked no field at all, fails instead of printing OK.
+
+## Ratchet
+
+`scripts/derived-descriptor-fields-baseline.json`, the shape and the reasoning
+of `scripts/board-maintainer-baseline.json` and
+`scripts/build-type-spelling-baseline.json`: history is grandfathered where a
+spelling cannot change, and new drift is refused. The VALUE stored is the
+spelling that was grandfathered, so swapping one divergence for a different
+one is a NEW violation rather than a covered one.
+
+Improving a row is REPORTED, never failed — a ratchet that punishes the good
+deed gets bypassed, which is `build-type-spelling`'s rule and this one's too.
+
+## What is NOT here
+
+**`names` is checked by `check-provider-announcements`, not by this gate.**
+That gate already compares a named family's `names` against the announcements
+(A2) and refuses a nameless family's restatement outright (A2n) — which is
+exactly "the stated value equals the derived value" for that one field, from
+the other side. A copy of the rule here would be the second spelling this
+whole wave exists to delete.
+
+**`cpp_define` is not derivable and is not checked.** Its own descriptor
+comment says the spellings "are INCONSISTENT across backends by history
+(`_CFFI` on two, bare on two) and are preserved exactly — consumers `#if` on
+them". A convention cannot produce it, so it stays authored.
+
+Dependency-light: TOML via the 3.10 `tomli` backport, the same spelling as the
+sibling gates; no cmake, no cargo, no build.
+"""
+
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import tomllib  # 3.11+
+except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parent.parent
+BASELINE = ROOT / "scripts/derived-descriptor-fields-baseline.json"
+
+PROVIDES_RE = r'<nano_ros_provides\s+kind="{kind}"\s+name="([^"]+)"\s*/?>'
+# An XML comment body cannot contain `--`, so this matches one exactly. The
+# strip is not optional (issue 0516): every provider package.xml documents the
+# announcement tag in a comment above the real one, and a regex cannot tell a
+# doc example from a claim.
+COMMENT_RE = re.compile(r"<!--([^-]|-[^-])*-->")
+
+# A sentinel distinct from None (= "not derivable here", D2) and from "" (= a
+# legitimately empty derived value).
+UNAVAILABLE = object()
+
+
+# ---------------------------------------------------------------------------
+# The conventions. One Python copy of `cargo-nano-ros/src/derived_descriptor.rs`
+# — unavoidable, because this gate is buildless and that one is Rust. It is a
+# CHECKER of the rule, not a second producer: nothing consumes what it computes,
+# and `rmw_resolver::the_scalar_lowerings_are_the_convention` asserts the Rust
+# side against the shared implementation, so the two cannot both be wrong
+# silently.
+# ---------------------------------------------------------------------------
+def conv_cargo_feature(kind, name):
+    return f"{kind}-{name}"
+
+
+def conv_cmake_value(_kind, name):
+    return name
+
+
+def conv_c_define_token(_kind, name):
+    return "".join(c.upper() if c.isascii() and c.isalnum() else "_" for c in name)
+
+
+def conv_cffi_feature(kind, name):
+    return conv_cargo_feature(kind, name) + "-cffi"
+
+
+def announced_names(pkg_dir, kind):
+    """The names a package's `package.xml` announces, in file order."""
+    pkg_xml = pkg_dir / "package.xml"
+    if not pkg_xml.is_file():
+        return None
+    body = COMMENT_RE.sub("", pkg_xml.read_text(encoding="utf-8"))
+    return re.findall(PROVIDES_RE.format(kind=kind), body)
+
+
+def own_crate_name(pkg_dir):
+    """`[package] name` of the `Cargo.toml` beside the descriptor, if any."""
+    manifest = pkg_dir / "Cargo.toml"
+    if not manifest.is_file():
+        return None
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    name = data.get("package", {}).get("name")
+    return name if isinstance(name, str) else None
+
+
+# ---------------------------------------------------------------------------
+# Families. A row says where the descriptors are, how to walk their entries,
+# and which fields in each entry are convention.
+#
+# `names` is deliberately absent from every field map — see the module header.
+# ---------------------------------------------------------------------------
+def rmw_entries(data):
+    """One backend per descriptor: `[rmw]`, plus `[rmw.provides.cargo]`."""
+    rmw = data.get("rmw")
+    if not isinstance(rmw, dict):
+        return []
+    provides = rmw.get("provides", {})
+    cargo = provides.get("cargo", {}) if isinstance(provides, dict) else {}
+    merged = {k: v for k, v in rmw.items() if not isinstance(v, dict)}
+    if isinstance(cargo, dict) and "crate" in cargo:
+        merged["crate"] = cargo["crate"]
+    return [("rmw", merged)]
+
+
+def board_entries(data):
+    """An ARRAY of boards: one package can ship several (nros-board-nuttx-qemu
+    declares the ARM and RISC-V variants), so entries are labelled by index."""
+    boards = data.get("board")
+    if not isinstance(boards, list):
+        return []
+    return [(f"board[{i}]", b) for i, b in enumerate(boards) if isinstance(b, dict)]
+
+
+FAMILIES = {
+    "rmw": {
+        "glob": "packages/rmw/*/*/nros-rmw.toml",
+        "entries": rmw_entries,
+        # field -> (canonical-name source, derivation)
+        "fields": {
+            "cargo_feature": conv_cargo_feature,
+            "cmake_value": conv_cmake_value,
+            "c_define_token": conv_c_define_token,
+            "cffi_feature": conv_cffi_feature,
+            # RFC-0087 D4 lists `crate` as derivable "from the package's own
+            # Cargo.toml". phase-420 W5 measured that and it is NOT true here:
+            # `nros-rmw-xrce` ships no Cargo.toml and names a SIBLING package.
+            # It is checked, and the exception is grandfathered rather than
+            # explained away.
+            "crate": None,
+        },
+    },
+    "board": {
+        "glob": "packages/boards/*/nros-board.toml",
+        "entries": board_entries,
+        "fields": {
+            # The board's own crate. Every board that states one states its own
+            # package name; the three crate-less boards (linux, zephyr,
+            # freertos-posix) state nothing, which is the right answer.
+            "board_crate": None,
+        },
+    },
+}
+
+# Fields whose derivation needs the PACKAGE rather than the canonical name.
+# `None` in a family's field map means "look here"; the convention functions
+# above stay pure functions of the name.
+PACKAGE_DERIVED = {"crate": own_crate_name, "board_crate": own_crate_name}
+assert all(
+    (conv is None) == (field in PACKAGE_DERIVED)
+    for fam in FAMILIES.values()
+    for field, conv in fam["fields"].items()
+), "a field is derived from the name OR from the package, never neither/both"
+
+
+def rel(p):
+    return str(Path(p).relative_to(ROOT)) if Path(p).is_absolute() else str(p)
+
+
+# ---------------------------------------------------------------------------
+# The scan
+# ---------------------------------------------------------------------------
+def scan(root):
+    """-> (rows, checked_fields, notes).
+
+    A row is `(key, stated, derived_or_UNAVAILABLE, why)`: a divergence, or a
+    stated field whose derivation is unavailable (D2).
+    """
+    rows, checked, notes = [], 0, []
+    for kind, fam in sorted(FAMILIES.items()):
+        paths = sorted(Path(root).glob(fam["glob"]))
+        if not paths:
+            notes.append(
+                f"family {kind!r}: no descriptor matched {fam['glob']!r} — "
+                f"refusing to pass on an empty set"
+            )
+            continue
+        for desc in paths:
+            key_path = str(desc.relative_to(root))
+            try:
+                data = tomllib.loads(desc.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                notes.append(f"{key_path}: not valid TOML: {exc}")
+                continue
+
+            pkg_dir = desc.parent
+            announced = announced_names(pkg_dir, kind)
+            entries = fam["entries"](data)
+            # The canonical name is the FIRST announced one. With several
+            # entries in one package the flat announcement cannot say which
+            # names belong to which entry (nros-board-nuttx-qemu: 2 entries, 7
+            # names), so a per-entry canonical name is unavailable — and every
+            # field derived from it with it.
+            attributable = announced is not None and len(entries) == 1
+
+            for label, entry in entries:
+                for field, conv in fam["fields"].items():
+                    if field not in entry:
+                        continue  # not stated: the whole point
+                    stated = entry[field]
+                    checked += 1
+                    key = f"{key_path}@{label}.{field}"
+                    if field in PACKAGE_DERIVED:
+                        derived = PACKAGE_DERIVED[field](pkg_dir)
+                        derived = UNAVAILABLE if derived is None else derived
+                    elif attributable and announced:
+                        derived = conv(kind, announced[0])
+                    else:
+                        derived = UNAVAILABLE
+                    if derived is UNAVAILABLE:
+                        why = (
+                            "states a derivable field whose derivation is "
+                            "unavailable here — nothing can check it"
+                        )
+                        rows.append((key, stated, UNAVAILABLE, why))
+                    elif stated != derived:
+                        why = (
+                            f"states {stated!r} but convention derives "
+                            f"{derived!r}"
+                        )
+                        rows.append((key, stated, derived, why))
+    return rows, checked, notes
+
+
+# ---------------------------------------------------------------------------
+# Baseline — the ratchet
+# ---------------------------------------------------------------------------
+def load_baseline(errors):
+    if not BASELINE.exists():
+        errors.append(
+            f"missing baseline {rel(BASELINE)} — regenerate with "
+            "--write-baseline. A missing baseline is a FAILURE, not an empty "
+            "exemption set: read as empty it would fail every grandfathered "
+            "row at once, with a message about derivation rather than about "
+            "the missing file, and invite the bypass the ratchet exists to "
+            "avoid"
+        )
+        return {}
+    try:
+        return json.loads(BASELINE.read_text())
+    except (OSError, ValueError) as exc:
+        errors.append(f"cannot read baseline {rel(BASELINE)}: {exc}")
+        return {}
+
+
+def write_baseline(rows):
+    out = {key: stated for key, stated, _d, _w in rows}
+    BASELINE.write_text(json.dumps(dict(sorted(out.items())), indent=2) + "\n")
+    print(f"wrote {rel(BASELINE)}: {len(out)} divergence(s) grandfathered")
+    return 0
+
+
+def apply_baseline(rows, baseline, root):
+    """-> (errors, exempt, improved)."""
+    errors, exempt, seen = [], [], set()
+    for key, stated, _derived, why in rows:
+        seen.add(key)
+        if key not in baseline:
+            errors.append(f"{key}: {why} (RFC-0087 D4)")
+        elif baseline[key] != stated:
+            errors.append(
+                f"{key}: grandfathered as {baseline[key]!r} but now states "
+                f"{stated!r} — a different divergence is not the one that was "
+                f"granted; fix it, do not re-baseline it"
+            )
+        else:
+            exempt.append(key)
+
+    improved = []
+    for key in sorted(set(baseline) - seen):
+        desc = key.split("@", 1)[0]
+        if not (Path(root) / desc).is_file():
+            errors.append(
+                f"baseline names {key}, whose descriptor does not exist — a "
+                f"stale exemption is how a rule gets reclaimed by accident; "
+                f"drop it (--write-baseline)"
+            )
+        else:
+            improved.append(key)
+    return errors, exempt, improved
+
+
+# ---------------------------------------------------------------------------
+# Negative controls — every rule is fired, then silenced by its escape.
+# ---------------------------------------------------------------------------
+def _rmw_pkg(root, name, descriptor, announce=("rmw",), cargo_name=None):
+    d = Path(root) / "packages/rmw" / name / f"nros-rmw-{name}"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "nros-rmw.toml").write_text(descriptor)
+    if announce is not None:
+        tags = "\n".join(
+            f'    <nano_ros_provides kind="rmw" name="{n}"/>' for n in announce
+        )
+        (d / "package.xml").write_text(
+            f'<package format="3"><name>p</name>\n  <export>\n{tags}\n'
+            f"  </export>\n</package>\n"
+        )
+    if cargo_name:
+        (d / "Cargo.toml").write_text(f'[package]\nname = "{cargo_name}"\n')
+    return str((d / "nros-rmw.toml").relative_to(root))
+
+
+def _board_pkg(root, name, descriptor, announce=(), cargo_name=None):
+    d = Path(root) / "packages/boards" / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "nros-board.toml").write_text(descriptor)
+    tags = "\n".join(
+        f'    <nano_ros_provides kind="board" name="{n}"/>' for n in announce
+    )
+    (d / "package.xml").write_text(
+        f'<package format="3"><name>p</name>\n  <export>\n{tags}\n'
+        f"  </export>\n</package>\n"
+    )
+    if cargo_name:
+        (d / "Cargo.toml").write_text(f'[package]\nname = "{cargo_name}"\n')
+    return str((d / "nros-board.toml").relative_to(root))
+
+
+def self_test(quiet=False):
+    """A gate nobody has watched fail is a gate that has not been shown to
+    have a failing mode. Each rule fires here on a constructed input."""
+    with tempfile.TemporaryDirectory() as td:
+        # A clean tree: one nameless rmw descriptor, one board.
+        good_rmw = _rmw_pkg(td, "good", '[rmw]\ncpp_define = "X"\n')
+        good_board = _board_pkg(
+            td, "nros-board-good", '[[board]]\nboard_crate = "nros-board-good"\n',
+            announce=("good",), cargo_name="nros-board-good",
+        )
+        rows, checked, notes = scan(td)
+        assert not notes, notes
+        assert not rows, rows
+        assert checked == 1, checked  # only board_crate is stated
+
+        # D1 — a restated derivable field that disagrees. Two of them, so the
+        # rule is seen firing per FIELD and not merely per descriptor.
+        bad = _rmw_pkg(
+            td, "bad",
+            '[rmw]\ncpp_define = "X"\ncargo_feature = "rmw-typo"\n'
+            'c_define_token = "WRONG"\n',
+            announce=("bad",),
+        )
+        rows, _c, _n = scan(td)
+        keys = {k for k, *_ in rows}
+        assert f"{bad}@rmw.cargo_feature" in keys, keys
+        assert f"{bad}@rmw.c_define_token" in keys, keys
+        errs, _e, _i = apply_baseline(rows, {}, td)
+        assert len(errs) == 2, errs
+
+        # …silenced by stating the derived value instead. Note `BAD` would be
+        # accepted, because it IS `UPPER("bad")`: the rule is equality with the
+        # convention, not "must be absent".
+        (Path(td) / bad).write_text(
+            '[rmw]\ncpp_define = "X"\ncargo_feature = "rmw-bad"\n'
+            'c_define_token = "BAD"\n'
+        )
+        rows, _c, _n = scan(td)
+        assert not [r for r in rows if r[0].startswith(f"{bad}@")], rows
+        # Restore one divergence for the baseline rules below.
+        (Path(td) / bad).write_text(
+            '[rmw]\ncpp_define = "X"\ncargo_feature = "rmw-typo"\n'
+        )
+
+        # D2 — a stated field whose derivation is unavailable. `crate` on a
+        # package with no Cargo.toml is exactly `nros-rmw-xrce`'s shape.
+        nocargo = _rmw_pkg(
+            td, "nocargo",
+            '[rmw]\ncpp_define = "X"\n\n[rmw.provides.cargo]\n'
+            'crate = "some-sibling-cffi"\n',
+            announce=("nocargo",),
+        )
+        rows, _c, _n = scan(td)
+        row = next(r for r in rows if r[0] == f"{nocargo}@rmw.crate")
+        assert row[2] is UNAVAILABLE, row
+        # …silenced by the package actually owning that crate.
+        (Path(td) / nocargo).parent.joinpath("Cargo.toml").write_text(
+            '[package]\nname = "some-sibling-cffi"\n'
+        )
+        rows, _c, _n = scan(td)
+        assert f"{nocargo}@rmw.crate" not in {k for k, *_ in rows}
+
+        # A multi-entry board: the flat announcement cannot be attributed, so
+        # a name-derived field is UNAVAILABLE rather than silently wrong.
+        multi = _board_pkg(
+            td, "nros-board-multi",
+            '[[board]]\nboard_crate = "nros-board-multi"\n\n'
+            '[[board]]\nboard_crate = "wrong-crate"\n',
+            announce=("a", "b"), cargo_name="nros-board-multi",
+        )
+        rows, _c, _n = scan(td)
+        keys = {k for k, *_ in rows}
+        assert f"{multi}@board[1].board_crate" in keys, keys
+        assert f"{multi}@board[0].board_crate" not in keys, keys
+
+        # D3 — the ratchet, in both directions.
+        rows, _c, _n = scan(td)
+        base = {k: s for k, s, _d, _w in rows}
+        errs, exempt, improved = apply_baseline(rows, base, td)
+        assert not errs and len(exempt) == len(rows) and not improved
+
+        # a DIFFERENT divergence at a grandfathered key is a new violation
+        swapped = dict(base)
+        swapped[f"{bad}@rmw.cargo_feature"] = "rmw-some-other-typo"
+        errs, _e, _i = apply_baseline(rows, swapped, td)
+        assert len(errs) == 1 and "do not re-baseline" in errs[0], errs
+
+        # fixing a row is REPORTED, never failed
+        errs, _e, improved = apply_baseline([], base, td)
+        assert not errs and improved == sorted(base), (errs, improved)
+
+        # a baseline row whose descriptor is gone is an ERROR
+        errs, _e, _i = apply_baseline([], {"packages/rmw/x/y/nros-rmw.toml@rmw.crate": "z"}, td)
+        assert len(errs) == 1 and "does not exist" in errs[0], errs
+
+        # D4 — vacuity. An empty tree must fail, not print OK.
+        with tempfile.TemporaryDirectory() as empty:
+            _rows, _c, notes = scan(empty)
+            assert len(notes) == len(FAMILIES), notes
+
+        assert good_rmw and good_board  # constructed, and clean
+
+    # A missing baseline must FAIL rather than read as an empty exemption set.
+    global BASELINE
+    real, BASELINE = BASELINE, ROOT / "scripts/does-not-exist.json"
+    try:
+        errs = []
+        assert load_baseline(errs) == {} and errs, (
+            "a missing baseline must be an error, not a silent empty set")
+    finally:
+        BASELINE = real
+
+    if not quiet:
+        print("check-derived-descriptor-fields self-test: OK")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+def main():
+    argv = sys.argv[1:]
+    if "--self-test" in argv:
+        return self_test()
+    # Always, not only behind the flag: a negative control nobody runs decays
+    # into a comment, and this rule's whole job is to fire.
+    self_test(quiet=True)
+
+    scan_root = None
+    if "--scan-root" in argv:
+        scan_root = argv[argv.index("--scan-root") + 1]
+    root = scan_root or ROOT
+
+    rows, checked, notes = scan(root)
+    errors = list(notes)
+
+    if "--list" in argv:
+        for key, stated, derived, _why in rows:
+            shown = "(underivable)" if derived is UNAVAILABLE else repr(derived)
+            print(f"{key}\tstated={stated!r}\tderived={shown}")
+        print(f"{checked} stated derivable field(s) examined")
+        return 0
+    if "--write-baseline" in argv:
+        if scan_root:
+            print("--write-baseline works on the repo, not --scan-root",
+                  file=sys.stderr)
+            return 2
+        return write_baseline(rows)
+
+    baseline = {} if scan_root else load_baseline(errors)
+    errs, exempt, improved = apply_baseline(rows, baseline, root)
+    errors += errs
+
+    # D4 — a scan that examined nothing is not a pass.
+    if checked == 0 and not errors:
+        errors.append(
+            "no descriptor states a single derivable field — this gate would "
+            "be vacuous. That is a legitimate END STATE, but it must be made "
+            "deliberately: delete this gate, or say here why zero is right"
+        )
+
+    print(
+        f"{checked} stated derivable field(s) across "
+        f"{len(FAMILIES)} provider famil(ies)"
+    )
+    if exempt:
+        print(
+            f"  {len(exempt)} grandfathered by {rel(BASELINE)} — the list only "
+            "shrinks; a NEW descriptor binds immediately"
+        )
+    for key in improved:
+        print(f"  {key} no longer diverges — drop it from the baseline "
+              "(--write-baseline)")
+
+    if errors:
+        print("\n[FAIL] derived descriptor fields (RFC-0087 D4):",
+              file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print("Every stated derivable field equals the value convention derives.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-provider-announcements.py
+++ b/scripts/check-provider-announcements.py
@@ -9,28 +9,19 @@ them.
 
   A1  a package.xml sitting beside a descriptor announces provisions of that
       kind — otherwise it is invisible to the scan while looking migrated;
-  A2  its provision names equal the descriptor's declared names EXACTLY and in
-      order, canonical first, since names[0] is what error messages list;
-  A3  for a family whose descriptors carry no names at all, the announced names
-      are UNIQUE across the family — see "Two shapes of family" below.
+  A2  for a NAMED family, its provision names equal the descriptor's declared
+      names EXACTLY and in order, canonical first, since names[0] is what
+      error messages list;
+  A2n for a NAMELESS family, the descriptor declares no names at all — the
+      announcement is the only spelling (RFC-0087 D4).
 
-**Two shapes of family, and A2 exists only for one of them.** `rmw`, `board` and
-`platform` predate RFC-0087 D4: their descriptors repeat the provider's names, so
-there are two spellings of one fact and A2 is what keeps them equal. D4 removed
-`names` from NEW descriptors — a descriptor now carries only what no convention
-can produce, and the announcement is the ONLY place a name is written. For such a
-family A2 has nothing to compare against and cannot be written honestly, so the
-row declares `extract=None` and the check becomes A1 + A3: the descriptor must
-still be announced (or it is invisible to the scan), and since the announcement
-is the sole spelling, the one thing that can still go wrong is two providers
-claiming one name.
-
-Do NOT "fix" a nameless family back into an A2 comparison by adding `names` to
-its descriptor: that re-creates the second spelling D4 deleted, and A2 would then
-be checking the descriptor against a copy of itself — the cannot-fail gate
-`check-rmw-descriptors` retired its own S-checks over (see its docstring).
-Equally, do not delete A2 from the three families that DO have `names`; their
-duplication is real and unchecked otherwise.
+**A2 and A2n are the same rule seen from two sides.** A family is nameless
+once its readers DERIVE the names from the announcement instead of reading
+them out of the descriptor; then a `names` key in a descriptor is not a
+duplicate to be compared, it is a duplicate that nothing reads — worse than a
+disagreement, because it can be edited with no effect. A2n refuses it, so the
+rule "the announcement is the only spelling" keeps a gate after the comparison
+it used to have stops existing.
 
 **One gate for every family, not one per family.** This started as S5 inside
 `check-rmw-descriptors.py`, covering rmw alone. Extending the rule to boards by
@@ -59,19 +50,31 @@ except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# kind -> (descriptor glob, how to pull the declared names out of it — or None
-# for a family whose descriptors carry no names, see A3 above).
+# kind -> (descriptor glob, how to pull the declared names out of it).
 #
-# The two families disagree in shape and that is not an accident: an rmw
+# `extract=None` means a NAMELESS family: its readers derive the names from the
+# `<nano_ros_provides>` announcements, so the descriptor must not declare any
+# (A2n). Everything else about the row is unchanged — A1 still applies, because
+# a provider that announces nothing is invisible to the scan whatever its
+# descriptor says.
+#
+# The named families disagree in shape and that is not an accident: an rmw
 # descriptor is ONE backend (`[rmw]`), while a board descriptor is an ARRAY
 # (`[[board]]`) because one package can ship several boards — nros-board-nuttx-qemu
 # declares both the ARM and RISC-V variants, disambiguated by `target_contains`.
 # So the board reader flattens entries in declaration order.
 FAMILIES = {
-    "rmw": (
-        "packages/rmw/*/*/nros-rmw.toml",
-        lambda d: list(d.get("rmw", {}).get("names", [])),
-    ),
+    # phase-420 W5 — rmw went NAMELESS. `cargo-nano-ros/build.rs` reads the
+    # announcements (via `derived_descriptor::announced_names`) and derives the
+    # rest of the lowering from names[0], so `[rmw].names` is deleted from all
+    # four descriptors. A2 has nothing left to compare; A2n keeps it that way.
+    "rmw": ("packages/rmw/*/*/nros-rmw.toml", None),
+    # Board is still NAMED, and phase-420 W5 measured why rather than assuming:
+    # `nros-board-nuttx-qemu` declares TWO `[[board]]` entries and announces
+    # seven names in one flat list, so the announcement cannot say which four
+    # belong to the ARM variant and which three to the RISC-V one. Deriving
+    # per-entry names needs a boundary the tag has no way to carry. The board
+    # reader also lives in `nros-cli-core`, not here.
     "board": (
         "packages/boards/*/nros-board.toml",
         lambda d: [n for b in d.get("board", []) for n in b.get("names", [])],
@@ -85,16 +88,13 @@ FAMILIES = {
         "config/*/nros-platform.toml",
         lambda d: list(d.get("names", [])),
     ),
-    # phase-421 W4 / RFC-0088 D6. The first family born after RFC-0087 D4, so
-    # its descriptor has NO `names` key and never will: `nros-serdes.toml`
-    # carries `impl` and `format_id`, the two facts no convention can derive,
-    # and the `<nano_ros_provides>` announcement is the name. `None` selects
-    # A1 + A3 instead of A1 + A2 (see the module docstring).
-    #
-    # Everything serdes-SPECIFIC — descriptor well-formedness, the `format_id`
-    # discriminant, and the descriptor a package announcing `serdes` must have —
-    # lives in `scripts/check-serdes-descriptors.py`, the same split that keeps
-    # this gate one gate for every family rather than one per family.
+    # phase-421 W4 / RFC-0088 D6 — the first family BORN nameless, where rmw was
+    # made nameless afterwards by W5. `nros-serdes.toml` carries `impl` and
+    # `format_id`, the two facts no convention can derive, and the announcement
+    # is the name. Everything serdes-SPECIFIC — descriptor well-formedness, the
+    # `format_id` discriminant, and the descriptor a package announcing `serdes`
+    # must have — lives in `scripts/check-serdes-descriptors.py`, the split that
+    # keeps this gate one gate for every family rather than one per family.
     "serdes": ("packages/*/*/nros-serdes.toml", None),
 }
 
@@ -114,11 +114,36 @@ def declared_provisions(path, kind):
     return re.findall(PROVIDES_RE.format(kind=kind), body)
 
 
+def restated_names(data):
+    """Every `names` key anywhere in a descriptor, flattened.
+
+    A nameless family's descriptor must declare none, and the search is over
+    the WHOLE document rather than one known table: the two live shapes put
+    `names` in `[rmw]`, in `[[board]]` entries and at top level
+    (`nros-platform.toml`), and a rule that only looked where today's families
+    happen to keep it would pass the next family's restatement.
+    """
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == "names" and isinstance(v, list):
+                    out.extend(v)
+                else:
+                    walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(data)
+    return out
+
+
 def main():
     problems = []
     checked = 0
     announced = 0
-    claimed = {}  # (kind, name) -> package.xml that announced it (A3)
 
     for kind, (pattern, extract) in sorted(FAMILIES.items()):
         paths = sorted(glob.glob(os.path.join(ROOT, pattern)))
@@ -146,7 +171,18 @@ def main():
                     problems.append(f"{desc_rel}: not valid TOML: {e}")
                     continue
             names = None if extract is None else extract(data)
-            if extract is not None and not names:
+            if extract is None:
+                # A2n — the announcement is the only spelling.
+                restated = restated_names(data)
+                if restated:
+                    problems.append(
+                        f"{desc_rel}: declares names {restated} in a NAMELESS "
+                        f"family — {kind} names come from the "
+                        f'<nano_ros_provides kind="{kind}"/> announcements and '
+                        f"nothing reads this key, so it can drift with no "
+                        f"symptom. Delete it (RFC-0087 D4)"
+                    )
+            elif not names:
                 problems.append(
                     f"{desc_rel}: declares no names — nothing could resolve to it"
                 )
@@ -155,28 +191,12 @@ def main():
             found = declared_provisions(pkg_xml, kind)
             announced += len(found)
             if not found:
-                # A1 — true for both shapes of family.
                 problems.append(
                     f'{rel}: sits beside a {kind} descriptor but announces no '
                     f'<nano_ros_provides kind="{kind}"/> — it would be invisible '
                     f"to the phase-348 scan"
                 )
-            elif names is None:
-                # A3 — a nameless-descriptor family (RFC-0087 D4). There is no
-                # second spelling to compare against, so the only failure left
-                # is two providers answering to one name.
-                for n in found:
-                    prior = claimed.get((kind, n))
-                    if prior is not None and prior != rel:
-                        problems.append(
-                            f"{rel}: announces {kind} name {n!r}, already announced "
-                            f"by {prior} — a name resolves to one provider, and "
-                            f"for this family the announcement is the ONLY place "
-                            f"it is written"
-                        )
-                    claimed[(kind, n)] = rel
-            elif found != names:
-                # A2 — a family whose descriptor repeats the names.
+            elif names is not None and found != names:
                 problems.append(
                     f"{rel}: provides {found} but {desc_rel} declares {names} — "
                     f"discovery and resolution must claim the same names, "
@@ -189,13 +209,12 @@ def main():
             sys.stderr.write(f"  {p}\n")
         return 1
 
-    nameless = sum(1 for _, e in FAMILIES.values() if e is None)
+    nameless = sorted(k for k, (_, e) in FAMILIES.items() if e is None)
     print(
         f"provider announcements: OK ({checked} migrated provider(s) across "
         f"{len(FAMILIES)} famil(ies), {announced} name(s) announced; "
-        f"{len(FAMILIES) - nameless} famil(ies) matched name-for-name against "
-        f"their descriptor, {nameless} nameless-descriptor famil(ies) checked "
-        f"for announcement + uniqueness)"
+        f"named families match their descriptor, nameless "
+        f"({', '.join(nameless) or 'none'}) restate nothing)"
     )
     return 0
 

--- a/scripts/check-rmw-descriptors.py
+++ b/scripts/check-rmw-descriptors.py
@@ -11,14 +11,31 @@ around green.
 
 It now checks what can still go wrong once there is a single source:
 
-  S1  every descriptor has the fields the generators read, and no empty ones
-      that would silently lower to nothing;
-  S2  no two descriptors claim the same name (ambiguous resolution);
-  S3  the canonical name is the FIRST entry of `names`, because that is what
-      `declared` becomes and what error messages list;
+  S1  every descriptor has the NON-DERIVABLE fields the generators read, and
+      no empty ones that would silently lower to nothing;
+  S2  no two backends claim the same name (ambiguous resolution);
   S4  a descriptor exists for every backend directory that looks like one, so
       adding a backend and forgetting the descriptor fails here rather than at
       a consumer's link.
+
+phase-420 W5 (RFC-0087 D4) retired two of the original five rules, because
+what they guarded stopped being writable:
+
+  * S1 checked `cargo_feature` / `cmake_value` / `c_define_token` /
+    `cffi_feature` were present and non-empty. All four are DERIVED now
+    (`cargo-nano-ros/src/derived_descriptor.rs`), so requiring them would
+    require the duplication the wave deleted. `cpp_define` is what is left —
+    the one lowering convention cannot produce, since the spellings are
+    inconsistent across backends by history and consumers `#if` on them.
+  * S3 asserted the canonical name was `names[0]`. `names` is gone from the
+    descriptors; `build.rs` takes the FIRST `<nano_ros_provides>` announcement
+    as canonical, so "the canonical name is the first one" is now structural
+    rather than checkable.
+
+**Names are read from the `package.xml` announcements here too**, for the same
+reason: after W5 that is where they live. `check-provider-announcements` A2n
+refuses a descriptor that restates them, so S2 cannot be looking at a stale
+second copy.
 
 Agreement between a descriptor and its `package.xml` provisions (phase-348) was
 briefly S5 here. It moved to `scripts/check-provider-announcements.py` when
@@ -34,6 +51,7 @@ failure.
 
 import glob
 import os
+import re
 import sys
 
 try:
@@ -43,9 +61,33 @@ except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Fields the generators read. An empty value lowers to nothing silently, so an
-# empty string is as much a failure as a missing key.
-REQUIRED = ["cargo_feature", "cmake_value", "c_define_token", "cffi_feature", "cpp_define"]
+# Fields the generators read that convention CANNOT produce. An empty value
+# lowers to nothing silently, so an empty string is as much a failure as a
+# missing key. (The four derivable ones left this list in phase-420 W5; the
+# gate for those is `check-derived-descriptor-fields`, which asserts a
+# RESTATEMENT equals its derived value rather than asserting presence.)
+REQUIRED = ["cpp_define"]
+
+PROVIDES_RE = re.compile(r'<nano_ros_provides\s+kind="rmw"\s+name="([^"]+)"\s*/?>')
+# An XML comment body cannot contain `--`, so this matches one exactly. The
+# strip is not optional (issue 0516): every backend package.xml documents the
+# tag in a comment above the real one.
+COMMENT_RE = re.compile(r"<!--([^-]|-[^-])*-->")
+
+
+def announced_names(desc_path):
+    """The backend's names, from the `package.xml` beside its descriptor.
+
+    Empty when the package.xml is absent, which is not an error here: an
+    unmigrated provider is simply not discoverable while its existing build
+    path keeps working (the same allowance `check-provider-announcements`
+    makes).
+    """
+    pkg_xml = os.path.join(os.path.dirname(desc_path), "package.xml")
+    if not os.path.exists(pkg_xml):
+        return []
+    with open(pkg_xml, encoding="utf-8") as fh:
+        return PROVIDES_RE.findall(COMMENT_RE.sub("", fh.read()))
 
 
 def main():
@@ -72,24 +114,19 @@ def main():
             problems.append(f"{rel}: no [rmw] table")
             continue
 
-        names = rmw.get("names") or []
+        names = announced_names(path)
         if not names:
-            problems.append(f"{rel}: [rmw].names is empty — nothing could resolve to it")
+            problems.append(
+                f"{rel}: the package.xml beside it announces no "
+                f'<nano_ros_provides kind="rmw"/> — nothing could resolve to it '
+                f"(phase-420 W5: the announcement is where a backend's names live)"
+            )
             continue
 
         # S1
         for field in REQUIRED:
             if not rmw.get(field):
                 problems.append(f"{rel}: [rmw].{field} is missing or empty")
-
-        # S3 — the canonical name is names[0]; a bare name that is not first
-        # means `declared` would be an alias, and error messages would list it.
-        canonical = names[0]
-        if rmw.get("cmake_value") and rmw["cmake_value"] != canonical:
-            problems.append(
-                f"{rel}: cmake_value {rmw['cmake_value']!r} != names[0] {canonical!r} — "
-                f"the canonical name must be the first entry"
-            )
 
         # S2
         for n in names:

--- a/scripts/derived-descriptor-fields-baseline.json
+++ b/scripts/derived-descriptor-fields-baseline.json
@@ -1,0 +1,3 @@
+{
+  "packages/rmw/xrce/nros-rmw-xrce/nros-rmw.toml@rmw.crate": "nros-rmw-xrce-cffi"
+}


### PR DESCRIPTION
RFC-0087 D4. Five fields — `names`, `cargo_feature`, `cmake_value`, `c_define_token`, `cffi_feature` — deleted from all four `nros-rmw.toml` and derived instead.

`nros-rmw-zenoh` is now:

```toml
[rmw]
cpp_define = "NROS_RMW_ZENOH_CFFI"
[rmw.provides.cargo]
crate = "nros-rmw-zenoh"
[rmw.link] …
[rmw.capabilities] …
```

Acceptance held: generated `rmw_table.rs` **byte-identical**, and `rmw_cmake_dispatch_is_current` still passes against the committed `NanoRosRmwDispatch.cmake` — one lowering further down. The conventions live in `derived_descriptor.rs`, and `build.rs` compiles **the same file** via `#[path]`; a generator that re-spelled them would be the drift this removes.

## Two things D4 claimed are not true

**`crate` is not derivable.** "The package's `Cargo.toml`" holds for one and a half of four backends: `nros-rmw-xrce` ships **no `Cargo.toml`** and names a *sibling* (`nros-rmw-xrce-cffi`); `nros-rmw-cyclonedds` states `sys_crate = "cyclonedds-sys"`, also not its own. A convention with exceptions is not a convention — `crate` stays authored, xrce is the ratchet's one grandfathered row.

**`names` is derivable per family, not universally.** `board` cannot: `nros-board-nuttx-qemu` declares **two** `[[board]]` entries and announces seven names in one flat list, and `<nano_ros_provides>` carries no boundary to say which four are the ARM variant's. Board stays **named**.

RFC-0087 D4 is amended for both rather than the descriptors bent to fit it.

## The gate grew a rule instead of losing one

`check-provider-announcements`: **A2** (announced names equal the descriptor's) for named families; **A2n** — a nameless family's descriptor declares no names *anywhere*, by recursive walk, not one known table.

Without A2n, deleting A2's comparison would leave `names` re-addable with **no reader and no gate**: an edit with no symptom, which is worse than a disagreement. serdes (phase-421 W4) is nameless *by birth* where rmw is nameless *by migration*; both rows read `None`.

`check-rmw-descriptors` had to move with them — S1 *required* the four derivable fields and S2/S3 read `names` from the descriptor, so it went red the instant they shrank. S1 now requires `cpp_define` alone; S2 claims names from the announcement; S3 retires, because the canonical name became structural when `build.rs` started taking the first announcement.

## Verification

Nine rules, each watched failing on a constructed input — including the `build.rs` **belt**, which panics on the same divergence the gate reports, and the vacuity guard, which refuses to pass on an empty descriptor set.

`cargo test -p cargo-nano-ros --lib` 120 pass · `check-derived-descriptor-fields`, `check-provider-announcements` (4 families, 47 names), `check-rmw-descriptors`, `check-serdes-descriptors`, `gate-lists`, `gate-selftests` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV