### PR TITLE
docs(phase-188): closed — what remained was a logo decision, not engineering

### DIFF
--- a/docs/issues/1141-book-visual-identity-favicon-logo-accent-css.md
+++ b/docs/issues/1141-book-visual-identity-favicon-logo-accent-css.md
@@ -1,0 +1,52 @@
+---
+id: 1141
+title: "The book has no visual identity — no favicon, no logo, no accent CSS, so the public front door looks like a stock mdBook"
+status: open
+type: enhancement
+area: docs
+severity: low
+related: [phase-188]
+found: 2026-09-06
+---
+
+# What is left of phase-188, rehomed
+
+Phase 188 ("Book front-door presentation") is **closed and archived**: 188.A
+(landing page + architecture entry) and 188.C (funnel + deploy hygiene) landed
+2026-05-28, `mdbook build book` is clean, and the dead-link sweep found 0 broken
+across 29 + 81 link targets.
+
+Only workstream **188.B** remained, and it is not engineering — it is two
+theming files that were **scoped but deferred on purpose, pending a logo
+decision** nobody has made in the three and a half months since:
+
+- **Favicon + logo** in `book/theme/`, wired via `[output.html]` in
+  `book/book.toml`.
+- **Accent CSS** at `book/theme/custom.css`, via `additional-css`.
+
+Filed as an issue rather than kept as a live phase because a phase held open by
+a favicon reads, to anyone scanning the roadmap, as an engineering workstream
+in progress. It is a design task with a design blocker.
+
+## The actual blocker
+
+**A logo decision.** Not a technical one: mdBook's `additional-css` /
+`[output.html]` wiring is already in place for mermaid
+(`book/book.toml` → `[preprocessor.mermaid]` + `additional-js`), so the plumbing
+this needs has a working precedent in the same file. Someone has to choose the
+mark and the accent colour; the wiring after that is small.
+
+## Acceptance
+
+- `mdbook build book` stays clean.
+- The deployed site at `NEWSLabNTU.github.io/nano-ros-book/` no longer renders
+  as an unstyled stock mdBook — a favicon in the browser tab, and an accent that
+  is not mdBook's default.
+
+## Not covered — carried over from phase-188 and still true
+
+A few stale source comments name shims that no longer exist:
+`nros-board-mps2-an385/src/lib.rs:19`, `nros-board-orin-spe/src/node.rs`,
+`nros-platform-api/src/lib.rs` (x2). Harmless — comments, not code — and worth a
+pass with the next platform-crate edit. Recorded here so closing the phase does
+not lose them.

--- a/docs/roadmap/archived/phase-188-front-door-presentation.md
+++ b/docs/roadmap/archived/phase-188-front-door-presentation.md
@@ -7,9 +7,20 @@ land a strong first impression in the first 30 seconds — *show*, not just
 phase reworks the landing page (`introduction.md`) and the architecture
 entry point.
 
-**Status.** 188.A + 188.C DONE (2026-05-28); `mdbook build book` clean
-(mermaid renders, no broken links). Workstream B (visual identity) scoped
-but deferred (needs a logo decision).
+**Status. CLOSED 2026-09-06.** 188.A + 188.C DONE (2026-05-28);
+`mdbook build book` clean (mermaid renders, no broken links). Workstream B
+(visual identity) was scoped but deferred pending a logo decision, and in the
+three and a half months since, that decision has not been made.
+
+It is rehomed as **issue 1141** rather than kept here. What remained was two
+theming files — a favicon/logo and an accent stylesheet — blocked on a DESIGN
+choice, not on engineering: the `[output.html]` / `additional-css` wiring they
+need already has a working precedent in the same `book.toml` (the mermaid
+preprocessor). A phase held open by a favicon reads, to anyone scanning the
+roadmap, as an engineering workstream in progress; it is not one.
+
+The stale-source-comment follow-up noted under 188.A is carried into 1141 too,
+so closing this loses nothing.
 
 **Priority.** P2 — presentation / adoption. No product capability depends
 on it, but the book is the public front door and the GitHub-Pages site is


### PR DESCRIPTION
Phase 188 was the **oldest active phase doc in the tree by two months** (last touched 2026-05-28).

188.A (landing page + architecture entry) and 188.C (funnel + deploy hygiene) landed then: `mdbook build book` clean, mermaid rendering, dead-link sweep finding **0 broken across 29 + 81** link targets. Only workstream **188.B** remained — and it had been *"scoped but deferred (needs a logo decision)"* for three and a half months.

What it asks for is two theming files: a favicon/logo in `book/theme/` wired via `[output.html]`, and an accent stylesheet via `additional-css`. The plumbing already has a working precedent in the same `book.toml` (the mermaid preprocessor’s `additional-js`), so **the blocker is not technical** — somebody has to choose a mark and a colour.

Rehomed as **issue #1141** rather than kept open, because a phase held open by a favicon reads — to anyone scanning `docs/roadmap/` for what is in flight — as an engineering workstream in progress. It is a design task with a design blocker.

Carried into #1141 rather than dropped: the stale source comments noted under 188.A that still name retired shims (`nros-board-mps2-an385/src/lib.rs:19`, `nros-board-orin-spe/src/node.rs`, `nros-platform-api/src/lib.rs` ×2).

Checked before moving: nothing outside `docs/roadmap/archived/` links to the live phase-188 path, so the move breaks no reference.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742