### PR TITLE
feat(platform): a portable stack-headroom probe

### DIFF
--- a/packages/platform/nros-platform-api/include/nros/platform.h
+++ b/packages/platform/nros-platform-api/include/nros/platform.h
@@ -261,6 +261,36 @@ static inline void nros_platform_free(void *ptr) {
  *  Rust `#[global_allocator]`. */
 size_t nros_platform_heap_used_bytes(void);
 
+/** Smallest number of bytes ever left unused on the CALLING task's stack, or
+ *  `0` if this port cannot report it.
+ *
+ *  HEADROOM, not usage, because that is what both kernels natively track and
+ *  it is the number a safety argument needs: how close the worst observed
+ *  excursion came to the end of the stack.
+ *
+ *  The heap has had `nros_platform_heap_used_bytes` since RFC-0034 D7; the
+ *  stack had nothing, and stack overflow is the classic way one component
+ *  corrupts another's state. ISO 26262 treats spatial freedom from
+ *  interference as a first-class requirement and AUTOSAR pairs memory
+ *  protection with stack monitoring for exactly this reason. Without a
+ *  portable probe the only recourse is a per-RTOS one: this repo's Zephyr
+ *  lane greps `thread_analyzer` printk output in CI, which is a text scrape
+ *  of a debug facility standing in for a platform capability, and reports
+ *  nothing on any other port.
+ *
+ *  SELF only, deliberately. Both kernels answer for the calling task with no
+ *  handle (`uxTaskGetStackHighWaterMark(NULL)`, `k_thread_stack_space_get`
+ *  with `k_current_get()`), whereas answering for an arbitrary task needs a
+ *  native handle this ABI does not carry -- on Zephyr the task storage is a
+ *  `pthread_t` and the mapping to `k_thread *` is not public. A task
+ *  reporting its own headroom is also the shape the callers want: each tier
+ *  says how much of its own stack it has ever needed.
+ *
+ *  `0` means "this port does not instrument it", matching
+ *  `nros_platform_heap_used_bytes`. It is not a claim that the stack is
+ *  full. */
+size_t nros_platform_task_stack_unused_bytes(void);
+
 /** Total managed heap size in bytes (used + free), or `0` if unknown. */
 size_t nros_platform_heap_total_bytes(void);
 

--- a/packages/platform/nros-platform-api/src/lib.rs
+++ b/packages/platform/nros-platform-api/src/lib.rs
@@ -485,6 +485,15 @@ pub trait PlatformTime {
 /// be no-ops returning `0`, except [`task_init`](Self::task_init)
 /// which should return `-1`.
 pub trait PlatformThreading {
+    /// Smallest number of bytes ever left unused on the CALLING task's
+    /// stack, or `0` if this platform does not instrument it.
+    ///
+    /// Defaulted so every existing impl keeps compiling: a port that says
+    /// nothing reports `0`, which the ABI documents as "not instrumented"
+    /// rather than "no headroom left".
+    fn task_stack_unused_bytes() -> usize {
+        0
+    }
     // -- Tasks --
 
     /// Spawn a new task. `task` is opaque caller-provided storage;

--- a/packages/platform/nros-platform-api/src/task.rs
+++ b/packages/platform/nros-platform-api/src/task.rs
@@ -47,6 +47,7 @@ struct TaskAttr {
 const PRIORITY_INHERIT: i32 = i32::MIN;
 
 unsafe extern "C" {
+    fn nros_platform_task_stack_unused_bytes() -> usize;
     fn nros_platform_task_init(
         task: *mut c_void,
         attr: *mut c_void,
@@ -186,4 +187,20 @@ impl Drop for PlatformTask {
         //
         // `join` calls `mem::forget`, so the normal path never lands here.
     }
+}
+
+/// Smallest number of bytes ever left unused on the CALLING task's stack, or
+/// `0` if this port does not instrument it.
+///
+/// The heap has had `heap_used_bytes` since RFC-0034 D7; the stack had
+/// nothing, and stack overflow is how one component corrupts another's state.
+/// A tier asks this about ITSELF -- both kernels answer for the calling task
+/// with no handle, and answering for an arbitrary one needs a native handle
+/// this ABI does not carry.
+///
+/// `0` means "not instrumented", not "no headroom".
+pub fn stack_unused_bytes() -> usize {
+    // SAFETY: a plain query with no arguments and no state; every port either
+    // answers or returns 0.
+    unsafe { nros_platform_task_stack_unused_bytes() }
 }

--- a/packages/platform/nros-platform-cffi/src/generated.rs
+++ b/packages/platform/nros-platform-cffi/src/generated.rs
@@ -83,6 +83,10 @@ unsafe extern "C" {
     pub fn nros_platform_heap_used_bytes() -> usize;
 }
 unsafe extern "C" {
+    #[doc = " Smallest number of bytes ever left unused on the CALLING task's stack, or\n  `0` if this port cannot report it.\n\n  HEADROOM, not usage, because that is what both kernels natively track and\n  it is the number a safety argument needs: how close the worst observed\n  excursion came to the end of the stack.\n\n  The heap has had `nros_platform_heap_used_bytes` since RFC-0034 D7; the\n  stack had nothing, and stack overflow is the classic way one component\n  corrupts another's state. ISO 26262 treats spatial freedom from\n  interference as a first-class requirement and AUTOSAR pairs memory\n  protection with stack monitoring for exactly this reason. Without a\n  portable probe the only recourse is a per-RTOS one: this repo's Zephyr\n  lane greps `thread_analyzer` printk output in CI, which is a text scrape\n  of a debug facility standing in for a platform capability, and reports\n  nothing on any other port.\n\n  SELF only, deliberately. Both kernels answer for the calling task with no\n  handle (`uxTaskGetStackHighWaterMark(NULL)`, `k_thread_stack_space_get`\n  with `k_current_get()`), whereas answering for an arbitrary task needs a\n  native handle this ABI does not carry -- on Zephyr the task storage is a\n  `pthread_t` and the mapping to `k_thread *` is not public. A task\n  reporting its own headroom is also the shape the callers want: each tier\n  says how much of its own stack it has ever needed.\n\n  `0` means \"this port does not instrument it\", matching\n  `nros_platform_heap_used_bytes`. It is not a claim that the stack is\n  full."]
+    pub fn nros_platform_task_stack_unused_bytes() -> usize;
+}
+unsafe extern "C" {
     #[doc = " Total managed heap size in bytes (used + free), or `0` if unknown."]
     pub fn nros_platform_heap_total_bytes() -> usize;
 }

--- a/packages/platform/nros-platform-cffi/src/lib.rs
+++ b/packages/platform/nros-platform-cffi/src/lib.rs
@@ -777,6 +777,10 @@ macro_rules! nros_platform_export_threading {
             <$ty as ::nros_platform_api::PlatformThreading>::task_init(task, attr, entry, arg)
         }
         #[unsafe(no_mangle)]
+        pub extern "C" fn nros_platform_task_stack_unused_bytes() -> usize {
+            <$ty as ::nros_platform_api::PlatformThreading>::task_stack_unused_bytes()
+        }
+        #[unsafe(no_mangle)]
         pub extern "C" fn nros_platform_task_join(task: *mut ::core::ffi::c_void) -> i8 {
             <$ty as ::nros_platform_api::PlatformThreading>::task_join(task)
         }

--- a/packages/platform/nros-platform-esp-idf/src/platform.c
+++ b/packages/platform/nros-platform-esp-idf/src/platform.c
@@ -661,3 +661,9 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     line[n] = '\0';
     esp_system_abort(line);
 }
+
+/* ESP-IDF is FreeRTOS underneath, so the same self-query applies; IDF always
+ * ships INCLUDE_uxTaskGetStackHighWaterMark, hence no gate. Words to bytes. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+    return (size_t) uxTaskGetStackHighWaterMark(NULL) * sizeof(StackType_t);
+}

--- a/packages/platform/nros-platform-freertos/src/platform.c
+++ b/packages/platform/nros-platform-freertos/src/platform.c
@@ -964,3 +964,16 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     for (;;) {
     }
 }
+
+/* Headroom for the calling task. `uxTaskGetStackHighWaterMark(NULL)` answers
+ * in WORDS of free space, so scale by the stack word size to reach the ABI's
+ * bytes. Gated on INCLUDE_uxTaskGetStackHighWaterMark, which FreeRTOSConfig.h
+ * may leave off; the documented 0 covers that build rather than failing to
+ * link. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+#if (INCLUDE_uxTaskGetStackHighWaterMark == 1)
+    return (size_t) uxTaskGetStackHighWaterMark(NULL) * sizeof(StackType_t);
+#else
+    return 0;
+#endif
+}

--- a/packages/platform/nros-platform-posix/src/platform.c
+++ b/packages/platform/nros-platform-posix/src/platform.c
@@ -1039,3 +1039,14 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     fflush(stderr);
     abort();
 }
+
+/* POSIX has no per-thread stack watermark. `pthread_attr_getstack` gives the
+ * REGION, not the deepest excursion into it, and deriving usage from the
+ * current frame address measures where the probe was called rather than the
+ * worst case -- a number that looks like headroom and is not. Reporting 0
+ * says "not instrumented", which is true and useful; a plausible wrong number
+ * would be neither. A pattern-fill scheme could answer honestly, but it
+ * belongs to whoever owns the stacks, and on this port the kernel does. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+    return 0;
+}

--- a/packages/platform/nros-platform-threadx/src/platform.c
+++ b/packages/platform/nros-platform-threadx/src/platform.c
@@ -911,3 +911,21 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     }
 #endif
 }
+
+/* ThreadX keeps `tx_thread_stack_highest_ptr` only when built with
+ * TX_ENABLE_STACK_CHECKING; without it the field is not maintained and any
+ * number derived from it would be fiction. Headroom is the highest pointer
+ * minus the stack start. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+#ifdef TX_ENABLE_STACK_CHECKING
+    TX_THREAD *self = tx_thread_identify();
+    if (self == TX_NULL || self->tx_thread_stack_highest_ptr == TX_NULL ||
+        self->tx_thread_stack_start == TX_NULL) {
+        return 0;
+    }
+    return (size_t) ((char *) self->tx_thread_stack_highest_ptr -
+                     (char *) self->tx_thread_stack_start);
+#else
+    return 0;
+#endif
+}

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -1199,3 +1199,15 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     for (;;) {
     }
 }
+
+/* Headroom for the calling thread. `k_thread_stack_space_get` answers in
+ * unused BYTES, which is the ABI's unit, so no conversion. Needs
+ * CONFIG_INIT_STACKS to have painted the stack; without it the kernel has no
+ * watermark to read and returns an error, which becomes the documented 0. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+    size_t unused = 0;
+    if (k_thread_stack_space_get(k_current_get(), &unused) != 0) {
+        return 0;
+    }
+    return unused;
+}


### PR DESCRIPTION
## Problem

The heap has had `nros_platform_heap_used_bytes` since RFC-0034 D7. **The stack has nothing** — and stack overflow is the classic way one component corrupts another's state. ISO 26262 treats spatial freedom from interference as first-class, and AUTOSAR pairs memory protection with stack monitoring for exactly that reason.

Without a portable probe the only recourse is a per-RTOS one. The downstream Zephyr lane (autoware-safety-island) greps `thread_analyzer` printk output in CI to get this number — a text scrape of a debug facility standing in for a platform capability, and one that reports nothing on any other port.

## API

```c
size_t nros_platform_task_stack_unused_bytes(void);
```

**Headroom, not usage** — that is what both kernels natively track, and it is what a safety argument needs: how close the worst observed excursion came to the end of the stack.

**Self only, deliberately.** Both kernels answer for the calling task with no handle (`uxTaskGetStackHighWaterMark(NULL)`, `k_thread_stack_space_get(k_current_get(), ..)`), while answering for an *arbitrary* task needs a native handle this ABI does not carry — on Zephyr the task storage is a `pthread_t` and the mapping to `struct k_thread *` is not public. Self-query is also the shape callers want: each tier reports how much of its own stack it has ever needed.

`0` means "this port does not instrument it", matching `heap_used_bytes`. It is not a claim that the stack is full.

## Per port

| port | implementation |
|---|---|
| zephyr | `k_thread_stack_space_get` — already unused **bytes** |
| freertos | `uxTaskGetStackHighWaterMark(NULL)` — **words** → bytes, gated on `INCLUDE_uxTaskGetStackHighWaterMark` |
| esp-idf | same call; IDF always ships the option, so no gate |
| threadx | `tx_thread_stack_highest_ptr` minus stack start, gated on `TX_ENABLE_STACK_CHECKING` because the field is not maintained without it |
| posix | `0` |

**POSIX returns 0 rather than inventing a number.** `pthread_attr_getstack` gives the *region*, not the deepest excursion into it, and deriving usage from the current frame address measures where the probe was called rather than the worst case — a value that looks like headroom and is not. `0` is documented as "not instrumented", which is true and useful; a plausible wrong number would be neither.

## Compatibility

The `PlatformThreading` method is **defaulted to 0**, so every existing impl keeps compiling. The cffi macro exports it, so a Rust-implemented platform still provides the symbol for C callers.

## Verification

- bindings regenerated with the repo's own `scripts/gen-abi-bindings.sh` (bindgen 0.72.1); the only diff is the new declaration
- the Zephyr port compiles clean under the project's **real** build flags, and `nm` on the object shows

```
0000000000000000 T nros_platform_task_stack_unused_bytes
                 U z_impl_k_thread_stack_space_get
```

  so the kernel call is emitted rather than folded away
- `nros-platform-api`, `nros-platform-cffi`, `nros-node` check clean; `cargo fmt` clean

## Not included

No reporter. A `stack-headroom` monitor rule wants a declared minimum, which is a `TierSpec` decision — this is the capability such a rule would rest on. Same split as the release-jitter series: probe first, rule once the bound is agreed.
