### PR TITLE
feat(issues): `just issue-new` shows prior art before reserving an id

### DIFF
--- a/scripts/reserve-issue-id.sh
+++ b/scripts/reserve-issue-id.sh
@@ -47,6 +47,77 @@ MAX_ATTEMPTS=25
 
 slug="${1:-}"
 
+# --------------------------------------------------------------------------
+# Before reserving: show what already exists on this subject.
+# --------------------------------------------------------------------------
+#
+# This script has always guarded duplicate IDs — the numbering race, where two
+# sessions pick the same number. It said nothing about duplicate SUBJECTS, and
+# that is the failure that actually costs: an issue filed for work already done
+# or in flight. Eleven of those happened in one session on 2026-09-04/05, every
+# one surfacing later through a merge conflict, a failing gate, or reading the
+# code — never at the moment of filing, which is where it is cheapest.
+#
+# `scripts/issues.py` already searches title and body, and `--all` reaches
+# `archived/` — which is where an ALREADY-FIXED issue lives, and therefore
+# exactly where a duplicate hides. Nothing prompted anyone to run it.
+#
+# Advisory, never fatal: a false match must not block filing, and the search
+# failing must not either. `NROS_ISSUE_SKIP_SEARCH=1` silences it for scripts.
+#
+# The terms are the slug's own words. `issues.py` ANDs them, so a six-word slug
+# matches nothing — hence the narrowing: three words, then two, then one. The
+# query that produced the hits is printed, because a reader has to know how
+# wide a net caught them.
+prior_art_search() {
+    [ -n "$slug" ] || return 0
+    [ -z "${NROS_ISSUE_SKIP_SEARCH:-}" ] || return 0
+    command -v python3 >/dev/null 2>&1 || return 0
+    [ -f scripts/issues.py ] || return 0
+
+    local words
+    words="$(printf '%s\n' "$slug" | tr '-' '\n' \
+        | awk 'length($0) >= 4' \
+        | grep -vxE 'with|when|that|this|from|into|does|only|then|than|were|been|have|they|what|make|made|used|uses|using|about|after|before' || true)"
+    [ -n "$words" ] || return 0
+
+    # Rank by SELECTIVITY, not by length. Length is the wrong proxy: in the case
+    # this was built for, the longest word (`nonconforming`) was the filer's own
+    # coinage and matched NOTHING, while `stdbool` — the shared vocabulary —
+    # matched the three issues that mattered. `nuttx` matched 256 and is equally
+    # useless in the other direction.
+    #
+    # So a term earns its place by matching FEW issues but more than zero. The
+    # ledger query is ~20 ms, so scoring every word costs a fraction of a second.
+    local best_term="" best_count=0 w c
+    while IFS= read -r w; do
+        [ -n "$w" ] || continue
+        c="$(python3 scripts/issues.py --all "$w" 2>/dev/null | wc -l || echo 0)"
+        [ "$c" -gt 0 ] || continue          # a word nobody else used says nothing
+        [ "$c" -le 12 ] || continue         # a word everybody used says nothing either
+        if [ -z "$best_term" ] || [ "$c" -lt "$best_count" ]; then
+            best_term="$w"
+            best_count="$c"
+        fi
+    done <<EOF
+$words
+EOF
+
+    [ -n "$best_term" ] || return 0
+
+    echo "" >&2
+    echo "Existing issues matching '$best_term' (open AND archived):" >&2
+    python3 scripts/issues.py --all "$best_term" 2>/dev/null | head -8 | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  If one of these is your subject, ADD to it rather than filing a" >&2
+    echo "  second row — an archived match means the work may already be DONE." >&2
+    echo "  Search wider yourself with: just issues --all <terms>" >&2
+    echo "" >&2
+    return 0
+}
+
+prior_art_search
+
 # Highest id already used by a FILE, in either docs/issues/ or archived/.
 # `archived/` counts — forgetting it is how ids get reused for a second time
 # after the first document is filed away.


### PR DESCRIPTION
`reserve-issue-id.sh` has always guarded duplicate **IDs** — the numbering race where two sessions pick the same number. It said nothing about duplicate **subjects**, and that is the failure that costs: an issue filed for work already done or in flight.

Eleven of those happened in one session (2026-09-04/05). Every one surfaced *later* — through a merge conflict, a failing gate, or finally reading the code — never at the moment of filing, which is where it is cheapest to catch. Two concrete ones:

- **#1024** (`NROS_XRCE_AGENT_VERBOSE` inert) duplicated work **#0741** had already landed, in both the agent build and the harness.
- **#1039** (NuttX `stdbool`) duplicated **#1035**, already resolved.

`scripts/issues.py` could have found both — it searches title and body, and `--all` reaches `archived/`, which is exactly where an already-fixed issue lives. Nothing prompted anyone to run it. Now `issue-new` runs it.

## Ranked by selectivity, not length — and that is the whole design

Length is the obvious proxy and it is **wrong**. For #1039's slug the longest word was `nonconforming` — the filer's own coinage, matching *nothing* — while `stdbool`, the shared vocabulary, matched the three issues that mattered. `nuttx` matched 256 and is useless in the other direction.

So a term earns its place by matching **few** issues and **more than zero** (1..12). The ledger query is ~20 ms, so scoring every slug word costs a fraction of a second.

## Verified against the real cases, not invented ones

| slug | picks | surfaces |
| --- | --- | --- |
| `xrce-agent-verbose-knob-silently-inert` | `verbose` | **#0741** (done) |
| `nuttx-stdbool-nonconforming-breaks-zenoh-pico` | `stdbool` | **#1035** (done) |
| `frobnicator-widget-quuxify-baseplate` | — | silent, no false noise |

**The first version ranked by length and missed #1039 entirely.** It is correct now only because it was tested against both cases rather than the one it was written for.

## Properties

- **Advisory, never fatal.** A false match must not block filing, and neither must the search failing — missing `python3`, missing script, or a query error all return quietly. `NROS_ISSUE_SKIP_SEARCH=1` silences it for scripted callers.
- **It does not decide.** It prints what exists and notes that an archived match may mean the work is already done. The reading is the filer's.
- **No shared file.** Nothing here reintroduces the `open.md` problem — every PR touching one path was what made that a conflict site.

## Two alternatives tested and rejected

- *"All acceptance boxes ticked → resolve it."* Only 3 open issues use checkboxes, none all-ticked — and it would **not** have caught #1011, whose boxes stayed unticked while the fix landed.
- *"Open issue with a merged `fix(#N)` commit."* 10+ matches, most legitimately open (#0870 has fix commits and is genuinely unsolved). As a gate it fails good builds; useful only as periodic triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)