### PR TITLE
test(#1017): the session name must come FROM THE NODE, at all five cmake sites

### DIFF
--- a/docs/issues/archived/1017-entry-template-session-name-ungated.md
+++ b/docs/issues/archived/1017-entry-template-session-name-ungated.md
@@ -118,3 +118,55 @@ distinct images get distinct names; a producer that passed the same constant
 everywhere would satisfy it. That is the shape this issue argued would have
 caught the original bug without anyone knowing the templates existed, and it
 still needs a runtime cell.
+
+
+## 2026-09-04 — the reachable half of the behavioural property is now guarded
+
+The section above says the check proves a name is PASSED, not that names are
+DISTINCT, and that "a producer that passed the same constant everywhere would
+satisfy it". That hole is now partly closed, and the part that closed it was not
+where I expected.
+
+Distinctness is not a property of the templates at all — they substitute
+`@NROS_ENTRY_NODE_NAME@`, and whether two images differ depends on what CMake
+puts there. `NanoRosNodeRegister.cmake` sets it from the node's own name, in
+**five separate places**, one per entry shape:
+
+    set(NROS_ENTRY_NODE_NAME "${_NRC_NAME}")
+
+Five spellings of one fact — the shape this campaign is named for. If ONE
+drifted to a literal, every image built through that entry shape would share a
+name, the templates would still reference the variable, and the existing check
+would still pass. That is the hole, and it is reachable statically.
+
+`check-entry-session-name` now asserts every site takes the node's own name, and
+reports the count it verified:
+
+    check-entry-session-name: OK (13 generated call(s) name a session;
+                                  5 cmake site(s) take it from the node)
+
+Non-vacuous by mutation on the real file: changing site 683 to
+`set(NROS_ENTRY_NODE_NAME "node")` fails the check, naming the assignment.
+Four selftest cases cover it — name from the node, a constant, one-of-several
+drifted, and a commented-out assignment.
+
+**The selftest caught a bug in the check while I wrote it**, which is the reason
+that rule exists: `code_only()` strips `//` and `///` because its inputs are C++
+and Rust, so a commented-out `# set(NROS_ENTRY_NODE_NAME "node")` counted as a
+real site. `#` cannot be stripped globally without eating Rust attributes like
+`#[cfg(test)]`, so CMake needed its own strip.
+
+## Still NOT guarded, and the gap is narrower now
+
+The runtime property — two same-language images on ONE agent registering
+distinct names — remains untested. What is guarded is the whole static chain:
+the templates pass a name, and every CMake site takes that name from the node.
+What is not is the observation that two live images actually differ, which would
+also catch a defect anywhere below CMake (in the substitution, the boot config,
+or the transport's key derivation).
+
+The venue for it is `graph_interop.rs`'s harness — `graph-probe` already opens a
+session, polls `get_node_names` to convergence, and exits non-zero unless it
+sees a named peer. Two template-built entries plus that probe is the shape. It
+was not done here because those images are per-package workspace fixtures that
+must be prebuilt, which is a build this change does not otherwise need.

--- a/scripts/check-entry-session-name.py
+++ b/scripts/check-entry-session-name.py
@@ -117,6 +117,59 @@ def scan(text: str, marker: str, is_rust: bool) -> list[str]:
 
 
 # --------------------------------------------------------------------------
+# The other half: the name must be PER NODE (issue 1017)
+# --------------------------------------------------------------------------
+#
+# The check above proves a session name is PASSED. It cannot prove the names are
+# DISTINCT — a producer that passed the same constant everywhere would satisfy
+# it, and that is exactly the collision issue 1003 was: every image registering
+# as `"node"`.
+#
+# Distinctness is not a property of the templates. They substitute
+# `@NROS_ENTRY_NODE_NAME@`, and whether two images differ depends on what CMake
+# puts there. `NanoRosNodeRegister.cmake` sets it from the node's own name --
+# in FIVE separate places, one per entry shape:
+#
+#     set(NROS_ENTRY_NODE_NAME "${_NRC_NAME}")
+#
+# Five spellings of one fact, which is the shape this whole campaign is named
+# for. If ONE drifted to a literal, every image built through that shape would
+# share a name, the templates would still reference the variable, and the check
+# above would still pass. That is the hole.
+#
+# This does not replace the behavioural test issue 1017 asks for (two images on
+# one agent registering distinct names). It closes the reachable half: the name
+# comes from the node, at every site that sets it.
+
+_NODE_NAME_ASSIGN = re.compile(r'set\s*\(\s*NROS_ENTRY_NODE_NAME\s+([^)]*)\)')
+_EXPECTED_SOURCE = "${_NRC_NAME}"
+
+
+def cmake_code_only(text: str) -> str:
+    """Drop CMake comments.
+
+    `code_only` strips `//` and `///` because its inputs are C++ and Rust; CMake
+    comments start with `#`, and `#` cannot be stripped globally without eating
+    Rust attributes like `#[cfg(test)]`. Found by the selftest: a commented-out
+    `# set(NROS_ENTRY_NODE_NAME "node")` was being counted as a real site."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def node_name_assignments(text: str) -> list[str]:
+    """Every `set(NROS_ENTRY_NODE_NAME ...)` value, comments excluded."""
+    return [
+        m.group(1).strip() for m in _NODE_NAME_ASSIGN.finditer(cmake_code_only(text))
+    ]
+
+
+def check_node_name_is_per_node(text: str) -> list[str]:
+    """Assignments that do NOT take the node's own name."""
+    return [v for v in node_name_assignments(text) if _EXPECTED_SOURCE not in v]
+
+
+# --------------------------------------------------------------------------
 # selftest — runs on the NORMAL path, never behind a flag (phase-395)
 # --------------------------------------------------------------------------
 #
@@ -169,6 +222,26 @@ def self_test(quiet: bool = True) -> int:
         ("rust string continuation", _RS_CONTINUATION, "nros_boot_config_node_name", True, False),
         ("rust test-only mention", _RS_TEST_ONLY, "nros_boot_config_node_name", True, False),
     ]
+
+    # The per-node half (issue 1017). A constant here collides every image built
+    # through that entry shape while the templates stay correct — the hole the
+    # call check above cannot see.
+    name_cases: list[tuple[str, str, bool]] = [
+        ("name taken from the node", 'set(NROS_ENTRY_NODE_NAME "${_NRC_NAME}")', False),
+        ("name is a constant", 'set(NROS_ENTRY_NODE_NAME "node")', True),
+        (
+            "one of several sites drifted",
+            'set(NROS_ENTRY_NODE_NAME "${_NRC_NAME}")\n'
+            'set(NROS_ENTRY_NODE_NAME "entry")',
+            True,
+        ),
+        (
+            "a commented-out assignment is not a site",
+            '# set(NROS_ENTRY_NODE_NAME "node")\n'
+            'set(NROS_ENTRY_NODE_NAME "${_NRC_NAME}")',
+            False,
+        ),
+    ]
     bad = 0
     for name, text, marker, is_rust, expect in cases:
         got = bool(scan(text, marker, is_rust))
@@ -178,6 +251,15 @@ def self_test(quiet: bool = True) -> int:
             print(f"SELFTEST FAIL: {name}: expected {want}, got the opposite", file=sys.stderr)
         elif not quiet:
             print(f"  ok: {name}")
+    for name, text, expect in name_cases:
+        got = bool(check_node_name_is_per_node(text))
+        if got != expect:
+            bad += 1
+            want = "a violation" if expect else "no violation"
+            print(f"SELFTEST FAIL: {name}: expected {want}, got the opposite", file=sys.stderr)
+        elif not quiet:
+            print(f"  ok: {name}")
+
     if bad:
         print(
             "check-entry-session-name: SELFTEST FAILED — the check cannot be "
@@ -185,7 +267,10 @@ def self_test(quiet: bool = True) -> int:
             file=sys.stderr,
         )
     elif not quiet:
-        print(f"check-entry-session-name selftest: OK ({len(cases)} case(s))")
+        print(
+            "check-entry-session-name selftest: OK "
+            f"({len(cases) + len(name_cases)} case(s))"
+        )
     return 1 if bad else 0
 
 
@@ -196,6 +281,47 @@ def main() -> int:
         return 2
     failures: list[str] = []
     checked = 0
+
+    # The name must also come FROM THE NODE at every site that sets it — see
+    # `check_node_name_is_per_node`. Checked first: if the name is a constant,
+    # every call below "passes" while every image collides.
+    reg = ROOT / "cmake/NanoRosNodeRegister.cmake"
+    if not reg.is_file():
+        print(
+            f"ERROR: {reg.relative_to(ROOT)} is missing — it is what makes the\n"
+            "       substituted name PER NODE, so this check cannot vouch for\n"
+            "       distinctness without it.",
+            file=sys.stderr,
+        )
+        return 2
+    reg_text = reg.read_text(encoding="utf8")
+    assigns = node_name_assignments(reg_text)
+    if not assigns:
+        print(
+            "ERROR: no `set(NROS_ENTRY_NODE_NAME ...)` in "
+            f"{reg.relative_to(ROOT)}.\n"
+            "       The templates substitute that variable; if nothing sets it\n"
+            "       the name is empty and every image shares it.",
+            file=sys.stderr,
+        )
+        return 2
+    bad = check_node_name_is_per_node(reg_text)
+    if bad:
+        print(
+            "check-entry-session-name: a session name is not taken from the "
+            "node (issue 1017):\n",
+            file=sys.stderr,
+        )
+        for v in bad:
+            print(f"  set(NROS_ENTRY_NODE_NAME {v})", file=sys.stderr)
+        print(
+            f"\n  Expected every site to use `{_EXPECTED_SOURCE}`. A constant "
+            "here gives\n  every image built through that entry shape the SAME "
+            "name, which is\n  issue 1003's collision with the templates left "
+            "correct.",
+            file=sys.stderr,
+        )
+        return 1
 
     for glob, marker, label in PRODUCERS:
         paths = sorted(ROOT.glob(glob))
@@ -265,7 +391,10 @@ def main() -> int:
         )
         return 2
 
-    print(f"check-entry-session-name: OK ({checked} generated call(s) name a session)")
+    print(
+        f"check-entry-session-name: OK ({checked} generated call(s) name a "
+        f"session; {len(assigns)} cmake site(s) take it from the node)"
+    )
     return 0
 
 


### PR DESCRIPTION
#1017's gate proved a session name is **passed**, and stated its own limit: *"a producer that passed the same constant everywhere would satisfy it."* This closes the reachable half of that — and the hole was not where I expected.

## Distinctness is not a property of the templates

They substitute `@NROS_ENTRY_NODE_NAME@`. Whether two images differ depends on what CMake puts there, and `NanoRosNodeRegister.cmake` sets it from the node's own name in **five separate places**, one per entry shape:

```cmake
set(NROS_ENTRY_NODE_NAME "${_NRC_NAME}")
```

Five spellings of one fact — this campaign's own defect. If **one** drifted to a literal, every image built through that entry shape would share a name, the templates would still reference the variable, and the existing check would still pass.

That is statically reachable, so it is now checked:

```
check-entry-session-name: OK (13 generated call(s) name a session;
                              5 cmake site(s) take it from the node)
```

The count is **reported rather than assumed** — a site that disappears is as much a regression as one that drifts, so "0 sites, all correct" must not read as OK. A missing `NanoRosNodeRegister.cmake`, or zero assignments in it, are hard errors for the same reason.

## Non-vacuous, by mutation on the real file

Changing site 683 to `set(NROS_ENTRY_NODE_NAME "node")` fails the check and names the assignment. Four selftest cases cover the class: name from the node, a constant, one-of-several drifted, and a commented-out assignment.

## The selftest earned itself immediately

It **failed on first run**, on a bug in my own check: `code_only()` strips `//` and `///` because its inputs are C++ and Rust, so a commented-out `# set(NROS_ENTRY_NODE_NAME "node")` counted as a real site. `#` cannot be stripped globally without eating Rust attributes like `#[cfg(test)]`, so CMake needed its own strip.

That is precisely what `check-gate-selftests` exists to force — *"a negative control nobody runs decays into a comment"* — and it caught me inside the gate written to close a class of unchecked assumptions.

## Still not guarded, with the gap narrowed

The **runtime** property — two same-language images on one agent registering distinct names — remains untested. What is covered now is the whole static chain: the templates pass a name, and every CMake site takes that name from the node. What is not is the observation that two live images actually differ, which would also catch a defect *below* CMake — in the substitution, the boot config, or the transport's key derivation.

The venue is `graph_interop.rs`'s harness: `graph-probe` already opens a session, polls `get_node_names` to convergence, and exits non-zero unless it sees a named peer. Two template-built entries plus that probe is the shape. Not done here because those are per-package workspace fixtures that must be prebuilt — a build this change does not otherwise need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
