### PR TITLE
fix(phase-433 W2): three harness defects before a single cell verdict

### DIFF
--- a/docs/issues/1144-box-env-path-order-depends-on-login-shell.md
+++ b/docs/issues/1144-box-env-path-order-depends-on-login-shell.md
@@ -1,0 +1,96 @@
+---
+id: 1144
+title: "`ros2-box-env.sh`'s PATH prepend is undone by `activate.sh` in a NON-login shell — the host's glibc-2.39 `just` wins and dies"
+status: open
+type: bug
+area: build, testing
+severity: medium
+found: 2026-09-06
+related: [0400, 0401, 0759]
+---
+
+# Whether the box's tools are on PATH depends on `bash -c` vs `bash -lc`
+
+`scripts/dev/ros2-box-env.sh:178` prepends the box's own tool dir and says why:
+
+```sh
+# BEFORE activate.sh: it sources scripts/sdk-env.sh, which shells out to `just`,
+# and the host's ~/.cargo/bin/just would otherwise win the PATH race and print
+# `GLIBC_2.xx not found`. activate.sh prepends packages/cli/target/release after
+# this, which is correct — nros_box_publish put a box binary there.
+export PATH="$CARGO_INSTALL_ROOT/bin:$PATH"
+
+. "$_nros_box_root/activate.sh"
+```
+
+The reasoning holds only when `$HOME/.cargo/bin` is **already** on PATH, because
+`activate.sh:90` prepends it conditionally:
+
+```sh
+if [ -d "$HOME/.cargo/bin" ]; then
+    case ":$PATH:" in
+        *":$HOME/.cargo/bin:"*) ;;
+        *) export PATH="$HOME/.cargo/bin:$PATH" ;;
+    esac
+fi
+```
+
+In a **login** shell the container's profile has already put `~/.cargo/bin` on
+PATH, the guard skips, and `~/.local-box/bin` stays in front. In a **non-login**
+shell it has not, so `activate.sh` prepends the host's cargo bin **in front of**
+the dir `ros2-box-env.sh` just prepended — and the host's `just`,
+`cargo-nextest` and friends are glibc-2.39 binaries that cannot run in a
+Jammy container.
+
+## Measured
+
+Non-login (`podman exec -u aeon ros2 bash -c`), `ros2-box-env.sh` alone:
+
+```
+PRE  PATH-head=/usr/local/sbin:/usr/local/bin:/usr/sbin
+POST CARGO_INSTALL_ROOT=/home/aeon/.local-box
+POST PATH-head=/home/aeon/.nros-box/sdk/espflash/…:/home/aeon/.nros-box/sdk/…
+$ command -v just
+/home/aeon/.cargo/bin/just          # ← the HOST binary
+```
+
+with `/home/aeon/.local-box/bin/just` present and executable. The failure it
+produces names neither PATH nor the box:
+
+```
+just: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by just)
+```
+
+`docs/development/ros2-on-non-ubuntu.md` already records that this class of
+error "surfaces as `just: … not found` or `no such command: nextest` rather than
+as anything mentioning glibc" — this is the same class, arriving through PATH
+order rather than through a missing install.
+
+## Why it has not bitten before
+
+The documented entry point is `distrobox enter ros2 -- bash -c '...'`, and
+distrobox's wrapper gives a login-ish environment where `~/.cargo/bin` is
+already present. Driving the container directly with `podman exec` — which is
+faster and what an agent reaches for — does not.
+
+## Fix
+
+Make `ros2-box-env.sh` put its dir in front **after** sourcing `activate.sh`, or
+have it prepend both times. The comment's intent (box tools beat host tools) is
+right; only the ordering assumption is wrong, and it is wrong silently.
+
+A cheap assertion is worth adding wherever the box's tools are required:
+
+```sh
+command -v just | grep -q local-box || { echo "host just won the PATH race"; exit 1; }
+```
+
+That line is what turned this from a mystery into a measurement.
+
+## Not a fix
+
+Sourcing `activate.sh` first and `ros2-box-env.sh` second works, and is what
+phase-433 W1 used to get moving, but it is a workaround: `ros2-box-env.sh`
+sources `activate.sh` itself, so the first source only exists to make
+`activate.sh`'s guard a no-op. Documenting the workaround instead of fixing the
+order would leave the trap armed for the next caller.

--- a/docs/roadmap/phase-433-rmw-live-verification.md
+++ b/docs/roadmap/phase-433-rmw-live-verification.md
@@ -93,10 +93,8 @@ Three of 11 binaries have a focused recipe (`interop_e2e`, `params`,
 0759). Verified 2026-09-06: the `ros2` box is fully provisioned — 290
 `ros-humble-*` packages, `rmw_zenoh_cpp` 0.1.9, `rmw_cyclonedds_cpp` 1.3.4,
 `rmw_fastrtps_cpp` 6.2.10, box-owned `just`/`cargo-nextest`/`nros`/`bindgen`
-under `~/.local-box/bin`. **Nothing about the environment is missing.** Source
-`activate.sh` FIRST and `ros2-box-env.sh` SECOND: box-env prepends
-`CARGO_INSTALL_ROOT/bin` last, and activate.sh otherwise re-shadows `just` with
-the host's glibc-2.39 build, which dies in the box.
+under `~/.local-box/bin`. **Nothing about the environment is missing.** Driving
+it correctly is the part with traps — see W1 below and issues 1144, 0759.
 
 ### W0 — unblock the lane (issue 1136)
 
@@ -199,14 +197,31 @@ cleared:
 1. `bash scripts/dev/ros2-box-sync.sh` — takes over an hour on this disk; do not
    wrap it in a timeout. It now excludes `/.claude/worktrees/`, which it was
    copying once per live agent session.
-2. In the box: source `activate.sh` FIRST, `ros2-box-env.sh` SECOND. box-env
-   prepends `CARGO_INSTALL_ROOT/bin` last, so the reverse order re-shadows
-   `just` with the host's glibc-2.39 build and it dies as `GLIBC_2.39 not
-   found`. This cost one build.
-3. `just setup-cli`, then `bash scripts/build/fixtures-build.sh linux rust
+2. **Enter as the user.** `podman exec` without `-u aeon` runs as ROOT, and
+   git then refuses the box tree as dubiously-owned. `git ls-files` fails,
+   `nros_source_manifest` cannot compute a workspace-fixture signature, and the
+   test emits `[SKIPPED] … fixture not built` — which nextest renders as
+   **FAIL**, because `skip!` panics and only `test-all`'s junit rewrite converts
+   it. Five cells reported red for a git-config reason, naming the fixture
+   rather than the ownership. It also stamps the box CLI inconsistently, so the
+   next run as `aeon` refuses everything with "in-tree nros CLI is STALE".
+   `distrobox enter` does not have this problem; `podman exec` is the shortcut
+   that does.
+3. **PATH: assert, do not assume** (issue 1144). In a NON-login shell
+   `~/.cargo/bin` is absent, so `activate.sh`'s conditional prepend fires and
+   lands the host's glibc-2.39 `just` ahead of the box's. Sourcing
+   `activate.sh` before `ros2-box-env.sh` makes that guard a no-op and works,
+   but it is a workaround — box-env sources `activate.sh` itself, and the
+   ordering belongs there. Either way, assert it:
+   `command -v just | grep -q local-box || exit 1`.
+4. `just setup-cli`, then `bash scripts/build/fixtures-build.sh linux rust
    <rmw>` — the positional filter narrows to a coordinate without needing a
    lane. 54 rows for zenoh, 11 for cyclonedds; roughly an hour together.
-4. `cargo nextest run -p nros-tests --test graph_interop`.
+   **`[[fixture]]` rows are not workspace fixtures**: cells whose nano side is a
+   workspace entry (the bridges, `qos_override_e2e`,
+   `rust_multi_node_per_node_graph`) additionally need `just native
+   build-workspace-fixtures`, a different builder.
+5. `cargo nextest run -p nros-tests --test graph_interop`.
 
 **Not done:** the `nano-ros-box-box` mirror-of-a-mirror still sits beside the
 box tree, and this procedure is recorded here rather than in


### PR DESCRIPTION
W2 ran five live-peer cells and produced five reds, **none of them a finding.** Recording the sequence, because filing from that output is exactly the 0859–0862 pattern — four issues retracted, two carrying a confident wrong root cause.

### 1. `podman exec` runs as ROOT

Git then refuses the box tree as dubiously-owned, `git ls-files` fails, `nros_source_manifest` cannot compute a workspace-fixture signature, and the test emits `[SKIPPED] … fixture not built` — which **nextest renders as FAIL**, because `skip!` panics and only `test-all`'s junit rewrite converts it.

So five cells reported red for a git-config reason, in a message naming the fixture rather than the ownership. `distrobox enter` does not have this problem; `podman exec` is the shortcut that does.

No ownership damage: rootless podman maps container-root to the host user, so `find -user root` over the box tree returns 0.

### 2. The root run stamped the box CLI inconsistently

Under root the source stamp cannot be computed the way it can under `aeon`, so the next run refused everything with `in-tree nros CLI is STALE — the checkout moved`. Rebuilding as `aeon` clears it.

### 3. Issue #1144 (medium) — ours, not my misuse

`ros2-box-env.sh:178` prepends the box's tool dir **before** sourcing `activate.sh`, with a comment explaining that the host's `just` would otherwise win. That reasoning holds only when `$HOME/.cargo/bin` is **already** on PATH, because `activate.sh:90` prepends it **conditionally**:

- **login shell** — `~/.cargo/bin` already present, guard skips, box wins.
- **non-login shell** — absent, so activate.sh lands the host's glibc-2.39 `just` *in front of* the box's, and it dies as `GLIBC_2.39 not found`, naming neither PATH nor the box.

Measured both ways; the issue carries the transcript.

## A claim of mine, retracted

I wrote *"ORDER IS LOAD-BEARING: activate.sh FIRST, ros2-box-env.sh SECOND"* into the phase doc and a PR body, with the reason "box-env prepends `CARGO_INSTALL_ROOT/bin` last". **That reason is false** — box-env prepends *first* and then sources `activate.sh` itself, so the leading `. ./activate.sh` exists only to make activate.sh's guard a no-op. The workaround works; the rule was wrong, and documenting a workaround as a rule leaves the trap armed for the next caller.

Replaced with the measurement, a pointer to #1144, and an assertion worth copying:

```sh
command -v just | grep -q local-box || exit 1
```

## Also corrected in the procedure

**`[[fixture]]` rows are not workspace fixtures.** `fixtures-build.sh linux rust <rmw>` builds the former; the bridges, `qos_override_e2e` and `rust_multi_node_per_node_graph` need `just native build-workspace-fixtures` — a different builder. Missing that is what made the first batch look uniformly broken.

## Verification

`just check fast` 237/237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP