### PR TITLE
fix(#1100): two nros-c units in one image, because two hand-built feature strings disagree

### DIFF
--- a/docs/issues/archived/1100-nros-c-feature-variants-share-one-header.md
+++ b/docs/issues/archived/1100-nros-c-feature-variants-share-one-header.md
@@ -2,7 +2,7 @@
 id: 1100
 title: "Two feature variants of `nros-c` in one build dir write the same
   generated header, and the writer guarantees a second build script run"
-status: open
+status: resolved
 type: bug
 area: build
 related: [issue-0528, issue-0475, rfc-0044]
@@ -112,3 +112,62 @@ Worth deciding separately whether a build that has just succeeded should be
 immediately dirty again. Even with one variant, the `rerun-if-changed` on a
 written byproduct means every second build re-runs these scripts; that is
 cheap when it agrees, but it is what turns this defect from latent into fatal.
+
+## Root cause, located 2026-09-05 — and the split is NOT deliberate
+
+This issue asked whether the two variants are intentional ("needs someone who
+knows which consumer is which"). They are not, and the file says so itself.
+
+`zephyr/CMakeLists.txt` builds two hand-written feature strings:
+
+| string | line | nros-c-relevant features |
+| --- | --- | --- |
+| `_nros_features` (the C-API `nros-c` build) | 305/313/323 | `rmw-cffi, cffi-*, platform-zephyr, ros-humble` (+`std`, +trace) |
+| `_nros_cpp_features` (the `nros-cpp` build) | 536/554/573 | the same **plus `alloc`** (554, 573) and **plus `param-services`** (593, under `param_services IN_LIST NANO_ROS_FEATURES`) |
+
+`nros-cpp`'s manifest forwards both: `alloc = [... "nros-c/alloc" ...]` and
+`param-services = ["rmw-cffi", "nros-c/param-services"]`. So in a mixed C + C++
+image cargo resolves TWO `nros-c` units, which is exactly the pair the issue
+observed — `alloc_..._param_services_...` against
+`critical_section_..._platform_...`.
+
+**The rule was already written down, two hundred lines below.** The
+`_nros_c_for_cpp_features` block (the inverse case, C++-only images) says:
+
+> both archives are linked into this image from one nros-node dep graph, and a
+> feature that reaches only one of them splits the unit.
+
+It was stated for `trace-callbacks` and applied only there.
+
+## Fix
+
+`_nros_features` now appends `,alloc` — and `,param-services` under the same
+`NANO_ROS_FEATURES` condition the C++ string uses — **when
+`CONFIG_NROS_CPP_API` is set**.
+
+Conditional on purpose. A C-ONLY image has no second unit to agree with, and
+adding `alloc` there would change what it links for nothing. Where both APIs are
+on, the image already contains the alloc-enabled `nros-node` through `nros-cpp`,
+so unifying removes a duplicate rather than adding a capability — the archive
+should get smaller, not larger.
+
+## NOT VERIFIED against a Zephyr build
+
+No Zephyr SDK is provisioned on the host this was written on, so the
+double-build reproduction was not run and the fix was not exercised. What backs
+it is static: the two feature strings and their line numbers, `nros-cpp`'s
+forwarding in its manifest, the two `NROS_CONFIG_VARIANT` values in this
+issue's own diff, and the fact that they differ by exactly `alloc` +
+`param_services`.
+
+**The acceptance is the reproduction in this issue**: build a mixed C + C++
+Zephyr image, then build again in the same directory. It should now succeed.
+
+## Left alone, and worth a decision of its own
+
+The issue's closing paragraph: `write_header_if_absent_or_verify` declares the
+header it writes as its own `rerun-if-changed` input, so every second build
+re-runs both scripts. That is what turned this from latent into fatal, and it is
+unchanged here — with one variant it is cheap and correct (it is what makes the
+absent-header self-heal reachable, issue 0834). Making a just-succeeded build
+not immediately dirty is a separate question from making the two halves agree.

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -331,6 +331,37 @@ if(CONFIG_NROS_C_API)
     # phase-8 W4 — callback tracing (see `_nros_trace_suffix` above).
     string(APPEND _nros_features "${_nros_trace_suffix}")
 
+    # Issue 1100 — the nros-c features nros-cpp FORWARDS must be on this string
+    # too, or the image carries TWO nros-c units.
+    #
+    # `nros-cpp`'s manifest forwards `alloc -> nros-c/alloc` and
+    # `param-services -> nros-c/param-services`, and `_nros_cpp_features` below
+    # sets both (`,alloc` unconditionally, `,param-services` under
+    # `param_services IN_LIST NANO_ROS_FEATURES`). This string set neither. In a
+    # mixed C + C++ image cargo therefore built nros-c twice, with different
+    # `EXECUTOR_SIZE`, and both build scripts write the SAME shared
+    # `nros-c-generated/nros/nros_config_generated.h`. The first build wins; the
+    # second aborts with "written by another crate with DIFFERENT probed sizes"
+    # — so a mixed image builds exactly once and every rebuild fails, including
+    # the one `west build --target run` performs.
+    #
+    # This is the rule the `_nros_c_for_cpp_features` block below already states
+    # for the inverse case: "a feature that reaches only one of them splits the
+    # unit". It was stated for `trace-callbacks` and not applied to `alloc` or
+    # `param-services`.
+    #
+    # Conditional on the C++ API being on, deliberately: a C-ONLY image has no
+    # second unit to agree with, and adding `alloc` there would change what it
+    # links for nothing. Where both are on, the image already contains the
+    # alloc-enabled nros-node through nros-cpp — unifying removes a duplicate
+    # rather than adding a capability.
+    if(CONFIG_NROS_CPP_API)
+        string(APPEND _nros_features ",alloc")
+        if("param_services" IN_LIST NANO_ROS_FEATURES)
+            string(APPEND _nros_features ",param-services")
+        endif()
+    endif()
+
     # Build nros-c static library via Cargo
     nros_cargo_build(
         PACKAGE nros-c


### PR DESCRIPTION
Closes #1100. A mixed C + C++ Zephyr image builds exactly once; every rebuild — including the one `west build --target run` performs — dies on *"written by another crate with DIFFERENT probed sizes"*, with the same rlib, same mtime, same size on both sides. The guard is right: two `nros-c` units really do resolve different layouts.

## The split is not deliberate, and the file says so itself

The issue asked whether it was ("needs someone who knows which consumer is which"). `zephyr/CMakeLists.txt` hand-builds two feature strings:

| string | line | nros-c-relevant features |
| --- | --- | --- |
| `_nros_features` (C-API `nros-c`) | 305/313/323 | `rmw-cffi, cffi-*, platform-zephyr, ros-humble` (+`std`, +trace) |
| `_nros_cpp_features` (`nros-cpp`) | 536/554/573 | the same **plus `alloc`**, **plus `param-services`** (593) |

`nros-cpp` forwards both — `alloc = [… "nros-c/alloc" …]`, `param-services = ["rmw-cffi", "nros-c/param-services"]` — so cargo resolves two units. That is exactly the pair in the issue's own diff, differing by `alloc` and `param_services`. Both build scripts write the same shared `nros_config_generated.h`, and the second one loses.

**The rule was already written down two hundred lines below.** The `_nros_c_for_cpp_features` block, covering the inverse C++-only case, says:

> both archives are linked into this image from one nros-node dep graph, and a feature that reaches only one of them splits the unit.

Stated for `trace-callbacks`, applied only there.

## Fix

`_nros_features` appends `,alloc`, and `,param-services` under the same `NANO_ROS_FEATURES` condition the C++ string uses, **when `CONFIG_NROS_CPP_API` is set**.

Conditional deliberately: a C-only image has no second unit to agree with, and adding `alloc` there would change what it links for nothing. Where both APIs are on, the image already carries the alloc-enabled `nros-node` through `nros-cpp` — unifying removes a duplicate rather than adding a capability, so the archive should get *smaller*.

## Not verified against a Zephyr build

No Zephyr SDK on this host, so the double-build reproduction was not run and the fix was not exercised. What backs it is static: the two strings with line numbers, `nros-cpp`'s forwarding in its manifest, and the issue's two `NROS_CONFIG_VARIANT` values differing by exactly those two features.

**The acceptance is the issue's own reproduction** — build a mixed C + C++ image, then build again in the same directory. Worth a reviewer with a Zephyr tree before this is trusted.

## Left alone

`write_header_if_absent_or_verify` declares the header it writes as its own `rerun-if-changed` input, so every second build re-runs both scripts. That is what turned this from latent into fatal — but with one variant it is cheap and correct, and it is what makes the absent-header self-heal reachable (issue 0834). Making a just-succeeded build not immediately dirty is a separate question from making the two halves agree.

`just check fast` 227/227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP