### PR TITLE
fix(#1015): rule on the five zpico extents the ratchet still carried

### DIFF
--- a/docs/issues/archived/1015-a-derived-pool-of-zero-silences-the-board.md
+++ b/docs/issues/archived/1015-a-derived-pool-of-zero-silences-the-board.md
@@ -144,6 +144,31 @@ Mutation-checked against the real tree, not only its own fixtures:
 | drop the cmake floor for `ZPICO_MAX_SUBSCRIBERS` | **FAIL** |
 | unmodified tree | OK (21 knob-sized arrays: 3 guarded, 3 zero-legal, 15 unclassified) |
 
+### 2026-09-06 — the remaining `zpico.c` extents are ruled on
+
+The `Resolution` above left fifteen knob-sized arrays UNCLASSIFIED, five of them
+in `zpico.c` itself: `ZPICO_MAX_LIVELINESS`, `ZPICO_MAX_PENDING_GETS`,
+`ZPICO_MAX_PENDING_REPLIES`, `ZPICO_MAX_SESSIONS` and
+`ZPICO_GET_REPLY_BUF_SIZE`. Two of those are Kconfig-settable and size arrays in
+the very same struct as `ZPICO_MAX_QUERYABLES`, so the image that went silent
+had four more ways to reach the same state.
+
+They carry a `#if <KNOB> < 1` / `#error` beside the array now, which is the
+GUARDED decision, and they have left the ratchet:
+
+    before   3 guarded, 3 zero-legal, 15 unclassified
+    after    8 guarded, 3 zero-legal, 10 unclassified   (ceiling 15 -> 10)
+
+`ZPICO_GRAPH_CACHE_SIZE` and `ZPICO_ZID_SIZE` are guarded too. The gate does not
+track them -- neither is build-settable -- but they are extents in the same
+file, and leaving two unruled beside eight ruled is the state the next reader
+has to re-derive.
+
+Deliberately NOT a blanket "an extent has a floor of one": that rule is
+measurably false one backend over, which is what the `Resolution` above records
+about issue 1033 and the 33,296 bytes a zero saves per XRCE subscriber slot. The
+decision stays per knob; this only makes five more of them.
+
 ### What is NOT covered, still
 
 * **The mechanism at zero was never isolated.** The board is out of tree; what

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -373,6 +373,27 @@ typedef struct {
 #if ZPICO_MAX_QUERYABLES < 1
 #error "ZPICO_MAX_QUERYABLES must be >= 1: it sizes a C array (issue 1015)"
 #endif
+#if ZPICO_MAX_LIVELINESS < 1
+#error "ZPICO_MAX_LIVELINESS must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+#if ZPICO_MAX_PENDING_GETS < 1
+#error "ZPICO_MAX_PENDING_GETS must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+#if ZPICO_MAX_PENDING_REPLIES < 1
+#error "ZPICO_MAX_PENDING_REPLIES must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+#if ZPICO_MAX_SESSIONS < 1
+#error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+#if ZPICO_GET_REPLY_BUF_SIZE < 1
+#error "ZPICO_GET_REPLY_BUF_SIZE must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+#if ZPICO_GRAPH_CACHE_SIZE < 1
+#error "ZPICO_GRAPH_CACHE_SIZE must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+#if ZPICO_ZID_SIZE < 1
+#error "ZPICO_ZID_SIZE must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
 #if ZPICO_MAX_SUBSCRIBERS < 1
 #error "ZPICO_MAX_SUBSCRIBERS must be >= 1: it sizes a C array (issue 1015)"
 #endif

--- a/scripts/check-c-array-pool-floors.py
+++ b/scripts/check-c-array-pool-floors.py
@@ -129,16 +129,11 @@ UNCLASSIFIED = {
     "XRCE_BUFFER_SIZE": "packages/rmw/xrce/nros-rmw-xrce/src/internal.h",
     "XRCE_MAX_PENDING_REPLIES": "packages/rmw/xrce/nros-rmw-xrce/src/internal.h",
     "XRCE_SERVICE_REQUEST_RING_DEPTH": "packages/rmw/xrce/nros-rmw-xrce/src/internal.h",
-    "ZPICO_GET_REPLY_BUF_SIZE": "packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c",
-    "ZPICO_MAX_LIVELINESS": "packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c",
-    "ZPICO_MAX_PENDING_GETS": "packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c",
-    "ZPICO_MAX_PENDING_REPLIES": "packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c",
-    "ZPICO_MAX_SESSIONS": "packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c",
     "Z_TASK_STACK_SIZE": "packages/rmw/zenoh/zpico-sys/c/platform/threadx/platform.h",
 }
 # The list may SHRINK. Raising this is a deliberate edit that says "one more
 # knob-sized array ships unruled on", beside the entry that says which.
-UNCLASSIFIED_CEILING = 15
+UNCLASSIFIED_CEILING = 10
 
 # --- the producer half -----------------------------------------------------
 


### PR DESCRIPTION
Successor to `#577`, which was closed. This is the non-contradictory subset of it: `+47 / -6` across three files instead of `+1470` across eleven.

`check-c-array-pool-floors` landed with fifteen knob-sized arrays `UNCLASSIFIED`, and **five of them are in `zpico.c` itself**:

```
ZPICO_MAX_LIVELINESS   ZPICO_MAX_PENDING_GETS   ZPICO_MAX_PENDING_REPLIES
ZPICO_MAX_SESSIONS     ZPICO_GET_REPLY_BUF_SIZE
```

Two of those are Kconfig-settable and size arrays in the **same struct** as `ZPICO_MAX_QUERYABLES` — so the board that went silent at 0 had four more ways to reach the same state. That was `#577`'s real finding.

Each now carries a `#if <KNOB> < 1` + `#error` beside the array — the `GUARDED` decision the gate asks for — and leaves the ratchet:

```
before   3 guarded, 3 zero-legal, 15 unclassified
after    8 guarded, 3 zero-legal, 10 unclassified   (ceiling 15 -> 10)
```

`ZPICO_GRAPH_CACHE_SIZE` and `ZPICO_ZID_SIZE` are guarded too. The gate tracks neither (neither is build-settable), but both are extents in the same file, and leaving two unruled beside eight ruled is a state the next reader has to re-derive.

## Not a blanket floor-of-one

`#577` proposed *"a number that sizes a FIXED C ARRAY has a floor of one, and every producer of that number enforces it."* The gate on `main` explicitly declines that rule, and gives the measurement:

> issue 1033 lowered the XRCE pool minima from 1 to 0 **on purpose** — the arrays are plain mid-struct members not flexible ones, `arr[0]` compiles on gnu99/c11/gnu11, every walk is `for (i = 0; i < MAX; ++i)` and does not run at 0, and a zero is worth **33,296 bytes of heap per subscriber slot** and **4,384 per service-server slot** from the zephyr cpp listener's DWARF — the difference between an image that fits its 65,536-byte heap and one that does not.

So zero-legality stays a **per-knob decision**. This makes five more of them, in the direction the storage in `zpico.c` actually requires, and adds no second gate.

## Mutation-tested

`zpico.c` cannot be compiled without the zenoh-pico submodule, so the guards — which are preprocessor constructs — were driven through `cc -E` directly. Each of the seven fires at 0 and is silent at 4:

```
ZPICO_MAX_LIVELINESS       at 0: error   at 4: clean
ZPICO_MAX_PENDING_GETS     at 0: error   at 4: clean
ZPICO_MAX_PENDING_REPLIES  at 0: error   at 4: clean
ZPICO_MAX_SESSIONS         at 0: error   at 4: clean
ZPICO_GET_REPLY_BUF_SIZE   at 0: error   at 4: clean
ZPICO_GRAPH_CACHE_SIZE     at 0: error   at 4: clean
ZPICO_ZID_SIZE             at 0: error   at 4: clean
```

All ten guards sit at preprocessor nesting depth **0**, so none is inside a conditional a build could switch off.

`check-c-array-pool-floors`, `doc-refs`, `issue-ids`, `ledger-doc-single-home`, `book-links` pass.

`#577`'s cmake-side enforcement (its R2/R3 — binding the Zephyr lane's `-D` where it supplies the extent) is **not** here and is compatible with this: it enforces whatever floor a knob was decided to have, which is orthogonal to the floor-of-one rule. It is preserved at `99df8ae7d` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
