### PR TITLE
test(phase-429): the Rust negative control, and the wrong reason it was skipped

### DIFF
--- a/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md
+++ b/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md
@@ -10,8 +10,7 @@ anchor symbol and was replaced: this project avoids those, and the check turned
 out to decompose into one new check plus `nros_config_variant_<slug>`, which
 already existed). Rust refuses under `cargo check`. The ratchet holds the
 authored integer to its surface. `check-codegen-version-refusal` is the negative
-control that proves the C/C++ arms actually fire, and names the one arm it does
-not cover.
+control that proves every arm actually fires — C, C++ and Rust.
 
 **Not done, and it is the point of all of it:** shipping a prebuilt binary. That
 is a release decision, now unblocked rather than taken.
@@ -170,6 +169,17 @@ refusals, not only the happy build.
   and asserts `nros build` refuses at the start; a job that hand-edits `G` in a
   generated tree and asserts the Rust / C / C++ assertion fires. A uniformly
   green lane proves nothing about a check that has never fired in it.
+* **A CORRECTION worth keeping (2026-09-06).** This item first shipped covering
+  C and C++ only, recording the Rust half as unreachable because "there is no
+  `trybuild` and CLAUDE.md bans compiling inside tests". The second clause is
+  true and irrelevant: the ban is on compiling at TEST RUNTIME, and a negative
+  control is a GATE. `check-c` has compiled an expected-failure probe
+  (`serialization_format_mismatch_probe.c`) for years — the same shape, one
+  language over. Arm D builds a scratch crate carrying a bad token and requires
+  `error[E0080]`; mutation-verified by raising `NROS_CODEGEN_VERSION` so the
+  out-of-range probe becomes acceptable, which turns the arm red. A scratch
+  crate rather than a tracked file, because the assertion under test lives in
+  EMITTED code and a hand-written probe could drift from it silently.
 * **The CLI cache key is narrower than the freshness stamp, and that is the
   shipped-binary bug reproduced inside our own CI.** Seven `actions/cache`
   blocks share one key:

--- a/packages/cli/rosidl-bindgen/src/generator.rs
+++ b/packages/cli/rosidl-bindgen/src/generator.rs
@@ -1538,13 +1538,17 @@ mod tests {
     /// phase-429 W1 — the emitted crate carries the codegen version it was
     /// emitted at, and that number is THE runtime constant.
     ///
-    /// This is the runnable half of the compatibility token. The other half —
-    /// that an unaccepted version is a compile error — cannot be asserted by a
-    /// running test (no compile-fail harness in this workspace, and CLAUDE.md
-    /// bans shelling out to `cargo` from a test); `nros_core::codegen_version`
-    /// records what covers it instead. What this test can prove is that the
-    /// assertion is really emitted, at CRATE scope rather than inside a
-    /// generic, and that it reads the constant it claims to.
+    /// This is the runnable half of the compatibility token: that the assertion
+    /// is really emitted, at CRATE scope rather than inside a generic, and that
+    /// it reads the constant it claims to.
+    ///
+    /// The other half — that an unaccepted version is a compile ERROR — is
+    /// covered by `just check codegen-version-refusal` (arm D), which builds a
+    /// scratch crate carrying a bad token and requires `error[E0080]`. It is a
+    /// GATE rather than a test, which is the distinction this comment used to
+    /// get wrong: CLAUDE.md bans compiling at TEST RUNTIME, and says nothing
+    /// about a gate — `check-c` has compiled an expected-failure probe for
+    /// years. There is still no `trybuild`; it turned out not to be needed.
     #[test]
     fn lib_rs_carries_the_codegen_version_token() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/packages/core/nros-core/src/lib.rs
+++ b/packages/core/nros-core/src/lib.rs
@@ -72,6 +72,14 @@ pub mod clock;
 ///
 /// The module's own file carries no `//!` docs deliberately; see the comment at
 /// its head.
+///
+/// # Where the negative case is proven
+///
+/// `just check codegen-version-refusal` builds artifacts carrying an
+/// out-of-range version and requires each language to refuse: `#error` for C and
+/// C++, `error[E0080]` for Rust. A check that has never been observed to fail is
+/// a check nobody has evidence still works, and this one guards a failure whose
+/// whole character is that it is silent.
 pub mod codegen_version;
 // issue 0783 — there is no `error` module here any more, and its absence is the
 // decision. It held `NanoRosError { code: RclReturnCode, context, nested }`, a

--- a/tests/codegen-version-refusal-tests.sh
+++ b/tests/codegen-version-refusal-tests.sh
@@ -16,13 +16,18 @@
 #   2. out of range  -> #error, both C and C++
 #   3. config header present but silent -> #error (fail-closed)
 #
-# NOT COVERED: the Rust half. Its assertion is a crate-scope `const _: () =
-# assert!(...)`, and proving it fires needs a compile-failure harness this repo
-# does not have — there is no `trybuild` (`format_check.rs` records the same
-# finding) and CLAUDE.md bans compiling inside tests. It was verified by hand
-# (`cargo check -p nros-lifecycle-msgs` with the token flipped gives E0080), and
-# `rosidl-bindgen`'s own test asserts the emitted token equals the runtime
-# constant. Stated rather than silently skipped.
+# Arm D covers the RUST half, and it exists because the first version of this
+# gate declined to — on a reason that was wrong. It said "CLAUDE.md bans
+# compiling inside tests", which is true and irrelevant: that ban is on
+# COMPILING AT TEST RUNTIME, and this is a GATE. `check-c` has compiled an
+# expected-failure probe for years (`serialization_format_mismatch_probe.c`),
+# which is the same shape one language over. `format_check.rs` is right that
+# there is no `trybuild`; it does not follow that the negative case cannot be
+# proven, only that it is proven with cargo instead.
+#
+# The probe is a scratch crate rather than an in-tree file, because the
+# assertion under test lives in EMITTED code: a tracked probe would have to be
+# hand-written to look like emitted code and could drift from it silently.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -129,6 +134,51 @@ if grep -q 'did not define NROS_CODEGEN_VERSION' <<< "$out"; then
 else
     bad "C  a silent config header did not produce the fail-closed diagnostic"
     printf '        %s\n' "$(head -1 <<< "$out")"
+fi
+
+# D — the Rust half: a crate-scope `const _: () = assert!(…)` against the same
+#     runtime constant, which is what every generated Rust crate carries.
+if command -v cargo >/dev/null; then
+    probe="$work/rustprobe"
+    mkdir -p "$probe/src"
+    cat > "$probe/Cargo.toml" <<TOML
+[package]
+name = "codegen_version_probe"
+version = "0.0.0"
+edition = "2021"
+[dependencies]
+nros-core = { path = "$root/packages/core/nros-core", default-features = false }
+[workspace]
+TOML
+    write_probe() {  # $1 = emitted version
+        cat > "$probe/src/lib.rs" <<RS
+#![no_std]
+pub const NROS_EMITTED_CODEGEN_VERSION: u32 = $1;
+const _: () = assert!(
+    nros_core::codegen_version::accepts(NROS_EMITTED_CODEGEN_VERSION),
+    "this crate's NROS_EMITTED_CODEGEN_VERSION is not accepted by the nros-core \
+     it is being compiled against"
+);
+RS
+    }
+    # `NROS_CARGO_FLAGS=` clears the repo's `--locked` shim: this crate is
+    # synthesized outside any workspace and has no lock to honour.
+    write_probe "$emitted"
+    if NROS_CARGO_FLAGS= cargo check -q --manifest-path "$probe/Cargo.toml" 2>/dev/null; then
+        ok "D  Rust: version $emitted inside the accepted range compiles"
+    else
+        bad "D  Rust: the emitted version does NOT compile against a runtime that accepts it"
+    fi
+    write_probe "$((emitted + 6))"
+    out="$(NROS_CARGO_FLAGS= cargo check -q --manifest-path "$probe/Cargo.toml" 2>&1 || true)"
+    if grep -q 'E0080' <<< "$out"; then
+        ok "D  Rust: a version outside the range is REFUSED at compile time"
+    else
+        bad "D  Rust: out-of-range version was accepted (expected error[E0080])"
+        printf '        %s\n' "$(head -1 <<< "$out")"
+    fi
+else
+    echo "  SKIP  D  Rust: cargo not on PATH" >&2
 fi
 
 echo


### PR DESCRIPTION
phase-429 shipped `check-codegen-version-refusal` covering C and C++ and recorded the Rust half as unreachable:

> there is no `trybuild` (`format_check.rs` records the same finding) and CLAUDE.md bans compiling inside tests

The first clause is true. **The second is true and irrelevant**, and it is the one I leaned on. CLAUDE.md bans compiling at **test runtime** — *"never `cargo`/`cmake`/`idf.py`/`west build` at run time"* — and a negative control is a **gate**.

`check-c` has compiled an expected-failure probe for years:

```sh
test -f …/serialization_format_mismatch_probe.c || exit 1   # a missing file is
                                                            # also a non-zero cc
if cc -fsyntax-only … mismatch_probe.c; then exit 1; fi
```

That is this exact shape, one language over — and I had already written its C/C++ equivalent by hand while believing the Rust case was closed to me. The option was never closed; I cited a rule that does not reach it.

## Arm D

Builds a scratch crate carrying an out-of-range token and requires `error[E0080]`, with the in-range crate compiling clean as the negative control — a refusal that refuses everything proves nothing.

```
codegen-version refusal (RFC-0090, emitted version 1)
  ok    A  C: version 1 inside the accepted range compiles
  ok    A  C++: version 1 inside the accepted range compiles
  ok    B  C: a version outside the range is REFUSED, naming the remedy
  ok    B  C++: a version outside the range is REFUSED, naming the remedy
  ok    C  a silent config header is refused as MISSING, not as out-of-range
  ok    D  Rust: version 1 inside the accepted range compiles
  ok    D  Rust: a version outside the range is REFUSED at compile time
```

**Mutation-verified by moving the runtime rather than the probe** — raising `NROS_CODEGEN_VERSION` to 9 makes the out-of-range probe acceptable, and the arm goes red:

```
FAIL  D  Rust: out-of-range version was accepted (expected error[E0080])
```

## Why a scratch crate and not a tracked probe file

The assertion under test lives in **emitted** code. A tracked probe would have to be hand-written to imitate emitted code, and could drift from it with nothing noticing — which is the failure mode this whole phase exists to close. The scratch crate is generated from the same constant the emitter reads.

## Corrected in every place the claim appeared

The gate's own header, `rosidl-bindgen`'s emitter test, and the phase doc. `nros_core::codegen_version`'s module docs now name where the negative case is proven — they previously said "what covers it instead" while pointing at nothing in particular.

`check fast` 230/230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK