### PR TITLE
feat(#1061): a leaf declares what the probe cannot read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ examples/**/target-*/
 # hard-errors on the missing include until `nros sync` runs in that leaf;
 # `_require-leaf-includes` is the preflight that says so.
 **/.cargo/nros-managed-patch.toml
+# Issue 0827 — sync's derived pool budgets, the `[env]` sibling of the file
+# above. Derived from the metadata probe's output, which is itself per-host and
+# ignored, so committing this would pin one host's answer for everyone.
+**/.cargo/nros-managed-env.toml
 
 # Issue 0559 / phase-341 W2 — the per-leaf board `cargo_config` projection
 # `nros sync` writes next to the config that `include`s it.

--- a/docs/issues/archived/0827-unused-rmw-pools-dominate-static-ram.md
+++ b/docs/issues/archived/0827-unused-rmw-pools-dominate-static-ram.md
@@ -2,7 +2,7 @@
 id: 827
 title: "Static RAM is a property of the RMW, not of the node — a talker reserves
   275 KB of service and large-payload pools it can never reach"
-status: open
+status: resolved
 type: performance
 area: rmw
 related: [phase-392, phase-391, phase-412, issue-0815, issue-0739]
@@ -561,3 +561,58 @@ for a known reason — a missing `include` target is a HARD cargo error during
 manifest parse (issue 0463) — so the file and its `include` must appear and
 disappear together, which is the same invariant the patch sidecar already holds
 and the reason to put it in the same place rather than a new one.
+
+
+## WIRED and MEASURED (2026-09-05) — `nros sync` writes the budget
+
+The remaining step is done: `write_patch_config` derives the leaf's budget and
+writes `.cargo/nros-managed-env.toml`, with the `include` entry added in the
+same decision that writes the file.
+
+**A/B on one host, one tree, one profile — not against a number from another
+day**, because a stale baseline is how this repo has been wrong before:
+
+| `examples/native/rust/talker` | RAM attributed to symbols |
+| --- | ---: |
+| without the derived sidecar | 417,316 |
+| with it | **240,596** |
+| **saved** | **176,720 (42.3 %)** |
+
+That lands within 2 KB of this issue's earlier hand-set `[env]` measurement
+(415,469 stock), reached from a different direction — the agreement is the
+cross-check.
+
+The mechanism is confirmed end to end rather than inferred from the file: the
+build's generated shim constants read
+
+```
+/// Maximum number of concurrent subscribers (set via ZPICO_MAX_SUBSCRIBERS, default 8).
+pub const ZPICO_MAX_SUBSCRIBERS: usize = 1;
+```
+
+so the derived number reached the crate that sizes the pool.
+
+### Two sidecars, not one section
+
+`nros-managed-env.toml` is a SEPARATE file from `nros-managed-patch.toml`
+because the two empty independently: a leaf can have a generated message dep and
+no probeable component, or the reverse. Sharing a file would make each one's
+presence depend on the other's. Both follow the same rule — the file and its
+`include` entry appear and disappear together, since a missing include target is
+a hard cargo error during manifest parse (issue 0463).
+
+Gitignored, like its sibling: it is derived from a probe output that is itself
+per-host and ignored, so committing it would pin one host's answer for everyone.
+
+### What is still NOT derived
+
+`ZPICO_MAX_LARGE_SUBSCRIBERS` — `LARGE_PAYLOADS` remains 131,072 B and is the
+largest single symbol left in that image. The entity inventory has no notion of
+a "large" subscriber, so nothing here can state that number honestly; it stays a
+knob a human sets. Recording it rather than leaving the impression this issue
+recovered everything.
+
+And the whole mechanism reaches only PROBEABLE leaves. A cross-compiled leaf
+whose metadata is `.json.unprobeable` still states its budgets by hand — issue
+1061 — and `nros sync` now says so on the terminal instead of leaving it to be
+inferred from an absent file.

--- a/docs/issues/archived/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
+++ b/docs/issues/archived/1061-entity-budgets-not-derived-for-pure-cargo-leaves.md
@@ -1,7 +1,7 @@
 ---
 id: 1061
 title: Entity budgets are derived for CMake consumers only, so pure-cargo leaves hand-set them
-status: open
+status: resolved
 area: build
 severity: medium
 related: [1052, 0827, 0832, 0190]
@@ -160,3 +160,73 @@ into the leaf does NOT rest on copy-out. It rests on the measured in-tree fact
 that a direct `cargo build` in the leaf overflowed DRAM by 11,184 B, because the
 numbers lived in a fixture manifest that a plain cargo build never reads — and
 that one I measured both before and after.
+
+
+## FIXED (2026-09-06): the leaf DECLARES what the probe cannot read
+
+The fix section above offered two shapes — "a host stub behind a feature, or a
+declaration channel that does not require compiling the component at all". The
+second one, because the first makes a target-only board crate pretend to build
+for a host and the pretence has to be maintained forever.
+
+```toml
+[package.metadata.nros.component]
+entities = ["publisher:std_msgs/msg/String:/chatter", "timer"]
+```
+
+Same grammar as `nano_ros_node_register(... ENTITIES ...)`, parsed by the same
+`EntityDecl::parse`. Nothing is compiled to read it. `nros sync` turns it into
+the same inventory the probe would have produced, so the budgets come out of one
+derivation whatever the source.
+
+**Measured on the leaf this issue is about** — `qemu-esp32-baremetal/rust/talker`,
+whose metadata is `talker.json.unprobeable`:
+
+```
+[env]
+NROS_EXECUTOR_ACTION_CLIENTS = "0"
+NROS_EXECUTOR_MAX_CBS        = "1"
+NROS_RMW_SUBSCRIBER_SLOTS    = "1"
+ZPICO_MAX_PUBLISHERS         = "1"
+ZPICO_MAX_SUBSCRIBERS        = "1"
+```
+
+### It cannot become a way to disagree with the code
+
+Where the probe CAN run, the declaration is cross-checked against it per kind
+and a mismatch REFUSES. Verified by breaking one on purpose:
+
+```
+sync: examples/native/rust/talker: cannot derive pool budgets
+  (talker: the manifest declares timerx1 but the code creates publisherx1, timerx1.
+   Refusing rather than choosing one: ...)
+```
+
+Compared by kind COUNT, not by row — a declaration may state a topic loosely and
+the budget is computed from counts.
+
+### `ZPICO_MAX_QUERYABLES` is deliberately NOT derived, and that was found by measuring
+
+`DerivedEntityKnobs::max_queryables` says of itself that it excludes the
+parameter and lifecycle families (6 and 5 queryables) because "those are per-image
+infrastructure enabled by a feature this inventory cannot see", concluding that
+"an image carrying them must still state the knob". The CMake path completes it
+with `NROS_DECLARED_INFRA_QUERYABLES`; a cargo leaf has no such channel.
+
+So issue 0827's sidecar was emitting a number that is SHORT for any image with
+param services, and a short queryable table is a registration failure at boot,
+not a smaller pool. It is dropped from the derived set, with the reason written
+into every generated sidecar.
+
+This surfaced from a measurement rather than a reading: the esp32 talker
+hand-sets the knob to 2, the derivation offered 1, and the build came out
+correct **only** because the leaf's own `[env]` wins over an included file
+(confirmed: `ZPICO_MAX_QUERYABLES: usize = 2` in the generated shim constants).
+A leaf that had not hand-set it would have taken the 1.
+
+### Also fixed
+
+`check-cargo-config-tracked` rejected the new sidecar's `include` — its
+allow-list of generated targets named only the patch and board files. That gate
+exists precisely to catch an include no generator writes, so it was right to
+fire; the fix is to teach it the fourth name, not to weaken it.

--- a/examples/qemu-esp32-baremetal/rust/listener/Cargo.toml
+++ b/examples/qemu-esp32-baremetal/rust/listener/Cargo.toml
@@ -80,3 +80,17 @@ codegen-units = 1
 # README's "standalone copy-out template" promise. Canonical in-tree builds
 # also pass via the root `exclude = [...]` list (belt-and-braces).
 [workspace]
+
+# Issue 1061 — what this component creates, stated because it cannot be PROBED.
+#
+# The probe compiles a component for the host to read its declarations; this
+# leaf sets `[unstable] build-std` for a foreign target AND depends on a board
+# crate with no host build, so its metadata is `.json.unprobeable` and there is
+# nothing to derive a budget from.
+#
+# Same grammar as `nano_ros_node_register(... ENTITIES ...)`, parsed by the same
+# code. `nros sync` reads it without compiling anything, and CROSS-CHECKS it
+# against the probe on any leaf where the probe does run — so this cannot
+# silently drift from `register()`: one subscription.
+[package.metadata.nros.component]
+entities = ["sub:std_msgs/msg/String:/chatter"]

--- a/examples/qemu-esp32-baremetal/rust/talker/Cargo.toml
+++ b/examples/qemu-esp32-baremetal/rust/talker/Cargo.toml
@@ -80,3 +80,17 @@ codegen-units = 1
 # README's "standalone copy-out template" promise. Canonical in-tree builds
 # also pass via the root `exclude = [...]` list (belt-and-braces).
 [workspace]
+
+# Issue 1061 — what this component creates, stated because it cannot be PROBED.
+#
+# The probe compiles a component for the host to read its declarations; this
+# leaf sets `[unstable] build-std` for a foreign target AND depends on a board
+# crate with no host build, so its metadata is `.json.unprobeable` and there is
+# nothing to derive a budget from.
+#
+# Same grammar as `nano_ros_node_register(... ENTITIES ...)`, parsed by the same
+# code. `nros sync` reads it without compiling anything, and CROSS-CHECKS it
+# against the probe on any leaf where the probe does run — so this cannot
+# silently drift from `register()`: a publisher and the timer that drives it.
+[package.metadata.nros.component]
+entities = ["publisher:std_msgs/msg/String:/chatter", "timer"]

--- a/packages/cli/nros-cli-core/src/cmd/ws.rs
+++ b/packages/cli/nros-cli-core/src/cmd/ws.rs
@@ -4411,7 +4411,20 @@ fn write_patch_config(
     let cfg_dir = authority_dir.join(".cargo");
     let cfg = cfg_dir.join("config.toml");
     let text = std::fs::read_to_string(&cfg).unwrap_or_default();
-    let out = render_patch_config_with(&text, managed, include_rel, sidecar)
+
+    // Issue 0827 — the derived pool budgets, computed BEFORE the config is
+    // rendered because the render needs to know whether the sidecar will exist.
+    // Deciding by "am I about to write it" rather than by guessing is what keeps
+    // the file and its `include` entry in step (issue 0463).
+    //
+    // Only for an in-tree leaf: an out-of-tree consumer gets no `include` at all
+    // (#272), so a sidecar it could not reference would be a file nothing reads.
+    let derived_env: Option<String> = if sidecar {
+        render_leaf_env_sidecar(authority_dir)
+    } else {
+        None
+    };
+    let out = render_patch_config_with(&text, managed, include_rel, sidecar, derived_env.is_some())
         .wrap_err_with(|| format!("sync: edit {}", cfg.display()))?;
 
     // Atomic write (create `.cargo/` first).
@@ -4453,14 +4466,94 @@ fn write_patch_config(
         atomic_write(&managed_path, &render_managed_patch_file(&generated))?;
     }
 
+    // Issue 0827 — same temp+rename and the same "no stale file" rule as the
+    // patch sidecar above.
+    let env_path = cfg_dir.join(MANAGED_ENV_FILE);
+    match &derived_env {
+        Some(body) => atomic_write(&env_path, body)?,
+        None => {
+            let _ = std::fs::remove_file(&env_path);
+        }
+    }
+
     atomic_write(&cfg, &out)?;
     Ok(())
+}
+
+/// Issue 0827 — the `[env]` body for this leaf, or `None` when there is nothing
+/// to state.
+///
+/// `None` on every path that is not a confident derivation, and the cases are
+/// deliberately different from each other:
+///
+/// * no `metadata/` directory, or no probeable component in it — nothing ran, so
+///   there is nothing to say;
+/// * the inventory REFUSES (`Derivation::Refused`) — it says why, and a refusal
+///   is not a budget;
+/// * a parse failure — reported, and then treated as "no sidecar", because a
+///   budget derived from a half-read probe can be SHORT, and short halts the
+///   board. The leaf keeps the crate defaults, which are large rather than wrong.
+fn render_leaf_env_sidecar(leaf: &Path) -> Option<String> {
+    use crate::{
+        entity_inventory::Derivation,
+        leaf_entity_env::{inventory_for_leaf, render_env_sidecar},
+    };
+
+    let (inv, unprobeable) = match inventory_for_leaf(leaf) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "sync: {}: cannot derive pool budgets ({e}); leaving the crate defaults in place",
+                leaf.display()
+            );
+            return None;
+        }
+    };
+    if inv.is_empty() {
+        // An unprobeable component is why a leaf can have `metadata/` and still
+        // get no budget. Say so once rather than leaving it to be inferred from
+        // an absent file (issue 1061).
+        if !unprobeable.is_empty() {
+            eprintln!(
+                "sync: {}: {} component(s) are un-probeable, so pool budgets stay at the crate \
+                 defaults (issue 1061): {}",
+                leaf.display(),
+                unprobeable.len(),
+                unprobeable.join(", ")
+            );
+        }
+        return None;
+    }
+    match inv.derive() {
+        Derivation::Derived(knobs) => Some(render_env_sidecar(&knobs, &inv.source)),
+        other => {
+            eprintln!(
+                "sync: {}: pool budgets not derived ({}); crate defaults stay",
+                leaf.display(),
+                other.tag()
+            );
+            None
+        }
+    }
 }
 
 /// Issue 0457 — basename of the per-leaf gitignored file holding sync's managed
 /// `[patch.crates-io]` block. Sibling of `config.toml` inside `.cargo/`, reached
 /// by an `include` entry that `render_patch_config` maintains.
 const MANAGED_PATCH_FILE: &str = "nros-managed-patch.toml";
+
+/// Issue 0827 — basename of the per-leaf gitignored file holding sync's derived
+/// pool budgets as `[env]`.
+///
+/// A second sidecar rather than a section in the patch one, because the two
+/// answer different questions and empty independently: a leaf can have a
+/// generated message dep and no probeable component, or the reverse. Sharing a
+/// file would make each one's presence depend on the other's.
+///
+/// Same appear-and-disappear-together rule as [`MANAGED_PATCH_FILE`], and for
+/// the same reason (issue 0463): a missing `include` target is a HARD cargo
+/// error during manifest parse, so the entry exists exactly when the file does.
+const MANAGED_ENV_FILE: &str = "nros-managed-env.toml";
 
 /// Render the standalone managed-patch file: a header saying who owns it and a
 /// single `[patch.crates-io]` table of the managed entries, alphabetised.
@@ -5133,7 +5226,7 @@ fn render_patch_config(
     managed: &[(String, String)],
     include_rel: Option<&str>,
 ) -> Result<String> {
-    render_patch_config_with(existing, managed, include_rel, true)
+    render_patch_config_with(existing, managed, include_rel, true, false)
 }
 
 /// [`render_patch_config`] with the sidecar split made explicit.
@@ -5150,6 +5243,10 @@ fn render_patch_config_with(
     managed: &[(String, String)],
     include_rel: Option<&str>,
     sidecar: bool,
+    // Issue 0827 — whether this leaf gets a derived `[env]` sidecar. Same
+    // appear-and-disappear-together rule as the patch one: the caller decides by
+    // whether it is about to WRITE the file, never by guessing.
+    want_env: bool,
 ) -> Result<String> {
     use toml_edit::{DocumentMut, Item, Table, Value, value};
 
@@ -5194,7 +5291,11 @@ fn render_patch_config_with(
             .unwrap_or_default();
         let survivors: Vec<String> = current
             .iter()
-            .filter(|s| !s.ends_with(CENTRAL_PATCH_FILE) && !s.ends_with(MANAGED_PATCH_FILE))
+            .filter(|s| {
+                !s.ends_with(CENTRAL_PATCH_FILE)
+                    && !s.ends_with(MANAGED_PATCH_FILE)
+                    && !s.ends_with(MANAGED_ENV_FILE)
+            })
             .cloned()
             .collect();
         let mut desired: Vec<String> = Vec::new();
@@ -5205,6 +5306,9 @@ fn render_patch_config_with(
         let want_sidecar = sidecar && managed.iter().any(|(_, rel)| is_generated_path(rel));
         if want_sidecar {
             desired.push(MANAGED_PATCH_FILE.to_string());
+        }
+        if want_env {
+            desired.push(MANAGED_ENV_FILE.to_string());
         }
 
         if current != desired {
@@ -5218,7 +5322,11 @@ fn render_patch_config_with(
                 .ok_or_else(|| eyre!("sync: `include` is not an array"))?;
             arr.retain(|v| {
                 v.as_str()
-                    .map(|s| !s.ends_with(CENTRAL_PATCH_FILE) && !s.ends_with(MANAGED_PATCH_FILE))
+                    .map(|s| {
+                        !s.ends_with(CENTRAL_PATCH_FILE)
+                            && !s.ends_with(MANAGED_PATCH_FILE)
+                            && !s.ends_with(MANAGED_ENV_FILE)
+                    })
                     .unwrap_or(true)
             });
             if let Some(rel) = include_rel {
@@ -5247,6 +5355,10 @@ fn render_patch_config_with(
             // "run `nros sync`" before cargo says anything at all.
             if want_sidecar {
                 arr.push(MANAGED_PATCH_FILE);
+            }
+            // Issue 0827 — the derived `[env]` sidecar, on the same terms.
+            if want_env {
+                arr.push(MANAGED_ENV_FILE);
             }
             if arr.is_empty() {
                 doc.as_table_mut().remove("include");
@@ -6672,18 +6784,28 @@ libc = { path = \"../../third-party/nuttx/libc\" }\n";
         // identical. Both spellings are therefore stable, and the old
         // tight/spaced distinction is moot.
         let spaced_single = "include = [ \"../nros-patch.toml\"]\n";
-        let only_managed =
-            render_patch_config_with(spaced_single, &mng(&[]), Some("../nros-patch.toml"), false)
-                .unwrap();
+        let only_managed = render_patch_config_with(
+            spaced_single,
+            &mng(&[]),
+            Some("../nros-patch.toml"),
+            false,
+            false,
+        )
+        .unwrap();
         assert!(
             only_managed.starts_with(spaced_single.trim_end()),
             "membership unchanged: sync must not renormalise the spelling:\n{only_managed}"
         );
 
         let spaced_pair = "include = [ \"../nros-patch.toml\", \"nros-board.toml\"]\n";
-        let with_survivor =
-            render_patch_config_with(spaced_pair, &mng(&[]), Some("../nros-patch.toml"), false)
-                .unwrap();
+        let with_survivor = render_patch_config_with(
+            spaced_pair,
+            &mng(&[]),
+            Some("../nros-patch.toml"),
+            false,
+            false,
+        )
+        .unwrap();
         assert!(
             with_survivor.starts_with(spaced_pair.trim_end()),
             "a survivor keeps the array's decor, so this leaf never churns:\n{with_survivor}"
@@ -6698,7 +6820,8 @@ libc = { path = \"../../third-party/nuttx/libc\" }\n";
         // output). Membership is unchanged here, so the bytes must be too.
         let tight = "include = [\"../nros-patch.toml\", \"nros-board.toml\"]\n";
         let unchanged =
-            render_patch_config_with(tight, &mng(&[]), Some("../nros-patch.toml"), false).unwrap();
+            render_patch_config_with(tight, &mng(&[]), Some("../nros-patch.toml"), false, false)
+                .unwrap();
         assert!(
             unchanged.starts_with(tight.trim_end()),
             "membership unchanged, so the array must be byte-identical:\n  was: {tight}  now: {unchanged}"
@@ -6729,6 +6852,7 @@ libc = { path = \"../../third-party/nuttx/libc\" }\n";
             existing,
             &mng(&[("nros-core", "../nros-core")]),
             None,
+            false,
             false,
         )
         .unwrap();
@@ -7079,6 +7203,7 @@ rustflags = [
             &[("std_msgs".into(), "generated/std_msgs".into())],
             Some("../../nros-patch.toml"),
             true,
+            false,
         )
         .unwrap();
         let inc = includes(&after_patch);
@@ -7623,5 +7748,68 @@ mod search_path_tests {
             text.contains("MISSING — nothing scanned"),
             "a configured root that contributed nothing must say so:\n{text}"
         );
+    }
+
+    // ---- issue 0827: the derived `[env]` sidecar ----------------------------
+
+    /// The include entry appears ONLY when the file will be written. A missing
+    /// include target is a hard cargo error during manifest parse (issue 0463),
+    /// so "wanted" and "written" are one decision, not two.
+    #[test]
+    fn env_sidecar_include_is_added_only_when_wanted() {
+        let with = render_patch_config_with("", &[], None, true, true).unwrap();
+        assert!(
+            with.contains(MANAGED_ENV_FILE),
+            "include missing the env sidecar:\n{with}"
+        );
+        let without = render_patch_config_with("", &[], None, true, false).unwrap();
+        assert!(
+            !without.contains(MANAGED_ENV_FILE),
+            "include names a file that will not be written:\n{without}"
+        );
+    }
+
+    /// And it is EVICTED when no longer wanted, so a leaf that loses its
+    /// probeable component does not keep an include to a deleted file.
+    #[test]
+    fn env_sidecar_include_is_evicted_when_no_longer_wanted() {
+        let existing = format!("include = [\"{MANAGED_ENV_FILE}\"]\n");
+        let out = render_patch_config_with(&existing, &[], None, true, false).unwrap();
+        assert!(
+            !out.contains(MANAGED_ENV_FILE),
+            "stale include survived:\n{out}"
+        );
+    }
+
+    /// The two sidecars are independent: a leaf may want either, both or
+    /// neither, which is why they are separate files.
+    #[test]
+    fn the_two_sidecars_do_not_depend_on_each_other() {
+        // Built inline rather than via the `mng` helper: these tests live in a
+        // different test module, and reaching across for a two-line helper
+        // would couple them for no benefit.
+        let generated: Vec<(String, String)> =
+            vec![("std_msgs".to_string(), "generated/std_msgs".to_string())];
+        let both = render_patch_config_with("", &generated, None, true, true).unwrap();
+        assert!(
+            both.contains(MANAGED_PATCH_FILE) && both.contains(MANAGED_ENV_FILE),
+            "{both}"
+        );
+
+        let env_only = render_patch_config_with("", &[], None, true, true).unwrap();
+        assert!(!env_only.contains(MANAGED_PATCH_FILE), "{env_only}");
+        assert!(env_only.contains(MANAGED_ENV_FILE), "{env_only}");
+
+        let patch_only = render_patch_config_with("", &generated, None, true, false).unwrap();
+        assert!(patch_only.contains(MANAGED_PATCH_FILE), "{patch_only}");
+        assert!(!patch_only.contains(MANAGED_ENV_FILE), "{patch_only}");
+    }
+
+    /// An OUT-OF-TREE consumer gets no include at all (#272), so it must not
+    /// gain an env one either.
+    #[test]
+    fn an_external_consumer_gets_no_env_include() {
+        let out = render_patch_config_with("", &[], None, false, false).unwrap();
+        assert!(!out.contains(MANAGED_ENV_FILE), "{out}");
     }
 }

--- a/packages/cli/nros-cli-core/src/leaf_entity_env.rs
+++ b/packages/cli/nros-cli-core/src/leaf_entity_env.rs
@@ -20,10 +20,27 @@
 //! this renders. A fresh clone has neither and gets both from `nros sync` — the
 //! contract `generated/` already has.
 //!
-//! What this does NOT reach: a leaf whose metadata is `<component>.json
-//! .unprobeable`. The probe cannot run for a foreign `[build] target` with
-//! `[unstable] build-std`, nor for a component whose board crate has no host
-//! build. Those leaves state their budgets by hand and that is issue 1061.
+//! A leaf whose metadata is `<component>.json.unprobeable` cannot be probed at
+//! all — the probe compiles the component for the HOST, and neither a foreign
+//! `[build] target` with `[unstable] build-std` nor a board crate with no host
+//! build allows that. Issue 1061.
+//!
+//! For those, the leaf DECLARES instead, in its own manifest:
+//!
+//! ```toml
+//! [package.metadata.nros.component]
+//! entities = ["publisher:std_msgs/msg/String:/chatter", "timer"]
+//! ```
+//!
+//! Same grammar as `nano_ros_node_register(... ENTITIES ...)`, parsed by the
+//! same [`EntityDecl::parse`], because a second spelling of one declaration is
+//! how the two drift. Nothing is compiled to read it.
+//!
+//! **A declaration is CROSS-CHECKED against the probe wherever the probe can
+//! run.** That is what keeps a hand-written list from quietly going stale: on a
+//! probeable leaf the two must agree, and a mismatch REFUSES rather than
+//! picking one. The declaration exists for leaves where there is nothing to
+//! check it against; it does not become a way to override what the code says.
 
 use std::{collections::BTreeMap, path::Path};
 
@@ -135,6 +152,95 @@ pub fn declaration_from_probe(doc_json: &str) -> Result<(String, String, Declara
     Ok((pkg, comp, declaration))
 }
 
+/// Issue 1061 — the entities a leaf DECLARES in its own manifest.
+///
+/// `[package.metadata.nros.component] entities = [...]`, each string in the
+/// `nano_ros_node_register(... ENTITIES ...)` grammar. `Ok(None)` means the key
+/// is absent, which is different from an empty list: an empty list is a leaf
+/// asserting it creates nothing.
+pub fn declared_entities(leaf: &Path) -> Result<Option<Vec<EntityDecl>>> {
+    let manifest = leaf.join("Cargo.toml");
+    let Ok(text) = std::fs::read_to_string(&manifest) else {
+        return Ok(None);
+    };
+    let doc: toml::Value =
+        toml::from_str(&text).wrap_err_with(|| format!("parsing {}", manifest.display()))?;
+    let Some(v) = doc
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("nros"))
+        .and_then(|n| n.get("component"))
+        .and_then(|c| c.get("entities"))
+    else {
+        return Ok(None);
+    };
+    let arr = v.as_array().ok_or_else(|| {
+        eyre::eyre!(
+            "{}: `[package.metadata.nros.component] entities` must be an ARRAY of \
+             declaration strings, e.g. [\"publisher:std_msgs/msg/String:/chatter\", \"timer\"]",
+            manifest.display()
+        )
+    })?;
+    let mut out = Vec::new();
+    for item in arr {
+        let spec = item.as_str().ok_or_else(|| {
+            eyre::eyre!(
+                "{}: every `entities` element must be a string; found {item}",
+                manifest.display()
+            )
+        })?;
+        // The SAME parser the CMake path uses. A private grammar here is how a
+        // declaration means one thing in a CMakeLists and another in a manifest.
+        let decls = EntityDecl::parse(spec)
+            .map_err(|e| eyre::eyre!("{}: entities entry `{spec}`: {e}", manifest.display()))?;
+        out.extend(decls);
+    }
+    Ok(Some(out))
+}
+
+/// Compare a declaration with what the probe found, as multisets of KIND.
+///
+/// Kind only, deliberately. The probe resolves topic names and interfaces that
+/// a hand-written declaration may legitimately state loosely (`timer` carries
+/// neither), so comparing the full row would refuse honest declarations. What a
+/// budget is computed from is the per-kind COUNT, so that is what has to agree —
+/// a mismatch there is a mismatch in the numbers this module exists to produce.
+fn kind_counts(decls: &[EntityDecl]) -> BTreeMap<&'static str, usize> {
+    let mut m = BTreeMap::new();
+    for d in decls {
+        *m.entry(d.kind.tag()).or_insert(0) += 1;
+    }
+    m
+}
+
+/// `Err` when a declaration and a successful probe disagree.
+pub fn reconcile(component: &str, declared: &[EntityDecl], probed: &[EntityDecl]) -> Result<()> {
+    let (d, p) = (kind_counts(declared), kind_counts(probed));
+    if d == p {
+        return Ok(());
+    }
+    let fmt = |m: &BTreeMap<&'static str, usize>| {
+        if m.is_empty() {
+            "nothing".to_string()
+        } else {
+            m.iter()
+                .map(|(k, v)| format!("{k}x{v}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    };
+    Err(eyre::eyre!(
+        "{component}: the manifest declares {} but the code creates {}.\n  \
+         Refusing rather than choosing one: a budget from the declaration would be \
+         wrong for the image, and silently preferring the probe would let the \
+         declaration rot until it reaches a leaf where nothing can check it.\n  \
+         Fix the `[package.metadata.nros.component] entities` list, or drop it and \
+         let the probe answer.",
+        fmt(&d),
+        fmt(&p)
+    ))
+}
+
 /// Every probeable component under `<leaf>/metadata/`, as one image's inventory.
 ///
 /// `.json.unprobeable` files are skipped BY NAME and reported, because their
@@ -144,7 +250,29 @@ pub fn inventory_for_leaf(leaf: &Path) -> Result<(EntityInventory, Vec<String>)>
     let dir = leaf.join("metadata");
     let mut inv = EntityInventory::new(dir.display().to_string());
     let mut unprobeable = Vec::new();
+    // Kept beside the inventory so the reconcile below can read what was probed
+    // without `EntityInventory` growing an accessor for one caller.
+    let mut probed_rows: Vec<(String, Vec<EntityDecl>)> = Vec::new();
+    // Issue 1061 — what the leaf DECLARES, if anything. Read before the probe
+    // results so it can serve both roles: the answer where nothing was probed,
+    // and the cross-check where something was.
+    let declared = declared_entities(leaf)?;
+
     let Ok(rd) = std::fs::read_dir(&dir) else {
+        // No `metadata/` at all. A declaration still answers — that is the whole
+        // point for a leaf the probe cannot reach.
+        if let Some(d) = declared {
+            inv.insert(ComponentEntities {
+                pkg: leaf_name(leaf),
+                component: leaf_name(leaf),
+                class: leaf_name(leaf),
+                declaration: if d.is_empty() {
+                    Declaration::None
+                } else {
+                    Declaration::Stated(d)
+                },
+            });
+        }
         return Ok((inv, unprobeable));
     };
     let mut entries: Vec<_> = rd.filter_map(|e| e.ok()).map(|e| e.path()).collect();
@@ -165,6 +293,7 @@ pub fn inventory_for_leaf(leaf: &Path) -> Result<(EntityInventory, Vec<String>)>
             .wrap_err_with(|| format!("reading {}", path.display()))?;
         let (pkg, component, declaration) = declaration_from_probe(&text)
             .wrap_err_with(|| format!("parsing {}", path.display()))?;
+        probed_rows.push((component.clone(), declaration.entities().to_vec()));
         inv.insert(ComponentEntities {
             pkg,
             component: component.clone(),
@@ -172,7 +301,43 @@ pub fn inventory_for_leaf(leaf: &Path) -> Result<(EntityInventory, Vec<String>)>
             declaration,
         });
     }
+    // Issue 1061 — reconcile, or stand in.
+    match (&declared, inv.is_empty()) {
+        // Probed AND declared: they must agree. Checked per component only when
+        // there is exactly one, because a multi-component leaf's manifest states
+        // one list for the whole package and splitting it across components
+        // would be inventing an attribution.
+        (Some(d), false) => {
+            if let [(component, probed)] = probed_rows.as_slice() {
+                reconcile(component, d, probed)?;
+            }
+        }
+        // Declared with nothing probed: the declaration IS the answer. This is
+        // the unprobeable leaf, which is what issue 1061 is about.
+        (Some(d), true) => {
+            inv.insert(ComponentEntities {
+                pkg: leaf_name(leaf),
+                component: leaf_name(leaf),
+                class: leaf_name(leaf),
+                declaration: if d.is_empty() {
+                    Declaration::None
+                } else {
+                    Declaration::Stated(d.clone())
+                },
+            });
+        }
+        (None, _) => {}
+    }
     Ok((inv, unprobeable))
+}
+
+/// The leaf directory's own name, used as pkg/component when a declaration
+/// stands in for a probe that never ran and there is no probed name to use.
+fn leaf_name(leaf: &Path) -> String {
+    leaf.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("<leaf>")
+        .to_string()
 }
 
 /// The knobs a derived budget sets, and which field answers each.
@@ -185,9 +350,28 @@ pub const DERIVED_ENV_KEYS: &[&str] = &[
     "NROS_EXECUTOR_MAX_CBS",
     "NROS_RMW_SUBSCRIBER_SLOTS",
     "ZPICO_MAX_PUBLISHERS",
-    "ZPICO_MAX_QUERYABLES",
     "ZPICO_MAX_SUBSCRIBERS",
 ];
+
+/// `ZPICO_MAX_QUERYABLES` is DELIBERATELY NOT DERIVED.
+///
+/// `DerivedEntityKnobs::max_queryables` says so itself: it counts service
+/// servers and actions and "does NOT include the parameter or lifecycle service
+/// families (`PARAM_SERVICE_QUERYABLES` 6, `LIFECYCLE_SERVICE_QUERYABLES` 5):
+/// those are per-image infrastructure enabled by a feature this inventory
+/// cannot see". Its own conclusion is that "an image carrying them must still
+/// state the knob".
+///
+/// The CMake path completes it with `NROS_DECLARED_INFRA_QUERYABLES`. A cargo
+/// leaf has no such channel, so a sidecar emitting the bare count would state a
+/// number that is SHORT for any image with param services — and a short
+/// queryable table is not a smaller pool, it is a registration failure at boot.
+/// The crate default (8) is larger and safe, so the knob is left alone.
+///
+/// Found by measuring rather than by reading: the esp32 talker hand-sets it to
+/// 2, the derivation offered 1, and only the leaf's own `[env]` winning kept
+/// the image correct. A leaf that had not hand-set it would have taken the 1.
+const NOT_DERIVED_NEEDS_INFRA_COUNT: &str = "ZPICO_MAX_QUERYABLES";
 
 /// Render the gitignored `[env]` sidecar for a derived budget.
 pub fn render_env_sidecar(
@@ -214,13 +398,17 @@ pub fn render_env_sidecar(
          # this deliberately does not use. A number a human states beats a number\n\
          # derived on their behalf.\n\n",
     );
+    s.push_str(&format!(
+        "# `{NOT_DERIVED_NEEDS_INFRA_COUNT}` is not derived here — the inventory cannot\n"
+    ));
+    s.push_str("# see whether this image enables the parameter or lifecycle service\n");
+    s.push_str("# families, and a count short of them fails at registration.\n\n");
     s.push_str("[env]\n");
     let vals: BTreeMap<&str, usize> = BTreeMap::from([
         ("NROS_EXECUTOR_ACTION_CLIENTS", knobs.heavy_slots),
         ("NROS_EXECUTOR_MAX_CBS", knobs.max_cbs),
         ("NROS_RMW_SUBSCRIBER_SLOTS", knobs.max_subscribers),
         ("ZPICO_MAX_PUBLISHERS", knobs.max_publishers),
-        ("ZPICO_MAX_QUERYABLES", knobs.max_queryables),
         ("ZPICO_MAX_SUBSCRIBERS", knobs.max_subscribers),
     ]);
     for (k, v) in &vals {
@@ -328,6 +516,91 @@ mod tests {
         );
     }
 
+    // ---- issue 1061: the manifest declaration --------------------------
+
+    fn write_leaf(dir: &std::path::Path, manifest: &str) {
+        std::fs::write(dir.join("Cargo.toml"), manifest).unwrap();
+    }
+
+    #[test]
+    fn a_manifest_declaration_parses_with_the_shared_grammar() {
+        let td = tempfile::tempdir().unwrap();
+        write_leaf(
+            td.path(),
+            r#"
+[package]
+name = "p"
+[package.metadata.nros.component]
+entities = ["publisher:std_msgs/msg/String:/chatter", "timer", "sub*2"]
+"#,
+        );
+        let d = declared_entities(td.path()).unwrap().expect("declared");
+        // `sub*2` is the repeat suffix -- the SHARED grammar's, not a second one.
+        assert_eq!(d.len(), 4, "{d:?}");
+        assert_eq!(d[0].kind, EntityKind::Publisher);
+        assert_eq!(d[0].name.as_deref(), Some("/chatter"));
+        assert_eq!(d[1].kind, EntityKind::Timer);
+        assert_eq!(d[2].kind, EntityKind::Subscription);
+        assert_eq!(d[3].kind, EntityKind::Subscription);
+    }
+
+    /// Absent and empty are DIFFERENT: absent means the leaf said nothing, empty
+    /// means it asserted it creates nothing.
+    #[test]
+    fn an_absent_key_is_none_and_an_empty_list_is_some_empty() {
+        let td = tempfile::tempdir().unwrap();
+        write_leaf(td.path(), "[package]\nname = \"p\"\n");
+        assert!(declared_entities(td.path()).unwrap().is_none());
+
+        write_leaf(
+            td.path(),
+            "[package]\nname = \"p\"\n[package.metadata.nros.component]\nentities = []\n",
+        );
+        assert_eq!(declared_entities(td.path()).unwrap(), Some(vec![]));
+    }
+
+    #[test]
+    fn a_malformed_declaration_names_the_entry() {
+        let td = tempfile::tempdir().unwrap();
+        write_leaf(
+            td.path(),
+            "[package]\nname = \"p\"\n[package.metadata.nros.component]\nentities = [\"nonsense\"]\n",
+        );
+        let e = declared_entities(td.path()).unwrap_err().to_string();
+        assert!(e.contains("nonsense"), "{e}");
+
+        write_leaf(
+            td.path(),
+            "[package]\nname = \"p\"\n[package.metadata.nros.component]\nentities = \"timer\"\n",
+        );
+        let e = declared_entities(td.path()).unwrap_err().to_string();
+        assert!(e.contains("ARRAY"), "{e}");
+    }
+
+    /// The safety property: a declaration that disagrees with the code REFUSES.
+    /// Without this the manifest becomes a way to state a budget smaller than
+    /// the image, and short halts the board.
+    #[test]
+    fn a_declaration_that_disagrees_with_the_probe_refuses() {
+        let probed = EntityDecl::parse("publisher").unwrap();
+        let same = EntityDecl::parse("publisher").unwrap();
+        assert!(reconcile("c", &same, &probed).is_ok());
+
+        let fewer = EntityDecl::parse("timer").unwrap();
+        let e = reconcile("c", &fewer, &probed).unwrap_err().to_string();
+        assert!(e.contains("declares") && e.contains("creates"), "{e}");
+        assert!(e.contains("timerx1") && e.contains("publisherx1"), "{e}");
+    }
+
+    /// Compared by KIND COUNT, not by row: a declaration may legitimately state
+    /// a topic loosely, and the budget is computed from counts.
+    #[test]
+    fn reconcile_compares_counts_not_topic_names() {
+        let probed = EntityDecl::parse("sub:std_msgs/msg/String:/chatter").unwrap();
+        let declared = EntityDecl::parse("sub").unwrap();
+        assert!(reconcile("c", &declared, &probed).is_ok());
+    }
+
     #[test]
     fn the_sidecar_states_every_declared_key() {
         let (pkg, comp, d) = declaration_from_probe(TALKER).unwrap();
@@ -348,6 +621,11 @@ mod tests {
         }
         assert!(out.contains("ZPICO_MAX_SUBSCRIBERS = \"1\""), "{out}");
         assert!(out.contains("ZPICO_MAX_PUBLISHERS = \"1\""), "{out}");
+        // The infra-incomplete knob must NOT be stated as a value.
+        assert!(
+            !out.lines().any(|l| l.starts_with("ZPICO_MAX_QUERYABLES")),
+            "the sidecar states a queryable count it cannot complete:\n{out}"
+        );
         // No `force = true` KEY: a value the caller states must win. Checked
         // line-wise, because the header prose explains `force` and a substring
         // test would match the explanation rather than a setting.

--- a/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/cargo_metadata_schema.rs
@@ -360,6 +360,37 @@ pub struct ComponentMetadata {
     /// [`publishes`](Self::publishes).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subscribes: Vec<TopicDecl>,
+    /// Issue 1061 — every entity this component creates, in the
+    /// `nano_ros_node_register(... ENTITIES ...)` grammar:
+    /// `["publisher:std_msgs/msg/String:/chatter", "timer", "sub*2"]`.
+    ///
+    /// # Why this is not `publishes` + `subscribes`
+    ///
+    /// Those two answer a DATA-FLOW question for the planner — which topics a
+    /// bridge can resolve pre-build. This answers a SLOT-DEMAND question: how
+    /// many callback entries, subscriber rings and queryables the image must
+    /// reserve. Timers, service servers and actions cost slots and carry no
+    /// topic, so they cannot be expressed there, and `MAX_CBS` /
+    /// `MAX_QUERYABLES` cannot be derived without them.
+    ///
+    /// # Why it exists at all
+    ///
+    /// The metadata PROBE normally answers this by compiling the component for
+    /// the host and reading what it declares. A leaf that sets
+    /// `[unstable] build-std` for a foreign target, or depends on a board crate
+    /// with no host build, cannot be probed — its metadata is
+    /// `<component>.json.unprobeable` — and before this it had no way to say
+    /// what it creates, so its pools kept the crate defaults. On a board where
+    /// `.bss` is subtracted from the stack that is not a footprint nicety
+    /// (issue 1052).
+    ///
+    /// # It does not become a way to disagree with the code
+    ///
+    /// Where the probe CAN run, `leaf_entity_env::reconcile` compares this list
+    /// against it per kind and REFUSES on a mismatch. The declaration is for
+    /// leaves with nothing to check it against; it is not an override.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<String>,
 }
 
 /// phase-267 W1c/C3a — one declared topic endpoint in node Cargo metadata:

--- a/scripts/check-cargo-config-tracked.sh
+++ b/scripts/check-cargo-config-tracked.sh
@@ -199,7 +199,11 @@ has_orphan_include() {
         [ -n "$entry" ] || continue
         base="$(basename "$entry")"
         case "$base" in
-            nros-patch.toml | nros-managed-patch.toml | nros-board.toml) continue ;;
+            # `nros-managed-env.toml` is issue 0827's per-leaf derived `[env]`
+            # sidecar: same generator, same gitignore, same
+            # appear-and-disappear-together rule as the patch one.
+            nros-patch.toml | nros-managed-patch.toml | nros-board.toml \
+                | nros-managed-env.toml) continue ;;
         esac
         echo "    $cfg" >&2
         echo "      include -> '$entry' — no generator writes this" >&2


### PR DESCRIPTION
Stacks on #519 (0827's wiring), which this needs to write anything.

#1061's fix offered two shapes — a host stub behind a feature, or a declaration channel needing no compilation. I took the second: the first makes a target-only board crate pretend to build for a host, and the pretence has to be maintained forever.

```toml
[package.metadata.nros.component]
entities = ["publisher:std_msgs/msg/String:/chatter", "timer"]
```

Same grammar as `nano_ros_node_register(... ENTITIES ...)`, parsed by the same `EntityDecl::parse`. Nothing is compiled to read it, and it becomes the same inventory the probe would have produced — one derivation whatever the source.

**Measured on the leaf this issue is about** (`qemu-esp32-baremetal/rust/talker`, metadata `talker.json.unprobeable`): now derives `MAX_CBS=1`, `SUBSCRIBER_SLOTS=1`, `MAX_PUBLISHERS=1`, `ACTION_CLIENTS=0` where it previously got crate defaults.

## It can't become a way to disagree with the code

Where the probe **can** run, the declaration is cross-checked per kind and a mismatch **refuses**, naming both sides. Verified by breaking one deliberately:

```
sync: examples/native/rust/talker: cannot derive pool budgets
  (talker: the manifest declares timerx1 but the code creates publisherx1, timerx1. …)
```

Compared by kind **count**, not by row — a declaration may state a topic loosely, and budgets are computed from counts.

## A safety bug in my own #0827 work, found by measuring

`ZPICO_MAX_QUERYABLES` is now **deliberately not derived**. `DerivedEntityKnobs::max_queryables` says of itself that it excludes the parameter and lifecycle families (6 and 5) because they're "enabled by a feature this inventory cannot see", concluding "an image carrying them must still state the knob". The CMake path completes it via `NROS_DECLARED_INFRA_QUERYABLES`; a cargo leaf has no such channel.

So #0827's sidecar was emitting a number **short** for any image with param services — a registration failure at boot, not a smaller pool.

It surfaced only because the esp32 talker hand-sets that knob to `2` while the derivation offered `1`, and the build came out correct **only** because a leaf's own `[env]` wins over an included file (confirmed: `ZPICO_MAX_QUERYABLES: usize = 2` in the generated shim constants). A leaf that hadn't hand-set it would have taken the 1.

## Also

`check-cargo-config-tracked` rejected the new sidecar's include — and was **right** to: that gate exists to catch an include no generator writes. Taught it the fourth name rather than weakening it.

Resolves #1061. `just check fast` 224/224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)