### PR TITLE
fix(#0963): a refused closure no longer poisons the payload classes

### DIFF
--- a/cmake/NanoRosMessageBounds.cmake
+++ b/cmake/NanoRosMessageBounds.cmake
@@ -305,6 +305,58 @@ function(nros_message_bounds_seed_knobs_file _path)
 endfunction()
 
 # nros_derive_message_bound_knobs(...)  -- see the header comment.
+# Issue 0963 — publish the three payload-class knobs from a completed join.
+#
+# A MACRO, not a function: it publishes through `_nros_bounds_publish`, which
+# sets in the caller's scope, and it reads a dozen locals the caller already
+# holds. A function would need all of them threaded through and would put the
+# publishes one scope too deep.
+#
+# Called from two places now, which is the point of factoring it: a closure that
+# refuses the take buffer can still answer the payload classes, because they are
+# a fact about what the image SUBSCRIBES to and the refusal is a fact about what
+# it LINKS.
+macro(_nros_bounds_publish_payload_classes)
+    _nros_bounds_publish(NROS_MESSAGE_BOUNDS_BASIS "${_basis}")
+
+    # BASIS `closure` -- this image declared no entities, so there is no
+    # join to make and the payload classes keep exactly the answer W8
+    # published: derived over every type in the linked closure. The label
+    # and the status line are what stop that being mistaken for the joined
+    # row.
+    if(_basis STREQUAL "closure")
+        set(_sub_small "${_small}")
+        set(_sub_large_types "${_large_types}")
+        set(_sub_large_max "${_large_max}")
+        list(LENGTH _large_types _sub_large_count)
+    endif()
+
+    # Buffer 2, the backend's staging pools: two classes, split at the
+    # policy ceiling. `_sub_small` is the largest bound AT OR UNDER the
+    # ceiling among the receiving set, so the shim's own
+    # `min(threshold, SUBSCRIBER_BUFFER_SIZE)` picks it and the
+    # classification here is the routing at runtime.
+    #
+    # `_sub_small == 0` means nothing received fits under the ceiling --
+    # including the case where nothing is received at all. The small class
+    # is still USED (a caller that states no hint is served from it), so
+    # there is nothing to derive and the configured value stands.
+    if(_sub_small GREATER 0)
+        _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE "${_sub_small}")
+    endif()
+
+    # The large COUNT is a count of BLOCKS, so on the `subscribed` basis it
+    # counts subscribing ENTITIES and not distinct types: two subscriptions
+    # on one large type need two blocks, and a type count would under-reserve
+    # by exactly the duplicates. On the `closure` basis there are no entities
+    # to count and it stays a type count, which is what it has always been.
+    _nros_bounds_publish(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS "${_sub_large_count}")
+    _nros_bounds_publish(NROS_DERIVED_LARGE_TYPES "${_sub_large_types}")
+    if(_sub_large_count GREATER 0)
+        _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE "${_sub_large_max}")
+    endif()
+endmacro()
+
 function(nros_derive_message_bound_knobs)
     cmake_parse_arguments(_B "QUIET"
         "SMALL_CLASS_CEILING;OUTPUT_FILE;ENTITY_INVENTORY" "FRAGMENTS" ${ARGN})
@@ -478,6 +530,23 @@ function(nros_derive_message_bound_knobs)
     _nros_bounds_publish(NROS_MESSAGE_BOUNDS_BOUNDED_COUNT "${_bounded}")
     _nros_bounds_publish(NROS_MESSAGE_BOUNDS_OPEN_TYPES "${_open}")
 
+    # ---- The JOIN: which of those types does this image RECEIVE? ---------
+    #
+    # phase-403 step 1. Everything above is a fact about the closure. The three
+    # payload-class knobs are a fact about the SUBSCRIPTIONS, and this is where
+    # the second inventory supplies them. See the header for why the take
+    # buffer deliberately does not take part.
+    #
+    # Issue 0963 — this runs BEFORE the closure refusal below, which it did not
+    # until 2026-09-06. The refusal `return()`s, so an image whose every
+    # SUBSCRIBED type is bounded was refused for a type it merely LINKS, and the
+    # narrowing this join exists to provide was unreachable through the public
+    # entry point. The join is pure (it publishes nothing), so computing it
+    # early changes no output on the path that then refuses everything.
+    _nros_bounds_join_subscribed("${_B_ENTITY_INVENTORY}" "${_ceiling}"
+        _basis _payload_status _payload_why _sub_count
+        _sub_small _sub_large_types _sub_large_max _sub_large_count)
+
     if(_open)
         list(LENGTH _open _open_count)
         string(REPLACE ";" "\n" _open_block "${_open_detail}")
@@ -499,19 +568,48 @@ function(nros_derive_message_bound_knobs)
                 "type is transitive: `\"std_msgs/Header.frame_id\" = { cap = 64, "
                 "mode = \"inline\" }` bounds every message that nests a Header.")
         endif()
+        # Issue 0963 — the take buffer refuses, and the PAYLOAD CLASSES need
+        # not. They are two different facts:
+        #
+        #   * `NROS_SUBSCRIPTION_BUFFER_SIZE` is one global size for every
+        #     entity, and `DEFAULT_TX_BUF` aliases it, so a type the image only
+        #     PUBLISHES must still fit. That is a fact about the whole linked
+        #     closure, and an open type in the closure genuinely poisons it.
+        #   * the three payload-class knobs size the backend's staging pools for
+        #     what the image RECEIVES. An unbounded type nothing subscribes to
+        #     cannot reach them.
+        #
+        # So an image whose every SUBSCRIBED type is bounded now gets its
+        # payload classes even while the take buffer keeps its configured value.
+        # That was this issue's second remedy — "an image pays only for the
+        # types it actually links" — and it was unreachable while this `return()`
+        # ran before the join.
+        #
+        # ONLY on a real `subscribed` join. The `closure` basis fallback inside
+        # the macro derives over `_small` / `_large_types`, which on THIS path
+        # were accumulated over the bounded types only — deriving a class size
+        # from those is precisely the under-derivation the refusal above exists
+        # to prevent, and its failure mode is a silent `BufferTooSmall`. A
+        # missing entity inventory therefore still gets nothing.
+        # The payload STATUS is published either way: a reader that gets no
+        # classes should be able to see whether the join declined and why,
+        # rather than inferring it from absent variables.
+        _nros_bounds_publish(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS "${_payload_status}")
+        _nros_bounds_publish(NROS_MESSAGE_BOUNDS_PAYLOAD_REASON "${_payload_why}")
+        _nros_bounds_publish(NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT "${_sub_count}")
+        if(_payload_status STREQUAL "derived" AND _basis STREQUAL "subscribed")
+            _nros_bounds_publish_payload_classes()
+            if(NOT _B_QUIET)
+                message(STATUS
+                    "nros: payload classes DERIVED over ${_sub_count} subscribed "
+                    "type(s) despite the closure refusal above -- every type this "
+                    "image RECEIVES is bounded. The take buffer keeps its "
+                    "configured value (issue 0963).")
+            endif()
+        endif()
         _nros_message_bounds_write_output("${_B_OUTPUT_FILE}" "refused" "${_why}" "${_ceiling}")
         return()
     endif()
-
-    # ---- The JOIN: which of those types does this image RECEIVE? ---------
-    #
-    # phase-403 step 1. Everything above is a fact about the closure. The three
-    # payload-class knobs are a fact about the SUBSCRIPTIONS, and this is where
-    # the second inventory supplies them. See the header for why the take
-    # buffer deliberately does not take part.
-    _nros_bounds_join_subscribed("${_B_ENTITY_INVENTORY}" "${_ceiling}"
-        _basis _payload_status _payload_why _sub_count
-        _sub_small _sub_large_types _sub_large_max _sub_large_count)
 
     # ---- Derive ----------------------------------------------------------
     #
@@ -529,44 +627,7 @@ function(nros_derive_message_bound_knobs)
     _nros_bounds_publish(NROS_MESSAGE_BOUNDS_SUBSCRIPTION_COUNT "${_sub_count}")
 
     if(_payload_status STREQUAL "derived")
-        _nros_bounds_publish(NROS_MESSAGE_BOUNDS_BASIS "${_basis}")
-
-        # BASIS `closure` -- this image declared no entities, so there is no
-        # join to make and the payload classes keep exactly the answer W8
-        # published: derived over every type in the linked closure. The label
-        # and the status line are what stop that being mistaken for the joined
-        # row.
-        if(_basis STREQUAL "closure")
-            set(_sub_small "${_small}")
-            set(_sub_large_types "${_large_types}")
-            set(_sub_large_max "${_large_max}")
-            list(LENGTH _large_types _sub_large_count)
-        endif()
-
-        # Buffer 2, the backend's staging pools: two classes, split at the
-        # policy ceiling. `_sub_small` is the largest bound AT OR UNDER the
-        # ceiling among the receiving set, so the shim's own
-        # `min(threshold, SUBSCRIBER_BUFFER_SIZE)` picks it and the
-        # classification here is the routing at runtime.
-        #
-        # `_sub_small == 0` means nothing received fits under the ceiling --
-        # including the case where nothing is received at all. The small class
-        # is still USED (a caller that states no hint is served from it), so
-        # there is nothing to derive and the configured value stands.
-        if(_sub_small GREATER 0)
-            _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE "${_sub_small}")
-        endif()
-
-        # The large COUNT is a count of BLOCKS, so on the `subscribed` basis it
-        # counts subscribing ENTITIES and not distinct types: two subscriptions
-        # on one large type need two blocks, and a type count would under-reserve
-        # by exactly the duplicates. On the `closure` basis there are no entities
-        # to count and it stays a type count, which is what it has always been.
-        _nros_bounds_publish(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS "${_sub_large_count}")
-        _nros_bounds_publish(NROS_DERIVED_LARGE_TYPES "${_sub_large_types}")
-        if(_sub_large_count GREATER 0)
-            _nros_bounds_publish(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE "${_sub_large_max}")
-        endif()
+        _nros_bounds_publish_payload_classes()
     endif()
     # A count of ZERO is an ANSWER, not an abstention -- W4 made
     # `ZPICO_MAX_LARGE_SUBSCRIBERS = 0` legal precisely so an image whose types
@@ -909,7 +970,44 @@ function(_nros_message_bounds_write_output _path _status _reason _ceiling)
         string(REPLACE "\"" "\\\"" _r "${_r}")
         string(REPLACE "\n" "\\n" _r "${_r}")
         string(APPEND _c "set(NROS_MESSAGE_BOUNDS_REASON \"${_r}\")\n")
-        string(APPEND _c "# No knob is derived. Every one keeps its configured value.\n")
+        # Issue 0963 — a refusal is about the TAKE BUFFER, and the payload
+        # classes can still have an answer. This branch used to write nothing
+        # but the reason, so the values the derivation had already computed
+        # never reached the consumer: the file IS the transport, and a knob
+        # published in memory but absent from it does not exist.
+        #
+        # Only ever written when the join ran on the `subscribed` basis — the
+        # caller enforces that, and the comment below states which knobs the
+        # refusal still covers so a reader is not left inferring it.
+        if(DEFINED NROS_MESSAGE_BOUNDS_BASIS
+                AND NROS_MESSAGE_BOUNDS_BASIS STREQUAL "subscribed")
+            string(APPEND _c
+                "# The TAKE BUFFER is refused: an unbounded type in the linked closure\n"
+                "# could be published through it (DEFAULT_TX_BUF aliases it), so\n"
+                "# NROS_SUBSCRIPTION_BUFFER_SIZE keeps its configured value.\n"
+                "#\n"
+                "# The PAYLOAD CLASSES below are derived anyway: they size the staging\n"
+                "# pools for what this image RECEIVES, every subscribed type IS bounded,\n"
+                "# and an unbounded type nothing subscribes to cannot reach them.\n")
+            string(APPEND _c
+                "set(NROS_MESSAGE_BOUNDS_BASIS \"${NROS_MESSAGE_BOUNDS_BASIS}\")\n")
+            string(APPEND _c
+                "set(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS \"${NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS}\")\n")
+            if(DEFINED NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE)
+                string(APPEND _c
+                    "set(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE ${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE})\n")
+            endif()
+            if(DEFINED NROS_DERIVED_MAX_LARGE_SUBSCRIBERS)
+                string(APPEND _c
+                    "set(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS ${NROS_DERIVED_MAX_LARGE_SUBSCRIBERS})\n")
+            endif()
+            if(DEFINED NROS_DERIVED_SUBSCRIBER_LARGE_SIZE)
+                string(APPEND _c
+                    "set(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE ${NROS_DERIVED_SUBSCRIBER_LARGE_SIZE})\n")
+            endif()
+        else()
+            string(APPEND _c "# No knob is derived. Every one keeps its configured value.\n")
+        endif()
     else()
         string(APPEND _c "set(NROS_MESSAGE_BOUNDS_PACKAGES \"${NROS_MESSAGE_BOUNDS_PACKAGES}\")\n")
         string(APPEND _c "set(NROS_MESSAGE_BOUNDS_TYPE_COUNT ${NROS_MESSAGE_BOUNDS_TYPE_COUNT})\n")

--- a/docs/issues/archived/0963-the-exported-bound-inventory-has-no-consumer.md
+++ b/docs/issues/archived/0963-the-exported-bound-inventory-has-no-consumer.md
@@ -1,7 +1,7 @@
 ---
 id: 963
 title: "The derived-bound inventory has readers now — what is left is the executor arena alone (was: nothing reads it)"
-status: open
+status: resolved
 area: codegen, memory, build
 severity: medium
 related: [0896, 0900, 0939, 0965, phase-403, phase-403-W6, phase-403-W8, phase-412]
@@ -293,3 +293,55 @@ type. A check that has never executed is indistinguishable from one that does
 not work, and the first version of this test passed for the wrong reason: the
 join iterates `TYPE_COUNTS`, not `TYPES`, so a fixture listing the unbounded type
 in only the latter never visited it.
+
+
+## The ordering blocker is LIFTED (2026-09-06) — all three steps
+
+The scoped fix above is done, and the third step turned out to be somewhere
+other than where it was predicted.
+
+**Step 1 — the join runs before the closure refusal.** It is pure (it publishes
+nothing), so computing it early changes no output on the path that then refuses
+everything.
+
+**Step 2 — a refused closure still answers the payload classes**, but only on a
+real `subscribed` join. That guard is the load-bearing part: the macro's
+`closure` basis fallback derives over `_small` / `_large_types`, which on the
+refused path were accumulated over the BOUNDED types only. Publishing those
+would be exactly the under-derivation the refusal exists to prevent, whose
+failure mode is a silent `BufferTooSmall`. So an image with no entity inventory
+still gets nothing.
+
+**Step 3 was not where this issue said it was.** The prediction was that
+`nros_cargo_build.cmake` "gates on the OVERALL status … or it will ignore values
+that are present". It does not: `_nros_resolve_derivable_knob` keys on
+`DEFINED ${derived_var}`, and `_nros_load_derived_message_bounds` forwards any
+of the five names it finds, neither consulting the status. Read rather than
+assumed, and the assumption was wrong.
+
+The real gap was one layer earlier, in `_nros_message_bounds_write_output`: its
+`refused` branch wrote the reason and the line "No knob is derived. Every one
+keeps its configured value.", and nothing else. **The file IS the transport** —
+a knob published in memory but absent from it does not reach the consumer at
+all. That branch now emits the payload-class knobs, the basis and the payload
+status when the join was `subscribed`, with a comment saying which knob the
+refusal still covers and why.
+
+### Held by case P, which asserts the FILE and not just the variables
+
+`tests/cmake-message-bounds-tests.sh` case P builds a closure with an unbounded
+type and subscribes only to the bounded one. It asserts `payload=derived`,
+`basis=subscribed`, the small class sized from the subscribed type, and that the
+take buffer is NOT derived. Then it asserts the same of the OUTPUT FILE — which
+is what caught the writer gap: every in-memory assertion passed while the file
+carried nothing.
+
+It also asserts the no-inventory case publishes nothing, in memory and in the
+file, so the `closure`-fallback hazard has a negative control rather than a
+comment.
+
+Mutation-tested three ways, each restoring the old behaviour and each failing
+the suite: dropping the `subscribed` guard, moving the join back after the
+refusal, and reverting the writer.
+
+92 assertions in the suite (was 83). `just check fast` 230/230.

--- a/tests/cmake-message-bounds-tests.sh
+++ b/tests/cmake-message-bounds-tests.sh
@@ -899,6 +899,134 @@ fi
 check
 
 # ---------------------------------------------------------------------------
+log_header "P -- an open CLOSURE type does not poison the payload classes"
+# ---------------------------------------------------------------------------
+#
+# issue 0963, the fix case O was written against. The take buffer and the
+# payload classes answer different questions:
+#
+#   * NROS_SUBSCRIPTION_BUFFER_SIZE is one global size, aliased by
+#     DEFAULT_TX_BUF, so a type the image only PUBLISHES must fit it -- an open
+#     type anywhere in the closure genuinely poisons it;
+#   * the payload classes size staging pools for what the image RECEIVES, which
+#     an unbounded type nothing subscribes to cannot reach.
+#
+# So: closure carries an unbounded type, every SUBSCRIBED type is bounded.
+# Expected -- overall `refused`, payload classes `derived`.
+_p_pkg="$T/p-pkgs"
+mkdir -p "$_p_pkg"
+cat > "$_p_pkg/bounds.cmake" <<'EOF'
+set(NROS_MESSAGE_BOUNDS_SCHEMA_VERSION 1)
+list(APPEND NROS_MESSAGE_BOUND_PACKAGES "demo")
+list(APPEND NROS_MESSAGE_BOUND_TYPES "std_msgs/msg/Int32")
+set(NROS_MESSAGE_BOUND_std_msgs_msg_Int32_STATE "bounded")
+set(NROS_MESSAGE_BOUND_std_msgs_msg_Int32_TX 12)
+set(NROS_MESSAGE_BOUND_std_msgs_msg_Int32_RX 12)
+list(APPEND NROS_MESSAGE_BOUND_TYPES "demo/msg/Open")
+set(NROS_MESSAGE_BOUND_demo_msg_Open_STATE "unbounded")
+set(NROS_MESSAGE_BOUND_demo_msg_Open_REASON "unbounded member: data (string)")
+EOF
+# Subscribes to the BOUNDED type only. The unbounded one is linked, never received.
+{
+    printf 'set(NROS_ENTITY_INVENTORY_SCHEMA_VERSION 3)\n'
+    printf 'set(NROS_ENTITY_INVENTORY_STATUS "derived")\n'
+    printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES_STATUS "resolved")\n'
+    printf 'set(NROS_ENTITY_SUBSCRIBED_TYPES "std_msgs/msg/Int32")\n'
+    printf 'set(NROS_ENTITY_SUBSCRIBED_TYPE_COUNTS "std_msgs/msg/Int32=1")\n'
+    printf 'set(NROS_ENTITY_SUBSCRIBED_ENTITY_COUNT 1)\n'
+} > "$T/p-entities.cmake"
+
+cat > "$T/p-run.cmake" <<EOF
+include("$MODULE")
+nros_derive_message_bound_knobs(
+    FRAGMENTS "$_p_pkg/bounds.cmake"
+    ENTITY_INVENTORY "$T/p-entities.cmake"
+    OUTPUT_FILE "$T/p-out.cmake"
+    QUIET)
+message(STATUS "status=\${NROS_MESSAGE_BOUNDS_STATUS}")
+message(STATUS "payload=\${NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS}")
+message(STATUS "basis=\${NROS_MESSAGE_BOUNDS_BASIS}")
+message(STATUS "why=\${NROS_MESSAGE_BOUNDS_PAYLOAD_REASON}")
+message(STATUS "small=\${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE}")
+message(STATUS "takebuf=\${NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE}")
+EOF
+_p_out=$(cmake -P "$T/p-run.cmake" 2>&1)
+
+if ! printf '%s' "$_p_out" | grep -q "payload=derived"; then
+    fail "P: every SUBSCRIBED type is bounded, so the payload classes must derive \
+even though the closure refused:"
+    printf '%s\n' "$_p_out"
+fi
+check
+if ! printf '%s' "$_p_out" | grep -q "basis=subscribed"; then
+    fail "P: the payload classes derived on the wrong basis -- a `closure` basis \
+here would be derived over the bounded types ONLY, which is the under-derivation \
+the refusal exists to prevent:"
+    printf '%s\n' "$_p_out"
+fi
+check
+if ! printf '%s' "$_p_out" | grep -q "small=12"; then
+    fail "P: the small class was not sized from the one subscribed type:"
+    printf '%s\n' "$_p_out"
+fi
+check
+# The take buffer must STILL refuse -- that is the half an open closure type
+# genuinely poisons, and the whole reason this is not just "stop refusing".
+if printf '%s' "$_p_out" | grep -q "takebuf=[0-9]"; then
+    fail "P: the take buffer was derived over a closure with an unbounded type -- \
+DEFAULT_TX_BUF aliases it, so a published type could exceed it silently:"
+    printf '%s\n' "$_p_out"
+fi
+check
+
+# The OUTPUT FILE is the transport -- a knob published in memory but absent from
+# it does not reach the consumer, which is exactly the gap the in-memory
+# assertions above cannot see. The refused branch of the writer emitted only the
+# reason until issue 0963.
+if ! grep -q 'NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE' "$T/p-out.cmake"; then
+    fail "P: the payload classes were derived but the OUTPUT FILE does not carry \
+them, so nros_cargo_build.cmake will never see them:"
+    cat "$T/p-out.cmake"
+fi
+check
+if grep -q 'NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE' "$T/p-out.cmake"; then
+    fail "P: the output file carries the TAKE BUFFER on a refused closure -- that \
+is the knob an unbounded closure type genuinely poisons:"
+    cat "$T/p-out.cmake"
+fi
+check
+if ! grep -q 'NROS_MESSAGE_BOUNDS_BASIS "subscribed"' "$T/p-out.cmake"; then
+    fail "P: the file does not record WHICH basis the payload classes used:"
+    cat "$T/p-out.cmake"
+fi
+check
+# ...and the no-inventory case must still write nothing derived.
+if grep -qE '^set\(NROS_DERIVED_' "$T/p-out2.cmake"; then
+    fail "P: with no entity inventory the output file carries derived knobs:"
+    cat "$T/p-out2.cmake"
+fi
+check
+
+# ...and with NO entity inventory, an open closure still publishes NOTHING: the
+# `closure` basis would derive the classes over the bounded types only.
+cat > "$T/p-run2.cmake" <<EOF
+include("$MODULE")
+nros_derive_message_bound_knobs(
+    FRAGMENTS "$_p_pkg/bounds.cmake"
+    OUTPUT_FILE "$T/p-out2.cmake"
+    QUIET)
+message(STATUS "small=\${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE}")
+message(STATUS "basis=\${NROS_MESSAGE_BOUNDS_BASIS}")
+EOF
+_p_out2=$(cmake -P "$T/p-run2.cmake" 2>&1)
+if printf '%s' "$_p_out2" | grep -q "small=[0-9]"; then
+    fail "P: with no entity inventory the classes were derived over the BOUNDED \
+types only -- exactly the under-derivation the refusal exists to prevent:"
+    printf '%s\n' "$_p_out2"
+fi
+check
+
+# ---------------------------------------------------------------------------
 log_header "Summary"
 if [ "$FAILURES" -eq 0 ]; then
     log_success "$CHECKS assertions held"


### PR DESCRIPTION
The scoped fix #0963 wrote out, all three steps — and the third wasn't where it predicted.

## Step 1 — the join runs before the closure refusal

It's pure (publishes nothing), so computing it early changes no output on the path that then refuses everything. Until now the refusal `return()`ed at `:481` while the join sat at `:512`, so an image whose every **subscribed** type is bounded was refused for a type it merely **links**.

## Step 2 — a refused closure still answers the payload classes

But **only on a real `subscribed` join**, and that guard is the load-bearing part. The macro's `closure`-basis fallback derives over `_small`/`_large_types`, which on the refused path were accumulated over the *bounded types only*. Publishing those is precisely the under-derivation the refusal exists to prevent, and its failure mode is a silent `BufferTooSmall`. An image with no entity inventory still gets nothing.

The two knobs answer different questions, which is why one can refuse while the other doesn't:

- `NROS_SUBSCRIPTION_BUFFER_SIZE` is one global size aliased by `DEFAULT_TX_BUF`, so a type the image only *publishes* must fit it — an open closure type genuinely poisons it;
- the payload classes size staging pools for what the image *receives*, which an unbounded type nothing subscribes to cannot reach.

## Step 3 was somewhere else

This issue predicted `nros_cargo_build.cmake` *"gates on the OVERALL status … or it will ignore values that are present"*. **It doesn't.** `_nros_resolve_derivable_knob` keys on `DEFINED ${derived_var}`, and `_nros_load_derived_message_bounds` forwards any of the five names it finds. Neither consults the status. I read it rather than assuming, and the assumption was wrong.

The real gap was one layer earlier, in `_nros_message_bounds_write_output`: its `refused` branch wrote the reason and *"No knob is derived"*, and nothing else. **The file is the transport** — a knob published in memory but absent from it never reaches the consumer.

## Held by case P — which asserts the file, not just the variables

That distinction is what caught the writer gap: every in-memory assertion passed while the file carried nothing.

Case P builds a closure with an unbounded type, subscribes only to the bounded one, and asserts `payload=derived`, `basis=subscribed`, the small class sized from the subscribed type, and the take buffer **not** derived — then asserts the same of the output file. It also gives the `closure`-fallback hazard a negative control rather than a comment.

**Mutation-tested three ways**, each restoring the old behaviour and each failing the suite: dropping the `subscribed` guard, moving the join back after the refusal, reverting the writer.

92 assertions (was 83). `just check fast` 230/230.

Resolves #0963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)