### PR TITLE
feat(sched): alive supervision — report a context that stopped running

### DIFF
--- a/packages/core/nros-node/src/executor/monitor.rs
+++ b/packages/core/nros-node/src/executor/monitor.rs
@@ -180,8 +180,7 @@ pub const MAX_VIOLATIONS: usize = 8;
 pub struct Violation {
     /// `"rate-hierarchy-runtime"` | `"max-age-runtime"` |
     /// `"max-latency-runtime"` | `"deadline-miss-runtime"` |
-    /// `"timer-overrun-runtime"` | `"release-jitter-runtime"` |
-    /// `"stack-headroom-runtime"`.
+    /// `"stack-headroom-runtime"` | `"alive-supervision-runtime"`.
     pub rule: &'static str,
     /// Violating endpoint ref (from the spec's `fqn`; the SC name for
     /// deadline misses).
@@ -716,6 +715,160 @@ mod publish_stamp_tests {
             0,
             "no stamp means no observation, not an enormous age"
         );
+    }
+}
+
+/// Per-SchedContext liveness accounting, one per SC slot.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AliveState {
+    pub opened: bool,
+    pub window_start_us: u64,
+    pub count_at_window_start: u32,
+    /// Report-once-until-recovery, matching the rate rule.
+    pub violated_last_window: bool,
+}
+
+impl Default for AliveState {
+    fn default() -> Self {
+        Self {
+            opened: false,
+            window_start_us: 0,
+            count_at_window_start: 0,
+            violated_last_window: false,
+        }
+    }
+}
+
+/// Report a SchedContext that has not dispatched AT ALL over a full window
+/// while declaring a period that says it should have.
+///
+/// AUTOSAR's Watchdog Manager separates ALIVE supervision -- did it run at
+/// all, at roughly the right rate -- from DEADLINE supervision, did it finish
+/// in time. Every rule here is the second kind or a variant of it: they fire
+/// when something happens and is wrong. Nothing fires when a callback stops
+/// happening altogether.
+///
+/// `rate-hierarchy-runtime` does not cover it. That rule counts PUBLISHES on
+/// a contracted publisher, so a timer callback that silently stops firing
+/// while its topic is published from elsewhere -- another tier, a bridge, a
+/// republisher -- leaves it satisfied. The gap is a callback, not an
+/// endpoint.
+///
+/// The bound needs no declaration: `period_us` is already on the SC, and a
+/// context claiming a period that produced no activation in a window many
+/// times longer than it is a contract failure for any period. `period_us ==
+/// 0` declares no cadence, so nothing is judged.
+///
+/// ZERO, not a fraction. A throttled-but-alive context is a different fault
+/// with different evidence -- `SporadicState` already counts window skips and
+/// dispatches for exactly that -- and picking a percentage here would invent
+/// a tolerance nobody declared. Zero activations against a declared period is
+/// unambiguous.
+pub(crate) fn check_alive(
+    period_us: u64,
+    dispatches: u32,
+    state: &mut AliveState,
+    now_us: u64,
+) -> Option<Violation> {
+    if period_us == 0 {
+        return None;
+    }
+    if !state.opened {
+        state.opened = true;
+        state.window_start_us = now_us;
+        state.count_at_window_start = dispatches;
+        return None;
+    }
+    let window_us = now_us.saturating_sub(state.window_start_us);
+    if window_us < RATE_CHECK_INTERVAL_US {
+        return None;
+    }
+    let fired = dispatches.wrapping_sub(state.count_at_window_start);
+    state.window_start_us = now_us;
+    state.count_at_window_start = dispatches;
+
+    // Only judge a window long enough to have contained an activation. A
+    // period longer than the check interval is not late merely for not having
+    // fired yet.
+    if window_us < period_us {
+        return None;
+    }
+    if fired > 0 {
+        state.violated_last_window = false;
+        return None;
+    }
+    if state.violated_last_window {
+        return None; // still silent — already reported
+    }
+    state.violated_last_window = true;
+    Some(Violation {
+        rule: "alive-supervision-runtime",
+        // SCs carry no name at this altitude; same stand-in as the deadline
+        // rule, which reports against the SC too.
+        fqn: "sched-context",
+        measured: 0,
+        declared: (window_us / period_us).min(u32::MAX as u64) as u32,
+    })
+}
+
+#[cfg(test)]
+mod alive_supervision_tests {
+    use super::*;
+
+    const W: u64 = RATE_CHECK_INTERVAL_US;
+
+    #[test]
+    fn a_zero_period_declares_no_cadence() {
+        let mut st = AliveState::default();
+        assert!(check_alive(0, 0, &mut st, 0).is_none());
+        assert!(check_alive(0, 0, &mut st, W * 4).is_none());
+    }
+
+    /// The first observation opens the window; there is no verdict yet.
+    #[test]
+    fn the_first_window_only_opens() {
+        let mut st = AliveState::default();
+        assert!(check_alive(1_000, 0, &mut st, 0).is_none());
+        assert!(st.opened);
+    }
+
+    #[test]
+    fn silence_across_a_full_window_reports() {
+        let mut st = AliveState::default();
+        check_alive(1_000, 0, &mut st, 0);
+        let v = check_alive(1_000, 0, &mut st, W).expect("no dispatch in a full window");
+        assert_eq!(v.rule, "alive-supervision-runtime");
+        assert_eq!(v.measured, 0);
+        assert_eq!(v.declared, (W / 1_000) as u32);
+    }
+
+    /// Any activation at all clears it -- this rule asks whether the context
+    /// is alive, not whether it is keeping up.
+    #[test]
+    fn a_single_dispatch_is_enough() {
+        let mut st = AliveState::default();
+        check_alive(1_000, 0, &mut st, 0);
+        assert!(check_alive(1_000, 1, &mut st, W).is_none());
+    }
+
+    /// Report once, then stay quiet until it recovers, like the rate rule.
+    #[test]
+    fn continued_silence_is_not_a_new_fault() {
+        let mut st = AliveState::default();
+        check_alive(1_000, 0, &mut st, 0);
+        assert!(check_alive(1_000, 0, &mut st, W).is_some());
+        assert!(check_alive(1_000, 0, &mut st, W * 2).is_none());
+        // Recovery, then silence again, reports afresh.
+        assert!(check_alive(1_000, 5, &mut st, W * 3).is_none());
+        assert!(check_alive(1_000, 5, &mut st, W * 4).is_some());
+    }
+
+    /// A period longer than the window has not had its chance yet.
+    #[test]
+    fn a_period_longer_than_the_window_is_not_judged() {
+        let mut st = AliveState::default();
+        check_alive(W * 10, 0, &mut st, 0);
+        assert!(check_alive(W * 10, 0, &mut st, W).is_none());
     }
 }
 

--- a/packages/core/nros-node/src/executor/monitor.rs
+++ b/packages/core/nros-node/src/executor/monitor.rs
@@ -719,24 +719,18 @@ mod publish_stamp_tests {
 }
 
 /// Per-SchedContext liveness accounting, one per SC slot.
-#[derive(Debug, Clone, Copy)]
+///
+/// `Default` is DERIVED, not hand-written: every field's default is its type's
+/// own (`false`, `0`), so a manual impl restates four of them and is one edit
+/// away from disagreeing with the struct — `clippy::derivable_impls` is a
+/// `-D warnings` error in the embedded lane, which is where this was caught.
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct AliveState {
     pub opened: bool,
     pub window_start_us: u64,
     pub count_at_window_start: u32,
     /// Report-once-until-recovery, matching the rate rule.
     pub violated_last_window: bool,
-}
-
-impl Default for AliveState {
-    fn default() -> Self {
-        Self {
-            opened: false,
-            window_start_us: 0,
-            count_at_window_start: 0,
-            violated_last_window: false,
-        }
-    }
 }
 
 /// Report a SchedContext that has not dispatched AT ALL over a full window

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1471,6 +1471,12 @@ pub struct Executor<'s> {
     /// image; every monitor path below folds away).
     pub(crate) monitor_table: &'static [super::monitor::MonitorSpec],
     pub(crate) monitor_states: [super::monitor::MonitorState; super::monitor::MAX_MONITORS],
+    /// Dispatches per SchedContext, for alive supervision. Counted in the
+    /// dispatch path where the SC index is already resolved, and read once
+    /// per monitor tick. A fixed array like `monitor_states`, not an arena
+    /// allocation: MAX_SC is a build-time constant (8 by default).
+    pub(crate) sc_dispatches: [u32; crate::config::MAX_SC],
+    pub(crate) alive_states: [super::monitor::AliveState; crate::config::MAX_SC],
     /// W3b.5 — baked subscriber age-contract table (empty = none).
     pub(crate) age_table: &'static [super::monitor::AgeMonitorSpec],
     pub(crate) age_states: [super::monitor::AgeState; super::monitor::MAX_MONITORS],
@@ -1711,6 +1717,8 @@ impl<'s> Executor<'s> {
             epoch_us_fn: super::types::default_epoch_us_fn(),
             monitor_table: &[],
             monitor_states: [super::monitor::MonitorState::default(); super::monitor::MAX_MONITORS],
+            sc_dispatches: [0; crate::config::MAX_SC],
+            alive_states: [super::monitor::AliveState::default(); crate::config::MAX_SC],
             age_table: &[],
             age_states: [super::monitor::AgeState::default(); super::monitor::MAX_MONITORS],
             fault_fn: None,
@@ -2546,6 +2554,44 @@ impl<'s> Executor<'s> {
             }
             if self.monitor_violations.push(v).is_err() {
                 self.monitor_violations_dropped = self.monitor_violations_dropped.saturating_add(1);
+            }
+        }
+    }
+
+    /// AUTOSAR-style ALIVE supervision: report a SchedContext that produced
+    /// no dispatch at all over a full window while declaring a period.
+    ///
+    /// Every other rule here fires when something happens and is wrong. This
+    /// one fires when nothing happens, which is the failure a watchdog
+    /// exists for and the one `rate-hierarchy-runtime` cannot see: that rule
+    /// counts publishes on an endpoint, so a callback that stops firing while
+    /// its topic is published from elsewhere leaves it satisfied.
+    fn check_alive_supervision(&mut self) {
+        let Some(now_us) = self.now_us() else {
+            // No clock, no windows. Silence here is honest: the rule cannot
+            // tell a stalled context from a fast one without time.
+            return;
+        };
+        let n = self.alive_states.len().min(self.sched_contexts.len());
+        for i in 0..n {
+            let period_us = match self.sched_contexts[i].as_ref() {
+                Some(sc) => sc.period_us.get().map(|nz| nz.get() as u64).unwrap_or(0),
+                None => continue,
+            };
+            let dispatches = self.sc_dispatches.get(i).copied().unwrap_or(0);
+            if let Some(v) = super::monitor::check_alive(
+                period_us,
+                dispatches,
+                &mut self.alive_states[i],
+                now_us,
+            ) {
+                if self.report_violations {
+                    super::monitor::log_violation(&v);
+                }
+                if self.monitor_violations.push(v).is_err() {
+                    self.monitor_violations_dropped =
+                        self.monitor_violations_dropped.saturating_add(1);
+                }
             }
         }
     }
@@ -7126,11 +7172,20 @@ impl<'s> Executor<'s> {
              sched_context_bindings: &[super::sched_context::SchedContextId],
              sched_contexts: &[Option<super::sched_context::SchedContext>],
              sporadic_states: &mut [Option<super::sched_context::SporadicState>],
+             sc_dispatches: &mut [u32],
              #[cfg(feature = "alloc")] sporadic_atomic_states: &[Option<(
                 portable_atomic_util::Arc<super::sched_context::AtomicSporadicState>,
                 OpaqueTimerHandle,
             )>]| {
                 let sc_idx = sched_context_bindings[desc_idx].0 as usize;
+                // Alive supervision counts EVERY dispatch, before the class
+                // gate below: a Fifo or time-triggered context can fall
+                // silent exactly as a sporadic one can, and the rule that
+                // notices must not be scoped to the class that happens to
+                // carry a budget.
+                if let Some(n) = sc_dispatches.get_mut(sc_idx) {
+                    *n = n.wrapping_add(1);
+                }
                 let sc_class = sched_contexts
                     .get(sc_idx)
                     .and_then(|s| s.as_ref())
@@ -7245,6 +7300,7 @@ impl<'s> Executor<'s> {
                             &self.sched_context_bindings[..],
                             &self.sched_contexts[..],
                             &mut self.sporadic_states[..],
+                            &mut self.sc_dispatches[..],
                             #[cfg(feature = "alloc")]
                             &self.sporadic_atomic_states[..],
                         );
@@ -7285,6 +7341,7 @@ impl<'s> Executor<'s> {
                             &self.sched_context_bindings[..],
                             &self.sched_contexts[..],
                             &mut self.sporadic_states[..],
+                            &mut self.sc_dispatches[..],
                             #[cfg(feature = "alloc")]
                             &self.sporadic_atomic_states[..],
                         );
@@ -7322,6 +7379,7 @@ impl<'s> Executor<'s> {
         self.check_timer_overruns();
         self.check_release_jitter_rule();
         self.check_stack_headroom_rule();
+        self.check_alive_supervision();
 
         // Process parameter services (outside the arena)
         #[cfg(feature = "param-services")]


### PR DESCRIPTION
## The gap

AUTOSAR's Watchdog Manager separates **alive** supervision (did it run at all, at roughly the right rate) from **deadline** supervision (did it finish in time). Every rule in `monitor.rs` was the second kind — they fire when something happens and is wrong.

**Nothing fired when a callback stopped happening altogether**, which is the failure a watchdog exists for.

`rate-hierarchy-runtime` does not cover it: that rule counts *publishes* on a contracted publisher, so a timer callback that silently stops firing while its topic is still published from elsewhere — another tier, a bridge, a republisher — leaves it satisfied. The gap is a callback, not an endpoint.

## No new contract field

`period_us` is already on the `SchedContext`. A context claiming a period that produced **no** activation in a window many times longer than that period is a contract failure for any period — the same argument `check_timer_overrun` makes for dropped activations. `period_us == 0` declares no cadence and is not judged.

## Zero, not a fraction

A throttled-but-alive context is a different fault with different evidence — `SporadicState` already counts window skips and dispatches for exactly that — and picking a percentage here would invent a tolerance nobody declared. Zero activations against a declared period is unambiguous.

Report-once-until-recovery, like the rate rule: continued silence is not a new fault, but silence *after* a recovery is.

## Counting before the class gate

The increment sits ahead of the `SchedClass::Sporadic` check in the dispatch path, deliberately. A `Fifo` or time-triggered context can fall silent exactly as a sporadic one can, and scoping the count to the class that happens to carry a budget is how issue 0736's per-callback runtime accounting ended up on a path no shipped image took.

Per-SC state is a fixed `[_; MAX_SC]` array alongside `monitor_states`, not an arena allocation — `MAX_SC` is a build-time constant, 8 by default.

## Silent without a clock

By construction. The rule cannot distinguish a stalled context from a fast one without time, so it reports nothing rather than guessing.

## Verification

```
cargo test -p nros-node --features std
  test result: ok. 319 passed; 0 failed
  test result: ok. 5 passed; 0 failed

alive_supervision_tests::a_zero_period_declares_no_cadence ... ok
alive_supervision_tests::the_first_window_only_opens ... ok
alive_supervision_tests::silence_across_a_full_window_reports ... ok
alive_supervision_tests::a_single_dispatch_is_enough ... ok
alive_supervision_tests::continued_silence_is_not_a_new_fault ... ok
alive_supervision_tests::a_period_longer_than_the_window_is_not_judged ... ok
```

Clean on default (no_std) and `alloc`; `cargo fmt` clean.

## Worth knowing for this file

**`cargo check -p nros-node` does not compile `spin.rs`.** `mod spin` is `#[cfg(any(has_rmw, test))]`, and a plain check selects no RMW backend, so the module is skipped entirely — appending invalid Rust to it passes cleanly.

Two call-site errors in this change were invisible to `cargo check` and appeared only under `cargo test`, which pulls the module in via `cfg(test)`. Anything touching that file needs `cargo test` to be validated at all.
