### PR TITLE
docs(#1124, #1125): file the two findings this campaign recorded but did not fix

### DIFF
--- a/docs/issues/1124-fixture-resolver-err-laundered-into-skip.md
+++ b/docs/issues/1124-fixture-resolver-err-laundered-into-skip.md
@@ -1,0 +1,63 @@
+---
+id: 1124
+title: "Twelve tests turn a fixture-resolver `Err` into a `skip!`, so a lane gap reports as coverage"
+status: open
+area: testing
+severity: medium
+related: [0584, 1112, 0196]
+---
+
+## What
+
+Twelve sites across five test files answer a failed fixture resolution with
+`nros_tests::skip!` instead of failing:
+
+```rust
+Err(e) => nros_tests::skip!("<name> fixture not prebuilt ({e})"),
+```
+
+| file | sites |
+| --- | ---: |
+| `declarative_bridge_zenoh_to_cyclonedds.rs` | 4 |
+| `bridge_zenoh_to_cyclonedds.rs` | 3 |
+| `declarative_bridge_zenoh_to_xrce.rs` | 3 |
+| `bridge_mixed_rmw.rs` | 1 |
+| `zephyr.rs` | 1 |
+
+Issue 0584's rule: an absent **in-lane** fixture is a hard failure, not a skip —
+a gated run has already asserted the lane's fixtures are built, so "not prebuilt"
+means the LANE is wrong. Reporting that as a skip reports a gap as coverage.
+
+## Why it is filed rather than swept
+
+Issue 1112 fixed the thirteenth site (`esp32_emulator.rs`, `int32-sink`) and
+deliberately stopped there. The rule is about an **in-lane** fixture, and a
+bridge test whose fixture is genuinely out of the current lane SHOULD skip.
+Converting all twelve blind would turn correct skips into hard failures across
+several lanes — the 0196 shape, a gate wider than its rule.
+
+What made the esp32 one answerable was independent evidence: `_check-skip-budget`
+named it on a lane that had already asserted its fixtures were built, and the
+same file's two sibling tests already `.expect()`ed their peers. Each of the
+twelve wants that same evidence.
+
+## What answering it looks like, per site
+
+1. Which lane(s) run this test? (`matrix::CELLS` / `interop::CELLS`, and the
+   `NROS_TEST_COORDS` narrowing.)
+2. Does the fixture have a manifest row in that lane's build set?
+   `nros_fixture_row_artifact_dir_by_id` and `fixtures-manifest.py coords` answer
+   it; issue 1112's fix is the worked example.
+3. **In lane** ⇒ `.expect(...)`, and add the row to the lane's build if it is
+   missing. **Out of lane** ⇒ the skip is correct; say so in a comment naming the
+   lane, so the next reader does not re-litigate it.
+
+The likely split is not uniform: the bridge tests need a PEER built for another
+RMW, which is exactly the case a lane may legitimately exclude.
+
+## Why it matters
+
+A skip is invisible in a green run. Issue 1112's site hid a real lane gap for as
+long as it existed, while `_check-skip-budget` complained on every run and the
+complaint had nowhere to land — it can see that something laundered an `Err`, but
+not which site did it.

--- a/docs/issues/1125-large-subscriber-pool-is-never-derived.md
+++ b/docs/issues/1125-large-subscriber-pool-is-never-derived.md
@@ -1,0 +1,59 @@
+---
+id: 1125
+title: "`ZPICO_MAX_LARGE_SUBSCRIBERS` is never derived, and `LARGE_PAYLOADS` is the biggest symbol left in the esp32 image"
+status: open
+area: rmw, memory, codegen
+severity: medium
+related: [0827, 0963, 0896, 1052, 1061]
+---
+
+## What
+
+Issue 0827's derivation now sizes a leaf's pools from what it declares, and issue
+0963's join sizes the payload CLASSES from what an image subscribes to. Neither
+answers `ZPICO_MAX_LARGE_SUBSCRIBERS`.
+
+Measured on `examples/native/rust/talker` with the derived budget applied:
+
+| bytes | symbol |
+| ---: | --- |
+| **131,072** | `nros_rmw_zenoh::shim::subscriber::LARGE_PAYLOADS` |
+| 83,784 | `g_sessions` |
+| 4,504 | `SERVICE_BUFFERS` |
+| 4,096 | `SMALL_PAYLOADS` |
+
+`LARGE_PAYLOADS` is `MAX_LARGE_SUBSCRIBERS × RING_DEPTH × LARGE_SIZE` and is the
+single largest symbol in that image — larger than everything 0827 recovered
+(176,720 B) leaves behind in the same class.
+
+## Why neither derivation reaches it
+
+The entity inventory counts SUBSCRIPTIONS. It has no notion of a *large*
+subscriber, because "large" is not a property of the declaration — it is a
+property of the TYPE's bound relative to the class ceiling
+(`NROS_MESSAGE_BOUNDS_DEFAULT_SMALL_CEILING`). That is the message-bound
+inventory's question, not the entity inventory's.
+
+Issue 0963's join DOES compute `NROS_DERIVED_MAX_LARGE_SUBSCRIBERS` — over the
+SUBSCRIBED types, counting entities rather than distinct types so two
+subscriptions on one large type reserve two blocks. So the number exists for a
+CMake image whose payload classes derive.
+
+What is missing is the cargo-leaf side: `leaf_entity_env` writes the
+`[env]` sidecar from the ENTITY inventory alone, and the message-bound inventory
+is not part of that path.
+
+## What answering it needs
+
+The leaf's per-type bounds. `nros codegen` already emits the message-bound
+fragments (`NROS_MESSAGE_BOUND_<t>_{STATE,RX}`); the question is whether a cargo
+leaf can read them the way the CMake path does, and whether the SUBSCRIBED set is
+knowable there — issue 1061's manifest declaration carries the type in
+`sub:std_msgs/msg/String:/chatter`, so the input may already be present.
+
+## Do NOT guess it
+
+Same rule as `ZPICO_MAX_QUERYABLES` (issue 1061): a pool short of what the image
+receives is not a smaller pool, it is a dropped sample or a refused creation. The
+crate default is large and safe. A derived number here has to come from the
+bounds, or not be written.


### PR DESCRIPTION
Both were surfaced during the memory campaign and deliberately left unfixed. Filing them so they stop living only in commit messages.

## #1124 — twelve skip-launderers

Twelve sites across five files answer a failed fixture resolution with `nros_tests::skip!` instead of failing:

| file | sites |
|---|---:|
| `declarative_bridge_zenoh_to_cyclonedds.rs` | 4 |
| `bridge_zenoh_to_cyclonedds.rs` | 3 |
| `declarative_bridge_zenoh_to_xrce.rs` | 3 |
| `bridge_mixed_rmw.rs` | 1 |
| `zephyr.rs` | 1 |

#0584: an absent **in-lane** fixture is a hard failure — a gated run has already asserted the lane's fixtures are built, so "not prebuilt" means the *lane* is wrong, and a skip reports a gap as coverage.

**Filed rather than swept.** #1112 fixed the thirteenth site and stopped, because a bridge test whose fixture is genuinely out of lane **should** skip; converting all twelve blind would turn correct skips into hard failures — #0196's shape, a gate wider than its rule. The issue records the three-step check each site needs.

## #1125 — `ZPICO_MAX_LARGE_SUBSCRIBERS` is never derived

At **131,072 B**, `LARGE_PAYLOADS` is the largest single symbol left in the esp32 image — bigger than what #0827 recovered leaves behind in the same class.

Neither derivation reaches it. The entity inventory counts *subscriptions* and has no notion of a **large** one, because "large" is a property of the type's bound against the class ceiling — the message-bound inventory's question. #0963's join does compute `NROS_DERIVED_MAX_LARGE_SUBSCRIBERS` for a CMake image; the gap is the cargo-leaf path, where `leaf_entity_env` writes the sidecar from the entity inventory alone. #1061's manifest declaration already carries the type, so the input may be present.

Recorded with the same refusal as `ZPICO_MAX_QUERYABLES`: a pool short of what the image receives is a dropped sample or a refused creation, not a smaller pool.

Docs only. `just check fast` 234/234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)