### PR TITLE
fix(#1057): the lane test read the DISPATCHER, not the recipe that runs

### DIFF
--- a/docs/issues/archived/1057-tier2-run-scope-declares-lanecoords-but-recipe-exports-none.md
+++ b/docs/issues/archived/1057-tier2-run-scope-declares-lanecoords-but-recipe-exports-none.md
@@ -2,7 +2,7 @@
 id: 1057
 title: "`ci_lane` unit test is RED on main: tier 2 declares `RunScope::LaneCoords`
   and `just ci matrix` no longer exports `NROS_TEST_COORDS`"
-status: open
+status: resolved
 type: bug
 area: ci, testing
 severity: high
@@ -59,3 +59,24 @@ owner and a written cause-so-far, not to guess which.
 `cargo nextest run -p nros-tests --lib -E 'test(recipes_run_the_scope_their_lane_declares)'`
 passes on `main`, and the assertion still fails if the export is removed from
 whichever recipe now carries it.
+
+## Resolution (2026-09-05)
+
+The first of the two possibilities: the export MOVED, and the test needed to
+follow the indirection. `_matrix-run` carries `NROS_TEST_COORDS` on both of its
+`just` invocations; nothing was dropped in the split.
+
+`recipes_run_the_scope_their_lane_declares` now follows a recipe's
+module-qualified private delegates before asserting, rather than hard-coding
+tier 2's inner name — so the next tier that grows a depth is covered by
+construction. A delegate that does not resolve fails the test (issue 0196's
+rule) instead of silently shortening the body it reads.
+
+Mutation-checked: removing every export from `_matrix-run` fails; renaming
+`_matrix-run` without updating the dispatcher fails.
+
+Noted while here, NOT fixed: the assertion is "the body mentions the variable",
+so removing one of the two exports in `_matrix-run` still passes. That is the
+assertion's existing granularity rather than something the fix narrowed, and
+tightening it to "every `just` invocation in the body carries it" is a separate
+change with its own blast radius across four tiers.

--- a/packages/testing/nros-tests/src/ci_lane.rs
+++ b/packages/testing/nros-tests/src/ci_lane.rs
@@ -539,6 +539,54 @@ mod tests {
         );
     }
 
+    /// One recipe's body: the `<name>:` / `<name> <args>:` header line through
+    /// the last line before the next column-0 non-blank one.
+    ///
+    /// Stopping at a column-0 COMMENT matters as much as at a recipe header:
+    /// that is where the next recipe's doc block starts, and the tier recipes
+    /// document each other constantly, so running past it would let a
+    /// neighbour's prose satisfy (or break) an assertion about this one.
+    fn recipe_body(text: &str, name: &str) -> Option<String> {
+        let mut lines = text.lines().skip_while(|l| {
+            !(l.starts_with(name) && l[name.len()..].starts_with([':', ' ']) && l.contains(':'))
+        });
+        let header = lines.next()?;
+        let mut body = String::from(header);
+        for l in lines {
+            if !l.is_empty() && !l.starts_with([' ', '\t']) {
+                break;
+            }
+            body.push('\n');
+            body.push_str(l);
+        }
+        Some(body)
+    }
+
+    /// The module-qualified PRIVATE recipes a body dispatches to, in order and
+    /// deduplicated: `just ci::_matrix-run` yields `_matrix-run`.
+    ///
+    /// Qualified-and-private is the whole filter. A qualified PUBLIC recipe
+    /// (`just check`) is a different lane with its own contract, and an
+    /// UNQUALIFIED private one (`just _lane-gate`) is a root recipe in a file
+    /// this test has not loaded — chasing either would widen what an assertion
+    /// about this recipe can accidentally read.
+    fn module_private_delegates(body: &str) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for token in body.split_whitespace() {
+            let Some((_, name)) = token.split_once("::") else {
+                continue;
+            };
+            let name = name.trim_end_matches([';', ')', '"', '\'']);
+            if !name.starts_with('_') || name.is_empty() {
+                continue;
+            }
+            if !out.iter().any(|n| n == name) {
+                out.push(name.to_string());
+            }
+        }
+        out
+    }
+
     /// Issue 0482 — the justfile recipe must set the `NROS_TEST_SCOPE` its lane
     /// declares, and must not build a NARROWER fixture lane than that run needs.
     ///
@@ -571,25 +619,37 @@ mod tests {
             let Some((text, name)) = tier.justfile_source() else {
                 continue;
             };
-            // The recipe body: from the `<name>:`/`<name> <args>:` line to the
-            // next line at column 0 that is not blank and not indented.
-            let mut lines = text.lines().skip_while(|l| {
-                !(l.starts_with(name) && l[name.len()..].starts_with([':', ' ']) && l.contains(':'))
-            });
-            let header = lines.next().unwrap_or_else(|| {
+            let mut body = recipe_body(&text, name).unwrap_or_else(|| {
                 panic!("justfile has no `{recipe}` recipe (gated by ci_tier_ladder_matches_justfile_recipes)")
             });
-            // Stop at the first column-0 non-blank line — including a comment,
-            // which is where the NEXT recipe's doc block starts. Running past it
-            // would let a neighbouring recipe's prose satisfy (or break) this
-            // assertion, and the tier recipes document each other constantly.
-            let mut body = String::from(header);
-            for l in lines {
-                if !l.is_empty() && !l.starts_with([' ', '\t']) {
-                    break;
-                }
+            // phase-410 split each tier's DEPTH into a fixed inner recipe --
+            // `matrix` is now a dispatcher whose body is a `case` over
+            // `just ci::_matrix-{run,build}` -- so the env the lane declares
+            // moved out of the body this test reads, and issue 1057 is the red
+            // that produced: a dispatcher can satisfy nothing and no assertion
+            // here could tell. Follow the dispatch instead of hard-coding tier
+            // 2's inner name, so the next tier that gains a depth is covered by
+            // construction.
+            //
+            // ONLY module-qualified private targets (`just <mod>::_<name>`) are
+            // followed: those are the dispatch targets and they live in the file
+            // already loaded. An unqualified `just _lane-gate` is a ROOT recipe
+            // in another file and is deliberately not chased.
+            //
+            // A named delegate that does not resolve is a FAILURE, not a skip
+            // (the issue-0196 rule): silently reading a shorter body is how this
+            // assertion would go quiet the next time a recipe is renamed.
+            for delegate in module_private_delegates(&body) {
+                let delegate_body = recipe_body(&text, &delegate).unwrap_or_else(|| {
+                    panic!(
+                        "`just {recipe}` dispatches to `{delegate}`, which does not exist in the \
+                         same justfile module. Either the recipe was renamed and the dispatcher \
+                         not updated, or this test is reading the wrong file -- both are the \
+                         defect, not a reason to skip:\n{body}"
+                    )
+                });
                 body.push('\n');
-                body.push_str(l);
+                body.push_str(&delegate_body);
             }
 
             let scope = lane.run_scope();


### PR DESCRIPTION
Closes #1057.

`ci_lane::tests::recipes_run_the_scope_their_lane_declares` has been red on main. Reproduced on a clean tree before touching anything:

```
Tier2 declares RunScope::LaneCoords but `just ci matrix` never exports
NROS_TEST_COORDS — the run would resolve every coordinate while the
preflight accepts a `lane=tier2` build
```

## The declaration and the recipe agree — the test was reading the wrong body

phase-410 split each tier's DEPTH into a fixed inner recipe, so `matrix` is now a `case` over `just ci::_matrix-{run,build}` and the export moved into `_matrix-run`. The recipe's own comment says why the split is shaped that way — *"so `check-lane-contracts` can walk each and prove its affordability claim"*. The Python gate was updated to walk them; this Rust test was not.

Nothing was dropped in the split, which was the issue's other hypothesis: `_matrix-run` carries `NROS_TEST_COORDS` on both of its `just` invocations.

## Why it matters more than one red test

`just check fast` runs no unit tests, and `test-unit` excludes `nros-tests` — so nothing pre-merge sees this. It fails where it costs the most, and an ejection from the queue is how anyone finds out.

## The fix

Follows the dispatch rather than hard-coding tier 2's inner name, so the next tier that grows a depth is covered by construction.

Only **module-qualified private** targets (`just <mod>::_<name>`) are chased. A qualified public one (`just check`) is a different lane with its own contract; an unqualified private one (`just _lane-gate`) is a root recipe in a file this test has not loaded. Following either would widen what an assertion about *this* recipe can accidentally read.

A named delegate that does not resolve is a **failure, not a skip** (issue 0196's rule) — silently reading a shorter body is exactly how this assertion would go quiet the next time a recipe is renamed.

Body extraction moved into `recipe_body` so the dispatcher and its delegates are parsed by one function instead of two spellings of the same scan.

## Verification

Mutation-checked three ways:

| mutation | result |
| --- | --- |
| remove every `NROS_TEST_COORDS` export from `_matrix-run` | FAILS |
| rename `_matrix-run` without updating the dispatcher | FAILS |
| unmodified tree | passes |

`just check fast` 217/217, `just test-lane-contracts` 17/17, all 12 `ci_lane` tests pass.

Left deliberately, and written into the archived issue: the assertion is "the body mentions the variable", so removing one of the two exports still passes. That is its existing granularity, not something this change narrowed; tightening it to "every `just` invocation in the body carries it" is a separate change across four tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP