### PR TITLE
feat(bench): time the platform ABI, so ports can be compared

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,6 +275,7 @@ exclude = [
     "examples/qemu-arm-baremetal/rust/listener",
     "packages/testing/nros-tests/bins/cdr-roundtrip-qemu",
     "packages/testing/nros-bench/wcet-cycles-qemu",
+    "packages/testing/nros-bench/port-metric",
     "packages/testing/nros-bench/large-msg-baremetal",
     "packages/testing/nros-tests/bins/lan9118-qemu",
     "examples/qemu-arm-baremetal/rust/talker-rtic",

--- a/packages/testing/nros-bench/port-metric/Cargo.toml
+++ b/packages/testing/nros-bench/port-metric/Cargo.toml
@@ -1,0 +1,22 @@
+[workspace]
+
+[package]
+name = "nros-port-metric-bench"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[[bin]]
+name = "port-metric"
+path = "src/main.rs"
+
+[dependencies]
+# The platform ABI is the whole subject: this bench times the primitives
+# every port must provide, not the middleware built on them.
+nros-platform-api = { path = "../../../../packages/platform/nros-platform-api" }
+# POSIX C symbols for the host runner. A target runner swaps this for its
+# own port and keeps `bench.rs` untouched.
+nros-platform-cffi = { path = "../../../../packages/platform/nros-platform-cffi", features = [
+    "posix-c-port",
+] }

--- a/packages/testing/nros-bench/port-metric/README.md
+++ b/packages/testing/nros-bench/port-metric/README.md
@@ -1,0 +1,67 @@
+# port-metric
+
+Times the `nros_platform_*` ABI primitives, so ports can be compared and
+regressions noticed.
+
+nano-ros supports Zephyr, FreeRTOS, ThreadX, NuttX, POSIX, ESP-IDF and several
+bare-metal boards. Nothing said what a port cost. The other benches here each
+measure the middleware on one target — `wcet-cycles-qemu` times publish and
+serialize through the DWT counter, `wake-latency-cortex-m3` times a wake — so
+none of them compares ports, because none measures the surface the ports
+actually implement.
+
+## What it measures
+
+EEMBC's Thread-Metric suite, reduced to the primitives this ABI exposes:
+
+| Thread-Metric        | here                |
+|----------------------|---------------------|
+| memory alloc/dealloc | `alloc+free`        |
+| cooperative switch   | `yield`             |
+| semaphore processing | `mutex lock+unlock` |
+
+Absolute numbers are board-specific and not the point. The per-port table and
+the regression signal are.
+
+## Running
+
+```console
+$ cargo run --release
+nros port-metric — platform ABI primitives
+port: posix
+budget: 200000 us per test
+
+test                     iterations       per second
+----------------------------------------------------
+alloc+free                 43662080        218310400
+yield                       2738496         13692206
+mutex lock+unlock          50379968        251899840
+```
+
+`NROS_BENCH_BUDGET_US` sets the per-test budget (default 200 ms, so the suite
+is under a second). `NROS_BENCH_PORT` labels the row.
+
+## Adding a target
+
+`src/bench.rs` has no target, allocator or std dependency, and takes its clock
+as a parameter. A board runner supplies an entry point and a clock and calls
+`bench::all(..)`; `src/main.rs` is the host version of exactly that. Depend on
+the port's platform crate instead of `nros-platform-cffi[posix-c-port]`.
+
+The clock is a parameter rather than something `bench.rs` reaches for because
+`nros_platform_time_now_ns` returns 0 on ports with no RTC, and a benchmark
+that silently divided by that would report nonsense.
+
+## Reading the output
+
+A time budget, not an iteration count, so a slow port finishes in the same
+wall time as a fast one. The clock is read once per 64 iterations, so what is
+timed is the primitive rather than the clock.
+
+An unsupported primitive is printed as `unsupported` rather than omitted: a
+missing row reads as "not measured yet", which is a different claim from "this
+port does not provide it".
+
+Uncontended for the mutex, deliberately. A contended number measures the
+scheduler's wake path, which `wake-latency-cortex-m3` already covers; this is
+the cost every guarded access pays whether or not anyone is waiting.

--- a/packages/testing/nros-bench/port-metric/src/bench.rs
+++ b/packages/testing/nros-bench/port-metric/src/bench.rs
@@ -1,0 +1,171 @@
+//! The measurements themselves. Deliberately free of any target, allocator
+//! or std dependency so a board runner can call exactly the same code the
+//! host runner does — a number is only comparable across ports if the thing
+//! being timed is identical.
+
+use core::ffi::c_void;
+
+/// One test's result. Iterations rather than a duration, because the point
+/// is comparison across ports whose clocks differ in resolution and cost.
+pub struct Outcome {
+    pub name: &'static str,
+    pub iterations: u64,
+    pub elapsed_us: u64,
+    /// `false` when the port does not provide the primitive. Reported rather
+    /// than skipped: "this port cannot do it" is a result, and omitting the
+    /// row would read as "not measured yet".
+    pub supported: bool,
+}
+
+impl Outcome {
+    pub fn per_second(&self) -> u64 {
+        if self.elapsed_us == 0 {
+            return 0;
+        }
+        self.iterations.saturating_mul(1_000_000) / self.elapsed_us
+    }
+}
+
+/// Clock the harness supplies. Taken as a parameter rather than reached for
+/// directly: `nros_platform_time_now_ns` returns 0 on ports with no RTC, and
+/// a bench that silently divided by that would report nonsense.
+pub type ClockUs = fn() -> u64;
+
+/// Run `body` until `budget_us` has elapsed, returning the iteration count.
+///
+/// A fixed time budget rather than a fixed iteration count, so a slow port
+/// finishes in the same wall time as a fast one. The clock is read once per
+/// batch of `BATCH` iterations, not per iteration, so the measurement is of
+/// the primitive and not of the clock.
+fn run_for(budget_us: u64, clock: ClockUs, mut body: impl FnMut()) -> (u64, u64) {
+    const BATCH: u64 = 64;
+    let start = clock();
+    let mut iterations = 0u64;
+    loop {
+        for _ in 0..BATCH {
+            body();
+        }
+        iterations += BATCH;
+        let elapsed = clock().saturating_sub(start);
+        if elapsed >= budget_us {
+            return (iterations, elapsed);
+        }
+    }
+}
+
+/// Allocate then free one small block.
+///
+/// EEMBC Thread-Metric calls this "memory allocation"; here it is the
+/// `nros_platform_alloc`/`dealloc` pair every port must supply. A port whose
+/// allocator is a bump arena and one with a real free list differ by an order
+/// of magnitude, and nothing currently says so.
+pub fn alloc_free(budget_us: u64, clock: ClockUs) -> Outcome {
+    unsafe extern "C" {
+        fn nros_platform_alloc(size: usize) -> *mut c_void;
+        fn nros_platform_dealloc(ptr: *mut c_void);
+    }
+    let mut ok = true;
+    let (iterations, elapsed_us) = run_for(budget_us, clock, || {
+        // SAFETY: a 64-byte request and its matching free; the pointer never
+        // escapes this closure.
+        unsafe {
+            let p = nros_platform_alloc(64);
+            if p.is_null() {
+                ok = false;
+                return;
+            }
+            nros_platform_dealloc(p);
+        }
+    });
+    Outcome {
+        name: "alloc+free",
+        iterations,
+        elapsed_us,
+        supported: ok,
+    }
+}
+
+/// Yield to the scheduler and come back.
+///
+/// Thread-Metric's cooperative context switch, reduced to the one primitive
+/// the ABI exposes. On a cooperative single-thread executor this is the cost
+/// of the loop deciding to let something else run.
+pub fn yield_cost(budget_us: u64, clock: ClockUs) -> Outcome {
+    unsafe extern "C" {
+        fn nros_platform_yield_now();
+    }
+    let (iterations, elapsed_us) = run_for(budget_us, clock, || {
+        // SAFETY: no arguments, no state.
+        unsafe { nros_platform_yield_now() }
+    });
+    Outcome {
+        name: "yield",
+        iterations,
+        elapsed_us,
+        supported: true,
+    }
+}
+
+/// Uncontended mutex lock/unlock.
+///
+/// Thread-Metric's "semaphore processing". Uncontended deliberately: a
+/// contended number measures the scheduler's wake path, which
+/// `wake-latency-cortex-m3` already covers, whereas this is the cost every
+/// guarded access pays whether or not anyone is waiting.
+pub fn mutex_uncontended(budget_us: u64, clock: ClockUs) -> Outcome {
+    unsafe extern "C" {
+        fn nros_platform_mutex_storage_size() -> usize;
+        fn nros_platform_mutex_init(m: *mut c_void) -> i8;
+        fn nros_platform_mutex_lock(m: *mut c_void) -> i8;
+        fn nros_platform_mutex_unlock(m: *mut c_void) -> i8;
+        fn nros_platform_mutex_drop(m: *mut c_void) -> i8;
+        fn nros_platform_alloc(size: usize) -> *mut c_void;
+        fn nros_platform_dealloc(ptr: *mut c_void);
+    }
+    // SAFETY: storage sized by the port's own probe, initialised before use
+    // and dropped after.
+    unsafe {
+        let size = nros_platform_mutex_storage_size();
+        if size == 0 {
+            return Outcome {
+                name: "mutex lock+unlock",
+                iterations: 0,
+                elapsed_us: 0,
+                supported: false,
+            };
+        }
+        let m = nros_platform_alloc(size);
+        if m.is_null() || nros_platform_mutex_init(m) != 0 {
+            if !m.is_null() {
+                nros_platform_dealloc(m);
+            }
+            return Outcome {
+                name: "mutex lock+unlock",
+                iterations: 0,
+                elapsed_us: 0,
+                supported: false,
+            };
+        }
+        let (iterations, elapsed_us) = run_for(budget_us, clock, || {
+            nros_platform_mutex_lock(m);
+            nros_platform_mutex_unlock(m);
+        });
+        nros_platform_mutex_drop(m);
+        nros_platform_dealloc(m);
+        Outcome {
+            name: "mutex lock+unlock",
+            iterations,
+            elapsed_us,
+            supported: true,
+        }
+    }
+}
+
+/// Every test, in a fixed order so two runs diff cleanly.
+pub fn all(budget_us: u64, clock: ClockUs) -> [Outcome; 3] {
+    [
+        alloc_free(budget_us, clock),
+        yield_cost(budget_us, clock),
+        mutex_uncontended(budget_us, clock),
+    ]
+}

--- a/packages/testing/nros-bench/port-metric/src/main.rs
+++ b/packages/testing/nros-bench/port-metric/src/main.rs
@@ -1,0 +1,84 @@
+//! Port conformance benchmark — the same primitives, timed on every port.
+//!
+//! nano-ros supports Zephyr, FreeRTOS, ThreadX, NuttX, POSIX, ESP-IDF and
+//! several bare-metal boards. There is no way to say what a port COSTS, or to
+//! notice when one regresses. The existing benches under `nros-bench` measure
+//! the middleware on one target apiece (`wcet-cycles-qemu` times publish and
+//! serialize through the DWT counter, `wake-latency-cortex-m3` times a wake);
+//! none of them compares ports, because none of them measures the surface the
+//! ports actually implement.
+//!
+//! This one times the `nros_platform_*` ABI directly, which is the only thing
+//! every port has in common. The shape is EEMBC's Thread-Metric suite reduced
+//! to the primitives this ABI exposes:
+//!
+//!   Thread-Metric               here
+//!   memory alloc/dealloc        alloc+free
+//!   cooperative switch          yield
+//!   semaphore processing        mutex lock+unlock
+//!
+//! The absolute numbers are board-specific and not the point. The point is the
+//! per-port table and the regression signal: a port that halves its alloc rate
+//! between two pins should say so.
+//!
+//! `src/bench.rs` carries no target, allocator or std dependency, so a board
+//! runner calls exactly the same code this host runner does. A number is only
+//! comparable across ports if the thing being timed is identical.
+//!
+//! Usage: `cargo run --release` (host/POSIX). For a target, write a runner
+//! beside this one that supplies an entry point and a clock, and depend on
+//! that port's platform crate instead of `posix-c-port`.
+
+mod bench;
+
+// Force-link the POSIX C port. Nothing in this crate NAMES the cffi crate --
+// the bench calls the `nros_platform_*` symbols directly through `extern "C"`
+// -- so without this the linker drops the dependency and every symbol comes
+// back undefined. `executor-fairness` gets the same crate transitively
+// through `nros` and so never had to say it out loud.
+use nros_platform_cffi as _;
+
+/// Host clock. A target runner supplies its own -- a DWT cycle counter scaled
+/// to microseconds, a kernel tick, whatever the board has -- which is why
+/// `bench` takes the clock as a parameter rather than reaching for one.
+fn clock_us() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros() as u64)
+        .unwrap_or(0)
+}
+
+fn main() {
+    // 200 ms per test: long enough that scheduler noise averages out, short
+    // enough that the whole suite is under a second in CI.
+    let budget_us: u64 = std::env::var("NROS_BENCH_BUDGET_US")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200_000);
+
+    println!("nros port-metric — platform ABI primitives");
+    println!(
+        "port: {}",
+        std::env::var("NROS_BENCH_PORT").unwrap_or_else(|_| "posix".into())
+    );
+    println!("budget: {budget_us} us per test\n");
+    println!("{:<20} {:>14} {:>16}", "test", "iterations", "per second");
+    println!("{}", "-".repeat(52));
+
+    let mut unsupported = 0;
+    for o in bench::all(budget_us, clock_us) {
+        if o.supported {
+            println!("{:<20} {:>14} {:>16}", o.name, o.iterations, o.per_second());
+        } else {
+            // Named, not omitted: a missing row reads as "not measured yet",
+            // which is a different claim from "this port does not provide it".
+            println!("{:<20} {:>14} {:>16}", o.name, "-", "unsupported");
+            unsupported += 1;
+        }
+    }
+
+    if unsupported > 0 {
+        println!("\n{unsupported} primitive(s) unsupported on this port.");
+    }
+}


### PR DESCRIPTION
## Problem

nano-ros supports Zephyr, FreeRTOS, ThreadX, NuttX, POSIX, ESP-IDF and several bare-metal boards. **Nothing says what a port costs**, or notices when one regresses.

The existing benches under `nros-bench` each measure the *middleware* on one target apiece — `wcet-cycles-qemu` times publish and serialize through the DWT counter, `wake-latency-cortex-m3` times a wake. None compares ports, because none measures the surface the ports actually implement.

## What this adds

Times the `nros_platform_*` primitives directly — the only thing every port has in common. EEMBC's Thread-Metric suite, reduced to what this ABI exposes:

| Thread-Metric        | here                |
|----------------------|---------------------|
| memory alloc/dealloc | `alloc+free`        |
| cooperative switch   | `yield`             |
| semaphore processing | `mutex lock+unlock` |

Measured on glibc/x86_64, which is also the first evidence it works:

```
test                     iterations       per second
----------------------------------------------------
alloc+free                 43662080        218310400
yield                       2738496         13692206
mutex lock+unlock          50379968        251899840
```

Yield costing ~16× an uncontended mutex is the expected shape — a syscall against an atomic — so the numbers are at least the right kind of thing to argue about.

## Four decisions, each guarding against a meaningless number

**A time budget, not an iteration count**, so a slow port finishes in the same wall time as a fast one. The clock is read once per 64 iterations, so what is timed is the primitive and not the clock.

**The clock is a parameter**, not something `bench.rs` reaches for. `nros_platform_time_now_ns` returns `0` on ports with no RTC, and a benchmark dividing by that reports nonsense with total confidence.

**An unsupported primitive is printed as `unsupported`, not omitted.** A missing row reads as "not measured yet", which is a different claim from "this port does not provide it".

**The mutex is uncontended.** A contended number measures the scheduler's wake path, which `wake-latency-cortex-m3` already covers; this is the cost every guarded access pays whether or not anyone is waiting.

## Portability

`src/bench.rs` carries no target, allocator or `std` dependency, so a board runner calls exactly the same code the host runner does — a number is only comparable across ports if the thing being timed is identical. Adding a target means writing a runner beside `main.rs` that supplies an entry point and a clock; the README says how.

**Only the host runner is included.** Six target runners I cannot execute would be six untested claims.

## Note

The bench calls the ABI symbols directly through `extern "C"`, so nothing in Rust names the cffi crate and the linker drops it — `use nros_platform_cffi as _;` is load-bearing. `executor-fairness` gets the same crate transitively through `nros` and never had to say it out loud.
