### PR TITLE
fix(#1040): check-api-parity ran in no workflow — nightly signal, and a gate for the class

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -787,12 +787,27 @@ jobs:
       # `borrowed-e2e` since at least 2026-09-01 with nobody noticing, which is
       # issue 0993's whole thesis arriving on schedule. Filed separately; a lane
       # cannot start gating pull requests while it is already red.
-      - name: just check build + no_std (nightly / manual only)
+      - name: just check build + no_std + api-parity (nightly / manual only)
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |
           source ./activate.sh
           just check build
           just check no-std
+          # issue 1040 — `check-api-parity` ran in NO workflow at all. Not on
+          # pull_request, not on merge_group, not nightly, not on dispatch:
+          # `grep -rl api-parity .github/workflows/` returned nothing. It
+          # existed only as a local recipe, so an unclassified row was invisible
+          # until somebody happened to run the full tier — and three landed on
+          # main on 2026-09-04 alone.
+          #
+          # It belongs HERE and not on the merge gate: it re-extracts our own
+          # surface with clang and nightly rustdoc, which is why it is not on
+          # the fast line. Making it required is what deadlocked the queue when
+          # `check-build` was required with prerequisites no CI job builds
+          # (`check-lane-contracts` now forbids that shape). A daily signal on
+          # the lane that already has one costs nothing extra and is the whole
+          # gap.
+          just check api-parity
 
       # Aspirational umbrella-decoupling guard — EXPECTED TO FAIL until the
       # Phase 104.A migration completes. Advisory only. (Build tier, non-push.)

--- a/just/check.just
+++ b/just/check.just
@@ -149,6 +149,7 @@ fast-serial: \
     cyclone-backend-sources \
     cyclone-domain-not-pinned \
     declared-qos-header \
+    default-gates-run-somewhere \
     deploy-board-resolves \
     doc-recipe-refs \
     doc-refs \
@@ -1787,6 +1788,17 @@ board-cargo-config-applied:
 [private]
 generated-schema-coverage:
     @python3 scripts/check-generated-schema-coverage.py
+
+# issue 1040 — `check-api-parity` sat in `just check`'s DEFAULT list and ran in
+# NO workflow at all: not pull_request, not merge_group, not nightly, not
+# dispatch. Its reds were therefore invisible between local full-tier runs, and
+# three landed on main in a single day alongside four others.
+#
+# The bar is a DAILY signal, not a blocking one — `check-build` is
+# schedule/dispatch-only for good reason and must stay that way.
+[private]
+default-gates-run-somewhere:
+    @python3 scripts/check-default-gates-run-somewhere.py
 
 # `nros sync` skips the leaf with a count instead of a name. Buildless.
 [private]

--- a/scripts/check-default-gates-run-somewhere.py
+++ b/scripts/check-default-gates-run-somewhere.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Every gate in `just check`'s DEFAULT list must run in some workflow.
+
+issue 1040 — `check-api-parity` is in that list and ran in NO workflow at all.
+Not on `pull_request`, not on `merge_group`, not nightly, not on dispatch:
+
+    grep -rl api-parity .github/workflows/    ->  (nothing)
+
+It existed only as a local recipe, so an unclassified ledger row was invisible
+until somebody happened to run the full tier. Three landed on main on
+2026-09-04 alone, alongside two compile-tier reds and a NuttX break — seven in
+one day, every one found by a person running `just ci gate` rather than by CI.
+
+This does NOT require them to be merge-gating. `check-build` is deliberately
+`schedule`/`workflow_dispatch` only: it resolves artifacts no CI job builds, and
+making it required once turned every PR red for a day (`check-lane-contracts`
+now forbids that shape). A DAILY signal is the bar here, not a blocking one.
+
+Scope is deliberately the default list and nothing wider. Asking it of all ~200
+individual gates would flag most of them, because they run collectively via
+`just check fast` -- and a gate that fires on almost everything teaches people
+to ignore it.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHECK_JUST = ROOT / "just/check.just"
+WORKFLOWS = ROOT / ".github/workflows"
+
+
+def default_list():
+    """The recipes `just check` runs with no argument."""
+    for line in CHECK_JUST.read_text().splitlines():
+        m = re.match(r"^default:\s*(.+?)\s*$", line)
+        if m:
+            return m.group(1).split()
+    return []
+
+
+def workflow_mentions():
+    """Every `just check <name>` invoked by any workflow."""
+    found = set()
+    for wf in sorted(WORKFLOWS.glob("*.yml")):
+        for m in re.finditer(r"just check ([a-z0-9-]+)", wf.read_text()):
+            found.add(m.group(1))
+    return found
+
+
+def self_test():
+    """On the NORMAL path — a control nobody runs decays into a comment."""
+    ok = True
+    names = default_list()
+    if not names:
+        print("self-test FAILED: could not parse `default:` from check.just", file=sys.stderr)
+        ok = False
+    # the parse must find the real list, not an empty one that passes vacuously
+    if names and not all(re.fullmatch(r"[a-z0-9-]+", n) for n in names):
+        print(f"self-test FAILED: default list looks wrong: {names}", file=sys.stderr)
+        ok = False
+    mentions = workflow_mentions()
+    if not mentions:
+        print("self-test FAILED: no `just check` found in any workflow", file=sys.stderr)
+        ok = False
+    if ok:
+        print(
+            f"check-default-gates-run-somewhere self-test: OK "
+            f"({len(names)} default gate(s), {len(mentions)} mentioned in workflows)"
+        )
+    return ok
+
+
+def main() -> int:
+    if not self_test():
+        return 1
+    names = default_list()
+    mentions = workflow_mentions()
+    missing = [n for n in names if n not in mentions]
+    if missing:
+        print(
+            f"check-default-gates-run-somewhere: {len(missing)} default gate(s) run in NO workflow",
+            file=sys.stderr,
+        )
+        for n in missing:
+            print(f"  just check {n}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("  A gate in `just check`'s default list that no workflow runs is", file=sys.stderr)
+        print("  invisible between local full-tier runs, and its reds accumulate", file=sys.stderr)
+        print("  until someone finds several at once (issue 1040).", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("  It need not be merge-gating — a nightly signal is the bar. Add it", file=sys.stderr)
+        print("  to gate.yml's `schedule`/`workflow_dispatch` step beside", file=sys.stderr)
+        print("  `just check build`.", file=sys.stderr)
+        return 1
+    print(
+        f"check-default-gates-run-somewhere: OK ({len(names)} default gate(s), "
+        f"all run in at least one workflow)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`check-api-parity` sits in `just check`'s default list and ran in **no workflow at all**. Measured, not inferred:

```
grep -rl api-parity .github/workflows/     ->  (nothing)
```

Not `pull_request`, not `merge_group`, not nightly, not `workflow_dispatch`. It existed only as a local recipe, so an unclassified ledger row was invisible until somebody happened to run the full tier.

On 2026-09-04 that produced **seven reds on main in one day** — three api-parity, two clippy and one test-compile in `check-build`, and a NuttX break no lane covers (#1035). Every one was found by a person running `just ci gate`, not by CI.

## The fix

`just check api-parity` joins gate.yml's existing `schedule` / `workflow_dispatch` step, beside `just check build` and `just check no-std`. gate.yml already has `cron: "0 2 * * *"`, so this is one line and no new workflow.

**Not made merge-gating, deliberately.** It re-extracts our own surface with clang and nightly rustdoc, which is why it is off the fast line — and making a lane required when it resolves artifacts no CI job builds is exactly what turned every PR red for a day when `check-build` was required. `check-lane-contracts` forbids that shape now. A daily signal is the bar here, not a blocking one.

## Gated so it cannot recur

`check-default-gates-run-somewhere`: every recipe in `just check`'s default list must be invoked by at least one workflow. Offline, no network.

Scope is the default list (`cli-fresh fast build api-parity`) and nothing wider, on purpose. Asking it of all ~200 individual gates would flag most of them — they run collectively through `just check fast` — and a gate that fires on almost everything teaches people to ignore it.

Control run, with the line removed again:

```
check-default-gates-run-somewhere: 1 default gate(s) run in NO workflow
  just check api-parity
```

It self-tests on the normal path, as `check-gate-selftests` requires — and that requirement is right: a negative control nobody runs decays into a comment. The self-test refuses a vacuous pass: an empty default list, or an empty set of workflow mentions, is a failure rather than a green.

## Left as a decision, not silently taken

`check-build` **already had** this nightly cron, and two of its reds still landed and sat unnoticed today. So a red scheduled run is evidently not, by itself, enough to make anyone look. Whether that wants a notification, a job summary, or nothing is repo policy rather than something to add unilaterally — recorded in #1040. What this fixes is the narrower, unambiguous half: a lane that ran nowhere now runs daily.

`nightly-report.yml` was considered and rejected as the home. It triages via `workflow_run` on the `nightly` workflow, and `nightly-triage.py` parses that matrix's cells — pointing it at `gate` would re-run nightly triage on a gate completion. Pointless rather than harmful, but wrong.

## Verification

- `check-default-gates-run-somewhere` — OK, 4 gates, all covered
- `check-gate-lists` — OK, 224 gates, one per line and sorted
- `check-gate-selftests` — OK, ratchet now 95/209
- `just check fast` — **203 gates OK**

`just ci gate` does **not** pass on this branch, and not because of this change: it stops at `node-std-tests` on `error[E0437]: type Format is not a member of trait`, which is phase-421 residue already fixed in **#407** and not yet merged. The same red reproduces on a branch that touches none of it. I verified every lane this PR can affect, individually, above.
