### PR TITLE
docs(phase-206): its foundation was removed by three unrelated retirements

### DIFF
--- a/docs/roadmap/phase-206-multi-homing-transport-interfaces.md
+++ b/docs/roadmap/phase-206-multi-homing-transport-interfaces.md
@@ -5,8 +5,46 @@ common "node reachable on multiple interfaces" need that stock DDS/zenoh do
 natively. Turn the already-plumbed `[[transport]].interfaces` list into real
 per-backend NIC binding.
 
-**Status.** Proposed (2026-05-29). Extracted from Phase 172.K.7 (archived) — its
-schema + plumbing half landed; this phase is the deferred **wire-emission** half.
+**Status (2026-09-04). Proposed, and its foundation is GONE.** Still unstarted
+as proposed 2026-05-29 — but the "Landed" section below is no longer true, and
+the way it stopped being true is the useful part.
+
+**172.K.7's half really did land. Three separate retirements took most of it
+back, and none of them knew it.**
+
+| landed 2026-05-29 | removed by | when |
+| --- | --- | --- |
+| generator emits `c.set_interfaces(&[…])`, + the test `multi_homed_interfaces_emit_set_interfaces_call` | `11a00b0f8` — #202, "retire the dead standalone-package pipeline" (it deleted `orchestration/generate.rs` whole) | 2026-07-16 |
+| `NanoRosConfig.cmake` + `NanoRosReadConfig.cmake` parsing `interfaces` → `NROS_CONFIG_INTERFACES` | `f473b78b4` / `53f2ddce7` — phase-212 M-F.10, "retire cmake codegen of `NROS_APP_CONFIG`" | phase-212 |
+| the `config.toml` readers those parsers lived in | phase-256 W9, the legacy `config.toml` reader removal | — |
+
+Each retirement had a good local reason and each was right on its own terms.
+Together they dismantled this phase one plank at a time, and nobody updating
+those commits was looking at this doc.
+
+**What actually survives, verified on `main` 2026-09-04:**
+
+* `PlanTransport.interfaces: Vec<String>` — `orchestration/plan.rs:684`
+* its ethernet/wifi-only validation — `plan.rs:854-856`
+* its copy into the IR — `model_ingest.rs:1457`
+* three of the four tests — `plan.rs:1022, 1036, 1052`, all **parse/validate
+  only**; none tests emission, because there is no emission
+* `BoardTransportConfig::set_interfaces` — `nros-platform/src/board/config.rs:108`,
+  a default no-op with **zero overrides and zero call sites tree-wide**
+
+So the value parses, validates, reaches the IR, is written into
+`<bake>/nros-plan.json` — **and is read by nothing.** `nros explain` cannot even
+print it (`explain.rs:384-396` prints `ip`/`device`/`baudrate` only).
+
+**This phase is now an instance of the class it would have to fix.** phase-349
+names the shape while flagging its sibling: `NROS_NETSTACK` is *"emitted too …
+and nothing reads it — the same declared-but-unread shape."* `set_interfaces` is
+the second live instance. Any revival that adds another declaration without a
+consumer repeats the defect.
+
+*Original status, 2026-05-29:* Proposed. Extracted from Phase 172.K.7 (archived)
+— its schema + plumbing half landed; this phase is the deferred
+**wire-emission** half.
 
 **Priority.** P2 — no shipped capability depends on it; meaningful only once a
 multi-NIC target exists. Cyclone is the one backend where it's both meaningful
@@ -18,9 +56,12 @@ Cyclone build path) for the Cyclone config seam (206.3).
 ## Overview
 
 `[[transport]].interfaces = ["eth0", "eth1"]` already parses → `PlanTransport.interfaces:
-Vec<String>`, validates (ethernet/wifi only), and the generator emits a no-op
-`BoardTransportConfig::set_interfaces(&[…])` board-Config call; both CMake parsers
-accept the TOML array. **But nothing binds an actual NIC yet** — the seam is inert.
+Vec<String>` and validates (ethernet/wifi only). **The rest of this paragraph
+was true in May and is not now** — there is no generator emitting
+`set_interfaces` and there are no CMake parsers; see the status table above.
+**Nothing binds an actual NIC**, and the seam is not merely inert, it is
+unreachable: the only surviving consumer of the parsed value is the serializer
+that writes it into `<bake>/nros-plan.json`.
 
 Three blockers gate real binding, in dependency order: a multi-endpoint runtime
 `SessionSpec` (206.1), the per-backend mapping (206.2 zenoh decision, 206.3
@@ -31,18 +72,41 @@ is *merge* — one session, many NICs.
 Design: [`docs/design/0004-configuration-and-transports.md`](../design/0004-configuration-and-transports.md)
 ("Two axes" taxonomy, cases B/C).
 
-## Landed (Phase 172.K.7 schema + plumbing, 2026-05-29)
+## Landed (Phase 172.K.7 schema + plumbing, 2026-05-29) — MOSTLY SINCE REMOVED
 
-- `PlanTransport.interfaces: Vec<String>` (serde default, skip-when-empty);
+Read this list as the record of what K.7 built, not as the state of the tree.
+The status table above says what took each piece back; **✓** survives, **✗**
+does not.
+
+- **✓** `PlanTransport.interfaces: Vec<String>` (serde default, skip-when-empty);
   `validate_transports` rejects it on serial/can (ethernet/wifi only).
-- Generator emits `c.set_interfaces(&[…])` (mirrors `set_ssid`/`set_mac`), backed
-  by a default-no-op `BoardTransportConfig::set_interfaces` seam.
-- Both CMake parsers (`NanoRosConfig.cmake`, nros-c `NanoRosReadConfig.cmake`)
+  (`plan.rs:684`, `:854-856`)
+- **✗** Generator emits `c.set_interfaces(&[…])` (mirrors `set_ssid`/`set_mac`),
+  backed by a default-no-op `BoardTransportConfig::set_interfaces` seam.
+  — the generator went with `orchestration/generate.rs` in `11a00b0f8`. The
+  no-op trait method survives with no callers; `set_ssid` and `set_mac` lost
+  their emitters in the same commit, so all three are dead together.
+- **✗** Both CMake parsers (`NanoRosConfig.cmake`, nros-c `NanoRosReadConfig.cmake`)
   accept `interfaces = ["eth0","eth1"]` (legacy scalar `interface` mirrored in) →
   `NROS_CONFIG_INTERFACES` list var.
-- Tests: `transport_tests::{multi_homed_interfaces_parse_and_validate,
+  — both files are gone; `NROS_CONFIG_INTERFACES` appears in no source or build
+  output today, only in this doc and archived phase-172.
+- **✓/✗** Tests: `transport_tests::{multi_homed_interfaces_parse_and_validate,
   interfaces_absent_round_trips_empty_and_skips_serialization,
-  interfaces_are_ethernet_wifi_only}` + `multi_homed_interfaces_emit_set_interfaces_call`.
+  interfaces_are_ethernet_wifi_only}` **survive** (`plan.rs:1022, 1036, 1052`) —
+  `multi_homed_interfaces_emit_set_interfaces_call` **does not**, deleted with
+  `tests/orchestration_e2e.rs` in `11a00b0f8`.
+
+> **Anyone reviving this phase should re-plan rather than resume.** 206.2 and
+> 206.3 below name a "generator `set_interfaces` seam" as the thing to emit
+> from, and that seam does not exist — an hour spent looking for it is the
+> predictable cost of leaving this section unmarked. The surviving architecture
+> reaches a backend by other routes (the RFC-0049 knob ladder already carries
+> `NROS_BOARD_TOML` into `nros-zpico-build`), and the per-backend picture has
+> changed too: zenoh-pico is structurally a client with one locator (peer mode
+> is refused, `MULTICAST_TRANSPORT = false`), which bears directly on 206.2's
+> open decision. None of that is decided here; this note only records that the
+> plan below is written against a tree that no longer exists.
 
 ## Architecture
 


### PR DESCRIPTION
**Status line and evidence only — no re-planning.** phase-206's "Landed" section
describes a seam that is gone.

The section was **accurate when written.** 172.K.7 really did land all of it on
2026-05-29. Three separate cleanups took most of it back, and none of them knew
this doc existed:

| landed 2026-05-29 | removed by |
| --- | --- |
| generator emitting `c.set_interfaces(&[…])`, + the test `multi_homed_interfaces_emit_set_interfaces_call` | `11a00b0f8` — #202, *"retire the dead standalone-package pipeline"* (deleted `orchestration/generate.rs` whole), 2026-07-16 |
| `NanoRosConfig.cmake` + `NanoRosReadConfig.cmake` parsing `interfaces` → `NROS_CONFIG_INTERFACES` | `f473b78b4` / `53f2ddce7` — phase-212 M-F.10, *"retire cmake codegen of `NROS_APP_CONFIG`"* |
| the `config.toml` readers those parsers lived in | phase-256 W9 |

Each was right on its own terms. Together they dismantled the phase one plank at
a time.

## What survives, verified on `main`

* `PlanTransport.interfaces: Vec<String>` — `plan.rs:684`
* ethernet/wifi-only validation — `plan.rs:854-856`
* copy into the IR — `model_ingest.rs:1457`
* three of four tests — `plan.rs:1022, 1036, 1052`, all **parse/validate**; none
  tests emission, because there is no emission
* `BoardTransportConfig::set_interfaces` — `config.rs:108`, default no-op,
  **zero overrides and zero call sites tree-wide**

The value parses, validates, reaches the IR, is serialized into
`<bake>/nros-plan.json` — and is read by nothing. `nros explain` cannot print it
(`explain.rs:384-396`).

## The phase is now an instance of the class it would have to fix

phase-349 already names the shape on its sibling: `NROS_NETSTACK` is *"emitted
too … and nothing reads it — the same declared-but-unread shape."*
`set_interfaces` is the second live instance. That is the constraint on any
revival: a design that adds another declaration without a consumer repeats the
defect.

## Scope

206.2 / 206.3 still name a generator seam that no longer exists. The section now
says so, and warns that reviving means **re-planning rather than resuming** — so
the next reader does not spend an hour looking for it. One per-backend fact is
recorded because it bears on 206.2's open decision (zenoh-pico is structurally a
client with one locator; peer mode is refused, `MULTICAST_TRANSPORT = false`)
**without deciding it.**

Original wordings kept inline, per the house rule that a phase doc is a living
record rather than a status field.

## A correction carried in the commit

An earlier reading — *"`NROS_CONFIG_INTERFACES` never existed"* — is **wrong**,
and the doc says so. Absence from the tree today is not the same claim as never
present: `git log -S` finds it added by `f66a30b78` (172.K.7) alongside a 22-line
`cmake/NanoRosConfig.cmake` and a 23-line `NanoRosReadConfig.cmake`. That
distinction is what turns this from "the doc invented a foundation" into "the
foundation was removed underneath it", which is a different lesson.

## Verification

    check-doc-refs        OK
    check-roadmap-claims  OK — 0 findings
    check-book-links      OK — 706 relative links in 123 pages
    pre-push fast tier    green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
