### PR TITLE
docs(RFC-0064 R5, phase-375, phase-215): one board process, and the descriptor holds only primitives

### DIFF
--- a/docs/design/0064-board-support-organization.md
+++ b/docs/design/0064-board-support-organization.md
@@ -3,8 +3,8 @@ rfc: 0064
 title: "Board support organization: nano-ros as an embeddable library, not a board framework"
 status: Draft (LIVE — under active exploration)
 since: 2026-07
-last-reviewed: 2026-08-22
-implements-tracked-by: [phase-337, phase-375]  # R3's matrix; 375 = tier policy + onboarding cost
+last-reviewed: 2026-09-06
+implements-tracked-by: [phase-337, phase-375, phase-215]  # R3's matrix; 375 = tier policy + onboarding cost + R5's process; 215 = the FVP migration
 supersedes: []
 superseded-by: null
 ---
@@ -17,6 +17,13 @@ superseded-by: null
 > what was checked and what it showed; body claims should trace to it.
 > (Renumbered 0062 → 0064 on 2026-08-01 after an id collision with
 > unified-dependency-ssot; 0064 is now the settled id.)
+>
+> **Revision 5 (2026-09-06)** makes board ARRIVAL uniform. A tree-wide audit
+> found four different processes for adding a board and three mechanisms that
+> were correct and unreachable, so R5 states one process (a board is a package,
+> discovered by `provider_scan`), folds the FVP board's private `board.cmake`
+> format into it, and audits every descriptor field down to primitives. R5
+> changes no R2/R3/R4 principle.
 >
 > **Revision 3 (2026-08-04)** adds "The supported matrix" — the witness set, the
 > `net_stack` cost axis it keys on, the `native`→`linux` naming decision, and the
@@ -1599,3 +1606,244 @@ policy](https://doc.rust-lang.org/nightly/rustc/target-tier-policy.html);
 [Zephyr Twister](https://docs.zephyrproject.org/latest/develop/twister/index.html);
 [twister scope rules #57595](https://github.com/zephyrproject-rtos/zephyr/issues/57595);
 [Zephyr board porting](https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html).
+
+---
+
+## Revision 5 (2026-09-06) — one board process, and the descriptor holds only primitives
+
+Written after auditing every board in the tree to answer a simple question: does
+a board of ours arrive the same way a user's board does? It does not. Revision 2
+established that nano-ros declares what it needs and the integrator satisfies it;
+revision 5 makes the *arrival* uniform, so that "no builtin road" is a property of
+the code rather than a statement in a document.
+
+R5 changes no R2/R3/R4 principle. It applies them to the descriptor and to
+discovery, and it deletes the one board that grew its own format.
+
+### The measurement — four processes, not one
+
+Twelve `[[board]]` rows across eleven `nros-board.toml` files, plus one board
+with no descriptor at all (2026-09-06):
+
+| Route | How a board is added | Boards |
+| --- | --- | --- |
+| 1. Package | crate + `nros-board.toml` + `package.xml` announcing `<nano_ros_provides kind="board">` | 9 |
+| 2. Descriptor-only package | route 1 minus the crate (`packages/boards/{linux,zephyr}/`) | 2 |
+| 3. Bundle + `board.cmake` | 14 `NROS_BOARD_*` cmake variables, a Cargo mirror, and a `west` extension | 1 (`fvp-aemv8r-smp`) |
+| 4. Nothing at all | an inline `board = "…"` string in `examples/fixtures.toml` plus a `.conf` hand-placed in each example leaf | the rest |
+
+Route 4 is the finding that reframes this. Three Zephyr board ids are actually
+built — `native_sim/native/64`, `mps2_an385`, `qemu_cortex_a53/qemu_cortex_a53/smp`
+— and only the first is declared anywhere, wedged into the `zephyr` descriptor's
+`names` array beside a real name. `qemu_cortex_a53` has no package, no descriptor
+and no announcement; its per-board `.conf` lives in the example leaf that uses
+it, so a second consumer copies the file. **Our own QEMU board did the same job
+as the FVP board with zero files, while the FVP board spent eight plus a west
+verb.** Neither is the process.
+
+Three mechanisms are correct and unreachable — the class this tree keeps
+re-finding (issues 0896, 0963, and `check-test-scripts-have-callers`):
+
+1. **The phase-215 drift gate checks zero boards.**
+   `phase215_f_manifest_drift.rs` walks top-level `packages/boards/nros-board-*/`
+   dirs needing both `Cargo.toml` and `board.cmake`. The only `board.cmake` in
+   the tree sits one level deeper, at
+   `nros-board-zephyr/boards/fvp-aemv8r-smp/`, so the loop never reaches it —
+   and no board carries `[package.metadata.nros.board]` at all, so even a fixed
+   glob would hit `if msg.contains("no `[package.metadata.nros.board]`")
+   { continue; }`. The gate guards an invariant nothing satisfies.
+
+2. **The announcement is optional, so the newest board skipped it.**
+   `check-provider-announcements.py` reads `if not os.path.exists(pkg_xml):
+   continue  # not migrated yet`. `nros-board-mps3-an536-freertos` (phase-385,
+   the most recent board) has a descriptor and no `package.xml`. Nothing said so.
+
+3. **Discovery is a one-level glob**, `packages/boards/*/nros-board.toml`. A
+   bundle board stays invisible even after gaining a descriptor — issue 0729's
+   class, still open structurally — and an out-of-tree board has no way in at
+   all. Note this is *not* what phase-346 fixed: that phase made the board
+   FRAMEWORK resolvable from an out-of-tree leaf, through the Entry's build
+   script. Descriptor discovery was never part of it.
+
+### D1 — A board is a package, and that is the whole identity
+
+Adopt RFC-0087 D1 for boards without exception: a directory with a `package.xml`
+announcing `<nano_ros_provides kind="board" name="…"/>`, plus a sibling
+`nros-board.toml` saying what it lowers to. A crate only if the board needs
+bring-up code.
+
+```
+<any dir>/
+├── package.xml        <nano_ros_provides kind="board" name="…"/>   ← identity
+├── nros-board.toml    what it lowers to                            ← behaviour
+├── prj.conf           optional, Zephyr only
+├── boards/<flat>.conf / .overlay   optional, derived by convention
+└── Cargo.toml, src/   optional — rung 2 of the customization ladder
+```
+
+Ours and a user's differ in exactly one respect: which search root found them.
+
+### D2 — Discovery is `provider_scan` over an ordered root list
+
+Replace the glob with the scan RFC-0087 D6 specifies, rooted at
+`[workspace] package_paths` in `nros.toml`. Depth-independent, so bundle boards
+resolve; root-list-driven, so an out-of-tree board package is found by the same
+code path as an in-tree one. This is what makes D1 true rather than aspirational.
+
+### D3 — `[board.zephyr]`, so routes 3 and 4 stop existing
+
+One block carries the Zephyr facts a board needs, and conventions supply the
+rest:
+
+* `west_board` — the Zephyr board id. It stops being a string in
+  `fixtures.toml` (route 4) and a `NROS_BOARD_ZEPHYR_ID` cmake variable
+  (route 3), and it stops being smuggled through `names`.
+* ``boards/<west_board with `/` → `_`>.{conf,overlay}`` — derived,
+  present-if-exists. `board.cmake` already stated this rule in a comment and
+  then hand-wrote both paths anyway.
+* `prj.conf` — derived, present-if-exists.
+* `runner` — from Zephyr's own board definition; stated only when it differs
+  (the FVP's `armfvp` does).
+* a Rust-support Kconfig module — derived and GENERATED, since its whole body is
+  `default y if BOARD_<UPPER(first segment of west_board)>`.
+
+### D4 — cmake reads a generated projection, never a second authored file
+
+`nano_ros_use_board(<name>)` keeps its signature — a downstream consumer's call
+site does not move — but its body runs `nros board cmake-vars <name> --out
+<build-dir>/…` and `include()`s the result. A build artifact, never committed
+(the SystemModel precedent, phase-330). `board.cmake` and the
+`[package.metadata.nros.board]` mirror are deleted, and with them the two-faces
+drift problem rather than the vacuous gate that watched for it.
+
+The replacement test is a round-trip — descriptor → projection → parse back ==
+descriptor — which cannot go vacuous, because it has no "skip if the other face
+is missing" arm.
+
+### D5 — The announcement becomes mandatory
+
+`check-provider-announcements` loses the `continue`: a descriptor with no
+sibling `package.xml` is an error, ratcheted against today's single offender.
+
+### D6 — The descriptor holds primitives only
+
+A field audit over all 12 rows. The rule is RFC-0087 D4's — a descriptor carries
+only what no convention can produce — plus RFC-0049's duty rule, which says a
+software-stack fact belongs to the platform and a hardware fact to the board.
+
+**Keep (primitive):** `names`, `platform`, `supported_netstacks`,
+`[board.capabilities]` heap/atomics/threads, `board_crate`, `target`, `chip`,
+`[board.cmake] toolchain_file`.
+
+**Move to the platform descriptor** — the board is copying a fact it can get
+wrong:
+
+| Field | Evidence |
+| --- | --- |
+| `platform_feature` (12/12) | 3 of 12 are NOT `platform-<platform>`: esp32 → `platform-bare-metal`, threadx-linux and threadx-riscv64 → `platform-threadx` |
+| `link_kind` (12/12) | 11 `none`, 1 `nuttx-staging` — and BOTH NuttX rows carry it |
+| `[board.priority_plan]` (6) | `mps2-an385-freertos` and `mps3-an536-freertos` hold byte-identical blocks (`[1,7]`, transport `[4,4]`, app `[1,3]`). That is `configMAX_PRIORITIES`, a FreeRTOS fact. A board that retunes it still overrides |
+
+The Zephyr row's `resolver = "scripts/lib/priority_plan.py:resolve_zephyr_plan"`
+is a file path and a Python symbol living in a board descriptor. It moves with
+the block.
+
+**Derive, override permitted:**
+
+| Field | Rule | Exceptions today |
+| --- | --- | --- |
+| `entry_kind` (12) | hosted platform → `hosted-main`; zephyr → `zephyr-staticlib`; else `board-run` | none |
+| `local_aliases` (10) | default `[platform_feature]` | 2 real (esp32, threadx-riscv64) |
+| `[board.entry] crate_name` (7) | `snake_case(board_crate)` | none — 7 of 7 |
+| `[board.entry] signature` (7) | default `#[unsafe(no_mangle)] extern "C" fn main() -> !` | 3 real (esp-hal, cortex-m-rt, plain `fn main`) |
+
+**Decompose.** `cargo_config` (8/12) is a raw TOML blob — a TOML document inside
+a TOML document, with no schema check on the inner one. The `rustflags` (8),
+`runner` (3) and `linker` (2) counts in this audit came from *inside* it as
+text; those primitives do not exist as fields. They should:
+
+```toml
+# today
+cargo_config = '''
+[target.thumbv7m-none-eabi]
+runner = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic …"
+rustflags = ["-C","link-arg=-Tlink.x","-C","link-arg=--gc-sections"]
+'''
+
+# after
+target    = "thumbv7m-none-eabi"
+runner    = "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic …"
+rustflags = ["-C","link-arg=-Tlink.x","-C","link-arg=--gc-sections"]
+```
+
+The CLI already composes the leaf `.cargo/config.toml`; it should build it from
+those rather than paste a blob through. This is also the field a user is most
+likely to get wrong, and the one they get the least help with.
+
+**Drop:**
+
+* `capability_features` (7) — all seven hold the identical value
+  `["safety-e2e"]`, and the only read in the entire tree is
+  `board_descriptor.rs:1118`, inside
+  `fn a_board_advertises_the_safety_capability_feature()`. A field whose sole
+  reader is a test asserting that the field is used.
+* `[board.entry] comment` (4) — a Rust `//` comment stored as an escaped
+  multi-line TOML string. Presentation, not a board fact.
+* `crate_path`, `board_features` — present in the struct, authored by nobody.
+
+**Keep but reclassify:** `target_contains` (2) is not a board property; it is a
+disambiguator so two `[[board]]` rows in one file can be told apart by target
+substring. Rename it to say so.
+
+**Left alone, flagged:** `toolchain` (10 stable / 2 nightly). Both nightly rows
+sit on custom targets needing `build-std`, which suggests a target fact rather
+than a board one. Not enough evidence to move it.
+
+Rung 3 of the customization ladder survives intact: `crate_root_extra`,
+`crate_root_deps` and `closure_extra` remain the escape hatch, renamed to say
+that is what they are. A model that cannot be escaped is worse than none.
+
+### What it costs to add a board, after
+
+A QEMU Zephyr board authors **6 keys**. Today's equivalent authors 19.
+
+```toml
+[[board]]
+names               = ["qemu-cortex-a53"]
+platform            = "zephyr"
+supported_netstacks = []
+
+[board.zephyr]
+west_board = "qemu_cortex_a53/qemu_cortex_a53/smp"
+
+[board.capabilities]
+heap = true
+atomics = true
+threads = true
+```
+
+`platform_feature`, `local_aliases`, `link_kind`, `entry_kind`, `toolchain` and
+the priority plan all follow from `platform = "zephyr"`.
+
+A real out-of-tree board on real silicon — the MR-CANHUBK3 this RFC was written
+against — authors the same shape plus what genuinely differs: a crate for rung-2
+bring-up (`nros_board_init_eth()`), a `[board.cmake] toolchain_file`, a linker
+script in `rustflags`, and a `[board.provisioning] gated` naming its own SDK
+entry. Field for field, that is the in-tree `s32z270-freertos` descriptor. The
+only difference is which root found it — which is the whole claim of D1 and D2,
+and today it is false, because the root list is a hardcoded glob.
+
+### Gates this revision asks for
+
+* `check-board-descriptor-single-source` — no `board.cmake` anywhere, no
+  `[package.metadata.nros.board]` anywhere.
+* The projection round-trip, replacing `phase215_f_manifest_drift.rs`.
+* D4's ratchet, in RFC-0087's shape: a stated derivable field must equal its
+  derived value, and a moved field must not be restated at board level unless it
+  differs.
+* `check-provider-announcements` without the `continue` (D5).
+
+Tracked by [phase-375](../roadmap/phase-375-board-tier-policy-and-onboarding-cost.md)
+W6–W9; the FVP migration is [phase-215](../roadmap/phase-215-board-crate-as-importable-unit.md)
+215.K. The package-shape half lands inside
+[phase-420](../roadmap/phase-420-package-identity-and-provider-format.md) W3.

--- a/docs/roadmap/phase-215-board-crate-as-importable-unit.md
+++ b/docs/roadmap/phase-215-board-crate-as-importable-unit.md
@@ -2,7 +2,8 @@
 
 **Goal.** Turn `packages/boards/nros-board-<name>/` into a unit a
 downstream Zephyr app (ASI is the reference consumer) imports with a
-**single cmake call** plus a **`west fvp run`** invocation, with no
+**single cmake call** plus a **stock `west build -t run`** (was `west fvp run`
+until RFC-0064 R5 / 215.K), with no
 hand-curated `EXTRA_CONF_FILE` / `DTC_OVERLAY_FILE` / hardcoded board
 id list / hand-rolled FVP launch flags on the consumer side. FVP
 AEMv8-R is the driving case; the shape is generic across boards.
@@ -21,7 +22,30 @@ ladder visits; see the bullet for what still holds):
   the `board_import_fvp` fixture both do; whether an entry layering its OWN
   config over the board's counts as "nothing else" is a judgement the phase
   owner should make rather than a gate;
-* `west fvp run` launching `FVP_BaseR_AEMv8R` end to end — needs the simulator;
+* the run path launching `FVP_BaseR_AEMv8R` end to end — needs the simulator.
+  Restated by 215.K.4: the thing to verify is stock `west build -t run` with
+  `ARMFVP_BIN_PATH` exported by `activate.sh`, not `west fvp run`;
+
+**RFC-0064 revision 5 (2026-09-06) SUPERSEDES the mechanism, not the goal.** The
+one-line import stands and does not move; what changes is what sits behind it. A
+tree-wide board audit found this phase invented a private descriptor format for
+one board — `board.cmake`, 14 `NROS_BOARD_*` variables and a `west` extension —
+while eleven other boards use `nros-board.toml`, and that two of the artifacts
+built here are unreachable:
+
+* **215.F's drift audit checks zero boards.** It walks top-level
+  `packages/boards/nros-board-*/` dirs needing both `Cargo.toml` and
+  `board.cmake`; the only `board.cmake` in the tree is one level deeper, and no
+  board carries `[package.metadata.nros.board]` at all.
+* **`west fvp` does not avoid the problem it exists for.** Its last statement is
+  `os.execvpe('west', ['west','build','-d',dir,'-t','run'])` — the exact command
+  ASI declined because a reconfigure diverges the size-probe identity. 117 lines
+  of env wiring wearing a verb.
+
+215.A, 215.C, 215.D and 215.F are therefore **superseded** and their artifacts
+are deleted by **215.K**; 215.B, 215.E, 215.G and 215.J survive unchanged, which
+is why the goal does not move. The general half is
+[phase-375](phase-375-board-tier-policy-and-onboarding-cost.md) W6–W9.
 
 **Priority note.** The `P1` below rests on "unblocks ASI's actuation consumption
 story". ASI has consumed it since its phase 2.C and its FVP lane is green across
@@ -120,7 +144,13 @@ against drift.
 
 ## Work Items
 
-### 215.A — Sidecar `board.cmake` per board crate
+### 215.A — Sidecar `board.cmake` per board crate — **SUPERSEDED (RFC-0064 R5, 2026-09-06)**
+
+> Landed and working, but it is a second descriptor format for one board. Folds
+> into `nros-board.toml`'s `[board.zephyr]` block; 14 variables become 8 authored
+> plus 6 derived. Deleted by 215.K. The two open boxes below (A.1 schema doc, A.3
+> cross-reference) are **withdrawn** — documenting a format being deleted is work
+> nobody should do.
 
 - [x] **215.A.1** Define the `board.cmake` schema. Variables:
       `NROS_BOARD_ZEPHYR_ID` (Zephyr `BOARD` string),
@@ -173,7 +203,11 @@ against drift.
 - **Files:** `zephyr/cmake/nano_ros_use_board.cmake` (new),
   `zephyr/CMakeLists.txt` (include + invocation site).
 
-### 215.C — Cargo.toml `[package.metadata.nros.board]` mirror
+### 215.C — Cargo.toml `[package.metadata.nros.board]` mirror — **SUPERSEDED (RFC-0064 R5, 2026-09-06)**
+
+> The second face exists in the reader and in zero producers: no board in the
+> tree carries the table. One descriptor replaces both faces, and cmake reads a
+> generated projection of it (RFC-0064 R5 D4). Deleted by 215.K.
 
 - [x] **215.C.1** Add the metadata table to _(landed `1b003afc2`)_
       `packages/boards/nros-board-fvp-aemv8r-smp/Cargo.toml`:
@@ -200,7 +234,12 @@ against drift.
   `nros-cli/packages/nros-cli-core/src/orchestration/board_metadata.rs`
   (new), `nros-cli/packages/nros-cli-core/src/cmd/board.rs` (new).
 
-### 215.D — `west fvp` extension (moves Phase 214.A runner)
+### 215.D — `west fvp` extension (moves Phase 214.A runner) — **SUPERSEDED (RFC-0064 R5, 2026-09-06)**
+
+> Replaced by `nros sdk-path arm-fvp` plus an `activate.sh` export of
+> `ARMFVP_BIN_PATH`, which is how every other SDK in the index already resolves,
+> and then stock `west build -t run`. Deleted by 215.K. 215.D.4 is **withdrawn**
+> with the extension.
 
 - [x] **215.D.1** `scripts/west_commands/fvp.py` — west command _(landed `41c4683da`)_
       `class FvpRun(WestCommand)`. `do_run`:
@@ -260,7 +299,12 @@ against drift.
   `packages/testing/nros-tests/fixtures/board_import_fvp/` (new),
   `packages/testing/nros-tests/tests/phase215_e_board_import.rs` (new).
 
-### 215.F — Drift audit: cmake vs Cargo metadata
+### 215.F — Drift audit: cmake vs Cargo metadata — **SUPERSEDED (RFC-0064 R5, 2026-09-06)**
+
+> Checks zero boards, for two independent reasons (see Status). Replaced by a
+> projection round-trip — descriptor → projection → parse back == descriptor —
+> which has no "skip if the other face is missing" arm and so cannot go vacuous
+> the same way. Deleted by 215.K.
 
 - [x] **215.F.1** `packages/cli/nros-cli-core/tests/phase215_f_manifest_drift.rs`
       (landed at the in-tree CLI sub-workspace, not `nros-tests/` — the
@@ -427,15 +471,65 @@ consumer's tree, board-driven.
 surface), `packages/boards/nros-board-*/west-downstream.yml` (new),
 a board Kconfig overlay module, `docs/reference/board-cmake-schema.md`.
 
+### 215.K — Migrate the FVP board onto the one board process
+
+Implements RFC-0064 revision 5 for this board. The general mechanism is
+phase-375 W6–W8; 215.K is the FVP board's side of it, and lands after W7 exists.
+
+- [ ] **K.1** `packages/boards/nros-board-zephyr/boards/fvp-aemv8r-smp/nros-board.toml`
+      — 14 `NROS_BOARD_*` variables become 8 authored keys across `[board.zephyr]`
+      and `[board.provisioning]`. Derived: `prj.conf`, both
+      `boards/fvp_baser_aemv8r_fvp_aemv8r_aarch64_smp.{conf,overlay}` paths
+      (`west_board` with `/` → `_`), `requires_rust` (from `rust_targets`
+      non-empty), and `zephyr-rust-support/`, whose Kconfig body is exactly
+      `default y if BOARD_FVP_BASER_AEMV8R` and is therefore generated.
+- [ ] **K.2** `package.xml` announcing
+      `<nano_ros_provides kind="board" name="fvp-aemv8r-smp"/>`. This board is
+      currently announced nowhere, and the discovery glob is one level too
+      shallow to see it even with a descriptor (issue 0729's class) — so K.2
+      needs W6's `provider_scan`.
+- [ ] **K.3** Delete `board.cmake`, `scripts/west_commands/fvp.py`, its
+      `scripts/west-commands.yml` entry, the `west.yml` comment about it, and
+      `zephyr/module.yml`'s pointer. `nano_ros_use_board()` reads the W7
+      projection; its signature does not change, so
+      `examples/workspaces/realtime-cpp/src/fvp_entry`, the `board_import_fvp`
+      fixture and ASI's `actuation_module/CMakeLists.txt:154-155` do not move.
+- [ ] **K.4** `nros sdk-path arm-fvp` resolves the model through the existing
+      `[gated.arm-fvp]` index entry; `activate.sh` exports `ARMFVP_BIN_PATH`.
+      `just/zephyr-setup.just` lines 239 and 348 move to stock
+      `west build -t run`. Three tests reference `west fvp run` in prose
+      (`board_import.rs`, `fvp_runtime_ws.rs`, `fvp_smoke.rs`) and follow.
+- [ ] **K.5** Delete `board_metadata.rs` and
+      `packages/cli/nros-cli-core/tests/phase215_f_manifest_drift.rs`; the
+      round-trip test replaces them.
+- [ ] **K.6** Book: `book/src/porting/board-crate-import.md` documents the
+      descriptor and stock `west build -t run`. Its current "Don't reimplement
+      the FVP runner as a shell script" note inverts once the runner is an env
+      export, so it is rewritten rather than retargeted.
+- [ ] **K.7** File the size-probe reconfigure-identity bug separately. It is the
+      real defect behind ASI's `build.sh --run` workaround, and `west fvp` never
+      dodged it — the probe identity is every `NROS_*` env var plus `$DOTCONFIG`'s
+      `CONFIG_NROS_*` lines, so a reconfigure that picks crate defaults produces a
+      different identity than the build did. K.4 is only honest once this is
+      fixed.
+
+**Acceptance:** the FVP board is discovered, announced and built by exactly the
+same code path as `qemu-cortex-a53` and as an out-of-tree user board; no
+`board.cmake` and no `west` extension remain in the tree; the one-line consumer
+call site is byte-identical to what ASI has today.
+
 ## Acceptance
 
 - [ ] A Zephyr app's `CMakeLists.txt` calls `nano_ros_use_board(<n>)`
       and NOTHING else of nano-ros-board-specific shape (no per-board
       conf, no overlay, no `EXTRA_CONF_FILE` hand-list, no
       `-DNANO_ROS_RMW=...`).
-- [ ] `west fvp run -d build/` discovers the Phase 214.A resolver +
-      launches `FVP_BaseR_AEMv8R` end-to-end, UART → stdout, exits
-      clean on Ctrl-C.
+- [ ] The run path launches `FVP_BaseR_AEMv8R` end-to-end, UART → stdout,
+      exits clean on Ctrl-C. **Restated by 215.K.4** — `ARMFVP_BIN_PATH` from
+      `activate.sh` (via `nros sdk-path arm-fvp`) plus stock
+      `west build -t run`, replacing `west fvp run -d build/`. Blocked on
+      215.K.7: a reconfigure diverges the size-probe identity, which is what
+      this bullet actually trips over.
 - [x] `nros board info fvp-aemv8r-smp` prints the board metadata
       from BOTH `board.cmake` and `Cargo.toml`; `--check-drift`
       exits 0 when they agree, non-zero with a clear field-by-field
@@ -489,19 +583,20 @@ a board Kconfig overlay module, `docs/reference/board-cmake-schema.md`.
   (native, freertos, threadx) carry the Phase 212.N Board trait
   impl in Rust; their consumption shape is `cargo` path-deps, not
   cmake. Two ecosystems, two surfaces — no unified verb attempted.
-- The `west fvp` extension sits outside Phase 212 §Non-Goals
-  (`nros build/test/flash/monitor`): `west` owns the verb, not
-  `nros`. Phase 212.J `nros launch` precedent confirms `west` /
-  ROS-tool ownership of run-time verbs is acceptable.
+- ~~The `west fvp` extension sits outside Phase 212 §Non-Goals~~ — the
+  reasoning held (`west` should own a run verb); the mistake was that `west`
+  ALREADY owns it. `west build -t run` is the verb, and `west fvp run` only
+  exported one environment variable before exec'ing it. RFC-0064 R5 / 215.K.
 - Phase 214.A recipes stay in `just zephyr` as developer ergonomic
-  thin shells over `west fvp run` (so `just zephyr build-* &&
+  thin shells over the run verb (so `just zephyr build-* &&
   just zephyr run-*` stays the in-tree dev loop). ASI never reaches
-  the justfile; nano-ros contributors do.
+  the justfile; nano-ros contributors do. 215.K.4 repoints them from
+  `west fvp run` to stock `west build -t run`.
 - Multiple FVP variants (Cortex-R52, Corstone-310, AEMv8-R aarch32)
-  follow the same shape: one board crate each, sibling
-  `board.cmake` files, all pointing at `runner = "armfvp"` so the
-  west extension is variant-agnostic. Deferred until a real second
-  variant lands.
+  follow the same shape: one board PACKAGE each (`package.xml` +
+  `nros-board.toml`), all naming `runner = "armfvp"`, so the resolver
+  is variant-agnostic. Deferred until a real second variant lands.
+  (Said "sibling `board.cmake` files" until RFC-0064 R5.)
 - The board crate's Rust skeleton (`src/lib.rs` `init_hardware()` +
   `run<F>(config, app) -> !`) is **NOT** changed by Phase 215.
   Phase 212.N Board trait migration is orthogonal. Phase 215 only

--- a/docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md
+++ b/docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md
@@ -1,12 +1,18 @@
 # Phase 375 — The board tier is a promise with an owner, and onboarding is the cost
 
-**Status (2026-08-22). PROPOSED — W0 landed, W1–W5 not started.** Opened from the
+**Status (2026-09-06). W0 and W1 LANDED; W2–W9 open.** Opened from the
 question "more and more boards appear; it bloats — balance the platforms per
 tier". The measurement says the tiers are NOT what bloats, so the waves below
 target owners and onboarding instead.
 
+**W6–W9 added 2026-09-06** for RFC-0064 revision 5. W2 asked for a scaffold that
+emits the five artifacts a board needs; auditing what those artifacts should
+CONTAIN found that the tree has four different board-addition processes and no
+single descriptor shape to scaffold. W6–W9 make one process exist, so W2 has
+something to emit.
+
 **Implements:** [RFC-0064](../design/0064-board-support-organization.md)
-revision 4 (2026-08-22).
+revision 4 (2026-08-22) and revision 5 (2026-09-06).
 **Related:** [phase-320](archived/phase-320-board-support-tiers.md) (W3.b opened
 the maintainer field and left it unenforced — this closes it),
 [phase-346](archived/phase-346-out-of-tree-board-seam.md) (the seam W5 needs,
@@ -145,6 +151,106 @@ platform's tier-2 entry cost is one cell.
 
 **Acceptance:** a recorded decision, not a default.
 
+## W6 — One board process: a board is a package, found by a scan
+
+RFC-0064 R5 D1/D2/D5. The measurement is in R5: four routes, and our own
+`qemu_cortex_a53` takes route 4 — an inline `board = "…"` string in
+`fixtures.toml` and a `.conf` copied into each example leaf, with no package, no
+descriptor and no announcement.
+
+- [ ] Every board is a directory with `package.xml` announcing
+      `<nano_ros_provides kind="board" name="…"/>` beside an `nros-board.toml`.
+      A crate only where the board needs bring-up code.
+- [ ] Replace the `packages/boards/*/nros-board.toml` glob with `provider_scan`
+      over `[workspace] package_paths` (RFC-0087 D6). Depth-independent, so
+      bundle boards resolve; root-driven, so an out-of-tree board package is
+      found by the same code path.
+- [ ] `check-provider-announcements` loses `if not os.path.exists(pkg_xml):
+      continue`. Ratchet against today's one offender,
+      `nros-board-mps3-an536-freertos` — the newest board in the tree, which
+      skipped the step because the step was optional.
+- [ ] `qemu-cortex-a53` and the Zephyr `mps2_an385` flavour become real board
+      packages; their fixture rows name a board instead of a Zephyr id, and the
+      per-board `.conf` moves out of the example leaf so consumers share it.
+
+**Acceptance:** every board the tree builds is announced; the announcement gate
+runs on all of them, not 10 of 14; an out-of-tree board directory resolves with
+no in-tree edit beyond a `package_paths` entry.
+
+## W7 — `[board.zephyr]`, and the projection replaces `board.cmake`
+
+RFC-0064 R5 D3/D4. Pairs with 215.K, which is the same change seen from the FVP
+board's side.
+
+- [ ] `[board.zephyr]` block: `west_board`, `sdk_abi`, `default_rmw`,
+      `default_transport`, `runner` (stated only when it differs from Zephyr's
+      own board definition).
+- [ ] Conventions supply the rest: `prj.conf` and
+      ``boards/<west_board with `/` → `_`>.{conf,overlay}`` present-if-exists; the
+      Rust-support Kconfig module derived AND generated, since its body is
+      `default y if BOARD_<UPPER(first segment)>`.
+- [ ] `nros board cmake-vars <name> --out <build-dir>/…`; `nano_ros_use_board()`
+      includes the result. Signature unchanged, so no consumer call site moves.
+      The projection is a build artifact, never committed (phase-330 precedent).
+- [ ] Delete `board.cmake`, `board_metadata.rs` and
+      `phase215_f_manifest_drift.rs`. Replace with a projection round-trip test
+      (descriptor → projection → parse back == descriptor), which has no
+      "skip if the other face is missing" arm and so cannot go vacuous the way
+      the drift gate did.
+- [ ] Gate `check-board-descriptor-single-source`: no `board.cmake` anywhere, no
+      `[package.metadata.nros.board]` anywhere.
+
+**Acceptance:** one authored descriptor per board; the drift gate that checked
+zero boards is gone rather than repaired.
+
+## W8 — The descriptor holds primitives only
+
+RFC-0064 R5 D6 carries the full audit over all 12 `[[board]]` rows. Landable
+field group by field group; each group is a gate plus a mechanical edit.
+
+- [ ] **Move to the platform descriptor:** `platform_feature` (3 of 12 are not
+      `platform-<platform>`), `link_kind` (11 `none`, and both NuttX rows carry
+      the exception), `[board.priority_plan]` (the two FreeRTOS QEMU boards hold
+      byte-identical blocks — that is `configMAX_PRIORITIES`). Board override
+      stays for a board that genuinely retunes one.
+- [ ] **Derive:** `entry_kind` (zero exceptions today), `local_aliases`
+      (8 of 10 are `[platform_feature]`), `[board.entry] crate_name` (7 of 7 are
+      `snake_case(board_crate)`), `[board.entry] signature` (4 of 7 identical).
+- [ ] **Decompose `cargo_config`** — a raw TOML blob in 8 of 12 rows, holding
+      `rustflags`/`runner`/`linker` as text with no schema check. Promote them to
+      real fields; the CLI composes the leaf `.cargo/config.toml` from those
+      instead of pasting the blob through.
+- [ ] **Drop:** `capability_features` (7 rows, all the single value
+      `["safety-e2e"]`; the only read in the tree is inside
+      `fn a_board_advertises_the_safety_capability_feature()`),
+      `[board.entry] comment` (an escaped Rust `//` comment in TOML),
+      `crate_path` and `board_features` (in the struct, authored by nobody).
+- [ ] **Reclassify** `target_contains` — a row disambiguator, not a board
+      property. Rename it to say so.
+- [ ] Rung 3 survives: `crate_root_extra` / `crate_root_deps` / `closure_extra`
+      stay, renamed to say they are the escape hatch.
+- [ ] Gate, in RFC-0087 D4's ratchet shape: a stated derivable field must equal
+      its derived value, and a moved field must not be restated at board level
+      unless it differs.
+
+**Acceptance:** a QEMU Zephyr board authors 6 keys where today's equivalent
+authors 19, and the in-tree and out-of-tree descriptors for comparable boards are
+identical field for field.
+
+## W9 — `just board-new` emits the shape W6–W8 defined
+
+W2 restated once there is one shape to scaffold. Kept separate because W2's
+acceptance (green `check-fast` before first commit) is unchanged and still the
+point.
+
+- [ ] Scaffold emits the W6 package (`package.xml` + descriptor), the
+      `board-support.toml` row, the weak-symbol allowlist stub and the leaf lock.
+- [ ] A `--out-of-tree <dir>` mode emits the same thing plus the
+      `package_paths` line, so a user's board is one command too.
+
+**Acceptance:** the scaffolded board and a hand-written in-tree board are the
+same files.
+
 ## Risks
 
 **The ratchet is the whole of W1.** A maintainer rule that fails every existing
@@ -155,3 +261,8 @@ selectively.
 **W4 changes what a tier PROMISES**, so it is the one wave that needs agreement
 before implementation rather than after. The smoke floor is cheap; the nightly
 ceiling removes coverage that exists today.
+
+**W8 moves fields between descriptors, and a move is invisible in a diff.** A
+board that silently loses its priority plan gets the platform default, which is
+plausible and wrong. The ratchet has to fire on a RESTATED field, not only on a
+missing one, and the move lands per field group with the gate in the same commit.


### PR DESCRIPTION
## Why

A board of ours does not arrive the way a user's board does. Auditing every board in the tree to check that found **four different board-addition processes** and three mechanisms that are correct and unreachable.

| Route | How a board is added | Boards |
|---|---|---|
| 1. Package | crate + `nros-board.toml` + `package.xml` announcement | 9 |
| 2. Descriptor-only package | route 1 minus the crate (`linux`, `zephyr`) | 2 |
| 3. Bundle + `board.cmake` | 14 `NROS_BOARD_*` vars + a `west` extension | 1 (FVP) |
| 4. Nothing | an inline `board = "…"` string in `fixtures.toml` + a `.conf` in each example leaf | the rest |

Route 4 is what reframes it: three Zephyr board ids get built, only `native_sim/native/64` is declared anywhere, and `qemu_cortex_a53` has no package, no descriptor and no announcement. **Our own QEMU board did the same job as the FVP board with zero files, while the FVP board spent eight plus a west verb.**

Three unreachable mechanisms, the class this tree keeps re-finding (0896, 0963, `check-test-scripts-have-callers`):

- **`phase215_f_manifest_drift.rs` checks zero boards.** It walks top-level `packages/boards/nros-board-*/` needing both `Cargo.toml` and `board.cmake`; the only `board.cmake` sits one level deeper, and no board carries `[package.metadata.nros.board]` at all.
- **`check-provider-announcements` has `if not os.path.exists(pkg_xml): continue`**, so `nros-board-mps3-an536-freertos` — the newest board — has a descriptor and no `package.xml`, and nothing said so.
- **Discovery is a one-level glob**, so a bundle board is invisible even with a descriptor (0729's class) and an out-of-tree board has no way in. Not what phase-346 fixed — that made the board *framework* resolvable, never descriptor discovery.

## What changed

**RFC-0064 revision 5** states one process: a board is a package, discovered by `provider_scan` over `[workspace] package_paths`; a `[board.zephyr]` block absorbs routes 3 and 4; cmake reads a generated projection instead of a second authored file. D6 audits every descriptor field down to primitives — moving platform facts to the platform, deriving what convention produces, decomposing the `cargo_config` blob, dropping `capability_features` (whose only reader in the tree is a test asserting the field is used). A QEMU Zephyr board then authors **6 keys where today's equivalent authors 19**.

**phase-375** is the home phase — it already implements RFC-0064 and its W2 is the onboarding scaffold. W6–W9 added. Its header status also corrected: it said "W1–W5 not started" while W1's own heading says LANDED 2026-08-23.

**phase-215** keeps its goal and loses its mechanism. 215.A/C/D/F superseded, their open boxes **withdrawn** rather than done, and 215.K added for the migration. `west fvp` goes — its last statement is `os.execvpe('west', ['west','build','-t','run'])`, the exact command ASI declined because a reconfigure diverges the size-probe identity, so it never dodged the problem it exists for. 215.K.7 files that as the real bug.

`nano_ros_use_board()`'s signature does not change, so **no consumer call site moves** — ASI's `actuation_module/CMakeLists.txt:154-155` included.

## Testing

Docs only. `just check fast` green: 230 gates ran, 0 failed, 5 skipped for wanting the in-tree `nros` CLI. The first run was 3 red — `c-fmt`/`cpp-fmt` on clang-format 22.1.8 vs the pinned 17.0.6, `rustdoc-links` on an uninitialised zenoh-pico — both worktree provisioning, fixed rather than bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj