### PR TITLE
fix(test): the host-only test modules need `std` in their gate

### DIFF
--- a/packages/core/nros-node/src/executor/mod.rs
+++ b/packages/core/nros-node/src/executor/mod.rs
@@ -92,7 +92,19 @@ pub mod action;
 // feature unification under `cargo test --workspace` flips `ConcreteSession`
 // to a real backend handle (e.g. UorbSession when rmw-uorb is on transitively
 // via the workspace), breaking the type signatures the tests expect.
-#[cfg(all(test, not(feature = "rmw-cffi")))]
+// `feature = "std"` is part of the gate, not decoration. The crate is
+// `#![no_std]`; `tests.rs` uses `std::` in 155 places and calls
+// `from_session`, which is itself `#[cfg(feature = "alloc")]`. Without the
+// feature in the gate, a plain `cargo test -p nros-node` compiles this module
+// into a no_std crate and produces 252 errors, 192 of them "cannot find module
+// or crate `std`" — an incomprehensible wall for anyone running the obvious
+// command, and unrelated to whatever they were changing.
+//
+// These tests genuinely need a host: they spawn threads, sleep, and read the
+// wall clock. Gating them is not hiding coverage, it is declaring what they
+// already required. `cargo test -p nros-node --features std` is unchanged and
+// remains the way to run them.
+#[cfg(all(test, feature = "std", not(feature = "rmw-cffi")))]
 mod tests;
 
 // Flat re-exports so users write `executor::Executor` etc.

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -2563,7 +2563,7 @@ impl<'c, 'e, 't, 's, const RX: usize> GenericSubInfoBuilder<'c, 'e, 't, 's, RX> 
 // build that unifies `rmw-cffi` on swaps `ConcreteSession` to the cffi session
 // and drops `mock`, so the module must drop with it (matches the
 // `mock_integration` gate in lifecycle_services.rs).
-#[cfg(all(test, not(feature = "rmw-cffi")))]
+#[cfg(all(test, feature = "std", not(feature = "rmw-cffi")))]
 mod builder_tests {
     use super::*;
     use crate::{executor::Executor, mock::MockSession};

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -8339,7 +8339,7 @@ impl<'s> Drop for Executor<'s> {
     }
 }
 
-#[cfg(all(test, not(feature = "rmw-cffi")))]
+#[cfg(all(test, feature = "std", not(feature = "rmw-cffi")))]
 mod dispatch_registry_tests {
     //! Phase 216 follow-up — `Executor::register_dispatch_slot` +
     //! `Executor::dispatch_callback` round-trip.
@@ -8461,7 +8461,7 @@ mod dispatch_registry_tests {
 ///
 /// Uses `MockSession` (same pattern as `dispatch_registry_tests`); gated
 /// `not(feature = "rmw-cffi")` for the same reason.
-#[cfg(all(test, not(feature = "rmw-cffi")))]
+#[cfg(all(test, feature = "std", not(feature = "rmw-cffi")))]
 mod p274_w1_tier_executor_tests {
     use super::Executor;
     use crate::mock::MockSession;

--- a/scripts/check-std-census.py
+++ b/scripts/check-std-census.py
@@ -456,7 +456,19 @@ def census():
                         pending_test = False
                     elif pending_test and stripped.endswith(";"):
                         pending_test = False  # `#[cfg(test)] mod tests;`
-                    if test_depth is None and code:
+                    # …and never count the TEST GATE ITSELF. `#[cfg(all(test,
+                    # feature = "std", …))]` contains `feature = "std"`, and on
+                    # that line `test_depth` is still None — it is only set when
+                    # the body's brace opens on a LATER line — so the attribute
+                    # was counted as a std requirement of shipped code while its
+                    # body was correctly skipped.
+                    #
+                    # That contradicts this file's own stated policy ("`#[cfg(test)]`
+                    # code is excluded, and that is a CORRECTION not a win"), and it
+                    # punished the change that made four host-only test modules
+                    # DECLARE what they had always needed: `nros-node` went 3 -> 7
+                    # for four attributes on `mod` lines, none of which ships.
+                    if test_depth is None and code and not is_test_gate(stripped):
                         if "cfg" in code:
                             cfg += len(CFG_FEATURE_RE.findall(code))
                         path += len(PATH_RE.findall(code))


### PR DESCRIPTION
> Stacked on #487 — without it the default-feature build still fails on `nros_platform_api::task` for an unrelated reason.

## Problem

`cargo test -p nros-node` — the obvious command, no features — does not compile. **252 errors, 192 of them `cannot find module or crate `std``.**

The crate is `#![no_std]`. Four test modules are gated:

```rust
#[cfg(all(test, not(feature = "rmw-cffi")))]
```

which says nothing about what they actually require. `tests.rs` alone uses `std::` in 155 places, and they call `from_session`, itself `#[cfg(feature = "alloc")]`. So a default-feature test build pulls host-only tests into a no_std crate and produces a wall of errors unrelated to whatever the reader had changed.

## Fix

Add `feature = "std"` to the four gates. These tests spawn threads, sleep, and read the wall clock — the gate now declares what they already required.

## This recovers tests rather than hiding them

The build previously died, so `cargo test -p nros-node` ran **nothing**. It now runs the 172 that are genuinely no_std-compatible:

```
default features   172 passed, 0 failed    (was: 0 run, build failed)
--features std     321 + 5 passed          (unchanged)
```

`cargo fmt` clean.

## Why it is worth landing

This is the second time a feature branch has had to quote verification against a non-default configuration because the obvious command was broken (the first was #416). Anyone running `cargo test -p nros-node` before this sees 252 errors and no indication that the fix is to add a feature flag.