### PR TITLE
fix(#0820): two more cargo custom commands had no edge on the Rust they compile

### DIFF
--- a/cmake/NanoRosGenerateInterfaces.cmake
+++ b/cmake/NanoRosGenerateInterfaces.cmake
@@ -484,6 +484,12 @@ function(nros_generate_interfaces target)
       # `_nros_resolve_rust_target` in NanoRosCodegenCore.cmake.
       _nros_resolve_rust_target(_ffi_rust_target)
       set(_ffi_lib "${_ffi_target_dir}/${_ffi_rust_target}/${_NROS_FFI_DIR}/libnano_ros_cpp_ffi_${target}.a")
+      # issue 0820 — cargo writes its dep-info beside the artifact, same
+      # basename, `.d`. The two spellings move together like the profile and
+      # the output path above: a `.d` derived from anything but `_ffi_lib`
+      # would name a file cargo never wrote, and ninja tolerates a missing
+      # depfile silently — which is the failure this edge exists to end.
+      string(REGEX REPLACE "\\.a$" ".d" _ffi_dep_file "${_ffi_lib}")
 
       file(MAKE_DIRECTORY "${_ffi_crate_src}")
 
@@ -582,10 +588,19 @@ function(nros_generate_interfaces target)
       if(NOT _NROS_FFI_ENV STREQUAL "")
         set(_ffi_env ${CMAKE_COMMAND} -E env ${_NROS_FFI_ENV} ${NROS_BOARD_FACTS_ENV})
       endif()
+      # issue 0820 — DEPENDS names the crate's OWN files and nothing else, so
+      # this archive had no edge on the nano-ros Rust it compiles in. Cargo's
+      # dep-info lists `packages/core/nros-serdes/src/{cdr,lib,...}.rs` for
+      # exactly this artifact (measured), and a hand-written DEPENDS is a
+      # standing approximation of a graph cargo already computes exactly.
+      # Without it, editing the CDR serializer left every generated message
+      # staticlib holding the previous build's code, with a fresh mtime — the
+      # museum-archive shape 0820 hit one seam over, on NuttX.
       add_custom_command(
         OUTPUT "${_ffi_lib}"
         COMMAND ${_ffi_env} cargo ${_ffi_cargo_prefix} ${_ffi_cargo_args}
         DEPENDS ${_generated_rs_files} "${_ffi_crate_dir}/Cargo.toml" "${_ffi_crate_src}/lib.rs"
+        DEPFILE "${_ffi_dep_file}"
         WORKING_DIRECTORY "${_ffi_crate_dir}"
         COMMENT "Building Rust FFI glue for ${target} C++ bindings"
         VERBATIM

--- a/docs/issues/archived/0820-riscv-nuttx-c-talker-no-runtime-delivery.md
+++ b/docs/issues/archived/0820-riscv-nuttx-c-talker-no-runtime-delivery.md
@@ -1,13 +1,120 @@
 ---
 id: 820
-title: "`c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — the NuttX seam had no
-  dependency edge on the Rust world, and hardcoded `--release` past a
-  miscompile carve-out"
-status: open
+title: "`c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — a cmake custom command
+  ran `cargo` with no rebuild edge on the Rust world it compiles"
+status: resolved
 type: bug
 area: cmake, testing
-related: [issue-0475, issue-0445, issue-0196, issue-0805]
+related: [issue-0475, issue-0445, issue-0196, issue-0805, phase-424]
+resolved_in: "6d363f5cc (NuttX seam) + this commit (the other two cargo commands + the gate)"
 ---
+
+## What was wrong
+
+`c_riscv_nuttx_talker_delivers_cross_process` failed at its full 90 s timeout
+and passed in 3.5 s after `rm -rf examples/qemu-riscv-nuttx/c/talker/build-zenoh`
+on UNMODIFIED sources. Per issue 0475's rule that is a missing dependency edge,
+and it was: `add_custom_command(OUTPUT ...)` rebuilds only when an input it
+NAMES is newer than the output, and cargo's inputs are a graph over the whole
+workspace. Every hand-written `DEPENDS` in this tree approximated that graph,
+and every one was wrong the same way — it named the crate's own files and no
+nano-ros Rust at all. The artifact came out NEWER than its sources holding
+older code, and nothing in the graph could notice.
+
+Cargo already publishes the exact answer: a Makefile-format dep-info file
+beside the artifact (`<artifact>.d`, absolute paths, one target), which is
+precisely what cmake's `DEPFILE` consumes. A missing depfile is a warning, not
+an error, so the edge is safe from the first configure.
+
+## Fixed, in three commands and one gate
+
+| site | what it built | state |
+| --- | --- | --- |
+| `packages/api/nros-c/cmake/nros-nuttx.cmake` | the NuttX kernel ELF | fixed 2026-08-27 (`6d363f5cc`), with the hardcoded `--release` replaced by the `nuttx-rust` carve-out in the same commit — the two move together, because the OUTPUT path spells the profile dir |
+| `cmake/NanoRosGenerateInterfaces.cmake` | the generated message C++ FFI staticlib | fixed here |
+| `zephyr/cmake/nros_generate_interfaces.cmake` | the same, Zephyr lane | fixed here |
+
+Gate: `just check cargo-custom-command-depfile`
+(`scripts/check-cargo-custom-command-depfile.py`, fast line, buildless) — an
+`add_custom_command` whose COMMAND runs the `cargo` program must carry a
+`DEPFILE`. It does NOT flag `add_custom_target(... COMMAND cargo ...)` (no
+output, always runs) nor the three commands that merely mention a cargo-shaped
+path or target name.
+
+## The sweep this issue got wrong, and why the gate exists
+
+The 2026-09-01 sweep here concluded NuttX was "one-of-a-kind" and declined to
+write a gate, on the reasoning that one instance cannot support a rule. Both
+halves were wrong, from the same mistake: the sweep matched FILES containing
+both `add_custom_command` and `cargo`, and then classified each file by what it
+mostly does. Both generators were in its output, labelled "codegen" — and both
+contain a codegen command (legitimately no depfile) AND a `cargo build` command
+(which needs one). The predicate has to be per-COMMAND. It cannot be applied by
+eye over a 700-line cmake module, which is what makes it a gate rather than
+three fixes.
+
+Measured with `git ls-files '*.cmake' '*CMakeLists.txt'` + paren-balanced block
+extraction, COMMAND sections only: three cargo commands, two without a depfile.
+
+## Evidence, established WITHOUT a wipe
+
+The NuttX seam, on the existing build dir (hard-linked to scratch; nothing in
+the shared tree was built or wiped). Another agent had edited
+`packages/core/nros-serdes/src/lib.rs` at 21:34 against an ELF built at 02:47,
+so the touch was performed by the world:
+
+| graph | `ninja -n -d explain nros-nuttx-ffi-out/nros-nuttx-ffi` |
+| --- | --- |
+| as shipped (`DEPFILE`) | `output … older than most recent input packages/core/nros-serdes/src/lib.rs` → rebuilds |
+| same graph, `depfile`/`deps` stripped | nothing to do — the museum binary |
+
+The generated-interfaces seam, on a native `cpp/talker` configured and built
+from the fixed tree:
+
+* `ninja -t query …/libnano_ros_cpp_ffi_std_msgs.a` before the fix: inputs are
+  the generated `.rs`, `Cargo.toml`, `src/lib.rs`. Cargo's own `.d` for that
+  same archive lists nine `packages/core/nros-serdes/src/*.rs`.
+* After: 72 deps recorded, 9 of them nros-serdes. Touching
+  `nros-serdes/src/cdr.rs` explains the rebuild by that exact file; the same
+  graph with `depfile`/`deps` stripped says `ninja: no work to do`.
+* A real content change (`NROS_0820_EDGE_PROBE` appended to
+  `nros-serdes/src/lib.rs`) moved the archive `46177a22…` → `43d1ed8c…` and the
+  symbol is in it — an incremental build, no wipe.
+
+## Notes for whoever meets this class again
+
+* **An mtime freshness check cannot detect the class it is invoked against.** A
+  museum binary is NEWER than its sources while holding older code — there is no
+  edge, so nothing moves the mtime. An earlier revision of this issue argued
+  "not a stale fixture" from mtimes and built a whole wrong root cause on it (a
+  "domain mismatch", a comparison to issue 0801, a suspected sentinel bug). The
+  sentinel ambiguity is real and lives on as [[issue-0972]]; it is not what
+  broke this test.
+* **An ABSENT signal is not evidence until the instrument is shown to work.**
+  Four readings here nearly produced wrong root causes: `nros_log` output goes
+  nowhere on this image (no sink installed), a probe string absent from the ELF
+  IS the museum binary (`strings <elf> | grep`), with no router running
+  `nros_support_init` returns -4 so entity creation is never reached, and an
+  `#[allow(dead_code)] const` probe is eliminated before it reaches the binary
+  (use `#[used]` + `#[unsafe(no_mangle)]`).
+* **`--release` is not a neutral default on NuttX.** `NUTTX_RUST_PROFILE` is
+  `nros-minsizerel` because at `lto = "off"` a cross-CGU miscompile corrupts
+  std's `lang_start` closure and the image reboots before `main` with no
+  console output (phase-177.8.c). Cargo's built-in `release` IS `lto = off`.
+* **A residual, not fixed here:** cargo's dep-info does not list `Cargo.lock`,
+  so a lockfile-only dependency bump does not retrigger these commands. It is
+  cargo's own granularity and corrosion shares it; nothing here depends on it
+  today, and widening the watch set is exactly what phase-424 warns against.
+
+## The record this issue accumulated while open
+
+Everything below is the issue as it stood before this commit, kept whole
+rather than summarised — including the `READ FIRST` section another
+session added on 2026-09-05, which records that the 2026-08-27 depfile fix
+was silently neutralised by issue 0805 for six days and re-fixed by
+retargeting the depfile. That is a different defect in the same seam from
+the two commands this commit gives an edge to, and it is not restated
+above.
 
 ## READ FIRST — the 2026-08-27 fix was live for six days (phase-424, 2026-09-05)
 

--- a/docs/roadmap/phase-424-build-graph-freshness-truth.md
+++ b/docs/roadmap/phase-424-build-graph-freshness-truth.md
@@ -46,7 +46,7 @@ they all rest on is built on build-system internals nobody supports.
 
 | issue | layer | shape |
 | --- | --- | --- |
-| [#0820](../issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md) | cmake seam | passes after `rm -rf` on unmodified sources — no rebuild edge |
+| ~~[#0820](../issues/archived/0820-riscv-nuttx-c-talker-no-runtime-delivery.md)~~ | cmake seam | RESOLVED — a cargo custom command with no `DEPFILE` had no edge on the Rust it compiles. Three such commands exist; two were still missing one. Gated by `check-cargo-custom-command-depfile`, which WIDENS no watch set: the depfile is the graph cargo already computes, so 0835 is untouched |
 | [#0835](../issues/0835-fixture-staleness-probe-families-restale-each-other.md) | fixtures | the cmake and rust families re-stale each other — **oscillation fixed + gated 2026-09-04**; open for the duplicated ThreadX corrosion group, which is wasted disk, not staleness |
 | [#0945](../issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | cargo | the shared-cargo-dir campaign rests on five unsupported build-system assumptions |
 | [#1002](../issues/archived/1002-a-derived-knob-needs-three-configures-not-two.md) | cmake | RESOLVED — three is the chain's depth, not a defect; the defect was a bound counting the build dir's lifetime |

--- a/just/check.just
+++ b/just/check.just
@@ -140,6 +140,7 @@ fast-serial: \
     capability-flavour-guards \
     capability-slot-counts \
     cargo-config-tracked \
+    cargo-custom-command-depfile \
     cargo-locked \
     cargo-profile-mirror \
     cargo-target-spelling \
@@ -4437,6 +4438,27 @@ artifact-identity-budget:
 [private]
 cargo-target-spelling:
     @bash packages/testing/nros-tests/tests/cargo_target_spelling.sh
+
+# issue 0820 — a cmake custom command that RUNS cargo must carry a `DEPFILE`.
+#
+# `add_custom_command(OUTPUT ...)` rebuilds only when an input it NAMES is newer
+# than the output, and cargo's inputs are a graph over the workspace. Every
+# hand-written `DEPENDS` here approximated that graph and every one of them was
+# wrong the same way — it named the crate's own files and no nano-ros Rust — so
+# the artifact came out NEWER than its sources holding older code, and nothing
+# in the graph could notice. That is the museum binary 0820 reported, and it is
+# indistinguishable from a runtime bug until someone wipes the directory.
+#
+# Cargo already writes the exact answer beside the artifact (`<artifact>.d`,
+# Makefile format), which is the shape `DEPFILE` consumes. Three commands in
+# this tree run cargo; two of them had no depfile when this gate landed, and
+# both survived the issue's own 2026-09-01 sweep because that sweep classified
+# FILES ("codegen") rather than commands. Hence a per-command predicate.
+#
+# Buildless — pure source analysis over the tracked cmake files, milliseconds.
+[private]
+cargo-custom-command-depfile:
+    @python3 scripts/check-cargo-custom-command-depfile.py
 
 # issue 0516 — a COMMENTED-OUT element in a package.xml must not read as a
 # declaration. cmake has no XML parser, so every reader here regexes raw text;

--- a/scripts/check-cargo-custom-command-depfile.py
+++ b/scripts/check-cargo-custom-command-depfile.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""A cmake custom command that runs `cargo` must carry a `DEPFILE`.
+
+Issue 0820. `add_custom_command(OUTPUT ...)` rebuilds only when one of the
+inputs it NAMES is newer than the output. Cargo's inputs are a graph over the
+whole workspace, so any hand-written `DEPENDS` is an approximation of it — and
+every approximation in this tree has been wrong in the same direction: it named
+the crate's own files and no nano-ros Rust at all. The result is a museum
+binary: an artifact NEWER than its sources, containing older code, with nothing
+in the build graph able to notice.
+
+Cargo already publishes the exact answer. It writes a Makefile-format dep-info
+file beside the artifact (`<artifact>.d`, absolute paths, one target), and cmake
+consumes exactly that shape via `DEPFILE`. A missing depfile on the first build
+is a warning, not an error, so the edge is safe from the very first configure.
+
+## Why a gate and not three fixes
+
+Three custom commands in this tree invoke cargo. When this gate was written,
+TWO of them had no depfile:
+
+* `packages/api/nros-c/cmake/nros-nuttx.cmake` — the reported site. Fixed
+  2026-08-27; a NuttX C example kept the previous build's Rust for as long as
+  nobody wiped the directory, and the test that caught it failed at its full
+  90 s timeout with no message that pointed anywhere near the build graph.
+* `cmake/NanoRosGenerateInterfaces.cmake` — the generated message C++ FFI
+  staticlib. Its `DEPENDS` named the generated `.rs`, the crate manifest and
+  the crate's `lib.rs`. Cargo's own dep-info for that same archive lists
+  `packages/core/nros-serdes/src/{cdr,lib,primitives,schema,traits}.rs`
+  (measured on a built tree) — the CDR serializer, with no edge.
+* `zephyr/cmake/nros_generate_interfaces.cmake` — the same command, narrower
+  still: not even the generated sources were named.
+
+The 2026-09-01 sweep on this issue looked for FILES containing both
+`add_custom_command` and `cargo`, and both generators were in its output — but
+they were classified by what the file mostly does ("codegen") rather than by
+what each command does, so the two survivors read as legitimate. That is the
+reason this is a gate: the predicate has to be per-COMMAND, and a person
+reading a 700-line cmake module will not apply it per-command by eye.
+
+## What is flagged
+
+An `add_custom_command(...)` block with a `COMMAND` argument list containing the
+bare token `cargo` (the program), and no `DEPFILE` keyword.
+
+Deliberately NOT flagged:
+
+* `add_custom_target(... COMMAND cargo ...)` — a custom target has no output and
+  always runs, so it needs no edge. The hazard is specific to an `OUTPUT` whose
+  freshness is decided by mtime.
+* A command that merely mentions a cargo-shaped path or target name —
+  `${CMAKE_BINARY_DIR}/cargo`, `cargo-build_nros_c` in `DEPENDS`, a
+  `_NROS_SHARED_CARGO_*` variable. Those do not invoke cargo, and the three of
+  them in this tree are why the predicate reads COMMAND sections only.
+
+If a cargo command ever legitimately cannot carry a depfile, extend this gate
+with the case and the reason rather than silencing it at the call site — a
+per-site exemption is how a rule stops describing the tree.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Keywords that end a COMMAND argument list inside add_custom_command().
+_KEYWORDS = {
+    "APPEND", "BYPRODUCTS", "COMMAND", "COMMAND_EXPAND_LISTS", "COMMENT",
+    "CODEGEN", "DEPENDS", "DEPENDS_EXPLICIT_ONLY", "DEPFILE", "IMPLICIT_DEPENDS",
+    "JOB_POOL", "JOB_SERVER_AWARE", "MAIN_DEPENDENCY", "OUTPUT", "PRE_BUILD",
+    "PRE_LINK", "POST_BUILD", "TARGET", "USES_TERMINAL", "VERBATIM",
+    "WORKING_DIRECTORY",
+}
+
+# The cargo PROGRAM: a bare `cargo` token. The lookbehind rejects a path
+# (`${CMAKE_BINARY_DIR}/cargo`) or a variable tail; the lookahead rejects a
+# target name (`cargo-build_nros_c`, `cargo_target_dir`).
+_CARGO = re.compile(r"(?<![\w/.$-])cargo(?![\w.-])")
+
+_STRIP_COMMENTS = re.compile(r"(?m)#.*$")
+
+
+def _blocks(text: str):
+    """Yield (line_no, block_text) for every add_custom_command(...) call."""
+    for m in re.finditer(r"\badd_custom_command\s*\(", text):
+        i, depth = m.end(), 1
+        while i < len(text) and depth:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        yield text[: m.start()].count("\n") + 1, text[m.start(): i]
+
+
+def _parse(block: str) -> tuple[list[str], set[str]]:
+    """(COMMAND argument texts, keywords actually present) for one block.
+
+    Comments are stripped first: a commented-out `COMMAND cargo` is not a
+    command, and a commented-out `DEPFILE` is not an edge.
+    """
+    body = _STRIP_COMMENTS.sub("", block)
+    seen: set[str] = set()
+    sections: list[str] = []
+    cur: list[str] | None = None
+    for tok in re.split(r"(\s+)", body):
+        bare = tok.strip().strip('"')
+        if bare in _KEYWORDS:
+            seen.add(bare)
+            if cur is not None:
+                sections.append(" ".join(cur))
+            cur = [] if bare == "COMMAND" else None
+            continue
+        if cur is not None and tok.strip():
+            cur.append(tok)
+    if cur is not None:
+        sections.append(" ".join(cur))
+    return sections, seen
+
+
+def scan(text: str) -> list[int]:
+    """Line numbers of add_custom_command blocks that run cargo without DEPFILE."""
+    bad = []
+    for line, block in _blocks(text):
+        commands, keywords = _parse(block)
+        if not any(_CARGO.search(c) for c in commands):
+            continue
+        if "DEPFILE" in keywords:
+            continue
+        bad.append(line)
+    return bad
+
+
+def cmake_files() -> list[Path]:
+    """Tracked cmake sources, via the git index (issue 0721 — never a walk)."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "*.cmake", "*CMakeLists.txt", "*.cmake.in"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout
+    return [ROOT / p for p in out.split("\0") if p]
+
+
+SELF_TESTS: list[tuple[str, str, int]] = [
+    ("cargo command, no depfile", 'add_custom_command(OUTPUT "a" COMMAND cargo build)\n', 1),
+    ("cargo command with depfile", 'add_custom_command(OUTPUT "a" COMMAND cargo build DEPFILE "a.d")\n', 0),
+    ("cargo behind a cmake -E env wrapper",
+     'add_custom_command(OUTPUT "a" COMMAND ${CMAKE_COMMAND} -E env X=1 cargo ${_args})\n', 1),
+    ("cargo with a +toolchain prefix",
+     'add_custom_command(OUTPUT "a" COMMAND cargo +${Rust_TOOLCHAIN} build)\n', 1),
+    ("a path that ENDS in cargo is not the program",
+     'add_custom_command(OUTPUT "a" COMMAND bash s.sh --link "${CMAKE_BINARY_DIR}/cargo")\n', 0),
+    ("a corrosion target named cargo-* in DEPENDS is not the program",
+     'add_custom_command(OUTPUT "a" COMMAND bash s.sh DEPENDS cargo-build_nros_c)\n', 0),
+    ("an uppercase CARGO variable is not the program",
+     'add_custom_command(OUTPUT "a" COMMAND bash "${_NROS_SHARED_CARGO_CHECK_SH}")\n', 0),
+    ("add_custom_target needs no edge",
+     'add_custom_target(t COMMAND cargo build)\n', 0),
+    ("a commented-out cargo command is not a command",
+     'add_custom_command(OUTPUT "a"\n  # COMMAND cargo build\n  COMMAND bash s.sh)\n', 0),
+    ("a DEPFILE in a comment does not count",
+     'add_custom_command(OUTPUT "a" COMMAND cargo build\n  # DEPFILE "a.d"\n)\n', 1),
+    ("two COMMANDs, cargo second, no depfile",
+     'add_custom_command(OUTPUT "a" COMMAND bash s.sh COMMAND cargo build)\n', 1),
+    ("nested parens do not end the block early",
+     'add_custom_command(OUTPUT "a" COMMAND cargo build $<TARGET_FILE:t>)\n', 1),
+]
+
+
+def self_test(quiet: bool = False) -> int:
+    bad = 0
+    for name, src, want in SELF_TESTS:
+        got = len(scan(src))
+        if got != want:
+            print(f"  SELF-TEST FAIL: {name}: expected {want} hit(s), got {got}")
+            bad += 1
+    if bad:
+        print(f"check-cargo-custom-command-depfile: {bad} self-test(s) failed")
+        return 1
+    if not quiet:
+        print(f"check-cargo-custom-command-depfile self-test: {len(SELF_TESTS)} case(s) OK")
+    return 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    # Always, not only behind the flag: a negative control nobody runs decays
+    # into a comment, and this rule's whole job is to fire.
+    if self_test(quiet=True):
+        return 1
+
+    findings = []
+    for path in cmake_files():
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in scan(text):
+            findings.append((path.relative_to(ROOT), line))
+
+    if findings:
+        print("check-cargo-custom-command-depfile: cargo command(s) with no rebuild edge\n")
+        for rel, line in findings:
+            print(f"  {rel}:{line}: add_custom_command runs `cargo` with no DEPFILE.")
+            print("      Its DEPENDS list is a hand-maintained guess at cargo's input")
+            print("      graph, and cmake will call the OUTPUT fresh whenever that")
+            print("      guess is incomplete — a museum binary (issue 0820).")
+            print("      Cargo writes `<artifact>.d` beside the artifact; point")
+            print("      DEPFILE at it, derived from the same variable that spells")
+            print("      the OUTPUT so the two cannot drift.\n")
+        return 1
+
+    print("check-cargo-custom-command-depfile OK — every cargo custom command has a DEPFILE.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr/cmake/nros_generate_interfaces.cmake
+++ b/zephyr/cmake/nros_generate_interfaces.cmake
@@ -434,6 +434,9 @@ function(nros_generate_interfaces target)
       # RUST_TARGET, so a missing `nros_detect_rust_target()` fails loudly
       # rather than writing to a path this line would not have predicted.
       set(_ffi_lib "${_ffi_target_dir}/${NROS_RUST_TARGET}/${_nros_cargo_profile_dir}/libnano_ros_cpp_ffi_${target}.a")
+      # issue 0820 — cargo writes its dep-info beside the artifact, same
+      # basename, `.d`. Derived from `_ffi_lib` so the two cannot drift.
+      string(REGEX REPLACE "\\.a$" ".d" _ffi_dep_file "${_ffi_lib}")
 
       # Generate Cargo.toml from template
       set(FFI_TARGET "${target}")
@@ -507,10 +510,16 @@ targets = [\"${NROS_RUST_TARGET}\"]
       if(NOT _NROS_FFI_ENV STREQUAL "")
         set(_ffi_env ${CMAKE_COMMAND} -E env ${_NROS_FFI_ENV} ${NROS_BOARD_FACTS_ENV})
       endif()
+      # issue 0820 — the sibling of the generic generator's block, and the
+      # narrower of the two: DEPENDS here names only the crate's manifest and
+      # `lib.rs`, so neither the GENERATED message sources nor any nano-ros
+      # Rust crate had an edge on this archive. The DEPFILE covers both, from
+      # the graph cargo already computes.
       add_custom_command(
         OUTPUT "${_ffi_lib}"
         COMMAND ${_ffi_env} cargo ${_cargo_ffi_args}
         DEPENDS "${_ffi_crate_dir}/Cargo.toml" "${_ffi_crate_src}/lib.rs"
+        DEPFILE "${_ffi_dep_file}"
         WORKING_DIRECTORY "${_ffi_crate_dir}"
         COMMENT "Building Rust FFI glue for ${target} C++ bindings"
         VERBATIM


### PR DESCRIPTION
Phase-424. The reported site was **already fixed** — `6d363f5cc` (2026-08-27) gave
`nros-c/cmake/nros-nuttx.cmake` a `DEPFILE`. The issue's "fails at 90 s, passes
after `rm -rf`" text predates it.

**But the class was not closed, and the issue's own sweep is why.** That sweep
matched *files* containing both `add_custom_command` and `cargo`, then classified
each file by what it mostly does. Both message-interface generators were **in that
output**, labelled "codegen" — and each file contains a codegen command
(legitimately no depfile) *and* a `cargo build` command (which needs one).
**Per-COMMAND is the only predicate that works.**

Re-swept per command — three cargo commands in the tree, **two with no edge**:

| site | state |
| --- | --- |
| `packages/api/nros-c/cmake/nros-nuttx.cmake:382` | OK (`6d363f5cc`) |
| `cmake/NanoRosGenerateInterfaces.cmake:585` | **MISS** |
| `zephyr/cmake/nros_generate_interfaces.cmake:510` | **MISS** |

Both build the generated message C++ FFI staticlib. `DEPENDS` named the crate's
own files only — Zephyr's not even the generated `.rs`. Cargo's own dep-info for
that same archive lists **nine `packages/core/nros-serdes/src/*.rs`**, so editing
the CDR serializer left every generated message staticlib holding the previous
build's code with a fresh mtime. A museum archive, on the crate that produces the
wire format.

## Established without a wipe, and without building in the shared tree

CLAUDE.md is explicit that `rm -rf` destroys the one reproduction you needed. The
existing riscv reproduction dir is intact. A hard-linked copy went to scratch, the
`RERUN_CMAKE` and codegen edges were neutralised so the ffi edge could be read in
isolation, and the "touch" was performed by the world — another agent had edited
`nros-serdes/src/lib.rs` at 21:34 against an ELF built at 02:47:

- shipped graph (`DEPFILE`): `output nros-nuttx-ffi older than most recent input
  …/nros-serdes/src/lib.rs` → rebuilds
- same graph with `depfile`/`deps` stripped: **`ninja: no work to do`** — the
  museum binary

## The fix, proved by touch-and-relink

`DEPFILE` on both commands, pointed at the `<artifact>.d` cargo already writes,
derived from `_ffi_lib` by regex so the two spellings cannot drift.

End-to-end on a native `cpp/talker` configured and built from the fixed tree:
`ninja -t deps` → 72 recorded deps, 9 of them nros-serdes; `touch cdr.rs` →
rebuild explained by that exact file; **same graph with `depfile`/`deps` stripped →
`ninja: no work to do`**; a real content change moved the archive hash and the
symbol appears in the `.a`, incrementally.

## The gate, and the issue-0196 check

A gate for the 0475 class exists — `check-cmake-support-library` — but it covers
`nano_ros_support_library()`'s `LINK_DEPENDS`, a different construction. Nothing
covered the cargo-custom-command shape. The issue declined to write one on the
grounds that one instance cannot support a rule; with three instances and a crisp
per-command predicate, that reasoning no longer holds.

Negative control against reality: with the fix stashed it reports exactly the two
sites and exits 1. It deliberately does not flag `add_custom_target(... COMMAND
cargo ...)` (no output, always runs) nor commands that merely mention a
cargo-shaped path.

**It widens no watch set** — the depfile *is* the graph cargo already computes — so
phase-424's #0835 warning does not apply. That constraint was checked, not assumed.

## Not settled, and one thing disturbed

- **The Zephyr site is not build-verified.** Its edit is textually identical to the
  generic one proved end-to-end, and the gate covers it, but a west + SDK build was
  more than this warranted. Worth a nightly zephyr cpp cell.
- **Residual, deliberately unfixed:** cargo's dep-info omits `Cargo.lock`, so a
  lockfile-only bump retriggers none of these commands. That is cargo's
  granularity, corrosion shares it, and widening past the depfile is exactly what
  this phase warns against.
- **One shared build dir disturbed:** `ninja -t query` in
  `examples/native/cpp/service-client/build-xrce` printed *"build log version is
  too old; starting over"* and discarded that dir's `.ninja_log`. That leaf will
  rebuild from scratch next use — minutes. Nothing else was written; the riscv
  reproduction dir is byte-for-byte intact.

`just check fast`: 205 gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
