### PR TITLE
fix(ci): check-lane-contracts was verifying nothing, for the third time

### DIFF
--- a/scripts/check-lane-contracts.py
+++ b/scripts/check-lane-contracts.py
@@ -537,6 +537,44 @@ def _parse_one(lines, mod):
 # that verified nothing while printing OK.
 JUST_CALL = re.compile(r"^\s*@?just\s+((?:[a-z0-9_:-]+)(?:\s+[a-z0-9_:-]+)*)\s*$")
 
+# A lane that names its steps in a shell ARRAY and runs them indirectly:
+#
+#     steps=(check::cli-fresh check::fast check::build test-unit)
+#     ...
+#     if just "${steps[$i]}"; then ...
+#
+# `ci::gate` is written exactly that way. The literal invocation is
+# `just "${steps[$i]}"`, which JUST_CALL cannot resolve, so the closure came
+# back as the lane itself and this gate reported "0 test target(s)" over the
+# tier whose affordability claim CLAUDE.md publishes. That is the third time
+# this walk has gone blind to a change in how the lane spells its steps -- a
+# header-only walk (fixed), `just ci l1` as two words (fixed), and now an array
+# -- which is why the vacuity guard at the end of `main` matters more than any
+# one of these patterns.
+STEPS_ARRAY = re.compile(r"^\s*steps=\(\s*([^)]*?)\s*\)\s*$", re.M)
+
+# Lanes whose membership is DERIVED rather than written as `just` edges.
+# `check::fast` is `@bash scripts/build/run-gates-parallel.sh`, which computes
+# its own set (issue 1072 deleted the registry that used to spell it). Walking
+# `just` edges from there reaches nothing, so the derivation is asked directly
+# -- the same list the runner itself uses, from the one tool that owns it.
+DERIVED_LANES = {"check::fast": "fast-serial", "check::fast-serial": "fast-serial",
+                 "check::fast-parallel": "fast-serial", "check::build": "build-serial"}
+
+
+def _derived_members(lane):
+    """The gate names a derived lane runs, as `check::<name>`."""
+    import subprocess
+
+    tool = os.path.join(ROOT, "scripts", "check", "check-gate-lists.py")
+    if not os.path.isfile(tool):
+        return []
+    r = subprocess.run([sys.executable, tool, "--list", DERIVED_LANES[lane]],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        return []
+    return [f"check::{n.strip()}" for n in r.stdout.split("\n") if n.strip()]
+
 
 def closure(recipes, root):
     seen, stack = set(), [root]
@@ -546,6 +584,10 @@ def closure(recipes, root):
             continue
         seen.add(r)
         stack.extend(recipes[r]["deps"])
+        if r in DERIVED_LANES:
+            stack.extend(_derived_members(r))
+        for m in STEPS_ARRAY.finditer("\n".join(recipes[r]["body"])):
+            stack.extend(m.group(1).split())
         for line in recipes[r]["body"]:
             m = JUST_CALL.match(line)
             if not m:
@@ -1150,6 +1192,44 @@ def main():
         for rec, _ev in {(a, tuple(sorted(b))) for a, b in r}
         if rec in ordered_now
     )
+    # A closure that reaches nothing reports the same OK as one that reaches
+    # everything. This gate has gone blind three times -- a header-only walk, a
+    # module rename read as two words, and a lane naming its steps in a shell
+    # array -- and each time the symptom was "0 test target(s)" sitting in a
+    # green summary that nobody reads. So make it the failure it always was.
+    #
+    # The bound is per LANE, not on the total: one healthy tier would otherwise
+    # cover for two dead ones, which is exactly how `ci::gate` and `check::fast`
+    # both walked to a closure of ONE while `ci::_matrix-build` looked fine.
+    blind = [lane for lane in LANES if len(closure(recipes_map, lane)) < 2]
+    if blind:
+        sys.stderr.write(
+            "check-lane-contracts: %d tier(s) resolve to a closure of ONE — the "
+            "walk cannot see their steps, so this gate is checking NOTHING for "
+            "them:\n" % len(blind)
+        )
+        for lane in blind:
+            sys.stderr.write(
+                f"  {lane}\n"
+                "      Its steps are reached by an edge this walk does not "
+                "follow. Past shapes: a bare dependency header, `just <mod> "
+                "<recipe>` as two words, `steps=(...)` run as `just \"${steps[i]}\"`, "
+                "and a lane whose membership a SCRIPT derives (see "
+                "DERIVED_LANES).\n"
+            )
+        sys.stderr.write(
+            "\nFix the walk, not this check: a tier whose closure is empty has "
+            "an affordability claim in CLAUDE.md that nothing verifies.\n"
+        )
+        return 1
+    if checked == 0:
+        sys.stderr.write(
+            "check-lane-contracts: examined 0 test target(s). Every lane's "
+            "closure is non-trivial, so the fixture scan itself found nothing "
+            "to check — fix the scan rather than accepting the green.\n"
+        )
+        return 1
+
     print(
         f"check-lane-contracts OK — {checked} test target(s) across "
         f"{len(LANES)} affordability tier(s) and {scanned} CI lane invocation(s) "

--- a/scripts/check-lane-contracts.py
+++ b/scripts/check-lane-contracts.py
@@ -696,12 +696,47 @@ def lane_filters(recipes, reached):
     return out if filtered else None
 
 
+def _strip_rust_comments(text):
+    """Blank out `//…` line comments and `/* … */` block comments, so a
+    substring search over the result cannot mistake PROSE about a resolver for
+    a CALL to it.
+
+    `lane_run_narrowing.rs` documents `require_west_leaf_in_lane`'s fail-open
+    behaviour in a `//` comment beside a DIFFERENT test, never calling the
+    function itself — and the naive `name in text` check the PR that reached
+    this test for the first time exposed could not tell the two apart, so a
+    test that resolves nothing failed the gate as if it were `t_runtime` from
+    the self-test below. Not a full Rust lexer — it does not understand string
+    or char literals, so a `//`/`/*` inside one would (wrongly) start erasing
+    from there; nothing in this file's inputs does that, and getting it exactly
+    right needs a tokenizer this file has no other reason to carry.
+    """
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        two = text[i:i + 2]
+        if two == "//":
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            out.append(" " * (j - i))
+            i = j
+        elif two == "/*":
+            j = text.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            out.append("".join(c if c == "\n" else " " for c in text[i:j]))
+            i = j
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
 def resolvers_used(test_name):
     path = os.path.join(TESTS_DIR, f"{test_name}.rs")
     if not os.path.exists(path):
         return set(), False
     with open(path, encoding="utf8", errors="replace") as fh:
-        text = fh.read()
+        text = _strip_rust_comments(fh.read())
     return {r for r in RUNTIME_RESOLVERS + COMPILE_RESOLVERS if r in text}, True
 
 
@@ -1285,6 +1320,19 @@ def selftest(verbose=False):
         used = resolvers_used("t_compile")[0]
         chk("a COMPILE-stage resolver is NOT a violation",
             bool(used) and not any(u in RUNTIME_RESOLVERS for u in used))
+
+        # A resolver name in PROSE, never called, is not a use. This is the
+        # exact shape of `lane_run_narrowing.rs`'s comment on
+        # `require_west_leaf_in_lane` — a naive `name in text` search cannot
+        # tell it apart from `t_runtime` above, which does call the function.
+        with open(os.path.join(td, "t_commented.rs"), "w", encoding="utf8") as fh:
+            fh.write("// require_west_leaf_in_lane fails open on an unknown\n"
+                     "// build_name; see lane::require_west_leaf_in_lane.\n"
+                     "/* also mentioned require_cmake_fixture in a block\n"
+                     "   comment */\n"
+                     "fn f() {}\n")
+        chk("a resolver name inside a comment is not a resolver USE",
+            resolvers_used("t_commented")[0] == set())
 
         with open(jf, "w", encoding="utf8") as fh:
             fh.write("ci-l1: \\\n    gate-a \\\n    gate-b\n\n"


### PR DESCRIPTION
```
check-lane-contracts OK — 0 test target(s) across 3 affordability tier(s)
```

Two of the three tiers resolved to a closure of **one** — themselves — so the gate that exists to keep CLAUDE.md's affordability claims true had nothing to check, and said OK.

```
closure(ci::gate)           1 -> 272
closure(check::fast)        1 -> 240
recipes parsed            460 -> 751     (`check::` 7 -> 298)
test targets examined       0 -> 15
```

## Three edges the walk could not follow

**`import`.** The split (`#573`) moved 287 gate recipes into `just/check/*.just`, and `parse_justfile` listed `just/*.just` without following imports — so the `check` module contributed its seven *lane* recipes and no gate at all. Imported recipes keep the **importing** module's prefix (`import` merges), which is what makes them reachable as `check::<name>`.

**A lane whose membership a script derives.** `check::fast` is `@bash scripts/build/run-gates-parallel.sh`; issue 1072 deleted the registry that used to spell its members as dependencies, so there is no `just` edge left to walk. It now asks the one tool that owns that derivation, `check-gate-lists.py --list`.

**Steps in a shell array.** `ci::gate` is `steps=(check::cli-fresh check::fast …)` run as `just "${steps[$i]}"` — an indirect invocation `JUST_CALL` cannot resolve.

That third one is the same defect this file already carries **two fixed cases of**: a header-only walk, and `just ci l1` read as two words. Three blindings in one file is not three bugs — it is one: the walk is coupled to how a lane happens to spell its steps, and every lane is free to respell them.

## So the vacuity is now the failure

A tier whose closure is one **fails**, per *lane* rather than on the total — one healthy tier would otherwise cover for two dead ones, which is exactly what happened here while `ci::_matrix-build` looked fine. `checked == 0` fails too.

Mutation-tested by blinding each walk in turn; each is caught:

```
blind the array walk    -> ci::gate     closure of ONE
blind the import walk   -> check::fast  closure of ONE
blind the derived walk  -> check::fast  closure of ONE
```

## What this does not fix

**Not the `rustdoc-links` red on `main`.** That gate fails because `cargo doc` compiles `zpico-sys`, whose build script needs the zenoh-pico submodule the push lane does not check out — a build-script prerequisite, not a `require_*` fixture resolution, so it is outside this gate's rule rather than something it was missing. Worth its own change; naming it here so the green is not read as covering it.

`lane-contracts`, `gate-lists`, `gate-selftests`, `just-recipe-refs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
