### PR TITLE
ci(gate): warm the compile-tier cache on main — the queue could never hit it

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -894,6 +894,77 @@ jobs:
           just check decoupling
 
   # ----- scaffold-journey (RFC-0040 resolve-only) -----
+  # phase-422 follow-up — WARM the compile-tier caches on `main`, so the
+  # pull_request and merge_group runs can actually restore them.
+  #
+  # Measured on merge_group: "Build nros CLI + provision" 128 s and "Build
+  # nros-launch-resolve" 91 s, EVERY entry, plus an sccache dir that missed both
+  # its exact key and its `sccache-Linux-check-` restore prefix. 219 s per entry
+  # rebuilding artifacts whose sources had not changed.
+  #
+  # The cause is cache SCOPING, not the keys. GitHub lets a run restore caches
+  # from its own ref or from the DEFAULT branch, and nothing else. A merge_group
+  # run executes on an ephemeral `gh-readonly-queue/main/pr-N-<sha>` ref, so the
+  # cache it saves is scoped to a ref that will never run again, and the only
+  # other scope it can read — `main` — was never written, because every cache
+  # step in the `check` job is gated to
+  # pull_request/merge_group/schedule/workflow_dispatch. Both halves of the
+  # restore therefore missed by construction, which is exactly what the logs
+  # showed: "Cache not found for input keys: nros-cli-Linux-<hash>,
+  # nros-cli-Linux-".
+  #
+  # This job writes those same keys on `push` to main — once per merge, instead
+  # of once per queue entry. It deliberately does NOT run the gates: its only
+  # product is a populated cache.
+  warm-cache:
+    name: warm the compile-tier cache (main only)
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/newslabntu/nano-ros-ci:humble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout nano-ros
+        uses: actions/checkout@v4
+
+      # Same path + key as the `check` job's cache, or this warms nothing.
+      # `check-gate-cache-keys-agree` asserts they stay identical.
+      - name: Cache CLI build (compile tier)
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/cli/target
+            packages/cli/nros-launch-resolve/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
+          restore-keys: |
+            nros-cli-${{ runner.os }}-
+
+      - name: Cache sccache directory
+        uses: actions/cache@v4
+        with:
+          path: /tmp/sccache
+          key: sccache-${{ runner.os }}-check-${{ github.sha }}
+          restore-keys: |
+            sccache-${{ runner.os }}-check-
+            sccache-${{ runner.os }}-
+
+      - name: Build nros CLI + the launch resolver
+        env:
+          SCCACHE_DIR: /tmp/sccache
+          SCCACHE_CACHE_SIZE: 1G
+        run: |
+          git submodule update --init --depth 1 packages/cli/third-party/play_launch
+          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
+          cargo build --release --manifest-path packages/cli/nros-launch-resolve/Cargo.toml
+
   scaffold-journey:
     name: nros new -> sync -> resolve
     needs: changes

--- a/just/check.just
+++ b/just/check.just
@@ -200,6 +200,7 @@ fast-serial: \
     flake-quarantine \
     flavour-lanes \
     format-macro-scope \
+    gate-cache-keys-agree \
     gate-lists \
     gate-selftests \
     gate-visibility \
@@ -2568,6 +2569,14 @@ ci-image-python-deps:
 [group("checks")]
 board-vocabulary:
     @python3 scripts/check-board-vocabulary.py
+
+# gate.yml's warm job must cache the SAME key+path as the job it warms.
+# GitHub scopes a cache to the ref that created it, so only `main` writes a
+# scope pull_request/merge_group can read — a drifted key means the warm job
+# succeeds, uploads, and warms nothing, with no error anywhere.
+[group("checks")]
+gate-cache-keys-agree:
+    @python3 scripts/check-gate-cache-keys-agree.py
 
 [group("checks")]
 prereq-roles:

--- a/scripts/check-gate-cache-keys-agree.py
+++ b/scripts/check-gate-cache-keys-agree.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""The warm job's cache must use the SAME key and path as the job it warms.
+
+`gate.yml` has two cache-writing jobs and they only cooperate if they agree
+exactly:
+
+  * `check`      — reads the cache on pull_request / merge_group.
+  * `warm-cache` — writes it on push to `main`, which is the ONLY scope the
+                   other two can read from.
+
+GitHub scopes a cache to the ref that created it; a run may restore from its own
+ref or from the default branch, and nothing else. A merge_group run executes on
+an ephemeral `gh-readonly-queue/...` ref, so the cache IT saves is unreadable
+forever and `main` is its only usable scope. That is why the warm job exists.
+
+If the two keys drift by one character, the warm job still succeeds, still
+uploads a cache, and warms NOTHING — the consumer misses and rebuilds, exactly
+as before, with no error anywhere. A silent no-op is the failure mode this
+guards, and it is the same shape as an authored map that stops matching what it
+names.
+
+Run:  python3 scripts/check-gate-cache-keys-agree.py [--self-test]
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GATE = os.path.join(ROOT, ".github", "workflows", "gate.yml")
+
+# (consumer job, warmer job, what the pair caches)
+PAIRS = [("check", "warm-cache", "the compile-tier CLI + resolver build")]
+
+
+def jobs(text):
+    """{job name: body text} for each top-level job in the workflow."""
+    out, cur, buf = {}, None, []
+    started = False
+    for line in text.split("\n"):
+        if line.startswith("jobs:"):
+            started = True
+            continue
+        if not started:
+            continue
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if m:
+            if cur:
+                out[cur] = "\n".join(buf)
+            cur, buf = m.group(1), []
+            continue
+        if cur:
+            buf.append(line)
+    if cur:
+        out[cur] = "\n".join(buf)
+    return out
+
+
+def cache_entries(body):
+    """[(path_block, key)] for every actions/cache step in a job body."""
+    out = []
+    for m in re.finditer(
+        r"uses:\s*actions/cache@[^\n]*\n(.*?)(?=\n\s*- name:|\Z)", body, re.S
+    ):
+        blk = m.group(1)
+        key = re.search(r"^\s*key:\s*(.+)$", blk, re.M)
+        paths = re.findall(r"^\s{10,}([^\s#][^\n]*)$", blk, re.M)
+        pth = re.search(r"^\s*path:\s*(.+)$", blk, re.M)
+        single = pth.group(1).strip() if pth and pth.group(1).strip() != "|" else None
+        norm = [single] if single else [p.strip() for p in paths if not p.strip().startswith("key:")]
+        if key:
+            out.append((tuple(sorted(p for p in norm if p)), key.group(1).strip()))
+    return out
+
+
+def self_test():
+    t = (
+        "jobs:\n"
+        "  a:\n"
+        "    steps:\n"
+        "      - uses: actions/cache@v4\n"
+        "        with:\n"
+        "          path: /tmp/x\n"
+        "          key: k-1\n"
+        "  b:\n"
+        "    steps:\n"
+        "      - uses: actions/cache@v4\n"
+        "        with:\n"
+        "          path: /tmp/x\n"
+        "          key: k-1\n"
+    )
+    js = jobs(t)
+    assert set(js) == {"a", "b"}, js.keys()
+    assert cache_entries(js["a"]) == cache_entries(js["b"]), (
+        cache_entries(js["a"]),
+        cache_entries(js["b"]),
+    )
+    assert cache_entries(js["a"])[0][1] == "k-1"
+    sys.stdout.write("check-gate-cache-keys-agree self-test: OK\n")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return 0
+    self_test()
+
+    with open(GATE, encoding="utf8") as fh:
+        js = jobs(fh.read())
+
+    problems = []
+    checked = 0
+    for consumer, warmer, what in PAIRS:
+        if consumer not in js or warmer not in js:
+            problems.append(
+                "gate.yml has no job %r or %r — this gate names a pair that does "
+                "not exist, so it was asserting nothing."
+                % (consumer, warmer)
+            )
+            continue
+        ce = {k: p for p, k in cache_entries(js[consumer])}
+        we = {k: p for p, k in cache_entries(js[warmer])}
+        if not ce or not we:
+            problems.append(
+                "no actions/cache step found in %r or %r (found %d / %d) — the "
+                "shape changed and this gate would pass vacuously."
+                % (consumer, warmer, len(ce), len(we))
+            )
+            continue
+        for key, paths in we.items():
+            checked += 1
+            if key not in ce:
+                problems.append(
+                    "`%s` warms key\n      %s\n    which `%s` never reads (%s).\n"
+                    "    A warm job whose key does not match its consumer still "
+                    "succeeds and still uploads — and warms NOTHING."
+                    % (warmer, key, consumer, what)
+                )
+            elif ce[key] != paths:
+                problems.append(
+                    "`%s` and `%s` share key\n      %s\n    but cache different "
+                    "paths:\n      consumer: %s\n      warmer:   %s"
+                    % (consumer, warmer, key, list(ce[key]), list(paths))
+                )
+
+    if problems:
+        sys.stderr.write("check-gate-cache-keys-agree: %d problem(s)\n\n" % len(problems))
+        for p in problems:
+            sys.stderr.write("  - %s\n\n" % p)
+        return 1
+
+    sys.stdout.write(
+        "check-gate-cache-keys-agree: OK — %d warmed key(s) match their consumer.\n" % checked
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The measurement

On `merge_group`, inside the 20.2 min `check` job:

| step | median |
| --- | --- |
| Build nros CLI + provision sources | **128 s** |
| Build `nros-launch-resolve` | **91 s** |

219 s **per entry**, rebuilding artifacts whose sources had not changed — and an sccache dir that missed both its exact key *and* its `sccache-Linux-check-` restore prefix.

## The cause is scoping, not keys

The logs said so plainly:

```
Cache not found for input keys: nros-cli-Linux-39b56aa9…, nros-cli-Linux-
```

**Both** the exact key and the prefix missed, which a stale-key theory cannot explain.

GitHub lets a run restore caches from its own ref or from the **default branch**, and nothing else. A `merge_group` run executes on an ephemeral `gh-readonly-queue/main/pr-N-<sha>` ref — so the cache it saves is scoped to a ref that will never run again, and its only other readable scope is `main`. Which was never written, because every cache step in `check` is gated to `pull_request | merge_group | schedule | workflow_dispatch`.

Both halves missed **by construction**. Every entry was cold on purpose, by omission.

## The fix

`warm-cache` writes those same keys on `push` to main — once per merge instead of once per queue entry. It runs no gates; its only product is a populated cache.

**Deliberately not added to `ci-ok`'s `needs`.** It runs only on `push`, and a required aggregator waiting on a job that never runs for a pull request blocks every PR forever — issue 0975, which froze this repo once already. Verified `ci-ok` still needs exactly `[changes, check, scaffold-journey, colcon-parity, sdk-index]`.

## The gate

`check-gate-cache-keys-agree` asserts the warm job and its consumer share key **and** path. Without it, a one-character drift leaves the warm job succeeding, uploading, and warming **nothing** — a silent no-op with no error anywhere.

I wrote the gate rather than just the comment because I made the opposite mistake earlier today: a comment crediting a gate with a rule it did not enforce.

Mutation-tested:

```
drift the warm key   -> "warms key … which `check` never reads"
drop a cached path   -> "cache different paths"
```

## Expected effect

Up to 219 s off each `check` run once main has been warmed once. Combined with the queue now batching (`min_entries_to_merge: 3`), the same saving applies per *batch* rather than per PR.

The honest caveat: the first push to main after this merges still builds cold — the warm job has to run once before anything can restore from it.

`just check fast` — 218 gates, 0 failures.