### PR TITLE
ci(gate): one cache writer, and warm what the expensive step actually needs

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -334,7 +334,15 @@ jobs:
       # older entry a partial hit, which is all a content-hashed cache needs.
       - name: Cache sccache directory (compiling events)
         if: ${{ contains(fromJSON('["pull_request","merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
-        uses: actions/cache@v4
+        # RESTORE-ONLY. A save here writes a cache the run can never read again:
+        # merge_group executes on an ephemeral `gh-readonly-queue/...` ref and a
+        # pull_request on `refs/pull/N/merge`, and GitHub scopes a cache to its
+        # creating ref. Measured 2026-09-05: 16 such entries held 13.34 GB of a
+        # 10 GB pool — 97.6% — so the pool ran 37% over its limit and evicted
+        # continuously, and `main`'s shared entry (the only one anything can
+        # restore from) was the small, least-recently-used thing it discarded.
+        # `warm-cache` on push to main is the ONE writer.
+        uses: actions/cache/restore@v4
         with:
           path: /tmp/sccache
           key: sccache-${{ runner.os }}-check-${{ github.sha }}
@@ -423,7 +431,15 @@ jobs:
       # sources, so a change to it still invalidates the entry.
       - name: Cache CLI build (compile tier)
         if: ${{ contains(fromJSON('["pull_request","merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
-        uses: actions/cache@v4
+        # RESTORE-ONLY. A save here writes a cache the run can never read again:
+        # merge_group executes on an ephemeral `gh-readonly-queue/...` ref and a
+        # pull_request on `refs/pull/N/merge`, and GitHub scopes a cache to its
+        # creating ref. Measured 2026-09-05: 16 such entries held 13.34 GB of a
+        # 10 GB pool — 97.6% — so the pool ran 37% over its limit and evicted
+        # continuously, and `main`'s shared entry (the only one anything can
+        # restore from) was the small, least-recently-used thing it discarded.
+        # `warm-cache` on push to main is the ONE writer.
+        uses: actions/cache/restore@v4
         with:
           path: |
             packages/cli/target
@@ -971,6 +987,13 @@ jobs:
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
           cargo build --release --manifest-path packages/cli/nros-launch-resolve/Cargo.toml
+          # `check cli-tests` is 338 s of the 20 min job and it is COMPILE-bound
+          # (measured: 350 CPU-s to build, tests run in under a second). Warming
+          # only the binary left the biggest step cold — main's warm entry was
+          # 208 MB against the 1.78 GB a `check` run actually caches. `--no-run`
+          # compiles the test harnesses without executing them, which is exactly
+          # the artifact that step waits on.
+          cargo test --no-run --manifest-path packages/cli/Cargo.toml
 
   scaffold-journey:
     name: nros new -> sync -> resolve

--- a/scripts/check-gate-cache-keys-agree.py
+++ b/scripts/check-gate-cache-keys-agree.py
@@ -59,8 +59,14 @@ def jobs(text):
 def cache_entries(body):
     """[(path_block, key)] for every actions/cache step in a job body."""
     out = []
+    # `actions/cache`, `actions/cache/restore` and `actions/cache/save` all count:
+    # the downstream jobs are RESTORE-only (a save on an ephemeral ref is a cache
+    # nothing can ever read), and the pairing this gate checks is between the
+    # reader's key and the writer's key regardless of which variant each uses.
     for m in re.finditer(
-        r"uses:\s*actions/cache@[^\n]*\n(.*?)(?=\n\s*- name:|\Z)", body, re.S
+        r"uses:\s*actions/cache(?:/(?:restore|save))?@[^\n]*\n(.*?)(?=\n\s*- name:|\Z)",
+        body,
+        re.S,
     ):
         blk = m.group(1)
         key = re.search(r"^\s*key:\s*(.+)$", blk, re.M)
@@ -78,7 +84,7 @@ def self_test():
         "jobs:\n"
         "  a:\n"
         "    steps:\n"
-        "      - uses: actions/cache@v4\n"
+        "      - uses: actions/cache/restore@v4\n"
         "        with:\n"
         "          path: /tmp/x\n"
         "          key: k-1\n"


### PR DESCRIPTION
Follow-up to #496. Verifying that change showed the warm job *was* writing to `main` — and that it bought almost nothing. Two measured reasons, both fixed here.

## 1. The pool was 37% over its limit, and the ephemeral scopes owned it

```
caches: 18   total: 13.67 GB   (GitHub repo limit: 10 GB)
  main    2 entries   0.32 GB
  pr      8 entries   6.62 GB
  queue   8 entries   6.72 GB
```

Every one of those 16 ephemeral entries is a cache **its own run can never read again** — `merge_group` executes on `gh-readonly-queue/...`, a pull request on `refs/pull/N/merge`, and GitHub scopes a cache to its creating ref.

So **13.34 GB — 97.6% of the pool — was written to be evicted**, and what LRU discarded was `main`'s small shared entry: the only one anything can restore from. No main-scope entry had been created since **08:21**, despite warm jobs succeeding at 09:03, 09:30, 10:04, 10:23 and 10:47. Written, then evicted, repeatedly.

The downstream steps become `actions/cache/restore@v4`. They **still restore** — gating the step to main would have stopped that too, which is the trap — they simply no longer write. `warm-cache` on push to main is the one writer.

`gate.yml`'s own comment predicted this thrashing ("caches are created and deleted at a high frequency") without connecting it to scoping.

## 2. The warm entry was the wrong subset

**208 MB** on main against the **1.78 GB** a `check` run caches, because the warm job built only `--bin nros` and the resolver.

`check cli-tests` is **338 s of the 20 min job** and is compile-bound — 350 CPU-s to build, tests run in under a second — so the biggest step stayed cold even on a hit. The warm job now also runs `cargo test --no-run`, compiling those harnesses without executing them.

## The gate caught its own obsolescence

Switching the consumer to `cache/restore` made `check-gate-cache-keys-agree` report *"no actions/cache step found … this gate would pass vacuously"* rather than silently matching nothing — exactly the behaviour it was written for. It now recognises all three variants, and the key-drift mutation still fails it.

## Measurement corrections

Recorded so the earlier numbers aren't re-trusted: the `0 s` build steps I first read as cache hits were **pending** steps in runs still in flight, and the one completed post-warm run was **73 s against a 78–92 s baseline** — within noise, not a hit.

## Verification

`just check fast` — 226 gates, 0 failures. Both `check` cache steps are restore-only and both `warm-cache` steps read+write, asserted by parsing the YAML rather than reading the diff.