### PR TITLE
fix(#1039): NuttX said it was Linux to borrow one function

### DIFF
--- a/just/check.just
+++ b/just/check.just
@@ -329,6 +329,7 @@ fast-serial: \
     workspace-order \
     xrce-source-manifest \
     zenoh-config-template \
+    zenoh-platform-macros \
     zenohd-flag-invocations \
     zenohd-resolution-parity \
     zenohd-router-skips \
@@ -2399,6 +2400,15 @@ zenohd-resolution-parity:
 # rejected, and the reader gets a default-configured router with no diagnostic.
 # Gated because the class regenerates by copy-paste from a neighbouring example
 # header — which is how it reached ~95 files.
+# Issue 1039 — a port may declare its own platform to zenoh-pico, never
+# somebody else's. `nros-platform-nuttx` defined ZENOH_LINUX to reach the
+# `getrandom()` arm; the arm was right and the name was not, and the claim
+# then became load-bearing in three unrelated guards. Scans BOTH producers
+# (the platform manifests and `runner.rs`'s `build.define`), and runs its own
+# negative control first.
+zenoh-platform-macros:
+    @python3 scripts/check-zenoh-platform-macros.py
+
 zenohd-flag-invocations:
     @python3 scripts/check-zenohd-flag-invocations.py
 

--- a/packages/platform/nros-platform-nuttx/nros-platform.toml
+++ b/packages/platform/nros-platform-nuttx/nros-platform.toml
@@ -19,7 +19,7 @@ names = ["nuttx"]
 ip_stack = true    # posix sockets, named in [build]
 
 [build.zenoh]
-defines = ["ZENOH_GENERIC", "ZENOH_NUTTX", "ZENOH_LINUX"]
+defines = ["ZENOH_GENERIC", "ZENOH_NUTTX", "ZENOH_HAS_GETRANDOM"]
 defines_kv = { ZENOH_DEBUG = "0", Z_FEATURE_MULTI_THREAD = "1", Z_CONFIG_SOCKET_TIMEOUT = "5000" }
 include = ["system/common"]
 # Phase 156 Sub-bug B (NuttX) — `system/common/platform.h` routes

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -1693,22 +1693,33 @@ fn probe_net_type_sizes(
         }
     } else if use_nuttx {
         build.define("ZENOH_NUTTX", None);
-        // ZENOH_LINUX ALONGSIDE ZENOH_NUTTX, deliberately. Its only effect here
-        // is to pick the Linux arm of the six `#if defined(ZENOH_LINUX) …
-        // #elif defined(ZENOH_NUTTX)` pairs in zenoh-pico's
-        // `src/system/unix/system.c` — everywhere else NuttX is already named
-        // explicitly (`platform.h`'s unix-header selection and `network.c`'s two
-        // `LINUX || NUTTX` sites), so it is NOT what selects the unix layer.
+        // Issue 1039 — this used to be `ZENOH_LINUX`, defined ALONGSIDE
+        // ZENOH_NUTTX so that the six `#if defined(ZENOH_LINUX)` arms in
+        // zenoh-pico's `src/system/unix/system.c` would compile: NuttX ships
+        // `<sys/random.h>` and `getrandom()`, and the NuttX arm they shadow
+        // opens `/dev/urandom`, a device node a NuttX configuration is not
+        // obliged to provide.
         //
-        // Keep it. NuttX ships `<sys/random.h>` and `getrandom()`, so the Linux
-        // arm compiles and works, while the NuttX arm it shadows opens
-        // `/dev/urandom` — a device node a NuttX configuration is not obliged
-        // to provide. Dropping this define would silently move every NuttX
-        // image onto six code paths nothing here has ever exercised.
+        // The arm was right and the NAME was wrong. Reaching a capability by
+        // asserting a platform makes the image claim to BE Linux for every
+        // OTHER guard that tests the same macro, which is why dropping the
+        // define was not a one-line change: three guards in
+        // `system/common/platform.c` (`<arpa/inet.h>` and the two endpoint
+        // helpers) were being reached through it too, and NuttX has no
+        // endpoint implementation of its own to fall back to.
         //
-        // The consequence worth knowing: those six `ZENOH_NUTTX` arms are DEAD
-        // in our builds. Do not "fix" one and expect it to take effect.
-        build.define("ZENOH_LINUX", None);
+        // Those guards now name NuttX, the randomness arms test
+        // `ZENOH_HAS_GETRANDOM`, and this says what the port actually has.
+        // Proven equivalent, not assumed: `gcc -E -P` output for
+        // `system/unix/system.c`, `system/common/platform.c` and
+        // `system/unix/network.c` is byte-identical before and after, so every
+        // NuttX image compiles the code it compiled before.
+        //
+        // Still worth knowing: the six `ZENOH_NUTTX` randomness arms remain
+        // DEAD in our builds, because we do define the capability. They are
+        // now REACHABLE — a NuttX port without `getrandom()` selects them by
+        // omitting this define — which they were not before.
+        build.define("ZENOH_HAS_GETRANDOM", None);
         // Issue 0551 — the SHARED tree's `include/` is not a guaranteed compile
         // input. `build-nuttx.sh`'s snapshot short-circuit says so in as many
         // words ("this path guarantees the SNAPSHOT, never the tree"): when the

--- a/scripts/check-zenoh-platform-macros.py
+++ b/scripts/check-zenoh-platform-macros.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""A port may declare its own platform to zenoh-pico, never somebody else's.
+
+Issue 1039. `nros-platform-nuttx` defined `ZENOH_LINUX` alongside `ZENOH_NUTTX`
+so that zenoh-pico's `getrandom()` arm would compile -- NuttX has the function,
+and the NuttX arm it shadows opens `/dev/urandom`, which a NuttX configuration
+is not obliged to provide. The arm was the right one. The NAME was not.
+
+Reaching a capability by asserting a platform is not a local shortcut. The
+macro is tested by every other guard in the library, so the image claims to be
+Linux everywhere at once, and the claim then becomes load-bearing in places
+nobody chose: three guards in `system/common/platform.c` (`<arpa/inet.h>` and
+two endpoint helpers) were being reached through it, which is why the define
+could not simply be dropped. A capability macro -- `ZENOH_HAS_*` -- says what
+the port has and is inert everywhere else.
+
+TWO PRODUCERS, because one was not enough
+-----------------------------------------
+The NuttX define set is authored twice: in `nros-platform.toml` and again in
+`nros-zpico-build`'s `runner.rs` as `build.define(...)`. A check that read only
+the manifests would pass while the build still defined the macro. Both are
+scanned.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# zenoh-pico's platform macros. `ZENOH_GENERIC` is a build MODE (use the
+# generated config header), not a platform, so it is not one of these.
+PLATFORM_MACROS = {
+    "ZENOH_LINUX",
+    "ZENOH_MACOS",
+    "ZENOH_BSD",
+    "ZENOH_WINDOWS",
+    "ZENOH_NUTTX",
+    "ZENOH_ZEPHYR",
+    "ZENOH_THREADX",
+    "ZENOH_FREERTOS_LWIP",
+    "ZENOH_ESPIDF",
+    "ZENOH_MBED",
+    "ZENOH_ARDUINO",
+    "ZENOH_RPI_PICO",
+    "ZENOH_EMSCRIPTEN",
+    "ZENOH_FLIPPER",
+}
+
+# Which platform macro each of our ports is entitled to claim. `posix` is the
+# host build and is Linux here (see CLAUDE.md "Naming" -- the board is
+# `["native", "linux"]`).
+OWN_MACRO = {
+    "posix": {"ZENOH_LINUX", "ZENOH_MACOS", "ZENOH_BSD"},
+    "nuttx": {"ZENOH_NUTTX"},
+    "zephyr": {"ZENOH_ZEPHYR"},
+    "threadx": {"ZENOH_THREADX"},
+    "freertos": {"ZENOH_FREERTOS_LWIP"},
+}
+
+
+def macros_in(text: str) -> set[str]:
+    """Every ZENOH_* platform macro this text DECLARES, comments excluded.
+
+    Matches a TOML `defines` entry and a Rust `build.define("...")` alike; both
+    quote the macro, and a comment mentioning one must not count -- the
+    `runner.rs` block explaining this very issue names `ZENOH_LINUX` four
+    times."""
+    found: set[str] = set()
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("#") or s.startswith("//"):
+            continue
+        for m in re.finditer(r'"(ZENOH_[A-Z0-9_]+)"', line):
+            if m.group(1) in PLATFORM_MACROS:
+                found.add(m.group(1))
+    return found
+
+
+def platform_of(path: Path) -> str | None:
+    """The port a file belongs to, or None if it is not port-specific."""
+    for part in path.parts:
+        if part.startswith("nros-platform-"):
+            return part[len("nros-platform-") :]
+    return None
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+
+    manifests = sorted(ROOT.glob("packages/platform/*/nros-platform.toml"))
+    if not manifests:
+        print(
+            "ERROR: no packages/platform/*/nros-platform.toml found — this "
+            "check would pass by having nothing to inspect.",
+            file=sys.stderr,
+        )
+        return 2
+
+    for man in manifests:
+        plat = platform_of(man)
+        if plat is None or plat not in OWN_MACRO:
+            continue
+        checked += 1
+        for macro in sorted(macros_in(man.read_text(encoding="utf8"))):
+            if macro not in OWN_MACRO[plat]:
+                failures.append(
+                    f"{man.relative_to(ROOT)}: the {plat} port declares {macro}"
+                )
+
+    # Second producer: the zpico build script defines the same set in Rust.
+    runner = ROOT / "packages/rmw/zenoh/nros-zpico-build/src/runner.rs"
+    if not runner.is_file():
+        print(
+            f"ERROR: {runner.relative_to(ROOT)} is missing — it is the second\n"
+            "       place the define set is authored, so this check cannot\n"
+            "       vouch for the build without it.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Per-port blocks are `} else if use_<plat> {`; attribute each define to the
+    # block it sits in.
+    #
+    # The attribution MUST clear at the closing `} else {`, or it latches the
+    # last port seen and blames it for everything after. That is not a
+    # hypothetical: the first version of this loop reported the POSIX fallback
+    # (`} else {` — which defines ZENOH_LINUX only when the target triple says
+    # linux, and is correct) as "the threadx branch defines ZENOH_LINUX". A
+    # confident wrong attribution is worse than no check.
+    plat_now: str | None = None
+    for lineno, line in enumerate(runner.read_text(encoding="utf8").splitlines(), 1):
+        m = re.search(r"\buse_([a-z0-9_]+)\s*\{", line)
+        if m:
+            plat_now = m.group(1)
+        elif re.match(r"\s*\}\s*else\s*\{", line) or line.startswith("fn "):
+            plat_now = None
+        if plat_now not in OWN_MACRO:
+            continue
+        for macro in sorted(macros_in(line)):
+            if macro not in OWN_MACRO[plat_now]:
+                failures.append(
+                    f"{runner.relative_to(ROOT)}:{lineno}: the {plat_now} "
+                    f"branch defines {macro}"
+                )
+    checked += 1
+
+    if failures:
+        print(
+            "check-zenoh-platform-macros: a port claims a platform that is not "
+            "its own (issue 1039):\n",
+            file=sys.stderr,
+        )
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        print(
+            "\n  zenoh-pico tests these macros everywhere, not only where you\n"
+            "  wanted the behaviour, so the claim becomes load-bearing in\n"
+            "  guards nobody chose. If the port needs a CAPABILITY, name it:\n"
+            "  `ZENOH_HAS_GETRANDOM` is inert outside the arms that test it.\n"
+            "  If zenoh-pico has no capability macro for what you need, add\n"
+            "  one there rather than borrowing a platform here.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check-zenoh-platform-macros: OK ({checked} producer(s); every port "
+        "declares only its own platform)"
+    )
+    return 0
+
+
+def self_test(quiet: bool = True) -> int:
+    """Negative control. The tree is expected to be clean, and a check that
+    only ever sees clean input prints the same thing whether or not it works."""
+    cases = [
+        # `macros_in` reports every platform macro DECLARED; whether the port
+        # is entitled to it is judged against OWN_MACRO afterwards. So the
+        # port's own macro is expected here, not filtered out.
+        (
+            "a port declaring its own macro",
+            'defines = ["ZENOH_GENERIC", "ZENOH_NUTTX"]',
+            {"ZENOH_NUTTX"},
+        ),
+        (
+            "a port borrowing another platform",
+            'defines = ["ZENOH_GENERIC", "ZENOH_NUTTX", "ZENOH_LINUX"]',
+            {"ZENOH_LINUX", "ZENOH_NUTTX"},
+        ),
+        (
+            "a capability macro is not a platform",
+            'defines = ["ZENOH_NUTTX", "ZENOH_HAS_GETRANDOM"]',
+            {"ZENOH_NUTTX"},
+        ),
+        (
+            "a TOML comment naming a macro is not a declaration",
+            '# ZENOH_LINUX used to be here\ndefines = ["ZENOH_NUTTX"]',
+            {"ZENOH_NUTTX"},
+        ),
+        (
+            "a Rust comment naming a macro is not a declaration",
+            '// this used to be "ZENOH_LINUX", see issue 1039\n'
+            'build.define("ZENOH_HAS_GETRANDOM", None);',
+            set(),
+        ),
+        (
+            "a Rust define is a declaration",
+            'build.define("ZENOH_LINUX", None);',
+            {"ZENOH_LINUX"},
+        ),
+    ]
+    bad = 0
+    for name, text, want in cases:
+        got = macros_in(text)
+        if got != want:
+            bad += 1
+            print(
+                f"SELFTEST FAIL: {name}: expected {sorted(want)}, got {sorted(got)}",
+                file=sys.stderr,
+            )
+        elif not quiet:
+            print(f"  ok: {name}")
+    if bad:
+        print(
+            "check-zenoh-platform-macros: SELFTEST FAILED — the check cannot "
+            "be trusted about the tree until it is right about these.",
+            file=sys.stderr,
+        )
+    elif not quiet:
+        print(f"check-zenoh-platform-macros selftest: OK ({len(cases)} case(s))")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv or "--selftest" in sys.argv:
+        sys.exit(self_test(quiet=False))
+    # The negative control runs BEFORE the tree is inspected.
+    if self_test() != 0:
+        sys.exit(2)
+    sys.exit(main())


### PR DESCRIPTION
`nros-platform-nuttx` defined `ZENOH_LINUX` alongside `ZENOH_NUTTX`, and
`nros-zpico-build` did the same in `runner.rs`. The reason was sound: the six
`z_random_*` arms in zenoh-pico's `system/unix/system.c` test `ZENOH_LINUX`,
NuttX ships `<sys/random.h>` and `getrandom()`, and the NuttX arm they shadow
opens `/dev/urandom` — a device node a NuttX configuration is not obliged to
provide. The arm was the right one to compile. The NAME was wrong.

Reaching a capability by asserting a platform is not a local shortcut, because
the macro is tested by every other guard in the library. The image claims to
be Linux everywhere at once, and the claim then becomes load-bearing in places
nobody chose: three guards in `system/common/platform.c` — `<arpa/inet.h>` and
the endpoint helpers `_z_ipv4_port_to_endpoint` / `_z_ip_port_to_endpoint` —
were being reached through it. NuttX uses the `unix` platform directory and
has no endpoint implementation of its own, and the fallback arm already
excludes NUTTX, so dropping the define alone would have failed the link on a
missing symbol rather than falling back to anything. That is why the previous
`runner.rs` comment said to keep it.

Submodule (zenoh-pico `nano-ros`, commit dd071b8d — pushed as a fast-forward,
49b4e635..dd071b8d): the randomness
arms test `ZENOH_HAS_GETRANDOM`, auto-defined when `ZENOH_LINUX` is set so no
existing build changes a flag; the three `platform.c` guards name NuttX
directly; `<fcntl.h>` is included only when the /dev/urandom fallback actually
compiles.

Here: both producers stop claiming Linux. The define set was authored TWICE —
in `nros-platform.toml` and again as `build.define(...)` in `runner.rs` — so a
change to either alone would have left the other still asserting it.

Verified by preprocessor equivalence, not by reading. `gcc -E -P` output is
byte-identical before and after for `system/unix/system.c`,
`system/common/platform.c` and `system/unix/network.c`, under both
`-DZENOH_NUTTX -DZENOH_LINUX` -> `-DZENOH_NUTTX -DZENOH_HAS_GETRANDOM` and
`-DZENOH_LINUX` -> `-DZENOH_LINUX`: six of six. Every NuttX image compiles
exactly the code it compiled before, and Linux is untouched. The configuration
this newly makes expressible was checked too — `-DZENOH_NUTTX` alone selects
the /dev/urandom fallback, and adding the capability deselects it. Those six
NuttX arms stay dead in our builds, but they are now REACHABLE, which they
were not before.

Gate: `check-zenoh-platform-macros` (fast line) — a port may declare its own
platform macro and no other. It reads BOTH producers, because a check that
read only the manifests would have passed while the build still defined it.
Its own negative control runs first, and caught two of my errors: a selftest
expectation that was simply wrong, and a block-attribution loop that latched
the last `use_<plat>` it saw and reported the POSIX fallback (correctly gated
on the target triple) as "the threadx branch defines ZENOH_LINUX".

The fork branch moved while this was in progress (`49b4e635`, an
INET6_ADDRSTRLEN fallback, landed on `nano-ros` and touches the same file), so
this was REBASED onto it rather than merged, and the preprocessor equivalence
was re-run against the new base — still six of six identical. The pin moves
`49b4e635..dd071b8d`, one commit forward.

Also noticed: the LOCAL `nano-ros` branch in that submodule (b3bce713) has
DIVERGED from the remote — neither is an ancestor of the other. Nothing was
pushed from it; the push used an explicit refspec off the rebased commit.

Verified: 219 fast gates green; clippy `-D warnings` clean for
`nros-zpico-build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)