### PR TITLE
docs(RFC-0089, phase-417): the design half of #329, split out so it can land

### DIFF
--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -47,6 +47,16 @@ have those semantics.
 A rename is therefore not a cosmetic change. It is the act of promising, for
 every name taken, that the contract behind it holds.
 
+And this is not hypothetical: the compat shim already ships two of them.
+`ParametersQoS()` returns `QoS(10)` where `rmw_qos_profile_parameters` is
+`KEEP_LAST, 1000` — a hundred-fold history difference under a name that claims
+to be the ROS 2 profile, costing samples under load with nothing to read. Ten
+`NodeOptions` setters store their argument in a private field that nothing
+reads, and return `*this` so the idiomatic chained call compiles and configures
+nothing; the header calls them "intentionally inert today" (`:125`), which is
+the deferral this RFC is written to end. **A rename would inherit both, not
+introduce them.**
+
 ## The rule
 
 > **An upstream name may be adopted only if its observable contract is the same,
@@ -65,6 +75,8 @@ this way rather than as "match ROS 2 where possible":
 | `rclcpp::init(argc, argv)` — `--ros-args` dropped | must fail to compile, or honour them | compiles, drops them silently |
 | `create_wall_timer` — period accuracy is the spin cadence | may be adopted, envelope documented | adopted, envelope undocumented |
 | `Publisher::get_publisher_handle` — reaches past the API | absent is correct | absent (RFC-0035) |
+| `ParametersQoS()` — history depth 10, upstream's is 1000 | must not carry that name at that value | **shipping** (`rclcpp_compat.hpp:117`) |
+| `NodeOptions::use_intra_process_comms(true)` — stored, never read | must fail to compile | **shipping**, chainable, inert (`:125`) |
 
 Note what the rule does NOT say. It does not require the implementation to
 match; it requires the *contract a caller can observe* to match. A timer whose
@@ -213,13 +225,34 @@ incompatible with ours:
 | --- | ---: | --- |
 | executor as wait-set assembler over polymorphic `Waitable`s | ~128 | no — dynamic membership needs an allocator (RFC-0002) |
 | parameters as a distributed service with owned-storage values | ~56 | partly — server side yes, client side is a product choice |
-| graph and middleware queryable at runtime | ~55 | no — no dynamic discovery |
+| graph and middleware queryable at runtime | ~55 | **partly, and the table above was wrong.** `nros::Executor` already ships `get_node_names`, `count_publishers`/`count_subscribers`, the four `*_names_and_types_by_node` forms and `get_{publishers,subscriptions}_info_by_topic` (`executor.hpp:205-301`) over shipped FFI. 18 rows are pure forwarders from `Executor` to `Node`. What is genuinely impossible is a GRANTED QoS read-back and graph *events* |
 | types erased and resolved at runtime | ~45 | no — no dynamic loader |
 
 The honest claim is therefore about PROGRAMS, not surface: *the shapes a ROS 2
 node is actually written in compile and behave, and everything else fails
 loudly.* That is measurable — the in-tree ported templates are the measurement —
 and it is what the roadmap targets.
+
+## The split, measured
+
+All 717 uncovered rclcpp items, classified against the rule:
+
+| disposition | rows | distinct sites | cost |
+| --- | ---: | ---: | --- |
+| ADOPT | 117 | ~45 | ~820 lines |
+| ADOPT-BOUNDED | 123 | ~50 | ~1150 lines |
+| REFUSE-LOUD | 69 | **17** | ~120 lines, diagnostics only |
+| ABSENT | 408 | — | 0 |
+
+ABSENT is 57 % and is not a concession — 83 rows are the wait-set/`Waitable`
+protocol, 42 runtime type erasure, 35 parameter-client internals, 18
+`get_node_*_interface`, 21 `make_shared` on types a user never constructs. A
+ported user program names none of them.
+
+The shape worth noticing: **69 refusals collapse into 17 diagnostics**, because
+a refusal is per-CONCEPT, not per-symbol — the sixteen inert `NodeOptions`
+setters share one message. That is the whole loudness pass at about 120 lines,
+which is why it can gate the rename without gating the schedule.
 
 ## Prerequisite: the measurement must include the shim
 

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -182,38 +182,65 @@ forces it, why no FFI slot can carry it, and what keeps the two from drifting.
 exceptions and Rust's `Result` cannot cross `extern "C"`, and it holds no state
 of its own.
 
-## Naming: alias, not replace
+## Naming: replace, with alias as the migration step
 
-Two readings of "rename our items to ROS 2's names":
+The end state is the one the rename intends: **our API carries ROS 2's names.**
+`nros::` stops being the spelling a user writes.
 
-**(a) Replace.** `nros::` becomes `rclcpp::`; one name, one namespace.
-**(b) Alias.** `nros::` stays the definition; the ROS 2 spelling becomes a
-first-class alias declared in the API headers themselves, and the separate
-`rclcpp_compat.hpp` file disappears because its content moved into the headers.
+Getting there is a two-step, and the intermediate step is what makes it safe
+rather than a flag day:
 
-**This RFC chooses (b)**, for three reasons.
+1. **Alias.** The ROS 2 spelling becomes a first-class name declared in the API
+   headers, `nros::` remains and both work. `rclcpp_compat.hpp` disappears as a
+   separate file because its content has moved into the headers it was shimming.
+2. **Replace.** `nros::` is deprecated, then removed, and in-tree call sites
+   (110 C++ and 75 C example files) migrate. This is the irreversible step for
+   out-of-tree consumers and happens once, deliberately, with a changelog entry
+   — the same discipline phase-379 W7 step 4 applies to the deprecated-alias
+   batch.
 
-1. **ODR.** If we define `rclcpp::Node` and a host build also links real
-   rclcpp — which host-side tests, bridges and tooling plausibly do — the two
-   definitions collide silently. Under (b) the collision is still possible, so
-   the compat header must `#error` when upstream's include guard is already
-   defined; under (a) there is no fallback spelling to recover with.
-2. **Diagnosability.** A compiler error, a stack trace or a `nm` dump should be
-   able to say *which* implementation this is. Under (a) it cannot.
-3. **It costs nothing.** An alias adds no member. `rclcpp::Publisher<T>::SharedPtr`
-   requires a nested `SharedPtr` on our `Publisher` whatever the namespace is
-   called.
+### On ODR
 
-Point 3 generalises into the strategic claim of this RFC:
+An earlier draft of this RFC treated the ODR collision — nano-ros defining
+`rclcpp::Node` in a build that also links real rclcpp — as a primary argument
+for keeping `nros::` permanently. **That is overstated: nano-ros and ROS 2 are
+not linked into one binary.** They interoperate over the wire, and the host-side
+tooling that talks to a nano-ros image is a separate process.
+
+It is kept as a guard rather than as an argument, because the guard is one line
+and the failure it prevents is silent:
+
+```cpp
+#ifdef RCLCPP__RCLCPP_HPP_
+#error "nano-ros and ROS 2's rclcpp are both in this translation unit. \
+        They define the same names differently. Link one."
+#endif
+```
+
+Cheap insurance against a configuration nobody intends, not a reason to keep two
+vocabularies forever.
+
+### What survives the correction
+
+The ordering does, and it never depended on ODR:
 
 > **The rename is cheap and cosmetic; the compatibility is the work.** Adopting
 > ROS 2's names does not by itself make one more ported line compile. What makes
 > lines compile is nested `SharedPtr` types, `create_service`, parameters on the
 > node, `now()`. Those are needed whatever the namespace is called.
 
-So the rename goes LAST. Doing it first would relabel the gaps without closing
-one, and would spend the safety property — "our names are different, so a
-mismatch is visible" — before the mismatches are fixed.
+So the rename lands last. Doing it first would relabel the gaps without closing
+one, and would spend the property that currently makes a mismatch visible —
+our names differ, so a shape that differs is *visible* — while the mismatches
+are still there. The two live inversions above (`ParametersQoS`, the inert
+`NodeOptions` setters) are exactly what "inherited by a rename" looks like.
+
+There is also one mismatch the rename makes strictly worse, and it is not
+fixable by a diagnostic: the shim `Node` pumps its own callbacks while
+`nros::Node` is arena-driven, and a file that mixes them gets no callbacks and
+no error. Today the two types have different NAMES, which is the only thing
+making that visible. That is a structural prerequisite for step 2, not a
+loudness item — see phase-417.
 
 ## What "mostly full compat" can honestly mean
 

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -1,0 +1,165 @@
+# RFC-0087 — ROS 2 API adoption, and the compile-or-conform rule
+
+**Status:** Draft (2026-09-04)
+**Amends / refines:** RFC-0036 (divergence catalog) — adds the DISPOSITION half:
+a divergence must say what a porting user gets, not only why we differ.
+RFC-0018 (C++ surface mirroring rclcpp) — states the condition under which the
+mirror may take upstream's names.
+**Motivated by:** phase-379's measurement of the three user APIs against rclc /
+rclcpp / rclrs, and the intent to retire `rclcpp_compat.hpp` by making our own
+names ROS 2's.
+**Implements-tracked-by:** phase-417-ros2-api-adoption
+**Related:** RFC-0002 (one executor per RTOS task), RFC-0021 (blocking API
+rules), RFC-0035 (RMW seam), RFC-0044 (component model); issues 1012, 1019, 1020.
+
+## The intent
+
+nano-ros should be a near drop-in replacement for ROS 2 client code. The
+end state is that our user API carries ROS 2's own names — `rclcpp::` for C++,
+`rcl_`/`rclc_` for C, `rclrs::` for Rust — and `rclcpp_compat.hpp` is deleted,
+because a shim exists only to bridge two spellings and there would be one.
+
+This RFC is about what has to be true BEFORE that rename, and the rule that
+decides, item by item, whether we may take a name at all.
+
+## The hazard, stated once
+
+Phase-379 W6 found `PollingSubscription::take()`. It had rclcpp's name, rclcpp's
+signature, and the opposite contract: it drained to newest and returned true if a
+value had ever arrived, so the idiomatic
+
+```cpp
+while (sub.take(msg)) { … }
+```
+
+terminates under rclcpp and spun forever here. **No compile error.** It was
+deleted, and the deletion is recorded with the trap in the header.
+
+That was one method found by accident. Adopting ROS 2's names across the whole
+user API generalises exactly that hazard to every item whose semantics differ —
+and 62 % of the rclcpp surface we do not cover is declined, meaning we do not
+have those semantics.
+
+A rename is therefore not a cosmetic change. It is the act of promising, for
+every name taken, that the contract behind it holds.
+
+## The rule
+
+> **An upstream name may be adopted only if its observable contract is the same,
+> or strictly weaker in a documented, non-inverting way. A contract that
+> inverts, or that silently drops data or configuration, must fail to COMPILE.**
+>
+> Never compile and differ.
+
+The rule is checkable against cases we already have, which is why it is stated
+this way rather than as "match ROS 2 where possible":
+
+| case | rule says | today |
+| --- | --- | --- |
+| `PollingSubscription::take()` — loop inverts | must not exist under that name | deleted (W6) |
+| `RCLCPP_INFO_STREAM` — message discarded | must fail to compile | compiles, logs `""` (issue 1019) |
+| `rclcpp::init(argc, argv)` — `--ros-args` dropped | must fail to compile, or honour them | compiles, drops them silently |
+| `create_wall_timer` — period accuracy is the spin cadence | may be adopted, envelope documented | adopted, envelope undocumented |
+| `Publisher::get_publisher_handle` — reaches past the API | absent is correct | absent (RFC-0035) |
+
+Note what the rule does NOT say. It does not require the implementation to
+match; it requires the *contract a caller can observe* to match. A timer whose
+period is quantised to the spin cadence is weaker, not inverted, and a caller
+who is told so can act on it. A `take()` whose loop never terminates is not
+weaker — it is a different function wearing the same name.
+
+## Four dispositions
+
+Every upstream item is exactly one of:
+
+- **ADOPT** — same name, same contract.
+- **ADOPT-BOUNDED** — same name and contract, weaker within an envelope stated
+  in the doc comment. The envelope is part of the API, not a footnote.
+- **REFUSE-LOUD** — we cannot have the contract, but the name is common enough
+  that a user will reach for it. The name EXISTS as a deleted overload or a
+  `static_assert`, whose message names the constraint and the nano-ros
+  alternative.
+- **ABSENT** — the name does not exist. Correct for rclcpp internals a user
+  program never names.
+
+REFUSE-LOUD is the disposition this RFC exists to introduce. Absence produces
+`no member named 'create_generic_subscription'`, which is honest and teaches
+nothing. A deleted overload produces the migration at the point of failure:
+
+```cpp
+// static_assert message, not prose in a book nobody opens
+"rclcpp::Node::create_generic_subscription resolves the type by NAME at "
+"runtime, which needs a dynamic loader and a heap. nano-ros resolves types "
+"at build time. Use create_subscription<T>() with the concrete type, or "
+"take_serialized() if you genuinely want bytes."
+```
+
+That costs one line and is the highest-leverage documentation in the design.
+
+## Naming: alias, not replace
+
+Two readings of "rename our items to ROS 2's names":
+
+**(a) Replace.** `nros::` becomes `rclcpp::`; one name, one namespace.
+**(b) Alias.** `nros::` stays the definition; the ROS 2 spelling becomes a
+first-class alias declared in the API headers themselves, and the separate
+`rclcpp_compat.hpp` file disappears because its content moved into the headers.
+
+**This RFC chooses (b)**, for three reasons.
+
+1. **ODR.** If we define `rclcpp::Node` and a host build also links real
+   rclcpp — which host-side tests, bridges and tooling plausibly do — the two
+   definitions collide silently. Under (b) the collision is still possible, so
+   the compat header must `#error` when upstream's include guard is already
+   defined; under (a) there is no fallback spelling to recover with.
+2. **Diagnosability.** A compiler error, a stack trace or a `nm` dump should be
+   able to say *which* implementation this is. Under (a) it cannot.
+3. **It costs nothing.** An alias adds no member. `rclcpp::Publisher<T>::SharedPtr`
+   requires a nested `SharedPtr` on our `Publisher` whatever the namespace is
+   called.
+
+Point 3 generalises into the strategic claim of this RFC:
+
+> **The rename is cheap and cosmetic; the compatibility is the work.** Adopting
+> ROS 2's names does not by itself make one more ported line compile. What makes
+> lines compile is nested `SharedPtr` types, `create_service`, parameters on the
+> node, `now()`. Those are needed whatever the namespace is called.
+
+So the rename goes LAST. Doing it first would relabel the gaps without closing
+one, and would spend the safety property — "our names are different, so a
+mismatch is visible" — before the mismatches are fixed.
+
+## What "mostly full compat" can honestly mean
+
+It cannot mean the whole rclcpp surface. Four upstream idioms account for most
+of what we decline, and three of them are load-bearing for ROS 2's design and
+incompatible with ours:
+
+| idiom | rows | can we? |
+| --- | ---: | --- |
+| executor as wait-set assembler over polymorphic `Waitable`s | ~128 | no — dynamic membership needs an allocator (RFC-0002) |
+| parameters as a distributed service with owned-storage values | ~56 | partly — server side yes, client side is a product choice |
+| graph and middleware queryable at runtime | ~55 | no — no dynamic discovery |
+| types erased and resolved at runtime | ~45 | no — no dynamic loader |
+
+The honest claim is therefore about PROGRAMS, not surface: *the shapes a ROS 2
+node is actually written in compile and behave, and everything else fails
+loudly.* That is measurable — the in-tree ported templates are the measurement —
+and it is what the roadmap targets.
+
+## Prerequisite: the measurement must include the shim
+
+The C++ parity lane reads three translation units and filters to namespace
+`nros`, so `rclcpp_compat.hpp` contributes zero rows (issue 1020). Every number
+in this RFC about "how far we are" is therefore measured against the NATIVE API,
+not against what ported code reaches. Fixing that is stage 0 of the roadmap:
+without it, progress and noise are indistinguishable.
+
+## Consequences for RFC-0036
+
+RFC-0036 catalogues divergences and says a preference may not be recorded as one.
+This RFC adds the missing half: a divergence must also declare its DISPOSITION —
+whether the upstream name is adopted, bounded, refused loudly, or absent. A
+`declined` verdict with no disposition does not say whether a ported program
+gets a compile error or a surprise, which is the only thing a porting user needs
+to know.

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -9,6 +9,10 @@ mirror may take upstream's names.
 rclcpp / rclrs, and the intent to retire `rclcpp_compat.hpp` by making our own
 names ROS 2's.
 **Implements-tracked-by:** phase-417-ros2-api-adoption
+**Governed by:** RFC-0019 / RFC-0020 (thin-wrapper discipline) — the Rust API
+is the implementation source of truth; C and C++ delegate. This RFC does not
+relax that, and §"Who implements an adopted name" states what it means for
+adoption.
 **Related:** RFC-0002 (one executor per RTOS task), RFC-0021 (blocking API
 rules), RFC-0035 (RMW seam), RFC-0044 (component model); issues 1012, 1019, 1020.
 
@@ -95,6 +99,76 @@ nothing. A deleted overload produces the migration at the point of failure:
 ```
 
 That costs one line and is the highest-leverage documentation in the design.
+
+## Who implements an adopted name
+
+RFC-0019 is Stable and says it plainly: **the Rust API is the source of truth;
+C and C++ are thin shims that delegate.** Adopting ROS 2's names must not become
+a licence to grow a second implementation behind them — a compat surface is
+exactly where that pressure appears, because the fastest way to make a ported
+line compile is often to write the logic in the wrapper.
+
+The distinction that decides the hard cases:
+
+> **Ergonomics may live in the wrapper. Behaviour may not.** A second
+> *spelling* is free; a second *code path that can produce a different answer*
+> is a violation.
+
+Not a second implementation, and therefore fine in C/C++ alone:
+
+* type aliases and nested typedefs (`Publisher<T>::SharedPtr`)
+* inline forwarders and convenience overloads that convert and delegate
+* `= delete` / `static_assert` diagnostics — a REFUSE-LOUD name emits no code
+* doc comments, including the ADOPT-BOUNDED envelopes
+* container/string conversions that copy and call through (`FixedString` ↔
+  `std::string`)
+
+A second implementation, and therefore Rust-side work first — these are
+RFC-0020's five violation classes, restated as they show up in adoption:
+
+* state machines (goal lifecycle, request/reply tracking)
+* retry / timeout / polling loops that spin the executor from inside the wrapper
+* CDR serialisation or deserialisation
+* topic / service / action name construction, and remap resolution
+* direct transport calls
+
+### The consequence for planning
+
+**A C or C++ gap is frequently a Rust gap wearing a wrapper's clothes**, and the
+two cost very different amounts. So every work item carries the question *which
+layer implements this?* and the order is Rust → FFI slot → C → C++.
+
+The cross-language audit makes this cheap to exploit: of the 37 capabilities
+where our own three surfaces disagree, roughly half are ones **Rust already has
+and one or both wrappers never exposed** — named loggers and per-logger levels,
+parameter type queries, undeclare, descriptors and ranges, QoS equality, GID
+attribution, name resolution. Under SSoT those are the cheapest work in the
+whole roadmap: the behaviour exists and is tested, and the wrapper is a
+forwarder.
+
+The remainder genuinely need Rust to grow first, and planning them as C/C++
+tasks would have mis-costed them by an order of magnitude:
+
+* typed C subscription delivery needs an `add_subscription` variant that carries
+  caller-owned message storage through the FFI (stage 5);
+* `rclcpp::init(argc, argv)` honouring `--ros-args` is remap resolution — name
+  construction, violation class 4 — so the parser belongs beside
+  `nros::resolve_name`, not in the shim;
+* `rclcpp::Rate` is the sharpest case: a loop in the wrapper that spins the
+  executor is violation class 2 *and* the thing RFC-0021 forbids. It is
+  admissible only as a forwarder onto an executor-driving entry point that
+  already exists in Rust — which is why it is planned that way rather than as
+  the obvious fifteen-line C++ class.
+
+### When a second path is warranted
+
+Only when the wrapper must satisfy a language contract the Rust side cannot
+express, and then it is recorded rather than assumed. The bar is the same one
+RFC-0020 audits against, and a new second path needs: what language contract
+forces it, why no FFI slot can carry it, and what keeps the two from drifting.
+`nros::Expected<T>` is the model — it exists because RFC-0018 forbids
+exceptions and Rust's `Result` cannot cross `extern "C"`, and it holds no state
+of its own.
 
 ## Naming: alias, not replace
 

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -301,17 +301,40 @@ converge or do not depending on RFC-0041 and W5.a, and forcing an order onto
 lists of different lengths would produce a signature that matches upstream in
 neither.
 
-### The hazard, and why this one is safe
+### The hazard, CORRECTED — a distinguishable type is not enough in C
 
-Reordering parameters of the SAME type is silent: a caller that is not updated
-still compiles and passes the wrong values. `node_init` is safe because the
-argument moving is `support` (a `struct nros_support_t *`) crossing `name` and
-`namespace_` (both `const char *`) — an un-updated caller puts a struct pointer
-where a `char *` is expected and fails to compile.
+The first version of this section said `node_init` was safe to reorder because
+the moved parameter is a `struct nros_support_t *` crossing two `const char *`,
+so a stale caller "fails to compile". **That is false for C**, and it was
+falsified by a mutation test rather than by review:
 
-That is luck, not a rule. **Before any future reorder, check whether the moved
-parameter's type is distinguishable from its neighbours'; where it is not, the
-reorder needs a rename alongside it so the old spelling cannot silently bind.**
+```
+C   : warning: passing argument 1 of 'f' from incompatible pointer type
+      ...even under -Wall -Wextra.
+C++ : error: cannot convert 'support_t*' to 'const char*'
+```
+
+C permits an incompatible pointer argument with a diagnostic that is a WARNING
+by default. So a reorder in the C API is silent-by-default for exactly the
+callers it must not be silent for: out-of-tree consumers, who do not build with
+our flags.
+
+**The rule, restated:**
+
+* A reorder is safe only where the build treats an incompatible pointer as an
+  ERROR. Ours does; a user's does not, and we do not control that.
+* Therefore a C reorder must be accompanied by a RENAME, so a stale call fails
+  on the identifier — which C does diagnose fatally — rather than on the
+  argument type, which it does not.
+* Where the moved parameter's type is INDISTINGUISHABLE from its neighbours
+  (two `const char *`), it is silent in C++ too, and the rename is not optional
+  in either language.
+
+This is why the compat header's reordering forwarder is a `static inline` that
+names each parameter and never a macro, and why its probe pins the reorder with
+`#pragma GCC diagnostic error "-Wincompatible-pointer-types"` scoped to that TU:
+the guard cannot be advisory when the reorder is the whole reason the forwarder
+exists. Without the pragma the guarding mutation PASSED.
 
 ## What "mostly full compat" can honestly mean
 

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -317,22 +317,42 @@ rclc binds it at `rclc_executor_add_subscription`. So "sort the arguments to
 match" is not reachable by reordering — those two arguments have to go
 somewhere else, or stay.
 
-**The decision, which is a design reversal and not a rename:**
+### CORRECTED — RFC-0041 does not decide this, and the rule cited instead does not exist
 
-1. **Adopt rclc's split** — `*_init` takes no callback; the callback and its
-   storage arrive at executor-add. That is what W5.a's
-   `nros_executor_add_subscription_typed` already does for the typed path, so
-   the shape exists and is proven; what remains is making it the ONLY shape and
-   reversing RFC-0041 for the three entity types.
-2. **Keep RFC-0041** — the three signatures stay 6-argument and are documented
-   divergences forever. Source compatibility for those three calls is
-   unreachable, and `rcl_compat.h` cannot be deleted for them.
+I first wrote that taking rclc's order requires reversing RFC-0041, which is
+Stable, and that this was the last blocker for deleting the C compat header.
+**Both halves are wrong**, and checking took one grep:
 
-(1) is the only choice consistent with "no compat layer survives", so choosing
-the end state chooses it. Worth saying plainly: **RFC-0041 becomes the last
-blocker for deleting the C compat header**, and it is Stable, so reversing it is
-an RFC amendment with its own acceptance — not something a rename sweep can do
-on the way past.
+* **RFC-0041 says nothing about a binding site.** Its normative content is the
+  DISPATCH MODEL — every callback-capable entity is callback-based by default,
+  the executor pumps once per `spin_once`, and an entity must be arena-registered
+  to be dispatched at all. Where the callback is *passed* — `*_init` or
+  `executor_add_*` — appears nowhere in it.
+* **`executor-owns-no-entity-storage`, cited by name in ten ledger rows as the
+  reason, is defined nowhere.** Zero occurrences in `docs/design/`. It reads as
+  a settled principle and is a phrase the ledger invented for itself.
+
+So the binding site is an implementation habit that was retroactively attributed
+to an RFC that does not mandate it. That is issue 1022's class — prose citing a
+source that does not support it — in the rows that were about to justify keeping
+a compat layer forever.
+
+**What IS real**, and is the only constraint found: `c:timer_exchange_callback`
+gives a concrete reason for the RUNTIME case — "the executor's static dispatch
+table cannot be rewritten while it is being walked". That forbids *swapping* a
+callback on a live entity. It says nothing about which call first supplies one.
+
+**So the decision is smaller and already unblocked.** Moving the callback from
+`*_init` to `executor_add_*` needs no RFC amendment; it needs the same shape
+W5.a shipped and proved this week
+(`nros_executor_add_subscription_typed(exec, sub, msg, cb, ctx, invocation)` —
+rclc's arguments in rclc's order). What remains is making it the only shape and
+migrating in-tree callers.
+
+**What still needs writing down** is the reverse: the ten rows asserting a rule
+that does not exist have to be corrected, and if the habit has a real
+justification, it belongs in an RFC rather than in ledger prose that cites
+itself.
 
 ## Argument ORDER follows the same decision, and is mostly not a separate task
 

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -271,6 +271,69 @@ Consequences, in the order they bite:
   seams. This is the one place where taking rcl's spelling must not mean taking
   rcl's values.
 
+## End state: no compat layer survives
+
+Confirmed 2026-09-04. The compat headers are SCAFFOLDING with a demolition
+date, not a permanent surface:
+
+* `rclcpp_compat.hpp` and `<nros/rcl_compat.h>` exist only to bridge two
+  spellings of one thing. When there is one spelling they have nothing to
+  bridge, so they do not have to be argued away — **they dissolve by
+  construction**, which is the property that keeps them from rotting into
+  permanent debt.
+* `cmake/compat/` likewise: it shadows `<rclcpp/rclcpp.hpp>` and stubs
+  `find_package(rclcpp)` because our headers live elsewhere under other names.
+
+The acceptance test for the end state is therefore sharp and mechanical: **the
+ported templates must build with every compat layer deleted.** Not "still
+compile with the shim present" — deleted.
+
+### The one thing that does NOT dissolve, and why that is fine
+
+`rcl_compat.h` does two jobs, and only one is a spelling. The other is the
+`RCL_RET_*` value mapping, and RFC-0087 forbids renumbering ours to match rcl's
+— that would silently flip the meaning of every stored return code across three
+FFI seams.
+
+So `RCL_RET_TIMEOUT` does not go away; it becomes the NAME of our constant, with
+our value. A ported `if (ret == RCL_RET_TIMEOUT)` is correct. A program that
+hardcodes `if (ret == 2)` is not, and never was. That is a defensible line: we
+adopt rcl's vocabulary, not its numbering, and the vocabulary is what source
+compatibility is made of.
+
+## Taking rclc's argument ORDER forces a decision on RFC-0041
+
+Measured over the seven entry points: only one is a pure permutation
+(`node_init`). Three more — `subscription_init`, `service_init`, `timer_init` —
+differ because **ours carry `callback` and `context` that rclc's do not**:
+
+```
+rclc_subscription_init_default(sub, node, type_support, topic_name)         [4]
+nros_subscription_init        (sub, node, type_info, topic_name, cb, ctx)   [6]
+```
+
+That is RFC-0041 (Stable): the callback binds to the ENTITY at creation, where
+rclc binds it at `rclc_executor_add_subscription`. So "sort the arguments to
+match" is not reachable by reordering — those two arguments have to go
+somewhere else, or stay.
+
+**The decision, which is a design reversal and not a rename:**
+
+1. **Adopt rclc's split** — `*_init` takes no callback; the callback and its
+   storage arrive at executor-add. That is what W5.a's
+   `nros_executor_add_subscription_typed` already does for the typed path, so
+   the shape exists and is proven; what remains is making it the ONLY shape and
+   reversing RFC-0041 for the three entity types.
+2. **Keep RFC-0041** — the three signatures stay 6-argument and are documented
+   divergences forever. Source compatibility for those three calls is
+   unreachable, and `rcl_compat.h` cannot be deleted for them.
+
+(1) is the only choice consistent with "no compat layer survives", so choosing
+the end state chooses it. Worth saying plainly: **RFC-0041 becomes the last
+blocker for deleting the C compat header**, and it is Stable, so reversing it is
+an RFC amendment with its own acceptance — not something a rename sweep can do
+on the way past.
+
 ## Argument ORDER follows the same decision, and is mostly not a separate task
 
 Settled 2026-09-04 with the spellings: where we and rclc/rclcpp name the same

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -271,6 +271,50 @@ Consequences, in the order they bite:
   seams. This is the one place where taking rcl's spelling must not mean taking
   rcl's values.
 
+## Settled: each language follows ITS OWN upstream (2026-09-04)
+
+Where the three upstreams disagree with each other, we follow each language's
+own. The worked case is logging:
+
+```
+rclrs    log_info!(logger, "…")
+rclcpp   RCLCPP_INFO(logger, "…")
+rcl/rcutils  RCUTILS_LOG_INFO_NAMED(name, "…")
+```
+
+There is no single "ROS 2 spelling" to match, so "respect the official API" does
+not resolve it on its own. The tie-break is what a porting user actually reads:
+**one client library, not three.** A Rust node ported from rclrs is read beside
+rclrs; matching rclcpp there would be matching a library that user never opens.
+
+**This deliberately gives up part of stage 4's convergence, and that is the
+cost, stated rather than hidden.** Stage 4 spent real effort making our three
+surfaces agree — and that was always INSTRUMENTAL to drop-in, never an end in
+itself. Where agreeing with each other and agreeing with upstream pull apart,
+upstream wins, because upstream is what a ported file was written against.
+
+The rule survives the exception: our languages must still agree about
+CAPABILITY and CONTRACT. What may differ is the spelling, and only where the
+upstreams differ first. A capability present in one of our languages and absent
+in another is still the defect stage 4 exists to remove.
+
+## Settled: the typesupport parameter keeps OUR type (2026-09-04)
+
+`rcl_publisher_init` takes `const rosidl_message_type_support_t *`; ours takes
+`const nros_message_type_t *` in the same position. We keep ours.
+
+Not a preference — a rosidl typesupport's MEMBERS are its contract
+(`typesupport_identifier`, `data`, and the `func` dispatcher that resolves the
+implementation at runtime), against our flat `type_name` / `type_hash` /
+`serialized_size_max`. Adopting the name would claim a dispatcher we do not
+have, and the "compiles and differs" that follows is exactly what this RFC
+forbids.
+
+It costs a ported call site nothing today, because the argument comes from our
+codegen either way — `ROSIDL_GET_MSG_TYPE_SUPPORT` does not exist here. What it
+costs is one type NAME visible in a signature after the compat layers are gone,
+and that is the honest price of not faking a structure.
+
 ## End state: no compat layer survives
 
 Confirmed 2026-09-04. The compat headers are SCAFFOLDING with a demolition

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -242,6 +242,35 @@ no error. Today the two types have different NAMES, which is the only thing
 making that visible. That is a structural prerequisite for step 2, not a
 loudness item — see phase-417.
 
+## Settled: C takes rcl's spellings (2026-09-04)
+
+The question the disposition pass could not answer, because it is a decision and
+not a reading: does the C API keep `nros_publisher_get_zero_initialized`
+(module-first, our convention) or take `rcl_get_zero_initialized_publisher`
+(rcl's free-function shape)?
+
+**It takes rcl's.** The goal is drop-in replacement, and a ported file's line is
+rcl's line. That resolves a real split — the same class landed `adopt` in four
+ledger shards and `refuse-loud` in one, which was never agent disagreement but
+an unmade decision surfacing five times.
+
+Consequences, in the order they bite:
+
+* **Every row declined on SPELLING alone flips to `adopt`.** Those declines
+  argued from our naming convention, and RFC-0036 already forbids recording a
+  preference as a divergence. They were the largest coherent group in the C
+  ledger with no platform content.
+* **New C entry points land under `nros_` and reach the user as `rcl_`.** The
+  alias comes from `<nros/rcl_compat.h>`, not from renaming as we go: a
+  half-renamed C surface is worse than either end state, and RFC-0087's
+  migration is alias-then-replace precisely so the two steps are separable.
+* **`nros_ret_t` is the sharpest case and is NOT a rename.** Its doc claims
+  compatibility with `rcl_ret_t` and only `OK` agrees — ours are −1/−2/−3/−7,
+  rcl's are 1/2/11/101. The compat header MAPS the constants; renumbering ours
+  would silently flip the meaning of every stored return code across three FFI
+  seams. This is the one place where taking rcl's spelling must not mean taking
+  rcl's values.
+
 ## What "mostly full compat" can honestly mean
 
 It cannot mean the whole rclcpp surface. Four upstream idioms account for most

--- a/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0087-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -271,6 +271,48 @@ Consequences, in the order they bite:
   seams. This is the one place where taking rcl's spelling must not mean taking
   rcl's values.
 
+## Argument ORDER follows the same decision, and is mostly not a separate task
+
+Settled 2026-09-04 with the spellings: where we and rclc/rclcpp name the same
+function, our parameters take THEIR order. A ported line has to compile
+unchanged, and an argument list is as much of the line as the name.
+
+Measured before committing to it, over the seven entry points the compat work
+touches. Only ONE is a reordering:
+
+```
+rclc_node_init_default(node, name, namespace_, support)
+nros_node_init        (node, support, name, namespace_)     <-- permutation
+```
+
+The other six differ for reasons a reorder cannot fix, and reading them is what
+makes the task tractable:
+
+| pair | difference | what closes it |
+| --- | --- | --- |
+| `publisher_init`, `client_init` | `type_support` vs `type_info` — a TYPE difference in the same position | a decision about the typesupport handle, not order |
+| `subscription_init`, `service_init` | ours carries `+2` (`callback`, `context`) | RFC-0041 binds the callback to the ENTITY at creation; changing it is a design reversal, not a rename |
+| `timer_init` | ours carries `+1` (`context`); also `timeout_ns` vs `period_ns` | same RFC-0041 question, plus a naming one |
+| `executor_add_subscription` | rclc carries `+2` (`msg`, `callback`) | W5.a's typed delivery — it converges when that lands |
+
+So argument order is **downstream of the shape decisions**, not parallel to
+them. Reordering the one true permutation is a day's work; the other six
+converge or do not depending on RFC-0041 and W5.a, and forcing an order onto
+lists of different lengths would produce a signature that matches upstream in
+neither.
+
+### The hazard, and why this one is safe
+
+Reordering parameters of the SAME type is silent: a caller that is not updated
+still compiles and passes the wrong values. `node_init` is safe because the
+argument moving is `support` (a `struct nros_support_t *`) crossing `name` and
+`namespace_` (both `const char *`) — an un-updated caller puts a struct pointer
+where a `char *` is expected and fails to compile.
+
+That is luck, not a rule. **Before any future reorder, check whether the moved
+parameter's type is distinguishable from its neighbours'; where it is not, the
+reorder needs a rename alongside it so the old spelling cannot silently bind.**
+
 ## What "mostly full compat" can honestly mean
 
 It cannot mean the whole rclcpp surface. Four upstream idioms account for most

--- a/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
+++ b/docs/design/0089-ros2-api-adoption-and-the-compile-or-conform-rule.md
@@ -1,4 +1,4 @@
-# RFC-0087 — ROS 2 API adoption, and the compile-or-conform rule
+# RFC-0089 — ROS 2 API adoption, and the compile-or-conform rule
 
 **Status:** Draft (2026-09-04)
 **Amends / refines:** RFC-0036 (divergence catalog) — adds the DISPOSITION half:
@@ -262,7 +262,7 @@ Consequences, in the order they bite:
   ledger with no platform content.
 * **New C entry points land under `nros_` and reach the user as `rcl_`.** The
   alias comes from `<nros/rcl_compat.h>`, not from renaming as we go: a
-  half-renamed C surface is worse than either end state, and RFC-0087's
+  half-renamed C surface is worse than either end state, and RFC-0089's
   migration is alias-then-replace precisely so the two steps are separable.
 * **`nros_ret_t` is the sharpest case and is NOT a rename.** Its doc claims
   compatibility with `rcl_ret_t` and only `OK` agrees — ours are −1/−2/−3/−7,
@@ -335,7 +335,7 @@ compile with the shim present" — deleted.
 ### The one thing that does NOT dissolve, and why that is fine
 
 `rcl_compat.h` does two jobs, and only one is a spelling. The other is the
-`RCL_RET_*` value mapping, and RFC-0087 forbids renumbering ours to match rcl's
+`RCL_RET_*` value mapping, and RFC-0089 forbids renumbering ours to match rcl's
 — that would silently flip the meaning of every stored return code across three
 FFI seams.
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -94,6 +94,7 @@ Each RFC carries frontmatter: `rfc`, `title`, `status`, `since`, `last-reviewed`
 | 0022 | [entity-api-tiers](0022-entity-api-tiers.md) | Stable | convenient `fork` + customizable `clone` entity ctors |
 | 0036 | [ros2-api-divergences](0036-ros2-api-divergences.md) | Draft | authoritative catalog of nano-ros vs rclrs/rclcpp/rclc divergences + rationale |
 | 0037 | [rust-c-user-api-surface](0037-rust-c-user-api-surface.md) | Draft | records the Rust (`nros-node`) + C (`nros-c`) user surfaces; C++ is 0018 |
+| 0087 | [ros2-api-adoption-and-the-compile-or-conform-rule](0087-ros2-api-adoption-and-the-compile-or-conform-rule.md) | Draft | when our API may take ROS 2's NAMES: adopt / adopt-bounded / refuse-loud / absent, never compile-and-differ |
 
 ### Codegen, workspace & user workflow
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -94,7 +94,7 @@ Each RFC carries frontmatter: `rfc`, `title`, `status`, `since`, `last-reviewed`
 | 0022 | [entity-api-tiers](0022-entity-api-tiers.md) | Stable | convenient `fork` + customizable `clone` entity ctors |
 | 0036 | [ros2-api-divergences](0036-ros2-api-divergences.md) | Draft | authoritative catalog of nano-ros vs rclrs/rclcpp/rclc divergences + rationale |
 | 0037 | [rust-c-user-api-surface](0037-rust-c-user-api-surface.md) | Draft | records the Rust (`nros-node`) + C (`nros-c`) user surfaces; C++ is 0018 |
-| 0087 | [ros2-api-adoption-and-the-compile-or-conform-rule](0087-ros2-api-adoption-and-the-compile-or-conform-rule.md) | Draft | when our API may take ROS 2's NAMES: adopt / adopt-bounded / refuse-loud / absent, never compile-and-differ |
+| 0089 | [ros2-api-adoption-and-the-compile-or-conform-rule](0089-ros2-api-adoption-and-the-compile-or-conform-rule.md) | Draft | when our API may take ROS 2's NAMES: adopt / adopt-bounded / refuse-loud / absent, never compile-and-differ |
 
 ### Codegen, workspace & user workflow
 

--- a/docs/issues/1022-ledger-rows-state-false-facts-about-our-code.md
+++ b/docs/issues/1022-ledger-rows-state-false-facts-about-our-code.md
@@ -1,0 +1,85 @@
+---
+id: 1022
+title: "~95 parity-ledger rows state something FALSE about our own code, and several
+  justify a divergence with a constraint the compared surface refutes"
+status: open
+type: bug
+area: docs, api
+related: [phase-379, phase-417, issue-1012, issue-1019, issue-1020, rfc-0036, rfc-0087]
+---
+
+## Problem
+
+Issue 1012 covers rows naming a symbol that no longer exists — a dead spelling,
+fixed by renaming the prose. This is the worse class: the symbol exists and the
+sentence about it is **wrong**. A dead spelling makes a reader look something
+up and fail. A false claim makes them act.
+
+Found by three independent audits of the C, C++ and cross-language surfaces
+(2026-09-04), each verified against the headers before filing.
+
+| # | claim | reality | rows |
+| --- | --- | --- | ---: |
+| 1 | "there is no runtime options struct" | seven ship — `nros_{node,publisher,subscription,service,client,action_client,action_server}_options_t` — plus seven `*_get_default_options`, and the correlator buckets all fourteen `same`. `nros_node_options_t` carries a runtime `domain_id_override` | 27 |
+| 2 | the C zero-copy types are `nros_borrowed_str_t` / `nros_borrowed_bytes_t` | neither exists; they are `nros_view_str_t` / `nros_view_bytes_t` (`view.h:39,45`). Same class as 1012, found outside its scan | 28 |
+| 3 | `get_actual_qos` "would return its own input" because QoS is compile-time | false. `Node::set_qos_overrides` (`node.hpp:292`) installs a launch-lowered table that `apply_qos_overrides` folds into every entity created afterwards. Actual ≠ requested exactly when a deploy plan says so — the accessor's whole use case. Should be `gap`, not `declined` | ~10 |
+| 4 | `cpp:` rows answering in C spellings | `nros_count_status_t` / `nros_liveliness_changed_status_t` are the C types; C++ has three distinct ones (`nros_cpp_{pub_count,count,liveliness_changed}_status_t`, `nros_cpp_ffi.h:441,513,524`), so both the names and the count are wrong | 15 |
+| 5 | verdict inflation — `declined` on rows whose own `why` describes a capability we HAVE under another spelling ("ours is `nros::spin_once(0)`") | those are `rename` / `remapped` by the ledger's own definitions | ~14 |
+| 6 | `cpp:ServerGoalHandle` maps onto `nros_action_succeed`/`_abort`/`_canceled` | declared only in `nros-c/include/nros/nros_generated.h:3896`; **no nros-cpp header includes it**. The C++ answer, `ActionServer::complete_goal` (`action_server.hpp:257`), is never named | 1 |
+| 7 | `cpp:Node::set_parameter` — "no setter at all, not even a typed one" | `ParameterServer::set_parameter<T>` exists (`parameter.hpp:363`). The true, narrower claim is: no setter on the NODE facade | 1 |
+| 8 | `c:log_severity_t` — "`<nros/nros.h>` does not `#include "nros/log.h"`" | it does, unconditionally, at `nros.h:40` | 1 |
+
+## The one that is a defect in shipped documentation, not the ledger
+
+`nros_generated.h:840` says `nros_ret_t` is *"Compatible with `rcl_ret_t` for
+familiarity."* Only `OK` agrees:
+
+| | ours | rcl |
+| --- | ---: | ---: |
+| OK | 0 | 0 |
+| ERROR | −1 | 1 |
+| TIMEOUT | −2 | 2 |
+| INVALID_ARGUMENT | −3 | 11 |
+| NOT_INIT | −7 | 101 |
+
+Ported code writing `if (ret == RCL_RET_TIMEOUT)` compiles and never matches.
+This is RFC-0087's compile-and-differ shape, in a comment rather than a
+signature.
+
+## The systematic one, and the reason this is worth a separate issue
+
+Rows 1 and 3 share a shape with a larger family: **a divergence justified by a
+constraint that the compared surface refutes.**
+
+The canonical case is byte-oriented delivery. Many C rows justify it with "no
+allocator". rclc has no allocator on that path either and still delivers a
+deserialised message, by making the caller own the storage:
+
+```c
+rclc_executor_add_subscription(executor, subscription, void *msg,
+                               rclc_subscription_callback_t callback, invocation);
+typedef void (*rclc_subscription_callback_t)(const void *);
+```
+
+Ours has no `msg` slot and delivers `(const uint8_t *, size_t)`. The generated
+`<Msg>_deserialize` already writes into caller storage and the typed *publish*
+half already shipped — only the receive half was never built. So the divergence
+is real and the stated reason is not, which is worse than an unexplained row:
+it forecloses the fix.
+
+RFC-0036 already forbids recording a preference as a divergence. This is the
+adjacent failure — recording a real divergence under a false cause — and the
+catalog has no rule against it.
+
+## Fix
+
+Correct the rows, and prefer deleting a justification to keeping a wrong one.
+Where a verdict changes (rows 3 and 5), that is a ledger edit plus a
+regenerated comparison, not code.
+
+Then close the class: RFC-0036 should require that a `divergence`'s stated
+constraint be one the COMPARED surface does not also operate under. That is
+checkable by hand at review time and would have caught rows 1, 3 and the
+allocator family.
+
+Homed in phase-417 (correction track).

--- a/docs/issues/1037-nros-log-cargo-features-violate-d5.md
+++ b/docs/issues/1037-nros-log-cargo-features-violate-d5.md
@@ -90,6 +90,91 @@ that is internal logic reading a public declaration, which is the distinction
 that matters. What must stop is a HUMAN writing `features = ["max-level-info"]`
 in a manifest to choose product behaviour.
 
+## The fix method
+
+The pattern already exists and `nros-node` is the exact precedent — phase-400 W6
+migrated the `executor` tenant from build-script env reads to the ladder, and
+that crate is in the same position as this one: **it deliberately has no
+`platform-*` cargo feature** (phase-248 C2), so its build script cannot learn
+its platform from a `cfg` either.
+
+### Step 1 — a `logging` tenant
+
+`LoggingKnobs` beside `ExecutorKnobs`/`MemoryKnobs`/`ParamKnobs`/`RmwKnobs`/
+`TransportKnobs` in `platform_config.rs`, plus a `LOGGING_KNOBS` table and a
+`logging_env_key()`. The env front-end names are DERIVED from that one table
+rather than retyped — `nros-node` does exactly this with `knob_for_env`, and
+retyping them is the drift `check-knob-single-reader` exists to catch.
+
+```toml
+[knobs.logging]
+max_level       = "info"   # compile-time CEILING
+buffer_size     = 256
+early_records   = 4
+dynamic_loggers = 16
+```
+
+### Step 2 — `nros-log` gains a build script
+
+```rust
+let rungs = BuildRungs::from_build_env().map(|r| r.logging_rungs()).unwrap_or_default();
+```
+
+Sizes become generated consts in `OUT_DIR`; `max_level` becomes a
+`cargo::rustc-cfg`, because it gates macro EXPANSION rather than a value.
+
+**This step also fixes the bug that started this issue, and that is the
+strongest argument for the migration.** `BuildRungs::from_build_env()` returns
+`None` when no lane exported a pointer, and every rung is then `None`. So:
+
+* a bare `cargo test -p nros-log` — no lane, no clock rung, no
+  `has_platform_clock` cfg, and the test binary links, because it never
+  references `nros_platform_clock_ns`;
+* a real image — the lane resolved a platform that declares the capability, the
+  cfg is on, the symbol exists.
+
+A Cargo feature cannot express that distinction *at all*: features unify across
+the workspace, so "on for `nros-c`, off for `nros-log`'s own tests" is
+unsayable. That is not a tidiness argument — it is the exact failure the tier
+caught, and the ladder is the mechanism that makes it expressible.
+
+### Step 3 — the clock is a capability, not a knob
+
+`capabilities` is an open `BTreeMap<String, bool>` (`platform_config.rs:92`), so:
+
+```toml
+# the five ports that export nros_platform_clock_us
+[capabilities]
+clock = true
+```
+
+A capability is a software-stack FACT, which is what this is — the same shape as
+`ip_stack` and `serial`. `capability_check` already errors when something
+requires a capability the platform does not declare, so a board asking for
+timestamps on a clockless port gets a configure-time error instead of records
+stamped `0`.
+
+### Step 4 — retire the sixteen features
+
+As ONE batch with a changelog entry, per the retirement discipline: it is the
+irreversible step for an out-of-tree consumer naming `features =
+["max-level-info"]`. `platform-clock` may survive as an internal cfg the build
+script sets; what retires is the human-written spelling.
+
+### The open decision, resolved
+
+I filed this saying a compile-time ceiling contradicting the runtime
+`nros_logger_set_level` would be two sources of truth. **On checking upstream,
+that was wrong and they compose.** rcutils has both: `RCUTILS_LOG_MIN_SEVERITY_*`
+(`logging_macros.h:40-43`) is a compile-time floor that eliminates code, and
+`rcutils_logging_set_logger_level` (`logging.h:403`) is the runtime threshold.
+
+They are a BOUND and a VALUE, not two answers to one question: the ceiling says
+what can possibly be emitted, the runtime level says what is emitted now, and a
+runtime level below the ceiling is simply unreachable. So `max_level` is
+per-image and `set_level` stays per-logger, which is also what ROS 2 does — the
+principle the campaign already follows.
+
 ## Why this is filed rather than fixed
 
 It reaches the config ladder, five platform manifests, `nros-log`'s build, the

--- a/docs/issues/1051-pinned-locks-gate-suggests-a-destructive-fix.md
+++ b/docs/issues/1051-pinned-locks-gate-suggests-a-destructive-fix.md
@@ -1,0 +1,60 @@
+---
+id: 1051
+title: "`check-submodule-pinned-locks` blames the lock for a drifted CHECKOUT, and
+  the remedy it prints would rewrite a correct lock to match the wrong tree"
+status: open
+type: bug
+area: tooling, ci
+---
+
+## Problem
+
+The gate resolves each submodule-pinned leaf under `--locked` and, on failure,
+prints:
+
+```
+  The submodule pointer moved and the lock did not follow (issue 0560).
+  Update it the sanctioned way — never a bare `cargo generate-lockfile`:
+      just lock-update "" "" <leaf-dir>
+```
+
+That is one of **two** causes, and the message asserts it as the only one.
+
+The other: the pointer did NOT move, the **worktree checkout** drifted from it.
+A rebase does this routinely — the superproject's gitlink advances and the
+submodule working tree stays where it was, which is the state CLAUDE.md
+describes as "the superproject's pin disagreeing with your checkout".
+
+Both produce the identical symptom, because `--locked` resolution reads the
+checked-out source either way.
+
+## Why the wrong remedy is destructive
+
+Following the printed advice on the second cause regenerates the lock **against
+the drifted checkout** — so a correct lock is rewritten to match a tree that is
+not what the pin names, and the result is committed looking like deliberate
+dependency work. The gate then passes, which is the worst part: the tree is
+consistent with itself and inconsistent with the pin.
+
+Encountered 2026-09-04 on `packages/cli/nros-launch-resolve` after a rebase.
+The lock and the gitlink were **byte-identical to `origin/main`** — nothing had
+moved — while the checkout sat at `8fda8d89` against a pin of `4c214a63`. The
+fix was `git submodule update packages/cli/third-party/play_launch`, which the
+message does not mention.
+
+## Fix
+
+Distinguish the two before advising, which is cheap — the gate already knows
+the leaf, so it can compare the recorded gitlink against the submodule's
+`HEAD`:
+
+* `HEAD != gitlink` → the CHECKOUT drifted. Print
+  `git submodule update <path>`, and do NOT mention `lock-update`.
+* `HEAD == gitlink` and the lock still fails → the pin genuinely moved ahead of
+  the lock. Print today's message.
+
+Worth a rule beyond this gate: **a remedy line is part of the diagnostic, and a
+wrong one is worse than none.** A gate that names a cause it has not
+distinguished sends the next person to make the tree worse in a way that then
+passes. Related in shape to issue 0445, where an absorbing STALE verdict
+replaced the runtime result with a confident wrong explanation.

--- a/docs/issues/1059-main-red-in-check-build-only-lane.md
+++ b/docs/issues/1059-main-red-in-check-build-only-lane.md
@@ -1,0 +1,82 @@
+---
+id: 1059
+title: "two reds sit on `main` in `check-build`, which no merge-gating event runs
+  — a half-landed `type Format` and a clippy `format!`-in-`assert!`"
+status: open
+type: bug
+area: ci, core
+related: [phase-421, phase-395, issue-1013]
+---
+
+## Problem
+
+`just ci gate` on a branch rebased onto `main` at `6cbc85fe7` fails step 3 with
+two `check-build` gates red. Both reproduce on **`main` itself**, checked out
+clean in a separate worktree — neither comes from the branch.
+
+### 1. `node-std-tests` — `type Format` is declared by nine impls and by no trait
+
+```
+error[E0437]: type `Format` is not a member of trait `nros_serdes::schema::Message`
+   --> packages/core/nros-node/src/executor/node.rs:2555
+```
+
+`main`'s `47880d2e1` (*feat(phase-421 W1-W3): the serialization format stops
+being a comment*) added `type Format = nros_serdes::format::Cdr;` to nine
+`Message` impls — one in `executor/node.rs`, eight in `executor/tests.rs` — but
+`nros_serdes::schema::Message` (`schema.rs:135`) declares no such associated
+type. `git grep "type Format" origin/main -- packages/core/nros-serdes` returns
+nothing.
+
+Reproduced on a pristine `origin/main` worktree with the gate's own feature set:
+
+```
+$ cargo test -p nros-node --lib --features std --no-run
+error[E0437]: type `Format` is not a member of trait `nros_serdes::schema::Message`   (×3)
+```
+
+Note `cargo check -p nros-node --lib --features std` **passes** — all nine sites
+are behind `#[cfg(test)]`, so only a test build reaches them. That is why a
+lane which merely compiles the library says nothing about this.
+
+### 2. `test-targets` — `format!` inside `assert!` args
+
+```
+error: `format!` in `assert!` args
+   --> packages/testing/nros-tests/tests/rtos_e2e.rs:903
+```
+
+From `05bf241eb` (*fix(#1013): the pubsub cell lets its talker run…*), same day.
+
+## Why both survived
+
+`check-build` runs on `schedule` / `workflow_dispatch` only. The required `CI`
+context on `pull_request` is `check-fast` + `check-submodule-commits-reachable`
++ `check-compile-smoke` + `check-cli-tests`, and the merge queue adds
+`test-unit` — **`check-build` is in none of them**. So a red here blocks
+nothing, is reported to nobody at merge time, and is first seen by whoever next
+runs the full local tier.
+
+This is the third instance in one session. `board_facts.rs`'s
+`items_after_test_module` red (`e453399de`) rode in the same way and was fixed
+by `09b653ec2` only because a local tier run surfaced it. CLAUDE.md already
+records the pattern for `check-build`; what it does not say is that the lane has
+now caught three separate reds that reached `main`, which makes this a gap in
+coverage rather than a stale gate.
+
+## Fix
+
+Two separate fixes and one policy question.
+
+* **`type Format`** — decide whether phase-421's associated type belongs on
+  `Message`. If yes, land the trait half (`type Format: SerializationFormat;`,
+  presumably with a default so generated messages need no edit). If the nine
+  impls were speculative, delete them. Do not guess: RFC-0088 makes format a
+  TYPE, so the trait shape is a design decision, not a mechanical repair.
+* **the clippy site** — inline the captured identifiers, or hoist the message.
+* **the lane** — the reason `check-build` is not merge-gating is cost, and that
+  reason still holds for the whole lane. But `node-std-tests` needs no fixture,
+  no SDK and no QEMU, and `test-targets` is clippy. Moving just those two into
+  a merge-gating event would have caught all three of this session's reds. That
+  is a `check-lane-contracts` question: an affordability tier may only resolve
+  artifacts the job itself builds, and both of these qualify.

--- a/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
+++ b/docs/roadmap/phase-379-api-parity-with-ros2-client-libraries.md
@@ -902,6 +902,24 @@ each rename lands. Two things to carry into it:
 * `--show all` prints matching rows too, which is the fastest way to check
   whether a name you are about to add already correlates.
 
+## Handoff to phase-417 (2026-09-04)
+
+This phase owns the MEASUREMENT campaign and W7 steps 1–4. Adoption — taking
+ROS 2's names, and everything that must be true first — moves to
+**phase-417**, which implements RFC-0087 and is the home for the correction,
+migration and retirement tracks going forward.
+
+W7 steps 1–3 stay here and are in flight. W7 step 4 (the deprecated-alias
+retirement batch) stays here too; 417 lists it as W-R1 so the retirement
+sequence reads end to end in one place.
+
+What moved: the ledger corrections found by the 2026-09-04 audits (issues 1012
+and 1022, ~140 rows), the measurement blind spot (1020 — the C++ lane cannot
+see `rclcpp_compat.hpp`, so every count in this doc measures the NATIVE API
+rather than what a ported file reaches), and the compat-surface defects (1019).
+
+Read 1020 before quoting any C++ number in this document.
+
 ## Issues homed here (survey 2026-09-03)
 Every open issue was checked for a home phase; these had none, or were
 mentioned here only in passing. A mention is not an owner — an issue with

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -313,6 +313,25 @@ shape is uniform (`nros_node_init(&x, &y, "name", "/")`). So a regex codemod is
 honest here — but it must be a codemod that reorders, not a `sed s/old/new/`,
 and the two must not be run as separate passes.
 
+### Work items
+
+* **W-B1 [rust]** — flip `nros-log/deprecate-legacy-names`, then fix the 208
+  sites it names across 50 files. The flip comes FIRST because
+  `warnings = "deny"` makes it enumerate the work instead of a grep guessing at
+  it.
+* **W-B2 [c]** — the 43 deprecated C names across 206 sites / 40 files,
+  **including the `nros_node_init` reorder in the same pass**. Rename and
+  reorder must not be separate passes: the rename is what makes a missed
+  reorder fail to compile.
+* **W-B3 [cpp]** — `nros::` → `rclcpp::` across 645 sites / 119 files.
+* **W-B4 [docs]** — 57 files in `book/` and `docs/` naming an old spelling in
+  prose or a code block. No compiler checks these.
+* **W-B5 [retire]** — delete the 110 `NROS_DEPRECATED_MSG` forwarders across 12
+  headers, the five Rust forwarders, and the feature flag. Last, and only after
+  W-B1..4 are green.
+* **W-B6 [changelog]** — one entry, carrying phase-379 W7 step 4's two
+  warnings.
+
 ### Order, and why
 
 1. **Flip `nros-log/deprecate-legacy-names`.** The workspace sets

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -1,8 +1,21 @@
 # Phase 417 — ROS 2 user-API adoption
 
-**Status (2026-09-04). Planning. Implements RFC-0087.** No work item has
-started. Stage 0 is a prerequisite for measuring any of the others, so it is
-also the first thing to land.
+**Status (2026-09-04). In flight. Implements RFC-0087.** Stages 0, 1 and 2b are
+LANDED, and so is the correction track (issues 1012 and 1022 resolved, 92 rows).
+Stage 1's acceptance is met: `cpp-port-minimal-publisher/src/minimal_publisher.cpp`
+is upstream's file again. Stages 2 (node surface), 3 (loudness), 4 (cross-language)
+and 5 (C) are open; stage 6 (the rename) is gated on stage 3 AND on the structural
+blocker below.
+
+**What stage 0 revealed, and it reframes the phase.** Admitting the compat shim as
+a fourth TU made the ported surface look better — `same` 84 → 110 — while the
+defects were unchanged. `ParametersQoS` and `NodeOptions::use_intra_process_comms`
+now correlate `same`: the first returns `QoS(10)` where upstream is `KEEP_LAST,
+1000`, the second stores its argument and is never read. Correlation compares names
+and shapes and neither differs, so **the instrument cannot see the defect it is
+measuring.** A row can be `same` by shape and `refuse-loud` by disposition at once,
+which is why `disposition` is not bookkeeping — it is the only thing between a
+compatibility number and a false one.
 
 Goal: a ROS 2 node written against rclcpp / rclc / rclrs compiles and behaves
 against nano-ros, or fails loudly. **End state is that our API carries ROS 2's

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -1,0 +1,175 @@
+# Phase 417 — ROS 2 user-API adoption
+
+**Status (2026-09-04). Planning. Implements RFC-0087.** No work item has
+started. Stage 0 is a prerequisite for measuring any of the others, so it is
+also the first thing to land.
+
+Goal: a ROS 2 node written against rclcpp / rclc / rclrs compiles and behaves
+against nano-ros, or fails loudly. End state is that our API carries ROS 2's
+names as first-class aliases and `rclcpp_compat.hpp` is gone.
+
+The ordering principle, from RFC-0087: **the rename is cheap and cosmetic; the
+compatibility is the work.** The rename lands last, after the shapes match,
+because before then it would relabel the gaps without closing one — and would
+spend the property that makes mismatches visible while the mismatches are still
+there.
+
+## Stage 0 — measure the thing we are changing (issue 1020)
+
+Blocks everything. Today the C++ lane reads `nros.hpp`, `component_node.hpp`
+and `nros.hpp -DNROS_CPP_STD`, and filters to namespace `nros`, so the 589-line
+compat shim contributes zero rows. Every "how far are we" number is currently
+about the native API rather than about what a ported file reaches.
+
+* W0.a — admit `rclcpp_compat.hpp` as a fourth TU with namespace `rclcpp`, and
+  decide the three questions issue 1020 records: does a `rclcpp::` alias
+  resolving to a `nros::` type correlate as `same`; are "how close is the
+  native API" and "what does a ported file hit" one surface or two; how is the
+  shim's std-only reachability marked.
+* W0.b — add a `disposition` field to the ledger (adopt / adopt-bounded /
+  refuse-loud / absent) per RFC-0087's consequence section, and a gate that a
+  `declined` row declares one.
+
+**Acceptance:** the C++ report distinguishes native-API distance from
+ported-file distance, and every `declined` row says what a porting user gets.
+
+## Stage 1 — the cheap unblockers
+
+Small, independent, and they unblock the first lines of nearly every ported
+file. Roughly 75 lines total.
+
+* W1.a — nested `SharedPtr` / `ConstSharedPtr` / `UniquePtr` on `Publisher`,
+  `Subscription`, `Service`, `Client`, `Timer`, and on `rclcpp::TimerBase`.
+  `detail::SharedPtrTrait` (`rclcpp_compat.hpp:96`) was written for this and is
+  dead code — one occurrence in all of `packages/api/`, its own definition.
+  Unblocks `rclcpp::Publisher<T>::SharedPtr member_;`, which is close to
+  universal in rclcpp source.
+* W1.b — emit `<pkg>/msg/<snake>.hpp` as an alias header including the
+  prefixed one. The name is already computed
+  (`packages/cli/rosidl-codegen/src/generator/cpp.rs:403`). Unblocks the FIRST
+  line of every ported file.
+* W1.c — `NROS_CPP_STD`-gated `std::string` interop on `FixedString<N>`
+  (`operator=`, conversion, `operator==`), plus ungated `size()`/`empty()`.
+* W1.d — forward `now()`, `get_clock()`, `get_name()`, `get_namespace()` on the
+  shim `Node`; alias `rclcpp::Time`/`Duration`/`Clock`. All four already exist
+  on `nros::Node` (`node.hpp:217,223,249,260`).
+
+**Acceptance:** `examples/templates/cpp-port-minimal-publisher/` compiles with
+its source byte-identical to upstream's tutorial. Today its README claims
+"verbatim" and three lines differ — W1.a and W1.c are exactly those three.
+That claim becomes true or the stage is not done.
+
+## Stage 2 — the node surface
+
+Where a real node stops being a tutorial. Each item is independently useful.
+
+* W2.a — **one parameter store.** Today there are three arrangements: C has two
+  disjoint stores (issue 0793), C++'s `ComponentNode` owns a private
+  `ParameterServer` and reads the executor store exactly once at boot under
+  `#if defined(NROS_SYSTEM_PARAM_SERVICES)` (`component_node.hpp:536`), and
+  Rust has one. Converge on the executor's, with node facades as views.
+  Unfiled twin of 0793 on the C++ side; file it as part of this item.
+* W2.b — rclcpp-shaped `declare_parameter<T>` / `get_parameter<T>` /
+  `set_parameter<T>` / `has_parameter` on the node reachable from the umbrella.
+  The implementation exists at `component_node.hpp:568-659`; the blocker is
+  that `nros.hpp` does not include `component_node.hpp` (15 of 46 headers are
+  unreachable from the umbrella).
+* W2.c — `create_service` / `create_client` on the node; `async_send_request`
+  returning something the existing `spin_until_future_complete` accepts.
+  `nros::Client<S>` and `nros::Future` already exist.
+* W2.d — `rclcpp::Rate` / `WallRate` implemented over `nros::spin(remaining_ms,
+  poll_ms)` (`nros.hpp:175`), which drives the executor and is therefore
+  RFC-0021-compliant by construction rather than by exception.
+
+**Acceptance:** a node that declares a parameter, calls a service and reads the
+clock compiles unmodified. Measured by a new ported template, not by inspection.
+
+## Stage 3 — the loudness pass (the safety gate)
+
+RFC-0087's rule applied to everything already adopted. **This stage gates the
+rename**: until it is done, taking more upstream names increases the number of
+ways a ported program can compile and differ.
+
+* W3.a — issue 1019: `RCLCPP_*_STREAM` discards its message; the family routes
+  to a sink that is a no-op on every embedded target. Fix or refuse loudly.
+* W3.b — `rclcpp::init(argc, argv)` drops `--ros-args` silently
+  (`rclcpp_compat.hpp:238`), turning a remap into a wrong-topic bug at runtime.
+  Honour them on posix boards, or refuse the two-argument form.
+* W3.c — write the REFUSE-LOUD diagnostics for the items a user will actually
+  reach. A deleted overload carrying the migration beats `no member named X`.
+* W3.d — document the ADOPT-BOUNDED envelopes in the doc comments, starting
+  with `create_wall_timer` (period accuracy is the spin cadence, because the
+  timer is polled from `Node::pump()`, not driven by the executor).
+* W3.e — a gate: no adopted upstream name may lack a disposition, and no
+  `adopt` row may carry a known contract inversion.
+
+**Acceptance:** every upstream name we define either behaves or fails to
+compile. Demonstrated by an expected-failure probe per REFUSE-LOUD item, in the
+shape `check c` / `check cpp` already use.
+
+## Stage 4 — make our own three languages agree
+
+A per-language drop-in claim is undermined while our own surfaces disagree
+about the same capability. 37 such disagreements are catalogued; C++ is the odd
+one out in 15.
+
+* W4.a — parameters: setter, type query, undeclare, descriptors (ranges,
+  read-only) in all three.
+* W4.b — actions: a goal-id TYPE in C++ (`uint8_t[16]` today, so it cannot be
+  stored or compared); `succeed`/`abort`/`canceled` verbs; Rust's `cancel`
+  renamed to `canceled` with a deprecated forwarder.
+* W4.c — executor: `cancel`/`is_spinning` in all three (a C++ node cannot stop
+  spinning today without tearing down the session).
+* W4.d — logging: named loggers, per-logger levels, throttle, sinks. C and C++
+  have none of it; Rust has it but the façade does not re-export it, which is
+  why `std::println!` is the path of least resistance from the façade — fatal
+  on Zephyr native_sim (issue 0589).
+* W4.e — guard conditions: one owner and one creation shape. The ledger already
+  records this as undecided ("Nothing about no_std picks between these").
+
+## Stage 5 — C
+
+* W5.a — **typed subscription delivery.** rclc delivers a deserialised message
+  on a path with no allocator, by having the caller own the storage:
+  `rclc_executor_add_subscription(executor, subscription, void *msg, callback,
+  invocation)` with `void (*)(const void *)`. Ours has no `msg` slot and
+  delivers `(const uint8_t *, size_t)`. The generated `<Msg>_deserialize`
+  already writes into caller storage and the typed publish half already
+  shipped. Every ported callback body currently has to be rewritten, and the
+  ledger blames an allocator that rclc does not have either.
+* W5.b — `<nros/rcl_compat.h>` mapping `RCL_RET_*` onto ours. `nros_ret_t`'s
+  own doc says "Compatible with `rcl_ret_t` for familiarity"
+  (`nros_generated.h:840`) and only `OK` agrees: ours are −1/−2/−3/−7, rcl's
+  are 1/2/11/101. Map, do not renumber.
+* W5.c — the node and timer accessors filed as `gap`, all thin forwarders over
+  state the executor already holds.
+* W5.d — rclc-shaped preset constructors as `static inline` forwarders; rodata
+  only, retires ~18 declined rows.
+* W5.e — a typed service/client path; `service.h.jinja` generates only
+  `_get_type_name`/`_get_type_hash` today, so every C service in the tree is
+  raw bytes with hand-written CDR.
+
+## Stage 6 — the rename
+
+Only after stages 1–4. Mechanical once the shapes match.
+
+* W6.a — declare the ROS 2 spellings as first-class aliases IN the API headers;
+  delete `rclcpp_compat.hpp` as a separate file.
+* W6.b — `#error` when upstream rclcpp's include guard is already defined, so
+  the ODR collision RFC-0087 names is a compile error rather than a silent one.
+* W6.c — migrate the in-tree call sites (110 C++ and 75 C example files) and
+  the book.
+
+**Acceptance:** the compat shim is gone, ported templates still build, and no
+in-tree source names a spelling that upstream does not have — except where a
+disposition says why.
+
+## What this phase does NOT promise
+
+Not the whole rclcpp surface. Four upstream idioms account for most of what we
+decline and three are incompatible with ours by construction: the wait-set /
+`Waitable` executor (~128 rows, needs an allocator), runtime-queryable graph and
+middleware (~55, needs discovery), runtime type erasure (~45, needs a dynamic
+loader). The claim this phase can honestly reach is about PROGRAMS — the shapes
+a ROS 2 node is actually written in compile and behave, everything else fails
+loudly — and the in-tree ported templates are the measurement.

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -54,15 +54,19 @@ file. Roughly 75 lines total.
   dead code — one occurrence in all of `packages/api/`, its own definition.
   Unblocks `rclcpp::Publisher<T>::SharedPtr member_;`, which is close to
   universal in rclcpp source.
-* W1.b **[wrapper]** — emit `<pkg>/msg/<snake>.hpp` as an alias header including the
-  prefixed one. The name is already computed
-  (`packages/cli/rosidl-codegen/src/generator/cpp.rs:403`). Unblocks the FIRST
-  line of every ported file.
+* W1.b — **ALREADY DONE; verify and close.** `write_b8_alias_header`
+  (`packages/cli/cargo-nano-ros/src/lib.rs:1858`) is called from three sites
+  (`:1706,1748,1790`), and `rosidl-bindgen` has the same. This item was written
+  from the ledger, which measures the native API and cannot see generated
+  headers. Confirm on a fresh `nros sync` and strike it.
 * W1.c **[wrapper]** — `NROS_CPP_STD`-gated `std::string` interop on `FixedString<N>`
   (`operator=`, conversion, `operator==`), plus ungated `size()`/`empty()`.
 * W1.d **[wrapper]** — forward `now()`, `get_clock()`, `get_name()`, `get_namespace()` on the
   shim `Node`; alias `rclcpp::Time`/`Duration`/`Clock`. All four already exist
   on `nros::Node` (`node.hpp:217,223,249,260`).
+
+W1.a and W1.c also gate stages 6's lifecycle and action work, which hand
+entities back and therefore need the nested pointer types first.
 
 **Acceptance:** `examples/templates/cpp-port-minimal-publisher/` compiles with
 its source byte-identical to upstream's tutorial. Today its README claims
@@ -98,6 +102,15 @@ Where a real node stops being a tutorial. Each item is independently useful.
 **Acceptance:** a node that declares a parameter, calls a service and reads the
 clock compiles unmodified. Measured by a new ported template, not by inspection.
 
+## Stage 2b — graph forwarders **[wrapper]**, 18 rows
+
+`nros::Executor` already ships the whole graph surface — `get_node_names`,
+`count_publishers`/`count_subscribers`, the four `*_names_and_types_by_node`
+forms, `get_{publishers,subscriptions}_info_by_topic` (`executor.hpp:205-301`)
+over FFI that exists. The rows are open because `Node`/`LifecycleNode` do not
+forward to it, not because the capability is missing. Pure delegation, no new
+behaviour, and it needs a `TopicEndpointInfo` value type.
+
 ## Stage 3 — the loudness pass (the safety gate)
 
 RFC-0087's rule applied to everything already adopted. **This stage gates the
@@ -111,8 +124,17 @@ ways a ported program can compile and differ.
   runtime. Honour them on posix boards, or refuse the two-argument form.
   Honouring them is remap resolution — name construction, RFC-0020 violation
   class 4 — so the parser belongs beside `nros::resolve_name`, not in the shim.
-* W3.c — write the REFUSE-LOUD diagnostics for the items a user will actually
-  reach. A deleted overload carrying the migration beats `no member named X`.
+* W3.c — write the REFUSE-LOUD diagnostics. **69 rows collapse into 17
+  messages** — a refusal is per-concept, not per-symbol; the sixteen inert
+  `NodeOptions` setters share one. ~120 lines for the whole pass.
+* W3.f — **the two live inversions the shim already ships**, which a rename
+  would inherit: `ParametersQoS()` returns `QoS(10)` where upstream is
+  `KEEP_LAST, 1000` (`rclcpp_compat.hpp:117`), and ten `NodeOptions` setters
+  store their argument and are never read (`:125`, "intentionally inert
+  today"). Adopting the named QoS profiles at all is ADOPT **only** with each
+  profile's values transcribed from upstream and a table-driven test against
+  `rmw_qos_profile_*` — the shim already got two wrong, which is the evidence
+  for why the test is not optional.
 * W3.d — document the ADOPT-BOUNDED envelopes in the doc comments, starting
   with `create_wall_timer` (period accuracy is the spin cadence, because the
   timer is polled from `Node::pump()`, not driven by the executor).
@@ -166,6 +188,26 @@ one out in 15.
 * W5.e **[rust-first]** — a typed service/client path; `service.h.jinja` generates only
   `_get_type_name`/`_get_type_hash` today, so every C service in the tree is
   raw bytes with hand-written CDR.
+
+## The structural blocker the rename cannot paper over
+
+**Two spin worlds, and no compile signal.** The shim `rclcpp::Node` dispatches
+subscription callbacks and wall timers from its own `pump()`, driven only by
+`rclcpp::spin(node)` / `rclcpp::spin_some(node)`
+(`rclcpp_compat.hpp:428-451,454-470`). A ported file that instead calls
+`nros::spin_once()`, `nros::spin()`, or drives an `nros::Executor` directly —
+all of which are in the umbrella, all of which a mixed file plausibly reaches —
+gets **zero callbacks and no diagnostic**.
+
+Today the two node types have different names, which is the only thing making
+this visible at all. **After the rename they would have the same name**, so the
+rename makes it strictly worse. No message can be written for it: both spellings
+are legitimate, and which one is wrong depends on which node object the file
+holds.
+
+This is why the rename is gated on more than the loudness pass. The fix is
+structural — one node stack, the shim `Node` re-parented onto the arena-driven
+one rather than pumping its own — and it belongs before stage 6, not in it.
 
 ## Stage 6 — the rename
 

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -8,11 +8,21 @@ Goal: a ROS 2 node written against rclcpp / rclc / rclrs compiles and behaves
 against nano-ros, or fails loudly. End state is that our API carries ROS 2's
 names as first-class aliases and `rclcpp_compat.hpp` is gone.
 
-The ordering principle, from RFC-0087: **the rename is cheap and cosmetic; the
-compatibility is the work.** The rename lands last, after the shapes match,
-because before then it would relabel the gaps without closing one — and would
-spend the property that makes mismatches visible while the mismatches are still
-there.
+Two ordering principles, both from RFC-0087.
+
+**The rename is cheap and cosmetic; the compatibility is the work.** The rename
+lands last, after the shapes match, because before then it would relabel the
+gaps without closing one — and would spend the property that makes mismatches
+visible while the mismatches are still there.
+
+**The Rust API is the implementation source of truth** (RFC-0019/0020). Every
+item below carries *which layer implements this?*, and the order within an item
+is Rust → FFI slot → C → C++. Ergonomics — aliases, forwarders, diagnostics,
+conversions — may live in the wrapper; behaviour may not. Items marked
+**[wrapper]** are pure delegation over behaviour Rust already has and is the
+cheapest work here; items marked **[rust-first]** need the Rust side to grow
+before either wrapper can expose anything, and planning them as C/C++ tasks
+would mis-cost them by an order of magnitude.
 
 ## Stage 0 — measure the thing we are changing (issue 1020)
 
@@ -38,19 +48,19 @@ ported-file distance, and every `declined` row says what a porting user gets.
 Small, independent, and they unblock the first lines of nearly every ported
 file. Roughly 75 lines total.
 
-* W1.a — nested `SharedPtr` / `ConstSharedPtr` / `UniquePtr` on `Publisher`,
+* W1.a **[wrapper]** — nested `SharedPtr` / `ConstSharedPtr` / `UniquePtr` on `Publisher`,
   `Subscription`, `Service`, `Client`, `Timer`, and on `rclcpp::TimerBase`.
   `detail::SharedPtrTrait` (`rclcpp_compat.hpp:96`) was written for this and is
   dead code — one occurrence in all of `packages/api/`, its own definition.
   Unblocks `rclcpp::Publisher<T>::SharedPtr member_;`, which is close to
   universal in rclcpp source.
-* W1.b — emit `<pkg>/msg/<snake>.hpp` as an alias header including the
+* W1.b **[wrapper]** — emit `<pkg>/msg/<snake>.hpp` as an alias header including the
   prefixed one. The name is already computed
   (`packages/cli/rosidl-codegen/src/generator/cpp.rs:403`). Unblocks the FIRST
   line of every ported file.
-* W1.c — `NROS_CPP_STD`-gated `std::string` interop on `FixedString<N>`
+* W1.c **[wrapper]** — `NROS_CPP_STD`-gated `std::string` interop on `FixedString<N>`
   (`operator=`, conversion, `operator==`), plus ungated `size()`/`empty()`.
-* W1.d — forward `now()`, `get_clock()`, `get_name()`, `get_namespace()` on the
+* W1.d **[wrapper]** — forward `now()`, `get_clock()`, `get_name()`, `get_namespace()` on the
   shim `Node`; alias `rclcpp::Time`/`Duration`/`Clock`. All four already exist
   on `nros::Node` (`node.hpp:217,223,249,260`).
 
@@ -63,23 +73,27 @@ That claim becomes true or the stage is not done.
 
 Where a real node stops being a tutorial. Each item is independently useful.
 
-* W2.a — **one parameter store.** Today there are three arrangements: C has two
+* W2.a **[wrapper]** — **one parameter store.** Rust already has the single
+  store; this is thin-wrapper COMPLIANCE work, not new capability. Today there are three arrangements: C has two
   disjoint stores (issue 0793), C++'s `ComponentNode` owns a private
   `ParameterServer` and reads the executor store exactly once at boot under
   `#if defined(NROS_SYSTEM_PARAM_SERVICES)` (`component_node.hpp:536`), and
   Rust has one. Converge on the executor's, with node facades as views.
   Unfiled twin of 0793 on the C++ side; file it as part of this item.
-* W2.b — rclcpp-shaped `declare_parameter<T>` / `get_parameter<T>` /
+* W2.b **[wrapper]** — rclcpp-shaped `declare_parameter<T>` / `get_parameter<T>` /
   `set_parameter<T>` / `has_parameter` on the node reachable from the umbrella.
   The implementation exists at `component_node.hpp:568-659`; the blocker is
   that `nros.hpp` does not include `component_node.hpp` (15 of 46 headers are
   unreachable from the umbrella).
-* W2.c — `create_service` / `create_client` on the node; `async_send_request`
+* W2.c **[wrapper]** — `create_service` / `create_client` on the node; `async_send_request`
   returning something the existing `spin_until_future_complete` accepts.
   `nros::Client<S>` and `nros::Future` already exist.
-* W2.d — `rclcpp::Rate` / `WallRate` implemented over `nros::spin(remaining_ms,
-  poll_ms)` (`nros.hpp:175`), which drives the executor and is therefore
-  RFC-0021-compliant by construction rather than by exception.
+* W2.d **[wrapper, carefully]** — `rclcpp::Rate` / `WallRate` as a FORWARDER
+  onto `nros::spin(remaining_ms, poll_ms)` (`nros.hpp:175`), which drives the
+  executor. The obvious fifteen-line C++ class with its own sleep loop is both
+  RFC-0020 violation class 2 (a polling loop that spins the executor from
+  inside the wrapper) and the thing RFC-0021 forbids. Same capability, and only
+  one of the two shapes is admissible.
 
 **Acceptance:** a node that declares a parameter, calls a service and reads the
 clock compiles unmodified. Measured by a new ported template, not by inspection.
@@ -92,9 +106,11 @@ ways a ported program can compile and differ.
 
 * W3.a — issue 1019: `RCLCPP_*_STREAM` discards its message; the family routes
   to a sink that is a no-op on every embedded target. Fix or refuse loudly.
-* W3.b — `rclcpp::init(argc, argv)` drops `--ros-args` silently
-  (`rclcpp_compat.hpp:238`), turning a remap into a wrong-topic bug at runtime.
-  Honour them on posix boards, or refuse the two-argument form.
+* W3.b **[rust-first]** — `rclcpp::init(argc, argv)` drops `--ros-args`
+  silently (`rclcpp_compat.hpp:238`), turning a remap into a wrong-topic bug at
+  runtime. Honour them on posix boards, or refuse the two-argument form.
+  Honouring them is remap resolution — name construction, RFC-0020 violation
+  class 4 — so the parser belongs beside `nros::resolve_name`, not in the shim.
 * W3.c — write the REFUSE-LOUD diagnostics for the items a user will actually
   reach. A deleted overload carrying the migration beats `no member named X`.
 * W3.d — document the ADOPT-BOUNDED envelopes in the doc comments, starting
@@ -113,39 +129,41 @@ A per-language drop-in claim is undermined while our own surfaces disagree
 about the same capability. 37 such disagreements are catalogued; C++ is the odd
 one out in 15.
 
-* W4.a — parameters: setter, type query, undeclare, descriptors (ranges,
+* W4.a **[wrapper]** — parameters: setter, type query, undeclare, descriptors (ranges,
   read-only) in all three.
-* W4.b — actions: a goal-id TYPE in C++ (`uint8_t[16]` today, so it cannot be
+* W4.b **[mixed]** — actions: a goal-id TYPE in C++ (`uint8_t[16]` today, so it cannot be
   stored or compared); `succeed`/`abort`/`canceled` verbs; Rust's `cancel`
   renamed to `canceled` with a deprecated forwarder.
-* W4.c — executor: `cancel`/`is_spinning` in all three (a C++ node cannot stop
+* W4.c **[wrapper]** — executor: `cancel`/`is_spinning` in all three (a C++ node cannot stop
   spinning today without tearing down the session).
-* W4.d — logging: named loggers, per-logger levels, throttle, sinks. C and C++
+* W4.d **[wrapper]** — logging: named loggers, per-logger levels, throttle, sinks. C and C++
   have none of it; Rust has it but the façade does not re-export it, which is
   why `std::println!` is the path of least resistance from the façade — fatal
   on Zephyr native_sim (issue 0589).
-* W4.e — guard conditions: one owner and one creation shape. The ledger already
+* W4.e **[rust-first]** — guard conditions: one owner and one creation shape. The ledger already
   records this as undecided ("Nothing about no_std picks between these").
 
 ## Stage 5 — C
 
-* W5.a — **typed subscription delivery.** rclc delivers a deserialised message
+* W5.a **[rust-first]** — **typed subscription delivery.** rclc delivers a deserialised message
   on a path with no allocator, by having the caller own the storage:
   `rclc_executor_add_subscription(executor, subscription, void *msg, callback,
   invocation)` with `void (*)(const void *)`. Ours has no `msg` slot and
   delivers `(const uint8_t *, size_t)`. The generated `<Msg>_deserialize`
   already writes into caller storage and the typed publish half already
   shipped. Every ported callback body currently has to be rewritten, and the
-  ledger blames an allocator that rclc does not have either.
-* W5.b — `<nros/rcl_compat.h>` mapping `RCL_RET_*` onto ours. `nros_ret_t`'s
+  ledger blames an allocator that rclc does not have either. The FFI needs an
+  `add_subscription` variant carrying caller-owned storage before C can expose
+  anything, so this is Rust work with a C surface, not C work.
+* W5.b **[wrapper]** — `<nros/rcl_compat.h>` mapping `RCL_RET_*` onto ours. `nros_ret_t`'s
   own doc says "Compatible with `rcl_ret_t` for familiarity"
   (`nros_generated.h:840`) and only `OK` agrees: ours are −1/−2/−3/−7, rcl's
   are 1/2/11/101. Map, do not renumber.
-* W5.c — the node and timer accessors filed as `gap`, all thin forwarders over
+* W5.c **[wrapper]** — the node and timer accessors filed as `gap`, all thin forwarders over
   state the executor already holds.
-* W5.d — rclc-shaped preset constructors as `static inline` forwarders; rodata
+* W5.d **[wrapper]** — rclc-shaped preset constructors as `static inline` forwarders; rodata
   only, retires ~18 declined rows.
-* W5.e — a typed service/client path; `service.h.jinja` generates only
+* W5.e **[rust-first]** — a typed service/client path; `service.h.jinja` generates only
   `_get_type_name`/`_get_type_hash` today, so every C service in the tree is
   raw bytes with hand-written CDR.
 
@@ -163,6 +181,16 @@ Only after stages 1–4. Mechanical once the shapes match.
 **Acceptance:** the compat shim is gone, ported templates still build, and no
 in-tree source names a spelling that upstream does not have — except where a
 disposition says why.
+
+## The cheapest work is wrapper work, and there is a lot of it
+
+Of the 37 capabilities where our own three surfaces disagree, roughly half are
+ones **Rust already has and one or both wrappers never exposed** — named
+loggers and per-logger levels, parameter type queries, undeclare, descriptors
+and ranges, QoS equality, GID attribution, name resolution. The behaviour
+exists and is tested; the wrapper is a forwarder. Under RFC-0019 that is both
+the cheapest work in this phase and the work that reduces the most divergence
+per line, which is why stage 4 is not deferred behind the C-side stages.
 
 ## What this phase does NOT promise
 

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -323,12 +323,33 @@ and the two must not be run as separate passes.
   **including the `nros_node_init` reorder in the same pass**. Rename and
   reorder must not be separate passes: the rename is what makes a missed
   reorder fail to compile.
-* **W-B3 [cpp]** — `nros::` → `rclcpp::` across 645 sites / 119 files.
+* **W-B3 [cpp]** — **LANDED, and the survey was wrong.** Not 645 pure renames:
+  measured 697 code occurrences over 120 files, of which only **288 (41 %) are
+  pure renames**. 409 stay `nros::`, and the reason is the campaign's own rule
+  rather than effort:
+  * `nros::Node` — **109 sites, 103 files**. `rclcpp::Node` is a DISTINCT CLASS,
+    not an alias: `make_shared` + shared_ptr-returning `create_publisher<M>`
+    against ours' out-ref `create_node(node, …)`. It is also hosted-only, so it
+    does not exist on the freestanding targets most of those files build for.
+  * `nros::init` (13) — `rclcpp::init()` returns **void**; every call site
+    consumes our `Result`. Renaming drops the error check.
+  * `nros::Timer` (28), `nros::spin_once` (32) — no counterpart with that
+    contract.
+  * ~200 more with no `rclcpp::` counterpart at all: the `bind_*` family,
+    `create_node`, `Seq`/`HeapString`, `GoalResponse`/`CancelResponse`/
+    `GoalStatus`, the whole lifecycle set (there is no `rclcpp_lifecycle`
+    namespace in our headers).
+
+* **W-B5 [retire] — PRECONDITION, added after W-B3 measured it.** The C
+  forwarders (43 names) and the five Rust logging forwarders CAN go: every one
+  has a live replacement. The C++ `nros::` spellings for `Node`, `init`,
+  `Timer`, `spin_once`, lifecycle and the action-response enums **cannot** —
+  deleting them removes a capability rather than a spelling. Retiring those
+  waits on the node-type merge that `nros.hpp`'s own comment defers to "a later
+  step".
 * **W-B4 [docs]** — 57 files in `book/` and `docs/` naming an old spelling in
   prose or a code block. No compiler checks these.
-* **W-B5 [retire]** — delete the 110 `NROS_DEPRECATED_MSG` forwarders across 12
-  headers, the five Rust forwarders, and the feature flag. Last, and only after
-  W-B1..4 are green.
+
 * **W-B6 [changelog]** — one entry, carrying phase-379 W7 step 4's two
   warnings.
 

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -271,6 +271,78 @@ exists and is tested; the wrapper is a forwarder. Under RFC-0019 that is both
 the cheapest work in this phase and the work that reduces the most divergence
 per line, which is why stage 4 is not deferred behind the C-side stages.
 
+## Stage 6 step B — surveyed 2026-09-04, its own PR
+
+Step A landed: the ROS 2 spellings are first-class, `rclcpp_compat.hpp` is
+deleted, and every `rcl_compat.h` FUNCTION alias became an identity and was
+deleted with it. Step B retires the old spellings. **It is the only irreversible
+step for an out-of-tree consumer**, so it is one batch, one PR, one changelog
+entry — never opportunistic.
+
+### The size, measured rather than estimated
+
+| surface | sites | files | shape |
+| --- | ---: | ---: | --- |
+| Rust logging macros | 208 | 50 | pure rename |
+| C symbols (43 deprecated names) | 206 | 40 | pure rename, **except the one below** |
+| C++ `nros::` → `rclcpp::` | 645 | 119 | pure rename |
+| docs / book | — | 57 | prose + code blocks |
+| the forwarders themselves | 110 | 12 headers | deletion |
+
+Largest concentrations: `examples/native/{c,rust}` (27 files), the five RTOS
+example families (25), `packages/testing/nros-tests` (12).
+
+### One site is not mechanical, and it is the whole risk
+
+`nros_node_init` is the single argument REORDER in the campaign:
+
+```
+nros_node_init        (node, support, name, namespace_)     <- 42 call sites
+rclc_node_init_default(node, name, namespace_, support)
+```
+
+A sweep that renames without reordering produces code that **compiles with a
+warning and passes the wrong values** — C diagnoses an incompatible pointer
+argument as a warning even under `-Wall -Wextra`, which is the measurement that
+forced RFC-0087's "a C reorder ships with a rename beside it". Here the rename
+IS the guard: the old identifier disappears, so a missed site fails to compile
+rather than silently mis-binding.
+
+Surveyed for tractability: **all 42 are single-line, zero multi-line**, and the
+shape is uniform (`nros_node_init(&x, &y, "name", "/")`). So a regex codemod is
+honest here — but it must be a codemod that reorders, not a `sed s/old/new/`,
+and the two must not be run as separate passes.
+
+### Order, and why
+
+1. **Flip `nros-log/deprecate-legacy-names`.** The workspace sets
+   `warnings = "deny"`, so arming the attribute turns all 208 Rust sites into
+   hard errors at once. That is the point: it enumerates the work rather than
+   trusting a grep.
+2. **Migrate Rust, then C, then C++.** Each is a rename; the compiler names
+   every site.
+3. **The `node_init` codemod, alone, with its own review.** Not folded into the
+   C rename sweep — it is the one change where a mistake is silent.
+4. **Docs and book.** `just book` builds them; a stale code block is not caught
+   by any compiler.
+5. **Delete the forwarders** — 110 `NROS_DEPRECATED_MSG` declarations across 12
+   headers, plus the five Rust forwarders, plus the feature flag itself.
+6. **Changelog entry**, carrying phase-379 W7 step 4's two warnings: C cannot
+   portably deprecate a `typedef`, so renamed C TYPES disappear with no warning
+   for anyone who never rebuilt; and a defaulted trait method's alias is weaker
+   than it looks, because an out-of-tree override is silently ignored.
+
+### Acceptance
+
+* every in-tree source builds with `deprecate-legacy-names` ON and zero
+  forwarders present;
+* `examples/templates/cpp-port-minimal-publisher` still byte-identical to
+  upstream's tutorial;
+* `rcl_compat.h` holds only the `RCL_RET_*` mapping and handle typedefs — the
+  two things RFC-0087 says cannot dissolve;
+* `just ci gate` green, and the ported templates build with **every** compat
+  layer deleted.
+
 ## Correction track — the ledger says false things, and they misdirect
 
 The measurement is the campaign's instrument; a wrong row is worse than a

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -5,8 +5,14 @@ started. Stage 0 is a prerequisite for measuring any of the others, so it is
 also the first thing to land.
 
 Goal: a ROS 2 node written against rclcpp / rclc / rclrs compiles and behaves
-against nano-ros, or fails loudly. End state is that our API carries ROS 2's
-names as first-class aliases and `rclcpp_compat.hpp` is gone.
+against nano-ros, or fails loudly. **End state is that our API carries ROS 2's
+names** — `nros::` stops being the spelling a user writes — and
+`rclcpp_compat.hpp` is gone because its content moved into the headers it was
+shimming.
+
+This phase is also the **home for every correction, migration and retirement
+job** in the API campaign: the tracks are listed below, and each names its
+issue. An issue with no work item is an issue nobody is accountable for.
 
 Two ordering principles, both from RFC-0087.
 
@@ -209,19 +215,37 @@ This is why the rename is gated on more than the loudness pass. The fix is
 structural — one node stack, the shim `Node` re-parented onto the arena-driven
 one rather than pumping its own — and it belongs before stage 6, not in it.
 
-## Stage 6 — the rename
+## Stage 6 — the rename, in two steps
 
-Only after stages 1–4. Mechanical once the shapes match.
+Only after stages 1–5 and the structural blocker above. Mechanical once the
+shapes match; the two steps exist so the irreversible half happens once.
 
-* W6.a — declare the ROS 2 spellings as first-class aliases IN the API headers;
-  delete `rclcpp_compat.hpp` as a separate file.
-* W6.b — `#error` when upstream rclcpp's include guard is already defined, so
-  the ODR collision RFC-0087 names is a compile error rather than a silent one.
-* W6.c — migrate the in-tree call sites (110 C++ and 75 C example files) and
-  the book.
+**Step A — alias (reversible).**
+
+* W6.a — declare the ROS 2 spellings as first-class names IN the API headers;
+  delete `rclcpp_compat.hpp` as a separate file. Both spellings work.
+* W6.b — `#error` when upstream rclcpp's include guard is already defined. Not
+  because we expect a build to link both — we do not, they interoperate over
+  the wire and the host tooling is a separate process — but because the guard
+  is one line and the failure it prevents is silent.
+
+**Step B — replace (irreversible for out-of-tree consumers).**
+
+* W6.c — deprecate `nros::` / `nros_` spellings, per the settled policy:
+  `NROS_DEPRECATED_MSG` static inline for C, `[[deprecated("…")]]` for C++,
+  and nothing for Rust trait methods (a rename there breaks implementors, and
+  a compile error is what a backend author wants).
+* W6.d — migrate the in-tree call sites: **110 C++ and 75 C example files**,
+  the six compat-built templates, and the book.
+* W6.e — remove the deprecated spellings as ONE batch, with a changelog entry.
+  Carry phase-379 W7 step 4's two warnings: **C cannot portably deprecate a
+  `typedef`** (MSVC rejects the attribute, `[[deprecated]]` is C23), so renamed
+  C types disappear silently for anyone who never rebuilt; and a defaulted
+  trait method's alias is weaker than it looks, because an out-of-tree
+  override is silently ignored rather than warned.
 
 **Acceptance:** the compat shim is gone, ported templates still build, and no
-in-tree source names a spelling that upstream does not have — except where a
+in-tree source names a spelling upstream does not have — except where a
 disposition says why.
 
 ## The cheapest work is wrapper work, and there is a lot of it
@@ -233,6 +257,75 @@ and ranges, QoS equality, GID attribution, name resolution. The behaviour
 exists and is tested; the wrapper is a forwarder. Under RFC-0019 that is both
 the cheapest work in this phase and the work that reduces the most divergence
 per line, which is why stage 4 is not deferred behind the C-side stages.
+
+## Correction track — the ledger says false things, and they misdirect
+
+The measurement is the campaign's instrument; a wrong row is worse than a
+missing one because it forecloses the fix. Three issues, ~140 rows, no code.
+
+* **W-C1 — issue 1012** (15 rows): prose names a symbol a rename retired.
+  Fifteen describe the CURRENT tree with a dead spelling; a further 21 name one
+  legitimately (a deprecated-alias row must). The distinguishing property is
+  tense, which is why a sweep on the spelling alone breaks the correct ones.
+  The issue's durable half — whether to gate it — needs the tense made
+  machine-readable first.
+* **W-C2 — issue 1022** (~95 rows): prose states something FALSE about our own
+  code. "There is no runtime options struct" where seven ship;
+  `nros_borrowed_str_t` for `nros_view_str_t`; `get_actual_qos` "would return
+  its own input" when `set_qos_overrides` makes it differ; `cpp:` rows
+  answering in C spellings; ~14 rows verdicted `declined` whose own prose
+  describes a capability we have under another name.
+* **W-C3 — issue 1022's systematic half**: a divergence justified by a
+  constraint the compared surface refutes. Byte-oriented delivery is blamed on
+  "no allocator"; rclc has no allocator on that path either and delivers typed
+  by making the caller own the storage. RFC-0036 forbids recording a preference
+  as a divergence and has no rule against recording a real divergence under a
+  false cause. Closing W-C3 means adding one.
+
+## Migration track — what moves, and in what order
+
+Inherited from phase-379 W7, which owns steps 1–3 and is in flight. This phase
+owns what follows.
+
+* **W-M1** — 379 W7 steps 1–3 (collapse landed rows, execute the W6 verb
+  decisions, the remaining open rows). **Stays homed in 379**; listed here so
+  the sequence is readable end to end.
+* **W-M2** — the disposition pass: every upstream item gets adopt /
+  adopt-bounded / refuse-loud / absent (stage 0 W0.b), because a `declined` row
+  that does not say what a porting user GETS is not actionable.
+* **W-M3** — stages 1–5 above, in dependency order.
+* **W-M4** — stage 6 step A (alias), then step B (replace).
+
+## Retirement track — irreversible, batched, once
+
+* **W-R1 — phase-379 W7 step 4**, in flight there: the `nros_param_*` family
+  (25 forwarders), the service reply verbs, the QoS `*_raw()`/`*_ms()`
+  accessors, `BoardConfig::zenoh_locator` and `ThreadxConfig::zenoh_locator`,
+  the five `with_zenoh_locator()` builders.
+* **W-R2 — `rclcpp_compat.hpp` itself** (stage 6 step A). Not a deletion of
+  capability: its content moves into the headers. What retires is the file and
+  the force-include.
+* **W-R3 — the `nros::` / `nros_` spellings** (stage 6 step B). The only step
+  in this phase that breaks an out-of-tree consumer who did nothing wrong.
+
+Retirement happens once per batch, deliberately, with a changelog entry — never
+opportunistically as each rename lands. That rule is phase-379's and it carries
+forward unchanged.
+
+## Issues homed here
+
+Every issue this phase owns, with what closing it means. A mention is not an
+owner.
+
+| issue | track | closing it means |
+| --- | --- | --- |
+| 1012 | correction | 15 rows re-worded; a decision on whether tense becomes machine-readable |
+| 1019 | correction + loudness (W3.a) | `RCLCPP_*` reaches `nros_log` on embedded, or refuses; `_STREAM` stops discarding its message |
+| 1020 | stage 0 | the C++ lane sees the compat shim; native-API distance and ported-file distance are distinguishable |
+| 1022 | correction | ~95 rows corrected; RFC-0036 gains the rule that a divergence's cause must not be one the compared surface also operates under |
+| 0793 | stage 2 (W2.a) | one parameter store in C; the unfiled C++ twin filed and fixed with it |
+| 0829 | stage 5 | `SYSTEM_DEFAULT` stops disagreeing with itself; folds into the named-profile transcription |
+| 0589 | stage 4 (W4.d) | the façade re-exports `nros_log`, so it is the easy path rather than `std::println!` |
 
 ## What this phase does NOT promise
 

--- a/docs/roadmap/phase-417-ros2-api-adoption.md
+++ b/docs/roadmap/phase-417-ros2-api-adoption.md
@@ -1,6 +1,6 @@
 # Phase 417 — ROS 2 user-API adoption
 
-**Status (2026-09-04). In flight. Implements RFC-0087.** Stages 0, 1 and 2b are
+**Status (2026-09-04). In flight. Implements RFC-0089.** Stages 0, 1 and 2b are
 LANDED, and so is the correction track (issues 1012 and 1022 resolved, 92 rows).
 Stage 1's acceptance is met: `cpp-port-minimal-publisher/src/minimal_publisher.cpp`
 is upstream's file again. Stages 2 (node surface), 3 (loudness), 4 (cross-language)
@@ -27,7 +27,7 @@ This phase is also the **home for every correction, migration and retirement
 job** in the API campaign: the tracks are listed below, and each names its
 issue. An issue with no work item is an issue nobody is accountable for.
 
-Two ordering principles, both from RFC-0087.
+Two ordering principles, both from RFC-0089.
 
 **The rename is cheap and cosmetic; the compatibility is the work.** The rename
 lands last, after the shapes match, because before then it would relabel the
@@ -56,7 +56,7 @@ about the native API rather than about what a ported file reaches.
   native API" and "what does a ported file hit" one surface or two; how is the
   shim's std-only reachability marked.
 * W0.b — add a `disposition` field to the ledger (adopt / adopt-bounded /
-  refuse-loud / absent) per RFC-0087's consequence section, and a gate that a
+  refuse-loud / absent) per RFC-0089's consequence section, and a gate that a
   `declined` row declares one.
 
 **Acceptance:** the C++ report distinguishes native-API distance from
@@ -132,7 +132,7 @@ behaviour, and it needs a `TopicEndpointInfo` value type.
 
 ## Stage 3 — the loudness pass (the safety gate)
 
-RFC-0087's rule applied to everything already adopted. **This stage gates the
+RFC-0089's rule applied to everything already adopted. **This stage gates the
 rename**: until it is done, taking more upstream names increases the number of
 ways a ported program can compile and differ.
 
@@ -304,7 +304,7 @@ rclc_node_init_default(node, name, namespace_, support)
 A sweep that renames without reordering produces code that **compiles with a
 warning and passes the wrong values** — C diagnoses an incompatible pointer
 argument as a warning even under `-Wall -Wextra`, which is the measurement that
-forced RFC-0087's "a C reorder ships with a rename beside it". Here the rename
+forced RFC-0089's "a C reorder ships with a rename beside it". Here the rename
 IS the guard: the old identifier disappears, so a missed site fails to compile
 rather than silently mis-binding.
 
@@ -379,7 +379,7 @@ and the two must not be run as separate passes.
 * `examples/templates/cpp-port-minimal-publisher` still byte-identical to
   upstream's tutorial;
 * `rcl_compat.h` holds only the `RCL_RET_*` mapping and handle typedefs — the
-  two things RFC-0087 says cannot dissolve;
+  two things RFC-0089 says cannot dissolve;
 * `just ci gate` green, and the ported templates build with **every** compat
   layer deleted.
 


### PR DESCRIPTION
**Splits #329.** That branch is 33 commits and 51 behind main; it has been rebased three times today, and each rebase costs a parity-ledger merge with clashes adjudicated by hand. This is the half that does not need to be in that branch.

## What is here

**17 commits, cherry-picked in order, every one of them `docs/`-only** — the RFC-0089 design track (what has to be true before our API takes ROS 2's names; the disposition split; rename as the end state; C takes rcl's spellings; the argument-order and reorder-hazard corrections; the RFC-0041 retraction), plus the phase-417 records and three issue notes.

They apply to `main` with **zero conflicts**. `just check fast`: 225 gates, 0 failed.

## What is not here

The other 16 commits touch `packages/`, `just/`, `scripts/`, `cmake/compat/` and ~150 example directories. They stay in #329 because they are genuinely one change: the mass rename (`refactor(#417): adopt rcl/rclcpp/rclrs spellings at call sites across all three languages`) does not compile half-applied, and the parity-ledger rows that go with it are only true once it lands.

**Two commits declined the cherry-pick and that is the right answer** — `docs: ledger the three public names main added in parallel` and `fix(ledger): merge three rows main and this branch each authored independently`. Both are merge repairs against a main that has since absorbed what they were reconciling. They belong with the code, or nowhere.

## One thing the split forced

These 17 were filed while this branch's RFC was numbered **0087**; main filed its own RFC-0087 (package identity) four hours earlier, and the renumber to 0089 happens later on the branch **inside commits that also carry code**. So extracting the design half reproduces the collision, and `check-issue-ids` catches it.

The renumber is applied here as its own commit, and **scoped rather than blanket-replaced**: `RFC-0087` is now a real id belonging to somebody else's document, so a tree-wide substitution would rewrite references to it. Confined to the filename (one `docs/design/README.md` row) and to `RFC-0087` inside this branch's own two files. The README row needed both halves — the link target *and* the id column, which had kept `0087` while pointing at `0089-`.

## Why bother

#329's conflict surface is the parity ledger and the phase docs. Landing the docs half now removes most of the second, and leaves a branch whose remaining conflicts are all in one file with one merge rule — which is a branch that can be rebased mechanically instead of adjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj