### PR TITLE
test(phase-433 W6): give the ACTIONS family a live-peer interop cell — and restore the half of it that was deleted

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -770,6 +770,25 @@ test-group = "host-dds-ros2-interop"
 slow-timeout = { period = "60s", terminate-after = 3 }
 retries = 2
 
+# phase-433 W6 — the ACTIONS live-peer lane, routed exactly like the cyclone
+# half of `interop_e2e` above and for the same two reasons.
+#
+# GROUP: it stands up a real RTPS participant on a `unique_ros_domain_id`
+# domain, so it competes for the same 232-slot space the group exists to bound.
+# It had no override at all, which is how a real-DDS binary ends up ungrouped.
+#
+# BUDGET: the default is `30s × 2` = terminated at 60 s, and this binary's own
+# budget is larger than that — up to 20 s of discovery polling plus a
+# `timeout 60` on the goal. So the default would kill it before its own timeout
+# fired, replacing the assertion's diagnostic with a nextest timeout. 60s × 3
+# covers the worst case with headroom; `retries = 2` re-rolls the PID → domain
+# on the residual collision, as for every sibling host-DDS lane.
+[[profile.default.overrides]]
+filter = "binary(=ros2_action_e2e)"
+test-group = "host-dds-ros2-interop"
+slow-timeout = { period = "60s", terminate-after = 3 }
+retries = 2
+
 [[profile.default.overrides]]
 filter = "binary(interop_e2e)"
 test-group = "ros2-interop"

--- a/just/native.just
+++ b/just/native.just
@@ -770,6 +770,7 @@ test-all verbose="":
     just native test-ros2 {{verbose}} || failed=1
     just native test-ros2-params {{verbose}} || failed=1
     just native test-ros2-lifecycle {{verbose}} || failed=1
+    just native test-ros2-action {{verbose}} || failed=1
     just native test-native-api {{verbose}} || failed=1
     just native test-c-xrce {{verbose}} || failed=1
     just native _test-c-codegen {{verbose}} || failed=1
@@ -860,6 +861,21 @@ test-ros2-lifecycle verbose="":
 [group("debug")]
 test-ros2-graph verbose="":
     @just _test-focused 'binary(=graph_interop)' {{verbose}}
+
+# The `ros2 action …` family against nano-ros action nodes — phase-433 W6 /
+# issue 1127. Two `interop::CELLS` cells (`native-action-rust-cyclone-*`), and
+# the n2r direction additionally needs
+# `ros-<distro>-examples-rclcpp-minimal-action-server` for its peer; each is a
+# `skip!` when absent, never a red.
+#
+# Written through `_test-focused` like its siblings above. The branch that
+# added this lane predates that helper and carried its own copy of the
+# skip-accounting tail; a second spelling of the same accounting is the #282 ->
+# #326 shape, so the copy went and the helper stayed.
+# Runs `ros2_action_e2e`; needs ROS 2 + `rmw_cyclonedds_cpp` + the native action fixtures.
+[group("debug")]
+test-ros2-action verbose="":
+    @just _test-focused 'binary(=ros2_action_e2e)' {{verbose}}
 
 # A plan-level QoS override reaches the ADVERTISED profile a stock
 # `ros2 topic info --verbose` peer reads (issue #52 / 0303 / 0306). Nextest

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -270,6 +270,30 @@ pub const CELLS: &[InteropCell] = &[
        c(Linux, Rust, Cyclonedds, Graph, Interop, Runtime),
        NativeFixtures, RosEdition(Cyclonedds), RosToNano, "graph_interop"),
 
+    // ── phase-433 W6 — the ACTIONS family's live peer ────────────────────
+    // tests/ros2_action_e2e.rs. Until this row the family had NO interop cell
+    // at all: every action row in `matrix::CELLS` is nano-to-nano, and both
+    // ends of such a pair share whatever convention `service.cpp`'s five CDR
+    // adapters implement, so the one property the adapters exist to provide is
+    // the one property those rows cannot observe (issue 0976). Actions are also
+    // the family with the widest unexplained runtime spread — issue 0902
+    // measured goals completing 20–90 % of the time on one build — which is a
+    // shape only a live peer surfaces.
+    //
+    // BOTH directions, one coordinate. The adapters sit on both sides of the
+    // service path: `strip_goal_id_len_at` / `strip_nested_cdr_at` fire only
+    // when nano-ros WRITES a SendGoal/GetResult request, so the R2N cell (a
+    // stock `ros2 action send_goal` into the nano server) does not reach them
+    // and the N2R cell (the nano client into a stock server) is where they run.
+    // `coords_for` collapses direction, so `assert_test_bound` in that file
+    // names the coordinate once.
+    ic("native-action-rust-cyclone-r2n",
+       c(Linux, Rust, Cyclonedds, Action, Interop, Runtime),
+       NativeFixtures, RosEdition(Cyclonedds), RosToNano, "ros2_action_e2e"),
+    ic("native-action-rust-cyclone-n2r",
+       c(Linux, Rust, Cyclonedds, Action, Interop, Runtime),
+       NativeFixtures, RosEdition(Cyclonedds), NanoToRos, "ros2_action_e2e"),
+
     // ── Native nano XRCE ↔ Agent ↔ fastrtps ─────────────────────────────
     // tests/xrce_ros2_interop.rs.
     ic("native-pubsub-rust-xrce-n2r",

--- a/packages/testing/nros-tests/tests/ros2_action_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros2_action_e2e.rs
@@ -15,19 +15,30 @@
 //! and service paths already had witnesses (`ros2_pubsub_e2e`, `ros2_srv_e2e`);
 //! actions had none.
 //!
-//! This is that witness: a stock `ros2 action send_goal`, over
-//! `rmw_cyclonedds_cpp`, against the nano-ros action server. It is also what
-//! unblocks issue 0970's service half — migrating `service.cpp` to a blob
-//! sertype would change the action wire format, and nothing in the tree could
-//! tell.
+//! This is that witness: a stock `ros2 action …`, over `rmw_cyclonedds_cpp`,
+//! against a nano-ros action node — in BOTH directions, because the adapters
+//! sit on both sides of the service path. It is also what unblocks issue 0970's
+//! service half — migrating `service.cpp` to a blob sertype would change the
+//! action wire format, and nothing in the tree could tell.
+//!
+//! Interop cells: `native-action-rust-cyclone-r2n` and
+//! `native-action-rust-cyclone-n2r` (`nros_tests::interop::CELLS`). This file is
+//! the ACTIONS family's only live-peer coverage — every action row in
+//! `matrix::CELLS` is nano-to-nano.
 
-use std::process::Command;
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
 
 use nros_tests::{
     fixtures,
     ros_env::{HostRosEnv, Middleware, RosEnv},
-    ros2::{DEFAULT_ROS_DISTRO, require_ros2_cyclonedds},
+    ros2::{DEFAULT_ROS_DISTRO, is_ros2_package_available, require_ros2_cyclonedds},
 };
+
+/// The stock ROS 2 action server the nano-ros CLIENT direction drives.
+const PEER_ACTION_SERVER_PKG: &str = "examples_rclcpp_minimal_action_server";
 
 /// A domain no concurrent copy of this test will pick.
 ///
@@ -39,6 +50,50 @@ fn action_domain() -> u8 {
     nros_tests::unique_ros_domain_id()
 }
 
+/// Single-quote a path for the shell `RosEnv::run` builds.
+///
+/// The fixture path comes from the build tree, so it is ours rather than a
+/// user's — but quoting it is one line and an unquoted path with a space
+/// fails as "command not found", which reads as a missing fixture.
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// Block until `/fibonacci` is on the bus, and FAIL — naming discovery — if it
+/// never gets there.
+///
+/// This replaces a flat `sleep(6)`, which answers the wrong question in both
+/// directions: when discovery is merely slow the sleep expires early and the
+/// failure surfaces one layer down as a missing `Goal accepted`, which reads as
+/// a wire-format defect — the exact misattribution this file exists to prevent
+/// (see the `strip_goal_id_len_at` note below). When discovery is fast the
+/// sleep is six seconds of nothing.
+///
+/// `--no-daemon`, for the reason every query helper in `nros_tests::ros2`
+/// passes it: the ros2cli daemon is a singleton keyed on `ROS_DOMAIN_ID` alone
+/// and serves a stale `RMW_IMPLEMENTATION` snapshot to whoever asks second.
+fn await_fibonacci_action(env: &HostRosEnv, whose: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut last;
+    loop {
+        last = env
+            .run_text("timeout --foreground 10 ros2 action list --no-daemon 2>&1")
+            .unwrap_or_else(|e| format!("<`ros2 action list` failed: {e}>"));
+        if last.lines().any(|l| l.trim() == "/fibonacci") {
+            return;
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    panic!(
+        "the {whose} `/fibonacci` action never appeared in `ros2 action list` \
+         within 20 s, so the goal below could only have failed for a discovery \
+         reason wearing a wire-format costume. Last listing:\n{last}"
+    );
+}
+
 /// A real ROS 2 client drives a goal on the nano-ros action server.
 ///
 /// Asserts the RESULT CONTENT, not merely that the call returned: the adapters
@@ -46,6 +101,8 @@ fn action_domain() -> u8 {
 /// shows up as a wrong sequence or a goal that is never accepted. Checking only
 /// for a zero exit would pass on a server that accepted the goal and computed
 /// nothing, which is the vacuous shape `check-no-vacuous-tests` exists for.
+///
+/// Interop cell: `native-action-rust-cyclone-r2n`.
 #[test]
 fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
     if !require_ros2_cyclonedds() {
@@ -68,10 +125,6 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
         .spawn()
         .expect("start the nano-ros action server");
 
-    // Discovery over DDS multicast is not instant, and `send_goal` on an
-    // undiscovered action fails rather than waiting.
-    std::thread::sleep(std::time::Duration::from_secs(6));
-
     // `RosEnv`, not a hand-rolled `source /opt/ros/...` (RFC-0058). A second
     // spelling drifts from the first invisibly: the last one dropped the peer's
     // ROS_DOMAIN_ID, and another hardcoded `humble` so every guarded test
@@ -81,10 +134,19 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
         DEFAULT_ROS_DISTRO,
         Middleware::Cyclonedds { domain_id: domain },
     );
+
+    // Discovery over DDS is not instant, and `send_goal` on an undiscovered
+    // action fails rather than waiting.
+    await_fibonacci_action(&env, "nano-ros");
+
     let out = env
         .run("timeout 60 ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci '{order: 5}'")
         .expect("run ros2 action send_goal");
 
+    // Whether the server was still ALIVE, asked before killing it. A server
+    // that died mid-goal and a server that answered wrongly produce the same
+    // missing `SUCCEEDED`, and the two want different investigations.
+    let died = server.try_wait().ok().flatten();
     let _ = server.kill();
     let _ = server.wait();
 
@@ -95,6 +157,12 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
     );
 
     assert!(
+        died.is_none(),
+        "the nano-ros action server exited on its own ({died:?}) before the \
+         goal finished — the client output below is about a dead peer, not \
+         about the wire format.\n{text}"
+    );
+    assert!(
         text.contains("Goal accepted"),
         "a stock ROS 2 client must get the goal ACCEPTED — the server has to \
          read a real ROS 2 SendGoal request, UUID and all.\n\
@@ -102,7 +170,8 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
          adapter fires only when nano-ros WRITES a SendGoal/GetResult request, \
          and here `ros2` writes them. What guards the server's receive side is \
          `split_wire_header`'s deliberate non-insertion (service.cpp:589-599, \
-         issue #68).\n{text}"
+         issue #68). The direction where nano-ros writes them is the sibling \
+         test below.\n{text}"
     );
     assert!(
         text.contains("SUCCEEDED"),
@@ -117,4 +186,122 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
              to the wrong numbers rather than failing.\n{text}"
         );
     }
+}
+
+/// The nano-ros action CLIENT drives a stock ROS 2 action server.
+///
+/// The reverse of the cell above, and not redundant with it: the adapters sit
+/// on BOTH sides of the service path. Sending a goal exercises
+/// `strip_goal_id_len_at` and `strip_nested_cdr_at` on what nano-ros WRITES;
+/// receiving feedback and a result exercises the take path against bytes a real
+/// ROS 2 server produced. One direction passing says nothing about the other —
+/// which is the whole reason a nano-ros-to-nano-ros test could not settle this.
+///
+/// The peer is [`PEER_ACTION_SERVER_PKG`], which serves `/fibonacci` over
+/// `example_interfaces/action/Fibonacci` — the same action and type the
+/// nano-ros client targets.
+///
+/// Interop cell: `native-action-rust-cyclone-n2r`.
+#[test]
+fn the_nano_ros_action_client_drives_a_stock_ros2_server() {
+    if !require_ros2_cyclonedds() {
+        nros_tests::skip!("ROS 2 + rmw_cyclonedds_cpp not available");
+    }
+    // The peer is a SEPARATE apt package from the distro and from the RMW, so a
+    // host that has both can still lack it. Without this guard the absence
+    // lands as a failed `Goal accepted` — an unprovisioned host reported as a
+    // wire-format red, which is the inverse of a false skip and just as
+    // misleading (`HostRosEnv::available`'s reasoning, one package further out).
+    if !is_ros2_package_available(DEFAULT_ROS_DISTRO, PEER_ACTION_SERVER_PKG) {
+        nros_tests::skip!(
+            "ROS 2 peer package `{PEER_ACTION_SERVER_PKG}` not installed \
+             (apt: ros-{DEFAULT_ROS_DISTRO}-examples-rclcpp-minimal-action-server)"
+        );
+    }
+
+    let client_bin = fixtures::build_native_rust_example_rmw(
+        "action-client",
+        "action-client",
+        fixtures::Rmw::Cyclonedds,
+    )
+    .unwrap_or_else(|e| {
+        nros_tests::skip!("native rust cyclonedds action-client fixture: {e}");
+    });
+
+    let domain = action_domain();
+    let env = HostRosEnv::new(
+        DEFAULT_ROS_DISTRO,
+        Middleware::Cyclonedds { domain_id: domain },
+    );
+
+    // `RosPeer` kills the whole process group on drop, so a failed assertion
+    // below cannot leave a `ros2` server behind to collide with the next run —
+    // the orphan-peer shape that makes a later test fail for an earlier test's
+    // reason.
+    let mut server = env
+        .spawn(
+            "minimal_action_server",
+            &format!("ros2 run {PEER_ACTION_SERVER_PKG} action_server_member_functions"),
+        )
+        .expect("start the stock ROS 2 action server");
+
+    await_fibonacci_action(&env, "stock ROS 2");
+
+    // Through the ROS env with an explicit `timeout`, NOT a bare
+    // `Command::output()`. The client blocks waiting for a server it has not
+    // discovered, and `output()` has no deadline — the first version of this
+    // test hung for ten minutes instead of failing in one. A test that cannot
+    // fail in bounded time is not a test.
+    let out = env
+        .run(&format!(
+            "timeout 60 {}",
+            shell_escape(&client_bin.to_string_lossy())
+        ))
+        .expect("run the nano-ros action client");
+
+    let peer_alive = server.is_running();
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Same reason as the forward cell: a peer that died mid-goal and a peer
+    // that answered wrongly are one symptom and two different bugs.
+    assert!(
+        peer_alive,
+        "the stock ROS 2 action server exited before the goal finished — the \
+         client output below is about a dead peer, not about the wire \
+         format.\n{text}"
+    );
+    assert!(
+        text.contains("Goal accepted"),
+        "a real ROS 2 server must ACCEPT the goal nano-ros wrote — this is the \
+         side `strip_goal_id_len_at` and `strip_nested_cdr_at` reshape.\n{text}"
+    );
+    // Fibonacci(10). Asserted as the whole sequence: a reshaped result decodes
+    // to wrong numbers rather than failing, so a substring like "Result" would
+    // pass on garbage.
+    assert!(
+        text.contains("Result received: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]"),
+        "the result from a stock server must decode to Fibonacci(10).\n{text}"
+    );
+    // Feedback travels a different message than the result, and only the
+    // feedback path exercises the server's own periodic publish.
+    assert!(
+        text.contains("Next number in sequence received"),
+        "feedback from a stock server must reach the nano-ros client.\n{text}"
+    );
+}
+
+// phase-433 W6 — bind this file to `interop::CELLS`. Both directions sit on ONE
+// coordinate (directions collapse, per `interop::coords_for`), so the list
+// below stays a single entry however many directions the file grows. Drift
+// between the cases here and the rows there turns this RED. Needs no fixtures
+// and no ROS 2 — it runs in tier 1.
+#[test]
+fn cases_bound_to_interop_cells() {
+    #[allow(unused_imports)]
+    use nros_tests::matrix::{Lang::*, PlatformId::*, Rmw::*, Workload::*};
+    nros_tests::interop::assert_test_bound("ros2_action_e2e", &[(Linux, Rust, Cyclonedds, Action)]);
 }


### PR DESCRIPTION
phase-433 W6 job 1 — the ACTIONS family had no `interop::CELLS` row at all, while
`tests/ros2_action_e2e.rs` drove a live ROS 2 peer bound to nothing and named by no
recipe. This adds the cells, the tripwire, a focused runner and the nextest routing
the binary never had — and restores the half of the test that a docs commit deleted.

## What `ros2_action_e2e.rs` actually tests

**Peer** a stock `ros2 action send_goal` over `rmw_cyclonedds_cpp`, on a
`unique_ros_domain_id` domain. **Nano side** the prebuilt
`examples/native/rust/action-server` cyclone fixture (`build_native_rust_example_rmw`
→ **Rust**, which is where the declared `Lang` comes from — phase-433 W3's lesson).
**Direction** ROS → nano (nano is the server).

**Assertions are strong enough to bind.** It checks the RESULT CONTENT — `Goal
accepted`, `SUCCEEDED`, and each Fibonacci term — not an exit code, and its own
failure text already names the adapter it does *not* exercise. No vacuous probe, no
bare `return` guard, no upper-bound-only timing assertion.

## The weakness that mattered: half the file was deleted

`8014045ce` added `the_nano_ros_action_client_drives_a_stock_ros2_server` — the
direction where nano-ros **writes** the SendGoal/GetResult request, which is the only
direction `strip_goal_id_len_at` and `strip_nested_cdr_at` run in, and the reason
issue 0976 exists. `3866550b6`, a docs commit an hour later, removed all 93 lines of
it in a 102-line `-` hunk and then described the result in prose ("the action witness
runs the server direction only") as though it had always been so. Nothing noticed:
the file was in no lane and bound to no cell — the same absence this PR closes.

**Restored**, with its peer (`examples_rclcpp_minimal_action_server`, a separate apt
package from the distro and the RMW) now guarded by `is_ros2_package_available` so an
unprovisioned host `skip!`s instead of reporting a wire-format red.

## Other fixes to the test

- Both directions replace `sleep(6)` with `await_fibonacci_action`, which polls
  `ros2 action list --no-daemon` and **fails naming discovery**. A fixed sleep expires
  early when discovery is merely slow, and the failure then surfaces one layer down as
  a missing `Goal accepted` — a discovery problem wearing a wire-format costume, in
  the one file whose job is telling those apart.
- Both directions assert the **peer is still alive** before reading its output. A peer
  that died mid-goal and a peer that answered wrongly are one symptom and two bugs.

## Cells, tripwire, runner, G5

| | |
|---|---|
| Cells | `native-action-rust-cyclone-r2n`, `native-action-rust-cyclone-n2r` |
| Coordinate | `(Linux, Rust, Cyclonedds, Action)` — one, since directions collapse in `coords_for` |
| Tripwire | `assert_test_bound("ros2_action_e2e", &[(Linux, Rust, Cyclonedds, Action)])` |
| Runner | `just native test-ros2-action`, in the `native` module beside `test-ros2{,-params,-lifecycle}`, with `just xrce test-ros2`'s skip-aware tail |
| Ledger | `.config/interop-cells-without-runner.txt` unchanged — no new line |

**G5 was already satisfied.** `examples/fixtures.toml` carries `linux`/`rust`/`cyclonedds`
rows for both `action-server` and `action-client` (the #234 pair), so the coordinate is
manifest-backed and every lane can narrow it. No fixture row invented.

## Nextest routing the binary had none of

It stands up a real RTPS participant on a `unique_ros_domain_id` domain and was in no
test-group, so it competed unbounded for the 232-slot space `host-dds-ros2-interop`
exists to bound. And the default budget is `30s × 2` = killed at 60 s, against a binary
whose own budget is up to 20 s of discovery plus a `timeout 60` — the default would
have terminated it *before its own timeout fired*, replacing the assertion's diagnostic
with a nextest timeout. Routed exactly like the cyclone half of `interop_e2e`.

## Verification

- `just check fast` — **243/243 OK** (after `just setup-clang-format`; `c-fmt`/`cpp-fmt`
  had flagged two untouched zephyr C files under this host's clang-format 22.1.8 vs the
  pinned 17.0.6).
- `cargo nextest run -p nros-tests --test matrix_fixture_coverage` — **10/10**, G5 included.
- `scripts/check-interop-cell-runners.py` — OK, **10/19** Runtime cells now have a named
  runner (was 8/17); `--self-test` OK.
- `just native test-ros2-action` on this ROS-less host — both live cases `[SKIPPED]`,
  `cases_bound_to_interop_cells` PASS, `Real failures: 0`, **exit 0**.

## Already red on `origin/main` (4ad88ef86), not from this PR

- **`just ci gate` cannot pass.** `check-build` loses 9 of 21 gates to one compile error:
  `nros_node_get_fully_qualified_name` defined twice in `packages/api/nros-c/src/node.rs`
  (`:672` and `:980`, from the #417 W-B5 forwarder retirement). `check-build` is
  `schedule`/`workflow_dispatch` only, which is how it landed.
- **`ci_lane::tests::documented_lane_table_is_live`** fails "Tier2: the table says 14
  coords; recomputed 13". Reproduced identically with this PR's `interop.rs` stashed, so
  the two new cells did not move it. `just test-unit` passes `--exclude nros-tests`, so no
  merge-gating lane runs it.

Also noted, not fixed: `ros2_action_e2e` spawns its nano side with no `CYCLONEDDS_URI`
while `HostRosEnv` pins the ROS side to loopback — the issue-1009 "pin both sides or
neither" shape. The pin landed 2026-09-04, a day *after* this test was last measured
passing, and it has not been re-measured since. Four nano-side cyclone spawns share the
gap (`ros_env::nano_node_cmd`, `nano_node_cmd_rmw`, this file, `ros_editions_nano_interop`);
closing it blind across the edition lanes is not something to do in a PR that can't run
them. Worth a follow-on that can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP
