### PR TITLE
fix(test): drop the associated type phase-421 removed

### DIFF
--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -2552,7 +2552,6 @@ mod builder_tests {
     // now required by `MessageForRmw` on EVERY backend, because that is where
     // a subscription's build-time size bound comes from.
     impl nros_serdes::schema::Message for TestMsg {
-        type Format = nros_serdes::format::Cdr;
         const TYPE_NAME: &'static str = "test/msg/TestMsg";
         const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
             name: "data",

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -112,7 +112,6 @@ impl RosMessage for TestMsg {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestMsg {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/msg/TestMsg";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "data",
@@ -169,7 +168,6 @@ impl RosMessage for UnboundedTestMsg {
 }
 
 impl nros_serdes::schema::Message for UnboundedTestMsg {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/msg/UnboundedTestMsg";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "data",
@@ -367,7 +365,6 @@ fn an_unbounded_type_yields_no_receive_buffer_size() {
 struct OddBoundTestMsg;
 
 impl nros_serdes::schema::Message for OddBoundTestMsg {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/msg/OddBoundTestMsg";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "data",
@@ -1842,7 +1839,6 @@ impl RosMessage for TestGoal {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestGoal {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/action/TestAction_Goal";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "order",
@@ -1879,7 +1875,6 @@ impl RosMessage for TestResult {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestResult {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/action/TestAction_Result";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "value",
@@ -1916,7 +1911,6 @@ impl RosMessage for TestFeedback {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestFeedback {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/action/TestAction_Feedback";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "progress",
@@ -3162,7 +3156,6 @@ impl RosMessage for TestServiceRequest {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestServiceRequest {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/srv/TestService_Request";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "a",
@@ -3194,7 +3187,6 @@ impl RosMessage for TestServiceReply {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestServiceReply {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/srv/TestService_Reply";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "sum",


### PR DESCRIPTION
`cargo test -p nros-node --features std` has not compiled since `47880d2e1`.

Nine impls still declare

```rust
type Format = nros_serdes::format::Cdr;
```

for `nros_serdes::schema::Message`, which no longer has that associated type — the trait now carries `TYPE_NAME`, `FIELDS` and the phase-380 bound, and nothing else.

```
error[E0437]: type `Format` is not a member of trait `nros_serdes::schema::Message`
```

Every site is a test fixture or a `cfg(test)` impl, so the library builds fine and the image runs — only the suite is dead. Removing the declarations is the whole fix; nothing referenced them.

## Verification

```
cargo test -p nros-node --features std
  test result: ok. 309 passed; 0 failed
  test result: ok. 5 passed; 0 failed
```

Before this commit the same command produced 246 errors and ran nothing.

## Why it is worth landing on its own

Separate from the work that found it. Two feature branches (#312's follow-up and the release-jitter monitor rule) have now had to quote their verification against an older commit because the suite could not run at main's tip. That makes every later change harder to trust than it should be, and the fix is nine deleted lines.