### PR TITLE
ci: arm auto-merge, because 16 of 23 open pull requests were not armed

### DIFF
--- a/.github/workflows/arm-auto-merge.yml
+++ b/.github/workflows/arm-auto-merge.yml
@@ -1,0 +1,94 @@
+# Arm auto-merge on every pull request that is ready for one.
+#
+# WHY THIS EXISTS
+#
+# `main` requires a pull request and the merge queue, so a PR reaches `main`
+# only if someone arms auto-merge. Nobody does it reliably, and the cost was
+# measured on 2026-09-06: of 23 open pull requests, **16 were not armed**. An
+# unarmed PR never enters the queue, so it sits while `main` moves -- 56 to 71
+# commits in a day at the current rate -- until it conflicts and needs a
+# rebase that nobody asked for.
+#
+# The loop closes on itself, which is the part worth naming: **a force-push
+# CANCELS auto-merge.** So the rebase that unsticks a stale PR also disarms it,
+# and the PR goes straight back to rotting. Nine PRs were rebased by hand that
+# morning and every one came out unarmed. Work in, no throughput out.
+#
+# `synchronize` in the trigger list is what closes it: a rebase re-arms.
+#
+# WHY `pull_request_target`
+#
+# `pull_request` from a fork gets a READ-ONLY token, so it cannot arm
+# anything -- which is the case that most needs arming. `pull_request_target`
+# runs with the base repository's token.
+#
+# That trigger is dangerous when a workflow CHECKS OUT the pull request's code,
+# because untrusted code then runs with a writable token. This one checks out
+# NOTHING and runs no code from the PR: it makes a single API call, by number.
+# Do not add `actions/checkout` here.
+#
+# NO `branches:` OR `paths:` FILTER, deliberately
+#
+# The same trap `gate.yml` documents at length. A `branches: [main]` filter
+# silently drops every event from a STACKED pull request (base is not `main`),
+# and retargeting a PR emits `edited`, which is not in the default type list --
+# so PR #71 sat thirteen hours with zero check suites. A filter here would fail
+# the same way, and the failure looks like "auto-merge just doesn't work
+# sometimes".
+#
+# WHAT IT DOES NOT CHANGE
+#
+# Arming auto-merge is not merging. The PR still waits for the required `CI`
+# context and still goes through the merge queue, which runs `test-unit` and
+# the rest before anything lands. This changes WHO pushes the button, not what
+# the button checks.
+#
+# Opt out per-PR with the `no-auto-merge` label, or by leaving the PR a draft.
+
+name: arm auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  # One arm per PR; a burst of pushes does not need a queue of identical calls.
+  group: arm-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  arm:
+    name: arm auto-merge
+    # A draft is a statement that the author is not done. `no-auto-merge` is
+    # the same statement for a PR that must not land on its own -- a spike, a
+    # discussion, anything wanting a human at the end.
+    if: >-
+      ${{ github.event.pull_request.draft == false
+          && !contains(github.event.pull_request.labels.*.name, 'no-auto-merge') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # `--rebase` names the method for repositories without a queue; where
+          # a queue IS configured GitHub owns the method and `gh` says so on
+          # stderr ("The merge strategy for main is set by the merge queue")
+          # while arming correctly. That notice is not an error.
+          #
+          # Already-armed is also not an error, and `synchronize` will re-run
+          # this on every push, so the common case is a no-op.
+          if gh pr merge "$NUMBER" --auto --rebase 2>&1 | tee /tmp/arm.log; then
+            echo "armed #$NUMBER"
+          else
+            # Never fail the workflow for this. A PR that cannot be armed yet
+            # (queued, closed, conflicting) is a state to report, not a red X
+            # on someone's pull request -- and a red check here would be a
+            # second, confusing signal beside the real `CI` one.
+            echo "::warning::could not arm auto-merge on #$NUMBER"
+            sed 's/^/  /' /tmp/arm.log
+          fi


### PR DESCRIPTION
## The measurement

`main` requires a pull request and the merge queue, so a PR reaches `main` **only** if someone arms auto-merge. Across the 23 open pull requests today:

```
armed        7
NOT armed   16
```

An unarmed PR never enters the queue. It sits while `main` moves — **56 to 71 commits in a day** at the current rate — until it conflicts, and then it needs a rebase nobody asked for.

## The loop that closes on itself

**A force-push cancels auto-merge.** So the rebase that unsticks a stale PR also disarms it, and it goes straight back to rotting. Nine PRs were rebased by hand this morning and *every one* came out unarmed — work in, no throughput out.

`synchronize` in the trigger list is what closes that loop: a rebase re-arms.

## Why `pull_request_target`

`pull_request` from a fork gets a **read-only** token and cannot arm anything — which is the case that most needs arming. `pull_request_target` runs with the base repository's token.

That trigger is dangerous when a workflow **checks out the PR's code**, because untrusted code then runs with a writable token. **This one checks out nothing** and runs no code from the PR: a single API call, by number, with `pull-requests: write` and no other permission.

This is the repo's first `pull_request_target` workflow, so please read that constraint as load-bearing — **do not add `actions/checkout` to it.**

## No `branches:` or `paths:` filter

Deliberately, and it is the trap `gate.yml` already documents at length: `branches: [main]` silently drops every event from a *stacked* PR, and retargeting emits `edited`, which is not a default type — PR #71 sat thirteen hours with zero check suites. The same filter here would fail the same way, and would read as "auto-merge just doesn't work sometimes".

## What this does not change

**Arming is not merging.** The PR still waits for the required `CI` context and still goes through the merge queue, which runs `test-unit` and the rest before anything lands. This changes *who pushes the button*, not what the button checks.

Opt out per-PR with the **`no-auto-merge`** label, or by leaving the PR a draft.

## Verification

`just check fast` — 224 gates green, 8 skipped for local prerequisites this worktree lacks (no built CLI, no submodules). YAML parses; `workflow-setup-spelling`, `ci-doc-workflow-refs`, `workflow-indexed-apt`, `workflow-repo-env`, `workflow-runner-isolation` and `ci-no-verb-fallback` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
