### PR TITLE
fix(#1114): the px4 leaf-include exemption asks about the LANE, not the host

### DIFF
--- a/docs/issues/archived/1114-px4-leaf-include-gate-demands-artifact-no-lane-builds.md
+++ b/docs/issues/archived/1114-px4-leaf-include-gate-demands-artifact-no-lane-builds.md
@@ -1,0 +1,118 @@
+---
+id: 1114
+title: "`_require-leaf-includes` demands `generated/px4_msgs` from every lane, so tier 2 dies on three leaves it never builds"
+status: resolved
+type: bug
+area: build, testing
+severity: high
+related: [0463, 0474, 0510, 1025, 0319]
+found: 2026-09-06
+---
+
+# The exemption was right; its predicate asked about the host
+
+## Symptom
+
+`run-matrix.yml` — the ONLY automated path to a tier-2 runtime verdict — fails in
+`just build tier2`:
+
+```
+error: 3 path dep(s) into `generated/` do not exist, across 3 manifest(s).
+
+  examples/px4/rust/companion/offboard-companion/Cargo.toml
+      path -> generated/px4_msgs  (absent)
+  examples/px4/rust/companion/px4-probe/Cargo.toml
+      path -> generated/px4_msgs  (absent)
+  examples/px4/rust/companion/px4-stub/Cargo.toml
+      path -> generated/px4_msgs  (absent)
+
+error: recipe `_require-leaf-includes` failed with exit code 1
+```
+
+The step's own `nros sync` had just run and reported success — for
+`builtin_interfaces` and `std_msgs`, the only two packages it can produce.
+
+## Cause
+
+`generated/px4_msgs` is **not** produced by `nros sync`. Issue 0510 records why:
+px4_msgs is not an ament package, so only `nros generate-px4-msgs` emits it, from
+the PX4 `.msg` tree, and only `just px4 build-fixtures` runs that.
+
+`scripts/build/leaf-config-includes.py` already knew this and carried an
+exemption. **The exemption's PREDICATE was wrong, not its existence:**
+
+```python
+px4_available = px4_msg_tree().is_dir()
+...
+if PX4_PRODUCED_RE.search(dep_path) and not px4_available:
+    gen_unprovisioned.append((rel, dep_path))   # reported, not required
+    continue
+gen_missing.append((rel, dep_path))             # FAILS
+```
+
+It asked *"could the producer have run?"* — a fact about the **host**. The
+question is about the **lane**. On a machine with PX4 provisioned (the
+self-hosted runner, and this dev box) the exemption lifts and the directory
+becomes mandatory for **every** lane — including the ones that never build a px4
+leaf.
+
+**px4 has ZERO rows in `examples/fixtures.toml`** — not `[[fixture]]`, not
+`[[workspace_fixture]]`, not `[[compile_check_fixture]]`. It is in no lane at
+all. So tier 2 was blocked by three leaves no tier builds.
+
+This is CLAUDE.md's affordability rule one level down:
+
+> A gate in an affordability tier may only resolve artifacts the JOB ITSELF
+> builds — `check-lane-contracts` enforces this for every merge-gating lane.
+
+Here the gate resolved an artifact whose producer is a lane the job never
+invokes. `check-lane-contracts` did not catch it because the dependency is not a
+fixture stamp; it is a directory a *different* lane writes.
+
+## Why it hid
+
+The condition needs BOTH halves: PX4 provisioned AND `generated/px4_msgs`
+absent. A dev box that has ever run `just px4 build-fixtures` has the directory,
+so the guard passes and the bug is invisible — this one did, which is why the
+first local reproduction attempt was green and the "local fails the same way"
+guess was wrong. It reproduces by moving the three directories aside.
+
+## Fix
+
+`generated/px4_msgs` is now **reported, never required**:
+
+```python
+if PX4_PRODUCED_RE.search(dep_path):
+    gen_unprovisioned.append((rel, dep_path))
+    continue
+```
+
+Correct because the one lane that CONSUMES these leaves PRODUCES the directory
+first — `just px4 build-fixtures` generates into all three before building any of
+them — so that lane passes on the directory EXISTING, not on this guard's
+verdict, and a lane that has not run the producer was never going to parse those
+manifests.
+
+Reporting rather than dropping keeps the diagnosis the guard exists for: a bare
+`cargo metadata` over a px4 leaf still gets cargo's raw manifest-parse error, and
+the note is what explains it. The note now names the LANE reason and tailors its
+hint to whether PX4 is provisioned.
+
+### Measured, both directions
+
+With the three directories moved aside on a PX4-provisioned host:
+
+| | rc |
+| --- | --- |
+| before the fix | **1** — the exact CI failure |
+| after the fix | **0**, with the narrowing reported |
+
+## Not covered
+
+* Whether `check-lane-contracts` should grow a rule for "artifact produced by
+  another lane", which is the class this instance belongs to. It currently
+  reasons about fixture stamps only.
+* px4 having no `fixtures.toml` row at all. That is a real coverage gap — the
+  px4 leaves are built by `just px4` and by no tier — and it is what made this
+  guard the only thing standing between tier 2 and a green run. Filed here as
+  context, not fixed.

--- a/scripts/build/leaf-config-includes.py
+++ b/scripts/build/leaf-config-includes.py
@@ -71,17 +71,32 @@ GENERATED_PATH_RE = re.compile(r'path\s*=\s*"([^"]*\bgenerated/[^"]*)"')
 # ...with ONE exception, and it is about the PRODUCER rather than the shape.
 # `generated/px4_msgs` is not written by `nros sync` — issue 0510 records that
 # px4_msgs is not an ament package, so only `nros generate-px4-msgs` can emit it,
-# from the PX4 `.msg` tree, and only `just px4 build-fixtures` runs that. That
-# lane SKIPS cleanly when the submodule is absent (`nros_lane_skip`), so on any
-# tree without PX4 provisioned these three leaves can never have the directory,
-# and no amount of `nros sync` will change it — this guard's remedy line would
-# be advice that cannot work.
+# from the PX4 `.msg` tree, and only `just px4 build-fixtures` runs that.
 #
-# So require it only when the producer could have run. Without the `.msg` tree
-# the leaves are REPORTED as not-required rather than dropped silently; with it,
-# a missing directory is real breakage and still fails. Same reasoning the
-# `packages/cli/testing_workspaces/**` exclusion above rests on: match the gate
-# to the leaves the rule covers.
+# ISSUE 1114 — the exemption's PREDICATE was wrong, not its existence. It read
+# "require it only when the producer COULD have run", keyed on the PX4 `.msg`
+# tree being present. That is a fact about the HOST, and the question is about
+# the LANE: on a machine with PX4 provisioned the exemption lifted and the guard
+# demanded `generated/px4_msgs` from every lane, including the ones that never
+# build a px4 leaf. px4 has ZERO rows in `examples/fixtures.toml` — it is in no
+# lane at all — so tier 2 died in `just build tier2` on three leaves it does not
+# build, and the scheduled `run-matrix` lane produced no verdict.
+#
+# That is CLAUDE.md's affordability rule ("a gate in an affordability tier may
+# only resolve artifacts the JOB ITSELF builds", `check-lane-contracts`) broken
+# one level down: the gate resolved an artifact whose producer is a lane the job
+# never invokes.
+#
+# So it is never REQUIRED here, and always REPORTED. The one lane that consumes
+# these leaves PRODUCES the directory first -- `just px4 build-fixtures`
+# generates into all three before it builds any of them -- so a lane that has
+# run the producer passes on the directory EXISTING, not on this guard's say-so,
+# and a lane that has not run it was never going to parse those manifests.
+# Reporting keeps the diagnosis: a bare `cargo metadata` over a px4 leaf still
+# gets cargo's raw manifest-parse error, and this note is what explains it.
+#
+# Same reasoning the `packages/cli/testing_workspaces/**` exclusion above rests
+# on: match the gate to the leaves the rule covers.
 PX4_PRODUCED_RE = re.compile(r"\bgenerated/px4_msgs\b")
 
 
@@ -147,7 +162,8 @@ def main() -> int:
             target = (man.parent / dep_path / "Cargo.toml").resolve()
             if target.is_file():
                 continue
-            if PX4_PRODUCED_RE.search(dep_path) and not px4_available:
+            if PX4_PRODUCED_RE.search(dep_path):
+                # Issue 1114 — reported, never required. See the note above.
                 gen_unprovisioned.append((rel, dep_path))
                 continue
             gen_missing.append((rel, dep_path))
@@ -157,11 +173,17 @@ def main() -> int:
         # to report the narrowing, or "OK" overstates what was checked.
         print(
             f"note: {len(gen_unprovisioned)} path dep(s) into `generated/px4_msgs` "
-            f"not required — no PX4 `.msg` tree at {px4_msg_tree()}."
+            f"not required by this lane (issue 1114)."
         )
         print("      They are produced by `just px4 build-fixtures` (via "
-              "`nros generate-px4-msgs`), not by `nros sync`.")
-        print("      Provision it with `just setup px4` if you need those leaves.")
+              "`nros generate-px4-msgs`), not by `nros sync`, and px4 has no "
+              "`examples/fixtures.toml` row — so no tier lane builds these leaves.")
+        if px4_available:
+            print("      PX4 IS provisioned here, so `just px4 build-fixtures` "
+                  "would produce them.")
+        else:
+            print(f"      No PX4 `.msg` tree at {px4_msg_tree()}; provision it "
+                  "with `just setup px4` if you need those leaves.")
 
     if not missing and not gen_missing:
         print(


### PR DESCRIPTION
Issue **1114**. `run-matrix.yml` — the only automated path to a tier-2 runtime verdict — dies in `just build tier2`:

```
error: 3 path dep(s) into `generated/` do not exist, across 3 manifest(s).
  examples/px4/rust/companion/{offboard-companion,px4-probe,px4-stub}/Cargo.toml
      path -> generated/px4_msgs  (absent)
error: recipe `_require-leaf-includes` failed with exit code 1
```

…immediately after its own `nros sync` reported success — for `builtin_interfaces` and `std_msgs`, the only two packages sync can produce. `generated/px4_msgs` is not one of them: issue 0510 records that px4_msgs is not an ament package, so only `nros generate-px4-msgs` emits it and only `just px4 build-fixtures` runs that.

## The exemption existed; its predicate asked the wrong question

```python
px4_available = px4_msg_tree().is_dir()
if PX4_PRODUCED_RE.search(dep_path) and not px4_available:
    gen_unprovisioned.append(...)   # reported, not required
```

*"Could the producer have run?"* is a fact about the **host**. The question is about the **lane**. On a machine with PX4 provisioned — the self-hosted runner, and any dev box that ever ran the px4 lane — the exemption **lifts**, and the directory becomes mandatory for every lane, including ones that never build a px4 leaf.

**px4 has zero rows in `examples/fixtures.toml`** — no `[[fixture]]`, no `[[workspace_fixture]]`, no `[[compile_check_fixture]]`. It is in no lane at all. Tier 2 was blocked by three leaves no tier builds.

That is CLAUDE.md’s affordability rule one level down — *"a gate in an affordability tier may only resolve artifacts the JOB ITSELF builds"* — with the artifact produced by a **different lane** rather than by this job. `check-lane-contracts` reasons about fixture stamps, so it could not see this.

## Fix

`generated/px4_msgs` is now **reported, never required**. Correct because the one lane that *consumes* these leaves *produces* the directory first — `just px4 build-fixtures` generates into all three (`just/px4.just:340`) before building any of them. That lane passes on the directory existing, not on this guard’s verdict; a lane that has not run the producer was never going to parse those manifests.

Reporting rather than dropping keeps the diagnosis the guard exists for: a bare `cargo metadata` over a px4 leaf still gets cargo’s raw manifest-parse error, and the note explains it. The note now gives the lane reason and tailors its hint to whether PX4 is provisioned.

## Measured, both directions

The condition needs **both** halves — PX4 provisioned **and** `generated/px4_msgs` absent — so a box that ever ran the px4 lane cannot see it. This one had, which is why my first local reproduction was green and my "local fails the same way" guess was wrong. Moving the three directories aside reproduces it:

| | rc |
|---|---|
| before the fix | **1** — the exact CI failure |
| after the fix | **0**, with the narrowing reported |

`just check fast` — 234 gates — green in the pre-push hook.

## Not covered

- Whether `check-lane-contracts` should grow a rule for "artifact produced by another lane", which is the class this belongs to.
- px4 having no `fixtures.toml` row at all — a real coverage gap, and what made this guard the only thing between tier 2 and a green run. Recorded as context, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742