### PR TITLE
phase-431: ship the `nros` binary — the plan, and W1's guard re-key

### DIFF
--- a/docs/design/0090-codegen-version-is-the-compatibility-token.md
+++ b/docs/design/0090-codegen-version-is-the-compatibility-token.md
@@ -312,10 +312,16 @@ serialization format.
 
 ## Open questions
 
-1. Does `MIN` start equal to `N` (no window) or one behind? A window costs
-   nothing until the first bump, and `generated/` is never committed, so
-   regeneration is always available — which argues for starting with no window
-   and adding one only when a real migration needs it.
+1. ~~Does `MIN` start equal to `N`?~~ **ANSWERED 2026-09-06 by phase-431's
+   release cadence.** `MIN` starts equal to `N`, and the rule for moving it
+   follows from the cadence rather than from taste: **bump `NROS_CODEGEN_VERSION`
+   freely, raise `NROS_CODEGEN_VERSION_MIN` only deliberately.** In-tree a bump
+   costs one regeneration, because `generated/` is never committed. Raising `MIN`
+   costs something different in kind — it strands every RELEASED binary emitting
+   below the new floor, and under a curated cadence (tag only when asked) those
+   are exactly the binaries users have. Raise it when you are willing to say
+   "that release can no longer build against this runtime", and say so in the
+   release notes.
 2. Where does the C/C++ anchor's `N` come from at *configure* time, for the four
    configure-time emitters phase-424 registered? The binary can be asked
    (`nros --codegen-version`), but that is a process launch per configure.

--- a/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md
+++ b/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md
@@ -1,19 +1,32 @@
 # Phase 429 — the codegen version is enforced everywhere
 
-**Status (2026-09-05).** W1, W2, W3, W5 and W7 landed. W4 and W6 resolved as
-"already true" and "smaller than filed" — each records the measurement that
-settled it, because both were written from a guess I did not check first.
+**Status (2026-09-06). Every work item is landed or resolved.** W1, W2, W3, W5
+and W7 shipped; W4 and W6 closed as "already true" and "smaller than filed", each
+recording the measurement that settled it, because both were written from a guess
+I did not check first.
 
 The token exists and every generated artifact carries it. C and C++ refuse at
 COMPILE time through the preprocessor (the first implementation used a weak
 anchor symbol and was replaced: this project avoids those, and the check turned
 out to decompose into one new check plus `nros_config_variant_<slug>`, which
 already existed). Rust refuses under `cargo check`. The ratchet holds the
-authored integer to its surface. `check-codegen-version-refusal` is the negative
-control that proves every arm actually fires — C, C++ and Rust.
+authored integer to its surface.
 
-**Not done, and it is the point of all of it:** shipping a prebuilt binary. That
-is a release decision, now unblocked rather than taken.
+`check-codegen-version-refusal` proves all of it fires, in **seven arms across
+three languages** — in range compiles, out of range is refused, and a config
+header that defines neither bound is refused as MISSING rather than as
+out-of-range. The Rust arm arrived last and is a correction: this phase first
+recorded it as unreachable, citing CLAUDE.md's ban on compiling inside tests.
+That ban is on compiling at TEST RUNTIME and a negative control is a GATE —
+`check-c` has compiled an expected-failure probe for years. The option was never
+closed; the reason given for skipping it was wrong.
+
+**Not done, and it is the point of all of it:** shipping a prebuilt binary. The
+correctness question that blocked it since phase-287/288 — *can this binary's
+output work with this runtime?* — now has an answer asserted at every layer and a
+negative control proving each refusal fires. The remaining work is distribution,
+and it has its own home:
+[phase-431](phase-431-ship-the-nros-binary.md).
 
 **Implements:** [RFC-0090](../design/0090-codegen-version-is-the-compatibility-token.md).
 **Closes:** the residue of [#1018](../issues/1018-a-codegen-change-invalidates-generated-interfaces-and-only-a-manual-step-connects-them.md).

--- a/docs/roadmap/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/phase-431-ship-the-nros-binary.md
@@ -1,0 +1,176 @@
+# Phase 431 — ship the `nros` binary
+
+**Status (2026-09-06).** Opened. No code yet. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
+removed the correctness blocker; what remains is distribution mechanics plus one
+hazard that shipping CREATES and that is worth fixing before the first release
+rather than after.
+
+**Implements:** [RFC-0014](../design/0014-nros-setup-toolchain-management.md)
+(provisioning) extended to the CLI itself, and
+[RFC-0040](../design/0040-distribution-and-scaffolding-deps.md).
+**Unblocks:** [#0171](../issues/archived/0171-no-external-distribution-path.md)'s
+D1/D2 — *"ship the `nros` CLI as an installable artifact … the single
+highest-leverage unlock"*, blocked since phase-287/288.
+**Depends on:** phase-429, which answers *can this binary's output work with this
+runtime?* — the question that made shipping unsafe.
+
+## Why this is a phase and not a release chore
+
+The distribution machinery already exists and is in daily use. `nros-sdk-index.toml`
+carries `[tool.X]` with `version`, `dist.<host>.{url,sha256}`, a `smoke` check and
+a `[tool.X.source]` fallback; assets live on `NEWSLabNTU/nano-ros-sdk` Releases
+(`tag = <tool>-<version>`, `asset = <tool>-<host>.tar.zst`); `nros setup --tool
+<name>` installs one; and `~/.nros/bin` already fronts `zenohd`,
+`MicroXRCEAgent` and `play_launch_parser`.
+
+`nros` is the one tool absent from it, for two reasons that are not paperwork:
+
+1. **The bootstrap paradox.** You cannot `nros setup --tool nros` without an
+   `nros`. Something outside the CLI has to place the first one.
+2. **Shipping inverts an exemption that is currently correct.** See W1 — this is
+   the item to do first, because it is a hazard from the day a binary exists on a
+   developer's machine, and it is independent of every other decision here.
+
+## Decisions taken (2026-09-06)
+
+| question | answer |
+| --- | --- |
+| hosts | **Linux only** for now. The index has `macos-arm64` and the tree defers macOS support; a `nros` asset for it would be a support claim we do not make. |
+| cadence | **Tag only when explicitly asked.** The CLI rolls rapidly in-tree; a release is a deliberate act, not a consequence of a version bump. |
+| what a release is for | working builds for USERS, cut when needed — not a mirror of `main`. |
+| one command | `nros` always means the newest installed. Versions accumulate in the store; the command does not fork. |
+
+### What "rapid in-tree, rare releases" implies for `NROS_CODEGEN_VERSION_MIN`
+
+This answers RFC-0090's open question 1, and the answer follows from the cadence
+rather than from taste.
+
+**Bump `NROS_CODEGEN_VERSION` freely; raise `NROS_CODEGEN_VERSION_MIN` only
+deliberately.** In-tree a bump costs one regeneration, because `generated/` is
+never committed. Raising `MIN` costs something different in kind: it **strands
+every released binary that emits below the new floor**, and under a curated
+cadence those binaries are exactly the ones users have.
+
+So `MIN` is not a hygiene knob. Raise it when you are willing to say "that
+release can no longer build against this runtime", and say so in the release
+notes. The set of versions in the wild is small and knowable precisely because
+releases are rare — which is what makes this policy affordable.
+
+## Work items
+
+### W1 — the stale guard keys on the WORKSPACE, not on the binary's path
+
+**Do this first. It is a latent hazard today and an active one the day a binary
+ships, and it depends on nothing else here.**
+
+`stale_guard.rs` decides whether to check freshness by asking where the BINARY
+lives:
+
+```rust
+/// `<root>` when `exe` is `<root>/packages/cli/target/**/nros`, else `None`.
+fn checkout_root_of(exe: &Path) -> Option<PathBuf>
+```
+
+An installed `~/.nros/bin/nros` is therefore **exempt from the staleness check
+entirely**. That is correct today: no released binary exists, so a non-checkout
+`nros` is someone's deliberate experiment. It stops being correct the moment we
+ship — a developer whose PATH resolves to the released binary inside a checkout
+gets no freshness check at all, and emits with whatever that release's emitters
+were.
+
+**Phase-429 does NOT cover this.** The codegen version catches an INCOMPATIBLE
+emitter. A released binary at the same version whose emitters have merely MOVED
+is a freshness question, and `codegen-fingerprint` — which answers it — is
+consulted by the fixture stamps, not at `nros` invocation.
+
+The question the guard should ask is about the WORKSPACE it is operating on: if
+that tree is a nano-ros checkout carrying CLI sources, the running binary must be
+that checkout's build, whoever it is. Then a shadow refuses with an explanation
+instead of quietly emitting, and correctness stops depending on `activate.sh`
+having been sourced.
+
+**Acceptance.** A released-shaped binary invoked against a checkout refuses and
+names the remedy. The same binary invoked against a user project with no CLI
+sources does not. Both observed, not reasoned.
+
+### W2 — a shadow is an error, and CI may not install the release
+
+* `warn_stale_shadow` in `justfile` warns today while its own text says
+  *"`just doctor` will FAIL until this is resolved"*. Make that true.
+* **A gate that no workflow installs the released binary.** The five CI
+  acquisition sites build from source and assert `nros source-stamp`
+  (phase-429 W5). A workflow that quietly switched to the download would stop
+  testing the tree while staying green — the class `check-lane-contracts` exists
+  for. Contributors and CI build from source, always; the release is for users.
+
+**Acceptance.** The gate fails when a workflow is edited to fetch the asset.
+
+### W3 — the store holds versions, `nros` means the newest
+
+```
+~/.nros/sdk/nros/<version>/bin/nros     versions accumulate
+~/.nros/bin/nros                        the one command -> newest
+```
+
+This is the shape the store already has — `~/.nros/sdk/qemu/` holds
+`11.0.0-nros2` and `11.0.0-nros6` side by side, and consumers enumerate
+newest-first (`sort -Vr`, `COMPARE NATURAL ORDER DESCENDING`).
+
+**Write `<store>/nros/<version>/` from the first install and never a flat
+prefix.** Issue 0625 is what a flat prefix costs: `corrosion` was installed
+without a version component, a `<store>/<tool>/*/` glob matched its `lib/` and
+`share/` as if they were versions, and under `sort -Vr` a pure-alpha name sorts
+AHEAD of numeric ones — `lib` won 155 of 183 resolutions in one configure.
+
+Plus the `[tool.nros]` index entry, with a `smoke` check that runs
+`bin/nros --codegen-version` rather than `--version`: the interesting property of
+this particular tool is what it emits.
+
+### W4 — `bootstrap.sh` downloads, and still builds from source
+
+The paradox-breaker. Fetch `nros-<host>.tar.zst` + verify sha256, install through
+W3, and keep the source build as the fallback for an unsupported host and as the
+contributor path (`--from-source`). The book's step 2 stops being "build the CLI"
+for a user and stays exactly that for a contributor.
+
+### W5 — the release workflow
+
+Manual dispatch plus an explicit tag, mirroring `nano-ros-sdk`'s `build-tool.yml`
+rather than inventing a second shape. Never a local build — the SDK repo's own
+convention, and the reason is reproducibility rather than convenience.
+
+**The release must assert what it ships**: the built binary's
+`--codegen-version` against the tree it was built from, so a release cannot go
+out claiming a compatibility it does not have.
+
+### W6 — the docs stop describing a source-only distribution
+
+`book/src/getting-started/installation.md` currently carries a note explaining
+why step 2 builds rather than downloads, added by phase-429 W7. That note becomes
+wrong on the first release and should be replaced, not deleted — the reason
+prebuilt binaries were withdrawn is worth keeping, with the answer now attached.
+`AGENTS.md` and `scripts/bootstrap.sh`'s header (*"there is no prebuilt `nros`
+download"*) likewise.
+
+## What this phase must not do
+
+**Do not let CI consume the release.** The whole value of building from source in
+CI is that it tests the tree. A green lane running last month's binary is worse
+than no lane.
+
+**Do not make `nros` mean two things.** One command, newest installed. A
+`nros-<version>` alias per install is a different feature and is not this.
+
+**Do not raise `MIN` to tidy up.** See the policy above: it strands released
+binaries, and under this cadence those are the ones users have.
+
+## Acceptance for the phase
+
+* A user on Linux with no checkout can obtain `nros`, run `nros setup`, and build
+  a workspace.
+* A developer with the release installed cannot silently use it against a
+  checkout.
+* No CI workflow consumes the release.
+* A second install of a newer version moves `nros` without removing the older
+  one.
+* The release states the codegen version it emits.

--- a/packages/cli/nros-cli-core/src/stale_guard.rs
+++ b/packages/cli/nros-cli-core/src/stale_guard.rs
@@ -43,11 +43,28 @@ fn command_is_guarded(name: &str) -> bool {
     )
 }
 
-/// Refuse to run when this binary is older than the sources it was built from.
+/// Refuse to run when this binary is older than the sources it was built from,
+/// or when it is a FOREIGN binary being run against a checkout.
 ///
-/// Only applies to a binary living INSIDE a checkout's `packages/cli/target/`.
-/// An installed copy (`~/.nros/bin/nros`) is not "stale relative to" a checkout
-/// it does not belong to, and blocking it would break every out-of-tree user.
+/// Two questions, and phase-431 W1 added the second because shipping a prebuilt
+/// `nros` inverts what the first one's exemption means.
+///
+/// 1. **Is this binary stale relative to the checkout it lives in?** Keyed on
+///    the binary's own path. Unchanged.
+/// 2. **Is a binary from somewhere else being run against a checkout?** Keyed on
+///    the WORKSPACE. Until there was a release to install, the only non-checkout
+///    `nros` was a deliberate experiment, so exempting it was right. Once
+///    `~/.nros/bin/nros` exists on developer machines, that exemption becomes a
+///    hole: a PATH accident silently disables the freshness check inside a
+///    checkout, and the binary emits with whatever ITS emitters were.
+///
+/// RFC-0090's codegen version does not cover case 2. It catches an INCOMPATIBLE
+/// emitter; a release at the same version whose emitters have merely MOVED is a
+/// freshness question, and the fingerprint that answers it is consulted by the
+/// fixture stamps, not here.
+///
+/// An installed copy run against a user's own project is still exempt, which is
+/// the case the original exemption existed to protect.
 pub fn refuse_if_stale(command_name: &str) -> Result<(), String> {
     if std::env::var_os("NROS_SKIP_STALE_CHECK").is_some() {
         return Ok(());
@@ -58,6 +75,13 @@ pub fn refuse_if_stale(command_name: &str) -> Result<(), String> {
     let Ok(exe) = std::env::current_exe() else {
         return Ok(());
     };
+    // The workspace is the cwd. Passed in rather than read inside, so the
+    // decision is a pure function of two paths and its tests need no
+    // `set_current_dir` — a process-global that leaks between parallel tests
+    // (issue 1101 is that hazard, one crate over).
+    if let Ok(cwd) = std::env::current_dir() {
+        refuse_if_foreign_to_workspace(&exe, &cwd)?;
+    }
     let Some(root) = checkout_root_of(&exe) else {
         return Ok(());
     };
@@ -103,6 +127,55 @@ pub fn refuse_if_stale(command_name: &str) -> Result<(), String> {
     ))
 }
 
+/// phase-431 W1 — refuse a binary that does not belong to the checkout it is
+/// being run against.
+///
+/// The workspace decides, not the binary: if the current directory sits inside a
+/// nano-ros checkout AND that checkout can build a CLI, then the running `nros`
+/// must be that checkout's own build. Anything else is a shadow — a released
+/// binary on `PATH`, another checkout's build, a stray copy — and it emits with
+/// emitters nobody in this tree can see.
+///
+/// Deliberately silent in three cases, each of which would otherwise break a
+/// legitimate flow:
+///
+/// * the cwd is not in a checkout — a user's own project, which is exactly what
+///   a released binary is FOR;
+/// * the checkout carries no `packages/cli` sources — nothing to be foreign to;
+/// * `current_exe` or the cwd cannot be resolved — skip rather than guess, the
+///   same rule the stamp comparison already follows.
+fn refuse_if_foreign_to_workspace(exe: &Path, workspace: &Path) -> Result<(), String> {
+    let Some(ws_root) = crate::abi_guard::find_monorepo_root(workspace) else {
+        return Ok(());
+    };
+    // A checkout with no CLI sources cannot expect one to be built from it.
+    if !ws_root.join("packages/cli/Cargo.toml").is_file() {
+        return Ok(());
+    }
+    let exe_real = exe.canonicalize().unwrap_or_else(|_| exe.to_path_buf());
+    let expected_dir = ws_root.join("packages/cli/target");
+    let expected_real = expected_dir
+        .canonicalize()
+        .unwrap_or_else(|_| expected_dir.clone());
+    if exe_real.starts_with(&expected_real) {
+        return Ok(());
+    }
+    Err(format!(
+        "this `nros` does not belong to the checkout it is being run against.\n\
+         \x20   running: {}\n\
+         \x20   checkout: {}\n\
+         A binary from outside this tree emits with ITS OWN codegen, which may\n\
+         differ from this checkout's while carrying the same codegen version —\n\
+         the version catches an incompatible emitter, not one that merely moved\n\
+         (RFC-0090, phase-431 W1). Build and use this checkout's own CLI:\n\
+         \x20   ./scripts/bootstrap.sh      (contributors: just setup-cli)\n\
+         \x20   source ./activate.sh\n\
+         Override for a deliberate experiment: NROS_SKIP_STALE_CHECK=1",
+        exe_real.display(),
+        ws_root.display(),
+    ))
+}
+
 /// `<root>` when `exe` is `<root>/packages/cli/target/**/nros`, else `None`.
 fn checkout_root_of(exe: &Path) -> Option<PathBuf> {
     let mut dir = exe.parent()?;
@@ -134,4 +207,96 @@ pub fn stamp_pair() -> Option<(String, String)> {
     let root = checkout_root_of(&exe)?;
     let current = source_stamp::source_stamp(&root)?;
     Some((BUILT_STAMP.to_string(), current))
+}
+
+#[cfg(test)]
+mod foreign_binary_tests {
+    use super::*;
+    use std::fs;
+
+    /// A checkout is "a tree with `packages/core/nros-core/Cargo.toml`" — the
+    /// marker `abi_guard::find_monorepo_root` already uses — plus CLI sources.
+    fn fake_checkout(root: &Path) {
+        fs::create_dir_all(root.join("packages/core/nros-core")).unwrap();
+        fs::write(root.join("packages/core/nros-core/Cargo.toml"), "").unwrap();
+        fs::create_dir_all(root.join("packages/cli/target/release")).unwrap();
+        fs::write(root.join("packages/cli/Cargo.toml"), "").unwrap();
+    }
+
+    fn stray(tmp: &Path) -> PathBuf {
+        let p = tmp.join("elsewhere/nros");
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, "").unwrap();
+        p
+    }
+
+    /// The whole point of phase-431 W1: a binary from outside the tree is
+    /// refused when it is run AGAINST that tree.
+    #[test]
+    fn a_foreign_binary_is_refused_against_a_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("checkout");
+        fake_checkout(&root);
+        let err = refuse_if_foreign_to_workspace(&stray(tmp.path()), &root)
+            .expect_err("a binary outside the checkout must be refused");
+        assert!(
+            err.contains("does not belong to the checkout"),
+            "the message must say WHICH problem this is: {err}"
+        );
+        // phase-368 / `check-emitter-just-spelling`: a user-reachable message
+        // that names a `just` recipe must name the USER spelling beside it.
+        // This message becomes MORE user-reachable once a binary ships — a
+        // user who wanders into a checkout is exactly who sees it.
+        assert!(
+            err.contains("./scripts/bootstrap.sh") && err.contains("just setup-cli"),
+            "the remedy must carry both spellings, user first: {err}"
+        );
+    }
+
+    /// The negative control, and the case the original exemption existed to
+    /// protect: a released binary building a USER's project must not be
+    /// refused. Without this, shipping would break every out-of-tree consumer.
+    #[test]
+    fn a_foreign_binary_is_fine_outside_any_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("user-project");
+        fs::create_dir_all(&project).unwrap();
+        assert!(refuse_if_foreign_to_workspace(&stray(tmp.path()), &project).is_ok());
+    }
+
+    /// The checkout's own build is what the tree wants, so it passes this check
+    /// and goes on to the staleness comparison.
+    #[test]
+    fn the_checkouts_own_binary_passes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("checkout");
+        fake_checkout(&root);
+        let own = root.join("packages/cli/target/release/nros");
+        fs::write(&own, "").unwrap();
+        assert!(refuse_if_foreign_to_workspace(&own, &root).is_ok());
+    }
+
+    /// A tree with the runtime marker but no CLI sources cannot expect a CLI to
+    /// be built from it, so there is nothing to be foreign to. Without this arm
+    /// a consumer vendoring `packages/core` would be refused.
+    #[test]
+    fn a_tree_with_no_cli_sources_is_not_a_checkout_for_this_purpose() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("vendored");
+        fs::create_dir_all(root.join("packages/core/nros-core")).unwrap();
+        fs::write(root.join("packages/core/nros-core/Cargo.toml"), "").unwrap();
+        assert!(refuse_if_foreign_to_workspace(&stray(tmp.path()), &root).is_ok());
+    }
+
+    /// A subdirectory of the checkout is still the checkout — the walk-up is
+    /// what makes this usable from anywhere in the tree.
+    #[test]
+    fn a_subdirectory_of_the_checkout_still_counts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("checkout");
+        fake_checkout(&root);
+        let deep = root.join("examples/native/rust/talker");
+        fs::create_dir_all(&deep).unwrap();
+        assert!(refuse_if_foreign_to_workspace(&stray(tmp.path()), &deep).is_err());
+    }
 }


### PR DESCRIPTION
[Phase-429](../blob/main/docs/roadmap/phase-429-the-codegen-version-is-enforced-everywhere.md) removed the correctness blocker on shipping a prebuilt `nros`. This carries the distribution plan **and W1**, which is not distribution work — it's a hazard that shipping *creates*, worth fixing before the first release rather than after.

## W1 — the guard asks about the WORKSPACE, not the binary

`refuse_if_stale` decided whether to check anything by asking where the **binary** lives:

```rust
/// `<root>` when `exe` is `<root>/packages/cli/target/**/nros`, else `None`.
```

so an installed `~/.nros/bin/nros` was **exempt from the staleness check entirely**. Correct while no release exists — a non-checkout `nros` is then a deliberate experiment, and blocking it would break every out-of-tree user. It stops being correct the day we ship: a developer whose PATH resolves to the release inside a checkout gets no freshness check at all.

**RFC-0090 does not cover this**, and the distinction is the point: the codegen version catches an *incompatible* emitter; a release at the *same* version whose emitters have merely **moved** is a freshness question, and the fingerprint that answers it is consulted by the fixture stamps, not at `nros` invocation.

Two questions now, and the second is new:

| | question | keyed on |
|---|---|---|
| 1 | is this binary stale relative to the checkout it lives in? | the binary (unchanged) |
| 2 | is a binary from *somewhere else* being run against a checkout? | **the workspace** |

**Additive on purpose.** Replacing (1) with (2) would have stopped guarding a case (1) covers — a stale in-tree binary building an out-of-tree project, where the workspace is in no checkout.

### Observed, with a real binary

```
foreign binary vs the checkout  -> refused, naming the remedy
same binary, user project       -> proceeds     <- what a release is FOR
the checkout's own binary       -> proceeds to the stamp comparison
```

The middle case is what the original exemption existed to protect, and why this had to be a new check rather than a tightened one.

### The decision is a pure function of two paths

My first version read `current_dir()` inside it and the tests used `set_current_dir` — process-global state that leaks between parallel tests. They passed **by luck**: my own mutex released before the cwd changed. That is [#1101](../blob/main/docs/issues/1101-sim-time-clock-source-test-depends-on-process-global-state.md)'s hazard exactly, filed a day earlier, one crate over. The workspace is a parameter now; verified across three parallel runs.

Five tests. The two that keep it honest are the negative controls: a released binary outside any checkout must **not** be refused, and a tree carrying `packages/core` but no CLI sources is not a checkout for this purpose — without that arm a consumer vendoring the runtime would be blocked.

`check-emitter-just-spelling` also caught the new message naming `just setup-cli` without the user spelling beside it (phase-368). Apt here, because W1 makes this message *more* user-reachable.

## Decisions recorded in the phase doc

| question | answer |
|---|---|
| hosts | **Linux only.** The index has `macos-arm64` and the tree defers macOS; an asset there would be a support claim we do not make. |
| cadence | **Tag only when explicitly asked.** The CLI rolls rapidly in-tree; a release is a deliberate act. |
| one command | `nros` always means the newest installed. Versions accumulate; the command does not fork. |

### The cadence answers RFC-0090's open question 1

**Bump `NROS_CODEGEN_VERSION` freely; raise `NROS_CODEGEN_VERSION_MIN` only deliberately.** In-tree a bump costs one regeneration (`generated/` is never committed). Raising `MIN` **strands every released binary** below the new floor — and under a curated cadence those are exactly the binaries users have.

## Two traps written down rather than rediscovered

* **`<store>/nros/<version>/` from the first install, never a flat prefix.** Issue 0625: `corrosion` had no version component, a `<store>/<tool>/*/` glob matched its `lib/` and `share/` as versions, and under `sort -Vr` a pure-alpha name sorts *ahead* of numeric ones — `lib` won 155 of 183 resolutions in one configure.
* **CI must never consume the release.** A green lane running last month's binary is worse than no lane. W2 gates it.

Also updates phase-429's status now that every item is landed, including the Rust negative control it had recorded as uncoverable for a reason that was wrong.

`check fast` 231/231; `nros-cli-core` lib tests 932/932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK