### PR TITLE
fix(#417): wire is_spinning into the real spin loops; order the typed-probe tests

### DIFF
--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -8197,8 +8197,12 @@ impl<'s> Executor<'s> {
         let timeout_us = opts.timeout.map(|d| d.as_micros() as u64);
         let mut total_callbacks = 0usize;
 
-        self.halt_flag
-            .store(false, core::sync::atomic::Ordering::SeqCst);
+        // phase-417 W4.c — clears the cancel flag AND raises `is_spinning`. The
+        // clear is the pre-existing behaviour (a cancel requested before this
+        // spin is not a cancel of this spin); the raise is what lets a peer
+        // thread see that its `cancel()` has not been acted on yet. Every exit
+        // below is a `break` to the single tail, which is where the scope ends.
+        self.enter_spin_loop();
 
         loop {
             if self.halt_flag.load(core::sync::atomic::Ordering::SeqCst) {
@@ -8225,6 +8229,7 @@ impl<'s> Executor<'s> {
             }
         }
 
+        self.exit_spin_loop();
         Ok(())
     }
 
@@ -8279,8 +8284,6 @@ impl<'s> Executor<'s> {
     /// executor.spin_period(core::time::Duration::from_millis(10))?;
     /// ```
     pub fn spin_period(&mut self, period: core::time::Duration) -> Result<(), NodeError> {
-        self.halt_flag
-            .store(false, core::sync::atomic::Ordering::SeqCst);
         let period_us = period.as_micros().min(u64::MAX as u128) as u64;
         // Absolute next-deadline in the executor's own clock. issue 0709 — the
         // sibling of `spin_blocking`'s guard above: with no clock there is no
@@ -8296,6 +8299,11 @@ impl<'s> Executor<'s> {
             );
             return Err(NodeError::NotInitialized);
         };
+        // phase-417 W4.c — after the clock guard, not before it: a call that
+        // returns an error never spun, and must not report that it did. (This
+        // also moved the cancel-flag clear past the guard, which is the same
+        // correction.)
+        self.enter_spin_loop();
         let mut next_us = Some(start_us + period_us);
 
         loop {
@@ -8318,6 +8326,7 @@ impl<'s> Executor<'s> {
                 next_us = Some(next + period_us);
             }
         }
+        self.exit_spin_loop();
         Ok(())
     }
 }
@@ -8545,9 +8554,18 @@ unsafe extern "C" fn threaded_spin_trampoline(
     // reported but not propagated — a runtime that fails to lift to SCHED_FIFO
     // still spins correctly at SCHED_OTHER (just without RT guarantees).
     let _ = (ctx.apply_policy)(ctx.policy);
+    // phase-417 W4.c — this loop owns its own iteration, so it is a spin and
+    // must say so. NOT `enter_spin_loop()`: that clears the cancel flag, and
+    // `open_threaded` hands the caller a `ThreadHandle` whose `halt()` may
+    // already have fired before this task was scheduled. Raising `is_spinning`
+    // without touching the cancel bit is the honest report here.
+    ctx.executor
+        .spinning
+        .store(true, core::sync::atomic::Ordering::SeqCst);
     while !ctx.executor.is_halted() {
         ctx.executor.spin_once(ctx.spin_period);
     }
+    ctx.executor.exit_spin_loop();
     core::ptr::null_mut()
 }
 

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -3247,6 +3247,36 @@ static TYPED_CB_VALUE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI
 static TYPED_CB_LEN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 static TYPED_CB_CTX_OK: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// Orders the two tests that share the `TYPED_CB_*` statics above.
+///
+/// Same shape, and the same reason, as `SimTimeGuard`: the four statics are
+/// PROCESS-global while `#[test]`s run concurrently, so
+/// `typed_c_subscription_delivers_into_caller_storage` — whose callback DOES
+/// fire — could land its `fetch_add` between the refused-decode test's
+/// `store(0)` and its `load`. The refused-decode test then read 1 and reported
+/// "a refused decode reached the callback", naming a delivery bug that had not
+/// happened. Measured at 7 failures in 15 runs with `--test-threads=2`, and 0
+/// in 15 solo or with `--test-threads=1`.
+///
+/// The counter is the reason a lock is the right tool rather than
+/// per-test statics: both tests assert on the SAME question ("did the callback
+/// fire, and how often"), so what they need is to not overlap, which is
+/// exactly what the lock says.
+struct TypedProbeGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl TypedProbeGuard {
+    fn acquire() -> Self {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        // A poisoned lock means the sibling panicked while holding it. That is a
+        // failure being reported elsewhere, not a reason to fail here too.
+        Self {
+            _lock: LOCK.lock().unwrap_or_else(|e| e.into_inner()),
+        }
+    }
+}
+
 /// The ported-rclc callback body: it reads FIELDS, and never CDR bytes.
 unsafe extern "C" fn typed_probe_callback(
     msg: *const core::ffi::c_void,
@@ -3261,6 +3291,7 @@ unsafe extern "C" fn typed_probe_callback(
 
 #[test]
 fn typed_c_subscription_delivers_into_caller_storage() {
+    let _typed_probe = TypedProbeGuard::acquire();
     let session = MockSession::new();
     let mut executor: Executor = executor_with_clock(session);
 
@@ -3334,6 +3365,7 @@ fn typed_c_subscription_delivers_into_caller_storage() {
 
 #[test]
 fn typed_c_subscription_refused_decode_is_loud_and_undelivered() {
+    let _typed_probe = TypedProbeGuard::acquire();
     let session = MockSession::new();
     let mut executor: Executor = executor_with_clock(session);
 


### PR DESCRIPTION
Two fixes the phase-417 parent (`284bf06de`) lacks, both measured on that tip.
A third was investigated and turned out to be **already present** — see
"What the brief got wrong" below.

## 1. `is_spinning()` was never true during a real spin

`enter_spin_loop` / `exit_spin_loop` landed on the parent as a documented
public pair, and nothing but a test ever called them. `spin_blocking`,
`spin_period` and the `open_threaded` worker each kept their own bare
`halt_flag.store(false, ..)` and never opened the scope, so `is_spinning()`
answered `false` for the whole duration of every real spin.

Before, on the parent tip — `cargo test -p nros-node --lib --features std is_spinning`:

```
test is_spinning_is_true_inside_the_loop ... FAILED
  spin.rs:9399: is_spinning() must read true while spin_blocking is running
test result: FAILED. 2 passed; 1 failed
```

After:

```
test result: ok. 3 passed; 0 failed
```

Whole crate: `cargo test -p nros-node --lib --features std` → **337 passed,
0 failed, 1 ignored**.

Note `--features std,rmw-cffi` reports **0 tests here and looks green**:
`cancel_tests` is `#[cfg(all(test, not(feature = "rmw-cffi")))]`, so the
feature set the branch was being compile-checked with compiles none of that
module. Run `--features std` alone.

Three sites, three different correct answers:

* `spin_blocking` — `enter_spin_loop()` replaces the cancel-flag clear outright
  (the pair clears it too); `exit_spin_loop()` on the single tail every `break`
  reaches.
* `spin_period` — the clear **moves past** the no-clock guard. A call returning
  `NotInitialized` never spun and must not report that it did; the pre-existing
  code also cleared a peer's pending cancel on the way out of an error path.
* the `open_threaded` trampoline — raises `spinning` **directly** rather than
  calling `enter_spin_loop()`. `open_threaded` returns a `ThreadHandle` whose
  `halt()` can fire before the task is scheduled, so clearing the cancel bit
  here would discard a halt the caller already requested.

Taken from the pre-restack working shape (`backup/w-b5-pre-restack`), narrowed
to the loop wiring. Deliberately **not** taken from it: that ref also
un-`alloc`-gates `halt_flag`/`spinning`/the lifecycle impl, and carries an older
hand-rolled `node_fqn` join that the parent has since replaced with
`crate::names::fully_qualified_name`. Both are the parent's to decide.

## 2. Typed-probe test race (cherry-picked `62f63ac1e`)

`typed_c_subscription_delivers_into_caller_storage` and its refused-decode
sibling share four process-global `TYPED_CB_*` statics while `#[test]`s run
concurrently. A `TypedProbeGuard`, same shape as the house `SimTimeGuard`,
orders them.

Measured here, 15 runs of `cargo test -p nros-node --lib --features std
typed_c_subscription -- --test-threads=2`:

| | failures |
| --- | --- |
| parent's `tests.rs` | **4 / 15** |
| with this commit | **0 / 15** |

## What the brief got wrong

**The `SimTimeGuard` gate fix (`6aaebd108`) is already on the parent.** The
campaign brief said it was absent, confirmed "by `git patch-id` comparison" —
but `patch-id` compares text, and the parent carries the same
`#[cfg(feature = "sim-time")]` on `ros_time_timer_follows_the_simulated_clock`
with a *differently worded* comment above it:

```
$ git show 284bf06de:packages/core/nros-node/src/executor/tests.rs | sed -n '1813,1819p'
// Gated to match `SimTimeGuard` and `register_timer_on_clock`, both of which
// are `sim-time`-only. Issue 1104 added the guard to an UNGATED test, so
// `cargo test -p nros-node --features std` — no `sim-time` — stopped compiling
// with `cannot find type SimTimeGuard`. …
#[cfg(feature = "sim-time")]
#[test]
```

Both `SimTimeGuard` callers are gated on the parent (lines 1818 and 1926). The
cherry-pick conflicted on comment text only and was skipped; nothing was
dropped.

## Tier: `just ci gate`

| step | result |
| --- | --- |
| `check::cli-fresh` | ok |
| `check::fast` | ok — 239 gates |
| `check::build` | **6 of 21 FAILED — all one pre-existing cause** |
| `check::api-parity` | **FAILED — same pre-existing cause** |
| `test-unit` | ok — 1153 tests, 1152 passed, 1 skipped (capability precondition, `ZPICO_MAX_SESSIONS=1`) |
| `test-lane-contracts` | ok — 17/17 |

`ci gate` stops at the first failure, so the last three were run individually
after attributing `check::build`.

### The one red, attributed

Every one of the seven failing gates reduces to a single `E0428` in
`packages/api/nros-c/src/node.rs`:

```
error[E0428]: the name `nros_node_get_fully_qualified_name` is defined multiple times
  672 | pub unsafe extern "C" fn nros_node_get_fully_qualified_name(node, buf, buf_len, out_len)
  980 | pub unsafe extern "C" fn nros_node_get_fully_qualified_name(node, output_name, output_size)
```

Six of the seven (`borrowed-e2e`, `staticlib-symbols`, `c`, `cpp`,
`required-features-tests`, `workspace-features`) are literally the same rustc
error; `api-parity` is the same duplication one layer up — clang refuses to
parse `nros_generated.h` (`conflicting types for 'nros_node_get_fully_qualified_name'`,
3 occurrences of the name in the generated header).

**Proven pre-existing on the parent, not introduced here:**

```
$ git show 284bf06de:packages/api/nros-c/src/node.rs | grep -n 'pub unsafe extern "C" fn nros_node_get_fully_qualified_name'
672:pub unsafe extern "C" fn nros_node_get_fully_qualified_name(
980:pub unsafe extern "C" fn nros_node_get_fully_qualified_name(

$ git diff --name-only 284bf06de..HEAD
packages/core/nros-node/src/executor/spin.rs
packages/core/nros-node/src/executor/tests.rs
```

This branch touches only `nros-node`. The two definitions are genuinely
different implementations with different ABIs (4-arg `out_len` +
`write_fqn` vs 3-arg + `expand_name`), so which survives is a design call for
whoever owns the restack — deliberately **not** fixed here.

This also contradicts the brief's expectation that the only known red would be
`check::api-parity` with ~48 UNLEDGERED rows. api-parity never got far enough
to produce a ledger verdict; it died at clang.

### Environment notes (this worktree, not the branch)

Two pre-existing worktree faults had to be repaired before the tier could run,
neither a code change: `packages/cli/third-party/play_launch` was **rewound**
one commit behind the recorded pin (`git submodule update`), and
`third-party/dds/cyclonedds` was unprovisioned (`git submodule update --init`),
which was the sole cause of the first run's `test-targets` red — it passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
