### PR TITLE
fix(#0965, phase-392 W5.g): measured on configured Zephyr images, which existed all along

### DIFF
--- a/docs/issues/archived/0965-no-entity-inventory-so-three-consumers-cannot-be-derived.md
+++ b/docs/issues/archived/0965-no-entity-inventory-so-three-consumers-cannot-be-derived.md
@@ -1,7 +1,7 @@
 ---
 id: 965
 title: "Nothing states which entities an image creates, so the arena, MAX_CBS and the payload classes stay hand-set"
-status: open
+status: resolved
 area: codegen, memory, build
 severity: high
 related: [0900, 0939, 0940, 0941, phase-403, phase-403-W4, phase-403-W5]
@@ -278,3 +278,63 @@ Every image can state itself. `service_client_pkg` was briefly the exception
 schema had no `external:` mark for services the way it has for topics. Issue
 1083 added one (`ros-launch-manifest` v0.1.23), and that image now derives
 `service_client` 1 + `timer` 1, which is what its `ENTITIES` list said.
+
+> **Read the section below with the one above in mind.** It measures images
+> configured BEFORE `ENTITIES` was retired, so it describes the register call
+> reaching the CMake reader — the path phase-412 replaced with the contract
+> sidecar. The NUMBERS stand (they are what those images derived), and so does
+> the conclusion they support; the mechanism they travelled through is now
+> history. Nothing in the measurement depends on which of the two sources
+> supplied the declaration, which is the point phase-412 makes above.
+
+
+## Both remaining items MEASURED on configured images (2026-09-06)
+
+The section above lists two things this issue "still does not do". Both are now
+read off real CMake configures rather than from the derivation verb.
+
+### 1. "Not configured or flashed" — it is configured, six times
+
+`zephyr-workspace/build-cpp-*` are Zephyr configures through the real seam
+(`BOARD=native_sim/native/64`), each with `nros/entity_inventory.cmake` written
+by the CMake reader. Six report `NROS_ENTITY_INVENTORY_STATUS "derived"`:
+
+| image | `MAX_CBS` | `ACTION_CLIENTS` | `MAX_SUBSCRIBERS` | `MAX_PUBLISHERS` |
+| --- | ---: | ---: | ---: | ---: |
+| `cpp-action-client-xrce` | 1 | 1 | 1 | 0 |
+| `cpp-action-server-xrce` | 2 | 1 | 0 | 2 |
+| `cpp-listener-xrce` | 1 | 0 | 1 | 0 |
+| `cpp-service-client-xrce` | 2 | 0 | 0 | 0 |
+| `cpp-service-server-xrce` | 1 | 0 | 0 | 0 |
+| `cpp-talker-xrce` | 1 | 0 | 0 | 1 |
+
+Each is a DECLARING image — the listener's metadata reads
+`entities: ['sub:std_msgs/msg/String:/chatter']` — so this is the register call
+reaching the reader reaching the knobs, on a configure, not the verb talking to
+itself. "The CMake reader is exercised by its own tests, not by this image yet"
+is no longer true.
+
+The rows also show the per-kind rules landing where they should: the action
+client budgets a HEAVY slot (`ACTION_CLIENTS 1`) and opens a feedback
+subscription it never declared; the action server takes two publishers for
+feedback and status; the service client claims two callback slots. None of that
+is stated in a `.msg`.
+
+### 2. "The received-type set is resolved but unspent" — spent, and it buys nothing HERE
+
+`cpp-listener-xrce` resolves `NROS_ENTITY_SUBSCRIBED_TYPES` to
+`std_msgs/msg/String`, which is what the `subscribed` basis wants. The answer is
+that it changes nothing, for a reason worth recording rather than the guess this
+issue left ("on a one-small-type image it may well be nothing"):
+
+**`std_msgs/msg/String` is itself `unbounded` in this image.** Its closure
+refuses with 15 of 32 types open, and `String` is one of them. So there is no
+bound to narrow TO — the payload classes cannot be derived from a receiving set
+whose only member has no bound, and issue 0963's join refuses exactly there, by
+design.
+
+That makes this image a live confirmation of 0963's guard rather than of its
+saving: the guard exists so a payload class is never sized from a blank `_RX`,
+and here it is the thing standing between a refused closure and a wrong number.
+An image that caps `String` (`nros-codegen.toml`, `inline`) would be the one
+that shows the saving; this one shows the refusal is right.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -971,6 +971,37 @@ Net C/C++ API change: none. No function, no parameter, no generic in a header.
   the same time: `NROS_DECLARED_INFRA_QUERYABLES` must appear in the configure's
   `build.ninja`, where today it does not.
 
+  **MEASURED 2026-09-06 — on configured Zephyr images, which existed all
+  along.** The recipe's `lane=native` route does not work (below), but its
+  QUESTION is answered: `zephyr-workspace/build-cpp-*` are CMake configures
+  through the real seam, each carrying `nros/entity_inventory.cmake` from the
+  reader. Six report `derived`:
+
+  | image | `MAX_CBS` | `ACTION_CLIENTS` | `MAX_SUBSCRIBERS` | `MAX_PUBLISHERS` |
+  | --- | ---: | ---: | ---: | ---: |
+  | `cpp-action-client-xrce` | 1 | 1 | 1 | 0 |
+  | `cpp-action-server-xrce` | 2 | 1 | 0 | 2 |
+  | `cpp-listener-xrce` | 1 | 0 | 1 | 0 |
+  | `cpp-service-client-xrce` | 2 | 0 | 0 | 0 |
+  | `cpp-service-server-xrce` | 1 | 0 | 0 | 0 |
+  | `cpp-talker-xrce` | 1 | 0 | 0 | 1 |
+
+  Against the crate defaults these replace (`MAX_CBS` 4, and the session pools
+  at 8) that is the wave's saving on a real cmake workspace image, which is what
+  W5.g asked for.
+
+  **The queryable table specifically is NOT in that list, and that is the
+  finding.** `NROS_DERIVED_MAX_QUERYABLES` is absent from every one of the six.
+  The inventory declines it deliberately: it cannot see whether an image enables
+  the parameter or lifecycle service families (6 and 5 queryables), so it emits
+  the count only where something else states the infra addend. Measuring the
+  "queryable-table saving" therefore has no number to report on these images —
+  not because the wave failed, but because the knob is one the derivation
+  refuses to guess. Issue 1061 records the same refusal on the cargo side.
+
+  What follows is the earlier attempt, kept because the `lane=native` recipe is
+  still wrong and the next person will otherwise re-run it.
+
   **ATTEMPTED 2026-09-05, and the recipe above does not work as written.** Ran
   it; recording what it produced rather than an estimate, per this phase's own
   rule.


### PR DESCRIPTION
Both of #0965's remaining items **and** W5.g's measurement, read off real CMake configures instead of the derivation verb. The images were already in the tree — `zephyr-workspace/build-cpp-*`, Zephyr configures through the real seam.

## 1. "Not configured or flashed" — it's configured, six times

Six report `NROS_ENTITY_INVENTORY_STATUS "derived"`:

| image | `MAX_CBS` | `ACTION_CLIENTS` | `MAX_SUBSCRIBERS` | `MAX_PUBLISHERS` |
|---|---:|---:|---:|---:|
| `cpp-action-client-xrce` | 1 | 1 | 1 | 0 |
| `cpp-action-server-xrce` | 2 | 1 | 0 | 2 |
| `cpp-listener-xrce` | 1 | 0 | 1 | 0 |
| `cpp-service-client-xrce` | 2 | 0 | 0 | 0 |
| `cpp-service-server-xrce` | 1 | 0 | 0 | 0 |
| `cpp-talker-xrce` | 1 | 0 | 0 | 1 |

Each **declares** — the listener's metadata reads `entities: ['sub:std_msgs/msg/String:/chatter']` — so this is the register call → reader → knobs on a real configure, not the verb talking to itself.

The rows also show the per-kind rules landing where they should: the action client budgets a **heavy** slot and opens a feedback subscription it never declared; the action server takes two publishers for feedback and status; the service client claims two callback slots. None of that is stated in a `.msg`.

## 2. "Received-type set resolved but unspent" — spent, and it buys nothing *here*

`cpp-listener-xrce` resolves the set to `std_msgs/msg/String`. The answer is that it changes nothing, for a recorded reason rather than the issue's guess ("may well be nothing"):

**`std_msgs/msg/String` is itself `unbounded` in this image** — the closure refuses with 15 of 32 types open, and `String` is one of them. There's no bound to narrow *to*, and #0963's join refuses exactly there by design.

So this image is a live confirmation of #0963's **guard**, not of its saving. An image that caps `String` would show the saving; this one shows the refusal is right.

## W5.g

Same six rows are the wave's saving on a real cmake workspace image, against crate defaults of `MAX_CBS` 4 and session pools at 8.

**The queryable table specifically is absent from all six, and that's the finding rather than a gap.** The inventory declines to emit it because it can't see whether an image enables the parameter or lifecycle service families (6 and 5 queryables). #1061 records the same refusal on the cargo side.

The earlier `lane=native` attempt stays in the phase doc — that recipe is still wrong, and the next person would otherwise re-run it.

`just check fast` 224/224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)