### PR TITLE
fix(phase-433 W3): the cyclone interop cells run C, and said Rust

### DIFF
--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -218,12 +218,41 @@ pub const CELLS: &[InteropCell] = &[
     ic("native-service-rust-zenoh-r2n",
        c(Linux, Rust, Zenoh, Service, Interop, Runtime),
        NativeFixtures, RosEdition(Zenoh), BiDir, "interop_e2e"),
-    ic("native-pubsub-rust-cyclone-n2r",
-       c(Linux, Rust, Cyclonedds, Pubsub, Interop, Runtime),
+    // phase-433 W3 — the cyclone half is C, not Rust. `interop_e2e`'s three
+    // cyclone cases spawn `nano_cyclone_c_binary(...)`: `c_talker`,
+    // `c_listener`, `c_service_server` out of `examples/native/c/`. These rows
+    // said Rust, `scenario_coord` returned `Lang::Rust` unconditionally, and
+    // the per-case tripwire compared the two — so the language axis was
+    // inverted and agreed with itself. The vacated Rust/Cyclonedds shapes are
+    // carved below.
+    ic("native-pubsub-c-cyclone-n2r",
+       c(Linux, C, Cyclonedds, Pubsub, Interop, Runtime),
        NativeFixtures, RosEdition(Cyclonedds), NanoToRos, "interop_e2e"),
-    ic("native-service-rust-cyclone-r2n",
-       c(Linux, Rust, Cyclonedds, Service, Interop, Runtime),
+    ic("native-service-c-cyclone-r2n",
+       c(Linux, C, Cyclonedds, Service, Interop, Runtime),
        NativeFixtures, RosEdition(Cyclonedds), BiDir, "interop_e2e"),
+    // The shapes the two rows above used to claim. Recorded rather than
+    // dropped because the artifacts EXIST — `examples/native/rust/{talker,
+    // listener,service-server,service-client}` all have `linux/rust/cyclonedds`
+    // rows in `examples/fixtures.toml` — so the absence is a missing lane, not
+    // a missing build, and nothing else in the tree would say so. Rust ↔
+    // stock-ROS-2 over Cyclone is not wholly unproven: `native-graph-rust-
+    // cyclone-r2n` runs that pairing for the Graph workload. Delivery is what
+    // has never been run.
+    ic("native-pubsub-rust-cyclone-n2r-CARVED",
+       c(Linux, Rust, Cyclonedds, Pubsub, Interop,
+         CarveOut("no Rust/Cyclonedds pubsub-interop lane; interop_e2e's cyclone \
+                   pubsub cases run the C examples (c_talker/c_listener). The Rust \
+                   cyclone talker/listener fixtures are built, so the lane is \
+                   affordable — file one if wanted.")),
+       NativeFixtures, RosEdition(Cyclonedds), NanoToRos, NO_TEST),
+    ic("native-service-rust-cyclone-r2n-CARVED",
+       c(Linux, Rust, Cyclonedds, Service, Interop,
+         CarveOut("no Rust/Cyclonedds service-interop lane; interop_e2e's cyclone \
+                   service case runs the C example (c_service_server). The Rust \
+                   cyclone service-server/client fixtures are built, so the lane is \
+                   affordable — file one if wanted.")),
+       NativeFixtures, RosEdition(Cyclonedds), BiDir, NO_TEST),
 
     // ── phase-381 — READ the graph a stock ROS 2 node is in ──────────────
     // tests/graph_interop.rs. The only cell whose subject is DISCOVERY rather

--- a/packages/testing/nros-tests/tests/interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/interop_e2e.rs
@@ -111,21 +111,37 @@ impl Scenario {
     }
 }
 
-/// The `interop::CELLS` coordinate a scenario exercises — all native/rust; the
-/// rmw + workload come from the scenario. Direction and the stock-demo variant
+/// The `interop::CELLS` coordinate a scenario exercises — all native; the lang,
+/// rmw and workload come from the scenario. Direction and the stock-demo variant
 /// collapse onto the same coordinate (the binding is at coordinate level).
+///
+/// phase-433 W3 — the LANGUAGE is the one the case actually spawns, not a
+/// constant. It was `Lang::Rust` unconditionally while every cyclone case runs
+/// `nano_cyclone_c_binary(...)` — `c_talker` / `c_listener` /
+/// `c_service_server` out of `examples/native/c/`. The per-case tripwire below
+/// could not catch it: `interop::CELLS` declared the same wrong language, so
+/// the coordinate agreed with itself and C/Cyclone ran while Rust/Cyclone was
+/// the shape the matrix claimed. The zenoh + lifecycle cases really are Rust —
+/// `talker_binary` / `listener_binary` / `service_{server,client}_binary` /
+/// `lifecycle_node_binary` all resolve `examples/native/rust/*`, and the
+/// stock-demo case's nano side is the Rust `bins/ros2-string-interop` (the C++
+/// in it is the PEER, which no coordinate names).
 fn scenario_coord(s: Scenario) -> (PlatformId, Lang, Rmw, Workload) {
     use Scenario::*;
-    let (rmw, workload) = match s {
+    let (lang, rmw, workload) = match s {
         ZenohPubsubNanoToRos2 | ZenohPubsubRos2ToNano | ZenohPubsubStockDemoToNano => {
-            (Rmw::Zenoh, Workload::Pubsub)
+            (Lang::Rust, Rmw::Zenoh, Workload::Pubsub)
         }
-        ZenohServiceNanoServer | ZenohServiceRos2Server => (Rmw::Zenoh, Workload::Service),
-        CyclonePubsubNanoToRos2 | CyclonePubsubRos2ToNano => (Rmw::Cyclonedds, Workload::Pubsub),
-        CycloneServiceNanoServer => (Rmw::Cyclonedds, Workload::Service),
-        ZenohLifecycle => (Rmw::Zenoh, Workload::Lifecycle),
+        ZenohServiceNanoServer | ZenohServiceRos2Server => {
+            (Lang::Rust, Rmw::Zenoh, Workload::Service)
+        }
+        CyclonePubsubNanoToRos2 | CyclonePubsubRos2ToNano => {
+            (Lang::C, Rmw::Cyclonedds, Workload::Pubsub)
+        }
+        CycloneServiceNanoServer => (Lang::C, Rmw::Cyclonedds, Workload::Service),
+        ZenohLifecycle => (Lang::Rust, Rmw::Zenoh, Workload::Lifecycle),
     };
-    (PlatformId::Linux, Lang::Rust, rmw, workload)
+    (PlatformId::Linux, lang, rmw, workload)
 }
 
 /// One interop matrix cell.
@@ -751,8 +767,10 @@ fn cases_bound_to_interop_cells() {
         &[
             (Linux, Rust, Zenoh, Pubsub),
             (Linux, Rust, Zenoh, Service),
-            (Linux, Rust, Cyclonedds, Pubsub),
-            (Linux, Rust, Cyclonedds, Service),
+            // The cyclone cases spawn the C examples, not the Rust ones
+            // (phase-433 W3) — see `scenario_coord`.
+            (Linux, C, Cyclonedds, Pubsub),
+            (Linux, C, Cyclonedds, Service),
             (Linux, Rust, Zenoh, Lifecycle),
         ],
     );


### PR DESCRIPTION
## The defect

`interop_e2e::scenario_coord` returned `Lang::Rust` for **every** scenario. All
three cyclone cases spawn `nano_cyclone_c_binary(...)` — `c_talker`,
`c_listener`, `c_service_server` out of `examples/native/c/`. The two
`interop::CELLS` rows they bind to (`native-pubsub-rust-cyclone-n2r`,
`native-service-rust-cyclone-r2n`) declared the same wrong language, so the
per-case tripwire `interop::test_covers` compared a constant against the
constant it was written from and passed. The declared language axis for cyclone
was inverted: C/Cyclone is what runs and is proven, Rust/Cyclone is what the
matrix claimed and nothing ran.

## What changed

- `scenario_coord` derives the language per scenario. The zenoh + lifecycle
  cases were **verified**, not assumed: `talker_binary`, `listener_binary`,
  `service_{server,client}_binary` and `lifecycle_node_binary` all resolve
  `examples/native/rust/*`, and the stock-demo case's nano side is the Rust
  `bins/ros2-string-interop` (the C++ in that cell is the peer, which no
  coordinate names). Rust was right for all six of those.
- The cyclone rows become `native-pubsub-c-cyclone-n2r` /
  `native-service-c-cyclone-r2n`, coordinate `(Linux, C, Cyclonedds, …)`. The
  old ids appear nowhere else in the tree.
- `cases_bound_to_interop_cells` tracks the same two coordinates.

## The vacated Rust/Cyclonedds coordinate

Carved per workload, following `zephyr-qos-cpp-cyclone-CARVED`, because the
artifacts **exist**: `examples/native/rust/{talker,listener,service-server,
service-client}` all carry `linux/rust/cyclonedds` rows in
`examples/fixtures.toml`. The absence is a missing lane, not a missing build,
and nothing else in the tree would record it. Both reasons say so and invite a
lane. (Rust over Cyclone against a stock ROS 2 peer is not wholly unproven —
`native-graph-rust-cyclone-r2n` runs that pairing for the Graph workload.
*Delivery* is what has never been run.) No new runtime test; out of scope for
W3.

## Gates

No gate failed on the change. G5 needs no new fixture row — `linux/c/cyclonedds`
rows exist for talker, listener and service-server. All 10
`matrix_fixture_coverage` tests pass, plus `interop::tests::*` and
`cases_bound_to_interop_cells`. `just check fast`: 228 ran, 0 failed, 6 skipped
(no in-tree CLI / zenoh-pico submodule in this fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP
