### PR TITLE
feat(phase-432): W1.2 memory-agreement gate, W2.2 board table, and a live codegen defect it found

### DIFF
--- a/just/check/codegen.just
+++ b/just/check/codegen.just
@@ -332,6 +332,52 @@ pool-inventory:
     # formula, and both still run here; the artifact the book needs falls out.
     @python3 scripts/gen-pool-inventory.py
 
+# phase-432 W1.2 (RFC-0091) — the two packs that describe ONE memory agree.
+#
+# W1.1 deleted `TargetProfile`: codegen models no target. Removing a model of
+# the target without adding a MEASUREMENT of it is worse than either, so this
+# is the measurement. It cross-compiles size/alignment/field-offset probes from
+# the C pack's `typedef struct` and the C++ pack's `#[repr(C)]` Rust glue for
+# one 32-bit non-host target and compares the SYMBOL SIZES — no linking, no
+# execution, and neither side ever reads the other's spelling.
+#
+# The idiomatic Rust pack is deliberately NOT in this pair: it carries no
+# `repr(C)` and shares CDR (a wire format) rather than memory. Neither is the
+# `rmw` pack, whose memory partner is upstream `rosidl_generator_c`. The header
+# of the script has both arguments in full.
+#
+# Skips on a missing cross toolchain or an absent/stale in-tree CLI (the packs
+# are `include_str!`-bundled, so a stale binary would answer for other sources).
+# `--self-test` is its negative control and needs neither.
+[private]
+repr-memory-agreement:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    python3 scripts/check-repr-memory-agreement.py --self-test
+    _missing=""
+    for _t in arm-none-eabi-gcc arm-none-eabi-nm rustc; do
+        command -v "$_t" >/dev/null 2>&1 || _missing="$_missing $_t"
+    done
+    if [ -z "$_missing" ] && [ ! -d "$(rustc --print target-libdir --target armv7a-none-eabi)" ]; then
+        _missing=" rust-std for armv7a-none-eabi (rustup target add armv7a-none-eabi)"
+    fi
+    if [ -n "$_missing" ]; then
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip repr-memory-agreement "missing:$_missing"
+        exit 0
+    fi
+    nros="packages/cli/target/release/nros"
+    # shellcheck source=scripts/build/cli-usable.sh
+    source scripts/build/cli-usable.sh
+    if ! nros_cli_usable "$nros"; then
+        # shellcheck source=scripts/build/check-skip.sh
+        source scripts/build/check-skip.sh
+        nros_check_skip repr-memory-agreement "$nros_cli_unusable_reason"
+        exit 0
+    fi
+    python3 scripts/check-repr-memory-agreement.py --nros "$nros"
+
 # Issue 0268 — the per-build sizes headers (`nros_{,cpp_}config_generated.h`)
 # mirrored onto the consumer include path must equal the copy build.rs wrote.
 # A stale mirror sizes the C `_opaque` buffers from museum data while Rust

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "minijinja",
  "nros-board-common",
  "nros-cargo-profile",
+ "nros-entry-lower",
  "nros-lang",
  "nros-launch-parser",
  "nros-msg-to-idl",
@@ -837,6 +838,13 @@ dependencies = [
  "heapless",
  "log",
  "nros-serdes",
+]
+
+[[package]]
+name = "nros-entry-lower"
+version = "0.5.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -10,6 +10,9 @@ members = [
     # phase-432 W2.1 (RFC-0091 §3) — the language enumeration, declared once.
     # serde-only on purpose: the proc-macro must be able to afford it.
     "nros-lang",
+    # phase-432 W2.2 (RFC-0091 §4) — entry Stage 2. Same budget rule as
+    # nros-lang: the proc-macro must be able to depend on it.
+    "nros-entry-lower",
     "nros-pkg-index",
     "nros-launch-parser",
     "nros-cli-core",
@@ -45,6 +48,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 minijinja = "2.5"
 nros-lang = { path = "nros-lang" }
+nros-entry-lower = { path = "nros-entry-lower" }
 toml = "0.8"
 
 # PyO3 for Python bindings

--- a/packages/cli/nros-cli-core/Cargo.toml
+++ b/packages/cli/nros-cli-core/Cargo.toml
@@ -43,6 +43,7 @@ nros-pkg-index = { path = "../nros-pkg-index" }
 nros-launch-parser = { path = "../nros-launch-parser" }
 thiserror = { workspace = true }
 minijinja = { workspace = true }
+nros-entry-lower = { workspace = true }
 nros-lang = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/cli/nros-cli-core/src/codegen/entry/emit_cpp.rs
+++ b/packages/cli/nros-cli-core/src/codegen/entry/emit_cpp.rs
@@ -65,122 +65,35 @@ fn emit_qos_overrides(out: &mut String, i: usize, overrides: &[QoSOverrideSpec])
     );
 }
 
-/// Board key → C++ Board adapter path.
+/// The C++ board class an entry calls.
 ///
-/// Two adapters ship today (Phase 235): `LinuxBoard` (the host native board —
-/// Linux; the platform port beneath it is `posix`) and
-/// `ZephyrBoard` (embedded Zephyr — RFC-0032 §8a). Per the §8a decision
-/// there is ONE metadata-driven `ZephyrBoard` rather than per-board C++
-/// types: everything board-specific (the Zephyr `BOARD` id, DTS overlay,
-/// default RMW, `west` runner) is supplied by the Phase 215
-/// `nano_ros_use_board(<name>)` cmake import at build time, so the C++
-/// adapter has nothing left to specialize. The `nano_ros_entry` cmake fn
-/// derives the `"zephyr"` board key from `NROS_BOARD_RUNNER` (set by the
-/// Phase 215 import) when the Entry pkg's DEPLOY target is embedded.
-///
-/// An explicit C++ path-like key (`"::nros::board::…"`) passes through
-/// verbatim so callers can name a board adapter the emitter doesn't yet
-/// know.
-fn board_cpp_path(board: &str) -> &str {
-    match board {
-        "native" | "posix" => "::nros::board::LinuxBoard",
-        // Embedded Zephyr family — every Phase 215 Zephyr board (FVP,
-        // qemu-zephyr, …) compiles with `__ZEPHYR__` and shares the one
-        // metadata-driven `ZephyrBoard` adapter.
-        "zephyr" | "fvp-aemv8r-smp" | "armfvp" => "::nros::board::ZephyrBoard",
-        // Phase 238 — embedded NuttX (qemu-arm-virt etc.). Network is up at
-        // kernel boot; shares the EntryNodeRuntime via the `NuttxBoard`
-        // lifecycle adapter.
-        "nuttx" | "nuttx-qemu-arm" | "nuttx-qemu-riscv" => "::nros::board::NuttxBoard",
-        // Phase 240.6 / phase-263 C2b — embedded FreeRTOS (QEMU MPS2-AN385 + lwIP). The
-        // board's C `startup.c` spawns the app task + starts the scheduler, brings up the
-        // netif, and dispatches to the typed entry's `app_main`, so `FreertosBoard`'s
-        // `run_components` runs WITHOUT re-entering the kernel — same machinery as the
-        // ThreadX/NuttX adapters.
-        // phase-370 — `freertos-posix` is the same adapter: the FreeRTOS POSIX
-        // simulator's `main` is owned by the board too
-        // (`nros-board-freertos-posix/c/freertos_posix_entry.c` creates the app
-        // task and starts the scheduler), so the entry must emit `nros_app_main`
-        // and NOT an `int main`. It is a host process, but the nodes still run
-        // as FreeRTOS TASKS — a plain `int main` would run them on the process
-        // thread and exercise no kernel at all.
-        //
-        // Until it was listed, this key fell through to the `LinuxBoard`
-        // default below, which is a SILENT wrong answer rather than the
-        // configure error that comment assumes: the emitter produced the native
-        // `int main` + `nros_board_native_run_components_named` shape, and the
-        // build got as far as the link before `app_main` came up undefined.
-        // phase-372 W2 — the S32Z270 RTU (Cortex-R52) joins the family list;
-        // same C startup ownership of `main` as every FreeRTOS board.
-        // phase-385 W1 — QEMU MPS3-AN536 joins on the same terms.
-        "freertos"
-        | "mps2-an385-freertos"
-        | "freertos-posix"
-        | "s32z270-freertos"
-        | "s32z270"
-        | "mps3-an536-freertos"
-        | "an536" => "::nros::board::FreertosBoard",
-        // Phase 246 — Azure RTOS ThreadX family (threadx-linux host sim +
-        // bare-metal qemu-riscv64). The board's C `startup.c` enters the kernel
-        // and dispatches to the typed entry's `app_main` inside the app thread, so
-        // the `ThreadxBoard` adapter runs `run_components` WITHOUT re-entering the
-        // kernel — same `EntryNodeRuntime` machinery as Native/NuttX/Zephyr.
-        "threadx" | "threadx-linux" | "threadx-qemu-riscv64" | "qemu-riscv64-threadx" => {
-            "::nros::board::ThreadxBoard"
-        }
-        // An explicit, already-qualified C++ board path passes through.
-        b if b.starts_with("::nros::board::") => b,
-        // Unknown / future board keys fall back to LinuxBoard with the
-        // assumption the cmake-side configure will have already errored
-        // on the DEPLOY check (`nano_ros_entry` requires a BOARD for
-        // non-`native` DEPLOY). Keeping the default as LinuxBoard lets
-        // unit tests cover the unhappy path without teaching the emitter
-        // every embedded board prematurely.
-        _ => "::nros::board::LinuxBoard",
+/// phase-432 W2.2 — this is a RENDERING of the board family, not a second
+/// table. The nineteen board keys collapse onto five families in
+/// `nros_entry_lower::board_family`, which is the neutral fact; a `::nros::board::`
+/// path is C++'s spelling of it and belongs here, in the emitter, rather than
+/// in the lowering. RFC-0091 §8b found the first draft leaking exactly this
+/// string into the IR, where a pure-C or Zig pack could not use it.
+fn board_cpp_path(board: &str) -> &'static str {
+    match nros_entry_lower::board_family(board) {
+        nros_entry_lower::BoardFamily::Native => "::nros::board::LinuxBoard",
+        nros_entry_lower::BoardFamily::Zephyr => "::nros::board::ZephyrBoard",
+        nros_entry_lower::BoardFamily::Nuttx => "::nros::board::NuttxBoard",
+        nros_entry_lower::BoardFamily::Freertos => "::nros::board::FreertosBoard",
+        nros_entry_lower::BoardFamily::Threadx => "::nros::board::ThreadxBoard",
     }
 }
 
-/// phase-263 C2 (issue 0097) — does this board boot via the RTOS `startup.c`
-/// (`nros_app_main` + `NROS_APP_MAIN_REGISTER_VOID`) rather than a plain `int main`?
-/// Every non-native board does: the board's `startup.c` owns `main` (kernel enter →
-/// app thread) and dispatches to the entry's `app_main`, so the LAUNCH entry must NOT
-/// define `int main` (it would double-main / never run under the kernel). Native keeps
-/// the POSIX `int main`.
-/// The boot wrapper a generated entry gets, derived from the board.
+/// The boot wrapper a generated entry gets.
 ///
-/// Issue 1003 — ONE derivation, used by both the per-tier and the
-/// single-executor path.
-///
-/// The two used to spell the branch chain separately, and they spelled it
-/// DIFFERENTLY: the per-tier path tested `freertos || nuttx` where the
-/// single-executor path tested `board_is_embedded`. That reads like a drift
-/// bug and is not one — `use_run_tiers` already excludes every embedded board
-/// except those three, so ThreadX (the only board the two predicates disagree
-/// about) cannot reach the per-tier chain at all, and both produced the same
-/// wrapper for every board that reaches them.
-///
-/// It is still worth one derivation: establishing that equivalence takes a
-/// reachability argument about a condition seventy lines away, and that
-/// argument has to be redone by hand every time either chain is touched. A
-/// board added to `use_run_tiers` tomorrow would make the difference real.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum BootShape {
-    /// The kernel calls `main(void)` directly (Zephyr).
-    Kernel,
-    /// The board's `startup.c` owns `main` and dispatches to `nros_app_main`.
-    App,
-    /// A host process keeping the POSIX `int main(argc, argv)`.
-    Host,
-}
+/// phase-432 W2.2 — re-exported from `nros-entry-lower`, which is where the
+/// derivation lives now. It was computed here from a board-string match, and
+/// the proc-macro computed the same thing a third time; a crate the macro can
+/// afford is what lets both stop.
+pub(crate) use nros_entry_lower::BootShape;
 
+/// The boot shape for a board key.
 pub(crate) fn boot_shape(board: &str) -> BootShape {
-    if board_is_zephyr(board) {
-        BootShape::Kernel
-    } else if board_is_embedded(board) {
-        BootShape::App
-    } else {
-        BootShape::Host
-    }
+    nros_entry_lower::board_family(board).boot_shape()
 }
 
 /// Wrap `call` — the board call whose value the entry returns — in the board's
@@ -208,7 +121,7 @@ fn emit_boot_wrapper(out: &mut String, shape: BootShape, call: &str) {
 }
 
 pub(crate) fn board_is_embedded(board: &str) -> bool {
-    board_cpp_path(board) != "::nros::board::LinuxBoard"
+    nros_entry_lower::board_family(board).is_embedded()
 }
 
 /// phase-263 C2d — Zephyr is the exception among embedded boards: the Zephyr kernel
@@ -220,7 +133,7 @@ pub(crate) fn board_is_embedded(board: &str) -> bool {
 /// in via the compile-time `CONFIG_NROS_ZENOH_LOCATOR` Kconfig (read through the
 /// `NROS_ENTRY_LOCATOR` default in `<nros/main.hpp>`), not a baked `-D`.
 pub(crate) fn board_is_zephyr(board: &str) -> bool {
-    board_cpp_path(board) == "::nros::board::ZephyrBoard"
+    nros_entry_lower::board_family(board) == nros_entry_lower::BoardFamily::Zephyr
 }
 
 /// Phase 274.W3 — FreeRTOS embedded boards support `run_tiers` (one RTOS task per tier
@@ -230,7 +143,7 @@ pub(crate) fn board_is_zephyr(board: &str) -> bool {
 /// the Rust `run_tiers_entry`. The generated entry emits `nros_app_main` +
 /// `NROS_APP_MAIN_REGISTER_VOID`, calling `FreertosBoard::run_tiers` (RFC-0015 §5).
 pub(crate) fn board_is_freertos_embedded(board: &str) -> bool {
-    board_cpp_path(board) == "::nros::board::FreertosBoard"
+    nros_entry_lower::board_family(board) == nros_entry_lower::BoardFamily::Freertos
 }
 
 /// phase-281 W3 (nuttx) — NuttX embedded boards support `run_tiers` (one pthread
@@ -242,7 +155,7 @@ pub(crate) fn board_is_freertos_embedded(board: &str) -> bool {
 /// path calls `app_main`, like FreeRTOS — NOT Zephyr's `main(void)`), calling
 /// `NuttxBoard::run_tiers` (RFC-0015 §5).
 pub(crate) fn board_is_nuttx(board: &str) -> bool {
-    board_cpp_path(board) == "::nros::board::NuttxBoard"
+    nros_entry_lower::board_family(board) == nros_entry_lower::BoardFamily::Nuttx
 }
 
 /// Phase 240.2 (RFC-0043) — **typed** entry emitter. Routes each launch node to

--- a/packages/cli/nros-entry-lower/Cargo.toml
+++ b/packages/cli/nros-entry-lower/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nros-entry-lower"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Stage 2 of the ENTRY codegen pipeline (RFC-0091 §4): board identity, boot shape and the facts every language pack renders from. Dependency-light on purpose — the `nros::main!()` proc-macro must be able to afford it (issue 0083)."
+
+[dependencies]
+serde = { workspace = true }

--- a/packages/cli/nros-entry-lower/src/lib.rs
+++ b/packages/cli/nros-entry-lower/src/lib.rs
@@ -1,0 +1,251 @@
+//! Stage 2 of the ENTRY pipeline: the facts every language pack renders from.
+//!
+//! RFC-0091 §4 / phase-432 W2.2. The entry emitters each derived these
+//! independently — and the `nros::main!()` proc-macro derived them a third
+//! time, because it cannot depend on `nros-cli-core` (issue 0083: that pulled
+//! the whole planner into every USER's entry build).
+//!
+//! ## The dependency budget is the design constraint
+//!
+//! This crate exists to be adoptable by that proc-macro. Its dependency list
+//! is `serde` today and may grow only to what the macro already accepts
+//! (`nros-pkg-index`, `nros-launch-parser`, `nros-orchestration-ir`). A heavy
+//! dependency here lands in every downstream user's build, which is the force
+//! that produced the duplication this crate removes. `eyre` in particular
+//! stays out: a leaf carries a plain error type, as `nros-lang` does.
+//!
+//! ## What belongs here, and what does not
+//!
+//! COMPUTATION belongs here: which family a board key names, which boot shape
+//! that family has, the encodings the ABI fixes. SPELLING does not — RFC-0091
+//! §8b found the first draft leaking C++ into this stage as a `board_path`
+//! like `::nros::board::LinuxBoard`, which a pure-C or Zig pack cannot use.
+//! The neutral fact is the board's IDENTITY; how that becomes a call is the
+//! pack's business.
+
+#![forbid(unsafe_code)]
+#![no_std]
+
+/// The board families the entry pipeline distinguishes.
+///
+/// Nineteen board keys collapse onto five families. The KEY is what a user
+/// writes and what cmake passes; the FAMILY is what the lowering reasons
+/// about, and what a pack turns into a call.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BoardFamily {
+    /// The host build (`native`, `posix`) — and the fallback for an
+    /// unrecognised key, see [`board_family`].
+    Native,
+    Zephyr,
+    Nuttx,
+    Freertos,
+    Threadx,
+}
+
+/// The boot wrapper a generated entry gets.
+///
+/// Derived from the family, once. It used to be spelled separately in the
+/// per-tier and single-executor paths of `emit_cpp`, and the two spellings
+/// tested DIFFERENT predicates — they agreed only because a condition seventy
+/// lines away excluded the one board they disagree about.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BootShape {
+    /// The kernel calls `main(void)` directly (Zephyr).
+    Kernel,
+    /// The board's `startup.c` owns `main` and dispatches to `nros_app_main`.
+    App,
+    /// A host process keeping the POSIX `int main(argc, argv)`.
+    Host,
+}
+
+impl BoardFamily {
+    /// Every family, in a stable order — so a consumer that must handle all of
+    /// them iterates rather than lists, and cannot go stale.
+    pub const ALL: [BoardFamily; 5] = [
+        BoardFamily::Native,
+        BoardFamily::Zephyr,
+        BoardFamily::Nuttx,
+        BoardFamily::Freertos,
+        BoardFamily::Threadx,
+    ];
+
+    /// Does this family boot through the board's own `startup.c`?
+    ///
+    /// Everything except the host: the board owns `main` and dispatches to the
+    /// entry's `app_main`, so a generated `int main` would be a second `main`
+    /// in an image whose board already defines one. Zephyr is embedded but the
+    /// KERNEL calls `main(void)`, which is why boot shape is three-valued and
+    /// not this predicate.
+    pub fn is_embedded(self) -> bool {
+        self != BoardFamily::Native
+    }
+
+    /// The boot wrapper this family's entry needs.
+    pub fn boot_shape(self) -> BootShape {
+        match self {
+            BoardFamily::Zephyr => BootShape::Kernel,
+            BoardFamily::Native => BootShape::Host,
+            BoardFamily::Nuttx | BoardFamily::Freertos | BoardFamily::Threadx => BootShape::App,
+        }
+    }
+
+    /// The family's canonical name — the same string the serde repr uses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BoardFamily::Native => "native",
+            BoardFamily::Zephyr => "zephyr",
+            BoardFamily::Nuttx => "nuttx",
+            BoardFamily::Freertos => "freertos",
+            BoardFamily::Threadx => "threadx",
+        }
+    }
+}
+
+/// Which family a board key names.
+///
+/// An unrecognised key falls back to [`BoardFamily::Native`], preserving the
+/// behaviour the C++ emitter had: cmake has already errored on a missing
+/// `BOARD` for a non-native `DEPLOY` by the time codegen runs, so this
+/// fallback exists to let unit tests cover the unhappy path without teaching
+/// the lowering every embedded board prematurely. It is a deliberate choice
+/// and not a silent default — a NEW board key that reaches production without
+/// a row here builds as a host image, which fails loudly at link.
+pub fn board_family(board: &str) -> BoardFamily {
+    match board {
+        "native" | "posix" => BoardFamily::Native,
+        // Every Phase 215 Zephyr board (FVP, qemu-zephyr, …) compiles with
+        // `__ZEPHYR__` and shares the one metadata-driven adapter.
+        "zephyr" | "fvp-aemv8r-smp" | "armfvp" => BoardFamily::Zephyr,
+        // Phase 238 — network is up at kernel boot; shares the lifecycle
+        // adapter.
+        "nuttx" | "nuttx-qemu-arm" | "nuttx-qemu-riscv" => BoardFamily::Nuttx,
+        // Phase 240.6 / phase-263 C2b, plus phase-370's `freertos-posix` and
+        // phase-372/385's S32Z270 and MPS3-AN536. `freertos-posix` is a HOST
+        // process whose nodes still run as FreeRTOS TASKS, so it belongs here
+        // and not with `native`: it once fell through to the host default,
+        // which is a silent wrong answer that only surfaced at link when
+        // `app_main` came up undefined.
+        "freertos"
+        | "mps2-an385-freertos"
+        | "freertos-posix"
+        | "s32z270-freertos"
+        | "s32z270"
+        | "mps3-an536-freertos"
+        | "an536" => BoardFamily::Freertos,
+        // Phase 246 — Azure RTOS ThreadX (host sim + bare-metal qemu-riscv64).
+        "threadx" | "threadx-linux" | "threadx-qemu-riscv64" | "qemu-riscv64-threadx" => {
+            BoardFamily::Threadx
+        }
+        _ => BoardFamily::Native,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every key the C++ emitter recognised, and the family it must land in.
+    /// This is the table the emitters used to each carry a copy of.
+    const KEYS: &[(&str, BoardFamily)] = &[
+        ("native", BoardFamily::Native),
+        ("posix", BoardFamily::Native),
+        ("zephyr", BoardFamily::Zephyr),
+        ("fvp-aemv8r-smp", BoardFamily::Zephyr),
+        ("armfvp", BoardFamily::Zephyr),
+        ("nuttx", BoardFamily::Nuttx),
+        ("nuttx-qemu-arm", BoardFamily::Nuttx),
+        ("nuttx-qemu-riscv", BoardFamily::Nuttx),
+        ("freertos", BoardFamily::Freertos),
+        ("mps2-an385-freertos", BoardFamily::Freertos),
+        ("freertos-posix", BoardFamily::Freertos),
+        ("s32z270-freertos", BoardFamily::Freertos),
+        ("s32z270", BoardFamily::Freertos),
+        ("mps3-an536-freertos", BoardFamily::Freertos),
+        ("an536", BoardFamily::Freertos),
+        ("threadx", BoardFamily::Threadx),
+        ("threadx-linux", BoardFamily::Threadx),
+        ("threadx-qemu-riscv64", BoardFamily::Threadx),
+        ("qemu-riscv64-threadx", BoardFamily::Threadx),
+    ];
+
+    #[test]
+    fn every_known_board_key_lands_in_its_family() {
+        for (key, want) in KEYS {
+            assert_eq!(board_family(key), *want, "board key `{key}`");
+        }
+        assert_eq!(KEYS.len(), 19, "a key was added or removed without a row");
+    }
+
+    /// `freertos-posix` is the trap this table exists to hold. It is a host
+    /// PROCESS, so it reads like `native` — but its nodes run as FreeRTOS
+    /// tasks and its `startup.c` owns `main`, so a host `int main` compiles
+    /// and then fails at link on an undefined `app_main`.
+    #[test]
+    fn freertos_posix_is_freertos_not_native() {
+        assert_eq!(board_family("freertos-posix"), BoardFamily::Freertos);
+        assert_eq!(
+            board_family("freertos-posix").boot_shape(),
+            BootShape::App,
+            "a host `int main` here is a second main"
+        );
+    }
+
+    /// The boot shape is three-valued for a reason: Zephyr is embedded AND
+    /// takes the host-looking `main(void)`, so `is_embedded` cannot decide it.
+    #[test]
+    fn zephyr_is_embedded_but_boots_through_main() {
+        assert!(BoardFamily::Zephyr.is_embedded());
+        assert_eq!(BoardFamily::Zephyr.boot_shape(), BootShape::Kernel);
+        assert_ne!(BoardFamily::Zephyr.boot_shape(), BootShape::Host);
+    }
+
+    /// ThreadX is the board the two former spellings in `emit_cpp` disagreed
+    /// about — one tested `freertos || nuttx`, the other `is_embedded`. Pinned
+    /// here so the one derivation stays right about it on its own terms.
+    #[test]
+    fn threadx_boots_through_the_board_not_a_host_main() {
+        assert_eq!(BoardFamily::Threadx.boot_shape(), BootShape::App);
+        assert_eq!(
+            BoardFamily::Threadx.boot_shape(),
+            BoardFamily::Nuttx.boot_shape()
+        );
+    }
+
+    #[test]
+    fn an_unknown_key_falls_back_to_native() {
+        assert_eq!(board_family("zigos"), BoardFamily::Native);
+        assert_eq!(board_family(""), BoardFamily::Native);
+    }
+
+    #[test]
+    fn only_native_is_not_embedded() {
+        for f in BoardFamily::ALL {
+            assert_eq!(
+                f.is_embedded(),
+                f != BoardFamily::Native,
+                "{} embeddedness",
+                f.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn all_is_exhaustive() {
+        for f in BoardFamily::ALL {
+            // Exhaustive match: a new family fails to compile here first.
+            let named = match f {
+                BoardFamily::Native => "native",
+                BoardFamily::Zephyr => "zephyr",
+                BoardFamily::Nuttx => "nuttx",
+                BoardFamily::Freertos => "freertos",
+                BoardFamily::Threadx => "threadx",
+            };
+            assert_eq!(named, f.as_str());
+        }
+        assert_eq!(BoardFamily::ALL.len(), 5);
+    }
+}

--- a/packages/cli/rosidl-codegen/src/generator/cpp.rs
+++ b/packages/cli/rosidl-codegen/src/generator/cpp.rs
@@ -674,50 +674,67 @@ pub fn generate_cpp_action_package(
         size: usize,
     }
 
-    let build_part = |part_name: &str, msg: &Message| -> Result<ActionPart, GeneratorError> {
-        let struct_name = format!("{}_action_{}_{}_t", c_pkg_name, act_snake, part_name);
-        let (cpp_f, ffi_f, seq_s) = build_fields(
-            &msg.fields,
-            &struct_name,
-            Some(package_name),
-            &format!("{action_name}_{part_name}"),
-            resolver,
-        )?;
-        let constants = build_constants(&msg.constants);
-        let size = compute_serialized_size_max(&ffi_f);
-        Ok(ActionPart {
-            publish_fn: format!(
-                "nros_cpp_publish_{}_action_{}_{}",
-                c_pkg_name, act_snake, part_name
-            ),
-            serialize_fn: format!(
-                "nros_cpp_serialize_{}_action_{}_{}",
-                c_pkg_name, act_snake, part_name
-            ),
-            deser_fn: format!(
-                "nros_cpp_deserialize_{}_action_{}_{}",
-                c_pkg_name, act_snake, part_name
-            ),
-            ser_fn: format!(
-                "serialize_{}_action_{}_{}_fields",
-                c_pkg_name, act_snake, part_name
-            ),
-            deser_fn_inner: format!(
-                "deserialize_{}_action_{}_{}_fields",
-                c_pkg_name, act_snake, part_name
-            ),
-            struct_name,
-            cpp_fields: cpp_f,
-            ffi_fields: ffi_f,
-            seq_structs: seq_s,
-            constants,
-            size,
-        })
-    };
+    // `part_name` is the C IDENTIFIER half (`goal`), `key_part` the PAYLOAD NAME
+    // half (`Goal`). They are two different vocabularies and this closure needs
+    // both: the struct is `..._action_probe_goal_t`, while the RFC-0033 capacity
+    // key is `<pkg>/<Action>_Goal.<field>` — the spelling `nros-codegen.toml`
+    // uses and the spelling the C (`action.rs`) and Rust generators already
+    // look up.
+    //
+    // phase-432 W1.2 — found by `check-repr-memory-agreement` on its first run.
+    // This site passed the lowercase `part_name` for BOTH, so every C++ action
+    // payload looked up `Probe_goal.waypoints`, matched nothing, and fell back
+    // to the built-in capacity: the C pack emitted `int64_t data[8]` for a
+    // `cap = 8` field while the C++ pack emitted `FixedSequence<int64_t, 64>`.
+    // A miss in a capacity resolver is silent by construction, so nothing said
+    // so — the two packs simply described different memory for one lowered
+    // field. `generate_cpp_service_package` spells `{service_name}_Request`
+    // correctly, which is why services were unaffected.
+    let build_part =
+        |part_name: &str, key_part: &str, msg: &Message| -> Result<ActionPart, GeneratorError> {
+            let struct_name = format!("{}_action_{}_{}_t", c_pkg_name, act_snake, part_name);
+            let (cpp_f, ffi_f, seq_s) = build_fields(
+                &msg.fields,
+                &struct_name,
+                Some(package_name),
+                &format!("{action_name}_{key_part}"),
+                resolver,
+            )?;
+            let constants = build_constants(&msg.constants);
+            let size = compute_serialized_size_max(&ffi_f);
+            Ok(ActionPart {
+                publish_fn: format!(
+                    "nros_cpp_publish_{}_action_{}_{}",
+                    c_pkg_name, act_snake, part_name
+                ),
+                serialize_fn: format!(
+                    "nros_cpp_serialize_{}_action_{}_{}",
+                    c_pkg_name, act_snake, part_name
+                ),
+                deser_fn: format!(
+                    "nros_cpp_deserialize_{}_action_{}_{}",
+                    c_pkg_name, act_snake, part_name
+                ),
+                ser_fn: format!(
+                    "serialize_{}_action_{}_{}_fields",
+                    c_pkg_name, act_snake, part_name
+                ),
+                deser_fn_inner: format!(
+                    "deserialize_{}_action_{}_{}_fields",
+                    c_pkg_name, act_snake, part_name
+                ),
+                struct_name,
+                cpp_fields: cpp_f,
+                ffi_fields: ffi_f,
+                seq_structs: seq_s,
+                constants,
+                size,
+            })
+        };
 
-    let goal = build_part("goal", &action.spec.goal)?;
-    let result = build_part("result", &action.spec.result)?;
-    let feedback = build_part("feedback", &action.spec.feedback)?;
+    let goal = build_part("goal", "Goal", &action.spec.goal)?;
+    let result = build_part("result", "Result", &action.spec.result)?;
+    let feedback = build_part("feedback", "Feedback", &action.spec.feedback)?;
 
     let dependencies = {
         let mut deps = extract_deps(&action.spec.goal.fields);

--- a/scripts/check-repr-memory-agreement.py
+++ b/scripts/check-repr-memory-agreement.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+"""phase-432 W1.2 — the two packs that describe ONE memory agree about it.
+
+WHAT THIS GATES, AND WHAT IT DELIBERATELY DOES NOT
+--------------------------------------------------
+W1.1 deleted `TargetProfile`: codegen models no target at all. Removing a model
+of the target without adding a MEASUREMENT of it is strictly worse than either,
+so this is the measurement.
+
+The pair is chosen by asking which two artifacts a single byte range is read
+through, not by which two look similar:
+
+  * `packs/c/message.h.jinja`         -> `typedef struct pkg_msg_name {...}`
+  * `packs/cpp/message_types.rs.jinja`-> `#[repr(C)] pub struct pkg_msg_name_t`
+
+The C++ pack's Rust glue receives a `*const c_void` that points at a C/C++
+object and reinterprets it as its `repr(C)` struct. Rust `repr(C)` and the C
+compiler follow the SAME ABI, so the two agree BY CONSTRUCTION unless the two
+pack filters (`c_type` + `c_array_suffix` vs `cpp_repr_c_type`) SPELL the same
+lowered field differently. That spelling is the whole hazard, and it is what
+this measures.
+
+NOT gated, on purpose:
+
+  * The IDIOMATIC Rust pack (`packs/nros/*.jinja`, what `nros generate rust`
+    emits) carries no `repr(C)` anywhere. It shares CDR with the C header --
+    a wire format, target-independent by specification -- and NOT memory.
+    Gating that pair would assert a property nobody needs.
+  * The `packs/rmw/*.jinja` pack also emits `repr(C)`, but its memory partner
+    is upstream ROS `rosidl_generator_c` (`crate::rosidl_runtime_rs::String` is
+    the `{char*, size, cap}` trio rclcpp's C generator emits), NOT this repo's C
+    pack. Our C header spells an unbounded string `char[256]`. Those two are
+    SUPPOSED to differ; pairing them would be the same mistake one pack over.
+
+HOW IT MEASURES
+---------------
+Neither side is asked to describe the other. Each side is asked, in its own
+language, for numbers:
+
+    C     char probe__X__size[sizeof(X) + 1];
+          char probe__X__f__a[offsetof(X, a) + 1];
+    Rust  #[no_mangle] static probe__X__size: [u8; size_of::<X>() + 1]
+          #[no_mangle] static probe__X__f__a: [u8; offset_of!(X, a) + 1]
+
+Both are cross-compiled for the SAME non-host target (32-bit `armv7a-none-eabi`
+/ `arm-none-eabi-gcc -march=armv7-a`) to object files -- no linking, no
+execution -- and the symbol SIZES are compared with `nm --print-size`. The `+ 1`
+exists only so a zero offset still produces a sized symbol.
+
+A 32-bit target is the point, not a convenience: `size_t` and pointers are 4
+bytes there and 8 on the host, so the RFC-0033 `heap` containers
+(`{T* data; size_t size; size_t capacity;}` vs `{*mut T, usize, usize}`) are
+measured where the answer actually depends on the target.
+
+WHAT A MISMATCH LOOKS LIKE
+--------------------------
+Three properties per struct pair, so a fault has somewhere to land:
+
+  * total size + alignment   -- a width or capacity that differs
+  * every top-level offset   -- a reordering, or an earlier field's size
+  * every sub-field offset of an anonymous C container (`{size, data}` vs
+    `{data, size, capacity}`) -- the sequence-container shape, which a
+    top-level offset cannot see because the container is ONE field
+
+Field NAMES are compared first: a pack that renames a field is a mismatch this
+reports directly rather than as a number.
+
+CORPUS
+------
+`packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus` -- the same
+in-tree corpus `codegen_fingerprint` hashes, so a shape added for one is covered
+by the other. It needs no ROS install and no ament index. Both storage arms are
+run: `inline` (empty resolver -- fixed arrays) and `configured`
+(`nros-codegen.toml` -- `heap` pointers and `borrowed` views).
+
+The packs reach this gate through the BUILT `nros` binary (`include_str!`
+bundles them), exactly as `codegen_fingerprint` does -- so a stale CLI would
+answer for sources that are no longer in the tree. `nros_cli_usable` in the
+recipe is what makes that a SKIP rather than a wrong verdict.
+
+`--self-test` is the negative control: it re-runs the comparator over a
+deliberately perturbed reading and requires it to report. A gate that can only
+say OK is not evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CORPUS = REPO / "packages/cli/rosidl-codegen/tests/fixtures/fingerprint-corpus"
+# The one hand-written C header the generated ones reach for. `borrowed` fields
+# are declared with its types, so the agreement spans a generated Rust struct
+# and an AUTHORED C one -- exactly the pairing issue 0346 created.
+VIEW_H = REPO / "packages/api/nros-c/include/nros/view.h"
+
+# One target, named in one place. 32-bit so pointer/size_t width is exercised.
+RUST_TARGET = "armv7a-none-eabi"
+CC_FLAGS = ["-march=armv7-a", "-ffreestanding", "-fno-common", "-std=gnu11"]
+
+PROBE = "nros_repr_probe"
+
+# C-pack structs with NO counterpart in the C++ pack's Rust glue, and why.
+#
+# A two-way ratchet: an unlisted orphan is a failure, and a listed one that
+# GAINS a counterpart is also a failure, so the map can only shrink. It is
+# empty, and both halves have already earned their keep -- the first run put
+# `fingerprint_corpus_action_probe_goal_View` here, the capacity-key fix in
+# `generate_cpp_action_package` then gave it a counterpart, and the second half
+# of the ratchet is what said so instead of leaving a permanent excuse behind.
+C_ONLY_EXPECTED: dict[str, str] = {}
+
+# C spellings that are types rather than struct references. Anything else that
+# looks like an identifier in a field declaration must resolve to a struct this
+# script extracted, or the script says so instead of guessing.
+C_BUILTIN = {
+    "bool",
+    "char",
+    "double",
+    "float",
+    "int",
+    "long",
+    "short",
+    "signed",
+    "unsigned",
+    "void",
+    "size_t",
+    "ptrdiff_t",
+    "int8_t",
+    "int16_t",
+    "int32_t",
+    "int64_t",
+    "uint8_t",
+    "uint16_t",
+    "uint32_t",
+    "uint64_t",
+    "struct",
+    "const",
+}
+
+
+# --------------------------------------------------------------------------
+# extraction
+# --------------------------------------------------------------------------
+
+
+def _balanced_body(text: str, open_at: int) -> tuple[str, int]:
+    """The `{...}` starting at `open_at`, and the index just past its `}`."""
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_at + 1 : i], i + 1
+    raise SystemExit(f"{PROBE}: unbalanced braces at offset {open_at}")
+
+
+def _split_members(body: str) -> list[str]:
+    """Depth-0 `;`-separated declarations of a struct body."""
+    out, depth, cur = [], 0, []
+    for ch in body:
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        if ch == ";" and depth == 0:
+            decl = "".join(cur).strip()
+            if decl:
+                out.append(decl)
+            cur = []
+        else:
+            cur.append(ch)
+    return out
+
+
+def _member_name(decl: str) -> str:
+    """The declarator name of one C member declaration (no trailing `;`)."""
+    # Drop array suffixes and pointer-to-array parens so the name is the last
+    # token: `char data[64][256]` -> `char data`; `char (*data)[8]` -> handled
+    # by the paren arm below.
+    m = re.search(r"\(\s*\*\s*([A-Za-z_]\w*)\s*\)", decl)
+    if m:
+        return m.group(1)
+    stripped = re.sub(r"\[[^\]]*\]", "", decl).strip()
+    stripped = re.sub(r"\*", " ", stripped)
+    toks = stripped.split()
+    if not toks:
+        raise SystemExit(f"{PROBE}: cannot name declarator in `{decl}`")
+    return toks[-1]
+
+
+def _struct_info(body: str) -> dict:
+    fields, subs = [], {}
+    for decl in _split_members(body):
+        name = _member_name(decl)
+        fields.append(name)
+        if re.match(r"^struct\s*\{", decl):
+            inner, _ = _balanced_body(decl, decl.index("{"))
+            subs[name] = [_member_name(d) for d in _split_members(inner)]
+    return {"body": body, "fields": fields, "subs": subs}
+
+
+def extract_c_macro_structs(text: str) -> dict[str, dict]:
+    """`view.h`'s LE views, which a macro defines once and instantiates nine times.
+
+    They are still AUTHORED C, so they are extracted rather than re-spelled: the
+    macro's own `typedef struct {...}` body is read, its `CT` parameter is bound
+    from the invocation lines at the bottom of the header, and the result is a
+    normal struct entry. A `view`-mode numeric sequence field lands on one of
+    these, so without them the `configured` arm cannot be probed at all.
+    """
+    ctypes = {
+        m.group(1): m.group(2).strip()
+        for m in re.finditer(r"NROS__LE_VIEW_(?:INT|FLT)\(\s*(\w+)\s*,\s*([^,]+),", text)
+    }
+    m = re.search(r"#define\s+NROS__LE_VIEW_COMMON\(\s*SUFFIX\s*,\s*CT\s*\)", text)
+    if not m or not ctypes:
+        return {}
+    tail = text[m.end() :]
+    end = re.search(r"(?<!\\)\n\s*\n", tail)
+    macro = re.sub(r"\\\n", "\n", tail[: end.start() if end else len(tail)])
+    tm = re.search(r"typedef\s+struct\s*\{", macro)
+    if not tm:
+        return {}
+    body, after = _balanced_body(macro, tm.end() - 1)
+    if not re.match(r"\s*nros_le_slice_view_##SUFFIX##_t\s*;", macro[after:]):
+        return {}
+    out = {}
+    for sfx, elem in ctypes.items():
+        out[f"nros_le_slice_view_{sfx}_t"] = _struct_info(re.sub(r"\bCT\b", elem, body))
+    return out
+
+
+def extract_c_structs(text: str) -> dict[str, dict]:
+    """`typedef struct <tag>? { ... } NAME;` blocks, by NAME.
+
+    Records the raw body (re-emitted verbatim into the probe TU, so the probe
+    measures the pack's own bytes and not a re-spelling of them), the top-level
+    field names in order, and -- for a field declared as an ANONYMOUS struct --
+    that container's own member names.
+    """
+    out: dict[str, dict] = {}
+    for m in re.finditer(r"\btypedef\s+struct\b[^{;]*\{", text):
+        body, after = _balanced_body(text, m.end() - 1)
+        tail = text[after:]
+        nm = re.match(r"\s*([A-Za-z_]\w*)\s*;", tail)
+        if not nm:
+            continue  # `typedef struct {...} *P;` and friends: not our shape
+        out[nm.group(1)] = _struct_info(body)
+    return out
+
+
+def extract_rust_structs(text: str) -> dict[str, dict]:
+    """`#[repr(C)] pub struct NAME { pub f: T, ... }` blocks, by NAME."""
+    out: dict[str, dict] = {}
+    for m in re.finditer(r"#\[repr\(C\)\]\s*(?:#\[[^\]]*\]\s*)*pub struct\s+(\w+)\s*\{", text):
+        body, _ = _balanced_body(text, m.end() - 1)
+        fields = re.findall(r"\bpub\s+(\w+)\s*:", body)
+        out[m.group(1)] = {"decl": text[m.start() : m.end()] + body + "}", "fields": fields}
+    return out
+
+
+# --------------------------------------------------------------------------
+# corpus generation
+# --------------------------------------------------------------------------
+
+
+def interface_files() -> list[str]:
+    files = (
+        sorted(CORPUS.glob("msg/*.msg"))
+        + sorted(CORPUS.glob("srv/*.srv"))
+        + sorted(CORPUS.glob("action/*.action"))
+    )
+    if not files:
+        raise SystemExit(f"{PROBE}: no interface files under {CORPUS}")
+    return [str(p) for p in files]
+
+
+def generate(nros: str, work: Path, arm: str, configured: bool) -> tuple[Path, Path]:
+    """Emit the C and C++ packs for one storage arm from the SAME corpus."""
+    outs = {}
+    for lang in ("c", "cpp"):
+        out = work / f"{arm}-{lang}"
+        out.mkdir(parents=True, exist_ok=True)
+        args = {
+            "package_name": "fingerprint-corpus",
+            "output_dir": str(out),
+            "interface_files": interface_files(),
+            "dependencies": [],
+            "ros_edition": "humble",
+        }
+        if configured:
+            args["codegen_config"] = str(CORPUS / "nros-codegen.toml")
+        af = work / f"{arm}-{lang}-args.json"
+        af.write_text(json.dumps(args))
+        r = subprocess.run(
+            [nros, "codegen", "--language", lang, "--args-file", str(af)],
+            capture_output=True,
+            text=True,
+        )
+        if r.returncode != 0:
+            raise SystemExit(
+                f"{PROBE}: `nros codegen --language {lang}` failed for the {arm} arm:\n"
+                f"{r.stdout}{r.stderr}"
+            )
+        outs[lang] = out
+    return outs["c"], outs["cpp"]
+
+
+# --------------------------------------------------------------------------
+# probe emission
+# --------------------------------------------------------------------------
+
+
+def topo_order(structs: dict[str, dict]) -> list[str]:
+    """C needs a complete type before it is embedded; Rust does not."""
+    order, seen = [], set()
+
+    def visit(name: str, stack: tuple[str, ...]) -> None:
+        if name in seen:
+            return
+        if name in stack:
+            raise SystemExit(f"{PROBE}: cyclic C struct reference: {' -> '.join(stack + (name,))}")
+        body = structs[name]["body"]
+        for other in structs:
+            if other != name and re.search(rf"\b{re.escape(other)}\b", body):
+                visit(other, stack + (name,))
+        seen.add(name)
+        order.append(name)
+
+    for name in structs:
+        visit(name, ())
+    return order
+
+
+def unresolved_c_types(structs: dict[str, dict]) -> set[str]:
+    """Identifiers used as types that this script did not extract."""
+    known = set(structs) | C_BUILTIN
+    missing: set[str] = set()
+
+    def walk(body: str) -> None:
+        for decl in _split_members(body):
+            declared = {_member_name(decl)}
+            flat = decl
+            while "{" in flat:
+                at = flat.index("{")
+                inner, after = _balanced_body(flat, at)
+                walk(inner)
+                for d in _split_members(inner):
+                    declared.add(_member_name(d))
+                flat = flat[:at] + " " + inner + " " + flat[after:]
+            for tok in re.findall(r"[A-Za-z_]\w*", flat):
+                if tok in declared or tok in known:
+                    continue
+                missing.add(tok)
+
+    for info in structs.values():
+        walk(info["body"])
+    return missing
+
+
+def c_probe_tu(structs: dict[str, dict], pairs: list[str], arm: str) -> str:
+    lines = [
+        "/* generated by scripts/check-repr-memory-agreement.py - do not edit */",
+        "#include <stdint.h>",
+        "#include <stdbool.h>",
+        "#include <stddef.h>",
+        "",
+    ]
+    for name in topo_order(structs):
+        lines.append(f"typedef struct {name} {{{structs[name]['body']}}} {name};")
+    lines.append("")
+    for name in pairs:
+        info = structs[name]
+        lines.append(f"char {sym(arm, name, 'size')}[sizeof({name}) + 1];")
+        lines.append(f"char {sym(arm, name, 'align')}[_Alignof({name}) + 1];")
+        for f in info["fields"]:
+            lines.append(f"char {sym(arm, name, 'f', f)}[offsetof({name}, {f}) + 1];")
+            for sub in info["subs"].get(f, []):
+                lines.append(
+                    f"char {sym(arm, name, 'f', f, sub)}[offsetof({name}, {f}.{sub}) + 1];"
+                )
+    return "\n".join(lines) + "\n"
+
+
+def rust_probe_crate(structs: dict[str, dict], pairs: list[tuple[str, str]], arm: str) -> str:
+    lines = [
+        "// generated by scripts/check-repr-memory-agreement.py - do not edit",
+        "#![no_std]",
+        "#![allow(non_camel_case_types, non_upper_case_globals, dead_code)]",
+        "",
+    ]
+    for name in sorted(structs):
+        lines.append(structs[name]["decl"])
+    lines.append("")
+    for c_name, r_name in pairs:
+        for kind, expr in (
+            ("size", f"core::mem::size_of::<{r_name}>()"),
+            ("align", f"core::mem::align_of::<{r_name}>()"),
+        ):
+            s = sym(arm, c_name, kind)
+            lines.append(
+                f"#[unsafe(no_mangle)] pub static {s}: [u8; {expr} + 1] = [0; {expr} + 1];"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def rust_field_probes(
+    c_structs: dict[str, dict], pairs: list[tuple[str, str]], arm: str
+) -> list[str]:
+    """Offset probes, emitted from the C side's FIELD NAMES only.
+
+    The names are the one thing the two packs must share; the TYPES are never
+    read across. A field the Rust struct does not have is a rustc error naming
+    it, which is the verdict we want anyway.
+    """
+    out = []
+    for c_name, r_name in pairs:
+        info = c_structs[c_name]
+        for f in info["fields"]:
+            for path, sfx in [(f, (f,))] + [
+                (f"{f}.{sub}", (f, sub)) for sub in info["subs"].get(f, [])
+            ]:
+                expr = f"core::mem::offset_of!({r_name}, {path})"
+                s = sym(arm, c_name, "f", *sfx)
+                out.append(
+                    f"#[unsafe(no_mangle)] pub static {s}: [u8; {expr} + 1] = [0; {expr} + 1];"
+                )
+    return out
+
+
+def sym(arm: str, struct: str, kind: str, *rest: str) -> str:
+    parts = [PROBE, arm.replace("-", "_"), struct, kind, *rest]
+    return "__".join(parts)
+
+
+# --------------------------------------------------------------------------
+# compile + read
+# --------------------------------------------------------------------------
+
+
+def nm_sizes(nm: str, obj: Path) -> dict[str, int]:
+    r = subprocess.run(
+        [nm, "--print-size", "--defined-only", str(obj)], capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        raise SystemExit(f"{PROBE}: {nm} failed on {obj}:\n{r.stderr}")
+    out = {}
+    for line in r.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 4 and parts[3].startswith(PROBE):
+            out[parts[3]] = int(parts[1], 16)
+    return out
+
+
+def run(cmd: list[str], what: str) -> None:
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SystemExit(f"{PROBE}: {what} failed:\n{' '.join(cmd)}\n{r.stdout}{r.stderr}")
+
+
+# --------------------------------------------------------------------------
+# comparison
+# --------------------------------------------------------------------------
+
+
+def compare(c_vals: dict[str, int], r_vals: dict[str, int]) -> list[str]:
+    """Every probe present on both sides must report the same number.
+
+    A probe missing from ONE side is reported too: it means a struct or field
+    exists in one pack and not the other, which is a spelling mismatch that
+    happens to be invisible to arithmetic.
+    """
+    problems = []
+    for name in sorted(set(c_vals) | set(r_vals)):
+        cv, rv = c_vals.get(name), r_vals.get(name)
+        # `name` came from the UNION, so at least one side has it; the type
+        # checker cannot see that, and spelling it out is cheaper than an
+        # ignore comment that would also hide a real None later.
+        if cv is None and rv is not None:
+            problems.append(f"  {name}: absent from the C probe, {rv - 1} in Rust")
+        elif rv is None and cv is not None:
+            problems.append(f"  {name}: {cv - 1} in C, absent from the Rust probe")
+        elif cv is None or rv is None:
+            problems.append(f"  {name}: absent from BOTH probes — unreachable")
+        elif cv != rv:
+            problems.append(f"  {name}: C says {cv - 1}, Rust says {rv - 1}")
+    return problems
+
+
+# --------------------------------------------------------------------------
+# driver
+# --------------------------------------------------------------------------
+
+
+def check_arm(
+    arm: str, nros: str, cc: str, nm: str, work: Path, configured: bool
+) -> tuple[int, int, list[str]]:
+    c_dir, cpp_dir = generate(nros, work, arm, configured)
+
+    c_structs: dict[str, dict] = {}
+    # walk-ok: `c_dir` is codegen output this function just produced under a
+    # temp dir — nothing here is tracked, so `git ls-files` would return
+    # nothing. The gate's own text allows scanning for untracked artifacts
+    # scoped to a build dir, which is exactly this.
+    for h in sorted(c_dir.rglob("*.h")):
+        for name, info in extract_c_structs(h.read_text(encoding="utf-8")).items():
+            c_structs[name] = info
+    generated_names = sorted(c_structs)
+
+    rust_structs: dict[str, dict] = {}
+    # walk-ok: same — `cpp_dir` is this run's generated pack output, untracked.
+    for rs in sorted(cpp_dir.rglob("*_types.rs")):
+        for name, info in extract_rust_structs(rs.read_text(encoding="utf-8")).items():
+            prev = rust_structs.get(name)
+            if prev and prev["decl"] != info["decl"]:
+                raise SystemExit(
+                    f"{PROBE}: two different `{name}` declarations in the C++ pack output"
+                )
+            rust_structs[name] = info
+
+    if not generated_names or not rust_structs:
+        raise SystemExit(
+            f"{PROBE}: the {arm} arm produced "
+            f"{len(generated_names)} C struct(s) and {len(rust_structs)} Rust struct(s) "
+            "- a corpus that emits nothing cannot agree about anything"
+        )
+
+    # Types the generated headers reach for but do not define (`nros_view_str_t`
+    # and friends) come from the authored C header, extracted the same way.
+    missing = unresolved_c_types(c_structs)
+    if missing:
+        view_text = VIEW_H.read_text(encoding="utf-8")
+        authored = extract_c_structs(view_text) | extract_c_macro_structs(view_text)
+        for name, info in authored.items():
+            if name in missing:
+                c_structs[name] = info
+        missing = unresolved_c_types(c_structs)
+    if missing:
+        raise SystemExit(
+            f"{PROBE}: the {arm} arm's C output names type(s) this script cannot "
+            f"resolve: {', '.join(sorted(missing))}.\n"
+            f"  They are not defined in the generated headers and not extractable\n"
+            f"  from {VIEW_H.relative_to(REPO)}. Extend the extractor rather than\n"
+            "  dropping the type - a silently skipped type is a gate that stops\n"
+            "  covering whatever it was added for."
+        )
+
+    # Pair by name. `X` -> `X_t`, `X_View` -> `X_t_view`: the only two spellings
+    # the C++ pack uses, and an unpaired generated struct is a failure, not a
+    # skip.
+    pairs: list[tuple[str, str]] = []
+    unpaired: list[str] = []
+    for c_name in generated_names:
+        if c_name.endswith("_View"):
+            r_name = c_name[: -len("_View")] + "_t_view"
+        else:
+            r_name = c_name + "_t"
+        if r_name in rust_structs:
+            if c_name in C_ONLY_EXPECTED:
+                unpaired.append(
+                    f"  {c_name}: recorded in C_ONLY_EXPECTED, but `{r_name}` now EXISTS.\n"
+                    "      The asymmetry is gone -- delete the entry so the pair is compared."
+                )
+            pairs.append((c_name, r_name))
+        elif c_name in C_ONLY_EXPECTED:
+            continue
+        else:
+            unpaired.append(
+                f"  {c_name}: no `{r_name}` in the C++ pack's Rust glue.\n"
+                "      One pack emits a type the other does not. If that is intended,\n"
+                "      record it in C_ONLY_EXPECTED with the reason; do not drop it."
+            )
+    if unpaired:
+        return 0, 0, unpaired
+
+    # Field NAMES first: a renamed field is a mismatch with a better message
+    # than an offset ever gives.
+    name_problems = []
+    for c_name, r_name in pairs:
+        cf, rf = c_structs[c_name]["fields"], rust_structs[r_name]["fields"]
+        if cf != rf:
+            name_problems.append(
+                f"  {c_name}: field names differ\n"
+                f"      C   : {', '.join(cf)}\n"
+                f"      Rust: {', '.join(rf)}"
+            )
+    if name_problems:
+        return len(pairs), 0, name_problems
+
+    c_src = work / f"{arm}-probe.c"
+    c_src.write_text(c_probe_tu(c_structs, [c for c, _ in pairs], arm))
+    c_obj = work / f"{arm}-probe-c.o"
+    run([cc, "-c", *CC_FLAGS, "-o", str(c_obj), str(c_src)], f"the {arm} C probe")
+
+    rs_src = work / f"{arm}-probe.rs"
+    rs_text = rust_probe_crate(rust_structs, pairs, arm)
+    rs_text += "\n".join(rust_field_probes(c_structs, pairs, arm)) + "\n"
+    rs_src.write_text(rs_text)
+    rs_obj = work / f"{arm}-probe-rs.o"
+    run(
+        [
+            "rustc",
+            "--edition",
+            "2024",
+            "--target",
+            RUST_TARGET,
+            "--crate-type",
+            "rlib",
+            "--emit",
+            "obj",
+            "-C",
+            "opt-level=0",
+            "-o",
+            str(rs_obj),
+            str(rs_src),
+        ],
+        f"the {arm} Rust probe",
+    )
+
+    c_vals = nm_sizes(nm, c_obj)
+    r_vals = nm_sizes(nm, rs_obj)
+    if not c_vals or not r_vals:
+        raise SystemExit(
+            f"{PROBE}: the {arm} arm read {len(c_vals)} C and {len(r_vals)} Rust probe "
+            "symbols - a comparison over nothing is not a pass"
+        )
+    return len(pairs), len(c_vals), compare(c_vals, r_vals)
+
+
+def self_test() -> int:
+    """The negative control: the comparator must SAY SO when readings differ.
+
+    A gate whose only demonstrated behaviour is printing OK has not been shown
+    to have any behaviour at all.
+    """
+    base = {f"{PROBE}__x__S__size": 41, f"{PROBE}__x__S__f__a": 9}
+    fails = 0
+
+    if compare(base, dict(base)):
+        print("self-test: identical readings were reported as a mismatch", file=sys.stderr)
+        fails += 1
+
+    perturbed = dict(base)
+    perturbed[f"{PROBE}__x__S__f__a"] = 5
+    if not compare(base, perturbed):
+        print("self-test: a differing field offset was NOT reported", file=sys.stderr)
+        fails += 1
+
+    if not compare(base, {f"{PROBE}__x__S__size": 41}):
+        print("self-test: a probe missing from one side was NOT reported", file=sys.stderr)
+        fails += 1
+
+    if fails == 0:
+        print("repr-memory-agreement self-test OK (3 comparator cases)")
+    return 1 if fails else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--nros", default="packages/cli/target/release/nros")
+    ap.add_argument("--cc", default="arm-none-eabi-gcc")
+    ap.add_argument("--nm", default="arm-none-eabi-nm")
+    ap.add_argument("--keep", action="store_true", help="keep the probe sources for inspection")
+    ap.add_argument("--self-test", action="store_true", help="negative control, no toolchain")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    for tool in (args.cc, args.nm):
+        if shutil.which(tool) is None:
+            raise SystemExit(f"{PROBE}: `{tool}` not on PATH (the recipe should have skipped)")
+
+    tmp_root = REPO / "tmp"
+    tmp_root.mkdir(exist_ok=True)
+    work = Path(tempfile.mkdtemp(prefix="repr-memory-agreement.", dir=tmp_root))
+    try:
+        total_pairs = total_probes = 0
+        problems: list[str] = []
+        for arm, configured in (("inline", False), ("configured", True)):
+            pairs, probes, probs = check_arm(
+                arm, args.nros, args.cc, args.nm, work, configured
+            )
+            total_pairs += pairs
+            total_probes += probes
+            problems += [f"  [{arm}] {p.strip()}" for p in probs]
+        if problems:
+            print(
+                "repr memory agreement FAILED - the C pack and the C++ pack's "
+                f"repr(C) Rust glue describe different memory on {RUST_TARGET}:",
+                file=sys.stderr,
+            )
+            for p in problems:
+                print(p, file=sys.stderr)
+            print(
+                "\n  Both render from ONE lowered field. A disagreement is the two\n"
+                "  pack type filters (`c_type`/`c_array_suffix` vs `cpp_repr_c_type`)\n"
+                "  spelling it differently - fix the filter, not the number.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"repr memory agreement OK ({total_pairs} struct pairs, "
+            f"{total_probes} probes, target {RUST_TARGET}, 2 storage arms)"
+        )
+        return 0
+    finally:
+        if args.keep:
+            print(f"  probe sources kept in {work}")
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-repr-memory-agreement.py
+++ b/scripts/check-repr-memory-agreement.py
@@ -110,12 +110,24 @@ PROBE = "nros_repr_probe"
 # C-pack structs with NO counterpart in the C++ pack's Rust glue, and why.
 #
 # A two-way ratchet: an unlisted orphan is a failure, and a listed one that
-# GAINS a counterpart is also a failure, so the map can only shrink. It is
-# empty, and both halves have already earned their keep -- the first run put
+# GAINS a counterpart is also a failure, so the map can only shrink. Both
+# halves have already earned their keep -- the first run put
 # `fingerprint_corpus_action_probe_goal_View` here, the capacity-key fix in
 # `generate_cpp_action_package` then gave it a counterpart, and the second half
 # of the ratchet is what said so instead of leaving a permanent excuse behind.
-C_ONLY_EXPECTED: dict[str, str] = {}
+C_ONLY_EXPECTED: dict[str, str] = {
+    "fingerprint_corpus_srv_probe_service_handler_t": (
+        "C-only convenience wrapper around the typed service trampoline: a "
+        "callback + context + caller-owned request/response storage + an error "
+        "tally. It carries no wire payload of its own -- the two payload "
+        "structs it embeds ARE paired and compared -- and the Rust side reaches "
+        "the same trampoline through its own typed service API rather than a "
+        "mirrored struct, so there is nothing for it to agree with."
+    ),
+    "fingerprint_corpus_srv_probe_client_handler_t": (
+        "Same shape on the client side, and C-only for the same reason."
+    ),
+}
 
 # C spellings that are types rather than struct references. Anything else that
 # looks like an identifier in a field declaration must resolve to a struct this
@@ -149,6 +161,72 @@ C_BUILTIN = {
 # --------------------------------------------------------------------------
 # extraction
 # --------------------------------------------------------------------------
+
+
+def strip_c_comments(text: str) -> str:
+    """Remove `/*...*/` and `//`/`///` comments, keeping line structure.
+
+    Not cosmetic. Every downstream reader of a struct body treats it as C
+    DECLARATIONS: `_split_members` splits on depth-0 `;`, `_member_name` takes
+    the last token, and `unresolved_c_types` reads every identifier as a type
+    reference. A doc comment defeats all three at once -- the generated typed
+    service handler carries `/// Last NROS_SERVICE_TYPED_* code; ...`, whose
+    `;` FORGES a member named `code` and whose prose ("Your", "Installed",
+    "verbatim") reads as unresolvable type names. Comments cannot change
+    layout, so removing them before extraction loses nothing the probe
+    measures.
+
+    String and char literals are preserved, because a `//` inside one is not a
+    comment; generated C has none in a struct body today, and a stripper that
+    is wrong about that would be a silent corruption rather than a loud one.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"' or c == "'":
+            q = c
+            out.append(c)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == q:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            if j < 0:
+                raise SystemExit(f"{PROBE}: unterminated block comment")
+            out.append("\n" * text.count("\n", i, j))
+            i = j + 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def extract_c_fnptr_typedefs(text: str) -> dict[str, str]:
+    """`typedef R (*NAME)(args);` declarations, by NAME, kept VERBATIM.
+
+    The typed service/client handlers embed one as a field, so the probe TU
+    cannot compile without it. Re-emitted rather than replaced by `void*`:
+    a function pointer is not required to be the size of a data pointer, and
+    the point of this gate is to measure what the pack actually declares.
+    """
+    out: dict[str, str] = {}
+    for m in re.finditer(r"\btypedef\b[^;{}]*?\(\s*\*\s*(\w+)\s*\)\s*\([^;{}]*\)\s*;", text):
+        out[m.group(1)] = m.group(0)
+    return out
 
 
 def _balanced_body(text: str, open_at: int) -> tuple[str, int]:
@@ -342,9 +420,11 @@ def topo_order(structs: dict[str, dict]) -> list[str]:
     return order
 
 
-def unresolved_c_types(structs: dict[str, dict]) -> set[str]:
+def unresolved_c_types(
+    structs: dict[str, dict], fnptrs: dict[str, str] | None = None
+) -> set[str]:
     """Identifiers used as types that this script did not extract."""
-    known = set(structs) | C_BUILTIN
+    known = set(structs) | C_BUILTIN | set(fnptrs or {})
     missing: set[str] = set()
 
     def walk(body: str) -> None:
@@ -368,7 +448,9 @@ def unresolved_c_types(structs: dict[str, dict]) -> set[str]:
     return missing
 
 
-def c_probe_tu(structs: dict[str, dict], pairs: list[str], arm: str) -> str:
+def c_probe_tu(
+    structs: dict[str, dict], pairs: list[str], arm: str, fnptrs: dict[str, str] | None = None
+) -> str:
     lines = [
         "/* generated by scripts/check-repr-memory-agreement.py - do not edit */",
         "#include <stdint.h>",
@@ -376,8 +458,20 @@ def c_probe_tu(structs: dict[str, dict], pairs: list[str], arm: str) -> str:
         "#include <stddef.h>",
         "",
     ]
-    for name in topo_order(structs):
-        lines.append(f"typedef struct {name} {{{structs[name]['body']}}} {name};")
+    order = topo_order(structs)
+    # Forward-declare every tag first so a function-pointer typedef may name a
+    # struct through a pointer before that struct is complete -- which the
+    # generated typed client handler does. Definitions still follow in topo
+    # order, because an EMBEDDED member needs a complete type.
+    for name in order:
+        lines.append(f"typedef struct {name} {name};")
+    lines.append("")
+    for _, decl in sorted((fnptrs or {}).items()):
+        lines.append(decl)
+    if fnptrs:
+        lines.append("")
+    for name in order:
+        lines.append(f"struct {name} {{{structs[name]['body']}}};")
     lines.append("")
     for name in pairs:
         info = structs[name]
@@ -508,13 +602,16 @@ def check_arm(
     c_dir, cpp_dir = generate(nros, work, arm, configured)
 
     c_structs: dict[str, dict] = {}
+    c_fnptrs: dict[str, str] = {}
     # walk-ok: `c_dir` is codegen output this function just produced under a
     # temp dir — nothing here is tracked, so `git ls-files` would return
     # nothing. The gate's own text allows scanning for untracked artifacts
     # scoped to a build dir, which is exactly this.
     for h in sorted(c_dir.rglob("*.h")):
-        for name, info in extract_c_structs(h.read_text(encoding="utf-8")).items():
+        text = strip_c_comments(h.read_text(encoding="utf-8"))
+        for name, info in extract_c_structs(text).items():
             c_structs[name] = info
+        c_fnptrs.update(extract_c_fnptr_typedefs(text))
     generated_names = sorted(c_structs)
 
     rust_structs: dict[str, dict] = {}
@@ -537,14 +634,15 @@ def check_arm(
 
     # Types the generated headers reach for but do not define (`nros_view_str_t`
     # and friends) come from the authored C header, extracted the same way.
-    missing = unresolved_c_types(c_structs)
+    missing = unresolved_c_types(c_structs, c_fnptrs)
     if missing:
-        view_text = VIEW_H.read_text(encoding="utf-8")
+        view_text = strip_c_comments(VIEW_H.read_text(encoding="utf-8"))
         authored = extract_c_structs(view_text) | extract_c_macro_structs(view_text)
         for name, info in authored.items():
             if name in missing:
                 c_structs[name] = info
-        missing = unresolved_c_types(c_structs)
+        c_fnptrs.update(extract_c_fnptr_typedefs(view_text))
+        missing = unresolved_c_types(c_structs, c_fnptrs)
     if missing:
         raise SystemExit(
             f"{PROBE}: the {arm} arm's C output names type(s) this script cannot "
@@ -598,7 +696,7 @@ def check_arm(
         return len(pairs), 0, name_problems
 
     c_src = work / f"{arm}-probe.c"
-    c_src.write_text(c_probe_tu(c_structs, [c for c, _ in pairs], arm))
+    c_src.write_text(c_probe_tu(c_structs, [c for c, _ in pairs], arm, c_fnptrs))
     c_obj = work / f"{arm}-probe-c.o"
     run([cc, "-c", *CC_FLAGS, "-o", str(c_obj), str(c_src)], f"the {arm} C probe")
 


### PR DESCRIPTION
**Stacked on #599** — its commits appear here until that lands. Three new commits on top.

## A live defect the gate found on its first run

`generate_cpp_action_package` passed the lowercase C identifier (`goal`) as the RFC-0033 capacity-resolver key, but the corpus keys on the payload name (`Probe_Goal.waypoints`). Every C++ action payload looked up a key that matched nothing and **silently fell back to the built-in capacity**.

Measured on a `cap = 8` field: C emitted `int64_t data[8]`, C++ emitted `FixedSequence<int64_t, 64>` — a 328-byte struct against 776, field `name` at offset 72 against 520. Two packs rendering **one** lowered field into layouts disagreeing by 448 bytes.

A resolver miss is silent *by construction* — an unmatched key is a default, not an error. That's why 140 green tests didn't see it: the C++ **action** output is in no golden and not in `emit_corpus`.

## W1.2 — the gate, scoped at the pair that actually shares memory

Corrected **twice** by implementing:

- **not** the idiomatic pair — the idiomatic Rust has no `repr(C)`; it shares CDR, a wire format
- **not** `packs/rmw` either — `rust_type_rmw` spells upstream `rosidl_generator_c` shapes (`{char*,size,cap}`) where our C pack spells `char[256]`. Those are *supposed* to differ.

The real partner of `packs/c/message.h.jinja` is `packs/cpp/message_types.rs.jinja`, exact arm by arm.

What it checks is **pack consistency over one IR**, not target modelling: both render from the same lowered field, and `repr(C)` + the C compiler follow the same ABI, so they agree by construction unless the two *filters* spell a field differently. Hence the error text: fix the filter, not the number.

20 struct pairs, 186 probes, cross-compiled to `armv7a-none-eabi`, compared by `nm` symbol size — nothing executes, neither side reads the other's spelling. **0.29 s**, fast line.

Negative control run independently, not taken on trust: `pub size: u32` → `u64` in the C++ pack ⇒ 31 disagreements across both storage arms, several caught *only* by sub-field probes. Restored, green.

## W2.2 — the board table is one derivation

`nros-entry-lower`, `no_std`, `serde`-only. Nineteen board keys → five families; `BootShape` derives from it; `board_cpp_path` becomes a *rendering* rather than a second table — RFC-0091 §8b defect 1 fixed at the source.

`check-no-tracked-file-find` caught two `rglob` walks in the gate; both scan the run's own generated output, so they carry `# walk-ok:` with reasons.

Verified: 240 fast gates, 955 lib tests, 140 rosidl-codegen, all 22 entry goldens byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vi3bKPpmrys3J3foFUH9oF