### PR TITLE
fix(#1110): rustdoc-links ran on the push lane, which provisions nothing

### DIFF
--- a/.config/gate-lane-exempt.txt
+++ b/.config/gate-lane-exempt.txt
@@ -54,6 +54,7 @@ fast-serial  # lane verb: the same lane, one gate at a time, fail-fast
 nextest-test-filters  # in no lane and no caller found — issue 1071's class
 no-std  # gate.yml + `just ci` run it by name; cross-compiles riscv32
 rmw-feature-matrix  # generator `--check`; in no lane and no caller found
+rustdoc-links  # `cargo doc` over the deployed crate set; compiles `zpico-sys`, whose build script needs the zenoh-pico source. Its own pull-request step in gate.yml runs it AFTER provisioning
 sched-matrix  # generator `--check`; in no lane and no caller found
 sdk-index  # NETWORK — downloads and sha256-checks SDK release assets
 stack-floor  # in no lane and no caller found — issue 1071's class

--- a/just/check/docs.just
+++ b/just/check/docs.just
@@ -221,10 +221,20 @@ roadmap-status:
 # reads too — one spelling, because a gate documenting a DIFFERENT set from the
 # one that deploys is a gate that can be green while the deploy is red.
 #
-# Not on the fast line: it compiles. It runs in the `compile-smoke` JOB, which
-# already builds the workspace on every pull request — `check-lane-contracts`'s
-# rule is that a lane may only resolve artifacts the job itself builds, and this
-# one does.
+# Not on the fast line: it compiles. That is stated in
+# `.config/gate-lane-exempt.txt` and not only here, which is the difference
+# between an intent and a mechanism — fast-lane membership is DERIVED (issue
+# 1072: a recipe is a fast gate unless it is exempt), so a comment saying "not
+# on the fast line" did not make it so. It WAS on the fast line, and on `push`
+# to main — where gate.yml does not provision `-sys` sources — `cargo doc`
+# reached `zpico-sys`'s build script and died on the absent zenoh-pico:
+#
+#   zenoh-pico source not provisioned at ".../zpico-sys/zenoh-pico"
+#   error: recipe `rustdoc-links` failed with exit code 101
+#
+# It runs from its OWN pull-request step in gate.yml, which sits after the
+# provisioning step — `check-lane-contracts`'s rule is that a lane may only
+# resolve artifacts the job itself builds, and that job does.
 [group("ci")]
 rustdoc-links:
     #!/usr/bin/env bash


### PR DESCRIPTION
`gate.yml` has been **red on pushes to `main`**:

```
===== FAIL (rustdoc-links, rc=101, 31968ms) =====
thread 'main' panicked at nros-zpico-build/src/runner.rs
zenoh-pico source not provisioned at ".../zpico-sys/zenoh-pico"
```

The gate compiles: `cargo doc` over the deployed crate set reaches `nros-rmw-zenoh`, which pulls `zpico-sys`, whose **build script** needs the zenoh-pico source. `gate.yml`'s *"Build nros CLI + provision compile-tier sources"* step is `pull_request` / `merge_group` / `schedule` / `workflow_dispatch` only — so on `push` that source is absent, and `just check fast` runs on **every** event.

## The intent was already written down. In a comment.

The recipe carried:

> *"Not on the fast line: it compiles. It runs in the `compile-smoke` JOB…"*

That was never true of the **mechanism**. Fast-lane membership is *derived* — issue 1072: a recipe in the check module is a fast gate unless it is exempt — and `rustdoc-links` was in no exempt file. So it ran **twice** on a pull request (its own dedicated step, and again inside `check fast`) and once, doomed, on every push.

It is exempt now, with its reason, in `.config/gate-lane-exempt.txt` — the place the derivation actually reads.

**Coverage is unchanged.** Its own `pull_request` step in `gate.yml` is untouched and sits *after* the provisioning step, so the property issue 1110 added it for still holds: nothing on a merge-gating path stops running rustdoc.

The comment is corrected to name the mechanism and quote the failure. A comment saying "not on the fast line" about a gate that is on the fast line is worse than no comment.

## Proven in both conditions

| lane | condition | result |
|---|---|---|
| push | no zenoh-pico (reproduced in a bare worktree) | `just check fast` — **232 gates ran, 8 skipped, none failed** |
| pull request | zenoh-pico present | `just check rustdoc-links` — **OK, the 6 published crates document cleanly** |

`gate-lists`, `gate-visibility`, `default-gates-run-somewhere`, `lane-contracts` all pass — `gate-visibility` in particular, since that is what objects if exempting a gate leaves it reachable from no merge-gating job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
