### PR TITLE
phase-412: a boot self-report on silicon, and the contract that sizes the pools

### DIFF
--- a/.config/doc-recipe-refs-baseline.txt
+++ b/.config/doc-recipe-refs-baseline.txt
@@ -64,13 +64,3 @@ docs/roadmap/phase-292-asi-reference-consumer-revisit.md	zephyr
 docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md	board-new
 docs/roadmap/phase-395-dev-workflow-migration.md	ci-l2
 docs/roadmap/phase-395-dev-workflow-migration.md	ci-l4-tier1
-packages/cli/CONTRIBUTING.md	build-build-tools
-packages/cli/CONTRIBUTING.md	build-user-libs
-packages/cli/CONTRIBUTING.md	clean-build-tools
-packages/cli/CONTRIBUTING.md	clean-user-libs
-packages/cli/CONTRIBUTING.md	test-build-tools
-packages/cli/CONTRIBUTING.md	test-user-libs
-packages/cli/testing_workspaces/complex_workspace/README.md	build-interfaces
-packages/cli/testing_workspaces/complex_workspace/README.md	build-rust
-packages/cli/testing_workspaces/complex_workspace/README.md	list
-packages/cli/testing_workspaces/complex_workspace/README.md	run

--- a/cmake/NanoRosEntityInventory.cmake
+++ b/cmake/NanoRosEntityInventory.cmake
@@ -122,8 +122,16 @@
 #   nros_derive_entity_inventory_knobs(
 #       CLI <path to nros>                  # required
 #       [METADATA <nros-metadata.json>]     # default ${CMAKE_BINARY_DIR}/...
+#       [MODEL <system_model.yaml>]         # resolved SystemModel, if any
 #       [OUTPUT_FILE <path>]                # default the knobs file below
 #       [QUIET])
+#
+# MODEL is a SECOND source of the same wiring, not a replacement: the verb
+# takes the larger of the two per component and per kind. The metadata
+# declaration knows the timers the model's schema cannot express; the model
+# knows the wiring an `ENTITIES` list can be silently short of. It is ignored
+# when the path is empty or missing, and the verb abstains on a model that
+# describes no wiring, so an image with no contract sees no change.
 #
 # Sets in the CALLER's scope:
 #
@@ -245,7 +253,7 @@ endmacro()
 
 # nros_derive_entity_inventory_knobs(...)  -- see the header comment.
 function(nros_derive_entity_inventory_knobs)
-    cmake_parse_arguments(_E "QUIET" "CLI;METADATA;OUTPUT_FILE" "" ${ARGN})
+    cmake_parse_arguments(_E "QUIET" "CLI;METADATA;MODEL;OUTPUT_FILE" "" ${ARGN})
 
     set(_metadata "${_E_METADATA}")
     if(NOT _metadata)
@@ -300,9 +308,18 @@ function(nros_derive_entity_inventory_knobs)
     # rule, the per-kind slot cost and the refusal all live in
     # `nros_cli_core::entity_inventory`, and this file only reads what it wrote.
     # A second count in cmake is how two green tools come to disagree.
+    # MODEL is optional and passed only when the file EXISTS. An entry that
+    # names no bringup resolves no model, and a path that is empty or absent
+    # must not reach the verb: `--model <missing>` is an error there, and the
+    # absence of a contract is a normal state, not a broken configure.
+    set(_model_arg "")
+    if(_E_MODEL AND EXISTS "${_E_MODEL}")
+        set(_model_arg --model "${_E_MODEL}")
+    endif()
     execute_process(
         COMMAND "${_E_CLI}" ws entity-inventory
                 --metadata "${_metadata}"
+                ${_model_arg}
                 --output-cmake "${_output}"
                 --output-json "${CMAKE_BINARY_DIR}/nros/entity_inventory.json"
         OUTPUT_VARIABLE _out
@@ -455,9 +472,13 @@ if(CMAKE_SCRIPT_MODE_FILE AND
     if(NOT DEFINED NROS_ENTITY_CLI OR NOT DEFINED NROS_ENTITY_METADATA)
         message(FATAL_ERROR
             "usage: cmake -DNROS_ENTITY_CLI=<nros> -DNROS_ENTITY_METADATA=<meta.json> "
-            "[-DNROS_ENTITY_OUTPUT=path] -P cmake/NanoRosEntityInventory.cmake")
+            "[-DNROS_ENTITY_MODEL=<system_model.yaml>] [-DNROS_ENTITY_OUTPUT=path] "
+            "-P cmake/NanoRosEntityInventory.cmake")
     endif()
     set(_args CLI "${NROS_ENTITY_CLI}" METADATA "${NROS_ENTITY_METADATA}")
+    if(DEFINED NROS_ENTITY_MODEL)
+        list(APPEND _args MODEL "${NROS_ENTITY_MODEL}")
+    endif()
     if(DEFINED NROS_ENTITY_OUTPUT)
         list(APPEND _args OUTPUT_FILE "${NROS_ENTITY_OUTPUT}")
     endif()

--- a/cmake/NanoRosEntry.cmake
+++ b/cmake/NanoRosEntry.cmake
@@ -921,7 +921,22 @@ function(_nros_entry_invoke_codegen)
     include("${_NROS_ENTRY_DIR}/NanoRosReconfigure.cmake")
     nros_entity_inventory_knobs_file(_entity_knobs_path)
     nros_reconfigure_snapshot("${_entity_knobs_path}" _entity_knobs_before)
-    nros_derive_entity_inventory_knobs(CLI "${_nros_bin}")
+    # phase-412 -- MODEL joins METADATA as a SECOND source of the wiring, and
+    # the verb takes the larger of the two per component and per kind.
+    #
+    # Neither source is complete, which is why it is a max and not a
+    # replacement. The `ENTITIES` lists in metadata are hand-maintained with
+    # nothing comparing them to the code, and on the safety island one of them
+    # declared six subscriptions for a node that creates seven -- every pool
+    # derived from it was short by one, and the eleventh subscription failed at
+    # boot with a transport error naming nothing. The MODEL's
+    # `structure.topics` comes from the contract sidecar the resolver folds in,
+    # so it states the wiring the launch tree cannot; but its schema has no
+    # timer entity, and the island runs four, so a model-only count is short by
+    # four callbacks. The verb ABSTAINS on a model that describes no wiring
+    # (`EntityInventory::from_model` returns None), so passing this for the 115
+    # images with no contract changes nothing.
+    nros_derive_entity_inventory_knobs(CLI "${_nros_bin}" MODEL "${_NRX_MODEL}")
     nros_reconfigure_on_change("${_entity_knobs_path}" "${_entity_knobs_before}"
         LABEL "this image's entity inventory")
 

--- a/cmake/NanoRosVerbs.cmake
+++ b/cmake/NanoRosVerbs.cmake
@@ -85,7 +85,7 @@ endfunction()
 
 # ---------------------------------------------------------------------------
 # nano_ros_add_executable(<name> <sources…> [DEPLOY <target>…] [BOARD <board>]
-#     [LAUNCH <pkg:launch.xml>] [TYPED])
+#     [BRINGUP <dir>] [LAUNCH <launch.xml>] [TYPED])
 #
 # Standalone entry. DEPLOY/BOARD default to the package.xml `<export>` tuple in
 # W4; until then DEPLOY defaults to `native` and an embedded board is passed
@@ -100,13 +100,13 @@ function(nano_ros_add_executable name)
     # phase-405 W1 — LOCATOR and ARGS dropped in lockstep with
     # `nano_ros_entry`. A verb that still accepted them would forward keywords
     # the callee no longer parses, which lands them in SOURCES.
-    cmake_parse_arguments(_NRE "TYPED" "BOARD;LAUNCH;MODEL;HOST;LANG" "DEPLOY;SOURCES" ${ARGN})
+    cmake_parse_arguments(_NRE "TYPED" "BOARD;BRINGUP;LAUNCH;MODEL;HOST;LANG" "DEPLOY;SOURCES" ${ARGN})
     set(_srcs ${_NRE_SOURCES} ${_NRE_UNPARSED_ARGUMENTS})
-    if(NOT _srcs AND NOT _NRE_LAUNCH AND NOT _NRE_MODEL)
+    if(NOT _srcs AND NOT _NRE_LAUNCH AND NOT _NRE_BRINGUP AND NOT _NRE_MODEL)
         message(FATAL_ERROR
             "nano_ros_add_executable(${name}): no sources given "
-            "(a LAUNCH-generated entry may omit sources; anything else "
-            "needs at least one).")
+            "(a BRINGUP/LAUNCH-generated entry may omit sources; anything "
+            "else needs at least one).")
     endif()
     _nros_infer_lang(_lang ${_srcs})
 
@@ -145,10 +145,23 @@ function(nano_ros_add_executable name)
     # Entry-carrier knobs (LAUNCH-generated multi-node entries + typed
     # components + connection overrides) forward verbatim.
     set(_entry_extra "")
+    # phase-330 W7 — BRINGUP is the INPUT-addressed spelling and the one a
+    # human writes: it names the package the user authors (system.toml +
+    # launch/ + the launch file's contract sidecar), and `nano_ros_entry`
+    # resolves the SystemModel BUILD ARTIFACT from it via `nros model-path`.
+    # It was parsed by `nano_ros_entry` and NOT by this verb, so every caller
+    # reaching the entry through the ament verb had no way to spell it and
+    # was pushed back onto MODEL — which names a resolved artifact directly
+    # and is exactly what phase-405 W4 retired for letting an entry build
+    # from a stale model.
+    if(_NRE_BRINGUP)
+        list(APPEND _entry_extra BRINGUP ${_NRE_BRINGUP})
+    endif()
     if(_NRE_LAUNCH)
         list(APPEND _entry_extra LAUNCH ${_NRE_LAUNCH})
     endif()
-    # R1 / W4.2 — the canonical resolved-model input (RFC-0052).
+    # R1 / W4.2 — the canonical resolved-model input (RFC-0052). Deprecated
+    # expert override; prefer BRINGUP.
     if(_NRE_MODEL)
         list(APPEND _entry_extra MODEL ${_NRE_MODEL})
     endif()

--- a/docs/issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md
+++ b/docs/issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md
@@ -1,0 +1,94 @@
+---
+id: 1036
+title: "Arena exhaustion was half silent, and on the island it was wholly
+  unreachable -- the two diagnostics written to explain it go to a sink that
+  does not exist"
+status: open
+type: bug
+area: core, boards, testing
+severity: high
+found: 2026-09-04
+related: [issue-0900, issue-0589, phase-412, phase-403, phase-409]
+---
+
+## What happens
+
+Two separate defects that compose into one blind spot, both found while
+building phase-412's boot self-report.
+
+**Half of arena exhaustion reported nothing.** `Executor::arena_alloc` has
+called `report_arena_exhausted` since issue 0900 -- it names the knob and the
+shortfall, because `NodeError::BufferTooSmall` is what a dozen other paths
+return and a bare return code cannot distinguish them. Its sibling
+`arena_alloc_with_trailing` returned the same error and said nothing:
+
+```rust
+let new_used = trailing_offset + trailing_bytes;
+if new_used > self.arena.len() {
+    return Err(NodeError::BufferTooSmall);   // <- and that was all of it
+}
+```
+
+The split is not random. `arena_alloc_with_trailing` is the path for the
+BUFFERED subscription entries and the action entries -- `spin.rs:3949`,
+`spin.rs:4124`, `spin.rs:4348`, `action.rs:1454`. Those are what an island
+image actually allocates, so the silent half is the half that matters on the
+board that hit it.
+
+**And on that board, the loud half is silent too.** Both diagnostics go through
+`nros_log`. On the MR-CANHUBK344 the console is on `lpuart0`, which is not
+wired; `lpuart2` carries the zenoh serial transport and cannot take a second
+protocol. So the two messages written specifically to explain an arena failure
+reach nothing, on the one board where the arena was being derived.
+
+## Why it was not caught
+
+Every hosted test has a sink, so the message is asserted and passes
+(`executor_arena_advisory.rs` does exactly that). The gap is only visible on a
+target with no sink, and there is no cell for that -- the assertion is "the
+advisory reaches a sink", which is untestable where the answer is "there is no
+sink".
+
+The `_with_trailing` half is worse: no test asserts anything about it, because
+it produced no output to assert on. It is the shape issue 0196 names -- a
+diagnostic nobody can observe is indistinguishable from one that was never
+written.
+
+## Measured
+
+Reading `git grep arena_alloc` across `packages/core/nros-node/src`: 20 call
+sites, of which 8 go through `arena_alloc_with_trailing`. Those 8 covered every
+buffered subscription and every action entry.
+
+On the island, the practical consequence is recorded in phase-412: the derived
+configuration produced a degraded ROS graph, the node count gave 4, 0, 0, 4, 4
+across five runs of one unchanged config, and no channel could say why. RTT was
+tried and could not discriminate -- a working image and a derived image both
+printed only the Zephyr banner, and a deliberate positive control (`MAX_CBS=1`)
+produced nothing at all.
+
+## Fixed here, one half of it
+
+`arena_alloc_with_trailing` now calls `report_arena_exhausted`, so both halves
+name the knob. That closes the asymmetry but not the reachability: on a board
+with no sink the message still goes nowhere.
+
+For the reachability half, phase-412 landed `boot_report` -- a fixed 60-byte
+RAM record read back with a debugger rather than a log stream, because the
+failure halts before any stream could carry it. `note_alloc_failed` records the
+first failing allocation and its shortfall, so a dump names the number to add.
+
+## Not fixed, and this issue stays open for it
+
+**No cell exercises the target-side path.** The record is unit-tested on the
+host (`boot_report::tests`), and `check-boot-report-layout` keeps the decoder
+in step with the struct, but nothing yet builds an image with
+`CONFIG_NROS_BOOT_REPORT=y`, exhausts its arena on purpose, and asserts the
+dump names the shortfall. Until that exists, the instrument is verified in
+every part except the one that runs on silicon -- which is the same shape as
+the defect it was built to find.
+
+**The sibling question is unswept.** `report_arena_exhausted` and
+`report_arena_headroom` are two of an unknown number of diagnostics that assume
+a sink. Nothing has enumerated which other `nros_log` call sites are reachable
+only on a target that cannot carry one.

--- a/docs/reference/api-parity-ledger/exec.json
+++ b/docs/reference/api-parity-ledger/exec.json
@@ -1124,5 +1124,10 @@
   "rust:Executor::clear_release_jitter_stats": {
     "verdict": "extension",
     "why": "Sibling of `Executor::release_jitter`, same commit, same reason there is no upstream name. Resets the window (`executor/spin.rs:2163`) so monitoring code can log-and-clear per period; without it a single early outlier pins the maximum for the life of the process, which is the failure mode that makes a max-only statistic useless on a long-running image."
+  },
+  "rust:Executor::set_min_stack_headroom_bytes": {
+    "verdict": "extension",
+    "why": "declare the fewest bytes a spin thread may leave unused before the executor reports a violation. rclrs has no equivalent because a hosted thread's stack grows on demand; an RTOS task's is a fixed buffer the entry handed over, and overflowing it corrupts whichever component's state sits next to it. The executor cannot infer the bound -- no portable query returns a task's TOTAL stack, so only the party that spawned the thread knows what it gave -- which is why this is a setter and not a derived percentage. Feeds the same monitor ring as the other spin rules; see `rust:Executor::*monitor_table`.",
+    "bucket": "ours-only"
   }
 }

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -285,6 +285,83 @@ that stopped matching cannot report success. Point it at a real dir by hand:
 Verified against the island both ways: it FAILS on the pre-fix build naming all
 four dropped knobs, and passes on the fixed one.
 
+## W5 -- the instrument, because the campaign ran out of oracle. LANDED 2026-09-04
+
+W1 through W4 all assume a way to tell a correct image from a broken one. On
+the island there is not one.
+
+The six derived knobs were unpinned, the graph came up degraded, and the
+bisect that followed could not converge because the signal itself was not
+reliable: **one unchanged configuration produced 4, 0, 0, 4, 4 nodes across
+five runs.** Three hypotheses were raised and each disproved by measurement --
+the arena (the 40,960 image failed identically), `MAX_CBS` (the restore trial
+gave 0 after giving 4), and a printk sink of my own (removing it changed
+nothing). None of those retractions was cheap, and all three were caused by
+reasoning against a 60%-reliable instrument rather than by reasoning badly.
+
+So the board `.conf` is currently pinned back to hand-set values with that
+evidence recorded in comments, and **acceptance 1 below is NOT met.** That is
+the honest state: the numbers derive, and nobody can say whether the derived
+image is right.
+
+### Why every stream was already disqualified
+
+| channel | why not |
+| --- | --- |
+| console UART | `lpuart0`, not wired on the MR-CANHUBK344 |
+| second UART | `lpuart2` carries the zenoh serial transport |
+| `nros_log` | therefore reaches nothing -- including BOTH of issue 0900's arena diagnostics |
+| SEGGER RTT | tried; could not discriminate. Working and derived images both printed only the Zephyr banner, and a deliberate positive control produced nothing |
+| semihosting | halts the core until a probe answers, and FAULTS with none attached, so the image cannot run standalone |
+
+What those share is that they are STREAMS: they need the board still running,
+and somebody attached at the moment the interesting thing happens. The failure
+this phase is chasing is the opposite shape -- an under-sized arena halts
+DURING entity creation, before the first spin, so the advisory that would
+explain it never runs. **W3 is blocked on this and not on arithmetic**, which
+is why it is still open with its derivation already written.
+
+### What landed
+
+`packages/core/nros-node/src/boot_report.rs` -- a fixed 60-byte record in RAM,
+not a stream. Fifteen `AtomicU32`s: the header, the stage boot reached, the
+knobs the image was COMPILED with, and the arena allocation that did not fit.
+Read back by halting the core and dumping memory, with the address resolved
+from the ELF's own symbol table so a relinked image cannot be read at a stale
+one:
+
+    python3 scripts/read-boot-report.py build/zephyr/zephyr.elf dump.bin
+
+A PARTIAL record is the useful case rather than a lost one, which is the whole
+difference from a log: the last stage reached and the failed allocation are
+exactly what names the knob to change.
+
+Opt-in (`NROS_BOOT_REPORT=1`, Zephyr `CONFIG_NROS_BOOT_REPORT=y`), so an image
+that does not enable it is byte-identical -- the rule issue 0900's arena knob
+and phase-403's `rx_buffer_from_type()` both keep.
+
+**The compile-time half is the part this phase needed most.** W4's
+`check-knob-delivery.py` asserts that the number reaching the compiler equals
+the number the resolver decided, read from `build.ninja`. The record asserts
+the same identity one step further along -- from the silicon. Six delivery
+failures reached `main` before W4 existed; this is the arm that would catch a
+seventh that survives the build system entirely.
+
+### Found while building it
+
+[#1036](../issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md):
+`arena_alloc_with_trailing` reported NOTHING on failure while its sibling
+`arena_alloc` has named the knob since issue 0900. Half of arena exhaustion was
+silent -- and it is the half carrying buffered subscriptions and action
+entries, which is what an island image actually allocates. Fixed with W5.
+
+### What W5 does NOT settle
+
+No cell builds an image with the record on, exhausts its arena on purpose, and
+asserts the dump names the shortfall. The instrument is verified in every part
+except the one that runs on silicon, which is the same shape as the defect it
+exists to find. Filed in #1036 rather than claimed here.
+
 ## Acceptance
 
 1. The island board `.conf` states no NROS count or size that W1 covers, and the

--- a/docs/roadmap/phase-412-derived-counts-and-sizes.md
+++ b/docs/roadmap/phase-412-derived-counts-and-sizes.md
@@ -285,7 +285,7 @@ that stopped matching cannot report success. Point it at a real dir by hand:
 Verified against the island both ways: it FAILS on the pre-fix build naming all
 four dropped knobs, and passes on the fixed one.
 
-## W5 -- the instrument, because the campaign ran out of oracle. LANDED 2026-09-04
+## W6 -- the instrument, because the campaign ran out of oracle. LANDED 2026-09-04
 
 W1 through W4 all assume a way to tell a correct image from a broken one. On
 the island there is not one.
@@ -355,7 +355,7 @@ seventh that survives the build system entirely.
 silent -- and it is the half carrying buffered subscriptions and action
 entries, which is what an island image actually allocates. Fixed with W5.
 
-### What W5 does NOT settle
+### What W6 does NOT settle
 
 No cell builds an image with the record on, exhausts its arena on purpose, and
 asserts the dump names the shortfall. The instrument is verified in every part

--- a/just/check.just
+++ b/just/check.just
@@ -131,6 +131,7 @@ fast-serial: \
     board-vocabulary \
     book-links \
     book-no-just \
+    boot-report-layout \
     box-sync-covers-tracked-source \
     build-profile-literals \
     build-root \
@@ -601,7 +602,14 @@ codegen-size-bound-golden:
 # correct one, and stamped it with a new mtime — so ninja found the mirror's
 # OUTPUT newer than its trigger and skipped the command that would have fixed
 # it. A repair for drift that caused drift and suppressed its own fix.
-#
+
+# phase-412 -- the boot self-report is decoded POSITIONALLY out of a memory
+# dump, so a field reordered on one side and not the other does not fail: it
+# decodes, and prints an arena size that is really a callback count.
+[private]
+boot-report-layout:
+    @python3 scripts/check-boot-report-layout.py
+
 # Static, no build. The whole 0088 -> 0114 -> 0122 -> 0123 -> 0245 -> 0268 ->
 # 0978 -> 0985 family is one shape: two ways to answer "which bytes are the
 # current sizes header".

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -876,8 +876,112 @@ pub(crate) fn transport_error_to_cpp_ret(err: nros_rmw::TransportError) -> nros_
 /// Phase 155.C — map `NodeError` to the closest `NROS_CPP_RET_*` code.
 /// Unknown variants stay TRANSPORT_ERROR (-100) — the legacy catch-all.
 #[cfg(feature = "rmw-cffi")]
+/// phase-412 -- stable codes for the boot self-report.
+///
+/// EXHAUSTIVE and no `_` arm, for the reason issue 0586's gate states about the
+/// ret mappers beside it: rustc must refuse a new variant until someone numbers
+/// it. A `_` arm here would silently file every future error under "unknown",
+/// which is the shape this whole record exists to remove.
+///
+/// The numbering is assigned HERE rather than taken from the Rust discriminant,
+/// because a discriminant shifts when a variant is inserted and a dump decoded
+/// against the wrong numbering names the wrong error, confidently. Append only.
+#[cfg(feature = "rmw-cffi")]
+fn node_error_class(err: &nros_node::NodeError) -> u32 {
+    use nros_node::NodeError as E;
+    match err {
+        E::Transport(_) => 1,
+        E::NameTooLong => 2,
+        E::Serialization => 3,
+        E::Deserialization => 4,
+        E::BufferTooSmall => 5,
+        E::ActionCreationFailed => 6,
+        E::ServiceRequestFailed => 7,
+        E::ServiceReplyFailed => 8,
+        E::Timeout => 9,
+        E::NotInitialized => 10,
+        E::RequestInFlight => 11,
+        E::NoSchedContextSlot => 12,
+        E::InvalidSchedContextBinding => 13,
+        E::NodeTableFull => 14,
+        E::ExecutorFull => 15,
+        E::BackendMismatch => 16,
+        E::ShutdownCallbacksFull => 17,
+    }
+}
+
+/// Which `TransportError`, for the report. Append only; see [`node_error_class`].
+///
+/// This is the field that pays for itself: the C++ ABI collapses eight distinct
+/// transport variants onto `-100`, so a board that fails to create a
+/// subscription reports "transport error" and nothing says which of the eight.
+#[cfg(feature = "rmw-cffi")]
+fn transport_error_class(err: &nros_rmw::TransportError) -> u32 {
+    use nros_rmw::TransportError as T;
+    match err {
+        T::ConnectionFailed => 1,
+        T::Disconnected => 2,
+        T::PublisherCreationFailed => 3,
+        T::SubscriberCreationFailed => 4,
+        T::ServiceServerCreationFailed => 5,
+        T::ServiceClientCreationFailed => 6,
+        T::PublishFailed => 7,
+        T::ServiceRequestFailed => 8,
+        T::ServiceReplyFailed => 9,
+        T::SerializationError => 10,
+        T::DeserializationError => 11,
+        T::BufferTooSmall => 12,
+        T::MessageTooLarge => 13,
+        T::Timeout => 14,
+        T::InvalidConfig => 15,
+        T::WouldBlock => 16,
+        T::TooLarge => 17,
+        T::TaskStartFailed => 18,
+        T::PollFailed => 19,
+        T::KeepaliveFailed => 20,
+        T::JoinFailed => 21,
+        T::InvalidArgument => 22,
+        T::Unsupported => 23,
+        T::BadAlloc => 24,
+        T::IncompatibleQos => 25,
+        T::TopicNameInvalid => 26,
+        T::NodeNameNonExistent => 27,
+        T::LoanNotSupported => 28,
+        T::NoData => 29,
+        T::IncompatibleAbi => 30,
+        T::Backend(_) => 31,
+        // Un-gated for the reason the arm below in `transport_error_to_cpp_ret`
+        // is: cargo unifies features across the graph, so the variant can exist
+        // while a `#[cfg(feature = "alloc")]` arm here is compiled out.
+        T::BackendDynamic(_) => 32,
+    }
+}
+
+/// Put the error in the boot self-report, then let the caller map it.
+///
+/// Called from the ONE funnel every FFI failure already passes through, so a
+/// path that starts returning errors tomorrow is recorded without anyone
+/// remembering to add a call.
+#[cfg(feature = "rmw-cffi")]
+fn record_node_error(err: &nros_node::NodeError) {
+    let (transport, ptr, len) = match err {
+        nros_node::NodeError::Transport(t) => {
+            let (ptr, len) = match t {
+                // The message is a static string already in the image, so the
+                // record carries where it is rather than a copy of it.
+                nros_rmw::TransportError::Backend(s) => (s.as_ptr() as u32, s.len() as u32),
+                _ => (0, 0),
+            };
+            (transport_error_class(t), ptr, len)
+        }
+        _ => (0, 0, 0),
+    };
+    nros_node::boot_report::note_error(node_error_class(err), transport, ptr, len);
+}
+
 pub(crate) fn node_error_to_cpp_ret(err: nros_node::NodeError) -> nros_cpp_ret_t {
     use nros_node::NodeError as E;
+    record_node_error(&err);
     // Issue 0436 — `-100` is documented as the catch-all for unmapped variants, so
     // a C++ caller sees "TransportError" for causes that are not transport at all.
     // That collapse is what made the PX4 bridge's init failure undiagnosable (the

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -592,7 +592,19 @@ pub unsafe extern "C" fn nros_cpp_init(
     namespace: *const c_char,
     storage: *mut c_void,
 ) -> nros_cpp_ret_t {
+    // phase-412 -- stamp the self-report BEFORE anything can reject an
+    // argument. This is the first nano-ros code an image runs, so a record that
+    // is still zero after this point means the image never got here at all.
+    //
+    // Version 1 stamped it inside the executor constructor instead. On the
+    // first board run that made "never entered nano-ros" and "entered and died
+    // before the executor" the same observation -- both read magic 0 -- and
+    // telling them apart took a walk through the disassembly to prove the call
+    // chain existed. That is the manual work the record exists to remove.
+    nros_node::boot_report::init();
+
     if node_name.is_null() || storage.is_null() {
+        nros_node::boot_report::note_cpp_init_ret(NROS_CPP_RET_INVALID_ARGUMENT);
         return NROS_CPP_RET_INVALID_ARGUMENT;
     }
 
@@ -610,7 +622,10 @@ pub unsafe extern "C" fn nros_cpp_init(
     // longer deps directly).
     let node_name_str = match unsafe { cstr_to_str(node_name) } {
         Some(s) => s,
-        None => return NROS_CPP_RET_INVALID_ARGUMENT,
+        None => {
+            nros_node::boot_report::note_cpp_init_ret(NROS_CPP_RET_INVALID_ARGUMENT);
+            return NROS_CPP_RET_INVALID_ARGUMENT;
+        }
     };
 
     let ns_str = if namespace.is_null() {
@@ -618,7 +633,10 @@ pub unsafe extern "C" fn nros_cpp_init(
     } else {
         match unsafe { cstr_to_str(namespace) } {
             Some(s) => s,
-            None => return NROS_CPP_RET_INVALID_ARGUMENT,
+            None => {
+                nros_node::boot_report::note_cpp_init_ret(NROS_CPP_RET_INVALID_ARGUMENT);
+                return NROS_CPP_RET_INVALID_ARGUMENT;
+            }
         }
     };
 
@@ -627,7 +645,10 @@ pub unsafe extern "C" fn nros_cpp_init(
     } else {
         match unsafe { cstr_to_str(locator) } {
             Some(s) => Some(s),
-            None => return NROS_CPP_RET_INVALID_ARGUMENT,
+            None => {
+                nros_node::boot_report::note_cpp_init_ret(NROS_CPP_RET_INVALID_ARGUMENT);
+                return NROS_CPP_RET_INVALID_ARGUMENT;
+            }
         }
     };
 
@@ -652,8 +673,15 @@ pub unsafe extern "C" fn nros_cpp_init(
     // edge's to supply, so the capability cfg sits at the call site.
     let config = match resolve_boot(baked) {
         Ok(cfg) => cfg,
-        Err(_) => return NROS_CPP_RET_INVALID_ARGUMENT,
+        Err(_) => {
+            nros_node::boot_report::note_cpp_init_ret(NROS_CPP_RET_INVALID_ARGUMENT);
+            return NROS_CPP_RET_INVALID_ARGUMENT;
+        }
     };
+    // Everything above this line is argument validation; everything below is
+    // the executor. A record stopping here says the inputs were rejected, and
+    // `cpp_init_ret` says by which check.
+    nros_node::boot_report::checkpoint(nros_node::boot_report::Stage::BootConfigResolved);
     let domain_id = config.domain_id as u8;
 
     // phase-271 — construct in place: carve the executor's per-entry backing from
@@ -692,7 +720,11 @@ pub unsafe extern "C" fn nros_cpp_init(
         // next `nros::init -> -X` log line in the FreeRTOS / RV64
         // C++ tests identifies which precondition the backend
         // rejected.
-        Err(e) => node_error_to_cpp_ret(e),
+        Err(e) => {
+            let ret = node_error_to_cpp_ret(e);
+            nros_node::boot_report::note_cpp_init_ret(ret);
+            ret
+        }
     }
 }
 

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -979,6 +979,12 @@ fn record_node_error(err: &nros_node::NodeError) {
     nros_node::boot_report::note_error(node_error_class(err), transport, ptr, len);
 }
 
+/// Phase 155.C -- map `NodeError` to the closest `NROS_CPP_RET_*` code, and
+/// record it in the boot self-report on the way past.
+///
+/// Gated with its two callees: without `rmw-cffi` there is no
+/// `nros_rmw::TransportError` to map, and nothing in this crate calls it.
+#[cfg(feature = "rmw-cffi")]
 pub(crate) fn node_error_to_cpp_ret(err: nros_node::NodeError) -> nros_cpp_ret_t {
     use nros_node::NodeError as E;
     record_node_error(&err);

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -210,12 +210,13 @@ pub fn run(args: EntityInventoryArgs) -> Result<()> {
             .wrap_err_with(|| format!("read model `{}`", model_path.display()))?;
         let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(&raw)
             .wrap_err_with(|| format!("parse model `{}`", model_path.display()))?;
-        match EntityInventory::from_model(model_path.display().to_string(), &model) {
-            Some(model_inv) => inv = inv.merged_per_kind_max(&model_inv),
-            // No wiring described. Not an error and not a zero: nobody authored
-            // a contract for this image, and the declaration is the only source
-            // there is.
-            None => {}
+        // `from_model` returning None means NO WIRING DESCRIBED. Not an error
+        // and not a zero: nobody authored a contract for this image, so the
+        // declaration is the only source there is and it stands alone.
+        if let Some(model_inv) =
+            EntityInventory::from_model(model_path.display().to_string(), &model)
+        {
+            inv = inv.merged_per_kind_max(&model_inv);
         }
     }
 

--- a/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/cmd/entity_inventory.rs
@@ -61,6 +61,22 @@ pub struct EntityInventoryArgs {
     #[arg(long, value_name = "PATH")]
     pub metadata: Option<PathBuf>,
 
+    /// phase-412 -- a resolved SystemModel whose `structure.topics` carries the
+    /// authored contract's wiring.
+    ///
+    /// When given AND the model describes wiring, its per-node sub/pub sets are
+    /// combined with the metadata declaration per component and per kind,
+    /// taking whichever says more (`EntityInventory::merged_per_kind_max`).
+    /// That is what lets a contract beside the launch file replace the
+    /// `ENTITIES` lists, WITHOUT losing the timers the contract schema cannot
+    /// express.
+    ///
+    /// Absent, or present but describing no wiring, the metadata declaration
+    /// stands alone -- which is every image in this tree that has not authored
+    /// a contract.
+    #[arg(long, value_name = "PATH")]
+    pub model: Option<PathBuf>,
+
     /// Write the canonical JSON artifact here.
     #[arg(long = "output-json", value_name = "PATH")]
     pub output_json: Option<PathBuf>,
@@ -183,6 +199,25 @@ pub fn run(args: EntityInventoryArgs) -> Result<()> {
     let doc: MetadataDoc = serde_json::from_str(&raw)
         .wrap_err_with(|| format!("parse metadata `{}`", metadata.display()))?;
     let mut inv = inventory_from_metadata(&metadata.display().to_string(), &doc)?;
+
+    // phase-412 -- fold in the model's wiring when a contract authored it.
+    //
+    // Deliberately a COMBINE and not a replace: the contract has no timer
+    // entity, so a model-only inventory under-sizes MAX_CBS by one per timer
+    // in the image. See `EntityInventory::merged_per_kind_max`.
+    if let Some(model_path) = &args.model {
+        let raw = std::fs::read_to_string(model_path)
+            .wrap_err_with(|| format!("read model `{}`", model_path.display()))?;
+        let model: ros_launch_manifest_model::SystemModel = serde_yaml_ng::from_str(&raw)
+            .wrap_err_with(|| format!("parse model `{}`", model_path.display()))?;
+        match EntityInventory::from_model(model_path.display().to_string(), &model) {
+            Some(model_inv) => inv = inv.merged_per_kind_max(&model_inv),
+            // No wiring described. Not an error and not a zero: nobody authored
+            // a contract for this image, and the declaration is the only source
+            // there is.
+            None => {}
+        }
+    }
 
     if let Some(want) = &args.component {
         inv = narrow_to_component(&inv, want)?;

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -833,6 +833,103 @@ impl EntityInventory {
         Some(inv)
     }
 
+    /// phase-412 -- combine a declaration-derived inventory with a
+    /// model-derived one, PER COMPONENT and PER KIND, taking whichever source
+    /// says more.
+    ///
+    /// Neither source is complete, which is why this is a max and not a choice
+    /// -- the same rule, for the same reason, that
+    /// `model_ingest::count_callbacks_with_metadata` applies one layer up:
+    ///
+    /// * The MODEL has no timer entity. The island runs four timers and the
+    ///   contract cannot express one, so a model-only `MAX_CBS` is short by
+    ///   four and short halts the board.
+    /// * The DECLARATION is hand-written. mrm_handler's said six subscriptions
+    ///   where the code creates seven, and nothing compared the two; the model
+    ///   gets its seven from an authored contract instead.
+    ///
+    /// Per KIND rather than per component total, because the two blind spots
+    /// are in different kinds: taking a whole-component max would let the
+    /// declaration's four timers hide the model's extra subscription, or the
+    /// reverse. Per kind, each source can only ever raise the answer.
+    ///
+    /// UNION would double-count: both sources describe the same subscriptions,
+    /// so adding them sizes every pool at twice the truth.
+    ///
+    /// The join key is the COMPONENT name -- `nano_ros_node_register(NAME ...)`
+    /// on one side and the launch `exec` on the other, which RFC-0057 already
+    /// requires to be the same string. A component in one source and not the
+    /// other is carried through unchanged rather than dropped.
+    #[must_use]
+    pub fn merged_per_kind_max(&self, model: &EntityInventory) -> EntityInventory {
+        use std::collections::BTreeMap;
+
+        fn by_kind(d: &Declaration) -> BTreeMap<EntityKind, Vec<EntityDecl>> {
+            let mut m: BTreeMap<EntityKind, Vec<EntityDecl>> = BTreeMap::new();
+            for e in d.entities() {
+                m.entry(e.kind).or_default().push(e.clone());
+            }
+            m
+        }
+
+        let model_rows: BTreeMap<&str, &ComponentEntities> = model
+            .components
+            .iter()
+            .map(|c| (c.component.as_str(), c))
+            .collect();
+
+        let mut out = Self::new(format!("{} + {}", self.source, model.source));
+        let mut seen: Vec<&str> = Vec::new();
+
+        for decl_row in &self.components {
+            let Some(model_row) = model_rows.get(decl_row.component.as_str()) else {
+                out.insert(decl_row.clone());
+                continue;
+            };
+            seen.push(decl_row.component.as_str());
+
+            // A component the declaration says nothing about is NOT a zero, so
+            // the model simply stands. `Declaration::None` IS a zero and the
+            // max still holds.
+            let decl_kinds = by_kind(&decl_row.declaration);
+            let model_kinds = by_kind(&model_row.declaration);
+
+            let mut merged: Vec<EntityDecl> = Vec::new();
+            let mut kinds: Vec<EntityKind> = decl_kinds
+                .keys()
+                .chain(model_kinds.keys())
+                .copied()
+                .collect();
+            kinds.sort_by_key(|k| k.tag());
+            kinds.dedup();
+            for k in kinds {
+                let d = decl_kinds.get(&k).map(Vec::as_slice).unwrap_or(&[]);
+                let m = model_kinds.get(&k).map(Vec::as_slice).unwrap_or(&[]);
+                // The LONGER list wins whole, so the winning source's types and
+                // topic names survive intact rather than being spliced.
+                merged.extend_from_slice(if m.len() > d.len() { m } else { d });
+            }
+
+            out.insert(ComponentEntities {
+                pkg: decl_row.pkg.clone(),
+                component: decl_row.component.clone(),
+                class: decl_row.class.clone(),
+                declaration: if merged.is_empty() {
+                    decl_row.declaration.clone()
+                } else {
+                    Declaration::Stated(merged)
+                },
+            });
+        }
+
+        for (name, row) in &model_rows {
+            if !seen.contains(name) {
+                out.insert((*row).clone());
+            }
+        }
+        out
+    }
+
     /// Record one component. A later record for the same `(pkg, component)`
     /// replaces the earlier one, so a configure that registers a component
     /// twice cannot double-count it.
@@ -2461,6 +2558,91 @@ structure:
         let k = d.knobs().expect("wiring yields knobs");
         assert_eq!(k.max_subscribers, 2, "two subscriptions across the image");
         assert_eq!(k.max_publishers, 1, "one publisher");
+    }
+
+    /// phase-412 -- the merge must take the model's EXTRA subscription and keep
+    /// the declaration's timer.
+    ///
+    /// This is the island's actual failure in miniature: the hand-written list
+    /// said one subscription where the contract says two, and the contract
+    /// cannot express the timer the list carries. Either source alone
+    /// under-sizes a pool, in a different kind each.
+    #[test]
+    fn the_merge_takes_the_larger_of_each_kind() {
+        let mut decl = EntityInventory::new("metadata");
+        decl.insert(ComponentEntities {
+            pkg: "autoware_mrm_handler".into(),
+            component: "mrm_handler".into(),
+            class: "MrmHandler".into(),
+            declaration: Declaration::Stated(vec![
+                EntityDecl {
+                    kind: EntityKind::Subscription,
+                    type_name: Some("a/msg/A".into()),
+                    name: Some("/one".into()),
+                    depth: None,
+                },
+                EntityDecl {
+                    kind: EntityKind::Timer,
+                    type_name: None,
+                    name: None,
+                    depth: None,
+                },
+            ]),
+        });
+
+        let mut model = EntityInventory::new("model");
+        model.insert(ComponentEntities {
+            pkg: "/mrm_handler".into(),
+            component: "mrm_handler".into(),
+            class: String::new(),
+            declaration: Declaration::Stated(vec![
+                EntityDecl {
+                    kind: EntityKind::Subscription,
+                    type_name: Some("a/msg/A".into()),
+                    name: Some("/one".into()),
+                    depth: None,
+                },
+                EntityDecl {
+                    kind: EntityKind::Subscription,
+                    type_name: Some("b/msg/B".into()),
+                    name: Some("/two".into()),
+                    depth: None,
+                },
+            ]),
+        });
+
+        let merged = decl.merged_per_kind_max(&model);
+        let d = merged.derive();
+        let k = d.knobs().expect("merged yields knobs");
+        assert_eq!(
+            k.max_subscribers, 2,
+            "the model's extra subscription survives"
+        );
+        assert_eq!(
+            k.max_cbs, 3,
+            "two subscriptions plus the timer only the declaration knows"
+        );
+    }
+
+    /// A component the model does not mention keeps its declaration whole.
+    #[test]
+    fn a_component_absent_from_the_model_is_not_dropped() {
+        let mut decl = EntityInventory::new("metadata");
+        decl.insert(ComponentEntities {
+            pkg: "p".into(),
+            component: "only_declared".into(),
+            class: "C".into(),
+            declaration: Declaration::Stated(vec![EntityDecl {
+                kind: EntityKind::Timer,
+                type_name: None,
+                name: None,
+                depth: None,
+            }]),
+        });
+        let merged = decl.merged_per_kind_max(&EntityInventory::new("model"));
+        assert_eq!(merged.len(), 1);
+        let d = merged.derive();
+        assert_eq!(d.knobs().expect("knobs").max_cbs, 1);
     }
 
     /// A model that describes NO wiring must abstain, never report zero.

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -748,6 +748,91 @@ impl EntityInventory {
         }
     }
 
+    /// phase-412 -- build the inventory from a resolved SystemModel's wiring
+    /// instead of from `ENTITIES`.
+    ///
+    /// `structure.topics` carries, per topic, its message type and the endpoint
+    /// refs on each side (`/node/endpoint`). That is exactly a per-node sub/pub
+    /// set with types attached, which is what this inventory holds -- so the
+    /// authored contract beside the launch file can replace the `ENTITIES` list
+    /// duplicated in every component's `CMakeLists.txt`.
+    ///
+    /// The two sources are not interchangeable, and the difference is the whole
+    /// reason this is a separate constructor rather than a swap:
+    ///
+    /// * The model has NO TIMER ENTITY. A component whose only callback is a
+    ///   timer contributes nothing here and one callback slot at runtime. The
+    ///   island has four such timers, so a `MAX_CBS` derived from the model
+    ///   alone is short by four. Callers must combine this with the declaration
+    ///   or the component sidecar -- `model_ingest` states the same rule as
+    ///   `max(model_wiring, recorded_metadata)`.
+    /// * Service and action wiring lives in `structure.{services,actions}`,
+    ///   which this reads too, but a model that describes no wiring at all is
+    ///   ABSENT rather than zero -- see `entity_facts::describes_wiring`, and
+    ///   the same three-valued rule [`Declaration`] keeps.
+    ///
+    /// Returns `None` when the model describes no wiring, so a caller cannot
+    /// mistake "nobody authored a contract" for "this image creates nothing".
+    /// That distinction is the one this module exists to preserve.
+    pub fn from_model(
+        source: impl Into<String>,
+        model: &ros_launch_manifest_model::SystemModel,
+    ) -> Option<Self> {
+        if model.structure.topics.is_empty()
+            && model.structure.services.is_empty()
+            && model.structure.actions.is_empty()
+        {
+            return None;
+        }
+
+        // Endpoint refs are `/ns/node/endpoint`; the node FQN is everything but
+        // the last segment. Group per node so each becomes one component row.
+        fn node_of(ep: &str) -> String {
+            ep.rsplit_once('/')
+                .map(|(n, _)| n)
+                .unwrap_or(ep)
+                .to_string()
+        }
+
+        let mut per_node: std::collections::BTreeMap<String, Vec<EntityDecl>> =
+            std::collections::BTreeMap::new();
+
+        for wiring in model.structure.topics.values() {
+            for ep in &wiring.subscribers {
+                per_node.entry(node_of(ep)).or_default().push(EntityDecl {
+                    kind: EntityKind::Subscription,
+                    type_name: Some(wiring.msg_type.clone()),
+                    name: Some(ep.clone()),
+                    depth: None,
+                });
+            }
+            for ep in &wiring.publishers {
+                per_node.entry(node_of(ep)).or_default().push(EntityDecl {
+                    kind: EntityKind::Publisher,
+                    type_name: Some(wiring.msg_type.clone()),
+                    name: Some(ep.clone()),
+                    depth: None,
+                });
+            }
+        }
+
+        let mut inv = Self::new(source);
+        for (node_fqn, entities) in per_node {
+            let component = node_fqn.rsplit('/').next().unwrap_or(&node_fqn).to_string();
+            inv.insert(ComponentEntities {
+                // The model names nodes, not ament packages. A node FQN is the
+                // stable identity here, and stating it as the package rather
+                // than inventing one keeps the provenance line honest about
+                // where the row came from.
+                pkg: node_fqn.clone(),
+                component,
+                class: String::new(),
+                declaration: Declaration::Stated(entities),
+            });
+        }
+        Some(inv)
+    }
+
     /// Record one component. A later record for the same `(pkg, component)`
     /// replaces the earlier one, so a configure that registers a component
     /// twice cannot double-count it.
@@ -2328,5 +2413,76 @@ mod tests {
         assert_eq!(k.per_kind["service_server"], 2);
         assert_eq!(k.per_kind["service_client"], 2);
         assert_eq!(k.max_cbs, 19);
+    }
+}
+
+#[cfg(test)]
+mod from_model_tests {
+    use super::*;
+    use ros_launch_manifest_model::SystemModel;
+
+    /// phase-412 -- the island's own resolved model, cut down to the shape that
+    /// matters: two nodes, three topics, one of them internal.
+    ///
+    /// Asserts the counts the pool derivation consumes, not the parse: the
+    /// question is whether `structure.topics` yields the same per-node sub/pub
+    /// sets the hand-written `ENTITIES` lists did.
+    fn model_from_yaml(y: &str) -> SystemModel {
+        serde_yaml_ng::from_str(y).expect("model fixture parses")
+    }
+
+    #[test]
+    fn topics_become_per_node_subscriptions_and_publishers() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /mrm_handler:
+      { scope: s.launch.xml, pkg: autoware_mrm_handler, exec: mrm_handler,
+        node_name: mrm_handler }
+    /stop_mode_operator:
+      { scope: s.launch.xml, pkg: autoware_stop_mode_operator,
+        exec: stop_mode_operator, node_name: stop_mode_operator }
+  topics:
+    /system/mrm/emergency_stop/status:
+      type: tier4_system_msgs/msg/MrmBehaviorStatus
+      sub: [/mrm_handler/emergency_stop_status]
+    /api/operation_mode/state:
+      type: autoware_adapi_v1_msgs/msg/OperationModeState
+      sub: [/mrm_handler/operation_mode_state]
+    /system/stop_mode/control:
+      type: autoware_control_msgs/msg/Control
+      pub: [/stop_mode_operator/control]
+"#,
+        );
+        let inv = EntityInventory::from_model("test", &m).expect("model describes wiring");
+        let d = inv.derive();
+        let k = d.knobs().expect("wiring yields knobs");
+        assert_eq!(k.max_subscribers, 2, "two subscriptions across the image");
+        assert_eq!(k.max_publishers, 1, "one publisher");
+    }
+
+    /// A model that describes NO wiring must abstain, never report zero.
+    ///
+    /// Every launch file in this tree without a contract resolves that way, and
+    /// reporting 0 would size each pool to the infrastructure alone and exhaust
+    /// it the moment a node registers -- a confident wrong number, which is the
+    /// failure shape this module exists to prevent.
+    #[test]
+    fn a_model_without_wiring_abstains() {
+        let m = model_from_yaml(
+            r#"
+meta: { version: 1 }
+structure:
+  nodes:
+    /talker:
+      { scope: s.launch.xml, pkg: demo, exec: talker, node_name: talker }
+"#,
+        );
+        assert!(
+            EntityInventory::from_model("test", &m).is_none(),
+            "no contract authored means unanswered, not zero"
+        );
     }
 }

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -21,6 +21,15 @@ fn main() {
     // this presence cfg.
     println!("cargo:rustc-check-cfg=cfg(rmw_needs_type_descriptors)");
 
+    // The boot self-report (`src/boot_report.rs`) is OPT-IN, so an image that
+    // does not ask for it is byte-identical to one built before it existed.
+    // Set NROS_BOOT_REPORT=1 (Zephyr: CONFIG_NROS_BOOT_REPORT=y) to enable.
+    println!("cargo:rustc-check-cfg=cfg(nros_boot_report)");
+    println!("cargo:rerun-if-env-changed=NROS_BOOT_REPORT");
+    if env::var("NROS_BOOT_REPORT").is_ok_and(|v| !v.is_empty() && v != "0" && v != "n") {
+        println!("cargo:rustc-cfg=nros_boot_report");
+    }
+
     // Emit `has_rmw` when an RMW seam is compiled in.
     //
     // phase-347 W1 — this used to test four features:

--- a/packages/core/nros-node/src/boot_report.rs
+++ b/packages/core/nros-node/src/boot_report.rs
@@ -70,7 +70,7 @@ pub const MAGIC: u32 = 0x4e52_5352;
 
 /// Layout version. Bump on any field change; a reader refuses what it does not
 /// know rather than decoding a record it would misread.
-pub const VERSION: u32 = 2;
+pub const VERSION: u32 = 3;
 
 /// How far boot got. Monotonic, and the single most useful field: an arena
 /// failure halts during entity creation, so the stage that was NOT reached
@@ -171,6 +171,29 @@ mod enabled {
         /// non-UTF-8 name, a bad domain id, a backend that refused to open --
         /// is one indistinguishable "did not reach the executor".
         cpp_init_ret: AtomicU32,
+        /// The LAST `NodeError` that crossed the C++ FFI, as a stable code.
+        ///
+        /// Stable here means assigned by `nros-cpp`'s exhaustive mapper, not
+        /// taken from the Rust discriminant -- a discriminant shifts whenever a
+        /// variant is inserted, and a dump decoded against the wrong numbering
+        /// names the wrong error, confidently.
+        err_class: AtomicU32,
+        /// For [`Self::err_class`] == Transport, which `TransportError`.
+        ///
+        /// The C++ ABI collapses eight distinct transport variants onto the
+        /// single code -100, which is what made an island subscription failure
+        /// undiagnosable: the return code said "transport" and nothing said
+        /// which. This is the field that separates them.
+        err_transport: AtomicU32,
+        /// Address of the `Backend(&'static str)` message, or 0.
+        ///
+        /// The pointer rather than the text: the message is a static string
+        /// already in the image, so copying it would cost the record a buffer
+        /// to hold something the reader can fetch. Paired with
+        /// [`Self::err_backend_len`].
+        err_backend_ptr: AtomicU32,
+        /// Length of the message at [`Self::err_backend_ptr`], or 0.
+        err_backend_len: AtomicU32,
     }
 
     impl BootReport {
@@ -192,6 +215,10 @@ mod enabled {
                 failed_alloc_size: AtomicU32::new(0),
                 failed_alloc_shortfall: AtomicU32::new(0),
                 cpp_init_ret: AtomicU32::new(0),
+                err_class: AtomicU32::new(0),
+                err_transport: AtomicU32::new(0),
+                err_backend_ptr: AtomicU32::new(0),
+                err_backend_len: AtomicU32::new(0),
             }
         }
 
@@ -234,6 +261,10 @@ mod enabled {
         pub failed_alloc_size: u32,
         pub failed_alloc_shortfall: u32,
         pub cpp_init_ret: u32,
+        pub err_class: u32,
+        pub err_transport: u32,
+        pub err_backend_ptr: u32,
+        pub err_backend_len: u32,
     }
 
     /// Read the record.
@@ -258,6 +289,10 @@ mod enabled {
             failed_alloc_size: g(&r.failed_alloc_size),
             failed_alloc_shortfall: g(&r.failed_alloc_shortfall),
             cpp_init_ret: g(&r.cpp_init_ret),
+            err_class: g(&r.err_class),
+            err_transport: g(&r.err_transport),
+            err_backend_ptr: g(&r.err_backend_ptr),
+            err_backend_len: g(&r.err_backend_len),
         }
     }
 
@@ -365,6 +400,24 @@ mod enabled {
             .store(ret as u32, Ordering::Relaxed);
     }
 
+    /// Record an error that crossed the FFI.
+    ///
+    /// Takes CODES, not the error type: `nros-node` must not need to know how
+    /// `nros-cpp` numbers its variants, and the numbering has to be assigned by
+    /// an exhaustive match that a new variant breaks at compile time. The caller
+    /// owns both.
+    ///
+    /// LAST writer wins. An image that fails one entity and carries on would
+    /// otherwise keep the first stumble instead of the one that stopped it, and
+    /// the failure that stops setup is the one that explains the boot.
+    pub fn note_error(class: u32, transport: u32, backend_ptr: u32, backend_len: u32) {
+        let r = &NROS_BOOT_REPORT;
+        r.err_class.store(class, Ordering::Relaxed);
+        r.err_transport.store(transport, Ordering::Relaxed);
+        r.err_backend_ptr.store(backend_ptr, Ordering::Relaxed);
+        r.err_backend_len.store(backend_len, Ordering::Relaxed);
+    }
+
     /// `usize` -> `u32`, saturating.
     ///
     /// Every field is a `u32` so the record's layout does not change between a
@@ -403,24 +456,27 @@ mod disabled {
 
     #[inline(always)]
     pub fn note_cpp_init_ret(_ret: i32) {}
+
+    #[inline(always)]
+    pub fn note_error(_class: u32, _transport: u32, _ptr: u32, _len: u32) {}
 }
 
 #[cfg(all(test, nros_boot_report))]
 mod tests {
     use super::*;
 
-    /// The reader decodes sixteen u32s positionally, so the record must be
+    /// The reader decodes twenty u32s positionally, so the record must be
     /// exactly that and nothing else -- no padding, no reordering.
     ///
     /// `size_of` on the TARGET, which is the half `check-boot-report-layout.py`
     /// cannot see: that gate compares two source files, and this compares the
     /// source against what the compiler actually laid out.
     #[test]
-    fn the_record_is_sixteen_packed_u32s() {
-        assert_eq!(BootReport::struct_size(), 16 * 4);
+    fn the_record_is_twenty_packed_u32s() {
+        assert_eq!(BootReport::struct_size(), 20 * 4);
         assert_eq!(
             core::mem::size_of::<BootReport>(),
-            16 * core::mem::size_of::<u32>(),
+            20 * core::mem::size_of::<u32>(),
             "the record grew padding; the reader decodes positionally"
         );
         assert_eq!(core::mem::align_of::<BootReport>(), 4);

--- a/packages/core/nros-node/src/boot_report.rs
+++ b/packages/core/nros-node/src/boot_report.rs
@@ -1,0 +1,444 @@
+//! A fixed RAM record the image writes about itself, for targets where no log
+//! sink reaches a human.
+//!
+//! # Why this exists
+//!
+//! phase-412 derived six pool counts and the executor arena for the
+//! mr-canhubk344 island, and then could not tell whether the derived image was
+//! correct. The only available signal was the ROS graph's node count, and one
+//! unchanged configuration produced 4, 0, 0, 4, 4 across five runs. Every other
+//! channel was already disqualified for that board:
+//!
+//! * The console is on `lpuart0`, which is not wired on the MR-CANHUBK344.
+//!   `lpuart2` is the zenoh serial transport and cannot carry a second protocol.
+//! * `nros_log` therefore reaches nothing. Both arena diagnostics (issue 0900)
+//!   go through it, so the two messages written specifically to explain an
+//!   arena failure are invisible on the one board that needed them.
+//! * SEGGER RTT was tried and could not discriminate: a working image and a
+//!   derived image both emitted only the Zephyr banner, and a deliberate
+//!   positive control produced nothing at all.
+//! * Semihosting halts the core until a probe answers and FAULTS with no probe
+//!   attached, so an image carrying it cannot run standalone.
+//!
+//! What all of those share is that they are STREAMS: they need the board to
+//! still be running, and they need somebody attached at the moment the
+//! interesting thing happens. The failure this campaign is trying to see is the
+//! opposite shape. An under-sized arena halts DURING entity creation, before
+//! the first spin, so issue 0900's advisory never prints -- the failure cannot
+//! report itself through any stream.
+//!
+//! So this is not a stream. It is a fixed-size record in RAM that the image
+//! keeps up to date as it boots, read out AFTERWARDS by halting the core and
+//! dumping memory. It survives the halt because it does not depend on anything
+//! still running, and a PARTIAL record is the useful case rather than a lost
+//! one: the last stage reached and the allocation that did not fit are exactly
+//! what names the knob to change.
+//!
+//! # Reading it
+//!
+//! The record is a `#[no_mangle]` static, so it has a symbol in the ELF and a
+//! debugger can find it without the address being wired in anywhere:
+//!
+//! ```text
+//! pyocd commander -t s32k344 -c "halt" -c "savemem <addr> <len> report.bin"
+//! python3 scripts/read-boot-report.py <elf> report.bin
+//! ```
+//!
+//! [`MAGIC`] distinguishes a written record from uninitialised RAM, and
+//! [`BootReport::struct_size`] lets a reader refuse a layout it does not know
+//! rather than decode it wrongly.
+//!
+//! # Cost, and why it is opt-in
+//!
+//! Enabled by setting `NROS_BOOT_REPORT=1` at build time (Zephyr:
+//! `CONFIG_NROS_BOOT_REPORT=y`), which makes `nros-node`'s build script emit
+//! `cfg(nros_boot_report)`. With the cfg absent every function here is an empty
+//! `#[inline(always)]` body and the static does not exist, so an image that
+//! does not opt in is byte-identical to one built before this module -- the
+//! same rule issue 0900's arena knob and phase-403's `rx_buffer_from_type()`
+//! both keep.
+//!
+//! Enabled, it costs [`BootReport::struct_size`] bytes of `.bss` (60 on a
+//! 32-bit target) and a handful of relaxed atomic stores on paths that run once
+//! per entity at registration. Nothing here is on the spin path.
+
+#![allow(clippy::module_name_repetitions)]
+
+/// `"NRSR"` -- nano-ros self report. Written LAST, so a reader that finds it
+/// knows every field before it is already valid.
+pub const MAGIC: u32 = 0x4e52_5352;
+
+/// Layout version. Bump on any field change; a reader refuses what it does not
+/// know rather than decoding a record it would misread.
+pub const VERSION: u32 = 1;
+
+/// How far boot got. Monotonic, and the single most useful field: an arena
+/// failure halts during entity creation, so the stage that was NOT reached
+/// names the phase to look at.
+///
+/// Values are stable across versions -- a new stage is appended, never
+/// inserted, so a stage number in an old dump keeps its meaning.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum Stage {
+    /// RAM as the loader left it. Never stored; a reader seeing this with a
+    /// valid magic has found a record that was reset but not re-entered.
+    Untouched = 0,
+    /// The record itself is initialised and the compile-time knobs are in it.
+    /// Reaching only here means the image died before the executor existed.
+    ReportReady = 1,
+    /// An `Executor` has bound its arena, so [`BootReport::arena_capacity`]
+    /// is the real slice length rather than the compiled constant.
+    ExecutorReady = 2,
+    /// Entity registration has begun. The interval between this and
+    /// [`Stage::EntitiesReady`] is where an under-sized arena halts.
+    RegisteringEntities = 3,
+    /// Every entity the image declares was registered successfully.
+    EntitiesReady = 4,
+    /// The first `spin_once` was entered, which is where issue 0900's
+    /// headroom advisory would have printed had a sink existed.
+    FirstSpin = 5,
+}
+
+#[cfg(nros_boot_report)]
+pub use enabled::*;
+
+#[cfg(nros_boot_report)]
+mod enabled {
+    use super::{MAGIC, Stage, VERSION};
+    use portable_atomic::{AtomicU32, Ordering};
+
+    /// The record. One per image, in `.bss`.
+    ///
+    /// `#[repr(C)]` with every field an `AtomicU32` -- which is
+    /// `repr(transparent)` over `u32` -- so the layout is exactly the sequence
+    /// of 32-bit words the reader script decodes, on every target this crate
+    /// builds for.
+    ///
+    /// Atomics rather than a `static mut` because the record is written from
+    /// registration paths that an application may reach from more than one
+    /// thread. `Relaxed` throughout: there is no ordering relationship to
+    /// establish with any other data, and the reader is a debugger that has
+    /// already halted the core.
+    #[repr(C)]
+    pub struct BootReport {
+        magic: AtomicU32,
+        version: AtomicU32,
+        struct_size: AtomicU32,
+        stage: AtomicU32,
+
+        // Compile-time, so that comparing these against what the build system
+        // BELIEVES it delivered turns a "derived value did not arrive" defect
+        // into a measurement. `scripts/check-knob-delivery.py` asserts the same
+        // identity one step earlier, at `build.ninja`; this is the same
+        // assertion made by the silicon.
+        arena_size: AtomicU32,
+        max_cbs: AtomicU32,
+        max_sc: AtomicU32,
+        max_nodes: AtomicU32,
+        default_rx_buf_size: AtomicU32,
+
+        // Runtime.
+        arena_capacity: AtomicU32,
+        arena_used: AtomicU32,
+        alloc_count: AtomicU32,
+        last_alloc_size: AtomicU32,
+        /// Bytes the allocation that FAILED asked for, or 0 if none has.
+        failed_alloc_size: AtomicU32,
+        /// Bytes by which that allocation overran the arena. This is the
+        /// number to add to `NROS_EXECUTOR_ARENA_SIZE`, which is why it is
+        /// stored rather than left to be recomputed from the two above.
+        failed_alloc_shortfall: AtomicU32,
+    }
+
+    impl BootReport {
+        const fn new() -> Self {
+            Self {
+                magic: AtomicU32::new(0),
+                version: AtomicU32::new(0),
+                struct_size: AtomicU32::new(0),
+                stage: AtomicU32::new(0),
+                arena_size: AtomicU32::new(0),
+                max_cbs: AtomicU32::new(0),
+                max_sc: AtomicU32::new(0),
+                max_nodes: AtomicU32::new(0),
+                default_rx_buf_size: AtomicU32::new(0),
+                arena_capacity: AtomicU32::new(0),
+                arena_used: AtomicU32::new(0),
+                alloc_count: AtomicU32::new(0),
+                last_alloc_size: AtomicU32::new(0),
+                failed_alloc_size: AtomicU32::new(0),
+                failed_alloc_shortfall: AtomicU32::new(0),
+            }
+        }
+
+        /// Size of the record in bytes, as the reader must expect it.
+        ///
+        /// ASKED OF THE COMPILER, not counted by hand. A hand-written word
+        /// count is a second statement of the field list that drifts the first
+        /// time a field is added, and it would drift SILENTLY -- the reader
+        /// would accept the record and decode one field short. This whole
+        /// campaign is about not hand-picking numbers the build already knows.
+        #[must_use]
+        pub const fn struct_size() -> u32 {
+            // The record is all `AtomicU32`, so this is exact on every target
+            // and there is no padding for the cast to lose.
+            core::mem::size_of::<Self>() as u32
+        }
+    }
+
+    /// A plain-value copy of the record.
+    ///
+    /// Field-for-field with [`BootReport`] and in the SAME ORDER, because
+    /// `scripts/read-boot-report.py` decodes that order out of a memory dump.
+    /// A test that reads through this therefore exercises the same layout the
+    /// script assumes, which is the only thing keeping the two in step.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub struct Snapshot {
+        pub magic: u32,
+        pub version: u32,
+        pub struct_size: u32,
+        pub stage: u32,
+        pub arena_size: u32,
+        pub max_cbs: u32,
+        pub max_sc: u32,
+        pub max_nodes: u32,
+        pub default_rx_buf_size: u32,
+        pub arena_capacity: u32,
+        pub arena_used: u32,
+        pub alloc_count: u32,
+        pub last_alloc_size: u32,
+        pub failed_alloc_size: u32,
+        pub failed_alloc_shortfall: u32,
+    }
+
+    /// Read the record.
+    #[must_use]
+    pub fn snapshot() -> Snapshot {
+        let r = &NROS_BOOT_REPORT;
+        let g = |f: &AtomicU32| f.load(Ordering::Relaxed);
+        Snapshot {
+            magic: g(&r.magic),
+            version: g(&r.version),
+            struct_size: g(&r.struct_size),
+            stage: g(&r.stage),
+            arena_size: g(&r.arena_size),
+            max_cbs: g(&r.max_cbs),
+            max_sc: g(&r.max_sc),
+            max_nodes: g(&r.max_nodes),
+            default_rx_buf_size: g(&r.default_rx_buf_size),
+            arena_capacity: g(&r.arena_capacity),
+            arena_used: g(&r.arena_used),
+            alloc_count: g(&r.alloc_count),
+            last_alloc_size: g(&r.last_alloc_size),
+            failed_alloc_size: g(&r.failed_alloc_size),
+            failed_alloc_shortfall: g(&r.failed_alloc_shortfall),
+        }
+    }
+
+    /// The record, findable by symbol name from a debugger.
+    ///
+    /// `#[used]` because nothing in a minimal image necessarily reads it, and a
+    /// static whose only writes are through this module's functions is exactly
+    /// what a linker is entitled to discard.
+    #[unsafe(no_mangle)]
+    #[used]
+    pub static NROS_BOOT_REPORT: BootReport = BootReport::new();
+
+    /// Stamp the header and the compile-time knobs.
+    ///
+    /// Idempotent, and safe to call from more than one place -- an image with
+    /// two executors should not have to decide which one owns the record.
+    /// MAGIC is stored LAST so a reader that finds it knows the rest is there.
+    pub fn init() {
+        let r = &NROS_BOOT_REPORT;
+        r.version.store(VERSION, Ordering::Relaxed);
+        r.struct_size
+            .store(BootReport::struct_size(), Ordering::Relaxed);
+        r.arena_size
+            .store(saturate(crate::config::ARENA_SIZE), Ordering::Relaxed);
+        r.max_cbs
+            .store(saturate(crate::config::MAX_CBS), Ordering::Relaxed);
+        r.max_sc
+            .store(saturate(crate::config::MAX_SC), Ordering::Relaxed);
+        r.max_nodes
+            .store(saturate(crate::config::MAX_NODES), Ordering::Relaxed);
+        r.default_rx_buf_size.store(
+            saturate(crate::config::DEFAULT_RX_BUF_SIZE),
+            Ordering::Relaxed,
+        );
+        r.magic.store(MAGIC, Ordering::Relaxed);
+        checkpoint(Stage::ReportReady);
+    }
+
+    /// Record that boot reached `stage`.
+    ///
+    /// MONOTONIC: a lower stage never overwrites a higher one, so a late call
+    /// on a re-entered path cannot make the record claim less progress than was
+    /// actually made. That matters because the field's whole purpose is to be
+    /// believed about a boot that did not finish.
+    pub fn checkpoint(stage: Stage) {
+        let want = stage as u32;
+        let r = &NROS_BOOT_REPORT;
+        let mut cur = r.stage.load(Ordering::Relaxed);
+        while want > cur {
+            match r
+                .stage
+                .compare_exchange_weak(cur, want, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    /// Record the arena slice an `Executor` actually bound.
+    ///
+    /// Not the same number as `ARENA_SIZE`, and the difference is a finding
+    /// rather than noise: the arena's placement is the caller's choice
+    /// (issue 0900), so an image can compile one size and hand the executor
+    /// another. Both are in the record so a dump can say which happened.
+    pub fn note_arena_capacity(capacity: usize) {
+        NROS_BOOT_REPORT
+            .arena_capacity
+            .store(saturate(capacity), Ordering::Relaxed);
+    }
+
+    /// Record a successful arena allocation.
+    pub fn note_alloc(size: usize, used_after: usize) {
+        let r = &NROS_BOOT_REPORT;
+        r.alloc_count.fetch_add(1, Ordering::Relaxed);
+        r.last_alloc_size.store(saturate(size), Ordering::Relaxed);
+        r.arena_used.store(saturate(used_after), Ordering::Relaxed);
+    }
+
+    /// Record the arena allocation that did not fit.
+    ///
+    /// FIRST writer wins, on the same reasoning as [`checkpoint`]: the first
+    /// failure is the one that explains the boot, and any later one is a
+    /// consequence of it.
+    pub fn note_alloc_failed(size: usize, shortfall: usize) {
+        let r = &NROS_BOOT_REPORT;
+        if r.failed_alloc_size
+            .compare_exchange(0, saturate(size), Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            r.failed_alloc_shortfall
+                .store(saturate(shortfall), Ordering::Relaxed);
+        }
+    }
+
+    /// `usize` -> `u32`, saturating.
+    ///
+    /// Every field is a `u32` so the record's layout does not change between a
+    /// 32-bit board and a 64-bit host running the same tests. Saturating rather
+    /// than truncating because a value too large to represent should read as
+    /// "enormous", not as its low half -- a truncated 4 GiB reads as 0, which
+    /// is the one wrong answer that looks like a normal one.
+    fn saturate(v: usize) -> u32 {
+        u32::try_from(v).unwrap_or(u32::MAX)
+    }
+}
+
+#[cfg(not(nros_boot_report))]
+pub use disabled::*;
+
+/// No-op stubs, so call sites need no `cfg` of their own and an image that does
+/// not opt in is byte-identical.
+#[cfg(not(nros_boot_report))]
+mod disabled {
+    use super::Stage;
+
+    #[inline(always)]
+    pub fn init() {}
+
+    #[inline(always)]
+    pub fn checkpoint(_stage: Stage) {}
+
+    #[inline(always)]
+    pub fn note_arena_capacity(_capacity: usize) {}
+
+    #[inline(always)]
+    pub fn note_alloc(_size: usize, _used_after: usize) {}
+
+    #[inline(always)]
+    pub fn note_alloc_failed(_size: usize, _shortfall: usize) {}
+}
+
+#[cfg(all(test, nros_boot_report))]
+mod tests {
+    use super::*;
+
+    /// The reader decodes fifteen u32s positionally, so the record must be
+    /// exactly that and nothing else -- no padding, no reordering.
+    ///
+    /// `size_of` on the TARGET, which is the half `check-boot-report-layout.py`
+    /// cannot see: that gate compares two source files, and this compares the
+    /// source against what the compiler actually laid out.
+    #[test]
+    fn the_record_is_fifteen_packed_u32s() {
+        assert_eq!(BootReport::struct_size(), 15 * 4);
+        assert_eq!(
+            core::mem::size_of::<BootReport>(),
+            15 * core::mem::size_of::<u32>(),
+            "the record grew padding; the reader decodes positionally"
+        );
+        assert_eq!(core::mem::align_of::<BootReport>(), 4);
+    }
+
+    /// The magic is written LAST, so finding it means the rest is valid.
+    ///
+    /// The reader leans on this to tell "the image died before it had an
+    /// executor" apart from "the dump is at the wrong address", and it can
+    /// only do so if the ordering actually holds.
+    #[test]
+    fn init_stamps_the_header_and_the_compiled_knobs() {
+        init();
+        let s = snapshot();
+        assert_eq!(s.magic, MAGIC);
+        assert_eq!(s.version, VERSION);
+        assert_eq!(s.struct_size, BootReport::struct_size());
+        assert_eq!(s.arena_size, crate::config::ARENA_SIZE as u32);
+        assert_eq!(s.max_cbs, crate::config::MAX_CBS as u32);
+        assert_eq!(s.max_nodes, crate::config::MAX_NODES as u32);
+        assert!(s.stage >= Stage::ReportReady as u32);
+    }
+
+    /// A late call on a re-entered path must not make the record claim LESS
+    /// progress than was actually made. The field's whole purpose is to be
+    /// believed about a boot that did not finish.
+    #[test]
+    fn a_checkpoint_never_goes_backwards() {
+        init();
+        checkpoint(Stage::FirstSpin);
+        assert_eq!(snapshot().stage, Stage::FirstSpin as u32);
+        checkpoint(Stage::ExecutorReady);
+        assert_eq!(
+            snapshot().stage,
+            Stage::FirstSpin as u32,
+            "an earlier stage overwrote a later one"
+        );
+    }
+
+    /// The FIRST failure is the one that explains the boot; a later one is a
+    /// consequence of it and must not overwrite the cause.
+    #[test]
+    fn the_first_alloc_failure_wins() {
+        init();
+        note_alloc_failed(100, 8);
+        note_alloc_failed(999, 512);
+        let s = snapshot();
+        assert_eq!(s.failed_alloc_size, 100);
+        assert_eq!(s.failed_alloc_shortfall, 8);
+    }
+
+    /// A value too large for the field must read as enormous, not as its low
+    /// half. A truncated 4 GiB reads as 0, which is the one wrong answer that
+    /// looks like a normal one.
+    #[test]
+    fn an_unrepresentable_size_saturates_rather_than_truncating() {
+        init();
+        note_arena_capacity(usize::MAX);
+        assert_eq!(snapshot().arena_capacity, u32::MAX);
+    }
+}

--- a/packages/core/nros-node/src/boot_report.rs
+++ b/packages/core/nros-node/src/boot_report.rs
@@ -70,14 +70,17 @@ pub const MAGIC: u32 = 0x4e52_5352;
 
 /// Layout version. Bump on any field change; a reader refuses what it does not
 /// know rather than decoding a record it would misread.
-pub const VERSION: u32 = 1;
+pub const VERSION: u32 = 2;
 
 /// How far boot got. Monotonic, and the single most useful field: an arena
 /// failure halts during entity creation, so the stage that was NOT reached
 /// names the phase to look at.
 ///
-/// Values are stable across versions -- a new stage is appended, never
-/// inserted, so a stage number in an old dump keeps its meaning.
+/// Numbers follow EXECUTION ORDER, because `checkpoint` keeps the maximum
+/// and a stage that runs earlier but numbers higher would make the record
+/// claim less progress than was made. Inserting one therefore renumbers the
+/// rest and bumps [`VERSION`]; the decoder refuses a version it does not
+/// know rather than misreading it, which is what makes that safe.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u32)]
 pub enum Stage {
@@ -85,19 +88,30 @@ pub enum Stage {
     /// valid magic has found a record that was reset but not re-entered.
     Untouched = 0,
     /// The record itself is initialised and the compile-time knobs are in it.
-    /// Reaching only here means the image died before the executor existed.
+    ///
+    /// Stamped at the TOP of the C++ entry point, before any argument is
+    /// validated, so "the image never entered nano-ros" is distinguishable
+    /// from "it entered and died before the executor". Version 1 stamped this
+    /// inside the executor constructor instead, which made those two cases
+    /// identical -- both read magic 0 -- and cost a disassembly walk to tell
+    /// apart on the first board run.
     ReportReady = 1,
+    /// The boot config resolved: node name, namespace, locator and domain id
+    /// all parsed. Everything between here and [`Stage::ReportReady`] is
+    /// argument validation, and [`BootReport::cpp_init_ret`] says which check
+    /// rejected it.
+    BootConfigResolved = 2,
     /// An `Executor` has bound its arena, so [`BootReport::arena_capacity`]
     /// is the real slice length rather than the compiled constant.
-    ExecutorReady = 2,
+    ExecutorReady = 3,
     /// Entity registration has begun. The interval between this and
     /// [`Stage::EntitiesReady`] is where an under-sized arena halts.
-    RegisteringEntities = 3,
+    RegisteringEntities = 4,
     /// Every entity the image declares was registered successfully.
-    EntitiesReady = 4,
+    EntitiesReady = 5,
     /// The first `spin_once` was entered, which is where issue 0900's
     /// headroom advisory would have printed had a sink existed.
-    FirstSpin = 5,
+    FirstSpin = 6,
 }
 
 #[cfg(nros_boot_report)]
@@ -149,6 +163,14 @@ mod enabled {
         /// number to add to `NROS_EXECUTOR_ARENA_SIZE`, which is why it is
         /// stored rather than left to be recomputed from the two above.
         failed_alloc_shortfall: AtomicU32,
+        /// `nros_cpp_init`'s return code, as the two's-complement bits of an
+        /// `i32`, or 0 (`NROS_CPP_RET_OK`) if it has not returned yet.
+        ///
+        /// The stage says HOW FAR init got; this says why it stopped. Without
+        /// it, every early return in that function -- a null argument, a
+        /// non-UTF-8 name, a bad domain id, a backend that refused to open --
+        /// is one indistinguishable "did not reach the executor".
+        cpp_init_ret: AtomicU32,
     }
 
     impl BootReport {
@@ -169,6 +191,7 @@ mod enabled {
                 last_alloc_size: AtomicU32::new(0),
                 failed_alloc_size: AtomicU32::new(0),
                 failed_alloc_shortfall: AtomicU32::new(0),
+                cpp_init_ret: AtomicU32::new(0),
             }
         }
 
@@ -210,6 +233,7 @@ mod enabled {
         pub last_alloc_size: u32,
         pub failed_alloc_size: u32,
         pub failed_alloc_shortfall: u32,
+        pub cpp_init_ret: u32,
     }
 
     /// Read the record.
@@ -233,6 +257,7 @@ mod enabled {
             last_alloc_size: g(&r.last_alloc_size),
             failed_alloc_size: g(&r.failed_alloc_size),
             failed_alloc_shortfall: g(&r.failed_alloc_shortfall),
+            cpp_init_ret: g(&r.cpp_init_ret),
         }
     }
 
@@ -328,6 +353,18 @@ mod enabled {
         }
     }
 
+    /// Record `nros_cpp_init`'s return code.
+    ///
+    /// LAST writer wins, unlike [`note_alloc_failed`]: an image may call
+    /// `nros_cpp_init` more than once (per component, per tier), and the
+    /// interesting one is the call that did not get through, which is the one
+    /// that leaves the stage where it stopped.
+    pub fn note_cpp_init_ret(ret: i32) {
+        NROS_BOOT_REPORT
+            .cpp_init_ret
+            .store(ret as u32, Ordering::Relaxed);
+    }
+
     /// `usize` -> `u32`, saturating.
     ///
     /// Every field is a `u32` so the record's layout does not change between a
@@ -363,24 +400,27 @@ mod disabled {
 
     #[inline(always)]
     pub fn note_alloc_failed(_size: usize, _shortfall: usize) {}
+
+    #[inline(always)]
+    pub fn note_cpp_init_ret(_ret: i32) {}
 }
 
 #[cfg(all(test, nros_boot_report))]
 mod tests {
     use super::*;
 
-    /// The reader decodes fifteen u32s positionally, so the record must be
+    /// The reader decodes sixteen u32s positionally, so the record must be
     /// exactly that and nothing else -- no padding, no reordering.
     ///
     /// `size_of` on the TARGET, which is the half `check-boot-report-layout.py`
     /// cannot see: that gate compares two source files, and this compares the
     /// source against what the compiler actually laid out.
     #[test]
-    fn the_record_is_fifteen_packed_u32s() {
-        assert_eq!(BootReport::struct_size(), 15 * 4);
+    fn the_record_is_sixteen_packed_u32s() {
+        assert_eq!(BootReport::struct_size(), 16 * 4);
         assert_eq!(
             core::mem::size_of::<BootReport>(),
-            15 * core::mem::size_of::<u32>(),
+            16 * core::mem::size_of::<u32>(),
             "the record grew padding; the reader decodes positionally"
         );
         assert_eq!(core::mem::align_of::<BootReport>(), 4);

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1503,6 +1503,15 @@ impl<'s> Executor<'s> {
         if let Some(slot0) = sched_contexts.first_mut() {
             *slot0 = Some(super::sched_context::SchedContext::default());
         }
+        // phase-412 -- stamp the self-report before anything can fail. `init`
+        // is idempotent, so an image with two executors need not decide which
+        // one owns the record, and `note_arena_capacity` records the slice this
+        // executor was actually handed rather than the compiled constant: the
+        // arena's placement is the caller's choice (issue 0900), so the two can
+        // legitimately differ and the difference is worth seeing.
+        crate::boot_report::init();
+        crate::boot_report::note_arena_capacity(arena.len());
+        crate::boot_report::checkpoint(crate::boot_report::Stage::ExecutorReady);
         Self {
             // `assemble` is reached from session-only entry points that have no
             // config, so 0 is the floor rather than a choice; `open_in` and any
@@ -3953,9 +3962,11 @@ impl<'s> Executor<'s> {
                 self.arena_used,
                 self.arena.len(),
             );
+            crate::boot_report::note_alloc_failed(size, new_used - self.arena.len());
             return Err(NodeError::BufferTooSmall);
         }
         self.arena_used = new_used;
+        crate::boot_report::note_alloc(size, new_used);
         Ok(aligned_offset)
     }
 
@@ -3975,9 +3986,24 @@ impl<'s> Executor<'s> {
             (entry_offset + entry_size).next_multiple_of(core::mem::align_of::<u64>());
         let new_used = trailing_offset + trailing_bytes;
         if new_used > self.arena.len() {
+            // This path reported NOTHING until phase-412's self-report went in,
+            // while its sibling `arena_alloc` has named the knob since issue
+            // 0900. Half of arena exhaustion was therefore silent -- and it is
+            // the half carrying buffered subscriptions and action entries,
+            // which is what an island image actually allocates.
+            super::arena::report_arena_exhausted(
+                new_used - self.arena.len(),
+                self.arena_used,
+                self.arena.len(),
+            );
+            crate::boot_report::note_alloc_failed(
+                new_used - entry_offset,
+                new_used - self.arena.len(),
+            );
             return Err(NodeError::BufferTooSmall);
         }
         self.arena_used = new_used;
+        crate::boot_report::note_alloc(new_used - entry_offset, new_used);
         Ok((entry_offset, trailing_offset))
     }
 
@@ -6024,6 +6050,11 @@ impl<'s> Executor<'s> {
         // registered. First spin rather than "end of registration", because
         // there is no such point: an app may register lazily.
         super::arena::maybe_report_arena_headroom(self.arena_used, self.arena.len());
+
+        // phase-412 -- the same moment, recorded where a board with no log sink
+        // can still be asked. Reaching this stage is the positive result the
+        // advisory above cannot deliver on the island: registration completed.
+        crate::boot_report::checkpoint(crate::boot_report::Stage::FirstSpin);
 
         // Phase 110.0 — cap against the backend's next internal-event
         // deadline (lease keepalive, heartbeat, ACK-NACK timeout, ...).

--- a/packages/core/nros-node/src/lib.rs
+++ b/packages/core/nros-node/src/lib.rs
@@ -84,6 +84,8 @@ extern crate std;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+/// phase-412 -- the boot self-report, for boards with no reachable log sink.
+pub mod boot_report;
 pub mod c_waker;
 pub mod config;
 /// RFC-0088 / phase-421 W1 — the compile-time message-format check.

--- a/packages/platform/nros-platform-api/src/lib.rs
+++ b/packages/platform/nros-platform-api/src/lib.rs
@@ -61,7 +61,11 @@
 // an ABI belongs with the ABI.
 #[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "alloc")]
+// The MODULE is not alloc-gated, only the spawning half of it. `task` also
+// carries `stack_unused_bytes`, a plain FFI query with no allocation, and the
+// executor's stack-headroom rule calls it from `nros-node` on every feature
+// set -- including `nros --no-default-features --features rmw-cffi`, which
+// has no `alloc` and could not name the module at all.
 pub mod task;
 
 use core::ffi::{c_int, c_void};

--- a/packages/platform/nros-platform-api/src/task.rs
+++ b/packages/platform/nros-platform-api/src/task.rs
@@ -65,11 +65,13 @@ unsafe extern "C" {
 /// have to signal their worker to stop BEFORE waiting for it — a `Drop` that
 /// joined implicitly would deadlock against a worker still blocked on its own
 /// wait.
+#[cfg(feature = "alloc")]
 pub struct PlatformTask {
     ptr: *mut u8,
     layout: core::alloc::Layout,
 }
 
+#[cfg(feature = "alloc")]
 impl PlatformTask {
     /// Spawn `entry(arg)`, or `None` when this platform cannot host a task
     /// (no storage sizing, allocation failure, or a refused spawn).
@@ -178,6 +180,7 @@ impl PlatformTask {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Drop for PlatformTask {
     fn drop(&mut self) {
         // Reached only if a caller dropped the handle without joining, which

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -233,33 +233,44 @@ void nros_platform_dealloc(void *ptr) {
     k_spin_unlock(&nros_heap_lock, key);
 }
 
-/* ---- Heap stats (phase-230 Z5 / RFC-0034 D7) ----
+/* ---- Heap stats (phase-230 Z5 / RFC-0034 D7, corrected phase-412) ----
  *
- * The true unified heap total on Zephyr: `k_malloc` (and thus
- * `nros_platform_alloc`, which backs zenoh-pico's `z_malloc`) AND
- * zephyr-lang-rust's `#[global_allocator]` (`malloc`) both draw from the
- * kernel system heap `_system_heap`. Querying its runtime stats gives the
- * exact C+Rust figure without owning the Rust allocator (D7 Mode B).
- * Requires CONFIG_SYS_HEAP_RUNTIME_STATS + a non-zero CONFIG_HEAP_MEM_POOL_SIZE
- * (which is what defines `_system_heap`); returns 0 ("unknown") otherwise. */
-#if defined(CONFIG_SYS_HEAP_RUNTIME_STATS) && (CONFIG_HEAP_MEM_POOL_SIZE > 0)
-extern struct k_heap _system_heap;
+ * These report the arena the application ACTUALLY allocates from: the rlsf
+ * heap in nros-platform's `zephyr_heap`, which `nros_platform_alloc` above
+ * calls into and which therefore backs both zenoh-pico's `z_malloc` and
+ * `__rust_alloc`. Its size is CONFIG_NROS_ZEPHYR_HEAP_SIZE.
+ *
+ * They used to answer from Zephyr's kernel heap `_system_heap`, sized by
+ * CONFIG_HEAP_MEM_POOL_SIZE. That was right when phase-230 wrote it and wrong
+ * from phase-391 W3 onward, which moved the funnel off the kernel heap --
+ * `zephyr/Kconfig` says so under NROS_ZEPHYR_HEAP_SIZE ("CONFIG_HEAP_MEM_POOL_SIZE
+ * does NOT govern application allocation any more; this does"), while this file
+ * kept measuring the heap that no longer governs anything.
+ *
+ * The cost of that was not a wrong number, it was NO number: the one figure
+ * that could size NROS_ZEPHYR_HEAP_SIZE reported a different arena, so the knob
+ * could only ever be guessed. The island carries 94,208 bytes chosen that way.
+ *
+ * `peak`, not `used`, is what the knob wants -- `used` sampled at an arbitrary
+ * instant reports whatever happened to be live at the moment of the read.
+ * Requires nros-platform's `heap-stats` feature; returns 0 ("unknown")
+ * otherwise, which is the convention this file already used. */
+extern size_t nros_zephyr_heap_capacity(void);
+extern size_t nros_zephyr_heap_used(void);
+extern size_t nros_zephyr_heap_peak(void);
 
-size_t nros_platform_heap_used_bytes(void) {
-    struct sys_memory_stats st;
-    if (sys_heap_runtime_stats_get(&_system_heap.heap, &st) != 0) return 0u;
-    return (size_t) st.allocated_bytes;
-}
+size_t nros_platform_heap_used_bytes(void) { return nros_zephyr_heap_used(); }
 
-size_t nros_platform_heap_total_bytes(void) {
-    struct sys_memory_stats st;
-    if (sys_heap_runtime_stats_get(&_system_heap.heap, &st) != 0) return 0u;
-    return (size_t) (st.allocated_bytes + st.free_bytes);
-}
-#else
-size_t nros_platform_heap_used_bytes(void) { return 0u; }
-size_t nros_platform_heap_total_bytes(void) { return 0u; }
-#endif
+size_t nros_platform_heap_total_bytes(void) { return nros_zephyr_heap_capacity(); }
+
+/* High-water mark, for sizing CONFIG_NROS_ZEPHYR_HEAP_SIZE from a measurement
+ * rather than from a round number.
+ *
+ * NOT added to `nros/platform.h`: that header is the cross-port ABI, and every
+ * other port would need a stub plus a regenerated cffi binding to carry a
+ * figure only this port can produce. `nros_zephyr_heap_peak()` is reachable
+ * directly by anything Zephyr-side that wants it. */
+size_t nros_zephyr_platform_heap_peak_bytes(void) { return nros_zephyr_heap_peak(); }
 
 /* ---- Sleep ---- */
 

--- a/packages/platform/nros-platform/Cargo.toml
+++ b/packages/platform/nros-platform/Cargo.toml
@@ -99,7 +99,18 @@ platform-esp32-qemu = [
 platform-nuttx = ["dep:nros-platform-cffi"]
 platform-freertos = ["dep:nros-platform-cffi"]
 platform-threadx = ["dep:nros-platform-cffi"]
-platform-zephyr = ["dep:nros-platform-cffi", "dep:zpico-alloc"]
+# phase-412 -- `zpico-alloc/stats` is NOT optional here. It is what makes
+# `nros_platform_heap_used_bytes()`/`_peak` able to answer about the arena
+# this port actually allocates from, and NROS_ZEPHYR_HEAP_SIZE cannot be set
+# from a measurement without it -- the island's 94,208 was guessed for
+# exactly that reason.
+#
+# Not a separate feature: threading one through nros-rmw-zenoh-staticlib,
+# nros-rmw-zenoh and a second cmake feature-set site delivered it to 1 of 3
+# cargo invocations, and the one that links the arena was not among them.
+# That is the delivery-failure class this phase exists to remove, so the
+# counters are simply always on for this port. Two atomics per alloc.
+platform-zephyr = ["dep:nros-platform-cffi", "dep:zpico-alloc", "zpico-alloc/stats"]
 # phase-337 W7.b — `platform-orin-spe` (a back-compat alias for
 # `platform-freertos` since 121.10) and `platform-esp32s3` are gone with their
 # boards. A Cortex-R5F FreeRTOS-FSP consumer selects `platform-freertos`
@@ -144,16 +155,6 @@ global-allocator = []
 alloc = ["nros-platform-api/alloc"]
 alloc-stats = []
 
-# phase-412 -- opt-in stats for the ZEPHYR ARENA (`zephyr_heap`), which is what
-# `z_malloc` and `__rust_alloc` actually draw from since phase-391 W3 moved the
-# funnel off Zephyr's kernel heap. Distinct from `alloc-stats` above, which
-# counts only what the Rust `#[global_allocator]` sees.
-#
-# Needed because `nros_platform_heap_used_bytes()` -- documented as the unified
-# C+Rust figure -- answered from `_system_heap`, the heap the application
-# stopped using. Without this the only number that could size
-# NROS_ZEPHYR_HEAP_SIZE measured a different arena.
-heap-stats = ["zpico-alloc/stats"]
 
 # Phase 97.1.cs — opt-in `critical_section::Impl` registered against
 # the active platform's interrupt-disable primitive. DDS's

--- a/packages/platform/nros-platform/Cargo.toml
+++ b/packages/platform/nros-platform/Cargo.toml
@@ -144,6 +144,17 @@ global-allocator = []
 alloc = ["nros-platform-api/alloc"]
 alloc-stats = []
 
+# phase-412 -- opt-in stats for the ZEPHYR ARENA (`zephyr_heap`), which is what
+# `z_malloc` and `__rust_alloc` actually draw from since phase-391 W3 moved the
+# funnel off Zephyr's kernel heap. Distinct from `alloc-stats` above, which
+# counts only what the Rust `#[global_allocator]` sees.
+#
+# Needed because `nros_platform_heap_used_bytes()` -- documented as the unified
+# C+Rust figure -- answered from `_system_heap`, the heap the application
+# stopped using. Without this the only number that could size
+# NROS_ZEPHYR_HEAP_SIZE measured a different arena.
+heap-stats = ["zpico-alloc/stats"]
+
 # Phase 97.1.cs — opt-in `critical_section::Impl` registered against
 # the active platform's interrupt-disable primitive. DDS's
 # oneshot channels reference `_critical_section_1_0_acquire` /

--- a/packages/platform/nros-platform/src/zephyr_heap.rs
+++ b/packages/platform/nros-platform/src/zephyr_heap.rs
@@ -81,3 +81,42 @@ pub extern "C" fn nros_zephyr_heap_free(ptr: *mut core::ffi::c_void) {
 pub extern "C" fn nros_zephyr_heap_capacity() -> usize {
     HEAP.capacity()
 }
+
+/// phase-412 -- bytes this arena currently has handed out.
+///
+/// `FreeListHeap` has tracked this all along; nothing exported it, so the
+/// platform's `nros_platform_heap_used_bytes()` answered from Zephyr's
+/// `_system_heap` instead -- the heap the application STOPPED allocating from
+/// when the funnel moved here (phase-391 W3). The figure that would size
+/// `NROS_ZEPHYR_HEAP_SIZE` was measuring a different arena.
+#[cfg(feature = "heap-stats")]
+#[unsafe(no_mangle)]
+pub extern "C" fn nros_zephyr_heap_used() -> usize {
+    HEAP.used()
+}
+
+/// 0 = "unknown", the convention `nros_platform_heap_used_bytes` already uses
+/// when its stats are not compiled in.
+#[cfg(not(feature = "heap-stats"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn nros_zephyr_heap_used() -> usize {
+    0
+}
+
+/// The most this arena has ever had handed out at once.
+///
+/// This is the number `NROS_ZEPHYR_HEAP_SIZE` should be set from, plus
+/// headroom. `used` sampled at an arbitrary instant reports whatever happened
+/// to be live at the moment of the read, which is not what the knob bounds.
+#[cfg(feature = "heap-stats")]
+#[unsafe(no_mangle)]
+pub extern "C" fn nros_zephyr_heap_peak() -> usize {
+    HEAP.peak()
+}
+
+/// See [`nros_zephyr_heap_used`] for the 0 convention.
+#[cfg(not(feature = "heap-stats"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn nros_zephyr_heap_peak() -> usize {
+    0
+}

--- a/packages/platform/nros-platform/src/zephyr_heap.rs
+++ b/packages/platform/nros-platform/src/zephyr_heap.rs
@@ -89,18 +89,9 @@ pub extern "C" fn nros_zephyr_heap_capacity() -> usize {
 /// `_system_heap` instead -- the heap the application STOPPED allocating from
 /// when the funnel moved here (phase-391 W3). The figure that would size
 /// `NROS_ZEPHYR_HEAP_SIZE` was measuring a different arena.
-#[cfg(feature = "heap-stats")]
 #[unsafe(no_mangle)]
 pub extern "C" fn nros_zephyr_heap_used() -> usize {
     HEAP.used()
-}
-
-/// 0 = "unknown", the convention `nros_platform_heap_used_bytes` already uses
-/// when its stats are not compiled in.
-#[cfg(not(feature = "heap-stats"))]
-#[unsafe(no_mangle)]
-pub extern "C" fn nros_zephyr_heap_used() -> usize {
-    0
 }
 
 /// The most this arena has ever had handed out at once.
@@ -108,15 +99,7 @@ pub extern "C" fn nros_zephyr_heap_used() -> usize {
 /// This is the number `NROS_ZEPHYR_HEAP_SIZE` should be set from, plus
 /// headroom. `used` sampled at an arbitrary instant reports whatever happened
 /// to be live at the moment of the read, which is not what the knob bounds.
-#[cfg(feature = "heap-stats")]
 #[unsafe(no_mangle)]
 pub extern "C" fn nros_zephyr_heap_peak() -> usize {
     HEAP.peak()
-}
-
-/// See [`nros_zephyr_heap_used`] for the 0 convention.
-#[cfg(not(feature = "heap-stats"))]
-#[unsafe(no_mangle)]
-pub extern "C" fn nros_zephyr_heap_peak() -> usize {
-    0
 }

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -332,12 +332,41 @@ pub struct SubscriberAllocReport {
     /// the application is taking blocks.
     small_taken: AtomicU32,
     large_taken: AtomicU32,
+    /// Bytes in the data keyexpr of the last subscription attempted.
+    ///
+    /// `to_key_wildcard` builds it into a `heapless::String<KEYEXPR_STRING_SIZE>`
+    /// and the writer DISCARDS the overflow, so a keyexpr too long for the buffer
+    /// is silently TRUNCATED rather than refused. A length exactly equal to
+    /// [`Self::keyexpr_cap`] is that truncation; the explicit
+    /// `bytes.len() >= keyexpr_buf.len()` guard below cannot see it, because a
+    /// truncated string is by construction short enough to pass.
+    keyexpr_len: AtomicU32,
+    /// `KEYEXPR_STRING_SIZE`, so a reader can spot the equality above without
+    /// knowing how the image was configured.
+    keyexpr_cap: AtomicU32,
+    /// Which `ZpicoError` the declare returned, or 0 if it succeeded.
+    ///
+    /// The variant, not the mapped error: crossing the C ABI turns
+    /// `Generic` and `Session` BOTH into `ConnectionFailed` (issue 0870) and
+    /// then into an indistinguishable `Backend("rmw_ret error")` on the way
+    /// back. Issue 0465 records what that collapse cost the last time -- an
+    /// exhausted pool "spent two months looking like a router problem". This
+    /// keeps the identity on the near side of the ABI.
+    zpico_err: AtomicU32,
+    /// How many METADATA slots have been handed out (`NEXT_BUFFER_INDEX`).
+    ///
+    /// A THIRD counter, and the one that guards first: its bound check runs
+    /// BEFORE `alloc_payload_block`, so an image that exhausts it never reaches
+    /// the payload classes and the refusal field stays 0. That is exactly how
+    /// this record read on the island before the counter was added -- ten
+    /// blocks taken, no refusal, and an error anyway.
+    buffer_taken: AtomicU32,
 }
 
 /// `"SUBA"` -- subscriber alloc. Written LAST by [`record_alloc_ceilings`].
 pub const SUBSCRIBER_ALLOC_MAGIC: u32 = 0x53554241;
 /// Layout version for [`SubscriberAllocReport`].
-pub const SUBSCRIBER_ALLOC_VERSION: u32 = 1;
+pub const SUBSCRIBER_ALLOC_VERSION: u32 = 3;
 
 /// The record, findable by symbol from a debugger.
 #[unsafe(no_mangle)]
@@ -355,7 +384,63 @@ pub static NROS_SUBSCRIBER_ALLOC_REPORT: SubscriberAllocReport = SubscriberAlloc
     subscriber_buffer_size: AtomicU32::new(0),
     small_taken: AtomicU32::new(0),
     large_taken: AtomicU32::new(0),
+    keyexpr_len: AtomicU32::new(0),
+    keyexpr_cap: AtomicU32::new(0),
+    zpico_err: AtomicU32::new(0),
+    buffer_taken: AtomicU32::new(0),
 };
+
+/// Record the metadata-slot index that was refused.
+///
+/// The INDEX, not the counter: the refusing path rolls the counter back, so
+/// reading it afterwards reports the pool as it looks once everyone has
+/// retreated rather than at the moment of refusal. `fetch_max` so a rollback
+/// can never make the record claim less than what actually refused.
+pub(super) fn record_buffer_index(idx: usize) {
+    NROS_SUBSCRIBER_ALLOC_REPORT
+        .buffer_taken
+        .fetch_max(u32::try_from(idx).unwrap_or(u32::MAX), Ordering::Relaxed);
+}
+
+/// Record the keyexpr the declare is about to use.
+///
+/// Separate from [`record_alloc`] because it is known LATER: the payload block
+/// is reserved before the key is built.
+pub(super) fn record_keyexpr(len: usize, cap: usize) {
+    let r = &NROS_SUBSCRIBER_ALLOC_REPORT;
+    let sat = |v: usize| u32::try_from(v).unwrap_or(u32::MAX);
+    r.keyexpr_len.store(sat(len), Ordering::Relaxed);
+    r.keyexpr_cap.store(sat(cap), Ordering::Relaxed);
+}
+
+/// Stable code per `ZpicoError` variant, for the report.
+///
+/// EXHAUSTIVE and no wildcard arm, the rule issue 0586 states for the ret
+/// mappers: rustc must refuse a new variant until someone numbers it.
+pub(super) fn zpico_err_class(e: &crate::zpico::ZpicoError) -> u32 {
+    use crate::zpico::ZpicoError as Z;
+    match e {
+        Z::Generic => 1,
+        Z::Config => 2,
+        Z::Session => 3,
+        Z::Task => 4,
+        Z::KeyExpr => 5,
+        Z::Full => 6,
+        Z::Invalid => 7,
+        Z::Publish => 8,
+        Z::NotOpen => 9,
+        Z::Timeout => 10,
+    }
+}
+
+/// Record which `ZpicoError` the subscriber declare returned. FIRST wins.
+pub(super) fn record_zpico_err(code: u32) {
+    let r = &NROS_SUBSCRIBER_ALLOC_REPORT;
+    let _ = r
+        .zpico_err
+        .compare_exchange(0, code, Ordering::Relaxed, Ordering::Relaxed);
+    r.magic.store(SUBSCRIBER_ALLOC_MAGIC, Ordering::Relaxed);
+}
 
 /// Stamp the compile-time ceilings and the running counters.
 ///
@@ -388,6 +473,12 @@ fn record_alloc(hint: usize, refusal: u32) {
     );
     r.large_taken.store(
         sat(NEXT_LARGE_PAYLOAD.load(Ordering::SeqCst)),
+        Ordering::Relaxed,
+    );
+    r.keyexpr_cap
+        .store(sat(KEYEXPR_STRING_SIZE), Ordering::Relaxed);
+    r.buffer_taken.fetch_max(
+        sat(NEXT_BUFFER_INDEX.load(Ordering::SeqCst)),
         Ordering::Relaxed,
     );
     // FIRST refusal wins: the one that stopped the boot is the one that
@@ -794,7 +885,20 @@ impl ZenohSubscriber {
         let buffer_index = NEXT_BUFFER_INDEX.fetch_add(1, Ordering::SeqCst);
         if buffer_index >= ZPICO_MAX_SUBSCRIBERS {
             // Roll back and return error
+            // BEFORE the rollback, and the INDEX rather than the counter --
+            // the first cut read the counter afterwards and reported 0 for a
+            // pool of 10, which is the wrong-number-that-looks-like-a-number
+            // this record exists to stop producing.
+            record_buffer_index(buffer_index);
             NEXT_BUFFER_INDEX.fetch_sub(1, Ordering::SeqCst);
+            // phase-412 -- refusal 4. This guard runs BEFORE the payload classes,
+            // so without recording here the report shows every block allocated
+            // and no refusal, and the failure looks like it came from somewhere
+            // else entirely. `SubscriberCreationFailed` then crosses the C ABI
+            // through `ret_from_error`'s `_ => NROS_RMW_RET_ERROR` fallback and
+            // comes back as `Backend("rmw_ret error")`, losing the last of its
+            // identity.
+            record_alloc(topic.rx_buffer_hint, 4);
             return Err(TransportError::SubscriberCreationFailed);
         }
 
@@ -817,6 +921,7 @@ impl ZenohSubscriber {
         // Create null-terminated keyexpr
         let mut keyexpr_buf = [0u8; KEYEXPR_BUFFER_SIZE];
         let bytes = key.as_bytes();
+        record_keyexpr(bytes.len(), KEYEXPR_STRING_SIZE);
         if bytes.len() >= keyexpr_buf.len() {
             return Err(TransportError::TopicNameInvalid);
         }
@@ -848,6 +953,7 @@ impl ZenohSubscriber {
                 >(s),
                 Err(e) => {
                     NEXT_BUFFER_INDEX.fetch_sub(1, Ordering::SeqCst);
+                    record_zpico_err(zpico_err_class(&e));
                     return Err(TransportError::from(e));
                 }
             }

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -361,12 +361,19 @@ pub struct SubscriberAllocReport {
     /// this record read on the island before the counter was added -- ten
     /// blocks taken, no refusal, and an error anyway.
     buffer_taken: AtomicU32,
+    /// Which exit the C shim's declare took: 1 session-not-open, 2 bad
+    /// descriptor, 3 table full, 4 keyexpr rejected, 5 the declare itself
+    /// failed, 6 success. 0 means it stamped nothing, which contradicts the
+    /// caller having seen an error from it.
+    zpico_exit: AtomicU32,
+    /// Raw `z_declare_subscriber` return, meaningful when the exit is 5.
+    zpico_ret: AtomicU32,
 }
 
 /// `"SUBA"` -- subscriber alloc. Written LAST by [`record_alloc_ceilings`].
 pub const SUBSCRIBER_ALLOC_MAGIC: u32 = 0x53554241;
 /// Layout version for [`SubscriberAllocReport`].
-pub const SUBSCRIBER_ALLOC_VERSION: u32 = 3;
+pub const SUBSCRIBER_ALLOC_VERSION: u32 = 4;
 
 /// The record, findable by symbol from a debugger.
 #[unsafe(no_mangle)]
@@ -388,6 +395,8 @@ pub static NROS_SUBSCRIBER_ALLOC_REPORT: SubscriberAllocReport = SubscriberAlloc
     keyexpr_cap: AtomicU32::new(0),
     zpico_err: AtomicU32::new(0),
     buffer_taken: AtomicU32::new(0),
+    zpico_exit: AtomicU32::new(0),
+    zpico_ret: AtomicU32::new(0),
 };
 
 /// Record the metadata-slot index that was refused.
@@ -430,6 +439,20 @@ pub(super) fn zpico_err_class(e: &crate::zpico::ZpicoError) -> u32 {
         Z::Publish => 8,
         Z::NotOpen => 9,
         Z::Timeout => 10,
+    }
+}
+
+/// Record the C shim's exit marker and raw declare code. FIRST wins.
+pub(super) fn record_zpico_declare(exit: i32, ret: i32) {
+    let r = &NROS_SUBSCRIBER_ALLOC_REPORT;
+    // The exit marker is written on EVERY call, so it is only meaningful
+    // paired with the failure that prompted the read -- hence first-wins,
+    // matching `record_zpico_err` beside it.
+    if r.zpico_exit
+        .compare_exchange(0, exit as u32, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
+    {
+        r.zpico_ret.store(ret as u32, Ordering::Relaxed);
     }
 }
 
@@ -953,6 +976,14 @@ impl ZenohSubscriber {
                 >(s),
                 Err(e) => {
                     NEXT_BUFFER_INDEX.fetch_sub(1, Ordering::SeqCst);
+                    // phase-412 -- read the C shim's exit marker and raw code
+                    // BEFORE anything else can call the function again. The
+                    // mapped ZpicoError cannot say which of five exits ran, and
+                    // `Generic` in particular discards the zenoh-pico code.
+                    record_zpico_declare(
+                        zpico_sys::zpico_last_sub_declare_exit,
+                        zpico_sys::zpico_last_sub_declare_ret,
+                    );
                     record_zpico_err(zpico_err_class(&e));
                     return Err(TransportError::from(e));
                 }

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -368,12 +368,30 @@ pub struct SubscriberAllocReport {
     zpico_exit: AtomicU32,
     /// Raw `z_declare_subscriber` return, meaningful when the exit is 5.
     zpico_ret: AtomicU32,
+    /// Which step of zenoh-pico's `_z_register_subscriber` ran: 1 keyexpr
+    /// prefix declaration, 2 session sync-group notifier, 3 subscriber
+    /// sync-group notifier, 4 subscription registration, 5 the Declare send,
+    /// 6 success. 0 = the function did not run.
+    inner_step: AtomicU32,
+    /// What that step returned.
+    inner_ret: AtomicU32,
+    /// The platform rlsf arena: bytes out now, the most ever out at once, and
+    /// its capacity.
+    ///
+    /// phase-412 -- `NROS_ZEPHYR_HEAP_SIZE` is hand-picked, and until the
+    /// port's stats were repointed at this arena nothing could say what it
+    /// used. `heap_peak` is the figure the knob wants; `heap_used` sampled here
+    /// is whatever is live at the last subscription. 0 means the image was
+    /// built without `nros-platform/heap-stats`.
+    heap_used: AtomicU32,
+    heap_peak: AtomicU32,
+    heap_capacity: AtomicU32,
 }
 
 /// `"SUBA"` -- subscriber alloc. Written LAST by [`record_alloc_ceilings`].
 pub const SUBSCRIBER_ALLOC_MAGIC: u32 = 0x53554241;
 /// Layout version for [`SubscriberAllocReport`].
-pub const SUBSCRIBER_ALLOC_VERSION: u32 = 4;
+pub const SUBSCRIBER_ALLOC_VERSION: u32 = 6;
 
 /// The record, findable by symbol from a debugger.
 #[unsafe(no_mangle)]
@@ -397,7 +415,39 @@ pub static NROS_SUBSCRIBER_ALLOC_REPORT: SubscriberAllocReport = SubscriberAlloc
     buffer_taken: AtomicU32::new(0),
     zpico_exit: AtomicU32::new(0),
     zpico_ret: AtomicU32::new(0),
+    inner_step: AtomicU32::new(0),
+    inner_ret: AtomicU32::new(0),
+    heap_used: AtomicU32::new(0),
+    heap_peak: AtomicU32::new(0),
+    heap_capacity: AtomicU32::new(0),
 };
+
+/// Sample the platform arena into the record.
+///
+/// Zephyr only: `nros_zephyr_heap_*` are that port's symbols. They exist
+/// whenever `nros-platform/platform-zephyr` is on and return 0 without
+/// `heap-stats`, so no second guard is needed.
+#[cfg(feature = "platform-zephyr")]
+fn record_heap(r: &SubscriberAllocReport, sat: &dyn Fn(usize) -> u32) {
+    unsafe extern "C" {
+        fn nros_zephyr_heap_used() -> usize;
+        fn nros_zephyr_heap_peak() -> usize;
+        fn nros_zephyr_heap_capacity() -> usize;
+    }
+    // SAFETY: three argument-free getters over atomics in the platform crate.
+    unsafe {
+        r.heap_used
+            .store(sat(nros_zephyr_heap_used()), Ordering::Relaxed);
+        r.heap_peak
+            .store(sat(nros_zephyr_heap_peak()), Ordering::Relaxed);
+        r.heap_capacity
+            .store(sat(nros_zephyr_heap_capacity()), Ordering::Relaxed);
+    }
+}
+
+/// Every other port: this arena is not theirs to measure.
+#[cfg(not(feature = "platform-zephyr"))]
+fn record_heap(_r: &SubscriberAllocReport, _sat: &dyn Fn(usize) -> u32) {}
 
 /// Record the metadata-slot index that was refused.
 ///
@@ -453,6 +503,18 @@ pub(super) fn record_zpico_declare(exit: i32, ret: i32) {
         .is_ok()
     {
         r.zpico_ret.store(ret as u32, Ordering::Relaxed);
+        // SAFETY: plain `int` globals in the C shim, written immediately before
+        // this on the same thread, read on a path that has already failed.
+        unsafe {
+            r.inner_step.store(
+                zpico_sys::zpico_last_sub_inner_step as u32,
+                Ordering::Relaxed,
+            );
+            r.inner_ret.store(
+                zpico_sys::zpico_last_sub_inner_ret as u32,
+                Ordering::Relaxed,
+            );
+        }
     }
 }
 
@@ -504,6 +566,7 @@ fn record_alloc(hint: usize, refusal: u32) {
         sat(NEXT_BUFFER_INDEX.load(Ordering::SeqCst)),
         Ordering::Relaxed,
     );
+    record_heap(r, &sat);
     // FIRST refusal wins: the one that stopped the boot is the one that
     // explains it, and a later refusal is a consequence.
     if refusal != 0 {

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -368,13 +368,6 @@ pub struct SubscriberAllocReport {
     zpico_exit: AtomicU32,
     /// Raw `z_declare_subscriber` return, meaningful when the exit is 5.
     zpico_ret: AtomicU32,
-    /// Which step of zenoh-pico's `_z_register_subscriber` ran: 1 keyexpr
-    /// prefix declaration, 2 session sync-group notifier, 3 subscriber
-    /// sync-group notifier, 4 subscription registration, 5 the Declare send,
-    /// 6 success. 0 = the function did not run.
-    inner_step: AtomicU32,
-    /// What that step returned.
-    inner_ret: AtomicU32,
     /// The platform rlsf arena: bytes out now, the most ever out at once, and
     /// its capacity.
     ///
@@ -391,7 +384,7 @@ pub struct SubscriberAllocReport {
 /// `"SUBA"` -- subscriber alloc. Written LAST by [`record_alloc_ceilings`].
 pub const SUBSCRIBER_ALLOC_MAGIC: u32 = 0x53554241;
 /// Layout version for [`SubscriberAllocReport`].
-pub const SUBSCRIBER_ALLOC_VERSION: u32 = 6;
+pub const SUBSCRIBER_ALLOC_VERSION: u32 = 7;
 
 /// The record, findable by symbol from a debugger.
 #[unsafe(no_mangle)]
@@ -415,8 +408,6 @@ pub static NROS_SUBSCRIBER_ALLOC_REPORT: SubscriberAllocReport = SubscriberAlloc
     buffer_taken: AtomicU32::new(0),
     zpico_exit: AtomicU32::new(0),
     zpico_ret: AtomicU32::new(0),
-    inner_step: AtomicU32::new(0),
-    inner_ret: AtomicU32::new(0),
     heap_used: AtomicU32::new(0),
     heap_peak: AtomicU32::new(0),
     heap_capacity: AtomicU32::new(0),
@@ -503,18 +494,6 @@ pub(super) fn record_zpico_declare(exit: i32, ret: i32) {
         .is_ok()
     {
         r.zpico_ret.store(ret as u32, Ordering::Relaxed);
-        // SAFETY: plain `int` globals in the C shim, written immediately before
-        // this on the same thread, read on a path that has already failed.
-        unsafe {
-            r.inner_step.store(
-                zpico_sys::zpico_last_sub_inner_step as u32,
-                Ordering::Relaxed,
-            );
-            r.inner_ret.store(
-                zpico_sys::zpico_last_sub_inner_ret as u32,
-                Ordering::Relaxed,
-            );
-        }
     }
 }
 

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 
 use atomic_waker::AtomicWaker;
-use portable_atomic::{AtomicUsize, Ordering};
+use portable_atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use nros_rmw::{Subscription, TransportError};
 
@@ -276,9 +276,128 @@ pub fn required_rx_bytes(rx_buffer_hint: usize) -> Option<usize> {
         return Some(SUBSCRIBER_BUFFER_SIZE);
     }
     if rx_buffer_hint > LARGEST_PAYLOAD_CLASS {
+        record_alloc(rx_buffer_hint, 1);
         return None;
     }
     Some(rx_buffer_hint)
+}
+
+/// phase-412 -- a RAM record of what the payload-class allocator decided.
+///
+/// # Why this is its own record and not a field of `boot_report`
+///
+/// `nros-node` owns the boot report, and `nros-node` DEPENDS on this crate --
+/// the edge runs the other way, so calling into it from here would be a cycle.
+/// The alternative, plumbing the refusal up through `TransportError`, cannot
+/// carry the numbers either: the variant that surfaces is
+/// `SubscriberCreationFailed`, which is one variant for three distinct exits.
+///
+/// So the crate that HAS the facts keeps them, and the reader takes two
+/// symbols instead of one. That is the honest shape here.
+///
+/// # What it answers
+///
+/// `alloc_payload_block` refuses on three conditions and the caller cannot tell
+/// them apart. On the mr-canhubk344 island the refusal cost a subscription and
+/// stopped boot, and reasoning from the source narrowed it to "one of three"
+/// twice without settling it -- the ceilings are compile-time and readable from
+/// the build, but WHICH exit fired and WITH WHAT HINT are runtime facts that
+/// nothing recorded.
+///
+/// Written unconditionally: it is 48 bytes of `.bss` and a few relaxed stores
+/// on a path that runs once per subscription at registration. Unlike the boot
+/// report this is not opt-in, because a refusal here is always a build
+/// misconfiguration worth explaining and there is no spin-path cost to weigh
+/// against it.
+#[repr(C)]
+pub struct SubscriberAllocReport {
+    magic: AtomicU32,
+    version: AtomicU32,
+    struct_size: AtomicU32,
+    /// 0 = no refusal, 1 = hint above every class, 2 = large class full,
+    /// 3 = small class full. The three exits of `alloc_payload_block`.
+    refusal: AtomicU32,
+    /// The hint that was refused, or the last one accepted.
+    rx_hint: AtomicU32,
+    /// Compile-time ceilings, so a dump says what the image was built with
+    /// rather than what the reader assumes it was built with.
+    largest_payload_class: AtomicU32,
+    small_class_ceiling: AtomicU32,
+    max_large_subscribers: AtomicU32,
+    subscriber_large_size: AtomicU32,
+    subscriber_buffer_size: AtomicU32,
+    /// How many blocks each class has handed out. The small counter reaching
+    /// `ZPICO_MAX_SUBSCRIBERS` is exit 3, and its value ABOVE the number of
+    /// subscriptions the image declares is the tell that something other than
+    /// the application is taking blocks.
+    small_taken: AtomicU32,
+    large_taken: AtomicU32,
+}
+
+/// `"SUBA"` -- subscriber alloc. Written LAST by [`record_alloc_ceilings`].
+pub const SUBSCRIBER_ALLOC_MAGIC: u32 = 0x53554241;
+/// Layout version for [`SubscriberAllocReport`].
+pub const SUBSCRIBER_ALLOC_VERSION: u32 = 1;
+
+/// The record, findable by symbol from a debugger.
+#[unsafe(no_mangle)]
+#[used]
+pub static NROS_SUBSCRIBER_ALLOC_REPORT: SubscriberAllocReport = SubscriberAllocReport {
+    magic: AtomicU32::new(0),
+    version: AtomicU32::new(0),
+    struct_size: AtomicU32::new(0),
+    refusal: AtomicU32::new(0),
+    rx_hint: AtomicU32::new(0),
+    largest_payload_class: AtomicU32::new(0),
+    small_class_ceiling: AtomicU32::new(0),
+    max_large_subscribers: AtomicU32::new(0),
+    subscriber_large_size: AtomicU32::new(0),
+    subscriber_buffer_size: AtomicU32::new(0),
+    small_taken: AtomicU32::new(0),
+    large_taken: AtomicU32::new(0),
+};
+
+/// Stamp the compile-time ceilings and the running counters.
+///
+/// Called on EVERY `alloc_payload_block`, success or refusal, so a healthy
+/// image still reports what its classes are -- the ceilings are half the
+/// answer even when nothing refused, and an image that never fails is exactly
+/// the one nobody would think to dump.
+fn record_alloc(hint: usize, refusal: u32) {
+    let r = &NROS_SUBSCRIBER_ALLOC_REPORT;
+    let sat = |v: usize| u32::try_from(v).unwrap_or(u32::MAX);
+    r.version.store(SUBSCRIBER_ALLOC_VERSION, Ordering::Relaxed);
+    r.struct_size.store(
+        core::mem::size_of::<SubscriberAllocReport>() as u32,
+        Ordering::Relaxed,
+    );
+    r.rx_hint.store(sat(hint), Ordering::Relaxed);
+    r.largest_payload_class
+        .store(sat(LARGEST_PAYLOAD_CLASS), Ordering::Relaxed);
+    r.small_class_ceiling
+        .store(sat(SMALL_CLASS_CEILING), Ordering::Relaxed);
+    r.max_large_subscribers
+        .store(sat(MAX_LARGE_SUBSCRIBERS), Ordering::Relaxed);
+    r.subscriber_large_size
+        .store(sat(SUBSCRIBER_LARGE_SIZE), Ordering::Relaxed);
+    r.subscriber_buffer_size
+        .store(sat(SUBSCRIBER_BUFFER_SIZE), Ordering::Relaxed);
+    r.small_taken.store(
+        sat(NEXT_SMALL_PAYLOAD.load(Ordering::SeqCst)),
+        Ordering::Relaxed,
+    );
+    r.large_taken.store(
+        sat(NEXT_LARGE_PAYLOAD.load(Ordering::SeqCst)),
+        Ordering::Relaxed,
+    );
+    // FIRST refusal wins: the one that stopped the boot is the one that
+    // explains it, and a later refusal is a consequence.
+    if refusal != 0 {
+        let _ = r
+            .refusal
+            .compare_exchange(0, refusal, Ordering::Relaxed, Ordering::Relaxed);
+    }
+    r.magic.store(SUBSCRIBER_ALLOC_MAGIC, Ordering::Relaxed);
 }
 
 pub(super) static NEXT_SMALL_PAYLOAD: AtomicUsize = AtomicUsize::new(0);
@@ -332,25 +451,30 @@ pub(super) fn alloc_payload_block(rx_buffer_hint: usize) -> Option<(*mut u8, usi
     // large class does not exist, so a hint past the small block has nowhere
     // legal to go and is refused rather than silently under-served.
     if rx_buffer_hint > LARGEST_PAYLOAD_CLASS {
+        record_alloc(rx_buffer_hint, 1);
         return None;
     }
     if rx_buffer_hint > SMALL_CLASS_CEILING {
         let idx = NEXT_LARGE_PAYLOAD.fetch_add(1, Ordering::SeqCst);
         if idx >= MAX_LARGE_SUBSCRIBERS {
             NEXT_LARGE_PAYLOAD.fetch_sub(1, Ordering::SeqCst);
+            record_alloc(rx_buffer_hint, 2);
             return None;
         }
         // Safety: idx is in-bounds; LARGE_PAYLOADS is a static with a stable address.
         let base = unsafe { (&raw mut LARGE_PAYLOADS[idx]) as *mut u8 };
+        record_alloc(rx_buffer_hint, 0);
         Some((base, SUBSCRIBER_LARGE_SIZE))
     } else {
         let idx = NEXT_SMALL_PAYLOAD.fetch_add(1, Ordering::SeqCst);
         if idx >= ZPICO_MAX_SUBSCRIBERS {
             NEXT_SMALL_PAYLOAD.fetch_sub(1, Ordering::SeqCst);
+            record_alloc(rx_buffer_hint, 3);
             return None;
         }
         // Safety: idx is in-bounds; SMALL_PAYLOADS is a static with a stable address.
         let base = unsafe { (&raw mut SMALL_PAYLOADS[idx]) as *mut u8 };
+        record_alloc(rx_buffer_hint, 0);
         Some((base, SUBSCRIBER_BUFFER_SIZE))
     }
 }

--- a/packages/rmw/zenoh/zpico-alloc/Cargo.toml
+++ b/packages/rmw/zenoh/zpico-alloc/Cargo.toml
@@ -21,7 +21,12 @@ categories = ["embedded", "no-std", "memory-management"]
 # it is proven to build for a bare-metal target in this tree, and it is present
 # in the local registry — which matters because `--locked` is injected
 # project-wide by the scripts/bin/cargo shim.
-rlsf = { version = "0.2.3", default-features = false }
+# `unstable` is an EMPTY, purely additive feature in rlsf 0.2.3 -- it gates
+# extra APIs and nothing else; the only nightly `feature(...)` in that crate
+# is behind `doc_cfg`, which stays off. It is enabled for
+# `Tlsf::allocation_usable_size`, without which a freed block's size is
+# unknown and `used_bytes` can only ever grow (phase-412).
+rlsf = { version = "0.2.3", default-features = false, features = ["unstable"] }
 
 # The counters below use atomic READ-MODIFY-WRITE (`fetch_add`), which
 # `core::sync::atomic` does not provide on every target this crate builds for:

--- a/packages/rmw/zenoh/zpico-alloc/src/lib.rs
+++ b/packages/rmw/zenoh/zpico-alloc/src/lib.rs
@@ -320,7 +320,18 @@ impl<const N: usize, const FLLEN: usize> FreeListHeap<N, FLLEN> {
                 Some(p) => {
                     #[cfg(feature = "stats")]
                     {
-                        let used = self.used_bytes.fetch_add(size, Ordering::Relaxed) + size;
+                        // phase-412 -- charge the USABLE size, not the requested
+                        // one. `free` has only the pointer, so the only size it
+                        // can credit is what rlsf reports for the block; if alloc
+                        // charged `size` and free credited the usable size (>= it,
+                        // rounded to GRANULARITY) the counter would drift toward
+                        // zero and stick there.
+                        //
+                        // Usable is also the honest figure: it is what the block
+                        // costs the arena, which is what a heap-size knob covers.
+                        let charged =
+                            Tlsf::<'static, FlBitmap, u16, FLLEN, SLLEN>::allocation_usable_size(p);
+                        let used = self.used_bytes.fetch_add(charged, Ordering::Relaxed) + charged;
                         let _ = self.peak_bytes.fetch_max(used, Ordering::Relaxed);
                     }
                     p.as_ptr() as *mut core::ffi::c_void
@@ -439,6 +450,24 @@ impl<const N: usize, const FLLEN: usize> FreeListHeap<N, FLLEN> {
             self.ensure_init();
             let tlsf = &mut *self.tlsf.get();
             if let Some(nn) = NonNull::new(ptr as *mut u8) {
+                // phase-412 -- BEFORE `deallocate`, which invalidates the block
+                // header the size is read from. Until this existed the rlsf path
+                // credited nothing, so `used()` was cumulative-allocated rather
+                // than live and `peak()` merely tracked it: the island reported
+                // 395,132 used against a 94,720-byte arena.
+                #[cfg(feature = "stats")]
+                {
+                    let freed =
+                        Tlsf::<'static, FlBitmap, u16, FLLEN, SLLEN>::allocation_usable_size(nn);
+                    // Saturating, not `fetch_sub`: an unmatched free would wrap,
+                    // and a counter stuck at zero is wrong in a way a reader can
+                    // see, where an enormous one looks like a measurement.
+                    let _ =
+                        self.used_bytes
+                            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |u| {
+                                Some(u.saturating_sub(freed))
+                            });
+                }
                 tlsf.deallocate(nn, ALIGN);
             }
         }
@@ -787,5 +816,66 @@ mod tests {
             assert_eq!(unsafe { *q.add(i as usize) }, i);
         }
         H.free(q as *mut core::ffi::c_void);
+    }
+}
+
+#[cfg(all(test, feature = "stats"))]
+mod stats_accounting_tests {
+    use super::*;
+
+    /// phase-412 -- `used()` must come back DOWN.
+    ///
+    /// The rlsf free path credited nothing, so `used()` was
+    /// cumulative-allocated: the island reported 395,132 used against a
+    /// 94,720-byte arena, and `peak()` merely tracked it. A counter that only
+    /// grows cannot size a heap knob, which is the whole reason it exists.
+    #[test]
+    fn freeing_returns_the_bytes_to_the_counter() {
+        static H: FreeListHeap<8192> = FreeListHeap::new();
+        let base = H.used();
+
+        // Larger than SLAB_SLOT_SIZE, so this is the rlsf path rather than the
+        // slab fast-path, which was already symmetric.
+        let p = H.alloc(1024);
+        assert!(!p.is_null());
+        let after_alloc = H.used();
+        assert!(
+            after_alloc >= base + 1024,
+            "alloc charged {} for a 1024-byte request",
+            after_alloc - base
+        );
+
+        H.free(p);
+        assert_eq!(H.used(), base, "free did not credit what alloc charged");
+    }
+
+    /// Churn must not drift the counter in either direction.
+    #[test]
+    fn repeated_churn_does_not_drift() {
+        static H: FreeListHeap<8192> = FreeListHeap::new();
+        let base = H.used();
+        for _ in 0..64 {
+            let p = H.alloc(512);
+            assert!(!p.is_null());
+            H.free(p);
+        }
+        assert_eq!(H.used(), base, "64 alloc/free pairs drifted the counter");
+    }
+
+    /// Sizes that are not multiples of GRANULARITY are where an asymmetric
+    /// charge/credit shows up fastest.
+    #[test]
+    fn odd_sizes_round_trip() {
+        static H: FreeListHeap<16384> = FreeListHeap::new();
+        let base = H.used();
+        let mut ps = [core::ptr::null_mut(); 8];
+        for (i, p) in ps.iter_mut().enumerate() {
+            *p = H.alloc(65 + i * 37);
+            assert!(!p.is_null());
+        }
+        for p in ps {
+            H.free(p);
+        }
+        assert_eq!(H.used(), base, "odd-sized blocks drifted the counter");
     }
 }

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -2344,14 +2344,39 @@ int32_t zpico_declare_subscriber_direct_write(zpico_session_t* session, const ch
     return idx;
 }
 
+/* phase-412 -- which exit `zpico_declare_subscriber_ring` took, and the raw
+ * zenoh-pico code when the declare itself is what failed.
+ *
+ * The return value cannot carry this. Five exits collapse onto four ZPICO_ERR_*
+ * codes, and ZPICO_ERR_GENERIC in particular DISCARDS `sub_ret`, the only
+ * number saying what zenoh-pico objected to. The printk beside it carries both
+ * -- to the console, which is not wired on the MR-CANHUBK344. On the one board
+ * that needed the message it is written and unreadable.
+ *
+ * Globals rather than an out-param, so the ABI does not move: the Rust caller
+ * reads them immediately after a failed call, on a path that already failed.
+ *
+ * Numbering is stable and append-only. 0 after a call means NO exit stamped,
+ * which is itself a finding when the caller reports an error it believes came
+ * from here.
+ */
+int32_t zpico_last_sub_declare_exit = 0;
+int32_t zpico_last_sub_declare_ret = 0;
+
 int32_t zpico_declare_subscriber_ring(zpico_session_t* session, const char* keyexpr,
                                       zpico_ring_desc_t* desc, ZpicoNotifyCallback callback,
                                       void* ctx) {
     struct zpico_session* s = (struct zpico_session*)session;
+    /* Reset at entry: a value left by an earlier call must not be read as
+     * this one's. 0 therefore means "entered but stamped no exit". */
+    zpico_last_sub_declare_exit = 0;
+    zpico_last_sub_declare_ret = 0;
     if (!s->session_open) {
+        zpico_last_sub_declare_exit = 1;
         return ZPICO_ERR_SESSION;
     }
     if (desc == NULL || desc->slot_count == 0) {
+        zpico_last_sub_declare_exit = 2;
         return ZPICO_ERR_INVALID;
     }
 
@@ -2363,6 +2388,7 @@ int32_t zpico_declare_subscriber_ring(zpico_session_t* session, const char* keye
         }
     }
     if (idx < 0) {
+        zpico_last_sub_declare_exit = 3;
         return ZPICO_ERR_FULL;
     }
 
@@ -2379,6 +2405,7 @@ int32_t zpico_declare_subscriber_ring(zpico_session_t* session, const char* keye
         s->subscribers[idx].ctx = NULL;
         s->subscribers[idx].ring_mode = false;
         s->subscribers[idx].ring = NULL;
+        zpico_last_sub_declare_exit = 4;
         return ZPICO_ERR_KEYEXPR;
     }
 
@@ -2394,10 +2421,13 @@ int32_t zpico_declare_subscriber_ring(zpico_session_t* session, const char* keye
         s->subscribers[idx].ctx = NULL;
         s->subscribers[idx].ring_mode = false;
         s->subscribers[idx].ring = NULL;
+        zpico_last_sub_declare_exit = 5;
+        zpico_last_sub_declare_ret = (int32_t)sub_ret;
         return ZPICO_ERR_GENERIC;
     }
 
     s->subscribers[idx].active = true;
+        zpico_last_sub_declare_exit = 6;
     return idx;
 }
 

--- a/packages/rmw/zenoh/zpico-sys/src/lib.rs
+++ b/packages/rmw/zenoh/zpico-sys/src/lib.rs
@@ -261,6 +261,15 @@ unsafe extern "C" {
         callback: ZpicoNotifyCallback,
         ctx: *mut c_void,
     ) -> i32;
+    /// phase-412 -- which exit `zpico_declare_subscriber_ring` took (1..=6,
+    /// 0 = entered and stamped nothing), and the raw zenoh-pico code when the
+    /// declare itself failed. Written by the C shim on every call; read by the
+    /// caller immediately after a failure. See the comment beside their
+    /// definition in `c/zpico/zpico.c`.
+    pub static zpico_last_sub_declare_exit: i32;
+    /// Raw `z_declare_subscriber` return, valid when the exit above is 5.
+    pub static zpico_last_sub_declare_ret: i32;
+
     pub fn zpico_declare_subscriber_ring(
         session: *mut zpico_session_t,
         keyexpr: *const core::ffi::c_char,

--- a/scripts/check-boot-report-layout.py
+++ b/scripts/check-boot-report-layout.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""The boot report's Rust layout and its Python decoder must agree.
+
+phase-412. `scripts/read-boot-report.py` decodes a memory dump positionally --
+fifteen little-endian u32s in a fixed order. Nothing in either language forces
+that order to match `BootReport` in
+`packages/core/nros-node/src/boot_report.rs`, and a mismatch does not fail: it
+DECODES, and prints an arena size that is really a callback count.
+
+That is the failure mode this gate exists for. A wrong number that looks like a
+number is worse than no number, and this record's whole purpose is to be
+believed about a board that cannot otherwise be asked.
+
+Checked here:
+
+* the struct's field order equals the script's `FIELDS`
+* `Snapshot`, which the Rust tests read through, has the same order again --
+  so a test asserting on the record exercises the layout the script assumes
+* `MAGIC` and `VERSION` are the same constants on both sides
+
+Not checked here: the size the RECORD reports at runtime. That comes from
+`size_of` on the target and is asserted by the Rust test, which is the only
+side that can see it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RUST = REPO / "packages/core/nros-node/src/boot_report.rs"
+PY = REPO / "scripts/read-boot-report.py"
+
+
+def fail(msg: str) -> int:
+    print(f"check-boot-report-layout: {msg}", file=sys.stderr)
+    return 1
+
+
+def rust_struct_fields(text: str, name: str, ty: str) -> list[str]:
+    """Field names of `struct <name>`, in declaration order."""
+    m = re.search(rf"\n\s*pub struct {name} \{{\n(.*?)\n\s*\}}\n", text, re.S)
+    if not m:
+        raise SystemExit(f"{RUST}: no `pub struct {name}` found")
+    fields = []
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("//") or line.startswith("///"):
+            continue
+        fm = re.match(rf"(?:pub )?([a-z_][a-z0-9_]*): {re.escape(ty)},", line)
+        if fm:
+            fields.append(fm.group(1))
+    return fields
+
+
+def py_fields(text: str) -> list[str]:
+    m = re.search(r"\nFIELDS = \(\n(.*?)\n\)\n", text, re.S)
+    if not m:
+        raise SystemExit(f"{PY}: no `FIELDS` tuple found")
+    return re.findall(r'"([a-z_][a-z0-9_]*)"', m.group(1))
+
+
+def const_u32(text: str, name: str) -> int:
+    m = re.search(rf"\npub const {name}: u32 = (0x[0-9a-fA-F_]+|\d+);", text)
+    if not m:
+        raise SystemExit(f"{RUST}: no `pub const {name}: u32` found")
+    return int(m.group(1).replace("_", ""), 0)
+
+
+def py_const(text: str, name: str) -> int:
+    m = re.search(rf"\n{name} = (0x[0-9a-fA-F]+|\d+)\n", text)
+    if not m:
+        raise SystemExit(f"{PY}: no `{name}` found")
+    return int(m.group(1), 0)
+
+
+def diff(
+    label: str,
+    a: list[str],
+    b: list[str],
+    a_name: str,
+    b_name: str,
+    quiet: bool = False,
+) -> int:
+    """Compare two field orders. `quiet` suppresses the report, for the
+    selftest's deliberate mismatches -- printing those on a PASSING run
+    would train a reader to skip exactly the output that matters."""
+    if a == b:
+        return 0
+    if quiet:
+        return 1
+    rc = fail(f"{label}: {a_name} and {b_name} disagree")
+    for i, (x, y) in enumerate(zip(a, b)):
+        if x != y:
+            print(f"  word {i}: {a_name} has `{x}`, {b_name} has `{y}`", file=sys.stderr)
+    if len(a) != len(b):
+        print(
+            f"  {a_name} has {len(a)} fields, {b_name} has {len(b)}: "
+            f"extra {sorted(set(a) ^ set(b))}",
+            file=sys.stderr,
+        )
+    return rc
+
+
+def main() -> int:
+    rust = RUST.read_text()
+    py = PY.read_text()
+
+    record = rust_struct_fields(rust, "BootReport", "AtomicU32")
+    snapshot = rust_struct_fields(rust, "Snapshot", "u32")
+    script = py_fields(py)
+
+    if not record:
+        return fail("parsed zero fields out of `BootReport` -- the gate is blind")
+
+    rc = 0
+    rc |= diff("record vs decoder", record, script, "BootReport", "read-boot-report.py")
+    rc |= diff("record vs snapshot", record, snapshot, "BootReport", "Snapshot")
+
+    for name, py_name in (("MAGIC", "MAGIC"), ("VERSION", "KNOWN_VERSION")):
+        r = const_u32(rust, name)
+        p = py_const(py, py_name)
+        if r != p:
+            rc |= fail(f"{name}: boot_report.rs has {r:#x}, read-boot-report.py has {p:#x}")
+
+    if rc == 0:
+        print(
+            f"check-boot-report-layout: OK ({len(record)} fields, "
+            f"{len(record) * 4} bytes, agreed by BootReport, Snapshot and the decoder)"
+        )
+    return rc
+
+
+def self_test() -> int:
+    """Negative controls: the gate must FAIL on each drift it exists to catch.
+
+    Run on the normal path, not behind a flag. A gate that only ever sees the
+    agreeing case reports OK for both reasons -- because the files agree, and
+    because it stopped being able to tell.
+    """
+    ok = True
+
+    def expect(name: str, got, want) -> None:
+        nonlocal ok
+        if got != want:
+            ok = False
+            print(f"  self-test FAIL {name}: {got!r} != {want!r}")
+
+    rust = RUST.read_text()
+    py = PY.read_text()
+    record = rust_struct_fields(rust, "BootReport", "AtomicU32")
+    snapshot = rust_struct_fields(rust, "Snapshot", "u32")
+    script = py_fields(py)
+
+    # The parsers must actually find something. A regex that silently matches
+    # nothing turns every comparison below into `[] == []`, which passes.
+    expect("parses the record", len(record) > 5, True)
+    expect("parses the snapshot", len(snapshot) > 5, True)
+    expect("parses the decoder", len(script) > 5, True)
+
+    # Reordering two words is the drift that DECODES rather than failing, and
+    # so is the whole reason this gate exists.
+    swapped = list(script)
+    swapped[0], swapped[1] = swapped[1], swapped[0]
+    expect("catches a reorder", diff("t", record, swapped, "a", "b", quiet=True) != 0, True)
+
+    # A field added on one side only.
+    expect("catches a missing field", diff("t", record, script[:-1], "a", "b", quiet=True) != 0, True)
+
+    # And the agreeing case must still pass, or the gate fails everything.
+    expect("passes when they agree", diff("t", record, script, "a", "b", quiet=True), 0)
+
+    print("check-boot-report-layout --self-test: " + ("OK" if ok else "FAILED"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    # The selftest runs on the NORMAL path -- a negative control nobody runs
+    # decays into a comment, which is what `check-gate-selftests` enforces.
+    rc = self_test()
+    sys.exit(rc if rc or "--self-test" in sys.argv else main())

--- a/scripts/check-boot-report-layout.py
+++ b/scripts/check-boot-report-layout.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 RUST = REPO / "packages/core/nros-node/src/boot_report.rs"
+ALLOC_RUST = REPO / "packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs"
 PY = REPO / "scripts/read-boot-report.py"
 
 
@@ -55,10 +56,10 @@ def rust_struct_fields(text: str, name: str, ty: str) -> list[str]:
     return fields
 
 
-def py_fields(text: str) -> list[str]:
-    m = re.search(r"\nFIELDS = \(\n(.*?)\n\)\n", text, re.S)
+def py_fields(text: str, name: str = "FIELDS") -> list[str]:
+    m = re.search(rf"\n{name} = \(\n(.*?)\n\)\n", text, re.S)
     if not m:
-        raise SystemExit(f"{PY}: no `FIELDS` tuple found")
+        raise SystemExit(f"{PY}: no `{name}` tuple found")
     return re.findall(r'"([a-z_][a-z0-9_]*)"', m.group(1))
 
 
@@ -70,7 +71,7 @@ def const_u32(text: str, name: str) -> int:
 
 
 def py_const(text: str, name: str) -> int:
-    m = re.search(rf"\n{name} = (0x[0-9a-fA-F]+|\d+)\n", text)
+    m = re.search(rf"\n{name} = (0x[0-9a-fA-F]+|\d+)[ \t]*(?:#[^\n]*)?\n", text)
     if not m:
         raise SystemExit(f"{PY}: no `{name}` found")
     return int(m.group(1), 0)
@@ -125,10 +126,29 @@ def main() -> int:
         if r != p:
             rc |= fail(f"{name}: boot_report.rs has {r:#x}, read-boot-report.py has {p:#x}")
 
+    # The SECOND record. Same positional decode, same drift, same gate -- it
+    # lives in another crate only because nros-node depends on that crate and
+    # the call would otherwise be a cycle, which changes nothing about how
+    # wrongly a reordered field decodes.
+    alloc_rust = ALLOC_RUST.read_text()
+    alloc_record = rust_struct_fields(alloc_rust, "SubscriberAllocReport", "AtomicU32")
+    alloc_script = py_fields(py, "ALLOC_FIELDS")
+    if not alloc_record:
+        rc |= fail("parsed zero fields out of `SubscriberAllocReport` -- blind")
+    rc |= diff("alloc record vs decoder", alloc_record, alloc_script,
+               "SubscriberAllocReport", "read-boot-report.py")
+    for name, py_name in (("SUBSCRIBER_ALLOC_MAGIC", "ALLOC_MAGIC"),
+                          ("SUBSCRIBER_ALLOC_VERSION", "ALLOC_VERSION")):
+        r = const_u32(alloc_rust, name)
+        p = py_const(py, py_name)
+        if r != p:
+            rc |= fail(f"{name}: subscriber.rs has {r:#x}, decoder has {p:#x}")
+
     if rc == 0:
         print(
-            f"check-boot-report-layout: OK ({len(record)} fields, "
-            f"{len(record) * 4} bytes, agreed by BootReport, Snapshot and the decoder)"
+            f"check-boot-report-layout: OK (BootReport {len(record)} fields / "
+            f"{len(record) * 4} bytes; SubscriberAllocReport {len(alloc_record)} fields / "
+            f"{len(alloc_record) * 4} bytes; all agreed with the decoder)"
         )
     return rc
 

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -91,6 +91,7 @@ KNOB_CLASS = {
     # "unresolved" hatch would make one variable mean two different
     # judgements, and a user silencing one would silence the other.
     "NROS_ALLOW_INFRA_DEPS": ("infra", "policy flag"),
+    "NROS_BOOT_REPORT": ("infra", "diagnostic toggle; a bool, so it has no rung"),
     "NROS_BUILD_ROOT": ("infra", "path"),
     "NROS_CARGO_FLAGS": ("infra", "the --locked shim"),
     "NROS_LINK_IP": ("infra", "link toggle"),

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -111,7 +111,7 @@ POOL_CLASSES = {5, 12, 14, 15, 17}
 # way and a call would be a cycle. See SubscriberAllocReport's own doc comment.
 ALLOC_SYMBOL = "NROS_SUBSCRIBER_ALLOC_REPORT"
 ALLOC_MAGIC = 0x53554241  # "SUBA"
-ALLOC_VERSION = 4
+ALLOC_VERSION = 6
 ALLOC_FIELDS = (
     "magic",
     "version",
@@ -131,6 +131,11 @@ ALLOC_FIELDS = (
     "buffer_taken",
     "zpico_exit",
     "zpico_ret",
+    "inner_step",
+    "inner_ret",
+    "heap_used",
+    "heap_peak",
+    "heap_capacity",
 )
 # Assigned by `zpico_err_class` in the zenoh shim. The variant is recorded on
 # the NEAR side of the C ABI because crossing it collapses Generic and Session
@@ -143,6 +148,24 @@ ZPICO_ERR = {
 }
 
 # Exit markers stamped by `zpico_declare_subscriber_ring` in the C shim.
+# Steps of zenoh-pico's `_z_register_subscriber`, from the nano-ros patch in
+# zenoh-pico/src/net/primitives.c.
+INNER_STEP = {
+    0: "did not run",
+    1: "keyexpr prefix declaration (_z_declared_keyexpr_declare_non_wild_prefix)",
+    2: "session sync-group notifier",
+    3: "subscriber sync-group notifier",
+    4: "subscription registration (_z_register_subscription returned NULL)",
+    5: "the Declare send (_z_send_declare)",
+    6: "success",
+    10: "entered _z_declare_subscriber; no later step stamped",
+    11: "_z_sync_group_create failed",
+    12: "_z_register_subscriber failed without stamping a step",
+    20: "_z_sync_group_create: z_malloc returned NULL (kernel heap)",
+    21: "_z_sync_group_create: _z_sync_group_state_create failed",
+    22: "_z_sync_group_create: rc_new returned NULL (kernel heap)",
+}
+
 ZPICO_EXIT = {
     0: "stamped NOTHING -- the function did not run, or ran a path with no marker",
     1: "session not open",
@@ -378,6 +401,29 @@ def report_alloc(rec: dict[str, int]) -> int:
     print(f"  small blocks taken              {rec['small_taken']}")
     print(f"  large blocks taken              {rec['large_taken']}")
     print(f"  last hint seen                  {rec['rx_hint']}")
+    hp, hc = rec["heap_peak"], rec["heap_capacity"]
+    if hc:
+        pct = f"   ({100.0 * hp / hc:.1f}% of the arena)" if hp else ""
+        print(f"  platform heap used              {rec['heap_used']}")
+        print(f"  platform heap PEAK              {hp}{pct}")
+        print(f"  platform heap capacity          {hc}   (NROS_ZEPHYR_HEAP_SIZE)")
+        if hp > hc:
+            print(
+                "  DO NOT SIZE A KNOB FROM THIS. A peak above capacity is impossible\n"
+                "  for a live figure, so the counter is not one: zpico-alloc\n"
+                "  decrements used_bytes only on the SLAB free path, never on the\n"
+                "  rlsf path, so `used` is cumulative-allocated and `peak` tracks it.\n"
+                "  Fixing it needs the block size at free -- rlsf 0.2.3 exposes\n"
+                "  allocation_usable_size only under its `unstable` feature."
+            )
+        elif hp:
+            print(
+                f"  -> size NROS_ZEPHYR_HEAP_SIZE from {hp}, not from a round number.\n"
+                "     This is the peak at the LAST subscription, so add the headroom\n"
+                "     the application's own later allocations need."
+            )
+    else:
+        print("  platform heap                   not instrumented (nros-platform/heap-stats off)")
     print()
     kl, kc = rec["keyexpr_len"], rec["keyexpr_cap"]
     print(f"  last keyexpr length             {kl} of {kc}")
@@ -396,6 +442,11 @@ def report_alloc(rec: dict[str, int]) -> int:
         print(f"  zpico declare exit              {zx} -- {ZPICO_EXIT.get(zx, 'unknown')}")
         if zx == 5:
             print(f"  z_declare_subscriber returned   {zr_s}")
+            ist = rec["inner_step"]
+            ir = rec["inner_ret"]
+            ir_s = ir - (1 << 32) if ir >= (1 << 31) else ir
+            print(f"  _z_register_subscriber step     {ist} -- {INNER_STEP.get(ist, 'unknown')}")
+            print(f"  that step returned              {ir_s}")
         elif zx == 0:
             print(
                 "  The caller saw an error it believes came from this function,\n"

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -33,7 +33,7 @@ SYMBOL = "NROS_BOOT_REPORT"
 # "NRSR". Must match boot_report.rs MAGIC.
 MAGIC = 0x4E525352
 # Layout this script knows how to decode. Must match boot_report.rs VERSION.
-KNOWN_VERSION = 2
+KNOWN_VERSION = 3
 
 # Field order, matching `BootReport` and `Snapshot` in boot_report.rs. Every
 # field is a u32; the record is all `AtomicU32`, which is repr(transparent).
@@ -54,6 +54,10 @@ FIELDS = (
     "failed_alloc_size",
     "failed_alloc_shortfall",
     "cpp_init_ret",
+    "err_class",
+    "err_transport",
+    "err_backend_ptr",
+    "err_backend_len",
 )
 
 STAGES = {
@@ -65,6 +69,39 @@ STAGES = {
     5: "EntitiesReady (NOT YET WIRED -- registration has no single end; see issue 0900)",
     6: "FirstSpin -- registration complete and spinning",
 }
+
+
+# Assigned by `node_error_class` in packages/api/nros-cpp/src/lib.rs. Append
+# only, and kept in step by hand -- the Rust side is exhaustive, so a new
+# variant fails THERE first, which is the half that matters.
+ERR_CLASS = {
+    0: "(none)", 1: "Transport", 2: "NameTooLong", 3: "Serialization",
+    4: "Deserialization", 5: "BufferTooSmall", 6: "ActionCreationFailed",
+    7: "ServiceRequestFailed", 8: "ServiceReplyFailed", 9: "Timeout",
+    10: "NotInitialized", 11: "RequestInFlight", 12: "NoSchedContextSlot",
+    13: "InvalidSchedContextBinding", 14: "NodeTableFull", 15: "ExecutorFull",
+    16: "BackendMismatch", 17: "ShutdownCallbacksFull",
+}
+
+# Assigned by `transport_error_class` in the same file.
+ERR_TRANSPORT = {
+    0: "(none)", 1: "ConnectionFailed", 2: "Disconnected",
+    3: "PublisherCreationFailed", 4: "SubscriberCreationFailed",
+    5: "ServiceServerCreationFailed", 6: "ServiceClientCreationFailed",
+    7: "PublishFailed", 8: "ServiceRequestFailed", 9: "ServiceReplyFailed",
+    10: "SerializationError", 11: "DeserializationError", 12: "BufferTooSmall",
+    13: "MessageTooLarge", 14: "Timeout", 15: "InvalidConfig", 16: "WouldBlock",
+    17: "TooLarge", 18: "TaskStartFailed", 19: "PollFailed",
+    20: "KeepaliveFailed", 21: "JoinFailed", 22: "InvalidArgument",
+    23: "Unsupported", 24: "BadAlloc", 25: "IncompatibleQos",
+    26: "TopicNameInvalid", 27: "NodeNameNonExistent", 28: "LoanNotSupported",
+    29: "NoData", 30: "IncompatibleAbi", 31: "Backend", 32: "BackendDynamic",
+}
+
+# Pools and tables map to NROS_CPP_RET_FULL, never to the transport code, so
+# seeing any of these here rules a sizing knob IN -- and seeing a transport
+# class rules every one of them OUT.
+POOL_CLASSES = {5, 12, 14, 15, 17}
 
 
 def resolve_symbol(elf: Path) -> tuple[int, int]:
@@ -186,6 +223,32 @@ def report(rec: dict[str, int]) -> int:
             "later allocations may also have failed as a consequence."
         )
         return 1
+
+    cls = rec["err_class"]
+    if cls:
+        print()
+        print(f"LAST ERROR   {ERR_CLASS.get(cls, f'unknown class {cls}')}")
+        if cls == 1:
+            tr = rec["err_transport"]
+            print(f"  transport  {ERR_TRANSPORT.get(tr, f'unknown transport {tr}')}")
+            if rec["err_backend_ptr"]:
+                print(
+                    f"  backend message at 0x{rec['err_backend_ptr']:08x}, "
+                    f"{rec['err_backend_len']} bytes. Read it with:\n"
+                    f"    pyocd commander -t <target> --connect attach \\\n"
+                    f"      -c \"savemem 0x{rec['err_backend_ptr']:08x} "
+                    f"{rec['err_backend_len']} msg.bin\""
+                )
+        if cls in POOL_CLASSES:
+            print(
+                "  This is a POOL or TABLE exhaustion, so a sizing knob IS the\n"
+                "  cause. Raise the one the name points at."
+            )
+        else:
+            print(
+                "  NOT a pool or table exhaustion -- those map to a different\n"
+                "  code. No sizing knob explains this one."
+            )
 
     ret = rec["cpp_init_ret"]
     if ret:

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -33,7 +33,7 @@ SYMBOL = "NROS_BOOT_REPORT"
 # "NRSR". Must match boot_report.rs MAGIC.
 MAGIC = 0x4E525352
 # Layout this script knows how to decode. Must match boot_report.rs VERSION.
-KNOWN_VERSION = 1
+KNOWN_VERSION = 2
 
 # Field order, matching `BootReport` and `Snapshot` in boot_report.rs. Every
 # field is a u32; the record is all `AtomicU32`, which is repr(transparent).
@@ -53,15 +53,17 @@ FIELDS = (
     "last_alloc_size",
     "failed_alloc_size",
     "failed_alloc_shortfall",
+    "cpp_init_ret",
 )
 
 STAGES = {
-    0: "Untouched -- the image never reached boot_report::init()",
-    1: "ReportReady -- record stamped; executor not constructed",
-    2: "ExecutorReady -- arena bound",
-    3: "RegisteringEntities -- entity creation begun, NOT finished",
-    4: "EntitiesReady -- every declared entity registered",
-    5: "FirstSpin -- registration complete and spinning",
+    0: "Untouched -- the image never entered nros_cpp_init",
+    1: "ReportReady -- entered nros_cpp_init; arguments NOT yet validated",
+    2: "BootConfigResolved -- arguments accepted; executor not yet open",
+    3: "ExecutorReady -- arena bound",
+    4: "RegisteringEntities (NOT YET WIRED -- no call site emits this)",
+    5: "EntitiesReady (NOT YET WIRED -- registration has no single end; see issue 0900)",
+    6: "FirstSpin -- registration complete and spinning",
 }
 
 
@@ -185,13 +187,38 @@ def report(rec: dict[str, int]) -> int:
         )
         return 1
 
-    if stage < 4:
+    ret = rec["cpp_init_ret"]
+    if ret:
+        signed = ret - (1 << 32) if ret >= (1 << 31) else ret
         print()
         print(
-            "Registration did NOT complete, and the arena is not why.\n"
-            "Look for a pool count instead: a full pool fails at registration\n"
-            "with ExecutorFull rather than in the arena."
+            f"nros_cpp_init RETURNED {signed} (nros_cpp_ret_t).\n"
+            "The stage above says how far it got; this says why it stopped.\n"
+            "Stage 1 with a return code means an argument was rejected before\n"
+            "anything was opened; stage 2 means the backend refused."
         )
+        return 1
+
+    if stage < 6:
+        print()
+        if rec["failed_alloc_size"]:
+            pass  # already reported above
+        elif rec["alloc_count"]:
+            print(
+                f"Never reached the first spin, and the arena is NOT why: all\n"
+                f"{rec['alloc_count']} allocations succeeded and "
+                f"{rec['arena_used']} of {cap} bytes are claimed.\n"
+                "The executor was built and its entities took their arena; what\n"
+                "did not happen is the spin. Look at what the application does\n"
+                "between registering and spinning -- a blocking wait there\n"
+                "presents exactly like this, and no knob is involved."
+            )
+        else:
+            print(
+                "The executor was built but claimed NO arena, so registration\n"
+                "never started. That is earlier than any sizing knob can\n"
+                "explain."
+            )
         return 1
 
     return 0

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Decode the nano-ros boot self-report out of a target memory dump.
+
+phase-412. The image writes a fixed record about itself into RAM
+(`packages/core/nros-node/src/boot_report.rs`); this reads it back after the
+core has been halted. See that module for WHY the record is not a log stream:
+the failure it exists to catch halts the board during entity creation, before
+any advisory can print, on a board whose console UART is not wired.
+
+Two inputs, and the ELF is not optional: the record's address is resolved from
+the image's own symbol table rather than hard-coded, so a relinked image cannot
+be read at a stale address and silently decode as garbage.
+
+    pyocd commander -t s32k344 -c halt -c "savemem ADDR LEN report.bin"
+    python3 scripts/read-boot-report.py build/zephyr/zephyr.elf report.bin
+
+`--addr-only` prints the address and length for that savemem line, so the two
+steps can be scripted without anyone copying a hex number by hand:
+
+    read $(python3 scripts/read-boot-report.py --addr-only build/zephyr/zephyr.elf)
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+SYMBOL = "NROS_BOOT_REPORT"
+
+# "NRSR". Must match boot_report.rs MAGIC.
+MAGIC = 0x4E525352
+# Layout this script knows how to decode. Must match boot_report.rs VERSION.
+KNOWN_VERSION = 1
+
+# Field order, matching `BootReport` and `Snapshot` in boot_report.rs. Every
+# field is a u32; the record is all `AtomicU32`, which is repr(transparent).
+FIELDS = (
+    "magic",
+    "version",
+    "struct_size",
+    "stage",
+    "arena_size",
+    "max_cbs",
+    "max_sc",
+    "max_nodes",
+    "default_rx_buf_size",
+    "arena_capacity",
+    "arena_used",
+    "alloc_count",
+    "last_alloc_size",
+    "failed_alloc_size",
+    "failed_alloc_shortfall",
+)
+
+STAGES = {
+    0: "Untouched -- the image never reached boot_report::init()",
+    1: "ReportReady -- record stamped; executor not constructed",
+    2: "ExecutorReady -- arena bound",
+    3: "RegisteringEntities -- entity creation begun, NOT finished",
+    4: "EntitiesReady -- every declared entity registered",
+    5: "FirstSpin -- registration complete and spinning",
+}
+
+
+def resolve_symbol(elf: Path) -> tuple[int, int]:
+    """Address and size of the record, from the ELF's symbol table.
+
+    `nm` rather than a parser, because every toolchain that produced one of
+    these images ships one, and the alternative is another dependency on the
+    host side of a debugging tool.
+    """
+    for tool in ("nm", "arm-zephyr-eabi-nm", "arm-none-eabi-nm", "llvm-nm"):
+        try:
+            out = subprocess.run(
+                [tool, "-S", "--defined-only", str(elf)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            continue
+        if out.returncode != 0:
+            continue
+        for line in out.stdout.splitlines():
+            parts = line.split()
+            # "<addr> <size> <type> <name>" -- the size column is why -S.
+            if len(parts) == 4 and parts[3] == SYMBOL:
+                return int(parts[0], 16), int(parts[1], 16)
+        # The tool worked and the symbol is not there. Say so rather than
+        # trying the next tool and blaming its absence.
+        raise SystemExit(
+            f"{elf}: no `{SYMBOL}` symbol.\n"
+            "The image was built WITHOUT the boot report. Rebuild with\n"
+            "  NROS_BOOT_REPORT=1        (Zephyr: CONFIG_NROS_BOOT_REPORT=y)"
+        )
+    raise SystemExit("no usable `nm` found (tried nm, arm-zephyr-eabi-nm, llvm-nm)")
+
+
+def decode(blob: bytes) -> dict[str, int]:
+    want = len(FIELDS) * 4
+    if len(blob) < want:
+        raise SystemExit(
+            f"dump is {len(blob)} bytes, need at least {want} for one record"
+        )
+    values = struct.unpack_from(f"<{len(FIELDS)}I", blob, 0)
+    return dict(zip(FIELDS, values, strict=True))
+
+
+def report(rec: dict[str, int]) -> int:
+    """Print the record. Returns the process exit code."""
+    if rec["magic"] != MAGIC:
+        print(
+            f"NO RECORD: magic is 0x{rec['magic']:08x}, expected 0x{MAGIC:08x}.\n"
+            "\n"
+            "The magic is written LAST by boot_report::init(), so this means the\n"
+            "image did not get as far as constructing an Executor -- not that the\n"
+            "dump is at the wrong address, which the ELF lookup already ruled out.\n"
+            "An image that halted even earlier than that is itself the finding.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if rec["version"] != KNOWN_VERSION:
+        print(
+            f"record version {rec['version']}, this script decodes {KNOWN_VERSION}.\n"
+            "Refusing to decode rather than misreading it -- update this script.",
+            file=sys.stderr,
+        )
+        return 2
+
+    expect = len(FIELDS) * 4
+    if rec["struct_size"] != expect:
+        print(
+            f"record says {rec['struct_size']} bytes, this script expects {expect}.\n"
+            "Same version, different layout: one side changed a field without\n"
+            "bumping VERSION.",
+            file=sys.stderr,
+        )
+        return 2
+
+    stage = rec["stage"]
+    print(f"stage      {stage}  {STAGES.get(stage, 'UNKNOWN -- newer image than this script')}")
+    print()
+    print("compiled in (compare against what the build believed it delivered):")
+    print(f"  NROS_EXECUTOR_ARENA_SIZE      {rec['arena_size']}")
+    print(f"  NROS_EXECUTOR_MAX_CBS         {rec['max_cbs']}")
+    print(f"  NROS_EXECUTOR_MAX_SC          {rec['max_sc']}")
+    print(f"  NROS_EXECUTOR_MAX_NODES       {rec['max_nodes']}")
+    print(f"  NROS_SUBSCRIPTION_BUFFER_SIZE {rec['default_rx_buf_size']}")
+    print()
+    print("measured on the board:")
+    cap = rec["arena_capacity"]
+    used = rec["arena_used"]
+    print(f"  arena capacity                {cap}")
+    print(f"  arena used                    {used}", end="")
+    if cap:
+        print(f"   ({100.0 * used / cap:.1f}%)")
+    else:
+        print()
+    print(f"  arena allocations             {rec['alloc_count']}")
+    print(f"  last allocation               {rec['last_alloc_size']} bytes")
+
+    if cap and cap != rec["arena_size"]:
+        print()
+        print(
+            f"  NOTE: the executor was handed {cap} bytes but the image compiled\n"
+            f"  {rec['arena_size']}. Both are legitimate -- the arena's placement is the\n"
+            "  caller's choice (issue 0900) -- but size against the one in use."
+        )
+
+    if rec["failed_alloc_size"]:
+        print()
+        print(
+            f"ARENA EXHAUSTED: an allocation of {rec['failed_alloc_size']} bytes did not fit,\n"
+            f"short by {rec['failed_alloc_shortfall']} bytes.\n"
+            "\n"
+            f"  set NROS_EXECUTOR_ARENA_SIZE >= {cap + rec['failed_alloc_shortfall']}\n"
+            "  (Zephyr: CONFIG_NROS_EXECUTOR_ARENA_SIZE)\n"
+            "\n"
+            "That is the FIRST failure, which is the one that explains the boot;\n"
+            "later allocations may also have failed as a consequence."
+        )
+        return 1
+
+    if stage < 4:
+        print()
+        print(
+            "Registration did NOT complete, and the arena is not why.\n"
+            "Look for a pool count instead: a full pool fails at registration\n"
+            "with ExecutorFull rather than in the arena."
+        )
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Decode the nano-ros boot self-report out of a target memory dump."
+    )
+    ap.add_argument("elf", type=Path, help="the image the board is running")
+    ap.add_argument("dump", type=Path, nargs="?", help="memory dumped from the target")
+    ap.add_argument(
+        "--addr-only",
+        action="store_true",
+        help="print '<addr> <len>' for a pyocd savemem line, and exit",
+    )
+    args = ap.parse_args()
+
+    if not args.elf.is_file():
+        raise SystemExit(f"{args.elf}: not a file")
+
+    addr, size = resolve_symbol(args.elf)
+    if args.addr_only:
+        print(f"0x{addr:08x} {size}")
+        return 0
+
+    if args.dump is None:
+        ap.error("a dump is required unless --addr-only is given")
+    if not args.dump.is_file():
+        raise SystemExit(f"{args.dump}: not a file")
+
+    return report(decode(args.dump.read_bytes()))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -111,7 +111,7 @@ POOL_CLASSES = {5, 12, 14, 15, 17}
 # way and a call would be a cycle. See SubscriberAllocReport's own doc comment.
 ALLOC_SYMBOL = "NROS_SUBSCRIBER_ALLOC_REPORT"
 ALLOC_MAGIC = 0x53554241  # "SUBA"
-ALLOC_VERSION = 3
+ALLOC_VERSION = 4
 ALLOC_FIELDS = (
     "magic",
     "version",
@@ -129,6 +129,8 @@ ALLOC_FIELDS = (
     "keyexpr_cap",
     "zpico_err",
     "buffer_taken",
+    "zpico_exit",
+    "zpico_ret",
 )
 # Assigned by `zpico_err_class` in the zenoh shim. The variant is recorded on
 # the NEAR side of the C ABI because crossing it collapses Generic and Session
@@ -138,6 +140,17 @@ ZPICO_ERR = {
     0: "(none -- the declare succeeded)",
     1: "Generic", 2: "Config", 3: "Session", 4: "Task", 5: "KeyExpr",
     6: "Full", 7: "Invalid", 8: "Publish", 9: "NotOpen", 10: "Timeout",
+}
+
+# Exit markers stamped by `zpico_declare_subscriber_ring` in the C shim.
+ZPICO_EXIT = {
+    0: "stamped NOTHING -- the function did not run, or ran a path with no marker",
+    1: "session not open",
+    2: "bad ring descriptor",
+    3: "the zpico subscriber table is full",
+    4: "zenoh-pico rejected the keyexpr",
+    5: "z_declare_subscriber itself failed (zpico_ret carries its code)",
+    6: "success",
 }
 
 ALLOC_REFUSAL = {
@@ -376,6 +389,19 @@ def report_alloc(rec: dict[str, int]) -> int:
             "  Raise NROS_KEYEXPR_STRING_SIZE (note: currently fails to compile,\n"
             "  service.rs hardcodes 257)."
         )
+    zx = rec["zpico_exit"]
+    if rec["zpico_err"] or zx:
+        zr = rec["zpico_ret"]
+        zr_s = zr - (1 << 32) if zr >= (1 << 31) else zr
+        print(f"  zpico declare exit              {zx} -- {ZPICO_EXIT.get(zx, 'unknown')}")
+        if zx == 5:
+            print(f"  z_declare_subscriber returned   {zr_s}")
+        elif zx == 0:
+            print(
+                "  The caller saw an error it believes came from this function,\n"
+                "  and the function stamped no exit. Either it never ran, or the\n"
+                "  error came from somewhere else."
+            )
     ze = rec["zpico_err"]
     if ze:
         print(f"  zpico declare returned          {ZPICO_ERR.get(ze, f'unknown {ze}')}")

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -111,7 +111,7 @@ POOL_CLASSES = {5, 12, 14, 15, 17}
 # way and a call would be a cycle. See SubscriberAllocReport's own doc comment.
 ALLOC_SYMBOL = "NROS_SUBSCRIBER_ALLOC_REPORT"
 ALLOC_MAGIC = 0x53554241  # "SUBA"
-ALLOC_VERSION = 6
+ALLOC_VERSION = 7
 ALLOC_FIELDS = (
     "magic",
     "version",
@@ -131,8 +131,6 @@ ALLOC_FIELDS = (
     "buffer_taken",
     "zpico_exit",
     "zpico_ret",
-    "inner_step",
-    "inner_ret",
     "heap_used",
     "heap_peak",
     "heap_capacity",
@@ -148,24 +146,6 @@ ZPICO_ERR = {
 }
 
 # Exit markers stamped by `zpico_declare_subscriber_ring` in the C shim.
-# Steps of zenoh-pico's `_z_register_subscriber`, from the nano-ros patch in
-# zenoh-pico/src/net/primitives.c.
-INNER_STEP = {
-    0: "did not run",
-    1: "keyexpr prefix declaration (_z_declared_keyexpr_declare_non_wild_prefix)",
-    2: "session sync-group notifier",
-    3: "subscriber sync-group notifier",
-    4: "subscription registration (_z_register_subscription returned NULL)",
-    5: "the Declare send (_z_send_declare)",
-    6: "success",
-    10: "entered _z_declare_subscriber; no later step stamped",
-    11: "_z_sync_group_create failed",
-    12: "_z_register_subscriber failed without stamping a step",
-    20: "_z_sync_group_create: z_malloc returned NULL (kernel heap)",
-    21: "_z_sync_group_create: _z_sync_group_state_create failed",
-    22: "_z_sync_group_create: rc_new returned NULL (kernel heap)",
-}
-
 ZPICO_EXIT = {
     0: "stamped NOTHING -- the function did not run, or ran a path with no marker",
     1: "session not open",
@@ -442,11 +422,6 @@ def report_alloc(rec: dict[str, int]) -> int:
         print(f"  zpico declare exit              {zx} -- {ZPICO_EXIT.get(zx, 'unknown')}")
         if zx == 5:
             print(f"  z_declare_subscriber returned   {zr_s}")
-            ist = rec["inner_step"]
-            ir = rec["inner_ret"]
-            ir_s = ir - (1 << 32) if ir >= (1 << 31) else ir
-            print(f"  _z_register_subscriber step     {ist} -- {INNER_STEP.get(ist, 'unknown')}")
-            print(f"  that step returned              {ir_s}")
         elif zx == 0:
             print(
                 "  The caller saw an error it believes came from this function,\n"

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -104,7 +104,37 @@ ERR_TRANSPORT = {
 POOL_CLASSES = {5, 12, 14, 15, 17}
 
 
-def resolve_symbol(elf: Path) -> tuple[int, int]:
+# --- the subscriber payload-class record (packages/rmw/zenoh/nros-rmw-zenoh) --
+#
+# A SECOND symbol, because the crate that owns these facts cannot call into the
+# boot report: nros-node depends on nros-rmw-zenoh, so the edge runs the other
+# way and a call would be a cycle. See SubscriberAllocReport's own doc comment.
+ALLOC_SYMBOL = "NROS_SUBSCRIBER_ALLOC_REPORT"
+ALLOC_MAGIC = 0x53554241  # "SUBA"
+ALLOC_VERSION = 1
+ALLOC_FIELDS = (
+    "magic",
+    "version",
+    "struct_size",
+    "refusal",
+    "rx_hint",
+    "largest_payload_class",
+    "small_class_ceiling",
+    "max_large_subscribers",
+    "subscriber_large_size",
+    "subscriber_buffer_size",
+    "small_taken",
+    "large_taken",
+)
+ALLOC_REFUSAL = {
+    0: "none -- every subscription got a payload block",
+    1: "the hint is above EVERY class, so it has nowhere legal to go",
+    2: "the LARGE class is full (MAX_LARGE_SUBSCRIBERS)",
+    3: "the SMALL class is full (ZPICO_MAX_SUBSCRIBERS)",
+}
+
+
+def resolve_symbol(elf: Path, symbol: str = SYMBOL) -> tuple[int, int]:
     """Address and size of the record, from the ELF's symbol table.
 
     `nm` rather than a parser, because every toolchain that produced one of
@@ -126,26 +156,26 @@ def resolve_symbol(elf: Path) -> tuple[int, int]:
         for line in out.stdout.splitlines():
             parts = line.split()
             # "<addr> <size> <type> <name>" -- the size column is why -S.
-            if len(parts) == 4 and parts[3] == SYMBOL:
+            if len(parts) == 4 and parts[3] == symbol:
                 return int(parts[0], 16), int(parts[1], 16)
         # The tool worked and the symbol is not there. Say so rather than
         # trying the next tool and blaming its absence.
         raise SystemExit(
-            f"{elf}: no `{SYMBOL}` symbol.\n"
+            f"{elf}: no `{symbol}` symbol.\n"
             "The image was built WITHOUT the boot report. Rebuild with\n"
             "  NROS_BOOT_REPORT=1        (Zephyr: CONFIG_NROS_BOOT_REPORT=y)"
         )
     raise SystemExit("no usable `nm` found (tried nm, arm-zephyr-eabi-nm, llvm-nm)")
 
 
-def decode(blob: bytes) -> dict[str, int]:
-    want = len(FIELDS) * 4
+def decode(blob: bytes, fields: tuple[str, ...] = FIELDS) -> dict[str, int]:
+    want = len(fields) * 4
     if len(blob) < want:
         raise SystemExit(
             f"dump is {len(blob)} bytes, need at least {want} for one record"
         )
-    values = struct.unpack_from(f"<{len(FIELDS)}I", blob, 0)
-    return dict(zip(FIELDS, values, strict=True))
+    values = struct.unpack_from(f"<{len(fields)}I", blob, 0)
+    return dict(zip(fields, values, strict=True))
 
 
 def report(rec: dict[str, int]) -> int:
@@ -287,12 +317,76 @@ def report(rec: dict[str, int]) -> int:
     return 0
 
 
+def report_alloc(rec: dict[str, int]) -> int:
+    """Print the subscriber payload-class record."""
+    if rec["magic"] != ALLOC_MAGIC:
+        print(
+            f"NO ALLOC RECORD: magic is 0x{rec['magic']:08x}, expected "
+            f"0x{ALLOC_MAGIC:08x}.\n"
+            "alloc_payload_block was never called, so no subscription got as far\n"
+            "as asking for a payload block.",
+            file=sys.stderr,
+        )
+        return 2
+    if rec["version"] != ALLOC_VERSION:
+        print(f"alloc record version {rec['version']}, this script decodes "
+              f"{ALLOC_VERSION}.", file=sys.stderr)
+        return 2
+
+    print("payload classes, as compiled:")
+    print(f"  SUBSCRIBER_BUFFER_SIZE (small)  {rec['subscriber_buffer_size']}")
+    print(f"  SMALL_CLASS_CEILING             {rec['small_class_ceiling']}")
+    print(f"  SUBSCRIBER_LARGE_SIZE           {rec['subscriber_large_size']}")
+    print(f"  MAX_LARGE_SUBSCRIBERS           {rec['max_large_subscribers']}")
+    print(f"  LARGEST_PAYLOAD_CLASS           {rec['largest_payload_class']}")
+    if rec["max_large_subscribers"] == 0:
+        print(
+            "  NOTE: no large slots, so the large class does not exist and the\n"
+            "  ceiling is the small block. Any hint above it is refused."
+        )
+    print()
+    print("measured on the board:")
+    print(f"  small blocks taken              {rec['small_taken']}")
+    print(f"  large blocks taken              {rec['large_taken']}")
+    print(f"  last hint seen                  {rec['rx_hint']}")
+    print()
+    r = rec["refusal"]
+    print(f"refusal    {r}  {ALLOC_REFUSAL.get(r, 'unknown')}")
+    if r == 0:
+        return 0
+    print()
+    if r == 1:
+        print(
+            f"  A subscription asked for {rec['rx_hint']} bytes and the largest class\n"
+            f"  is {rec['largest_payload_class']}. Raise NROS_SUBSCRIBER_LARGE_SIZE and give the\n"
+            "  image large slots (NROS_MAX_LARGE_SUBSCRIBERS), or lower the type's bound."
+        )
+    elif r == 2:
+        print(
+            f"  {rec['large_taken']} large blocks were taken and MAX_LARGE_SUBSCRIBERS is\n"
+            f"  {rec['max_large_subscribers']}. Raise NROS_MAX_LARGE_SUBSCRIBERS."
+        )
+    else:
+        print(
+            f"  {rec['small_taken']} small blocks were taken. Compare that against the number\n"
+            "  of subscriptions the image DECLARES: if it is higher, something\n"
+            "  other than the application is taking blocks, and the derivation\n"
+            "  from the entity inventory is short by that many."
+        )
+    return 1
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         description="Decode the nano-ros boot self-report out of a target memory dump."
     )
     ap.add_argument("elf", type=Path, help="the image the board is running")
     ap.add_argument("dump", type=Path, nargs="?", help="memory dumped from the target")
+    ap.add_argument(
+        "--alloc",
+        action="store_true",
+        help="decode the subscriber payload-class record instead of the boot report",
+    )
     ap.add_argument(
         "--addr-only",
         action="store_true",
@@ -303,7 +397,8 @@ def main() -> int:
     if not args.elf.is_file():
         raise SystemExit(f"{args.elf}: not a file")
 
-    addr, size = resolve_symbol(args.elf)
+    sym = ALLOC_SYMBOL if args.alloc else SYMBOL
+    addr, size = resolve_symbol(args.elf, sym)
     if args.addr_only:
         print(f"0x{addr:08x} {size}")
         return 0
@@ -313,7 +408,10 @@ def main() -> int:
     if not args.dump.is_file():
         raise SystemExit(f"{args.dump}: not a file")
 
-    return report(decode(args.dump.read_bytes()))
+    blob = args.dump.read_bytes()
+    if args.alloc:
+        return report_alloc(decode(blob, ALLOC_FIELDS))
+    return report(decode(blob))
 
 
 if __name__ == "__main__":

--- a/scripts/read-boot-report.py
+++ b/scripts/read-boot-report.py
@@ -111,7 +111,7 @@ POOL_CLASSES = {5, 12, 14, 15, 17}
 # way and a call would be a cycle. See SubscriberAllocReport's own doc comment.
 ALLOC_SYMBOL = "NROS_SUBSCRIBER_ALLOC_REPORT"
 ALLOC_MAGIC = 0x53554241  # "SUBA"
-ALLOC_VERSION = 1
+ALLOC_VERSION = 3
 ALLOC_FIELDS = (
     "magic",
     "version",
@@ -125,12 +125,27 @@ ALLOC_FIELDS = (
     "subscriber_buffer_size",
     "small_taken",
     "large_taken",
+    "keyexpr_len",
+    "keyexpr_cap",
+    "zpico_err",
+    "buffer_taken",
 )
+# Assigned by `zpico_err_class` in the zenoh shim. The variant is recorded on
+# the NEAR side of the C ABI because crossing it collapses Generic and Session
+# into one ConnectionFailed and then into an indistinguishable
+# Backend("rmw_ret error") -- issues 0870 and 0465.
+ZPICO_ERR = {
+    0: "(none -- the declare succeeded)",
+    1: "Generic", 2: "Config", 3: "Session", 4: "Task", 5: "KeyExpr",
+    6: "Full", 7: "Invalid", 8: "Publish", 9: "NotOpen", 10: "Timeout",
+}
+
 ALLOC_REFUSAL = {
     0: "none -- every subscription got a payload block",
     1: "the hint is above EVERY class, so it has nowhere legal to go",
     2: "the LARGE class is full (MAX_LARGE_SUBSCRIBERS)",
     3: "the SMALL class is full (ZPICO_MAX_SUBSCRIBERS)",
+    4: "the METADATA slots are full (ZPICO_MAX_SUBSCRIBERS) -- guarded FIRST",
 }
 
 
@@ -346,14 +361,40 @@ def report_alloc(rec: dict[str, int]) -> int:
         )
     print()
     print("measured on the board:")
+    print(f"  metadata slots taken            {rec['buffer_taken']}")
     print(f"  small blocks taken              {rec['small_taken']}")
     print(f"  large blocks taken              {rec['large_taken']}")
     print(f"  last hint seen                  {rec['rx_hint']}")
     print()
+    kl, kc = rec["keyexpr_len"], rec["keyexpr_cap"]
+    print(f"  last keyexpr length             {kl} of {kc}")
+    if kc and kl >= kc:
+        print(
+            "  TRUNCATED: the keyexpr filled its buffer exactly. `to_key_wildcard`\n"
+            "  discards the overflow, so this is a silently shortened key, and the\n"
+            "  length guard cannot see it -- a truncated string always fits.\n"
+            "  Raise NROS_KEYEXPR_STRING_SIZE (note: currently fails to compile,\n"
+            "  service.rs hardcodes 257)."
+        )
+    ze = rec["zpico_err"]
+    if ze:
+        print(f"  zpico declare returned          {ZPICO_ERR.get(ze, f'unknown {ze}')}")
+        if ze == 3:
+            print(
+                "  Session -- the zenoh session was NOT OPEN when the declare ran.\n"
+                "  Nothing about sizing; the transport went away mid-registration.\n"
+                "  This exit has no printk, which is why the console showed nothing."
+            )
+        elif ze == 1:
+            print("  Generic -- z_declare_subscriber itself failed; zpico printk carries the code.")
+        elif ze == 6:
+            print("  Full -- the zpico subscriber table is exhausted (ZPICO_MAX_SUBSCRIBERS).")
+    print()
+
     r = rec["refusal"]
     print(f"refusal    {r}  {ALLOC_REFUSAL.get(r, 'unknown')}")
     if r == 0:
-        return 0
+        return 1 if ze else 0
     print()
     if r == 1:
         print(
@@ -365,6 +406,14 @@ def report_alloc(rec: dict[str, int]) -> int:
         print(
             f"  {rec['large_taken']} large blocks were taken and MAX_LARGE_SUBSCRIBERS is\n"
             f"  {rec['max_large_subscribers']}. Raise NROS_MAX_LARGE_SUBSCRIBERS."
+        )
+    elif r == 4:
+        print(
+            f"  {rec['buffer_taken']} metadata slots were taken and the pool is that size.\n"
+            "  Compare against the number of subscriptions the image DECLARES: if\n"
+            "  the image needed MORE, something other than the application is\n"
+            "  taking slots, and the derivation of NROS_RMW_SUBSCRIBER_SLOTS from\n"
+            "  COUNT_SUBSCRIPTION is short by that many."
         )
     else:
         print(

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1075,6 +1075,29 @@ config NROS_SUBSCRIPTION_BUFFER_SIZE
       NROS_EXECUTOR_ARENA_SIZE must move the two together; leaving both to
       derive is the shape that cannot disagree.
 
+config NROS_BOOT_REPORT
+    bool "Write a boot self-report into RAM"
+    default n
+    help
+      The image keeps a fixed 60-byte record in RAM describing itself: the
+      knobs it was COMPILED with, how far boot got, and the arena allocation
+      that did not fit. Read it back with a debugger after halting the core:
+
+        python3 scripts/read-boot-report.py build/zephyr/zephyr.elf dump.bin
+
+      For boards where no log sink reaches a human. On the MR-CANHUBK344 the
+      console UART is not wired and the second UART carries the zenoh serial
+      transport, so both of issue 0900's arena diagnostics -- the two messages
+      written specifically to explain an arena failure -- go nowhere.
+
+      Unlike a log, this survives the failure it reports. An under-sized arena
+      halts DURING entity creation, before the first spin, so the advisory
+      never prints; the record's last stage and failed allocation are still
+      there to be read.
+
+      OFF by default: an image that does not enable it is byte-identical to one
+      built before the feature existed.
+
 config NROS_EXECUTOR_MAX_SC
     int "Maximum scheduling-context slots per executor"
     default 8

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -721,6 +721,17 @@ function(nros_set_cargo_env_from_kconfig)
         set(ENV{${_knob}} "${NROS_RESOLVED_${_knob}}")
     endforeach()
 
+    # phase-412 -- the boot self-report. A BOOL, so it is exported directly
+    # rather than through the resolve ladder above: that machinery exists to
+    # carry a tri-state (env > Kconfig > derived, with -1 and 0 as sentinels for
+    # "derive it"), and a bool has no derive state to represent. Passing it
+    # through would mean inventing a third meaning for a sentinel, which is the
+    # shape that has already produced three double-resolution defects in this
+    # file.
+    if(CONFIG_NROS_BOOT_REPORT)
+        set(ENV{NROS_BOOT_REPORT} "1")
+    endif()
+
     if(CONFIG_NROS_RMW_ZENOH)
         # zpico-sys build.rs needs the nros-platform-cffi header dir. In-tree dev
         # gets it from .env/direnv; set it from the known module path so a

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -424,6 +424,51 @@ function(nros_resolve_knobs)
     _nros_resolve_derivable_knob(NROS_MAX_QUERYABLES
         "${CONFIG_NROS_MAX_QUERYABLES}" NROS_DERIVED_MAX_QUERYABLES
         "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
+    # phase-412 -- the POSIX mutex pool bounds the subscriber count, and nothing
+    # said so until an island image spent days failing at the eleventh
+    # subscription.
+    #
+    # zenoh-pico's Zephyr port creates one pthread mutex per subscriber sync
+    # group (`_z_declare_subscriber` -> `_z_sync_group_create` ->
+    # `_z_sync_group_state_create` -> `pthread_mutex_init`), and Zephyr's POSIX
+    # mutex pool is STATIC. Past it, pthread_mutex_init fails, and the failure
+    # reaches the application as an opaque -100 "transport error" naming
+    # nothing, on a board whose console is not wired.
+    #
+    # DELIBERATELY NOT DERIVED. The remaining consumers are zenoh-pico's own
+    # (session mutexes, liveliness subscribers, fifo/ring channels, the
+    # scheduler, cancellation tokens), so a derivation would encode that crate's
+    # internal structure into this build and break silently whenever upstream
+    # adds a sync group. A floor with a measured constant is honest about being
+    # a bound rather than a model.
+    #
+    # MEASURED on mr-canhubk344, 2026-09-04: 10 subscribers boot at 32, 11 fail
+    # at 32 and boot at 64. One mutex per subscriber, so the fixed overhead is
+    # 22. The +4 is headroom for a subscriber added without re-measuring.
+    if(CONFIG_NROS_RMW_ZENOH AND DEFINED NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS
+       AND NOT "${NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS}" STREQUAL "")
+        set(_nros_zpico_mutex_overhead 22)
+        math(EXPR _nros_mutex_floor
+             "${NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS} + ${_nros_zpico_mutex_overhead} + 4")
+        if(DEFINED CONFIG_MAX_PTHREAD_MUTEX_COUNT
+           AND CONFIG_MAX_PTHREAD_MUTEX_COUNT LESS _nros_mutex_floor)
+            message(FATAL_ERROR
+                "CONFIG_MAX_PTHREAD_MUTEX_COUNT=${CONFIG_MAX_PTHREAD_MUTEX_COUNT} is too "
+                "small for ${NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS} subscribers.\n"
+                "\n"
+                "  need at least ${_nros_mutex_floor}"
+                " = ${NROS_RESOLVED_NROS_RMW_SUBSCRIBER_SLOTS} subscribers"
+                " + ${_nros_zpico_mutex_overhead} zenoh-pico fixed + 4 headroom\n"
+                "\n"
+                "zenoh-pico takes one pthread mutex per subscriber sync group and "
+                "Zephyr's POSIX mutex pool is static. Past it pthread_mutex_init "
+                "fails, and by the time that crosses the C ABI it is an opaque "
+                "-100 transport error that names nothing.\n"
+                "\n"
+                "Set CONFIG_MAX_PTHREAD_MUTEX_COUNT=${_nros_mutex_floor} or higher.")
+        endif()
+    endif()
+
     # phase-412 W2 -- one node per declared component. The one under-count is a
     # bridge, whose two nodes are runtime strings declared nowhere; that path
     # now names this knob when the table fills, which is what makes deriving it

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -721,17 +721,6 @@ function(nros_set_cargo_env_from_kconfig)
         set(ENV{${_knob}} "${NROS_RESOLVED_${_knob}}")
     endforeach()
 
-    # phase-412 -- the boot self-report. A BOOL, so it is exported directly
-    # rather than through the resolve ladder above: that machinery exists to
-    # carry a tri-state (env > Kconfig > derived, with -1 and 0 as sentinels for
-    # "derive it"), and a bool has no derive state to represent. Passing it
-    # through would mean inventing a third meaning for a sentinel, which is the
-    # shape that has already produced three double-resolution defects in this
-    # file.
-    if(CONFIG_NROS_BOOT_REPORT)
-        set(ENV{NROS_BOOT_REPORT} "1")
-    endif()
-
     if(CONFIG_NROS_RMW_ZENOH)
         # zpico-sys build.rs needs the nros-platform-cffi header dir. In-tree dev
         # gets it from .env/direnv; set it from the known module path so a
@@ -1151,6 +1140,23 @@ function(nros_cargo_build)
     foreach(_knob IN LISTS NROS_RESOLVED_KNOBS)
         list(APPEND _nros_knob_env "${_knob}=${NROS_RESOLVED_${_knob}}")
     endforeach()
+
+    # phase-412 -- the boot self-report. A BOOL, so it does not go through the
+    # resolve ladder: that machinery carries a tri-state (env > Kconfig >
+    # derived, with -1 and 0 as sentinels for "derive it") and a bool has no
+    # derive state to represent. Putting one through would mean inventing a
+    # third meaning for a sentinel, which is the shape that has already produced
+    # three double-resolution defects in this file.
+    #
+    # But it rides THIS list, not `set(ENV{})`, for the reason the comment below
+    # gives: the cargo that reads it is spawned by a custom target at BUILD
+    # time, so a configure-time environment never reaches it. Written the wrong
+    # way first, and the image linked without the record while every cmake
+    # variable said it was on -- the delivery-failure class phase-412 W4 exists
+    # for, arriving in the work that was meant to instrument it.
+    if(CONFIG_NROS_BOOT_REPORT)
+        list(APPEND _nros_knob_env "NROS_BOOT_REPORT=1")
+    endif()
 
     # phase-351 W5 — the board FACTS + SITE config ride the same command, for
     # the same reason the knobs do: Zephyr's cargo is spawned by this custom


### PR DESCRIPTION
Twenty-two commits from the phase-412 campaign, all found or verified on an MR-CANHUBK344.

## The instrument

The island reached FirstSpin on no run and no channel could say why. The board has one UART and zenoh owns it, so every diagnostic written to explain an arena or entity failure went to a sink that does not exist (issue 1036). `boot_report` is a fixed RAM record -- `#[no_mangle]` statics read back by halting the core, address resolved from the ELF -- because the failures halt before any stream could carry them. `scripts/read-boot-report.py` decodes it and `scripts/check-boot-report-layout.py` keeps the Rust struct, the snapshot and the decoder in agreement.

## Three root causes it found

* An **undeclared eleventh subscription**. `mrm_handler` creates seven and its `ENTITIES` list declared six, so every pool derived from that list was short by one. The eleventh hit the buffer-index guard, returned `SubscriberCreationFailed`, and the `_ =>` arm collapsed it into `-100 Backend("rmw_ret error")`.
* **`CONFIG_MAX_PTHREAD_MUTEX_COUNT=32`.** zenoh-pico takes one pthread mutex per subscriber sync group. Ten subscribers boot at 32; eleven fail at 32 and reach FirstSpin at 64. The configure now fails with the number to write instead of the image failing at boot.
* **The rlsf free path credited nothing.** `used()` was cumulative-allocated: 395,132 bytes reported in a 94,720 byte arena, 417 percent. Charging the usable size on alloc and crediting it before deallocate makes the real peak 75,480, or 79.7 percent. Three tests, two of which fail without the fix.

## The wiring, so the count stops being hand-maintained

A launch file cannot say a node creates seven subscriptions, and `<remap>` only renames a topic the node already has. play_launch supplies a contract sidecar for exactly that, and the resolver folds it into the SystemModel, whose `structure.topics` is what `count_callbacks` counts. `nros ws entity-inventory` gains `--model`, and takes the larger of the model and the declaration per component and per kind -- neither source is complete, because the model has no timer entity and the declaration is what was wrong.

Measured on the island with the recovered subscription deliberately deleted from the declaration:

```
metadata alone      28 entities, 14 callback slots
metadata + model    29 entities, 15 callback slots
```

Two cmake fixes went with it. `nano_ros_add_executable` never parsed `BRINGUP`, so every caller reaching the entry through the ament verb was pushed back onto the `MODEL` phase-405 W4 retired -- and an unparsed keyword does not error, it joins `SOURCES`. And nothing passed `--model` to the inventory, which is a capability nobody could observe.

## Two reds that were on main

Both reproduced on a clean `origin/main` worktree before being fixed here: `nros_platform_api::task` was alloc-gated while the executor calls its stack query on every feature set, and `check-api-parity` had no ledger row for `Executor::set_min_stack_headroom_bytes`.

## Falsified along the way

`transient_local` QoS, `NROS_ZEPHYR_HEAP_SIZE`, `CONFIG_HEAP_MEM_POOL_SIZE`, `Z_BATCH_UNICAST_SIZE`, `Z_RX_CACHE_SIZE` (compiled out), and the payload-class allocator. Each was proposed, instrumented and killed by measurement.

## Still open

Issue 1036 stays open: no cell exercises the boot report on silicon, which is the same shape as the defect it was built to find. And `_z_sync_group_state_create` returns `-1` where the source predicts `-80`; the empirical fix is verified but that attribution is a loose end.

## Verification

`just ci gate` green (`check::cli-fresh`, `check::fast`, `check::build`, `check::api-parity`, `test-unit`, `test-lane-contracts`). `nros_rmw_cyclonedds_ros2_pubsub_e2e` failed twice under the 21-way parallel gate and passed solo and on re-run with none of its inputs touched; recorded as load flake, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EST8f2UDcrw2Ztm5eLTuMC