### PR TITLE
phase-431 W2: a shadowing `nros` fails doctor, and CI may not install the release

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1087,6 +1087,13 @@ jobs:
         run: |
           git submodule update --init --depth 1 packages/cli/third-party/play_launch
           cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
+          # phase-429 W5 — ASSERT the binary matches the checkout, do not hope.
+          # The other four acquisition sites carried this and this one did not,
+          # which is worse than a missing check: four green steps taught that
+          # the rule was in force here too. A warmed cache whose key is narrower
+          # than `source_stamp.rs`'s watch set hands `check cli-tests` a binary
+          # from a different tree (phase-431 W2, `check-ci-cli-from-source`).
+          "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
           cargo build --release --manifest-path packages/cli/nros-launch-resolve/Cargo.toml
           # `check cli-tests` is 338 s of the 20 min job and it is COMPILE-bound
           # (measured: 350 CPU-s to build, tests run in under a second). Warming

--- a/docs/roadmap/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/phase-431-ship-the-nros-binary.md
@@ -1,6 +1,7 @@
 # Phase 431 — ship the `nros` binary
 
-**Status (2026-09-06).** Opened. No code yet. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
+**Status (2026-09-06).** **W1 and W2 landed.** W3–W6 open — the distribution
+mechanics proper. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
 removed the correctness blocker; what remains is distribution mechanics plus one
 hazard that shipping CREATES and that is worth fixing before the first release
 rather than after.
@@ -104,6 +105,58 @@ sources does not. Both observed, not reasoned.
   for. Contributors and CI build from source, always; the release is for users.
 
 **Acceptance.** The gate fails when a workflow is edited to fetch the asset.
+
+**Landed 2026-09-06.**
+
+*The doctor half.* `_doctor-host` now reports a shadow as `[FAIL]` and
+`_doctor-host` / `doctor` / `_doctor-scope native` carry the verdict out, so the
+phase-220 promise is true. Three things had to move together, and the second is
+the one worth recording: `doctor` had `set -e`, so a failing host block would
+have skipped every platform probe — doctor's contract is that it reports every
+unmet precondition in ONE run, so the verdict is aggregated and emitted at the
+end instead. `just doctor native` reaches the same block and now returns the
+same code, because one block with two verdicts is how a check stops meaning
+anything.
+
+Why a FAIL and not a WARN, stated in the recipe itself: `nros_cli_bin` resolves
+**PATH before the per-checkout binary** (cargo.sh, phase 218.D.3), so a shadow is
+not cosmetic — it is the binary every `nros …` in this tree actually runs. W1
+refuses it at `nros build`; this is the same answer at the moment someone is
+asking whether their machine is ready.
+
+Observed:
+
+```
+no `nros` on PATH            -> [INFO], rc 0   (recipes use the in-tree binary)
+a foreign `nros` on PATH     -> [FAIL], rc 1   (and the blocks below it still run)
+the checkout's own on PATH   -> [OK],   rc 0
+```
+
+`setup-cli`'s warning was rewritten with it. Its old remedy said to delete
+`~/.nros/bin/nros`, which W3/W4 make the *supported* user install — so the
+remedy is now `source ./activate.sh` (put the checkout first), with removing a
+pre-218 `~/.cargo/bin/nros` as the fallback.
+
+*The gate half.* `check-ci-cli-from-source` (fast lane, 232 gates) runs two arms:
+
+* **no workflow acquires the CLI as a release asset** — `gh release download`,
+  a `releases/download/` URL, the `nros-<host>.tar.zst` asset name,
+  `--tool nros`, or `bootstrap.sh` without `--from-source` (W4 makes download
+  its default, so an unflagged invocation *is* the release path).
+* **every from-source build asserts `nros source-stamp` in the same step** —
+  phase-429 W5's rule, which nothing enforced.
+
+The second arm found an offender immediately: `gate.yml`'s CLI warm-up for
+`check cli-tests` built the binary and asserted nothing, so **four of five sites
+carried the rule and the fifth read exactly like the other four**. Fixed in the
+same commit.
+
+Two false-positive lessons are in the script. Arm A first flagged `docs.yml`
+downloading **mdbook-mermaid** from a GitHub release — CI legitimately fetches
+other projects' releases, so a match now also has to name `nros` (with
+`bootstrap.sh` exempt from that filter, since it is the front door and spells
+the binary nowhere). And the name is often not on the line the verb is, so the
+scan joins backslash continuations into logical lines first.
 
 ### W3 — the store holds versions, `nros` means the newest
 

--- a/just/check.just
+++ b/just/check.just
@@ -148,6 +148,7 @@ fast-serial: \
     cbindgen-headers \
     cbindgen-pin \
     cc-build-policy \
+    ci-cli-from-source \
     ci-doc-workflow-refs \
     ci-image-python-deps \
     ci-no-fixture-tolerance \
@@ -1156,6 +1157,19 @@ config-knob-census:
 # scanned: they narrate what a command DID at a time, so gating them would be a
 # steady false-positive stream. The recipe keeps its `workflow-` name because
 # the workflow arm is still the one a red usually means.
+# phase-431 W2 — CI builds the CLI from source and PROVES it, and never
+# installs the release. Two directions: no workflow acquires a release asset
+# (a released binary emits its own codegen, so such a job stops testing this
+# tree while staying green — and RFC-0090's version does not catch it, because
+# a release at the same version is different, not incompatible), and every
+# from-source build asserts `nros source-stamp` in the SAME step (phase-429 W5;
+# the CLI cache key is narrower than the stamp's watch set). The second arm
+# found `gate.yml`'s CLI warm-up asserting nothing, four sites into a five-site
+# rule.
+[group("checks")]
+ci-cli-from-source:
+    @python3 scripts/check-ci-cli-from-source.py
+
 [group("checks")]
 workflow-setup-spelling:
     @python3 scripts/check-workflow-setup-spelling.py

--- a/justfile
+++ b/justfile
@@ -3434,11 +3434,15 @@ setup-cli:
         bin_real="$(readlink -f "$bin" 2>/dev/null || echo "$bin")"
         if [ "$resolved_real" != "$bin_real" ]; then
             echo "[setup-cli] WARNING: \`which nros\` -> $resolved" >&2
-            echo "[setup-cli]   This shadows the in-tree CLI we just built ($bin)." >&2
-            echo "[setup-cli]   Clean up the stale shadow so post-218 builds use this checkout:" >&2
-            echo "[setup-cli]       rm -f \"\$HOME/.cargo/bin/nros\" \"\$HOME/.nros/bin/nros\"" >&2
+            echo "[setup-cli]   This shadows the in-tree CLI we just built ($bin)," >&2
+            echo "[setup-cli]   and recipes resolve PATH first, so THAT binary is the" >&2
+            echo "[setup-cli]   one this tree would run." >&2
+            echo "[setup-cli]   Put the checkout first:" >&2
             echo "[setup-cli]       source ./activate.sh" >&2
-            echo "[setup-cli]   (\`just doctor\` will FAIL until this is resolved.)" >&2
+            echo "[setup-cli]   A pre-218 install that still wins is removable:" >&2
+            echo "[setup-cli]       rm -f \"\$HOME/.cargo/bin/nros\"" >&2
+            echo "[setup-cli]   (\`just doctor\` FAILS until this is resolved — phase-431 W2." >&2
+            echo "[setup-cli]    It said so from phase 220 and did not; now it does.)" >&2
         fi
     }
     # Up-to-date iff the binary exists and NO cli SOURCE (Cargo.toml/lock or any
@@ -4232,13 +4236,17 @@ doctor *scope:
     if [[ -z "$chosen_tier" ]]; then
         chosen_tier="${NROS_SETUP_TIER:-base}"
     fi
-    just _doctor-host
-    just _orchestrate doctor "$chosen_tier"
+    # `set -e` would stop here on a host FAIL, and doctor's job is the whole
+    # picture: a shadowing `nros` must not hide an absent Zephyr SDK.
+    host_rc=0
+    just _doctor-host || host_rc=1
+    just _orchestrate doctor "$chosen_tier" || host_rc=1
     # The DERIVED default scope — every platform probed, nothing recorded.
     # This is the line that makes an absent platform visible at the moment a
     # person is asking about readiness, instead of as a skip inside a green run.
     echo ""
     nros_scope_report doctor
+    exit "$host_rc"
 
 # One scope token's readiness. `native` is the host, so its readiness IS the
 # shared-tooling block — there is no `native` module `doctor` to call and there
@@ -4254,8 +4262,11 @@ _doctor-scope tok:
         echo ""
         echo "=== $tok ==="
         if [ "$tok" = "native" ]; then
-            nros_scope_exec just _doctor-host
-            exit 0
+            # Propagate: `just doctor native` and the default scope reach ONE
+            # block, so they must reach one verdict too (phase-431 W2).
+            rc=0
+            nros_scope_exec just _doctor-host || rc=$?
+            exit "$rc"
         fi
         nros_scope_require_module_verb "$tok" doctor
         nros_scope_exec just "$tok" doctor
@@ -4281,12 +4292,52 @@ _doctor-host:
     # uses the same resolver as every recipe that shells `nros …`, so a
     # skew between resolver and what doctor reports is impossible.
     # shellcheck disable=SC1091
+    host_rc=0
     if . "{{justfile_directory()}}/scripts/build/cargo.sh" 2>/dev/null && \
        cli_bin="$(nros_cli_bin 2>/dev/null)"; then
         cli_ver="$("$cli_bin" --version 2>/dev/null | head -1)"
         echo "  [OK] nros CLI: ${cli_ver:-unknown} ($cli_bin)"
     else
         echo "  [MISSING] nros CLI — run: just setup-cli"
+    fi
+    # phase-431 W2 — A SHADOWING `nros` IS A FAILURE, not a warning.
+    #
+    # `setup-cli` has warned about this since phase 220 and its own text said
+    # "`just doctor` will FAIL until this is resolved". It did not; the promise
+    # was the whole enforcement. That was survivable while no release existed —
+    # a non-checkout `nros` was then somebody's old `cargo install` — and stops
+    # being survivable the day phase-431 ships one, because the shadow becomes
+    # the NORMAL state of a user's machine and a contributor's PATH inherits it.
+    #
+    # What it costs is not hypothetical: `nros_cli_bin` resolves PATH BEFORE the
+    # per-checkout binary (cargo.sh, phase 218.D.3), so every recipe that shells
+    # `nros …` runs the shadow, and it emits ITS OWN codegen against this tree.
+    # RFC-0090's version does not catch that — a release at the same version is
+    # different, not incompatible. `refuse_if_foreign_to_workspace` (W1) refuses
+    # it at `nros build`; this is the same answer at the moment someone is
+    # asking whether their machine is ready, which is cheaper than at build time.
+    if command -v nros >/dev/null 2>&1; then
+        in_tree="{{justfile_directory()}}/packages/cli/target/release/nros"
+        shadow="$(command -v nros)"
+        shadow_real="$(readlink -f "$shadow" 2>/dev/null || echo "$shadow")"
+        in_tree_real="$(readlink -f "$in_tree" 2>/dev/null || echo "$in_tree")"
+        if [ "$shadow_real" != "$in_tree_real" ]; then
+            echo "  [FAIL] \`nros\` on PATH is not this checkout's binary."
+            echo "         on PATH:  $shadow_real"
+            echo "         expected: $in_tree_real"
+            echo "         Recipes resolve PATH first, so every \`nros …\` this tree"
+            echo "         runs would come from somewhere else and emit its own"
+            echo "         codegen (RFC-0090; \`nros build\` refuses it outright)."
+            echo "         Fix:  just setup-cli && source ./activate.sh"
+            echo "         A pre-218 install lingers at ~/.cargo/bin/nros or"
+            echo "         ~/.nros/bin/nros — remove it if activate.sh does not win."
+            host_rc=1
+        else
+            echo "  [OK] \`nros\` on PATH is this checkout's binary"
+        fi
+    else
+        echo "  [INFO] no \`nros\` on PATH — recipes fall back to the in-tree"
+        echo "         binary. \`source ./activate.sh\` to type \`nros\` yourself."
     fi
     # issue 0653 — a RETIRED SDK store entry that is still installed.
     #
@@ -4436,6 +4487,10 @@ _doctor-host:
         echo "         than as absent coverage."
         echo "         Install:  nros setup --system    (declared in nros-sdk-index.toml)"
     fi
+    # One verdict, at the END. doctor's contract is that it reports every unmet
+    # precondition in one run (the `check tier-preconditions` shape), so a FAIL
+    # above must not short-circuit the blocks below it.
+    exit "$host_rc"
 
 # Internal: walk every module in `tier` calling the requested recipe
 # (setup or doctor). `base` is the safe quick-start tier; `all` is the

--- a/scripts/check-ci-cli-from-source.py
+++ b/scripts/check-ci-cli-from-source.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""CI builds the `nros` CLI from source and proves it -- it never installs the
+release (phase-431 W2, RFC-0090).
+
+Two directions, and neither implies the other.
+
+ARM A -- no workflow acquires the CLI as a RELEASE ASSET.
+
+    Phase-431 ships a prebuilt `nros`. From that day a workflow can get the
+    binary in one line, and a job that does stops testing THIS TREE while
+    staying green: it exercises whatever emitter the last release carried. The
+    codegen version does not catch it -- a release at the SAME version emits
+    ITS OWN bytes (that is exactly the gap phase-431 W1's workspace guard
+    closes for a developer, and a workflow has no developer to warn).
+
+    So the release is for users; contributors and CI build from source, always.
+
+ARM B -- every from-source build ASSERTS the binary matches the checkout.
+
+    phase-429 W5's rule. The CLI cache key is narrower than `source_stamp.rs`'s
+    watch set (it misses `.jinja`, `cli-source-dirs.txt`, the out-of-tree crate
+    dirs and the `play_launch` pin), so an exact-key cache hit exists for a tree
+    whose stamp has moved, and cargo will not rebuild it. `nros source-stamp`
+    is the binary's own answer to "do I match these sources"; a build step that
+    skips it is hoping.
+
+    This arm found its first offender on the run that introduced it: `gate.yml`
+    warms the CLI for `check cli-tests` and asserted nothing, so four of five
+    sites carried the rule and the fifth read exactly like the other four.
+
+Run:  python3 scripts/check-ci-cli-from-source.py [--self-test]
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+# The from-source build, and the assertion that must accompany it.
+BUILD_RE = re.compile(r"cargo build\b.*--bin nros\b")
+STAMP_RE = re.compile(r"\bsource-stamp\b")
+
+# Arm A. Each entry is (regex, what it would do). Matched against every
+# non-comment LOGICAL line of every workflow (backslash continuations joined),
+# and a match counts only when that logical line also names `nros`: CI legitimately
+# downloads OTHER projects' releases, and `docs.yml` fetching `mdbook-mermaid`
+# from a GitHub release URL was this gate's first false positive.
+#
+# `bootstrap.sh` is here because phase-431 W4 makes DOWNLOAD its default: the
+# user front door stops building from source, and `--from-source` is the
+# contributor opt-in. A workflow invoking it without that flag is the release
+# path spelled differently.
+RELEASE_ACQUISITION = [
+    (
+        re.compile(r"gh release download"),
+        "downloads a release asset",
+    ),
+    (
+        re.compile(r"releases/download/"),
+        "fetches a release asset by URL",
+    ),
+    (
+        re.compile(r"\bnros-[^\s\"']*\.tar\.(zst|gz|xz)"),
+        "names the released CLI tarball",
+    ),
+    (
+        re.compile(r"--tool[= ]nros\b"),
+        "installs the CLI through the SDK store",
+    ),
+]
+BOOTSTRAP_RE = re.compile(r"bootstrap\.sh")
+FROM_SOURCE_RE = re.compile(r"--from-source\b")
+
+# (workflow, exact stripped line) -> reason. Checked in BOTH directions: an
+# exemption matching nothing is a stale allow-list, which is how a gate quietly
+# stops covering what it names.
+#
+# EMPTY. A future entry needs a reason that is a property of the LANE -- "this
+# job tests the release itself" is the only shape that qualifies, and W5's
+# release workflow will be that entry when it lands.
+EXEMPT = {}
+
+
+def run_blocks(text):
+    """[(lineno_of_run_key, [body lines])] for every `run:` in a workflow.
+
+    Block-scoped rather than file-scoped on purpose: arm B asks whether the
+    assertion sits WITH the build. A `source-stamp` in some other job's step
+    proves nothing about this one, and a file-wide search would accept it.
+    """
+    lines = text.split("\n")
+    out = []
+    i = 0
+    while i < len(lines):
+        block = re.match(r"^(\s*)run:\s*([|>][-+0-9]*)?\s*$", lines[i])
+        if not block:
+            inline = re.match(r"^(\s*)run:\s+(\S.*)$", lines[i])
+            if inline:
+                out.append((i + 1, [inline.group(2)]))
+            i += 1
+            continue
+        key_indent = len(block.group(1))
+        body = []
+        j = i + 1
+        while j < len(lines):
+            line = lines[j]
+            if line.strip():
+                indent = len(line) - len(line.lstrip())
+                if indent <= key_indent:
+                    break
+            body.append(line)
+            j += 1
+        out.append((i + 1, body))
+        i = j
+    return out
+
+
+def build_sites(text):
+    """[(lineno, line, asserts_stamp)] for every from-source CLI build."""
+    out = []
+    for start, body in run_blocks(text):
+        has_stamp = any(
+            STAMP_RE.search(b) for b in body if not b.strip().startswith("#")
+        )
+        for offset, line in enumerate(body):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if BUILD_RE.search(stripped):
+                out.append((start + 1 + offset, stripped, has_stamp))
+    return out
+
+
+NROS_RE = re.compile(r"\bnros\b")
+
+
+def logical_lines(text):
+    """[(lineno_of_first_line, joined text)] with `\\` continuations joined.
+
+    A shell command wrapped over three lines is ONE command, and the URL that
+    decides whether it acquires our CLI is often not on the line the verb is.
+    Attributed to the first line, which is where a reader looks.
+    """
+    out = []
+    start = None
+    buf = []
+    for i, raw in enumerate(text.split("\n"), 1):
+        line = raw.strip()
+        if start is None:
+            start = i
+        buf.append(line[:-1].rstrip() if line.endswith("\\") else line)
+        if line.endswith("\\"):
+            continue
+        out.append((start, " ".join(buf).strip()))
+        start = None
+        buf = []
+    if buf:
+        out.append((start, " ".join(buf).strip()))
+    return out
+
+
+def release_sites(text):
+    """[(lineno, line, what)] for every release-asset acquisition of the CLI."""
+    out = []
+    for i, line in logical_lines(text):
+        if not line or line.startswith("#"):
+            continue
+        # `bootstrap.sh` is exempt from the name filter: it IS the nros front
+        # door, and it spells the binary nowhere on its own invocation line.
+        if not NROS_RE.search(line) and not BOOTSTRAP_RE.search(line):
+            continue
+        for pattern, what in RELEASE_ACQUISITION:
+            if pattern.search(line):
+                out.append((i, line, what))
+                break
+        else:
+            if BOOTSTRAP_RE.search(line) and not FROM_SOURCE_RE.search(line):
+                out.append(
+                    (i, line, "runs bootstrap.sh, whose default is the download")
+                )
+    return out
+
+
+def workflow_files():
+    return sorted(
+        fn for fn in os.listdir(WORKFLOWS) if fn.endswith((".yml", ".yaml"))
+    )
+
+
+def self_test():
+    # --- run_blocks ---
+    y = "\n".join(
+        [
+            "jobs:",
+            "  a:",
+            "    steps:",
+            "      - name: build",
+            "        run: |",
+            "          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros",
+            '          "$X/nros" source-stamp >/dev/null',
+            "      - name: other",
+            "        run: echo hi",
+            "  b:",
+            "    steps:",
+            "      - name: build without the assertion",
+            "        run: |",
+            "          cargo build --release --bin nros",
+            "      - name: elsewhere",
+            "        run: nros source-stamp",
+        ]
+    )
+    blocks = run_blocks(y)
+    assert len(blocks) == 4, blocks
+    assert blocks[1][1] == ["echo hi"], blocks[1]
+
+    got = build_sites(y)
+    assert [(g[0], g[2]) for g in got] == [(6, True), (14, False)], got
+
+    # A stamp in a DIFFERENT step must not satisfy the build in this one --
+    # that is the whole reason the scan is block-scoped.
+    assert got[1][2] is False, got[1]
+
+    # A commented-out assertion is not an assertion.
+    y2 = "\n".join(
+        [
+            "      - name: build",
+            "        run: |",
+            "          cargo build --bin nros",
+            "          # nros source-stamp   (disabled while debugging)",
+        ]
+    )
+    assert build_sites(y2)[0][2] is False, build_sites(y2)
+
+    # --- arm A ---
+    bad = "\n".join(
+        [
+            "        run: |",
+            "          gh release download v1.2.3 -p 'nros-*'",
+            "          curl -L https://example/releases/download/v1/nros.tar.zst",
+            "          tar xf nros-x86_64-linux.tar.zst",
+            "          nros setup --tool nros",
+            "          ./scripts/bootstrap.sh",
+            "          # gh release download in a comment is prose",
+        ]
+    )
+    hits = release_sites(bad)
+    assert [h[0] for h in hits] == [2, 3, 4, 5, 6], hits
+    assert "bootstrap.sh" in hits[4][2], hits[4]
+
+    # Another project's release is not ours. `docs.yml` fetching mdbook-mermaid
+    # from a `releases/download/` URL was this gate's first false positive.
+    other = "\n".join(
+        [
+            "        run: |",
+            "          curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.17.0/x.tar.gz \\",
+            "            | tar -xz",
+        ]
+    )
+    assert release_sites(other) == [], release_sites(other)
+
+    # ...but a wrapped acquisition of OURS is still one command.
+    wrapped = "\n".join(
+        [
+            "        run: |",
+            "          curl -sSL \\",
+            "            https://github.com/NEWSLabNTU/nano-ros/releases/download/v1/nros-linux.tar.zst \\",
+            "            -o nros.tar.zst",
+        ]
+    )
+    assert [h[0] for h in release_sites(wrapped)] == [2], release_sites(wrapped)
+
+    ok = "\n".join(
+        [
+            "        run: |",
+            "          ./scripts/bootstrap.sh --from-source",
+            "          cargo build --release --bin nros",
+        ]
+    )
+    assert release_sites(ok) == [], release_sites(ok)
+
+    sys.stdout.write("check-ci-cli-from-source self-test: OK\n")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return 0
+    self_test()
+
+    problems = []
+    seen_exempt = set()
+    total_builds = 0
+
+    for fn in workflow_files():
+        with open(os.path.join(WORKFLOWS, fn), encoding="utf8") as fh:
+            text = fh.read()
+
+        for lineno, line, what in release_sites(text):
+            if (fn, line) in EXEMPT:
+                seen_exempt.add((fn, line))
+                continue
+            problems.append(
+                "%s:%d %s\n"
+                "      %s\n"
+                "    CI must build the CLI from source. A released binary emits\n"
+                "    ITS OWN codegen, so this job would stop testing the tree while\n"
+                "    staying green -- and the codegen version does not catch it,\n"
+                "    because a release at the same version is not incompatible,\n"
+                "    merely different (RFC-0090, phase-431 W1/W2).\n"
+                "    Build it:  cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros\n"
+                "               \"$GITHUB_WORKSPACE/packages/cli/target/release/nros\" source-stamp >/dev/null"
+                % (fn, lineno, what, line)
+            )
+
+        for lineno, line, has_stamp in build_sites(text):
+            total_builds += 1
+            if has_stamp or (fn, line) in EXEMPT:
+                if (fn, line) in EXEMPT:
+                    seen_exempt.add((fn, line))
+                continue
+            problems.append(
+                "%s:%d builds the CLI without asserting it matches the checkout\n"
+                "      %s\n"
+                "    The CLI cache key is narrower than `source_stamp.rs`'s watch\n"
+                "    set, so an exact-key hit exists for a tree whose stamp moved\n"
+                "    and cargo will not rebuild it (phase-429 W5). Add to the SAME\n"
+                "    step:\n"
+                "        \"$GITHUB_WORKSPACE/packages/cli/target/release/nros\" source-stamp >/dev/null"
+                % (fn, lineno, line)
+            )
+
+    for key in EXEMPT:
+        if key not in seen_exempt:
+            problems.append(
+                "STALE exemption %r matches no workflow line.\n"
+                "    Delete it -- an allow-list checked one way stops covering\n"
+                "    what it claims to." % (key,)
+            )
+
+    # Anti-vacuity. Arm A passes on a tree that acquires the CLI nowhere, and
+    # arm B on a tree that builds it nowhere -- both of which mean the workflows
+    # were restructured out from under this gate, not that they are clean.
+    if total_builds == 0:
+        sys.stderr.write(
+            "error: no workflow builds the nros CLI from source.\n"
+            "This gate would then pass vacuously. Either the build moved into a\n"
+            "recipe (teach BUILD_RE about it) or CI stopped building the CLI,\n"
+            "which is the very thing phase-431 W2 forbids.\n"
+        )
+        return 1
+
+    if problems:
+        sys.stderr.write(
+            "check-ci-cli-from-source: %d problem(s)\n\n" % len(problems)
+        )
+        for p in problems:
+            sys.stderr.write("  - %s\n\n" % p)
+        return 1
+
+    sys.stdout.write(
+        "check-ci-cli-from-source OK -- %d from-source CLI build(s), each asserting\n"
+        "its source stamp; no workflow installs the release.\n" % total_builds
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #537 (W1). The binary this tree runs must be the binary this tree built.

## The doctor half

`setup-cli` has warned about a shadowing `nros` since phase 220, and its own text said **"`just doctor` will FAIL until this is resolved"**. It did not — the promise was the entire enforcement. That was survivable while no release existed. It stops being survivable the day phase-431 ships one, because the shadow becomes the *normal* state of a user's machine and a contributor's PATH inherits it.

It is not cosmetic. `nros_cli_bin` resolves **PATH before the per-checkout binary** (cargo.sh, phase 218.D.3), so the shadow is the binary every `nros …` in this tree actually runs — emitting *its own* codegen against these sources. RFC-0090's version does not catch that: a release at the same version is different, not incompatible. #537 refuses it at `nros build`; this is the same answer at the moment someone is asking whether their machine is ready, which is cheaper.

**`doctor` had `set -e`.** A failing host block would have skipped every platform probe, and doctor's contract is that one run reports every unmet precondition. So the verdict is aggregated and emitted at the end, and `_doctor-scope native` propagates it — one block with two verdicts is how a check stops meaning anything.

```
no `nros` on PATH            -> [INFO], rc 0   (recipes use the in-tree binary)
a foreign `nros` on PATH     -> [FAIL], rc 1   (and the blocks below it still run)
the checkout's own on PATH   -> [OK],   rc 0
```

`setup-cli`'s remedy was rewritten alongside: it told you to delete `~/.nros/bin/nros`, which W3/W4 make the *supported* user install. Now it is `source ./activate.sh`, with removing a pre-218 `~/.cargo/bin/nros` as the fallback.

## The gate half

`check-ci-cli-from-source`, on the fast lane (232 gates), holds two directions:

| arm | rule |
|---|---|
| A | no workflow acquires the CLI as a **release asset** — `gh release download`, a `releases/download/` URL, the `nros-<host>.tar.zst` name, `--tool nros`, or `bootstrap.sh` without `--from-source` (W4 makes download its default, so an unflagged invocation *is* the release path) |
| B | every from-source build asserts **`nros source-stamp` in the same step** — phase-429 W5's rule, which nothing enforced |

**Arm B found an offender on its first run.** `gate.yml`'s CLI warm-up for `check cli-tests` built the binary and asserted nothing, so four of five sites carried the rule and the fifth read exactly like the other four. Fixed here.

Two false-positive lessons are recorded in the script. Arm A first flagged `docs.yml` fetching **mdbook-mermaid** from a release URL — CI legitimately downloads other projects' releases, so a match must also name `nros` (`bootstrap.sh` is exempt from that filter: it is the front door and spells the binary nowhere). And that name is often not on the line the verb is, so the scan joins backslash continuations into logical lines first.

`just check fast`: 232/232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK