### PR TITLE
ci: arm auto-merge only for authors with repository access

### DIFF
--- a/.github/workflows/arm-auto-merge.yml
+++ b/.github/workflows/arm-auto-merge.yml
@@ -47,38 +47,45 @@
 #
 # WHOSE PULL REQUESTS GET ARMED
 #
-# Only ones that could ONLY have come from someone who already has write
-# access. Two conditions, and both must hold:
+# `author_association` is OWNER, MEMBER or COLLABORATOR. That is the whole
+# test, and it carries the distinction on its own -- those three are exactly
+# the values that mean the account has access to THIS repository.
 #
-#   * the head branch lives in THIS repository, not a fork. Creating that
-#     branch required push access, so the PR is from inside the trust
-#     boundary by construction. A third-party contributor has no such access
-#     and must fork -- that is the whole distinction, and it is structural
-#     rather than a guess about identity.
-#   * `author_association` is OWNER, MEMBER or COLLABORATOR. GitHub computes
-#     this per event and it is the field that says "this account has a
-#     relationship with this repository".
+# The one that looks close and is not is `CONTRIBUTOR`. GitHub gives it to
+# anyone who has had a commit merged here, so an outside contributor's SECOND
+# pull request arrives as `CONTRIBUTOR` with no more access than their first.
+# It is a history, not a permission. `FIRST_TIME_CONTRIBUTOR` and `NONE` are
+# the same case, said differently.
 #
-# The two overlap, deliberately. The fork test is the one that matters and the
-# association test costs nothing, so a scoped or revoked permission does not
-# turn into an auto-merged pull request through the other door.
+# WHERE THE BRANCH LIVES IS REPORTED, NOT ENFORCED
 #
-# Everything else -- a fork PR, a first-time contributor, `NONE` -- is simply
-# NOT ARMED. Nothing is blocked and nothing is rejected: CI still runs, the PR
-# is still reviewable, and a maintainer who wants it to land arms it by hand
-# after reading it. Auto-merge is a convenience for work that was already
-# going to land unattended; an outside contribution is exactly the case that
-# wants a human at the end.
+# An earlier version also required the head branch to be in this repository,
+# on the argument that pushing it proved write access. True, but the converse
+# does not hold: a member who prefers to work from their own fork has the same
+# access and was getting the outsider's treatment, and "not armed" would then
+# depend on the contributor's workflow rather than on their permissions. The
+# fork flag is still printed, because it is the first thing anyone asks when
+# reading one of these logs.
+#
+# Nothing is lost by dropping it. A fork PR from a non-member still fails the
+# association test, which is the check that was doing the work.
+#
+# Everything else -- a fork PR from an outsider, a first-time contributor,
+# `NONE` -- is simply NOT ARMED. Nothing is blocked and nothing is rejected:
+# CI still runs, the PR is still reviewable, and a maintainer who wants it to
+# land arms it by hand after reading it. Auto-merge is a convenience for work
+# that was already going to land unattended; an outside contribution is
+# exactly the case that wants a human at the end.
 #
 # `AUTO_MERGE_AUTHORS` (a repository variable, optional) narrows it further:
 # a comma-separated list of accounts, and when set, ONLY those accounts are
 # armed. Use it to name the agent accounts explicitly instead of trusting
-# every member. Unset -- the default -- means the two conditions above decide.
+# every member. Unset -- the default -- means the association decides.
 #
 # Note this rule has NO history to validate against: all 556 pull requests
 # ever opened here are from one MEMBER account on non-fork branches, so no
 # third-party PR has ever existed to test it. It is written to fail CLOSED for
-# that reason -- an unrecognised case is not armed.
+# that reason -- an unrecognised association is not armed.
 
 name: arm auto-merge
 
@@ -117,15 +124,16 @@ jobs:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           ALLOWLIST: ${{ vars.AUTO_MERGE_AUTHORS }}
         run: |
+          # `fork=` is REPORTED and not tested: a member working from their own
+          # fork has the same access as one pushing a branch here, and it is
+          # the first thing anyone asks when reading this log.
           echo "author=$AUTHOR association=$ASSOCIATION fork=$IS_FORK"
 
           arm=yes
-          if [ "$IS_FORK" = "true" ]; then
-            # The structural test: this branch could not have been pushed here.
-            echo "not arming — the head branch is on a fork, so the author has no write access"
-            arm=no
-          fi
           case "$ASSOCIATION" in
+            # The three values that mean access to THIS repository. CONTRIBUTOR
+            # is deliberately absent: GitHub gives it to anyone who has had a
+            # commit merged, so it is a history rather than a permission.
             OWNER|MEMBER|COLLABORATOR) ;;
             *)
               echo "not arming — author_association is '$ASSOCIATION', not OWNER/MEMBER/COLLABORATOR"

--- a/.github/workflows/arm-auto-merge.yml
+++ b/.github/workflows/arm-auto-merge.yml
@@ -44,6 +44,41 @@
 # the button checks.
 #
 # Opt out per-PR with the `no-auto-merge` label, or by leaving the PR a draft.
+#
+# WHOSE PULL REQUESTS GET ARMED
+#
+# Only ones that could ONLY have come from someone who already has write
+# access. Two conditions, and both must hold:
+#
+#   * the head branch lives in THIS repository, not a fork. Creating that
+#     branch required push access, so the PR is from inside the trust
+#     boundary by construction. A third-party contributor has no such access
+#     and must fork -- that is the whole distinction, and it is structural
+#     rather than a guess about identity.
+#   * `author_association` is OWNER, MEMBER or COLLABORATOR. GitHub computes
+#     this per event and it is the field that says "this account has a
+#     relationship with this repository".
+#
+# The two overlap, deliberately. The fork test is the one that matters and the
+# association test costs nothing, so a scoped or revoked permission does not
+# turn into an auto-merged pull request through the other door.
+#
+# Everything else -- a fork PR, a first-time contributor, `NONE` -- is simply
+# NOT ARMED. Nothing is blocked and nothing is rejected: CI still runs, the PR
+# is still reviewable, and a maintainer who wants it to land arms it by hand
+# after reading it. Auto-merge is a convenience for work that was already
+# going to land unattended; an outside contribution is exactly the case that
+# wants a human at the end.
+#
+# `AUTO_MERGE_AUTHORS` (a repository variable, optional) narrows it further:
+# a comma-separated list of accounts, and when set, ONLY those accounts are
+# armed. Use it to name the agent accounts explicitly instead of trusting
+# every member. Unset -- the default -- means the two conditions above decide.
+#
+# Note this rule has NO history to validate against: all 556 pull requests
+# ever opened here are from one MEMBER account on non-fork branches, so no
+# third-party PR has ever existed to test it. It is written to fail CLOSED for
+# that reason -- an unrecognised case is not armed.
 
 name: arm auto-merge
 
@@ -70,7 +105,55 @@ jobs:
           && !contains(github.event.pull_request.labels.*.name, 'no-auto-merge') }}
     runs-on: ubuntu-latest
     steps:
+      # The trust decision is a STEP, not another `if:` on the job, so that
+      # "why was my pull request not armed?" has an answer in a log somewhere.
+      # A job skipped by an expression leaves no record of which clause was
+      # false, and this one has four.
+      - name: Decide whether this author's pull requests arm themselves
+        id: trust
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          ALLOWLIST: ${{ vars.AUTO_MERGE_AUTHORS }}
+        run: |
+          echo "author=$AUTHOR association=$ASSOCIATION fork=$IS_FORK"
+
+          arm=yes
+          if [ "$IS_FORK" = "true" ]; then
+            # The structural test: this branch could not have been pushed here.
+            echo "not arming — the head branch is on a fork, so the author has no write access"
+            arm=no
+          fi
+          case "$ASSOCIATION" in
+            OWNER|MEMBER|COLLABORATOR) ;;
+            *)
+              echo "not arming — author_association is '$ASSOCIATION', not OWNER/MEMBER/COLLABORATOR"
+              arm=no
+              ;;
+          esac
+          if [ -n "$ALLOWLIST" ]; then
+            # An explicit list, when the repository sets one: name the agent
+            # accounts rather than trusting every member.
+            case ",$ALLOWLIST," in
+              *",$AUTHOR,"*) ;;
+              *)
+                echo "not arming — '$AUTHOR' is not in AUTO_MERGE_AUTHORS"
+                arm=no
+                ;;
+            esac
+          fi
+
+          if [ "$arm" = yes ]; then
+            echo "arming — the author already has write access to this repository"
+          else
+            echo "This is not a rejection. CI still runs and the pull request is"
+            echo "still mergeable; a maintainer arms it by hand after reading it."
+          fi
+          echo "arm=$arm" >> "$GITHUB_OUTPUT"
+
       - name: Enable auto-merge
+        if: steps.trust.outputs.arm == 'yes'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Follow-up to `#556`, which merged before this distinction could be added — so **right now a fork PR from an outside contributor would be auto-armed.** That is the case that most wants a human at the end.

## The test

`author_association` is `OWNER`, `MEMBER` or `COLLABORATOR`. That is the whole test, and it carries the distinction on its own: those three are exactly the values that mean the account has access to **this** repository.

The one that looks close and is not is **`CONTRIBUTOR`**. GitHub gives it to anyone who has had a commit merged here, so an outside contributor's *second* pull request arrives as `CONTRIBUTOR` with no more access than their first. It is a history, not a permission. `FIRST_TIME_CONTRIBUTOR` and `NONE` are the same case said differently.

## Where the branch lives is reported, not enforced

An earlier revision of this PR also required the head branch to be in this repository, on the argument that pushing it proved write access. True — but the converse does not hold: **a member who prefers to work from their own fork has the same access** and was getting the outsider's treatment. "Not armed" would then depend on a contributor's *workflow* rather than their *permissions*.

Nothing is lost by dropping it: a fork PR from a non-member still fails the association test, which was the check doing the work. The fork flag is still printed, because it is the first thing anyone asks when reading one of these logs.

## Not a rejection

Anything not armed is **not blocked**. CI still runs, the PR is still mergeable, and a maintainer arms it by hand after reading it. The log says so in those words so a skip is not read as a refusal.

**`AUTO_MERGE_AUTHORS`** (optional repository variable) narrows further to a named list — use it to name the agent accounts explicitly rather than trusting every member. It **narrows and never promotes**: it is applied on top of the association test, so naming an outsider does not arm them.

## The decision is a step, not another `if:`

A job skipped by an expression leaves no record of *which* clause was false. As a step it prints the author, association, fork flag, and reason.

## What I could not verify

**All 556 pull requests ever opened here are from one `MEMBER` account on non-fork branches.** No third-party PR has ever existed on this repo, so this rule has no history to validate against. It is written to **fail closed**.

What it *is* tested against is the decision script — extracted from the shipped workflow, not retyped — across 15 author shapes:

```
  ok  agent: MEMBER, branch in repo                  -> yes
  ok  OWNER, branch in repo                          -> yes
  ok  COLLABORATOR, branch in repo                   -> yes
  ok  RELAXED: MEMBER working from a fork            -> yes
  ok  RELAXED: COLLABORATOR from a fork              -> yes
  ok  RELAXED: OWNER from a fork                     -> yes
  ok  third party: fork + CONTRIBUTOR                -> no
  ok  third party: fork + FIRST_TIME_CONTRIBUTOR     -> no
  ok  third party: fork + NONE                       -> no
  ok  non-fork but CONTRIBUTOR                       -> no
  ok  allowlist set, author listed                   -> yes
  ok  allowlist set, member from fork, listed        -> yes
  ok  allowlist set, author not listed               -> no
  ok  allowlist substring trap: agent vs agentbot    -> no
  ok  allowlist cannot promote a CONTRIBUTOR         -> no
```

Two of those are the ones that must stay closed no matter how the rule is relaxed: an allowlist entry cannot promote a `CONTRIBUTOR`, and an account named `agent` does not match an allowlist entry `agentbot` (the match is comma-wrapped).

Workflow gates pass: `workflow-setup-spelling`, `ci-doc-workflow-refs`, `workflow-indexed-apt`, `workflow-repo-env`, `workflow-runner-isolation`, `ci-no-verb-fallback`. Still no `actions/checkout` — the constraint that makes `pull_request_target` safe here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
