### PR TITLE
fix(#1119): a clean build ships the pass-2 knob value, and a feature-gated guard had an ungated caller

### DIFF
--- a/cmake/NanoRosReconfigure.cmake
+++ b/cmake/NanoRosReconfigure.cmake
@@ -73,12 +73,18 @@
 #   |  2   | real            | subscribed (880)| 1496  <- still stale  |
 #   |  3   | real            | subscribed (880)| 880   <- settled      |
 #
-# Issue 1002 measured that and read it as a defect in this mechanism. It is
-# not: ninja re-runs cmake until `build.ninja` stops being stale, so all three
-# passes happen inside ONE `west build` and the build compiles at 880. What was
-# wrong was the DOCUMENTATION -- three call sites said "configure again", which
-# is right for one link and one short for two -- and what is a defect is the
-# bound below, which was counting the wrong thing.
+# Issue 1002 measured that and read it as a defect in this mechanism. It is not
+# a defect in the ARMING -- the bound below was counting the wrong thing, and
+# that half was real.
+#
+# But the claim issue 1002 replaced it with, that "ninja re-runs cmake until
+# `build.ninja` stops being stale, so all three passes happen inside ONE `west
+# build`", IS NOT TRUE, and issue 1119 measures it: a clean island build dir
+# gets 2 configures against 3 arming requests and links with the pass-2 value.
+# The arming works; the third restart does not happen. On the safety island
+# that shipped a 70296-byte arena where 46272 is correct -- silent, because
+# over-sizing always is. Do not read the table below as a description of what
+# one `west build` delivers.
 #
 # The rule, so the next producer does not re-derive it: a fragment needs one
 # arm per producer UPSTREAM of it in the chain, and the number of configures is

--- a/docs/issues/1119-ninja-runs-two-configures-for-a-three-configure-chain.md
+++ b/docs/issues/1119-ninja-runs-two-configures-for-a-three-configure-chain.md
@@ -1,0 +1,81 @@
+---
+id: 1119
+title: "The knob chain needs three configures and one `west build` runs two, so
+  a clean build dir ships the pass-2 value -- 24 KB of arena on the island"
+status: open
+type: bug
+area: build, boards, memory
+severity: high
+related: [issue-0991, issue-1002, phase-403, phase-412]
+---
+
+## The claim, and the measurement that contradicts it
+
+`cmake/NanoRosReconfigure.cmake` and `zephyr/cmake/nros_cargo_build.cmake` both
+state the same invariant, in detail and with a table:
+
+> ninja re-runs cmake until `build.ninja` stops being stale, so all three
+> passes happen inside ONE `west build` and the build compiles at 880.
+
+Measured on the safety island (MR-CANHUBK344), 2026-09-06, clean build dir, one
+the island's `board-build` recipe -- which is one `west build`:
+
+    configures actually run        2
+    re-configures armed            3
+    NROS_SUBSCRIBER_BUFFER_SIZE    1496   <- pass-2 value, the linked CLOSURE
+    NROS_DERIVED_SUBSCRIBER_...    880    <- the fragment on disk, SUBSCRIBED
+
+A second run of it on the same dir runs one more configure and
+delivers 880. So the chain converges -- in two invocations, not one.
+
+The arming is not the defect: three arms were requested and the fragments were
+future-dated. Ninja ran the generator twice and started the build.
+
+## What it costs
+
+The arena model bills each subscription three receive buffers at the delivered
+class. On this image, 11 subscriptions:
+
+    delivered 1496   arena 70296    RAM 307640 B / 320 KB   93.88%
+    delivered  880   arena 46272    RAM 280536 B / 320 KB   85.61%
+
+24,024 bytes of arena and 27,104 bytes of RAM, on a part with 320 KB, and the
+measured arena peak is 17,736 either way. Both images boot and both serve the
+full graph, which is the problem: over-sizing is silent. The island read the
+70296 figure as "the derivation over-budgets" and nearly went looking for a
+modelling error that does not exist.
+
+`check-knob-delivery` DOES catch it -- pointed at the unconverged dir it names
+the knob, the derived value and the resolved one exactly. Nothing runs it on a
+board build, so it caught nothing.
+
+## Why the two-deep chain is the shape
+
+    pass 1   entity=placeholder   bounds derived over the CLOSURE   readers: nothing
+    pass 2   entity=real          bounds derived over SUBSCRIBED    readers: 1496 (stale)
+    pass 3   entity=real          bounds unchanged                  readers: 880
+
+The readers run FIRST in a configure (`nros_resolve_knobs` inside
+`find_package(Zephyr)`) and the producers run mid- and end-configure, so each
+link in the chain costs a whole pass. Pass 3 exists only to let the readers see
+what pass 2 wrote, and pass 2's fragment is UNCHANGED from pass 3's point of
+view -- so whatever makes ninja restart has to survive a pass in which nothing
+the producer writes has changed.
+
+## Directions, none of them free
+
+* Make ninja actually restart the third time. It regenerates and re-executes,
+  but it did not do so twice here; whether that is a ninja bound, a west/cmake
+  wrapper, or the future-dating losing a race is not established, and guessing
+  is how this gets a second wrong fix.
+* Shorten the chain so readers do not run before producers -- read the fragment
+  lazily at the point of use instead of loading it in `find_package(Zephyr)`.
+  Removes the ordering entirely and is the largest change.
+* Fail the build instead of shipping the stale value. The safety island does
+  this now (`board-build` runs `check-knob-delivery` and refuses), which is a
+  guard rather than a fix: it converts a silent 24 KB into "run it again".
+
+## Do not
+
+Do not "fix" it by making the recipe build twice. That hides how many passes
+the chain needs, and the number of passes is the bug.

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -263,11 +263,17 @@ set(NROS_KNOB_DERIVE_SENTINEL -1)
 #   pass 2  entity=real         ->  sizes re-derived over the SUBSCRIBED set
 #   pass 3                          this loader finally reads them
 #
-# Ninja runs all three before the build starts, so a `west build` on a clean
-# dir is correct. A HAND-driven `cmake -S -B` sequence that stops after two is
-# not, and it looks correct: the fragment on disk already states the derived
-# size while `NROS_RESOLVED_*` in the cache still holds the closure one. That
-# is measured by case H of `tests/cmake-reconfigure-tests.sh`.
+# Issue 1119 -- this used to say ninja runs all three before the build starts,
+# so a `west build` on a clean dir is correct. Measured on the safety island
+# 2026-09-06, it gets TWO configures against three arming requests and links
+# with the pass-2 value: the fragment on disk states the derived size while
+# `NROS_RESOLVED_*` in the cache still holds the closure one. A HAND-driven
+# `cmake -S -B` that stops after two is in the same state, and so is a clean
+# `west build`. Both look correct, because over-sizing is silent.
+#
+# `check-knob-delivery <build-dir>` is the check that answers it; run it before
+# trusting a size out of a build dir. Case H of
+# `tests/cmake-reconfigure-tests.sh` measures the arming, not the restart.
 function(_nros_load_derived_message_bounds)
     nros_message_bounds_knobs_file(_knobs)
     if(NOT EXISTS "${_knobs}")


### PR DESCRIPTION
Two defects found by taking a board build apart, one of them costing 24 KB of RAM silently.

## The knob chain settles a pass late (issue 1119, filed here)

Two modules state that ninja re-runs cmake until `build.ninja` settles, so all three passes of the entity -> bounds -> knobs chain happen inside one `west build`. Measured on an MR-CANHUBK344, clean build dir, one build:

```
configures actually run        2
re-configures armed            3
NROS_SUBSCRIBER_BUFFER_SIZE    1496   <- pass-2 value, the linked CLOSURE
NROS_DERIVED_SUBSCRIBER_...     880   <- the fragment on disk, SUBSCRIBED
```

A second invocation converges. The arming is not the defect -- three arms were requested and the fragments were future-dated; ninja simply did not restart a third time.

What it costs: the arena model bills three receive buffers per subscription at the delivered class, so eleven subscriptions came out at 70296 bytes where 46272 is correct.

```
delivered 1496   arena 70296   RAM 307640 B / 320 KB   93.88%
delivered  880   arena 46272   RAM 280536 B / 320 KB   85.61%
```

24,024 bytes of arena, 27,104 of RAM, measured peak 17,736 either way. **Both images boot and serve the full graph**, which is the problem -- over-sizing is silent, and the consuming project was one step from filing a modelling bug against a model that is correct.

This PR corrects the two false claims and files the measurement. It deliberately does **not** attempt the restart fix: whether that is a ninja bound, the west/cmake wrapper, or the future-dating losing a race is not established, and a second wrong fix here is worse than a documented defect. `check-knob-delivery <build-dir>` already answers "did it arrive" by name and value; the consuming project now runs it and refuses to flash an image that fails it.

## A feature-gated guard with an ungated caller

`SimTimeGuard` is `#[cfg(feature = "sim-time")]`; `ros_time_timer_follows_the_simulated_clock`, which acquires it, was not.

```
error[E0433]: cannot find type `SimTimeGuard` in this scope
    --> packages/core/nros-node/src/executor/tests.rs:1779:21
```

Two changes that were each fine alone: main added the guard for issue 1104, and phase-412 added a boot-report lane running `--features std` without sim-time. They sit two lines apart in the same `check node-std-tests` recipe -- the first invocation turns sim-time on and passes 349 tests, the fourth leaves it off and cannot compile the test binary.

The lane that MEANS to cover that file hid the defect; the lane covering something else found it. Verified both directions: `--features std` compiles, and `--features std,sim-time,param-services` still runs the test green.

## Verification

`just ci gate` green. The board figures above are from an MR-CANHUBK344 with a serial router attached -- stage 6 FirstSpin either way, 4 nodes / 25 topics / 2 services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EST8f2UDcrw2Ztm5eLTuMC