### PR TITLE
fix(#1075): the Zephyr stack probe is guarded at COMPILE time, not run time

### DIFF
--- a/docs/issues/archived/1075-zephyr-stack-headroom-probe-breaks-native-sim-link.md
+++ b/docs/issues/archived/1075-zephyr-stack-headroom-probe-breaks-native-sim-link.md
@@ -1,7 +1,7 @@
 ---
 id: 1075
 title: "The Zephyr stack-headroom probe calls a syscall that is not COMPILED unless two Kconfigs are set, so every native_sim image fails to link"
-status: open
+status: resolved
 type: bug
 area: platform, build
 severity: high
@@ -10,6 +10,37 @@ related: [0589, 0876]
 ---
 
 # A fallback that only works at run time, for a failure that happens at link time
+
+## FIXED 2026-09-05 — option A, guarded on BOTH Kconfigs
+
+`nros_platform_task_stack_unused_bytes` is now compiled two ways: the real probe
+under `#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)`, and
+a `return 0` otherwise — the ABI's documented "this port does not instrument it",
+the same answer `nros_platform_heap_used_bytes` gives.
+
+Both symbols, not one: guarding on `CONFIG_INIT_STACKS` alone reproduces the bug
+wherever only that one is set, which is exactly the mistake the original comment
+made. The old comment is kept in the replacement, quoted, with why it was wrong —
+someone will read this function again and the trap is worth leaving visible.
+
+**Verified by rebuilding the fixture that failed**, not by a compile-tier check
+(which passed before the fix and would pass after it):
+
+    just zephyr build-one cpp/service-client xrce
+
+    before:  undefined reference to `z_impl_k_thread_stack_space_get'
+             ninja: build stopped: subcommand failed.
+    after:   [148/148] Running utility command for native_runner_executable
+             Built: …/zephyr.elf   →   zephyr.exe, 11.8 MB, exit 0
+             undefined references: 0
+
+The two `ld: error in …(.eh_frame); no .eh_frame_hdr table will be created`
+lines survive and are unrelated — they were present before the fatal error too.
+
+**Not done:** turning the two Kconfigs ON. That would make the probe return a
+real number instead of `0`, at the cost of stack painting at every thread start.
+It is a decision about the shipped image, and it belongs with whoever needs the
+safety argument the probe was written for — see option B below.
 
 ## Symptom
 

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -1219,9 +1219,31 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
 }
 
 /* Headroom for the calling thread. `k_thread_stack_space_get` answers in
- * unused BYTES, which is the ABI's unit, so no conversion. Needs
- * CONFIG_INIT_STACKS to have painted the stack; without it the kernel has no
- * watermark to read and returns an error, which becomes the documented 0. */
+ * unused BYTES, which is the ABI's unit, so no conversion.
+ *
+ * ISSUE 1075 — THE GUARD IS A COMPILE-TIME ONE, and the original comment here
+ * assumed a run-time one. It said: "Needs CONFIG_INIT_STACKS to have painted
+ * the stack; without it the kernel has no watermark to read and returns an
+ * error, which becomes the documented 0."
+ *
+ * There is no function to return that error. `zephyr/kernel/thread.c` encloses
+ * `z_impl_k_thread_stack_space_get` in
+ *
+ *     #if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
+ *
+ * so without BOTH symbols the implementation is not compiled at all and the
+ * call is an undefined reference — every Zephyr native_sim image failed at the
+ * final link, not at run time. The old comment also named only the first of the
+ * two Kconfigs; guarding on `CONFIG_INIT_STACKS` alone reproduces the bug
+ * wherever only that one is set, which is why both appear below.
+ *
+ * `0` is the ABI's documented "this port does not instrument it", the same
+ * answer `nros_platform_heap_used_bytes` gives — so an image built without the
+ * Kconfigs reports no headroom rather than failing to build. Turning them ON to
+ * get a real number is a separate decision about the shipped image (stack
+ * painting costs time at every thread start), and belongs with whoever needs
+ * the safety argument the probe was written for. */
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
 size_t nros_platform_task_stack_unused_bytes(void) {
     size_t unused = 0;
     if (k_thread_stack_space_get(k_current_get(), &unused) != 0) {
@@ -1229,3 +1251,8 @@ size_t nros_platform_task_stack_unused_bytes(void) {
     }
     return unused;
 }
+#else
+size_t nros_platform_task_stack_unused_bytes(void) {
+    return 0;
+}
+#endif /* CONFIG_INIT_STACKS && CONFIG_THREAD_STACK_INFO */


### PR DESCRIPTION
**Stacked on #477** (queued while this fix was being verified, so its branch was
locked). Carries #477's issue commit plus the fix.

Every Zephyr `native_sim` image failed at the final link with `undefined
reference to z_impl_k_thread_stack_space_get`. **Found by a tier-2 fixture
build; the compile tiers were green throughout, which is how it reached main.**

## The mistake

`411addfd2` documented a fallback:

> Needs CONFIG_INIT_STACKS to have painted the stack; without it the kernel has
> no watermark to read and **returns an error, which becomes the documented 0**.

That reasoning is about **run time**; the failure is at **link time**. There is
no function to return that error — `zephyr/kernel/thread.c:806` encloses
`z_impl_k_thread_stack_space_get` (`:862`) in:

```c
#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
```

Without both symbols the implementation isn't compiled at all. The comment also
named only the first of the two, and **neither is set anywhere in this repo**.

## The fix

The body is compiled two ways: the real probe under both symbols, `return 0`
otherwise — the ABI's documented *"this port does not instrument it"*, the same
answer `nros_platform_heap_used_bytes` gives. An image without the Kconfigs
reports no headroom rather than failing to build.

**Both symbols, deliberately.** Guarding on `CONFIG_INIT_STACKS` alone
reproduces the bug wherever only that one is set — the exact mistake the original
comment made. The old comment is kept in the replacement, quoted, with why it was
wrong: someone will read this function again and the trap is worth leaving
visible.

## Verified by rebuilding the fixture that failed

Not by a compile-tier check — that passed before the fix and would pass after it.

```
just zephyr build-one cpp/service-client xrce

before:  undefined reference to `z_impl_k_thread_stack_space_get'
         ninja: build stopped: subcommand failed.

after:   [148/148] Running utility command for native_runner_executable
         Built: …/zephyr.elf  →  zephyr.exe, 11.8 MB, exit 0
         undefined references: 0
```

The two surviving `ld: error in …(.eh_frame); no .eh_frame_hdr table will be
created` lines are unrelated and predate the fatal error.

## Not done

Turning the two Kconfigs **on**. That would make the probe return a real number
instead of `0`, at the cost of stack painting at every thread start — a decision
about the shipped image, belonging with whoever needs the safety argument the
probe was written for. Recorded as option B in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742