### PR TITLE
fix(#1074): a deleted package's leftover config is residue, not a finding

### DIFF
--- a/docs/issues/archived/1074-cargo-config-gate-reports-deleted-package-residue.md
+++ b/docs/issues/archived/1074-cargo-config-gate-reports-deleted-package-residue.md
@@ -1,0 +1,102 @@
+---
+id: 1074
+title: "`check-cargo-config-tracked` reports a deleted package's leftover config as an untracked authored one — and its remedy would resurrect it"
+status: resolved
+type: bug
+area: build
+severity: medium
+found: 2026-09-05
+related: [0587, 0463, phase-338, phase-383]
+---
+
+# A gate that tells you to commit a corpse
+
+## What it printed
+
+On a developer machine, blocking `just build-test-fixtures` (which depends on
+`check::fast`):
+
+```
+check-cargo-config-tracked: hand-authored cargo config NOT tracked:
+  examples/qemu-arm-freertos/rust/action-server-entry/.cargo/config.toml
+  examples/qemu-arm-nuttx/rust/service-client-entry/.cargo/config.toml
+  … 12 in total
+```
+
+The remedy that follows from the gate's own rule — a config with authored
+content must be tracked — is `git add -f`. **That would have committed config
+files for packages deleted a month earlier.**
+
+## What those files actually were
+
+`git ls-files` on each package directory returns **nothing**. The packages were
+removed by `ab486a8db` (phase-338 W2, 2026-08-05, *"collapse the 18 `-entry`
+packages into their node packages"*), and later by phase-383 W10.a for the
+workspace migrations — one of whose commit subjects is *"the bridges migrate,
+and the shape cannot come back"*.
+
+What survived on disk is entirely ignored residue: `Cargo.lock`, `generated/`,
+and `.cargo/config.toml`.
+
+**The mechanism is one sentence:** `git rm` cannot delete a gitignored file, and
+every leaf `.cargo/config.toml` is gitignored (`.gitignore:111`, blanket — which
+is the whole reason this gate exists). So deleting a package leaves its config
+behind, in a directory that is no longer a package, and a FILESYSTEM walk finds
+it.
+
+The content really is authored — it was, when the package existed and the file
+was tracked. The gate's content test is correct. What it lacks is any notion
+that the package around the file is gone.
+
+## Why it survived a month
+
+**It cannot fire on CI.** A fresh clone has no residue, so the gate is green
+there. It only fires on a machine that once built the old packages — so the
+signal appears exactly where it is least likely to be read as a repo-wide fact,
+and looks like local mess rather than a gate defect.
+
+Same shape as issue 0587, which made this gate demand the DELETION of
+documentation: both are the gate reasoning correctly about content while missing
+what the file is *for*.
+
+## Fixed 2026-09-05
+
+`package_is_deleted()` — a config whose package directory has no tracked files
+is residue, and is skipped. The discriminator is cheap and cannot mistake a live
+leaf for a dead one: a live package always has at least a tracked manifest.
+
+**The skip is REPORTED, not silent.** A skip nobody can see would be the same
+defect one layer over — the residue would sit forever and the next person
+wondering why a deleted example still has a `generated/` tree would have nothing
+to read. The gate now prints the count and the remedy that is actually correct:
+
+```
+  note: skipped N cargo config(s) whose package has no tracked files — residue
+  of a deleted package (`git rm` cannot remove a gitignored file, and every leaf
+  config is gitignored). Not a finding, and not tracked by anything; delete the
+  directories when convenient:
+      rm -rf examples/…
+```
+
+Advisory rather than fatal: residue is local state that no clone and no CI run
+has, so failing on it would make a green tree depend on a developer's history.
+
+## It found more than the hand sweep did
+
+The twelve `-entry` directories were found by eye. The guard's report then named
+**eleven more** the sweep had missed, because they use underscores
+(`native_rust_params_entry`, `native_entry`, `freertos_realtime_entry`, …) and
+the glob searched for `*-entry`. All confirmed removed by phase-383 W10.a.
+
+That is the argument for reporting rather than skipping, made by the change
+itself on its first run.
+
+## Not covered
+
+* Whether a package that is GENERATED IN PLACE under a walked directory could be
+  misread as deleted. It should not be — generated entry packages live under
+  `build/<coord>/`, which the walk already prunes (phase-300 W3) — but the
+  discriminator would be wrong for one that did not.
+* The residue in other forms: `Cargo.lock` and `generated/` trees survive the
+  same way and no gate mentions them. Only the config is checked, because only
+  the config has a tracking rule.

--- a/scripts/check-cargo-config-tracked.sh
+++ b/scripts/check-cargo-config-tracked.sh
@@ -211,9 +211,42 @@ has_orphan_include() {
 
 untracked_authored=0
 tracked_pure=0
+orphan_residue=0
+orphan_dirs=()
+
+# Issue 1074 — a config whose PACKAGE no longer exists is residue, not a finding.
+#
+# `git rm` cannot delete a gitignored file, and every leaf `.cargo/config.toml`
+# is gitignored (`.gitignore:111`, blanket, which is the whole reason this gate
+# exists). So deleting a package leaves its config on disk, in a directory that
+# is no longer a package — and the walk below, which is a FILESYSTEM walk, finds
+# it and reports it as an untracked authored config.
+#
+# phase-338 W2 (`ab486a8db`) collapsed 18 `-entry` example packages into their
+# node packages. Twelve of the eighteen corpses were still reporting here a
+# month later, and the remedy the gate printed — track it — would have
+# RESURRECTED config files for packages the tree had deliberately removed.
+#
+# The discriminator is "does anything in this package's directory survive in
+# git". Nothing does, for a deleted package; something always does for a live
+# one, because a package needs at least a manifest. Cheap, and it cannot
+# mistake a live leaf for a dead one.
+#
+# NOT VISIBLE ON CI, which is why it lasted: a fresh clone has no residue, so
+# this only ever fires on a machine that once built the old packages.
+package_is_deleted() {
+    local dir
+    dir="$(dirname "$(dirname "$1")")"   # <pkg>/.cargo/config.toml -> <pkg>
+    [ -z "$(git ls-files "$dir" 2>/dev/null)" ]
+}
 
 while IFS= read -r -d '' cfg; do
     cfg="${cfg#./}"
+    if package_is_deleted "$cfg"; then
+        orphan_residue=$((orphan_residue + 1))
+        orphan_dirs+=("$(dirname "$(dirname "$cfg")")")
+        continue
+    fi
     tracked=0
     git ls-files --error-unmatch "$cfg" >/dev/null 2>&1 && tracked=1
 
@@ -320,6 +353,28 @@ if [ "$tracked_pure" -ne 0 ]; then
         echo "      git rm --cached <path>"
     } >&2
     rc=1
+fi
+
+# Issue 1074 — the skip above is REPORTED, never silent.
+#
+# Skipping a config because its package is gone is right, but a skip nobody can
+# see is the same defect one layer over: the residue would sit there forever,
+# and the next person to wonder why an old example still has a `generated/` tree
+# would have nothing to read. So the count is printed, with the remedy that is
+# actually correct — DELETE the directory. Not `git add -f`, which is what this
+# gate used to imply and which would resurrect a deleted package's config.
+#
+# Advisory, not a failure: residue is local state that no clone and no CI run
+# has, so failing on it would make a green tree depend on a developer's history.
+if [ "$orphan_residue" -ne 0 ]; then
+    {
+        echo
+        echo "  note: skipped $orphan_residue cargo config(s) whose package has no tracked"
+        echo "  files — residue of a deleted package (\`git rm\` cannot remove a gitignored"
+        echo "  file, and every leaf config is gitignored). Not a finding, and not tracked"
+        echo "  by anything; delete the directories when convenient:"
+        printf '      rm -rf %s\n' "${orphan_dirs[@]}" | sort -u
+    } >&2
 fi
 
 [ "$rc" -eq 0 ] && echo "check-cargo-config-tracked: OK (tracked <=> hand-authored content)"


### PR DESCRIPTION
`check-cargo-config-tracked` blocked `just build-test-fixtures` with twelve
*"hand-authored cargo config NOT tracked"* reports. Following the gate's own
rule — a config with authored content must be tracked — the remedy is
`git add -f`, and **that would have committed config files for packages deleted
a month earlier.**

## What those files were

`git ls-files` on each package directory returns **nothing**. They were removed
by `ab486a8db` (phase-338 W2, *"collapse the 18 `-entry` packages into their node
packages"*) and by phase-383 W10.a, one of whose subjects is *"the bridges
migrate, and the shape cannot come back"*.

**The mechanism is one sentence:** `git rm` cannot delete a gitignored file, and
every leaf `.cargo/config.toml` is gitignored (`.gitignore:111`, blanket — the
whole reason this gate exists). Deleting a package leaves its config on disk in a
directory that is no longer a package, and a **filesystem** walk finds it.

The content really is authored — it was, when the package existed and the file
was tracked. What the gate lacked was any notion that the package around the file
is gone.

## Why it survived a month

**It cannot fire on CI.** A fresh clone has no residue, so the gate is green
there — it only fires on a machine that once built the old packages, where it
reads as local mess rather than a gate defect.

Same shape as issue 0587, which made this gate demand the *deletion of
documentation*: both are correct reasoning about content, missing what the file
is **for**.

## The fix

`package_is_deleted()` skips a config whose package directory has no tracked
files. Cheap, and it cannot mistake a live leaf for a dead one — a live package
always has at least a tracked manifest. Generated entry packages aren't at risk:
those live under `build/<coord>/`, which the walk already prunes (phase-300 W3).

**The skip is reported, not silent.** A skip nobody can see is the same defect
one layer over — the residue would sit forever, and the next person wondering why
a deleted example still has a `generated/` tree would have nothing to read. The
gate prints the count and the remedy that is *actually* correct: delete the
directory, not `git add -f`.

Advisory rather than fatal, because residue is local state that no clone and no
CI run has — failing on it would make a green tree depend on a developer's
history.

## It found more than the hand sweep did

Twelve `-entry` directories were found by eye. The guard's report then named
**eleven more** the sweep had missed, because they use underscores
(`native_rust_params_entry`, `freertos_realtime_entry`, `native_entry`, …) and
the glob searched for `*-entry`. All confirmed removed by phase-383 W10.a.

That's the argument for reporting rather than skipping, made by the change on its
first run.

29 orphaned directories were deleted from the working tree — untracked and
gitignored throughout, so no tracked file was touched.

```
just check cargo-config-tracked   OK  (previously failed with 12 findings)
just check issue-index            OK  (92 open rows)
check-doc-refs                    OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
