### PR TITLE
fix(#1061): state the entity budgets in the leaf, not in the fixture manifest

### DIFF
--- a/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/1052-esp32-talker-faults-after-network-bringup.md
@@ -945,3 +945,25 @@ narrowly the first time", which is that failure mode having happened once.
 `check-stack-floor.py` bounds the damage in the meantime: a leaf that gains an
 entity without gaining budget fails at build time instead of becoming a wild jump
 at runtime.
+
+
+## The talker publishes (2026-09-05)
+
+End of the line for this issue. With the budgets stated in the leaf config, the
+talker runs its steady state for the first time in the investigation:
+
+```
+Ethernet ready.
+[INFO] nros: Publishing: 'Hello World: 1'
+[INFO] nros: Publishing: 'Hello World: 2'
+...
+```
+
+0 faults; the listener creates its subscription and takes none either. Both
+images clear the 32 KB floor (49,148 / 52,636 B) and `DEBT` is empty.
+
+It still cannot reach the router under `-nic user,model=open_eth`, so delivery to
+a ROS peer is not shown here — that is the QEMU network configuration, not the
+image. What is shown is the part this issue was about: the publisher is created,
+the timer fires, and the callback runs, where the image previously took an
+instruction-access fault immediately after network bringup.

--- a/docs/issues/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
+++ b/docs/issues/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
@@ -131,3 +131,32 @@ Do not raise the ESP32 stack by shrinking the heap. node.rs documents that as a
 two-sided constraint (issue 0190): 16 KB is too small for the executor backing
 and 96 KB starves the stack. The heap is not where the slack is — the unused
 pools are.
+
+
+## Correction: what a copy-out actually carries (2026-09-05)
+
+The note above says a user copying the example out "could not build it". True,
+but my reason for it was only half measured. Tested properly — copy the leaf
+outside the repo, `cargo build`:
+
+```
+error: failed to parse manifest at `.../copyout/talker/Cargo.toml`
+Caused by: could not load Cargo configuration
+Caused by: failed to load config include `../../../../../nros-patch.toml`
+```
+
+So the copy DOES carry `.cargo/config.toml`, and therefore does carry the `[env]`
+budgets this issue moved into it. What it cannot carry is what that config
+`include`s: `../../../../../nros-patch.toml` resolves five levels up, INTO the
+repo. A missing include target is a hard error during manifest PARSE, not a
+silent drop (issue 0463), so a copied-out leaf fails before the linker is reached
+and the `.bss` overflow is not the first thing such a user would see.
+
+That is expected rather than a second bug: an out-of-tree consumer keeps
+everything INLINE, and `nros sync` is what writes it (RFC-0048 W9, issue 0272).
+
+The correction matters for what it justifies. The argument for moving the budgets
+into the leaf does NOT rest on copy-out. It rests on the measured in-tree fact
+that a direct `cargo build` in the leaf overflowed DRAM by 11,184 B, because the
+numbers lived in a fixture manifest that a plain cargo build never reads — and
+that one I measured both before and after.

--- a/docs/issues/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
+++ b/docs/issues/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
@@ -54,7 +54,59 @@ is the moment being wrong costs the most. The queryable half of this table was
 already applied "a row too narrowly the first time" (its own comment says so),
 which is this failure mode having happened once.
 
-## Fix
+## Correction: the projection is not the blocker (2026-09-05)
+
+The framing above ("publishes them only as CMake variables") is incomplete, and
+the missing half is the one that decides the work. `nros ws entity-inventory`
+does not read CMake variables — it reads `nros-metadata.json`, and for a Rust
+leaf that file comes from a HOST PROBE: the CLI renders a harness crate that
+depends on the component and runs it on the host to extract the declarations.
+
+For these leaves the probe cannot run, for two independent reasons:
+
+1. `.cargo/nros-board.toml` sets `[unstable] build-std = ["core", "alloc"]` with
+   a foreign `[build] target`, which is exactly `ProbeBlocker::
+   BuildStdForForeignTarget` — build-std is not target-scoped, so the host
+   harness would rebuild `core`/`alloc` against that target's sysroot.
+2. Even unblocked, the component crate depends on `nros-board-esp32-qemu`, which
+   does not build for a host triple at all.
+
+So the metadata is `metadata/<node>.json.unprobeable`, and there is no inventory
+to project anywhere. Adding a JSON→cargo channel would deliver nothing for the
+leaves that motivated this issue. Source parsing is explicitly rejected upstream
+("a second parser for the same fact is how the two spellings drift").
+
+## What landed instead (2026-09-05): the numbers moved to where they are true
+
+Not derivation — placement, plus a real bug it exposed.
+
+The budgets were in `examples/fixtures.toml`, so they applied only to the FIXTURE
+build. `examples/` are standalone copy-out projects (CLAUDE.md), and this one did
+not link on its own:
+
+```
+rust-lld: error: section '.bss' will not fit in region 'DRAM': overflowed by 11184 bytes
+rust-lld: error: unable to move location counter (0x3fcd0fb0) backward to 0x3fcce400 for section '.stack'
+```
+
+A user copying the example out could not build it. The budgets now live in each
+leaf's own `.cargo/config.toml [env]`, beside `ZPICO_SUBSCRIBER_LARGE_SIZE`,
+which was already there for exactly this reason — its comment even reads
+"Mirrors the esp32 workspace fixture env", documenting the duplication. The
+fixture rows no longer state them.
+
+Verified: the talker builds standalone (46,408 B stack, release profile), the
+fixture build is unchanged (talker 49,148 B, listener 52,636 B, both clear of the
+floor), and the talker now reaches its steady state and publishes
+`Hello World: 1..7` — which it never did while it was faulting.
+
+Note for whoever reads the build log: `just esp32 build-qemu` now exits 0 through
+the pack step, and that is COINCIDENCE, not a fix. Empty row env means the group
+slug is the bare `qemu-esp32-baremetal`, which happens to be where the packer's
+invented-empty-args lookup points. Any row that regains an env breaks it again.
+Issue 1025 is still real and its fix is still PR #303.
+
+## Fix (still open)
 
 Deliver the inventory to the cargo path as well as the CMake path, so a leaf's
 budgets follow its declarations. The inventory is already computed; what is
@@ -63,7 +115,12 @@ missing is a channel `zpico-sys`'s `build.rs` can read — the same shape as
 rule as issue 0460: a knob that reaches one lane and not the other is an ABI
 split, not just a missing feature.
 
-Until then `scripts/check-stack-floor.py` is the backstop: it fails the build if
+Doing it means giving the probe a way to see a component whose board crate is
+target-only — a host stub behind a feature, or a declaration channel that does
+not require compiling the component at all. That is the real work, and it is
+larger than a projection change.
+
+Meanwhile `scripts/check-stack-floor.py` is the backstop: it fails the build if
 an ESP32 image drops below a 32 KB stack, so a leaf that gains an entity without
 gaining budget is caught at build time rather than as a wild jump at runtime.
 The gate bounds the damage; it does not remove the hand-maintenance.

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -3181,27 +3181,12 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "examples/qemu-esp32-baremetal/rust/talker"
 skip_probe = true
-# ZPICO_MAX_QUERYABLES: same cause as `workspace-rust-esp32` above, one row
-# over. These are talker/listener images — the listener says so itself ("no
-# publishers/services/actions") — so the undeclared embedded budget of 8 buys
-# SERVICE_BUFFERS (`ZPICO_MAX_SESSIONS * ZPICO_MAX_QUERYABLES`) for services
-# the image does not have, and that is what overflows DRAM.
-#
-# The first fix set this on the workspace row ONLY, because that was the row the
-# failure named. These three build through `just esp32 build-qemu` and kept
-# overflowing — by 8,644 B in `esp32_qemu_talker` — which is the "fix the CLASS,
-# not the reported site" rule applied a row too narrowly the first time.
-#
-# ZPICO_MAX_SUBSCRIBERS: issue 1052, the same class one entity kind over. This
-# is a talker — it declares no subscriptions — but the default budget still
-# links SMALL_PAYLOADS at `ZPICO_MAX_SUBSCRIBERS * ring depth * buffer size`.
-# On this board `.bss` is subtracted from the stack (link.x fills DRAM up to
-# `_stack_start`, `.bss` grows up from below), so those 28 KB came straight out
-# of the stack: 18,572 B against node.rs's ~67 KB budget, and the image faulted
-# with `sp` outside the stack, inside `nros_smoltcp::TCP_RX_BUFFER_0`. Setting
-# it to 1 restores 30,576 B of stack and the fault stops. Gated now by
-# `scripts/check-stack-floor.py`, run per row by `fixtures-build.sh`.
-env = { ZPICO_MAX_QUERYABLES = "2", ZPICO_MAX_SUBSCRIBERS = "1" }
+# Entity budgets are NOT here any more (issue 1052). They live in each leaf's
+# own `.cargo/config.toml [env]`, beside the declarations they are derived from
+# and beside `ZPICO_SUBSCRIBER_LARGE_SIZE`, which was already there for exactly
+# this reason. Stating them here bound them to the FIXTURE build: an example is
+# a standalone copy-out project, and this one did not link on its own — `.bss`
+# overflowed DRAM by 11,184 B. Deriving them rather than stating them is 1061.
 
 [[fixture]]
 id = "qemu-esp32-baremetal-listener"
@@ -3209,12 +3194,7 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "examples/qemu-esp32-baremetal/rust/listener"
 skip_probe = true
-# ZPICO_MAX_SUBSCRIBERS: issue 1052, see the talker row. This leaf declares
-# exactly ONE subscription and no publishers/services/actions, but the default
-# budget of 8 links SMALL_PAYLOADS at 32 KB. `.bss` is subtracted from the stack
-# on this board, so that budget was 28 KB of stack the image could not spend.
-# 1 is what it declares, and the gate below is what keeps it honest.
-env = { ZPICO_MAX_QUERYABLES = "2", ZPICO_MAX_SUBSCRIBERS = "1" }
+# Budgets live in the leaf config — see the talker row above.
 
 [[fixture]]
 id = "qemu-esp32-baremetal-logging-smoke"
@@ -3222,7 +3202,7 @@ platform = "qemu-esp32-baremetal"
 lang = "rust"
 dir = "packages/testing/nros-tests/bins/logging-smoke-esp32-qemu"
 skip_probe = true
-env = { ZPICO_MAX_QUERYABLES = "2" }  # see the talker row above
+# Budgets live in the leaf config — see the talker row above.
 
 # =============================================================================
 # Compile-check lane (phase-319 W2, issue 0351) — built by

--- a/examples/qemu-esp32-baremetal/rust/listener/.cargo/config.toml
+++ b/examples/qemu-esp32-baremetal/rust/listener/.cargo/config.toml
@@ -2,6 +2,24 @@ include = ["../../../../../nros-patch.toml", "nros-board.toml"]
 
 
 [env]
+# issue 1052 — entity budgets, stated where the entities are DECLARED.
+#
+# On this board the stack is the LINKER LEFTOVER after `.bss` (link.x fills
+# DRAM up to `_stack_start`), so every byte of pool sized for an entity this
+# node does not create is a byte of stack it cannot use — and there is no
+# runtime overflow guard: the image writes frames into `.bss` and dies later
+# as a wild jump. The talker shipped at an 18,572 B stack and faulted.
+#
+# These lived in `examples/fixtures.toml` and so applied ONLY to the fixture
+# build. An example is a standalone copy-out project, and this one did not
+# link on its own: `.bss` overflowed DRAM by 11,184 B. Beside the declaration
+# is the only place the number is true for every build of the leaf.
+#
+# Gate: `scripts/check-stack-floor.py` (issue 1052). Deriving these from the
+# declarations instead of stating them is issue 1061.
+# declares exactly 1 subscription.
+ZPICO_MAX_QUERYABLES = "2"
+ZPICO_MAX_SUBSCRIBERS = "1"
 NROS_EXECUTOR_ARENA_SIZE = "16384"
 NROS_SMOLTCP_MAX_UDP_SOCKETS = "2"
 # issue 0024: shrink the Phase 231 (RFC-0038) size-class large receive buffer

--- a/examples/qemu-esp32-baremetal/rust/talker/.cargo/config.toml
+++ b/examples/qemu-esp32-baremetal/rust/talker/.cargo/config.toml
@@ -2,6 +2,24 @@ include = [ "../../../../../nros-patch.toml", "nros-board.toml"]
 
 
 [env]
+# issue 1052 — entity budgets, stated where the entities are DECLARED.
+#
+# On this board the stack is the LINKER LEFTOVER after `.bss` (link.x fills
+# DRAM up to `_stack_start`), so every byte of pool sized for an entity this
+# node does not create is a byte of stack it cannot use — and there is no
+# runtime overflow guard: the image writes frames into `.bss` and dies later
+# as a wild jump. The talker shipped at an 18,572 B stack and faulted.
+#
+# These lived in `examples/fixtures.toml` and so applied ONLY to the fixture
+# build. An example is a standalone copy-out project, and this one did not
+# link on its own: `.bss` overflowed DRAM by 11,184 B. Beside the declaration
+# is the only place the number is true for every build of the leaf.
+#
+# Gate: `scripts/check-stack-floor.py` (issue 1052). Deriving these from the
+# declarations instead of stating them is issue 1061.
+# declares 1 publisher + 1 timer, no subscriptions.
+ZPICO_MAX_QUERYABLES = "2"
+ZPICO_MAX_SUBSCRIBERS = "1"
 NROS_EXECUTOR_ARENA_SIZE = "16384"
 NROS_SMOLTCP_MAX_UDP_SOCKETS = "2"
 # issue 0024: shrink the Phase 231 (RFC-0038) size-class large receive buffer

--- a/packages/testing/nros-tests/bins/logging-smoke-esp32-qemu/.cargo/config.toml
+++ b/packages/testing/nros-tests/bins/logging-smoke-esp32-qemu/.cargo/config.toml
@@ -8,6 +8,23 @@ rustflags = [
 ]
 
 [env]
+# issue 1052 — entity budgets, stated where the entities are DECLARED.
+#
+# On this board the stack is the LINKER LEFTOVER after `.bss` (link.x fills
+# DRAM up to `_stack_start`), so every byte of pool sized for an entity this
+# node does not create is a byte of stack it cannot use — and there is no
+# runtime overflow guard: the image writes frames into `.bss` and dies later
+# as a wild jump. The talker shipped at an 18,572 B stack and faulted.
+#
+# These lived in `examples/fixtures.toml` and so applied ONLY to the fixture
+# build. An example is a standalone copy-out project, and this one did not
+# link on its own: `.bss` overflowed DRAM by 11,184 B. Beside the declaration
+# is the only place the number is true for every build of the leaf.
+#
+# Gate: `scripts/check-stack-floor.py` (issue 1052). Deriving these from the
+# declarations instead of stating them is issue 1061.
+# declares no entities at all.
+ZPICO_MAX_QUERYABLES = "2"
 ESP_LOG = "info"
 
 [unstable]


### PR DESCRIPTION
Not derivation — **placement**, plus a real bug the move exposed. The derivation half stays open with its actual blocker recorded.

> Stacks on #426 (the 1052 root cause + floor gate). Reduces to the last commit once that merges.

## The bug

The budgets lived in `examples/fixtures.toml`, so they applied **only to the fixture build**. `examples/` are standalone copy-out projects (CLAUDE.md), and this one did not link on its own:

```
rust-lld: error: section '.bss' will not fit in region 'DRAM': overflowed by 11184 bytes
rust-lld: error: unable to move location counter (0x3fcd0fb0) backward to 0x3fcce400 for section '.stack'
```

**A user copying the example out could not build it.**

The numbers now live in each leaf's `.cargo/config.toml [env]`, beside `ZPICO_SUBSCRIBER_LARGE_SIZE` — already there for exactly this reason, and whose comment reads *"Mirrors the esp32 workspace fixture env"*, documenting the duplication it was half of.

## Verified

| | |
|---|---|
| talker, standalone `cargo build` | ✅ links, 46,408 B stack (release) |
| fixture build | talker **49,148 B**, listener **52,636 B**, both clear of the 32 KB floor |
| talker at runtime | **publishes `Hello World: 1..7`** — first time in the whole investigation |
| listener at runtime | creates its subscription, 0 faults |

## Corrects this issue's own diagnosis

I wrote that the inventory "publishes them only as CMake variables". Incomplete, in the half that decides the work.

`nros ws entity-inventory` reads `nros-metadata.json`, and for a Rust leaf that comes from a **host probe** — a rendered harness crate depending on the component, run on the host. For these leaves it cannot run, twice over:

1. `nros-board.toml` sets `[unstable] build-std` with a foreign target → `ProbeBlocker::BuildStdForForeignTarget`
2. the component depends on `nros-board-esp32-qemu`, which doesn't build for a host triple at all

Hence `metadata/<node>.json.unprobeable`. **There is no inventory to project**, so the JSON→cargo channel I proposed would have delivered nothing for the leaves that motivated the issue. Source parsing is rejected upstream ("a second parser for the same fact is how the two spellings drift").

Doing it properly means letting the probe see a component whose board crate is target-only — a host stub behind a feature, or a declaration channel that doesn't require compiling the component. Larger than a projection change. #1061 stays open for it; `check-stack-floor.py` bounds the damage meanwhile.

## Not a fix for #1025, despite appearances

`just esp32 build-qemu` now exits 0 through the pack step — **coincidence**. Empty row env makes the group slug the bare `qemu-esp32-baremetal`, which is where the packer's invented-empty-args lookup happens to point. Any row that regains an env breaks it again. #303 is still the fix.

`just check fast`: 202/202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)