### PR TITLE
fix(#0883): terminate the gate registries with a sentinel, so appending costs one line

### DIFF
--- a/.config/ungated-gates.txt
+++ b/.config/ungated-gates.txt
@@ -37,6 +37,7 @@ nros-log-riscv32
 staticlib-symbols
 test-targets
 workspace-all
+workspace-features
 
 # --- need the in-tree CLI built, or build it ---
 cli-fresh

--- a/just/check.just
+++ b/just/check.just
@@ -91,6 +91,23 @@ default: cli-fresh fast build api-parity
 fast:
     @bash scripts/build/run-gates-parallel.sh
 
+# The terminator both gate registries end on — a no-op that exists only to give
+# the LAST real gate a trailing `\`.
+#
+# Without it the final entry is the one line in the list with different syntax,
+# so every gate that sorts last must edit SOMEONE ELSE's line to add the
+# backslash as well as adding its own. Two such pull requests then conflict with
+# certainty rather than by bad luck — the "trailing comma" problem, and the one
+# residual conflict class the one-name-per-line format could not reach.
+#
+# `_`-prefixed on purpose: `run-gates-parallel.sh` filters derived names with
+# `^[a-z][a-z0-9-]*$`, so the sentinel is excluded from the fan-out without that
+# script needing to know it exists. `check-gate-lists` DOES know — it requires
+# the sentinel to be last and excludes it from the sort, which is what keeps
+# this from being a name someone quietly moves.
+[private]
+_gate-list-end:
+
 # The GATE LIST, and the serial runner — phase-395 W11.
 #
 # `fast` (below) fans these out; this recipe both DECLARES them and runs
@@ -303,7 +320,8 @@ fast-serial: \
     zenohd-resolution-parity \
     zenohd-router-skips \
     zenohd-spawn-sites \
-    zephyr-knob-agreement
+    zephyr-knob-agreement \
+    _gate-list-end
     # `_check-skip-reset` is shared skip-ledger infrastructure at the ROOT
     # (`run-gates-parallel.sh` calls it too), not a gate — and a module cannot
     # depend on a root recipe, so it is called rather than depended on. It must
@@ -377,7 +395,8 @@ build-serial: \
     staticlib-symbols \
     test-targets \
     workspace-all \
-    workspace-features
+    workspace-features \
+    _gate-list-end
     # `native::check`, which was a DEPENDENCY at the root. A module cannot name
     # another module's recipe — from in here `native::` would mean a submodule
     # of `check` — so it becomes an explicit call. Same constraint the sibling

--- a/scripts/check/check-gate-lists.py
+++ b/scripts/check/check-gate-lists.py
@@ -69,11 +69,43 @@ def names_per_line(lines: list[str], s: int, e: int) -> list[list[str]]:
     return out
 
 
+# The no-op every registry ends on, so the LAST real gate carries a trailing
+# backslash like every other. Without it the final entry is the one line with
+# different syntax, and a gate that sorts last must edit someone else's line to
+# add the backslash — two such PRs conflict with CERTAINTY rather than by bad
+# luck. The "trailing comma" fix, and the one conflict class the
+# one-name-per-line format could not reach.
+SENTINEL = "_gate-list-end"
+
+
 def check(lines: list[str], name: str) -> list[str]:
     s, e = dep_block(lines, name)
     per_line = names_per_line(lines, s, e)
     flat = [n for group in per_line for n in group]
     problems = []
+
+    # The sentinel is REQUIRED and must be last. Checked before it is dropped:
+    # if it drifts into the middle it stops terminating anything, and the last
+    # real gate silently becomes the odd line again.
+    if flat and flat[-1] == SENTINEL:
+        flat = flat[:-1]
+        per_line = per_line[:-1]
+    elif SENTINEL in flat:
+        problems.append(
+            f"  {name}: `{SENTINEL}` is present but not LAST.\n"
+            f"      It exists to give the final real gate a trailing backslash;\n"
+            f"      anywhere else it terminates nothing."
+        )
+        flat = [n for n in flat if n != SENTINEL]
+        per_line = [[n for n in g if n != SENTINEL] for g in per_line]
+        per_line = [g for g in per_line if g]
+    else:
+        problems.append(
+            f"  {name}: missing the `{SENTINEL}` terminator.\n"
+            f"      End the list with it so every real gate's line looks the\n"
+            f"      same; otherwise a gate that sorts last has to edit the\n"
+            f"      previous line too, and two such PRs always conflict."
+        )
 
     crowded = sum(1 for group in per_line if len(group) > 1)
     if crowded:
@@ -106,22 +138,47 @@ def self_test() -> None:
     `check-gate-selftests` requires this on the normal path: a control nobody
     runs decays into a comment.
     """
-    good = ["build: \\", "    alpha \\", "    beta \\", "    gamma", "    @echo hi"]
+    good = ["build: \\", "    alpha \\", "    beta \\", "    gamma \\",
+            f"    {SENTINEL}", "    @echo hi"]
     assert check(good, "build") == [], "selftest: rejected a well-formed list"
 
-    crowded = ["build: \\", "    alpha beta \\", "    gamma", "    @echo hi"]
+    crowded = ["build: \\", "    alpha beta \\", "    gamma \\",
+               f"    {SENTINEL}", "    @echo hi"]
     assert any("more than one gate" in p for p in check(crowded, "build")), (
         "selftest: missed two names sharing a line"
     )
 
-    unsorted = ["build: \\", "    gamma \\", "    alpha", "    @echo hi"]
+    unsorted = ["build: \\", "    gamma \\", "    alpha \\",
+                f"    {SENTINEL}", "    @echo hi"]
     assert any("not sorted" in p for p in check(unsorted, "build")), (
         "selftest: missed an out-of-order list"
     )
 
-    dup = ["build: \\", "    alpha \\", "    alpha", "    @echo hi"]
+    dup = ["build: \\", "    alpha \\", "    alpha \\",
+           f"    {SENTINEL}", "    @echo hi"]
     assert any("listed twice" in p for p in check(dup, "build")), (
         "selftest: missed a duplicate"
+    )
+
+    # The sentinel itself. Absent, the last real gate is the odd line again.
+    no_sentinel = ["build: \\", "    alpha \\", "    beta", "    @echo hi"]
+    assert any("missing the" in p for p in check(no_sentinel, "build")), (
+        "selftest: missed an absent terminator"
+    )
+
+    # Present but not last terminates nothing — and would ALSO read as
+    # out-of-order, so the message has to name the real fault.
+    misplaced = ["build: \\", f"    {SENTINEL} \\", "    alpha \\",
+                 "    beta", "    @echo hi"]
+    probs = check(misplaced, "build")
+    assert any("not LAST" in p for p in probs), (
+        f"selftest: missed a misplaced terminator: {probs}"
+    )
+
+    # And it must not be counted as a gate: with it last, a two-gate list is
+    # sorted, not "alpha, beta, _gate-list-end out of order".
+    assert not any("not sorted" in p for p in check(good, "build")), (
+        "selftest: the sentinel was sorted as if it were a gate"
     )
 
     # The block must end at the first line with no continuation, so a BODY line


### PR DESCRIPTION
`just/check.just` was the top structural conflict site in today's survey — **3 of 14** dirty PRs, more than any other file.

To answer the question directly: the `\` one-name-per-line format **is already in use**, and it isn't the problem. It's why a conflict is a one-line window instead of the whole 220-entry list.

## The residual problem is the last line

`zephyr-knob-agreement` and `workspace-features` carried **no trailing `\`** — the one line in each list with different syntax. Any gate sorting after them had to edit *someone else's* line to add the backslash, as well as adding its own. Two such PRs conflict with **certainty**, not bad luck. The trailing-comma problem.

Both lists now end on `_gate-list-end`, a private no-op. Measured:

```
BEFORE sentinel — appending a last-sorting gate:  3 lines changed
AFTER  sentinel — same append:                   1 line added, 0 removed
```

## No behaviour change to the runner

`_`-prefixed deliberately: `run-gates-parallel.sh` filters derived names through `^[a-z][a-z0-9-]*$`, so the sentinel drops out of the fan-out with **no change to that script**. Verified rather than assumed — derived lists byte-identical before and after, both lanes (md5 `3f023143` / `4e8e050e`).

`check-gate-lists` is taught the shape rather than worked around: the sentinel is **required**, must be **last**, and is excluded from the sort so it doesn't read as out-of-order. Mutation-checked both ways in the tree — deleting it → *"missing the `_gate-list-end` terminator"*; moving it to the front → *"present but not LAST"* rather than a misleading sort complaint. Self-test fixtures gained the sentinel plus two cases for the new rule.

## A third consumer, and a silent coverage hole

`check-gate-visibility` matches members with `^    [a-z0-9-]+ \\$` — every line must end in a backslash — so **it never parsed the final entry of either registry**. Measured: it saw **204 of 205** fast-serial gates and **20 of 21** build-serial ones. The last gate in each list has been invisible to the "is any PR job running this?" check for as long as that regex has looked like that.

The sentinel closes the hole as a side effect, and the newly visible entry immediately failed: `workspace-features` sits in `build-serial`, a lane no `pull_request` or `merge_group` job runs, and wasn't in `.config/ungated-gates.txt`. Its immediate neighbour `workspace-all` **is** listed, one line above — same lane, same situation, omitted only because nothing could see it. Acknowledged there now; that list may only decrease.

`just check fast` 205/205.

## What this does not fix

Adjacency. Two PRs adding alphabetically neighbouring gates still collide — git needs context lines to merge, and that's inherent to a sorted list. Only sharding would help, and unlike the census table this content **isn't derivable**: which gates the fast tier runs is a decision, not a fact readable from the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)