### PR TITLE
feat(phase-434): read the three contract seams play_launch carries for us

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -2751,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/roadmap/phase-434-contract-seams-closed.md
+++ b/docs/roadmap/phase-434-contract-seams-closed.md
@@ -1,0 +1,64 @@
+# Phase 434 — the contract seams with play_launch are closed on this side
+
+**Status (2026-09-06). Complete.** Implements nothing new in the RMW; consumes
+three model fields play_launch has carried across the model boundary for this
+crate since its phases 67/68, and which this side never read.
+
+## What was open
+
+play_launch's phase 70 W1 census (2026-09-05) found the claim in its own
+docs — that nano-ros reads `node_concurrency` and `max_jitter_ms` from the
+model — false in every branch here. The real reads of `model.contracts` were
+`node_paths`, `pub_endpoints`, `sub_endpoints`. The seam had teeth:
+
+- `mapper_input_from_model` built `MapperPath` with `max_jitter_ms: None`
+  and `miss: None` while the model carried both — a jitter requirement and a
+  weakly-hard miss tolerance that could never reach `chain_aware_rank`.
+- `MapperNode::claims_concurrency` was never set, so a contract's exclusion
+  relation — which decides whether summing a chain's latencies is sound and
+  whether a per-thread reservation is — was invisible to the mapper.
+- `infer_callback_groups` gave every chainless callback its own `reentrant`
+  group, while the contract's absent `concurrency:` means everything
+  serialises: the default `rclcpp`'s implicit callback group uses and
+  `default_cbg_type` here uses. Two toolchains, opposite defaults, each
+  picked silently.
+
+## What closes it
+
+**Pin** `ros-launch-manifest` v0.1.23 → v0.1.31 (eight tags of vocabulary
+work upstream; one compile error was expected from the model changes and
+none occurred — every model literal here already uses `..Default::default()`).
+
+**Mapper input** (`nros-orchestration-ir::mapper_input`): `max_jitter_ms`
+and `miss` read straight through from `contracts.node_paths`;
+`claims_concurrency` is true when a node's `node_concurrency` entry leaves
+any path outside every `exclusive` set — the author claiming MORE
+concurrency than the safe default.
+
+**Planner** (`nros-cli-core::orchestration::planner`): the record a model
+produces now carries `node_concurrency` (always present when the record came
+from a model, even empty — its presence is what says the contract's default
+applies). `infer_callback_groups_with_declarations` prefers the declaration:
+
+| record | node entry | chainless callbacks become |
+| --- | --- | --- |
+| legacy (no key) | — | one `reentrant` group each (unchanged) |
+| from a model | none | ONE `mutually_exclusive` group per node — `declared: default` |
+| from a model | `exclusive: [[a, b]]` | `[a, b]` mutually exclusive (`declared: exclusive`); the rest `reentrant`, because that is the claim |
+
+Chains keep their mutually-exclusive groups either way: dataflow coupling is
+a fact the contract does not override. Path names are matched to callback
+ids by the callback's own name (`…/plan` ↔ `plan`); a declared set naming no
+callback of the node is ignored rather than guessed at.
+
+## Still open on this side
+
+- `srv_endpoints`, `max_response_ms` and `tolerance_ms` are carried in the
+  model and read by nothing here. They stay on play_launch's census
+  baseline as this repo's debt until something consumes them.
+- Whether `claims_concurrency` should also relax the executor's dispatch
+  (a `Reentrant` group where the author claimed it) is the multi-worker
+  executor question RFC-0047 OQ1 already holds.
+
+Cross-reference: play_launch `docs/roadmap/phase-70-consumer-census.md`
+(the finding), `docs/design/contract-axes.md` §3.4 (the exclusion relation).

--- a/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385-freertos/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -586,7 +586,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-mps2-an385/Cargo.lock
+++ b/packages/boards/nros-board-mps2-an385/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
+++ b/packages/boards/nros-board-mps3-an536-freertos/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-nuttx-qemu/Cargo.lock
+++ b/packages/boards/nros-board-nuttx-qemu/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-s32z270-freertos/Cargo.lock
+++ b/packages/boards/nros-board-s32z270-freertos/Cargo.lock
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-threadx-linux/Cargo.lock
+++ b/packages/boards/nros-board-threadx-linux/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
+++ b/packages/boards/nros-board-threadx-qemu-riscv64/Cargo.lock
@@ -517,7 +517,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -530,7 +530,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -1226,7 +1226,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -1251,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/cli/nros-cli-core/Cargo.toml
+++ b/packages/cli/nros-cli-core/Cargo.toml
@@ -59,10 +59,10 @@ cargo_metadata = "0.18"
 # built by `just setup-launch-resolve`, invoked by ABSOLUTE path from cmd/ws.rs —
 # never via $PATH, per issue 0285). It is NOT the external `play_launch_parser`
 # this comment used to name; nothing in packages/cli/ spawns that binary any more.
-ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
+ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
 # RFC-0052 / phase-296 W1 — SystemModel ingestion (shared schema, RFC-0050)
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
-ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
+ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
 
 # Phase 228.E — shared per-tier orchestration schema + resolver (RFC-0015),
 # from the runtime workspace at `packages/core/`. Same crate the

--- a/packages/cli/nros-cli-core/src/orchestration/model_ingest.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/model_ingest.rs
@@ -1427,7 +1427,24 @@ pub fn plan_record_from_model(model: &SystemModel) -> serde_json::Value {
             }));
         }
     }
-    serde_json::json!({ "node": nodes, "container": containers, "load_node": load_nodes })
+    // Phase 434 — the exclusion relation rides the record, because the
+    // planner infers callback groups from a record and never sees the model.
+    // The KEY is always present when the record came from a model, even when
+    // no node declares anything: its presence is what tells the planner the
+    // contract's default applies (everything serialises), as opposed to a
+    // legacy record where the planner's own inference is all there is.
+    let node_concurrency: serde_json::Map<String, serde_json::Value> = model
+        .contracts
+        .node_concurrency
+        .iter()
+        .map(|(fqn, c)| (fqn.clone(), serde_json::json!(c.exclusive)))
+        .collect();
+    serde_json::json!({
+        "node": nodes,
+        "container": containers,
+        "load_node": load_nodes,
+        "node_concurrency": node_concurrency,
+    })
 }
 
 pub fn plan_transports(

--- a/packages/cli/nros-cli-core/src/orchestration/plan.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/plan.rs
@@ -504,6 +504,14 @@ pub struct PlanCallbackGroup {
     /// `true` when the planner inferred this group from the chains;
     /// `false` when it came from an explicit `[[group]]` override.
     pub inferred: bool,
+    /// Phase 434 — how a MODEL-derived record settled this group, when one
+    /// was consulted: `"default"` (the node declared nothing, so the
+    /// contract's default applied) or `"exclusive"` (an explicit
+    /// `concurrency:` set named these callbacks). `None` for a chain group
+    /// or for any group produced from a legacy record with no
+    /// `node_concurrency` key — the planner's own inference is all there is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared: Option<String>,
 }
 
 /// Phase 172.A — boot autostart policy for a managed-lifecycle (REP-2002) node.

--- a/packages/cli/nros-cli-core/src/orchestration/planner.rs
+++ b/packages/cli/nros-cli-core/src/orchestration/planner.rs
@@ -219,6 +219,7 @@ pub fn plan_system(options: PlanOptions) -> Result<PlanningOutput> {
         ));
     }
 
+    let declared_concurrency = declared_concurrency_from_record(&record);
     let plan = schema_plan_json(
         &options,
         &record_path,
@@ -227,6 +228,7 @@ pub fn plan_system(options: PlanOptions) -> Result<PlanningOutput> {
         &metadata,
         system_toml_path.as_deref(),
         build_json,
+        declared_concurrency.as_ref(),
     );
 
     let plan_path = options.out_root.join("nros-plan.json");
@@ -619,6 +621,35 @@ fn preserve_metadata(metadata: &[JsonArtifact], metadata_dir: &Path) -> Result<(
     Ok(())
 }
 
+/// Phase 434 — the exclusion relation a model-derived record carries. `None`
+/// for a legacy record (no key): the planner's own inference is then all
+/// there is. `Some(empty)` for a model where no node declared anything: the
+/// contract's default — everything serialises — applies to every node.
+#[allow(clippy::type_complexity)]
+fn declared_concurrency_from_record(record: &Value) -> Option<BTreeMap<String, Vec<Vec<String>>>> {
+    let map = record.get("node_concurrency")?.as_object()?;
+    Some(
+        map.iter()
+            .map(|(fqn, groups)| {
+                let groups: Vec<Vec<String>> = groups
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .map(|g| {
+                        g.as_array()
+                            .into_iter()
+                            .flatten()
+                            .filter_map(|s| s.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .collect();
+                (fqn.clone(), groups)
+            })
+            .collect(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 fn schema_plan_json(
     options: &PlanOptions,
     record_path: &Path,
@@ -627,6 +658,7 @@ fn schema_plan_json(
     metadata: &[JsonArtifact],
     system_toml: Option<&Path>,
     build: Value,
+    declared_concurrency: Option<&BTreeMap<String, Vec<Vec<String>>>>,
 ) -> Value {
     let components = schema_components(metadata);
     // Phase 256 W4.2 — the planner emits no scheduling tiers: tiers resolve in the
@@ -636,7 +668,11 @@ fn schema_plan_json(
     let plan_instances = instances.iter().map(schema_instance).collect::<Vec<_>>();
     let interfaces = schema_interfaces(&plan_instances);
     let callback_chains = infer_callback_chains(&plan_instances);
-    let callback_groups = infer_callback_groups(&plan_instances, &callback_chains);
+    let callback_groups = infer_callback_groups_with_declarations(
+        &plan_instances,
+        &callback_chains,
+        declared_concurrency,
+    );
     let sched_contexts = vec![default_sched_context()];
 
     let mut plan = json!({
@@ -1995,7 +2031,50 @@ fn infer_callback_chains(instances: &[Value]) -> Vec<Value> {
 /// emit in `chains` order (already id-sorted by component root), then
 /// reentrant singletons in callback-id order. Overridable by an explicit
 /// `[[group]]`.
+/// The legacy-record form, kept for the tests that pin the inference alone.
+#[cfg(test)]
 fn infer_callback_groups(instances: &[Value], chains: &[Value]) -> Vec<Value> {
+    infer_callback_groups_with_declarations(instances, chains, None)
+}
+
+/// The node FQN a plan instance stands for, the way the model keys it.
+fn instance_fqn(instance: &Value) -> String {
+    let ns = instance
+        .get("namespace")
+        .and_then(Value::as_str)
+        .unwrap_or("/")
+        .trim_end_matches('/');
+    let name = instance
+        .get("launch_name")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    format!("{ns}/{name}")
+}
+
+/// Phase 434 — group inference that prefers a DECLARATION over its own
+/// guess, closing the seam play_launch's phase 68 W5 found: this planner
+/// gave every chainless callback its own `reentrant` group, while the
+/// contract's absent `concurrency:` means everything serialises — the same
+/// default `rclcpp`'s implicit callback group and `default_cbg_type` already
+/// use. Opposite answers, each picked silently, deciding whether a summed
+/// chain latency is sound and whether a per-thread reservation is.
+///
+/// With `declared` present (a model-derived record):
+///
+/// - a node with NO entry: every chainless callback of that node lands in
+///   ONE mutually-exclusive group — the contract's default, not a guess;
+/// - a node with an entry: each `exclusive` set whose path names match
+///   callback names becomes a mutually-exclusive group, and a callback in no
+///   declared set is `reentrant`, because the author claimed exactly that.
+///
+/// Chains keep their mutually-exclusive groups either way: dataflow coupling
+/// is a fact the contract does not override. With `declared` absent (a
+/// legacy record) the behaviour is unchanged.
+fn infer_callback_groups_with_declarations(
+    instances: &[Value],
+    chains: &[Value],
+    declared: Option<&BTreeMap<String, Vec<Vec<String>>>>,
+) -> Vec<Value> {
     use std::collections::BTreeSet;
 
     let mut grouped: BTreeSet<String> = BTreeSet::new();
@@ -2022,20 +2101,68 @@ fn infer_callback_groups(instances: &[Value], chains: &[Value]) -> Vec<Value> {
         }));
     }
 
-    // One reentrant singleton group per callback outside any chain.
+    // Callbacks outside any chain.
     let mut singles: Vec<String> = Vec::new();
     for instance in instances {
-        for cb in instance
+        let chainless: Vec<String> = instance
             .get("callbacks")
             .and_then(Value::as_array)
             .into_iter()
             .flatten()
-        {
-            let Some(id) = cb.get("id").and_then(Value::as_str) else {
-                continue;
-            };
-            if !grouped.contains(id) {
-                singles.push(id.to_string());
+            .filter_map(|cb| cb.get("id").and_then(Value::as_str))
+            .filter(|id| !grouped.contains(*id))
+            .map(str::to_string)
+            .collect();
+        if chainless.is_empty() {
+            continue;
+        }
+        let Some(declared) = declared else {
+            singles.extend(chainless);
+            continue;
+        };
+        let fqn = instance_fqn(instance);
+        match declared.get(&fqn) {
+            None => {
+                // The contract's default: no declaration means the node's
+                // paths serialise. One group, the whole node.
+                let instance_id = instance.get("id").and_then(Value::as_str).unwrap_or("");
+                groups.push(json!({
+                    "id": format!("group/{instance_id}"),
+                    "kind": "mutually_exclusive",
+                    "callbacks": chainless,
+                    "inferred": false,
+                    "declared": "default",
+                }));
+            }
+            Some(sets) => {
+                let mut claimed: BTreeSet<String> = BTreeSet::new();
+                for set in sets {
+                    // A declared set names PATHS; callback ids end in the
+                    // callback name. Match on that name.
+                    let members: Vec<String> = chainless
+                        .iter()
+                        .filter(|id| {
+                            set.iter()
+                                .any(|p| id.rsplit('/').next().is_some_and(|tail| tail == p))
+                        })
+                        .cloned()
+                        .collect();
+                    if members.is_empty() {
+                        continue;
+                    }
+                    claimed.extend(members.iter().cloned());
+                    let head = members.first().cloned().unwrap_or_default();
+                    groups.push(json!({
+                        "id": format!("group/{head}"),
+                        "kind": "mutually_exclusive",
+                        "callbacks": members,
+                        "inferred": false,
+                        "declared": "exclusive",
+                    }));
+                }
+                // Everything the author left out of every set may run
+                // concurrently — that is the claim a declaration makes.
+                singles.extend(chainless.into_iter().filter(|id| !claimed.contains(id)));
             }
         }
     }
@@ -5927,6 +6054,60 @@ topics:
         assert_eq!(groups[0]["kind"], json!("reentrant"));
         assert_eq!(groups[0]["callbacks"], json!(["a/tick"]));
         assert_eq!(groups[0]["inferred"], json!(true));
+    }
+
+    /// Phase 434 — the contract's default beats the planner's guess.
+    #[test]
+    fn a_model_record_without_a_declaration_serialises_the_node() {
+        let instances = vec![json!({
+            "id": "a",
+            "namespace": "/",
+            "launch_name": "a",
+            "callbacks": [{ "id": "a/tick" }, { "id": "a/work" }],
+            "nodes": [{ "entities": [
+                { "role": "timer", "id": "a/timer", "callback": "a/tick" },
+                { "role": "timer", "id": "a/timer2", "callback": "a/work" },
+            ]}]
+        })];
+        let chains = infer_callback_chains(&instances);
+        assert!(chains.is_empty());
+        // Legacy record: two reentrant singletons, as before.
+        let legacy = infer_callback_groups_with_declarations(&instances, &chains, None);
+        assert_eq!(legacy.len(), 2);
+        assert!(legacy.iter().all(|g| g["kind"] == json!("reentrant")));
+        // Model record, nothing declared for /a: ONE mutually-exclusive group.
+        let declared = BTreeMap::new();
+        let groups = infer_callback_groups_with_declarations(&instances, &chains, Some(&declared));
+        assert_eq!(groups.len(), 1, "got {groups:?}");
+        assert_eq!(groups[0]["kind"], json!("mutually_exclusive"));
+        assert_eq!(groups[0]["callbacks"], json!(["a/tick", "a/work"]));
+        assert_eq!(groups[0]["declared"], json!("default"));
+    }
+
+    /// Phase 434 — a declared exclusion set is honoured, and what it leaves
+    /// out is the concurrency the author claimed.
+    #[test]
+    fn a_declared_exclusion_set_groups_its_members_and_frees_the_rest() {
+        let instances = vec![json!({
+            "id": "a",
+            "namespace": "/",
+            "launch_name": "a",
+            "callbacks": [{ "id": "a/plan" }, { "id": "a/replan" }, { "id": "a/telemetry" }],
+            "nodes": [{ "entities": [] }]
+        })];
+        let chains = infer_callback_chains(&instances);
+        let mut declared = BTreeMap::new();
+        declared.insert(
+            "/a".to_string(),
+            vec![vec!["plan".to_string(), "replan".to_string()]],
+        );
+        let groups = infer_callback_groups_with_declarations(&instances, &chains, Some(&declared));
+        assert_eq!(groups.len(), 2, "got {groups:?}");
+        assert_eq!(groups[0]["kind"], json!("mutually_exclusive"));
+        assert_eq!(groups[0]["callbacks"], json!(["a/plan", "a/replan"]));
+        assert_eq!(groups[0]["declared"], json!("exclusive"));
+        assert_eq!(groups[1]["kind"], json!("reentrant"));
+        assert_eq!(groups[1]["callbacks"], json!(["a/telemetry"]));
     }
 
     #[test]

--- a/packages/core/nros-macros/Cargo.toml
+++ b/packages/core/nros-macros/Cargo.toml
@@ -48,7 +48,7 @@ nros-orchestration-ir = { workspace = true }
 # SystemModel at compile time (the canonical bake input). Same vendored crate
 # the CLI uses; path crosses into the cli sub-workspace (host-only proc-macro
 # dep, same rationale as nros-pkg-index / nros-launch-parser above).
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
 
 [lints]
 workspace = true

--- a/packages/core/nros-orchestration-ir/Cargo.toml
+++ b/packages/core/nros-orchestration-ir/Cargo.toml
@@ -40,11 +40,11 @@ thiserror = { workspace = true }
 # depping nros-pkg-index / nros-launch-parser).
 # `[tiers.*]` duration keys accept both the canonical and the deprecated
 # `_us` spelling; the parser is rlm's own, never a second one here.
-ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
-ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
+ros-launch-manifest-types = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
+ros-launch-manifest-sched = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
 # W5.13 follow-up — `mapper_input` adapts a resolved `SystemModel` into the
 # `MapperInput` the realizer ranks; the model types live in the sibling crate.
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
 # issue 0303 — `qos_override` lowers `qos_overrides.<topic>.<role>.<policy>`
 # params into the codes the entry bakes. The role/policy NUMBERING is
 # `nros-rmw`'s (it owns the decoder every runtime uses), so the lowering must

--- a/packages/core/nros-orchestration-ir/src/mapper_input.rs
+++ b/packages/core/nros-orchestration-ir/src/mapper_input.rs
@@ -92,14 +92,14 @@ fn node_paths_for(model: &SystemModel, fqn: &str, wcet: Option<&WcetProfile>) ->
             exec_ms: wcet.and_then(|w| w.exec_ms(path_ref)),
             inputs: pc.input.clone(),
             outputs: pc.output.clone(),
-            // Issue 0951's pin bump (rlm v0.1.11 -> v0.1.21) added these two.
-            // `None` is the correct value rather than a placeholder: nano-ros
-            // authors neither a jitter budget nor a weakly-hard miss tolerance
-            // today, and rlm treats `None` as UNDECLARED and says so — the same
-            // rule `exec_ms` above already follows. Inventing a zero would
-            // assert a bound nobody wrote.
-            max_jitter_ms: None,
-            miss: None,
+            // play_launch phase 68 W5 / nano-ros phase 434 — both crossed the
+            // model boundary so THIS side could read them, and until now it
+            // did not: rlm's `MapperPath` carried the bound, the model carried
+            // it, and the copy built here filled in `None`. Read straight
+            // through; `None` still means undeclared, and only when the
+            // contract declared nothing.
+            max_jitter_ms: pc.max_jitter_ms,
+            miss: pc.miss.clone(),
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
@@ -128,11 +128,24 @@ pub fn mapper_input_from_model_with_wcet(
     let mut nodes = Vec::with_capacity(model.structure.nodes.len());
     for (fqn, node) in &model.structure.nodes {
         let criticality = node.criticality.as_deref().and_then(parse_criticality);
+        // The exclusion relation (play_launch phase 67/68). PRESENCE in
+        // `node_concurrency` is the declaration: no entry means every path
+        // of the node serialises — what rclcpp's implicit callback group
+        // does, and what `default_cbg_type` here does too — while an entry
+        // is the author claiming MORE concurrency than that. That claim is
+        // what makes a per-thread reservation unsound and a summed chain
+        // latency optimistic, so it has to reach the mapper. Until phase 434
+        // it stopped at the model, and the two toolchains scheduled the same
+        // system from opposite defaults.
+        let claims_concurrency = model.contracts.node_concurrency.get(fqn).is_some_and(|c| {
+            c.exclusive.iter().flatten().count() < node_paths_for(model, fqn, None).len()
+        });
         nodes.push(MapperNode {
             name: fqn.clone(),
             scope: node.scope.clone(),
             criticality,
             paths: node_paths_for(model, fqn, wcet),
+            claims_concurrency,
             ..Default::default()
         });
     }
@@ -346,6 +359,65 @@ mod tests {
             execution: Execution::default(),
             ..Default::default()
         }
+    }
+
+    /// Phase 434 — the three fields play_launch carried across the model
+    /// boundary for this crate reach the mapper. Before this they stopped at
+    /// the model: `max_jitter_ms`/`miss` were filled `None` here, and the
+    /// concurrency relation was never read at all, so an author's claim that
+    /// two callbacks may run at once — which is what makes a summed chain
+    /// latency optimistic and a per-thread reservation unsound — was invisible
+    /// on this side.
+    #[test]
+    fn contract_seams_reach_the_mapper() {
+        use ros_launch_manifest_sched::{ConcurrencyContract, MapperMiss};
+        let mut model = model_with_two_nodes();
+        model
+            .contracts
+            .node_paths
+            .get_mut("/planner/plan")
+            .unwrap()
+            .max_jitter_ms = Some(4.0);
+        model
+            .contracts
+            .node_paths
+            .get_mut("/planner/plan")
+            .unwrap()
+            .miss = Some(MapperMiss {
+            tolerate_n: Some(1),
+            ..Default::default()
+        });
+        // /planner has two paths; declaring `exclusive: [[plan]]` leaves the
+        // other free to run concurrently — a claim of MORE concurrency.
+        model.contracts.node_paths.insert(
+            "/planner/telemetry".to_string(),
+            PathContract {
+                input: vec![],
+                output: vec!["/planner/stats".to_string()],
+                ..Default::default()
+            },
+        );
+        model.contracts.node_concurrency.insert(
+            "/planner".to_string(),
+            ConcurrencyContract {
+                exclusive: vec![vec!["plan".to_string()]],
+            },
+        );
+
+        let input = mapper_input_from_model(&model);
+        let planner = input.nodes.iter().find(|n| n.name == "/planner").unwrap();
+        let plan = planner.paths.iter().find(|p| p.name == "plan").unwrap();
+        assert_eq!(plan.max_jitter_ms, Some(4.0));
+        assert_eq!(plan.miss.as_ref().and_then(|m| m.tolerate_n), Some(1));
+        assert!(
+            planner.claims_concurrency,
+            "a declared exclusion that leaves a path out claims concurrency"
+        );
+        let sensor = input.nodes.iter().find(|n| n.name == "/sensor").unwrap();
+        assert!(
+            !sensor.claims_concurrency,
+            "no declaration means everything serialises"
+        );
     }
 
     #[test]

--- a/packages/testing/nros-tests/Cargo.toml
+++ b/packages/testing/nros-tests/Cargo.toml
@@ -42,7 +42,7 @@ nros-orchestration-ir = { workspace = true }
 # `target/<triple>/<profile>/` from it instead of re-implementing the mapping
 # the builder used.
 nros-cargo-profile = { path = "../../tooling/nros-cargo-profile" }
-ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.23" }
+ros-launch-manifest-model = { git = "https://github.com/NEWSLabNTU/ros-launch-manifest.git", tag = "v0.1.31" }
 # Phase 212.M.11 + M.12 — TOML parsing for the example-canonical-shape
 # + pre-212-file regression tests. Reads
 # `[package.metadata.nros.{component,entry,deploy.*}]` out of each

--- a/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/logging-smoke-threadx-linux/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
+++ b/packages/testing/nros-tests/bins/pool-exhaustion-threadx-linux/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/testing/nros-tests/bins/sim-clock-listener/Cargo.lock
+++ b/packages/testing/nros-tests/bins/sim-clock-listener/Cargo.lock
@@ -784,7 +784,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/testing/nros-tests/bins/sim-clock-publisher/Cargo.lock
+++ b/packages/testing/nros-tests/bins/sim-clock-publisher/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 [[package]]
 name = "ros-launch-manifest-model"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "indexmap",
  "ros-launch-manifest-sched",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-sched"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "ros-launch-manifest-types",
  "serde",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "ros-launch-manifest-types"
 version = "0.1.4"
-source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.23#c66c534a8125321c0c232e4c24ab75913b90412f"
+source = "git+https://github.com/NEWSLabNTU/ros-launch-manifest.git?tag=v0.1.31#ebbb22ac1fdb02bcd05d0968f9422921827356aa"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
play_launch's phase 70 census found the claim that nano-ros reads `node_concurrency` and `max_jitter_ms` from the model false in every branch. This closes the seam on this side: the pin moves v0.1.23 → v0.1.31, `mapper_input` reads `max_jitter_ms`/`miss`/`claims_concurrency`, and the planner's group inference prefers a declaration over its own guess — a node with no `concurrency:` gets one mutually-exclusive group (the contract's default, rclcpp's, `default_cbg_type`'s) instead of a `reentrant` singleton per callback.

Phase doc: `docs/roadmap/phase-434-contract-seams-closed.md`. Tests: `nros-orchestration-ir` 101/101, `nros-cli-core --lib` 957/957 + 3 new.

Worked in a separate clone; another agent is active on the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUezTfD1ZtWMZibC4dbi9z