### PR TITLE
fix(#0961): both criteria are met — resolve it, and gate the check so it stays

### DIFF
--- a/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/0827-unused-rmw-pools-dominate-static-ram.md
@@ -438,3 +438,69 @@ derivation, published into a carrier that already exists on both sides. The open
 question is no longer WHERE the number goes, it is what a cargo leaf derives
 FROM — and that is a question about where entities are declared, not about
 transport.
+
+
+## The SOURCE exists too, and it is already in the tree (2026-09-05)
+
+The section above closed the carrier question and left one open: *"what a cargo
+leaf derives FROM"*. It has an answer that needs no new mechanism, and the
+answer was sitting beside the leaf the whole time.
+
+**`<leaf>/metadata/<component>.json` — the metadata probe's output.** It is
+present today for every probeable native leaf:
+
+```
+examples/native/rust/talker/metadata/talker.json
+examples/native/rust/listener/metadata/listener.json
+examples/native/rust/action-client/metadata/fibonacci_action_client.json
+examples/native/rust/action-server/metadata/fibonacci_action_server.json
+```
+
+and it carries exactly the counts the pools are sized by. Per node, the list
+keys are `publishers`, `subscribers`, `timers`, `services`, `actions` — read out
+of the files, not from a schema doc:
+
+| leaf | what its metadata states |
+| --- | --- |
+| `talker` | `publishers: 1`, `timers: 1` |
+| `listener` | `subscribers: 1` |
+| `fibonacci_action_client` | `action_clients: 1` |
+
+So `ZPICO_MAX_SUBSCRIBERS` comes from `subscribers`, `ZPICO_MAX_QUERYABLES` from
+`services` plus the infra floor, and so on. The declaration is already parsed;
+nothing needs a second parser.
+
+### Why this does not contradict the ordering argument above
+
+It does not reach backwards across the dependency edge — it does not try to.
+The probe runs BEFORE the build, as its own step, and writes a file. The build
+script then reads an `[env]` value, exactly as it does today for a hand-written
+one. The ordering argument rules out deriving the number *inside* the cargo
+graph; it says nothing against deriving it before the graph is built, which is
+what `nros sync` already is.
+
+### Both artifacts are gitignored, and that is consistent rather than a problem
+
+`examples/**/metadata/*.json` is ignored (`.gitignore:184`), and so is the
+`.cargo/` sidecar the derived `[env]` belongs in (issues 0457/0463). Both are
+per-host, regenerated, never committed. A fresh clone has neither and gets both
+from `nros sync` — the same contract `generated/` already has.
+
+### What is left, precisely
+
+One step: read the probe output, apply the counting rules
+`entity_inventory` already encodes, write the `[env]` block into the sidecar.
+Carrier measured (415,469 -> 136,293 B), source verified present, rules already
+written. No new mechanism, no second SSoT.
+
+### The one place this does NOT reach, and it has an issue
+
+Leaves whose metadata is `<component>.json.unprobeable` — the probe cannot run
+for them, twice over: `[unstable] build-std` with a foreign `[build] target`
+(`ProbeBlocker::BuildStdForForeignTarget`), and a board crate that does not build
+for a host triple at all. Every `examples/qemu-esp32-baremetal/rust/*` leaf is in
+this set. That is **issue 1061**, and it is the reason those leaves still state
+their budgets by hand in `.cargo/config.toml`.
+
+So the derivation splits by leaf kind, and the split is measured rather than
+assumed: native leaves have a source today, cross-compiled ones need 1061 first.

--- a/docs/issues/archived/0961-executor-open-in-needs-more-than-32k-of-caller-stack.md
+++ b/docs/issues/archived/0961-executor-open-in-needs-more-than-32k-of-caller-stack.md
@@ -1,7 +1,7 @@
 ---
 id: 961
 title: "Executor::open_in needs more than 32 KiB of the calling thread's stack, and nothing says so"
-status: open
+status: resolved
 area: core, memory
 severity: high
 found: 2026-08-31
@@ -262,7 +262,59 @@ floor is 3104 and every in-tree image (minimum 16384) passes, so the check is
 silent on the current tree and armed against a regression in `MAX_CBS`,
 `MAX_NODES`, or anything else that grows the value.
 
-**What this still does NOT do.** The board has not booted it — item 1 of the two
-above is unchanged and needs the part. And the floor remains roughly a third of
+**What this still does NOT do.** ~~The board has not booted it -- item 1 of the
+two above is unchanged and needs the part.~~ **That sentence was wrong when
+written (2026-09-04).** Item 1 was met on 2026-08-31 and says so in its own
+text three sections up: the island entry boots on `mr_canhubk3/s32k344` at
+`CONFIG_MAIN_STACK_SIZE=16384`. Two statements about the same criterion, in one
+file, disagreeing — the same failure this issue already recorded once, in the
+same direction: a HIGH-severity issue overstating what is still broken. And the floor remains roughly a third of
 the true frame cost, by this issue's own x86_64 measurement; it is a necessary
 condition and its message says so in those words.
+
+
+## RESOLVED 2026-09-05 — both criteria met, and the check is now GATED
+
+Both acceptance criteria are satisfied:
+
+1. **The board has booted it** — met 2026-08-31 on `mr_canhubk3/s32k344` at
+   `CONFIG_MAIN_STACK_SIZE=16384`, half the previously smallest workable value,
+   with `Executor::open_in` 16000 -> 2244 and `nros_cpp_init` 15104 -> 1396.
+2. **Something states the number** — `NROS_EXECUTOR_MAIN_STACK_MIN` is emitted
+   with its `#if` / `#error` guard, in the caller's translation unit, by all
+   four producers: `nros-build-helpers::cpp` inlines the text, `::c` substitutes
+   `@EXECUTOR_STACK_MIN@` into `nros_config_generated.h.template` and
+   `nros_config_generated_exact.h.template`, which carry it.
+
+### What was missing until now: nothing kept it there
+
+The check had no gate and no test. It was mutation-tested by hand on 2026-09-04
+and then nothing would have noticed it going away — which matters more here than
+usual, because both ways of losing it are SILENT:
+
+* drop the `#define` and the `#if` compares against an undefined identifier,
+  which the preprocessor reads as `0`, so the guard passes for every stack size;
+* keep the `#define` and drop the `#if` and the number becomes documentation —
+  which is precisely the state this issue was filed about.
+
+`scripts/check-executor-stack-floor.py` (gate `check-executor-stack-floor`)
+asserts every producer still defines the floor, still compares against it, still
+has an `#error`, and still offers the `NROS_STACK_MIN_ACKNOWLEDGE` opt-out.
+Source-level deliberately: the generated headers are build artifacts and a gate
+in an affordability tier may not resolve one, but the disarming regression is
+visible in the emitters without building anything.
+
+Mutation-tested against a REAL producer, not only synthetic text: deleting the
+`#if` line from `nros_config_generated.h.template` fails the gate naming that
+file. Its selftest runs on the normal path so the controls cannot rot, and one
+of those controls earned its keep immediately — the first `#define` regex used
+`\s+`, which matches a NEWLINE, so a valueless `#define` followed by the `#if`
+line passed. Anchored to `[^\S\n]` now.
+
+### What is deliberately still true
+
+The floor is a NECESSARY condition, roughly a third of the true frame cost by
+this issue's own x86_64 measurement, and its message says so in those words. An
+image below it provably cannot boot; one above it may still not. The value is
+that the failure arrives at compile time naming the number, instead of as a
+prologue overflow four bring-up sessions deep.

--- a/just/check.just
+++ b/just/check.just
@@ -3053,6 +3053,20 @@ stack-floor:
     @python3 scripts/check-stack-floor.py --selftest
     @python3 scripts/check-stack-floor.py --claims
 
+# Issue 0961 — `Executor::open_in` builds the executor as a VALUE in its own
+# frame and `nros_cpp_init` moves it again, so an image whose main thread is
+# smaller overflows in a function PROLOGUE, before any statement runs and so
+# before any check written inside those functions could execute. Four bring-up
+# sessions went into finding that once. The answer is a compile-time guard in
+# the CALLER's translation unit; it exists in all four producers and nothing
+# kept it there. Source-level by necessity: the generated headers are build
+# artifacts and an affordability tier may not resolve one, but "does every
+# producer still emit the define AND still compare against it" is exactly the
+# regression that would silently disarm it.
+[private]
+executor-stack-floor:
+    @python3 scripts/check-executor-stack-floor.py
+
 # The per-RMW capability page is derived from the two C vtables + the zenoh
 # shim's trait overrides. Prose versions of this table drifted in BOTH
 # directions (cyclone services documented unsupported after service.cpp landed;

--- a/scripts/check-executor-stack-floor.py
+++ b/scripts/check-executor-stack-floor.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""The executor's main-stack floor must be EMITTED, and guarded, by every producer.
+
+Issue 0961: `Executor::open_in` builds the executor as a VALUE in its own frame
+and `nros_cpp_init` moves it again, so an image whose main thread is smaller
+than that overflows in a function PROLOGUE — before any statement runs, and
+therefore before any check written inside those functions could execute. Four
+bring-up sessions went into finding that once.
+
+The answer is a compile-time check in the CALLER's translation unit:
+
+    #define NROS_EXECUTOR_MAIN_STACK_MIN <2 x the executor VALUE size>
+    #if defined(CONFIG_MAIN_STACK_SIZE) && !defined(NROS_STACK_MIN_ACKNOWLEDGE)
+    #if CONFIG_MAIN_STACK_SIZE < NROS_EXECUTOR_MAIN_STACK_MIN
+    #error ...
+    #endif
+    #endif
+
+It exists in all four producers. Nothing kept it there — no gate, no test — so
+this file is that. It is a SOURCE check on the emitters, deliberately: the
+generated headers are build artifacts, and a gate in an affordability tier may
+not resolve one (CLAUDE.md). What is checkable without a build is that every
+producer still emits the define and still wraps it in the guard, which is the
+regression that would silently disarm the whole thing.
+
+Two failure modes it is aimed at:
+
+* a producer stops emitting the define — the `#if` then compares against an
+  undefined identifier, which the preprocessor reads as 0, so the guard passes
+  for EVERY stack size and the check is silently gone;
+* a producer keeps the define and drops the `#if`/`#error` — the number is then
+  documentation, which is what this issue already had and what cost the four
+  sessions.
+
+The VALUE is not asserted here. It comes from a probe of the real type and moves
+whenever `MAX_CBS` / `MAX_NODES` move, which is the point; pinning it would make
+this gate a second, staler SSoT.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Every producer of a header a caller compiles against. Two Rust emitters (the
+# C++ one inlines the text, the C one substitutes into the templates below) and
+# the two templates themselves.
+PRODUCERS = [
+    "packages/tooling/nros-build-helpers/src/cpp.rs",
+    "packages/api/nros-c/templates/nros_config_generated.h.template",
+    "packages/api/nros-c/templates/nros_config_generated_exact.h.template",
+]
+
+# `c.rs` reaches the header THROUGH the templates, so it is checked for the
+# substitution rather than the guard text.
+C_EMITTER = "packages/tooling/nros-build-helpers/src/c.rs"
+C_SUBSTITUTION = "@EXECUTOR_STACK_MIN@"
+
+DEFINE = "NROS_EXECUTOR_MAIN_STACK_MIN"
+OPT_OUT = "NROS_STACK_MIN_ACKNOWLEDGE"
+
+
+class Failure(Exception):
+    pass
+
+
+def check_text(name: str, text: str) -> list[str]:
+    """Every producer must DEFINE the floor and GUARD on it."""
+    problems = []
+
+    # `[^\S\n]` not `\s`: the latter matches the NEWLINE, so a valueless
+    # `#define NROS_EXECUTOR_MAIN_STACK_MIN` followed by the `#if` line would
+    # satisfy `\s+\S` and pass. The selftest below catches exactly that, and
+    # did — the first version of this regex was wrong.
+    if not re.search(rf"#define[^\S\n]+{DEFINE}[^\S\n]+\S", text):
+        problems.append(
+            f"{name}: does not `#define {DEFINE}`.\n"
+            f"    Without the define the `#if` below compares against an undefined\n"
+            f"    identifier, which the preprocessor evaluates as 0 — so the guard\n"
+            f"    passes for every stack size and the check is silently gone."
+        )
+
+    if f"CONFIG_MAIN_STACK_SIZE < {DEFINE}" not in text:
+        problems.append(
+            f"{name}: defines {DEFINE} but does not COMPARE against it\n"
+            f"    (`#if CONFIG_MAIN_STACK_SIZE < {DEFINE}`).\n"
+            f"    A number nobody checks is documentation. That is the state issue 0961\n"
+            f"    was filed about, and it cost four bring-up sessions."
+        )
+
+    if "#error" not in text:
+        problems.append(f"{name}: has the comparison but no `#error` — it cannot fail.")
+
+    if OPT_OUT not in text:
+        problems.append(
+            f"{name}: no `{OPT_OUT}` escape hatch.\n"
+            f"    An image that builds its executor off the main thread is measured\n"
+            f"    against a stack this header cannot see, and needs a way to say so."
+        )
+
+    return problems
+
+
+def run() -> int:
+    problems = []
+    checked = 0
+
+    for rel in PRODUCERS:
+        p = REPO / rel
+        if not p.is_file():
+            raise Failure(
+                f"{rel}: missing. This gate names its producers explicitly, so a\n"
+                "renamed or deleted one is a failure rather than a silent pass."
+            )
+        problems += check_text(rel, p.read_text())
+        checked += 1
+
+    c = REPO / C_EMITTER
+    if not c.is_file():
+        raise Failure(f"{C_EMITTER}: missing.")
+    if C_SUBSTITUTION not in c.read_text():
+        problems.append(
+            f"{C_EMITTER}: does not substitute `{C_SUBSTITUTION}`.\n"
+            f"    It reaches the header through the templates rather than inlining the\n"
+            f"    text, so the substitution IS its half of the guard."
+        )
+    checked += 1
+
+    if problems:
+        print(
+            f"check-executor-stack-floor: {len(problems)} problem(s)\n", file=sys.stderr
+        )
+        for pr in problems:
+            print(f"  [FAIL] {pr}", file=sys.stderr)
+        print(
+            "\n  Issue 0961. The floor is a NECESSARY condition, not a sufficient one —\n"
+            "  it is roughly a third of the true frame cost — but an image below it\n"
+            "  provably cannot boot, and the whole value is that the failure arrives at\n"
+            "  compile time naming the number instead of as a prologue overflow.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check-executor-stack-floor: OK ({checked} producer(s) define "
+        f"{DEFINE} and guard on it)"
+    )
+    return 0
+
+
+def selftest() -> int:
+    good = (
+        f"#define {DEFINE} 3104\n"
+        f"#if defined(CONFIG_MAIN_STACK_SIZE) && !defined({OPT_OUT})\n"
+        f"#if CONFIG_MAIN_STACK_SIZE < {DEFINE}\n"
+        '#error "too small"\n'
+        "#endif\n#endif\n"
+    )
+    assert check_text("t", good) == [], check_text("t", good)
+
+    # NEGATIVE: each way the guard can be disarmed must be CAUGHT.
+    no_define = good.replace(f"#define {DEFINE} 3104\n", "")
+    assert any("does not `#define" in p for p in check_text("t", no_define))
+
+    no_compare = good.replace(f"#if CONFIG_MAIN_STACK_SIZE < {DEFINE}\n", "")
+    assert any("does not COMPARE" in p for p in check_text("t", no_compare))
+
+    no_error = good.replace('#error "too small"\n', "")
+    assert any("no `#error`" in p for p in check_text("t", no_error))
+
+    no_optout = good.replace(f" && !defined({OPT_OUT})", "").replace(OPT_OUT, "")
+    assert any("escape hatch" in p for p in check_text("t", no_optout))
+
+    # A define whose value is empty is not a define worth having.
+    empty = good.replace(f"#define {DEFINE} 3104", f"#define {DEFINE}")
+    assert any("does not `#define" in p for p in check_text("t", empty))
+
+    print("check-executor-stack-floor: selftest OK")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) > 1 and sys.argv[1] == "--selftest":
+            sys.exit(selftest())
+        selftest()  # on the NORMAL path too, so the controls cannot rot
+        sys.exit(run())
+    except Failure as exc:
+        print(f"check-executor-stack-floor: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
#0961 asked for two things. Both are done, so this resolves it — and closes the gap that would have quietly undone the second.

## Both criteria met

1. **The board boots it** — 2026-08-31 on `mr_canhubk3/s32k344` at `CONFIG_MAIN_STACK_SIZE=16384`, half the previously smallest workable value (`Executor::open_in` 16000→2244, `nros_cpp_init` 15104→1396).
2. **Something states the number** — `NROS_EXECUTOR_MAIN_STACK_MIN` with its `#if`/`#error` guard, in the **caller's** translation unit, from all four producers.

## What was missing: nothing kept it there

No gate, no test. It was mutation-tested by hand once and would then have rotted unnoticed — and both ways of losing it are **silent**:

- drop the `#define` → the `#if` compares against an undefined identifier, which the preprocessor reads as `0`, so the guard passes for *every* stack size;
- keep the `#define`, drop the `#if` → the number becomes documentation, which is the exact state this issue was filed about.

`check-executor-stack-floor` asserts every producer still defines the floor, compares against it, has an `#error`, and offers the `NROS_STACK_MIN_ACKNOWLEDGE` opt-out.

**Source-level deliberately**: the generated headers are build artifacts and an affordability-tier gate may not resolve one — but the disarming regression is visible in the emitters with no build at all.

**Mutation-tested against a real producer**, not just synthetic text: deleting the `#if` from `nros_config_generated.h.template` fails the gate naming that file. The selftest runs on the normal path, and one control earned its keep immediately — my first `#define` regex used `\s+`, which matches a **newline**, so a valueless `#define` followed by the `#if` line passed. Anchored to `[^\S\n]` now.

## Also fixes a contradiction inside the issue

Its last section said *"the board has not booted it — item 1 is unchanged and needs the part"*, while item 1 three sections up says **MET 2026-08-31**. Two statements about one criterion disagreeing in one file — the same failure this issue had already recorded once, in the same direction: a HIGH-severity issue overstating what is still broken.

## Deliberately still true

The floor is a **necessary** condition, ~a third of the true frame cost by this issue's own measurement, and its message says so. Below it an image provably cannot boot; above it, it still might not. The value is a compile-time failure naming the number instead of a prologue overflow four bring-up sessions deep.

`just check fast`: 213/213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)