### PR TITLE
fix(cli): merge two identical branches in `nros setup`'s remedy print

### DIFF
--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -2791,12 +2791,19 @@ fn run_workspace_scan(
             }
             None => {}
         }
-        if scopes.is_empty() {
-            println!(
-                "      contributors: ./scripts/bootstrap.sh  (or: just setup {})",
-                t.deploy
-            );
-        } else if scopes.iter().any(|s| *s == t.deploy) {
+        // One arm, because both cases end in the same remedy: either no scope
+        // list could be read at all, or the deploy name IS a scope. Split, the
+        // two branches were byte-identical — `clippy::if_same_then_else` — and
+        // the second also spelled a membership test as `iter().any(|s| *s ==
+        // x)`, which is `clippy::manual_contains`. Both are `-D warnings` here,
+        // so this was a hard error in `check test-targets`.
+        //
+        // Behaviour is unchanged. If the two cases were ever meant to say
+        // DIFFERENT things — "no scopes readable" is not the same situation as
+        // "your deploy is a scope" — that is a message to write, not a branch
+        // to keep empty-handed, and it belongs with whoever knows which text
+        // each deserves.
+        if scopes.is_empty() || scopes.contains(&t.deploy) {
             println!(
                 "      contributors: ./scripts/bootstrap.sh  (or: just setup {})",
                 t.deploy


### PR DESCRIPTION
`just check test-targets` fails on **main**:

```
error: this `if` has identical blocks
    --> nros-cli-core/src/cmd/setup.rs:2794:30
error: using `contains()` instead of `iter().any()` is more efficient
    --> nros-cli-core/src/cmd/setup.rs:2799:19
```

`if scopes.is_empty()` and `else if scopes.iter().any(|s| *s == t.deploy)` ran **byte-identical** `println!`s — `clippy::if_same_then_else` — and the second spelled a membership test the long way, `clippy::manual_contains`. Both are `-D warnings` in that lane, so it's a hard error, not a style note.

## The fix

One arm, because both cases end in the same remedy: either no scope list could be read at all, or the deploy name *is* a scope.

Behaviour unchanged, checked as a truth table rather than by eye:

| case | before | after |
|---|---|---|
| empty list | True | True |
| deploy is a scope | True | True |
| deploy not a scope | False | False |

**Left for whoever owns the text:** if those two situations were ever meant to say *different* things — "no scopes readable" is not the same as "your deploy is a scope" — that's a message to write, not a branch to keep saying nothing distinct. Merging preserves today's output rather than inventing tomorrow's.

## How it was found, and why it hid

Turned up while rebasing #447, whose author is sweeping this exact class — their commits call out *"main's eighth silent red today"* and *"main's tenth"*. Two of those had already reached main from elsewhere and dropped out of that rebase as `patch contents already upstream`; this is another they hadn't got to.

It stayed hidden for the documented reason: `test-targets` runs in the **build lane, which no `pull_request` or `merge_group` job runs**, so nothing gates it — the rot `check-gate-visibility` exists to name. `just check fast` is 212/212 and says nothing about it.

## Verified

`check test-targets` green, `check cli-tests` green, `check fast` 212/212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)