### PR TITLE
fix(#1015): a guard the preprocessor cannot reach is not a guard — static rule + compile probe

### DIFF
--- a/just/check/abi.just
+++ b/just/check/abi.just
@@ -240,3 +240,32 @@ weak-symbols:
 # The fast source-level half is `weak_symbol_audit.rs` (in `just test`).
 weak-symbols-image:
     @bash scripts/check-weak-symbols-image.sh
+
+# The BUILD-tier half of `check-c-array-pool-floors` — issue 1015.
+#
+# That gate is on the fast line and reasons about the SOURCE: a guard must sit
+# after the `#ifndef` fallback that defines its knob. This one asks the
+# COMPILER, which is the only way to answer "can this guard fire" for a guard
+# unreachable for a reason no static rule enumerates.
+#
+# It needs the zenoh-pico SOURCE, and where that is provisioned decides where
+# this runs. `gate.yml` provisions `--source zenoh-pico` on
+# pull_request/merge_group at a step BEFORE `just check fast`, so the fast lane
+# runs it on both merge-gating events and SKIPS it on push, where the source is
+# absent. That skip is recorded, so the lane summary says what did not run.
+#
+# NOT `build-serial:`. That lane is schedule/workflow_dispatch only, and
+# `check-gate-visibility` refuses a gate no pull request reaches -- "a gate no
+# pull request runs is a gate that rots (issue 0981)". Putting a probe of a
+# defect that shipped THIS WEEK somewhere no pull request looks would have been
+# the wrong half of the trade.
+#
+# It compiles, in a lane documented as buildless. One `cc -fsyntax-only` per
+# guarded knob, ~0.4 s total, over a source the SAME JOB provisioned -- which is
+# the affordability rule as `check-lane-contracts` states it (an artifact the
+# job itself builds). Called out rather than buried: if that reads as too much
+# for the fast tier, the answer is a dedicated pull-request step like
+# `rustdoc-links` has, not a build tier nobody runs.
+[private]
+c-array-guard-probe:
+    @python3 scripts/check-c-array-guard-probe.py

--- a/scripts/check-c-array-guard-probe.py
+++ b/scripts/check-c-array-guard-probe.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Every guard on a knob-sized C array must FIRE at 0, proven by compiling it.
+
+The build-tier half of `check-c-array-pool-floors`. That gate is on the fast
+line, must run on a bare worktree, and therefore reasons about the SOURCE: it
+checks that a guard sits after the `#ifndef` fallback that defines its knob.
+That catches the two shapes that shipped, and nothing else.
+
+This one asks the compiler. It is the only way to answer "can this guard fire"
+for a guard that is unreachable for a reason no static rule enumerates -- nested
+inside an unrelated `#if`, disabled by a config header, or in a file the
+translation unit never reaches.
+
+WHY IT IS A SEPARATE GATE AND NOT A BRANCH OF THE OTHER ONE
+
+It needs the zenoh-pico submodule, which the push lane does not check out. A
+gate that silently weakens depending on which lane ran it reports the same OK
+either way, and the reader cannot tell which answer they got -- the shape this
+campaign has removed four times. Two gates, two lanes, two honest answers.
+
+WHAT IT DOES
+
+For every macro `check-c-array-pool-floors` classifies as GUARDED:
+
+  * compile the file at DEFAULTS and require NO guard to fire. This is the
+    half that catches `#607`: a guard placed before its `#define` reads the
+    macro as undefined, which the preprocessor evaluates as 0, so it fired on
+    every build.
+  * compile with `-D<KNOB>=0` and require THAT guard to fire. This is the half
+    that catches the first attempted fix: a guard inside the `#ifndef` is
+    skipped by the very `-D` it is meant to catch.
+
+Failures that are not a guard diagnostic are ignored on purpose. This asks one
+question about the preprocessor; whether the whole TU type-checks is
+`check-c`'s job, and coupling the two would make this red for reasons that say
+nothing about guards.
+
+Run:  python3 scripts/check-c-array-guard-probe.py [--self-test]
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The include set a zpico translation unit needs to reach its guards. Kept here
+# rather than derived from the build: this compiles ONE file to ask ONE
+# preprocessor question, and reproducing the build's flag assembly would couple
+# a source gate to the build system it is checking. If a build change breaks
+# these, the probe reports that it could not compile rather than passing.
+INCLUDES = [
+    "packages/rmw/zenoh/zpico-sys/c/include",
+    "packages/rmw/zenoh/zpico-sys/zenoh-pico/include",
+    "packages/platform/nros-platform-api/include",
+]
+DEFINES = ["-DZENOH_LINUX=1", "-DZ_FEATURE_UNSTABLE_API=1"]
+GUARD_TEXT = "must be >= 1"
+
+# The submodule whose absence means this gate cannot run. Named as a FILE, not a
+# directory: an initialised-but-empty submodule dir is the state that makes a
+# "does the directory exist" probe lie.
+SUBMODULE_PROBE = "packages/rmw/zenoh/zpico-sys/zenoh-pico/include/zenoh-pico/config.h"
+
+
+def guarded_knobs():
+    """{macro: path} for everything the source-level gate calls GUARDED."""
+    path = os.path.join(ROOT, "scripts", "check-c-array-pool-floors.py")
+    spec = importlib.util.spec_from_file_location("pool_floors", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    found = mod.scan(mod.read_sources())
+    return {m: i["path"] for m, i in found.items() if i["guarded"]}
+
+
+def compile_probe(rel_path, extra):
+    """Guard diagnostics from compiling `rel_path`. (text, ran) — never raises."""
+    cmd = ["cc", "-fsyntax-only", "-std=c11", *DEFINES, *extra]
+    for inc in INCLUDES:
+        cmd += ["-I", os.path.join(ROOT, inc)]
+    cmd.append(os.path.join(ROOT, rel_path))
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"could not run the compiler: {exc}", False
+    return r.stderr, True
+
+
+def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    if not os.path.isfile(os.path.join(ROOT, SUBMODULE_PROBE)):
+        sys.path.insert(0, os.path.join(ROOT, "scripts", "build"))
+        print(
+            "[SKIPPED] c-array-guard-probe: zenoh-pico submodule not checked out "
+            "(git submodule update --init packages/rmw/zenoh/zpico-sys/zenoh-pico)"
+        )
+        return 0
+
+    knobs = guarded_knobs()
+    if not knobs:
+        sys.stderr.write(
+            "check-c-array-guard-probe: the source gate reports NO guarded knob, "
+            "so this would compile nothing and pass vacuously.\n"
+        )
+        return 1
+
+    problems = []
+    files = sorted(set(knobs.values()))
+
+    # One compile per file at defaults: nothing may fire.
+    for rel in files:
+        out, ran = compile_probe(rel, [])
+        if not ran:
+            sys.stderr.write(f"check-c-array-guard-probe: {out}\n")
+            return 1
+        fired = [l for l in out.split("\n") if GUARD_TEXT in l]
+        if fired:
+            problems.append(
+                f"{rel} fires {len(fired)} guard at DEFAULT knob values.\n"
+                "      A guard that fires with no `-D` at all is not guarding a "
+                "zero — it is\n"
+                "      reading its macro as UNDEFINED, which the preprocessor "
+                "evaluates as 0.\n"
+                "      First: " + fired[0].strip()
+            )
+
+    # One compile per knob at zero: exactly that knob's guard must fire.
+    for macro, rel in sorted(knobs.items()):
+        out, ran = compile_probe(rel, [f"-D{macro}=0"])
+        if not ran:
+            sys.stderr.write(f"check-c-array-guard-probe: {out}\n")
+            return 1
+        if not any(GUARD_TEXT in l and macro in l for l in out.split("\n")):
+            problems.append(
+                f"{macro} ({rel}) has a guard that does NOT fire at `-D{macro}=0`.\n"
+                "      The `#if` is present but the preprocessor never reaches it "
+                "with the\n"
+                "      macro set — inside its own `#ifndef` (a `-D` skips the "
+                "block), behind\n"
+                "      an unrelated `#if`, or in a file this TU does not include."
+            )
+
+    if problems:
+        sys.stderr.write(
+            "check-c-array-guard-probe: %d problem(s)\n\n" % len(problems)
+        )
+        for p in problems:
+            sys.stderr.write(f"  [FAIL] {p}\n\n")
+        return 1
+
+    print(
+        "check-c-array-guard-probe: OK — %d guard(s) across %d file(s) fire at 0 "
+        "and are silent at defaults." % (len(knobs), len(files))
+    )
+    return 0
+
+
+def self_test():
+    """Prove the probe can fail, on synthetic C rather than on the tree."""
+    import tempfile
+
+    good = ("#ifndef K\n#define K 8\n#endif\n"
+            "#if K < 1\n#error \"K must be >= 1\"\n#endif\n"
+            "int a[K];\n")
+    before = ("#if K < 1\n#error \"K must be >= 1\"\n#endif\n"
+              "#ifndef K\n#define K 8\n#endif\nint a[K];\n")
+    inside = ("#ifndef K\n#define K 8\n"
+              "#if K < 1\n#error \"K must be >= 1\"\n#endif\n#endif\n"
+              "int a[K];\n")
+    bad = 0
+    with tempfile.TemporaryDirectory() as d:
+        for name, src, want_default, want_zero in [
+            ("good", good, 0, 1),
+            ("before", before, 1, 1),   # fires with NO -D at all
+            ("inside", inside, 0, 0),   # never fires, even at -DK=0
+        ]:
+            p = os.path.join(d, f"{name}.c")
+            open(p, "w").write(src)
+            def probe(extra):
+                r = subprocess.run(["cc", "-fsyntax-only", "-std=c11", *extra, p],
+                                   capture_output=True, text=True)
+                return sum(1 for l in r.stderr.split("\n") if "must be >= 1" in l)
+            got_d, got_z = min(probe([]), 1), min(probe(["-DK=0"]), 1)
+            if (got_d, got_z) != (want_default, want_zero):
+                print(f"  self-test FAIL: {name} -> default={got_d} zero={got_z}, "
+                      f"want default={want_default} zero={want_zero}")
+                bad += 1
+    if bad:
+        print(f"check-c-array-guard-probe self-test: {bad} case(s) FAILED")
+        return 1
+    print("check-c-array-guard-probe self-test: OK (3 cases: good, "
+          "guard-before-define, guard-inside-ifndef)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-c-array-pool-floors.py
+++ b/scripts/check-c-array-pool-floors.py
@@ -178,22 +178,48 @@ def scan(files: dict[str, str]) -> dict[str, dict]:
     found: dict[str, dict] = {}
     for path, text in sorted(files.items()):
         lines = text.splitlines()
-        settable = set()
+        settable = {}
         for i, line in enumerate(lines):
             m = IFNDEF.match(line)
             if m and i + 1 < len(lines):
                 d = DEFINE.match(lines[i + 1])
                 if d and d.group(1) == m.group(1):
-                    settable.add(m.group(1))
+                    # Remember where the fallback block ENDS. A guard is only
+                    # reachable after it: before, the macro is undefined and the
+                    # preprocessor reads that as 0, so `#if K < 1` fires on
+                    # EVERY build; inside, a `-D` skips the block and takes the
+                    # guard with it. Both shipped (see `guard_placement`).
+                    depth, end = 0, None
+                    for j in range(i, len(lines)):
+                        t = lines[j].strip()
+                        if t.startswith(("#if", "#ifdef", "#ifndef")):
+                            depth += 1
+                        elif t.startswith("#endif"):
+                            depth -= 1
+                            if depth == 0:
+                                end = j
+                                break
+                    settable[m.group(1)] = end
         arrays = set(ARRAY.findall(text))
-        guards = set()
+        guards = {}
         for i, line in enumerate(lines):
             g = GUARD.search(line)
             # A comparison with no `#error` under it is a number nobody checks.
             if g and ERROR.search("\n".join(lines[i + 1 : i + 4])):
-                guards.add(g.group(1))
-        for macro in sorted(settable & arrays):
-            found[macro] = {"path": path, "guarded": macro in guards}
+                guards.setdefault(g.group(1), i)
+        for macro in sorted(set(settable) & arrays):
+            at = guards.get(macro)
+            fallback_end = settable[macro]
+            found[macro] = {
+                "path": path,
+                "guarded": at is not None,
+                # None when there is no guard, or when the fallback block is
+                # unterminated (a malformed file, reported elsewhere).
+                "reachable": None if at is None or fallback_end is None
+                else at > fallback_end,
+                "guard_line": None if at is None else at + 1,
+                "fallback_end_line": None if fallback_end is None else fallback_end + 1,
+            }
     return found
 
 
@@ -201,6 +227,18 @@ def check_arrays(found: dict[str, dict]) -> list[str]:
     problems = []
 
     for macro, info in sorted(found.items()):
+        if info["guarded"] and info.get("reachable") is False:
+            problems.append(
+                f"{macro} ({info['path']}:{info['guard_line']}) is guarded where the "
+                f"guard CANNOT FIRE.\n"
+                f"      Its `#ifndef` fallback closes at line {info['fallback_end_line']}, "
+                f"and the guard is at {info['guard_line']}.\n"
+                "      Before that line the macro is UNDEFINED, which the preprocessor\n"
+                "      evaluates as 0 — so the guard fires on every build; inside the\n"
+                "      block, a `-D` skips it and takes the guard with it. Both shipped.\n"
+                "      Move the guard AFTER the `#endif` that closes the fallback."
+            )
+            continue
         if info["guarded"]:
             if macro in ZERO_LEGAL:
                 problems.append(
@@ -400,6 +438,31 @@ GOOD_C = """
 struct s { entry_t slots[POOL_MAX]; };
 """
 
+# The guard PRECEDES the fallback, so `POOL_MAX` is undefined where it is
+# tested. The preprocessor reads an undefined macro as 0, so this fires on
+# every build. Shipped as `#607`; broke `just setup tier2`.
+GUARD_BEFORE_DEFINE_C = """
+#if POOL_MAX < 1
+#error "POOL_MAX must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#ifndef POOL_MAX
+#define POOL_MAX 8
+#endif
+struct s { entry_t slots[POOL_MAX]; };
+"""
+
+# The guard is INSIDE the fallback, so a `-D` skips the block and the guard
+# with it — the mirror image, and the first attempted fix for the above.
+GUARD_INSIDE_IFNDEF_C = """
+#ifndef POOL_MAX
+#define POOL_MAX 8
+#if POOL_MAX < 1
+#error "POOL_MAX must be >= 1: it sizes a C array (issue 1015)"
+#endif
+#endif
+struct s { entry_t slots[POOL_MAX]; };
+"""
+
 GOOD_CMAKE = """
 _nros_c_array_pool_floor(_a "${X}" ZPICO_MAX_PUBLISHERS)
 _nros_c_array_pool_floor(_b "${X}" ZPICO_MAX_SUBSCRIBERS)
@@ -430,7 +493,17 @@ def producer_texts(cmake=GOOD_CMAKE, rust=GOOD_RUST, derive=GOOD_DERIVE):
 def selftest() -> int:
     # POSITIVE: a guarded array with an `#ifndef` default is the shape we want.
     found = scan({"a.c": GOOD_C})
-    assert found == {"POOL_MAX": {"path": "a.c", "guarded": True}}, found
+    assert found["POOL_MAX"]["guarded"] and found["POOL_MAX"]["reachable"], found
+
+    # NEGATIVE, both shapes that shipped: a guard the preprocessor can never
+    # reach with the macro defined is not a guard, and grepping for `#if K < 1`
+    # cannot tell the difference. Both of these satisfied the old check.
+    before = scan({"a.c": GUARD_BEFORE_DEFINE_C})["POOL_MAX"]
+    assert before["guarded"] and before["reachable"] is False, before
+    assert check_arrays({"POOL_MAX": before}), "a guard before its #define must FAIL"
+    inside = scan({"a.c": GUARD_INSIDE_IFNDEF_C})["POOL_MAX"]
+    assert inside["guarded"] and inside["reachable"] is False, inside
+    assert check_arrays({"POOL_MAX": inside}), "a guard inside its #ifndef must FAIL"
 
     # NEGATIVE 1 — the guard is gone. This is issue 1015 exactly.
     no_guard = GOOD_C.replace("#if POOL_MAX < 1", "#if POOL_MAX < 0")


### PR DESCRIPTION
Collapsed from a three-PR stack. `#636` (the zpico fix) has merged; this carries the two gates that keep it from recurring, in **two commits against `main`** rather than a chain nobody can arm.

`check-c-array-pool-floors` greps for `#if <KNOB> < 1` and asks nothing about whether that `#if` can ever see the macro **defined**. Both shapes that shipped this week satisfied it:

- **`#607`** put a guard 100 lines *before* its `#ifndef`/`#define` fallback. The macro is undefined there, the preprocessor reads that as `0`, and the guard fired on **every** build — breaking `just setup tier2` on the merge-queue lane. **The gate was green.**
- The **first attempt at fixing that** put the guard *inside* the `#ifndef`, where a `-D` skips the block and takes the guard with it. **Green for that too.**

## Two gates, two lanes, two honest answers

**1 — the static rule** (`check-c-array-pool-floors`, fast lane). The scan records where a knob's `#ifndef` fallback ends; a guard at or before that line fails, naming both reasons. Costs nothing and runs on a bare worktree, which is where the push lane lives.

**2 — the compile probe** (`check-c-array-guard-probe`, new). Two compiles per guarded knob: at **defaults** nothing may fire (catches `#607`); at **`-D<KNOB>=0`** that guard **must** fire (catches the first fix attempt). Measured: 8 guards, 1 file, ~0.4 s.

They are separate gates rather than one gate with a skip branch: a gate that silently weakens depending on the lane reports the same `OK` either way, and the reader cannot tell which answer they got.

## Where the probe runs — and why not the build tier

`build-serial` was its first home, and **`check-gate-visibility` refused it**:

> *"a gate no pull request runs is a gate that rots (issue 0981: a red sat on `main` for a day behind a green required check)"*

That lane is `schedule`/`workflow_dispatch` only. `gate.yml` provisions `--source zenoh-pico` on `pull_request`/`merge_group` at a step **before** `just check fast`, so the fast lane runs the probe on both merge-gating events and **skips** it on push, with the skip recorded.

**It compiles, in a lane documented as buildless** — stated in the recipe rather than buried. One `cc -fsyntax-only` per guarded knob over a source the *same job* provisioned, which is the affordability rule as `check-lane-contracts` states it. If that reads as too much for the fast tier, the right answer is a dedicated PR step like `rustdoc-links` has, not a tier nobody runs.

## A correction carried in the commit message

An earlier version of this PR claimed the compile probe was impossible because `zpico_config_keys.h` is a build output. **It is tracked**, and the compile that "proved" otherwise was run against a copy in `/tmp`, so the quoted `#include` resolved relative to `/tmp` instead of the source directory. The real constraint is only the submodule.

## Verification

Both gates mutation-tested on this branch by reinstating `#607`'s bug:

```
[FAIL] zpico.c fires 2 guard at DEFAULT knob values.
[FAIL] ZPICO_MAX_SESSIONS (…zpico.c:373) is guarded where the guard CANNOT FIRE.
```

Clean state: `pool-floors` OK (8 guarded / 3 zero-legal / 10 unclassified), `guard-probe` OK (8 guards fire at 0, silent at defaults). Negative controls for both shapes live in each gate's self-test. `gate-lists`, `gate-visibility`, `gate-selftests`, `default-gates-run-somewhere`, `lane-contracts`, `just-recipe-refs` pass.

Supersedes `#642`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N