### PR TITLE
feat(phase-433 W2): three live verdicts, each reproduced twice

### DIFF
--- a/docs/roadmap/phase-433-rmw-live-verification.md
+++ b/docs/roadmap/phase-433-rmw-live-verification.md
@@ -305,6 +305,46 @@ the eleventh, and `just cyclonedds setup` + `just xrce setup` in the box.
 so nine binaries would skip on "zenohd not found" with a perfectly good router
 sitting in `/opt/ros/humble`.
 
+### W2 — verdicts so far (2026-09-06, in progress)
+
+| cell / binary | verdict | note |
+| --- | --- | --- |
+| `graph_interop` (zenoh) | **PASS** ×2 | 18.8 s. Enumerates a stock `rmw_zenoh_cpp` peer. |
+| `graph_interop` (cyclone) | **FAIL** ×2 | Issue 1137 — identical signature both runs: `NODE_COUNT 1`, `UNSUPPORTED_COUNT 9`, never sees the talker in 20 s. Peer ruled out by control run. |
+| `rust_multi_node_per_node_graph` | **PASS** ×2 | 2/2. One graph node per launch component, seen by a stock peer. |
+| `qos_override_e2e` | blocked | workspace-entry fixture; needs W0 in the box tree. |
+| `declarative_bridge_zenoh_to_cyclonedds` | blocked | as above. |
+| `bridge_zenoh_to_cyclonedds` | blocked | as above. |
+| `declarative_bridge_zenoh_to_xrce` | blocked | as above. |
+| `params` | blocked | issue 1135 — four tests report PASS on an unmet precondition. |
+| `cpp_multi_node_entry` | not yet run | needs `build-compile-check-fixtures`. |
+| `interop_e2e`, `xrce_ros2_interop` | not yet run | reachable, later batch. |
+| `qos_zephyr_ros2_interop_e2e` | deferred | only `ZephyrWestLeaves` cell; second build channel. |
+
+**The box reproduces issue 1136 independently** — `Cannot find source file:
+LAUNCH_ARGS` at `NanoRosEntry.cmake:426`, the same coordinate CI dies on. So
+every workspace-entry cell is blocked in the box until W0 lands and the mirror
+re-syncs; the mirror predates the fix. That is also useful confirmation that
+1136 is not a CI-only artifact.
+
+**The build ORDER is load-bearing and cost a whole batch.** `just native
+build-workspace-fixtures` runs `nros sync`, which rewrites `generated/` trees
+and therefore re-stales every row fixture built before it. The correct sequence
+is **CLI → anything that syncs → row fixtures → tests**, and nothing that
+rewrites sources may run in between. Doing rows first produced a batch where
+every cell failed `Test fixture is STALE — a source is newer than the built
+binary`, which reads exactly like breakage.
+
+All three verdicts above were reproduced on a second, independent run with the
+harness defects fixed — which is the standard this phase should hold itself to,
+given how many first-run reds turned out to be mine.
+
+**Scoreboard for the method, not the code.** Of the reds W2 has produced so far,
+**one** was a real defect (1137) and **four** were harness defects of mine:
+running the container as root, an inconsistently stamped CLI, the PATH order of
+issue 1144, and this ordering. The cells have been honest every time. Filing
+from any of those four would have been an 0859-0862 repeat.
+
 ### W3 — the language-axis correction — **DONE 2026-09-06 (PR #587)**
 
 `scenario_coord` derives the language now. Only the cyclone half was wrong:


### PR DESCRIPTION
Supersedes #615 (its branch went push-protected in the merge queue); the harness commit is carried here.

## Verdicts

| cell | verdict | |
| --- | --- | --- |
| `graph_interop` zenoh | **PASS** | ×2 |
| `graph_interop` cyclone | **FAIL** | ×2 — issue #1137 |
| `rust_multi_node_per_node_graph` | **PASS** | ×2 |

Cyclone's signature is **identical across both runs** — `GRAPH_PROBE_NODE_COUNT 1`, `GRAPH_PROBE_UNSUPPORTED_COUNT 9`, never sees the talker in 20 s — so #1137 is confirmed, not a one-off. Every verdict here was reproduced on a second independent run after the harness defects were fixed, which is the standard this phase should hold itself to given how many first-run reds turned out to be mine.

## The box reproduces #1136 independently

`Cannot find source file: LAUNCH_ARGS` at `NanoRosEntry.cmake:426`, the same coordinate CI dies on. So it is not a CI-only artifact. Every workspace-entry cell (`qos_override_e2e`, the three bridges) stays blocked in the box until #621 lands and the mirror re-syncs — the mirror predates the fix.

## Harness defects (the earlier commit, plus one more)

Carried from #615: `podman exec` runs as **root** (git refuses the box tree as dubiously-owned → `[SKIPPED] fixture not built` → nextest renders it **FAIL**); the root run stamps the box CLI inconsistently; and **issue #1144** — `ros2-box-env.sh` prepends the box's tool dir before sourcing `activate.sh`, whose own prepend of `$HOME/.cargo/bin` is *conditional*, so in a non-login shell the host's glibc-2.39 `just` wins.

**New here, and the one most worth writing down.** `just native build-workspace-fixtures` runs `nros sync`, which rewrites `generated/` trees and therefore **re-stales every row fixture built before it**. I built rows first, then synced, then tested: every cell failed `Test fixture is STALE — a source is newer than the built binary`, which reads exactly like breakage. The order is **CLI → anything that syncs → row fixtures → tests**, with nothing that rewrites sources in between. CLAUDE.md documents this treadmill; I walked into it anyway.

## Scoreboard for the method, not the code

Of W2's reds so far, **one** was a real defect (#1137) and **five** were mine: container-as-root, the inconsistently stamped CLI, the #1144 PATH order, this fixture ordering, and a module-recipe spelling. **The cells have been honest every time.** Filing from any of the five would have been an 0859–0862 repeat — four retracted issues, two with confident wrong root causes.

## Verification

`just check fast` 243/243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP