### PR TITLE
fix(#1033): the six zephyr C++ leaves could not configure at all

### DIFF
--- a/changelog.d/1033.fix.md
+++ b/changelog.d/1033.fix.md
@@ -1,0 +1,1 @@
+the six standalone zephyr C++ examples build again — phase-412 retired the `ENTITIES` declaration they had just gained, and their XRCE session caps are now stated where the derivation can no longer reach (listener: 54,928 bytes against a 65,536-byte heap, from an image that would not configure)

--- a/docs/issues/archived/1033-xrce-subscriber-slots-budget-eight-for-one.md
+++ b/docs/issues/archived/1033-xrce-subscriber-slots-budget-eight-for-one.md
@@ -368,3 +368,151 @@ changed is that a Zephyr image can now claim that saving at all.
   `nros_cc_flags::strict_decls` (`cargo check -p nros-rmw-xrce-cffi`, both new
   strings verified present in `libnros_rmw_xrce_c_inline.a`); the Zephyr image
   was not rebuilt on this host.
+## The derivation was retired out from under these leaves (2026-09-06)
+
+The section above closes this issue and says, in its own last line, "the Zephyr
+image was not rebuilt on this host". Rebuilding it is how the following was
+found, and it is the whole reason this survived: every claim above is about a
+saving that, on `main`, no longer builds. Measured,
+not inferred: `west build -p always` on `examples/zephyr/cpp/listener` with
+`prj-xrce.conf` fails at CONFIGURE.
+
+```
+CMake Error at cmake/NanoRosNodeRegister.cmake:1129 (message):
+  nano_ros_node_register(listener): ENTITIES was retired (phase-412).
+Call Stack (most recent call first):
+  cmake/NanoRosVerbs.cmake:471 (nano_ros_node_register)
+  CMakeLists.txt:45 (nros_components_register_node)
+```
+
+phase-412 (`3016c16a9`, 2026-09-05 21:59Z) retired `ENTITIES` and moved the
+declaration to a `<bringup>/launch/<stem>.contract.yaml` sidecar. It migrated
+the six `examples/workspaces/cpp` packages. It did **not** migrate the six
+`examples/zephyr/cpp` leaves this issue had taught to declare 41 hours earlier
+(`0768e0c59`), and those six are the only remaining `ENTITIES` callers in the
+tree.
+
+**The blast radius is not six files.** The error is raised before the RMW
+matters, so it takes all 19 `examples/fixtures.toml` rows over
+`examples/zephyr/cpp/` — zenoh, xrce and cyclonedds alike. Confirmed by
+building `cpp/talker` against `prj-zenoh.conf` and getting the same error.
+
+**And nothing said so**, because those leaves are configured only by
+`build-test-fixtures`, which needs the Zephyr SDK and west and therefore runs on
+no `pull_request` lane. The retirement's `FATAL_ERROR` is the right mechanism
+reporting to nobody — the shape of issues 1025 and 1070.
+
+### The replacement has no shape that fits a standalone application
+
+`nros_derive_entity_inventory_knobs` has two callers. Only
+`NanoRosEntry.cmake:1028` supplies `MODEL`, and it sits inside
+`_nros_entry_invoke_codegen`, reachable only from the `LAUNCH`/`MODEL` arm of
+`nano_ros_entry()`. These leaves are standalone Zephyr applications: no
+`nano_ros_entry`, no launch file, no bringup, no `system.toml`, so no contract
+sidecar and no SystemModel.
+
+The deferred standalone composer this issue added (`d11a14f5f`) still exists at
+`NanoRosNodeRegister.cmake:144`, and still runs — it just cannot produce
+anything any more, because it passes no `MODEL` and `nano_ros_node_register` no
+longer emits an `entities` metadata key. Every component reads `Absent`, and the
+refusal it returns said, in as many words:
+
+> Add `ENTITIES ...` to each `nano_ros_node_register()` above -- `ENTITIES NONE`
+> for a component that really creates none.
+
+**The one remedy the diagnostic named was the one thing the caller could not
+do.** A message that outlives the mechanism it describes aims the next reader at
+a wall, and this one did it for every standalone image in the tree. Fixed here.
+
+### Measured, on the listener that motivated this issue
+
+`sizeof(xrce_session_state_t)` from each image's own DWARF
+(`gdb -batch -ex "ptype /o xrce_session_state_t" zephyr.elf`), all three built
+`west build -p always -b native_sim/native/64` on one host, one tree:
+
+| state | request | outcome |
+| --- | ---: | --- |
+| `main` as it stands | — | **configure `FATAL_ERROR`** |
+| `ENTITIES` deleted, nothing else | **309,696** | builds; dies at boot |
+| this change | **54,928** | boots clean |
+
+The middle row is the naive way to complete phase-412's sweep, and it is worth
+stating because it looks like a fix. It is the pre-issue-1033 number exactly,
+and the image says so itself:
+
+```
+nros: HEAP EXHAUSTED: request 309696 bytes, arena 66048 bytes, caller 0x42c11e
+```
+
+Against the same run of the image built here, which prints no such line.
+
+Across the leaves rebuilt to check the multipliers:
+
+| leaf | subscriber / server / client slots | `sizeof` |
+| --- | --- | ---: |
+| `cpp/talker` | 0 / 0 / 0 | **21,632** |
+| `cpp/listener` | 1 / 0 / 0 | **54,928** |
+| `cpp/action-client` | 1 / 0 / 3 | **58,048** |
+
+All three boot with no heap message. 54,928 is also the number
+`nros-rmw-xrce-cffi/build.rs` has claimed in a comment since `28d916c66` while
+the tree delivered 59,088 — the service-client cap was never stated, so the
+comment described an end state nothing reached. It does now.
+
+### Divergence from this issue's own preference, and why
+
+This issue chose option (2), DERIVE, over option (1), "state the caps per
+example", calling the latter "twenty hand-picked numbers". This change states
+them. Not because the reasoning changed — because the mechanism (2) depended on
+was retired, and phase-412 left nothing in its place for an image that runs from
+no launch file. phase-412's own `FATAL_ERROR` says what such an image gets:
+
+> A system with no contract yet keeps its configured `NROS_EXECUTOR_MAX_CBS`,
+> exactly as it did before phase-403.
+
+So the numbers are stated in each leaf's `prj-xrce.conf`, and they are not
+hand-invented: each is the leaf's own retired `ENTITIES` line put through the
+same multipliers the derivation uses — `ACTION_SERVER_QUERYABLES` (3) for the
+action server, `ACTION_CLIENT_SUBSCRIPTIONS` (1) plus the three service clients
+`RawActionClientSpec` documents for the action client. Every conf carries the
+declaration it came from and the arithmetic.
+
+This is a HOLDING POSITION, not the campaign's answer. The campaign's answer is
+a declaration path for an image with no launch file, and that is a change to the
+contract/SystemModel seam rather than something to bolt on at a call site —
+the same conclusion this issue reached about the composition gap, one mechanism
+later.
+
+### The class, and the gate
+
+`check-retired-cmake-keywords` (fast line): a keyword any cmake verb retires
+must appear in no caller. The retired set is DISCOVERED from the
+`message(FATAL_ERROR "<fn>(...): <KEYWORD> was retired|removed ...")` guards
+under `cmake/`, so the next retirement arms the gate by itself, and a guard
+whose wording moves makes the gate BLIND rather than silently permissive — that
+case fails. It finds `ENTITIES` (`nano_ros_node_register`) and `HOST`
+(`nano_ros_entry`) today; run against the tree before this change it names all
+six leaves and their line numbers.
+
+Sweep command:
+
+```
+python3 scripts/check-retired-cmake-keywords.py
+```
+
+### A lead, measured but not fixed here
+
+`floor1` in `entity_inventory.rs` (issue 1015 — "a derived pool that sizes a C
+array has a floor of ONE") is applied at the PRODUCER, so
+`NROS_DERIVED_MAX_SUBSCRIBERS` and `NROS_DERIVED_MAX_QUERYABLES` are never zero.
+Issue 1015's evidence is entirely about zenoh: `zpico.c`'s
+`queryable_entry_t queryables[ZPICO_MAX_QUERYABLES]` at zero transmitted nothing
+for 15 seconds on the reference island. The XRCE consumer reads the same two
+values, and this issue measured the opposite there — 0 is legal, honoured, and
+boots. So an XRCE image that DERIVES (rather than states, as these leaves now
+do) pays 33,296 bytes for a subscriber ring and 4,384 for a server slot it
+declared none of: the floor belongs to the zenoh pool, not to the fact. Latent
+for these six leaves while they state their caps; live for any XRCE image that
+derives. Not fixed here because moving the floor to the consumers is a change to
+both the Zephyr ladder and `leaf_entity_env.rs`, and it wants its own
+measurement.

--- a/examples/zephyr/cpp/action-client/CMakeLists.txt
+++ b/examples/zephyr/cpp/action-client/CMakeLists.txt
@@ -35,8 +35,9 @@ nros_components_register_node(fibonacci_action_client_lib
     EXECUTABLE fibonacci_action_client
     SHAPE configure
     TYPED
-    # issue 1033 — what this image CREATES, read off its own source.
-    # The XRCE subscriber cap derives from this; absence means "nobody
-    # said" and the image keeps the 8-slot default.
-    ENTITIES
-             action_client:example_interfaces/action/Fibonacci:/fibonacci)
+    # phase-412 -- `ENTITIES` is retired. A standalone Zephyr application has
+    # no launch file, so it has no contract sidecar to state itself in; what
+    # this image creates is stated as the XRCE session caps in prj-xrce.conf,
+    # which is what phase-412's own guidance leaves such an image ("a system
+    # with no contract yet keeps its configured" knobs). See issue 1033.
+)

--- a/examples/zephyr/cpp/action-client/prj-xrce.conf
+++ b/examples/zephyr/cpp/action-client/prj-xrce.conf
@@ -12,3 +12,18 @@ CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=32
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=64
+
+# issue 1033 -- the XRCE session struct is one heap allocation sized from these
+# three caps, and the crate defaults (8 subscribers / 4 service servers / 4
+# service clients) cost 309,696 bytes against the 65,536-byte heap above -- the
+# image cannot boot. They are STATED rather than derived because a standalone
+# Zephyr application reaches no entity inventory: it calls no `nano_ros_entry`,
+# and phase-412 retired the `ENTITIES` declaration that used to feed the
+# standalone composer.
+#
+# This image creates: action_client:example_interfaces/action/Fibonacci:/fibonacci
+# so: one action client = 3 service clients (send_goal / cancel_goal /
+# get_result) + ACTION_CLIENT_SUBSCRIPTIONS (1) subscription (feedback).
+CONFIG_NROS_XRCE_MAX_SUBSCRIBERS=1
+CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS=3

--- a/examples/zephyr/cpp/action-server/CMakeLists.txt
+++ b/examples/zephyr/cpp/action-server/CMakeLists.txt
@@ -35,9 +35,9 @@ nros_components_register_node(fibonacci_action_server_lib
     EXECUTABLE fibonacci_action_server
     SHAPE configure
     TYPED
-    # issue 1033 — what this image CREATES, read off its own source.
-    # The XRCE subscriber cap derives from this; absence means "nobody
-    # said" and the image keeps the 8-slot default.
-    ENTITIES
-             action_server:example_interfaces/action/Fibonacci:/fibonacci
-             timer)
+    # phase-412 -- `ENTITIES` is retired. A standalone Zephyr application has
+    # no launch file, so it has no contract sidecar to state itself in; what
+    # this image creates is stated as the XRCE session caps in prj-xrce.conf,
+    # which is what phase-412's own guidance leaves such an image ("a system
+    # with no contract yet keeps its configured" knobs). See issue 1033.
+)

--- a/examples/zephyr/cpp/action-server/prj-xrce.conf
+++ b/examples/zephyr/cpp/action-server/prj-xrce.conf
@@ -12,3 +12,18 @@ CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=32
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=64
+
+# issue 1033 -- the XRCE session struct is one heap allocation sized from these
+# three caps, and the crate defaults (8 subscribers / 4 service servers / 4
+# service clients) cost 309,696 bytes against the 65,536-byte heap above -- the
+# image cannot boot. They are STATED rather than derived because a standalone
+# Zephyr application reaches no entity inventory: it calls no `nano_ros_entry`,
+# and phase-412 retired the `ENTITIES` declaration that used to feed the
+# standalone composer.
+#
+# This image creates: action_server:example_interfaces/action/Fibonacci:/fibonacci + timer
+# so: one action server = ACTION_SERVER_QUERYABLES (3) service servers
+# (send_goal / cancel_goal / get_result); feedback and status are topics.
+CONFIG_NROS_XRCE_MAX_SUBSCRIBERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=3
+CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS=0

--- a/examples/zephyr/cpp/listener/CMakeLists.txt
+++ b/examples/zephyr/cpp/listener/CMakeLists.txt
@@ -48,8 +48,9 @@ nros_components_register_node(listener_lib
     EXECUTABLE listener
     SHAPE configure
     TYPED
-    # issue 1033 — what this image CREATES, read off its own source.
-    # The XRCE subscriber cap derives from this; absence means "nobody
-    # said" and the image keeps the 8-slot default.
-    ENTITIES
-             sub:std_msgs/msg/String:/chatter)
+    # phase-412 -- `ENTITIES` is retired. A standalone Zephyr application has
+    # no launch file, so it has no contract sidecar to state itself in; what
+    # this image creates is stated as the XRCE session caps in prj-xrce.conf,
+    # which is what phase-412's own guidance leaves such an image ("a system
+    # with no contract yet keeps its configured" knobs). See issue 1033.
+)

--- a/examples/zephyr/cpp/listener/prj-xrce.conf
+++ b/examples/zephyr/cpp/listener/prj-xrce.conf
@@ -12,3 +12,17 @@ CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=32
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=64
+
+# issue 1033 -- the XRCE session struct is one heap allocation sized from these
+# three caps, and the crate defaults (8 subscribers / 4 service servers / 4
+# service clients) cost 309,696 bytes against the 65,536-byte heap above -- the
+# image cannot boot. They are STATED rather than derived because a standalone
+# Zephyr application reaches no entity inventory: it calls no `nano_ros_entry`,
+# and phase-412 retired the `ENTITIES` declaration that used to feed the
+# standalone composer.
+#
+# This image creates: sub:std_msgs/msg/String:/chatter
+# so: one subscription; no service of either direction.
+CONFIG_NROS_XRCE_MAX_SUBSCRIBERS=1
+CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS=0

--- a/examples/zephyr/cpp/service-client/CMakeLists.txt
+++ b/examples/zephyr/cpp/service-client/CMakeLists.txt
@@ -47,9 +47,9 @@ nros_components_register_node(add_two_ints_client_lib
     EXECUTABLE add_two_ints_client
     SHAPE configure
     TYPED
-    # issue 1033 — what this image CREATES, read off its own source.
-    # The XRCE subscriber cap derives from this; absence means "nobody
-    # said" and the image keeps the 8-slot default.
-    ENTITIES
-             service_client:example_interfaces/srv/AddTwoInts:/add_two_ints
-             timer)
+    # phase-412 -- `ENTITIES` is retired. A standalone Zephyr application has
+    # no launch file, so it has no contract sidecar to state itself in; what
+    # this image creates is stated as the XRCE session caps in prj-xrce.conf,
+    # which is what phase-412's own guidance leaves such an image ("a system
+    # with no contract yet keeps its configured" knobs). See issue 1033.
+)

--- a/examples/zephyr/cpp/service-client/prj-xrce.conf
+++ b/examples/zephyr/cpp/service-client/prj-xrce.conf
@@ -12,3 +12,17 @@ CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=32
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=64
+
+# issue 1033 -- the XRCE session struct is one heap allocation sized from these
+# three caps, and the crate defaults (8 subscribers / 4 service servers / 4
+# service clients) cost 309,696 bytes against the 65,536-byte heap above -- the
+# image cannot boot. They are STATED rather than derived because a standalone
+# Zephyr application reaches no entity inventory: it calls no `nano_ros_entry`,
+# and phase-412 retired the `ENTITIES` declaration that used to feed the
+# standalone composer.
+#
+# This image creates: service_client:example_interfaces/srv/AddTwoInts:/add_two_ints + timer
+# so: one service client; nothing subscribes and nothing is served.
+CONFIG_NROS_XRCE_MAX_SUBSCRIBERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS=1

--- a/examples/zephyr/cpp/service-server/CMakeLists.txt
+++ b/examples/zephyr/cpp/service-server/CMakeLists.txt
@@ -47,8 +47,9 @@ nros_components_register_node(add_two_ints_server_lib
     EXECUTABLE add_two_ints_server
     SHAPE configure
     TYPED
-    # issue 1033 — what this image CREATES, read off its own source.
-    # The XRCE subscriber cap derives from this; absence means "nobody
-    # said" and the image keeps the 8-slot default.
-    ENTITIES
-             service_server:example_interfaces/srv/AddTwoInts:/add_two_ints)
+    # phase-412 -- `ENTITIES` is retired. A standalone Zephyr application has
+    # no launch file, so it has no contract sidecar to state itself in; what
+    # this image creates is stated as the XRCE session caps in prj-xrce.conf,
+    # which is what phase-412's own guidance leaves such an image ("a system
+    # with no contract yet keeps its configured" knobs). See issue 1033.
+)

--- a/examples/zephyr/cpp/service-server/prj-xrce.conf
+++ b/examples/zephyr/cpp/service-server/prj-xrce.conf
@@ -12,3 +12,17 @@ CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=32
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=64
+
+# issue 1033 -- the XRCE session struct is one heap allocation sized from these
+# three caps, and the crate defaults (8 subscribers / 4 service servers / 4
+# service clients) cost 309,696 bytes against the 65,536-byte heap above -- the
+# image cannot boot. They are STATED rather than derived because a standalone
+# Zephyr application reaches no entity inventory: it calls no `nano_ros_entry`,
+# and phase-412 retired the `ENTITIES` declaration that used to feed the
+# standalone composer.
+#
+# This image creates: service_server:example_interfaces/srv/AddTwoInts:/add_two_ints
+# so: one service server; nothing subscribes and nothing calls out.
+CONFIG_NROS_XRCE_MAX_SUBSCRIBERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=1
+CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS=0

--- a/examples/zephyr/cpp/talker/CMakeLists.txt
+++ b/examples/zephyr/cpp/talker/CMakeLists.txt
@@ -50,9 +50,9 @@ nros_components_register_node(talker_lib
     EXECUTABLE talker
     SHAPE configure
     TYPED
-    # issue 1033 — what this image CREATES, read off its own source.
-    # The XRCE subscriber cap derives from this; absence means "nobody
-    # said" and the image keeps the 8-slot default.
-    ENTITIES
-             pub:std_msgs/msg/String:/chatter
-             timer)
+    # phase-412 -- `ENTITIES` is retired. A standalone Zephyr application has
+    # no launch file, so it has no contract sidecar to state itself in; what
+    # this image creates is stated as the XRCE session caps in prj-xrce.conf,
+    # which is what phase-412's own guidance leaves such an image ("a system
+    # with no contract yet keeps its configured" knobs). See issue 1033.
+)

--- a/examples/zephyr/cpp/talker/prj-xrce.conf
+++ b/examples/zephyr/cpp/talker/prj-xrce.conf
@@ -12,3 +12,17 @@ CONFIG_NET_PKT_RX_COUNT=32
 CONFIG_NET_PKT_TX_COUNT=32
 CONFIG_NET_BUF_RX_COUNT=64
 CONFIG_NET_BUF_TX_COUNT=64
+
+# issue 1033 -- the XRCE session struct is one heap allocation sized from these
+# three caps, and the crate defaults (8 subscribers / 4 service servers / 4
+# service clients) cost 309,696 bytes against the 65,536-byte heap above -- the
+# image cannot boot. They are STATED rather than derived because a standalone
+# Zephyr application reaches no entity inventory: it calls no `nano_ros_entry`,
+# and phase-412 retired the `ENTITIES` declaration that used to feed the
+# standalone composer.
+#
+# This image creates: pub:std_msgs/msg/String:/chatter + timer
+# so: no subscription, no service of either direction.
+CONFIG_NROS_XRCE_MAX_SUBSCRIBERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_SERVERS=0
+CONFIG_NROS_XRCE_MAX_SERVICE_CLIENTS=0

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -73,6 +73,24 @@ cmake-find-program-shadowed:
     @python3 scripts/check-cmake-find-program-shadowed.py --self-test
     @python3 scripts/check-cmake-find-program-shadowed.py
 
+# issue 1033 — a RETIRED cmake API keyword must survive in no caller.
+#
+# Our verbs retire a keyword by keeping it PARSED and raising a FATAL_ERROR
+# naming the replacement, so an old caller fails loudly instead of having the
+# keyword fall into UNPARSED_ARGUMENTS and become source files nobody can find.
+# Right shape, but it only fires when somebody CONFIGURES the caller — and the
+# six standalone `examples/zephyr/cpp` leaves are configured by no lane a pull
+# request runs. phase-412 retired `ENTITIES`, migrated the six workspace
+# packages and missed those six, so all of them (and the 19 fixture rows over
+# them, across all three RMWs, since the error precedes the RMW) could not
+# configure on main and nothing said so. The retirement is a good mechanism
+# reporting to nobody; this is the reader.
+#
+# The retired set is DISCOVERED from the cmake sources, so the next retirement
+# arms this gate by itself and a moved wording makes it BLIND, not permissive.
+retired-cmake-keywords:
+    @python3 scripts/check-retired-cmake-keywords.py
+
 # issue 0719 — the C/C++ half of the same question. `check-image-panic-policy`
 # reads what a RUST image declares (`nros::main!(panic = …)`) and says outright
 # that it cannot see "the C/C++ side, where the policy is a cargo feature on the

--- a/packages/cli/nros-cli-core/src/entity_inventory.rs
+++ b/packages/cli/nros-cli-core/src/entity_inventory.rs
@@ -1075,12 +1075,22 @@ impl EntityInventory {
                 .join("\n");
             return Derivation::Refused {
                 reason: format!(
+                    // issue 1033 -- this used to say "Add `ENTITIES ...` to each
+                    // `nano_ros_node_register()`", which phase-412 turned into a
+                    // FATAL_ERROR: the one remedy the refusal named was the one
+                    // thing the caller could not do. A diagnostic that survives the
+                    // mechanism it describes aims the next reader at a wall, and
+                    // this one did it for every standalone image in the tree.
                     "{} of {} components in this image declare no entities:\n{block}\n\
                      Deriving over only the components that did would publish a slot count \
                      smaller than the image needs, and a short NROS_EXECUTOR_MAX_CBS fails \
-                     entity creation at boot. Add `ENTITIES ...` to each \
-                     `nano_ros_node_register()` above -- `ENTITIES NONE` for a component that \
-                     really creates none.",
+                     entity creation at boot. State what each component creates in the \
+                     contract sidecar beside the launch file that runs it \
+                     (<bringup>/launch/<stem>.contract.yaml), which reaches this through the \
+                     SystemModel. An image that runs from no launch file -- a standalone \
+                     Zephyr application, say -- reaches no contract, so it keeps its \
+                     CONFIGURED pool knobs and must state the ones its RMW session sizes \
+                     (see issue 1033).",
                     undeclared.len(),
                     self.components.len()
                 ),
@@ -1901,9 +1911,17 @@ mod tests {
         match inv.derive() {
             Derivation::Refused { reason } => {
                 assert!(reason.contains("b::two"), "names the component: {reason}");
+                // issue 1033 -- the remedy must be one the caller can still
+                // perform. This asserted `ENTITIES NONE` for a phase after
+                // phase-412 made `ENTITIES` a FATAL_ERROR, so the test held the
+                // message to advice that could not be followed.
                 assert!(
-                    reason.contains("ENTITIES NONE"),
-                    "names the remedy: {reason}"
+                    reason.contains("contract.yaml"),
+                    "names a remedy that still exists: {reason}"
+                );
+                assert!(
+                    !reason.contains("ENTITIES"),
+                    "never names a retired keyword as the remedy: {reason}"
                 );
             }
             other => panic!("expected a refusal, got {other:?}"),

--- a/scripts/check-retired-cmake-keywords.py
+++ b/scripts/check-retired-cmake-keywords.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""issue 1033 — a RETIRED cmake API keyword must survive in no caller.
+
+# The failure this prevents
+
+Our public cmake verbs retire a keyword by KEEPING IT PARSED and raising a
+`FATAL_ERROR` naming the replacement, so an old caller fails loudly instead of
+having the keyword and its values fall into `UNPARSED_ARGUMENTS` and become
+source files nobody can find. That is the right shape — but it only fires when
+somebody CONFIGURES the caller, and this repo has callers that only a Zephyr
+SDK + west lane configures. Nothing on the `pull_request` lane does.
+
+So phase-412 retired `nano_ros_node_register(... ENTITIES ...)`, migrated the
+six `examples/workspaces/cpp` packages, and MISSED the six standalone
+`examples/zephyr/cpp` leaves that issue 1033 had taught to declare the day
+before. All six — and the 19 `examples/fixtures.toml` rows over them, across
+zenoh, xrce AND cyclonedds, since the error is raised before the RMW matters —
+could not CONFIGURE on `main`, and stayed that way because the only lane that
+would have said so is one the schedule reaches.
+
+The retirement is a good mechanism reporting to nobody. This gate is the
+reader.
+
+# What it checks
+
+The retired set is DISCOVERED from the cmake sources, never hand-listed: every
+`message(FATAL_ERROR "<fn>(...): <KEYWORD> was retired|removed ...")` under
+`cmake/` contributes one `(function, keyword)` pair. So retiring the next
+keyword arms this gate by itself, and a retirement whose wording moves makes
+the gate BLIND rather than silently permissive — which is why finding zero
+pairs is a failure.
+
+Every tracked `CMakeLists.txt` / `*.cmake` OUTSIDE `cmake/` and `tests/` is
+then scanned for the keyword as a standalone argument token. `cmake/` is
+exempt because that is where the retirement and its keyword-forwarding
+wrapper legitimately live (`nros_components_register_node` must keep parsing
+and forwarding `ENTITIES`, or the bare-keyword spelling silently joins
+SOURCES); `tests/` is exempt because the gate harnesses set `_NRC_ENTITIES`
+to exercise the refusal.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# `message(FATAL_ERROR "nano_ros_node_register(${_NRC_NAME}): ENTITIES was
+#  retired (phase-412).\n"` — and the `HOST was removed (phase-326 ...)` shape
+# in `nano_ros_entry`. Both say `<fn>(<anything>): <KEYWORD> was <verb>`.
+RETIREMENT = re.compile(
+    r'"(?P<fn>[A-Za-z_][A-Za-z0-9_]*)\([^"]*\):\s*'
+    r'(?P<kw>[A-Z][A-Z0-9_]*)\s+was\s+(?:retired|removed)\b'
+)
+
+# Directories whose cmake IS the API (the retirement guard and the wrappers
+# that forward the keyword into it), plus the gate harnesses that exercise it.
+EXEMPT_PREFIXES = ("cmake/", "tests/")
+
+
+def retired_keywords(root):
+    """{keyword: (function, file)} discovered from the cmake API sources."""
+    found = {}
+    api = os.path.join(root, "cmake")
+    # walk-ok: `cmake/` is a single flat directory of the API modules, and the
+    # self-test's synthetic tree is not a git repository, so there is no index
+    # to query.
+    for dirpath, _dirnames, filenames in os.walk(api):
+        for fn in sorted(filenames):
+            if not fn.endswith(".cmake"):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, fn), root)
+            try:
+                with open(os.path.join(dirpath, fn), encoding="utf8", errors="replace") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            for m in RETIREMENT.finditer(text):
+                found.setdefault(m.group("kw"), (m.group("fn"), rel))
+    return found
+
+
+def caller_files(root):
+    """Tracked CMakeLists.txt / *.cmake outside the API and the harnesses."""
+    out = subprocess.run(
+        ["git", "-C", root, "ls-files", "*CMakeLists.txt", "*.cmake"],
+        capture_output=True, text=True,
+    )
+    if out.returncode == 0:
+        paths = out.stdout.split()
+    else:
+        paths = []
+        # walk-ok: the self-test builds a synthetic tree with no git index.
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in (".git", "build", "target")]
+            for fn in filenames:
+                if fn == "CMakeLists.txt" or fn.endswith(".cmake"):
+                    paths.append(os.path.relpath(os.path.join(dirpath, fn), root))
+    return [
+        p for p in paths
+        if not p.startswith(EXEMPT_PREFIXES) and "/third-party/" not in p
+        and not p.startswith("third-party/")
+    ]
+
+
+def check(root):
+    """Return a list of problem strings (empty == pass)."""
+    problems = []
+    retired = retired_keywords(root)
+    if not retired:
+        # Never pass because the pattern stopped matching: that is a blind gate
+        # reporting success, and the thing it guards configures on no PR lane.
+        return [
+            "no retirement guards found under cmake/ — this gate looks for\n"
+            '  message(FATAL_ERROR "<fn>(...): <KEYWORD> was retired|removed ...")\n'
+            "  and found none. Either the wording moved (fix the pattern) or the\n"
+            "  guards were deleted. Do not delete this check."
+        ]
+
+    # A standalone argument token: `\n    ENTITIES\n` or `ENTITIES value)`.
+    matchers = {
+        kw: re.compile(rf"(?<![A-Za-z0-9_]){re.escape(kw)}(?![A-Za-z0-9_])")
+        for kw in retired
+    }
+    for rel in caller_files(root):
+        try:
+            with open(os.path.join(root, rel), encoding="utf8", errors="replace") as fh:
+                lines = fh.read().split("\n")
+        except OSError:
+            continue
+        for i, line in enumerate(lines, 1):
+            # Comments legitimately explain that a keyword is retired.
+            code = line.split("#", 1)[0]
+            if not code.strip():
+                continue
+            for kw, rx in matchers.items():
+                if rx.search(code):
+                    fn, where = retired[kw]
+                    problems.append(
+                        f"{rel}:{i} passes {kw}, which {fn}() RETIRED "
+                        f"({where}). Configuring this file is a FATAL_ERROR — and "
+                        f"nothing on the pull_request lane configures it, so the "
+                        f"error reports to nobody. Delete the argument and follow "
+                        f"the replacement the guard names."
+                    )
+    return problems
+
+
+def _write(root, guard, caller):
+    for rel, text in (("cmake/NanoRosNodeRegister.cmake", guard),
+                      ("examples/leaf/CMakeLists.txt", caller)):
+        os.makedirs(os.path.join(root, os.path.dirname(rel)), exist_ok=True)
+        with open(os.path.join(root, rel), "w", encoding="utf8") as fh:
+            fh.write(text)
+
+
+GUARD = (
+    'message(FATAL_ERROR\n'
+    '    "nano_ros_node_register(${_NRC_NAME}): ENTITIES was retired (phase-412).\\n"\n'
+    '    "  state it in the contract sidecar instead")\n'
+)
+GUARD_REMOVED = (
+    'message(FATAL_ERROR\n'
+    '    "nano_ros_entry(${_NRA_NAME}): HOST was removed (phase-326) - use MODEL.")\n'
+)
+
+
+def self_test():
+    """Every probe asserts a failure this gate must catch, plus the clean case,
+    so a gate that stopped matching anything cannot report success."""
+    clean_caller = (
+        "nros_components_register_node(listener_lib\n"
+        "    EXECUTABLE listener\n"
+        "    # phase-412 -- ENTITIES is retired; the contract states it.\n"
+        ")\n"
+    )
+    dirty_caller = (
+        "nros_components_register_node(listener_lib\n"
+        "    EXECUTABLE listener\n"
+        "    ENTITIES\n"
+        "             sub:std_msgs/msg/String:/chatter)\n"
+    )
+    bare_caller = (
+        "nros_components_register_node(listener_lib\n"
+        "    ENTITIES)\n"
+    )
+    substring_caller = (
+        "set(BUDGET_IDENTITIES 4)\n"
+        "set(UCLIENT_SHARED_MEMORY_MAX_ENTITIES 4)\n"
+    )
+    cases = [
+        ((GUARD, clean_caller), 0, "a caller that deleted the retired keyword"),
+        ((GUARD, dirty_caller), 1, "a caller still passing ENTITIES with specs"),
+        ((GUARD, bare_caller), 1, "a caller passing the BARE keyword"),
+        ((GUARD, substring_caller), 0,
+         "IDENTITIES / MAX_ENTITIES must not match as substrings"),
+        ((GUARD_REMOVED, "nano_ros_entry(app HOST alpha)\n"), 1,
+         "the `was removed` spelling is a retirement too"),
+        ((GUARD_REMOVED, "nano_ros_entry(app MODEL m.yaml)\n"), 0,
+         "the same guard with a compliant caller"),
+        (("# no retirement guard at all\n", clean_caller), 1,
+         "the guard wording moved and this gate went blind"),
+    ]
+    failures = 0
+    tmp = tempfile.mkdtemp()
+    try:
+        for args, want, label in cases:
+            root = os.path.join(tmp, "t")
+            shutil.rmtree(root, ignore_errors=True)
+            _write(root, *args)
+            got = 1 if check(root) else 0
+            if got != want:
+                sys.stderr.write(f"  self-test FAIL: {label} — got {got}, want {want}\n")
+                failures += 1
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    if failures:
+        sys.stderr.write(f"check-retired-cmake-keywords: {failures} self-test failure(s)\n")
+        return 1
+    print(f"check-retired-cmake-keywords: self-test OK ({len(cases)} cases)")
+    return 0
+
+
+def main():
+    # On the NORMAL path, not behind a flag: a negative control nobody runs
+    # decays into a comment (`check-gate-selftests`).
+    if self_test():
+        return 1
+    if "--self-test" in sys.argv:
+        return 0
+    problems = check(ROOT)
+    if problems:
+        sys.stderr.write("check-retired-cmake-keywords FAILED:\n")
+        for p in problems:
+            sys.stderr.write(f"  {p}\n")
+        return 1
+    retired = retired_keywords(ROOT)
+    names = ", ".join(f"{k} ({v[0]})" for k, v in sorted(retired.items()))
+    print(f"check-retired-cmake-keywords OK: no caller passes {names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The defect

phase-412 (`3016c16a9`) retired `nano_ros_node_register(... ENTITIES ...)` and migrated the six `examples/workspaces/cpp` packages to a contract sidecar. It did not migrate the six `examples/zephyr/cpp` leaves that issue 1033 had taught to declare 41 hours earlier (`0768e0c59`) — the only remaining `ENTITIES` callers in the tree. They fail at CONFIGURE:

```
CMake Error at cmake/NanoRosNodeRegister.cmake:1129 (message):
  nano_ros_node_register(listener): ENTITIES was retired (phase-412).
```

The error precedes the RMW, so this takes all **19 `examples/fixtures.toml` rows** over `examples/zephyr/cpp/` — zenoh, xrce **and** cyclonedds (confirmed on `cpp/talker` against `prj-zenoh.conf`). Nothing said so: those leaves are configured only by `build-test-fixtures`, which needs the Zephyr SDK and west and runs on no `pull_request` lane. The retirement's `FATAL_ERROR` is the right mechanism reporting to nobody — the shape of issues 1025 and 1070.

Issue 1033 was closed the same morning; its closing note says, in its own last line, *"the Zephyr image was not rebuilt on this host."* Rebuilding it is how this was found.

**The replacement has no shape that fits these leaves.** Only `NanoRosEntry.cmake:1028` supplies a `MODEL` to the composer, from the `LAUNCH`/`MODEL` arm of `nano_ros_entry()`. A standalone Zephyr application has no launch file, no bringup and no SystemModel. The deferred standalone composer 1033 added (`d11a14f5f`) still runs and can no longer produce anything — and the refusal it returns said *"Add `ENTITIES ...`"*: the one remedy the diagnostic named was the one thing the caller could not do. Fixed here too.

## Measured

`sizeof(xrce_session_state_t)` from each image's own DWARF, `west build -p always -b native_sim/native/64`, one host, one tree:

| state | request | outcome |
| --- | ---: | --- |
| `main` as it stands | — | **configure `FATAL_ERROR`** |
| `ENTITIES` deleted, nothing else | **309,696** | builds; dies at boot |
| this PR | **54,928** | boots clean |

The middle row is the naive way to complete phase-412's sweep and it looks like a fix. It is the pre-issue-1033 number exactly, and the image says so:

```
nros: HEAP EXHAUSTED: request 309696 bytes, arena 66048 bytes, caller 0x42c11e
```

Also built and booted with no heap message — these are what check the multipliers:

| leaf | sub / server / client slots | `sizeof` |
| --- | --- | ---: |
| `cpp/talker` | 0 / 0 / 0 | **21,632** |
| `cpp/listener` | 1 / 0 / 0 | **54,928** |
| `cpp/action-client` | 1 / 0 / 3 | **58,048** |

54,928 is the number `nros-rmw-xrce-cffi/build.rs` has claimed in a comment since `28d916c66` while the tree delivered 59,088 — the service-client cap was never stated. It is now.

## Divergence, stated rather than silent

Issue 1033 chose DERIVE over "state the caps per example", calling the latter twenty hand-picked numbers. This states them, because the mechanism DERIVE depended on was retired and phase-412 left nothing for an image that runs from no launch file — whose own `FATAL_ERROR` says such an image *"keeps its configured"* knobs.

The numbers are not invented: each is the leaf's own retired `ENTITIES` line put through the same multipliers the derivation uses (`ACTION_SERVER_QUERYABLES` 3; `ACTION_CLIENT_SUBSCRIPTIONS` 1 plus the three service clients `RawActionClientSpec` documents). Every conf carries the declaration it came from and the arithmetic. This is recorded in the issue as a **holding position**, not the campaign's answer.

## The class

`check-retired-cmake-keywords` (fast line): a keyword any cmake verb retires must survive in no caller. The retired set is **discovered** from the `message(FATAL_ERROR "<fn>(...): <KEYWORD> was retired|removed ...")` guards under `cmake/`, so the next retirement arms the gate by itself, and a guard whose wording moves makes the gate **blind** rather than silently permissive — that case fails. It finds `ENTITIES` (`nano_ros_node_register`) and `HOST` (`nano_ros_entry`); run against the tree before this change it names all six leaves and their line numbers.

Sweep command:

```
python3 scripts/check-retired-cmake-keywords.py
```

## Deliberately not done

* **No declaration path for a standalone image.** That is the campaign's real answer and it is a change to the contract/SystemModel seam, not something to bolt on at a call site — the same conclusion issue 1033 reached about the composition gap, one mechanism later.
* **`floor1` left alone.** Issue 1015's floor-of-one is applied at the PRODUCER, so `NROS_DERIVED_MAX_SUBSCRIBERS` / `_MAX_QUERYABLES` are never zero. Its evidence is entirely zenoh (`zpico.c`'s `queryable_entry_t queryables[...]` at zero transmitted nothing for 15 s on the reference island); the XRCE consumer reads the same values, where 1033 measured that 0 is legal and boots. So a DERIVING XRCE image pays 33,296 + 4,384 bytes for entities it declared none of. Latent for these six while they state their caps. Filed as a measured lead in the issue.

## Gates

`just check fast`: **236 gates OK**. `just check cli-tests`: green. Zephyr images built and booted as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyCVgGEqVRY71PYDHKmWSv
