### PR TITLE
fix(#0996): every push to main has failed `gate` for five days — a fast gate needed a CLI the push lane does not build

### DIFF
--- a/.config/gate-selftest-baseline.txt
+++ b/.config/gate-selftest-baseline.txt
@@ -101,7 +101,6 @@ scripts/check-zenoh-archive-symbols.sh
 scripts/check-zenohd-flag-invocations.py
 scripts/check-zenohd-resolution-parity.sh
 scripts/check-zenohd-spawn-sites.sh
-scripts/check-zephyr-fixture-rows.py
 scripts/ci/absolute-path-check.sh
 scripts/ci/codegen-invocation-check.sh
 scripts/ci/dep-chain-check.sh

--- a/docs/issues/0996-ci-workflow-audit-tier-promises.md
+++ b/docs/issues/0996-ci-workflow-audit-tier-promises.md
@@ -197,3 +197,61 @@ is an RFC, and no code should be written against it first.
    `container: ci-base`).
 4. Decide the `package.xml`-vs-index question in an RFC before writing code —
    it changes what a `package.xml` in this repo means.
+
+## Addendum (2026-09-05): §2's last green lane has joined the list
+
+The §2 table records `gate.yml` as *"green (the required `CI`)"*. That was true
+of the `pull_request` and `merge_group` arms and is still true of them. It was
+never true of the `push` arm, and I did not check it when I wrote the table.
+
+Every `gate` run on a push to `main` has failed, without interruption, from
+`321642a20` (2026-08-31) to `eac294028` (2026-09-04) — 14 failures in the
+visible window and no success. Two fast-line gates,
+`check-fixtures-manifest` and `check-kconfig-overridden-values`, both reach
+`scripts/build/zephyr-fixture-leaves.sh`, which resolved the pinned make with a
+bare command substitution:
+
+    make_bin="$(nros sdk-path make)/bin/make"
+
+`gate.yml` builds the CLI only on `pull_request`, `merge_group`, `schedule` and
+`workflow_dispatch` — the "Build nros CLI + provision compile-tier sources" step
+carries that `if:`. So on a plain `push` there is no `nros`, the substitution
+exits 127, and `set -euo pipefail` takes the emitter and both gates with it:
+
+    zephyr-fixture-rows: emitter failed (rc=127):
+    scripts/build/zephyr-fixture-leaves.sh: line 181: nros: command not found
+
+This is §2's own thesis one lane over, and it cost exactly what §2 says it
+costs: for five days those two gates could not have reported a regression on the
+event they still ran on, and nobody could have told a new failure from the
+standing one. It also means the last "green" entry in the table was a lane
+selected for greenness — the arm that was red was simply not looked at.
+
+The rule CLAUDE.md already states covers it: *a gate in an affordability tier
+may only resolve artifacts the JOB ITSELF builds*. `check-lane-contracts`
+enforces that, but its `GATING_EVENTS` is `{"pull_request", "merge_group"}` —
+`push` is out of scope, which is why the gate that exists for this class did not
+fire.
+
+**Fixed** by guarding the resolution the way its own sibling in
+`check-tier-preconditions.sh` already did (`command -v nros` first, `command -v
+make` as the documented fallback), and by giving
+`scripts/check-zephyr-fixture-rows.py` a self-test that runs the emitter with
+every `nros`-bearing directory removed from `PATH`. That control reproduces the
+CI failure locally, on a host that has the CLI, in 0.4 s — the mutation test is
+in the commit message.
+
+Swept: with `nros` off `PATH`, all 212 fast-line gates pass. No other fast gate
+depends on the CLI.
+
+**Still open here**, and deliberately not done in that commit: extending
+`check-lane-contracts`' `GATING_EVENTS` to cover the `push` arm, so the class is
+caught structurally rather than by one gate's own control. That is the fifth
+item in the order below.
+
+## Order to fix (5)
+
+5. Decide whether `check-lane-contracts` should hold the `push` arm of
+   `gate.yml` to the same artifact rule as the merge-gating arms. If it should,
+   the fix is one entry in `GATING_EVENTS`; if it should not, the reason belongs
+   in that file, because the next person will ask.

--- a/scripts/build/zephyr-fixture-leaves.sh
+++ b/scripts/build/zephyr-fixture-leaves.sh
@@ -178,10 +178,29 @@ if [ -z "$toolchain_cache_dir" ]; then
     toolchain_cache_dir="$nros_root/build/zephyr-cache/ToolchainCapabilityDatabase"
 fi
 if [ -z "$make_bin" ]; then
-    make_bin="$(nros sdk-path make)/bin/make"
-    if [ ! -x "$make_bin" ]; then
-        make_bin="$(command -v make)"
+    # `nros` is NOT on PATH in every lane that emits records, and this mode is a
+    # pure emitter that never runs make -- it only names it in the signature.
+    # `gate.yml` builds the CLI only on pull_request/merge_group/schedule/
+    # dispatch, so on a `push` there is no `nros`, and an unguarded call exits
+    # 127 under `set -e` and takes the whole gate with it. That is what
+    # `check-fixtures-manifest` and `check-kconfig-overridden-values` did on
+    # EVERY push to main, from 2026-08-31 (321642a20, which introduced this
+    # resolution) until 2026-09-05 -- a uniformly red lane, which is the one
+    # state that cannot report a regression.
+    #
+    # The guarded shape is not new: `check-tier-preconditions.sh` resolves the
+    # same tool the same way and already carries the `command -v` test. This is
+    # its unguarded sibling.
+    _sdk_make=""
+    if command -v nros >/dev/null 2>&1; then
+        _sdk_make="$(nros sdk-path make 2>/dev/null || true)"
     fi
+    if [ -n "$_sdk_make" ] && [ -x "$_sdk_make/bin/make" ]; then
+        make_bin="$_sdk_make/bin/make"
+    else
+        make_bin="$(command -v make || true)"
+    fi
+    unset _sdk_make
 fi
 
 log_dir="$nros_root/build/zephyr-fixtures"

--- a/scripts/check-zephyr-fixture-rows.py
+++ b/scripts/check-zephyr-fixture-rows.py
@@ -31,6 +31,7 @@ equality. A missing leaf and an orphan row are both caught, on every host, and
 the cyclonedds rows are simply out of scope where cyclonedds is.
 """
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -45,7 +46,7 @@ ROLES = ("talker", "listener", "service-server", "service-client",
          "action-server", "action-client")
 
 
-def emitted_leaves():
+def emitted_leaves(env=None):
     """Every leaf the emitter would build. Read-only: it runs no build tool."""
     proc = subprocess.run(
         [
@@ -53,7 +54,7 @@ def emitted_leaves():
             "--emit", "records",
             "--include-workspace-entry",
         ],
-        capture_output=True, text=True, cwd=REPO,
+        capture_output=True, text=True, cwd=REPO, env=env,
     )
     if proc.returncode != 0:
         print(f"zephyr-fixture-rows: emitter failed (rc={proc.returncode}):\n{proc.stderr}",
@@ -99,7 +100,82 @@ def manifest_rows():
     return out
 
 
+def path_without_nros():
+    """A PATH with every directory holding an `nros` executable removed.
+
+    Not an empty PATH: the emitter legitimately needs bash, realpath, git and
+    friends. Only the CLI goes.
+    """
+    keep = []
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        if not d:
+            continue
+        cand = Path(d) / "nros"
+        if cand.exists() and os.access(cand, os.X_OK):
+            continue
+        keep.append(d)
+    return os.pathsep.join(keep)
+
+
+def self_test(quiet=False):
+    """Negative control: the emitter must work with NO `nros` on PATH.
+
+    WHY. `gate.yml` builds the CLI only on pull_request/merge_group/schedule/
+    dispatch, so on a plain `push` to main there is no `nros`. From 2026-08-31
+    (321642a20, which made `make` come from the SDK store) until 2026-09-05 the
+    emitter resolved it with a bare `$(nros sdk-path make)`, which exits 127
+    under `set -e` -- so THIS gate and `check-kconfig-overridden-values` failed
+    on every push to main for five days. A lane that is uniformly red cannot
+    report a regression, which is the whole cost: the two gates went on looking
+    like gates while guarding nothing on the one event they still ran on.
+
+    It is a control rather than a comment because the emitter has three
+    CLI-derived inputs now (`nros sdk-path`, `nros_cargo_codegen_c_bin`, and
+    whatever the next one is) and each is one unguarded `$(...)` away from the
+    same 127.
+
+    Runs on the NORMAL path, not behind a flag: a control nobody runs decays
+    into a comment, and `check-gate-selftests` holds this file to that. ~0.4 s.
+    """
+    env = dict(os.environ)
+    env["PATH"] = path_without_nros()
+    if shutil.which("nros", path=env["PATH"]) is not None:
+        # Nothing to prove on a host where the CLI cannot be taken off PATH.
+        if not quiet:
+            print("zephyr-fixture-rows self-test: SKIPPED (nros not removable from PATH)")
+        return 0
+
+    bare = emitted_leaves(env=env)
+
+    # The identity tuple must not depend on the CLI at all. It resolves the
+    # codegen tool and `make`, both of which land in the SIGNATURE and in no
+    # identity field -- so a difference here means a CLI-derived value has
+    # leaked into the matrix, which would make the push lane and the PR lane
+    # disagree about which fixtures exist.
+    full = emitted_leaves()
+    if bare != full:
+        only_full = sorted(full - bare)
+        only_bare = sorted(bare - full)
+        print("zephyr-fixture-rows self-test FAILED: the emitted leaf SET depends on\n"
+              "  whether the nros CLI is on PATH. It must not -- the CLI resolves the\n"
+              "  codegen tool and `make`, which are signature inputs, not identity.\n"
+              f"  only with the CLI: {only_full}\n"
+              f"  only without it:   {only_bare}", file=sys.stderr)
+        return 1
+
+    if not quiet:
+        print(f"zephyr-fixture-rows self-test: OK ({len(bare)} leaf/leaves with no CLI on PATH)")
+    return 0
+
+
 def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+    # Always, not only behind the flag. See `scripts/check-board-tiers.py`.
+    rc = self_test(quiet=True)
+    if rc:
+        return rc
+
     emitted = emitted_leaves()
     rows = manifest_rows()
 


### PR DESCRIPTION
## The failure

`gate.yml` builds the nros CLI only on `pull_request`, `merge_group`, `schedule` and `workflow_dispatch`. On a plain `push` to main there is no `nros` on PATH.

Since `321642a20` (2026-08-31), `scripts/build/zephyr-fixture-leaves.sh` resolved the pinned make with a bare command substitution:

```sh
make_bin="$(nros sdk-path make)/bin/make"
```

Under `set -euo pipefail` that exits 127 and takes with it the two fast-line gates that reach the emitter — `check-fixtures-manifest` and `check-kconfig-overridden-values`:

```
zephyr-fixture-rows: emitter failed (rc=127):
scripts/build/zephyr-fixture-leaves.sh: line 181: nros: command not found
```

**Every `gate` run on a push to main has failed since — 14 failures in the visible window, no successes, through `eac294028`.** The two gates went on looking like gates while guarding nothing on the one event they still ran on. That is CLAUDE.md's own *"a uniformly-red lane has NO signal capacity"*, and issue 0996 §2's thesis one lane over. §2 records `gate.yml` as the last green lane; that was true of its PR and merge-queue arms, and the push arm was never checked.

The guarded shape was not new: `scripts/check-tier-preconditions.sh` resolves the same tool for the same reason and already carried the `command -v nros` test. This was its unguarded sibling — and the emitter's own `--help` already documented the fallback it could not reach (*"when nros is unavailable"*).

## What changed

- The resolution is guarded and the documented `command -v make` fallback is reachable. `make_bin` is a **signature** input and is never executed by this mode, which emits records and runs no build tool.
- `scripts/check-zephyr-fixture-rows.py` gains a self-test that runs the emitter with every `nros`-bearing directory stripped from PATH, and asserts the emitted leaf **set** is unchanged — the CLI resolves the codegen tool and make, both signature inputs and neither an identity field, so a difference would mean the push lane and the PR lane disagree about which fixtures exist. Normal path, ~0.4 s; `check-gate-selftests` drops it from the baseline.

## Evidence

**Mutation test** — restore the unguarded substitution and the control fires on a host that *has* the CLI, reproducing CI's message locally:

```
zephyr-fixture-rows: emitter failed (rc=127):
.../zephyr-fixture-leaves.sh: line 194: nros: command not found
```

**Sweep** — `just check fast` with every `nros`-bearing PATH entry stripped: **212/212 gates pass**. No other fast-line gate depends on the CLI. (Two format gates fail in a fresh worktree for an unrelated reason: the pinned clang-format lives at `build/clang-format/bin/`, which a new worktree lacks. Both pass once it is present.)

## Not done, deliberately

`check-lane-contracts` exists for exactly this class — *a gate in an affordability tier may only resolve artifacts the job itself builds* — but its `GATING_EVENTS` is `{pull_request, merge_group}`, so the push arm is out of scope and **the gate for this class could not fire**. Whether it should cover `push` is a decision rather than a cleanup; it is recorded as item 5 in issue 0996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj