### PR TITLE
fix(#1112): the workspace-entry fixture — stage it, and stop the test laundering its Err

### DIFF
--- a/docs/issues/archived/1112-esp32-lane-omits-the-native-peers-its-interop-tests-need.md
+++ b/docs/issues/archived/1112-esp32-lane-omits-the-native-peers-its-interop-tests-need.md
@@ -58,10 +58,56 @@ validator's rule against work-item ids.
 Verified: after deleting both artifacts, the two commands rebuild them at exactly
 the paths the tests demand.
 
+## The workspace entry: BOTH halves, and the second one is the interesting half
+
+`test_esp32_workspace_entry_e2e` needed the same treatment plus a fix the peers
+did not:
+
+**The build set.** It subscribes with `bins/int32-sink` — a `linux` fixture,
+because the entry's own in-process listener sees nothing (no same-session zenoh
+loopback), so that native binary IS the test's only observable endpoint. Staged
+by id like the peers. The three `int32-sink` rows had no `id`, so all three
+gained one (`int32-sink-{zenoh,xrce,cyclonedds}`); the esp32 lane builds the
+zenoh one, since the images speak zenoh. It lands in a variant group dir
+(`linux-3263301353`) rather than beside the peers because the row carries
+`no_default_features` + `features`.
+
+**The laundering, which was in the TEST.** The skip-budget check kept saying
+"Something is still laundering the resolver's Err into a `[SKIPPED]`" and this
+was it:
+
+```rust
+let native_listener = match build_int32_sink() {
+    Ok(p) => p.to_path_buf(),
+    Err(e) => nros_tests::skip!("int32-sink fixture not prebuilt ({e})"),
+};
+```
+
+Issue 0584: an absent IN-LANE fixture is a hard failure, because a gated run has
+already asserted the lane's fixtures are built. "Not prebuilt" there means the
+LANE is wrong, and a skip reports that as coverage. Its own two sibling tests
+twenty lines up already `.expect()` their native peers — one file, two spellings,
+and the inconsistent one is the one that hid a lane gap.
+
+Now `.expect("Failed to build int32-sink")`.
+
+## The class, NOT swept — deliberately
+
+Twelve sites across five files share the shape (`bridge_mixed_rmw`,
+`bridge_zenoh_to_cyclonedds`, `declarative_bridge_zenoh_to_{cyclonedds,xrce}`,
+`zephyr`). CLAUDE.md says fix the class, and here that would be wrong without
+evidence per site: 0584's rule is about an **in-lane** fixture, and a bridge test
+whose fixture is genuinely out of lane SHOULD skip. Converting all twelve would
+turn correct skips into hard failures across several lanes.
+
+What made this one answerable is that the skip-budget check named it on a lane
+that had already asserted its fixtures were built. Each of the other twelve wants
+that same evidence before it moves.
+
 ## What this does NOT fix
 
-`test_esp32_workspace_entry_e2e` still reports a missing `int32-sink` fixture,
-and its own message says the deeper problem:
+Nothing further on this lane is known-open. For the record, the message that
+pointed at the laundering was:
 
 > Since issue 0584 an absent in-lane fixture is a hard failure, not a skip — a
 > gated run already asserted the lane's fixtures are built. **Something is still

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -1413,6 +1413,7 @@ features = ["rmw-cyclonedds"]
 # std_msgs/String chatter, so the Int32 side-topic observer role moved here).
 # Consumed by the service/action/param/safety/realtime e2e tests.
 [[fixture]]
+id = "int32-sink-zenoh"
 platform = "linux"
 lang = "rust"
 rmw = "zenoh"
@@ -1452,6 +1453,7 @@ features = ["rmw-cyclonedds"]
 # switch, because this fixture was hardcoded to zenoh. A test fixture must not
 # pin the RMW any more than an example does.
 [[fixture]]
+id = "int32-sink-xrce"
 platform = "linux"
 lang = "rust"
 rmw = "xrce"
@@ -1466,6 +1468,7 @@ features = ["rmw-xrce"]
 # demo has. The examples follow the ROS demos (std_msgs/String); test-only
 # payload shapes belong in a test bin.
 [[fixture]]
+id = "int32-sink-cyclonedds"
 platform = "linux"
 lang = "rust"
 rmw = "cyclonedds"

--- a/just/esp32.just
+++ b/just/esp32.just
@@ -263,6 +263,13 @@ build-fixtures: build-qemu build-logging-smoke
     for _peer in native-rust-talker native-rust-listener; do
         bash scripts/build/fixtures-build.sh linux rust --id "$_peer"
     done
+    # ...and the Int32 sink `test_esp32_workspace_entry_e2e` subscribes with.
+    # The entry publishes Int32 and its own in-process listener sees nothing (no
+    # same-session zenoh loopback), so this native binary IS the test's only
+    # observable endpoint. zenoh: the esp32 images speak zenoh, and the row
+    # carries `no_default_features` + `features = ["rmw-zenoh"]`, which is why it
+    # lands in a variant group dir rather than beside the peers above.
+    bash scripts/build/fixtures-build.sh linux rust --id int32-sink-zenoh
     # esp-idf build-stage fixtures (issue 0041): build the idf.py ELF the
     # cli_bringup_esp_idf test consumes, so it doesn't run idf.py at test time.
     # Self-gates on idf.py/IDF env; non-fatal (a failed build leaves no stamp,

--- a/packages/testing/nros-tests/tests/esp32_emulator.rs
+++ b/packages/testing/nros-tests/tests/esp32_emulator.rs
@@ -525,10 +525,16 @@ fn test_esp32_workspace_entry_e2e() {
     // which subscribes Int32 natively, so the example can drop its branching.
     // Readiness is unchanged ("Waiting for"); the per-message marker is not —
     // the sink prints "Received:", the example printed "I heard:".
-    let native_listener = match build_int32_sink() {
-        Ok(p) => p.to_path_buf(),
-        Err(e) => nros_tests::skip!("int32-sink fixture not prebuilt ({e})"),
-    };
+    // Issue 1112 — `.expect`, not `skip!`. An absent in-lane fixture is a HARD
+    // FAILURE (issue 0584): a gated run has already asserted this lane's
+    // fixtures are built, so "not prebuilt" here means the LANE is wrong, and a
+    // skip reports that as coverage. This site was the laundering the
+    // skip-budget check kept naming ("Something is still laundering the
+    // resolver's Err into a [SKIPPED]") — its own two sibling tests twenty
+    // lines up already `.expect()` their native peers.
+    let native_listener = build_int32_sink()
+        .expect("Failed to build int32-sink")
+        .to_path_buf();
     let mut listener_cmd = Command::new(native_listener);
     listener_cmd
         .env(


### PR DESCRIPTION
Two halves. The second is the one the skip-budget check kept naming.

## The build set

`test_esp32_workspace_entry_e2e` subscribes with `bins/int32-sink`, a **linux** fixture — the entry's own in-process listener sees nothing (no same-session zenoh loopback), so that native binary is the test's only observable endpoint.

Staged by id, like the peers in #555. The three `int32-sink` rows had no `id`, so all three gained one; the esp32 lane builds the **zenoh** variant, since the images speak zenoh. It lands in a variant group dir — `linux-3263301353`, exactly the path CI reported missing — because the row carries `no_default_features` + `features`.

## The laundering, which was in the test

```rust
let native_listener = match build_int32_sink() {
    Ok(p) => p.to_path_buf(),
    Err(e) => nros_tests::skip!("int32-sink fixture not prebuilt ({e})"),
};
```

**#0584**: an absent *in-lane* fixture is a hard failure, because a gated run has already asserted the lane's fixtures are built. "Not prebuilt" there means the **lane** is wrong, and a skip reports that as coverage — which is precisely how this gap stayed invisible while the check complained every single run.

Its own two sibling tests twenty lines up already `.expect()` their native peers. One file, two spellings, and the inconsistent one is the one that hid a lane gap. Now `.expect`.

## The class is not swept — deliberately

Twelve sites across five files share the shape (`bridge_mixed_rmw`, `bridge_zenoh_to_cyclonedds`, `declarative_bridge_zenoh_to_{cyclonedds,xrce}`, `zephyr`).

CLAUDE.md says fix the class. Here that would be **wrong** without per-site evidence: 0584's rule is about an *in-lane* fixture, and a bridge test whose fixture is genuinely out of lane **should** skip. Converting all twelve would turn correct skips into hard failures across several lanes.

What made this one answerable is that the skip-budget check named it on a lane that had already asserted its fixtures were built. The other twelve want that same evidence before they move.

## Verified

- the row ids resolve
- `nros_fixture_row_artifact_dir_by_id int32-sink-zenoh linux` → `linux-3263301353`
- the artifact is present there
- `cargo check -p nros-tests --test esp32_emulator` compiles the `.expect`
- `just check fast` 234/234

🤖 Generated with [Claude Code](https://claude.com/claude-code)