### PR TITLE
docs(phase-215, #1103): seven boxes had landed and were never ticked, and no gate asks

### DIFF
--- a/docs/issues/1103-roadmap-boxes-unticked-while-their-subject-exists.md
+++ b/docs/issues/1103-roadmap-boxes-unticked-while-their-subject-exists.md
@@ -1,0 +1,92 @@
+---
+id: 1103
+title: "A roadmap box can stay UNTICKED while the file, function or recipe it
+  names is in the tree — `check-roadmap-claims` never asks"
+status: open
+type: bug
+area: tooling, docs
+related: [1071, 1085]
+---
+
+## What was found
+
+Auditing the eleven oldest phase docs still in `docs/roadmap/` (active), against
+a tree whose newest phase is 429: **phase-215 carried seven boxes that had
+landed and were never ticked.** Each is a claim about something that either
+exists in the tree or does not:
+
+| box | claim | in the tree |
+| --- | --- | --- |
+| 215.A.1 | define the `board.cmake` schema, nine `NROS_BOARD_*` variables | all nine present in `docs/reference/board-cmake-schema.md` AND in the fvp-aemv8r-smp `board.cmake` |
+| 215.A.3 | schema doc cross-references this phase | `board-cmake-schema.md:15` |
+| 215.B.2 | `zephyr/CMakeLists.txt` includes the new fn | `zephyr/CMakeLists.txt:53,60`, comment cites "Phase 215.B.2" |
+| 215.B.3 | callable BEFORE `find_package(Zephyr)` | `nano_ros_use_board.cmake:8` usage + `:27,35` enforcement |
+| 215.D.4 | recipes delegate to `west fvp run` | `scripts/west_commands/fvp.py`, `scripts/west-commands.yml`, `just/zephyr-setup.just:239` |
+| 215.I.1 | `book/src/porting/board-crate-import.md` | exists |
+| 215.I.2 | SUMMARY.md update | `book/src/SUMMARY.md:100` |
+
+The phase read as 20 of 38 with a `**Status.** OPEN` line implying the schema
+work had not started. It was 27 of 38, and the in-repo half was complete.
+
+## Why nothing caught it
+
+`check-roadmap-claims` is the gate for this file and it PASSES — *"0 known
+finding(s), no new ones across 68 active phase doc(s)"*. Its rules ask:
+
+* R1/R2 — does the status TEXT agree with the box COUNTS?
+* R3 — does an `**Owns:**` line name an issue that is `status: resolved`
+  without saying so?
+* R4 — is a document in `docs/roadmap/` disclaiming that it is a phase?
+
+Every one compares the document against ITSELF or against an issue's
+frontmatter. **None asks whether a box's SUBJECT is already in the tree.** So
+"unticked but done" is structurally invisible: the status line and the counts
+agreed with each other, and both were wrong about the world.
+
+This is 1071's shape a third time — the gate exists, runs, is green, and the
+rule it enforces is narrower than the rule its name implies. 1071 was a registry
+whose count could silently fall; 1085 was a link whose target could silently
+move; this is a checkbox whose subject can silently arrive.
+
+## What is checkable, and what is not
+
+Deliberately narrow, because the failure mode of a clever version is a gate
+that nags about prose:
+
+**CHECKABLE — a box that names a concrete artifact.** The seven above are all
+of one shape: a backticked path (`book/src/porting/board-crate-import.md`,
+`scripts/west_commands/fvp.py`), a cmake function (`nano_ros_use_board()`), or
+a recipe. If an UNTICKED box names a path that EXISTS, that is worth one line of
+output — not an error, a report, because the box may name a file that exists for
+another reason.
+
+**NOT CHECKABLE.** "Parity check vs Phase 175.A native cyclonedds Rust
+talker/listener: byte-equal wire format" (217.C.3) names no artifact and blocks
+on a real FVP run. Neither does "ASI's `actuation_module/CMakeLists.txt` builds
+clean against the Zephyr 3.7 floor" — an external repo this worktree cannot see.
+A gate that reported those would be reporting on documents it cannot read.
+
+**A WARNING, not a failure**, and that distinction is the design. A ticked box
+is a human's verdict that the work is DONE, which is more than "a file with this
+name exists"; the gate can say "this looks landed, check it" and cannot say "tick
+it". Making it fail would push people to tick boxes to get green, which is worse
+than the drift.
+
+## Where it bites
+
+The same class the session that found it hit six times in issues: work lands,
+the record does not move, and the next person re-derives or re-does it. For a
+roadmap the cost is specific — phase-215 is `**Priority.** P1`, so anyone
+scanning for what to pick up read seven finished items as available work.
+
+## Proposed
+
+`check-roadmap-boxes`, on the fast line: for every UNTICKED box in an active
+phase doc, extract backticked tokens that look like a repo-relative path, and
+report the ones that resolve against `git ls-files`. Index lookup, no walk
+(issue 0844). Ratcheted like `check-gate-selftests` so the known set may only
+shrink — the phases audited here are the seed, and a new occurrence is the
+signal.
+
+Not done in the same change as the phase-215 fix, deliberately: the fix is a
+verified edit to one document, and the gate is a new rule over 68 of them.

--- a/docs/roadmap/phase-215-board-crate-as-importable-unit.md
+++ b/docs/roadmap/phase-215-board-crate-as-importable-unit.md
@@ -7,8 +7,26 @@ hand-curated `EXTRA_CONF_FILE` / `DTC_OVERLAY_FILE` / hardcoded board
 id list / hand-rolled FVP launch flags on the consumer side. FVP
 AEMv8-R is the driving case; the shape is generic across boards.
 
-**Status.** OPEN. Driven by ASI's Phase 190 follow-up — ASI today
-hand-glues every layer Phase 215 collapses.
+**Status (2026-09-05).** OPEN, and **the in-repo half is done** — 27 of 38
+boxes, up from 20 after an audit found seven that had landed and were never
+ticked (A.1, A.3, B.2, B.3, D.4, I.1, I.2). Each carries its witness now; the
+schema, the `nano_ros_use_board()` import, the `west fvp` delegation and the
+book page were all in the tree while the doc read as unstarted work.
+
+**What is actually left splits in two**, and neither half is nano-ros
+engineering:
+
+* **215.H / 215.J.5 — the ASI side.** `actuation_module/CMakeLists.txt`,
+  `build.sh`, `fvp/NOTES.md`, `bootstrap-asi.sh`. External repo; this phase's
+  worktree cannot verify or land them.
+* **The acceptance bullets that need a RUN.** `west fvp run -d build/`
+  launching `FVP_BaseR_AEMv8R` end to end, and the 215.E fixture building in
+  CI — the fixture and its build test landed, and the build is
+  gated-pending-Zephyr-SDK in this environment, so the test skips loudly rather
+  than passing vacuously.
+
+Driven by ASI's Phase 190 follow-up — ASI today hand-glues every layer Phase 215
+collapses.
 
 **Priority.** P1 — unblocks ASI's actuation consumption story + every
 future external Zephyr consumer of a nano-ros board crate.
@@ -101,7 +119,7 @@ against drift.
 
 ### 215.A — Sidecar `board.cmake` per board crate
 
-- [ ] **215.A.1** Define the `board.cmake` schema. Variables:
+- [x] **215.A.1** Define the `board.cmake` schema. Variables:
       `NROS_BOARD_ZEPHYR_ID` (Zephyr `BOARD` string),
       `NROS_BOARD_TOOLCHAIN` (SDK abi target, e.g. `aarch64-zephyr-elf`),
       `NROS_BOARD_GATED_PKGS` (semicolon list keyed on
@@ -116,7 +134,10 @@ against drift.
 - [x] **215.A.2** Write `packages/boards/nros-board-fvp-aemv8r-smp/board.cmake`
       filling every variable. Absolute paths via
       `${CMAKE_CURRENT_LIST_DIR}`. _(landed `01ef6bd1a`, 2026-06)_
-- [ ] **215.A.3** Documented schema cross-references this phase doc.
+- [x] **215.A.3** Documented schema cross-references this phase doc.
+      _(verified 2026-09-05: `docs/reference/board-cmake-schema.md:15`
+      cross-refs this file, and all nine `NROS_BOARD_*` variables of A.1
+      appear in BOTH that doc and the fvp-aemv8r-smp `board.cmake`.)_
 - **Files:** `packages/boards/nros-board-fvp-aemv8r-smp/board.cmake`
   (new), `docs/reference/board-cmake-schema.md` (new).
 
@@ -137,10 +158,10 @@ against drift.
       7. If `NANO_ROS_RMW` undefined → cache `${NROS_BOARD_DEFAULT_RMW}`.
       8. Cache `NROS_BOARD_RUNNER` so `west fvp run` reads it from
          `CMakeCache.txt`.
-- [ ] **215.B.2** `zephyr/CMakeLists.txt` `include()`s the new fn so
+- [x] **215.B.2** `zephyr/CMakeLists.txt` `include()`s the new fn so
       it's available to every downstream app once nano-ros's Zephyr
       module is on `ZEPHYR_EXTRA_MODULES`.
-- [ ] **215.B.3** `nano_ros_use_board()` must be call-able BEFORE
+- [x] **215.B.3** `nano_ros_use_board()` must be call-able BEFORE
       `find_package(Zephyr)` OR after — order tested both ways. The
       `EXTRA_CONF_FILE` / `BOARD` overrides need to land before
       Zephyr's board-resolution phase, so the fn either re-orders
@@ -199,7 +220,7 @@ against drift.
       scripts/west-commands.yml` so any workspace that has nano-ros as
       a west project gets the extension for free (no manual
       registration).
-- [ ] **215.D.4** Phase 214.A `just zephyr run-fvp-aemv8r*` recipes
+- [x] **215.D.4** Phase 214.A `just zephyr run-fvp-aemv8r*` recipes
       are RETAINED (developer ergonomics inside nano-ros) but
       delegate to `west fvp run` instead of duplicating the resolver
       + `-t run` invocation. ~3-line recipes.
@@ -317,10 +338,12 @@ External landing in `github.com/NEWSLabNTU/autoware-safety-island`:
 
 ### 215.I — Book chapter
 
-- [ ] **215.I.1** `book/src/porting/board-crate-import.md` — the
+- [x] **215.I.1** `book/src/porting/board-crate-import.md` — the
       consumer guide. Cross-refs Phase 212.N.8 board-trait porting +
       Phase 214 FVP runtime + Phase 191 sdk provisioning.
-- [ ] **215.I.2** SUMMARY.md update.
+- [x] **215.I.2** SUMMARY.md update.
+      _(verified 2026-09-05: `book/src/SUMMARY.md:100`
+      — `[Importing a Board Crate](./porting/board-crate-import.md)`.)_
 - **Files:** `book/src/porting/board-crate-import.md` (new),
   `book/src/SUMMARY.md` (edit).
 


### PR DESCRIPTION
Auditing the eleven oldest phase docs still in `docs/roadmap/` — against a tree whose newest phase is 429 — found **phase-215 reading 20 of 38 boxes** with a `**Status.** OPEN` line implying the schema work had not started. It was **27 of 38**, and the whole in-repo half was complete.

## Ticked, each with its witness

| box | evidence |
| --- | --- |
| `215.A.1` | all nine `NROS_BOARD_*` variables in **both** `docs/reference/board-cmake-schema.md` and the fvp-aemv8r-smp `board.cmake` |
| `215.A.3` | `board-cmake-schema.md:15` cross-refs this phase doc |
| `215.B.2` | `zephyr/CMakeLists.txt:53,60` — the comment cites *"Phase 215.B.2"* |
| `215.B.3` | `nano_ros_use_board.cmake:8` usage + `:27,35` enforcement of the before-`find_package(Zephyr)` constraint |
| `215.D.4` | `scripts/west_commands/fvp.py`, `scripts/west-commands.yml`, and `just/zephyr-setup.just:239` running `west fvp run -d build-fvp-ws-entry` |
| `215.I.1` | `book/src/porting/board-crate-import.md` |
| `215.I.2` | `book/src/SUMMARY.md:100` |

## Not ticked, and the status now says why

- **215.H / 215.J.5 — the ASI side** (`actuation_module/CMakeLists.txt`, `build.sh`, `fvp/NOTES.md`, `bootstrap-asi.sh`). External repo; this worktree cannot verify or land them.
- **Acceptance bullets that need a run** — `west fvp run` launching `FVP_BaseR_AEMv8R` end to end, and the 215.E fixture building in CI. The fixture and its build test landed; the build is gated-pending-Zephyr-SDK here, so the test *skips loudly* rather than passing vacuously.

Left for the phase owner on purpose: a ticked box is a human's verdict that the work is done, and *"the artifact exists"* is less than that.

## #1103 — why nothing caught it

`check-roadmap-claims` **passes** on this file: *"0 known finding(s), no new ones across 68 active phase doc(s)"*.

Its rules compare the status **text** against the box **counts**, an `**Owns:**` line against an issue's frontmatter, and whether a document disclaims being a phase. Every one compares the document **against itself**. None asks whether a box's *subject* is in the tree — so "unticked but done" is structurally invisible: the status line and the counts agreed with each other, and both were wrong about the world.

That's #1071's shape a third time. #1071 was a registry whose count could silently fall; #1085 a link whose target could silently move; this is a checkbox whose subject can silently arrive.

Filed with the scope worked out rather than implemented here — this PR is a verified edit to one document, and the gate is a new rule over 68 of them. The checkable half is a box naming a concrete artifact (a backticked repo path, a cmake function, a recipe); the uncheckable half is prose like *"byte-equal wire format"* or a claim about an external repo. And it must **warn, never fail**: a gate that fails here pushes people to tick boxes for green, which is worse than the drift it would catch.

`just check fast`: 220 gates ran, 0 failed. `check-roadmap-claims` and `check-roadmap-status` both green after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj