### PR TITLE
phase-431 W6: the distribution is described by audience, not by absence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,14 @@ source ./activate.sh          # or: direnv allow / source ./activate.fish
 just doctor
 ```
 
+**Build the CLI here, do not install a release.** `scripts/install.sh` exists
+for users and puts a released `nros` in `~/.nros/bin`; in a checkout that binary
+is refused. It emits *its own* generated code, and this tree's runtime is what
+has to compile it — a release at the same codegen version is different, not
+compatible (RFC-0090, phase-431 W1). `just doctor` FAILS when a `nros` on PATH
+is not this checkout's, because `nros_cli_bin` resolves PATH first, so a shadow
+is the binary every recipe here would run.
+
 **`source ./activate.sh` is not optional, and skipping it fails in a confusing
 place.** It puts the per-checkout `nros` binary on PATH and exports the SDK
 environment the build scripts read; without it `zpico-sys/build.rs` panics with

--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ cd nano-ros
 ./scripts/bootstrap.sh
 ```
 
-The script installs rustup if needed and builds the CLI from source —
-nano-ros is a source distribution (there is no prebuilt `nros`).
+The script installs rustup if needed and builds the CLI from source. In a
+checkout that is the point: the tree's own build is the binary this tree
+accepts, because a released `nros` emits its own generated code and this
+runtime is what has to compile it (RFC-0090). To just *use* nano-ros, install
+a release instead — `curl -fsSL
+https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh`.
 Equivalent, if you already have cargo:
 `git submodule update --init packages/cli/third-party/play_launch &&
 cargo build --release --manifest-path packages/cli/Cargo.toml --bin nros`.

--- a/book/src/getting-started/first-node-c.md
+++ b/book/src/getting-started/first-node-c.md
@@ -15,7 +15,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/first-node-cpp.md
+++ b/book/src/getting-started/first-node-cpp.md
@@ -16,7 +16,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/first-node-rust.md
+++ b/book/src/getting-started/first-node-rust.md
@@ -18,7 +18,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -1,10 +1,23 @@
 # Installation
 
-nano-ros is distributed as **source**, vendored into the consumer's
+The **library** is distributed as source, vendored into the consumer's
 project tree (git submodule, `west` manifest, ESP-IDF component, etc.)
 and built in-tree via `add_subdirectory(nano-ros)`. There is no binary
-tarball, no system-wide install step, no `find_package(NanoRos)`, and
-no prebuilt `nros` CLI.
+tarball, no system-wide install step and no `find_package(NanoRos)`.
+
+The **`nros` CLI** is a separate question with a separate answer, and
+which one you want depends on who you are:
+
+| you are… | you get `nros` by… |
+| --- | --- |
+| **using** nano-ros to build your own project | installing a release — `scripts/install.sh`, below |
+| **developing** nano-ros itself | building it from the checkout — `./scripts/bootstrap.sh` |
+
+That is not a preference. Inside a nano-ros checkout the tree's own
+build is the only correct binary: a released `nros` run against a
+checkout is refused outright, because it emits *its own* generated code
+and this tree's runtime is the one that has to compile it
+([RFC-0090](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0090-codegen-version-is-the-compatibility-token.md)).
 
 ## Host prerequisites
 
@@ -76,19 +89,24 @@ first: they are what it takes to clone the repo and build the CLI.
 Four steps take a bare machine to a building project; each is detailed
 in a section below.
 
-> **Why step 2 builds the CLI instead of downloading it.** nano-ros is a source
-> distribution today: there is no prebuilt `nros` to fetch, so obtaining the tool
-> requires the repository and its toolchain. That is backwards — `nros`
-> provisions dependencies and builds workspaces, so it is meant to be the thing
-> you get *first*, and the thing that makes cloning this repository unnecessary.
+> **Why step 2 builds the CLI here.** These four steps are the *contributor*
+> flow — they start by cloning the repository, so step 2 is the checkout's own
+> build, which is the only binary that may be used against it.
 >
 > Prebuilt binaries were shipped early and withdrawn, because a released binary
 > emitted code that had drifted from the runtime — and drifted generated code
-> *compiles*, so the failure was silent. Restoring the download is blocked on one
-> question having a checkable answer: *can this binary's output work with this
-> runtime?* [RFC-0090](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0090-codegen-version-is-the-compatibility-token.md)
+> *compiles*, so the failure was silent. Restoring the download needed one
+> question to have a checkable answer: *can this binary's output work with this
+> runtime?*
+> [RFC-0090](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/design/0090-codegen-version-is-the-compatibility-token.md)
 > answers it with a codegen version that every generated artifact carries and
-> every runtime asserts. Until that ships in a release, step 2 stays.
+> every runtime asserts, and every arm of it refuses at compile time.
+>
+> **No release has been cut yet.** The machinery is in place (`scripts/install.sh`
+> and a manual release workflow), and cutting one is a deliberate act rather
+> than a consequence of a version bump — so until the first one exists, building
+> from the checkout is how everyone gets `nros`. `install.sh` says so itself if
+> you run it early, and points you back here.
 
 ```sh probe=20
 # 1. Pull the source at a pinned version (or `main` for latest):
@@ -294,9 +312,24 @@ both vendored submodules) and no daemon at all.
 
 ### 1. Get the `nros` CLI onto PATH
 
-nano-ros is a **source distribution** — there is no prebuilt `nros`
-download. One front door from a fresh checkout (`just` is NOT a
-prereq; rustup is installed on demand):
+**If you only want to use nano-ros**, install a release — no checkout,
+no cargo, no `just`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+```
+
+It verifies the download's sha256 (and refuses an asset it cannot
+verify), installs into `~/.nros/sdk/nros/<version>/` and points
+`~/.nros/bin/nros` at the newest version installed — so however many
+versions accumulate, `nros` means one command. Put `~/.nros/bin` on
+your PATH. Until the first release is cut it will tell you so and send
+you to the source build below.
+
+**If you are working on nano-ros itself**, build the CLI from the
+checkout — that binary is the only one this tree accepts. One front
+door from a fresh checkout (`just` is NOT a prereq; rustup is installed
+on demand):
 
 > Sourcing `activate.sh` on a host without `just` prints one line about
 > RTOS SDK path defaults (`FREERTOS_DIR`, `NUTTX_DIR`, `IDF_PATH`, …)

--- a/book/src/getting-started/workspace-bringup.md
+++ b/book/src/getting-started/workspace-bringup.md
@@ -20,7 +20,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/workspace-entry-pkg.md
+++ b/book/src/getting-started/workspace-entry-pkg.md
@@ -20,7 +20,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/workspace-from-app-node.md
+++ b/book/src/getting-started/workspace-from-app-node.md
@@ -82,7 +82,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/getting-started/workspace-node-pkgs.md
+++ b/book/src/getting-started/workspace-node-pkgs.md
@@ -21,7 +21,8 @@ Pick one path from a fresh checkout — `just` is NOT a prereq.
 ```
 Installs rustup if needed and builds the in-tree `nros` CLI from
 source at `packages/cli/target/release/nros`, leaving it on PATH for
-this shell (nano-ros is a source distribution — no prebuilt `nros`).
+this shell (in a checkout, the tree's own build is the binary this tree
+accepts — RFC-0090 / phase-431).
 
 **B. Already have cargo** (equivalent — same build, same binary):
 ```sh

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -9,11 +9,26 @@ directly.
 
 ## Install
 
-The `nros` CLI ships from the in-tree sub-workspace at `packages/cli/`
-nano-ros is a **source distribution** — there is no
-prebuilt `nros` download. One front door — bootstrap
-(builds the CLI from source; installs rustup if needed), then activate
-the workspace to put it on PATH:
+Two front doors, and which one is right depends on who you are.
+
+**Using nano-ros** — install a release, with no checkout and no cargo:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+```
+
+It verifies the sha256, installs into `~/.nros/sdk/nros/<version>/` and points
+`~/.nros/bin/nros` at the newest installed version — one command, however many
+versions accumulate. (No release is cut yet; the installer says so and sends
+you to the source build.)
+
+**Working on nano-ros** — build the CLI from the checkout. That is not a
+fallback: in a checkout the tree's own build is the only binary this tree
+accepts, because a released `nros` emits its own generated code and this
+runtime is what compiles it (RFC-0090, phase-431 W1). `just doctor` fails when
+another `nros` shadows it. The CLI ships from the in-tree sub-workspace at
+`packages/cli/`; bootstrap builds it (installing rustup if needed), then
+activate the workspace to put it on PATH:
 
 ```sh
 ./scripts/bootstrap.sh

--- a/docs/issues/1110-rustdoc-broken-intra-doc-link-in-clienttrait.md
+++ b/docs/issues/1110-rustdoc-broken-intra-doc-link-in-clienttrait.md
@@ -1,0 +1,65 @@
+---
+id: 1110
+title: "`just book` and the docs deploy have been red since 2026-09-03 — a doc link to a method that commit deleted"
+status: open
+type: bug
+area: docs, core
+severity: medium
+found: 2026-09-06
+related: [1008, 1076]
+---
+
+# The link outlived the method it points at
+
+```
+$ just book
+error: unresolved link to `Self::is_server_ready`
+    --> packages/core/nros-rmw/src/traits.rs:2837:29
+     |
+2837 |     /// [`is_server_ready`](Self::is_server_ready), which collapses
+     |                             ^^^^^^^^^^^^^^^^^^^^^ the trait `ClientTrait` has no associated item named `is_server_ready`
+
+error: could not document `nros-rmw`
+error: recipe `book` failed with exit code 101
+```
+
+`3941b569a` (*"fix(#1008): `wait_for_service` never waited — W6 decision 2
+deletes the collapse"*, 2026-09-03) removed `is_server_ready` from
+`ClientTrait`. The paragraph **beside** it still contrasts `server_available()`
+with that method, by intra-doc link:
+
+```rust
+/// "don't know" and "no server" into the same `false` answer.
+/// Distinct from [`is_server_ready`](Self::is_server_ready), which collapses
+```
+
+`grep -c 'fn is_server_ready' packages/core/nros-rmw/src/traits.rs` → **0**.
+
+## Why it went unnoticed for three days
+
+rustdoc's broken-link lint is deny-level in this configuration, so this is an
+`error`, not a warning — but nothing on the merge-gating lanes runs rustdoc.
+`just book` does, and it is not in `check-fast`, `ci gate`, or the required `CI`
+context. `docs.yml` runs on `push` to `main` under a path filter that
+**includes** `packages/core/nros-rmw/**`, so the docs deploy has been failing
+since that commit landed.
+
+Same class as issue 0319 (a backend suite nothing on the `just check` line ran)
+and 0896 (`check-cli-tests` living only in a lane no merge-gating event runs):
+the check exists, is correct, and is not on a path anything traverses.
+
+## The fix, and the fix for the class
+
+1. The paragraph. `server_available()` is now the only spelling, so the contrast
+   has no other side — the sentence should be rewritten to state what
+   `server_available()` returns rather than what the deleted method collapsed.
+   Deleting the link alone leaves a dangling "Distinct from" clause.
+
+2. The class. Deleting a method must fail somewhere that runs on a PR. Either
+   `just book` joins a lane, or a cheap `cargo doc --no-deps` over the core
+   crates does — the full book build is expensive (it also runs Doxygen and the
+   rustdoc driver), and the value here is the link check, not the HTML.
+
+Found while verifying a docs change for phase-431 W6: the book built fine
+(`mdbook build` alone is green), and `just book` was red before the change and
+after it.

--- a/docs/roadmap/phase-431-ship-the-nros-binary.md
+++ b/docs/roadmap/phase-431-ship-the-nros-binary.md
@@ -1,7 +1,7 @@
 # Phase 431 — ship the `nros` binary
 
-**Status (2026-09-06).** **W1–W5 landed.** W6 (docs) open. No release has been
-cut: W5 is manual dispatch, and cutting one is a decision, not a consequence — the distribution
+**Status (2026-09-06). Every work item is landed.** No release has been cut:
+W5 is manual dispatch, and cutting one is a decision, not a consequence — the distribution
 mechanics proper. [Phase-429](phase-429-the-codegen-version-is-enforced-everywhere.md)
 removed the correctness blocker; what remains is distribution mechanics plus one
 hazard that shipping CREATES and that is worth fixing before the first release
@@ -400,6 +400,35 @@ wrong on the first release and should be replaced, not deleted — the reason
 prebuilt binaries were withdrawn is worth keeping, with the answer now attached.
 `AGENTS.md` and `scripts/bootstrap.sh`'s header (*"there is no prebuilt `nros`
 download"*) likewise.
+
+**Landed 2026-09-06.**
+
+The claim that needed replacing was **"there is no prebuilt `nros`"**, in 12
+places across 11 files. That sentence is a fact with an expiry date, and the
+replacement deliberately is not: the durable statement is about **audience**, not
+existence — a checkout builds its own binary because that is the only one it
+accepts, and a user installs a release because they have no checkout. That reads
+correctly before the first release and after it.
+
+The four-step quick start stays a *contributor* flow (it opens with `git clone`),
+with the user path stated above it as a table. `installation.md` and
+`reference/cli.md` lead with `install.sh`; the seven getting-started pages carried
+the same parenthetical and were rewritten together rather than one at a time.
+`CONTRIBUTING.md` gains the sentence a contributor actually needs — *do not
+install a release here, `just doctor` fails on it, and here is why* — since a
+contributor who has both is the person this phase's hazard is aimed at.
+
+One thing is said once and not eleven times: **no release is cut yet.** It sits
+in `installation.md`, and `install.sh` says the same thing itself when run early,
+so a user who skips the book still lands somewhere useful.
+
+**Filed while verifying:** [#1110](../issues/1110-rustdoc-broken-intra-doc-link-in-clienttrait.md)
+— `just book` and the docs deploy have been red since 2026-09-03. `3941b569a`
+deleted `ClientTrait::is_server_ready`; the paragraph beside it still links to it,
+rustdoc's broken-link lint is deny-level, and nothing on a merge-gating lane runs
+rustdoc. Not this phase's change (`mdbook build` alone is green, and `just book`
+was red before the edit and after it), and the class is 0319/0896 again: a correct
+check on a path nothing traverses.
 
 ## What this phase must not do
 

--- a/packages/api/nros/src/guide/getting_started.rs
+++ b/packages/api/nros/src/guide/getting_started.rs
@@ -46,8 +46,9 @@
 //!
 //! ## 3. Generate message bindings
 //!
-//! Build the `nros` tool (one-time, from a nano-ros checkout — nano-ros
-//! is a source distribution; there is no prebuilt `nros`):
+//! Build the `nros` tool (one-time, from a nano-ros checkout — in a
+//! checkout the tree's own build is the binary it accepts, RFC-0090;
+//! to just USE nano-ros, install a release with `scripts/install.sh`):
 //!
 //! ```bash
 //! ./scripts/bootstrap.sh   # builds packages/cli/target/release/nros

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,9 +17,16 @@ nano-ros itself lives at [NEWSLabNTU/nano-ros](https://github.com/NEWSLabNTU/nan
 
 ## Install
 
-nano-ros is a **source distribution** (phase-288 D1/D2): there is no
-prebuilt `nros`. From a nano-ros checkout, the front door builds it —
-installing rustup if needed:
+Users install a release and need no checkout:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NEWSLabNTU/nano-ros/main/scripts/install.sh | sh
+```
+
+From a nano-ros checkout, the front door builds it instead — installing rustup
+if needed. That is the correct binary here and a released one is not: it emits
+its own generated code, and this tree's runtime is what has to compile it
+(RFC-0090, phase-431 W1/W2).
 
 ```bash
 ./scripts/bootstrap.sh


### PR DESCRIPTION
Stacked on #547 (W5) → #546 → #545 → #543 → #537. Closes out phase-431.

The claim that needed replacing was **"there is no prebuilt `nros`"** — 12 places across 11 files. It is a fact with an expiry date, and the replacement deliberately is not: the durable statement is about **who**, not about what exists.

| you are… | you get `nros` by… |
|---|---|
| **using** nano-ros to build your own project | installing a release — `scripts/install.sh` |
| **developing** nano-ros itself | building it from the checkout — `./scripts/bootstrap.sh` |

That reads correctly before the first release and after it, which the old sentence would not have.

## What moved

- **`installation.md`** and **`reference/cli.md`** lead with `install.sh`. The four-step quick start stays a *contributor* flow — it opens with `git clone` — with the user path stated above it.
- The **seven getting-started pages** carried one identical parenthetical (*"nano-ros is a source distribution — no prebuilt `nros`"*) and were rewritten together rather than one at a time.
- **`CONTRIBUTING.md`** gains the sentence a contributor actually needs: *do not install a release here, `just doctor` fails on it, and here is why* — `nros_cli_bin` resolves PATH before the per-checkout binary, so a shadow is the binary every recipe here would run.
- The rustdoc guide in `packages/api/nros` and `packages/cli/README.md` likewise.

**Said once and not eleven times: no release is cut yet.** It sits in `installation.md`, and `install.sh` says the same thing itself when run early — so a user who skips the book still lands somewhere useful.

## Filed while verifying: #1110

`just book` and the docs deploy have been **red since 2026-09-03**. `3941b569a` deleted `ClientTrait::is_server_ready`; the paragraph beside it still links to it, rustdoc's broken-link lint is deny-level, and nothing on a merge-gating lane runs rustdoc — while `docs.yml`'s path filter *includes* `packages/core/nros-rmw/**`.

Not this change: `mdbook build` alone is green, and `just book` was red before the edit and after it. The class is issues 0319 / 0896 again — a correct check sitting on a path nothing traverses.

Sweep: `grep -rn 'no prebuilt \`nros\`\|source distribution' --include='*.md' --include='*.rs' .` — the remaining hits are about *SDK packages* having no prebuilt for a host, a different sentence and still true.

`just check fast`: 233/233. `mdbook build`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK