### PR TITLE
phase-431 W3: the store holds versions, `nros` means the newest

### DIFF
--- a/docs/roadmap/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/phase-431-ship-the-nros-binary.md
@@ -1,6 +1,6 @@
 # Phase 431 — ship the `nros` binary
 
-**Status (2026-09-06).** **W1 and W2 landed.** W3–W6 open — the distribution
+**Status (2026-09-06).** **W1, W2 and W3 landed.** W4–W6 open — the distribution
 mechanics proper. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
 removed the correctness blocker; what remains is distribution mechanics plus one
 hazard that shipping CREATES and that is worth fixing before the first release
@@ -178,6 +178,68 @@ AHEAD of numeric ones — `lib` won 155 of 183 resolutions in one configure.
 Plus the `[tool.nros]` index entry, with a `smoke` check that runs
 `bin/nros --codegen-version` rather than `--version`: the interesting property of
 this particular tool is what it emits.
+
+**Landed 2026-09-06.**
+
+The store already wrote `<store>/<tool>/<version>/` — `tool_prefix` has been the
+one constructor since phase-365 — so W3 is the *front* half plus the entry.
+
+*Fronting.* `front = ["bin/nros"]` in `[tool.<name>]` names prefix-relative paths
+that must be reachable by bare name from `$NROS_HOME/bin`. `front_newest`
+recomputes from the store on every install and links the **newest installed**
+version, not the one just installed: versions accumulate, nothing prunes them
+(issue 0500), and installing an older one on purpose must not silently downgrade
+the command. It is a parameter of `execute` rather than a separate call, because
+three call sites reach that function and a fourth spelling of "and then link it"
+is how one of them ends up not doing it.
+
+`installed_versions` **enumerates** the store, which `check-sdk-store-not-
+enumerated` bans — and correctly, for the question that gate is about. These are
+two different questions: *where is the version I pinned* is constructible from
+two inputs; *what is the newest thing installed here* is not, and nothing but the
+store knows it. Issue 0625's defence moved into the filter rather than the sort:
+a candidate must begin with a digit **and** carry a `.nros-provenance` marker, so
+a legacy flat prefix's `lib/` cannot win by sorting. The comparator is
+natural-order on top of that (`nros2` < `nros10`, which a string compare gets
+backwards and the store's vocabulary already reaches — `qemu 11.0.0-nros6`).
+The gate's docstring now says all of this, so the next reader does not have to
+re-derive whether the two rules conflict.
+
+*The verb.* `nros sdk-front <tool>` exists for the one caller that cannot go
+through `nros setup`: W4's `bootstrap.sh`, which unpacks the CLI itself and has
+no `nros` to run `nros setup --tool nros` with until it has. One implementation,
+two callers — a second spelling in shell is how they would come to disagree about
+which version `nros` means.
+
+*The entry.* `[tool.nros]` was REMOVED by phase-288 D1/D2, and the index still
+carried the comment saying why: the archived standalone repo's 0.3.6 binaries
+were 15 releases stale and ABI-mismatched with the checkout, so installing one
+was a footgun. That reason is now **answered rather than waived**, and the index
+says which three things answer it (RFC-0090, W1, W2). No `dist` rows until W5
+seeds an asset; until then the source recipe builds it, pinned to a **commit**
+(issue 1060 — a tag is a ref on a server we do not control).
+
+`smoke` asserts the codegen version, which makes it an authored mirror of
+`NROS_CODEGEN_VERSION` — the shape that has drifted every time nothing bound it
+(`check-rmw-api-parity`, 25 symbols, reading green). A test binds it to
+`abi_guard::EMITTED_VERSION`.
+
+*And `nros` is deliberately absent from `scripts/sdk-path-tools.txt`.* That list
+puts a store `bin/` on PATH for binaries something we do not control invokes by
+bare name; the CLI is not one, and if it were on the list, sourcing `activate.sh`
+in a checkout would put a foreign emitter first — the exact state W1 refuses and
+W2 fails on. `check-activate-shells` now asserts the behaviour rather than the
+list: a store holding `nros/<version>/bin/nros` must not reach PATH. Verified by
+mutation (adding `nros` to the list turns it red).
+
+Observed, against a real binary in a scratch store:
+
+```
+install 0.5.0-nros1, front  -> ~/.nros/bin/nros -> …/0.5.0-nros1/bin/nros
+install 0.6.0-nros1, front  -> …/0.6.0-nros1/bin/nros    (newest wins)
+install an OLDER one, front -> unchanged                 (no silent downgrade)
+$NROS_HOME/bin/nros --codegen-version -> 1
+```
 
 ### W4 — `bootstrap.sh` downloads, and still builds from source
 

--- a/nros-sdk-index.toml
+++ b/nros-sdk-index.toml
@@ -34,13 +34,48 @@ build_sources = [
 
 # --- prebuilt host tools (target-agnostic) ---
 
-# The `nros` CLI is NOT an index tool. It lives in-tree at `packages/cli/`
-# and is built from source per checkout (`scripts/bootstrap.sh`, or the
-# internal alias `just setup-cli`) — nano-ros is a source distribution
-# (phase-288 D1/D2). The pre-288 `[tool.nros]` entry pointed at the ARCHIVED
-# standalone `NEWSLabNTU/nros-cli` repo's 0.3.6 binaries — 15 releases stale
-# and ABI-mismatched with the checkout; installing it via
-# `nros setup --tool nros` was a footgun and the entry is removed.
+# The `nros` CLI itself (phase-431). This entry was REMOVED by phase-288 D1/D2
+# and is back, because the reason it was removed has been answered rather than
+# waived. The pre-288 entry pointed at the archived standalone
+# `NEWSLabNTU/nros-cli` repo's 0.3.6 binaries — 15 releases stale and
+# ABI-mismatched with the checkout — so `nros setup --tool nros` installed a
+# binary that emitted code the runtime did not expect, silently. Three things
+# now stand between that and a user:
+#
+#   RFC-0090     the codegen version — an emitter incompatible with a runtime
+#                refuses, at `nros build` and at compile time in C/C++/Rust
+#   phase-431 W1 a binary from outside the checkout it is run against refuses,
+#                because "same version" is not "same bytes"
+#   phase-431 W2 `just doctor` FAILS when a store `nros` shadows a checkout's
+#
+# `front = ["bin/nros"]` is the "one command" promise: versions accumulate in
+# the store (nothing prunes it, issue 0500) and `$NROS_HOME/bin/nros` always
+# points at the NEWEST installed one. `nros` is deliberately absent from
+# `scripts/sdk-path-tools.txt` — that list puts a store `bin/` on PATH, which
+# in a contributor's shell would shadow the checkout's own CLI.
+#
+# `smoke` asks for `--codegen-version`, not `--version`. Both run the binary;
+# only one answers the question that makes this tool safe to install.
+#
+# No `dist.<host>` rows yet: phase-431 W5 cuts the first release, and until an
+# asset is seeded `nros setup --tool nros` falls back to the source recipe
+# below (the index's documented behaviour, top of file). Linux only for now —
+# the tree defers macOS support, and an asset for it would be a support claim
+# we do not make.
+[tool.nros]
+version = "0.5.0-nros1"
+front = ["bin/nros"]
+smoke = [
+    { run = "bin/nros --codegen-version", expect = "1" },
+]
+upstream = "32b0d2efe61ec66a1cb6c0ff4c780c0f0bc8f10c" # = source.ref
+[tool.nros.source]
+git = "https://github.com/NEWSLabNTU/nano-ros"
+# A COMMIT, not a branch or a tag — issue 1060. A ref on a server we do not
+# control moves what we build with no local diff and no review; releases here
+# are cut deliberately (phase-431: tag only when asked), so the pin is a sha.
+ref = "32b0d2efe61ec66a1cb6c0ff4c780c0f0bc8f10c"
+install = "cargo install --path packages/cli/nros-cli --root {prefix} --locked"
 
 # nros2: rebuilt with --enable-slirp (nano-ros QEMU tests use -netdev user;
 # nros1 lacked slirp and couldn't network).

--- a/packages/cli/nros-cli-core/src/cmd/mod.rs
+++ b/packages/cli/nros-cli-core/src/cmd/mod.rs
@@ -40,6 +40,7 @@ pub mod new_system;
 pub mod plan;
 pub mod profile;
 pub mod scaffold_deploy;
+pub mod sdk_front;
 pub mod sdk_path;
 pub mod setup;
 pub mod version;
@@ -135,6 +136,12 @@ pub enum Cmd {
     /// never searched (issue 0625).
     #[command(name = "sdk-path")]
     SdkPath(sdk_path::Args),
+
+    /// phase-431 W3 — point `$NROS_HOME/bin/<name>` at the NEWEST installed
+    /// version of a tool. The bridge for `scripts/bootstrap.sh`, which unpacks
+    /// the CLI itself and has no `nros setup` to run until it has.
+    #[command(name = "sdk-front")]
+    SdkFront(sdk_front::Args),
 
     /// phase-336 — the cargo build-profile table (CMAKE_BUILD_TYPE mapping,
     /// flags, artifact dir, env-injected definitions). The bridge cmake/bash

--- a/packages/cli/nros-cli-core/src/cmd/sdk_front.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_front.rs
@@ -1,0 +1,75 @@
+//! `nros sdk-front` — phase-431 W3: point `$NROS_HOME/bin/<name>` at the NEWEST
+//! installed version of a tool.
+//!
+//! `nros setup --tool <name>` already does this as part of an install, so this
+//! verb exists for the one caller that cannot go through `nros setup`:
+//! `scripts/bootstrap.sh` (W4), which downloads and unpacks the CLI itself —
+//! there is no `nros` to run `nros setup --tool nros` with until it has. Rather
+//! than let bootstrap re-implement "and then link the newest one" in shell,
+//! it unpacks into the store and asks the binary it just placed.
+//!
+//! One implementation, two callers. A second spelling of this rule in shell is
+//! how the two would come to disagree about which version `nros` means.
+//!
+//! It is deliberately NOT a general "put this on PATH" verb: what gets fronted
+//! is `[tool.<name>] front = [...]` in the index, so the decision stays data.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use eyre::{Result, bail};
+
+use crate::orchestration::{sdk_index::SdkIndex, sdk_store};
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Tool name, as spelled by `[tool.<name>]` in the SDK index.
+    pub tool: String,
+
+    /// Path to the SDK index.
+    #[arg(long, default_value = "nros-sdk-index.toml")]
+    pub index: PathBuf,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let index = SdkIndex::load(&args.index)?;
+    let Some(tool) = index.tool.get(&args.tool) else {
+        let known: Vec<&str> = index.tool.keys().map(String::as_str).collect();
+        bail!(
+            "no `[tool.{}]` in {} — the index pins: {}",
+            args.tool,
+            args.index.display(),
+            known.join(", ")
+        );
+    };
+
+    if tool.front.is_empty() {
+        bail!(
+            "`[tool.{}]` declares no `front`, so nothing about it belongs in {}. \
+             Resolve it with `nros sdk-path {}` instead — the store is on PATH \
+             only for the names in scripts/sdk-path-tools.txt, which is for \
+             binaries something we do not control invokes by bare name.",
+            args.tool,
+            sdk_store::front_dir().display(),
+            args.tool
+        );
+    }
+
+    let root = sdk_store::store_root();
+    let linked = sdk_store::front_newest(&root, &args.tool, &tool.front)?;
+    if linked.is_empty() {
+        // Not an error at the library layer (an install may simply not have
+        // happened yet), but here the user ASKED, so say what is missing.
+        bail!(
+            "no installed version of {} under {} — nothing to point at.\n\
+             Provision it:  nros setup --tool {}",
+            args.tool,
+            root.join(&args.tool).display(),
+            args.tool
+        );
+    }
+    for link in linked {
+        println!("{}", link.display());
+    }
+    Ok(())
+}

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -354,7 +354,7 @@ pub fn run(args: Args) -> Result<()> {
                 );
             }
             other => {
-                let provenance = execute(&other, name, &tool.version, &prefix)
+                let provenance = execute(&other, name, &tool.version, &prefix, &tool.front)
                     .wrap_err_with(|| format!("install {name} {}", tool.version))?;
                 lock.record(name, &provenance);
                 installed = true;
@@ -781,7 +781,7 @@ fn install_single_tool(
             tool.version
         ),
         other => {
-            let prov = execute(&other, name, &tool.version, &prefix)
+            let prov = execute(&other, name, &tool.version, &prefix, &tool.front)
                 .wrap_err_with(|| format!("install {name} {}", tool.version))?;
             // Only the shared store is tracked by the lock; --prefix is local.
             if prefix_override.is_none() {
@@ -977,7 +977,7 @@ pub fn ensure_tools(board: &str, workspace: Option<&Path>) -> Result<Vec<PathBuf
                     "nros: auto-installing {name} {} (set NROS_NO_AUTO_SETUP to skip)",
                     tool.version
                 );
-                let prov = execute(&action, name, &tool.version, &prefix)
+                let prov = execute(&action, name, &tool.version, &prefix, &tool.front)
                     .wrap_err_with(|| format!("auto-setup {name} {}", tool.version))?;
                 lock.record(name, &prov);
                 installed = true;

--- a/packages/cli/nros-cli-core/src/lib.rs
+++ b/packages/cli/nros-cli-core/src/lib.rs
@@ -82,6 +82,7 @@ fn cmd_name(cmd: &cmd::Cmd) -> &'static str {
         cmd::Cmd::CodegenSystem(_) => "codegen-system",
         cmd::Cmd::ModelPath(_) => "model-path",
         cmd::Cmd::SdkPath(_) => "sdk-path",
+        cmd::Cmd::SdkFront(_) => "sdk-front",
         cmd::Cmd::GenerateRust(_) => "generate-rust",
         cmd::Cmd::Setup(_) => "setup",
         // Everything else stays runnable on a stale binary ON PURPOSE —
@@ -130,6 +131,7 @@ pub fn run(cmd: cmd::Cmd) -> Result<()> {
         cmd::Cmd::CodegenSystem(args) => cmd::codegen_system::run(args),
         cmd::Cmd::ModelPath(args) => cmd::model_path::run(args),
         cmd::Cmd::SdkPath(args) => cmd::sdk_path::run(args),
+        cmd::Cmd::SdkFront(args) => cmd::sdk_front::run(args),
         cmd::Cmd::Profile(args) => cmd::profile::run(args),
         cmd::Cmd::Metadata(args) => cmd::metadata::run(args),
         cmd::Cmd::Plan(args) => cmd::plan::run(args),

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_index.rs
@@ -613,6 +613,22 @@ pub struct ToolPackage {
     /// exact shape issue 0926 removed for openocd, reappearing one cause over.
     #[serde(default)]
     pub smoke: Vec<SmokeCheck>,
+    /// phase-431 W3 — prefix-relative paths (`bin/nros`) that must be reachable
+    /// by BARE NAME from `$NROS_HOME/bin`, which is the one directory a user
+    /// puts on PATH.
+    ///
+    /// The store accumulates versions and the link always points at the NEWEST
+    /// installed one, so `nros` means one command however many versions are
+    /// present. That is the promise; `sdk_store::front_newest` is where it is
+    /// kept.
+    ///
+    /// This is NOT `scripts/sdk-path-tools.txt`. That list puts a store `bin/`
+    /// dir on PATH for tools an RTOS `make` or a cmake `find_program` invokes
+    /// by bare name, and `nros` must never be on it: it would shadow the
+    /// checkout's own CLI in a contributor's shell, which `just doctor` now
+    /// fails on (phase-431 W2) and `nros build` refuses (W1).
+    #[serde(default)]
+    pub front: Vec<String>,
 }
 
 /// One "does it actually run?" probe for a `[tool.*]` dist (issue 0929).

--- a/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/sdk_store.rs
@@ -120,6 +120,151 @@ pub fn tool_dir_candidates(index: &super::sdk_index::SdkIndex, tool: &str) -> Ve
     out
 }
 
+/// The user-facing bin dir: `$NROS_HOME/bin`, else `~/.nros/bin`, else
+/// `./.nros/bin` — the sibling of [`store_root`], resolved the same way.
+///
+/// This is the ONE directory a user puts on PATH. The store itself never is:
+/// `activate.sh` only adds a store `bin/` for the tools named in
+/// `scripts/sdk-path-tools.txt`, which exists for binaries something we do not
+/// control invokes by bare name.
+pub fn front_dir() -> PathBuf {
+    if let Some(h) = std::env::var_os("NROS_HOME") {
+        return PathBuf::from(h).join("bin");
+    }
+    if let Some(h) = std::env::var_os("HOME") {
+        return PathBuf::from(h).join(".nros").join("bin");
+    }
+    PathBuf::from(".nros").join("bin")
+}
+
+/// Order two store version strings — digit runs numerically, the rest as text.
+///
+/// `sort -Vr` is what the store's other consumers use and it is not usable
+/// here. Issue 0625: a flat `corrosion/` prefix put `lib/` and `share/` where
+/// versions go, and a pure-alpha name sorts AHEAD of numeric ones under `-V`,
+/// so `lib` won 155 of 183 resolutions in a single configure. The filter in
+/// [`installed_versions`] is the real defence; this is the second one, and it
+/// also gets `nros1` vs `nros10` right, which a plain string compare does not.
+fn version_key(v: &str) -> Vec<(u64, String)> {
+    let mut out = Vec::new();
+    let mut rest = v;
+    while !rest.is_empty() {
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        rest = &rest[digits.len()..];
+        let text: String = rest.chars().take_while(|c| !c.is_ascii_digit()).collect();
+        rest = &rest[text.len()..];
+        out.push((digits.parse::<u64>().unwrap_or(0), text));
+    }
+    out
+}
+
+/// Every version of `tool` actually installed under `root`, newest LAST.
+///
+/// "Installed" means the directory carries a provenance marker — the file
+/// [`execute`] writes on success. That is what keeps a partial unpack, a
+/// legacy flat prefix's `lib/`, and a directory somebody created by hand out
+/// of the answer. A name that does not begin with a digit is skipped for the
+/// same reason: a version starts with a number, and the alternative is issue
+/// 0625 again.
+///
+/// This ENUMERATES the store, which the pinned-resolution path is forbidden to
+/// do (`tool_dir`, phase-365). The two are asking different questions: that one
+/// means "where does the version I pinned live" and has one right answer to
+/// construct; this one means "what is the newest thing here", which nothing but
+/// the store knows.
+pub fn installed_versions(root: &Path, tool: &str) -> Vec<String> {
+    let mut found: Vec<String> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root.join(tool)) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with(|c: char| c.is_ascii_digit()) {
+            continue;
+        }
+        if Provenance::read(&entry.path()).is_none() {
+            continue;
+        }
+        found.push(name);
+    }
+    found.sort_by(|a, b| version_key(a).cmp(&version_key(b)));
+    found
+}
+
+/// The newest installed version of `tool`, if any.
+pub fn newest_installed(root: &Path, tool: &str) -> Option<String> {
+    installed_versions(root, tool).pop()
+}
+
+/// Point `<front_dir>/<name>` at the NEWEST installed version of `tool`, for
+/// each `bin/<name>` the index's `front` list names. Returns what was linked.
+///
+/// Versions accumulate — nothing prunes the store (issue 0500) — and the user
+/// is promised exactly one command: `nros` is whichever version is newest, not
+/// whichever was installed last. So this recomputes from the store rather than
+/// linking the prefix it was just handed; installing an older version on
+/// purpose must not silently downgrade the command.
+///
+/// A symlink, not a copy: the store is the single artifact and `readlink -f`
+/// then answers "which version am I running" without a provenance lookup.
+pub fn front_newest(root: &Path, tool: &str, front: &[String]) -> Result<Vec<PathBuf>> {
+    front_newest_into(root, &front_dir(), tool, front)
+}
+
+/// [`front_newest`] with the destination passed in.
+///
+/// The public wrapper reads `$NROS_HOME`; this takes both directories as
+/// parameters so the decision is a pure function of them and its tests need no
+/// `set_var` — a process-global that leaks between parallel tests (issue 1101),
+/// and the same refactor phase-431 W1 made for the workspace guard.
+pub fn front_newest_into(
+    root: &Path,
+    dir: &Path,
+    tool: &str,
+    front: &[String],
+) -> Result<Vec<PathBuf>> {
+    if front.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(version) = newest_installed(root, tool) else {
+        return Ok(Vec::new());
+    };
+    let prefix = tool_prefix(root, tool, &version);
+    std::fs::create_dir_all(dir).wrap_err_with(|| format!("create {}", dir.display()))?;
+    let mut linked = Vec::new();
+    for rel in front {
+        let target = prefix.join(rel);
+        if !target.is_file() {
+            bail!(
+                "{tool} {version} declares `front = [\"{rel}\"]` in the index, but \
+                 {} does not exist. The install is incomplete, or the index names \
+                 the wrong path.",
+                target.display()
+            );
+        }
+        let Some(name) = Path::new(rel).file_name() else {
+            bail!("{tool}: `front` entry {rel:?} has no file name");
+        };
+        let link = dir.join(name);
+        // Replace rather than fail: this runs on every install, and the whole
+        // point is that the link MOVES to the newest version.
+        match std::fs::symlink_metadata(&link) {
+            Ok(_) => {
+                std::fs::remove_file(&link)
+                    .wrap_err_with(|| format!("replace {}", link.display()))?;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).wrap_err_with(|| format!("stat {}", link.display()));
+            }
+        }
+        std::os::unix::fs::symlink(&target, &link)
+            .wrap_err_with(|| format!("link {} -> {}", link.display(), target.display()))?;
+        linked.push(link);
+    }
+    Ok(linked)
+}
+
 /// How a tool was installed; persisted to `<prefix>/.nros-provenance`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -278,7 +423,28 @@ pub fn plan_install(tool: &ToolPackage, host: &str, prefix: &Path) -> InstallAct
 
 /// Execute an install action into `prefix`, returning the recorded provenance.
 /// Side-effecting (shells out to curl / sha256sum / tar / git); real-run only.
+/// Install `tool` at `prefix`, then front whatever the index's `front` list
+/// names (phase-431 W3).
+///
+/// `front` is a parameter of the INSTALL rather than a separate call, because
+/// three call sites reach this function and a fourth spelling of "and then link
+/// it" is how one of them ends up not doing it. Fronting is a no-op for the
+/// tools that declare nothing, which is all of them but `nros`.
 pub fn execute(
+    action: &InstallAction,
+    tool: &str,
+    version: &str,
+    prefix: &Path,
+    front: &[String],
+) -> Result<Provenance> {
+    let provenance = execute_install(action, tool, version, prefix)?;
+    for link in front_newest(&store_root(), tool, front)? {
+        eprintln!("    → {} (newest installed)", link.display());
+    }
+    Ok(provenance)
+}
+
+fn execute_install(
     action: &InstallAction,
     tool: &str,
     version: &str,
@@ -976,6 +1142,37 @@ mod phase365_tool_dir_tests {
         }
     }
 
+    /// phase-431 W3 — the index's `nros` smoke check asserts the CODEGEN
+    /// VERSION, so it must be the version this binary actually emits.
+    ///
+    /// The entry exists to make a released CLI safe to install, and the property
+    /// that makes it safe is what it emits — so `smoke` runs
+    /// `bin/nros --codegen-version` rather than `--version`. That number is
+    /// AUTHORED in two places once it is written into the index, and an
+    /// authored mirror in this tree has drifted every time nothing bound it
+    /// (`check-rmw-api-parity`'s map: 25 symbols, reading green). Bound here.
+    #[test]
+    fn the_nros_smoke_check_expects_the_version_this_binary_emits() {
+        let index = repo_index();
+        let tool = index
+            .tool
+            .get("nros")
+            .expect("`[tool.nros]` — phase-431 W3 added it; if it went away, so should this test");
+        let expected = crate::abi_guard::EMITTED_VERSION.to_string();
+        let probe = tool
+            .smoke
+            .iter()
+            .find(|p| p.run.contains("--codegen-version"))
+            .expect("`[tool.nros].smoke` must probe `--codegen-version`");
+        assert_eq!(
+            probe.expect, expected,
+            "the index expects `{}` from `{}` while this binary emits `{expected}`",
+            probe.expect, probe.run
+        );
+        // The other half of the promise: one command, newest version.
+        assert_eq!(tool.front, vec!["bin/nros".to_string()]);
+    }
+
     /// Issue 0628 — the candidate list is CONSTRUCTED, versioned first.
     ///
     /// Order is the whole contract: a host carrying both shapes must get the
@@ -1051,6 +1248,150 @@ mod tests {
 
     fn tmp(tag: &str) -> PathBuf {
         crate::test_support::scratch_path(&format!("store_{tag}"))
+    }
+
+    /// A version prefix the store would accept: populated, with the marker
+    /// `execute` writes on success.
+    fn install_fake(root: &Path, tool: &str, version: &str, rel: &str) -> PathBuf {
+        let prefix = tool_prefix(root, tool, version);
+        let file = prefix.join(rel);
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, format!("#!/bin/sh\necho {version}\n")).unwrap();
+        Provenance {
+            kind: ProvenanceKind::Prebuilt,
+            version: version.to_string(),
+            sha256: None,
+        }
+        .write(&prefix)
+        .unwrap();
+        prefix
+    }
+
+    /// Issue 0625's shape, in the one place that is ALLOWED to enumerate: a
+    /// directory where a version belongs must not be able to win by sorting.
+    #[test]
+    fn installed_versions_ignores_what_is_not_an_install() {
+        let root = tmp("versions");
+        std::fs::remove_dir_all(&root).ok();
+        install_fake(&root, "nros", "0.5.0-nros1", "bin/nros");
+        install_fake(&root, "nros", "0.6.0-nros1", "bin/nros");
+        // A pure-alpha sibling — `lib`/`share` under a legacy flat prefix. Under
+        // `sort -Vr` this sorts AHEAD of every numeric version, which is how it
+        // won 155 of 183 resolutions once.
+        std::fs::create_dir_all(root.join("nros").join("lib")).unwrap();
+        // A version-shaped directory with no provenance: a partial unpack, or a
+        // prefix somebody created by hand. Not an install.
+        std::fs::create_dir_all(root.join("nros").join("9.9.9-nros1").join("bin")).unwrap();
+
+        assert_eq!(
+            installed_versions(&root, "nros"),
+            vec!["0.5.0-nros1".to_string(), "0.6.0-nros1".to_string()]
+        );
+        assert_eq!(
+            newest_installed(&root, "nros").as_deref(),
+            Some("0.6.0-nros1")
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// `nros1` < `nros2` < `nros10` — a string compare gets the last pair
+    /// backwards, and the store's own vocabulary reaches double digits
+    /// (`qemu 11.0.0-nros6` today).
+    #[test]
+    fn version_order_is_numeric_not_lexical() {
+        let root = tmp("order");
+        std::fs::remove_dir_all(&root).ok();
+        for v in ["0.5.0-nros2", "0.5.0-nros10", "0.5.0-nros1"] {
+            install_fake(&root, "nros", v, "bin/nros");
+        }
+        assert_eq!(
+            newest_installed(&root, "nros").as_deref(),
+            Some("0.5.0-nros10")
+        );
+        assert!("0.5.0-nros10" < "0.5.0-nros2", "a string compare disagrees");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The promise: ONE `nros`, and it is the newest — not the last installed.
+    #[test]
+    fn front_points_at_the_newest_even_when_an_older_one_is_installed_after() {
+        let root = tmp("front_newest");
+        let bin = tmp("front_newest_bin");
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&bin).ok();
+        let front = vec!["bin/nros".to_string()];
+
+        install_fake(&root, "nros", "0.6.0-nros1", "bin/nros");
+        let linked = front_newest_into(&root, &bin, "nros", &front).unwrap();
+        assert_eq!(linked, vec![bin.join("nros")]);
+        assert_eq!(
+            std::fs::read_link(bin.join("nros")).unwrap(),
+            tool_prefix(&root, "nros", "0.6.0-nros1").join("bin/nros")
+        );
+
+        // Installing an OLDER version afterwards must not downgrade the command.
+        install_fake(&root, "nros", "0.5.0-nros1", "bin/nros");
+        front_newest_into(&root, &bin, "nros", &front).unwrap();
+        assert_eq!(
+            std::fs::read_link(bin.join("nros")).unwrap(),
+            tool_prefix(&root, "nros", "0.6.0-nros1").join("bin/nros")
+        );
+
+        // A NEWER one does move it, and replaces the existing link rather than
+        // failing on it — this runs on every install.
+        install_fake(&root, "nros", "0.7.0-nros1", "bin/nros");
+        front_newest_into(&root, &bin, "nros", &front).unwrap();
+        assert_eq!(
+            std::fs::read_link(bin.join("nros")).unwrap(),
+            tool_prefix(&root, "nros", "0.7.0-nros1").join("bin/nros")
+        );
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&bin).ok();
+    }
+
+    /// Declaring nothing fronts nothing — every tool but `nros` is this case,
+    /// and it must not create `$NROS_HOME/bin` as a side effect.
+    #[test]
+    fn front_is_a_no_op_for_a_tool_that_declares_none() {
+        let root = tmp("front_none");
+        let bin = tmp("front_none_bin");
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&bin).ok();
+        install_fake(&root, "qemu", "11.0.0-nros6", "bin/qemu-system-arm");
+        assert!(
+            front_newest_into(&root, &bin, "qemu", &[])
+                .unwrap()
+                .is_empty()
+        );
+        assert!(!bin.exists(), "no `front` must not create the bin dir");
+
+        // An UNINSTALLED tool that declares one is also silent -- there is
+        // nothing to point at yet, and that is not an error.
+        assert!(
+            front_newest_into(&root, &bin, "nros", &["bin/nros".to_string()])
+                .unwrap()
+                .is_empty()
+        );
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&bin).ok();
+    }
+
+    /// An index that names a path the install does not contain is an INDEX bug,
+    /// and it must say so rather than leave a dangling link behind.
+    #[test]
+    fn front_refuses_a_path_the_install_does_not_have() {
+        let root = tmp("front_missing");
+        let bin = tmp("front_missing_bin");
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&bin).ok();
+        install_fake(&root, "nros", "0.5.0-nros1", "bin/nros");
+        let err = front_newest_into(&root, &bin, "nros", &["bin/nrs".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("bin/nrs"), "{err}");
+        assert!(!bin.join("nrs").exists(), "left a link behind");
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&bin).ok();
     }
 
     /// Issue 0374 d4 — the workspace channel is what source recipes build with,

--- a/scripts/check-activate-shells.sh
+++ b/scripts/check-activate-shells.sh
@@ -193,6 +193,32 @@ for tool in espflash play_launch_parser; do
     fi
 done
 
+# phase-431 W3 — and a STORE-INSTALLED `nros` must NOT reach PATH.
+#
+# The store gained a `[tool.nros]` entry, so from now on a contributor's machine
+# can hold a released `nros` beside the checkout's own. `activate.sh` only adds a
+# store bin dir for the names in `scripts/sdk-path-tools.txt`, and `nros` is
+# deliberately absent from it: that list exists for binaries something we do not
+# control invokes by BARE NAME (an RTOS `make`, a cmake `find_program`), and the
+# CLI is not one of those. If it were on the list, sourcing activate.sh in a
+# checkout would put a foreign emitter first on PATH — which `nros build` now
+# refuses (W1) and `just doctor` now fails on (W2). Better that it never
+# happens than that two other checks catch it.
+#
+# The user reaches the released binary through `$NROS_HOME/bin` (the `front`
+# link), which is a directory THEY put on PATH, not one activate.sh adds.
+mkdir -p "$versioned_store/sdk/nros/0.5.0-nros1/bin"
+: >"$versioned_store/sdk/nros/0.5.0-nros1/bin/nros"
+chmod +x "$versioned_store/sdk/nros/0.5.0-nros1/bin/nros"
+path_out="$(NROS_HOME="$versioned_store" NROS_QUIET_ACTIVATE=1 bash -c \
+    ". '$REPO_ROOT/activate.sh'; printf '%s' \"\$PATH\"" 2>/dev/null)"
+if nros_grep_q "^$versioned_store/sdk/nros/" <<<"${path_out//:/$'\n'}"; then
+    fail "activate.sh: a STORE-installed nros reached PATH — it would shadow the checkout's CLI (phase-431 W2/W3)"
+else
+    echo "ok: bash/store-nros-does-not-shadow"
+fi
+RAN=$((RAN + 1))
+
 if [ "$RAN" -eq 0 ]; then
     fail "no shell was exercised"
 fi

--- a/scripts/check-sdk-store-not-enumerated.py
+++ b/scripts/check-sdk-store-not-enumerated.py
@@ -35,7 +35,20 @@ made this worth a gate:
     `riscv-none-elf-gcc/*/` and took `list(GET … -1)`. Same class, other tools,
     both found by this rule rather than by a failure.
 
-Issue 0625; phase-365.
+WHAT IS NOT BANNED (phase-431 W3)
+
+`sdk_store::installed_versions` reads `<store>/<tool>/` and takes the newest.
+That is enumeration, and it is correct, because it answers a DIFFERENT question:
+not "where is the version I pinned" (constructible from two inputs) but "what is
+the newest thing installed here" (nothing but the store knows). It backs the
+`front` link — `$NROS_HOME/bin/nros` points at the newest installed CLI, which is
+the "one command" promise. It carries 0625's defence in the filter rather than in
+the sort: a candidate must begin with a digit AND carry a `.nros-provenance`
+marker, so `lib/` under a legacy flat prefix cannot win by sorting.
+
+The rule is unchanged for consumers: a PIN is constructed, never searched.
+
+Issue 0625; phase-365; phase-431 W3.
 """
 
 import re


### PR DESCRIPTION
Stacked on #543 (W2), which is stacked on #537 (W1).

`<store>/<tool>/<version>/` is already what the store writes (`tool_prefix`, phase-365), so this is the **front** half plus the index entry.

## Fronting

`[tool.<name>] front = ["bin/nros"]` names prefix-relative paths that must be reachable by bare name from `$NROS_HOME/bin` — the one directory a user puts on PATH.

`front_newest` recomputes from the store on every install and links the **newest installed** version, not the one just installed. Versions accumulate and nothing prunes them (issue 0500), so installing an older one on purpose must not silently downgrade the command. It is a **parameter of `execute`** rather than a separate call: three call sites reach that function, and a fourth spelling of "and then link it" is how one of them ends up not doing it.

### It enumerates the store, and that is not a violation

`check-sdk-store-not-enumerated` bans enumeration — correctly, for the question that gate is about. These are two questions:

| question | answer |
|---|---|
| where is the version I **pinned**? | constructible from two inputs — `tool_dir`, never a search |
| what is the **newest** thing installed here? | nothing but the store knows |

Issue 0625's defence moves into the **filter** rather than the sort: a candidate must begin with a digit **and** carry a `.nros-provenance` marker, so a legacy flat prefix's `lib/` cannot win by sorting the way it won 155 of 183 resolutions once. The comparator is natural-order on top of that — `nros2` < `nros10`, which a string compare gets backwards and the store's own vocabulary already reaches (`qemu 11.0.0-nros6`). The gate's docstring now records the distinction so the next reader does not have to re-derive it.

## `nros sdk-front <tool>`

For the one caller that cannot go through `nros setup`: W4's `bootstrap.sh`, which unpacks the CLI itself and has no `nros` to run `nros setup --tool nros` with until it has. One implementation, two callers — a second spelling in shell is how they would come to disagree about which version `nros` means.

## The index entry

`[tool.nros]` was **removed** by phase-288 D1/D2, and the index still carried the comment saying why: the archived standalone repo's 0.3.6 binaries were 15 releases stale and ABI-mismatched with the checkout, so installing one was a footgun. That reason is now **answered rather than waived** — RFC-0090 (an incompatible emitter refuses), #537 (a binary foreign to the checkout refuses), #543 (doctor fails on a shadow) — and the entry says which three.

No `dist` rows until W5 seeds an asset; until then the source recipe builds it, pinned to a **commit** (issue 1060 — a tag is a ref on a server we do not control).

`smoke` asserts `--codegen-version` rather than `--version`, because what makes this particular tool safe to install is what it emits. That makes it an authored mirror of `NROS_CODEGEN_VERSION` — the shape that has drifted every time nothing bound it (`check-rmw-api-parity`: 25 symbols, reading green). A test binds it to `abi_guard::EMITTED_VERSION`.

## `nros` stays off `scripts/sdk-path-tools.txt`

That list puts a store `bin/` on PATH for binaries something we do not control invokes by bare name (an RTOS `make`, a cmake `find_program`). The CLI is not one, and on that list `source ./activate.sh` in a checkout would put a foreign emitter **first** — the exact state #537 refuses and #543 fails on.

`check-activate-shells` asserts the **behaviour**, not the list: a store holding `nros/<version>/bin/nros` must not reach PATH. Mutation-verified — adding the name to the list turns it red.

## Observed, with a real binary in a scratch store

```
install 0.5.0-nros1, front  -> ~/.nros/bin/nros -> …/0.5.0-nros1/bin/nros
install 0.6.0-nros1, front  -> …/0.6.0-nros1/bin/nros    (newest wins)
install an OLDER one, front -> unchanged                 (no silent downgrade)
$NROS_HOME/bin/nros --codegen-version -> 1
```

`just check fast`: 232/232. `nros-cli-core` lib: 945/945, 6 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK