### PR TITLE
fix(#0835, phase-424): key the shared cargo dir on features, not the platform label

### DIFF
--- a/docs/issues/archived/0835-fixture-staleness-probe-families-restale-each-other.md
+++ b/docs/issues/archived/0835-fixture-staleness-probe-families-restale-each-other.md
@@ -3,7 +3,7 @@ id: 835
 title: "The cmake and rust fixture families re-stale each other, so
   `check-fixtures-stale` never reaches a fixed point and `just ci-matrix` fails
   ~190 tests on every run"
-status: open
+status: resolved
 type: bug
 area: testing
 related: [issue-0828, issue-0196, issue-0466, phase-344, phase-340]
@@ -342,3 +342,53 @@ The two candidate fixes, for whoever takes it:
 grep -rn 'inputsig' scripts/test/*.sh scripts/build/*.sh | head
 grep -rn 'nros_fixture_target_dir_flag\|cargo-fixtures' scripts/
 ```
+
+
+## RESIDUAL CLOSED 2026-09-05 — the cargo dir keys on the resolved feature set
+
+The oscillation half was fixed and gated 2026-09-04. This closes the remainder:
+the duplicated ThreadX corrosion groups, which were wasted disk rather than
+staleness.
+
+Done as this issue recommended — `packages/api/nros-c/CMakeLists.txt`'s key field
+`platform=${NANO_ROS_PLATFORM}` becomes `features=<sorted resolved set>`.
+
+**The duplication, re-measured from the `.key` files themselves before the
+change:**
+
+    036d16e80e45  platform=threadx         |rmw=zenoh     |board=riscv64-qemu|caps=|release|riscv64gc-…
+    89bb1118ba8f  platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|caps=|release|riscv64gc-…
+    591f35a52a72  platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|caps=|release|riscv64gc-…
+    4ec5af25ffb6  platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|caps=|release|riscv64gc-…
+
+Four groups differing in nothing but the label. The survey holds: freertos has
+one group, native's four and threadx-linux's two differ by `rmw` or `caps`,
+which are real.
+
+**That the two spellings resolve identically is now measured, not read.** Driving
+the real `nros_feature_set` for this board:
+
+    threadx          ->  features=alloc,cffi-zenoh-cffi,platform-threadx,ros-humble
+    threadx_riscv64  ->  features=alloc,cffi-zenoh-cffi,platform-threadx,ros-humble
+
+so each pair collapses to one group: 4 -> 2 on this board.
+
+**Dropping the label is safe because it is not load-bearing for CARGO, checked
+rather than assumed.** `NANO_ROS_PLATFORM` reaches no cargo environment and no
+build script reads it — the only references outside cmake are two tests
+asserting that cmake sets it. It stays load-bearing for cmake dispatch, where
+five sites key on the exact string; this changes what the DIRECTORY is keyed on,
+not what the variable means.
+
+The key is SORTED, because it must not depend on the order features happened to
+be appended in.
+
+**Cost, as this issue priced it:** every existing group hash changes, so the
+first build after this lands rebuilds the corrosion cargo dirs once. The old
+group directories are not removed by this change — they are inert and will be
+reclaimed by whatever prunes build output, which is the disk-waste half of this
+issue arriving one more time before it goes away.
+
+**Not run:** no cross build was performed. The merge is established by driving
+the real feature-set function and by the `.key` files above, not by observing two
+leaves land in one directory.

--- a/packages/api/nros-c/CMakeLists.txt
+++ b/packages/api/nros-c/CMakeLists.txt
@@ -100,10 +100,41 @@ nros_resolve_cargo_profile()
 # make (board="", caps="x") and (board="x", caps="") hash IDENTICALLY — two
 # different configurations sharing one directory, which is precisely the defect
 # being fixed. A label keeps every field non-empty and positional.
+#
+# issue 0835 — the first field is the resolved FEATURE SET, not
+# `platform=${NANO_ROS_PLATFORM}`. `NANO_ROS_PLATFORM` carries two meanings at
+# once: a platform FAMILY for cmake dispatch and a platform VARIANT for tier
+# selection, and this directory only ever cared about the second. Keying on the
+# label hashed a cmake-dispatch detail that merely CORRELATES with the artifacts.
+#
+# Measured before the change, on one board, from the `.key` files themselves:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — four groups differing in nothing but the label, where two would do, because
+# `NanoRosFeatureSet.cmake` resolves BOTH spellings to `alloc platform-threadx`
+# on this board (`threadx` takes its `_cross` arm; riscv64-qemu IS cross).
+# ThreadX was the only platform that split: freertos has one group, native's four
+# and threadx-linux's two differ by `rmw` or `caps`, which are real.
+#
+# The label is safe to drop because it is not load-bearing for CARGO, checked
+# rather than assumed: `NANO_ROS_PLATFORM` reaches no cargo environment and no
+# build script reads it. It stays load-bearing for cmake dispatch, where five
+# sites key on the exact string — this changes what the DIRECTORY is keyed on,
+# not what the variable means.
+#
+# Sorted, because a key must not depend on the order the features happened to be
+# appended in.
 if(COMMAND nros_share_corrosion_cargo_dir)
     string(REPLACE ";" "," _caps_flat "${_caps}")
+    set(_features_key ${_features})
+    list(SORT _features_key)
+    string(REPLACE ";" "," _features_flat "${_features_key}")
     nros_share_corrosion_cargo_dir(KEY
-        "platform=${NANO_ROS_PLATFORM}"
+        "features=${_features_flat}"
         "rmw=${NANO_ROS_RMW}"
         "board=${NANO_ROS_BOARD}"
         "caps=${_caps_flat}"


### PR DESCRIPTION
Closes #0835's residual — the duplicated ThreadX corrosion groups, which are wasted disk rather than staleness. The oscillation half was fixed and gated 2026-09-04.

Done as the issue recommended: the key's first field becomes the **resolved feature set** instead of `platform=${NANO_ROS_PLATFORM}`. That variable carries two meanings at once — a platform *family* for cmake dispatch and a platform *variant* for tier selection — and this directory only ever cared about the second, so the key hashed a label that merely **correlates** with the artifacts.

## The duplication, re-measured from the `.key` files

```
platform=threadx         |rmw=zenoh     |board=riscv64-qemu|caps=|release|riscv64gc-…
platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|caps=|release|riscv64gc-…
platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|caps=|release|riscv64gc-…
platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|caps=|release|riscv64gc-…
```

Four groups differing in **nothing but the label**.

## That they resolve identically is measured, not read

Driving the real `nros_feature_set` for this board:

```
threadx          ->  features=alloc,cffi-zenoh-cffi,platform-threadx,ros-humble
threadx_riscv64  ->  features=alloc,cffi-zenoh-cffi,platform-threadx,ros-humble
```

So each pair collapses: **4 groups → 2** on this board. The survey holds elsewhere — freertos has one group; native's four and threadx-linux's two differ by `rmw` or `caps`, which are real.

## Dropping the label is safe, and that was checked

`NANO_ROS_PLATFORM` reaches **no cargo environment** and **no build script reads it** — the only references outside cmake are two tests asserting that cmake sets it. It stays load-bearing for cmake **dispatch**, where five sites key on the exact string. This changes what the *directory* is keyed on, not what the variable means.

The key is **sorted**, because it must not depend on the order features happened to be appended in.

## Cost, as the issue priced it

Every existing group hash changes, so the first build after this rebuilds the corrosion cargo dirs **once**. The old directories are inert and are not removed here.

## Phase-424 constraint

Doesn't bind — this is a directory *key*, not a watch set. It hashes no build output and adds no path to any `.inputsig`.

## Not run

No cross build. The merge is established by the real feature-set function and the `.key` files above, not by watching two leaves land in one directory.

`just check fast` 212/212, `check fixture-staleness-probes` 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK