### PR TITLE
fix(#1015): my guard fired on every build, and my test defined what the build does not

### DIFF
--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -382,18 +382,19 @@ typedef struct {
 #if ZPICO_MAX_PENDING_REPLIES < 1
 #error "ZPICO_MAX_PENDING_REPLIES must be >= 1: it sizes a fixed C array (issue 1015)"
 #endif
-#if ZPICO_MAX_SESSIONS < 1
-#error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
-#endif
 #if ZPICO_GET_REPLY_BUF_SIZE < 1
 #error "ZPICO_GET_REPLY_BUF_SIZE must be >= 1: it sizes a fixed C array (issue 1015)"
 #endif
 #if ZPICO_GRAPH_CACHE_SIZE < 1
 #error "ZPICO_GRAPH_CACHE_SIZE must be >= 1: it sizes a fixed C array (issue 1015)"
 #endif
-#if ZPICO_ZID_SIZE < 1
-#error "ZPICO_ZID_SIZE must be >= 1: it sizes a fixed C array (issue 1015)"
-#endif
+/* ZPICO_ZID_SIZE is NOT guarded, deliberately. `zpico.h:28` defines it
+ * UNCONDITIONALLY -- no `#ifndef` -- so no build can set it to 0 and a
+ * `#if ... < 1` there can never fire. Measured: `-DZPICO_ZID_SIZE=0`
+ * produces no diagnostic, because the header redefines it first. A
+ * guard that cannot fire reads as coverage and is not, which is the
+ * shape this whole family of gates exists to remove. Make it settable
+ * first if a guard is ever wanted. */
 #if ZPICO_MAX_SUBSCRIBERS < 1
 #error "ZPICO_MAX_SUBSCRIBERS must be >= 1: it sizes a C array (issue 1015)"
 #endif
@@ -483,6 +484,19 @@ typedef void (*zpico_waker_fn)(int32_t session_index, int32_t slot);
 
 #ifndef ZPICO_MAX_SESSIONS
 #define ZPICO_MAX_SESSIONS 1 // single-session targets keep TODAY's footprint
+#endif
+
+/* Guarded HERE, and AFTER the `#endif` above rather than beside the
+ * other extents: `ZPICO_MAX_SESSIONS` is defined further down the file
+ * than they are, and an `#if` that precedes a `#define` reads the macro
+ * as UNDEFINED — which the preprocessor evaluates as 0, so the guard
+ * fires on every build instead of on a zero. It shipped that way and
+ * broke `just setup tier2`; the mutation test that missed it drove an
+ * EXTRACTED block with `-D` for every knob, so it defined what the real
+ * translation unit does not. Inside the `#ifndef` is wrong for the
+ * mirror-image reason: a `-D` skips the block and the guard with it. */
+#if ZPICO_MAX_SESSIONS < 1
+#error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
 #endif
 
 struct zpico_session {


### PR DESCRIPTION
**`#607` broke `just setup tier2`** on the merge-queue lane — visible the moment `#616` made that lane start completing runs again:

```
zpico.c:386: #error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
error: recipe `build-zenoh-pico` failed
```

`ZPICO_MAX_SESSIONS` is `#define`d at line **485**; I put its guard at **385**, with the others. An `#if` that *precedes* a `#define` reads the macro as undefined, which the preprocessor evaluates as `0` — so the guard fired on **every** build rather than on a zero.

## How it got past a mutation test

The test extracted the guard block into a standalone header and drove it with `-D` for every knob. **That defines what the real translation unit does not**, so it could not see the ordering at all.

It is exactly the trap issue 0999 records — *"a passing COMMAND is not a passing ASSERTION"* — committed while citing 0999 two commits earlier.

The **first attempt at this fix was wrong too**, in the mirror image: placing the guard after the `#define` put it *inside* `#ifndef ZPICO_MAX_SESSIONS`, so a `-D` skipped the block and took the guard with it. Caught only because the test now drives the real file — `-DZPICO_MAX_SESSIONS=0` produced no diagnostic.

## Verified now, on the real `zpico.c` with the real includes

```
defaults (no -D)              0 guard errors
-D<each of nine knobs>=0      fires, every one
```

## `ZPICO_ZID_SIZE` is no longer guarded

`zpico.h:28` defines it **unconditionally** — no `#ifndef` — so no build can set it to 0 and `#if ZPICO_ZID_SIZE < 1` can never fire. Measured: `-DZPICO_ZID_SIZE=0` produces no diagnostic, because the header redefines it first.

A guard that cannot fire reads as coverage and is not, which is the shape this family of gates exists to remove. The comment says to make the knob settable first if a guard is ever wanted.

## A gap this does not fix

`check-c-array-pool-floors` reports 8 guarded / 3 zero-legal / 10 unclassified and was **green through all of this**: it keys on the *presence* of a `#if <KNOB> < 1`, not on whether that guard can fire. Both of my broken placements satisfied it. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N