### PR TITLE
fix(#1018): a configure-time emitter had no edge on the tool that emits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -749,6 +749,19 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   `nros_fixture_row_artifact_dir_by_id <row-id>`. Gate: `check-fixture-artifact-dir-inputs`
   (a packer of a lane-built artifact must derive its row's args and env from the manifest, not
   supply them); acceptance is still a BUILD, never a gate.
+
+- **A CONFIGURE-time emitter has no `DEPENDS` to carry its tool — put the tool in
+  `CMAKE_CONFIGURE_DEPENDS` (issue 1018).** `execute_process()` has already run by
+  the time ninja decides anything, so the freshness of anything it emits reduces to
+  *does a configure happen*. Four sites emit at configure time and #182 registered
+  the CLI at exactly one of them, inline; the Zephyr interfaces generator's own
+  `IS_NEWER_THAN` predicate on the tool was therefore unreachable on an incremental
+  build (measured: `build-rust-talker-zenoh`'s `RERUN_CMAKE` edge, 3592 inputs, none
+  under `packages/cli`), so a single-example Zephyr image kept museum generated code
+  after a `nros` rebuild. One spelling now: `nros_codegen_tool_reconfigure()`, gated
+  by `check-codegen-tool-reconfigure`. The BUILD-time lane is fine — its
+  `add_custom_command` names the tool in `DEPENDS`, and `restat = 1` plus codegen's
+  write-if-changed keep an emitter-identical rebuild from cascading.
 - **A lib reached through a raw `-Wl,...` link FLAG gets no rebuild edge (issue 0475)** — CMake cannot
   see a file inside a flag string, and `add_dependencies()` only adds build ORDER, which ninja renders
   `||` (order-only): "must exist before linking", never "relink when it changes". The RMW backends are

--- a/cmake/NanoRosCodegenCore.cmake
+++ b/cmake/NanoRosCodegenCore.cmake
@@ -129,6 +129,66 @@ function(_nros_write_ffi_lib_rs)
     configure_file("${_L_TEMPLATE}" "${_L_CRATE_SRC}/lib.rs" @ONLY)
 endfunction()
 
+# nros_codegen_tool_reconfigure(<tool>)
+#
+# issue 1018 — make a CONFIGURE-TIME emitter re-run when the tool that emits is
+# rebuilt.
+#
+# The build-time generator states the edge outright: its codegen
+# `add_custom_command` carries `DEPENDS … "${_NANO_ROS_CODEGEN_TOOL}"`, so a
+# newer `nros` re-emits (and CMake's `restat = 1` plus codegen's
+# write-if-changed keep an emitter-identical rebuild from cascading downstream —
+# measured, the command re-runs once and nothing else rebuilds).
+#
+# A configure-time emitter has no such edge available: `execute_process()` runs
+# during configure, so its freshness is decided by whether a configure happens
+# AT ALL. The Zephyr interfaces generator even carries the right predicate
+# already — an `IS_NEWER_THAN` loop that names the tool — but it is dead on an
+# incremental build, because nothing makes `build.ninja` stale when the tool
+# moves. Measured in this checkout: `zephyr-workspace/build-rust-talker-zenoh`'s
+# RERUN_CMAKE edge lists 3592 inputs and NOT ONE is under `packages/cli`.
+#
+# `nano_ros_entry()` learned this as issue #182 and registered the binary right
+# there, in its own function. That fixed the site, not the class: the three
+# sibling configure-time emitters (this Zephyr interfaces lane,
+# `nros_system_generate()`, the ESP-IDF shim's `codegen-system`) kept nothing,
+# and a Zephyr image inherits freshness only if it ALSO happens to call
+# `nano_ros_entry()` — which no single-example image does. So an image that
+# generates its interfaces at configure time and does not use an entry package
+# keeps museum generated code after a `nros` rebuild, silently.
+#
+# WHY THE BINARY AND NOT `nros codegen-fingerprint`
+#
+# The fingerprint (RFC-0061 / phase-318 W1) is the better key where it applies:
+# it hashes what the EMITTERS produce for a compiled-in corpus, so 41 distinct
+# `nros` binaries map to 9 fingerprints and 78 % of `just setup-cli` rebuilds
+# would cost nothing. But its corpus covers the MESSAGE/SERVICE/ACTION emitters
+# only — not `codegen entry`, not `codegen-system` — so keying those two on it
+# would report FRESH for a real change to their emitters. One key for all four
+# sites, and it is the conservative one. Narrowing the interfaces site onto the
+# fingerprint is a follow-up that needs a producer for the fingerprint value
+# outside the build dir (a configure cannot write its own configure input
+# without a first configure to write it).
+#
+# The widening this costs was measured before it landed: of the 7 Zephyr build
+# dirs in this checkout, 3 reach a configure-time emitter and all 3 already
+# carry the CLI as a configure dependency via `nano_ros_entry()`; the other 4
+# reach no configure-time emitter and gain nothing, because this registers at
+# the emitter's own call site. Zero build dirs gain a reconfigure. What changes
+# is that the freshness stops being an accident of which other function the
+# image happened to call.
+#
+# Deduplicated because a single directory legitimately reaches several emitters.
+function(nros_codegen_tool_reconfigure _tool)
+    if(_tool STREQUAL "" OR NOT EXISTS "${_tool}")
+        return()
+    endif()
+    get_property(_nctr_deps DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+    if(NOT "${_tool}" IN_LIST _nctr_deps)
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_tool}")
+    endif()
+endfunction()
+
 # _nros_write_codegen_args_json(ARGS_FILE <path> PACKAGE <name> OUTPUT_DIR <dir>
 #     ROS_EDITION <edition> [CODEGEN_CONFIG <path>]
 #     INTERFACE_FILES <files...> DEPS <pkgs...>)

--- a/cmake/NanoRosEntry.cmake
+++ b/cmake/NanoRosEntry.cmake
@@ -933,10 +933,11 @@ function(_nros_entry_invoke_codegen)
     # reads the toolchain dep graph and is equally blind to the tool). Depend
     # on the CLI binary itself: its mtime change → cmake re-configure →
     # `nros codegen entry` re-runs.
-    if(EXISTS "${_nros_bin}")
-        set_property(DIRECTORY APPEND PROPERTY
-            CMAKE_CONFIGURE_DEPENDS "${_nros_bin}")
-    endif()
+    #
+    # issue 1018 — this WAS four lines of `set_property` here, and it was the
+    # only configure-time emitter in the tree that had them. Same rule, shared
+    # spelling, so the sibling emitters cannot drift back out of it.
+    nros_codegen_tool_reconfigure("${_nros_bin}")
 
     # CONFIGURE_DEPENDS from the depfile so any change to the launch
     # XML, any package.xml the pkg-index walked, or the bringup's

--- a/docs/issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md
+++ b/docs/issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md
@@ -77,3 +77,112 @@ The same shape as issue 0963: the build knows a fact -- here, that the CLI
 predates its sources -- and can only say so by stopping. 0963 is about numbers
 that are computed and never read; this is about a dependency that is detected
 and never acted on.
+
+## NARROWED 2026-09-05 (phase-424) — the right arrow was broken, not just blunt
+
+The claim above that "the check is the ONLY thing holding the chain" is **false,
+and measuring it found a worse bug than the one reported.**
+
+### What already held, measured
+
+`cmake/NanoRosGenerateInterfaces.cmake:405` carries
+`DEPENDS … "${_NANO_ROS_CODEGEN_TOOL}"`, and it has since 2026-05-23. Built a
+minimal consumer against that generator and touched the CLI binary: the codegen
+command re-ran (`ninja -t query` lists the binary as an input), and — because
+CMake gives custom commands `restat = 1` and codegen writes only-if-changed —
+**nothing downstream rebuilt and the edge settled on the next build**. So the
+over-firing cost of a `just setup-cli` on the BUILD-time lane is one codegen
+run per package, not a cascade. My first hypothesis, that the command would be
+permanently dirty, was refuted by running it.
+
+### What did not hold
+
+A CONFIGURE-time emitter cannot express that edge. `execute_process()` has
+already run by the time ninja decides anything, so its freshness reduces to
+*does a configure happen at all*. Four sites emit at configure time:
+
+| site | verb | registered the tool for reconfigure |
+| --- | --- | --- |
+| `cmake/NanoRosEntry.cmake` | `codegen entry` | yes — issue #182, inline, in its own function |
+| `zephyr/cmake/nros_generate_interfaces.cmake` | `codegen` | **no** |
+| `zephyr/cmake/nros_system_generate.cmake` | `codegen-system` | **no** |
+| `integrations/nano-ros/CMakeLists.txt` (ESP-IDF) | `codegen-system` | **no**, and it fails SOFT |
+
+The Zephyr interfaces generator even carries the right predicate already — an
+`IS_NEWER_THAN` loop at `:284` that names the tool — and it is dead on an
+incremental build, because nothing makes `build.ninja` stale when the tool
+moves. Measured: `zephyr-workspace/build-rust-talker-zenoh`'s `RERUN_CMAKE`
+edge lists **3592 inputs, none under `packages/cli`**.
+
+So a Zephyr image inherited codegen freshness only if it ALSO happened to call
+`nano_ros_entry()`. Grep: **no `examples/zephyr/**/CMakeLists.txt` calls it.**
+Those images generate their interfaces at configure time and keep museum
+generated code after a `nros` rebuild — silently, which is the failure this
+issue argued the stale check exists to prevent, arriving through the door
+nobody was watching. #182 fixed the site; this is the class.
+
+### The fix
+
+`nros_codegen_tool_reconfigure(<tool>)` in `cmake/NanoRosCodegenCore.cmake` —
+one deduplicated spelling, called at all four sites (the entry site's four
+inline lines now route through it). Gate: `just check codegen-tool-reconfigure`
+(`scripts/check-codegen-tool-reconfigure.py`, on the fast line, 15 self-test
+cases on the normal path).
+
+Proved by touch-and-reconfigure in the real shape — registration from inside a
+function frame, called twice:
+
+* REGISTER=OFF → tool absent from `RERUN_CMAKE`, artifact **not** re-emitted.
+* REGISTER=ON  → tool present once (deduped), artifact re-emitted, and the next
+  two `ninja` runs are `no work to do` (no reconfigure loop).
+
+Mutation: reverting the helper call at each of the four sites individually
+turns the gate red at that site, and the gate run against `origin/main` reports
+all four.
+
+### Widening cost — measured, and it is zero
+
+Phase-424 forbids widening a watch set without pricing it against #0835. Of the
+7 Zephyr build dirs in this checkout: 3 reach a configure-time emitter and all
+3 **already** carry the CLI as a configure dependency via `nano_ros_entry()`;
+the other 4 reach no configure-time emitter and gain nothing, because the
+registration happens at the emitter's own call site. **No build dir here gains a
+reconfigure.** What changes is that freshness stops being an accident of which
+other function the image happened to call.
+
+### Why the key is the binary and not `nros codegen-fingerprint`
+
+Option (2) above is still the better key where it applies — the fingerprint
+hashes what the emitters PRODUCE, and 41 distinct `nros` binaries map to 9
+fingerprints, so 78 % of `setup-cli` rebuilds would cost nothing. Two reasons
+it is not this change:
+
+1. **Its corpus covers the message/service/action emitters only** — not
+   `codegen entry`, not `codegen-system`. Keying those two on it would report
+   FRESH for a real change to their emitters, which is the failure mode being
+   closed. One key for four sites, and it has to be the conservative one.
+2. **A configure cannot write its own configure input.** A fingerprint-keyed
+   file needs a producer OUTSIDE the build dir, on the same event that rebuilds
+   the CLI (`just setup-cli` / `scripts/bootstrap.sh`), or the first configure
+   after a CLI rebuild never happens and the narrowing becomes a false FRESH.
+
+That producer plus a fingerprint-keyed key for the interfaces site (only) is
+the remaining work.
+
+### Still open
+
+* The reported symptom — three build stops from the stale-CLI refusal — is
+  **unchanged**, and one of them is a genuine false stop: measured, appending a
+  comment to `packages/cli/nros-cli-core/src/cmd/doctor.rs`, a file that cannot
+  affect any emitted byte, makes every consumer `nros codegen` refuse. The
+  refusal's watch set is the whole CLI closure.
+* Narrowing that watch set is **rejected for now**, deliberately. The emitters
+  reach through `cargo-nano-ros` and `nros-cli-core`, so a crate-level codegen
+  closure is very nearly the whole CLI closure and would not have excluded
+  `cmd/doctor.rs` anyway; and issue 0604 measured a hand-rolled closure walk
+  wrong in both directions at once. A narrowing that is wrong is museum
+  generated code reported as success — strictly worse than the stop.
+* Option (3), one-step recovery, is untouched.
+* `integrations/platformio/nros_codegen.py` runs `codegen-system` per build with
+  no stamping and a soft failure. PlatformIO has no reconfigure model for the
+  cmake helper to hook, so it is out of this fix's reach and stays a known gap.

--- a/docs/roadmap/phase-424-build-graph-freshness-truth.md
+++ b/docs/roadmap/phase-424-build-graph-freshness-truth.md
@@ -52,7 +52,7 @@ they all rest on is built on build-system internals nobody supports.
 | [#0835](../issues/0835-fixture-staleness-probe-families-restale-each-other.md) | fixtures | the cmake and rust families re-stale each other — **oscillation fixed + gated 2026-09-04**; open for the duplicated ThreadX corrosion group, which is wasted disk, not staleness |
 | [#0945](../issues/archived/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | cargo | ~~the shared-cargo-dir campaign rests on five unsupported build-system assumptions~~ **RESOLVED** — six, classified, one gap named |
 | [#1002](../issues/archived/1002-a-derived-knob-needs-three-configures-not-two.md) | cmake | RESOLVED — three is the chain's depth, not a defect; the defect was a bound counting the build dir's lifetime |
-| [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md) | codegen | a codegen change invalidates every consumer, connected only by a manual step |
+| [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md) | codegen | ~~a codegen change invalidates every consumer~~ the configure-time half is closed; **open** for the stale-CLI refusal |
 | [#1046](../issues/archived/1046-px4-stale-tree-guard-checks-a-surviving-directory.md) | px4 | RESOLVED 2026-09-05 — the guard asserted a DIRECTORY that outlives the build that linked it; it asserts `bin/px4`'s CONTENT now, and the three "not covered" sweeps came back empty |
 | [#1050](../issues/1050-px4-demo-links-whatever-archive-was-built-last.md) | px4 | links whatever `libnros_cpp.a` was built last — the recipe (1) and the configure-time guard (2) are fixed; open for (3), `nros::init()` taking slot 0 |
 | [#1056](../issues/archived/1056-session-churn-window-too-short-for-start-skew.md) | test window | ~~a check that can pass on the build it exists to reject~~ **RESOLVED** — it can, and no affordable window fixes it |
@@ -124,9 +124,21 @@ dressed as a self-healing WARNING. Measured today: 116 of 117 rust rows find an
 artifact, 120 of 120 cmake cells do, and exactly one row
 (`packages/testing/qemu-smoltcp-bridge`) is on the silent fallback right now. The
 remedy is specified in the issue — a `DEGRADED\t` line beside the existing
-`FAILED\t` bucket, widening no watch set — and deliberately not landed: it needs
-a built fixture tree to verify, and unverified shell in the freshness gate is the
-defect this phase exists to remove.
+`FAILED\t` bucket, widening no watch set — and **LANDED 2026-09-05** — deferred here
+for a day for want of a way to verify it. Both fallback branches announce
+themselves, `check-fixtures-stale.sh` buckets and counts them as a WARNING, and
+the COUNT is the signal: one is expected, more means a layout moved. Gated by
+case **E** of `check-fixture-staleness-probes`, which builds a library-only cargo
+leaf — the real shape, since that is why `qemu-smoltcp-bridge` is on the fallback
+— and is mutation-verified. Cases A–D all have the artifact PRESENT, so none of
+them reached this branch.
+
+One defect surfaced in the writing, and it would not have failed loudly: a
+degrading probe prints its marker line AND, if the fallback fires, the stale
+line, while `check-fixtures-stale.sh` reads probe output through `mapfile` or
+through one `$( )` capture depending on whether GNU `parallel` is installed — so
+bucketing without re-splitting would have classified the pair **differently
+depending on a tool being present on the machine**.
 
 **The register's biggest item is not the one it named.** Item 4's stated risk (a
 future cargo target-dir GC) has never fired; the side channel having no OWNER has,
@@ -170,3 +182,62 @@ The free alternative is recorded and declined with a reason: dropping
 `MAX_ROUTER_SESSIONS` to 2 buys the same `L <= 18 s` for no wall clock, but needs
 a healthy-count measurement on all twelve cells first, and a flaky cell is worse
 than four seconds of lease band.
+
+## Narrowed: #1018, the codegen chain (2026-09-05)
+
+**The reported defect was a false STOP; measuring it found a false FRESH one
+layer over, and that is what got fixed.**
+
+The issue said the staleness refusal "is the ONLY thing holding the chain".
+Measured, it is not: the BUILD-time generator's codegen command has carried
+`DEPENDS … ${_NANO_ROS_CODEGEN_TOOL}` since 2026-05-23, and touching the binary
+in a minimal consumer re-runs codegen — then, thanks to `restat = 1` plus
+codegen's write-if-changed, settles with nothing downstream rebuilt. (My first
+hypothesis was that this edge would leave the command permanently dirty. Running
+it refuted that; the cost of an emitter-identical `setup-cli` is one codegen run
+per package, not a cascade.)
+
+What has no edge is the CONFIGURE-time emitters, because `execute_process()`
+cannot have one: their freshness is the question *does a configure happen*.
+Four sites emit at configure time and **one** registered the tool — the
+`nano_ros_entry()` site, inline, from issue #182. The Zephyr interfaces
+generator carries the correct `IS_NEWER_THAN` predicate and it is unreachable on
+an incremental build: measured, `build-rust-talker-zenoh`'s `RERUN_CMAKE` edge
+has 3592 inputs and none under `packages/cli`. No `examples/zephyr/**`
+CMakeLists calls `nano_ros_entry()`, so every single-example Zephyr C/C++ image
+keeps museum generated code after a `nros` rebuild.
+
+**Is this #0820's shape? No.** #0820's remedy is a `DEPFILE` on a `cargo` custom
+command — a command that IS in the build graph, missing the file that lists its
+inputs. Here the producer (`just setup-cli`) is deliberately not in the graph at
+all, and the consumer half runs before the graph exists. The `DEPFILE` answer
+does not apply; `CMAKE_CONFIGURE_DEPENDS` is the only edge a configure-time
+emitter can carry.
+
+**Remedy:** `nros_codegen_tool_reconfigure()` in `NanoRosCodegenCore.cmake`, one
+spelling at all four sites, gated by `check-codegen-tool-reconfigure` (fast
+line, 15 self-test cases on the normal path, mutation-verified at each site and
+red on `origin/main` for all four).
+
+**Widening cost: zero, measured.** Of 7 Zephyr build dirs here, the 3 that reach
+a configure-time emitter already carry the CLI as a configure dependency; the
+other 4 reach no emitter and the registration is at the emitter's call site.
+#0835's re-staling is untouched.
+
+**What the phase's fingerprint budget bought here — a refusal.** The obvious
+narrowing is to key on `nros codegen-fingerprint` (41 binaries → 9 fingerprints;
+78 % of rebuilds would cost nothing). It is wrong for three of the four sites:
+the corpus covers the message/service/action emitters and NOT `codegen entry`
+or `codegen-system`, so those two would report FRESH for a real emitter change.
+And a configure cannot write its own configure input, so a fingerprint-keyed
+file needs a producer on the CLI-build event first. Recorded in #1018 as the
+follow-up rather than done badly.
+
+**Still open in #1018:** the stale-CLI refusal itself. Measured: appending a
+comment to `packages/cli/nros-cli-core/src/cmd/doctor.rs` — a file that cannot
+change one emitted byte — makes every consumer `nros codegen` refuse. Narrowing
+that watch set is rejected for now with the reason written down (the emitters
+reach through `cargo-nano-ros`/`nros-cli-core`, so a crate-level closure is
+nearly the whole closure and would not have excluded that file; and 0604
+measured a hand-rolled closure wrong in both directions at once).
+

--- a/integrations/nano-ros/CMakeLists.txt
+++ b/integrations/nano-ros/CMakeLists.txt
@@ -93,6 +93,11 @@ nros_resolve_cli(NROS_EXECUTABLE OPTIONAL CONTEXT "integrations/nano-ros")
 
 if(NROS_EXECUTABLE AND EXISTS "${_nros_bringup_dir}/system.toml")
     file(MAKE_DIRECTORY "${_nros_system_out}")
+    # issue 1018 — same rule as the Zephyr bake: the emitted `system_config.h`
+    # is compiled into the image, so a rebuilt `nros` must re-run this
+    # configure. Doubly so here, because the failure below is SOFT: without the
+    # reconfigure a stale bake is not merely kept, it is kept silently.
+    nros_codegen_tool_reconfigure("${NROS_EXECUTABLE}")
     # Configure-time bake. If the running CLI lacks `codegen-system`
     # (Phase 212.E not yet shipped in this nros-cli), this fails soft
     # so the shim still configures.

--- a/just/check.just
+++ b/just/check.just
@@ -159,6 +159,7 @@ fast-serial: \
     cmake-support-library \
     codegen-invocation \
     codegen-size-bound-golden \
+    codegen-tool-reconfigure \
     config-header-single-writer \
     config-knob-census \
     config-surface \
@@ -998,6 +999,16 @@ embedded-feature-unification:
 [private]
 codegen-invocation:
     @scripts/ci/codegen-invocation-check.sh
+
+# A configure-time emitter must make a rebuilt `nros` re-run its configure
+# (issue 1018). The build-time generator says so in `DEPENDS`; `execute_process`
+# cannot, so the tool goes in `CMAKE_CONFIGURE_DEPENDS` via
+# `nros_codegen_tool_reconfigure()`. #182 registered it at ONE of four sites,
+# inline, so the other three kept museum generated code after a `just setup-cli`
+# unless the image also happened to call `nano_ros_entry()`.
+[group("checks")]
+codegen-tool-reconfigure:
+    @python3 scripts/check-codegen-tool-reconfigure.py
 
 # String-convention guards (forbidden org / retired-tool refs in user surfaces).
 # The `check.yml` step (SSoT).

--- a/scripts/check-codegen-tool-reconfigure.py
+++ b/scripts/check-codegen-tool-reconfigure.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""A configure-time emitter must make a rebuilt `nros` re-run its configure.
+
+Issue 1018. The chain is::
+
+    rosidl-codegen sources  ->  the in-tree `nros` CLI  ->  generated interfaces
+
+and the middle arrow is manual by design (`just setup-cli`; compiling at build
+time is forbidden here). This gate is about the RIGHT arrow, which is not
+manual and is easy to lose.
+
+The BUILD-time generator states it outright: `cmake/NanoRosGenerateInterfaces
+.cmake`'s codegen `add_custom_command` carries `DEPENDS … ${_NANO_ROS_CODEGEN
+_TOOL}`, so a newer tool re-emits. A CONFIGURE-time emitter cannot express that
+edge at all — `execute_process()` has already run by the time ninja is deciding
+anything — so its freshness reduces to *does a configure happen*. If the tool is
+not a `CMAKE_CONFIGURE_DEPENDS` of the directory that emits, the answer after a
+`just setup-cli` is no, and the build dir keeps museum generated code while
+every source-level dependency looks current.
+
+`nano_ros_entry()` learned this as issue #182 and registered the binary inline,
+in its own function body. That fixed the site and not the class: three sibling
+configure-time emitters — the Zephyr interfaces generator, `nros_system_
+generate()`, and the ESP-IDF shim's `codegen-system` — registered nothing, so a
+Zephyr image inherited freshness only when it ALSO happened to call
+`nano_ros_entry()`, which no single-example image does.
+
+WHAT IT CHECKS
+
+Every cmake file that runs an EMITTING `nros` verb at CONFIGURE time must also
+call `nros_codegen_tool_reconfigure()`. `add_custom_command` / `add_custom_target`
+blocks are excluded: those carry the tool in `DEPENDS`, which is the edge this
+gate demands where it cannot be expressed.
+
+The verb is matched wherever it appears as a bare token, not only next to the
+tool, because the three spellings in this tree differ — a direct
+`execute_process(COMMAND "${tool}" codegen-system …)`, a command built into a
+variable (`set(_cmd "${tool}" codegen …)`), and arguments built into a variable
+with the tool supplied at the call (`set(_args codegen entry …)`). An
+adjacency-based first draft missed two of the four sites, which is why the rule
+is written this way. Verbs inside double-quoted strings are prose (a
+`FATAL_ERROR` naming the command) and are blanked before matching.
+
+Run against `origin/main` this reports four files, `NanoRosEntry.cmake` among
+them: that one DID register, inline, in its own function body. Demanding the
+shared spelling is the point — a rule with one call site and no name is a rule
+the next three emitters cannot find.
+
+Emitting verbs are the ones whose output OUTLIVES the configure and is compiled
+into the image: `codegen` (message/service/action bindings, and `codegen entry`)
+and `codegen-system` (`system_config.h`). Deliberately NOT every CLI call:
+
+* `codegen resolve-deps` writes a `.cmake` fragment that the SAME configure
+  `include()`s and that every configure rewrites — it cannot be stale relative
+  to the configure that produced it.
+* the fact/inventory verbs (`ws entity-inventory`, `board facts`, `profile …`)
+  are the same shape: read back inside their own configure.
+
+Both of those still get the tool change the moment any configure runs, and the
+emitters above are what make one run.
+
+The check is FILE-level rather than block-level on purpose. A directory
+legitimately reaches several emitters from one module, the registration is
+deduplicated, and a per-block rule would demand a call beside each one for no
+extra safety.
+
+Usage::
+
+    check-codegen-tool-reconfigure.py [--selftest]
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+HELPER = "nros_codegen_tool_reconfigure"
+
+# Verbs whose emitted files outlive the configure. See the module docstring for
+# why `resolve-deps` and the fact verbs are not here.
+EMITTING_VERBS = ("codegen", "codegen-system")
+
+# `codegen` with this argument is the same-configure fragment writer, not an
+# emitter of anything a later build step compiles.
+NON_EMITTING_ARG = "resolve-deps"
+
+
+def strip_comments(text):
+    """Drop cmake `#` comments, keeping quoted `#` (and every newline)."""
+    out = []
+    for line in text.splitlines(keepends=True):
+        in_str = False
+        cut = None
+        i = 0
+        while i < len(line):
+            c = line[i]
+            if c == "\\" and in_str:
+                i += 2
+                continue
+            if c == '"':
+                in_str = not in_str
+            elif c == "#" and not in_str:
+                cut = i
+                break
+            i += 1
+        out.append(line if cut is None else line[:cut] + "\n")
+    return "".join(out)
+
+
+def blank_blocks(text, command):
+    """Replace every paren-balanced `<command>(...)` call with blanks.
+
+    Keeps the file's length and newlines so later offsets stay meaningful.
+    """
+    pat = re.compile(r"(?<![\w.-])" + re.escape(command) + r"\s*\(")
+    out = list(text)
+    for m in pat.finditer(text):
+        depth = 1
+        i = m.end()
+        while i < len(text) and depth:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        for j in range(m.start(), i):
+            if out[j] != "\n":
+                out[j] = " "
+    return "".join(out)
+
+
+def blank_strings(text):
+    """Blank the contents of double-quoted strings.
+
+    A verb NAMED in a message — `nros codegen entry` inside a FATAL_ERROR — is
+    prose, not an invocation. Every real invocation spells the verb as a bare
+    argument, because cmake would otherwise pass it as one word.
+    """
+    out = list(text)
+    i, in_str = 0, False
+    while i < len(text):
+        c = text[i]
+        if in_str and c == "\\":
+            out[i] = " "
+            if i + 1 < len(text) and text[i + 1] != "\n":
+                out[i + 1] = " "
+            i += 2
+            continue
+        if c == '"':
+            in_str = not in_str
+        elif in_str and c != "\n":
+            out[i] = " "
+        i += 1
+    return "".join(out)
+
+
+VERB_RE = re.compile(
+    r"(?<![\w./$-])(" + "|".join(sorted(EMITTING_VERBS, key=len, reverse=True)) + r")(?![\w./-])"
+)
+
+
+def emitting_verbs(text):
+    """Emitting verbs invoked at CONFIGURE time in this file.
+
+    Build-time `add_custom_command` / `add_custom_target` are excluded: those
+    carry the tool in `DEPENDS`, which is the edge this gate exists to demand
+    where it cannot be expressed.
+
+    The verb is matched wherever it appears as a bare token, not only adjacent
+    to the tool, because all three spellings in this tree are different:
+    `execute_process(COMMAND "${tool}" codegen-system …)`,
+    `set(_cmd "${tool}" codegen …)` run later, and `set(_args codegen entry …)`
+    with the tool supplied at the call. Requiring adjacency missed two of four.
+    """
+    text = blank_strings(blank_blocks(blank_blocks(text, "add_custom_command"), "add_custom_target"))
+    found = set()
+    for m in VERB_RE.finditer(text):
+        verb = m.group(1)
+        if verb == "codegen":
+            tail = text[m.end() : m.end() + 40].split()
+            if tail and tail[0] == NON_EMITTING_ARG:
+                continue
+        found.add(verb)
+    return sorted(found)
+
+
+def offenders(files, read):
+    """Files running an emitting verb at configure time with no registration."""
+    bad = []
+    for rel in files:
+        text = strip_comments(read(rel))
+        verbs = emitting_verbs(text)
+        if verbs and HELPER + "(" not in blank_strings(text):
+            bad.append((rel, verbs))
+    return bad
+
+
+def tracked_cmake():
+    out = subprocess.run(
+        ["git", "ls-files", "*.cmake", "*CMakeLists.txt", "*.cmake.in"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    return [p for p in out if not p.startswith("third-party/")]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest(verbose=True)
+    # On the NORMAL path, every time — a negative control nobody runs decays
+    # into a comment (AGENTS.md "a gate must run its own selftest").
+    selftest()
+
+    files = tracked_cmake()
+    bad = offenders(files, lambda rel: (REPO / rel).read_text(errors="replace"))
+    if bad:
+        print("check-codegen-tool-reconfigure: FAILED", file=sys.stderr)
+        for rel, verbs in bad:
+            print(
+                f"  {rel}: runs `nros {'`, `nros '.join(verbs)}` at configure time "
+                f"but never calls {HELPER}()",
+                file=sys.stderr,
+            )
+        print(
+            "\nA configure-time emitter has no add_custom_command DEPENDS to carry the\n"
+            "tool, so nothing re-runs it when `nros` is rebuilt and the build dir keeps\n"
+            "museum generated code (issue 1018, and #182 one site over). Call\n"
+            f"  {HELPER}(\"<resolved nros path>\")\n"
+            "beside the emitter. Do not exempt the call site — extend this gate if a\n"
+            "genuinely non-emitting verb trips it.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"check-codegen-tool-reconfigure: OK ({len(files)} cmake files)")
+    return 0
+
+
+def selftest(verbose=False):
+    ok = fail = 0
+
+    def chk(what, cond):
+        nonlocal ok, fail
+        if cond:
+            ok += 1
+            if verbose:
+                print(f"  ok   {what}")
+        else:
+            fail += 1
+            print(f"  FAIL {what}", file=sys.stderr)
+
+    reg = f'{HELPER}("${{_tool}}")\n'
+    emit = 'execute_process(COMMAND "${_tool}" codegen --args-file "${_a}")\n'
+    emit_sys = 'execute_process(COMMAND "${_cli}" codegen-system --out "${_o}")\n'
+    resolve = (
+        'execute_process(COMMAND "${_tool}" codegen resolve-deps\n'
+        '    --package-xml "${_x}" --output-cmake "${_o}")\n'
+    )
+    # The two real spellings an adjacency rule missed.
+    via_cmd_var = (
+        'set(_codegen_cmd "${_tool}" codegen --language cpp --args-file "${_a}")\n'
+        "execute_process(COMMAND ${_codegen_cmd} RESULT_VARIABLE _rc)\n"
+    )
+    via_args_var = (
+        "set(_cli_args\n    codegen entry\n    --lang c)\n"
+        'execute_process(COMMAND "${_tool}" ${_cli_args})\n'
+    )
+
+    files = {
+        "bare.cmake": emit,
+        "registered.cmake": reg + emit,
+        "system.cmake": emit_sys,
+        "resolve.cmake": resolve,
+        "custom.cmake": 'add_custom_command(OUTPUT o COMMAND "${_tool}" codegen -a x)\n',
+        "commented.cmake": "# execute_process(COMMAND nros codegen --args-file x)\n",
+        "varonly.cmake": 'execute_process(COMMAND "${_NANO_ROS_CODEGEN_TOOL}" --version)\n',
+        "nested.cmake": (
+            reg + 'execute_process(COMMAND ${CMAKE_COMMAND} -E env A=b\n'
+            '    "${_tool}" codegen --args-file "${_a}"\n'
+            '    RESULT_VARIABLE _rc)\n'
+        ),
+        "both.cmake": emit + resolve,
+        "cmdvar.cmake": via_cmd_var,
+        "argsvar.cmake": via_args_var,
+        "prose.cmake": (
+            reg.replace(HELPER, "other_fn")
+            + 'message(FATAL_ERROR "`nros codegen entry` failed")\n'
+        ),
+    }
+    run = lambda names: offenders(names, files.get)  # noqa: E731
+
+    chk("an unregistered configure-time `codegen` FAILS",
+        run(["bare.cmake"]) == [("bare.cmake", ["codegen"])])
+    chk("registering it passes", run(["registered.cmake"]) == [])
+    chk("`codegen-system` counts too",
+        run(["system.cmake"]) == [("system.cmake", ["codegen-system"])])
+    chk("`codegen-system` is not reported as `codegen`",
+        run(["system.cmake"])[0][1] == ["codegen-system"])
+    chk("`codegen resolve-deps` is not an emitter", run(["resolve.cmake"]) == [])
+    chk("a BUILD-time add_custom_command is out of scope (it carries DEPENDS)",
+        run(["custom.cmake"]) == [])
+    chk("a commented-out emitter is not a finding", run(["commented.cmake"]) == [])
+    chk("a variable NAMED for codegen is not a verb", run(["varonly.cmake"]) == [])
+    chk("an env-prefixed, multi-line COMMAND is still seen",
+        run(["nested.cmake"]) == [])
+    chk("a resolve-deps sibling does not excuse a real emitter",
+        run(["both.cmake"]) == [("both.cmake", ["codegen"])])
+    # Mutation: the gate must not pass merely because the helper NAME appears.
+    chk("the helper name in a comment does not satisfy the rule",
+        offenders(["m.cmake"], {"m.cmake": f"# {HELPER}\n" + emit}.get)
+        == [("m.cmake", ["codegen"])])
+    chk("a command built into a VARIABLE is still an invocation",
+        run(["cmdvar.cmake"]) == [("cmdvar.cmake", ["codegen"])])
+    chk("arguments built into a variable are too",
+        run(["argsvar.cmake"]) == [("argsvar.cmake", ["codegen"])])
+    chk("a verb named inside a quoted message is prose, not an invocation",
+        run(["prose.cmake"]) == [])
+    chk("the whole tracked set is enumerable", len(tracked_cmake()) > 0)
+
+    if verbose:
+        print(f"\n{ok} passed, {fail} failed")
+    if fail:
+        print("check-codegen-tool-reconfigure self-test: FAILED", file=sys.stderr)
+        raise SystemExit(1)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zephyr/cmake/nros_generate_interfaces.cmake
+++ b/zephyr/cmake/nros_generate_interfaces.cmake
@@ -275,6 +275,13 @@ function(nros_generate_interfaces target)
     message(STATUS "Generating nros C interfaces for ${target}")
   endif()
 
+  # issue 1018 — the IS_NEWER_THAN loop below is the right predicate and it was
+  # unreachable: it only runs when a configure runs, and nothing made a
+  # configure run when the tool moved. Register the emitter's own tool as a
+  # configure dependency so this lane's freshness is a property of THIS call
+  # site, not of whether the image also called `nano_ros_entry()`.
+  nros_codegen_tool_reconfigure("${_NROS_ZEPHYR_CODEGEN_TOOL}")
+
   set(_codegen_needed FALSE)
   foreach(_out ${_expected_outputs})
     if(NOT EXISTS "${_out}")

--- a/zephyr/cmake/nros_system_generate.cmake
+++ b/zephyr/cmake/nros_system_generate.cmake
@@ -163,6 +163,12 @@ function(nros_system_generate bringup_pkg)
     else()
         get_filename_component(_workspace "${_bringup_dir}" DIRECTORY)
     endif()
+    # issue 1018 — `codegen-system` writes `system_config.h`, which is compiled
+    # into the image, so the bake outlives the configure that produced it. This
+    # runs unconditionally per configure, which means its freshness is entirely
+    # the question of whether a configure happens at all.
+    nros_codegen_tool_reconfigure("${_nros_cli}")
+
     execute_process(
         COMMAND "${_nros_cli}" codegen-system
                 --workspace "${_workspace}"


### PR DESCRIPTION
Phase-424's last "no edge at all" case. **The issue's central claim is false, and
measuring it found a worse bug.**

## What the issue said, and what is actually there

#1018 says the staleness check is the only thing holding the codegen chain.
Measured against the real generator with a minimal consumer:
`cmake/NanoRosGenerateInterfaces.cmake:405` has carried
`DEPENDS … "${_NANO_ROS_CODEGEN_TOOL}"` since 2026-05-23. `ninja -t query` lists
the binary as an input, touching it re-runs codegen, and because CMake sets
`restat = 1` and codegen writes only-if-changed, **nothing downstream rebuilt and
the edge settled on the next build**.

My first hypothesis — a permanently dirty command — was refuted by running it.

## The worse bug: a configure-time emitter cannot express that edge at all

`execute_process()` has already run by the time ninja decides anything, so a
configure-time emitter's freshness reduces to *does a configure happen*. Four
sites emit at configure time; **one** registered the tool
(`cmake/NanoRosEntry.cmake`, inline, issue #182). The Zephyr interfaces generator
carries the correct predicate — an `IS_NEWER_THAN` loop naming the tool — and it is
**unreachable on an incremental build**.

Measured: `zephyr-workspace/build-rust-talker-zenoh`'s `RERUN_CMAKE` edge lists
**3592 inputs, none under `packages/cli`**. And **0 of 18**
`examples/zephyr/**/CMakeLists.txt` call `nano_ros_entry()` — verified
independently before publishing.

So every single-example Zephyr C/C++ image keeps **museum generated code** after a
`nros` rebuild, silently. That is a false FRESH, and it is worse than the false
STOP the issue reported.

**Not #0820's shape.** There a cargo custom command *is* in the graph and lacks its
`DEPFILE`; here the producer (`just setup-cli`) is deliberately not in the graph and
the consumer runs before the graph exists. `CMAKE_CONFIGURE_DEPENDS` is the only
edge available.

## The fix, proved by touch-and-reconfigure

`nros_codegen_tool_reconfigure()` — one deduplicated spelling at all four sites,
with the entry site's inline lines routed through it. Registration happens at the
emitter's own call site, which is what makes the cost zero (below).

Real shape, registration from inside a function frame called twice:

- `REGISTER=OFF` → tool absent from `RERUN_CMAKE`, artifact **not** re-emitted
- `REGISTER=ON` → tool present **once** (deduped), artifact re-emitted, next two
  `ninja` runs `no work to do` — no reconfigure loop

Gate `check-codegen-tool-reconfigure`, fast line, 15 self-test cases on the normal
path. Mutation: reverting the helper call at each of the four sites individually
reds the gate **at that site**; run against `origin/main` it reports all four.

## Widening cost: zero, measured

Of the 7 Zephyr build dirs in the shared checkout, the 3 that reach a configure-time
emitter **already** carry the CLI as a configure dependency via `nano_ros_entry()`;
the other 4 reach no configure-time emitter and gain nothing. #0835 is untouched —
that constraint was checked, not assumed.

**The fingerprint narrowing was refused, with the reason recorded:**
`codegen-fingerprint`'s corpus covers the message/service/action emitters and *not*
`codegen entry` or `codegen-system`, so three of four sites would report FRESH for a
real emitter change — and a configure cannot write its own configure input.

## Left open, narrowed

The refusal itself. Measured: appending a comment to
`packages/cli/nros-cli-core/src/cmd/doctor.rs` — a file that cannot change one
emitted byte — makes every consumer `nros codegen` refuse. Narrowing that watch set
is rejected with the reason written down (issue 0604's lesson; the emitters reach
through `cargo-nano-ros`/`nros-cli-core`, so a crate-level closure would not have
excluded that file anyway). `integrations/platformio/nros_codegen.py` stays a known
gap — no reconfigure model to hook.

## Tier

`check::cli-fresh` ok · `check::fast` **207 gates green** · `test-unit` 1107 green ·
`check lane-contracts` ok. `check::build` red on three pre-existing items
(`test-targets`' clippy — that one is mine, fixed in #424; `workspace-features`;
api-parity), all Rust-only, and this diff touches **zero** `.rs`/`.toml`.

Rebased before pushing: the branch was 6 behind and its diff would otherwise have
reverted #419's new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
