### PR TITLE
fix(#0964): the unbounded arm poisons — the half of #494 the queue merged without

### DIFF
--- a/docs/issues/archived/0964-two-different-sizes-for-the-same-type.md
+++ b/docs/issues/archived/0964-two-different-sizes-for-the-same-type.md
@@ -1,7 +1,7 @@
 ---
 id: 964
 title: "The C++ header states an ESTIMATED size for every type, including types that have no bound"
-status: open
+status: resolved
 area: codegen
 severity: medium
 related: [0896, 0939, 0940, phase-403, phase-380]
@@ -292,3 +292,64 @@ Still a product decision, and unchanged in substance: 81 of 120 stock Humble
 types have no derived bound, so the flip makes code that compiled yesterday stop
 compiling until each type gains a `cap` or each call site uses the `_sized`
 form.
+
+
+## DECIDED and LANDED 2026-09-05: the unbounded arm poisons
+
+Maintainer decision, in their words: avoid silent truncation; over-long messages
+fail with explicit errors; **an under-size estimate should be a compile-time
+error, because the calculation is incorrect and cannot accept the message size
+the user expects.**
+
+That is the argument this issue could not make for itself, and it is the right
+one. The estimate is not a conservative bound — `compute_serialized_size_max`
+uses a flat 512 per nested message and a default capacity per string, and over
+the measured corpus it over-stated 38 of 39 bounded types and UNDER-stated one.
+An under-state sizes a stack array that cannot hold what the program
+legitimately sends, and no run-time check repairs a number already baked into
+`uint8_t buf[N]`. It is a fact about the build, so it is a build error.
+
+`detail::buffer_bounds<M, bound_shape::unbounded>` now delegates to
+`strict_bounds`. The `legacy` arm is deliberately NOT flipped: a legacy type
+predates the bound marker and never had a derivation to disagree with, so it
+keeps the estimate and an existing consumer keeps compiling.
+
+### What it cost in-tree: nothing
+
+Measured, not assumed. `compile-check-fixtures.sh` builds **36 rows across 5
+builders** with **zero** `states no serialized-size bound` errors, and
+`just check cpp`, `just check c` and `just check fast` (213/213) all pass. Every
+in-tree C++ consumer either uses a bounded type on these paths or does not reach
+them.
+
+(That run needed the zenoh-pico INET6 fix present, which is a separate PR. The
+first attempt reported zero poison hits with `cxx=0` — the C++ checks had not
+run at all, because the config-header step died on that unrelated bug. A zero
+from a check that did not execute is not a zero.)
+
+### How it is held
+
+* `unbounded_buffer_probe.cpp` — an EXPECTED-FAILURE TU that asks an unbounded
+  type to size a buffer, in both directions, and must not compile. A
+  `static_assert` cannot express "this must not compile", so the assertion that
+  the poison still fires has to live in a TU of its own.
+* Wired into `check-cpp`, asserted-present first, because a missing file is also
+  a non-zero `c++` and reads as a pass.
+* Mutation-tested: reverting the arm to the estimate makes `check-cpp` fail with
+  "a type with NO derived bound sized a buffer and compiled clean".
+
+### What a user does now
+
+Unchanged from the analysis above, and the cost is real — 81 of 120 stock Humble
+types state no derived bound:
+
+1. **Bound the type** — `string<=64` in the `.msg`, or a `cap` in
+   `nros-codegen.toml` (`[fields]` / `[types]` / `[packages]` / `[defaults]`).
+   One edit fixes every site for that type. `heap` / `view` caps do NOT bound.
+2. **Or call the `_sized` form** at the one site that needs it.
+
+The receive paths were already strict before this (`component.hpp` passes
+`rx_size_bound`), so what changed is the 15 TX sites the previous section
+rerouted — and on those the old failure was loud rather than silent. The
+decision was made on the correctness of the number, not on a silent-data-loss
+risk that did not exist there.

--- a/just/check.just
+++ b/just/check.just
@@ -3935,6 +3935,29 @@ cpp: cpp-fmt
         -Ipackages/api/nros-c/include \
         -Ipackages/platform/nros-platform-api/include \
         packages/api/nros-cpp/tests/compile/serialization_format.cpp
+    echo "  - an unbounded type cannot size a buffer (issue 0964)"
+    # Expected-failure, and asserted-present first for the same reason every
+    # other probe here is: a missing file is also a non-zero c++, and reads as a
+    # pass.
+    test -f packages/api/nros-cpp/tests/compile/unbounded_buffer_probe.cpp || { \
+        echo "ERROR: unbounded_buffer_probe.cpp is MISSING -- the expected-failure" >&2; \
+        echo "       check below would PASS on a missing file." >&2; \
+        exit 1; \
+    }
+    if c++ -fsyntax-only -std=c++17 \
+        -Itarget/nros-cpp-generated \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-cpp/include \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-cpp/tests/compile/unbounded_buffer_probe.cpp 2>/dev/null; then \
+        echo "ERROR: a type with NO derived bound sized a buffer and compiled clean." >&2; \
+        echo "       detail::buffer_bounds' unbounded arm has been disarmed, so an" >&2; \
+        echo "       INVENTED number is back in a stack array -- and the estimate" >&2; \
+        echo "       under-states as well as over-states, so the buffer can be too" >&2; \
+        echo "       small for a message the user legitimately sends (issue 0964)." >&2; \
+        exit 1; \
+    fi
     test -f packages/api/nros-cpp/tests/compile/serialization_format_mismatch_probe.cpp || { \
         echo "ERROR: serialization_format_mismatch_probe.cpp is MISSING -- the expected-failure" >&2; \
         echo "       check below would PASS on a missing file." >&2; \

--- a/packages/api/nros-cpp/include/nros/size_bound.hpp
+++ b/packages/api/nros-cpp/include/nros/size_bound.hpp
@@ -113,16 +113,19 @@ template <class M> struct strict_bounds<M, bound_shape::unbounded> {
     static constexpr size_t rx = M::template rx_size_bound<>::value;
 };
 
-/// CAPACITY: the number these headers actually stack a `uint8_t buf[N]` on
-/// today. Same answer as `strict_bounds` for a bounded type; the legacy
-/// estimate for a type with no derived bound, so an existing consumer keeps
-/// compiling. Never poisons.
+/// CAPACITY: the number these headers actually stack a `uint8_t buf[N]` on.
+/// Same answer as `strict_bounds` for a bounded type, and — since issue 0964
+/// was decided — the same poison for a MARKED type with no bound. It still
+/// differs from `strict_bounds` in one arm: a `legacy` type, which predates the
+/// bound marker entirely and never had a derivation to disagree with, keeps the
+/// estimate so an existing consumer keeps compiling.
 ///
-/// The `unbounded` arm is issue 0964's OPEN half, deliberately: flipping it to
-/// `strict_bounds` would turn every receive path over an unbounded type into a
-/// compile error, and the migration a user would have to make (a `cap` in
-/// `nros-codegen.toml`, or the `_sized` form beside each call) is a product
-/// decision, not one a header can take on their behalf.
+/// The `unbounded` arm WAS issue 0964's open half. Decided 2026-09-05: it
+/// poisons. The reasoning is on the arm itself; in short, a buffer sized from an
+/// invented number cannot accept a message the user legitimately sends, and
+/// that is a fact about the build rather than something a run can recover from.
+/// The migration is a `cap` in `nros-codegen.toml` (or a bound in the `.msg`),
+/// which fixes every site for that type, or the `_sized` form at one site.
 template <class M, bound_shape = shape_of<M>()> struct buffer_bounds;
 
 template <class M> struct buffer_bounds<M, bound_shape::legacy> {
@@ -134,8 +137,25 @@ template <class M> struct buffer_bounds<M, bound_shape::derived> {
     static constexpr size_t rx = M::RX_MAX_SERIALIZED_SIZE;
 };
 template <class M> struct buffer_bounds<M, bound_shape::unbounded> {
-    static constexpr size_t tx = M::SERIALIZED_SIZE_MAX;
-    static constexpr size_t rx = M::SERIALIZED_SIZE_MAX;
+    // Issue 0964, DECIDED 2026-09-05: this arm poisons.
+    //
+    // The estimate is not a smaller-than-ideal bound, it is a WRONG one: this
+    // type's derivation ran and found no bound at all, so any fixed number
+    // here is invented, and `compute_serialized_size_max` is not even trying to
+    // be an upper bound (a flat 512 per nested message, a default capacity per
+    // string). It over-stated 38 of 39 bounded types and under-stated 1.
+    //
+    // Under-stating is the case that decides it. A buffer smaller than the
+    // message a user legitimately sends cannot accept that message, and the
+    // program cannot be made correct at run time — the number is baked into a
+    // stack array. That is a fact about the build, so it is a build error.
+    //
+    // Two ways out, both stating a number somebody chose: bound the type
+    // (`string<=64` in the `.msg`, or a `cap` in `nros-codegen.toml`), which
+    // fixes every site at once; or call the `_sized` form at the one site that
+    // needs it. `heap` / `view` caps do NOT bound (RFC-0033).
+    static constexpr size_t tx = strict_bounds<M>::tx;
+    static constexpr size_t rx = strict_bounds<M>::rx;
 };
 
 } // namespace detail

--- a/packages/api/nros-cpp/tests/compile/rx_size_bound.cpp
+++ b/packages/api/nros-cpp/tests/compile/rx_size_bound.cpp
@@ -148,11 +148,14 @@ static_assert(::nros::tx_buffer_capacity<Bounded>::value == 133,
               "a bounded type's transmit capacity is TX_MAX_SERIALIZED_SIZE -- XCDR1");
 static_assert(::nros::rx_buffer_capacity<Legacy>::value == Legacy::SERIALIZED_SIZE_MAX,
               "a type with no derivation keeps the pre-phase-408 behaviour");
-static_assert(::nros::rx_buffer_capacity<Unbounded>::value == Unbounded::SERIALIZED_SIZE_MAX,
-              "issue 0964 step 3, PINNED so a future flip is a deliberate edit here: a type with "
-              "NO bound stays on the estimate at a receive site rather than becoming a compile "
-              "error. `rx_size_bound<Unbounded>` is still the poison -- that is the difference "
-              "between the two traits, and the whole reason both exist");
+// Issue 0964, DECIDED 2026-09-05: `rx_buffer_capacity<Unbounded>` no longer
+// HAS a value -- instantiating it is the deliberate compile error, so it cannot
+// be asserted about here. The proof that it fires lives in
+// `unbounded_buffer_probe.cpp`, an expected-failure TU, because a static_assert
+// cannot express "this expression must not compile".
+//
+// What still holds, and is asserted above: `has_derived_size_bound<Unbounded>`
+// is false. That is the FACT; the poison is the POLICY built on it.
 
 // Anti-drift, the 0088-family rule: `shape_of` decides `derived` by probing the
 // CONSTANTS, while the poison arm reads the nested TEMPLATES. Both come out of
@@ -252,32 +255,33 @@ static_assert(
                  ::nros::Future<Bounded, 137>>::value,
     "Client<S>::send_request must hand back a Future sized from the response type's DERIVED "
     "bound, not from its SERIALIZED_SIZE_MAX estimate");
-static_assert(std::is_same<decltype(std::declval<::nros::Client<SvcOf<Unbounded>>&>().send_request(
-                               std::declval<const Unbounded&>())),
-                           ::nros::Future<Unbounded, Unbounded::SERIALIZED_SIZE_MAX>>::value,
-              "a response type with NO derived bound keeps the estimate -- issue 0964 step 3");
+// Issue 0964: the matching `Client<SvcOf<Unbounded>>` assertion is gone for the
+// same reason -- `send_request` over an unbounded response type is now a build
+// error, which is the point, and an expected-failure TU is where that is shown.
 
-/// The point of the whole arrangement: the SAME bodies instantiate for a type
-/// with a derived bound and for one with none. Before this, a blanket switch to
-/// `rx_size_bound<M>` would have made the second column a compile error for 81
-/// of the 120 stock Humble types.
+/// Every path instantiates for a type with a derived bound.
+///
+/// The `Unbounded` column that used to sit beside each of these is GONE, and
+/// its absence is the change issue 0964 asked for: those bodies size a buffer,
+/// an unbounded type has no size to give them, and the estimate they used to
+/// fall back on was invented. Each of them is now a build error, proven in
+/// `unbounded_buffer_probe.cpp` rather than here.
+///
+/// This is a real migration cost and it is not hidden: 81 of the 120 stock
+/// Humble types state no derived bound, so a user reaching any of these paths
+/// with one must bound the type (`string<=64`, or a `cap` in
+/// `nros-codegen.toml`) or call the `_sized` form. The trade accepted is that a
+/// wrong number found at build time beats a buffer that cannot hold what the
+/// program sends.
 inline ::nros::Result instantiate_recv_paths(
     ::nros::Subscription<Bounded>& bsub, ::nros::Stream<Bounded>& bstream, Bounded& bmsg,
-    ::nros::Subscription<Unbounded>& usub, ::nros::Stream<Unbounded>& ustream, Unbounded& umsg,
     ::nros::Client<SvcOf<Bounded>>& bclient, ::nros::Service<SvcOf<Bounded>>& bservice,
-    ::nros::Client<SvcOf<Unbounded>>& uclient, ::nros::Service<SvcOf<Unbounded>>& uservice,
     ::nros::TickCtx& tick, ::nros::ActionClient<ActionOf<Bounded>>& bac,
     ::nros::PollingActionClient<ActionOf<Bounded>>& bpac,
-    ::nros::PollingActionServer<ActionOf<Bounded>>& bpas,
-    ::nros::ActionClient<ActionOf<Unbounded>>& uac,
-    ::nros::PollingActionClient<ActionOf<Unbounded>>& upac,
-    ::nros::PollingActionServer<ActionOf<Unbounded>>& upas) {
+    ::nros::PollingActionServer<ActionOf<Bounded>>& bpas) {
     (void)recv_paths<Bounded>(bsub, bstream, bmsg);
-    (void)recv_paths<Unbounded>(usub, ustream, umsg);
     (void)client_paths<Bounded>(bclient, bservice, tick, bmsg);
-    (void)client_paths<Unbounded>(uclient, uservice, tick, umsg);
     (void)action_paths<Bounded>(bac, bpac, bpas, bmsg);
-    (void)action_paths<Unbounded>(uac, upac, upas, umsg);
     return ::nros::Result::success();
 }
 

--- a/packages/api/nros-cpp/tests/compile/unbounded_buffer_probe.cpp
+++ b/packages/api/nros-cpp/tests/compile/unbounded_buffer_probe.cpp
@@ -1,0 +1,54 @@
+// Issue 0964 — EXPECTED-FAILURE probe. This TU must NOT compile.
+//
+// The `unbounded` arm of `detail::buffer_bounds` poisons: a type whose
+// derivation ran and found no bound cannot size a buffer, and the estimate it
+// used to fall back on is invented — `compute_serialized_size_max` is a flat
+// 512 per nested message and a default capacity per string, which over-stated
+// 38 of 39 bounded types and UNDER-stated one. A buffer smaller than the
+// message a user legitimately sends cannot accept it, and no run-time check can
+// repair a size already baked into a stack array. So it is a build error.
+//
+// Written as an expected failure because a static_assert cannot say "this
+// expression must not compile" — the sibling `rx_size_bound.cpp` asserts
+// everything that must still SUCCEED, and this asserts the one thing that must
+// not. If this TU ever compiles clean, the poison has been disarmed and the
+// estimate is back in a buffer, silently.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "nros/size_bound.hpp"
+
+namespace {
+
+/// The shape codegen emits for a type whose derivation found no bound: the
+/// marker is present, the bound CONSTANTS are absent, and the nested templates
+/// carry the diagnostic. Mirrors the `Unbounded` stub in `rx_size_bound.cpp`.
+struct Unbounded {
+    int32_t data{0};
+    static constexpr const char* TYPE_NAME = "p::msg::dds_::Unbounded_";
+    static constexpr const char* TYPE_HASH = "RIHS01_unbounded_stub";
+    static const size_t SERIALIZED_SIZE_MAX = 264;
+    using nros_derived_size_bounds = void;
+    template <class NROS_size_bound_required = void> struct tx_size_bound {
+        static_assert(::nros::detail::size_bound_dependent_false<NROS_size_bound_required>::value,
+                      "NROS_UNBOUNDED__p_msg_unbounded__field_data: p/Unbounded states no "
+                      "serialized-size bound -- unbounded member: data (string).");
+        static constexpr size_t value = 0;
+    };
+    template <class NROS_size_bound_required = void> struct rx_size_bound {
+        static_assert(::nros::detail::size_bound_dependent_false<NROS_size_bound_required>::value,
+                      "NROS_UNBOUNDED__p_msg_unbounded__field_data: p/Unbounded states no "
+                      "serialized-size bound -- unbounded member: data (string).");
+        static constexpr size_t value = 0;
+    };
+};
+
+// THE ASSERTION OF THIS FILE: asking an unbounded type to size a buffer is a
+// build error. Both directions, because both stack an array.
+constexpr size_t rx = ::nros::detail::buffer_bounds<Unbounded>::rx;
+constexpr size_t tx = ::nros::detail::buffer_bounds<Unbounded>::tx;
+
+} // namespace
+
+int main() { return static_cast<int>(rx + tx); }


### PR DESCRIPTION
**#494 merged without the decision it was about.** The queue took the branch's earlier state, so `main` got the reroute (`0fb15bd25`) and not the flip — `buffer_bounds<M, bound_shape::unbounded>` on `main` still reads `M::SERIALIZED_SIZE_MAX`. This is that commit, cherry-picked onto current `main`.

Worth noticing rather than just fixing: a PR titled for a decision merged with the decision absent, and the only thing that caught it was checking `main`'s content afterward instead of trusting the MERGED status.

## What it does

Per your call — avoid silent truncation, over-long messages fail explicitly, and an **under-size estimate is a compile-time error because the calculation is incorrect and cannot accept the message size the user expects**.

`compute_serialized_size_max` isn't a conservative bound (flat 512 per nested message, default capacity per string); it over-stated 38 of 39 bounded types and **under-stated one**. An under-state sizes a stack array that can't hold what the program legitimately sends, and nothing at run time repairs a number already baked into `uint8_t buf[N]`.

The **`legacy` arm is deliberately not flipped** — such a type predates the bound marker and never had a derivation to disagree with, so existing consumers keep compiling.

## Verified on this base

`main` now carries #488's INET6 fix, so the C++ checks actually run rather than skipping:

- `check-cpp` exit 0, including the new `- an unbounded type cannot size a buffer (issue 0964)` step
- `check fast` 223/223
- earlier on the same content: `compile-check-fixtures` 36 rows across 5 builders, **zero** `states no serialized-size bound` errors

## Held by

- `unbounded_buffer_probe.cpp` — expected-failure TU, both directions, must not compile. A `static_assert` can't say "this must not compile".
- Asserted-present first, because a missing file is also a non-zero `c++` and reads as a pass.
- **Mutation-tested**: reverting the arm to the estimate fails `check-cpp` naming exactly that.

The old pin test is updated, not deleted: the `Unbounded` column is gone from `instantiate_recv_paths`, its two positive assertions replaced by pointers to the probe, and `has_derived_size_bound<Unbounded>` stays asserted — that's the *fact*, the poison is the *policy* on it.

## Migration cost, unchanged and real

81 of 120 stock Humble types state no derived bound. Reaching these paths with one needs a bound on the type (`string<=64`, or a `cap` in `nros-codegen.toml` — `heap`/`view` do **not** bound) or the `_sized` form at that site.

Resolves #0964; the issue moves to `archived/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)