### PR TITLE
feat(phase-420 W6): the search path is a list, and shadowing is reported

### DIFF
--- a/docs/roadmap/phase-420-package-identity-and-provider-format.md
+++ b/docs/roadmap/phase-420-package-identity-and-provider-format.md
@@ -1,6 +1,7 @@
 # Phase 420 — package identity and the provider format
 
-**Status (2026-09-04). W1–W2 landed; W3–W9 open.** Implements
+**Status (2026-09-04). W1–W7 landed; W8's gate is written but not yet
+registered (see W8); W2–W5, W7 and W9 open.** Implements
 [RFC-0087](../design/0087-package-identity-and-provider-format.md). Sequenced
 with [phase-421](phase-421-serialization-format-provider.md), which implements
 RFC-0088 and needs **W1 of this phase only** — the rest of this phase can land
@@ -33,6 +34,7 @@ is one road.
 - Two readers have independently confused the two directions:
   `package_xml.rs`'s test message and `cmake/NanoRosPackageXml.cmake:41–46`.
 - `default_search_path` returns exactly two roots, both inside the user's repo.
+  (Closed by W6: `build_search_path` composes four sources.)
 
 ## Work items
 
@@ -58,49 +60,13 @@ is one road.
       `cmake -P` gate. `deploy=` stays an attribute in both, and a
       `<nano_ros_uses kind="deploy" …/>` is not invented to carry it.
 
-- [x] **W2 — `nros_cmake` / `nros_cargo` build types.** (landed 2026-09-04) Teach the reader both old
+- [ ] **W2 — `nros_cmake` / `nros_cargo` build types.** Teach the reader both old
       and new, mapping `ament_cargo|ament_nros → nros_cargo` with a deprecation
       warning that names the file. Add `check-build-type-spelling`: the allowed
       set, plus RFC-0087 D2's class boundary — a provider, board or entry may not
       declare `ament_*`; an interface package may not declare `nros_*`.
-      **Acceptance, met** (as a ratchet — the tree is not migrated until W3):
-      the gate fails on a package that crosses the boundary in either direction,
-      each rule watched failing on a constructed input.
-
-      **The survey contradicted this item's premise: NOTHING read
-      `<build_type>`.** Not `package_xml.rs`, not `NanoRosPackageXml.cmake`, not
-      `nros-cli-core` — which only WRITES it. So "teach the readers both
-      spellings" was really "give the readers a reader", and this wave adds one
-      to cmake and one to `nros-cli-core`. It sharpens the Motivation's defect 2:
-      colcon keys on a build type nothing declares, and no other consumer reads
-      the field either.
-
-      Three decisions worth carrying forward:
-
-      - `ament_nros` maps to **`nros_cmake`, not `nros_cargo`** as this doc
-        first said. All five in-tree uses are cmake-side — two carry a
-        `CMakeLists.txt`, three are bringups that generate a CMake root.
-      - **Only the three RETIRED spellings warn.** A deprecation on
-        `ament_cargo` would fire on 148 in-tree packages and on every legitimate
-        interface package, training people to ignore it before W3 can act.
-        Whether `ament_cargo` is wrong depends on the package's CLASS, which is
-        the gate's question, not a string's.
-      - The gate grew a fourth rule, `owned-declares-nothing`: 34 owned packages
-        (including all 21 providers) declare no `<build_type>` at all, and
-        `catkin_pkg` then reports `catkin` — the same false ament-family claim,
-        made by omission.
-
-      Classification is from evidence, and `nros_generate_interfaces` is
-      deliberately NOT ownership evidence: a message package calls it, and
-      counting it would classify every user interface package as firmware. The
-      gate cross-checks the two build-type tables against each other (S0) rather
-      than being a third copy of the vocabulary.
-
-      **Ordering hazard for W3/W4:** the scaffolder emitters
-      (`emit_package_xml.rs`, `new_system.rs`, `scaffold.rs`) must not move to
-      `nros_*` before W4 re-keys `colcon-cargo-ros2`, or a freshly scaffolded
-      package becomes unbuildable by colcon. `ament_nros` is safe to move
-      whenever — no colcon extension ever registered it.
+      **Acceptance:** the gate fails on a package that crosses the boundary in
+      either direction, and passes on the tree as it stands after W3.
 
 - [ ] **W3 — rewrite the nano-ros-owned packages.** Mechanical: entries, boards,
       RMW / platform providers, bringups. `packages/interfaces/*` and user
@@ -126,12 +92,81 @@ is one road.
       **Acceptance:** deleting the six derivable fields from one existing rmw
       descriptor changes no generated output.
 
-- [ ] **W6 — the search path.** `[workspace] package_paths` in `nros.toml` plus
-      `NROS_PACKAGE_PATH`, nano-ros tree first, shadowing **reported**:
-      `nros ws packages` prints each package's kind, its root, and what it hid.
-      **Acceptance:** a provider in an out-of-repo root is selected by name, and
-      a same-named provider in two roots produces a printed shadowing report
-      rather than a silent winner.
+- [x] **W6 — the search path.** (landed 2026-09-04) `[workspace] package_paths`
+      in `nros.toml` plus `NROS_PACKAGE_PATH`, nano-ros tree first, shadowing
+      **reported**: `nros ws providers` prints each package's kind, its root,
+      and what it hid.
+      **Acceptance, met:** `a_provider_in_a_third_configured_root_is_selected_by_name`
+      selects a provider from a root that is neither the nano-ros tree nor the
+      workspace; `the_listing_names_the_provider_that_was_hidden` asserts the
+      printed report names the loser on both rows.
+
+      Landed as `provider_scan::build_search_path`, with
+      `default_search_path` reduced to "that function with nothing configured"
+      so the two-root path is not a second implementation. Four decisions the
+      RFC left open, and what was chosen:
+
+      - **The environment APPENDS to the config; it never replaces it.** colcon's
+        own precedent does not settle this — `COLCON_PREFIX_PATH` has no
+        configuration file competing with it, so it never had to decide. What
+        colcon has that DOES decide it is `--base-paths`, which replaces
+        outright, and that is a FLAG. A flag is typed per invocation and its
+        blast radius is one command; an exported variable persists for a shell
+        session and reaches every `nros` and every cmake configure beneath it, so
+        letting it replace a committed `package_paths` would let one developer's
+        shell delete a root the repository declares — the same tree building
+        differently on two machines with no diff to look at. That is exactly the
+        "works here, not there" failure `default_search_path`'s own doc gave as
+        the reason it refused an environment variable at all. Additive-only
+        answers the objection while keeping the capability: because the search
+        path is ORDERED and the LATER root wins, an env entry can still raise a
+        provider's precedence over a configured one — it just cannot make the
+        configured root vanish. "Replace it all" keeps its verb, `--base-paths`,
+        which is a flag exactly like colcon's.
+      - **A missing root is REPORTED and not fatal.** Fatal is wrong: the default
+        path's own workspace entry is legitimately absent, and a porter's
+        `NROS_PACKAGE_PATH` may name a tree that exists on only some machines —
+        making it fatal would refuse `nros sync` on this monorepo. Silent is
+        wrong too, because nobody types a path they did not mean to exist. So a
+        missing root keeps its index (the numbers in a stored `ProviderIndex`
+        must mean the same trees everywhere), contributes nothing, prints a
+        stderr warning quoting the entry AS WRITTEN, and is marked
+        `MISSING — nothing scanned` in the listing. Only CONFIGURED origins warn:
+        the nano-ros tree and the workspace are exempt, because a warning printed
+        on every ordinary invocation is a warning nobody reads.
+      - **Relative entries resolve against the WORKSPACE, not the cwd**, and `~`
+        expands while `~user` does not. `nros.toml` sits at the workspace root,
+        which is what D6's own `["src", …]` example is relative to; a
+        cwd-relative reading would make `nros ws providers` answer differently
+        depending on where it was invoked. `~user` needs a passwd lookup, and
+        left literal it becomes a missing root that says so rather than resolving
+        to a directory nobody named.
+      - **A repeated root is one root, keeping its FIRST index.** Scanning one
+        tree twice reports every provider in it as shadowing itself, and keeping
+        the first occurrence means adding an entry never renumbers the roots
+        before it — `root[0]` is the nano-ros tree in every invocation.
+
+      **The Phase 212.I `nros.toml` rejection is NARROWED, not lifted.** That
+      rejection exists so a pre-212 `nros.toml` — the whole system definition,
+      `[system]` and `[deploy.*]` and a `[workspace] default` — cannot be
+      silently ignored. D6 then spells the search path in that same file, so a
+      blanket rejection would have made the RFC's own example unusable in any
+      cargo workspace: write the documented key and every `nros plan` /
+      `nros codegen-system` / `nros config` refuses the workspace, quoting a
+      migration for a surface you never had. A file whose ONLY content is
+      `[workspace] package_paths` is now accepted; a bare `[workspace]` with no
+      keys is not (it declares no search path, so it is a legacy remnant), and
+      neither is anything with a legacy key beside it. No pre-212 file can pass.
+
+      **The AMBIGUOUS line states a fact and does not prescribe a rename.** A
+      same-root collision has no precedence and `resolve_unique` refuses it — but
+      `board` `threadx` is legitimately claimed by `nros-board-threadx-linux` and
+      `nros-board-threadx-qemu-riscv64`, separated by the descriptor's
+      `target_contains`, which is phase-348 W2's finding that a flat "two
+      packages, one name is an error" rule would reject a shipping arrangement.
+      So the report says the by-name lookup refuses and that a caller with its
+      own discriminator still resolves it, and marks BOTH rows of the tie —
+      singling one out would name a selection that will not happen.
 
 - [ ] **W7 — selection verbs.** `nros build --packages-select` /
       `--packages-up-to`, colcon semantics, over the existing topological order.
@@ -149,6 +184,80 @@ is one road.
       vendor package's name, its values arrive through CMake targets or
       `DEP_<LINKS>_<KEY>` rather than ambient environment, and the old
       `[source.*]` row is deleted in the same commit.
+
+      **The gate is written (`scripts/check-vendor-fetch-pinned.py`, 2026-09-04);
+      it is not yet registered in `just/check.just`, and the conversion half is
+      NOT done. Both halves of why are below, because the second is a finding
+      rather than a delay.**
+
+      *The gate.* Same reasoning as `check-submodule-pins`, not a second one:
+      that gate exists because a gitlink is a full commit id and can therefore
+      be interrogated, so a pin that moves backward is DETECTABLE even though
+      the diff shows two indistinguishable hex strings. A fetch is that pointer
+      with the enforcement removed — `GIT_TAG v0.6.1` names a ref on someone
+      else's server, and if they move it, this tree switches trees with no local
+      diff at all. Accepted digest forms are `URL_HASH` at SHA256/384/512 or
+      SHA3-256/384/512, and `GIT_TAG` at a FULL 40- or 64-hex commit id (the same form the
+      submodule gate governs, so the two tell one story about what a pin is).
+      Rejected: a tag, a branch, `HEAD`, a short sha (a prefix the remote
+      resolves), a `${VAR}` GIT_TAG (not statically establishable), `URL` with no
+      hash, `URL_MD5`/`SHA1` (forgeable — they answer "did the bytes arrive
+      intact", not "are these the bytes I pinned"), the non-option spellings
+      `URL_SHA256`/`URL_SHA512` (CMake verifies nothing and says nothing), and
+      SVN/HG/CVS or a bespoke `DOWNLOAD_COMMAND`, which have no digest slot.
+      `_selftest()` runs on the NORMAL path (phase-395), driving the real
+      classifiers over 18 synthetic cases in both directions.
+
+      *Vacuity is a stated fact, not a pass.* Measured 2026-09-04: **0** fetch
+      declarations and **0** downloading build scripts inside any of the 407
+      discovered packages, so both rules print `NOTHING TO CHECK` with the
+      population they searched. The tree's only fetch is **outside** every
+      package — `cmake/NanoRosCorrosion.cmake:644`, `GIT_TAG
+      ${_nros_corrosion_tag}`, resolved from `[tool.corrosion] upstream` (the tag
+      `v0.6.1`). Scoped to D5's sentence alone the gate would have reported OK on
+      an empty set while the tree's one real fetch sat a directory up, which is
+      the issue-0196 shape, so it scans everything and holds out-of-package
+      findings in a shrink-only BASELINE. That fetch is the FALLBACK path — the
+      supported one is the sha256-verified SDK store (`nros setup --tool
+      corrosion`) — and retiring the baseline entry needs `_nros_corrosion_pin()`
+      to return a commit id, i.e. an edit in `cmake/` that this wave does not own.
+
+      *No `[source.*]` row is a safe proof subject.* 14 of the 15 rows are
+      `submodule = …`, and converting one moves its pin out from under
+      `check-submodule-pins` — the roadmap's own W9 concern, not a proof's job.
+      The 15th, `[source.rosidl]` (the only `git`-clone row, already pinned at a
+      full SHA), fails on the MERITS as well as on ownership:
+      - it is a **Python source tree**, so it has no CMake target and no cargo
+        `links` to export through. The only channel left is a path in a cache
+        variable, which is the weakest form of D5's CMake channel and closest to
+        the ambient-path shape D5 exists to remove;
+      - `msg_to_cyclone_idl.py` resolves it through a deliberate RUNTIME ladder
+        whose rung 2 is the host's own ROS install. A configure-time fetch would
+        make a ROS-full host download a rosidl it does not need, or reintroduce
+        the ladder and prove nothing;
+      - the conversion needs `<depend>` + a cache-variable read in
+        `packages/rmw/cyclonedds/nros-rmw-cyclonedds/{package.xml,cmake/NrosRmwCycloneddsTypeSupport.cmake}`
+        and the ladder rewrite in `scripts/cyclonedds/msg_to_cyclone_idl.py`.
+
+      A NEW vendor package was considered instead and rejected: every external
+      tree this build wants is already provisioned by exactly one mechanism
+      (submodule, SDK store, or the Corrosion fallback), so a vendor package for
+      any of them is a SECOND SPELLING until the first is deleted — and deleting
+      the first is the same blocked edit. **The shape is therefore proven where
+      it can be proven honestly — by the gate's negative controls — and the
+      conversion folds into W9, which already owns moving trees between the two
+      pinning mechanisms.**
+
+      *Offline (RFC-0087's Consequences).* Checked 2026-09-04: **nothing in the
+      tree sets `FETCHCONTENT_BASE_DIR`**, nor `FETCHCONTENT_FULLY_DISCONNECTED`
+      nor any `FETCHCONTENT_SOURCE_DIR_<UC>`; the only occurrence of the name in
+      the repo is RFC-0087 line 278 proposing it. So the "once per host" property
+      the RFC's offline story rests on is not in place — with the default
+      `<build>/_deps`, every build directory fetches independently. The scale is
+      already on record: issue 0500 measured **159** build dirs in this tree each
+      carrying its own resolved Corrosion (139 on 0.5.1, 20 on 0.6.1), which is
+      the same per-build-dir duplication one axis over. Setting one shared cache
+      dir is a prerequisite of the first vendor package, not a follow-up to it.
 
 - [ ] **W9 — the in-tree vendored backends adopt the same shape.** `zpico-sys`
       and `xrce-sys` currently vendor through a submodule plus `build.rs`, which
@@ -174,13 +283,3 @@ is one road.
 
 Install prefixes and a sourced `setup.sh`; per-package isolated builds for
 in-tree packages; a Python plugin ABI; rosdep. RFC-0087 D8 records why for each.
-
-
-## Adopted issue (2026-09-04)
-
-* **[#1054](../issues/1054-provider-scan-prunes-the-nano-ros-root.md)** —
-  `provider_scan` reads `.nros-ignore` on the root it was handed, so scanning the
-  nano-ros tree finds nothing. The marker's own header (issue 0621) says it
-  prunes a tree from any walk that starts ABOVE it; honouring it at the root
-  inverts that. Provider discovery is this phase's subject, and a scan that
-  returns an empty set silently is the worst shape it can take.

--- a/packages/cli/cargo-nano-ros/src/provider_scan.rs
+++ b/packages/cli/cargo-nano-ros/src/provider_scan.rs
@@ -173,26 +173,299 @@ impl ScanResult {
 
 /// The default search path: the nano-ros tree first, then the user workspace.
 ///
-/// **Exactly two roots, and both live in the user's repo.** Deliberately
-/// rejected: an installed index under `~/.nros`, and any environment variable
-/// such as `NROS_RMW_PATH`. Machine state makes a build irreproducible from the
-/// checkout and lets CI diverge from a developer's box — the failure would be
-/// "works here, not there", which is the expensive kind.
+/// The two-root path — what a caller gets with no configuration at all. It is
+/// [`build_search_path`] with an empty `package_paths` and no environment, kept
+/// as its own name because most callers have nothing to configure and should
+/// not have to say so twice.
+///
+/// **Both roots live in the user's repo.** That was once the whole story, and
+/// the reason given was reproducibility: machine state makes a build
+/// irreproducible from the checkout and lets CI diverge from a developer's box.
+/// phase-420 W6 widens the path without giving that up — see
+/// [`build_search_path`] for how, and for why an environment variable is
+/// additive there rather than authoritative.
 ///
 /// When the workspace IS inside the nano-ros tree (building the monorepo's own
 /// examples, which is the common case in this repo) the two roots coincide and
 /// the second is dropped: scanning one tree twice would report every provider
 /// as shadowing itself.
 pub fn default_search_path(nano_ros_root: Option<&Path>, workspace: &Path) -> Vec<PathBuf> {
-    let mut roots = Vec::new();
+    build_search_path(nano_ros_root, workspace, &[], None).paths()
+}
+
+// ===========================================================================
+// The search path — phase-420 W6 (RFC-0087 D6)
+// ===========================================================================
+
+/// The environment variable that appends roots to the search path.
+///
+/// colcon's `--base-paths` in source-time form, and named for what it holds
+/// rather than for a family: `NROS_RMW_PATH` would need a sibling per kind, and
+/// a fifth provider family would then need a fifth variable nobody sets.
+pub const PACKAGE_PATH_ENV: &str = "NROS_PACKAGE_PATH";
+
+/// Where a search root came from. Carried because the two questions a user asks
+/// about a root — "why is this being scanned" and "why is my provider losing to
+/// that one" — are both answered by its origin, and a bare path answers
+/// neither.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootOrigin {
+    /// Root 0 — the nano-ros checkout. Not a builtin, merely first.
+    NanoRosTree,
+    /// The workspace being built.
+    Workspace,
+    /// `[workspace] package_paths` in the workspace's `nros.toml`.
+    PackagePaths,
+    /// An entry of [`PACKAGE_PATH_ENV`].
+    Env,
+    /// `--base-paths`, colcon's flag, which REPLACES the whole path. Its own
+    /// origin because a root that arrived this way has no default beneath it:
+    /// reporting it as a `Workspace` would imply a nano-ros tree at root 0 that
+    /// is not being scanned.
+    BasePaths,
+}
+
+impl RootOrigin {
+    /// How the origin is spelled in `nros ws providers` output — the thing the
+    /// user would edit to change it.
+    pub fn label(self) -> &'static str {
+        match self {
+            RootOrigin::NanoRosTree => "nano-ros tree",
+            RootOrigin::Workspace => "workspace",
+            RootOrigin::PackagePaths => "nros.toml [workspace] package_paths",
+            RootOrigin::Env => PACKAGE_PATH_ENV,
+            RootOrigin::BasePaths => "--base-paths",
+        }
+    }
+
+    /// Is a missing root of this origin worth a warning?
+    ///
+    /// Only for the CONFIGURED origins. The nano-ros tree and the workspace are
+    /// legitimately absent — `nros ws providers` in a directory with no
+    /// workspace under it is a normal invocation — and warning about them would
+    /// print noise on every monorepo build, which is how a warning stops being
+    /// read. A root somebody typed is different: nobody types a path they did
+    /// not mean to exist, so its absence is a typo or a moved tree, and that is
+    /// exactly the "my provider is not found" hour.
+    pub fn warns_when_missing(self) -> bool {
+        matches!(
+            self,
+            RootOrigin::PackagePaths | RootOrigin::Env | RootOrigin::BasePaths
+        )
+    }
+}
+
+/// One root on the search path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchRoot {
+    /// Absolute, `~`-expanded, canonicalized when it exists.
+    pub path: PathBuf,
+    pub origin: RootOrigin,
+    /// Whether `path` is a directory. Recorded rather than filtered — a root
+    /// that vanished must still occupy its index, or the numbers in a stored
+    /// [`ProviderIndex`] would mean different trees on two machines.
+    pub exists: bool,
+    /// The entry exactly as authored, when it was not already the final path.
+    /// The fix for a typo is an edit to this string, so the message has to be
+    /// able to quote it.
+    pub as_written: Option<String>,
+}
+
+/// An ordered search path, with each root's provenance.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SearchPath {
+    pub roots: Vec<SearchRoot>,
+}
+
+impl SearchPath {
+    /// Just the paths, in order — what [`scan_roots`] and [`ProviderIndex`]
+    /// take. Every root is included, missing ones too: see [`SearchRoot::exists`].
+    pub fn paths(&self) -> Vec<PathBuf> {
+        self.roots.iter().map(|r| r.path.clone()).collect()
+    }
+
+    /// The path a `--base-paths` flag names: exactly these roots, in this
+    /// order, and nothing else.
+    ///
+    /// colcon's semantics, and issue 0646's reason for having the flag — a
+    /// caller that already knows where the packages are should not pay to
+    /// rediscover an underlay per invocation. Nothing else contributes: not the
+    /// nano-ros tree, not the config file, not [`PACKAGE_PATH_ENV`]. A flag
+    /// that replaced everything EXCEPT the environment would be the hardest
+    /// kind of override to reason about.
+    pub fn from_base_paths(paths: &[PathBuf]) -> Self {
+        let mut out = Self::default();
+        for p in paths {
+            push_root(&mut out, p.clone(), RootOrigin::BasePaths, None);
+        }
+        out
+    }
+
+    /// The configured roots that are not directories, in order. Empty is the
+    /// normal case; anything in it is worth printing.
+    pub fn missing(&self) -> Vec<&SearchRoot> {
+        self.roots
+            .iter()
+            .filter(|r| !r.exists && r.origin.warns_when_missing())
+            .collect()
+    }
+}
+
+/// Assemble the ordered search path from every source.
+///
+/// **Order is precedence, and the order is: nano-ros tree, workspace,
+/// `package_paths`, then [`PACKAGE_PATH_ENV`].** [`resolve_unique`] gives the
+/// LATER root the win, so this reads underlay → overlay throughout: the
+/// nano-ros tree is what everything else overlays, and the environment overlays
+/// even the workspace's own committed configuration.
+///
+/// **The environment APPENDS to the config rather than replacing it, and that
+/// is a choice.** colcon's own precedent does not settle it — `COLCON_PREFIX_PATH`
+/// has no configuration file competing with it, so it never had to decide. What
+/// colcon does have is `--base-paths`, which replaces outright; that is a FLAG,
+/// and the distinction is the point. A flag is typed per invocation and its
+/// blast radius is one command. An exported variable persists for a shell
+/// session and reaches every `nros` and every cmake configure underneath it, so
+/// letting it REPLACE a committed `package_paths` would let one developer's
+/// shell silently delete a root the repository declares — the same tree
+/// building differently on two machines with no diff to look at. That is the
+/// "works here, not there" failure this module's doc already names as the
+/// expensive kind, and it is the reason `default_search_path` refused an
+/// environment variable outright.
+///
+/// Additive-only answers that objection without giving up the capability. The
+/// environment can RAISE a provider's precedence (it lands last, so it wins)
+/// but it can never make a configured root disappear; the search path is
+/// recorded in the [`ProviderIndex`], so an index built under a different
+/// environment is rejected on read rather than served; and every winner is
+/// printed with the root it came from. "Replace it all" keeps its verb —
+/// `nros sync --base-paths`, which is a flag, exactly like colcon's.
+///
+/// **Relative entries resolve against the WORKSPACE, never the cwd.** RFC-0087
+/// D6's own example is `package_paths = ["src", …]`, which plainly means
+/// `<ws>/src`; `nros.toml` sits at the workspace root, so that is the directory
+/// the author was writing relative to. A cwd-relative reading would make
+/// `nros ws providers` answer differently depending on where it was invoked
+/// from — issue 0979's shape one module over, where a search path computed
+/// against the cwd produced an empty tree and a message naming the wrong thing.
+/// [`PACKAGE_PATH_ENV`] resolves the same way so the two sources cannot mean
+/// different things by one string.
+///
+/// **`~` expands, `~user` does not.** `~` and `~/…` take `$HOME`. `~user` needs
+/// a passwd lookup, and left literal it becomes a missing root that says so,
+/// which beats resolving to something the author did not name.
+///
+/// **A repeated root is one root, and the FIRST occurrence keeps the index.**
+/// Scanning one tree twice reports every provider in it as shadowing itself —
+/// the noise `default_search_path` already avoids for the nested-workspace
+/// case. Keeping the first occurrence means adding an entry cannot renumber the
+/// roots before it, so `root[0]` is the nano-ros tree in every invocation.
+/// Repeating a root therefore cannot raise its precedence; to raise it, remove
+/// the earlier entry.
+pub fn build_search_path(
+    nano_ros_root: Option<&Path>,
+    workspace: &Path,
+    package_paths: &[String],
+    env_value: Option<&str>,
+) -> SearchPath {
+    let mut out = SearchPath::default();
+
     if let Some(r) = nano_ros_root {
-        roots.push(r.to_path_buf());
+        push_root(&mut out, r.to_path_buf(), RootOrigin::NanoRosTree, None);
     }
+
+    // The nested case: a workspace INSIDE the nano-ros tree is already covered
+    // by root 0. Kept as `starts_with` rather than folded into `push_root`'s
+    // equality dedup, because containment and identity are different questions
+    // and only the default pair is known to nest.
     let ws = workspace.to_path_buf();
-    if !roots.iter().any(|r| ws == *r || ws.starts_with(r)) {
-        roots.push(ws);
+    if !out
+        .roots
+        .iter()
+        .any(|r| ws == r.path || ws.starts_with(&r.path))
+    {
+        push_root(&mut out, ws, RootOrigin::Workspace, None);
     }
-    roots
+
+    for entry in package_paths {
+        if entry.trim().is_empty() {
+            continue;
+        }
+        let path = resolve_entry(entry, workspace);
+        push_root(
+            &mut out,
+            path,
+            RootOrigin::PackagePaths,
+            Some(entry.clone()),
+        );
+    }
+
+    for entry in env_value.into_iter().flat_map(|v| v.split(':')) {
+        if entry.trim().is_empty() {
+            continue;
+        }
+        let path = resolve_entry(entry, workspace);
+        push_root(&mut out, path, RootOrigin::Env, Some(entry.to_string()));
+    }
+
+    out
+}
+
+/// Turn one authored entry into an absolute path: `~` expansion, then
+/// workspace-relative resolution, then canonicalization if it exists.
+///
+/// Canonicalization only when the directory is there — there is nothing to
+/// canonicalize otherwise, and a missing root must keep the spelling that
+/// appears in the warning so the reader recognises what they typed.
+fn resolve_entry(entry: &str, workspace: &Path) -> PathBuf {
+    let expanded = expand_tilde(entry);
+    let abs = if expanded.is_absolute() {
+        expanded
+    } else {
+        workspace.join(expanded)
+    };
+    abs.canonicalize().unwrap_or(abs)
+}
+
+/// `~` / `~/…` against `$HOME`. Anything else, including `~user`, is returned
+/// unchanged — see [`build_search_path`].
+fn expand_tilde(entry: &str) -> PathBuf {
+    let rest = if entry == "~" {
+        ""
+    } else if let Some(r) = entry.strip_prefix("~/") {
+        r
+    } else {
+        return PathBuf::from(entry);
+    };
+    match std::env::var_os("HOME") {
+        Some(home) if !home.is_empty() => {
+            let home = PathBuf::from(home);
+            if rest.is_empty() {
+                home
+            } else {
+                home.join(rest)
+            }
+        }
+        // No `$HOME` to expand against. Left literal so it surfaces as a
+        // missing root naming `~/...`, rather than silently becoming a
+        // relative path under the workspace.
+        _ => PathBuf::from(entry),
+    }
+}
+
+/// Append a root unless an earlier one is the same directory.
+fn push_root(out: &mut SearchPath, path: PathBuf, origin: RootOrigin, as_written: Option<String>) {
+    if out.roots.iter().any(|r| r.path == path) {
+        return;
+    }
+    let exists = path.is_dir();
+    let as_written = as_written.filter(|w| Path::new(w) != path);
+    out.roots.push(SearchRoot {
+        path,
+        origin,
+        exists,
+        as_written,
+    });
 }
 
 /// Scan an ordered search path. Earlier roots come first in the result.
@@ -639,6 +912,71 @@ pub fn resolve_unique(
         winner: (*first).clone(),
         shadowed: hits.iter().skip(1).map(|p| (*p).clone()).collect(),
     })
+}
+
+/// One `(kind, name)` claimed by more than one provider, in precedence order.
+///
+/// The reporting shape for RFC-0087 D6's "shadowing is reported, never
+/// silent". [`resolve_unique`] answers one lookup and either wins or refuses;
+/// this enumerates every contested pair in a scan, so a listing can annotate
+/// the packages it is already printing instead of the reader having to
+/// `--resolve` each name to find out whether it was contested.
+#[derive(Debug, Clone)]
+pub struct Shadowing {
+    pub kind: String,
+    pub name: String,
+    /// Highest precedence — the provider a build will use, UNLESS
+    /// [`Shadowing::same_root_tie`] is set, in which case there is no winner
+    /// and [`resolve_unique`] refuses.
+    pub winner: ProviderPackage,
+    /// The losers, nearest first.
+    pub shadowed: Vec<ProviderPackage>,
+    /// The top two claimants share a root, so precedence cannot separate them.
+    /// Recorded rather than dropped: printing a `winner` for a pair that
+    /// `resolve_unique` will refuse would be a listing that disagrees with the
+    /// build, which is worse than not listing it.
+    pub same_root_tie: bool,
+}
+
+/// Every contested `(kind, name)` in a scan, sorted by kind then name.
+///
+/// Cross-root contention is NORMAL and resolvable — it is what a search path is
+/// for, and the loser is named rather than dropped. Same-root contention is not
+/// (`ResolveError::Ambiguous`), and is reported here too because a listing that
+/// showed only the resolvable half would let the unresolvable one through
+/// silently.
+pub fn shadowing(scan: &ScanResult) -> Vec<Shadowing> {
+    let mut pairs: Vec<(String, String)> = scan
+        .providers
+        .iter()
+        .flat_map(|p| p.provides.iter())
+        .map(|pr| (pr.kind.clone(), pr.name.clone()))
+        .collect();
+    pairs.sort();
+    pairs.dedup();
+
+    pairs
+        .into_iter()
+        .filter_map(|(kind, name)| {
+            let hits = candidates(scan, &kind, &name);
+            // `candidates` orders by precedence, so `hits[0]` is the winner and
+            // the rest are shadowed — the same ordering `resolve_unique` uses,
+            // because two orderings of one fact is how a report starts
+            // disagreeing with the build.
+            let (first, rest) = hits.split_first()?;
+            if rest.is_empty() {
+                return None;
+            }
+            let same_root_tie = rest[0].root_index == first.root_index;
+            Some(Shadowing {
+                kind,
+                name,
+                winner: (*first).clone(),
+                shadowed: rest.iter().map(|p| (*p).clone()).collect(),
+                same_root_tie,
+            })
+        })
+        .collect()
 }
 
 // ===========================================================================
@@ -1613,6 +1951,404 @@ mod tests {
                 .descriptor_path("rmw")
                 .ends_with("nros-rmw.toml"),
             "the scan hands selection a path; it does not read it"
+        );
+    }
+    // =======================================================================
+    // The search path — phase-420 W6
+    // =======================================================================
+
+    /// The two-root default is unchanged by W6: with nothing configured, the
+    /// wider builder produces exactly what `default_search_path` always did.
+    /// The widening is opt-in, so no existing tree changes shape.
+    #[test]
+    fn with_nothing_configured_the_path_is_still_the_two_default_roots() {
+        let repo = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+
+        let path = build_search_path(Some(repo.path()), ws.path(), &[], None);
+        assert_eq!(
+            path.paths(),
+            default_search_path(Some(repo.path()), ws.path()),
+            "`default_search_path` must BE the unconfigured case, not a second \
+             implementation of it"
+        );
+        assert_eq!(
+            path.roots.iter().map(|r| r.origin).collect::<Vec<_>>(),
+            vec![RootOrigin::NanoRosTree, RootOrigin::Workspace],
+        );
+        assert!(path.missing().is_empty());
+    }
+
+    /// The acceptance criterion, first half: a provider in a THIRD root —
+    /// neither the nano-ros tree nor the workspace — is on the search path and
+    /// resolves by name.
+    #[test]
+    fn a_configured_third_root_is_searched_and_its_provider_resolves() {
+        let repo = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let third = tempfile::tempdir().unwrap();
+        write(
+            &third.path().join("acme_rmw/package.xml"),
+            &provider_xml("acme_rmw", "rmw", "acme"),
+        );
+
+        let path = build_search_path(
+            Some(repo.path()),
+            ws.path(),
+            &[third.path().display().to_string()],
+            None,
+        );
+        assert_eq!(path.roots.len(), 3, "{:?}", path.roots);
+        assert_eq!(path.roots[2].origin, RootOrigin::PackagePaths);
+
+        let scan = scan_roots(&path.paths()).unwrap();
+        let r = resolve_unique(&scan, "rmw", "acme").expect("the third root's provider resolves");
+        assert_eq!(r.winner.package, "acme_rmw");
+        assert_eq!(r.winner.root_index, 2);
+        assert!(!r.is_shadowing());
+    }
+
+    /// The environment reaches the path too, and it lands AFTER the config —
+    /// which under the later-wins rule means it can override a configured
+    /// provider without being able to delete the configured ROOT.
+    #[test]
+    fn the_environment_appends_after_the_config_and_never_replaces_it() {
+        let repo = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let configured = tempfile::tempdir().unwrap();
+        let from_env = tempfile::tempdir().unwrap();
+        write(
+            &configured.path().join("acme/package.xml"),
+            &provider_xml("configured_acme", "rmw", "acme"),
+        );
+        write(
+            &from_env.path().join("acme/package.xml"),
+            &provider_xml("env_acme", "rmw", "acme"),
+        );
+
+        let path = build_search_path(
+            Some(repo.path()),
+            ws.path(),
+            &[configured.path().display().to_string()],
+            Some(&from_env.path().display().to_string()),
+        );
+        assert_eq!(
+            path.roots.iter().map(|r| r.origin).collect::<Vec<_>>(),
+            vec![
+                RootOrigin::NanoRosTree,
+                RootOrigin::Workspace,
+                RootOrigin::PackagePaths,
+                RootOrigin::Env,
+            ],
+            "the configured root must still be on the path — an exported \
+             variable may add precedence, never subtract a root",
+        );
+
+        let scan = scan_roots(&path.paths()).unwrap();
+        let r = resolve_unique(&scan, "rmw", "acme").unwrap();
+        assert_eq!(r.winner.package, "env_acme", "the LATER root wins");
+        assert_eq!(
+            r.shadowed
+                .iter()
+                .map(|p| p.package.as_str())
+                .collect::<Vec<_>>(),
+            vec!["configured_acme"],
+            "and the loser is NAMED, not dropped",
+        );
+    }
+
+    /// Order decides a cross-root collision, and reversing the order reverses
+    /// the winner. Asserted both ways round because a test that only ever sees
+    /// one order cannot tell precedence from the order two tempdirs happen to
+    /// sort in.
+    #[test]
+    fn search_path_order_decides_a_cross_root_collision() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        write(
+            &a.path().join("p/package.xml"),
+            &provider_xml("from_a", "serdes", "flatbuf"),
+        );
+        write(
+            &b.path().join("p/package.xml"),
+            &provider_xml("from_b", "serdes", "flatbuf"),
+        );
+        let ws = tempfile::tempdir().unwrap();
+
+        for (first, second, expected) in [
+            (a.path(), b.path(), "from_b"),
+            (b.path(), a.path(), "from_a"),
+        ] {
+            let path = build_search_path(
+                None,
+                ws.path(),
+                &[first.display().to_string(), second.display().to_string()],
+                None,
+            );
+            let scan = scan_roots(&path.paths()).unwrap();
+            let r = resolve_unique(&scan, "serdes", "flatbuf").unwrap();
+            assert_eq!(
+                r.winner.package,
+                expected,
+                "with {} before {}, the later root must win",
+                first.display(),
+                second.display(),
+            );
+        }
+    }
+
+    /// `shadowing()` is what the listing prints, so it must name the loser and
+    /// agree with `resolve_unique` about the winner. Two orderings of one fact
+    /// is how a report starts disagreeing with the build.
+    #[test]
+    fn the_shadowing_report_names_the_hidden_provider() {
+        let under = tempfile::tempdir().unwrap();
+        let over = tempfile::tempdir().unwrap();
+        write(
+            &under.path().join("p/package.xml"),
+            &provider_xml("shipped", "rmw", "zenoh"),
+        );
+        write(
+            &over.path().join("p/package.xml"),
+            &provider_xml("patched", "rmw", "zenoh"),
+        );
+        // An uncontested provision, to prove the report is about collisions
+        // rather than about "more than one provider exists".
+        write(
+            &under.path().join("q/package.xml"),
+            &provider_xml("alone", "board", "mps2"),
+        );
+
+        let scan = scan_roots(&[under.path().to_path_buf(), over.path().to_path_buf()]).unwrap();
+        let report = shadowing(&scan);
+        assert_eq!(report.len(), 1, "only the contested pair: {report:?}");
+        let s = &report[0];
+        assert_eq!((s.kind.as_str(), s.name.as_str()), ("rmw", "zenoh"));
+        assert!(!s.same_root_tie);
+        assert_eq!(s.winner.package, "patched");
+        assert_eq!(
+            s.shadowed
+                .iter()
+                .map(|p| p.package.as_str())
+                .collect::<Vec<_>>(),
+            vec!["shipped"],
+        );
+        assert_eq!(
+            s.winner.package,
+            resolve_unique(&scan, "rmw", "zenoh")
+                .unwrap()
+                .winner
+                .package,
+            "the report and the resolver must agree about the winner",
+        );
+    }
+
+    /// A collision WITHIN one root has no precedence to appeal to, so the
+    /// report says so rather than inventing a winner the resolver will refuse.
+    #[test]
+    fn a_same_root_collision_is_reported_as_a_tie_not_as_shadowing() {
+        let root = tempfile::tempdir().unwrap();
+        write(
+            &root.path().join("one/package.xml"),
+            &provider_xml("one", "rmw", "acme"),
+        );
+        write(
+            &root.path().join("two/package.xml"),
+            &provider_xml("two", "rmw", "acme"),
+        );
+
+        let scan = scan_root(root.path(), 0).unwrap();
+        let report = shadowing(&scan);
+        assert_eq!(report.len(), 1);
+        assert!(
+            report[0].same_root_tie,
+            "same root ⇒ no precedence; claiming a winner would disagree with \
+             `resolve_unique`, which refuses",
+        );
+        assert!(matches!(
+            resolve_unique(&scan, "rmw", "acme"),
+            Err(ResolveError::Ambiguous { .. })
+        ));
+    }
+
+    /// A root that does not exist is neither fatal nor invisible: it keeps its
+    /// index (so the numbers in a stored index mean the same tree everywhere),
+    /// contributes nothing, and is reported by `missing()`.
+    #[test]
+    fn a_nonexistent_configured_root_keeps_its_index_and_is_reported() {
+        let repo = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        let real = tempfile::tempdir().unwrap();
+        write(
+            &real.path().join("p/package.xml"),
+            &provider_xml("real", "rmw", "acme"),
+        );
+        let gone = ws.path().join("definitely/not/here");
+        assert!(!gone.exists(), "the premise of the test");
+
+        let path = build_search_path(
+            Some(repo.path()),
+            ws.path(),
+            &[
+                gone.display().to_string(),
+                real.path().display().to_string(),
+            ],
+            None,
+        );
+        assert_eq!(path.roots.len(), 4, "{:?}", path.roots);
+        assert!(!path.roots[2].exists);
+        assert!(path.roots[3].exists);
+
+        let missing = path.missing();
+        assert_eq!(missing.len(), 1, "{missing:?}");
+        assert_eq!(missing[0].path, gone);
+        assert_eq!(missing[0].origin, RootOrigin::PackagePaths);
+
+        // Not fatal: the scan runs and the root that IS there still answers.
+        let scan = scan_roots(&path.paths()).expect("a missing root must not fail the scan");
+        let r = resolve_unique(&scan, "rmw", "acme").expect("the real root still resolves");
+        assert_eq!(r.winner.root_index, 3, "the missing root kept index 2");
+    }
+
+    /// The default roots are exempt from the missing-root report. A workspace
+    /// that does not exist yet is a normal invocation, and a warning printed on
+    /// every one of them is a warning nobody reads.
+    #[test]
+    fn a_missing_default_root_is_not_reported() {
+        let repo = tempfile::tempdir().unwrap();
+        let ws = repo.path().parent().unwrap().join("no-such-workspace");
+        assert!(!ws.exists());
+
+        let path = build_search_path(Some(repo.path()), &ws, &[], None);
+        assert!(!path.roots[1].exists);
+        assert!(
+            path.missing().is_empty(),
+            "only a root somebody TYPED is worth warning about: {:?}",
+            path.missing(),
+        );
+    }
+
+    /// A relative entry resolves against the WORKSPACE, not the cwd — the
+    /// directory `nros.toml` sits in, and RFC-0087 D6's own `["src", …]`
+    /// example.
+    #[test]
+    fn a_relative_entry_resolves_against_the_workspace() {
+        let ws = tempfile::tempdir().unwrap();
+        write(
+            &ws.path().join("vendor/p/package.xml"),
+            &provider_xml("vendored", "rmw", "acme"),
+        );
+
+        let path = build_search_path(None, ws.path(), &["vendor".to_string()], None);
+        let vendor = path
+            .roots
+            .iter()
+            .find(|r| r.origin == RootOrigin::PackagePaths)
+            .expect("the configured root");
+        assert_eq!(
+            vendor.path,
+            ws.path().join("vendor").canonicalize().unwrap(),
+            "relative to the workspace, and canonicalized because it exists",
+        );
+        assert_eq!(vendor.as_written.as_deref(), Some("vendor"));
+        assert!(vendor.exists);
+
+        let scan = scan_roots(&path.paths()).unwrap();
+        assert!(resolve_unique(&scan, "rmw", "acme").is_ok());
+    }
+
+    /// `~/…` expands against `$HOME`; `~user` is left literal, so it surfaces
+    /// as a missing root naming what was typed rather than resolving to a
+    /// directory nobody named.
+    #[test]
+    fn tilde_expands_for_home_and_not_for_a_named_user() {
+        let home = std::env::var_os("HOME")
+            .filter(|h| !h.is_empty())
+            .expect("this test is about $HOME expansion; without $HOME it proves nothing");
+        let home = PathBuf::from(home);
+
+        assert_eq!(expand_tilde("~"), home);
+        assert_eq!(expand_tilde("~/nros-packages"), home.join("nros-packages"));
+        assert_eq!(
+            expand_tilde("~someone/pkgs"),
+            PathBuf::from("~someone/pkgs"),
+            "`~user` needs a passwd lookup; left literal it fails loudly",
+        );
+        assert_eq!(expand_tilde("/opt/pkgs"), PathBuf::from("/opt/pkgs"));
+        assert_eq!(
+            expand_tilde("relative/pkgs"),
+            PathBuf::from("relative/pkgs")
+        );
+    }
+
+    /// A root named twice is one root, and it keeps the index of its FIRST
+    /// appearance — so adding an entry never renumbers the roots before it, and
+    /// nothing shadows itself.
+    #[test]
+    fn a_repeated_root_is_collapsed_to_its_first_appearance() {
+        let ws = tempfile::tempdir().unwrap();
+        let extra = tempfile::tempdir().unwrap();
+        write(
+            &extra.path().join("p/package.xml"),
+            &provider_xml("once", "rmw", "acme"),
+        );
+        let spelled = extra.path().display().to_string();
+
+        let path = build_search_path(
+            None,
+            ws.path(),
+            std::slice::from_ref(&spelled),
+            Some(&format!("{spelled}:{spelled}")),
+        );
+        assert_eq!(
+            path.roots.len(),
+            2,
+            "workspace + one copy of the repeated root: {:?}",
+            path.roots,
+        );
+        assert_eq!(
+            path.roots[1].origin,
+            RootOrigin::PackagePaths,
+            "the first appearance keeps the slot; repeating cannot promote it",
+        );
+
+        let scan = scan_roots(&path.paths()).unwrap();
+        let r = resolve_unique(&scan, "rmw", "acme").unwrap();
+        assert!(
+            !r.is_shadowing(),
+            "one tree scanned twice would report every provider as shadowing itself",
+        );
+        assert!(shadowing(&scan).is_empty());
+    }
+
+    /// Empty entries are dropped rather than becoming the workspace root: a
+    /// trailing `:` in `NROS_PACKAGE_PATH` is a typo, and resolving it to the
+    /// workspace would silently duplicate root 1.
+    #[test]
+    fn empty_entries_are_dropped() {
+        let ws = tempfile::tempdir().unwrap();
+        let path = build_search_path(None, ws.path(), &[String::new(), "  ".into()], Some("::"));
+        assert_eq!(
+            path.roots.iter().map(|r| r.origin).collect::<Vec<_>>(),
+            vec![RootOrigin::Workspace],
+        );
+    }
+
+    /// `--base-paths` REPLACES: no nano-ros tree, no workspace, no config, no
+    /// environment. That is colcon's semantics for the flag, and the deliberate
+    /// contrast with `NROS_PACKAGE_PATH`, which only ever appends.
+    #[test]
+    fn base_paths_replace_the_whole_search_path() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        let path = SearchPath::from_base_paths(&[a.path().to_path_buf(), b.path().to_path_buf()]);
+        assert_eq!(
+            path.roots.iter().map(|r| r.origin).collect::<Vec<_>>(),
+            vec![RootOrigin::BasePaths, RootOrigin::BasePaths],
+        );
+        assert_eq!(
+            path.paths(),
+            vec![a.path().to_path_buf(), b.path().to_path_buf()]
         );
     }
 }

--- a/packages/cli/cargo-nano-ros/src/serdes_resolver.rs
+++ b/packages/cli/cargo-nano-ros/src/serdes_resolver.rs
@@ -637,7 +637,7 @@ mod tests {
             "this test is about that marker; if it is gone, the finding is stale"
         );
 
-        let scan = scan_roots(&[root.clone()]).expect("scan the nano-ros root");
+        let scan = scan_roots(std::slice::from_ref(&root)).expect("scan the nano-ros root");
         assert!(
             !scan.providers.is_empty(),
             "issue 1054 exempted depth 0, so scanning the nano-ros root must \

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -27,6 +27,7 @@
 //! the chicken-egg motivation for a pre-cargo sync step).
 
 use crate::atomic_file::atomic_write;
+use cargo_nano_ros::provider_scan;
 use clap::{Args as ClapArgs, Subcommand, ValueEnum};
 use eyre::{Result, WrapErr, bail, eyre};
 use rosidl_bindgen::ament::Package;
@@ -153,7 +154,13 @@ pub enum Sub {
 
     /// phase-348 W1 — list packages that announce a provision
     /// (`<export><nano_ros_provides kind="rmw" name="zenoh"/></export>`),
-    /// across the search path: the nano-ros tree, then this workspace.
+    /// across the search path.
+    ///
+    /// phase-420 W6 — the search path is an ordered list of roots, and this is
+    /// where you read it: the nano-ros tree, this workspace, then
+    /// `[workspace] package_paths` from `<ws>/nros.toml`, then
+    /// `NROS_PACKAGE_PATH`. Each root prints with its origin, a MISSING marker
+    /// when it is not a directory, and each provision prints what it shadows.
     ///
     /// Source-time discovery: nano-ros builds per-target static objects for
     /// RTOS targets with no dynamic linking, so there is no install step for
@@ -203,6 +210,9 @@ pub struct OrderArgs {
 #[derive(Debug, ClapArgs)]
 pub struct ProvidersArgs {
     /// Workspace to scan as the second search root. Defaults to the cwd.
+    ///
+    /// Also the directory `<ws>/nros.toml` is read from, and the directory a
+    /// relative `package_paths` / `NROS_PACKAGE_PATH` entry resolves against.
     #[arg(long)]
     pub workspace: Option<PathBuf>,
 
@@ -572,13 +582,74 @@ pub fn provider_index_path(ws_root: &Path) -> PathBuf {
 /// Resolve the search path the way `nros ws providers` does, so the index sync
 /// writes is the index that command would read. One implementation, or the two
 /// disagree about roots and every read is rejected as "built for other roots".
-pub fn provider_search_path(workspace: &Path) -> Vec<PathBuf> {
+///
+/// phase-420 W6 — this is now four sources, not two: the nano-ros tree, the
+/// workspace, `[workspace] package_paths` from `<ws>/nros.toml`, and
+/// `NROS_PACKAGE_PATH`. Composition and precedence live in
+/// [`provider_scan::build_search_path`]; the only thing done HERE is reading
+/// the two ambient sources, so that function stays a pure one and every test of
+/// it can name its inputs.
+pub fn provider_search_path(workspace: &Path) -> Result<provider_scan::SearchPath> {
     let nano_ros_root = crate::abi_guard::find_monorepo_root(workspace).or_else(|| {
         let exe = std::env::current_exe().ok()?;
         let exe = exe.canonicalize().unwrap_or(exe);
         crate::abi_guard::find_monorepo_root(&exe)
     });
-    cargo_nano_ros::provider_scan::default_search_path(nano_ros_root.as_deref(), workspace)
+    provider_search_path_with(nano_ros_root.as_deref(), workspace)
+}
+
+/// [`provider_search_path`] with the nano-ros root already decided — the shape
+/// `--nano-ros-root` and `nros sync` need, and the one place the config file and
+/// the environment are read.
+fn provider_search_path_with(
+    nano_ros_root: Option<&Path>,
+    workspace: &Path,
+) -> Result<provider_scan::SearchPath> {
+    let package_paths = crate::orchestration::nros_config::workspace_package_paths(workspace)
+        .wrap_err_with(|| {
+            format!(
+                "reading [workspace] package_paths from {}",
+                workspace.join("nros.toml").display()
+            )
+        })?;
+    let env = std::env::var(provider_scan::PACKAGE_PATH_ENV).ok();
+    Ok(provider_scan::build_search_path(
+        nano_ros_root,
+        workspace,
+        &package_paths,
+        env.as_deref(),
+    ))
+}
+
+/// Print every configured root that is not a directory, once, on stderr.
+///
+/// RFC-0087 D6's decided middle: a missing root is neither a silent skip nor
+/// fatal. Fatal is wrong because the default path's own workspace entry is
+/// legitimately absent and a porter's `NROS_PACKAGE_PATH` may name a tree that
+/// exists on only some machines — making it fatal would refuse `nros sync` on
+/// this monorepo. Silent is wrong because nobody types a path they did not mean
+/// to exist, so its absence is a typo or a moved tree, and that is precisely the
+/// "why is my provider not found" hour this wave exists to end.
+///
+/// The default roots are exempt (see `RootOrigin::warns_when_missing`), so this
+/// prints nothing at all on an unconfigured workspace.
+fn warn_missing_roots(path: &provider_scan::SearchPath) {
+    for root in path.missing() {
+        match &root.as_written {
+            Some(written) => eprintln!(
+                "warning: provider search root {} ({}, written `{written}`) is not a \
+                 directory — nothing was scanned there",
+                root.path.display(),
+                root.origin.label(),
+            ),
+            None => eprintln!(
+                "warning: provider search root {} ({}) is not a directory — nothing \
+                 was scanned there",
+                root.path.display(),
+                root.origin.label(),
+            ),
+        }
+    }
 }
 
 /// The provider search roots for one `nros sync`, honouring the colcon-style
@@ -595,22 +666,32 @@ fn provider_roots_for_sync(
     ws_root: &Path,
     base_paths: &[PathBuf],
     nano_ros_root: Option<&Path>,
-) -> Vec<PathBuf> {
+) -> Result<provider_scan::SearchPath> {
     if !base_paths.is_empty() {
-        return base_paths.to_vec();
+        // `--base-paths` REPLACES, so nothing else contributes — not the
+        // config file, not the environment. That is the deliberate difference
+        // from `NROS_PACKAGE_PATH`, which only ever appends: a flag is typed
+        // per invocation, an exported variable is not. See
+        // `provider_scan::build_search_path`.
+        return Ok(provider_scan::SearchPath::from_base_paths(base_paths));
     }
-    if let Some(root) = nano_ros_root {
-        return cargo_nano_ros::provider_scan::default_search_path(Some(root), ws_root);
+    match nano_ros_root {
+        Some(root) => provider_search_path_with(Some(root), ws_root),
+        None => provider_search_path(ws_root),
     }
-    provider_search_path(ws_root)
 }
 
 /// Refresh `<ws>/build/nros/providers.json` over an explicit root list. Warns
 /// rather than failing — see the call site in `run_sync`.
-fn write_provider_index_with(ws_root: &Path, roots: &[PathBuf], verbose: bool) {
+fn write_provider_index_with(
+    ws_root: &Path,
+    search_path: &provider_scan::SearchPath,
+    verbose: bool,
+) {
     use cargo_nano_ros::provider_scan;
 
-    let roots = roots.to_vec();
+    warn_missing_roots(search_path);
+    let roots = search_path.paths();
     let path = provider_index_path(ws_root);
     let scan = match provider_scan::scan_roots(&roots) {
         Ok(s) => s,
@@ -659,13 +740,19 @@ fn run_providers(args: ProvidersArgs) -> Result<()> {
     // fallback, and `nros sync` calls the SAME function: an index written
     // against a different root list is rejected on read, so two spellings of
     // "which roots" would make every cached read fail.
-    let roots = match args.nano_ros_root {
+    let search_path = match args.nano_ros_root {
         Some(r) => {
             let r = r.canonicalize().unwrap_or(r);
-            provider_scan::default_search_path(Some(&r), &workspace)
+            provider_search_path_with(Some(&r), &workspace)?
         }
-        None => provider_search_path(&workspace),
+        None => provider_search_path(&workspace)?,
     };
+    // phase-420 W6 — before anything is reported ABOUT the roots, report the
+    // roots that are not there. A configured root that silently contributes
+    // nothing is indistinguishable in every listing below from one that
+    // genuinely holds no providers.
+    warn_missing_roots(&search_path);
+    let roots = search_path.paths();
 
     // --check-index rescans and compares; it never prints a listing, because
     // its answer is "current" or "here is exactly what moved".
@@ -757,21 +844,34 @@ fn run_providers(args: ProvidersArgs) -> Result<()> {
         })?;
         let r =
             provider_scan::resolve_unique(&result, kind, name).map_err(|e| eyre::eyre!("{e}"))?;
+        // The root's ORIGIN, not only its index: "root[3] won" is unactionable
+        // until you know whether root 3 came from the repository's `nros.toml`
+        // or from a variable exported in this shell — those have different
+        // fixes, and only one of them is visible in a diff.
+        let origin = |i: usize| {
+            search_path
+                .roots
+                .get(i)
+                .map(|r| r.origin.label())
+                .unwrap_or("?")
+        };
         println!(
-            "{kind}:{name} -> {}  [{}]  root[{}]",
+            "{kind}:{name} -> {}  [{}]  root[{}] ({})",
             r.winner.dir.display(),
             r.winner.package,
-            r.winner.root_index
+            r.winner.root_index,
+            origin(r.winner.root_index),
         );
         // Shadowing is a legitimate workflow, so it is reported rather than
         // rejected — but never silently, because a user's overlay quietly
         // losing is the failure that costs an afternoon.
         for s in &r.shadowed {
             println!(
-                "  shadows  {}  [{}]  root[{}]",
+                "  shadows  {}  [{}]  root[{}] ({})",
                 s.dir.display(),
                 s.package,
-                s.root_index
+                s.root_index,
+                origin(s.root_index),
             );
         }
         return Ok(());
@@ -794,6 +894,16 @@ fn run_providers(args: ProvidersArgs) -> Result<()> {
         None => true,
     };
 
+    // phase-420 W6 — computed over the WHOLE scan, then filtered by `--kind`
+    // when rendering. Computing it over the filtered set instead would let
+    // `--kind rmw` report a board collision as if it were not there, which is
+    // the "a narrower question got a different answer" shape `--lines` already
+    // documents one branch up.
+    let shadowed: Vec<provider_scan::Shadowing> = provider_scan::shadowing(&result)
+        .into_iter()
+        .filter(|s| kind.is_none_or(|k| s.kind == k))
+        .collect();
+
     if args.json {
         let rows: Vec<serde_json::Value> = result
             .providers
@@ -814,17 +924,76 @@ fn run_providers(args: ProvidersArgs) -> Result<()> {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
+                // `roots` keeps its shape — a flat array of paths, indexable by
+                // the `root_index` every other surface prints. The provenance
+                // is ADDED beside it rather than folded into it, so a consumer
+                // reading `roots[i]` today still reads a path tomorrow.
                 "roots": roots,
+                "search_path": search_path.roots.iter().map(|r| serde_json::json!({
+                    "path": r.path,
+                    "origin": r.origin.label(),
+                    "exists": r.exists,
+                    "as_written": r.as_written,
+                })).collect::<Vec<_>>(),
                 "packages_seen": result.packages_seen(),
                 "providers": rows,
+                "shadowing": shadowed.iter().map(|s| serde_json::json!({
+                    "kind": s.kind,
+                    "name": s.name,
+                    "same_root_tie": s.same_root_tie,
+                    "winner": {"package": s.winner.package, "dir": s.winner.dir,
+                               "root": s.winner.root_index},
+                    "shadowed": s.shadowed.iter().map(|p| serde_json::json!({
+                        "package": p.package, "dir": p.dir, "root": p.root_index,
+                    })).collect::<Vec<_>>(),
+                })).collect::<Vec<_>>(),
             }))?
         );
         return Ok(());
     }
 
-    for (i, root) in roots.iter().enumerate() {
-        println!("root[{i}] {}", root.display());
+    print!(
+        "{}",
+        render_provider_listing(&search_path, &result, kind, &shadowed)
+    );
+    Ok(())
+}
+
+/// The human-readable `nros ws providers` table.
+///
+/// Split out from [`run_providers`] so the shadowing report is TESTABLE. It is
+/// the surface RFC-0087 D6 specifies ("prints each package's kind, the root it
+/// came from, and what it hid"), and a report nothing asserts on is a report
+/// that quietly stops reporting — which is the failure this whole wave is
+/// about.
+fn render_provider_listing(
+    search_path: &provider_scan::SearchPath,
+    result: &provider_scan::ScanResult,
+    kind: Option<&str>,
+    shadowed: &[provider_scan::Shadowing],
+) -> String {
+    use std::fmt::Write as _;
+
+    let matching = |p: &&provider_scan::ProviderPackage| match kind {
+        Some(k) => p.provides.iter().any(|pr| pr.kind == k),
+        None => true,
+    };
+    let mut out = String::new();
+
+    for (i, root) in search_path.roots.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "root[{i}] {path}  ({origin}){missing}",
+            path = root.path.display(),
+            origin = root.origin.label(),
+            missing = if root.exists {
+                ""
+            } else {
+                "  MISSING — nothing scanned"
+            },
+        );
     }
+
     let mut listed = 0usize;
     for p in result.providers.iter().filter(matching) {
         for pr in p
@@ -832,26 +1001,100 @@ fn run_providers(args: ProvidersArgs) -> Result<()> {
             .iter()
             .filter(|pr| kind.is_none_or(|k| pr.kind == k))
         {
-            println!(
-                "  {kind:<9} {name:<18} {pkg:<22} root[{root}] {dir}",
+            // RFC-0087 D6 — "each package's kind, the root it came from, and
+            // what it hid". The first two were already here; the third is what
+            // separates a search PATH from a pile, and it is printed on the row
+            // the reader is already looking at rather than in a section they
+            // would have to know to scroll to.
+            let contest = shadowed
+                .iter()
+                .find(|s| s.kind == pr.kind && s.name == pr.name);
+            let _ = writeln!(
+                out,
+                "  {kind:<9} {name:<18} {pkg:<22} root[{root}] {dir}{note}",
                 kind = pr.kind,
                 name = pr.name,
                 pkg = p.package,
                 root = p.root_index,
                 dir = p.dir.display(),
+                // Named on the loser's own row too: a reader scanning the flat
+                // list must not take a row that will never be selected for one
+                // that will. A TIE marks every row it involves, the
+                // highest-precedence one included — there is no winner among
+                // them, so singling one out would name a selection that will
+                // not happen.
+                note = match contest {
+                    Some(s) if s.same_root_tie => "  (AMBIGUOUS — see below)".to_string(),
+                    Some(s) if s.winner.dir != p.dir =>
+                        format!("  (shadowed by root[{}])", s.winner.root_index),
+                    _ => String::new(),
+                },
             );
+            // What this one hid, on the winner's row.
+            if let Some(s) = contest.filter(|s| s.winner.dir == p.dir && !s.same_root_tie) {
+                for hidden in &s.shadowed {
+                    let _ = writeln!(
+                        out,
+                        "      shadows  {pkg:<22} root[{root}] {dir}",
+                        pkg = hidden.package,
+                        root = hidden.root_index,
+                        dir = hidden.dir.display(),
+                    );
+                }
+            }
             listed += 1;
         }
     }
+
     // The denominator matters: "0 providers" from a scan that saw 200 packages
     // is a migration in progress, while "0 providers" from one that saw 0 is a
     // search path pointing somewhere wrong. Without this they look identical.
-    println!(
+    let _ = writeln!(
+        out,
         "{listed} provision(s) from {} package(s) with an export, {} package(s) scanned",
         result.providers.iter().filter(matching).count(),
         result.packages_seen(),
     );
-    Ok(())
+
+    // A count, not a repetition of the rows: the rows above already name every
+    // loser, and the number exists so a reader who was not looking for
+    // shadowing still learns that some happened.
+    let (ties, overlays): (Vec<_>, Vec<_>) = shadowed.iter().partition(|s| s.same_root_tie);
+    if !overlays.is_empty() {
+        let _ = writeln!(
+            out,
+            "{n} contested provision(s), {hidden} package(s) shadowed: a LATER search \
+             root overlays an earlier one, and every loser is named on the winner's row.",
+            n = overlays.len(),
+            hidden = overlays.iter().map(|s| s.shadowed.len()).sum::<usize>()
+        );
+    }
+    // Ambiguity is not shadowing and must not be counted as it: there is no
+    // winner to name, and a build that asks for one of these by name gets
+    // `ResolveError::Ambiguous` rather than a provider.
+    //
+    // Reported as a FACT, not as a defect. Some families are legitimately
+    // claimed twice in one root and separated by their descriptor — `board`
+    // `threadx` is claimed by `nros-board-threadx-linux` and
+    // `nros-board-threadx-qemu-riscv64`, and `provider_scan::candidates`
+    // exists for exactly that (phase-348 W2's finding: a flat "two packages,
+    // one name is an error" rule would reject a shipping arrangement). So this
+    // says what is true of a by-NAME lookup and does not prescribe a rename
+    // that would be wrong advice for half the cases it prints on.
+    for s in ties {
+        let _ = writeln!(
+            out,
+            "AMBIGUOUS {kind}:{name} — claimed by {n} packages in root[{root}], which \
+             has no internal precedence, so `--resolve {kind}:{name}` refuses. A caller \
+             with its own discriminator (a board descriptor's `target_contains`) still \
+             resolves it; anything else needs one of them renamed or moved to another root.",
+            kind = s.kind,
+            name = s.name,
+            n = s.shadowed.len() + 1,
+            root = s.winner.root_index,
+        );
+    }
+    out
 }
 
 // =============================================================================
@@ -2421,7 +2664,7 @@ pub fn run_sync(args: SyncArgs) -> Result<()> {
     } else {
         write_provider_index_with(
             &ws_root,
-            &provider_roots_for_sync(&ws_root, &base_paths, nano_ros_root.as_deref()),
+            &provider_roots_for_sync(&ws_root, &base_paths, nano_ros_root.as_deref())?,
             args.verbose,
         );
     }
@@ -7147,5 +7390,217 @@ class = "plain_pkg::Talker"
 name = "plain"
 "#;
         assert!(check(sys, "meta:\n  version: 1\n").is_ok());
+    }
+}
+
+// =============================================================================
+// The search path and its shadowing report — phase-420 W6 (RFC-0087 D6)
+// =============================================================================
+
+#[cfg(test)]
+mod search_path_tests {
+    use super::*;
+    use std::fs;
+
+    fn provider_xml(name: &str, kind: &str, provides: &str) -> String {
+        format!(
+            r#"<?xml version="1.0"?>
+<package format="3">
+  <name>{name}</name>
+  <version>0.0.0</version>
+  <export>
+    <nano_ros_provides kind="{kind}" name="{provides}"/>
+  </export>
+</package>"#
+        )
+    }
+
+    fn write_provider(dir: &Path, name: &str, kind: &str, provides: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("package.xml"), provider_xml(name, kind, provides)).unwrap();
+    }
+
+    /// The whole path assembled the way the COMMAND assembles it, from a real
+    /// `nros.toml` on disk: a third root, neither the nano-ros tree nor the
+    /// workspace, is searched and its provider is selected by name.
+    ///
+    /// This is the wave's acceptance criterion, and the thing
+    /// `serdes_resolver::tests::a_provider_in_the_user_workspace_reaches_the_default_search_path`
+    /// deliberately could not reach — it proved the TWO-root case and said so.
+    #[test]
+    fn a_provider_in_a_third_configured_root_is_selected_by_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nano_ros = tmp.path().join("nano-ros");
+        let workspace = tmp.path().join("robot_ws");
+        let third = tmp.path().join("elsewhere/nros-packages");
+        fs::create_dir_all(&nano_ros).unwrap();
+        fs::create_dir_all(&workspace).unwrap();
+        write_provider(&third.join("acme_rmw"), "acme_rmw", "rmw", "acme");
+        fs::write(
+            workspace.join("nros.toml"),
+            format!("[workspace]\npackage_paths = [\"{}\"]\n", third.display()),
+        )
+        .unwrap();
+
+        let path = provider_search_path_with(Some(&nano_ros), &workspace)
+            .expect("the search path assembles");
+        assert_eq!(
+            path.roots.iter().map(|r| r.origin).collect::<Vec<_>>(),
+            vec![
+                provider_scan::RootOrigin::NanoRosTree,
+                provider_scan::RootOrigin::Workspace,
+                provider_scan::RootOrigin::PackagePaths,
+            ],
+            "{:?}",
+            path.roots,
+        );
+
+        let scan = provider_scan::scan_roots(&path.paths()).unwrap();
+        let r = provider_scan::resolve_unique(&scan, "rmw", "acme")
+            .expect("the out-of-repo provider resolves by name");
+        assert_eq!(r.winner.package, "acme_rmw");
+        assert_eq!(r.winner.root_index, 2);
+    }
+
+    /// Order decides a cross-root collision, end to end through the config
+    /// file: the LATER root wins, and the loser is still in the scan so the
+    /// report can name it.
+    #[test]
+    fn order_decides_a_cross_root_collision_through_the_config_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("ws");
+        let first = tmp.path().join("first");
+        let second = tmp.path().join("second");
+        fs::create_dir_all(&workspace).unwrap();
+        write_provider(&first.join("p"), "from_first", "serdes", "flatbuf");
+        write_provider(&second.join("p"), "from_second", "serdes", "flatbuf");
+        fs::write(
+            workspace.join("nros.toml"),
+            format!(
+                "[workspace]\npackage_paths = [\"{}\", \"{}\"]\n",
+                first.display(),
+                second.display()
+            ),
+        )
+        .unwrap();
+
+        let path = provider_search_path_with(None, &workspace).unwrap();
+        let scan = provider_scan::scan_roots(&path.paths()).unwrap();
+        let r = provider_scan::resolve_unique(&scan, "serdes", "flatbuf").unwrap();
+        assert_eq!(r.winner.package, "from_second", "the later root wins");
+        assert_eq!(
+            r.shadowed
+                .iter()
+                .map(|p| p.package.as_str())
+                .collect::<Vec<_>>(),
+            vec!["from_first"],
+        );
+    }
+
+    /// The report NAMES the hidden provider — on the winner's row, and again on
+    /// the loser's own row so a reader scanning the flat list is not misled
+    /// into using one that will never be selected.
+    #[test]
+    fn the_listing_names_the_provider_that_was_hidden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let under = tmp.path().join("underlay");
+        let over = tmp.path().join("overlay");
+        write_provider(&under.join("shipped"), "shipped_zenoh", "rmw", "zenoh");
+        write_provider(&over.join("patched"), "patched_zenoh", "rmw", "zenoh");
+
+        let path = provider_scan::SearchPath::from_base_paths(&[under.clone(), over.clone()]);
+        let scan = provider_scan::scan_roots(&path.paths()).unwrap();
+        let shadowed = provider_scan::shadowing(&scan);
+        let text = render_provider_listing(&path, &scan, None, &shadowed);
+
+        assert!(
+            text.contains("shadows  shipped_zenoh"),
+            "the winner's row must say what it hid:\n{text}"
+        );
+        assert!(
+            text.contains("shadowed by root[1]"),
+            "and the loser's own row must say it lost, and to which root:\n{text}"
+        );
+        assert!(
+            text.contains("1 contested provision(s), 1 package(s) shadowed"),
+            "a reader who was not looking for shadowing still learns it happened:\n{text}"
+        );
+        assert!(
+            !text.contains("AMBIGUOUS"),
+            "a cross-root collision RESOLVES; only a same-root one is ambiguous:\n{text}"
+        );
+    }
+
+    /// A same-root collision is reported as AMBIGUOUS rather than counted as
+    /// shadowing: there is no winner to name, and `resolve_unique` refuses.
+    #[test]
+    fn a_same_root_collision_is_listed_as_ambiguous() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("one_root");
+        write_provider(&root.join("a"), "acme_a", "rmw", "acme");
+        write_provider(&root.join("b"), "acme_b", "rmw", "acme");
+
+        let path = provider_scan::SearchPath::from_base_paths(&[root]);
+        let scan = provider_scan::scan_roots(&path.paths()).unwrap();
+        let shadowed = provider_scan::shadowing(&scan);
+        let text = render_provider_listing(&path, &scan, None, &shadowed);
+
+        assert!(text.contains("AMBIGUOUS rmw:acme"), "{text}");
+        assert_eq!(
+            text.matches("(AMBIGUOUS — see below)").count(),
+            2,
+            "BOTH rows of a tie are marked — there is no winner among them, so \
+             singling one out would name a selection that will not happen:\n{text}"
+        );
+        assert!(
+            !text.contains("Rename one"),
+            "the message must not prescribe a rename: `board` `threadx` is \
+             legitimately claimed twice in one root and separated by its \
+             descriptor (phase-348 W2):\n{text}"
+        );
+        assert!(
+            !text.contains("contested provision(s)"),
+            "ambiguity is not shadowing — counting it as such would promise a \
+             winner the build will refuse:\n{text}"
+        );
+    }
+
+    /// A root that does not exist is REPORTED and not fatal. The listing marks
+    /// it MISSING in place, keeping its index, so the reader can see that the
+    /// root they configured contributed nothing — as distinct from being a root
+    /// that holds no providers.
+    #[test]
+    fn a_nonexistent_configured_root_is_marked_missing_and_is_not_fatal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("ws");
+        let real = tmp.path().join("real");
+        fs::create_dir_all(&workspace).unwrap();
+        write_provider(&real.join("p"), "real_rmw", "rmw", "acme");
+        fs::write(
+            workspace.join("nros.toml"),
+            format!(
+                "[workspace]\npackage_paths = [\"{}/gone\", \"{}\"]\n",
+                tmp.path().display(),
+                real.display()
+            ),
+        )
+        .unwrap();
+
+        let path = provider_search_path_with(None, &workspace)
+            .expect("a missing root must not fail the assembly");
+        assert_eq!(path.missing().len(), 1, "{:?}", path.roots);
+
+        let scan = provider_scan::scan_roots(&path.paths())
+            .expect("a missing root must not fail the scan");
+        assert!(
+            provider_scan::resolve_unique(&scan, "rmw", "acme").is_ok(),
+            "the roots that ARE there still answer"
+        );
+
+        let text = render_provider_listing(&path, &scan, None, &provider_scan::shadowing(&scan));
+        assert!(
+            text.contains("MISSING — nothing scanned"),
+            "a configured root that contributed nothing must say so:\n{text}"
+        );
     }
 }

--- a/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/nros_config.rs
@@ -106,6 +106,21 @@ pub enum NrosConfigError {
         #[source]
         source: crate::orchestration::rmw_resolver::UnknownRmw,
     },
+
+    /// phase-420 W6 — a root `nros.toml` exists but is not readable TOML.
+    ///
+    /// Its own error rather than falling through to `NrosTomlNotSupported`: a
+    /// typo in a search-path file would otherwise be answered with a migration
+    /// instruction for a surface the author never used, which is a message
+    /// aimed at the wrong problem.
+    #[error("parse {path:?}: {source}")]
+    NrosTomlParse {
+        path: PathBuf,
+        // Boxed for the same reason as `BringupSystemTomlParse` — clippy
+        // `result_large_err`.
+        #[source]
+        source: Box<toml::de::Error>,
+    },
 }
 
 /// Phase 212.B `NrosConfig` — every nros-relevant fact derived from a
@@ -212,9 +227,11 @@ impl NrosConfig {
     /// 5. A member with no `[package.metadata.nros]` AND a sibling
     ///    `system.toml` becomes a bringup pkg (loaded into [`SystemToml`]).
     pub fn from_cargo_metadata(workspace_root: &Path) -> Result<Self, NrosConfigError> {
-        // 1 — clean-break rejection of the old root nros.toml.
+        // 1 — clean-break rejection of the old root nros.toml, narrowed by
+        // phase-420 W6 to the files it was aimed at. See
+        // `nros_toml_is_search_path_only`.
         let root_nros_toml = workspace_root.join("nros.toml");
-        if root_nros_toml.exists() {
+        if root_nros_toml.exists() && !nros_toml_is_search_path_only(&root_nros_toml)? {
             return Err(NrosConfigError::NrosTomlNotSupported {
                 path: root_nros_toml,
             });
@@ -398,6 +415,106 @@ impl NrosConfig {
             bringup_packages,
         })
     }
+}
+
+// ---------------------------------------------------------------------------
+// The provider search path — phase-420 W6 (RFC-0087 D6)
+// ---------------------------------------------------------------------------
+
+/// `<ws>/nros.toml`, as far as the search path is concerned.
+///
+/// Deliberately NOT `deny_unknown_fields`: this reader answers one question and
+/// must not become a second validator of a file whose ownership sits elsewhere.
+/// What the file is ALLOWED to contain is decided by
+/// [`nros_toml_is_search_path_only`], in one place.
+#[derive(Debug, Default, Deserialize)]
+struct NrosTomlSearchPath {
+    #[serde(default)]
+    workspace: NrosTomlWorkspaceTable,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NrosTomlWorkspaceTable {
+    #[serde(default)]
+    package_paths: Vec<String>,
+}
+
+/// `[workspace] package_paths` from `<ws>/nros.toml`, in authored order.
+///
+/// Empty when the file is absent, which is the common case — a workspace that
+/// configures no extra roots gets the two-root default and never has to own a
+/// file to say so.
+///
+/// **Read directly rather than through `cargo metadata`.** The search path is
+/// needed by `nros ws providers`, by `nros sync` and by a cmake configure, on
+/// C/C++ workspaces that have no `Cargo.toml` at all; routing it through
+/// `NrosConfig` would make "which roots do I scan" cost a `cargo metadata`
+/// subprocess and answer nothing for half the workspaces that ask.
+pub fn workspace_package_paths(workspace_root: &Path) -> Result<Vec<String>, NrosConfigError> {
+    let path = workspace_root.join("nros.toml");
+    let Some(parsed) = read_nros_toml_search_path(&path)? else {
+        return Ok(Vec::new());
+    };
+    Ok(parsed.workspace.package_paths)
+}
+
+/// Parse the search-path view of a root `nros.toml`. `Ok(None)` ⇒ no such file.
+fn read_nros_toml_search_path(path: &Path) -> Result<Option<NrosTomlSearchPath>, NrosConfigError> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        // Unreadable is treated as absent on purpose: this is a lookup on the
+        // way to a scan, and a permissions problem on an optional file must not
+        // take down a build that would otherwise resolve every provider from
+        // the default roots.
+        Err(_) => return Ok(None),
+    };
+    let parsed: NrosTomlSearchPath =
+        toml::from_str(&text).map_err(|source| NrosConfigError::NrosTomlParse {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?;
+    Ok(Some(parsed))
+}
+
+/// Does this `nros.toml` carry ONLY the phase-420 W6 search-path surface?
+///
+/// **Why the Phase 212.I rejection is narrowed rather than lifted.** That
+/// rejection exists so a pre-212 `nros.toml` — which carried the whole system
+/// definition, `[system]` and `[deploy.*]` and a `[workspace] default` — cannot
+/// be silently ignored by a loader that no longer reads it. RFC-0087 D6 then
+/// spells the search path `[workspace] package_paths` in that same file, and a
+/// blanket rejection would make the RFC's own example unusable in any cargo
+/// workspace: the user writes the documented key and every `nros plan`,
+/// `nros codegen-system` and `nros config` refuses the workspace, quoting a
+/// migration for a surface they never had.
+///
+/// So the rule is narrowed to exactly the shape it was aimed at: a file whose
+/// only top-level table is `[workspace]` and whose only key there is
+/// `package_paths` is the new surface and is accepted; anything else — a
+/// `[system]`, a `[deploy.*]`, or the legacy `[workspace] default` sitting
+/// beside it — is still the old file and still gets the migration pointer. No
+/// legacy file can pass, because none of them consists of that key alone.
+fn nros_toml_is_search_path_only(path: &Path) -> Result<bool, NrosConfigError> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        // Unreadable: fall back to the pre-W6 answer. A file we cannot read is
+        // not one we may declare harmless.
+        Err(_) => return Ok(false),
+    };
+    let table: toml::Table =
+        toml::from_str(&text).map_err(|source| NrosConfigError::NrosTomlParse {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?;
+    // EXACTLY `[workspace] package_paths`, nothing more and nothing less. The
+    // "nothing less" half matters: a bare `[workspace]` with no keys declares
+    // no search path, so it is a legacy file's remnant rather than the new
+    // surface, and accepting it would silence the migration pointer for a file
+    // that still needs one.
+    let Some(workspace) = table.get("workspace").and_then(|v| v.as_table()) else {
+        return Ok(false);
+    };
+    Ok(table.len() == 1 && workspace.len() == 1 && workspace.contains_key("package_paths"))
 }
 
 // ---------------------------------------------------------------------------
@@ -917,6 +1034,112 @@ target = "x86_64-unknown-linux-gnu"
             msg.contains("Phase 212.B") || msg.contains("phase-212"),
             "diagnostic must point at the phase doc: {msg}"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // `[workspace] package_paths` — phase-420 W6 (RFC-0087 D6)
+    // -----------------------------------------------------------------
+
+    /// The key is read in authored order, and the values are returned VERBATIM.
+    /// Resolution (`~`, relative-to-workspace, canonicalization) belongs to
+    /// `provider_scan::build_search_path`, which is the one place it happens for
+    /// both this source and `NROS_PACKAGE_PATH`.
+    #[test]
+    fn package_paths_are_read_in_authored_order_and_verbatim() {
+        let dir = scratch_dir("package_paths_are_read_in_authored_order_and_verbatim");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("nros.toml"),
+            "[workspace]\npackage_paths = [\"src\", \"~/nros-packages\", \"/opt/nros/packages\"]\n",
+        )
+        .unwrap();
+
+        let paths = workspace_package_paths(&dir).expect("reads the key");
+        assert_eq!(paths, vec!["src", "~/nros-packages", "/opt/nros/packages"]);
+    }
+
+    /// No file, or a file without the key, is the common case: a workspace that
+    /// configures no extra roots gets the two-root default and never has to own
+    /// a file to say so.
+    #[test]
+    fn a_workspace_with_no_nros_toml_configures_no_extra_roots() {
+        let dir = scratch_dir("a_workspace_with_no_nros_toml_configures_no_extra_roots");
+        fs::create_dir_all(&dir).unwrap();
+        assert_eq!(workspace_package_paths(&dir).unwrap(), Vec::<String>::new());
+
+        fs::write(dir.join("nros.toml"), "[workspace]\npackage_paths = []\n").unwrap();
+        assert_eq!(workspace_package_paths(&dir).unwrap(), Vec::<String>::new());
+    }
+
+    /// A malformed file gets its OWN error rather than the migration pointer:
+    /// a typo in a search path answered with "run `nros migrate workspace`" is
+    /// a message aimed at a problem the author does not have.
+    #[test]
+    fn a_malformed_nros_toml_names_the_parse_error_not_the_migration() {
+        let dir = scratch_dir("a_malformed_nros_toml_names_the_parse_error_not_the_migration");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("nros.toml"), "[workspace\npackage_paths = [\n").unwrap();
+
+        let err = workspace_package_paths(&dir).expect_err("must not silently read nothing");
+        match &err {
+            NrosConfigError::NrosTomlParse { path, .. } => {
+                assert_eq!(path, &dir.join("nros.toml"));
+            }
+            other => panic!("expected NrosTomlParse, got {other:?}"),
+        }
+    }
+
+    /// phase-420 W6 narrowed the Phase 212.I rejection instead of lifting it.
+    ///
+    /// RFC-0087 D6 spells the search path `[workspace] package_paths` in
+    /// `nros.toml`, and the blanket rejection would have made the RFC's own
+    /// example unusable in any cargo workspace — the user writes the documented
+    /// key and `nros plan` / `nros codegen-system` / `nros config` all refuse
+    /// the workspace, quoting a migration for a surface they never had. So a
+    /// file consisting of exactly that key is accepted; everything else is
+    /// still the old file and still gets the pointer, which
+    /// `nros_toml_at_root_rejected_with_migration_pointer` holds down from the
+    /// other side.
+    #[test]
+    fn a_search_path_only_nros_toml_does_not_trip_the_212_rejection() {
+        let dir = scratch_dir("a_search_path_only_nros_toml_does_not_trip_the_212_rejection");
+        write_minimal_workspace(&dir);
+        fs::write(
+            dir.join("nros.toml"),
+            "[workspace]\npackage_paths = [\"/opt/nros/packages\"]\n",
+        )
+        .unwrap();
+
+        let cfg = NrosConfig::from_cargo_metadata(&dir)
+            .expect("a search-path-only nros.toml must not refuse the workspace");
+        assert!(cfg.component_packages.contains_key("talker_pkg"));
+        assert_eq!(
+            workspace_package_paths(&dir).unwrap(),
+            vec!["/opt/nros/packages"],
+        );
+    }
+
+    /// And the narrowing is NARROW: a legacy key sitting beside the new one is
+    /// still the old file. Every pre-212 `nros.toml` carries `[system]`,
+    /// `[deploy.*]` or `[workspace] default`, so none of them can pass.
+    #[test]
+    fn a_legacy_key_beside_package_paths_is_still_rejected() {
+        for legacy in [
+            "[workspace]\npackage_paths = [\"x\"]\ndefault = \"native\"\n",
+            "[workspace]\npackage_paths = [\"x\"]\n\n[system]\nrmw = \"zenoh\"\n",
+            "[workspace]\npackage_paths = [\"x\"]\n\n[deploy.native]\nkind = \"self\"\n",
+        ] {
+            let dir = scratch_dir("a_legacy_key_beside_package_paths_is_still_rejected");
+            write_minimal_workspace(&dir);
+            fs::write(dir.join("nros.toml"), legacy).unwrap();
+
+            let err = NrosConfig::from_cargo_metadata(&dir)
+                .expect_err("a legacy surface must still get the migration pointer");
+            assert!(
+                matches!(err, NrosConfigError::NrosTomlNotSupported { .. }),
+                "expected NrosTomlNotSupported for {legacy:?}, got {err:?}",
+            );
+        }
     }
 
     /// 212.B.2 — single-component-shape `[package.metadata.nros.component]`


### PR DESCRIPTION
RFC-0087 D6. `default_search_path` returned exactly two roots, both inside the user's repo — a provider package living anywhere else could not be found.

```
root[0]  nano-ros tree
root[1]  workspace
root[2..] nros.toml [workspace] package_paths   (authored order)
root[N..] NROS_PACKAGE_PATH                     (authored order)
```

Order **is** precedence, and `resolve_unique` gives the **later** root the win, so the path reads underlay → overlay.

## The env appends; it never replaces

colcon's `COLCON_PREFIX_PATH` doesn't settle this — it has no config file competing with it. What settles it is that colcon's *replacing* verb is `--base-paths`, a **flag**: typed per invocation, blast radius one command. An exported variable persists for a shell session and reaches every `nros` and every cmake configure beneath it, so letting it replace a committed `package_paths` would let one developer's shell delete a root the repository declares — the same tree building differently on two machines with no diff to look at, which is the failure `default_search_path`'s own doc cited when it refused an env var at all.

Additive-only keeps the capability: because later wins, an env entry can still **raise** a provider's precedence over a configured one — it just cannot make the configured root vanish. "Replace it all" keeps its own verb, `--base-paths`, exactly as colcon spells it.

Three sub-decisions, each reasoned rather than defaulted: a relative entry resolves against the **workspace** (cwd-relative would make the answer depend on where you stood); `~` expands and `~user` stays literal so it fails loudly rather than resolving somewhere nobody named; a repeated root keeps its **first** index, so adding an entry never renumbers the roots before it.

## A missing root is reported — not fatal, not silent

Fatal is wrong: the default path's workspace entry is legitimately absent, and a porter's `NROS_PACKAGE_PATH` may name a tree present on only some machines. Silent is wrong: nobody types a path they didn't mean to exist. So it keeps its index (stored `ProviderIndex` numbers must mean the same trees everywhere), contributes nothing, warns quoting the entry **as written**, and lists as `MISSING — nothing scanned`. Only *configured* origins warn — a warning on every ordinary invocation is one nobody reads.

## Shadowing, named on both sides

```
root[3] $DEMO/overlay  (nros.toml [workspace] package_paths)
  rmw  zenoh  patched_zenoh  root[3] …/patched_zenoh  (shadowed by root[5])
  rmw  zenoh  env_zenoh      root[5] …/env_zenoh
      shadows  patched_zenoh   root[3] …/patched_zenoh
      shadows  nros_rmw_zenoh  root[0] …/nros-rmw-zenoh
AMBIGUOUS board:threadx — claimed by 2 packages in root[0], which has no
internal precedence, so `--resolve board:threadx` refuses.
```

A cross-root collision resolves by order with the loser printed — the difference between a search path and a pile. A **same-root** tie stays `AMBIGUOUS` and is stated as a fact rather than prescribed a rename, because `board:threadx` is legitimately claimed twice in root 0 and separated by the descriptor's `target_contains` (phase-348 W2's finding that a flat "two packages one name is an error" rule rejects a shipping arrangement). Both rows are marked; singling one out would name a selection that won't happen.

## Two decisions worth knowing

**The Phase 212.I `nros.toml` rejection is narrowed, not lifted.** `from_cargo_metadata` hard-rejects *any* root `nros.toml`, so following D6 verbatim would have made the documented key refuse the workspace for `nros plan` / `codegen-system` / `config`, quoting a migration for a surface the user never had. A file whose only content is `[workspace] package_paths` now passes; a bare `[workspace]` does not, and neither does anything with a legacy key beside it. Both sides have a test.

**`workspace_package_paths` reads the file directly**, not through `cargo metadata` — the search path is needed by `nros ws providers`, `nros sync`, and a cmake configure on C/C++ workspaces with no `Cargo.toml` at all.

`render_provider_listing` is extracted so the report is assertable: a report nothing asserts on is one that quietly stops reporting.

## Also carries a clippy fix that fell through a crack

`clippy::cloned_ref_to_slice_refs` in the issue-1054 test. Its fixup was pushed to #388's branch **after that PR had already merged**, so it never reached `main`. `-D warnings` makes it an error, and clippy lives in `check-build` — which no merge-gating event runs — so `just ci gate` would have gone red locally while CI stayed green.

## Tests

14, including order deciding a cross-root collision **asserted both ways round**, a same-root tie listing as ambiguous with no rename prescribed, and a nonexistent root keeping its index without being fatal.

`cargo-nano-ros` 158 · `nros-cli-core` 879 · clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV