### PR TITLE
fix(platform): the stack probe needs no allocator, so stop gating it behind one

### DIFF
--- a/packages/platform/nros-platform-api/src/lib.rs
+++ b/packages/platform/nros-platform-api/src/lib.rs
@@ -61,7 +61,9 @@
 // an ABI belongs with the ABI.
 #[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "alloc")]
+// Not `alloc`-gated: `task::stack_unused_bytes` is a plain FFI query, and a
+// stack-headroom probe is most load-bearing exactly on the no-alloc targets.
+// Only the allocate-spawn-join half inside needs the feature.
 pub mod task;
 
 use core::ffi::{c_int, c_void};

--- a/packages/platform/nros-platform-api/src/task.rs
+++ b/packages/platform/nros-platform-api/src/task.rs
@@ -23,6 +23,7 @@
 // once here is the cheaper truth.
 #![allow(dead_code)]
 
+#[cfg(feature = "alloc")]
 use core::ffi::c_void;
 
 /// The ABI's task attributes, mirrored for the `extern` declaration below.
@@ -33,6 +34,12 @@ use core::ffi::c_void;
 /// the wake and task symbols are declared here by hand. The layout is checked
 /// against the header by `check-ffi-struct-mirrors`; see the note at the spawn
 /// site for what a drift would cost.
+//
+// Gated with the spawn path that uses it: `stack_unused_bytes` below needs no
+// allocator, so the module is compiled without the `alloc` feature too, and an
+// ungated private struct would be dead code there. `check-ffi-struct-mirrors`
+// reads the source, not a build, so the layout stays checked either way.
+#[cfg(feature = "alloc")]
 #[repr(C)]
 struct TaskAttr {
     name: *const core::ffi::c_char,
@@ -44,10 +51,18 @@ struct TaskAttr {
 }
 
 /// `INT32_MIN` — inherit the creating task's priority.
+#[cfg(feature = "alloc")]
 const PRIORITY_INHERIT: i32 = i32::MIN;
 
+// The stack probe is a plain query with no arguments and no storage, so it is
+// declared unconditionally — see `stack_unused_bytes`.
 unsafe extern "C" {
     fn nros_platform_task_stack_unused_bytes() -> usize;
+}
+
+// Spawning is the half that allocates.
+#[cfg(feature = "alloc")]
+unsafe extern "C" {
     fn nros_platform_task_init(
         task: *mut c_void,
         attr: *mut c_void,
@@ -65,11 +80,13 @@ unsafe extern "C" {
 /// have to signal their worker to stop BEFORE waiting for it — a `Drop` that
 /// joined implicitly would deadlock against a worker still blocked on its own
 /// wait.
+#[cfg(feature = "alloc")]
 pub struct PlatformTask {
     ptr: *mut u8,
     layout: core::alloc::Layout,
 }
 
+#[cfg(feature = "alloc")]
 impl PlatformTask {
     /// Spawn `entry(arg)`, or `None` when this platform cannot host a task
     /// (no storage sizing, allocation failure, or a refused spawn).
@@ -178,6 +195,7 @@ impl PlatformTask {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Drop for PlatformTask {
     fn drop(&mut self) {
         // Reached only if a caller dropped the handle without joining, which


### PR DESCRIPTION
`main` does not build for the embedded target:

    packages/core/nros-node/src/executor/spin.rs:2415
    error[E0433]: cannot find `task` in `nros_platform_api`
    note: found an item that was configured out — gated behind the `alloc` feature

Two commits met: cb2be0ca4 added `check_stack_headroom_rule`, which calls
`nros_platform_api::task::stack_unused_bytes()`, and 411addfd2 put the probe
inside `pub mod task` — a module gated on `alloc` because it also holds the
allocate-spawn-join helper. `stack_unused_bytes` is a plain FFI query with no
arguments and no storage; it needs nothing from an allocator. It was only in
there because the spawn helper lives there too.

So the module is no longer alloc-gated, and the half that actually allocates
is gated instead: `PlatformTask` with its `impl` and `Drop`, the four spawn
symbols, `TaskAttr`, `PRIORITY_INHERIT`, and the `c_void` import. The extern
declaration for the probe stands on its own. `check-ffi-struct-mirrors` reads
the source rather than a build, so gating `TaskAttr` does not stop its layout
being checked against the header.

Gating the CALLER instead would have compiled just as well and been wrong:
that disables stack-headroom monitoring precisely on the no-alloc targets,
which are the ones where a stack overflow silently corrupts another
component's state and where `heap_used_bytes` has had a counterpart since
RFC-0034 D7.

Why it sat on main: the lane that catches it is `check::build`, which
`schedule`/`workflow_dispatch` run and no merge-gating event does (CLAUDE.md,
"PR cheap, batch thorough"). Both halves were individually green on the
required `CI` context. Not proposing a lane change here — `workspace-all` is
62 s and `workspace-features` 435 s measured, which is a real per-PR cost and
somebody else's call.

Verified: `check-workspace-all` and `check-workspace-features` both green
(each was red before this); clippy `-D warnings` clean for
`nros-platform-api` under `--no-default-features` and `--features alloc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)