### PR TITLE
ci(gate): the warm job never ran sccache, so it warmed nothing

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1030,10 +1030,60 @@ jobs:
             sccache-${{ runner.os }}-check-
             sccache-${{ runner.os }}-
 
+      # The warm job must START sccache, and must name it as the compiler
+      # wrapper ITSELF. Both halves were missing and the job warmed nothing.
+      #
+      # The `check` job gets away without either because every build it runs
+      # goes through `just`, and `justfile:13` is
+      # `export RUSTC_WRAPPER := command -v sccache`. This job calls `cargo`
+      # DIRECTLY, so that export never applies: no wrapper ran, `/tmp/sccache`
+      # was never created, and the save step ended every run with
+      #
+      #   Path Validation Error: Path(s) specified in the action for caching
+      #   do(es) not exist, hence no cache is being saved.
+      #
+      # which is a warning, not a failure, so the job stayed green while
+      # producing nothing. Measured consequence: NO `sccache-*` entry has ever
+      # existed on `refs/heads/main`, and a `pull_request` run may restore only
+      # from its own ref or the default branch — so every PR compiled cold at a
+      # 1.55% hit rate (19 hits / 1210 misses on run 33991268794), which is
+      # most of `check cli-tests`' 311 s.
+      #
+      # Same shape as the `check` job's configure step and for the same reason
+      # (issue 0874): PROVE the backend in this step, publish to `$GITHUB_ENV`
+      # only if the server started. A broken sccache handed to `rustc` fails
+      # the COMPILER rather than losing a cache.
+      - name: Configure sccache
+        run: |
+          # Create the dir unconditionally: the cache path must exist at save
+          # time or the step warns and saves nothing, which is the failure this
+          # is fixing. An empty dir is a 0-byte entry, not a wrong one.
+          mkdir -p /tmp/sccache
+          if ! command -v sccache >/dev/null 2>&1; then
+            echo "::warning::sccache absent from the image — this job warms NOTHING."
+            exit 0
+          fi
+          sccache --version
+          export SCCACHE_DIR=/tmp/sccache
+          export SCCACHE_CACHE_SIZE=1G
+          export SCCACHE_ERROR_LOG=/tmp/sccache-server.log
+          export SCCACHE_LOG=warn
+          if sccache --start-server >/tmp/sccache-start.log 2>&1; then
+            {
+              echo "SCCACHE_DIR=/tmp/sccache"
+              echo "SCCACHE_ERROR_LOG=/tmp/sccache-server.log"
+              echo "SCCACHE_LOG=warn"
+              echo "SCCACHE_CACHE_SIZE=1G"
+              # The half the `check` job does not need. Without it the builds
+              # below are plain rustc and this job is decorative.
+              echo "RUSTC_WRAPPER=sccache"
+            } >> "$GITHUB_ENV"
+          else
+            echo "::warning::sccache unavailable — this job warms NOTHING (issue 0874)."
+            sed 's/^/  /' /tmp/sccache-start.log || true
+          fi
+
       - name: Build nros CLI + the launch resolver
-        env:
-          SCCACHE_DIR: /tmp/sccache
-          SCCACHE_CACHE_SIZE: 1G
         run: |
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
@@ -1045,6 +1095,22 @@ jobs:
           # compiles the test harnesses without executing them, which is exactly
           # the artifact that step waits on.
           cargo test --no-run --manifest-path packages/cli/Cargo.toml
+
+      # Say what was actually warmed. This job was green for its whole life
+      # while saving nothing, because the only evidence was a `::warning::` in
+      # the save step's log. A size of 0 here means the wrapper did not run and
+      # every PR after this one will compile cold — the one number that says
+      # whether the job did its job.
+      - name: Report what was warmed
+        if: always()
+        run: |
+          if command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats || true
+          fi
+          echo "sccache dir: $(du -sh /tmp/sccache 2>/dev/null | cut -f1) in $(find /tmp/sccache -type f 2>/dev/null | wc -l) file(s)"
+          if [ -z "$(find /tmp/sccache -type f 2>/dev/null | head -1)" ]; then
+            echo "::warning::sccache dir is EMPTY — nothing to save, so every pull request will compile cold."
+          fi
 
   scaffold-journey:
     name: nros new -> sync -> resolve


### PR DESCRIPTION
`#520` fixed the **scoping** of the compile-tier cache and left its **writer** dead.

## What is wrong

`warm-cache` sets `SCCACHE_DIR` and then calls `cargo` directly. But `RUSTC_WRAPPER` comes from `justfile:13`, which only applies to builds that go through `just` — the `check` job's do, this job's do not. So no wrapper ever ran, `/tmp/sccache` was never created, and every run ended with:

```
Post Cache sccache directory
[warning]Path Validation Error: Path(s) specified in the action for caching
do(es) not exist, hence no cache is being saved.
```

A warning, not a failure — so the job has been green for its whole life while producing nothing.

## What it costs

There is **no `sccache-*` entry on `refs/heads/main` at all**. A `pull_request` run may restore only from its own ref or the default branch, so every PR compiles cold:

```
Cache not found for input keys: sccache-Linux-check-<sha>, sccache-Linux-check-
Cache hits                 19
Cache misses             1210
Cache hits rate          1.55 %      (run 33991268794)
```

That is most of `just check cli-tests` — the single biggest step, 311 s of an 866 s `check` job — and the step is **compile-bound, not test-bound**: measured warm locally, 25 s to compile the harnesses and ~98 s to run them.

## The fix

Two halves, both required:

* **start the server**, in the same proven-backend shape as the `check` job's configure step (issue 0874: a broken sccache handed to `rustc` fails the *compiler*, so publish to `$GITHUB_ENV` only if it started);
* **export `RUSTC_WRAPPER`** here — the half the `check` job does not need and this job cannot work without.

`mkdir -p` on the cache dir unconditionally, since the save step warns and skips on a missing path, which is the failure being fixed.

Plus a **`Report what was warmed`** step. The only evidence this job did nothing was a `::warning::` buried in the save step's log, which nobody reads on a green run. An explicit size, and a loud warning at zero, is what makes the next regression of this visible.

## What is not verified

sccache is not installed on the host I wrote this on, so "the wrapper populates the dir" is asserted from the workflow, not measured. The new report step is what answers it: **on the first push to main, check that it prints a non-zero size before trusting the hit rate to improve.**

Expected if it works: `sccache-Linux-check-<sha>` appears on `refs/heads/main`, PR runs restore it through the `sccache-Linux-check-` prefix, and `cli-tests` drops by roughly its compile share.

Related: the cache pool is at **10.17 GB against the 10 GB limit**, ~5 GB of it sccache entries on ephemeral queue and PR refs that nothing can ever restore. That is pre-`#520` residue and should age out on its own now that downstream runs are restore-only; worth re-checking once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
