### PR TITLE
feat(cpp): expose the stack-headroom bound to C++ entries, and give it a caller

### DIFF
--- a/docs/issues/1232-zephyr-tier-stack-bytes-is-ignored.md
+++ b/docs/issues/1232-zephyr-tier-stack-bytes-is-ignored.md
@@ -1,0 +1,91 @@
+---
+id: 1232
+title: "A tier's declared `stack_bytes` does nothing on Zephyr — every tier thread gets the fixed pool slot"
+status: open
+type: bug
+area: zephyr
+related: [phase-436]
+---
+
+## Problem
+
+`stack_bytes` is a contract field. It rides the whole way from `system.toml`
+through the resolver, `NativeTierSpecC` and the generated entry into
+`nros_zephyr_tier_task_create` — and is then **not used to size the stack**.
+
+```c
+k_tid_t tid = k_thread_create(&nros_tier_threads[idx], nros_tier_stacks[idx],
+                              NROS_ZEPHYR_TIER_STACK_SIZE, nros_zephyr_tier_trampoline,
+                              (void*)entry, arg, NULL, (int)priority, 0, start_delay);
+```
+(`zephyr/nros_platform_zephyr_shims.c:696`)
+
+The stacks are a compile-time pool:
+
+```c
+#ifndef NROS_ZEPHYR_TIER_STACK_SIZE
+#define NROS_ZEPHYR_TIER_STACK_SIZE 16384
+K_THREAD_STACK_ARRAY_DEFINE(nros_tier_stacks, NROS_ZEPHYR_MAX_TIERS, NROS_ZEPHYR_TIER_STACK_SIZE);
+```
+(`shims.c:639`)
+
+So **every** tier thread gets `NROS_ZEPHYR_TIER_STACK_SIZE`, whatever the tier
+declared. `stack_bytes` is read once, only to decide whether to print a
+warning:
+
+```c
+if (stack_bytes > (size_t) NROS_ZEPHYR_TIER_STACK_SIZE) {
+    printk("nros: tier stack request %u > fixed slot %u tier=`%s` — running with the "
+           "slot; raise NROS_ZEPHYR_TIER_STACK_SIZE\n", ...);
+}
+```
+
+## Why this is worse than a missing feature
+
+A tier that declares **less** than the slot gets silently more, which is
+merely wasteful. A tier that declares **more** gets a printk and runs
+undersized — and that warning is the only signal, on a lane where a stack
+overflow is the classic spatial-freedom-from-interference failure ISO 26262
+asks about.
+
+Worse, the number is *believed* elsewhere. Anything deriving from
+`stack_bytes` on Zephyr computes against a stack that does not exist. Phase-436
+hit this directly: the first version of the stack-headroom derive used
+`stack_bytes` and had to be changed to ask `nros_zephyr_tier_stack_size()` for
+what the thread actually got. That workaround is in place, but it works
+*around* the contract rather than fixing it.
+
+Two neighbouring defects found in the same pass, both fixed there:
+
+* `ctx->stack_bytes` in `zephyr_run_tiers.c` was **never assigned** — the
+  field existed and nothing set it.
+* The boot tier's `stack_bytes` describes no thread at all: it runs on the
+  Zephyr `main()` thread, sized by `CONFIG_MAIN_STACK_SIZE`.
+
+## Contrast: FreeRTOS honours it
+
+```c
+uint32_t stack_words = (t->stack_bytes > 0u) ? (uint32_t)(t->stack_bytes / 4u) : (262144u / 4u);
+```
+(`freertos_run_tiers.c`) — declared size honoured, with a documented default.
+So the same contract field means two different things depending on the board,
+and only one of them is what it says.
+
+## Fix direction
+
+Three options, roughly increasing cost:
+
+1. **Say so.** Document `stack_bytes` as advisory-on-Zephyr in the contract and
+   in `NativeTierSpecC`, and make the oversize case louder than a printk. Cheap
+   and honest, but leaves the field lying by default.
+2. **Refuse.** Fail the build (or the resolve) when a Zephyr tier declares a
+   `stack_bytes` the pool cannot provide, rather than warning at runtime and
+   continuing undersized. Matches the repo's "refuse rather than degrade"
+   discipline (issue 0709).
+3. **Honour it.** Size the pool slots from the resolved tiers at build time —
+   the toolchain holds every tier's `stack_bytes` before the image is built, so
+   `NROS_ZEPHYR_TIER_STACK_SIZE` could be generated as the max, or per-tier
+   stacks emitted. This is the only option under which the contract is true.
+
+(2) is the minimum that stops the field misleading. (3) is what the field
+already promises.

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -1400,7 +1400,24 @@ nros_cpp_ret_t nros_cpp_bind_group_sched(void *handle,
  * `node_name`, `from`, `to` must be valid null-terminated UTF-8 strings.
  * `node_namespace` may be NULL (defaults to `"/"`), otherwise must be a valid
  * null-terminated UTF-8 string.
+ * Declare the minimum stack headroom this executor's thread must keep, in
+ * bytes. `0` (the default) leaves the `stack-headroom-runtime` rule off.
+ *
+ * Exists because the bound cannot be derived from anything the executor can
+ * see. It never receives `stack_bytes` -- that lives in the spawn attr and
+ * goes no further -- and no portable query returns a task's total stack, so
+ * neither an absolute floor nor a percentage can be inferred. The entry that
+ * spawned the thread is the only party that knows what it handed over, and
+ * on a C++ image that entry is on this side of the ABI.
+ *
+ * Call from a tier's `setup(executor)`, beside the other declarations the
+ * generated entry already makes there.
+ *
+ * # Safety
+ * `handle` must be a live executor handle from this ABI, or NULL.
  */
+nros_cpp_ret_t nros_cpp_executor_set_min_stack_headroom(void *handle, size_t bytes);
+
 nros_cpp_ret_t nros_cpp_declare_remap(void *handle,
                                       const char *node_name,
                                       const char *node_namespace,

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -1401,6 +1401,19 @@ nros_cpp_ret_t nros_cpp_bind_group_sched(void *handle,
 nros_cpp_ret_t nros_cpp_executor_derive_min_stack_headroom(void *handle, size_t stack_bytes);
 
 /**
+ * Declare the minimum stack headroom this executor's thread must keep, in
+ * bytes. `0` (the default) leaves the `stack-headroom-runtime` rule off.
+ *
+ * Exists because the bound cannot be derived from anything the executor can
+ * see. It never receives `stack_bytes` -- that lives in the spawn attr and
+ * goes no further -- and no portable query returns a task's total stack, so
+ * neither an absolute floor nor a percentage can be inferred. The entry that
+ * spawned the thread is the only party that knows what it handed over, and
+ * on a C++ image that entry is on this side of the ABI.
+ *
+ * Call from a tier's `setup(executor)`, beside the other declarations the
+ * generated entry already makes there.
+ *
  * # Safety
  * `handle` must be a live executor handle from this ABI, or NULL.
  */

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -1387,32 +1387,20 @@ nros_cpp_ret_t nros_cpp_bind_group_sched(void *handle,
                                          uint8_t sc_id);
 
 /**
- * Phase 305 W3 (issue 0255) — declare one launch `<remap from= to=/>` rule for
- * the node identified by `(node_name, node_namespace)`. Call BEFORE the node's
- * component registers its entities (the entry codegen emits these right after
- * `nros_cpp_node_create`); every subsequent entity registration resolves its
- * source name through the executor-side remap table (`~`/relative expansion +
- * exact-FQN match, first rule wins). Errors on a full table / oversized string
- * so a dropped routing rule is never silent.
+ * Set the minimum stack headroom from the stack the thread was created with,
+ * using the default fraction.
+ *
+ * Boards call this BEFORE the tier's `setup()`, which is what makes an
+ * explicit `nros_cpp_executor_set_min_stack_headroom` inside `setup` win:
+ * declared beats derived by ordering, with no precedence logic to keep in
+ * step. Same shape as `set_spin_nominal_us` (phase-436).
  *
  * # Safety
- * `handle` must be a context returned by `nros_cpp_init`.
- * `node_name`, `from`, `to` must be valid null-terminated UTF-8 strings.
- * `node_namespace` may be NULL (defaults to `"/"`), otherwise must be a valid
- * null-terminated UTF-8 string.
- * Declare the minimum stack headroom this executor's thread must keep, in
- * bytes. `0` (the default) leaves the `stack-headroom-runtime` rule off.
- *
- * Exists because the bound cannot be derived from anything the executor can
- * see. It never receives `stack_bytes` -- that lives in the spawn attr and
- * goes no further -- and no portable query returns a task's total stack, so
- * neither an absolute floor nor a percentage can be inferred. The entry that
- * spawned the thread is the only party that knows what it handed over, and
- * on a C++ image that entry is on this side of the ABI.
- *
- * Call from a tier's `setup(executor)`, beside the other declarations the
- * generated entry already makes there.
- *
+ * `handle` must be a live executor handle from this ABI, or NULL.
+ */
+nros_cpp_ret_t nros_cpp_executor_derive_min_stack_headroom(void *handle, size_t stack_bytes);
+
+/**
  * # Safety
  * `handle` must be a live executor handle from this ABI, or NULL.
  */

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3192,6 +3192,56 @@ pub unsafe extern "C" fn nros_cpp_bind_group_sched(
 /// Call from a tier's `setup(executor)`, beside the other declarations the
 /// generated entry already makes there.
 ///
+/// Fraction of a thread's stack that must stay unused before
+/// `stack-headroom-runtime` complains: one eighth, 12.5 %.
+///
+/// A power of two so the derivation is a shift, and conservative enough that a
+/// healthy tier never trips it — a bound a healthy tier trips is noise, and
+/// noise gets muted, which costs more than having no bound at all.
+const STACK_HEADROOM_DIVISOR: usize = 8;
+
+/// Derive a default minimum-headroom bound from the stack a tier was actually
+/// created with.
+///
+/// `check_stack_headroom` documents why the bound is a DECLARATION rather than
+/// a percentage: *"the executor never sees `stack_bytes` — it lives in the
+/// spawn attr and goes no further"*, and FreeRTOS reports a high-water mark
+/// without the size it was taken against, so the executor cannot compute a
+/// fraction even in principle.
+///
+/// The board can. `zephyr_run_tiers.c` and its FreeRTOS mirror hold
+/// `stack_bytes` because they just created the thread with it, so they are in
+/// a position to make the declaration on the tier's behalf. That is what this
+/// is for: the policy lives HERE, in one place, rather than being spelled
+/// twice in two board files that would drift.
+///
+/// `0` in gives `0` out — a tier that declared no stack size has made no claim
+/// to derive from, and `0` is the rule's own "no declaration" sentinel, which
+/// leaves it off.
+pub(crate) fn derive_min_stack_headroom(stack_bytes: usize) -> usize {
+    stack_bytes / STACK_HEADROOM_DIVISOR
+}
+
+/// Set the minimum stack headroom from the stack the thread was created with,
+/// using the default fraction.
+///
+/// Boards call this BEFORE the tier's `setup()`, which is what makes an
+/// explicit `nros_cpp_executor_set_min_stack_headroom` inside `setup` win:
+/// declared beats derived by ordering, with no precedence logic to keep in
+/// step. Same shape as `set_spin_nominal_us` (phase-436).
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_derive_min_stack_headroom(
+    handle: *mut c_void,
+    stack_bytes: usize,
+) -> nros_cpp_ret_t {
+    unsafe {
+        nros_cpp_executor_set_min_stack_headroom(handle, derive_min_stack_headroom(stack_bytes))
+    }
+}
+
 /// # Safety
 /// `handle` must be a live executor handle from this ABI, or NULL.
 #[unsafe(no_mangle)]
@@ -3836,6 +3886,46 @@ pub(crate) unsafe fn cstr_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
     }
     let bytes = unsafe { core::slice::from_raw_parts(ptr.cast::<u8>(), len) };
     core::str::from_utf8(bytes).ok()
+}
+
+#[cfg(test)]
+mod stack_headroom_derivation_tests {
+    use super::derive_min_stack_headroom;
+
+    /// A tier that declares no stack size has made no claim the board can turn
+    /// into a bound, so the rule must stay OFF — `0` is the rule's own
+    /// "no declaration" sentinel.
+    #[test]
+    fn an_undeclared_stack_derives_no_bound() {
+        assert_eq!(derive_min_stack_headroom(0), 0);
+    }
+
+    /// The bound is a fixed fraction of the stack the thread was actually
+    /// created with.
+    #[test]
+    fn the_bound_is_an_eighth_of_the_declared_stack() {
+        assert_eq!(derive_min_stack_headroom(32_768), 4_096);
+        assert_eq!(derive_min_stack_headroom(8_192), 1_024);
+    }
+
+    /// The derived bound must leave the great majority of the stack usable —
+    /// a bound that a healthy tier trips is noise, and noise gets muted.
+    #[test]
+    fn the_bound_leaves_most_of_the_stack_usable() {
+        let stack = 32_768;
+        let bound = derive_min_stack_headroom(stack);
+        assert!(
+            bound * 4 < stack,
+            "a bound of {bound} on a {stack}-byte stack reserves too much"
+        );
+    }
+
+    /// A stack too small to yield a whole byte of bound derives nothing rather
+    /// than rounding up into a bound larger than the stack itself.
+    #[test]
+    fn a_stack_smaller_than_the_divisor_derives_no_bound() {
+        assert_eq!(derive_min_stack_headroom(4), 0);
+    }
 }
 
 #[cfg(test)]

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3178,20 +3178,6 @@ pub unsafe extern "C" fn nros_cpp_bind_group_sched(
 /// `node_name`, `from`, `to` must be valid null-terminated UTF-8 strings.
 /// `node_namespace` may be NULL (defaults to `"/"`), otherwise must be a valid
 /// null-terminated UTF-8 string.
-#[cfg(feature = "rmw-cffi")]
-/// Declare the minimum stack headroom this executor's thread must keep, in
-/// bytes. `0` (the default) leaves the `stack-headroom-runtime` rule off.
-///
-/// Exists because the bound cannot be derived from anything the executor can
-/// see. It never receives `stack_bytes` -- that lives in the spawn attr and
-/// goes no further -- and no portable query returns a task's total stack, so
-/// neither an absolute floor nor a percentage can be inferred. The entry that
-/// spawned the thread is the only party that knows what it handed over, and
-/// on a C++ image that entry is on this side of the ABI.
-///
-/// Call from a tier's `setup(executor)`, beside the other declarations the
-/// generated entry already makes there.
-///
 /// Fraction of a thread's stack that must stay unused before
 /// `stack-headroom-runtime` complains: one eighth, 12.5 %.
 ///
@@ -3232,6 +3218,7 @@ pub(crate) fn derive_min_stack_headroom(stack_bytes: usize) -> usize {
 ///
 /// # Safety
 /// `handle` must be a live executor handle from this ABI, or NULL.
+#[cfg(feature = "rmw-cffi")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_executor_derive_min_stack_headroom(
     handle: *mut c_void,
@@ -3242,8 +3229,22 @@ pub unsafe extern "C" fn nros_cpp_executor_derive_min_stack_headroom(
     }
 }
 
+/// Declare the minimum stack headroom this executor's thread must keep, in
+/// bytes. `0` (the default) leaves the `stack-headroom-runtime` rule off.
+///
+/// Exists because the bound cannot be derived from anything the executor can
+/// see. It never receives `stack_bytes` -- that lives in the spawn attr and
+/// goes no further -- and no portable query returns a task's total stack, so
+/// neither an absolute floor nor a percentage can be inferred. The entry that
+/// spawned the thread is the only party that knows what it handed over, and
+/// on a C++ image that entry is on this side of the ABI.
+///
+/// Call from a tier's `setup(executor)`, beside the other declarations the
+/// generated entry already makes there.
+///
 /// # Safety
 /// `handle` must be a live executor handle from this ABI, or NULL.
+#[cfg(feature = "rmw-cffi")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_executor_set_min_stack_headroom(
     handle: *mut c_void,
@@ -3256,6 +3257,7 @@ pub unsafe extern "C" fn nros_cpp_executor_set_min_stack_headroom(
     NROS_CPP_RET_OK
 }
 
+#[cfg(feature = "rmw-cffi")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_declare_remap(
     handle: *mut c_void,

--- a/packages/api/nros-cpp/src/lib.rs
+++ b/packages/api/nros-cpp/src/lib.rs
@@ -3179,6 +3179,33 @@ pub unsafe extern "C" fn nros_cpp_bind_group_sched(
 /// `node_namespace` may be NULL (defaults to `"/"`), otherwise must be a valid
 /// null-terminated UTF-8 string.
 #[cfg(feature = "rmw-cffi")]
+/// Declare the minimum stack headroom this executor's thread must keep, in
+/// bytes. `0` (the default) leaves the `stack-headroom-runtime` rule off.
+///
+/// Exists because the bound cannot be derived from anything the executor can
+/// see. It never receives `stack_bytes` -- that lives in the spawn attr and
+/// goes no further -- and no portable query returns a task's total stack, so
+/// neither an absolute floor nor a percentage can be inferred. The entry that
+/// spawned the thread is the only party that knows what it handed over, and
+/// on a C++ image that entry is on this side of the ABI.
+///
+/// Call from a tier's `setup(executor)`, beside the other declarations the
+/// generated entry already makes there.
+///
+/// # Safety
+/// `handle` must be a live executor handle from this ABI, or NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nros_cpp_executor_set_min_stack_headroom(
+    handle: *mut c_void,
+    bytes: usize,
+) -> nros_cpp_ret_t {
+    let Some(ctx) = (unsafe { cpp_ctx_checked(handle) }) else {
+        return NROS_CPP_RET_INVALID_ARGUMENT;
+    };
+    ctx.executor.set_min_stack_headroom_bytes(bytes);
+    NROS_CPP_RET_OK
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_declare_remap(
     handle: *mut c_void,

--- a/packages/boards/nros-board-freertos/c/freertos_run_tiers.c
+++ b/packages/boards/nros-board-freertos/c/freertos_run_tiers.c
@@ -37,6 +37,7 @@ extern int nros_cpp_executor_open_over_session(void* session_handle, const char*
                                                uint32_t domain_id, void* out_storage);
 
 extern int nros_cpp_executor_set_active_groups(void* executor, const char* const* groups, size_t n);
+extern int nros_cpp_executor_derive_min_stack_headroom(void* executor, size_t stack_bytes);
 
 extern int nros_cpp_spin_once(void* handle, int32_t timeout_ms);
 
@@ -343,6 +344,28 @@ static void freertos_tier_task(void* arg) {
         nros_cpp_executor_set_active_groups(ctx->executor_storage, ctx->groups, ctx->n_groups);
     }
 
+    /* phase-436 follow-up — declare a default stack-headroom bound from the
+     * stack this tier's task was actually created with. The executor cannot
+     * derive one itself (`check_stack_headroom`: it never sees `stack_bytes`),
+     * but this layer can, because it just spawned the task with that size.
+     *
+     * BEFORE `setup()` deliberately: an explicit
+     * `nros_cpp_executor_set_min_stack_headroom` inside the tier's setup then
+     * overwrites this, so declared beats derived by ordering alone.
+     *
+     * Spawned tiers only. The boot tier runs on the caller (`app_task`, a
+     * 512 KiB stack this layer never sized), so a bound derived from its spec
+     * would be measured against the wrong stack. */
+    if (nros_cpp_executor_derive_min_stack_headroom(ctx->executor_storage, ctx->stack_bytes)
+        != 0) {
+        /* Same fail-loud rule as a spawn failure above: a bound that was never
+         * set leaves `stack-headroom-runtime` off, and a monitor that silently
+         * fails to arm is indistinguishable from a healthy system. */
+        nros_board_freertos_console_write("nros: stack-headroom bound NOT set tier=`");
+        nros_board_freertos_console_write((ctx->name != NULL) ? ctx->name : "?");
+        nros_board_freertos_console_write("` — the rule stays off\n");
+    }
+
     /* Run the tier's node-setup function. */
     if (ctx->setup != NULL) {
         rc = ctx->setup(ctx->executor_storage);
@@ -451,6 +474,13 @@ static int freertos_spawn_next_tier(void* session_handle, uint8_t domain_id,
      * emit_cpp (the pre-W2 literal hardcoded 0), so a configured stack is
      * honored; this default covers unset specs. */
     uint32_t stack_words = (t->stack_bytes > 0u) ? (uint32_t)(t->stack_bytes / 4u) : (262144u / 4u);
+
+    /* The EFFECTIVE stack, not the declared one: an unset `stack_bytes` still
+     * gets 256 KiB above, and a bound derived from `0` would leave the
+     * stack-headroom rule off on exactly the tiers that declared nothing and
+     * therefore most need a default. The field is otherwise unread — nothing
+     * assigned it before this. */
+    ctx->stack_bytes = (size_t)stack_words * 4u;
 
     /* Raw FreeRTOS priority from the tier spec (the system.toml [tiers.*.freertos]
      * priority is the numeric FreeRTOS value; clamp to configMAX_PRIORITIES-1). */
@@ -591,6 +621,15 @@ int32_t nros_board_freertos_run_tiers(const char* locator, uint8_t domain_id,
      * the console and RFC-0052's fail-loud rule is broken by this file. NULL
      * task = pin the CALLING task, which is what the boot tier runs on. */
     freertos_apply_core_pin(NULL, boot->name, boot->core_plus1);
+
+    /* No derived stack-headroom bound for the boot tier here, unlike Zephyr.
+     * It runs on the caller (`app_task`), and FreeRTOS offers no way to ask a
+     * task how large its stack IS — `uxTaskGetStackHighWaterMark` reports what
+     * is left, not what it was taken against, which is the same asymmetry
+     * `check_stack_headroom` cites for why the bound must be declared. Zephyr
+     * can answer (CONFIG_MAIN_STACK_SIZE) and so derives there; hardcoding
+     * startup.c's 512 KiB here would be a second copy of a number that file
+     * owns. A boot tier that wants the rule declares it in `setup()`. */
 
     /* Gate the boot executor to its tier's callback groups. */
     if (boot->n_groups > 0 && boot->groups != NULL) {

--- a/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
+++ b/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
@@ -362,7 +362,10 @@ static void* zephyr_tier_task(void* arg) {
      *
      * The SLOT size, not `ctx->stack_bytes`: the shim creates every tier
      * thread with the fixed pool slot and only warns when a declared size
-     * exceeds it, so the declared number describes no real stack here. */
+     * exceeds it, so the declared number describes no real stack here.
+     * That is issue 1232 — this asks for the truth rather than fixing the
+     * contract, and should follow the field once 1232 makes it mean
+     * something. */
     if (nros_cpp_executor_derive_min_stack_headroom(ctx->executor_storage,
                                                     nros_zephyr_tier_stack_size()) != 0) {
         /* Fail LOUD. A bound that was never set leaves `stack-headroom-runtime`

--- a/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
+++ b/packages/boards/nros-board-zephyr/c/zephyr_run_tiers.c
@@ -162,6 +162,14 @@ extern int nros_cpp_executor_open_over_session(void* session_handle, const char*
                                                uint32_t domain_id, void* out_storage);
 
 extern int nros_cpp_executor_set_active_groups(void* executor, const char* const* groups, size_t n);
+extern int nros_cpp_executor_derive_min_stack_headroom(void* executor, size_t stack_bytes);
+/* The stack a spawned tier thread actually gets (the fixed pool slot). The
+ * shim ignores the tier's declared `stack_bytes` — see its definition. */
+extern size_t nros_zephyr_tier_stack_size(void);
+/* The stack the boot tier runs on (the `main()` thread's
+ * CONFIG_MAIN_STACK_SIZE) — its spec's `stack_bytes` describes no real
+ * thread. */
+extern size_t nros_zephyr_main_stack_size(void);
 
 extern int nros_cpp_spin_once(void* handle, int32_t timeout_ms);
 
@@ -341,6 +349,27 @@ static void* zephyr_tier_task(void* arg) {
     /* Gate this executor to its tier's callback groups. */
     if (ctx->n_groups > 0 && ctx->groups != NULL) {
         nros_cpp_executor_set_active_groups(ctx->executor_storage, ctx->groups, ctx->n_groups);
+    }
+
+    /* phase-436 follow-up — declare a default stack-headroom bound from the
+     * stack this tier's thread was actually created with. The executor cannot
+     * derive one itself (`check_stack_headroom`: it never sees `stack_bytes`),
+     * but this layer can, because it just spawned the thread with that size.
+     *
+     * BEFORE `setup()` deliberately: an explicit
+     * `nros_cpp_executor_set_min_stack_headroom` inside the tier's setup then
+     * overwrites this, so declared beats derived by ordering alone.
+     *
+     * The SLOT size, not `ctx->stack_bytes`: the shim creates every tier
+     * thread with the fixed pool slot and only warns when a declared size
+     * exceeds it, so the declared number describes no real stack here. */
+    if (nros_cpp_executor_derive_min_stack_headroom(ctx->executor_storage,
+                                                    nros_zephyr_tier_stack_size()) != 0) {
+        /* Fail LOUD. A bound that was never set leaves `stack-headroom-runtime`
+         * off, and a monitor that silently fails to arm reads exactly like a
+         * system with nothing to report. */
+        printk("nros: stack-headroom bound NOT set tier=`%s` — the rule stays off\n",
+               (ctx->name != NULL) ? ctx->name : "?");
     }
 
     /* Run the tier's node-setup function. */
@@ -551,6 +580,18 @@ int32_t nros_board_zephyr_run_tiers(const char* locator, uint8_t domain_id,
     /* Gate the boot executor to its tier's callback groups. */
     if (boot->n_groups > 0 && boot->groups != NULL) {
         nros_cpp_executor_set_active_groups(boot_storage, boot->groups, boot->n_groups);
+    }
+
+    /* Same derive for the boot tier, but from the `main()` thread's own stack.
+     * `boot->stack_bytes` describes a thread that was never spawned — the
+     * kernel created this one with CONFIG_MAIN_STACK_SIZE before any nano-ros
+     * code ran — so the shim is asked instead. Excluding the boot tier
+     * entirely would leave the rule off on every single-tier app, which is the
+     * common shape and includes the Zephyr FVP lane. */
+    if (nros_cpp_executor_derive_min_stack_headroom(boot_storage,
+                                                    nros_zephyr_main_stack_size()) != 0) {
+        printk("nros: stack-headroom bound NOT set tier=`%s` (boot) — the rule stays off\n",
+               (boot->name != NULL) ? boot->name : "?");
     }
 
     /* Boot tier node setup. */

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -685,7 +685,7 @@ K_THREAD_STACK_ARRAY_DEFINE(nros_tier_stacks, NROS_ZEPHYR_MAX_TIERS, NROS_ZEPHYR
  * `k_thread_create` below is passed NROS_ZEPHYR_TIER_STACK_SIZE, not the
  * tier's declared `stack_bytes` — the pool slots are fixed at compile time, so
  * a declared size can only be checked against the slot (and warned about),
- * never honoured. Anything deriving a bound FROM the stack has to ask for this
+ * never honoured. That gap is issue 1232. Anything deriving a bound FROM the stack has to ask for this
  * number rather than the declared one, or it measures against a stack that
  * does not exist. */
 size_t nros_zephyr_tier_stack_size(void) {

--- a/zephyr/nros_platform_zephyr_shims.c
+++ b/zephyr/nros_platform_zephyr_shims.c
@@ -679,6 +679,28 @@ void nros_zephyr_log_2int(const char* tag, int64_t a, int64_t b) {
 #endif
 
 K_THREAD_STACK_ARRAY_DEFINE(nros_tier_stacks, NROS_ZEPHYR_MAX_TIERS, NROS_ZEPHYR_TIER_STACK_SIZE);
+
+/* The stack a spawned tier thread ACTUALLY gets.
+ *
+ * `k_thread_create` below is passed NROS_ZEPHYR_TIER_STACK_SIZE, not the
+ * tier's declared `stack_bytes` — the pool slots are fixed at compile time, so
+ * a declared size can only be checked against the slot (and warned about),
+ * never honoured. Anything deriving a bound FROM the stack has to ask for this
+ * number rather than the declared one, or it measures against a stack that
+ * does not exist. */
+size_t nros_zephyr_tier_stack_size(void) {
+    return (size_t)NROS_ZEPHYR_TIER_STACK_SIZE;
+}
+
+/* The stack the BOOT tier runs on.
+ *
+ * The boot tier is not spawned — it runs on the Zephyr `main()` thread, which
+ * the kernel created with CONFIG_MAIN_STACK_SIZE before any nano-ros code ran.
+ * The tier spec's `stack_bytes` describes a thread that was never created, so
+ * this is the only honest answer for that tier. */
+size_t nros_zephyr_main_stack_size(void) {
+    return (size_t)CONFIG_MAIN_STACK_SIZE;
+}
 static struct k_thread nros_tier_threads[NROS_ZEPHYR_MAX_TIERS];
 static int nros_tier_index;
 


### PR DESCRIPTION
> **Scope grew after review.** The setter as originally opened had **no caller**, so `stack-headroom-runtime` stayed off on every image even though the rule and the platform accessor both existed. A slot nothing calls is the "a slot exists, therefore it works" overstatement issue 0800 measured. Second commit adds the caller.

## 1 — the setter (original)

`nros_cpp_executor_set_min_stack_headroom` exposes `Executor::set_min_stack_headroom_bytes` to C++ entries.

## 2 — the caller

`check_stack_headroom` says why the bound must be a **declaration**:

> *"the executor never sees `stack_bytes` — it lives in the spawn attr and goes no further"*

and FreeRTOS reports a high-water mark without the size it was taken against, so a percentage isn't computable there even in principle.

The executor can't. The **board** can — it just created the thread. So the policy lives once, in Rust beside the setter (`derive_min_stack_headroom`, 1/8 of the stack), exported and called by both board entries, rather than the same fraction spelt twice in two C files that would drift. Keeping it in Rust also made the fraction unit-testable, which the C version wouldn't have been.

Called **before** the tier's `setup()`, so an explicit setter call inside setup overrides it — declared beats derived by ordering alone, no precedence logic. Same shape as `set_spin_nominal_us`.

## Three corrections found while wiring it

Each the same mistake: deriving from a number that isn't the real stack.

| | |
|---|---|
| **The boot tier isn't spawned with `stack_bytes`** | It runs on Zephyr's `main()` thread / FreeRTOS's `app_task`. Zephyr can answer (`CONFIG_MAIN_STACK_SIZE`, new shim accessor) and derives; FreeRTOS can't, so its boot tier stays underived rather than hardcoding a number `startup.c` owns. |
| **`ctx->stack_bytes` was never assigned on Zephyr** | The field existed; nothing set it. |
| **The Zephyr shim ignores `stack_bytes`** | Every tier thread gets the fixed `NROS_ZEPHYR_TIER_STACK_SIZE` pool slot; a declared size only earns a warning when it exceeds the slot. `nros_zephyr_tier_stack_size()` now exposes what the thread actually got. |

All three call sites **fail loud** when the bound doesn't take — a monitor that silently fails to arm is indistinguishable from a healthy system, which is the argument `freertos_announce_spawn_failure` already makes one function up.

## Verification — which needed its own correction

The first three FVP runs linked a **stale object**: the build reused a `.obj` six minutes older than the source, so none of them contained this change. `strings` on the ELF found zero copies of the diagnostic. Any conclusion from those runs was worthless.

On a clean build, with the divisor temporarily set to 1 so the bound is the whole stack:

```
nros: DEBUG headroom derive main_stack=524288 rc=0
contract violation: stack-headroom-runtime stack measured=428320 declared=524288
```

`rc=0` — handle valid, bound set. And the rule **fires**. At the shipped 1/8 it's silent (65536 bound vs 428320 unused, ~6.5× headroom) — and that silence now means something, which a quiet run alone could never have established.

`cargo test -p nros-cpp --features std,rmw-cffi`: 19 passed, 0 failed (4 new, RED first). `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP2Rw4c4Hm9qfcbwCMQ1XD