### PR TITLE
docs(#1025): salvage the prose from #422 before closing it as superseded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -737,6 +737,18 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   fields (`Z_FEATURE_LOCAL_QUERYABLE`…) make mismatched TUs a silent ABI break (queries went
   session-local-only). `build_c_shim` injects `ZENOH_GENERIC` + the OUT_DIR config. → issue 0135
   (archived). Local fixture binaries embed the shim — rebuild fixtures after zpico config changes.
+- **One FORMULA is not enough — the INPUTS are derived twice too (issue 1025).** The group key
+  is a function of (platform, cargo args, env); `just esp32 build-qemu` called the shared helper
+  with the platform and `"" ""`, the producer passed the ROW's, and supplying two of the three
+  constants a different answer. It agreed until the esp32 rows gained
+  `env = { ZPICO_MAX_QUERYABLES = "2" }`, after which NO esp32 flash image could be packed. Not
+  silently: the nightly esp32 lane went red and printed this exact path every night. It survived
+  because the PUSH gates are green either way — the packer runs in `build-all`, which only the
+  schedule reaches — and because a lane already red reports its FIRST failure, so a second fault
+  behind it (issue 1070) stayed invisible until this one was fixed. A consumer that did not itself run the build names the ROW:
+  `nros_fixture_row_artifact_dir_by_id <row-id>`. Gate: `check-fixture-artifact-dir-inputs`
+  (a packer of a lane-built artifact must derive its row's args and env from the manifest, not
+  supply them); acceptance is still a BUILD, never a gate.
 - **A lib reached through a raw `-Wl,...` link FLAG gets no rebuild edge (issue 0475)** — CMake cannot
   see a file inside a flag string, and `add_dependencies()` only adds build ORDER, which ninja renders
   `||` (order-only): "must exist before linking", never "relink when it changes". The RMW backends are

--- a/book/src/reference/build-commands.md
+++ b/book/src/reference/build-commands.md
@@ -272,7 +272,11 @@ can carry a hash suffix when a row builds with distinct env, so treat
 the path above as *what it is on a default build*, not as a guarantee —
 `scripts/build/fixtures-target-dir.sh` (`nros_fixture_row_artifact_dir`)
 is the single source of truth, and it is what the test side uses to
-find the same file.
+find the same file. That helper takes the row's cargo args and env as
+arguments, so a script that did not itself run the build should ask for
+the row by id — `nros_fixture_row_artifact_dir_by_id <row-id>` reads all
+three key fields from the manifest, and cannot disagree with the builder
+about which group a row landed in (issue 1025).
 
 Run `just qemu help` for more options.
 


### PR DESCRIPTION
Two sessions fixed #1025 independently. Mine merged (#303 — the by-id helper plus `check-fixture-artifact-dir-inputs`). #422 carries the same fix with a differently-named gate (`-keys`) and, uniquely, a CLAUDE.md entry and a book paragraph.

Two gates for one rule is exactly the drift the repo warns about, so the gate goes. The prose is worth keeping, and is what closing #422 would have dropped silently.

## Changed while salvaging

**Gate name** corrected to the one that actually merged (`-inputs`, not `-keys`), along with its stated scope.

**A false claim removed.** #422's text says no flash image could be packed *"for four days with every gate green"*. That's wrong, and CLAUDE.md is loaded every session — it would have taught the wrong lesson permanently. The nightly esp32 lane **went red and printed the exact failing path every night**.

What's true is narrower and more useful, so that's what the entry now says:

- the **push** gates are green either way, because the packer runs in `build-all` and only the schedule reaches it;
- a lane already red reports its **first** failure — which is why #1070 sat behind this one, invisible until it was fixed.

Follow-up: #422 closes as superseded once this lands.

Docs only. `just check fast`: 212/212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)