### PR TITLE
fix(#0835): six example leaves misreported their own platform, and two link decisions had come to depend on it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,12 @@ elseif(NANO_ROS_RMW STREQUAL "cyclonedds")
         # `std::nothrow`. Propagate the C++ stdlib through the INTERFACE
         # so any C consumer resolves them. Harmless for C++ apps (the
         # C++ driver already links it).
-        if(NOT (DEFINED NANO_ROS_PLATFORM AND NANO_ROS_PLATFORM STREQUAL "threadx"))
+        # issue 0835 — the property, not the label. See
+        # `nros_platform_hosted_cxx_runtime` for why this used to read
+        # `NANO_ROS_PLATFORM STREQUAL "threadx"` and why that spelling was
+        # load-bearing on six example leaves misreporting their platform.
+        nros_platform_hosted_cxx_runtime(_nros_hosted_cxx "${NANO_ROS_PLATFORM}")
+        if(_nros_hosted_cxx)
             target_link_libraries(NanoRos INTERFACE stdc++)
         endif()
         # Phase 241.D3-rev — the C++ umbrella (NanoRosCpp = nros-cpp-headers) no longer
@@ -383,7 +388,9 @@ elseif(NANO_ROS_RMW STREQUAL "cyclonedds")
             else()
                 target_link_libraries(nros-cpp-headers INTERFACE nros_rmw_cyclonedds)
             endif()
-            if(NOT (DEFINED NANO_ROS_PLATFORM AND NANO_ROS_PLATFORM STREQUAL "threadx"))
+            # issue 0835 — same property, same helper; one defect, two consumers.
+            nros_platform_hosted_cxx_runtime(_nros_hosted_cxx "${NANO_ROS_PLATFORM}")
+            if(_nros_hosted_cxx)
                 target_link_libraries(nros-cpp-headers INTERFACE stdc++)
             endif()
         endif()

--- a/cmake/NanoRosFeatureSet.cmake
+++ b/cmake/NanoRosFeatureSet.cmake
@@ -24,6 +24,60 @@ include_guard(GLOBAL)
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosRosEdition.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/NanoRosRmwDispatch.cmake")
 
+# nros_platform_hosted_cxx_runtime(<out> <platform>)
+#
+# TRUE when a binary for `<platform>` can link the toolchain's C++ runtime
+# (`stdc++`). The Cyclone RMW wrapper is C++, so a C application linking
+# `NanoRos::NanoRos` needs it propagated through the INTERFACE or the link fails
+# on `operator new` — but a bare-metal ThreadX image has no `libstdc++` to link
+# and the flag is fatal there.
+#
+# issue 0835 — this exists because the test was written inline, TWICE, as
+# `NANO_ROS_PLATFORM STREQUAL "threadx"`. That is a platform LABEL standing in
+# for a property, which is the defect RFC-0064 records and phase-338 W5.a already
+# fixed one layer down (the ThreadX tier derives from `_cross`, not from the
+# board name). It also silently DEPENDED on six example leaves misreporting their
+# platform: `examples/qemu-riscv64-threadx/rust/*/CMakeLists.txt` each carried
+# `set(NANO_ROS_PLATFORM threadx)`, shadowing the `-DNANO_ROS_PLATFORM=
+# threadx_riscv64` their own build passes. Those leaves now report honestly, so a
+# test on the bare label would have stopped matching — silently, and the failure
+# would have been a link error on a platform nobody was editing.
+#
+# THE LIST IS EXACTLY TODAY'S RULE, and that is deliberate: this change must not
+# remove `stdc++` from any link that currently has it. Two derivations were
+# considered and both would have:
+#
+#  * `CMAKE_SYSTEM_NAME STREQUAL "Generic"` — `freertos` is also a Generic cross
+#    target, also builds Cyclone fixtures, and today DOES link `stdc++`.
+#  * "any bare-metal ThreadX", i.e. adding `threadx_riscv64` — MEASURED from the
+#    generated ninja files: `examples/qemu-riscv64-threadx/c/talker/
+#    build-cyclonedds` carries `-lstdc++` and its rust sibling does not. The c/cpp
+#    leaves are exactly the case the comment at the call site describes (a C
+#    driver linking the C++ Cyclone wrapper), so taking it away is the direction
+#    that breaks.
+#
+# So bare `threadx` stays the only entry. The visible consequence is that the six
+# `examples/qemu-riscv64-threadx/rust/*` leaves, which used to reach this by
+# MISREPORTING their platform, now take the same branch their c/cpp siblings on
+# the identical board and toolchain already take, and gain `-lstdc++`. Adding a
+# library to a link that does not reference it is benign with GNU ld, and those
+# siblings prove it resolves for `riscv-none-elf`. NOT build-verified in the
+# branch that made this change: a fresh worktree has no `nros sync` output, so
+# corrosion cannot read `nros-patch.toml` and the leaf will not configure there.
+#
+# The generalisation — derive from a property instead of listing a label — is
+# still the right end state and is what RFC-0064 and phase-338 W5.a argue for.
+# What it needs first is a measurement nobody has taken: whether freertos-cross
+# actually wants the `stdc++` it currently gets.
+function(nros_platform_hosted_cxx_runtime out platform)
+    set(_freestanding threadx)
+    if(platform IN_LIST _freestanding)
+        set(${out} FALSE PARENT_SCOPE)
+    else()
+        set(${out} TRUE PARENT_SCOPE)
+    endif()
+endfunction()
+
 # nros_feature_set(<out>
 #     CRATE        <c|cpp>               which crate's feature vocabulary
 #     EDITION      <humble|iron|jazzy>   default: NANO_ROS_ROS_EDITION, else humble

--- a/docs/issues/archived/0835-fixture-staleness-probe-families-restale-each-other.md
+++ b/docs/issues/archived/0835-fixture-staleness-probe-families-restale-each-other.md
@@ -131,10 +131,65 @@ are held elsewhere rather than by the probe:
    varying (a timestamp, a temp path) would make the affected rows permanently
    STALE with nothing to fix — and it would look exactly like this issue.
 
-### What is NOT fixed, and why it was left
+### FIXED 2026-09-05 — the leaves no longer misreport, and a gate holds it
 
-The duplicated `threadx-riscv64` corrosion group (below, 2026-08-31) is still
-real: the `set(NANO_ROS_PLATFORM threadx)` hardcode is present in all six
+The last piece of this issue is closed. The section below was written while it
+was open and is kept for its measurements; what follows is what changed.
+
+`examples/qemu-riscv64-threadx/rust/*/CMakeLists.txt` now reads
+
+    if(NOT DEFINED NANO_ROS_PLATFORM)
+        set(NANO_ROS_PLATFORM threadx_riscv64)
+    endif()
+
+— the honest platform, and only as the copy-out DEFAULT, so the
+`-DNANO_ROS_PLATFORM=threadx_riscv64` the leaf's own build passes wins instead
+of being shadowed. Gate: `check-example-platform-not-shadowed`, on the fast
+line. It rejects an unconditional `set()` in any leaf whose `[[fixture]]` row
+carries a `platform` coordinate — **even when the value agrees**, because
+agreement today is what makes the next label-keyed thing quietly depend on which
+of the two wins. It also rejects a guarded default that disagrees with the row.
+Mutation-tested against the original line: it fires, naming the leaf.
+
+**The re-key that was feared is not part of this.** Keying the shared cargo
+directory on the resolved feature set landed separately (`8033bc3f0`), so the
+duplicate groups were already gone; this half is about the leaf telling the
+truth, which is what stops the class rather than the instance.
+
+**What this change was NOT allowed to do, and the measurement that decided it.**
+Two `stdc++` link decisions in the root `CMakeLists.txt` were written as
+`NANO_ROS_PLATFORM STREQUAL "threadx"` and so DEPENDED on the leaves
+misreporting. They are now one named predicate,
+`nros_platform_hosted_cxx_runtime`, and its membership is **exactly the old
+rule** — bare `threadx` only. Both tempting generalisations would have removed
+`stdc++` from a link that currently has it:
+
+* `CMAKE_SYSTEM_NAME STREQUAL "Generic"` — `freertos` is also a Generic cross
+  target and today links it.
+* "any bare-metal ThreadX" — measured from the generated ninja files:
+  `examples/qemu-riscv64-threadx/c/talker/build-cyclonedds` carries `-lstdc++`
+  and its rust sibling does not. The c/cpp leaves are exactly the case the call
+  site describes (a C driver linking the C++ Cyclone wrapper), so taking it away
+  is the direction that breaks.
+
+So no platform's decision changes. The one visible consequence: the six rust
+leaves now take the same branch their c/cpp siblings on the identical board and
+toolchain already take, and gain `-lstdc++`. Adding an unreferenced library to a
+GNU ld link is benign and those siblings prove it resolves for `riscv-none-elf`
+— but this was **not build-verified in the branch that made the change**: a
+fresh worktree has no `nros sync` output, corrosion cannot read
+`nros-patch.toml`, and the leaf will not configure there. The first
+`just threadx_riscv64 build-fixtures` after this lands is the check.
+
+Deriving the predicate from a property instead of listing a label is still the
+right end state — it is what RFC-0064 and phase-338 W5.a argue for. It needs one
+measurement first: whether freertos-cross actually wants the `stdc++` it
+currently gets.
+
+### The original note, written while this was open
+
+The duplicated `threadx-riscv64` corrosion group (below, 2026-08-31) was still
+real at the time: the `set(NANO_ROS_PLATFORM threadx)` hardcode is present in all six
 `examples/qemu-riscv64-threadx/rust/*/CMakeLists.txt`. But it is **wasted disk
 and CPU, not staleness** — after 2fa1ed09f a duplicated group cannot make a
 probe fire, because it cannot change a row's artifact bytes. It could not be

--- a/docs/issues/archived/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md
+++ b/docs/issues/archived/0945-shared-cargo-dir-rests-on-unsupported-build-internals.md
@@ -246,3 +246,59 @@ or target-dir GC (items 3 and 4), or the NuttX crate leaving its nightly pin
 (item 2). Item 4 also closes properly on its own terms the day the 13 readers
 above reach zero — that is a migration with a countable finish line, and it is
 the only one of the five that has one.
+
+## Item 6's gap is CLOSED 2026-09-05 — the fallback branches announce themselves
+
+The register's one entry with no detection story now has one.
+
+**What was unguarded.** Both staleness probes decide from the artifact's bytes
+(issue 0835). When the locator finds NOTHING they fall back to the older rule —
+cargo's `"fresh":false` for the rust probe, the build-chatter grep for the cmake
+one — and say nothing about having done so. That branch is what an on-disk
+LAYOUT change produces: `_row_artifacts` globs
+`<target-dir>/[<triple>/]<profile>/<bin>`, which is cargo's convention rather
+than anything cargo promises, and `cmake-fixture-stale.sh` assumes a cell has
+exactly one top-level executable.
+
+The consequence is not a missing warning, it is a WRONG VERDICT that reads as a
+right one: for rows sharing a phase-340 cargo group the old rule is
+*permanently* stale, because those rows evict each other. Issue 0835 measured
+that state — ~22 rows reporting stale on every run with byte-identical binaries,
+and ~190 fixture-stale failures per `just ci-matrix` — and it surfaces as a
+self-healing WARNING, which reads as the gate working.
+
+**What landed.** Both fallback branches emit
+`DEGRADED\t<row>\t<reason>`, the convention `rust-fixture-stale.sh` already used
+for `FAILED\t`. `check-fixtures-stale.sh` buckets and counts them beside the
+stale list, as a WARNING: a degraded row is not known to be stale or fresh, it
+is known to have been decided by a rule this gate does not stand behind, so
+escalating would redden a lane over something nobody can act on. **The COUNT is
+the signal** — measured 2026-09-05, 116 of 117 rust rows and 120 of 120 cmake
+cells locate their artifact, so the expected reading is ONE
+(`packages/testing/qemu-smoltcp-bridge`, which names no `[[bin]]` the glob can
+find). More than one means a layout moved.
+
+This widens no watch set, so it cannot make 0835 worse — phase-424's constraint.
+It is a fact ABOUT a verdict, never a new input to one.
+
+**Gated, with the case that was missing.** `check-fixture-staleness-probes` had
+cases A–D and every one of them has the artifact PRESENT, so none reached this
+branch. Case **E** builds a LIBRARY-ONLY cargo leaf — the real shape, not a
+contrived one, since that is exactly why `qemu-smoltcp-bridge` is on the
+fallback today — and asserts both that `DEGRADED` is emitted and that it carries
+a reason. Mutation-tested: removing the `printf` makes E fail, and the leaf then
+appears in the output as an ordinary stale row, which is the silent state
+itself.
+
+**One defect found while writing it, worth recording because it would not have
+failed loudly.** A degrading probe prints its `DEGRADED` line *and*, if the
+fallback rule fires, the stale line. `check-fixtures-stale.sh` reads probe
+output two different ways — `mapfile` when GNU `parallel` is installed, one
+`$( )` capture per record when it is not — so the pair arrives as two array
+elements or as one, and bucketing without re-splitting would have classified
+them by whichever line came first, **differently depending on whether a tool is
+installed on the machine**. The caller re-splits on newlines before bucketing;
+five shapes are checked, including that divergence.
+
+The rest of item 6 stands as written: the layout assumption itself is still an
+assumption. What changed is that it can no longer fail in silence.

--- a/examples/qemu-riscv64-threadx/rust/action-client/CMakeLists.txt
+++ b/examples/qemu-riscv64-threadx/rust/action-client/CMakeLists.txt
@@ -8,7 +8,29 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # the C/C++ examples. CMake owns Cyclone's C++ backend + generated
 # descriptors; the Rust crate is imported as a staticlib exposing
 # app_main().
-set(NANO_ROS_PLATFORM threadx)
+# issue 0835 — the caller decides, and this is only the copy-out default.
+#
+# This line used to read `set(NANO_ROS_PLATFORM threadx)`, an unconditional
+# normal variable that SHADOWED the `-DNANO_ROS_PLATFORM=threadx_riscv64` this
+# leaf's own build passes (`just/threadx-riscv64.just`, both the Rust
+# `nros_cmake_fixture_build` path and the C/C++ `NROS_CMAKE_EXTRA_DEFS` one).
+# The leaf therefore reported one platform while its CMakeCache recorded
+# another, both written in the same second, and the shared cargo directory keyed
+# on the label got FOUR groups where the configuration space has two:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…   <- these six
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…   <- the c/cpp leaves
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — 2.8 GB of duplicate build output for a spelling difference. The key now
+# hashes the resolved feature set rather than the label (`8033bc3f0`), so the
+# duplication is already gone; this makes the leaf stop lying, which is the
+# other half and the one that keeps the next label-keyed thing from repeating
+# it.
+if(NOT DEFINED NANO_ROS_PLATFORM)
+    set(NANO_ROS_PLATFORM threadx_riscv64)
+endif()
 set(NROS_RMW "cyclonedds" CACHE STRING
     "Active RMW (zenoh|dds|xrce|cyclonedds) — selects the backend linked into this example.")
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING

--- a/examples/qemu-riscv64-threadx/rust/action-server/CMakeLists.txt
+++ b/examples/qemu-riscv64-threadx/rust/action-server/CMakeLists.txt
@@ -8,7 +8,29 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # the C/C++ examples. CMake owns Cyclone's C++ backend + generated
 # descriptors; the Rust crate is imported as a staticlib exposing
 # app_main().
-set(NANO_ROS_PLATFORM threadx)
+# issue 0835 — the caller decides, and this is only the copy-out default.
+#
+# This line used to read `set(NANO_ROS_PLATFORM threadx)`, an unconditional
+# normal variable that SHADOWED the `-DNANO_ROS_PLATFORM=threadx_riscv64` this
+# leaf's own build passes (`just/threadx-riscv64.just`, both the Rust
+# `nros_cmake_fixture_build` path and the C/C++ `NROS_CMAKE_EXTRA_DEFS` one).
+# The leaf therefore reported one platform while its CMakeCache recorded
+# another, both written in the same second, and the shared cargo directory keyed
+# on the label got FOUR groups where the configuration space has two:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…   <- these six
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…   <- the c/cpp leaves
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — 2.8 GB of duplicate build output for a spelling difference. The key now
+# hashes the resolved feature set rather than the label (`8033bc3f0`), so the
+# duplication is already gone; this makes the leaf stop lying, which is the
+# other half and the one that keeps the next label-keyed thing from repeating
+# it.
+if(NOT DEFINED NANO_ROS_PLATFORM)
+    set(NANO_ROS_PLATFORM threadx_riscv64)
+endif()
 set(NROS_RMW "cyclonedds" CACHE STRING
     "Active RMW (zenoh|dds|xrce|cyclonedds) — selects the backend linked into this example.")
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING

--- a/examples/qemu-riscv64-threadx/rust/listener/CMakeLists.txt
+++ b/examples/qemu-riscv64-threadx/rust/listener/CMakeLists.txt
@@ -8,7 +8,29 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # the C/C++ examples. CMake owns Cyclone's C++ backend + generated
 # descriptors; the Rust crate is imported as a staticlib exposing
 # app_main().
-set(NANO_ROS_PLATFORM threadx)
+# issue 0835 — the caller decides, and this is only the copy-out default.
+#
+# This line used to read `set(NANO_ROS_PLATFORM threadx)`, an unconditional
+# normal variable that SHADOWED the `-DNANO_ROS_PLATFORM=threadx_riscv64` this
+# leaf's own build passes (`just/threadx-riscv64.just`, both the Rust
+# `nros_cmake_fixture_build` path and the C/C++ `NROS_CMAKE_EXTRA_DEFS` one).
+# The leaf therefore reported one platform while its CMakeCache recorded
+# another, both written in the same second, and the shared cargo directory keyed
+# on the label got FOUR groups where the configuration space has two:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…   <- these six
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…   <- the c/cpp leaves
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — 2.8 GB of duplicate build output for a spelling difference. The key now
+# hashes the resolved feature set rather than the label (`8033bc3f0`), so the
+# duplication is already gone; this makes the leaf stop lying, which is the
+# other half and the one that keeps the next label-keyed thing from repeating
+# it.
+if(NOT DEFINED NANO_ROS_PLATFORM)
+    set(NANO_ROS_PLATFORM threadx_riscv64)
+endif()
 set(NROS_RMW "cyclonedds" CACHE STRING
     "Active RMW (zenoh|dds|xrce|cyclonedds) — selects the backend linked into this example.")
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING

--- a/examples/qemu-riscv64-threadx/rust/service-client/CMakeLists.txt
+++ b/examples/qemu-riscv64-threadx/rust/service-client/CMakeLists.txt
@@ -8,7 +8,29 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # the C/C++ examples. CMake owns Cyclone's C++ backend + generated
 # descriptors; the Rust crate is imported as a staticlib exposing
 # app_main().
-set(NANO_ROS_PLATFORM threadx)
+# issue 0835 — the caller decides, and this is only the copy-out default.
+#
+# This line used to read `set(NANO_ROS_PLATFORM threadx)`, an unconditional
+# normal variable that SHADOWED the `-DNANO_ROS_PLATFORM=threadx_riscv64` this
+# leaf's own build passes (`just/threadx-riscv64.just`, both the Rust
+# `nros_cmake_fixture_build` path and the C/C++ `NROS_CMAKE_EXTRA_DEFS` one).
+# The leaf therefore reported one platform while its CMakeCache recorded
+# another, both written in the same second, and the shared cargo directory keyed
+# on the label got FOUR groups where the configuration space has two:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…   <- these six
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…   <- the c/cpp leaves
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — 2.8 GB of duplicate build output for a spelling difference. The key now
+# hashes the resolved feature set rather than the label (`8033bc3f0`), so the
+# duplication is already gone; this makes the leaf stop lying, which is the
+# other half and the one that keeps the next label-keyed thing from repeating
+# it.
+if(NOT DEFINED NANO_ROS_PLATFORM)
+    set(NANO_ROS_PLATFORM threadx_riscv64)
+endif()
 set(NROS_RMW "cyclonedds" CACHE STRING
     "Active RMW (zenoh|dds|xrce|cyclonedds) — selects the backend linked into this example.")
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING

--- a/examples/qemu-riscv64-threadx/rust/service-server/CMakeLists.txt
+++ b/examples/qemu-riscv64-threadx/rust/service-server/CMakeLists.txt
@@ -8,7 +8,29 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # the C/C++ examples. CMake owns Cyclone's C++ backend + generated
 # descriptors; the Rust crate is imported as a staticlib exposing
 # app_main().
-set(NANO_ROS_PLATFORM threadx)
+# issue 0835 — the caller decides, and this is only the copy-out default.
+#
+# This line used to read `set(NANO_ROS_PLATFORM threadx)`, an unconditional
+# normal variable that SHADOWED the `-DNANO_ROS_PLATFORM=threadx_riscv64` this
+# leaf's own build passes (`just/threadx-riscv64.just`, both the Rust
+# `nros_cmake_fixture_build` path and the C/C++ `NROS_CMAKE_EXTRA_DEFS` one).
+# The leaf therefore reported one platform while its CMakeCache recorded
+# another, both written in the same second, and the shared cargo directory keyed
+# on the label got FOUR groups where the configuration space has two:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…   <- these six
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…   <- the c/cpp leaves
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — 2.8 GB of duplicate build output for a spelling difference. The key now
+# hashes the resolved feature set rather than the label (`8033bc3f0`), so the
+# duplication is already gone; this makes the leaf stop lying, which is the
+# other half and the one that keeps the next label-keyed thing from repeating
+# it.
+if(NOT DEFINED NANO_ROS_PLATFORM)
+    set(NANO_ROS_PLATFORM threadx_riscv64)
+endif()
 set(NROS_RMW "cyclonedds" CACHE STRING
     "Active RMW (zenoh|dds|xrce|cyclonedds) — selects the backend linked into this example.")
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING

--- a/examples/qemu-riscv64-threadx/rust/talker/CMakeLists.txt
+++ b/examples/qemu-riscv64-threadx/rust/talker/CMakeLists.txt
@@ -8,7 +8,29 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # the C/C++ examples. CMake owns Cyclone's C++ backend + generated
 # descriptors; the Rust crate is imported as a staticlib exposing
 # app_main().
-set(NANO_ROS_PLATFORM threadx)
+# issue 0835 — the caller decides, and this is only the copy-out default.
+#
+# This line used to read `set(NANO_ROS_PLATFORM threadx)`, an unconditional
+# normal variable that SHADOWED the `-DNANO_ROS_PLATFORM=threadx_riscv64` this
+# leaf's own build passes (`just/threadx-riscv64.just`, both the Rust
+# `nros_cmake_fixture_build` path and the C/C++ `NROS_CMAKE_EXTRA_DEFS` one).
+# The leaf therefore reported one platform while its CMakeCache recorded
+# another, both written in the same second, and the shared cargo directory keyed
+# on the label got FOUR groups where the configuration space has two:
+#
+#   platform=threadx         |rmw=zenoh     |board=riscv64-qemu|…   <- these six
+#   platform=threadx_riscv64 |rmw=zenoh     |board=riscv64-qemu|…   <- the c/cpp leaves
+#   platform=threadx         |rmw=cyclonedds|board=riscv64-qemu|…
+#   platform=threadx_riscv64 |rmw=cyclonedds|board=riscv64-qemu|…
+#
+# — 2.8 GB of duplicate build output for a spelling difference. The key now
+# hashes the resolved feature set rather than the label (`8033bc3f0`), so the
+# duplication is already gone; this makes the leaf stop lying, which is the
+# other half and the one that keeps the next label-keyed thing from repeating
+# it.
+if(NOT DEFINED NANO_ROS_PLATFORM)
+    set(NANO_ROS_PLATFORM threadx_riscv64)
+endif()
 set(NROS_RMW "cyclonedds" CACHE STRING
     "Active RMW (zenoh|dds|xrce|cyclonedds) — selects the backend linked into this example.")
 set(NANO_ROS_RMW "${NROS_RMW}" CACHE STRING

--- a/just/check.just
+++ b/just/check.just
@@ -183,6 +183,7 @@ fast-serial: \
     example-leaf-build-dirs \
     example-leaf-target-dirs \
     example-matrix \
+    example-platform-not-shadowed \
     export-f-closure \
     eyre-context-alias \
     feature-contract \
@@ -4226,6 +4227,19 @@ example-leaf-target-dirs:
 [private]
 example-leaf-build-dirs:
     @python3 scripts/check-example-leaf-build-dirs.py
+
+# issue 0835 — an example leaf must not overrule the platform its own build
+# passes. Six threadx rust leaves carried a plain `set(NANO_ROS_PLATFORM
+# threadx)`, a NORMAL variable that shadows the cache entry
+# `-DNANO_ROS_PLATFORM=threadx_riscv64` wrote — so each leaf and its own
+# CMakeCache disagreed, written in the same second. Visible cost: four shared
+# corrosion cargo groups where the configuration space has two, 2.8 GB of
+# duplicate output. Quieter cost: two `stdc++` link decisions had come to depend
+# on the wrong label, so making the leaves honest would have stopped them
+# matching, silently. Buildless, reads the manifest and the leaves.
+[private]
+example-platform-not-shadowed:
+    @python3 scripts/check-example-platform-not-shadowed.py
 
 # issue 0720 — a test asks a fixture resolver for an artifact BY NAME, and a
 # name no CMake target produces resolves to a missing path, which the test

--- a/scripts/check-example-platform-not-shadowed.py
+++ b/scripts/check-example-platform-not-shadowed.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""An example leaf must not overrule the platform its own build passes.
+
+WHY THIS EXISTS (issue 0835). Six leaves --
+`examples/qemu-riscv64-threadx/rust/*/CMakeLists.txt` -- each carried
+
+    set(NANO_ROS_PLATFORM threadx)
+
+on line 11. A plain `set()` creates a NORMAL variable, which SHADOWS the cache
+entry that `-DNANO_ROS_PLATFORM=threadx_riscv64` wrote -- and that `-D` is what
+`just/threadx-riscv64.just` passes to these very leaves, on both its Rust and
+its C/C++ path. So each leaf reported one platform while its own
+`CMakeCache.txt` recorded another, both written in the same second.
+
+The visible cost was 2.8 GB of duplicate build output: the shared Corrosion
+cargo directory keyed on the label, so `build/corrosion-cargo/threadx-riscv64/`
+held FOUR groups where the configuration space has two --
+`{threadx, threadx_riscv64} x {zenoh, cyclonedds}` -- split exactly by family,
+six rust leaves in one and thirteen c/cpp leaves in the other.
+
+The quieter cost is the one this gate is for. Two `stdc++` link decisions in the
+root `CMakeLists.txt` were written as `NANO_ROS_PLATFORM STREQUAL "threadx"`,
+which means they DEPENDED on the leaves misreporting. Making the leaves honest
+would have stopped those matching -- silently, surfacing as a link error on a
+platform nobody was editing. A label that is wrong is worse than a label that is
+missing, because things start keying on it.
+
+WHAT IT CHECKS. For every example leaf with a `[[fixture]]` row that carries a
+`platform` coordinate:
+
+  1. an unconditional `set(NANO_ROS_PLATFORM ...)` is an ERROR -- it shadows
+     whatever the build passes, even when the two happen to agree today;
+  2. the value it defaults to must MATCH the row's platform coordinate.
+
+Guarded (`if(NOT DEFINED NANO_ROS_PLATFORM)`) is the accepted form: a copied-out
+project still configures with no `-D`, and the repo's own build still wins.
+
+Leaves with NO platform coordinate -- `examples/templates/*`, which are
+compile-check rows -- are out of scope. For a template the platform IS the thing
+the reader is being shown how to choose, and no build contradicts it.
+
+Exit 0 when every leaf agrees with its own build, 1 otherwise.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MANIFEST = os.path.join(ROOT, "examples", "fixtures.toml")
+
+SET_RE = re.compile(r"^([ \t]*)set\(\s*NANO_ROS_PLATFORM\s+([^)\s]+)\s*\)", re.M)
+GUARD_RE = re.compile(r"if\s*\(\s*NOT\s+DEFINED\s+NANO_ROS_PLATFORM\s*\)", re.I)
+
+
+def norm(p):
+    """`threadx-riscv64` (manifest) and `threadx_riscv64` (cmake) are one name."""
+    return p.strip().strip('"').replace("-", "_")
+
+
+def rows(manifest_text):
+    """{leaf dir -> platform coordinate} for rows that declare one."""
+    out = {}
+    for blk in re.split(r"\n(?=\[\[)", manifest_text):
+        d = re.search(r'^\s*dir\s*=\s*"([^"]+)"', blk, re.M)
+        p = re.search(r'^\s*platform\s*=\s*"([^"]+)"', blk, re.M)
+        if d and p:
+            out.setdefault(d.group(1), norm(p.group(1)))
+    return out
+
+
+def guarded(text, at):
+    """Is the `set()` at offset `at` inside an `if(NOT DEFINED …)` guard?
+
+    Deliberately crude: the guard has to be the nearest preceding `if(` on the
+    same nesting level, and these files put it immediately above. A leaf that
+    needs something cleverer should say so in a comment and the gate can grow a
+    case; guessing at arbitrary CMake control flow with a regex would make this
+    gate lie in the direction that matters.
+    """
+    before = text[:at]
+    last_if = before.rfind("if(")
+    last_endif = before.rfind("endif()")
+    if last_if == -1 or last_if < last_endif:
+        return False
+    return bool(GUARD_RE.search(text[last_if:at]))
+
+
+def scan(root, manifest_text):
+    problems = []
+    checked = 0
+    for leaf, platform in sorted(rows(manifest_text).items()):
+        path = os.path.join(root, leaf, "CMakeLists.txt")
+        if not os.path.isfile(path):
+            continue
+        with open(path, encoding="utf8") as fh:
+            text = fh.read()
+        for m in SET_RE.finditer(text):
+            checked += 1
+            value = norm(m.group(2))
+            line = text[:m.start()].count("\n") + 1
+            if not guarded(text, m.start()):
+                problems.append(
+                    (leaf, line, f"unconditional `set(NANO_ROS_PLATFORM {m.group(2)})` "
+                                 f"shadows the -D its own build passes")
+                )
+            elif value != platform:
+                problems.append(
+                    (leaf, line, f"defaults to `{m.group(2)}` but its fixture row's "
+                                 f"platform is `{platform}`")
+                )
+    return problems, checked
+
+
+def self_test(quiet=False):
+    """Negative control: the rule must FIRE on the shape it exists for.
+
+    Runs on the NORMAL path, not behind a flag -- `check-gate-selftests` holds
+    this file to that, and a control nobody runs decays into a comment.
+    """
+    import tempfile
+
+    manifest = (
+        '[[fixture]]\ndir = "examples/leaf"\nplatform = "threadx-riscv64"\n'
+    )
+    cases = [
+        # (leaf CMakeLists body, expected number of problems, what it proves)
+        ("set(NANO_ROS_PLATFORM threadx)\n", 1,
+         "the exact 0835 shape: unconditional, and the wrong value"),
+        ("set(NANO_ROS_PLATFORM threadx_riscv64)\n", 1,
+         "unconditional is a problem even when the value AGREES -- that is the "
+         "state this gate exists to stop, because the next label-keyed thing "
+         "silently depends on which one wins"),
+        ("if(NOT DEFINED NANO_ROS_PLATFORM)\n"
+         "    set(NANO_ROS_PLATFORM threadx)\nendif()\n", 1,
+         "guarded but disagreeing with the row's coordinate"),
+        ("if(NOT DEFINED NANO_ROS_PLATFORM)\n"
+         "    set(NANO_ROS_PLATFORM threadx_riscv64)\nendif()\n", 0,
+         "the accepted form: guarded, and matching"),
+        ("# threadx_riscv64 is the platform here\n", 0,
+         "prose naming a platform is not a set()"),
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        os.makedirs(os.path.join(tmp, "examples", "leaf"))
+        for body, want, why in cases:
+            with open(os.path.join(tmp, "examples", "leaf", "CMakeLists.txt"),
+                      "w", encoding="utf8") as fh:
+                fh.write(body)
+            got, _ = scan(tmp, manifest)
+            assert len(got) == want, (
+                f"self-test: expected {want} problem(s), got {len(got)} — {why}\n"
+                f"  body: {body!r}\n  got: {got}"
+            )
+    if not quiet:
+        print("check-example-platform-not-shadowed self-test: OK "
+              f"({len(cases)} case(s))")
+    return 0
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    # Always, not only behind the flag. See `scripts/check-board-tiers.py`.
+    rc = self_test(quiet=True)
+    if rc:
+        return rc
+
+    with open(MANIFEST, encoding="utf8") as fh:
+        manifest_text = fh.read()
+    problems, checked = scan(ROOT, manifest_text)
+    if problems:
+        print("check-example-platform-not-shadowed: "
+              f"{len(problems)} leaf/leaves overrule their own build:")
+        for leaf, line, why in problems:
+            print(f"  {leaf}/CMakeLists.txt:{line}")
+            print(f"      {why}")
+        print(
+            "\n  A plain `set()` is a NORMAL variable and shadows the cache entry a\n"
+            "  `-DNANO_ROS_PLATFORM=…` wrote, so the leaf and its own CMakeCache\n"
+            "  disagree. Write it as the copy-out DEFAULT instead:\n"
+            "\n"
+            "      if(NOT DEFINED NANO_ROS_PLATFORM)\n"
+            "          set(NANO_ROS_PLATFORM <the row's platform>)\n"
+            "      endif()\n"
+            "\n  Issue 0835 — this cost 2.8 GB of duplicate corrosion cargo groups,\n"
+            "  and two `stdc++` link decisions had come to depend on the wrong label."
+        )
+        return 1
+    print(f"check-example-platform-not-shadowed: OK ({checked} declaration(s) "
+          f"across {len(rows(manifest_text))} leaf/leaves with a platform coordinate)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-fixtures-stale.sh
+++ b/scripts/check-fixtures-stale.sh
@@ -90,6 +90,38 @@ else
         [ -n "$out" ] && cmake_stale+=("$out")
     done < <(cmake_records)
 fi
+# issue 0945 item 6 — a cell whose artifact the probe could not find decides its
+# verdict by a DIFFERENT rule (the pre-`2fa1ed09f` output grep), so it is not an
+# ordinary member of the stale list. Split it out before counting.
+#
+# Re-split on newlines FIRST. A degrading probe prints its `DEGRADED` line AND
+# then, if the fallback rule fires, the stale line — two lines from one run. The
+# `parallel` branch above reads them through `mapfile` and gets two elements;
+# the serial branch captures the whole run in ONE `$( )` and gets one element
+# holding both. Bucketing without this would classify the pair by whichever line
+# came first, differently depending on whether GNU parallel is installed.
+_split_lines() {
+    local _e _l
+    _NROS_SPLIT=()
+    for _e in "$@"; do
+        while IFS= read -r _l; do
+            [ -n "$_l" ] && _NROS_SPLIT+=("$_l")
+        done <<<"$_e"
+    done
+}
+
+cmake_degraded=()
+_cmake_kept=()
+_split_lines ${cmake_stale[@]+"${cmake_stale[@]}"}
+for line in ${_NROS_SPLIT[@]+"${_NROS_SPLIT[@]}"}; do
+    case "$line" in
+        DEGRADED$'\t'*) cmake_degraded+=("${line#DEGRADED$'\t'}") ;;
+        *)              _cmake_kept+=("$line") ;;
+    esac
+done
+cmake_stale=(${_cmake_kept[@]+"${_cmake_kept[@]}"})
+unset _cmake_kept
+
 if [ ${#cmake_stale[@]} -gt 0 ]; then
     echo "WARNING: ${#cmake_stale[@]} C/C++ fixture cell(s) were STALE and have now been rebuilt (cmake):" >&2
     printf '  %s\n' "${cmake_stale[@]}" >&2
@@ -150,10 +182,13 @@ fi
 # self-heal for a fixture that had never compiled.
 rust_failed=()
 rust_rebuilt=()
-for line in ${rust_stale[@]+"${rust_stale[@]}"}; do
+rust_degraded=()
+_split_lines ${rust_stale[@]+"${rust_stale[@]}"}
+for line in ${_NROS_SPLIT[@]+"${_NROS_SPLIT[@]}"}; do
     case "$line" in
-        FAILED$'\t'*) rust_failed+=("${line#FAILED$'\t'}") ;;
-        *)            rust_rebuilt+=("$line") ;;
+        FAILED$'\t'*)   rust_failed+=("${line#FAILED$'\t'}") ;;
+        DEGRADED$'\t'*) rust_degraded+=("${line#DEGRADED$'\t'}") ;;
+        *)              rust_rebuilt+=("$line") ;;
     esac
 done
 
@@ -161,6 +196,34 @@ if [ ${#rust_rebuilt[@]} -gt 0 ]; then
     echo "WARNING: ${#rust_rebuilt[@]} rust fixture(s) were STALE and have now been rebuilt by cargo:" >&2
     printf '  %s\n' "${rust_rebuilt[@]}" >&2
     echo "  (cargo incremental self-heal; bypass with  NROS_SKIP_FIXTURE_CHECK=1 )" >&2
+fi
+
+# issue 0945 item 6 — report the rows whose verdict came from the FALLBACK rule.
+#
+# A WARNING, not an error, and the distinction is the point: a degraded row is
+# not known to be stale or fresh, it is known to have been decided by a rule
+# this gate does not stand behind. Escalating would make a `just ci` red on a
+# row nobody can act on; staying silent is what let the state exist unnoticed.
+#
+# The COUNT is the signal, not any single line. Measured 2026-09-05: 116 of 117
+# rust rows and 120 of 120 cmake cells locate their artifact, so the expected
+# reading is ONE. A jump means cargo's output layout or a build dir's shape
+# moved, and every affected row silently reverted to the pre-0835 rule — which
+# for rows sharing a phase-340 cargo group is permanently "stale", the exact
+# ~190-failure state issue 0835 measured and removed.
+_degraded_total=$(( ${#rust_degraded[@]} + ${#cmake_degraded[@]} ))
+if [ "$_degraded_total" -gt 0 ]; then
+    echo "WARNING: $_degraded_total fixture row(s)/cell(s) fell back to a DEGRADED staleness rule:" >&2
+    for _d in ${rust_degraded[@]+"${rust_degraded[@]}"} ${cmake_degraded[@]+"${cmake_degraded[@]}"}; do
+        printf '  %s\n' "$_d" | sed 's/\t/\n      /' >&2
+    done
+    echo "  These are neither confirmed fresh nor confirmed stale: the probe could not" >&2
+    echo "  locate the artifact it compares, so the verdict came from cargo's \"fresh\"" >&2
+    echo "  flag (rust) or the output grep (cmake) — the pre-2fa1ed09f rules, which are" >&2
+    echo "  permanently \"stale\" for rows sharing a phase-340 cargo group (issue 0835)." >&2
+    echo "  ONE is expected today (packages/testing/qemu-smoltcp-bridge names no [[bin]]" >&2
+    echo "  the locator can find). MORE than that means an on-disk layout moved —" >&2
+    echo "  see issue 0945 item 6 before trusting any staleness verdict in this run." >&2
 fi
 
 if [ ${#rust_failed[@]} -gt 0 ]; then

--- a/scripts/test/cmake-fixture-stale.sh
+++ b/scripts/test/cmake-fixture-stale.sh
@@ -67,6 +67,19 @@ after="$(_arts)"
 if [ -z "$before" ] && [ -z "$after" ]; then
     # No artifact to compare (shape changed). Fall back to the output grep so
     # this degrades to the previous behaviour instead of passing blindly.
+    #
+    # issue 0945 item 6 — SAY SO, for the same reason the rust probe does. The
+    # grep this falls back to is the pre-`2fa1ed09f` rule, which is permanently
+    # "stale" for the 17 Corrosion cells issue 0835 identified: their link
+    # re-runs on an order-only edge and produces a byte-identical executable.
+    # So a cell that lands here is not degrading to "the previous behaviour"
+    # neutrally — it is degrading to the behaviour 0835 exists to have removed,
+    # and reporting it as an ordinary stale cell.
+    #
+    # Measured 2026-09-05: 120 of 120 cmake cells find their executable, so this
+    # branch is unreachable today and any occurrence is news.
+    printf 'DEGRADED\t%s\t%s\n' "$bd" \
+        "no top-level executable in the build dir; verdict falls back to the pre-2fa1ed09f output grep"
     if printf '%s' "$out" | grep -qE "Building (C|CXX|ASM) object|Linking (C|CXX|CXX shared)|Compiling [a-z0-9_-]+ v"; then
         echo "$bd"
     fi

--- a/scripts/test/rust-fixture-stale.sh
+++ b/scripts/test/rust-fixture-stale.sh
@@ -134,6 +134,28 @@ build_rc=$?
 if [ -z "$art_before" ] && [ -z "$(_row_artifacts)" ]; then
     # Nothing to compare — an unbuilt row, or a leaf whose bins this cannot
     # name. Fall back to cargo's own signal rather than passing blindly.
+    #
+    # issue 0945 item 6 — SAY SO. This branch is the one a cargo output-layout
+    # change produces, and it is silent: `_row_artifacts` globs
+    # `<target-dir>/[<triple>/]<profile>/<bin>`, cargo's convention rather than
+    # anything cargo promises. If that layout moves, every row lands here at
+    # once, the probe reverts to `"fresh":false`, and for rows sharing a
+    # phase-340 group that signal is PERMANENTLY true because they evict each
+    # other — which is issue 0835 exactly: ~22 rows reporting stale on every run
+    # with byte-identical binaries, and ~190 fixture-stale failures per
+    # `just ci-matrix`. Reported as a self-healing WARNING, which reads as the
+    # gate working.
+    #
+    # Measured 2026-09-05 across the shared checkout: 116 of 117 rust rows find
+    # an artifact, so this branch is nearly unreachable today and a jump in the
+    # count is the signal. The one row already on it is
+    # `packages/testing/qemu-smoltcp-bridge`, whose Cargo.toml names no binary
+    # the glob can find.
+    #
+    # `DEGRADED` widens no watch set, so it cannot make 0835 worse — phase-424's
+    # constraint. It is a fact ABOUT the verdict, not a new input to it.
+    printf 'DEGRADED\t%s\t%s\n' "$dir${cargo_args:+ ($cargo_args)}" \
+        "no artifact matched $(_row_bins | tr '\n' ' ' | sed 's/ $//' | sed 's/^$/(no [[bin]] name in Cargo.toml)/'); verdict falls back to cargo's \"fresh\" flag"
     if [ "$build_rc" -eq 0 ]; then
         # `nros_grep_q`, not a bare `grep -q`: this branch decides a VERDICT, and
         # a grep that fails to start (issue 0726 — measured under a 32-way gate

--- a/tests/fixture-staleness-probe-tests.sh
+++ b/tests/fixture-staleness-probe-tests.sh
@@ -298,6 +298,65 @@ echo "== D. negative control: the pre-fix rules FIRE on these same trees =="
 # which is simultaneously the proof that the fixtures reproduce the hazard and
 # the proof that the assertions above are not vacuous.
 
+echo "== E. the fallback branch ANNOUNCES itself (issue 0945 item 6) =="
+
+# Cases A-D all have the artifact PRESENT, so none of them reaches the branch
+# taken when the locator finds NOTHING — which is the branch an on-disk layout
+# change produces, and the one that silently reverts the verdict to the
+# pre-`2fa1ed09f` rule. That rule is permanently "stale" for rows sharing a
+# phase-340 cargo group, so a layout change would reproduce issue 0835's ~190
+# failures while reading as ordinary self-healing.
+#
+# A LIBRARY-ONLY leaf is the real shape, not a contrived one:
+# `packages/testing/qemu-smoltcp-bridge` is on this branch in the live tree
+# today, because its Cargo.toml names no `[[bin]]` the glob can find.
+mkdir -p "$work/libleaf/src"
+cat > "$work/libleaf/Cargo.toml" <<'TOMLEOF'
+[workspace]
+
+[package]
+name = "nros-staleness-probe-libleaf"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+name = "nros_staleness_probe_libleaf"
+path = "src/lib.rs"
+TOMLEOF
+cat > "$work/libleaf/Cargo.lock" <<'LOCKEOF'
+version = 3
+
+[[package]]
+name = "nros-staleness-probe-libleaf"
+version = "0.0.0"
+LOCKEOF
+printf 'pub fn probe() -> u8 { 7 }\n' > "$work/libleaf/src/lib.rs"
+case "$probe_profile" in
+    dev | release | test | bench) ;;
+    *) printf '\n[profile.%s]\ninherits = "release"\n' "$probe_profile" >> "$work/libleaf/Cargo.toml" ;;
+esac
+
+libleaf_record="$(printf 'linux\x1f%s\x1f\x1f' "$work/libleaf")"
+out="$(bash "$RUST_PROBE" "$libleaf_record")"
+if printf '%s' "$out" | grep -q '^DEGRADED'"$(printf '\t')"; then
+    ok "a leaf whose artifact the locator cannot find reports DEGRADED"
+else
+    fail "the fallback branch stayed SILENT — a layout change would revert every row to the pre-0835 rule with nothing saying so. got: ${out:-<empty>}"
+fi
+checks=$((checks + 1))
+
+# And the reason has to be usable: a bare marker with no cause is a line nobody
+# can act on, which is how the silent state survived in the first place.
+if printf '%s' "$out" | grep -q 'falls back to'; then
+    ok "the DEGRADED line names what the verdict fell back to"
+else
+    fail "the DEGRADED line carries no reason: ${out:-<empty>}"
+fi
+checks=$((checks + 1))
+
+echo ""
+echo "== the OLD rules still fire on this fixture (negative control) =="
+
 out="$(cmake --build "$work/cell/build-probe" 2>&1)"
 if printf '%s' "$out" | grep -qE "Building (C|CXX|ASM) object|Linking (C|CXX|CXX shared)|Compiling [a-z0-9_-]+ v"; then
     ok "the old cmake rule (grep the build chatter) reports STALE — as it did forever"


### PR DESCRIPTION
## The hardcode

`examples/qemu-riscv64-threadx/rust/*/CMakeLists.txt:11` each carried:

```cmake
set(NANO_ROS_PLATFORM threadx)
```

A plain `set()` is a **normal** variable, so it shadowed the cache entry `-DNANO_ROS_PLATFORM=threadx_riscv64` wrote — and that `-D` is what `just/threadx-riscv64.just` passes to these very leaves, on both its Rust and its C/C++ path. Each leaf reported one platform while its own `CMakeCache.txt` recorded another, both written in the same second.

Swept: these six were the **only** producers of the bare `threadx` spelling in the tree.

## What it cost

**Visible** — `build/corrosion-cargo/threadx-riscv64/` held four groups where the configuration space has two, split exactly by family (6 rust leaves / 13 c-cpp), 2.8 GB of duplicate output. *That half was already fixed* by `8033bc3f0`, which keys the shared cargo directory on the resolved feature set rather than the label.

**Quieter, and why this half matters** — two `stdc++` link decisions in the root `CMakeLists.txt` were written as `NANO_ROS_PLATFORM STREQUAL "threadx"`, so they **depended on the leaves being wrong**. Making the leaves honest without noticing would have stopped them matching, silently, surfacing later as a link error on a platform nobody was editing.

## What changed

- The leaves declare the honest platform, and only as the copy-out **default** (`if(NOT DEFINED NANO_ROS_PLATFORM)`). The build's `-D` wins; a copied-out project still configures.
- The two inline `STREQUAL "threadx"` tests become one named predicate, `nros_platform_hosted_cxx_runtime`, in the module that already owns platform-string semantics.
- **`check-example-platform-not-shadowed`** (fast line, buildless): an unconditional `set(NANO_ROS_PLATFORM …)` is rejected in any leaf whose `[[fixture]]` row carries a `platform` coordinate — **even when the value agrees**, because agreement today is exactly what lets the next label-keyed thing depend on which of the two wins. `examples/templates/*` have no platform coordinate and are out of scope: there the platform is the thing the reader is being shown how to choose.

## The predicate is exactly the old rule, deliberately

No platform's `stdc++` decision changes. Both tempting generalisations would have **removed** the flag from a link that currently has it:

- `CMAKE_SYSTEM_NAME STREQUAL "Generic"` — freertos is also a Generic cross target and today links it.
- *"any bare-metal ThreadX"* — measured from the generated ninja files: `c/talker/build-cyclonedds` carries `-lstdc++`, its rust sibling does not. The c/cpp leaves are the case the call site describes (a C driver linking the C++ Cyclone wrapper), so removing it is the direction that breaks.

**One visible consequence:** the six rust leaves now take the same branch their c/cpp siblings on the identical board and toolchain already take, and gain `-lstdc++`. Benign with GNU ld for an unreferenced library, and those siblings prove it resolves for `riscv-none-elf` — but **not build-verified here**: a fresh worktree has no `nros sync` output, so corrosion cannot read `nros-patch.toml` and the leaf will not configure. The first `just threadx_riscv64 build-fixtures` after this lands is the check.

Deriving the predicate from a property rather than listing a label is still the right end state (RFC-0064, phase-338 W5.a). It needs one measurement first: whether freertos-cross actually wants the `stdc++` it currently gets.

## Verified

- **Mutation test** — restoring the original line makes the gate fire, naming the leaf and the shadowing.
- `nros_platform_hosted_cxx_runtime` answers identically to the old inline test for all seven platform labels (`cmake -P`).
- `just check fast`: **208 gates ran, 0 failed**, 6 skipped (all needing an in-tree `nros` this worktree does not build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj