### PR TITLE
phase-431 W5: the release workflow, and a released `nros` that can find its index

### DIFF
--- a/.github/workflows/release-nros.yml
+++ b/.github/workflows/release-nros.yml
@@ -1,0 +1,219 @@
+# Cut a release of the `nros` CLI — phase-431 W5.
+#
+# MANUAL DISPATCH ONLY, and with an explicit version. The CLI rolls rapidly
+# in-tree; a release is a deliberate act for USERS, not a consequence of a
+# version bump landing on main. Nothing here is scheduled and nothing triggers
+# on a tag: the tag is created BY this workflow, from the version you type.
+#
+# Never a local build. That is the `nano-ros-sdk` repo's own convention for the
+# assets it publishes, and the reason is reproducibility rather than
+# convenience — a binary built on somebody's laptop carries that laptop's
+# glibc, its toolchain and whatever was in its environment, and nothing
+# afterwards can tell you which.
+#
+# WHAT A RELEASE MUST ASSERT ABOUT ITSELF
+#
+# The last time nano-ros shipped a prebuilt `nros`, the binary emitted code
+# that had drifted from the runtime, and drifted generated code COMPILES — so
+# the failure was silent and the download was withdrawn (phase-288 D1/D2). The
+# checks below are what makes shipping safe again, and each one is here because
+# it is the property a user cannot verify for themselves:
+#
+#   source-stamp        the binary matches the checkout it was built from
+#   --codegen-version   it equals `NROS_CODEGEN_VERSION` in that same tree
+#   version agreement   the tag, the crate version and `[tool.nros].version`
+#                       in the index describe one artifact
+#
+# WHAT THE ASSET CONTAINS, and why each part is not optional
+#
+#   bin/nros                          the binary
+#   share/nros/VERSION                the STORE version (`0.5.0-nros1`), which
+#                                     `nros --version` does not print — without
+#                                     it `install.sh` cannot name the prefix the
+#                                     index pins, and a later
+#                                     `nros setup --tool nros` installs a second
+#                                     copy of the same binary
+#   share/nros/nros-sdk-index.toml    a released `nros` has no checkout to find
+#                                     an index in, so `nros setup <board>` fails
+#                                     outright without this (phase-431 W5,
+#                                     `setup::shipped_index`)
+#   <asset>.sha256                    `install.sh` REFUSES an asset it cannot
+#                                     verify, so a release without this is
+#                                     un-installable by design
+#
+# Linux x86_64 only for now. macOS is deferred by the tree, and linux-arm64
+# waits on a runner decision — it is one matrix row when that is made, and the
+# index already has the host key for it.
+name: release nros
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "store version to release, e.g. 0.5.0-nros1 (must equal [tool.nros].version)"
+        required: true
+        type: string
+      publish:
+        description: "create the tag + GitHub release (off = build and verify only)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: release-nros
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build + verify nros-linux-x86_64
+    # 22.04, not `latest`: the binary links the runner's glibc, and a newer one
+    # will not run on the LTS the book's install instructions target. The floor
+    # is a property of the release, so it is pinned rather than inherited.
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # The asset is `.tar.zst` and `tar` shells out to the `zstd` binary. The
+      # package NAME comes from the index, not from here: it carries the
+      # apt/dnf/pacman/brew spellings, and a copy in a workflow is the one that
+      # goes stale (`check-workflow-indexed-apt`, which caught this line).
+      - name: Install zstd
+        run: |
+          sudo apt-get update
+          # shellcheck disable=SC2046
+          sudo apt-get install -y $(python3 scripts/sdk/prereq-packages.py --manager apt zstd)
+
+      - name: Build the CLI from source
+        run: |
+          git submodule update --init --depth 1 packages/cli/third-party/play_launch
+          cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros
+          # phase-429 W5 — the binary must match the checkout it was built from.
+          # A release is the one artifact where nobody downstream can re-check
+          # this, so it is asserted here rather than assumed.
+          "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
+
+      - name: Verify the release describes itself
+        run: |
+          set -euo pipefail
+          nros="$GITHUB_WORKSPACE/packages/cli/target/release/nros"
+          want_version='${{ inputs.version }}'
+
+          # 1. The codegen version the binary emits must be the one THIS TREE's
+          #    runtime accepts. A release claiming a compatibility it does not
+          #    have is the exact failure that withdrew the last one.
+          emitted="$("$nros" --codegen-version)"
+          declared="$(sed -n 's/^pub const NROS_CODEGEN_VERSION: u32 = \([0-9]\+\);.*/\1/p' \
+              packages/core/nros-core/src/codegen_version.rs)"
+          if [ "$emitted" != "$declared" ]; then
+              echo "::error::the binary emits codegen version $emitted, the tree declares $declared" >&2
+              exit 1
+          fi
+          echo "codegen version: $emitted (binary and tree agree)"
+
+          # 2. The index must already pin the version being released. The store
+          #    prefix is named from it, and `install.sh` reads it out of the
+          #    asset — three places, one string.
+          indexed="$(sed -n '/^\[tool\.nros\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' nros-sdk-index.toml)"
+          if [ "$indexed" != "$want_version" ]; then
+              echo "::error::releasing $want_version but [tool.nros].version is $indexed — bump the index first" >&2
+              exit 1
+          fi
+
+          # 3. The store version is the crate version plus a repackaging
+          #    counter, so the crate version must be its prefix. This catches
+          #    releasing `0.6.0-nros1` off a 0.5.0 tree, which would install
+          #    under a name that promises code the binary does not have.
+          crate="$("$nros" --version | awk '{print $NF}')"
+          case "$want_version" in
+              "$crate"-nros*) ;;
+              *)
+                  echo "::error::version $want_version is not <crate>-nrosN for crate version $crate" >&2
+                  exit 1
+                  ;;
+          esac
+          echo "version: $want_version (crate $crate, index agrees)"
+
+      - name: Stage the prefix
+        run: |
+          set -euo pipefail
+          stage="$RUNNER_TEMP/prefix"
+          mkdir -p "$stage/bin" "$stage/share/nros"
+          cp packages/cli/target/release/nros "$stage/bin/nros"
+          printf '%s\n' '${{ inputs.version }}' >"$stage/share/nros/VERSION"
+          cp nros-sdk-index.toml "$stage/share/nros/nros-sdk-index.toml"
+          # Prefix-rooted, the mirror shape every other dist in the index uses,
+          # so `sdk_store::execute`'s default unpack lands it unchanged.
+          tar --zstd -cf "$RUNNER_TEMP/nros-linux-x86_64.tar.zst" -C "$stage" bin share
+          cd "$RUNNER_TEMP"
+          sha256sum nros-linux-x86_64.tar.zst >nros-linux-x86_64.tar.zst.sha256
+          cat nros-linux-x86_64.tar.zst.sha256
+
+      - name: Prove the asset installs, before publishing it
+        run: |
+          set -euo pipefail
+          # The installer's own refusals are gated in `just check nros-installer`
+          # against a synthetic tarball. This runs the REAL one, which is the
+          # only way to catch an asset that is well-formed and wrong — a missing
+          # VERSION file, a prefix rooted one directory too deep, a binary that
+          # does not run on a clean runner.
+          python3 -m http.server 8422 --directory "$RUNNER_TEMP" &
+          server=$!
+          trap 'kill $server' EXIT
+          for _ in $(seq 1 50); do
+              curl -fsS -o /dev/null "http://127.0.0.1:8422/nros-linux-x86_64.tar.zst" && break
+              sleep 0.2
+          done
+          NROS_HOME="$RUNNER_TEMP/probe" \
+            NROS_INSTALL_URL="http://127.0.0.1:8422/nros-linux-x86_64.tar.zst" \
+            sh scripts/install.sh
+          installed="$RUNNER_TEMP/probe/bin/nros"
+          test -x "$installed"
+          test "$(readlink -f "$installed")" = "$RUNNER_TEMP/probe/sdk/nros/${{ inputs.version }}/bin/nros"
+          # The fronted binary must be able to do the thing a user installs it
+          # for, from a directory that is not a checkout.
+          cd "$RUNNER_TEMP"
+          "$installed" --codegen-version
+          "$installed" setup --list >/dev/null
+          echo "the asset installs, fronts, and finds its own index"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nros-linux-x86_64
+          path: |
+            ${{ runner.temp }}/nros-linux-x86_64.tar.zst
+            ${{ runner.temp }}/nros-linux-x86_64.tar.zst.sha256
+
+      - name: Publish the release
+        if: ${{ inputs.publish }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="nros-${{ inputs.version }}"
+          nros="$GITHUB_WORKSPACE/packages/cli/target/release/nros"
+          # The notes go through a FILE, one `printf` argument per line. A
+          # column-0 line inside a YAML `run:` block is parsed as syntax, not as
+          # text, so a heredoc is unusable here and its terminator would have to
+          # sit where YAML expects a key (CLAUDE.md's pitfall index).
+          printf '%s\n' \
+            "The \`nros\` CLI, codegen version $("$nros" --codegen-version)." \
+            "" \
+            "Install:" \
+            "" \
+            '```' \
+            "curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | sh" \
+            '```' \
+            "" \
+            "Contributors build from source instead: inside a checkout the tree's own" \
+            "build is the only correct binary (RFC-0090, phase-431 W1/W2)." \
+            >"$RUNNER_TEMP/notes.md"
+          # `--target` pins the release to the commit that was verified above,
+          # not to whatever the branch points at when this step runs.
+          gh release create "$tag" \
+              --target "$GITHUB_SHA" \
+              --title "nros ${{ inputs.version }}" \
+              --notes-file "$RUNNER_TEMP/notes.md" \
+              "$RUNNER_TEMP/nros-linux-x86_64.tar.zst" \
+              "$RUNNER_TEMP/nros-linux-x86_64.tar.zst.sha256"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,14 @@ source ./activate.sh          # or: direnv allow / source ./activate.fish
 just doctor
 ```
 
+**Build the CLI here, do not install a release.** `scripts/install.sh` exists
+for users and puts a released `nros` in `~/.nros/bin`; in a checkout that binary
+is refused. It emits *its own* generated code, and this tree's runtime is what
+has to compile it — a release at the same codegen version is different, not
+compatible (RFC-0090, phase-431 W1). `just doctor` FAILS when a `nros` on PATH
+is not this checkout's, because `nros_cli_bin` resolves PATH first, so a shadow
+is the binary every recipe here would run.
+
 **`source ./activate.sh` is not optional, and skipping it fails in a confusing
 place.** It puts the per-checkout `nros` binary on PATH and exports the SDK
 environment the build scripts read; without it `zpico-sys/build.rs` panics with

--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ cd nano-ros
 ./scripts/bootstrap.sh
 ```
 
-The script installs rustup if needed and builds the CLI from source —
-nano-ros is a source distribution (there is no prebuilt `nros`).
+The script installs rustup if needed and builds the CLI from source. In a
+checkout that is the point: the tree's own build is the binary this tree
+accepts, because a released `nros` emits its own generated code and this
+runtime is what has to compile it (RFC-0090). To just *use* nano-ros, install
+a release instead — `curl -fsSL
+https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh`.
 Equivalent, if you already have cargo:
 `git submodule update --init packages/cli/third-party/play_launch &&
 cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros`.

--- a/book/src/getting-started/first-node-c.md
+++ b/book/src/getting-started/first-node-c.md
@@ -15,7 +15,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/first-node-cpp.md
+++ b/book/src/getting-started/first-node-cpp.md
@@ -16,7 +16,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/first-node-rust.md
+++ b/book/src/getting-started/first-node-rust.md
@@ -18,7 +18,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -1,10 +1,23 @@
 # Installation
 
-nano-ros is distributed as **source**, vendored into the consumer's
+The **library** is distributed as source, vendored into the consumer's
 project tree (git submodule, `west` manifest, ESP-IDF component, etc.)
 and built in-tree via `add_subdirectory(nano-ros)`. There is no binary
-tarball, no system-wide install step, no `find_package(NanoRos)`, and
-no prebuilt `nros` CLI.
+tarball, no system-wide install step and no `find_package(NanoRos)`.
+
+The **`nros` CLI** is a separate question with a separate answer, and
+which one you want depends on who you are:
+
+| you are… | you get `nros` by… |
+| --- | --- |
+| **using** nano-ros to build your own project | installing a release — `scripts/install.sh`, below |
+| **developing** nano-ros itself | building it from the checkout — `./scripts/bootstrap.sh` |
+
+That is not a preference. Inside a nano-ros checkout the tree's own
+build is the only correct binary: a released `nros` run against a
+checkout is refused outright, because it emits *its own* generated code
+and this tree's runtime is the one that has to compile it
+([RFC-0090](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0090-codegen-version-is-the-compatibility-token.md)).
 
 ## Host prerequisites
 
@@ -76,19 +89,24 @@ first: they are what it takes to clone the repo and build the CLI.
 Four steps take a bare machine to a building project; each is detailed
 in a section below.
 
-> **Why step 2 builds the CLI instead of downloading it.** nano-ros is a source
-> distribution today: there is no prebuilt `nros` to fetch, so obtaining the tool
-> requires the repository and its toolchain. That is backwards — `nros`
-> provisions dependencies and builds workspaces, so it is meant to be the thing
-> you get *first*, and the thing that makes cloning this repository unnecessary.
+> **Why step 2 builds the CLI here.** These four steps are the *contributor*
+> flow — they start by cloning the repository, so step 2 is the checkout's own
+> build, which is the only binary that may be used against it.
 >
 > Prebuilt binaries were shipped early and withdrawn, because a released binary
 > emitted code that had drifted from the runtime — and drifted generated code
-> *compiles*, so the failure was silent. Restoring the download is blocked on one
-> question having a checkable answer: *can this binary's output work with this
-> runtime?* [RFC-0090](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0090-codegen-version-is-the-compatibility-token.md)
+> *compiles*, so the failure was silent. Restoring the download needed one
+> question to have a checkable answer: *can this binary's output work with this
+> runtime?*
+> [RFC-0090](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0090-codegen-version-is-the-compatibility-token.md)
 > answers it with a codegen version that every generated artifact carries and
-> every runtime asserts. Until that ships in a release, step 2 stays.
+> every runtime asserts, and every arm of it refuses at compile time.
+>
+> **No release has been cut yet.** The machinery is in place (`scripts/install.sh`
+> and a manual release workflow), and cutting one is a deliberate act rather
+> than a consequence of a version bump — so until the first one exists, building
+> from the checkout is how everyone gets `nros`. `install.sh` says so itself if
+> you run it early, and points you back here.
 
 ```sh probe=20
 # 1. Pull the source at a pinned version (or `main` for latest):
@@ -294,9 +312,24 @@ both vendored submodules) and no daemon at all.
 
 ### 1. Get the `nros` CLI onto PATH
 
-nano-ros is a **source distribution** — there is no prebuilt `nros`
-download. One front door from a fresh checkout (`just` is NOT a
-prereq; rustup is installed on demand):
+**If you only want to use nano-ros**, install a release — no checkout,
+no cargo, no `just`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+```
+
+It verifies the download's sha256 (and refuses an asset it cannot
+verify), installs into `~/.nros/sdk/nros/<version>/` and points
+`~/.nros/bin/nros` at the newest version installed — so however many
+versions accumulate, `nros` means one command. Put `~/.nros/bin` on
+your PATH. Until the first release is cut it will tell you so and send
+you to the source build below.
+
+**If you are working on nano-ros itself**, build the CLI from the
+checkout — that binary is the only one this tree accepts. One front
+door from a fresh checkout (`just` is NOT a prereq; rustup is installed
+on demand):
 
 > Sourcing `activate.sh` on a host without `just` prints one line about
 > RTOS SDK path defaults (`FREERTOS_DIR`, `NUTTX_DIR`, `IDF_PATH`, …)

--- a/book/src/getting-started/workspace-bringup.md
+++ b/book/src/getting-started/workspace-bringup.md
@@ -20,7 +20,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/workspace-entry-pkg.md
+++ b/book/src/getting-started/workspace-entry-pkg.md
@@ -20,7 +20,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/workspace-from-app-node.md
+++ b/book/src/getting-started/workspace-from-app-node.md
@@ -82,7 +82,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/workspace-node-pkgs.md
+++ b/book/src/getting-started/workspace-node-pkgs.md
@@ -21,7 +21,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -9,11 +9,26 @@ directly.
 
 ## Install
 
-The `nros` CLI ships from the in-tree sub-workspace at `packages/cli/`
-nano-ros is a **source distribution** — there is no
-prebuilt `nros` download. One front door — bootstrap
-(builds the CLI from source; installs rustup if needed), then activate
-the workspace to put it on PATH:
+Two front doors, and which one is right depends on who you are.
+
+**Using nano-ros** — install a release, with no checkout and no cargo:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+```
+
+It verifies the sha256, installs into `~/.nros/sdk/nros/<version>/` and points
+`~/.nros/bin/nros` at the newest installed version — one command, however many
+versions accumulate. (No release is cut yet; the installer says so and sends
+you to the source build.)
+
+**Working on nano-ros** — build the CLI from the checkout. That is not a
+fallback: in a checkout the tree's own build is the only binary this tree
+accepts, because a released `nros` emits its own generated code and this
+runtime is what compiles it (RFC-0090, phase-431 W1). `just doctor` fails when
+another `nros` shadows it. The CLI ships from the in-tree sub-workspace at
+`packages/cli/`; bootstrap builds it (installing rustup if needed), then
+activate the workspace to put it on PATH:
 
 ```sh
 ./scripts/bootstrap.sh

--- a/docs/issues/1110-rustdoc-broken-intra-doc-link-in-clienttrait.md
+++ b/docs/issues/1110-rustdoc-broken-intra-doc-link-in-clienttrait.md
@@ -1,0 +1,65 @@
+---
+id: 1110
+title: "`just book` and the docs deploy have been red since 2026-09-03 — a doc link to a method that commit deleted"
+status: open
+type: bug
+area: docs, core
+severity: medium
+found: 2026-09-06
+related: [1008, 1076]
+---
+
+# The link outlived the method it points at
+
+```
+$ just book
+error: unresolved link to `Self::is_server_ready`
+    --> packages/core/nros-rmw/src/traits.rs:2837:29
+     |
+2837 |     /// [`is_server_ready`](Self::is_server_ready), which collapses
+     |                             ^^^^^^^^^^^^^^^^^^^^^ the trait `ClientTrait` has no associated item named `is_server_ready`
+
+error: could not document `nros-rmw`
+error: recipe `book` failed with exit code 101
+```
+
+`3941b569a` (*"fix(#1008): `wait_for_service` never waited — W6 decision 2
+deletes the collapse"*, 2026-09-03) removed `is_server_ready` from
+`ClientTrait`. The paragraph **beside** it still contrasts `server_available()`
+with that method, by intra-doc link:
+
+```rust
+/// "don't know" and "no server" into the same `false` answer.
+/// Distinct from [`is_server_ready`](Self::is_server_ready), which collapses
+```
+
+`grep -c 'fn is_server_ready' packages/core/nros-rmw/src/traits.rs` → **0**.
+
+## Why it went unnoticed for three days
+
+rustdoc's broken-link lint is deny-level in this configuration, so this is an
+`error`, not a warning — but nothing on the merge-gating lanes runs rustdoc.
+`just book` does, and it is not in `check-fast`, `ci gate`, or the required `CI`
+context. `docs.yml` runs on `push` to `main` under a path filter that
+**includes** `packages/core/nros-rmw/**`, so the docs deploy has been failing
+since that commit landed.
+
+Same class as issue 0319 (a backend suite nothing on the `just check` line ran)
+and 0896 (`check-cli-tests` living only in a lane no merge-gating event runs):
+the check exists, is correct, and is not on a path anything traverses.
+
+## The fix, and the fix for the class
+
+1. The paragraph. `server_available()` is now the only spelling, so the contrast
+   has no other side — the sentence should be rewritten to state what
+   `server_available()` returns rather than what the deleted method collapsed.
+   Deleting the link alone leaves a dangling "Distinct from" clause.
+
+2. The class. Deleting a method must fail somewhere that runs on a PR. Either
+   `just book` joins a lane, or a cheap `cargo doc --no-deps` over the core
+   crates does — the full book build is expensive (it also runs Doxygen and the
+   rustdoc driver), and the value here is the link check, not the HTML.
+
+Found while verifying a docs change for phase-431 W6: the book built fine
+(`mdbook build` alone is green), and `just book` was red before the change and
+after it.

--- a/docs/roadmap/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/phase-431-ship-the-nros-binary.md
@@ -1,7 +1,7 @@
 # Phase 431 — ship the `nros` binary
 
-**Status (2026-09-06).** **W1–W5 landed.** W6 (docs) open. No release has been
-cut: W5 is manual dispatch, and cutting one is a decision, not a consequence — the distribution
+**Status (2026-09-06). Every work item is landed.** No release has been cut:
+W5 is manual dispatch, and cutting one is a decision, not a consequence — the distribution
 mechanics proper. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
 removed the correctness blocker; what remains is distribution mechanics plus one
 hazard that shipping CREATES and that is worth fixing before the first release
@@ -400,6 +400,35 @@ wrong on the first release and should be replaced, not deleted — the reason
 prebuilt binaries were withdrawn is worth keeping, with the answer now attached.
 `AGENTS.md` and `scripts/bootstrap.sh`'s header (*"there is no prebuilt `nros`
 download"*) likewise.
+
+**Landed 2026-09-06.**
+
+The claim that needed replacing was **"there is no prebuilt `nros`"**, in 12
+places across 11 files. That sentence is a fact with an expiry date, and the
+replacement deliberately is not: the durable statement is about **audience**, not
+existence — a checkout builds its own binary because that is the only one it
+accepts, and a user installs a release because they have no checkout. That reads
+correctly before the first release and after it.
+
+The four-step quick start stays a *contributor* flow (it opens with `git clone`),
+with the user path stated above it as a table. `installation.md` and
+`reference/cli.md` lead with `install.sh`; the seven getting-started pages carried
+the same parenthetical and were rewritten together rather than one at a time.
+`CONTRIBUTING.md` gains the sentence a contributor actually needs — *do not
+install a release here, `just doctor` fails on it, and here is why* — since a
+contributor who has both is the person this phase's hazard is aimed at.
+
+One thing is said once and not eleven times: **no release is cut yet.** It sits
+in `installation.md`, and `install.sh` says the same thing itself when run early,
+so a user who skips the book still lands somewhere useful.
+
+**Filed while verifying:** [#1110](../issues/1110-rustdoc-broken-intra-doc-link-in-clienttrait.md)
+— `just book` and the docs deploy have been red since 2026-09-03. `3941b569a`
+deleted `ClientTrait::is_server_ready`; the paragraph beside it still links to it,
+rustdoc's broken-link lint is deny-level, and nothing on a merge-gating lane runs
+rustdoc. Not this phase's change (`mdbook build` alone is green, and `just book`
+was red before the edit and after it), and the class is 0319/0896 again: a correct
+check on a path nothing traverses.
 
 ## What this phase must not do
 

--- a/docs/roadmap/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/phase-431-ship-the-nros-binary.md
@@ -1,7 +1,7 @@
 # Phase 431 — ship the `nros` binary
 
-**Status (2026-09-06).** **W1–W4 landed.** W5 (the release workflow) and W6
-(docs) open — the distribution
+**Status (2026-09-06).** **W1–W5 landed.** W6 (docs) open. No release has been
+cut: W5 is manual dispatch, and cutting one is a decision, not a consequence — the distribution
 mechanics proper. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
 removed the correctness blocker; what remains is distribution mechanics plus one
 hazard that shipping CREATES and that is worth fixing before the first release
@@ -337,6 +337,60 @@ rediscovered:
   asset it cannot verify — a release without one is un-installable, by design;
 * and the asset must be **prefix-rooted** (`bin/nros`, `share/…`), the mirror
   shape every other dist in the index uses, so it lands in the store unchanged.
+
+**Landed 2026-09-06** as `.github/workflows/release-nros.yml`. Nothing is
+scheduled and nothing triggers on a tag: the tag is created BY the workflow,
+from the version you type, and `publish` defaults to **false** so a dispatch
+builds and verifies without releasing anything.
+
+*What it asserts*, each because it is a property a user cannot check for
+themselves:
+
+| check | what it catches |
+| --- | --- |
+| `nros source-stamp` | the binary does not match the checkout it was built from |
+| `--codegen-version` vs `NROS_CODEGEN_VERSION` in the same tree | a release claiming a compatibility it does not have — the failure that withdrew the last one |
+| `[tool.nros].version` == the dispatched version | an asset whose store prefix is not the one the index pins |
+| the version is `<crate>-nrosN` | releasing `0.6.0-nros1` off a 0.5.0 tree |
+
+*And it installs its own asset before publishing it.* The installer's refusals
+are gated against a synthetic tarball (W4); only this catches an asset that is
+well-formed and **wrong** — a missing `VERSION`, a prefix rooted one directory
+too deep, a binary that does not run on a clean runner. It serves the tarball
+over loopback and asserts the fronted binary runs `--codegen-version` and
+`setup --list` **from a directory that is not a checkout**.
+
+That last assertion found a real gap. **A released `nros` could not run
+`nros setup <board>` at all**: `locate_index` looked in the cwd and in a
+workspace, both of which assume a checkout, and the whole point of shipping a
+binary is that there is no checkout. So the asset carries
+`share/nros/nros-sdk-index.toml` and `setup::shipped_index` resolves it from the
+running executable — from the executable rather than `$NROS_HOME`, so two
+versions in the store each answer with their own and stay independently
+installable. `resolve_index` falls back only for the DEFAULT: a `--index` the
+user typed names a file they chose, and silently reading another one is how a
+build gets provisioned from a table nobody looked at.
+
+*Runner and reach.* `ubuntu-22.04`, pinned rather than `latest`: the binary
+links the runner's glibc, and a newer one will not run on the LTS the book's
+install instructions target — the floor is a property of the release. Linux
+x86_64 only; `linux-arm64` is one matrix row whenever a runner is decided on,
+and the index already carries the host key.
+
+*The gate exempts it, in one direction only.* `check-ci-cli-from-source`'s arm A
+does not apply to a workflow that PRODUCES the release — it names the asset a
+dozen times because it builds one, and it runs `scripts/install.sh` on purpose.
+Arm B still applies, and that is what keeps the exemption from being a hole:
+mutation-verified by deleting the `source-stamp` line, which turns the gate red.
+
+`check-workflow-indexed-apt` caught the workflow restating `zstd` as an apt
+package name; it now asks `scripts/sdk/prereq-packages.py`, since the index
+carries the per-manager spellings and a workflow copy is the one that goes
+stale.
+
+Rehearsed locally end to end — build, verify, stage, serve, install, front, run
+outside a checkout — before the workflow was committed, because a release
+workflow's first real run should not be its first run.
 
 ### W6 — the docs stop describing a source-only distribution
 

--- a/packages/api/nros/src/guide/getting_started.rs
+++ b/packages/api/nros/src/guide/getting_started.rs
@@ -46,8 +46,9 @@
 //!
 //! ## 3. Generate message bindings
 //!
-//! Build the `nros` tool (one-time, from a nano-ros checkout — nano-ros
-//! is a source distribution; there is no prebuilt `nros`):
+//! Build the `nros` tool (one-time, from a nano-ros checkout — in a
+//! checkout the tree's own build is the binary it accepts, RFC-0090;
+//! to just USE nano-ros, install a release with `scripts/install.sh`):
 //!
 //! ```bash
 //! ./scripts/bootstrap.sh   # builds packages/cli/target/release/nros

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,9 +17,16 @@ nano-ros itself lives at [NEWSLabNTU/nano-ros](https://github.com/NEWSLabNTU/nan
 
 ## Install
 
-nano-ros is a **source distribution** (phase-288 D1/D2): there is no
-prebuilt `nros`. From a nano-ros checkout, the front door builds it —
-installing rustup if needed:
+Users install a release and need no checkout:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+```
+
+From a nano-ros checkout, the front door builds it instead — installing rustup
+if needed. That is the correct binary here and a released one is not: it emits
+its own generated code, and this tree's runtime is what has to compile it
+(RFC-0090, phase-431 W1/W2).
 
 ```bash
 ./scripts/bootstrap.sh

--- a/packages/cli/nros-cli-core/src/cmd/sdk_front.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_front.rs
@@ -45,7 +45,7 @@ pub struct Args {
 
 pub fn run(args: Args) -> Result<()> {
     let front = if args.front.is_empty() {
-        let index = SdkIndex::load(&args.index)?;
+        let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index))?;
         let Some(tool) = index.tool.get(&args.tool) else {
             let known: Vec<&str> = index.tool.keys().map(String::as_str).collect();
             bail!(

--- a/packages/cli/nros-cli-core/src/cmd/sdk_path.rs
+++ b/packages/cli/nros-cli-core/src/cmd/sdk_path.rs
@@ -43,7 +43,7 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> Result<()> {
-    let index = SdkIndex::load(&args.index)?;
+    let index = SdkIndex::load(&crate::cmd::setup::resolve_index(&args.index))?;
 
     let Some(dir) = sdk_store::tool_dir(&index, &args.tool) else {
         // Name what IS pinned: a typo and an unprovisioned tool look identical

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -214,7 +214,8 @@ pub fn run(args: Args) -> Result<()> {
         };
     }
 
-    let index = SdkIndex::load(&args.index)?;
+    let index_path = resolve_index(&args.index);
+    let index = SdkIndex::load(&index_path)?;
     let host = host_key();
 
     if args.list {
@@ -226,7 +227,7 @@ pub fn run(args: Args) -> Result<()> {
         return Ok(());
     }
     if let Some(ws) = args.workspace_scan.clone() {
-        let root = args.index.parent().map(std::path::Path::to_path_buf);
+        let root = index_path.parent().map(std::path::Path::to_path_buf);
         return run_workspace_scan(&index, &ws, root.as_deref());
     }
     // `--sudo` means "execute the install", and there are exactly two things it
@@ -244,7 +245,7 @@ pub fn run(args: Args) -> Result<()> {
         // `path` probe resolves against (phase-398 W2). Derived rather than
         // re-discovered, so the probe and the provisioner cannot disagree
         // about where a checkout is.
-        let root = args.index.parent().map(std::path::Path::to_path_buf);
+        let root = index_path.parent().map(std::path::Path::to_path_buf);
         return run_system(&index, args.check, args.sudo, root.as_deref(), &args.roles);
     }
     // #0390 — must precede the generic `--check` below: `--build-sources --check`
@@ -252,7 +253,7 @@ pub fn run(args: Args) -> Result<()> {
     if args.build_sources {
         return run_build_sources(
             &index,
-            &args.index,
+            &index_path,
             args.check,
             args.dry_run,
             shallow_override(&args),
@@ -282,7 +283,7 @@ pub fn run(args: Args) -> Result<()> {
     if !args.sources.is_empty() {
         return provision_named_sources(
             &index,
-            &args.index,
+            &index_path,
             &args.sources,
             args.dry_run,
             shallow_override(&args),
@@ -304,7 +305,7 @@ pub fn run(args: Args) -> Result<()> {
     );
 
     let root = store_root();
-    let workspace = index_workspace(&args.index);
+    let workspace = index_workspace(&index_path);
     let lock_path = PathBuf::from(LOCK_FILE);
     let mut lock = SdkLock::load(&lock_path)?;
     let mut installed = false;
@@ -1016,8 +1017,9 @@ pub fn activate_store_path(dirs: &[PathBuf]) {
 }
 
 /// Locate the SDK index for auto-setup: cwd, then the passed workspace, then
-/// `$NROS_WORKSPACE`. `None` ⇒ auto-setup is a no-op (not every build runs near
-/// a nano-ros workspace). Shared with `nros doctor`'s license-gate check (187.7).
+/// `$NROS_WORKSPACE`, then the copy SHIPPED BESIDE THE BINARY. `None` ⇒
+/// auto-setup is a no-op (not every build runs near a nano-ros workspace).
+/// Shared with `nros doctor`'s license-gate check (187.7).
 pub(crate) fn locate_index(workspace: Option<&Path>) -> Option<PathBuf> {
     let cwd = PathBuf::from("nros-sdk-index.toml");
     if cwd.is_file() {
@@ -1028,6 +1030,39 @@ pub(crate) fn locate_index(workspace: Option<&Path>) -> Option<PathBuf> {
         .or_else(|| std::env::var_os("NROS_WORKSPACE").map(PathBuf::from));
     ws.map(|w| w.join("nros-sdk-index.toml"))
         .filter(|p| p.is_file())
+        .or_else(shipped_index)
+}
+
+/// The index shipped inside the release, at `<prefix>/share/nros/` — phase-431
+/// W5.
+///
+/// Without this a released `nros` cannot run `nros setup <board>` AT ALL: the
+/// index was only ever looked for in the cwd or a workspace, both of which
+/// assume a checkout, and the whole point of shipping a binary is that there
+/// is no checkout. The release asset carries it; this is where it is found.
+///
+/// Resolved from the running executable rather than from `$NROS_HOME`, so a
+/// binary and the index it was released with stay together — two versions in
+/// the store each answer with their own, which is what makes them independently
+/// installable.
+pub(crate) fn shipped_index() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let prefix = exe.parent()?.parent()?; // <prefix>/bin/nros -> <prefix>
+    let candidate = prefix.join("share/nros/nros-sdk-index.toml");
+    candidate.is_file().then_some(candidate)
+}
+
+/// The index a command should read, given what the user passed.
+///
+/// `--index` defaults to the bare name `nros-sdk-index.toml`, which resolves
+/// against the cwd — right inside a checkout, and unusable for a released
+/// binary. So a DEFAULT that does not resolve falls back to the shipped copy;
+/// a path the user actually typed is never second-guessed.
+pub fn resolve_index(explicit: &Path) -> PathBuf {
+    if explicit != Path::new("nros-sdk-index.toml") || explicit.is_file() {
+        return explicit.to_path_buf();
+    }
+    shipped_index().unwrap_or_else(|| explicit.to_path_buf())
 }
 
 /// The workspace root a `[source.*]` `dest` is resolved against: the directory
@@ -2310,6 +2345,30 @@ fn compose_packages(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// phase-431 W5 — a path the user TYPED is never second-guessed; only the
+    /// default falls back to the copy shipped beside the binary.
+    ///
+    /// The fallback exists because a released `nros` has no checkout to find an
+    /// index in, and without one `nros setup <board>` fails outright — which
+    /// would make the shipped binary unable to do the thing it is installed
+    /// for. But an explicit `--index` names a file the caller chose, and
+    /// silently reading a different one is how a build gets provisioned from a
+    /// table nobody looked at.
+    #[test]
+    fn an_explicit_index_is_never_replaced_by_the_shipped_one() {
+        let typed = Path::new("some/other/index.toml");
+        assert_eq!(resolve_index(typed), typed.to_path_buf());
+
+        // The default, when it resolves in the cwd, is also left alone: inside
+        // a checkout the tree's own index must win over any shipped copy.
+        let dir = crate::test_support::scratch_path("resolve_index_cwd");
+        std::fs::create_dir_all(&dir).unwrap();
+        let here = dir.join("nros-sdk-index.toml");
+        std::fs::write(&here, "").unwrap();
+        assert_eq!(resolve_index(&here), here);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     /// issue 0603 — a `header` probe answers about the `-dev` package, where
     /// `sharedlib` answers about the runtime one.

--- a/scripts/check-ci-cli-from-source.py
+++ b/scripts/check-ci-cli-from-source.py
@@ -87,10 +87,28 @@ RELEASE_ACQUISITION = [
 # exemption matching nothing is a stale allow-list, which is how a gate quietly
 # stops covering what it names.
 #
-# EMPTY. A future entry needs a reason that is a property of the LANE -- "this
-# job tests the release itself" is the only shape that qualifies, and W5's
-# release workflow will be that entry when it lands.
+# EMPTY. A per-line entry needs a reason that is a property of the LANE.
 EXEMPT = {}
+
+# Workflows that PRODUCE the release rather than acquire it -- arm A does not
+# apply to them, arm B still does.
+#
+# The distinction is this gate's whole subject. `release-nros.yml` names the
+# asset a dozen times because it BUILDS one, and it runs `scripts/install.sh`
+# against what it just built -- the strongest check the release has, since the
+# installer's own refusals are gated against a synthetic tarball and only this
+# catches an asset that is well-formed and wrong. Banning that removes a check
+# rather than adding one.
+#
+# Arm B is what keeps this from being a hole: a producer must still build the
+# CLI from source and assert its source stamp, which matters most for the one
+# artifact nobody downstream can re-check.
+RELEASE_WORKFLOWS = {
+    "release-nros.yml": (
+        "phase-431 W5 -- it BUILDS the release, and installs its own asset as "
+        "a pre-publish check"
+    ),
+}
 
 
 def run_blocks(text):
@@ -290,6 +308,18 @@ def self_test():
     )
     assert release_sites(ok) == [], release_sites(ok)
 
+    # A producer is exempt from arm A and NOT from arm B -- the half that keeps
+    # the exemption from being a hole.
+    prod = "\n".join(
+        [
+            "        run: |",
+            "          gh release create v1 nros-linux-x86_64.tar.zst",
+            "          cargo build --release --bin nros",
+        ]
+    )
+    assert len(release_sites(prod)) == 1, release_sites(prod)
+    assert build_sites(prod)[0][2] is False, build_sites(prod)
+
     sys.stdout.write("check-ci-cli-from-source self-test: OK\n")
 
 
@@ -303,11 +333,20 @@ def main():
     seen_exempt = set()
     total_builds = 0
 
+    known = set(workflow_files())
+    for name, reason in RELEASE_WORKFLOWS.items():
+        if name not in known:
+            problems.append(
+                "STALE producer exemption %r (%s) -- no such workflow.\n"
+                "    Delete it; an allow-list checked one way stops covering\n"
+                "    what it claims to." % (name, reason)
+            )
+
     for fn in workflow_files():
         with open(os.path.join(WORKFLOWS, fn), encoding="utf8") as fh:
             text = fh.read()
 
-        for lineno, line, what in release_sites(text):
+        for lineno, line, what in ([] if fn in RELEASE_WORKFLOWS else release_sites(text)):
             if (fn, line) in EXEMPT:
                 seen_exempt.add((fn, line))
                 continue


### PR DESCRIPTION
Stacked on #546 (W4) → #545 (W3) → #543 (W2) → #537 (W1).

Manual dispatch with an explicit version, mirroring `nano-ros-sdk`'s `build-tool.yml` rather than inventing a second shape. Nothing is scheduled and nothing triggers on a tag — the tag is created **by** the workflow, from the version you type — and `publish` defaults to **false**, so a dispatch builds and verifies without releasing anything. Never a local build: reproducibility, not convenience.

**No release is cut by this PR.** Cutting one stays a decision.

## What it asserts

Each of these is a property a user cannot check for themselves:

| check | what it catches |
|---|---|
| `nros source-stamp` | the binary does not match the checkout it was built from |
| `--codegen-version` vs `NROS_CODEGEN_VERSION` in the same tree | a release claiming a compatibility it does not have — the exact failure that withdrew the last prebuilt `nros` |
| `[tool.nros].version` == the dispatched version | an asset whose store prefix is not the one the index pins |
| the version is `<crate>-nrosN` | releasing `0.6.0-nros1` off a 0.5.0 tree |

## It installs its own asset before publishing it

#546 gates the installer's *refusals* against a synthetic tarball. Only this catches an asset that is well-formed and **wrong** — a missing `VERSION`, a prefix rooted one directory too deep, a binary that does not run on a clean runner. It serves the tarball over loopback and asserts the fronted binary runs `--codegen-version` and `setup --list` **from a directory that is not a checkout**.

### That assertion found a real gap

**A released `nros` could not run `nros setup <board>` at all.** `locate_index` looked in the cwd and in a workspace — both of which assume a checkout, and the whole point of shipping a binary is that there is no checkout.

So the asset carries `share/nros/nros-sdk-index.toml`, and `setup::shipped_index` resolves it from the **running executable** rather than from `$NROS_HOME`: two versions in the store then each answer with their own index and stay independently installable. `resolve_index` falls back only for the *default* — a `--index` the user typed names a file they chose, and silently reading a different one is how a build gets provisioned from a table nobody looked at.

## Runner and reach

`ubuntu-22.04`, pinned rather than `latest`: the binary links the runner's glibc, and a newer one will not run on the LTS the book's install instructions target. The floor is a property of the release, so it is pinned rather than inherited. Linux x86_64 only — `linux-arm64` is one matrix row whenever a runner is decided on, and the index already carries the host key.

## The gate exempts it in one direction only

`check-ci-cli-from-source`'s **arm A** does not apply to a workflow that *produces* the release: it names the asset a dozen times because it builds one, and it runs `scripts/install.sh` on purpose. **Arm B still applies**, and that is what keeps the exemption from being a hole — mutation-verified by deleting the `source-stamp` line, which turns the gate red.

`check-workflow-indexed-apt` caught the workflow restating `zstd` as an apt package name; it asks `scripts/sdk/prereq-packages.py` now, since the index carries the per-manager spellings and a workflow copy is the one that goes stale.

## Rehearsed locally

Build → verify → stage → serve → install → front → run outside a checkout, all before the workflow was committed, because a release workflow's first real run should not be its first run.

`just check fast`: 233/233. `nros-cli-core` lib: 946/946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK