### PR TITLE
feat(monitor): record how old the data a publisher put on the wire was

### DIFF
--- a/packages/core/nros-node/src/executor/handles.rs
+++ b/packages/core/nros-node/src/executor/handles.rs
@@ -114,6 +114,11 @@ pub struct EmbeddedPublisher<M> {
     /// RFC-0052 W3b.4 — contracted endpoint's publish counter (`None`
     /// for uncontracted publishers; one relaxed atomic bump when set).
     pub(crate) monitor: Option<&'static crate::executor::monitor::PubMonitorCell>,
+    /// Epoch clock for the publish-stamp observation, paired with `monitor`
+    /// the way the subscriber's `AgeMon` pairs cell and clock. Separate
+    /// field rather than a tuple so an uncontracted publisher costs nothing
+    /// and the existing `monitor` construction sites keep their shape.
+    pub(crate) epoch: Option<fn() -> u64>,
     pub(crate) _phantom: PhantomData<M>,
 }
 
@@ -137,6 +142,7 @@ impl<M: RosMessage> EmbeddedPublisher<M> {
             .map_err(|_| NodeError::Serialization)?;
         let len = writer.position();
         self.bump_monitor();
+        self.observe_publish_stamp(&buffer[..len]);
         self.handle
             .publish_raw(&buffer[..len])
             .map_err(|_| NodeError::Transport(TransportError::PublishFailed))
@@ -144,6 +150,20 @@ impl<M: RosMessage> EmbeddedPublisher<M> {
 
     /// RFC-0052 W3b.4 — one relaxed bump per publish on contracted
     /// endpoints; a predictable no-op otherwise.
+    /// Record how old the data we just put on the wire was.
+    ///
+    /// Folds away completely for a type with no `STAMP_OFFSET`, an
+    /// uncontracted publisher, or a build with no epoch source -- the same
+    /// three exits as the subscriber's `observe_age`.
+    #[inline]
+    fn observe_publish_stamp(&self, raw: &[u8]) {
+        if let (Some(cell), Some(epoch), Some(off)) =
+            (self.monitor, self.epoch, <M as RosMessage>::STAMP_OFFSET)
+        {
+            crate::executor::monitor::observe_publish_stamp(cell, raw, off, epoch());
+        }
+    }
+
     #[inline]
     fn bump_monitor(&self) {
         if let Some(cell) = self.monitor {

--- a/packages/core/nros-node/src/executor/monitor.rs
+++ b/packages/core/nros-node/src/executor/monitor.rs
@@ -39,6 +39,28 @@ pub struct PubMonitorCell {
     /// check window. Written by the dispatch loop (fetch_max), drained
     /// (swap 0) by the latency check.
     pub max_latency_us: AtomicU32,
+    /// Age of the stamp this publisher last put ON THE WIRE, in
+    /// microseconds: `epoch_now - outgoing header.stamp`.
+    ///
+    /// Distinct from `max_latency_us`, which times this node's own
+    /// take→publish work. This says how old the DATA is that the node just
+    /// published, which is the quantity a chain is made of.
+    ///
+    /// It exists to answer a question `max-age-runtime` cannot. That rule
+    /// measures `epoch_now - stamp` on the TAKE path, so if every node in a
+    /// chain propagates the original stamp -- the usual ROS convention, each
+    /// node copying its input's stamp to its output -- the age at the final
+    /// consumer already IS the end-to-end latency. If any node re-stamps
+    /// with `now`, the clock silently resets and the same number becomes
+    /// single-hop age instead. Same units, same magnitude, no warning.
+    ///
+    /// A publish age near zero on a node that consumes input is the
+    /// signature of re-stamping. Recording it here is what lets a chain's
+    /// provenance be checked at all, rather than assumed.
+    ///
+    /// `0` = never observed, matching the other cells: the type has no
+    /// `STAMP_OFFSET`, or no epoch source is installed.
+    pub last_publish_stamp_age_us: AtomicU32,
 }
 
 impl PubMonitorCell {
@@ -46,6 +68,7 @@ impl PubMonitorCell {
         Self {
             count: AtomicU32::new(0),
             max_latency_us: AtomicU32::new(0),
+            last_publish_stamp_age_us: AtomicU32::new(0),
         }
     }
 }
@@ -79,6 +102,24 @@ impl SubMonitorCell {
 /// raw CDR receive buffer (encapsulation header included) and return µs
 /// since the UNIX epoch. `None` when the buffer is too short or the
 /// stamp is pre-epoch/zero (unstamped messages never fire age monitors).
+/// Record the age of the stamp a publisher just put on the wire.
+///
+/// Called from the publish path with the encoded CDR still in hand, using the
+/// same `STAMP_OFFSET` peek the take path uses. A no-op when the type carries
+/// no stamp, when no epoch source is installed, or when the publisher is
+/// uncontracted -- the same three ways `observe_age` folds away.
+///
+/// Stores rather than accumulates: this is "how old was the last thing
+/// published", a state, not a window maximum. A chain check wants the current
+/// value, and a max would be pinned forever by one stale message at startup.
+#[inline]
+pub fn observe_publish_stamp(cell: &PubMonitorCell, raw: &[u8], offset: usize, now_us: u64) {
+    if let Some(stamp_us) = peek_stamp_us(raw, offset) {
+        let age = now_us.saturating_sub(stamp_us).min(u32::MAX as u64) as u32;
+        cell.last_publish_stamp_age_us.store(age, Ordering::Relaxed);
+    }
+}
+
 pub fn peek_stamp_us(raw: &[u8], offset: usize) -> Option<u64> {
     let sec_b = raw.get(offset..offset + 4)?;
     let nsec_b = raw.get(offset + 4..offset + 8)?;
@@ -525,6 +566,74 @@ pub(crate) fn check_release_jitter(
         measured: max_jitter_us.min(u32::MAX as u64) as u32,
         declared: period_us.min(u32::MAX as u64) as u32,
     })
+}
+
+#[cfg(test)]
+mod publish_stamp_tests {
+    use super::*;
+
+    /// CDR: 4-byte encapsulation header, then `Time { i32 sec; u32 nanosec }`
+    /// little-endian, so `sec` sits at byte 4 — the layout `STAMP_OFFSET`
+    /// encodes.
+    fn cdr_with_stamp(sec: i32, nanosec: u32) -> [u8; 12] {
+        let mut b = [0u8; 12];
+        b[4..8].copy_from_slice(&sec.to_le_bytes());
+        b[8..12].copy_from_slice(&nanosec.to_le_bytes());
+        b
+    }
+
+    #[test]
+    fn records_the_age_of_what_was_published() {
+        let cell = PubMonitorCell::new();
+        let raw = cdr_with_stamp(10, 0); // stamped at 10_000_000 us
+        observe_publish_stamp(&cell, &raw, 4, 10_500_000);
+        assert_eq!(
+            cell.last_publish_stamp_age_us.load(Ordering::Relaxed),
+            500_000,
+            "published data was half a second old"
+        );
+    }
+
+    /// The signature of a node that RE-STAMPED: it publishes data whose
+    /// stamp is now, so downstream age is single-hop, not end-to-end.
+    #[test]
+    fn a_restamping_node_shows_near_zero_age() {
+        let cell = PubMonitorCell::new();
+        let raw = cdr_with_stamp(10, 0);
+        observe_publish_stamp(&cell, &raw, 4, 10_000_000);
+        assert_eq!(cell.last_publish_stamp_age_us.load(Ordering::Relaxed), 0);
+    }
+
+    /// A state, not a window maximum: one stale message at startup must not
+    /// pin the value for the life of the process.
+    #[test]
+    fn the_latest_publish_replaces_the_previous() {
+        let cell = PubMonitorCell::new();
+        observe_publish_stamp(&cell, &cdr_with_stamp(10, 0), 4, 12_000_000);
+        assert_eq!(
+            cell.last_publish_stamp_age_us.load(Ordering::Relaxed),
+            2_000_000
+        );
+        observe_publish_stamp(&cell, &cdr_with_stamp(20, 0), 4, 20_100_000);
+        assert_eq!(
+            cell.last_publish_stamp_age_us.load(Ordering::Relaxed),
+            100_000,
+            "a fresh publish replaces the old age rather than maxing with it"
+        );
+    }
+
+    /// An unset stamp is not an age of `now`. `peek_stamp_us` rejects
+    /// `sec <= 0`, so a zeroed header records nothing at all.
+    #[test]
+    fn an_unstamped_message_records_nothing() {
+        let cell = PubMonitorCell::new();
+        observe_publish_stamp(&cell, &cdr_with_stamp(0, 0), 4, 5_000_000);
+        assert_eq!(
+            cell.last_publish_stamp_age_us.load(Ordering::Relaxed),
+            0,
+            "no stamp means no observation, not an enormous age"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -279,6 +279,7 @@ impl<'a> NodeHandle<'a> {
             handle,
             event_regs: crate::executor::handles::empty_event_regs(),
             monitor,
+            epoch: self.epoch_us_fn,
             _phantom: PhantomData,
         })
     }

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -2742,6 +2742,7 @@ impl<'s> Executor<'s> {
             handle,
             event_regs: crate::executor::handles::empty_event_regs(),
             monitor,
+            epoch: self.epoch_us_fn,
             _phantom: PhantomData,
         })
     }


### PR DESCRIPTION
## The finding that changed the design

This started as "add a correlation id for end-to-end chain latency". Investigating first turned that premise over.

`max-age-runtime` computes `epoch_now - header.stamp` on the **take** path. If every node in a chain propagates the original stamp — the usual ROS convention of copying the input's stamp to the output — then **the age at the final consumer already is the sensor-to-actuator latency**. No correlation id, no header field, nothing added to the protocol.

So the wire-format change the survey called unavoidable is avoidable.

## What is actually missing

Nothing knows whether propagation happened.

If one node re-stamps its output with `now`, the clock resets and the same `max-age` number silently becomes **single-hop age**. Same units, same magnitude, no warning — and nothing documents which of the two it is, so a reader would reasonably assume the narrower one.

## The measurement

```rust
PubMonitorCell::last_publish_stamp_age_us   // epoch_now - outgoing header.stamp
```

Taken in the publish path with the encoded CDR still in hand, through the same `STAMP_OFFSET` peek the take path uses. **A publish age near zero on a node that consumes input is the signature of re-stamping.**

Distinct from `max_latency_us` beside it, which times this node's own take→publish work. This says how old the *data* is, which is the quantity a chain is made of.

## Details that could each have gone wrong

**A state, not a window maximum.** A chain check wants the current value; a max would be pinned forever by one stale message at startup. Asserted by `the_latest_publish_replaces_the_previous`.

**An unset stamp records nothing**, not an enormous age. `peek_stamp_us` already rejects `sec <= 0`, and a zeroed header must not read as "this data is 55 years old".

**The publisher gains an `epoch` field** to pair with its cell, mirroring the subscriber's `AgeMon` tuple. Separate field rather than a tuple so uncontracted publishers cost nothing and existing `monitor` construction sites keep their shape. Folds away entirely for a type with no `STAMP_OFFSET`, an uncontracted publisher, or a build with no epoch source — the same three exits as `observe_age`.

## No rule yet

A chain-provenance rule needs a declaration of which publishers are mid-chain, and inventing that contract surface is a separate decision. Same probe-first split as the stack-headroom work (#432 then #455).

## Verification

```
cargo test -p nros-node --features std
  test result: ok. 317 passed; 0 failed
  test result: ok. 5 passed; 0 failed

publish_stamp_tests::records_the_age_of_what_was_published ... ok
publish_stamp_tests::a_restamping_node_shows_near_zero_age ... ok
publish_stamp_tests::the_latest_publish_replaces_the_previous ... ok
publish_stamp_tests::an_unstamped_message_records_nothing ... ok
```

Clean on default (no_std) and `alloc`; `cargo fmt` clean.

Validated with `cargo test`, **not** `cargo check`: `mod spin` is `#[cfg(any(has_rmw, test))]`, so a plain check does not compile that file at all — one of this change's edits lives there.
