### PR TITLE
docs(#0945, #1056): classify the assumptions, and re-derive the window that was going to be doubled

### DIFF
--- a/docs/issues/archived/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md
+++ b/docs/issues/archived/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md
@@ -1,14 +1,15 @@
 ---
 id: 945
-title: "The shared-cargo-dir campaign rests on five unsupported build-system
+title: "The shared-cargo-dir campaign rests on unsupported build-system
   internals — a Corrosion path formula, an unstable cargo flag, cargo's private
-  `.fingerprint` format, a side channel inside cargo's target dir, and an
-  undocumented depfile location"
+  `.fingerprint` format, a side channel inside cargo's target dir, an
+  undocumented depfile location, and (found here) cargo's target-dir output
+  layout"
 status: resolved
 type: tech-debt
 area: build
-resolved: 2026-09-05
-related: [issue-1031, issue-0805, issue-0616, issue-0499, issue-0834, issue-0112]
+related: [issue-0805, issue-0616, issue-0499, issue-0834, issue-0835, issue-0112,
+  phase-424]
 ---
 
 ## Symptom
@@ -22,7 +23,82 @@ sharing and reads the wrong file.
 Filed because the exposure was reviewed once, deliberately, and that review
 should not have to be reconstructed from commit messages.
 
-## The five
+## RESOLVED 2026-09-05 (phase-424)
+
+The phase's acceptance was: *"0945's five assumptions are either supported by
+something we can point at, or written down as accepted risk with what would break
+if each fails."* Every item below now carries a VERDICT, an EVIDENCE line, and a
+DETECTION line. Three things changed on the way:
+
+1. **One claimed mitigation was false and is now real.** Item 3 said both
+   fingerprint tools have a `--self-test` that would surface a schema change.
+   `nros-leaf-graph`'s never touched the parser at all, and
+   `nros-shared-dir-churn`'s wrote the same key names it read, so both stayed
+   green through a rename while answering wrongly. Both now REFUSE, both
+   self-tests mutate the key, and both run that self-test on their NORMAL path
+   so the control is exercised at the moment a number is about to be quoted.
+2. **A SIXTH assumption was found**, in the layer this issue is about but not on
+   the list: cargo's `[<triple>/]<profile>/<bin>` output layout inside a
+   `--target-dir`, which the two DIFFERENTIAL staleness probes glob for. Item 6.
+3. **The classification is now per PROBE FAMILY**, because "which of these does
+   the freshness machinery actually rest on" turned out to have a different
+   answer than the register implied — see the map below.
+
+Nothing is retired: items 1, 2, 4, 5 and 6 remain live exposure, by design, with
+their detection stories written down. What remains as WORK is item 4's consumer
+migration, which is a wave and is recorded in phase-424.
+
+## Which probe family depends on which assumption
+
+Measured on `origin/main`, 2026-09-05, by running the manifest:
+
+| family | rows | decides by |
+| --- | ---: | --- |
+| cmake cells (`--lang c` 61, `--lang cpp` 59) | **120** | DIFFERENTIAL — md5 of the top-level executables in the cell's own build dir, before and after an incremental `cmake --build` |
+| rust fixtures (`--builder cargo`) | **117** | DIFFERENTIAL — md5 of the ROW's own binaries under the phase-340 group `--target-dir` |
+| workspace fixtures | **94** | `.inputsig` — a signature over sources + codegen fingerprint + measured dep closure |
+| compile-checks | **40** | `.inputsig` — same shape |
+| | **371** | 237 differential, 134 signature |
+
+The two kinds fail in OPPOSITE directions, and that is what decides which
+assumption hurts which:
+
+* A **differential** family answers "did these bytes move?". It needs to FIND the
+  artifact. If cargo's directory identity or output layout moves under it, it
+  finds nothing, falls back, and the fallback is the pre-0835 signal that is
+  permanently "stale" for these rows — a false STALE dressed as a self-healing
+  WARNING. It is also structurally blind to an input that is stale in a STABLE
+  way: a wrong generated header produces the same wrong bytes twice, so the
+  verdict is FRESH.
+* A **signature** family answers "does the recorded stamp still match a recomputed
+  one?". It never hashes an ARTIFACT, so a directory-identity or layout change
+  cannot corrupt its verdict — it can only make the stamp unfindable, and that
+  reads as MISSING and fails loud. (`workspace-fixture-stale.sh` puts the stamp
+  under the row's own `target_dir`/`build_subdir`; `compile-check-stale.sh` puts
+  it under `nros_build_dir`, our root. Neither is Corrosion's.) The one place a
+  signature family reaches into a build tree is
+  `nros_dep_closure_manifest` -> `dep-closure.py`, and what it reads there is
+  Make-syntax `*.d` dep-info plus cmake/ninja re-configure edges — item 5's
+  class, and it degrades to an empty closure rather than a wrong one.
+
+Per assumption:
+
+| # | assumption | cmake cells (120, diff) | rust fixtures (117, diff) | workspace (94, sig) | compile-check (40, sig) |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Corrosion symlink | **cost only** | no | no | no |
+| 2 | `--artifact-dir` | 13 nuttx rows, loud | no | no | no |
+| 3 | `.fingerprint` parse | no | no | no | no |
+| 4 | header side channel | **yes, and invisible** | leaves that link nros-c/cpp | partly | partly |
+| 5 | depfile location | **yes** (short watch list) | yes | no | no |
+| 6 | target-dir layout | fallback exists, unused | **yes, silent** | no | no |
+
+Item 3 touches no family: both tools are hand-invoked diagnostics, nothing in
+`check-fast` or the probe path parses `.fingerprint`, and nothing should.
+(`scripts/build/dep-closure.py`, which the two signature families DO use, reads
+Make-syntax `*.d` dep-info and cmake/ninja re-configure edges — that is item 5's
+class, not item 3's.)
+
+## The six
 
 ### 1. The Corrosion symlink redirects a path Corrosion computes privately
 
@@ -32,99 +108,159 @@ symlinking over `${CMAKE_BINARY_DIR}/cargo`, because Corrosion derives its
 and, in its own words there, *"Corrosion 0.6.1 exposes no knob for the directory
 (it is a plain local)"*.
 
-RISK: a Corrosion upgrade that moves or renames that path leaves the symlink
-pointing at nothing, or at a directory Corrosion no longer uses. Sharing then
-stops silently — the build still succeeds, just slower, and the only signal is a
-number nobody is watching.
-
-BLAST RADIUS: six platforms (freertos, native, nuttx, qemu-baremetal,
-threadx-linux, threadx-riscv64). This is the campaign's single largest
-dependency on someone else's internals, and it PREDATES phase-400.
-
-MITIGATED 2026-08-31 — the redirect stays, but it is now WITNESSED.
-
-First the retirement question, since it is the better outcome and had not been
-asked: is there a supported knob yet? No. Read against the pinned v0.6.1 AND
-against upstream `master`: the same
+**VERDICT: accepted risk, witnessed.** Read against the pinned v0.6.1 AND against
+upstream `master`: the same
 `cmake_path(APPEND CMAKE_BINARY_DIR ${build_dir} cargo "<folder>_<hash5>")`,
-still a plain local, still no cache variable, no `corrosion_import_crate()`
-argument, no target property. So the symlink is not a workaround for a version
-we are behind on — it is the only override point that exists, and "bump
-Corrosion and use the knob" is not available.
+still a plain local, no cache variable, no `corrosion_import_crate()` argument,
+no target property. The symlink is not a workaround for a version we are behind
+on — it is the only override point that exists.
 
-What landed instead is `nros_assert_shared_cargo_dir_used()`
-(cmake/NanoRosCorrosion.cmake) driving `scripts/check-shared-cargo-dir-used.sh`
-as a build-time check on every Corrosion leaf that shares. It asserts the
-RESULT, never the formula — a second copy of Corrosion's path rule would drift
-from it silently, which is the defect rather than the fix:
+**WHAT BREAKS: not correctness — AFFORDABILITY, and that is the correction this
+review makes.** The intuition is that a dead redirect corrupts the cmake cells'
+freshness verdict. It cannot: `cmake-fixture-stale.sh::_arts()` hashes the
+executables in `$dir/$sub`, the CELL's own build dir, and never reads the cargo
+tree, so where Corrosion writes cannot change the bytes being compared. What a
+dead redirect does instead is make each of the 120 cells rebuild nros-c /
+nros-cpp from scratch — inside a probe that builds all 120. The gate stops being
+runnable rather than starting to lie, which is a different failure needing a
+different alarm.
+
+**DETECTION: `nros_assert_shared_cargo_dir_used()`** (cmake/NanoRosCorrosion.cmake)
+driving `scripts/check-shared-cargo-dir-used.sh` as a build-time check on every
+Corrosion leaf that shares. It asserts the RESULT, never the formula — a second
+copy of Corrosion's path rule would drift from it silently, which is the defect
+rather than the fix:
 
   1. `${CMAKE_BINARY_DIR}/cargo` is still a symlink at the directory THIS
      configure chose;
   2. an artifact with the built target's name exists under that directory and
      its size matches the copy Corrosion produced.
 
-Everything it consumes is documented or ours — `$<TARGET_FILE:...>` and
-stat(2). It parses nothing.
-
-Measured on `examples/native/c/talker` with sharing on: the healthy build prints
-`shared-cargo-dir OK (nros_c-static)`, and all four dead-redirect states fail
-with the artifact paths named. `ninja -t query` puts `libnros_c.a` above the
+Everything it consumes is documented or ours — `$<TARGET_FILE:...>` and stat(2).
+It parses nothing. Measured on `examples/native/c/talker`: the healthy build
+prints `shared-cargo-dir OK (nros_c-static)`, and all four dead-redirect states
+fail with the artifact paths named. `ninja -t query` puts `libnros_c.a` above the
 `||` line, so the witness re-runs on a real archive change and not on an
 order-only edge (issue 0268's rule); a no-op rebuild does not re-run it.
 
-WHAT IT STILL CANNOT CATCH, precisely: a long-lived build dir that shared
-successfully BEFORE a Corrosion upgrade keeps a same-named artifact in place,
-so with no code change the sizes can still match and this passes. It cannot
-pass for long — any edit moves the size — and it cannot pass at all for a new
-key, which is what a reconfigure after an upgrade produces. Byte-comparing
-would close the hole and cost a full read of a multi-hundred-MB archive on
-every leaf build; not worth it for a performance-regression detector.
+**WHAT IT STILL CANNOT CATCH, precisely:** a long-lived build dir that shared
+successfully BEFORE a Corrosion upgrade keeps a same-named artifact in place, so
+with no code change the sizes can still match and this passes. It cannot pass for
+long — any edit moves the size — and it cannot pass at all for a new key, which
+is what a reconfigure after an upgrade produces. Byte-comparing would close the
+hole and cost a full read of a multi-hundred-MB archive on every leaf build; not
+worth it for a performance-regression detector.
 
 Escape hatch: `NROS_ALLOW_UNSHARED_CARGO_DIR=1` downgrades the failure to a
-warning, for someone mid-upgrade who wants the build to finish.
+warning, for someone mid-upgrade who wants the build to finish. The witness's own
+negative control (five fixtures, including the state only the symlink arm can
+catch) runs on the NORMAL path, not behind the flag — a witness that had quietly
+stopped witnessing would be this very defect one level up. `just check
+shared-cargo-dir-witness` (fast line) runs it standalone.
 
-The witness's own negative control (five fixtures, including the state only the
-symlink arm can catch) runs on the NORMAL path, not behind the flag — a witness
-that had quietly stopped witnessing would be this very defect one level up.
-`just check shared-cargo-dir-witness` (fast line) runs it standalone.
+BLAST RADIUS: six platforms (freertos, native, nuttx, qemu-baremetal,
+threadx-linux, threadx-riscv64). This is the campaign's single largest dependency
+on someone else's internals, and it PREDATES phase-400.
 
 ### 2. `--artifact-dir` is an explicitly unstable cargo flag
 
-The NuttX FFI driver (packages/api/nros-c/cmake/nros-nuttx.cmake) passes
+The NuttX FFI driver (packages/api/nros-c/cmake/nros-nuttx.cmake:334) passes
 `-Z unstable-options --artifact-dir` to evict per-leaf artifacts from a shared
-target dir. It survives only because that crate is pinned to a nightly
-toolchain, and the flag has already been renamed once (`--out-dir`).
+target dir. It survives only because that crate is pinned to a nightly toolchain
+(`packages/boards/nros-board-nuttx-qemu/nros-nuttx*-ffi/rust-toolchain.toml`),
+and the flag has already been renamed once (`--out-dir`).
 
-RISK: a rename or a semantics change breaks the NuttX lane at the point where it
-copies its kernel ELF. Loud, at least.
+**VERDICT: accepted risk, loud in every direction.** A rename, a removal or a
+stabilisation all make cargo exit non-zero, and every consumer of that artifact
+is downstream of the same cargo command. There is no arm where the flag silently
+stops copying: the CMake byproduct `${_artifact_dir}/nros-nuttx-ffi` is what the
+kernel link consumes, so an uncopied artifact is a missing file, not a stale one.
+
+**WHAT BREAKS:** the thirteen nuttx cells in the cmake differential family
+(measured: 6 `examples/qemu-arm-nuttx/c`, 1 `examples/qemu-riscv-nuttx/c`, 6
+`examples/qemu-arm-nuttx/cpp`) plus the nuttx compile-check and workspace rows.
+
+**HOW YOU NOTICE, and the one weak spot:** `cmake-fixture-stale.sh` reports a
+cell whose build FAILS by printing its build dir — so it surfaces as STALE, and
+the cell then fails the fixture gate. But that probe captures cmake's output into
+`$out` and discards it on the failure branch, and `check-fixtures-stale.sh` sends
+probe stderr to a file it only prints on a probe CRASH. So the verdict is loud and
+the CAUSE is not: the reader sees "stale", not "cargo rejected `--artifact-dir`".
+That is an attribution gap, not a detection gap, and it is shared with every other
+way a cell can fail to build.
 
 NOTE: this is also why the Zephyr C/C++ lane cannot use the same eviction —
 native_sim builds on STABLE, so the flag is unavailable there. That constraint is
 what forces features into the shared-dir key and caps the Zephyr collapse at
 70 -> 28 build dirs instead of 70 -> 14 (phase-400 W5).
 
-### 3. `just leaf-graph` and `just shared-dir-churn` parse cargo's private
-`.fingerprint` format
+### 3. `just leaf-graph` and `just shared-dir-churn` parse cargo's private `.fingerprint` format
 
 Both tools read `<target-dir>/**/.fingerprint/<unit>/*.json` — an on-disk format
 with no stability guarantee and no documentation. `deps`, `features`,
 `compile_kind` and the `local` array of `RerunIfEnvChanged` / `RerunIfChanged`
 entries are all internal.
 
-RISK: a cargo release changes the schema and the tools return wrong answers
-rather than errors — the shape that already cost this phase real time when
-`leaf-graph` reported a dependency that had been removed.
+**VERDICT: accepted risk — and the mitigation this issue claimed did not exist.
+It does now.**
 
-WHY IT WAS STILL WORTH BUILDING: the question they answer ("what did THIS build
-compile, and who required it?") has no supported interface. `cargo tree`
+The claim was: *"both have `--self-test`, so a schema change that breaks parsing
+surfaces as a failing self-test rather than a plausible wrong number."* Checked,
+2026-09-05, and FALSE on both counts:
+
+* `nros-leaf-graph --self-test` fed `requirer_map` a hand-written `units` list.
+  It never opened a `.json` file, so it could not see a schema change at all.
+  Every key is read with `.get(..., default)`, so a renamed `deps` does not
+  raise — every crate reads as a build root and `--exclusive-to X` answers
+  **"nothing leaves"**. That is plausible, optimistic, and wrong in exactly the
+  direction of the three phase-400 estimates this tool exists to correct.
+  A renamed `compile_kind` labels every unit "host" and conflates the two graphs
+  — the same class as the path-based guess the tool already replaced once.
+* `nros-shared-dir-churn --self-test` DID exercise the parser, but by WRITING the
+  same key names it reads. A rename moves both ends together: every unit parses
+  to an empty env dict and an empty path set, every unit therefore agrees with
+  every other, and the tool prints *"These trees are safe to collapse onto one
+  --target-dir"* — the most dangerous sentence it can say, on evidence it did not
+  read. Its existing vacuity guard does not catch this: it fires on "no unit is
+  common to two trees", and here every unit is common.
+
+**DETECTION, landed here.** Both tools now REFUSE (`INCONCLUSIVE`, rc 2) when
+records were read and not one carried the key the answer depends on:
+
+* `nros-leaf-graph`: `schema_complaint()` on `deps` and on `compile_kind`.
+  Measured: every record cargo writes today carries both — `lib-*`,
+  `build-script-build*` and `run-build-script-*` in a populated tree all have the
+  identical key set — so "records read, none carried it" is a rename, not a legal
+  shape.
+* `nros-shared-dir-churn`: refuses when no record in any tree yielded a
+  `RerunIfEnvChanged` or `RerunIfChanged` entry. `Precalculated` entries are
+  normal and carry neither (measured: 14 of 125 records in the freertos tree, 16
+  of 72 in qemu-arm-baremetal), so the predicate is "not ONE record in ANY tree",
+  never "some record yielded none".
+
+Both self-tests now MUTATE the key and assert the refusal, and assert that the
+refusal NAMES the key. Mutation-checked in both directions: disable
+`schema_complaint` and `nros-leaf-graph --self-test` reports 3 FAILs (rc 1) while
+printing the wrong graph; disable the churn guard and its self-test dies on
+`a renamed .fingerprint schema still certified sharing`.
+
+**And the self-tests are RUN — from `main`, not from a flag.** The first cut of
+this added a dedicated `check` gate for the pair; `check-gate-selftests` rejected
+it, and it was right to: *"a negative control nobody runs decays into a comment.
+Call it from main."* For a hand-invoked DIAGNOSTIC that is the stronger placement
+anyway — the moment the guard has to be wired is the moment someone is about to
+quote a number out of the tool, not a CI lane nobody reads. Both `main()`s now run
+`self_test(quiet=True)` before doing any work and refuse to report if it fails
+(`run_selftest=False` on the self-test's own re-entrant calls). Measured overhead:
+~10 ms for `leaf-graph`, ~50 ms for `shared-dir-churn`, on tools that then walk a
+target dir.
+
+**WHY THEY ARE STILL WORTH HAVING:** the question they answer ("what did THIS
+build compile, and who required it?") has no supported interface. `cargo tree`
 re-resolves the workspace and answers a different question, which is exactly the
-mistake these tools exist to prevent. The honest position is that they are
-DIAGNOSTIC tools, not gates: nothing in `check-fast` depends on them, and nothing
-should.
-
-PARTIAL MITIGATION ALREADY IN PLACE: both have `--self-test`, so a schema change
-that breaks parsing surfaces as a failing self-test rather than a plausible wrong
-number.
+mistake these tools exist to prevent. They remain DIAGNOSTIC tools: nothing in
+`check-fast` depends on their OUTPUT, and nothing should. The gate checks that
+they still parse, not that a tree is healthy.
 
 ### 4. The generated headers are a side channel inside cargo's target dir
 
@@ -132,21 +268,51 @@ Build scripts write `$CARGO_TARGET_DIR/nros-{c,cpp}-generated/nros/*.h` — a pa
 INSIDE cargo's tree that cargo does not manage. It works because nothing cleans
 it, not because it is supported.
 
-RISK: any future cargo target-dir GC treats those files as unowned. And it is
-already the direct cause of the W5 blocker: share the target dir and the second
-image takes a cache hit, the build script never re-runs, and the directory the
-consumers were pointed at is never written.
+**VERDICT: accepted risk, and the highest-incidence one in the register — but not
+for the reason first written.** The stated risk was a future cargo target-dir GC
+treating those files as unowned. That has never fired. What HAS fired, six times,
+is the consequence of the side channel having no owner, so every consumer grows
+its own rule for which copy is authoritative:
 
-BEING ADDRESSED: phase-400 W5.c emits the same headers to `$OUT_DIR` — cargo's
+| issue | what went wrong |
+| --- | --- |
+| 0360 | written to a FLAT path, so two feature sets overwrite one header |
+| 0834 | the mirror reaches a state no re-run repairs (stamp present, header absent) |
+| 0978 | the mirror prefers a leaf's OWN header whenever present |
+| 0985 | a configure-time heal wrote a museum sizes header over a correct one |
+| 0987 | the mirror's `cargo/*/` glob took the FIRST candidate, not the newest |
+| 1031 | no RMW selected, both build scripts decline to write, three snippets fail |
+
+**WHAT BREAKS, and why the differential probes cannot see it.** The cmake cells
+compile against `-Itarget/nros-{c,cpp}-generated`. A header that is stale, absent
+or from the wrong variant produces the same wrong bytes on the "before" build and
+on the "after" build, so `md5(before) == md5(after)` and the cell reads FRESH. A
+differential probe is structurally blind to an input that is stale in a STABLE
+way. This is the one place in the register where an assumption failing makes a
+freshness verdict WRONG rather than merely expensive.
+
+**DETECTION:** `check-orphan-generated-stamp` (fast line) catches 0834's state —
+a `.stamp` with no `.h` beside it. `nros_config_generated.h`'s variant slug and
+`integrations/px4/NanoRosArchivePairing.cmake` (phase-424) catch a header paired
+with the wrong archive, at configure time. Nothing catches "header present,
+correct variant, older than the sources", which is why the migration below is the
+real remedy rather than another guard.
+
+**BEING ADDRESSED:** phase-400 W5.c emits the same headers to `$OUT_DIR` — cargo's
 sanctioned location, per-unit and hashed BY CARGO, so two feature sets cannot
 collide without us keying anything. Measured: default features and
-`rmw-cffi,platform-posix,std,ros-humble` land in different `OUT_DIR`s. The path
-is discoverable on the stable JSON stream (`{"reason":"build-script-executed",
-… "out_dir": …}`), which cargo emits even on a FULLY CACHED run (measured: 13
-events with nothing to rebuild) — the property the side channel lacks.
+`rmw-cffi,platform-posix,std,ros-humble` land in different `OUT_DIR`s. The path is
+discoverable on the stable JSON stream (`{"reason":"build-script-executed", …
+"out_dir": …}`), which cargo emits even on a FULLY CACHED run (measured: 13 events
+with nothing to rebuild) — the property the side channel lacks.
 
-The side-channel write stays for now; consumers migrate to the OUT_DIR copy, and
-the side channel can be deleted once none remain.
+**REMAINING WORK, counted not estimated** (`git grep -n
+'nros-c-generated\|nros-cpp-generated' -- ':!docs'`, 2026-09-05): **128 hits
+across 26 files**, including `cmake/NanoRosNodeRegister.cmake`,
+`cmake/NanoRosVerbs.cmake`, `integrations/nuttx/Make.defs`,
+`integrations/px4/NanoRosPx4Module.cmake`, `zephyr/CMakeLists.txt`, and 49 hits in
+`just/check.just` alone. Deleting `write_header_to_target_dir` needs all of them
+moved first, which is a wave, not an afternoon. Tracked in phase-424.
 
 ### 5. The probe depfile's location is an undocumented layout convention
 
@@ -155,37 +321,97 @@ the UPLIFTED artifact and never beside the hashed `deps/` copy. Measured in this
 repo's probe store: 182 uplifted rlibs with 182 depfiles, 269 `deps/` rlibs with
 none.
 
-RISK: a layout change silently removes the watch list, which is issue 0563's
-defect (a probe that measures a crate and then does not watch it).
+**VERDICT: accepted risk, loud in the direction that matters, quiet in one that
+does not have a cheap guard.**
 
-MITIGATION ALREADY IN PLACE: the lookup tries both spellings and PANICS if
-neither exists, so the failure is loud and names the file. Pinned by a unit test.
+**WHAT BREAKS:** a layout change removes the watch list, which is issue 0563's
+defect — a probe that measures a crate and then does not watch it. The consumer's
+build script then stops rebuilding when that crate changes, and both differential
+families report FRESH on an artifact built from a stale measurement (the sizes
+header reaches the C/C++ cells through `nros-build-helpers`).
+
+**DETECTION:** `probe_depfile` tries both spellings and PANICS if neither exists,
+naming the file and the issue. Pinned by
+`probe_depfile_found_beside_and_uplifted`. Be exact about what that pins: the
+test constructs the directory shape itself, so it fixes the RESOLVER's behaviour
+against a shape we assert, not cargo's actual behaviour. If cargo moved the
+depfile somewhere neither spelling names, the panic fires and the build stops
+loudly — which is the case that matters. If cargo instead kept the file where it
+is but wrote a SHORTER list into it, nothing here notices; that is 0563's
+original defect and it has no cheap guard, because the correct list is exactly
+what we do not independently know.
+
+### 6. Cargo's output layout inside a `--target-dir` (NEW — found reviewing this register)
+
+`scripts/test/rust-fixture-stale.sh::_row_artifacts` locates a row's binaries by
+globbing `<target-dir>/*/*/<bin>` and `<target-dir>/*/<bin>` — cargo's
+`[<triple>/]<profile>/<bin>` convention. Its own comment says why it globs rather
+than deriving ("the triple comes from the leaf's own .cargo/config.toml"), which
+is the honest reason and also an admission that the LAYOUT is being assumed.
+`cmake-fixture-stale.sh` makes the milder assumption that a cell has exactly one
+top-level executable in its build dir.
+
+This belongs in this register: it is the same kind of dependency as item 5 (an
+undocumented on-disk layout), it is load-bearing for 237 of the 371 probe rows,
+and it was not on the list.
+
+**VERDICT: accepted risk with no detection story. This is the register's one
+genuine gap — and it is NOT covered by the gate that landed for #0835 on the same
+day.** `check-fixture-staleness-probes`
+(`tests/fixture-staleness-probe-tests.sh`, commit `4746f93d5`) runs the REAL probe
+scripts against a two-file cmake cell and a one-binary cargo leaf, with a negative
+control that re-applies the pre-`2fa1ed09f` decision rules. Every one of its cases
+— A (activity vs bytes), B (a re-run unit with identical output), C (cross-family
+re-staling), D (the negative control) — has the artifact PRESENT. What is
+unguarded is the branch taken when the glob finds NOTHING, which is the one a
+layout change produces.
+
+**WHAT BREAKS:** the glob matches nothing, `_row_artifacts` is empty before and
+after, and the probe silently falls back to cargo's `"fresh":false` — the
+pre-0835 signal, which for these rows is PERMANENTLY true, because rows sharing
+one phase-340 group evict each other. Issue 0835 measured that exact state: ~22
+rows reporting stale on every run with byte-identical binaries, the gate never
+reaching a fixed point, and ~190 fixture-stale test failures on every
+`just ci-matrix`. The failure is reported as a self-healing WARNING, which reads
+as the gate working. The cmake probe has the same shape: no artifact means it
+falls back to the output grep, which is permanently "stale" for the 17 Corrosion
+cells 0835 identified.
+
+**HOW CLOSE IS IT TODAY:** measured read-only against the shared checkout,
+2026-09-05, by replicating both locators without building — **116 of 117** rust
+rows find an artifact, and **120 of 120** cmake cells do. Exactly one row is on
+the silent fallback right now: `packages/testing/qemu-smoltcp-bridge`, whose
+`Cargo.toml` names no binary the glob can find. Its verdict comes from
+`"fresh":false` and nothing says so.
+
+**REMEDY, specified but not landed:** both fallback branches should emit a
+`DEGRADED\t<row>\t<reason>` line — the same convention `rust-fixture-stale.sh`
+already uses for `FAILED\t` — and `check-fixtures-stale.sh` should bucket and
+count them the way it buckets `rust_failed`, as a WARNING beside the stale list.
+That widens no watch set, so it cannot make 0835 worse (phase-424's constraint).
+Not done here for one reason, stated rather than hidden: verifying it needs a
+built fixture tree, this worktree has none, and shipping unverified shell into
+the gate that decides whether every test result is trustworthy is the defect this
+phase exists to remove. It is a small, well-specified change for whoever next has
+fixtures built.
 
 ## Not on this list, deliberately
 
 `nros_shared_cargo_dir()` itself (a directory plus a SHA1), the fixture stamp and
 its `.started` sidecar (our file, our format), the `nros-sizes-build` nested cargo
 using `--message-format=json` (stable, documented), and `rerun-if-env-changed` /
-`rerun-if-changed` (documented). These are ours or supported, and carry no
-version exposure.
+`rerun-if-changed` (documented). These are ours or supported, and carry no version
+exposure.
 
-## Suggested order if this is picked up
+## Order for whoever picks up what remains
 
-1. ~~**#1**, because it is the largest, the quietest, and it predates the
-   campaign.~~ DONE 2026-08-31 — witnessed, not retired; Corrosion still
-   offers no knob to retire it with. See item 1.
-2. **#4**, the one still worth work. W5.c gave the Zephyr lane the OUT_DIR
-   placer, so the W5 blocker is gone and the side channel has one fewer
-   reader — but the WRITE is still there, because the other readers are not
-   migrated: `NanoRosNodeRegister.cmake`, `NanoRosVerbs.cmake`, the px4
-   integration module, and ~20 `just check` lanes that compile against
-   `-Itarget/nros-c-generated`. Counted, not estimated: `git grep -n
-   'nros-c-generated\|nros-cpp-generated'`. Deleting
-   `write_header_to_target_dir` needs all of them moved first, which is a wave,
-   not an afternoon.
+1. **#4's consumer migration** — the only item with real work left, and a wave.
+   128 hits, 26 files. Tracked in phase-424.
+2. **#6's `DEGRADED` marker** — an afternoon, on a machine with fixtures built.
 3. **#2** only if the NuttX lane's nightly pin is ever revisited.
-4. **#3** and **#5** are acceptable as-is: both fail loudly, neither gates CI.
-
+4. **#1, #3, #5** are as closed as they can be: #1 is witnessed and Corrosion
+   offers no knob to retire it with, #3 now refuses instead of guessing, #5 fails
+   loudly in the direction that ships.
 
 ## CLOSED 2026-09-05 — accepted risk, each item re-verified against the tree
 
@@ -195,6 +421,14 @@ what would break if each fails."* Nothing here is fixed by closing it; what
 changes is that the register has been CHECKED rather than remembered, and each
 item now carries how its failure would be DETECTED, which is the property
 phase-424 is actually about.
+
+**The table below verifies FIVE, and the register above lists six.** Two
+sessions worked this issue at once and each found something the other did not:
+this verification pass (with its detection column and the 1031 evidence) came
+from one, and item 6 — cargo's output layout inside a `--target-dir` — from the
+other, found while reviewing the register itself. Item 6 has NOT been through
+this pass; it carries its own analysis above and is the second entry in the
+order below.
 
 | # | assumption | verified 2026-09-05 | how a failure surfaces |
 | --- | --- | --- | --- |

--- a/docs/issues/archived/1056-session-churn-window-too-short-for-start-skew.md
+++ b/docs/issues/archived/1056-session-churn-window-too-short-for-start-skew.md
@@ -1,121 +1,188 @@
 ---
 id: 1056
-title: "`assert_no_session_churn` can PASS on a broken lease, because start skew
-  can push one node's only lapse past the 60 s window"
+title: "`assert_no_session_churn` can PASS on a broken lease — but not because of
+  start skew, and lengthening the window does not fix it"
 status: resolved
 type: bug
 area: testing
 severity: medium
 found: 2026-09-04
 resolved: 2026-09-05
-related: [issue-1044, issue-1013, issue-0906]
+related: [issue-1044, issue-1013, issue-0906, phase-424]
 ---
 
-## The hole
+## The hole as filed
 
-`MAX_ROUTER_SESSIONS = 3` stands in for a rate with a count, and issue 1044
-recorded the arithmetic in its doc rather than closing it. A client lease
+`MAX_ROUTER_SESSIONS = 3` stands in for a rate with a count. A client lease
 `L < 30 s` cannot hear the router's 30 s keep-alive, so each node re-dials every
-`2L`. In a 60 s window that is one re-open per node, two nodes, four sessions —
-over the limit, correctly.
+`2L`; in a 60 s window that is one re-open per node, two nodes, four sessions —
+over the limit. That holds only if BOTH nodes lapse inside the window, and they
+do not start together, so the later node's only lapse could land past the
+window's end and leave 3 sessions and a PASS on a broken build.
 
-That holds only if BOTH nodes lapse inside the window. They do not start
-together: the listener is launched after the talker's readiness banner. For a
-lease near the top of the band (say 29 s, lapsing at 58 s) the later node's only
-lapse can land past the window's end, leaving **3 sessions and a PASS on a build
-that is broken**.
+**Direction proposed:** lengthen the window to ~120 s, so every lease under 30 s
+produces at least two re-opens per node. Cost: roughly doubles the pub/sub cell.
 
-The exposure is to start SKEW, not to the lease value, which is why it is not
-visible in the lease table: every lease in the band is "covered" on paper.
+## RESOLVED 2026-09-05 — the hole is real, the mechanism is not, and the fix
+## does not deliver
 
-## Why the obvious fix is unavailable
+The arithmetic was re-derived from `_zp_unicast_lease_task`
+(zenoh-pico `src/transport/unicast/lease.c:219-279`) and checked against every
+measurement available on this host. Three of the four load-bearing claims are
+wrong, and the fourth — that a broken build can pass — is right for a reason that
+no affordable window closes.
 
-Counting per NODE would make skew irrelevant — the slack becomes "one re-open
-each" and one node re-dialling twice is caught however the other behaves. It
-cannot be done from the router log: **the client zid is regenerated on every
-session open.** `zpico.c`'s `zpico_next_session_zid_counter()` mixes a monotonic
-counter and the clock into the zid, so two opens by one node carry two different
-identities and grouping by zid reads as more NODES rather than more sessions.
-(Measured by reading the generator, not inferred from the log.)
+### 1. One node lapses, not two
 
-## Direction
+The lease task wakes every `lease` ms and closes only if `_received` was false
+for that whole window; ANY inbound frame sets it. The LISTENER is fed a 1 Hz
+sample stream by the router, so its check windows always contain traffic and it
+never lapses. The TALKER hears nothing back but keep-alives. Our own fork's
+`config.h` says it in one line: *"a pure publisher hears nothing back and closes
+at 2 x Z_TRANSPORT_LEASE"*.
 
-**Lengthen the window to ~120 s.** At that length every lease under 30 s produces
-at least two re-opens per node, so no amount of skew can hide one, and the count
-becomes sufficient again. The cost is real and is the whole reason it was not
-just done: `PUBSUB_MIN_SAMPLES` is 60 at 1 Hz, so this roughly doubles the
-pub/sub cell — currently ~61 s per language per platform.
+So `sessions = 2 + talker lapses`, not `2 + lapses(A) + lapses(B)`.
 
-Worth pricing against the alternative before spending it: a delivery assertion
-cannot substitute (issue 1013 measured a 10 s lease delivering 60/60, because the
-reopen now completes in ~15 ms), so the session count is the only signal there
-is, and a signal that can be skewed into silence is the thing being bought back.
+**The evidence was already in the doc comment and had been noticed without being
+chased.** The per-node table predicted ~8 sessions for issue 0906's 10 s lease
+and the cell measured **5**; the discrepancy was written down as
+`~8 (5 measured)`. One node gives `2 + floor(60 / 20) = 5` exactly.
+
+### 2. The lapse period is `2L` only while `2L < 30 s`
+
+The check window is `L` wide; `rmw_zenohd` speaks every 30 s. The session dies at
+the end of the first `L`-window that no keep-alive lands in — a beat between `L`
+and 30, which runs away as `L -> 30`. Simulated from the loop above:
+
+| lease | first close | ratio to L |
+| ---: | ---: | ---: |
+| 10 s | 20.0 s | 2 |
+| 14 s | 28.0 s | 2 |
+| 15 s | 45.0 s | 3 |
+| 18 s | 54.0 s | 3 |
+| 20 s | 80.0 s | 4 |
+| 24 s | 144.0 s | 6 |
+| 29 s | **899.0 s** | 31 |
+| 29.9 s | **9000 s** | 301 |
+| >= 30 s | never | — |
+
+So the acceptance as filed — *"a build with `Z_TRANSPORT_LEASE_MS` anywhere in
+`(0, 30_000)` fails this cell regardless of how far apart the two nodes start"* —
+**is not reachable by any affordable window**. Every `L < 30 s` does close
+eventually, so the acceptance is not impossible in principle — it is unpayable:
+covering `L = 29.9 s` needs two lapses at 9000 s each, five hours per cell,
+twelve cells.
+
+### 3. Start skew is not the exposure
+
+Both nodes must participate for all `PUBSUB_MIN_SAMPLES` samples — the talker
+publishes all 60, the listener hears all 60 — so each one's observed session life
+is at least that span WHATEVER the skew. Skew lengthens the EARLIER node's life
+and leaves the later one alone.
+
+Measured across the nine `test-logs/fixtures/zenohd-*.log` router logs on this
+host (2026-09-04):
+
+| log | router span | session opens, relative | sessions |
+| --- | ---: | --- | ---: |
+| 7800 | 82.0 s | 2.05 s, 22.04 s | 2 |
+| 7900 | 82.2 s | 2.10 s, 21.99 s | 2 |
+| 8000 | 82.1 s | 2.11 s, 22.14 s | 2 |
+| 8200 | 65.5 s | 5.28 s, 5.28 s | 2 |
+| 8300 | 60.6 s | 0.07 s, 0.07 s | 2 |
+| 8400 | 60.6 s | 0.06 s, 0.06 s | 2 |
+| 9000 | 61.4 s | 0.00 s, 1.00 s | 2 |
+| 9100 | 61.5 s | 0.00 s, 1.00 s | 2 |
+| 9200 | 61.5 s | 0.00 s, 1.00 s | 2 |
+
+Skew ranges 0.00 s to 20.0 s, and the later node is alive ~60 s in every one
+(82.0 - 22.04 = 60.0). The span grows with the skew; the later node's life does
+not shrink. Exactly 2 sessions in 9 of 9, on the shipped 60 s lease.
+
+### 4. What the cell DOES cover, and what a longer window would buy
+
+Failing needs 2 lapses (the slack is one), all from the talker, whose life is
+~60 s. So the covered band is `2 x first_close(L) <= 60`, i.e. **`L <= 14 s`**.
+
+| talker life | added cell time | band covered |
+| ---: | ---: | --- |
+| 60 s (today) | — | `L <= 14 s` |
+| 90 s | +30 s x 12 cells = +6 min | `L <= 15 s` |
+| 120 s (as filed) | +60 s x 12 = +12 min | `L <= 18 s` |
+| 180 s | +120 s x 12 = +24 min | `L <= 22 s` |
+| 300 s | +240 s x 12 = +48 min | `L <= 24 s` |
+
+Doubling the cell moves the frontier by four seconds of lease. What is actually
+shipped is 60 s (ours) and **10 s** — zenoh-pico's own upstream default
+(`CMakeLists.txt:245`, `config.h:53`), which is both issue 0906's value and what
+a regression here would revert to. That is inside the covered band with margin:
+5 sessions against a limit of 3.
+
+### Decision: the window is NOT lengthened
+
+Paying 12 minutes of suite time to move the frontier from 14 s to 18 s, for lease
+values nobody has ever shipped, is a bad trade — and the benefit the issue priced
+it against (covering all of `(0, 30_000)`) does not exist.
+
+**What landed instead**, in `packages/testing/nros-tests/tests/rtos_e2e.rs`:
+
+* the `MAX_ROUTER_SESSIONS` doc comment now carries the derivation above,
+  replacing the per-node `2L` table that predicted 8 where 5 was measured;
+* `PUBSUB_MIN_SAMPLES`'s "the lease values split cleanly" paragraph is corrected
+  — the middle of the band is a beat, not a clean split;
+* the assertion message no longer claims "any client lease under 30 s lapses
+  deterministically";
+* a new `COVERED_LEASE_SECS = 14` is PRINTED on every run, so a PASS states its
+  own scope (issue 0445's rule, one layer down): *"this count can fail a lease of
+  <= 14 s, and nothing above it"*. A verdict that does not report its scope cannot
+  be caught having the wrong one, which is how this survived.
+
+### The cheap alternative, priced and declined
+
+Dropping `MAX_ROUTER_SESSIONS` from 3 to 2 needs only ONE lapse, which buys
+`L <= 18 s` for **no wall clock at all** — the same band as doubling the cell,
+free. Not taken: the slack exists for a single genuine re-dial, nine healthy runs
+on an unknown subset of the twelve cells is not enough evidence to retire it on
+all four platforms, and turning this cell flaky is worse than the four seconds of
+lease band it buys. Whoever wants it should first measure the healthy session
+count on all twelve cells across a few runs; if it is 2 every time, the change is
+one constant.
+
+### Still unavailable, as filed
+
+Counting per NODE would make the slack "one re-open each". The client zid is
+regenerated on every session open — `zpico.c`'s
+`zpico_next_session_zid_counter()` mixes a monotonic counter and the clock into
+it — so grouping the router log by zid reads as more NODES rather than more
+sessions. Unchanged, and confirmed by reading the generator.
+
+## Appendix — the model, so the table can be re-derived
+
+```python
+def first_close(lease_s, ka=30.0, horizon=100000.0):
+    """Seconds from session open to the first close, per
+    `_zp_unicast_lease_task`: wake every `lease`, consume `_received` if set,
+    otherwise close. The handshake sets it at t=0; an idle router sets it every
+    `ka` seconds."""
+    received, t, k = True, 0.0, 0
+    while t < horizon:
+        prev, k = t, k + 1
+        t = k * lease_s
+        if int(t // ka) - int(prev // ka) > 0:
+            received = True
+        if received:
+            received = False
+        else:
+            return t
+    return None
+```
+
+`first_close(10) == 20.0`, matching issue 0906's measured ~20 s and the cell's
+measured 5 sessions (`2 + floor(60 / 20)`). Sessions in a talker life `D` are
+`2 + floor(D / first_close(L))`; the cell fails when that exceeds
+`MAX_ROUTER_SESSIONS`.
 
 ## Not a regression
 
-Nothing here is newly broken — this is the standing accuracy of a check that has
-always been a count. It is filed because issue 1044 established the bound
-precisely enough to act on, and a test that can pass on a build it exists to
-reject should not live only in a doc comment.
-
-## Acceptance
-
-A build with `Z_TRANSPORT_LEASE_MS` anywhere in `(0, 30_000)` fails this cell
-regardless of how far apart the two nodes start.
-
-
-## RESOLVED 2026-09-05 — and the mechanism above is WRONG in two places
-
-Fixed by `PUBSUB_MIN_SAMPLES` 60 -> 70, with each `pubsub_window` arm raised
-+10 s to keep its headroom. But the reasoning that produced the 120 s proposal
-does not survive reading the cell, and the corrections are the useful part.
-
-**1. The listener is spawned FIRST, not after the talker.** `rtos_e2e.rs` starts
-the listener, sleeps `stabilization_delay()` — 20 s on freertos / nuttx /
-threadx_riscv64, 1 s on threadx-linux — and only then starts the talker. So the
-LATER node is the talker. The skew runs the other way, and it gives the earlier
-node EXTRA observation rather than robbing the later one.
-
-**2. There is no fixed window for skew to push a lapse past.** The run ends when
-`collect_until_count` sees the LISTENER's Nth sample, and those samples cannot
-arrive until the talker is up and publishing. So the later node always gets
-~N seconds of its own uptime whatever the skew is. `pubsub_window` is the
-TIMEOUT on that collection, not the length of the observation.
-
-Both halves of "start skew can push one node's only lapse past the window's end"
-therefore fail: the node it names is the early one, and the end it names is not
-fixed.
-
-**What is real is the MARGIN, at the top of the band.** The talker's uptime at
-the assertion is ~N seconds; its first lapse is at `2L`, which for `L -> 30 s`
-is `-> 59.8 s`. Against 60 samples that is a **sub-second** margin, and missing
-it drops the count to 3 — a PASS on a build this cell exists to reject. That is
-the same conclusion the issue reached, reached correctly.
-
-    lease L    sessions@60    sessions@70    (limit 3)
-        5          16             18
-       10           9              9
-       20           5              5
-       25           4              4
-       29           4              4
-     29.9           4              4
-    healthy L=60:   2 sessions, passes correctly at both
-
-The table is the point: the verdict does not change, the MARGIN does — 0.2 s
-becomes 10.2 s, about 17 % of the lapse period, against a lapse that is
-timer-driven and jitters in milliseconds.
-
-**Cost.** +10 s per cell, 12 cells, ~2 minutes total — against the ~12 minutes
-the 120 s direction would have cost. What 120 s buys beyond this is a SECOND
-lapse per node, i.e. tolerance of missing one entirely; no mechanism on record
-misses a timer by ten seconds, so that is margin nobody has priced a need for.
-
-**Not run here.** The cell needs QEMU and built fixtures; this change is
-justified by the arithmetic above and compile-checked (`cargo check --test
-rtos_e2e`). The acceptance — every `L` in `(0, 30_000)` fails the cell — is a
-property of the count, and the count is unchanged; what was bought is the margin
-that makes it observable.
-
-**The per-NODE counting section stands unchanged.** The zid really is
-regenerated per session (`zpico_next_session_zid_counter`), so grouping by zid
-still reads as more nodes rather than more sessions. Nothing here needed it.
+Nothing here was newly broken. What is now different is that the cell's coverage
+is derived rather than asserted, and it says so at runtime.

--- a/docs/roadmap/phase-424-build-graph-freshness-truth.md
+++ b/docs/roadmap/phase-424-build-graph-freshness-truth.md
@@ -1,12 +1,14 @@
 # Phase 424 — does the build graph tell the truth about what needs rebuilding?
 
-**Status (2026-09-04).** Enabling work done, seven issues untouched. 0835 — the
-one every other fix has to be checked against — has been re-measured, its
-remaining scope narrowed to a disk-waste defect, and the property that ended its
-oscillation is now gated by `just check fixture-staleness-probes`. The rest of
-the phase is not started. What it adds beyond that is the constraint in "What
-this phase must not do", which is the part that would otherwise be rediscovered
-per issue — and which is now backed by numbers rather than by a warning.
+**Status (2026-09-05).** Enabling work done; #0945 and #1056 resolved and
+archived; five issues untouched. 0835 — the one every other fix has to be checked
+against — has been re-measured, its remaining scope narrowed to a disk-waste
+defect, and the property that ended its oscillation is now gated by `just check
+fixture-staleness-probes`. #0945 and #1056 both closed by DERIVATION rather than
+by widening a watch set, so the phase's own constraint held without being paid
+for. What the phase adds beyond that is the constraint in "What this phase must
+not do", which is the part that would otherwise be rediscovered per issue — and
+which is now backed by numbers rather than by a warning.
 
 **Opened 2026-09-04 as a HOME.** Eight open issues say the same thing from
 different layers: something in this tree reports FRESH when it is not, or STALE
@@ -48,12 +50,12 @@ they all rest on is built on build-system internals nobody supports.
 | --- | --- | --- |
 | [#0820](../issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md) | cmake seam | passes after `rm -rf` on unmodified sources — no rebuild edge |
 | [#0835](../issues/0835-fixture-staleness-probe-families-restale-each-other.md) | fixtures | the cmake and rust families re-stale each other — **oscillation fixed + gated 2026-09-04**; open for the duplicated ThreadX corrosion group, which is wasted disk, not staleness |
-| [#0945](../issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | cargo | the shared-cargo-dir campaign rests on five unsupported build-system assumptions |
+| [#0945](../issues/archived/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | cargo | ~~the shared-cargo-dir campaign rests on five unsupported build-system assumptions~~ **RESOLVED** — six, classified, one gap named |
 | [#1002](../issues/archived/1002-a-derived-knob-needs-three-configures-not-two.md) | cmake | RESOLVED — three is the chain's depth, not a defect; the defect was a bound counting the build dir's lifetime |
 | [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md) | codegen | a codegen change invalidates every consumer, connected only by a manual step |
 | [#1046](../issues/archived/1046-px4-stale-tree-guard-checks-a-surviving-directory.md) | px4 | RESOLVED 2026-09-05 — the guard asserted a DIRECTORY that outlives the build that linked it; it asserts `bin/px4`'s CONTENT now, and the three "not covered" sweeps came back empty |
 | [#1050](../issues/1050-px4-demo-links-whatever-archive-was-built-last.md) | px4 | links whatever `libnros_cpp.a` was built last — the recipe (1) and the configure-time guard (2) are fixed; open for (3), `nros::init()` taking slot 0 |
-| [#1056](../issues/1056-session-churn-window-too-short-for-start-skew.md) | test window | a check that can pass on the build it exists to reject |
+| [#1056](../issues/archived/1056-session-churn-window-too-short-for-start-skew.md) | test window | ~~a check that can pass on the build it exists to reject~~ **RESOLVED** — it can, and no affordable window fixes it |
 
 #1056 is here rather than with the RTOS work because its defect is the same
 shape: a verdict whose window is too small to observe the thing it claims to
@@ -93,3 +95,78 @@ project** (2026-09-04). The numbers are in issue 0835 under "Measured
   re-staling did not get worse, in the same commit.
 * 0945's five assumptions are either supported by something we can point at, or
   written down as accepted risk with what would break if each fails.
+
+
+## Resolved: #0945, the assumption register (2026-09-05)
+
+The acceptance was *"either supported by something we can point at, or written
+down as accepted risk with what would break if each fails"*. Every item now
+carries a verdict, an evidence line and a detection line. Three findings are
+worth carrying up here:
+
+**A claimed mitigation did not exist.** Item 3 said both `.fingerprint`-parsing
+tools have a `--self-test` that would surface a cargo schema change. Neither did:
+`nros-leaf-graph`'s never opened a json file, and `nros-shared-dir-churn`'s wrote
+the same key names it read, so a rename moves both ends together. Both now REFUSE
+(`INCONCLUSIVE`, rc 2) when records were read and none carried the key the answer
+depends on; both self-tests mutate the key and are mutation-checked; and both
+now run that self-test from `main` on the NORMAL path, so the control is
+exercised exactly when someone is about to quote a number out of the tool. (A
+dedicated `check` gate for the pair was tried first and `check-gate-selftests`
+refused it — *"a negative control nobody runs decays into a comment. Call it from
+main."* It was right; the gate is gone.) Measured ~10 ms and ~50 ms.
+
+**A sixth assumption was found, and it is the register's one real gap.** Cargo's
+`[<triple>/]<profile>/<bin>` output layout inside a `--target-dir` is globbed by
+`rust-fixture-stale.sh`. If it moves, the probe finds nothing, silently falls back
+to the pre-0835 `"fresh":false` signal, and #0835's permanent oscillation returns
+dressed as a self-healing WARNING. Measured today: 116 of 117 rust rows find an
+artifact, 120 of 120 cmake cells do, and exactly one row
+(`packages/testing/qemu-smoltcp-bridge`) is on the silent fallback right now. The
+remedy is specified in the issue — a `DEGRADED\t` line beside the existing
+`FAILED\t` bucket, widening no watch set — and deliberately not landed: it needs
+a built fixture tree to verify, and unverified shell in the freshness gate is the
+defect this phase exists to remove.
+
+**The register's biggest item is not the one it named.** Item 4's stated risk (a
+future cargo target-dir GC) has never fired; the side channel having no OWNER has,
+six times (issues 0360, 0834, 0978, 0985, 0987, 1031), because every consumer grows
+its own rule for which copy is authoritative. And the differential probe families
+are structurally blind to it: a wrong generated header produces the same wrong
+bytes twice, so the verdict is FRESH.
+
+### Carried forward as work
+
+Item 4's consumer migration off `write_header_to_target_dir`. Counted, not
+estimated: **128 hits across 26 files** (`git grep -n
+'nros-c-generated\|nros-cpp-generated' -- ':!docs'`), including
+`NanoRosNodeRegister.cmake`, `NanoRosVerbs.cmake`, `integrations/nuttx/Make.defs`,
+`integrations/px4/NanoRosPx4Module.cmake`, `zephyr/CMakeLists.txt`, and 49 hits in
+`just/check.just`. A wave, not an afternoon.
+
+## Resolved: #1056, the session-churn window (2026-09-05)
+
+Same shape as the PX4 pair, one layer over: the reported defect is real and its
+stated MECHANISM is not, so the priced fix buys nothing.
+
+`assert_no_session_churn` can pass on a build it exists to reject. But not because
+of start skew — both nodes must participate for all 60 samples, so each one's
+session life is at least that span whatever the skew, and the nine stored router
+logs measure skew from 0.00 s to 20.0 s with the later node alive ~60 s in every
+one. The real reasons are that **only the talker lapses** (the listener is fed a
+1 Hz stream, which resets its lease; our fork's own `config.h` says a pure
+publisher is the one that closes) and that **the lapse period is `2 x lease` only
+while `2 x lease < 30 s`** — above that it is a beat against the router's 30 s
+keep-alive, and it diverges: 899 s at a 29 s lease, 9000 s at 29.9 s.
+
+So the filed acceptance ("every lease in `(0, 30_000)` fails this cell") is
+unreachable at any window length, and the proposed 120 s moves the covered band
+from `L <= 14 s` to `L <= 18 s` for +12 minutes across the twelve cells. Declined.
+What shipped is the derivation, in the doc comments that had the wrong model, plus
+`COVERED_LEASE_SECS` printed on every run so a PASS states its own scope. The
+zenoh-pico default that a regression would revert to is 10 s, inside the band.
+
+The free alternative is recorded and declined with a reason: dropping
+`MAX_ROUTER_SESSIONS` to 2 buys the same `L <= 18 s` for no wall clock, but needs
+a healthy-count measurement on all twelve cells first, and a flaky cell is worse
+than four seconds of lease band.

--- a/packages/testing/nros-tests/tests/rtos_e2e.rs
+++ b/packages/testing/nros-tests/tests/rtos_e2e.rs
@@ -692,31 +692,23 @@ fn boot_budget(platform: Platform) -> Duration {
 /// `keep_alive: 2`, i.e. an idle router speaks every **30 s**. zenoh-pico takes
 /// `min(peer_lease, Z_TRANSPORT_LEASE)`. So the lease values split cleanly:
 ///
-/// * `L >= 30 s` — the router is heard before the deadline; the session holds
-///   indefinitely. The shipped 60 s is in this set.
-/// * `L < 30 s` — it cannot be heard in time, and the session closes at
-///   `2L < 60 s`. Issue 0906's 10 s is in this set.
+/// * `L >= 30 s` — every `L`-wide check window contains a keep-alive; the
+///   session holds indefinitely. The shipped 60 s is in this set.
+/// * `2L < 30 s`, i.e. `L < 15 s` — the second window contains none and the
+///   session closes at `2L`. Issue 0906's 10 s is in this set, and so is
+///   zenoh-pico's own upstream default, which is what a regression here would
+///   revert to.
 ///
-/// 60 samples was exactly the frontier between those two for DELIVERY: every
-/// client-lease configuration that cannot hold a session fails on delivery, and
-/// none that can hold one is asked to prove more. A shorter window readmits part
-/// of the broken half (a 40 s window passes any `L >= 20 s`).
-///
-/// **70, not 60, because a second assertion now shares this window** (issue
-/// 1056). `assert_no_session_churn` needs each node to be up for longer than one
-/// lapse period, and the worst case in the broken band is `L -> 30 s`, lapsing
-/// at `2L -> 59.8 s`. Against 60 samples the later node's uptime is ~60 s, so
-/// that lapse sits under a SUB-SECOND margin: miss it and the count is 3, which
-/// is a PASS on a build this cell exists to reject. 70 gives ~10 s of margin —
-/// about 17 % of the lapse period, against a lapse that is timer-driven and so
-/// jitters in milliseconds.
-///
-/// Priced deliberately: +10 s per cell (12 cells, ~2 min total) against the
-/// +60 s per cell (~12 min) that issue 1056 first proposed, and it buys the same
-/// acceptance. What the 120 s version buys beyond this is a SECOND lapse per
-/// node, i.e. tolerance of missing one entirely; there is no mechanism on record
-/// that misses a timer by ten seconds, so that is margin nobody has priced a
-/// need for.
+/// **Corrected (issue 1056): the middle is not a clean split.** For
+/// `15 s <= L < 30 s` the first close is neither `2L` nor never — it is the end
+/// of the first `L`-window that no 30 s keep-alive lands in, which is a beat
+/// between `L` and 30 and runs away as `L -> 30`: 45 s at `L = 15`, 80 s at 20,
+/// **899 s at 29**, 9000 s at 29.9. The table at [`MAX_ROUTER_SESSIONS`] has the
+/// numbers. So 60 samples is the frontier for the DETERMINISTIC half of the
+/// broken set (`L <= 14 s`), not for all of it, and no affordable sample count
+/// reaches the top of the band — 120 samples buys `L <= 18 s`, 180 buys
+/// `L <= 22 s`. A shorter window would readmit part of what IS covered (a 40 s
+/// window passes any `L >= 10 s`); a longer one buys leases nobody ships.
 ///
 /// **The bound this does NOT cover, stated:** a defect whose first symptom is
 /// beyond 60 s of session life stays invisible here — the shipped 60 s lease's
@@ -780,44 +772,81 @@ const ROUTER_SESSION_LOG_FILTER: &str = "zenoh_transport=debug";
 /// because a lease of `L` costs one re-open per node per `2L` and issue 0906's
 /// 10 s lease measured FIVE in this cell's window.
 ///
-/// # The blind spot, stated (issue 1044)
+/// # What this count actually covers, and what it does not (issues 1044, 1056)
 ///
-/// This is a COUNT, and the thing it stands in for is a RATE. Work the
-/// arithmetic: a client lease `L < 30 s` cannot hear the router's 30 s
-/// keep-alive, so each node re-dials every `2L`, and in a `W`-second window each
-/// contributes about `floor(W / 2L)` re-opens on top of its first session.
+/// This is a COUNT and the thing it stands in for is a RATE, so the band it
+/// separates has to be derived rather than assumed. The derivation below
+/// REPLACES the "each node re-dials every `2 x lease`" table that stood here:
+/// that table predicted **8** sessions for issue 0906's 10 s lease where the
+/// cell measured **5**, and the discrepancy was recorded without being chased.
+/// Chasing it is what produced this.
 ///
-/// At `W = 60`:
+/// **One node lapses, not two.** `_zp_unicast_lease_task`
+/// (zenoh-pico `src/transport/unicast/lease.c`) wakes every `lease` ms and
+/// closes only if `_received` was false for that whole window; any inbound frame
+/// sets it. The LISTENER is fed a 1 Hz sample stream by the router, so its
+/// windows always contain traffic and it never lapses. The TALKER hears nothing
+/// back but keep-alives — our fork's own `config.h` says so: *"a pure publisher
+/// hears nothing back and closes at 2 x Z_TRANSPORT_LEASE"*. So
+/// `sessions = 2 + talker lapses`, and 0906's five is `2 + floor(60 / 20)`
+/// exactly.
 ///
-/// | lease | re-opens per node | sessions | verdict |
+/// **The lapse period is `2L` only while `2L < 30 s`.** The check window is `L`
+/// wide and `rmw_zenohd` speaks every 30 s (`lease: 60000, keep_alive: 2`), so
+/// the session dies at the end of the first `L`-window that no keep-alive falls
+/// into. That is a beat between `L` and 30, and it diverges as `L -> 30`:
+///
+/// | lease | first close | sessions in a 60 s talker life | verdict |
 /// | ---: | ---: | ---: | --- |
-/// | 10 s | 3 | ~8 (5 measured) | fails |
-/// | 20 s | 1 | 4 | fails |
-/// | 29 s | 1 | 4 | fails |
-/// | >= 30 s | 0 | 2 | passes, correctly |
+/// | 10 s | 20 s | 5 (measured) | fails |
+/// | 14 s | 28 s | 4 | fails |
+/// | 15 s | 45 s | 3 | passes — inside the slack |
+/// | 20 s | 80 s | 2 | passes |
+/// | 29 s | 899 s | 2 | passes |
+/// | 29.9 s | 8999 s | 2 | passes |
+/// | >= 30 s | never | 2 | passes, correctly |
 ///
-/// So the band is covered on paper — but only because BOTH nodes lapse inside
-/// the window. They do not start together: the listener is launched after the
-/// talker's readiness banner, so for a lease near the top of the band one node's
-/// single lapse can fall past the window's end, giving 3 sessions and a PASS on
-/// a build that is broken. The exposure is to start SKEW, not to the lease.
+/// **So the covered band is `L <= 14 s`, and no AFFORDABLE window reaches 30 s.**
+/// (Every `L < 30` closes eventually, so a long enough window would see it — at
+/// `L = 29.9` that is two closes of 9000 s each, five hours per cell.)
+/// Issue 1056 proposed doubling the cell to 120 s to cover all of `(0, 30_000)`;
+/// the arithmetic does not support it. A 120 s talker life moves the band to
+/// `L <= 18 s` and a 180 s one to `L <= 22 s` — 12 and 24 extra minutes across
+/// the twelve cells, for leases nobody has ever shipped. What IS shipped
+/// is 60 s (here) and 10 s (zenoh-pico's own default, and 0906's regression),
+/// and the cell separates those with margin.
 ///
-/// Two ways to close it, neither taken here:
+/// **Start skew is not the exposure.** Both nodes must participate for all
+/// [`PUBSUB_MIN_SAMPLES`] samples, so each one's observed life is at least that
+/// span whatever the skew; the skew lengthens the EARLIER node's life and leaves
+/// the later one alone. Measured across nine stored router logs: opens 0.00 s to
+/// 20.0 s apart, router span 60.6-82.2 s, later node alive ~60 s in every one,
+/// and exactly 2 sessions in all nine.
 ///
-/// * a longer `W` — at 120 s every lease under 30 s produces at least two
-///   re-opens per node, so skew cannot hide one. It doubles the cell.
-/// * counting per NODE instead of in aggregate, which would let the slack be
-///   "one re-open EACH" and make skew irrelevant. **Not available**: the client
-///   zid is regenerated on every session open — `zpico.c`'s
-///   `zpico_next_session_zid_counter()` mixes a monotonic counter and the clock
-///   into it — so the router log cannot tell one node re-dialling twice from two
-///   nodes dialling once, and grouping by zid would read as more nodes rather
-///   than more sessions.
+/// **The slack of one is what costs the 15-18 s band.** Dropping
+/// `MAX_ROUTER_SESSIONS` to 2 would buy `L <= 18 s` for no wall clock at all,
+/// since it only needs ONE lapse. Not taken: the slack is there for a single
+/// genuine re-dial, nine healthy runs is not enough evidence to retire it on all
+/// four platforms, and turning this cell flaky is worse than the band it buys.
+///
+/// **Per-NODE counting would make the slack "one re-open each" and is still not
+/// available**: the client zid is regenerated on every session open —
+/// `zpico.c`'s `zpico_next_session_zid_counter()` mixes a monotonic counter and
+/// the clock into it — so grouping the router log by zid reads as more NODES
+/// rather than more sessions.
 ///
 /// The gaps between consecutive opens are printed on both paths below, so a
 /// human reading a run can see the period even where the count cannot assert on
 /// it: evenly spaced opens are a lapse, one late outlier is a drop.
 const MAX_ROUTER_SESSIONS: usize = 3;
+
+/// The largest `Z_TRANSPORT_LEASE_MS` this cell can still fail, in seconds.
+///
+/// Derived at [`MAX_ROUTER_SESSIONS`] from the talker's ~60 s life, the router's
+/// 30 s keep-alive cadence and the one-slot slack. Printed on every run so a
+/// PASS says what it proved: leases above this are NOT covered here, and no
+/// affordable window covers the top of the band.
+const COVERED_LEASE_SECS: u32 = 14;
 
 /// Turn on the router's accept log for this test process.
 ///
@@ -901,13 +930,21 @@ fn assert_no_session_churn(platform: Platform, lang: Lang, port: u16, window: Du
         )
     });
     let sessions = count_pattern(&log, ROUTER_SESSION_MARKER);
+    // Say what this verdict covers, not just what it counted (issue 1056; the
+    // same rule as issue 0445 one layer up — a check that does not report its
+    // own scope cannot be caught having the wrong one). A PASS here means "no
+    // lease at or below COVERED_LEASE_SECS", never "the lease is healthy": the
+    // band above it is unreachable from a count, at any window length.
     eprintln!(
-        "[{} {}] router sessions opened: {} (max {}); gaps between opens: {}",
+        "[{} {}] router sessions opened: {} (max {}); gaps between opens: {}; \
+         this count can fail a lease of <= {} s, and nothing above it \
+         (see MAX_ROUTER_SESSIONS)",
         platform,
         lang,
         sessions,
         MAX_ROUTER_SESSIONS,
-        session_open_spacing(&log)
+        session_open_spacing(&log),
+        COVERED_LEASE_SECS,
     );
     assert!(
         sessions >= 2,
@@ -933,17 +970,21 @@ fn assert_no_session_churn(platform: Platform, lang: Lang, port: u16, window: Du
         sessions <= MAX_ROUTER_SESSIONS,
         "{platform} {lang} pubsub E2E: the router opened {sessions} sessions in {window:?} \
          for TWO nodes — they are re-dialling on a timer, not holding one session each.\n\
-         That is issue 0906's signature: zenoh-pico closes a session after 2 x \
-         `Z_TRANSPORT_LEASE` of silence, and `rmw_zenohd` speaks only every 30 s \
-         (`lease: 60000, keep_alive: 2`), so any client lease under 30 s lapses \
-         deterministically. Note delivery can look PERFECT while this fails — the reopen \
+         That is issue 0906's signature: zenoh-pico's lease task closes a session at the \
+         end of the first `Z_TRANSPORT_LEASE`-wide window with nothing received, and \
+         `rmw_zenohd` speaks only every 30 s (`lease: 60000, keep_alive: 2`), so a client \
+         lease under 15 s lapses deterministically at 2 x lease (issue 1056 — above 15 s \
+         it is a beat against the 30 s cadence and this count stops seeing it, which is \
+         why a PASS here is scoped, not clean). Note delivery can look PERFECT while this \
+         fails — the reopen \
          is fast now, which is exactly why the count is what this asserts on. Check \
          `Z_TRANSPORT_LEASE_MS` in `packages/rmw/zenoh/nros-zpico-build/src/lib.rs` \
          (60_000) and what the leaf actually BAKED — issue 1005: the staleness probe does \
          not watch that constant, so a stale image can carry an old value.\n\n\
          Sessions:\n{}\n\nGaps between opens: {} — evenly spaced means a lease \
-         lapsing on a timer (the period is 2 x lease); one outlier means a single \
-         dropped link.",
+         lapsing on a timer (the period is 2 x lease while 2 x lease < 30 s, and a \
+         longer beat against the router's keep-alive above that); one outlier means \
+         a single dropped link.",
         session_lines,
         session_open_spacing(&log),
     );

--- a/scripts/nros-leaf-graph.py
+++ b/scripts/nros-leaf-graph.py
@@ -70,7 +70,7 @@ import sys
 RECENT_WINDOW_SECS = 6 * 60 * 60
 
 
-def load_units(target_dir: pathlib.Path, all_units: bool = False):
+def load_units(target_dir: pathlib.Path, all_units: bool = False, schema: dict = None):
     """Every unit cargo built, as (side, crate, requires) triples.
 
     `side` is "host" or "target", read from cargo's own `compile_kind`.
@@ -78,7 +78,21 @@ def load_units(target_dir: pathlib.Path, all_units: bool = False):
     By default only units from the tree's most recent build are returned; pass
     `all_units` to include stale ones, which is a historical view and must not be
     quoted as a property of the current build.
+
+    `schema`, when given, is filled with what the PARSE actually found:
+    `records` (json objects read), `with_deps` and `with_compile_kind` (how many
+    carried each key this tool reads). Issue 0945 item 3 — cargo's `.fingerprint`
+    format carries no stability guarantee, and every key here is read with
+    `.get(..., default)`, so a rename does not raise: `deps` gone means every
+    crate looks like a build root and `--exclusive-to` answers "nothing leaves",
+    which is plausible, optimistic and wrong in exactly the direction the failed
+    estimates in this file's header were wrong. The caller refuses rather than
+    printing it.
     """
+    if schema is not None:
+        schema.setdefault("records", 0)
+        schema.setdefault("with_deps", 0)
+        schema.setdefault("with_compile_kind", 0)
     units = []
     stale = 0
     # Bounded globs, NOT `**`: a populated target dir holds hundreds of thousands
@@ -108,6 +122,10 @@ def load_units(target_dir: pathlib.Path, all_units: bool = False):
                     continue
                 if not isinstance(data, dict):
                     continue
+                if schema is not None:
+                    schema["records"] += 1
+                    schema["with_deps"] += "deps" in data
+                    schema["with_compile_kind"] += "compile_kind" in data
                 side = "host" if data.get("compile_kind") in (0, None) else "target"
                 requires = {d[1] for d in data.get("deps", []) if len(d) > 1}
                 # A crate's own build script is an internal edge, not a dependency.
@@ -134,6 +152,41 @@ def load_units(target_dir: pathlib.Path, all_units: bool = False):
             )
         units = keep
     return [(s, c, r) for s, c, r, _ in units]
+
+
+def schema_complaint(schema):
+    """The reason this parse cannot be trusted, or None.
+
+    Issue 0945 item 3. Both keys are present in EVERY record cargo writes today —
+    measured across `lib-*`, `build-script-build*` and `run-build-script-*` in a
+    populated tree, all carrying the identical key set — so "records were read
+    and none carried this key" is a rename, not a legitimate shape.
+
+    This is the honest version of the mitigation issue 0945 claimed for these
+    tools. `--self-test` did NOT cover it: it feeds `requirer_map` a hand-written
+    `units` list and never touches the parser, so a schema change left the
+    self-test green and the answer wrong.
+    """
+    if not schema or not schema.get("records"):
+        return None
+    if not schema["with_deps"]:
+        return (f"{schema['records']} fingerprint record(s) read and NOT ONE carried a "
+                "`deps` key.\n"
+                "      cargo's .fingerprint format is private and undocumented (issue 0945 "
+                "item 3);\n"
+                "      a rename here does not raise — every crate would read as a build root "
+                "and\n"
+                "      `--exclusive-to` would answer \"nothing leaves\". That answer is "
+                "plausible,\n"
+                "      optimistic, and wrong, which is the failure this tool exists to "
+                "prevent.")
+    if not schema["with_compile_kind"]:
+        return (f"{schema['records']} fingerprint record(s) read and NOT ONE carried a "
+                "`compile_kind` key.\n"
+                "      Host and target units would all be labelled \"host\" and the two "
+                "graphs conflated —\n"
+                "      the same class of error as the path-based guess this tool replaced.")
+    return None
 
 
 def requirer_map(units):
@@ -174,7 +227,7 @@ def exclusive_to(reqmap, roots):
     return dropped - roots
 
 
-def self_test() -> int:
+def self_test(quiet: bool = False) -> int:
     """Prove the fixpoint on a graph whose right answer is known by hand.
 
     The repo's gate-selftest convention (see `gen-issue-index.py --self-test`):
@@ -223,15 +276,61 @@ def self_test() -> int:
     if m2.get("nros_pkg_index") != {"nros_macros"}:
         failures.append(f"name normalisation: {dict(m2)}")
 
+    # Issue 0945 item 3 — the PARSER, not just the fixpoint.
+    #
+    # Everything above feeds `requirer_map` a hand-written `units` list, so it
+    # cannot see a `.fingerprint` schema change at all. That is why 0945's claim
+    # that "--self-test surfaces a schema change" was false for this tool. These
+    # two cases read a real on-disk tree and then MUTATE the key cargo owns: the
+    # healthy shape must be reported, and the renamed shape must be REFUSED
+    # rather than answered.
+    import contextlib
+    import io
+    import tempfile
+
+    def _tree(root, keyname="deps", kindkey="compile_kind"):
+        d = pathlib.Path(root) / "trip" / "prof" / ".fingerprint" / "app-0a605463647b4af3"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "lib-app.json").write_text(json.dumps({
+            kindkey: 0, keyname: [[1, "serde", False, 2]],
+        }))
+        e = pathlib.Path(root) / "trip" / "prof" / ".fingerprint" / "serde-0b605463647b4af3"
+        e.mkdir(parents=True, exist_ok=True)
+        (e / "lib-serde.json").write_text(json.dumps({kindkey: 0, keyname: []}))
+        return pathlib.Path(root)
+
+    with tempfile.TemporaryDirectory() as root, \
+            contextlib.redirect_stdout(io.StringIO()):
+        rc = main([str(_tree(root))], run_selftest=False)
+        if rc != 0:
+            failures.append(f"healthy fingerprint tree was refused (rc={rc})")
+    with tempfile.TemporaryDirectory() as root, \
+            contextlib.redirect_stderr(io.StringIO()) as refusal:
+        rc = main([str(_tree(root, keyname="dependencies"))], run_selftest=False)
+        if "deps" not in refusal.getvalue():
+            failures.append("the refusal does not name the key that went missing")
+        if rc != 2:
+            failures.append(
+                f"`deps` renamed and the tool still answered (rc={rc}) — a schema "
+                "change must be INCONCLUSIVE, not a plausible empty graph")
+    with tempfile.TemporaryDirectory() as root, \
+            contextlib.redirect_stderr(io.StringIO()):
+        rc = main([str(_tree(root, kindkey="kind"))], run_selftest=False)
+        if rc != 2:
+            failures.append(
+                f"`compile_kind` renamed and the tool still answered (rc={rc}) — host "
+                "and target would be conflated")
+
     for f in failures:
         print(f"[FAIL] {f}", file=sys.stderr)
     if failures:
         return 1
-    print("nros-leaf-graph --self-test: OK (4 checks, incl. the contested-crate case)")
+    if not quiet:
+        print("nros-leaf-graph --self-test: OK (7 checks — 4 fixpoint, 3 fingerprint-schema)")
     return 0
 
 
-def main() -> int:
+def main(argv=None, run_selftest=True) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("target_dir", type=pathlib.Path, nargs="?")
     ap.add_argument("--self-test", action="store_true",
@@ -243,7 +342,7 @@ def main() -> int:
     ap.add_argument("--all-units", action="store_true",
                     help="include stale fingerprint records (historical view; "
                          "they report dependencies the current build does not have)")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
     if args.self_test:
         return self_test()
@@ -253,9 +352,27 @@ def main() -> int:
         print(f"[FAIL] no such target dir: {args.target_dir}", file=sys.stderr)
         return 2
 
-    units = load_units(args.target_dir, all_units=args.all_units)
+    # The negative control runs on the NORMAL path, not only behind a flag
+    # (`check-gate-selftests`' rule, and the right one here): what it proves is
+    # that the schema refusal below is still wired, and the moment that matters
+    # is the moment someone is about to quote a number out of this tool. Issue
+    # 0945 item 3 — the previous shape ran only under `--self-test`, which
+    # nothing invoked. ~10 ms, in-process.
+    if run_selftest and self_test(quiet=True) != 0:
+        print("[FAIL] nros-leaf-graph: own selftest failed — not reporting a graph.",
+              file=sys.stderr)
+        return 1
+
+    schema = {}
+    units = load_units(args.target_dir, all_units=args.all_units, schema=schema)
     if not units:
         print(f"[FAIL] no .fingerprint units under {args.target_dir} — was anything built there?",
+              file=sys.stderr)
+        return 2
+    complaint = schema_complaint(schema)
+    if complaint:
+        print(f"[INCONCLUSIVE] {complaint}\n"
+              "      Nothing is reported, because a wrong number here is worse than none.",
               file=sys.stderr)
         return 2
     reqmap = requirer_map(units)

--- a/scripts/nros-shared-dir-churn.py
+++ b/scripts/nros-shared-dir-churn.py
@@ -99,7 +99,7 @@ def newest_record(tree):
     return best
 
 
-def records(tree):
+def records(tree, schema=None):
     """{unit: (env {var: val}, paths frozenset)} for one build tree.
 
     Only units live in the tree's LAST build (see `_live_units`); a stale orphan
@@ -128,6 +128,10 @@ def records(tree):
                     env[d["var"]] = d.get("val")
                 if p := e.get("RerunIfChanged"):
                     paths |= set(p.get("paths", []))
+            if schema is not None:
+                schema["records"] = schema.get("records", 0) + 1
+                if env or paths:
+                    schema["with_entries"] = schema.get("with_entries", 0) + 1
             out[unit] = (env, frozenset(paths))
     return out
 
@@ -155,7 +159,7 @@ def compare(trees):
     return findings
 
 
-def self_test():
+def self_test(quiet=False):
     """The two divergences, and the case that must NOT be reported.
 
     Encoded as a test because the interesting predicate is "same unit, different
@@ -163,13 +167,16 @@ def self_test():
     instead — which is normal (feature variants) and would make the tool cry wolf
     on every build.
     """
+    import contextlib
+    import io
     import tempfile
 
-    def write(root, tree, unit, env, paths):
+    def write(root, tree, unit, env, paths, envkey="RerunIfEnvChanged",
+             pathkey="RerunIfChanged"):
         d = os.path.join(root, tree, "trip", "prof", ".fingerprint", unit)
         os.makedirs(d, exist_ok=True)
-        local = [{"RerunIfEnvChanged": {"var": k, "val": v}} for k, v in env.items()]
-        local.append({"RerunIfChanged": {"output": "x", "paths": list(paths)}})
+        local = [{envkey: {"var": k, "val": v}} for k, v in env.items()]
+        local.append({pathkey: {"output": "x", "paths": list(paths)}})
         with open(os.path.join(d, RUN), "w", encoding="utf-8") as fh:
             json.dump({"local": local}, fh)
 
@@ -203,24 +210,89 @@ def self_test():
     with tempfile.TemporaryDirectory() as root:
         write(root, "a", "only-in-a", {"K": "4"}, ["/s/x.rs"])
         write(root, "b", "only-in-b", {"K": "4"}, ["/s/x.rs"])
-        rc = main([os.path.join(root, "a"), os.path.join(root, "b")])
+        with contextlib.redirect_stderr(io.StringIO()):
+            rc = main([os.path.join(root, "a"), os.path.join(root, "b")], run_selftest=False)
     assert rc == 2, f"comparing zero shared units must be INCONCLUSIVE, got rc={rc}"
-    print("nros-shared-dir-churn: self-test OK (5 cases: identical, env, paths, feature-variants, vacuity)")
+
+    # Issue 0945 item 3 — the SCHEMA guard. Two trees whose records are identical
+    # and readable must certify; rename the keys cargo owns and the same two trees
+    # must become INCONCLUSIVE rather than "safe to collapse". Without this the
+    # self-test writes the same names it reads and is blind to a cargo rename,
+    # which is the mitigation 0945 credited these tools with and they did not have.
+    with tempfile.TemporaryDirectory() as root:
+        write(root, "a", "pkg-1", {"K": "4"}, ["/s/x.rs"])
+        write(root, "b", "pkg-1", {"K": "4"}, ["/s/x.rs"])
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = main([os.path.join(root, "a"), os.path.join(root, "b")], run_selftest=False)
+    assert rc == 0, f"identical readable trees must certify, got rc={rc}"
+
+    with tempfile.TemporaryDirectory() as root:
+        write(root, "a", "pkg-1", {"K": "4"}, ["/s/x.rs"],
+              envkey="RerunIfEnvironmentChanged", pathkey="RerunIfPathChanged")
+        write(root, "b", "pkg-1", {"K": "4"}, ["/s/x.rs"],
+              envkey="RerunIfEnvironmentChanged", pathkey="RerunIfPathChanged")
+        with contextlib.redirect_stderr(io.StringIO()) as refusal:
+            rc = main([os.path.join(root, "a"), os.path.join(root, "b")], run_selftest=False)
+    assert "RerunIfEnvChanged" in refusal.getvalue(), \
+        "the refusal must name the key it could not find"
+    assert rc == 2, (
+        f"a renamed .fingerprint schema still certified sharing (rc={rc}) — an "
+        "unparsed record set reads as 'every unit agrees'")
+
+    if not quiet:
+        print("nros-shared-dir-churn: self-test OK (7 cases: identical, env, paths, "
+              "feature-variants, vacuity, readable-certifies, renamed-schema-refuses)")
 
 
-def main(argv):
+def main(argv, run_selftest=True):
     if "--self-test" in argv:
         self_test()
         return 0
+    # The negative control runs on the NORMAL path, not only behind a flag
+    # (`check-gate-selftests`' rule). This tool's output sentence is "safe to
+    # collapse onto one --target-dir"; the moment to prove its parser and its
+    # schema refusal are still wired is the moment before it says that, not a
+    # `--self-test` nobody invokes. Issue 0945 item 3. ~50 ms, in-process.
+    if run_selftest:
+        self_test(quiet=True)
     trees = [a for a in argv if not a.startswith("-")]
     if len(trees) < 2:
         print(__doc__.strip().splitlines()[0], file=sys.stderr)
         print("\nneed at least two build trees to compare", file=sys.stderr)
         return 2
     findings = compare(trees)
-    seen = {t: records(t) for t in trees}
+    schema = {}
+    seen = {t: records(t, schema) for t in trees}
     counts = collections.Counter(u for r in seen.values() for u in r)
     shared = sum(1 for u, n in counts.items() if n > 1)
+
+    # Issue 0945 item 3 — never certify on an unparsed schema either.
+    #
+    # `local` and its `RerunIfEnvChanged` / `RerunIfChanged` entries are cargo's
+    # private on-disk format, read here with `.get(..., default)`. A rename does
+    # not raise: every unit parses to an EMPTY env dict and an EMPTY path set,
+    # every unit therefore agrees with every other, `findings` is empty, and the
+    # tool prints "safe to collapse onto one --target-dir" — the most dangerous
+    # sentence it can say, on evidence it did not read.
+    #
+    # `Precalculated` entries are normal and carry neither key (measured: 14 of
+    # 125 records in the freertos tree, 16 of 72 in qemu-arm-baremetal), so the
+    # predicate is "not ONE record in ANY tree yielded an entry", not "some
+    # record yielded none".
+    #
+    # This is what 0945 assumed `--self-test` already provided. It did not: the
+    # self-test writes the same key names it reads, so it pins the parser against
+    # itself and stays green through a rename.
+    if schema.get("records") and not schema.get("with_entries"):
+        print(
+            f"nros-shared-dir-churn: INCONCLUSIVE — {schema['records']} build-script "
+            "record(s) read and NOT ONE\n"
+            "yielded a RerunIfEnvChanged or RerunIfChanged entry. Cargo's .fingerprint\n"
+            "format is private; a renamed key reads as \"every unit agrees\", which is\n"
+            "indistinguishable from a clean result and would certify sharing on nothing.",
+            file=sys.stderr,
+        )
+        return 2
 
     # Never certify on nothing. A tool that prints OK when it compared zero units
     # is the vacuous-pass shape this repo gates against elsewhere


### PR DESCRIPTION
Phase-424's last two. One is classified; the other is **declined**, and the reason
is that the issue I filed was wrong.

## #0945 — five assumptions, and there are six

| # | assumption | verdict |
| --- | --- | --- |
| 1 | Corrosion symlink | accepted risk, witnessed — **and it is a COST dependency, not a correctness one**: `_arts()` hashes the cell's own build dir and never the cargo tree, so a dead redirect makes the 120-cell probe unaffordable, not wrong |
| 2 | `-Z --artifact-dir` | accepted risk, loud in every direction; blast radius measured at **13** nuttx cmake cells, not 7 |
| 3 | `.fingerprint` parsing | **the claimed mitigation did not exist — now it does** |
| 4 | header side channel | accepted risk, **highest incidence and invisible to the differential families** |
| 5 | depfile beside the uplifted artifact | accepted risk, loud where it matters |
| **6** | **cargo's `[<triple>/]<profile>/<bin>` layout (new)** | **accepted risk, NO detection today — the register's one real gap** |

**Item 3 is the sharp one.** #0945 claimed both tools' `--self-test` would surface a
schema change. Both claims are false: `nros-leaf-graph`'s never opened a json file,
and `nros-shared-dir-churn`'s wrote the same key names it read. Every key is read
with `.get(...)`, so a rename yields a *plausible wrong answer* — "nothing leaves",
"safe to collapse onto one `--target-dir`". Both now refuse (INCONCLUSIVE, rc 2),
mutation-checked in both directions.

**Item 4's real incidence is not the stated risk.** A cargo GC has never fired; the
side channel having no owner has, **six times** — 0360, 0834, 0978, 0985, 0987,
1031. A wrong header yields the same wrong bytes twice, so the differential
families read FRESH. Remaining work counted rather than estimated: 128 hits, 26
files.

**Item 6 is the one nobody had written down.** If cargo's layout moves,
`_row_artifacts` empties, the probe silently falls back to the pre-#0835
`"fresh":false`, and #0835's permanent oscillation returns as a self-healing
warning. Measured read-only: 116/117 rust rows and 120/120 cmake cells find an
artifact; exactly one is on the silent fallback today. Its remedy is **specified
and deliberately not landed** — verifying it needs a built fixture tree, and
unverified shell in the freshness gate is the defect this phase exists to remove.

A gate caught the agent here too: it first wired the self-tests as a `check` gate
and `check-gate-selftests` rejected it — *"a negative control nobody runs decays
into a comment."* Both `main()`s now run their self-test on the normal path.

## #1056 — declined, because I filed it wrong

Three of the four load-bearing claims in the issue are false:

1. **One node lapses, not two.** The listener is fed a 1 Hz stream, which resets
   its lease; only the pure publisher closes. The evidence was already in my own
   doc comment and I did not chase it: the per-node model predicts ~8 sessions for
   #0906's 10 s lease where the cell measured **5**. One node gives
   `2 + floor(60/20) = 5`, exactly.
2. **The period is `2 x lease` only while `2 x lease < 30 s`.** Above that it is a
   beat against the router's 30 s keep-alive: first close at 45 s for L=15, 80 s
   for L=20, **899 s for L=29**. So the acceptance I wrote — every lease in
   `(0, 30_000)` — is **unpayable**, not merely unbought.
3. **Skew is not the exposure.** Both nodes must participate for all 60 samples, so
   each one's life spans that window whatever the skew. Nine stored router logs:
   skew 0.00–20.0 s, span 60.6–82.2 s, exactly 2 sessions 9/9.

Covered band is **L ≤ 14 s**. 120 s moves it to 18 s for +12 minutes across twelve
cells; 180 s to 22 s for +24. What ships is 60 s (ours) and **10 s** (zenoh-pico's
upstream default, and what a regression reverts to) — inside the band with margin.

So: not 120 s, and not any number. What landed instead is the corrected derivation
in both doc comments and the assertion message, plus `COVERED_LEASE_SECS = 14`
printed on every run so a PASS states its scope. The free alternative
(`MAX_ROUTER_SESSIONS` 3→2, same 18 s for zero wall clock) is recorded and declined
pending a healthy-count measurement on all twelve cells.

## Merge note

Rebased onto main after #424 landed. The agent had independently fixed the same
`format_in_format_args` red inside the assert it was rewriting; I kept my binding
from #424 and took its corrected physics wording for the message.

`just check fast` **210/210**; `cargo clippy -p nros-tests --test rtos_e2e -D
warnings` clean. `check::build` cannot run in a fresh worktree — 19 of 22
submodules uninitialised — and the agent initialised two to confirm the class
rather than assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj
