### PR TITLE
fix(#0820, phase-424): retarget the NuttX depfile — a copy loses the whole edge

### DIFF
--- a/docs/issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md
+++ b/docs/issues/0820-riscv-nuttx-c-talker-no-runtime-delivery.md
@@ -6,8 +6,78 @@ title: "`c_riscv_nuttx_e2e` failed on a MUSEUM BINARY — the NuttX seam had no
 status: open
 type: bug
 area: cmake, testing
-related: [issue-0475, issue-0445, issue-0196]
+related: [issue-0475, issue-0445, issue-0196, issue-0805]
 ---
+
+## READ FIRST — the 2026-08-27 fix was live for six days (phase-424, 2026-09-05)
+
+The `DEPFILE` this issue landed was **silently neutralised by issue 0805's shared
+cargo dir**, and the verification recipe recorded below cannot see it. Fixed
+again here, by retargeting the depfile rather than copying it.
+
+**A depfile names the artifact it describes, and ninja CHECKS that name.**
+`DependencyScan::LoadDepFile` compares the rule's target against the edge's first
+output; on a mismatch it discards the ENTIRE depfile and marks the edge
+`deps_missing_` — permanently dirty.
+
+0805 moved the artifact out of the shared cargo target dir with cargo's
+`--artifact-dir`, so the `add_custom_command` OUTPUT became
+`<build>/nros-nuttx-ffi-out/nros-nuttx-ffi` while cargo's dep-info kept naming
+its own `<shared>/…/nros-minsizerel/nros-nuttx-ffi`. The seam copied that file
+across verbatim, target line included.
+
+Measured on the riscv leaf's REAL depfile (`build-zenoh/CMakeFiles/d/93e9….d`,
+fed to ninja 1.13.2 with the edge's real output name):
+
+```
+ninja explain: expected depfile 'real.d' to mention
+  'nros-nuttx-ffi-out/nros-nuttx-ffi', got
+  '/home/…/build/corrosion-cargo/nuttx-riscv/682805377484/
+   riscv32imac-unknown-nuttx-elf/nros-minsizerel/nros-nuttx-ffi'
+[1/1] Building NuttX example: c_talker      <- and again on every subsequent run
+```
+
+So all **308** nano-ros Rust paths in that depfile were read by nobody, and the
+seam had silently become the **always-run custom target** this issue explicitly
+rejected on cost grounds ("pays a cargo + NuttX kernel invocation on every build
+of every NuttX example"). It was still correct — but by accident, not by an edge.
+
+**Why the recorded verification could not catch it.** "Touch
+`nros-node/src/lib.rs`, rebuild without wiping, confirm the ELF hash changes"
+passes identically whether the DEPFILE works or the edge is permanently dirty.
+The recipe proves the artifact is not a museum binary; it does not prove the
+mechanism that would keep it that way is alive. A no-op rebuild reporting
+`ninja: no work to do` is the check that separates them.
+
+Note also that the two branches differ: when `nros_shared_cargo_dir` is
+unavailable, `_output_binary` IS cargo's own path and the depfile matched. That
+is the branch the 2026-08-27 verification ran, which is why it was honest then
+and stale six days later.
+
+**Fix (2026-09-05).** `packages/api/nros-c/cmake/nros-nuttx-depfile.cmake` — a
+`cmake -P` script that rewrites the rule's target to the
+`add_custom_command` OUTPUT before cmake's `cmake_transform_depfile` runs;
+`nros-nuttx.cmake` invokes it in place of the `copy_if_different`. The module dir
+is captured `CACHE INTERNAL` at file scope because — measured —
+`CMAKE_CURRENT_LIST_DIR` inside a cmake `function` resolves to the CALLER's list
+dir, not the defining file's.
+
+Measured after the fix, on the same real depfile:
+
+* the script retargets it and preserves all 308 prerequisites;
+* `cmake -E cmake_transform_depfile Ninja gccdepfile …` renders the target as
+  `nros-nuttx-ffi-out/nros-nuttx-ffi:` — ninja's exact output spelling;
+* ninja accepts it (no `expected depfile` explain line) and, in a controlled
+  positive control, reports `no work to do` on a no-op rebuild and rebuilds when
+  a depfile-named source is touched.
+
+**Not verified:** an in-situ incremental `just nuttx build-riscv-c` (needs a full
+NuttX kernel + cross cargo build). And cargo dep-info may name paths that do not
+exist; ninja degrades those to always-rebuild — no worse than the state this
+replaces, never a museum binary — but whether the current dep-info contains any
+is unmeasured.
+
+This changed no probe's watch set, so phase-424's 0835 constraint does not bind.
 
 ## Resolution of the reported failure: stale artifact, not a code defect
 

--- a/packages/api/nros-c/cmake/nros-nuttx-depfile.cmake
+++ b/packages/api/nros-c/cmake/nros-nuttx-depfile.cmake
@@ -1,0 +1,59 @@
+# nros-nuttx-depfile.cmake — retarget cargo's dep-info onto the path ninja builds.
+#
+# Run as a script:
+#
+#   cmake -DNROS_DEPFILE_IN=<cargo's .d>
+#         -DNROS_DEPFILE_OUT=<the .d cmake's DEPFILE names>
+#         -DNROS_DEPFILE_TARGET=<the add_custom_command OUTPUT>
+#         -P nros-nuttx-depfile.cmake
+#
+# Why this exists (issue 0820, second round).
+#
+# A Makefile-format depfile names the artifact it describes, and ninja CHECKS
+# that name: `LoadDepFile` compares the rule's target against the edge's first
+# output and, when they differ, discards the WHOLE depfile and marks the edge
+# `deps_missing_` — permanently dirty. Measured with ninja 1.13.2 against the
+# real riscv leaf's depfile:
+#
+#   ninja explain: expected depfile 'real.d' to mention
+#     'nros-nuttx-ffi-out/nros-nuttx-ffi', got
+#     '.../corrosion-cargo/nuttx-riscv/<key>/riscv32imac-unknown-nuttx-elf/
+#      nros-minsizerel/nros-nuttx-ffi'
+#
+# That is exactly the shape the NuttX seam acquired when issue 0805 moved the
+# artifact out of the SHARED cargo target dir with `--artifact-dir`: cargo still
+# writes its dep-info naming its own output, while the add_custom_command OUTPUT
+# is now the artifact-dir copy. Copying the file across (which is what this
+# replaced) preserves the stale target line, so all 308 dependency paths in it —
+# the entire nano-ros Rust closure 0820's fix went to the trouble of capturing —
+# are thrown away unread.
+#
+# The failure is silent in both directions and neither is what the fix intended:
+# the edge re-runs cargo on EVERY build (the always-run cost 0820 explicitly
+# rejected), and the depfile contributes nothing, so the only thing standing
+# between this seam and a museum binary is that accident. Rewriting the target
+# is a two-token change to a file cargo already computed exactly.
+#
+# One rule, one target: cargo writes a single line for a binary target (measured:
+# 1 line, 308 prerequisites), and its paths are absolute with no ':' in them, so
+# "everything up to the first colon" is the target.
+
+if(NOT NROS_DEPFILE_IN OR NOT NROS_DEPFILE_OUT OR NOT NROS_DEPFILE_TARGET)
+    message(FATAL_ERROR
+        "nros-nuttx-depfile.cmake: NROS_DEPFILE_IN, NROS_DEPFILE_OUT and "
+        "NROS_DEPFILE_TARGET are all required")
+endif()
+
+if(NOT EXISTS "${NROS_DEPFILE_IN}")
+    # Cargo writes dep-info on every successful build, so an absent one means the
+    # rebuild edge is gone. Fail rather than leave a stale `.d` in place: a stale
+    # depfile is worse than none, because ninja BELIEVES it.
+    message(FATAL_ERROR
+        "nros: cargo wrote no dep-info at ${NROS_DEPFILE_IN} — the NuttX seam "
+        "would lose its rebuild edge on the nano-ros Rust world (issue 0820)")
+endif()
+
+file(READ "${NROS_DEPFILE_IN}" _nros_depfile_content)
+string(REGEX REPLACE "^[^:\n]*:" "${NROS_DEPFILE_TARGET}:"
+    _nros_depfile_content "${_nros_depfile_content}")
+file(WRITE "${NROS_DEPFILE_OUT}" "${_nros_depfile_content}")

--- a/packages/api/nros-c/cmake/nros-nuttx.cmake
+++ b/packages/api/nros-c/cmake/nros-nuttx.cmake
@@ -60,6 +60,14 @@ set(_NROS_NUTTX_INCLUDED TRUE)
 
 include("${CMAKE_CURRENT_LIST_DIR}/nros-rtos-helpers.cmake")
 
+# The `_NROS_ENTRY_DIR` pattern from CLAUDE.md, and it is not optional here:
+# measured, `CMAKE_CURRENT_LIST_DIR` inside a FUNCTION body resolves to the
+# CALLER's list dir, not to the file the function was defined in. The depfile
+# script below is invoked from inside `nros_nuttx_build_example`, so its path
+# has to be captured at FILE scope.
+set(_NROS_NUTTX_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL
+    "Directory holding nros-nuttx.cmake and its helper scripts")
+
 # issue 0820 — the cargo profile for this seam is a CARVE-OUT, not the ambient
 # one, and it must come from the table rather than be spelled here.
 #
@@ -284,7 +292,10 @@ function(nros_nuttx_build_example)
     #
     #   * the ARTIFACT via cargo's own `--artifact-dir`, so cargo places it
     #     rather than a copy racing whatever runs next;
-    #   * the DEPFILE by copying it in the same command, immediately after.
+    #   * the DEPFILE by RETARGETING it in the same command, immediately after
+    #     — a plain copy keeps cargo's own path as the rule's target, which
+    #     ninja rejects and which cost the seam its whole rebuild edge again
+    #     (see the `_depfile_retarget_cmd` note below).
     #
     # The key MUST separate the architectures. `<target>/release/build/` holds
     # HOST build-script output and is NOT triple-separated inside one target
@@ -329,11 +340,28 @@ function(nros_nuttx_build_example)
     # crate is already pinned to a nightly and already passes `-Z build-std`.
     # It does NOT copy the depfile (verified), hence the explicit copy below.
     set(_artifact_dir_arg "")
-    set(_depfile_copy_cmd "")
+    set(_depfile_retarget_cmd "")
     if(_artifact_dir)
         set(_artifact_dir_arg -Z unstable-options --artifact-dir "${_artifact_dir}")
-        set(_depfile_copy_cmd COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${_cargo_out_dir}/nros-nuttx-ffi.d" "${_output_binary}.d")
+        # issue 0820, second round — a COPY is not enough, and the difference is
+        # invisible: a depfile names the artifact it describes, and ninja
+        # CHECKS that name against the edge's output. Cargo names its OWN output
+        # in the shared target dir; this command's OUTPUT is the artifact-dir
+        # copy. Measured with ninja 1.13.2 on the real riscv leaf's depfile:
+        #
+        #   ninja explain: expected depfile 'real.d' to mention
+        #     'nros-nuttx-ffi-out/nros-nuttx-ffi', got '<shared>/…/nros-nuttx-ffi'
+        #
+        # and on a mismatch ninja discards the depfile ENTIRELY and marks the
+        # edge permanently dirty. So between 0805 and here, all 308 nano-ros
+        # Rust paths were read by nobody and cargo re-ran on every build — the
+        # always-run cost 0820 rejected, buying the correctness by accident
+        # instead of by the edge. Retarget the rule, don't copy it.
+        set(_depfile_retarget_cmd COMMAND ${CMAKE_COMMAND}
+            "-DNROS_DEPFILE_IN=${_cargo_out_dir}/nros-nuttx-ffi.d"
+            "-DNROS_DEPFILE_OUT=${_output_binary}.d"
+            "-DNROS_DEPFILE_TARGET=${_output_binary}"
+            -P "${_NROS_NUTTX_CMAKE_DIR}/nros-nuttx-depfile.cmake")
     endif()
 
     # 194.4: self-provision the NuttX export before the example links it. The
@@ -394,7 +422,7 @@ function(nros_nuttx_build_example)
             "NUTTX_APPS_DIR=${NUTTX_APPS_DIR}"
             "CARGO_TARGET_DIR=${_cargo_target_dir}"
             cargo build --profile ${_NROS_NUTTX_PROFILE} ${_artifact_dir_arg}
-        ${_depfile_copy_cmd}
+        ${_depfile_retarget_cmd}
         # Issue 0159 — make `cmake --build` itself honest: an exit-0 build with
         # no kernel ELF (up-to-date skip edge / a sub-step whose failure isn't
         # propagated) must fail HERE, not only in the outer fixture script's


### PR DESCRIPTION
The 2026-08-27 fix for this seam is in the tree and is correct. **Its mechanism has been dead since `afec7ef57` (issue 0805) the next day**, and nothing said so.

## What happened

0805 moved the NuttX artifact out of the shared cargo dir with `--artifact-dir`, so the `add_custom_command` OUTPUT became `<build>/nros-nuttx-ffi-out/…` while cargo's dep-info still names its own path. The seam **copied** that file across, target line included.

A depfile *names the artifact it describes*, and ninja **checks that name**. On a mismatch it discards the depfile entirely and marks the edge permanently dirty.

Measured on the real riscv leaf's depfile (308 prerequisites), ninja 1.13.2:

```
ninja explain: expected depfile 'real.d' to mention
  'nros-nuttx-ffi-out/nros-nuttx-ffi', got '<shared>/…/nros-nuttx-ffi'
```

and reproduced minimally, both directions:

```
mismatched target →  rebuilds on every run
matching target   →  second run: ninja: no work to do
```

So between 0805 and here the seam bought its correctness **by accident** — cargo re-ran on every build, which is the always-run cost #0820 explicitly rejected — while all 308 nano-ros Rust paths were read by nobody.

## Fix

**Retarget the rule, don't copy it.** `nros-nuttx-depfile.cmake` rewrites the dep-info target to the `add_custom_command` OUTPUT before cmake's `cmake_transform_depfile` runs, and fails loudly if cargo wrote no dep-info — a stale `.d` is worse than none, because ninja believes it.

`_NROS_NUTTX_CMAKE_DIR` is captured at file scope as `CACHE INTERNAL`: measured, `CMAKE_CURRENT_LIST_DIR` inside a cmake **function** resolves to the *caller's* list dir. That's CLAUDE.md's `_NROS_ENTRY_DIR` class, and without it the script path would follow whichever leaf called in.

## Why the recorded verification couldn't see it

*"Touch a source, rebuild without wiping, confirm the ELF hash changes"* passes **identically** whether the depfile works or the edge is permanently dirty. The discriminating check is a **no-op rebuild** reporting `ninja: no work to do`. The 2026-08-27 run was honest — it exercised the non-shared branch, where the names match — and went stale six days later.

## Phase-424 constraint

This adds a dependency **edge** and widens no watch set, so the 0835 budget doesn't bind.

## Not verified

**No in-situ incremental NuttX build** — that needs a kernel export plus a cross cargo build, and the only existing build dir belongs to a checkout at a different HEAD. The chain is measured on real artifacts at every step; the final *"run the lane twice, second is a no-op"* is inferred. **The issue stays open for that reason**, with a READ FIRST section recording it.

`just check fast` 212/212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK