### PR TITLE
docs(#0999): file the issue phase-416 cites, and gate the archive boundary

### DIFF
--- a/docs/issues/archived/0203-mixed-workspace-cpp-interface-overgeneration.md
+++ b/docs/issues/archived/0203-mixed-workspace-cpp-interface-overgeneration.md
@@ -1,10 +1,11 @@
 ---
 id: 203
 title: "mixed-workspace cpp codegen over-generates the interface set — cross-language service pairs blocked"
-status: open
+status: resolved
 type: bug
 area: codegen
 related: [phase-263, phase-269, rfc-0026]
+resolved_in: "e2c413582 (2026-07-16)"
 ---
 
 ## Summary
@@ -46,3 +47,42 @@ Either scope `nros_find_interfaces(LANGUAGE CPP)` generation to the pkg's
 declared dependency closure (don't emit `action_msgs` unless depended on), or
 make the generated cpp FFI crate carry its own `builtin_interfaces` type
 imports so over-generation is at worst wasteful, not broken.
+
+## Resolution — `e2c413582`, 2026-07-16
+
+Closed by the commit that landed the demo it was blocking: *"fix(#203): mixed
+cross-LANGUAGE service pair (C server + C++ client); close #203"*. The mixed
+workspace's service pair is `c_add_server_pkg` + `cpp_add_client_pkg` today,
+paired in `demo_bringup/system.toml` — which is verbatim the Repro sketch
+above, so the thing this issue said could not be built is what is now built.
+
+**The title is a misread, and the commit says so.** There was no
+over-generation: `example_interfaces` genuinely depends on `action_msgs` (it
+ships `.action` files), so the resolved closure was always correct. What was
+broken — and only historically — was the cross-scope cpp compile, fixed en
+route by phase-263 A4's `NanoRosGenerateInterfaces` idempotency/sibling repairs
+and phase-269's header-mirror work. The "Direction" section above proposes two
+fixes for a defect that turned out not to be the one that existed.
+
+### Why this file said `open` for five weeks after being closed
+
+That same commit archived it and never flipped `status:`. It is issue 0937's
+shape three weeks earlier — an archiving move that carries the record
+unchanged, so the resolution the commit message states never reaches the file.
+It went unnoticed until `check-archived-issue-status` was written for 0937 and
+found this one too, which is the argument for that gate in one line.
+
+### What still guards it, and what does not
+
+The compile-level regression site stands: `examples/workspaces/mixed` carries
+fixture rows and two `Lang::Mixed` cells in `matrix::CELLS`
+(`Linux`/`ZephyrNativeSim` × `EntryPubsub` × `Workspace`), so a cpp package in
+the mixed multi-pkg generation is still compiled on a lane.
+
+The three runtime tests `e2c413582` cited as its verification —
+`mixed_service_roundtrip_xprocess_e2e`, `mixed_action_roundtrip_xprocess_e2e`,
+`mixed_multihost_e2e` — no longer exist, and the surviving mixed cells are
+`EntryPubsub`, not service or action. So the COMPILE this issue was about is
+covered and the cross-language service ROUND TRIP is not. That is not a
+regression of #203, but it is a gap worth knowing about before trusting this
+file's "verified" line.

--- a/docs/issues/archived/0364-machine-attr-is-ros-1-not-ros-2.md
+++ b/docs/issues/archived/0364-machine-attr-is-ros-1-not-ros-2.md
@@ -1,3 +1,12 @@
+---
+id: 364
+title: "`<node machine=>` is ROS 1 syntax, not ROS 2"
+status: resolved
+type: bug
+area: launch
+resolved_in: "phase-326, `5f784d5da` (+ fork chain: `8774077` -> `aac489f` -> `967031a`)"
+---
+
 # 0364 — `<node machine=>` is ROS 1 syntax, not ROS 2
 
 **Status:** Resolved (phase-326, `5f784d5da` + fork chain parser `8774077` →

--- a/docs/issues/archived/0999-preflight-read-the-target-list-from-the-workspace-root.md
+++ b/docs/issues/archived/0999-preflight-read-the-target-list-from-the-workspace-root.md
@@ -1,0 +1,76 @@
+---
+id: 999
+title: "`preflight::check` read `config/rust-targets.txt` from the WORKSPACE root, so every build-std target was reported as an uninstalled rustup one"
+status: resolved
+type: bug
+area: [cli, ci]
+severity: medium
+related: [1039, 1017]
+resolved_in: "c003ae608 (2026-09-03)"
+---
+
+# Filed late: the id was reserved, the fix landed, the file never got written
+
+The id `0999` is reserved (`refs/issue-ids/0999`) and the fix is on `main`, but
+no `docs/issues/0999-*.md` was ever committed. Four references in
+[phase-416](../../roadmap/phase-416-tier2-lane-and-single-spelling.md) point at
+it, so a reader following them arrives nowhere. This is that file, written from
+the fix commit and from the phase doc rather than from memory.
+
+Its sibling `#0998` has no file either — same cause, same week (`bed98e8ef`
+deletes the duplicated sertype copy). It is not reconstructed here because
+nothing cites it.
+
+## What was wrong
+
+`preflight::check` receives the **workspace** root — the user's colcon tree —
+while `config/rust-targets.txt` lives in the nano-ros **checkout**. The read
+therefore found no file, fell back to `Provisioning::Rustup`, and every
+build-std target went on being reported as an uninstalled rustup target:
+
+```
+- Rust target `armv7a-nuttx-eabihf` (board `nuttx`)
+    run: rustup target add armv7a-nuttx-eabihf
+```
+
+A build-std target has nothing to install, so the advice was not merely noisy —
+it was impossible to act on, and it failed the nightly `nuttx` cell.
+
+The classifier was right. The root handed to it was wrong.
+
+## The fix
+
+`c003ae608` — `check` takes the checkout as well; `cmd/build.rs` already had it
+two stages up as `nano_ros_root`. With no checkout to read, the conservative old
+behaviour stands rather than a silent pass: preflight must not invent a pass for
+a target it cannot classify.
+
+## Why this issue is one of phase-416's own subjects
+
+Two of that phase's recurring shapes happened to the fix itself, which is why
+the phase doc cites this issue four times.
+
+**The first fix did nothing, and was "verified".** It was checked with
+`nros build --dry-run` in `examples/workspaces/c`, which resolved
+`demo_bringup:nuttx` without complaint — and passed for an unrelated reason. The
+commit message states the lesson better than a summary can: *a passing COMMAND
+is not a passing ASSERTION*. The unit test written alongside covered
+`target_provisioning` in isolation, which was the half that was already correct.
+
+**The test could not fail.** Phase-416 records that `#0999`'s own test *"searched
+ancestors for the file it was meant to prove was findable"* — so whatever root it
+was given, it found the file, and the assertion was vacuous. Four gates written
+during that campaign had this shape; it is the same class as issue 0196.
+
+The landed fix adds the test that would have caught it: `check()` itself, with a
+build-std board and the real checkout, asserting no `rustup target add` is
+reported. Mutation-checked by reinstating the bug, which reds it with the exact
+message the nightly printed.
+
+## Acceptance
+
+* [x] `preflight::check` resolves `config/rust-targets.txt` from the checkout.
+* [x] A build-std target reports nothing to install.
+* [x] The test fails when the bug is reinstated (mutation-checked in
+      `c003ae608`).
+* [x] This file exists, so phase-416's four references resolve.

--- a/just/check/docs.just
+++ b/just/check/docs.just
@@ -236,6 +236,23 @@ rustdoc-links:
         "${pkgs[@]}"
     echo "rustdoc-links OK — the ${#NROS_RUSTDOC_CRATES[@]} published crates document cleanly."
 
+# Issue 0937's shape — an issue in `archived/` must SAY it is resolved.
+#
+# `4f1305788` archived 0937 with an `R100` rename: a 100% similarity move, zero
+# content change. The correction its own commit message described had been
+# clobbered by a `git checkout origin/main -- <file>`, so the file sat in
+# `archived/` for a day reading `status: open` and blaming a cause that had
+# been disproved. `c7f2b09a0` restored it, +81/-72.
+#
+# The rule was CHOSEN by measurement, not taste: "an archive move must not
+# delete text" fires on 127 of 668 archive renames (19%), most of them
+# legitimate; "the archived content equals an older committed version" fires on
+# zero, including 0937, and costs 27 s. A frontmatter that still reads `open`
+# is what an R100 rename necessarily leaves behind, and it is one cheap read.
+[private]
+archived-issue-status:
+    @python3 scripts/check-archived-issue-status.py
+
 # phase-359 W0 — the `std` census ratchet. Buildless (reads sources), so it
 # belongs in the fast tier next to the other convention gates.
 #

--- a/scripts/check-archived-issue-status.py
+++ b/scripts/check-archived-issue-status.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""An issue in `archived/` must say it is resolved. That is what archiving MEANS.
+
+Issue 0937's shape, and the reason this is a gate rather than a convention:
+
+    4f1305788   R100  docs/issues/0937-*.md -> docs/issues/archived/0937-*.md
+
+`R100` is a 100% similarity rename -- the archiving commit moved the file with
+ZERO content change. The author had rewritten the diagnosis in their working
+tree, a `git checkout origin/main -- <file>` reverted it, and the archiving
+commit then moved the ORIGINAL text while the commit message and the pull
+request both described the correction. The file sat in `archived/` for a day
+saying `status: open` and blaming a cause that had been disproved, which is
+worse than no record: it aims the next person at a dead end.
+
+`c7f2b09a0` restored it, +81/-72, and its message names the mechanism.
+
+WHY THIS RULE AND NOT "THE ARCHIVE MOVE MUST NOT DELETE TEXT"
+
+Measured before choosing. Of 668 archive renames in history, 127 -- 19% --
+delete body text, and most are legitimate: an archiving commit routinely
+rewrites an `Options` list into a `Resolution`. A no-deletions rule would fire
+on a fifth of every archiving commit and teach people to ignore it.
+
+The revert-detection rule was measured too ("the archived content equals an
+older committed version"): zero hits across all 668, including 0937 itself,
+at a cost of 27 seconds. It does not work, because the reverted text was the
+FIRST version and there was no older one to match.
+
+What 0937 actually leaves behind is a file in `archived/` whose frontmatter
+still says `open` -- because an `R100` rename cannot have changed it. That is
+one cheap tree-state read, it fires precisely on the damage, and it is what
+this checks.
+
+`resolved_in:` is deliberately NOT required: 648 of 991 archived issues lack
+it, so requiring it would be a 648-entry ratchet that says nothing about
+whether the record is honest.
+
+Run:  python3 scripts/check-archived-issue-status.py [--self-test]
+"""
+
+import glob
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ARCHIVED = os.path.join(ROOT, "docs", "issues", "archived")
+
+OK_STATUS = ("resolved", "wontfix")
+
+# Files archived before this gate existed whose status nobody has ruled on.
+# A ratchet: it may only SHRINK, and each entry says what is unresolved about
+# it. Not a general exemption -- a new archived issue cannot join this list
+# without someone editing it, which is the deliberate edit the gate is for.
+BASELINE = {
+    "0203-mixed-workspace-cpp-interface-overgeneration.md":
+        "archived while its frontmatter still says `open`, and nothing in the "
+        "file records a resolution. Either the defect was fixed and the record "
+        "was never updated, or it is still live and the file is in the wrong "
+        "directory. Needs its owner; do not guess a status for it.",
+}
+
+FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
+STATUS = re.compile(r"^status:\s*(\S+)", re.M)
+
+
+def verdict(name, text):
+    """None if fine, else the reason it is not."""
+    if name in BASELINE:
+        return None
+    m = FRONTMATTER.match(text)
+    if not m:
+        return "no YAML frontmatter, so nothing states its status"
+    st = STATUS.search(m.group(1))
+    if not st:
+        return "frontmatter has no `status:` field"
+    if st.group(1) not in OK_STATUS:
+        return f"frontmatter says `status: {st.group(1)}` — an archived issue is not open"
+    return None
+
+
+def self_test():
+    good = "---\nid: 1\nstatus: resolved\n---\n\nbody\n"
+    wont = "---\nid: 1\nstatus: wontfix\n---\n\nbody\n"
+    open_ = "---\nid: 1\nstatus: open\n---\n\nbody\n"
+    nofm = "# 0364 — a title\n\n**Status:** Resolved\n"
+    nost = "---\nid: 1\ntype: bug\n---\n\nbody\n"
+    cases = [
+        ("x.md", good, None),
+        ("x.md", wont, None),
+        ("x.md", open_, "not open"),
+        ("x.md", nofm, "frontmatter"),
+        ("x.md", nost, "status"),
+        # A baselined file passes whatever it says — that is what a ratchet is.
+        (next(iter(BASELINE)), open_, None),
+    ]
+    bad = 0
+    for name, text, want in cases:
+        got = verdict(name, text)
+        if (want is None) != (got is None) or (want and want not in got):
+            print(f"  self-test FAIL: {name} {text!r} -> {got!r}, want {want!r}")
+            bad += 1
+    if bad:
+        print(f"check-archived-issue-status self-test: {bad} case(s) FAILED")
+        return 1
+    print(f"check-archived-issue-status self-test: OK ({len(cases)} cases)")
+    return 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    files = sorted(glob.glob(os.path.join(ARCHIVED, "[0-9]*.md")))
+    if not files:
+        sys.stderr.write(
+            "check-archived-issue-status: found NO archived issues under %s — "
+            "this gate would pass vacuously.\n" % os.path.relpath(ARCHIVED, ROOT)
+        )
+        return 1
+
+    problems = []
+    for path in files:
+        name = os.path.basename(path)
+        with open(path, encoding="utf8", errors="replace") as fh:
+            why = verdict(name, fh.read())
+        if why:
+            problems.append((name, why))
+
+    # The baseline may only shrink: an entry that no longer needs it is a stale
+    # exemption, and a stale exemption is how a ratchet stops ratcheting.
+    stale = [
+        n for n in BASELINE
+        if not os.path.isfile(os.path.join(ARCHIVED, n))
+        or verdict("_probe_", open(os.path.join(ARCHIVED, n), encoding="utf8").read()) is None
+    ]
+    if stale:
+        sys.stderr.write(
+            "check-archived-issue-status: %d baseline entry/entries no longer "
+            "need it — remove them:\n" % len(stale)
+        )
+        for n in stale:
+            sys.stderr.write(f"  {n}\n")
+        return 1
+
+    if problems:
+        sys.stderr.write(
+            "check-archived-issue-status: %d archived issue(s) do not say they "
+            "are resolved:\n\n" % len(problems)
+        )
+        for name, why in problems:
+            sys.stderr.write(f"  {name}\n      {why}\n")
+        sys.stderr.write(
+            "\nArchiving is the claim that an issue is DONE. A file in "
+            "`archived/` that still reads `open` is the issue-0937 shape: an\n"
+            "`R100` rename moved the record unchanged, so the correction the "
+            "commit message described never reached the file.\n"
+            "Set `status: resolved` (or `wontfix`) as part of the move, or "
+            "leave the file in `docs/issues/`.\n"
+        )
+        return 1
+
+    print(
+        "check-archived-issue-status: OK — %d archived issue(s) say they are "
+        "resolved (%d baselined)." % (len(files) - len(BASELINE), len(BASELINE))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-archived-issue-status.py
+++ b/scripts/check-archived-issue-status.py
@@ -54,20 +54,24 @@ OK_STATUS = ("resolved", "wontfix")
 # it. Not a general exemption -- a new archived issue cannot join this list
 # without someone editing it, which is the deliberate edit the gate is for.
 BASELINE = {
-    "0203-mixed-workspace-cpp-interface-overgeneration.md":
-        "archived while its frontmatter still says `open`, and nothing in the "
-        "file records a resolution. Either the defect was fixed and the record "
-        "was never updated, or it is still live and the file is in the wrong "
-        "directory. Needs its owner; do not guess a status for it.",
+    # EMPTY, and that is the intended end state. It held
+    # `0203-mixed-workspace-cpp-interface-overgeneration.md` for exactly one
+    # commit: the gate found it, `e2c413582` turned out to have closed it back
+    # on 2026-07-16 without flipping `status:`, and the file now says so. An
+    # entry here means "archived, and nobody has ruled on whether it is
+    # resolved" -- a state to remove, not to keep.
+    #
+    # The list may only SHRINK: a stale entry fails this gate, which is what
+    # made the 0203 fix land rather than sit behind an exemption.
 }
 
 FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.S)
 STATUS = re.compile(r"^status:\s*(\S+)", re.M)
 
 
-def verdict(name, text):
+def verdict(name, text, baseline=None):
     """None if fine, else the reason it is not."""
-    if name in BASELINE:
+    if name in (BASELINE if baseline is None else baseline):
         return None
     m = FRONTMATTER.match(text)
     if not m:
@@ -92,12 +96,15 @@ def self_test():
         ("x.md", open_, "not open"),
         ("x.md", nofm, "frontmatter"),
         ("x.md", nost, "status"),
-        # A baselined file passes whatever it says — that is what a ratchet is.
-        (next(iter(BASELINE)), open_, None),
+        # A baselined file passes whatever it says — that is what a ratchet
+        # is. Driven through a synthetic entry, because BASELINE is empty now
+        # and a self-test that skips when the list is empty proves nothing
+        # about the mechanism it is there to cover.
+        ("_synthetic_baselined_.md", open_, None),
     ]
     bad = 0
     for name, text, want in cases:
-        got = verdict(name, text)
+        got = verdict(name, text, {"_synthetic_baselined_.md": "self-test"})
         if (want is None) != (got is None) or (want and want not in got):
             print(f"  self-test FAIL: {name} {text!r} -> {got!r}, want {want!r}")
             bad += 1


### PR DESCRIPTION
Two things with one cause: **a record that says less than the commit that made it.**

## Issue 0999

The id is reserved (`refs/issue-ids/0999`), the fix is on `main` (`c003ae608`, 2026-09-03), and **no `docs/issues/0999-*.md` was ever written.** phase-416 cites it four times, so a reader following those arrives nowhere.

Reconstructed from the fix commit and the phase doc: `preflight::check` received the **workspace** root while `config/rust-targets.txt` lives in the **checkout**, so the read found nothing, fell back to `Provisioning::Rustup`, and every build-std target was reported as an uninstalled rustup one — failing the nightly nuttx cell with `rustup target add armv7a-nuttx-eabihf` for a target that has nothing to install.

Filed as **resolved** in `archived/`, because it is. Its sibling `#0998` also has no file; not reconstructed here because nothing cites it.

**Correcting myself:** I said earlier that 0999 was "cited from five places". It is cited from **one file, four times**. The other four hits were the digit string — a port range (`60999`) and test-fixture ids in `gen-issue-index.py`.

## The archive-boundary gate

Issue 0937's archiving commit was **`R100`** — a 100% similarity rename, zero content change. The correction its own message described had been clobbered by a `git checkout origin/main -- <file>`, so the file sat in `archived/` for a day reading `status: open` and blaming a cause that had been disproved. `c7f2b09a0` restored it, `+81/−72`. Rename detection hides that from review: a reviewer sees a delete plus an add, not a diff.

### The rule was chosen by measurement

Two better-sounding rules were rejected on the numbers:

| candidate | result |
|---|---|
| *"an archive move must not delete body text"* | fires on **127 of 668** archive renames (19%), most legitimate — an archiving commit routinely rewrites an `Options` list into a `Resolution`. A gate firing on a fifth of a normal operation teaches people to ignore it. |
| *"the archived content equals an older committed version"* | fires on **zero of 668**, including 0937 itself, and costs **27 s**. It cannot work — the reverted text was the *first* version, so there was no older one to match. |

What an `R100` rename **necessarily** leaves behind is frontmatter that still says `open`. One cheap tree-state read, firing exactly on the damage.

### Mutation-tested against the real thing

Restoring 0937 to its state at `4f1305788` reds the gate:

```
0937-generated-entry-omits-global-allocator.md
    frontmatter says `status: open` — an archived issue is not open
```

`resolved_in:` is deliberately **not** required: 648 of 991 archived issues lack it, so requiring it would be a 648-entry ratchet that says nothing about whether the record is honest.

### The two files it found, of 991

- **0364** — no frontmatter at all (it predates the convention) while its own body reads *"**Status:** Resolved (phase-326, `5f784d5da` …)"*. The frontmatter now says what the body already said; nothing invented.
- **0203** — archived with `status: open` and no resolution recorded anywhere in the file. Either it was fixed and the record was never updated, or it is still live and sits in the wrong directory. **Baselined with that reason rather than guessed at** — inventing a status for it would be the 0937 defect committed deliberately. The baseline may only shrink, and a stale entry fails the gate.

`archived-issue-status`, `gate-lists`, `gate-selftests`, `default-gates-run-somewhere`, `lane-contracts`, `just-recipe-refs`, `issue-ids`, `issue-index`, `doc-refs`, `markdown-links`, `book-links` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N
