### PR TITLE
docs(RFC-0004, #1063): the middleware's configuration is the middleware's own

### DIFF
--- a/docs/design/0004-configuration-and-transports.md
+++ b/docs/design/0004-configuration-and-transports.md
@@ -3,7 +3,7 @@ rfc: 0004
 title: "Configuration model: language-agnostic config across single-node and workspace"
 status: Stable
 since: 2026-05
-last-reviewed: 2026-06
+last-reviewed: 2026-09
 implements-tracked-by: [phase-212, phase-227]
 supersedes: []
 superseded-by: null
@@ -288,7 +288,12 @@ Per-kind field rules (validated by `PlanBuildOptions::validate_transports`):
 | all | `id`, `rmw`, `locator` |
 
 The `id` makes a transport first-class and addressable, and disambiguates two
-transports that share an `rmw`. `interfaces` (a list) multi-homes one session
+transports that share an `rmw`.
+
+> **AMENDED 2026-09-04 — `interface` / `interfaces` are RETRACTED.** See the
+> amendment below. The rest of this section stands; those two fields do not.
+
+*Retracted text:* `interfaces` (a list) multi-homes one session
 over several NICs (one merged discovery graph) — distinct from two `[[transport]]`
 entries (two *separate* sessions).
 
@@ -303,8 +308,105 @@ entries (two *separate* sessions).
 
 A–C bind by `rmw`; only D (two separate sessions of the same backend,
 intentionally not merged) needs `create_node_on`-by-`id` (Phase 172.K.5).
-Multi-homing maps per backend (zenoh → listen/connect per NIC + scouting
+
+> **AMENDED 2026-09-04.** Cases **B** and **C** are retracted along with the
+> `interfaces` field; **A** and **D** stand unchanged. The per-backend mapping
+> sentence below is retracted in full — see the amendment.
+
+*Retracted text:* Multi-homing maps per backend (zenoh → listen/connect per NIC + scouting
 interface; Cyclone → `<Interfaces>`; Fast DDS → whitelist).
+
+## Amendment (2026-09-04) — the middleware's configuration is the middleware's own
+
+**Retracts:** the `interface` / `interfaces` transport fields, cases **B** and
+**C** of the two-axes table, and the per-backend multi-homing mapping.
+**Tracked by:** [phase-206](../roadmap/phase-206-multi-homing-transport-interfaces.md).
+**Sibling reading:** RFC-0087 (a package is a `package.xml`) applies the same
+"do not invent a second vocabulary" move to provider identity.
+
+### The principle
+
+> **nano-ros transports the user's backend config VERBATIM; it does not
+> re-model it.** The board brings the devices up before ROS exists; the
+> middleware is configured in the middleware's own language, parsed by the
+> middleware's own parser.
+
+This is what ROS 2 does, and it is why a ROS 2 user never writes an interface
+list into a node: they set `CYCLONEDDS_URI`, or hand zenoh a config, naming an
+IP or a device. The application code knows nothing about NICs.
+
+### Why the retracted design could not work
+
+`interfaces = ["eth0", "eth1"]` requires nano-ros to own a second vocabulary for
+NICs, and there is no vocabulary that spans the targets:
+
+| platform | how a NIC is named |
+| --- | --- |
+| POSIX | `getifaddrs` / `ifa_name` — real names, resolved at run time by the HOST |
+| Zephyr | `net_if_get_default()` — **cannot be named at all** |
+| smoltcp | exactly one `Interface`, **no names** |
+| lwIP / FreeRTOS / esp-idf / ThreadX | the platform `iface` argument is accepted and ignored; the ports say so in their own source |
+
+A portable declaration naming `eth0` is issue 0623's shape one layer up — a
+value authored in one vocabulary and resolved in another, with nothing checking
+they agree. Every fix for that needs a resolver, a gate, and a per-platform
+story only Linux can satisfy.
+
+### The feature already exists, in the backend
+
+Measured 2026-09-04 in the CycloneDDS we link (`third-party/dds/cyclonedds`,
+0.10.5, `src/core/ddsi/include/dds/ddsi/ddsi_cfgelems.h:79-88`):
+
+```c
+GROUP("NetworkInterface", NULL, network_interface_attributes, INT_MAX,
+  MEMBER(network_interfaces), ...
+```
+
+`INT_MAX` multiplicity — an unbounded `<NetworkInterface>` list, each with
+`name` / `address` / `autodetermine` / `priority`, and the group's own
+description: *"Multiple interfaces can be specified with an assigned priority.
+The list in use will be sorted by priority."* Multi-homing is therefore not a
+nano-ros feature at all; it is an element in a config the user writes.
+
+### What each backend's "own language" IS — and it differs
+
+The verbatim unit is **not the same shape for both backends**, because the
+backends are not the same shape. This is the part most likely to be
+mis-generalised, so it is written down:
+
+| backend | native config surface | how nano-ros carries it |
+| --- | --- | --- |
+| **CycloneDDS** | an XML **document**, and `dds_create_domain` parses inline XML itself (`ddsrt_xmlp_new_string`) | hand the file's bytes over as one comma token; **nano-ros parses no XML** |
+| **zenoh-pico** | **no document format exists** — the API is `z_config_default` / `zp_config_insert(config, uint8_t key, const char *value)` over ~23 numbered keys | a flat `key = value` list whose key NAMES are upstream's; each pair goes to `zp_config_insert` |
+
+**Cyclone composes; nano-ros must stop replacing.** `dds_create_domain` accepts
+a comma-separated list of sources and merges every token into one `cfgst`
+(`ddsi_config.c:2538-2570`). nano-ros selects exactly one with a three-way
+ternary, so a user config **silently discards the baked baseline** — including
+`<Threads>` stack sizes that are load-bearing on FreeRTOS and ThreadX.
+
+**zenoh-pico's lack of a config file is a position, not a gap.** Upstream's
+manual defines three categories and names run-time options — `zp_config_insert`
+— as *"the primary configuration method"*. JSON5/YAML config files are
+documented for **`zenohd`**, the router; the zenoh-pico manual does not mention
+a file format at all. **nano-ros must not add a JSON5 parser**: that would mean
+owning a parser for a format its own backend does not speak, which is this
+amendment's mistake wearing a friendlier hat.
+
+### Consequences for this RFC's model
+
+* `[[transport]]` keeps `id`, `rmw`, `locator`, and the device fields that name
+  hardware (`device`, `baudrate`, `ip`, `mac`, `gateway`, `ssid`, `password`).
+  It does **not** grow transport tuning: `system.toml` says what the system
+  IS — nodes, topics, capabilities — and the middleware's tuning lives in the
+  middleware's own config. That is the ROS 2 split.
+* `Executor::open_multi([SessionSpec…])` stays exactly as it is: one session per
+  spec, **segregate**, which is phase-172 K.5. There is no "merge" primitive to
+  build, because merging NICs is something Cyclone does inside one participant
+  when its config says so.
+* `rmw_session_options_t` does not grow a list field. It is
+  `{u8 localhost_only; u8 _reserved[7]; const char *enclave;}` and nothing in
+  the tree passes it non-NULL; config does not need it.
 
 ### Runtime mapping & binding
 

--- a/docs/issues/1063-netstack-declared-validated-and-unread.md
+++ b/docs/issues/1063-netstack-declared-validated-and-unread.md
@@ -1,0 +1,101 @@
+---
+id: 1063
+title: "`netstack` is declared by users, validated against the board, emitted as `NROS_NETSTACK` — and read by nothing"
+status: open
+type: bug
+area: build, config
+severity: medium
+found: 2026-09-04
+related: [0941, 0940, 0949, 0842, phase-349, phase-351, phase-206]
+---
+
+# A user-facing knob whose value reaches no build
+
+## The chain, and where it stops
+
+1. A user declares `netstack` in a site-config `[deploy.<target>.nros]` block.
+   **Twelve such blocks across seven bringups in six workspaces**, and issue
+   0941 records that *"every one of them declaring a netstack"*.
+2. `BoardDescriptor::resolve_netstack`
+   (`packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs`)
+   validates the request against the board's `supported_netstacks` and returns
+   a typed `NetstackError` naming what IS available.
+3. `nros board-facts` emits the result as `NROS_NETSTACK`
+   (`packages/cli/nros-cli-core/src/cmd/board_facts.rs:245`).
+4. **Nothing reads it.** Tree-wide, the only non-test occurrences are the
+   writer and a COMMENT in `cmake/NanoRosWorkspace.cmake:258`. Four tests in
+   `board_facts.rs` assert the emission; none asserts an effect.
+
+So a user states a preference, the tool validates it and reports success, and
+the value changes nothing about the image.
+
+## Why this is not simply "delete the dead variable"
+
+**The validation half is real and worth keeping.** `resolve_netstack` is the
+seam that knows both the board's domain and the user's request, and phase-351 W4
+built it deliberately so an unsupported pair fails there rather than as a link
+error inside a stack nobody selected. Deleting the emission must not delete that.
+
+**But the choice is degenerate today.** Measured across
+`packages/boards/*/nros-board.toml` on 2026-09-04:
+
+| `supported_netstacks` | boards |
+| --- | ---: |
+| `[]` | 5 |
+| `["lwip"]` | 3 |
+| `["smoltcp"]` | 2 |
+| `["netxduo"]` | 2 |
+
+**No board declares more than one.** So `resolve_netstack` can never *choose*:
+it either passes through the single declared value or rejects a request that
+disagrees with it. The emitted value is always exactly `supported_netstacks[0]`
+— information the descriptor already carries and the board crate already
+encodes in its features.
+
+**And it interacts with an open issue.** 0941 (`nros_resolve_board_facts` fails
+SOFT) treats a missing `NROS_NETSTACK` as one of the observable symptoms that
+board facts were never delivered. Removing the emission without settling 0941
+would remove a signal that issue currently relies on.
+
+## The class
+
+This is the shape phase-349 named while flagging this very variable:
+
+> `NROS_NETSTACK` is emitted too … and **nothing reads it** — the same
+> declared-but-unread shape, now with a writer and no consumer rather than a
+> reader and no writer.
+
+Its sibling is `BoardTransportConfig::set_interfaces`, which phase-206 W5
+deletes. Two live instances of one class; this is the one that is *harder*,
+because unlike `set_interfaces` it has real users who believe it works.
+
+## Options, none of them free
+
+**A. Give it a consumer.** Something in the build selects or asserts the stack
+from `NROS_NETSTACK`. Honest only if there is a decision to make — and with
+≤1 netstack per board there is not, until a board declares two.
+
+**B. Delete the emission, keep the validation.** Smallest change, and correct
+under today's data. Costs: four tests to update, and 0941 loses a symptom.
+Should carry a note that a board declaring two netstacks re-opens the question —
+and that the emission then returns **with a consumer in the same commit**, not
+before.
+
+**C. Refuse the knob.** If the user's `netstack` can only ever restate what the
+board already declares, the most ROS-2-like answer is that the user does not
+name a netstack at all — the board does, the way the OS owns the device. This
+is the largest change (it removes a user-facing key) and belongs to phase-351,
+whose W4 built the validation.
+
+**Recommendation: B now, with the note, and C as the question for phase-351.**
+A is only worth building the day a board has two stacks.
+
+## Not covered
+
+* Whether any out-of-tree board build consumes `NROS_NETSTACK`. The variable is
+  part of `nros board-facts` output, which is a CLI surface; nothing in-tree
+  documents it as a contract, but absence of an in-tree reader is not proof of
+  absence of an out-of-tree one.
+* Whether the twelve site-config blocks 0941 found would behave differently
+  under any of the three options — they are currently unreachable for a
+  different reason, which 0941 owns.

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -6514,6 +6514,7 @@ rustflags = [
             crate_path: None,
             board_features: vec![],
             capability_features: vec![],
+            priority_plan: None,
             cargo_config: cargo_config.map(str::to_string),
             entry: None,
             target_contains: None,

--- a/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/board_descriptor.rs
@@ -190,7 +190,19 @@ impl BoardCapabilities {
 
 /// One board profile. Mirrors the old hardcoded `PlatformProfile` +
 /// `BoardEntry`, but every field is owned data read from `nros-board.toml`.
+/// RFC-0049 promised this: "Unknown keys fail loud with the valid-key list
+/// (`deny_unknown_fields`, the RFC-0033 precedent)" (RFC-0049 §"Schema"). It
+/// shipped without it, so a typo'd board key was silently ignored by this
+/// reader AND by `BoardKnobsFile`, which `#[serde(flatten)]`s the remainder
+/// into a discarded `_rest`. A board descriptor is a hardware SSoT read by
+/// four different consumers; a key nobody reads reads exactly like a key that
+/// works.
+///
+/// `priority_plan` below is the reason this could not simply be switched on:
+/// six boards declare `[board.priority_plan]` and no field modelled it, so a
+/// naive `deny_unknown_fields` would have rejected every one of them.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BoardDescriptor {
     /// Board name + accepted aliases (the values a user passes as `board`).
     pub names: Vec<String>,
@@ -285,6 +297,18 @@ pub struct BoardDescriptor {
     /// sends the next reader to edit the wrong descriptor.
     #[serde(skip)]
     pub source: Option<String>,
+    /// `[board.priority_plan]` — ACKNOWLEDGED here, interpreted elsewhere.
+    ///
+    /// The tier/transport priority plan (RFC-0049; `linux/nros-board.toml`
+    /// declares `reserved.transport = [90, 99]` for zenoh-pico's read and
+    /// lease tasks) is consumed by `check-tier-priority-plan` and by
+    /// `nros-platform-config`, not by this reader. It is modelled as an opaque
+    /// value ON PURPOSE: `deny_unknown_fields` above must not mean "every
+    /// consumer's schema is restated here", which would make this struct the
+    /// union of four readers and guarantee drift. Declaring it says "this key
+    /// is real and someone else owns it"; omitting it would have said "typo".
+    #[serde(default)]
+    pub priority_plan: Option<toml::Value>,
 }
 
 /// `[board.cmake]` — CMake toolchain facts for the ament-shape preset flow.
@@ -408,7 +432,11 @@ fn path_for_template(path: &Path) -> String {
         .replace('"', "\\\"")
 }
 
+/// `deny_unknown_fields` here too: the file level is where a whole MISPLACED
+/// table lands (a `[bard]` typo, or a `[knobs]` written at top level instead of
+/// under the board). Without it the file parses and the table vanishes.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct BoardFile {
     #[serde(default, rename = "board")]
     boards: Vec<BoardDescriptor>,
@@ -1328,6 +1356,7 @@ signature = "#[nros_board_stm32f4::entry]\nfn main() -> !"
             crate_path: None,
             board_features: vec![],
             capability_features: vec![],
+            priority_plan: None,
             cargo_config: Some("inc = \"${workspace}/third-party/x\"".into()),
             entry: None,
             target_contains: None,
@@ -1550,6 +1579,7 @@ signature = "#[nros_board_stm32f4::entry]\nfn main() -> !"
             crate_path: None,
             board_features: vec![],
             capability_features: vec![],
+            priority_plan: None,
             cargo_config: None,
             entry: None,
             target_contains: None,
@@ -1700,5 +1730,49 @@ entry_kind = "zephyr-staticlib"
             .resolve("native_sim/native/64", "")
             .expect("the zephyr board");
         assert_eq!(zephyr.west_board, None);
+    }
+
+    /// `deny_unknown_fields` is only worth having if it is exercised against
+    /// the REAL descriptors, not a fixture. Six of them declare
+    /// `[board.priority_plan]`, which no field modelled until this change — so
+    /// a naive `deny_unknown_fields` would have rejected them and this test is
+    /// what says so.
+    #[test]
+    fn every_in_tree_descriptor_parses_under_deny_unknown_fields() {
+        let root = repo_root_for_tests();
+        let cat = BoardCatalog::load_with_extra(&root, &[]).expect(
+            "every packages/boards/*/nros-board.toml must parse; an unknown-field              error here names the key and the file",
+        );
+        assert!(
+            cat.descriptors.len() >= 12,
+            "expected the in-tree board descriptors, found {}",
+            cat.descriptors.len()
+        );
+        assert!(
+            cat.descriptors.iter().any(|d| d.priority_plan.is_some()),
+            "at least one in-tree board declares [board.priority_plan]; if none              does, this test has stopped covering the case it exists for"
+        );
+    }
+
+    /// The other half of the same claim: a key nobody reads must now FAIL, and
+    /// fail naming itself. Before this change it parsed and vanished.
+    #[test]
+    fn an_unknown_board_key_is_rejected_and_names_itself() {
+        let err = toml::from_str::<BoardFile>(
+            "[[board]]\n\
+             names = [\"demo\"]\n\
+             platform = \"posix\"\n\
+             toolchain = \"stable\"\n\
+             platform_feature = \"platform-posix\"\n\
+             link_kind = \"none\"\n\
+             entry_kind = \"hosted-main\"\n\
+             supported_netstakcs = []\n",
+        )
+        .expect_err("a misspelled key must not parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("supported_netstakcs"),
+            "the error must name the offending key, got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
Folds phase-206's rescope into the **design layer**, where the retracted fields
actually live, and files the sibling defect the same reasoning exposes.

## RFC-0004 amendment

**Retracts** the `interface` / `interfaces` transport fields, cases **B** and
**C** of the two-axes table, and the per-backend multi-homing mapping sentence.
Cases A and D stand. The principle that replaces them:

> **nano-ros transports the user's backend config VERBATIM; it does not
> re-model it.**

### The feature already exists in the backend

cyclonedds 0.10.5, `ddsi_cfgelems.h:79-88`:

```c
GROUP("NetworkInterface", NULL, network_interface_attributes, INT_MAX,
  MEMBER(network_interfaces), ...
```

Unbounded list, `name`/`address`/`autodetermine`/`priority`, and the group's own
description: *"Multiple interfaces can be specified with an assigned priority."*
Multi-homing is an element in a config the user writes — not a nano-ros feature.

### The "own language" is NOT the same shape for both backends

The part most likely to be mis-generalised, so the amendment writes it down:

| backend | native surface | how nano-ros carries it |
| --- | --- | --- |
| **CycloneDDS** | an XML **document**, parsed by `ddsrt_xmlp_new_string` | hand over the bytes as one comma token; **nano-ros parses no XML** |
| **zenoh-pico** | **no document format** — `z_config_default` / `zp_config_insert` over ~23 numbered keys | a flat `key = value` list whose key names are upstream's |

Upstream's manual names run-time options *"the primary configuration method"*;
JSON5/YAML is documented for **`zenohd`**, the router. **Adding a JSON5 parser
would mean owning a parser for a format our own backend does not speak** — this
amendment's mistake in a friendlier hat, so it is refused by name.

Also recorded: Cyclone **composes** comma-separated sources into one `cfgst`
(`ddsi_config.c:2538-2570`) while nano-ros selects one with a three-way ternary,
so a user config silently discards the baked baseline — including `<Threads>`
stack sizes that are load-bearing on FreeRTOS and ThreadX.

## Issue 1063 — filed, not fixed

`netstack` is declared by users, validated against the board, emitted as
`NROS_NETSTACK`, and **read by nothing**. It looks like a dead variable and is
not:

- **The validation half is real** — phase-351 W4 built it so an unsupported pair
  fails at the seam that knows both halves.
- **The choice is degenerate** — no board declares more than one netstack, so the
  emitted value is always `supported_netstacks[0]`.
- **Open issue 0941 uses a missing `NROS_NETSTACK` as a symptom** that board
  facts were never delivered, so deleting the emission takes away a signal that
  issue relies on.

Three options written out with costs. Recommendation: delete the emission, keep
the validation, and note that a board declaring two netstacks re-opens it — the
emission then returns **with a consumer in the same commit**. The larger question
(should a user name a netstack at all, when the board already does?) belongs to
phase-351.

This is the harder sibling of `BoardTransportConfig::set_interfaces`, which
phase-206 W5 deletes — **two live instances of the declared-but-unread class**
phase-349 named, and this is the one with real users who believe it works.

## Verification

    check-doc-refs    OK
    check-book-links  OK — 706 relative links in 123 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
