### PR TITLE
fix(#1006): esp32-qemu's link surface is the recipe's now, not the build host's

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -979,6 +979,10 @@ jobs:
       # must not drift (else prebuilt != source-built).
       - name: Check qemu configure flags match (index vs build script)
         run: ./scripts/sdk/check-qemu-configure.sh
+      # issue 1006 — a qemu recipe with no `dist` is source-built by every user,
+      # so an auto-detected backend makes its runtime deps the build host's.
+      - name: Check source-only qemu recipes pin their backends
+        run: python3 scripts/sdk/check-qemu-source-features.py nros-sdk-index.toml
 
   # ---------------------------------------------------------------------------
   # THE REQUIRED CHECK — phase-395 W20.

--- a/docs/issues/1006-esp32-qemu-configure-nondeterministic-deps.md
+++ b/docs/issues/1006-esp32-qemu-configure-nondeterministic-deps.md
@@ -70,3 +70,64 @@ observable on a host that has actually built this tool. That is why the gap sat
 unnoticed: CI never provisions esp32-qemu (it is nightly-only), and a developer
 who has built it sees a 75-line failure that looks like index rot rather than a
 configure problem.
+
+## What landed (the configure is pinned; the closure is NOT re-measured)
+
+`[tool.esp32-qemu.source].configure` now names 69 flags instead of 13. The added
+ones are all `--disable-*`, grouped as UI, audio, host-device passthrough,
+block drivers beyond the raw image, TLS, and the remaining host libraries — the
+whole set of qemu feature options that reach for a system library and that
+`-M esp32c3 -icount 3 -nographic -drive file=…,if=mtd,format=raw -nic
+user,model=open_eth` never touches. `--enable-gcrypt`, `--enable-slirp`,
+`--target-list=riscv32-softmmu` and `--disable-werror` are untouched; `fdt`,
+`pixman` and `zlib` are left auto deliberately (the riscv boards require fdt,
+and zlib is `required: true`).
+
+**Measured, without a build:** every one of those 69 flag tokens is accepted by
+the pinned tag. Checked against the fork's own generated
+`scripts/meson-buildoptions.sh` and `configure`'s case list at
+`esp-develop-9.2.2-20260417` — an unrecognised option is `ERROR: unknown
+option`, so this is the failure mode the "not done here" note was worried about,
+and it is now excluded statically rather than hoped away.
+
+**NOT measured:** what the resulting ldd closure is. That still needs
+`nros setup --tool esp32-qemu` + `check-dist-runtime-deps`, exactly as "How to
+verify a fix" says. The issue therefore stays open until someone rebuilds.
+
+## Two corrections to the reasoning above
+
+**`--audio-drv-list=` alone would not have worked.** `audio/meson.build` at the
+pinned tag builds an audio module for every driver whose dependency `.found()`
+— `foreach m : [['alsa', alsa, …], ['pa', pulse, …], …] if m[1].found()` — and
+not for the drivers named in `audio_drv_list`. An empty list changes
+`CONFIG_AUDIO_DRIVERS`, i.e. what the RUNTIME selects, and leaves libasound and
+libpulse (with libpulse's libsndfile/FLAC/vorbis/ogg/X11 tail) linked. The
+per-driver `--disable-alsa --disable-pa --disable-jack --disable-oss
+--disable-sndio --disable-pipewire` is what cuts the link surface, and once they
+are off the default list resolves to empty anyway — so the flag the fix
+prescribed is redundant, not merely insufficient, and is not in the new line.
+
+**The control table compares two different things.** `[tool.qemu]`'s
+`system = [..]` is 2 because its DIST bundles its closure into `lib/` with
+`RUNPATH=$ORIGIN/../lib` (18 libs; the `-nros6` comment in the index measures
+external closure 20 → 2), not because its configure is tighter.
+`[tool.qemu.source]`'s configure says nothing about audio, curl or tools' block
+drivers either — it is the same auto-detection, and `ci/nano-ros-sdk/scripts/
+build-qemu.sh` mirrors it flag for flag. The real difference is that qemu ships
+a dist for the three host keys and esp32-qemu ships none, so nobody but the
+release job runs qemu's configure while EVERY esp32 user runs this one. That is
+the property the new gate keys on.
+
+## Gate coverage (issue-0196 rule)
+
+`check-dist-runtime-deps` does cover this tool — a source build installs into
+the same `<store>/<tool>/<version>` it walks, which is how the 69 were found —
+but only AFTER a provision, and CI never provisions esp32-qemu. So the gate
+could not have caught the defect, and cannot catch a future flag deletion
+either. `scripts/sdk/check-qemu-source-features.py` (wired into
+`just check sdk-index` and the `sdk-index` job in `gate.yml`) is the static
+half: for a `[tool.*]` whose `source.git` names qemu, whose `source.configure`
+runs `./configure`, and which publishes NO `dist.*`, every host-library feature
+must be pinned by name. `[tool.qemu]` is exempt because it has a dist. Negative
+control run: against this file's pre-fix revision the gate reports 55 of its 58
+host-library features unpinned and exits 1; against the new one it passes.

--- a/just/check.just
+++ b/just/check.just
@@ -2999,10 +2999,17 @@ no-std:
 
 # Verify nros-sdk-index.toml + the QEMU configure flags
 # (the `sdk-index` job in .github/workflows/gate.yml). Buildless + fast.
+#
+# The third one is issue 1006: a qemu recipe with no `dist` is source-built by
+# EVERY user, so a backend it leaves auto-detected makes the runtime dependency
+# set a property of that user's machine. `check-dist-runtime-deps` can only see
+# that after a provision (and CI never provisions esp32-qemu), so the static
+# half lives here.
 [group("ci")]
 sdk-index:
     python3 scripts/sdk/verify-index.py nros-sdk-index.toml
     ./scripts/sdk/check-qemu-configure.sh
+    python3 scripts/sdk/check-qemu-source-features.py nros-sdk-index.toml
 
 # #310 — gate the in-tree cli sub-workspace's rustfmt-cleanliness (it is outside
 # the root workspace that `check-workspace`'s `cargo fmt --check` covers).

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -379,12 +379,21 @@ version = "esp-develop-nros1"
 # applied to source recipes; probed BEFORE the build so the failure names
 # packages).
 #
-# The rest are RUNTIME sonames the built binary links unconditionally, found by
+# The rest are RUNTIME sonames the built binary linked, found by
 # `check-dist-runtime-deps` against a source build of this very recipe. Each was
 # already a `[prereq.*]` key; only this list was missing them, which is the
-# hand-authored half issue 0926 named. They are core (zlib, pcre2, selinux,
-# tinfo, openssl via glib and qemu's block layer), not optional backends, so
-# they hold for any build of this recipe on any host.
+# hand-authored half issue 0926 named.
+#
+# They were called core, and three of them are NOT — read off the fork's own
+# `meson.build` at the pinned tag (issue 1006). Unconditional: `zlib`
+# (`dependency('zlib', required: true)`) and `pcre2` (glib's transitive).
+# `selinux` and curses -> `libtinfo` are AUTO-DETECTED features like every other
+# backend, and qemu links no openssl anywhere in `meson.build` at all — `libssl3`
+# arrived through libcurl/libssh, which the `configure` below now disables BY
+# NAME. So those three are expected to leave the closure on the next rebuild.
+# They stay declared until one happens: `check-dist-runtime-deps` checks
+# COVERAGE, not minimality, so an over-declaration is safe, while deleting them
+# without a re-measure would be a guess.
 system = [
     "libglib2-dev",
     "libpixman-dev",
@@ -411,7 +420,43 @@ ref = "esp-develop-9.2.2-20260417"
 # alternative (patching upstream C in a vendored fork we do not maintain) is
 # strictly worse. `[tool.qemu]` does not need it — it is 11.0.0 and normally
 # arrives as a prebuilt `dist`.
-configure = "./configure --target-list=riscv32-softmmu --prefix={prefix} --enable-gcrypt --enable-slirp --disable-werror --disable-strip --disable-user --disable-capstone --disable-vnc --disable-gtk --disable-sdl --disable-docs"
+#
+# issue 1006 — THE REST OF THIS LINE IS A LINK-SURFACE PIN, not taste. qemu's
+# configure AUTO-DETECTS every optional backend: a feature whose `--enable-`/
+# `--disable-` is not passed stays `auto`, so `dependency(..., required:
+# get_option(<f>))` resolves against whatever dev headers the BUILD HOST happens
+# to carry and the binary links them. This recipe is source-built with NO dist —
+# every user runs it — so an unpinned feature makes the runtime dependency set a
+# property of the machine rather than of the recipe. Measured:
+# `check-dist-runtime-deps` against a source build here found 69 sonames no
+# `[prereq.*]` declares (audio, X11, curl/ssh/usb/dbus), which is exactly why
+# DECLARING them would have recorded one host's accident as a contract.
+#
+# What is left reachable is what `-M esp32c3 -icount 3 -nographic -drive
+# file=...,if=mtd,format=raw -nic user,model=open_eth` needs (the invocation in
+# `scripts/esp32/launch-esp32c3.sh` and `nros-tests/src/esp32.rs`): TCG, the raw
+# block layer, slirp, and gcrypt for the fork's secure-boot crypto. The rest is
+# off BY NAME, in groups: UI, audio, host-device passthrough, network/format
+# block drivers, TLS, and the remaining host libraries.
+#
+# NOT `--audio-drv-list=` on its own, which is the fix the issue prescribed and
+# which the tag REFUTES: `audio/meson.build` builds a module for every driver
+# whose dependency `.found()`, not for the ones named in `audio_drv_list`, so an
+# empty list only changes `CONFIG_AUDIO_DRIVERS` and leaves libasound/libpulse
+# (and libpulse's libsndfile/FLAC/vorbis/ogg/X11 tail) linked. The per-driver
+# `--disable-alsa --disable-pa ...` is what cuts them, and with all of them off
+# the default list resolves to empty anyway, so the list flag buys nothing.
+#
+# Every flag token here is ACCEPTED BY THIS TAG — checked against the fork's own
+# generated `scripts/meson-buildoptions.sh` and configure's case list at
+# `esp-develop-9.2.2-20260417`, where an unrecognised option is `ERROR: unknown
+# option`, a hard configure failure. What the resulting closure actually is
+# stays UNMEASURED until someone runs `nros setup --tool esp32-qemu` and re-runs
+# `check-dist-runtime-deps` (this recipe was not rebuilt to land the pin).
+#
+# Left auto DELIBERATELY: fdt (the riscv boards require it), pixman, zlib
+# (`required: true`), and the slirp/gcrypt pair enabled above.
+configure = "./configure --target-list=riscv32-softmmu --prefix={prefix} --enable-gcrypt --enable-slirp --disable-werror --disable-strip --disable-user --disable-capstone --disable-docs --disable-tools --disable-guest-agent --disable-gtk --disable-vnc --disable-sdl --disable-sdl-image --disable-curses --disable-spice --disable-spice-protocol --disable-dbus-display --disable-opengl --disable-virglrenderer --disable-png --disable-vte --disable-xkbcommon --disable-alsa --disable-pa --disable-jack --disable-oss --disable-sndio --disable-pipewire --disable-libusb --disable-usb-redir --disable-smartcard --disable-u2f --disable-canokey --disable-brlapi --disable-libudev --disable-mpath --disable-curl --disable-libssh --disable-rbd --disable-glusterfs --disable-libiscsi --disable-libnfs --disable-blkio --disable-fuse --disable-gnutls --disable-seccomp --disable-cap-ng --disable-attr --disable-virtfs --disable-numa --disable-selinux --disable-libdw --disable-libcbor --disable-libkeyutils --disable-auth-pam --disable-vde --disable-af-xdp --disable-bpf --disable-linux-aio --disable-linux-io-uring --disable-libpmem --disable-libdaxctl --disable-zstd --disable-lzo --disable-snappy --disable-bzip2 --disable-lzfse"
 install = "ninja -C build -j$(nproc) && ninja -C build install"
 
 # issue 0486 — espflash packs an ELF into the ESP32 flash image the QEMU runner

--- a/scripts/check-python-deps.py
+++ b/scripts/check-python-deps.py
@@ -112,7 +112,7 @@ GROUPS = {
         ],
     ),
     "sdk-tools": (
-        "scripts/sdk/verify-index.py on Python older than 3.11 (needs tomllib)",
+        "scripts/sdk/{verify-index,check-qemu-source-features}.py on Python older than 3.11 (needs tomllib)",
         [("tomllib", "tomli")],
     ),
     # issue 0885 — the DEV utilities: tools a contributor runs, not a build.

--- a/scripts/sdk/check-qemu-source-features.py
+++ b/scripts/sdk/check-qemu-source-features.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""A qemu recipe every user SOURCE-BUILDS must pin its optional backends.
+
+WHY THIS EXISTS
+
+qemu's configure auto-detects: a feature whose `--enable-`/`--disable-` is not
+passed stays `auto`, and `dependency(..., required: get_option(<f>))` then
+resolves against whatever dev headers the BUILD HOST carries. The binary links
+what it found. For a recipe that ships a `dist` this is survivable — the release
+job bundles the closure and the pin is the tarball — but `[tool.esp32-qemu]` has
+NO dist, so every user runs the recipe on their own machine and the runtime
+dependency set becomes a property of that machine.
+
+Issue 1006 measured the consequence: `check-dist-runtime-deps` against a source
+build of `[tool.esp32-qemu]` found 69 sonames no `[prereq.*]` declares — audio,
+X11, curl/ssh/usb/dbus — none of which a headless `-M esp32c3 -nographic`
+emulator ever uses. Declaring them was the WRONG fix (they are one host's
+accident); pinning the configure is the right one.
+
+WHY IT IS NOT `check-dist-runtime-deps`
+
+That gate re-measures a PROVISIONED store, so it can only speak on a host that
+has already built the tool — and CI never provisions esp32-qemu (nightly-only).
+That is why the gap sat unnoticed. This gate reads the index instead, so it
+answers on every host, before any build, and it is what stops the flags being
+dropped again.
+
+WHAT IT CHECKS
+
+For every `[tool.<name>]` whose `source.git` names a qemu repository and whose
+`source.configure` invokes `./configure`, AND which publishes no `dist.*`:
+every feature in HOST_LIB_FEATURES must appear in that configure line as either
+`--disable-<f>` or `--enable-<f>`. Enable counts: the rule is that the RECIPE
+decides, not the host. A recipe WITH a dist is exempt and reported as such.
+
+KNOWN NARROWING, stated rather than papered over: the dist exemption is about
+who RUNS the configure, and it is not airtight. `nros setup` falls back to the
+source build on a host key the tool publishes no dist for, so a dist-carrying
+recipe can still be source-built by a user on, say, linux-riscv64 — with the
+same host-dependent result. The exemption is kept because the alternative is
+demanding flags on `[tool.qemu.source]`, whose second copy
+(`ci/nano-ros-sdk/scripts/build-qemu.sh`, kept identical by
+`check-qemu-configure.sh`) builds the PUBLISHED dist and cannot be changed
+without a release build to verify it. Tighten this when someone can rebuild it.
+
+HOST_LIB_FEATURES is the subset of qemu's feature options that reach for a
+system library. It is hand-maintained (qemu's option set moves between
+releases); adding a feature here is a ratchet, and a new one that a source-only
+recipe leaves unpinned is the defect this gate names.
+
+Usage:  check-qemu-source-features.py [nros-sdk-index.toml]
+"""
+
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Grouped as the recipe's own comment groups them, so the two read together.
+HOST_LIB_FEATURES = [
+    # UI — nothing but `-nographic` is ever passed.
+    "gtk", "vnc", "sdl", "sdl-image", "curses", "spice", "spice-protocol",
+    "dbus-display", "opengl", "virglrenderer", "png", "vte", "xkbcommon",
+    # Audio. Per-driver, NOT `--audio-drv-list=`: audio/meson.build builds a
+    # module for every driver whose dependency `.found()`, so the list option
+    # does not touch the link surface.
+    "alsa", "pa", "jack", "oss", "sndio", "pipewire",
+    # Host-device passthrough.
+    "libusb", "usb-redir", "smartcard", "u2f", "canokey", "brlapi", "libudev",
+    "mpath",
+    # Block drivers beyond the raw file the emulator boots.
+    "curl", "libssh", "rbd", "glusterfs", "libiscsi", "libnfs", "blkio", "fuse",
+    # TLS (gcrypt is the crypto backend and is enabled deliberately).
+    "gnutls",
+    # Remaining host libraries.
+    "seccomp", "cap-ng", "attr", "virtfs", "numa", "selinux", "libdw",
+    "libcbor", "libkeyutils", "auth-pam", "vde", "af-xdp", "bpf", "linux-aio",
+    "linux-io-uring", "libpmem", "libdaxctl", "zstd", "lzo", "snappy", "bzip2",
+    "lzfse",
+]
+
+
+def load(path):
+    try:
+        import tomllib as toml
+    except ModuleNotFoundError:
+        import tomli as toml
+    with open(path, "rb") as fh:
+        return toml.load(fh)
+
+
+def unpinned(configure, features=HOST_LIB_FEATURES):
+    """Features the configure line leaves to auto-detection."""
+    tokens = set(configure.split())
+    return [
+        f
+        for f in features
+        if f"--disable-{f}" not in tokens and f"--enable-{f}" not in tokens
+    ]
+
+
+def audit(index):
+    """[(tool, [unpinned features])] for every source-only qemu recipe."""
+    problems, seen = [], []
+    for name, tool in sorted(index.get("tool", {}).items()):
+        source = tool.get("source") or {}
+        git = source.get("git", "")
+        configure = source.get("configure", "")
+        if "qemu" not in git or "./configure" not in configure:
+            continue
+        if tool.get("dist"):
+            # A dist means the release job's build is what users get; its
+            # closure is pinned by the tarball, not by this line.
+            seen.append((name, "has dist — exempt"))
+            continue
+        missing = unpinned(configure)
+        seen.append((name, "source-only" + (f" — {len(missing)} unpinned" if missing else " — pinned")))
+        if missing:
+            problems.append((name, missing))
+    return problems, seen
+
+
+def self_test():
+    """Prove the check can fail — a negative control nobody runs is a comment."""
+    pinned = "./configure --disable-" + " --disable-".join(HOST_LIB_FEATURES)
+    checks = [
+        ("a fully pinned line is clean", unpinned(pinned) == []),
+        ("a bare line is entirely unpinned", unpinned("./configure") == HOST_LIB_FEATURES),
+        ("--enable- counts as pinned", unpinned("./configure --enable-curl", ["curl"]) == []),
+        (
+            "a source-only qemu recipe with a bare configure is a problem",
+            audit(
+                {
+                    "tool": {
+                        "t": {"source": {"git": "https://x/qemu", "configure": "./configure"}}
+                    }
+                }
+            )[0]
+            != [],
+        ),
+        (
+            "the same recipe WITH a dist is exempt",
+            audit(
+                {
+                    "tool": {
+                        "t": {
+                            "dist": {"linux-x86_64": {}},
+                            "source": {"git": "https://x/qemu", "configure": "./configure"},
+                        }
+                    }
+                }
+            )[0]
+            == [],
+        ),
+        (
+            "a non-qemu source recipe is out of scope",
+            audit({"tool": {"t": {"source": {"git": "https://x/dtc", "configure": "./configure"}}}})[0]
+            == [],
+        ),
+    ]
+    bad = [name for name, ok in checks if not ok]
+    if bad:
+        for b in bad:
+            print(f"check-qemu-source-features self-test: FAIL {b}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, "nros-sdk-index.toml")
+    problems, seen = audit(load(path))
+    if problems:
+        print(
+            "check-qemu-source-features: a qemu recipe every user source-builds "
+            "leaves backends to\nauto-detection, so its runtime dependency set is "
+            "the build HOST's, not the recipe's:\n",
+            file=sys.stderr,
+        )
+        for tool, missing in problems:
+            print(f"  [tool.{tool}.source] unpinned: {' '.join(missing)}", file=sys.stderr)
+        print(
+            "\n  Pass `--disable-<f>` (or `--enable-<f>` if the recipe really wants it)\n"
+            "  for each. Issue 1006: an unpinned build linked 69 sonames no [prereq.*]\n"
+            "  declares, and declaring THOSE records one host's accident as a contract.",
+            file=sys.stderr,
+        )
+        return 1
+    detail = "; ".join(f"{n}: {why}" for n, why in seen) or "no qemu source recipes"
+    print(f"check-qemu-source-features OK — {detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    self_test()
+    sys.exit(main())


### PR DESCRIPTION
Phase-423. `[tool.esp32-qemu]` is source-built with **no dist**, so every user runs
its `configure` on their own machine — and qemu's configure auto-detects: a
feature whose `--enable-`/`--disable-` is not passed stays `auto`, so
`dependency(..., required: get_option(<f>))` resolves against whatever dev headers
the build host carries. **55 host-library features were unpinned**, which is the
69 undeclared sonames #1006 reported.

The link surface is now the recipe's, not the host's: **12 flags → 69**, in six
groups (UI, audio, host-device passthrough, block drivers beyond the raw image,
TLS, remaining host libs). `--enable-gcrypt`, `--enable-slirp`,
`--target-list=riscv32-softmmu` and `--disable-werror` are untouched; `fdt`,
`pixman` and `zlib` are deliberately left auto (riscv boards require fdt; zlib is
`required: true`).

## Verified without a build

**All 65 disable flags are accepted at the pinned tag.** This is the load-bearing
safety property — an unknown option is `ERROR: unknown option`, a hard failure,
and it is exactly the risk the issue cited for *not* doing this. Checked twice,
independently: by the agent against the fork's generated
`scripts/meson-buildoptions.sh` and `configure`, and again by me fetching both
files from `espressif/qemu@esp-develop-9.2.2-20260417` and matching all 65. Zero
unknown.

**The issue's own prescription would not have worked.** It suggested
`--audio-drv-list=`; `audio/meson.build` builds a module for every driver whose
dependency `.found()`, *not* for the ones in that list, so the empty list only
changes `CONFIG_AUDIO_DRIVERS`. The per-driver `--disable-alsa/pa/jack/oss/sndio/
pipewire` is what cuts the link — and with those off the default list is empty
anyway, so the prescribed flag is redundant and is not in the new line.

**Three of the five "safe on any build" entries are not.** Only `zlib` is
`required: true`; `pcre2` is glib's transitive. `selinux` and curses→`libtinfo`
are ordinary auto features, and the fork's `meson.build` references **no openssl
at all** — `libssl3` arrived via libcurl/libssh. They stay declared (the gate
checks coverage, not minimality) with the comment corrected; deleting them without
a re-measure would be a guess.

**Why the two recipes differ is not the configure.** `[tool.qemu.source]` is
*equally* unpinned; its `system = 2` comes from its dist bundling its closure. The
real difference is that nobody but the release job runs qemu's configure, while
every esp32 user runs this one. The issue's control table is misleading on this
and the doc now says so.

## New gate, with a negative control

`check-qemu-source-features.py`, wired into `just check sdk-index` and gate.yml: a
`[tool.*]` whose source is qemu, whose configure runs `./configure`, and which
publishes no dist must pin every host-library feature by name. Green after the
fix; **exit 1 with 55 of 58 unpinned against the pre-fix revision.**

Its narrowing is in the docstring rather than hidden: a dist-carrying recipe still
source-builds on a host key with no dist, and tightening that means editing
`build-qemu.sh`, which needs a release build to verify.

## Unverified — and why the issue stays open

The resulting `ldd` closure. Only `nros setup --tool esp32-qemu` +
`check-dist-runtime-deps` answers that, esp32-qemu is not provisioned on this host,
and CI never provisions it — which is also why the existing gate could not have
caught this. Which soname each disable drops is inferred from Debian's link graph.
That the full 69-flag configure *completes* is argued (every `error_message:` line
checked) but not run.

`status: open` deliberately: the issue's own acceptance needs a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
