### PR TITLE
fix(zenoh-pico): INET6_ADDRSTRLEN fallback — unblocks the native fixture lane; W5.g attempted

### DIFF
--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -971,6 +971,43 @@ Net C/C++ API change: none. No function, no parameter, no generic in a header.
   the same time: `NROS_DECLARED_INFRA_QUERYABLES` must appear in the configure's
   `build.ninja`, where today it does not.
 
+  **ATTEMPTED 2026-09-05, and the recipe above does not work as written.** Ran
+  it; recording what it produced rather than an estimate, per this phase's own
+  rule.
+
+  `just build-test-fixtures lane=native` completes green (after two unrelated
+  breaks that had to be fixed first, below), and
+  `workspace-fixtures-build.sh linux rust` builds 21 entries — **through cargo,
+  producing zero CMake configures**. There is no `build.ninja` to inspect,
+  because the native workspace entries are cargo leaves. That also confirms
+  issue 0965's statement that "every entry in `examples/workspaces/` targets
+  Zephyr or FVP, so there is no host entry to configure": the directories
+  `native_entry` and `native_rust_params_entry` exist, which makes the claim
+  look wrong, and they are cargo-built, which makes it right.
+
+  So the measurement needs a CMake-configured workspace image, and on this tree
+  that means a Zephyr or FVP cross build — not `lane=native`. The instruction
+  above should be rewritten for whoever picks this up.
+
+  What IS measurable now, and consistent with the expectation above:
+  `NROS_DECLARED_INFRA_QUERYABLES` appears in **0 of 26** existing workspace
+  `build.ninja` files, as do `NROS_DERIVED_MAX_QUERYABLES` and
+  `NROS_DERIVED_MAX_SUBSCRIBERS`. Those configures are stale, so this is
+  consistent-with rather than proof-of; it is not a substitute for the A/B.
+
+  **Two blockers were cleared to get this far**, both unrelated to W5:
+
+  * 24 `build.ninja` still referenced `sertype_min.cpp`, retired on main by
+    `6ab5ab7db` (issue 0976). Re-configured 21 in place (`cmake <build-dir>`,
+    the documented fix rather than a wipe); the other 3 are synthesised
+    workspace dirs with no committed root `CMakeLists.txt`.
+  * zenoh-pico did not compile for FreeRTOS + lwIP:
+    `_z_ipv6_port_to_endpoint` uses `INET6_ADDRSTRLEN` unconditionally while
+    `lwip/inet.h` defines it only under `LWIP_IPV6`. Compile-check units u10
+    (`freertos_firmware`) and u11 (`orch_tiers_freertos`) died Error 101. Fixed
+    in the fork (`jerry73204/zenoh-pico` `nano-ros`, `49b4e635`) and the pin
+    bumped forward.
+
 ### Open, and deliberately not assumed away
 
 **Hand-written `main`s.** They create entities at runtime, have no generated


### PR DESCRIPTION
Two commits: a submodule fix that unblocks `just build-test-fixtures lane=native`, and the W5.g attempt it enabled.

## The submodule fix

`_z_ipv6_port_to_endpoint` uses `INET6_ADDRSTRLEN` unconditionally, but nothing guarantees it: `<arpa/inet.h>` is included only for `ZENOH_LINUX/MACOS/BSD`, and the lwIP path gets `lwip/inet.h`, which defines `INET_ADDRSTRLEN` unconditionally and `INET6_ADDRSTRLEN` **only under `LWIP_IPV6`**.

With IPv6 off, the IPv4 helper twelve lines up compiles and only the IPv6 one fails — which is why it survived until an image needed that translation unit. It killed compile-check units u10 (`freertos_firmware`) and u11 (`orch_tiers_freertos`) with Error 101.

Fixed in `jerry73204/zenoh-pico` `nano-ros` (`49b4e635`, fast-forward), pin bumped forward.

**How this nearly went wrong, recorded because it matters:** my first probe built `thumbv7m-none-eabi`, which compiles clean **with or without** the change — it would have "confirmed" a fix for a failure it never reproduced. I reverted the patch and didn't commit until the real fixture reproduced the error:

| | exit | INET6 errors |
|---|---:|---:|
| `freertos_firmware` before | 101 | 2 |
| after | **0** | **0** |

## W5.g: attempted, and the recipe doesn't work as written

Recorded rather than estimated, per the phase's own rule.

`lane=native` now completes green, and `workspace-fixtures-build.sh linux rust` builds 21 entries **through cargo, producing zero CMake configures**. There's no `build.ninja` to inspect — the native workspace entries are cargo leaves.

That also settles **#0965**'s claim that there's no host entry to configure. `native_entry` and `native_rust_params_entry` exist, which makes it *look* wrong — I doubted it on that basis — and they're cargo-built, which makes it right. Recorded so the next reader doesn't repeat my doubt.

Measurable now and consistent with the expectation: `NROS_DECLARED_INFRA_QUERYABLES` appears in **0 of 26** existing workspace `build.ninja`, as do the two `NROS_DERIVED_*` knobs. Those are stale configures, so it's consistent-with, not proof-of — **not** a substitute for the A/B, which needs a Zephyr/FVP cross build.

## Also cleared

24 `build.ninja` still referenced `sertype_min.cpp`, retired by `6ab5ab7db` (#0976). Re-configured 21 in place — `cmake <build-dir>`, the documented fix, not a wipe. The other 3 are synthesised workspace dirs with no committed root `CMakeLists.txt`.

`just check fast`: 213/213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)