### PR TITLE
fix(#1081): the merge queue is frozen for everyone — the setup guard tests presence, not the pin

### DIFF
--- a/docs/issues/archived/1081-setup-submodule-guard-tests-presence-not-pin.md
+++ b/docs/issues/archived/1081-setup-submodule-guard-tests-presence-not-pin.md
@@ -1,0 +1,98 @@
+---
+id: 1081
+title: "`_setup-common`'s submodule guard tests PRESENCE, not the pin — so a persistent CI workspace builds against the wrong play_launch and froze the merge queue for seven PRs"
+status: resolved
+type: bug
+area: tooling, ci
+severity: high
+found: 2026-09-05
+related: [0409, 0996]
+---
+
+# One red, seven pull requests, none of them the cause
+
+`just queue-triage` reported `queue` failing in the merge group for **seven
+different pull requests** (#333, #429, #438, #459, #478, #479, #482), every one
+of them green on its own branch. The same check failing across unrelated changes
+is not a property of any of them.
+
+Every failure was byte-identical:
+
+```
+error: cannot update the lock file …/packages/cli/nros-launch-resolve/Cargo.lock
+because --locked was passed to prevent this
+error: recipe `setup-launch-resolve` failed with exit code 101
+```
+
+## Cause
+
+`_setup-common` guarded the play_launch submodule like this:
+
+```sh
+sub="packages/cli/third-party/play_launch"
+if [ ! -f "$sub/src/ros-launch-resolve/resolve/Cargo.toml" ]; then
+    git submodule update --init "$sub"
+fi
+```
+
+That answers **"is it initialised?"**. It does not answer **"is it at the commit
+this tree pins?"** — and a checkout can be initialised and at the wrong commit.
+
+The CI runner is self-hosted with a persistent workspace, and
+`actions/checkout` runs with `submodules: false`, so nothing moves the submodule
+back to the pin between runs. `git submodule status` in the run log reads:
+
+```
++8fda8d89e7314e7684e22673c2c0b8f32d4f560c packages/cli/third-party/play_launch (heads/main)
+```
+
+The leading `+` is git saying "differs from the recorded pointer". The pin is
+`4c214a63`. The file the guard looks for exists at either commit, so the guard
+skipped, and every build resolved `nros-launch-resolve` against a source tree
+its committed `Cargo.lock` does not describe. Cargo wanted to rewrite the lock;
+`--locked` — injected project-wide by the `scripts/bin/cargo` shim — correctly
+refused.
+
+So the error names the lockfile, and the lockfile is fine. Nothing about the
+message points at a submodule.
+
+## Reproduced locally, exactly
+
+```sh
+git -C packages/cli/third-party/play_launch checkout HEAD~2   # = 8fda8d89
+just setup-launch-resolve
+# error: cannot update the lock file … because --locked was passed
+```
+
+The runner was simply two commits ahead on `main` and behind the pin — the
+superproject's pointer and the checkout disagreeing, which is the state
+CLAUDE.md already says is fixed by `git submodule update <path>`.
+
+## Fix
+
+The guard now reads `git submodule status --cached`, whose first column
+distinguishes the two states that need different handling:
+
+- `-` — not initialised. Init it, non-recursively (RFC-0060).
+- `+` — present at another commit. If the submodule worktree is **clean**,
+  update it to the pin and say so. If it is **dirty**, FAIL with the command,
+  because `git submodule update` discards work in a submodule and AGENTS.md
+  makes that a human decision. Failing loudly beats resolving against a tree the
+  lockfiles do not describe.
+
+The distinction matters: `post-rebase` deliberately only REPORTS a moved
+submodule for exactly this reason, and it would have named this one. `setup` is
+a provisioning verb, so it may repair — but only where there is provably nothing
+to lose.
+
+## What this is not
+
+Not a lockfile problem, and `nros-launch-resolve/Cargo.lock` is unchanged. A
+regenerated lock would have made the symptom disappear on the runner while
+encoding the wrong graph for everyone else.
+
+## Related
+
+Issue 0996 is the same lane failing for a different reason a hand-rolled
+workflow step was hiding. The pattern both share: a claim that the toolchain
+does the work, where the toolchain does *almost* the work.

--- a/justfile
+++ b/justfile
@@ -4041,9 +4041,43 @@ _setup-common:
     #!/usr/bin/env bash
     set -e
     sub="packages/cli/third-party/play_launch"
-    if [ ! -f "$sub/src/ros-launch-resolve/resolve/Cargo.toml" ]; then
+    # Issue 1081 — the guard tests the PIN, not merely presence. Testing for a
+    # file answers "is it initialised", and a checkout can be initialised and at
+    # the WRONG COMMIT: a persistent CI workspace keeps whatever the last run
+    # left, and `actions/checkout` runs with `submodules: false`, so nothing
+    # moves it back. That is not hypothetical — the merge queue was frozen for
+    # SEVEN pull requests with an identical `cannot update the lock file …
+    # because --locked was passed`, because the runner sat on `8fda8d89`
+    # (heads/main) while the pin was `4c214a63`. `nros-launch-resolve`'s lock
+    # matches the PIN, so cargo wanted to rewrite it and `--locked` refused. The
+    # same red on unrelated PRs is never a property of any of them.
+    #
+    # `git submodule status --cached` prefixes `+` for "checkout differs from
+    # the recorded pointer" and `-` for "not initialised" — different states,
+    # and only one of them is safe to fix by force.
+    _sub_state="$(git submodule status --cached "$sub" 2>/dev/null | cut -c1)"
+    if [ "$_sub_state" = "-" ]; then
         echo "setup: initialising in-tree CLI submodule ($sub)"
+        # NON-recursive on purpose (RFC-0060): layer 2 is regular files inside
+        # play_launch; its layer-3 submodules are never built by nano-ros.
         git submodule update --init "$sub"
+    elif [ "$_sub_state" = "+" ]; then
+        # Present but at another commit. Updating DISCARDS work in the
+        # submodule, which AGENTS.md makes a human decision — so this only
+        # forces it when there is provably nothing to lose, and otherwise stops
+        # rather than resolving against a tree the lockfiles do not describe.
+        if [ -z "$(git -C "$sub" status --porcelain 2>/dev/null)" ]; then
+            echo "setup: $sub is at $(git -C "$sub" rev-parse --short HEAD), not the recorded pin — updating (worktree clean)"
+            git submodule update "$sub"
+        else
+            echo "setup: FAILED — $sub is at $(git -C "$sub" rev-parse --short HEAD), not the pin this tree records," >&2
+            echo "  and it has uncommitted changes, so this cannot move it for you (issue 1081)." >&2
+            echo "  Building against it resolves a graph the lockfiles do not describe, which" >&2
+            echo "  surfaces as \`cannot update the lock file … --locked\` several steps later." >&2
+            echo "" >&2
+            echo "  Commit or stash the submodule work, then:  git submodule update $sub" >&2
+            exit 1
+        fi
     fi
     just setup-cli
     just setup-launch-resolve


### PR DESCRIPTION
**This unblocks the merge queue for seven pull requests.** Please prioritise it over anything else in the queue.

`just queue-triage` reports `queue` failing in the merge group for #333, #429, #438, #459, #478, #479 and #482 — all green on their own branches, all failing byte-identically:

```
error: cannot update the lock file …/nros-launch-resolve/Cargo.lock
because --locked was passed to prevent this
```

The same check failing across unrelated changes is not a property of any of them, and the message names a file that is not the problem. **Do not re-queue those PRs until this lands** — re-queuing burns a batch slot against a check that cannot go green for anyone.

## Cause

`_setup-common` guarded the play_launch submodule by testing for a file:

```sh
if [ ! -f "$sub/src/ros-launch-resolve/resolve/Cargo.toml" ]; then
```

That answers *"is it initialised"*, not *"is it at the commit this tree pins"* — and a checkout can be initialised and at the wrong commit.

The runner is self-hosted with a persistent workspace and `actions/checkout` runs `submodules: false`, so nothing moves the submodule back between runs. Its own log says so, in a line that scrolls past:

```
+8fda8d89… packages/cli/third-party/play_launch (heads/main)
```

The leading `+` is git reporting "differs from the recorded pointer". The pin is `4c214a63` — the runner is two commits ahead on `main` and behind the pin. The guard's file exists at either commit, so it skipped, and every build resolved `nros-launch-resolve` against a source tree its committed `Cargo.lock` does not describe. Cargo wanted to rewrite the lock; `--locked` correctly refused.

## Reproduced locally before changing anything

```sh
git -C packages/cli/third-party/play_launch checkout HEAD~2   # = 8fda8d89
just setup-launch-resolve
# error: cannot update the lock file … because --locked was passed
```

Identical error. `HEAD~2` landing exactly on the runner's commit is what confirmed the diagnosis rather than merely fitting it.

## Fix

The guard reads `git submodule status --cached`, whose first column separates two states that need different handling:

- `-` uninitialised → init, non-recursively (RFC-0060).
- `+` present at another commit → update to the pin **only if the submodule worktree is clean**, and otherwise **fail with the command**, because `git submodule update` discards work in a submodule and AGENTS.md makes that a human decision.

That asymmetry is deliberate: `post-rebase` only *reports* a moved submodule for the same reason. `setup` is a provisioning verb, so it may repair — but only where there is provably nothing to lose.

Verified by putting the tree in the runner's exact state and running the recipe: it prints `is at 8fda8d89, not the recorded pin — updating (worktree clean)`, restores `4c214a63`, and `setup-launch-resolve` then succeeds.

## What this is not

**The lockfile is not touched.** Regenerating it would have made the symptom disappear on the runner while encoding the wrong graph for everyone else — the tempting fix, and the wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV