### PR TITLE
docs(#1052, #1048): resolve both — the fixes landed, and CI confirms the pair delivers

### DIFF
--- a/docs/issues/0968-tier2-runtime-failures-unreproduced.md
+++ b/docs/issues/0968-tier2-runtime-failures-unreproduced.md
@@ -508,7 +508,7 @@ line announcing it is dropped by the facade — so the cell greps for a marker t
 image is structurally unable to emit, and reports a messaging failure for a
 logging defect.
 
-Filed as [issue 1048](1048-esp32-log-records-are-silently-dropped.md) with the
+Filed as [issue 1048](archived/1048-esp32-log-records-are-silently-dropped.md) with the
 five closed hypotheses and the one remaining candidate (`log::set_logger`
 succeeds at most once per process, and this image has two log paths racing for
 the facade — the board registers a platform writer immediately above its

--- a/docs/issues/archived/1048-esp32-log-records-are-silently-dropped.md
+++ b/docs/issues/archived/1048-esp32-log-records-are-silently-dropped.md
@@ -1,7 +1,7 @@
 ---
 id: 1048
 title: "Every `log::info!` on the esp32-qemu board is silently dropped, so four e2e cells grep for a marker the image cannot emit"
-status: open
+status: resolved
 area: boards, testing
 severity: high
 found: 2026-09-04
@@ -177,3 +177,29 @@ silence hid where the image stopped. Filed as
 `Instruction access fault` whose `mepc` and `ra` are printable ASCII from
 source-path strings, i.e. a corrupted code pointer. It is what remains of
 `test_esp32_talker_listener_e2e` and `test_esp32_to_native`.
+
+
+## RESOLVED 2026-09-06 — and the defect it exposed is resolved too
+
+The fix (the `nros_log` sink installed on esp32, and the markers routed through
+it) landed 2026-09-04. What kept this issue open was the section above: the
+silence had hidden a SECOND defect, the talker stopping after `Ethernet ready.`,
+filed as issue 1052 and described here as "what remains of
+`test_esp32_talker_listener_e2e` and `test_esp32_to_native`".
+
+Both are answered now. Issue 1052 was a stack overflow — `.stack` is the linker
+leftover after `.bss` on this board, and `.bss` had squeezed it to 18,572 B — and
+in nightly run `33996315057` the esp32 job reports:
+
+| test | verdict |
+| --- | --- |
+| `test_esp32_qemu_talker_boots` | **PASS** |
+| `test_esp32_talker_listener_e2e` | **PASS** |
+
+`test_esp32_to_native` fails for an unrelated reason that is not the board: the
+esp32 lane never built the NATIVE half of that test (issue 1112).
+
+The pairing is worth stating because it is the argument for this issue's
+severity. A silently dropped log made a crash look like a hang, and the crash was
+found only after the logging was fixed — the diagnostic was load-bearing for
+diagnosing something else.

--- a/docs/issues/archived/1052-esp32-talker-faults-after-network-bringup.md
+++ b/docs/issues/archived/1052-esp32-talker-faults-after-network-bringup.md
@@ -1,7 +1,7 @@
 ---
 id: 1052
 title: "The esp32-qemu talker takes an instruction-access fault right after network bring-up, with a return address made of ASCII"
-status: open
+status: resolved
 area: rmw, boards
 severity: high
 found: 2026-09-04
@@ -73,7 +73,7 @@ creates one subscription.
 ## What this blocks
 
 `test_esp32_talker_listener_e2e` and `test_esp32_to_native` in
-[issue 0968](0968-tier2-runtime-failures-unreproduced.md). Both wait on the
+[issue 0968](../0968-tier2-runtime-failures-unreproduced.md). Both wait on the
 talker's `Publishing:` marker, which the image cannot reach.
 
 ## BISECTED 2026-09-04 — it is NOT in `register()`
@@ -244,7 +244,7 @@ Executor::open failed: Transport(ConnectionFailed)
 
 The reason was environmental — the router had failed to start with
 `libzenohc.so: cannot open shared object file`, which is
-[issue 0774](archived/0774-zenohd-loads-unpaired-libzenohc.md) exactly (`rmw_zenohd` resolves but does not run without the
+[issue 0774](0774-zenohd-loads-unpaired-libzenohc.md) exactly (`rmw_zenohd` resolves but does not run without the
 paired library on `LD_LIBRARY_PATH`). But the accident is the datum:
 
 | router | session | fault |
@@ -967,3 +967,44 @@ a ROS peer is not shown here — that is the QEMU network configuration, not the
 image. What is shown is the part this issue was about: the publisher is created,
 the timer fires, and the callback runs, where the image previously took an
 instruction-access fault immediately after network bringup.
+
+
+## RESOLVED 2026-09-06 — confirmed by CI, which closed the one caveat left
+
+The section above ends: "It still cannot reach the router under `-nic
+user,model=open_eth`, so delivery to a ROS peer is not shown here." That was my
+QEMU networking, not the image, and it is exactly what CI answers.
+
+Nightly run `33996315057`, esp32 job, first run in this sequence to reach its
+tests:
+
+| test | verdict |
+| --- | --- |
+| `test_esp32_qemu_talker_boots` | **PASS** |
+| `test_esp32_talker_listener_e2e` | **PASS** |
+
+The pair delivers. That is this issue's whole subject — the talker took an
+`Instruction access fault` immediately after network bringup and never reached
+its publish loop — and the test that exercises it passes on the lane.
+
+### What the fix was, in one line each
+
+* **Root cause**: `.stack` is the LINKER LEFTOVER after `.bss` on this board, so
+  every byte a static gains the stack loses, and there is no runtime overflow
+  guard. `.bss` had reached 295,444 B; the stack was 18,572 B against node.rs's
+  ~67 KB budget. `sp` at the fault was 2,548 B BELOW `_stack_end`, inside
+  `nros_smoltcp::TCP_RX_BUFFER_0`.
+* **Fix**: stop paying for undeclared entities. The talker declared no
+  subscriptions and still linked `SMALL_PAYLOADS` for eight; the listener the
+  same. Stack 18,572 -> 49,148 B (talker) and 22,060 -> 52,636 B (listener).
+* **Gate**: `check-executor-stack-floor` and `check-stack-floor`, because
+  node.rs had asked for this check in a COMMENT since issue 0190 and a comment
+  cannot run on a schedule.
+
+### Two claims of mine that were wrong, kept above rather than deleted
+
+The record is more useful with them than without: the "fault is on the CONNECTED
+path" finding was an artifact of faulting first, and the `create_publisher`
+symbol probe was a command that did not exist on PATH returning 0 for every
+input. Both are corrected in place. The bisect they supported (variants E/F/H)
+was measuring a stale image, which is issue 1025.

--- a/docs/roadmap/phase-423-esp32-qemu-bring-up.md
+++ b/docs/roadmap/phase-423-esp32-qemu-bring-up.md
@@ -26,10 +26,10 @@ each fix lands with no way to demonstrate it.
 * **[#1006](../issues/1006-esp32-qemu-configure-nondeterministic-deps.md) —
   the configure builds backends the board never uses.** Cost and blast radius,
   and it widens what a bring-up failure could be caused by.
-* **[#1052](../issues/1052-esp32-talker-faults-after-network-bringup.md) — the talker
+* **[#1052](../issues/archived/1052-esp32-talker-faults-after-network-bringup.md) — the talker
   takes an instruction-access fault right after network bring-up.** The runtime
   defect proper.
-* **[#1048](../issues/1048-esp32-log-records-are-silently-dropped.md) — every `log::info!` is
+* **[#1048](../issues/archived/1048-esp32-log-records-are-silently-dropped.md) — every `log::info!` is
   silently dropped**, so four e2e cells grep for a marker nothing prints. This is
   the OBSERVER, and it is the reason to sequence the phase rather than pick off
   whichever looks easiest: while it stands, the other three can only be debugged


### PR DESCRIPTION
Both carried `status: open` with their fixes already on `main` — the failure mode #1052's own text records: *"a HIGH-severity issue whose text overstates what is still broken is as misleading as one that understates it."*

## #1052 — the esp32 talker's fault after network bringup

Root cause was a **stack overflow**. `.stack` is the linker *leftover* after `.bss` on this board; `.bss` had reached 295,444 B, the stack was down to **18,572 B** against node.rs's ~67 KB budget, and `sp` at the fault sat 2,548 B below `_stack_end`, inside `nros_smoltcp::TCP_RX_BUFFER_0`.

Fixed by not paying for undeclared entities (talker 18,572 → **49,148 B**, listener 22,060 → **52,636 B**), and gated by `check-stack-floor` / `check-executor-stack-floor` — node.rs had asked for that check in a **comment** since #0190, and a comment can't run on a schedule.

Its last caveat was mine, not the image's: *"still cannot reach the router under `-nic user,model=open_eth`"*. CI answers it — nightly `33996315057`:

| test | verdict |
|---|---|
| `test_esp32_qemu_talker_boots` | **PASS** |
| `test_esp32_talker_listener_e2e` | **PASS** |

## #1048 — every `log::info!` silently dropped on esp32

`log::set_logger` doesn't *exist* on `riscv32imc` — it's `#[cfg(target_has_atomic = "ptr")]`. Fix landed 2026-09-04.

What kept it open was the **second defect its silence had hidden**: the talker stopping after `Ethernet ready.`, which it filed as #1052 and called "what remains of `test_esp32_talker_listener_e2e` and `test_esp32_to_native`". Both answered — the first passes; the second fails for a reason that isn't the board (the lane never built its native half, #1112).

That pairing is the argument for 1048's severity, so it's recorded rather than dropped: **a silently discarded log made a crash look like a hang, and the crash was found only after the logging was fixed.**

## Kept, not deleted

#1052's two wrong claims stay in place — the "fault is on the CONNECTED path" finding was an artifact of faulting first, and the `create_publisher` symbol probe was a command that didn't exist on PATH returning 0 for every input. The record is more useful with them.

## Link fallout

Archiving broke three links in live documents (0968, phase-423) and two inside 1052 itself. The `markdown-links` ratchet caught the latter — it counts dead links in **archived** documents and only lets that number fall, so archiving a doc with an already-dead link is refused. Baseline held at 422.

`just check fast` 234/234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)