### PR TITLE
fix(#1106): apt install retries behind an update — an empty index reads as a bad package name

### DIFF
--- a/docs/issues/archived/1106-apt-install-without-an-index-reads-as-a-bad-package-name.md
+++ b/docs/issues/archived/1106-apt-install-without-an-index-reads-as-a-bad-package-name.md
@@ -1,0 +1,87 @@
+---
+id: 1106
+title: "`apt-get install` with an empty index reports a bad package NAME, and the names were right"
+status: resolved
+area: cli, testing
+severity: medium
+related: [1025, 1070, 1038, 0062]
+---
+
+# The third fault in one lane, visible only once the first two were fixed
+
+## What
+
+`native_install_command` composed `sudo apt-get install -y <list>`. A container
+image ships with an EMPTY `/var/lib/apt/lists`, and apt against an empty index
+does not say "no index" — it says:
+
+```
+E: Unable to locate package libgcrypt20-dev
+E: Unable to locate package libglib2.0-dev
+E: Unable to locate package libpixman-1-dev
+E: Unable to locate package openocd
+E: Unable to locate package qemu-system-arm
+```
+
+Every one of those is a real Debian package. So the failure reads as a bad
+package NAME in `nros-sdk-index.toml`, and the names are correct — the
+`[prereq.*]` entries map `libglib2-dev` to apt `libglib2.0-dev` exactly as they
+should. The evidence points at the declaration, and the declaration is fine.
+
+## Why it took three fixes to see
+
+The nightly `esp32` cell has been red continuously, and a lane that is already
+red reports its FIRST failure. Three independent faults were stacked in it, each
+invisible until the one in front was fixed:
+
+1. **issue 1025** — the flash packer read a directory the build never wrote, so
+   `Build (esp32)` failed and nothing after it ran.
+2. **issue 1070** — `--sudo` carried `requires = "system"` in clap, so
+   `nros setup --tool esp32-qemu --sudo` exited 2 on a usage error before
+   installing anything, skipping every later step.
+3. **this** — with provisioning finally reached, it ran `apt-get install`
+   against an index that does not exist.
+
+Each fix moved the failure one step earlier in the job and revealed the next.
+That is the shape a uniformly-red lane has: no signal capacity, so a new fault
+and yesterday's fault look identical (CLAUDE.md, "A red CI lane answers one of
+two questions").
+
+## Fix, and why it is a RETRY rather than an unconditional update
+
+```
+sudo apt-get install -y <list> || { sudo apt-get update && sudo apt-get install -y <list>; }
+```
+
+Prefixing `apt-get update &&` would be simpler and is WRONG here: an update needs
+the NETWORK, and a host that is offline with a warm index installs fine today.
+Making every install fetch an index would break exactly that host to fix a
+different one — the same class as the Corrosion note in CLAUDE.md, where a
+resolver that reached for git failed offline while the store already held the
+package.
+
+Install-first leaves the warm path untouched: no network, no wait, and the retry
+branch is never entered. The update is paid only where the first attempt failed,
+which is the cold-container case this exists for.
+
+The cost is that a package that really IS missing prints its error twice. That is
+the right trade — the second is the real answer and both name the package.
+
+## Verified in a container, both directions
+
+Not from the mechanism, which is what made the CI log misleading in the first
+place:
+
+| container state | command | result |
+| --- | --- | --- |
+| `rm -rf /var/lib/apt/lists/*` | old | **exit 100**, `Unable to locate package libglib2.0-dev` |
+| `rm -rf /var/lib/apt/lists/*` | new | **exit 0**, packages installed |
+| warm index | new | exit 0, retry branch **never entered** (0 occurrences) |
+
+The third row is the one that justifies the shape: it is the offline-warm host
+the simpler fix would have broken.
+
+Unit-tested too, on the composed STRING (install appears first, the retry
+re-installs rather than only refreshing, and `sh -n` accepts it — it is both run
+via `sh -c` and printed for a human to paste), plus a guard that the other three
+managers are unchanged and `brew` never gains a `sudo`.

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -1348,10 +1348,34 @@ fn command_exists(cmd: &str) -> bool {
 /// The composed native install command for `manager` over `packages`.
 /// One command, the user's to run — sudo is spelled out where the manager
 /// needs it (brew must NOT run under sudo).
+///
+/// # apt retries behind an `apt-get update`
+///
+/// A container image ships with an EMPTY `/var/lib/apt/lists`, and
+/// `apt-get install` against an empty index does not say "no index" — it says
+/// `E: Unable to locate package libglib2.0-dev` for a package that plainly
+/// exists. So the failure reads as a bad package NAME, and the names were
+/// checked and correct. That cost the nightly esp32 lane a third consecutive
+/// red (behind issues 1025 and 1070, each of which had to be fixed before this
+/// one became visible at all).
+///
+/// It is a RETRY rather than an unconditional `apt-get update &&` because an
+/// update needs the NETWORK. A host that is offline with a warm index installs
+/// fine today, and prefixing the update would break exactly that host to fix a
+/// different one. Ordering it install-first keeps the warm path untouched — no
+/// network, no wait — and pays the update only where the first attempt failed,
+/// which is the cold-container case this exists for.
+///
+/// The cost is that a GENUINE failure (a package that really is missing) prints
+/// its error twice. That is the right trade: the second one is the real answer,
+/// and both name the package.
 pub(crate) fn native_install_command(manager: &str, packages: &[String]) -> String {
     let list = packages.join(" ");
     match manager {
-        "apt" => format!("sudo apt-get install -y {list}"),
+        "apt" => format!(
+            "sudo apt-get install -y {list} \
+             || {{ sudo apt-get update && sudo apt-get install -y {list}; }}"
+        ),
         "dnf" => format!("sudo dnf install -y {list}"),
         "pacman" => format!("sudo pacman -S --needed {list}"),
         "brew" => format!("brew install {list}"),
@@ -2948,6 +2972,60 @@ mod workspace_scan_tests {
     /// A parse-level test, because the defect was parse-level: the install code
     /// underneath was correct and unreachable, so no test of THAT could have
     /// failed.
+    /// The apt command must survive an EMPTY package index.
+    ///
+    /// A container ships no `/var/lib/apt/lists`, and `apt-get install` there
+    /// reports `Unable to locate package <real-package>` — a name error for a
+    /// name that is correct. Retry behind an update, install-first so an
+    /// OFFLINE host with a warm index never touches the network.
+    #[test]
+    fn apt_retries_behind_an_update_and_tries_install_first() {
+        let pkgs = vec!["libglib2.0-dev".to_string(), "libpixman-1-dev".to_string()];
+        let cmd = native_install_command("apt", &pkgs);
+
+        // install FIRST: the warm/offline path must not begin with an update.
+        assert!(
+            cmd.starts_with("sudo apt-get install -y "),
+            "an offline host with a warm index would now need the network:\n{cmd}"
+        );
+        assert!(
+            cmd.contains("apt-get update"),
+            "no retry behind an update:\n{cmd}"
+        );
+        // the retry must re-run the install, not just refresh the index
+        let installs = cmd.matches("apt-get install -y").count();
+        assert_eq!(installs, 2, "the retry does not re-install:\n{cmd}");
+        for p in &pkgs {
+            assert!(cmd.contains(p.as_str()), "{p} missing from:\n{cmd}");
+        }
+        // valid `sh -c` input: that is how it is RUN, and it is also printed.
+        let st = std::process::Command::new("sh")
+            .args(["-n", "-c", &cmd])
+            .status()
+            .expect("spawn sh -n");
+        assert!(
+            st.success(),
+            "composed apt command is not valid shell:\n{cmd}"
+        );
+    }
+
+    /// The other managers are untouched — brew must never gain a sudo, and
+    /// none of them gains a retry they did not ask for.
+    #[test]
+    fn the_other_managers_are_unchanged() {
+        let pkgs = vec!["z".to_string()];
+        assert_eq!(
+            native_install_command("dnf", &pkgs),
+            "sudo dnf install -y z"
+        );
+        assert_eq!(
+            native_install_command("pacman", &pkgs),
+            "sudo pacman -S --needed z"
+        );
+        assert_eq!(native_install_command("brew", &pkgs), "brew install z");
+        assert!(!native_install_command("brew", &pkgs).contains("sudo"));
+    }
+
     #[test]
     fn sudo_parses_with_tool_as_well_as_system() {
         use clap::Parser;


### PR DESCRIPTION
The third fault in the esp32 lane, visible only once the first two were fixed.

## The failure lies about itself

`native_install_command` composed a bare `apt-get install`. A container image ships an **empty** `/var/lib/apt/lists`, and apt against an empty index doesn't say "no index" — it says:

```
E: Unable to locate package libgcrypt20-dev
E: Unable to locate package libglib2.0-dev
E: Unable to locate package libpixman-1-dev
E: Unable to locate package openocd
E: Unable to locate package qemu-system-arm
```

Every one is a real Debian package. So it reads as a bad package **name**, and the `[prereq.*]` names are correct. The evidence points at the declaration; the declaration is fine.

## Why it took three fixes to see

The nightly `esp32` cell has been red continuously, and a red lane reports its **first** failure:

1. **#1025** — flash packer read a directory the build never wrote → `Build (esp32)` failed, nothing after it ran
2. **#1070** — `--sudo` carried `requires = "system"`, so the provisioning line exited 2 on a usage error → every later step skipped
3. **this** — provisioning finally reached, running `apt-get install` against an index that doesn't exist

Each fix moved the failure one step earlier and revealed the next. That's the shape CLAUDE.md describes: a uniformly-red lane has no signal capacity.

## A retry, not an unconditional update

```sh
sudo apt-get install -y LIST || { sudo apt-get update && sudo apt-get install -y LIST; }
```

Prefixing `apt-get update &&` is simpler and **wrong here**: an update needs the network, and a host that's offline with a warm index installs fine today. That would break exactly that host to fix a different one — the class of the Corrosion note, where a resolver reaching for git failed offline while the store already held the package.

Install-first leaves the warm path untouched and pays the update only where the first attempt failed. Cost: a genuinely missing package prints its error twice — the right trade, since the second is the real answer and both name the package.

## Verified in a container, both directions

From the actual failure, not the mechanism — the mechanism is what made the log misleading:

| container state | command | result |
|---|---|---|
| `rm -rf /var/lib/apt/lists/*` | old | **exit 100**, `Unable to locate package libglib2.0-dev` |
| `rm -rf /var/lib/apt/lists/*` | new | **exit 0**, installed |
| warm index | new | exit 0, retry branch **never entered** |

The third row is what justifies the shape — it's the offline-warm host the simpler fix would have broken.

Unit tests on the composed **string**: install appears first, the retry re-installs rather than only refreshing, and `sh -n` accepts it (it's both run via `sh -c` and printed for a human to paste). Plus a guard that dnf/pacman/brew are unchanged and brew never gains a `sudo`.

`just check fast` 231/231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)