### PR TITLE
fix(test): a `format!` among another format's arguments — my own red on main

### DIFF
--- a/packages/testing/nros-tests/tests/rtos_e2e.rs
+++ b/packages/testing/nros-tests/tests/rtos_e2e.rs
@@ -900,6 +900,15 @@ fn assert_no_session_churn(platform: Platform, lang: Lang, port: u16, window: Du
          file. Log: {}",
         log_path.display(),
     );
+    // Bound before the assertion rather than formatted inside it: a `format!`
+    // among another format's arguments is `clippy::format_in_format_args`, and
+    // the lane that catches it (`check test-targets`) runs on no merge-gating
+    // event, so it landed on main and sat there.
+    let session_lines = log
+        .lines()
+        .filter(|l| l.contains(ROUTER_SESSION_MARKER))
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(
         sessions <= MAX_ROUTER_SESSIONS,
         "{platform} {lang} pubsub E2E: the router opened {sessions} sessions in {window:?} \
@@ -911,16 +920,12 @@ fn assert_no_session_churn(platform: Platform, lang: Lang, port: u16, window: Du
          is fast now, which is exactly why the count is what this asserts on. Check \
          `Z_TRANSPORT_LEASE_MS` in `packages/rmw/zenoh/nros-zpico-build/src/lib.rs` \
          (60_000) and what the leaf actually BAKED — issue 1005: the staleness probe does \
-         not watch that constant, so a stale image can carry an old value. Sessions:\n{}",
-        format!(
-            "{}\n\nGaps between opens: {} — evenly spaced means a lease lapsing on a \
-             timer (the period is 2 x lease); one outlier means a single dropped link.",
-            log.lines()
-                .filter(|l| l.contains(ROUTER_SESSION_MARKER))
-                .collect::<Vec<_>>()
-                .join("\n"),
-            session_open_spacing(&log)
-        ),
+         not watch that constant, so a stale image can carry an old value.\n\n\
+         Sessions:\n{}\n\nGaps between opens: {} — evenly spaced means a lease \
+         lapsing on a timer (the period is 2 x lease); one outlier means a single \
+         dropped link.",
+        session_lines,
+        session_open_spacing(&log),
     );
 }
 


### PR DESCRIPTION
`assert_no_session_churn` built its "Sessions:" detail with a `format!` passed as an argument to the `assert!`'s own format string — `clippy::format_in_format_args`, denied by `-D warnings`, so `check test-targets` fails to compile `rtos_e2e`.

**I introduced it in #1044 (PR #386)** and it reached main, because the lane that catches it runs on **no merge-gating event**: `check test-targets` lives in `check build`, which is `schedule`/`workflow_dispatch` only. `check-fast` compiles no test targets, so neither the push lane nor the required `pull_request` context could see it — and `just ci gate`, which would have, is the tier I skipped for a test-file edit.

Third instance of that class today, and this one names the cost: #1057 was a unit test only the merge queue could see, #1040 is a gate in no workflow at all, and this is a **compile break that reached main from a PR green everywhere anyone looked**.

The detail is now bound before the assertion, with both placeholders in the assert's own format string. The diagnostic is unchanged — same session lines, same gap summary, same prose.

Verified: `just check test-targets` clean (was `error: could not compile nros-tests (test "rtos_e2e")`); `just check fast` 203 OK.

Found by a subagent running `just ci gate` in a worktree while verifying unrelated work — not by any lane that owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj