### PR TITLE
fix(#1023): the freestanding-include gate read one directory of the two the toolchain compiles

### DIFF
--- a/docs/issues/archived/1023-sertype-hosted-includes-break-freestanding.md
+++ b/docs/issues/archived/1023-sertype-hosted-includes-break-freestanding.md
@@ -1,7 +1,7 @@
 ---
 id: 1023
 title: "`nros_sertype.cpp` includes `<memory>` and `<string>`, so cyclonedds cannot compile for a freestanding target"
-status: open
+status: resolved
 area: rmw, build
 severity: high
 found: 2026-09-04
@@ -100,3 +100,60 @@ currently reproducible" — which is the first tier-2 fixture build in some time
 None of 0968's twelve runtime failures are on threadx_riscv64: they are esp32
 (5), threadx_linux (3), zephyr xrce-cpp (3) and one qemu-rtic. Those modules
 built. This issue is a separate finding from the same run.
+
+## Resolution (2026-09-05) — the code half was already done by issue 1014
+
+`bed98e8ef` ("the Cyclone sertype TU compiles freestanding — by deleting a copy,
+not replacing it") landed both includes' removal, and took the better of the two
+options this issue laid out for `std::string`:
+
+* `<memory>` — replaced by a ten-line local RAII holder, as recommended here.
+* `<string>` — **not** the `ddsrt_strdup` this issue proposed. The copy was
+  deleted outright: `ddsi_sertype_init_flags` already does
+  `tp->type_name = ddsrt_strdup(name)`, so the `std::string` member was a
+  redundant SECOND copy of a string Cyclone already owns and already frees in
+  `ddsi_sertype_fini`. The comparison, the hash loop and the `.c_str()` all read
+  `ddsi_sertype::type_name` now. No lifetime question to settle, no new free op
+  — which is why the "needs a decision" framing here turned out to be avoidable.
+
+## What this pass adds: the gate's coverage
+
+`check-cpp-freestanding-includes` existed for this exact class (issue 0332) and
+read `packages/api/nros-cpp/include/nros/*.hpp` ONLY, while
+`cmake/toolchain/riscv64-threadx.cmake:219` puts `-nostdinc++ -isystem
+<cxx-compat>` on every C++ TU built for that board. The 0196 rule: coverage
+narrower than the rule it enforces. The class then bit twice in one Cyclone
+file — 0942 (`<cstdio>`) and 1014 (`<memory>` + `<string>`).
+
+The gate now also reads the Cyclone backend's `src/`, `.cpp` as well as `.hpp`,
+under a SECOND contract: nros-cpp headers must gate on `NROS_CPP_STD`
+specifically (the 0112 rule — a hosted compiler run `-nostdinc++` still has no
+`<string>`), while a backend TU may gate on anything, because it guards on the
+PLATFORM and that is the right question there. `internal.hpp` takes
+`<chrono>`/`<thread>` in the `#else` of its `NROS_PLATFORM_*` chain and is
+correct.
+
+**A latent bug in the gate fell out of widening it.** Its "other" push used
+`\b` for a word boundary, which POSIX ERE does not have, so
+`/#[[:space:]]*(ifdef|ifndef|if)\b/` **matched nothing** — the neutral push the
+comment says prevents a nested `#endif` from closing an `NROS_CPP_STD` region
+early had never happened. Invisible while every guarded include sat in a flat
+`#ifdef`; found the moment a real `#if/#elif/#else` chain came into scope.
+`([[:space:]]|$)` now.
+
+Mutation-checked in both directions: an ungated `#include <memory>` in
+`nros_sertype.cpp` is caught, and an ungated `#include <string>` in
+`nros-cpp/node.hpp` is caught.
+
+## What was NOT verified, and how far it got
+
+The acceptance is a threadx_riscv64 fixture build, and it did not run — that
+coordinate needs a configured Cyclone for the board and this host has none.
+
+What DID run is a direct `-ffreestanding -nostdinc++` syntax-only compile of
+`nros_sertype.cpp` with the board's own `riscv-none-elf-g++ 14.2` and its
+ten-header `cxx-compat` shim. It no longer stops on `<memory>`: it now reaches
+`ddsrt/sockets/posix.h` and fails on `sys/socket.h`, i.e. on a C header selected
+by a Linux-generated `dds/features.h` that a real board configure would not
+produce. That is not a pass, and it is evidence that the C++-library blocker
+this issue is about is gone.

--- a/scripts/check-cpp-freestanding-includes.sh
+++ b/scripts/check-cpp-freestanding-includes.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # Issue 0332 — the freestanding-header contract, enforced at the source.
 #
+# Issue 1023 widened the SCOPE, and the reason is the 0196 rule: this gate's
+# coverage was narrower than the rule it enforces. It read `nros-cpp`'s public
+# headers only, while `cmake/toolchain/riscv64-threadx.cmake:219` puts
+# `-nostdinc++ -isystem <cxx-compat>` on EVERY C++ TU built for that board —
+# which includes the whole Cyclone backend. The class then bit there twice in
+# one file: issue 0942 (`<cstdio>`) and issue 1014 (`<memory>` + `<string>`,
+# which meant the Cyclone backend had never built for that board at all).
+#
 # nros-cpp public headers must be includable on an embedded target with a
 # MINIMAL C++ library (Zephyr's libcpp: `<cstdint>`/`<cstddef>` yes,
 # `<string>`/`<vector>` no). The 0112 rule is that a hosted STL include gates on
@@ -16,7 +24,19 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-HEADER_DIR="packages/api/nros-cpp/include/nros"
+# The two trees this toolchain compiles with the shim on the include path. Not
+# a universal claim: it is these two because these are what a board build
+# reaches, and naming them is honest where "every C++ file" would not be.
+#
+# There is a THIRD location that compiles `-nostdinc++`, deliberately left out:
+# `packages/api/nros-cpp/tests/compile/*.cpp`. Those TUs exist to BE compiled
+# under the constraint, so a hosted include there fails the compile probe in
+# `just check cpp` loudly and immediately. This gate earns its keep where no
+# compile runs — a source-level check is a substitute for a build, not a
+# duplicate of one. Measured 2026-09-05 by grepping `-nostdinc++` across
+# `packages/` and `cmake/`; the only other hits are prose.
+SCAN_DIRS="packages/api/nros-cpp/include/nros packages/rmw/cyclonedds/nros-rmw-cyclonedds/src"
+
 
 # Hosted-only STL headers absent from a minimal freestanding libcpp. The
 # freestanding-guaranteed set (`<cstdint>`, `<cstddef>`, `<cstdlib>`,
@@ -27,7 +47,26 @@ HOSTED='string|vector|map|unordered_map|unordered_set|set|functional|memory|chro
 
 violations=0
 
-for hdr in "$HEADER_DIR"/*.hpp; do
+# TWO CONTRACTS, and conflating them would either miss violations or reject
+# correct code:
+#
+#   strict=1  nros-cpp's public headers. The 0112 rule is specific — a hosted
+#             include gates on `NROS_CPP_STD` and on nothing else, because a
+#             HOSTED compiler run `-nostdinc++` against Zephyr's minimal libcpp
+#             still has no `<string>`. `__STDC_HOSTED__` is the wrong question.
+#   strict=0  a backend TU. It has no `NROS_CPP_STD` notion; it guards on the
+#             PLATFORM, which is the right question there —
+#             `nros-rmw-cyclonedds/src/internal.hpp` takes `<chrono>`/`<thread>`
+#             only in the `#else` of its `NROS_PLATFORM_*` chain. Any
+#             conditional counts; depth 0 does not.
+for entry in "packages/api/nros-cpp/include/nros:1" \
+             "packages/rmw/cyclonedds/nros-rmw-cyclonedds/src:0"; do
+  dir="${entry%:*}"
+  strict="${entry##*:}"
+  # `.cpp` too, not only headers: the 1014 break was in a TRANSLATION UNIT, and
+  # a TU that cannot compile is exactly as broken as a header that cannot be
+  # included.
+  for hdr in $(ls "$dir"/*.hpp "$dir"/*.cpp 2>/dev/null); do
     base="$(basename "$hdr")"
     # rclcpp_compat.hpp is a deliberately-ungated source-compat shim, excluded
     # from the freestanding probe by design (phase 209) — skip it here too.
@@ -35,18 +74,29 @@ for hdr in "$HEADER_DIR"/*.hpp; do
 
     # Walk the file tracking NROS_CPP_STD guard depth. Flag a hosted `#include`
     # that appears at guard-depth 0.
-    hits="$(awk -v hosted="$HOSTED" '
+    hits="$(awk -v hosted="$HOSTED" -v strict="$strict" '
         BEGIN { depth = 0 }
         # Enter an NROS_CPP_STD region: `#ifdef NROS_CPP_STD` or
         # `#if defined(NROS_CPP_STD)`. Other #if/#ifdef push a neutral level so
         # a nested #endif does not close the NROS_CPP_STD region prematurely.
         /^[[:space:]]*#[[:space:]]*(ifdef|if)([[:space:]]|\().*NROS_CPP_STD/ { stack[++sp] = "std"; next }
-        /^[[:space:]]*#[[:space:]]*(ifdef|ifndef|if)\b/ { stack[++sp] = "other"; next }
-        /^[[:space:]]*#[[:space:]]*endif\b/ { if (sp > 0) sp-- ; next }
+        # `\b` is NOT a word boundary in POSIX ERE — awk reads it as an escape
+        # with no such meaning, so these two rules MATCHED NOTHING. The "other"
+        # push therefore never happened, which is the very bug the comment above
+        # says it prevents: a nested `#endif` popped the NROS_CPP_STD region
+        # early. Latent while every guarded include sat in a flat `#ifdef`;
+        # found by issue 1023 when a backend TU with a real `#if/#elif/#else`
+        # chain came into scope. `([[:space:]]|$)` is the portable spelling.
+        /^[[:space:]]*#[[:space:]]*(ifdef|ifndef|if)([[:space:]]|$)/ { stack[++sp] = "other"; next }
+        /^[[:space:]]*#[[:space:]]*endif([[:space:]]|$)/ { if (sp > 0) sp-- ; next }
         {
-            in_std = 0
-            for (i = 1; i <= sp; i++) if (stack[i] == "std") in_std = 1
-            if (in_std) next
+            guarded = 0
+            if (strict == 1) {
+                for (i = 1; i <= sp; i++) if (stack[i] == "std") guarded = 1
+            } else {
+                guarded = (sp > 0)
+            }
+            if (guarded) next
             if ($0 ~ ("^[[:space:]]*#[[:space:]]*include[[:space:]]*<(" hosted ")>")) {
                 printf "%d: %s\n", NR, $0
             }
@@ -54,16 +104,21 @@ for hdr in "$HEADER_DIR"/*.hpp; do
     ' "$hdr")"
 
     if [ -n "$hits" ]; then
-        echo "check-cpp-freestanding-includes: $base includes a hosted STL header outside NROS_CPP_STD (issue 0332):" >&2
+        echo "check-cpp-freestanding-includes: $base includes a hosted STL header outside a guard (issues 0332/1023):" >&2
         while IFS= read -r line; do echo "  $base:$line" >&2; done <<<"$hits"
         violations=1
     fi
+  done
 done
 
 if [ "$violations" -ne 0 ]; then
     echo >&2
-    echo "Fix: wrap the hosted section in \`#ifdef NROS_CPP_STD\` (see std_compat.hpp / bridge.hpp)." >&2
+    echo "Fix: wrap the hosted section in a guard — \`#ifdef NROS_CPP_STD\` for nros-cpp" >&2
+    echo "(std_compat.hpp / bridge.hpp), or a platform \`#if\` for a backend TU" >&2
+    echo "(nros-rmw-cyclonedds/src/internal.hpp does the latter for <chrono>/<thread>)." >&2
+    echo "If neither fits, the header is not available on that board: do without it." >&2
     exit 1
 fi
 
-echo "check-cpp-freestanding-includes: OK (no ungated hosted STL includes in nros-cpp headers)"
+count="$(for d in $SCAN_DIRS; do ls "$d"/*.hpp "$d"/*.cpp 2>/dev/null; done | wc -l)"
+echo "check-cpp-freestanding-includes: OK ($count file(s) across nros-cpp headers and the Cyclone backend; no ungated hosted STL includes)"


### PR DESCRIPTION
Closes #1023.

## The code half was already done, and better than the issue proposed

`bed98e8ef` (issue 1014) removed both hosted includes. For `<string>` it did **not** do the `ddsrt_strdup` this issue recommended — it deleted the copy outright, because `ddsi_sertype_init_flags` already does `tp->type_name = ddsrt_strdup(name)` and `ddsi_sertype_fini` already frees it. The `std::string` member was a redundant *second* copy of a string Cyclone owns, so the lifetime question the issue called "not mechanical" was avoidable rather than answerable.

## What was left: the gate's coverage

`check-cpp-freestanding-includes` exists for exactly this class (issue 0332) and read `packages/api/nros-cpp/include/nros/*.hpp` **only** — while `cmake/toolchain/riscv64-threadx.cmake:219` puts `-nostdinc++ -isystem <cxx-compat>` on *every* C++ TU built for that board.

That is the 0196 rule, and the class duly bit twice in one Cyclone file: 0942 (`<cstdio>`) and 1014 (`<memory>` + `<string>` — which meant the Cyclone backend had never built for that board at all).

The gate now reads the Cyclone backend's `src/` as well, `.cpp` as well as `.hpp`: the 1014 break was in a translation unit, and a TU that cannot compile is as broken as a header that cannot be included.

**Two contracts**, because conflating them would either miss violations or reject correct code:

| scope | rule | why |
| --- | --- | --- |
| nros-cpp headers | must gate on `NROS_CPP_STD` | the 0112 rule — a *hosted* compiler run `-nostdinc++` against a minimal libcpp still has no `<string>`, so `__STDC_HOSTED__` is the wrong question |
| backend TUs | any conditional counts | they guard on the PLATFORM, which is the right question there — `internal.hpp` takes `<chrono>`/`<thread>` in the `#else` of its `NROS_PLATFORM_*` chain and is correct |

## A latent bug fell out of widening it

The gate's "other" push used `\b` for a word boundary. **POSIX ERE has no `\b`**, so `/#[[:space:]]*(ifdef|ifndef|if)\b/` matched nothing — the neutral push its own comment says prevents a nested `#endif` from closing an `NROS_CPP_STD` region early had never happened. Invisible while every guarded include sat in a flat `#ifdef`; found the moment a real `#if/#elif/#else` chain came into scope.

## Verification

Mutation-checked in both directions — an ungated `<memory>` in `nros_sertype.cpp` is caught, an ungated `<string>` in `nros-cpp/node.hpp` is caught, tree clean at 64 files. `just check fast` 225/225, `gate-selftests` green.

**Not verified**: the acceptance is a threadx_riscv64 fixture build and it did not run — that needs a Cyclone configured for the board, and this host has none.

What *did* run is a direct `-ffreestanding -nostdinc++` syntax-only compile of `nros_sertype.cpp` with the board's own `riscv-none-elf-g++ 14.2` and its ten-header shim. It no longer stops on `<memory>`: it reaches `ddsrt/sockets/posix.h` and fails on `sys/socket.h` — a C header selected by a Linux-generated `dds/features.h` that a board configure would not produce. Not a pass; evidence that the C++-library blocker this issue is about is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP