### PR TITLE
fix(rmw-doc): a visitor parameter hid the fields it yields, so the row read as a loss

### DIFF
--- a/book/src/reference/rmw-api-comparison.md
+++ b/book/src/reference/rmw-api-comparison.md
@@ -523,7 +523,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
   <span class='ty'>const char *node_name</span><span class=pu>,</span>
   <span class='ty'>const char *node_namespace</span><span class=pu>,</span>
-  <span class='ty add'>rmw_names_and_types_visitor_t visitor</span>
+  <span class='ty add'>rmw_names_and_types_visitor_t visitor  /* visit(ctx, name, types, types_count) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — Upstream fills a heap-owning out-parameter the caller must `fini`. We pass a VISITOR callback invoked once per entry, with borrowed strings valid for the call. No allocation, bounded work, and nothing for a caller to leak — which is what makes the graph family available on a target with no allocator at all.</td>
 </tr>
@@ -557,7 +557,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
 <td class=c><pre><span class=ret>rmw_ret_t</span>
 <span class=pu>(*</span><span class='fn'>get_node_names</span><span class=pu>)</span><span class=pu>(</span>
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
-  <span class='ty add'>rmw_node_visitor_t visitor</span>
+  <span class='ty add'>rmw_node_visitor_t visitor  /* visit(ctx, node_name, node_namespace, enclave) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-mapped'>◆ re-mapped · 2 upstream → 1 slot</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>visitor, not an owning out-param</b> — As `rmw_names_and_types_t` — an owning array upstream, a visitor here.</td>
 </tr>
@@ -572,7 +572,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
 <td class=c><pre><span class=ret>rmw_ret_t</span>
 <span class=pu>(*</span><span class='fn ren'>get_node_names</span><span class=pu>)</span><span class=pu>(</span>
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
-  <span class='ty add'>rmw_node_visitor_t visitor</span>
+  <span class='ty add'>rmw_node_visitor_t visitor  /* visit(ctx, node_name, node_namespace, enclave) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-mapped'>◆ re-mapped · 2 upstream → 1 slot</div><b>renamed</b> — the slot is <code>get_node_names</code>.<br><br><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>visitor, not an owning out-param</b> — As `rmw_names_and_types_t` — an owning array upstream, a visitor here.</td>
 </tr>
@@ -592,7 +592,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
   <span class='ty'>const char *node_name</span><span class=pu>,</span>
   <span class='ty'>const char *node_namespace</span><span class=pu>,</span>
   <span class='ty'>bool no_demangle</span><span class=pu>,</span>
-  <span class='ty add'>rmw_names_and_types_visitor_t visitor</span>
+  <span class='ty add'>rmw_names_and_types_visitor_t visitor  /* visit(ctx, name, types, types_count) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — Upstream fills a heap-owning out-parameter the caller must `fini`. We pass a VISITOR callback invoked once per entry, with borrowed strings valid for the call. No allocation, bounded work, and nothing for a caller to leak — which is what makes the graph family available on a target with no allocator at all.</td>
 </tr>
@@ -610,7 +610,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
   <span class='ty'>const char *topic_name</span><span class=pu>,</span>
   <span class='ty'>bool no_mangle</span><span class=pu>,</span>
-  <span class='ty add'>rmw_topic_endpoint_info_visitor_t visitor</span>
+  <span class='ty add'>rmw_topic_endpoint_info_visitor_t visitor  /* visit(ctx, info) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — `rmw_topic_endpoint_info_array_t` and `rmw_network_flow_endpoint_array_t` are heap-owning arrays with their own `fini`. Visited one entry at a time instead.</td>
 </tr>
@@ -641,7 +641,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
 <td class=c><pre><span class=ret>rmw_ret_t</span>
 <span class=pu>(*</span><span class='fn'>get_service_names_and_types</span><span class=pu>)</span><span class=pu>(</span>
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
-  <span class='ty add'>rmw_names_and_types_visitor_t visitor</span>
+  <span class='ty add'>rmw_names_and_types_visitor_t visitor  /* visit(ctx, name, types, types_count) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — Upstream fills a heap-owning out-parameter the caller must `fini`. We pass a VISITOR callback invoked once per entry, with borrowed strings valid for the call. No allocation, bounded work, and nothing for a caller to leak — which is what makes the graph family available on a target with no allocator at all.</td>
 </tr>
@@ -659,7 +659,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
   <span class='ty'>const char *node_name</span><span class=pu>,</span>
   <span class='ty'>const char *node_namespace</span><span class=pu>,</span>
-  <span class='ty add'>rmw_names_and_types_visitor_t visitor</span>
+  <span class='ty add'>rmw_names_and_types_visitor_t visitor  /* visit(ctx, name, types, types_count) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — Upstream fills a heap-owning out-parameter the caller must `fini`. We pass a VISITOR callback invoked once per entry, with borrowed strings valid for the call. No allocation, bounded work, and nothing for a caller to leak — which is what makes the graph family available on a target with no allocator at all.</td>
 </tr>
@@ -679,7 +679,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
   <span class='ty'>const char *node_name</span><span class=pu>,</span>
   <span class='ty'>const char *node_namespace</span><span class=pu>,</span>
   <span class='ty'>bool no_demangle</span><span class=pu>,</span>
-  <span class='ty add'>rmw_names_and_types_visitor_t visitor</span>
+  <span class='ty add'>rmw_names_and_types_visitor_t visitor  /* visit(ctx, name, types, types_count) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — Upstream fills a heap-owning out-parameter the caller must `fini`. We pass a VISITOR callback invoked once per entry, with borrowed strings valid for the call. No allocation, bounded work, and nothing for a caller to leak — which is what makes the graph family available on a target with no allocator at all.</td>
 </tr>
@@ -697,7 +697,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
   <span class='ty'>const char *topic_name</span><span class=pu>,</span>
   <span class='ty'>bool no_mangle</span><span class=pu>,</span>
-  <span class='ty add'>rmw_topic_endpoint_info_visitor_t visitor</span>
+  <span class='ty add'>rmw_topic_endpoint_info_visitor_t visitor  /* visit(ctx, info) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — `rmw_topic_endpoint_info_array_t` and `rmw_network_flow_endpoint_array_t` are heap-owning arrays with their own `fini`. Visited one entry at a time instead.</td>
 </tr>
@@ -713,7 +713,7 @@ text-transform:uppercase;margin:0 0 .45rem;opacity:.95}
 <span class=pu>(*</span><span class='fn'>get_topic_names_and_types</span><span class=pu>)</span><span class=pu>(</span>
   <span class='ty add'>const rmw_session_t *session</span><span class=pu>,</span>
   <span class='ty'>bool no_demangle</span><span class=pu>,</span>
-  <span class='ty add'>rmw_names_and_types_visitor_t visitor</span>
+  <span class='ty add'>rmw_names_and_types_visitor_t visitor  /* visit(ctx, name, types, types_count) */</span>
 <span class=pu>)</span></pre></td>
 <td class=why><div class='st s-re-shaped'>● re-shaped</div><b>the SESSION is the seam</b> — Upstream passes the node into almost every call. Our vtable is scoped to a session handle that already knows its node, so re-passing it would ask the caller to carry an identity the callee holds — the same argument that decided `handle-owns-node` in the C API, one layer down.<br><br><b>no allocator at this seam</b> — This ABI does not allocate. Upstream hands an `rcutils_allocator_t` so the implementation can size and own the result; ours writes into a caller-owned byte range whose capacity the caller already knows. An allocator parameter cannot cross a seam that has nothing to give it.<br><br><b>visitor, not an owning out-param</b> — Upstream fills a heap-owning out-parameter the caller must `fini`. We pass a VISITOR callback invoked once per entry, with borrowed strings valid for the call. No allocation, bounded work, and nothing for a caller to leak — which is what makes the graph family available on a target with no allocator at all.</td>
 </tr>

--- a/scripts/gen-rmw-api-comparison.py
+++ b/scripts/gen-rmw-api-comparison.py
@@ -84,6 +84,61 @@ def _split_params(raw):
     return out
 
 
+def visitor_payloads():
+    """`{visitor struct: "visit(ctx, a, b, c)"}` from the `*_visit_fn` typedefs.
+
+    A slot that takes `rmw_node_visitor_t` prints two parameters where upstream
+    prints four, and a reader comparing the columns concludes we dropped two
+    fields. We did not — they moved INTO the callback, which the slot signature
+    cannot show because the payload lives behind the typedef.
+
+    Reported from the header, not restated here: the visitor argument list is
+    the thing most likely to gain a field (issue 0785 added `enclave` to exactly
+    this one), and a hand-copied list would be wrong the first time that
+    happened.
+    """
+    src = open(os.path.join(ABI_DIR, "rmw_vtable.h"), encoding="utf-8").read()
+    body = re.sub(r"/\*.*?\*/", " ", src, flags=re.S)
+    body = re.sub(r"(?m)//.*$", " ", body)
+    fns = {}
+    for m in re.finditer(
+        r"typedef\s+bool\s*\(\s*\*\s*(rmw_\w+_visit_fn)\s*\)\s*\(([^;]*?)\)\s*;", body
+    ):
+        names = []
+        for p in _split_params(m.group(2)):
+            # The NAME is what a reader needs; the types are on the typedef.
+            tok = re.findall(r"[A-Za-z_][A-Za-z0-9_]*", p)
+            names.append(tok[-1] if tok else p)
+        fns[m.group(1)] = names
+    out = {}
+    for m in re.finditer(
+        r"typedef\s+struct\s+(rmw_\w+_visitor_t)\s*\{(.*?)\}\s*\1\s*;", body, flags=re.S
+    ):
+        fm = re.search(r"(rmw_\w+_visit_fn)\s+visit\s*;", m.group(2))
+        if fm and fm.group(1) in fns:
+            out[m.group(1)] = "visit(" + ", ".join(fns[fm.group(1)]) + ")"
+    return out
+
+
+def annotate_visitors(params, visitors):
+    """Say what a visitor parameter yields, beside the parameter.
+
+    `rmw_node_visitor_t visitor` is two words where upstream's column shows
+    `node_names` and `node_namespaces` as separate out-parameters, so the row
+    reads as though we dropped them. They are the callback's arguments. Naming
+    them here is the smallest place to put that: in the cell where the reader
+    is already comparing.
+    """
+    out = []
+    for p in params:
+        for struct, payload in visitors.items():
+            if struct in p:
+                p = f"{p}  /* {payload} */"
+                break
+        out.append(p)
+    return out
+
+
 def vtable_slots_named():
     """{slot: [param text with names]} straight from the vtable header."""
     src = open(os.path.join(ABI_DIR, "rmw_vtable.h"), encoding="utf-8").read()
@@ -343,6 +398,7 @@ def build():
     slots, rets = shape.vtable_slots()
     globs = global_signatures()
     slots_named = vtable_slots_named()
+    visitors = visitor_payloads()
     kinds = parity._slot_kinds()
     rules = arg_rules()
 
@@ -370,7 +426,9 @@ def build():
                 name = re.split(r"[ ,(]", detail.strip())[0]
                 inert = kinds.get(name) == "inert"
                 our_ret, our_params = rets.get(name, "?"), slots.get(name, [])
-                our_display = slots_named.get(name, our_params)
+                our_display = annotate_visitors(
+                    slots_named.get(name, our_params), visitors
+                )
                 is_slot = True
             else:
                 name = sym


### PR DESCRIPTION
Stacked on #541 (queued); GitHub retargets this to `main` when that lands.

Second reader in two turns concluded we had dropped something, and both times the page was under-reporting our side rather than the tree being wrong. This one: *"ours does not return the namespace, does it"*.

**It does.** `rmw_node_visit_fn` is `(ctx, node_name, node_namespace, enclave)`, and both producers pass a namespace — zenoh demangles it off the liveliness token (`shim/session.rs:1236`), cyclone forwards its adapter's `ns` (`vtable.cpp:137`).

What the page showed was the **slot** signature, where upstream enumerates `node_names` and `node_namespaces` as separate out-parameters and ours collapses to `rmw_node_visitor_t visitor`. Two words against four — the comparison the page exists to support led straight to the wrong conclusion.

The payload now prints beside the parameter:

```c
rmw_node_visitor_t visitor  /* visit(ctx, node_name, node_namespace, enclave) */
```

**Parsed from the `*_visit_fn` typedefs in `rmw_vtable.h`, not restated.** The visitor argument list is the thing most likely to gain a field — issue 0785 added `enclave` to this exact one — and a hand-copied list would have been wrong the first time that happened.

Covers all three visitors (node, names-and-types, topic-endpoint-info), ten rows in total.

## Verification

`just check rmw-api-comparison` OK (88 symbols) · `rmw-api-parity` · `rmw-abi-shape` · `just check fast` 231/231.

Tally unchanged — 13 same, 34 re-shaped, 28 re-mapped, 13 not-supported. This changes what a cell **says**, not what any comparison computes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP