### PR TITLE
fix(#1112): the esp32 lane stages the native peers its interop tests need

### DIFF
--- a/docs/issues/archived/1112-esp32-lane-omits-the-native-peers-its-interop-tests-need.md
+++ b/docs/issues/archived/1112-esp32-lane-omits-the-native-peers-its-interop-tests-need.md
@@ -1,0 +1,71 @@
+---
+id: 1112
+title: "The esp32 lane never builds the NATIVE half of its own interop tests, so the failure names the esp32 side"
+status: resolved
+area: testing, build
+severity: medium
+related: [1025, 1070, 1106, 0968, 0584]
+---
+
+# Half of an interop test is a fixture the lane does not build
+
+## What
+
+`test_esp32_to_native` and `test_native_to_esp32` each start ONE esp32 image and
+ONE host binary. The esp32 half comes from `just esp32 build-all`; the host half
+is a `linux` fixture that module never builds. So both tests fail immediately:
+
+```
+Failed to build native listener: BuildFailed("Test fixture binary not prebuilt:
+  /__w/nano-ros/nano-ros/build/cargo-fixtures/linux/nros-relwithdebinfo/listener
+Run `just build-test-fixtures` first.")
+```
+
+Three retries, 0.36–0.41 s each. The speed is the tell: a delivery problem takes
+seconds to time out, a missing prerequisite fails instantly.
+
+## Why it read as an esp32 fault
+
+The failure is reported under `esp32_emulator`, in the esp32 job, on a lane whose
+last three reds were genuinely esp32 defects (issues 1025, 1070, 1106). Every
+signal points at the board. Nothing in the message says "this half of the test is
+a different platform's fixture" — it names a path, and reading the path is what
+answers it.
+
+Issue 0968 listed `test_native_to_esp32` among its undiagnosed failures for that
+reason.
+
+## Fix
+
+`just esp32 build-fixtures` stages the two peers by ID:
+
+```
+for _peer in native-rust-talker native-rust-listener; do
+    bash scripts/build/fixtures-build.sh linux rust --id "$_peer"
+done
+```
+
+Same reasoning the recipe already applies one line up to the workspace entry —
+"the test's skip message (correctly) points users to `build-fixtures`, so this
+lane must stage it too". The tests belong to this module, so their prerequisites
+are this lane's to stage.
+
+**By ID, not `fixtures-build.sh linux rust`**, which is 74 rows to obtain two.
+The rows had no `id` key, so they gained one (`native-rust-talker`,
+`native-rust-listener`) — named for what the fixture IS, per the manifest
+validator's rule against work-item ids.
+
+Verified: after deleting both artifacts, the two commands rebuild them at exactly
+the paths the tests demand.
+
+## What this does NOT fix
+
+`test_esp32_workspace_entry_e2e` still reports a missing `int32-sink` fixture,
+and its own message says the deeper problem:
+
+> Since issue 0584 an absent in-lane fixture is a hard failure, not a skip — a
+> gated run already asserted the lane's fixtures are built. **Something is still
+> laundering the resolver's Err into a `[SKIPPED]`.**
+
+That is a different defect in the skip path, not a missing build step, and it
+wants its own look rather than another fixture added to this list.

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -1195,12 +1195,19 @@ cmake_defs = { NANO_ROS_PLATFORM = "freertos", NANO_ROS_BOARD = "mps2-an385-free
 # ===========================================================================
 
 # Collapsed role examples — default features, default target dir.
+#
+# These two carry ids because they are also the NATIVE PEERS of the esp32
+# interop tests (`test_esp32_to_native` / `test_native_to_esp32`), which the
+# esp32 lane has to stage by id — building every `linux rust` row to get two of
+# them would be 74 rows for 2. Issue 1112.
 [[fixture]]
+id = "native-rust-talker"
 platform = "linux"
 lang = "rust"
 dir = "examples/native/rust/talker"
 
 [[fixture]]
+id = "native-rust-listener"
 platform = "linux"
 lang = "rust"
 dir = "examples/native/rust/listener"

--- a/just/esp32.just
+++ b/just/esp32.just
@@ -248,6 +248,21 @@ build-fixtures: build-qemu build-logging-smoke
     # built it, but the test's skip message (correctly) points users to
     # `build-fixtures` — so this lane must stage it too. Idempotent + cached.
     bash scripts/build/workspace-fixtures-build.sh esp32 rust
+    # Issue 1112 — the NATIVE PEERS of the esp32 interop tests.
+    #
+    # `test_esp32_to_native` and `test_native_to_esp32` each start one esp32
+    # image and one HOST binary, so half of each test is a `linux` fixture this
+    # module never builds. In the nightly that read as an esp32 failure —
+    # `BuildFailed("Test fixture binary not prebuilt: .../cargo-fixtures/linux/
+    # nros-relwithdebinfo/listener")`, three retries, 0.4 s each — which points
+    # at the esp32 side and is not about it at all.
+    #
+    # Same reasoning as the workspace entry above: the tests belong to THIS
+    # module, so their prerequisites are this lane's to stage. By ID rather than
+    # `fixtures-build.sh linux rust`, which is 74 rows to obtain two.
+    for _peer in native-rust-talker native-rust-listener; do
+        bash scripts/build/fixtures-build.sh linux rust --id "$_peer"
+    done
     # esp-idf build-stage fixtures (issue 0041): build the idf.py ELF the
     # cli_bringup_esp_idf test consumes, so it doesn't run idf.py at test time.
     # Self-gates on idf.py/IDF env; non-fatal (a failed build leaves no stamp,


### PR DESCRIPTION
The fourth fault in the esp32 lane — and, unlike the first three, not an esp32 defect at all.

## Half of an interop test is a fixture the lane doesn't build

`test_esp32_to_native` and `test_native_to_esp32` each start **one** esp32 image and **one** host binary. The esp32 half comes from `just esp32 build-all`; the host half is a `linux` fixture this module never built:

```
Failed to build native listener: BuildFailed("Test fixture binary not prebuilt:
  .../build/cargo-fixtures/linux/nros-relwithdebinfo/listener")
```

Three retries, **0.36–0.41 s each**. The speed is the tell — a delivery problem takes seconds to time out; a missing prerequisite fails at once.

## Why it read as an esp32 fault

Reported under `esp32_emulator`, in the esp32 job, on a lane whose last three reds were genuine esp32 defects (#1025, #1070, #1106). Every signal points at the board. Nothing in the message says half the test is another platform's fixture — it names a path, and reading the path is what answers it.

#0968 listed `test_native_to_esp32` among its undiagnosed failures for exactly that reason.

## Fix

`just esp32 build-fixtures` stages both peers **by id** — the same reasoning the recipe already applies one line up to the workspace entry (*"the test's skip message points users to `build-fixtures`, so this lane must stage it too"*). The tests belong to this module, so their prerequisites are this lane's to stage.

By id rather than `fixtures-build.sh linux rust`, which is **74 rows to obtain two**. The rows carried no `id`, so they gained one — named for what the fixture *is*, per the manifest validator's rule against work-item ids.

**Verified** by deleting both artifacts and rebuilding: the commands produce them at exactly the paths the tests demand.

## What this does not fix

`test_esp32_workspace_entry_e2e` still reports a missing `int32-sink` fixture, and its own message names a different defect:

> Since issue 0584 an absent in-lane fixture is a hard failure, not a skip … **Something is still laundering the resolver's Err into a `[SKIPPED]`.**

That's the skip path, not a missing build step. It wants its own look rather than another fixture appended to this list.

`just check fast` 232/232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)