### PR TITLE
fix(#1152): the log throttle sentinel lived in the timestamp domain, so a clock stuck at 0 admitted every record

### DIFF
--- a/docs/issues/archived/1152-log-throttle-fails-open-on-stuck-clock.md
+++ b/docs/issues/archived/1152-log-throttle-fails-open-on-stuck-clock.md
@@ -1,0 +1,83 @@
+---
+id: 1152
+title: "log throttle fails OPEN on a stuck clock — the `wrapping_sub` that protects against a wrapping clock admits every record when the clock does not move"
+status: resolved
+type: bug
+area: log
+severity: medium
+found: 2026-09-06
+resolved: 2026-09-06
+resolved_in: "fix/1152-throttle-stuck-clock"
+related: [phase-417, phase-428, 0160]
+---
+
+## Problem
+
+`packages/core/nros-log/src/throttle.rs`: `NEVER = 0` (`:43`), `storable(0)`
+returns `1` (`:133`), and `throttle_admits` is
+`now_ns.wrapping_sub(last_ns) >= interval_ns` (`:56`).
+
+With a clock pinned at 0: first call admits and stores `1`; every later call
+computes `0u64.wrapping_sub(1) == u64::MAX >= interval_ns` and **admits
+forever**. The throttle becomes a no-op exactly when a port's clock is broken,
+which is when a log flood is most likely.
+
+The doc at `:50-53` explains `wrapping_sub` as protection for a WRAPPING clock
+and does not consider a STUCK one. The safety measure is the failure mode.
+
+## Why the existing affordance cannot see it
+
+`timestamp_available()` is `cfg!(feature = "platform-clock")` (`lib.rs:633`) —
+a compile-time check that returns `true` for a linked-but-broken port. The
+`compile_error!` covers only the ABSENT-clock case.
+
+## Fix
+
+Treat `now == last` as "throttled", or detect the sentinel returned twice and
+degrade loudly. Add a test with a pinned clock.
+
+## Resolution
+
+The sentinel moved OUT of the timestamp domain. The defect was not
+`wrapping_sub` — it was that "never emitted" was spelled as a timestamp value
+(`0`), which forced a real reading of `0` to be displaced to `1` so the
+sentinel stayed unambiguous, and a clock stuck on `0` then never equalled what
+was stored. Any sentinel in the timestamp domain has this hole at the value it
+occupies; the fix is a flag.
+
+The C storage is one caller-owned, zero-initialised `uint64_t`
+(`static uint64_t x = 0;` in every `NROS_LOG_*_THROTTLE` expansion), so the
+flag could not become a second word without an ABI change. Instead the state
+word is `(last_ns << 1) | 1`: bit 0 is "has emitted", the 63 bits above hold
+the reading verbatim (mod 2^63), and `0` is still the fresh state a C site
+carries with no initialiser. Elapsed time is `(now - last) mod 2^63`; a clock
+that wraps at 2^64 also wraps at 2^63, so a real wrap still measures real
+elapsed time, and a stuck clock (any value, `0` included) reads as zero elapsed
+and stays shut. The only thing given up is that a jump of exactly 2^63 ns
+(292 years) between two records reads as no time at all.
+
+One pure function, `nros_log::throttle_decide(word, now_ns, interval_ns) ->
+Option<u64>`, replaces `throttle_admits`: it returns the NEXT word rather than
+a `bool`, so a storage cannot admit with the shared rule and then arm with its
+own spelling of "last emitted" — which is exactly what the C shim did
+(`nros_log_throttle_admit` carried a second copy of the `0 -> 1` skew). Both
+storages (`ThrottleState` under its one-bit guard; the C `uint64_t`) now store
+what `throttle_decide` hands back and interpret nothing.
+`ThrottleState::last_emitted_ns` returns `Option<u64>`.
+
+Tests in `throttle.rs`: stuck at 0 (the negative control — it FAILED on the
+pre-fix code at the second record, `a clock that never moves is a window that
+never elapses`), stuck at nonzero (five values including `u64::MAX`, which
+already passed pre-fix: the hole was only at the sentinel's value), stuck at
+the word's own boundaries (`1 << 63`, `u64::MAX >> 1`), normal 1 kHz cadence
+against a 100 ms window (exactly 10 of 1000), and the same cadence walked
+through `u64::MAX` and through `2^63` (10 of 1000 each — the wrap costs neither
+a lost nor an extra record).
+
+Behavioural consequence worth stating: a build without `platform-clock` now
+emits the FIRST record at each throttled C site and then NONE, where it used to
+emit every record. The once-only WARN in `nros_log_throttle_admit` says so; the
+Rust clock-reading macros still refuse to compile without the feature. The C++
+`RCLCPP_*_THROTTLE` path (`nros-cpp/include/nros/log.hpp`) is REFUSE-LOUD
+(issue 1019) and has no arithmetic of its own, so there was no third copy to
+align.

--- a/packages/api/nros-c/Cargo.toml
+++ b/packages/api/nros-c/Cargo.toml
@@ -163,8 +163,10 @@ critical-section = ["dep:critical-section"]
 # phase-417 W4.d — every platform arm activates `nros-log/platform-clock`,
 # because a linked port is exactly the condition under which
 # `nros_platform_clock_ns` resolves. Without it `nros_log_*` records carry
-# `timestamp_ns: 0` and `nros_log_throttle_admit` has no time base, so a 200 ms
-# window admits EVERY record: measured 40 of 40 without, 5 of 40 with.
+# `timestamp_ns: 0` and `nros_log_throttle_admit` has no time base — a stuck
+# clock is a window that never elapses, so a 200 ms window admits the FIRST
+# record and then none (issue 1152; before it the same constant admitted EVERY
+# record: measured 40 of 40 without, 5 of 40 with).
 platform-posix = [
     "nros-log/platform-clock",
     "nros-platform/platform-posix",

--- a/packages/api/nros-c/include/nros/log.h
+++ b/packages/api/nros-c/include/nros/log.h
@@ -323,18 +323,23 @@ bool nros_log_timestamp_available(void);
  *                     `static uint64_t x = 0;`, one per call site. Caller-owned
  *                     rather than a handle into a pool because a pool needs a
  *                     bound, and a throttled call site is not a resource anyone
- *                     should have to budget.
+ *                     should have to budget. OPAQUE: `0` means "never emitted"
+ *                     and every other value is written by this function — read
+ *                     it as a timestamp and you will read it wrong (bit 0 is a
+ *                     flag; the timestamp sits above it, mod 2^63).
  * @param interval_ms  Minimum gap between emitted records at this site.
  * @return true when the record should be emitted. The FIRST record at a site
  *         always is (as in `rclcpp`). NULL `last_ns` returns true: a broken
  *         caller gets every record, never silence.
  *
- * The rule itself is `nros_log::throttle_admits` — the same function the Rust
- * `nros_*_throttle!` macros use. Only the storage differs.
+ * The rule itself is `nros_log::throttle_decide` — the same function the Rust
+ * `nros_*_throttle!` macros use. Only the storage differs. A clock that wraps
+ * still measures real elapsed time across the wrap; a clock that is STUCK (at
+ * any value, 0 included) admits once and then never (issue 1152).
  *
  * Without a monotonic clock every timestamp is 0, the window can never elapse,
- * and every record is emitted; the first such call reports that at WARN rather
- * than degrading quietly.
+ * and each site emits its first record and nothing after it; the first such
+ * call reports that at WARN rather than degrading quietly.
  */
 bool nros_log_throttle_admit(uint64_t* last_ns, uint64_t interval_ms);
 

--- a/packages/api/nros-c/src/log.rs
+++ b/packages/api/nros-c/src/log.rs
@@ -499,9 +499,11 @@ pub unsafe extern "C" fn nros_log_add_sink(
 /// than a handle into a Rust-side pool because a pool needs a bound, and a
 /// throttled call site is not a resource anyone should have to budget.
 ///
-/// The RULE is `nros_log::throttle_admits` — the same function
-/// `nros_log::ThrottleState` and the Rust `nros_*_throttle!` macros use. Only
-/// the storage differs.
+/// The RULE — and the ENCODING of the word — is `nros_log::throttle_decide`,
+/// the same function `nros_log::ThrottleState` and the Rust `nros_*_throttle!`
+/// macros use. Only the storage differs. This shim never interprets the word:
+/// issue 1152 was a second spelling of "last emitted" living here (`0 -> 1`),
+/// and the rule then measured `u64::MAX` of elapsed time against it.
 ///
 /// Returns `true` when the record should be emitted. NULL `last_ns` returns
 /// `true`: a broken caller gets every record, never silence.
@@ -516,14 +518,13 @@ pub unsafe extern "C" fn nros_log_throttle_admit(last_ns: *mut u64, interval_ms:
     }
     warn_once_if_no_clock();
     let now = nros_log::__timestamp_ns();
-    let last = last_ns.read();
-    if nros_log::throttle_admits(last, now, nros_log::interval_ms_to_ns(interval_ms)) {
-        // `max(1)`: `0` is the "never emitted" sentinel the facade uses, so a
-        // clock that legitimately reads 0 must not re-arm the window forever.
-        last_ns.write(if now == 0 { 1 } else { now });
-        true
-    } else {
-        false
+    let word = last_ns.read();
+    match nros_log::throttle_decide(word, now, nros_log::interval_ms_to_ns(interval_ms)) {
+        Some(next) => {
+            last_ns.write(next);
+            true
+        }
+        None => false,
     }
 }
 
@@ -532,10 +533,11 @@ static NO_CLOCK_REPORTED: AtomicBool = AtomicBool::new(false);
 /// Say it once, out loud, rather than degrading quietly.
 ///
 /// Without `nros-log/platform-clock` every timestamp is a constant `0`, so
-/// `throttle_admits` sees an elapsed time that never grows and admits every
-/// record. That is the safe direction to fail — a throttle that silences is
-/// worse than one that does not throttle — but it is still not what the call
-/// site says, and RFC-0089 puts the burden on us to say so.
+/// `throttle_decide` sees an elapsed time that never grows: each throttled
+/// site emits its FIRST record and then nothing (issue 1152 — a clock that
+/// does not move must read as a window that never elapses, because a broken
+/// clock is when a log flood is most likely). That is not what the call site
+/// says, and RFC-0089 puts the burden on us to say so, once, out loud.
 fn warn_once_if_no_clock() {
     if nros_log::timestamp_available() {
         return;
@@ -547,8 +549,9 @@ fn warn_once_if_no_clock() {
         nros_log::log_warn!(
             &nros_log::DEFAULT_LOGGER,
             "NROS_LOG_*_THROTTLE has no monotonic clock (nros-log's `platform-clock` feature is \
-             off), so every timestamp is 0 and the window can never elapse: throttled sites will \
-             emit EVERY record. Enable `nros-log/platform-clock` on the nros-c dependency."
+             off), so every timestamp is 0 and the window can never elapse: each throttled site \
+             will emit its FIRST record and then NOTHING. Enable `nros-log/platform-clock` on \
+             the nros-c dependency."
         );
     }
 }

--- a/packages/core/nros-log/README.md
+++ b/packages/core/nros-log/README.md
@@ -45,8 +45,8 @@ fn main() {
   clock. **Needs the `platform-clock` feature**, and says so with a
   `compile_error!` rather than compiling into a window with no time base:
   without a clock every timestamp is a constant `0`, so the window can never
-  elapse and the site would emit every record while reading exactly like a
-  working throttle.
+  elapse and the site would emit its first record and then nothing, while
+  reading exactly like a working throttle.
 - `nros_info_throttle_at!(logger, now_ns, interval_ms, fmt, args…)` — you supply
   the time. This is `rclcpp`'s shape (`RCLCPP_INFO_THROTTLE(logger, clock, …)`
   names its clock) and the only throttled form available with no platform port.
@@ -55,8 +55,13 @@ fn main() {
 - The FIRST record at a site always emits, as in `rclcpp`. The severity
   threshold is tested BEFORE the window, so a record the level filters does not
   consume it.
-- The rule itself is `nros_log::throttle_admits`, a pure function; the C API's
-  `nros_log_throttle_admit` calls the same one over caller-owned storage.
+- The rule itself is `nros_log::throttle_decide`, a pure function over ONE
+  state word — bit 0 says "has emitted", the 63 bits above it hold the last
+  emitted timestamp; the C API's `nros_log_throttle_admit` calls the same one
+  over caller-owned storage. A clock that wraps still measures real elapsed
+  time across the wrap; a clock that is STUCK (at any value, `0` included)
+  admits once and then never (issue 1152 — the old `0`-sentinel-plus-skew made
+  a clock pinned at 0 admit every record after the first).
 
 There is no `*_once` / `*_skip_first` family here. `nros_core::logger::Logger`
 has one, on the logger that forwards to the `log` crate rather than to

--- a/packages/core/nros-log/src/lib.rs
+++ b/packages/core/nros-log/src/lib.rs
@@ -60,7 +60,7 @@ pub use buffer::{FormatBuffer, format_buffer_capacity};
 pub use pool::{
     MAX_LOGGER_NAME_LEN, dynamic_logger_capacity, dynamic_logger_name_arena, dynamic_loggers_in_use,
 };
-pub use throttle::{ThrottleState, interval_ms_to_ns, throttle_admits};
+pub use throttle::{ThrottleState, interval_ms_to_ns, throttle_decide};
 
 /// REP-2012 severity levels, mirroring `rcutils_log_severity_t`.
 ///
@@ -625,10 +625,12 @@ fn deliver_to_added(record: &Record<'_>) -> usize {
 /// Whether [`__timestamp_ns`] can answer with a real clock.
 ///
 /// `false` means every `Record::timestamp_ns` is `0` and anything DERIVED from
-/// the timestamp — the throttle windows above all of them — has no time base.
-/// Exposed so a wrapper can say so out loud instead of degrading quietly:
-/// without this, a throttled C call site looks identical whether it is
-/// rate-limiting or not.
+/// the timestamp — the throttle windows above all of them — has no time base:
+/// a throttled site then emits its FIRST record and nothing after it (a clock
+/// that never moves is a window that never elapses — issue 1152). Exposed so a
+/// wrapper can say so out loud instead of degrading quietly: without this, a
+/// throttled C call site looks identical whether it is rate-limiting or
+/// permanently shut.
 #[must_use]
 pub const fn timestamp_available() -> bool {
     cfg!(feature = "platform-clock")

--- a/packages/core/nros-log/src/macros.rs
+++ b/packages/core/nros-log/src/macros.rs
@@ -179,9 +179,10 @@ macro_rules! log_fatal {
 // The clock-reading form REFUSES TO COMPILE without the `platform-clock`
 // feature, rather than compiling into a throttle with no time base. Without a
 // clock `__timestamp_ns()` is a constant `0`, and a window measured against a
-// constant does not rate-limit — it admits every record, forever, while
-// reading at the call site exactly like a working throttle. RFC-0089: never
-// compile and differ.
+// constant never elapses — the site emits its first record and then nothing,
+// forever (issue 1152; before it, the same constant admitted EVERY record),
+// while reading at the call site exactly like a working throttle. RFC-0089:
+// never compile and differ.
 //
 // WHY THIS FAMILY KEEPS THE `nros_` PREFIX WHILE THE FIVE SEVERITY MACROS TOOK
 // rclrs's (phase-417, 2026-09-04). rclrs has no `log_info_throttle!` to follow.

--- a/packages/core/nros-log/src/throttle.rs
+++ b/packages/core/nros-log/src/throttle.rs
@@ -18,7 +18,7 @@
 //! macros declare at the call site) and a caller-owned `uint64_t` (what the C
 //! macros declare, because a C call site cannot name a Rust type without a
 //! hand-mirrored struct — the drift class issue 0160 catalogues). Both call
-//! [`throttle_admits`]. RFC-0089: a second *spelling* is free, a second *code
+//! [`throttle_decide`]. RFC-0089: a second *spelling* is free, a second *code
 //! path that can produce a different answer* is not.
 //!
 //! ## Contract
@@ -31,35 +31,87 @@
 //!   attempt.
 //! - The severity threshold is checked BEFORE the window, so a record filtered
 //!   by [`crate::Logger::level`] does not consume the window.
+//! - A clock that does not move is a window that never elapses: a site whose
+//!   clock is stuck (at ANY value, `0` included) emits once and then never
+//!   (issue 1152). A clock that wraps still measures real elapsed time across
+//!   the wrap. Both are tested below.
 
 use core::cell::UnsafeCell;
 
 use portable_atomic::{AtomicBool, Ordering};
 
-/// `0` means "nothing emitted yet at this site". A real timestamp of `0` is
-/// stored as `1` so the sentinel stays unambiguous — a 1 ns skew on the very
-/// first record, against silently re-arming the throttle every time a clock
-/// reports zero.
+/// The state word of a site that has never emitted. `0` because the C macros
+/// declare their storage as a zero-initialised `static uint64_t`, so this is
+/// the one value a fresh C site can carry without an initialiser.
 const NEVER: u64 = 0;
+
+/// Bit 0 of the state word: set once the site has emitted. The sentinel is a
+/// FLAG, not a value in the timestamp domain — see the module docs.
+const ARMED: u64 = 1;
+
+/// Elapsed time is measured in this many bits: the state word keeps 63 bits of
+/// timestamp above the flag, so the clock is reduced mod 2^63 on the way in
+/// and the subtraction is reduced the same way on the way out.
+const ELAPSED_MASK: u64 = u64::MAX >> 1;
 
 /// The whole rule, as a pure function. Both storages call this.
 ///
-/// Returns `true` iff a record raised at `now_ns` should be EMITTED given that
-/// the last emitted record at this site was at `last_ns` ([`NEVER`] = none).
+/// `state` is the site's state word — [`NEVER`] for a site that has not
+/// emitted, otherwise what an earlier call returned. Returns `Some(next)` iff a
+/// record raised at `now_ns` should be EMITTED, and `next` is the word to store
+/// in its place; `None` means suppressed and the word is left alone. Returning
+/// the encoded word rather than a bare `bool` is what keeps the encoding in
+/// ONE place: a caller cannot admit with this rule and then arm with a
+/// different spelling of "last emitted" (issue 1152 was exactly that — the
+/// arming step stored `1` for a clock reading `0`, and the rule then measured
+/// `u64::MAX` of elapsed time against it).
 ///
-/// `now_ns.wrapping_sub(last_ns)` rather than `last_ns + interval_ns`: a
-/// platform clock that wraps (or a caller passing a `u64` derived from a
-/// 32-bit counter) then costs at most one extra record instead of silencing
-/// the site forever.
+/// ## Two clock pathologies, one rule (issue 1152)
+///
+/// * A WRAPPING clock (a platform counter rolling over, or a `u64` derived from
+///   a 32-bit counter) must still measure real elapsed time across the wrap,
+///   so the elapsed time is `now - last` in modular arithmetic, never
+///   `last + interval` (which overflows to a tiny number and admits everything
+///   for the rest of the program).
+/// * A STUCK clock (a port whose clock is broken and reports a constant —
+///   including `0`, which is what a build without `platform-clock` reports)
+///   must admit ONCE and then never, because a stuck clock is exactly when a
+///   log flood is most likely. That needs `now == last` to read as zero
+///   elapsed, which a sentinel living in the timestamp domain cannot deliver:
+///   some real reading has to be displaced to keep the sentinel unambiguous,
+///   and a clock stuck on that reading then never equals what was stored.
+///
+/// The word is `(last_ns << 1) | ARMED`: the flag is bit 0 and the timestamp
+/// keeps 63 bits above it. A clock that wraps at 2^64 also wraps at 2^63, so
+/// reducing both the stored reading and the subtraction mod 2^63 measures
+/// elapsed time exactly across the wrap — the only thing given up is that a
+/// jump of exactly 2^63 ns (292 years) between two records reads as no time
+/// at all.
 #[must_use]
-pub const fn throttle_admits(last_ns: u64, now_ns: u64, interval_ns: u64) -> bool {
-    last_ns == NEVER || now_ns.wrapping_sub(last_ns) >= interval_ns
+pub const fn throttle_decide(state: u64, now_ns: u64, interval_ns: u64) -> Option<u64> {
+    let admit = if state & ARMED == 0 {
+        true
+    } else {
+        let last_ns = state >> 1;
+        let elapsed_ns = now_ns.wrapping_sub(last_ns) & ELAPSED_MASK;
+        elapsed_ns >= interval_ns
+    };
+    if admit {
+        Some((now_ns << 1) | ARMED)
+    } else {
+        None
+    }
 }
 
-/// Normalise a timestamp for STORAGE, keeping [`NEVER`] unambiguous.
+/// The timestamp a state word records, if the site has emitted. Reduced mod
+/// 2^63 — see [`throttle_decide`].
 #[must_use]
-const fn storable(now_ns: u64) -> u64 {
-    if now_ns == NEVER { 1 } else { now_ns }
+const fn recorded_ns(state: u64) -> Option<u64> {
+    if state & ARMED == 0 {
+        None
+    } else {
+        Some(state >> 1)
+    }
 }
 
 /// Milliseconds to nanoseconds, saturating.
@@ -86,7 +138,8 @@ pub const fn interval_ms_to_ns(interval_ms: u64) -> u64 {
 /// thumbv7m. A plain non-atomic `u64` would TEAR on those targets — a half-old,
 /// half-new timestamp is a window of arbitrary length.
 ///
-/// So: a one-bit guard around a `u64`. The critical section is a load, a
+/// So: a one-bit guard around a `u64` — the same state word the C storage
+/// holds, decoded by the same [`throttle_decide`]. The critical section is a load, a
 /// comparison and a store, with no call inside it, and a thread that finds the
 /// guard taken does NOT spin — it treats the record as suppressed and returns.
 /// That is what makes this safe to reach from an ISR on a single core, where
@@ -99,10 +152,11 @@ pub const fn interval_ms_to_ns(interval_ms: u64) -> u64 {
 pub struct ThrottleState {
     /// `true` while a decision is in flight. See the type docs.
     deciding: AtomicBool,
-    last_ns: UnsafeCell<u64>,
+    /// The state word [`throttle_decide`] reads and returns.
+    word: UnsafeCell<u64>,
 }
 
-// SAFETY: `last_ns` is read and written only between the `Acquire`
+// SAFETY: `word` is read and written only between the `Acquire`
 // `compare_exchange` that claims `deciding` and the `Release` store that frees
 // it, so exactly one thread touches it at a time and the release/acquire pair
 // publishes the write to the next claimant.
@@ -114,7 +168,7 @@ impl ThrottleState {
     pub const fn new() -> Self {
         Self {
             deciding: AtomicBool::new(false),
-            last_ns: UnsafeCell::new(NEVER),
+            word: UnsafeCell::new(NEVER),
         }
     }
 
@@ -124,32 +178,33 @@ impl ThrottleState {
         if !self.claim() {
             return false;
         }
-        // SAFETY: `claim` succeeded, so this thread owns `last_ns` until
+        // SAFETY: `claim` succeeded, so this thread owns `word` until
         // `release`.
-        let last = unsafe { *self.last_ns.get() };
-        let admit = throttle_admits(last, now_ns, interval_ns);
-        if admit {
+        let word = unsafe { *self.word.get() };
+        let next = throttle_decide(word, now_ns, interval_ns);
+        if let Some(next) = next {
             // SAFETY: as above.
-            unsafe { *self.last_ns.get() = storable(now_ns) };
+            unsafe { *self.word.get() = next };
         }
         self.release();
-        admit
+        next.is_some()
     }
 
-    /// Timestamp of the last emitted record, or `0` if none.
+    /// Timestamp of the last emitted record, or `None` if none.
     ///
-    /// Returns `0` if a decision is in flight — this is an observability
-    /// accessor, and blocking on it would give the guard the property the
-    /// type docs say it must not have.
+    /// Reduced mod 2^63 (see [`throttle_decide`]), so a reading at or above
+    /// 2^63 ns comes back with its top bit cleared. Also `None` if a decision
+    /// is in flight — this is an observability accessor, and blocking on it
+    /// would give the guard the property the type docs say it must not have.
     #[must_use]
-    pub fn last_emitted_ns(&self) -> u64 {
+    pub fn last_emitted_ns(&self) -> Option<u64> {
         if !self.claim() {
-            return NEVER;
+            return None;
         }
         // SAFETY: `claim` succeeded.
-        let last = unsafe { *self.last_ns.get() };
+        let word = unsafe { *self.word.get() };
         self.release();
-        last
+        recorded_ns(word)
     }
 
     /// Re-arm: the next record emits whatever the window says.
@@ -158,7 +213,7 @@ impl ThrottleState {
             return;
         }
         // SAFETY: `claim` succeeded.
-        unsafe { *self.last_ns.get() = NEVER };
+        unsafe { *self.word.get() = NEVER };
         self.release();
     }
 
@@ -188,8 +243,8 @@ mod tests {
     fn first_record_always_admits() {
         // The behaviour `nros_core`'s throttle got wrong: at `now < interval`
         // its `now >= last + interval` test dropped the very first message.
-        assert!(throttle_admits(NEVER, 0, 1_000));
-        assert!(throttle_admits(NEVER, 5, 1_000_000_000));
+        assert!(throttle_decide(NEVER, 0, 1_000).is_some());
+        assert!(throttle_decide(NEVER, 5, 1_000_000_000).is_some());
         let state = ThrottleState::new();
         assert!(state.should_log(5, 1_000_000_000));
     }
@@ -215,7 +270,7 @@ mod tests {
             !state.should_log(1_150_000_000, interval),
             "the window restarts from the record that emitted, not from the attempt"
         );
-        assert_eq!(state.last_emitted_ns(), 1_100_000_000);
+        assert_eq!(state.last_emitted_ns(), Some(1_100_000_000));
     }
 
     #[test]
@@ -227,14 +282,39 @@ mod tests {
     }
 
     #[test]
-    fn zero_timestamp_is_stored_as_one_so_never_stays_unambiguous() {
+    fn zero_timestamp_is_recorded_as_zero_and_distinct_from_never() {
+        // The pre-1152 code displaced a reading of `0` to `1` to keep a
+        // `0`-sentinel unambiguous; the armed FLAG makes the displacement
+        // unnecessary, so what was emitted is what is recorded.
         let state = ThrottleState::new();
+        assert_eq!(state.last_emitted_ns(), None, "fresh site");
         assert!(state.should_log(0, 1_000));
-        assert_eq!(state.last_emitted_ns(), 1, "not the NEVER sentinel");
+        assert_eq!(state.last_emitted_ns(), Some(0), "recorded verbatim");
         assert!(
             !state.should_log(500, 1_000),
             "a second record at t=500 must still be inside the window"
         );
+        assert!(
+            state.should_log(1_000, 1_000),
+            "and t=1000 is exactly the window"
+        );
+    }
+
+    #[test]
+    fn normal_cadence_emits_at_the_interval_and_no_faster() {
+        // A 1 kHz caller against a 100 ms window: exactly one record per 100
+        // attempts, at the attempt where the window elapses.
+        let state = ThrottleState::new();
+        let interval = interval_ms_to_ns(100);
+        let mut emitted = 0;
+        for tick in 0..1_000_u64 {
+            let now = 7 + tick * interval_ms_to_ns(1);
+            if state.should_log(now, interval) {
+                emitted += 1;
+                assert_eq!(tick % 100, 0, "emits on the tick where 100 ms elapsed");
+            }
+        }
+        assert_eq!(emitted, 10);
     }
 
     #[test]
@@ -252,13 +332,13 @@ mod tests {
         // `last_ns + interval_ns` would overflow here and (in release) wrap to
         // a tiny number, admitting every record for the rest of the program.
         // `now.wrapping_sub(last)` is the elapsed time and stays right.
-        let last = u64::MAX - 5;
+        let armed = throttle_decide(NEVER, u64::MAX - 5, 0).expect("first record");
         assert!(
-            !throttle_admits(last, 10, interval_ms_to_ns(1)),
+            throttle_decide(armed, 10, interval_ms_to_ns(1)).is_none(),
             "16 ns after the last record is inside a 1 ms window, wrap or no wrap"
         );
         assert!(
-            throttle_admits(last, 2_000_000, interval_ms_to_ns(1)),
+            throttle_decide(armed, 2_000_000, interval_ms_to_ns(1)).is_some(),
             "2 ms after the last record admits, across the wrap"
         );
         // And the same through the stateful form.
@@ -266,6 +346,86 @@ mod tests {
         assert!(state.should_log(u64::MAX - 5, interval_ms_to_ns(1)));
         assert!(!state.should_log(10, interval_ms_to_ns(1)));
         assert!(state.should_log(2_000_000, interval_ms_to_ns(1)));
+    }
+
+    #[test]
+    fn a_wrapping_clock_keeps_cadence_through_the_wrap() {
+        // Issue 1152 asks for both properties at once: a real wrap must not
+        // look like a stuck clock, and a stuck clock must not look like a
+        // wrap. Walk a 1 kHz clock through u64::MAX with a 100 ms window and
+        // count — the wrap must cost neither a lost nor an extra record.
+        let state = ThrottleState::new();
+        let interval = interval_ms_to_ns(100);
+        let start = u64::MAX - 350 * interval_ms_to_ns(1);
+        let mut emitted = 0;
+        for tick in 0..1_000_u64 {
+            let now = start.wrapping_add(tick * interval_ms_to_ns(1));
+            if state.should_log(now, interval) {
+                emitted += 1;
+                assert_eq!(tick % 100, 0, "tick {tick} (now={now})");
+            }
+        }
+        assert_eq!(emitted, 10);
+        // The 2^63 boundary is a wrap of the REDUCED clock; same property.
+        let state = ThrottleState::new();
+        let start = (1_u64 << 63) - 350 * interval_ms_to_ns(1);
+        let mut emitted = 0;
+        for tick in 0..1_000_u64 {
+            let now = start + tick * interval_ms_to_ns(1);
+            if state.should_log(now, interval) {
+                emitted += 1;
+                assert_eq!(tick % 100, 0, "tick {tick} (now={now})");
+            }
+        }
+        assert_eq!(emitted, 10);
+    }
+
+    #[test]
+    fn a_stuck_clock_at_the_word_boundaries_stays_shut() {
+        // Readings whose top bit is lost to the flag, or which are the
+        // sentinel itself: the flag, not the value, says whether the site is
+        // armed, so none of them re-arm it.
+        for stuck in [0_u64, 1, 1 << 63, u64::MAX >> 1, u64::MAX] {
+            let armed = throttle_decide(NEVER, stuck, 1).expect("first");
+            assert_ne!(armed, NEVER, "an armed site never reads as fresh");
+            assert!(
+                throttle_decide(armed, stuck, 1).is_none(),
+                "stuck at {stuck}"
+            );
+        }
+    }
+
+    /// Issue 1152 — the negative control. A port whose clock is broken reports
+    /// a constant; the throttle must then admit ONCE and never again, because
+    /// a stuck clock is when a log flood is most likely. Before the fix the
+    /// `0 -> 1` storage skew made `now.wrapping_sub(last)` read `u64::MAX` and
+    /// every record after the first was admitted.
+    #[test]
+    fn a_clock_stuck_at_zero_admits_once_then_never() {
+        let state = ThrottleState::new();
+        let interval = interval_ms_to_ns(100);
+        assert!(
+            state.should_log(0, interval),
+            "the first record always emits"
+        );
+        for _ in 0..1_000 {
+            assert!(
+                !state.should_log(0, interval),
+                "a clock that never moves is a window that never elapses"
+            );
+        }
+    }
+
+    #[test]
+    fn a_clock_stuck_at_a_nonzero_value_admits_once_then_never() {
+        for stuck in [1_u64, 42, 1_000_000_000, u64::MAX - 1, u64::MAX] {
+            let state = ThrottleState::new();
+            let interval = interval_ms_to_ns(100);
+            assert!(state.should_log(stuck, interval), "first record at {stuck}");
+            for _ in 0..1_000 {
+                assert!(!state.should_log(stuck, interval), "stuck at {stuck}");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Issue 1152

`nros_log::throttle` spelled "never emitted" as the timestamp `0` and displaced a real reading of `0` to `1` to keep it unambiguous. A clock pinned at 0 stored `1`, then measured `u64::MAX` of elapsed time on every later record and admitted all of them — the throttle became a no-op exactly when a port's clock is broken, which is when a log flood is most likely. Stuck at any *other* value already behaved: the hole was only at the sentinel's value.

## Fix

- The sentinel is a **flag**, not a value. The C storage is one caller-owned zero-initialised `uint64_t` per `NROS_LOG_*_THROTTLE` site, so a second word would be an ABI change; the state word is `(last_ns << 1) | 1` — bit 0 "has emitted", 63 bits of timestamp above it, `0` still the fresh state a C site carries with no initialiser.
- Elapsed time is `(now - last) mod 2^63`. A clock that wraps at 2^64 also wraps at 2^63, so a real wrap still measures real elapsed time; a stuck clock reads as zero elapsed and stays shut. Price: a jump of exactly 2^63 ns (292 years) reads as no time.
- One pure fn `throttle_decide(word, now, interval) -> Option<u64>` replaces `throttle_admits`. It returns the **next word**, because the C shim (`nros_log_throttle_admit`) carried its own copy of the `0 -> 1` skew beside the shared rule — now both storages store what the rule hands back and interpret nothing. `ThrottleState::last_emitted_ns` returns `Option<u64>`.
- Siblings swept: `grep -rn 'throttle_admits\|storable\|wrapping_sub' packages/core/nros-log packages/api/nros-c/src packages/api/nros-cpp/include` — the only other `wrapping_sub`s are pointer arithmetic in `nros-c/src/cdr.rs`; the C++ `RCLCPP_*_THROTTLE` path is refuse-loud (issue 1019) and has no arithmetic.
- Behaviour change to note: a build without `platform-clock` now emits the **first** record per C site and then **none**, where it emitted every record. The once-only WARN, `log.h`, the README, `macros.rs` and the `nros-c` Cargo comment say so.

## Tests (`cargo test -p nros-log`, 20 unit + integration, all green)

- `a_clock_stuck_at_zero_admits_once_then_never` — **negative control: FAILED on the pre-fix code** at the second record (`a clock that never moves is a window that never elapses`).
- `a_clock_stuck_at_a_nonzero_value_admits_once_then_never` (5 values incl. `u64::MAX`), `a_stuck_clock_at_the_word_boundaries_stays_shut` (`1<<63`, `u64::MAX>>1`).
- `normal_cadence_emits_at_the_interval_and_no_faster` — 1 kHz vs 100 ms window, exactly 10 of 1000.
- `a_wrapping_clock_keeps_cadence_through_the_wrap` — same cadence walked through `u64::MAX` and through `2^63`, 10 of 1000 each; the existing `a_wrapped_clock_still_measures_real_elapsed_time` kept.

Local: `cargo test -p nros-log` (default and `--features platform-clock --lib`), `cargo check -p nros-c`, `cargo clippy -p nros-log -p nros-c --all-targets -D warnings`, `just check fast` — all green. Issue moved to `docs/issues/archived/` with a resolution section.

Note: the issue file was filed on `phase-428-w10-qos-ssot` (#629), not yet on `main`; this PR adds only the archived copy. When #629 lands, its open `docs/issues/1152-*.md` should be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
