### PR TITLE
feat(sched): report a spin wake that arrived a whole period late

### DIFF
--- a/packages/core/nros-node/src/executor/monitor.rs
+++ b/packages/core/nros-node/src/executor/monitor.rs
@@ -139,7 +139,7 @@ pub const MAX_VIOLATIONS: usize = 8;
 pub struct Violation {
     /// `"rate-hierarchy-runtime"` | `"max-age-runtime"` |
     /// `"max-latency-runtime"` | `"deadline-miss-runtime"` |
-    /// `"timer-overrun-runtime"`.
+    /// `"timer-overrun-runtime"` | `"release-jitter-runtime"`.
     pub rule: &'static str,
     /// Violating endpoint ref (from the spec's `fqn`; the SC name for
     /// deadline misses).
@@ -480,6 +480,93 @@ pub(crate) fn check_timer_overrun(
         measured: dropped,
         declared: tolerated,
     })
+}
+
+/// Issue #515 — report a spin wake that arrived so late the cadence it
+/// claims cannot have been met.
+///
+/// Like `check_timer_overrun` and unlike the rate/age/latency rules, this
+/// needs no baked spec table. The bound is the spin period ITSELF: the
+/// caller passes it to `spin_once` as the pacing quantum, it is what
+/// `system.toml` declares as `spin_period_us`, and a wake later than a full
+/// period past its predecessor means an activation's worth of cadence was
+/// lost. That is a contract failure for any declared period, so there is
+/// nothing further to declare.
+///
+/// The tolerance is one whole period rather than zero, and deliberately so.
+/// Sub-period lateness is ordinary scheduling noise -- on the measured FVP
+/// lane the executor is late on a large fraction of wakes while still
+/// holding its rate -- and a rule that fired on each one would report a
+/// healthy system as broken thousands of times a second. What is NOT
+/// ordinary is being a full period late, because by then the wake that
+/// should have happened in between never did.
+///
+/// `max_jitter_us` is the executor's high-water since the last check and
+/// `last_reported` the value at the previous one, so the verdict is on the
+/// delta -- the same shape as the overrun counter, and for the same reason:
+/// a maximum that has not moved is not a new fault.
+pub(crate) fn check_release_jitter(
+    max_jitter_us: u64,
+    last_reported: &mut u64,
+    period_us: u64,
+) -> Option<Violation> {
+    if period_us == 0 || max_jitter_us <= *last_reported {
+        return None;
+    }
+    *last_reported = max_jitter_us;
+    if max_jitter_us < period_us {
+        return None;
+    }
+    Some(Violation {
+        rule: "release-jitter-runtime",
+        // Same stand-in as the timer and deadline rules: the spin loop is
+        // not an endpoint and carries no fqn at this altitude.
+        fqn: "spin",
+        measured: max_jitter_us.min(u32::MAX as u64) as u32,
+        declared: period_us.min(u32::MAX as u64) as u32,
+    })
+}
+
+#[cfg(test)]
+mod release_jitter_rule_tests {
+    use super::*;
+
+    /// Sub-period lateness is noise, not a violation -- otherwise a
+    /// healthy-but-jittery loop reports thousands of faults a second.
+    #[test]
+    fn tolerates_lateness_within_one_period() {
+        let mut last = 0;
+        assert!(check_release_jitter(4_000, &mut last, 5_000).is_none());
+        assert_eq!(last, 4_000, "still recorded, so the next delta is honest");
+    }
+
+    /// A full period late means the wake that belonged in between never
+    /// happened.
+    #[test]
+    fn reports_a_wake_a_whole_period_late() {
+        let mut last = 0;
+        let v = check_release_jitter(5_000, &mut last, 5_000).expect("one period late reports");
+        assert_eq!(v.rule, "release-jitter-runtime");
+        assert_eq!(v.measured, 5_000);
+        assert_eq!(v.declared, 5_000);
+    }
+
+    /// The verdict is on the DELTA. A high-water that has not moved is the
+    /// same fault already reported, not a new one.
+    #[test]
+    fn an_unchanged_maximum_is_not_a_new_fault() {
+        let mut last = 0;
+        assert!(check_release_jitter(9_000, &mut last, 5_000).is_some());
+        assert!(check_release_jitter(9_000, &mut last, 5_000).is_none());
+        assert!(check_release_jitter(12_000, &mut last, 5_000).is_some());
+    }
+
+    /// No declared period means no cadence to be late for.
+    #[test]
+    fn a_zero_period_declares_nothing() {
+        let mut last = 0;
+        assert!(check_release_jitter(1_000_000, &mut last, 0).is_none());
+    }
 }
 
 #[cfg(test)]

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -2552,7 +2552,6 @@ mod builder_tests {
     // now required by `MessageForRmw` on EVERY backend, because that is where
     // a subscription's build-time size bound comes from.
     impl nros_serdes::schema::Message for TestMsg {
-        type Format = nros_serdes::format::Cdr;
         const TYPE_NAME: &'static str = "test/msg/TestMsg";
         const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
             name: "data",

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1414,6 +1414,15 @@ pub struct Executor<'s> {
     /// jitter is measured over. `None` until the first spin, and reset by
     /// `clear_release_jitter_stats` so a window starts clean.
     pub(crate) last_spin_entry_us: Option<u64>,
+    /// Jitter high-water at the previous `release-jitter-runtime` check, so
+    /// the rule reports the DELTA. Same shape as `overruns_reported` on a
+    /// timer header, and for the same reason: a maximum that has not moved
+    /// is the fault already reported, not a new one.
+    pub(crate) jitter_reported_us: u64,
+    /// The pacing quantum the spin loop was last driven at, in microseconds.
+    /// This is the bound the jitter rule judges against -- the caller's own
+    /// declared cadence, so nothing further has to be declared.
+    pub(crate) spin_nominal_us: u64,
     /// Wakes that were already past their nominal deadline, and wakes total.
     ///
     /// The maximum alone cannot distinguish one bad wake from a loop that is
@@ -1581,6 +1590,8 @@ impl<'s> Executor<'s> {
             monitor_violations_dropped: 0,
             max_release_jitter_us: 0,
             last_spin_entry_us: None,
+            jitter_reported_us: 0,
+            spin_nominal_us: 0,
             late_wakes: 0,
             total_wakes: 0,
             report_violations: true,
@@ -2158,6 +2169,7 @@ impl<'s> Executor<'s> {
         let Some(now) = self.now_us() else {
             return;
         };
+        self.spin_nominal_us = nominal_us;
         if let Some(last) = self.last_spin_entry_us {
             let interval = now.saturating_sub(last);
             self.total_wakes = self.total_wakes.saturating_add(1);
@@ -2199,6 +2211,7 @@ impl<'s> Executor<'s> {
         self.late_wakes = 0;
         self.total_wakes = 0;
         self.last_spin_entry_us = None;
+        self.jitter_reported_us = 0;
     }
 
     pub fn set_fault_handler(&mut self, f: fn(&super::monitor::Violation)) {
@@ -2364,6 +2377,27 @@ impl<'s> Executor<'s> {
     /// activation is a contract failure for any declared period. It runs
     /// on the same tick so violations land in the same ring the entry
     /// glue drains.
+    /// Issue #515 — report a spin wake a whole period late.
+    ///
+    /// Runs on the same tick as `check_timer_overruns` and feeds the same
+    /// ring, so the entry glue drains it with the other rules and no caller
+    /// needs to know this one exists. Like that rule it needs no spec table:
+    /// the bound is the spin period the caller already passes in.
+    fn check_release_jitter_rule(&mut self) {
+        let (max_us, _late, _total) = self.release_jitter();
+        let period_us = self.spin_nominal_us;
+        if let Some(v) =
+            super::monitor::check_release_jitter(max_us, &mut self.jitter_reported_us, period_us)
+        {
+            if self.report_violations {
+                super::monitor::log_violation(&v);
+            }
+            if self.monitor_violations.push(v).is_err() {
+                self.monitor_violations_dropped = self.monitor_violations_dropped.saturating_add(1);
+            }
+        }
+    }
+
     fn check_timer_overruns(&mut self) {
         let arena_ptr = self.arena.as_mut_ptr() as *mut u8;
         for i in 0..self.entries.len() {
@@ -6791,6 +6825,7 @@ impl<'s> Executor<'s> {
         // that just happened, and a tier that is stalling should not have
         // to wait for the next spin to say so.
         self.check_timer_overruns();
+        self.check_release_jitter_rule();
 
         // Process parameter services (outside the arena)
         #[cfg(feature = "param-services")]

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -112,7 +112,6 @@ impl RosMessage for TestMsg {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestMsg {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/msg/TestMsg";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "data",
@@ -169,7 +168,6 @@ impl RosMessage for UnboundedTestMsg {
 }
 
 impl nros_serdes::schema::Message for UnboundedTestMsg {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/msg/UnboundedTestMsg";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "data",
@@ -367,7 +365,6 @@ fn an_unbounded_type_yields_no_receive_buffer_size() {
 struct OddBoundTestMsg;
 
 impl nros_serdes::schema::Message for OddBoundTestMsg {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/msg/OddBoundTestMsg";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "data",
@@ -1842,7 +1839,6 @@ impl RosMessage for TestGoal {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestGoal {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/action/TestAction_Goal";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "order",
@@ -1879,7 +1875,6 @@ impl RosMessage for TestResult {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestResult {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/action/TestAction_Result";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "value",
@@ -1916,7 +1911,6 @@ impl RosMessage for TestFeedback {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestFeedback {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/action/TestAction_Feedback";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "progress",
@@ -3162,7 +3156,6 @@ impl RosMessage for TestServiceRequest {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestServiceRequest {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/srv/TestService_Request";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "a",
@@ -3194,7 +3187,6 @@ impl RosMessage for TestServiceReply {
 // now required by `MessageForRmw` on EVERY backend, because that is where
 // a subscription's build-time size bound comes from.
 impl nros_serdes::schema::Message for TestServiceReply {
-    type Format = nros_serdes::format::Cdr;
     const TYPE_NAME: &'static str = "test/srv/TestService_Reply";
     const FIELDS: &'static [nros_serdes::schema::Field] = &[nros_serdes::schema::Field {
         name: "sum",


### PR DESCRIPTION
> Stacked on #416. Without that fix the `nros-node` suite does not compile at all, so none of the verification below can be run. Review this one after it lands, or read the top commit only.

## Problem

The release-jitter probe (#312, #379) records a maximum **nothing can read**.

`release_jitter()` is a Rust method on `Executor` with no C ABI export, and on the Zephyr lane the executor lives inside nros-cpp's tier loop where no application holds it. The number existed and no image could surface it — which is the same defect class as Zephyr's `tracing_packet_drop_num`, counted into a `static` with no reader anywhere in the tree.

## Change

Make it a monitor rule, alongside the five that already drain through `nros-diagnostics`:

```
rate-hierarchy-runtime   max-age-runtime   max-latency-runtime
deadline-miss-runtime    timer-overrun-runtime   release-jitter-runtime  <- new
```

Nothing new has to be called. An entry that already reports violations reports this one too, with no ASI-side change at all.

## No new contract field, deliberately

`check_timer_overrun`'s doc argues that a dropped activation "is a contract failure for any declared period", so it needs no baked spec table. The same holds here.

The bound **is the spin period** — the caller already passes it to `spin_once` as the pacing quantum, and `system.toml` already declares it as `spin_period_us`. A wake arriving later than a full period past its predecessor means the activation that belonged in between never happened. There is nothing further to declare.

## Tolerance is one whole period, not zero

Sub-period lateness is ordinary scheduling noise. On the measured FVP lane the executor is late on a large fraction of wakes while comfortably holding its rate; a rule firing on each would report a healthy system as broken thousands of times a second.

A **full** period late is different in kind rather than degree, and that is where the line sits.

Reports on the delta, like the overrun counter — a high-water that has not moved is the fault already reported, not a new one.

## Verification

```
cargo test -p nros-node --features std
  test result: ok. 313 passed; 0 failed
  test result: ok. 5 passed; 0 failed

release_jitter_rule_tests::tolerates_lateness_within_one_period ... ok
release_jitter_rule_tests::reports_a_wake_a_whole_period_late ... ok
release_jitter_rule_tests::an_unchanged_maximum_is_not_a_new_fault ... ok
release_jitter_rule_tests::a_zero_period_declares_nothing ... ok
```

Clean on default (no_std) and `alloc`; `cargo fmt` clean.

## Series

- #312 added the probe, on `spin_period`
- #379 moved it to `spin_once`, because nros-cpp never calls `spin_period`
- this makes the number reportable, which is what makes the probe worth having
