### PR TITLE
fix(#1080): the stack probe allocates nothing, so it must not be alloc-gated

### DIFF
--- a/docs/issues/1080-stack-unused-bytes-trapped-behind-alloc-gate.md
+++ b/docs/issues/1080-stack-unused-bytes-trapped-behind-alloc-gate.md
@@ -1,0 +1,102 @@
+---
+id: 1080
+title: "`stack_unused_bytes` allocates nothing but lives in an `alloc`-gated module, so the new stack-headroom rule breaks every `no_std`-without-`alloc` image"
+status: open
+type: bug
+area: platform, core
+severity: high
+found: 2026-09-05
+related: [1075, 0589, phase-359]
+---
+
+# A gate that belongs to the neighbours
+
+## Symptom
+
+Every Zephyr cortex-m fixture fails to compile. Found by a tier-2 fixture build
+on 2026-09-05, at `build-cortex-m-c-talker-zenoh`:
+
+```
+error[E0433]: cannot find `task` in `nros_platform_api`
+    --> packages/core/nros-node/src/executor/spin.rs:2415:41
+     |
+2415 |         let unused = nros_platform_api::task::stack_unused_bytes();
+     |                                         ^^^^ could not find `task` in `nros_platform_api`
+     |
+note: found an item that was configured out
+    --> packages/platform/nros-platform-api/src/lib.rs:65:9
+     |
+  64 | #[cfg(feature = "alloc")]
+     |       ----------------- the item is gated behind the `alloc` feature
+```
+
+It surfaces through the `nros-c` size probe, which runs a nested cargo build, so
+the first line a reader sees is *"size probe could not locate the `nros` rlib"* —
+several frames from the cause.
+
+## Cause
+
+`cb2be0ca4` (*"feat(sched): report a stack that has come too close to its end"*)
+added `check_stack_headroom_rule` to the executor, calling
+`nros_platform_api::task::stack_unused_bytes()` unconditionally.
+
+`pub mod task` is `#[cfg(feature = "alloc")]`
+(`nros-platform-api/src/lib.rs:64-65`) — and correctly so for most of it:
+`PlatformTask` allocates its own stack and join slot
+(`alloc::alloc::alloc`, `task.rs:128-162`).
+
+**But `stack_unused_bytes` allocates nothing.** It is one `extern "C"` call
+returning a `usize`:
+
+```rust
+pub fn stack_unused_bytes() -> usize {
+    unsafe { nros_platform_task_stack_unused_bytes() }
+}
+```
+
+So the gate is about its NEIGHBOURS, not about it. That cost nothing until
+something outside `alloc` wanted the function — and then every `no_std` image
+without an allocator stopped compiling.
+
+## Why guarding the CALL SITE would be the wrong fix
+
+The obvious patch is `#[cfg(feature = "alloc")]` on
+`check_stack_headroom_rule`'s body. That builds, and it is wrong.
+
+The rule is a SAFETY feature: it reports a spin thread that has come closer to
+the end of its stack than its declared minimum. The targets it would be silently
+removed from — `no_std`, no allocator, small embedded — are exactly the ones
+where a stack overflow is how one component corrupts another's state, and where
+nobody is watching a console. **A gate that quietly deletes a safety check on
+the platforms it exists for is worse than the build error that revealed it.**
+
+## Fix
+
+`stack_unused_bytes` moves to a new `crate::stack` module that is NOT
+alloc-gated; `crate::task` re-exports it, so every existing
+`nros_platform_api::task::stack_unused_bytes` caller is unchanged. The function
+lands where its own requirements put it rather than where its neighbours did.
+
+## The family
+
+Second regression from the same stack-instrumentation work in one day, and the
+two fail at different phases of the build:
+
+| commit | what it added | how it broke |
+| --- | --- | --- |
+| `411addfd2` | the platform probe | **link** — `undefined reference to z_impl_k_thread_stack_space_get`, issue 1075 |
+| `cb2be0ca4` | the executor rule that calls it | **compile** — this issue |
+
+Both are invisible to the compile tiers, which build the host configuration
+where `alloc` is on and the Zephyr syscall is irrelevant. Only a fixture build
+reaches either.
+
+## Not covered
+
+* `packages/core/nros-node/src/executor/os_priority.rs:61` carries a bare
+  `use nros_platform_api::task::PlatformTask;` and its module is gated on
+  `#[cfg(any(has_rmw, test))]`, not on `alloc`. That import genuinely needs
+  `alloc`, so it is a different question from this one — but whether a
+  `has_rmw` build without `alloc` is reachable was not established.
+* Whether any other caller reaches an alloc-gated item from a non-alloc path.
+  Not swept.

--- a/docs/issues/archived/1080-stack-unused-bytes-trapped-behind-alloc-gate.md
+++ b/docs/issues/archived/1080-stack-unused-bytes-trapped-behind-alloc-gate.md
@@ -1,7 +1,7 @@
 ---
 id: 1080
 title: "`stack_unused_bytes` allocates nothing but lives in an `alloc`-gated module, so the new stack-headroom rule breaks every `no_std`-without-`alloc` image"
-status: open
+status: resolved
 type: bug
 area: platform, core
 severity: high
@@ -73,9 +73,44 @@ the platforms it exists for is worse than the build error that revealed it.**
 ## Fix
 
 `stack_unused_bytes` moves to a new `crate::stack` module that is NOT
-alloc-gated; `crate::task` re-exports it, so every existing
-`nros_platform_api::task::stack_unused_bytes` caller is unchanged. The function
-lands where its own requirements put it rather than where its neighbours did.
+alloc-gated, **and the caller names that path**. The function lands where its own
+requirements put it rather than where its neighbours did.
+
+**The re-export alone was not enough, and the first attempt shipped that
+mistake.** `crate::task` re-exports the function so out-of-tree callers keep
+working — but `task` is itself `#[cfg(feature = "alloc")]`, so
+`nros_platform_api::task::stack_unused_bytes` is *still* unreachable without an
+allocator. Re-exporting through a gated module helps nobody in the failing case.
+`spin.rs` now says `nros_platform_api::stack::stack_unused_bytes()`.
+
+### The check that finally discriminated
+
+Three attempts did not:
+
+* `cargo check -p nros-platform-api --no-default-features` — passes either way;
+  the defect is in the CALLER.
+* `cargo check -p nros-node --no-default-features` — passes with the fix
+  **stashed** too. Workspace resolution gives `nros-platform-api` its default
+  features regardless, so `alloc` is always on.
+* `just zephyr build-one c/talker zenoh mps2_an385` — cannot reach the
+  coordinate at all. `build-one` names its build dir from example+rmw, while the
+  cortex-m rows carry a distinct `west_build_name`, so it refused on a board
+  mismatch against the existing native_sim dir.
+
+The size probe's own key-inputs file (`build/sizes-probe/.../nros-probe-key-inputs.txt`)
+records what it actually builds — target `thumbv7m-none-eabi`, features
+`rmw-cffi,ros-humble`, no defaults — which is the reproduction:
+
+```
+cargo check -p nros --target thumbv7m-none-eabi \
+      --no-default-features --features rmw-cffi,ros-humble
+
+  with `task::`   -> error[E0433]: cannot find `task` in `nros_platform_api`
+  with `stack::`  -> Finished
+```
+
+Seconds rather than a 20-minute fixture build, and it fails for the right
+reason — which none of the earlier three did.
 
 ## The family
 

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -2412,7 +2412,11 @@ impl<'s> Executor<'s> {
         if self.min_stack_headroom_bytes == 0 {
             return;
         }
-        let unused = nros_platform_api::task::stack_unused_bytes();
+        // issue 1080 — `stack`, not `task`. `task` is `#[cfg(feature = "alloc")]`
+        // for `PlatformTask`'s sake, so naming it here made this rule — a SAFETY
+        // check — uncompilable on every `no_std` image without an allocator,
+        // which is exactly where a stack overflow goes unnoticed.
+        let unused = nros_platform_api::stack::stack_unused_bytes();
         // 0 means the port does not instrument stacks, not that the stack is
         // full. Reporting a violation there would be a fault invented from an
         // absence of data.

--- a/packages/platform/nros-platform-api/src/lib.rs
+++ b/packages/platform/nros-platform-api/src/lib.rs
@@ -63,6 +63,10 @@
 extern crate alloc;
 #[cfg(feature = "alloc")]
 pub mod task;
+// issue 1080 — the stack probe is NOT alloc-gated. It shares the task ABI's
+// header but allocates nothing, and `nros-node`'s stack-headroom rule needs it
+// on exactly the `no_std` images that have no allocator.
+pub mod stack;
 
 use core::ffi::{c_int, c_void};
 

--- a/packages/platform/nros-platform-api/src/stack.rs
+++ b/packages/platform/nros-platform-api/src/stack.rs
@@ -1,0 +1,46 @@
+//! Stack instrumentation — the part of the task ABI that needs no allocator.
+//!
+//! ISSUE 1080. `stack_unused_bytes` lived in [`crate::task`], which is
+//! `#[cfg(feature = "alloc")]` because `PlatformTask` allocates its own stack
+//! and join slot. This function allocates nothing — it is one `extern "C"` call
+//! returning a `usize` — so the gate was about its NEIGHBOURS, not about it.
+//!
+//! That mattered the moment something outside `alloc` wanted it.
+//! `nros-node`'s `check_stack_headroom_rule` (`cb2be0ca4`) called it
+//! unconditionally, and every `no_std`-without-`alloc` image stopped compiling:
+//!
+//! ```text
+//! error[E0433]: cannot find `task` in `nros_platform_api`
+//!   --> packages/core/nros-node/src/executor/spin.rs:2415:41
+//!   note: found an item that was configured out
+//! ```
+//!
+//! **Guarding the CALL SITE would have been the wrong fix.** The stack-headroom
+//! rule is a safety feature, and the targets that lose it under an
+//! `#[cfg(feature = "alloc")]` are exactly the small embedded ones where a
+//! stack overflow is how one component corrupts another's state. A gate that
+//! silently removes a safety check on the platforms it exists for is worse than
+//! the build error that revealed it.
+//!
+//! So the function moves to where its own requirements put it. `crate::task`
+//! re-exports it, so every existing caller is unchanged.
+
+unsafe extern "C" {
+    fn nros_platform_task_stack_unused_bytes() -> usize;
+}
+
+/// Smallest number of bytes ever left unused on the CALLING task's stack, or
+/// `0` if this port does not instrument it.
+///
+/// The heap has had `heap_used_bytes` since RFC-0034 D7; the stack had
+/// nothing, and stack overflow is how one component corrupts another's state.
+/// A tier asks this about ITSELF -- both kernels answer for the calling task
+/// with no handle, and answering for an arbitrary one needs a native handle
+/// this ABI does not carry.
+///
+/// `0` means "not instrumented", not "no headroom".
+pub fn stack_unused_bytes() -> usize {
+    // SAFETY: a plain query with no arguments and no state; every port either
+    // answers or returns 0.
+    unsafe { nros_platform_task_stack_unused_bytes() }
+}

--- a/packages/platform/nros-platform-api/src/task.rs
+++ b/packages/platform/nros-platform-api/src/task.rs
@@ -47,7 +47,6 @@ struct TaskAttr {
 const PRIORITY_INHERIT: i32 = i32::MIN;
 
 unsafe extern "C" {
-    fn nros_platform_task_stack_unused_bytes() -> usize;
     fn nros_platform_task_init(
         task: *mut c_void,
         attr: *mut c_void,
@@ -189,18 +188,8 @@ impl Drop for PlatformTask {
     }
 }
 
-/// Smallest number of bytes ever left unused on the CALLING task's stack, or
-/// `0` if this port does not instrument it.
-///
-/// The heap has had `heap_used_bytes` since RFC-0034 D7; the stack had
-/// nothing, and stack overflow is how one component corrupts another's state.
-/// A tier asks this about ITSELF -- both kernels answer for the calling task
-/// with no handle, and answering for an arbitrary one needs a native handle
-/// this ABI does not carry.
-///
-/// `0` means "not instrumented", not "no headroom".
-pub fn stack_unused_bytes() -> usize {
-    // SAFETY: a plain query with no arguments and no state; every port either
-    // answers or returns 0.
-    unsafe { nros_platform_task_stack_unused_bytes() }
-}
+// issue 1080 — `stack_unused_bytes` moved to `crate::stack`, which is NOT
+// alloc-gated, because it allocates nothing and a `no_std` image needs it. This
+// re-export keeps every existing `nros_platform_api::task::stack_unused_bytes`
+// caller working.
+pub use crate::stack::stack_unused_bytes;


### PR DESCRIPTION
Every Zephyr cortex-m fixture fails to **compile**. Found by a tier-2 fixture
build at `build-cortex-m-c-talker-zenoh`.

```
error[E0433]: cannot find `task` in `nros_platform_api`
  --> packages/core/nros-node/src/executor/spin.rs:2415:41
  note: found an item that was configured out
       #[cfg(feature = "alloc")]
```

## Cause

`cb2be0ca4` added `check_stack_headroom_rule`, calling
`nros_platform_api::task::stack_unused_bytes()` unconditionally. `pub mod task`
is `#[cfg(feature = "alloc")]` — correctly for most of it, since `PlatformTask`
allocates its own stack and join slot.

**But `stack_unused_bytes` allocates nothing** — one `extern "C"` call returning
a `usize`. The gate is about its *neighbours*.

## Why not guard the call site

The obvious patch is `#[cfg(feature = "alloc")]` on the rule. It builds, and it's
wrong: the rule is a **safety** feature, and the targets it would be silently
removed from — `no_std`, no allocator, small embedded — are exactly where a stack
overflow is how one component corrupts another's state and nobody is watching a
console.

## The fix, and the mistake in the first attempt

`stack_unused_bytes` moves to a non-gated `crate::stack`, **and the caller names
that path**.

The first commit only moved it and re-exported from `task` — which fixed nothing,
because `task` is still gated. The tier-2 rebuild returned the identical error at
the identical line. The re-export stays for out-of-tree callers that have `alloc`
anyway.

## The check that finally discriminated

Three did not, and each was reported as verification before being shown otherwise:

| attempt | why it proved nothing |
| --- | --- |
| `cargo check -p nros-platform-api --no-default-features` | passes either way — the defect is in the caller |
| `cargo check -p nros-node --no-default-features` | passes with the fix **stashed** too; workspace resolution gives the API crate its default features regardless |
| `just zephyr build-one c/talker zenoh mps2_an385` | cannot reach the coordinate — `build-one` names its dir from example+rmw, cortex-m rows carry a distinct `west_build_name` |

The size probe records what it actually builds
(`build/sizes-probe/…/nros-probe-key-inputs.txt`): target `thumbv7m-none-eabi`,
features `rmw-cffi,ros-humble`, no defaults.

```
cargo check -p nros --target thumbv7m-none-eabi \
      --no-default-features --features rmw-cffi,ros-humble

  with `task::`   → error[E0433]: cannot find `task` in `nros_platform_api`
  with `stack::`  → Finished
```

Seconds instead of a 20-minute fixture build, **both directions run**, and it
fails for the right reason.

## The family

Second regression from the same stack-instrumentation work, failing at a
different build phase each time:

| commit | | |
|---|---|---|
| `411addfd2` | the platform probe | **link** — issue 1075 (PR #480) |
| `cb2be0ca4` | the executor rule calling it | **compile** — this |

Both invisible to the compile tiers, which build the host configuration where
`alloc` is on and the Zephyr syscall is irrelevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742