### PR TITLE
fix(#1099): lifecycle transition ids take lifecycle_msgs' numbering — ours crossed four of eight

### DIFF
--- a/docs/reference/api-parity-ledger/lifecycle.json
+++ b/docs/reference/api-parity-ledger/lifecycle.json
@@ -438,7 +438,7 @@
   "cpp:Transition": {
     "verdict": "gap",
     "bucket": "theirs-only",
-    "why": "OUR LANGUAGES DISAGREE: Rust has a full `LifecycleTransition` enum (`from_u8`, `from_shorthand`, `source_state`), C has the `NROS_LIFECYCLE_TRANSITION_*` constants, and C++ has NO transition type or constants at all -- a caller passes a bare `uint8_t` to the protected `trigger()`. rclcpp's `Transition` carries `id`, `label`, `start_state`, `goal_state`. Nothing forbids an `enum class` here: we already ship `enum class LifecycleState` in the same header. Bucket-covered with its members. Phase 379 W3."
+    "why": "OUR LANGUAGES DISAGREE, though less than they did: Rust has a full `LifecycleTransition` enum (`from_u8`, `from_shorthand`, `source_state`), C has the `NROS_LIFECYCLE_TRANSITION_*` constants, and C++ now has `enum class nros::LifecycleTransition` too (issue 1099 -- it had NO transition type or constants at all, so every caller wrote a bare `uint8_t`, and the id space that byte landed in was not `lifecycle_msgs`'. All three languages now carry the SAME `lifecycle_msgs/msg/Transition` numbers, pinned by `nros-cpp/tests/compile/lifecycle_transition_ids.cpp`). Still a gap: rclcpp's `Transition` is an OBJECT carrying `id`, `label`, `start_state` and `goal_state`, and an enum is not that -- the label and the two states are served over `~/get_available_transitions` and have no in-process accessor in any of our three languages (see `cpp:LifecycleNode::get_available_transitions`). Bucket-covered with its members. Phase 379 W3; prose corrected by issue 1099."
   },
   "cpp:Transition::goal_state": {
     "verdict": "declined",
@@ -509,7 +509,7 @@
   },
   "rust:LifecyclePollingNode::trigger_transition": {
     "verdict": "extension",
-    "why": "see `rust:LifecyclePollingNode`. This is rclcpp's word for the operation, and it is public here -- the same operation is `protected trigger()` in our C++ and `nros_lifecycle_change_state` in our C. See `cpp:LifecycleNode::trigger_transition`."
+    "why": "see `rust:LifecyclePollingNode`. This is rclcpp's word for the operation, and it is public here -- as it now is in our C++ (`nros::LifecycleNode::trigger_transition`, public since phase 379 W5; this row used to say `protected trigger()`), and as `nros_lifecycle_change_state` in our C. All three take the same `lifecycle_msgs/msg/Transition` ids since issue 1099; before it, the C and C++ entry points took nano-ros's own numbering, which disagreed with upstream on four of eight values. NOTE: there is no `cpp:LifecycleNode::trigger_transition` row in this ledger to point at, although rclcpp has the method -- the correlator never emitted one, which is the same blind spot that let the id divergence through (`correlate.py:compare()` matches on name and arity and never on VALUES)."
   },
   "rust:LifecyclePollingNodeCtx": {
     "verdict": "extension",
@@ -517,7 +517,7 @@
   },
   "rust:LifecycleTransition": {
     "verdict": "extension",
-    "why": "the REP-2002 transition set as a closed enum, with `from_u8`, `from_shorthand` (so the generic `\"shutdown\"` label a `ChangeState` request may carry resolves against the current state) and `source_state`. **rclrs 0.5.1 has no lifecycle support whatsoever** -- the whole stage reports zero theirs-only rows in the Rust lane -- so every item here is an extension by definition. The RTOS scenario is REP-2002 itself: a device that owns hardware needs a supervisor-driven `configure`/`activate`/`deactivate` protocol so an actuator can be brought up and parked without restarting the image, and `ros2 lifecycle set` is how the rest of the graph asks for it. We implement the state machine once in `nros_core::lifecycle` and surface it in all three languages. See `cpp:Transition` -- this type has no C++ counterpart, which is a gap on that side."
+    "why": "the REP-2002 transition set as a closed enum, with `from_u8`, `from_shorthand` (so the generic `\"shutdown\"` label a `ChangeState` request may carry resolves against the current state) and `source_state`. **rclrs 0.5.1 has no lifecycle support whatsoever** -- the whole stage reports zero theirs-only rows in the Rust lane -- so every item here is an extension by definition. The RTOS scenario is REP-2002 itself: a device that owns hardware needs a supervisor-driven `configure`/`activate`/`deactivate` protocol so an actuator can be brought up and parked without restarting the image, and `ros2 lifecycle set` is how the rest of the graph asks for it. We implement the state machine once in `nros_core::lifecycle` and surface it in all three languages. See `cpp:Transition`: since issue 1099 C++ has a counterpart ENUM with the same discriminants, but not rclcpp's `Transition` object, so that row stays a gap."
   },
   "rust:LifecycleTransition::source_state": {
     "verdict": "extension",

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -430,6 +430,29 @@ cpp: cpp-fmt
         -Ipackages/api/nros-c/include \
         -Ipackages/platform/nros-platform-api/include \
         packages/api/nros-cpp/tests/compile/graph_query_entry_points.cpp
+    echo "  - lifecycle transition ids ARE lifecycle_msgs, in BOTH languages (issue 1099)"
+    # `nros::LifecycleNode::trigger_transition(uint8_t)` has rclcpp's exact
+    # signature, so its id space must be rclcpp's. It was not: four of eight
+    # ids disagreed with `lifecycle_msgs/msg/Transition`, and a ported
+    # `trigger_transition(2)` on an Inactive node ACTIVATED it and returned OK
+    # where ROS 2 cleans it up. Nothing could catch it -- `correlate.py` never
+    # compares enum VALUES, only names and arities.
+    #
+    # The TU also pins the C++ enum against the C `NROS_LIFECYCLE_TRANSITION_*`
+    # macros: one id space per image, so a mixed C/C++ node cannot hold two.
+    # And it pins `shutdown()` resolving from the CURRENT state -- it hardcoded
+    # 5, whose only legal source state is Unconfigured.
+    test -f packages/api/nros-cpp/tests/compile/lifecycle_transition_ids.cpp || { \
+        echo "ERROR: lifecycle_transition_ids.cpp is MISSING -- issue 1099 is unpinned." >&2; \
+        exit 1; \
+    }
+    c++ -fsyntax-only -std=c++14 -fno-exceptions -fno-rtti \
+        -Itarget/nros-cpp-generated \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-cpp/include \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        packages/api/nros-cpp/tests/compile/lifecycle_transition_ids.cpp
     echo "  - a module can NAME the backend it means (issue 1050 defect 3)"
     # `nros::init()` opens whichever backend registered FIRST, and on a hosted
     # target that order is decided before `main` by `.init_array` ctors. A PX4

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -154,44 +154,51 @@ struct nros_goal_uuid_t;
 #define NROS_LIFECYCLE_STATE_ERROR_PROCESSING 5
 
 /**
- * Lifecycle transition: Configure
+ * Lifecycle transition: Configure (`lifecycle_msgs` `TRANSITION_CONFIGURE`)
  */
 #define NROS_LIFECYCLE_TRANSITION_CONFIGURE 1
 
 /**
- * Lifecycle transition: Activate
+ * Lifecycle transition: Cleanup (`lifecycle_msgs` `TRANSITION_CLEANUP`)
  */
-#define NROS_LIFECYCLE_TRANSITION_ACTIVATE 2
+#define NROS_LIFECYCLE_TRANSITION_CLEANUP 2
 
 /**
- * Lifecycle transition: Deactivate
+ * Lifecycle transition: Activate (`lifecycle_msgs` `TRANSITION_ACTIVATE`)
  */
-#define NROS_LIFECYCLE_TRANSITION_DEACTIVATE 3
+#define NROS_LIFECYCLE_TRANSITION_ACTIVATE 3
 
 /**
- * Lifecycle transition: Cleanup
+ * Lifecycle transition: Deactivate (`lifecycle_msgs` `TRANSITION_DEACTIVATE`)
  */
-#define NROS_LIFECYCLE_TRANSITION_CLEANUP 4
+#define NROS_LIFECYCLE_TRANSITION_DEACTIVATE 4
 
 /**
  * Lifecycle transition: Shutdown (from Unconfigured)
+ * (`lifecycle_msgs` `TRANSITION_UNCONFIGURED_SHUTDOWN`)
  */
 #define NROS_LIFECYCLE_TRANSITION_SHUTDOWN_UNCONFIGURED 5
 
 /**
  * Lifecycle transition: Shutdown (from Inactive)
+ * (`lifecycle_msgs` `TRANSITION_INACTIVE_SHUTDOWN`)
  */
 #define NROS_LIFECYCLE_TRANSITION_SHUTDOWN_INACTIVE 6
 
 /**
  * Lifecycle transition: Shutdown (from Active)
+ * (`lifecycle_msgs` `TRANSITION_ACTIVE_SHUTDOWN`)
  */
 #define NROS_LIFECYCLE_TRANSITION_SHUTDOWN_ACTIVE 7
 
 /**
  * Lifecycle transition: Error Recovery
+ * (`lifecycle_msgs` `TRANSITION_ON_ERROR_SUCCESS`). Upstream `8` is
+ * `TRANSITION_DESTROY`, which nano-ros does not implement, and upstream models
+ * error recovery as an implicit transition — `60` is upstream's id for its
+ * success edge and is what nano-ros already put on the wire for it.
  */
-#define NROS_LIFECYCLE_TRANSITION_ERROR_RECOVERY 8
+#define NROS_LIFECYCLE_TRANSITION_ERROR_RECOVERY 60
 
 /**
  * Transition result: Success

--- a/packages/api/nros-c/src/lifecycle.rs
+++ b/packages/api/nros-c/src/lifecycle.rs
@@ -40,22 +40,38 @@ pub const NROS_LIFECYCLE_STATE_FINALIZED: u8 = 4;
 /// Lifecycle state: ErrorProcessing
 pub const NROS_LIFECYCLE_STATE_ERROR_PROCESSING: u8 = 5;
 
-/// Lifecycle transition: Configure
+// Issue 1099 — the transition ids below ARE `lifecycle_msgs/msg/Transition`.
+// They are the ids `nros_lifecycle_change_state` and
+// `nros::LifecycleNode::trigger_transition` accept and the ids a `ChangeState`
+// request carries, so a caller who writes the number instead of the name must
+// still get the transition ROS 2 would give them. Four of these used to
+// disagree with upstream (2/3/4 were Activate/Deactivate/Cleanup, 8 was Error
+// Recovery), which made `trigger_transition(2)` ACTIVATE an Inactive node
+// where ROS 2 cleans it up.
+
+/// Lifecycle transition: Configure (`lifecycle_msgs` `TRANSITION_CONFIGURE`)
 pub const NROS_LIFECYCLE_TRANSITION_CONFIGURE: u8 = 1;
-/// Lifecycle transition: Activate
-pub const NROS_LIFECYCLE_TRANSITION_ACTIVATE: u8 = 2;
-/// Lifecycle transition: Deactivate
-pub const NROS_LIFECYCLE_TRANSITION_DEACTIVATE: u8 = 3;
-/// Lifecycle transition: Cleanup
-pub const NROS_LIFECYCLE_TRANSITION_CLEANUP: u8 = 4;
+/// Lifecycle transition: Cleanup (`lifecycle_msgs` `TRANSITION_CLEANUP`)
+pub const NROS_LIFECYCLE_TRANSITION_CLEANUP: u8 = 2;
+/// Lifecycle transition: Activate (`lifecycle_msgs` `TRANSITION_ACTIVATE`)
+pub const NROS_LIFECYCLE_TRANSITION_ACTIVATE: u8 = 3;
+/// Lifecycle transition: Deactivate (`lifecycle_msgs` `TRANSITION_DEACTIVATE`)
+pub const NROS_LIFECYCLE_TRANSITION_DEACTIVATE: u8 = 4;
 /// Lifecycle transition: Shutdown (from Unconfigured)
+/// (`lifecycle_msgs` `TRANSITION_UNCONFIGURED_SHUTDOWN`)
 pub const NROS_LIFECYCLE_TRANSITION_SHUTDOWN_UNCONFIGURED: u8 = 5;
 /// Lifecycle transition: Shutdown (from Inactive)
+/// (`lifecycle_msgs` `TRANSITION_INACTIVE_SHUTDOWN`)
 pub const NROS_LIFECYCLE_TRANSITION_SHUTDOWN_INACTIVE: u8 = 6;
 /// Lifecycle transition: Shutdown (from Active)
+/// (`lifecycle_msgs` `TRANSITION_ACTIVE_SHUTDOWN`)
 pub const NROS_LIFECYCLE_TRANSITION_SHUTDOWN_ACTIVE: u8 = 7;
 /// Lifecycle transition: Error Recovery
-pub const NROS_LIFECYCLE_TRANSITION_ERROR_RECOVERY: u8 = 8;
+/// (`lifecycle_msgs` `TRANSITION_ON_ERROR_SUCCESS`). Upstream `8` is
+/// `TRANSITION_DESTROY`, which nano-ros does not implement, and upstream models
+/// error recovery as an implicit transition — `60` is upstream's id for its
+/// success edge and is what nano-ros already put on the wire for it.
+pub const NROS_LIFECYCLE_TRANSITION_ERROR_RECOVERY: u8 = 60;
 
 /// Transition result: Success
 pub const NROS_LIFECYCLE_RET_OK: u8 = 0;
@@ -74,9 +90,9 @@ const _: () = {
     assert!(NROS_LIFECYCLE_STATE_ERROR_PROCESSING == LifecycleState::ErrorProcessing as u8);
 
     assert!(NROS_LIFECYCLE_TRANSITION_CONFIGURE == LifecycleTransition::Configure as u8);
+    assert!(NROS_LIFECYCLE_TRANSITION_CLEANUP == LifecycleTransition::Cleanup as u8);
     assert!(NROS_LIFECYCLE_TRANSITION_ACTIVATE == LifecycleTransition::Activate as u8);
     assert!(NROS_LIFECYCLE_TRANSITION_DEACTIVATE == LifecycleTransition::Deactivate as u8);
-    assert!(NROS_LIFECYCLE_TRANSITION_CLEANUP == LifecycleTransition::Cleanup as u8);
     assert!(
         NROS_LIFECYCLE_TRANSITION_SHUTDOWN_UNCONFIGURED
             == LifecycleTransition::ShutdownUnconfigured as u8
@@ -90,6 +106,32 @@ const _: () = {
     assert!(NROS_LIFECYCLE_RET_OK == TransitionResult::Success as u8);
     assert!(NROS_LIFECYCLE_RET_FAILURE == TransitionResult::Failure as u8);
     assert!(NROS_LIFECYCLE_RET_ERROR == TransitionResult::Error as u8);
+};
+
+/// Issue 1099 — the 0792 block above proves the header agrees with our enum;
+/// it cannot catch the two being wrong TOGETHER, which is exactly what
+/// happened. These literals are transcribed from
+/// `lifecycle_msgs/msg/Transition.msg` and are what a ported ROS 2 caller
+/// means by the number.
+const _: () = {
+    assert!(NROS_LIFECYCLE_TRANSITION_CONFIGURE == 1); // TRANSITION_CONFIGURE
+    assert!(NROS_LIFECYCLE_TRANSITION_CLEANUP == 2); // TRANSITION_CLEANUP
+    assert!(NROS_LIFECYCLE_TRANSITION_ACTIVATE == 3); // TRANSITION_ACTIVATE
+    assert!(NROS_LIFECYCLE_TRANSITION_DEACTIVATE == 4); // TRANSITION_DEACTIVATE
+    assert!(NROS_LIFECYCLE_TRANSITION_SHUTDOWN_UNCONFIGURED == 5); // ..._UNCONFIGURED_SHUTDOWN
+    assert!(NROS_LIFECYCLE_TRANSITION_SHUTDOWN_INACTIVE == 6); // ..._INACTIVE_SHUTDOWN
+    assert!(NROS_LIFECYCLE_TRANSITION_SHUTDOWN_ACTIVE == 7); // ..._ACTIVE_SHUTDOWN
+    assert!(NROS_LIFECYCLE_TRANSITION_ERROR_RECOVERY == 60); // TRANSITION_ON_ERROR_SUCCESS
+
+    // The primary states already match `lifecycle_msgs/msg/State.msg`.
+    // `NROS_LIFECYCLE_STATE_ERROR_PROCESSING` deliberately does NOT: upstream
+    // spells it `TRANSITION_STATE_ERRORPROCESSING = 15`. `5` is UNASSIGNED
+    // upstream, so unlike the transition ids it can never silently mean a
+    // different state; `state_wire()` in `nros-node` maps it to 15 on the wire.
+    assert!(NROS_LIFECYCLE_STATE_UNCONFIGURED == 1);
+    assert!(NROS_LIFECYCLE_STATE_INACTIVE == 2);
+    assert!(NROS_LIFECYCLE_STATE_ACTIVE == 3);
+    assert!(NROS_LIFECYCLE_STATE_FINALIZED == 4);
 };
 
 // ============================================================================

--- a/packages/api/nros-cpp/include/nros/lifecycle.hpp
+++ b/packages/api/nros-cpp/include/nros/lifecycle.hpp
@@ -36,6 +36,12 @@ namespace nros {
 /// REP-2002 primary states. Values match `nros_cpp_lifecycle_get_current_state()` /
 /// `nros_core::lifecycle::LifecycleState` (`Unknown` is the `0` sentinel returned for a
 /// null executor or before services are registered).
+///
+/// The four primary states carry their `lifecycle_msgs/msg/State` ids.
+/// `ErrorProcessing` deliberately does not: upstream spells it
+/// `TRANSITION_STATE_ERRORPROCESSING = 15`, but `5` is UNASSIGNED upstream, so
+/// unlike the transition ids (issue 1099) it can never silently name a
+/// different state. The wire mapping in `nros-node` sends 15.
 enum class LifecycleState : uint8_t {
     Unknown = 0,
     Unconfigured = 1,
@@ -45,6 +51,36 @@ enum class LifecycleState : uint8_t {
     ErrorProcessing = 5,
 };
 
+/// REP-2002 transition ids — the values of `lifecycle_msgs/msg/Transition`.
+///
+/// Issue 1099: these ids used to be nano-ros's own numbering, which collided
+/// with upstream's on four of eight values (ours had `Activate = 2`, upstream
+/// has `CLEANUP = 2`). A ported rclcpp file calling
+/// `trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)`
+/// — i.e. `2` — on an Inactive node was silently ACTIVATING it and getting
+/// `Result::ok` back. The numbering is now upstream's everywhere: here, in
+/// `NROS_LIFECYCLE_TRANSITION_*`, in `nros_core::lifecycle`, and on the wire.
+///
+/// Prefer these names over the raw byte; `trigger_transition` accepts either.
+enum class LifecycleTransition : uint8_t {
+    Configure = 1,
+    Cleanup = 2,
+    Activate = 3,
+    Deactivate = 4,
+    /// Shutdown from `Unconfigured`. `LifecycleNode::shutdown()` picks the
+    /// right one of the three for you.
+    ShutdownUnconfigured = 5,
+    /// Shutdown from `Inactive`.
+    ShutdownInactive = 6,
+    /// Shutdown from `Active`.
+    ShutdownActive = 7,
+    /// `ErrorProcessing` -> `Unconfigured`. Upstream models error recovery as
+    /// an implicit transition and gives its success edge id `60`; upstream `8`
+    /// is `TRANSITION_DESTROY`, which nano-ros does not implement and which
+    /// `trigger_transition` rejects.
+    ErrorRecovery = 60,
+};
+
 /// Transition-callback outcome (rclcpp `CallbackReturn` shape). `Failure` rolls
 /// the transition back; `Error` routes to the error-processing transition.
 enum class CallbackReturn : uint8_t {
@@ -52,6 +88,25 @@ enum class CallbackReturn : uint8_t {
     Failure = 1,
     Error = 2,
 };
+
+/// The shutdown transition legal from `state`, or `ShutdownUnconfigured` when
+/// none is (`Unknown`, `Finalized`, `ErrorProcessing`).
+///
+/// REP-2002 gives shutdown three ids, one per legal source state, so no fixed
+/// id can shut down a node in an arbitrary state — which is why
+/// `LifecycleNode::shutdown()` sending `5` unconditionally could not shut down
+/// an Inactive or Active node (issue 1099).
+///
+/// The no-legal-shutdown states fall back to `ShutdownUnconfigured` on purpose:
+/// the state machine already refuses it from those states, so the error comes
+/// from the ONE place that owns the rule instead of being re-derived here.
+///
+/// `constexpr` so a test can pin every arm without building an executor.
+constexpr LifecycleTransition shutdown_transition_for(LifecycleState state) {
+    return state == LifecycleState::Inactive ? LifecycleTransition::ShutdownInactive
+           : state == LifecycleState::Active ? LifecycleTransition::ShutdownActive
+                                             : LifecycleTransition::ShutdownUnconfigured;
+}
 
 /// rclcpp-shape managed node (REP-2002).
 ///
@@ -156,17 +211,48 @@ class LifecycleNode {
         return static_cast<LifecycleState>(nros_cpp_lifecycle_get_current_state(exec_));
     }
 
-    // Programmatic transitions (REP-2002 transition ids).
-    Result configure() { return trigger_transition(1); }
-    Result activate() { return trigger_transition(2); }
-    Result deactivate() { return trigger_transition(3); }
-    Result cleanup() { return trigger_transition(4); }
-    Result shutdown() { return trigger_transition(5); }
+    // Programmatic transitions. Spelled with the enum, never a literal —
+    // issue 1099 is what a literal costs.
+    Result configure() { return trigger_transition(LifecycleTransition::Configure); }
+    Result activate() { return trigger_transition(LifecycleTransition::Activate); }
+    Result deactivate() { return trigger_transition(LifecycleTransition::Deactivate); }
+    Result cleanup() { return trigger_transition(LifecycleTransition::Cleanup); }
+
+    /// Shut the node down from WHEREVER it currently is.
+    ///
+    /// REP-2002 gives shutdown three ids, one per legal source state, so a
+    /// fixed id can only ever shut down a node in one state. This used to send
+    /// `5` (`ShutdownUnconfigured`) unconditionally, which meant `shutdown()`
+    /// could not shut down an Inactive or Active node — the two states a node
+    /// that has done any work is actually in — and returned an
+    /// invalid-transition error instead (issue 1099).
+    ///
+    /// Resolution matches `nros_node::lifecycle`'s own `shutdown()` and the
+    /// generic `"shutdown"` label the `ChangeState` service accepts, so the
+    /// C++ API, the Rust API and `ros2 lifecycle set <node> shutdown` now agree
+    /// about the same node.
+    ///
+    /// The mapping is [`shutdown_transition_for`]; see it for the
+    /// no-legal-shutdown states.
+    Result shutdown() { return trigger_transition(shutdown_transition_for(get_current_state())); }
+
+    /// Drive an arbitrary REP-2002 transition — the type-safe spelling, and the
+    /// one to prefer.
+    Result trigger_transition(LifecycleTransition transition) {
+        return trigger_transition(static_cast<uint8_t>(transition));
+    }
 
     /// Drive an arbitrary REP-2002 transition by id — rclcpp's
     /// `LifecycleNode::trigger_transition(uint8_t)`, and PUBLIC for the same
     /// reason: it is how a ported node reaches a transition that has no named
-    /// helper above. The five helpers are this call with the id filled in.
+    /// helper above. The four helpers are this call with the id filled in.
+    ///
+    /// `transition_id` is a `lifecycle_msgs/msg/Transition` id — the SAME
+    /// number rclcpp means (issue 1099; it was nano-ros's own numbering before,
+    /// which disagreed with upstream on four of eight values and made this
+    /// call silently do the wrong transition). `0` (`TRANSITION_CREATE`) and
+    /// `8` (`TRANSITION_DESTROY`) are not implemented and return
+    /// `InvalidArgument` rather than aliasing onto a transition we do have.
     ///
     /// Phase 379 W5: this was the `protected` `trigger(uint8_t)`, which a
     /// ported rclcpp node could not call at all.

--- a/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
+++ b/packages/api/nros-cpp/include/nros/nros_cpp_ffi.h
@@ -2802,8 +2802,15 @@ nros_cpp_ret_t nros_cpp_register_lifecycle_services(void *executor);
 /**
  * Trigger a lifecycle transition on the C++ executor's state machine.
  *
- * `transition_id` follows the REP-2002 numbering: Configure=1, Activate=2,
- * Deactivate=3, Cleanup=4, Shutdown=5, ErrorProcessed=6.
+ * `transition_id` is a `lifecycle_msgs/msg/Transition` id — the SAME numbering
+ * rclcpp uses (issue 1099): Configure=1, Cleanup=2, Activate=3, Deactivate=4,
+ * UnconfiguredShutdown=5, InactiveShutdown=6, ActiveShutdown=7,
+ * ErrorRecovery=60. `0` (CREATE) and `8` (DESTROY) are not implemented and
+ * return `INVALID_ARGUMENT`.
+ *
+ * (This comment used to read "Configure=1, Activate=2, Deactivate=3,
+ * Cleanup=4, Shutdown=5, ErrorProcessed=6" — three of those were nano-ros's
+ * own numbering and `ErrorProcessed=6` was never a transition at all.)
  *
  * # Safety
  * `executor` must be a valid, live `CppContext*`. Any registered transition
@@ -2815,9 +2822,13 @@ nros_cpp_ret_t nros_cpp_lifecycle_change_state(void *executor, uint8_t transitio
 /**
  * Get the current REP-2002 lifecycle state of the C++ executor's state machine.
  *
- * Returns `0` (`Unconfigured`) if the executor is null or lifecycle services are
- * not registered yet. State numbering: `Unconfigured = 0`, `Inactive = 1`,
- * `Active = 2`, `Finalized = 3`.
+ * Returns `0` if the executor is null or lifecycle services are not registered
+ * yet — that is the `Unknown` sentinel (`nros::LifecycleState::Unknown`), NOT
+ * `Unconfigured`. State numbering is `lifecycle_msgs/msg/State`'s:
+ * `Unconfigured = 1`, `Inactive = 2`, `Active = 3`, `Finalized = 4`, plus
+ * `ErrorProcessing = 5` (upstream numbers that one 15; see
+ * `nros_core::lifecycle`). This comment previously documented a 0-based
+ * numbering that has never been what the function returns.
  *
  * # Safety
  * `executor` must be a valid, live `CppContext*` produced by `nros_cpp_init`.

--- a/packages/api/nros-cpp/src/lifecycle_shim.rs
+++ b/packages/api/nros-cpp/src/lifecycle_shim.rs
@@ -51,8 +51,15 @@ pub unsafe extern "C" fn nros_cpp_register_lifecycle_services(
 
 /// Trigger a lifecycle transition on the C++ executor's state machine.
 ///
-/// `transition_id` follows the REP-2002 numbering: Configure=1, Activate=2,
-/// Deactivate=3, Cleanup=4, Shutdown=5, ErrorProcessed=6.
+/// `transition_id` is a `lifecycle_msgs/msg/Transition` id — the SAME numbering
+/// rclcpp uses (issue 1099): Configure=1, Cleanup=2, Activate=3, Deactivate=4,
+/// UnconfiguredShutdown=5, InactiveShutdown=6, ActiveShutdown=7,
+/// ErrorRecovery=60. `0` (CREATE) and `8` (DESTROY) are not implemented and
+/// return `INVALID_ARGUMENT`.
+///
+/// (This comment used to read "Configure=1, Activate=2, Deactivate=3,
+/// Cleanup=4, Shutdown=5, ErrorProcessed=6" — three of those were nano-ros's
+/// own numbering and `ErrorProcessed=6` was never a transition at all.)
 ///
 /// # Safety
 /// `executor` must be a valid, live `CppContext*`. Any registered transition
@@ -62,6 +69,9 @@ pub unsafe extern "C" fn nros_cpp_register_lifecycle_services(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn nros_cpp_lifecycle_change_state(
     executor: *mut c_void,
+    // `transition_id` is a `lifecycle_msgs/msg/Transition` id (issue 1099) —
+    // the same number rclcpp means. Unimplemented ids (`0` CREATE, `8`
+    // DESTROY) fall out of `from_u8` as `INVALID_ARGUMENT`.
     transition_id: u8,
 ) -> nros_cpp_ret_t {
     let Some(ctx) = (unsafe { cpp_ctx_checked(executor) }) else {
@@ -84,9 +94,13 @@ pub unsafe extern "C" fn nros_cpp_lifecycle_change_state(
 
 /// Get the current REP-2002 lifecycle state of the C++ executor's state machine.
 ///
-/// Returns `0` (`Unconfigured`) if the executor is null or lifecycle services are
-/// not registered yet. State numbering: `Unconfigured = 0`, `Inactive = 1`,
-/// `Active = 2`, `Finalized = 3`.
+/// Returns `0` if the executor is null or lifecycle services are not registered
+/// yet — that is the `Unknown` sentinel (`nros::LifecycleState::Unknown`), NOT
+/// `Unconfigured`. State numbering is `lifecycle_msgs/msg/State`'s:
+/// `Unconfigured = 1`, `Inactive = 2`, `Active = 3`, `Finalized = 4`, plus
+/// `ErrorProcessing = 5` (upstream numbers that one 15; see
+/// `nros_core::lifecycle`). This comment previously documented a 0-based
+/// numbering that has never been what the function returns.
 ///
 /// # Safety
 /// `executor` must be a valid, live `CppContext*` produced by `nros_cpp_init`.
@@ -230,16 +244,23 @@ pub unsafe extern "C" fn nros_cpp_lifecycle_autostart(
         return ret;
     }
     // autostart_code: 1 = configure, 2 = configure + activate.
+    //
+    // Issue 1099 — spelled through the enum, not as literals. These WERE `1`
+    // and `2`; `2` is `lifecycle_msgs`' CLEANUP, so once the ids became
+    // upstream's, an autostart-to-Active would have configured the node and
+    // then immediately cleaned it back up.
     if autostart_code >= 1 {
-        // Configure (transition_id = 1).
-        let ret = unsafe { nros_cpp_lifecycle_change_state(executor, 1) };
+        let ret = unsafe {
+            nros_cpp_lifecycle_change_state(executor, LifecycleTransition::Configure as u8)
+        };
         if ret != NROS_CPP_RET_OK {
             return ret;
         }
     }
     if autostart_code >= 2 {
-        // Activate (transition_id = 2).
-        let ret = unsafe { nros_cpp_lifecycle_change_state(executor, 2) };
+        let ret = unsafe {
+            nros_cpp_lifecycle_change_state(executor, LifecycleTransition::Activate as u8)
+        };
         if ret != NROS_CPP_RET_OK {
             return ret;
         }

--- a/packages/api/nros-cpp/tests/compile/lifecycle_transition_ids.cpp
+++ b/packages/api/nros-cpp/tests/compile/lifecycle_transition_ids.cpp
@@ -1,0 +1,138 @@
+// Issue 1099 — `nros::LifecycleNode::trigger_transition(uint8_t)` has rclcpp's
+// exact signature, so the id space it accepts MUST be rclcpp's too. It was not:
+// four of eight ids disagreed with `lifecycle_msgs/msg/Transition`, and a ported
+// `trigger_transition(2)` on an Inactive node ACTIVATED it and returned
+// `Result::ok` where ROS 2 cleans it up. Same name, same arity, same type,
+// opposite effect — nothing a compiler or a reviewer would flag.
+//
+// This TU pins three things at compile time:
+//
+//   1. the C++ enum carries the UPSTREAM numbers (transcribed below from
+//      `/opt/ros/humble/share/lifecycle_msgs/msg/Transition.msg`);
+//   2. the C++ enum and the C `NROS_LIFECYCLE_TRANSITION_*` macros agree, so a
+//      mixed C/C++ image cannot hold two id spaces — the failure mode a
+//      translate-at-the-C++-boundary fix would have created;
+//   3. `shutdown()` resolves its transition from the CURRENT state, exhaustively.
+//
+// (1) and (2) fail to compile against the pre-fix header. Built by
+// `just check cpp`.
+
+#include <cstdint>
+
+#include "nros/lifecycle.hpp"
+#include "nros/nros_generated.h" // NROS_LIFECYCLE_TRANSITION_*
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// 1. The enum IS lifecycle_msgs/msg/Transition.
+// ---------------------------------------------------------------------------
+// Literals, deliberately: an assertion written against the constants it is
+// checking proves nothing. These are the numbers a ported rclcpp file means.
+
+constexpr uint8_t id_of(nros::LifecycleTransition t) {
+    return static_cast<uint8_t>(t);
+}
+
+static_assert(id_of(nros::LifecycleTransition::Configure) == 1, "TRANSITION_CONFIGURE = 1");
+static_assert(id_of(nros::LifecycleTransition::Cleanup) == 2, "TRANSITION_CLEANUP = 2");
+static_assert(id_of(nros::LifecycleTransition::Activate) == 3, "TRANSITION_ACTIVATE = 3");
+static_assert(id_of(nros::LifecycleTransition::Deactivate) == 4, "TRANSITION_DEACTIVATE = 4");
+static_assert(id_of(nros::LifecycleTransition::ShutdownUnconfigured) == 5,
+              "TRANSITION_UNCONFIGURED_SHUTDOWN = 5");
+static_assert(id_of(nros::LifecycleTransition::ShutdownInactive) == 6,
+              "TRANSITION_INACTIVE_SHUTDOWN = 6");
+static_assert(id_of(nros::LifecycleTransition::ShutdownActive) == 7,
+              "TRANSITION_ACTIVE_SHUTDOWN = 7");
+// Upstream 8 is TRANSITION_DESTROY, which nano-ros does not implement; upstream
+// models error recovery as the implicit TRANSITION_ON_ERROR_SUCCESS = 60.
+static_assert(id_of(nros::LifecycleTransition::ErrorRecovery) == 60,
+              "TRANSITION_ON_ERROR_SUCCESS = 60");
+
+// The four primary states carry their `lifecycle_msgs/msg/State` ids too.
+// `ErrorProcessing` deliberately does not (upstream 15) — but 5 is UNASSIGNED
+// upstream, so unlike the transition ids it can never name a different state.
+static_assert(static_cast<uint8_t>(nros::LifecycleState::Unconfigured) == 1, "");
+static_assert(static_cast<uint8_t>(nros::LifecycleState::Inactive) == 2, "");
+static_assert(static_cast<uint8_t>(nros::LifecycleState::Active) == 3, "");
+static_assert(static_cast<uint8_t>(nros::LifecycleState::Finalized) == 4, "");
+
+// ---------------------------------------------------------------------------
+// 2. C and C++ share ONE id space.
+// ---------------------------------------------------------------------------
+// This is the assertion that rules out the other candidate fix. Translating
+// only at the C++ boundary would have left `NROS_LIFECYCLE_TRANSITION_ACTIVATE`
+// (our 2) and `trigger_transition(2)` (upstream CLEANUP) meaning different
+// things inside a single mixed-language image — a worse trap than the one being
+// fixed, because both spellings look correct.
+
+static_assert(id_of(nros::LifecycleTransition::Configure) == NROS_LIFECYCLE_TRANSITION_CONFIGURE,
+              "");
+static_assert(id_of(nros::LifecycleTransition::Cleanup) == NROS_LIFECYCLE_TRANSITION_CLEANUP, "");
+static_assert(id_of(nros::LifecycleTransition::Activate) == NROS_LIFECYCLE_TRANSITION_ACTIVATE, "");
+static_assert(id_of(nros::LifecycleTransition::Deactivate) == NROS_LIFECYCLE_TRANSITION_DEACTIVATE,
+              "");
+static_assert(id_of(nros::LifecycleTransition::ShutdownUnconfigured) ==
+                  NROS_LIFECYCLE_TRANSITION_SHUTDOWN_UNCONFIGURED,
+              "");
+static_assert(id_of(nros::LifecycleTransition::ShutdownInactive) ==
+                  NROS_LIFECYCLE_TRANSITION_SHUTDOWN_INACTIVE,
+              "");
+static_assert(id_of(nros::LifecycleTransition::ShutdownActive) ==
+                  NROS_LIFECYCLE_TRANSITION_SHUTDOWN_ACTIVE,
+              "");
+static_assert(id_of(nros::LifecycleTransition::ErrorRecovery) ==
+                  NROS_LIFECYCLE_TRANSITION_ERROR_RECOVERY,
+              "");
+
+// No two transitions may share an id — a renumbering that collapsed two
+// variants would otherwise satisfy every row above that it did not touch.
+static_assert(id_of(nros::LifecycleTransition::Configure) !=
+                  id_of(nros::LifecycleTransition::Cleanup),
+              "");
+static_assert(id_of(nros::LifecycleTransition::Activate) !=
+                  id_of(nros::LifecycleTransition::Deactivate),
+              "");
+static_assert(id_of(nros::LifecycleTransition::Cleanup) !=
+                  id_of(nros::LifecycleTransition::Activate),
+              "");
+
+// ---------------------------------------------------------------------------
+// 3. shutdown() resolves from the current state.
+// ---------------------------------------------------------------------------
+// `LifecycleNode::shutdown()` used to hardcode 5 (`ShutdownUnconfigured`),
+// whose only legal source state is `Unconfigured` — so it could not shut down
+// an Inactive or Active node, i.e. any node that had done work. Every arm,
+// including the three states with no legal shutdown, which fall back to
+// `ShutdownUnconfigured` so the state machine (not this header) reports the
+// error.
+
+static_assert(nros::shutdown_transition_for(nros::LifecycleState::Unconfigured) ==
+                  nros::LifecycleTransition::ShutdownUnconfigured,
+              "");
+static_assert(nros::shutdown_transition_for(nros::LifecycleState::Inactive) ==
+                  nros::LifecycleTransition::ShutdownInactive,
+              "shutdown() from Inactive must send INACTIVE_SHUTDOWN, not 5");
+static_assert(nros::shutdown_transition_for(nros::LifecycleState::Active) ==
+                  nros::LifecycleTransition::ShutdownActive,
+              "shutdown() from Active must send ACTIVE_SHUTDOWN, not 5");
+static_assert(nros::shutdown_transition_for(nros::LifecycleState::Unknown) ==
+                  nros::LifecycleTransition::ShutdownUnconfigured,
+              "");
+static_assert(nros::shutdown_transition_for(nros::LifecycleState::Finalized) ==
+                  nros::LifecycleTransition::ShutdownUnconfigured,
+              "");
+static_assert(nros::shutdown_transition_for(nros::LifecycleState::ErrorProcessing) ==
+                  nros::LifecycleTransition::ShutdownUnconfigured,
+              "");
+
+// The typed overload must exist and be reachable — it is what keeps a caller
+// from writing the literal that caused this issue.
+using TypedOverload = nros::Result (nros::LifecycleNode::*)(nros::LifecycleTransition);
+using RawOverload = nros::Result (nros::LifecycleNode::*)(uint8_t);
+constexpr TypedOverload typed_ = &nros::LifecycleNode::trigger_transition;
+constexpr RawOverload raw_ = &nros::LifecycleNode::trigger_transition;
+static_assert(typed_ != nullptr, "");
+static_assert(raw_ != nullptr, "");
+
+} // namespace

--- a/packages/core/nros-core/src/lifecycle.rs
+++ b/packages/core/nros-core/src/lifecycle.rs
@@ -57,25 +57,61 @@ impl LifecycleState {
 ///
 /// Each transition has a specific source state. Shutdown has three variants
 /// because it can originate from Unconfigured, Inactive, or Active.
+///
+/// # The discriminants ARE `lifecycle_msgs/msg/Transition` (issue 1099)
+///
+/// These numbers are not ours to choose. They cross the C ABI as
+/// `NROS_LIFECYCLE_TRANSITION_*`, they are what
+/// `nros::LifecycleNode::trigger_transition(uint8_t)` accepts, and they are
+/// what a `ChangeState` request carries on the wire — so a caller reaching any
+/// one of those surfaces with a literal must get the transition ROS 2 would
+/// give them.
+///
+/// They did not, until issue 1099: `Activate`/`Deactivate`/`Cleanup` were
+/// `2`/`3`/`4` where upstream is `3`/`4`/`2`, so a ported
+/// `trigger_transition(2)` on an Inactive node ACTIVATED it and returned OK
+/// where ROS 2 cleans it up. Four of eight ids disagreed, and only the wire
+/// path translated — the C and C++ paths passed the raw byte through.
+///
+/// The one id with no upstream counterpart is [`Self::ErrorRecovery`]: upstream
+/// `8` is `TRANSITION_DESTROY`, which we do not implement (nothing is
+/// deallocated in a fixed arena), and upstream models error recovery as the
+/// IMPLICIT `TRANSITION_ON_ERROR_SUCCESS = 60`. So `ErrorRecovery` is `60` —
+/// the id `transition_wire()` in `nros-node` already put on the wire for it —
+/// and `8` is now rejected rather than silently meaning error recovery.
+///
+/// Do not renumber these. `nros_c::lifecycle` re-asserts every one against its
+/// `NROS_LIFECYCLE_TRANSITION_*` literal (issue 0792), and `nros-node`'s
+/// `transition_wire` / `from_msg_transition_id` are now identity functions that
+/// a test pins.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum LifecycleTransition {
     /// Unconfigured -> (configuring) -> Inactive
+    /// (`lifecycle_msgs` `TRANSITION_CONFIGURE`)
     Configure = 1,
-    /// Inactive -> (activating) -> Active
-    Activate = 2,
-    /// Active -> (deactivating) -> Inactive
-    Deactivate = 3,
     /// Inactive -> (cleaning up) -> Unconfigured
-    Cleanup = 4,
+    /// (`lifecycle_msgs` `TRANSITION_CLEANUP`)
+    Cleanup = 2,
+    /// Inactive -> (activating) -> Active
+    /// (`lifecycle_msgs` `TRANSITION_ACTIVATE`)
+    Activate = 3,
+    /// Active -> (deactivating) -> Inactive
+    /// (`lifecycle_msgs` `TRANSITION_DEACTIVATE`)
+    Deactivate = 4,
     /// Unconfigured -> (shutting down) -> Finalized
+    /// (`lifecycle_msgs` `TRANSITION_UNCONFIGURED_SHUTDOWN`)
     ShutdownUnconfigured = 5,
     /// Inactive -> (shutting down) -> Finalized
+    /// (`lifecycle_msgs` `TRANSITION_INACTIVE_SHUTDOWN`)
     ShutdownInactive = 6,
     /// Active -> (shutting down) -> Finalized
+    /// (`lifecycle_msgs` `TRANSITION_ACTIVE_SHUTDOWN`)
     ShutdownActive = 7,
     /// ErrorProcessing -> (error recovery) -> Unconfigured
-    ErrorRecovery = 8,
+    /// (`lifecycle_msgs` `TRANSITION_ON_ERROR_SUCCESS`; see the type doc for
+    /// why this is 60 and not 8 — 8 is upstream's `TRANSITION_DESTROY`.)
+    ErrorRecovery = 60,
 }
 
 impl LifecycleTransition {
@@ -100,17 +136,22 @@ impl LifecycleTransition {
         }
     }
 
-    /// Try to convert from a u8 value.
+    /// Try to convert from a `lifecycle_msgs/msg/Transition` id.
+    ///
+    /// `0` (`TRANSITION_CREATE`) and `8` (`TRANSITION_DESTROY`) are upstream
+    /// ids we deliberately do not implement — construction and deallocation are
+    /// not transitions in a fixed arena — so both are `None` rather than
+    /// aliases for something else (issue 1099).
     pub const fn from_u8(value: u8) -> Option<Self> {
         match value {
             1 => Some(Self::Configure),
-            2 => Some(Self::Activate),
-            3 => Some(Self::Deactivate),
-            4 => Some(Self::Cleanup),
+            2 => Some(Self::Cleanup),
+            3 => Some(Self::Activate),
+            4 => Some(Self::Deactivate),
             5 => Some(Self::ShutdownUnconfigured),
             6 => Some(Self::ShutdownInactive),
             7 => Some(Self::ShutdownActive),
-            8 => Some(Self::ErrorRecovery),
+            60 => Some(Self::ErrorRecovery),
             _ => None,
         }
     }
@@ -252,18 +293,91 @@ mod tests {
         assert_eq!(LifecycleState::from_u8(6), None);
     }
 
+    /// Issue 1099 — the discriminants ARE `lifecycle_msgs/msg/Transition`.
+    ///
+    /// The table below is transcribed from
+    /// `/opt/ros/humble/share/lifecycle_msgs/msg/Transition.msg`; it is the
+    /// contract every id-taking surface inherits (`NROS_LIFECYCLE_TRANSITION_*`,
+    /// `nros::LifecycleNode::trigger_transition`, `ChangeState.transition.id`).
+    ///
+    /// Before the fix this failed on FOUR of eight rows: `2` was `Activate`,
+    /// `3` was `Deactivate`, `4` was `Cleanup`, `8` was `ErrorRecovery`. The
+    /// `(2, Cleanup)` row is the dangerous one — `trigger_transition(2)` on an
+    /// Inactive node ACTIVATED it and returned OK.
     #[test]
-    fn test_transition_from_u8() {
-        assert_eq!(
-            LifecycleTransition::from_u8(1),
-            Some(LifecycleTransition::Configure)
-        );
-        assert_eq!(
-            LifecycleTransition::from_u8(8),
-            Some(LifecycleTransition::ErrorRecovery)
-        );
+    fn transition_discriminants_are_lifecycle_msgs_ids() {
+        // (upstream id, upstream constant name, our variant)
+        let table = [
+            (1u8, "TRANSITION_CONFIGURE", LifecycleTransition::Configure),
+            (2, "TRANSITION_CLEANUP", LifecycleTransition::Cleanup),
+            (3, "TRANSITION_ACTIVATE", LifecycleTransition::Activate),
+            (4, "TRANSITION_DEACTIVATE", LifecycleTransition::Deactivate),
+            (
+                5,
+                "TRANSITION_UNCONFIGURED_SHUTDOWN",
+                LifecycleTransition::ShutdownUnconfigured,
+            ),
+            (
+                6,
+                "TRANSITION_INACTIVE_SHUTDOWN",
+                LifecycleTransition::ShutdownInactive,
+            ),
+            (
+                7,
+                "TRANSITION_ACTIVE_SHUTDOWN",
+                LifecycleTransition::ShutdownActive,
+            ),
+            (
+                60,
+                "TRANSITION_ON_ERROR_SUCCESS",
+                LifecycleTransition::ErrorRecovery,
+            ),
+        ];
+        for (id, name, variant) in table {
+            assert_eq!(
+                variant as u8, id,
+                "{variant:?} must be lifecycle_msgs::{name} = {id}"
+            );
+            assert_eq!(
+                LifecycleTransition::from_u8(id),
+                Some(variant),
+                "lifecycle_msgs::{name} = {id} must decode to {variant:?}"
+            );
+        }
+    }
+
+    /// The two upstream ids we deliberately do not implement must be REJECTED,
+    /// not silently aliased onto a transition we do have (issue 1099).
+    #[test]
+    fn unimplemented_upstream_transition_ids_are_rejected() {
+        // TRANSITION_CREATE = 0 and TRANSITION_DESTROY = 8: construction and
+        // deallocation are not transitions in a fixed arena. `8` used to mean
+        // `ErrorRecovery` here.
         assert_eq!(LifecycleTransition::from_u8(0), None);
+        assert_eq!(LifecycleTransition::from_u8(8), None);
+        // Not an id at all.
         assert_eq!(LifecycleTransition::from_u8(9), None);
+    }
+
+    /// Every transition round-trips through its id, and no two share one.
+    #[test]
+    fn transition_ids_are_injective_and_round_trip() {
+        let all = [
+            LifecycleTransition::Configure,
+            LifecycleTransition::Cleanup,
+            LifecycleTransition::Activate,
+            LifecycleTransition::Deactivate,
+            LifecycleTransition::ShutdownUnconfigured,
+            LifecycleTransition::ShutdownInactive,
+            LifecycleTransition::ShutdownActive,
+            LifecycleTransition::ErrorRecovery,
+        ];
+        for (i, a) in all.iter().enumerate() {
+            assert_eq!(LifecycleTransition::from_u8(*a as u8), Some(*a));
+            for b in &all[i + 1..] {
+                assert_ne!(*a as u8, *b as u8, "{a:?} and {b:?} share an id");
+            }
+        }
     }
 
     #[test]

--- a/packages/core/nros-node/src/lifecycle_services.rs
+++ b/packages/core/nros-node/src/lifecycle_services.rs
@@ -62,7 +62,15 @@ pub mod state_id {
 }
 
 /// Publicly invocable transition IDs from `lifecycle_msgs/Transition`.
+///
+/// Issue 1099 — since `nros_core::lifecycle::LifecycleTransition` carries these
+/// same numbers as its discriminants, this module is no longer a TRANSLATION
+/// table: `transition_wire` and `from_msg_transition_id` are identity, and
+/// `transition_ids_match_enum_discriminants` below pins that. Keep the
+/// constants anyway; they are the names the wire code reads by, and they are
+/// what makes the two ids we do NOT implement (`CREATE`, `DESTROY`) visible.
 pub mod transition_id {
+    /// Not implemented: a node is constructed by the arena, not by a transition.
     pub const CREATE: u8 = 0;
     pub const CONFIGURE: u8 = 1;
     pub const CLEANUP: u8 = 2;
@@ -71,7 +79,12 @@ pub mod transition_id {
     pub const UNCONFIGURED_SHUTDOWN: u8 = 5;
     pub const INACTIVE_SHUTDOWN: u8 = 6;
     pub const ACTIVE_SHUTDOWN: u8 = 7;
+    /// Not implemented: nothing is deallocated in a fixed arena.
     pub const DESTROY: u8 = 8;
+    /// `TRANSITION_ON_ERROR_SUCCESS` — upstream's implicit
+    /// `ErrorProcessing -> Unconfigured` edge, which is what our explicit
+    /// `ErrorRecovery` is.
+    pub const ERROR_RECOVERY: u8 = 60;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -109,9 +122,11 @@ pub(crate) fn transition_wire(t: InternalTransition) -> (u8, &'static str) {
         }
         InternalTransition::ShutdownInactive => (transition_id::INACTIVE_SHUTDOWN, "shutdown"),
         InternalTransition::ShutdownActive => (transition_id::ACTIVE_SHUTDOWN, "shutdown"),
-        // ErrorRecovery is an implicit transition in rclcpp_lifecycle — map
-        // it to a reserved internal ID so it's still round-trippable.
-        InternalTransition::ErrorRecovery => (60, "error_recovery"),
+        // ErrorRecovery is an implicit transition in rclcpp_lifecycle; 60 is
+        // upstream's `TRANSITION_ON_ERROR_SUCCESS`. Since issue 1099 that is
+        // also the enum's own discriminant, so this row is identity like the
+        // rest — `transition_id::ERROR_RECOVERY` names it.
+        InternalTransition::ErrorRecovery => (transition_id::ERROR_RECOVERY, "error_recovery"),
     }
 }
 
@@ -157,22 +172,19 @@ pub fn to_msg_transition(t: InternalTransition) -> MsgTransition {
 /// Map a wire `Transition.id` back to an internal transition, given the
 /// current state (needed to disambiguate the three shutdown variants).
 pub fn from_msg_transition_id(id: u8, current: InternalState) -> Option<InternalTransition> {
-    match id {
-        transition_id::CONFIGURE => Some(InternalTransition::Configure),
-        transition_id::CLEANUP => Some(InternalTransition::Cleanup),
-        transition_id::ACTIVATE => Some(InternalTransition::Activate),
-        transition_id::DEACTIVATE => Some(InternalTransition::Deactivate),
-        transition_id::UNCONFIGURED_SHUTDOWN => Some(InternalTransition::ShutdownUnconfigured),
-        transition_id::INACTIVE_SHUTDOWN => Some(InternalTransition::ShutdownInactive),
-        transition_id::ACTIVE_SHUTDOWN => Some(InternalTransition::ShutdownActive),
-        // The catch-all "shutdown" id (UNCONFIGURED_SHUTDOWN == 5) is handled
-        // above; rclcpp additionally accepts a generic `shutdown` matched by
-        // label. With label-free requests, fall back to the current state.
-        _ => match (id, current) {
-            (transition_id::DESTROY, _) => None, // destroy is not supported here
-            _ => None,
-        },
-    }
+    // `current` is unused: every id in `lifecycle_msgs/Transition` names its own
+    // source state, so nothing here is ambiguous. Only the generic `"shutdown"`
+    // LABEL is, and that is `from_msg_transition_label`'s job. The parameter
+    // stays for symmetry with that function and for callers that pass both.
+    let _ = current;
+    // Issue 1099 — this is now exactly `LifecycleTransition::from_u8`, because
+    // the enum's discriminants ARE these ids. Delegating rather than
+    // re-listing them means the wire path cannot drift from the C/C++/Rust
+    // paths again, which is how the ids came to disagree in the first place:
+    // this function translated and nothing else did.
+    //
+    // `CREATE` (0) and `DESTROY` (8) are unimplemented and fall out as `None`.
+    InternalTransition::from_u8(id)
 }
 
 /// Map a wire `Transition.label` back to an internal transition. `"shutdown"`
@@ -709,6 +721,67 @@ mod tests {
             from_msg_transition_id(msg.id, InternalState::Unconfigured),
             Some(InternalTransition::Configure)
         );
+    }
+
+    /// Issue 1099 — the wire ids and the ENUM DISCRIMINANTS are the same
+    /// numbers, so `transition_wire` is identity.
+    ///
+    /// This is the invariant that was missing. `transition_wire` translated
+    /// between two id spaces, so `ros2 lifecycle set` behaved correctly while
+    /// the C and C++ APIs — which pass the byte straight through — did not,
+    /// about the same node. A translation table that exists is a translation
+    /// table that can be the only thing correct.
+    ///
+    /// Fails on the pre-fix enum at `Cleanup`, `Activate`, `Deactivate` and
+    /// `ErrorRecovery`.
+    #[test]
+    fn transition_ids_match_enum_discriminants() {
+        for t in ALL_TRANSITIONS {
+            let (wire_id, _) = transition_wire(t);
+            assert_eq!(
+                wire_id, t as u8,
+                "{t:?}: wire id {wire_id} != discriminant {}. The C/C++ APIs pass \
+                 the discriminant straight to the state machine, so any gap here is \
+                 a transition that means one thing on the wire and another in-process.",
+                t as u8
+            );
+            // ...and the decode is the same function the FFI entry points use.
+            assert_eq!(
+                from_msg_transition_id(wire_id, transition_start_state(t)),
+                Some(t)
+            );
+            assert_eq!(InternalTransition::from_u8(wire_id), Some(t));
+        }
+    }
+
+    /// The two upstream ids nano-ros does not implement must decode to
+    /// `None` on the wire, not onto some transition we do have (issue 1099 —
+    /// `DESTROY` used to be our `ErrorRecovery`).
+    #[test]
+    fn unimplemented_wire_ids_are_rejected() {
+        for state in ALL_STATES {
+            assert_eq!(from_msg_transition_id(transition_id::CREATE, state), None);
+            assert_eq!(from_msg_transition_id(transition_id::DESTROY, state), None);
+        }
+    }
+
+    /// The states are NOT identity, and that is deliberate: upstream numbers
+    /// `ErrorProcessing` 15 while ours is 5. Unlike the transition ids, `5` is
+    /// UNASSIGNED in `lifecycle_msgs/msg/State`, so it can never silently name
+    /// a different state — which is why issue 1099 renumbered the transitions
+    /// and left the states alone. `state_wire` is the one place that bridges.
+    #[test]
+    fn state_wire_bridges_the_one_deliberate_divergence() {
+        for s in ALL_STATES {
+            let (wire_id, _) = state_wire(s);
+            if s == InternalState::ErrorProcessing {
+                assert_eq!(wire_id, state_id::TRANSITION_STATE_ERRORPROCESSING);
+                assert_eq!(wire_id, 15);
+                assert_eq!(s as u8, 5);
+            } else {
+                assert_eq!(wire_id, s as u8, "{s:?} is a primary state; ids match");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Stacked on `phase-428-w10-qos-ssot`, where issue 1099 lives.

`LifecycleNode::trigger_transition(uint8_t)` took upstream's exact signature
over a different id space. Verified against `lifecycle_msgs/msg/Transition.msg`:

| id | ours | upstream |
| --- | --- | --- |
| 2 | Activate | **CLEANUP** |
| 3 | Deactivate | **ACTIVATE** |
| 4 | Cleanup | **DEACTIVATE** |
| 8 | ErrorRecovery | **DESTROY** |

So `trigger_transition(2)` on an Inactive node silently **activated** it where
ROS 2 cleans up, returning `ok`.

## Renumbered the core enum, not the C++ boundary

Translating only in `lifecycle.hpp` makes it worse: the C side carried the
identical latent defect (`NROS_LIFECYCLE_TRANSITION_CLEANUP == 4`), so a
boundary fix leaves `NROS_LIFECYCLE_TRANSITION_ACTIVATE` and
`trigger_transition(2)` meaning different things inside one mixed image, both
spellings looking correct. **Two independent audits reached this conclusion
without seeing each other.** The issue's own diagnosis (C++ header defect) was
too narrow.

ABI checked first: the discriminant crosses only as cbindgen `#define`s — no
`rmw_entity.h` entry, no bindgen output, no `_Static_assert`.

`ErrorRecovery` → 60 = `TRANSITION_ON_ERROR_SUCCESS`, the id the wire already
emitted (upstream's 8 is DESTROY, which we do not implement). `shutdown()` now
resolves from the current state — it hardcoded id 5, legal only from
Unconfigured. `autostart` used literals `1`/`2`; `2` is now CLEANUP, so
autostart-to-Active would have configured then immediately cleaned up.

New `const _` block pins the C literals to **upstream** values. Issue 0792's
block proves header-agrees-with-enum, which cannot catch both being wrong
together — which is what happened.

State ids deliberately **not** renumbered: `ErrorProcessing = 5` vs upstream
15, but 5 is unassigned upstream, so it can never silently mean a different
state. Recorded with a test.

## Verified

Mutation-tested against the pre-fix numbering: 2 nros-core + 2 nros-node tests
fail, and the new compile probe fails all six `static_assert`s. `just check c`,
`just check cpp`, `just check fast` (227 gates); nros-core 67/67, nros-node
365/365, nros-c 84/84, nros-cpp 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j