### PR TITLE
fix(#0900): the end-to-end measurement — 66,048 B off a talker, 54,144 off an action client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ examples/**/target-*/
 # hard-errors on the missing include until `nros sync` runs in that leaf;
 # `_require-leaf-includes` is the preflight that says so.
 **/.cargo/nros-managed-patch.toml
+# Issue 0827 — sync's derived pool budgets, the `[env]` sibling of the file
+# above. Derived from the metadata probe's output, which is itself per-host and
+# ignored, so committing this would pin one host's answer for everyone.
+**/.cargo/nros-managed-env.toml
 
 # Issue 0559 / phase-341 W2 — the per-leaf board `cargo_config` projection
 # `nros sync` writes next to the config that `include`s it.

--- a/docs/issues/archived/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/archived/0827-unused-rmw-pools-dominate-static-ram.md
@@ -2,7 +2,7 @@
 id: 827
 title: "Static RAM is a property of the RMW, not of the node — a talker reserves
   275 KB of service and large-payload pools it can never reach"
-status: open
+status: resolved
 type: performance
 area: rmw
 related: [phase-392, phase-391, phase-412, issue-0815, issue-0739]
@@ -561,3 +561,58 @@ for a known reason — a missing `include` target is a HARD cargo error during
 manifest parse (issue 0463) — so the file and its `include` must appear and
 disappear together, which is the same invariant the patch sidecar already holds
 and the reason to put it in the same place rather than a new one.
+
+
+## WIRED and MEASURED (2026-09-05) — `nros sync` writes the budget
+
+The remaining step is done: `write_patch_config` derives the leaf's budget and
+writes `.cargo/nros-managed-env.toml`, with the `include` entry added in the
+same decision that writes the file.
+
+**A/B on one host, one tree, one profile — not against a number from another
+day**, because a stale baseline is how this repo has been wrong before:
+
+| `examples/native/rust/talker` | RAM attributed to symbols |
+| --- | ---: |
+| without the derived sidecar | 417,316 |
+| with it | **240,596** |
+| **saved** | **176,720 (42.3 %)** |
+
+That lands within 2 KB of this issue's earlier hand-set `[env]` measurement
+(415,469 stock), reached from a different direction — the agreement is the
+cross-check.
+
+The mechanism is confirmed end to end rather than inferred from the file: the
+build's generated shim constants read
+
+```
+/// Maximum number of concurrent subscribers (set via ZPICO_MAX_SUBSCRIBERS, default 8).
+pub const ZPICO_MAX_SUBSCRIBERS: usize = 1;
+```
+
+so the derived number reached the crate that sizes the pool.
+
+### Two sidecars, not one section
+
+`nros-managed-env.toml` is a SEPARATE file from `nros-managed-patch.toml`
+because the two empty independently: a leaf can have a generated message dep and
+no probeable component, or the reverse. Sharing a file would make each one's
+presence depend on the other's. Both follow the same rule — the file and its
+`include` entry appear and disappear together, since a missing include target is
+a hard cargo error during manifest parse (issue 0463).
+
+Gitignored, like its sibling: it is derived from a probe output that is itself
+per-host and ignored, so committing it would pin one host's answer for everyone.
+
+### What is still NOT derived
+
+`ZPICO_MAX_LARGE_SUBSCRIBERS` — `LARGE_PAYLOADS` remains 131,072 B and is the
+largest single symbol left in that image. The entity inventory has no notion of
+a "large" subscriber, so nothing here can state that number honestly; it stays a
+knob a human sets. Recording it rather than leaving the impression this issue
+recovered everything.
+
+And the whole mechanism reaches only PROBEABLE leaves. A cross-compiled leaf
+whose metadata is `.json.unprobeable` still states its budgets by hand — issue
+1061 — and `nros sync` now says so on the terminal instead of leaving it to be
+inferred from an absent file.

--- a/docs/issues/archived/0900-arena-slots-budgeted-at-action-client-worst-case.md
+++ b/docs/issues/archived/0900-arena-slots-budgeted-at-action-client-worst-case.md
@@ -1,7 +1,7 @@
 ---
 id: 900
 title: "Every executor arena slot is budgeted at the ActionClient worst case, so a pub/sub-only image carries ~56 KiB it cannot use"
-status: open
+status: resolved
 area: core, memory
 severity: medium
 found: 2026-08-29
@@ -539,3 +539,58 @@ Not measured here: an end-to-end image build showing the stack reservation
 shrink. The constant is what sizes it, and no image in the tree currently
 derives a non-default value, so that measurement needs an image built through
 the CMake seam with a declaring `nano_ros_node_register`.
+
+
+## The end-to-end measurement this issue was waiting for (2026-09-05)
+
+The section above closes with "Not measured here: an end-to-end image build
+showing the stack reservation shrink … no image in the tree currently derives a
+non-default value, so that measurement needs an image built through the CMake
+seam with a declaring `nano_ros_node_register`."
+
+That is no longer true, and it did not need the CMake seam. Issue 0827's
+derivation makes `nros sync` write `NROS_EXECUTOR_ACTION_CLIENTS` and
+`NROS_EXECUTOR_MAX_CBS` into a per-leaf `[env]` sidecar, computed from the
+metadata probe through the same `entity_inventory` rules. So in-tree cargo
+leaves now derive non-default values, and the constant can be read from a real
+build instead of a synthetic one.
+
+Read from `nros-node`'s generated `nros_node_config.rs`, same host, same tree,
+same profile, sidecar present vs absent:
+
+| leaf | | `MAX_CBS` | `ARENA_SIZE` |
+| --- | --- | ---: | ---: |
+| `native/rust/talker` | stock | 4 | 74,240 |
+| | derived | 1 | **8,192** |
+| | **saved** | | **66,048 (64.5 KiB)** |
+| `native/rust/action-client` | stock | 4 | 74,240 |
+| | derived | 1 | **20,096** |
+| | **saved** | | **54,144 (52.9 KiB)** |
+
+**Both rows are larger than this issue predicted, and for a reason worth
+stating.** The 56.5 KiB and 43,392 B figures above were measured with `MAX_CBS`
+held at its default of 4 and only `ACTION_CLIENTS` varied. A derived image moves
+BOTH: the talker declares one callback, so it gets `MAX_CBS=1` as well, and the
+two compound.
+
+The action-client row is the one that settles the argument this issue kept
+having with itself. An image that genuinely HAS an action client — the case the
+worst-case default was chosen to protect — still recovers **52.9 KiB**, because
+the default budgets all four slots at action-client size when exactly one needs
+it. The default was not conservative for that image; it was wrong by 52 KiB.
+
+### What that does to the three options
+
+Option 1 ("declare client-side entities … costs a schema addition, a resolver
+change and a migration") is delivered for probeable leaves at none of those
+costs: the probe already records `action_clients`, so nothing new is declared
+and no model migrates. Option 3's gate stays as the backstop, and option 2 —
+flipping the default — is not needed where the derivation runs.
+
+### Where it does not run
+
+A leaf whose metadata is `.json.unprobeable` derives nothing and keeps the
+worst-case default: correct, and loud rather than silent, since `nros sync` now
+says so. That set is issue 1061. An image built through the CMake seam gets the
+same numbers from `entity-inventory` directly, which is the path phase-403 W9
+already wired.

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -4411,7 +4411,20 @@ fn write_patch_config(
     let cfg_dir = authority_dir.join(".cargo");
     let cfg = cfg_dir.join("config.toml");
     let text = std::fs::read_to_string(&cfg).unwrap_or_default();
-    let out = render_patch_config_with(&text, managed, include_rel, sidecar)
+
+    // Issue 0827 — the derived pool budgets, computed BEFORE the config is
+    // rendered because the render needs to know whether the sidecar will exist.
+    // Deciding by "am I about to write it" rather than by guessing is what keeps
+    // the file and its `include` entry in step (issue 0463).
+    //
+    // Only for an in-tree leaf: an out-of-tree consumer gets no `include` at all
+    // (#272), so a sidecar it could not reference would be a file nothing reads.
+    let derived_env: Option<String> = if sidecar {
+        render_leaf_env_sidecar(authority_dir)
+    } else {
+        None
+    };
+    let out = render_patch_config_with(&text, managed, include_rel, sidecar, derived_env.is_some())
         .wrap_err_with(|| format!("sync: edit {}", cfg.display()))?;
 
     // Atomic write (create `.cargo/` first).
@@ -4453,14 +4466,94 @@ fn write_patch_config(
         atomic_write(&managed_path, &render_managed_patch_file(&generated))?;
     }
 
+    // Issue 0827 — same temp+rename and the same "no stale file" rule as the
+    // patch sidecar above.
+    let env_path = cfg_dir.join(MANAGED_ENV_FILE);
+    match &derived_env {
+        Some(body) => atomic_write(&env_path, body)?,
+        None => {
+            let _ = std::fs::remove_file(&env_path);
+        }
+    }
+
     atomic_write(&cfg, &out)?;
     Ok(())
+}
+
+/// Issue 0827 — the `[env]` body for this leaf, or `None` when there is nothing
+/// to state.
+///
+/// `None` on every path that is not a confident derivation, and the cases are
+/// deliberately different from each other:
+///
+/// * no `metadata/` directory, or no probeable component in it — nothing ran, so
+///   there is nothing to say;
+/// * the inventory REFUSES (`Derivation::Refused`) — it says why, and a refusal
+///   is not a budget;
+/// * a parse failure — reported, and then treated as "no sidecar", because a
+///   budget derived from a half-read probe can be SHORT, and short halts the
+///   board. The leaf keeps the crate defaults, which are large rather than wrong.
+fn render_leaf_env_sidecar(leaf: &Path) -> Option<String> {
+    use crate::{
+        entity_inventory::Derivation,
+        leaf_entity_env::{inventory_for_leaf, render_env_sidecar},
+    };
+
+    let (inv, unprobeable) = match inventory_for_leaf(leaf) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "sync: {}: cannot derive pool budgets ({e}); leaving the crate defaults in place",
+                leaf.display()
+            );
+            return None;
+        }
+    };
+    if inv.is_empty() {
+        // An unprobeable component is why a leaf can have `metadata/` and still
+        // get no budget. Say so once rather than leaving it to be inferred from
+        // an absent file (issue 1061).
+        if !unprobeable.is_empty() {
+            eprintln!(
+                "sync: {}: {} component(s) are un-probeable, so pool budgets stay at the crate \
+                 defaults (issue 1061): {}",
+                leaf.display(),
+                unprobeable.len(),
+                unprobeable.join(", ")
+            );
+        }
+        return None;
+    }
+    match inv.derive() {
+        Derivation::Derived(knobs) => Some(render_env_sidecar(&knobs, &inv.source)),
+        other => {
+            eprintln!(
+                "sync: {}: pool budgets not derived ({}); crate defaults stay",
+                leaf.display(),
+                other.tag()
+            );
+            None
+        }
+    }
 }
 
 /// Issue 0457 — basename of the per-leaf gitignored file holding sync's managed
 /// `[patch.crates-io]` block. Sibling of `config.toml` inside `.cargo/`, reached
 /// by an `include` entry that `render_patch_config` maintains.
 const MANAGED_PATCH_FILE: &str = "nros-managed-patch.toml";
+
+/// Issue 0827 — basename of the per-leaf gitignored file holding sync's derived
+/// pool budgets as `[env]`.
+///
+/// A second sidecar rather than a section in the patch one, because the two
+/// answer different questions and empty independently: a leaf can have a
+/// generated message dep and no probeable component, or the reverse. Sharing a
+/// file would make each one's presence depend on the other's.
+///
+/// Same appear-and-disappear-together rule as [`MANAGED_PATCH_FILE`], and for
+/// the same reason (issue 0463): a missing `include` target is a HARD cargo
+/// error during manifest parse, so the entry exists exactly when the file does.
+const MANAGED_ENV_FILE: &str = "nros-managed-env.toml";
 
 /// Render the standalone managed-patch file: a header saying who owns it and a
 /// single `[patch.crates-io]` table of the managed entries, alphabetised.
@@ -5133,7 +5226,7 @@ fn render_patch_config(
     managed: &[(String, String)],
     include_rel: Option<&str>,
 ) -> Result<String> {
-    render_patch_config_with(existing, managed, include_rel, true)
+    render_patch_config_with(existing, managed, include_rel, true, false)
 }
 
 /// [`render_patch_config`] with the sidecar split made explicit.
@@ -5150,6 +5243,10 @@ fn render_patch_config_with(
     managed: &[(String, String)],
     include_rel: Option<&str>,
     sidecar: bool,
+    // Issue 0827 — whether this leaf gets a derived `[env]` sidecar. Same
+    // appear-and-disappear-together rule as the patch one: the caller decides by
+    // whether it is about to WRITE the file, never by guessing.
+    want_env: bool,
 ) -> Result<String> {
     use toml_edit::{DocumentMut, Item, Table, Value, value};
 
@@ -5194,7 +5291,11 @@ fn render_patch_config_with(
             .unwrap_or_default();
         let survivors: Vec<String> = current
             .iter()
-            .filter(|s| !s.ends_with(CENTRAL_PATCH_FILE) && !s.ends_with(MANAGED_PATCH_FILE))
+            .filter(|s| {
+                !s.ends_with(CENTRAL_PATCH_FILE)
+                    && !s.ends_with(MANAGED_PATCH_FILE)
+                    && !s.ends_with(MANAGED_ENV_FILE)
+            })
             .cloned()
             .collect();
         let mut desired: Vec<String> = Vec::new();
@@ -5205,6 +5306,9 @@ fn render_patch_config_with(
         let want_sidecar = sidecar && managed.iter().any(|(_, rel)| is_generated_path(rel));
         if want_sidecar {
             desired.push(MANAGED_PATCH_FILE.to_string());
+        }
+        if want_env {
+            desired.push(MANAGED_ENV_FILE.to_string());
         }
 
         if current != desired {
@@ -5218,7 +5322,11 @@ fn render_patch_config_with(
                 .ok_or_else(|| eyre!("sync: `include` is not an array"))?;
             arr.retain(|v| {
                 v.as_str()
-                    .map(|s| !s.ends_with(CENTRAL_PATCH_FILE) && !s.ends_with(MANAGED_PATCH_FILE))
+                    .map(|s| {
+                        !s.ends_with(CENTRAL_PATCH_FILE)
+                            && !s.ends_with(MANAGED_PATCH_FILE)
+                            && !s.ends_with(MANAGED_ENV_FILE)
+                    })
                     .unwrap_or(true)
             });
             if let Some(rel) = include_rel {
@@ -5247,6 +5355,10 @@ fn render_patch_config_with(
             // "run `nros sync`" before cargo says anything at all.
             if want_sidecar {
                 arr.push(MANAGED_PATCH_FILE);
+            }
+            // Issue 0827 — the derived `[env]` sidecar, on the same terms.
+            if want_env {
+                arr.push(MANAGED_ENV_FILE);
             }
             if arr.is_empty() {
                 doc.as_table_mut().remove("include");
@@ -6672,18 +6784,28 @@ libc = { path = \"../../third-party/nuttx/libc\" }\n";
         // identical. Both spellings are therefore stable, and the old
         // tight/spaced distinction is moot.
         let spaced_single = "include = [ \"../nros-patch.toml\"]\n";
-        let only_managed =
-            render_patch_config_with(spaced_single, &mng(&[]), Some("../nros-patch.toml"), false)
-                .unwrap();
+        let only_managed = render_patch_config_with(
+            spaced_single,
+            &mng(&[]),
+            Some("../nros-patch.toml"),
+            false,
+            false,
+        )
+        .unwrap();
         assert!(
             only_managed.starts_with(spaced_single.trim_end()),
             "membership unchanged: sync must not renormalise the spelling:\n{only_managed}"
         );
 
         let spaced_pair = "include = [ \"../nros-patch.toml\", \"nros-board.toml\"]\n";
-        let with_survivor =
-            render_patch_config_with(spaced_pair, &mng(&[]), Some("../nros-patch.toml"), false)
-                .unwrap();
+        let with_survivor = render_patch_config_with(
+            spaced_pair,
+            &mng(&[]),
+            Some("../nros-patch.toml"),
+            false,
+            false,
+        )
+        .unwrap();
         assert!(
             with_survivor.starts_with(spaced_pair.trim_end()),
             "a survivor keeps the array's decor, so this leaf never churns:\n{with_survivor}"
@@ -6698,7 +6820,8 @@ libc = { path = \"../../third-party/nuttx/libc\" }\n";
         // output). Membership is unchanged here, so the bytes must be too.
         let tight = "include = [\"../nros-patch.toml\", \"nros-board.toml\"]\n";
         let unchanged =
-            render_patch_config_with(tight, &mng(&[]), Some("../nros-patch.toml"), false).unwrap();
+            render_patch_config_with(tight, &mng(&[]), Some("../nros-patch.toml"), false, false)
+                .unwrap();
         assert!(
             unchanged.starts_with(tight.trim_end()),
             "membership unchanged, so the array must be byte-identical:\n  was: {tight}  now: {unchanged}"
@@ -6729,6 +6852,7 @@ libc = { path = \"../../third-party/nuttx/libc\" }\n";
             existing,
             &mng(&[("nros-core", "../nros-core")]),
             None,
+            false,
             false,
         )
         .unwrap();
@@ -7079,6 +7203,7 @@ rustflags = [
             &[("std_msgs".into(), "generated/std_msgs".into())],
             Some("../../nros-patch.toml"),
             true,
+            false,
         )
         .unwrap();
         let inc = includes(&after_patch);
@@ -7623,5 +7748,68 @@ mod search_path_tests {
             text.contains("MISSING — nothing scanned"),
             "a configured root that contributed nothing must say so:\n{text}"
         );
+    }
+
+    // ---- issue 0827: the derived `[env]` sidecar ----------------------------
+
+    /// The include entry appears ONLY when the file will be written. A missing
+    /// include target is a hard cargo error during manifest parse (issue 0463),
+    /// so "wanted" and "written" are one decision, not two.
+    #[test]
+    fn env_sidecar_include_is_added_only_when_wanted() {
+        let with = render_patch_config_with("", &[], None, true, true).unwrap();
+        assert!(
+            with.contains(MANAGED_ENV_FILE),
+            "include missing the env sidecar:\n{with}"
+        );
+        let without = render_patch_config_with("", &[], None, true, false).unwrap();
+        assert!(
+            !without.contains(MANAGED_ENV_FILE),
+            "include names a file that will not be written:\n{without}"
+        );
+    }
+
+    /// And it is EVICTED when no longer wanted, so a leaf that loses its
+    /// probeable component does not keep an include to a deleted file.
+    #[test]
+    fn env_sidecar_include_is_evicted_when_no_longer_wanted() {
+        let existing = format!("include = [\"{MANAGED_ENV_FILE}\"]\n");
+        let out = render_patch_config_with(&existing, &[], None, true, false).unwrap();
+        assert!(
+            !out.contains(MANAGED_ENV_FILE),
+            "stale include survived:\n{out}"
+        );
+    }
+
+    /// The two sidecars are independent: a leaf may want either, both or
+    /// neither, which is why they are separate files.
+    #[test]
+    fn the_two_sidecars_do_not_depend_on_each_other() {
+        // Built inline rather than via the `mng` helper: these tests live in a
+        // different test module, and reaching across for a two-line helper
+        // would couple them for no benefit.
+        let generated: Vec<(String, String)> =
+            vec![("std_msgs".to_string(), "generated/std_msgs".to_string())];
+        let both = render_patch_config_with("", &generated, None, true, true).unwrap();
+        assert!(
+            both.contains(MANAGED_PATCH_FILE) && both.contains(MANAGED_ENV_FILE),
+            "{both}"
+        );
+
+        let env_only = render_patch_config_with("", &[], None, true, true).unwrap();
+        assert!(!env_only.contains(MANAGED_PATCH_FILE), "{env_only}");
+        assert!(env_only.contains(MANAGED_ENV_FILE), "{env_only}");
+
+        let patch_only = render_patch_config_with("", &generated, None, true, false).unwrap();
+        assert!(patch_only.contains(MANAGED_PATCH_FILE), "{patch_only}");
+        assert!(!patch_only.contains(MANAGED_ENV_FILE), "{patch_only}");
+    }
+
+    /// An OUT-OF-TREE consumer gets no include at all (#272), so it must not
+    /// gain an env one either.
+    #[test]
+    fn an_external_consumer_gets_no_env_include() {
+        let out = render_patch_config_with("", &[], None, false, false).unwrap();
+        assert!(!out.contains(MANAGED_ENV_FILE), "{out}");
     }
 }


### PR DESCRIPTION
Stacks on #519 (0827's wiring), which is what makes this measurable.

#0900 closed with: *"Not measured here: an end-to-end image build showing the stack reservation shrink … no image in the tree currently derives a non-default value, so that measurement needs an image built through the CMake seam."*

No longer true, and it didn't need the CMake seam. 0827's derivation makes `nros sync` write `NROS_EXECUTOR_ACTION_CLIENTS` and `NROS_EXECUTOR_MAX_CBS` per leaf, so in-tree cargo leaves now derive non-default values and the constant can be read from a **real** build.

## Measured — same host, tree, profile; sidecar present vs absent

Read from `nros-node`'s generated `nros_node_config.rs`:

| leaf | | `MAX_CBS` | `ARENA_SIZE` |
|---|---|---:|---:|
| `native/rust/talker` | stock | 4 | 74,240 |
| | derived | 1 | **8,192** |
| | **saved** | | **66,048 (64.5 KiB)** |
| `native/rust/action-client` | stock | 4 | 74,240 |
| | derived | 1 | **20,096** |
| | **saved** | | **54,144 (52.9 KiB)** |

**Both beat this issue's own prediction**, and the reason matters: the 56.5 KiB / 43,392 B figures were measured with `MAX_CBS` pinned at 4 and only `ACTION_CLIENTS` varied. A derived image moves **both**, and they compound.

## The action-client row settles the argument

An image that genuinely *has* an action client — the case the worst-case default was chosen to protect — still recovers **52.9 KiB**, because the default budgets all four slots at action-client size when exactly one needs it. The default wasn't conservative for that image; it was **wrong by 52 KiB**.

## What that does to the three options

**Option 1** ("declare client-side entities … costs a schema addition, a resolver change and a migration for every existing model") is delivered for probeable leaves at **none** of those costs — the probe already records `action_clients`, so nothing new is declared and no model migrates.

**Option 3**'s gate stays the backstop. **Option 2** (flipping the default) isn't needed where the derivation runs.

## Where it doesn't run

A `.json.unprobeable` leaf keeps the worst-case default — correct, and **loud** rather than silent, since sync now says so. That set is #1061.

Resolves #0900. `just check fast` 224/224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)