### PR TITLE
fix(#1050, #1046, phase-424): a PX4 module's BACKENDS becomes an assertion

### DIFF
--- a/docs/issues/1050-px4-demo-links-whatever-archive-was-built-last.md
+++ b/docs/issues/1050-px4-demo-links-whatever-archive-was-built-last.md
@@ -6,7 +6,9 @@ type: bug
 area: build, testing
 severity: high
 found: 2026-09-04
-related: [1046, 0436, phase-325, 0616]
+# defects (1) and (2) are fixed; (3) — `nros::init()` takes slot 0 — is why
+# this stays open.
+related: [1046, 0436, phase-325, 0616, phase-424]
 ---
 
 # Same source, same recipe, same command — different result
@@ -103,19 +105,103 @@ guard survived:
    — `Executor::open_with_rmw("uorb", …)` exists, but the C++ one-liner the
    examples use does not reach it.
 
-Only (1) is fixed here. (2) and (3) are design questions: (2) would mean either
-suppressing the ctor path when a stub is generated, or making `BACKENDS` an
-assertion rather than a hint; (3) would mean the examples naming their backend.
-Both change behaviour for every consumer, so they want an owner and a decision,
-not a drive-by.
+## (2) FIXED 2026-09-05 — `BACKENDS` is an assertion now, taking the cheaper of
+## the two options the paragraph below offered
 
-## Not covered
+The choice was "suppress the ctor path when a stub is generated" or "make
+`BACKENDS` an assertion rather than a hint". The first changes runtime behaviour
+for every consumer; the second is a configure-time check. Took the second.
 
-* Whether `build-sitl-cpp` (the register-check gate) has the same exposure. Its
-  comments quote the `cargo build -p nros-cpp --features std,rmw-cffi` command,
-  but whether the recipe RUNS it was not checked.
-* Whether any non-PX4 lane links `libnros_cpp.a` ambiently the same way.
-* Whether the 1046 guard should also assert the archive's feature variant. It
-  currently answers "is this module linked", not "was it linked against the
-  right archive" — a strictly harder question, and arguably the anchor symbol
-  already answers it at link time.
+**The precheck already existed and was blind in exactly the direction that
+matters.** `nros_px4_add_module` ran its `llvm-nm` check inside
+`if(_networked_backends)` — the set of modules this bug CANNOT happen to — and
+inside it only asked "is every DECLARED backend present". The uORB demo declares
+`BACKENDS uorb`, so the whole block was skipped for it. That is issue 1046's
+shape one layer up: a guard whose predicate cannot observe the case its own
+message describes.
+
+So the check now runs for EVERY module and asks both directions:
+
+* (a) every declared networked backend is in the archive (unchanged);
+* (b) **no undeclared one is**, because on hosted POSIX it registers itself
+      first and takes slot 0.
+
+Measured, through the real `nros_px4_add_module` with a stub `px4_add_module`:
+
+| module `BACKENDS` | archive | before | after |
+| --- | --- | --- | --- |
+| `uorb` | zenoh-carrying (the bug) | configure OK, dies at `start` | **FATAL, names the rebuild** |
+| `uorb` | `rmw-cffi` only | OK | OK |
+| `uorb zenoh` | `rmw-cffi` only | FATAL (missing) | FATAL (missing) |
+| `uorb zenoh` | zenoh-carrying (bridge) | OK | OK |
+
+The discriminator is the unmangled C symbol `nros_rmw_<b>_register`, matched on
+word boundaries because the same archive carries Rust-mangled names that contain
+its prefix (`_RNvNtCs..._14nros_rmw_zenoh13cffi_register8register`) — a bare
+substring test would read those as a definition. One predicate serves both
+directions, so presence and absence cannot drift apart.
+
+**Cost, against phase-424's constraint:** one extra `llvm-nm --defined-only` per
+configure for a uORB-only module, **measured 0.012 s** on the 26 MB archive. It
+hashes nothing and watches nothing, so it widens no watch set and re-stales
+nothing — issue 0835's budget is untouched by construction, not by measurement.
+
+This is also what makes the (1) fix hold at the SEAM rather than only in the
+recipe. `just px4 build-sitl-example` builds the archive it links, which is
+right, but a hand-run `make px4_sitl_default EXTERNAL_MODULES_LOCATION=...`
+against an archive some other recipe left behind bypasses it entirely — and
+that state is present on this host right now: the ambient
+`target/release/libnros_cpp.a` defines `nros_rmw_zenoh_register`.
+
+## (3) is the one still open
+
+`nros::init()` takes slot 0, so *which* backend a module gets is still decided
+by registration order rather than by the module. (2)'s fix removes the way that
+order goes wrong by accident; it does not give a C++ one-liner any way to NAME
+its backend. `Executor::open_with_rmw("uorb", …)` exists and the examples'
+`nros::init()` does not reach it. That is a consumer-facing API decision and
+still wants an owner.
+
+## Three separable defects (original framing, kept)
+
+Only (1) was fixed at filing. (2) is fixed above. (3) remains.
+
+## Not covered — swept 2026-09-05
+
+* **`build-sitl-cpp` has NO exposure.** Its root,
+  `packages/testing/nros-px4-register-check`, calls `px4_add_module` directly —
+  not `nros_px4_add_module` — and links no nano-ros archive: it compiles the
+  uORB backend's sources inline and its only Rust seam is the weak
+  `register_fallback.c`. So there is no ambient archive for it to inherit. (The
+  `cargo build -p nros-cpp --features std,rmw-cffi` command this issue thought
+  was quoted in `build-sitl-cpp`'s comments is in fact quoted in
+  `build-sitl-example`'s prereq block and in `NanoRosPx4Module.cmake`'s header —
+  that claim in the original text was wrong.)
+* **No non-PX4 lane links `libnros_cpp.a` ambiently.**
+  `${NANO_ROS_ROOT}/target/release/libnros_cpp.a` as a path is named in exactly
+  one place in the tree, `integrations/px4/NanoRosPx4Module.cmake:86`. Every
+  other consumer reaches the umbrella through Corrosion/cmake, which builds it
+  per configure.
+* **The 1046 guard should NOT also assert the feature variant.** The anchor
+  symbol `nros_cpp_config_variant_...` already makes a header/archive mismatch a
+  LINK error, which this issue's own repro shows firing; and the archive check
+  above now catches the backend half at CONFIGURE time, which is earlier than
+  either. A third copy in the test would be a fourth spelling of the same fact.
+
+## NOT the issue-0475 class — checked
+
+`libnros_cpp.a` is not reached through a raw `-Wl,` flag: the helper passes it
+to `target_link_libraries(${NPX_MODULE} PUBLIC <absolute path>)`, and CMake does
+create a file-level edge for an absolute-path link item. Confirmed in the real
+build graph — it is under `|` (implicit), not `||` (order-only):
+
+```
+$ ninja -C build/px4_sitl_default -t query bin/px4 | grep -i nros
+    | external_modules/modules/nros_uorb_bridge/libmodules__nros_uorb_bridge.a
+    | .../target/release/libnros_cpp.a
+    | .../build/nros-platform-posix/libnros_platform_posix.a
+    | .../examples/px4/cpp/bridge/ffi/target/release/libnros_px4_bridge_ffi.a
+```
+
+So `bin/px4` DOES relink when the archive changes. The defect was never a
+missing edge — it was that nothing decided WHICH archive should be there.

--- a/docs/issues/archived/1046-px4-stale-tree-guard-checks-a-surviving-directory.md
+++ b/docs/issues/archived/1046-px4-stale-tree-guard-checks-a-surviving-directory.md
@@ -1,11 +1,13 @@
 ---
 id: 1046
 title: "The PX4 SITL stale-tree guard asserts a module DIRECTORY, which outlives the build that linked it — so it passes on exactly the tree it exists to reject"
-status: open
+status: resolved
 type: bug
 area: testing
 severity: medium
 found: 2026-09-04
+resolved: 2026-09-05
+resolved_in: 0a47f949a (guard) + the sweep below
 related: [phase-325, 0196, 0445, 0859]
 ---
 
@@ -114,14 +116,57 @@ enough to turn a confusing runtime failure into the message that already exists.
 
 **Keep the existing message.** It is right. Only the predicate is wrong.
 
-## Not covered
+## The three "not covered" items, now swept (2026-09-05)
 
-* Whether `px4_xrce_e2e.rs` has the same shape. It guards
-  `path.join("Tools").is_dir()` (`:42`), which is a *tree* check rather than a
-  built-module check, so it is probably a different question — unverified.
-* Whether anything else in the tree proxies "was X built into this artifact" by
-  a directory test. Not swept.
-* The `bin/px4-<mod>` shims surviving is itself worth a look: a shim for a module
-  that is not in the binary is a second stale artifact, and it may be what makes
-  the runtime failure read as "command exists but does nothing" rather than
-  "command not found". Not investigated.
+Re-measured on the same host. The fix in `0a47f949a` still rejects the stale
+tree — run against the build dir as it stands today (last built from
+`build-bridge-example`):
+
+```
+$ cd packages/testing/nros-px4-sitl-test
+$ PX4_AUTOPILOT_DIR=.../PX4-Autopilot cargo test --test px4_uorb_interop_e2e
+SITL tree at .../build/px4_sitl_default was built WITHOUT the uORB interop
+example: .../bin/px4 does not contain `nros_uorb_demo`.
+...
+test result: FAILED. 0 passed; 1 failed; finished in 0.04s
+```
+
+and the table it keys on still holds — `strings -a bin/px4 | grep -c <name>`:
+
+| module | module dir | `bin/px4-<mod>` shim | occurrences in `bin/px4` |
+| --- | --- | --- | ---: |
+| `nros_uorb_demo` | present | **absent** | 0 |
+| `nros_uorb_bridge` | present | present | 8 |
+
+**One number in the original table does not reproduce: the demo's shim is now
+absent.** So the shims are *not* reliably stale — PX4 cleans some of them. That
+makes the third item below a non-finding rather than a second stale artifact:
+the shim is inconsistent, which is a reason not to key a guard on it, and the
+guard no longer does. The module DIRECTORY, which is the half the guard used to
+key on, does survive — that claim reproduces exactly.
+
+* **`px4_xrce_e2e.rs` — different question, confirmed.** Its
+  `path.join("Tools").is_dir()` (`:42`) asks "is this a PX4 checkout", which is
+  what it says and is correct for it. It needs no built-module guard because it
+  BUILDS SITL itself (`build_vanilla_sitl()`, `:50`). That is worth its own
+  look for two unrelated reasons — it is a `make` inside a test (CLAUDE.md's
+  "no compilation inside tests"), and PX4's `cmake-cache-check` only compares
+  options it was PASSED, so a `make px4_sitl_default` with no
+  `EXTERNAL_MODULES_LOCATION` reconfigures nothing and inherits the cached one,
+  i.e. "vanilla" is not vanilla. Neither affects this issue: an extra module in
+  the tree does not break the XRCE path. Not filed here.
+* **Nothing else proxies "was X built into this artifact" by a directory test.**
+  Swept the whole PX4 seam: `nros_px4_add_module` has exactly three callers
+  (`examples/px4/cpp/firmware`, `examples/px4/cpp/bridge`,
+  `integrations/px4/module-template`), and the only other consumer of a built
+  nano-ros artifact in this area, `packages/testing/nros-px4-register-check`,
+  calls `px4_add_module` directly and links no nano-ros archive at all.
+* **The surviving shim: see above** — it does not reliably survive, so there is
+  nothing to chase.
+
+## The class this belongs to also existed one layer up — see #1050
+
+The same "a guard whose predicate cannot observe the case its own message
+describes" shape sat in `nros_px4_add_module`'s archive precheck, which ran only
+`if(_networked_backends)` — i.e. never for the uORB-only module the bug happens
+to. Fixed with this issue's sweep; recorded in #1050.

--- a/docs/roadmap/phase-424-build-graph-freshness-truth.md
+++ b/docs/roadmap/phase-424-build-graph-freshness-truth.md
@@ -19,7 +19,12 @@ rebuild knows what the artifact was built from* — and the failures are
 symmetrical, which is what makes the grouping useful rather than tidy:
 
 * **False FRESH** hands the test a museum binary, and the run reports on code
-  that is not in the tree. Issues 0820 and 1050.
+  that is not in the tree. Issues 0820 and 1050. **1050 turned out NOT to be a
+  missing edge** (measured 2026-09-05): `bin/px4` carries a real `|` dependency
+  on `libnros_cpp.a`, so it relinks when the archive moves. Nothing decided
+  WHICH archive should be there — a different failure, one the build graph
+  cannot express, and the remedy was a configure-time assertion rather than an
+  edge or a wider watch set.
 * **False STALE** hands the developer a rebuild they did not earn, and the ones
   here are not merely slow: 0835's two families re-stale *each other*, so the
   cost is unbounded rather than one wasted build.
@@ -46,8 +51,8 @@ they all rest on is built on build-system internals nobody supports.
 | [#0945](../issues/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md) | cargo | the shared-cargo-dir campaign rests on five unsupported build-system assumptions |
 | [#1002](../issues/archived/1002-a-derived-knob-needs-three-configures-not-two.md) | cmake | RESOLVED — three is the chain's depth, not a defect; the defect was a bound counting the build dir's lifetime |
 | [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md) | codegen | a codegen change invalidates every consumer, connected only by a manual step |
-| [#1046](../issues/1046-px4-stale-tree-guard-checks-a-surviving-directory.md) | px4 | the stale-tree guard asserts a DIRECTORY that outlives the build that linked it |
-| [#1050](../issues/1050-px4-demo-links-whatever-archive-was-built-last.md) | px4 | links whatever `libnros_cpp.a` was built last |
+| [#1046](../issues/archived/1046-px4-stale-tree-guard-checks-a-surviving-directory.md) | px4 | RESOLVED 2026-09-05 — the guard asserted a DIRECTORY that outlives the build that linked it; it asserts `bin/px4`'s CONTENT now, and the three "not covered" sweeps came back empty |
+| [#1050](../issues/1050-px4-demo-links-whatever-archive-was-built-last.md) | px4 | links whatever `libnros_cpp.a` was built last — the recipe (1) and the configure-time guard (2) are fixed; open for (3), `nros::init()` taking slot 0 |
 | [#1056](../issues/1056-session-churn-window-too-short-for-start-skew.md) | test window | a check that can pass on the build it exists to reject |
 
 #1056 is here rather than with the RTOS work because its defect is the same

--- a/integrations/px4/NanoRosPx4Module.cmake
+++ b/integrations/px4/NanoRosPx4Module.cmake
@@ -95,6 +95,33 @@ _nros_px4_resolve_archive(_NROS_PX4_PLATFORM_A NROS_PLATFORM_ARCHIVE NROS_PLATFO
     "${NANO_ROS_ROOT}/build/nros-platform-posix/libnros_platform_posix.a"
     "cmake -S ${NANO_ROS_ROOT}/packages/platform/nros-platform-posix -B ${NANO_ROS_ROOT}/build/nros-platform-posix && cmake --build ${NANO_ROS_ROOT}/build/nros-platform-posix")
 
+# The NETWORKED backends this helper knows, in ONE place. Three sites read it —
+# the BACKENDS dispatch, the unknown-backend error, and the archive precheck
+# below — and when it was spelled out at each, the precheck's copy is the one
+# that would have been forgotten.
+set(_NROS_PX4_NETWORKED_BACKENDS zenoh xrce cyclonedds)
+
+# Does ${_nm_out} (llvm-nm --defined-only output) define nros_rmw_<backend>_register?
+#
+# Bounded on both sides rather than a bare substring, because the archive also
+# carries Rust-mangled names that CONTAIN the C one's prefix — measured on a
+# `rmw-zenoh-cffi` archive:
+#
+#   nros_rmw_zenoh_register                                    <- the C symbol
+#   _RNvNtCs..._14nros_rmw_zenoh13cffi_register8register       <- not it
+#   _RNvNvNtCs..._14nros_rmw_zenoh13cffi_register1__32___nros_rmw_backend_auto_register
+#
+# One predicate for BOTH directions of the check below: a presence test and an
+# absence test that disagree about what "defines" means is how a guard ends up
+# right in one direction and blind in the other.
+function(_nros_px4_archive_defines_backend OUT_VAR NM_OUT BACKEND)
+    if("\n${NM_OUT}\n" MATCHES "[^A-Za-z0-9_]nros_rmw_${BACKEND}_register[^A-Za-z0-9_]")
+        set(${OUT_VAR} TRUE PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} FALSE PARENT_SCOPE)
+    endif()
+endfunction()
+
 # nros-cpp / nros-c live under packages/api (phase-321 moved them there from
 # packages/core); the ABI headers stayed in packages/core. Validated below rather
 # than trusted: the W1 probe declared its symbols by hand instead of including
@@ -205,7 +232,7 @@ function(nros_px4_add_module)
                     ${_uorb}/src/callback_default.cpp
                     ${_uorb}/src/px4_callback_glue.cpp)
             set(_needs_work_queue TRUE)
-        elseif(_b MATCHES "^(zenoh|xrce|cyclonedds)$")
+        elseif(_b IN_LIST _NROS_PX4_NETWORKED_BACKENDS)
             # A NETWORKED backend contributes nothing at the cmake layer: it is
             # compiled INTO libnros_cpp.a by the cargo feature
             # `rmw-<name>-cffi`, which also pulls in `rmw-cffi` (the seam uORB
@@ -224,8 +251,8 @@ function(nros_px4_add_module)
         else()
             message(FATAL_ERROR
                 "nros_px4_add_module: BACKENDS '${_b}' is not a backend this "
-                "helper knows. In-firmware: uorb. Networked: zenoh, xrce, "
-                "cyclonedds.")
+                "helper knows. In-firmware: uorb. Networked: "
+                "${_NROS_PX4_NETWORKED_BACKENDS}.")
         endif()
     endforeach()
 
@@ -313,39 +340,101 @@ function(nros_px4_add_module)
     #
     # So: locate llvm-nm through rustc's own sysroot, and if it is not there,
     # SKIP the check rather than guess. The link error remains the backstop.
-    if(_networked_backends)
-        execute_process(COMMAND rustc --print sysroot
-            OUTPUT_VARIABLE _rustc_sysroot OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET RESULT_VARIABLE _sysroot_rc)
-        set(_llvm_nm "")
-        if(_sysroot_rc EQUAL 0)
-            file(GLOB _llvm_nm_candidates
-                "${_rustc_sysroot}/lib/rustlib/*/bin/llvm-nm")
-            if(_llvm_nm_candidates)
-                list(GET _llvm_nm_candidates 0 _llvm_nm)
-            endif()
+    #
+    # Issue 1050 — the check runs for EVERY module, not only for one that named a
+    # networked backend, and it checks BOTH directions.
+    #
+    # It used to sit behind `if(_networked_backends)`, which is exactly the set of
+    # modules the bug cannot happen to. The uORB demo declares `BACKENDS uorb`, so
+    # the whole block was skipped for it — and a uORB-only module linking a
+    # zenoh-carrying archive is the failure: on hosted POSIX the backend's
+    # `.init_array` ctor registers zenoh BEFORE main, hence before the generated
+    # `nros_app_register_backends()`, zenoh takes slot 0, `nros::init()` opens the
+    # default slot, dials tcp/127.0.0.1:7447, finds nothing, and the module dies
+    # with `nros::init() failed` -> PX4_ERROR -> shell status 255.
+    #
+    # So `BACKENDS` did not mean what it reads as. It read "this image registers
+    # uorb"; what it named was "this image ALSO registers uorb". The absence half
+    # below is what makes the keyword an assertion instead of a hint, and it is
+    # the same defect shape as issue 1046 one layer up: a guard whose predicate
+    # cannot observe the case its own message describes.
+    #
+    # `just px4 build-sitl-example` now builds the archive it links, which fixes
+    # the RECIPE. This fixes the SEAM: a hand-run
+    # `make px4_sitl_default EXTERNAL_MODULES_LOCATION=...` against an archive
+    # someone else's recipe left behind is caught here, at configure time,
+    # instead of at `nros_uorb_demo start`.
+    #
+    # Cost: one extra `llvm-nm --defined-only` per configure for a uORB-only
+    # module. Measured 0.012 s on the 26 MB archive. It hashes nothing and
+    # watches nothing, so it re-stales nothing (phase-424's constraint).
+    execute_process(COMMAND rustc --print sysroot
+        OUTPUT_VARIABLE _rustc_sysroot OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET RESULT_VARIABLE _sysroot_rc)
+    set(_llvm_nm "")
+    if(_sysroot_rc EQUAL 0)
+        file(GLOB _llvm_nm_candidates
+            "${_rustc_sysroot}/lib/rustlib/*/bin/llvm-nm")
+        if(_llvm_nm_candidates)
+            list(GET _llvm_nm_candidates 0 _llvm_nm)
         endif()
+    endif()
 
-        if(_llvm_nm)
-            execute_process(COMMAND "${_llvm_nm}" --defined-only "${_NROS_PX4_CPP_A}"
-                OUTPUT_VARIABLE _nm_out ERROR_QUIET)
-            foreach(_nb IN LISTS _networked_backends)
-                if(NOT _nm_out MATCHES "nros_rmw_${_nb}_register")
-                    message(FATAL_ERROR
-                        "nros_px4_add_module: BACKENDS lists '${_nb}', but\n"
-                        "    ${_NROS_PX4_CPP_A}\n"
-                        "does not define nros_rmw_${_nb}_register. Rebuild it "
-                        "with that backend:\n"
-                        "    cargo build -p nros-cpp --no-default-features "
-                        "--features std,rmw-${_nb}-cffi --release")
-                endif()
-            endforeach()
-        else()
-            message(STATUS
-                "nros_px4_add_module: llvm-nm not found via rustc sysroot; "
-                "skipping the backend-symbol precheck (the link will still catch "
-                "a mismatched archive, ~10 min later).")
-        endif()
+    if(_llvm_nm)
+        execute_process(COMMAND "${_llvm_nm}" --defined-only "${_NROS_PX4_CPP_A}"
+            OUTPUT_VARIABLE _nm_out ERROR_QUIET)
+
+        # (a) every DECLARED networked backend must be in the archive, or the
+        #     link dies on nros_rmw_<name>_register ~10 minutes from now.
+        foreach(_nb IN LISTS _networked_backends)
+            _nros_px4_archive_defines_backend(_has "${_nm_out}" "${_nb}")
+            if(NOT _has)
+                message(FATAL_ERROR
+                    "nros_px4_add_module: BACKENDS lists '${_nb}', but\n"
+                    "    ${_NROS_PX4_CPP_A}\n"
+                    "does not define nros_rmw_${_nb}_register. Rebuild it "
+                    "with that backend:\n"
+                    "    cargo build -p nros-cpp --no-default-features "
+                    "--features std,rmw-${_nb}-cffi --release")
+            endif()
+        endforeach()
+
+        # (b) and no UNDECLARED one may be, because it registers itself first.
+        foreach(_nb IN LISTS _NROS_PX4_NETWORKED_BACKENDS)
+            if(_nb IN_LIST _networked_backends)
+                continue()
+            endif()
+            _nros_px4_archive_defines_backend(_has "${_nm_out}" "${_nb}")
+            if(_has)
+                string(REPLACE ";" " " _declared "${NPX_BACKENDS}")
+                message(FATAL_ERROR
+                    "nros_px4_add_module: ${NPX_MODULE} declares BACKENDS "
+                    "'${_declared}', but\n"
+                    "    ${_NROS_PX4_CPP_A}\n"
+                    "defines nros_rmw_${_nb}_register — a backend this module did "
+                    "not ask for.\n"
+                    "That archive was left by another build (e.g. `just px4 "
+                    "build-bridge-example`). On hosted POSIX the '${_nb}' backend "
+                    "registers itself from an .init_array ctor BEFORE main, so it "
+                    "takes RMW slot 0 ahead of this module's generated "
+                    "nros_app_register_backends(), nros::init() opens IT, and the "
+                    "module fails at startup with `nros::init() failed` (issue "
+                    "1050).\n"
+                    "Rebuild the archive for THIS module:\n"
+                    "    cargo build -p nros-cpp --no-default-features "
+                    "--features std,rmw-cffi,platform-posix --release\n"
+                    "or, from the repo root, just:\n"
+                    "    just px4 build-sitl-example\n"
+                    "To link a different archive on purpose, point at it with "
+                    "-DNROS_CPP_ARCHIVE=<path> / NROS_CPP_ARCHIVE=<path>.")
+            endif()
+        endforeach()
+    else()
+        message(STATUS
+            "nros_px4_add_module: llvm-nm not found via rustc sysroot; "
+            "skipping the backend-symbol precheck (the link will still catch "
+            "a mismatched archive, ~10 min later; an UNDECLARED backend in the "
+            "archive links fine and fails at runtime — issue 1050).")
     endif()
 
     # PUBLIC so the archives propagate to the final px4 link. px4_add_module


### PR DESCRIPTION
Two issues. Most of what was open turned out to be **stale bookkeeping** — 1046's guard and 1050's defect (1) were already fixed and committed (`0a47f949a`, `0364c5405`). What was still broken is **1050 defect (2)**, fixed here.

## The live bug

`nros_px4_add_module`'s symbol precheck ran inside `if(_networked_backends)` — **exactly the set of modules the bug cannot happen to**. The uORB demo declares `BACKENDS uorb`, so the block was skipped entirely for it; and inside the block the check was one-directional anyway (declared ⇒ present, never present ⇒ declared).

Measured on the ambient archive as it sits today:

```
3 nros_rmw_cffi_register
3 nros_rmw_zenoh13cffi_register
1 nros_rmw_zenoh_register
```

So a hand-run `make px4_sitl_default EXTERNAL_MODULES_LOCATION=…` reproduces #1050 **right now**. The earlier fix guarded the recipe, not the shape.

The check now runs for **every** module and in **both** directions, over one shared backend list and one shared predicate rather than the two spellings that let the directions drift apart.

## The tool is part of the fix

It must be the **rust toolchain's** `llvm-nm`. The system nm (binutils + LLVM 14 gold plugin) cannot parse rust-1.96/LLVM 22 bitcode members and **does not fail cleanly** — it reads the few non-bitcode members and reports their symbols, missing `nros_rmw_zenoh_register` entirely.

Verified independently during review: the system nm errors with `Opaque pointers are only supported in -opaque-pointers mode (Producer: LLVM22.1.2-rust-1.96.0-stable, Reader: LLVM 14.0.0)` and under-reports, while the sysroot nm returns the three counts above.

A first draft failed open on *"nm saw nothing"*; a partial read defeats that, and the guard then rejects a good archive **with authority**. So the tool is located through rustc's own sysroot, and if it isn't there the check **skips rather than guesses** — the link error stays the backstop.

## Not the 0475 class — measured, not assumed

`libnros_cpp.a` is under `|` in `ninja -t query bin/px4`, not `||`, because `target_link_libraries(… PUBLIC <absolute path>)` **does** create a file edge. `bin/px4` relinks when the archive moves. Nothing decided *which* archive should be there, and that isn't expressible as an edge — hence an assertion.

## Phase-424 constraint

Doesn't bind: widens no watch set, hashes nothing. One `llvm-nm --defined-only` at configure, **0.012 s** on the 26 MB archive.

## #1046 closed

Its guard byte-scans `bin/px4` for the module command name; the module *directory* does survive (the load-bearing claim, reproduced); its three "not covered" sweeps came back empty. Its table claimed the demo's shim was present — **it is absent today**, which retires the third sweep as a non-finding.

**#1050 stays open for defect (3) only**, which is a design question rather than a check.

## Not verified

No end-to-end PX4 SITL build or runtime run — the worktree's `PX4-Autopilot` submodule is empty, and building in the shared checkout would have reconfigured a bridge-configured tree (~10 min). The guard is exercised through the real `nros_px4_add_module` with a stubbed `px4_add_module`, over a four-case truth table plus a predicate negative control.

`just check fast` 212/212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK