### PR TITLE
fix(#1033): the XRCE ring depth was a dead knob, and over-subscription was mute

### DIFF
--- a/book/src/getting-started/zephyr.md
+++ b/book/src/getting-started/zephyr.md
@@ -314,11 +314,12 @@ The answer, and why it came out that way, is written to
 | `CONFIG_NROS_XRCE_AGENT_ADDR` | string | `"127.0.0.1"` | Agent IP address |
 | `CONFIG_NROS_XRCE_AGENT_PORT` | int | 2018 | Agent UDP port |
 | `CONFIG_NROS_XRCE_TRANSPORT_MTU` | int | 512 | Transport MTU |
-| `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | int | 8 | Max concurrent subscribers |
-| `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS` | int | 4 | Max service servers |
+| `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | int | -1 (derive) | Max concurrent subscribers |
+| `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS` | int | -1 (derive) | Max service servers |
 | `CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS` | int | 4 | Max service clients |
+| `CONFIG_NROS_XRCE_SUBSCRIBER_RING_DEPTH` | int | 32 | Queued samples per subscriber |
 | `CONFIG_NROS_XRCE_BUFFER_SIZE` | int | 1024 | Per-slot buffer size |
-| `CONFIG_NROS_XRCE_STREAM_HISTORY` | int | 4 | Reliable stream depth (2-16) |
+| `CONFIG_NROS_XRCE_STREAM_HISTORY` | int | 16 | Reliable stream depth (2-16) |
 
 ### C API Options (visible when `CONFIG_NROS_C_API=y`)
 

--- a/book/src/reference/environment-variables.md
+++ b/book/src/reference/environment-variables.md
@@ -132,15 +132,38 @@ and reports no error.
 |------------------------------------|-----------------------------------------------------------------------------|---------|-----|---------------|
 | `NROS_XRCE_BUFFER_SIZE`            | Per-slot receive buffer. See the note below — this is the receive ceiling.   | `1024`  | 64  | nros-rmw-xrce |
 | `NROS_XRCE_SUBSCRIBER_RING_DEPTH`  | Queued samples per subscriber                                               | `32`    | 1   | nros-rmw-xrce |
-| `NROS_XRCE_MAX_SUBSCRIBERS`        | Max concurrent subscribers                                                  | `8`     | 1   | nros-rmw-xrce |
-| `NROS_XRCE_MAX_SERVICE_SERVERS`    | Max concurrent service servers                                              | `4`     | 1   | nros-rmw-xrce |
-| `NROS_XRCE_MAX_SERVICE_CLIENTS`    | Max concurrent service clients                                              | `4`     | 1   | nros-rmw-xrce |
+| `NROS_XRCE_MAX_SUBSCRIBERS`        | Max concurrent subscribers. On Zephyr, DERIVED — see below.                 | `8`     | 0   | nros-rmw-xrce |
+| `NROS_XRCE_MAX_SERVICE_SERVERS`    | Max concurrent service servers. On Zephyr, DERIVED — see below.             | `4`     | 0   | nros-rmw-xrce |
+| `NROS_XRCE_MAX_SERVICE_CLIENTS`    | Max concurrent service clients                                              | `4`     | 0   | nros-rmw-xrce |
 | `NROS_XRCE_STREAM_HISTORY`         | Reliable stream history depth; sizes the per-session output buffer          | `16`    | 4   | nros-rmw-xrce |
 | `NROS_XRCE_CUSTOM_TRANSPORT_MTU`   | Custom transport MTU; stream buffers are `MTU x STREAM_HISTORY`             | `4096`  | 128 | nros-rmw-xrce |
 
 Dropping `MAX_SUBSCRIBERS`, `MAX_SERVICE_*` and `SUBSCRIBER_RING_DEPTH` to 1,
 `BUFFER_SIZE` to 256, `STREAM_HISTORY` to 4 and `CUSTOM_TRANSPORT_MTU` to 512
 takes the session struct from ~390 KB to ~10-20 KB.
+
+#### On Zephyr the three entity caps DERIVE, and the minimum is 0
+
+`CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` and `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS`
+default to `-1`, which means *take the number from the entities this image
+declares* (`nano_ros_node_register(... ENTITIES ...)`). A listener that declares
+one subscription and no service is built with one subscriber slot and zero
+service-server slots, which is what took the session struct from 427,968 bytes
+to 59,088 on the zephyr cpp listener ([issue
+1033](https://github.com/NEWSLabNTU/nano-ros/blob/main/docs/issues/archived/1033-xrce-subscriber-slots-budget-eight-for-one.md)).
+Stating a number in Kconfig or the environment still wins over the derivation,
+in both directions.
+
+Zero is a legal, honoured value for all three caps — it is not rounded up to 1.
+So creating an entity the image never declared does not truncate silently: the
+create fails with `InvalidConfig` and the backend logs which cap it hit, which
+knob moves it, and that the count came from the declaration.
+
+`NROS_XRCE_SUBSCRIBER_RING_DEPTH` is deliberately NOT derivable — no inventory
+knows how deep a burst a subscriber must survive — but it does now have a
+Kconfig symbol. It did not before issue 1033, which made it unsettable on
+Zephyr however it was spelled: a Zephyr cargo build sees only the knobs
+`nros_cargo_build.cmake` forwards, and shell exports do not survive that.
 
 #### `NROS_XRCE_BUFFER_SIZE` is the XRCE receive ceiling
 

--- a/docs/guides/zephyr-setup.md
+++ b/docs/guides/zephyr-setup.md
@@ -256,11 +256,12 @@ you receive, in the [book](../../book/src/getting-started/zephyr.md) and
 | `CONFIG_NROS_XRCE_AGENT_ADDR` | string | `"127.0.0.1"` | Agent IP address |
 | `CONFIG_NROS_XRCE_AGENT_PORT` | int | 2018 | Agent UDP port |
 | `CONFIG_NROS_XRCE_TRANSPORT_MTU` | int | 512 | Transport MTU |
-| `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | int | 8 | Max concurrent subscribers |
-| `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS` | int | 4 | Max service servers |
+| `CONFIG_NROS_XRCE_MAX_SUBSCRIBERS` | int | -1 (derive) | Max concurrent subscribers |
+| `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS` | int | -1 (derive) | Max service servers |
 | `CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS` | int | 4 | Max service clients |
+| `CONFIG_NROS_XRCE_SUBSCRIBER_RING_DEPTH` | int | 32 | Queued samples per subscriber |
 | `CONFIG_NROS_XRCE_BUFFER_SIZE` | int | 1024 | Per-slot buffer size |
-| `CONFIG_NROS_XRCE_STREAM_HISTORY` | int | 4 | Reliable stream depth (2–16) |
+| `CONFIG_NROS_XRCE_STREAM_HISTORY` | int | 16 | Reliable stream depth (2–16) |
 
 ### C API Options (visible when `CONFIG_NROS_C_API=y`)
 

--- a/docs/issues/archived/1033-xrce-subscriber-slots-budget-eight-for-one.md
+++ b/docs/issues/archived/1033-xrce-subscriber-slots-budget-eight-for-one.md
@@ -1,7 +1,7 @@
 ---
 id: 1033
 title: "The XRCE session budgets eight 32-deep subscriber rings, so a one-subscriber image pays 266,368 bytes for seven it will never use"
-status: open
+status: resolved
 area: rmw, memory
 severity: high
 found: 2026-09-04
@@ -75,7 +75,7 @@ ladder beside the zenoh ones.
 ## Do not just raise the heap
 
 Raising `NROS_ZEPHYR_HEAP_SIZE` past 310 KB would make the three cells in
-[issue 0968](0968-tier2-runtime-failures-unreproduced.md) pass while leaving an
+[issue 0968](../0968-tier2-runtime-failures-unreproduced.md) pass while leaving an
 image that reserves 86% of its session struct for entities it does not create.
 That is the shape this campaign exists to remove, and the boot failure is
 currently the only thing making it visible.
@@ -236,3 +236,135 @@ as user input, so changing a Kconfig DEFAULT does not reach a configured build
 dir. The first attempt at this read `CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=4`
 from a `.config` written before the sentinel existed and looked like the
 derivation had failed. `west build -p always` is what proves it.
+
+
+## Closed (2026-09-06) — the two things the derivation left open
+
+The saving above is real and shipped. Two things were still wrong once it
+landed, and both are fixed here.
+
+### 1. The other factor of a slot was a DEAD KNOB on Zephyr
+
+A slot is `XRCE_SUBSCRIBER_RING_DEPTH x XRCE_BUFFER_SIZE`. The derivation moved
+the slot COUNT; `BUFFER_SIZE` was already forwarded; `RING_DEPTH` — the `32` in
+`32 x 1024` — was not settable on Zephyr **by any means**, which is what this
+issue's opening section suspected and nobody had confirmed.
+
+Confirmed now, and the mechanism is issue 0460's, in the direction its gate does
+not look:
+
+* `nros-rmw-xrce-cffi/build.rs` has read `NROS_XRCE_SUBSCRIBER_RING_DEPTH` since
+  phase-207, `book/src/reference/environment-variables.md` documented it with a
+  default and a minimum, and `internal.h` invites `-DXRCE_SUBSCRIBER_RING_DEPTH`
+  — so it read as live from three directions;
+* there was **no `config NROS_XRCE_SUBSCRIBER_RING_DEPTH`** in `zephyr/Kconfig`
+  and **no `_nros_resolve_knob`** line in `nros_cargo_build.cmake`;
+* the reader's `$DOTCONFIG` fallback keys on `CONFIG_<name>`, so with no symbol
+  it finds nothing, and the curated cargo environment forwards only what the
+  resolver resolved (`NROS_RESOLVED_KNOBS` -> `_nros_knob_env`) — a shell export
+  does not survive it;
+* it also has no RFC-0049 rung: `XRCE_KNOBS` in
+  `nros-platform-config/src/platform_config.rs` is `custom_transport_mtu` and
+  `stream_history` only, so the descriptor was not a second carrier either.
+
+Fixed: a Kconfig symbol (default **32**, the value every Zephyr XRCE image has
+always compiled, so no image moves) plus the `_nros_resolve_knob` line.
+Deliberately NOT on the derivable ladder — the count is a fact about the image,
+the depth is a policy about bursts, and no entity inventory knows the second.
+
+**The class was swept and is larger than this issue.** A read-side inventory
+across the seven build scripts `check-kconfig-knob-forwarding` names finds ~10
+more sizing knobs the resolver never forwards — `NROS_MAX_PARAM_NAME_LEN`,
+`NROS_MAX_ARRAY_LEN`, `NROS_MAX_STRING_VALUE_LEN`, `NROS_MAX_BYTE_ARRAY_LEN`,
+`NROS_RMW_MAX_BACKENDS`, `NROS_RMW_MAX_NODES`, `NROS_RMW_MESSAGE_INFO_SLOTS`,
+`NROS_KEYEXPR_STRING_SIZE`, `NROS_SERVICE_TIMEOUT_MS`. **That is a lead, not a
+verdict**: several of them have a second carrier (the params ones read RFC-0049
+`rungs`, as `NROS_XRCE_CUSTOM_TRANSPORT_MTU` does), and which are genuinely
+unreachable was not established here. It is not filed as an issue for exactly
+that reason — a confident wrong root cause is worse than no filing (0859-0862).
+Whoever takes it should re-run the sweep and check each knob's rung before
+claiming any of them is dead:
+
+```
+python3 - <<'PY'
+import re
+cmake = open('zephyr/cmake/nros_cargo_build.cmake').read()
+fwd = set(re.findall(r'_nros_resolve(?:_derivable)?_knob\(\s*([A-Z0-9_]+)', cmake))
+kc  = set(re.findall(r'^config\s+([A-Z0-9_]+)', open('zephyr/Kconfig').read(), re.M))
+for f in ['packages/rmw/zenoh/nros-zpico-build/src/runner.rs',
+          'packages/rmw/zenoh/nros-rmw-zenoh/build.rs',
+          'packages/core/nros-node/build.rs',
+          'packages/rmw/xrce/nros-rmw-xrce-cffi/build.rs',
+          'packages/core/nros-params/build.rs',
+          'packages/rmw/cffi/build.rs',
+          'packages/platform/nros-platform/build.rs']:
+    for k in sorted(set(re.findall(r'"(NROS_[A-Z0-9_]+)"', open(f).read()))):
+        if k not in fwd:
+            print(('KCONFIG' if k in kc else '   -   '), k, f)
+PY
+```
+
+`check-kconfig-knob-forwarding` asks whether every FORWARDED knob has a reader.
+Nothing asks whether every READ knob is forwarded, which is why this hid.
+
+### 2. Exceeding a derived cap was not LOUD
+
+Before the derivation, exhausting a cap meant creating a ninth subscriber on an
+image budgeted for eight. Now the cap IS the declared count, so the ordinary way
+to hit it is to create an entity that was never declared — and all three
+exhaustion sites returned a bare `NROS_RMW_RET_ERROR`, the same value a NULL
+`backend_data` returns three lines up, with nothing logged. A correct
+derivation had made its own failure mode common and left it undiagnosable.
+
+Not silent truncation — it did fail the create — but nothing named the cap, the
+knob, or the declaration the number came from.
+
+Fixed, one shared spelling (`xrce_report_capacity_exhausted`, `session.c`):
+
+* the code is **`NROS_RMW_RET_INVALID_CONFIG`**, issue 0468's, added for exactly
+  this on the zenoh side — "a COMPILE-TIME capacity or configuration made the
+  call impossible ... the remedy is a rebuild, never a different argument". Same
+  failure one backend over, so the same code rather than a second spelling. It
+  round-trips to `TransportError::InvalidConfig`;
+* the diagnostic names the entity, its name, the cap, the knob, and *that the
+  default is derived from the declaration* — which is the sentence a reader
+  needs and could not have guessed;
+* delivery is `nros_platform_log_write`, the "platform's printk-equivalent"
+  `nros/rmw_ret.h` already names as where a backend logs at the failure site. It
+  reaches every platform, native_sim included, where Rust `std` stdio is fatal
+  (issue 0589).
+
+The session allocation gained the same treatment: `xrce_report_session_alloc_failed`
+prints `sizeof(xrce_session_state_t)` and the knobs that decide it. That is the
+one request this whole issue is about, and for as long as issue 0968 was open it
+presented as an anonymous boot failure because the number was never printed.
+
+### The ring depth's saving, and how it was measured
+
+`sizeof` on the host, with `xrce_subscriber_ring_entry` and
+`xrce_subscriber_slot` copied VERBATIM out of `internal.h` by a script (no
+retyping), at three depths:
+
+| `XRCE_SUBSCRIBER_RING_DEPTH` | one slot | vs default |
+| ---: | ---: | ---: |
+| 32 (default) | 33,296 | — |
+| 4 | 4,176 | -29,120 |
+| 1 | 1,056 | -32,240 |
+
+The depth-32 row reproduces this issue's DWARF measurement (33,296) exactly,
+which is what makes the other two trustworthy. Carried onto the listener's
+59,088-byte session: **29,968 at depth 4, 26,848 at depth 1** — computed by
+subtraction from that measured total, not re-measured on a target ELF.
+
+**The default does not move**, so no shipped image changes size today. What
+changed is that a Zephyr image can now claim that saving at all.
+
+### Not done
+
+* The ~10 swept sibling knobs above — a lead, not a verdict; see the caveat.
+* A gate for "every knob a build script reads is forwarded or has a rung".
+  Writing one means adjudicating each of those ~10, which is the work above.
+* No target build. The C changes compile clean under `cc-rs` with
+  `nros_cc_flags::strict_decls` (`cargo check -p nros-rmw-xrce-cffi`, both new
+  strings verified present in `libnros_rmw_xrce_c_inline.a`); the Zephyr image
+  was not rebuilt on this host.

--- a/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/internal.h
@@ -440,6 +440,57 @@ void xrce_dds_reply_type(const char* type_name, char* out, size_t out_cap);
 /* QoS mapping. */
 uxrQoS_t xrce_map_qos(const rmw_qos_profile_t* qos);
 
+/* ---- Capacity diagnostics (issue 1033) ------------------------------- */
+
+/* Severity for `nros_platform_log_write`, which takes `nros_log::Severity`'s
+ * `as_u8()`: 0 Trace, 1 Debug, 2 Info, 3 Warn, 4 Error, 5 Fatal. Spelled here
+ * rather than included from `nros/log.h`: that header belongs to `nros-c`, the
+ * layer ABOVE this one, and an RMW backend must not depend upward. */
+#define XRCE_LOG_ERROR 4
+
+/* Report that this image was BUILT with fewer `kind` slots than it has just
+ * been asked to create, then let the caller return
+ * `NROS_RMW_RET_INVALID_CONFIG`.
+ *
+ * issue 1033. Until the entity caps joined the derivable ladder, exhausting one
+ * meant creating a ninth subscriber on an image budgeted for eight — rare, and
+ * arguably the caller's problem. Now the cap is DERIVED from what the image
+ * DECLARED (`nano_ros_node_register(... ENTITIES ...)`), so it is exactly the
+ * declared count, and the ordinary way to hit it is to create an entity that
+ * was never declared. The remedy is a rebuild, and the reader needs to be told
+ * WHICH knob and WHY it is the number it is — a bare `NROS_RMW_RET_ERROR`, the
+ * code these paths used to return, says none of that and is the same value a
+ * NULL `backend_data` returns three lines up.
+ *
+ * `NROS_RMW_RET_INVALID_CONFIG` is issue 0468's code, added for precisely this
+ * on the zenoh side: "a COMPILE-TIME capacity or configuration made the call
+ * impossible ... the remedy is a rebuild, never a different argument". This is
+ * the same failure one backend over, so it gets the same code rather than a
+ * second spelling of it.
+ *
+ * Delivery is `nros_platform_log_write` — the "platform's printk-equivalent"
+ * `nros/rmw_ret.h` already names as where backends log at the failure site. It
+ * reaches every platform including Zephyr native_sim, where Rust `std` stdio is
+ * fatal (issue 0589).
+ *
+ * `kind` names the entity ("subscriber"), `name` the topic or service it was
+ * for, `cap` the compile-time maximum and `knob` the Kconfig symbol that moves
+ * it. */
+void xrce_report_capacity_exhausted(const char* kind, const char* name, unsigned cap,
+                                    const char* knob);
+
+/* Report that the ONE per-session allocation could not be served, with the size
+ * that was asked for and the knobs that decide it.
+ *
+ * issue 1033 — `sizeof(xrce_session_state_t)` is decided entirely at build time
+ * and dominated by `subscriber_slots`, and the whole struct is a single
+ * request. When it fails the caller gets `NROS_RMW_RET_BAD_ALLOC` and nothing
+ * else, which is how a 309,696-byte request against a 65,536-byte Zephyr heap
+ * presented as an anonymous boot failure for as long as issue 0968 was open.
+ * The number is knowable at the failure site; printing it is the difference
+ * between a nine-step bisect and one line. */
+void xrce_report_session_alloc_failed(size_t bytes);
+
 /* ---- session.c ---- */
 rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain_id,
                               const char* node_name, const rmw_session_options_t* options,

--- a/packages/rmw/xrce/nros-rmw-xrce/src/service.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/service.c
@@ -121,7 +121,14 @@ rmw_ret_t xrce_service_create(const rmw_node_t* node,
         }
     }
     if (slot == NULL) {
-        return NROS_RMW_RET_ERROR;
+        /* issue 1033 — see subscriber.c. This cap derives from
+         * NROS_DERIVED_MAX_QUERYABLES, which is 0 on an image that declared no
+         * served endpoint, so "the image was built with 0" is the common case
+         * here and it must not read as an internal error. */
+        xrce_report_capacity_exhausted("service server", service_name,
+                                       (unsigned)XRCE_MAX_SERVICE_SERVERS,
+                                       "NROS_XRCE_MAX_SERVICE_SERVERS");
+        return NROS_RMW_RET_INVALID_CONFIG;
     }
 
     xrce_service_server_state* ss =
@@ -566,7 +573,14 @@ rmw_ret_t xrce_client_create(const rmw_node_t* node, const rmw_service_type_supp
         }
     }
     if (slot == NULL) {
-        return NROS_RMW_RET_ERROR;
+        /* issue 1033 — see subscriber.c. Service CLIENTS are the one cap of the
+         * three that is still STATED rather than derived (no audited aggregate
+         * counts them, and the raw count would under-size an action client), so
+         * the remedy named here is the only one there is. */
+        xrce_report_capacity_exhausted("service client", service_name,
+                                       (unsigned)XRCE_MAX_SERVICE_CLIENTS,
+                                       "NROS_XRCE_MAX_SERVICE_CLIENTS");
+        return NROS_RMW_RET_INVALID_CONFIG;
     }
 
     xrce_service_client_state* cs =
@@ -654,7 +668,8 @@ rmw_ret_t xrce_client_destroy(rmw_client_t* client) {
     if (!xrce_session_is_closed(st)) {
         /* Phase 376 W5 — see xrce_publisher_destroy: fire-and-forget by design,
          * so a buffering failure is the only verdict this frame can have. */
-        uint16_t req = uxr_buffer_delete_entity(&st->session, st->output_reliable, cs->requester_oid);
+        uint16_t req =
+            uxr_buffer_delete_entity(&st->session, st->output_reliable, cs->requester_oid);
         (void)uxr_run_session_time(&st->session, 0);
         ret = req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
     }

--- a/packages/rmw/xrce/nros-rmw-xrce/src/session.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/session.c
@@ -28,6 +28,7 @@
 #include <uxr/client/core/session/object_id.h>
 #include <uxr/client/util/ping.h>
 
+#include <stdarg.h>
 #include <stdint.h>
 #include <time.h>
 #include <stdio.h>
@@ -36,13 +37,62 @@
 
 /* ---- Helpers ------------------------------------------------------- */
 
+/* issue 1033 — the ONE place this backend renders a diagnostic. Both reporters
+ * below funnel through it so there is a single answer to "where does an XRCE
+ * capacity failure come out", and adding a third reporter does not add a third
+ * spelling of the delivery.
+ *
+ * The buffer is a local, sized for a name at `XRCE_DDS_NAME_BUF_SIZE` plus the
+ * fixed prose. `snprintf` truncates rather than overflowing, and a truncated
+ * diagnostic is still strictly more than the nothing these paths printed
+ * before. Never called from the topic/request callbacks — only from the create
+ * paths and session open — so the stack cost is not on the RX path. */
+#if defined(__GNUC__)
+__attribute__((format(printf, 1, 2)))
+#endif
+static void
+xrce_log_error(const char* fmt, ...) {
+    char msg[352];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+    if (n < 0) {
+        return;
+    }
+    size_t len = ((size_t)n < sizeof(msg)) ? (size_t)n : sizeof(msg) - 1;
+    static const char kLogger[] = "nros_rmw_xrce";
+    nros_platform_log_write(XRCE_LOG_ERROR, (const uint8_t*)kLogger, sizeof(kLogger) - 1,
+                            (const uint8_t*)msg, (uintptr_t)len);
+}
+
+void xrce_report_capacity_exhausted(const char* kind, const char* name, unsigned cap,
+                                    const char* knob) {
+    xrce_log_error("no free %s slot for '%s': this image was BUILT with %s=%u. "
+                   "The default is DERIVED from the entities this image declares "
+                   "(nano_ros_node_register(... ENTITIES ...)), so an entity created "
+                   "without being declared is not counted. State CONFIG_%s, or declare "
+                   "it. Not truncating; the create fails.",
+                   kind, (name != NULL) ? name : "(unnamed)", knob, cap, knob);
+}
+
+void xrce_report_session_alloc_failed(size_t bytes) {
+    xrce_log_error("xrce_session_state_t (%lu bytes) did not fit. Its size is decided "
+                   "at BUILD time by NROS_XRCE_MAX_SUBSCRIBERS x "
+                   "NROS_XRCE_SUBSCRIBER_RING_DEPTH x NROS_XRCE_BUFFER_SIZE, plus the "
+                   "service server/client slots; it is ONE allocation, so a heap larger "
+                   "than the shortfall does not help. Lower a cap or raise the platform "
+                   "heap (CONFIG_NROS_ZEPHYR_HEAP_SIZE on Zephyr).",
+                   (unsigned long)bytes);
+}
+
 uxrObjectId xrce_alloc_entity_id(xrce_session_state_t* st, uint8_t type) {
     uint16_t id = st->next_entity_id++;
     return uxr_object_id(id, type);
 }
 
 rmw_ret_t xrce_confirm_entities(xrce_session_state_t* st, const uint16_t* requests,
-                                     uint8_t* statuses, size_t count) {
+                                uint8_t* statuses, size_t count) {
     bool ok = uxr_run_session_until_all_status(&st->session, XRCE_ENTITY_CREATION_TIMEOUT_MS,
                                                requests, statuses, count);
     if (!ok) {
@@ -341,8 +391,8 @@ static const char* locator_serial_path(const char* locator) {
 }
 
 rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain_id,
-                                 const char* node_name,
-                                 const rmw_session_options_t* options, rmw_session_t* out) {
+                              const char* node_name, const rmw_session_options_t* options,
+                              rmw_session_t* out) {
     /* XRCE has no discovery to restrict and no enclave. */
     (void)mode;
     if (out == NULL || node_name == NULL) {
@@ -361,8 +411,13 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
         return NROS_RMW_RET_ERROR;
     }
 
-    xrce_session_state_t* st = (xrce_session_state_t*)nros_xrce_calloc(1, sizeof(xrce_session_state_t));
+    xrce_session_state_t* st =
+        (xrce_session_state_t*)nros_xrce_calloc(1, sizeof(xrce_session_state_t));
     if (st == NULL) {
+        /* issue 1033 — say the SIZE. This is the request that dominated the
+         * struct and it is the one an oversized cap kills; a bare BAD_ALLOC
+         * names neither the number nor the knobs behind it. */
+        xrce_report_session_alloc_failed(sizeof(xrce_session_state_t));
         return NROS_RMW_RET_BAD_ALLOC;
     }
     st->next_entity_id = 2; /* id 1 reserved for the participant */
@@ -426,8 +481,7 @@ rmw_ret_t xrce_session_create(const char* locator, uint8_t mode, uint32_t domain
          * cannot express NULL through a string-literal macro). Treat both the
          * same: fall back to the local agent host, with the port defaulting
          * to XRCE_DEFAULT_AGENT_PORT just below. */
-        const char* addr_locator =
-            (locator != NULL && locator[0] != '\0') ? locator : "127.0.0.1";
+        const char* addr_locator = (locator != NULL && locator[0] != '\0') ? locator : "127.0.0.1";
         (void)locator_strip_udp_prefix(&addr_locator);
 
         char host[64];

--- a/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/subscriber.c
@@ -102,7 +102,11 @@ xrce_subscription_create(const rmw_node_t* node, const rmw_message_type_support_
         }
     }
     if (slot == NULL) {
-        return NROS_RMW_RET_ERROR;
+        /* issue 1033 — LOUD, and a code that says "rebuild", not the generic
+         * one. See `xrce_report_capacity_exhausted` in internal.h. */
+        xrce_report_capacity_exhausted("subscriber", topic_name, (unsigned)XRCE_MAX_SUBSCRIBERS,
+                                       "NROS_XRCE_MAX_SUBSCRIBERS");
+        return NROS_RMW_RET_INVALID_CONFIG;
     }
 
     xrce_subscriber_state* ss =
@@ -211,7 +215,8 @@ rmw_ret_t xrce_subscription_destroy(rmw_subscription_t* subscriber) {
          * agent acks), so the only failure this frame can see is a request that
          * would not BUFFER. That is worth reporting; the agent's own verdict is
          * not available at any price this path is willing to pay. */
-        uint16_t req = uxr_buffer_delete_entity(&st->session, st->output_reliable, ss->datareader_oid);
+        uint16_t req =
+            uxr_buffer_delete_entity(&st->session, st->output_reliable, ss->datareader_oid);
         (void)uxr_run_session_time(&st->session, 0);
         ret = req == UXR_INVALID_REQUEST_ID ? NROS_RMW_RET_ERROR : NROS_RMW_RET_OK;
     }

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -976,6 +976,39 @@ config NROS_XRCE_MAX_SERVICE_CLIENTS
       Maximum number of concurrent XRCE service clients.
       Maps to XRCE_MAX_SERVICE_CLIENTS.
 
+config NROS_XRCE_SUBSCRIBER_RING_DEPTH
+    int "Queued samples per subscriber"
+    default 32
+    range 1 1024
+    help
+      How many samples one subscriber slot buffers before the topic
+      callback drops the newest. Maps to XRCE_SUBSCRIBER_RING_DEPTH.
+
+      This is the OTHER multiplier of a subscriber slot: a slot costs
+      NROS_XRCE_SUBSCRIBER_RING_DEPTH x NROS_XRCE_BUFFER_SIZE (32 x 1024
+      by default) plus bookkeeping. Issue 1033 derived the slot COUNT
+      from the image's declared entities; this is the per-slot DEPTH,
+      and it is deliberately NOT derivable -- no inventory knows how
+      deep a burst a subscriber must survive. It is a policy, so it is
+      stated.
+
+      Issue 1033 also found it DEAD on Zephyr. `nros-rmw-xrce-cffi`'s
+      build.rs has read NROS_XRCE_SUBSCRIBER_RING_DEPTH since phase-207
+      and the book documented it, but there was no Kconfig symbol and
+      no `_nros_resolve_knob` line, and a Zephyr cargo build sees ONLY
+      the knobs that resolver forwards -- shell exports do not survive
+      it (issue 0460). So a Zephyr image could not change the depth by
+      any means, and setting it looked like it had worked. 32 is the
+      value every Zephyr XRCE image has always compiled; this makes it
+      reachable without moving it.
+
+      Depth 32 exists because the Agent batches a whole publish burst
+      onto the input stream inside one `uxr_run_session_time` call, so
+      the listener cannot drain between callbacks -- see the comment on
+      XRCE_SUBSCRIBER_RING_DEPTH in nros-rmw-xrce/src/internal.h before
+      lowering it. A node that publishes only, or reads a slow topic,
+      can drop it to 1 and save 31/32 of every subscriber slot.
+
 config NROS_XRCE_BUFFER_SIZE
     int "Per-slot static buffer size"
     default 1024

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -710,6 +710,29 @@ function(nros_resolve_knobs)
             "entity inventory" "${CMAKE_BINARY_DIR}/nros/entity_inventory.cmake")
         _nros_resolve_knob(NROS_XRCE_MAX_SERVICE_CLIENTS
             "${CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS}")
+        # issue 1033 — the slot COUNT above is half the arithmetic; this is the
+        # other half. A slot is RING_DEPTH x BUFFER_SIZE, and BUFFER_SIZE was
+        # forwarded while RING_DEPTH was not, so the 32 in `32 x 1024` was the
+        # one factor of `subscriber_slots` no Zephyr image could touch.
+        #
+        # `nros-rmw-xrce-cffi/build.rs` has read this knob since phase-207 and
+        # the book documented it with a default and a minimum, which is what
+        # made it look live. It was not: this resolver decides what reaches the
+        # cargo command (`NROS_RESOLVED_KNOBS` -> `_nros_knob_env`), a knob it
+        # never resolves reaches no build script, and a shell export does not
+        # survive the curated environment. Issue 0460's class, in the direction
+        # `check-kconfig-knob-forwarding` does not look: that gate asks whether
+        # every FORWARDED knob has a reader, never whether every READ knob is
+        # forwarded.
+        #
+        # NOT on the derivable ladder, deliberately. The count is a fact about
+        # the image ("how many subscriptions does it declare"); the depth is a
+        # policy about bursts ("how many samples must survive one
+        # `uxr_run_session_time` batch"), which no inventory knows. Default 32
+        # is what every Zephyr XRCE image has always compiled, so this makes the
+        # knob reachable without moving any image.
+        _nros_resolve_knob(NROS_XRCE_SUBSCRIBER_RING_DEPTH
+            "${CONFIG_NROS_XRCE_SUBSCRIBER_RING_DEPTH}")
         _nros_resolve_knob(NROS_XRCE_BUFFER_SIZE "${CONFIG_NROS_XRCE_BUFFER_SIZE}")
         _nros_resolve_knob(NROS_XRCE_STREAM_HISTORY
             "${CONFIG_NROS_XRCE_STREAM_HISTORY}")


### PR DESCRIPTION
Issue 1033's derivation landed on 2026-09-04 and took the zephyr cpp listener's
`xrce_session_state_t` from 427,968 bytes to 59,088 — the image boots. Two
things it left open are fixed here, and the issue is closed and archived.

## 1. `NROS_XRCE_SUBSCRIBER_RING_DEPTH` was a dead knob on Zephyr

A subscriber slot is `RING_DEPTH x BUFFER_SIZE`. The derivation moved the slot
COUNT; `BUFFER_SIZE` was already forwarded; the **32** in `32 x 1024` could not
be set on a Zephyr image by any means.

It read as live from three directions — `nros-rmw-xrce-cffi/build.rs` has read
it since phase-207, the book documents a default and a minimum, `internal.h`
invites `-DXRCE_SUBSCRIBER_RING_DEPTH` — and it was not:

* no `config NROS_XRCE_SUBSCRIBER_RING_DEPTH` in `zephyr/Kconfig`, so the
  reader's `$DOTCONFIG` fallback had no symbol to find;
* no `_nros_resolve_knob` line, and the curated cargo environment
  (`NROS_RESOLVED_KNOBS` -> `_nros_knob_env`) forwards only what the resolver
  resolved — a shell export does not survive it;
* no RFC-0049 rung either: `XRCE_KNOBS` is `custom_transport_mtu` and
  `stream_history` only, so the platform descriptor was not a second carrier.

This is issue 0460's class in the direction its gate does not look:
`check-kconfig-knob-forwarding` asks whether every FORWARDED knob has a reader,
never whether every READ knob is forwarded.

**The default stays 32** — the value every Zephyr XRCE image has always
compiled — so no shipped image changes size. Deliberately NOT on the derivable
ladder: the count is a fact about the image, the depth is a burst policy no
entity inventory knows.

The class was swept. ~10 more sizing knobs look unforwarded
(`NROS_MAX_PARAM_NAME_LEN`, `NROS_RMW_MESSAGE_INFO_SLOTS`, …), but several have
a second carrier via the RFC-0049 `rungs`, and which are genuinely unreachable
was **not** established. That is recorded in the issue doc as a lead with the
sweep command, not filed as an issue — a confident wrong root cause is worse
than no filing (0859-0862).

## 2. Exceeding a derived cap was not loud

Before the derivation, exhausting a cap meant creating a ninth subscriber on an
image budgeted for eight. Now the cap **is** the declared count, so the ordinary
way to hit it is to create an entity that was never declared — and all three
exhaustion sites returned a bare `NROS_RMW_RET_ERROR`, the same value a NULL
`backend_data` returns three lines up, with nothing logged. A correct derivation
had made its own failure mode common and undiagnosable.

Fixed with one shared spelling (`xrce_report_capacity_exhausted`, `session.c`):

* **`NROS_RMW_RET_INVALID_CONFIG`** — issue 0468's code, added for exactly this
  on the zenoh side ("a COMPILE-TIME capacity ... the remedy is a rebuild, never
  a different argument"). Same failure one backend over, same code;
* a diagnostic naming the entity, its name, the cap, the knob, **and that the
  default is derived from the declaration** — the sentence a reader needs and
  could not have guessed;
* delivered via `nros_platform_log_write`, the "platform's printk-equivalent"
  `nros/rmw_ret.h` already names, which reaches native_sim where Rust `std`
  stdio is fatal (issue 0589).

The session allocation gained the same treatment:
`xrce_report_session_alloc_failed` prints `sizeof(xrce_session_state_t)` and the
knobs that decide it — the one request this whole issue is about, which
presented as an anonymous boot failure for as long as issue 0968 was open.

## Numbers

**MEASURED** by host `sizeof`, with `xrce_subscriber_ring_entry` and
`xrce_subscriber_slot` copied verbatim out of `internal.h` by a script:

| `XRCE_SUBSCRIBER_RING_DEPTH` | one slot | vs default |
| ---: | ---: | ---: |
| 32 (default) | 33,296 | — |
| 4 | 4,176 | -29,120 |
| 1 | 1,056 | -32,240 |

The depth-32 row reproduces the issue's DWARF measurement (33,296) exactly,
which is what makes the other two trustworthy. Carried onto the listener's
59,088-byte session: **29,968 at depth 4, 26,848 at depth 1** — computed by
subtraction from that measured total, **not** re-measured on a target ELF.

## Rebuild note

No struct field moved and no `repr(C)` changed, so incremental build dirs stay
valid. A Zephyr image does need `west build -p always` to pick up the new
Kconfig **default**, since Zephyr treats an existing `.config` as user input.

## Verification

* `just check fast` — green (227 gates, 7 skipped for tooling absent in a fresh
  worktree: `nros` not built, zenoh-pico submodule not checked out).
* `cargo check -p nros-rmw-xrce-cffi` — clean, which compiles the C backend
  under `nros_cc_flags::strict_decls`; both new diagnostic strings verified
  present in `libnros_rmw_xrce_c_inline.a`.
* Same, clean, with `MAX_SUBSCRIBERS=MAX_SERVICE_SERVERS=MAX_SERVICE_CLIENTS=0`
  and `RING_DEPTH=1` — the zero-cap layout the derivation produces.
* **No target image was built on this host** (memory-constrained, other sessions
  building). The runtime diagnostic paths are therefore compiled but not
  executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
