### PR TITLE
fix(#1110): the docs deploy was red for three days, and no lane could say so

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -639,6 +639,28 @@ jobs:
           source ./activate.sh
           just check compile-smoke
 
+      # issue 1110 — rustdoc, on a lane a PR actually runs.
+      #
+      # The broken-link lint is deny-level here and NOTHING on a merge-gating
+      # path ran rustdoc, so `just book` and every docs deploy were red for
+      # three days with no lane saying so (`docs.yml`'s path filter includes the
+      # crate that broke, so it was failing rather than skipping). A second
+      # break sat behind the first, invisible, because rustdoc stops at the
+      # first crate that fails.
+      #
+      # It lives in THIS job because the job already compiles the workspace on a
+      # pull request — `check-lane-contracts`'s rule is that a lane may only
+      # resolve artifacts the job itself builds. It documents the DEPLOYED crate
+      # set (scripts/build/rustdoc-set.sh, shared with `just book`), not the
+      # workspace: the wider pass has ~70 diagnostics in crates nothing
+      # publishes (issue 1116), which is a separate cleanup and would make this
+      # gate un-landable rather than useful.
+      - name: just check rustdoc-links (pull request only)
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        run: |
+          source ./activate.sh
+          just check rustdoc-links
+
       # The CLI sub-workspace's own tests, on BOTH merge-gating events.
       #
       # `cli-tests` lived only in `check-build`, which is `schedule` /

--- a/docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md
+++ b/docs/issues/1116-rustdoc-diagnostics-outside-the-published-crate-set.md
@@ -1,0 +1,60 @@
+---
+id: 1116
+title: "~70 rustdoc diagnostics in crates the book does not publish — five of them fail to document at all"
+status: open
+type: tech-debt
+area: docs, core
+severity: low
+found: 2026-09-06
+related: [1110, 0319, 0896]
+---
+
+# What issue 1110 fixed, and what it deliberately did not
+
+Issue 1110 put rustdoc on a lane a pull request runs (`just check rustdoc-links`, in the `compile-smoke`
+job). Its scope is the **deployed** crate set — the six crates `just book`
+publishes — because that is what keeps the docs deploy green.
+
+A workspace-wide pass is a different story. Measured on a cold pass,
+2026-09-06:
+
+```
+$ cargo doc --no-deps --workspace $HOST_UNCHECKABLE
+… ~70 diagnostics …
+error: could not document `nros-node`
+error: could not document `nros-orchestration-ir`
+error: could not document `nros-platform`
+error: could not document `nros-serdes`
+error: could not document `zpico-alloc`
+```
+
+Five crates do not document at all. The diagnostics fall into three kinds, and
+they need different fixes:
+
+1. **A link to an item that no longer exists** — the 1110 shape, e.g.
+   `crate::Node::session_mut` (3×), `crate::Executor::register_lifecycle_node`
+   (2×), `Executor::open_multi`. Each is a rename or deletion whose prose was
+   not moved with it.
+2. **A public item linking to a PRIVATE one** — ~14 of them
+   (`ExecutorSizing` → `carve`, `loan` → `TxArena::release`, `dispatch_callback`
+   → `DispatchSlot`). rustdoc rejects these because a reader of the public page
+   cannot follow the link. The fix is prose or `pub(crate)` visibility, not a
+   link.
+3. **Markdown that reads as a link and is not one** — `[iu]{8,16,32,64}` in
+   `nros-serdes::schema`, `[must_use]`, `[planned]`. Backticks, not brackets.
+
+## Why this is not urgent, and not nothing
+
+Nothing publishes these crates, so no deploy is broken by them and no user sees
+a 404. What they cost is the ability to WIDEN the gate: `rustdoc-links` cannot
+grow to the workspace while 70 diagnostics stand, so every crate outside the
+published six keeps the property 1110 was about — a doc link can rot with
+nothing to say so.
+
+## Doing it
+
+A ratchet is the wrong tool here (the count only goes down, and the fixes are
+mechanical). Better: fix by kind, in three commits, then widen
+`NROS_RUSTDOC_CRATES` in `scripts/build/rustdoc-set.sh` to the workspace and
+delete this issue's reason for existing. The gate is ~3 s warm on six crates and
+was measured at 3.2 s warm on the whole workspace, so cost is not the obstacle.

--- a/just/check.just
+++ b/just/check.just
@@ -2901,6 +2901,38 @@ compile-smoke:
     cargo check --workspace --all-targets --quiet {{HOST_UNCHECKABLE}}
     echo "compile smoke: workspace + all targets check clean (no lints; see check-build)."
 
+# Issue 1110 — the PUBLISHED API docs must still build, on a lane a PR runs.
+#
+# rustdoc's broken-link lint is deny-level here, and NOTHING on a merge-gating
+# path ran rustdoc. `3941b569a` deleted `ClientTrait::is_server_ready` while the
+# paragraph beside it still linked to it, so `just book` and every docs deploy
+# went red and stayed red for three days — `docs.yml`'s path filter includes
+# that crate, so the deploy was failing, not skipping. A SECOND break sat behind
+# it (`nros-rmw-zenoh` naming a `record_alloc_ceilings` that never existed),
+# invisible because rustdoc stops at the first crate that fails.
+#
+# Same class as issues 0319 and 0896: a correct check on a path nothing
+# traverses. The fix is the path, not the check.
+#
+# The crate + feature set is `scripts/build/rustdoc-set.sh`, which `just book`
+# reads too — one spelling, because a gate documenting a DIFFERENT set from the
+# one that deploys is a gate that can be green while the deploy is red.
+#
+# Not on the fast line: it compiles. It runs in the `compile-smoke` JOB, which
+# already builds the workspace on every pull request — `check-lane-contracts`'s
+# rule is that a lane may only resolve artifacts the job itself builds, and this
+# one does.
+[group("ci")]
+rustdoc-links:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source scripts/build/rustdoc-set.sh
+    mapfile -t pkgs < <(nros_rustdoc_package_args)
+    cargo doc --no-deps --quiet \
+        --features "$NROS_RUSTDOC_FEATURES" \
+        "${pkgs[@]}"
+    echo "rustdoc-links OK — the ${#NROS_RUSTDOC_CRATES[@]} published crates document cleanly."
+
 # phase-359 W9 — every matrix platform resolves to exactly ONE std flavour, so a
 # lane keyed on the platform cannot mix std and no_std images. Buildless (reads
 # board manifests + the registry), so it belongs in the fast tier.

--- a/justfile
+++ b/justfile
@@ -4781,14 +4781,16 @@ book:
     # without them rustdoc drops ExecutorConfigEnvExt::from_env, the alloc-
     # gated ExecutorNodeRuntime::spin and `nros::node!` — and every doc
     # comment linking those fails the build (2026-08-21 book red).
+    # The crate + feature set is DATA, in scripts/build/rustdoc-set.sh, because
+    # `just check rustdoc-links` builds the same set on every pull request
+    # (issue 1110). A gate documenting a different set from the one that
+    # deploys can be green while the deploy is red, which is the state that
+    # issue records.
+    source scripts/build/rustdoc-set.sh
+    mapfile -t _nros_doc_pkgs < <(nros_rustdoc_package_args)
     cargo doc --no-deps \
-        --features rmw-cffi,platform-posix,ros-humble,safety-e2e,std,env,macros \
-        -p nros \
-        -p nros-rmw \
-        -p nros-rmw-cffi \
-        -p nros-rmw-zenoh \
-        -p nros-platform-api \
-        -p nros-platform-cffi
+        --features "$NROS_RUSTDOC_FEATURES" \
+        "${_nros_doc_pkgs[@]}"
     just doc-c
     just doc-cpp
     just doc-rmw-cffi

--- a/packages/core/nros-rmw/src/traits.rs
+++ b/packages/core/nros-rmw/src/traits.rs
@@ -2833,9 +2833,15 @@ pub trait ClientTrait {
     /// Returns `Ok(true)` if at least one matching server has been
     /// discovered, `Ok(false)` if none yet, or `Err(_)` if the
     /// backend cannot answer (e.g. XRCE — micro-XRCE-DDS-Client has
-    /// no participant enumeration). Distinct from
-    /// [`is_server_ready`](Self::is_server_ready), which collapses
-    /// "don't know" and "no server" into the same `false` answer.
+    /// no participant enumeration).
+    ///
+    /// Those are three answers, not two, and keeping them apart is the whole
+    /// point: `is_server_ready` used to sit beside this method collapsing
+    /// "don't know" and "no server" into one `false`, its trait default was
+    /// `true`, and only zenoh overrode it — so on every other image
+    /// `wait_for_service` returned success without probing anything. Issue
+    /// 1008 deleted it rather than fixing it, because a caller cannot recover
+    /// from an answer that does not distinguish the two.
     ///
     /// User-facing surface: `Client<S>::server_available()` in Rust,
     /// `nros_client_server_available()` in C/C++. Clients use this

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/shim/subscriber.rs
@@ -381,7 +381,13 @@ pub struct SubscriberAllocReport {
     heap_capacity: AtomicU32,
 }
 
-/// `"SUBA"` -- subscriber alloc. Written LAST by [`record_alloc_ceilings`].
+/// `"SUBA"` -- subscriber alloc.
+///
+/// Written LAST by this module's private `record_alloc`, so a reader that finds
+/// the magic is looking at a fully populated record. Not a doc LINK: the writer
+/// is private, and rustdoc rejects a public item linking to one (which is how
+/// this line's previous target, a `record_alloc_ceilings` that no longer
+/// exists, went unnoticed -- see issue 1110).
 pub const SUBSCRIBER_ALLOC_MAGIC: u32 = 0x53554241;
 /// Layout version for [`SubscriberAllocReport`].
 pub const SUBSCRIBER_ALLOC_VERSION: u32 = 7;

--- a/scripts/build/rustdoc-set.sh
+++ b/scripts/build/rustdoc-set.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# The crate + feature set the PUBLISHED API docs are built from — issue 1110.
+#
+# ONE spelling, because there are two consumers and they must not drift:
+#
+#   just book                 builds and deploys these pages (`docs.yml`)
+#   just check rustdoc-links  proves they still build, on a lane a PR runs
+#
+# The gate exists because nothing on a merge-gating path ran rustdoc, and
+# rustdoc's broken-link lint is deny-level here. `3941b569a` deleted
+# `ClientTrait::is_server_ready` while the paragraph beside it still linked to
+# it, and `just book` — plus every docs deploy — stayed red for three days
+# without any lane saying so. A second break (`nros-rmw-zenoh` naming a
+# `record_alloc_ceilings` that never existed) was sitting behind it, invisible
+# because rustdoc stops at the first crate that fails.
+#
+# The FEATURES are load-bearing and were learned the hard way (2026-08-21):
+# without `std,env,macros` rustdoc drops `ExecutorConfigEnvExt::from_env`, the
+# alloc-gated `ExecutorNodeRuntime::spin` and `nros::node!` — and every doc
+# comment linking those then fails to resolve. A narrower set does not make the
+# gate cheaper, it makes it wrong.
+#
+# Scope is the DEPLOYED set, not the workspace. A workspace-wide pass reports
+# ~70 diagnostics in crates nothing publishes (issue 1116): real, worth fixing,
+# and not what keeps the book from deploying. Widening this list is a ratchet
+# decision, not a drive-by.
+NROS_RUSTDOC_FEATURES="rmw-cffi,platform-posix,ros-humble,safety-e2e,std,env,macros"
+NROS_RUSTDOC_CRATES=(
+    nros
+    nros-rmw
+    nros-rmw-cffi
+    nros-rmw-zenoh
+    nros-platform-api
+    nros-platform-cffi
+)
+
+# `-p a -p b …`, for a caller that wants the cargo spelling.
+nros_rustdoc_package_args() {
+    local p
+    for p in "${NROS_RUSTDOC_CRATES[@]}"; do
+        printf '%s\n' "-p" "$p"
+    done
+}


### PR DESCRIPTION
`3941b569a` deleted `ClientTrait::is_server_ready` and left the paragraph beside it linking to the method. rustdoc's broken-link lint is deny-level here, so `just book` failed — and **`docs.yml`'s path filter includes `packages/core/nros-rmw/**`**, so the docs deploy was *failing*, not skipping, from 2026-09-03 until now.

**A second break sat behind it, invisible.** `nros-rmw-zenoh` documented `SUBSCRIBER_ALLOC_MAGIC` as *"Written LAST by `record_alloc_ceilings`"* — a function that never existed. rustdoc stops at the first crate that fails, so fixing one revealed the other. That is the argument for a lane rather than for two fixes.

## The prose

`is_server_ready` was deleted by #1008 rather than fixed, because it collapsed "don't know" and "no server" into one `false` while its trait default was `true`. Deleting the link alone would leave a dangling *"Distinct from"* clause, so the paragraph now states the three-way answer `service_is_ready` gives and records why the collapsing sibling is gone.

The zenoh line names its writer in prose: `record_alloc` is private, and a public item may not link to a private one — rustdoc rejects that too, which the first attempt at this fix discovered.

## The class

Nothing on a merge-gating path ran rustdoc. Same shape as issue 0319 (a backend suite with no lane, red on main for two days) and 0896 (`check-cli-tests` living only where no merge-gating event runs): **a correct check on a path nothing traverses.** The fix is the path.

`just check rustdoc-links` runs in the **`compile-smoke` job**, which already compiles the workspace on every pull request — so `check-lane-contracts`'s rule holds: a lane may only resolve artifacts its own job builds.

The crate + feature set is **data**, in `scripts/build/rustdoc-set.sh`, read by the gate *and* by `just book`. One spelling, because a gate documenting a different set from the one that deploys can be green while the deploy is red — which is exactly the state this issue records. The features are load-bearing: without `std,env,macros` rustdoc drops `from_env`, the alloc-gated `spin` and `nros::node!`, and every comment linking those fails to resolve (learned 2026-08-21).

## Scope, and what is deliberately left

The deployed six crates, not the workspace. A workspace pass reports **~70 diagnostics with five crates failing to document at all**, in crates nothing publishes — real, and a separate cleanup. Filed as **#1116** with the three kinds it decomposes into (a link to a deleted item; a public item linking to a private one; markdown that reads as a link and is not), and the plan to widen this gate once they are fixed.

## Verification

Mutation-verified: restoring the deleted link turns the gate red (2 diagnostics); removing it turns it green.

`just check fast`: 235/235 (one new gate). `just check rustdoc-links`: ~3 s warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK