### PR TITLE
feat(phase-420 W9): a fork is a vendor package whose fetch is a submodule

### DIFF
--- a/docs/issues/1068-xrce-cmake-lane-ignores-link-ip.md
+++ b/docs/issues/1068-xrce-cmake-lane-ignores-link-ip.md
@@ -1,0 +1,45 @@
+---
+id: 1068
+title: "`NROS_LINK_IP=0` drops the UDP transports in the Rust lane and not in the CMake one, so a serial-only XRCE node cannot be built from C/C++"
+status: open
+type: bug
+area: rmw, build
+severity: medium
+found: 2026-09-05
+related: [1069, phase-420, phase-321]
+---
+
+# One vendored tree, two compilers, one honouring the knob
+
+Micro-XRCE-DDS is compiled twice — once by `nros-rmw-xrce-cffi/build.rs`
+(lines 160–245) and once by `nros-rmw-xrce/CMakeLists.txt` (143–193), from a
+hand-copied source list. The two have drifted.
+
+`build.rs` honours `NROS_LINK_IP=0` (phase-204.7's per-build override, the one a
+serial-only node uses to shed the IP link) and drops
+`udp_transport{,_posix}.c`. The CMakeLists compiles them unconditionally.
+
+So the knob works from Rust and silently does nothing from C or C++: **a
+serial-only XRCE node cannot be built through the CMake lane**, and the failure
+is not a build error — it is a larger image than the user asked for, with an IP
+transport they deliberately removed.
+
+## Why the mirror is unguarded
+
+The lockstep between the two lists is asserted by a comment, and that comment
+names `packages/rmw/xrce/xrce-sys/build.rs` — a file phase-321 W1.d **deleted**
+when it removed the `xrce-sys` crate ("zero dependents"). So the only thing
+holding the two lists together points at nothing.
+
+Found by the phase-420 W9 survey, which was measuring how each vendored tree is
+obtained and found it is obtained once and compiled twice.
+
+## Fix
+
+The source list should be derived once and consumed by both lanes, rather than
+mirrored. That is the same remedy class as `check-ffi-struct-mirrors` (a
+hand-mirrored thing drifts on append) and the sizes-header family — and until it
+exists, a gate comparing the two lists would at least make a divergence loud.
+
+Do not fix it by editing the CMake list to match today's `build.rs`: that
+restores the mirror and leaves the next append to drift again.

--- a/docs/issues/1069-microcdr-version-string-differs-by-lane.md
+++ b/docs/issues/1069-microcdr-version-string-differs-by-lane.md
@@ -1,0 +1,40 @@
+---
+id: 1069
+title: "`MICROCDR_VERSION_STR` compiles as 2.4.1 under CMake and 2.0.2 under cargo, against a tree that is 2.0.2 — three numbers, none authoritative"
+status: open
+type: bug
+area: rmw, build
+severity: low
+found: 2026-09-05
+related: [1068, phase-420]
+---
+
+# The version is restated by hand in four places
+
+Measured during the phase-420 W9 survey:
+
+| Where | Says |
+| --- | --- |
+| the `micro-cdr` gitlink | upstream **v2.0.2** |
+| the `micro-xrce-dds-client` gitlink | upstream **v3.0.1** |
+| `nros-sdk-index.toml` `[source.micro-xrce-dds-client]` | `2.4.3-nros1` |
+| `nros-rmw-xrce/CMakeLists.txt:59-62` | `PROJECT_VERSION* = 2.4.1` |
+
+The CMakeLists sets `PROJECT_VERSION*` for the XRCE client and never resets it
+before the micro-CDR `configure_file` at line 117, so `MICROCDR_VERSION_STR`
+compiles as `"2.4.1"` under CMake and `"2.0.2"` under cargo — for the same
+vendored tree, which is neither.
+
+## Severity: low, on evidence
+
+`git grep` finds **zero readers** of those macros in either vendored tree or in
+ours, so nothing behaves differently today. It is filed because the next reader
+will believe one of them, and because four hand-written restatements of one fact
+is the shape that produced issue 1068 next door.
+
+## Fix
+
+Derive it. The gitlink is the fact — `git -C <submodule> describe --tags` — and
+everything else should read from one place, the way phase-420 W5 made rmw
+descriptor fields derived rather than authored. Correcting the four literals
+would leave the same four literals.

--- a/docs/roadmap/phase-420-package-identity-and-provider-format.md
+++ b/docs/roadmap/phase-420-package-identity-and-provider-format.md
@@ -1,7 +1,6 @@
 # Phase 420 — package identity and the provider format
 
-**Status (2026-09-04). W1–W7 landed; W8's gate is written but not yet
-registered (see W8); W2–W5, W7 and W9 open.** Implements
+**Status (2026-09-04). W1–W2 landed; W3–W9 open.** Implements
 [RFC-0087](../design/0087-package-identity-and-provider-format.md). Sequenced
 with [phase-421](phase-421-serialization-format-provider.md), which implements
 RFC-0088 and needs **W1 of this phase only** — the rest of this phase can land
@@ -34,7 +33,6 @@ is one road.
 - Two readers have independently confused the two directions:
   `package_xml.rs`'s test message and `cmake/NanoRosPackageXml.cmake:41–46`.
 - `default_search_path` returns exactly two roots, both inside the user's repo.
-  (Closed by W6: `build_search_path` composes four sources.)
 
 ## Work items
 
@@ -60,13 +58,49 @@ is one road.
       `cmake -P` gate. `deploy=` stays an attribute in both, and a
       `<nano_ros_uses kind="deploy" …/>` is not invented to carry it.
 
-- [ ] **W2 — `nros_cmake` / `nros_cargo` build types.** Teach the reader both old
+- [x] **W2 — `nros_cmake` / `nros_cargo` build types.** (landed 2026-09-04) Teach the reader both old
       and new, mapping `ament_cargo|ament_nros → nros_cargo` with a deprecation
       warning that names the file. Add `check-build-type-spelling`: the allowed
       set, plus RFC-0087 D2's class boundary — a provider, board or entry may not
       declare `ament_*`; an interface package may not declare `nros_*`.
-      **Acceptance:** the gate fails on a package that crosses the boundary in
-      either direction, and passes on the tree as it stands after W3.
+      **Acceptance, met** (as a ratchet — the tree is not migrated until W3):
+      the gate fails on a package that crosses the boundary in either direction,
+      each rule watched failing on a constructed input.
+
+      **The survey contradicted this item's premise: NOTHING read
+      `<build_type>`.** Not `package_xml.rs`, not `NanoRosPackageXml.cmake`, not
+      `nros-cli-core` — which only WRITES it. So "teach the readers both
+      spellings" was really "give the readers a reader", and this wave adds one
+      to cmake and one to `nros-cli-core`. It sharpens the Motivation's defect 2:
+      colcon keys on a build type nothing declares, and no other consumer reads
+      the field either.
+
+      Three decisions worth carrying forward:
+
+      - `ament_nros` maps to **`nros_cmake`, not `nros_cargo`** as this doc
+        first said. All five in-tree uses are cmake-side — two carry a
+        `CMakeLists.txt`, three are bringups that generate a CMake root.
+      - **Only the three RETIRED spellings warn.** A deprecation on
+        `ament_cargo` would fire on 148 in-tree packages and on every legitimate
+        interface package, training people to ignore it before W3 can act.
+        Whether `ament_cargo` is wrong depends on the package's CLASS, which is
+        the gate's question, not a string's.
+      - The gate grew a fourth rule, `owned-declares-nothing`: 34 owned packages
+        (including all 21 providers) declare no `<build_type>` at all, and
+        `catkin_pkg` then reports `catkin` — the same false ament-family claim,
+        made by omission.
+
+      Classification is from evidence, and `nros_generate_interfaces` is
+      deliberately NOT ownership evidence: a message package calls it, and
+      counting it would classify every user interface package as firmware. The
+      gate cross-checks the two build-type tables against each other (S0) rather
+      than being a third copy of the vocabulary.
+
+      **Ordering hazard for W3/W4:** the scaffolder emitters
+      (`emit_package_xml.rs`, `new_system.rs`, `scaffold.rs`) must not move to
+      `nros_*` before W4 re-keys `colcon-cargo-ros2`, or a freshly scaffolded
+      package becomes unbuildable by colcon. `ament_nros` is safe to move
+      whenever — no colcon extension ever registered it.
 
 - [ ] **W3 — rewrite the nano-ros-owned packages.** Mechanical: entries, boards,
       RMW / platform providers, bringups. `packages/interfaces/*` and user
@@ -92,81 +126,12 @@ is one road.
       **Acceptance:** deleting the six derivable fields from one existing rmw
       descriptor changes no generated output.
 
-- [x] **W6 — the search path.** (landed 2026-09-04) `[workspace] package_paths`
-      in `nros.toml` plus `NROS_PACKAGE_PATH`, nano-ros tree first, shadowing
-      **reported**: `nros ws providers` prints each package's kind, its root,
-      and what it hid.
-      **Acceptance, met:** `a_provider_in_a_third_configured_root_is_selected_by_name`
-      selects a provider from a root that is neither the nano-ros tree nor the
-      workspace; `the_listing_names_the_provider_that_was_hidden` asserts the
-      printed report names the loser on both rows.
-
-      Landed as `provider_scan::build_search_path`, with
-      `default_search_path` reduced to "that function with nothing configured"
-      so the two-root path is not a second implementation. Four decisions the
-      RFC left open, and what was chosen:
-
-      - **The environment APPENDS to the config; it never replaces it.** colcon's
-        own precedent does not settle this — `COLCON_PREFIX_PATH` has no
-        configuration file competing with it, so it never had to decide. What
-        colcon has that DOES decide it is `--base-paths`, which replaces
-        outright, and that is a FLAG. A flag is typed per invocation and its
-        blast radius is one command; an exported variable persists for a shell
-        session and reaches every `nros` and every cmake configure beneath it, so
-        letting it replace a committed `package_paths` would let one developer's
-        shell delete a root the repository declares — the same tree building
-        differently on two machines with no diff to look at. That is exactly the
-        "works here, not there" failure `default_search_path`'s own doc gave as
-        the reason it refused an environment variable at all. Additive-only
-        answers the objection while keeping the capability: because the search
-        path is ORDERED and the LATER root wins, an env entry can still raise a
-        provider's precedence over a configured one — it just cannot make the
-        configured root vanish. "Replace it all" keeps its verb, `--base-paths`,
-        which is a flag exactly like colcon's.
-      - **A missing root is REPORTED and not fatal.** Fatal is wrong: the default
-        path's own workspace entry is legitimately absent, and a porter's
-        `NROS_PACKAGE_PATH` may name a tree that exists on only some machines —
-        making it fatal would refuse `nros sync` on this monorepo. Silent is
-        wrong too, because nobody types a path they did not mean to exist. So a
-        missing root keeps its index (the numbers in a stored `ProviderIndex`
-        must mean the same trees everywhere), contributes nothing, prints a
-        stderr warning quoting the entry AS WRITTEN, and is marked
-        `MISSING — nothing scanned` in the listing. Only CONFIGURED origins warn:
-        the nano-ros tree and the workspace are exempt, because a warning printed
-        on every ordinary invocation is a warning nobody reads.
-      - **Relative entries resolve against the WORKSPACE, not the cwd**, and `~`
-        expands while `~user` does not. `nros.toml` sits at the workspace root,
-        which is what D6's own `["src", …]` example is relative to; a
-        cwd-relative reading would make `nros ws providers` answer differently
-        depending on where it was invoked. `~user` needs a passwd lookup, and
-        left literal it becomes a missing root that says so rather than resolving
-        to a directory nobody named.
-      - **A repeated root is one root, keeping its FIRST index.** Scanning one
-        tree twice reports every provider in it as shadowing itself, and keeping
-        the first occurrence means adding an entry never renumbers the roots
-        before it — `root[0]` is the nano-ros tree in every invocation.
-
-      **The Phase 212.I `nros.toml` rejection is NARROWED, not lifted.** That
-      rejection exists so a pre-212 `nros.toml` — the whole system definition,
-      `[system]` and `[deploy.*]` and a `[workspace] default` — cannot be
-      silently ignored. D6 then spells the search path in that same file, so a
-      blanket rejection would have made the RFC's own example unusable in any
-      cargo workspace: write the documented key and every `nros plan` /
-      `nros codegen-system` / `nros config` refuses the workspace, quoting a
-      migration for a surface you never had. A file whose ONLY content is
-      `[workspace] package_paths` is now accepted; a bare `[workspace]` with no
-      keys is not (it declares no search path, so it is a legacy remnant), and
-      neither is anything with a legacy key beside it. No pre-212 file can pass.
-
-      **The AMBIGUOUS line states a fact and does not prescribe a rename.** A
-      same-root collision has no precedence and `resolve_unique` refuses it — but
-      `board` `threadx` is legitimately claimed by `nros-board-threadx-linux` and
-      `nros-board-threadx-qemu-riscv64`, separated by the descriptor's
-      `target_contains`, which is phase-348 W2's finding that a flat "two
-      packages, one name is an error" rule would reject a shipping arrangement.
-      So the report says the by-name lookup refuses and that a caller with its
-      own discriminator still resolves it, and marks BOTH rows of the tie —
-      singling one out would name a selection that will not happen.
+- [ ] **W6 — the search path.** `[workspace] package_paths` in `nros.toml` plus
+      `NROS_PACKAGE_PATH`, nano-ros tree first, shadowing **reported**:
+      `nros ws packages` prints each package's kind, its root, and what it hid.
+      **Acceptance:** a provider in an out-of-repo root is selected by name, and
+      a same-named provider in two roots produces a printed shadowing report
+      rather than a silent winner.
 
 - [ ] **W7 — selection verbs.** `nros build --packages-select` /
       `--packages-up-to`, colcon semantics, over the existing topological order.
@@ -185,89 +150,122 @@ is one road.
       `DEP_<LINKS>_<KEY>` rather than ambient environment, and the old
       `[source.*]` row is deleted in the same commit.
 
-      **The gate is written (`scripts/check-vendor-fetch-pinned.py`, 2026-09-04);
-      it is not yet registered in `just/check.just`, and the conversion half is
-      NOT done. Both halves of why are below, because the second is a finding
-      rather than a delay.**
-
-      *The gate.* Same reasoning as `check-submodule-pins`, not a second one:
-      that gate exists because a gitlink is a full commit id and can therefore
-      be interrogated, so a pin that moves backward is DETECTABLE even though
-      the diff shows two indistinguishable hex strings. A fetch is that pointer
-      with the enforcement removed — `GIT_TAG v0.6.1` names a ref on someone
-      else's server, and if they move it, this tree switches trees with no local
-      diff at all. Accepted digest forms are `URL_HASH` at SHA256/384/512 or
-      SHA3-256/384/512, and `GIT_TAG` at a FULL 40- or 64-hex commit id (the same form the
-      submodule gate governs, so the two tell one story about what a pin is).
-      Rejected: a tag, a branch, `HEAD`, a short sha (a prefix the remote
-      resolves), a `${VAR}` GIT_TAG (not statically establishable), `URL` with no
-      hash, `URL_MD5`/`SHA1` (forgeable — they answer "did the bytes arrive
-      intact", not "are these the bytes I pinned"), the non-option spellings
-      `URL_SHA256`/`URL_SHA512` (CMake verifies nothing and says nothing), and
-      SVN/HG/CVS or a bespoke `DOWNLOAD_COMMAND`, which have no digest slot.
-      `_selftest()` runs on the NORMAL path (phase-395), driving the real
-      classifiers over 18 synthetic cases in both directions.
-
-      *Vacuity is a stated fact, not a pass.* Measured 2026-09-04: **0** fetch
-      declarations and **0** downloading build scripts inside any of the 407
-      discovered packages, so both rules print `NOTHING TO CHECK` with the
-      population they searched. The tree's only fetch is **outside** every
-      package — `cmake/NanoRosCorrosion.cmake:644`, `GIT_TAG
-      ${_nros_corrosion_tag}`, resolved from `[tool.corrosion] upstream` (the tag
-      `v0.6.1`). Scoped to D5's sentence alone the gate would have reported OK on
-      an empty set while the tree's one real fetch sat a directory up, which is
-      the issue-0196 shape, so it scans everything and holds out-of-package
-      findings in a shrink-only BASELINE. That fetch is the FALLBACK path — the
-      supported one is the sha256-verified SDK store (`nros setup --tool
-      corrosion`) — and retiring the baseline entry needs `_nros_corrosion_pin()`
-      to return a commit id, i.e. an edit in `cmake/` that this wave does not own.
-
-      *No `[source.*]` row is a safe proof subject.* 14 of the 15 rows are
-      `submodule = …`, and converting one moves its pin out from under
-      `check-submodule-pins` — the roadmap's own W9 concern, not a proof's job.
-      The 15th, `[source.rosidl]` (the only `git`-clone row, already pinned at a
-      full SHA), fails on the MERITS as well as on ownership:
-      - it is a **Python source tree**, so it has no CMake target and no cargo
-        `links` to export through. The only channel left is a path in a cache
-        variable, which is the weakest form of D5's CMake channel and closest to
-        the ambient-path shape D5 exists to remove;
-      - `msg_to_cyclone_idl.py` resolves it through a deliberate RUNTIME ladder
-        whose rung 2 is the host's own ROS install. A configure-time fetch would
-        make a ROS-full host download a rosidl it does not need, or reintroduce
-        the ladder and prove nothing;
-      - the conversion needs `<depend>` + a cache-variable read in
-        `packages/rmw/cyclonedds/nros-rmw-cyclonedds/{package.xml,cmake/NrosRmwCycloneddsTypeSupport.cmake}`
-        and the ladder rewrite in `scripts/cyclonedds/msg_to_cyclone_idl.py`.
-
-      A NEW vendor package was considered instead and rejected: every external
-      tree this build wants is already provisioned by exactly one mechanism
-      (submodule, SDK store, or the Corrosion fallback), so a vendor package for
-      any of them is a SECOND SPELLING until the first is deleted — and deleting
-      the first is the same blocked edit. **The shape is therefore proven where
-      it can be proven honestly — by the gate's negative controls — and the
-      conversion folds into W9, which already owns moving trees between the two
-      pinning mechanisms.**
-
-      *Offline (RFC-0087's Consequences).* Checked 2026-09-04: **nothing in the
-      tree sets `FETCHCONTENT_BASE_DIR`**, nor `FETCHCONTENT_FULLY_DISCONNECTED`
-      nor any `FETCHCONTENT_SOURCE_DIR_<UC>`; the only occurrence of the name in
-      the repo is RFC-0087 line 278 proposing it. So the "once per host" property
-      the RFC's offline story rests on is not in place — with the default
-      `<build>/_deps`, every build directory fetches independently. The scale is
-      already on record: issue 0500 measured **159** build dirs in this tree each
-      carrying its own resolved Corrosion (139 on 0.5.1, 20 on 0.6.1), which is
-      the same per-build-dir duplication one axis over. Setting one shared cache
-      dir is a prerequisite of the first vendor package, not a follow-up to it.
-
-- [ ] **W9 — the in-tree vendored backends adopt the same shape.** `zpico-sys`
-      and `xrce-sys` currently vendor through a submodule plus `build.rs`, which
-      is a third mechanism. Split each into a vendor package (fetch/build of the
-      upstream tree) and a provider package (the backend), so ours and a user's
-      differ in nothing but location. Largest wave; do it after W8 has proven the
-      shape on a simpler row.
+- [~] **W9 — the in-tree vendored backends adopt the same shape.** (surveyed +
+      partially landed 2026-09-05) `zpico-sys` and `xrce-sys` currently vendor
+      through a submodule plus `build.rs`, which is a third mechanism. Split each
+      into a vendor package (fetch/build of the upstream tree) and a provider
+      package (the backend), so ours and a user's differ in nothing but location.
+      Largest wave; do it after W8 has proven the shape on a simpler row.
       **Acceptance:** `zenoh-pico` and Micro-XRCE-DDS are reached by package
       name; `check-submodule-pins` still governs whichever remain submodules; no
       backend keeps a bespoke vendoring path.
+
+      **The survey moved the wave, and two of this item's premises are false.** What landed is identity for the one directory that already IS a
+      vendor package; the conversion this item names is refused, with reasons.
+
+      **S1 — `xrce-sys` has no `build.rs`, and no crate.** phase-321 W1.d deleted
+      the `xrce-sys` crate (701 LoC + a 307-line build script) for having zero
+      dependents, leaving a directory holding two submodules and a README that
+      says so: *"this directory is a SUBMODULE HOST, not a crate … Do not re-add
+      a crate here."* So "vendor through a submodule plus `build.rs`" describes
+      only `zpico-sys`.
+
+      **S2 — the bespoke path is not the submodule, it is that every vendored
+      tree is compiled TWICE, once per language lane.** Measured:
+
+      | tree | cargo lane | cmake / west lane |
+      | --- | --- | --- |
+      | zenoh-pico | `zpico-sys/build.rs` → `nros-zpico-build` (2,593 LoC) | `zephyr/cmake/nros_rmw_zenoh.cmake:11` — a `GLOB_RECURSE` over the same submodule |
+      | micro-XRCE + micro-CDR | `nros-rmw-xrce-cffi/build.rs:160-245` | `nros-rmw-xrce/CMakeLists.txt:143-193` — a hand-copied source list |
+
+      The XRCE pair is the sharpest case: its lockstep is asserted by a comment
+      calling it "a 115.K.2 invariant", and until this wave that comment named
+      `packages/rmw/xrce/xrce-sys/build.rs` — **the file phase-321 W1.d deleted.**
+      The invariant has been pointed at a ghost since phase-321.
+
+      **S3 — the mirror has already drifted, in two respects.**
+      `nros-rmw-xrce-cffi/build.rs` honours `NROS_LINK_IP=0` (phase-204.7) and
+      drops `udp_transport{,_posix}.c`; `nros-rmw-xrce/CMakeLists.txt` compiles
+      them unconditionally, so the CMake lane cannot build a serial-only XRCE
+      node. And the vendored VERSION is restated by hand in four places, only one of
+      which agrees with the tree it describes: the client gitlink is upstream **v3.0.1**
+      (`bdfa2809` = "Release v3.0.1") and micro-CDR is **v2.0.2**, while
+      `nros-rmw-xrce-cffi/build.rs:359-383` bakes `2.4.1` (wrong) and `2.0.2`
+      (right), `nros-rmw-xrce/CMakeLists.txt:59-62` bakes
+      `2.4.1` for BOTH — `PROJECT_VERSION*` is never reset between the two
+      `configure_file` calls, so `MICROCDR_VERSION_STR` compiles as `"2.4.1"` in
+      the CMake lane and `"2.0.2"` in the Rust one — and `[source.micro-xrce-dds-
+      client] version` in `nros-sdk-index.toml` says `2.4.3-nros1`. Nothing reads
+      those macros (grepped: zero uses in either vendored tree and in ours), so
+      the drift is cosmetic today; it is left ALONE on purpose, because the fix
+      is to derive the version from the tree that has it, not to correct four
+      literals and leave five spellings.
+
+      **S4 — converting either to a fetch is strictly worse, and for zenoh-pico
+      it is impossible.** `zenoh-pico` is a PATCH LINE: `jerry73204/zenoh-pico`
+      branch `nano-ros`, pinned `c5853157`. D5's worked example is `URL` +
+      `URL_HASH`, and a tarball has nowhere to put patches; a `PATCH_COMMAND`
+      would resurrect the `patches/` directory `.gitmodules` records as
+      deliberately deleted for the qemu fork in favour of the fork's own history.
+      The remaining option, `GIT_TAG <full sha>` against our own fork, satisfies
+      `check-vendor-fetch-pinned` but is the identical pointer with
+      `check-submodule-pins` removed — W8's own argument for converting no row.
+      The eProsima pair IS unpatched upstream (no `branch =`, upstream URL, both
+      on release commits), so a fetch is mechanically possible there — and still
+      buys nothing: it trades a gitlink for a weaker pin, drops the trees out of
+      `nros setup --source`, and leaves the duplicated build untouched, which is
+      the actual defect.
+
+      **Decision: a fork IS a vendor package whose "fetch" is a submodule.** That
+      is the finished shape, not a way-station. RFC-0087 D5 should say so — it
+      currently reads as though `FetchContent` were the only spelling of "fetches
+      an external source tree", and a gitlink is the strongest of the three pin
+      forms, not an unmigrated one. **Recommended amendment to D5, not made here
+      (`docs/design/` was outside this change's ownership):** add that a vendor
+      package's fetch may be a submodule, that a PATCHED upstream must be one,
+      and that `check-submodule-pins` and `check-vendor-fetch-pinned` partition
+      the surface rather than ranking it.
+
+      **Landed:**
+
+      - `packages/rmw/zenoh/zpico-sys/package.xml` — the zenoh-pico vendor
+        package gets an identity. It already owned the fetch (the gitlink), the
+        build (the C compile for six platforms) and the export (`links = "zpico"`
+        → `DEP_ZPICO_*`, which is D5's cargo channel, live since phase-214). The
+        only thing missing was that it was not a package, so nothing could name
+        it. `nros_cargo`, no `<nano_ros_provides>` — a vendor package is not a
+        kind (D5).
+      - `nros_rmw_zenoh` gains `<depend>zpico_sys</depend>`, so the vendored tree
+        is reached BY PACKAGE NAME. Inert by construction: `topo_inner` filters a
+        `<depend>` naming a package outside the scanned set
+        (`provider_scan.rs:438`), and `check_declared_depends` reads only the
+        workspace being built, never the nano-ros tree.
+      - `nros-rmw-xrce/CMakeLists.txt` — the mirror comment now names the file
+        that exists, and records both measured divergences instead of asserting a
+        lockstep that does not hold.
+
+      **Not done, and why:** `xrce-sys` gets NO `package.xml`. It builds nothing —
+      its two consumers each build its contents — so any `<build_type>` it
+      declared would be the same false claim D2 exists to delete, and a vendor
+      package nothing builds is W8's fixture. (Checked: neither eProsima tree
+      ships a `package.xml` of its own, so there is no discovery-shadowing reason
+      to add one either.) XRCE's vendor package cannot be created by adding a
+      file; it needs the two copies of its build to become one.
+
+      **W9 remainder, the real content:** give each vendored tree ONE build with
+      ONE source list, consumed by both lanes.
+      - XRCE: a vendor build under `xrce-sys/` producing `microxrcedds_client` +
+        `microcdr` targets and a cargo `links` crate, with the source list and the
+        version read from the vendored tree; `nros-rmw-xrce` and
+        `nros-rmw-xrce-cffi` consume it instead of listing sources. This is what
+        closes "no backend keeps a bespoke vendoring path", and it re-adds the
+        crate phase-321 W1.d removed — legitimately, since this one has two
+        dependents, which is exactly what that deletion said it lacked.
+      - zenoh: fold `zephyr/cmake/nros_rmw_zenoh.cmake`'s `GLOB_RECURSE` into the
+        same source list `nros-zpico-build` computes.
+      Both are build-affecting and need the submodules checked out and both lanes
+      built; neither is a documentation change, and neither should be attempted
+      in the same commit as the identity above.
 
 ## Risks
 
@@ -283,3 +281,13 @@ is one road.
 
 Install prefixes and a sourced `setup.sh`; per-package isolated builds for
 in-tree packages; a Python plugin ABI; rosdep. RFC-0087 D8 records why for each.
+
+
+## Adopted issue (2026-09-04)
+
+* **[#1054](../issues/1054-provider-scan-prunes-the-nano-ros-root.md)** —
+  `provider_scan` reads `.nros-ignore` on the root it was handed, so scanning the
+  nano-ros tree finds nothing. The marker's own header (issue 0621) says it
+  prunes a tree from any walk that starts ABOVE it; honouring it at the root
+  inverts that. Provider discovery is this phase's subject, and a scan that
+  returns an empty set silently is the worst shape it can take.

--- a/packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt
+++ b/packages/rmw/xrce/nros-rmw-xrce/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 # rather than going through the upstream CMakeLists' add_subdirectory
 # / find_package machinery. The upstream client's `find_package(microcdr
 # REQUIRED CONFIG)` requires a separate install step that buys nothing
-# in our in-tree case; xrce-sys's `build.rs` already proved the
-# inline-compile approach (same source list mirrored below).
+# in our in-tree case; the inline-compile approach was proven by the
+# Rust lane first (same source list mirrored below).
 set(MICROXRCEDDS_CLIENT_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/../xrce-sys/micro-xrce-dds-client"
     CACHE PATH "Path to vendored micro-xrce-dds-client checkout")
@@ -53,7 +53,7 @@ set(MICROCDR_DIR
     CACHE PATH "Path to vendored micro-cdr checkout")
 
 # Generate `<uxr/client/config.h>` from the upstream template. Values
-# match xrce-sys's `posix_compat = true, mtu = 4096` defaults; further
+# match the Rust lane's `posix_compat = true, mtu = 4096` defaults; further
 # tuning lands when 115.K.2.5 flips the C backend on under
 # `-DNROS_C_RMW=xrce`.
 set(NROS_RMW_XRCE_C_PROJECT_VERSION_MAJOR 2)
@@ -118,10 +118,28 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/ucdr_generated/ucdr/config.h"
     @ONLY)
 
-# Source lists mirror packages/rmw/xrce/xrce-sys/build.rs (proven
-# working set). Keeping these in lockstep is a 115.K.2 invariant —
-# if the Rust build.rs adds a file, this CMakeLists must add it too,
-# and vice versa.
+# Source lists mirror packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs
+# (proven working set). Keeping these in lockstep is a 115.K.2
+# invariant — if that build.rs adds a file, this CMakeLists must add
+# it too, and vice versa.
+#
+# phase-420 W9 surveyed the mirror and found two things worth writing
+# down. First, this comment named `packages/rmw/xrce/xrce-sys/build.rs`
+# until now: a file phase-321 W1.d DELETED along with the crate that
+# owned it. The invariant was pointed at a ghost, so "keep them in
+# lockstep" named a file nobody could open. The live counterpart is the
+# path above.
+#
+# Second, the two lists have already diverged in one place. `build.rs`
+# honours `NROS_LINK_IP=0` (phase-204.7) and drops
+# `profile/transport/ip/udp/udp_transport{,_posix}.c`; this file compiles
+# them unconditionally, so the CMake lane cannot build a serial-only XRCE
+# node. That is not a source-list typo, it is what a hand-maintained
+# mirror does. The structural fix is ONE vendor build with ONE source list
+# that both lanes consume — RFC-0087 D5's shape, recorded as W9's
+# remaining work in docs/roadmap/phase-420-package-identity-and-provider-
+# format.md. Until that lands, a source added on either side must be added
+# on the other, by hand.
 set(_uxr_session_src
     core/session/session.c
     core/session/session_info.c
@@ -242,7 +260,7 @@ endif()
 target_compile_definitions(nros_rmw_xrce PRIVATE
     # POSIX feature gate — `time.c` calls `clock_gettime`, which
     # only resolves under `_POSIX_C_SOURCE >= 199309L`. Match
-    # xrce-sys's build environment.
+    # the Rust lane's build environment.
     _POSIX_C_SOURCE=200809L
     _DEFAULT_SOURCE
 )

--- a/packages/rmw/zenoh/nros-rmw-zenoh/package.xml
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/package.xml
@@ -14,6 +14,16 @@
   <maintainer email="dev@example.com">Developer</maintainer>
   <license>Apache-2.0</license>
 
+  <!--
+    phase-420 W9 — the vendor package this backend is built on, reached by
+    PACKAGE NAME rather than by a path. `zpico_sys` owns the zenoh-pico gitlink,
+    compiles it, and exports the result over `links = "zpico"`; this package is
+    the provider that consumes it. Cargo already states the same edge as a path
+    dep, and `provider_scan` ignores a `<depend>` naming a package outside the
+    scanned set, so this is a declaration, not a new build edge.
+  -->
+  <depend>zpico_sys</depend>
+
   <export>
     <!--
       Provision, NOT consumption. `<nano_ros rmw="zenoh"/>` in a leaf package

--- a/packages/rmw/zenoh/zpico-sys/package.xml
+++ b/packages/rmw/zenoh/zpico-sys/package.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>zpico_sys</name>
+  <version>0.0.0</version>
+  <description>
+    The zenoh-pico VENDOR package (RFC-0087 D5, phase-420 W9): it owns the
+    upstream tree, builds it, and exports the result. ROS 2 would spell this
+    `zenoh_pico_vendor`; the name here is the crate's (`zpico-sys`) because two
+    spellings of one identity drift, and `&lt;depend&gt;` resolves against this
+    name while cargo resolves against the crate.
+
+    What it vendors: `zenoh-pico/`, a gitlink onto the `nano-ros` patch branch
+    of jerry73204/zenoh-pico, plus `mbedtls/` for the TLS link. What it exports:
+    the compiled zenoh-pico + shim archive on the normal cargo link, and the
+    probed sizes over `links = "zpico"` as `DEP_ZPICO_*` — D5's cargo channel,
+    already live, not something this file adds.
+
+    **Its fetch is a submodule, and that is the finished shape, not a step
+    toward `FetchContent`.** D5's worked example is `URL` + `URL_HASH`, which
+    cannot carry a patch line: this tree IS patched, the patches live in the
+    fork's git history rather than a `patches/` dir (the same choice recorded
+    for the qemu fork in `.gitmodules`), and a tarball has nowhere to put them.
+    The remaining option, `GIT_TAG &lt;full sha&gt;` against our own fork, is the
+    identical pointer with `check-submodule-pins` removed — phase-420 W8's
+    argument for why it converted no row. A gitlink is the strongest of the
+    three pin forms, so the vendor package keeps it.
+
+    This file adds identity and nothing else. It does not change how the source
+    arrives, what is built, or what is linked.
+  </description>
+  <maintainer email="dev@example.com">Developer</maintainer>
+  <license>Apache-2.0</license>
+
+  <export>
+    <!--
+      Cargo-built and nano-ros-owned: the build script compiles the upstream C
+      for six platforms against our platform ABI, which no stock colcon build
+      can do. No `<nano_ros_provides>` — this package is not a provider of any
+      kind. It is an ordinary package whose build happens to fetch (RFC-0087 D5:
+      "a vendor package is not a kind at all"). The provider that consumes it is
+      the sibling `nros_rmw_zenoh`.
+    -->
+    <build_type>nros_cargo</build_type>
+  </export>
+</package>


### PR DESCRIPTION
W9 asked for `zpico-sys` and `xrce-sys` to be split into a vendor package and a provider package. **The survey says the split is the wrong shape for a patched fork — and that the vendor package is already there, it just had no identity.**

## Where the phase doc's premise was wrong

`zpico-sys` **is** a crate: submodule + a 9-line `build.rs` delegating to `nros-zpico-build`, pinned by gitlink, declared in the index, provisioned by `nros setup --source zenoh-pico`. It already owns fetch, build **and export** — `links = "zpico"` emitting `DEP_ZPICO_SOCKET_SIZE` / `DEP_ZPICO_ENDPOINT_SIZE`, D5's cargo channel, live since phase-214.

`xrce-sys` is **not a crate at all** — no `Cargo.toml`, no `build.rs`, no `CMakeLists.txt`. phase-321 W1.d deleted it for having zero dependents, and its README says: *"this directory is a SUBMODULE HOST, not a crate … Do not re-add a crate here."*

## A tarball has nowhere to put patches

zenoh-pico is a patch line (`jerry73204/zenoh-pico`, branch `nano-ros`), and D5's worked example is `URL` + `URL_HASH`. A `PATCH_COMMAND` would resurrect the `patches/` directory `.gitmodules` records as deliberately deleted. The remaining option — `GIT_TAG <full sha>` at our own fork — passes `check-vendor-fetch-pinned` and is **the identical pointer with `check-submodule-pins` removed**, which is W8's own argument against it.

The eProsima pair *is* unpatched upstream, so a fetch is mechanically possible there — and still buys nothing: weaker pin, dropped from `nros setup --source`, duplicated build untouched.

## So: no conversion. Identity, not relocation

| | |
|---|---|
| `zpico-sys` | gains a `package.xml` (`nros_cargo`, **no** `<nano_ros_provides>` — a vendor package is not a kind) |
| `nros-rmw-zenoh` | gains `<depend>zpico_sys</depend>` — the vendored tree is reached by package name |
| `xrce-sys` | deliberately gets none: it builds nothing, so any `<build_type>` is the false claim D2 exists to delete, and a vendor package nothing builds is W8's fixture |

A user's equivalent now reads identically: `package.xml` with no announcement, a build that populates its tree (`FetchContent` for clean upstream, a submodule for a patched one), exporting through a CMake target or `links` + `DEP_<LINKS>_<KEY>`, with the provider beside it depending on it by name.

## Two divergences measured on the way — filed, not patched over

Every vendored tree here is compiled **twice**, once per language lane, and the mirrors have drifted:

- **issue 1068** — `build.rs` honours `NROS_LINK_IP=0` and drops the UDP transports; the CMakeLists compiles them unconditionally. **A serial-only XRCE node cannot be built from C/C++**, and it fails silently: a larger image, not an error.
- **issue 1069** — `MICROCDR_VERSION_STR` compiles as `2.4.1` under CMake and `2.0.2` under cargo, against a tree that is 2.0.2, while the index says `2.4.3-nros1`. Four hand-written restatements, zero readers, cosmetic today.

Both want **derivation, not corrected literals**, which is why neither is fixed here. The comment asserting the two source lists stay in lockstep named `xrce-sys/build.rs` — a file phase-321 W1.d **deleted** — so it now names what exists and records both divergences.

## Verification

`check-submodule-pins`: **0 pins moved, all fast-forward**. `micro-cdr` and `micro-xrce-dds-client` were initialised at their recorded commits to read them — a checkout, not a pin move. `build-type-spelling`, `provider-announcements` (18 providers, 4 families), `derived-descriptor-fields`, `rmw-descriptors`, `package-xml-uses`, `issue-index`, `doc-refs`, `roadmap-status` all green.

**Recommendation recorded in the phase doc:** RFC-0087 D5 should say a vendor package's fetch **may** be a submodule, that a patched upstream **must** be one, and that the two pin gates partition the surface rather than rank it. D5 currently reads as though `FetchContent` were the only spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV