### PR TITLE
feat(sched): report a stack that has come too close to its end

### DIFF
--- a/packages/core/nros-node/src/executor/monitor.rs
+++ b/packages/core/nros-node/src/executor/monitor.rs
@@ -139,7 +139,8 @@ pub const MAX_VIOLATIONS: usize = 8;
 pub struct Violation {
     /// `"rate-hierarchy-runtime"` | `"max-age-runtime"` |
     /// `"max-latency-runtime"` | `"deadline-miss-runtime"` |
-    /// `"timer-overrun-runtime"` | `"release-jitter-runtime"`.
+    /// `"timer-overrun-runtime"` | `"release-jitter-runtime"` |
+    /// `"stack-headroom-runtime"`.
     pub rule: &'static str,
     /// Violating endpoint ref (from the spec's `fqn`; the SC name for
     /// deadline misses).
@@ -525,6 +526,88 @@ pub(crate) fn check_release_jitter(
         measured: max_jitter_us.min(u32::MAX as u64) as u32,
         declared: period_us.min(u32::MAX as u64) as u32,
     })
+}
+
+/// Report a spin thread whose stack has come closer to its end than the
+/// declared minimum.
+///
+/// Unlike every other rule here the bound CANNOT be derived from something
+/// already declared, and that is worth stating rather than papering over.
+/// `check_timer_overrun` and `check_release_jitter` both judge against a
+/// period the caller already passes in; there is no equivalent for a stack.
+/// The executor never sees `stack_bytes` -- it lives in the spawn attr and
+/// goes no further -- and the total is not portably queryable either:
+/// FreeRTOS exposes the high-water mark and not the size it was taken
+/// against, so even a percentage cannot be computed. A minimum headroom is
+/// therefore a real declaration, and `min_bytes == 0` means the caller has
+/// not made one, which disables the rule.
+///
+/// Reports on the WORST case, not on each crossing: `worst_reported` holds
+/// the lowest headroom already reported, so a stack hovering just under the
+/// bound says so once and then only when it gets worse. The same delta
+/// discipline as the overrun and jitter rules, inverted because for headroom
+/// smaller is worse.
+pub(crate) fn check_stack_headroom(
+    unused_bytes: usize,
+    min_bytes: usize,
+    worst_reported: &mut usize,
+) -> Option<Violation> {
+    if min_bytes == 0 || unused_bytes >= min_bytes {
+        return None;
+    }
+    // `usize::MAX` is the "nothing reported yet" sentinel: any real headroom
+    // is below it, so the first breach always reports.
+    if *worst_reported != usize::MAX && unused_bytes >= *worst_reported {
+        return None;
+    }
+    *worst_reported = unused_bytes;
+    Some(Violation {
+        rule: "stack-headroom-runtime",
+        // The spin thread is not an endpoint; same stand-in as the timer,
+        // deadline and jitter rules.
+        fqn: "stack",
+        measured: unused_bytes.min(u32::MAX as usize) as u32,
+        declared: min_bytes.min(u32::MAX as usize) as u32,
+    })
+}
+
+#[cfg(test)]
+mod stack_headroom_rule_tests {
+    use super::*;
+
+    /// No declared minimum means no claim to breach.
+    #[test]
+    fn a_zero_minimum_disables_the_rule() {
+        let mut worst = usize::MAX;
+        assert!(check_stack_headroom(8, 0, &mut worst).is_none());
+    }
+
+    #[test]
+    fn headroom_at_the_bound_is_not_a_breach() {
+        let mut worst = usize::MAX;
+        assert!(check_stack_headroom(1024, 1024, &mut worst).is_none());
+        assert!(check_stack_headroom(2048, 1024, &mut worst).is_none());
+    }
+
+    #[test]
+    fn reports_the_first_breach_with_both_numbers() {
+        let mut worst = usize::MAX;
+        let v = check_stack_headroom(512, 1024, &mut worst).expect("under the bound reports");
+        assert_eq!(v.rule, "stack-headroom-runtime");
+        assert_eq!(v.measured, 512);
+        assert_eq!(v.declared, 1024);
+    }
+
+    /// Smaller is worse for headroom, so the delta runs the other way.
+    #[test]
+    fn only_a_new_low_is_a_new_fault() {
+        let mut worst = usize::MAX;
+        assert!(check_stack_headroom(512, 1024, &mut worst).is_some());
+        assert!(check_stack_headroom(512, 1024, &mut worst).is_none());
+        assert!(check_stack_headroom(600, 1024, &mut worst).is_none());
+        let v = check_stack_headroom(100, 1024, &mut worst).expect("a new low reports");
+        assert_eq!(v.measured, 100);
+    }
 }
 
 #[cfg(test)]

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1419,6 +1419,17 @@ pub struct Executor<'s> {
     /// timer header, and for the same reason: a maximum that has not moved
     /// is the fault already reported, not a new one.
     pub(crate) jitter_reported_us: u64,
+    /// Declared minimum stack headroom in bytes for the thread this executor
+    /// spins on; `0` (default) disables the rule.
+    ///
+    /// An executor-level install rather than a contract field, because the
+    /// bound cannot be derived from anything already declared -- see
+    /// `check_stack_headroom`. The entry that spawned the thread is the one
+    /// that knows what it gave it, so that is where the number comes from.
+    pub(crate) min_stack_headroom_bytes: usize,
+    /// Lowest headroom already reported, so the rule fires on new lows only.
+    /// `usize::MAX` = nothing reported yet.
+    pub(crate) stack_headroom_reported: usize,
     /// The pacing quantum the spin loop was last driven at, in microseconds.
     /// This is the bound the jitter rule judges against -- the caller's own
     /// declared cadence, so nothing further has to be declared.
@@ -1591,6 +1602,8 @@ impl<'s> Executor<'s> {
             max_release_jitter_us: 0,
             last_spin_entry_us: None,
             jitter_reported_us: 0,
+            min_stack_headroom_bytes: 0,
+            stack_headroom_reported: usize::MAX,
             spin_nominal_us: 0,
             late_wakes: 0,
             total_wakes: 0,
@@ -2377,6 +2390,49 @@ impl<'s> Executor<'s> {
     /// activation is a contract failure for any declared period. It runs
     /// on the same tick so violations land in the same ring the entry
     /// glue drains.
+    /// Declare the minimum stack headroom this executor's thread must keep,
+    /// in bytes. `0` (the default) disables the `stack-headroom-runtime`
+    /// rule.
+    ///
+    /// Set by the entry that spawned the thread, because it is the only
+    /// party that knows what stack it handed over: the executor never sees
+    /// `stack_bytes`, and no portable query returns a task's total stack, so
+    /// neither an absolute floor nor a percentage can be inferred here.
+    pub fn set_min_stack_headroom_bytes(&mut self, bytes: usize) {
+        self.min_stack_headroom_bytes = bytes;
+    }
+
+    /// Report a spin thread that has come closer to the end of its stack
+    /// than `set_min_stack_headroom_bytes` allows.
+    ///
+    /// Runs on the same tick as the other rules and feeds the same ring.
+    /// Costs one platform query per tick, and nothing at all when no minimum
+    /// was declared.
+    fn check_stack_headroom_rule(&mut self) {
+        if self.min_stack_headroom_bytes == 0 {
+            return;
+        }
+        let unused = nros_platform_api::task::stack_unused_bytes();
+        // 0 means the port does not instrument stacks, not that the stack is
+        // full. Reporting a violation there would be a fault invented from an
+        // absence of data.
+        if unused == 0 {
+            return;
+        }
+        if let Some(v) = super::monitor::check_stack_headroom(
+            unused,
+            self.min_stack_headroom_bytes,
+            &mut self.stack_headroom_reported,
+        ) {
+            if self.report_violations {
+                super::monitor::log_violation(&v);
+            }
+            if self.monitor_violations.push(v).is_err() {
+                self.monitor_violations_dropped = self.monitor_violations_dropped.saturating_add(1);
+            }
+        }
+    }
+
     /// Issue #515 — report a spin wake a whole period late.
     ///
     /// Runs on the same tick as `check_timer_overruns` and feeds the same
@@ -6826,6 +6882,7 @@ impl<'s> Executor<'s> {
         // to wait for the next spin to say so.
         self.check_timer_overruns();
         self.check_release_jitter_rule();
+        self.check_stack_headroom_rule();
 
         // Process parameter services (outside the arena)
         #[cfg(feature = "param-services")]

--- a/packages/platform/nros-platform-api/include/nros/platform.h
+++ b/packages/platform/nros-platform-api/include/nros/platform.h
@@ -261,6 +261,36 @@ static inline void nros_platform_free(void *ptr) {
  *  Rust `#[global_allocator]`. */
 size_t nros_platform_heap_used_bytes(void);
 
+/** Smallest number of bytes ever left unused on the CALLING task's stack, or
+ *  `0` if this port cannot report it.
+ *
+ *  HEADROOM, not usage, because that is what both kernels natively track and
+ *  it is the number a safety argument needs: how close the worst observed
+ *  excursion came to the end of the stack.
+ *
+ *  The heap has had `nros_platform_heap_used_bytes` since RFC-0034 D7; the
+ *  stack had nothing, and stack overflow is the classic way one component
+ *  corrupts another's state. ISO 26262 treats spatial freedom from
+ *  interference as a first-class requirement and AUTOSAR pairs memory
+ *  protection with stack monitoring for exactly this reason. Without a
+ *  portable probe the only recourse is a per-RTOS one: this repo's Zephyr
+ *  lane greps `thread_analyzer` printk output in CI, which is a text scrape
+ *  of a debug facility standing in for a platform capability, and reports
+ *  nothing on any other port.
+ *
+ *  SELF only, deliberately. Both kernels answer for the calling task with no
+ *  handle (`uxTaskGetStackHighWaterMark(NULL)`, `k_thread_stack_space_get`
+ *  with `k_current_get()`), whereas answering for an arbitrary task needs a
+ *  native handle this ABI does not carry -- on Zephyr the task storage is a
+ *  `pthread_t` and the mapping to `k_thread *` is not public. A task
+ *  reporting its own headroom is also the shape the callers want: each tier
+ *  says how much of its own stack it has ever needed.
+ *
+ *  `0` means "this port does not instrument it", matching
+ *  `nros_platform_heap_used_bytes`. It is not a claim that the stack is
+ *  full. */
+size_t nros_platform_task_stack_unused_bytes(void);
+
 /** Total managed heap size in bytes (used + free), or `0` if unknown. */
 size_t nros_platform_heap_total_bytes(void);
 

--- a/packages/platform/nros-platform-api/src/lib.rs
+++ b/packages/platform/nros-platform-api/src/lib.rs
@@ -485,6 +485,15 @@ pub trait PlatformTime {
 /// be no-ops returning `0`, except [`task_init`](Self::task_init)
 /// which should return `-1`.
 pub trait PlatformThreading {
+    /// Smallest number of bytes ever left unused on the CALLING task's
+    /// stack, or `0` if this platform does not instrument it.
+    ///
+    /// Defaulted so every existing impl keeps compiling: a port that says
+    /// nothing reports `0`, which the ABI documents as "not instrumented"
+    /// rather than "no headroom left".
+    fn task_stack_unused_bytes() -> usize {
+        0
+    }
     // -- Tasks --
 
     /// Spawn a new task. `task` is opaque caller-provided storage;

--- a/packages/platform/nros-platform-api/src/task.rs
+++ b/packages/platform/nros-platform-api/src/task.rs
@@ -47,6 +47,7 @@ struct TaskAttr {
 const PRIORITY_INHERIT: i32 = i32::MIN;
 
 unsafe extern "C" {
+    fn nros_platform_task_stack_unused_bytes() -> usize;
     fn nros_platform_task_init(
         task: *mut c_void,
         attr: *mut c_void,
@@ -186,4 +187,20 @@ impl Drop for PlatformTask {
         //
         // `join` calls `mem::forget`, so the normal path never lands here.
     }
+}
+
+/// Smallest number of bytes ever left unused on the CALLING task's stack, or
+/// `0` if this port does not instrument it.
+///
+/// The heap has had `heap_used_bytes` since RFC-0034 D7; the stack had
+/// nothing, and stack overflow is how one component corrupts another's state.
+/// A tier asks this about ITSELF -- both kernels answer for the calling task
+/// with no handle, and answering for an arbitrary one needs a native handle
+/// this ABI does not carry.
+///
+/// `0` means "not instrumented", not "no headroom".
+pub fn stack_unused_bytes() -> usize {
+    // SAFETY: a plain query with no arguments and no state; every port either
+    // answers or returns 0.
+    unsafe { nros_platform_task_stack_unused_bytes() }
 }

--- a/packages/platform/nros-platform-cffi/src/generated.rs
+++ b/packages/platform/nros-platform-cffi/src/generated.rs
@@ -83,6 +83,10 @@ unsafe extern "C" {
     pub fn nros_platform_heap_used_bytes() -> usize;
 }
 unsafe extern "C" {
+    #[doc = " Smallest number of bytes ever left unused on the CALLING task's stack, or\n  `0` if this port cannot report it.\n\n  HEADROOM, not usage, because that is what both kernels natively track and\n  it is the number a safety argument needs: how close the worst observed\n  excursion came to the end of the stack.\n\n  The heap has had `nros_platform_heap_used_bytes` since RFC-0034 D7; the\n  stack had nothing, and stack overflow is the classic way one component\n  corrupts another's state. ISO 26262 treats spatial freedom from\n  interference as a first-class requirement and AUTOSAR pairs memory\n  protection with stack monitoring for exactly this reason. Without a\n  portable probe the only recourse is a per-RTOS one: this repo's Zephyr\n  lane greps `thread_analyzer` printk output in CI, which is a text scrape\n  of a debug facility standing in for a platform capability, and reports\n  nothing on any other port.\n\n  SELF only, deliberately. Both kernels answer for the calling task with no\n  handle (`uxTaskGetStackHighWaterMark(NULL)`, `k_thread_stack_space_get`\n  with `k_current_get()`), whereas answering for an arbitrary task needs a\n  native handle this ABI does not carry -- on Zephyr the task storage is a\n  `pthread_t` and the mapping to `k_thread *` is not public. A task\n  reporting its own headroom is also the shape the callers want: each tier\n  says how much of its own stack it has ever needed.\n\n  `0` means \"this port does not instrument it\", matching\n  `nros_platform_heap_used_bytes`. It is not a claim that the stack is\n  full."]
+    pub fn nros_platform_task_stack_unused_bytes() -> usize;
+}
+unsafe extern "C" {
     #[doc = " Total managed heap size in bytes (used + free), or `0` if unknown."]
     pub fn nros_platform_heap_total_bytes() -> usize;
 }

--- a/packages/platform/nros-platform-cffi/src/lib.rs
+++ b/packages/platform/nros-platform-cffi/src/lib.rs
@@ -777,6 +777,10 @@ macro_rules! nros_platform_export_threading {
             <$ty as ::nros_platform_api::PlatformThreading>::task_init(task, attr, entry, arg)
         }
         #[unsafe(no_mangle)]
+        pub extern "C" fn nros_platform_task_stack_unused_bytes() -> usize {
+            <$ty as ::nros_platform_api::PlatformThreading>::task_stack_unused_bytes()
+        }
+        #[unsafe(no_mangle)]
         pub extern "C" fn nros_platform_task_join(task: *mut ::core::ffi::c_void) -> i8 {
             <$ty as ::nros_platform_api::PlatformThreading>::task_join(task)
         }

--- a/packages/platform/nros-platform-esp-idf/src/platform.c
+++ b/packages/platform/nros-platform-esp-idf/src/platform.c
@@ -661,3 +661,9 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     line[n] = '\0';
     esp_system_abort(line);
 }
+
+/* ESP-IDF is FreeRTOS underneath, so the same self-query applies; IDF always
+ * ships INCLUDE_uxTaskGetStackHighWaterMark, hence no gate. Words to bytes. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+    return (size_t) uxTaskGetStackHighWaterMark(NULL) * sizeof(StackType_t);
+}

--- a/packages/platform/nros-platform-freertos/src/platform.c
+++ b/packages/platform/nros-platform-freertos/src/platform.c
@@ -964,3 +964,16 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     for (;;) {
     }
 }
+
+/* Headroom for the calling task. `uxTaskGetStackHighWaterMark(NULL)` answers
+ * in WORDS of free space, so scale by the stack word size to reach the ABI's
+ * bytes. Gated on INCLUDE_uxTaskGetStackHighWaterMark, which FreeRTOSConfig.h
+ * may leave off; the documented 0 covers that build rather than failing to
+ * link. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+#if (INCLUDE_uxTaskGetStackHighWaterMark == 1)
+    return (size_t) uxTaskGetStackHighWaterMark(NULL) * sizeof(StackType_t);
+#else
+    return 0;
+#endif
+}

--- a/packages/platform/nros-platform-posix/src/platform.c
+++ b/packages/platform/nros-platform-posix/src/platform.c
@@ -1039,3 +1039,14 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     fflush(stderr);
     abort();
 }
+
+/* POSIX has no per-thread stack watermark. `pthread_attr_getstack` gives the
+ * REGION, not the deepest excursion into it, and deriving usage from the
+ * current frame address measures where the probe was called rather than the
+ * worst case -- a number that looks like headroom and is not. Reporting 0
+ * says "not instrumented", which is true and useful; a plausible wrong number
+ * would be neither. A pattern-fill scheme could answer honestly, but it
+ * belongs to whoever owns the stacks, and on this port the kernel does. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+    return 0;
+}

--- a/packages/platform/nros-platform-threadx/src/platform.c
+++ b/packages/platform/nros-platform-threadx/src/platform.c
@@ -911,3 +911,21 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     }
 #endif
 }
+
+/* ThreadX keeps `tx_thread_stack_highest_ptr` only when built with
+ * TX_ENABLE_STACK_CHECKING; without it the field is not maintained and any
+ * number derived from it would be fiction. Headroom is the highest pointer
+ * minus the stack start. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+#ifdef TX_ENABLE_STACK_CHECKING
+    TX_THREAD *self = tx_thread_identify();
+    if (self == TX_NULL || self->tx_thread_stack_highest_ptr == TX_NULL ||
+        self->tx_thread_stack_start == TX_NULL) {
+        return 0;
+    }
+    return (size_t) ((char *) self->tx_thread_stack_highest_ptr -
+                     (char *) self->tx_thread_stack_start);
+#else
+    return 0;
+#endif
+}

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -1199,3 +1199,15 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
     for (;;) {
     }
 }
+
+/* Headroom for the calling thread. `k_thread_stack_space_get` answers in
+ * unused BYTES, which is the ABI's unit, so no conversion. Needs
+ * CONFIG_INIT_STACKS to have painted the stack; without it the kernel has no
+ * watermark to read and returns an error, which becomes the documented 0. */
+size_t nros_platform_task_stack_unused_bytes(void) {
+    size_t unused = 0;
+    if (k_thread_stack_space_get(k_current_get(), &unused) != 0) {
+        return 0;
+    }
+    return unused;
+}


### PR DESCRIPTION
> Stacked on #432 — the rule cannot build without the probe. Review the top commit only, or wait for #432 to land.

## What it does

Turns #432's probe into the sixth monitor rule, so the number reaches `nros-diagnostics` alongside the other five and no caller has to know it exists.

```
rate-hierarchy-runtime   max-age-runtime        max-latency-runtime
deadline-miss-runtime    timer-overrun-runtime  release-jitter-runtime
stack-headroom-runtime   <- new
```

This closes a real workaround downstream: the autoware-safety-island Zephyr lane currently greps `thread_analyzer` printk output in CI to check stack headroom. With this the executor reports it directly, on every port that instruments stacks.

## The bound is declared, and this rule is the one that cannot avoid it

`check_timer_overrun` and `check_release_jitter` both judge against a period the caller already passes in — which is why neither needed a spec table, and I made that argument in both PRs.

**It does not hold here.** The executor never sees `stack_bytes` (it lives in the spawn attr and goes no further), and the total is not portably queryable: FreeRTOS exposes the high-water mark and *not the size it was taken against*. So not even a percentage can be computed, and a minimum has to be stated.

`Executor::set_min_stack_headroom_bytes(n)` is that statement — installed by the entry rather than baked into a contract table, because the entry that spawned the thread is the only party that knows what stack it handed over. `0` (the default) disables the rule, so nothing changes for an image that declares nothing.

If a `TierSpec` field is wanted later, this is the mechanism it would drive.

## Two ways it could invent a fault, both closed

**A port that does not instrument stacks** returns `0` from `stack_unused_bytes`, which means "no data", not "no headroom". The check returns early rather than reporting a breach conjured from an absence — the same reasoning as POSIX returning 0 in #432 instead of a plausible wrong number.

**Headroom hovering just under the bound** would otherwise report every tick. `worst_reported` holds the lowest already seen, so it reports once and then only on a new low. Same delta discipline as the overrun and jitter rules, inverted because for headroom smaller is worse.

## Verification

```
cargo test -p nros-node --features std
  test result: ok. 317 passed; 0 failed
  test result: ok. 5 passed; 0 failed

stack_headroom_rule_tests::a_zero_minimum_disables_the_rule ... ok
stack_headroom_rule_tests::headroom_at_the_bound_is_not_a_breach ... ok
stack_headroom_rule_tests::reports_the_first_breach_with_both_numbers ... ok
stack_headroom_rule_tests::only_a_new_low_is_a_new_fault ... ok
```

Clean on default (no_std) and `alloc`; `cargo fmt` clean.
