### PR TITLE
fix(#0964): an unbounded type cannot size a buffer — reroute, RX/TX audit, and the arm flipped

### DIFF
--- a/docs/issues/0964-two-different-sizes-for-the-same-type.md
+++ b/docs/issues/0964-two-different-sizes-for-the-same-type.md
@@ -219,3 +219,76 @@ simplest type in the corpus, which is a fair summary of why it was replaced.
 Not measured: an image delta. That still needs the second instrument 0896 named
 — these are stack frames, and the number of live buffers depends on which of the
 13 sites an image instantiates.
+
+
+## The lever was connected to nothing — rerouted, and the RX/TX split audited (2026-09-05)
+
+The open half above says the flip is "the `unbounded` arm of
+`detail::buffer_bounds` … the one line it turns on". That line existed;
+**nothing called it.** `buffer_bounds` had no consumer anywhere outside
+`size_bound.hpp`, so flipping it would have changed nothing at all.
+
+### Where the estimate actually was
+
+| | sites |
+| --- | ---: |
+| `uint8_t buf[M::SERIALIZED_SIZE_MAX]`, bypassing both templates | **15** |
+| strict `rx_size_bound` / `tx_size_bound` (poisons on unbounded) | 2 |
+
+(24 grep hits, but 8 are doc comments and one is a stub type defining its own
+constant. 15 are real buffer declarations.)
+
+Spread over `client` (3), `action_client` (3), `polling_action_server` (3),
+`action_server` (2), `tick_ctx` (2), `service` (1), `polling_action_client` (1).
+
+### The audit answer: all 15 are TX, and none is the 0896 hazard
+
+Every one of the fifteen is
+`X::ffi_serialize(&value, buf, sizeof(buf), &len)` with the return checked.
+**There is no RX buffer sized by the estimate** — the receive paths already go
+through `component.hpp`, which passes `nros::rx_size_bound<M>::value`, the
+STRICT template that poisons on an unbounded type.
+
+That matters for the product decision, and it lowers the stakes:
+
+* the silent-truncation failure 0896 exists to remove **does not apply here**.
+  These buffers are written by us, bounds-checked against `sizeof(buf)`, and an
+  over-long message returns a non-zero code rather than corrupting anything;
+* so an under-sized estimate on these paths is a LOUD runtime failure, not
+  data loss. Flipping the unbounded arm would convert that into a compile-time
+  failure — better in kind, but a usability change, not a safety fix.
+
+The safety argument for the flip should not be made from these sites. It has to
+be made about `component.hpp`'s receive path, which is already strict.
+
+### What changed here
+
+The 15 sites now size through `::nros::detail::buffer_bounds<T>::tx`, and
+`action_server.hpp` gained the `size_bound.hpp` include it had been getting by
+luck. This is deliberately NOT a semantic no-op — I predicted it would be and
+was wrong, so the measurement is on real generated headers rather than an
+assumption. `buffer_bounds` answers `TX_MAX_SERIALIZED_SIZE` for a DERIVED type,
+so those buffers shrink to the bound:
+
+| | bytes |
+| --- | ---: |
+| estimate, over the 19 types carrying both constants | 1,928 |
+| derived, same 19 | **202** |
+| TX buffers shrink by | **1,726** |
+
+Zero buffers grow. The other 21 generated types in that tree state no derived
+bound, so they keep the estimate and are untouched — which is exactly the
+`legacy`/`unbounded` arm doing its job.
+
+`just check cpp`, `just check c` and `just check fast` (213/213) all pass.
+
+### What this leaves for the decision
+
+The flip is now genuinely one line at one control point, and it is a real lever.
+Staging it is possible where it was not before: the arm can be turned on for RX
+before TX, and `has_derived_size_bound<M>` already exists for a per-site opt-in.
+
+Still a product decision, and unchanged in substance: 81 of 120 stock Humble
+types have no derived bound, so the flip makes code that compiled yesterday stop
+compiling until each type gains a `cap` or each call site uses the `_sized`
+form.

--- a/packages/api/nros-cpp/include/nros/action_client.hpp
+++ b/packages/api/nros-cpp/include/nros/action_client.hpp
@@ -125,7 +125,7 @@ template <typename A> class ActionClient {
     Result send_goal(const GoalType& goal, uint8_t goal_id[16]) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
 
-        uint8_t buf[GoalType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<GoalType>::tx];
         size_t len = 0;
         if (GoalType::ffi_serialize(&goal, buf, sizeof(buf), &len) != 0) {
             return Result(ErrorCode::Error);
@@ -187,7 +187,7 @@ template <typename A> class ActionClient {
     Future<GoalAccept> send_goal_future(const GoalType& goal) {
         if (!initialized_) return Future<GoalAccept>();
 
-        uint8_t buf[GoalType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<GoalType>::tx];
         size_t len = 0;
         if (GoalType::ffi_serialize(&goal, buf, sizeof(buf), &len) != 0) {
             return Future<GoalAccept>();
@@ -335,7 +335,7 @@ template <typename A> class ActionClient {
     Result send_goal_async(const GoalType& goal, uint8_t goal_id[16]) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
 
-        uint8_t buf[GoalType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<GoalType>::tx];
         size_t len = 0;
         if (GoalType::ffi_serialize(&goal, buf, sizeof(buf), &len) != 0) {
             return Result(ErrorCode::Error);

--- a/packages/api/nros-cpp/include/nros/action_server.hpp
+++ b/packages/api/nros-cpp/include/nros/action_server.hpp
@@ -16,6 +16,10 @@
 
 #include "nros/config.hpp"
 #include "nros/result.hpp"
+// issue 0964 — the feedback/result TX buffers below size through
+// `detail::buffer_bounds`, so this header needs it directly rather than by
+// luck through a transitive include.
+#include "nros/size_bound.hpp"
 
 // Phase 118.D — most action_server FFI symbols come from
 // `nros_cpp_ffi.h`; cbindgen renders Rust `*const [u8; 16]` as
@@ -237,7 +241,7 @@ template <typename A> class ActionServer {
     Result publish_feedback(const uint8_t goal_id[16], const FeedbackType& feedback) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
 
-        uint8_t buf[FeedbackType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<FeedbackType>::tx];
         size_t len = 0;
         if (FeedbackType::ffi_serialize(&feedback, buf, sizeof(buf), &len) != 0) {
             return Result(ErrorCode::Error);
@@ -257,7 +261,7 @@ template <typename A> class ActionServer {
     Result complete_goal(const uint8_t goal_id[16], GoalStatus status, const ResultType& result) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
 
-        uint8_t buf[ResultType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<ResultType>::tx];
         size_t len = 0;
         if (ResultType::ffi_serialize(&result, buf, sizeof(buf), &len) != 0) {
             return Result(ErrorCode::Error);

--- a/packages/api/nros-cpp/include/nros/client.hpp
+++ b/packages/api/nros-cpp/include/nros/client.hpp
@@ -90,7 +90,7 @@ template <typename S> class Client {
         using Fut = Future<ResponseType, RespCap>;
         if (!initialized_) return Fut();
 
-        uint8_t req_buf[RequestType::SERIALIZED_SIZE_MAX];
+        uint8_t req_buf[::nros::detail::buffer_bounds<RequestType>::tx];
         size_t req_len = 0;
         if (RequestType::ffi_serialize(&req, req_buf, sizeof(req_buf), &req_len) != 0) {
             return Fut();
@@ -155,7 +155,7 @@ template <typename S> class Client {
     Result call_polling_sized(const RequestType& req, ResponseType& resp,
                               uint32_t timeout_ms = 100) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
-        uint8_t req_buf[RequestType::SERIALIZED_SIZE_MAX];
+        uint8_t req_buf[::nros::detail::buffer_bounds<RequestType>::tx];
         size_t req_len = 0;
         if (RequestType::ffi_serialize(&req, req_buf, sizeof(req_buf), &req_len) != 0) {
             return Result(ErrorCode::Error);
@@ -239,7 +239,7 @@ template <typename S> class Client {
     /// during `spin_once` (no Future). Returns immediately after sending.
     Result async_send_request(const RequestType& req) {
         if (!initialized_ || !callback_mode_) return Result(ErrorCode::NotInitialized);
-        uint8_t req_buf[RequestType::SERIALIZED_SIZE_MAX];
+        uint8_t req_buf[::nros::detail::buffer_bounds<RequestType>::tx];
         size_t req_len = 0;
         if (RequestType::ffi_serialize(&req, req_buf, sizeof(req_buf), &req_len) != 0) {
             return Result(ErrorCode::Error);

--- a/packages/api/nros-cpp/include/nros/polling_action_client.hpp
+++ b/packages/api/nros-cpp/include/nros/polling_action_client.hpp
@@ -73,7 +73,7 @@ template <typename A> class PollingActionClient {
     /// `goal_id_out`.
     Result send_goal(const GoalType& goal, uint8_t goal_id_out[16]) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
-        uint8_t buf[GoalType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<GoalType>::tx];
         size_t len = 0;
         if (GoalType::ffi_serialize(&goal, buf, sizeof(buf), &len) != 0)
             return Result(ErrorCode::Error);

--- a/packages/api/nros-cpp/include/nros/polling_action_server.hpp
+++ b/packages/api/nros-cpp/include/nros/polling_action_server.hpp
@@ -116,7 +116,7 @@ template <typename A> class PollingActionServer {
     /// Publish a feedback message for an accepted goal.
     Result publish_feedback(const uint8_t goal_id[16], const FeedbackType& fb) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
-        uint8_t buf[FeedbackType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<FeedbackType>::tx];
         size_t len = 0;
         if (FeedbackType::ffi_serialize(&fb, buf, sizeof(buf), &len) != 0)
             return Result(ErrorCode::Error);
@@ -127,7 +127,7 @@ template <typename A> class PollingActionServer {
     /// Mark a goal terminal with a typed result.
     Result complete_goal(const uint8_t goal_id[16], GoalStatus status, const ResultType& result) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
-        uint8_t buf[ResultType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<ResultType>::tx];
         size_t len = 0;
         if (ResultType::ffi_serialize(&result, buf, sizeof(buf), &len) != 0)
             return Result(ErrorCode::Error);
@@ -215,7 +215,7 @@ template <typename A> class PollingActionServer {
     /// ErrorCode::TryAgain if none pending.
     Result try_handle_get_result(const ResultType& default_result = ResultType{}) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
-        uint8_t buf[ResultType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<ResultType>::tx];
         size_t len = 0;
         if (ResultType::ffi_serialize(&default_result, buf, sizeof(buf), &len) != 0)
             return Result(ErrorCode::Error);

--- a/packages/api/nros-cpp/include/nros/service.hpp
+++ b/packages/api/nros-cpp/include/nros/service.hpp
@@ -119,7 +119,7 @@ template <typename S> class Service {
     /// @return Result indicating success or failure.
     Result send_response(int64_t seq_id, const ResponseType& resp) {
         if (!initialized_) return Result(ErrorCode::NotInitialized);
-        uint8_t buf[ResponseType::SERIALIZED_SIZE_MAX];
+        uint8_t buf[::nros::detail::buffer_bounds<ResponseType>::tx];
         size_t len = 0;
         if (ResponseType::ffi_serialize(&resp, buf, sizeof(buf), &len) != 0) {
             return Result(ErrorCode::Error);

--- a/packages/api/nros-cpp/include/nros/tick_ctx.hpp
+++ b/packages/api/nros-cpp/include/nros/tick_ctx.hpp
@@ -126,7 +126,7 @@ class TickCtx {
     /// over-estimate only wastes stack.
     template <typename Req, typename Resp, size_t RespCap>
     Result call_sized(const char* service_entity, const Req& request, Resp& response) {
-        uint8_t req_buf[Req::SERIALIZED_SIZE_MAX];
+        uint8_t req_buf[::nros::detail::buffer_bounds<Req>::tx];
         size_t req_len = 0;
         if (Req::ffi_serialize(&request, req_buf, sizeof(req_buf), &req_len) != 0) {
             return Result(ErrorCode::Error);
@@ -170,7 +170,7 @@ class TickCtx {
     /// codegen-emitted interface, same as `nros::ActionClient<A>`).
     template <typename G>
     Result send_goal(const char* action_entity, const G& goal, uint8_t goal_id_out[16]) {
-        uint8_t goal_buf[G::SERIALIZED_SIZE_MAX];
+        uint8_t goal_buf[::nros::detail::buffer_bounds<G>::tx];
         size_t goal_len = 0;
         if (G::ffi_serialize(&goal, goal_buf, sizeof(goal_buf), &goal_len) != 0) {
             return Result(ErrorCode::Error);


### PR DESCRIPTION
You asked me to do the reroute and audit the RX/TX split. Both are here, and the audit changes the decision you're weighing.

## The lever was connected to nothing

#0964 says the flip is *"the `unbounded` arm of `detail::buffer_bounds` … the one line it turns on"*. That line existed — and **nothing called it**. `buffer_bounds` had no consumer anywhere outside `size_bound.hpp`. Flipping it would have changed nothing.

The estimate actually lived in **15** direct `uint8_t buf[M::SERIALIZED_SIZE_MAX]` declarations: `client` (3), `action_client` (3), `polling_action_server` (3), `action_server` (2), `tick_ctx` (2), `service` (1), `polling_action_client` (1). (24 grep hits, but 8 are doc comments and one is a stub defining its own constant — I'd quoted 24 earlier; 15 is the real number.)

## Audit: all 15 are TX, and none is the #0896 hazard

Every one is `X::ffi_serialize(&value, buf, sizeof(buf), &len)` with the return checked. **No RX buffer is sized by the estimate** — the receive paths already go through `component.hpp`, which passes the strict `rx_size_bound` that poisons on unbounded.

That lowers the stakes of the decision:

- the silent-truncation failure #0896 exists to remove **does not apply here** — these buffers are written by us, bounds-checked, and an over-long message returns non-zero rather than corrupting anything;
- an under-sized estimate on these paths is a **loud runtime failure**. Flipping converts it to a **compile-time** failure — better in kind, but a usability change, not a safety fix.

**The safety argument for the flip can't be made from these sites.** It has to be made about the receive path, which is already strict.

## Not a semantic no-op — I predicted it would be and was wrong

So this is measured on real generated headers rather than assumed. `buffer_bounds` answers `TX_MAX_SERIALIZED_SIZE` for a **derived** type, so those buffers shrink to the bound:

| | bytes |
|---|---:|
| estimate, over the 19 types carrying both constants | 1,928 |
| derived | **202** |
| TX buffers shrink by | **1,726** |

Zero buffers grow. The other 21 generated types state no derived bound, keep the estimate, and are untouched — the `legacy`/`unbounded` arm doing its job.

`action_server.hpp` also gains the `size_bound.hpp` include it had been getting by luck.

## What this leaves you

The flip is now genuinely one line at one control point, and **stageable** where it wasn't: the arm can be turned on for RX before TX, and `has_derived_size_bound<M>` already exists for a per-site opt-in.

The product decision is unchanged in substance — 81 of 120 stock Humble types have no derived bound, so flipping makes code that compiled yesterday stop until each type gains a `cap` or each call site uses the `_sized` form.

`just check cpp`, `just check c`, `just check fast` (213/213) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)