### PR TITLE
fix(#1029, second pass): the first fix did not work, and the reason is unreadable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -541,9 +541,57 @@ jobs:
           echo "All tier-2 nightly lane modules have a home (platform matrix result: $PLATFORM_RESULT)."
 
   # ===== Zephyr dual-line (cron 0 5) ====================================
+
+  # Issue 1029, second pass. The first fix computed `run_zephyr` once and the
+  # lane STILL skipped on both scheduled runs after it landed (2026-09-04T05:11
+  # and 2026-09-05T05:10, both on the fixed workflow — checked by `head_sha`),
+  # while the 2026-09-04T19:39 workflow_dispatch on the SAME version ran all
+  # three jobs.
+  #
+  # So one of the two gate clauses is not the string it is supposed to be on a
+  # schedule event, and BOTH are `true` by reading:
+  #
+  #   * `run_zephyr` is `true` in every branch of its `case` except a literal
+  #     `0 7 ` cron — including the fail-open default;
+  #   * `zephyr` is the literal `"true"` whenever the event is not
+  #     `pull_request`, and `pull_request` is NOT A TRIGGER of this workflow.
+  #
+  # Which of them is empty is not READABLE. `gh api .../jobs/<id>/logs` returns
+  # zero bytes for this workflow's `changes` job, and a step summary is not
+  # exposed by the API at all — the two places the first fix put the value.
+  #
+  # This job puts it somewhere that survives: an ARTIFACT. It runs on every
+  # event, including the ones where the lane is correctly skipped, so the next
+  # scheduled run answers the question whatever it does.
+  zephyr-gate-report:
+    needs: changes
+    if: ${{ always() }}
+    name: zephyr gate inputs (issue 1029)
+    runs-on: ubuntu-latest
+    steps:
+      - name: record the gate inputs
+        run: |
+          set -euo pipefail
+          # Quoted deliberately: an EMPTY output and the string "true" are the
+          # two candidates, and unquoted they look the same in a log.
+          {
+            echo "event_name='${{ github.event_name }}'"
+            echo "event_schedule='${{ github.event.schedule }}'"
+            echo "changes_result='${{ needs.changes.result }}'"
+            echo "outputs_zephyr='${{ needs.changes.outputs.zephyr }}'"
+            echo "outputs_run_zephyr='${{ needs.changes.outputs.run_zephyr }}'"
+            echo "outputs_platforms='${{ needs.changes.outputs.platforms }}'"
+            echo "gate_would_pass='${{ needs.changes.outputs.run_zephyr == 'true' }}'"
+          } | tee zephyr-gate-inputs.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zephyr-gate-inputs
+          path: zephyr-gate-inputs.txt
+          retention-days: 14
+
   zephyr-example-matrix:
     needs: changes
-    if: ${{ needs.changes.outputs.zephyr == 'true' && needs.changes.outputs.run_zephyr == 'true' }}
+    if: ${{ needs.changes.outputs.run_zephyr == 'true' }}
     name: zephyr ${{ matrix.line }} / ${{ matrix.example }}
     runs-on: ubuntu-latest
     concurrency:
@@ -662,7 +710,7 @@ jobs:
 
   zephyr-dual-line-summary:
     needs: changes
-    if: ${{ needs.changes.outputs.zephyr == 'true' && needs.changes.outputs.run_zephyr == 'true' }}
+    if: ${{ needs.changes.outputs.run_zephyr == 'true' }}
     name: zephyr ci-both (3.7 + 4.4)
     env:
       # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to
@@ -736,7 +784,7 @@ jobs:
 
   zephyr-copy-out:
     needs: changes
-    if: ${{ needs.changes.outputs.zephyr == 'true' && needs.changes.outputs.run_zephyr == 'true' }}
+    if: ${{ needs.changes.outputs.run_zephyr == 'true' }}
     name: zephyr copy-out check (4.4)
     env:
       # The 4.4 line needs a Python >=3.12 venv, which nano-ros refuses to

--- a/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
+++ b/docs/issues/1029-zephyr-nightly-never-produces-a-verdict.md
@@ -141,3 +141,60 @@ gate nobody can debug, which is how this went unnoticed for eight runs.
 * Whether the two crons fire at all. Every run above exists, so they fire; what
   is unmeasured is whether any 05:00 run has EVER produced a zephyr verdict
   since phase-253 merged the workflows.
+
+## SECOND PASS 2026-09-05 — the first fix did not work, measured
+
+Two scheduled runs have fired since `2794adf0b` landed (2026-09-04T02:36 UTC),
+and both still skipped all three zephyr jobs:
+
+    2026-09-05T05:10   skipped,skipped,skipped   run 33946510222
+    2026-09-04T05:11   skipped,skipped,skipped   run 33839588525
+
+Both ran the FIXED workflow — verified by resolving each run's `head_sha` and
+grepping that commit's `nightly.yml`, not by assuming. And a
+`workflow_dispatch` on the same version (2026-09-04T19:39, run 33912319861) ran
+all three: `zephyr copy-out check` success, `zephyr ci-both` success, the
+example matrix expanded and reported per-cell results.
+
+So the outputs propagate on dispatch and the gate closes on schedule, and BOTH
+of its clauses are `true` by reading:
+
+* `run_zephyr` is `true` in every branch of its `case` except a literal `0 7 `
+  cron — including the fail-open default the first fix added;
+* `zephyr` is the literal `"true"` whenever the event is not `pull_request`,
+  and **`pull_request` is not a trigger of this workflow at all** (`on:` is
+  `workflow_dispatch` + two `schedule` crons).
+
+### What could not be read, and it is the same wall as last time
+
+Which of the two strings is actually empty is not observable:
+
+* `gh api .../actions/jobs/<id>/logs` returns **zero bytes** for this
+  workflow's `changes` job;
+* the step summary the first fix added is not exposed by the REST API
+  (`check-runs/<id>.output.summary` is null, `.text` is empty).
+
+The first fix put the value in exactly the two places that cannot be read back.
+That is not a criticism of the reasoning — it is the finding.
+
+### This pass
+
+1. **The dead clause is gone.** `needs.changes.outputs.zephyr == 'true'` cannot
+   be false by construction on any reachable trigger, so it can only ever fail
+   CLOSED and invisibly. The three gates now read `run_zephyr` alone, which is
+   the decision this lane is actually about. `zephyr` is still computed and
+   still reported; it just no longer decides anything.
+2. **`zephyr-gate-report`**, an `always()` job that writes the raw values —
+   quoted, so an empty string and `"true"` cannot be confused — to an
+   ARTIFACT. Artifacts survive; this workflow's logs and summaries demonstrably
+   do not.
+
+**Honest status: (1) may well be the repair, and it is justified regardless.**
+It is not confirmed, and it cannot be until a scheduled run fires. If the lane
+is still skipped at the next 05:00, the artifact says which string is wrong,
+which is the thing nobody has been able to see for ten nights.
+
+### Still not covered
+
+* The `0 7` platform family's guards, unchanged. They work today.
+* Whether any 05:00 run has EVER produced a zephyr verdict since phase-253.


### PR DESCRIPTION
The 2026-09-04 fix computed the zephyr cron decision once and made it fail open. **It did not work.** Two scheduled runs have fired since and both still skipped all three zephyr jobs.

| run | trigger | zephyr jobs |
| --- | --- | --- |
| 2026-09-04T05:11 | schedule | skipped ×3 |
| 2026-09-05T05:10 | schedule | skipped ×3 |
| 2026-09-04T19:39 | workflow_dispatch | **ran** — copy-out ✅, ci-both ✅, matrix expanded |

All three ran the *fixed* workflow — verified by resolving each run's `head_sha` and grepping that commit's `nightly.yml`, not by assuming the schedule picked up the new file.

## Both gate clauses are `true` by reading

- `run_zephyr` is `true` in every branch of its `case` except a literal `0 7 ` cron — including the fail-open default the first fix added.
- `zephyr` is the literal `"true"` whenever the event is not `pull_request`, and **`pull_request` is not a trigger of this workflow** (`on:` is `workflow_dispatch` plus two `schedule` crons).

Yet the gate closes on schedule and opens on dispatch. So one of the two strings is not what it reads as, and:

- `gh api .../actions/jobs/<id>/logs` returns **zero bytes** for this workflow's `changes` job;
- a step summary is **not exposed by the REST API** (`check-runs/<id>.output.summary` is null, `.text` empty).

The first fix put the value in exactly those two places. That is the finding rather than a criticism of it — the same lossy-evidence wall the issue documented, one layer further in.

## This pass

**1. The dead clause is gone.** `needs.changes.outputs.zephyr == 'true'` cannot be false by construction on any reachable trigger — the branch that could make it false is the `pull_request` one, and there is no such trigger. A clause that cannot be false and empirically might be can only fail *closed*, invisibly, which is this issue. The three gates read `run_zephyr` alone; `zephyr` is still computed and reported, it just no longer decides anything.

**2. `zephyr-gate-report`** — an `always()` job that writes the raw values to an **artifact**, quoted so an empty string and `"true"` cannot be confused. Artifacts survive; this workflow's logs and summaries demonstrably do not.

## Honest status

Change 1 may well be the repair, and it is justified on its own terms either way. **It is not confirmed and cannot be until a scheduled run fires.** If the lane is still skipped at the next 05:00, the artifact names which string is wrong — the thing nobody has been able to see for ten nights.

`just check fast` 225/225 · `check-default-gates-run-somewhere` and `check-lane-contracts` green with the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP