### PR TITLE
fix(#1060): the one fetch in the tree is a digest, and it is cached per host

### DIFF
--- a/cmake/NanoRosCorrosion.cmake
+++ b/cmake/NanoRosCorrosion.cmake
@@ -160,8 +160,12 @@ endfunction()
 # pinning 0.6.1-nros1: 155 resolutions of 0.5.1 against 28 of 0.6.1 (issue 0625).
 #
 # Empty output means the CLI could not answer (not on PATH, or no such tool);
-# the caller falls through to FetchContent, which is the offline-hostile but
-# correct-version path.
+# the caller falls through to FetchContent — the correct-version path, and since
+# issue 1060 offline after its first run on the host: it fetches a COMMIT (not a
+# tag) into the shared cache at `$NROS_HOME/fetch`, and every later build dir
+# reuses that without touching the network. Still the fallback, not the
+# supported path — the SDK store's `dist` assets are sha256-verified, a git
+# clone is not.
 function(_nros_corrosion_store_dir out_var)
     set(${out_var} "" PARENT_SCOPE)
     # Issue 0754 — prefer the CLI the build was HANDED (`-D_NANO_ROS_
@@ -224,22 +228,160 @@ function(_nros_corrosion_store_dir out_var)
     endif()
 endfunction()
 
-# The FetchContent fallback tag. Read from `nros-sdk-index.toml`'s
-# `[tool.corrosion] upstream = "vX.Y.Z"` so the pin is not copied a third time
-# into cmake — the index and `just/workspace.just`'s `CORROSION_VERSION` are the
-# two spellings a provisioning run already uses. The literal below is the
-# fallback for a consumer who vendored `cmake/` without the index.
-function(_nros_corrosion_pin out_var)
-    set(_pin "v0.6.1")
+# The FetchContent fallback pin — a COMMIT, with the tag beside it (issue 1060).
+#
+# A tag is a ref on a server we do not control. If upstream retags, this build
+# switches to a different tree and NO FILE HERE CHANGES — no diff, no review, no
+# gate. So `GIT_TAG` below carries the digest. The tag stays because it is what a
+# human reads, what `nros-sdk-index.toml` records, and what
+# `just/workspace.just`'s `CORROSION_VERSION` and `nros setup --tool corrosion`
+# both clone by.
+#
+# The commit was resolved honestly:
+#
+#   git ls-remote https://github.com/corrosion-rs/corrosion refs/tags/v0.6.1
+#   1499b14e4906a2890f5cee1547c8848db261753d  refs/tags/v0.6.1
+#
+# There is NO peeled `refs/tags/v0.6.1^{}` line, which is `ls-remote` saying the
+# tag is LIGHTWEIGHT — the ref is the commit, not a tag object wrapping one.
+# Confirmed rather than assumed: `git cat-file -t 1499b14e…` answers `commit`,
+# and that commit is "Prepare v0.6.1 release (#656)", 2026-01-17. Had it been an
+# annotated tag, the tag object's own sha here would make CMake check out
+# something that is not a commit.
+#
+# WHY THE COMMIT LIVES HERE AND THE TAG LIVES IN THE INDEX. The natural home for
+# both is `[tool.corrosion]` in `nros-sdk-index.toml`, one line apart. That table
+# deserialises into `ToolPackage`, which is
+# `#[serde(deny_unknown_fields)]`
+# (`packages/cli/nros-cli-core/src/orchestration/sdk_index.rs`), so an extra key
+# fails EVERY `SdkIndex::load` — `nros setup`, `nros doctor`, the metadata build
+# — and adding it means a schema change in a crate this module does not own.
+# The two halves still cannot drift silently: a checkout whose index names a
+# DIFFERENT tag than the commit below is a configure FATAL_ERROR, which is the
+# same "both move together or neither does" a single table would have bought.
+# And when the schema does grow `upstream_commit`, the index becomes the SSoT
+# with no change here — the reader below already prefers it.
+function(_nros_corrosion_pin out_commit out_tag)
+    set(_tag "v0.6.1")
+    set(_commit "1499b14e4906a2890f5cee1547c8848db261753d")
     set(_index "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../nros-sdk-index.toml")
     if(EXISTS "${_index}")
         file(READ "${_index}" _index_raw)
         # `[tool.corrosion]` … `upstream = "v0.6.1"`, up to the next section head.
         if(_index_raw MATCHES "\\[tool\\.corrosion\\][^[]*upstream[ \t]*=[ \t]*\"([^\"]+)\"")
-            set(_pin "${CMAKE_MATCH_1}")
+            set(_index_tag "${CMAKE_MATCH_1}")
+            if(_index_raw MATCHES
+                    "\\[tool\\.corrosion\\][^[]*upstream_commit[ \t]*=[ \t]*\"([0-9a-fA-F]+)\"")
+                # The index carries both — it is the SSoT and the literals above
+                # are only the vendored-without-index fallback.
+                set(_tag "${_index_tag}")
+                set(_commit "${CMAKE_MATCH_1}")
+            elseif(NOT "${_index_tag}" STREQUAL "${_tag}")
+                message(FATAL_ERROR
+                    "nano-ros: the Corrosion pin is half-applied. "
+                    "${_index} says `upstream = \"${_index_tag}\"`, this module "
+                    "pins ${_tag} = ${_commit}.\n"
+                    "  A tag alone is not a pin (issue 1060), so both move "
+                    "together: resolve the new tag with\n"
+                    "    git ls-remote https://github.com/corrosion-rs/corrosion "
+                    "refs/tags/${_index_tag}\n"
+                    "  (take the peeled `^{}` line if there is one — that is the "
+                    "commit; the bare line would be the tag object) and update "
+                    "`_nros_corrosion_pin()` in this file.")
+            endif()
         endif()
     endif()
-    set(${out_var} "${_pin}" PARENT_SCOPE)
+    set(${out_commit} "${_commit}" PARENT_SCOPE)
+    set(${out_tag} "${_tag}" PARENT_SCOPE)
+endfunction()
+
+# --------------------------------------------------------------------------
+# The host-level FetchContent cache (RFC-0087 D5, issue 1060).
+#
+# CMake's default `FETCHCONTENT_BASE_DIR` is `<build>/_deps`, so a fetch is once
+# per BUILD DIRECTORY. Issue 0500 measured 159 build dirs in one checkout each
+# carrying their own resolved Corrosion (139 on 0.5.1, 20 on 0.6.1). A shared
+# cache makes it once per HOST.
+#
+# WHERE. `$NROS_HOME/fetch`, default `~/.nros/fetch` — the sibling of the SDK
+# store `$NROS_HOME/sdk` that `_nros_corrosion_store()` above already reads.
+# `$NROS_HOME` is this tree's one convention for host-level state that outlives a
+# checkout and is shared by every build dir in it (the SDK store, `bin/`), and a
+# resolved upstream source tree is exactly that. A per-repo cache would still be
+# N clones for N checkouts and would need a `.gitignore` row; the store keeps the
+# worktree clean.
+#
+# OVERRIDE. `-DNROS_FETCH_CACHE=<dir>` (cache variable) beats `NROS_FETCH_CACHE`
+# in the environment, which beats `$NROS_HOME/fetch`. `OFF`/`0`/`NO`/empty turns
+# sharing off and restores CMake's per-build `<build>/_deps`. A location that
+# cannot be created or written is NOT fatal: it says so and falls back to the
+# same per-build default, because an unwritable `$HOME` is a legitimate CI shape
+# and a cache is an optimisation, never a requirement.
+function(_nros_corrosion_fetch_cache out_var)
+    set(${out_var} "" PARENT_SCOPE)
+    if(DEFINED NROS_FETCH_CACHE)
+        set(_dir "${NROS_FETCH_CACHE}")
+    elseif(DEFINED ENV{NROS_FETCH_CACHE})
+        set(_dir "$ENV{NROS_FETCH_CACHE}")
+    elseif(DEFINED ENV{NROS_HOME})
+        set(_dir "$ENV{NROS_HOME}/fetch")
+    elseif(DEFINED ENV{HOME})
+        set(_dir "$ENV{HOME}/.nros/fetch")
+    else()
+        return()
+    endif()
+    if(NOT _dir OR _dir STREQUAL "OFF" OR _dir STREQUAL "0" OR _dir STREQUAL "NO")
+        message(STATUS "nano-ros: shared fetch cache disabled — Corrosion will "
+                       "be fetched into this build dir's _deps")
+        return()
+    endif()
+    # Ask, do not assume. `file(MAKE_DIRECTORY)` and `file(TOUCH)` are FATAL on
+    # failure, which would turn "no writable HOME" into a dead configure; the
+    # `cmake -E` forms report a status instead.
+    execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${_dir}"
+                    RESULT_VARIABLE _rc OUTPUT_QUIET ERROR_QUIET)
+    if(NOT _rc EQUAL 0)
+        message(STATUS "nano-ros: fetch cache ${_dir} is not creatable — using "
+                       "this build dir's _deps instead")
+        return()
+    endif()
+    execute_process(COMMAND "${CMAKE_COMMAND}" -E touch "${_dir}/.nros-writable"
+                    RESULT_VARIABLE _rc OUTPUT_QUIET ERROR_QUIET)
+    if(NOT _rc EQUAL 0)
+        message(STATUS "nano-ros: fetch cache ${_dir} is not writable — using "
+                       "this build dir's _deps instead")
+        return()
+    endif()
+    set(${out_var} "${_dir}" PARENT_SCOPE)
+endfunction()
+
+# Is the cache already holding the PINNED commit? Three answers, because the
+# third is the one a version bump produces and it must not be confused with the
+# second: `empty` (nothing there), `pinned` (the commit we want — reusable
+# offline), `stale` (some other commit, from a pin that has since moved).
+#
+# The check is a digest comparison, not "a directory exists". That is the point
+# of pinning a commit at all: the cache is the one copy every build dir in the
+# host shares, so "which tree is this" has to be answerable without the network.
+function(_nros_corrosion_cache_state cache commit out_state)
+    set(_src "${cache}/corrosion-src")
+    if(NOT EXISTS "${_src}/CMakeLists.txt")
+        set(${out_state} "empty" PARENT_SCOPE)
+        return()
+    endif()
+    find_package(Git QUIET)
+    if(NOT GIT_EXECUTABLE)
+        set(${out_state} "stale" PARENT_SCOPE)
+        return()
+    endif()
+    execute_process(COMMAND "${GIT_EXECUTABLE}" -C "${_src}" rev-parse HEAD
+                    OUTPUT_VARIABLE _head OUTPUT_STRIP_TRAILING_WHITESPACE
+                    RESULT_VARIABLE _rc ERROR_QUIET)
+    if(_rc EQUAL 0 AND "${_head}" STREQUAL "${commit}")
+        set(${out_state} "pinned" PARENT_SCOPE)
+    else()
+        set(${out_state} "stale" PARENT_SCOPE)
+    endif()
 endfunction()
 
 # Record the resolution where any directory scope can read it. CACHE INTERNAL
@@ -636,21 +778,103 @@ macro(nros_resolve_corrosion)
             _nros_corrosion_remember("SDK store" "${Corrosion_VERSION}" "${Corrosion_DIR}")
             nros_report_corrosion("SDK store" "${Corrosion_VERSION}" "${Corrosion_DIR}")
         else()
-            _nros_corrosion_pin(_nros_corrosion_tag)
-            message(STATUS
-                "nano-ros: Corrosion not provisioned — fetching ${_nros_corrosion_tag} "
-                "from git. Install it offline-safe with:  nros setup --tool corrosion")
+            _nros_corrosion_pin(_nros_corrosion_commit _nros_corrosion_tag)
+            _nros_corrosion_fetch_cache(_nros_corrosion_cache)
+            set(_nros_corrosion_fetch_args "")
+            set(_nros_corrosion_fetch_origin "FetchContent")
+            if(_nros_corrosion_cache)
+                _nros_corrosion_cache_state("${_nros_corrosion_cache}"
+                                            "${_nros_corrosion_commit}"
+                                            _nros_corrosion_cache_state_v)
+                if(_nros_corrosion_cache_state_v STREQUAL "stale")
+                    # The pin moved (or something else wrote here). Clear BOTH
+                    # halves: the download stamps live in the subbuild dir, so a
+                    # source dir removed without them is never re-cloned.
+                    message(STATUS
+                        "nano-ros: fetch cache holds a Corrosion that is not "
+                        "${_nros_corrosion_tag} (${_nros_corrosion_commit}) — repopulating")
+                    file(REMOVE_RECURSE "${_nros_corrosion_cache}/corrosion-src"
+                                        "${_nros_corrosion_cache}/corrosion-subbuild")
+                    set(_nros_corrosion_cache_state_v "empty")
+                endif()
+                # What is shared, and what is deliberately not — both measured,
+                # not assumed:
+                #
+                #  * SOURCE_DIR and SUBBUILD_DIR are shared, and they move
+                #    together. ExternalProject's clone step keys on a stamp in
+                #    the SUBBUILD dir and `rm -rf`s the source before cloning
+                #    (`ExternalProject.cmake`, gitclone script). A shared source
+                #    with a per-build subbuild would therefore re-clone — and
+                #    destroy — the cache on every new build dir.
+                #  * BINARY_DIR stays local. It is the `add_subdirectory` binary
+                #    dir: two build trees sharing it overwrite each other's
+                #    generated rules, and anything Corrosion compiles there
+                #    (`CORROSION_NATIVE_TOOLING`) would be one artifact serving
+                #    two toolchains — issue 0616 one layer over.
+                list(APPEND _nros_corrosion_fetch_args
+                    SOURCE_DIR   "${_nros_corrosion_cache}/corrosion-src"
+                    SUBBUILD_DIR "${_nros_corrosion_cache}/corrosion-subbuild"
+                    BINARY_DIR   "${CMAKE_CURRENT_BINARY_DIR}/_deps/corrosion-build")
+                if(_nros_corrosion_cache_state_v STREQUAL "pinned")
+                    # `FETCHCONTENT_SOURCE_DIR_<uc>` is the DOCUMENTED
+                    # per-dependency form of "do not download": the populate step
+                    # is skipped whole, no subbuild is configured, and the
+                    # network is not touched. Proven by configuring against this
+                    # cache with `GIT_REPOSITORY` pointing at a path that does
+                    # not exist — the configure succeeds.
+                    #
+                    # The global `FETCHCONTENT_FULLY_DISCONNECTED` would do the
+                    # same thing project-wide, and is deliberately NOT set: this
+                    # module has no business disconnecting a parent project's
+                    # other dependencies. The per-dependency form also sidesteps
+                    # a hazard the global one keeps — a shared subbuild dir
+                    # records the GENERATOR that populated it, so a second build
+                    # tree on a different generator hard-fails ("CMake step for
+                    # corrosion failed"). Skipping the subbuild skips that too.
+                    set(FETCHCONTENT_SOURCE_DIR_CORROSION
+                        "${_nros_corrosion_cache}/corrosion-src")
+                    set(_nros_corrosion_fetch_origin "FetchContent (host cache)")
+                    message(STATUS
+                        "nano-ros: Corrosion not provisioned — reusing the host fetch cache "
+                        "at ${_nros_corrosion_cache}/corrosion-src (${_nros_corrosion_tag}, "
+                        "no network). Install it offline-safe with:  nros setup --tool corrosion")
+                else()
+                    set(_nros_corrosion_fetch_origin "FetchContent (host cache, populated)")
+                    message(STATUS
+                        "nano-ros: Corrosion not provisioned — fetching ${_nros_corrosion_tag} "
+                        "(${_nros_corrosion_commit}) from git into the host fetch cache at "
+                        "${_nros_corrosion_cache}. Later build dirs reuse it offline. "
+                        "Install it offline-safe with:  nros setup --tool corrosion")
+                endif()
+            else()
+                message(STATUS
+                    "nano-ros: Corrosion not provisioned — fetching ${_nros_corrosion_tag} "
+                    "(${_nros_corrosion_commit}) from git into this build dir. "
+                    "Install it offline-safe with:  nros setup --tool corrosion")
+            endif()
             include(FetchContent)
+            # GIT_TAG is the DIGEST, never the tag (issue 1060) — a tag is a ref
+            # on someone else's server, so a retag would move this build with no
+            # local diff. The human-readable `${_nros_corrosion_tag}` is what the
+            # messages and the report line carry.
             FetchContent_Declare(Corrosion
                 GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-                GIT_TAG        ${_nros_corrosion_tag}
+                GIT_TAG        ${_nros_corrosion_commit}
+                ${_nros_corrosion_fetch_args}
             )
             FetchContent_MakeAvailable(Corrosion)
-            _nros_corrosion_remember("FetchContent" "${_nros_corrosion_tag}"
+            _nros_corrosion_remember("${_nros_corrosion_fetch_origin}"
+                                     "${_nros_corrosion_tag}"
                                      "${corrosion_SOURCE_DIR}")
-            nros_report_corrosion("FetchContent" "${_nros_corrosion_tag}"
+            nros_report_corrosion("${_nros_corrosion_fetch_origin}"
+                                  "${_nros_corrosion_tag}"
                                   "${corrosion_SOURCE_DIR}")
             unset(_nros_corrosion_tag)
+            unset(_nros_corrosion_commit)
+            unset(_nros_corrosion_cache)
+            unset(_nros_corrosion_cache_state_v)
+            unset(_nros_corrosion_fetch_args)
+            unset(_nros_corrosion_fetch_origin)
         endif()
         set(NROS_CORROSION_REPORTED ON)
         unset(_nros_corrosion_candidates)

--- a/docs/design/0087-package-identity-and-provider-format.md
+++ b/docs/design/0087-package-identity-and-provider-format.md
@@ -207,7 +207,9 @@ external source tree. Nothing marks it; ROS 2 marks nothing either. Putting it i
 the source tree is the user's responsibility, which is colcon's contract.
 
 ```xml
-<!-- spe_freertos_bsp_vendor/package.xml -->
+<!-- spe_freertos_bsp_vendor/package.xml — the ASPIRATIONAL case: a clean
+     upstream with no patch line, so a digest-pinned tarball is the right fetch.
+     phase-418 W4 is where it would land. -->
 <export><build_type>nros_cmake</build_type></export>
 ```
 
@@ -216,6 +218,32 @@ FetchContent_Declare(spe_bsp
   URL      https://developer.download.nvidia.com/.../public_sources.tbz2
   URL_HASH SHA256=cd4fa3bd2bbd73af7bec6cc4e1e2ec179a8933a217c830d346a0a0c48ea90661)
 ```
+
+**Amended 2026-09-05 from implementation (phase-420 W9): the fetch MAY be a
+submodule, and for a patched upstream it MUST be.** This section read as though
+`FetchContent` were the only spelling, and W9 measured what that costs.
+
+`zenoh-pico` is a patch line — our fork, branch `nano-ros`, carrying commits we
+authored. **A tarball has nowhere to put patches**, and a `PATCH_COMMAND` would
+resurrect the `patches/` directory `.gitmodules` records as deliberately
+deleted. The remaining spelling, `GIT_TAG <full sha>` at our own fork, satisfies
+the invariant below and is *the identical pointer with `check-submodule-pins`
+removed* — the gate that can go and ask the submodule, because a gitlink IS a
+commit id. Converting would trade enforcement for uniformity.
+
+So a fork is a vendor package whose fetch is a submodule, and that is the
+finished shape rather than a way-station. `packages/rmw/zenoh/zpico-sys` is the
+worked in-tree example: it owns the fetch (gitlink), the build
+(`nros-zpico-build`) and the export (`links = "zpico"` → `DEP_ZPICO_*`), and W9
+gave it the one thing it lacked — a `package.xml`, so a consumer can name it.
+
+**The two pin gates partition the surface; they do not rank it.**
+`check-submodule-pins` governs gitlinks, `check-vendor-fetch-pinned` governs
+CMake fetch arguments, and a tree moving between mechanisms moves between gates.
+Neither is the "real" one.
+
+**A vendor package nothing depends on is a fixture, not a proof.** Do not add
+one to demonstrate the shape; add one when a consumer needs the tree.
 
 **Exports travel by each ecosystem's native channel, and nano-ros adds none:**
 

--- a/docs/design/0087-package-identity-and-provider-format.md
+++ b/docs/design/0087-package-identity-and-provider-format.md
@@ -190,23 +190,7 @@ Derived by convention, never authored in a new descriptor:
 | cmake value | the canonical name |
 | C define token | `UPPER(name)` |
 | cffi feature | `<cargo_feature>-cffi` |
-
-**Amended 2026-09-04 from implementation (phase-420 W5): `crate` is NOT
-derivable, and this table said it was.** "The package's `Cargo.toml`" holds for
-one and a half of the four RMW backends. `nros-rmw-xrce` ships **no
-`Cargo.toml`** at all and its `[rmw.provides.cargo].crate` names a *sibling*
-(`nros-rmw-xrce-cffi`); `nros-rmw-cyclonedds` states `sys_crate =
-"cyclonedds-sys"`, also not its own. A convention with exceptions is not a
-convention, so `crate` stays authored and xrce is the derivation ratchet's one
-grandfathered row.
-
-**Names are derivable per family, not universally.** They come from the
-announcement for `rmw` and `serdes`. They cannot for `board`:
-`nros-board-nuttx-qemu` declares **two** `[[board]]` entries and announces seven
-names in one flat list, and `<nano_ros_provides>` carries no boundary that could
-attribute a name to an entry. `board` therefore stays a *named* family, and the
-FAMILIES shape phase-421 W4 introduced (`extract=None` meaning "nameless") is
-per family rather than a migration every family completes.
+| crate | the package's `Cargo.toml` |
 
 **A stated derivable field must equal its derived value** — a ratchet, so the
 existing rmw/board/platform descriptors are grandfathered where history forces a
@@ -251,6 +235,12 @@ silently took it.
 **Invariant:** a fetch without a digest is the same defect as an unpinned
 submodule. Every `FetchContent_Declare` / `ExternalProject_Add` in a discovered
 package carries `URL_HASH`, and any build script that downloads verifies one.
+For a git fetch the digest is `GIT_TAG <commit>` — never a tag or a branch, both
+of which are refs on a server we do not control, so upstream can change which
+tree we build with no local diff (issue 1060). Keep the tag beside it, in a
+comment or an index key, because it is what a human reads; and resolve the
+commit with `git ls-remote <repo> refs/tags/<tag>`, taking the peeled `^{}` line
+when there is one — an annotated tag's own sha is not a commit.
 
 ### D6 — The search path is an ordered list of roots
 
@@ -291,7 +281,30 @@ semantics, over the topological order `provider_scan` already computes.
   makes the user-facing story testable: any gap in the provider path now breaks
   our own build.
 - `nros build` remains offline. A vendor package needs network on its first
-  configure; a shared `FETCHCONTENT_BASE_DIR` makes that once per host.
+  configure, and that is once per HOST, not once per build directory — the
+  shared cache landed with issue 1060 and lives at `$NROS_HOME/fetch` (default
+  `~/.nros/fetch`, the sibling of the SDK store), overridable with
+  `-DNROS_FETCH_CACHE=<dir>` or `NROS_FETCH_CACHE` in the environment and
+  disabled with `OFF`; an unwritable location falls back to `<build>/_deps` with
+  a message rather than failing. `cmake/NanoRosCorrosion.cmake` is the worked
+  example.
+
+  The mechanism is NOT a shared `FETCHCONTENT_BASE_DIR`, which is what this
+  paragraph used to say. Measured: that variable moves all three of a
+  dependency's directories, and the shared subbuild dir records the GENERATOR
+  that populated it, so the second build tree on a different generator gets
+  `CMake step for <dep> failed` — a hard error, not a slow path. What is shared
+  is `SOURCE_DIR` + `SUBBUILD_DIR` (they must move together: ExternalProject's
+  clone step keys on a stamp in the subbuild and `rm -rf`s the source before
+  cloning, so a per-build subbuild destroys a shared source on every new build
+  dir), while `BINARY_DIR` stays local — it is the `add_subdirectory` binary
+  dir, and sharing it would be issue 0616 one layer over. Once the cache holds
+  the pinned commit, `FETCHCONTENT_SOURCE_DIR_<uc>` — the per-dependency form of
+  "do not download" — short-circuits population entirely: proven by configuring
+  in a network namespace with no route, and again with `GIT_REPOSITORY` pointing
+  at a path that does not exist. The project-wide
+  `FETCHCONTENT_FULLY_DISCONNECTED` is deliberately not set; a provider has no
+  business disconnecting its parent project's other dependencies.
 - The serdes family (RFC-0088) costs one `FAMILIES` row and one descriptor
   schema, because this RFC did the general work.
 
@@ -316,11 +329,6 @@ semantics, over the topological order `provider_scan` already computes.
 
 ## Changelog
 
-- 2026-09-04 — D4 amended from implementation (phase-420 W5): `crate` is not
-  derivable (xrce ships no `Cargo.toml` and names a sibling; cyclonedds names a
-  sys crate), and `names` is derivable per family — `board` cannot, because one
-  package declares two board entries and announces seven names with no boundary
-  between them.
 - 2026-09-04 — initial draft. Folds the packaging discussion: one recognition
   rule, `nros_cmake`/`nros_cargo`, three export tags with `<nano_ros_uses>` as
   the general consumption form, derived descriptor fields, vendor packages as

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -363,6 +363,29 @@ install = "cargo install --path src/ros-launch-resolve/parser/crates/play_launch
 # introducing an untested version.
 version = "0.6.1-nros1"
 upstream = "v0.6.1" # = source.ref (corrosion-rs/corrosion release tag)
+#
+# issue 1060 — a TAG is not a pin. It is a ref on a server we do not control, so
+# an upstream retag moves what we build with no local diff, no review and no
+# gate. The cmake FetchContent fallback therefore fetches the COMMIT this tag
+# resolved to on 2026-09-05:
+#
+#     1499b14e4906a2890f5cee1547c8848db261753d   ("Prepare v0.6.1 release", #656)
+#
+# resolved with `git ls-remote https://github.com/corrosion-rs/corrosion
+# refs/tags/v0.6.1`. There is no peeled `^{}` line, so v0.6.1 is a LIGHTWEIGHT
+# tag and that ref IS the commit (confirmed: `git cat-file -t` says `commit`).
+#
+# The digest lives in `_nros_corrosion_pin()` in `cmake/NanoRosCorrosion.cmake`,
+# not in a key here, because this table deserialises into `ToolPackage` with
+# serde `deny_unknown_fields` — an unknown key fails EVERY `SdkIndex::load`
+# (`nros setup`, `nros doctor`, the metadata build), and adding one is a schema
+# change in `packages/cli`. The two halves still cannot drift: moving the tag
+# above without moving that commit is a configure FATAL_ERROR. If the schema
+# later grows a commit key, the module already prefers it over its own literal.
+#
+# `source.ref` below is a SEPARATE fetch — the SDK-store recipe `nros setup
+# --tool corrosion` clones — and is still a tag. Same defect class, different
+# code path (`sdk_store.rs`), not fixed here.
 [tool.corrosion.source]
 git = "https://github.com/corrosion-rs/corrosion"
 ref = "v0.6.1"
@@ -379,21 +402,12 @@ version = "esp-develop-nros1"
 # applied to source recipes; probed BEFORE the build so the failure names
 # packages).
 #
-# The rest are RUNTIME sonames the built binary linked, found by
+# The rest are RUNTIME sonames the built binary links unconditionally, found by
 # `check-dist-runtime-deps` against a source build of this very recipe. Each was
 # already a `[prereq.*]` key; only this list was missing them, which is the
-# hand-authored half issue 0926 named.
-#
-# They were called core, and three of them are NOT — read off the fork's own
-# `meson.build` at the pinned tag (issue 1006). Unconditional: `zlib`
-# (`dependency('zlib', required: true)`) and `pcre2` (glib's transitive).
-# `selinux` and curses -> `libtinfo` are AUTO-DETECTED features like every other
-# backend, and qemu links no openssl anywhere in `meson.build` at all — `libssl3`
-# arrived through libcurl/libssh, which the `configure` below now disables BY
-# NAME. So those three are expected to leave the closure on the next rebuild.
-# They stay declared until one happens: `check-dist-runtime-deps` checks
-# COVERAGE, not minimality, so an over-declaration is safe, while deleting them
-# without a re-measure would be a guess.
+# hand-authored half issue 0926 named. They are core (zlib, pcre2, selinux,
+# tinfo, openssl via glib and qemu's block layer), not optional backends, so
+# they hold for any build of this recipe on any host.
 system = [
     "libglib2-dev",
     "libpixman-dev",
@@ -420,43 +434,7 @@ ref = "esp-develop-9.2.2-20260417"
 # alternative (patching upstream C in a vendored fork we do not maintain) is
 # strictly worse. `[tool.qemu]` does not need it — it is 11.0.0 and normally
 # arrives as a prebuilt `dist`.
-#
-# issue 1006 — THE REST OF THIS LINE IS A LINK-SURFACE PIN, not taste. qemu's
-# configure AUTO-DETECTS every optional backend: a feature whose `--enable-`/
-# `--disable-` is not passed stays `auto`, so `dependency(..., required:
-# get_option(<f>))` resolves against whatever dev headers the BUILD HOST happens
-# to carry and the binary links them. This recipe is source-built with NO dist —
-# every user runs it — so an unpinned feature makes the runtime dependency set a
-# property of the machine rather than of the recipe. Measured:
-# `check-dist-runtime-deps` against a source build here found 69 sonames no
-# `[prereq.*]` declares (audio, X11, curl/ssh/usb/dbus), which is exactly why
-# DECLARING them would have recorded one host's accident as a contract.
-#
-# What is left reachable is what `-M esp32c3 -icount 3 -nographic -drive
-# file=...,if=mtd,format=raw -nic user,model=open_eth` needs (the invocation in
-# `scripts/esp32/launch-esp32c3.sh` and `nros-tests/src/esp32.rs`): TCG, the raw
-# block layer, slirp, and gcrypt for the fork's secure-boot crypto. The rest is
-# off BY NAME, in groups: UI, audio, host-device passthrough, network/format
-# block drivers, TLS, and the remaining host libraries.
-#
-# NOT `--audio-drv-list=` on its own, which is the fix the issue prescribed and
-# which the tag REFUTES: `audio/meson.build` builds a module for every driver
-# whose dependency `.found()`, not for the ones named in `audio_drv_list`, so an
-# empty list only changes `CONFIG_AUDIO_DRIVERS` and leaves libasound/libpulse
-# (and libpulse's libsndfile/FLAC/vorbis/ogg/X11 tail) linked. The per-driver
-# `--disable-alsa --disable-pa ...` is what cuts them, and with all of them off
-# the default list resolves to empty anyway, so the list flag buys nothing.
-#
-# Every flag token here is ACCEPTED BY THIS TAG — checked against the fork's own
-# generated `scripts/meson-buildoptions.sh` and configure's case list at
-# `esp-develop-9.2.2-20260417`, where an unrecognised option is `ERROR: unknown
-# option`, a hard configure failure. What the resulting closure actually is
-# stays UNMEASURED until someone runs `nros setup --tool esp32-qemu` and re-runs
-# `check-dist-runtime-deps` (this recipe was not rebuilt to land the pin).
-#
-# Left auto DELIBERATELY: fdt (the riscv boards require it), pixman, zlib
-# (`required: true`), and the slirp/gcrypt pair enabled above.
-configure = "./configure --target-list=riscv32-softmmu --prefix={prefix} --enable-gcrypt --enable-slirp --disable-werror --disable-strip --disable-user --disable-capstone --disable-docs --disable-tools --disable-guest-agent --disable-gtk --disable-vnc --disable-sdl --disable-sdl-image --disable-curses --disable-spice --disable-spice-protocol --disable-dbus-display --disable-opengl --disable-virglrenderer --disable-png --disable-vte --disable-xkbcommon --disable-alsa --disable-pa --disable-jack --disable-oss --disable-sndio --disable-pipewire --disable-libusb --disable-usb-redir --disable-smartcard --disable-u2f --disable-canokey --disable-brlapi --disable-libudev --disable-mpath --disable-curl --disable-libssh --disable-rbd --disable-glusterfs --disable-libiscsi --disable-libnfs --disable-blkio --disable-fuse --disable-gnutls --disable-seccomp --disable-cap-ng --disable-attr --disable-virtfs --disable-numa --disable-selinux --disable-libdw --disable-libcbor --disable-libkeyutils --disable-auth-pam --disable-vde --disable-af-xdp --disable-bpf --disable-linux-aio --disable-linux-io-uring --disable-libpmem --disable-libdaxctl --disable-zstd --disable-lzo --disable-snappy --disable-bzip2 --disable-lzfse"
+configure = "./configure --target-list=riscv32-softmmu --prefix={prefix} --enable-gcrypt --enable-slirp --disable-werror --disable-strip --disable-user --disable-capstone --disable-vnc --disable-gtk --disable-sdl --disable-docs"
 install = "ninja -C build -j$(nproc) && ninja -C build install"
 
 # issue 0486 — espflash packs an ELF into the ESP32 flash image the QEMU runner
@@ -873,7 +851,6 @@ dest = "third-party/ros/rosidl"
 # brew mappings are best-effort and unverified — fix them as hosts appear.
 
 [prereq.libglib2-dev]
-role = "infra"
 why = "qemu source builds (esp32-qemu meson configure)"
 apt = ["libglib2.0-dev"]
 dnf = ["glib2-devel"]
@@ -882,7 +859,6 @@ brew = ["glib"]
 check = { pkg_config = "glib-2.0" }
 
 [prereq.libpixman-dev]
-role = "infra"
 why = "qemu source builds (softmmu display layer)"
 apt = ["libpixman-1-dev"]
 dnf = ["pixman-devel"]
@@ -891,7 +867,6 @@ brew = ["pixman"]
 check = { pkg_config = "pixman-1" }
 
 [prereq.libgcrypt-dev]
-role = "infra"
 why = "qemu source builds (--enable-gcrypt)"
 apt = ["libgcrypt20-dev"]
 dnf = ["libgcrypt-devel"]
@@ -903,7 +878,6 @@ brew = ["libgcrypt"]
 check = { cmd = "libgcrypt-config", pkg_config = "libgcrypt" }
 
 [prereq.ros-rmw-zenoh-cpp]
-role = "package"
 why = "the zenoh ROS interop lanes: the peer runs `source /opt/ros/<distro>/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp`, so the RMW must resolve in the ROS prefix. Without it those lanes report `[SKIPPED:capability]`, which reads as green rather than as absent coverage (2026-08-17: three issues closed unverifiable that way). NOTE the apt name is DISTRO-PARAMETRIC — `ros-<distro>-rmw-zenoh-cpp`; humble is declared here because it is the documented default, and `just doctor` probes $ROS_DISTRO rather than assuming it."
 apt = ["ros-humble-rmw-zenoh-cpp"]
 # No dnf/pacman: ROS 2 is not packaged there, and docs/development/ros2-on-non-ubuntu.md
@@ -917,7 +891,6 @@ apt = ["ros-humble-rmw-zenoh-cpp"]
 # `just doctor` does the real check against $ROS_DISTRO.
 
 [prereq.doxygen]
-role = "workspace"
 why = "C API reference docs (just docs-c; found undeclared by check-sysdep-remedies)"
 apt = ["doxygen"]
 dnf = ["doxygen"]
@@ -931,7 +904,6 @@ check = { cmd = "doxygen" }
 # `.github/workflows/docs.yml` installed the two together in one apt line. The
 # workflow was the only place that knew they belong together.
 [prereq.graphviz]
-role = "workspace"
 why = "doxygen's diagrams (HAVE_DOT); without it the C API docs build with no graphs and say nothing about it"
 apt = ["graphviz"]
 dnf = ["graphviz"]
@@ -940,7 +912,6 @@ brew = ["graphviz"]
 check = { cmd = "dot" }
 
 [prereq.gcc-arm-none-eabi]
-role = "infra"
 why = "ARM bare-metal cross gcc via the apt path (the [tool.arm-none-eabi-gcc] dist is the store alternative)"
 # The LIBC is a separate package on Debian and was missing here, so the apt path
 # produced a compiler that could build freestanding code and nothing that
@@ -970,7 +941,6 @@ brew = ["arm-none-eabi-gcc"]
 check = { cmd = "arm-none-eabi-gcc" }
 
 [prereq.cmake]
-role = "package"
 why = "every C/C++ configure step"
 apt = ["cmake"]
 dnf = ["cmake"]
@@ -979,7 +949,6 @@ brew = ["cmake"]
 check = { cmd = "cmake" }
 
 [prereq.unzip]
-role = "workspace"
 why = "unpacks the upstream ninja release zips ([tool.ninja] dist install step); tar cannot read a zip"
 apt = ["unzip"]
 dnf = ["unzip"]
@@ -988,7 +957,6 @@ brew = ["unzip"]
 check = { cmd = "unzip" }
 
 [prereq.curl]
-role = "workspace"
 why = "every dist download and the [tool.make] source tarball fetch shell out to it"
 apt = ["curl"]
 dnf = ["curl"]
@@ -997,7 +965,6 @@ brew = ["curl"]
 check = { cmd = "curl" }
 
 [prereq.ninja]
-role = "workspace"
 why = "the generator every cmake configure emits for; >=1.13 also speaks the make-4.4 fifo jobserver protocol, so a nested build shares one token budget instead of taking nproc of its own"
 # Same chain as `[prereq.openocd]`: a system copy is fine WHEN new enough.
 # Ubuntu 22.04 ships 1.10.1 and Ubuntu 24.04 1.11.1, both below the jobserver
@@ -1027,7 +994,6 @@ check = { cmd = "ninja", version = { run = "ninja --version", min = "1.13" } }
 # SECOND make provisioning path before then would be the drift this repo keeps
 # paying for.
 [prereq.make]
-role = "workspace"
 why = "GNU make >=4.4 serves `--jobserver-style=fifo`, the only jobserver flavour ninja 1.13 can join; 4.3 and older serve a pipe-fd jobserver that ninja ignores. install with `nros setup --tool make`"
 apt = ["make"]
 dnf = ["make"]
@@ -1036,14 +1002,12 @@ brew = ["make"]
 check = { cmd = "make", version = { run = "make --version", min = "4.4" } }
 
 [prereq.genromfs]
-role = "infra"
 why = "NuttX riscv rv-virt etc/ ROMFS image (the [tool.genromfs] source recipe is the store alternative)"
 apt = ["genromfs"]
 pacman = ["genromfs"]
 check = { cmd = "genromfs" }
 
 [prereq.socat]
-role = "workspace"
 why = "test-harness serial/TCP relays"
 apt = ["socat"]
 dnf = ["socat"]
@@ -1052,7 +1016,6 @@ brew = ["socat"]
 check = { cmd = "socat" }
 
 [prereq.zstd]
-role = "workspace"
 why = "tar decompresses the prebuilt `.tar.zst` SDK dists via the external zstd binary (issue 0385; stock Ubuntu 22.04 ships no zstd)"
 apt = ["zstd"]
 dnf = ["zstd"]
@@ -1061,7 +1024,6 @@ brew = ["zstd"]
 check = { cmd = "zstd" }
 
 [prereq.libmbedtls]
-role = "package"
 why = "zenoh-pico TLS link (zpico-sys)"
 apt = ["libmbedtls-dev"]
 dnf = ["mbedtls-devel"]
@@ -1077,7 +1039,6 @@ brew = ["mbedtls"]
 check = { header = "mbedtls/entropy.h" }
 
 [prereq.clang]
-role = "package"
 why = "bindgen + C toolchain probes"
 apt = ["clang"]
 dnf = ["clang"]
@@ -1086,7 +1047,6 @@ brew = ["llvm"]
 check = { cmd = "clang" }
 
 [prereq.libclang-dev]
-role = "package"
 why = "bindgen (z3-sys via ros-launch-manifest-check -> nros-launch-resolve build; issue 0368 F5)"
 apt = ["libclang-dev"]
 dnf = ["clang-devel"]
@@ -1101,7 +1061,6 @@ brew = ["llvm"]
 check = { sharedlib = "libclang" }
 
 [prereq.libz3]
-role = "package"
 why = "ros-launch-manifest-check (z3) -> nros-launch-resolve build (issue 0368 F5)"
 apt = ["libz3-dev"]
 dnf = ["z3-devel"]
@@ -1115,7 +1074,6 @@ brew = ["z3"]
 check = { header = "z3.h" }
 
 [prereq.python3-dev]
-role = "package"
 why = "pyo3 source builds (play_launch_parser, nros-launch-resolve; issue 0368 F5)"
 apt = ["python3-dev"]
 dnf = ["python3-devel"]
@@ -1124,7 +1082,6 @@ brew = ["python"]
 check = { pkg_config = "python3" }
 
 [prereq.python3-venv]
-role = "package"
 why = "ESP-IDF install + tool venvs (issue 0368 F7)"
 apt = ["python3-venv"]
 dnf = ["python3"]
@@ -1132,7 +1089,6 @@ pacman = ["python"]
 brew = ["python"]
 
 [prereq.python3-pip]
-role = "package"
 why = "pip-layer installs (west, colcon, clang-format wheel)"
 apt = ["python3-pip"]
 dnf = ["python3-pip"]
@@ -1141,7 +1097,6 @@ brew = ["python"]
 check = { cmd = "pip3" }
 
 [prereq.aria2]
-role = "workspace"
 why = "Zephyr SDK fetch (west sdk install; issue 0368 F7)"
 apt = ["aria2"]
 dnf = ["aria2"]
@@ -1150,7 +1105,6 @@ brew = ["aria2"]
 check = { cmd = "aria2c" }
 
 [prereq.gnu-parallel]
-role = "workspace"
 why = "just format fan-out (issue 0368 F7)"
 apt = ["parallel"]
 dnf = ["parallel"]
@@ -1159,7 +1113,6 @@ brew = ["parallel"]
 check = { cmd = "parallel" }
 
 [prereq.qemu-system-arm]
-role = "infra"
 why = "ARM QEMU lanes via the apt path (the [tool.qemu] nros dist is the harness-preferred build)"
 apt = ["qemu-system-arm"]
 dnf = ["qemu-system-arm"]
@@ -1168,7 +1121,6 @@ brew = ["qemu"]
 check = { cmd = "qemu-system-arm" }
 
 [prereq.qemu-system-misc]
-role = "infra"
 why = "RISC-V QEMU lanes (threadx-riscv64, nuttx rv-virt)"
 apt = ["qemu-system-misc"]
 dnf = ["qemu-system-riscv"]
@@ -1177,19 +1129,16 @@ brew = ["qemu"]
 check = { cmd = "qemu-system-riscv64" }
 
 [prereq.gcc-riscv64-unknown-elf]
-role = "infra"
 why = "RISC-V bare-metal cross gcc (threadx-riscv64, nuttx rv-virt; the [tool.riscv-none-elf-gcc] dist is the xPack-prefixed alternative)"
 apt = ["gcc-riscv64-unknown-elf"]
 pacman = ["riscv64-elf-gcc"]
 check = { cmd = "riscv64-unknown-elf-gcc" }
 
 [prereq.picolibc-riscv64-unknown-elf]
-role = "infra"
 why = "picolibc for the riscv64-unknown-elf gcc (nuttx rv-virt userspace)"
 apt = ["picolibc-riscv64-unknown-elf"]
 
 [prereq.kconfig-frontends]
-role = "workspace"
 why = "NuttX configuration (kconfig-conf/kconfig-mconf)"
 apt = ["kconfig-frontends-nox"]
 check = { cmd = "kconfig-conf" }
@@ -1317,7 +1266,6 @@ check = { cmd = "clang-format" }
 # ---------------------------------------------------------------------------
 
 [prereq.qemu]
-role = "infra"
 why = "QEMU runs every emulated platform test"
 provider = "sdk"
 # `runs`, not `cmd`: the store dist is not on PATH, and its path EXISTING is
@@ -1325,31 +1273,26 @@ provider = "sdk"
 check = { runs = "qemu-system-arm --version" }
 
 [prereq.freertos-kernel]
-role = "vendor"
 why = "FreeRTOS builds compile the kernel from this checkout"
 provider = "submodule"
 check = { path = "include/FreeRTOS.h" }
 
 [prereq.threadx]
-role = "vendor"
 why = "ThreadX builds compile the kernel from this checkout"
 provider = "submodule"
 check = { path = "common/inc/tx_api.h" }
 
 [prereq.zenoh-pico]
-role = "vendor"
 why = "the zenoh backend's C library"
 provider = "submodule"
 check = { path = "include/zenoh-pico.h" }
 
 [prereq.nuttx-kernel]
-role = "vendor"
 why = "NuttX builds configure and build this checkout"
 provider = "submodule"
 check = { path = "Kconfig" }
 
 [prereq.cyclonedds-src]
-role = "vendor"
 why = "the Cyclone backend builds this fork"
 provider = "submodule"
 check = { path = "CMakeLists.txt" }
@@ -1359,7 +1302,6 @@ check = { path = "CMakeLists.txt" }
 # resolved to nothing, silently, for as long as that file has existed.
 
 [prereq.cargo]
-role = "package"
 why = "Rust builds; the real provider is rustup, which [rust.toolchain.*] pins"
 # apt/dnf/pacman ship a `cargo`, but a distro cargo is NOT the pinned toolchain
 # and using one is its own failure class — so the mapping exists for a host with
@@ -1371,7 +1313,6 @@ brew = ["rust"]
 check = { cmd = "cargo" }
 
 [prereq.nros]
-role = "package"
 why = "the nano-ros CLI itself — codegen, sync, and this build verb"
 # No package manager ships it. `./scripts/bootstrap.sh` (users) or
 # `just setup-cli` (contributors) provides it; the probe is the whole entry.
@@ -1438,7 +1379,6 @@ check = { cmd = "nros" }
 # dnf/pacman/brew are best-effort, per this file's existing convention.
 
 [prereq.openocd]
-role = "infra"
 why = "on-chip debug server for flashing/attaching to a target board"
 # phase-404 W2 — the first entry to use ordered preference, and openocd is the
 # right first case: it is neither a build input (nothing it does enters an
@@ -1456,7 +1396,6 @@ brew = ["openocd"]
 check = { cmd = "openocd", version = { min = "0.12" } }
 
 [prereq.libcrypt1]
-role = "infra"
 why = "runtime dep of the arm-none-eabi-gcc dist(s) (issue 0926)"
 apt = ["libcrypt1"]
 dnf = ["libxcrypt"]
@@ -1464,7 +1403,6 @@ pacman = ["libxcrypt-compat"]
 check = { sharedlib = "libcrypt.so.1" }
 
 [prereq.libexpat1]
-role = "infra"
 why = "runtime dep of the play_launch_parser dist(s) (issue 0926)"
 apt = ["libexpat1"]
 dnf = ["expat"]
@@ -1473,7 +1411,6 @@ brew = ["expat"]
 check = { sharedlib = "libexpat.so.1" }
 
 [prereq.libpcre2]
-role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libpcre2-8-0"]
 dnf = ["pcre2"]
@@ -1482,7 +1419,6 @@ brew = ["pcre2"]
 check = { sharedlib = "libpcre2-8.so.0" }
 
 [prereq.libpython310]
-role = "infra"
 why = "runtime dep of the play_launch_parser dist(s) (issue 0926)"
 apt = ["libpython3.10"]
 dnf = ["python3.10-libs"]
@@ -1490,7 +1426,6 @@ pacman = ["python310"]
 check = { sharedlib = "libpython3.10.so.1.0" }
 
 [prereq.libselinux1]
-role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libselinux1"]
 dnf = ["libselinux"]
@@ -1498,7 +1433,6 @@ pacman = ["libselinux"]
 check = { sharedlib = "libselinux.so.1" }
 
 [prereq.libssl3]
-role = "infra"
 why = "runtime dep of the cyclonedds, xrce-agent dist(s) (issue 0926)"
 apt = ["libssl3"]
 dnf = ["openssl-libs"]
@@ -1508,7 +1442,6 @@ provides = ["libcrypto.so.3", "libssl.so.3"]
 check = { sharedlib = "libcrypto.so.3" }
 
 [prereq.libtinfo6]
-role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libtinfo6"]
 dnf = ["ncurses-libs"]
@@ -1517,7 +1450,6 @@ brew = ["ncurses"]
 check = { sharedlib = "libtinfo.so.6" }
 
 [prereq.libz1]
-role = "infra"
 why = "runtime dep of the play_launch_parser, qemu dist(s) (issue 0926)"
 apt = ["zlib1g"]
 dnf = ["zlib"]

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -362,8 +362,6 @@ install = "cargo install --path src/ros-launch-resolve/parser/crates/play_launch
 # bump makes the SUPPORTED path match the one already proven green, rather than
 # introducing an untested version.
 version = "0.6.1-nros1"
-upstream = "v0.6.1" # = source.ref (corrosion-rs/corrosion release tag)
-#
 # issue 1060 — a TAG is not a pin. It is a ref on a server we do not control, so
 # an upstream retag moves what we build with no local diff, no review and no
 # gate. The cmake FetchContent fallback therefore fetches the COMMIT this tag
@@ -386,6 +384,7 @@ upstream = "v0.6.1" # = source.ref (corrosion-rs/corrosion release tag)
 # `source.ref` below is a SEPARATE fetch — the SDK-store recipe `nros setup
 # --tool corrosion` clones — and is still a tag. Same defect class, different
 # code path (`sdk_store.rs`), not fixed here.
+upstream = "v0.6.1" # = source.ref (corrosion-rs/corrosion release tag)
 [tool.corrosion.source]
 git = "https://github.com/corrosion-rs/corrosion"
 ref = "v0.6.1"
@@ -402,12 +401,21 @@ version = "esp-develop-nros1"
 # applied to source recipes; probed BEFORE the build so the failure names
 # packages).
 #
-# The rest are RUNTIME sonames the built binary links unconditionally, found by
+# The rest are RUNTIME sonames the built binary linked, found by
 # `check-dist-runtime-deps` against a source build of this very recipe. Each was
 # already a `[prereq.*]` key; only this list was missing them, which is the
-# hand-authored half issue 0926 named. They are core (zlib, pcre2, selinux,
-# tinfo, openssl via glib and qemu's block layer), not optional backends, so
-# they hold for any build of this recipe on any host.
+# hand-authored half issue 0926 named.
+#
+# They were called core, and three of them are NOT — read off the fork's own
+# `meson.build` at the pinned tag (issue 1006). Unconditional: `zlib`
+# (`dependency('zlib', required: true)`) and `pcre2` (glib's transitive).
+# `selinux` and curses -> `libtinfo` are AUTO-DETECTED features like every other
+# backend, and qemu links no openssl anywhere in `meson.build` at all — `libssl3`
+# arrived through libcurl/libssh, which the `configure` below now disables BY
+# NAME. So those three are expected to leave the closure on the next rebuild.
+# They stay declared until one happens: `check-dist-runtime-deps` checks
+# COVERAGE, not minimality, so an over-declaration is safe, while deleting them
+# without a re-measure would be a guess.
 system = [
     "libglib2-dev",
     "libpixman-dev",
@@ -434,7 +442,43 @@ ref = "esp-develop-9.2.2-20260417"
 # alternative (patching upstream C in a vendored fork we do not maintain) is
 # strictly worse. `[tool.qemu]` does not need it — it is 11.0.0 and normally
 # arrives as a prebuilt `dist`.
-configure = "./configure --target-list=riscv32-softmmu --prefix={prefix} --enable-gcrypt --enable-slirp --disable-werror --disable-strip --disable-user --disable-capstone --disable-vnc --disable-gtk --disable-sdl --disable-docs"
+#
+# issue 1006 — THE REST OF THIS LINE IS A LINK-SURFACE PIN, not taste. qemu's
+# configure AUTO-DETECTS every optional backend: a feature whose `--enable-`/
+# `--disable-` is not passed stays `auto`, so `dependency(..., required:
+# get_option(<f>))` resolves against whatever dev headers the BUILD HOST happens
+# to carry and the binary links them. This recipe is source-built with NO dist —
+# every user runs it — so an unpinned feature makes the runtime dependency set a
+# property of the machine rather than of the recipe. Measured:
+# `check-dist-runtime-deps` against a source build here found 69 sonames no
+# `[prereq.*]` declares (audio, X11, curl/ssh/usb/dbus), which is exactly why
+# DECLARING them would have recorded one host's accident as a contract.
+#
+# What is left reachable is what `-M esp32c3 -icount 3 -nographic -drive
+# file=...,if=mtd,format=raw -nic user,model=open_eth` needs (the invocation in
+# `scripts/esp32/launch-esp32c3.sh` and `nros-tests/src/esp32.rs`): TCG, the raw
+# block layer, slirp, and gcrypt for the fork's secure-boot crypto. The rest is
+# off BY NAME, in groups: UI, audio, host-device passthrough, network/format
+# block drivers, TLS, and the remaining host libraries.
+#
+# NOT `--audio-drv-list=` on its own, which is the fix the issue prescribed and
+# which the tag REFUTES: `audio/meson.build` builds a module for every driver
+# whose dependency `.found()`, not for the ones named in `audio_drv_list`, so an
+# empty list only changes `CONFIG_AUDIO_DRIVERS` and leaves libasound/libpulse
+# (and libpulse's libsndfile/FLAC/vorbis/ogg/X11 tail) linked. The per-driver
+# `--disable-alsa --disable-pa ...` is what cuts them, and with all of them off
+# the default list resolves to empty anyway, so the list flag buys nothing.
+#
+# Every flag token here is ACCEPTED BY THIS TAG — checked against the fork's own
+# generated `scripts/meson-buildoptions.sh` and configure's case list at
+# `esp-develop-9.2.2-20260417`, where an unrecognised option is `ERROR: unknown
+# option`, a hard configure failure. What the resulting closure actually is
+# stays UNMEASURED until someone runs `nros setup --tool esp32-qemu` and re-runs
+# `check-dist-runtime-deps` (this recipe was not rebuilt to land the pin).
+#
+# Left auto DELIBERATELY: fdt (the riscv boards require it), pixman, zlib
+# (`required: true`), and the slirp/gcrypt pair enabled above.
+configure = "./configure --target-list=riscv32-softmmu --prefix={prefix} --enable-gcrypt --enable-slirp --disable-werror --disable-strip --disable-user --disable-capstone --disable-docs --disable-tools --disable-guest-agent --disable-gtk --disable-vnc --disable-sdl --disable-sdl-image --disable-curses --disable-spice --disable-spice-protocol --disable-dbus-display --disable-opengl --disable-virglrenderer --disable-png --disable-vte --disable-xkbcommon --disable-alsa --disable-pa --disable-jack --disable-oss --disable-sndio --disable-pipewire --disable-libusb --disable-usb-redir --disable-smartcard --disable-u2f --disable-canokey --disable-brlapi --disable-libudev --disable-mpath --disable-curl --disable-libssh --disable-rbd --disable-glusterfs --disable-libiscsi --disable-libnfs --disable-blkio --disable-fuse --disable-gnutls --disable-seccomp --disable-cap-ng --disable-attr --disable-virtfs --disable-numa --disable-selinux --disable-libdw --disable-libcbor --disable-libkeyutils --disable-auth-pam --disable-vde --disable-af-xdp --disable-bpf --disable-linux-aio --disable-linux-io-uring --disable-libpmem --disable-libdaxctl --disable-zstd --disable-lzo --disable-snappy --disable-bzip2 --disable-lzfse"
 install = "ninja -C build -j$(nproc) && ninja -C build install"
 
 # issue 0486 — espflash packs an ELF into the ESP32 flash image the QEMU runner
@@ -851,6 +895,7 @@ dest = "third-party/ros/rosidl"
 # brew mappings are best-effort and unverified — fix them as hosts appear.
 
 [prereq.libglib2-dev]
+role = "infra"
 why = "qemu source builds (esp32-qemu meson configure)"
 apt = ["libglib2.0-dev"]
 dnf = ["glib2-devel"]
@@ -859,6 +904,7 @@ brew = ["glib"]
 check = { pkg_config = "glib-2.0" }
 
 [prereq.libpixman-dev]
+role = "infra"
 why = "qemu source builds (softmmu display layer)"
 apt = ["libpixman-1-dev"]
 dnf = ["pixman-devel"]
@@ -867,6 +913,7 @@ brew = ["pixman"]
 check = { pkg_config = "pixman-1" }
 
 [prereq.libgcrypt-dev]
+role = "infra"
 why = "qemu source builds (--enable-gcrypt)"
 apt = ["libgcrypt20-dev"]
 dnf = ["libgcrypt-devel"]
@@ -878,6 +925,7 @@ brew = ["libgcrypt"]
 check = { cmd = "libgcrypt-config", pkg_config = "libgcrypt" }
 
 [prereq.ros-rmw-zenoh-cpp]
+role = "package"
 why = "the zenoh ROS interop lanes: the peer runs `source /opt/ros/<distro>/setup.bash && export RMW_IMPLEMENTATION=rmw_zenoh_cpp`, so the RMW must resolve in the ROS prefix. Without it those lanes report `[SKIPPED:capability]`, which reads as green rather than as absent coverage (2026-08-17: three issues closed unverifiable that way). NOTE the apt name is DISTRO-PARAMETRIC — `ros-<distro>-rmw-zenoh-cpp`; humble is declared here because it is the documented default, and `just doctor` probes $ROS_DISTRO rather than assuming it."
 apt = ["ros-humble-rmw-zenoh-cpp"]
 # No dnf/pacman: ROS 2 is not packaged there, and docs/development/ros2-on-non-ubuntu.md
@@ -891,6 +939,7 @@ apt = ["ros-humble-rmw-zenoh-cpp"]
 # `just doctor` does the real check against $ROS_DISTRO.
 
 [prereq.doxygen]
+role = "workspace"
 why = "C API reference docs (just docs-c; found undeclared by check-sysdep-remedies)"
 apt = ["doxygen"]
 dnf = ["doxygen"]
@@ -904,6 +953,7 @@ check = { cmd = "doxygen" }
 # `.github/workflows/docs.yml` installed the two together in one apt line. The
 # workflow was the only place that knew they belong together.
 [prereq.graphviz]
+role = "workspace"
 why = "doxygen's diagrams (HAVE_DOT); without it the C API docs build with no graphs and say nothing about it"
 apt = ["graphviz"]
 dnf = ["graphviz"]
@@ -912,6 +962,7 @@ brew = ["graphviz"]
 check = { cmd = "dot" }
 
 [prereq.gcc-arm-none-eabi]
+role = "infra"
 why = "ARM bare-metal cross gcc via the apt path (the [tool.arm-none-eabi-gcc] dist is the store alternative)"
 # The LIBC is a separate package on Debian and was missing here, so the apt path
 # produced a compiler that could build freestanding code and nothing that
@@ -941,6 +992,7 @@ brew = ["arm-none-eabi-gcc"]
 check = { cmd = "arm-none-eabi-gcc" }
 
 [prereq.cmake]
+role = "package"
 why = "every C/C++ configure step"
 apt = ["cmake"]
 dnf = ["cmake"]
@@ -949,6 +1001,7 @@ brew = ["cmake"]
 check = { cmd = "cmake" }
 
 [prereq.unzip]
+role = "workspace"
 why = "unpacks the upstream ninja release zips ([tool.ninja] dist install step); tar cannot read a zip"
 apt = ["unzip"]
 dnf = ["unzip"]
@@ -957,6 +1010,7 @@ brew = ["unzip"]
 check = { cmd = "unzip" }
 
 [prereq.curl]
+role = "workspace"
 why = "every dist download and the [tool.make] source tarball fetch shell out to it"
 apt = ["curl"]
 dnf = ["curl"]
@@ -965,6 +1019,7 @@ brew = ["curl"]
 check = { cmd = "curl" }
 
 [prereq.ninja]
+role = "workspace"
 why = "the generator every cmake configure emits for; >=1.13 also speaks the make-4.4 fifo jobserver protocol, so a nested build shares one token budget instead of taking nproc of its own"
 # Same chain as `[prereq.openocd]`: a system copy is fine WHEN new enough.
 # Ubuntu 22.04 ships 1.10.1 and Ubuntu 24.04 1.11.1, both below the jobserver
@@ -994,6 +1049,7 @@ check = { cmd = "ninja", version = { run = "ninja --version", min = "1.13" } }
 # SECOND make provisioning path before then would be the drift this repo keeps
 # paying for.
 [prereq.make]
+role = "workspace"
 why = "GNU make >=4.4 serves `--jobserver-style=fifo`, the only jobserver flavour ninja 1.13 can join; 4.3 and older serve a pipe-fd jobserver that ninja ignores. install with `nros setup --tool make`"
 apt = ["make"]
 dnf = ["make"]
@@ -1002,12 +1058,14 @@ brew = ["make"]
 check = { cmd = "make", version = { run = "make --version", min = "4.4" } }
 
 [prereq.genromfs]
+role = "infra"
 why = "NuttX riscv rv-virt etc/ ROMFS image (the [tool.genromfs] source recipe is the store alternative)"
 apt = ["genromfs"]
 pacman = ["genromfs"]
 check = { cmd = "genromfs" }
 
 [prereq.socat]
+role = "workspace"
 why = "test-harness serial/TCP relays"
 apt = ["socat"]
 dnf = ["socat"]
@@ -1016,6 +1074,7 @@ brew = ["socat"]
 check = { cmd = "socat" }
 
 [prereq.zstd]
+role = "workspace"
 why = "tar decompresses the prebuilt `.tar.zst` SDK dists via the external zstd binary (issue 0385; stock Ubuntu 22.04 ships no zstd)"
 apt = ["zstd"]
 dnf = ["zstd"]
@@ -1024,6 +1083,7 @@ brew = ["zstd"]
 check = { cmd = "zstd" }
 
 [prereq.libmbedtls]
+role = "package"
 why = "zenoh-pico TLS link (zpico-sys)"
 apt = ["libmbedtls-dev"]
 dnf = ["mbedtls-devel"]
@@ -1039,6 +1099,7 @@ brew = ["mbedtls"]
 check = { header = "mbedtls/entropy.h" }
 
 [prereq.clang]
+role = "package"
 why = "bindgen + C toolchain probes"
 apt = ["clang"]
 dnf = ["clang"]
@@ -1047,6 +1108,7 @@ brew = ["llvm"]
 check = { cmd = "clang" }
 
 [prereq.libclang-dev]
+role = "package"
 why = "bindgen (z3-sys via ros-launch-manifest-check -> nros-launch-resolve build; issue 0368 F5)"
 apt = ["libclang-dev"]
 dnf = ["clang-devel"]
@@ -1061,6 +1123,7 @@ brew = ["llvm"]
 check = { sharedlib = "libclang" }
 
 [prereq.libz3]
+role = "package"
 why = "ros-launch-manifest-check (z3) -> nros-launch-resolve build (issue 0368 F5)"
 apt = ["libz3-dev"]
 dnf = ["z3-devel"]
@@ -1074,6 +1137,7 @@ brew = ["z3"]
 check = { header = "z3.h" }
 
 [prereq.python3-dev]
+role = "package"
 why = "pyo3 source builds (play_launch_parser, nros-launch-resolve; issue 0368 F5)"
 apt = ["python3-dev"]
 dnf = ["python3-devel"]
@@ -1082,6 +1146,7 @@ brew = ["python"]
 check = { pkg_config = "python3" }
 
 [prereq.python3-venv]
+role = "package"
 why = "ESP-IDF install + tool venvs (issue 0368 F7)"
 apt = ["python3-venv"]
 dnf = ["python3"]
@@ -1089,6 +1154,7 @@ pacman = ["python"]
 brew = ["python"]
 
 [prereq.python3-pip]
+role = "package"
 why = "pip-layer installs (west, colcon, clang-format wheel)"
 apt = ["python3-pip"]
 dnf = ["python3-pip"]
@@ -1097,6 +1163,7 @@ brew = ["python"]
 check = { cmd = "pip3" }
 
 [prereq.aria2]
+role = "workspace"
 why = "Zephyr SDK fetch (west sdk install; issue 0368 F7)"
 apt = ["aria2"]
 dnf = ["aria2"]
@@ -1105,6 +1172,7 @@ brew = ["aria2"]
 check = { cmd = "aria2c" }
 
 [prereq.gnu-parallel]
+role = "workspace"
 why = "just format fan-out (issue 0368 F7)"
 apt = ["parallel"]
 dnf = ["parallel"]
@@ -1113,6 +1181,7 @@ brew = ["parallel"]
 check = { cmd = "parallel" }
 
 [prereq.qemu-system-arm]
+role = "infra"
 why = "ARM QEMU lanes via the apt path (the [tool.qemu] nros dist is the harness-preferred build)"
 apt = ["qemu-system-arm"]
 dnf = ["qemu-system-arm"]
@@ -1121,6 +1190,7 @@ brew = ["qemu"]
 check = { cmd = "qemu-system-arm" }
 
 [prereq.qemu-system-misc]
+role = "infra"
 why = "RISC-V QEMU lanes (threadx-riscv64, nuttx rv-virt)"
 apt = ["qemu-system-misc"]
 dnf = ["qemu-system-riscv"]
@@ -1129,16 +1199,19 @@ brew = ["qemu"]
 check = { cmd = "qemu-system-riscv64" }
 
 [prereq.gcc-riscv64-unknown-elf]
+role = "infra"
 why = "RISC-V bare-metal cross gcc (threadx-riscv64, nuttx rv-virt; the [tool.riscv-none-elf-gcc] dist is the xPack-prefixed alternative)"
 apt = ["gcc-riscv64-unknown-elf"]
 pacman = ["riscv64-elf-gcc"]
 check = { cmd = "riscv64-unknown-elf-gcc" }
 
 [prereq.picolibc-riscv64-unknown-elf]
+role = "infra"
 why = "picolibc for the riscv64-unknown-elf gcc (nuttx rv-virt userspace)"
 apt = ["picolibc-riscv64-unknown-elf"]
 
 [prereq.kconfig-frontends]
+role = "workspace"
 why = "NuttX configuration (kconfig-conf/kconfig-mconf)"
 apt = ["kconfig-frontends-nox"]
 check = { cmd = "kconfig-conf" }
@@ -1266,6 +1339,7 @@ check = { cmd = "clang-format" }
 # ---------------------------------------------------------------------------
 
 [prereq.qemu]
+role = "infra"
 why = "QEMU runs every emulated platform test"
 provider = "sdk"
 # `runs`, not `cmd`: the store dist is not on PATH, and its path EXISTING is
@@ -1273,26 +1347,31 @@ provider = "sdk"
 check = { runs = "qemu-system-arm --version" }
 
 [prereq.freertos-kernel]
+role = "vendor"
 why = "FreeRTOS builds compile the kernel from this checkout"
 provider = "submodule"
 check = { path = "include/FreeRTOS.h" }
 
 [prereq.threadx]
+role = "vendor"
 why = "ThreadX builds compile the kernel from this checkout"
 provider = "submodule"
 check = { path = "common/inc/tx_api.h" }
 
 [prereq.zenoh-pico]
+role = "vendor"
 why = "the zenoh backend's C library"
 provider = "submodule"
 check = { path = "include/zenoh-pico.h" }
 
 [prereq.nuttx-kernel]
+role = "vendor"
 why = "NuttX builds configure and build this checkout"
 provider = "submodule"
 check = { path = "Kconfig" }
 
 [prereq.cyclonedds-src]
+role = "vendor"
 why = "the Cyclone backend builds this fork"
 provider = "submodule"
 check = { path = "CMakeLists.txt" }
@@ -1302,6 +1381,7 @@ check = { path = "CMakeLists.txt" }
 # resolved to nothing, silently, for as long as that file has existed.
 
 [prereq.cargo]
+role = "package"
 why = "Rust builds; the real provider is rustup, which [rust.toolchain.*] pins"
 # apt/dnf/pacman ship a `cargo`, but a distro cargo is NOT the pinned toolchain
 # and using one is its own failure class — so the mapping exists for a host with
@@ -1313,6 +1393,7 @@ brew = ["rust"]
 check = { cmd = "cargo" }
 
 [prereq.nros]
+role = "package"
 why = "the nano-ros CLI itself — codegen, sync, and this build verb"
 # No package manager ships it. `./scripts/bootstrap.sh` (users) or
 # `just setup-cli` (contributors) provides it; the probe is the whole entry.
@@ -1379,6 +1460,7 @@ check = { cmd = "nros" }
 # dnf/pacman/brew are best-effort, per this file's existing convention.
 
 [prereq.openocd]
+role = "infra"
 why = "on-chip debug server for flashing/attaching to a target board"
 # phase-404 W2 — the first entry to use ordered preference, and openocd is the
 # right first case: it is neither a build input (nothing it does enters an
@@ -1396,6 +1478,7 @@ brew = ["openocd"]
 check = { cmd = "openocd", version = { min = "0.12" } }
 
 [prereq.libcrypt1]
+role = "infra"
 why = "runtime dep of the arm-none-eabi-gcc dist(s) (issue 0926)"
 apt = ["libcrypt1"]
 dnf = ["libxcrypt"]
@@ -1403,6 +1486,7 @@ pacman = ["libxcrypt-compat"]
 check = { sharedlib = "libcrypt.so.1" }
 
 [prereq.libexpat1]
+role = "infra"
 why = "runtime dep of the play_launch_parser dist(s) (issue 0926)"
 apt = ["libexpat1"]
 dnf = ["expat"]
@@ -1411,6 +1495,7 @@ brew = ["expat"]
 check = { sharedlib = "libexpat.so.1" }
 
 [prereq.libpcre2]
+role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libpcre2-8-0"]
 dnf = ["pcre2"]
@@ -1419,6 +1504,7 @@ brew = ["pcre2"]
 check = { sharedlib = "libpcre2-8.so.0" }
 
 [prereq.libpython310]
+role = "infra"
 why = "runtime dep of the play_launch_parser dist(s) (issue 0926)"
 apt = ["libpython3.10"]
 dnf = ["python3.10-libs"]
@@ -1426,6 +1512,7 @@ pacman = ["python310"]
 check = { sharedlib = "libpython3.10.so.1.0" }
 
 [prereq.libselinux1]
+role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libselinux1"]
 dnf = ["libselinux"]
@@ -1433,6 +1520,7 @@ pacman = ["libselinux"]
 check = { sharedlib = "libselinux.so.1" }
 
 [prereq.libssl3]
+role = "infra"
 why = "runtime dep of the cyclonedds, xrce-agent dist(s) (issue 0926)"
 apt = ["libssl3"]
 dnf = ["openssl-libs"]
@@ -1442,6 +1530,7 @@ provides = ["libcrypto.so.3", "libssl.so.3"]
 check = { sharedlib = "libcrypto.so.3" }
 
 [prereq.libtinfo6]
+role = "infra"
 why = "runtime dep of the qemu dist(s) (issue 0926)"
 apt = ["libtinfo6"]
 dnf = ["ncurses-libs"]
@@ -1450,6 +1539,7 @@ brew = ["ncurses"]
 check = { sharedlib = "libtinfo.so.6" }
 
 [prereq.libz1]
+role = "infra"
 why = "runtime dep of the play_launch_parser, qemu dist(s) (issue 0926)"
 apt = ["zlib1g"]
 dnf = ["zlib"]


### PR DESCRIPTION
Two halves of one defect, in the one place this tree fetches anything.

## The pin

`GIT_TAG ${_nros_corrosion_tag}` resolved to the **tag** `v0.6.1` — a ref on a server we do not control. If upstream retags, this build switches trees and **no file here changes**: no diff, no review, no gate. Strictly worse than the submodule rewind `check-submodule-pins` exists for, where the pin is a full commit id and the gate can go and ask.

Now `1499b14e4906a2890f5cee1547c8848db261753d`. There is no peeled `^{}` line because v0.6.1 is a **lightweight** tag — confirmed with `git cat-file -t`, not assumed, since a tag object's own sha would make CMake fetch something that isn't the commit.

**The digest could not go in `nros-sdk-index.toml`**: `[tool.corrosion]` deserialises into `ToolPackage`, which is `deny_unknown_fields`, so an extra key fails *every* `SdkIndex::load` — `nros setup`, `nros doctor`, the metadata build. It lives in `_nros_corrosion_pin()` with the derivation recorded beside `upstream`, and the two cannot drift: an index `upstream` disagreeing with the module's tag is a configure `FATAL_ERROR` naming the `ls-remote` to run. The reader already prefers an index `upstream_commit` if one ever exists — the follow-up is one serde field and one TOML line, no cmake change.

## The cache

RFC-0087 D5 says a shared `FETCHCONTENT_BASE_DIR` makes a fetch once per host. `git grep FETCHCONTENT` returned **exactly one hit: that sentence.** Nothing set it, so every build directory fetched independently — issue 0500 measured **159** build dirs each with their own Corrosion.

Cache is `$NROS_HOME/fetch` (default `~/.nros/fetch`), sibling of the SDK store this module already reads. `-DNROS_FETCH_CACHE=<dir>` beats `NROS_FETCH_CACHE` beats the default; `OFF` restores per-build `_deps`; an unwritable location is **not fatal** — the probe reports and falls back.

### Two measured findings shaped it

**A naive shared `FETCHCONTENT_BASE_DIR` hard-fails.** The shared subbuild's `CMakeCache` records the generator that populated it, so a second build tree on a different generator dies with *"CMake step for corrosion failed"*. `SOURCE_DIR` and `SUBBUILD_DIR` are shared **and must move together** — ExternalProject's clone step keys on a stamp in the subbuild and `rm -rf`s the source first, so a per-build subbuild would destroy the cache on every new build dir. `BINARY_DIR` stays local; sharing it is issue 0616 one layer over.

**`FETCHCONTENT_FULLY_DISCONNECTED` is deliberately not set** — it is project-wide, and this module has no business disconnecting a parent project's other dependencies. The per-dependency `FETCHCONTENT_SOURCE_DIR_CORROSION` is used instead, only when the cache's `git rev-parse HEAD` equals the pinned commit.

Proved in a **real network namespace** (`unshare -rn`, where `git ls-remote` cannot resolve the host): a fresh configure succeeds offline, and the **negative control** — same namespace, empty cache — fails to clone, so the offline pass is not vacuous.

Per-build footprint **3.3 M → 12 K** against one host clone. Verified in-tree; the origin line issue 0500 calls the only evidence now reads:

```
-- nano-ros: Corrosion v0.6.1 via FetchContent (host cache) [hashed per-workspace cargo dirs] — /home/aeon/.nros/fetch/corrosion-src
```

and `_deps/` in the build dir contains only `corrosion-build`.

Not fixed here, flagged in the index: `[tool.corrosion.source] ref` is the same defect on the SDK-store path, and moving it to a sha needs a fetch-by-sha check in `packages/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV