### PR TITLE
test(#0835): the staleness probes' fixed point is gated, and the phase gets a budget

### DIFF
--- a/docs/issues/0835-fixture-staleness-probe-families-restale-each-other.md
+++ b/docs/issues/0835-fixture-staleness-probe-families-restale-each-other.md
@@ -9,7 +9,144 @@ area: testing
 related: [issue-0828, issue-0196, issue-0466, phase-344, phase-340]
 ---
 
-## Problem
+## Measured 2026-09-04 (phase-424) — the oscillation is GONE and now GATED; the budget
+
+Phase-424 needs 0835's numbers as the budget its other seven issues are checked
+against ("a fix that widens a watch set must show 0835 did not get worse, in the
+same commit"), so this is the re-measurement. Everything below is measured
+unless labelled otherwise.
+
+### 1. There are FOUR probe families, not two, and they use TWO mechanisms
+
+`scripts/check-fixtures-stale.sh` runs four probes over 371 manifest rows:
+
+| family | rows | verdict is a function of |
+| --- | --- | --- |
+| cmake c / cpp | 61 + 59 | md5 of the cell build dir's top-level executables, BEFORE and AFTER `cmake --build` |
+| cargo | 117 | md5 of the row's OWN binaries under its group `--target-dir`, before and after `cargo build` |
+| workspace | 94 | `.inputsig`: a signature over a declared input set |
+| compile-check | 40 | `.inputsig`: same shape |
+
+The first two are **differential** — since 2fa1ed09f they have no watch set at
+all. Their verdict is "did my artifact's bytes move", so no widening anywhere
+can reach them, and family B may rebuild, evict, relink or re-date anything
+family A reads without A firing. That is the structural reason the title's
+oscillation is over, and it is why the budget below is about the OTHER 134 rows.
+
+### 2. The differential probes reach a fixed point — measured against the real scripts
+
+`tests/fixture-staleness-probe-tests.sh` (added by this commit, 2.2 s, on the
+fast line as `just check fixture-staleness-probes`) drives the production probe
+scripts against a two-file cmake cell whose always-dirty custom command
+recompiles and relinks on every build — Corrosion's shape with no Rust in it —
+and a one-binary cargo leaf in a phase-340-style group dir:
+
+```
+                                       pre-2fa1ed09f rule   today
+cmake, unchanged tree, 3 runs               3/3 STALE        0/3
+cargo, unit re-runs, bytes identical        3/3 STALE        0/3
+cross-family: the cmake build dates the
+  cargo row's source forward, 3 rounds      3/3 STALE        0/3
+real source edit (both families)            reported         reported, once
+```
+
+The pre-fix rules are re-applied to the same trees inside the test as its
+NEGATIVE CONTROL, so a probe silently broken into never reporting anything fails
+it. Both mutations were run: reverting either script to its `2fa1ed09f^` version
+fails the file (7 of 19 checks for the cmake half, 4 of 19 for the cargo half).
+
+### 3. The `.inputsig` watch sets contain ZERO build output
+
+Measured on a fully-built checkout (every one of these dirs has build trees; all
+of them gitignored):
+
+| enumeration | files | untracked-and-unignored |
+| --- | --- | --- |
+| 14 workspace fixture dirs (94 rows) | 568 tracked | **0** |
+| 23 compile-check dirs (40 rows) | 243 tracked | **0** |
+| dep-closure union over 38 built dirs | 792 distinct in-repo paths | 7 |
+
+The 7 are 6 zenoh-pico submodule sources (tracked in the nested repo, kept
+deliberately — `git check-ignore` refuses to answer inside a submodule) and
+`packages/cli/third-party/play_launch/.git`, a gitfile whose content is a
+constant. None is build output.
+
+Both halves of a signature already use ONE policy for "is this build output?" —
+git's ignore rules — which is what keeps this at zero.
+
+### 4. The one genuinely shared input, and how much of its cost is inherent
+
+`tool:nros` — the codegen fingerprint — is in all 134 `.inputsig` signatures, so
+when it moves it re-stales every one of them. Measured on this host's cache:
+
+    41 distinct `nros` binaries  ->  9 distinct codegen fingerprints
+
+so 32 of 41 CLI rebuilds (78 %) re-staled nothing. The 9 that did are real: the
+emitter's output changed. This is the phase-318 W1 fix working, and it is the
+model for the budget below — key on what a tool EMITS, not on the tool.
+
+It still over-approximates: a workspace row that runs no codegen hashes the
+fingerprint anyway. That is a deliberate fail-safe and is the only known
+spurious term.
+
+### 5. THE BUDGET, stated for the other seven issues
+
+* **Differential families (237 rows): spurious re-staling is 0, structurally.**
+  There is no watch set. A fix elsewhere cannot make this worse. It CAN make it
+  worse by changing the decision rule back to an activity signal — that is what
+  the new gate refuses.
+* **`.inputsig` families (134 rows): spurious re-staling is 0 today**, and stays
+  0 while every path a signature hashes is one git does not ignore and no build
+  writes. The cost of a proposed widening is arithmetic, not judgement:
+  `(rows whose signature gains the path) x (how often the path moves)`.
+  - a tracked source path: 0 until someone edits it — free;
+  - a path some build WRITES: unbounded, and it is exactly how this issue
+    happened. Nothing in the tree may hash one.
+* **The shared-tool term is the one to watch.** A new input hashed into all 134
+  rows costs 134 rebuilds every time it moves, so it must be keyed on what the
+  thing EMITS, the way `codegen-fingerprint` is. Anything keyed on a binary hash
+  re-stales 134 rows per `just setup-cli` — measured as the 41-vs-9 gap above.
+
+Re-run the arithmetic with:
+
+```sh
+just check fixture-staleness-probes                    # the fixed point, 2.2 s
+git ls-files --others --exclude-standard -- <sig-dir>  # must be empty
+for f in .nros-cache/codegen-fingerprint/*; do cat "$f"; echo; done | sort -u | wc -l
+```
+
+### The two ways the differential families could still come back
+
+Stated because "structurally impossible" is only true given two things, and both
+are held elsewhere rather than by the probe:
+
+1. **Artifact-name collisions inside one cargo group.** Cargo uplifts the final
+   artifact to an UNHASHED name, so two rows in one group producing the same
+   binary name would overwrite each other and each would see the other's bytes.
+   That is phase-340's A1 precondition, gated by `check-fixture-groups` (fast
+   line) at 0 collisions. If that gate is ever narrowed, this issue returns.
+2. **A non-reproducible build.** The probe assumes a rebuild of unchanged inputs
+   produces identical bytes. Verified for the synthetic leaf here and measured
+   on the real fixtures by 2fa1ed09f. A toolchain or flag that embeds something
+   varying (a timestamp, a temp path) would make the affected rows permanently
+   STALE with nothing to fix — and it would look exactly like this issue.
+
+### What is NOT fixed, and why it was left
+
+The duplicated `threadx-riscv64` corrosion group (below, 2026-08-31) is still
+real: the `set(NANO_ROS_PLATFORM threadx)` hardcode is present in all six
+`examples/qemu-riscv64-threadx/rust/*/CMakeLists.txt`. But it is **wasted disk
+and CPU, not staleness** — after 2fa1ed09f a duplicated group cannot make a
+probe fire, because it cannot change a row's artifact bytes. It could not be
+re-measured here: this host's `build/corrosion-cargo/` currently holds no
+`threadx-riscv64` root at all (7 groups over 5 platforms, and every key text is
+a real configuration difference — verified by reading the `.key` files).
+
+Choosing between the two candidate fixes below re-keys EVERY corrosion cargo
+directory on every platform, i.e. schedules a one-time full rebuild. That is the
+phase owner's call, and deliberately not slipped in here.
+
+## Problem (as filed — the oscillation below is FIXED; see the measurement above)
 
 `scripts/check-fixtures-stale.sh` probes two families in order: cmake cells
 first, then rust fixtures. Each family "self-heals" — it rebuilds what it finds

--- a/docs/roadmap/phase-424-build-graph-freshness-truth.md
+++ b/docs/roadmap/phase-424-build-graph-freshness-truth.md
@@ -1,9 +1,12 @@
 # Phase 424 — does the build graph tell the truth about what needs rebuilding?
 
-**Status (2026-09-04).** Not started — opened as a HOME for eight issues that
-had none. Nothing here is in progress; what the phase adds today is the
-constraint in "What this phase must not do", which is the part that would
-otherwise be rediscovered per issue.
+**Status (2026-09-04).** Enabling work done, seven issues untouched. 0835 — the
+one every other fix has to be checked against — has been re-measured, its
+remaining scope narrowed to a disk-waste defect, and the property that ended its
+oscillation is now gated by `just check fixture-staleness-probes`. The rest of
+the phase is not started. What it adds beyond that is the constraint in "What
+this phase must not do", which is the part that would otherwise be rediscovered
+per issue — and which is now backed by numbers rather than by a warning.
 
 **Opened 2026-09-04 as a HOME.** Eight open issues say the same thing from
 different layers: something in this tree reports FRESH when it is not, or STALE
@@ -36,7 +39,7 @@ they all rest on is built on build-system internals nobody supports.
 | issue | layer | shape |
 | --- | --- | --- |
 | [#0820](../issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md) | cmake seam | passes after `rm -rf` on unmodified sources — no rebuild edge |
-| [#0835](../issues/0835-fixture-staleness-probe-families-restale-each-other.md) | fixtures | the cmake and rust families re-stale each other |
+| [#0835](../issues/0835-fixture-staleness-probe-families-restale-each-other.md) | fixtures | the cmake and rust families re-stale each other — **oscillation fixed + gated 2026-09-04**; open for the duplicated ThreadX corrosion group, which is wasted disk, not staleness |
 | [#0945](../issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | cargo | the shared-cargo-dir campaign rests on five unsupported build-system assumptions |
 | [#1002](../issues/1002-a-derived-knob-needs-three-configures-not-two.md) | cmake | a derived knob converges after three configures, not the two 0991 documented |
 | [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md) | codegen | a codegen change invalidates every consumer, connected only by a manual step |
@@ -55,6 +58,25 @@ invites, and it is how the two families came to re-stale each other. Issue 1045
 just landed the other half of the same lesson: a probe that examined NOTHING
 reported FRESH across the whole cross-compiled tree, and the fix was to make the
 degradation VISIBLE rather than to watch more.
+
+**The measurement now exists, so "measuring 0835" is a command rather than a
+project** (2026-09-04). The numbers are in issue 0835 under "Measured
+2026-09-04"; the short version a widening has to answer to:
+
+* The 237 cmake + cargo rows are **differential** — their verdict is "did my
+  artifact's bytes move", so they have no watch set and no widening can reach
+  them. `just check fixture-staleness-probes` (2.2 s, on the fast line) holds
+  them there, with the pre-fix rules as its own negative control.
+* The 134 `.inputsig` rows are the ones with a watch set, and today it contains
+  **zero build output** — 568 + 243 tracked files across the signature dirs with
+  0 untracked-and-unignored, and 792 dep-closure paths with 0. That is what a
+  widening must not change.
+* The cost of a widening is arithmetic: `(rows that gain the path) x (how often
+  the path moves)`. A tracked source path is free until edited; a path a build
+  WRITES is unbounded, and is how 0835 happened.
+* A new input hashed into all 134 rows must key on what the tool EMITS, not on
+  its binary — measured 41 distinct `nros` binaries against 9 distinct codegen
+  fingerprints, i.e. 78 % of CLI rebuilds re-staling nothing.
 
 ## Acceptance
 

--- a/just/check.just
+++ b/just/check.just
@@ -171,6 +171,7 @@ fast-serial: \
     fixture-binary-names \
     fixture-groups \
     fixture-id-guard \
+    fixture-staleness-probes \
     fixture-stamp-honesty \
     fixtures-manifest \
     flake-quarantine \
@@ -1906,6 +1907,37 @@ ci-no-fixture-tolerance:
 [private]
 fixture-stamp-honesty:
     @python3 scripts/check-fixture-stamp-honesty.py
+
+# Issue 0835 — a fixture staleness probe decides from the ARTIFACT's BYTES, not
+# from whether the build did work. Corrosion's cargo step is an always-dirty
+# edge and the phase-340 cargo groups evict rows nobody touched, so an
+# activity-keyed probe reports work on EVERY run forever: it reported the same
+# 17 cmake cells + 23 rust rows stale on a tree whose `lane=all` build had just
+# gone green, which is what failed ~190 tests on every `just ci matrix`.
+#
+# Fixed in 2fa1ed09f with nothing guarding it. This runs the REAL probe scripts
+# against a two-file cmake cell and a one-binary cargo leaf, and carries its own
+# negative control: the pre-fix decision rules are re-applied to the same trees
+# and must FIRE.
+fixture-staleness-probes:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    _missing=""
+    for _t in cmake ninja cargo cc; do
+        command -v "$_t" >/dev/null 2>&1 || _missing="$_missing $_t"
+    done
+    # The probe asks the CLI for the platform's cargo profile, so the leaf
+    # cannot be built without it — and a missing CLI would surface as every case
+    # failing on `profile ... is not defined`, which reads as a probe defect.
+    _cli="${NROS_CLI:-packages/cli/target/release/nros}"
+    [ -x "$_cli" ] || _missing="$_missing nros(just setup-cli)"
+    if [ -n "$_missing" ]; then
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip fixture-staleness-probes "missing:$_missing"
+        exit 0
+    fi
+    ./tests/fixture-staleness-probe-tests.sh
 
 # Every CI job gated on a `vars.*` interlock must have a job that reports
 # whether it ran. A skipped job does not colour its run, so post-submit reported

--- a/tests/fixture-staleness-probe-tests.sh
+++ b/tests/fixture-staleness-probe-tests.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+# tests/fixture-staleness-probe-tests.sh -- issue 0835
+#
+# Gates the DECISION RULE of the two differential fixture staleness probes:
+#
+#   scripts/test/cmake-fixture-stale.sh    (120 c/cpp manifest rows)
+#   scripts/test/rust-fixture-stale.sh     (117 cargo-builder rows)
+#
+# THE CONTRACT: a probe's verdict is a function of the ARTIFACT BYTES, never of
+# whether the build did work.
+#
+# WHY THAT SENTENCE IS THE WHOLE ISSUE. Both probes used to ask "did the build
+# do work?", and for these fixtures the answer is permanently yes, for reasons
+# that are by design and will not go away:
+#
+#   * a cmake cell links nros-c / nros-cpp through Corrosion, whose cargo step
+#     is an always-dirty custom command feeding the link, so ninja recompiles
+#     and relinks on EVERY build;
+#   * cargo rows share one `--target-dir` per platform (the phase-340 group) and
+#     rows in a group evict each other's units, so `"fresh":false` fires on a
+#     row nobody touched.
+#
+# The linked executable is byte-identical throughout. So the probe reported 17
+# cmake cells + 23 rust rows STALE on every run of a tree whose `lane=all` build
+# had just gone green — a fixed oscillation, not a treadmill converging, and the
+# reason `just ci matrix` failed ~190 tests with "fixture is stale" on runs
+# either side of an unrelated change. Fixed in 2fa1ed09f by hashing the
+# artifact; NOTHING guarded it, which is what this file is.
+#
+# It matters beyond its own two scripts. Phase-424 groups eight freshness
+# issues, and every one of them is tempting to close by widening what a prober
+# watches. The property asserted here is what makes cross-family re-staling
+# impossible: family B may rebuild, touch, evict or relink whatever family A
+# reads, and A stays silent as long as A's bytes do not move. Widen a watch set
+# without that property and 0835 comes straight back.
+#
+# WHAT IS ASSERTED:
+#
+#   A. cmake — an always-dirty edge that recompiles and RELINKS on every build
+#      leaves the probe silent, three runs running. A real source edit reports
+#      stale EXACTLY ONCE, then silent. (Silence alone would be satisfied by a
+#      probe that says nothing ever, so both halves are required.)
+#
+#   B. cargo — a unit re-run that produces identical bytes leaves the probe
+#      silent. A real source edit reports stale exactly once, then silent.
+#
+#   C. CROSS-FAMILY, which is the issue's title. The cmake cell's build TOUCHES
+#      the cargo row's source, so building the cmake family forces the cargo
+#      family to re-run a unit. Three alternating rounds: both stay silent.
+#
+#   D. THE NEGATIVE CONTROL. The pre-2fa1ed09f decision rules — grep the cmake
+#      output for "Building/Linking/Compiling", grep cargo's json for
+#      `"fresh":false` — are re-applied to the SAME unchanged trees and must
+#      FIRE. Without this, A/B/C would also pass against a probe that had been
+#      quietly broken into never reporting anything, and the whole file would be
+#      the mistake it exists to prevent. It also proves the fixtures below
+#      really do reproduce the hazard rather than modelling something easier.
+#
+# The projects are the smallest ones with the right SHAPE: a cmake cell whose
+# always-dirty custom command byproduct is a header the executable includes
+# (ninja therefore recompiles + relinks every build, printing the exact strings
+# the old grep matched), and a cargo leaf with one binary and no dependencies.
+# No nano-ros build, no SDK, no codegen, no fixture manifest. Seconds.
+#
+# PRECONDITIONS ARE HARD FAILURES. A green here reads as "the staleness probes
+# cannot oscillate"; skipping belongs in the just recipe, which checks for the
+# host tools before calling this at all.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root" || exit 1
+
+CMAKE_PROBE="scripts/test/cmake-fixture-stale.sh"
+RUST_PROBE="scripts/test/rust-fixture-stale.sh"
+
+failures=0
+checks=0
+
+fail() {
+    failures=$((failures + 1))
+    echo "  [FAIL] $*" >&2
+}
+ok() {
+    echo "  [ok]   $*"
+}
+check_eq() {
+    # check_eq <what> <expected> <actual>
+    checks=$((checks + 1))
+    if [ "$2" = "$3" ]; then
+        ok "$1"
+    else
+        fail "$1: expected [$2], got [$3]"
+    fi
+}
+
+for tool in cmake ninja cargo cc; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "FATAL: $tool is required — this script never skips, see header" >&2
+        exit 2
+    }
+done
+[ -x "$CMAKE_PROBE" ] || [ -r "$CMAKE_PROBE" ] || {
+    echo "FATAL: $CMAKE_PROBE not found" >&2
+    exit 2
+}
+
+work="$(mktemp -d)" || exit 1
+trap 'rm -rf "$work"' EXIT
+
+# ---------------------------------------------------------------------------
+# The two fixtures.
+# ---------------------------------------------------------------------------
+
+# The cmake cell. `OUTPUT` names a stamp the command never creates, so ninja
+# runs the edge on every build ("output ... doesn't exist"); its BYPRODUCT is a
+# header main.c includes, whose mtime therefore moves, so main.c recompiles and
+# the executable relinks. That is Corrosion's shape (its `_cargo-build_*` stamp
+# is never created and its declared `.a` feeds the link) with no Rust in it.
+mkdir -p "$work/cell"
+cat > "$work/cell/CMakeLists.txt" <<'CMAKEEOF'
+cmake_minimum_required(VERSION 3.20)
+project(probe_cell C)
+set(_gen "${CMAKE_CURRENT_BINARY_DIR}/gen.h")
+# NROS_PROBE_TOUCH is the cross-family lever (case C): when set, this edge also
+# dates a file OUTSIDE this project forward, exactly as a shared cargo group
+# does to a sibling row.
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/never-created.stamp"
+    BYPRODUCTS "${_gen}"
+    COMMAND "${CMAKE_COMMAND}" -E echo "#define PROBE_CONST 7" > "${_gen}"
+    COMMAND "${CMAKE_COMMAND}" -E touch "${_gen}"
+    COMMAND "${CMAKE_COMMAND}"
+            -DNROS_PROBE_TOUCH=$ENV{NROS_PROBE_TOUCH}
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/touch-foreign.cmake"
+    COMMENT "always-dirty (models Corrosion's cargo step)"
+    VERBATIM)
+add_custom_target(always_dirty DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/never-created.stamp")
+add_executable(probe_cell main.c)
+target_include_directories(probe_cell PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+add_dependencies(probe_cell always_dirty)
+CMAKEEOF
+cat > "$work/cell/touch-foreign.cmake" <<'CMAKEEOF'
+if(NROS_PROBE_TOUCH AND EXISTS "${NROS_PROBE_TOUCH}")
+    execute_process(COMMAND "${CMAKE_COMMAND}" -E touch "${NROS_PROBE_TOUCH}")
+endif()
+CMAKEEOF
+printf '#include "gen.h"\nint main(void){return PROBE_CONST - 7;}\n' > "$work/cell/main.c"
+
+# The cargo leaf. `[workspace]` detaches it from any enclosing workspace; the
+# lock is written by hand because the `scripts/bin/cargo` shim injects
+# `--locked` project-wide and a dependency-free crate's lock is three lines.
+mkdir -p "$work/leaf/src"
+cat > "$work/leaf/Cargo.toml" <<'TOMLEOF'
+[workspace]
+
+[package]
+name = "nros-staleness-probe-leaf"
+version = "0.0.0"
+edition = "2021"
+
+[[bin]]
+name = "nros_staleness_probe_leaf"
+path = "src/main.rs"
+TOMLEOF
+cat > "$work/leaf/Cargo.lock" <<'LOCKEOF'
+version = 3
+
+[[package]]
+name = "nros-staleness-probe-leaf"
+version = "0.0.0"
+LOCKEOF
+printf 'fn main() { println!("probe"); }\n' > "$work/leaf/src/main.rs"
+
+# The probe builds a row at its PLATFORM's profile (`nros_cargo_platform_profile`,
+# phase-340 P2), and this leaf is detached from the workspace that defines the
+# repo's custom profiles. Resolve the name the SAME way the probe does and give
+# the leaf that profile, rather than hardcoding today's answer — a profile table
+# change would otherwise make every case here fail as `profile ... is not
+# defined`, which reads as a probe defect and is not one.
+# shellcheck source=scripts/build/cargo.sh
+source scripts/build/cargo.sh 2>/dev/null || {
+    echo "FATAL: cannot source scripts/build/cargo.sh" >&2
+    exit 2
+}
+probe_profile="$(nros_cargo_platform_profile linux)" || probe_profile=""
+[ -n "$probe_profile" ] || {
+    echo "FATAL: could not resolve the linux fixture profile (is the nros CLI built?" >&2
+    echo "       \`just setup-cli\`)" >&2
+    exit 2
+}
+case "$probe_profile" in
+    dev | release | test | bench) ;;
+    *) printf '\n[profile.%s]\ninherits = "release"\n' "$probe_profile" >> "$work/leaf/Cargo.toml" ;;
+esac
+
+# The probes derive the cargo group dir through `nros_build_dir`, so pointing
+# NROS_BUILD_ROOT at the scratch tree keeps every byte this test writes inside
+# it — the repo's own build/ is untouched.
+export NROS_BUILD_ROOT="$work/build-root"
+
+cmake_record="$(printf '%s\x1fbuild-probe\x1f\x1f' "$work/cell")"
+rust_record="$(printf 'linux\x1f%s\x1f\x1f' "$work/leaf")"
+
+cmake_probe() { bash "$CMAKE_PROBE" "$cmake_record"; }
+rust_probe() { bash "$RUST_PROBE" "$rust_record"; }
+
+# Configure + first build, so both fixtures start FRESH. A probe run would also
+# do it, but then case A's first assertion would be measuring the initial build.
+cmake -S "$work/cell" -B "$work/cell/build-probe" -G Ninja > "$work/configure.log" 2>&1 || {
+    echo "FATAL: cmake configure failed" >&2
+    cat "$work/configure.log" >&2
+    exit 2
+}
+cmake --build "$work/cell/build-probe" > "$work/build.log" 2>&1 || {
+    echo "FATAL: cmake build failed" >&2
+    cat "$work/build.log" >&2
+    exit 2
+}
+[ -x "$work/cell/build-probe/probe_cell" ] || {
+    echo "FATAL: the cell produced no executable — the probe would have nothing to hash" >&2
+    exit 2
+}
+out="$(rust_probe)"
+[ -n "$out" ] || {
+    echo "FATAL: the cargo leaf's first probe reported FRESH — it had never been built," >&2
+    echo "       so the probe cannot be distinguishing anything. $out" >&2
+    exit 2
+}
+
+echo "== A. cmake: an always-dirty relink is not staleness =="
+
+# The premise, asserted rather than assumed: every build really does recompile
+# and relink. If cmake/ninja ever stopped doing that, cases A and D would both
+# pass while measuring nothing.
+cmake --build "$work/cell/build-probe" > "$work/relink.log" 2>&1
+if grep -qE 'Building C object' "$work/relink.log" && grep -qE 'Linking C executable' "$work/relink.log"; then
+    ok "premise: the cell recompiles and relinks on an unchanged tree"
+else
+    fail "premise: the cell did NOT relink — cases A and D no longer model the hazard"
+    sed 's/^/    /' "$work/relink.log" >&2
+fi
+checks=$((checks + 1))
+
+for i in 1 2 3; do
+    check_eq "run $i on an unchanged cell is silent" "" "$(cmake_probe)"
+done
+
+printf '#include "gen.h"\nint main(void){return PROBE_CONST - 6;}\n' > "$work/cell/main.c"
+check_eq "a real source edit reports the cell stale" \
+    "$work/cell/build-probe" "$(cmake_probe)"
+check_eq "and is silent on the next run" "" "$(cmake_probe)"
+
+echo "== B. cargo: a unit re-run with identical bytes is not staleness =="
+
+check_eq "the freshly built leaf is silent" "" "$(rust_probe)"
+
+# `touch` is the smallest thing that makes cargo re-run a unit without changing
+# what it produces. In the tree it is group eviction; the probe cannot tell the
+# two apart and must not need to.
+before="$(md5sum "$NROS_BUILD_ROOT"/cargo-fixtures/linux/*/nros_staleness_probe_leaf 2>/dev/null | awk '{print $1}' | head -1)"
+touch "$work/leaf/src/main.rs"
+check_eq "a touched source (unit re-runs, bytes identical) is silent" "" "$(rust_probe)"
+after="$(md5sum "$NROS_BUILD_ROOT"/cargo-fixtures/linux/*/nros_staleness_probe_leaf 2>/dev/null | awk '{print $1}' | head -1)"
+check_eq "premise: the rebuilt binary is byte-identical" "$before" "$after"
+
+printf 'fn main() { println!("probe changed"); }\n' > "$work/leaf/src/main.rs"
+check_eq "a real source edit reports the leaf stale" \
+    "$work/leaf" "$(rust_probe)"
+check_eq "and is silent on the next run" "" "$(rust_probe)"
+
+echo "== C. cross-family: building one family does not stale the other =="
+
+# Arm the lever: from here the cmake cell's always-dirty edge dates the cargo
+# leaf's source forward on every build, so running the cmake probe forces the
+# cargo probe's next build to re-run a unit. That is what "the two families
+# re-stale each other" means, reduced to two files.
+export NROS_PROBE_TOUCH="$work/leaf/src/main.rs"
+cmake -S "$work/cell" -B "$work/cell/build-probe" -G Ninja >> "$work/configure.log" 2>&1 || {
+    echo "FATAL: cmake re-configure failed" >&2
+    exit 2
+}
+cmake_probe > /dev/null # settle the re-configure's own rebuild
+rust_probe > /dev/null
+
+for round in 1 2 3; do
+    check_eq "round $round: cmake probe silent" "" "$(cmake_probe)"
+    check_eq "round $round: rust probe silent after the cmake build touched its source" \
+        "" "$(rust_probe)"
+done
+unset NROS_PROBE_TOUCH
+
+echo "== D. negative control: the pre-fix rules FIRE on these same trees =="
+
+# Everything above would also pass against a probe that had been broken into
+# reporting nothing at all. These two blocks apply the decision rules the probes
+# used before 2fa1ed09f to the SAME unchanged fixtures; each must report stale,
+# which is simultaneously the proof that the fixtures reproduce the hazard and
+# the proof that the assertions above are not vacuous.
+
+out="$(cmake --build "$work/cell/build-probe" 2>&1)"
+if printf '%s' "$out" | grep -qE "Building (C|CXX|ASM) object|Linking (C|CXX|CXX shared)|Compiling [a-z0-9_-]+ v"; then
+    ok "the old cmake rule (grep the build chatter) reports STALE — as it did forever"
+else
+    fail "the old cmake rule did NOT fire: this fixture no longer models the defect"
+fi
+checks=$((checks + 1))
+
+touch "$work/leaf/src/main.rs"
+out="$(cd "$work/leaf" && cargo build --profile "$probe_profile" \
+    --target-dir "$NROS_BUILD_ROOT/cargo-fixtures/linux" \
+    --message-format=json --quiet 2>/dev/null)"
+if printf '%s' "$out" | grep -q '"fresh":false'; then
+    ok "the old cargo rule (\"fresh\":false) reports STALE — as it did forever"
+else
+    fail "the old cargo rule did NOT fire: this fixture no longer models the defect"
+fi
+checks=$((checks + 1))
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+    echo "fixture-staleness-probe-tests: $checks check(s) passed"
+    exit 0
+fi
+echo "fixture-staleness-probe-tests: $failures of $checks check(s) FAILED" >&2
+echo "" >&2
+echo "  A probe that decides from the build's ACTIVITY instead of the artifact's" >&2
+echo "  BYTES cannot reach a fixed point on this tree: Corrosion's cargo step is" >&2
+echo "  an always-dirty edge and the phase-340 cargo groups evict rows nobody" >&2
+echo "  touched, so it reports work on every run forever (issue 0835)." >&2
+exit 1


### PR DESCRIPTION
Phase-424's enabling work. The result is not the one the phase expected.

## The cycle #0835 is named for was already fixed — and nothing guarded it

`2fa1ed09f` (2026-08-28), *"the staleness probes decide from the ARTIFACT, not
from build chatter"*, ended the oscillation. The issue was never closed, and its
body was **rewritten on 08-31 with a different finding** (a duplicated ThreadX
corrosion group), so phase-424 inherited it as though the re-staling were live.
**Zero tests referenced either probe script**, so nothing would have told us if
the fix regressed.

Verified before publishing: the commit exists, touches both probes, and both now
decide by `md5sum` of the artifact.

## The measured cycle

There are **four** probe families over **371** rows, not two, and two different
mechanisms:

| family | rows | verdict is a function of |
|---|---|---|
| cmake c / cpp | 61 + 59 | md5 of the cell build dir's executables, before/after the build |
| cargo | 117 | md5 of the row's own binaries in its group target-dir |
| workspace | 94 | `.inputsig` over a declared watch set |
| compile-check | 40 | `.inputsig`, same shape |

The first two are **differential — they have no watch set at all**, which is the
structural answer to "where do the sets overlap such that building A restales B":
since `2fa1ed09f` there is no set to overlap.

Running the **real production scripts** against synthetic fixtures modelling both
mechanisms:

```
                                          pre-2fa1ed09f   today
cmake, unchanged tree, 3 runs                 3/3 STALE     0/3
cargo, unit re-runs, bytes identical          3/3 STALE     0/3
cross-family (cmake build dates the cargo
  row's source forward), 3 alternating rounds 3/3 STALE     0/3
real source edit, both families               reported      reported, exactly once
```

Watch sets on a fully-built checkout: 568 + 243 tracked files, **0 untracked-and-
unignored**, and no build output anywhere in either — both halves use one policy
for "is this build output?", git's ignore rules, which is what holds it there.

## The budget the phase asked for

- **237 differential rows: spurious re-staling is 0, structurally.** No watch set,
  so no widening can reach them — it can only be undone by reverting the decision
  rule to an activity signal, which the new gate refuses.
- **134 `.inputsig` rows: 0 today**, and stays 0 while every hashed path is one git
  does not ignore and no build writes.
- **The cost of a proposed widening is arithmetic, not judgement:**
  `(rows that gain the path) × (how often the path moves)`. A tracked source path
  is free until edited; a path a build *writes* is unbounded — that is how #0835
  happened.
- A new input hashed into all 134 rows must key on what the tool **emits**, not on
  its binary: 41 distinct `nros` binaries on this host map to **9** fingerprints,
  so 78 % of `just setup-cli` rebuilds re-stale nothing.

**So phase-424's stated constraint is now half wrong, and the phase doc is updated
to say so.** "Every remedy invites widening a watch set" cannot reach the 237
differential rows at all.

## The gate

`tests/fixture-staleness-probe-tests.sh` — 19 checks, **2.2 s**, driving the real
probe scripts. Each family's fixed point *and* that a real edit is still caught
(silence alone would be satisfied by a probe that never reports), the cross-family
case over 3 alternating rounds, and a **negative control** re-applying the pre-fix
rules to the same trees, which must fire.

Mutation-checked both halves: reverting `cmake-fixture-stale.sh` fails 7 of 19;
reverting `rust-fixture-stale.sh` fails 4 of 19.

## Left for a decision, and #0835 stays open for it

The duplicated `threadx-riscv64` corrosion group — the 08-31 finding. It is
**wasted disk and CPU, not staleness**: after `2fa1ed09f` a duplicated group
cannot move a row's artifact bytes. Either candidate fix re-keys *every* corrosion
cargo directory on *every* platform, i.e. schedules a one-time full rebuild. That
is the phase owner's call, not a subagent's.

## Measured vs inferred

**Inferred:** that the fixed point holds on the real 371-row tree.
`check-fixtures-stale` self-heals, so an end-to-end run needs a `lane=all` fixture
build, and running it in the shared checkout would have rebuilt other agents'
artifacts. The synthetic reproduction models both mechanisms exactly and each
premise was verified rather than assumed — but it is a model.

**Two ways it could return**, recorded because "structurally impossible" is
conditional: artifact-name collisions inside one cargo group (held at 0 by
`check-fixture-groups`), and a non-reproducible build, which would make affected
rows permanently STALE and look exactly like this issue.

`just check fast` green. Not run: `check build` / `test-unit` — the diff touches
no Rust, C, C++ or Python, so this is a green `check fast`, not a green `ci gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
