### PR TITLE
fix(#1062): an unreadable SOURCES list is not evidence of C

### DIFF
--- a/cmake/NanoRosVerbs.cmake
+++ b/cmake/NanoRosVerbs.cmake
@@ -188,10 +188,17 @@ function(nano_ros_add_executable name)
 endfunction()
 
 # ---------------------------------------------------------------------------
-# nano_ros_add_node(<name> <sources…> CLASS <ns::Class> [DEPLOY <target>…])
+# nano_ros_add_node(<name> <sources…> CLASS <ns::Class> [LANGUAGE C|CPP]
+#                   [DEPLOY <target>…])
 #
 # Workspace component. Registers a component library via `nano_ros_node_register`;
 # the carrier entry ELF is assembled by the workspace root / `nros plan`.
+#
+# LANGUAGE is optional and normally inferred from the source extensions. State
+# it when SOURCES arrives through a variable or a generator expression: cmake
+# expands those before inferring, `nros`'s static CMakeLists scanner cannot, and
+# the two readers then disagree about which ABI seam the component has
+# (issue 1062).
 # ---------------------------------------------------------------------------
 function(nano_ros_add_node name)
     # RFC-0057 (phase-305 W4.1): this fused spelling remains supported as the
@@ -202,7 +209,7 @@ function(nano_ros_add_node name)
             "nano_ros_add_node(${name}): consider the RFC-0057 split shape "
             "(nano_ros_auto_add_library + nros_components_register_node).")
     endif()
-    cmake_parse_arguments(_NRN "TYPED" "CLASS;HEADER;SHAPE" "SOURCES;DEPLOY;CALLBACK_GROUPS" ${ARGN})
+    cmake_parse_arguments(_NRN "TYPED" "CLASS;HEADER;SHAPE;LANGUAGE" "SOURCES;DEPLOY;CALLBACK_GROUPS" ${ARGN})
     set(_srcs ${_NRN_SOURCES} ${_NRN_UNPARSED_ARGUMENTS})
     if(NOT _srcs)
         message(FATAL_ERROR "nano_ros_add_node(${name}): no sources given.")
@@ -223,7 +230,25 @@ function(nano_ros_add_node name)
     if(NOT _NRN_DEPLOY AND NROS_DEPLOY)
         set(_NRN_DEPLOY "${NROS_DEPLOY}")
     endif()
-    _nros_infer_lang(_lang ${_srcs})
+    # Explicit LANGUAGE wins over inference. Inference reads EXPANDED sources,
+    # which is exactly what the static CMakeLists scanner in `nros` cannot do —
+    # so a component whose SOURCES hides behind `${var}` states the language
+    # here and both readers agree (issue 1062).
+    if(_NRN_LANGUAGE)
+        string(TOLOWER "${_NRN_LANGUAGE}" _lang)
+        if(_lang STREQUAL "cxx")
+            set(_lang cpp)
+        endif()
+        if(NOT _lang STREQUAL "c" AND NOT _lang STREQUAL "cpp")
+            message(FATAL_ERROR
+                "nano_ros_add_node(${name}): LANGUAGE '${_NRN_LANGUAGE}' rejected "
+                "— this verb compiles C/C++ SOURCES into a component library, so "
+                "LANGUAGE is C, CPP, or CXX. A Rust component registers through "
+                "nano_ros_node_register(LANGUAGE RUST) against its Cargo.toml.")
+        endif()
+    else()
+        _nros_infer_lang(_lang ${_srcs})
+    endif()
 
     # Generate the package's declared interface closure (no-op when package.xml
     # declares none — a TYPED component publishes raw topics with no bindings).

--- a/docs/design/0048-cmake-ament-consumption.md
+++ b/docs/design/0048-cmake-ament-consumption.md
@@ -103,9 +103,11 @@ them:
   `main` / self-bringup). Emits `add_executable` on native/FreeRTOS/NuttX/ThreadX
   and `add_library`-into-`app` on Zephyr; the platform choice comes from
   `package.xml` (§4), so the call is identical everywhere.
-- **`nano_ros_add_node(<name> <sources…> CLASS <ns::Class>)`** — a *workspace
-  component* (no own `main`; registered into a carrier ELF). Always a component
-  library.
+- **`nano_ros_add_node(<name> <sources…> CLASS <ns::Class> [LANGUAGE C|CPP])`** —
+  a *workspace component* (no own `main`; registered into a carrier ELF). Always
+  a component library. `LANGUAGE` is inferred from the source extensions; it
+  needs stating only when `nros`'s static CMakeLists scanner cannot see them —
+  sources reached through a variable or a generator expression (issue 1062).
 
 Both are followed by `ament_target_dependencies(<name> <msg_pkg>…)` — the
 familiar verb — which links the generated `*__nano_ros_<lang>` bindings.

--- a/docs/issues/1062-add-node-language-inference.md
+++ b/docs/issues/1062-add-node-language-inference.md
@@ -1,0 +1,119 @@
+---
+id: 1062
+title: "`nano_ros_add_node` has two language readers that disagree — cmake
+  expands SOURCES, the scanner reads the raw text, and the loser is a silent
+  `C`"
+status: open
+type: bug
+area: tooling
+related: [issue-0939, issue-0641, rfc-0057]
+---
+
+## Symptom
+
+Autoware Safety Island's `controller_pkg` is a C++ component. Its metadata
+probe is generated against the **C** ABI seam and fails to link:
+
+```
+sync: source metadata — no producer for controller_pkg::controller
+      (metadata probe build failed for `controller_pkg::controller` (exit 2):
+...
+probe_controller_pkg__controller.cpp:(.text+0x6a): undefined reference to
+      `__nros_c_component_controller_pkg_create'
+probe_controller_pkg__controller.cpp:(.text+0xa4): undefined reference to
+      `__nros_c_component_controller_pkg_configure'
+```
+
+Those symbols come from `NROS_C_COMPONENT`. The component registers with
+`NROS_COMPONENT`, which exports `__nros_component_factory_controller_pkg`.
+
+Nothing else breaks. The image builds and runs; only the sidecar the probe
+exists to produce goes missing, and `sync` carries on with a model that lacks
+it. This is the same failure shape as issue 0939 — a probe that cannot link,
+reported once and then tolerated — one layer further in.
+
+## Cause
+
+The emitter is right. `is_c_node` routes on `lang`, and `lang` arrives already
+wrong.
+
+A `nano_ros_add_node` declaration is read by **two** different readers, and
+only one of them can see CMake variables:
+
+```cmake
+nano_ros_add_node(controller
+  CLASS   controller_pkg::Controller
+  SHAPE   rclcpp
+  SOURCES ${_controller_sources})
+```
+
+**Reader 1 — cmake, at configure time.** `${_controller_sources}` expands to
+real `.cpp` paths, `_nros_infer_lang` answers `cpp`, and the verb forwards
+`LANGUAGE cpp` to `nano_ros_node_register`. Correct.
+
+**Reader 2 — the Rust scanner, statically.** `parse_add_node_call`
+(`workspace.rs`) reads `CMakeLists.txt` as *text*. It never expands anything,
+so `sources` holds one token — the literal string `${_controller_sources}` —
+and:
+
+```rust
+// Infer from the source extension, NOT the class: a C node's class still uses
+// `::` (e.g. `c_talker_pkg::Talker`), so class-based inference mislabels it Cpp.
+let language = infer_language_from_sources(&sources);
+```
+
+```rust
+/// C++ if any source has a C++ extension, else C.
+fn infer_language_from_sources(sources: &[String]) -> ComponentLanguage {
+    for s in sources {
+        if s.ends_with(".cpp") || … { return ComponentLanguage::Cpp; }
+    }
+    ComponentLanguage::C
+}
+```
+
+No `.cpp` suffix is visible, so it falls off the end into `C`. That answer
+reaches `metadata_refresh.rs`, which maps `ComponentLanguage::C → "c"`, which
+routes the probe through the C-ABI seam.
+
+The `else C` is doing two unrelated jobs: *"every source is a C file"* and
+*"this list told me nothing"*. Only the first deserves an answer.
+
+## Two defects, one symptom
+
+**1. The default is silent, and it is the wrong shape.** Any `SOURCES` the
+scanner cannot resolve — a variable, a generator expression, an empty list —
+reads as C. The sibling path already learned exactly this lesson;
+`infer_cmake_language` fails loudly and its comment cites issue 0641:
+
+> An unrecognised value now falls back LOUDLY rather than silently, because a
+> silent fallback is exactly what hid this: the declaration said one thing, the
+> inference did another, and nothing printed.
+
+`parse_add_node_call` never got that treatment. The third reader
+(`parse_register_call`) already handles the empty case by deferring to the
+class; only this one guesses.
+
+**2. There is no way to say it.** `nano_ros_node_register` accepts
+`LANGUAGE C|CPP|RUST`. `nano_ros_add_node` does not:
+
+```cmake
+cmake_parse_arguments(_NRN "TYPED" "CLASS;HEADER;SHAPE" "SOURCES;DEPLOY;CALLBACK_GROUPS" ${ARGN})
+```
+
+and the scanner has no `LANGUAGE` keyword either. So a package that knows the
+guess is wrong cannot correct it — and passing `LANGUAGE CPP` today is worse
+than useless: unmatched keywords land in `_NRN_UNPARSED_ARGUMENTS`, which the
+verb appends to `_srcs`, so `LANGUAGE` and `CPP` become two source files.
+
+## Fix
+
+- Give `nano_ros_add_node` the `LANGUAGE` keyword its own callee already has,
+  explicit value winning over inference, and teach the scanner to read it.
+- Split "this list says C" from "this list says nothing". Only a source that
+  actually carries a recognised extension is evidence; when none does, fall
+  back to the class shape and **print why**, naming `LANGUAGE` as the fix.
+
+The class fallback is still a guess — that is the point of printing it. A C
+component whose class carries `::` and whose sources are hidden behind a
+variable will guess wrong, out loud, with the remedy in the message.

--- a/packages/cli/nros-cli-core/src/orchestration/workspace.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/workspace.rs
@@ -778,11 +778,11 @@ fn parse_register_node_call(
         .as_ref()
         .and_then(|t| lib_sources.get(t))
         .unwrap_or(&empty);
-    let language = if sources.is_empty() {
-        infer_cmake_language(None, plugin.as_deref())
-    } else {
-        infer_language_from_sources(sources)
-    };
+    let language = language_from_sources_or_class(
+        sources,
+        plugin.as_deref(),
+        &format!("{package_name}: nros_components_register_node(EXECUTABLE {executable})"),
+    );
     Some(CmakeNodeSummary {
         package: package_name.to_string(),
         component: executable.clone(),
@@ -833,6 +833,7 @@ fn parse_add_node_call(
         "SHAPE",
         "CALLBACK_GROUPS",
         "SOURCES",
+        "LANGUAGE",
     ];
     let tokens = tokenize_cmake_body(body);
     let mut name: Option<String> = None;
@@ -841,6 +842,7 @@ fn parse_add_node_call(
     let mut sources: Vec<String> = Vec::new();
     let mut header: Option<String> = None;
     let mut shape: Option<String> = None;
+    let mut language_kw: Option<String> = None;
     let mut current: Option<&str> = None;
     for tok in tokens {
         if KEYWORDS.contains(&tok.as_str()) {
@@ -851,6 +853,7 @@ fn parse_add_node_call(
                 "SHAPE" => Some("SHAPE"),
                 "CALLBACK_GROUPS" => Some("CALLBACK_GROUPS"),
                 "SOURCES" => Some("SOURCES"),
+                "LANGUAGE" => Some("LANGUAGE"),
                 _ => None, // TYPED — bare flag, no value
             };
             continue;
@@ -858,6 +861,10 @@ fn parse_add_node_call(
         match current {
             Some("CLASS") => {
                 class = Some(tok);
+                current = None;
+            }
+            Some("LANGUAGE") => {
+                language_kw = Some(tok);
                 current = None;
             }
             Some("HEADER") => {
@@ -884,9 +891,21 @@ fn parse_add_node_call(
         }
     }
     let name = name?;
-    // Infer from the source extension, NOT the class: a C node's class still uses
-    // `::` (e.g. `c_talker_pkg::Talker`), so class-based inference mislabels it Cpp.
-    let language = infer_language_from_sources(&sources);
+    // An explicit LANGUAGE is the whole point of the keyword — it is the only
+    // thing this scanner and cmake are guaranteed to read the same way.
+    //
+    // Without one, infer from the source extension and NOT the class: a C node's
+    // class still uses `::` (e.g. `c_talker_pkg::Talker`), so class-shape
+    // inference mislabels it Cpp. The class is the LAST resort, taken out loud,
+    // for sources this scanner cannot read at all (issue 1062).
+    let language = match language_kw.as_deref() {
+        Some(kw) => infer_cmake_language(Some(kw), class.as_deref()),
+        None => language_from_sources_or_class(
+            &sources,
+            class.as_deref(),
+            &format!("{package_name}: nano_ros_add_node({name})"),
+        ),
+    };
     Some(CmakeNodeSummary {
         package: package_name.to_string(),
         component: name.clone(),
@@ -903,14 +922,67 @@ fn parse_add_node_call(
     })
 }
 
-/// C++ if any source has a C++ extension, else C.
-fn infer_language_from_sources(sources: &[String]) -> ComponentLanguage {
+/// C++ if any source carries a C++ extension, C if any carries `.c` — and
+/// `None` when the list settles nothing.
+///
+/// # Why `None` exists (issue 1062)
+///
+/// This used to end in a bare `else C`, which made one answer serve two
+/// unrelated questions: "every source is a C file" and "this list told me
+/// nothing". The second is common, because the scanner reads `CMakeLists.txt`
+/// as TEXT — `SOURCES ${_controller_sources}` is one token that expands to
+/// nothing here, though cmake expands it fine at configure time. A C++
+/// component then read as C, was probed against the C ABI seam, and the probe
+/// failed to link against symbols `NROS_C_COMPONENT` never emitted.
+///
+/// Returning `None` hands the decision back to the caller, which has the class
+/// shape to fall back on and can say out loud that it is guessing.
+fn language_from_sources(sources: &[String]) -> Option<ComponentLanguage> {
+    let mut saw_c = false;
     for s in sources {
         if s.ends_with(".cpp") || s.ends_with(".cxx") || s.ends_with(".cc") || s.ends_with(".C") {
-            return ComponentLanguage::Cpp;
+            return Some(ComponentLanguage::Cpp);
+        }
+        if s.ends_with(".c") {
+            saw_c = true;
         }
     }
-    ComponentLanguage::C
+    saw_c.then_some(ComponentLanguage::C)
+}
+
+/// Source extensions decide; when they cannot, the class shape decides and says
+/// so. `decl` names the declaration in the warning so the message points at the
+/// line to edit.
+///
+/// The class fallback is a guess and stays one — a C component whose class
+/// carries `::` (`c_talker_pkg::Talker`) guesses Cpp. That is why it prints:
+/// the remedy, `LANGUAGE`, travels with the guess. Silence is what let the
+/// wrong answer through before (issues 1062, 0641).
+fn language_from_sources_or_class(
+    sources: &[String],
+    class: Option<&str>,
+    decl: &str,
+) -> ComponentLanguage {
+    if let Some(lang) = language_from_sources(sources) {
+        return lang;
+    }
+    // No sources at all is not a mystery to report — there is nothing the
+    // author could have written differently. An unreadable list is.
+    if !sources.is_empty() {
+        eprintln!(
+            "nros: {decl}: no source in `{}` carries a C/C++ extension — a cmake \
+             variable or generator expression expands at configure time but not \
+             for this scanner. Guessing `{}` from the class shape; pass \
+             `LANGUAGE C` or `LANGUAGE CPP` to state it (issue 1062).",
+            sources.join(" "),
+            match infer_language_from_class(class) {
+                Some(ComponentLanguage::C) => "c",
+                Some(ComponentLanguage::Rust) => "rust",
+                _ => "cpp",
+            }
+        );
+    }
+    infer_language_from_class(class).unwrap_or(ComponentLanguage::Cpp)
 }
 
 /// Strip `#` line comments from a CMake source while preserving line
@@ -2300,6 +2372,54 @@ type = "std_msgs/msg/Int32"
         assert_eq!(s.component, "listener");
         assert_eq!(s.language, ComponentLanguage::Cpp);
         assert_eq!(s.deploy_targets, vec!["native".to_string()]);
+    }
+
+    #[test]
+    fn add_node_unexpandable_sources_fall_back_to_the_class_not_to_c() {
+        // Issue 1062, and the exact ASI declaration that found it. cmake expands
+        // `${_controller_sources}` to `.cpp` paths before inferring; this scanner
+        // reads CMakeLists as text and sees one token with no extension. The old
+        // `else C` called that C, and the C++ component was then probed against
+        // `__nros_c_component_*` — symbols `NROS_COMPONENT` never emits.
+        let body = "controller CLASS controller_pkg::Controller SHAPE rclcpp \
+                    SOURCES ${_controller_sources}";
+        let s = parse_add_node_call(body, "controller_pkg", Path::new("CMakeLists.txt")).unwrap();
+        assert_eq!(
+            s.language,
+            ComponentLanguage::Cpp,
+            "an unreadable source list is not evidence of C"
+        );
+    }
+
+    #[test]
+    fn add_node_language_keyword_beats_the_source_extensions() {
+        // The keyword exists because it is the one thing cmake and this scanner
+        // are guaranteed to read identically. It therefore has to win even when
+        // the extensions disagree — otherwise it cannot fix the case it is for.
+        let body = "shim CLASS shim_pkg::Shim LANGUAGE C SOURCES src/shim.cpp";
+        let s = parse_add_node_call(body, "shim_pkg", Path::new("CMakeLists.txt")).unwrap();
+        assert_eq!(s.language, ComponentLanguage::C);
+    }
+
+    #[test]
+    fn add_node_language_keyword_is_not_swallowed_as_a_source() {
+        // Before the keyword existed, `LANGUAGE CPP` was two positional tokens:
+        // cmake put them in UNPARSED_ARGUMENTS and appended both to SOURCES.
+        // The parser has to consume the value, not file it under sources.
+        let body = "listener CLASS ws::Listener LANGUAGE CPP src/Listener.cpp DEPLOY native";
+        let s = parse_add_node_call(body, "cpp_pkg", Path::new("CMakeLists.txt")).unwrap();
+        assert_eq!(s.language, ComponentLanguage::Cpp);
+        assert_eq!(s.component, "listener");
+        assert_eq!(s.deploy_targets, vec!["native".to_string()]);
+    }
+
+    #[test]
+    fn add_node_literal_c_sources_still_read_as_c() {
+        // The fallback must not swallow the case it replaced: a real `.c` list
+        // is evidence, and the `::`-bearing class must not override it.
+        let body = "talker CLASS c_talker_pkg::Talker TYPED SOURCES src/Talker.c src/util.c";
+        let s = parse_add_node_call(body, "c_talker_pkg", Path::new("CMakeLists.txt")).unwrap();
+        assert_eq!(s.language, ComponentLanguage::C);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1062. Files the issue and fixes it.

## Two readers, one declaration

Autoware Safety Island declares a C++ component:

```cmake
nano_ros_add_node(controller
  CLASS   controller_pkg::Controller
  SHAPE   rclcpp
  SOURCES ${_controller_sources})
```

**cmake, at configure time** expands the variable to real `.cpp` paths, infers `cpp`, and forwards `LANGUAGE cpp` to `nano_ros_node_register`. Correct.

**The Rust scanner** reads the same line as *text*. It cannot expand anything, so `sources` holds one token — the literal `${_controller_sources}` — and fell off the end of

```rust
/// C++ if any source has a C++ extension, else C.
```

into C. That answer chose the ABI seam, so a C++ component was probed against `__nros_c_component_*` — symbols `NROS_COMPONENT` never emits:

```
probe_controller_pkg__controller.cpp: undefined reference to `__nros_c_component_controller_pkg_create'
sync: source metadata — no producer for controller_pkg::controller
```

Reported once, then tolerated: the image still builds and runs, and only the sidecar the probe exists to produce goes missing. Same shape as #0939, one layer further in.

## The `else C` was answering two questions

"Every source is a C file" and "this list told me nothing" got the same word. Only the first is evidence.

`language_from_sources` now returns `Option`. When it declines, the caller falls back to the class shape and **says so** — the policy `infer_cmake_language` already adopted for #0641, whose comment reads: *"a silent fallback is exactly what hid this: the declaration said one thing, the inference did another, and nothing printed."*

The fallback is still a guess — a C component whose class carries `::` guesses wrong. So it prints its own remedy.

## The remedy had to be built first

`nano_ros_node_register` has always taken `LANGUAGE C|CPP|RUST`. `nano_ros_add_node` did not, and passing it was worse than useless: unmatched keywords land in `_NRN_UNPARSED_ARGUMENTS`, which the verb appends to `_srcs` — so `LANGUAGE` and `CPP` became two source files. Both the verb and the scanner now take the keyword, explicit value winning over inference. It is the one thing cmake and the scanner are guaranteed to read identically.

## Testing

Four tests in `workspace.rs`, one per behavior: the ASI declaration verbatim, keyword-beats-extensions, keyword-not-swallowed-as-a-source, and a literal `.c` list still reading as C.

**Negative control run**, not assumed: with the old `else C` restored, 4 pass and only `add_node_unexpandable_sources_fall_back_to_the_class_not_to_c` fails.

`nros-cli-core` 873/873. `just check`: 2 of 205 gates fail, the same two that fail on a clean tree (`kconfig-overridden-values`, `fixtures-manifest` — both environment). End-to-end, the ASI probe that motivated this now links and produces its sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M58snQxzQwRkPTvr3baXw
