### PR TITLE
fix(#1136, phase-433 W0): the keyword survey excluded the only caller CI runs

### DIFF
--- a/cmake/NanoRosEntry.cmake
+++ b/cmake/NanoRosEntry.cmake
@@ -108,12 +108,21 @@ function(nano_ros_entry)
     # Phase 219.D — LAUNCH + ARGS + LANG keyword args.
     # R1 / W4.2 — MODEL <system_model.yaml>: the canonical resolved-model
     # input (RFC-0052); mutually exclusive with LAUNCH.
-    # phase-405 W1 — LOCATOR, ARGS and LAUNCH_ARGS are GONE. Each had zero
-    # authored users in the tree (generated CMakeLists excluded, since those are
-    # tool output rather than a caller's choice), and each carried live-looking
-    # code that could never run. Dropping them from the parse turns such a call
-    # into an UNPARSED_ARGUMENTS error rather than a line that silently does
-    # nothing.
+    # phase-405 W1 — LOCATOR and ARGS are GONE. Each had zero users and carried
+    # live-looking code that could never run; dropping them from the parse turns
+    # such a call into an UNPARSED_ARGUMENTS error rather than a line that
+    # silently does nothing.
+    #
+    # LAUNCH_ARGS went with them and came BACK (issue 1136, phase-433 W0). The
+    # survey that retired it excluded generated CMakeLists "since those are tool
+    # output rather than a caller's choice" — and the generator is the only
+    # caller that runs in CI. `cmake_root.rs` emits `LAUNCH_ARGS host=robot1`
+    # for every arg-bound image, so the removal turned two words into positional
+    # SOURCES and every workspace fixture configure died on `Cannot find source
+    # file: LAUNCH_ARGS`. It was never dead: it selects the `[[model]]` variant
+    # (`--arg` below), which is the ONLY difference between the robot1 and
+    # robot2 images — without it both resolve the whole system and become one
+    # program.
     #
     # phase-405 W4 — MODEL is GONE. Zero callers passed it, authored OR
     # generated, and it named a resolved artifact directly while BRINGUP+LAUNCH
@@ -129,7 +138,7 @@ function(nano_ros_entry)
     cmake_parse_arguments(_NRA
         "TYPED"
         "NAME;BOARD;LAUNCH;LANG;HOST;BRINGUP;PANIC"
-        "SOURCES;DEPLOY"
+        "SOURCES;DEPLOY;LAUNCH_ARGS"
         ${ARGN})
 
     # BRINGUP with no LAUNCH means this bringup's default launch. Conditional on
@@ -287,6 +296,13 @@ function(nano_ros_entry)
             if(NOT _NRA_LAUNCH STREQUAL "default")
                 list(APPEND _nra_mp_args --launch "${_NRA_LAUNCH}")
             endif()
+            # The arg-bound variant selector. Each `k=v` must match a
+            # `[[model]]` declaration in the bringup's system.toml (phase-330
+            # W4.0); `nros model-path` refuses an undeclared binding rather
+            # than deriving a name nothing produces.
+            foreach(_kv IN LISTS _NRA_LAUNCH_ARGS)
+                list(APPEND _nra_mp_args --arg "${_kv}")
+            endforeach()
             nros_resolve_cli(_nra_mp_tool CONTEXT "nano_ros_entry LAUNCH")
             execute_process(
                 COMMAND "${_nra_mp_tool}" model-path ${_nra_mp_args}

--- a/cmake/NanoRosVerbs.cmake
+++ b/cmake/NanoRosVerbs.cmake
@@ -85,7 +85,8 @@ endfunction()
 
 # ---------------------------------------------------------------------------
 # nano_ros_add_executable(<name> <sources…> [DEPLOY <target>…] [BOARD <board>]
-#     [BRINGUP <dir>] [LAUNCH <launch.xml>] [TYPED])
+#     [BRINGUP <dir>] [LAUNCH <launch.xml>] [LAUNCH_ARGS <k=v>…] [LANG c|cpp]
+#     [PANIC <policy>] [TYPED])
 #
 # Standalone entry. DEPLOY/BOARD default to the package.xml `<export>` tuple in
 # W4; until then DEPLOY defaults to `native` and an embedded board is passed
@@ -100,7 +101,17 @@ function(nano_ros_add_executable name)
     # phase-405 W1 — LOCATOR and ARGS dropped in lockstep with
     # `nano_ros_entry`. A verb that still accepted them would forward keywords
     # the callee no longer parses, which lands them in SOURCES.
-    cmake_parse_arguments(_NRE "TYPED" "BOARD;BRINGUP;LAUNCH;MODEL;HOST;LANG" "DEPLOY;SOURCES" ${ARGN})
+    #
+    # PANIC and LAUNCH_ARGS are parsed HERE, not left to the accident (issue
+    # 1136). Both used to reach `nano_ros_entry` only because this frame
+    # dropped them into `_srcs`, which the callee re-tokenized back into
+    # keywords — so they worked while `nano_ros_entry` happened to parse them,
+    # and became positional sources the moment it stopped. phase-405 W1 named
+    # that hazard ("add one positional source to any of them and it breaks")
+    # and removed the callee's half of it; this is the other half. Parsing them
+    # explicitly also makes the chain checkable: `check-generated-cmake-keywords`
+    # compares what `cmake_root.rs` emits against BOTH frames' keyword sets.
+    cmake_parse_arguments(_NRE "TYPED" "BOARD;BRINGUP;LAUNCH;MODEL;HOST;LANG;PANIC" "DEPLOY;SOURCES;LAUNCH_ARGS" ${ARGN})
     set(_srcs ${_NRE_SOURCES} ${_NRE_UNPARSED_ARGUMENTS})
     if(NOT _srcs AND NOT _NRE_LAUNCH AND NOT _NRE_BRINGUP AND NOT _NRE_MODEL)
         message(FATAL_ERROR
@@ -160,10 +171,13 @@ function(nano_ros_add_executable name)
     if(_NRE_LAUNCH)
         list(APPEND _entry_extra LAUNCH ${_NRE_LAUNCH})
     endif()
-    # R1 / W4.2 — the canonical resolved-model input (RFC-0052). Deprecated
-    # expert override; prefer BRINGUP.
-    if(_NRE_MODEL)
-        list(APPEND _entry_extra MODEL ${_NRE_MODEL})
+    # The arg-bound `[[model]]` variant selector — how an image picks ONE host
+    # out of a multi-host system (issue 1136).
+    if(_NRE_LAUNCH_ARGS)
+        list(APPEND _entry_extra LAUNCH_ARGS ${_NRE_LAUNCH_ARGS})
+    endif()
+    if(_NRE_PANIC)
+        list(APPEND _entry_extra PANIC ${_NRE_PANIC})
     endif()
     if(_NRE_TYPED)
         list(APPEND _entry_extra TYPED)
@@ -171,13 +185,29 @@ function(nano_ros_add_executable name)
     # phase-326 (issue 0364) — HOST removed with `<node machine=>` (ROS 1
     # syntax); kept PARSED so an old caller fails loud with guidance instead
     # of the keyword silently joining SOURCES via UNPARSED_ARGUMENTS.
+    #
+    # The guidance used to name MODEL, which phase-405 W4 then retired — a
+    # message pointing at a keyword nothing parses. LAUNCH_ARGS is the live
+    # answer, and the one the generator emits.
     if(_NRE_HOST)
         message(FATAL_ERROR
             "nano_ros_add_executable(${name}): HOST was removed (phase-326 / "
-            "issue 0364) — multi-host partitions at RESOLVE time now. Point "
-            "MODEL at the per-host SystemModel instead (resolved with "
-            "`host:=${_NRE_HOST}`, e.g. "
-            "MODEL config/multihost_${_NRE_HOST}_model.yaml).")
+            "issue 0364) — multi-host partitions at RESOLVE time now. Name the "
+            "INPUT and the binding instead: `BRINGUP <dir> LAUNCH "
+            "<multihost.launch.xml> LAUNCH_ARGS host=${_NRE_HOST}`, with a "
+            "matching `[[model]]` declaration in the bringup's system.toml.")
+    endif()
+    # MODEL retired with phase-405 W4: `nano_ros_entry` stopped parsing it and
+    # this frame kept forwarding it, so the keyword reached the callee's
+    # UNPARSED_ARGUMENTS and was DROPPED — an entry silently built from the
+    # bringup default instead of the model it named. Zero callers passed it,
+    # which is why nobody saw it. Fail loudly rather than forward into a void.
+    if(_NRE_MODEL)
+        message(FATAL_ERROR
+            "nano_ros_add_executable(${name}): MODEL was removed (phase-405 "
+            "W4) — an entry names the INPUT that produces a model, not the "
+            "resolved artifact. Use `BRINGUP <dir> LAUNCH <file>` (plus "
+            "`LAUNCH_ARGS k=v` for a declared variant).")
     endif()
     # Language: explicit LANG wins (the only way a LAUNCH-only entry — no
     # sources to infer from — can select C; nano_ros_entry's sourceless

--- a/docs/roadmap/phase-433-rmw-live-verification.md
+++ b/docs/roadmap/phase-433-rmw-live-verification.md
@@ -98,16 +98,51 @@ under `~/.local-box/bin`. **Nothing about the environment is missing.** Source
 `CARGO_INSTALL_ROOT/bin` last, and activate.sh otherwise re-shadows `just` with
 the host's glibc-2.39 build, which dies in the box.
 
-### W0 — unblock the lane (issue 1136)
+### W0 LANDED — the host-tests job could not build its fixtures (issue 1136)
 
-Make the CLI's emitted `nano_ros_entry` keywords and the function's parsed
-keywords agree, and gate the agreement — both sides are literals in the tree,
-so it is a static check. Not by dropping the emission: `system.toml` says
-`native_entry_robot1` and `_robot2` differ ONLY in `LAUNCH_ARGS host=`, so
-dropping it makes two images the same program, silently. Then confirm
-`host-tests.yml`'s integration job reaches `just ci tier1`.
+Nothing in this phase is observable while `host-tests.yml`'s `nros-tests
+integration (host)` job dies at **Build workspace fixtures**: measured
+2026-09-06 over its last 30 runs, 0 success / 10 failure / 18 cancelled, the
+last five failures all at that step.
 
-*Acceptance:* one green `host-tests` run, and a gate on the keyword sets.
+phase-405 W1 removed `LAUNCH_ARGS` from `nano_ros_entry`'s
+`cmake_parse_arguments` on a survey of "authored users in the tree (**generated
+CMakeLists excluded, since those are tool output rather than a caller's
+choice**)". The generator is the only caller that runs in CI, and
+`builder/cmake_root.rs` still emitted it — so the keyword fell into
+`UNPARSED_ARGUMENTS`, was spliced into `SOURCES`, and every workspace configure
+died on `Cannot find source file: LAUNCH_ARGS`. Six days, unseen, because
+host-tests runs on no gating event.
+
+**The capability was LIVE, not dead — measured, because the phase-405 note
+suggested otherwise.** Two frames, both checked:
+
+* `nros model-path --launch multihost.launch.xml` → `config/multihost_model.yaml`;
+  with `--arg host=robot1` / `robot2` → `config/multihost_robot1_model.yaml` /
+  `..._robot2_model.yaml`. Three distinct models; `--arg` was never removed.
+* The cmake side reached it by ACCIDENT and still worked. Replaying both
+  parses (`cmake -P`) on a generated call: pre-W1 the verb left
+  `LAUNCH_ARGS;host=robot1` in `UNPARSED_ARGUMENTS`, `_srcs` carried it into
+  `SOURCES`, and `nano_ros_entry` re-tokenized it back into
+  `_NRA_LAUNCH_ARGS=[host=robot1]` — which the `--arg` loop forwarded.
+  Post-W1 the same call yields `SOURCES=[LAUNCH_ARGS;host=robot1]`.
+
+So the per-host images were never silently identical: the loss was a hard
+configure error, which is the good failure. What was silent is the sibling
+found on the way — the verb kept forwarding `MODEL` after phase-405 W4 stopped
+parsing it, so a `MODEL <path>` reached `UNPARSED_ARGUMENTS` and was DROPPED.
+Zero callers passed it, which is why nobody saw it.
+
+Landed: `LAUNCH_ARGS` restored in `nano_ros_entry` with its `--arg` forward;
+`LAUNCH_ARGS` and `PANIC` parsed and forwarded EXPLICITLY by
+`nano_ros_add_executable` instead of riding the `UNPARSED_ARGUMENTS`
+re-tokenization phase-405 W1 itself named as a hazard; `MODEL` now a
+`FATAL_ERROR` there. Gate `check-generated-cmake-keywords` (fast lane) compares
+what `cmake_root.rs` emits against every cmake frame the call traverses — the
+complement of `check-retired-cmake-keywords`, which scans tracked cmake and
+therefore cannot see a generated root. Tests:
+`model_location::per_host_images_resolve_to_distinct_models` and
+`cmake_root::two_images_differing_only_in_args_render_differently`.
 
 ## Coverage map — what a live peer has actually seen
 

--- a/just/check/cmake.just
+++ b/just/check/cmake.just
@@ -91,6 +91,20 @@ cmake-find-program-shadowed:
 retired-cmake-keywords:
     @python3 scripts/check-retired-cmake-keywords.py
 
+# issue 1136 — the same question from the GENERATOR's end. The sibling above
+# scans tracked cmake for a caller still passing a retired keyword; a generated
+# root lives under `build/<coord>/` and is tracked by nothing, so the one caller
+# that runs in CI is the one it cannot see. phase-405 W1 dropped `LAUNCH_ARGS`
+# from `nano_ros_entry` on a survey that excluded generated CMakeLists, and
+# every workspace-fixture configure died on `Cannot find source file:
+# LAUNCH_ARGS` — for six days, because host-tests runs on no gating event.
+#
+# Both sides are literals, so the comparison is static: what `cmake_root.rs`
+# emits, against the keyword lists of every cmake frame the call traverses.
+[private]
+generated-cmake-keywords:
+    @python3 scripts/check-generated-cmake-keywords.py
+
 # issue 0719 — the C/C++ half of the same question. `check-image-panic-policy`
 # reads what a RUST image declares (`nros::main!(panic = …)`) and says outright
 # that it cannot see "the C/C++ side, where the policy is a cargo feature on the

--- a/packages/cli/nros-cli-core/src/builder/cmake_root.rs
+++ b/packages/cli/nros-cli-core/src/builder/cmake_root.rs
@@ -605,6 +605,48 @@ mod tests {
     }
 
     #[test]
+    fn two_images_differing_only_in_args_render_differently() {
+        // Issue 1136. `native_robot1` and `native_robot2` share a board, a
+        // launch file, a language and a deploy — `args` is the ONLY thing that
+        // distinguishes them, and it is what picks the per-host `[[model]]`
+        // variant. Stop emitting it and the two calls become the same call:
+        // two binaries, one program, no error anywhere. The resolver half is
+        // `model_location::per_host_images_resolve_to_distinct_models`.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let d = discovered(vec![pkg(root, "talker_pkg", true)]);
+        let mut sp = spec(root);
+        sp.board = Some("native".to_string());
+        sp.entries = ["robot1", "robot2"]
+            .iter()
+            .map(|host| CmakeEntry {
+                name: format!("native_{host}_entry"),
+                launch: "multihost.launch.xml".to_string(),
+                args: vec![("host".to_string(), (*host).to_string())],
+                lang: "c".to_string(),
+                deploy: "native".to_string(),
+                panic: None,
+            })
+            .collect();
+        let body = render(&d, &root.join("build/posix"), &sp).expect("renders");
+
+        let calls: Vec<&str> = body.split("nano_ros_add_executable(").skip(1).collect();
+        assert_eq!(calls.len(), 2, "{body}");
+        // Compare with the target NAME removed: that difference is free, and
+        // the question is whether anything the BUILD reads differs too.
+        let strip = |c: &str| {
+            c.replacen("native_robot1_entry", "", 1)
+                .replacen("native_robot2_entry", "", 1)
+        };
+        assert_ne!(
+            strip(calls[0]),
+            strip(calls[1]),
+            "the two per-host images render identically apart from their target \
+             name — they resolve one model and are one program: {body}"
+        );
+    }
+
+    #[test]
     fn no_entry_is_emitted_while_the_package_still_exists() {
         // The property that makes D13's migration incremental: two targets of
         // one name would collide, so the emitter stays silent until the

--- a/packages/core/nros-orchestration-ir/src/model_location.rs
+++ b/packages/core/nros-orchestration-ir/src/model_location.rs
@@ -698,6 +698,87 @@ mod tests {
         });
     }
 
+    /// The in-tree bringups whose `[image.*]` tables carry `args`.
+    fn arg_bound_bringups() -> Vec<PathBuf> {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("repo root")
+            .to_path_buf();
+        ["c", "mixed"]
+            .iter()
+            .map(|ws| {
+                repo.join("examples/workspaces")
+                    .join(ws)
+                    .join("src/demo_bringup")
+            })
+            .collect()
+    }
+
+    /// Two images of one multi-host system must not resolve to ONE model.
+    ///
+    /// Issue 1136. `native_robot1` and `native_robot2` differ in exactly one
+    /// thing — `args = { host = … }`, emitted as `LAUNCH_ARGS host=…` — and
+    /// that single difference is what picks the per-host `[[model]]` variant.
+    /// Drop it anywhere along the chain and both images resolve the whole
+    /// system: two binaries, one program, no error. phase-405 W1 dropped it at
+    /// the cmake end, where the loss was loud (a missing "source file"); this
+    /// asserts the half where it would be SILENT.
+    #[test]
+    fn per_host_images_resolve_to_distinct_models() {
+        let mut bound = 0;
+        for bringup in arg_bound_bringups() {
+            let raw = std::fs::read_to_string(bringup.join("system.toml"))
+                .unwrap_or_else(|e| panic!("{}: {e}", bringup.display()));
+            let doc: toml::Table = raw.parse().expect("system.toml parses");
+            let images = doc
+                .get("image")
+                .and_then(|i| i.as_table())
+                .expect("[image.*] tables");
+
+            let mut seen: Vec<(String, String)> = Vec::new();
+            for (name, img) in images {
+                let Some(args) = img.get("args").and_then(|a| a.as_table()) else {
+                    continue;
+                };
+                bound += 1;
+                let launch = img.get("launch").and_then(|v| v.as_str());
+                let pairs: Vec<(String, String)> = args
+                    .iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect();
+                let rel = launch_to_model_rel(&bringup, launch, &pairs)
+                    .unwrap_or_else(|e| panic!("{name}: {e}"));
+
+                // The binding must CHANGE the answer, not merely be accepted.
+                let unbound = launch_to_model_rel(&bringup, launch, &[])
+                    .unwrap_or_else(|e| panic!("{name} unbound: {e}"));
+                assert_ne!(
+                    rel,
+                    unbound,
+                    "{}: image `{name}` binds {pairs:?} and still resolves the \
+                     unbound model — the binding reaches nothing",
+                    bringup.display(),
+                );
+                if let Some((other, _)) = seen.iter().find(|(_, r)| *r == rel) {
+                    panic!(
+                        "{}: images `{other}` and `{name}` both resolve `{rel}` — \
+                         two per-host images are one program",
+                        bringup.display(),
+                    );
+                }
+                seen.push((name.clone(), rel));
+            }
+        }
+        // A sweep over nothing passes. Both workspaces declare a robot1/robot2
+        // pair, so anything under four means the tables moved and this test
+        // stopped asking the question.
+        assert!(
+            bound >= 4,
+            "expected >= 4 arg-bound images in-tree, found {bound}"
+        );
+    }
+
     #[test]
     fn missing_everywhere_reports_the_committed_path() {
         with_env(

--- a/scripts/check-generated-cmake-keywords.py
+++ b/scripts/check-generated-cmake-keywords.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""A keyword the CLI writes into a generated CMakeLists must be PARSED.
+
+Issue 1136. `nros` generates the workspace's root `CMakeLists.txt`
+(`builder/cmake_root.rs`) as `nano_ros_workspace(...)` plus one
+`nano_ros_add_executable(...)` per image. Both sides are literals in this tree,
+and nothing compared them.
+
+phase-405 W1 removed `LAUNCH_ARGS` from `nano_ros_entry`'s
+`cmake_parse_arguments` on a survey that counted "authored users in the tree
+(generated CMakeLists excluded, since those are tool output rather than a
+caller's choice)". The generator is the only caller that runs in CI. cmake does
+not reject an unknown keyword — it collects it into `UNPARSED_ARGUMENTS`, which
+`nano_ros_add_executable` splices into `_srcs` and forwards as `SOURCES`, so two
+words became positional sources and every workspace-fixture configure died on::
+
+    CMake Error at cmake/NanoRosEntry.cmake:426 (add_executable):
+      Cannot find source file:
+        LAUNCH_ARGS
+
+WHAT IT CHECKS
+
+1. Every keyword `cmake_root.rs` can emit into a `nano_ros_*` call is in the
+   keyword list of EVERY cmake frame that call traverses. `nano_ros_add_
+   executable` is a forwarder, so a generated keyword has to survive two
+   `cmake_parse_arguments` — the verb's and `nano_ros_entry`'s. Only the verb's
+   frame is where the keyword ARRIVES; both are where it can be dropped.
+
+2. Every keyword `nano_ros_add_executable` forwards through `_entry_extra` is
+   parsed by `nano_ros_entry`. That is the same rule one frame later, and it
+   had its own live violation: phase-405 W4 retired `MODEL` from
+   `nano_ros_entry` and left the verb appending it, so a `MODEL <path>` reached
+   the callee's `UNPARSED_ARGUMENTS` and was silently DROPPED — an entry built
+   from the bringup default instead of the model it named.
+
+WHY NOT JUST "DON'T EMIT IT"
+
+`LAUNCH_ARGS host=<h>` is the ONLY difference between the `native_robot1` and
+`native_robot2` images of `examples/workspaces/{c,mixed}`: it selects the
+`[[model]]` variant, so without it both resolve the whole system and the two
+images are one program. Measured, on the tree that removed it::
+
+    nros model-path --launch multihost.launch.xml                    -> config/multihost_model.yaml
+    nros model-path --launch multihost.launch.xml --arg host=robot1  -> config/multihost_robot1_model.yaml
+    nros model-path --launch multihost.launch.xml --arg host=robot2  -> config/multihost_robot2_model.yaml
+
+THE SIBLING, AND WHY IT CANNOT COVER THIS
+
+`check-retired-cmake-keywords` asks the same question from the other end: does
+any CALLER still pass a keyword some verb retired. It scans tracked cmake, and
+a generated root is a build artifact under `build/<coord>/` that is tracked by
+nothing — so the one caller that runs in CI is exactly the one it cannot see.
+This gate reads the GENERATOR instead. Both are needed.
+
+WHY A SKELETON AND NOT A GREP
+
+The keywords are attributed to the call they appear in, which a grep cannot do:
+`BACKEND` belongs to `nano_ros_workspace` and `BOARD` to
+`nano_ros_add_executable`, and checking either against the other's keyword list
+would be noise. So the emitter's `out.push_str(...)` literals are concatenated
+in source order into the text skeleton the generator produces, and that
+skeleton is parsed as cmake.
+
+A generated call to a `nano_ros_*` verb this gate has no chain for is a
+FAILURE, not a skip — otherwise a new generated verb escapes the rule by being
+new.
+
+Usage::
+
+    check-generated-cmake-keywords.py [--selftest]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+EMITTER = "packages/cli/nros-cli-core/src/builder/cmake_root.rs"
+
+# Which cmake frames a generated call traverses. A keyword must survive EVERY
+# one of them: `nano_ros_add_executable` re-emits into `nano_ros_entry`, and a
+# keyword dropped at either end lands in SOURCES.
+CHAINS: dict[str, list[tuple[str, str]]] = {
+    "nano_ros_workspace": [("cmake/NanoRosWorkspace.cmake", "nano_ros_workspace")],
+    "nano_ros_add_executable": [
+        ("cmake/NanoRosVerbs.cmake", "nano_ros_add_executable"),
+        ("cmake/NanoRosEntry.cmake", "nano_ros_entry"),
+    ],
+}
+
+# Rule 2's forwarding vector and its destination frame.
+FORWARDER = ("cmake/NanoRosVerbs.cmake", "nano_ros_add_executable")
+FORWARD_VAR = "_entry_extra"
+FORWARD_TARGET = ("cmake/NanoRosEntry.cmake", "nano_ros_entry")
+
+# `out.push_str("…")` / `out.push_str(&format!("…", …))` — the emitter's only
+# two writing spellings. `out.push('\n')` adds no keyword.
+PUSH_RE = re.compile(r'out\.push_str\(\s*(?:&format!\(\s*)?"((?:[^"\\]|\\.)*)"', re.S)
+
+# A cmake keyword as the generator writes it: indented, ALL CAPS, at the start
+# of an emitted line.
+KEYWORD_RE = re.compile(r"^[ \t]+([A-Z][A-Z0-9_]*)(?![a-z0-9_])")
+
+# A call opening at column 0 in the emitted skeleton.
+CALL_RE = re.compile(r"^([a-z_][a-z0-9_]*)\s*\(")
+
+
+def rust_test_split(text: str) -> str:
+    """The emitter's non-test half.
+
+    `mod tests` asserts on rendered text with literals of the same shape; those
+    are ASSERTIONS about the output, not the output.
+    """
+    m = re.search(r"^#\[cfg\(test\)\]", text, re.M)
+    return text[: m.start()] if m else text
+
+
+def unescape(lit: str) -> str:
+    """Rust string-literal escapes, as far as this needs them.
+
+    The line-continuation (`\\` before a real newline) comes FIRST and eats the
+    following indentation, exactly as rustc does — without it a wrapped literal
+    contributes phantom indented lines to the skeleton, and an indented line is
+    what this gate reads as a keyword.
+    """
+    lit = re.sub(r"\\\n[ \t]*", "", lit)
+    lit = re.sub(r"\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), lit)
+    return lit.replace("\\n", "\n").replace("\\t", "\t").replace('\\"', '"').replace("\\\\", "\\")
+
+
+def skeleton(rust: str) -> str:
+    """The cmake text `cmake_root.rs` writes, with `{…}` placeholders intact."""
+    return "".join(unescape(m.group(1)) for m in PUSH_RE.finditer(rust_test_split(rust)))
+
+
+def emitted_keywords(text: str) -> dict[str, set[str]]:
+    """`{call name: keywords}` over a generated cmake skeleton.
+
+    Depth is counted over parentheses OUTSIDE `{…}` placeholders and outside
+    double quotes, so `"{ws_rel}"` and a quoted path with a paren in it do not
+    close the call.
+    """
+    out: dict[str, set[str]] = {}
+    call: str | None = None
+    depth = 0
+    for line in text.splitlines():
+        if depth == 0:
+            m = CALL_RE.match(line)
+            if m:
+                call = m.group(1)
+                out.setdefault(call, set())
+        elif call:
+            k = KEYWORD_RE.match(line)
+            if k:
+                out[call].add(k.group(1))
+        depth += _paren_delta(line)
+        if depth <= 0:
+            depth, call = 0, None
+    return out
+
+
+def _paren_delta(line: str) -> int:
+    delta = 0
+    in_str = in_placeholder = False
+    for c in line:
+        if c == '"':
+            in_str = not in_str
+        elif c == "{":
+            in_placeholder = True
+        elif c == "}":
+            in_placeholder = False
+        elif not in_str and not in_placeholder:
+            if c == "(":
+                delta += 1
+            elif c == ")":
+                delta -= 1
+    return delta
+
+
+def function_body(cmake: str, name: str) -> str:
+    """The body of `function(<name> …)`, up to its `endfunction()`."""
+    m = re.search(r"^function\(\s*" + re.escape(name) + r"[\s)]", cmake, re.M)
+    if not m:
+        return ""
+    end = re.compile(r"^endfunction\(", re.M).search(cmake, m.end())
+    return cmake[m.end() : end.start() if end else len(cmake)]
+
+
+def parsed_keywords(cmake: str, name: str) -> set[str]:
+    """The keywords `<name>`'s first `cmake_parse_arguments` accepts.
+
+    All three lists — options, one-value, multi-value — are one namespace as
+    far as "does this word get consumed" goes, which is the question here.
+    """
+    body = function_body(cmake, name)
+    m = re.search(r"cmake_parse_arguments\(([^)]*)\)", body, re.S)
+    if not m:
+        return set()
+    lists = re.findall(r'"([^"]*)"', m.group(1))
+    words: set[str] = set()
+    for group in lists:
+        words.update(w for w in group.split(";") if w)
+    return words
+
+
+def forwarded_keywords(cmake: str, name: str, var: str) -> set[str]:
+    """Uppercase tokens appended to `<var>` in `<name>`'s body.
+
+    Narrow on purpose: `list(APPEND _entry_extra <KW> …)` is the ONE vector by
+    which this verb hands optional keywords on, and it is where `MODEL`
+    outlived its callee. The fixed arguments of the `nano_ros_entry(…)` call
+    itself are covered by rule 1.
+    """
+    body = function_body(cmake, name)
+    found: set[str] = set()
+    for m in re.finditer(r"list\(\s*APPEND\s+" + re.escape(var) + r"\s+([A-Z][A-Z0-9_]*)", body):
+        found.add(m.group(1))
+    return found
+
+
+def findings(read):
+    """`(rule, detail)` pairs; empty means the emitter and the parsers agree."""
+    bad = []
+    emitted = emitted_keywords(skeleton(read(EMITTER)))
+    for call, keywords in sorted(emitted.items()):
+        if not call.startswith("nano_ros_"):
+            continue  # a cmake builtin: project(), find_package(), set().
+        if call not in CHAINS:
+            bad.append(("chain", f"generated call `{call}(…)` has no frame chain in this gate"))
+            continue
+        for path, fn in CHAINS[call]:
+            accepted = parsed_keywords(read(path), fn)
+            for kw in sorted(keywords - accepted):
+                bad.append(
+                    ("emit", f"{EMITTER} emits `{call}(… {kw} …)`, {path}'s {fn}() does not parse it")
+                )
+    fwd_path, fwd_fn = FORWARDER
+    tgt_path, tgt_fn = FORWARD_TARGET
+    accepted = parsed_keywords(read(tgt_path), tgt_fn)
+    for kw in sorted(forwarded_keywords(read(fwd_path), fwd_fn, FORWARD_VAR) - accepted):
+        bad.append(
+            ("forward", f"{fwd_path}'s {fwd_fn}() forwards `{kw}`, {tgt_path}'s {tgt_fn}() does not parse it")
+        )
+    return bad
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest(verbose=True)
+    # On the normal path too: a negative control nobody runs decays into a
+    # comment (AGENTS.md, "a gate must run its own selftest").
+    selftest()
+
+    read = lambda rel: (REPO / rel).read_text(errors="replace")  # noqa: E731
+    bad = findings(read)
+    if bad:
+        print("check-generated-cmake-keywords: FAILED", file=sys.stderr)
+        for _, detail in bad:
+            print(f"  {detail}", file=sys.stderr)
+        print(
+            "\ncmake does not reject an unknown keyword — it collects it into\n"
+            "UNPARSED_ARGUMENTS, which `nano_ros_add_executable` splices into `_srcs`\n"
+            "and forwards as SOURCES. The keyword then reaches `add_executable` and the\n"
+            "configure dies naming a missing SOURCE FILE (issue 1136). Restore the\n"
+            "keyword in the parse list, or stop emitting it — but read what it carries\n"
+            "first: `LAUNCH_ARGS` is the whole difference between the per-host images.",
+            file=sys.stderr,
+        )
+        return 1
+    calls = sum(1 for c in emitted_keywords(skeleton(read(EMITTER))) if c.startswith("nano_ros_"))
+    print(f"check-generated-cmake-keywords: OK ({calls} generated nano_ros calls)")
+    return 0
+
+
+def selftest(verbose=False):
+    ok = fail = 0
+
+    def chk(what, cond):
+        nonlocal ok, fail
+        if cond:
+            ok += 1
+            if verbose:
+                print(f"  ok   {what}")
+        else:
+            fail += 1
+            print(f"  FAIL {what}", file=sys.stderr)
+
+    emitter = r'''
+fn render() -> String {
+    let mut out = String::new();
+    out.push_str("cmake_minimum_required(VERSION 3.20)\n");
+    out.push_str(&format!("project({} LANGUAGES C CXX)\n", name));
+    out.push_str("nano_ros_workspace(\n");
+    out.push_str(&format!("    BACKEND  {}\n", spec.rmw));
+    out.push_str("    ORDER_FROM_DEPENDS\n");
+    out.push_str(")\n");
+    out.push_str(&format!("nano_ros_add_executable({}\n", e.name));
+    out.push_str(&format!("    LAUNCH  {}\n", e.launch));
+    for (k, v) in &e.args {
+        out.push_str(&format!("    LAUNCH_ARGS {k}={v}\n"));
+    }
+    out.push_str("    TYPED\n");
+    out.push_str(&format!("    DEPLOY  {})\n", e.deploy));
+    out
+}
+#[cfg(test)]
+mod tests {
+    fn t() { assert!(body.contains("    NEVER_EMITTED x\n")); }
+}
+'''
+    ws = 'function(nano_ros_workspace)\n  cmake_parse_arguments(_NRW\n    "ORDER_FROM_DEPENDS"\n    "BACKEND"\n    "SUBDIRS"\n    ${ARGN})\nendfunction()\n'
+    verbs_ok = (
+        "function(nano_ros_add_executable name)\n"
+        '  cmake_parse_arguments(_NRE "TYPED" "LAUNCH" "DEPLOY;LAUNCH_ARGS" ${ARGN})\n'
+        "  list(APPEND _entry_extra LAUNCH ${_NRE_LAUNCH})\n"
+        "endfunction()\n"
+    )
+    entry_ok = (
+        "function(nano_ros_entry)\n"
+        '  cmake_parse_arguments(_NRA "TYPED" "LAUNCH" "DEPLOY;LAUNCH_ARGS" ${ARGN})\n'
+        "endfunction()\n"
+    )
+    files = {
+        EMITTER: emitter,
+        "cmake/NanoRosWorkspace.cmake": ws,
+        "cmake/NanoRosVerbs.cmake": verbs_ok,
+        "cmake/NanoRosEntry.cmake": entry_ok,
+    }
+    run = lambda over=None: findings((files | (over or {})).get)  # noqa: E731
+
+    chk("an emitter whose keywords are all parsed is clean", run() == [])
+
+    # The 1136 mutation, on each frame in turn.
+    drop_entry = entry_ok.replace(";LAUNCH_ARGS", "")
+    chk(
+        "dropping LAUNCH_ARGS from the CALLEE is caught",
+        [r for r, _ in run({"cmake/NanoRosEntry.cmake": drop_entry})] == ["emit"],
+    )
+    drop_verb = verbs_ok.replace(";LAUNCH_ARGS", "")
+    chk(
+        "dropping it from the receiving VERB is caught too",
+        [r for r, _ in run({"cmake/NanoRosVerbs.cmake": drop_verb})] == ["emit"],
+    )
+    chk(
+        "the message names the keyword and the file that stopped parsing it",
+        "LAUNCH_ARGS" in run({"cmake/NanoRosEntry.cmake": drop_entry})[0][1]
+        and "NanoRosEntry" in run({"cmake/NanoRosEntry.cmake": drop_entry})[0][1],
+    )
+
+    # Rule 2 — the MODEL shape: forwarded by the verb, unparsed by the callee.
+    fwd_model = verbs_ok.replace(
+        "  list(APPEND _entry_extra LAUNCH", "  list(APPEND _entry_extra MODEL ${_NRE_MODEL})\n  list(APPEND _entry_extra LAUNCH"
+    )
+    chk(
+        "a keyword forwarded into _entry_extra but unparsed by the callee is caught",
+        [r for r, _ in run({"cmake/NanoRosVerbs.cmake": fwd_model})] == ["forward"],
+    )
+
+    # Attribution: keywords belong to the call they appear in.
+    kws = emitted_keywords(skeleton(emitter))
+    chk("BACKEND is attributed to nano_ros_workspace", kws["nano_ros_workspace"] == {"BACKEND", "ORDER_FROM_DEPENDS"})
+    chk(
+        "LAUNCH/LAUNCH_ARGS/TYPED/DEPLOY are attributed to the entry call",
+        kws["nano_ros_add_executable"] == {"LAUNCH", "LAUNCH_ARGS", "TYPED", "DEPLOY"},
+    )
+    chk("a `#[cfg(test)]` assertion is not an emission", "NEVER_EMITTED" not in str(kws))
+    chk("cmake builtins are collected but not ruled on", "project" in kws)
+
+    # A new generated verb must not escape by being new.
+    plus = emitter.replace(
+        '    out\n}',
+        '    out.push_str("nano_ros_new_verb(\\n    THING\\n)\\n");\n    out\n}',
+    )
+    chk(
+        "a generated nano_ros call with no declared chain FAILS",
+        [r for r, _ in findings((files | {EMITTER: plus}).get)] == ["chain"],
+    )
+
+    # The parser itself, against the real files — a rule that reads nothing
+    # passes for the wrong reason.
+    real = lambda rel: (REPO / rel).read_text(errors="replace")  # noqa: E731
+    chk("the real emitter yields a non-empty skeleton", len(skeleton(real(EMITTER))) > 200)
+    for path, fn in CHAINS["nano_ros_add_executable"]:
+        chk(f"{fn}() has a readable keyword list", len(parsed_keywords(real(path), fn)) >= 5)
+    chk(
+        "the real verb forwards at least one keyword",
+        len(forwarded_keywords(real(FORWARDER[0]), FORWARDER[1], FORWARD_VAR)) > 0,
+    )
+
+    if verbose:
+        print(f"\n{ok} passed, {fail} failed")
+    if fail:
+        print("check-generated-cmake-keywords self-test: FAILED", file=sys.stderr)
+        raise SystemExit(1)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes the `host-tests.yml` **Build workspace fixtures** step, which has been red
for six days — 0 success / 10 failure / 18 cancelled over its last 30 runs, the
last five failures all at that step. Nothing else in phase-433 is observable in
CI until this lands. Issue 1136 (write-up on `work/rmw-verification-plan`, #593).

```
CMake Error at cmake/NanoRosEntry.cmake:426 (add_executable):
  Cannot find source file:
    LAUNCH_ARGS
```

## What was wrong

phase-405 W1 removed `LAUNCH_ARGS` from `nano_ros_entry`'s
`cmake_parse_arguments` on a count of *"authored users in the tree (**generated
CMakeLists excluded, since those are tool output rather than a caller's
choice**)"*. The generator is the only caller that runs in CI, and
`builder/cmake_root.rs` still emits `LAUNCH_ARGS host=robot1` for every
arg-bound image. cmake does not reject an unknown keyword — it collects it into
`UNPARSED_ARGUMENTS`, which `nano_ros_add_executable` splices into `_srcs` and
forwards as `SOURCES`, so two words became positional source files.

## Was the capability live or already dead? — LIVE, measured

The removal's note reads as if it was dead, so this was measured rather than
assumed, at both frames:

| invocation | result |
| --- | --- |
| `nros model-path --launch multihost.launch.xml` | `config/multihost_model.yaml` |
| `… --arg host=robot1` | `config/multihost_robot1_model.yaml` |
| `… --arg host=robot2` | `config/multihost_robot2_model.yaml` |

`--arg` was never removed. And the cmake side reached it **by accident** and
still worked — replaying both parses with `cmake -P` on a generated call:

```
pre-W1   verb unparsed=[LAUNCH_ARGS;host=robot1;PANIC;abort]
         -> nano_ros_entry: LAUNCH_ARGS=[host=robot1]  SOURCES=[]
post-W1  -> nano_ros_entry: SOURCES=[LAUNCH_ARGS;host=robot1]
```

So the per-host images were **never silently identical** — the loss was a hard
configure error, which is the good failure. Built and compared on this branch:
`native_robot1_entry` contains `Talker.c` and not `Listener.c`,
`native_robot2_entry` the reverse. One `LAUNCH_ARGS host=` is the whole
difference.

## The silent sibling this turned up

phase-405 W4 retired `MODEL` from `nano_ros_entry` and left
`nano_ros_add_executable` appending it to `_entry_extra`, so a `MODEL <path>`
reached the callee's `UNPARSED_ARGUMENTS` and was **dropped** — an entry built
from the bringup default instead of the model it named. Zero callers passed it,
which is why nobody saw it. It is a `FATAL_ERROR` now, and the `HOST` refusal
beside it stops pointing users at that dead keyword.

## The fix

* `LAUNCH_ARGS` is a multi-value keyword of `nano_ros_entry` again, with its
  `--arg` forward to `nros model-path`.
* `nano_ros_add_executable` **parses and forwards** `LAUNCH_ARGS` and `PANIC`
  instead of letting them ride `UNPARSED_ARGUMENTS`. phase-405 W1 named that
  hazard ("add one positional source to any of them and it breaks") and removed
  the callee's half of it; this is the other half. Three in-tree entries pass
  `PANIC` through this verb.

## The gate

`check-generated-cmake-keywords` — **fast lane**, `just check
generated-cmake-keywords`. It concatenates `cmake_root.rs`'s `out.push_str`
literals into the cmake skeleton the generator writes, attributes each keyword
to the call it appears in, and requires it to be parsed by **every** frame that
call traverses (the verb *and* `nano_ros_entry`). Rule 2 is the same one frame
later: a keyword forwarded through `_entry_extra` must be parsed by
`nano_ros_entry` — which is what `MODEL` violated. A generated `nano_ros_*` call
with no declared chain fails rather than being skipped.

Complement of `check-retired-cmake-keywords`, not a duplicate: that one scans
**tracked** cmake for a caller passing a retired keyword, and a generated root
lives under `build/<coord>/` where nothing tracks it — so the one caller that
runs in CI is exactly the one it cannot see.

**Proof it can fail** (removing `LAUNCH_ARGS` from the parse again, then
reverted):

```
check-generated-cmake-keywords: FAILED
  packages/cli/nros-cli-core/src/builder/cmake_root.rs emits
    `nano_ros_add_executable(… LAUNCH_ARGS …)`,
    cmake/NanoRosEntry.cmake's nano_ros_entry() does not parse it
  cmake/NanoRosVerbs.cmake's nano_ros_add_executable() forwards `LAUNCH_ARGS`,
    cmake/NanoRosEntry.cmake's nano_ros_entry() does not parse it
```

14 self-test cases, run on the normal path.

## The images-differ assertion

* `model_location::per_host_images_resolve_to_distinct_models` walks every
  arg-bound `[image.*]` in `examples/workspaces/{c,mixed}` and requires the
  binding to **change** the resolved model (≥ 4 images, or the sweep is
  vacuous). Mutation-checked: making `launch_to_model_rel` ignore `args` turns
  it red with the two model paths printed.
* `cmake_root::two_images_differing_only_in_args_render_differently` covers the
  emitter end — dropping the emission would leave both other checks green.

## Verification

* `just check fast` — **244 gates OK** on the rebased tree.
* The exact CI coordinate configures and links:
  `scripts/build/workspace-fixtures-build.sh linux --id workspace-c-native-robot1`
  (and `-robot2`, and `workspace-mixed-native-robot1`) all reach
  `built: examples/workspaces/c/build/posix-zenoh-native/cmake/native_robot1_entry`.
* `cargo nextest run -p nros-cli-core -E 'test(cmake_root)'` — 15/15.
* The full `just native build-workspace-fixtures` **cannot finish on this host**:
  no ROS, so `std_msgs` resolves to nothing before cmake is reached. The three
  rows above were built with `NROS_ALLOW_UNRESOLVED_DEPS=1`; the acceptance CI
  actually measures is one green `host-tests` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP
