### PR TITLE
fix(#1111): the generated cmake root says where the workspace's own msg packages are

### DIFF
--- a/docs/issues/archived/1111-generated-root-omits-interface-search-path.md
+++ b/docs/issues/archived/1111-generated-root-omits-interface-search-path.md
@@ -1,0 +1,89 @@
+---
+id: 1111
+title: "The generated cmake root never sets `NROS_INTERFACE_SEARCH_PATH`, so a C++ node consuming its own workspace's msg package fails `find_package` with a raw cmake error"
+status: resolved
+type: bug
+area: cli, tooling
+severity: medium
+found: 2026-09-06
+related: [0862, 1107, 1108]
+---
+
+# The builder knows the answer and does not say it
+
+A workspace with an in-workspace interface package consumed by a C++ node
+cannot be built by `nros build` on a clean shell:
+
+```
+CMake Error at src/heartbeat_pkg/CMakeLists.txt:9 (find_package):
+  By not providing "Findspe_msgs.cmake" in CMAKE_MODULE_PATH this project has
+  asked CMake to find a package configuration file provided by "spe_msgs",
+  but CMake did not find one.
+```
+
+Export `NROS_INTERFACE_SEARCH_PATH=<ws>/src` and the same command succeeds:
+
+```
+-- nros: find_package(spe_msgs) -> .../src/spe_msgs
+[100%] Built target linux_entry
+```
+
+## Why
+
+An interface package is deliberately NOT a subdir of the generated root —
+`builder/cmake_root.rs` says so at the discovery loop (issue 0862): its
+CMakeLists is verbatim upstream ROS, nano-ros never configures it, and
+`nros sync` routes `rosidl_generate_interfaces` through the codegen pipeline
+instead.
+
+So a component's `find_package(<pkg>)` resolves through the compat layer's
+auto-emitted Find-stub, which scans `NROS_INTERFACE_SEARCH_PATH`.
+`cmake/NanoRosGenerateInterfaces.cmake` documents the shape, including that the
+ordering matters:
+
+```cmake
+set(NROS_INTERFACE_SEARCH_PATH "${CMAKE_SOURCE_DIR}/src")
+# MUST precede `find_package(nano_ros)`
+```
+
+The hand-written roots set it. **The generated root did not** — `grep -c
+NROS_INTERFACE_SEARCH_PATH` over a generated root returned 0 — and
+`nano_ros_workspace()` does not set it either. The only two callers of
+`nros_workspace_interfaces()` in the tree are templates with hand-written roots.
+
+## Not "unsupported" — unstated
+
+`nros ws env` exists and prints the export, so a user who knows to run
+`eval "$(nros ws env)"` is fine. Two things make it a defect anyway:
+
+1. **The builder already knows the workspace root.** It writes `WORKSPACE_ROOT`
+   into the same file three lines later. Leaving the answer to the caller's
+   environment is the shape CLAUDE.md rejects for knobs: a value that arrives
+   through a dependency edge cannot be poisoned by an ambient variable, and one
+   that arrives through the environment can.
+2. **The error names neither the cause nor the remedy.** It is cmake's generic
+   `find_package` failure. Nothing in it mentions interface packages, the search
+   path, or `nros ws env`.
+
+## Fix
+
+The emitter sets it, immediately before `find_package(nano_ros)`, from the
+workspace root it already computes. It **prepends** rather than assigns, so a
+caller who has sourced `nros ws env` — or who points at an out-of-workspace
+package tree — keeps their entry and its precedence, since the search path's
+shadowing rule is that earlier roots win.
+
+Guarded by `the_interface_search_path_precedes_find_package_nano_ros` in
+`builder/cmake_root.rs`, beside the test that pins the toolchain-before-project
+ordering, which is the same class of bug — a value set after the thing that
+reads it is a value nobody used. Mutation-tested both ways: moving the block
+after `find_package(nano_ros)` fails it, and assigning instead of prepending
+fails it.
+
+## How it was found
+
+Building a first out-of-tree consumer
+([`orin-spe-heartbeat`](https://github.com/jerry73204/orin-spe-heartbeat)),
+whose C++ node publishes its own workspace's message type. Every in-tree
+workspace with that shape (`examples/workspaces/features`) is exercised through
+fixture rows that carry a `codegen_out` step, so the gap did not surface there.

--- a/packages/cli/nros-cli-core/src/builder/cmake_root.rs
+++ b/packages/cli/nros-cli-core/src/builder/cmake_root.rs
@@ -260,6 +260,45 @@ pub fn render(
         );
     }
 
+    // Issue 1111 — where a C++ package finds a WORKSPACE-LOCAL interface
+    // package.
+    //
+    // An interface package is deliberately NOT a subdir (see the loop above,
+    // issue 0862), so a component's `find_package(my_msgs REQUIRED)` resolves
+    // through the compat layer's Find-stub, which scans
+    // `NROS_INTERFACE_SEARCH_PATH`. The hand-written roots set it — the
+    // documented shape in `NanoRosGenerateInterfaces.cmake` is
+    // `set(NROS_INTERFACE_SEARCH_PATH "${CMAKE_SOURCE_DIR}/src")` — and this
+    // emitter did not, so a workspace whose C++ node consumes its own msg
+    // package configured fine with `nros ws env` sourced and failed with a raw
+    // cmake "Could not find a package configuration file provided by
+    // <pkg>" without it. The builder knows the workspace root (it writes
+    // WORKSPACE_ROOT below), so it can answer the question rather than leaving
+    // it to the caller's environment — which is also the rule the tree already
+    // follows for knobs: a value that arrives through a dependency edge cannot
+    // be poisoned by an ambient variable.
+    //
+    // MUST precede `find_package(nano_ros)`: the compat layer reads this while
+    // it is being included, and the ordering is the hand-written roots' own.
+    //
+    // Prepends rather than assigns, so a caller who HAS sourced
+    // `nros ws env` (or set it for an out-of-workspace package tree) keeps
+    // their entry and its precedence — earlier roots win the shadowing order.
+    let src_rel = super::paths::relative_or_err(manifest_dir, &spec.workspace.join("src"))?;
+    out.push_str(&format!(
+        "# Issue 1111 — the workspace's own interface packages. Prepended, so an\n\
+         # entry the caller already exported keeps its precedence.\n\
+         get_filename_component(_nros_ws_src \"{src_rel}\" ABSOLUTE)\n\
+         if(EXISTS \"${{_nros_ws_src}}\")\n\
+         \x20   if(DEFINED ENV{{NROS_INTERFACE_SEARCH_PATH}})\n\
+         \x20       set(NROS_INTERFACE_SEARCH_PATH\n\
+         \x20           \"${{_nros_ws_src}};$ENV{{NROS_INTERFACE_SEARCH_PATH}}\")\n\
+         \x20   else()\n\
+         \x20       set(NROS_INTERFACE_SEARCH_PATH \"${{_nros_ws_src}}\")\n\
+         \x20   endif()\n\
+         endif()\n\n"
+    ));
+
     out.push_str("find_package(nano_ros REQUIRED COMPONENTS workspace)\n");
     out.push('\n');
 
@@ -407,6 +446,51 @@ mod tests {
         let a = body.find("aaa_pkg").unwrap();
         let z = body.find("zzz_pkg").unwrap();
         assert!(a < z, "sorted: {body}");
+    }
+
+    #[test]
+    fn the_interface_search_path_precedes_find_package_nano_ros() {
+        // Issue 1111. An interface package is not a subdir, so a component's
+        // `find_package(my_msgs)` resolves through the compat layer's
+        // Find-stub, which reads `NROS_INTERFACE_SEARCH_PATH`. The layer reads
+        // it while it is being INCLUDED, so a value set after
+        // `find_package(nano_ros)` is a value nobody used — the same shape as
+        // the toolchain-after-project() bug below.
+        //
+        // Compares LINE positions among non-comment lines: the explanatory
+        // comment above the block names `find_package(nano_ros)`, and a naive
+        // substring search matches that first.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let d = discovered(vec![pkg(root, "a_pkg", true)]);
+        let body = render(&d, &root.join("build/posix"), &spec(root)).expect("renders");
+        let code: Vec<&str> = body
+            .lines()
+            .filter(|l| !l.trim_start().starts_with('#'))
+            .collect();
+        let set = code
+            .iter()
+            .position(|l| l.contains("set(NROS_INTERFACE_SEARCH_PATH"))
+            .unwrap_or_else(|| panic!("the root must set the search path: {body}"));
+        let fp = code
+            .iter()
+            .position(|l| l.contains("find_package(nano_ros"))
+            .unwrap_or_else(|| panic!("no find_package(nano_ros): {body}"));
+        assert!(
+            set < fp,
+            "NROS_INTERFACE_SEARCH_PATH must precede find_package(nano_ros): {body}"
+        );
+        // Workspace-relative, never absolute (W3.c) — the file must stay
+        // byte-identical across machines.
+        assert!(
+            !body.contains(root.to_str().unwrap()),
+            "no absolute path: {body}"
+        );
+        // An entry the caller already exported keeps its precedence.
+        assert!(
+            body.contains("$ENV{NROS_INTERFACE_SEARCH_PATH}"),
+            "must prepend to, not clobber, a caller's value: {body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Found by building a first out-of-tree consumer rather than by reading the tree.

A workspace whose C++ node consumes its **own** interface package cannot be built by `nros build` on a clean shell:

```
CMake Error at src/heartbeat_pkg/CMakeLists.txt:9 (find_package):
  Could not find a package configuration file provided by "spe_msgs"
```

Export `NROS_INTERFACE_SEARCH_PATH=<ws>/src` and the same command succeeds.

## Why

An interface package is **deliberately** not a subdir of the generated root (issue 0862) — its CMakeLists is verbatim upstream ROS, nano-ros never configures it, and `nros sync` routes `rosidl_generate_interfaces` through codegen instead. So `find_package(<pkg>)` resolves through the compat layer's auto-emitted Find-stub, which scans `NROS_INTERFACE_SEARCH_PATH`.

`NanoRosGenerateInterfaces.cmake` documents the variable *and* that setting it **must precede `find_package(nano_ros)`**, because the layer reads it while being included.

The hand-written roots set it. This emitter did not, and `nano_ros_workspace()` doesn't either — the only two callers of `nros_workspace_interfaces()` in the tree are templates with hand-written roots. The migration to a generated root dropped a line that was load-bearing for exactly one workspace shape, and no in-tree workspace has that shape outside fixture rows carrying a `codegen_out` step.

## Not "unsupported" — unstated

`nros ws env` prints the export, so a user who knows to run `eval "$(nros ws env)"` is fine. It's a defect anyway:

1. **The builder already knows the workspace root** — it writes `WORKSPACE_ROOT` into the same file three lines later. Leaving the answer to the caller's environment is the shape CLAUDE.md rejects for knobs.
2. **The error names neither cause nor remedy** — cmake's generic `find_package` failure, mentioning no interface package, no search path, no `nros ws env`.

## The fix

Emitted immediately before `find_package(nano_ros)`, from the workspace root already computed. It **prepends** rather than assigns: a caller who sourced `nros ws env`, or who points at an out-of-workspace package tree, keeps their entry *and its precedence* — the shadowing rule is that earlier roots win, so clobbering would silently change which package a name resolves to.

Guarded beside the test pinning toolchain-before-`project()`, which is the same class — a value set after the thing that reads it is a value nobody used. **Mutation-tested both ways**: moving the block after `find_package(nano_ros)` fails it; assigning instead of prepending fails it.

## Verification

`nros build linux` in [`orin-spe-heartbeat`](https://github.com/jerry73204/orin-spe-heartbeat) now succeeds with the variable **unset** (`env -u NROS_INTERFACE_SEARCH_PATH`):

```
-- nros: find_package(spe_msgs) -> .../src/spe_msgs
[100%] Built target linux_entry
```

`just check fast`: **231/231 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdCiT6U5eYGsEdWSDgXZV