### PR TITLE
fix(#1072, #1040, #1030): delete the gate registry, and make a lane that cannot report a failure

### DIFF
--- a/.config/gate-lane-exempt.txt
+++ b/.config/gate-lane-exempt.txt
@@ -1,0 +1,70 @@
+# Recipes in `just/check.just` that are NOT fast-lane gates.
+#
+# Issue 1072. `just/check.just` is the tree's busiest merge target — 15 of the
+# 31 pull requests open on 2026-09-05 touch it, 36 % more than the next path —
+# and until this file existed it carried a 218-name `fast-serial:` dependency
+# list that every gate-adding PR appended to. A sorted one-name-per-line list
+# does not survive two authors adding ALPHABETICALLY ADJACENT names: both
+# insertions land at the same base line, git has no unchanged line between them
+# to anchor on, and it conflicts. PR #472 hit exactly that with
+# `codegen-stamp-inputs` next to main's `codegen-tool-reconfigure`.
+#
+# Issues 0883/0884 already established the only fix that reaches the merge
+# queue: REMOVE THE SHARED AUTHORED LINE. A `.gitattributes` merge driver does
+# not run on GitHub's server-side rebase, so union-merging the list was never
+# available here.
+#
+# So the polarity is inverted. A recipe in `just/check.just` is a FAST-LANE
+# GATE by default; the exceptions are the ~20 gates in `build-serial:` (they
+# need something built) and the names below. Adding a gate is now writing its
+# recipe — one insertion, at one place, in the author's own region of the file.
+# No shared list is touched at all.
+#
+# That also closes the other half of issue 1071. Under the old design a gate
+# could be lost by deleting its registry line while the recipe stayed (PR #431
+# lost four that way and `check-gate-lists` stayed green). There is no registry
+# line to delete now: a fast gate can only leave the lane by having its RECIPE
+# deleted, which is visible in review and which a name-set ratchet catches.
+#
+# FORMAT: one name per line, sorted, `# reason` REQUIRED on every line.
+# `check-gate-lists` enforces the format, that every name here names a real
+# recipe, that nothing is both exempt and in `build-serial:`, and that every
+# recipe in the file is classified exactly once.
+#
+# This is a ratchet in spirit, like `.config/ungated-gates.txt`: it should
+# SHRINK. An entry marked `no caller` is not a decision — it is issue 1071's
+# class caught in passing, recorded so it stops being invisible.
+
+_gate-list-end  # the `build-serial:` terminator, a no-op, not a gate
+api-parity  # a REPORT, not a gate; `just ci gate` and gate.yml run it by name
+archive-lang-items  # in no lane and no caller found — issue 1071's class
+book-identifiers  # in no lane and no caller found — issue 1071's class
+build  # lane verb: fans `build-serial` out through run-gates-parallel.sh
+build-serial  # the build-tier registry, still an authored dependency list
+cli-clippy  # called by `check-cli-fmt`'s body, not run standalone
+compile-smoke  # gate.yml runs it by name on pull_request; needs a compile
+decoupling  # RFC-0031 superseded its goal; kept runnable, must not gate (see the file header)
+default  # lane verb: `cli-fresh` + `fast` + `build` + `api-parity`
+dep-chain  # post-submit.yml runs it by name; needs codegen output
+dist-runtime-deps  # re-implemented inline by `just workspace doctor`; no lane
+executor-stack-floor  # in no lane and no caller found — issue 1071's class
+fast  # lane verb: fans this lane out through run-gates-parallel.sh
+fast-parallel  # retired alias for `fast`, kept for muscle memory
+fast-serial  # lane verb: the same lane, one gate at a time, fail-fast
+nextest-test-filters  # in no lane and no caller found — issue 1071's class
+no-std  # gate.yml + `just ci` run it by name; cross-compiles riscv32
+rmw-feature-matrix  # generator `--check`; in no lane and no caller found
+sched-matrix  # generator `--check`; in no lane and no caller found
+sdk-index  # NETWORK — downloads and sha256-checks SDK release assets
+stack-floor  # in no lane and no caller found — issue 1071's class
+submodule-commits-reachable  # gate.yml runs it by name; needs the remote
+submodule-drift  # in no lane and no caller found — issue 1071's class
+support-status  # generator `--check`; in no lane and no caller found
+tier-preconditions  # a PRECONDITION reporter; runs at the head of `just ci`
+weak-symbols-image  # needs built fixtures, so it cannot be buildless
+workspace  # aggregate: depends on `workspace-fmt`, echoes where its jobs went
+workspace-embedded  # cross-compiles the workspace for thumbv7; minutes
+workspace-rmw-agreement  # in no lane and no caller found — issue 1071's class
+zenoh  # `cargo clippy -p nros-rmw`; a compile, not a source gate
+zenoh-archive  # reads a built `libnros_rmw_zenoh_staticlib.a`
+zephyr-kconfig-symbols  # needs the fetched Zephyr Kconfig trees (~600 MB)

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -801,27 +801,34 @@ jobs:
       # `borrowed-e2e` since at least 2026-09-01 with nobody noticing, which is
       # issue 0993's whole thesis arriving on schedule. Filed separately; a lane
       # cannot start gating pull requests while it is already red.
-      - name: just check build + no_std + api-parity (nightly / manual only)
+
+      # ONE GATE PER STEP — issue 1040, measured 2026-09-05.
+      #
+      # These three shared a single `run:` block, and a `run:` block is `bash
+      # -e`: the first non-zero command ends it. `check build` has been red on
+      # this lane since 2026-09-01 (`workspace-all`, `workspace-features`), so
+      # `check no-std` and `check api-parity` NEVER EXECUTED on any of the five
+      # scheduled runs since they were wired here. The step reported one red for
+      # three gates, and two of them had no verdict at all — issue 0952's
+      # withdrawal class, one level down from the recipe that names it.
+      #
+      # That is worse than not wiring them: `grep -rl api-parity
+      # .github/workflows/` now answers yes while the gate has still never run
+      # in CI. A placement that cannot report is not a placement.
+      #
+      # `!cancelled()` on each is what makes the split work: GitHub skips later
+      # steps after a failure only under the default `success()` condition.
+      - name: just check build (nightly / manual only)
         if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
         run: |
           source ./activate.sh
           just check build
+
+      - name: just check no-std (nightly / manual only)
+        if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) && !cancelled() }}
+        run: |
+          source ./activate.sh
           just check no-std
-          # issue 1040 — `check-api-parity` ran in NO workflow at all. Not on
-          # pull_request, not on merge_group, not nightly, not on dispatch:
-          # `grep -rl api-parity .github/workflows/` returned nothing. It
-          # existed only as a local recipe, so an unclassified row was invisible
-          # until somebody happened to run the full tier — and three landed on
-          # main on 2026-09-04 alone.
-          #
-          # It belongs HERE and not on the merge gate: it re-extracts our own
-          # surface with clang and nightly rustdoc, which is why it is not on
-          # the fast line. Making it required is what deadlocked the queue when
-          # `check-build` was required with prerequisites no CI job builds
-          # (`check-lane-contracts` now forbids that shape). A daily signal on
-          # the lane that already has one costs nothing extra and is the whole
-          # gap.
-          just check api-parity
 
       # Aspirational umbrella-decoupling guard — EXPECTED TO FAIL until the
       # Phase 104.A migration completes. Advisory only. (Build tier, non-push.)

--- a/.github/workflows/post-submit.yml
+++ b/.github/workflows/post-submit.yml
@@ -23,7 +23,9 @@
 # COMPLETES NEVER — a lane that always cancels looks busy while reporting
 # nothing, which is worse than the skipped job phase-411 made visible.
 #
-# What stays here is `dep-chain`: hosted, 158 s, genuinely per-merge.
+# What stays here is `dep-chain` (hosted, 158 s) and `api-parity` (hosted,
+# 28.6 s measured, no fixture/SDK/QEMU/ROS) — both genuinely per-merge, both
+# in their OWN job so one red cannot withdraw the other's verdict.
 #
 # WHAT THIS DOES NOT DO YET
 #
@@ -122,12 +124,85 @@ jobs:
           source ./activate.sh
           just check dep-chain
 
+  # issue 1040 — `check-api-parity`, the gate whose placement could not report.
+  #
+  # WHY HERE AND NOT ON THE MERGE GATE
+  #
+  # COST says it could gate: measured 28.6 s wall for `just check api-parity` on
+  # a 24-core host, and there is no warm/cold split to hide behind — the tool
+  # builds rustdoc JSON into a FRESH temp target dir every run, so 28.6 s is
+  # what it always costs. It needs no fixture, no SDK, no QEMU, no cross
+  # toolchain and no ROS install: the ROS 2 side is the committed surface under
+  # `docs/reference/api-surface/`, and our C/C++ side parses the COMMITTED
+  # `nros_cpp_config_generated_nuttx.h` (`-DNROS_PLATFORM_NUTTX`), so nothing
+  # here resolves an artifact this job does not have. That is cheaper than
+  # `dep-chain` (158 s) already on this lane, and cheaper than `test-unit`
+  # (~3.5 min) which the merge group affords.
+  #
+  # STATE says it must not gate yet. The gate is RED on main today —
+  # `rust:Executor::set_min_stack_headroom_bytes` has no ledger row — and
+  # gate.yml's own comment states the rule this repo has now paid for five
+  # times: a lane cannot start gating pull requests while it is already red.
+  # Promotion to `merge_group` is a follow-up, once the ledger row lands.
+  #
+  # So: `push` to main, which is what post-submit is for. It bounds an
+  # unledgered surface change to ONE commit with a named author instead of to a
+  # nightly batch, which is issue 1040's actual complaint — "the person who
+  # broke it pays nothing, the person who runs the tier pays everything".
+  #
+  # ITS OWN JOB, not a step beside `dep-chain`: two gates in one job serialise
+  # their verdicts, and gate.yml just spent five nights proving what that costs
+  # (`check build` red => `no-std` and `api-parity` never ran, reported as one
+  # red for three gates).
+  api-parity:
+    name: api-parity (C/C++/Rust surface vs rclc/rclcpp/rclrs)
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/newslabntu/nano-ros-ci:humble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      # clang is NOT in the ci-base image (`ci/docker/ci-base/Dockerfile` installs
+      # gcc cross toolchains and a PINNED clang-format, never clang itself), and
+      # `scripts/api_parity/extract_cxx.py` shells out to `clang`/`clang++` for
+      # `-Xclang -ast-dump=json`. Without this the gate cannot run at all — which
+      # is the other half of why it had never produced a verdict.
+      #
+      # Package names come from `nros-sdk-index.toml` via prereq-packages.py, the
+      # same SSoT `nightly.yml` uses for its bindgen cells, so a distro rename
+      # moves in one place.
+      - name: Install clang (extract_cxx dumps a clang AST)
+        run: |
+          apt-get update -q
+          apt-get install -y --no-install-recommends \
+            $(python3 scripts/sdk/prereq-packages.py --manager apt clang)
+      - name: just check api-parity
+        run: |
+          source ./activate.sh
+          just check api-parity
+
   coverage:
-    name: coverage report (did dep-chain run?)
-    needs: [dep-chain]
+    name: coverage report (did the post-submit lanes run?)
+    needs: [dep-chain, api-parity]
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Report whether the interlocked lane ran
-        run: ./scripts/ci/report-interlock-coverage.sh "dep-chain" "${{ needs.dep-chain.result }}" "true"
+      # Both lanes reported, then the verdicts combined — NOT two commands in a
+      # row. A `run:` block is `bash -e`, so a leading non-zero call withdraws
+      # the one behind it, and this job exists precisely to say whether a lane
+      # ran. Reporting one lane's coverage by silently not reporting the other's
+      # is the defect issue 1040 is about, in the job that reports on it.
+      - name: Report whether each interlocked lane ran
+        run: |
+          rc=0
+          ./scripts/ci/report-interlock-coverage.sh \
+            "dep-chain" "${{ needs.dep-chain.result }}" "true" || rc=1
+          ./scripts/ci/report-interlock-coverage.sh \
+            "api-parity" "${{ needs.api-parity.result }}" "true" || rc=1
+          exit "$rc"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,25 @@ Four entry points live in the module beside the gates: `default` (the full tier,
 and it must stay FIRST — `just check` runs a module's first recipe, not the one
 named `default`), `fast`, `fast-serial` and `build`.
 
-`fast-serial` both DECLARES the fan-out set and runs it serially, so its
-dependency list is the contract: `scripts/build/run-gates-parallel.sh` awks
-`/^fast-serial:/` out of `just/check.just` to build the parallel set. Moving it
-silently empties the runner rather than failing. Adding a gate means adding it
-to `fast-serial`'s list — **not** to `build`, which since phase-396 W1 runs on
+**Adding a fast gate is writing its recipe. There is no list to append to**
+(issue 1072). `fast-serial:` used to carry all 218 names as a sorted
+dependency list, and that list was the single busiest merge target in the tree
+— 15 of the 31 pull requests open on 2026-09-05 touched `just/check.just`, and
+two authors adding ALPHABETICALLY ADJACENT gate names insert at the same base
+line, which git cannot merge. No `.gitattributes` driver can fix it either,
+because GitHub rebases queue entries server-side (issue 0884), so the shared
+line was deleted rather than reformatted.
+
+Membership is now DERIVED: a recipe in `just/check.just` is a fast gate unless
+it is in `build-serial:`, named in `.config/gate-lane-exempt.txt` with a
+reason, or declares parameters (a gate runs as `just check <name>`, with
+nothing after the name). `scripts/check/check-gate-lists.py --list <lane>` is
+the one place that derivation lives; `run-gates-parallel.sh` and
+`check-gate-visibility.py` both ask it rather than parsing the justfile, and it
+exits non-zero rather than emitting a short list.
+
+Put a gate in `build-serial:` only when it CANNOT run without something built
+— **not** as a default, because since phase-396 W1 that lane runs on
 `schedule`/`workflow_dispatch` only and therefore gates nothing a merge passes
 through.
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -60,6 +60,7 @@
 - [Message Generation](./user-guide/message-generation.md)
 - [Configuration](./user-guide/configuration.md)
 - [Logging](./user-guide/logging.md)
+- [Simulated Time](./user-guide/simulated-time.md)
 - [Build Profiles](./user-guide/build-profiles.md)
 - [Profiling Your Build](./user-guide/build-profiling.md)
 - [Deployment Workflow](./user-guide/deployment.md)

--- a/book/src/user-guide/simulated-time.md
+++ b/book/src/user-guide/simulated-time.md
@@ -1,0 +1,146 @@
+# Simulated Time
+
+A node in a simulation or replaying a bag should run on the simulator's clock,
+not the wall. nano-ros implements ROS 2's answer to that: `rosgraph_msgs/msg/Clock`
+on `/clock`, the `use_sim_time` parameter, and timers that can be told which
+clock advances them.
+
+## The distinction the names carry
+
+rclcpp draws it in the method name, and so do we:
+
+| you write | it advances with | affected by `/clock` |
+|---|---|---|
+| `create_wall_timer(period, cb)` | the platform's monotonic clock | no |
+| `create_timer(clock, period, cb)` | whatever `clock` is | yes, if it is a ROS-time clock |
+
+A wall timer is the right choice for a watchdog, a transport keep-alive, or
+anything whose job is to notice that real time has passed — a paused simulator
+must not pause those. Everything that consumes simulated data wants the other
+one.
+
+If you are porting from rclcpp, the spelling you already write is the spelling
+that works. If you are reading older nano-ros code, note that `create_timer`
+used to mean the wall timer here; it does not any more, and there is no alias.
+
+## Reading the time
+
+A node's clock is ROS time, as in rclcpp:
+
+```cpp
+nros::Time now = node.get_clock()->now();
+```
+
+With no `/clock` source installed, a ROS-time clock reads system time. That is
+the same fallback `rclcpp::Clock` has, and it is what makes a node written for
+simulation still run standalone.
+
+Two predicates report which situation you are in:
+
+```cpp
+node.get_clock()->ros_time_is_active();  // is a /clock source driving this?
+node.get_clock()->started();             // has a first sample arrived?
+```
+
+## Turning it on
+
+### With the parameter, as in ROS 2
+
+Declare `use_sim_time` and the runtime attaches the source itself — from a
+launch file, a params YAML, or `ros2 param set`:
+
+```yaml
+talker:
+  ros__parameters:
+    use_sim_time: true
+```
+
+`use_sim_time` is reserved: nothing reads its value, the runtime acts on it.
+Set it false and `/clock` samples stop being installed.
+
+The Rust crate needs the `sim-time` feature, because the subscription costs an
+entity slot and an RX buffer:
+
+```toml
+nros-node = { version = "0.5", features = ["sim-time"] }
+```
+
+### Explicitly
+
+```rust
+node.install_ros_time_source()?;          // subscribes /clock
+node.install_ros_time_source_on("/sim/clock")?;  // a remapped clock
+```
+
+QoS is `ClockQoS` — best effort, keep-last 1, volatile. A late subscriber wants
+the next sample, not a replay of the simulation's history.
+
+## Writing a timer that follows it
+
+### C++
+
+```cpp
+nros::Timer t;
+NROS_TRY(node.create_timer(t, *node.get_clock(), 100, on_tick));
+```
+
+### Rust
+
+```rust
+executor.register_timer_on_clock(
+    TimerDuration::from_millis(100),
+    TimerClockSource::Ros,
+    || { /* … */ },
+)?;
+```
+
+`TimerClockSource::Steady` is the default everywhere and stays free: it consumes
+the spin delta the executor has already measured. `Ros` and `System` read their
+clock on every poll of the timer, which on a target is a platform call — that is
+why the choice is a separate entry point rather than a defaulted argument.
+
+## What happens at the edges
+
+**Paused.** `/clock` stops advancing, so the delta is zero and a ROS-time timer
+does not fire. Wall timers on the same executor keep their cadence.
+
+**Replayed at 0.5x or 2x.** The timer tracks the rate, because it advances by
+the clock's own delta rather than by elapsed real time.
+
+**A jump backwards** — a bag looping, a simulator reset — restarts the period.
+The alternative would be a timer that stays silent for the length of the jump.
+
+**A jump forwards** is not special-cased. It lands as a backlog, and
+`TimerOverrunPolicy` decides: `Skip` (the default) coalesces it into one
+activation and counts the rest, `CatchUp` replays every missed period.
+
+**Unsubscribing does not reset the clock.** A node that stops listening keeps
+the last simulated time rather than snapping back to the wall, which every
+ROS-time timer would otherwise absorb as a jump backwards. Clearing is
+deliberate: `Clock::clear_ros_time_override()`.
+
+## Limits worth knowing before you rely on this
+
+**One simulated clock per image.** The override is process-global, which is the
+model `nros_core::Clock` has always documented. Two nodes in one image cannot be
+on different simulated times.
+
+**No jump callbacks.** `rclcpp::Clock::create_jump_callback` and the
+`rcl_jump_threshold_t` machinery have no counterpart. The behaviour a jump
+produces is fixed (above); you cannot subscribe to the event.
+
+**No `wait_until_started` / `sleep_until`.** RFC-0021 forbids a blocking helper
+that does not drive the executor. Poll `started()` from your spin loop.
+
+**Timers only.** A ROS-time clock changes what `now()` returns and what a
+ROS-time timer does. It does not retime message delivery, QoS deadlines, or
+transport lease timers — those remain on the monotonic clock, which is what you
+want for a link that has to stay up while the simulation is paused.
+
+**The age monitor is on a different clock from your stamps.** RFC-0052's
+`max-age-runtime` rule compares a message's `header.stamp` against an EPOCH
+clock (µs since the UNIX epoch, installed by the board via
+`Executor::set_epoch_clock`). If you stamp with `node.get_clock()->now()` while
+a simulator is driving ROS time, the two disagree and the reported ages are
+meaningless — usually enormous. Either stamp from the epoch clock, or leave the
+age rule off for that topic while running under simulation.

--- a/docs/issues/1040-gating-lanes-that-report-nothing-accumulate-reds.md
+++ b/docs/issues/1040-gating-lanes-that-report-nothing-accumulate-reds.md
@@ -6,7 +6,7 @@ title: "`check-api-parity` runs in NO workflow and `check-build` only on
 status: open
 type: task
 area: [ci, process]
-related: [1035, 1021, 0952]
+related: [1035, 1021, 0952, 1030, 1071, 1072]
 ---
 
 ## The measurement
@@ -33,6 +33,8 @@ JSON parsers keep the last silently. Now gated in `api-parity.py`.
    .github/workflows/` returns nothing. Not on `pull_request`, not on
    `merge_group`, not nightly, not on dispatch. It exists only as a local
    recipe.
+   *(2026-09-05: `2019640f7` changed the answer to that grep and did not change
+   the fact — see "Why the 2026-09-04 fix did not fix it" below.)*
 2. **`check-build` runs on `schedule` / `workflow_dispatch` only**
    (`gate.yml:740`). That is deliberate and correct — CLAUDE.md records why:
    it needs generated bindings and prebuilt `.compile-ok` that no CI job
@@ -86,3 +88,113 @@ Making these required checks. That is what put `check-build` on the merge group
 and made it red for every PR for a day, because it resolves artifacts no CI job
 builds — the failure mode `check-lane-contracts` now gates against. The problem
 here is reporting, not enforcement.
+
+---
+
+## The survey (2026-09-05) — gate → workflow event
+
+Measured, not reasoned: `python3 scripts/check-default-gates-run-somewhere.py
+--survey` prints the table, derived from `.github/workflows/` and from
+`check-gate-lists.py --list`, which is where lane membership lives since issue
+1072 deleted the authored `fast-serial:` registry.
+
+| bucket | count | who |
+| --- | --- | --- |
+| merge-gating (`pull_request` and/or `merge_group`) | 222 | the derived fast lane (218) + `cli-tests`, `compile-smoke`, `decoupling`, `submodule-commits-reachable` |
+| post-submit (`push`) but not gating | 22 | the `build-serial` tier (20 of 21) + `api-parity` + `dep-chain` — reached by `just ci tier1` in `host-tests.yml` and by `post-submit.yml` |
+| `schedule`/`workflow_dispatch` only | 1 | `no-std` |
+| **NO event at all** | **0** | — |
+
+So the headline claim above is now stale in one direction and was never the
+whole story in the other. `check-api-parity` IS named in a workflow (gate.yml,
+`schedule`/`workflow_dispatch`, added by `2019640f7`) — and had still never
+produced a verdict. See below.
+
+Two further facts the survey turned up, both outside the table because they are
+about lane MEMBERSHIP rather than events:
+
+* The gates that reach no event at all are the ones in NEITHER lane, and issue
+  1071/1072 already enumerated them in `.config/gate-lane-exempt.txt` (ten
+  entries marked `in no lane and no caller found`). Nothing is duplicated here.
+* `just check sdk-index` reaches no event by NAME, but gate.yml's `sdk-index`
+  job runs the same three scripts directly, so the checks do run.
+
+## Why the 2026-09-04 fix did not fix it
+
+`2019640f7` appended `just check api-parity` to gate.yml's existing
+`just check build + no_std` step. A GitHub `run:` block is `bash -e`, so the
+three shared a fate — and `just check build` has been red on that lane since
+2026-09-01 (`workspace-all`, `workspace-features`; run 33937933817 and the four
+before it). On every scheduled run since api-parity was wired there it
+**never executed**. The lane reported one red for three gates, two of which had
+no verdict at all.
+
+That is issue 0952's withdrawal class one level down: `ci::gate` prints what a
+red step withdrew precisely because a count of reds is not a coverage report,
+and in YAML there is no recipe to print it. It is also the worse kind of
+not-fixed, because `grep -rl api-parity .github/workflows/` now answers yes.
+
+## What landed
+
+1. **gate.yml: one gate per step.** `check build` and `check no-std` are now two
+   steps, each with the same `schedule`/`workflow_dispatch` + `!cancelled()`
+   guard — `!cancelled()` is what lets a step run after an earlier failure.
+2. **post-submit.yml: `api-parity` as its own job**, on `push` to main +
+   `workflow_dispatch`.
+   * **Cost, measured:** `just check api-parity` is **28.6 s** wall on a 24-core
+     host, and there is no warm/cold split — `extract_rust.rustdoc_json` builds
+     into a FRESH temp target dir every run. It needs no fixture, no SDK, no
+     QEMU, no cross toolchain and no ROS install: the ROS 2 side is the
+     committed surface under `docs/reference/api-surface/`, and the C/C++ side
+     parses the committed `nros_cpp_config_generated_nuttx.h`.
+   * **One prerequisite the wiring had missed:** `clang` is NOT in
+     `ci/docker/ci-base/Dockerfile` (it installs gcc cross toolchains and a
+     pinned clang-format, never clang), and `extract_cxx` shells out to
+     `clang`/`clang++` for `-Xclang -ast-dump=json`. The job installs it from
+     the index SSoT (`scripts/sdk/prereq-packages.py --manager apt clang`), the
+     same way nightly.yml does for its bindgen cells. Until this, the step could
+     not have run even had it been reached.
+   * **Why not `pull_request`/`merge_group`:** cost says it could — it is
+     cheaper than `dep-chain` (158 s) already on this lane and than `test-unit`
+     (~3.5 min) which the merge group affords. STATE says not yet: the gate is
+     RED on main today (`rust:Executor::set_min_stack_headroom_bytes` has no
+     ledger row), and a lane cannot start gating pull requests while it is
+     already red. Promotion is a follow-up once that row lands.
+   * **Its own job, not a step beside `dep-chain`** — for the reason this issue
+     is about.
+3. **`check-default-gates-run-somewhere` now carries the class**, in two rules:
+   R1 every gate in `just check`'s lanes must reach some workflow event
+   (widened from the four names on `default:`), and R2 no placement may be
+   sequenced behind another gate in the same `run:` block. Verified against the
+   UNFIXED `gate.yml`: two findings (`api-parity`, `no-std`), no false
+   positives; green against the fixed one. Both allowlists
+   (`NO_PLACEMENT_NEEDED`, `SHADOWED_PLACEMENT_OK`) are EMPTY by measurement.
+4. **`check-lane-contracts` no longer looks away from report-only lanes** — see
+   issue 1030's follow-up.
+
+## Still open
+
+* ~~`rust:Executor::set_min_stack_headroom_bytes` is unledgered, so
+  `api-parity` is red on main.~~ CLEARED 2026-09-05: PR #474 landed the row (in
+  `exec.json` — the ledger is sharded by TOPIC across all three languages;
+  there is no `rust.json`) and `just check api-parity` is green.
+
+  **Promotion to `merge_group` is now unblocked and deliberately NOT taken.**
+  Cost allows it — 28.6 s, cheaper than `dep-chain` at 158 s which already
+  gates. What is missing is a track record: one green local run is not evidence
+  that a gate is stable enough to freeze the repo on. Promote it after it has
+  been green on post-submit for a cycle, and remember that making it gating
+  means adding it to the `CI` aggregator's `needs:`, never to the required-check
+  set directly.
+
+  The ROW ITSELF is still wrong about one thing, and that correction is owed:
+  it claims the item was "newly EXTRACTABLE" after phase-425 moved an `alloc`
+  gate off `nros_platform_api::task`. Measured 2026-09-05 on a tree WITHOUT
+  that change and the extractor reports the item anyway, so the causal story is
+  unverified. The row is right that it needed classifying; it is wrong about
+  why it appeared.
+* `check build` is red on the scheduled lane (`workspace-all`,
+  `workspace-features`). Now that the steps are split, `no-std` reports
+  independently of it.
+* #1035 (a platform that does not build at all) still has no lane. Unchanged by
+  this work.

--- a/docs/issues/1072-every-pr-conflicts-on-five-shared-append-targets.md
+++ b/docs/issues/1072-every-pr-conflicts-on-five-shared-append-targets.md
@@ -155,3 +155,180 @@ comm -12 <(git diff --name-only $mb..origin/<branch> | sort) \
 
 `git merge-tree --write-tree` would answer this directly and is unavailable —
 git 2.34.1 here, it needs 2.38+.
+
+---
+
+## RE-MEASURED 2026-09-05, later the same day — the picture moved
+
+Twenty of the 51 pull requests merged between the two measurements, so the
+numbers above are stale. Re-run against `origin/main` at `29d8dd61d`, with
+`git merge-tree --write-tree` — which **is** available: this host has git 2.55,
+and the "git 2.34.1 here, it needs 2.38+" note in the Method section was wrong
+about the machine it was written on.
+
+**31 open pull requests, 11 CONFLICTING.**
+
+| conflicting path | in how many of the 11 |
+| --- | --- |
+| `docs/reference/api-parity-ledger/node.json` | 4 |
+| `docs/reference/api-parity-ledger/other.json` | 3 |
+| `docs/roadmap/phase-424-build-graph-freshness-truth.md` | 3 |
+| `docs/reference/api-parity-ledger/graph.json` | 2 |
+| **`just/check.just`** | **2** |
+| seven other paths (one issue file each, two executor sources, one cmake) | 1 |
+
+As a group, `docs/reference/api-parity-ledger/*.json` is the largest cluster —
+4 distinct pull requests (#329, #446, #471, #481). `phase-424` is 3 (#434,
+#472, #492). `just/check.just` has dropped from 12 to 2.
+
+### Conflict count is the wrong lead indicator, and the touch count says so
+
+Two more measurements, because "conflicts against main today" only counts the
+hazards that have already fired:
+
+**Paths the most open PRs TOUCH** — the pool every future conflict comes from:
+
+| path | open PRs touching it |
+| --- | --- |
+| **`just/check.just`** | **15 of 31** |
+| `packages/core/nros-node/src/executor/spin.rs` | 11 |
+| `packages/api/nros-cpp/src/lib.rs` | 8 |
+| `packages/api/nros-cpp/include/nros/node.hpp` | 6 |
+| `docs/reference/api-parity-ledger/init.json` | 6 |
+
+`just/check.just` is touched by nearly half of all open pull requests, 36 %
+more than the next path. Its conflict count is low today because most of those
+15 have not yet had `main` move under their particular anchor — not because
+the hazard went away.
+
+**Merge-queue simulation** — for each of the 20 PRs that are mergeable now,
+land it on `main` and then merge each of the other 19 (`git commit-tree` on the
+merge-tree result, then a second merge-tree). Of 190 pairs, **6 collide**, on
+`phase-412`/`boot_report.rs`/`spin.rs`/`task.rs` — none on `just/check.just`.
+Two independent appends to that file usually *do* merge; the question is what
+happens when they do not.
+
+### §1 was wrong: the registry is not innocent
+
+The issue says above that the `fast-serial:` registry "merges **cleanly**" and
+that only the recipe bodies conflict. Both live `just/check.just` conflicts
+were examined; they are one of each, and the registry one is real:
+
+* **#472** conflicts **in the registry**, at one hunk of three lines. It adds
+  `codegen-stamp-inputs` and `codegen-tool-reconfigure`; `main` had already
+  landed `codegen-tool-reconfigure`. Both insert at the same base index (42),
+  git has no unchanged line between them to anchor on, and it conflicts.
+* **#471** conflicts **in a recipe body** — but not by appending at a shared
+  anchor. Both sides *rewrote the same block* of `check-c` (one adding a
+  serialization-format probe, the other retiring the deprecation probes). That
+  is a genuine semantic disagreement about what the gate checks, and no
+  positional rule fixes it.
+
+The "four lines apart produced no conflict" observation was right and does not
+generalise. A sorted list is conflict-free only when the two new names are far
+enough apart, and **gate names are not independent**: related work produces
+related names, so sorting converts name correlation directly into position
+correlation. Measured across the 8 open PRs that add registry entries, the
+insertion indices are 15, 15, 15, 42, 42, 84, 139, 151, 208, 209, 209, 210,
+210 — clustered, not spread.
+
+### Why "sort the recipe bodies" (proposal 1 above) was rejected
+
+1. **It fixes neither measured conflict.** #472 is the registry. #471 is two
+   rewrites of one block, which relocating does not help.
+2. **It makes the two conflict classes correlated instead of independent.**
+   Sorting bodies by name puts `codegen-stamp-inputs`'s body immediately
+   beside `codegen-tool-reconfigure`'s *by construction* — the same
+   name-adjacency that already collides in the registry, now also colliding in
+   the bodies.
+3. **The cure costs more than the disease.** Reordering ~4,000 lines conflicts
+   with all 15 in-flight pull requests at once, converting a latent hazard into
+   15 certain conflicts.
+4. It scatters gates that share a comment block and a subject.
+
+## FIXED (the `just/check.just` half)
+
+The lesson from 0883/0884 is that the only fix which reaches the merge queue
+removes the **shared authored line** — a `.gitattributes` driver does not run
+on GitHub's server-side rebase. So the registry was not reformatted; it was
+deleted.
+
+**A recipe in `just/check.just` is a fast-lane gate unless it is listed in
+`build-serial:`, named in `.config/gate-lane-exempt.txt` with a reason, or
+declares parameters** (a gate runs as `just check <name>`, with nothing after
+the name, so a recipe requiring an argument can never be one).
+
+* The 218-name `fast-serial:` dependency list is **gone**. Adding a gate is
+  writing its recipe: one insertion, in the author's own region of the file,
+  colliding with nobody. The 13 registry additions across the currently open
+  PRs become 0.
+* `fast-serial:` keeps its name and its meaning — the same set, one gate at a
+  time, fail-fast — via `run-gates-parallel.sh --serial`, so both spellings
+  answer from one derived list rather than two copies.
+* `build-serial:` stays an authored dependency list, deliberately: ~20 names
+  that change rarely (none of the 13 additions went to it), read directly by
+  `check-gate-visibility`, and a gate belongs there only when it *cannot* run
+  without something built — worth stating explicitly.
+* `.config/gate-lane-exempt.txt` holds the 33 recipes that are not fast gates,
+  each with a required reason. It is a ratchet in spirit, like
+  `.config/ungated-gates.txt`: it should shrink.
+
+### This also closes issue 1071's other half
+
+PR #431 lost four gates by deleting their registry lines while the recipes
+stayed, and `check-gate-lists` — which verified the list's SHAPE — stayed
+green. There is no fast-lane registry line to delete now. A fast gate can only
+leave the lane by having its RECIPE deleted, which is visible in review.
+
+The polarity flip also inverts the failure mode, in the direction this repo
+keeps asking for. Forgetting the registry line meant the gate NEVER RAN —
+silent, issue 0196's class. Forgetting to exempt a new recipe means it runs on
+the fast lane: loud, and on the author's own pull request.
+
+**The name-set ratchet (PR #493) still works**, and reads one function instead
+of a regex: `check_gate_lists.gate_names()` returns the sorted fast + build
+set, raising rather than returning a short list if the classification is
+broken. `.config/gate-registry-baseline.txt` compares against that. The
+baseline's contents do not change — the derived set is byte-identical to what
+the old registry declared (218 fast + 21 build = 239).
+
+`check-gate-lists` stays meaningful, and checks something stronger than before:
+that the classification is **total and unambiguous** — every name in the build
+registry or the exemption ledger resolves to a real recipe, nothing is claimed
+twice, a parameterized recipe is never listed as a gate, and every exemption
+says why. The old shape checks on `build-serial:` (one per line, sorted,
+sentinel last, no duplicates) are unchanged.
+
+### Caught in passing: 12 recipes in no lane and with no caller
+
+Deriving the classification required enumerating every recipe, which turned up
+recipes that are in neither registry and that nothing invokes:
+`archive-lang-items`, `book-identifiers`, `dist-runtime-deps`,
+`executor-stack-floor`, `nextest-test-filters`, `rmw-feature-matrix`,
+`sched-matrix`, `stack-floor`, `submodule-drift`, `support-status`,
+`workspace-rmw-agreement`, `zenoh-archive`. They are recorded in the exemption
+ledger marked `no caller` so they stop being invisible; deciding their fate is
+issue 1071's business, not this one's.
+
+It also turned up **5 recipes the old parse never saw at all** — `stack`,
+`stack-all`, `stack-c`, `stack-elf`, `tier-priority-plan-image`, all of which
+take parameters. Any audit of `just/check.just` written against
+`^[a-z][a-z0-9-]*:` has been missing them.
+
+## STILL OPEN, and out of scope for this change
+
+* **`docs/reference/api-parity-ledger/*.json` (4 PRs) is now the largest
+  cluster.** The recommendation stands and is unchanged by the re-measurement:
+  a merge driver cannot reach the queue, so the untracking-shaped answer is the
+  one available — one file per key, or generate the ledgers and gitignore them
+  the way `docs/issues/open.md` was. They are written by `scripts/api-parity.py`
+  with `sort_keys=True`, so on-disk order carries no information and two
+  branches adding disjoint keys collide with certainty.
+* **`docs/roadmap/phase-424-*.md` (3 PRs)** — the Status paragraph, as
+  described in §4 above.
+* **`check-gate-visibility` had a latent vacuity** created by this change and
+  closed with it: it read `fast-serial:`'s dependency line, which now returns
+  an empty list. It asks `check-gate-lists.py --list fast` instead. Today the
+  branch is unreachable (`just check fast` IS run by a gating job), so this is
+  defensive — but a gate that silently reports zero is the exact shape that
+  file exists to prevent.

--- a/docs/issues/1091-ledger-shards-conflict-on-sorted-key-insert.md
+++ b/docs/issues/1091-ledger-shards-conflict-on-sorted-key-insert.md
@@ -1,0 +1,89 @@
+---
+id: 1091
+title: "The api-parity ledger is the largest PR-conflict cluster left: 17 sorted
+  JSON shards, and two branches adding disjoint keys collide with certainty"
+status: open
+type: tech-debt
+area: tooling, docs
+related: [0883, 0884, 1071, 1072]
+---
+
+## The measurement
+
+Re-measured 2026-09-05 against `origin/main`, over all 31 open pull requests
+(the run that produced issue 1072's table):
+
+| conflicting path | PRs |
+| --- | --- |
+| `docs/reference/api-parity-ledger/node.json` | 4 |
+| `docs/reference/api-parity-ledger/other.json` | 3 |
+| `docs/roadmap/phase-424-*.md` | 3 |
+| `docs/reference/api-parity-ledger/graph.json` | 2 |
+| `just/check.just` | 2 (fixed by 1072) |
+
+As a group the ledger is **4 distinct PRs** (#329, #446, #471, #481) — the
+largest remaining cluster, and now the largest full stop, since 1072 removed
+`just/check.just`'s shared list.
+
+## Why it conflicts, and why it will keep conflicting
+
+The shards are written by `scripts/api-parity.py` with `sort_keys=True`, so a
+new row lands at a position determined entirely by its KEY. Two branches adding
+rows for adjacent items — which is the normal case, because the campaign closes
+a feature at a time and a feature's items sort together — insert at the same
+base line with no unchanged line between them to anchor on. Git cannot merge
+that.
+
+This is issue 1072's finding one directory over: **sorting converts NAME
+correlation into POSITION correlation.** The shards were introduced precisely so
+"one agent per lane can write without a rebase conflict against the others"
+(`_doc` says so). Sharding by topic was the right first move and it is no longer
+enough — `pubsub.json` alone holds 376 rows, `action.json` 290, `exec.json` 260.
+
+Current sizes, 2504 rows over 17 files:
+
+```
+action 290   exec 260   pubsub 376   service 258   timer 259   other 255
+param 134    qos 133    lifecycle 124   node 115   graph 89   serde 48
+log 46       metadata 40   init 30   types 31   boot 16
+```
+
+## What does NOT work, already established
+
+* **A `.gitattributes` merge driver.** Issue 0884 settled it: GitHub rebases
+  merge-queue entries SERVER-SIDE, where `.gitattributes` drivers do not run.
+  `merge=union` fixed `docs/issues/open.md` locally and not in the queue.
+* **Generating the file and gitignoring it**, which is what 0884 did for
+  `open.md`. Not available here: the ledger is AUTHORED. Its whole value is the
+  hand-written `why` on each row — there is no generator to re-run.
+
+## The shape that does work
+
+Remove the shared file, the same answer 1072 reached for the gate registry and
+0884 for the issue index. Two candidates:
+
+1. **One file per row**, mirroring `docs/issues/` — a directory whose per-file
+   design is exactly why issue FILINGS stopped conflicting while the generated
+   index still did. 2504 small files; `api-parity.py` merges them the way it
+   already merges 17.
+2. **Shard harder by key prefix** — cheaper to land, and only pushes the
+   collision out: `pubsub.json` splitting into `pubsub-c/cpp/rust` still puts
+   every C++ pubsub row in one sorted file, and that is where the adjacent
+   insertions are.
+
+(1) is the one that actually ends it. (2) is a palliative and should be
+recorded as such if chosen.
+
+## Sequencing — do NOT start this while the cluster is open
+
+The migration rewrites every ledger file, so it conflicts with all four PRs it
+is meant to help, plus any phase-425 work in flight. Land the open ledger PRs
+first, then migrate in one commit against a quiet tree.
+
+## Acceptance
+
+Two branches each adding a row whose key sorts adjacent to the other's merge
+with no conflict, demonstrated rather than argued. `just check api-parity`
+green, and `--self-test` still rejects a row in the wrong stage — the shard
+identity that check depends on has to survive whatever layout replaces the
+files.

--- a/docs/issues/archived/1030-schedule-lane-producer-events.md
+++ b/docs/issues/archived/1030-schedule-lane-producer-events.md
@@ -130,3 +130,46 @@ see it, and the summary line says how little it covers (1 invocation today)
 rather than printing a bare OK. Declaring more requirements widens the rule for
 free; inventing a wrapper recipe nobody calls, purely to feed the gate, would
 not, so it was not done.
+
+---
+
+## Follow-up (2026-09-05, issue 1040): the scope call was reversed, with a measurement
+
+"Why the gate did not catch it" gives two reasons. Reason 2 (the predicate) was
+fixed here. Reason 1 (the scope — `GATING_EVENTS = {pull_request, merge_group}`)
+was recorded as a deliberate severity call and explicitly not proposed for
+reversal. It has now been reversed anyway, because the severity argument turned
+out to be an argument about how a finding should READ, not about whether to look:
+
+    SCANNED_EVENTS = GATING_EVENTS | {"push", "schedule", "workflow_dispatch"}
+
+Measured before changing anything: widening the scope moves the tier rules from
+3 resolved lanes to 15, and the finding count from 0 to 0. There is no cost to
+weigh, and the narrow scope's only effect was that the tier rules were
+structurally unable to look at the very lane this issue is about — the scheduled
+gate, red four consecutive nights.
+
+The severity distinction is KEPT, in the output: every derived finding is
+labelled `[gating]` or `[report]`, so "a repository nobody can merge into" still
+reads differently from "a bad nightly". Dropping the lane was never the only way
+to say that. `workflow_run` stays out of scope — `queue-notify.yml`'s `just ci
+l1` is a line of ADVICE TEXT in a comment it posts, not a lane it runs.
+
+**A second bug found while widening.** The derived loop tested each word of the
+`just` command against the recipe map on its own, which is wrong twice:
+
+* It MISSED every module lane. Neither `ci` nor `tier1` is a recipe, so
+  `just ci tier1` — `host-tests.yml`'s tier-1 job, which runs the whole default
+  `just check` — resolved to nothing and was never examined.
+* It MISATTRIBUTED. `just check api-parity` has two candidate recipes and the
+  bare-word test picked the wrong one: the root `api-parity lang=""` is a
+  parameterised REPORT, while the gate is `check::api-parity`. Their closures
+  differ, so the rule was answering about a recipe no workflow runs.
+
+`lane_invocations()` now pairs a word with the next when `<a>::<b>` is a real
+recipe, module spelling first. 3 lanes resolved before, 15 after, 0 findings
+either way. The summary line counts RESOLVED LANES rather than raw words — it
+used to say "51 CI lane invocation(s)" for 15 lanes, a number that grows when a
+workflow adds a `setup` step and says nothing about coverage.
+
+Five new self-tests (33 total, 0 failed).

--- a/scripts/build/run-gates-parallel.sh
+++ b/scripts/build/run-gates-parallel.sh
@@ -48,29 +48,49 @@ jobs="${NROS_GATE_JOBS:-$(nproc)}"
 # this setting. Kept because it is correct on its own terms; do not read it as
 # the resolution.
 export GIT_OPTIONAL_LOCKS=0
-# The gate list is DERIVED from check-fast's own dependency line, never kept
-# beside it: a second copy silently drifts the moment someone adds a gate, and
-# this runner would then report OK over a set that is missing it.
-list="${1:-}"
+
+# `--serial` runs the same set one gate at a time, fail-fast, output
+# unshredded — what `just check fast-serial` is for. A bare positional is a
+# pre-built list file, which is how a caller pins the set it wants.
+serial=0
+list=""
+for arg in "$@"; do
+    case "$arg" in
+        --serial) serial=1 ;;
+        -*) echo "$0: unknown flag: $arg" >&2; exit 2 ;;
+        *) list="$arg" ;;
+    esac
+done
+
+# `NROS_GATE_LANE` picks WHICH lane to run — issue 0993. `build` gained a
+# parallel runner when it moved onto the pull-request path: serial it is
+# ~587 s, and its slowest single gate is ~148 s, so the fan-out is the
+# difference between a tolerable PR and an intolerable one. Defaulting to
+# `fast-serial` keeps every existing caller unchanged.
+lane="${NROS_GATE_LANE:-fast-serial}"
+
+# The gate list is DERIVED, never kept beside the recipes: a second copy
+# silently drifts the moment someone adds a gate, and this runner would then
+# report OK over a set that is missing it.
+#
+# It used to be awk over `fast-serial:`'s dependency line. That line is GONE
+# (issue 1072) — it was a 218-name list every gate-adding pull request appended
+# to, and two authors adding alphabetically adjacent names insert at the same
+# base line and conflict with certainty. No merge driver can fix that, because
+# GitHub rebases queue entries server-side (issue 0884), so the list had to
+# stop existing. A recipe in `just/check.just` is now a fast gate unless it is
+# in `build-serial:`, exempt in `.config/gate-lane-exempt.txt`, or takes
+# parameters.
+#
+# `check-gate-lists.py --list` is the ONE place that derivation lives, shared
+# with the gate that verifies it, and it exits non-zero rather than emitting a
+# short list — which the emptiness check below backstops.
 if [ -z "$list" ]; then
     list="$(mktemp "${TMPDIR:-/tmp}/nros-gate-list.XXXXXX")"
-    # The list moved with the recipes: `fast-serial` now lives in the `check`
-    # MODULE, and its gates are bare names there (`abi-bindings`, not
-    # `check-abi-bindings`). Parsing the root justfile would silently derive an
-    # EMPTY list, which is why the emptiness check below is a hard refusal
-    # rather than a warning.
-    # `NROS_GATE_LANE` picks WHICH dependency line to fan out — issue 0993.
-    # `build` gained a parallel runner when it moved onto the pull-request
-    # path: serial it is ~587 s, and its slowest single gate is ~148 s, so the
-    # fan-out is the difference between a tolerable PR and an intolerable one.
-    # Defaulting to `fast-serial` keeps every existing caller unchanged.
-    lane="${NROS_GATE_LANE:-fast-serial}"
-    awk -v pat="^${lane}:" '$0 ~ pat {f=1} f{print; if ($0 !~ /\\$/) exit}' just/check.just \
-        | tr -s ' \\' '\n' \
-        | sed 's/:$//' \
-        | grep -E '^[a-z][a-z0-9-]*$' \
-        | grep -vE '^(fast|fast-serial|build|build-serial)$' \
-        | sort -u > "$list"
+    if ! python3 scripts/check/check-gate-lists.py --list "$lane" > "$list"; then
+        echo "$0: could not derive the \`$lane\` gate list — refusing to run" >&2
+        exit 2
+    fi
 fi
 [ -s "$list" ] || {
     echo "$0: derived an EMPTY gate list — refusing to report OK over nothing" >&2
@@ -81,13 +101,47 @@ fi
 # "check-fast", which became a lie the moment `build` got a parallel runner
 # too (issue 0993) — a summary naming the wrong lane is how a green build
 # line gets read as a green fast line.
-label="${NROS_GATE_LANE:-fast-serial}"
-label="${label%-serial}"
+label="${lane%-serial}"
 out_dir="$(mktemp -d "${TMPDIR:-/tmp}/nros-gates.XXXXXX")"
 trap 'rm -rf "$out_dir"' EXIT
 
 # The skip log is shared, so reset it once, before the fan-out.
 just _check-skip-reset >/dev/null 2>&1 || true
+
+# The skip ledger's reader. Sourced here rather than at the bottom because
+# BOTH paths close on it now. Derive the path, do NOT spell it (RFC-0070):
+# `nros_check_skip` writes through `nros_build_dir`, which honours
+# `NROS_BUILD_ROOT` and resolves against the REPO rather than `$PWD` — so a
+# literal `$(pwd)/build/...` reads a different file in a git worktree or with
+# the cache root moved, and every skip is invisible exactly where it was
+# recorded.
+# shellcheck source=scripts/build/check-skip.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-skip.sh"
+
+# `just check fast-serial`'s path: in list order, one at a time, output
+# streaming, STOP at the first red. That fail-fast ordering is the whole reason
+# the serial spelling exists — the parallel path deliberately reports every
+# failure instead, which is the right default and the wrong thing when you are
+# bisecting one.
+#
+# It runs through this script rather than through `just` dependencies so that
+# the two spellings answer from ONE derived list. Under dependencies the serial
+# lane had its own copy of the gate names, which is exactly the drift the
+# derivation exists to remove.
+if [ "$serial" = 1 ]; then
+    ran=0
+    while IFS= read -r gate; do
+        case "$gate" in ''|'#'*) continue ;; esac
+        ran=$((ran + 1))
+        if ! just check "$gate"; then
+            printf '\ncheck-%s (serial): FAILED at `%s` (%d gate(s) in)\n' \
+                "$label" "$gate" "$ran" >&2
+            exit 1
+        fi
+    done <"$list"
+    nros_check_skip_report "check-$label (serial): $ran gate(s) OK"
+    exit 0
+fi
 
 run_one() {
     local gate="$1" dir="$2" start end rc
@@ -135,15 +189,10 @@ fi
 # Still exit 0: these are missing tools and build products, not failures, and
 # `check-fast` must stay green on a bare worktree. What changes is only that
 # the sentence stops overstating what happened.
-# Derive the ledger path, do NOT spell it (RFC-0070). `nros_check_skip` writes
-# through `nros_build_dir`, which honours `NROS_BUILD_ROOT` and resolves against
-# the REPO rather than `$PWD` — so a literal `$(pwd)/build/...` reads a
-# different file in a git worktree or with the cache root moved, and every skip
-# is invisible exactly where it was recorded. Found while adding
-# `action-client-arena-budget`, which skips whenever nothing is built and
-# therefore skips in most CI runs.
-# shellcheck source=scripts/build/check-skip.sh
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-skip.sh"
+#
+# `check-skip.sh` is sourced ABOVE, before the serial path, which closes on the
+# same ledger. Found while adding `action-client-arena-budget`, which skips
+# whenever nothing is built and therefore skips in most CI runs.
 skips="$(nros_build_dir "$NROS_KIND_CHECK_SKIPS")/checks.skipped"
 skipped=0
 if [ -s "$skips" ]; then

--- a/scripts/check-default-gates-run-somewhere.py
+++ b/scripts/check-default-gates-run-somewhere.py
@@ -1,25 +1,56 @@
 #!/usr/bin/env python3
-"""Every gate in `just check`'s DEFAULT list must run in some workflow.
+"""A gate CI never runs, and a gate CI runs but cannot hear — issue 1040.
 
-issue 1040 — `check-api-parity` is in that list and ran in NO workflow at all.
-Not on `pull_request`, not on `merge_group`, not nightly, not on dispatch:
+Two rules over one scan of `.github/workflows/`. They are the two halves of one
+question, "does this gate report", and both halves have now failed in
+production:
 
-    grep -rl api-parity .github/workflows/    ->  (nothing)
+  R1 PLACEMENT   Every gate `just check` runs -- the derived fast lane, the
+                 `build-serial:` registry, and the names on `default:` -- must
+                 be reached by SOME workflow event. A gate no event runs is
+                 invisible between local full-tier runs, so its reds accumulate
+                 until whoever next runs the tier finds five at once with five
+                 unrelated owners. `check-api-parity` was exactly this: `grep
+                 -rl api-parity .github/workflows/` returned nothing, and three
+                 unclassified ledger rows landed on main on 2026-09-04 alone.
 
-It existed only as a local recipe, so an unclassified ledger row was invisible
-until somebody happened to run the full tier. Three landed on main on
-2026-09-04 alone, alongside two compile-tier reds and a NuttX break — seven in
-one day, every one found by a person running `just ci gate` rather than by CI.
+  R2 VERDICT     A placement must be able to REPORT. A GitHub `run:` block is
+                 `bash -e`, so a `just check <gate>` sequenced after another
+                 `just check` in the same block does not execute when the
+                 earlier one is red -- and a gate that did not execute is
+                 indistinguishable from one that passed.
 
-This does NOT require them to be merge-gating. `check-build` is deliberately
-`schedule`/`workflow_dispatch` only: it resolves artifacts no CI job builds, and
-making it required once turned every PR red for a day (`check-lane-contracts`
-now forbids that shape). A DAILY signal is the bar here, not a blocking one.
+R2 is not hypothetical and it is why R1 alone is not enough. Measured
+2026-09-05: gate.yml ran `check build`, `check no-std` and `check api-parity`
+from a single `run:` block. `check build` had been red on that lane since
+2026-09-01 (`workspace-all`, `workspace-features`), so on all five scheduled
+runs since api-parity was wired there it NEVER EXECUTED -- while `grep -rl`
+answered yes and the fix for 1040 read as landed. One red was reported for
+three gates and two of them had no verdict at all. That is issue 0952's
+withdrawal class (`ci::gate` prints what it withdrew for the same reason) one
+level down, in YAML, where no recipe can print anything.
 
-Scope is deliberately the default list and nothing wider. Asking it of all ~200
-individual gates would flag most of them, because they run collectively via
-`just check fast` -- and a gate that fires on almost everything teaches people
-to ignore it.
+WHAT THIS DOES NOT REQUIRE
+
+Merge-gating. `check-build` is deliberately `schedule`/`workflow_dispatch` only:
+it resolves artifacts no PR job builds, and making it required once turned every
+pull request red for a day (`check-lane-contracts` now forbids that shape). A
+DAILY or PER-COMMIT signal is the bar here, not a blocking one -- so both rules
+ask only that a verdict EXISTS somewhere, never that it gates.
+
+MEMBERSHIP IS READ, NEVER RE-DERIVED
+
+`check-gate-lists.py --list <lane>` is the one place lane membership lives
+(issue 1072 deleted the authored `fast-serial:` registry; a fast gate is now any
+recipe in `just/check.just` that is not in `build-serial:`, not exempt in
+`.config/gate-lane-exempt.txt`, and takes no parameters). A second derivation
+here would be the two-spellings bug this repo has paid for repeatedly -- and it
+would answer from a stale set the day the derivation moves again.
+
+Usage::
+
+    check-default-gates-run-somewhere.py            # the gate
+    check-default-gates-run-somewhere.py --survey   # gate -> events, never fails
 """
 
 import re
@@ -29,7 +60,50 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 CHECK_JUST = ROOT / "just/check.just"
+CI_JUST = ROOT / "just/ci.just"
 WORKFLOWS = ROOT / ".github/workflows"
+GATE_LISTS = ROOT / "scripts/check/check-gate-lists.py"
+
+EVENTS = ("pull_request", "merge_group", "push", "schedule", "workflow_dispatch",
+          "workflow_run")
+
+# ---------------------------------------------------------------------------
+# Gates that need no workflow placement, each with the reason it needs none.
+#
+# EMPTY BY MEASUREMENT, not by weakening. Every gate in scope reaches at least
+# one event today, so there is nothing to excuse and inventing entries to be
+# safe would be the six-entry false baseline issue 1030 rejected for the sibling
+# rule. The shape stays because the honest exemption does exist in principle --
+# a gate that can only run on hardware CI does not have, say -- and when one
+# turns up it belongs here with its reason, not in a bare list and not by
+# quietly narrowing the scope above.
+#
+# NOT the place for "it is not really a gate": that classification already has a
+# home in `.config/gate-lane-exempt.txt`, which decides lane MEMBERSHIP. This
+# file only ever asks whether something already in a lane is heard.
+# ---------------------------------------------------------------------------
+NO_PLACEMENT_NEEDED: "dict[str, str]" = {}
+
+# Gates allowed to sit behind another gate in one `run:` block. Same reasoning
+# as above, and the same emptiness: after the 2026-09-05 split every placement
+# in the tree is first in its own block, and a shared block has no upside worth
+# an exemption -- splitting a step costs three lines of YAML.
+SHADOWED_PLACEMENT_OK: "dict[str, str]" = {}
+
+
+def lane_members(lane):
+    """Gate names in `lane`, from the ONE derivation that owns them."""
+    out = subprocess.run(
+        [sys.executable, str(GATE_LISTS), "--list", lane],
+        capture_output=True, text=True, cwd=str(ROOT),
+    )
+    if out.returncode != 0:
+        raise SystemExit(
+            f"check-default-gates-run-somewhere: `check-gate-lists.py --list {lane}` "
+            f"failed — membership has exactly one home and it did not answer:\n"
+            f"{out.stderr.strip()}"
+        )
+    return [n.strip() for n in out.stdout.split() if n.strip()]
 
 
 def default_list():
@@ -41,63 +115,342 @@ def default_list():
     return []
 
 
-def workflow_mentions():
-    """Every `just check <name>` invoked by any workflow."""
-    found = set()
-    for wf in sorted(WORKFLOWS.glob("*.yml")):
-        for m in re.finditer(r"just check ([a-z0-9-]+)", wf.read_text()):
-            found.add(m.group(1))
+def _events_of(guard, wf_events):
+    """Which of the workflow's events this `if:` guard admits.
+
+    Over-approximates, like `check-lane-contracts._events_of` and for the same
+    reason: this decides whether a gate is HEARD, and crediting an event too
+    many costs a missed finding only if the guard was already narrower than it
+    looks, while crediting too few invents findings nobody can act on.
+    """
+    if not guard:
+        return set(wf_events)
+    in_list = re.search(r"fromJSON\(\s*'\[([^\]]*)\]'\s*\)\s*,\s*github\.event_name", guard)
+    if in_list:
+        named = set(re.findall(r"['\"](" + "|".join(EVENTS) + r")['\"]", in_list.group(1)))
+        if guard[: in_list.start()].rstrip().endswith("!"):
+            return set(wf_events) - named
+        return (named & set(wf_events)) or named
+    eq = set(re.findall(r"github\.event_name\s*==\s*['\"](" + "|".join(EVENTS) + r")['\"]", guard))
+    if eq:
+        return (eq & set(wf_events)) or eq
+    ne = set(re.findall(r"github\.event_name\s*!=\s*['\"](" + "|".join(EVENTS) + r")['\"]", guard))
+    if ne and "||" not in guard:
+        return set(wf_events) - ne
+    return set(wf_events)
+
+
+def run_blocks():
+    """[(workflow, events, [command lines])] — one entry per `run:` block.
+
+    Text-scanned, not YAML-parsed. The unit that matters is the `run:` BLOCK,
+    because that is the unit `bash -e` aborts: two `just check` lines in one
+    block share a fate, and two in adjacent steps do not. A YAML load would give
+    the same blocks and would also have to re-implement the `if:` handling, so
+    it buys nothing here.
+
+    A step's own `if:` wins over the workflow's event list, including the folded
+    form whose events live on continuation lines — reading only the `if:` line
+    credits every step with every event the workflow declares, which is the
+    scanner bug issue 1030 had to fix in the sibling gate before its rule could
+    fire at all.
+    """
+    out = []
+    if not WORKFLOWS.is_dir():
+        return out
+    for path in sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml")):
+        lines = path.read_text().split("\n")
+        wf_events = set(re.findall(r"^\s{2}(" + "|".join(EVENTS) + r")\s*:", "\n".join(lines), re.M))
+        guard, guard_indent = "", None
+        block, block_indent = None, None
+        for line in lines:
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip())
+            # Inside a `run:` block: everything more-indented than the key.
+            if block is not None:
+                if not stripped or indent > block_indent:
+                    block.append(stripped)
+                    continue
+                out.append((path.name, _events_of(guard, wf_events), block))
+                block, block_indent = None, None
+            if re.match(r"^\s*- (name|uses|run):", line):
+                if re.match(r"^\s*- (name|uses):", line):
+                    guard, guard_indent = "", None
+            m_if = re.match(r"^(\s+)if:", line)
+            if m_if:
+                guard, guard_indent = line, len(m_if.group(1))
+                continue
+            if guard and guard_indent is not None:
+                if (stripped and indent > guard_indent
+                        and not re.match(r"^(name|uses|run|with|env|shell|id|"
+                                         r"continue-on-error|timeout-minutes):", stripped)):
+                    guard += "\n" + line
+                    continue
+                guard_indent = None
+            m_run = re.match(r"^(\s*)-?\s*run:\s*(\S.*)?$", line)
+            if m_run:
+                inline = (m_run.group(2) or "").strip()
+                if inline and inline not in ("|", ">", "|-", ">-", "|+", ">+"):
+                    out.append((path.name, _events_of(guard, wf_events), [inline]))
+                else:
+                    block, block_indent = [], indent
+        if block is not None:
+            out.append((path.name, _events_of(guard, wf_events), block))
+    return out
+
+
+def lane_gates(lane, fast, build, default):
+    """`just check <lane>` -> the gate names it runs."""
+    if lane in ("fast", "fast-serial", "fast-parallel"):
+        return set(fast)
+    if lane in ("build", "build-serial"):
+        return set(build)
+    if lane == "default":
+        out = set()
+        for name in default:
+            out |= lane_gates(name, fast, build, default)
+        return out
+    return {lane}
+
+
+def _ci_lane_body(lane):
+    """The body lines of `just ci <lane>`, continuation-joined."""
+    text = CI_JUST.read_text() if CI_JUST.exists() else ""
+    m = re.search(r"^%s(?:\s+\w+=\S*)*:.*$" % re.escape(lane), text, re.M)
+    if not m:
+        return []
+    body, started = [], False
+    for line in text[m.end():].split("\n"):
+        if not started:
+            started = True
+        if line and not line[:1].isspace():
+            break
+        body.append(line)
+    return body
+
+
+def ci_lane_gates(lane, depth, fast, build, default):
+    """`just ci <lane> [depth]` -> the gate names it reaches.
+
+    Bounded at one hop on purpose: a tier reaches gates by naming `just check`
+    (bare, or with an argument) or a `check::<gate>` step, and both are visible
+    in the tier's own body. A full recipe-graph walk would over-attribute --
+    `ci::matrix`'s `case` arms are two branches of which a given invocation runs
+    exactly one, and crediting both makes `check::default` look merge-gating
+    when only `_matrix-build` runs in the queue.
+    """
+    if lane == "matrix" and depth in ("run", "build"):
+        lane = "_matrix-" + depth
+    out = set()
+    for line in _ci_lane_body(lane):
+        if line.lstrip().startswith("#"):
+            continue
+        for m in re.finditer(r"check::([a-z0-9-]+)", line):
+            out |= lane_gates(m.group(1), fast, build, default)
+        for m in re.finditer(r"\bjust\s+check\b([^\n|&;]*)", line):
+            args = [w for w in m.group(1).split() if re.fullmatch(r"[a-z0-9-]+", w)]
+            out |= lane_gates(args[0] if args else "default", fast, build, default)
+        for m in re.finditer(r"\bjust\s+ci::(_?[a-z0-9-]+)", line):
+            if m.group(1) != lane:
+                out |= ci_lane_gates(m.group(1), None, fast, build, default)
+    return out
+
+
+def placements(fast, build, default):
+    """{gate: [(workflow, events, shadowed_by)]} over every workflow `run:` block."""
+    found = {}
+    for wf, events, cmds in run_blocks():
+        seen_gate = None
+        for cmd in cmds:
+            if cmd.startswith("#"):
+                continue
+            hits = set()
+            m = re.search(r"\bjust\s+check\b([^\n|&;#]*)", cmd)
+            if m:
+                args = [w for w in m.group(1).split() if re.fullmatch(r"[a-z0-9-]+", w)]
+                hits |= lane_gates(args[0] if args else "default", fast, build, default)
+            m = re.search(r"\bjust\s+ci\s+([a-z0-9-]+)(?:\s+([a-z0-9-]+))?", cmd)
+            if m:
+                hits |= ci_lane_gates(m.group(1), m.group(2), fast, build, default)
+            if not hits:
+                continue
+            named = sorted(hits)[0] if len(hits) == 1 else None
+            for gate in hits:
+                found.setdefault(gate, []).append((wf, frozenset(events), seen_gate))
+            seen_gate = seen_gate or named or "a lane"
     return found
 
 
 def self_test():
-    """On the NORMAL path — a control nobody runs decays into a comment."""
+    """Prove both rules can fail. Runs on the NORMAL path, every invocation —
+    a negative control nobody runs decays into a comment."""
     ok = True
-    names = default_list()
-    if not names:
-        print("self-test FAILED: could not parse `default:` from check.just", file=sys.stderr)
-        ok = False
-    # the parse must find the real list, not an empty one that passes vacuously
-    if names and not all(re.fullmatch(r"[a-z0-9-]+", n) for n in names):
-        print(f"self-test FAILED: default list looks wrong: {names}", file=sys.stderr)
-        ok = False
-    mentions = workflow_mentions()
-    if not mentions:
-        print("self-test FAILED: no `just check` found in any workflow", file=sys.stderr)
-        ok = False
+
+    def chk(desc, cond):
+        nonlocal ok
+        if not cond:
+            print(f"self-test FAILED: {desc}", file=sys.stderr)
+            ok = False
+
+    # The parse must find the real lists, not empty ones that pass vacuously.
+    fast, build, default = lane_members("fast-serial"), lane_members("build-serial"), default_list()
+    chk("the fast lane is empty", len(fast) > 50)
+    chk("the build lane is empty", len(build) > 5)
+    chk("`default:` did not parse", bool(default))
+    chk("a lane name looks wrong",
+        all(re.fullmatch(r"[a-z0-9-]+", n) for n in fast + build + default))
+
+    # R1's expansion: `just check fast` IS every fast gate, not the literal name.
+    chk("`fast` does not expand to the lane",
+        lane_gates("fast", fast, build, default) == set(fast))
+    chk("a bare `just check` does not reach the build tier",
+        set(build) <= lane_gates("default", fast, build, default))
+
+    # R2's shadow detection, on the exact shape measured on 2026-09-05.
+    blocks = run_blocks()
+    chk("no `run:` block was scanned at all", len(blocks) > 10)
+    probe = ["source ./activate.sh", "just check build", "just check api-parity"]
+    seen, shadow = None, {}
+    for cmd in probe:
+        hits = set()
+        m = re.search(r"\bjust\s+check\b([^\n|&;#]*)", cmd)
+        if m:
+            args = [w for w in m.group(1).split() if re.fullmatch(r"[a-z0-9-]+", w)]
+            if args:
+                hits = {args[0]}
+        for g in hits:
+            shadow[g] = seen
+        seen = seen or (sorted(hits)[0] if len(hits) == 1 else None)
+    chk("a leading `just check` is not credited as unshadowed", shadow.get("build") is None)
+    chk("a trailing `just check` is not seen as shadowed", shadow.get("api-parity") == "build")
+
+    # The event reader decides which lane a placement counts for.
+    allev = {"pull_request", "merge_group", "push", "schedule"}
+    chk("no `if:` must mean every event the workflow declares",
+        _events_of("", allev) == allev)
+    chk("a fromJSON list must narrow to exactly those events",
+        _events_of("""if: ${{ contains(fromJSON('["schedule","workflow_dispatch"]'),"""
+                   """ github.event_name) }}""", allev) == {"schedule"})
+    chk("a folded guard must keep the events on its continuation lines",
+        _events_of("        if: >-\n"
+                   "          ${{ contains(fromJSON('[\"pull_request\"]'), github.event_name)\n"
+                   "              && !cancelled() }}", allev) == {"pull_request"})
+    chk("an exclusion OR-ed with a non-event condition must not exclude",
+        _events_of("if: ${{ always() && (github.event_name != 'pull_request'"
+                   " || needs.changes.outputs.code == 'true') }}", allev) == allev)
+
     if ok:
         print(
             f"check-default-gates-run-somewhere self-test: OK "
-            f"({len(names)} default gate(s), {len(mentions)} mentioned in workflows)"
+            f"({len(fast)} fast + {len(build)} build gate(s), "
+            f"{len(blocks)} workflow `run:` block(s))"
         )
     return ok
+
+
+def survey(fast, build, default, place):
+    """gate -> the events that run it. Never fails; this is the measurement."""
+    scope = sorted(set(fast) | set(build) | set(default) | set(place))
+    rows = []
+    for gate in scope:
+        ev = set()
+        for _wf, events, _sh in place.get(gate, []):
+            ev |= set(events)
+        rows.append((gate, ev))
+    for gate, ev in rows:
+        lane = "fast" if gate in fast else "build" if gate in build else "other"
+        print(f"  {lane:6s} {gate:44s} {','.join(sorted(ev)) or 'NO EVENT'}")
+    # Three buckets, because two would hide the interesting one. "not
+    # merge-gating" lumps a post-submit gate (a verdict per landed commit)
+    # together with a nightly-only one (a verdict per day, attributed to a
+    # batch), and the whole of issue 1040 is about that difference.
+    gating = [g for g, e in rows if e & {"pull_request", "merge_group"}]
+    post = [g for g, e in rows if not (e & {"pull_request", "merge_group"}) and "push" in e]
+    sched = [g for g, e in rows
+             if e and not (e & {"pull_request", "merge_group", "push"})]
+    none = [g for g, e in rows if not e]
+    print(f"\n  {len(rows)} gate(s): {len(gating)} merge-gating, {len(post)} "
+          f"post-submit (push) but not gating, {len(sched)} schedule/dispatch "
+          f"only, {len(none)} on NO event")
+    if post:
+        print("  post-submit only: " + " ".join(sorted(post)))
+    if sched:
+        print("  schedule/dispatch only: " + " ".join(sorted(sched)))
+    if none:
+        print("  NO event: " + " ".join(sorted(none)))
 
 
 def main() -> int:
     if not self_test():
         return 1
-    names = default_list()
-    mentions = workflow_mentions()
-    missing = [n for n in names if n not in mentions]
-    if missing:
-        print(
-            f"check-default-gates-run-somewhere: {len(missing)} default gate(s) run in NO workflow",
-            file=sys.stderr,
+    fast, build, default = lane_members("fast-serial"), lane_members("build-serial"), default_list()
+    default = sorted(lane_gates("default", fast, build, default))
+    place = placements(fast, build, default)
+
+    if "--survey" in sys.argv:
+        survey(fast, build, default, place)
+        return 0
+
+    scope = sorted(set(fast) | set(build) | set(default))
+    errs = []
+
+    # R1 — a gate no workflow event runs.
+    for gate in scope:
+        if place.get(gate) or gate in NO_PLACEMENT_NEEDED:
+            continue
+        errs.append(
+            f"`just check {gate}` runs in NO workflow.\n"
+            f"      No event reaches it, so it is invisible between local\n"
+            f"      full-tier runs and its reds accumulate until somebody finds\n"
+            f"      several at once (issue 1040). It need not gate a merge — a\n"
+            f"      nightly or post-submit signal is the bar. Add it to gate.yml's\n"
+            f"      `schedule`/`workflow_dispatch` steps, or to post-submit.yml if\n"
+            f"      per-commit attribution is worth its cost."
         )
-        for n in missing:
-            print(f"  just check {n}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("  A gate in `just check`'s default list that no workflow runs is", file=sys.stderr)
-        print("  invisible between local full-tier runs, and its reds accumulate", file=sys.stderr)
-        print("  until someone finds several at once (issue 1040).", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("  It need not be merge-gating — a nightly signal is the bar. Add it", file=sys.stderr)
-        print("  to gate.yml's `schedule`/`workflow_dispatch` step beside", file=sys.stderr)
-        print("  `just check build`.", file=sys.stderr)
+
+    # R2 — a placement that cannot produce a verdict.
+    #
+    # PER PLACEMENT, not "every placement of this gate": a gate that is heard
+    # elsewhere is still silent HERE, and the whole cost of the 2026-09-05
+    # defect was a lane reporting one red for three gates. Weakening this to
+    # "all placements shadowed" lets exactly that stand — `api-parity` also
+    # reaches an unshadowed `just ci tier1` in host-tests.yml, so the weaker
+    # rule found only `no-std` when run against the unfixed gate.yml.
+    for gate, where in sorted(place.items()):
+        if gate in SHADOWED_PLACEMENT_OK:
+            continue
+        shadowed = sorted({f"{wf} (behind `{sh}`)" for wf, _ev, sh in where if sh})
+        if not shadowed:
+            continue
+        errs.append(
+            f"`just check {gate}` is SEQUENCED BEHIND another\n"
+            f"      gate in the same `run:` block: {', '.join(shadowed)}.\n"
+            f"      A `run:` block is `bash -e`, so the earlier gate going red\n"
+            f"      means this one never executes — and a gate that did not run\n"
+            f"      is indistinguishable from one that passed. gate.yml reported\n"
+            f"      one red for three gates for five consecutive nights that way\n"
+            f"      (issue 1040; issue 0952's withdrawal class, in YAML).\n"
+            f"      Give it its own step with the same `if:` — `!cancelled()` is\n"
+            f"      what lets a later step run after an earlier failure."
+        )
+
+    if errs:
+        print(f"check-default-gates-run-somewhere: {len(errs)} gate(s) CI cannot hear\n",
+              file=sys.stderr)
+        for e in errs:
+            print(f"  - {e}\n", file=sys.stderr)
         return 1
+
+    heard = sum(1 for g in scope if place.get(g))
+    gating = sum(1 for g in scope
+                 for ev in [set().union(*(set(e) for _w, e, _s in place[g]))]
+                 if place.get(g) and ev & {"pull_request", "merge_group"})
     print(
-        f"check-default-gates-run-somewhere: OK ({len(names)} default gate(s), "
-        f"all run in at least one workflow)"
+        f"check-default-gates-run-somewhere: OK — {len(scope)} gate(s) in "
+        f"`just check`'s lanes, all reached by some workflow event ({gating} on a "
+        f"merge-gating one, {heard - gating} report-only); no placement anywhere "
+        f"is sequenced behind another gate in its `run:` block. "
+        f"`--survey` prints gate -> events."
     )
     return 0
 

--- a/scripts/check-gate-visibility.py
+++ b/scripts/check-gate-visibility.py
@@ -28,6 +28,7 @@ in the build tier, whatever its history.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -44,6 +45,29 @@ def lane_members(text: str, lane: str) -> list[str]:
     if not m:
         return []
     return re.findall(r"^    ([a-z0-9-]+) \\", m.group(1), re.M)
+
+
+def lane_gates(text: str, lane: str) -> list[str]:
+    """A lane's members, however that lane records them.
+
+    `build-serial` is still an authored dependency list, so `lane_members`
+    reads it. `fast-serial` has none: issue 1072 deleted the 218-name registry
+    because two authors adding alphabetically adjacent gates insert at the same
+    base line and conflict, and no `.gitattributes` driver runs on GitHub's
+    server-side rebase to fix it. Its membership is DERIVED by
+    `check-gate-lists.py`, and it is asked rather than parsed here — a regex
+    over a dependency line that no longer exists returns [], which would make
+    this gate silently vacuous the moment `just check fast` stopped being run
+    by a gating job. That is the exact shape this file exists to prevent.
+    """
+    if lane.removesuffix("-serial") == "fast":
+        out = subprocess.run(
+            [sys.executable, str(ROOT / "scripts/check/check-gate-lists.py"),
+             "--list", "fast"],
+            capture_output=True, text=True, check=True,
+        )
+        return [ln for ln in out.stdout.split("\n") if ln.strip()]
+    return lane_members(text, lane)
 
 
 def lanes_run_by_gating_jobs() -> set[str]:
@@ -119,7 +143,7 @@ def main() -> int:
         verb = lane.removesuffix("-serial")
         if lane in gated_lanes or verb in gated_lanes:
             continue
-        ungated.extend(lane_members(text, lane))
+        ungated.extend(lane_gates(text, lane))
 
     listed = set(read_baseline())
     actual = set(ungated)

--- a/scripts/check-lane-contracts.py
+++ b/scripts/check-lane-contracts.py
@@ -241,10 +241,80 @@ def workflow_jobs():
     ]
 
 
-# Events on which a merge cannot happen without the step passing. A tier that
-# runs here MUST be satisfiable by its own job; anywhere else a broken tier is a
-# bad lane, not a frozen repository.
+def lane_invocations(words, recipes_map):
+    """{(qualified recipe, events)} for the lanes a job's `run:` lines invoke.
+
+    `workflow_jobs` yields a FLAT word stream, and a lane is often two words:
+    `just check build`, `just ci tier1`, `just native build-workspace-fixtures`.
+    Testing each word against the recipe map on its own is wrong twice over.
+
+      * It MISSES every module lane. Neither `ci` nor `tier1` is a recipe, so
+        `just ci tier1` resolved to nothing and host-tests.yml's tier-1 lane —
+        the one that runs `just check`, the whole default tier — was invisible
+        to this rule.
+      * It MISATTRIBUTES. `just check api-parity` has two candidate recipes and
+        the bare-word test picks the wrong one: the ROOT `api-parity lang=""`
+        is a parameterised REPORT, while the gate is `check::api-parity`. Their
+        closures differ, so the rule was answering about a recipe the workflow
+        never runs.
+
+    So: pair a word with the next one when `<a>::<b>` is a real recipe, and only
+    then fall back to the bare word. Pairing is tried FIRST because the module
+    spelling is the more specific of the two, which is what makes the
+    `api-parity` collision resolve the way the workflow means it.
+
+    Measured 2026-09-05: 3 lanes resolved before, 15 after, 0 findings either
+    way — coverage, not a new baseline.
+    """
+    out, i = set(), 0
+    while i < len(words):
+        word, events = words[i]
+        if (i + 1 < len(words) and words[i + 1][1] == events
+                and f"{word}::{words[i + 1][0]}" in recipes_map):
+            out.add((f"{word}::{words[i + 1][0]}", tuple(sorted(events))))
+            i += 2
+            continue
+        if word in recipes_map:
+            out.add((word, tuple(sorted(events))))
+        i += 1
+    return out
+
+
+# Events on which a merge cannot happen without the step passing.
 GATING_EVENTS = {"pull_request", "merge_group"}
+
+# Events that produce a VERDICT nobody is blocked on — post-submit, the nightly,
+# and a hand-fired run.
+REPORTING_EVENTS = {"push", "schedule", "workflow_dispatch"}
+
+# The tier rules' scope. WIDENED beyond `GATING_EVENTS` — issue 1030's stated
+# gap, closed with a measurement rather than an argument.
+#
+# 1030 recorded the narrow scope as a deliberate severity call and did not
+# propose reversing it: "a broken tier on `schedule` is a bad nightly, a broken
+# tier on `merge_group` is a repository nobody can merge into". That is true
+# about SEVERITY and was mistaken as a reason to look away. A lane whose job
+# cannot build what it resolves is broken on every event it runs on; on the
+# nightly it simply fails silently, which is the property issue 1040 is about —
+# reds accumulate in a lane nobody is blocked on until someone finds five at
+# once.
+#
+# MEASURED 2026-09-05 before widening: the scope goes from 7 merge-gating lane
+# invocations to 49, and the finding count goes from 0 to 0. There is no cost
+# to weigh against the severity call, because nothing new fails. What the
+# narrow scope actually bought was blindness — the scheduled gate was red four
+# consecutive nights on exactly this shape (1030's own defect) and the tier
+# rules were structurally unable to look at it.
+#
+# The severity distinction is KEPT, in the output rather than in the scope:
+# every finding is labelled `[gating]` or `[report]`, so "a repository nobody
+# can merge into" still reads differently from "a bad nightly". Dropping the
+# lane was never the only way to say that.
+#
+# `workflow_run` is deliberately absent. `queue-notify.yml` runs on it and its
+# `just ci l1` is TEXT — a line in the comment it posts telling a human what to
+# run — so scanning it attributes lanes to a workflow that runs none of them.
+SCANNED_EVENTS = GATING_EVENTS | REPORTING_EVENTS
 
 
 EVENT = r"(?:pull_request|merge_group|push|schedule|workflow_dispatch|workflow_run)"
@@ -680,15 +750,13 @@ def main():
     for wf, job, recipes, producers in workflow_jobs():
         if producers:
             continue  # the job builds artifacts; it may resolve them
-        for recipe, events in sorted({(r, tuple(sorted(e))) for r, e in recipes}):
-            if recipe not in recipes_map:
+        for recipe, events in sorted(lane_invocations(recipes, recipes_map)):
+            # Every lane that produces a verdict, gating or not — see
+            # SCANNED_EVENTS. `workflow_run` is excluded because the only lane
+            # names on it are advice text in a posted comment.
+            if not (set(events) & SCANNED_EVENTS):
                 continue
-            # Only lanes that GATE a merge. A broken tier on `schedule` is a bad
-            # nightly (issue 0878's territory); a broken tier on `merge_group`
-            # or `pull_request` is a repository nobody can merge into, which is
-            # a different severity and the one this gate exists for.
-            if not (set(events) & GATING_EVENTS):
-                continue
+            sev = "gating" if set(events) & GATING_EVENTS else "report"
             reached = closure(recipes_map, recipe)
             job_makes_stamps = any(
                 "compile-check-fixtures.sh" in line
@@ -696,7 +764,7 @@ def main():
                 for line in recipes_map.get(r, {}).get("body", [])
             )
             for producer, via in sorted(required_producers(recipes_map, reached).items()):
-                ci_findings.append(f"{wf}:{job} runs `{recipe}` -> `{via}` "
+                ci_findings.append(f"[{sev}] {wf}:{job} runs `{recipe}` -> `{via}` "
                                    f"hard-requires `just {producer}`, which the job never runs")
             for test, via in sorted(tests_invoked(recipes_map, reached).items()):
                 used, found = resolvers_used(test)
@@ -704,10 +772,10 @@ def main():
                     continue
                 runtime = sorted(u for u in used if u in RUNTIME_RESOLVERS)
                 if runtime:
-                    ci_findings.append(f"{wf}:{job} runs `{recipe}` -> `{test}` "
+                    ci_findings.append(f"[{sev}] {wf}:{job} runs `{recipe}` -> `{test}` "
                                        f"needs RUNTIME fixture ({','.join(runtime)})")
                 elif not job_makes_stamps:
-                    ci_findings.append(f"{wf}:{job} runs `{recipe}` -> `{test}` "
+                    ci_findings.append(f"[{sev}] {wf}:{job} runs `{recipe}` -> `{test}` "
                                        f"needs a COMPILE stamp nothing in the job builds")
 
     base_path = os.path.join(ROOT, ".config", "lane-contract-baseline.json")
@@ -758,11 +826,19 @@ def main():
         )
         return 1
 
-    gating = sum(
-        1 for _w, _j, r, p in workflow_jobs() if not p
-        for _rec, ev in {(a, tuple(sorted(b))) for a, b in r}
-        if set(ev) & GATING_EVENTS
-    )
+    # Count what the rule RESOLVED, not how many words it saw. The old count
+    # was over the raw word stream, so it reported 51 "lane invocations" for 15
+    # lanes — a number that grows when a workflow adds a `setup` step and says
+    # nothing about coverage, which is the shape this gate's own history warns
+    # about (a green summary beside an uncovered lane).
+    def _count(scope):
+        return sum(
+            1 for _w, _j, r, p in workflow_jobs() if not p
+            for _rec, ev in lane_invocations(r, recipes_map)
+            if set(ev) & scope
+        )
+    gating = _count(GATING_EVENTS)
+    scanned = _count(SCANNED_EVENTS)
     # Say what the producer rule EXAMINED, not just that it passed. A rule that
     # covers nothing prints the same "OK" as one that covers everything, and
     # this gate's own history is a green summary next to an uncovered lane.
@@ -774,8 +850,9 @@ def main():
     )
     print(
         f"check-lane-contracts OK — {checked} test target(s) across "
-        f"{len(LANES)} affordability tier(s) and {gating} merge-gating CI "
-        f"lane invocation(s); none resolves an artifact its job does not build. "
+        f"{len(LANES)} affordability tier(s) and {scanned} CI lane invocation(s) "
+        f"({gating} merge-gating, {scanned - gating} report-only); none resolves "
+        f"an artifact its job does not build. "
         f"{covered} step invocation(s) on any event carry a justfile-ordered "
         f"`setup-*` precondition; each runs where its producer does."
     )
@@ -925,6 +1002,32 @@ def selftest(verbose=False):
     chk("a schedule-only step is NOT gating",
         not (_events_of("""if: ${{ contains(fromJSON('["schedule"]'), github.event_name) }}""",
                         allev) & GATING_EVENTS))
+    # ...and is still SCANNED. Issue 1030 named the narrow scope as the reason
+    # the tier rules could not see the scheduled gate; keeping only the first
+    # assertion is what let that stand, so both directions are pinned here.
+    chk("a schedule-only step IS in scope for the tier rules",
+        bool(_events_of("""if: ${{ contains(fromJSON('["schedule"]'), github.event_name) }}""",
+                        allev) & SCANNED_EVENTS))
+    chk("`workflow_run` is NOT in scope — queue-notify's lane names are advice text",
+        not (_events_of("", {"workflow_run"}) & SCANNED_EVENTS))
+
+    # Lane resolution. `just ci tier1` is one lane spelled in two words, and
+    # `just check api-parity` collides with a DIFFERENT root recipe of the same
+    # name — the two failures the bare-word test had.
+    ev = ("pull_request",)
+    words = [("ci", ev), ("tier1", ev)]
+    chk("a `just <mod> <recipe>` pair resolves to <mod>::<recipe>",
+        lane_invocations(words, {"ci::tier1": {}}) == {("ci::tier1", ev)})
+    chk("the MODULE spelling wins over a root recipe of the same name",
+        lane_invocations([("check", ev), ("api-parity", ev)],
+                         {"api-parity": {}, "check::api-parity": {}})
+        == {("check::api-parity", ev)})
+    chk("a bare word that IS a recipe still resolves",
+        lane_invocations([("test-unit", ev)], {"test-unit": {}}) == {("test-unit", ev)})
+    chk("a word that names no recipe resolves to nothing",
+        lane_invocations([("setup", ev)], {"test-unit": {}}) == set())
+    chk("words with DIFFERENT event sets are never paired",
+        lane_invocations([("ci", ("push",)), ("tier1", ev)], {"ci::tier1": {}}) == set())
     chk("a LONE `!=` guard subtracts rather than selects",
         _events_of("if: ${{ github.event_name != 'pull_request' }}", allev)
         == allev - {"pull_request"})

--- a/scripts/check/check-gate-lists.py
+++ b/scripts/check/check-gate-lists.py
@@ -1,54 +1,58 @@
 #!/usr/bin/env python3
-"""A gate registry holds ONE name per line, sorted.
+"""The fast lane is DERIVED from the recipes; only its exceptions are authored.
 
+WHY THERE IS NO LONGER A `fast-serial:` REGISTRY
+------------------------------------------------
 `just/check.just` names every gate twice: once as a recipe, and once as a
-dependency of the lane that runs it. That dependency list is the shape issues
-0883/0884 are about — a file EVERY pull request appends to — and it had the
-worse variant of it: up to fifteen names packed onto a line, with new gates
-appended at the tail. Two agents adding unrelated gates edited the same
-physical line, so git conflicted on changes that do not overlap in meaning, and
-the merge queue ejected them.
+dependency of the lane that runs it. That second name is the shape issues
+0883/0884 are about — a line EVERY pull request appends to.
 
-0884 fixed the same shape for `docs/issues/open.md` with `merge=union`, and that
-IS working (measured: it conflicts in none of the open PRs). Union is not
-available here — `.gitattributes` says so in as many words, "NEVER apply this to
-an authored file" — because a union of two recipe bodies is not a recipe, it is
-both of them.
+The first fix was to make the list one-name-per-line and sorted, on the
+reasoning that two gates with different names then land at different lines.
+Measured on 2026-09-05, that is only true when the names are far enough apart.
+Two ADJACENT names insert at the SAME base line, git has no unchanged line
+between them to anchor on, and it conflicts with certainty. PR #472 hit exactly
+that: `codegen-stamp-inputs` against main's `codegen-tool-reconfigure`, one
+hunk, three lines. And names are not independent — related work produces
+related names (`codegen-*`, `xrce-*`, `zenoh-*`), so sorting turns name
+correlation directly into position correlation.
 
-One name per line, sorted, is the fix that does not need a merge driver: two
-gates with different names land at different, usually non-adjacent, lines, and
-git merges them without help. It costs nothing, because ORDER IN THIS LIST HAS
-NEVER BEEN LOAD-BEARING: `fast` runs the same gates concurrently, and
-`run-gates-parallel.sh` `sort -u`s the list it derives from this very block. A
-list whose consumer sorts it cannot have been ordered on purpose.
+No merge driver can fix it. 0884 established that GitHub rebases queue entries
+SERVER-SIDE, where `.gitattributes` drivers do not run; the fix that reached the
+queue for `open.md` was to stop committing the shared line at all. The same
+answer applies here, and this file is it:
 
-AND THE REGISTRY MAY NOT SHRINK (issue 1071)
---------------------------------------------
-Sorted-and-one-per-line are properties a DELETION satisfies perfectly. PR #431
-added one gate and removed four unrelated ones -- recipes and registry entries
-both, against a stale copy of this file -- and every gate stayed green, this one
-included: it printed `232 gate(s)` where main had 236, and compared that number
-to nothing. One of the four was the guard for a defect that had survived from
-2026-06-13 to 2026-09-03.
+    a recipe in `just/check.just` is a FAST-LANE GATE unless it is listed in
+    `build-serial:` (it needs something built), named in
+    `.config/gate-lane-exempt.txt` (with a reason), or declares parameters
+    (a gate is invoked as `just check <name>` with no arguments, so a recipe
+    that requires one cannot be one).
 
-So the registry now carries a BASELINE name set that may only grow. A name in
-the baseline and not in the registries is a failure; new names are free.
+Adding a gate is now writing its recipe. Nothing shared is touched, so two
+authors adding gates cannot collide on a registry that no longer exists.
 
-On the NAME SET and not the count, deliberately: #431 was one addition against
-four removals, so a count ratchet would have had to notice a net of -3, and a
-delete-plus-add that nets to zero would pass it outright. The set catches both,
-and costs a longer file.
+WHAT THIS BUYS BEYOND THE MERGE QUEUE
+-------------------------------------
+Issue 1071: PR #431 deleted four gates by dropping their registry lines and
+`check-gate-lists` stayed green, because it verified the list's SHAPE and never
+its size. There is no fast-lane registry line to drop now. A fast gate can only
+leave the lane by having its RECIPE deleted, which is visible in review, and
+which a name-set ratchet over `gate_names()` catches outright.
 
-A FLAT set across registries rather than per-registry, so moving a gate between
-`fast` and `build` -- a real and legitimate change -- is not a deletion. What it
-asserts is only that a gate that once existed still exists somewhere.
+The polarity flip also inverts the failure mode. Forgetting the registry line
+used to mean the gate NEVER RAN — silent, and the repo's most-repeated defect
+(issue 0196's class). Forgetting to exempt a new recipe now means it runs on the
+fast lane, which is loud and lands on the author's own pull request.
 
-Retiring a gate is rare and always deliberate:
+`build-serial:` stays an authored dependency list. It holds ~20 names, none of
+the 13 registry additions across the pull requests open on 2026-09-05 went to
+it, and `scripts/check-gate-visibility.py` reads its members directly.
 
-    python3 scripts/check/check-gate-lists.py --write-baseline
-
-and say in the commit message which gate went and why. Re-stating the number is
-the right price for a deletion nobody meant to make.
+FOR A NAME-SET RATCHET
+----------------------
+`gate_names()` returns the full sorted set (fast + build). A baseline file of
+names that may only grow compares against that one call — the same interface a
+registry-parsing ratchet had, minus the registry.
 """
 
 from __future__ import annotations
@@ -59,19 +63,45 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 JUSTFILE = REPO / "just" / "check.just"
-# Beside `.config/gate-selftest-baseline.txt`, the same shape one question over:
-# that one ratchets how many gates TEST THEMSELVES, this one how many EXIST.
-# Deleting a gate that has a selftest makes that ratchet EASIER to satisfy,
-# which is why it could not have caught #431.
+EXEMPT_FILE = REPO / ".config" / "gate-lane-exempt.txt"
+# phase-425/issue 1071 — the deletion ratchet's baseline. It survived the
+# 1072 rewrite unchanged in CONTENT: its 239 names are byte-identical to the
+# derived fast+build set, so inverting where membership is WRITTEN did not
+# move what the ratchet reads.
 BASELINE = REPO / ".config" / "gate-registry-baseline.txt"
 
-# The lane recipes whose dependencies are a gate REGISTRY. A lane with a
-# handful of names on one line (`default: cli-fresh fast build api-parity`) is
-# not one: nobody appends to it, so it is not a conflict site.
-# `build` gained a parallel runner (issue 0993), so its LIST moved to
-# `build-serial` exactly as `fast`'s did — the registry is the dependency line,
-# not the verb.
-REGISTRIES = ("fast-serial", "build-serial")
+# The one lane whose membership is still authored. A build gate is the
+# EXCEPTION — it cannot run without something compiled — so it is listed, and
+# `check-gate-visibility` reads this same list to decide which gates no
+# merge-gating job reaches.
+BUILD_REGISTRY = "build-serial"
+
+# The no-op `build-serial:` ends on, so the LAST real gate carries a trailing
+# backslash like every other. Without it the final entry is the one line with
+# different syntax, and a gate that sorts last must edit someone else's line to
+# add the backslash — two such PRs conflict with CERTAINTY rather than by bad
+# luck. The "trailing comma" fix.
+SENTINEL = "_gate-list-end"
+
+# A recipe header at column 0. Variables use `:=`, attributes start with `[`,
+# comments with `#`, and bodies are indented, so none of them match.
+RECIPE_RE = re.compile(r"^([a-z_][a-z0-9_-]*)([^:\n]*):(?!=)")
+
+
+def recipes(lines: list[str]) -> dict[str, bool]:
+    """Every top-level recipe name -> whether it declares parameters.
+
+    A recipe that takes an argument cannot be a gate: the runners invoke
+    `just check <name>` with nothing after the name. `stack-elf elf top="30"`
+    would fail on the missing `elf` every time, so excluding it is a property
+    of the recipe rather than a decision someone has to remember to record.
+    """
+    out: dict[str, bool] = {}
+    for line in lines:
+        m = RECIPE_RE.match(line)
+        if m:
+            out[m.group(1)] = bool(m.group(2).strip())
+    return out
 
 
 def dep_block(lines: list[str], name: str) -> tuple[int, int]:
@@ -102,16 +132,41 @@ def names_per_line(lines: list[str], s: int, e: int) -> list[list[str]]:
     return out
 
 
-# The no-op every registry ends on, so the LAST real gate carries a trailing
-# backslash like every other. Without it the final entry is the one line with
-# different syntax, and a gate that sorts last must edit someone else's line to
-# add the backslash — two such PRs conflict with CERTAINTY rather than by bad
-# luck. The "trailing comma" fix, and the one conflict class the
-# one-name-per-line format could not reach.
-SENTINEL = "_gate-list-end"
+def parse_exempt(text: str) -> tuple[list[str], list[str]]:
+    """(names, problems). Every entry needs a name and a `# reason`."""
+    names: list[str] = []
+    problems: list[str] = []
+    for lineno, raw in enumerate(text.split("\n"), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, sep, reason = line.partition("#")
+        name = name.strip()
+        if " " in name or not re.fullmatch(r"[a-z_][a-z0-9_-]*", name or ""):
+            problems.append(
+                f"  {EXEMPT_FILE.name}:{lineno}: `{line}` is not `<name>  # reason`"
+            )
+            continue
+        if not sep or not reason.strip():
+            problems.append(
+                f"  {EXEMPT_FILE.name}:{lineno}: `{name}` has no reason.\n"
+                f"      Say why it is not a fast gate; a bare name is how a\n"
+                f"      temporary exclusion becomes permanent."
+            )
+        names.append(name)
+    if names != sorted(names):
+        first = next((a for a, b in zip(names, sorted(names)) if a != b), "?")
+        problems.append(
+            f"  {EXEMPT_FILE.name}: not sorted (first out of order: `{first}`)."
+        )
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    if dupes:
+        problems.append(f"  {EXEMPT_FILE.name}: listed twice: {', '.join(dupes)}")
+    return names, problems
 
 
-def check(lines: list[str], name: str) -> list[str]:
+def check_registry(lines: list[str], name: str) -> tuple[list[str], list[str]]:
+    """(gate names, problems) for an authored dependency-line registry."""
     s, e = dep_block(lines, name)
     per_line = names_per_line(lines, s, e)
     flat = [n for group in per_line for n in group]
@@ -149,9 +204,7 @@ def check(lines: list[str], name: str) -> list[str]:
         )
 
     if flat != sorted(flat):
-        first = next(
-            (a for a, b in zip(flat, sorted(flat)) if a != b), "?"
-        )
+        first = next((a for a, b in zip(flat, sorted(flat)) if a != b), "?")
         problems.append(
             f"  {name}: not sorted (first out of order: `{first}`).\n"
             f"      Sorted order is what makes a new gate's line position\n"
@@ -162,17 +215,89 @@ def check(lines: list[str], name: str) -> list[str]:
     if dupes:
         problems.append(f"  {name}: listed twice: {', '.join(dupes)}")
 
-    return problems
+    return flat, problems
 
 
-def registry_names(lines: list[str]) -> set[str]:
-    """Every gate named by any registry, sentinel excluded."""
-    out: set[str] = set()
-    for name in REGISTRIES:
-        s, e = dep_block(lines, name)
-        for group in names_per_line(lines, s, e):
-            out.update(n for n in group if n != SENTINEL)
-    return out
+def classify(just_text: str, exempt_text: str) -> tuple[dict[str, list[str]], list[str]]:
+    """Split every recipe into fast / build / exempt / parameterized.
+
+    Returns (buckets, problems). This is the whole contract: a recipe lands in
+    exactly one bucket, and the fast lane is whatever is left over.
+    """
+    lines = just_text.split("\n")
+    rec = recipes(lines)
+    build, problems = check_registry(lines, BUILD_REGISTRY)
+    exempt, ex_problems = parse_exempt(exempt_text)
+    problems += ex_problems
+
+    parameterized = sorted(n for n, has_args in rec.items() if has_args)
+    plain = {n for n, has_args in rec.items() if not has_args}
+
+    ghost_build = [n for n in build if n not in rec]
+    if ghost_build:
+        problems.append(
+            f"  {BUILD_REGISTRY}: names with no recipe: {', '.join(sorted(ghost_build))}.\n"
+            f"      `just check <name>` would fail; delete the entry with the recipe."
+        )
+    ghost_exempt = [n for n in exempt if n not in rec]
+    if ghost_exempt:
+        problems.append(
+            f"  {EXEMPT_FILE.name}: names with no recipe: "
+            f"{', '.join(sorted(ghost_exempt))}.\n"
+            f"      A stale exemption is a note nobody can act on — and the next\n"
+            f"      recipe to take that name inherits it silently."
+        )
+    both = sorted(set(build) & set(exempt))
+    if both:
+        problems.append(
+            f"  in `{BUILD_REGISTRY}` AND exempt: {', '.join(both)}.\n"
+            f"      A gate has one home; pick the lane or the exemption."
+        )
+    args_claimed = sorted((set(build) | set(exempt)) & set(parameterized))
+    if args_claimed:
+        problems.append(
+            f"  declares parameters but is listed as a gate/exemption: "
+            f"{', '.join(args_claimed)}.\n"
+            f"      A recipe with arguments can never run as `just check <name>`,\n"
+            f"      so it is excluded structurally and needs no entry."
+        )
+
+    fast = sorted(plain - set(build) - set(exempt))
+    if not fast:
+        problems.append(
+            "  the derived FAST lane is EMPTY.\n"
+            "      Refusing to report OK over nothing — the runner would too."
+        )
+    return (
+        {
+            "fast": fast,
+            "build": sorted(build),
+            "exempt": sorted(exempt),
+            "parameterized": parameterized,
+        },
+        problems,
+    )
+
+
+def buckets() -> tuple[dict[str, list[str]], list[str]]:
+    return classify(
+        JUSTFILE.read_text(encoding="utf-8"),
+        EXEMPT_FILE.read_text(encoding="utf-8") if EXEMPT_FILE.is_file() else "",
+    )
+
+
+def gate_names() -> list[str]:
+    """Every gate `just check <name>` can run, fast lane and build lane.
+
+    The hook a name-set ratchet reads (issue 1071). One call, one sorted list,
+    with no knowledge of where the names are written down.
+    """
+    b, problems = buckets()
+    if problems:
+        raise SystemExit(
+            "check-gate-lists: cannot derive the gate set:\n" + "\n".join(problems)
+        )
+    return sorted(b["fast"] + b["build"])
 
 
 def load_baseline() -> set[str] | None:
@@ -225,88 +350,150 @@ def self_test() -> None:
     `check-gate-selftests` requires this on the normal path: a control nobody
     runs decays into a comment.
     """
-    good = ["build: \\", "    alpha \\", "    beta \\", "    gamma \\",
+    good = [f"{BUILD_REGISTRY}: \\", "    alpha \\", "    beta \\", "    gamma \\",
             f"    {SENTINEL}", "    @echo hi"]
-    assert check(good, "build") == [], "selftest: rejected a well-formed list"
+    assert check_registry(good, BUILD_REGISTRY)[1] == [], "selftest: rejected a well-formed list"
 
-    crowded = ["build: \\", "    alpha beta \\", "    gamma \\",
+    crowded = [f"{BUILD_REGISTRY}: \\", "    alpha beta \\", "    gamma \\",
                f"    {SENTINEL}", "    @echo hi"]
-    assert any("more than one gate" in p for p in check(crowded, "build")), (
+    assert any("more than one gate" in p for p in check_registry(crowded, BUILD_REGISTRY)[1]), (
         "selftest: missed two names sharing a line"
     )
 
-    unsorted = ["build: \\", "    gamma \\", "    alpha \\",
+    unsorted = [f"{BUILD_REGISTRY}: \\", "    gamma \\", "    alpha \\",
                 f"    {SENTINEL}", "    @echo hi"]
-    assert any("not sorted" in p for p in check(unsorted, "build")), (
+    assert any("not sorted" in p for p in check_registry(unsorted, BUILD_REGISTRY)[1]), (
         "selftest: missed an out-of-order list"
     )
 
-    dup = ["build: \\", "    alpha \\", "    alpha \\",
+    dup = [f"{BUILD_REGISTRY}: \\", "    alpha \\", "    alpha \\",
            f"    {SENTINEL}", "    @echo hi"]
-    assert any("listed twice" in p for p in check(dup, "build")), (
+    assert any("listed twice" in p for p in check_registry(dup, BUILD_REGISTRY)[1]), (
         "selftest: missed a duplicate"
     )
 
-    # The sentinel itself. Absent, the last real gate is the odd line again.
-    no_sentinel = ["build: \\", "    alpha \\", "    beta", "    @echo hi"]
-    assert any("missing the" in p for p in check(no_sentinel, "build")), (
+    no_sentinel = [f"{BUILD_REGISTRY}: \\", "    alpha \\", "    beta", "    @echo hi"]
+    assert any("missing the" in p for p in check_registry(no_sentinel, BUILD_REGISTRY)[1]), (
         "selftest: missed an absent terminator"
     )
 
-    # Present but not last terminates nothing — and would ALSO read as
-    # out-of-order, so the message has to name the real fault.
-    misplaced = ["build: \\", f"    {SENTINEL} \\", "    alpha \\",
+    misplaced = [f"{BUILD_REGISTRY}: \\", f"    {SENTINEL} \\", "    alpha \\",
                  "    beta", "    @echo hi"]
-    probs = check(misplaced, "build")
-    assert any("not LAST" in p for p in probs), (
-        f"selftest: missed a misplaced terminator: {probs}"
+    assert any("not LAST" in p for p in check_registry(misplaced, BUILD_REGISTRY)[1]), (
+        "selftest: missed a misplaced terminator"
     )
-
-    # And it must not be counted as a gate: with it last, a two-gate list is
-    # sorted, not "alpha, beta, _gate-list-end out of order".
-    assert not any("not sorted" in p for p in check(good, "build")), (
+    assert not any("not sorted" in p for p in check_registry(good, BUILD_REGISTRY)[1]), (
         "selftest: the sentinel was sorted as if it were a gate"
     )
 
-    # The block must end at the first line with no continuation, so a BODY line
-    # that happens to look like a name is not read as a dependency.
-    body = ["build: \\", "    alpha", "    zzz-not-a-dep", "    @echo hi"]
-    s, e = dep_block(body, "build")
-    assert (s, e) == (0, 2), f"selftest: block boundary wrong: {(s, e)}"
+    body = [f"{BUILD_REGISTRY}: \\", "    alpha", "    zzz-not-a-dep", "    @echo hi"]
+    assert dep_block(body, BUILD_REGISTRY) == (0, 2), "selftest: block boundary wrong"
 
-    # --- the ratchet (issue 1071) ---------------------------------------
-    # A deletion, which every OTHER check here accepts: the list below is
-    # sorted, one per line, terminated, and missing `beta`.
+    # --- the derivation itself -------------------------------------------
+    # A miniature justfile: two plain recipes, one build gate, one exempt
+    # verb, one parameterized helper.
+    mini = "\n".join([
+        "NIGHTLY := `true`",
+        "",
+        "[private]",
+        "alpha-gate:",
+        "    @true",
+        "",
+        "[private]",
+        "beta-gate:",
+        "    @true",
+        "",
+        "[private]",
+        f"{BUILD_REGISTRY}: \\",
+        "    heavy-gate \\",
+        f"    {SENTINEL}",
+        "    @true",
+        "",
+        "[private]",
+        "heavy-gate:",
+        "    @true",
+        "",
+        "[private]",
+        "some-verb:",
+        "    @true",
+        "",
+        "[private]",
+        f"{SENTINEL}:",
+        "",
+        "[private]",
+        'stack-elf elf top="30":',
+        "    @true",
+    ])
+    ex = f"{SENTINEL}  # terminator\n{BUILD_REGISTRY}  # the registry\nsome-verb  # a verb\n"
+    b, problems = classify(mini, ex)
+    assert problems == [], f"selftest: rejected a well-formed tree: {problems}"
+    assert b["fast"] == ["alpha-gate", "beta-gate"], b["fast"]
+    assert b["build"] == ["heavy-gate"], b["build"]
+    assert b["parameterized"] == ["stack-elf"], b["parameterized"]
+
+    # A NEW recipe joins the fast lane with no list to edit — the whole point.
+    plus = mini + "\n\n[private]\ngamma-gate:\n    @true\n"
+    assert classify(plus, ex)[0]["fast"] == ["alpha-gate", "beta-gate", "gamma-gate"], (
+        "selftest: a new recipe did not become a fast gate"
+    )
+
+    # A reason is mandatory.
+    assert any("has no reason" in p for p in classify(mini, ex + "orphan\n")[1]), (
+        "selftest: accepted an exemption with no reason"
+    )
+    # An exemption naming nothing.
+    assert any("no recipe" in p for p in classify(mini, ex + "ghost  # gone\n")[1]), (
+        "selftest: accepted an exemption for a recipe that does not exist"
+    )
+    # Exempt AND in the build registry.
+    assert any("AND exempt" in p for p in classify(mini, ex + "heavy-gate  # both\n")[1]), (
+        "selftest: accepted a gate claimed twice"
+    )
+    # A parameterized recipe cannot be listed.
+    assert any("declares parameters" in p
+               for p in classify(mini, ex + "stack-elf  # nope\n")[1]), (
+        "selftest: accepted an entry for a parameterized recipe"
+    )
+    # The ledger must be sorted, like the registry.
+    assert any("not sorted" in p
+               for p in classify(mini, f"some-verb  # v\n{SENTINEL}  # t\n")[1]), (
+        "selftest: missed an unsorted exemption ledger"
+    )
+
+
+    # --- the deletion ratchet (issue 1071) -------------------------------
+    # Carried through the 1072 rewrite. What changed is only WHERE the present
+    # set comes from — a derived classification instead of a registry line —
+    # so these cases are about the ratchet itself and stay as they were.
+    #
+    # A deletion, which every other check here accepts: sorted, one per line,
+    # terminated, and missing `beta`.
     assert ratchet({"alpha", "gamma"}, {"alpha", "beta", "gamma"}), (
-        "selftest: a gate that left the registry was not reported"
+        "selftest: a gate that left the set was not reported"
     )
     # Growth is free — that is the whole point of a ratchet.
     assert ratchet({"alpha", "beta", "delta"}, {"alpha", "beta"}) == [], (
         "selftest: an ADDED gate was reported as a problem"
     )
-    # And a delete-plus-add that nets to ZERO, which is #431's exact shape and
-    # the case a count ratchet cannot see.
+    # A delete-plus-add netting to ZERO: #431's exact shape, and the case a
+    # count ratchet cannot see.
     assert ratchet({"alpha", "delta"}, {"alpha", "beta"}), (
         "selftest: one added and one removed netted out and passed"
     )
-    # A missing baseline is a failure, not a silent pass: the ratchet would
-    # otherwise disappear the moment someone deleted the file.
+    # A missing baseline fails, or the ratchet disappears the moment someone
+    # deletes the file.
     assert ratchet({"alpha"}, None), "selftest: a missing baseline passed"
 
-    # The set is FLAT across registries, so a gate moving from `fast` to
-    # `build` is not a deletion.
-    moved = ["fast-serial: \\", f"    {SENTINEL}", "    @echo f", "",
-             "build-serial: \\", "    alpha \\", f"    {SENTINEL}", "    @echo b"]
-    assert registry_names(moved) == {"alpha"}, (
-        f"selftest: flat name set wrong: {registry_names(moved)}"
-    )
-
-
 def main(argv: list[str]) -> int:
-    lines = JUSTFILE.read_text(encoding="utf-8").split("\n")
+    b, problems = buckets()
 
     if "--write-baseline" in argv:
-        present = registry_names(lines)
+        if problems:
+            print("check-gate-lists: refusing to write a baseline over a broken "
+                  "classification:", file=sys.stderr)
+            print("\n".join(problems), file=sys.stderr)
+            return 1
+        present = set(gate_names())
         write_baseline(present)
         print(
             f"check-gate-lists: wrote {len(present)} gate name(s) to "
@@ -317,31 +504,50 @@ def main(argv: list[str]) -> int:
         )
         return 0
 
-    problems = [p for name in REGISTRIES for p in check(lines, name)]
-    problems += ratchet(registry_names(lines), load_baseline())
+    if argv and argv[0] == "--list":
+        # The runners' one source of truth. `fast-serial`/`build-serial` are
+        # accepted as well as the verbs, because `NROS_GATE_LANE` is spelled
+        # with the suffix and predates this.
+        if problems:
+            print("check-gate-lists: refusing to emit a list over a broken registry:",
+                  file=sys.stderr)
+            print("\n".join(problems), file=sys.stderr)
+            return 1
+        lane = (argv[1] if len(argv) > 1 else "fast").removesuffix("-serial")
+        if lane == "all":
+            names = sorted(b["fast"] + b["build"])
+        elif lane in ("fast", "build"):
+            names = b[lane]
+        else:
+            print(f"check-gate-lists: unknown lane `{lane}`", file=sys.stderr)
+            return 2
+        print("\n".join(names))
+        return 0
+
+    # The deletion ratchet (issue 1071) reads the DERIVED set, not a registry
+    # line — that is the whole of its 1072 rebase. A gate can now only leave by
+    # having its recipe deleted, and this is what notices.
+    if not problems:
+        problems = ratchet(set(b["fast"] + b["build"]), load_baseline())
+
     if problems:
-        print("check-gate-lists: a gate registry is a conflict site again\n")
+        print("check-gate-lists: the gate classification does not hold\n")
         print("\n".join(problems))
         print(
-            "\nA gate registry may not SHRINK, and one gate per line, sorted.\n"
-            "A retirement is deliberate:\n"
-            "    python3 scripts/check/check-gate-lists.py --write-baseline\n"
-            "and name the gate in the commit message.\n"
-            "\n`just/check.just` is the file every PR\n"
-            "that adds a gate must touch, and packing names onto shared lines\n"
-            "turns that into a merge conflict for changes that do not overlap\n"
-            "(issues 0883/0884, same shape, no union merge available here --\n"
-            "a union of two authored recipe bodies is both of them, not one)."
+            "\nA recipe in just/check.just is a FAST gate unless it is in\n"
+            "`build-serial:`, named in .config/gate-lane-exempt.txt with a\n"
+            "reason, or declares parameters. There is deliberately no\n"
+            "fast-lane registry to append to: a shared authored list is the\n"
+            "conflict issues 0883/0884/1072 measured, and no merge driver can\n"
+            "fix it because GitHub rebases queue entries server-side."
         )
         return 1
 
-    total = sum(
-        len([n for g in names_per_line(lines, *dep_block(lines, name)) for n in g])
-        for name in REGISTRIES
-    )
     print(
-        f"check-gate-lists OK — {len(REGISTRIES)} registry(ies), {total} gate(s), "
-        "one per line and sorted."
+        f"check-gate-lists OK — {len(b['fast'])} fast gate(s) derived, "
+        f"{len(b['build'])} in `{BUILD_REGISTRY}` (one per line and sorted), "
+        f"{len(b['exempt'])} exempt with a reason, "
+        f"{len(b['parameterized'])} parameterized recipe(s) excluded."
     )
     return 0
 


### PR DESCRIPTION
Three CI-hygiene defects that share one shape: a control that exists, runs, and reports nothing.

Also carries the phase-425 book page (first commit) — trivially separable if you'd rather it went alone.

## #1072 — the 218-name gate registry is deleted

Re-measured against current main: 31 open PRs, 11 conflicting. `just/check.just` is only **5th by conflict count** (2) but **1st by exposure** — 15 of 31 PRs touch it, 36 % more than the next path. Conflict count is a lagging indicator.

**The issue's own §1 was wrong**, and the doc is corrected. It claimed the registry merges cleanly and only recipe bodies conflict. Both live conflicts were inspected: #472 conflicts *in the registry*. Sorting does not spread insertions out — it converts NAME correlation into POSITION correlation, and the eight registry-adding PRs cluster at a handful of indices.

Membership is now **derived**: a recipe in `just/check.just` is a fast gate unless it is in `build-serial:`, named in `.config/gate-lane-exempt.txt` with a reason, or declares parameters (a gate runs as `just check <name>`, so a recipe needing an argument can never be one). Adding a gate is writing its recipe. No shared list is touched at all.

Why the alternatives lose: sorting the recipe bodies fixes neither measured conflict and reorders ~4,000 lines against 15 in-flight PRs; a merge driver is 0884's dead end (GitHub rebases queue entries server-side); moving the list to its own file keeps the sorted-insert collision.

This closes **#1071's other half** too: there is no registry line left to delete, so the failure mode inverts from "gate silently never runs" to "gate runs on the fast lane" — loud, and on the author's own PR.

**Acceptance**: gate set unchanged, verified against this branch's own base rather than a moving main — fast 218 → 218, build 21 → 21, empty symmetric difference both directions. (Post-rebase it is 219/21, because main added `codegen-tool-reconfigure` and the derivation picks it up with no registry edit — which is the point.)

The #1071 ratchet survives the rewrite reading the **derived** set instead of a registry line; its 239-name baseline needed no edit. Mutation-checked after the merge.

## #1040 — `check-api-parity` was already wired, and had still never run

The premise was half wrong, and that half is worse than the half that was right.

It was put in gate.yml on 2026-09-04 — sharing one `run:` block with `just check build`. A `run:` block is `bash -e`. `check build` has been red on that lane since 2026-09-01, so on **all five scheduled runs since**, `check no-std` and `check api-parity` never executed. One red reported for three gates.

That is issue 0952's withdrawal class in YAML, where no recipe can print what it withdrew — and worse than not wiring it, because `grep -rl api-parity .github/workflows/` now answers *yes* while the gate has never run.

Each gate gets its own step with `!cancelled()`. api-parity gets its own post-submit job: measured **28.6 s**, no fixture/SDK/QEMU/cross-toolchain/ROS. One prerequisite the earlier wiring also missed — `clang` is not in the CI base image and `extract_cxx` shells out to it, so the step could not have run even had it been reached.

**The class**: `check-default-gates-run-somewhere` gains a second rule — per placement, no `just check <gate>` may sit behind another gate in the same `run:` block. Proven against the real unfixed `gate.yml`, not a mutation: it names exactly `api-parity` and `no-std`, no false positives, green against the fixed one. Both allowlists are **empty by measurement**.

## #1030 — lane contracts now scan report-only lanes

Widened to push/schedule/dispatch. Measured before changing: **0 new findings**, so the severity concern 1030 recorded is about how a finding should *read*, and lives in the output labels rather than the scope.

A second bug surfaced while widening: the derived loop tested each command word alone, so it **missed** module lanes (`just ci tier1` resolved to nothing) and **misattributed** — `just check api-parity` resolved to the root `api-parity` *report* recipe, so the rule was answering about a recipe no workflow runs. 3 lanes resolved before, 15 after.

## Verification

`just check fast` 219/219 · `api-parity` **green** (the missing row landed with #474) · `default-gates-run-somewhere` · `lane-contracts` · `gate-lists` · `gate-selftests` · `gate-visibility` all green · `just test-lane-contracts` 17/17.

## Cost, accepted rather than hidden

7 in-flight PRs gain a conflict in `just/check.just`, all resolved by taking the deletion and dropping their line.

## Deliberately not done

Promoting api-parity to `merge_group`. It is unblocked now that it is green, and cheaper than `dep-chain` which already gates — but one green run is not a track record, and a red gate on a merge-gating event freezes the repo.

Also filed, not fixed: **#1091** — with the gate registry gone, the api-parity ledger is the largest conflict cluster left (4 PRs). Same cause one directory over. Both obvious fixes are ruled out already; the migration would conflict with all four PRs it is meant to help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP