### PR TITLE
fix(#1070): `--sudo` no longer requires `--system` — issue 1038's `--tool` form was unreachable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -320,10 +320,17 @@ jobs:
       # appropriate; the default still refuses and prints the command, which is
       # the right behaviour on a developer's machine.
       #
-      # NOT the cause of this cell's RED — that is issue 1025 (#303), where the
-      # flash packer looks in a directory the build stopped using. This step
-      # stops the ESP32 e2e from SKIPPING for want of a QEMU that knows
-      # `esp32c3`, which is a coverage hole that reads as green.
+      # This step stops the ESP32 e2e from SKIPPING for want of a QEMU that
+      # knows `esp32c3`, which is a coverage hole that reads as green.
+      #
+      # It could never have done that until now: `--sudo` carried
+      # `requires = "system"` in clap, so this exact line exited 2 on a usage
+      # error before installing anything, and every step after it was skipped —
+      # including `Build (esp32)`. The comment that used to sit here said the
+      # cell's red was issue 1025 and not this step; with 1025 fixed (#303) the
+      # red simply moved here, which is how the contradiction surfaced. The
+      # `--tool ... --sudo` form the help text has promised since issue 1038 is
+      # reachable as of this branch.
       - name: Provision esp32-qemu's declared system deps (issue 1038)
         if: matrix.plat == 'esp32'
         run: |

--- a/docs/issues/archived/1065-esp32-build-qemu-recipe-has-no-lane.md
+++ b/docs/issues/archived/1065-esp32-build-qemu-recipe-has-no-lane.md
@@ -1,7 +1,7 @@
 ---
 id: 1065
-title: "`just esp32 build-qemu` is run by no lane, so it can be wholly broken with every test green"
-status: open
+title: "RETRACTED — `just esp32 build-qemu` does have a lane; the premise was a truncated grep"
+status: wontfix
 area: testing
 severity: medium
 related: [1025, 0196, 0883]
@@ -89,3 +89,68 @@ path has no coverage from those tests, however green they are. The test proves
 the SECOND path. Any recipe the book or `just --list` offers a human should have
 one lane that invokes it the way a human would — otherwise its correctness is
 asserted only by the last person who happened to run it.
+
+
+---
+
+# RETRACTED (2026-09-05). The premise is false.
+
+`just esp32 build-qemu` **is** run by a lane, and that lane **did** report issue
+1025, loudly, every night.
+
+## What I got wrong, and how
+
+`just/esp32.just:241` reads:
+
+```
+build-fixtures: build-qemu build-logging-smoke
+```
+
+and `build-all: build build-examples build-fixtures`, which is what
+`nightly.yml`'s `Build (${{ matrix.plat }})` step runs on the schedule path. So
+the chain `build-all -> build-fixtures -> build-qemu` has always existed.
+
+I missed it because the grep I based this issue on ended in `| head -10`, and
+that line was the eleventh. Everything downstream followed from a truncated
+command whose truncation I never checked — the same shape as the
+`nm ... 2>/dev/null | grep -c` probe earlier in this same investigation, where a
+command that could not answer was read as an answer.
+
+## The claim that should have caught it
+
+I wrote that 1025 "stayed that way through many green CI runs". I did not look at
+a single run. They were not green. From the 2026-09-04 scheduled nightly, job
+`esp32`, step `Build (esp32)`:
+
+```
+ERROR: /__w/nano-ros/nano-ros/build/cargo-fixtures/qemu-esp32-baremetal/
+       riscv32imc-unknown-none-elf/nros-relwithdebinfo/esp32_qemu_talker is
+       missing, and nothing narrowed this build.
+error: recipe `build-qemu` failed with exit code 1
+```
+
+That is issue 1025, named exactly, by the lane this issue says does not exist.
+The workflow even carries a comment saying so: *"NOT the cause of this cell's RED
+— that is issue 1025 (#303)"*. The evidence was in the repo I was editing.
+
+## What survives
+
+One change, kept and landed separately: `build-qemu` now asserts its OUTPUT
+rather than espflash's exit code. That stands on its own — the recipe's history
+is of exiting 0 while producing nothing (issue 0181), and the existing guard
+covers only a missing INPUT.
+
+## What is actually worth pursuing
+
+The esp32 cell is red across every run in the scanned window (`just
+nightly-triage`: *"red across all 3 scanned run(s)"*). That is the real
+signal-capacity problem CLAUDE.md describes — a uniformly red lane cannot
+report a NEW regression, because the new one looks like yesterday's. With #303
+merged, the next nightly should show whether anything else is behind it; the log
+also carries `nros setup --tool esp32-qemu: needs 3 system package(s) this host
+is missing: libglib2-dev, libpixman-dev, libgcrypt-dev`, whose `[prereq.*]`
+declarations are CORRECT (`apt = ["libglib2.0-dev"]` etc.), so that is a
+provisioning question and not a naming one.
+
+File that against the measured state after a green-or-not nightly, rather than
+inheriting this issue's guesses.

--- a/docs/issues/archived/1070-sudo-with-tool-unreachable-blocks-esp32-lane.md
+++ b/docs/issues/archived/1070-sudo-with-tool-unreachable-blocks-esp32-lane.md
@@ -1,0 +1,80 @@
+---
+id: 1070
+title: "`--sudo` required `--system` in clap, so issue 1038's `--tool <name> --sudo` was unreachable and the nightly esp32 lane never built"
+status: resolved
+area: cli
+severity: high
+related: [1038, 1025, 0062]
+---
+
+## What
+
+`nros setup`'s `--sudo` flag carried `requires = "system"`:
+
+```rust
+/// issue 1038 — ALSO applies to `--tool`: a tool declaring its own
+/// `[tool.<name>] system = [..]` build deps installs them instead of
+/// bailing with a line for a human to copy.
+#[arg(long, requires = "system", conflicts_with = "check")]
+pub sudo: bool,
+```
+
+The doc comment and the attribute contradict each other. The install path for
+the `--tool` form exists and is correct (`setup.rs`, the `run_sudo` branch that
+prints `nros setup --tool {name} --sudo: running:`), and **clap rejected every
+invocation that could reach it**. `nros setup --tool esp32-qemu --sudo` exited 2
+on `the following required arguments were not provided: --system`.
+
+So issue 1038 shipped a feature nothing could call.
+
+## How it surfaced
+
+`nightly.yml` runs exactly that line:
+
+```yaml
+- name: Provision esp32-qemu's declared system deps (issue 1038)
+  run: nros setup --tool esp32-qemu --sudo
+```
+
+It exited 2, and because it is a plain step, **every step after it was skipped —
+including `Build (esp32)`**. The esp32 cell was red in every nightly.
+
+It stayed invisible because a DIFFERENT failure was in front of it. While issue
+1025 was live, `Build (esp32)` ran and failed on the flash packer, so that is
+what the log showed and what the workflow comment blamed:
+
+> NOT the cause of this cell's RED — that is issue 1025 (#303), where the flash
+> packer looks in a directory the build stopped using.
+
+That comment was correct about 1025 and wrong to acquit this step. With #303
+merged, a dispatched nightly on `main` moved the failure from `Build (esp32)` to
+this step, with everything after it skipped — which is what named it.
+
+Two independent faults in one lane, the second only observable once the first
+was gone. A red lane reports its FIRST failure, not its faults.
+
+## Fix
+
+`--sudo` no longer requires `--system`. It is validated in `run()` instead,
+which can say which of the two forms is missing rather than naming one of them:
+
+```
+`--sudo` executes an install and needs to know WHAT to install.
+  --system --sudo         the `[system.*]` OS-package closure
+  --tool <name> --sudo    that tool's own `[tool.<name>] system = [..]` build deps
+```
+
+`conflicts_with = "check"` stays — one reports, the other acts.
+
+Regression test: `sudo_parses_with_tool_as_well_as_system`, at PARSE level,
+because the defect was parse-level. The install code underneath was correct and
+unreachable, so no test of that code could have failed. Verified in both
+directions — restoring `requires = "system"` fails the test with
+`MissingRequiredArgument`.
+
+## Why no test caught it before
+
+The feature's acceptance was the install BEHAVIOUR, and that behaviour was
+correct. Nothing asserted the CLI could be invoked in the shape the feature
+documented. A flag's reachability is part of its contract, and the only place
+that shows is argument parsing.

--- a/just/esp32.just
+++ b/just/esp32.just
@@ -178,6 +178,15 @@ build-qemu:
             exit 1
         fi
         espflash save-image --chip esp32c3 --flash-size 4mb --merge "$elf" "$out"
+        # Issue 1065 — assert the ARTIFACT, not the exit code. This recipe's own
+        # history is of exiting 0 while producing nothing (#181: espflash opening
+        # a nonexistent path while the lane went green), and the guard above only
+        # covers a missing INPUT. A packer that writes no output, or an empty
+        # one, is the same lie one step later.
+        if [ ! -s "$out" ]; then
+            echo "ERROR: espflash exited 0 but $out is missing or empty." >&2
+            exit 1
+        fi
         echo "  $out"
     done
     echo "ESP32 QEMU examples built!"

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -145,7 +145,14 @@ pub struct Args {
     /// issue 1038 — ALSO applies to `--tool`: a tool declaring its own
     /// `[tool.<name>] system = [..]` build deps installs them instead of
     /// bailing with a line for a human to copy.
-    #[arg(long, requires = "system", conflicts_with = "check")]
+    ///
+    /// NOT `requires = "system"`. It was, and that made the `--tool` half above
+    /// UNREACHABLE: the implementation for it has existed since issue 1038 and
+    /// the parser rejected every invocation that could reach it, so
+    /// `nros setup --tool esp32-qemu --sudo` exited 2 on a clap usage error
+    /// while the doc comment promised it worked. Validated below instead, where
+    /// the message can say which of the two flags is missing.
+    #[arg(long, conflicts_with = "check")]
     pub sudo: bool,
 }
 
@@ -221,6 +228,16 @@ pub fn run(args: Args) -> Result<()> {
     if let Some(ws) = args.workspace_scan.clone() {
         let root = args.index.parent().map(std::path::Path::to_path_buf);
         return run_workspace_scan(&index, &ws, root.as_deref());
+    }
+    // `--sudo` means "execute the install", and there are exactly two things it
+    // can install: the `[system.*]` closure (`--system`) or a tool's own
+    // `[tool.<name>] system = [..]` build deps (`--tool`). Alone it names no
+    // target. Checked here rather than as `requires = "system"` on the arg,
+    // which is what made the `--tool` form unreachable (issue 1038).
+    if args.sudo && !args.system && args.tool.is_none() {
+        bail!(
+            "`--sudo` executes an install and needs to know WHAT to install.\n               --system --sudo   the `[system.*]` OS-package closure\n               --tool <name> --sudo   that tool's own `[tool.<name>] system = [..]` build deps"
+        );
     }
     if args.system {
         // The index lives AT the repo root, so its parent is the base a
@@ -2911,5 +2928,43 @@ mod workspace_scan_tests {
     #[test]
     fn no_export_yields_no_target() {
         assert!(deploy_targets("<package><name>x</name></package>").is_empty());
+    }
+
+    /// Issue 1038's `--tool <name> --sudo` must PARSE.
+    ///
+    /// It did not, for as long as the feature existed: `--sudo` carried
+    /// `requires = "system"`, so clap rejected the one spelling that reaches
+    /// the `--tool` install path — exit 2 on a usage error, while the flag's
+    /// own doc comment promised the form worked. The nightly esp32 lane ran
+    /// this exact line and skipped every step after it.
+    ///
+    /// A parse-level test, because the defect was parse-level: the install code
+    /// underneath was correct and unreachable, so no test of THAT could have
+    /// failed.
+    #[test]
+    fn sudo_parses_with_tool_as_well_as_system() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(flatten)]
+            args: Args,
+        }
+
+        let tool = Cli::try_parse_from(["nros", "--tool", "esp32-qemu", "--sudo"])
+            .expect("`--tool <name> --sudo` must parse (issue 1038)");
+        assert!(tool.args.sudo);
+        assert_eq!(tool.args.tool.as_deref(), Some("esp32-qemu"));
+
+        let system = Cli::try_parse_from(["nros", "--system", "--sudo"])
+            .expect("`--system --sudo` must parse");
+        assert!(system.args.sudo && system.args.system);
+
+        // Still mutually exclusive with `--check`: one reports, the other acts.
+        assert!(Cli::try_parse_from(["nros", "--system", "--sudo", "--check"]).is_err());
+
+        // `--sudo` alone parses now — it is rejected in `run()` with a message
+        // naming both valid forms, which a clap `requires` cannot express.
+        assert!(Cli::try_parse_from(["nros", "--sudo"]).is_ok());
     }
 }


### PR DESCRIPTION
You asked me to check the esp32 nightly after #303 merged. I dispatched one on `main`, and the failure **moved** — which named a second, independent fault.

## The bug

```rust
/// issue 1038 — ALSO applies to `--tool`: a tool declaring its own
/// `[tool.<name>] system = [..]` build deps installs them instead of
/// bailing with a line for a human to copy.
#[arg(long, requires = "system", conflicts_with = "check")]
pub sudo: bool,
```

The doc comment and the attribute contradict each other, and the attribute won. `nros setup --tool esp32-qemu --sudo` exited **2** on `the following required arguments were not provided: --system`. The install path for the `--tool` form exists and is correct — clap rejected every invocation that could reach it. **Issue 1038 shipped a feature nothing could call.**

## Why the whole esp32 lane was red

`nightly.yml` runs exactly that line. It exited 2, and being a plain step, **every step after it was skipped — including `Build (esp32)`**.

It stayed invisible because another failure stood in front of it. While #1025 was live, `Build (esp32)` ran and failed on the flash packer, so that's what the log showed and what the workflow comment blamed:

> NOT the cause of this cell's RED — that is issue 1025 (#303) …

Correct about 1025; wrong to acquit this step. With #303 merged, the dispatched run moved the failure here, everything after skipped. **Two independent faults in one lane, the second only observable once the first was gone** — a red lane reports its first failure, not its faults.

## Fix

Validated in `run()` rather than on the arg, so the message names *both* forms:

```
`--sudo` executes an install and needs to know WHAT to install.
  --system --sudo         the `[system.*]` OS-package closure
  --tool <name> --sudo    that tool's own `[tool.<name>] system = [..]` build deps
```

`conflicts_with = "check"` stays — one reports, the other acts.

## Test

`sudo_parses_with_tool_as_well_as_system`, at **parse** level, because the defect was parse-level: the install code underneath was correct and unreachable, so no test of *that* could have failed. Verified both directions — restoring `requires = "system"` fails it with `MissingRequiredArgument`.

**Why nothing caught it before:** the feature's acceptance was the install *behaviour*, which was correct. Nothing asserted the CLI could be invoked in the shape the feature documented. A flag's reachability is part of its contract, and the only place that shows is argument parsing.

`just check fast`: 212/212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)