### PR TITLE
fix(phase-428): eager-created C entities resolve their names; a failed rclcpp create aborts

### DIFF
--- a/just/check.just
+++ b/just/check.just
@@ -3492,6 +3492,35 @@ cpp: cpp-fmt
     # from a `cc` line that says nothing about cargo. Diagnosing that cost four
     # wrong hypotheses; the build's own error names the cause in one line.
     cargo build -p nros-c -p nros-cpp --no-default-features --features "std,rmw-cffi,platform-posix,ros-humble" --quiet
+    # phase-428 W5 finding 9 — a failed `rclcpp::Node::create_*` must ABORT,
+    # not hand back a shared_ptr to a dead entity. RUNTIME, and forking,
+    # because the defect was that nothing happened: a compile probe cannot tell
+    # "aborts" from "returns".
+    #
+    # Links NO nano-ros archive. What it exercises (`detail::require_created`)
+    # is a header-only inline function over `nros::Result`, so the only
+    # unresolved symbols are the issue-0360 VARIANT ANCHORS the config headers
+    # plant — `__attribute__((used))` data pointers nothing dereferences.
+    # `--unresolved-symbols=ignore-all` is deliberate and does not weaken 0360:
+    # the stamp exists to stop a TU linking an archive built with OTHER
+    # features, and there is no archive here to mismatch. Linking one instead
+    # was tried and is NOT reproducible — `target/nros-cpp-generated` is a
+    # shared dir written by whichever unit last ran its build script, so the
+    # header's variant is the CLIPPY step's while the archive is this build's,
+    # and the link fails on a stamp mismatch on every run after the first
+    # (issue 0834's class, not a race).
+    echo "  - a failed create aborts (runtime, c++14)"
+    mkdir -p target/nros-cpp-tests
+    c++ -std=c++14 -fno-exceptions -fno-rtti \
+        -Itarget/nros-cpp-generated \
+        -Itarget/nros-c-generated \
+        -Ipackages/api/nros-cpp/include \
+        -Ipackages/api/nros-c/include \
+        -Ipackages/platform/nros-platform-api/include \
+        -Wl,--unresolved-symbols=ignore-all \
+        -o target/nros-cpp-tests/failed_create_aborts \
+        packages/api/nros-cpp/tests/compile/failed_create_aborts.cpp
+    ./target/nros-cpp-tests/failed_create_aborts
     # issue 0730 — the (zephyr-embedded × C++ × cyclonedds) coordinate is a
     # pairwise-class gap no runtime tier covers (cyclone fixtures run on
     # native_sim, which appends `,std`), and it failed E0599 at COMPILE time:

--- a/packages/api/nros-c/src/action/client.rs
+++ b/packages/api/nros-c/src/action/client.rs
@@ -1095,6 +1095,18 @@ pub unsafe extern "C" fn nros_action_client_init_polling(
 
     client_mut.node = unsafe { crate::node::node_ref_of(node) };
 
+    // Resolve the SOURCE action name to its wire name — see
+    // `nros_publisher_init_with_qos`. All five channel keyexprs are derived
+    // from it below, so resolving once here moves the whole action.
+    let _resolved_name = {
+        let source =
+            core::str::from_utf8_unchecked(&client_mut.action_name[..client_mut.action_name_len]);
+        match crate::node::resolve_entity_name_on_node(node_ref, source) {
+            Some(r) => r,
+            None => return NROS_RET_INVALID_ARGUMENT,
+        }
+    };
+
     #[cfg(feature = "rmw-cffi")]
     {
         // Phase 156 Sub-bug D — multi-Session dispatch (see
@@ -1104,8 +1116,8 @@ pub unsafe extern "C" fn nros_action_client_init_polling(
             None => return NROS_RET_NOT_INIT,
         };
 
-        let action_str =
-            core::str::from_utf8_unchecked(&client_mut.action_name[..client_mut.action_name_len]);
+        // RESOLVED name on the wire — see the resolution above.
+        let action_str = _resolved_name.as_str();
         let type_str =
             core::str::from_utf8_unchecked(&client_mut.type_name[..client_mut.type_name_len]);
         let type_hash_str =

--- a/packages/api/nros-c/src/action/server.rs
+++ b/packages/api/nros-c/src/action/server.rs
@@ -935,6 +935,18 @@ pub unsafe extern "C" fn nros_action_server_init_polling(
 
     server_mut.node = unsafe { crate::node::node_ref_of(node) };
 
+    // Resolve the SOURCE action name to its wire name — see
+    // `nros_publisher_init_with_qos`. All five channel keyexprs are derived
+    // from it below, so resolving once here moves the whole action.
+    let _resolved_name = {
+        let source =
+            core::str::from_utf8_unchecked(&server_mut.action_name[..server_mut.action_name_len]);
+        match crate::node::resolve_entity_name_on_node(node_ref, source) {
+            Some(r) => r,
+            None => return NROS_RET_INVALID_ARGUMENT,
+        }
+    };
+
     #[cfg(feature = "rmw-cffi")]
     {
         // Phase 156 Sub-bug D — multi-Session dispatch (see
@@ -944,8 +956,8 @@ pub unsafe extern "C" fn nros_action_server_init_polling(
             None => return NROS_RET_NOT_INIT,
         };
 
-        let action_str =
-            core::str::from_utf8_unchecked(&server_mut.action_name[..server_mut.action_name_len]);
+        // RESOLVED name on the wire — see the resolution above.
+        let action_str = _resolved_name.as_str();
         let type_str =
             core::str::from_utf8_unchecked(&server_mut.type_name[..server_mut.type_name_len]);
         let type_hash_str =

--- a/packages/api/nros-c/src/node.rs
+++ b/packages/api/nros-c/src/node.rs
@@ -953,6 +953,78 @@ pub unsafe extern "C" fn nros_node_resolve_name(
     }
 }
 
+/// Resolve an entity's SOURCE name to the name that goes on the wire, for the
+/// C entity-init paths that create their entity EAGERLY.
+///
+/// **Why this exists.** Most C entities are created at REGISTRATION, not at
+/// init: `nros_subscription_init` only records the request and
+/// `nros_executor_add_subscription` builds the entity — and that path resolves
+/// the name (`executor.rs`, eight sites, `Executor::resolve_entity_name`).
+/// Publishers and polling subscriptions have no registration step, so they
+/// create inside `*_init` and never reached that seam. The result was a
+/// namespaced node whose publisher and subscription, given the SAME string,
+/// landed on DIFFERENT keys and never connected, and a launch
+/// `<remap from= to=/>` that moved one and not the other — both returning
+/// `NROS_RET_OK`. `TopicInfo::with_namespace` does not close it: the zenoh
+/// keyexpr is built from `TopicInfo::name` alone (`keyexpr.rs::to_key`), so a
+/// namespace attached beside an unexpanded name reaches nothing.
+///
+/// It resolves through the SAME two primitives every other path uses —
+/// `Executor::resolve_entity_name_for` (expansion + this node's launch remap
+/// table) and `nros_node::names::expand_name` — so the answer cannot drift
+/// from what registering the entity would have produced. The nros-cpp CFFI
+/// layer's `resolve_node_entity_name` is this function one crate over.
+///
+/// The two arms are a property of the NODE, not a choice:
+///
+/// * executor-bound node (`nros_executor_node_init`) → expansion + remaps.
+///   Identity comes from the executor's `NodeRecord` when it has one, because
+///   that is the identity the remap table is KEYED on; the caller's struct is
+///   the fallback, not the preference.
+/// * legacy node (`rclc_node_init_default` / `nros_node_init`) → expansion
+///   only. There is no executor, and `declare_remap` is an executor call, so
+///   there are no rules to drop — unlike `nros_node_resolve_name`, which is
+///   ASKED for the rules and must refuse when it cannot read them.
+///
+/// Returns `None` when the source name cannot be expanded (empty, a `~` with
+/// no node name, or a result past `MAX_RESOLVED_NAME_LEN`). Callers surface
+/// that as `NROS_RET_INVALID_ARGUMENT`; a name we cannot resolve must never
+/// fall back to the raw spelling, which is the bug this closes.
+///
+/// # Safety
+/// `node` must be an initialised `nros_node_t`, and when it is executor-bound
+/// its `executor` pointer must reference a live `nros_executor_t`.
+pub(crate) unsafe fn resolve_entity_name_on_node(
+    node: &nros_node_t,
+    source: &str,
+) -> Option<nros_node::names::ResolvedName> {
+    let struct_name = inline_str(&node.name, node.name_len);
+    let struct_ns = inline_str(&node.namespace, node.namespace_len);
+
+    if !node.is_multi_session() {
+        return nros_node::names::expand_name(source, struct_name, struct_ns).ok();
+    }
+
+    let exec_mut = &mut *(node.executor as *mut crate::executor::nros_executor_t);
+    let rust_exec = crate::executor::get_executor(&mut exec_mut._opaque);
+    let id = nros_node::executor::node_record::NodeId::from_raw(node.node_id);
+    // Clone out of the record so the immutable borrow ends before the resolve
+    // call; `set_executor_node_identity` reads the same two strings for the
+    // registration paths, which is why they are read from here and not from
+    // the caller's struct.
+    let record_identity = rust_exec
+        .node(id)
+        .map(|rec| (rec.name.clone(), rec.namespace.clone()));
+    match record_identity {
+        Some((name, ns)) => rust_exec
+            .resolve_entity_name_for(name.as_str(), ns.as_str(), source)
+            .ok(),
+        None => rust_exec
+            .resolve_entity_name_for(struct_name, struct_ns, source)
+            .ok(),
+    }
+}
+
 #[cfg(kani)]
 mod verification {
     use super::*;

--- a/packages/api/nros-c/src/publisher.rs
+++ b/packages/api/nros-c/src/publisher.rs
@@ -217,6 +217,32 @@ pub unsafe extern "C" fn nros_publisher_init_with_qos(
     // Store node reference
     publisher.node = unsafe { crate::node::node_ref_of(node) };
 
+    // Resolve the SOURCE topic name to its wire name — ROS 2 expansion plus
+    // this node's launch remap rules.
+    //
+    // A publisher is created HERE, not at executor registration, so it is one
+    // of the two C entities that never reached the resolution seam every other
+    // kind goes through (`nros_executor_add_*`). On a `/ns` node a publisher
+    // and a subscription created with the same string therefore landed on
+    // different keys and never connected, and a launch remap moved the
+    // subscription and not the publisher — both returning `NROS_RET_OK`.
+    // `TopicInfo::with_namespace` below does NOT close it: the zenoh key is
+    // built from `TopicInfo::name` alone.
+    //
+    // Resolved BEFORE `resolve_session_and_domain`: both reach the executor
+    // through `node.executor`, and taking the second `&mut` while the first
+    // session borrow is live would alias. The order is also the better
+    // contract — an unresolvable name is INVALID_ARGUMENT rather than
+    // whatever the session lookup happens to answer first.
+    let _resolved_topic = {
+        let source =
+            core::str::from_utf8_unchecked(&publisher.topic_name[..publisher.topic_name_len]);
+        match crate::node::resolve_entity_name_on_node(node_ref, source) {
+            Some(r) => r,
+            None => return NROS_RET_INVALID_ARGUMENT,
+        }
+    };
+
     // Get QoS settings
     let _qos_settings = if qos.is_null() {
         crate::qos::NROS_QOS_DEFAULT.to_qos_settings()
@@ -241,7 +267,11 @@ pub unsafe extern "C" fn nros_publisher_init_with_qos(
             None => return NROS_RET_NOT_INIT,
         };
 
-        // Build the topic key expression for ROS 2 compatibility
+        // Build the topic key expression for ROS 2 compatibility. `topic_str`
+        // is the SOURCE spelling and is used only for the QoS-override lookup
+        // below (the deploy plan writes overrides against launch names, which
+        // is the same choice `nros-cpp/src/publisher.rs` records); the wire
+        // name is `_resolved_topic`.
         let topic_str =
             core::str::from_utf8_unchecked(&publisher.topic_name[..publisher.topic_name_len]);
         let type_str =
@@ -255,8 +285,8 @@ pub unsafe extern "C" fn nros_publisher_init_with_qos(
         let namespace_str =
             core::str::from_utf8_unchecked(&node_ref.namespace[..node_ref.namespace_len]);
 
-        // Build TopicInfo
-        let topic_info = TopicInfo::new(topic_str, type_str, type_hash_str)
+        // Build TopicInfo from the RESOLVED name — see the resolution above.
+        let topic_info = TopicInfo::new(_resolved_topic.as_str(), type_str, type_hash_str)
             .with_domain(domain_id)
             .with_node_name(node_name_str)
             .with_namespace(namespace_str);
@@ -862,5 +892,128 @@ mod verification {
         );
         assert!(!pub_.node.is_bound(), "fini must unbind the node reference");
         assert!(pub_._opaque.iter().all(|&v| v == 0));
+    }
+}
+
+/// Name resolution on the eager entity-init paths (phase-428 W5 finding 3).
+///
+/// `nros_publisher_init_with_qos` used to hand `TopicInfo` the RAW string the
+/// caller passed. Every other C entity kind reaches
+/// `Executor::resolve_entity_name` through `nros_executor_add_*`; a publisher
+/// has no registration step, so it never did — and `.with_namespace()` does not
+/// substitute, because the zenoh key is built from `TopicInfo::name` alone
+/// (`nros-rmw-zenoh/src/keyexpr.rs::to_key`, whose own test
+/// `an_unresolved_name_and_its_resolved_form_are_different_keys` pins that).
+///
+/// The resolution runs BEFORE the session is resolved, so it is observable
+/// with no backend session at all: an unresolvable name answers
+/// `NROS_RET_INVALID_ARGUMENT` where the un-fixed code got as far as
+/// `NROS_RET_NOT_INIT`. (`mod publisher` itself is `rmw-cffi`-gated in
+/// `lib.rs`, so these run under that feature.)
+#[cfg(test)]
+mod name_resolution_tests {
+    use super::*;
+    use crate::node::resolve_entity_name_on_node;
+
+    /// A legacy (`rclc_node_init_default`) node with a name and namespace.
+    /// Not executor-bound, so `resolve_entity_name_on_node` takes its
+    /// expansion-only arm — the arm every standalone C example is on.
+    fn node_named(name: &str, namespace: &str) -> nros_node_t {
+        let mut node = crate::node::rcl_get_zero_initialized_node();
+        node.name[..name.len()].copy_from_slice(name.as_bytes());
+        node.name_len = name.len();
+        node.namespace[..namespace.len()].copy_from_slice(namespace.as_bytes());
+        node.namespace_len = namespace.len();
+        node.state = nros_node_state_t::NROS_NODE_STATE_INITIALIZED;
+        node
+    }
+
+    /// THE regression: on a `/ns` node, a publisher and a subscription created
+    /// with the same string must reach the same wire name.
+    ///
+    /// Both call sites go through one function, and the assertion that it is
+    /// the RIGHT function is the third one: `names::resolve_name` is what
+    /// `Executor::resolve_entity_name_for` — the L2/registration path — calls,
+    /// so publisher, polling subscription and callback subscription cannot
+    /// drift.
+    ///
+    /// Fails on the pre-fix code, where the publisher's name was the raw
+    /// `"chatter"` while the subscription's was `"/ns/chatter"`.
+    #[test]
+    fn namespaced_publisher_and_subscription_reach_the_same_name() {
+        let node = node_named("talker", "/ns");
+
+        // The call `nros_publisher_init_with_qos` makes.
+        let publisher_side = unsafe { resolve_entity_name_on_node(&node, "chatter") }
+            .expect("a relative name on a named node must resolve");
+        // The call `nros_subscription_init_polling_with_qos` makes.
+        let subscription_side = unsafe { resolve_entity_name_on_node(&node, "chatter") }
+            .expect("a relative name on a named node must resolve");
+        // What the executor-registration path (`nros_executor_add_subscription`
+        // → `Executor::resolve_entity_name_for`) computes for the same input.
+        let registration_side =
+            nros_node::names::resolve_name("chatter", "talker", "/ns", core::iter::empty())
+                .expect("the registration seam must resolve it too");
+
+        assert_eq!(publisher_side.as_str(), "/ns/chatter");
+        assert_eq!(publisher_side, subscription_side);
+        assert_eq!(publisher_side, registration_side);
+        // The pre-fix value, stated so the test says what it is protecting.
+        assert_ne!(publisher_side.as_str(), "chatter");
+    }
+
+    /// `~` is the case a namespace alone could never have covered: it needs the
+    /// NODE NAME too, which `TopicInfo` never carried into the key.
+    #[test]
+    fn a_private_name_expands_against_the_node_not_just_the_namespace() {
+        let node = node_named("filter", "/sensing");
+        let resolved = unsafe { resolve_entity_name_on_node(&node, "~/points") }
+            .expect("a private name on a named node must resolve");
+        assert_eq!(resolved.as_str(), "/sensing/filter/points");
+    }
+
+    /// An absolute name is already the wire name — resolution must not touch
+    /// it. This is why the fix is invisible to every root-namespace C example.
+    #[test]
+    fn an_absolute_name_passes_through_unchanged() {
+        let node = node_named("talker", "/ns");
+        let resolved = unsafe { resolve_entity_name_on_node(&node, "/chatter") }
+            .expect("an absolute name must resolve");
+        assert_eq!(resolved.as_str(), "/chatter");
+    }
+
+    /// The resolver is WIRED INTO the FFI entry point, not merely present.
+    ///
+    /// Observable with no session: the resolution runs before
+    /// `resolve_session_and_domain`, so a name that cannot be expanded is
+    /// `NROS_RET_INVALID_ARGUMENT` here. `~` needs a node name; this node has
+    /// none, so `expand_name` errors. Pre-fix this call never consulted the
+    /// name at all and reached the session lookup, answering
+    /// `NROS_RET_NOT_INIT`.
+    #[test]
+    fn an_unresolvable_name_is_rejected_by_publisher_init() {
+        let node = node_named("", "/ns");
+        let type_name = b"std_msgs::msg::dds_::Int32_\0";
+        let type_hash = b"RIHS01_test\0";
+        let type_info = nros_message_type_t {
+            type_name: type_name.as_ptr() as *const c_char,
+            type_hash: type_hash.as_ptr() as *const c_char,
+            serialized_size_max: 4,
+        };
+        let topic = b"~/private\0";
+        let mut pub_ = rcl_get_zero_initialized_publisher();
+
+        let ret = unsafe {
+            rclc_publisher_init_default(
+                &mut pub_,
+                &node,
+                &type_info,
+                topic.as_ptr() as *const c_char,
+            )
+        };
+        assert_eq!(
+            ret, NROS_RET_INVALID_ARGUMENT,
+            "a name the resolver cannot expand must be refused, never published raw"
+        );
     }
 }

--- a/packages/api/nros-c/src/service.rs
+++ b/packages/api/nros-c/src/service.rs
@@ -519,6 +519,19 @@ pub unsafe extern "C" fn nros_service_init_polling(
     service_mut.callback = None;
     service_mut.context = ptr::null_mut();
 
+    // Resolve the SOURCE service name to its wire name — see
+    // `nros_publisher_init_with_qos`. The callback-mode service reaches this
+    // through `nros_executor_add_service`; the polling one creates here.
+    let _resolved_name = {
+        let source = core::str::from_utf8_unchecked(
+            &service_mut.service_name[..service_mut.service_name_len],
+        );
+        match crate::node::resolve_entity_name_on_node(node_ref, source) {
+            Some(r) => r,
+            None => return NROS_RET_INVALID_ARGUMENT,
+        }
+    };
+
     #[cfg(feature = "rmw-cffi")]
     {
         use nros_node::{ServiceInfo, Session};
@@ -530,9 +543,6 @@ pub unsafe extern "C" fn nros_service_init_polling(
             None => return NROS_RET_NOT_INIT,
         };
 
-        let service_str = core::str::from_utf8_unchecked(
-            &service_mut.service_name[..service_mut.service_name_len],
-        );
         let type_str =
             core::str::from_utf8_unchecked(&service_mut.type_name[..service_mut.type_name_len]);
         let type_hash_str =
@@ -541,7 +551,9 @@ pub unsafe extern "C" fn nros_service_init_polling(
         let namespace_str =
             core::str::from_utf8_unchecked(&node_ref.namespace[..node_ref.namespace_len]);
 
-        let info = ServiceInfo::new(service_str, type_str, type_hash_str)
+        // RESOLVED name on the wire — the source spelling is what the caller
+        // stored in `service_mut.service_name` and what the getters return.
+        let info = ServiceInfo::new(_resolved_name.as_str(), type_str, type_hash_str)
             .with_domain(domain_id)
             .with_node_name(node_name_str)
             .with_namespace(namespace_str);
@@ -1374,6 +1386,18 @@ pub unsafe extern "C" fn nros_client_init_polling(
     client_mut.response_callback = None;
     client_mut.context = ptr::null_mut();
 
+    // Resolve the SOURCE service name to its wire name — see
+    // `nros_publisher_init_with_qos`. A client that resolved differently from
+    // the server it calls is the same split one direction over.
+    let _resolved_name = {
+        let source =
+            core::str::from_utf8_unchecked(&client_mut.service_name[..client_mut.service_name_len]);
+        match crate::node::resolve_entity_name_on_node(node_ref, source) {
+            Some(r) => r,
+            None => return NROS_RET_INVALID_ARGUMENT,
+        }
+    };
+
     #[cfg(feature = "rmw-cffi")]
     {
         use nros_node::{ServiceInfo, Session};
@@ -1385,8 +1409,6 @@ pub unsafe extern "C" fn nros_client_init_polling(
             None => return NROS_RET_NOT_INIT,
         };
 
-        let service_str =
-            core::str::from_utf8_unchecked(&client_mut.service_name[..client_mut.service_name_len]);
         let type_str =
             core::str::from_utf8_unchecked(&client_mut.type_name[..client_mut.type_name_len]);
         let type_hash_str =
@@ -1395,7 +1417,8 @@ pub unsafe extern "C" fn nros_client_init_polling(
         let namespace_str =
             core::str::from_utf8_unchecked(&node_ref.namespace[..node_ref.namespace_len]);
 
-        let info = ServiceInfo::new(service_str, type_str, type_hash_str)
+        // RESOLVED name on the wire — see the resolution above.
+        let info = ServiceInfo::new(_resolved_name.as_str(), type_str, type_hash_str)
             .with_domain(domain_id)
             .with_node_name(node_name_str)
             .with_namespace(namespace_str);

--- a/packages/api/nros-c/src/subscription.rs
+++ b/packages/api/nros-c/src/subscription.rs
@@ -490,6 +490,21 @@ pub unsafe extern "C" fn nros_subscription_init_polling_with_qos(
     subscription_mut.context = ptr::null_mut();
     subscription_mut.handle_id = usize::MAX;
 
+    // Resolve the SOURCE topic name to its wire name. The L2 (callback) path
+    // gets this from `nros_executor_add_subscription`; the L1 path creates the
+    // entity right here and so never reached that seam — the same gap
+    // `nros_publisher_init_with_qos` had, and the reason both are fixed
+    // together rather than at the site the sweep reported.
+    let _resolved_topic = {
+        let source = core::str::from_utf8_unchecked(
+            &subscription_mut.topic_name[..subscription_mut.topic_name_len],
+        );
+        match crate::node::resolve_entity_name_on_node(node_ref, source) {
+            Some(r) => r,
+            None => return NROS_RET_INVALID_ARGUMENT,
+        }
+    };
+
     // Create the subscriber NOW (vs deferred for L2). The L1 path
     // owns the entity inline; no executor arena involved.
     #[cfg(feature = "rmw-cffi")]
@@ -516,7 +531,10 @@ pub unsafe extern "C" fn nros_subscription_init_polling_with_qos(
         let namespace_str =
             core::str::from_utf8_unchecked(&node_ref.namespace[..node_ref.namespace_len]);
 
-        let topic_info = TopicInfo::new(topic_str, type_str, type_hash_str)
+        // RESOLVED name on the wire; `topic_str` stays the SOURCE spelling for
+        // the QoS-override lookup below (the plan writes overrides against
+        // launch names — same split as `nros-cpp/src/publisher.rs`).
+        let topic_info = TopicInfo::new(_resolved_topic.as_str(), type_str, type_hash_str)
             .with_domain(domain_id)
             .with_node_name(node_name_str)
             .with_namespace(namespace_str);

--- a/packages/api/nros-cpp/include/nros/log.hpp
+++ b/packages/api/nros-cpp/include/nros/log.hpp
@@ -202,6 +202,26 @@ template <typename T> struct refuse {
     "into the environment before exec. Call the zero-argument rclcpp::init(), or "                 \
     "nros::init_with_launch_auto(0, nullptr, \"my_session\") for the launch-aware entry point."
 
+// phase-428 W5 finding 9. Runtime, like `NROS_RCLCPP_REFUSE_INIT_ARGV` above
+// and for the same reason: only the VALUE carries the defect, so the earliest
+// point loudness is available is the call. Prose tail only — the verb, the
+// name and the code are printed by `rclcpp::detail::abort_failed_create`.
+#define NROS_RCLCPP_ABORT_FAILED_CREATE                                                            \
+    "Upstream rclcpp THROWS here, so control never continues past a failed create; nano-ros has "  \
+    "no exceptions (RFC-0018) and the verb returns a shared_ptr, which left two ways to differ. "  \
+    "It used to discard the Result and hand back a NON-NULL pointer to a dead entity: publish "    \
+    "went nowhere, and rclcpp::spin(node) returned at once because the node was never "            \
+    "initialized, so init -> create -> spin -> shutdown ran to completion and exited 0. "          \
+    "Returning "                                                                                   \
+    "null instead would be quieter still -- a nullptr dereference with no message, and entirely "  \
+    "inert for create_wall_timer, whose result a ported node stores and never dereferences. "      \
+    "RFC-0089's rule is that a difference the compiler cannot point at must be made loud by "      \
+    "other means, so this aborts. To HANDLE the failure rather than die on it, drop to the "       \
+    "underlying nros API, where every create verb RETURNS nros::Result into caller-owned "         \
+    "storage: nros::create_node(node, name), node.create_publisher(pub, topic, qos), "             \
+    "node.create_subscription(sub, topic, qos, cb), node.create_service<S>(srv, name, cb), "       \
+    "node.create_client<S>(cli, name), node.create_timer(t, period_ms, cb, ctx)."
+
 #define NROS_RCLCPP_REFUSE_SYSTEM_DEFAULTS_QOS                                                     \
     "rclcpp::SystemDefaultsQoS is REFUSED by nano-ros (RFC-0089 W3.f, issue 0829). Upstream's "    \
     "rmw_qos_profile_system_default names NO concrete policy: every field is a sentinel meaning "  \

--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -332,6 +332,58 @@ constexpr bool argv_has_ros_args(int argc, char const* const* argv, int i = 0) {
            : is_ros_args_flag(argv[i]) ? true
                                        : argv_has_ros_args(argc, argv, i + 1);
 }
+
+/// What upstream's `throw` becomes here — phase-428 W5 finding 9.
+///
+/// Seven `create_*` verbs on `rclcpp::Node` used to write
+/// `(void)node_.create_…(…)` and return the `shared_ptr` regardless. The
+/// `(void)` was not incidental: `nros::Result` carries `[[nodiscard]]`
+/// (`result.hpp`, phase-428 W6), and the casts SUPPRESSED the one signal that
+/// existed. Measured, because the claim is easy to overstate: no C++ lane in
+/// this tree compiles with `-Werror`, so a bare discard here is a
+/// `-Wunused-result` WARNING and `just check cpp` stays green through it —
+/// the Rust-side `-D warnings` has no C++ counterpart. Even at full strength
+/// it would only have told the AUTHOR of this header, never the porting user,
+/// which is why the fix is a runtime refusal rather than a lint.
+///
+/// Every alternative was weighed against RFC-0089 Part I ("a difference must
+/// be one the compiler points at, and where it cannot be, it must be loud by
+/// other means"):
+///
+/// * a `Result`-returning overload makes the compiler point at it — and at
+///   every SUCCEEDING call too, so a ported `auto pub = node->create_publisher
+///   <M>("chatter", 10);` no longer compiles. That trades clause 2 (port
+///   upstream: same name, same shape) for a diagnostic on the path that is
+///   not broken. Rejected.
+/// * a null `shared_ptr` says nothing at compile time and, at runtime, says
+///   nothing either: `create_wall_timer`'s result is stored and never
+///   dereferenced, so a null there is a timer that silently never fires —
+///   the same "reads as success" one level down. Rejected.
+/// * an `ok()` flag on the node is opt-in, and a ported file never asks. It
+///   would also be a member written by us and read by nobody, which is
+///   finding 10 in the same sweep. Rejected.
+///
+/// So: the loudest thing available, at the earliest point the defect is
+/// knowable, which is the CALL. This is the identical shape
+/// `rclcpp::init(argc, argv)` uses for `--ros-args` a few lines below, and it
+/// is what an uncaught upstream throw actually does to a tutorial `main` —
+/// terminate with a diagnostic, rather than continue with a dead object.
+///
+/// The failure is still HANDLEABLE: the underlying `nros::Node` verbs return
+/// `nros::Result` into caller-owned storage, and the message names them.
+[[noreturn]] inline void abort_failed_create(const char* verb, const char* name, int32_t code) {
+    NROS_ERROR("rclcpp::Node::%s(\"%s\") failed with nros::ErrorCode %d. %s", verb, name,
+               static_cast<int>(code), NROS_RCLCPP_ABORT_FAILED_CREATE);
+    ::std::abort();
+}
+
+/// The one spelling every `create_*` verb uses. Takes the `Result` by value so
+/// the `[[nodiscard]]` is consumed HERE and cannot be silently dropped again.
+inline void require_created(::nros::Result r, const char* verb, const char* name) {
+    if (!r.ok()) {
+        abort_failed_create(verb, name, r.raw());
+    }
+}
 } // namespace detail
 
 /// `rclcpp::init(argc, argv)` — ADOPT-BOUNDED, refused at RUNTIME when it must be.
@@ -375,9 +427,20 @@ inline void init(int argc, char const* const* argv) {
 inline void init() {
     (void)::nros::init();
 }
+/// `rclcpp::shutdown()` — ADOPT-BOUNDED.
+///
+/// phase-428 W5 finding 9, one site over from the seven `create_*` verbs and
+/// the only one the compiler already pointed at: this DISCARDED
+/// `nros::shutdown()`'s `[[nodiscard]]` Result and returned a hardcoded
+/// `true`, so `just check cpp` carried a standing `-Wunused-result` and a
+/// teardown that actually failed still reported success. Upstream's `bool` is
+/// the answer, so there is somewhere to put it.
+///
+/// The bound: upstream returns `false` when the context was never initialised;
+/// `nros::shutdown()` answers `success()` for that case (it is a no-op), so we
+/// return `true` there. `false` here means the teardown itself failed.
 inline bool shutdown() {
-    ::nros::shutdown();
-    return true;
+    return ::nros::shutdown().ok();
 }
 inline bool ok() {
     return ::nros::ok();
@@ -578,6 +641,13 @@ class Node : public std::enable_shared_from_this<Node> {
         // "constructor never returns an error code" contract and subsequent
         // `create_*` fail visibly.
         //
+        // phase-428 W5 finding 9 — "fail visibly" was the INTENT and was false
+        // until the seven `create_*` verbs stopped discarding their `Result`.
+        // They now abort with a diagnostic (`detail::require_created`), which
+        // is what makes this deferral honest: the failure surfaces at the
+        // first create, naming the entity, instead of at a `spin` that returns
+        // immediately and an exit code of 0.
+        //
         // Issue 0465 — this used to call `Executor::create(executor_)`, giving
         // every Node its OWN executor and therefore its own RMW session.
         // A non-bridge application has exactly one session; two is the bridge
@@ -604,7 +674,8 @@ class Node : public std::enable_shared_from_this<Node> {
     std::shared_ptr<::nros::Publisher<M>> create_publisher(const std::string& topic,
                                                            const ::nros::QoS& qos) {
         auto p = std::make_shared<::nros::Publisher<M>>();
-        (void)node_.create_publisher(*p, topic.c_str(), qos);
+        detail::require_created(node_.create_publisher(*p, topic.c_str(), qos), "create_publisher",
+                                topic.c_str());
         return p;
     }
 
@@ -674,9 +745,11 @@ class Node : public std::enable_shared_from_this<Node> {
                                                                  const ::nros::QoS& qos, Cb cb) {
         auto cell = std::make_shared<detail::SubscriptionCallback<M>>();
         cell->fn = std::move(cb);
-        (void)::nros::create_subscription_raw(
-            node_, topic.c_str(), M::TYPE_NAME, &detail::SubscriptionCallback<M>::trampoline,
-            cell.get(), qos, ::nros::rx_buffer_capacity<M>::value);
+        detail::require_created(
+            ::nros::create_subscription_raw(node_, topic.c_str(), M::TYPE_NAME,
+                                            &detail::SubscriptionCallback<M>::trampoline,
+                                            cell.get(), qos, ::nros::rx_buffer_capacity<M>::value),
+            "create_subscription", topic.c_str());
         owned_entities_.push_back(cell);
         return std::shared_ptr<::nros::Subscription<M>>(cell, &cell->handle);
     }
@@ -704,8 +777,13 @@ class Node : public std::enable_shared_from_this<Node> {
         auto t = std::make_shared<detail::WallTimer>();
         t->callback = std::move(cb);
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(period).count();
-        (void)node_.create_timer(t->timer, ms > 0 ? static_cast<uint64_t>(ms) : uint64_t(0),
-                                 &detail::WallTimer::trampoline, t.get());
+        // A null return would be silent HERE above all: a ported node stores
+        // the timer handle and never dereferences it, so a dead timer would
+        // simply never fire.
+        detail::require_created(node_.create_timer(t->timer,
+                                                   ms > 0 ? static_cast<uint64_t>(ms) : uint64_t(0),
+                                                   &detail::WallTimer::trampoline, t.get()),
+                                "create_wall_timer", "");
         // The arena holds `t.get()`; the node keeps the cell alive, and
         // `~nros::Timer` cancels the slot when it finally drops.
         // `owned_entities_`, NOT a typed `timers_` member. The typed vector
@@ -846,7 +924,8 @@ class Node : public std::enable_shared_from_this<Node> {
     std::shared_ptr<::nros::Service<S>> create_service(const std::string& name,
                                                        const ::nros::QoS& qos = ServicesQoS()) {
         auto s = std::make_shared<::nros::Service<S>>();
-        (void)node_.template create_service<S>(*s, name.c_str(), qos);
+        detail::require_created(node_.template create_service<S>(*s, name.c_str(), qos),
+                                "create_service", name.c_str());
         return s;
     }
 
@@ -858,7 +937,8 @@ class Node : public std::enable_shared_from_this<Node> {
                                                        const ::nros::QoS& qos = ServicesQoS()) {
         auto s = std::make_shared<::nros::Service<S>>();
         owned_entities_.push_back(s);
-        (void)node_.template create_service<S>(*s, name.c_str(), callback, qos);
+        detail::require_created(node_.template create_service<S>(*s, name.c_str(), callback, qos),
+                                "create_service", name.c_str());
         return s;
     }
 
@@ -881,7 +961,8 @@ class Node : public std::enable_shared_from_this<Node> {
     std::shared_ptr<::nros::Client<S>> create_client(const std::string& name,
                                                      const ::nros::QoS& qos = ServicesQoS()) {
         auto c = std::make_shared<::nros::Client<S>>();
-        (void)node_.template create_client<S>(*c, name.c_str(), qos);
+        detail::require_created(node_.template create_client<S>(*c, name.c_str(), qos),
+                                "create_client", name.c_str());
         return c;
     }
 
@@ -893,7 +974,8 @@ class Node : public std::enable_shared_from_this<Node> {
                                                      const ::nros::QoS& qos = ServicesQoS()) {
         auto c = std::make_shared<::nros::Client<S>>();
         owned_entities_.push_back(c);
-        (void)node_.template create_client<S>(*c, name.c_str(), callback, qos);
+        detail::require_created(node_.template create_client<S>(*c, name.c_str(), callback, qos),
+                                "create_client", name.c_str());
         return c;
     }
 

--- a/packages/api/nros-cpp/src/action.rs
+++ b/packages/api/nros-cpp/src/action.rs
@@ -2209,8 +2209,19 @@ pub unsafe extern "C" fn nros_cpp_action_server_init_polling(
         .unwrap_or("/");
     let ctx = unsafe { &mut *(node_ref.executor as *mut CppContext) };
 
+    // phase-428 W5 finding 3, swept — the CALLBACK action path resolves
+    // (`:902`); these polling ones created from the raw name, so a `~` or a
+    // launch remap moved the callback-mode action and not this one. All five
+    // channel keyexprs derive from `action_info`, so resolving once here moves
+    // the whole action.
+    let resolved_act = match crate::resolve_node_entity_name(ctx, node_ref, action_str) {
+        Ok(r) => r,
+        Err(()) => return NROS_CPP_RET_INVALID_ARGUMENT,
+    };
+
     use nros_node::{ActionInfo, QoSProfile, ServiceInfo, Session, TopicInfo};
-    let action_info = ActionInfo::new(action_str, type_str, hash_str).with_domain(ctx.domain_id);
+    let action_info =
+        ActionInfo::new(resolved_act.as_str(), type_str, hash_str).with_domain(ctx.domain_id);
     let session = ctx.executor.session_mut();
 
     fn with_node<'a>(info: ServiceInfo<'a>, node_name: Option<&'a str>) -> ServiceInfo<'a> {
@@ -2619,8 +2630,19 @@ pub unsafe extern "C" fn nros_cpp_action_client_init_polling(
         .unwrap_or("/");
     let ctx = unsafe { &mut *(node_ref.executor as *mut CppContext) };
 
+    // phase-428 W5 finding 3, swept — the CALLBACK action path resolves
+    // (`:902`); these polling ones created from the raw name, so a `~` or a
+    // launch remap moved the callback-mode action and not this one. All five
+    // channel keyexprs derive from `action_info`, so resolving once here moves
+    // the whole action.
+    let resolved_act = match crate::resolve_node_entity_name(ctx, node_ref, action_str) {
+        Ok(r) => r,
+        Err(()) => return NROS_CPP_RET_INVALID_ARGUMENT,
+    };
+
     use nros_node::{ActionInfo, QoSProfile, ServiceInfo, Session, TopicInfo};
-    let action_info = ActionInfo::new(action_str, type_str, hash_str).with_domain(ctx.domain_id);
+    let action_info =
+        ActionInfo::new(resolved_act.as_str(), type_str, hash_str).with_domain(ctx.domain_id);
     let session = ctx.executor.session_mut();
 
     fn with_node<'a>(info: ServiceInfo<'a>, node_name: Option<&'a str>) -> ServiceInfo<'a> {

--- a/packages/api/nros-cpp/tests/compile/failed_create_aborts.cpp
+++ b/packages/api/nros-cpp/tests/compile/failed_create_aborts.cpp
@@ -1,0 +1,147 @@
+// phase-428 W5 finding 9 — a failed `rclcpp::Node::create_*` must not read as
+// success.
+//
+// RUNTIME probe, not a syntax one: the whole defect was that nothing happened.
+// The seven `create_*` verbs wrote `(void)node_.create_…(…)` and returned the
+// `shared_ptr` regardless, so a failed create handed back a valid-looking
+// pointer to a dead entity — and `rclcpp::spin(node)` then returned
+// immediately on the uninitialised node, so `init -> create -> spin ->
+// shutdown` ran to completion and exited 0.
+//
+// All seven now funnel through `rclcpp::detail::require_created`, which is
+// what this exercises. Three properties, and the third is the one a
+// success/failure exit code alone would miss:
+//
+//   1. a create that SUCCEEDED returns normally (the path every working
+//      ported node is on);
+//   2. a create that FAILED does not return — the process dies on SIGABRT;
+//   3. it dies LOUDLY. RFC-0089 Part I's requirement is not "stop", it is
+//      "say so", so the child's stderr is captured and checked for the
+//      migration text. A silent abort would satisfy (2) and still be the
+//      wrong answer.
+//
+// Forked, because a test that asserts a process dies cannot be that process.
+//
+// Why abort and not a null `shared_ptr` or an `ok()` flag: see the doc comment
+// on `require_created` in `nros/nros.hpp`, which weighs all three against
+// RFC-0089 Part I. Short version: upstream throws, we have no exceptions, and
+// of the options that remain only this one is loud for `create_wall_timer`,
+// whose returned pointer a ported node stores and never dereferences.
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <nros/nros.hpp>
+
+// Links no nano-ros archive: `require_created` is a header-only inline over
+// `nros::Result` and touches no FFI symbol. The recipe passes
+// `--unresolved-symbols=ignore-all` for the issue-0360 variant anchors the
+// config headers plant — see the rationale beside the compile line in
+// `just/check.just`.
+
+namespace {
+
+struct Outcome {
+    int status;         // raw waitpid status
+    char stderr_[4096]; // what the child wrote to fd 2, NUL-terminated
+};
+
+// Run `body` in a child process with its stderr piped back.
+template <typename F> Outcome run_forked(F body) {
+    Outcome out;
+    out.status = 0;
+    out.stderr_[0] = '\0';
+
+    int fds[2];
+    if (::pipe(fds) != 0) {
+        ::std::fprintf(stderr, "failed_create_aborts: pipe failed\n");
+        ::std::abort();
+    }
+    ::fflush(nullptr);
+    const pid_t pid = ::fork();
+    if (pid == 0) {
+        ::close(fds[0]);
+        ::dup2(fds[1], 2);
+        ::close(fds[1]);
+        body();
+        // Reached only when `body` did NOT abort. A distinctive code so the
+        // parent can tell "returned normally" from "died some other way".
+        ::_exit(17);
+    }
+    ::close(fds[1]);
+
+    ::size_t used = 0;
+    for (;;) {
+        const ::ssize_t n = ::read(fds[0], out.stderr_ + used, sizeof(out.stderr_) - 1 - used);
+        if (n <= 0) break;
+        used += static_cast<::size_t>(n);
+        if (used >= sizeof(out.stderr_) - 1) break;
+    }
+    out.stderr_[used] = '\0';
+    ::close(fds[0]);
+
+    if (::waitpid(pid, &out.status, 0) != pid) {
+        ::std::fprintf(stderr, "failed_create_aborts: waitpid failed\n");
+        ::std::abort();
+    }
+    return out;
+}
+
+void expect(bool cond, const char* what) {
+    if (!cond) {
+        ::std::fprintf(stderr, "failed_create_aborts: FAILED: %s\n", what);
+        ::std::abort();
+    }
+}
+
+void expect_aborts_loudly(const Outcome& o, const char* verb, const char* what) {
+    expect(WIFSIGNALED(o.status) && WTERMSIG(o.status) == SIGABRT, what);
+    expect(::std::strstr(o.stderr_, verb) != nullptr,
+           "the diagnostic must name the verb that failed");
+    expect(::std::strstr(o.stderr_, "node.create_publisher(pub, topic, qos)") != nullptr,
+           "the diagnostic must name the Result-returning API to use instead");
+}
+
+} // namespace
+
+int main() {
+    // (1) A create that SUCCEEDED must be transparent.
+    {
+        const Outcome o = run_forked([] {
+            ::rclcpp::detail::require_created(::nros::Result::success(), "create_publisher",
+                                              "chatter");
+        });
+        expect(WIFEXITED(o.status) && WEXITSTATUS(o.status) == 17,
+               "a successful create must return normally, not abort");
+        expect(o.stderr_[0] == '\0', "a successful create must say nothing");
+    }
+
+    // (2) + (3) A create that FAILED must not return, and must say why.
+    // Pre-fix, the seven call sites discarded exactly this value and carried on.
+    {
+        const Outcome o = run_forked([] {
+            ::rclcpp::detail::require_created(::nros::Result(::nros::ErrorCode::NotInitialized),
+                                              "create_publisher", "chatter");
+        });
+        expect_aborts_loudly(o, "create_publisher",
+                             "a failed create must abort, never return a handle to a dead entity");
+    }
+
+    // Same for a timer: the case a null return could never have covered,
+    // because a ported node stores the handle and never dereferences it.
+    {
+        const Outcome o = run_forked([] {
+            ::rclcpp::detail::require_created(::nros::Result(::nros::ErrorCode::TransportError),
+                                              "create_wall_timer", "");
+        });
+        expect_aborts_loudly(o, "create_wall_timer",
+                             "a failed create_wall_timer must abort rather than never fire");
+    }
+
+    ::std::printf("failed_create_aborts: OK\n");
+    return 0;
+}

--- a/packages/rmw/zenoh/nros-rmw-zenoh/src/keyexpr.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/src/keyexpr.rs
@@ -379,4 +379,51 @@ mod tests {
         let s: heapless::String<32> = qos.to_qos_string();
         assert_eq!(s.as_str(), "2:1:2,42:,:,:,,");
     }
+
+    /// phase-428 W5 finding 3 — the namespace never reaches the key, so a name
+    /// must arrive here ALREADY RESOLVED.
+    ///
+    /// `TopicInfo::with_namespace` exists (liveliness tokens use it) and reads
+    /// as if it placed the entity in a namespace. `to_key` does not consult
+    /// it: the key is `<domain>/<name>/<type>/<hash>`, `name` trimmed of its
+    /// slashes and nothing else. So a publisher handed the raw `"chatter"` on a
+    /// `/ns` node and a subscription handed the resolved `"/ns/chatter"` are on
+    /// two different keys with no error anywhere — which is precisely what
+    /// `nros_publisher_init_with_qos` did until it resolved first.
+    ///
+    /// This is the CONSEQUENCE half of the fix; the resolution half is pinned
+    /// by `nros-c/src/publisher.rs`'s `name_resolution_tests`.
+    #[test]
+    fn an_unresolved_name_and_its_resolved_form_are_different_keys() {
+        const TYPE: &str = "std_msgs::msg::dds_::String_";
+        const HASH: &str = "TypeHashNotSupported";
+
+        // What the publisher used to build: the source spelling, with the
+        // node's namespace attached beside it.
+        let unresolved = TopicInfo::new("chatter", TYPE, HASH)
+            .with_domain(0)
+            .with_namespace("/ns");
+        // What the subscription's registration path builds for the SAME input.
+        let resolved = TopicInfo::new("/ns/chatter", TYPE, HASH)
+            .with_domain(0)
+            .with_namespace("/ns");
+
+        let unresolved_key: heapless::String<128> = unresolved.to_key();
+        let resolved_key: heapless::String<128> = resolved.to_key();
+
+        assert_ne!(
+            unresolved_key, resolved_key,
+            "with_namespace does not place the entity — if these ever match, \
+             the key gained a namespace segment and the resolution contract \
+             moved"
+        );
+        assert!(
+            unresolved_key.starts_with("0/chatter/"),
+            "the namespace is absent from the unresolved key: {unresolved_key}"
+        );
+        assert!(
+            resolved_key.starts_with("0/ns/chatter/"),
+            "the resolved name carries the namespace as key segments: {resolved_key}"
+        );
+    }
 }


### PR DESCRIPTION
Stacked on `phase-428-w10-qos-ssot`. Two confirmed sweep findings — and the first was **seven sites, not one**.

## Name resolution

`rclc_publisher_init_default` built `TopicInfo` from the raw topic name; the namespace went in via `.with_namespace()`, which the key builders never read. Every executor-registered entity resolves first; publishers never reached that seam because there is no `nros_executor_add_publisher`.

But the rule is *created at `*_init` instead of at registration*, and every polling path had it: publisher, polling subscription/service/client, both polling action kinds in C, and both in C++. One shared helper routing through the same two primitives every other path uses. Unresolvable name is `INVALID_ARGUMENT`, never a fallback to the raw spelling.

**Blast radius is narrower than the finding said**: all three key builders `trim_matches('/')`, so on a root-namespace node the defect is invisible — which is every shipped C example. Real exposure: executor-bound namespaced nodes, launch remaps, any nano-ros C publisher talking to a ROS 2 subscriber.

## Discarded creates

Seven `create_*` verbs in `nros.hpp` were `(void)node_.create_…`, returning a valid-looking `shared_ptr` to a dead entity, and `rclcpp::spin` returned silently on `!initialized()` — so a failed session ran to completion and exited 0.

Now `rclcpp::detail::require_created` logs and aborts. Upstream throws; an uncaught throw in a tutorial `main` *is* terminate-with-a-diagnostic, so abort is the faithful port under RFC-0018 — and it is what `rclcpp::init(argc, argv)` already does for `--ros-args`. A `Result`-returning overload was rejected because it makes the compiler point at every **succeeding** call too.

**Corrects a claim from the brief:** `[[nodiscard]]` does not make a bare discard a `-D warnings` error here. No C++ lane compiles with bare `-Werror`; it is a warning and the lane stays green. `rclcpp::shutdown()` carried exactly that discard and nothing failed. That is why the refusal must be at runtime.

## Verified

4 nros-c tests (3 fail on the old code, measured by neutering the helper), 1 characterization test pinning the invariant that made the bug possible, and a compile probe that spawns a child and checks it dies loudly on SIGABRT. `just check c`, `just check cpp` twice consecutively, `just check fast` 203/204 (`submodule-pins`, pre-existing).

One finding worth its own row: the probe cannot link the real archives — `target/nros-cpp-generated` is written by whichever unit last ran its build script, so the variant stamp came from the clippy step while the archive came from the lane's own build. Issue 0834's class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j