### PR TITLE
docs(#1071, #1072): 22 of 51 PRs conflicted, none on code — and one of them deleted four gates

### DIFF
--- a/docs/issues/1071-gate-registry-has-no-deletion-ratchet.md
+++ b/docs/issues/1071-gate-registry-has-no-deletion-ratchet.md
@@ -1,0 +1,100 @@
+---
+id: 1071
+title: "A pull request deleted four gates from `just/check.just` and every gate
+  stayed green — `check-gate-lists` verifies the registry's SHAPE, never its size"
+status: open
+type: bug
+area: tooling, ci
+related: [1072, 0196]
+---
+
+## What happened
+
+PR #431 (`feat/phase-420-w8-vendor-fetch-gate`) added one gate,
+`vendor-fetch-pinned`, and **deleted four unrelated ones** — recipes and
+`fast-serial:` registry entries both:
+
+* `box-sync-covers-tracked-source`
+* `build-type-spelling`
+* `entry-session-name`
+* `format-macro-scope`
+
+Measured against the branch's own merge-base, so this is not a rebase artifact:
+
+```
+                                 base   branch tip
+box-sync-covers-tracked-source      1             0
+build-type-spelling                 1             0
+entry-session-name                  1             0
+format-macro-scope                  1             0
+```
+
+All four had landed on `main` before the branch forked. The branch had rewritten
+`just/check.just` against an older copy of the file; the loss was not
+deliberate, and nothing in the commit message mentions it.
+
+`entry-session-name` is the gate for issues 1003/1017 — *every emitted
+`run_components` call must NAME a session* — whose defect "survived from
+2026-06-13 to 2026-09-03". It would have gone back to unguarded.
+
+## Why nothing caught it
+
+`check-gate-lists` is the gate that reads the registries. Its verdict:
+
+```
+check-gate-lists OK — 2 registry(ies), 232 gate(s), one per line and sorted.
+```
+
+232, where `main` has 236. **It passed.** It asks whether the list is
+one-name-per-line and sorted — properties a deletion satisfies perfectly. The
+count is printed and nothing compares it to anything.
+
+That is the repo's own recurring shape, one level up from issue 0196: the gate
+exists, it runs, it is green, and the rule it enforces is narrower than the rule
+anyone reading its name would assume. A registry that only ever grows has no
+mechanism saying so.
+
+The two neighbouring controls do not cover it either:
+
+* `check-gate-selftests` is already a ratchet, but over "how many gates run
+  their own selftest", not over how many gates exist. Deleting a gate that has
+  a selftest makes that ratchet *easier* to satisfy.
+* `check-test-scripts-have-callers` catches a `tests/*.sh` whose recipe was
+  dropped — the sibling failure, from `e569d9a55` — but only for shell scripts
+  under `tests/`. A gate whose recipe AND `scripts/check-*.py` both go leaves
+  nothing stranded to find.
+
+## Swept
+
+Every open pull request, gate names at merge-base vs branch tip: **#431 was the
+only one.** No other branch loses a gate.
+
+```
+python3 - <<'PY'   # full script in the issue history; short form:
+# for each open PR: gates(merge-base) - gates(branch tip) must be empty
+PY
+```
+
+## What would fix it
+
+A ratchet on the registry's size, in the shape `check-gate-selftests` already
+uses: a committed baseline count that may only increase, with a
+`--write-baseline` escape for a deliberate retirement that says why. Retiring a
+gate is rare and always intentional; re-stating the number is the right price.
+
+Worth deciding at the same time whether the ratchet is on the COUNT or on the
+NAME SET. The name set is strictly better — it catches a delete-plus-add that
+nets to zero, which is exactly the shape #431 had (one added, four removed, net
+−3 and still passing) — and costs a longer baseline file.
+
+## Also worth noting
+
+#431's four deletions and its one addition sat in the same file as **twelve of
+the twenty-two conflicting pull requests** measured in issue 1072.
+`just/check.just` is the tree's single busiest merge target, which is both why
+the branch had a stale copy of it and why nobody diffing the PR would have
+looked past the hunk they cared about.
+
+Repaired in the branch (restored from `origin/main`, W8's own gate re-applied on
+top, 236 gates, `check-gate-lists` green); the missing ratchet is what this
+issue tracks.

--- a/docs/issues/1072-every-pr-conflicts-on-five-shared-append-targets.md
+++ b/docs/issues/1072-every-pr-conflicts-on-five-shared-append-targets.md
@@ -1,0 +1,157 @@
+---
+id: 1072
+title: "22 of 51 open pull requests conflicted, none of them on code — five
+  shared append targets account for every one"
+status: open
+type: tech-debt
+area: tooling, ci
+related: [0883, 0884, 1071]
+---
+
+## The measurement
+
+On 2026-09-05, 51 pull requests were open and **22 were `CONFLICTING`**. For
+each, the files it touches were intersected with the files `main` moved since
+that branch's merge-base. The result is not a spread:
+
+| conflicting path | in how many of the 22 |
+| --- | --- |
+| `just/check.just` | **12** |
+| `docs/issues/README.md` | 5 |
+| `docs/issues/0968-tier2-runtime-failures-unreproduced.md` | 4 |
+| `docs/issues/1052-esp32-talker-faults-after-network-bringup.md` | 4 |
+| `docs/roadmap/phase-424-build-graph-freshness-truth.md` | 4 |
+| `docs/reference/api-parity-ledger/*.json` | 3 |
+
+**Not one conflict was a genuine disagreement about code.** Every one was two
+authors appending to the same shared file. Nineteen of the 22 were resolved
+mechanically — keep both sides, order them by narrative — and the resolution was
+the same shape every time.
+
+This is issue 0883's finding, which was thought to be closed. It is not; it
+recurred in four more places at once.
+
+## The five, and why each is a different problem
+
+### 1. `just/check.just` — the format fix worked; the recipe bodies never got one
+
+The obvious suspect is the `fast-serial:` registry, and the obvious suspect is
+innocent. That list is already hardened: one name per line, sorted, with a
+`_gate-list-end` sentinel added specifically so the last entry is not the one
+line with different syntax. It merges **cleanly**. Two branches inserting
+`preconditions-provisioned` and `prereq-roles` four lines apart produced no
+conflict at all.
+
+What conflicts is the **recipe body**. A new gate is ~15 lines of comment plus
+three lines of recipe, appended at a spot the author chooses, and there is no
+ordering rule for bodies — so authors pick a semantically-related neighbour, and
+two people adding related gates pick the *same* neighbour. Both PRs above
+appended immediately after the `kconfig-overridden-values` comment block.
+
+The registry got the treatment and the bodies did not, which reads as an
+oversight rather than a decision. Sorting bodies the way the registry is sorted
+would make two additions land at different offsets by construction.
+
+### 2. `docs/issues/README.md` — frozen, and the in-flight PRs predate the freeze
+
+`main` now carries `## Recently resolved — FROZEN, do not append (issue 0883's
+class)`, which says outright that *adding an entry here is the conflict everyone
+else then has to resolve*. That is the right fix. But five open branches were
+written before it and still add a digest line, so each one now conflicts against
+the paragraph explaining why it should not.
+
+Resolution is to drop the row: the digest is a summary of `archived/<id>-*.md`,
+which is consistently the larger document (#0870: 41,035 bytes archived vs a
+~2,000-byte digest). Nothing is lost. But nothing *tells* the author that —
+the freeze is prose, not a gate.
+
+### 3. A live issue file — several sessions investigating one bug
+
+`0968` and `1052` are open issues under active investigation by more than one
+session, and each session appends a findings section. Four PRs each on the same
+file, all at the same anchor.
+
+Unlike the others this one is **not obviously wrong**. The alternative — one
+file per finding — trades a merge conflict for a reader who has to assemble the
+narrative from six files. What makes it expensive here is that the sections have
+a real ORDER (`gdb names the frame` → `STATIC ANALYSIS` → `RESOLVED, both
+halves` → `ROOT CAUSE`), and a positional 3-way merge gets that order wrong
+silently: resolving four of #426's six commits by anchor left `STATIC ANALYSIS`
+sitting after `CONFIRMED by experiment`, reading as the newest word when it is
+the superseded one.
+
+### 4. A phase doc's `**Status**` paragraph and issue table
+
+`phase-424` carries one Status paragraph and an eight-row issue table. Every PR
+in the phase rewrites the paragraph and one row. Two sides each rewriting the
+same paragraph is not a merge git can do — and taking both is worse than taking
+one, because the doc then states two different counts of what is closed. (That
+exact defect shipped once already and had to be repaired.)
+
+The table rows are the tractable half: each row belongs to the side that
+actually moved that issue, and picking per-row is mechanical once stated. The
+Status paragraph has to be rewritten by hand from the merged table, every time.
+
+### 5. `docs/reference/api-parity-ledger/*.json` — a textual merge on a sorted map
+
+These are flat JSON objects written by `scripts/api-parity.py` with
+`sort_keys=True, indent=1`. **On-disk order carries no information**, so two
+branches adding disjoint keys land at the same byte offset and conflict with
+certainty. Union-merging `node.json` gave `116 ours + 120 theirs -> 122 keys, 0
+clashes` — a merge git had no way to perform and a five-line script does
+exactly.
+
+This is the one with an unambiguous fix: a `.gitattributes` merge driver that
+parses, unions, and re-dumps.
+
+**Except it cannot be, and that is the load-bearing part** — issue 0884 already
+established that GitHub rebases queue entries **server-side**, where
+`.gitattributes` drivers do not run. So a driver fixes local merges and leaves
+the merge queue exactly as it is. The fix that reached the queue for `open.md`
+was *untracking the file*. Whatever is done here has to work with no custom
+driver.
+
+## Why it costs more than the resolutions
+
+The merge queue is serial. A batch ejects when one entry conflicts, and every
+entry behind it re-runs. With 22 of 51 conflicting on six files, an ejection is
+not bad luck — it is the expected state.
+
+CLAUDE.md already names the class for one file:
+
+> **A generated file that is COMMITTED and touched by every PR serialises the
+> merge queue** (issues 0883/0884)
+
+The generalisation the measurement supports is stronger, because four of these
+five are not generated: **any file every PR appends to serialises the queue,
+generated or authored.** `open.md` could be fixed by generating it and
+gitignoring it. `just/check.just` cannot be untracked, `docs/issues/README.md`
+is authored prose, a live issue file is the record itself, and a phase doc's
+Status is a human sentence.
+
+## What to decide
+
+1. **`just/check.just` recipe bodies** — sort them, the way the registry already
+   is, and gate it. Highest count by a factor of two, and the cheapest.
+2. **`docs/issues/README.md`** — the freeze is prose; make it a gate, so a PR
+   adding a digest row fails at `check` instead of at the queue.
+3. **The parity ledgers** — decide the shape given that a merge driver does not
+   reach the queue. Splitting one file per key is the untracking-shaped answer.
+4. **Phase docs** — the issue TABLE can be per-row mechanical. Whether the
+   Status paragraph should exist at all, when the table beneath it already
+   carries the state, is the real question.
+5. **Live issue files** — probably leave alone. Worth stating the append
+   convention (newest section last, and say what it supersedes) so a positional
+   merge is less likely to reorder a narrative silently.
+
+## Method
+
+```
+# for each open PR: files it touches ∩ files main moved since its merge-base
+mb=$(git merge-base origin/main origin/<branch>)
+comm -12 <(git diff --name-only $mb..origin/<branch> | sort) \
+         <(git diff --name-only $mb..origin/main     | sort)
+```
+
+`git merge-tree --write-tree` would answer this directly and is unavailable —
+git 2.34.1 here, it needs 2.38+.


### PR DESCRIPTION
Two findings from rebasing the 22 `CONFLICTING` pull requests onto current `main`. Nineteen are now rebased and pushed; three were superseded and closed (#356, #360, #401); three are left to their owners (#329, #400, #446 — see below).

## #1072 — the conflicts are six files, not bad luck

For each conflicting PR, the files it touches ∩ the files `main` moved since its merge-base:

| path | in how many of the 22 |
| --- | --- |
| `just/check.just` | **12** |
| `docs/issues/README.md` | 5 |
| `docs/issues/0968-*.md` | 4 |
| `docs/issues/1052-*.md` | 4 |
| `docs/roadmap/phase-424-*.md` | 4 |
| `docs/reference/api-parity-ledger/*.json` | 3 |

**Not one was a disagreement about code.** Every one was two authors appending to a shared file, and 19 of 22 resolved mechanically as *keep both, order them*.

The `just/check.just` result is the surprising half: **the `fast-serial:` registry is innocent.** It is already one-name-per-line, sorted, with a `_gate-list-end` sentinel added for exactly this — and it merges cleanly, including two branches inserting names four lines apart. What conflicts is the **recipe body**, which has no ordering rule, so two authors adding related gates append at the same semantically-related neighbour. The registry got the treatment; the bodies never did.

This generalises 0883/0884: CLAUDE.md states the class for a *generated* file, and four of these five are authored, so `open.md`'s fix — generate it, gitignore it — reaches none of them. 0884's other finding constrains the remedy too: GitHub rebases queue entries **server-side**, where `.gitattributes` merge drivers do not run, so a union driver for the JSON ledgers would fix local merges and leave the queue exactly as it is.

## #1071 — a PR deleted four gates and `check-gate-lists` said OK

PR #431 added `vendor-fetch-pinned` and removed `box-sync-covers-tracked-source`, `build-type-spelling`, `entry-session-name`, `format-macro-scope` — recipes and registry entries both. Measured at the branch's own merge-base, so not a rebase artifact.

```
check-gate-lists OK — 2 registry(ies), 232 gate(s), one per line and sorted.
```

232 where `main` has 236, and it **passed**: the gate asks whether the list is sorted and one-per-line, which a deletion satisfies perfectly. The count is printed and compared to nothing. `entry-session-name` is the guard for issues 1003/1017, whose defect had already survived from 2026-06-13 to 2026-09-03.

**Swept:** every open PR, gate names at merge-base vs tip. #431 was the only one. Repaired in that branch (restored from `origin/main`, W8's own gate re-applied, 236 gates, green); the missing ratchet is what #1071 tracks.

## Left to their owners

- **#329, #400** — moved on the remote minutes before I looked; actively held by another session.
- **#446** — 37 commits re-authoring `api-parity-ledger/node.json`. A union merge preferring `main` reported 26–27 clashing keys per step, i.e. it was discarding the branch's own point. Needs its author, not a rebase.
- **#422** — collides substantively with an 1025 fix already on `main`: two competing implementations of `nros_fixture_row_artifact_dir_by_id`, the branch's deriving the platform from the manifest rather than taking it as an argument. That is a re-author, not a conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj