### PR TITLE
feat(phase-392 W6): the executor backing was on the HEAP, not the stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -623,7 +623,7 @@ and verified.
 - **Rust edition 2024:** `unsafe extern "C" {}`, `#[unsafe(no_mangle)]`, explicit `unsafe {}` in `unsafe fn`. `nros-c` keeps `#![allow(unsafe_op_in_unsafe_fn)]`.
 - **No POSIX-style Rust ctor sections on Zephyr/native_sim/RTOS** — backend registration is an explicit call. A pure-Rust image needs the REAL backend dep (`rmw-zenoh = ["dep:nros-rmw-zenoh"]`) — and a direct reference, or rustc's staticlib DCE drops the dep's `#[no_mangle]` export (symbol in the rlib, absent from the `.a`).
 - **Domain ID:** compile-time on embedded (Kconfig / per-example `config.toml`), runtime env on native. `CONFIG_NROS_CYCLONE_DOMAIN_ID` defaults to `NROS_DOMAIN_ID` — never pin it to a literal in confs (the phase-180 split-brain silently ran every cyclone image on domain 0). Cyclone fixture pairs bake distinct domains (50–58) for parallel SPDP.
-- **FreeRTOS:** `APP_TASK_STACK` 64 KB → "Invalid mbox" otherwise; IP-seeded `srand()`; poll-task priority ≥ 4; manual action server needs `try_handle_get_result()`.
+- **FreeRTOS:** IP-seeded `srand()`; poll-task priority ≥ 4; manual action server needs `try_handle_get_result()`. `APP_TASK_STACK` was deleted in phase-76 — the live knob is `app_stack_bytes` (default 384 KiB, override `NROS_FREERTOS_APP_STACK_KB`), and the executor arena it was sized for has not been on that stack since phase-271. → platform-implementation-notes.md "FreeRTOS pitfalls".
 - **Zephyr POSIX:** raise `CONFIG_MAX_PTHREAD_MUTEX_COUNT` (zenoh-pico needs ~8+; default 5 fails with -80).
 - **Zephyr zsock serializes send/recv per-fd:** `Z_CONFIG_SOCKET_TIMEOUT` must stay 100 ms (5 s starves tx → lease death); intra-image pub→sub needs `Z_FEATURE_LOCAL_SUBSCRIBER=1`.
 - **NuttX spin uses `sem_timedwait`** (pthread condvar hangs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,9 +617,23 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   parallel SPDP. → issue 0161 (archived), platform-implementation-notes.md.
 - **`zpico_spin_once` on multi-threaded platforms uses `z_sleep_ms()`, not `select()`** (else
   `Promise::wait()` burns its budget in ~39 ms). → platform-implementation-notes.md.
-- **FreeRTOS:** `APP_TASK_STACK` 64 KB (inline executor arena on stack) → "Invalid mbox" otherwise;
-  IP-seeded `srand()`; poll-task priority ≥ 4; manual action server needs
+- **FreeRTOS:** IP-seeded `srand()`; poll-task priority ≥ 4; manual action server needs
   `try_handle_get_result()`. → platform-implementation-notes.md.
+- **The executor arena is NOT on the task stack, and has not been since phase-271** —
+  three documents, a build-script comment and a RUNTIME advisory string said it was,
+  for five phases (corrected phase-392 W6). `Executor` holds `arena: &'s mut
+  [MaybeUninit<u8>]`, a slice borrowed from caller-supplied backing, so **placement is
+  the CALLER's**: all 34 C `nros_executor_t` objects are file-scope statics, C++ uses
+  `Node::GlobalStorageHolder<0>::storage`, and every RUST board reached an `alloc`
+  convenience constructor that `Box::leak`ed it — **invisible to `mem-report`, which
+  reads symbols**. The Rust arm is a named `.bss` static now
+  (`nros_node::executor::backing::EXECUTOR_BACKING`, RFC-0002 § 4.4b); the heap arm
+  survives for a SECOND executor (tiered boot) and for an entry sized past the default.
+  It is a MOVE, not a saving — the same bytes leave the allocator arena
+  (`CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` / heap_4) and become linker-visible, so never
+  report the `.bss` growth without subtracting the heap requirement it replaces. The
+  companion stale number: `APP_TASK_STACK` was deleted in phase-76; the live default is
+  `app_stack_bytes` = **384 KiB**, and nothing in the tree overrides it.
 - **Tier and transport priorities land in ONE scheduler — they now share ONE vocabulary,
   RAW FreeRTOS (issue 0623, FIXED).** `FreertosScheduling`'s `zenoh_read_priority` /
   `zenoh_lease_priority` / `poll_priority` are raw `0..configMAX_PRIORITIES-1`, the same

--- a/book/src/porting/custom-platform.md
+++ b/book/src/porting/custom-platform.md
@@ -335,7 +335,7 @@ This is the approach used by platforms with mature C networking stacks (lwIP on 
 ## Common pitfalls
 
 - **Poll-driven clocks.** If the clock only advances when you call a function, timeouts and keep-alives break silently. Use a free-running hardware timer.
-- **Stack overflow on RTOS.** The `Executor` has an inline arena on the task stack. Use at least 16384 words (64 KB) for the application task on action examples.
+- **Stack overflow on RTOS.** The application task's frame is dominated by the transport session open and by the `Executor` value the constructor builds and returns; size it by measuring an overflow, not by copying a number. (The executor's *arena* is no longer part of that frame — it is borrowed from caller-supplied backing, which is a `.bss` static on every in-tree entry.)
 - **Deterministic PRNG seeds.** Duplicate zenoh session IDs cause silent connection failures. Seed from a source that varies across instances.
 - **Missing recursive mutexes.** zenoh-pico re-enters the same mutex. Non-recursive mutexes deadlock.
 - **QEMU clock drift.** Use `-icount shift=auto` for QEMU targets so the virtual clock tracks wall time during WFI.

--- a/docs/design/0002-rt-execution-model.md
+++ b/docs/design/0002-rt-execution-model.md
@@ -382,31 +382,60 @@ tier's spin period quantizes to the spin grid (33 ms on a 5 ms spin alternates
 so no rule fires — correctly — but the jitter is predictable at resolve time and
 would be better as a resolver warning than a surprise on target.
 
-### 4.4b Arena placement: a named static, not the caller's stack
+### 4.4b Arena placement: a named static, not an anonymous allocation
 
-**Decision.** The executor arena is a named static in `.bss`, not an inline
-`[MaybeUninit<u8>; ARENA_SIZE]` field of `Executor`.
+**Decision.** The executor's backing — and therefore the arena carved from it —
+is a **named static in `.bss`** on every entry path, so the largest single RAM
+reservation in an image has a symbol.
 
-Today it is the latter, so the arena lands on whichever task calls `spin`. Three
-consequences, all of them working against the properties this RFC exists to
+**Implemented 2026-09-06, phase-392 W6.** The section's original text said the
+arena was *"an inline `[MaybeUninit<u8>; ARENA_SIZE]` field of `Executor`"* that
+*"lands on whichever task calls `spin`"*. **That had not been true since
+phase-271 (issue 0110)**, and it mattered: it aimed the fix at the wrong memory.
+Corrected here with the measurement that settled it.
+
+`Executor` holds `arena: &'s mut [MaybeUninit<u8>]`, a slice carved by
+`executor::storage::carve` out of caller-supplied backing. **Placement is
+therefore the caller's**, and it decided everything:
+
+* **C** — all 34 in-tree `nros_executor_t` objects are file-scope statics, so
+  the backing is carved from `_opaque` in `.bss`.
+* **C++** — `Node::GlobalStorageHolder<0>::storage`, also `.bss`.
+* **Rust** — every board entry (linux, zephyr, freertos, nuttx, threadx,
+  esp32-qemu, mps2-an385) reached an `alloc` convenience constructor, which
+  `Box::leak`ed the backing. **A heap allocation has no symbol**, so this was the
+  invisible one, on every Rust image, on every platform.
+
+Two consequences, both working against the properties this RFC exists to
 provide:
 
-* **It is invisible to the tools that are supposed to bound it.** `mem-report`
-  reads symbols; a stack-resident arena has none. The largest single RAM
-  consumer in an image is the one thing the memory instrument cannot see.
-* **It pushes its cost onto a number nobody derives.** The FreeRTOS action
-  examples pin an 8192-byte arena and still need a 64 KB app-task stack — a
-  figure found by hitting `Invalid mbox` and working backwards (issues
-  0271/0739). A task stack sized by bisection is not an analysable bound.
-* **It scales with subscription buffers.** Each `SubInfoEntry` embeds
-  `buffer: [u8; RX_BUF]`, so raising `NROS_SUBSCRIPTION_BUFFER_SIZE` for one
-  large topic multiplies across every subscription and lands on that stack. An
-  image with five subscriptions at a 64 KiB default reserves ~320 KiB of
-  **stack** for ~20 KiB of actual need.
+* **It was invisible to the tools that are supposed to bound it.** `mem-report`
+  reads symbols. Measured on the native zenoh talker: the largest `nros_node`
+  RAM symbol in the whole ELF was **1 byte**, and the crate did not appear in
+  the by-crate table. After: `nros_node::executor::backing::EXECUTOR_BACKING`,
+  **21,560 bytes**, 5.1 % of the image's RAM, fourth-largest symbol.
+* **It charged the allocator instead of the linker.** On a hosted target that is
+  free — the OS heap has no fixed reservation. On an RTOS the allocator arena is
+  *itself* a fixed static (`CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` on Zephyr,
+  `configTOTAL_HEAP_SIZE` on FreeRTOS), sized to hold this backing, so the bytes
+  were reserved statically anyway — just under a name that says "heap".
 
-As a named static the same bytes are a linker-visible symbol: `mem-report` sees
-it, the map file bounds it, and the task stack no longer carries a term that
-depends on how many topics the application happens to subscribe to.
+`nros_node::executor::backing::EXECUTOR_BACKING` is that static.
+`NROS_EXECUTOR_BACKING_SECTION` places it in a named section (a `NOLOAD` one:
+the static is uninitialised) for parts with tightly-coupled memory;
+`NROS_EXECUTOR_BACKING_U64S` resizes it, or removes it entirely at `0`, because
+the RTOS half of the move — lowering the allocator arena by the same amount — is
+per-image and only its author can measure it (issue 1145). The heap arm remains
+for a second executor (tiered boot opens one per tier) and for an entry sized
+past the reservation.
+
+**What this does NOT buy, contrary to the original text.** It does not shrink a
+task stack. The claim that raising `NROS_SUBSCRIPTION_BUFFER_SIZE` "lands on
+that stack", and that a five-subscription image reserves ~320 KiB of *stack*,
+followed from the inline-field premise and went with it: phase-271 took the
+arena out of the caller's frame, so no task stack has carried a
+subscription-proportional term since. The FreeRTOS app-task stack is a separate
+number that has still never been derived (issue 1146).
 
 **Orthogonal, and deliberately not decided here: whether payload buffers
 themselves become heap-backed.** Phase 392 amendment B reopened that as a

--- a/docs/guides/freertos-lan9118-debugging.md
+++ b/docs/guides/freertos-lan9118-debugging.md
@@ -210,18 +210,20 @@ srand(seed);
 
 **Problem**: Service server or action server crashes with `lwIP ASSERT: Invalid mbox` during network init or shortly after `z_open()`. Simpler examples (pub/sub) work fine.
 
-**Cause**: The `Executor` struct has an inline `arena: [MaybeUninit<u8>; ARENA_SIZE]` array that lives on the FreeRTOS task stack. Service examples use `NROS_EXECUTOR_ARENA_SIZE=4096` (4 KB) and action examples use `NROS_EXECUTOR_ARENA_SIZE=8192` (8 KB). Combined with zenoh-pico's internal stack buffers (transport TX/RX, peer structures) and Rust function frames, the total stack usage exceeds a small task stack.
+**Cause**: The application task's frame is dominated by zenoh-pico's internal stack buffers (transport TX/RX, peer structures) and by the Rust frames of the executor-open chain — `Executor::open_in` builds an `Executor` in its own frame and returns it by value. The total exceeds a small task stack.
+
+> **Corrected 2026-09-06 (phase-392 W6).** This paragraph used to say the cause was `Executor`'s inline `arena: [MaybeUninit<u8>; ARENA_SIZE]`, and that service/action examples pin `NROS_EXECUTOR_ARENA_SIZE` to 4096/8192. **Neither is true and neither has been since phase-271 (issue 0110).** The arena is a slice borrowed from caller-supplied backing, which on FreeRTOS is a named `.bss` static; no example in the tree sets `NROS_EXECUTOR_ARENA_SIZE`. Raising the arena knob will not change this symptom.
 
 When the stack overflows, it corrupts adjacent memory including lwIP's global `tcpip_mbox` variable (declared in `tcpip.c`). Any subsequent call to `tcpip_input()`, `tcpip_callback()`, or `sys_mbox_trypost()` triggers the "Invalid mbox" assertion, which enters an infinite `for(;;){}` loop.
 
-**Diagnosis**: If pub/sub examples work but service/action examples crash with "Invalid mbox":
-- Compare the arena sizes: talker sets `NROS_EXECUTOR_MAX_CBS=0` (no callbacks), service server uses defaults (4 slots, 4096 arena), action server sets `NROS_EXECUTOR_MAX_CBS=8` and `NROS_EXECUTOR_ARENA_SIZE=8192`
-- Larger arena = more stack needed = more likely to overflow
+**Diagnosis**: If pub/sub examples work but service/action examples crash with "Invalid mbox", the extra depth is in the registration pass, not in the arena — a service or action entry registers more entities and each registration adds frames.
 
-**Fix**: Set `APP_TASK_STACK` large enough for the largest example. 64 KB (16384 words) provides adequate headroom for all example types:
-```rust
-const APP_TASK_STACK: u32 = 16384; // 64 KB
-```
+**Fix**: Raise the application task's stack. The knob is `app_stack_bytes`
+(`nros_board_common::freertos_config`), whose default is **393216** (384 KiB);
+override it at build time with `NROS_FREERTOS_APP_STACK_KB=<kib>`, or per tier with
+`[node.rt] app_stack_bytes`.
+
+> **Corrected 2026-09-06 (phase-392 W6).** This step used to read *"set `APP_TASK_STACK` to 16384 words (64 KB)"*. `APP_TASK_STACK` was **deleted in phase-76** and 64 KB is six times below today's default, so following it verbatim would have made the problem worse. The C/C++ carrier keeps its own mirror of the number in `cmake/templates/freertos_app_config.c.in` (524288); the two are allowed to differ and the divergence is documented there.
 
 **Note**: The 256 KB FreeRTOS heap (`configTOTAL_HEAP_SIZE`) has plenty of room. The constraint is the per-task stack, not total memory.
 

--- a/docs/issues/1145-executor-backing-static-unpaired-with-rtos-heap.md
+++ b/docs/issues/1145-executor-backing-static-unpaired-with-rtos-heap.md
@@ -1,0 +1,86 @@
+---
+id: 1145
+title: "The executor backing is a `.bss` static now, but on an RTOS the allocator
+  arena it used to come out of was never lowered — so those images reserve the
+  same bytes twice, and nobody has measured it"
+status: open
+type: tech-debt
+area: core
+related: [phase-392, RFC-0002, 0163, 0880]
+---
+
+## Problem
+
+phase-392 W6 moved the executor's per-entry storage off the heap and into a
+named `.bss` static (`nros_node::executor::backing::EXECUTOR_BACKING`), because
+`mem-report` reads symbols and a `Box::leak` has none.
+
+On a **hosted** target that is free: the allocator is the OS heap, which has no
+fixed reservation, so nothing was double-counted and the bytes simply became
+visible. Measured on the native zenoh talker — see phase-392 W6.
+
+On an **RTOS** it is not free, because the allocator arena is *itself* a fixed
+static sized to hold this backing:
+
+| platform | the knob that already reserves these bytes |
+| --- | --- |
+| Zephyr | `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` (CLAUDE.md records "executor backing alone needs ~75 KB"; the default is 16 KB, so every Zephyr Rust image raises it) |
+| FreeRTOS | `configTOTAL_HEAP_SIZE` / heap_4, which also draws the task stacks |
+| NuttX / ThreadX / ESP-IDF | the port's own heap sizing |
+
+Nothing lowers those knobs, so an RTOS image built after W6 carries the
+reservation **twice**: once as `.bss`, once as heap headroom it no longer needs.
+
+## Why it was not fixed in W6
+
+The pairing is per-image and the second half can only be established by
+building the image and measuring — lowering a heap knob by an argued number is
+exactly the "never claim a saving you did not measure" rule this phase carries.
+W6 built and measured **one** image, a native host ELF; it built no Zephyr,
+FreeRTOS, NuttX, ThreadX or ESP32 image, and says so.
+
+## What W6 left in place instead
+
+An opt-out, so no RTOS image is forced to pay twice while this is open:
+
+```
+NROS_EXECUTOR_BACKING_U64S=0
+```
+
+emits no static at all and restores the `Box::leak`. A non-zero value overrides
+the reservation's size. Read by `nros-node/build.rs` through the same
+env → `$DOTCONFIG` reader every other executor knob uses (issue 0460).
+
+**The Zephyr `CONFIG_` half is deliberately NOT declared yet, and declaring it
+is part of closing this.** The reader already looks for
+`CONFIG_NROS_EXECUTOR_BACKING_U64S` in the dotconfig, but `zephyr/Kconfig`
+declares no such symbol, and a symbol nothing declares never reaches the
+dotconfig — so on Zephyr today the env knob is the only interface. It was left
+out because the obvious declaration is wrong in an interesting way: an
+`int … default 0` would read as **"no static"** on every Zephyr image from the
+day it landed, silently reverting the change for the whole platform, and there
+is no other integer that spells "use the crate's default". Whoever does the
+measurement below decides the shape — most likely a `bool NROS_EXECUTOR_BACKING_STATIC`
+(`default y`) for the on/off decision plus the existing int for the size, one
+symbol per decision.
+
+## What closing this looks like
+
+For each RTOS platform, in this order, and one platform per commit:
+
+1. Build the platform's talker fixture at HEAD, record `just mem-report <elf> --json`.
+2. Lower that platform's allocator-arena knob by the measured
+   `EXECUTOR_BACKING` size, rebuild, and confirm the image still **boots and
+   delivers** — not merely links. An under-sized allocator fails at the first
+   allocation the executor no longer makes but something else still does.
+3. Record the before/after in phase-392 W6's table with the exact command.
+
+Do not do this as one sweeping commit: the failure mode is a runtime allocation
+failure on one platform, and a six-platform diff makes that unattributable.
+
+## Related
+
+- phase-392 W6 — the change that created this, and the measurement that is done.
+- Issue 0163 (archived) — where the "~75 KB from the picolibc arena" figure comes from.
+- Issue 0880 — the other half of amendment A: a named section for the static
+  (`NROS_EXECUTOR_BACKING_SECTION`) exists but nothing places it yet.

--- a/docs/issues/1146-freertos-app-task-stack-never-derived.md
+++ b/docs/issues/1146-freertos-app-task-stack-never-derived.md
@@ -1,0 +1,81 @@
+---
+id: 1146
+title: "The FreeRTOS app-task stack is 384 KiB by bisection, its C/C++ mirror says
+  512 KiB, and the reason all three documents gave for the number stopped being
+  true five phases ago"
+status: open
+type: tech-debt
+area: boards
+related: [phase-392, phase-76, 0271, 0739, 1145]
+---
+
+## Problem
+
+`nros_board_common::freertos_config::DEFAULT_APP_STACK_BYTES` is **393216**
+(384 KiB), drawn from the FreeRTOS heap. It has never been derived from
+anything. Its own doc comment is a bisection log:
+
+> The default is 384 KiB: the Rust zenoh executor can exceed 160 KiB opening a
+> FreeRTOS session with lwIP up, and the phase-212 Entry / run-plan Executor
+> open overflows the older 256 KiB (issue #46). […] A 10-node macro entry's
+> register pass overflows even 384 KiB, hence the override.
+
+Three separate things follow from that, and all three are open:
+
+1. **The number is unattributed.** Nobody knows how much of the 384 KiB is the
+   zenoh-pico session open, how much is the executor-open call chain, and how
+   much is headroom. No high-water measurement exists.
+2. **The C/C++ carrier disagrees.** `cmake/templates/freertos_app_config.c.in`
+   sets `.app_stack_bytes = 524288u` — 512 KiB, a third independent number.
+   The divergence is documented there but not justified by a measurement
+   either.
+3. **Nothing sets the override.** `NROS_FREERTOS_APP_STACK_KB` exists and no
+   file in the tree uses it, so every FreeRTOS example runs at the default.
+
+## The stale explanation, corrected
+
+phase-392 W6 was to "re-derive one over-large task stack against the new
+figure — the FreeRTOS action examples' 64 KB app task". **Every noun in that
+sentence was stale**, which is why W6 could not carry it:
+
+| the claim | the fact |
+| --- | --- |
+| `APP_TASK_STACK` is 64 KB | `APP_TASK_STACK` was **deleted in phase-76**. The live knob is `app_stack_bytes` and the default is 384 KiB — six times larger, in the opposite direction from the one the wave predicted. |
+| the executor's arena is inline on that stack | `Executor` has held `arena: &'s mut [MaybeUninit<u8>]` since phase-271 (issue 0110). On FreeRTOS the backing is a `.bss` static (phase-392 W6). Nothing arena-sized is in that frame. |
+| the action examples pin `NROS_EXECUTOR_ARENA_SIZE=8192` | No example in the tree sets that knob. It is pre-phase-271 prose in `docs/guides/freertos-lan9118-debugging.md`. |
+
+So the wave's hypothesis — "the stack is carrying the arena, drop it and the
+number falls" — is **already false**: the arena left that frame five phases
+before the wave was written. Whatever the 384 KiB is holding, it is not the
+arena, and lowering the knob on that reasoning would have been a guess dressed
+as a measurement.
+
+## What deriving it actually requires
+
+A FreeRTOS image, a stack high-water reading, and a run — not a link:
+
+1. Build `examples/qemu-arm-freertos/rust/action-server` (and the `c`/`cpp`
+   twins, which take a different init path — `Node::global_storage()` rather
+   than the Rust `alloc` constructor, so their frames differ).
+2. Enable `configRECORD_STACK_HIGH_ADDRESS` / `uxTaskGetStackHighWaterMark`
+   and read the app task's mark after the registration pass, which is the
+   deepest point the doc comment names.
+3. Attribute the peak: session open vs `Executor::open_in`'s frame vs the
+   register pass. `Executor::open_in` builds an `Executor` in its own frame and
+   returns it by value, so the header's size is in there too (phase-409 shrank
+   it; that shrink has never been measured against this knob either).
+4. Set the default from the measurement plus a stated margin, reconcile
+   `freertos_app_config.c.in` to it or document why the C carrier differs, and
+   put the command in the commit message.
+
+Acceptance is a booting image that still delivers, at the lower number — the
+failure mode here is `lwIP ASSERT: Invalid mbox` from a stack overflow
+corrupting `tcpip_mbox`, which is silent until it is fatal.
+
+## Related
+
+- phase-392 W6 — landed the visible-arena half; this is the task-stack half it
+  could not honestly carry.
+- Issue 1145 — the same "the bytes moved, the knob that reserved them did not"
+  shape, one layer over, on the RTOS allocator arena.
+- Issues 0271 / 0739 — the knob-nobody-can-enumerate class this belongs to.

--- a/docs/issues/1147-mem-report-cannot-attribute-cpp-executor-storage.md
+++ b/docs/issues/1147-mem-report-cannot-attribute-cpp-executor-storage.md
@@ -1,0 +1,77 @@
+---
+id: 1147
+title: "`mem-report` counts the C++ executor storage but files it under the `nros`
+  RUST crate, so the C/C++ half of every embedded image's largest pool is
+  attributed to the wrong owner and can never join a declared pool"
+status: open
+type: tech-debt
+area: tooling
+related: [phase-392, 0815]
+---
+
+## Problem
+
+`scripts/nros-mem-report.py` attributes a symbol to a crate lexically, on the
+first `lowercase_ident::` of the DEMANGLED name:
+
+```python
+CRATE = re.compile(r"\b([a-z][a-z0-9_]*)::")
+```
+
+`nm -C` demangles Itanium C++ as well as Rust v0, so the C++ executor storage
+— `Node::GlobalStorageHolder<0>::storage`, an `alignas(8) uint8_t
+[NROS_CPP_EXECUTOR_STORAGE_SIZE]` in `.bss` (`packages/api/nros-cpp/include/nros/node.hpp`)
+— arrives as `nros::Node::GlobalStorageHolder<0>::storage` and matches `nros`.
+That is the name of a **Rust crate in this workspace** (`packages/api/nros`), so
+the bytes land in its bucket, indistinguishable from Rust `nros` statics.
+
+Pool attribution then cannot reach it either. The join key is
+(crate ident, last `::` segment), and it additionally requires
+`name.startswith(crate + "::")` where `crate` comes from the declaring file's
+`Cargo.toml` name. A pool would have to be declared in a crate literally named
+`nros` and named `storage` — and `gen-pool-inventory.py` scans tracked `*.rs`
+only (`git ls-files '*.rs'`), so a `// nros-pool:` comment in the C++ header is
+invisible to it regardless.
+
+The plain C path is worse: a file-scope `static struct { … nros_executor_t
+executor; … } app;` has no `::` at all, so it falls into the
+`(C / asm / no path)` bucket. On the native Rust zenoh talker that bucket is
+91,216 bytes; on a C or C++ image it also holds the executor storage.
+
+## Why it matters now
+
+phase-392 W6 made the RUST arm visible (`nros_node::executor::backing::EXECUTOR_BACKING`,
+21,560 B measured on the native talker). The C and C++ arms were already in
+`.bss` — they were never the invisible ones — but they are **mis-attributed**,
+and the embedded images are exactly the C/C++ ones. So the campaign can now
+price this pool on the platform where it matters least and not on the platforms
+it was opened for.
+
+## Not "just add a mapping"
+
+The tempting fix — special-case `nros::Node::GlobalStorageHolder` — is the
+authored-map drift class this tree already has scars from (the RMW parity map,
+CLAUDE.md). Two shapes worth considering instead:
+
+1. **Give the storage an unmangled name.** Define it once in Rust
+   (`#[unsafe(no_mangle)] static mut nros_cpp_executor_storage`) and have
+   `node.hpp` declare it `extern "C"`. That removes the C++ template-static
+   COMDAT trick, removes the `NROS_CPP_EXECUTOR_STORAGE_SIZE` header/Rust size
+   mirror, and gives one greppable symbol across every C/C++ image. It also
+   inherits `NROS_EXECUTOR_BACKING_SECTION` for free. Cost: it touches
+   `nros_cpp_init`'s storage parameter and the NuttX `__cxa_guard` workaround
+   the template-static exists to dodge (`node.hpp` documents that empirically),
+   so it needs a NuttX build to accept.
+2. **Teach the report a C++ arm.** Attribute a demangled `A::B::C` with no Rust
+   crate of that name to the DECLARING header's component. Cheaper, but it
+   invents a second attribution rule, and the mis-attribution to a real Rust
+   crate would still need a tiebreak.
+
+Whichever is chosen, the acceptance is the phase's standing rule: a BUILT C or
+C++ image showing the storage under an owner a reader would guess, confirmed
+with `just mem-report`.
+
+## Related
+
+- phase-392 W1 (issue 0815) — the instrument this is about.
+- phase-392 W6 — fixed the Rust arm and measured it; this is the arm it left.

--- a/docs/reference/platform-implementation-notes.md
+++ b/docs/reference/platform-implementation-notes.md
@@ -141,9 +141,22 @@ are prefixed with the enum name (`prefix_with_name = true`) to avoid C++ name co
 
 ## FreeRTOS pitfalls
 
-- Stack overflow → "Invalid mbox": `Executor` has an inline `arena: [MaybeUninit<u8>; ARENA_SIZE]`
-  on the task stack. Action examples use `NROS_EXECUTOR_ARENA_SIZE=8192`; `APP_TASK_STACK` must be
-  16384 words (64 KB) for headroom.
+- Stack overflow → "Invalid mbox". **The three numbers this entry used to name are all gone —
+  read it as a symptom, not as a recipe** (corrected phase-392 W6, 2026-09-06):
+  - `Executor` has NOT held an inline `arena: [MaybeUninit<u8>; ARENA_SIZE]` since phase-271
+    (issue 0110). It holds `arena: &'s mut [MaybeUninit<u8>]`, a slice borrowed from
+    caller-supplied backing, and on FreeRTOS that backing is a named `.bss` static
+    (`nros_node::executor::backing::EXECUTOR_BACKING`, phase-392 W6) — not the task stack.
+  - `APP_TASK_STACK` was deleted in phase-76. The live knob is `app_stack_bytes`
+    (`nros_board_common::freertos_config::DEFAULT_APP_STACK_BYTES`, **393216** = 384 KiB),
+    overridable with `NROS_FREERTOS_APP_STACK_KB`. No file in the tree sets that override.
+    The C/C++ carrier's own mirror in `cmake/templates/freertos_app_config.c.in` is 524288.
+  - No example pins `NROS_EXECUTOR_ARENA_SIZE=8192`; that was pre-phase-271 prose.
+
+  What is still true is the SYMPTOM: the app task's frame is dominated by the zenoh-pico
+  session open and the `Executor` value `open_in` builds and returns by value, so an
+  undersized app task dies as "Invalid mbox" rather than as a stack fault. Size it by
+  measuring, not by copying a number out of a document.
 - Deterministic `rand()` starts from seed 1 → duplicate Zenoh session IDs across QEMU instances;
   `srand()` with an IP-based unique seed in `nros_freertos_init_network()`.
 - Manual-polling action server: `create_action_server()` is not arena-registered, so `spin_once()`

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -74,30 +74,45 @@ Half the mechanism already exists: `MAX_LARGE_SUBSCRIBERS` /
 It is simply **decoupled from codegen**, so a human picks which subscribers are
 "large".
 
-### 1b. The arena is on the STACK, so none of lever 1 is visible
+### 1b. The arena is invisible to the instrument, so none of lever 1 is visible
 
-`Executor` holds `arena: [MaybeUninit<u8>; ARENA_SIZE]` inline, so the arena —
-and every `SubInfoEntry::buffer` inside it — lands on whichever task calls
-`spin`, not in `.bss`.
+> **Corrected 2026-09-06 by W6, which MEASURED it.** This section said
+> *"`Executor` holds `arena: [MaybeUninit<u8>; ARENA_SIZE]` inline, so the arena
+> lands on whichever task calls `spin`, not in `.bss`"*. **The mechanism was
+> wrong; the consequence was right.** `Executor` has held `arena: &'s mut
+> [MaybeUninit<u8>]` — a slice borrowed from caller-supplied backing — since
+> phase-271 (issue 0110), five phases before this section was written. Placement
+> is therefore the CALLER's, and the tree answered it three ways: C statics
+> (`.bss`), the C++ `Node::GlobalStorageHolder` (`.bss`), and — on **every Rust
+> board** — a `Box::leak` in the `alloc` convenience constructors, which is the
+> one that has no symbol. So the arena was invisible because it was on the HEAP,
+> not because it was on a stack, and the fix was not "move it off the stack" but
+> "give the backing a name". Everything below about *what that costs the
+> campaign* stands unchanged; the stack arithmetic does not. The measurement is
+> in W6.
+
+The arena — and every `SubInfoEntry::buffer` inside it — was reserved somewhere
+the symbol table could not describe.
 
 That defeats this campaign's own instrument. W1 exists to price every pool by
-reading symbols; a stack-resident arena has no symbol, so **the largest single
-RAM consumer in an image is the one thing `mem-report` cannot see**. It is also
-why the FreeRTOS action examples pin an 8192-byte arena and still need a 64 KB
-app-task stack — a number found by hitting `Invalid mbox` and working backwards
-(issues 0271/0739).
-
-And it makes lever 1 land in the worst place: raising
-`SUBSCRIPTION_BUFFER_SIZE` for one large topic multiplies across every
-subscription and lands on a *stack*. A five-subscription image at the 64 KiB
-default reserves ~320 KiB of stack for ~20 KiB of real need.
+reading symbols; a heap allocation has no symbol, so **the largest single RAM
+consumer in a Rust image was the one thing `mem-report` could not see**.
+Measured on the native zenoh talker before W6: the largest `nros_node` RAM
+symbol in the whole ELF was **1 byte**, and `nros_node` did not appear in the
+by-crate table at all.
 
 Moving it to a named static changes no allocation strategy — the same bytes,
-reserved the same way — and buys three things this campaign is otherwise
-paying for: a symbol `mem-report` can price, a map-file bound, and a task stack
-that no longer carries a term proportional to the subscription graph. Decision
-recorded in [RFC-0002 § 4.4b](../design/0002-rt-execution-model.md); wave W6
-below.
+reserved for the same lifetime — and buys two things this campaign is otherwise
+paying for: a symbol `mem-report` can price, and a map-file bound. It also takes
+the term out of the image's allocator arena, which on an RTOS is itself a fixed
+static (see W6 and issue 1145). Decision recorded in
+[RFC-0002 § 4.4b](../design/0002-rt-execution-model.md); wave W6 below.
+
+The third thing this section used to claim — a task stack that no longer carries
+a term proportional to the subscription graph — is **not** what W6 bought,
+because the stack never carried it: the same phase-271 change that made the
+arena a borrowed slice took it out of the frame. The FreeRTOS app-task stack is
+a separate, still-underived number, now issue 1146.
 
 ### 2. Component buffers — 1:1 with per-field storage mode
 
@@ -1062,37 +1077,143 @@ It is currently 1 everywhere, which is why it has never been the visible term.
 
 ### W6 — the executor arena becomes a named static
 
-**Why it is a wave and not a patch.** The move itself is small; what it touches
-is where every image's largest allocation is accounted. Do it after W1 so the
-instrument can show the before/after, and measure on a named image rather than
-asserting the saving.
+**LANDED 2026-09-06, on a premise that was half wrong.** Read the correction
+first: it changes what the wave did and what it could not do.
 
-Steps:
+#### The premise, verified before building on it
 
-1. Replace `Executor`'s inline `arena` field with a reference to a
-   platform-provided static. The arena is already bound to `Dispatcher` at
-   construction as a stable pointer (RFC-0002 § 4.4), so the ownership change
-   is confined to construction.
-2. Give the static a name the instrument can find, and a section a linker
-   script can place — TCM is a candidate on parts that have it (amendment A).
-3. `mem-report` gains a row it previously could not see. That row IS the
-   acceptance evidence.
-4. Re-derive one over-large task stack against the new figure. The FreeRTOS
-   action examples' 64 KB app task is the honest test: if it can drop, the
-   number was carrying the arena and the campaign can say so with a diff.
+Step 1 as written — *"replace `Executor`'s inline `arena` field with a
+reference to a platform-provided static"* — **was already done, five phases
+earlier.** phase-271 (issue 0110) moved the executor's sized tables off
+build-time consts, and `Executor` has held
 
-**Acceptance.** A named image shows the arena as a priced symbol in
-`mem-report`, and one task-stack knob is reduced by a measured amount rather
-than by bisection.
+```rust
+pub(crate) arena: &'s mut [MaybeUninit<u8>],
+```
 
-**Interaction with amendment B.** This does not decide whether payload buffers
-become heap-backed; it makes that question measurable, because the pools stop
-being invisible. If B later moves them, this wave is not wasted work — the
-arena still needs an address.
+ever since: a slice carved out of caller-supplied backing by
+`executor::storage::carve`. phase-403 had already caught the stale claim
+(2026-08-31) and listed the sites to fix; nothing had fixed them. RFC-0002 § 4.4's
+stable-pointer claim **does still hold** — `Dispatcher` binds the arena at
+construction, so the ownership change was confined to construction exactly as
+the wave predicted.
 
-**Non-goal.** Sizing each subscription to its type is W3a's job, not this
-wave's. The two compound (a static sized by type is both smaller and visible)
-but neither depends on the other.
+So the real defect was one layer down, in WHO SUPPLIES the backing. Surveyed
+exhaustively:
+
+| entry path | supplier | placement | visible to `mem-report`? |
+| --- | --- | --- | --- |
+| C (all 34 in-tree `nros_executor_t` objects) | file-scope `static struct { … } app;` | `.bss` | counted, mis-attributed (issue 1147) |
+| C++ / all six cmake entry templates | `Node::GlobalStorageHolder<0>::storage` | `.bss` | counted, mis-attributed (issue 1147) |
+| **Rust — every board**: linux, zephyr, freertos, nuttx, threadx, esp32-qemu, mps2-an385, RTIC, bridge codegen, scaffold | `Executor::open`/`open_sized`/`from_session` → `Box::leak` | **heap** | **no — no symbol at all** |
+| `heap-free-poc-mps2`, `large-msg-baremetal` | their own `static mut` + `open_in` | `.bss` | yes |
+
+**The arena was invisible because it was on the HEAP, not because it was on a
+stack.** Both the campaign's § 1b and RFC-0002 § 4.4b said stack; both were
+corrected with this wave, along with `platform-implementation-notes.md`,
+`freertos-lan9118-debugging.md`, `book/src/porting/custom-platform.md`,
+`nros-node/build.rs`'s comment and — the one that reached users — the RUNTIME
+advisory string in `report_arena_headroom`, which told every over-provisioned
+image that "the arena is INLINE ON THE TASK STACK".
+
+#### What landed
+
+`nros_node::executor::backing` — a named `.bss` static the `alloc` convenience
+constructors serve from, falling back to the old `Box::leak` when they cannot.
+One change, every Rust board.
+
+* **Named**: `nros_node::executor::backing::EXECUTOR_BACKING`, sized
+  `ExecutorSizing::DEFAULT.u64_len()`.
+* **Placeable**: `NROS_EXECUTOR_BACKING_SECTION=<name>` emits
+  `#[unsafe(link_section = "…")]` on it (amendment A / issue 0880's `DTCM`
+  pattern). The section must be `NOLOAD` — the static is uninitialised — and
+  must be reachable by every bus master touching the executor's buffers, which
+  TCM on Cortex-M7 typically is not. **Nothing places it yet**; the seam exists
+  and is compile-verified, the linker fragment is not written.
+* **Declinable**: `NROS_EXECUTOR_BACKING_U64S=0` (build-time env; the Zephyr
+  `CONFIG_` half is deliberately undeclared, see issue 1145 for why the obvious
+  `int … default 0` would silently disable it platform-wide)
+  emits no static at all. A non-zero value overrides its size, which is also how
+  a fat entry keeps a static instead of falling back to the heap.
+* The heap arm still runs, legitimately, in three cases: the opt-out, a SECOND
+  executor (tiered boot opens one per tier), and an entry sized past the
+  reservation.
+
+**No `// nros-pool:` annotation**, deliberately. The inventory evaluates a pool
+as a PRODUCT of knobs at literal defaults; this is a SUM (nine carved tables
+plus the arena, with alignment padding) whose largest term is itself derived.
+Same reasoning as the two existing deliberate non-annotations. `mem-report`
+prices the symbol from the ELF, which needs no formula and cannot drift.
+
+#### Acceptance evidence — MEASURED
+
+Image: `examples/native/rust/talker`, zenoh, built by
+`bash scripts/build/fixtures-build.sh linux rust --id native-rust-talker` →
+`build/cargo-fixtures/linux/nros-relwithdebinfo/talker`.
+
+```
+python3 scripts/nros-mem-report.py build/cargo-fixtures/linux/nros-relwithdebinfo/talker --json
+```
+
+| | before | after | delta |
+| --- | ---: | ---: | ---: |
+| `.bss` | 378,050 | 399,618 | **+21,568** |
+| RAM attributed to symbols | 383,112 | 404,673 | +21,561 |
+| by-crate `nros_node` | **6** | **21,567** | +21,561 |
+| `nros_node::executor::backing::EXECUTOR_BACKING` | *(absent)* | **21,560** | **NEW** |
+
+Every other RAM symbol is **+0**. The new row is 5.1 % of the image's RAM and is
+now the fourth-largest symbol in it; before the change the largest `nros_node`
+RAM symbol in the whole ELF was 1 byte. `nm` type letter is `b` — genuinely
+`.bss`, not `.data`, so it costs no flash.
+
+**The first before/after was thrown away, and saying why is the point.** It
+reported `−11,199` bytes. The two builds had run different configurations: the
+baseline was built before `nros sync`'s component probe had artifacts to read,
+so it took the crate-default pool budgets (`SMALL_PAYLOADS` 32,768) while the
+after build took the probed ones (4,096). That is W5's own retracted-claim
+failure, reproduced within this wave, and it was caught by checking that the
+unrelated symbols were unchanged. The table above is the re-run in which they
+are.
+
+**And it RUNS, not merely links.** With the ROS router up
+(`nros_router_exec tcp/127.0.0.1:7452`, ROS setup sourced so the paired
+`libzenohc.so` loads — issue 0774): session open, node + publisher registered,
+`Publishing: 'Hello World: 1..7'`. The corrected advisory appears in that run
+too: `arena over-provisioned: set NROS_EXECUTOR_ARENA_SIZE=1024 … 192/8192 bytes
+claimed at first spin` — no truncation, no false placement claim. Plus 328
+`nros-node` unit tests, which register entities into an arena carved from the
+static.
+
+#### What this wave did NOT do
+
+* **Half of the acceptance is not met.** *"One task-stack knob is reduced by a
+  measured amount"* did not happen, and the wave's own step 4 named a target
+  that does not exist: `APP_TASK_STACK` was deleted in phase-76, the live
+  default is `app_stack_bytes` = **384 KiB** (not 64 KB), nothing in the tree
+  sets the override, the C/C++ carrier mirrors a third number (512 KiB), and no
+  example pins `NROS_EXECUTOR_ARENA_SIZE=8192`. The wave's hypothesis — "the
+  stack is carrying the arena" — was already false when it was written, because
+  phase-271 had taken the arena out of that frame. Deriving that number needs a
+  FreeRTOS image and a stack high-water reading. → **issue 1146**.
+* **Only ONE platform was built and measured: native/linux.** No Zephyr,
+  FreeRTOS, NuttX, ThreadX, ESP32 or bare-metal image was built. The change
+  reaches them all by construction (one shared constructor), and on an RTOS the
+  move is *not* free the way it is on a host: the allocator arena those images
+  draw from is itself a fixed static and nothing lowers it, so they would
+  reserve the bytes twice. That is why the opt-out knob exists and why the
+  pairing is → **issue 1145**.
+* **The C/C++ arm is left mis-attributed.** It was never invisible — it is in
+  `.bss` — but `mem-report` files `nros::Node::GlobalStorageHolder<0>::storage`
+  under the Rust `nros` crate, and plain C's `app` struct under
+  `(C / asm / no path)`. → **issue 1147**.
+
+**Interaction with amendment B.** Unchanged: this does not decide whether
+payload buffers become heap-backed, it makes the question measurable. A `.bss`
+arena is the better starting point for that measurement.
+
+**Non-goal, respected.** Sizing each subscription to its type is W3a's; nothing
+here touches buffer sizing.
 
 ## Explicitly out of scope
 

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -179,6 +179,21 @@ to the linker: `executor/arena.rs` (in `report_arena_headroom`) and
 `executor/spin.rs` (on `arena_capacity`). Both predate phase-271 and both should
 go with this wave; see the W5 note.
 
+> **DONE by phase-392 W6 (2026-09-06), and it was wider than two comments.** The
+> `arena.rs` one was not only a doc comment — the claim was in the RUNTIME
+> advisory STRING, so every over-provisioned image was told "the arena is INLINE
+> ON THE TASK STACK". Corrected there plus `nros-node/build.rs`,
+> `nros/src/metadata_mode.rs`, RFC-0002 § 4.4b, phase-392 § 1b,
+> `platform-implementation-notes.md`, `freertos-lan9118-debugging.md`,
+> `book/src/porting/custom-platform.md`, CLAUDE.md and AGENTS.md.
+> W6 also answered the placement question this section left open: the third
+> path, which the survey above missed, is the Rust `alloc` convenience
+> constructors — they `Box::leak`ed the backing, so on EVERY Rust board it was
+> on the HEAP and had no symbol at all. It is a named `.bss` static now
+> (`nros_node::executor::backing::EXECUTOR_BACKING`, measured 21,560 B on the
+> native talker), so a linker-symbol check for `NROS_ARENA_REQUIRED` now works
+> for the Rust path too, not only the C/C++ component path.
+
 ## Waves
 
 **W0 -- an unbounded type stops being sizeable (landed 2026-08-31).** The

--- a/packages/api/nros/src/metadata_mode.rs
+++ b/packages/api/nros/src/metadata_mode.rs
@@ -232,8 +232,11 @@ mod tests {
     /// `record_entity` has always accepted `ActionClient`/`ServiceClient`, and
     /// the serializer dropped them: a sidecar described only what a component
     /// SERVES. The executor arena is sized from the client count, so the
-    /// omission had a size cost (74,240 vs 16,384 bytes, on the task stack) and
-    /// not merely a descriptive one.
+    /// omission had a size cost (74,240 vs 16,384 bytes) and not merely a
+    /// descriptive one. (phase-392 W6: this used to add "on the task stack",
+    /// which was inherited from 0900 and false since phase-271 — the arena is
+    /// borrowed from caller-supplied backing, a `.bss` static on every entry
+    /// path. The size cost is real; the placement claim was not.)
     #[test]
     fn client_entities_reach_the_sidecar() {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -105,8 +105,13 @@ fn main() {
     // (issue 0460); an enum would need a second reader shape for no gain.
     //
     // Setting it to 0 on a pub/sub-only image is the whole point: 74,240 bytes
-    // becomes 16,384 at the defaults, and that arena is INLINE ON THE TASK
-    // STACK, not in `.bss`.
+    // becomes 16,384 at the defaults.
+    //
+    // phase-392 W6 — this comment used to end "and that arena is INLINE ON THE
+    // TASK STACK, not in `.bss`". False since phase-271 (issue 0110), and it is
+    // the reason the saving read as a stack saving rather than a RAM one. The
+    // arena is a slice borrowed from caller-supplied backing; see
+    // `executor::backing` for where that backing lives on each entry path.
     //
     // Too small fails at REGISTRATION (`NodeError::BufferTooSmall`), not at
     // link — same caveat `NROS_EXECUTOR_ARENA_SIZE` carries, and the reason
@@ -291,11 +296,98 @@ fn main() {
 
     std::fs::write(Path::new(&out_dir).join("nros_node_config.rs"), contents).unwrap();
 
+    emit_executor_backing(&out_dir);
+
     // Export via `links = "nros_node"` so dependents (nros-c, nros-cpp)
     // can read these as DEP_NROS_NODE_MAX_CBS, DEP_NROS_NODE_ARENA_SIZE, etc.
     println!("cargo:max_cbs={max_cbs}");
     println!("cargo:arena_size={arena_size}");
     println!("cargo:rx_buf_size={rx_buf_size}");
+}
+
+/// phase-392 W6 — emit the ONE item that has to be generated for
+/// `executor::backing`: the named static itself, because
+/// `#[unsafe(link_section = …)]` takes a string LITERAL and the section name is
+/// a build-time input.
+///
+/// `NROS_EXECUTOR_BACKING_SECTION` is a SECTION NAME, not a path, so watching
+/// the env value is the correct fingerprint here (issue 0491 is about paths,
+/// which have several spellings for one directory; a section name has one).
+///
+/// The generated file is deliberately tiny and carries no arithmetic — the size
+/// is `EXECUTOR_BACKING_U64S`, a `const` in the module, so a reader looking for
+/// "how big is it?" never has to open `OUT_DIR`.
+fn emit_executor_backing(out_dir: &str) {
+    // Words to reserve. ABSENT means "the crate's own default sizing", which is
+    // why this is `env_opt_usize` and not `env_usize` with a number: build.rs
+    // cannot call `ExecutorSizing::DEFAULT.u64_len()` (it lives in the crate it
+    // is building), and RETYPING that arithmetic here is the single-derivation
+    // rule's exact failure mode — a second copy that agrees until a table moves.
+    // So absence emits the const EXPRESSION and the crate computes it.
+    //
+    // **ZERO means "no static; leak from the heap as before"**, and it is the
+    // documented opt-out for a memory-constrained image: on a hosted target the
+    // allocator has no fixed reservation, so the static is free, but on an RTOS
+    // the allocator arena IS a fixed static (`CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE`
+    // on Zephyr, `configTOTAL_HEAP_SIZE` on FreeRTOS) and it is sized to hold
+    // this backing already. Turning the static on there without lowering that
+    // knob reserves the same bytes twice. The pairing is per-image and nobody
+    // but the image's author can measure it — see phase-392 W6.
+    let words = env_opt_usize("NROS_EXECUTOR_BACKING_U64S");
+    println!("cargo:rustc-check-cfg=cfg(nros_executor_backing_static)");
+    if words == Some(0) {
+        // No item at all, and no cfg: `backing::take` is then a `None` stub and
+        // the crate carries no reservation. The file still has to EXIST because
+        // `include!` is unconditional at the module's top level.
+        std::fs::write(
+            Path::new(out_dir).join("nros_executor_backing.rs"),
+            "// NROS_EXECUTOR_BACKING_U64S=0 -- no static reservation; the alloc\n\
+             // convenience constructors leak from the heap (phase-392 W6).\n",
+        )
+        .unwrap();
+        return;
+    }
+    println!("cargo:rustc-cfg=nros_executor_backing_static");
+    let len = match words {
+        Some(n) => n.to_string(),
+        None => "EXECUTOR_BACKING_DEFAULT_U64S".to_string(),
+    };
+    println!("cargo:rerun-if-env-changed=NROS_EXECUTOR_BACKING_SECTION");
+    let section = env::var("NROS_EXECUTOR_BACKING_SECTION").unwrap_or_default();
+    let attr = if section.is_empty() {
+        String::new()
+    } else {
+        // A section name reaches the assembler verbatim, so refuse anything that
+        // could close the string literal or smuggle a directive: a mangled
+        // section is a link error four layers from here, or worse, a silently
+        // misplaced 74 KiB.
+        assert!(
+            section
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '$')),
+            "NROS_EXECUTOR_BACKING_SECTION must be [A-Za-z0-9._$]+, got {section:?}"
+        );
+        format!("#[unsafe(link_section = \"{section}\")]\n")
+    };
+    let contents = format!(
+        "/// GENERATED by `nros-node/build.rs` -- see `executor::backing` for what \
+         this is\n\
+         /// and why it is generated rather than written.\n\
+         ///\n\
+         /// The executor's per-entry storage, reserved ONCE in `.bss` so \
+         `mem-report`\n\
+         /// can price what a leaked `Box` made invisible (phase-392 W6, RFC-0002 \
+         SS 4.4b).\n\
+         pub(crate) const EXECUTOR_BACKING_U64S: usize = {len};\n\
+         {attr}\
+         static mut EXECUTOR_BACKING: [MaybeUninit<u64>; EXECUTOR_BACKING_U64S] =\n    \
+         [MaybeUninit::uninit(); EXECUTOR_BACKING_U64S];\n"
+    );
+    std::fs::write(
+        Path::new(out_dir).join("nros_executor_backing.rs"),
+        contents,
+    )
+    .unwrap();
 }
 
 /// The platform and board rungs of the RFC-0049 ladder for `[knobs.executor]`.

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -586,19 +586,27 @@ static ARENA_ADVISORY_DONE: portable_atomic::AtomicBool = portable_atomic::Atomi
 /// enumerate is a knob nobody sets — and this turns it from folklore into a
 /// measurement.
 ///
-/// **Where the arena lives is the CALLER's choice**, and both answers are real.
-/// `Executor` holds `arena: &'s mut [MaybeUninit<u8>]` -- a borrowed slice, since
-/// phase-271 (issue 0110) moved the sized tables off build-time consts. What is
-/// inline is `ExecutorInlineStorage::backing`, which the C FFI sizes its
-/// `_opaque` from, so a stack-declared `nros_executor_t` does put the arena on
-/// the task stack -- that is the FreeRTOS "Invalid mbox" case in
-/// `docs/reference/platform-implementation-notes.md`. The C++ component entry
-/// does not take that path: `run_components` -> `nros::init` ->
-/// `Node::GlobalStorageHolder` is a `static`, so the arena is `.bss` and IS
-/// visible to `nm` and `mem-report`. Measured on mr-canhubk344: DTCM tracked
-/// ARENA_SIZE one-for-one across MAX_CBS 24 -> 36.
+/// **Where the arena lives is the CALLER's choice**, and THREE answers are real
+/// -- phase-392 W6 surveyed every entry path and found a third this comment had
+/// missed. `Executor` holds `arena: &'s mut [MaybeUninit<u8>]` -- a borrowed
+/// slice, since phase-271 (issue 0110) moved the sized tables off build-time
+/// consts. What is inline is `ExecutorInlineStorage::backing`, which the C FFI
+/// sizes its `_opaque` from.
 ///
-/// Do not size against one placement and assume the other.
+/// * **`.bss`** -- all 34 in-tree C `nros_executor_t` objects are file-scope
+///   statics; the C++ entry reaches `Node::GlobalStorageHolder`, also a static;
+///   and the `alloc` convenience constructors serve from
+///   `super::backing::EXECUTOR_BACKING`. Visible to `nm` and `mem-report`.
+///   Measured on mr-canhubk344: DTCM tracked ARENA_SIZE one-for-one across
+///   MAX_CBS 24 -> 36. Measured on the native zenoh talker: 21,560 B.
+/// * **the heap** -- the `alloc` constructors' fallback (a second executor, or
+///   an entry sized past the reservation, or `NROS_EXECUTOR_BACKING_U64S=0`).
+///   This was the ONLY Rust answer before W6, and it has no symbol, which is
+///   why the campaign's own instrument could not see its largest consumer.
+/// * **a task stack** -- a stack-declared `nros_executor_t`. Legal, and nothing
+///   in the tree does it.
+///
+/// Do not size against one placement and assume another.
 ///
 /// `nros_log`, never stdio: this is reached on `no_std` targets and inside
 /// Zephyr `native_sim`, where a Rust `std` stdio call is FATAL (issue 0589).
@@ -618,7 +626,14 @@ fn report_arena_headroom(used: usize, capacity: usize) {
     // reasoning in this comment and issue 0900, and a test that fails on `…`.
     nros_log::nros_info!(
         nros_log::get_logger("nros"),
-        "arena over-provisioned: set NROS_EXECUTOR_ARENA_SIZE={suggest}          (Zephyr: CONFIG_ prefix). {used}/{capacity} bytes claimed at first          spin, and the arena is INLINE ON THE TASK STACK. Later registrations          need more. issue 0900"
+        // phase-392 W6 — the clause "and the arena is INLINE ON THE TASK STACK"
+        // stood here and was FALSE on every path (see the doc comment above);
+        // dropping it is also what buys the budget back. Placement is the
+        // caller's, so this line names the NUMBER, which is the same whichever
+        // memory the backing came from.
+        "arena over-provisioned: set NROS_EXECUTOR_ARENA_SIZE={suggest} \
+         (Zephyr: CONFIG_ prefix). {used}/{capacity} bytes claimed at first \
+         spin; later registrations need more. issue 0900"
     );
 }
 

--- a/packages/core/nros-node/src/executor/backing.rs
+++ b/packages/core/nros-node/src/executor/backing.rs
@@ -1,0 +1,243 @@
+//! phase-392 W6 — the executor's storage as a NAMED STATIC (RFC-0002 § 4.4b).
+//!
+//! # What this fixes, and what it does not
+//!
+//! Phase 392 prices an image's static RAM by reading its symbol table
+//! (`just mem-report`). Every later wave of that campaign is defined as a saving
+//! against those numbers, so a consumer the symbol table cannot see is a
+//! consumer the campaign cannot price — and the executor's storage was exactly
+//! that on every Rust image.
+//!
+//! **Not because the arena is inline.** It stopped being an inline
+//! `[MaybeUninit<u8>; ARENA_SIZE]` field in phase-271 (issue 0110), and
+//! [`Executor`](super::spin::Executor) has held `arena: &'s mut
+//! [MaybeUninit<u8>]` — a slice carved out of caller-supplied backing — ever
+//! since. Four documents, a build-script comment and a runtime advisory string
+//! went on asserting the inline shape for five phases; phase-403 caught the
+//! claim and phase-392 W6 corrected the sites.
+//!
+//! **Where that backing lives is the caller's choice**, and before this module
+//! the tree answered it three different ways:
+//!
+//! * **C** — all 34 in-tree `nros_executor_t` objects are file-scope `static`,
+//!   so the backing is carved from `_opaque` in `.bss`. Visible.
+//! * **C++** — `nros::Node::GlobalStorageHolder<0>::storage`, a template static
+//!   member, so also `.bss`. Visible.
+//! * **Rust** — every board entry (`linux`, `zephyr`, `freertos`, `nuttx`,
+//!   `threadx`, `esp32-qemu`, `mps2-an385`) reaches an `alloc` convenience
+//!   constructor, which leaked a `Box`. **Invisible**: a heap allocation has no
+//!   symbol. Measured on the native zenoh talker before this module: the largest
+//!   `nros_node` RAM symbol in the whole image was **1 byte**.
+//!
+//! This module closes the Rust arm — one change, every Rust board.
+//!
+//! # It is a MOVE, not a saving, and the second half is the caller's
+//!
+//! The same bytes are reserved either way; what changes is *which budget pays*.
+//! A leaked `Box` is drawn from the image's allocator arena. On a hosted target
+//! that arena is the OS heap and has no fixed reservation, so the static costs
+//! nothing that was not already spent. **On an RTOS it is itself a fixed
+//! static** — `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` on Zephyr,
+//! `configTOTAL_HEAP_SIZE` on FreeRTOS — already sized to hold this backing, so
+//! turning the reservation on there without lowering that knob reserves the same
+//! bytes twice.
+//!
+//! That pairing is per-image and only the image's author can measure it, so the
+//! opt-out is a knob rather than a guess: `NROS_EXECUTOR_BACKING_U64S=0` emits
+//! no static at all and restores the leak. A non-zero value overrides the
+//! reservation's SIZE, which is also how a fat entry — one declaring
+//! `max_callbacks` above `NROS_EXECUTOR_MAX_CBS` — keeps a static instead of
+//! falling back to the heap.
+//!
+//! **The Zephyr `CONFIG_` spelling is NOT wired yet.** `nros-node`'s build
+//! script resolves this through the same env → `$DOTCONFIG` reader every other
+//! executor knob uses, so `CONFIG_NROS_EXECUTOR_BACKING_U64S` would be honoured
+//! the moment `zephyr/Kconfig` declares it — but it does not, and a symbol no
+//! Kconfig declares never reaches the dotconfig. Declaring it belongs with the
+//! measurement that makes it necessary (issue 1145), not ahead of it: the
+//! natural `int … default 0` would mean "no static" on every Zephyr image the
+//! day it landed, which is the opposite of the default this chose. Until then
+//! the env knob is the whole interface.
+//!
+//! # Why there is no `// nros-pool:` annotation
+//!
+//! `scripts/gen-pool-inventory.py` evaluates a pool as a PRODUCT of knobs at
+//! their literal defaults. This one is a SUM — the executor's carved tables plus
+//! the arena, laid out with alignment padding between them — and its largest
+//! term, `ARENA_SIZE`, is itself derived
+//! (`env_usize("NROS_EXECUTOR_ARENA_SIZE", derived_arena)` in
+//! `nros-node/build.rs`), so the inventory would record it as a computed default
+//! even if the sum were expressible. A formula that is right for one build and
+//! wrong for the rest is the drift class this tree gates against, so this
+//! follows the two documented deliberate non-annotations
+//! (`nros_rmw_zenoh::shim::publisher`, `nros_rmw_cffi`): **the size is known to
+//! the compiler, so read it from the compiler's output.** `mem-report` prices
+//! the symbol from the ELF, exactly, with no formula to drift.
+//!
+//! # Placement
+//!
+//! `NROS_EXECUTOR_BACKING_SECTION` (build-time env, read by `nros-node`'s build
+//! script) puts the static in a named section, for the amendment-A case where a
+//! part has tightly-coupled memory the linker script can target — issue 0880
+//! does the same for `nros_thread_stacks` with `DTCM`. Two constraints, both
+//! load-bearing: **the section must be `NOLOAD`**, because this static is
+//! uninitialised and a loadable section would add its whole size to the image's
+//! flash footprint; and it must be reachable by every bus master that touches
+//! the executor's buffers, which on Cortex-M7 the TCMs typically are not.
+
+use core::mem::MaybeUninit;
+
+#[cfg(nros_executor_backing_static)]
+use portable_atomic::{AtomicBool, Ordering};
+
+use super::storage::ExecutorSizing;
+
+/// The reservation's size when nothing overrides it: one default-sized
+/// executor's worth.
+///
+/// One executor, not a multiple, because an entry opens ONE: the tiered boot
+/// paths open a second per tier, and those correctly fall through to the heap
+/// (see [`take`]).
+///
+/// Named by the GENERATED file when nothing overrides the size, so it is unused
+/// under `NROS_EXECUTOR_BACKING_U64S=0` (no static) and under an explicit
+/// override (a literal). Kept rather than `cfg`'d: it is what the override is
+/// judged against, and a constant that disappears with its consumer cannot be
+/// compared to anything.
+#[allow(dead_code)]
+pub(crate) const EXECUTOR_BACKING_DEFAULT_U64S: usize = ExecutorSizing::DEFAULT.u64_len();
+
+// `EXECUTOR_BACKING`, its size const, and the optional
+// `#[unsafe(link_section = …)]` on it are emitted by `build.rs`: `link_section`
+// takes a string LITERAL and the section name is a build-time input, and the
+// size may be overridden or the whole item suppressed. The file is EMPTY when
+// `NROS_EXECUTOR_BACKING_U64S=0`, which is why the include is unconditional
+// while everything that reads it is `cfg`-gated.
+include!(concat!(env!("OUT_DIR"), "/nros_executor_backing.rs"));
+
+/// The reservation must cover the sizing every `alloc` convenience constructor
+/// passes, or it is dead weight every image carries and no executor ever uses.
+///
+/// A `const` assertion rather than a test, deliberately: the only way to make it
+/// false is to set `NROS_EXECUTOR_BACKING_U64S` too low, and the person doing
+/// that wants to hear about it from the build they just ran, not from a test
+/// suite they may not run at all. `0` is the documented opt-out and is not
+/// reached here — it emits no static, so this whole arm is `cfg`'d away.
+#[cfg(nros_executor_backing_static)]
+const _: () = assert!(
+    EXECUTOR_BACKING_U64S >= EXECUTOR_BACKING_DEFAULT_U64S,
+    "NROS_EXECUTOR_BACKING_U64S is below the default executor sizing, so the \
+     reservation can never be taken and is pure dead weight; use 0 to decline \
+     the static entirely"
+);
+
+/// Has [`EXECUTOR_BACKING`] been handed out?
+///
+/// A latch, not a free list: the backing is handed out as `&'static mut` and
+/// never returned, exactly like the `Box::leak` it replaces. An executor that
+/// drops does not give it back — reclaiming it would need the executor's own
+/// tables to be provably dead first, which `Drop` cannot show for a slice it has
+/// already lent to `Dispatcher`.
+#[cfg(nros_executor_backing_static)]
+static TAKEN: AtomicBool = AtomicBool::new(false);
+
+/// Hand out [`EXECUTOR_BACKING`], once, if it can hold `words`.
+///
+/// `None` means "use the heap", and every path to it is legitimate rather than
+/// degraded — it is the caller's behaviour from before this module existed:
+///
+/// * the reservation is switched off (`NROS_EXECUTOR_BACKING_U64S=0`);
+/// * another executor already took it (a tiered boot opens one per tier);
+/// * this executor is sized past the reservation (a fat entry).
+///
+/// The `swap` is what makes the returned `&'static mut` sound: exactly one
+/// caller observes `false`, so exactly one reference to the static ever exists.
+#[cfg(nros_executor_backing_static)]
+pub(crate) fn take(words: usize) -> Option<&'static mut [MaybeUninit<u64>]> {
+    if words > EXECUTOR_BACKING_U64S {
+        return None;
+    }
+    if TAKEN.swap(true, Ordering::AcqRel) {
+        return None;
+    }
+    // SAFETY: the swap above succeeds exactly once for the life of the process,
+    // so this is the only reference ever created to `EXECUTOR_BACKING`, and it
+    // is `'static` because the static is. `words <= EXECUTOR_BACKING_U64S` was
+    // checked, so the slice is in bounds.
+    // The raw ref is bound first rather than dereferenced in place: `&mut
+    // *(&raw mut X)` reads as `deref_addrof` to clippy, and the obvious
+    // rewrite it suggests (`&mut X`) is the `static_mut_refs` hazard this
+    // spelling exists to avoid.
+    let ptr = &raw mut EXECUTOR_BACKING;
+    let all: &'static mut [MaybeUninit<u64>; EXECUTOR_BACKING_U64S] = unsafe { &mut *ptr };
+    Some(&mut all[..words])
+}
+
+/// The reservation is switched off, so there is nothing to hand out.
+///
+/// A stub rather than a `cfg` at the call site: `default_backing` reads the same
+/// either way, which is the paired-stub idiom `trace_register` uses one file
+/// over, and it keeps the `#[cfg]` in exactly one place.
+#[cfg(not(nros_executor_backing_static))]
+pub(crate) fn take(_words: usize) -> Option<&'static mut [MaybeUninit<u64>]> {
+    None
+}
+
+/// Has the static been claimed? Tests only.
+#[cfg(all(test, nros_executor_backing_static))]
+pub(crate) fn is_taken() -> bool {
+    TAKEN.load(Ordering::Acquire)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The POSITIVE CONTROL, and the reason it and the two `None` cases share
+    /// one test: `TAKEN` is process-scoped by design, so a second test would
+    /// observe an already-consumed latch and assert nothing — the vacuous shape
+    /// `check-no-vacuous-tests` exists to catch.
+    ///
+    /// A test that only ever saw `take` return `None` would pass against a `take`
+    /// that can never succeed, which is exactly the bug that would make this
+    /// whole module inert while reading as if it worked.
+    #[cfg(nros_executor_backing_static)]
+    #[test]
+    fn the_static_is_handed_out_once_and_only_once() {
+        // Too large for the reservation: refused BEFORE the latch is touched, so
+        // this case cannot consume the one handout.
+        assert!(
+            take(EXECUTOR_BACKING_U64S + 1).is_none(),
+            "a request past the reservation must fall back to the heap"
+        );
+        assert!(
+            !is_taken(),
+            "an over-large request must not claim the latch"
+        );
+
+        let first = take(EXECUTOR_BACKING_U64S).expect("the first taker gets the static");
+        assert_eq!(
+            first.len(),
+            EXECUTOR_BACKING_U64S,
+            "the handout is the requested length, not the whole reservation"
+        );
+        assert!(is_taken());
+
+        assert!(
+            take(1).is_none(),
+            "a second taker must fall back to the heap — two `&'static mut` to \
+             one static is UB, which is the whole reason for the latch"
+        );
+    }
+
+    /// With the reservation off there is no static, so `take` is inert and no
+    /// image carries the bytes.
+    #[cfg(not(nros_executor_backing_static))]
+    #[test]
+    fn the_opt_out_removes_the_reservation_entirely() {
+        assert!(
+            take(1).is_none(),
+            "NROS_EXECUTOR_BACKING_U64S=0 must hand out nothing"
+        );
+    }
+}

--- a/packages/core/nros-node/src/executor/mod.rs
+++ b/packages/core/nros-node/src/executor/mod.rs
@@ -27,6 +27,13 @@ pub mod action_core;
 pub(crate) mod activator;
 #[cfg(any(has_rmw, test))]
 mod arena;
+// phase-392 W6 — the named `.bss` static the `alloc` convenience constructors
+// serve their backing from. `alloc`-gated because it exists to replace a
+// `Box::leak`: a no-alloc entry already supplies its own `static` through
+// `open_in`, and reserving a second one there would be pure waste in exactly
+// the images this campaign is about.
+#[cfg(all(any(has_rmw, test), feature = "alloc"))]
+mod backing;
 // Phase 8 (autoware-safety-island `docs/design/callback_tracing.rst`) —
 // callback-level dispatch tracing. Same gating shape as `wake_probe`, for the
 // same reason: hot-path hooks that must vanish in production. The module ALSO

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -67,14 +67,32 @@ fn trace_register(_slot: usize, _kind: EntryKind, _name: TraceName<'_>) {}
 // Executor::open() factory method
 // ============================================================================
 
-/// phase-271 — leak a default-sized (`ExecutorSizing::DEFAULT`) `u64` backing,
-/// yielding the `'static` storage the `alloc` convenience constructors borrow.
-/// One-time, executor-lifetime allocation (the executor lives for the program);
-/// intentionally not freed. `alloc`-only — no_std-no-alloc entries supply their
-/// own `static`/stack backing via `from_session_in` / the `nros::main!` macro.
+/// phase-271 / phase-392 W6 — the `'static` `u64` backing the `alloc`
+/// convenience constructors borrow, sized to `sizing`.
+///
+/// **The named static first, the heap second.** phase-271 made this a
+/// `Box::leak`, and a leak has no symbol: `mem-report` reads an ELF's symbol
+/// table, so the largest single RAM consumer of every Rust image was the one
+/// thing the memory instrument could not see (RFC-0002 § 4.4b). It is served
+/// from `executor::backing::EXECUTOR_BACKING` now — same bytes, same
+/// executor-lifetime reservation, in `.bss` where the linker can print them and
+/// out of the allocator arena that used to pay for them.
+///
+/// The heap arm is still reached, and both cases are legitimate rather than
+/// degraded: a SECOND executor (the tiered boot paths open one per tier) and an
+/// entry sized past the build-time default. Neither is an error, so neither
+/// warns — `report_arena_headroom` is where an over-provisioned executor gets
+/// told about itself, and a duplicate line here would just be noise.
+///
+/// `alloc`-only — no_std-no-alloc entries supply their own `static`/stack
+/// backing via `open_in` / `from_session_in`.
 #[cfg(feature = "alloc")]
-fn leak_default_backing(sizing: super::storage::ExecutorSizing) -> &'static mut [MaybeUninit<u64>] {
-    alloc::boxed::Box::leak(alloc::boxed::Box::new_uninit_slice(sizing.u64_len()))
+fn default_backing(sizing: super::storage::ExecutorSizing) -> &'static mut [MaybeUninit<u64>] {
+    let words = sizing.u64_len();
+    match super::backing::take(words) {
+        Some(backing) => backing,
+        None => alloc::boxed::Box::leak(alloc::boxed::Box::new_uninit_slice(words)),
+    }
 }
 
 #[cfg(feature = "rmw-cffi")]
@@ -275,9 +293,9 @@ impl Executor<'static> {
         config: &ExecutorConfig<'_>,
         sizing: super::storage::ExecutorSizing,
     ) -> Result<Self, NodeError> {
-        // SAFETY: leaked backing is exactly `sizing.u64_len()` words, `'static`,
+        // SAFETY: the backing is exactly `sizing.u64_len()` words, `'static`,
         // uniquely owned by the returned executor.
-        unsafe { Self::open_in(config, leak_default_backing(sizing), sizing) }
+        unsafe { Self::open_in(config, default_backing(sizing), sizing) }
     }
 
     /// Phase 128.F.1 — explicit per-backend session declaration for
@@ -299,8 +317,8 @@ impl Executor<'static> {
     #[cfg(feature = "rmw-cffi")]
     pub fn open_multi(specs: &[SessionSpec<'_>]) -> Result<Self, NodeError> {
         let sizing = super::storage::ExecutorSizing::DEFAULT;
-        // SAFETY: leaked backing is exactly `sizing.u64_len()` words, `'static`.
-        unsafe { Self::open_multi_in(specs, leak_default_backing(sizing), sizing) }
+        // SAFETY: the backing is exactly `sizing.u64_len()` words, `'static`.
+        unsafe { Self::open_multi_in(specs, default_backing(sizing), sizing) }
     }
 
     /// Phase 104.C.1 — open the Executor against a specific RMW
@@ -322,8 +340,8 @@ impl Executor<'static> {
     #[cfg(feature = "rmw-cffi")]
     pub fn open_with_rmw(rmw_name: &str, config: &ExecutorConfig<'_>) -> Result<Self, NodeError> {
         let sizing = super::storage::ExecutorSizing::DEFAULT;
-        // SAFETY: leaked backing is exactly `sizing.u64_len()` words, `'static`.
-        unsafe { Self::open_with_rmw_in(rmw_name, config, leak_default_backing(sizing), sizing) }
+        // SAFETY: the backing is exactly `sizing.u64_len()` words, `'static`.
+        unsafe { Self::open_with_rmw_in(rmw_name, config, default_backing(sizing), sizing) }
     }
 }
 
@@ -1703,9 +1721,9 @@ impl Executor<'static> {
     #[cfg(feature = "alloc")]
     pub fn from_session(session: session::ConcreteSession) -> Self {
         let sizing = super::storage::ExecutorSizing::DEFAULT;
-        // SAFETY: the leaked backing is exactly `sizing.u64_len()` words,
+        // SAFETY: the backing is exactly `sizing.u64_len()` words,
         // `'static`, and uniquely owned by this executor.
-        unsafe { Self::from_session_in(session, leak_default_backing(sizing), sizing) }
+        unsafe { Self::from_session_in(session, default_backing(sizing), sizing) }
     }
 
     /// [`from_session`](Self::from_session) with an [`ExecutorConfig`], so a
@@ -1752,9 +1770,9 @@ impl Executor<'static> {
     #[cfg(feature = "alloc")]
     pub unsafe fn from_session_ptr(session_ptr: *mut session::ConcreteSession) -> Self {
         let sizing = super::storage::ExecutorSizing::DEFAULT;
-        // SAFETY: leaked backing as in `from_session`; session_ptr contract
+        // SAFETY: the backing as in `from_session`; session_ptr contract
         // forwarded to `from_session_ptr_in`.
-        unsafe { Self::from_session_ptr_in(session_ptr, leak_default_backing(sizing), sizing) }
+        unsafe { Self::from_session_ptr_in(session_ptr, default_backing(sizing), sizing) }
     }
 }
 
@@ -3972,9 +3990,11 @@ impl<'s> Executor<'s> {
 
     /// Total arena bytes this executor was given.
     ///
-    /// The arena is a borrowed slice; whether its storage is stack or `.bss` is
-    /// the caller's choice, not a property of this type (see
-    /// `report_arena_headroom`).
+    /// The arena is a borrowed slice; where its storage lives is the caller's
+    /// choice, not a property of this type. Three answers are real — a `.bss`
+    /// static (the C/C++ entries, and the `alloc` constructors since phase-392
+    /// W6), the heap (those constructors' fallback), and a stack-declared
+    /// `nros_executor_t`. See `super::backing` and `report_arena_headroom`.
     pub fn arena_capacity(&self) -> usize {
         self.arena.len()
     }

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -84,6 +84,26 @@ KNOB_CLASS = {
     "NROS_XRCE_TRANSPORT_MTU": ("sizing", "transport MTU (UDP/TCP); numeric"),
     "ZPICO_MAX_LARGE_SUBSCRIBERS": ("derived", "pool cardinality; multiplies LARGE_PAYLOADS, phase-392"),
     "ZPICO_SERVICE_BUFFER_SIZE": ("derived", "SERVICE_BUFFERS is MAX_SESSIONS x MAX_QUERYABLES; phase-392"),
+    # --- phase-392 W6: the executor backing static ---
+    # NOT a ladder candidate, and the DECISION is the interesting part. A rung
+    # gives a global a per-platform default, which is exactly wrong here: the
+    # question this answers is "has the image's author lowered the allocator
+    # arena by the same amount?", which is per-IMAGE, not per-platform (issue
+    # 1145). It is also not `derived` — nothing is computing it, and claiming a
+    # campaign owns it would overstate the backlog. It is the escape hatch on a
+    # placement decision, so: infra.
+    "NROS_EXECUTOR_BACKING_U64S": (
+        "infra",
+        "opt-out/size override for the `.bss` executor backing (phase-392 W6). "
+        "Per-image, not per-platform: the RTOS half of the move is lowering "
+        "that image's allocator arena, which only its author can measure "
+        "(issue 1145)",
+    ),
+    "NROS_EXECUTOR_BACKING_SECTION": (
+        "infra",
+        "linker section name for the executor backing (phase-392 W6, amendment "
+        "A / issue 0880). A placement, not a size",
+    ),
     # --- infra: not knobs ---
     "NROS_ALLOW_UNRESOLVED_DEPS": ("infra", "policy flag"),
     # phase-422 W8 — its own flag, deliberately NOT reusing the one above.


### PR DESCRIPTION
## The premise was half wrong, and verifying it changed the wave

W6 step 1 — *"replace `Executor`'s inline `arena` field with a reference to a
platform-provided static"* — **was already done, five phases earlier.**
phase-271 (issue 0110) made it `arena: &'s mut [MaybeUninit<u8>]`, a slice
carved from caller-supplied backing. RFC-0002 § 4.4's stable-pointer claim does
still hold, so the ownership change stayed confined to construction exactly as
predicted. phase-403 had already caught the stale text (2026-08-31); nothing had
fixed it.

So the defect was one layer down: **who supplies the backing.** Surveyed every
entry path:

| entry path | supplier | placement |
| --- | --- | --- |
| C — all 34 in-tree `nros_executor_t` objects | file-scope `static` | `.bss` |
| C++ / all six cmake entry templates | `Node::GlobalStorageHolder<0>::storage` | `.bss` |
| **Rust — every board** (linux, zephyr, freertos, nuttx, threadx, esp32-qemu, mps2-an385, RTIC, bridge, scaffold) | `Executor::open`/`open_sized`/`from_session` → `Box::leak` | **heap** |

**The arena was invisible because it was on the HEAP, not because it was on a
stack.** `mem-report` reads symbols; a leak has none.

## What landed

`nros_node::executor::backing` — a named `.bss` static the `alloc` convenience
constructors serve from, falling back to the old `Box::leak` when they cannot
(a second executor, a fat entry, or the opt-out). One shared constructor, so it
reaches every Rust board at once.

- `NROS_EXECUTOR_BACKING_SECTION` emits `#[unsafe(link_section = "…")]`
  (amendment A / issue 0880). The seam is compile-verified; nothing places it yet.
- `NROS_EXECUTOR_BACKING_U64S` resizes it; `0` declines it entirely, because on
  an RTOS the allocator arena it came out of is itself a fixed static that
  nobody lowered (issue 1145).
- No `// nros-pool:` formula: the size is a SUM whose largest term is derived,
  so the ELF is the source. Same reasoning as the two existing deliberate
  non-annotations.

## Measured, both ends, same configuration

```
bash scripts/build/fixtures-build.sh linux rust --id native-rust-talker
python3 scripts/nros-mem-report.py build/cargo-fixtures/linux/nros-relwithdebinfo/talker --json
```

| | before | after | delta |
| --- | ---: | ---: | ---: |
| `.bss` | 378,050 | 399,618 | **+21,568** |
| by-crate `nros_node` | **6** | **21,567** | +21,561 |
| `nros_node::executor::backing::EXECUTOR_BACKING` | *absent* | **21,560** | **NEW** |

Every other RAM symbol is **+0**. `nm` type letter `b` — genuinely `.bss`, no
flash cost. It is now the fourth-largest symbol in the image at 5.1 % of RAM;
before, the largest `nros_node` RAM symbol in the whole ELF was **1 byte**.

**And it runs, not merely links**: router up, session open, node + publisher
registered, `Publishing: 'Hello World: 1..7'`. Plus 328 `nros-node` unit tests
that register entities into an arena carved from the static.

**The first before/after was discarded and that is worth reading.** It reported
`−11,199`. The two builds had different pool budgets — `nros sync`'s component
probe had no artifacts on the baseline run — which is W5's own retracted-claim
failure reproduced inside this wave. Caught by requiring the *unrelated* symbols
to be unchanged; the table above is the re-run in which they are.

## The stale claim, swept

It was wider than a doc bug: it was in the **runtime advisory string**, so every
over-provisioned image was told *"the arena is INLINE ON THE TASK STACK"*.
Corrected in `report_arena_headroom`, `nros-node/build.rs`, `metadata_mode.rs`,
`Executor::arena_capacity`, RFC-0002 § 4.4b, phase-392 § 1b, phase-403,
`platform-implementation-notes.md`, `freertos-lan9118-debugging.md`,
`book/src/porting/custom-platform.md`, CLAUDE.md and AGENTS.md. Sweep:

```
grep -rn "INLINE ON THE TASK STACK\|inline arena\|arena.*on the task stack\|APP_TASK_STACK"
```

`APP_TASK_STACK` is stale too — deleted in phase-76. The live default is
`app_stack_bytes` = 384 KiB, and the debugging guide told readers to set it to
64 KB.

## Half the acceptance is NOT met, and is filed rather than fudged

- **#1146** — *"one task-stack knob reduced by a measured amount"* did not
  happen. W6's step 4 named a target that does not exist: `APP_TASK_STACK` is
  gone, the live default is 6× larger than the wave assumed, no example pins
  `NROS_EXECUTOR_ARENA_SIZE=8192`, and the wave's hypothesis ("the stack is
  carrying the arena") was already false when written.
- **#1145** — only **native/linux** was built and measured. On an RTOS the move
  is not free the way it is on a host, and the pairing needs a per-image
  measurement. Hence the opt-out knob.
- **#1147** — the C/C++ arm is in `.bss` but `mem-report` files it under the
  Rust `nros` crate.

## Tier

`just ci gate`, run step by step because the shared volume hit **0 bytes free**
mid-run (`No space left on device` across 20+ crates — reproduced twice, not
attributable to this change):

| step | result |
| --- | --- |
| `check::cli-fresh` | ok |
| `check::fast` | **239/239 ok** |
| `check-compile-smoke` | ok (workspace + all targets) |
| `check::api-parity` | ok |
| `test-unit` | **1139 tests, green** (1 capability skip) |
| `test-lane-contracts` | 17/17 |
| `check::build` (whole) | could not complete — disk exhaustion |

Plus one native image **built and run**. **No Zephyr, FreeRTOS, NuttX, ThreadX,
ESP32 or bare-metal image was built** — that is #1145, stated rather than
implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyCVgGEqVRY71PYDHKmWSv
