### PR TITLE
fix(#1048): the class is ATOMICS, and the sweep says esp32-c3 is the only board

### DIFF
--- a/docs/issues/1123-zephyr-pure-rust-nros-log-has-no-sinks.md
+++ b/docs/issues/1123-zephyr-pure-rust-nros-log-has-no-sinks.md
@@ -1,0 +1,107 @@
+---
+id: 1123
+title: "A pure-Rust Zephyr image installs the `log` bridge and never publishes an `nros_log` sink list, so every framework record sits in the early ring"
+status: open
+area: boards, core
+severity: medium
+found: 2026-09-06
+related: [1048, 0589, 0708, 0710]
+---
+
+# The facade that works is not the facade CLAUDE.md tells you to use
+
+Found while sweeping the CLASS of issue 1048 (`log::set_logger` does not exist
+on `riscv32imc`, so the esp32-qemu board dropped every record). The esp32 half
+is fixed. This is the OTHER instance the sweep turned up, and it is the mirror
+image: on Zephyr the `log` facade works fine and `nros_log` is the one that
+goes nowhere.
+
+## What is claimed, and where
+
+CLAUDE.md's issue-0589 entry is explicit that `std::println!` kills a Zephyr
+native_sim image and that the replacement is:
+
+> Write `nros_log::nros_error!(nros_log::get_logger("<crate>"), …)`: it lands on
+> `LOG_ERR`/`printk`, never fatal, and reaches `no_std` targets that every
+> `cfg(feature = "std")` arm silently skipped.
+
+That is true of the delivery MECHANISM — `nros_platform_log_write` is defined
+unconditionally in `packages/platform/nros-platform-zephyr/src/platform.c:1117`
+and maps severity onto `LOG_ERR`/`LOG_WRN`/`LOG_INF` (or `printk` without
+`CONFIG_LOG`). It is not true of the DISPATCH, for a pure-Rust image.
+
+## The gap
+
+`nros_log::dispatch_to_sinks` (`packages/core/nros-log/src/lib.rs`) reads a sink
+list that `nros_log::init` publishes. With none published it does not fall back
+to the platform — issue 0710 deliberately removed that, because reaching for
+`nros_platform_log_write` on a path every binary executes turned a pluggable
+delivery into a link-time requirement. Instead it HOLDS the record in
+`nros_log::early`'s bounded ring, to be drained by whatever `init` eventually
+runs.
+
+For a pure-Rust Zephyr image, no `init` ever runs:
+
+* `nros::zephyr_component_main!` (`packages/api/nros/src/lib.rs:772`) installs
+  `zephyr::set_logger()` — the `log` facade — and nothing else.
+* `nros::main!`'s Zephyr `rust_main` codegen
+  (`packages/core/nros-macros/src/main_macro.rs:1906`) does the same.
+* `nros-board-zephyr` calls `::nros_platform_cffi::log::init_default()` at
+  exactly one funnel, `entry_tiers.rs:363` (`run_tiers`) — so only a MULTI-TIER
+  image is covered.
+* The C/C++ path is fine and is why this has stayed invisible:
+  `nros_log_emit` lazily calls `ensure_default_sinks()`
+  (`packages/api/nros-c/src/log.rs`), and `nros_log_init()` exists as an explicit
+  C entry. A pure-Rust image has no `libnros_c.a` (issue 0163), so neither runs.
+
+The records that go missing are not user records — a Zephyr example body writes
+`log::info!`, which works. They are the FRAMEWORK's: `nros-node`'s executor
+(`arena.rs`, `monitor.rs`, `action.rs`, `node.rs`, `spin.rs`),
+`nros-rmw-zenoh` (`shim/session.rs`, `zpico.rs` — including the session-pool
+diagnostic that issue 0589 moved to `nros_log` specifically so it would reach
+`no_std` targets), `nros-rmw-cffi`, and `nros-rmw-bridge`. On a pure-Rust Zephyr
+image every one of those is constructed, dispatched, held, and never seen.
+
+## Evidence, and what is NOT evidence
+
+STATIC only. This was read out of the sources listed above; no Zephyr image was
+built or booted for it, because the host it was found on could not afford a west
+build. Specifically NOT established:
+
+* whether any pure-Rust Zephyr fixture in the tree would visibly change output
+  once a sink list is published (the early ring has a bounded depth, so some
+  records may already have overflowed by the time an `init` lands);
+* whether the `early-records-<N>` default in a Zephyr build is non-zero at all —
+  `early-records-0` restores pre-0708 dropping.
+
+Both need a build to answer. Anyone picking this up should start there rather
+than trusting this section.
+
+## Why this is 1048's class and not a separate bug
+
+Issue 0708 required "every board boot funnel calls `init_default()`", and
+`nros_log::early`'s own module docs already record that as a SEARCH for boot
+paths that "kept losing". 1048 was that search losing on esp32-qemu: the board
+published at `run_bare` and not at `BoardEntry::run`, so a fixture image printed
+and a `nros::main!` image did not. This is the same search losing on Zephyr,
+where the funnel is a MACRO rather than a board method and so was never in the
+set anyone was grepping.
+
+## Fix sketch (not yet attempted)
+
+The two macros are the funnels, so they are where the call belongs — but neither
+expansion can name `nros_platform_cffi` today: the Zephyr example leaves
+(`examples/zephyr/rust/*/Cargo.toml`) dep `nros`, `nros-platform`, `zephyr`,
+`log` and the backend, and `nros` itself deps `nros-log` but NOT
+`nros-platform-cffi`. So a fix is either
+
+1. re-export the sink from a crate the leaves already dep — `nros-platform` gains
+   `pub use nros_platform_cffi::log;` under the features that already pull it in
+   (`platform-zephyr` enables `dep:nros-platform-cffi`), and both macros emit
+   `::nros_platform::log::init_default();`; or
+2. give the leaves the dep, which is worse — it is a link-time requirement
+   pushed onto every consumer, which is the shape issue 0710 rejected.
+
+(1) keeps the requirement on the crate that already declares the platform.
+Whichever is chosen, the acceptance is a BUILT native_sim image whose console
+shows a framework `nros_log` record, not a green `cargo check`.

--- a/docs/issues/archived/1048-esp32-log-records-are-silently-dropped.md
+++ b/docs/issues/archived/1048-esp32-log-records-are-silently-dropped.md
@@ -5,7 +5,8 @@ status: resolved
 area: boards, testing
 severity: high
 found: 2026-09-04
-related: [0968, 1025, 0064]
+related: [0968, 1025, 0064, 0589, 0708, 0710, 1052, 1123]
+resolved_in: 2026-09-06
 ---
 
 # The entity exists; the line announcing it does not
@@ -203,3 +204,107 @@ The pairing is worth stating because it is the argument for this issue's
 severity. A silently dropped log made a crash look like a hang, and the crash was
 found only after the logging was fixed — the diagnostic was load-bearing for
 diagnosing something else.
+---
+
+## The CLASS sweep (2026-09-06) — what was checked, and how
+
+The fix above landed at the reported site. This section closes the issue by
+answering the question the site could not: *where else does this hold?* The
+class has TWO halves, because the fix needed two changes, and they generalise
+differently.
+
+### Half 1 — "the `log` facade cannot hold a logger here"
+
+The condition is exactly `target_has_atomic = "ptr"` being absent. That is a
+question `rustc` answers, so it was ASKED rather than reasoned. Every bare-metal
+triple that appears anywhere in the tree, against
+`rustc --print cfg --target <t> | grep target_has_atomic=\"ptr\"`:
+
+| target | `target_has_atomic="ptr"` |
+| --- | --- |
+| `thumbv7m-none-eabi` | yes |
+| `thumbv7em-none-eabi{,hf}` | yes |
+| `thumbv8m.main-none-eabi{,h}` | yes |
+| `armv7a-none-eabi` | yes |
+| `aarch64-unknown-none` | yes |
+| `riscv32imac-unknown-none-elf` | yes |
+| `riscv64gc-unknown-none-elf` | yes |
+| **`riscv32imc-unknown-none-elf`** | **no** |
+| **`thumbv6m-none-eabi`** | **no** |
+
+Two targets have the property. `riscv32imc` is esp32-c3, this board, the
+reported site. `thumbv6m` has NO board crate — it appears only in
+`tests/qemu-baremetal/Dockerfile`'s installed-target list, in a NEGATIVE
+assertion in `nros-board-common/src/arch_flags.rs` ("thumbv6m (Cortex-M0) is not
+declared by freertos-lwip"), and in `Cargo.toml` comments in
+`nros-rmw-cyclonedds` / `nros-smoltcp` noting that neither target has atomic
+CAS. So **esp32-qemu is the only live instance**, and the sweep is complete
+rather than merely broad.
+
+It is now written into the source: the `esp_println::logger::init_logger` call
+carries `#[cfg(target_has_atomic = "ptr")]`, so on this board the dead call is
+dead in the SOURCE, and the next board on a non-atomic target inherits the
+statement instead of the silence. `cargo check --target
+riscv32imc-unknown-none-elf` is green with and without `--features rmw-zenoh`.
+
+A false premise was removed with it. `nros-board-mps2-an385/src/entry.rs` cited
+this very board as W7's evidence that `log` works on `no_std`
+("qemu-esp32-baremetal disproves that: it bridges `log` on a `no_std` target
+through `esp_println`"). The call existed; nobody had read the console. The
+axis is ATOMICS, not `std` — that comment now says so, and points here.
+
+### Half 2 — "nobody published an `nros_log` sink list"
+
+This one has no target property to key on, so every board crate was read.
+Coverage of `::nros_platform_cffi::log::init_default()` (or `nros_log::init`) at
+each boot funnel:
+
+* installs directly: `nros-board-linux` (`boot_hosted`), `nros-board-mps2-an385`
+  (`boot`, `rtic::init_with_config`, `node::run_bare`), `nros-board-freertos`
+  (`run_entry`, `run_bare`, `run_tiers_entry`), `nros-board-threadx`
+  (`run_entry`, `run_bare`, `run_tiers_entry`, `run_app_thread`),
+  `nros-board-nuttx` (`run_entry`, `run_tiers`), `nros-board-nuttx-qemu`
+  (`nsh_main`), `nros-board-esp32-qemu` (both funnels, as of this fix).
+* delegates to one of those and is therefore covered:
+  `nros-board-mps2-an385-freertos`, `nros-board-mps3-an536-freertos`,
+  `nros-board-s32z270-freertos`, `nros-board-freertos-posix` (→
+  `nros_board_freertos::run_*`); `nros-board-threadx-linux`,
+  `nros-board-threadx-qemu-riscv64`, `nros-board-threadx-port-riscv64` (→
+  `nros_board_threadx::run_*`).
+* not a board: `nros-board-cffi`, `nros-board-common`, `mps2-an385-pac`,
+  `boards/{linux,zephyr}` (support dirs).
+* **`nros-board-zephyr` covers `run_tiers` ONLY**, and the pure-Rust Zephyr
+  entry is a MACRO rather than a board method, so it was never in anybody's
+  grep. `zephyr_component_main!` and `nros::main!`'s Zephyr codegen install
+  `zephyr::set_logger()` and no sink list. Filed as **issue 1123** — same class,
+  mirrored: on Zephyr the `log` facade is the one that works and `nros_log` is
+  the one that goes nowhere. Static evidence only; it is marked as such there.
+
+### One spelling, and an ordering that was backwards
+
+The fix's `nros_log::init(&[&nros_platform_cffi::log::PlatformSink])` was a
+second spelling of `init_default()` — the same list, hand-written. It is now
+`init_default()`, matching every other board.
+
+Publishing it moved INTO `register_log_writer`, one line after the fn-pointer
+writer it feeds, and out of `run_bare`, where it ran BEFORE
+`nros_platform_esp32_qemu::register_log_writer`. That order was wrong in a way
+that only showed at the boundary: `nros_log::init` DRAINS the early ring through
+the sinks it installs, and `Esp32QemuPlatform::write` drops when the writer slot
+is `None` (`log_slot::get()` returns `None` for a zero slot). So every record
+held during `init_hardware` was drained straight into a null writer — the one
+window the early ring exists to serve. Both funnels now reach the pair together.
+
+### What was EXECUTED here, and what was reasoned
+
+Executed: the `rustc --print cfg` table above; the per-board grep and the reads
+behind the coverage list; `cargo check -p nros-board-esp32-qemu --target
+riscv32imc-unknown-none-elf`, green both with default features (`rmw-zenoh`) and
+with `--no-default-features --features ethernet`.
+
+NOT re-executed: the QEMU run. The `[INFO] nros: Subscriber created for topic:
+/chatter` line recorded in the FIXED section above is from the original fix run
+and stands as the runtime evidence; this session did not rebuild the image
+(the host could not afford a fixture build), so the cleanup is argued as a
+compile-verified refactor of a delivery path already observed working, not as a
+second observation.

--- a/docs/roadmap/phase-423-esp32-qemu-bring-up.md
+++ b/docs/roadmap/phase-423-esp32-qemu-bring-up.md
@@ -33,7 +33,11 @@ each fix lands with no way to demonstrate it.
   silently dropped**, so four e2e cells grep for a marker nothing prints. This is
   the OBSERVER, and it is the reason to sequence the phase rather than pick off
   whichever looks easiest: while it stands, the other three can only be debugged
-  by inference.
+  by inference. **RESOLVED 2026-09-06** — the markers deliver through `nros_log`
+  + the platform writer, and the class sweep is recorded in the archived issue.
+  Its one sibling instance (Zephyr pure-Rust images publish no sink list) is
+  [#1123](../issues/1123-zephyr-pure-rust-nros-log-has-no-sinks.md), which is
+  NOT part of this phase — no esp32 cell depends on it.
 
 ## Sequencing, and the reason for it
 

--- a/packages/boards/nros-board-esp32-qemu/src/node.rs
+++ b/packages/boards/nros-board-esp32-qemu/src/node.rs
@@ -308,11 +308,18 @@ pub fn run_bare<F, E: core::fmt::Debug>(config: Config, setup: F) -> !
 where
     F: FnOnce() -> core::result::Result<(), E>,
 {
-    // issue 0708 — publish the nros_log sink list at the boot funnel.
-    // A record raised inside a LIBRARY (the zenoh session-pool diagnostic of
-    // issue 0589, for one) is dropped until a sink list exists, and its author
-    // cannot know whether the board published one. Idempotent.
-    ::nros_platform_cffi::log::init_default();
+    // issue 0708 — publish the nros_log sink list at the boot funnel. A record
+    // raised inside a LIBRARY (the zenoh session-pool diagnostic of issue 0589,
+    // for one) is dropped until a sink list exists, and its author cannot know
+    // whether the board published one.
+    //
+    // issue 1048 — the publication moved INTO `register_log_writer`, one line
+    // after the fn-pointer writer it feeds, and this funnel no longer publishes
+    // ahead of it. Order is load-bearing and it used to be backwards here:
+    // `init` DRAINS the early ring through the sinks it installs, so installing
+    // `PlatformSink` before `nros_platform_esp32_qemu::register_log_writer` sent
+    // every record held during `init_hardware` to a null writer — the one place
+    // the early ring exists to serve. Both funnels now reach the pair together.
     init_hardware(&config);
     register_log_writer();
     match setup() {
@@ -355,25 +362,37 @@ pub(crate) fn register_log_writer() {
         }
     }
     nros_platform_esp32_qemu::register_log_writer(Some(writer));
-    // Issue #64 — also install a `log::Log` for the `log` crate facade so the
-    // examples' `log::info!("Published:/Received:")` (and nros's framework
-    // `::log::info!`) route to the console. Without it the `log` crate has no
-    // logger installed and silently drops every record. esp-println's logger
-    // writes straight to the same console as the platform writer above.
+
+    // Issue #64 — bridge the `log` crate facade too, so a node body written
+    // against `log::info!` (and nros's own framework `::log::info!`) reaches the
+    // same console. esp-println's logger writes straight to it.
+    //
+    // Issue 1048 — and the CFG IS THE POINT, not decoration. `log::set_logger`
+    // and `log::set_max_level` are both `#[cfg(target_has_atomic = "ptr")]` in
+    // `log` 0.4, and this board's target is `riscv32imc-unknown-none-elf` — RV32
+    // I M C, no `A` extension, so `rustc --print cfg` lists no
+    // `target_has_atomic="ptr"` and NEITHER FUNCTION EXISTS. `init_logger` was
+    // therefore a call that compiled, ran, and installed nothing: no logger can
+    // be installed on this board, by anyone, and every `log::*` record was
+    // dropped. Writing the condition out means the dead call is dead in the
+    // SOURCE rather than only in the binary, and any future board on a
+    // non-atomic target (thumbv6m is the other one rustc reports here) gets the
+    // same statement instead of the same silence.
+    #[cfg(target_has_atomic = "ptr")]
     esp_println::logger::init_logger(log::LevelFilter::Info);
 
-    // Issue 1048 — install the nros_log sink, which is what actually delivers
-    // on this board.
+    // Issue 1048 — publish the `nros_log` sink list, which is what actually
+    // delivers on this board, and publish it at EVERY funnel: `run_bare` did
+    // this and `BoardEntry::run` did not, so a `nros::main!` image reached the
+    // application with no sinks while a fixture image printed fine.
     //
-    // `init_logger` above cannot work here: `log::set_logger` is
-    // `#[cfg(target_has_atomic = "ptr")]` and riscv32imc has no atomic
-    // pointers, so the `log` facade can never hold a logger and drops every
-    // record. It is left in place for boards that DO have atomics.
-    //
-    // Without this call `nros_log` does not print either — `dispatch_to_sinks`
-    // finds a null sink list and HOLDS each record in the early buffer for a
-    // board that never speaks. `PlatformSink` routes to
-    // `nros_platform_log_write`, which is the fn-pointer writer registered
-    // immediately above: no atomics, and the same console.
-    nros_log::init(&[&nros_platform_cffi::log::PlatformSink]);
+    // Without it `nros_log` is no better off than `log` was — `dispatch_to_sinks`
+    // finds a null sink list and HOLDS each record in the early ring for a board
+    // that never speaks. `init_default` installs `PlatformSink`, which routes to
+    // `nros_platform_log_write`, the fn-pointer writer registered immediately
+    // above: no atomics, and the same console. Same spelling every other board
+    // uses (`nros-board-{linux,mps2-an385,freertos,threadx,nuttx,zephyr}`) —
+    // naming the sink by hand here was a second spelling of one idea.
+    // Idempotent: re-calling swaps the list pointer for the same default.
+    ::nros_platform_cffi::log::init_default();
 }

--- a/packages/boards/nros-board-mps2-an385/src/entry.rs
+++ b/packages/boards/nros-board-mps2-an385/src/entry.rs
@@ -129,10 +129,23 @@ where
     //
     // Note the direction. W7 was drafted the other way round — add `nros_log`
     // to the boards that lack it — on the premise that `log` needs `std`.
-    // qemu-esp32-baremetal disproves that: it bridges `log` on a `no_std`
-    // target through `esp_println`. So `log` is the user-facing facade
-    // everywhere and `nros_log` stays the platform/ABI layer (it is what
-    // `nros_platform_log_write`, and therefore the C API, is built on).
+    // `no_std` is indeed not what stops `log`: THIS board bridges it on a
+    // `no_std` target through semihosting, one line below. So `log` is the
+    // user-facing facade wherever it can be installed and `nros_log` stays the
+    // platform/ABI layer (it is what `nros_platform_log_write`, and therefore
+    // the C API, is built on).
+    //
+    // Issue 1048 — W7's evidence for that premise USED to be
+    // qemu-esp32-baremetal ("it bridges `log` on a `no_std` target through
+    // `esp_println`"), and that claim was FALSE: the call was there, it did
+    // nothing, and nobody had read the console. `log::set_logger` is
+    // `#[cfg(target_has_atomic = "ptr")]`, esp32-c3 is `riscv32imc` (no `A`
+    // extension), so on that board the facade cannot hold a logger at all and
+    // dropped every record for as long as the claim stood. What separates the
+    // two boards is ATOMICS, not `std` and not `no_std`: thumbv7m has them,
+    // riscv32imc and thumbv6m do not. A board on a non-atomic target must
+    // deliver through `nros_log` + the platform writer, which is why that half
+    // is not optional anywhere.
     crate::log_bridge::install_semihosting_log_bridge();
 
     // Phase 248 C5a (#60 T4) — the board owns RMW selection: register the linked


### PR DESCRIPTION
Closes #1048.

The reported site was already fixed on `main` (`6d9b2b7`, "install the nros_log
sink on esp32, and route the markers through it"). This PR closes the issue by
answering the question that fix could not — *where else does this hold?* — and by
removing the two things about it that would not survive a reader.

## Root cause, restated so the class is visible

`log::set_logger` and `log::set_max_level` are both `#[cfg(target_has_atomic =
"ptr")]` in `log` 0.4. esp32-c3 is `riscv32imc-unknown-none-elf` — RV32 I M C, no
`A` extension — so neither function exists and **no logger can be installed on
that board by anyone**. `esp_println::logger::init_logger` compiled, ran, and
installed nothing.

The condition is something `rustc` answers, so it was asked rather than reasoned:

```
for t in thumbv7m-none-eabi riscv32imc-unknown-none-elf thumbv7em-none-eabihf \
         aarch64-unknown-none riscv64gc-unknown-none-elf armv7a-none-eabi \
         thumbv8m.main-none-eabi thumbv6m-none-eabi riscv32imac-unknown-none-elf; do
  echo "$t $(rustc --print cfg --target $t | grep -c 'target_has_atomic="ptr"')"
done
```

Two of the nine lack it: `riscv32imc` (the reported site) and `thumbv6m`, which
has **no board crate** — it appears only in a Dockerfile target list, a NEGATIVE
assertion in `arch_flags.rs`, and two `Cargo.toml` comments. So the sweep is
complete, not merely broad, and esp32-qemu is the only live instance.

## What changed

* `esp_println::logger::init_logger` now carries `#[cfg(target_has_atomic =
  "ptr")]`. The dead call is dead in the SOURCE, and the next board on a
  non-atomic target inherits the statement instead of the silence.
* **The false premise that let this stand is removed.**
  `nros-board-mps2-an385/src/entry.rs` cited *this board* as phase-338 W7's
  evidence that `log` works on `no_std` — "qemu-esp32-baremetal disproves that:
  it bridges `log` on a `no_std` target through `esp_println`". The call existed;
  nobody had read the console. The axis is atomics, not `std`, and that comment
  now says so.
* **One spelling.** `nros_log::init(&[&PlatformSink])` was `init_default()`
  written out by hand; it is now `init_default()`, matching every other board.
* **An ordering that was backwards.** Publishing moved into
  `register_log_writer`, one line after the fn-pointer writer it feeds, and out
  of `run_bare`, where it ran *first*. `nros_log::init` DRAINS the early ring
  through the sinks it installs, and `Esp32QemuPlatform::write` drops when the
  writer slot is `None` — so every record held during `init_hardware` was drained
  straight into a null writer, which is the one window the ring exists to serve.

## The other half of the class, and the one instance it found

"Nobody published an `nros_log` sink list" has no target property to key on, so
all 20 board crates were read. Every funnel reaches `init_default()` directly or
through the freertos/threadx family lift — **except `nros-board-zephyr`**, which
covers `run_tiers` only. A pure-Rust Zephyr image enters through a MACRO
(`zephyr_component_main!`, `nros::main!`'s Zephyr codegen), which installs
`zephyr::set_logger()` and no sink list, and so was never in anybody's grep.
`nros_log::early`'s own module docs already call the 0708 rule "a SEARCH for boot
paths [that] kept losing"; this is it losing again.

Filed as **#1123** rather than fixed blind: it is the mirror image (on Zephyr
`log` works and `nros_log` is the one that goes nowhere), the evidence is STATIC
only, and it is marked as such in the issue. Acceptance there is a built
native_sim image, not a green `cargo check`.

## Verified vs. reasoned

**Executed:** the `rustc --print cfg` table; the per-board grep and the reads
behind the coverage list; `cargo check --target riscv32imc-unknown-none-elf`
green both with default features (`rmw-zenoh`) and with `--no-default-features
--features ethernet`; `just check fast` — 228 gates green, 6 skipped (all want an
in-tree `nros` this worktree has not built).

**NOT re-executed:** the QEMU run. The `[INFO] nros: Subscriber created for
topic: /chatter` line in the issue is from the original fix, and stands as the
runtime evidence. This PR is argued as a compile-verified refactor of a delivery
path already observed working, not as a second observation — the host could not
afford a fixture build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742
