### PR TITLE
feat(phase-433, #1127): a focused runner for every live-peer interop cell

### DIFF
--- a/.config/interop-cells-without-runner.txt
+++ b/.config/interop-cells-without-runner.txt
@@ -31,13 +31,3 @@
 # the exclusion behind. There is no flag that regenerates it: a regenerate
 # button would turn "add a Runtime cell no lane runs" back into a one-command
 # move, which is the thing being ratcheted.
-
-bridge-zenoh-to-cyclone  # issue 1127 -- `declarative_bridge_zenoh_to_cyclonedds` has no lane
-bridge-zenoh-to-cyclone-imperative  # issue 1127 -- `bridge_zenoh_to_cyclonedds` has no lane
-bridge-zenoh-to-xrce  # issue 1127 -- `declarative_bridge_zenoh_to_xrce` has no lane
-native-graph-rust-cyclone-r2n  # issue 1127 -- `graph_interop` has no lane; the cyclone reader has never met a live participant
-native-graph-rust-zenoh-r2n  # issue 1127 -- `graph_interop` has no lane, the gap issue 0903 rode in through
-native-multinode-cpp-zenoh  # issue 1127 -- `cpp_multi_node_entry` has no lane
-native-multinode-rust-zenoh  # issue 1127 -- `rust_multi_node_per_node_graph` has no lane
-native-qos-override-rust-zenoh  # issue 1127 -- `qos_override_e2e` has no lane
-zephyr-qos-rust-zenoh  # issue 1127 -- `qos_zephyr_ros2_interop_e2e` has no lane; needs the west leaf built too

--- a/just/native.just
+++ b/just/native.just
@@ -841,6 +841,89 @@ test-ros2-lifecycle verbose="":
     fi
     cargo nextest run "${cargo_nextest_args[@]}" "${args[@]}"
 
+# phase-433 / issue 1127 — the focused live-peer lanes below. Each aims at ONE
+# `interop::CELLS` Runtime cell's binary; a sweep reaches the same binaries but
+# cannot be aimed at one, brings up no peer, and turns an unmet precondition
+# into a `<skipped>` nobody can tell from a pass. `_test-focused` (root
+# justfile) carries the shared skip accounting. Preconditions are per recipe.
+#
+# `just --list` shows the LAST comment line of a block, so each ends with the
+# one that is worth seeing there: the binary and what the host must provide.
+
+# READ the graph a live ROS 2 node is in — phase-381 / issue 0903, where twelve
+# produced, parity-clean rmw graph slots did not work because every check
+# tested our code against our own assumptions. Both backends are here because
+# they discover through entirely different mechanisms — zenoh through `@ros2_lv`
+# liveliness tokens, Cyclone through the `ros_discovery_info` topic — so a green
+# on one is no evidence about the other. Each half skips on its own.
+# Runs `graph_interop`; needs ROS 2 + `rmw_zenoh_cpp` and `rmw_cyclonedds_cpp`.
+[group("debug")]
+test-ros2-graph verbose="":
+    @just _test-focused 'binary(=graph_interop)' {{verbose}}
+
+# A plan-level QoS override reaches the ADVERTISED profile a stock
+# `ros2 topic info --verbose` peer reads (issue #52 / 0303 / 0306). Nextest
+# serializes it with the tree's only other endpoint-profile reader in the
+# `native-qos-discovery` group — concurrent pairs make that peer miss an
+# endpoint inside the settle window (issues 0312 / 0747).
+# Runs `qos_override_e2e`; needs ROS 2 + `rmw_zenoh_cpp` + the qos native entry.
+[group("debug")]
+test-ros2-qos-override verbose="":
+    @just _test-focused 'binary(=qos_override_e2e)' {{verbose}}
+
+# One graph node per launch component in `ros2 node list`, Rust entry (#104 /
+# phase-268 W3). The gate it exercises lives in the shared zenoh shim, so this
+# and the C++ lane below are the two languages of one claim. The entry is
+# `workspace-rust-native`, from `just native build-fixtures`; the router ships
+# with `rmw_zenoh_cpp`.
+# Runs `rust_multi_node_per_node_graph`; needs ROS 2 + `rmw_zenoh_cpp` + that entry.
+[group("debug")]
+test-ros2-multinode-rust verbose="":
+    @just _test-focused 'binary(=rust_multi_node_per_node_graph)' {{verbose}}
+
+# The same per-node graph proof through the C++ TYPED entry (phase-257 / 268).
+# It INSPECTS a prebuilt cmake fixture and never configures cmake itself
+# (issue 0034), so `cpp_robot_entry` from `just build-test-fixtures` is a
+# precondition rather than something this lane can produce. Unlike the peer,
+# it is not optional: the artifact assertion FAILS on a missing fixture rather
+# than skipping (issue 0584), so this is the one lane here that is red on a
+# host that has simply never built fixtures.
+# Runs `cpp_multi_node_entry`; needs ROS 2 + `rmw_zenoh_cpp` + that cmake fixture.
+[group("debug")]
+test-ros2-multinode-cpp verbose="":
+    @just _test-focused 'binary(=cpp_multi_node_entry)' {{verbose}}
+
+# DECLARATIVE zenoh → Cyclone DDS bridge e2e (phase-267 W-B, issues 0106 / 0107
+# / 0109). The bridge is a `native_entry` whose `system.toml` declares the
+# `[[bridge]]`; `nros sync` bakes `nros-bridge.toml` and the macro emits the
+# pump. Only the receiver-asserting case wants a stock ROS 2 peer, and it
+# needs `rmw_cyclonedds_cpp` specifically.
+# Runs `declarative_bridge_zenoh_to_cyclonedds`; needs `rmw_zenohd` + the bridge fixtures.
+[group("debug")]
+test-bridge-zenoh-to-cyclonedds verbose="":
+    @just _test-focused 'binary(=declarative_bridge_zenoh_to_cyclonedds)' {{verbose}}
+
+# The IMPERATIVE sibling (issue #53): the hand-written
+# `bridge-zenoh-to-cyclonedds-fwd` bin at the SAME coordinate as the
+# declarative one, which is the G4 blind spot `interop::CELLS` closes.
+# `binary(=...)` is exact on purpose — unanchored, this name is a SUBSTRING of
+# `declarative_bridge_zenoh_to_cyclonedds` and would run both.
+# The `_ros2` receiver case additionally needs ROS 2 + `rmw_cyclonedds_cpp`.
+# Runs `bridge_zenoh_to_cyclonedds`; needs `rmw_zenohd` + the bridge fixtures.
+[group("debug")]
+test-bridge-zenoh-to-cyclonedds-imperative verbose="":
+    @just _test-focused 'binary(=bridge_zenoh_to_cyclonedds)' {{verbose}}
+
+# DECLARATIVE zenoh → XRCE bridge e2e. xrce is lazy-registration, so unlike the
+# Cyclone sibling there is no descriptor staging on the egress side. It lives
+# here rather than under `xrce` because its nano side is a `NativeFixtures`
+# entry, same as its Cyclone siblings — the Agent is the peer, not the subject.
+# The Agent comes from `just xrce setup`.
+# Runs `declarative_bridge_zenoh_to_xrce`; needs `rmw_zenohd` + an XRCE Agent + fixtures.
+[group("debug")]
+test-bridge-zenoh-to-xrce verbose="":
+    @just _test-focused 'binary(=declarative_bridge_zenoh_to_xrce)' {{verbose}}
+
 # Run ROS 2 interop tests (shell script)
 [group("debug")]
 test-ros2-shell:

--- a/just/zephyr-dev.just
+++ b/just/zephyr-dev.just
@@ -406,6 +406,23 @@ test-xrce verbose="":
     fi
     cargo nextest run "${cargo_nextest_args[@]}" "${args[@]}"
 
+# An nros zenoh-pico publisher ON TARGET reaches a stock `ros2 topic echo`
+# subscriber (issue #141) — the only `interop::CELLS` cell built through the
+# west leaves rather than native fixtures, so it has TWO build channels and
+# skips on either (phase-433 / issue 1127).
+#
+# Deliberately NOT sequenced after `build-fixtures` the way `just zephyr test`
+# is: this is an aimable unit, and running the whole west lane to reach one
+# cell is not something anyone would type. Build the fixture, then aim.
+#
+# Its baked router port is shared with `entry_e2e`'s zephyr_rust_qos cell, so
+# nextest serializes the two in `matrix-consumers-serial`.
+# The west-built qos entry comes from `just zephyr build-fixtures`.
+# Runs `qos_zephyr_ros2_interop_e2e`; needs ROS 2 + `rmw_zenoh_cpp` + that entry.
+[group("debug")]
+test-ros2-qos verbose="":
+    @just _test-focused 'binary(=qos_zephyr_ros2_interop_e2e)' {{verbose}}
+
 # Run Zephyr C examples test
 [group("debug")]
 test-c:

--- a/justfile
+++ b/justfile
@@ -1042,6 +1042,70 @@ test-select filter verbose="":
     echo "  everything is legitimate (out-of-lane is the normal case) — but it is"
     echo "  NOT evidence about the code. Reasons are in the [SKIPPED] lines above."
 
+# Run ONE `nros-tests` binary with `test-select`'s skip accounting — the shared
+# body of the focused live-peer lanes (phase-433, issue 1127).
+#
+# Not `test-select` itself, for two reasons: that one is workspace-scoped, and
+# these lanes all live in `nros-tests`, so `-p` cuts the build to one package;
+# and its verbose spelling is `--no-capture`, where every `test-ros2*` sibling
+# means "print the outputs". Everything else here is `test-select`'s tail.
+#
+# That tail is load-bearing rather than decoration. Every lane that calls this
+# has a precondition the host may not meet — a ROS 2 install, `rmw_zenohd`, an
+# XRCE Agent, a west-built zephyr leaf — and an unmet one is a `[SKIPPED]`
+# panic, which nextest scores as a FAILURE. Without the rewrite, "this host has
+# no ROS" prints character-for-character as "the interop is broken".
+#
+# `-E <filterset>`, not `--test <name>`: a caller narrows further with
+# `and test(...)`, and it is the spelling `check-interop-cell-runners` reads.
+# Callers write `binary(=x)`, exact — `binary(x)` is a SUBSTRING match, and
+# `bridge_zenoh_to_cyclonedds` is a substring of its declarative sibling.
+_test-focused filter verbose="":
+    #!/usr/bin/env bash
+    set -e
+    source scripts/build/cargo.sh
+    source scripts/test/nextest-profile.sh
+    cargo_nextest_args=($(nros_cargo_nextest_args))
+    args=(-p nros-tests --no-fail-fast -E '{{filter}}')
+    if [ -z "{{verbose}}" ]; then
+        args+=(--success-output never --failure-output never)
+    fi
+    nros_nextest_junit_reset
+    set +e
+    cargo nextest run "${cargo_nextest_args[@]}" "${args[@]}"
+    rc=$?
+    set -e
+    junit="$(nros_nextest_junit_path)"
+    just _rewrite-skipped-junit "$junit" || true
+    [ $rc -eq 0 ] && exit 0
+    # Exit 4 is "no tests to run": the filter named a binary that does not
+    # exist, or was narrowed past every case. A focused lane selecting nothing
+    # reads exactly like a lane with nothing to do, so it is a failure here.
+    if [ "$rc" -eq 4 ]; then
+        echo "ERROR: '{{filter}}' selected NO tests — nothing ran."
+        echo "       Check it against \`cargo nextest list -p nros-tests\`."
+        exit 1
+    fi
+    # Issue #29 — nextest exits 100 only when tests RAN and some failed. Any
+    # other non-zero is a build/setup failure, which emits no junit cases and
+    # would otherwise tally as "0 real failures" over a broken build.
+    if [ "$rc" -ne 100 ] || [ ! -f "$junit" ]; then
+        echo "ERROR: nros-tests build/setup failed (nextest exit $rc) — not a [SKIPPED] precondition."
+        exit 1
+    fi
+    real="$(just _count-real-failures "$junit")"
+    just _test-summary "$junit" || true
+    if [ "$real" -ne 0 ]; then
+        echo "ERROR: $real real (non-[SKIPPED]) test failure(s):"
+        just _name-real-failures "$junit" || true
+        exit 1
+    fi
+    skipped="$(grep -c '<skipped' "$junit" 2>/dev/null || echo 0)"
+    echo "All failures were [SKIPPED] preconditions — treating as pass."
+    echo "  $skipped selected test(s) SKIPPED: the peer or fixture they need was"
+    echo "  not there. A skip is NOT evidence about the code — the reasons are in"
+    echo "  the [SKIPPED] lines above."
+
 # nros-tests integration tests, skipping heavy cross-compile / QEMU groups.
 # Filters mirror the `test` recipe's `-E` predicate, just scoped to
 # `package(nros-tests)` so the workspace unit tests aren't re-run.


### PR DESCRIPTION
phase-433 W5 groundwork for issue 1127: a focused runner for each live-peer interop cell that had none, and the ledger that tracked them emptied.

## What was missing

`nros_tests::interop::CELLS` declares 17 `Tier::Runtime` cells across 11 test binaries. Three binaries had a focused recipe (`interop_e2e`, `params`, `xrce_ros2_interop`); **eight had none**, covering nine cells, each listed in `.config/interop-cells-without-runner.txt` against issue 1127.

The gap is being **aimable**, not being executed. Root `just test-all` reaches all of these binaries. What it cannot do is run one cell against a live peer: it brings up no peer, cannot be pointed at a cell, and an unmet precondition inside it becomes a `skip!` that renders `<skipped>` — indistinguishable from a pass. Issue 1127's Direction is one cell end to end by hand, verdict recorded, *then* a lane. **No lane here** — no CI wiring, no `just ci …` change, no schedule. That is W5.

## The eight recipes

| recipe | binary |
| --- | --- |
| `just native test-ros2-graph` | `graph_interop` |
| `just native test-ros2-qos-override` | `qos_override_e2e` |
| `just native test-ros2-multinode-rust` | `rust_multi_node_per_node_graph` |
| `just native test-ros2-multinode-cpp` | `cpp_multi_node_entry` |
| `just native test-bridge-zenoh-to-cyclonedds` | `declarative_bridge_zenoh_to_cyclonedds` |
| `just native test-bridge-zenoh-to-cyclonedds-imperative` | `bridge_zenoh_to_cyclonedds` |
| `just native test-bridge-zenoh-to-xrce` | `declarative_bridge_zenoh_to_xrce` |
| `just zephyr test-ros2-qos` | `qos_zephyr_ros2_interop_e2e` |

Placement follows each cell's **build channel**, not its peer. Every bridge's nano side is a `NativeFixtures` entry, so all three sit beside the other native lanes even though one wants an XRCE Agent — `just native test-c-xrce` already does. Only `zephyr-qos-rust-zenoh` is `ZephyrWestLeaves`, so only it moves module.

`qos_zephyr_ros2_interop_e2e` gets a real recipe rather than a corrected ledger line: `just zephyr build-fixtures` does produce the west leaf, and without it the test skips saying so. It is deliberately *not* sequenced after that recipe — running the whole west lane to reach one cell is not something anyone would type.

## One shared body

`_test-focused` in the root justfile, rather than eight copies of the tail. It is `test-select` narrowed to `-p nros-tests` and to the quiet-unless-verbose default the `test-ros2*` siblings carry. The narrowing is load-bearing: workspace-scoped, the build needs `zpico-sys`, which panics on an unprovisioned `zenoh-pico` submodule before any test runs.

The skip accounting is `just xrce test-ros2`'s, and it is what makes these lanes usable — an unmet precondition is a `[SKIPPED]` panic that nextest scores as a FAILURE, so without the rewrite "this host has no ROS" prints character-for-character as "the interop is broken".

Callers write `binary(=x)`, **exact**. Unanchored, `binary(bridge_zenoh_to_cyclonedds)` is a substring match that also selects `declarative_bridge_zenoh_to_cyclonedds` — the same hazard `.config/nextest.toml` records for `binary(~zephyr)`.

## Measured

On a host with no ROS (`/opt/ros` absent, `ros2` off PATH), every recipe reaches its tests — no filter parse error anywhere (issue 0743's failure mode). Seven of eight exit 0 with every case skipped for a named precondition.

`test-ros2-multinode-cpp` reaches its four cases: the coordinate tripwire passes, the two live-peer cases skip, and `multi_node_workspace_cpp_typed_configures_and_builds` fails on `BuildFailed("Test fixture binary not prebuilt: …/cpp_robot_entry/…")`. That is issue 0584's rule — a missing fixture is a hard failure, not a skip — so the recipe's doc comment says the lane is red on a host that has never built fixtures.

- `just check interop-cell-runners`: **17/17 Runtime cells have a named runner, 11/11 binaries, 0 in the ledger** (was 8/17 and 9).
- `just check fast`: 239/239 green (via the `pre-push` hook).
- `just --list` shows all eight with a description.

## `.config/nextest.toml` gap found, not fixed here

`graph_interop` and `rust_multi_node_per_node_graph` both drive `ros2 node list` — the singleton ROS 2 daemon that the `ros2-interop` group (`max-threads = 1`) exists to serialize — and **neither has any override**, so both are ungrouped on the default 30 s / terminate-after-2 budget. Their siblings `interop_e2e` and `params` are both in that group. `cpp_multi_node_entry` and the three bridge binaries are ungrouped too. Left alone deliberately: a group assignment is a scheduling change that wants its own measurement, and this PR adds no lane that would run them concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP
