### PR TITLE
feat(phase-420 W7): --packages-select and --packages-up-to, and two refusals colcon does not make

### DIFF
--- a/packages/cli/nros-cli-core/src/builder/discover.rs
+++ b/packages/cli/nros-cli-core/src/builder/discover.rs
@@ -29,7 +29,7 @@
 //! later by `$(find …)` substitution.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
 };
 
@@ -249,6 +249,243 @@ pub fn cargo_members_or_walk(root: &Path) -> Vec<PathBuf> {
     } else {
         declared
     }
+}
+
+/// Stage 1b — narrow the workspace to the packages the user asked for
+/// (RFC-0087 D7, phase-420 W7).
+///
+/// Empty means "no narrowing", which is the overwhelmingly common case and is
+/// why [`select`] short-circuits on it: a build that named no package must be
+/// byte-identical to one built before these flags existed.
+///
+/// ## Why this is a filter over an order, not a second order
+///
+/// [`discover`] already returns `packages` in topological order. A subset of a
+/// topologically ordered list, taken in place, is a topological order of the
+/// subset — every edge that survives had its endpoints in the original order,
+/// and filtering removes elements without reordering the ones that remain. So
+/// there is exactly one dependency sort in this crate and this does not add a
+/// second one.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Selection {
+    /// `--packages-select`: exactly these packages, no dependencies and no
+    /// dependents. Empty imposes no constraint.
+    pub select: Vec<String>,
+    /// `--packages-up-to`: these packages plus everything they depend on,
+    /// transitively, and nothing else. Empty imposes no constraint.
+    pub up_to: Vec<String>,
+}
+
+impl Selection {
+    /// Whether the user narrowed anything.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.select.is_empty() && self.up_to.is_empty()
+    }
+}
+
+/// Apply `sel` to what stage 1 discovered.
+///
+/// ## Where this matches colcon and where it deliberately does not
+///
+/// Matched: `--packages-select A B` is exactly A and B; `--packages-up-to A` is
+/// A and its transitive `<depend>` closure; the two flags **compose as an
+/// intersection**, because each is an independent deselecting filter — that is
+/// colcon's own shape (`packages_select` and `packages_up_to` each clear
+/// `decorator.selected` for anything they do not name), and it is the only
+/// composition under which adding a flag can never widen a build.
+///
+/// Diverged, twice, and both times toward failing instead of continuing:
+///
+/// **1. A name matching no package is an ERROR, not a warning.** colcon warns
+/// and carries on, which is defensible there because the unmatched name might
+/// legitimately name something in an install prefix. nano-ros has no install
+/// prefix (RFC-0087 D8) — the selection is resolved against the source tree and
+/// nothing else — so an unmatched name can only be a typo or a stale script.
+/// Warning past it narrows the build to something the user did not ask for and
+/// then reports success, which is the failure this codebase treats as worse
+/// than a red. `plan::resolve` already answers an unknown IMAGE the same way,
+/// with the available names in the message.
+///
+/// **2. A selection that drops a package another selected package needs is an
+/// ERROR.** This is colcon's headline use for `--packages-select` — rebuild one
+/// package against the install prefix the others already populated — and it
+/// does not survive the port. nano-ros builds per-target static objects through
+/// one merged root with no install-and-source stage (RFC-0087 D8), so a package
+/// left out of the selection is not "already built and available"; it is simply
+/// absent from the generated `[workspace] members` / `add_subdirectory` set.
+/// Honouring colcon's answer would hand the user a half-built workspace whose
+/// failure surfaces one layer down as an unresolved path dependency or a
+/// missing CMake target — an error about the wrong thing. So the closure is
+/// checked here and named here, with `--packages-up-to` offered as the fix.
+///
+/// ## What the check can and cannot see
+///
+/// It sees the `<depend>` graph, which is what `provider_scan` returns and what
+/// the topological order is built from. It does NOT see a cargo `path`
+/// dependency between two crates that declare nothing in `package.xml` — a
+/// cargo-only member (`cargo_only`) carries no `depends` at all, deliberately,
+/// because "cargo resolves its own dependency order from `Cargo.toml`". Dropping
+/// one of those is still loud, just later and from cargo rather than from here.
+pub fn select(found: &Discovered, sel: &Selection) -> Result<Discovered, String> {
+    if sel.is_empty() {
+        return Ok(found.clone());
+    }
+
+    let by_name: BTreeMap<&str, &WorkspacePackage> = found
+        .packages
+        .iter()
+        .map(|p| (p.name.as_str(), p))
+        .collect();
+
+    // Both flags at once: a script with two typos should learn about both.
+    let mut unknown: Vec<String> = Vec::new();
+    for (flag, names) in [
+        ("--packages-select", &sel.select),
+        ("--packages-up-to", &sel.up_to),
+    ] {
+        for n in names {
+            if !by_name.contains_key(n.as_str()) {
+                unknown.push(format!("{flag} {n}"));
+            }
+        }
+    }
+    if !unknown.is_empty() {
+        return Err(format!(
+            "no such package in this workspace: {}.\n\nDiscovered: {}",
+            unknown.join(", "),
+            name_list(&found.packages)
+        ));
+    }
+
+    let mut keep: Option<BTreeSet<&str>> = None;
+    if !sel.select.is_empty() {
+        keep = Some(sel.select.iter().map(String::as_str).collect());
+    }
+    if !sel.up_to.is_empty() {
+        let closure = up_to_closure(&by_name, &sel.up_to);
+        keep = Some(match keep {
+            // Intersection — see the doc comment. Each flag deselects.
+            Some(k) => k.intersection(&closure).copied().collect(),
+            None => closure,
+        });
+    }
+    let keep = keep.expect("a non-empty Selection sets at least one constraint");
+
+    if keep.is_empty() {
+        return Err(format!(
+            "`--packages-select` and `--packages-up-to` select no package in \
+             common, so there is nothing to build. They compose as an \
+             INTERSECTION: each narrows, neither widens.\n\n  \
+             --packages-select {}\n  --packages-up-to  {} (closure: {})",
+            sel.select.join(" "),
+            sel.up_to.join(" "),
+            {
+                let c = up_to_closure(&by_name, &sel.up_to);
+                c.into_iter().collect::<Vec<_>>().join(", ")
+            }
+        ));
+    }
+
+    // The closure check. Runs over the FINAL set, so it covers a selection
+    // broken by the intersection as well as one broken by `--packages-select`
+    // alone — an `--packages-up-to` closure is complete by construction, but
+    // intersecting it with a `--packages-select` can punch a hole in it.
+    let mut broken: Vec<String> = Vec::new();
+    for pkg in found
+        .packages
+        .iter()
+        .filter(|p| keep.contains(p.name.as_str()))
+    {
+        let mut missing: Vec<&str> = pkg
+            .depends
+            .iter()
+            .map(String::as_str)
+            .filter(|d| *d != pkg.name && by_name.contains_key(d) && !keep.contains(d))
+            .collect();
+        if missing.is_empty() {
+            continue;
+        }
+        missing.sort_unstable();
+        broken.push(format!("  {} needs {}", pkg.name, missing.join(", ")));
+    }
+    if !broken.is_empty() {
+        let mut up_to: Vec<&str> = keep.iter().copied().collect();
+        up_to.sort_unstable();
+        return Err(format!(
+            "this selection drops packages that selected packages depend on:\n\
+             \n{}\n\n\
+             colcon allows that, because a dropped dependency is found in the \
+             install prefix. nano-ros has none (RFC-0087 D8): it builds one \
+             merged root with no install-and-source stage, so a package left \
+             out is absent from the build, not resolved from a previous one. \
+             The failure would surface a layer down as an unresolved path \
+             dependency or a missing CMake target.\n\n\
+             Build the closure instead:  --packages-up-to {}",
+            broken.join("\n"),
+            up_to.join(" ")
+        ));
+    }
+
+    // Filter in place — see `Selection`'s note on why this needs no second sort.
+    let packages: Vec<WorkspacePackage> = found
+        .packages
+        .iter()
+        .filter(|p| keep.contains(p.name.as_str()))
+        .cloned()
+        .collect();
+    let kept_dirs: BTreeSet<&PathBuf> = packages.iter().map(|p| &p.dir).collect();
+    let cargo_only = found
+        .cargo_only
+        .iter()
+        .filter(|d| kept_dirs.contains(d))
+        .cloned()
+        .collect();
+
+    Ok(Discovered {
+        packages,
+        cargo_only,
+        warnings: found.warnings.clone(),
+    })
+}
+
+/// `roots` plus everything they `<depend>` on, transitively, restricted to
+/// packages of this workspace.
+///
+/// External names (`std_msgs`) are skipped for the same reason
+/// `topological_order` skips them: they impose no local build order and are not
+/// ours to select.
+fn up_to_closure<'a>(
+    by_name: &BTreeMap<&'a str, &'a WorkspacePackage>,
+    roots: &[String],
+) -> BTreeSet<&'a str> {
+    let mut out: BTreeSet<&str> = BTreeSet::new();
+    let mut stack: Vec<&str> = roots
+        .iter()
+        .filter_map(|r| by_name.get_key_value(r.as_str()).map(|(k, _)| *k))
+        .collect();
+    while let Some(name) = stack.pop() {
+        if !out.insert(name) {
+            continue;
+        }
+        let Some(pkg) = by_name.get(name) else {
+            continue;
+        };
+        for dep in &pkg.depends {
+            if let Some((k, _)) = by_name.get_key_value(dep.as_str()) {
+                stack.push(k);
+            }
+        }
+    }
+    out
+}
+
+/// Every discovered package name, sorted, for an error message.
+fn name_list(packages: &[WorkspacePackage]) -> String {
+    let mut names: Vec<&str> = packages.iter().map(|p| p.name.as_str()).collect();
+    names.sort_unstable();
+    names.dedup();
+    names.join(", ")
 }
 
 #[cfg(test)]
@@ -476,5 +713,240 @@ mod tests {
         // A pure C/C++ workspace is normal, not broken.
         let tmp = tempfile::tempdir().unwrap();
         assert!(cargo_workspace_members(tmp.path()).is_empty());
+    }
+
+    // ---- phase-420 W7 — the selection verbs (RFC-0087 D7) ---------------
+
+    /// The graph every selection test below reasons about:
+    ///
+    /// ```text
+    ///   entry ──> talker_pkg ──> msgs_pkg
+    ///     └─────> listener_pkg ─┘
+    ///   other_pkg          (unrelated)
+    ///   helper             (cargo member, no package.xml)
+    /// ```
+    ///
+    /// `talker_pkg` also declares `std_msgs`, which is NOT a workspace package
+    /// — the closure must ignore it rather than fail on it.
+    fn selection_workspace(root: &Path) -> Discovered {
+        write(
+            &root.join("src/entry/package.xml"),
+            &pkg_xml("entry", &["talker_pkg", "listener_pkg"]),
+        );
+        write(
+            &root.join("src/talker_pkg/package.xml"),
+            &pkg_xml("talker_pkg", &["msgs_pkg", "std_msgs"]),
+        );
+        write(
+            &root.join("src/listener_pkg/package.xml"),
+            &pkg_xml("listener_pkg", &["msgs_pkg"]),
+        );
+        write(
+            &root.join("src/msgs_pkg/package.xml"),
+            &pkg_xml("msgs_pkg", &[]),
+        );
+        write(
+            &root.join("src/other_pkg/package.xml"),
+            &pkg_xml("other_pkg", &[]),
+        );
+        write(
+            &root.join("src/helper/Cargo.toml"),
+            "[package]\nname = \"helper\"\n",
+        );
+        discover(root, &[root.join("src/helper")]).expect("discovers")
+    }
+
+    fn sel(select: &[&str], up_to: &[&str]) -> Selection {
+        Selection {
+            select: select.iter().map(|s| (*s).to_string()).collect(),
+            up_to: up_to.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn names(d: &Discovered) -> Vec<&str> {
+        d.packages.iter().map(|p| p.name.as_str()).collect()
+    }
+
+    #[test]
+    fn no_selection_is_the_whole_workspace() {
+        // A build that named no package must be identical to one built before
+        // these flags existed — not "the same set by a different route".
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &Selection::default()).expect("no-op");
+        assert_eq!(got, d, "an empty selection must not perturb stage 1");
+    }
+
+    #[test]
+    fn a_select_of_one_package_builds_only_that_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &sel(&["msgs_pkg"], &[])).expect("selects");
+        assert_eq!(names(&got), vec!["msgs_pkg"], "no deps, no dependents");
+        assert!(
+            got.cargo_only.is_empty(),
+            "the cargo-only member is not selected: {:?}",
+            got.cargo_only
+        );
+    }
+
+    #[test]
+    fn up_to_takes_the_transitive_closure_and_nothing_more() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &sel(&[], &["talker_pkg"])).expect("selects");
+        let mut n = names(&got);
+        n.sort_unstable();
+        assert_eq!(
+            n,
+            vec!["msgs_pkg", "talker_pkg"],
+            "the closure is the package and what it depends on — `entry` \
+             depends on it and must NOT come along, and `std_msgs` is not a \
+             workspace package at all"
+        );
+    }
+
+    #[test]
+    fn up_to_reaches_through_two_edges() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &sel(&[], &["entry"])).expect("selects");
+        let mut n = names(&got);
+        n.sort_unstable();
+        assert_eq!(
+            n,
+            vec!["entry", "listener_pkg", "msgs_pkg", "talker_pkg"],
+            "transitive, and still excludes other_pkg and the cargo-only helper"
+        );
+    }
+
+    #[test]
+    fn a_selection_keeps_the_topological_order_it_was_given() {
+        // The wave's rule: filter the order stage 1 computed, never sort again.
+        // A subset of a topological order, taken in place, is a topological
+        // order of the subset — this asserts the filter does not disturb it.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &sel(&[], &["entry"])).expect("selects");
+        let full = names(&d);
+        let kept = names(&got);
+        let expected: Vec<&str> = full.into_iter().filter(|n| kept.contains(n)).collect();
+        assert_eq!(kept, expected, "order must be stage 1's, filtered");
+        let pos = |n: &str| kept.iter().position(|k| *k == n).expect("present");
+        assert!(pos("msgs_pkg") < pos("talker_pkg"), "{kept:?}");
+        assert!(pos("talker_pkg") < pos("entry"), "{kept:?}");
+    }
+
+    #[test]
+    fn an_unknown_name_is_an_error_listing_what_exists() {
+        // Diverges from colcon, which warns. There is no install prefix the
+        // unmatched name could name (RFC-0087 D8), so it is a typo, and warning
+        // past it builds a set the user did not ask for and reports success.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let e = select(&d, &sel(&["talkr_pkg"], &[])).expect_err("must refuse");
+        assert!(e.contains("talkr_pkg"), "names what was asked for: {e}");
+        assert!(e.contains("talker_pkg"), "names what exists: {e}");
+        assert!(e.contains("msgs_pkg"), "lists ALL of them: {e}");
+    }
+
+    #[test]
+    fn both_flags_report_their_unknown_names_at_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let e = select(&d, &sel(&["nope_a"], &["nope_b"])).expect_err("must refuse");
+        assert!(e.contains("--packages-select nope_a"), "{e}");
+        assert!(e.contains("--packages-up-to nope_b"), "{e}");
+    }
+
+    #[test]
+    fn a_selection_that_drops_a_needed_dependency_is_refused() {
+        // The decision this wave had to make, and the one place colcon's answer
+        // does not port: colcon lets `--packages-select entry` succeed because
+        // `talker_pkg` is in the install prefix. nano-ros has no install prefix
+        // and one merged root, so the package would simply be absent.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let e = select(&d, &sel(&["entry"], &[])).expect_err("must refuse");
+        assert!(
+            e.contains("entry needs listener_pkg, talker_pkg"),
+            "names the hole: {e}"
+        );
+        assert!(e.contains("--packages-up-to entry"), "offers the fix: {e}");
+    }
+
+    #[test]
+    fn an_unrelated_dependency_of_an_unselected_package_is_not_a_hole() {
+        // Only edges OUT of kept packages matter. `other_pkg` being dropped
+        // while `msgs_pkg` is kept is not a hole in either direction.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &sel(&["msgs_pkg", "talker_pkg"], &[])).expect("closed");
+        let mut n = names(&got);
+        n.sort_unstable();
+        assert_eq!(n, vec!["msgs_pkg", "talker_pkg"]);
+    }
+
+    #[test]
+    fn the_two_flags_compose_as_their_intersection() {
+        // colcon's composition: each flag deselects independently, so adding
+        // one can only narrow. `--packages-up-to entry` is the four-package
+        // closure; intersecting it with a two-name select leaves those two.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(
+            &d,
+            &sel(&["talker_pkg", "msgs_pkg", "other_pkg"], &["entry"]),
+        )
+        .expect("selects");
+        let mut n = names(&got);
+        n.sort_unstable();
+        assert_eq!(
+            n,
+            vec!["msgs_pkg", "talker_pkg"],
+            "`other_pkg` is in the select and NOT in the up-to closure, so the \
+             intersection drops it; `listener_pkg` is in the closure and not \
+             the select, so the intersection drops that too"
+        );
+    }
+
+    #[test]
+    fn an_intersection_that_punches_a_hole_is_still_refused() {
+        // The closure check runs over the FINAL set for this reason: an up-to
+        // closure is complete by construction, and intersecting it is not.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let e = select(&d, &sel(&["entry", "talker_pkg", "msgs_pkg"], &["entry"]))
+            .expect_err("must refuse");
+        assert!(e.contains("entry needs listener_pkg"), "{e}");
+    }
+
+    #[test]
+    fn disjoint_flags_say_the_intersection_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let e = select(&d, &sel(&["other_pkg"], &["msgs_pkg"])).expect_err("nothing to build");
+        assert!(e.contains("INTERSECTION"), "says how they compose: {e}");
+        assert!(e.contains("other_pkg"), "{e}");
+        assert!(e.contains("msgs_pkg"), "{e}");
+    }
+
+    #[test]
+    fn a_cargo_only_member_is_selectable_by_its_directory_name() {
+        // It is discovered under its directory name and carries NO `depends`
+        // (cargo resolves its own order), so it is selectable and imposes no
+        // constraint. Its cargo `path` edges are the documented blind spot in
+        // `select`: dropping it is loud, but the noise comes from cargo.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = selection_workspace(tmp.path());
+        let got = select(&d, &sel(&["helper", "msgs_pkg"], &[])).expect("selects");
+        let mut n = names(&got);
+        n.sort_unstable();
+        assert_eq!(n, vec!["helper", "msgs_pkg"]);
+        assert_eq!(
+            got.cargo_only,
+            [tmp.path().join("src/helper")].into_iter().collect(),
+            "a kept cargo-only member stays cargo-only"
+        );
     }
 }

--- a/packages/cli/nros-cli-core/src/cmd/build.rs
+++ b/packages/cli/nros-cli-core/src/cmd/build.rs
@@ -73,6 +73,33 @@ pub struct Args {
     #[arg(long)]
     pub offline: bool,
 
+    /// Build only these packages — no dependencies, no dependents
+    /// (RFC-0087 D7, phase-420 W7).
+    ///
+    /// colcon's flag, with colcon's meaning, and two deliberate divergences
+    /// documented on `builder::discover::select`: a name matching no package is
+    /// an ERROR here rather than a warning, and a selection that drops a
+    /// package another selected package depends on is REFUSED rather than left
+    /// to resolve against an install prefix nano-ros does not have.
+    ///
+    /// The selection narrows what the build CONTAINS — the generated cargo
+    /// root's member list and the generated CMake root's subdirectories. It
+    /// does not narrow which images exist: an image is declared by a bringup's
+    /// `system.toml`, which is a property of the workspace, not of the
+    /// selection, so `nros build native --packages-select talker_pkg` still
+    /// means the `native` image, built from a narrowed workspace.
+    #[arg(long, value_name = "PKG", num_args = 1..)]
+    pub packages_select: Vec<String>,
+
+    /// Build these packages and everything they depend on, transitively, and
+    /// nothing else (RFC-0087 D7, phase-420 W7).
+    ///
+    /// Composes with `--packages-select` as an INTERSECTION, which is colcon's
+    /// composition too: each flag deselects independently, so adding one can
+    /// only ever narrow the build.
+    #[arg(long, value_name = "PKG", num_args = 1..)]
+    pub packages_up_to: Vec<String>,
+
     /// Arguments after `--` go to the native tool verbatim.
     #[arg(last = true)]
     pub native_args: Vec<String>,
@@ -157,7 +184,29 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
     }
 
     // ---- stage 2 --------------------------------------------------------
+    // Images come from the FULL workspace, before any selection: an image is
+    // declared by a bringup's `system.toml` and is a property of the workspace,
+    // exactly as the generated cargo root's member list is. A selection that
+    // happened to drop a bringup package must not make its images cease to
+    // exist — that would answer `--packages-select` with "this workspace
+    // declares no `[image.*]`", an error about the wrong thing.
     let bringups = collect_images(&found.packages)?;
+
+    // ---- stage 1b — the selection verbs (RFC-0087 D7, phase-420 W7) -----
+    //
+    // Filters the topological order stage 1 already computed; it does not sort
+    // again. `all_packages` keeps the unnarrowed set, because
+    // `check_declared_depends` walks the whole tree itself and would read a
+    // deliberately-dropped package as an unresolved `<depend>`.
+    let all_packages = found.packages.clone();
+    let found = discover::select(
+        &found,
+        &discover::Selection {
+            select: args.packages_select.clone(),
+            up_to: args.packages_up_to.clone(),
+        },
+    )
+    .map_err(|e| eyre::eyre!("{e}"))?;
 
     let requested: Vec<String> = if args.all {
         plan::all_images(&bringups)
@@ -183,7 +232,7 @@ pub fn plan_builds(args: &Args) -> Result<Vec<ResolvedBuild>> {
     // Runs once per invocation, before anything is generated, because an
     // undeclared prerequisite is cheapest to report before a toolchain is
     // touched (RFC-0065 D2's reasoning, applied to dependencies).
-    check_declared_depends(&root, &found.packages, nano_ros_root.as_deref())?;
+    check_declared_depends(&root, &all_packages, nano_ros_root.as_deref())?;
 
     // The workspace's OWN packages can carry board descriptors, so a board is
     // declared where everything else about this workspace is declared.
@@ -2425,5 +2474,139 @@ mod zephyr_workspace_flag_tests {
         let empty = tmp.path().join("empty");
         std::fs::create_dir_all(&empty).unwrap();
         assert_eq!(zephyr_base_with(Some(&empty), None, None, tmp.path()), None);
+    }
+}
+
+/// phase-420 W7 — the selection verbs, asserted where they are WIRED.
+///
+/// `builder::discover` unit-tests the filter itself. These assert the two
+/// things a unit test of a pure function cannot: that clap spells the flags the
+/// way colcon does, and that `plan_builds` actually applies them. This crate
+/// has shipped a lint with four passing unit tests and no production caller
+/// before (`deprecation_wiring_tests`, below), which is why the wiring gets its
+/// own assertions rather than being assumed.
+#[cfg(test)]
+mod selection_wiring_tests {
+    use super::*;
+    use clap::Parser;
+
+    fn args_for(root: &std::path::Path, select: &[&str], up_to: &[&str]) -> Args {
+        Args {
+            images: Vec::new(),
+            workspace: Some(root.to_path_buf()),
+            nano_ros_path: None,
+            zephyr_workspace: None,
+            all: false,
+            dry_run: true,
+            offline: true,
+            packages_select: select.iter().map(|s| (*s).to_string()).collect(),
+            packages_up_to: up_to.iter().map(|s| (*s).to_string()).collect(),
+            native_args: Vec::new(),
+        }
+    }
+
+    fn pkg(root: &std::path::Path, name: &str, depends: &[&str]) {
+        let dir = root.join("src").join(name);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let deps: String = depends
+            .iter()
+            .map(|d| format!("  <depend>{d}</depend>\n"))
+            .collect();
+        std::fs::write(
+            dir.join("package.xml"),
+            format!(
+                "<?xml version=\"1.0\"?>\n<package format=\"3\">\n  \
+                 <name>{name}</name>\n  <version>0.0.0</version>\n  \
+                 <description>t</description>\n  \
+                 <maintainer email=\"a@b.c\">m</maintainer>\n  \
+                 <license>Apache-2.0</license>\n{deps}</package>\n"
+            ),
+        )
+        .expect("write package.xml");
+    }
+
+    /// colcon's spelling, and both flags taking several names.
+    #[test]
+    fn the_flags_parse_with_colcons_spelling() {
+        let a = Args::try_parse_from([
+            "build",
+            "--packages-select",
+            "talker_pkg",
+            "msgs_pkg",
+            "--packages-up-to",
+            "entry",
+        ])
+        .expect("parses");
+        assert_eq!(a.packages_select, vec!["talker_pkg", "msgs_pkg"]);
+        assert_eq!(a.packages_up_to, vec!["entry"]);
+        assert!(a.images.is_empty(), "no image was named: {:?}", a.images);
+    }
+
+    /// A selection composes with the flags the verb already has — here the
+    /// positional image, which must not be swallowed by the multi-valued flag.
+    #[test]
+    fn an_image_argument_survives_beside_a_selection() {
+        let a = Args::try_parse_from(["build", "--packages-up-to", "entry", "--", "-j4"])
+            .expect("parses");
+        assert_eq!(a.packages_up_to, vec!["entry"]);
+        assert_eq!(a.native_args, vec!["-j4"]);
+
+        let b = Args::try_parse_from(["build", "native", "--packages-select", "talker_pkg"])
+            .expect("parses");
+        assert_eq!(b.images, vec!["native"]);
+        assert_eq!(b.packages_select, vec!["talker_pkg"]);
+    }
+
+    /// The wiring: an unknown name must be refused by `plan_builds` itself.
+    ///
+    /// It is also refused EARLY — before the board catalog, which needs a
+    /// nano-ros checkout this temp workspace does not have. If the selection
+    /// ran later, this test would see "no nano-ros checkout found" instead, so
+    /// the assertion doubles as the ordering check.
+    #[test]
+    fn plan_builds_refuses_an_unknown_selected_package() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        pkg(tmp.path(), "talker_pkg", &[]);
+        pkg(tmp.path(), "msgs_pkg", &[]);
+
+        let e = plan_builds(&args_for(tmp.path(), &["talkr_pkg"], &[]))
+            .expect_err("an unknown package must not be warned past");
+        let msg = format!("{e:#}");
+        assert!(msg.contains("no such package"), "{msg}");
+        assert!(msg.contains("talker_pkg"), "lists what exists: {msg}");
+    }
+
+    /// The other wiring direction: an incomplete `--packages-select` is refused
+    /// by `plan_builds`, not left to fail later as a missing artifact.
+    #[test]
+    fn plan_builds_refuses_a_selection_that_drops_a_dependency() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        pkg(tmp.path(), "entry", &["talker_pkg"]);
+        pkg(tmp.path(), "talker_pkg", &[]);
+
+        let e = plan_builds(&args_for(tmp.path(), &["entry"], &[]))
+            .expect_err("an open selection must not build");
+        let msg = format!("{e:#}");
+        assert!(msg.contains("entry needs talker_pkg"), "{msg}");
+        assert!(msg.contains("--packages-up-to entry"), "{msg}");
+    }
+
+    /// And a well-formed selection is NOT refused here — it passes stage 1b and
+    /// fails later, on the image, which is a different message. Without this,
+    /// the two tests above would pass on a `select` that refused everything.
+    #[test]
+    fn a_closed_selection_passes_stage_1b() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        pkg(tmp.path(), "entry", &["talker_pkg"]);
+        pkg(tmp.path(), "talker_pkg", &[]);
+
+        let e = plan_builds(&args_for(tmp.path(), &[], &["entry"]))
+            .expect_err("this workspace declares no image");
+        let msg = format!("{e:#}");
+        assert!(
+            !msg.contains("no such package") && !msg.contains("needs talker_pkg"),
+            "the selection is closed and must not be the complaint: {msg}"
+        );
+        assert!(msg.contains("[image.*]"), "{msg}");
     }
 }

--- a/packages/cli/nros-cli-core/src/cmd/image_facts.rs
+++ b/packages/cli/nros-cli-core/src/cmd/image_facts.rs
@@ -146,6 +146,10 @@ pub fn run(args: Args) -> Result<()> {
         all: args.for_entry.is_some(),
         dry_run: true,
         offline: true,
+        // phase-420 W7 — a QUERY resolves the whole workspace. Narrowing it
+        // would answer a question nobody asked.
+        packages_select: Vec::new(),
+        packages_up_to: Vec::new(),
         native_args: Vec::new(),
     };
 

--- a/packages/cli/nros-cli-core/src/cmd/materialize.rs
+++ b/packages/cli/nros-cli-core/src/cmd/materialize.rs
@@ -56,6 +56,10 @@ pub fn run(args: Args) -> Result<()> {
         all: false,
         dry_run: true,
         offline: true,
+        // phase-420 W7 — a QUERY resolves the whole workspace. Narrowing it
+        // would answer a question nobody asked.
+        packages_select: Vec::new(),
+        packages_up_to: Vec::new(),
         native_args: Vec::new(),
     };
     let plans = super::build::plan_builds(&build_args)?;

--- a/packages/cli/nros-cli-core/tests/build_verb_pipeline.rs
+++ b/packages/cli/nros-cli-core/tests/build_verb_pipeline.rs
@@ -28,6 +28,20 @@ fn write(path: &Path, body: &str) {
     std::fs::write(path, body).unwrap();
 }
 
+/// A `package.xml` declaring `<depend>` on each of `depends`.
+fn pkg_xml_needing(name: &str, depends: &[&str]) -> String {
+    let deps: String = depends
+        .iter()
+        .map(|d| format!("<depend>{d}</depend>\n"))
+        .collect();
+    format!(
+        "<?xml version=\"1.0\"?>\n<package format=\"3\">\n<name>{name}</name>\n\
+         <version>0.0.0</version>\n<description>t</description>\n\
+         <maintainer email=\"a@b.c\">m</maintainer>\n<license>Apache-2.0</license>\n\
+         {deps}</package>\n"
+    )
+}
+
 fn pkg_xml(name: &str) -> String {
     format!(
         "<?xml version=\"1.0\"?>\n<package format=\"3\">\n<name>{name}</name>\n\
@@ -95,6 +109,11 @@ fn fixture(dir: &Path) {
 }
 
 fn args(ws: &Path, images: &[&str]) -> Args {
+    selected_args(ws, images, &[], &[])
+}
+
+/// [`args`], narrowed by the phase-420 W7 selection verbs.
+fn selected_args(ws: &Path, images: &[&str], select: &[&str], up_to: &[&str]) -> Args {
     Args {
         images: images.iter().map(|s| (*s).to_string()).collect(),
         workspace: Some(ws.to_path_buf()),
@@ -105,6 +124,8 @@ fn args(ws: &Path, images: &[&str]) -> Args {
         all: false,
         dry_run: true,
         offline: false,
+        packages_select: select.iter().map(|s| (*s).to_string()).collect(),
+        packages_up_to: up_to.iter().map(|s| (*s).to_string()).collect(),
         native_args: Vec::new(),
     }
 }
@@ -751,4 +772,164 @@ fn a_missing_framework_names_how_to_supply_it() {
     };
     assert!(err.contains("--nano-ros-path"), "{err}");
     assert!(err.contains("NROS_REPO_DIR"), "{err}");
+}
+
+// ---- phase-420 W7 — the selection verbs, end to end (RFC-0087 D7) --------
+
+/// Two extra packages on top of [`fixture`]: `app_pkg` depending on
+/// `talker_pkg`, and an unrelated `other_pkg`. The closure of `app_pkg` is
+/// therefore `{app_pkg, talker_pkg}` — everything else in the workspace is
+/// outside it, which is what "and nothing more" is measured against.
+fn selection_fixture(dir: &Path) {
+    fixture(dir);
+    write(
+        &dir.join("src/app_pkg/package.xml"),
+        &pkg_xml_needing("app_pkg", &["talker_pkg"]),
+    );
+    write(
+        &dir.join("src/app_pkg/Cargo.toml"),
+        "[package]\nname = \"app_pkg\"\nversion = \"0.0.0\"\n",
+    );
+    write(
+        &dir.join("src/other_pkg/package.xml"),
+        &pkg_xml("other_pkg"),
+    );
+    write(
+        &dir.join("src/other_pkg/Cargo.toml"),
+        "[package]\nname = \"other_pkg\"\nversion = \"0.0.0\"\n",
+    );
+    // The tracked root is what `cargo_root::ensure` refuses to clobber, so a
+    // selection could not be observed through it. Delete it and let stage 4
+    // generate one, which is RFC-0065 D13's end state anyway.
+    std::fs::remove_file(dir.join("Cargo.toml")).unwrap();
+}
+
+/// The wave's acceptance line: `--packages-up-to <pkg>` builds the package and
+/// its dependencies and NOTHING else.
+///
+/// Measured on the generated cargo root, because that is where "what this build
+/// contains" is written down for the cargo driver.
+#[test]
+fn up_to_narrows_the_generated_cargo_root_to_the_closure() {
+    let tmp = tempfile::tempdir().unwrap();
+    selection_fixture(tmp.path());
+
+    let plans =
+        plan_builds(&selected_args(tmp.path(), &["native"], &[], &["app_pkg"])).expect("resolves");
+    assert_eq!(plans[0].driver, Driver::Cargo);
+
+    let body = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+    assert!(body.starts_with("# GENERATED"), "{body}");
+    assert!(
+        body.contains("\"src/app_pkg\""),
+        "the named package: {body}"
+    );
+    assert!(
+        body.contains("\"src/talker_pkg\""),
+        "its dependency: {body}"
+    );
+    assert!(
+        !body.contains("\"src/other_pkg\""),
+        "and nothing else — other_pkg is outside the closure: {body}"
+    );
+    assert!(
+        !body.contains("\"src/helper\""),
+        "the cargo-only helper is outside the closure too: {body}"
+    );
+}
+
+/// The same narrowing, seen by the OTHER driver. cmake's root is the one place
+/// where being listed and being built are the same thing, so this is where the
+/// selection has to hold if it holds anywhere.
+#[test]
+fn a_selection_narrows_the_generated_cmake_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    selection_fixture(tmp.path());
+    // Cross languages so cmake wins (RFC-0024 §6.3).
+    write(
+        &tmp.path().join("src/talker_pkg/CMakeLists.txt"),
+        "# c pkg\n",
+    );
+    write(
+        &tmp.path().join("src/other_pkg/CMakeLists.txt"),
+        "# c pkg\n",
+    );
+
+    let plans =
+        plan_builds(&selected_args(tmp.path(), &["native"], &[], &["app_pkg"])).expect("resolves");
+    assert_eq!(plans[0].driver, Driver::CMake);
+
+    let body =
+        std::fs::read_to_string(tmp.path().join("build/posix-zenoh-linux/CMakeLists.txt")).unwrap();
+    assert!(body.contains("talker_pkg"), "{body}");
+    assert!(
+        !body.contains("other_pkg"),
+        "a package outside the closure must not be a subdirectory of the \
+         generated root: {body}"
+    );
+}
+
+/// A select of one package builds one package.
+#[test]
+fn select_of_one_leaf_package_narrows_to_exactly_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    selection_fixture(tmp.path());
+
+    plan_builds(&selected_args(
+        tmp.path(),
+        &["native"],
+        &["talker_pkg"],
+        &[],
+    ))
+    .expect("resolves");
+
+    let body = std::fs::read_to_string(tmp.path().join("Cargo.toml")).unwrap();
+    assert!(body.contains("\"src/talker_pkg\""), "{body}");
+    for absent in ["\"src/app_pkg\"", "\"src/other_pkg\"", "\"src/helper\""] {
+        assert!(!body.contains(absent), "{absent} must be gone: {body}");
+    }
+}
+
+/// The images a workspace declares are a property of the WORKSPACE, not of the
+/// selection. A narrowing that excludes the bringup package must still resolve
+/// the image it declared — otherwise `--packages-select` would answer with
+/// "this workspace declares no `[image.*]`", an error about the wrong thing.
+#[test]
+fn a_selection_that_excludes_the_bringup_still_resolves_its_image() {
+    let tmp = tempfile::tempdir().unwrap();
+    selection_fixture(tmp.path());
+
+    let plans = plan_builds(&selected_args(
+        tmp.path(),
+        &["native"],
+        &["talker_pkg"],
+        &[],
+    ))
+    .expect("the image is declared by the workspace, not by the selection");
+    assert_eq!(plans[0].qualified, "demo_bringup:native");
+}
+
+/// An incomplete `--packages-select` is refused BEFORE anything is generated.
+///
+/// The decision this wave made and colcon's does not survive: colcon lets this
+/// through because the dropped dependency is in the install prefix. There is no
+/// install prefix here (RFC-0087 D8), so the package would simply be missing
+/// from the root about to be written.
+#[test]
+fn an_incomplete_selection_is_refused_before_a_root_is_written() {
+    let tmp = tempfile::tempdir().unwrap();
+    selection_fixture(tmp.path());
+
+    let e = plan_builds(&selected_args(tmp.path(), &["native"], &["app_pkg"], &[]))
+        .expect_err("app_pkg needs talker_pkg");
+    let msg = format!("{e:#}");
+    assert!(msg.contains("app_pkg needs talker_pkg"), "{msg}");
+    assert!(
+        msg.contains("--packages-up-to app_pkg"),
+        "offers the fix: {msg}"
+    );
+    assert!(
+        !tmp.path().join("Cargo.toml").exists(),
+        "nothing may be generated for a selection that cannot build"
+    );
 }


### PR DESCRIPTION
RFC-0087 D7. One pure function, `builder::discover::select`, applied as stage 1b in `plan_builds`.

It **filters the existing order in place** — a subset of a topological order taken in place *is* a topological order of the subset, so no second sort exists, and a test asserts the kept sequence equals stage 1's filtered.

## Matched from colcon

`--packages-select A B` is exactly A and B; `--packages-up-to A` is A plus its transitive `<depend>` closure (external names ignored, as `topological_order` already does); the two compose as an **intersection**, which is colcon's own shape — each is an independent deselecting filter, so adding one can never widen a build.

## Diverged twice, both toward failing

**An unmatched name is an error, not a warning.** colcon can warn because the name might exist in an install prefix. RFC-0087 D8 says nano-ros has none — selection resolves against the source tree only — so an unmatched name is a typo, and warning past it narrows the build to something nobody asked for and *then reports success*. `plan::resolve` already answers an unknown **image** this way; this is the same answer one noun over.

**An incomplete selection is refused.** colcon permits it — that is how you rebuild one package against an existing install. nano-ros cannot: it builds **one merged root** of per-target static objects with no install-and-source stage, so a dropped dependency is not "already built and available", it is absent from the generated `[workspace] members` / `add_subdirectory` set. The failure would surface a layer down as an unresolved path dep — an error about the wrong thing.

The closure is checked on the **final** set, not on `--packages-select` alone: an up-to closure is complete by construction, but an intersection of one is not.

## Two placement seams where the obvious answer is wrong

- **Images are collected before the selection.** An image is declared by a bringup's `system.toml` and is a property of the workspace; narrowing first makes `--packages-select talker_pkg` answer *"this workspace declares no `[image.*]`"*.
- **`check_declared_depends` keeps the unnarrowed set** — it walks the tree itself, and the narrowed name set would report every deliberately-dropped package as unresolved.

Both commented in place.

## Stated blind spot

The check sees the `<depend>` graph, not a cargo `path` dep between two crates with no `package.xml`. A `cargo_only` member carries no `depends` by design, so dropping one is still loud — the noise just comes from cargo instead. Also recorded: a narrowed cargo selection narrows the generated root's member list and therefore `Cargo.lock`, which under the `--locked` shim is a hard error rather than a silent re-resolve.

## Tests

23: closure one and two edges deep, order preservation, an unknown name listing what exists, both flags reporting their unknowns at once, the intersection, an intersection that punches a hole, a disjoint pair, and five end-to-end over the generated roots — including one asserting **no root is written** when the refusal fires.

`cargo test -p nros-cli-core --lib` 881 pass. `build_verb_pipeline` 27 pass, 1 fail: `two_boards_on_one_platform_get_separate_cmake_roots` needs `rustup target add thumbv7m-none-eabi`, absent on this host. **Confirmed pre-existing** by stashing the diff and re-running on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV