### PR TITLE
refactor(#417 stage 6 step B): our own call sites take the ROS 2 spellings

### DIFF
--- a/book/src/concepts/comparison-vs-microros.md
+++ b/book/src/concepts/comparison-vs-microros.md
@@ -74,11 +74,16 @@ comparison.
 
 If you're porting from micro-ROS to nano-ros:
 
+Several rows below are now **identity** on the C side: phase-417 took rcl/rclc's
+spellings, so `rclc_publisher_init_default` and `rclc_executor_t` are what
+nano-ros calls them too. The migration is a rename only where the shape differs.
+
 - `rcl_node_init` → `Executor::create_node` (Rust) /
-  `nros_executor_node_init` (C).
-- `rclc_executor_t` → `nros::Executor`.
-- `rclc_publisher_init_default` → `Node::create_publisher::<M>` or
-  `nros_publisher_init`.
+  `rclc_node_init_default` (C — same name as micro-ROS, but the ARGUMENTS are
+  rclc's order `(node, name, namespace, support)`).
+- `rclc_executor_t` → `nros::Executor` (Rust/C++); **unchanged** in C.
+- `rclc_publisher_init_default` → `Node::create_publisher::<M>` (Rust) or
+  the identically-spelled `rclc_publisher_init_default` (C).
 - micro-ROS's `rmw_uros_set_custom_transport` → nano-ros's custom
   transport pattern via `nros_platform_*` C ABI (see
   [Custom Transport](../porting/custom-transport.md)).

--- a/book/src/concepts/ros2-comparison.md
+++ b/book/src/concepts/ros2-comparison.md
@@ -206,7 +206,7 @@ zenoh endpoints communicate intent through the topic-key encoding.
 `MANUAL_BY_TOPIC` / `MANUAL_BY_NODE` liveliness call
 `assert_liveliness()` explicitly to refresh the lease. Available on
 every language surface (Rust `Publisher<M>::assert_liveliness()`, C
-`nros_publisher_assert_liveliness(&pub)`, C++
+`rcl_publisher_assert_liveliness(&pub)`, C++
 `pub.assert_liveliness()`). The zenoh backend wires it: a shim-side
 keepalive lease that `assert_liveliness()` refreshes, with
 `LivelinessLost` fired on expiry. Backends without manual-assertion
@@ -343,9 +343,10 @@ If you are coming from `rclrs`:
 
 If you are coming from `rclc`:
 
-- Same C names where they map (`nros_node_init`, `nros_publisher_init`,
-  `nros_subscription_init`). Memory ownership rules are the same — the
-  caller owns storage, the API initialises it.
+- The C entry points carry rclc's own names (`rclc_node_init_default`,
+  `rclc_publisher_init_default`, `rclc_subscription_init_default`), in
+  rclc's argument order and at rclc's arity. Memory ownership rules are
+  the same — the caller owns storage, the API initialises it.
 - See the [C API reference](../reference/c-api.md) for the full
   surface.
 

--- a/book/src/concepts/two-layer-api.md
+++ b/book/src/concepts/two-layer-api.md
@@ -21,7 +21,7 @@ The two layers are deliberately **separate verb sets** so the choice is explicit
 - `node.create_subscription::<M>("/topic")` — caller polls. No executor magic.
 - `executor.register_subscription::<M, _>("/topic", |m| { ... })` — executor dispatches.
 
-The C / C++ FFI mirrors this split: `nros_subscription_init` (L1) vs `nros_executor_register_subscription` (L2); `nros_subscription_init_polling` (L1, inline-storage) vs `register_subscription_*` (L2, executor arena).
+The C / C++ FFI mirrors this split: `nros_subscription_init_polling` + `nros_subscription_take_serialized` (L1, inline storage — the caller takes from the entity) vs `rclc_subscription_init_default` + `nros_executor_add_subscription*` (L2, executor arena, callback supplied at registration).
 
 ## What goes where
 
@@ -79,7 +79,7 @@ Service clients and action clients **stay on L1** in the current code — they h
 Both layers cross the FFI cleanly:
 
 - **C, L1 polling** — `nros_subscription_init_polling` writes a `RawSubscription` inline in `nros_subscription_t._opaque`. `nros_subscription_take_serialized` reads from the inline buffer. Same shape for service / service-client / action server / action client.
-- **C, L2 callback** — `nros_subscription_init` records the C callback pointer; `nros_executor_register_subscription` allocates the executor-arena entry.
+- **C, L2 callback** — `rclc_subscription_init_default` creates the entity; the callback is supplied at registration (`nros_executor_add_subscription_typed` for the typed path, `nros_executor_add_subscription_raw` for the byte path), which also allocates the executor-arena entry.
 - **C++** — typed templates wrap each FFI surface: `nros::Subscription<M>` + `take` for L1, `nros::PollingActionServer<A>` for the L1 action path (122.3.d.b), the L2 executor-registered callback model via the existing `nros::ActionServer<A>` API.
 
 For the per-FFI-function spec, see the [Doxygen reference](../api/platform-cffi/index.html). For the example migration tally (32 examples on L2, 16 intentionally L1), see the [unify-api-paths roadmap doc](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/roadmap/archived/phase-122-unify-api-paths.md).

--- a/book/src/design/rmw-vs-upstream.md
+++ b/book/src/design/rmw-vs-upstream.md
@@ -511,7 +511,7 @@ publishers call `assert_liveliness()` explicitly:
 pub.assert_liveliness()?;   // refresh this publisher's lease
 ```
 
-C side: `nros_publisher_assert_liveliness(&pub)`. C++ side:
+C side: `rcl_publisher_assert_liveliness(&pub)`. C++ side:
 `pub.assert_liveliness()`. No-op for `AUTOMATIC` and `NONE` kinds.
 
 ### Differences from upstream's matching

--- a/book/src/getting-started/first-node-c.md
+++ b/book/src/getting-started/first-node-c.md
@@ -113,10 +113,10 @@ stub that wires signal handling and forwards to your function.
 
 int nros_app_main(int argc, char** argv) {
     // 1. nros_support_init() — opens the zenoh session
-    // 2. nros_executor_init() / nros_node_init()
+    // 2. nros_executor_init() / rclc_node_init_default()
     // 3. std_msgs_msg_int32_publisher_init() — typed publisher
     // 4. nros_timer_init() with a 1 Hz period + publish callback
-    // 5. nros_executor_spin() until SIGINT
+    // 5. rclc_executor_spin() until SIGINT
 }
 ```
 

--- a/book/src/getting-started/porting-a-cpp-node.md
+++ b/book/src/getting-started/porting-a-cpp-node.md
@@ -2,9 +2,13 @@
 
 Goal: take a normal ROS 2 C++ node (one that compiles + runs under
 `colcon build` against `ros-humble-*`) and run it under nano-ros — without
-rewriting the source. The rclcpp source-compat layer (`nros/rclcpp_compat.hpp` +
-`cmake/compat/NrosRclcppCompat.cmake` + `nros-diagnostic-updater`) is built for
-this; the only delta is **build-script glue**.
+rewriting the source. The `rclcpp::` names are declared by nano-ros's own C++
+headers — `#include <rclcpp/rclcpp.hpp>` resolves through
+`cmake/compat/include/rclcpp/rclcpp.hpp` straight to `<nros/nros.hpp>`, with no
+compat header in between (phase-417 stage 6 deleted `nros/rclcpp_compat.hpp`).
+What remains of the compat layer is build glue —
+`cmake/compat/NrosRclcppCompat.cmake` plus `nros-diagnostic-updater` — so the
+only delta is **build-script glue**.
 
 The canonical proof lives at
 [`examples/templates/cpp-port-minimal-publisher/`](https://github.com/NEWSLabNTU/nano-ros/tree/main/examples/templates/cpp-port-minimal-publisher) —
@@ -33,8 +37,10 @@ ament_target_dependencies(my_node rclcpp std_msgs)
 ament_package()
 ```
 
-`find_package(rclcpp)` resolves through the rclcpp Find-stub (which
-auto-applies the `rclcpp_compat.hpp` force-include); `find_package(std_msgs)`
+`find_package(rclcpp)` resolves through the rclcpp Find-stub (which puts
+`cmake/compat/include/` on the include path so `<rclcpp/rclcpp.hpp>` lands on
+nano-ros's headers, and force-includes `nros/rclcpp_components_compat.hpp` for
+the components macros); `find_package(std_msgs)`
 resolves through the smart Find-stub (it walks
 `NROS_INTERFACE_SEARCH_PATH > AMENT_PREFIX_PATH > bundled`); the
 `ament_target_dependencies` compat shim wires both link targets.

--- a/book/src/porting/custom-transport.md
+++ b/book/src/porting/custom-transport.md
@@ -146,7 +146,7 @@ int main(void) {
     };
     nros_set_custom_transport(&ops);
 
-    // ... continue with nros_support_init, nros_node_init, etc.
+    // ... continue with nros_support_init, rclc_node_init_default, etc.
 }
 ```
 

--- a/book/src/reference/c-api.md
+++ b/book/src/reference/c-api.md
@@ -13,8 +13,8 @@ public surface a user application needs.
 ## Where to start
 
 - [`nros/nros.h`](../api/c/nros_8h.html) — convenience umbrella include
-- [`nros/init.h`](../api/c/init_8h.html) — `nros_support_init`, `nros_support_fini`
-- [`nros/node.h`](../api/c/node_8h.html) — `nros_node_init`, `nros_node_fini`
+- [`nros/init.h`](../api/c/init_8h.html) — `nros_support_init`, `rclc_support_fini`
+- [`nros/node.h`](../api/c/node_8h.html) — `rclc_node_init_default`, `rcl_node_fini`
 - [`nros/executor.h`](../api/c/executor_8h.html) — spin loop, executor lifecycle
 - [`nros/publisher.h`](../api/c/publisher_8h.html) / [`subscription.h`](../api/c/subscription_8h.html) — pub/sub
 - [`nros/service.h`](../api/c/service_8h.html) / [`client.h`](../api/c/client_8h.html) — services
@@ -23,12 +23,14 @@ public surface a user application needs.
 - [`nros/lifecycle.h`](../api/c/lifecycle_8h.html) — REP-2002 lifecycle states
 
 > **Two-layer API.** Every entity exposes two parallel C entry-point
-> sets: `nros_*_init` (Layer 1, caller polls) and
-> `nros_executor_register_*` (Layer 2, executor callback). Layer 1
+> sets: `rclc_*_init_default` (Layer 1, caller polls) and
+> `nros_executor_add_*` (Layer 2, executor callback). Layer 1
 > grew an `_init_polling` + `take_*_raw` / `send_*_raw` family
 > for inline-storage callers (no executor arena).
-> Layer 2 keeps the existing `nros_*_init` + executor-register
-> pair. See [Two-Layer API](../concepts/two-layer-api.md) for the
+> Layer 2 pairs the same `rclc_*_init_default` with the
+> executor-add call, which is where the callback is supplied
+> (rclc's binding site). See
+> [Two-Layer API](../concepts/two-layer-api.md) for the
 > verb discipline and per-layer trade-offs.
 
 > **Event-driven wake callbacks.** Each L1 polling entity supports
@@ -52,11 +54,11 @@ goals, requesting results, and cancelling:
   `nros_action_client_set_goal_response_callback()`,
   `nros_action_client_set_feedback_callback()`, and
   `nros_action_client_set_result_callback()`. The callbacks fire from
-  `nros_executor_spin_some()` — your spin loop is the only place
+  `rclc_executor_spin_some()` — your spin loop is the only place
   callbacks run.
 - **Blocking convenience:** `nros_action_send_goal()` and
   `nros_action_get_result()`. These call the async variant and then
-  drive `nros_executor_spin_some()` internally on a wall-clock budget
+  drive `rclc_executor_spin_some()` internally on a wall-clock budget
   until the reply lands (or 15 s / 30 s timeout). They take the
   `nros_executor_t*` explicitly because the action client stores its
   handle as an opaque slot inside the executor (registered via
@@ -71,7 +73,7 @@ during `nros_executor_register_client()` and recovers it internally —
 but it follows the same async-then-spin contract.
 
 Canonical pattern: declare the executor, register the client, then
-either call the blocking helper or drive `nros_executor_spin_some()`
+either call the blocking helper or drive `rclc_executor_spin_some()`
 yourself between async calls until your callback flags the result. See
 the example layouts in `examples/native/c/action-client/` and
 `examples/qemu-arm-freertos/c/action-client/`.

--- a/book/src/user-guide/cross-backend-bridges.md
+++ b/book/src/user-guide/cross-backend-bridges.md
@@ -292,7 +292,7 @@ lists which `<plat> × <lang>` combinations ship a bridge today
 |---------|--------------|
 | `Transport(ConnectionFailed)` on `open_with_rmw("X", ...)` | Backend X's rlib not pulled into the link line. Rust: add a `register()` call. C / C++: confirm `--whole-archive` wraps the staticlib. |
 | Second node's `.rmw("zenoh")` returns `Transport(...)` | Both nodes try to open against the same singleton-state backend. Set `NROS_RMW=zenoh` so the primary lands on zenoh + the second Node hits the session-cache (slot 0) instead of double-opening. |
-| `nros_publisher_init -> -7` after `nros_executor_node_init` | Stale build — the C-side multi-Session dispatch predates nros-v0.5.0; rebuild `nros-c` after updating. |
+| `rclc_publisher_init_default -> -7` after `nros_executor_node_init` | Stale build — the C-side multi-Session dispatch predates nros-v0.5.0; rebuild `nros-c` after updating. |
 | `Bridge spinning` marker never reaches piped test harness | Add `setvbuf(stdout, NULL, _IOLBF, 0)` at the top of `nros_app_main`. glibc full-buffers piped stdout; line-buffering surfaces readiness markers before the long-lived `spin_period` loop. |
 
 ## See also

--- a/book/src/user-guide/logging.md
+++ b/book/src/user-guide/logging.md
@@ -29,7 +29,7 @@ The numeric representation is stable and used by the
 
 ```rust
 use nros_log::{Logger, Severity};
-use nros_log::{nros_info, nros_warn};
+use nros_log::{log_info, log_warn};
 
 static LOGGER: Logger = Logger::new("my_node");
 
@@ -37,8 +37,8 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_log::sinks::default());
 
-    nros_info!(&LOGGER, "started; domain = {}", 42);
-    nros_warn!(&LOGGER, "queue depth {} exceeds soft limit", 5);
+    log_info!(&LOGGER, "started; domain = {}", 42);
+    log_warn!(&LOGGER, "queue depth {} exceeds soft limit", 5);
 }
 ```
 
@@ -47,7 +47,7 @@ to the same intern'd entry when the name matches:
 
 ```rust
 let mut node = executor.create_node("my_node")?;
-nros_info!(node.logger(), "subscribed to {}", topic);
+log_info!(node.logger(), "subscribed to {}", topic);
 ```
 
 ### C
@@ -61,15 +61,15 @@ int main(void) {
     nros_support_t support = nros_support_get_zero_initialized();
     nros_support_init(&support, "tcp/127.0.0.1:7447", 0);
 
-    nros_node_t node = nros_node_get_zero_initialized();
-    nros_node_init(&node, &support, "my_node", "/");
+    nros_node_t node = rcl_get_zero_initialized_node();
+    rclc_node_init_default(&node, "my_node", "/", &support);
 
     nros_logger_t logger = nros_node_get_logger(&node);
     NROS_LOG_INFO(logger, "started; domain=%u", 42);
     NROS_LOG_WARN(logger, "queue depth %u exceeds soft limit", 5);
 
-    nros_node_fini(&node);
-    nros_support_fini(&support);
+    rcl_node_fini(&node);
+    rclc_support_fini(&support);
     return 0;
 }
 ```

--- a/cmake/compat/diagnostic-updater/include/diagnostic_updater/diagnostic_updater.hpp
+++ b/cmake/compat/diagnostic-updater/include/diagnostic_updater/diagnostic_updater.hpp
@@ -148,7 +148,7 @@ private:
     std::chrono::steady_clock::time_point last_publish_;
     std::string hardware_id_;
     std::vector<Task> tasks_;
-    std::shared_ptr<::nros::Publisher<::diagnostic_msgs::msg::DiagnosticArray>> publisher_;
+    std::shared_ptr<::rclcpp::Publisher<::diagnostic_msgs::msg::DiagnosticArray>> publisher_;
 };
 
 }  // namespace diagnostic_updater

--- a/docs/design/0019-nros-c-thin-wrapper-discipline.md
+++ b/docs/design/0019-nros-c-thin-wrapper-discipline.md
@@ -110,7 +110,7 @@ extend to L1 cleanly.
    `validate_state!` macro, etc. — these belong inside the Rust
    impl, not the C wrapper. The C wrapper trusts Rust to validate.
 
-5. **Getters delegate via opaque cast.** `nros_subscription_get_topic_name`
+5. **Getters delegate via opaque cast.** `rcl_subscription_get_topic_name`
    reads the topic name from the Rust value inside `_opaque`, doesn't
    read a C-side mirror byte array.
 
@@ -228,7 +228,7 @@ for Executor / Node).
 
 - **Rust users:** no change (Rust API is the source of truth).
 - **C users:** stop reading `sub.topic_name` / `sub.callback`
-  fields directly. Use getters (e.g. `nros_subscription_get_topic_name`).
+  fields directly. Use getters (e.g. `rcl_subscription_get_topic_name`).
   These already exist for most entities; missing ones get added.
 - **C++ users:** mostly transparent — wrappers hide the change.
   C++ consumers that reach into `.handle.field_x` need to switch

--- a/docs/design/0021-blocking-api-rules.md
+++ b/docs/design/0021-blocking-api-rules.md
@@ -57,7 +57,7 @@ nros_client_call(&client, req, req_len, resp, cap, &resp_len);
 ```
 
 `nros_client_call` reads the stashed `executor_ptr` from the client's
-internal storage and spins it via `nros_executor_spin_some`. No
+internal storage and spins it via `rclc_executor_spin_some`. No
 signature change — the executor dependency is captured at registration
 time. Same pattern for `nros_action_send_goal` and
 `nros_action_get_result`.
@@ -75,7 +75,7 @@ no blocking overloads.
 ## Reentrancy guard
 
 `nros_executor_t` carries an `in_dispatch` flag set by
-`nros_executor_spin_some` for the duration of the dispatch loop.
+`rclc_executor_spin_some` for the duration of the dispatch loop.
 Blocking helpers check this flag and return `NROS_RET_REENTRANT` (C) or
 `ErrorCode::Reentrant` (C++) immediately if a callback re-enters.
 

--- a/docs/design/0037-rust-c-user-api-surface.md
+++ b/docs/design/0037-rust-c-user-api-surface.md
@@ -69,7 +69,7 @@ timeout)`.
 ~120 functions (cbindgen → `nros_generated.h` + hand-written
 `visibility.h`/`platform.h`/`types.h`). Where rclc/rcl has a counterpart the
 entry point carries **rclc's own name**, in rclc's argument order and arity
-(RFC-0087, settled 2026-09-04); everything with no counterpart keeps the
+(RFC-0089, settled 2026-09-04); everything with no counterpart keeps the
 `nros_` prefix:
 
 - init: `nros_executor_init`, `rclc_node_init_default`, `nros_support_init`.

--- a/docs/design/0037-rust-c-user-api-surface.md
+++ b/docs/design/0037-rust-c-user-api-surface.md
@@ -66,21 +66,27 @@ timeout)`.
 
 ### C surface (`nros-c`)
 
-~120 `nros_*` functions (cbindgen → `nros_generated.h` + hand-written
-`visibility.h`/`platform.h`/`types.h`), mirroring rclc:
+~120 functions (cbindgen → `nros_generated.h` + hand-written
+`visibility.h`/`platform.h`/`types.h`). Where rclc/rcl has a counterpart the
+entry point carries **rclc's own name**, in rclc's argument order and arity
+(RFC-0087, settled 2026-09-04); everything with no counterpart keeps the
+`nros_` prefix:
 
-- init: `nros_executor_init`, `nros_node_init`, `nros_support_init`.
-- pub/sub: `nros_publisher_init[_with_qos|_with_options]`, `nros_publish_raw`,
-  `nros_subscription_init[_with_qos|_polling]`.
-- services/clients: `nros_service_init[_polling]`, `nros_service_send_response_raw`,
-  `nros_client_init`, `nros_client_send_request_raw`, `nros_client_call`;
+- init: `nros_executor_init`, `rclc_node_init_default`, `nros_support_init`.
+- pub/sub: `rclc_publisher_init_default`,
+  `nros_publisher_init_{with_qos,with_options}`, `nros_publish_raw`,
+  `rclc_subscription_init_default`,
+  `nros_subscription_init_{with_qos,polling}`.
+- services/clients: `rclc_service_init_default`, `nros_service_init_polling`,
+  `nros_service_send_response_raw`,
+  `rclc_client_init_default`, `nros_client_send_request_raw`, `nros_client_call`;
   callback receive (RFC-0041): `nros_client_set_response_callback` +
-  `nros_client_send_request_async` (reply dispatched at `nros_executor_spin_some`).
+  `nros_client_send_request_async` (reply dispatched at `rclc_executor_spin_some`).
 - actions: `nros_action_{server,client}_init`, `nros_action_send_goal`,
   `nros_action_get_result`; callback receive (RFC-0041):
   `nros_action_client_set_{goal_response,feedback,result}_callback`.
-- executor: `nros_executor_register_{subscription,timer}`,
-  `nros_executor_spin[_some]`.
+- executor: `nros_executor_add_subscription*`, `rclc_executor_add_timer`,
+  `rclc_executor_spin[_some]`.
 - guard/lifecycle/params: `nros_guard_condition_*`, `nros_lifecycle_*`,
   `nros_param_*`.
 

--- a/docs/issues/1058-scaffold-output-is-grepped-never-built.md
+++ b/docs/issues/1058-scaffold-output-is-grepped-never-built.md
@@ -1,0 +1,69 @@
+---
+id: 1058
+title: "`nros new` scaffold tests grep the emitted text and never build it, so a
+  template can name three undeclared types and every test passes"
+status: open
+type: bug
+area: cli, api
+related: [phase-417, rfc-0043]
+---
+
+## Problem
+
+`cargo-nano-ros/tests/integration_tests.rs` verifies every scaffold variant by
+substring match on the generated sources — `assert!(hpp.contains("::nros::Result
+configure(::nros::Node& node);"))` and ~30 siblings. Nothing compiles the
+result.
+
+So the tests answer "did we emit the string we meant to emit", which is a
+question about the template, not about the scaffold. A user's first build is
+the first compile the emitted code ever gets.
+
+## How it surfaced
+
+Phase-417 W-B3 migrated the C++ template's four type names from `::nros::` to
+`::rclcpp::`. Three of the four do not exist:
+
+| renamed to | reality |
+| --- | --- |
+| `rclcpp::Publisher<M>` | real alias (`publisher.hpp:381`) |
+| `rclcpp::Result` | not declared anywhere in the tree |
+| `rclcpp::Timer` | not declared anywhere in the tree |
+| `rclcpp::Node` | a DISTINCT hosted class — `create_publisher<M>(name)` returns a `shared_ptr` where the template body passes an out-ref |
+
+The migrated template therefore compiled in **no** configuration. The suite
+went green: the only test that noticed was the one asserting the OLD string,
+and it read as "the rename is incomplete" rather than "the rename is wrong".
+Had the survey renamed that assertion too — the obvious next step — the defect
+would have shipped with a fully green suite.
+
+## Why it matters more than one bad edit
+
+The scaffold is the first nano-ros code a new user compiles, so a broken
+template is a first-run failure with no prior art to compare against. And the
+gap is systematic, not specific to this edit: any change to a template — a
+renamed header, a changed signature, a dropped include — is invisible to the
+suite unless it also changes a string some assertion happens to name.
+
+Same shape as the `<type_traits>` gap found the same day: a check standing next
+to the real question, asking a proxy. There the proxy was a synthesised minimal
+libcpp more complete than the real toolchain's; here it is text equality
+standing in for compilation.
+
+## Fix
+
+Build at least one scaffold variant per language in `check-cli-tests`:
+`nros new` into a temp dir, then configure + build it against the in-tree
+`NANO_ROS_ROOT`. The C++ variant is the one that matters most — it is the only
+template whose types come from a namespace that is partly aliases and partly
+distinct classes, which is exactly the confusion that produced this.
+
+Cost is a real compile per variant, so this is a `check-cli-tests` addition
+rather than a fast-line one. `check-cli-tests` already builds
+`nros-launch-resolve` before running, so the lane is not a no-compile lane.
+
+Cheaper interim: assert every `::rclcpp::`-qualified name a template emits is
+declared in the headers, by grepping the header set. That catches the
+undeclared-type half (2 of the 3 here) without a build, but not the
+`rclcpp::Node` half, whose name resolves and whose SHAPE differs — the
+compile-or-conform hazard RFC-0087 exists for.

--- a/docs/issues/1058-scaffold-output-is-grepped-never-built.md
+++ b/docs/issues/1058-scaffold-output-is-grepped-never-built.md
@@ -66,4 +66,4 @@ Cheaper interim: assert every `::rclcpp::`-qualified name a template emits is
 declared in the headers, by grepping the header set. That catches the
 undeclared-type half (2 of the 3 here) without a build, but not the
 `rclcpp::Node` half, whose name resolves and whose SHAPE differs — the
-compile-or-conform hazard RFC-0087 exists for.
+compile-or-conform hazard RFC-0089 exists for.

--- a/docs/reference/c-api-cmake.md
+++ b/docs/reference/c-api-cmake.md
@@ -86,10 +86,10 @@ Action and service client entrypoints split into two families:
 - `nros_action_send_goal_async()`, `nros_action_get_result_async()`,
   `nros_action_cancel_goal()`, `nros_client_send_request_async()` — non-blocking,
   return immediately. Replies arrive via callbacks invoked from
-  `nros_executor_spin_some()`.
+  `rclc_executor_spin_some()`.
 - `nros_action_send_goal()`, `nros_action_get_result()`, `nros_client_call()` —
   blocking convenience wrappers. They call the async variant and then drive the
-  executor (`nros_executor_spin_some` internally in a wall-clock budgeted loop)
+  executor (`rclc_executor_spin_some` internally in a wall-clock budgeted loop)
   until the reply lands or timeout. They never call `zpico_get` directly — all
   I/O still flows through the registered executor. Calling any of them from
   inside a dispatch callback returns `NROS_RET_REENTRANT`.
@@ -109,7 +109,7 @@ Canonical call pattern (C):
 
 ```c
 nros_support_init(&support, locator, domain_id);
-nros_node_init(&node, &support, "c_action_client", "/");
+rclc_node_init_default(&node, "c_action_client", "/", &support);
 nros_action_client_init(&client, &node, "/fibonacci", &type_info);
 nros_action_client_set_feedback_callback(&client, on_feedback, NULL);
 nros_action_client_set_result_callback(&client, on_result, NULL);
@@ -119,14 +119,14 @@ nros_executor_register_action_client(&executor, &client);
 
 /* Warm-up: let zenoh discover the action server. */
 for (int i = 0; i < 300; ++i) {
-    nros_executor_spin_some(&executor, 10000000ULL); /* 10 ms */
+    rclc_executor_spin_some(&executor, 10000000ULL); /* 10 ms */
 }
 
 /* Async path: returns immediately; goal_response_callback fires during spin. */
 nros_goal_uuid_t goal_uuid;
 nros_action_send_goal_async(&client, goal_buf, goal_len, &goal_uuid);
 while (!state.goal_responded) {
-    nros_executor_spin_some(&executor, 10000000ULL);
+    rclc_executor_spin_some(&executor, 10000000ULL);
 }
 
 /* Blocking convenience: same async-then-spin pattern, packaged. */

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -313,6 +313,25 @@ shape is uniform (`nros_node_init(&x, &y, "name", "/")`). So a regex codemod is
 honest here — but it must be a codemod that reorders, not a `sed s/old/new/`,
 and the two must not be run as separate passes.
 
+### Work items
+
+* **W-B1 [rust]** — flip `nros-log/deprecate-legacy-names`, then fix the 208
+  sites it names across 50 files. The flip comes FIRST because
+  `warnings = "deny"` makes it enumerate the work instead of a grep guessing at
+  it.
+* **W-B2 [c]** — the 43 deprecated C names across 206 sites / 40 files,
+  **including the `nros_node_init` reorder in the same pass**. Rename and
+  reorder must not be separate passes: the rename is what makes a missed
+  reorder fail to compile.
+* **W-B3 [cpp]** — `nros::` → `rclcpp::` across 645 sites / 119 files.
+* **W-B4 [docs]** — 57 files in `book/` and `docs/` naming an old spelling in
+  prose or a code block. No compiler checks these.
+* **W-B5 [retire]** — delete the 110 `NROS_DEPRECATED_MSG` forwarders across 12
+  headers, the five Rust forwarders, and the feature flag. Last, and only after
+  W-B1..4 are green.
+* **W-B6 [changelog]** — one entry, carrying phase-379 W7 step 4's two
+  warnings.
+
 ### Order, and why
 
 1. **Flip `nros-log/deprecate-legacy-names`.** The workspace sets

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -304,7 +304,7 @@ rclc_node_init_default(node, name, namespace_, support)
 A sweep that renames without reordering produces code that **compiles with a
 warning and passes the wrong values** — C diagnoses an incompatible pointer
 argument as a warning even under `-Wall -Wextra`, which is the measurement that
-forced RFC-0087's "a C reorder ships with a rename beside it". Here the rename
+forced RFC-0089's "a C reorder ships with a rename beside it". Here the rename
 IS the guard: the old identifier disappears, so a missed site fails to compile
 rather than silently mis-binding.
 
@@ -379,7 +379,7 @@ and the two must not be run as separate passes.
 * `examples/templates/cpp-port-minimal-publisher` still byte-identical to
   upstream's tutorial;
 * `rcl_compat.h` holds only the `RCL_RET_*` mapping and handle typedefs — the
-  two things RFC-0087 says cannot dissolve;
+  two things RFC-0089 says cannot dissolve;
 * `just ci gate` green, and the ported templates build with **every** compat
   layer deleted.
 

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -323,12 +323,33 @@ and the two must not be run as separate passes.
   **including the `nros_node_init` reorder in the same pass**. Rename and
   reorder must not be separate passes: the rename is what makes a missed
   reorder fail to compile.
-* **W-B3 [cpp]** — `nros::` → `rclcpp::` across 645 sites / 119 files.
+* **W-B3 [cpp]** — **LANDED, and the survey was wrong.** Not 645 pure renames:
+  measured 697 code occurrences over 120 files, of which only **288 (41 %) are
+  pure renames**. 409 stay `nros::`, and the reason is the campaign's own rule
+  rather than effort:
+  * `nros::Node` — **109 sites, 103 files**. `rclcpp::Node` is a DISTINCT CLASS,
+    not an alias: `make_shared` + shared_ptr-returning `create_publisher<M>`
+    against ours' out-ref `create_node(node, …)`. It is also hosted-only, so it
+    does not exist on the freestanding targets most of those files build for.
+  * `nros::init` (13) — `rclcpp::init()` returns **void**; every call site
+    consumes our `Result`. Renaming drops the error check.
+  * `nros::Timer` (28), `nros::spin_once` (32) — no counterpart with that
+    contract.
+  * ~200 more with no `rclcpp::` counterpart at all: the `bind_*` family,
+    `create_node`, `Seq`/`HeapString`, `GoalResponse`/`CancelResponse`/
+    `GoalStatus`, the whole lifecycle set (there is no `rclcpp_lifecycle`
+    namespace in our headers).
+
+* **W-B5 [retire] — PRECONDITION, added after W-B3 measured it.** The C
+  forwarders (43 names) and the five Rust logging forwarders CAN go: every one
+  has a live replacement. The C++ `nros::` spellings for `Node`, `init`,
+  `Timer`, `spin_once`, lifecycle and the action-response enums **cannot** —
+  deleting them removes a capability rather than a spelling. Retiring those
+  waits on the node-type merge that `nros.hpp`'s own comment defers to "a later
+  step".
 * **W-B4 [docs]** — 57 files in `book/` and `docs/` naming an old spelling in
   prose or a code block. No compiler checks these.
-* **W-B5 [retire]** — delete the 110 `NROS_DEPRECATED_MSG` forwarders across 12
-  headers, the five Rust forwarders, and the feature flag. Last, and only after
-  W-B1..4 are green.
+
 * **W-B6 [changelog]** — one entry, carrying phase-379 W7 step 4's two
   warnings.
 

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -271,6 +271,78 @@ exists and is tested; the wrapper is a forwarder. Under RFC-0019 that is both
 the cheapest work in this phase and the work that reduces the most divergence
 per line, which is why stage 4 is not deferred behind the C-side stages.
 
+## Stage 6 step B — surveyed 2026-09-04, its own PR
+
+Step A landed: the ROS 2 spellings are first-class, `rclcpp_compat.hpp` is
+deleted, and every `rcl_compat.h` FUNCTION alias became an identity and was
+deleted with it. Step B retires the old spellings. **It is the only irreversible
+step for an out-of-tree consumer**, so it is one batch, one PR, one changelog
+entry — never opportunistic.
+
+### The size, measured rather than estimated
+
+| surface | sites | files | shape |
+| --- | ---: | ---: | --- |
+| Rust logging macros | 208 | 50 | pure rename |
+| C symbols (43 deprecated names) | 206 | 40 | pure rename, **except the one below** |
+| C++ `nros::` → `rclcpp::` | 645 | 119 | pure rename |
+| docs / book | — | 57 | prose + code blocks |
+| the forwarders themselves | 110 | 12 headers | deletion |
+
+Largest concentrations: `examples/native/{c,rust}` (27 files), the five RTOS
+example families (25), `packages/testing/nros-tests` (12).
+
+### One site is not mechanical, and it is the whole risk
+
+`nros_node_init` is the single argument REORDER in the campaign:
+
+```
+nros_node_init        (node, support, name, namespace_)     <- 42 call sites
+rclc_node_init_default(node, name, namespace_, support)
+```
+
+A sweep that renames without reordering produces code that **compiles with a
+warning and passes the wrong values** — C diagnoses an incompatible pointer
+argument as a warning even under `-Wall -Wextra`, which is the measurement that
+forced RFC-0087's "a C reorder ships with a rename beside it". Here the rename
+IS the guard: the old identifier disappears, so a missed site fails to compile
+rather than silently mis-binding.
+
+Surveyed for tractability: **all 42 are single-line, zero multi-line**, and the
+shape is uniform (`nros_node_init(&x, &y, "name", "/")`). So a regex codemod is
+honest here — but it must be a codemod that reorders, not a `sed s/old/new/`,
+and the two must not be run as separate passes.
+
+### Order, and why
+
+1. **Flip `nros-log/deprecate-legacy-names`.** The workspace sets
+   `warnings = "deny"`, so arming the attribute turns all 208 Rust sites into
+   hard errors at once. That is the point: it enumerates the work rather than
+   trusting a grep.
+2. **Migrate Rust, then C, then C++.** Each is a rename; the compiler names
+   every site.
+3. **The `node_init` codemod, alone, with its own review.** Not folded into the
+   C rename sweep — it is the one change where a mistake is silent.
+4. **Docs and book.** `just book` builds them; a stale code block is not caught
+   by any compiler.
+5. **Delete the forwarders** — 110 `NROS_DEPRECATED_MSG` declarations across 12
+   headers, plus the five Rust forwarders, plus the feature flag itself.
+6. **Changelog entry**, carrying phase-379 W7 step 4's two warnings: C cannot
+   portably deprecate a `typedef`, so renamed C TYPES disappear with no warning
+   for anyone who never rebuilt; and a defaulted trait method's alias is weaker
+   than it looks, because an out-of-tree override is silently ignored.
+
+### Acceptance
+
+* every in-tree source builds with `deprecate-legacy-names` ON and zero
+  forwarders present;
+* `examples/templates/cpp-port-minimal-publisher` still byte-identical to
+  upstream's tutorial;
+* `rcl_compat.h` holds only the `RCL_RET_*` mapping and handle typedefs — the
+  two things RFC-0087 says cannot dissolve;
+* `just ci gate` green, and the ported templates build with **every** compat
+  layer deleted.
+
 ## Correction track — the ledger says false things, and they misdirect
 
 The measurement is the campaign's instrument; a wrong row is worse than a

--- a/examples/native/c/action-client/src/main.c
+++ b/examples/native/c/action-client/src/main.c
@@ -132,8 +132,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_client", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(
         nros_action_client_init(&app.action_client, &app.node, "/fibonacci", &fibonacci_type), 1);
@@ -150,7 +151,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Warm-up: spin to allow Zenoh to discover the server's queryables
     for (int i = 0; i < 300; i++) {
-        nros_executor_spin_some(&app.executor, 10000000ULL); // 10ms
+        rclc_executor_spin_some(&app.executor, 10000000ULL); // 10ms
     }
 
     // Send goal: compute Fibonacci sequence of order 10
@@ -243,10 +244,10 @@ int nros_app_main(int argc, char** argv) {
 cleanup:
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_client_fini(&app.action_client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return (ret == NROS_RET_OK) ? 0 : 1;

--- a/examples/native/c/action-server/src/main.c
+++ b/examples/native/c/action-server/src/main.c
@@ -52,7 +52,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -221,8 +221,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_server", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(nros_action_server_init(&app.action_server, &app.node, "/fibonacci",
                                            &fibonacci_type, goal_callback, cancel_callback,
@@ -241,7 +242,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -249,10 +250,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", app.ctx.goal_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_server_fini(&app.action_server);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/c/custom-platform/src/main.c
+++ b/examples/native/c/custom-platform/src/main.c
@@ -85,7 +85,7 @@ static struct {
 // Serialization buffer (statically allocated)
 static uint8_t g_serialize_buffer[64];
 
-// Phase 88.16.B — set after `nros_node_init`; used by post-init
+// Phase 88.16.B — set after `rclc_node_init_default`; used by post-init
 // diagnostics + the timer callback. NULL before init = `NROS_LOG_*`
 // silently drops. Moved here from after `main` (Phase 212.M native/c
 // sweep) so the C compiler sees the declaration before the callback's
@@ -133,7 +133,7 @@ static void shutdown_callback(void* context) {
     (void)context;
     printf("[Guard] Shutdown signal received!\n");
     app.running = false;
-    (void)nros_executor_stop(&app.executor);
+    (void)nros_executor_cancel(&app.executor);
 }
 
 // ============================================================================
@@ -146,7 +146,7 @@ static void signal_handler(int signum) {
 
     // This is how you would signal from an interrupt handler:
     // The guard condition trigger is thread-safe and can be called from any context
-    (void)nros_guard_condition_trigger(&app.shutdown_guard);
+    (void)rcl_trigger_guard_condition(&app.shutdown_guard);
 }
 
 // ============================================================================
@@ -176,7 +176,7 @@ static void demo_platform_time(void) {
     int64_t elapsed_ns = nros_time_to_nanoseconds(&t2) - nros_time_to_nanoseconds(&t1);
     printf("Elapsed time: %.3f ms\n", (double)elapsed_ns / 1000000.0);
 
-    (void)nros_clock_fini(&clock);
+    (void)rcl_clock_fini(&clock);
 }
 
 // ============================================================================
@@ -187,7 +187,7 @@ static void demo_guard_condition(void) {
     printf("\n=== Guard Condition Demo ===\n");
 
     // Initialize guard condition with callback
-    app.shutdown_guard = nros_guard_condition_get_zero_initialized();
+    app.shutdown_guard = rcl_get_zero_initialized_guard_condition();
     nros_ret_t ret = nros_guard_condition_init(&app.shutdown_guard, &app.support);
     if (ret != NROS_RET_OK) {
         fprintf(stderr, "Failed to init guard condition: %d\n", ret);
@@ -208,7 +208,7 @@ static void demo_guard_condition(void) {
 
     // Demonstrate trigger/clear cycle
     printf("Triggering guard condition...\n");
-    (void)nros_guard_condition_trigger(&app.shutdown_guard);
+    (void)rcl_trigger_guard_condition(&app.shutdown_guard);
     printf("  Is triggered: %s\n",
            nros_guard_condition_is_triggered(&app.shutdown_guard) ? "yes" : "no");
 
@@ -277,13 +277,13 @@ int nros_app_main(int argc, char** argv) {
     printf("Support initialized\n");
 
     // Initialize node
-    app.node = nros_node_get_zero_initialized();
-    ret = nros_node_init(&app.node, &app.support, "baremetal_demo", "/");
+    app.node = rcl_get_zero_initialized_node();
+    ret = rclc_node_init_default(&app.node, "baremetal_demo", "/", &app.support);
     if (ret != NROS_RET_OK) {
         fprintf(stderr, "Failed to init node: %d\n", ret);
         goto cleanup_support;
     }
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     // Fetch the node's logger so NROS_LOG_* in the timer callback emits.
     // Without this g_logger stays NULL and every log call silently drops
@@ -292,17 +292,17 @@ int nros_app_main(int argc, char** argv) {
     g_logger = nros_node_get_logger(&app.node);
 
     // Initialize publisher
-    app.publisher = nros_publisher_get_zero_initialized();
-    ret = nros_publisher_init(&app.publisher, &app.node, &std_msgs_Int32_type,
-                              "/baremetal_demo/counter");
+    app.publisher = rcl_get_zero_initialized_publisher();
+    ret = rclc_publisher_init_default(&app.publisher, &app.node, &std_msgs_Int32_type,
+                                      "/baremetal_demo/counter");
     if (ret != NROS_RET_OK) {
         fprintf(stderr, "Failed to init publisher: %d\n", ret);
         goto cleanup_node;
     }
-    printf("Publisher created: %s\n", nros_publisher_get_topic_name(&app.publisher));
+    printf("Publisher created: %s\n", rcl_publisher_get_topic_name(&app.publisher));
 
     // Initialize timer (500ms period)
-    app.timer = nros_timer_get_zero_initialized();
+    app.timer = rcl_get_zero_initialized_timer();
     ret = nros_timer_init(&app.timer, &app.support, 500000000ULL, timer_callback, NULL);
     if (ret != NROS_RET_OK) {
         fprintf(stderr, "Failed to init timer: %d\n", ret);
@@ -311,7 +311,7 @@ int nros_app_main(int argc, char** argv) {
     printf("Timer created (500ms period)\n");
 
     // Initialize executor
-    app.executor = nros_executor_get_zero_initialized();
+    app.executor = rclc_executor_get_zero_initialized_executor();
     ret = nros_executor_init(&app.executor, &app.support, 4);
     if (ret != NROS_RET_OK) {
         fprintf(stderr, "Failed to init executor: %d\n", ret);
@@ -319,7 +319,7 @@ int nros_app_main(int argc, char** argv) {
     }
 
     // Add timer to executor
-    ret = nros_executor_add_timer(&app.executor, &app.timer);
+    ret = rclc_executor_add_timer(&app.executor, &app.timer);
     if (ret != NROS_RET_OK) {
         fprintf(stderr, "Failed to add timer: %d\n", ret);
         goto cleanup_executor;
@@ -340,20 +340,20 @@ int nros_app_main(int argc, char** argv) {
     // The executor handles all callbacks including:
     // - Timer callbacks (periodic publishing)
     // - Guard condition callbacks (shutdown signal)
-    ret = nros_executor_spin_period(&app.executor, 50000000ULL); // 50ms spin period
+    ret = rclc_executor_spin_period(&app.executor, 50000000ULL); // 50ms spin period
 
     // Cleanup (in reverse order of initialization)
     printf("\n=== Cleanup ===\n");
 
-    (void)nros_guard_condition_fini(&app.shutdown_guard);
+    (void)rcl_guard_condition_fini(&app.shutdown_guard);
     printf("Guard condition finalized\n");
 
 cleanup_executor:
-    (void)nros_executor_fini(&app.executor);
+    (void)rclc_executor_fini(&app.executor);
     printf("Executor finalized\n");
 
 cleanup_timer:
-    (void)nros_timer_fini(&app.timer);
+    (void)rcl_timer_fini(&app.timer);
     printf("Timer finalized\n");
 
 cleanup_publisher:
@@ -361,11 +361,11 @@ cleanup_publisher:
     printf("Publisher finalized\n");
 
 cleanup_node:
-    (void)nros_node_fini(&app.node);
+    (void)rcl_node_fini(&app.node);
     printf("Node finalized\n");
 
 cleanup_support:
-    (void)nros_support_fini(&app.support);
+    (void)rclc_support_fini(&app.support);
     printf("Support finalized\n");
 
     printf("\n");

--- a/examples/native/c/custom-transport-loopback/src/main.c
+++ b/examples/native/c/custom-transport-loopback/src/main.c
@@ -14,7 +14,7 @@
 ///     bring-up invoked the transport's open callback).
 ///  3. `write_count >= 1` after publishing a frame.
 ///  4. `read_count >= 1` after the executor's spin tick.
-///  5. `close_count >= 1` after `nros_support_fini` /
+///  5. `close_count >= 1` after `rclc_support_fini` /
 ///     `nros_set_custom_transport(NULL)`.
 
 #include <pthread.h>
@@ -158,7 +158,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor != NULL) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -211,10 +211,11 @@ int nros_app_main(int argc, char** argv) {
     (void)nros_clock_init(&app.clock, NROS_CLOCK_SYSTEM_TIME);
     (void)nros_parameter_server_init(&app.params, app.param_storage, 4);
     NROS_CHECK_RET(nros_support_init(&app.support, "custom://loopback", 0), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "loopback_demo", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "loopback_demo", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_int32_get_type_support(), "/loopback_chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_int32_get_type_support(),
+                                               "/loopback_chatter"),
                    1);
 
     app.demo_ctx.publisher = &app.publisher;
@@ -225,7 +226,7 @@ int nros_app_main(int argc, char** argv) {
                                    timer_callback, &app.demo_ctx),
                    1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
     g_executor = &app.executor;
 
     signal(SIGINT, signal_handler);
@@ -242,15 +243,15 @@ int nros_app_main(int argc, char** argv) {
             (now.tv_sec == deadline.tv_sec && now.tv_nsec >= deadline.tv_nsec)) {
             break;
         }
-        (void)nros_executor_spin_some(&app.executor, 100ULL * 1000 * 1000 /* 100ms */);
+        (void)rclc_executor_spin_some(&app.executor, 100ULL * 1000 * 1000 /* 100ms */);
     }
 
     /* 3. Teardown — exercises the transport's close callback. */
-    (void)nros_timer_fini(&app.timer);
+    (void)rcl_timer_fini(&app.timer);
     (void)nros_publisher_fini(&app.publisher);
-    (void)nros_node_fini(&app.node);
-    (void)nros_executor_fini(&app.executor);
-    (void)nros_support_fini(&app.support);
+    (void)rcl_node_fini(&app.node);
+    (void)rclc_executor_fini(&app.executor);
+    (void)rclc_support_fini(&app.support);
 
     /* Drop the registered transport explicitly so `close` fires
      * even on backends that don't tear it down at session-end. */

--- a/examples/native/c/listener/src/main.c
+++ b/examples/native/c/listener/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -104,30 +104,33 @@ int nros_app_main(int argc, char** argv) {
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "listener", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "listener", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     // Create application context
     app.listener_ctx = (listener_context_t){
         .message_count = 0,
     };
 
-    NROS_CHECK_RET(nros_subscription_init(&app.subscription, &app.node,
-                                          std_msgs_msg_string_get_type_support(), "/chatter",
-                                          subscription_callback, &app.listener_ctx),
+    NROS_CHECK_RET(rclc_subscription_init_default(&app.subscription, &app.node,
+                                                  std_msgs_msg_string_get_type_support(),
+                                                  "/chatter"),
                    1);
     // phase-342 — "Subscriber", matching the rust and C++ listeners: this line
     // is the READINESS marker the test matrix waits on
     // (`nros_tests::output::LISTENER_READY_MARKER`), and one demo should not
     // spell its own readiness three ways.
     printf("Subscriber created for topic: %s\n",
-           nros_subscription_get_topic_name(&app.subscription));
+           rcl_subscription_get_topic_name(&app.subscription));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(
-        nros_executor_add_subscription(&app.executor, &app.subscription, NROS_EXECUTOR_ON_NEW_DATA),
-        1);
+    /* phase-417 stage 6 — rclc arity: the byte callback is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(nros_executor_add_subscription_raw(&app.executor, &app.subscription,
+                                                      subscription_callback, &app.listener_ctx,
+                                                      NROS_EXECUTOR_ON_NEW_DATA),
+                   1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -137,7 +140,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for messages (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -145,10 +148,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", app.listener_ctx.message_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_subscription_fini(&app.subscription);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/c/logging/src/main.c
+++ b/examples/native/c/logging/src/main.c
@@ -40,18 +40,18 @@ int main(void) {
         return 1;
     }
 
-    nros_node_t node = nros_node_get_zero_initialized();
-    if (nros_node_init(&node, &support, "demo", "/") != 0) {
-        fprintf(stderr, "nros_node_init failed\n");
-        nros_support_fini(&support);
+    nros_node_t node = rcl_get_zero_initialized_node();
+    if (rclc_node_init_default(&node, "demo", "/", &support) != 0) {
+        fprintf(stderr, "rclc_node_init_default failed\n");
+        rclc_support_fini(&support);
         return 1;
     }
 
     nros_logger_t logger = nros_node_get_logger(&node);
     if (logger == NULL) {
         fprintf(stderr, "nros_node_get_logger returned NULL\n");
-        nros_node_fini(&node);
-        nros_support_fini(&support);
+        rcl_node_fini(&node);
+        rclc_support_fini(&support);
         return 1;
     }
 
@@ -65,7 +65,7 @@ int main(void) {
     NROS_LOG_ERROR(logger, "round 1: error=%d", 1);
     NROS_LOG_FATAL(logger, "round 1: fatal=%d", 1);
 
-    nros_node_fini(&node);
-    nros_support_fini(&support);
+    rcl_node_fini(&node);
+    rclc_support_fini(&support);
     return 0;
 }

--- a/examples/native/c/parameters/src/main.c
+++ b/examples/native/c/parameters/src/main.c
@@ -25,7 +25,7 @@ static int run(void) {
         if (nros_clock_get_now(&clock, &now) == NROS_RET_OK) {
             printf("System time: %d.%09u sec\n", now.sec, now.nanosec);
         }
-        (void)nros_clock_fini(&clock);
+        (void)rcl_clock_fini(&clock);
     }
 
     // Parameter server backed by static storage (no heap). The server struct

--- a/examples/native/c/safety-listener/src/main.c
+++ b/examples/native/c/safety-listener/src/main.c
@@ -45,7 +45,7 @@ int nros_app_main(int argc, char** argv) {
     printf("nros C Safety Listener\n");
     memset(&app, 0, sizeof(app));
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "c_safety_listener", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "c_safety_listener", "/", &app.support), 1);
 
     // Polling-mode subscription — the validated receive path is poll-only.
     NROS_CHECK_RET(nros_subscription_init_polling(&app.subscription, &app.node,
@@ -79,8 +79,8 @@ int nros_app_main(int argc, char** argv) {
     }
 
     nros_subscription_fini(&app.subscription);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
     return 0;
 }
 

--- a/examples/native/c/service-client-callback/src/main.c
+++ b/examples/native/c/service-client-callback/src/main.c
@@ -2,7 +2,7 @@
 /// @brief C service client example — **callback** variant.
 ///
 /// Mirrors the blocking `service-client` example, but receives each reply
-/// through a `nros_response_callback_t` dispatched by `nros_executor_spin_some`
+/// through a `nros_response_callback_t` dispatched by `rclc_executor_spin_some`
 /// — the dual-mode alternative to `nros_client_call`. Send is non-blocking
 /// (`nros_client_send_request_async`); the reply lands in the callback when the
 /// executor next spins (the C analogue of rclcpp `async_send_request(req, cb)`).
@@ -37,7 +37,7 @@ static struct {
 } app;
 
 // ----------------------------------------------------------------------------
-// Response callback — fired from `nros_executor_spin_some`, not a poll.
+// Response callback — fired from `rclc_executor_spin_some`, not a poll.
 // ----------------------------------------------------------------------------
 
 static void on_response(const uint8_t* response, size_t response_len, void* context) {
@@ -103,12 +103,13 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_client_cb", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
-
-    NROS_CHECK_RET(nros_client_init(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"),
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_client_cb", "/", &app.support),
                    1);
-    printf("Client created for service: %s\n", nros_client_get_service_name(&app.client));
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
+
+    NROS_CHECK_RET(
+        rclc_client_init_default(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Client created for service: %s\n", rcl_client_get_service_name(&app.client));
 
     // Clients must be registered with an executor before use.
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
@@ -120,7 +121,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Let discovery settle (the callback client has no blocking call to gate on).
     for (int i = 0; i < 20; i++) {
-        nros_executor_spin_some(&app.executor, 50ull * 1000 * 1000);
+        rclc_executor_spin_some(&app.executor, 50ull * 1000 * 1000);
     }
 
     int exit_code = 0;
@@ -146,7 +147,7 @@ int nros_app_main(int argc, char** argv) {
             // Spin until the reply callback fires (or a 5 s budget elapses).
             uint64_t waited_ms = 0;
             while (app.reply_count == 0 && waited_ms < 5000) {
-                nros_executor_spin_some(&app.executor, 50ull * 1000 * 1000);
+                rclc_executor_spin_some(&app.executor, 50ull * 1000 * 1000);
                 waited_ms += 50;
             }
 
@@ -158,10 +159,10 @@ int nros_app_main(int argc, char** argv) {
     }
 
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_client_fini(&app.client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/native/c/service-client/src/main.c
+++ b/examples/native/c/service-client/src/main.c
@@ -82,12 +82,12 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_client", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_client_init(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"),
-                   1);
-    printf("Client created for service: %s\n", nros_client_get_service_name(&app.client));
+    NROS_CHECK_RET(
+        rclc_client_init_default(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Client created for service: %s\n", rcl_client_get_service_name(&app.client));
 
     // Clients must be registered with an executor before use.
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
@@ -137,10 +137,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_client_fini(&app.client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/native/c/service-server/src/main.c
+++ b/examples/native/c/service-server/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -131,17 +131,19 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_server", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_service_init(&app.service, &app.node, &add_two_ints_type, "/add_two_ints",
-                                     service_callback, &app.ctx),
-                   1);
-    printf("Service created: %s\n", nros_service_get_service_name(&app.service));
+    NROS_CHECK_RET(
+        rclc_service_init_default(&app.service, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Service created: %s\n", rcl_service_get_service_name(&app.service));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_service(&app.executor, &app.service), 1);
+    /* phase-417 stage 6 — rclc arity: the request handler is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(
+        nros_executor_add_service_raw(&app.executor, &app.service, service_callback, &app.ctx), 1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -151,7 +153,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for service requests (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -159,10 +161,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", app.ctx.request_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_service_fini(&app.service);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/c/talker/src/main.c
+++ b/examples/native/c/talker/src/main.c
@@ -49,7 +49,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -100,10 +100,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "talker", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "talker", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_string_get_type_support(), "/chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_string_get_type_support(), "/chatter"),
                    1);
 
     // Create application context
@@ -119,24 +119,24 @@ int nros_app_main(int argc, char** argv) {
         1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
 
     // Cleanup
-    nros_executor_fini(&app.executor);
-    nros_timer_fini(&app.timer);
+    rclc_executor_fini(&app.executor);
+    rcl_timer_fini(&app.timer);
     nros_publisher_fini(&app.publisher);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     return 0;
 }

--- a/examples/native/cpp/action-client-callback/src/main.cpp
+++ b/examples/native/cpp/action-client-callback/src/main.cpp
@@ -101,12 +101,12 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client_cb"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionClient<example_interfaces::action::Fibonacci> client;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci> client;
     NROS_TRY_RET(node.create_action_client(client, "/fibonacci"), 1);
     printf("Callback action client created for: /fibonacci\n");
 
     // Register the three callbacks before sending the goal.
-    nros::ActionClient<example_interfaces::action::Fibonacci>::SendGoalOptions options;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci>::SendGoalOptions options;
     options.goal_response = &on_goal_response;
     options.feedback = &on_feedback;
     options.result = &on_result;
@@ -133,7 +133,7 @@ int nros_app_main(int argc, char** argv) {
     goal.order = order;
     if (!client.send_goal_async(goal, g_goal_id).ok()) {
         fprintf(stderr, "send_goal_async failed\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -145,12 +145,12 @@ int nros_app_main(int argc, char** argv) {
     }
     if (g_accepted == 0) {
         fprintf(stderr, "Goal rejected\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
     if (g_accepted < 0) {
         fprintf(stderr, "No goal response\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -179,7 +179,7 @@ int nros_app_main(int argc, char** argv) {
     }
 
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return rc;

--- a/examples/native/cpp/action-client/src/main.cpp
+++ b/examples/native/cpp/action-client/src/main.cpp
@@ -36,9 +36,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionClient<example_interfaces::action::Fibonacci> client;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci> client;
     NROS_TRY_RET(node.create_action_client(client, "/fibonacci"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Default order=10; override via NROS_TEST_GOAL_ORDER for tests that
     // want to exercise server-side rejection (order >= 64) or other edges.
@@ -66,7 +66,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_action_server(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Action server did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -100,7 +100,7 @@ int nros_app_main(int argc, char** argv) {
         } else {
             fprintf(stderr, "Failed to send goal (order=%d, ret=%d)\n", order, ret.raw());
         }
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -138,13 +138,13 @@ int nros_app_main(int argc, char** argv) {
         printf("]\n");
     } else {
         fprintf(stderr, "Failed to get result: %d\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/cpp/action-server/src/main.cpp
+++ b/examples/native/cpp/action-server/src/main.cpp
@@ -29,7 +29,7 @@ static volatile sig_atomic_t g_running = 1;
 /// globals; `_with_ctx` lets us pass a `void*` through each invocation
 /// so the callback reaches the server and counter without any globals.
 struct ServerState {
-    nros::ActionServer<Fibonacci>* srv;
+    rclcpp_action::Server<Fibonacci>* srv;
     int goal_count;
 };
 
@@ -113,7 +113,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionServer<Fibonacci> srv;
+    rclcpp_action::Server<Fibonacci> srv;
     NROS_TRY_RET(node.create_action_server(srv, "/fibonacci"), 1);
 
     // Register the goal callback with a ServerState context — no globals
@@ -126,13 +126,13 @@ int nros_app_main(int argc, char** argv) {
 
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", state.goal_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/cpp/component-node-poc/src/main.cpp
+++ b/examples/native/cpp/component-node-poc/src/main.cpp
@@ -25,7 +25,7 @@ using Int32 = std_msgs::msg::Int32;
 
 // ---- Talker: IS-A node; ctor creates a publisher + a typed member timer ----
 class Talker : public nros::ComponentNode {
-    nros::Publisher<Int32> pub_;
+    rclcpp::Publisher<Int32> pub_;
     int count_ = 0;
 
   public:

--- a/examples/native/cpp/component-poc/src/main.cpp
+++ b/examples/native/cpp/component-poc/src/main.cpp
@@ -21,7 +21,7 @@ using Int32 = std_msgs::msg::Int32;
 
 // ---- Talker: a timer member callback publishes a real counter --------------
 class Talker {
-    nros::Publisher<Int32> pub_;
+    rclcpp::Publisher<Int32> pub_;
     nros::Timer timer_;
     int count_ = 0;
 
@@ -34,8 +34,8 @@ class Talker {
     }
 
   public:
-    nros::Result configure(nros::Node& node) {
-        nros::Result r = node.create_publisher(pub_, "/chatter");
+    rclcpp::Result configure(nros::Node& node) {
+        rclcpp::Result r = node.create_publisher(pub_, "/chatter");
         if (!r.ok()) return r;
         return nros::bind_timer<Talker, &Talker::on_tick>(node, timer_, 500, this);
     }
@@ -57,7 +57,7 @@ class Listener {
     }
 
   public:
-    nros::Result configure(nros::Node& node) {
+    rclcpp::Result configure(nros::Node& node) {
         // NB: the wire keyexpr uses the DDS-mangled type name the typed
         // `Publisher<Int32>` registers (`std_msgs::msg::dds_::Int32_`), not the
         // ROS slash form — so the raw sub must pass `Int32::TYPE_NAME` to match.
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
     // driving the REAL executor (no synthesizing interpreter). `setup`
     // constructs the topology + binds the real member callbacks.
     return ::nros::board::LinuxBoard::run_components([&]() -> int32_t {
-        nros::Result r = nros::create_node(node, "component_poc");
+        rclcpp::Result r = nros::create_node(node, "component_poc");
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         if (std::strcmp(role, "listener") != 0) {
             r = talker.configure(node);

--- a/examples/native/cpp/listener/src/main.cpp
+++ b/examples/native/cpp/listener/src/main.cpp
@@ -53,7 +53,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Subscription<std_msgs::msg::String> sub;
+    rclcpp::Subscription<std_msgs::msg::String> sub;
     NROS_TRY_RET(node.create_subscription(sub, "/chatter"), 1);
     // phase-342 — the READINESS marker the test matrix waits on
     // (`nros_tests::output::LISTENER_READY_MARKER`). The rust and C listeners
@@ -73,7 +73,7 @@ int nros_app_main(int argc, char** argv) {
     // sub.stream().wait_next(nros::global_handle(), 1000, msg);
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         std_msgs::msg::String msg;
@@ -86,7 +86,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", message_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/cpp/logging/src/main.cpp
+++ b/examples/native/cpp/logging/src/main.cpp
@@ -40,14 +40,14 @@ int nros_app_main(int argc, char** argv) {
     auto created = nros::create_node(node, "demo");
     if (!created.ok()) {
         fprintf(stderr, "create_node failed: %d\n", created.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
     auto logger = node.get_logger();
     if (logger == nullptr) {
         fprintf(stderr, "node.get_logger() returned NULL\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -59,7 +59,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_LOG_ERROR(logger, "round 1: error=%d", 1);
     NROS_LOG_FATAL(logger, "round 1: fatal=%d", 1);
 
-    nros::shutdown();
+    rclcpp::shutdown();
     return 0;
 }
 

--- a/examples/native/cpp/parameters/src/main.cpp
+++ b/examples/native/cpp/parameters/src/main.cpp
@@ -67,7 +67,7 @@ int run() {
     if (params.has_parameter("missing")) return 5;
 
     bool tmp = false;
-    nros::Result missing = params.get_parameter<bool>("missing", tmp);
+    rclcpp::Result missing = params.get_parameter<bool>("missing", tmp);
     if (missing.ok()) return 5;
 
     // ---- Sequence parameters (Phase 242.3) ----

--- a/examples/native/cpp/safety-listener/src/main.cpp
+++ b/examples/native/cpp/safety-listener/src/main.cpp
@@ -39,12 +39,12 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "cpp_safety_listener"), 1);
 
     // Poll-mode subscription — the validated receive path is poll-only.
-    nros::Subscription<std_msgs::msg::Int32> sub;
+    rclcpp::Subscription<std_msgs::msg::Int32> sub;
     NROS_TRY_RET(node.create_subscription(sub, "/chatter"), 1);
     printf("Waiting for Int32 messages on /chatter...\n");
 
     int count = 0;
-    while (nros::ok()) {
+    while (rclcpp::ok()) {
         nros::spin_once(100);
 
         std_msgs::msg::Int32 msg;
@@ -58,7 +58,7 @@ int nros_app_main(int argc, char** argv) {
         }
     }
 
-    nros::shutdown();
+    rclcpp::shutdown();
     return 0;
 }
 

--- a/examples/native/cpp/service-client-callback/src/main.cpp
+++ b/examples/native/cpp/service-client-callback/src/main.cpp
@@ -77,7 +77,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Callback-style client. The arena dispatches `on_response` at
     // `spin_once`; sends are non-blocking via `async_send_request`.
-    nros::Client<example_interfaces::srv::AddTwoInts> client;
+    rclcpp::Client<example_interfaces::srv::AddTwoInts> client;
     NROS_TRY_RET(node.create_client(client, "/add_two_ints", &on_response), 1);
     printf("Callback service client created for: /add_two_ints\n");
 
@@ -92,7 +92,7 @@ int nros_app_main(int argc, char** argv) {
 
     int exit_code = 0;
 
-    nros::Result send = client.async_send_request(req);
+    rclcpp::Result send = client.async_send_request(req);
     if (!send.ok()) {
         fprintf(stderr, "Async send failed with error %d\n", send.raw());
         exit_code = 1;
@@ -111,7 +111,7 @@ int nros_app_main(int argc, char** argv) {
     }
 
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/native/cpp/service-client/src/main.cpp
+++ b/examples/native/cpp/service-client/src/main.cpp
@@ -56,13 +56,13 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Client<example_interfaces::srv::AddTwoInts> client;
+    rclcpp::Client<example_interfaces::srv::AddTwoInts> client;
     NROS_TRY_RET(node.create_client(client, "/add_two_ints"), 1);
 
     example_interfaces::srv::AddTwoInts::Request req;
     req.a = a;
     req.b = b;
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // phase-338 W8 — wait for the service, then call ONCE.
     //
@@ -80,7 +80,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_service(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Service did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -88,7 +88,7 @@ int nros_app_main(int argc, char** argv) {
     auto fut = client.send_request(req);
     if (fut.is_consumed()) {
         fprintf(stderr, "send_request failed\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
     ret = fut.wait(nros::global_handle(), 5000, resp);
@@ -103,7 +103,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/native/cpp/service-server/src/main.cpp
+++ b/examples/native/cpp/service-server/src/main.cpp
@@ -50,9 +50,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Service<example_interfaces::srv::AddTwoInts> srv;
+    rclcpp::Service<example_interfaces::srv::AddTwoInts> srv;
     NROS_TRY_RET(node.create_service(srv, "/add_two_ints"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
@@ -63,7 +63,7 @@ int nros_app_main(int argc, char** argv) {
     int request_count = 0;
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         example_interfaces::srv::AddTwoInts::Request req;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", request_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/cpp/talker/src/main.cpp
+++ b/examples/native/cpp/talker/src/main.cpp
@@ -20,7 +20,7 @@
 // ----------------------------------------------------------------------------
 
 struct TalkerContext {
-    nros::Publisher<std_msgs::msg::String>* publisher;
+    rclcpp::Publisher<std_msgs::msg::String>* publisher;
     int count;
 };
 
@@ -50,7 +50,7 @@ static void timer_callback(void* context) {
     std_msgs::msg::String msg;
     msg.data = payload;
 
-    nros::Result ret = ctx->publisher->publish(msg);
+    rclcpp::Result ret = ctx->publisher->publish(msg);
     if (ret.ok()) {
         printf("Publishing: '%s'\n", msg.data.c_str());
     } else {
@@ -83,7 +83,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Publisher<std_msgs::msg::String> pub;
+    rclcpp::Publisher<std_msgs::msg::String> pub;
     NROS_TRY_RET(node.create_publisher(pub, "/chatter"), 1);
 
     TalkerContext ctx;
@@ -100,13 +100,13 @@ int nros_app_main(int argc, char** argv) {
     printf("\nPublishing messages (Ctrl+C to exit)...\n\n");
 
     // Spin
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/native/cpp/transform-poc/src/main.cpp
+++ b/examples/native/cpp/transform-poc/src/main.cpp
@@ -30,7 +30,7 @@ static int32_t read_i32_le(const uint8_t* p) {
 
 // ---- Source: timer publishes a counter on /in -----------------------------
 class Source {
-    nros::Publisher<Int32> pub_;
+    rclcpp::Publisher<Int32> pub_;
     nros::Timer timer_;
     int count_ = 0;
 
@@ -43,9 +43,9 @@ class Source {
     }
 
   public:
-    nros::Result configure(nros::Node& node) {
+    rclcpp::Result configure(nros::Node& node) {
         std::setvbuf(stdout, nullptr, _IONBF, 0);
-        nros::Result r = node.create_publisher(pub_, "/in");
+        rclcpp::Result r = node.create_publisher(pub_, "/in");
         if (!r.ok()) return r;
         return nros::bind_timer<Source, &Source::on_tick>(node, timer_, 500, this);
     }
@@ -53,7 +53,7 @@ class Source {
 
 // ---- Relay: the TRANSFORM — sub /in → callback doubles → pub /out ----------
 class Relay {
-    nros::Publisher<Int32> out_;
+    rclcpp::Publisher<Int32> out_;
 
     void on_in(const uint8_t* data, size_t len) {
         int32_t v = (len >= 8) ? read_i32_le(data + 4) : 0;
@@ -65,9 +65,9 @@ class Relay {
     }
 
   public:
-    nros::Result configure(nros::Node& node) {
+    rclcpp::Result configure(nros::Node& node) {
         std::setvbuf(stdout, nullptr, _IONBF, 0);
-        nros::Result r = node.create_publisher(out_, "/out");
+        rclcpp::Result r = node.create_publisher(out_, "/out");
         if (!r.ok()) return r;
         return nros::bind_subscription_raw<Relay, &Relay::on_in>(node, "/in", Int32::TYPE_NAME,
                                                                  this);
@@ -82,9 +82,9 @@ class Sink {
     }
 
   public:
-    nros::Result configure(nros::Node& node) {
+    rclcpp::Result configure(nros::Node& node) {
         std::setvbuf(stdout, nullptr, _IONBF, 0);
-        nros::Result r =
+        rclcpp::Result r =
             nros::bind_subscription_raw<Sink, &Sink::on_out>(node, "/out", Int32::TYPE_NAME, this);
         if (r.ok()) std::printf("Waiting for messages\n");
         return r;
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
     Sink sink;
 
     return ::nros::board::LinuxBoard::run_components([&]() -> int32_t {
-        nros::Result r = nros::create_node(node, "transform_poc");
+        rclcpp::Result r = nros::create_node(node, "transform_poc");
         if (!r.ok()) return static_cast<int32_t>(r.raw());
         if (std::strcmp(role, "source") == 0) {
             r = source.configure(node);

--- a/examples/native/rust/action-client-async/src/main.rs
+++ b/examples/native/rust/action-client-async/src/main.rs
@@ -23,7 +23,7 @@
 use example_interfaces::action::{Fibonacci, FibonacciGoal};
 use futures::StreamExt;
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info, nros_warn};
+use nros_log::{Logger, log_error, log_info, log_warn};
 
 // Diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("action-client-async");
@@ -55,7 +55,7 @@ async fn main() {
 
     let goal = FibonacciGoal { order: 10 };
     let order = goal.order;
-    nros_info!(&LOGGER, "Sending goal");
+    log_info!(&LOGGER, "Sending goal");
 
     // LocalSet enables spawn_local (single-threaded, no Send bound needed)
     let local = tokio::task::LocalSet::new();
@@ -71,7 +71,7 @@ async fn main() {
             let (goal_id, promise) = match client.send_goal(&goal) {
                 Ok(pair) => pair,
                 Err(e) => {
-                    nros_error!(&LOGGER, "Failed to send goal: {:?}", e);
+                    log_error!(&LOGGER, "Failed to send goal: {:?}", e);
                     return;
                 }
             };
@@ -79,16 +79,16 @@ async fn main() {
             let accepted = match promise.await {
                 Ok(accepted) => accepted,
                 Err(e) => {
-                    nros_error!(&LOGGER, "Goal acceptance failed: {:?}", e);
+                    log_error!(&LOGGER, "Goal acceptance failed: {:?}", e);
                     return;
                 }
             };
 
             if !accepted {
-                nros_warn!(&LOGGER, "Goal was rejected by the server");
+                log_warn!(&LOGGER, "Goal was rejected by the server");
                 return;
             }
-            nros_info!(&LOGGER, "Goal accepted by server, waiting for result");
+            log_info!(&LOGGER, "Goal accepted by server, waiting for result");
 
             // ── Step 2: Stream feedback with StreamExt ──────────────
             {
@@ -99,7 +99,7 @@ async fn main() {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok(feedback) => {
-                            nros_info!(
+                            log_info!(
                                 &LOGGER,
                                 "Next number in sequence received: {:?}",
                                 feedback.sequence
@@ -110,7 +110,7 @@ async fn main() {
                             }
                         }
                         Err(e) => {
-                            nros_error!(&LOGGER, "Feedback error: {:?}", e);
+                            log_error!(&LOGGER, "Feedback error: {:?}", e);
                             break;
                         }
                     }
@@ -122,13 +122,13 @@ async fn main() {
                 Ok(promise) => match promise.await {
                     Ok((status, result)) => {
                         if status != GoalStatus::Succeeded {
-                            nros_warn!(&LOGGER, "Goal finished with status {:?}", status);
+                            log_warn!(&LOGGER, "Goal finished with status {:?}", status);
                         }
-                        nros_info!(&LOGGER, "Result received: {:?}", result.sequence);
+                        log_info!(&LOGGER, "Result received: {:?}", result.sequence);
                     }
-                    Err(e) => nros_error!(&LOGGER, "get_result failed: {:?}", e),
+                    Err(e) => log_error!(&LOGGER, "get_result failed: {:?}", e),
                 },
-                Err(e) => nros_error!(&LOGGER, "get_result failed: {:?}", e),
+                Err(e) => log_error!(&LOGGER, "get_result failed: {:?}", e),
             }
         })
         .await;

--- a/examples/native/rust/action-client-rtic/src/main.rs
+++ b/examples/native/rust/action-client-rtic/src/main.rs
@@ -13,7 +13,7 @@
 
 use example_interfaces::action::{Fibonacci, FibonacciGoal};
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 
 // Diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("action-client-rtic");
@@ -28,7 +28,7 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
-    nros_info!(&LOGGER, "nros RTIC-pattern Action Client (native)");
+    log_info!(&LOGGER, "nros RTIC-pattern Action Client (native)");
 
     let config = ExecutorConfig::from_env().node_name("fibonacci_action_client");
     let mut executor = Executor::open(&config).expect("Failed to open session");
@@ -40,7 +40,7 @@ fn main() {
         .create_action_client::<Fibonacci>("/fibonacci")
         .expect("Failed to create action client");
 
-    nros_info!(
+    log_info!(
         &LOGGER,
         "Action client created for /fibonacci (RTIC pattern)"
     );
@@ -52,7 +52,7 @@ fn main() {
     }
 
     let goal = FibonacciGoal { order: 10 };
-    nros_info!(&LOGGER, "Sending goal");
+    log_info!(&LOGGER, "Sending goal");
 
     let (goal_id, mut promise) = client.send_goal(&goal).expect("Failed to send goal");
 
@@ -68,10 +68,10 @@ fn main() {
     }
 
     if !accepted {
-        nros_error!(&LOGGER, "Goal not accepted (timeout)");
+        log_error!(&LOGGER, "Goal not accepted (timeout)");
         std::process::exit(1);
     }
-    nros_info!(&LOGGER, "Goal accepted by server, waiting for result");
+    log_info!(&LOGGER, "Goal accepted by server, waiting for result");
 
     // Receive feedback via try_recv_feedback() loop; this client is
     // feedback-stream-only, so the final/full sequence doubles as the result.
@@ -82,13 +82,13 @@ fn main() {
         if let Ok(Some((id, feedback))) = client.try_recv_feedback()
             && id.uuid == goal_id.uuid
         {
-            nros_info!(
+            log_info!(
                 &LOGGER,
                 "Next number in sequence received: {:?}",
                 &feedback.sequence[..]
             );
             if feedback.sequence.len() as i32 > goal.order {
-                nros_info!(&LOGGER, "Result received: {:?}", &feedback.sequence[..]);
+                log_info!(&LOGGER, "Result received: {:?}", &feedback.sequence[..]);
                 got_result = true;
                 break;
             }
@@ -98,7 +98,7 @@ fn main() {
     }
 
     if !got_result {
-        nros_error!(&LOGGER, "Timeout waiting for the full sequence");
+        log_error!(&LOGGER, "Timeout waiting for the full sequence");
         std::process::exit(1);
     }
 }

--- a/examples/native/rust/action-server-rtic/src/main.rs
+++ b/examples/native/rust/action-server-rtic/src/main.rs
@@ -10,7 +10,7 @@
 
 use example_interfaces::action::{Fibonacci, FibonacciFeedback, FibonacciGoal, FibonacciResult};
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 
 // Diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("action-server-rtic");
@@ -25,7 +25,7 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
-    nros_info!(&LOGGER, "nros RTIC-pattern Action Server (native)");
+    log_info!(&LOGGER, "nros RTIC-pattern Action Server (native)");
 
     let config = ExecutorConfig::from_env().node_name("fibonacci_action_server");
     let mut executor = Executor::open(&config).expect("Failed to open session");
@@ -37,8 +37,8 @@ fn main() {
         .create_action_server::<Fibonacci>("/fibonacci")
         .expect("Failed to create action server");
 
-    nros_info!(&LOGGER, "Action server ready: /fibonacci");
-    nros_info!(&LOGGER, "Waiting for action goals (RTIC pattern)...");
+    log_info!(&LOGGER, "Action server ready: /fibonacci");
+    log_info!(&LOGGER, "Waiting for action goals (RTIC pattern)...");
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
 
@@ -47,7 +47,7 @@ fn main() {
 
         // Try to accept new goals
         match server.try_accept_goal(|_goal_id, goal: &FibonacciGoal| {
-            nros_info!(&LOGGER, "Received goal request with order {}", goal.order);
+            log_info!(&LOGGER, "Received goal request with order {}", goal.order);
             GoalResponse::AcceptAndExecute
         }) {
             Ok(Some(goal_id)) => {
@@ -55,7 +55,7 @@ fn main() {
                     let order = active_goal.goal.order;
 
                     server.set_goal_status(&goal_id, GoalStatus::Executing);
-                    nros_info!(&LOGGER, "Executing goal");
+                    log_info!(&LOGGER, "Executing goal");
 
                     // Compute Fibonacci with feedback
                     let mut sequence: heapless::Vec<i32, 64> = heapless::Vec::new();
@@ -75,9 +75,9 @@ fn main() {
                             sequence: sequence.clone(),
                         };
                         if let Err(e) = server.publish_feedback(&goal_id, &feedback) {
-                            nros_error!(&LOGGER, "Feedback error: {:?}", e);
+                            log_error!(&LOGGER, "Feedback error: {:?}", e);
                         } else {
-                            nros_info!(&LOGGER, "Publish feedback");
+                            log_info!(&LOGGER, "Publish feedback");
                         }
 
                         // Drive I/O between feedback publishes
@@ -88,11 +88,11 @@ fn main() {
                     }
 
                     let result = FibonacciResult { sequence };
-                    nros_info!(&LOGGER, "Goal succeeded");
+                    log_info!(&LOGGER, "Goal succeeded");
                     // Issue 0796 — `complete_goal` reports a result the
                     // server could not retain for a later `get_result`.
                     if let Err(e) = server.complete_goal(&goal_id, GoalStatus::Succeeded, result) {
-                        nros_error!(&LOGGER, "complete_goal failed: {:?}", e);
+                        log_error!(&LOGGER, "complete_goal failed: {:?}", e);
                     }
                 }
 
@@ -104,7 +104,7 @@ fn main() {
                 }
             }
             Ok(None) => {}
-            Err(e) => nros_error!(&LOGGER, "Accept error: {:?}", e),
+            Err(e) => log_error!(&LOGGER, "Accept error: {:?}", e),
         }
 
         // Handle cancel requests
@@ -113,5 +113,5 @@ fn main() {
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 
-    nros_info!(&LOGGER, "Done");
+    log_info!(&LOGGER, "Done");
 }

--- a/examples/native/rust/custom-msg/src/main.rs
+++ b/examples/native/rust/custom-msg/src/main.rs
@@ -29,7 +29,7 @@
 
 use heapless::String as HString;
 use nros::{CdrReader, CdrWriter, DeserError, Deserialize, RosMessage, SerError, Serialize};
-use nros_log::{Logger, nros_info};
+use nros_log::{Logger, log_info};
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("custom-msg");
@@ -228,7 +228,7 @@ fn main() {
                 return;
             }
         };
-        nros_info!(&LOGGER, "Session created");
+        log_info!(&LOGGER, "Session created");
 
         // Create publisher
         let nid = executor
@@ -239,7 +239,7 @@ fn main() {
             .node_mut(nid)
             .create_publisher::<SensorReading>("/sensor_data")
             .expect("Failed to create publisher");
-        nros_info!(&LOGGER, "Publisher created for: /sensor_data");
+        log_info!(&LOGGER, "Publisher created for: /sensor_data");
 
         // Register subscription callback
         executor
@@ -251,7 +251,7 @@ fn main() {
                 );
             })
             .expect("Failed to add subscription");
-        nros_info!(&LOGGER, "Subscriber created for: /sensor_data");
+        log_info!(&LOGGER, "Subscriber created for: /sensor_data");
 
         println!();
         println!("Publishing sensor readings...");

--- a/examples/native/rust/custom-transport-listener/src/main.rs
+++ b/examples/native/rust/custom-transport-listener/src/main.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 use std_msgs::msg::String as StringMsg;
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
@@ -26,7 +26,7 @@ fn main() {
     let target =
         std::env::var("NROS_CUSTOM_TCP_TARGET").unwrap_or_else(|_| "127.0.0.1:7447".to_string());
 
-    nros_info!(
+    log_info!(
         &LOGGER,
         "nros Custom-Transport Listener — bridging to TCP {target}"
     );
@@ -38,13 +38,13 @@ fn main() {
     let ops = match nros_transport_callbacks::tcp_transport_ops(&target) {
         Ok(ops) => ops,
         Err(e) => {
-            nros_error!(&LOGGER, "TCP connect to {target} failed: {e}");
+            log_error!(&LOGGER, "TCP connect to {target} failed: {e}");
             std::process::exit(1);
         }
     };
     // SAFETY: the factory leaks its backing state, so it lives until process exit.
     unsafe { nros_rmw::set_custom_transport(Some(ops)).expect("abi v1 ok") };
-    nros_info!(&LOGGER, "Custom transport vtable registered");
+    log_info!(&LOGGER, "Custom transport vtable registered");
 
     // Phase 115.L.5-custom-transport — install zenoh-pico C-vtable
     // backend after staging the custom-transport slot (zenoh-pico
@@ -60,13 +60,13 @@ fn main() {
     executor
         .node_mut(nid)
         .create_subscription::<StringMsg, _>("/chatter", |msg: &StringMsg| {
-            nros_info!(&LOGGER, "I heard: [{}]", msg.data);
+            log_info!(&LOGGER, "I heard: [{}]", msg.data);
         })
         .expect("Failed to add subscription");
     // Issue 0480 — the shared readiness spelling (`output::LISTENER_READY_MARKER`).
     // This bin and `serial-listener` were the only two saying "created on", a
     // second spelling of the same fact that no shared constant could cover.
-    nros_info!(&LOGGER, "Subscriber created for topic: /chatter");
+    log_info!(&LOGGER, "Subscriber created for topic: /chatter");
 
     let max_secs: u64 = std::env::var("NROS_LISTENER_SECS")
         .ok()
@@ -78,5 +78,5 @@ fn main() {
         let _ = executor.spin_once(Duration::from_millis(50));
     }
 
-    nros_info!(&LOGGER, "Listener done");
+    log_info!(&LOGGER, "Listener done");
 }

--- a/examples/native/rust/custom-transport-talker/src/main.rs
+++ b/examples/native/rust/custom-transport-talker/src/main.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 
 use core::fmt::Write as _;
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 use std_msgs::msg::String as StringMsg;
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
@@ -60,14 +60,14 @@ fn main() {
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
     let target = std::env::var("NROS_CUSTOM_TCP_TARGET").unwrap_or_else(|_| {
-        nros_info!(
+        log_info!(
             &LOGGER,
             "NROS_CUSTOM_TCP_TARGET not set; defaulting to 127.0.0.1:7447"
         );
         "127.0.0.1:7447".to_string()
     });
 
-    nros_info!(
+    log_info!(
         &LOGGER,
         "nros Custom-Transport Talker — bridging to TCP {target}"
     );
@@ -81,7 +81,7 @@ fn main() {
     let ops = match nros_transport_callbacks::tcp_transport_ops(&target) {
         Ok(ops) => ops,
         Err(e) => {
-            nros_error!(&LOGGER, "TCP connect to {target} failed: {e}");
+            log_error!(&LOGGER, "TCP connect to {target} failed: {e}");
             std::process::exit(1);
         }
     };
@@ -90,7 +90,7 @@ fn main() {
     unsafe {
         nros_rmw::set_custom_transport(Some(ops)).expect("abi_version v1 ok");
     }
-    nros_info!(&LOGGER, "Custom transport vtable registered");
+    log_info!(&LOGGER, "Custom transport vtable registered");
 
     // Phase 115.L.5-custom-transport — install zenoh-pico C-vtable
     // backend before Executor::open. Order matters: the custom-
@@ -110,7 +110,7 @@ fn main() {
     let publisher = node
         .create_publisher::<StringMsg>("/chatter")
         .expect("Failed to create publisher");
-    nros_info!(&LOGGER, "Publisher created on /chatter");
+    log_info!(&LOGGER, "Publisher created on /chatter");
 
     let max_msgs: i32 = std::env::var("NROS_TALKER_COUNT")
         .ok()
@@ -121,14 +121,14 @@ fn main() {
         let mut msg = StringMsg::default();
         let _ = write!(msg.data, "Hello World: {i}");
         if let Err(e) = publisher.publish(&msg) {
-            nros_error!(&LOGGER, "Publish failed: {e:?}");
+            log_error!(&LOGGER, "Publish failed: {e:?}");
         } else {
-            nros_info!(&LOGGER, "Publishing: '{}'", msg.data);
+            log_info!(&LOGGER, "Publishing: '{}'", msg.data);
         }
         std::thread::sleep(Duration::from_millis(100));
         // Drive session I/O so writes flush.
         let _ = executor.spin_once(Duration::from_millis(10));
     }
 
-    nros_info!(&LOGGER, "Talker done — published {max_msgs} messages");
+    log_info!(&LOGGER, "Talker done — published {max_msgs} messages");
 }

--- a/examples/native/rust/lifecycle-node/src/main.rs
+++ b/examples/native/rust/lifecycle-node/src/main.rs
@@ -36,7 +36,7 @@ use nros::{
     ExecutorConfigEnvExt as _,
     lifecycle::{LifecycleCallbacks, TransitionResult},
 };
-use nros_log::{Logger, nros_info};
+use nros_log::{Logger, log_info};
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("lifecycle-node");
@@ -50,27 +50,27 @@ struct LifecycleDemo;
 
 impl LifecycleCallbacks for LifecycleDemo {
     fn on_configure(&mut self) -> TransitionResult {
-        nros_info!(&LOGGER, "[callback] on_configure — allocating resources");
+        log_info!(&LOGGER, "[callback] on_configure — allocating resources");
         TransitionResult::Success
     }
 
     fn on_activate(&mut self) -> TransitionResult {
-        nros_info!(&LOGGER, "[callback] on_activate — starting work");
+        log_info!(&LOGGER, "[callback] on_activate — starting work");
         TransitionResult::Success
     }
 
     fn on_deactivate(&mut self) -> TransitionResult {
-        nros_info!(&LOGGER, "[callback] on_deactivate — pausing work");
+        log_info!(&LOGGER, "[callback] on_deactivate — pausing work");
         TransitionResult::Success
     }
 
     fn on_cleanup(&mut self) -> TransitionResult {
-        nros_info!(&LOGGER, "[callback] on_cleanup — releasing resources");
+        log_info!(&LOGGER, "[callback] on_cleanup — releasing resources");
         TransitionResult::Success
     }
 
     fn on_shutdown(&mut self) -> TransitionResult {
-        nros_info!(&LOGGER, "[callback] on_shutdown — finalizing");
+        log_info!(&LOGGER, "[callback] on_shutdown — finalizing");
         TransitionResult::Success
     }
 }
@@ -82,7 +82,7 @@ fn main() {
 
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
-    nros_info!(&LOGGER, "Lifecycle demo starting…");
+    log_info!(&LOGGER, "Lifecycle demo starting…");
 
     // `node` is declared before `executor` so it outlives the lifecycle
     // registration (the executor holds a context pointer to it for the run).
@@ -96,9 +96,9 @@ fn main() {
     executor
         .register_lifecycle_node(&mut node)
         .expect("Failed to register lifecycle node");
-    nros_info!(&LOGGER, "Lifecycle services registered on /lifecycle_demo");
+    log_info!(&LOGGER, "Lifecycle services registered on /lifecycle_demo");
 
-    nros_info!(
+    log_info!(
         &LOGGER,
         "Ready. Drive the lifecycle with `ros2 lifecycle set /lifecycle_demo configure`, etc."
     );

--- a/examples/native/rust/listener-rtic/src/main.rs
+++ b/examples/native/rust/listener-rtic/src/main.rs
@@ -8,7 +8,7 @@
 //! This is the native equivalent of `examples/stm32f4/rust/rtic-listener/`.
 
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 use std_msgs::msg::String as StringMsg;
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
@@ -24,7 +24,7 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
-    nros_info!(&LOGGER, "nros RTIC-pattern Listener (native)");
+    log_info!(&LOGGER, "nros RTIC-pattern Listener (native)");
 
     let config = ExecutorConfig::from_env().node_name("listener");
     let mut executor = Executor::open(&config).expect("Failed to open session");
@@ -36,7 +36,7 @@ fn main() {
         .create_subscription::<StringMsg>("/chatter")
         .expect("Failed to create subscription");
 
-    nros_info!(
+    log_info!(
         &LOGGER,
         "Waiting for messages on /chatter (RTIC pattern)..."
     );
@@ -46,10 +46,10 @@ fn main() {
 
         match subscription.take() {
             Ok(Some(msg)) => {
-                nros_info!(&LOGGER, "I heard: [{}]", msg.data);
+                log_info!(&LOGGER, "I heard: [{}]", msg.data);
             }
             Ok(None) => {}
-            Err(e) => nros_error!(&LOGGER, "Receive error: {:?}", e),
+            Err(e) => log_error!(&LOGGER, "Receive error: {:?}", e),
         }
 
         std::thread::sleep(std::time::Duration::from_millis(10));

--- a/examples/native/rust/logging/src/main.rs
+++ b/examples/native/rust/logging/src/main.rs
@@ -26,9 +26,7 @@
 //! [FATAL] demo: round 2: hello with fatal=true
 //! ```
 
-use nros_log::{
-    Logger, Severity, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn,
-};
+use nros_log::{Logger, Severity, log_debug, log_error, log_fatal, log_info, log_warn, nros_trace};
 
 // Pre-register a Logger so `get_logger("demo")` / `Node::logger()`
 // resolve to the same instance.
@@ -56,11 +54,11 @@ fn main() {
             LOGGER.set_level(Severity::Warn);
         }
         nros_trace!(&LOGGER, "round {}: hello with trace={}", round, true);
-        nros_debug!(&LOGGER, "round {}: hello with debug={}", round, true);
-        nros_info!(&LOGGER, "round {}: hello with info={}", round, true);
-        nros_warn!(&LOGGER, "round {}: hello with warn={}", round, true);
-        nros_error!(&LOGGER, "round {}: hello with error={}", round, true);
-        nros_fatal!(&LOGGER, "round {}: hello with fatal={}", round, true);
+        log_debug!(&LOGGER, "round {}: hello with debug={}", round, true);
+        log_info!(&LOGGER, "round {}: hello with info={}", round, true);
+        log_warn!(&LOGGER, "round {}: hello with warn={}", round, true);
+        log_error!(&LOGGER, "round {}: hello with error={}", round, true);
+        log_fatal!(&LOGGER, "round {}: hello with fatal={}", round, true);
     }
 
     nros_log::flush();

--- a/examples/native/rust/serial-listener/src/main.rs
+++ b/examples/native/rust/serial-listener/src/main.rs
@@ -18,7 +18,7 @@ use std::{
 };
 use std_msgs::msg::String as StringMsg;
 
-use nros_log::{Logger, nros_info, nros_warn};
+use nros_log::{Logger, log_info, log_warn};
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("serial-listener");
@@ -43,7 +43,7 @@ fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(5);
 
-    nros_warn!(
+    log_warn!(
         &LOGGER,
         "XRCE Serial Listener: pty={}, domain={}, count={}",
         pty_path,
@@ -69,7 +69,7 @@ fn main() {
         .domain_id(domain_id)
         .node_name("xrce_serial_listener");
     let mut executor: Executor = Executor::open(&config).expect("Failed to open XRCE session");
-    nros_warn!(&LOGGER, "Session created");
+    log_warn!(&LOGGER, "Session created");
 
     // Register subscription callback
     let received = Arc::new(AtomicUsize::new(0));
@@ -82,16 +82,16 @@ fn main() {
         .node_mut(nid)
         .create_subscription::<StringMsg, _>("/chatter", move |msg: &StringMsg| {
             let n = received_cb.fetch_add(1, Ordering::SeqCst) + 1;
-            nros_info!(&LOGGER, "[{}] I heard: [{}]", n, msg.data);
+            log_info!(&LOGGER, "[{}] I heard: [{}]", n, msg.data);
         })
         .expect("Failed to add subscription");
     // Issue 0480 — the shared readiness spelling (`output::LISTENER_READY_MARKER`).
     // Was "Subscriber created on /chatter", the second of two spellings for one
     // fact; the XRCE suites waited on the ambiguous "Waiting for" instead.
-    nros_warn!(&LOGGER, "Subscriber created for topic: /chatter");
+    log_warn!(&LOGGER, "Subscriber created for topic: /chatter");
 
     // Spin loop with timeout
-    nros_info!(&LOGGER, "Waiting for messages...");
+    log_info!(&LOGGER, "Waiting for messages...");
     let start = Instant::now();
     let timeout = std::time::Duration::from_secs(30);
 
@@ -101,9 +101,9 @@ fn main() {
 
     let final_count = received.load(Ordering::SeqCst);
     if final_count >= msg_count {
-        nros_info!(&LOGGER, "Received {} messages, exiting", final_count);
+        log_info!(&LOGGER, "Received {} messages, exiting", final_count);
     } else {
-        nros_warn!(
+        log_warn!(
             &LOGGER,
             "Timeout: received only {}/{} messages",
             final_count,

--- a/examples/native/rust/serial-talker/src/main.rs
+++ b/examples/native/rust/serial-talker/src/main.rs
@@ -16,7 +16,7 @@ use std::sync::{
 };
 use std_msgs::msg::String as StringMsg;
 
-use nros_log::{Logger, nros_info, nros_warn};
+use nros_log::{Logger, log_info, log_warn};
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("serial-talker");
@@ -37,7 +37,7 @@ fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
 
-    nros_warn!(
+    log_warn!(
         &LOGGER,
         "XRCE Serial Talker: pty={}, domain={}",
         pty_path,
@@ -62,7 +62,7 @@ fn main() {
         .domain_id(domain_id)
         .node_name("xrce_serial_talker");
     let mut executor: Executor = Executor::open(&config).expect("Failed to open XRCE session");
-    nros_warn!(&LOGGER, "Session created");
+    log_warn!(&LOGGER, "Session created");
 
     // Create publisher
     let mut node = executor
@@ -71,7 +71,7 @@ fn main() {
     let publisher = node
         .create_publisher::<StringMsg>("/chatter")
         .expect("Failed to create publisher");
-    nros_warn!(&LOGGER, "Publisher created on /chatter");
+    log_warn!(&LOGGER, "Publisher created on /chatter");
 
     // Register timer callback that publishes every 500ms
     let counter = Arc::new(AtomicI32::new(0));
@@ -82,8 +82,8 @@ fn main() {
             let mut msg = StringMsg::default();
             let _ = write!(msg.data, "Hello World: {i}");
             match publisher.publish(&msg) {
-                Ok(()) => nros_info!(&LOGGER, "Publishing: '{}'", msg.data),
-                Err(e) => nros_warn!(&LOGGER, "Publish error: {:?}", e),
+                Ok(()) => log_info!(&LOGGER, "Publishing: '{}'", msg.data),
+                Err(e) => log_warn!(&LOGGER, "Publish error: {:?}", e),
             }
         })
         .expect("Failed to add timer");
@@ -95,5 +95,5 @@ fn main() {
 
     // Clean up
     let _ = executor.close();
-    nros_warn!(&LOGGER, "Talker done");
+    log_warn!(&LOGGER, "Talker done");
 }

--- a/examples/native/rust/service-client-async/src/main.rs
+++ b/examples/native/rust/service-client-async/src/main.rs
@@ -28,7 +28,7 @@
 
 use example_interfaces::srv::{AddTwoInts, AddTwoIntsRequest};
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 
 // Diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("service-client-async");
@@ -83,17 +83,17 @@ async fn main() {
                 Ok(promise) => match promise.await {
                     Ok(reply) => reply,
                     Err(e) => {
-                        nros_error!(&LOGGER, "Service call failed: {:?}", e);
+                        log_error!(&LOGGER, "Service call failed: {:?}", e);
                         std::process::exit(1);
                     }
                 },
                 Err(e) => {
-                    nros_error!(&LOGGER, "Failed to send request: {:?}", e);
+                    log_error!(&LOGGER, "Failed to send request: {:?}", e);
                     std::process::exit(1);
                 }
             };
 
-            nros_info!(&LOGGER, "Result of add_two_ints: {}", reply.sum);
+            log_info!(&LOGGER, "Result of add_two_ints: {}", reply.sum);
         })
         .await;
 }

--- a/examples/native/rust/service-client-rtic/src/main.rs
+++ b/examples/native/rust/service-client-rtic/src/main.rs
@@ -12,7 +12,7 @@
 
 use example_interfaces::srv::{AddTwoInts, AddTwoIntsRequest};
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 
 // Diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("service-client-rtic");
@@ -27,7 +27,7 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
-    nros_info!(&LOGGER, "nros RTIC-pattern Service Client (native)");
+    log_info!(&LOGGER, "nros RTIC-pattern Service Client (native)");
 
     let config = ExecutorConfig::from_env().node_name("add_two_ints_client");
     let mut executor = Executor::open(&config).expect("Failed to open session");
@@ -39,7 +39,7 @@ fn main() {
         .create_client::<AddTwoInts>("/add_two_ints")
         .expect("Failed to create client");
 
-    nros_info!(
+    log_info!(
         &LOGGER,
         "Service client created for /add_two_ints (RTIC pattern)"
     );
@@ -56,7 +56,7 @@ fn main() {
     let mut promise = match client.call(&request) {
         Ok(p) => p,
         Err(e) => {
-            nros_error!(&LOGGER, "Failed to send request: {:?}", e);
+            log_error!(&LOGGER, "Failed to send request: {:?}", e);
             std::process::exit(1);
         }
     };
@@ -69,7 +69,7 @@ fn main() {
         executor.spin_once(core::time::Duration::from_millis(0));
 
         if let Ok(Some(reply)) = promise.take() {
-            nros_info!(&LOGGER, "Result of add_two_ints: {}", reply.sum);
+            log_info!(&LOGGER, "Result of add_two_ints: {}", reply.sum);
             got_reply = true;
             break;
         }
@@ -78,7 +78,7 @@ fn main() {
     }
 
     if !got_reply {
-        nros_error!(&LOGGER, "Timeout waiting for reply");
+        log_error!(&LOGGER, "Timeout waiting for reply");
         std::process::exit(1);
     }
 }

--- a/examples/native/rust/service-server-rtic/src/main.rs
+++ b/examples/native/rust/service-server-rtic/src/main.rs
@@ -9,7 +9,7 @@
 
 use example_interfaces::srv::{AddTwoInts, AddTwoIntsResponse};
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 
 // Diagnostics route through `nros-log`.
 static LOGGER: Logger = Logger::new("service-server-rtic");
@@ -24,7 +24,7 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
-    nros_info!(&LOGGER, "nros RTIC-pattern Service Server (native)");
+    log_info!(&LOGGER, "nros RTIC-pattern Service Server (native)");
 
     let config = ExecutorConfig::from_env().node_name("add_two_ints_server");
     let mut executor = Executor::open(&config).expect("Failed to open session");
@@ -36,8 +36,8 @@ fn main() {
         .create_service::<AddTwoInts>("/add_two_ints")
         .expect("Failed to create service");
 
-    nros_info!(&LOGGER, "Service server ready: /add_two_ints");
-    nros_info!(&LOGGER, "Waiting for service requests (RTIC pattern)...");
+    log_info!(&LOGGER, "Service server ready: /add_two_ints");
+    log_info!(&LOGGER, "Waiting for service requests (RTIC pattern)...");
 
     let mut handled = 0u32;
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
@@ -46,17 +46,17 @@ fn main() {
         executor.spin_once(core::time::Duration::from_millis(0));
 
         match service.handle_request(|req| {
-            nros_info!(&LOGGER, "Incoming request");
-            nros_info!(&LOGGER, "a: {} b: {}", req.a, req.b);
+            log_info!(&LOGGER, "Incoming request");
+            log_info!(&LOGGER, "a: {} b: {}", req.a, req.b);
             AddTwoIntsResponse { sum: req.a + req.b }
         }) {
             Ok(true) => handled += 1,
             Ok(false) => {}
-            Err(e) => nros_error!(&LOGGER, "Service error: {:?}", e),
+            Err(e) => log_error!(&LOGGER, "Service error: {:?}", e),
         }
 
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 
-    nros_info!(&LOGGER, "Done. Handled {} requests", handled);
+    log_info!(&LOGGER, "Done. Handled {} requests", handled);
 }

--- a/examples/native/rust/talker-rtic/src/main.rs
+++ b/examples/native/rust/talker-rtic/src/main.rs
@@ -10,7 +10,7 @@
 use core::fmt::Write as _;
 
 use nros::prelude::*;
-use nros_log::{Logger, nros_error, nros_info};
+use nros_log::{Logger, log_error, log_info};
 use std_msgs::msg::String as StringMsg;
 
 // Phase 88.16.B — diagnostics route through `nros-log`.
@@ -26,7 +26,7 @@ fn main() {
     nros_log::register_logger(&LOGGER);
     nros_log::init(nros_platform_cffi::log::default_sinks());
 
-    nros_info!(&LOGGER, "nros RTIC-pattern Talker (native)");
+    log_info!(&LOGGER, "nros RTIC-pattern Talker (native)");
 
     let config = ExecutorConfig::from_env().node_name("talker");
     let mut executor = Executor::open(&config).expect("Failed to open session");
@@ -38,7 +38,7 @@ fn main() {
         .create_publisher::<StringMsg>("/chatter")
         .expect("Failed to create publisher");
 
-    nros_info!(&LOGGER, "Publishing on /chatter (RTIC pattern)...");
+    log_info!(&LOGGER, "Publishing on /chatter (RTIC pattern)...");
 
     // Stabilization delay (like RTIC Mono::delay(2000.millis()))
     for _ in 0..200 {
@@ -52,8 +52,8 @@ fn main() {
         let mut msg = StringMsg::default();
         let _ = write!(msg.data, "Hello World: {count}");
         match publisher.publish(&msg) {
-            Ok(()) => nros_info!(&LOGGER, "Publishing: '{}'", msg.data),
-            Err(e) => nros_error!(&LOGGER, "Publish error: {:?}", e),
+            Ok(()) => log_info!(&LOGGER, "Publishing: '{}'", msg.data),
+            Err(e) => log_error!(&LOGGER, "Publish error: {:?}", e),
         }
 
         // Drive I/O with spin_once(0) — non-blocking, like RTIC net_poll task

--- a/examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/NrosUorbBridge.cpp
+++ b/examples/px4/cpp/bridge/src/modules/nros_uorb_bridge/NrosUorbBridge.cpp
@@ -131,8 +131,8 @@ class NrosUorbBridge : public ModuleBase<NrosUorbBridge>, public px4::ScheduledW
 
     nros::Node _in_node{};
     nros::Node _out_node{};
-    nros::Subscription<px4_msgs::msg::DebugKeyValue> _in_sub{};
-    nros::Publisher<px4_msgs::msg::DebugKeyValue> _out_pub{};
+    rclcpp::Subscription<px4_msgs::msg::DebugKeyValue> _in_sub{};
+    rclcpp::Publisher<px4_msgs::msg::DebugKeyValue> _out_pub{};
 
     uint32_t _forwarded{0};
     uint32_t _drops{0};

--- a/examples/px4/cpp/firmware/src/modules/nros_uorb_demo/NrosUorbDemo.cpp
+++ b/examples/px4/cpp/firmware/src/modules/nros_uorb_demo/NrosUorbDemo.cpp
@@ -97,8 +97,8 @@ class NrosUorbDemo : public ModuleBase<NrosUorbDemo>, public px4::ScheduledWorkI
     void Run() override;
 
     nros::Node _node{};
-    nros::Publisher<DebugKeyValueTag> _debug_pub{};
-    nros::Subscription<VehicleStatusTag> _status_sub{};
+    rclcpp::Publisher<DebugKeyValueTag> _debug_pub{};
+    rclcpp::Subscription<VehicleStatusTag> _status_sub{};
 
     uint32_t _published{0};
     uint32_t _received{0};

--- a/examples/qemu-arm-freertos/c/action-client/src/main.c
+++ b/examples/qemu-arm-freertos/c/action-client/src/main.c
@@ -132,8 +132,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_client", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(
         nros_action_client_init(&app.action_client, &app.node, "/fibonacci", &fibonacci_type), 1);
@@ -150,7 +151,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Warm-up: spin to allow Zenoh to discover the server's queryables
     for (int i = 0; i < 300; i++) {
-        nros_executor_spin_some(&app.executor, 10000000ULL); // 10ms
+        rclc_executor_spin_some(&app.executor, 10000000ULL); // 10ms
     }
 
     // Send goal: compute Fibonacci sequence of order 10
@@ -243,10 +244,10 @@ int nros_app_main(int argc, char** argv) {
 cleanup:
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_client_fini(&app.action_client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return (ret == NROS_RET_OK) ? 0 : 1;

--- a/examples/qemu-arm-freertos/c/action-server/src/main.c
+++ b/examples/qemu-arm-freertos/c/action-server/src/main.c
@@ -52,7 +52,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -221,8 +221,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_server", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(nros_action_server_init(&app.action_server, &app.node, "/fibonacci",
                                            &fibonacci_type, goal_callback, cancel_callback,
@@ -241,7 +242,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -249,10 +250,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", app.ctx.goal_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_server_fini(&app.action_server);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/c/listener/src/main.c
+++ b/examples/qemu-arm-freertos/c/listener/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -108,26 +108,29 @@ int nros_app_main(int argc, char** argv) {
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "listener", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "listener", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     // Create application context
     app.listener_ctx = (listener_context_t){
         .message_count = 0,
     };
 
-    NROS_CHECK_RET(nros_subscription_init(&app.subscription, &app.node,
-                                          std_msgs_msg_string_get_type_support(), "/chatter",
-                                          subscription_callback, &app.listener_ctx),
+    NROS_CHECK_RET(rclc_subscription_init_default(&app.subscription, &app.node,
+                                                  std_msgs_msg_string_get_type_support(),
+                                                  "/chatter"),
                    1);
     printf("Subscriber created for topic: %s\n",
-           nros_subscription_get_topic_name(&app.subscription));
+           rcl_subscription_get_topic_name(&app.subscription));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(
-        nros_executor_add_subscription(&app.executor, &app.subscription, NROS_EXECUTOR_ON_NEW_DATA),
-        1);
+    /* phase-417 stage 6 — rclc arity: the byte callback is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(nros_executor_add_subscription_raw(&app.executor, &app.subscription,
+                                                      subscription_callback, &app.listener_ctx,
+                                                      NROS_EXECUTOR_ON_NEW_DATA),
+                   1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -137,7 +140,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for messages (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -145,10 +148,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", app.listener_ctx.message_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_subscription_fini(&app.subscription);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/c/service-client/src/main.c
+++ b/examples/qemu-arm-freertos/c/service-client/src/main.c
@@ -82,12 +82,12 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_client", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_client_init(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"),
-                   1);
-    printf("Client created for service: %s\n", nros_client_get_service_name(&app.client));
+    NROS_CHECK_RET(
+        rclc_client_init_default(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Client created for service: %s\n", rcl_client_get_service_name(&app.client));
 
     // Clients must be registered with an executor before use.
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
@@ -137,10 +137,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_client_fini(&app.client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/qemu-arm-freertos/c/service-server/src/main.c
+++ b/examples/qemu-arm-freertos/c/service-server/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -131,17 +131,19 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_server", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_service_init(&app.service, &app.node, &add_two_ints_type, "/add_two_ints",
-                                     service_callback, &app.ctx),
-                   1);
-    printf("Service created: %s\n", nros_service_get_service_name(&app.service));
+    NROS_CHECK_RET(
+        rclc_service_init_default(&app.service, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Service created: %s\n", rcl_service_get_service_name(&app.service));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_service(&app.executor, &app.service), 1);
+    /* phase-417 stage 6 — rclc arity: the request handler is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(
+        nros_executor_add_service_raw(&app.executor, &app.service, service_callback, &app.ctx), 1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -151,7 +153,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for service requests (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -159,10 +161,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", app.ctx.request_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_service_fini(&app.service);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/c/talker/src/main.c
+++ b/examples/qemu-arm-freertos/c/talker/src/main.c
@@ -49,7 +49,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -100,10 +100,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "talker", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "talker", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_string_get_type_support(), "/chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_string_get_type_support(), "/chatter"),
                    1);
 
     // Create application context
@@ -119,24 +119,24 @@ int nros_app_main(int argc, char** argv) {
         1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
 
     // Cleanup
-    nros_executor_fini(&app.executor);
-    nros_timer_fini(&app.timer);
+    rclc_executor_fini(&app.executor);
+    rcl_timer_fini(&app.timer);
     nros_publisher_fini(&app.publisher);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     return 0;
 }

--- a/examples/qemu-arm-freertos/cpp/action-client/src/main.cpp
+++ b/examples/qemu-arm-freertos/cpp/action-client/src/main.cpp
@@ -36,9 +36,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionClient<example_interfaces::action::Fibonacci> client;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci> client;
     NROS_TRY_RET(node.create_action_client(client, "/fibonacci"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Default order=10; override via NROS_TEST_GOAL_ORDER for tests that
     // want to exercise server-side rejection (order >= 64) or other edges.
@@ -66,7 +66,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_action_server(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Action server did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -100,7 +100,7 @@ int nros_app_main(int argc, char** argv) {
         } else {
             fprintf(stderr, "Failed to send goal (order=%d, ret=%d)\n", order, ret.raw());
         }
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -138,13 +138,13 @@ int nros_app_main(int argc, char** argv) {
         printf("]\n");
     } else {
         fprintf(stderr, "Failed to get result: %d\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/cpp/action-server/src/main.cpp
+++ b/examples/qemu-arm-freertos/cpp/action-server/src/main.cpp
@@ -29,7 +29,7 @@ static volatile sig_atomic_t g_running = 1;
 /// globals; `_with_ctx` lets us pass a `void*` through each invocation
 /// so the callback reaches the server and counter without any globals.
 struct ServerState {
-    nros::ActionServer<Fibonacci>* srv;
+    rclcpp_action::Server<Fibonacci>* srv;
     int goal_count;
 };
 
@@ -113,7 +113,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionServer<Fibonacci> srv;
+    rclcpp_action::Server<Fibonacci> srv;
     NROS_TRY_RET(node.create_action_server(srv, "/fibonacci"), 1);
 
     // Register the goal callback with a ServerState context — no globals
@@ -126,13 +126,13 @@ int nros_app_main(int argc, char** argv) {
 
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", state.goal_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/cpp/listener/src/main.cpp
+++ b/examples/qemu-arm-freertos/cpp/listener/src/main.cpp
@@ -53,7 +53,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Subscription<std_msgs::msg::String> sub;
+    rclcpp::Subscription<std_msgs::msg::String> sub;
     NROS_TRY_RET(node.create_subscription(sub, "/chatter"), 1);
     // phase-342 W7 — the READINESS marker the test harness waits on
     // (`nros_tests::output::LISTENER_READY_MARKER`, via `expect_ready`). Every
@@ -74,7 +74,7 @@ int nros_app_main(int argc, char** argv) {
     // sub.stream().wait_next(nros::global_handle(), 1000, msg);
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         std_msgs::msg::String msg;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", message_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/cpp/service-client/src/main.cpp
+++ b/examples/qemu-arm-freertos/cpp/service-client/src/main.cpp
@@ -56,13 +56,13 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Client<example_interfaces::srv::AddTwoInts> client;
+    rclcpp::Client<example_interfaces::srv::AddTwoInts> client;
     NROS_TRY_RET(node.create_client(client, "/add_two_ints"), 1);
 
     example_interfaces::srv::AddTwoInts::Request req;
     req.a = a;
     req.b = b;
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // phase-338 W8 — wait for the service, then call ONCE.
     //
@@ -80,7 +80,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_service(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Service did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -88,7 +88,7 @@ int nros_app_main(int argc, char** argv) {
     auto fut = client.send_request(req);
     if (fut.is_consumed()) {
         fprintf(stderr, "send_request failed\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
     ret = fut.wait(nros::global_handle(), 5000, resp);
@@ -103,7 +103,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/qemu-arm-freertos/cpp/service-server/src/main.cpp
+++ b/examples/qemu-arm-freertos/cpp/service-server/src/main.cpp
@@ -50,9 +50,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Service<example_interfaces::srv::AddTwoInts> srv;
+    rclcpp::Service<example_interfaces::srv::AddTwoInts> srv;
     NROS_TRY_RET(node.create_service(srv, "/add_two_ints"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
@@ -63,7 +63,7 @@ int nros_app_main(int argc, char** argv) {
     int request_count = 0;
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         example_interfaces::srv::AddTwoInts::Request req;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", request_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-freertos/cpp/talker/src/main.cpp
+++ b/examples/qemu-arm-freertos/cpp/talker/src/main.cpp
@@ -20,7 +20,7 @@
 // ----------------------------------------------------------------------------
 
 struct TalkerContext {
-    nros::Publisher<std_msgs::msg::String>* publisher;
+    rclcpp::Publisher<std_msgs::msg::String>* publisher;
     int count;
 };
 
@@ -50,7 +50,7 @@ static void timer_callback(void* context) {
     std_msgs::msg::String msg;
     msg.data = payload;
 
-    nros::Result ret = ctx->publisher->publish(msg);
+    rclcpp::Result ret = ctx->publisher->publish(msg);
     if (ret.ok()) {
         printf("Publishing: '%s'\n", msg.data.c_str());
     } else {
@@ -83,7 +83,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Publisher<std_msgs::msg::String> pub;
+    rclcpp::Publisher<std_msgs::msg::String> pub;
     NROS_TRY_RET(node.create_publisher(pub, "/chatter"), 1);
 
     TalkerContext ctx;
@@ -100,13 +100,13 @@ int nros_app_main(int argc, char** argv) {
     printf("\nPublishing messages (Ctrl+C to exit)...\n\n");
 
     // Spin
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/c/action-client/src/main.c
+++ b/examples/qemu-arm-nuttx/c/action-client/src/main.c
@@ -132,8 +132,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_client", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(
         nros_action_client_init(&app.action_client, &app.node, "/fibonacci", &fibonacci_type), 1);
@@ -150,7 +151,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Warm-up: spin to allow Zenoh to discover the server's queryables
     for (int i = 0; i < 300; i++) {
-        nros_executor_spin_some(&app.executor, 10000000ULL); // 10ms
+        rclc_executor_spin_some(&app.executor, 10000000ULL); // 10ms
     }
 
     // Send goal: compute Fibonacci sequence of order 10
@@ -243,10 +244,10 @@ int nros_app_main(int argc, char** argv) {
 cleanup:
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_client_fini(&app.action_client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return (ret == NROS_RET_OK) ? 0 : 1;

--- a/examples/qemu-arm-nuttx/c/action-server/src/main.c
+++ b/examples/qemu-arm-nuttx/c/action-server/src/main.c
@@ -52,7 +52,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -221,8 +221,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_server", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(nros_action_server_init(&app.action_server, &app.node, "/fibonacci",
                                            &fibonacci_type, goal_callback, cancel_callback,
@@ -241,7 +242,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -249,10 +250,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", app.ctx.goal_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_server_fini(&app.action_server);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/c/listener/src/main.c
+++ b/examples/qemu-arm-nuttx/c/listener/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -108,26 +108,29 @@ int nros_app_main(int argc, char** argv) {
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "listener", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "listener", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     // Create application context
     app.listener_ctx = (listener_context_t){
         .message_count = 0,
     };
 
-    NROS_CHECK_RET(nros_subscription_init(&app.subscription, &app.node,
-                                          std_msgs_msg_string_get_type_support(), "/chatter",
-                                          subscription_callback, &app.listener_ctx),
+    NROS_CHECK_RET(rclc_subscription_init_default(&app.subscription, &app.node,
+                                                  std_msgs_msg_string_get_type_support(),
+                                                  "/chatter"),
                    1);
     printf("Subscriber created for topic: %s\n",
-           nros_subscription_get_topic_name(&app.subscription));
+           rcl_subscription_get_topic_name(&app.subscription));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(
-        nros_executor_add_subscription(&app.executor, &app.subscription, NROS_EXECUTOR_ON_NEW_DATA),
-        1);
+    /* phase-417 stage 6 — rclc arity: the byte callback is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(nros_executor_add_subscription_raw(&app.executor, &app.subscription,
+                                                      subscription_callback, &app.listener_ctx,
+                                                      NROS_EXECUTOR_ON_NEW_DATA),
+                   1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -137,7 +140,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for messages (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -145,10 +148,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", app.listener_ctx.message_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_subscription_fini(&app.subscription);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/c/service-client/src/main.c
+++ b/examples/qemu-arm-nuttx/c/service-client/src/main.c
@@ -82,12 +82,12 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_client", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_client_init(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"),
-                   1);
-    printf("Client created for service: %s\n", nros_client_get_service_name(&app.client));
+    NROS_CHECK_RET(
+        rclc_client_init_default(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Client created for service: %s\n", rcl_client_get_service_name(&app.client));
 
     // Clients must be registered with an executor before use.
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
@@ -137,10 +137,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_client_fini(&app.client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/qemu-arm-nuttx/c/service-server/src/main.c
+++ b/examples/qemu-arm-nuttx/c/service-server/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -131,17 +131,19 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_server", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_service_init(&app.service, &app.node, &add_two_ints_type, "/add_two_ints",
-                                     service_callback, &app.ctx),
-                   1);
-    printf("Service created: %s\n", nros_service_get_service_name(&app.service));
+    NROS_CHECK_RET(
+        rclc_service_init_default(&app.service, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Service created: %s\n", rcl_service_get_service_name(&app.service));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_service(&app.executor, &app.service), 1);
+    /* phase-417 stage 6 — rclc arity: the request handler is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(
+        nros_executor_add_service_raw(&app.executor, &app.service, service_callback, &app.ctx), 1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -151,7 +153,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for service requests (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -159,10 +161,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", app.ctx.request_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_service_fini(&app.service);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/c/talker/src/main.c
+++ b/examples/qemu-arm-nuttx/c/talker/src/main.c
@@ -49,7 +49,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -100,10 +100,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "talker", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "talker", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_string_get_type_support(), "/chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_string_get_type_support(), "/chatter"),
                    1);
 
     // Create application context
@@ -119,24 +119,24 @@ int nros_app_main(int argc, char** argv) {
         1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
 
     // Cleanup
-    nros_executor_fini(&app.executor);
-    nros_timer_fini(&app.timer);
+    rclc_executor_fini(&app.executor);
+    rcl_timer_fini(&app.timer);
     nros_publisher_fini(&app.publisher);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     return 0;
 }

--- a/examples/qemu-arm-nuttx/cpp/action-client/src/main.cpp
+++ b/examples/qemu-arm-nuttx/cpp/action-client/src/main.cpp
@@ -36,9 +36,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionClient<example_interfaces::action::Fibonacci> client;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci> client;
     NROS_TRY_RET(node.create_action_client(client, "/fibonacci"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Default order=10; override via NROS_TEST_GOAL_ORDER for tests that
     // want to exercise server-side rejection (order >= 64) or other edges.
@@ -66,7 +66,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_action_server(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Action server did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -100,7 +100,7 @@ int nros_app_main(int argc, char** argv) {
         } else {
             fprintf(stderr, "Failed to send goal (order=%d, ret=%d)\n", order, ret.raw());
         }
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -138,13 +138,13 @@ int nros_app_main(int argc, char** argv) {
         printf("]\n");
     } else {
         fprintf(stderr, "Failed to get result: %d\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/cpp/action-server/src/main.cpp
+++ b/examples/qemu-arm-nuttx/cpp/action-server/src/main.cpp
@@ -29,7 +29,7 @@ static volatile sig_atomic_t g_running = 1;
 /// globals; `_with_ctx` lets us pass a `void*` through each invocation
 /// so the callback reaches the server and counter without any globals.
 struct ServerState {
-    nros::ActionServer<Fibonacci>* srv;
+    rclcpp_action::Server<Fibonacci>* srv;
     int goal_count;
 };
 
@@ -113,7 +113,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionServer<Fibonacci> srv;
+    rclcpp_action::Server<Fibonacci> srv;
     NROS_TRY_RET(node.create_action_server(srv, "/fibonacci"), 1);
 
     // Register the goal callback with a ServerState context — no globals
@@ -126,13 +126,13 @@ int nros_app_main(int argc, char** argv) {
 
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", state.goal_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/cpp/listener/src/main.cpp
+++ b/examples/qemu-arm-nuttx/cpp/listener/src/main.cpp
@@ -53,7 +53,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Subscription<std_msgs::msg::String> sub;
+    rclcpp::Subscription<std_msgs::msg::String> sub;
     NROS_TRY_RET(node.create_subscription(sub, "/chatter"), 1);
     // phase-342 W7 — the READINESS marker the test harness waits on
     // (`nros_tests::output::LISTENER_READY_MARKER`, via `expect_ready`). Every
@@ -74,7 +74,7 @@ int nros_app_main(int argc, char** argv) {
     // sub.stream().wait_next(nros::global_handle(), 1000, msg);
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         std_msgs::msg::String msg;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", message_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/cpp/service-client/src/main.cpp
+++ b/examples/qemu-arm-nuttx/cpp/service-client/src/main.cpp
@@ -56,13 +56,13 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Client<example_interfaces::srv::AddTwoInts> client;
+    rclcpp::Client<example_interfaces::srv::AddTwoInts> client;
     NROS_TRY_RET(node.create_client(client, "/add_two_ints"), 1);
 
     example_interfaces::srv::AddTwoInts::Request req;
     req.a = a;
     req.b = b;
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // phase-338 W8 — wait for the service, then call ONCE.
     //
@@ -80,7 +80,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_service(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Service did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -88,7 +88,7 @@ int nros_app_main(int argc, char** argv) {
     auto fut = client.send_request(req);
     if (fut.is_consumed()) {
         fprintf(stderr, "send_request failed\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
     ret = fut.wait(nros::global_handle(), 5000, resp);
@@ -103,7 +103,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/qemu-arm-nuttx/cpp/service-server/src/main.cpp
+++ b/examples/qemu-arm-nuttx/cpp/service-server/src/main.cpp
@@ -50,9 +50,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Service<example_interfaces::srv::AddTwoInts> srv;
+    rclcpp::Service<example_interfaces::srv::AddTwoInts> srv;
     NROS_TRY_RET(node.create_service(srv, "/add_two_ints"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
@@ -63,7 +63,7 @@ int nros_app_main(int argc, char** argv) {
     int request_count = 0;
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         example_interfaces::srv::AddTwoInts::Request req;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", request_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-arm-nuttx/cpp/talker/src/main.cpp
+++ b/examples/qemu-arm-nuttx/cpp/talker/src/main.cpp
@@ -20,7 +20,7 @@
 // ----------------------------------------------------------------------------
 
 struct TalkerContext {
-    nros::Publisher<std_msgs::msg::String>* publisher;
+    rclcpp::Publisher<std_msgs::msg::String>* publisher;
     int count;
 };
 
@@ -50,7 +50,7 @@ static void timer_callback(void* context) {
     std_msgs::msg::String msg;
     msg.data = payload;
 
-    nros::Result ret = ctx->publisher->publish(msg);
+    rclcpp::Result ret = ctx->publisher->publish(msg);
     if (ret.ok()) {
         printf("Publishing: '%s'\n", msg.data.c_str());
     } else {
@@ -83,7 +83,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Publisher<std_msgs::msg::String> pub;
+    rclcpp::Publisher<std_msgs::msg::String> pub;
     NROS_TRY_RET(node.create_publisher(pub, "/chatter"), 1);
 
     TalkerContext ctx;
@@ -100,13 +100,13 @@ int nros_app_main(int argc, char** argv) {
     printf("\nPublishing messages (Ctrl+C to exit)...\n\n");
 
     // Spin
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv-nuttx/c/talker/src/main.c
+++ b/examples/qemu-riscv-nuttx/c/talker/src/main.c
@@ -49,7 +49,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -100,10 +100,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "talker", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "talker", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_string_get_type_support(), "/chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_string_get_type_support(), "/chatter"),
                    1);
 
     // Create application context
@@ -119,24 +119,24 @@ int nros_app_main(int argc, char** argv) {
         1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
 
     // Cleanup
-    nros_executor_fini(&app.executor);
-    nros_timer_fini(&app.timer);
+    rclc_executor_fini(&app.executor);
+    rcl_timer_fini(&app.timer);
     nros_publisher_fini(&app.publisher);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     return 0;
 }

--- a/examples/qemu-riscv64-threadx/c/action-client/src/main.c
+++ b/examples/qemu-riscv64-threadx/c/action-client/src/main.c
@@ -132,8 +132,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_client", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(
         nros_action_client_init(&app.action_client, &app.node, "/fibonacci", &fibonacci_type), 1);
@@ -150,7 +151,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Warm-up: spin to allow Zenoh to discover the server's queryables
     for (int i = 0; i < 300; i++) {
-        nros_executor_spin_some(&app.executor, 10000000ULL); // 10ms
+        rclc_executor_spin_some(&app.executor, 10000000ULL); // 10ms
     }
 
     // Send goal: compute Fibonacci sequence of order 10
@@ -243,10 +244,10 @@ int nros_app_main(int argc, char** argv) {
 cleanup:
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_client_fini(&app.action_client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return (ret == NROS_RET_OK) ? 0 : 1;

--- a/examples/qemu-riscv64-threadx/c/action-server/src/main.c
+++ b/examples/qemu-riscv64-threadx/c/action-server/src/main.c
@@ -52,7 +52,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -221,8 +221,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_server", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(nros_action_server_init(&app.action_server, &app.node, "/fibonacci",
                                            &fibonacci_type, goal_callback, cancel_callback,
@@ -241,7 +242,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -249,10 +250,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", app.ctx.goal_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_server_fini(&app.action_server);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/c/listener/src/main.c
+++ b/examples/qemu-riscv64-threadx/c/listener/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -108,26 +108,29 @@ int nros_app_main(int argc, char** argv) {
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "listener", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "listener", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     // Create application context
     app.listener_ctx = (listener_context_t){
         .message_count = 0,
     };
 
-    NROS_CHECK_RET(nros_subscription_init(&app.subscription, &app.node,
-                                          std_msgs_msg_string_get_type_support(), "/chatter",
-                                          subscription_callback, &app.listener_ctx),
+    NROS_CHECK_RET(rclc_subscription_init_default(&app.subscription, &app.node,
+                                                  std_msgs_msg_string_get_type_support(),
+                                                  "/chatter"),
                    1);
     printf("Subscriber created for topic: %s\n",
-           nros_subscription_get_topic_name(&app.subscription));
+           rcl_subscription_get_topic_name(&app.subscription));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(
-        nros_executor_add_subscription(&app.executor, &app.subscription, NROS_EXECUTOR_ON_NEW_DATA),
-        1);
+    /* phase-417 stage 6 — rclc arity: the byte callback is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(nros_executor_add_subscription_raw(&app.executor, &app.subscription,
+                                                      subscription_callback, &app.listener_ctx,
+                                                      NROS_EXECUTOR_ON_NEW_DATA),
+                   1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -137,7 +140,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for messages (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -145,10 +148,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", app.listener_ctx.message_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_subscription_fini(&app.subscription);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/c/service-client/src/main.c
+++ b/examples/qemu-riscv64-threadx/c/service-client/src/main.c
@@ -82,12 +82,12 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_client", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_client_init(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"),
-                   1);
-    printf("Client created for service: %s\n", nros_client_get_service_name(&app.client));
+    NROS_CHECK_RET(
+        rclc_client_init_default(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Client created for service: %s\n", rcl_client_get_service_name(&app.client));
 
     // Clients must be registered with an executor before use.
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
@@ -137,10 +137,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_client_fini(&app.client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/qemu-riscv64-threadx/c/service-server/src/main.c
+++ b/examples/qemu-riscv64-threadx/c/service-server/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -131,17 +131,19 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_server", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_service_init(&app.service, &app.node, &add_two_ints_type, "/add_two_ints",
-                                     service_callback, &app.ctx),
-                   1);
-    printf("Service created: %s\n", nros_service_get_service_name(&app.service));
+    NROS_CHECK_RET(
+        rclc_service_init_default(&app.service, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Service created: %s\n", rcl_service_get_service_name(&app.service));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_service(&app.executor, &app.service), 1);
+    /* phase-417 stage 6 — rclc arity: the request handler is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(
+        nros_executor_add_service_raw(&app.executor, &app.service, service_callback, &app.ctx), 1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -151,7 +153,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for service requests (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -159,10 +161,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", app.ctx.request_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_service_fini(&app.service);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/c/talker/src/main.c
+++ b/examples/qemu-riscv64-threadx/c/talker/src/main.c
@@ -49,7 +49,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -100,10 +100,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "talker", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "talker", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_string_get_type_support(), "/chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_string_get_type_support(), "/chatter"),
                    1);
 
     // Create application context
@@ -119,24 +119,24 @@ int nros_app_main(int argc, char** argv) {
         1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
 
     // Cleanup
-    nros_executor_fini(&app.executor);
-    nros_timer_fini(&app.timer);
+    rclc_executor_fini(&app.executor);
+    rcl_timer_fini(&app.timer);
     nros_publisher_fini(&app.publisher);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     return 0;
 }

--- a/examples/qemu-riscv64-threadx/cpp/action-client/src/main.cpp
+++ b/examples/qemu-riscv64-threadx/cpp/action-client/src/main.cpp
@@ -36,9 +36,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionClient<example_interfaces::action::Fibonacci> client;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci> client;
     NROS_TRY_RET(node.create_action_client(client, "/fibonacci"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Default order=10; override via NROS_TEST_GOAL_ORDER for tests that
     // want to exercise server-side rejection (order >= 64) or other edges.
@@ -66,7 +66,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_action_server(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Action server did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -100,7 +100,7 @@ int nros_app_main(int argc, char** argv) {
         } else {
             fprintf(stderr, "Failed to send goal (order=%d, ret=%d)\n", order, ret.raw());
         }
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -138,13 +138,13 @@ int nros_app_main(int argc, char** argv) {
         printf("]\n");
     } else {
         fprintf(stderr, "Failed to get result: %d\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/cpp/action-server/src/main.cpp
+++ b/examples/qemu-riscv64-threadx/cpp/action-server/src/main.cpp
@@ -29,7 +29,7 @@ static volatile sig_atomic_t g_running = 1;
 /// globals; `_with_ctx` lets us pass a `void*` through each invocation
 /// so the callback reaches the server and counter without any globals.
 struct ServerState {
-    nros::ActionServer<Fibonacci>* srv;
+    rclcpp_action::Server<Fibonacci>* srv;
     int goal_count;
 };
 
@@ -113,7 +113,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionServer<Fibonacci> srv;
+    rclcpp_action::Server<Fibonacci> srv;
     NROS_TRY_RET(node.create_action_server(srv, "/fibonacci"), 1);
 
     // Register the goal callback with a ServerState context — no globals
@@ -126,13 +126,13 @@ int nros_app_main(int argc, char** argv) {
 
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", state.goal_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/cpp/listener/src/main.cpp
+++ b/examples/qemu-riscv64-threadx/cpp/listener/src/main.cpp
@@ -53,7 +53,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Subscription<std_msgs::msg::String> sub;
+    rclcpp::Subscription<std_msgs::msg::String> sub;
     NROS_TRY_RET(node.create_subscription(sub, "/chatter"), 1);
     // phase-342 W7 — the READINESS marker the test harness waits on
     // (`nros_tests::output::LISTENER_READY_MARKER`, via `expect_ready`). Every
@@ -74,7 +74,7 @@ int nros_app_main(int argc, char** argv) {
     // sub.stream().wait_next(nros::global_handle(), 1000, msg);
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         std_msgs::msg::String msg;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", message_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/cpp/service-client/src/main.cpp
+++ b/examples/qemu-riscv64-threadx/cpp/service-client/src/main.cpp
@@ -56,13 +56,13 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Client<example_interfaces::srv::AddTwoInts> client;
+    rclcpp::Client<example_interfaces::srv::AddTwoInts> client;
     NROS_TRY_RET(node.create_client(client, "/add_two_ints"), 1);
 
     example_interfaces::srv::AddTwoInts::Request req;
     req.a = a;
     req.b = b;
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // phase-338 W8 — wait for the service, then call ONCE.
     //
@@ -80,7 +80,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_service(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Service did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -88,7 +88,7 @@ int nros_app_main(int argc, char** argv) {
     auto fut = client.send_request(req);
     if (fut.is_consumed()) {
         fprintf(stderr, "send_request failed\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
     ret = fut.wait(nros::global_handle(), 5000, resp);
@@ -103,7 +103,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/qemu-riscv64-threadx/cpp/service-server/src/main.cpp
+++ b/examples/qemu-riscv64-threadx/cpp/service-server/src/main.cpp
@@ -50,9 +50,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Service<example_interfaces::srv::AddTwoInts> srv;
+    rclcpp::Service<example_interfaces::srv::AddTwoInts> srv;
     NROS_TRY_RET(node.create_service(srv, "/add_two_ints"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
@@ -63,7 +63,7 @@ int nros_app_main(int argc, char** argv) {
     int request_count = 0;
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         example_interfaces::srv::AddTwoInts::Request req;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", request_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/qemu-riscv64-threadx/cpp/talker/src/main.cpp
+++ b/examples/qemu-riscv64-threadx/cpp/talker/src/main.cpp
@@ -20,7 +20,7 @@
 // ----------------------------------------------------------------------------
 
 struct TalkerContext {
-    nros::Publisher<std_msgs::msg::String>* publisher;
+    rclcpp::Publisher<std_msgs::msg::String>* publisher;
     int count;
 };
 
@@ -50,7 +50,7 @@ static void timer_callback(void* context) {
     std_msgs::msg::String msg;
     msg.data = payload;
 
-    nros::Result ret = ctx->publisher->publish(msg);
+    rclcpp::Result ret = ctx->publisher->publish(msg);
     if (ret.ok()) {
         printf("Publishing: '%s'\n", msg.data.c_str());
     } else {
@@ -83,7 +83,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Publisher<std_msgs::msg::String> pub;
+    rclcpp::Publisher<std_msgs::msg::String> pub;
     NROS_TRY_RET(node.create_publisher(pub, "/chatter"), 1);
 
     TalkerContext ctx;
@@ -100,13 +100,13 @@ int nros_app_main(int argc, char** argv) {
     printf("\nPublishing messages (Ctrl+C to exit)...\n\n");
 
     // Spin
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
+++ b/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
@@ -19,7 +19,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_listener_pkg

--- a/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/src/Listener.cpp
+++ b/examples/templates/c-and-cpp-mixed-workspace/src/cpp_listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::nros::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::nros::Node& node) {
     std::setvbuf(stdout, nullptr, _IONBF, 0);
     // Typed member binding (RFC-0044): keyexpr + deserialize come from the
     // generated `std_msgs::msg::Int32` (issue #218 — hand-decode retired).

--- a/examples/templates/multi-node-workspace-cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
+++ b/examples/templates/multi-node-workspace-cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
@@ -20,7 +20,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace listener_pkg

--- a/examples/templates/multi-node-workspace-cpp/src/listener_pkg/src/Listener.cpp
+++ b/examples/templates/multi-node-workspace-cpp/src/listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::nros::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::nros::Node& node) {
     std::setvbuf(stdout, nullptr, _IONBF, 0);
     // The typed `Publisher<Int32>` registers the DDS-mangled keyexpr, so the
     // raw sub must match on `Int32::TYPE_NAME` (240.1 finding; raw↔typed

--- a/examples/templates/multi-node-workspace-cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
+++ b/examples/templates/multi-node-workspace-cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
@@ -13,14 +13,14 @@ namespace talker_pkg {
 /// constructs this object in static storage and calls `configure(node)`; the
 /// executor dispatches `on_tick` during `spin_once`.
 class Talker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick(); // real body; bound via &Talker::on_tick (no callback name)
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace talker_pkg

--- a/examples/templates/multi-node-workspace-cpp/src/talker_pkg/src/Talker.cpp
+++ b/examples/templates/multi-node-workspace-cpp/src/talker_pkg/src/Talker.cpp
@@ -15,9 +15,9 @@ void Talker::on_tick() {
     }
 }
 
-::nros::Result Talker::configure(::nros::Node& node) {
+::rclcpp::Result Talker::configure(::nros::Node& node) {
     std::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
     // Member-fn-pointer-as-template-param → no-alloc trampoline; `this` is ctx.
     return ::nros::bind_timer<Talker, &Talker::on_tick>(node, timer_, 500, this);

--- a/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.cpp
+++ b/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.cpp
@@ -15,10 +15,10 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
                 ++recv_);
 }
 
-::nros::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::nros::Node& node) {
     // Typed member binding (RFC-0044): keyexpr + deserialize come from the
     // generated `std_msgs::msg::Int32` (issue #218 — hand-decode retired).
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::bind_subscription<::std_msgs::msg::Int32, Listener, &Listener::on_msg>(
             node, "/chatter", this);
     if (r.ok()) {

--- a/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.hpp
+++ b/examples/templates/multi-package-workspace/src/pkg_cpp_listener/src/Listener.hpp
@@ -22,7 +22,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // real body; bound by identity
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace pkg_cpp_listener

--- a/examples/threadx-linux/c/action-client/src/main.c
+++ b/examples/threadx-linux/c/action-client/src/main.c
@@ -132,8 +132,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_client", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(
         nros_action_client_init(&app.action_client, &app.node, "/fibonacci", &fibonacci_type), 1);
@@ -150,7 +151,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Warm-up: spin to allow Zenoh to discover the server's queryables
     for (int i = 0; i < 300; i++) {
-        nros_executor_spin_some(&app.executor, 10000000ULL); // 10ms
+        rclc_executor_spin_some(&app.executor, 10000000ULL); // 10ms
     }
 
     // Send goal: compute Fibonacci sequence of order 10
@@ -243,10 +244,10 @@ int nros_app_main(int argc, char** argv) {
 cleanup:
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_client_fini(&app.action_client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return (ret == NROS_RET_OK) ? 0 : 1;

--- a/examples/threadx-linux/c/action-server/src/main.c
+++ b/examples/threadx-linux/c/action-server/src/main.c
@@ -52,7 +52,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -221,8 +221,9 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "fibonacci_action_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "fibonacci_action_server", "/", &app.support),
+                   1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     NROS_CHECK_RET(nros_action_server_init(&app.action_server, &app.node, "/fibonacci",
                                            &fibonacci_type, goal_callback, cancel_callback,
@@ -241,7 +242,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -249,10 +250,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", app.ctx.goal_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_action_server_fini(&app.action_server);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/c/listener/src/main.c
+++ b/examples/threadx-linux/c/listener/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -108,26 +108,29 @@ int nros_app_main(int argc, char** argv) {
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "listener", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "listener", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
     // Create application context
     app.listener_ctx = (listener_context_t){
         .message_count = 0,
     };
 
-    NROS_CHECK_RET(nros_subscription_init(&app.subscription, &app.node,
-                                          std_msgs_msg_string_get_type_support(), "/chatter",
-                                          subscription_callback, &app.listener_ctx),
+    NROS_CHECK_RET(rclc_subscription_init_default(&app.subscription, &app.node,
+                                                  std_msgs_msg_string_get_type_support(),
+                                                  "/chatter"),
                    1);
     printf("Subscriber created for topic: %s\n",
-           nros_subscription_get_topic_name(&app.subscription));
+           rcl_subscription_get_topic_name(&app.subscription));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(
-        nros_executor_add_subscription(&app.executor, &app.subscription, NROS_EXECUTOR_ON_NEW_DATA),
-        1);
+    /* phase-417 stage 6 — rclc arity: the byte callback is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(nros_executor_add_subscription_raw(&app.executor, &app.subscription,
+                                                      subscription_callback, &app.listener_ctx,
+                                                      NROS_EXECUTOR_ON_NEW_DATA),
+                   1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -137,7 +140,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for messages (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -145,10 +148,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", app.listener_ctx.message_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_subscription_fini(&app.subscription);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/c/service-client/src/main.c
+++ b/examples/threadx-linux/c/service-client/src/main.c
@@ -82,12 +82,12 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_client", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_client", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_client_init(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"),
-                   1);
-    printf("Client created for service: %s\n", nros_client_get_service_name(&app.client));
+    NROS_CHECK_RET(
+        rclc_client_init_default(&app.client, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Client created for service: %s\n", rcl_client_get_service_name(&app.client));
 
     // Clients must be registered with an executor before use.
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
@@ -137,10 +137,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_client_fini(&app.client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/threadx-linux/c/service-server/src/main.c
+++ b/examples/threadx-linux/c/service-server/src/main.c
@@ -45,7 +45,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -131,17 +131,19 @@ int nros_app_main(int argc, char** argv) {
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
     printf("Support initialized\n");
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "add_two_ints_server", "/"), 1);
-    printf("Node created: %s\n", nros_node_get_name(&app.node));
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "add_two_ints_server", "/", &app.support), 1);
+    printf("Node created: %s\n", rcl_node_get_name(&app.node));
 
-    NROS_CHECK_RET(nros_service_init(&app.service, &app.node, &add_two_ints_type, "/add_two_ints",
-                                     service_callback, &app.ctx),
-                   1);
-    printf("Service created: %s\n", nros_service_get_service_name(&app.service));
+    NROS_CHECK_RET(
+        rclc_service_init_default(&app.service, &app.node, &add_two_ints_type, "/add_two_ints"), 1);
+    printf("Service created: %s\n", rcl_service_get_service_name(&app.service));
 
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_service(&app.executor, &app.service), 1);
+    /* phase-417 stage 6 — rclc arity: the request handler is supplied at
+     * REGISTRATION, not at `*_init`. */
+    NROS_CHECK_RET(
+        nros_executor_add_service_raw(&app.executor, &app.service, service_callback, &app.ctx), 1);
     printf("Executor created with %d handle(s)\n", nros_executor_get_handle_count(&app.executor));
 
     // Set up signal handler
@@ -151,7 +153,7 @@ int nros_app_main(int argc, char** argv) {
     printf("\nWaiting for service requests (Ctrl+C to exit)...\n\n");
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
@@ -159,10 +161,10 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", app.ctx.request_count);
-    nros_executor_fini(&app.executor);
+    rclc_executor_fini(&app.executor);
     nros_service_fini(&app.service);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/c/talker/src/main.c
+++ b/examples/threadx-linux/c/talker/src/main.c
@@ -49,7 +49,7 @@ static void signal_handler(int signum) {
     (void)signum;
     g_running = 0;
     if (g_executor) {
-        nros_executor_stop(g_executor);
+        nros_executor_cancel(g_executor);
     }
 }
 
@@ -100,10 +100,10 @@ int nros_app_main(int argc, char** argv) {
 
     // Initialize support context
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "talker", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "talker", "/", &app.support), 1);
 
-    NROS_CHECK_RET(nros_publisher_init(&app.publisher, &app.node,
-                                       std_msgs_msg_string_get_type_support(), "/chatter"),
+    NROS_CHECK_RET(rclc_publisher_init_default(&app.publisher, &app.node,
+                                               std_msgs_msg_string_get_type_support(), "/chatter"),
                    1);
 
     // Create application context
@@ -119,24 +119,24 @@ int nros_app_main(int argc, char** argv) {
         1);
     NROS_CHECK_RET(nros_executor_init(&app.executor, &app.support, 4), 1);
     g_executor = &app.executor;
-    NROS_CHECK_RET(nros_executor_add_timer(&app.executor, &app.timer), 1);
+    NROS_CHECK_RET(rclc_executor_add_timer(&app.executor, &app.timer), 1);
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 
     // Spin with 100ms period
-    nros_ret_t ret = nros_executor_spin_period(&app.executor, 100000000ULL);
+    nros_ret_t ret = rclc_executor_spin_period(&app.executor, 100000000ULL);
     if (ret != NROS_RET_OK && g_running) {
         fprintf(stderr, "Executor spin failed: %d\n", ret);
     }
 
     // Cleanup
-    nros_executor_fini(&app.executor);
-    nros_timer_fini(&app.timer);
+    rclc_executor_fini(&app.executor);
+    rcl_timer_fini(&app.timer);
     nros_publisher_fini(&app.publisher);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
 
     return 0;
 }

--- a/examples/threadx-linux/cpp/action-client/src/main.cpp
+++ b/examples/threadx-linux/cpp/action-client/src/main.cpp
@@ -36,9 +36,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionClient<example_interfaces::action::Fibonacci> client;
+    rclcpp_action::Client<example_interfaces::action::Fibonacci> client;
     NROS_TRY_RET(node.create_action_client(client, "/fibonacci"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Default order=10; override via NROS_TEST_GOAL_ORDER for tests that
     // want to exercise server-side rejection (order >= 64) or other edges.
@@ -66,7 +66,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_action_server(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Action server did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -100,7 +100,7 @@ int nros_app_main(int argc, char** argv) {
         } else {
             fprintf(stderr, "Failed to send goal (order=%d, ret=%d)\n", order, ret.raw());
         }
-        nros::shutdown();
+        rclcpp::shutdown();
         return 2;
     }
 
@@ -138,13 +138,13 @@ int nros_app_main(int argc, char** argv) {
         printf("]\n");
     } else {
         fprintf(stderr, "Failed to get result: %d\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/cpp/action-server/src/main.cpp
+++ b/examples/threadx-linux/cpp/action-server/src/main.cpp
@@ -29,7 +29,7 @@ static volatile sig_atomic_t g_running = 1;
 /// globals; `_with_ctx` lets us pass a `void*` through each invocation
 /// so the callback reaches the server and counter without any globals.
 struct ServerState {
-    nros::ActionServer<Fibonacci>* srv;
+    rclcpp_action::Server<Fibonacci>* srv;
     int goal_count;
 };
 
@@ -113,7 +113,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "fibonacci_action_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::ActionServer<Fibonacci> srv;
+    rclcpp_action::Server<Fibonacci> srv;
     NROS_TRY_RET(node.create_action_server(srv, "/fibonacci"), 1);
 
     // Register the goal callback with a ServerState context — no globals
@@ -126,13 +126,13 @@ int nros_app_main(int argc, char** argv) {
 
     printf("\nWaiting for action goals (Ctrl+C to exit)...\n\n");
 
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     printf("\nShutting down...\n");
     printf("Total goals handled: %d\n", state.goal_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/cpp/listener/src/main.cpp
+++ b/examples/threadx-linux/cpp/listener/src/main.cpp
@@ -53,7 +53,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "listener"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Subscription<std_msgs::msg::String> sub;
+    rclcpp::Subscription<std_msgs::msg::String> sub;
     NROS_TRY_RET(node.create_subscription(sub, "/chatter"), 1);
     // phase-342 W7 — the READINESS marker the test harness waits on
     // (`nros_tests::output::LISTENER_READY_MARKER`, via `expect_ready`). Every
@@ -74,7 +74,7 @@ int nros_app_main(int argc, char** argv) {
     // sub.stream().wait_next(nros::global_handle(), 1000, msg);
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         std_msgs::msg::String msg;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total messages received: %d\n", message_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/cpp/service-client/src/main.cpp
+++ b/examples/threadx-linux/cpp/service-client/src/main.cpp
@@ -56,13 +56,13 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_client"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Client<example_interfaces::srv::AddTwoInts> client;
+    rclcpp::Client<example_interfaces::srv::AddTwoInts> client;
     NROS_TRY_RET(node.create_client(client, "/add_two_ints"), 1);
 
     example_interfaces::srv::AddTwoInts::Request req;
     req.a = a;
     req.b = b;
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // phase-338 W8 — wait for the service, then call ONCE.
     //
@@ -80,7 +80,7 @@ int nros_app_main(int argc, char** argv) {
     ret = client.wait_for_service(10000);
     if (!ret.ok()) {
         fprintf(stderr, "Service did not appear within 10s (ret=%d)\n", ret.raw());
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
 
@@ -88,7 +88,7 @@ int nros_app_main(int argc, char** argv) {
     auto fut = client.send_request(req);
     if (fut.is_consumed()) {
         fprintf(stderr, "send_request failed\n");
-        nros::shutdown();
+        rclcpp::shutdown();
         return 1;
     }
     ret = fut.wait(nros::global_handle(), 5000, resp);
@@ -103,7 +103,7 @@ int nros_app_main(int argc, char** argv) {
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return exit_code;

--- a/examples/threadx-linux/cpp/service-server/src/main.cpp
+++ b/examples/threadx-linux/cpp/service-server/src/main.cpp
@@ -50,9 +50,9 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "add_two_ints_server"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Service<example_interfaces::srv::AddTwoInts> srv;
+    rclcpp::Service<example_interfaces::srv::AddTwoInts> srv;
     NROS_TRY_RET(node.create_service(srv, "/add_two_ints"), 1);
-    nros::Result ret;
+    rclcpp::Result ret;
 
     // Set up signal handler
     signal(SIGINT, signal_handler);
@@ -63,7 +63,7 @@ int nros_app_main(int argc, char** argv) {
     int request_count = 0;
 
     // Spin + poll loop
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
 
         example_interfaces::srv::AddTwoInts::Request req;
@@ -87,7 +87,7 @@ int nros_app_main(int argc, char** argv) {
     // Cleanup
     printf("\nShutting down...\n");
     printf("Total requests handled: %d\n", request_count);
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/threadx-linux/cpp/talker/src/main.cpp
+++ b/examples/threadx-linux/cpp/talker/src/main.cpp
@@ -20,7 +20,7 @@
 // ----------------------------------------------------------------------------
 
 struct TalkerContext {
-    nros::Publisher<std_msgs::msg::String>* publisher;
+    rclcpp::Publisher<std_msgs::msg::String>* publisher;
     int count;
 };
 
@@ -50,7 +50,7 @@ static void timer_callback(void* context) {
     std_msgs::msg::String msg;
     msg.data = payload;
 
-    nros::Result ret = ctx->publisher->publish(msg);
+    rclcpp::Result ret = ctx->publisher->publish(msg);
     if (ret.ok()) {
         printf("Publishing: '%s'\n", msg.data.c_str());
     } else {
@@ -83,7 +83,7 @@ int nros_app_main(int argc, char** argv) {
     NROS_TRY_RET(nros::create_node(node, "talker"), 1);
     printf("Node created: %s\n", node.get_name());
 
-    nros::Publisher<std_msgs::msg::String> pub;
+    rclcpp::Publisher<std_msgs::msg::String> pub;
     NROS_TRY_RET(node.create_publisher(pub, "/chatter"), 1);
 
     TalkerContext ctx;
@@ -100,13 +100,13 @@ int nros_app_main(int argc, char** argv) {
     printf("\nPublishing messages (Ctrl+C to exit)...\n\n");
 
     // Spin
-    while (g_running && nros::ok()) {
+    while (g_running && rclcpp::ok()) {
         nros::spin_once(100);
     }
 
     // Cleanup
     printf("\nShutting down...\n");
-    nros::shutdown();
+    rclcpp::shutdown();
 
     printf("Goodbye!\n");
     return 0;

--- a/examples/workspaces/cpp/src/action_client_pkg/include/action_client_pkg/FibClient.hpp
+++ b/examples/workspaces/cpp/src/action_client_pkg/include/action_client_pkg/FibClient.hpp
@@ -55,7 +55,7 @@ class FibClient {
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace action_client_pkg

--- a/examples/workspaces/cpp/src/action_client_pkg/src/FibClient.cpp
+++ b/examples/workspaces/cpp/src/action_client_pkg/src/FibClient.cpp
@@ -92,12 +92,12 @@ void FibClient::on_tick() {
     }
 }
 
-::nros::Result FibClient::configure(::nros::Node& node) {
+::rclcpp::Result FibClient::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     phase_ = Idle;
     waits_ = 0;
 
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::create_action_client_raw(node, client_.bytes, "/fibonacci", Action::TYPE_NAME);
     if (!r.ok()) {
         return r;
@@ -106,7 +106,7 @@ void FibClient::on_tick() {
         nros_cpp_action_client_set_callbacks(client_.bytes, &FibClient::s_goal_response,
                                              /*feedback=*/nullptr, &FibClient::s_result, this);
     if (ret != 0) {
-        return ::nros::Result(ret);
+        return ::rclcpp::Result(ret);
     }
     return ::nros::bind_timer<FibClient, &FibClient::on_tick>(node, timer_, 500, this);
 }

--- a/examples/workspaces/cpp/src/action_server_pkg/include/action_server_pkg/FibServer.hpp
+++ b/examples/workspaces/cpp/src/action_server_pkg/include/action_server_pkg/FibServer.hpp
@@ -35,7 +35,7 @@ class FibServer {
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace action_server_pkg

--- a/examples/workspaces/cpp/src/action_server_pkg/src/FibServer.cpp
+++ b/examples/workspaces/cpp/src/action_server_pkg/src/FibServer.cpp
@@ -69,13 +69,13 @@ void FibServer::on_tick() {
     }
 }
 
-::nros::Result FibServer::configure(::nros::Node& node) {
+::rclcpp::Result FibServer::configure(::nros::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr picolibc lacks the std:: name.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     executor_ = node.executor_handle();
     has_pending_ = false;
 
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::bind_action_server_raw<FibServer, &FibServer::on_goal, &FibServer::on_cancel>(
             node, storage_.bytes, "/fibonacci", Action::TYPE_NAME, this);
     if (!r.ok()) {

--- a/examples/workspaces/cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
+++ b/examples/workspaces/cpp/src/listener_pkg/include/listener_pkg/Listener.hpp
@@ -21,7 +21,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace listener_pkg

--- a/examples/workspaces/cpp/src/listener_pkg/src/Listener.cpp
+++ b/examples/workspaces/cpp/src/listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::nros::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::nros::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr's picolibc <cstdio> does not put
     // setvbuf in namespace std; the C global is available on every platform.
     ::setvbuf(stdout, nullptr, _IONBF, 0);

--- a/examples/workspaces/cpp/src/service_client_pkg/include/service_client_pkg/AddClient.hpp
+++ b/examples/workspaces/cpp/src/service_client_pkg/include/service_client_pkg/AddClient.hpp
@@ -32,7 +32,7 @@ class AddClient {
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace service_client_pkg

--- a/examples/workspaces/cpp/src/service_client_pkg/src/AddClient.cpp
+++ b/examples/workspaces/cpp/src/service_client_pkg/src/AddClient.cpp
@@ -41,9 +41,9 @@ void AddClient::on_tick() {
     }
 }
 
-::nros::Result AddClient::configure(::nros::Node& node) {
+::rclcpp::Result AddClient::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::create_service_client_raw(node, client_.bytes, "/add_two_ints", Svc::TYPE_NAME);
     if (!r.ok()) {
         return r;

--- a/examples/workspaces/cpp/src/service_server_pkg/include/service_server_pkg/AddServer.hpp
+++ b/examples/workspaces/cpp/src/service_server_pkg/include/service_server_pkg/AddServer.hpp
@@ -18,7 +18,7 @@ class AddServer {
     Svc::Response on_request(const Svc::Request& req);
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace service_server_pkg

--- a/examples/workspaces/cpp/src/service_server_pkg/src/AddServer.cpp
+++ b/examples/workspaces/cpp/src/service_server_pkg/src/AddServer.cpp
@@ -16,10 +16,10 @@ AddServer::on_request(const example_interfaces::srv::AddTwoInts::Request& req) {
     return resp;
 }
 
-::nros::Result AddServer::configure(::nros::Node& node) {
+::rclcpp::Result AddServer::configure(::nros::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr picolibc lacks the std:: name.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::bind_service<Svc, AddServer, &AddServer::on_request>(node, "/add_two_ints", this);
     if (r.ok()) {
         std::printf("[service_server_pkg] add_two_ints server ready\n");

--- a/examples/workspaces/cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
+++ b/examples/workspaces/cpp/src/talker_pkg/include/talker_pkg/Talker.hpp
@@ -14,14 +14,14 @@ namespace talker_pkg {
 /// executor dispatches `on_tick` during `spin_once`. Replaces the legacy
 /// `register_node` + `record_callback_effect` declarative seam.
 class Talker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick(); // real body; bound via &Talker::on_tick (no callback name)
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace talker_pkg

--- a/examples/workspaces/cpp/src/talker_pkg/src/Talker.cpp
+++ b/examples/workspaces/cpp/src/talker_pkg/src/Talker.cpp
@@ -21,11 +21,11 @@ void Talker::on_tick() {
     NROS_LOG_INFO(nros_log_default_logger(), "cpp_talker logging seq=%d", m.data);
 }
 
-::nros::Result Talker::configure(::nros::Node& node) {
+::rclcpp::Result Talker::configure(::nros::Node& node) {
     // `::setvbuf` (C global), not `std::setvbuf` — Zephyr's picolibc <cstdio> does not put
     // setvbuf in namespace std; the C global is available on every platform.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
     // Member-fn-pointer-as-template-param → no-alloc trampoline; `this` is ctx.
     return ::nros::bind_timer<Talker, &Talker::on_tick>(node, timer_, 1000, this);

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
@@ -11,14 +11,14 @@ namespace cpp_lifecycle_talker_pkg {
 /// Lifecycle state machine (register + Configure→Activate) is handled by the
 /// generated entry's `__nros_entry_setup` via `nros_cpp_lifecycle_autostart`.
 class LifecycleTalker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int32_t counter_ = 0;
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
@@ -17,7 +17,7 @@ namespace cpp_lifecycle_talker_pkg {
 /// (Configure→Activate, firing the overrides below). Publishing is GATED on the
 /// active state by `on_activate`/`on_deactivate` — proof the overrides run.
 class ManagedTalker : public ::nros::LifecycleNode {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int32_t counter_ = 0;
     bool active_ = false;
@@ -33,7 +33,7 @@ class ManagedTalker : public ::nros::LifecycleNode {
     ::nros::CallbackReturn on_deactivate(::nros::LifecycleState previous) override;
 
     // Component install hook.
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
@@ -18,12 +18,11 @@ void LifecycleTalker::on_tick() {
     }
 }
 
-::nros::Result LifecycleTalker::configure(::nros::Node& node) {
+::rclcpp::Result LifecycleTalker::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
-    return ::nros::bind_timer<LifecycleTalker, &LifecycleTalker::on_tick>(
-        node, timer_, 1000, this);
+    return ::nros::bind_timer<LifecycleTalker, &LifecycleTalker::on_tick>(node, timer_, 1000, this);
 }
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
+++ b/examples/workspaces/features/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
@@ -39,11 +39,11 @@ void ManagedTalker::on_tick() {
     }
 }
 
-::nros::Result ManagedTalker::configure(::nros::Node& node) {
+::rclcpp::Result ManagedTalker::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     // Two-phase: bind the executor handle the component install exposes.
     bind(node.executor_handle());
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) {
         return r;
     }

--- a/examples/workspaces/features/src/cpp_param_talker_pkg/include/cpp_param_talker_pkg/ParamTalker.hpp
+++ b/examples/workspaces/features/src/cpp_param_talker_pkg/include/cpp_param_talker_pkg/ParamTalker.hpp
@@ -11,14 +11,14 @@ namespace cpp_param_talker_pkg {
 /// executor-backed parameter store via `nros_cpp_get_param_integer` and publishes
 /// the value on /chatter.
 class ParamTalker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     void* executor_handle_ = nullptr; /* saved at configure for live reads in on_tick */
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_param_talker_pkg

--- a/examples/workspaces/features/src/cpp_param_talker_pkg/src/ParamTalker.cpp
+++ b/examples/workspaces/features/src/cpp_param_talker_pkg/src/ParamTalker.cpp
@@ -24,10 +24,10 @@ void ParamTalker::on_tick() {
     }
 }
 
-::nros::Result ParamTalker::configure(::nros::Node& node) {
+::rclcpp::Result ParamTalker::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     executor_handle_ = node.executor_handle();
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
     return ::nros::bind_timer<ParamTalker, &ParamTalker::on_tick>(node, timer_, 500, this);
 }

--- a/examples/workspaces/features/src/cpp_qos_listener_pkg/include/cpp_qos_listener_pkg/QosListener.hpp
+++ b/examples/workspaces/features/src/cpp_qos_listener_pkg/include/cpp_qos_listener_pkg/QosListener.hpp
@@ -13,7 +13,7 @@ namespace cpp_qos_listener_pkg {
 /// QosListener — a stateful typed component (RFC-0043). `configure` binds the
 /// member `on_msg` as a typed subscription on `/chatter` with a QoS
 /// profile that MATCHES the talker's publisher (RELIABLE + TRANSIENT_LOCAL +
-/// KEEP_LAST(10), built via the `nros::QoS` builder). Matching the per-entity QoS
+/// KEEP_LAST(10), built via the `rclcpp::QoS` builder). Matching the per-entity QoS
 /// contract is what lets the QoS-tagged endpoints connect. The member decodes the
 /// CDR-encoded Int32 and prints `Received: N`.
 class QosListener {
@@ -22,7 +22,7 @@ class QosListener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_qos_listener_pkg

--- a/examples/workspaces/features/src/cpp_qos_listener_pkg/src/QosListener.cpp
+++ b/examples/workspaces/features/src/cpp_qos_listener_pkg/src/QosListener.cpp
@@ -1,5 +1,5 @@
 // QosListener — typed component (RFC-0043), the C++ projection of ws-qos-c's
-// QosListener. `configure` builds the SAME non-default `nros::QoS`
+// QosListener. `configure` builds the SAME non-default `rclcpp::QoS`
 // (`.reliable().transient_local().keep_last(10)`) the talker declares and passes
 // it to the raw subscription bind. Matching the per-entity QoS contract is what
 // lets the QoS-tagged endpoints connect; a mismatch makes the listener receive
@@ -16,13 +16,13 @@ void QosListener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::nros::Result QosListener::configure(::nros::Node& node) {
+::rclcpp::Result QosListener::configure(::nros::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `Received:` flushes live.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     // Byte-identical to the talker's profile — both endpoints must declare the same
     // RELIABLE + TRANSIENT_LOCAL + KEEP_LAST(10) contract to connect.
-    const ::nros::QoS qos =
-        ::nros::QoS::default_profile().reliable().transient_local().keep_last(10);
+    const ::rclcpp::QoS qos =
+        ::rclcpp::QoS::default_profile().reliable().transient_local().keep_last(10);
     // Typed member binding (RFC-0044): keyexpr + deserialize come from the
     // generated `std_msgs::msg::Int32` (issue #218 — hand-decode retired).
     return ::nros::bind_subscription<::std_msgs::msg::Int32, QosListener, &QosListener::on_msg>(

--- a/examples/workspaces/features/src/cpp_qos_talker_pkg/include/cpp_qos_talker_pkg/QosTalker.hpp
+++ b/examples/workspaces/features/src/cpp_qos_talker_pkg/include/cpp_qos_talker_pkg/QosTalker.hpp
@@ -10,19 +10,19 @@ namespace cpp_qos_talker_pkg {
 /// QosTalker — a stateful typed component (RFC-0043). `configure` creates a
 /// typed `Publisher<std_msgs::msg::Int32>` on `/chatter` with a NON-DEFAULT QoS
 /// profile (RELIABLE + TRANSIENT_LOCAL + KEEP_LAST(10)) built via the
-/// `nros::QoS` builder, and binds the member `on_tick` as a 1 Hz timer that
+/// `rclcpp::QoS` builder, and binds the member `on_tick` as a 1 Hz timer that
 /// publishes a real counter. QoS is a per-entity contract set IN CODE (no launch
 /// `qos_overrides`); the matching `QosListener` declares the byte-identical
 /// profile so the two endpoints connect.
 class QosTalker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick(); // real body; bound via &QosTalker::on_tick (no callback name)
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_qos_talker_pkg

--- a/examples/workspaces/features/src/cpp_qos_talker_pkg/src/QosTalker.cpp
+++ b/examples/workspaces/features/src/cpp_qos_talker_pkg/src/QosTalker.cpp
@@ -1,7 +1,7 @@
 // QosTalker — typed component (RFC-0043), the C++ projection of ws-qos-c's
 // QosTalker. The nano-ros QoS differentiator in C++: instead of the default
 // profile the committed cpp_lifecycle_talker_pkg uses, `configure` builds a NON-DEFAULT
-// `nros::QoS` via the fluent builder (`.reliable().transient_local().keep_last(10)`)
+// `rclcpp::QoS` via the fluent builder (`.reliable().transient_local().keep_last(10)`)
 // and passes it to `Node::create_publisher`. The matching QosListener declares
 // the byte-identical profile so the QoS-matched endpoints connect.
 
@@ -19,15 +19,15 @@ void QosTalker::on_tick() {
     }
 }
 
-::nros::Result QosTalker::configure(::nros::Node& node) {
+::rclcpp::Result QosTalker::configure(::nros::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `Published:` flushes
     // immediately when piped (the test reads the output live).
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     // Non-default QoS contract both endpoints declare: RELIABLE delivery,
     // TRANSIENT_LOCAL durability, KEEP_LAST(10) history depth.
-    const ::nros::QoS qos =
-        ::nros::QoS::default_profile().reliable().transient_local().keep_last(10);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter", qos);
+    const ::rclcpp::QoS qos =
+        ::rclcpp::QoS::default_profile().reliable().transient_local().keep_last(10);
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter", qos);
     if (!r.ok()) return r;
     // Member-fn-pointer-as-template-param → no-alloc trampoline; `this` is ctx.
     return ::nros::bind_timer<QosTalker, &QosTalker::on_tick>(node, timer_, 1000, this);

--- a/examples/workspaces/features/src/cpp_reading_listener_pkg/include/cpp_reading_listener_pkg/ReadingListener.hpp
+++ b/examples/workspaces/features/src/cpp_reading_listener_pkg/include/cpp_reading_listener_pkg/ReadingListener.hpp
@@ -21,7 +21,7 @@ class ReadingListener {
     void on_reading(const ::custom_msgs::msg::Reading& msg); // typed member callback
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_reading_listener_pkg

--- a/examples/workspaces/features/src/cpp_reading_listener_pkg/src/ReadingListener.cpp
+++ b/examples/workspaces/features/src/cpp_reading_listener_pkg/src/ReadingListener.cpp
@@ -14,7 +14,7 @@ void ReadingListener::on_reading(const ::custom_msgs::msg::Reading& msg) {
     ++recv_;
 }
 
-::nros::Result ReadingListener::configure(::nros::Node& node) {
+::rclcpp::Result ReadingListener::configure(::nros::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `reading seq=` flushes live.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
     // Typed member binding (RFC-0044 §242.2): keyexpr + deserialize come from

--- a/examples/workspaces/features/src/cpp_reading_talker_pkg/include/cpp_reading_talker_pkg/ReadingTalker.hpp
+++ b/examples/workspaces/features/src/cpp_reading_talker_pkg/include/cpp_reading_talker_pkg/ReadingTalker.hpp
@@ -17,14 +17,14 @@ namespace cpp_reading_talker_pkg {
 /// own `msg/Reading.msg`). `configure` creates a typed publisher on
 /// `/reading` and binds `on_tick` as a 1 Hz timer whose `sequence` ramps.
 class ReadingTalker {
-    ::nros::Publisher<::custom_msgs::msg::Reading> pub_;
+    ::rclcpp::Publisher<::custom_msgs::msg::Reading> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick(); // real body; bound via &ReadingTalker::on_tick
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_reading_talker_pkg

--- a/examples/workspaces/features/src/cpp_reading_talker_pkg/src/ReadingTalker.cpp
+++ b/examples/workspaces/features/src/cpp_reading_talker_pkg/src/ReadingTalker.cpp
@@ -22,10 +22,10 @@ void ReadingTalker::on_tick() {
     count_++;
 }
 
-::nros::Result ReadingTalker::configure(::nros::Node& node) {
+::rclcpp::Result ReadingTalker::configure(::nros::Node& node) {
     // `::setvbuf` (C global): line-buffer stdout so each `sent seq=` flushes live.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/reading");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/reading");
     if (!r.ok()) return r;
     return ::nros::bind_timer<ReadingTalker, &ReadingTalker::on_tick>(node, timer_, 1000, this);
 }

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/LifecycleTalker.hpp
@@ -11,14 +11,14 @@ namespace cpp_lifecycle_talker_pkg {
 /// Lifecycle state machine (register + Configure→Activate) is handled by the
 /// generated entry's `__nros_entry_setup` via `nros_cpp_lifecycle_autostart`.
 class LifecycleTalker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int32_t counter_ = 0;
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/include/cpp_lifecycle_talker_pkg/ManagedTalker.hpp
@@ -17,7 +17,7 @@ namespace cpp_lifecycle_talker_pkg {
 /// (Configure→Activate, firing the overrides below). Publishing is GATED on the
 /// active state by `on_activate`/`on_deactivate` — proof the overrides run.
 class ManagedTalker : public ::nros::LifecycleNode {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int32_t counter_ = 0;
     bool active_ = false;
@@ -33,7 +33,7 @@ class ManagedTalker : public ::nros::LifecycleNode {
     ::nros::CallbackReturn on_deactivate(::nros::LifecycleState previous) override;
 
     // Component install hook.
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/LifecycleTalker.cpp
@@ -18,12 +18,11 @@ void LifecycleTalker::on_tick() {
     }
 }
 
-::nros::Result LifecycleTalker::configure(::nros::Node& node) {
+::rclcpp::Result LifecycleTalker::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
-    return ::nros::bind_timer<LifecycleTalker, &LifecycleTalker::on_tick>(
-        node, timer_, 1000, this);
+    return ::nros::bind_timer<LifecycleTalker, &LifecycleTalker::on_tick>(node, timer_, 1000, this);
 }
 
 } // namespace cpp_lifecycle_talker_pkg

--- a/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
+++ b/examples/workspaces/managed/src/cpp_lifecycle_talker_pkg/src/ManagedTalker.cpp
@@ -39,11 +39,11 @@ void ManagedTalker::on_tick() {
     }
 }
 
-::nros::Result ManagedTalker::configure(::nros::Node& node) {
+::rclcpp::Result ManagedTalker::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     // Two-phase: bind the executor handle the component install exposes.
     bind(node.executor_handle());
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) {
         return r;
     }

--- a/examples/workspaces/mixed/src/cpp_add_client_pkg/include/cpp_add_client_pkg/AddClient.hpp
+++ b/examples/workspaces/mixed/src/cpp_add_client_pkg/include/cpp_add_client_pkg/AddClient.hpp
@@ -32,7 +32,7 @@ class AddClient {
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_add_client_pkg

--- a/examples/workspaces/mixed/src/cpp_add_client_pkg/src/AddClient.cpp
+++ b/examples/workspaces/mixed/src/cpp_add_client_pkg/src/AddClient.cpp
@@ -41,9 +41,9 @@ void AddClient::on_tick() {
     }
 }
 
-::nros::Result AddClient::configure(::nros::Node& node) {
+::rclcpp::Result AddClient::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::create_service_client_raw(node, client_.bytes, "/add_two_ints", Svc::TYPE_NAME);
     if (!r.ok()) {
         return r;

--- a/examples/workspaces/mixed/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
+++ b/examples/workspaces/mixed/src/cpp_listener_pkg/include/cpp_listener_pkg/Listener.hpp
@@ -19,7 +19,7 @@ class Listener {
     void on_msg(const ::std_msgs::msg::Int32& msg); // typed member callback
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_listener_pkg

--- a/examples/workspaces/mixed/src/cpp_listener_pkg/src/Listener.cpp
+++ b/examples/workspaces/mixed/src/cpp_listener_pkg/src/Listener.cpp
@@ -12,7 +12,7 @@ void Listener::on_msg(const ::std_msgs::msg::Int32& msg) {
     ++recv_;
 }
 
-::nros::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::nros::Node& node) {
     // `::setvbuf`, not `std::setvbuf` — Zephyr picolibc declares it only at global scope
     // (phase-263 C2c-zephyr; same fix as the cpp workspace listener).
     ::setvbuf(stdout, nullptr, _IONBF, 0);

--- a/examples/workspaces/realtime-cpp-subnode-portable/src/subnode_pkg/include/subnode_pkg/SubNode.hpp
+++ b/examples/workspaces/realtime-cpp-subnode-portable/src/subnode_pkg/include/subnode_pkg/SubNode.hpp
@@ -10,8 +10,8 @@ namespace subnode_pkg {
 /// ws-realtime-cpp-subnode's SubNode. Deployed here with "fast"/"bulk" tier names
 /// instead of "high"/"low" — no package change, tier binding from system.toml.
 class SubNode : public ::nros::ComponentNode {
-    ::nros::Publisher<std_msgs::msg::Int32> ctrl_pub_;
-    ::nros::Publisher<std_msgs::msg::Int32> telem_pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> ctrl_pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> telem_pub_;
     int ctrl_count_ = 0;
     int telem_count_ = 0;
 

--- a/examples/workspaces/realtime-cpp/src/aux_pkg/include/aux_pkg/Aux.hpp
+++ b/examples/workspaces/realtime-cpp/src/aux_pkg/include/aux_pkg/Aux.hpp
@@ -14,14 +14,14 @@ namespace aux_pkg {
 /// tier is spawned BY a spawned tier (boot→mid→low), so it is the middle hop
 /// the #144 chained-spawn fix serializes.
 class Aux {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace aux_pkg

--- a/examples/workspaces/realtime-cpp/src/aux_pkg/src/Aux.cpp
+++ b/examples/workspaces/realtime-cpp/src/aux_pkg/src/Aux.cpp
@@ -22,10 +22,10 @@ void Aux::on_tick() {
     count_++;
 }
 
-::nros::Result Aux::configure(::nros::Node& node) {
+::rclcpp::Result Aux::configure(::nros::Node& node) {
     // Line-buffer stdout so each tick flushes immediately when piped.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/aux");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/aux");
     if (!r.ok()) return r;
     return ::nros::bind_timer<Aux, &Aux::on_tick>(node, timer_, 50, this);
 }

--- a/examples/workspaces/realtime-cpp/src/ctrl_pkg/include/ctrl_pkg/Ctrl.hpp
+++ b/examples/workspaces/realtime-cpp/src/ctrl_pkg/include/ctrl_pkg/Ctrl.hpp
@@ -12,14 +12,14 @@ namespace ctrl_pkg {
 /// publishers and timers; the entry binds it to the high-priority sched
 /// context via nros_cpp_node_create_ex (emitted by the C++ codegen path).
 class Ctrl {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace ctrl_pkg

--- a/examples/workspaces/realtime-cpp/src/ctrl_pkg/src/Ctrl.cpp
+++ b/examples/workspaces/realtime-cpp/src/ctrl_pkg/src/Ctrl.cpp
@@ -21,10 +21,10 @@ void Ctrl::on_tick() {
     count_++;
 }
 
-::nros::Result Ctrl::configure(::nros::Node& node) {
+::rclcpp::Result Ctrl::configure(::nros::Node& node) {
     // Line-buffer stdout so each tick flushes immediately when piped.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/ctrl");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/ctrl");
     if (!r.ok()) return r;
     return ::nros::bind_timer<Ctrl, &Ctrl::on_tick>(node, timer_, 10, this);
 }

--- a/examples/workspaces/realtime-cpp/src/subnode_pkg/include/subnode_pkg/SubNode.hpp
+++ b/examples/workspaces/realtime-cpp/src/subnode_pkg/include/subnode_pkg/SubNode.hpp
@@ -21,8 +21,8 @@ namespace subnode_pkg {
 /// bind_group_sched("sub_node", "telem", SC_LOW) before construction, so both
 /// timers land on their respective sched contexts at registration.
 class SubNode : public ::nros::ComponentNode {
-    ::nros::Publisher<std_msgs::msg::Int32> ctrl_pub_;
-    ::nros::Publisher<std_msgs::msg::Int32> telem_pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> ctrl_pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> telem_pub_;
     int ctrl_count_ = 0;
     int telem_count_ = 0;
 

--- a/examples/workspaces/realtime-cpp/src/telem_pkg/include/telem_pkg/Telem.hpp
+++ b/examples/workspaces/realtime-cpp/src/telem_pkg/include/telem_pkg/Telem.hpp
@@ -12,14 +12,14 @@ namespace telem_pkg {
 /// (NodeBuilder::sched). Runs at 1/10 the cadence of ctrl_pkg; the e2e test
 /// asserts ctrl publishes ≥3× as many messages as telem.
 class Telem {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace telem_pkg

--- a/examples/workspaces/realtime-cpp/src/telem_pkg/src/Telem.cpp
+++ b/examples/workspaces/realtime-cpp/src/telem_pkg/src/Telem.cpp
@@ -20,10 +20,10 @@ void Telem::on_tick() {
     count_++;
 }
 
-::nros::Result Telem::configure(::nros::Node& node) {
+::rclcpp::Result Telem::configure(::nros::Node& node) {
     // Line-buffer stdout so each tick flushes immediately when piped.
     ::setvbuf(stdout, nullptr, _IOLBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/telem");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/telem");
     if (!r.ok()) return r;
     return ::nros::bind_timer<Telem, &Telem::on_tick>(node, timer_, 100, this);
 }

--- a/examples/workspaces/safety/src/cpp_safety_listener_pkg/include/cpp_safety_listener_pkg/SafetyListener.hpp
+++ b/examples/workspaces/safety/src/cpp_safety_listener_pkg/include/cpp_safety_listener_pkg/SafetyListener.hpp
@@ -20,15 +20,15 @@ namespace cpp_safety_listener_pkg {
 /// CRC-valid messages increment the counter and republish the count on /safe_ok.
 /// Requires NANO_ROS_SAFETY_E2E=ON (lowered from [system].features = ["safety"]).
 class SafetyListener {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_ok_;
-    ::nros::Subscription<std_msgs::msg::Int32> sub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_ok_;
+    ::rclcpp::Subscription<std_msgs::msg::Int32> sub_;
     int32_t received_ = 0;
     int32_t integrity_faults_ = 0;
 
     void on_chatter(const std_msgs::msg::Int32& msg, const nros_cpp_integrity_status_t& status);
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_safety_listener_pkg

--- a/examples/workspaces/safety/src/cpp_safety_listener_pkg/src/SafetyListener.cpp
+++ b/examples/workspaces/safety/src/cpp_safety_listener_pkg/src/SafetyListener.cpp
@@ -49,12 +49,12 @@ void SafetyListener::on_chatter(const std_msgs::msg::Int32& msg,
     }
 }
 
-::nros::Result SafetyListener::configure(::nros::Node& node) {
+::rclcpp::Result SafetyListener::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     g_safety_listener_self = this;
 
     // Create /safe_ok publisher for reporting CRC-valid counts.
-    ::nros::Result r = node.create_publisher(pub_ok_, "/safe_ok");
+    ::rclcpp::Result r = node.create_publisher(pub_ok_, "/safe_ok");
     if (!r.ok()) return r;
 
     // Register the integrity-carrying subscription on /chatter.

--- a/examples/workspaces/safety/src/cpp_safety_talker_pkg/include/cpp_safety_talker_pkg/SafetyTalker.hpp
+++ b/examples/workspaces/safety/src/cpp_safety_talker_pkg/include/cpp_safety_talker_pkg/SafetyTalker.hpp
@@ -11,14 +11,14 @@ namespace cpp_safety_talker_pkg {
 /// When built with NANO_ROS_SAFETY_E2E=ON the zenoh backend automatically
 /// attaches a CRC-32 + sequence number on every publish — no code change needed.
 class SafetyTalker {
-    ::nros::Publisher<std_msgs::msg::Int32> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::Int32> pub_;
     ::nros::Timer timer_;
     int32_t counter_ = 0;
 
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace cpp_safety_talker_pkg

--- a/examples/workspaces/safety/src/cpp_safety_talker_pkg/src/SafetyTalker.cpp
+++ b/examples/workspaces/safety/src/cpp_safety_talker_pkg/src/SafetyTalker.cpp
@@ -18,9 +18,9 @@ void SafetyTalker::on_tick() {
     }
 }
 
-::nros::Result SafetyTalker::configure(::nros::Node& node) {
+::rclcpp::Result SafetyTalker::configure(::nros::Node& node) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
     return ::nros::bind_timer<SafetyTalker, &SafetyTalker::on_tick>(node, timer_, 1000, this);
 }

--- a/examples/zephyr/cpp/action-client/src/FibonacciClient.cpp
+++ b/examples/zephyr/cpp/action-client/src/FibonacciClient.cpp
@@ -53,14 +53,14 @@ void FibonacciClient::on_result(const uint8_t* /*goal_id*/, int32_t /*status*/, 
     print_sequence("Result received: ", data, len);
 }
 
-::nros::Result FibonacciClient::configure(::nros::Node& node) {
+::rclcpp::Result FibonacciClient::configure(::nros::Node& node) {
     // Unbuffered stdout — the callback prints only on transitions, so a
     // full-buffered console would swallow them when the harness kills the QEMU.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc
     // `<cstdio>` declares it in the global namespace only.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
 
-    ::nros::Result r =
+    ::rclcpp::Result r =
         ::nros::bind_action_client<FibonacciClient, &FibonacciClient::on_goal_response,
                                    &FibonacciClient::on_feedback, &FibonacciClient::on_result>(
             node, client_, poll_timer_, "/fibonacci", "example_interfaces/action/Fibonacci", this);
@@ -76,7 +76,7 @@ void FibonacciClient::on_result(const uint8_t* /*goal_id*/, int32_t /*status*/, 
     uint8_t goal_id[16];
     std::printf("Sending goal\n");
     nros_cpp_action_client_send_goal_async(client_.bytes, goal, sizeof(goal), &goal_id);
-    return ::nros::Result();
+    return ::rclcpp::Result();
 }
 
 } // namespace zephyr_cpp_action_client

--- a/examples/zephyr/cpp/action-client/src/FibonacciClient.hpp
+++ b/examples/zephyr/cpp/action-client/src/FibonacciClient.hpp
@@ -26,7 +26,7 @@ class FibonacciClient {
     void on_result(const uint8_t goal_id[16], int32_t status, const uint8_t* data, size_t len);
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace zephyr_cpp_action_client

--- a/examples/zephyr/cpp/action-server/src/FibonacciServer.cpp
+++ b/examples/zephyr/cpp/action-server/src/FibonacciServer.cpp
@@ -89,15 +89,15 @@ void FibonacciServer::on_tick() {
     }
 }
 
-::nros::Result FibonacciServer::configure(::nros::Node& node) {
+::rclcpp::Result FibonacciServer::configure(::nros::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc
     // `<cstdio>` declares it in the global namespace only.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     executor_ = node.executor_handle();
-    ::nros::Result r = ::nros::bind_action_server_raw<FibonacciServer, &FibonacciServer::on_goal,
-                                                      &FibonacciServer::on_cancel>(
+    ::rclcpp::Result r = ::nros::bind_action_server_raw<FibonacciServer, &FibonacciServer::on_goal,
+                                                        &FibonacciServer::on_cancel>(
         node, storage_.bytes, "/fibonacci", "example_interfaces/action/Fibonacci", this);
     if (!r.ok()) {
         return r;

--- a/examples/zephyr/cpp/action-server/src/FibonacciServer.hpp
+++ b/examples/zephyr/cpp/action-server/src/FibonacciServer.hpp
@@ -33,7 +33,7 @@ class FibonacciServer {
     void on_tick();
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace zephyr_cpp_action_server

--- a/examples/zephyr/cpp/listener/src/Listener.cpp
+++ b/examples/zephyr/cpp/listener/src/Listener.cpp
@@ -17,7 +17,7 @@ void Listener::on_raw(const uint8_t* data, size_t len) {
     }
 }
 
-::nros::Result Listener::configure(::nros::Node& node) {
+::rclcpp::Result Listener::configure(::nros::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc
@@ -25,7 +25,7 @@ void Listener::on_raw(const uint8_t* data, size_t len) {
     ::setvbuf(stdout, nullptr, _IONBF, 0);
     // Raw (zero-copy) subscription bound to the member by identity; type name is
     // the DDS-mangled form to match the sibling typed talker's Publisher<String>.
-    ::nros::Result r = ::nros::bind_subscription_raw<Listener, &Listener::on_raw>(
+    ::rclcpp::Result r = ::nros::bind_subscription_raw<Listener, &Listener::on_raw>(
         node, "/chatter", std_msgs::msg::String::TYPE_NAME, this);
     if (r.ok()) {
         // Readiness marker the rtos_e2e harness greps before driving the talker.

--- a/examples/zephyr/cpp/listener/src/Listener.hpp
+++ b/examples/zephyr/cpp/listener/src/Listener.hpp
@@ -22,7 +22,7 @@ class Listener {
     void on_raw(const uint8_t* data, size_t len); // real body; bound by identity
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace zephyr_cpp_listener

--- a/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.cpp
+++ b/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.cpp
@@ -50,14 +50,14 @@ void AddTwoIntsClient::on_tick() {
     }
 }
 
-::nros::Result AddTwoIntsClient::configure(::nros::Node& node) {
+::rclcpp::Result AddTwoIntsClient::configure(::nros::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc
     // `<cstdio>` declares it in the global namespace only.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = ::nros::create_service_client_raw(node, client_.bytes, "/add_two_ints",
-                                                         "example_interfaces/srv/AddTwoInts");
+    ::rclcpp::Result r = ::nros::create_service_client_raw(node, client_.bytes, "/add_two_ints",
+                                                           "example_interfaces/srv/AddTwoInts");
     if (!r.ok()) return r;
     r = ::nros::bind_timer<AddTwoIntsClient, &AddTwoIntsClient::on_tick>(node, timer_, 1000, this);
     if (r.ok()) {

--- a/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.hpp
+++ b/examples/zephyr/cpp/service-client/src/AddTwoIntsClient.hpp
@@ -26,7 +26,7 @@ class AddTwoIntsClient {
     void on_tick(); // send / poll driver, bound by identity
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace zephyr_cpp_service_client

--- a/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.cpp
+++ b/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.cpp
@@ -44,13 +44,13 @@ bool AddTwoIntsServer::handle_add(const uint8_t* req, size_t req_len, uint8_t* r
     return true;
 }
 
-::nros::Result AddTwoIntsServer::configure(::nros::Node& node) {
+::rclcpp::Result AddTwoIntsServer::configure(::nros::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc
     // `<cstdio>` declares it in the global namespace only.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = ::nros::bind_service_raw<AddTwoIntsServer, &AddTwoIntsServer::handle_add>(
+    ::rclcpp::Result r = ::nros::bind_service_raw<AddTwoIntsServer, &AddTwoIntsServer::handle_add>(
         node, "/add_two_ints", "example_interfaces/srv/AddTwoInts", this);
     if (r.ok()) {
         // Readiness marker the e2e harness greps before driving the client.

--- a/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.hpp
+++ b/examples/zephyr/cpp/service-server/src/AddTwoIntsServer.hpp
@@ -21,7 +21,7 @@ class AddTwoIntsServer {
                     size_t* resp_len);
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace zephyr_cpp_service_server

--- a/examples/zephyr/cpp/talker/src/Talker.cpp
+++ b/examples/zephyr/cpp/talker/src/Talker.cpp
@@ -20,13 +20,13 @@ void Talker::on_tick() {
     }
 }
 
-::nros::Result Talker::configure(::nros::Node& node) {
+::rclcpp::Result Talker::configure(::nros::Node& node) {
     // Unbuffered stdout — a full-buffered console can swallow the final
     // line(s) when the harness kills the QEMU before a flush.
     // `::setvbuf` (global) not `std::setvbuf` — Zephyr's minimal libcpp/picolibc
     // `<cstdio>` declares it in the global namespace only.
     ::setvbuf(stdout, nullptr, _IONBF, 0);
-    ::nros::Result r = node.create_publisher(pub_, "/chatter");
+    ::rclcpp::Result r = node.create_publisher(pub_, "/chatter");
     if (!r.ok()) return r;
     return ::nros::bind_timer<Talker, &Talker::on_tick>(node, timer_, 500, this);
 }

--- a/examples/zephyr/cpp/talker/src/Talker.hpp
+++ b/examples/zephyr/cpp/talker/src/Talker.hpp
@@ -14,14 +14,14 @@
 namespace zephyr_cpp_talker {
 
 class Talker {
-    ::nros::Publisher<std_msgs::msg::String> pub_;
+    ::rclcpp::Publisher<std_msgs::msg::String> pub_;
     ::nros::Timer timer_;
     int count_ = 0;
 
     void on_tick(); // real body, bound by identity
 
   public:
-    ::nros::Result configure(::nros::Node& node);
+    ::rclcpp::Result configure(::nros::Node& node);
 };
 
 } // namespace zephyr_cpp_talker

--- a/just/check.just
+++ b/just/check.just
@@ -3794,7 +3794,7 @@ cpp: cpp-fmt
     echo "  - phase-417: ported-file surface COMPILES (aliases, string interop, graph, actions, executor)"
     for probe in ros2_api_adoption node_graph_forwarders ros2_api_adoption_stage2 ros2_one_dispatch_path \
                  ros2_init_argv_refusal action_goal_uuid executor_cancel; do \
-        c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+        c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti -DNROS_CPP_STD \
             -Itarget/nros-cpp-generated \
             -Itarget/nros-c-generated \
             -Ipackages/api/nros-cpp/include \

--- a/packages/api/nros-c/src/log.rs
+++ b/packages/api/nros-c/src/log.rs
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn nros_log_get_logger(name: *const c_char) -> *const c_vo
         Some(logger) => (logger as *const nros_log::Logger).cast(),
         None => {
             let (used, total) = nros_log::dynamic_logger_name_arena();
-            nros_log::nros_warn!(
+            nros_log::log_warn!(
                 &nros_log::DEFAULT_LOGGER,
                 "nros_log_get_logger(\"{name}\"): no logger created — {} of {} slots and {used} \
                  of {total} name bytes are spent, or the name is over {} bytes. Returning the \
@@ -544,7 +544,7 @@ fn warn_once_if_no_clock() {
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
         .is_ok()
     {
-        nros_log::nros_warn!(
+        nros_log::log_warn!(
             &nros_log::DEFAULT_LOGGER,
             "NROS_LOG_*_THROTTLE has no monotonic clock (nros-log's `platform-clock` feature is \
              off), so every timestamp is 0 and the window can never elapse: throttled sites will \

--- a/packages/api/nros-c/src/node.rs
+++ b/packages/api/nros-c/src/node.rs
@@ -41,7 +41,7 @@ fn resolve_domain_from_c_abi(raw: u8, session_domain: u32) -> Option<u32> {
         // wrong one — it is unroutable, and silent, because a domain is just
         // the first element of the discovery key (issue 0801).
         Some(d) if d > nros_node::DOMAIN_ID_MAX => {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros-c"),
                 "domain id {} exceeds the ROS maximum of {}; refusing to create \
                  the entity rather than keying it on an unroutable domain \

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -246,14 +246,25 @@ inline Result spin(uint32_t duration_ms, int32_t poll_ms = 10) {
 #include <cstdlib>     // std::abort -- the runtime half of RFC-0089 W3.b
 #include <type_traits> // the SFINAE guards on create_service / create_client
 
+// `<chrono>` requires the EXPLICIT opt-in, not `__has_include`, and that is
+// measured rather than stylistic.
+//
+// `__has_include(<chrono>)` is TRUE on the Zephyr arm-none-eabi toolchain --
+// the file exists -- but under `-ffreestanding` libstdc++ ships it INCOMPLETE:
+// `std::chrono::duration_cast` is absent, so `create_wall_timer` and `Rate`
+// failed to compile on every Zephyr C++ image with
+// `'duration_cast' is not a member of 'std::chrono'`. Replayed from that build
+// dir's own recorded compile command, not inferred.
+//
+// So the idiom has a boundary worth stating: `__has_include` answers "does the
+// header exist", which is the right question for `<memory>` (present or absent
+// as a unit) and the WRONG one for `<chrono>` (present but hollowed out). Where
+// a freestanding toolchain ships a partial header, only the consumer's own
+// `NROS_CPP_STD` opt-in is a reliable signal. Issue 0112's class, one layer past
+// where step A caught it.
 #if defined(NROS_CPP_STD)
 #include <chrono>
 #define NROS_CPP_HAS_STD_CHRONO 1
-#elif defined(__has_include)
-#if __has_include(<chrono>)
-#include <chrono>
-#define NROS_CPP_HAS_STD_CHRONO 1
-#endif
 #endif
 
 namespace rclcpp {

--- a/packages/api/nros-cpp/include/nros/qos.hpp
+++ b/packages/api/nros-cpp/include/nros/qos.hpp
@@ -22,7 +22,17 @@
 // `NROS_RCLCPP_REFUSE_*` diagnostics, used by `SystemDefaultsQoS` below.
 // `log.hpp` includes nothing of ours, so this adds no cycle.
 #include "nros/log.hpp"
-#include <type_traits> // rclcpp::detail::is_qos_arg
+// `<type_traits>` is GATED, and this is issue 0112's class one step further
+// than step A caught it. Zephyr's minimal libcpp ships exactly THREE headers --
+// `cstddef`, `cstdint`, `new` (`zephyr/lib/cpp/minimal/include/`) -- so an
+// UNGATED include here made `#include <nros/nros.hpp>` fail to compile on every
+// Zephyr C++ image. Step A verified against a SYNTHESISED minimal libcpp that
+// happened to provide `<type_traits>`, so the lane stayed green.
+//
+// `is_qos_arg` exists only to disambiguate `rclcpp::Node`'s create_service
+// overloads, and that node type is itself hosted-only, so nothing freestanding
+// can reach the predicate.
+// This header includes NOTHING, deliberately -- see `is_qos_arg` below.
 
 // FFI struct definition — mirrors `nros_cpp_qos_t` in
 // nros_cpp_ffi.h. Phase 118.D: guarded by `NROS_CPP_FFI_H`. If
@@ -500,8 +510,55 @@ namespace detail {
 /// good poll-style call fails with the shared_ptr-callback diagnostic — a
 /// refusal firing on something it does not describe, which is worse than no
 /// refusal. Caught by the positive probe on its first compile.
-template <typename F>
-struct is_qos_arg : ::std::is_base_of<::nros::QoS, typename ::std::decay<F>::type> {};
+/// Written WITHOUT `<type_traits>`, and the two failures that forced it are
+/// different failures:
+///
+/// * On the Zephyr arm-none-eabi toolchain `__has_include(<type_traits>)` is
+///   TRUE and the header is INCOMPLETE -- `enable_if` and `is_convertible` are
+///   there, `is_base_of` and `decay` are not. `__has_include` answers "does the
+///   header exist", which is the wrong question for a header a freestanding
+///   toolchain ships hollowed out. (Issue 0112's class; step A verified against
+///   a SYNTHESISED minimal libcpp that happened to be more complete than the
+///   real one, so the lane stayed green.)
+/// * Gating the include on `NROS_CPP_STD` instead fixed Zephyr and broke the
+///   freestanding-syntax lane, because the two predicates do not partition the
+///   lanes the way the names suggest. The `rclcpp::` block in `nros.hpp` is
+///   NOT behind `NROS_CPP_STD` -- step A declared it unconditionally, and it
+///   hands out `std::shared_ptr` and `std::string` -- so the freestanding lane
+///   compiles `rclcpp::Node` against a SYNTHESISED minimal libcpp while
+///   defining no opt-in at all. There the header exists and the macro does not;
+///   on Zephyr the macro is available and the header is hollow. Neither
+///   predicate is true in both lanes.
+///
+/// So the predicate depends on neither: a derived-to-base pointer conversion
+/// under overload resolution answers `is_base_of` with nothing but the core
+/// language, and the partial specialisations answer `decay` for every form a
+/// by-value template parameter can take.
+template <typename F> struct qos_arg_strip {
+    typedef F type;
+};
+template <typename F> struct qos_arg_strip<F&> {
+    typedef F type;
+};
+template <typename F> struct qos_arg_strip<const F&> {
+    typedef F type;
+};
+template <typename F> struct qos_arg_strip<const F> {
+    typedef F type;
+};
+
+template <typename F> class is_qos_arg {
+    typedef char yes_t[1];
+    typedef char no_t[2];
+    // Declared, never defined: both calls live in `sizeof`, which does not
+    // evaluate its operand.
+    static yes_t& probe(const ::nros::QoS*);
+    static no_t& probe(...);
+    static typename qos_arg_strip<F>::type* arg();
+
+  public:
+    static const bool value = sizeof(probe(arg())) == sizeof(yes_t);
+};
 
 } // namespace detail
 

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -743,7 +743,7 @@ pub unsafe extern "C" fn nros_cpp_init(
 macro_rules! cpp_diag {
     ($($arg:tt)+) => {{
         let logger: &'static nros_log::Logger = nros_log::get_logger("nros_cpp");
-        nros_log::nros_error!(logger, $($arg)+);
+        nros_log::log_error!(logger, $($arg)+);
     }};
 }
 

--- a/packages/api/nros/src/env.rs
+++ b/packages/api/nros/src/env.rs
@@ -82,7 +82,7 @@ fn env_cache() -> &'static EnvCache {
         let locator = std::env::var("NROS_LOCATOR")
             .or_else(|_| {
                 std::env::var("ZENOH_LOCATOR").inspect(|_| {
-                    nros_log::nros_warn!(
+                    nros_log::log_warn!(
                         nros_log::get_logger("nros"),
                         "ZENOH_LOCATOR is deprecated; use NROS_LOCATOR instead"
                     );
@@ -94,7 +94,7 @@ fn env_cache() -> &'static EnvCache {
         let mode_str = std::env::var("NROS_SESSION_MODE")
             .or_else(|_| {
                 std::env::var("ZENOH_MODE").inspect(|_| {
-                    nros_log::nros_warn!(
+                    nros_log::log_warn!(
                         nros_log::get_logger("nros"),
                         "ZENOH_MODE is deprecated; use NROS_SESSION_MODE instead"
                     );

--- a/packages/api/nros/src/node_runtime.rs
+++ b/packages/api/nros/src/node_runtime.rs
@@ -2055,7 +2055,7 @@ fn decl_err_from_node(e: nros_node::NodeError) -> NodeDeclError {
     // also means a `no_std` image gets the diagnostic, which the old
     // `cfg(feature = "std")` arm never delivered.
     if !matches!(e, nros_node::NodeError::ExecutorFull) {
-        nros_log::nros_error!(
+        nros_log::log_error!(
             nros_log::get_logger("nros"),
             "node declaration failed — NodeError::{e:?}"
         );

--- a/packages/boards/nros-board-freertos/src/entry.rs
+++ b/packages/boards/nros-board-freertos/src/entry.rs
@@ -769,7 +769,7 @@ where
     B::init_hardware();
     // Wire the default nros_log sink (platform console) at the boot funnel,
     // as the linux/zephyr run_tiers do — idempotent; without it Node-pkg
-    // `nros_info!` output is silently dropped on multi-tier entries.
+    // `log_info!` output is silently dropped on multi-tier entries.
     ::nros_platform_cffi::log::init_default();
 
     report_tiers_above_transport::<B>(&config, tiers);

--- a/packages/boards/nros-board-linux/src/lib.rs
+++ b/packages/boards/nros-board-linux/src/lib.rs
@@ -284,7 +284,7 @@ impl LinuxBoard {
         register_linked_rmw();
         <Self as BoardInit>::init_hardware();
         // Phase 264 W3 — wire the default log sink (host → stdout/stderr) so a Node
-        // pkg's `nros_info!` produces output without per-app `nros_log::init`.
+        // pkg's `log_info!` produces output without per-app `nros_log::init`.
         // Idempotent (swaps the sink list atomically).
         ::nros_platform_cffi::log::init_default();
         // phase-338 W3 — and the `log` facade's host sink, for the same reason.

--- a/packages/boards/nros-board-mps2-an385/src/entry.rs
+++ b/packages/boards/nros-board-mps2-an385/src/entry.rs
@@ -113,7 +113,7 @@ where
     init_hardware(&cfg);
 
     // Phase 244.D1 — install the agnostic `nros_log` dispatcher so declarative
-    // nodes can `nros_info!` (the mps2-an385 semihosting `PlatformLog` already
+    // nodes can `log_info!` (the mps2-an385 semihosting `PlatformLog` already
     // ships; this only wires the dispatcher to the default sinks). Replaces the
     // per-example `nros_log::init(...)` that used to live in each talker's boot
     // closure. Nodes still `register_logger(&LOGGER)` in their `register()`.
@@ -121,7 +121,7 @@ where
 
     // phase-338 W7 — bridge the `log` facade too, so BOTH work here.
     //
-    // This board was the last one whose node bodies had to use `nros_info!`:
+    // This board was the last one whose node bodies had to use `log_info!`:
     // every other platform bridges `log`, so a body written against `log`
     // compiled here and printed nothing. That made the logging facade a board
     // property leaking into user source, which is the defect class this phase

--- a/packages/boards/nros-board-mps2-an385/src/rtic.rs
+++ b/packages/boards/nros-board-mps2-an385/src/rtic.rs
@@ -207,7 +207,7 @@ fn init_with_config(config: Config, deploy: Option<&DeployOverlay>) -> (RticBoot
     crate::init_hardware(&config);
 
     // Phase 289 (#191 class) — install the agnostic `nros_log` dispatcher so
-    // the Node pkgs' `nros_info!` marker lines (`Publishing:` / `I heard:`)
+    // the Node pkgs' `log_info!` marker lines (`Publishing:` / `I heard:`)
     // reach the semihosting console. The direct-exec entry does this in its
     // `BoardEntry` boot (`crate::entry`); the RTIC entry never did — nodes
     // registered their `Logger` against an uninitialized dispatcher and every

--- a/packages/boards/nros-board-nuttx/src/lib.rs
+++ b/packages/boards/nros-board-nuttx/src/lib.rs
@@ -546,7 +546,7 @@ where
     // issue 0708 — publish the nros_log sink list at the boot funnel.
     //
     // The board also installs a `log`-crate logger below, and that is a
-    // DIFFERENT facade: an `nros_error!` raised inside a LIBRARY (the zenoh
+    // DIFFERENT facade: an `log_error!` raised inside a LIBRARY (the zenoh
     // session-pool diagnostic of issue 0589, for one) dispatches through
     // nros_log, which drops every record until a sink list is published.
     // Measured before the fix: the threadx-linux logging fixture with its own
@@ -835,7 +835,7 @@ where
     // issue 0708 — publish the nros_log sink list at the boot funnel.
     //
     // The board also installs a `log`-crate logger below, and that is a
-    // DIFFERENT facade: an `nros_error!` raised inside a LIBRARY (the zenoh
+    // DIFFERENT facade: an `log_error!` raised inside a LIBRARY (the zenoh
     // session-pool diagnostic of issue 0589, for one) dispatches through
     // nros_log, which drops every record until a sink list is published.
     // Measured before the fix: the threadx-linux logging fixture with its own

--- a/packages/boards/nros-board-threadx/src/entry.rs
+++ b/packages/boards/nros-board-threadx/src/entry.rs
@@ -580,7 +580,7 @@ where
     // issue 0708 — publish the nros_log sink list at the boot funnel.
     //
     // The board also installs a `log`-crate logger below, and that is a
-    // DIFFERENT facade: an `nros_error!` raised inside a LIBRARY (the zenoh
+    // DIFFERENT facade: an `log_error!` raised inside a LIBRARY (the zenoh
     // session-pool diagnostic of issue 0589, for one) dispatches through
     // nros_log, which drops every record until a sink list is published.
     // Measured before the fix: the threadx-linux logging fixture with its own
@@ -765,7 +765,7 @@ where
     // issue 0708 — publish the nros_log sink list at the boot funnel.
     //
     // The board also installs a `log`-crate logger below, and that is a
-    // DIFFERENT facade: an `nros_error!` raised inside a LIBRARY (the zenoh
+    // DIFFERENT facade: an `log_error!` raised inside a LIBRARY (the zenoh
     // session-pool diagnostic of issue 0589, for one) dispatches through
     // nros_log, which drops every record until a sink list is published.
     // Measured before the fix: the threadx-linux logging fixture with its own
@@ -967,7 +967,7 @@ where
     // issue 0708 — publish the nros_log sink list at the boot funnel.
     //
     // The board also installs a `log`-crate logger below, and that is a
-    // DIFFERENT facade: an `nros_error!` raised inside a LIBRARY (the zenoh
+    // DIFFERENT facade: an `log_error!` raised inside a LIBRARY (the zenoh
     // session-pool diagnostic of issue 0589, for one) dispatches through
     // nros_log, which drops every record until a sink list is published.
     // Measured before the fix: the threadx-linux logging fixture with its own
@@ -1096,7 +1096,7 @@ where
     // issue 0708 — publish the nros_log sink list at the boot funnel.
     //
     // The board also installs a `log`-crate logger below, and that is a
-    // DIFFERENT facade: an `nros_error!` raised inside a LIBRARY (the zenoh
+    // DIFFERENT facade: an `log_error!` raised inside a LIBRARY (the zenoh
     // session-pool diagnostic of issue 0589, for one) dispatches through
     // nros_log, which drops every record until a sink list is published.
     // Measured before the fix: the threadx-linux logging fixture with its own

--- a/packages/boards/nros-board-zephyr/src/entry_tiers.rs
+++ b/packages/boards/nros-board-zephyr/src/entry_tiers.rs
@@ -358,7 +358,7 @@ impl ZephyrBoard {
     {
         // Wire the default nros_log sink (platform console) at the boot
         // funnel, as nros-board-linux does in its `run`/`run_tiers` —
-        // idempotent, and without it Node-pkg `nros_info!` output is
+        // idempotent, and without it Node-pkg `log_info!` output is
         // silently dropped on Zephyr multi-tier entries.
         ::nros_platform_cffi::log::init_default();
 

--- a/packages/cli/cargo-nano-ros/src/scaffold.rs
+++ b/packages/cli/cargo-nano-ros/src/scaffold.rs
@@ -567,6 +567,15 @@ target_link_libraries({pkg_sym}_{node_name}_component
     fs::write(dir.join("CMakeLists.txt"), cmake)?;
 
     let class_hpp = format!(
+        // phase-417 W-B3 -- the C++ template STAYS on `::nros::` spellings, and the
+        // attempt to migrate it is worth recording because three of the four names do
+        // not exist. `rclcpp::Publisher<M>` is a real alias; `rclcpp::Result` and
+        // `rclcpp::Timer` are not declared anywhere, and `rclcpp::Node` is a DISTINCT
+        // hosted class whose `create_publisher<M>(name)` returns a `shared_ptr` where
+        // the body below passes an out-ref. So the migrated template compiled in no
+        // configuration -- and the scaffold test greps the emitted TEXT rather than
+        // building it, so it reported the rename as a success. Migrating this template
+        // waits on the same node-type merge W-B5 waits on.
         r#"#pragma once
 
 #include <nros/component.hpp>
@@ -1068,7 +1077,7 @@ use nros::{{
     Callback, CallbackCtx, DispatchStrategy, ExecutableNode, Node, NodeContext, NodeResult,
     TickCtx, TimerDuration,
 }};
-use nros_log::{{Logger, nros_error, nros_info}};
+use nros_log::{{Logger, log_error, log_info}};
 use std_msgs::msg::String as StringMsg;
 
 static LOGGER: Logger = Logger::new("{name}");
@@ -1101,8 +1110,8 @@ impl ExecutableNode for Talker {{
             let mut msg = StringMsg::default();
             let _ = write!(msg.data, "Hello World: {{}}", *state);
             match ctx.publish_to_topic::<StringMsg, 64>("/chatter", &msg) {{
-                Ok(()) => nros_info!(&LOGGER, "Publishing: '{{}}'", msg.data),
-                Err(e) => nros_error!(&LOGGER, "Publish failed: {{:?}}", e),
+                Ok(()) => log_info!(&LOGGER, "Publishing: '{{}}'", msg.data),
+                Err(e) => log_error!(&LOGGER, "Publish failed: {{:?}}", e),
             }}
         }}
     }}
@@ -1221,16 +1230,16 @@ int main(int argc, char** argv) {{
     }}
 
     nros_node_t node = rcl_get_zero_initialized_node();
-    if (nros_node_init(&node, &support, "{name}", "/") != NROS_RET_OK) {{
-        fprintf(stderr, "nros_node_init failed\n");
+    if (rclc_node_init_default(&node, "{name}", "/", &support) != NROS_RET_OK) {{
+        fprintf(stderr, "rclc_node_init_default failed\n");
         return 1;
     }}
 
     nros_publisher_t pub = rcl_get_zero_initialized_publisher();
-    if (nros_publisher_init(&pub, &node,
-                            std_msgs_msg_int32_get_type_support(),
-                            "/chatter") != NROS_RET_OK) {{
-        fprintf(stderr, "nros_publisher_init failed\n");
+    if (rclc_publisher_init_default(&pub, &node,
+                                    std_msgs_msg_int32_get_type_support(),
+                                    "/chatter") != NROS_RET_OK) {{
+        fprintf(stderr, "rclc_publisher_init_default failed\n");
         return 1;
     }}
 
@@ -1241,8 +1250,8 @@ int main(int argc, char** argv) {{
     printf("{name}: published 0 on /chatter\n");
 
     nros_publisher_fini(&pub);
-    nros_node_fini(&node);
-    nros_support_fini(&support);
+    rcl_node_fini(&node);
+    rclc_support_fini(&support);
     return 0;
 }}
 "#,

--- a/packages/cli/nros-cli-core/src/builder/preflight.rs
+++ b/packages/cli/nros-cli-core/src/builder/preflight.rs
@@ -178,19 +178,45 @@ fn rust_component_installed(component: &str) -> bool {
 /// a nix shell), this reports installed and lets the build speak for itself.
 /// Preflight exists to give a better message than the compiler, never to refuse
 /// a build the compiler would have accepted.
+/// The installed-target list, probed ONCE per process.
+///
+/// `None` means the probe could not answer -- no `rustup` on PATH, or it
+/// failed. Both callers then report the target as installed, because inventing
+/// a missing target is the worse error.
+///
+/// Probed once because the two failure modes are INDISTINGUISHABLE at the call
+/// site and only one of them is stable. "no rustup here" gives the same `Err`
+/// as a spawn that failed under load, and under an 80-way parallel build the
+/// second happens intermittently -- so two calls in one process could disagree,
+/// and `check()` would report a target as present that a caller had just
+/// measured as absent. Caching does not make the probe more accurate; it makes
+/// the process SELF-CONSISTENT, which is what a caller comparing two answers
+/// actually needs. Issue 0726's class.
+fn installed_rust_targets() -> &'static Option<Vec<String>> {
+    static CACHE: std::sync::OnceLock<Option<Vec<String>>> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| {
+        let out = std::process::Command::new("rustup")
+            .args(["target", "list", "--installed"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        Some(
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(|l| l.trim().to_string())
+                .collect(),
+        )
+    })
+}
+
 fn rust_target_installed(target: &str) -> bool {
-    let Ok(out) = std::process::Command::new("rustup")
-        .args(["target", "list", "--installed"])
-        .output()
-    else {
-        return true;
-    };
-    if !out.status.success() {
-        return true;
+    match installed_rust_targets() {
+        // Cannot answer -- see above.
+        None => true,
+        Some(list) => list.iter().any(|l| l == target),
     }
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .any(|l| l.trim() == target)
 }
 
 /// Render the problems as the message stage 3 fails with.

--- a/packages/core/nros-log/Cargo.toml
+++ b/packages/core/nros-log/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["embedded", "no-std", "development-tools::debugging"]
 # `nros_platform_log_write` / `nros_platform_log_flush` ABI; the
 # `PlatformSink` here is the only sink that calls the ABI.
 #
-# `default = ["max-level-trace", "buffer-size-256"]` keeps the
+# The `max-level-*` / `buffer-size-*` half of `default` keeps the
 # library-only case zero-cost: pull the crate in, get types +
 # macros, no sink wired until the app calls `nros_log::init(...)`.
 #
@@ -31,7 +31,7 @@ categories = ["embedded", "no-std", "development-tools::debugging"]
 # smaller N = more truncation. Pick at most one.
 
 [features]
-default = ["max-level-trace", "buffer-size-256"]
+default = ["max-level-trace", "buffer-size-256", "deprecate-legacy-names"]
 std = ["alloc"]
 alloc = []
 
@@ -81,17 +81,24 @@ buffer-size-512  = []
 buffer-size-1024 = []
 
 # phase-417 — ARMS the `#[deprecated]` on the pre-rename `nros_debug!` ..
-# `nros_fatal!` forwarders. Off by default, and the reason is structural rather
-# than timid: this workspace sets `warnings = "deny"` (root `Cargo.toml`
+# `nros_fatal!` forwarders. It WAS off by default, and the reason was structural
+# rather than timid: this workspace sets `warnings = "deny"` (root `Cargo.toml`
 # `[workspace.lints.rust]`), so an always-armed deprecation is not a migration
 # STEP -- it is a hard compile error in every crate that has not moved yet, i.e.
 # the flag day RFC-0089's two-step alias exists to avoid. Measured at the rename:
 # 9 errors in `nros-rmw-cffi` alone stopped the workspace build.
 #
-# So the attribute is authored, reviewed and inert, and the migration batch is
+# So the attribute was authored, reviewed and inert, and the migration batch is
 # `--features deprecate-legacy-names` -> fix what it names -> delete the
-# forwarders. Turning it on before the call sites move breaks the build; that is
-# the point of it being a switch.
+# forwarders.
+#
+# phase-417 stage 6 W-B1, 2026-09-04: THE SWITCH IS NOW ON -- it moved into
+# `default` above, which is what made the compiler enumerate the batch instead
+# of a grep guessing at it (208 macro call sites across 50 files, plus the
+# `use` lists that import them). It stays a named feature rather than being
+# deleted outright so W-B5 has exactly one thing to remove alongside the five
+# forwarders, and so a consumer mid-migration can still buy time with
+# `default-features = false` plus the level/buffer features it wants.
 deprecate-legacy-names = []
 
 # Optional `log` crate bridge (Phase 88.10). Lets ecosystem crates

--- a/packages/core/nros-node/src/executor/action.rs
+++ b/packages/core/nros-node/src/executor/action.rs
@@ -1261,7 +1261,7 @@ impl<'s> Executor<'s> {
                 session
                     .create_client(&send_goal_info, QoSProfile::services_default())
                     .map_err(|e| {
-                        nros_log::nros_error!(
+                        nros_log::log_error!(
                             nros_log::get_logger("nros_node"),
                             "action client: send_goal client failed: {:?}",
                             e
@@ -1271,7 +1271,7 @@ impl<'s> Executor<'s> {
                 session
                     .create_client(&cancel_goal_info, QoSProfile::services_default())
                     .map_err(|e| {
-                        nros_log::nros_error!(
+                        nros_log::log_error!(
                             nros_log::get_logger("nros_node"),
                             "action client: cancel_goal client failed: {:?}",
                             e
@@ -1281,7 +1281,7 @@ impl<'s> Executor<'s> {
                 session
                     .create_client(&get_result_info, QoSProfile::services_default())
                     .map_err(|e| {
-                        nros_log::nros_error!(
+                        nros_log::log_error!(
                             nros_log::get_logger("nros_node"),
                             "action client: get_result client failed: {:?}",
                             e
@@ -1291,7 +1291,7 @@ impl<'s> Executor<'s> {
                 session
                     .create_subscription(&feedback_topic, QoSProfile::BEST_EFFORT)
                     .map_err(|e| {
-                        nros_log::nros_error!(
+                        nros_log::log_error!(
                             nros_log::get_logger("nros_node"),
                             "action client: feedback subscription failed: {:?}",
                             e

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -567,7 +567,7 @@ fn report_arena_headroom(used: usize, capacity: usize) {
     // diagnostic that explains itself past the budget delivers exactly the
     // folklore it was written to replace. So: the actionable value FIRST, the
     // reasoning in this comment and issue 0900, and a test that fails on `…`.
-    nros_log::nros_info!(
+    nros_log::log_info!(
         nros_log::get_logger("nros"),
         "arena over-provisioned: set NROS_EXECUTOR_ARENA_SIZE={suggest}          (Zephyr: CONFIG_ prefix). {used}/{capacity} bytes claimed at first          spin, and the arena is INLINE ON THE TASK STACK. Later registrations          need more. issue 0900"
     );
@@ -613,7 +613,7 @@ pub(crate) fn report_arena_exhausted(want: usize, used: usize, capacity: usize) 
     if ARENA_EXHAUSTED_REPORTED.swap(true, portable_atomic::Ordering::Relaxed) {
         return;
     }
-    nros_log::nros_error!(
+    nros_log::log_error!(
         nros_log::get_logger("nros"),
         "arena exhausted: {want} more bytes needed, {used}/{capacity} in use. \
          Raise NROS_EXECUTOR_ARENA_SIZE, or NROS_EXECUTOR_ACTION_CLIENTS if \
@@ -761,7 +761,7 @@ fn report_dropped_take(err: &TransportError, buf_len: usize) {
     if n != 0 && !n.is_multiple_of(64) {
         return;
     }
-    nros_log::nros_error!(
+    nros_log::log_error!(
         nros_log::get_logger("nros"),
         "subscription take DROPPED ({err:?}); buffer is {buf_len} bytes. The \
          sample was received and ACKed, then discarded — raise the subscription \
@@ -1639,7 +1639,7 @@ fn report_typed_deserialize_failure(rc: i32, len: usize) {
     if n != 0 && !n.is_multiple_of(64) {
         return;
     }
-    nros_log::nros_error!(
+    nros_log::log_error!(
         nros_log::get_logger("nros"),
         "typed subscription DROPPED a {len}-byte sample: deserialize returned \
          {rc}. The callback was NOT invoked and the storage still holds the \

--- a/packages/core/nros-node/src/executor/monitor.rs
+++ b/packages/core/nros-node/src/executor/monitor.rs
@@ -435,7 +435,7 @@ mod tests {
 /// site sits inside a loop that already borrows the executor's spec
 /// tables.
 pub(crate) fn log_violation(v: &Violation) {
-    nros_log::nros_warn!(
+    nros_log::log_warn!(
         nros_log::get_logger("nros"),
         "contract violation: {} {} measured={} declared={}",
         v.rule,

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -139,7 +139,7 @@ impl<'a> NodeHandle<'a> {
     ///
     /// // Inside any node-creating code:
     /// let logger = node.logger();
-    /// nros_log::nros_info!(logger, "started; domain = {}", node.domain_id());
+    /// nros_log::log_info!(logger, "started; domain = {}", node.domain_id());
     /// ```
     #[must_use]
     pub fn logger(&self) -> &'static nros_log::Logger {

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -152,7 +152,7 @@ impl<'s> Executor<'s> {
                         }
                         nros_rmw_cffi::BackendResolution::Single(_) => unreachable!(),
                     };
-                    nros_log::nros_error!(
+                    nros_log::log_error!(
                         nros_log::get_logger("nros"),
                         "cannot select an RMW backend — {why}"
                     );
@@ -184,7 +184,7 @@ impl<'s> Executor<'s> {
             // exhausted session pool (`InvalidConfig`) and a router that is not
             // there produced the same sentence. Same lesson as the selection
             // arm above: say which failure happened.
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros"),
                 "RMW session open failed — {e:?}"
             );
@@ -2276,7 +2276,7 @@ impl<'s> Executor<'s> {
             // The two periods the timer will actually alternate between.
             let early_us = (period_us / spin_us) * spin_us;
             let late_us = early_us.saturating_add(spin_us);
-            nros_log::nros_warn!(
+            nros_log::log_warn!(
                 nros_log::get_logger("nros"),
                 "timer period {} us is not a multiple of the {} us spin period: activations will alternate between {} us and {} us (mean cadence preserved)",
                 period_us,
@@ -6597,7 +6597,7 @@ impl<'s> Executor<'s> {
                         .and_then(|st| st.as_mut())
                         .and_then(|st| st.take_budget_window())
                     {
-                        nros_log::nros_warn!(
+                        nros_log::log_warn!(
                             nros_log::get_logger("nros"),
                             "sporadic budget throttled sched context {}: {} of the last {} dispatch opportunities were skipped for want of budget. The declared budget_us/period_us cannot sustain this tier's callbacks on this target.",
                             sc_idx,
@@ -6611,7 +6611,7 @@ impl<'s> Executor<'s> {
                         .and_then(|st| st.as_mut())
                         .and_then(|st| st.note_budget_skip())
                     {
-                        nros_log::nros_warn!(
+                        nros_log::log_warn!(
                             nros_log::get_logger("nros"),
                             "sporadic budget exhausted for {} consecutive spins (sched context {}): its callbacks are not being dispatched. Either the callback runtime exceeds the declared budget_us per period_us, or the declaration is unsatisfiable on this target.",
                             streak,
@@ -7913,7 +7913,7 @@ impl<'s> Executor<'s> {
         // is a promise this build can keep.
         let start_us = self.now_us();
         if opts.timeout.is_some() && start_us.is_none() {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros"),
                 "spin_blocking: a timeout was requested but this build has no clock \
                  — install one with `ExecutorConfig::clock_us` (issue 0709)"
@@ -8020,7 +8020,7 @@ impl<'s> Executor<'s> {
         // this build cannot honour is a configuration error, not a silent
         // busy-loop.
         let Some(start_us) = self.now_us() else {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros"),
                 "spin_period: a period was requested but this build has no clock \
                  — install one with `ExecutorConfig::clock_us` (issue 0709)"

--- a/packages/core/nros-rmw/src/traits.rs
+++ b/packages/core/nros-rmw/src/traits.rs
@@ -2833,9 +2833,17 @@ pub trait ClientTrait {
     /// Returns `Ok(true)` if at least one matching server has been
     /// discovered, `Ok(false)` if none yet, or `Err(_)` if the
     /// backend cannot answer (e.g. XRCE — micro-XRCE-DDS-Client has
-    /// no participant enumeration). Distinct from
-    /// [`is_server_ready`](Self::is_server_ready), which collapses
-    /// "don't know" and "no server" into the same `false` answer.
+    /// no participant enumeration).
+    ///
+    /// This USED to be contrasted with an `is_server_ready` that collapsed
+    /// "don't know" and "no server" into one `false`. That method is gone
+    /// (issue 1008, W6 decision 2): its trait DEFAULT was `true`, only zenoh
+    /// overrode it, and `wait_for_service`'s fast path read it — so on every
+    /// cffi-reached backend the wait returned `Ok(true)` immediately, without
+    /// probing, whether or not any server existed. The two-channel form here is
+    /// what replaced it; there is no longer a collapsing sibling to contrast
+    /// with. (The rustdoc link to the deleted method is what kept `just book`
+    /// red from 2026-09-03 until phase-417 W-B4 tripped over it.)
     ///
     /// User-facing surface: `Client<S>::server_available()` in Rust,
     /// `nros_client_server_available()` in C/C++. Clients use this

--- a/packages/rmw/bridge/src/cffi.rs
+++ b/packages/rmw/bridge/src/cffi.rs
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn nros_pubsub_bridge_create(
     let inner = match PubSubBridge::new(sub, pubr, origin_static) {
         Ok(b) => b,
         Err(e) => {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros_rmw_bridge"),
                 "nros_pubsub_bridge_create: {}",
                 e

--- a/packages/rmw/bridge/src/cffi.rs
+++ b/packages/rmw/bridge/src/cffi.rs
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn nros_init_multi(
         // reaches `no_std` targets, which the old `cfg(feature = "std")` arm
         // never did.
         Err(e) => {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros_rmw_bridge"),
                 "nros_init_multi failed — {e:?}"
             );
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn nros_pubsub_bridge_create(
     let mut src = match eb.executor.create_node_on(src_node, src_rmw) {
         Ok(n) => n,
         Err(nros_node::executor::NodeError::NodeTableFull) => {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros_rmw_bridge"),
                 "nros_pubsub_bridge_create: node table FULL creating the source \
                  node -- raise NROS_EXECUTOR_MAX_NODES. A bridge creates TWO \
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn nros_pubsub_bridge_create(
     let mut dst = match eb.executor.create_node_on(dst_node, dst_rmw) {
         Ok(n) => n,
         Err(nros_node::executor::NodeError::NodeTableFull) => {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros_rmw_bridge"),
                 "nros_pubsub_bridge_create: node table FULL creating the \
                  destination node -- raise NROS_EXECUTOR_MAX_NODES (phase-412 W2)."

--- a/packages/rmw/bridge/src/lib.rs
+++ b/packages/rmw/bridge/src/lib.rs
@@ -451,7 +451,7 @@ impl<const RX_BUF: usize, const TX_BUF: usize, const CONV_BUF: usize>
                         // cannot be represented on the far side. Counted AND
                         // logged, never silent: a converter that fails every
                         // sample must not read as a quiet bridge.
-                        nros_log::nros_error!(
+                        nros_log::log_error!(
                             nros_log::get_logger("nros_bridge"),
                             "bridge conversion failed, sample dropped: {}",
                             e

--- a/packages/rmw/cffi/src/lib.rs
+++ b/packages/rmw/cffi/src/lib.rs
@@ -1406,7 +1406,7 @@ fn release_session_nodes(
             // `create_node`, and the session is still open.
             let ret = unsafe { destroy(&mut view) };
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "destroy_node failed with {}; the backend may still hold node state",
                     ret
@@ -1905,7 +1905,7 @@ impl CffiSession {
         // decide whether to emit.
         #[cfg(feature = "std")]
         if std::env::var_os("NROS_RMW_TRACE_OPEN").is_some() {
-            nros_log::nros_info!(
+            nros_log::log_info!(
                 nros_log::get_logger("nros_rmw_cffi"),
                 "open: locator={locator:?} mode={mode} ret={ret} backend_data={:p}",
                 view.backend_data
@@ -1958,7 +1958,7 @@ fn report_qos_downgrade(kind: &str, name: &str, requested: &NrosRmwQos, granted:
         }
     }
     if requested.reliability != granted.reliability {
-        nros_log::nros_warn!(
+        nros_log::log_warn!(
             nros_log::get_logger("nros_rmw_cffi"),
             "{kind} `{name}`: asked for reliability {} and the backend granted {}. A RELIABLE \
              reader does not match a BEST_EFFORT writer, so this is the usual reason a pair \
@@ -1968,7 +1968,7 @@ fn report_qos_downgrade(kind: &str, name: &str, requested: &NrosRmwQos, granted:
         );
     }
     if requested.durability != granted.durability {
-        nros_log::nros_warn!(
+        nros_log::log_warn!(
             nros_log::get_logger("nros_rmw_cffi"),
             "{kind} `{name}`: asked for durability {} and the backend granted {}.",
             durability(requested.durability),
@@ -1976,7 +1976,7 @@ fn report_qos_downgrade(kind: &str, name: &str, requested: &NrosRmwQos, granted:
         );
     }
     if requested.depth != granted.depth && granted.depth != 0 {
-        nros_log::nros_warn!(
+        nros_log::log_warn!(
             nros_log::get_logger("nros_rmw_cffi"),
             "{kind} `{name}`: asked for history depth {} and the backend granted {}.",
             requested.depth,
@@ -2862,7 +2862,7 @@ impl<'a> Drop for CffiSlot<'a> {
             // `'a` borrows it).
             let ret = unsafe { discard(&view, self.token) };
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "return_loaned_message_from_publisher failed with {}; the loan slot may be stranded",
                     ret
@@ -2966,7 +2966,7 @@ impl nros_rmw::SlotLending for CffiPublisher {
                 // second fault in a row and worth a line.
                 let ret = unsafe { discard(&view, out_token) };
                 if ret != NROS_RMW_RET_OK {
-                    nros_log::nros_error!(
+                    nros_log::log_error!(
                         nros_log::get_logger("nros_rmw_cffi"),
                         "discarding an undersized loan also failed with {}",
                         ret
@@ -3336,7 +3336,7 @@ impl Drop for CffiPublisher {
             // surfaces later as an allocation failure with no provenance.
             // `nros_log`, never std stdio — issue 0589.
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "destroy_publisher failed with {}; the backend may have leaked the publisher",
                     ret
@@ -3480,7 +3480,7 @@ impl<'a> Drop for CffiView<'a> {
             // this subscriber and the subscriber is still alive.
             let ret = unsafe { release(&view, self.token) };
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "return_loaned_message_from_subscription failed with {}; the sample may stay checked out",
                     ret
@@ -3791,7 +3791,7 @@ impl Drop for CffiSubscription {
             // surfaces later as an allocation failure with no provenance.
             // `nros_log`, never std stdio — issue 0589.
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "destroy_subscription failed with {}; the backend may have leaked the subscription",
                     ret
@@ -3922,7 +3922,7 @@ impl Drop for CffiService {
             // surfaces later as an allocation failure with no provenance.
             // `nros_log`, never std stdio — issue 0589.
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "destroy_service failed with {}; the backend may have leaked the service",
                     ret
@@ -4072,7 +4072,7 @@ impl Drop for CffiClient {
             // surfaces later as an allocation failure with no provenance.
             // `nros_log`, never std stdio — issue 0589.
             if ret != NROS_RMW_RET_OK {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("nros_rmw_cffi"),
                     "destroy_client failed with {}; the backend may have leaked the client",
                     ret

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/mod.rs
@@ -280,7 +280,7 @@ impl From<ZpicoError> for TransportError {
         // `ConnectionFailed`, and they are the only ones whose identity is
         // lost here; every other variant maps 1:1 and needs no announcement.
         if matches!(err, ZpicoError::Generic | ZpicoError::Session) {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros_rmw_zenoh"),
                 "zpico {:?} -> ConnectionFailed (the two are indistinguishable downstream)",
                 err

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/session.rs
@@ -288,7 +288,7 @@ impl ZenohSession {
             // Kept under nros-log's 256-byte buffer: a message that overflows is
             // replaced by "…", and a diagnostic nobody can read is the failure
             // this guard exists to prevent.
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("nros_rmw_zenoh"),
                 "peer mode unsupported: shim built without multicast transport/scouting \
                  (issue 0682). Use client mode with a router, or rebuild with \

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/zpico.rs
@@ -267,7 +267,7 @@ fn acquire_session_slot() -> Result<*mut zpico_sys::zpico_session_t> {
     // SAFETY: no arguments; returns a pool slot or null.
     let handle = unsafe { zpico_session_acquire() };
     if handle.is_null() {
-        nros_log::nros_error!(
+        nros_log::log_error!(
             nros_log::get_logger("nros_rmw_zenoh"),
             "{} — this build allows ZPICO_MAX_SESSIONS={} and one is already \
              open. A non-bridge application opens exactly ONE session; two \

--- a/packages/testing/nros-tests/bins/action-raw-goal-probe/src/main.c
+++ b/packages/testing/nros-tests/bins/action-raw-goal-probe/src/main.c
@@ -127,7 +127,7 @@ int nros_app_main(int argc, char** argv) {
     };
 
     NROS_CHECK_RET(nros_support_init(&app.support, locator, domain_id), 1);
-    NROS_CHECK_RET(nros_node_init(&app.node, &app.support, "raw_goal_probe", "/"), 1);
+    NROS_CHECK_RET(rclc_node_init_default(&app.node, "raw_goal_probe", "/", &app.support), 1);
     // The RAW arms live on the polling (L1) core — `polling_client_core()`
     // returns NULL for an executor-mode client, so this must be init_polling.
     NROS_CHECK_RET(nros_action_client_init_polling(&app.action_client, &app.node, &fibonacci_type,
@@ -247,8 +247,8 @@ int nros_app_main(int argc, char** argv) {
     printf("raw goal shipped exactly one encapsulation header\n");
 
     nros_action_client_fini(&app.action_client);
-    nros_node_fini(&app.node);
-    nros_support_fini(&app.support);
+    rcl_node_fini(&app.node);
+    rclc_support_fini(&app.support);
     return 0;
 }
 

--- a/packages/testing/nros-tests/bins/logging-smoke-esp32-qemu/src/main.rs
+++ b/packages/testing/nros-tests/bins/logging-smoke-esp32-qemu/src/main.rs
@@ -13,7 +13,7 @@
 
 use esp_backtrace as _;
 use nros_board_esp32_qemu::{Config, entry, run_bare};
-use nros_log::{Logger, Severity, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn, register_logger};
+use nros_log::{Logger, Severity, log_debug, log_error, log_fatal, log_info, nros_trace, log_warn, register_logger};
 
 nros_board_esp32_qemu::esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -36,11 +36,11 @@ fn main() -> ! {
         logger.set_level(Severity::Trace);
 
         nros_trace!(logger, "trace payload");
-        nros_debug!(logger, "debug payload");
-        nros_info!(logger, "info payload");
-        nros_warn!(logger, "warn payload");
-        nros_error!(logger, "error payload");
-        nros_fatal!(logger, "fatal payload");
+        log_debug!(logger, "debug payload");
+        log_info!(logger, "info payload");
+        log_warn!(logger, "warn payload");
+        log_error!(logger, "error payload");
+        log_fatal!(logger, "fatal payload");
         nros_log::flush();
 
         Ok::<(), &'static str>(())

--- a/packages/testing/nros-tests/bins/logging-smoke-freertos-mps2/src/main.rs
+++ b/packages/testing/nros-tests/bins/logging-smoke-freertos-mps2/src/main.rs
@@ -12,7 +12,7 @@
 #![no_main]
 
 use nros_board_mps2_an385_freertos::{Config, Mps2An385};
-use nros_log::{Logger, Severity, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn, register_logger};
+use nros_log::{Logger, Severity, log_debug, log_error, log_fatal, log_info, nros_trace, log_warn, register_logger};
 use panic_semihosting as _;
 
 // Link `nros-platform` so its FreeRTOS C symbols + `global-allocator`
@@ -38,7 +38,7 @@ extern "C" fn main() -> ! {
         // A fixture that publishes its own sink list proves the PLATFORM half
         // (`nros_platform_log_write` exists, issue 0420's question) and nothing about
         // whether this BOARD publishes one. Six boards did not, and library records —
-        // `nros_error!` raised inside a crate whose author cannot know what the board
+        // `log_error!` raised inside a crate whose author cannot know what the board
         // did — were dropped. Relying on the board is what makes this an assertion
         // about the board.
         //
@@ -49,11 +49,11 @@ extern "C" fn main() -> ! {
         logger.set_level(Severity::Trace);
 
         nros_trace!(logger, "trace payload");
-        nros_debug!(logger, "debug payload");
-        nros_info!(logger, "info payload");
-        nros_warn!(logger, "warn payload");
-        nros_error!(logger, "error payload");
-        nros_fatal!(logger, "fatal payload");
+        log_debug!(logger, "debug payload");
+        log_info!(logger, "info payload");
+        log_warn!(logger, "warn payload");
+        log_error!(logger, "error payload");
+        log_fatal!(logger, "fatal payload");
         nros_log::flush();
 
         cortex_m_semihosting::debug::exit(cortex_m_semihosting::debug::EXIT_SUCCESS);

--- a/packages/testing/nros-tests/bins/logging-smoke-mps2-baremetal/src/main.rs
+++ b/packages/testing/nros-tests/bins/logging-smoke-mps2-baremetal/src/main.rs
@@ -12,7 +12,7 @@
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
 use nros_log::{
-    Logger, Severity, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn,
+    Logger, Severity, log_debug, log_error, log_fatal, log_info, nros_trace, log_warn,
     register_logger,
 };
 use panic_semihosting as _;
@@ -40,11 +40,11 @@ fn main() -> ! {
     logger.set_level(Severity::Trace);
 
     nros_trace!(logger, "trace payload");
-    nros_debug!(logger, "debug payload");
-    nros_info!(logger, "info payload");
-    nros_warn!(logger, "warn payload");
-    nros_error!(logger, "error payload");
-    nros_fatal!(logger, "fatal payload");
+    log_debug!(logger, "debug payload");
+    log_info!(logger, "info payload");
+    log_warn!(logger, "warn payload");
+    log_error!(logger, "error payload");
+    log_fatal!(logger, "fatal payload");
 
     nros_log::flush();
     debug::exit(debug::EXIT_SUCCESS);

--- a/packages/testing/nros-tests/bins/logging-smoke-nuttx-qemu-arm/src/main.rs
+++ b/packages/testing/nros-tests/bins/logging-smoke-nuttx-qemu-arm/src/main.rs
@@ -60,7 +60,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 // `CONFIG_INIT_ENTRYPOINT`) and its build.rs's propagating image-link
 // directives are the whole point of the dependency.
 use nros_board_nuttx_qemu as _;
-use nros_log::{Logger, Severity, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn, register_logger};
+use nros_log::{Logger, Severity, log_debug, log_error, log_fatal, log_info, nros_trace, log_warn, register_logger};
 
 static LOGGER: Logger = Logger::new("smoke");
 
@@ -75,11 +75,11 @@ pub extern "C" fn main(_argc: i32, _argv: *const *const core::ffi::c_char) -> i3
     LOGGER.set_level(Severity::Trace);
 
     nros_trace!(&LOGGER, "trace payload");
-    nros_debug!(&LOGGER, "debug payload");
-    nros_info!(&LOGGER, "info payload");
-    nros_warn!(&LOGGER, "warn payload");
-    nros_error!(&LOGGER, "error payload");
-    nros_fatal!(&LOGGER, "fatal payload");
+    log_debug!(&LOGGER, "debug payload");
+    log_info!(&LOGGER, "info payload");
+    log_warn!(&LOGGER, "warn payload");
+    log_error!(&LOGGER, "error payload");
+    log_fatal!(&LOGGER, "fatal payload");
     nros_log::flush();
     0
 }

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/src/main.rs
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/src/main.rs
@@ -5,7 +5,7 @@
 
 use nros_board_threadx_linux::ThreadxLinux;
 use nros_log::{
-    Logger, Severity, init, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn,
+    Logger, Severity, init, log_debug, log_error, log_fatal, log_info, nros_trace, log_warn,
     register_logger, sinks,
 };
 
@@ -23,7 +23,7 @@ fn main() {
         // This fixture used to publish its own sink list, which made it prove
         // that the platform's `nros_platform_log_write` works (issue 0420's
         // question) and nothing about whether a BOARD publishes one. It did
-        // not, and library records — `nros_error!` raised inside a crate whose
+        // not, and library records — `log_error!` raised inside a crate whose
         // author cannot know what the board did — were dropped on this whole
         // family. Relying on the board is what makes this an assertion about
         // the board.
@@ -34,11 +34,11 @@ fn main() {
         LOGGER.set_level(Severity::Trace);
 
         nros_trace!(&LOGGER, "trace payload");
-        nros_debug!(&LOGGER, "debug payload");
-        nros_info!(&LOGGER, "info payload");
-        nros_warn!(&LOGGER, "warn payload");
-        nros_error!(&LOGGER, "error payload");
-        nros_fatal!(&LOGGER, "fatal payload");
+        log_debug!(&LOGGER, "debug payload");
+        log_info!(&LOGGER, "info payload");
+        log_warn!(&LOGGER, "warn payload");
+        log_error!(&LOGGER, "error payload");
+        log_fatal!(&LOGGER, "fatal payload");
         nros_log::flush();
 
         Ok::<(), &'static str>(())

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-riscv64/src/main.rs
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-riscv64/src/main.rs
@@ -10,7 +10,7 @@
 #![no_main]
 
 use nros_board_threadx_qemu_riscv64::{Config, ThreadxQemuRiscv64};
-use nros_log::{Logger, Severity, nros_debug, nros_error, nros_fatal, nros_info, nros_trace, nros_warn, register_logger};
+use nros_log::{Logger, Severity, log_debug, log_error, log_fatal, log_info, nros_trace, log_warn, register_logger};
 
 static LOGGER: Logger = Logger::new("smoke");
 
@@ -68,7 +68,7 @@ extern "C" fn main() -> ! {
         // A fixture that publishes its own sink list proves the PLATFORM half
         // (`nros_platform_log_write` exists, issue 0420's question) and nothing about
         // whether this BOARD publishes one. Six boards did not, and library records —
-        // `nros_error!` raised inside a crate whose author cannot know what the board
+        // `log_error!` raised inside a crate whose author cannot know what the board
         // did — were dropped. Relying on the board is what makes this an assertion
         // about the board.
         //
@@ -79,11 +79,11 @@ extern "C" fn main() -> ! {
         logger.set_level(Severity::Trace);
 
         nros_trace!(logger, "trace payload");
-        nros_debug!(logger, "debug payload");
-        nros_info!(logger, "info payload");
-        nros_warn!(logger, "warn payload");
-        nros_error!(logger, "error payload");
-        nros_fatal!(logger, "fatal payload");
+        log_debug!(logger, "debug payload");
+        log_info!(logger, "info payload");
+        log_warn!(logger, "warn payload");
+        log_error!(logger, "error payload");
+        log_fatal!(logger, "fatal payload");
         nros_log::flush();
 
         Ok::<(), &'static str>(())

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/src/main.rs
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
         // of the program — never released, which is the point.
         let held = unsafe { zpico_sys::zpico_session_acquire() };
         if held.is_null() {
-            nros_log::nros_error!(
+            nros_log::log_error!(
                 nros_log::get_logger("pool-exhaustion"),
                 "could not take the FIRST slot of a pool of {} — the precondition \
                  does not hold and this run proves nothing",
@@ -63,12 +63,12 @@ fn main() {
         // The pool is now full. This is the call under test.
         match Context::new(b"tcp/127.0.0.1:7447") {
             Err(nros_rmw_zenoh::ZpicoError::Full) => {
-                nros_log::nros_info!(nros_log::get_logger("pool-exhaustion"), "{}", VERDICT_OK);
+                nros_log::log_info!(nros_log::get_logger("pool-exhaustion"), "{}", VERDICT_OK);
                 nros_log::flush();
                 Ok(())
             }
             Err(other) => {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("pool-exhaustion"),
                     "second session failed with {other:?}, not Full — an exhausted \
                      pool must stay distinguishable from a transport failure (issue 0465)"
@@ -76,7 +76,7 @@ fn main() {
                 Err("wrong error")
             }
             Ok(_) => {
-                nros_log::nros_error!(
+                nros_log::log_error!(
                     nros_log::get_logger("pool-exhaustion"),
                     "a session opened with the pool already full — the bound is not \
                      being enforced"

--- a/packages/testing/nros-tests/fixtures/cpp_compat_snippets/subscription_with_info.cpp
+++ b/packages/testing/nros-tests/fixtures/cpp_compat_snippets/subscription_with_info.cpp
@@ -33,7 +33,7 @@ struct FakeString {
 
 int main() {
     nros::Node node;
-    nros::Subscription<FakeString> info_sub;
+    rclcpp::Subscription<FakeString> info_sub;
     (void)node.create_subscription_with_info<FakeString>(
         info_sub, "/chatter_info",
         [](const FakeString& m, const uint8_t* attachment, size_t attachment_len) {

--- a/packages/testing/nros-tests/src/fixtures/zenohd_router.rs
+++ b/packages/testing/nros-tests/src/fixtures/zenohd_router.rs
@@ -121,7 +121,7 @@ fn router_command(overrides: &[String]) -> TestResult<std::process::Command> {
     // the user is testing; what must not happen is it being SILENT.
     let provenance = crate::process::ros_zenohd_provenance(&path);
     if !provenance.is_ros_shipped() {
-        nros_log::nros_warn!(
+        nros_log::log_warn!(
             nros_log::get_logger("nros_tests"),
             "zenoh router {} — {}. Interop results from this run say nothing \
              about the paired configuration (RFC-0075).",

--- a/packages/testing/nros-tests/src/output.rs
+++ b/packages/testing/nros-tests/src/output.rs
@@ -320,7 +320,7 @@ pub const WS_CUSTOM_MSG_READING_PREFIX: &str = "reading seq=";
 /// proves the full CDR layout, not just a counter, survives the trip.
 pub const WS_CUSTOM_MSG_TEMP_FIELD: &str = "temp=";
 
-/// The Rust workspace `talker_pkg`'s per-tick `nros_info!` line marker
+/// The Rust workspace `talker_pkg`'s per-tick `log_info!` line marker
 /// (`"talker publishing chatter seq=N"` — phase-263 A5 logging demo).
 pub const WS_RUST_LOGGING_MARKER: &str = "talker publishing chatter";
 

--- a/packages/testing/nros-tests/src/qemu.rs
+++ b/packages/testing/nros-tests/src/qemu.rs
@@ -470,7 +470,7 @@ impl QemuProcess {
         // Phase 88.16.A — drain stderr alongside stdout so logging
         // records (which route through `hstderr()` on bare-metal
         // semihosting) reach the captured string. Examples that
-        // emit via `nros_info!` would otherwise look silent to the
+        // emit via `log_info!` would otherwise look silent to the
         // harness.
         let mut stdout = self
             .handle

--- a/packages/testing/nros-tests/tests/logging.rs
+++ b/packages/testing/nros-tests/tests/logging.rs
@@ -26,8 +26,8 @@
 use std::sync::Mutex;
 
 use nros_log::{
-    LogSink, Logger, Record, Severity, init, nros_debug, nros_error, nros_fatal, nros_info,
-    nros_trace, nros_warn, register_logger, severity_enabled_at_compile_time,
+    LogSink, Logger, Record, Severity, init, log_debug, log_error, log_fatal, log_info, log_warn,
+    nros_trace, register_logger, severity_enabled_at_compile_time,
 };
 
 /// Process-wide serialization for tests that mutate the global
@@ -115,14 +115,14 @@ fn per_logger_runtime_threshold_filters_below() {
     loud.set_level(Severity::Info);
 
     nros_trace!(quiet, "drop-trace");
-    nros_debug!(quiet, "drop-debug");
-    nros_info!(quiet, "drop-info");
-    nros_warn!(quiet, "keep-warn");
-    nros_error!(quiet, "keep-error");
-    nros_fatal!(quiet, "keep-fatal");
+    log_debug!(quiet, "drop-debug");
+    log_info!(quiet, "drop-info");
+    log_warn!(quiet, "keep-warn");
+    log_error!(quiet, "keep-error");
+    log_fatal!(quiet, "keep-fatal");
 
-    nros_info!(loud, "loud-info");
-    nros_warn!(loud, "loud-warn");
+    log_info!(loud, "loud-info");
+    log_warn!(loud, "loud-warn");
 
     let records = drain(&SINK_A_BUF);
     let quiet_records: Vec<_> = records
@@ -169,9 +169,9 @@ fn every_sink_receives_each_record_in_order() {
     let l = register_logger(&FANOUT_LOGGER);
     l.set_level(Severity::Trace);
 
-    nros_info!(l, "first");
-    nros_warn!(l, "second {}", 2);
-    nros_error!(l, "third");
+    log_info!(l, "first");
+    log_warn!(l, "second {}", 2);
+    log_error!(l, "third");
 
     let a = drain(&SINK_A_BUF);
     let b = drain(&SINK_B_BUF);
@@ -216,9 +216,9 @@ fn dropped_records_reach_no_sink() {
     let l = register_logger(&DROP_LOGGER);
     l.set_level(Severity::Error);
 
-    nros_info!(l, "should-be-dropped");
-    nros_warn!(l, "should-also-be-dropped");
-    nros_error!(l, "kept");
+    log_info!(l, "should-be-dropped");
+    log_warn!(l, "should-also-be-dropped");
+    log_error!(l, "kept");
 
     for buf in [&SINK_A_BUF, &SINK_B_BUF] {
         let records: Vec<_> = drain(buf)

--- a/packages/testing/nros-tests/tests/workspace_features_e2e.rs
+++ b/packages/testing/nros-tests/tests/workspace_features_e2e.rs
@@ -19,7 +19,7 @@
 //!   the listener prints ≥3 decoded `reading seq=` lines AND the `temp=`
 //!   second field (full CDR layout, not just a counter).
 //! - **Logging** (phase-263 A5 / phase-264 W3): a Node pkg's
-//!   `nros_info!` / `NROS_LOG_INFO(nros_log_default_logger(), …)` reaches
+//!   `log_info!` / `NROS_LOG_INFO(nros_log_default_logger(), …)` reaches
 //!   the entry's OWN stdout — process-local, no subscriber (issue 0096
 //!   does not apply to logging). Per-lang markers differ (the mixed ws
 //!   reuses the C talker).
@@ -105,7 +105,7 @@ enum Proof {
     /// `printf("<marker> seq=%d")` would satisfy it: the proof could not tell
     /// the facade from a direct write, nor notice the level/logger metadata
     /// being lost. Every one of these nodes logs through
-    /// `nros_info!` / `NROS_LOG_INFO` → the default sink → the posix writer,
+    /// `log_info!` / `NROS_LOG_INFO` → the default sink → the posix writer,
     /// whose output is `[INFO] nros: <marker> seq=N`, so requiring the tag on
     /// the SAME line makes the assertion about the facade rather than about
     /// stdout.
@@ -209,7 +209,7 @@ fn exec_for(lang: ML, workload: MW) -> Exec {
             note: "phase-338 W7: talker_pkg logs through the `log` facade like every other \
                    example body, and nros-board-linux's stdout bridge carries it — no \
                    per-app logging init. This cell USED to prove the same for the \
-                   nros_log chain (`nros_info!` + the board's boot-time platform sink); \
+                   nros_log chain (`log_info!` + the board's boot-time platform sink); \
                    that property now rests on the C and C++ siblings below, which reach \
                    the identical board mechanism through their projections",
         },

--- a/scripts/check-book-identifiers.py
+++ b/scripts/check-book-identifiers.py
@@ -49,11 +49,27 @@ EXEMPT = {
     "nros_platform_myrtos": "porting/overview scaffold output name",
     "nros_board_stm32f4_freertos": "vendor-overlay worked example (out-of-tree crate)",
     "my_stm32f4_board": "stm32f4-out-of-tree worked example",
+    # phase-417 widened this gate to `rcl_*`/`rclc_*`, and a MIGRATION table
+    # names upstream's identifier on the left of the arrow. `rcl_node_init` is
+    # micro-ROS's, not ours -- ours is `rclc_node_init_default`. The gate reads
+    # backtick spans and cannot see arrow direction, so the "from" side of a
+    # port table needs naming here rather than being silently accepted.
+    "rcl_node_init": "comparison-vs-microros names it as micro-ROS's spelling, the FROM side of the port table",
 }
 
 SPAN = re.compile(r"`([^`\n]+)`")
 RUST_PATH = re.compile(r"^nros(::[A-Za-z_][A-Za-z0-9_]*!?)+(\(\))?$")
-C_IDENT = re.compile(r"^nros_[a-z0-9_]+$")
+# phase-417 stage 6 — `rcl_*` / `rclc_*` too, not only `nros_*`.
+#
+# The book now teaches rcl/rclc spellings, because the C API took them
+# (RFC-0087). Before this, every `rcl_get_zero_initialized_node` a doc author
+# typed was INVISIBLE to this gate: it validated `nros_*` only, so a typo in the
+# new vocabulary shipped green while the old vocabulary was checked. W-B4
+# grep-verified its 22 new identifiers by hand for exactly that reason.
+#
+# `rmw_*` is deliberately NOT here: the book names upstream `rmw_qos_profile_*`
+# constants we do not declare, and they would all read as unknown.
+C_IDENT = re.compile(r"^(nros|rcl|rclc)_[a-z0-9_]+$")
 CMAKE_CALL = re.compile(r"^(nros_[a-z0-9_]+|nano_ros_[a-z0-9_]+)\(")
 
 

--- a/scripts/check-book-identifiers.py
+++ b/scripts/check-book-identifiers.py
@@ -62,7 +62,7 @@ RUST_PATH = re.compile(r"^nros(::[A-Za-z_][A-Za-z0-9_]*!?)+(\(\))?$")
 # phase-417 stage 6 — `rcl_*` / `rclc_*` too, not only `nros_*`.
 #
 # The book now teaches rcl/rclc spellings, because the C API took them
-# (RFC-0087). Before this, every `rcl_get_zero_initialized_node` a doc author
+# (RFC-0089). Before this, every `rcl_get_zero_initialized_node` a doc author
 # typed was INVISIBLE to this gate: it validated `nros_*` only, so a typo in the
 # new vocabulary shipped green while the old vocabulary was checked. W-B4
 # grep-verified its 22 new identifiers by hand for exactly that reason.


### PR DESCRIPTION
Stacked on #329 (`phase-417-ros2-api-adoption`) — review that first.

Stage 6 step A made the ROS 2 spellings first-class names declared by the API
headers. Step B moves **our own call sites** onto them, so the tree reads the
way a ported ROS 2 program does instead of teaching a second vocabulary beside
it.

| item | scope |
| --- | --- |
| W-B1 rust | 277 occurrences, 50 files |
| W-B2 c | 296 sites, 38 files |
| W-B3 cpp | 288 sites migrated, 120 files surveyed |
| W-B4 docs | 14 files |

## Two survey numbers did not survive contact

Both are recorded rather than quietly fixed.

W-B2 found that 2 of the 43 C names called "pure renames" are **arity changes**,
so they carry a signature edit, not a substitution.

W-B3 found the larger error: the survey called all 645 C++ sites a pure rename.
Only **288 of 697 (41 %)** are. The remaining 409 stay `nros::` for the
campaign's own rule rather than for effort:

* `nros::Node` — **109 sites across 103 files**. `rclcpp::Node` is a *distinct
  class*, not an alias: `make_shared` plus a shared_ptr-returning
  `create_publisher<M>` against ours' out-ref `create_node(node, …)`. It is also
  hosted-only, so it does not exist on the freestanding targets most of those
  files build for.
* `nros::init` — `rclcpp::init()` returns **void** while every one of our 13
  call sites consumes a `Result`. A rename there silently drops the error
  check: exactly the compile-and-differ RFC-0089 exists to prevent.
* `Timer`, `spin_once`, the whole lifecycle set and the action-response enums
  have no counterpart at all.

## W-B5 gains a precondition it did not have

The C forwarders and the five Rust logging forwarders can be deleted — every one
has a live replacement. The C++ `nros::` spellings for
`Node`/`init`/`Timer`/`spin_once`/lifecycle/action-response **cannot**: deleting
them removes a *capability* rather than a spelling. Retiring those waits on the
node-type merge that `nros.hpp`'s own comment already defers to "a later step",
which nothing currently schedules.

## Fixes carried here

* **`is_qos_arg` depends on no standard header.** Step A gated hosted STL on
  `__has_include`, which is wrong on Zephyr — the header exists and is
  *hollow*. Gating on `NROS_CPP_STD` instead broke the freestanding lane, which
  compiles `rclcpp::Node` against a synthesised minimal libcpp while defining no
  opt-in. Neither predicate is true in both lanes, so the predicate now uses
  neither: a derived-to-base pointer conversion answers `is_base_of` with
  nothing but the core language.
* **The C++ scaffold template is reverted to `::nros::`.** Three of the four
  names the migration introduced do not exist. Filed as #1058: the scaffold
  tests grep the emitted text and never build it, so the migration went green.
* **`nros-bridge`'s two missed `nros_error!` sites** — that crate compiles only
  in the workspace lanes.
* **`rust_target_installed` is probed once per process.** It mapped both "no
  rustup" and "spawn failed" to `true`, so two calls could disagree under an
  80-way build. Caching makes the process self-consistent; it does not claim to
  make the probe more accurate.

## Known red, not from this branch

`check-build`'s `node-std-tests` and `test-targets` fail here **and on a
pristine `main`** — a half-landed `type Format` from phase-421 and a clippy
`format!`-in-`assert!`. Filed as #1059. Neither is in the required `CI` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j