### PR TITLE
fix(#1094): the sweeper evicts by content age, and the host target dirs are an area

### DIFF
--- a/docs/issues/archived/1094-sweeper-lru-sorts-by-directory-mtime.md
+++ b/docs/issues/archived/1094-sweeper-lru-sorts-by-directory-mtime.md
@@ -1,0 +1,178 @@
+---
+id: 1094
+title: "`runner-sweep`'s LRU sorts by DIRECTORY mtime, which a cargo target dir
+  never updates — so it proposes deleting the 13 GiB group used yesterday to
+  reclaim 60 MiB"
+status: resolved
+resolved: 2026-09-05
+type: bug
+area: ci, tooling
+related: [0844, 0616]
+---
+
+## Symptom
+
+`./scripts/ci/runner-sweep.sh --check`, 2026-09-05, on this host:
+
+```
+fixtures: 60.1 GiB used / 60.0 GiB budget (high-water 60.1 GiB)
+fixtures: OVER BUDGET by 60 MiB — evicting least-recently-modified entries
+  [would] rm -rf build/cmake-fixtures/l9_register_c    (488 KiB, mtime 2026-08-10)
+  [would] rm -rf build/cmake-fixtures/l9_register_cpp  (488 KiB, mtime 2026-08-10)
+  [would] rm -rf build/cargo-fixtures/linux            (12.8 GiB, mtime 2026-08-15)
+fixtures: 12.8 GiB would be freed
+```
+
+**60 MiB over budget, 12.8 GiB deleted** — a 213× overshoot — and the entry it
+picks is the shared cargo group for the NATIVE platform, which every tier-1 run
+needs and which was written to the previous day.
+
+## Cause: a directory's mtime is not a record of use
+
+`_evict` orders candidates with `stat -c '%Y' "$child"`. A directory's mtime
+changes when an entry is created or removed **in that directory**, and a cargo
+`--target-dir` writes into `<profile>/deps/…` several levels down. So a group
+dir's mtime freezes near creation and stays there while the group is used daily.
+
+Measured across all 20 children of `build/cargo-fixtures`:
+
+| child | dir mtime | newest content | gap |
+| --- | --- | --- | --- |
+| `linux` | 2026-08-15 | 2026-09-04 | **20 days** |
+| `linux-1147932602` | 2026-08-15 | 2026-09-04 | 20 days |
+| `linux-228170020` | 2026-08-15 | 2026-09-04 | 20 days |
+| `linux-3000917972` | 2026-08-15 | 2026-09-04 | 20 days |
+| `linux-3263301353` | 2026-08-15 | 2026-09-04 | 20 days |
+| `linux-553222167` | 2026-08-15 | 2026-09-04 | 20 days |
+| `linux-865285299` | 2026-08-15 | 2026-09-04 | 20 days |
+| `threadx-riscv64` | 2026-08-18 | 2026-08-21 | 3 days |
+| `qemu-arm-baremetal` | 2026-08-15 | 2026-08-15 | 0 — genuinely cold |
+
+**Eleven of twenty are wrong by ~20 days, and the error is not random**: it is
+biased toward the LARGEST and most-used groups, because a group that has existed
+longest has both the oldest creation date and the most accumulated bytes. The
+two entries that are genuinely cold (`qemu-arm-baremetal`,
+`qemu-esp32-baremetal`) carry the same 08-15 stamp as the busiest one, so they
+sort as ties and the tie is broken by listing order.
+
+The comment above `_evict` states the intent this defeats:
+
+> Never the dir itself: deleting `build/cargo-fixtures` wholesale turns a budget
+> overrun into a full rebuild of everything, when dropping the three coldest
+> coordinates would have done.
+
+The reasoning is right; `linux` is simply not one of the coldest, and the
+timestamp it is ranked by cannot say so.
+
+## Fix
+
+Rank by the newest mtime found INSIDE each candidate, not by the candidate's own
+mtime. That is a real walk and this is already a between-jobs operation whose
+header prices `du` at "seconds to a minute or two" — the walk can share it.
+
+Cheaper alternative if the walk is unwelcome: rank a cargo-shaped child by the
+mtime of its `<profile>/` subdirectory, which does move, rather than by the group
+root.
+
+## Should `cargo-sweep` replace this? No — it cannot reach the area
+
+Asked, and answered by measurement rather than preference.
+
+**Where cargo-sweep works, it works well.** On the two manifest-rooted target
+dirs it reclaimed **41.3 GiB** here (31.53 from `target/`, 9.80 from
+`packages/cli/target`) with no whole-group deletion — it prunes stale UNITS and
+leaves current ones, which is exactly the granularity `_evict` lacks.
+
+**But it requires a manifest.** Every mode routes through `cargo metadata` on the
+path it is given:
+
+```
+$ cargo-sweep sweep --dry-run --maxsize 5GB build/cargo-fixtures/linux
+Error during execution of `cargo metadata`:
+  manifest path `build/cargo-fixtures/linux/Cargo.toml` does not exist
+```
+
+The phase-340 shared groups are DETACHED `--target-dir`s with no project of
+their own, so cargo-sweep cannot address `build/cargo-fixtures` at all — 39 GiB,
+and the reason the fixtures budget exists. `--file`, `--maxsize` and `--time`
+all fail the same way.
+
+So the two tools are complementary and the split is not a matter of taste:
+
+| | `runner-sweep` | `cargo-sweep` |
+| --- | --- | --- |
+| operates on | any directory tree | a cargo PROJECT (needs `Cargo.toml`) |
+| granularity | whole child directory | individual build artifacts |
+| has a budget, pinning, high-water | yes | no |
+| reaches `build/cargo-fixtures/*` | yes | **no** |
+| reaches `target/`, `packages/cli/target` | **no** | yes |
+
+## FIXED 2026-09-05 — (1) and (2) landed, (3) is refuted
+
+**(1) The mtime proxy.** `_newest_mtime` walks each candidate and ranks by the
+newest file inside it, falling back to the directory's own mtime when the walk
+yields nothing — ordering by a stale timestamp is bad, and ordering by `0`,
+which sorts FIRST and evicts hardest, is worse. `find` is correct here for the
+reason `_evict`'s own comment already gives: issue 0844's rule is about TRACKED
+files, and nothing under these roots has been in the index.
+
+The same dry run, before and after, on the same tree:
+
+```
+before:  [would] rm -rf build/cargo-fixtures/linux                 (12.8 GiB)
+after:   [would] rm -rf build/cargo-fixtures/qemu-esp32-baremetal   (2.2 GiB)
+```
+
+`qemu-esp32-baremetal` is one of the two entries whose directory mtime and
+content mtime AGREE — genuinely cold. The busiest group is no longer a
+candidate.
+
+Gated by `check-runner-sweep-eviction-order` (fast line, ~1 s, tmpdir): two
+5 MiB entries with IDENTICAL directory mtimes, one written today and one 40 days
+ago, asserting the cold one is proposed first. It asserts its own premise too —
+if the fixture's directory mtimes ever stop matching it no longer models the
+hazard, and a pass would mean nothing. Mutation-verified: restoring
+`stat -c '%Y' "$child"` fails it.
+
+**(2) The host target dirs are an area now.** `cargo-targets` reports their size,
+records a high-water mark, and prunes with `cargo-sweep --time ${NROS_SWEEP_CARGO_DAYS:-21}`.
+
+They are pruned, never LRU-evicted, for the reason `_evict` already gives for
+never deleting a candidate ROOT: a cargo target dir is one cache with internal
+structure, so dropping it is a full rebuild when pruning the stale units would
+have done. Measured on this host: **31.53 GiB** from `target/` and **9.80 GiB**
+from `packages/cli/target/`, with current artifacts and the in-tree `nros`
+binary left in place.
+
+A runner without `cargo-sweep` reports the size and says what it could not do,
+rather than failing a machine that is otherwise fine. `NROS_CARGO_FLAGS` is
+cleared around the call: `scripts/bin/cargo` injects `--locked` project-wide
+(0359/0378) and `cargo-sweep` shells out to `cargo metadata`, which then sees a
+flag meant for a build — the same collision that breaks `cargo binstall`.
+
+Also fixed while wiring it: `Would clean: nothing from "…"` is cargo-sweep's
+NO-OP answer, and matching on `Would clean` alone marked the sweep dirty on a
+clean tree — which under `--check` is an exit 1, a between-jobs hook failing a
+healthy machine.
+
+**(3) REFUTED, by measurement.** The proposal was to point `cargo-sweep` at a
+detached group through a throwaway manifest. The manifest does let it resolve
+the directory — but it then cleans **nothing**, at any age:
+
+```
+$ CARGO_TARGET_DIR=build/cargo-fixtures/linux cargo-sweep sweep --dry-run --time 3 .
+[INFO] Would clean: nothing from ".../build/cargo-fixtures/linux"
+```
+
+against a group that really holds 7.18 GiB in the 7–21 day band and 1.24 GiB
+over 21 days.
+
+The reason is sharper than "it needs a manifest": **it needs the RIGHT manifest.**
+`cargo-sweep` enumerates the packages the project's `cargo metadata` declares and
+keeps artifacts belonging to them; a throwaway project declares one package, so
+nothing in the group is explained and nothing is swept. A phase-340 shared group
+serves many leaf workspaces at once, so no single manifest can explain it, and
+there is no combination of flags that changes that.
+
+So the fixtures area keeps whole-entry eviction, and (1) is what makes that
+tolerable — it now drops the coldest coordinate rather than the largest one.

--- a/just/check.just
+++ b/just/check.just
@@ -294,6 +294,7 @@ fast-serial: \
     roadmap-status \
     ros-env-spelling \
     runner-doctor-sdk-resolution \
+    runner-sweep-eviction-order \
     rust-stdio-on-zephyr \
     rust-targets-covered \
     scope-namespace \
@@ -2298,6 +2299,17 @@ fixtures-manifest:
     # briefly two spellings of one thing. This makes them unable to drift until
     # the emitter reads the rows. Read-only: the emitter runs no build tool.
     @python3 scripts/check-zephyr-fixture-rows.py
+
+# issue 1094 — `runner-sweep` must evict the least recently WRITTEN entry, not
+# the one with the oldest directory inode. A cargo `--target-dir` writes several
+# levels down, so a shared fixture group's dir mtime freezes near creation while
+# the group is used daily: eleven of twenty `cargo-fixtures` children were wrong
+# by ~20 days, and the sweep proposed deleting the 12.8 GiB NATIVE group — used
+# the previous day — to reclaim a 60 MiB overrun. Silent either way; the cost
+# shows up as the next job rebuilding a fixture nobody touched. ~1 s, tmpdir.
+[private]
+runner-sweep-eviction-order:
+    @bash tests/runner-sweep-eviction-order-tests.sh
 
 # Every `docs/{design,issues}/NNNN-*.md` path written anywhere — prose, issue
 # frontmatter, or a cmake error message — must resolve. Renumbering on an id

--- a/scripts/ci/runner-sweep.sh
+++ b/scripts/ci/runner-sweep.sh
@@ -459,7 +459,49 @@ _hwm_put() {
     return 0
 }
 
-# Evict entries from an area, oldest mtime first, until it fits its budget.
+# Newest mtime found ANYWHERE inside a candidate, as a unix timestamp.
+#
+# issue 1094 — the eviction order used `stat -c '%Y' "$child"`, and a DIRECTORY's
+# mtime moves only when an entry is created or removed IN THAT DIRECTORY. A cargo
+# `--target-dir` writes into `<profile>/deps/…` several levels down, so a group
+# dir's mtime freezes near creation and stays there while the group is used every
+# day.
+#
+# Measured across the 20 children of `build/cargo-fixtures` on 2026-09-05:
+# ELEVEN were wrong by ~20 days (dir 2026-08-15, newest content 2026-09-04), and
+# the error is not random — it is biased toward the LARGEST and most-used groups,
+# because the group that has existed longest has both the oldest creation date
+# and the most accumulated bytes. The two genuinely cold entries carried the SAME
+# 08-15 stamp as the busiest one, so they sorted as ties.
+#
+# What that produced: 60 MiB over budget, and the sweep proposed deleting
+# `cargo-fixtures/linux` — 12.8 GiB, the shared group for the NATIVE platform
+# that every tier-1 run needs, written to the previous day. A 213x overshoot on
+# the wrong entry.
+#
+# `find` is correct here and the file's own `_evict` comment says why: issue
+# 0844's rule is about TRACKED files, and nothing under these roots has ever been
+# in the index. The walk costs what `_du_bytes` already costs on the same tree,
+# and this is a between-jobs operation the header prices at "seconds to a minute
+# or two".
+#
+# Falls back to the directory's own mtime when the walk yields nothing (an empty
+# candidate, or an unreadable one): ordering by a stale timestamp is bad, and
+# ordering by 0 — which sorts FIRST and evicts hardest — is worse.
+_newest_mtime() {
+    local newest=""
+    newest="$(find "$1" -type f -printf '%T@\n' 2>/dev/null | sort -rn | head -1 || true)"
+    newest="${newest%%.*}"
+    case "${newest:-}" in
+        ''|*[!0-9]*) stat -c '%Y' "$1" 2>/dev/null || printf '0' ;;
+        *)           printf '%s' "$newest" ;;
+    esac
+    return 0
+}
+
+# Evict entries from an area, least-recently-WRITTEN first, until it fits its
+# budget. "Recently written" means the newest file anywhere inside the entry —
+# see `_newest_mtime` above for why the entry's own mtime cannot answer.
 #
 #   _evict <area> <budget-bytes> <pinned-glob-or-empty> <candidate-dir>...
 #
@@ -512,7 +554,7 @@ _evict() {
                     $pinned) _say "      pinned, never evicted: $child"; continue ;;
                 esac
             fi
-            listing="${listing}$(stat -c '%Y' "$child" 2>/dev/null || echo 0)"$'\t'"$child"$'\n'
+            listing="${listing}$(_newest_mtime "$child")"$'\t'"$child"$'\n'
         done
     done
 
@@ -619,6 +661,82 @@ _sweep_disk() {
             "${work_dirs[@]}"
     else
         _say "  runner-work: no _actions/_temp under $work_dir"
+    fi
+
+    # --- the HOST cargo target dirs ------------------------------------------
+    #
+    # issue 1094 — these were outside every budget, and on the box this was
+    # written for they were the two LARGEST consumers on the disk: 156 GiB in
+    # `target/` and 30 GiB in `packages/cli/target/`, against a 60 GiB budget
+    # for all the fixture trees put together.
+    #
+    # They are not evicted the way an area of fixture coordinates is, and the
+    # reason is the same one `_evict`'s own comment gives for never deleting a
+    # candidate root: a cargo target dir is ONE cache with internal structure,
+    # so dropping it is a full rebuild when pruning the stale units would have
+    # done. `cargo-sweep` prunes at that granularity; nothing here does.
+    #
+    # Measured on 2026-09-05 with `--time 21`: 31.53 GiB from `target/` and
+    # 9.80 GiB from `packages/cli/target/`, with the current artifacts and the
+    # in-tree `nros` binary left in place.
+    #
+    # ABSENT TOOL IS NOT A FAILURE. A runner without `cargo-sweep` still sweeps
+    # everything else and says what it could not do — the alternative is a
+    # between-jobs hook that exits non-zero on a machine that is otherwise fine.
+    local -a cargo_roots=()
+    [ -f "$repo_root/Cargo.toml" ] && cargo_roots+=("$repo_root")
+    [ -f "$repo_root/packages/cli/Cargo.toml" ] && cargo_roots+=("$repo_root/packages/cli")
+    local sweep_days="${NROS_SWEEP_CARGO_DAYS:-21}"
+    if [ "${#cargo_roots[@]}" -eq 0 ]; then
+        _say "  cargo-targets: no cargo manifest at the checkout root"
+    elif ! command -v cargo-sweep >/dev/null 2>&1; then
+        local total=0 root sz
+        for root in "${cargo_roots[@]}"; do
+            [ -d "$root/target" ] || continue
+            sz="$(_du_bytes "$root/target")"
+            total=$((total + sz))
+        done
+        _hwm_put cargo-targets "$total"
+        _say "  cargo-targets: $(_human "$total") in host target dir(s), NOT pruned —"
+        _say "      \`cargo-sweep\` is not installed. \`cargo binstall cargo-sweep\`, then"
+        _say "      this area prunes artifacts older than ${sweep_days}d instead of reporting them."
+    else
+        local total=0 root sz
+        for root in "${cargo_roots[@]}"; do
+            [ -d "$root/target" ] || continue
+            sz="$(_du_bytes "$root/target")"
+            total=$((total + sz))
+        done
+        _hwm_put cargo-targets "$total"
+        _say "  cargo-targets: $(_human "$total") in host target dir(s), pruning artifacts older than ${sweep_days}d"
+        for root in "${cargo_roots[@]}"; do
+            [ -d "$root/target" ] || continue
+            local out=""
+            # NROS_CARGO_FLAGS is cleared for the same reason `cargo binstall`
+            # needs it cleared: `scripts/bin/cargo` injects `--locked`
+            # project-wide (issues 0359/0378), and `cargo-sweep` shells out to
+            # `cargo metadata`, which then sees a flag meant for a build.
+            if [ "$CHECK" -eq 1 ]; then
+                out="$(NROS_CARGO_FLAGS= cargo-sweep sweep --dry-run --time "$sweep_days" "$root" 2>&1 || true)"
+                # `Would clean: nothing from "…"` is cargo-sweep's NO-OP
+                # answer, not a finding. Matching on "Would clean" alone marks
+                # the sweep dirty on a tree with nothing to do, which under
+                # `--check` is an exit 1 — a between-jobs hook failing a healthy
+                # machine.
+                case "$out" in
+                    *"Would clean: nothing"*) _say "      $root: nothing older than ${sweep_days}d" ;;
+                    *"Would clean"*) dirty=1; _would "cargo-sweep --time $sweep_days $root: ${out##*Would clean: }" ;;
+                    *) _say "      $root: nothing older than ${sweep_days}d" ;;
+                esac
+            else
+                out="$(NROS_CARGO_FLAGS= cargo-sweep sweep --time "$sweep_days" "$root" 2>&1 || true)"
+                case "$out" in
+                    *"Cleaned nothing"*) _say "      $root: nothing older than ${sweep_days}d" ;;
+                    *"Cleaned"*) dirty=1; _did "cargo-sweep --time $sweep_days $root: ${out##*Cleaned }" ;;
+                    *) _say "      $root: nothing older than ${sweep_days}d" ;;
+                esac
+            fi
+        done
     fi
 
     # --- sccache: reported, never evicted ------------------------------------

--- a/tests/runner-sweep-eviction-order-tests.sh
+++ b/tests/runner-sweep-eviction-order-tests.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# issue 1094 — `runner-sweep` must evict the entry that was least recently
+# WRITTEN, not the one whose directory inode is oldest.
+#
+# The two are different for exactly the entries that hold the most bytes. A
+# directory's mtime moves only when an entry is created or removed IN THAT
+# DIRECTORY, and a cargo `--target-dir` writes into `<profile>/deps/…` several
+# levels down — so a shared fixture group's dir mtime freezes near creation and
+# stays there while the group is used every day.
+#
+# Measured on 2026-09-05 before the fix: eleven of the twenty children of
+# `build/cargo-fixtures` were wrong by ~20 days, and the sweep proposed deleting
+# `cargo-fixtures/linux` (12.8 GiB, the NATIVE platform group every tier-1 run
+# needs, written to the previous day) to reclaim a 60 MiB overrun.
+#
+# This builds that exact shape and asserts the order, because the failure is
+# silent: the sweep reports a successful eviction either way, and what it cost
+# only shows up as the next job rebuilding a fixture nobody touched.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+sweep="$repo_root/scripts/ci/runner-sweep.sh"
+failures=0
+checks=0
+
+ok()   { echo "  [ok]   $1"; checks=$((checks + 1)); }
+fail() { echo "  [FAIL] $1" >&2; failures=$((failures + 1)); checks=$((checks + 1)); }
+
+[ -x "$sweep" ] || { echo "FATAL: $sweep missing or not executable" >&2; exit 2; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Two eviction units, both with an OLD directory mtime, differing only in when
+# their contents were last written. `cargo-fixtures` is one of the kinds the
+# fixtures area collects, so this exercises the real code path.
+fx="$work/build/cargo-fixtures"
+mkdir -p "$fx/busy/nros-relwithdebinfo/deps" "$fx/cold/nros-relwithdebinfo/deps"
+
+# ~5 MiB each, so both are worth evicting and the choice is about age alone.
+dd if=/dev/zero of="$fx/busy/nros-relwithdebinfo/deps/libbusy.rlib" bs=1M count=5 status=none
+dd if=/dev/zero of="$fx/cold/nros-relwithdebinfo/deps/libcold.rlib" bs=1M count=5 status=none
+
+# `busy` was WRITTEN today; `cold` was written 40 days ago. Both directory
+# inodes are stamped 40 days old — which is the whole point: before the fix the
+# two were indistinguishable, and `busy` sorted first often enough to be deleted.
+old="$(date -d '40 days ago' +%Y%m%d%H%M)"
+touch -t "$old" "$fx/cold/nros-relwithdebinfo/deps/libcold.rlib"
+touch -t "$old" "$fx/busy" "$fx/cold" \
+      "$fx/busy/nros-relwithdebinfo" "$fx/cold/nros-relwithdebinfo" \
+      "$fx/busy/nros-relwithdebinfo/deps" "$fx/cold/nros-relwithdebinfo/deps"
+
+# The premise, asserted rather than assumed: if the directory mtimes ever stop
+# being equal, this fixture no longer models the hazard and a pass means nothing.
+if [ "$(stat -c '%Y' "$fx/busy")" = "$(stat -c '%Y' "$fx/cold")" ]; then
+    ok "premise: both entries carry the same directory mtime"
+else
+    fail "premise: the directory mtimes differ, so this no longer models issue 1094"
+fi
+
+# A 1 MiB budget against ~10 MiB used: over budget, and one eviction is not
+# enough, so the ORDER is what the assertions below read.
+out="$(NROS_RUNNER_REPO_ROOT="$work" \
+       NROS_SWEEP_BUDGET_FIXTURES_GIB=0 \
+       NROS_SWEEP_STATE_DIR="$work/state" \
+       "$sweep" --check --disk 2>&1)" || true
+
+busy_line="$(printf '%s\n' "$out" | grep -n 'rm -rf .*/busy' | head -1 | cut -d: -f1)"
+cold_line="$(printf '%s\n' "$out" | grep -n 'rm -rf .*/cold' | head -1 | cut -d: -f1)"
+
+if [ -n "$cold_line" ]; then
+    ok "the entry whose CONTENT is old is proposed for eviction"
+else
+    fail "the cold entry was never proposed — the fixtures area did not run:
+$out"
+fi
+
+if [ -n "$cold_line" ] && [ -n "$busy_line" ]; then
+    if [ "$cold_line" -lt "$busy_line" ]; then
+        ok "cold is evicted BEFORE busy — ordering follows content, not the inode"
+    else
+        fail "busy (written today) is evicted before cold (written 40d ago):
+$out"
+    fi
+elif [ -n "$cold_line" ] && [ -z "$busy_line" ]; then
+    ok "only the cold entry is proposed; the busy one is left alone"
+fi
+
+# And the negative control: with the old rule the two are indistinguishable, so
+# assert the helper itself separates them. This is what actually regressed.
+newest_busy="$(bash -c 'source "$0"; _newest_mtime "$1"' "$sweep" "$fx/busy" 2>/dev/null | tail -1 || true)"
+if [ -z "${newest_busy//[0-9]/}" ] && [ -n "$newest_busy" ]; then
+    if [ "$newest_busy" -gt "$(stat -c '%Y' "$fx/busy")" ]; then
+        ok "_newest_mtime reports content time, which is newer than the inode"
+    else
+        fail "_newest_mtime returned the directory's own mtime ($newest_busy)"
+    fi
+else
+    echo "  [skip] _newest_mtime not separately callable (sourcing runs the sweep)"
+fi
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+    echo "runner-sweep-eviction-order: $checks check(s) passed"
+    exit 0
+fi
+echo "runner-sweep-eviction-order: $failures of $checks check(s) FAILED" >&2
+echo "" >&2
+echo "  Evicting by directory mtime deletes the BUSIEST fixture group, because" >&2
+echo "  the group that has existed longest has both the oldest inode and the" >&2
+echo "  most accumulated bytes (issue 1094)." >&2
+exit 1


### PR DESCRIPTION
Implements the two steps from #504, and **refutes the third by measurement**.

## (1) The mtime proxy — the defect

`_evict` ordered candidates by `stat -c '%Y' "$child"`. A directory's mtime moves only when an entry is created or removed *in that directory*, and a cargo `--target-dir` writes into `<profile>/deps/…` several levels down — so a shared fixture group's dir mtime freezes near creation while the group is used daily.

The same dry run, before and after, on the same tree:

```
before:  [would] rm -rf build/cargo-fixtures/linux                (12.8 GiB)
after:   [would] rm -rf build/cargo-fixtures/qemu-esp32-baremetal  (2.2 GiB)
```

`linux` is the shared group for the **native** platform every tier-1 run needs, written to the previous day, and it was going to be deleted to reclaim a **60 MiB** overrun. `qemu-esp32-baremetal` is one of the two entries whose directory and content mtimes agree — genuinely cold.

`_newest_mtime` falls back to the directory's own mtime when the walk finds nothing: ordering by a stale timestamp is bad, and ordering by `0` — which sorts **first** and evicts hardest — is worse.

**Gated** by `check-runner-sweep-eviction-order` (fast line, ~1 s, tmpdir): two 5 MiB entries with *identical* directory mtimes, one written today and one 40 days ago, asserting the cold one goes first. It asserts its own **premise** too — if the fixture's directory mtimes ever stop matching, it no longer models the hazard and a pass would mean nothing. Mutation-verified: restoring `stat -c '%Y'` fails it.

## (2) The host target dirs are an area

`target/` and `packages/cli/target/` were outside every budget, and on this box they were the two **largest** consumers: 156 GiB and 30 GiB, against 60 GiB for all the fixture trees together.

They are **pruned, never LRU-evicted** — the reason `_evict` already gives for never deleting a candidate root: a cargo target dir is one cache with internal structure, so dropping it is a full rebuild when pruning the stale units would have done. Measured: **31.53 GiB** and **9.80 GiB**, with current artifacts and the in-tree `nros` binary left in place.

A runner *without* `cargo-sweep` reports the size and says what it could not do, rather than failing a machine that is otherwise fine. `NROS_CARGO_FLAGS` is cleared around the call — `scripts/bin/cargo` injects `--locked` project-wide (0359/0378) and `cargo-sweep` shells out to `cargo metadata`, the same collision that breaks `cargo binstall`.

Fixed while wiring it: `Would clean: nothing from "…"` is cargo-sweep's **no-op** answer, and matching on `Would clean` alone marked the sweep dirty on a clean tree — under `--check` that's an exit 1, a between-jobs hook failing a healthy machine.

## (3) My own proposal, refuted

I suggested reaching a detached group via a throwaway manifest. It resolves the directory and then cleans **nothing**, at any age:

```
$ CARGO_TARGET_DIR=build/cargo-fixtures/linux cargo-sweep sweep --dry-run --time 3 .
[INFO] Would clean: nothing from ".../build/cargo-fixtures/linux"
```

— against a group that really holds 7.18 GiB in the 7–21 day band and 1.24 GiB over 21 days.

The reason is sharper than *"it needs a manifest"*: **it needs the right one.** `cargo-sweep` keeps artifacts belonging to the packages the project's `cargo metadata` declares, so a throwaway project explains nothing in the group. A phase-340 shared group serves many leaf workspaces at once, so no single manifest can explain it.

So the fixtures area keeps whole-entry eviction, and (1) is what makes that tolerable.

## Verified

`just check fast`: **218 gates ran, 0 failed.**

One thing the tree caught on the way: `check-submodule-pins` went red because this branch was 30 commits behind and would have proposed rewinding zenoh-pico past the `INET6_ADDRSTRLEN` fix (#488). Rebased; `submodule-pins: OK (0 pin(s) moved, all fast-forward)`. The gate did exactly what it exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj