### PR TITLE
fix(#1162): the FQN C symbol was defined TWICE, and main could not compile it

### DIFF
--- a/docs/issues/archived/1162-fqn-c-symbol-defined-twice.md
+++ b/docs/issues/archived/1162-fqn-c-symbol-defined-twice.md
@@ -1,0 +1,85 @@
+---
+id: 1162
+title: "`nros_node_get_fully_qualified_name` was defined TWICE with different signatures — main's C API could not compile, and no merge-gating lane noticed"
+status: resolved
+type: bug
+area: api, build
+severity: high
+found: 2026-09-06
+related: [0417]
+---
+
+# Two PRs shipped the same capability, and the collision was invisible
+
+`packages/api/nros-c/src/node.rs` on `origin/main` carried two
+`#[unsafe(no_mangle)]` definitions of `nros_node_get_fully_qualified_name`,
+with **different signatures**:
+
+| | source | signature |
+| --- | --- | --- |
+| `:672` | PR #567 (phase-433 side work) | `(node, buf, buf_len, out_len)` |
+| `:980` | PR #417 W-B5 | `(node, output_name, output_size)` |
+
+Both were emitted into the committed `nros_generated.h`, so the header
+declared the same symbol twice with incompatible prototypes. `check-build`
+lost **9 of 21 gates** to it.
+
+Neither author was wrong about the capability — the parity ledger had
+`c:node_get_fully_qualified_name` as a `gap`, and two work streams closed it
+independently within days. Both even reached the same design conclusions
+(compose via `expand_name`, refuse rcl's `const char *`, return `NROS_RET_FULL`
+on a short buffer), which is reassuring about the design and damning about the
+coordination.
+
+## Why nothing caught it
+
+`check-build` is `schedule`/`workflow_dispatch` only — deliberately, because it
+needs generated bindings and prebuilt `.compile-ok` artifacts that no
+merge-gating job produces (recorded in CLAUDE.md). It is the **only** lane that
+compiles `packages/api/nros-c/tests/compile/*.c`. So a duplicate `no_mangle`
+export, a broken generated header, and a compile test pinning the wrong arity
+all landed on `main` and stayed.
+
+`just ci gate` — the tier a contributor is told to run before pushing — could
+not pass on `main` for as long as this sat there.
+
+## Resolution
+
+Kept the four-argument form and merged the better half of the other:
+
+* **Signature**: `(node, buf, buf_len, out_len)`. `out_len` is a real
+  capability — a caller that gets `NROS_RET_FULL` learns the size that would
+  have worked — and `nros-cpp`'s `Node::get_fully_qualified_name` and
+  `std_compat`'s `std::string` overload are both written against it.
+* **Body**: taken from #417's version. It reads the name with
+  `inline_str(&node_ref.name, node_ref.name_len)` rather than
+  `CStr::from_ptr`, which matters because the name is an inline array with a
+  stored length and a name that fills it need not be NUL-terminated. It also
+  uses the file's own `validate_not_null!` / `validate_state!` macros.
+* **Docs**: kept #417's RFC-0020 violation-class-4 argument for why the
+  composition is not written in the C layer.
+* The shared `write_fqn` tail stays, so this and the two-string
+  `nros_get_fully_qualified_name` cannot disagree about the terminator, the
+  too-small report, or what `out_len` means.
+* `packages/api/nros-c/tests/compile/node_timer_accessors.c` asserted the
+  three-argument shape; updated, with a comment recording why it was wrong.
+* Header regenerated (`cargo run -p nros-cbindgen-headers`).
+
+Verified: `cargo build -p nros-c`, `cargo nextest run -p nros-c` 31/31,
+`just check c` green.
+
+## The durable question
+
+A duplicate `#[no_mangle]` in one crate is a compile error the moment anything
+builds it, so this is not subtle — it is only invisible because the lane that
+would see it is unaffordable on a pull request. Two candidate fixes, neither
+free:
+
+1. A cheap static gate: no two `#[unsafe(no_mangle)] pub unsafe extern "C" fn`
+   in the C API crate may share a name. Buildless, so it can sit on the fast
+   line. Narrow, but it catches exactly this.
+2. Compile *one* representative C TU on the merge path. That is the general
+   answer and it costs what `check-build` costs, which is why it is not there.
+
+Option 1 is worth doing regardless; it is minutes of work and this class has
+now cost a day of `ci gate` on `main`.

--- a/packages/api/nros-c/include/nros/nros_generated.h
+++ b/packages/api/nros-c/include/nros/nros_generated.h
@@ -5716,6 +5716,15 @@ nros_ret_t nros_get_fully_qualified_name(const char *node_name,
  * As [`nros_get_fully_qualified_name`], plus `NROS_RET_NOT_INIT` when the node
  * is not initialised.
  *
+ * The composition is NOT written here. It is `nros_node::names::
+ * fully_qualified_name`, which is `expand_name` with the private-name source
+ * `~` — the same seam every entity name on this node goes through
+ * (`Executor::resolve_entity_name_for`), so a node's FQN and its entities'
+ * FQNs can never disagree about namespace normalisation. A second
+ * `push(namespace); push('/'); push(name)` in the C layer is exactly
+ * RFC-0020's violation class 4, name construction in a wrapper, and it is
+ * what the four sibling implementations of this already spelled differently.
+ *
  * # Safety
  * * `node` must be a valid pointer to an initialised node
  * * `buf` must be writable for `buf_len` bytes; `out_len` must be valid or NULL
@@ -5827,38 +5836,6 @@ NROS_PUBLIC bool rcl_node_is_valid(const struct nros_node_t *node);
  * * `domain_id` must be NULL or writable.
  */
 NROS_PUBLIC nros_ret_t nros_node_get_domain_id(const struct nros_node_t *node, uint32_t *domain_id);
-
-/**
- * The node's namespace and name as one string — `/ns/name`, the form that
- * appears on the wire.
- *
- * rcl's `rcl_node_get_fully_qualified_name`. Gap
- * `c:node_get_fully_qualified_name` records that we exposed
- * `rcl_node_get_name` and `rcl_node_get_namespace` separately and never
- * their composition.
- *
- * The composition is NOT written here. It is `nros_node::names::expand_name`
- * with the private-name source `~`, which is by definition
- * `/<ns>/<node>` — the same seam every entity name on this node goes
- * through (`Executor::resolve_entity_name_for`), so a node's FQN and its
- * entities' FQNs can never disagree about namespace normalisation. A second
- * `push(namespace); push('/'); push(name)` in the C layer is exactly
- * RFC-0020's violation class 4 (name construction in a wrapper), and it is
- * what the four sibling implementations of this already spelled differently.
- *
- * **Divergence from rcl, deliberate:** rcl returns `const char *` into
- * node-owned storage. We have no allocator and the node struct holds no
- * composed buffer, so the caller supplies one. `NROS_RET_FULL` when it is
- * too small — a truncated FQN names a different node.
- *
- * # Safety
- * * `node` must be NULL or point to a valid `nros_node_t`.
- * * `output_name` must be NULL or writable for `output_size` bytes.
- */
-NROS_PUBLIC
-nros_ret_t nros_node_get_fully_qualified_name(const struct nros_node_t *node,
-                                              char *output_name,
-                                              size_t output_size);
 
 /**
  * Expand `input_name` against this node's namespace and apply its remap

--- a/packages/api/nros-c/src/node.rs
+++ b/packages/api/nros-c/src/node.rs
@@ -665,6 +665,15 @@ pub unsafe extern "C" fn nros_get_fully_qualified_name(
 /// As [`nros_get_fully_qualified_name`], plus `NROS_RET_NOT_INIT` when the node
 /// is not initialised.
 ///
+/// The composition is NOT written here. It is `nros_node::names::
+/// fully_qualified_name`, which is `expand_name` with the private-name source
+/// `~` — the same seam every entity name on this node goes through
+/// (`Executor::resolve_entity_name_for`), so a node's FQN and its entities'
+/// FQNs can never disagree about namespace normalisation. A second
+/// `push(namespace); push('/'); push(name)` in the C layer is exactly
+/// RFC-0020's violation class 4, name construction in a wrapper, and it is
+/// what the four sibling implementations of this already spelled differently.
+///
 /// # Safety
 /// * `node` must be a valid pointer to an initialised node
 /// * `buf` must be writable for `buf_len` bytes; `out_len` must be valid or NULL
@@ -675,19 +684,23 @@ pub unsafe extern "C" fn nros_node_get_fully_qualified_name(
     buf_len: usize,
     out_len: *mut usize,
 ) -> nros_ret_t {
-    if node.is_null() || buf.is_null() || buf_len == 0 {
+    validate_not_null!(node, buf);
+    if buf_len == 0 {
         return NROS_RET_INVALID_ARGUMENT;
     }
-    let node = &*node;
-    if node.state != nros_node_state_t::NROS_NODE_STATE_INITIALIZED {
+    let node_ref = &*node;
+    validate_state!(node_ref, nros_node_state_t::NROS_NODE_STATE_INITIALIZED);
+
+    // `inline_str` and not `CStr::from_ptr`: the name is an inline array with a
+    // stored length, and a name that fills it need not be NUL-terminated. This
+    // half came from the duplicate definition #417 landed (issue 1162) — it was
+    // the better read, and keeping it is most of why that collision was worth
+    // resolving by hand rather than by deleting one side.
+    let name = inline_str(&node_ref.name, node_ref.name_len);
+    if name.is_empty() {
         return NROS_RET_NOT_INIT;
     }
-    let (Ok(name), Ok(ns)) = (
-        core::ffi::CStr::from_ptr(node.name.as_ptr() as *const c_char).to_str(),
-        core::ffi::CStr::from_ptr(node.namespace.as_ptr() as *const c_char).to_str(),
-    ) else {
-        return NROS_RET_INVALID_ARGUMENT;
-    };
+    let ns = inline_str(&node_ref.namespace, node_ref.namespace_len);
     write_fqn(name, ns, buf, buf_len, out_len)
 }
 
@@ -948,53 +961,6 @@ pub unsafe extern "C" fn nros_node_get_domain_id(
     {
         let _ = node_ref;
         NROS_RET_UNSUPPORTED
-    }
-}
-
-/// The node's namespace and name as one string — `/ns/name`, the form that
-/// appears on the wire.
-///
-/// rcl's `rcl_node_get_fully_qualified_name`. Gap
-/// `c:node_get_fully_qualified_name` records that we exposed
-/// `rcl_node_get_name` and `rcl_node_get_namespace` separately and never
-/// their composition.
-///
-/// The composition is NOT written here. It is `nros_node::names::expand_name`
-/// with the private-name source `~`, which is by definition
-/// `/<ns>/<node>` — the same seam every entity name on this node goes
-/// through (`Executor::resolve_entity_name_for`), so a node's FQN and its
-/// entities' FQNs can never disagree about namespace normalisation. A second
-/// `push(namespace); push('/'); push(name)` in the C layer is exactly
-/// RFC-0020's violation class 4 (name construction in a wrapper), and it is
-/// what the four sibling implementations of this already spelled differently.
-///
-/// **Divergence from rcl, deliberate:** rcl returns `const char *` into
-/// node-owned storage. We have no allocator and the node struct holds no
-/// composed buffer, so the caller supplies one. `NROS_RET_FULL` when it is
-/// too small — a truncated FQN names a different node.
-///
-/// # Safety
-/// * `node` must be NULL or point to a valid `nros_node_t`.
-/// * `output_name` must be NULL or writable for `output_size` bytes.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn nros_node_get_fully_qualified_name(
-    node: *const nros_node_t,
-    output_name: *mut c_char,
-    output_size: usize,
-) -> nros_ret_t {
-    validate_not_null!(node, output_name);
-    let node_ref = &*node;
-    validate_state!(node_ref, nros_node_state_t::NROS_NODE_STATE_INITIALIZED);
-
-    let name = inline_str(&node_ref.name, node_ref.name_len);
-    if name.is_empty() {
-        return NROS_RET_NOT_INIT;
-    }
-    let namespace = inline_str(&node_ref.namespace, node_ref.namespace_len);
-
-    match nros_node::names::expand_name("~", name, namespace) {
-        Ok(fqn) => write_cstr_out(fqn.as_str(), output_name, output_size),
-        Err(()) => NROS_RET_FULL,
     }
 }
 

--- a/packages/api/nros-c/tests/compile/node_timer_accessors.c
+++ b/packages/api/nros-c/tests/compile/node_timer_accessors.c
@@ -48,8 +48,14 @@ int main(void) {
     nros_ret_t (*p_domain)(const struct nros_node_t*, uint32_t*) = nros_node_get_domain_id;
 
     /* Caller-owned buffer, not rcl's `const char *` return: we have no
-     * allocator and the node struct holds no composed FQN. */
-    nros_ret_t (*p_fqn)(const struct nros_node_t*, char*, size_t) =
+     * allocator and the node struct holds no composed FQN. The trailing
+     * `size_t *out_len` is the retry size — a caller that gets NROS_RET_FULL
+     * learns how large a buffer would have worked instead of doubling blindly.
+     * This assertion previously named a THREE-argument form, which is how
+     * issue 1162 (the symbol defined twice, with two signatures) stayed
+     * invisible to every merge-gating lane: `check-build` is the only lane
+     * that compiles this file, and it runs on schedule only. */
+    nros_ret_t (*p_fqn)(const struct nros_node_t*, char*, size_t, size_t*) =
         nros_node_get_fully_qualified_name;
 
     /* `only_expand` is rcl's own parameter and keeps rcl's meaning. rcl's


### PR DESCRIPTION
`packages/api/nros-c/src/node.rs` on `main` carried **two** `#[unsafe(no_mangle)]` definitions of `nros_node_get_fully_qualified_name`, with different signatures:

| | source | signature |
| --- | --- | --- |
| `:672` | PR #567 | `(node, buf, buf_len, out_len)` |
| `:980` | PR #417 W-B5 | `(node, output_name, output_size)` |

Both reached the committed `nros_generated.h`, so the header declared one symbol twice with incompatible prototypes. **`check-build` lost 9 of 21 gates, and `just ci gate` — the tier a contributor is told to run before pushing — could not pass on `main`.**

Neither author was wrong. `c:node_get_fully_qualified_name` was a `gap` row in the parity ledger and two work streams closed it days apart, independently reaching the same three design conclusions (compose via `expand_name`, refuse rcl's `const char *`, `NROS_RET_FULL` on a short buffer). That says something good about the design and nothing good about the coordination.

## Why no merge-gating lane saw it

`check-build` is `schedule`/`workflow_dispatch` only — deliberately, since it needs generated bindings and prebuilt `.compile-ok` that no gating job produces — and it is the **only** lane that compiles `packages/api/nros-c/tests/compile/*.c`. So a duplicate export, a broken generated header, and a compile test pinning the wrong arity all landed and stayed.

## Resolution — keep one, take the better half of the other

- **Signature:** the four-argument form. `out_len` is a real capability (a caller that gets `NROS_RET_FULL` learns the size that would have worked), and both `nros-cpp`'s `Node::get_fully_qualified_name` and `std_compat`'s `std::string` overload are written against it.
- **Body: #417's.** It reads via `inline_str(&node_ref.name, node_ref.name_len)` rather than `CStr::from_ptr` — the name is an inline array with a *stored length*, and a name that fills it need not be NUL-terminated. That was the better read, and keeping it is most of why this was worth resolving by hand rather than deleting one side. Also adopts the file's own `validate_not_null!` / `validate_state!`.
- **Docs: #417's** RFC-0020 violation-class-4 argument for why the composition is not written in the C layer.
- `node_timer_accessors.c` asserted the three-argument shape through a function pointer; corrected, with a comment recording that its wrongness was invisible because only `check-build` compiles it.
- Header regenerated via `cargo run -p nros-cbindgen-headers`.

## The durable question, named rather than assumed

A duplicate `#[no_mangle]` is a compile error the instant anything builds it — this is not subtle, it is only invisible because the lane that sees it is unaffordable per-PR. Two candidate fixes:

1. A **buildless** gate: no two `#[unsafe(no_mangle)] pub unsafe extern "C" fn` in the C API crate may share a name. Fits the fast line. Narrow, but catches exactly this.
2. Compile **one** representative C TU on the merge path. The general answer, and it costs what `check-build` costs.

Option 1 is minutes of work and this class has now cost a day of `ci gate` on `main`. Not done here — this PR restores the build; the gate deserves its own change.

## Verification

`cargo build -p nros-c` · `cargo nextest run -p nros-c` 31/31 · `just check c` green · `just check fast` 243/243.

Found by the phase-433 W6.1 agent running `just ci gate` — not by any lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaST26nBgH9mLezz4TWKmP