### PR TITLE
fix(#1052): ESP32 talker faults from a stack overflow — root cause, fix, and the floor gate

### DIFF
--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -857,3 +857,41 @@ Cause established and demonstrated both directions. Remaining work is the fix
 ladder above — and item 1, the `.stack` floor gate, is the one that matters: this
 image shipped with an 18 KB stack against a comment budgeting ~67 KB, and nothing
 said a word.
+
+
+## Both images now clear the floor on what they DECLARE (2026-09-04)
+
+The listener was carried as recorded debt when the gate landed. It is fixed, and
+the table is empty:
+
+| image | declares | before | after |
+| --- | --- | ---: | ---: |
+| `esp32_qemu_talker` | 1 pub, 1 timer | 18,572 B | **49,148 B** |
+| `esp32_qemu_listener` | 1 sub | 22,060 B | **52,636 B** |
+
+Both against a 32,768 B floor; `DEBT` in `check-stack-floor.py` is now empty.
+
+The listener declared exactly one subscription and paid a budget of 8
+(`SMALL_PAYLOADS`, 32 KB), plus `SERVICE_BUFFERS` for services it never declares.
+Setting `ZPICO_MAX_SUBSCRIBERS = "1"` returns 30,576 B of stack. Verified at
+runtime, not only at link: it boots, logs `Subscriber created for topic:
+/chatter`, and takes no fault — a budget of 1 is enough for a leaf that declares
+1.
+
+The gate proved itself on the way through. Raising the listener tripped
+`EXCEEDS its recorded debt of 22,060 B` and refused the build until the entry was
+deleted, which is what a ceiling-that-may-only-fall is for: an improvement is not
+allowed to sit quietly in a table that says the image is broken.
+
+### The hand-maintenance is now issue 1061
+
+Three rows in `fixtures.toml` now restate, by hand and in another file, what
+`register` already says. `entity_inventory.rs` computes exactly these numbers but
+publishes them only as CMake variables, and these leaves are pure-cargo — so they
+take `zpico-sys`'s compiled-in defaults no matter what they declare. Filed as
+**1061**; the queryable half of the same table was already applied "a row too
+narrowly the first time", which is that failure mode having happened once.
+
+`check-stack-floor.py` bounds the damage in the meantime: a leaf that gains an
+entity without gaining budget fails at build time instead of becoming a wild jump
+at runtime.

--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -568,3 +568,52 @@ rather than a line of code.
   from that capture is recorded here. Two instruction-access faults are not
   necessarily the same fault, and the pre-fix build had no `nros_log` record
   path in the leaves.
+
+
+
+## gdb names the frame (2026-09-04): `ZenohSession::create_publisher`
+
+`riscv32-esp-elf-gdb` against QEMU's gdbstub, with the router CONFIRMED serving
+on :9800 first. Break at the handler, dump the stack, resolve every code address
+on it:
+
+```
+0x42017ec8  <nros_rmw_zenoh::shim::session::ZenohSession as nros_rmw::traits::Session>::create_publisher
+0x420531ca  esp_hal::interrupt::riscv::vectored::enable_on_cpu
+0x4205334c  <riscv_rt::TrapFrame as core::fmt::Debug>::fmt
+0x4205e950  <i32 as core::fmt::Display>::fmt
+```
+
+Everything but the first is the exception handler printing itself. **The only
+application frame on the faulting stack is `ZenohSession::create_publisher`.**
+
+At the handler: `sp` is in `.bss` near `nros_smoltcp::TCP_RX_BUFFER_0`, and `ra`
+resolves to `core::panicking::assert_failed_inner+2` — a mid-symbol offset, so
+treat that as nearest-preceding resolution and NOT as proof of a panic frame.
+The `a0`/`a2` strings are the handler's own format literals
+(`"Exception '...' mepc=0x..."`), not an assertion message; an earlier reading of
+them as one would have been wrong.
+
+### It fits the leaf split — and CONTRADICTS the empty-register result
+
+A publisher is what the talker creates and the listener does not, so the frame
+explains the split immediately. But variants E, F and H registered NOTHING and
+faulted identically, and with an empty `register` no publisher is created.
+
+Both cannot be true. Either:
+
+* the empty-`register` images were not actually rebuilt before packing — the
+  pack step may have used a cached ELF, which would make E/F/H measurements of
+  the ORIGINAL image; or
+* something creates a publisher during session setup regardless of what the node
+  registers (liveliness, the graph, an internal token), in which case the frame
+  is reached on every image and the leaf split has a different cause.
+
+**Resolve that before acting on either.** The check is cheap: rebuild an
+empty-`register` talker, confirm the string `Hello World` is ABSENT from the ELF
+(it only exists in the publishing path), and re-run. If it faults with the
+publisher genuinely gone, the second explanation holds.
+
+This is the same class as the four retracted issues 0859-0862: a measurement
+whose artifact provenance was never checked. My E/F/H runs did not verify that
+the packed image contained the edit.

--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -674,3 +674,127 @@ provenance was never checked — the ASCII lead, the "fault is on the CONNECTED
 path" claim, and now E/F/H. The control that caught it costs one command
 (`nm | grep -c <symbol>` on the ELF you are about to run) and would have caught
 all three.
+
+
+## Correction: my `create_publisher` symbol probe was vacuous (2026-09-04)
+
+The section above reports "`create_publisher` symbol count in the freshly built
+ELF is **0**". That number came from a command that does not exist on PATH:
+
+```
+riscv32-esp-elf-nm $E 2>/dev/null | grep -c create_publisher
+```
+
+`riscv32-esp-elf-nm` is not on PATH (it lives under
+`~/.espressif/tools/riscv32-esp-elf/esp-13.2.0_20240530/riscv32-esp-elf/bin/`);
+`2>/dev/null` swallowed "command not found" and `grep -c` dutifully returned 0.
+It returns 0 for EVERY input, so it discriminated nothing — and I never ran it on
+the full image at all, I inferred "present" from the source. Run properly, the
+full talker has 5 `create_publisher` and 3 `create_subscription` symbols.
+
+**The behavioural conclusion still stands**, on evidence that does not depend on
+that probe: the two images have different checksums (`bd256c2963a8` vs
+`501cfc6d5412`), they were run back to back under identical arguments, and the
+build log for the edited one carries `warning: unused imports: NodeOptions and
+TimerDuration` — imports that can only become unused once `register` is emptied.
+That is direct evidence the edited source is what compiled.
+
+So: E/F/H stay retracted, `register` still decides it, and the stated
+verification method was worthless. A probe needs a POSITIVE CONTROL — run it
+against the artifact where the symbol MUST appear, and if that also returns
+nothing, the probe is broken rather than the artifact.
+
+## ROOT CAUSE: `.stack` is the linker leftover, and `.bss` has eaten it
+
+`create_publisher` is not the bug. It is the deepest frame on the deepest chain,
+so it is where a stack that is already too small runs out.
+
+From the fixture ELF:
+
+| symbol | value |
+| --- | --- |
+| `.bss` | `0x3fc81960` + `0x048214` = **295,444 B** |
+| `_stack_end` (low bound) | `0x3fcc9b74` |
+| `_stack_start` (high; grows down) | `0x3fcce400` |
+| **stack size** | **18,572 B** |
+| **faulting `sp`** | **`0x3fcc9180`** |
+
+`sp` is **2,548 bytes below `_stack_end`** — outside the stack, inside `.bss`,
+landing in `nros_smoltcp::TCP_RX_BUFFER_0` (`0x3fcc8a1c`) + 1892. That is exactly
+what gdb symbolised it as. **This is a stack overflow**, and the instruction-access
+fault is the smashed frame being returned through.
+
+`nros-board-esp32-qemu/src/node.rs` already describes this failure mode in full —
+it is issue **#190**:
+
+> `.stack` is the LINKER LEFTOVER after `.bss` (link.x fills DRAM up to
+> 0x3fcce400) … At 96 KB the stack shrank to ~18 KB … the overflow wrote frames
+> straight down into `.bss` … producing the #190 phantom corruptions … wild jumps
+> (mepc=0x9ae65930) … **None of them were allocator or zenoh-pico bugs.**
+>
+> 48 KB fits the executor arena AND leaves a **~67 KB stack** … Check `.stack` in
+> `readelf -S` after changing ANY large static — **there is no runtime
+> stack-overflow guard on this target.**
+
+The heap knob is still 48 KB, but the stack is **18,572 B, not ~67 KB**. `.bss`
+grew by roughly the difference and nobody re-ran the check the comment
+prescribes. **Issue 1052 is a regression of #190 by `.bss` growth.**
+
+### Why the talker and not the listener
+
+The publisher chain is ~5.1 KB of frames on its own:
+
+```
+create_publisher_with_qos  2048
+  create_publisher_raw_on  1120
+    CffiSession::create_publisher   928
+      create_publisher_trampoline   272
+        ZenohSession::create_publisher  768
+```
+
+and the talker's `register` also calls `create_timer` (2048). The listener's
+subscription path is shallower. With ~18 KB of stack under a zenoh-pico +
+smoltcp poll path, the publisher side crosses the line first. Nothing in
+`create_publisher` is wrong; both it and `create_subscription` are structurally
+identical, differing only in `ENTITY_PUBLISHER`/`ENTITY_SUBSCRIBER` ("MP"/"MS",
+same length).
+
+### What is in `.bss`, and two findings that belong to the memory campaign
+
+| bytes | symbol |
+| --- | --- |
+| 83,648 | `g_sessions` (zenoh-pico C) |
+| 49,152 | `nros_board_esp32_qemu::node::init_hardware::HEAP` (the documented 48 KB) |
+| 34,480 | `nros_platform_esp32_qemu::memory::HEAP` |
+| 32,768 | `nros_rmw_zenoh::shim::subscriber::SMALL_PAYLOADS` |
+| 32,768 | `nros_rmw_zenoh::shim::subscriber::LARGE_PAYLOADS` |
+| 9,556 | `ETH_DEVICE` |
+| 8,856 | `SERVICE_BUFFERS` |
+
+**Two heaps coexist.** The node.rs comment describes one (48 KB `esp_alloc`), and
+says the DDS path swaps in a `FreeListHeap` *instead*. But
+`nros-platform-esp32-qemu/src/memory.rs:20` declares `FreeListHeap<{32 * 1024}>`
+on the non-DDS arm too, so both are linked: **83,632 B of heap in `.bss`**,
+directly out of the stack. Whether that is intended needs an owner's answer; the
+comment reads as though it is not.
+
+**The talker pays 65,536 B for subscriber pools it never uses.** `SMALL_PAYLOADS`
+and `LARGE_PAYLOADS` are `[_; ZPICO_MAX_SUBSCRIBERS]` / `[_; MAX_LARGE_SUBSCRIBERS]`
+— sized on the configured maximum, not on what the node declares. A pure
+publisher declares zero subscriptions and still pays both. That is precisely the
+campaign thesis (0827 / 0832: pay for what you declare) and the same shape as the
+queryable table. Here it is not a footprint nicety — on this target `.bss` is
+subtracted from the stack, so it is the crash.
+
+### Fixes, in order
+
+1. **Gate it.** The comment says to check `.stack` after any large static and
+   there is no runtime guard, so the check must not be a comment. Assert a
+   `.stack` floor for the ESP32 image in the build, the way `just mem-report`
+   already reads sections. A silent 18 KB stack is how this got here.
+2. **Stop paying for undeclared entities** — the two payload pools, via the
+   inventory the campaign already computes. Recovers up to 64 KB of stack on a
+   publisher-only image.
+3. **Resolve the two heaps** — 83,632 B where the comment budgets 49,152.
+
+Item 1 is the one that keeps it fixed; 2 and 3 are what buy the headroom back.

--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -617,3 +617,60 @@ publisher genuinely gone, the second explanation holds.
 This is the same class as the four retracted issues 0859-0862: a measurement
 whose artifact provenance was never checked. My E/F/H runs did not verify that
 the packed image contained the edit.
+
+
+## RESOLVED, both halves: the frame is real and the bisect was stale (2026-09-04)
+
+Ran the check the section above asked for, and it settles both.
+
+An empty-`register` talker, **with the artifact verified this time** — the
+`create_publisher` symbol count in the freshly built ELF is **0**, so the
+publisher is genuinely gone. (`Hello World` is a BAD probe and stays present:
+the string lives in the callback body, which still compiles. Symbol count is the
+probe that discriminates.) Run against the same router, same QEMU arguments as
+the harness (`-M esp32c3 -icount 3 -nic user,model=open_eth`), with the ORIGINAL
+image kept as a matched control in the same session:
+
+| image | `create_publisher` in ELF | faults in 60 s |
+| --- | --- | --- |
+| empty `register` | 0 | **0** |
+| full talker (control) | present | **2** |
+
+So `register` decides it, `ZenohSession::create_publisher` on the stack is real,
+and **variants E, F and H are RETRACTED** — they measured the original image.
+
+### Why they were stale: this issue's own sibling, #1025
+
+`just esp32 build-qemu` resolved the ELF with
+
+```
+nros_fixture_row_artifact_dir "<leaf>" qemu-esp32-baremetal "" ""
+```
+
+— empty `cargo_args` and empty `envstr`, INVENTED at the call site rather than
+read from the row. The talker row carries the variant `ZPICO_MAX_QUERYABLES=2`,
+so cargo writes to the group dir `qemu-esp32-baremetal-4118800323` while the
+packer looks in the bare `qemu-esp32-baremetal`. During E/F/H a stale ELF sat at
+the bare path, so every "rebuild" packed the SAME original image, and three
+variants agreed because they were one binary.
+
+That is issue **#1025** exactly, and its fix (the by-id helper, which reads the
+row instead of inventing its inputs) is in open PR **#303** — unmerged, which is
+why the broken spelling is still on `main` and why the trap was still armed
+today. It now fails LOUD (`is missing, and nothing narrowed this build`) rather
+than packing a stale image, because #700 landed in between; that is the only
+reason this was catchable at all.
+
+### What is actually established
+
+The fault is reached from `ZenohSession::create_publisher`, on the connected
+path, in the talker only. The listener creates a subscription and does not
+fault. Next step is that function, not another bisect.
+
+### Method note
+
+Every wrong turn in this issue has one shape: a measurement whose artifact
+provenance was never checked — the ASCII lead, the "fault is on the CONNECTED
+path" claim, and now E/F/H. The control that caught it costs one command
+(`nm | grep -c <symbol>` on the ELF you are about to run) and would have caught
+all three.

--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -798,3 +798,62 @@ subtracted from the stack, so it is the crash.
 3. **Resolve the two heaps** — 83,632 B where the comment budgets 49,152.
 
 Item 1 is the one that keeps it fixed; 2 and 3 are what buy the headroom back.
+
+
+## CONFIRMED by experiment: give the stack back 30 KB and the fault goes away
+
+Prediction from the root cause: recover `.bss` and the overflow stops. The talker
+declares no subscriptions, so its subscriber payload pools are pure waste. Set
+`ZPICO_MAX_SUBSCRIBERS = "1"` on the talker row — the same move the row already
+makes for `ZPICO_MAX_QUERYABLES`, one knob over.
+
+| | `.bss` | stack | `SMALL_PAYLOADS` |
+| --- | ---: | ---: | ---: |
+| shipped | 295,444 | **18,572** | 32,768 |
+| `ZPICO_MAX_SUBSCRIBERS=1` | 264,868 | **49,148** | 4,096 |
+
+**Stack 18,572 → 49,148 B (2.6x).** The faulting `sp` `0x3fcc9180` now sits well
+inside the stack (`_stack_end` moved `0x3fcc9b74` → `0x3fcc2404`).
+
+Three runs, same router, identical QEMU arguments, back to back:
+
+| image | stack | lines of output | `ConnectionFailed` | faults |
+| --- | ---: | ---: | ---: | ---: |
+| full talker (shipped) | 18,572 | **70 — died** | 0 | **2** |
+| empty `register` | 18,572 | 23,083 | 23,033 | 0 |
+| `ZPICO_MAX_SUBSCRIBERS=1` | 49,148 | 23,850 | 23,565 | **0** |
+
+The comparison is sound in the way that matters: the shipped talker dies at line
+70, BEFORE the connection-retry loop that the other two then run for 23k lines.
+All three traverse the same early path; only the one with an 18 KB stack faults
+on it. (None of the three connects — the host router is not reachable through
+`-nic user,model=open_eth`. That is irrelevant here, because the fault happens
+before the retry loop, not on the connected path.)
+
+### This also corrects "the faulting PC is CONSTANT across builds"
+
+That earlier section recorded `mepc = 0x732f7264` in all three
+`ZPICO_MAX_QUERYABLES` builds and reasoned: constancy rules out stack smashing,
+"which would move with layout". Today's shipped-talker run faults with
+**`mepc = 0x02250042`**, and `ra = 35979330` = `0x02250042` — a different value
+entirely. So the PC is not constant, and the argument built on its constancy does
+not hold.
+
+The two observations were never in conflict anyway. That section concluded "the
+value is DATA the code reads deterministically ... from a fixed place",
+`0x732f7264` being the printable text `"s/rd"`. The fixed place is now named: the
+overflowed stack sits inside `nros_smoltcp::TCP_RX_BUFFER_0`, so a return-address
+slot is overwritten by received network bytes — and keyexpr traffic is exactly
+where printable `"s/rd"` comes from. A deterministic overflow landing in a
+deterministic buffer reads the same bytes every run; constancy was evidence FOR
+this mechanism, read as evidence against it.
+
+**Memory pressure is un-refuted and is the cause.** The direct measurement (`sp`
+2,548 B outside the stack) outranks the inference either way.
+
+### Status
+
+Cause established and demonstrated both directions. Remaining work is the fix
+ladder above — and item 1, the `.stack` floor gate, is the one that matters: this
+image shipped with an 18 KB stack against a comment budgeting ~67 KB, and nothing
+said a word.

--- a/docs/issues/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
+++ b/docs/issues/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
@@ -1,0 +1,76 @@
+---
+id: 1061
+title: Entity budgets are derived for CMake consumers only, so pure-cargo leaves hand-set them
+status: open
+area: build
+severity: medium
+related: [1052, 0827, 0832, 0190]
+---
+
+## What
+
+`nros-cli-core/src/entity_inventory.rs` computes how many entities of each kind
+a component declares, and publishes the result as CMake variables:
+
+```rust
+"set(NROS_DERIVED_MAX_SUBSCRIBERS {})\n",
+```
+
+That reaches every leaf built through `cmake`. It reaches **no pure-cargo leaf**
+— `examples/qemu-esp32-baremetal/rust/{talker,listener}` and
+`packages/testing/nros-tests/bins/logging-smoke-esp32-qemu` are built by plain
+`cargo build`, so they take `zpico-sys`'s compiled-in defaults (8 subscribers,
+8 queryables) whatever they declare.
+
+## Why it matters here specifically
+
+On `qemu-esp32-baremetal` an over-budget static is not a footprint nicety. The
+stack is the **linker leftover** after `.bss` (`link.x` fills DRAM up to
+`_stack_start`, `.bss` grows up from below), so every byte of unused pool comes
+straight out of the stack, and there is no runtime overflow guard: the image
+writes frames into `.bss` and dies later as a wild jump somewhere unrelated.
+
+That is issue 1052. The talker shipped with an **18,572 B** stack against
+node.rs's ~67 KB budget and faulted with `sp` outside the stack, inside
+`nros_smoltcp::TCP_RX_BUFFER_0`. Two of its pools were sized for entities it does
+not declare.
+
+## The workaround now in the tree, and why it is one
+
+`examples/fixtures.toml` hand-sets the budgets per row:
+
+| row | declares | hand-set |
+| --- | --- | --- |
+| talker | 1 pub, 1 timer | `ZPICO_MAX_QUERYABLES=2`, `ZPICO_MAX_SUBSCRIBERS=1` |
+| listener | 1 sub | `ZPICO_MAX_QUERYABLES=2`, `ZPICO_MAX_SUBSCRIBERS=1` |
+| logging-smoke | — | `ZPICO_MAX_QUERYABLES=2` |
+
+Stacks recovered: talker 18,572 → 49,148 B, listener 22,060 → 52,636 B.
+
+It works, and it is the third time the same edit has been made by hand. The
+numbers restate what `register` already says, in a different file, with nothing
+tying them together — so they go stale exactly when a leaf gains an entity, which
+is the moment being wrong costs the most. The queryable half of this table was
+already applied "a row too narrowly the first time" (its own comment says so),
+which is this failure mode having happened once.
+
+## Fix
+
+Deliver the inventory to the cargo path as well as the CMake path, so a leaf's
+budgets follow its declarations. The inventory is already computed; what is
+missing is a channel `zpico-sys`'s `build.rs` can read — the same shape as
+`nros_zephyr_build::knob_usize` reading `$DOTCONFIG`, and subject to the same
+rule as issue 0460: a knob that reaches one lane and not the other is an ABI
+split, not just a missing feature.
+
+Until then `scripts/check-stack-floor.py` is the backstop: it fails the build if
+an ESP32 image drops below a 32 KB stack, so a leaf that gains an entity without
+gaining budget is caught at build time rather than as a wild jump at runtime.
+The gate bounds the damage; it does not remove the hand-maintenance.
+
+## Not to do
+
+Do not raise the ESP32 stack by shrinking the heap. node.rs documents that as a
+two-sided constraint (issue 0190): 16 KB is too small for the executor backing
+and 96 KB starves the stack. The heap is not where the slack is — the unused
+pools are.

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -3191,7 +3191,7 @@ skip_probe = true
 # failure named. These three build through `just esp32 build-qemu` and kept
 # overflowing — by 8,644 B in `esp32_qemu_talker` — which is the "fix the CLASS,
 # not the reported site" rule applied a row too narrowly the first time.
-env = { ZPICO_MAX_QUERYABLES = "2" }
+env = { ZPICO_MAX_QUERYABLES = "2", ZPICO_MAX_SUBSCRIBERS = "1" }
 
 [[fixture]]
 id = "qemu-esp32-baremetal-listener"

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -3191,6 +3191,16 @@ skip_probe = true
 # failure named. These three build through `just esp32 build-qemu` and kept
 # overflowing — by 8,644 B in `esp32_qemu_talker` — which is the "fix the CLASS,
 # not the reported site" rule applied a row too narrowly the first time.
+#
+# ZPICO_MAX_SUBSCRIBERS: issue 1052, the same class one entity kind over. This
+# is a talker — it declares no subscriptions — but the default budget still
+# links SMALL_PAYLOADS at `ZPICO_MAX_SUBSCRIBERS * ring depth * buffer size`.
+# On this board `.bss` is subtracted from the stack (link.x fills DRAM up to
+# `_stack_start`, `.bss` grows up from below), so those 28 KB came straight out
+# of the stack: 18,572 B against node.rs's ~67 KB budget, and the image faulted
+# with `sp` outside the stack, inside `nros_smoltcp::TCP_RX_BUFFER_0`. Setting
+# it to 1 restores 30,576 B of stack and the fault stops. Gated now by
+# `scripts/check-stack-floor.py`, run per row by `fixtures-build.sh`.
 env = { ZPICO_MAX_QUERYABLES = "2", ZPICO_MAX_SUBSCRIBERS = "1" }
 
 [[fixture]]

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -3209,7 +3209,12 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "examples/qemu-esp32-baremetal/rust/listener"
 skip_probe = true
-env = { ZPICO_MAX_QUERYABLES = "2" }  # see the talker row above
+# ZPICO_MAX_SUBSCRIBERS: issue 1052, see the talker row. This leaf declares
+# exactly ONE subscription and no publishers/services/actions, but the default
+# budget of 8 links SMALL_PAYLOADS at 32 KB. `.bss` is subtracted from the stack
+# on this board, so that budget was 28 KB of stack the image could not spend.
+# 1 is what it declares, and the gate below is what keeps it honest.
+env = { ZPICO_MAX_QUERYABLES = "2", ZPICO_MAX_SUBSCRIBERS = "1" }
 
 [[fixture]]
 id = "qemu-esp32-baremetal-logging-smoke"

--- a/just/check.just
+++ b/just/check.just
@@ -3002,6 +3002,23 @@ no-alloc-image:
     @python3 scripts/check-no-alloc-image.py --selftest
     @python3 scripts/check-no-alloc-image.py --claims
 
+# Issue 1052 — the ESP32 stack is the LINKER LEFTOVER after `.bss`
+# (`_stack_start - _stack_end`), so every byte a static gains is a byte the
+# stack loses, and there is no runtime overflow guard on the target: the image
+# writes frames into `.bss` and dies later as a wild jump somewhere unrelated.
+# `nros-board-esp32-qemu/src/node.rs` has instructed "check `.stack` after
+# changing ANY large static" since issue 0190; a comment cannot be run on a
+# schedule, and the talker duly shipped with 18,572 B against a ~67 KB budget.
+#
+# Only the artifact-free half runs here — the real per-image assertion lives in
+# `just esp32 build-qemu`, on the ELF that step just linked. Resolving a built
+# image from a `check` lane would need a fixture (banned) or would skip when
+# absent, and a skip is exactly the silence this gate exists to end.
+[private]
+stack-floor:
+    @python3 scripts/check-stack-floor.py --selftest
+    @python3 scripts/check-stack-floor.py --claims
+
 # The per-RMW capability page is derived from the two C vtables + the zenoh
 # shim's trait overrides. Prose versions of this table drifted in BOTH
 # directions (cyclone services documented unsupported after service.cpp landed;

--- a/scripts/build/fixtures-build.sh
+++ b/scripts/build/fixtures-build.sh
@@ -382,7 +382,49 @@ else
           if [ -n "$envstr" ]; then export $envstr; fi
           if [ -n "$facts" ]; then export $facts; fi
           cargo build $cargo_profile_args $args $tdir_flag --quiet )
+        # Issue 1052 — assert the stack floor HERE, on the row that was just
+        # linked, because this is the only place the artifact's directory is
+        # known correctly: `$tdir_flag` comes from the row's own `$args` and
+        # `$envstr`, so it names where cargo actually wrote. (The esp32 pack
+        # loop invents empty args for the same lookup and reads a directory
+        # nothing writes — issue 1025.)
+        #
+        # Boards whose stack is the LINKER LEFTOVER after `.bss` only. On those
+        # there is no runtime overflow guard: a static that grows takes the
+        # stack directly and the image dies later as a wild jump somewhere
+        # unrelated. node.rs has asked for this check since issue 0190; a
+        # comment cannot run on a schedule, and the talker shipped at 18,572 B
+        # against a ~67 KB budget.
+        case "$platform" in
+            qemu-esp32-baremetal)
+                nros_fixture_check_stack_floor "$platform" "$args" "$envstr"
+                ;;
+        esac
     }
+    # Locate every ELF the row just produced and put it through the floor
+    # check. A row that resolves no artifact directory, or whose directory
+    # holds no executable, FAILS: this runs only for boards that were named
+    # above, so "nothing to check" means the lookup broke, not that the row is
+    # exempt. Silence is the failure mode this whole gate exists to end.
+    nros_fixture_check_stack_floor() {
+        local platform="$1" args="$2" envstr="$3"
+        local adir
+        adir="$(nros_fixture_row_artifact_dir "$dir" "$platform" "$args" "$envstr")"
+        if [ -z "$adir" ] || [ ! -d "$adir" ]; then
+            echo "ERROR: $dir — no artifact dir resolved for the stack-floor check" >&2
+            echo "       (platform=$platform). Refusing to skip it silently." >&2
+            return 1
+        fi
+        # `--row`: the script resolves THIS leaf's binary names from its own
+        # Cargo.toml and checks only those. phase-340 group dirs are SHARED —
+        # several rows build into one dir, and it also keeps binaries from
+        # earlier env combinations that no row produces any more. A glob would
+        # check other rows' artifacts: during development it failed the
+        # listener's build over a stale talker ELF from before the fix under
+        # test.
+        python3 "$NROS_REPO_ROOT/scripts/check-stack-floor.py" --row "$dir" "$adir"
+    }
+    export -f nros_fixture_check_stack_floor
     export -f nros_fixture_build_one
 
     # issue 0649 — sync each row DIRECTORY once, in the parent, before the rows

--- a/scripts/check-stack-floor.py
+++ b/scripts/check-stack-floor.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Assert a floor on the runtime stack of ESP32 images (issues 0190, 1052).
+
+On `qemu-esp32-baremetal` the stack is not declared — it is the LINKER
+LEFTOVER. `link.x` fills DRAM up to `_stack_start` (0x3fcce400) and `.bss`
+grows up from below, so `_stack_end` is wherever `.bss` happens to end and
+
+    stack = _stack_start - _stack_end
+
+shrinks by exactly one byte for every byte any static gains. There is no
+runtime stack-overflow guard on this target, so an overflow does not trap:
+it writes frames down into `.bss` and the image dies later, somewhere else,
+as a wild jump.
+
+That is issue 0190, and `nros-board-esp32-qemu/src/node.rs` closes its
+explanation with the instruction this script exists to enforce:
+
+    Check `.stack` in `readelf -S` after changing ANY large static — there
+    is no runtime stack-overflow guard on this target.
+
+Nobody could run that instruction on a schedule. Issue 1052 is what happened
+next: the comment budgets a ~67 KB stack, the shipped `esp32_qemu_talker`
+had 18,572 B, and it faulted with `sp` 2,548 B outside the stack, inside
+`nros_smoltcp::TCP_RX_BUFFER_0`. The measurement was always one command away
+and the failure looked like a zenoh-pico bug for as long as nobody took it.
+
+Read the numbers, not just the verdict: this prints every image's stack, so
+a shrink that stays above the floor is still visible in a diff.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Floors, per board.
+#
+# NOT a ratchet over what the tree happens to link today. 18,572 B crashes and
+# 22,060 B does not, but 22,060 is not evidence of safety — the listener merely
+# runs a shallower call chain than the publisher path. The number to respect is
+# the one node.rs and issue 0064 measured for the zenoh-pico handshake + nested
+# smoltcp poll path (≈98 KB deep at its worst; ~67 KB budgeted). A floor set
+# just above the last crash would bless the next one.
+# --------------------------------------------------------------------------
+FLOORS = {
+    "qemu-esp32-baremetal": 32 * 1024,
+}
+
+# Images that do NOT meet their board floor and are allowed to link anyway,
+# each with the issue that tracks getting it there. An entry here is a DEBT
+# ON RECORD, not an exemption from the rule: the recorded value is the worst
+# stack the image may have, so it can only improve, and removing the entry is
+# what closing the issue looks like.
+#
+# The repo's rule for a real-but-open gap (CLAUDE.md, the rmw-api-parity map):
+# it carries a TRACKED ISSUE ID in the reason, and that is what --check
+# tolerates — nothing else.
+DEBT = {
+    "esp32_qemu_listener": (
+        22_060,
+        "1052",
+        "declares no publishers/services/actions but still links the full "
+        "embedded entity budget; same class as the talker, one entity kind over",
+    ),
+}
+
+
+class Failure(Exception):
+    pass
+
+
+def find_nm() -> str:
+    """Locate a RISC-V `nm`, or fail LOUDLY.
+
+    A missing tool must never read as a passing check. During issue 1052 a
+    probe spelled `riscv32-esp-elf-nm ... 2>/dev/null | grep -c <sym>` was
+    used to decide whether a symbol was present; the tool was not on PATH,
+    the redirect ate "command not found", `grep -c` returned 0, and the 0 was
+    read as "absent". It returns 0 for every input, so it discriminated
+    nothing — and it shipped in a published conclusion. Hence: resolve
+    explicitly, raise if absent.
+    """
+    for name in ("riscv32-esp-elf-nm", "riscv64-unknown-elf-nm", "llvm-nm"):
+        found = shutil.which(name)
+        if found:
+            return found
+    for root in (Path.home() / ".espressif" / "tools" / "riscv32-esp-elf",):
+        if root.is_dir():
+            for cand in sorted(root.glob("*/riscv32-esp-elf/bin/riscv32-esp-elf-nm")):
+                if os.access(cand, os.X_OK):
+                    return str(cand)
+    raise Failure(
+        "no RISC-V `nm` found (tried riscv32-esp-elf-nm, riscv64-unknown-elf-nm, "
+        "llvm-nm, and ~/.espressif/tools/riscv32-esp-elf/*/riscv32-esp-elf/bin/).\n"
+        "Refusing to report a verdict without one — a missing tool is not a pass."
+    )
+
+
+def parse_stack_symbols(nm_output: str) -> tuple[int, int]:
+    """Extract (_stack_end, _stack_start) from `nm` output.
+
+    Pure text in, numbers out, so the logic is testable without an ELF.
+    """
+    end = start = None
+    for line in nm_output.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        sym = parts[-1]
+        if sym == "_stack_end":
+            end = int(parts[0], 16)
+        elif sym == "_stack_start":
+            start = int(parts[0], 16)
+    if end is None or start is None:
+        missing = " and ".join(
+            n for n, v in (("_stack_end", end), ("_stack_start", start)) if v is None
+        )
+        raise Failure(
+            f"{missing} not found in the symbol table.\n"
+            "On this board the stack has no section — it is the gap between these "
+            "two linker symbols. Without them there is nothing to measure, which "
+            "is a failure to answer, not an answer."
+        )
+    if start <= end:
+        raise Failure(
+            f"_stack_start (0x{start:08x}) is not above _stack_end (0x{end:08x}); "
+            "the stack region is inverted or empty."
+        )
+    return end, start
+
+
+def stack_size(elf: Path, nm: str) -> tuple[int, int, int]:
+    proc = subprocess.run(
+        [nm, str(elf)], capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        raise Failure(f"{nm} failed on {elf}:\n{proc.stderr.strip()}")
+    end, start = parse_stack_symbols(proc.stdout)
+    return start - end, end, start
+
+
+def board_of(elf: Path) -> str | None:
+    """Which board's floor applies. Path-based: these images are built into
+    `build/cargo-fixtures/<board>[-<group cksum>]/…` (phase-340 group dirs)."""
+    for part in elf.parts:
+        for board in FLOORS:
+            if part == board or part.startswith(board + "-"):
+                return board
+    return None
+
+
+def verdict(elf: Path, size: int, board: str) -> tuple[bool, str]:
+    floor = FLOORS[board]
+    name = elf.name
+    if name in DEBT:
+        cap, issue, reason = DEBT[name]
+        if size > cap:
+            return False, (
+                f"{name}: stack {size:,} B EXCEEDS its recorded debt of {cap:,} B.\n"
+                f"    The entry in DEBT is a ceiling that may only fall. It rose, so "
+                f"either something regressed or the entry is stale — re-measure and "
+                f"lower it, or delete it if the image now clears the {floor:,} B floor."
+            )
+        return True, (
+            f"{name}: {size:,} B — below the {floor:,} B floor, tracked by issue "
+            f"{issue} (cap {cap:,} B)\n      {reason}"
+        )
+    if size < floor:
+        return False, (
+            f"{name}: stack {size:,} B is BELOW the {board} floor of {floor:,} B.\n"
+            f"    The stack on this board is the linker leftover after `.bss`, so a "
+            f"static that grew took this directly. There is no runtime overflow "
+            f"guard here: the image will not trap, it will write frames into `.bss` "
+            f"and die later as a wild jump (issues 0190, 1052).\n"
+            f"    Fix the static, do not lower the floor. `just mem-report <elf>` "
+            f"ranks what is in `.bss`; the usual answer is a pool sized on a "
+            f"configured maximum rather than on what the node declares.\n"
+            f"    If it must ship anyway, add it to DEBT in {Path(__file__).name} "
+            f"with a tracked issue id."
+        )
+    return True, f"{name}: {size:,} B (floor {floor:,} B)"
+
+
+def check(paths: list[str]) -> int:
+    # Run the selftest on the NORMAL path, not only under `--selftest`.
+    # It is pure text/arithmetic and costs nothing, and it means the controls
+    # cannot rot into decoration while the gate keeps reporting verdicts —
+    # `check-gate-selftests` enforces this repo-wide.
+    selftest(quiet=True)
+    nm = find_nm()
+    failures = []
+    checked = 0
+    for p in paths:
+        elf = Path(p)
+        if not elf.is_file():
+            raise Failure(f"{elf}: not a file. Refusing to skip it silently.")
+        board = board_of(elf)
+        if board is None:
+            raise Failure(
+                f"{elf}: no board in this path matches a floor in FLOORS "
+                f"({', '.join(sorted(FLOORS))}).\n"
+                "Passing an image this script cannot classify is how a check goes "
+                "quiet — name the board or do not pass the file."
+            )
+        size, end, start = stack_size(elf, nm)
+        ok, msg = verdict(elf, size, board)
+        checked += 1
+        print(f"  {'[OK]  ' if ok else '[FAIL]'} {msg}")
+        if not ok:
+            failures.append(msg)
+    if checked == 0:
+        raise Failure("no images were checked; a check over nothing is not a pass.")
+    if failures:
+        print(f"\ncheck-stack-floor: {len(failures)} image(s) below floor", file=sys.stderr)
+        return 1
+    print(f"check-stack-floor: {checked} image(s) OK")
+    return 0
+
+
+def claims() -> int:
+    """What this gate asserts, printable without any artifact."""
+    print("check-stack-floor asserts, for every image it is given:")
+    for board, floor in sorted(FLOORS.items()):
+        print(f"  {board}: _stack_start - _stack_end >= {floor:,} B")
+    print("\nStack is the linker leftover after `.bss` on these boards; there is no")
+    print("runtime overflow guard, so an overflow corrupts `.bss` instead of trapping.")
+    if DEBT:
+        print("\nRecorded debt (below floor, tracked, ceiling may only fall):")
+        for name, (cap, issue, reason) in sorted(DEBT.items()):
+            print(f"  {name}: <= {cap:,} B, issue {issue}")
+            print(f"      {reason}")
+    return 0
+
+
+def selftest(quiet: bool = False) -> int:
+    """Controls, including the negative ones.
+
+    A gate is only worth its runtime if it FAILS on the thing it exists to
+    catch, so the below-floor and missing-symbol cases are asserted here, not
+    just the passing one.
+    """
+    nm_ok = "3fcc2404 A _stack_end\n3fcce400 A _stack_start\n"
+    end, start = parse_stack_symbols(nm_ok)
+    assert start - end == 49_148, start - end
+
+    # tolerate other symbols and orderings
+    noise = "42051d70 t some_fn\n3fcce400 A _stack_start\n0 n x\n3fcc9b74 A _stack_end\n"
+    end, start = parse_stack_symbols(noise)
+    assert start - end == 18_572, start - end
+
+    # NEGATIVE: symbols absent must raise, never default to a size
+    for bad in ("", "42051d70 t some_fn\n", "3fcce400 A _stack_start\n"):
+        try:
+            parse_stack_symbols(bad)
+        except Failure:
+            pass
+        else:
+            raise AssertionError(f"missing stack symbols accepted: {bad!r}")
+
+    # NEGATIVE: inverted region must raise
+    try:
+        parse_stack_symbols("3fcce400 A _stack_end\n3fcc2404 A _stack_start\n")
+    except Failure:
+        pass
+    else:
+        raise AssertionError("inverted stack region accepted")
+
+    board = "qemu-esp32-baremetal"
+    floor = FLOORS[board]
+
+    # the shipped talker that crashed must FAIL
+    ok, msg = verdict(Path("esp32_qemu_talker"), 18_572, board)
+    assert not ok, msg
+    assert "BELOW" in msg
+
+    # the same image with the pools fixed must PASS
+    ok, _ = verdict(Path("esp32_qemu_talker"), 49_148, board)
+    assert ok
+
+    # exactly at the floor passes; one byte under fails
+    assert verdict(Path("esp32_qemu_talker"), floor, board)[0]
+    assert not verdict(Path("esp32_qemu_talker"), floor - 1, board)[0]
+
+    # a DEBT image passes under its cap and FAILS above it, so the ceiling
+    # cannot silently rise
+    ok, _ = verdict(Path("esp32_qemu_listener"), 22_060, board)
+    assert ok
+    ok, msg = verdict(Path("esp32_qemu_listener"), 22_061, board)
+    assert not ok and "EXCEEDS" in msg, msg
+
+    # board resolution must see phase-340 group dirs, and must NOT invent a
+    # board for a path it does not recognise
+    assert board_of(Path(f"build/cargo-fixtures/{board}/x/y/talker")) == board
+    assert board_of(Path(f"build/cargo-fixtures/{board}-4118800323/x/talker")) == board
+    assert board_of(Path("build/cargo-fixtures/some-other-board/x/talker")) is None
+
+    # bin-name parsing: [package] name plus every [[bin]] name, comments
+    # stripped, other sections ignored
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        leaf = Path(td)
+        (leaf / "Cargo.toml").write_text(
+            '[package]\nname = "esp32_qemu_talker"  # trailing comment\n'
+            'version = "0.1.0"\n\n'
+            '[dependencies]\nname_like_key = "1"\n\n'
+            '[[bin]]\nname = "esp32_qemu_talker"\npath = "src/main.rs"\n\n'
+            '[[bin]]\nname = "second-bin"\n'
+        )
+        got = bin_names(leaf)
+        assert got == ["esp32_qemu_talker", "second-bin"], got
+
+        # NEGATIVE: a manifest with no name must raise, not return []
+        (leaf / "Cargo.toml").write_text('[dependencies]\nfoo = "1"\n')
+        try:
+            bin_names(leaf)
+        except Failure:
+            pass
+        else:
+            raise AssertionError("manifest with no name accepted")
+
+    if not quiet:
+        print("check-stack-floor: selftest OK")
+    return 0
+
+
+def bin_names(leaf: Path) -> list[str]:
+    """Binary names a leaf produces, from its own `Cargo.toml`.
+
+    Needed because phase-340 group dirs are SHARED: several rows build into one
+    `build/cargo-fixtures/<group>/` and the directory therefore holds sibling
+    rows' binaries, plus binaries left by earlier env combinations that no row
+    produces any more. Globbing it checks other people's artifacts — during
+    development that failed the listener's build over a stale talker ELF from
+    before the fix under test.
+    """
+    manifest = leaf / "Cargo.toml"
+    if not manifest.is_file():
+        raise Failure(f"{manifest}: not found; cannot determine this row's binaries.")
+    names: list[str] = []
+    section = None
+    for raw in manifest.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line.strip("[]")
+            continue
+        if section not in ("package", "bin") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        if key.strip() != "name":
+            continue
+        val = val.strip().strip('"').strip("'")
+        if val and val not in names:
+            names.append(val)
+    if not names:
+        raise Failure(
+            f"{manifest}: no `name` under [package] or [[bin]].\n"
+            "Refusing to fall back to a directory glob — that would check other "
+            "rows' artifacts in the shared group dir."
+        )
+    return names
+
+
+def check_row(leaf: str, adir: str) -> int:
+    """Check the binaries THIS row produces, inside a shared artifact dir."""
+    leafp, adirp = Path(leaf), Path(adir)
+    if not adirp.is_dir():
+        raise Failure(f"{adirp}: artifact dir does not exist.")
+    wanted = set()
+    for n in bin_names(leafp):
+        wanted.update({n, n.replace("-", "_"), n.replace("_", "-")})
+    found = [
+        f
+        for f in adirp.glob("*/*/*")
+        if f.is_file() and os.access(f, os.X_OK) and f.name in wanted
+    ]
+    if not found:
+        raise Failure(
+            f"{leafp}: none of {sorted(wanted)} found under {adirp}.\n"
+            "The row was just built, so its binary must be there. Refusing to "
+            "report a pass over an empty set."
+        )
+    return check([str(f) for f in sorted(found)])
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    if not args:
+        print(__doc__)
+        print(
+            "usage: check-stack-floor.py <elf>...\n"
+            "       check-stack-floor.py --row <leaf-dir> <artifact-dir>\n"
+            "       check-stack-floor.py --selftest | --claims"
+        )
+        return 2
+    if args[0] == "--selftest":
+        return selftest()
+    if args[0] == "--claims":
+        return claims()
+    if args[0] == "--row":
+        if len(args) != 3:
+            raise Failure("--row takes exactly <leaf-dir> <artifact-dir>")
+        return check_row(args[1], args[2])
+    return check(args)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except Failure as exc:
+        print(f"check-stack-floor: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/check-stack-floor.py
+++ b/scripts/check-stack-floor.py
@@ -59,13 +59,15 @@ FLOORS = {
 # The repo's rule for a real-but-open gap (CLAUDE.md, the rmw-api-parity map):
 # it carries a TRACKED ISSUE ID in the reason, and that is what --check
 # tolerates — nothing else.
-DEBT = {
-    "esp32_qemu_listener": (
-        22_060,
-        "1052",
-        "declares no publishers/services/actions but still links the full "
-        "embedded entity budget; same class as the talker, one entity kind over",
-    ),
+DEBT: dict[str, tuple[int, str, str]] = {
+    # Empty, and that is the point: both ESP32 images now clear the floor on
+    # what they DECLARE (issue 1052 — talker 49,148 B, listener 52,636 B, from
+    # 18,572 and 22,060). An entry here is a debt on record, never a waiver:
+    # the value is a CEILING that may only fall, so the gate fails if an image
+    # regresses toward it, and deleting the entry is what closing the issue
+    # looks like. That is how the listener left this table — it was added at
+    # 22,060 B, the fix took it to 52,636 B, and the gate refused the rise until
+    # the row was removed.
 }
 
 
@@ -285,12 +287,20 @@ def selftest(quiet: bool = False) -> int:
     assert verdict(Path("esp32_qemu_talker"), floor, board)[0]
     assert not verdict(Path("esp32_qemu_talker"), floor - 1, board)[0]
 
-    # a DEBT image passes under its cap and FAILS above it, so the ceiling
-    # cannot silently rise
-    ok, _ = verdict(Path("esp32_qemu_listener"), 22_060, board)
-    assert ok
-    ok, msg = verdict(Path("esp32_qemu_listener"), 22_061, board)
-    assert not ok and "EXCEEDS" in msg, msg
+    # The DEBT mechanism, exercised with a SYNTHETIC entry. DEBT is empty now
+    # that both real images clear the floor, and an untested mechanism is how
+    # the next entry gets added wrong — so inject one rather than letting the
+    # controls lapse with the table.
+    DEBT["_selftest_image"] = (22_060, "1052", "synthetic, selftest only")
+    try:
+        ok, _ = verdict(Path("_selftest_image"), 22_060, board)
+        assert ok, "an image at exactly its cap must pass"
+        ok, msg = verdict(Path("_selftest_image"), 22_061, board)
+        assert not ok and "EXCEEDS" in msg, msg
+        # below the cap is fine — the ceiling may always fall
+        assert verdict(Path("_selftest_image"), 1_000, board)[0]
+    finally:
+        del DEBT["_selftest_image"]
 
     # board resolution must see phase-340 group dirs, and must NOT invent a
     # board for a path it does not recognise


### PR DESCRIPTION
`create_publisher` is not the bug. It's the deepest frame on the deepest chain, so it's where an already-too-small stack runs out.

> Stacks on commits also present in queued PR #410 (the gdb finding it builds on). Once #410 merges this reduces to the last two commits.

## Root cause

| symbol | value |
|---|---|
| `.bss` | `0x3fc81960` + `0x048214` = **295,444 B** |
| `_stack_end` (low bound) | `0x3fcc9b74` |
| `_stack_start` (high; grows down) | `0x3fcce400` |
| **stack size** | **18,572 B** |
| **faulting `sp`** | **`0x3fcc9180`** |

`sp` is **2,548 bytes below `_stack_end`** — outside the stack, inside `.bss`, in `nros_smoltcp::TCP_RX_BUFFER_0`+1892, exactly as gdb symbolised it. Stack overflow; the instruction-access fault is the smashed frame returned through.

`nros-board-esp32-qemu/src/node.rs` already documents this as issue **#190**:

> `.stack` is the LINKER LEFTOVER after `.bss` … At 96 KB the stack shrank to ~18 KB … the overflow wrote frames straight down into `.bss` … wild jumps … **None of them were allocator or zenoh-pico bugs.**
> 48 KB … leaves a **~67 KB stack** … Check `.stack` in `readelf -S` after changing ANY large static — **there is no runtime stack-overflow guard on this target.**

Heap knob still 48 KB; stack is **18,572 B, not ~67 KB**. `.bss` grew and nobody re-ran that check. **1052 is a regression of #190.**

## Confirmed both directions

| | `.bss` | stack | `SMALL_PAYLOADS` |
|---|---:|---:|---:|
| shipped | 295,444 | **18,572** | 32,768 |
| `ZPICO_MAX_SUBSCRIBERS=1` | 264,868 | **49,148** | 4,096 |

| image | stack | output | `ConnectionFailed` | faults |
|---|---:|---:|---:|---:|
| full talker | 18,572 | **70 — died** | 0 | **2** |
| empty `register` | 18,572 | 23,083 | 23,033 | 0 |
| `SUBSCRIBERS=1` | 49,148 | 23,850 | 23,565 | **0** |

The shipped talker dies at line 70, *before* the retry loop the others run 23k lines of — same early path, only the 18 KB build faults.

## Corrects 91241878b

That commit recorded `mepc=0x732f7264` across three builds and argued constancy rules out stack smashing, "which would move with layout". Today's run faults at **`mepc=0x02250042`** — not constant, so the argument doesn't hold.

They never conflicted. It concluded the value is "DATA the code reads deterministically from a fixed place", `0x732f7264` being printable `"s/rd"`. **The fixed place now has a name:** the overflowed stack sits inside `TCP_RX_BUFFER_0`, so a return-address slot is overwritten by received network bytes — keyexpr traffic is where `"s/rd"` comes from. Constancy was evidence *for* the mechanism, read as evidence against it.

## Two campaign findings in `.bss`

- **Two heaps coexist.** node.rs budgets one (48 KB `esp_alloc`) and says DDS swaps in a `FreeListHeap` *instead* — but `memory.rs:20` declares `FreeListHeap<{32*1024}>` on the **non-DDS** arm too. Both link: **83,632 B** of heap.
- **The talker pays 65,536 B for subscriber pools it never uses.** Sized on `ZPICO_MAX_SUBSCRIBERS`, not on what the node declares — 0827/0832's thesis exactly. On this target `.bss` is subtracted from the stack, so it isn't a footprint nicety, it's the crash.

## Fixes, in order

1. **Gate a `.stack` floor.** The comment asks for a check a comment can't enforce, and there's no runtime guard. A silent 18 KB stack is how this got here.
2. **Stop allocating pools for undeclared entities** — up to 64 KB back.
3. **Resolve the two heaps** — 83,632 B where the comment budgets 49,152.

This PR does (2) for the talker row and documents the rest. (1) is the one that keeps it fixed.

## Also corrects my own previous commit

Its "`create_publisher` symbol count is 0" came from `riscv32-esp-elf-nm … 2>/dev/null | grep -c` — that tool isn't on PATH, the redirect ate "command not found", and `grep -c` returned 0 for *every* input. Run properly, the full talker has 5. The behavioural conclusion is unaffected (distinct checksums, back-to-back identical args, and a build log carrying `unused imports: NodeOptions and TimerDuration`, which only appears once `register` is emptied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)