### PR TITLE
fix(ci): the queue lane called a linked pool "not linked"

### DIFF
--- a/scripts/nros-mem-report.py
+++ b/scripts/nros-mem-report.py
@@ -422,12 +422,12 @@ def check(res):
         )
         return 1
     priced = [p for p in res["pools"] if p["declared"] is not None]
-    if not priced:
+    if not res["pools"]:
         # A check with nothing to check reads as coverage and is not. Every
         # image this is pointed at links a backend, and every backend has at
-        # least one annotated pool — so zero means the join broke (a renamed
-        # symbol, a stripped binary, a demangler that did not run), not that
-        # the image is lean.
+        # least one annotated pool — so zero MATCHES means the join broke (a
+        # renamed symbol, a stripped binary, a demangler that did not run),
+        # not that the image is lean.
         print(
             f"check-mem-report: NO annotated pool is linked into {res['elf']} — "
             "the check would be vacuous.\n"
@@ -435,6 +435,40 @@ def check(res):
             "join broke (stripped binary, renamed pool, demangling off)."
         )
         return 1
+    if not priced:
+        # MATCHED but not PRICEABLE, which is a different state and not an
+        # error. The join worked -- these pools are in the image and were
+        # identified -- but their formulas multiply a knob whose default is
+        # computed rather than literal, so there is no static number to
+        # compare against.
+        #
+        # Conflating the two cost `queue.yml` every run it ever made. The
+        # nuttx talker links exactly `SMALL_PAYLOADS` and `LARGE_PAYLOADS`,
+        # both priced through `ZPICO_SUBSCRIBER_RING_DEPTH`, whose default is
+        # computed (issue 0829's SYSTEM_DEFAULT sentinel) -- so `priced` was
+        # empty and the image was reported as linking no backend, which it
+        # plainly does. The freertos talker passes only because it also links
+        # `nros_rmw_cffi`'s `SLOTS`, whose formula is literal.
+        #
+        # Reported, not silent: an unpriceable pool is a gap in what this tool
+        # can assert, and a lane that prints nothing about it invites the same
+        # misreading from the other direction.
+        print(
+            f"check-mem-report: {len(res['pools'])} annotated pool(s) linked into "
+            f"{res['elf']}, none PRICEABLE.\n"
+            "The join worked -- these are the pools, measured -- but every formula\n"
+            "multiplies a knob with a computed default, so there is no static\n"
+            "number to check the arithmetic against:\n"
+        )
+        for p in res["pools"]:
+            print(f"  {fmt(p['measured']):>12}  {p['pool']}  ({p['declared_at']})")
+            print(f"                formula   {p['formula']}")
+            print(f"                unpriced  {p['unpriced_because']}")
+        print(
+            "\nNot a failure: the check asserts arithmetic it cannot compute here.\n"
+            "Give one of these knobs a literal default to make the pool checkable."
+        )
+        return 0
     bad = [p for p in priced if p["declared"] != p["measured"]]
     if not bad:
         print(
@@ -496,6 +530,7 @@ def selftest():
                 "measured": 2048,
                 "formula": "K * SZ",
                 "declared_at": "x.rs:1",
+                "unpriced_because": "knob `K` has a computed default",
             }
         ],
     }
@@ -522,9 +557,21 @@ def selftest():
         with contextlib.redirect_stdout(buf):
             return check(case)
 
+    # An unpriceable pool BESIDE a drifted one must still fail on the drift:
+    # the tolerance is for "nothing to compare", never for "did not compare".
+    mixed = {
+        "elf": "synthetic",
+        "pools": [unpriceable["pools"][0], drifted["pools"][0]],
+    }
+
     assert quiet(agreeing) == 0, "agreeing pool must pass"
     assert quiet(drifted) == 1, "drifted pool must FAIL"
-    assert quiet(unpriceable) == 1, "measured-only alone leaves nothing to check"
+    assert quiet(unpriceable) == 0, (
+        "a pool that MATCHED but cannot be priced is not a failure — the join "
+        "worked; there is simply no static number to compare. Conflating this "
+        "with the empty case is what kept queue.yml red on every run"
+    )
+    assert quiet(mixed) == 1, "an unpriceable pool must not mask a drifted one"
     assert quiet(empty) == 1, "a vacuous check must FAIL, not read as coverage"
     assert quiet(stale) == 1, "an agreeing pool on a STALE image must still FAIL"
     print("selftest: ok — the check passes on agreement and fails on drift")


### PR DESCRIPTION
`queue.yml` runs on **`merge_group`** — the merge path — and has failed **every completed run it has ever made** (13 of 13 in the last 60; no success on record). A uniformly-red lane on the merge path has no signal capacity: a real regression landing there is indistinguishable from yesterday's failure.

## What it dies on

```
mem-report --check: examples/qemu-arm-nuttx/rust/talker/.../talker
check-mem-report: NO annotated pool is linked into … — the check would be vacuous.
Either the image links no RMW backend, or the symbol-to-annotation join broke
(stripped binary, renamed pool, demangling off).
```

**None of that is true.** Reproduced locally against the nuttx ELF:

```
matched pools: 2   priced (declared not None): 0
   32,768  SMALL_PAYLOADS   ZPICO_MAX_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * NROS_SUBSCRIBER_BUFFER_SIZE
  131,072  LARGE_PAYLOADS   ZPICO_MAX_LARGE_SUBSCRIBERS * ZPICO_SUBSCRIBER_RING_DEPTH * ZPICO_SUBSCRIBER_LARGE_SIZE
```

The backend **is** linked and the join **did** work — the symbols are present, demangled, and both were identified. What is missing is a static *number*: both formulas multiply `ZPICO_SUBSCRIBER_RING_DEPTH`, whose default is computed rather than literal (issue 0829's `SYSTEM_DEFAULT` sentinel), so `pool_bytes` returns `None` with *"knob has a computed default"* — exactly as designed.

## The conflation

`check()` treated two different states as one error:

| state | meaning | correct verdict |
|---|---|---|
| no pool **matched** | join broke, or no backend | failure |
| matched, none **priced** | nothing to compare | not a failure |

Only **three** pools carry an annotation tree-wide, and two of them are the unpriceable pair above. The freertos talker passes the same step only because it *additionally* links `nros_rmw_cffi`'s `SLOTS`, whose formula is literal. So this was never nuttx-specific breakage — nuttx is simply the image whose linked pools happen to be the unpriceable ones.

(The nuttx image does contain a `SLOTS`, but it is `nros_log::early::SLOTS` — a different crate, and the join's crate guard correctly declines it. That guard is working as intended.)

## What changes

The **empty** case still fails, which is the anti-vacuity property that mattered: a broken join must not read as coverage. A pool that matched and cannot be priced is now **reported** — measured size, formula, and the knob blocking pricing — and returns 0:

```
check-mem-report: 2 annotated pool(s) linked into …, none PRICEABLE.
The join worked -- these are the pools, measured -- but every formula
multiplies a knob with a computed default …
        32,768  SMALL_PAYLOADS  (…/subscriber.rs:199)
                formula   ZPICO_MAX_SUBSCRIBERS * …
                unpriced  knob `ZPICO_SUBSCRIBER_RING_DEPTH` has a computed default
```

Reported rather than silent on purpose: an unpriceable pool is a gap in what this tool can assert, and a lane that says nothing about it invites the same misreading from the other side.

## Self-test

`unpriceable` flips from expecting 1 to expecting 0, and a new **`mixed`** case pins that an unpriceable pool beside a *drifted* one still fails — the tolerance is for "nothing to compare", never for "did not compare".

## Not fixed here, deliberately

Giving `ZPICO_SUBSCRIBER_RING_DEPTH` a literal default would make both pools checkable. That is a product decision about a sentinel issue 0829 introduced on purpose, not a CI fix.

Verified: `just check mem-report`, `gate-selftests`, `pool-inventory` all pass; the selftest passes; and the real nuttx ELF now returns 0 with the report above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
