### PR TITLE
fix(#1075): the Zephyr stack probe calls a syscall Kconfig can compile OUT

### DIFF
--- a/docs/issues/archived/1075-zephyr-stack-headroom-probe-breaks-native-sim-link.md
+++ b/docs/issues/archived/1075-zephyr-stack-headroom-probe-breaks-native-sim-link.md
@@ -1,7 +1,7 @@
 ---
 id: 1075
 title: "The Zephyr stack-headroom probe calls a syscall that is not COMPILED unless two Kconfigs are set, so every native_sim image fails to link"
-status: open
+status: resolved
 type: bug
 area: platform, build
 severity: high
@@ -106,3 +106,47 @@ safety argument the probe was written for actually needs a non-zero answer.
   compiled-out-under-Kconfig property.
 * The tier-1 lanes stayed green throughout, so nothing in the compile tiers
   would have caught this — only a Zephyr fixture build does.
+
+## Resolution (2026-09-05) — option A
+
+Guarded on BOTH Kconfigs, returning the ABI's documented `0` otherwise.
+
+This also restores consistency the commit had broken rather than inventing a
+policy: of the five ports `411addfd2` touched, three already gate
+(`INCLUDE_uxTaskGetStackHighWaterMark` on FreeRTOS, `TX_ENABLE_STACK_CHECKING`
+on ThreadX, POSIX returns 0 outright). Zephyr was the one left ungated, and it
+is the only one of the five whose probe is a SYSCALL — the only kind that can
+vanish from the link rather than answer an error.
+
+### The two "not covered" items, answered
+
+* **FreeRTOS has the same shape and already handles it.** Verified in the
+  commit's own diff: `#if (INCLUDE_uxTaskGetStackHighWaterMark == 1)` with a `0`
+  fallback. The guess in this issue ("probably links unconditionally") was
+  right about the mechanism and unnecessary about the risk.
+* **No other symbol from `411addfd2` has the property.** The commit adds exactly
+  one function per port and nothing else executable; the rest is the header, the
+  Rust binding and the cffi mirror.
+
+Left for whoever wants the number, and it is not free: on this tree the probe
+now returns `0` on Zephyr, so `stack-headroom-runtime` is INERT there. That is
+honest — `0` is the ABI's "not instrumented" and matches POSIX — but it means
+the safety argument the probe was written for is not yet supported on Zephyr.
+Option B (turning both Kconfigs on) buys a real answer at the cost of stack
+painting at boot and per-thread bytes, and it is a decision about the shipped
+image.
+
+### What this fix was NOT verified against
+
+No Zephyr SDK is provisioned on the host that made it, so the link was not
+reproduced or re-run here. The Kconfig names come from the issue's own reading
+of `zephyr/kernel/thread.c:806`, and `git grep` confirms neither is set anywhere
+in this repo, so every image in this tree takes the `#else`. A Zephyr fixture
+build is the acceptance, and it has not run.
+
+### And the reason it reached main
+
+The compile tiers stayed green throughout — nothing below a Zephyr fixture build
+can see a Zephyr link failure. That is the same gap issue 1029 records for the
+Zephyr dual-line nightly being skipped on every scheduled run, and it is not
+closed by this fix.

--- a/packages/platform/nros-platform-zephyr/src/platform.c
+++ b/packages/platform/nros-platform-zephyr/src/platform.c
@@ -1219,13 +1219,40 @@ _Noreturn void nros_platform_panic(const char *msg, size_t len) {
 }
 
 /* Headroom for the calling thread. `k_thread_stack_space_get` answers in
- * unused BYTES, which is the ABI's unit, so no conversion. Needs
- * CONFIG_INIT_STACKS to have painted the stack; without it the kernel has no
- * watermark to read and returns an error, which becomes the documented 0. */
+ * unused BYTES, which is the ABI's unit, so no conversion.
+ *
+ * GATED, and on BOTH Kconfigs (issue 1075). The original comment here said the
+ * kernel "returns an error, which becomes the documented 0" without
+ * CONFIG_INIT_STACKS, and that was wrong twice over:
+ *
+ *   1. it named only CONFIG_INIT_STACKS. `zephyr/kernel/thread.c` encloses
+ *      `z_impl_k_thread_stack_space_get` in
+ *      `#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)`,
+ *      so a build with only the first still has no implementation;
+ *   2. it reasoned about RUN time for a failure that happens at LINK time.
+ *      Without both symbols the function is not compiled at all, so there is
+ *      nothing to return an error — the reference is undefined and every
+ *      native_sim image failed to link. Neither Kconfig is set anywhere in
+ *      this repo.
+ *
+ * The other four ports already do this: freertos gates on
+ * INCLUDE_uxTaskGetStackHighWaterMark, threadx on TX_ENABLE_STACK_CHECKING,
+ * posix returns 0 outright. Zephyr was the one that needed it most — a syscall
+ * is the only one of the four that can vanish from the link — and the one that
+ * did not have it.
+ *
+ * `0` is the ABI's "not instrumented", which is exactly what a build without
+ * the watermark is. Turning the Kconfigs ON is a separate decision about the
+ * shipped image (stack painting costs boot time and per-thread bytes), not
+ * about this bug. */
 size_t nros_platform_task_stack_unused_bytes(void) {
+#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
     size_t unused = 0;
     if (k_thread_stack_space_get(k_current_get(), &unused) != 0) {
         return 0;
     }
     return unused;
+#else
+    return 0;
+#endif
 }


### PR DESCRIPTION
Closes #1075. **Every Zephyr `native_sim` image currently fails at the final link on main.**

```
undefined reference to `z_impl_k_thread_stack_space_get'
```

## The reasoning error

`411addfd2` added `nros_platform_task_stack_unused_bytes` ungated on Zephyr, with a comment about **run time** — *"the kernel has no watermark to read and returns an error, which becomes the documented 0"*. The failure is at **link time**. `zephyr/kernel/thread.c:806` encloses the implementation in `#if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)`, so without both symbols there is no function to return anything.

The comment was wrong twice: it named only `CONFIG_INIT_STACKS`, and it assumed the function exists. `git grep` finds neither Kconfig set anywhere in this repo.

## The fix, and why it is a restoration rather than a policy

Guarded on both, returning the ABI's `0` — "not instrumented", which is exactly what a build without the watermark is.

Of the five ports that commit touched, **three already gate**:

| port | gate |
| --- | --- |
| FreeRTOS | `INCLUDE_uxTaskGetStackHighWaterMark` |
| ThreadX | `TX_ENABLE_STACK_CHECKING` |
| POSIX | returns 0 outright |
| ESP-IDF | documented as always available in IDF |
| **Zephyr** | **none — and the only one whose probe is a syscall** |

A syscall is the only one of the five that can vanish from the link rather than answer an error, so the port that most needed the guard was the one without it.

**Class swept**, as the issue asked: the commit adds exactly one function per port and nothing else executable, so no other symbol has this property. The FreeRTOS guess (*"probably links unconditionally"*) was right about the mechanism and unnecessary about the risk.

## What this is not

On this tree the probe now returns `0` on Zephyr, so `stack-headroom-runtime` is **inert** there. That is honest — `0` is the ABI's "not instrumented", matching POSIX — but the safety argument the probe was written for is not yet supported on Zephyr. Turning both Kconfigs on buys a real answer at the cost of stack painting at boot and per-thread bytes; that is a decision about the shipped image, recorded in the archived issue rather than taken here.

## Not verified by a Zephyr link

No Zephyr SDK is provisioned on the host that made this, so the failure was not reproduced and the fix was not re-run against it. The Kconfig names come from the issue's reading of the Zephyr source, and `git grep` confirms every image in this tree takes the `#else`. **A Zephyr fixture build is the acceptance, and it has not run** — worth a reviewer's eye before this is trusted to have fixed the lane rather than merely to compile.

The reason it reached main at all: nothing below a Zephyr fixture build can see a Zephyr link failure, which is the gap #1029 records for the dual-line nightly being skipped on every scheduled run. Not closed by this.

`just check fast` 225/225 · `just check c` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP