### PR TITLE
fix(#1036): the boot record's tests ran in no lane, and nothing tested the link

### DIFF
--- a/docs/issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md
+++ b/docs/issues/1036-arena-exhaustion-is-half-silent-and-wholly-unreachable.md
@@ -92,3 +92,53 @@ the defect it was built to find.
 `report_arena_headroom` are two of an unknown number of diagnostics that assume
 a sink. Nothing has enumerated which other `nros_log` call sites are reachable
 only on a target that cannot carry one.
+
+## 2026-09-05 — the "unit-tested on the host" claim was not true either
+
+This issue's resolution rests on the record being verified on the host, with the
+silicon path left open. Measured today: **no lane sets `NROS_BOOT_REPORT`.**
+`git grep` over `just/`, `justfile` and `.github/` finds it only in
+`config-knob-census.py` and in `read-boot-report.py`'s own usage text. The cfg
+is set from an env var, so unlike a cargo feature it cannot even arrive by
+`--workspace` unification — every test in `boot_report::tests` had run zero
+times in CI.
+
+Same defect class as `sim-time` (phase-425) and the `env` tests (issue 0687),
+and `check node-std-tests` exists precisely for it. Both now run there.
+
+### And the gap that mattered was one layer further in
+
+Those unit tests exercise the RECORD — layout, magic, monotonic stage. Nothing
+exercised the LINK: that the allocator, on failing, actually writes the number
+an operator would dump. That link is the whole instrument. On the board this was
+built for the console UART is not wired, so the record is the only channel, and
+a record nobody writes to is indistinguishable from the silence it replaced.
+
+`executor::tests::arena_exhaustion_reaches_the_boot_record` closes it, through
+`arena_alloc_with_trailing` specifically — the half that was silent, and the
+half carrying every buffered subscription and every action entry. It asserts
+four things: the failure is recorded at all, the SHORTFALL is non-zero (that is
+the actionable number, not a flag), the shortfall is a plausible difference
+rather than an arbitrary value, and a SECOND failure does not overwrite the
+first — the allocation that explains the boot must survive later incidental
+ones.
+
+Mutation-checked: deleting the `note_alloc_failed` call from the `_with_trailing`
+path fails the test.
+
+### One thing the writing of it found
+
+The test cannot share a process with `boot_report::tests`. The record is a
+process-global static keeping only the first failure, and that module has a
+`note_alloc_failed(100, 8)` case — with both in one binary the link test read
+`(100, 8)` and its "nothing recorded before me" precondition fired. It is two
+cargo invocations for that reason, stated in the recipe.
+
+### STILL open, and unchanged
+
+No cell exercises the TARGET-side path: an image with
+`CONFIG_NROS_BOOT_REPORT=y`, an arena exhausted on purpose, a dump read back
+with the decoder. That needs a Zephyr SDK, and the host this was written on has
+none — the same wall issue 1075 hit today. What has moved is that the host side
+is now genuinely verified rather than nominally: the record is written by the
+real allocator on the real failure path, and a lane runs it.

--- a/just/check.just
+++ b/just/check.just
@@ -672,6 +672,23 @@ node-std-tests:
     # tests need the store — and `Executor::declare_parameter`, the seam W3b
     # hooks, lives in a `#[cfg(feature = "param-services")]` impl block.
     cargo test -p nros-node --lib --features std,sim-time,param-services --quiet
+    # Issue 1036 — the boot self-report, third entry and the same defect class.
+    # `boot_report` is behind a BUILD-TIME cfg set from an env var
+    # (`NROS_BOOT_REPORT=1`, Zephyr `CONFIG_NROS_BOOT_REPORT=y`), and nothing in
+    # `just` or `.github/` set it, so every test in `boot_report::tests` — the
+    # ones issue 1036's resolution calls "unit-tested on the host" — had never
+    # run. An env-var cfg is worse than a cargo feature here: `--workspace`
+    # cannot even unify it in by accident.
+    #
+    # TWO INVOCATIONS, and that is not tidiness. The record is a process-global
+    # static keeping only the FIRST allocation failure; `boot_report::tests` has
+    # a `note_alloc_failed(100, 8)` case, and the link test asserts the record
+    # is untouched before it writes. Sharing a binary means sharing a process
+    # and the link test reads the other's numbers — measured, it failed with
+    # `(100, 8)`. Two cargo invocations are two processes.
+    NROS_BOOT_REPORT=1 cargo test -p nros-node --lib --features std --quiet boot_report::tests
+    NROS_BOOT_REPORT=1 cargo test -p nros-node --lib --features std --quiet -- \
+        --exact executor::tests::arena_exhaustion_reaches_the_boot_record
     # `env,std` and NOT `rmw-cffi`: the cffi flavour makes the wall clock an
     # extern the linker wants a platform port for, and this lane links none.
     cargo test -p nros --lib --features env,std --quiet
@@ -681,7 +698,7 @@ node-std-tests:
     # linked; without the combination the test is in no lane at all, which is how
     # the `not(std)` gate on `platform_wall_clock` survived unnoticed.
     cargo test -p nros-core --lib --no-default-features --features std,platform-clock --quiet
-    echo "non-default-feature unit tests passed (nros-node std, nros env, nros-core clock)!"
+    echo "non-default-feature unit tests passed (nros-node std + boot-report, nros env, nros-core clock)!"
 
 # Issue 0652 — the `required-features` targets that were in NO lane.
 #

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -1905,6 +1905,94 @@ fn a_non_bool_use_sim_time_attaches_nothing() {
     );
 }
 
+/// Issue 1036 — arena exhaustion must REACH the boot record, not merely return
+/// an error.
+///
+/// The issue's own resolution rests on the record being "unit-tested on the
+/// host". Those tests exercise the RECORD (`boot_report::tests` — layout,
+/// magic, monotonic stage). Nothing tested the LINK: that the allocator, on
+/// failing, actually writes the number an operator would dump. That link is the
+/// whole instrument — on the board this was written for, the console UART is
+/// not wired, so the record is the only channel, and a record nobody writes to
+/// is indistinguishable from the silence it was built to replace.
+///
+/// `arena_alloc_with_trailing` specifically, because that is the half that was
+/// silent (issue 0900 fixed the sibling and left this one), and it is the half
+/// carrying every buffered subscription and every action entry — what an island
+/// image actually allocates.
+///
+/// The record is a process-global static and only the FIRST failure is kept
+/// (`compare_exchange` from 0), so this test must be the ONLY one in its
+/// process that records a failure. It is not named `boot_report*` for exactly
+/// that reason: `boot_report::tests` has its own `note_alloc_failed(100, 8)`
+/// case, and a shared filter put both in one binary — measured, this assertion
+/// caught it reading `(100, 8)`. `just check boot-report-tests` runs the two
+/// groups as SEPARATE cargo invocations, which is two processes and therefore
+/// two records.
+#[cfg(nros_boot_report)]
+#[test]
+fn arena_exhaustion_reaches_the_boot_record() {
+    let session = MockSession::new();
+    let mut executor: Executor = executor_with_clock(session);
+
+    // Untouched to start with, which is also the assertion that nothing else in
+    // this run got here first — if it fails, the filter let a sibling in and
+    // every number below would be that sibling's.
+    let before = crate::boot_report::snapshot();
+    assert_eq!(
+        (before.failed_alloc_size, before.failed_alloc_shortfall),
+        (0, 0),
+        "another test recorded an allocation failure before this one; the \
+         record keeps only the FIRST, so this run cannot attribute it"
+    );
+
+    // One byte more than the arena can hold, asked for through the path that
+    // used to say nothing.
+    let capacity = executor.arena.len();
+    let ask = capacity + 1;
+    let err = executor
+        .arena_alloc_with_trailing::<u8>(ask)
+        .expect_err("an allocation larger than the whole arena must fail");
+    assert!(
+        matches!(err, NodeError::BufferTooSmall),
+        "unexpected error for an over-large arena request: {err:?}"
+    );
+
+    let after = crate::boot_report::snapshot();
+    assert!(
+        after.failed_alloc_size > 0,
+        "the arena refused an allocation and the boot record says nothing. On a \
+         board with no console this record is the ONLY channel, so a zero here \
+         is the original defect with an instrument bolted on."
+    );
+    // The SHORTFALL is the number an operator adds to the knob, so it has to be
+    // the real difference rather than a flag that something failed.
+    assert!(
+        after.failed_alloc_shortfall > 0,
+        "size recorded but shortfall zero: the record names a failure without \
+         naming what would fix it, and the shortfall is the actionable half"
+    );
+    assert!(
+        u64::from(after.failed_alloc_shortfall) <= ask as u64,
+        "shortfall {} exceeds the request {ask}, which cannot be a difference \
+         against a non-negative capacity",
+        after.failed_alloc_shortfall
+    );
+
+    // And the record must survive a SECOND failure unchanged: the first
+    // allocation to fail is the one that explains the boot, and a later,
+    // larger, incidental failure overwriting it would replace the cause with a
+    // symptom.
+    let _ = executor.arena_alloc_with_trailing::<u8>(ask * 4);
+    let again = crate::boot_report::snapshot();
+    assert_eq!(
+        (again.failed_alloc_size, again.failed_alloc_shortfall),
+        (after.failed_alloc_size, after.failed_alloc_shortfall),
+        "a second failure overwrote the first; the record must keep the \
+         allocation that explains the boot, not the last one to be attempted"
+    );
+}
+
 #[test]
 fn test_timer_repeats() {
     let session = MockSession::new();


### PR DESCRIPTION
Two findings, and the first undermines the issue's own resolution.

## `NROS_BOOT_REPORT` is set by no lane

`git grep` over `just/`, `justfile` and `.github/` finds it only in the knob census and in `read-boot-report.py`'s usage text. The cfg comes from an **env var**, so unlike a cargo feature it cannot even arrive by `--workspace` unification — every test in `boot_report::tests`, the ones this issue calls *"unit-tested on the host"*, had run **zero times**.

Same class as `sim-time` (phase-425) and the `env` tests (0687). `check node-std-tests` exists for exactly this; third entry, same recipe.

## The gap that mattered was one layer further in

Those tests exercise the **record** — layout, magic, monotonic stage. Nothing exercised the **link**: that the allocator, on failing, writes the number an operator would dump.

That link is the whole instrument. On the board this was built for the console UART is not wired, so the record is the only channel — and a record nobody writes to is indistinguishable from the silence it was built to replace.

`arena_exhaustion_reaches_the_boot_record` closes it, through `arena_alloc_with_trailing` specifically: the half that was silent until phase-412, and the half carrying every buffered subscription and every action entry. Four assertions:

1. the failure is recorded at all;
2. the **shortfall** is non-zero — that is the actionable number, not a flag;
3. it is a plausible difference rather than an arbitrary value;
4. a **second** failure does not overwrite the first, because the allocation that explains the boot must survive later incidental ones.

Mutation-checked: deleting the `note_alloc_failed` call from that path fails the test.

## Two cargo invocations, found by writing it

The record is a process-global static keeping only the first failure, and `boot_report::tests` has its own `note_alloc_failed(100, 8)` case. In one binary the link test read `(100, 8)` and its "nothing recorded before me" precondition fired. Two invocations are two processes.

## Placement, after getting it wrong twice

A standalone gate landed in the **fast** lane by derivation — wrong, it compiles. Moving it to `build-serial` tripped `check-gate-visibility`'s ratchet, which may only shrink. It belongs inside `node-std-tests`, whose docstring already describes this defect class: no new gate, no ratchet change, one home for the class.

## Still open, unchanged

No cell exercises the **target** path — an image with `CONFIG_NROS_BOOT_REPORT=y`, an arena exhausted on purpose, a dump read back with the decoder. That needs a Zephyr SDK this host does not have, the same wall #1075 hit today. What moved is that the host side is verified rather than nominal: the record is written by the real allocator on the real failure path, and a lane runs it.

`just check fast` 227/227 · `node-std-tests` green · `gate-visibility` unchanged at 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP