### PR TITLE
fix(platform): the stack probe was gated behind alloc, breaking no_std

### DIFF
--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -2412,7 +2412,7 @@ impl<'s> Executor<'s> {
         if self.min_stack_headroom_bytes == 0 {
             return;
         }
-        let unused = nros_platform_api::task::stack_unused_bytes();
+        let unused = nros_platform_api::stack_unused_bytes();
         // 0 means the port does not instrument stacks, not that the stack is
         // full. Reporting a violation there would be a fault invented from an
         // absence of data.

--- a/packages/platform/nros-platform-api/src/lib.rs
+++ b/packages/platform/nros-platform-api/src/lib.rs
@@ -1091,3 +1091,28 @@ pub trait PlatformSerial {
     /// `usize::MAX` on error.
     fn write(h: Self::Handle, buf: *const u8, len: usize) -> usize;
 }
+
+/// Smallest number of bytes ever left unused on the CALLING task's stack, or
+/// `0` if this port does not instrument it.
+///
+/// Lives at the crate root, NOT in [`task`], because that module is
+/// `#[cfg(feature = "alloc")]` -- `PlatformTask` allocates its own storage --
+/// while this is a bare `extern "C"` query returning a `usize`. Gating it
+/// behind `alloc` made it unavailable on exactly the no_std targets whose
+/// stacks are worth watching, and broke the executor's stack-headroom rule
+/// on the Zephyr build.
+///
+/// The heap has had `heap_used_bytes` since RFC-0034 D7; this is the stack's
+/// counterpart. HEADROOM, not usage, and for the CALLING task only -- both
+/// kernels answer for self with no handle, and answering for an arbitrary
+/// task needs a native handle this ABI does not carry.
+///
+/// `0` means "not instrumented", not "no headroom".
+pub fn stack_unused_bytes() -> usize {
+    unsafe extern "C" {
+        fn nros_platform_task_stack_unused_bytes() -> usize;
+    }
+    // SAFETY: a plain query with no arguments and no state; every port either
+    // answers or returns 0.
+    unsafe { nros_platform_task_stack_unused_bytes() }
+}

--- a/packages/platform/nros-platform-api/src/task.rs
+++ b/packages/platform/nros-platform-api/src/task.rs
@@ -47,7 +47,6 @@ struct TaskAttr {
 const PRIORITY_INHERIT: i32 = i32::MIN;
 
 unsafe extern "C" {
-    fn nros_platform_task_stack_unused_bytes() -> usize;
     fn nros_platform_task_init(
         task: *mut c_void,
         attr: *mut c_void,
@@ -187,20 +186,4 @@ impl Drop for PlatformTask {
         //
         // `join` calls `mem::forget`, so the normal path never lands here.
     }
-}
-
-/// Smallest number of bytes ever left unused on the CALLING task's stack, or
-/// `0` if this port does not instrument it.
-///
-/// The heap has had `heap_used_bytes` since RFC-0034 D7; the stack had
-/// nothing, and stack overflow is how one component corrupts another's state.
-/// A tier asks this about ITSELF -- both kernels answer for the calling task
-/// with no handle, and answering for an arbitrary one needs a native handle
-/// this ABI does not carry.
-///
-/// `0` means "not instrumented", not "no headroom".
-pub fn stack_unused_bytes() -> usize {
-    // SAFETY: a plain query with no arguments and no state; every port either
-    // answers or returns 0.
-    unsafe { nros_platform_task_stack_unused_bytes() }
 }


### PR DESCRIPTION
**Main does not build for no_std targets.** My bug, from #432 + #455.

#432 put `stack_unused_bytes` in `nros_platform_api::task`, and #455's stack-headroom rule calls it unconditionally. That module is `#[cfg(feature = "alloc")]` — because `PlatformTask` allocates its own storage. The function is a bare `extern "C"` query returning a `usize` and needs no allocator at all.

```
error[E0433]: cannot find `task` in `nros_platform_api`
  note: found an item that was configured out
error: could not compile `nros-node` (lib)
```

That is the Zephyr image. Found by bumping the downstream ASI pin onto this main and watching the build fail — `cargo check -p nros-node --features std` never reaches it, because that config *has* alloc.

**The gate also defeated the purpose.** A stack-headroom probe unavailable on no_std is unavailable on exactly the targets whose stacks are worth watching: the ones with a few KiB and no MMU.

## Fix

Move it to the crate root, ungated, with the extern declaration beside it. No behaviour change on any config that already worked.

## Verification

All three configurations, rather than the one that happened to pass before:

```
cargo check -p nros-node                  # no_std   OK
cargo check -p nros-node --features alloc # alloc    OK
cargo test  -p nros-node --features std   # 321 + 5 passed, 0 failed
```

`cargo fmt` clean.