### PR TITLE
docs(#1101): resolved as a duplicate of 1104 — the fix is already on main

### DIFF
--- a/docs/issues/archived/1101-sim-time-clock-source-test-depends-on-process-global-state.md
+++ b/docs/issues/archived/1101-sim-time-clock-source-test-depends-on-process-global-state.md
@@ -1,7 +1,7 @@
 ---
 id: 1101
 title: "`use_sim_time_attaches_and_detaches_the_clock_source` fails in the suite and passes alone — the `/clock` armed flag is a process global"
-status: open
+status: resolved
 type: bug
 area: core, testing
 severity: medium
@@ -83,3 +83,33 @@ the file.
    SHOULD be per-instance hides the defect rather than fixing it.
 3. Whichever wins, the test must fail when the flag is not armed, so keep the
    assertion.
+
+## Resolution — FIXED, as issue 1104
+
+**This is the same defect as issue 1104**, filed independently the same day by
+another session. Same test, same assertion, same mechanism: `time_source`'s
+armed flag is a process-global `AtomicBool` while an `Executor` is per-test, and
+`reconcile_ros_time_source` writes it from `spin_once`.
+
+Fixed on `main` by `SimTimeGuard` in `packages/core/nros-node/src/executor/
+tests.rs` — a mutex both sim-time-aware tests take, restoring on drop the value
+OBSERVED ON ENTRY rather than a guessed default. The clobbering neighbour turned
+out to be `ros_time_timer_follows_the_simulated_clock`, whose own doc comment had
+already reasoned about the hazard and solved half of it ("One test rather than
+four, deliberately... so four tests would race each other inside the one test
+binary") — which handles those four and nothing about a fifth test landing beside
+them.
+
+Measured there, both directions: 349 passed 0 failed over 5 runs; and with the
+guard removed from the NEIGHBOUR only, the original failure returns 3 of 3.
+
+Read `docs/issues/archived/1104-node-std-tests-red-time-source-process-global.md`
+for the full record, including a wider product guard that was tried and REJECTED
+because a mutation test showed the lock alone was sufficient.
+
+**Note for the next reader:** 1104 also records that under `--test-threads=1` a
+DIFFERENT test fails for an unrelated reason (a 1 ms window asserted off a
+free-running process clock) — that is issue 1105, not this one.
+
+No further work is needed here; this doc is archived so the defect is not fixed
+twice.


### PR DESCRIPTION
Two sessions filed the same defect on 2026-09-05. **#1101 and #1104 are the same issue**: same test (`use_sim_time_attaches_and_detaches_the_clock_source`), same assertion, same mechanism — `time_source`'s armed flag is a process-global `AtomicBool` while an `Executor` is per-test, and `reconcile_ros_time_source` writes it from `spin_once`, so a sibling test clears it under the assertion.

#1104 was fixed and merged (PR #526): `SimTimeGuard`, a mutex both sim-time-aware tests take, restoring on drop the value **observed on entry** rather than a guessed default.

Verified on `origin/main` before writing this:

- `SimTimeGuard` present in `packages/core/nros-node/src/executor/tests.rs`
- `1104-*.md` present in `docs/issues/archived/`
- #1101 names the identical test

## Why archive rather than leave it open

An open issue whose defect is already fixed is an invitation to fix it twice — and the second fix gets measured against a tree where the symptom no longer reproduces, which is exactly how a plausible-and-wrong root cause gets written down (the 0859–0862 class, where four issues were filed against artifacts built before the fix).

The resolution note also points forward: #1104 records that under `--test-threads=1` a **different** test fails for an unrelated reason — #1105, a 1 ms window asserted off a free-running process clock — so a reader arriving from a red single-threaded run is not sent chasing this one.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742