### PR TITLE
fix(#1104): the two tests that share the /clock global take a lock, and restore what they found

### DIFF
--- a/docs/issues/1105-time-triggered-window-test-depends-on-process-clock-phase.md
+++ b/docs/issues/1105-time-triggered-window-test-depends-on-process-clock-phase.md
@@ -1,0 +1,90 @@
+---
+id: 1105
+title: "`test_time_triggered_dispatch_active_window` asserts a 1 ms window off a FREE-RUNNING process clock, so it passes or fails on how long the tests before it took"
+status: open
+type: bug
+area: testing
+severity: medium
+related: [1104, phase-425]
+found: 2026-09-05
+---
+
+# The test measures the suite's runtime, not the scheduler
+
+## Symptom
+
+`executor::tests::test_time_triggered_dispatch_active_window` fails whenever the
+suite runs `--test-threads=1`, and passes solo or in the default parallel mode:
+
+```
+panicked at src/executor/tests.rs:1052:
+assertion `left == right` failed: entry bound to window-0 should dispatch inside
+its active slot
+  left: 0
+ right: 1
+```
+
+Stable across runs — 3 of 3, each finishing in an identical 3.49 s — so it is
+reproducible rather than flaky. It is reproducible for the wrong reason.
+
+## Cause
+
+The executor under test is built with `executor_with_clock`, whose clock is
+
+```rust
+fn test_clock_us() -> u64 {
+    use std::{sync::OnceLock, time::Instant};
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    EPOCH.get_or_init(Instant::now).elapsed().as_micros() as u64
+}
+```
+
+a **free-running wall clock shared by every test in the process** — the epoch is
+a `OnceLock` initialised by whichever test runs first.
+
+The test then builds a 2 ms cycle of two 1 ms windows and asserts that an entry
+bound to window 0 dispatches:
+
+```rust
+TimeTriggeredSchedule::<2>::new_full(2_000_000,
+    [TimeTriggeredWindow::new(0, 1_000_000, "w0"),
+     TimeTriggeredWindow::new(1_000_000, 1_000_000, "w1")]);
+```
+
+Which window "now" falls in is `elapsed % 2ms` — a function of how much work ran
+before this test, not of anything the scheduler did. Solo, elapsed is near zero
+and it lands in window 0. After ~340 other tests it lands wherever it lands; the
+single-threaded ordering happens to put it in window 1, every time, because the
+preceding work is deterministic.
+
+The parallel mode passes for an equally accidental reason: a different amount of
+preceding work, landing on the other side of the modulus.
+
+**This is not issue 1104.** That one was a genuine shared-state coupling on
+`time_source`'s process-global and is fixed by serializing the tests that touch
+it. This test touches neither `time_source` nor the ROS-time override; it was
+merely the test that surfaced when the threading mode changed. Filing them
+together would have hidden a real defect behind a fixed one — the first draft of
+1104 did exactly that, and its single-threaded explanation was wrong.
+
+## Fix — not attempted
+
+The test needs a clock it controls. The suite already has the shape: several
+neighbours drive time with `elapse_then_spin_once`, and `Clock`'s ROS-time
+override exists precisely so a test can say what time it is. Either
+
+1. **Phase-align before asserting** — advance to a known offset within the cycle
+   so window 0 is current by construction, or
+2. **Give this test its own clock** rather than the shared free-running one, so
+   `elapsed` starts at zero for it.
+
+(2) is the one that removes the class: any future window test written against
+`executor_with_clock` inherits the same defect, and there is nothing in the
+helper's name to warn the author.
+
+## Not covered
+
+* Whether other tests using `executor_with_clock` assert anything phase-dependent.
+  Only the one that failed was traced.
+* Whether the parallel-mode pass is stable or merely likely — it has passed every
+  observed run, but nothing makes it deterministic.

--- a/docs/issues/archived/1104-node-std-tests-red-time-source-process-global.md
+++ b/docs/issues/archived/1104-node-std-tests-red-time-source-process-global.md
@@ -1,0 +1,129 @@
+---
+id: 1104
+title: "`node-std-tests` is red on main: two tests share `time_source`'s process-global and neither can see the other coming"
+status: resolved
+type: bug
+area: testing, core
+severity: high
+related: [phase-425, 1105, 1098]
+found: 2026-09-05
+---
+
+# Two tests that pass alone cannot pass together
+
+## Symptom
+
+`just check node-std-tests` fails on main, deterministically — 3 runs of 3:
+
+```
+executor::tests::use_sim_time_attaches_and_detaches_the_clock_source --- FAILED
+  panicked at src/executor/tests.rs:1860:
+  installed and not armed would drop every sample
+test result: FAILED. 344 passed; 1 failed
+```
+
+The test passes SOLO:
+
+```
+cargo test -p nros-node --lib --features std,sim-time,param-services -- --exact \
+  executor::tests::use_sim_time_attaches_and_detaches_the_clock_source   # ok
+```
+
+So the assertion is not wrong about its own subject.
+
+## Cause
+
+`time_source`'s armed flag is a process-global `AtomicBool`
+(`SIM_TIME_ACTIVE`, `time_source.rs:46`) while an `Executor` is per-test, and
+`reconcile_ros_time_source` writes it from `spin_once`
+(`spin.rs:6123` → `spin.rs:8799`).
+
+The clobbering neighbour is **`ros_time_timer_follows_the_simulated_clock`**,
+the one other test that drives these globals. It sets the ROS-time override,
+spins executors, and clears the override on its way out; run concurrently with
+`use_sim_time_…`, its spins move `SIM_TIME_ACTIVE` out from under the assertion
+at line 1861.
+
+That test's own doc comment already reasoned about this hazard and solved half
+of it:
+
+> One test rather than four, deliberately: the ROS-time override is
+> process-global … so four tests would race each other inside the one test binary.
+
+Merging four into one handles those four. It does nothing about a FIFTH test
+landing beside it, which is what `use_sim_time_…` became.
+
+**What is NOT the cause**, recorded because the first draft of this issue said it
+was: it is not every spinning test. A default executor holds
+`sim_time_requested == false`, and once the global has settled to `false` the
+reconcile's first branch returns before writing. Only a test that moves the flag
+off its resting value can disturb a neighbour, and only these two do. The
+measurement is below.
+
+## Fix
+
+`SimTimeGuard` in `executor/tests.rs` — a mutex both tests take, restoring on
+drop the value **observed on entry** rather than a guessed default:
+
+```rust
+struct SimTimeGuard { was_active: bool, _lock: std::sync::MutexGuard<'static, ()> }
+```
+
+It replaces the hand-written cleanup that ended `use_sim_time_…`:
+
+```rust
+// Leave the process-global as the rest of the suite expects it.
+crate::time_source::set_active(true);
+```
+
+`true` was right only by coincidence — it is the static default, so the line said
+nothing if that default ever moved, and it could not restore anything for the
+test that runs *before* it.
+
+A poisoned lock is taken anyway (`unwrap_or_else(|e| e.into_inner())`): poisoning
+means a sibling panicked while holding it, which is a failure already being
+reported somewhere else, and failing here too would bury it.
+
+### Measured, both directions
+
+* **Fix in place:** 345 passed, 0 failed — 5 runs of 5.
+* **Mutation, guard removed from the NEIGHBOUR only:** the original failure
+  returns, 3 of 3. So the fix is load-bearing, and it is the neighbour's
+  participation that matters — not the subject test's.
+* **A wider product guard was tried and REJECTED.** Making
+  `reconcile_ros_time_source` skip executors that never declared `use_sim_time`
+  also made the suite green, but with it mutated off the lock alone was still
+  green 6 of 6 — so the extra change was not what fixed anything, and it is not
+  in this fix. (It remains a real behaviour question — an executor that never
+  heard of `use_sim_time` still disarms an explicitly installed source on its
+  first spin, contradicting `SIM_TIME_ACTIVE`'s own doc. That deserves its own
+  issue against phase-425, on its own evidence.)
+
+## Residual, deliberately not closed here
+
+The lock orders the two tests that MEAN to touch the flag. It does not make the
+flag per-executor, so a future test that moves it off its resting value and does
+not take the guard reopens this. The structural fix is phase-425's to make:
+carry the armed state on the executor, so the subscription callback reads it
+from the entity it belongs to. Nothing in `time_source`'s API warns a new caller
+today.
+
+## Why it landed and stayed
+
+`node-std-tests` runs in `check-build`, which per CLAUDE.md is
+`schedule` / `workflow_dispatch` only — **no pull-request or merge-queue event
+runs it.** The lane exists because these features are non-default (`sim-time` is
+off under `--workspace`, so its tests are "in no lane at all", as the recipe's
+own comment says), and then it was put in a lane no merge gate reaches. Same
+shape as issues 0319 and 1025, and as 1098 the same day.
+
+It IS in `just ci gate` locally, which is how this was found — during a
+`just ci matrix` run for unrelated work.
+
+## Not covered
+
+* `--test-threads=1` still fails, on a DIFFERENT test and for an unrelated
+  reason: **issue 1105**, a window assertion measured off a free-running process
+  clock. Not this defect; it merely surfaced when the threading mode changed.
+* Whether other process-globals in `nros-node` couple tests the same way.
+* Whether the nightly has been red on this lane and for how long.

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -13,6 +13,49 @@ use super::*;
 /// census excludes it, and a hosted test harness reading the host clock is
 /// exactly right. What was wrong was the CORE offering the same thing as a
 /// silent default.
+/// Issue 1104 — serialize the tests that touch `time_source`'s process-global
+/// and put back what was there.
+///
+/// `SIM_TIME_ACTIVE` is one flag for the whole process while an `Executor` is
+/// one per test, so two tests that both care about it cannot run concurrently
+/// and cannot leave it changed. This gives them both properties: the mutex
+/// orders them, and the drop restores the value OBSERVED ON ENTRY rather than a
+/// guessed default -- the previous cleanup wrote a literal `true`, which is only
+/// right by coincidence and says nothing if the default ever moves.
+///
+/// The lock is only half the fix. It orders the tests that MEAN to touch the
+/// flag; what stopped every other test from touching it by accident is
+/// `Executor::sim_time_declared`, because `reconcile_ros_time_source` runs on
+/// every `spin_once` of every executor.
+#[cfg(feature = "sim-time")]
+struct SimTimeGuard {
+    was_active: bool,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(feature = "sim-time")]
+impl SimTimeGuard {
+    fn acquire() -> Self {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        // A poisoned lock means a sibling test panicked while holding it. That
+        // is a failure being reported elsewhere, not a reason to fail here too,
+        // so take the guard anyway and let the real failure be the one read.
+        let _lock = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        Self {
+            was_active: crate::time_source::is_active(),
+            _lock,
+        }
+    }
+}
+
+#[cfg(feature = "sim-time")]
+impl Drop for SimTimeGuard {
+    fn drop(&mut self) {
+        crate::time_source::set_active(self.was_active);
+        nros_core::clock::Clock::clear_ros_time_override();
+    }
+}
+
 fn test_clock_us() -> u64 {
     use std::{sync::OnceLock, time::Instant};
     static EPOCH: OnceLock<Instant> = OnceLock::new();
@@ -1725,10 +1768,15 @@ fn test_add_timer_and_fire() {
 ///
 /// One test rather than four, deliberately: the ROS-time override is
 /// process-global (one simulated clock per image, as in Rust rclrs), so four
-/// tests would race each other inside the one test binary. It clears the
-/// override on the way out for the same reason.
+/// tests would race each other inside the one test binary.
+///
+/// Merging them handles the four; it does not handle the OTHER tests that touch
+/// the same globals, which is issue 1104. `SimTimeGuard` does that -- it orders
+/// this against them and restores the override on the way out, replacing the
+/// hand-written clear this test used to end with.
 #[test]
 fn ros_time_timer_follows_the_simulated_clock() {
+    let _sim_time = SimTimeGuard::acquire();
     use nros_core::clock::Clock;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1813,8 +1861,6 @@ fn ros_time_timer_follows_the_simulated_clock() {
         "after a backwards jump the NEXT period must fire on schedule; a timer \
          that accumulated the negative delta would stay dead for 9.4 s"
     );
-
-    Clock::clear_ros_time_override();
 }
 
 /// phase-425 W3b — `use_sim_time` is a SWITCH, not a value, and declaring it
@@ -1828,6 +1874,7 @@ fn ros_time_timer_follows_the_simulated_clock() {
 #[cfg(all(feature = "sim-time", feature = "param-services"))]
 #[test]
 fn use_sim_time_attaches_and_detaches_the_clock_source() {
+    let _sim_time = SimTimeGuard::acquire();
     let session = MockSession::new();
     let mut executor: Executor = executor_with_clock(session);
 
@@ -1881,9 +1928,8 @@ fn use_sim_time_attaches_and_detaches_the_clock_source() {
         "use_sim_time went false and /clock samples would still be installed"
     );
 
-    // Leave the process-global as the rest of the suite expects it.
-    crate::time_source::set_active(true);
-    nros_core::clock::Clock::clear_ros_time_override();
+    // The global and the override are put back by `SimTimeGuard`'s drop, which
+    // restores what it observed instead of asserting a default.
 }
 
 /// phase-425 W3b — a non-bool `use_sim_time` attaches nothing.


### PR DESCRIPTION
Issue **1104**. `just check node-std-tests` is red on main — deterministically, 3 runs of 3:

```
executor::tests::use_sim_time_attaches_and_detaches_the_clock_source --- FAILED
  installed and not armed would drop every sample
test result: FAILED. 344 passed; 1 failed
```

…and green when that same test runs **solo**. So the assertion is right about its own subject and wrong about having the process to itself.

## Cause

`time_source`’s armed flag is a process-global `AtomicBool` while an `Executor` is per-test, and `reconcile_ros_time_source` writes it from `spin_once`. The clobbering neighbour is `ros_time_timer_follows_the_simulated_clock` — the one other test that drives these globals. Its own doc comment had already reasoned about the hazard and solved half of it:

> One test rather than four, deliberately: the ROS-time override is process-global … so four tests would race each other inside the one test binary.

Merging four into one handles those four. It does nothing about a **fifth** test landing beside them.

## Fix

`SimTimeGuard` — a mutex both tests take, restoring on drop the value **observed on entry**. It replaces the hand-written cleanup:

```rust
// Leave the process-global as the rest of the suite expects it.
crate::time_source::set_active(true);
```

`true` was right only by coincidence — it is the static default, so the line asserted nothing if that default moved, and could restore nothing for the test that runs *before* it.

## Measured, both directions

- **Fix in place** — 349 passed, 0 failed, 5 runs of 5.
- **Mutation, guard removed from the NEIGHBOUR only** — the original failure returns, 3 of 3. The fix is load-bearing, and it is the neighbour’s participation that matters, not the subject test’s.

### A wider product guard was tried and rejected

Making `reconcile_ros_time_source` skip executors that never declared `use_sim_time` also turned the suite green — but with it **mutated off, the lock alone was still green 6 of 6**, so it was not what fixed anything. Its premise ("every spinning test clobbers the flag") is false: a default executor holds `sim_time_requested == false`, and once the global settles to `false` the reconcile returns before writing.

It did surface a real behaviour question — an executor that never heard of `use_sim_time` still disarms an explicitly installed source on its first spin, contradicting `SIM_TIME_ACTIVE`’s own doc. That belongs to phase-425 and wants its own evidence, so it is **not** smuggled in here.

## Residual, deliberately open

The lock orders the tests that *mean* to touch the flag. It does not make the flag per-executor, so a future test that moves it and skips the guard reopens this. Nothing in `time_source`’s API warns a new caller.

## Why it landed

`node-std-tests` lives in `check-build`, which is `schedule`/`workflow_dispatch` only — no pull-request or merge-queue event runs it. Same shape as issues 0319, 1025, and 1098 the same day. It *is* in `just ci gate` locally, which is how it was found.

## Also filed, not fixed — #1105

Under `--test-threads=1` a **different** test fails: `test_time_triggered_dispatch_active_window` asserts a 1 ms window off `test_clock_us`, a free-running clock shared by the whole process, so which window "now" lands in is a function of how long the preceding tests took. Not this defect. Merging the two would have hidden it — the first draft of #1104 did exactly that, and its single-threaded explanation was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742