### PR TITLE
fix(#1167): the guard 1015 added sits above the knob it guards

### DIFF
--- a/docs/issues/archived/1167-zpico-knob-guard-precedes-its-default.md
+++ b/docs/issues/archived/1167-zpico-knob-guard-precedes-its-default.md
@@ -1,0 +1,101 @@
+---
+id: 1167
+title: "`#if ZPICO_MAX_SESSIONS < 1` sits ABOVE the knob's default, so the guard issue
+  1015 added refuses every Zephyr zenoh build instead of protecting the array"
+status: resolved
+type: bug
+area: [rmw, build, embedded]
+severity: high
+found: 2026-09-06
+related: [1015, 0460, 1029]
+---
+
+## What
+
+Issue 1015 gave every knob-sized C array in `zpico.c` a compile-time refusal:
+
+```c
+#if ZPICO_MAX_SESSIONS < 1
+#error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
+#endif
+```
+
+The C preprocessor evaluates an **undefined** identifier in `#if` as `0`. Nine
+of the ten guards were safe because the knob's `#ifndef`/`#define` default sits
+in the defaults block above them. `ZPICO_MAX_SESSIONS`'s default was ~100 lines
+**below**:
+
+| knob | guard | default | |
+| --- | ---: | ---: | --- |
+| `ZPICO_MAX_QUERYABLES` | 373 | 205 | ok |
+| `ZPICO_MAX_LIVELINESS` | 376 | 208 | ok |
+| `ZPICO_MAX_PENDING_GETS` | 379 | 247 | ok |
+| `ZPICO_MAX_PENDING_REPLIES` | 382 | 265 | ok |
+| **`ZPICO_MAX_SESSIONS`** | **385** | **484** | **guard first** |
+| `ZPICO_GET_REPLY_BUF_SIZE` | 388 | 241 | ok |
+| `ZPICO_GRAPH_CACHE_SIZE` | 391 | 226 | ok |
+| `ZPICO_ZID_SIZE` | 394 | `zpico.h:28` | ok |
+| `ZPICO_MAX_SUBSCRIBERS` | 397 | 202 | ok |
+| `ZPICO_MAX_PUBLISHERS` | 400 | 199 | ok |
+
+## Why it is exactly this knob that broke
+
+`ZPICO_MAX_SESSIONS` is the one guarded knob with **no Kconfig row and no cmake
+bridge** — `nros-zpico-build/src/runner.rs` says so in as many words ("A knob
+with no `KCONFIG_KNOBS` row (`ZPICO_MAX_SESSIONS`, …)"). Every other guarded
+knob arrives as a `-D` on the Zephyr C lane's command line, so the guard reads a
+real number whatever the ordering. This one does not, so the in-file default was
+the only definition the TU would ever get — and it came too late.
+
+The two facts are independently correct and only wrong together, which is why
+reading the diff does not catch it.
+
+## Measured
+
+`west build -b mps2_an385 examples/zephyr/rust/talker` (zenoh):
+
+```
+FAILED: modules/nros/CMakeFiles/nros.dir/…/zpico.c.obj
+zpico.c:386:2: error: #error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
+```
+
+The compile line carries `-DZPICO_MAX_QUERYABLES=8`, `-DZPICO_MAX_PUBLISHERS=8`,
+`-DZPICO_MAX_SUBSCRIBERS=8`, `-DZPICO_MAX_LIVELINESS=16` … and no
+`-DZPICO_MAX_SESSIONS`.
+
+## Why CI did not catch it
+
+No merge-gating event builds Zephyr. The Zephyr jobs live in `nightly.yml` and
+are gated on `needs.changes.outputs.run_zephyr`; the tier-2 lane that would have
+built a Zephyr image is issue 1158 (no runtime verdict in six consecutive runs),
+and the one cortex-m Zephyr build that did run on 2026-09-06 died earlier, on
+the cross-checkout fault of issue 1166. Three independent gaps, and the guard
+landed through all three.
+
+## Resolution
+
+The default moved up beside its neighbours, with a comment at both ends saying
+why the order is load-bearing.
+
+**Gate: `check-c-knob-guard-order`** — for every `#if KNOB < 1` guard in a
+tracked `.c`/`.h`, the knob must be defined earlier in the same file or
+unconditionally by a header under the component's `include/`. Buildless, tracked
+files only (`git ls-files`, not a filesystem walk — issues 1157/1166), and
+self-testing on the normal path with six cases.
+
+Mutation-tested against the real tree rather than a fixture: reverting the
+one-block move turns the gate red with the exact site, and restoring it turns it
+green.
+
+**Verified by a build**, not only by the gate: the same `west build` that
+produced the `#error` now links, `RAM: 1789196 B / 4 MB (42.66%)`.
+
+## The class, and what is NOT claimed
+
+The rule is about ORDER, and it generalises past this file — any
+`#if X < 1`/`#error` pair added above its own default has it. The gate covers
+every tracked C source, so a second occurrence anywhere is caught.
+
+Not claimed: that the other nine guards were ever wrong (they were not), or that
+`ZPICO_MAX_SESSIONS` should gain a Kconfig row. Whether it should is
+phase-392 W5's open question about this knob, and it is a separate decision.

--- a/just/check/platform.just
+++ b/just/check/platform.just
@@ -274,6 +274,21 @@ knob-fixpoint:
 c-array-pool-floors:
     @python3 scripts/check-c-array-pool-floors.py
 
+# issue 1167 — the guard 1015 added must come AFTER the knob's default. The C
+# preprocessor reads an UNDEFINED identifier in `#if` as 0, so a `#if KNOB < 1`
+# placed above the knob's `#ifndef`/`#define` does not protect the array: it
+# refuses every build that does not pass a `-D` for that knob.
+#
+# Nine of the ten guards were safe because the defaults block sits above them.
+# The tenth, `ZPICO_MAX_SESSIONS`, is the one guarded knob with no Kconfig row
+# and no cmake bridge, so the in-file default was the ONLY definition the TU
+# would get and it came ~100 lines too late. Both facts are correct alone and
+# wrong together, which is why reading the diff does not catch it — and no
+# merge-gating event builds Zephyr, so it reached `main`.
+[private]
+c-knob-guard-order:
+    @python3 scripts/check-c-knob-guard-order.py
+
 # A knob is resolved EXACTLY ONCE. phase-412 hit this three times: a knob
 # gained a derivable resolution and kept its old plain one, the second call
 # won, and what it passed was the raw Kconfig value — which for a derivable

--- a/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
+++ b/packages/rmw/zenoh/zpico-sys/c/zpico/zpico.c
@@ -265,6 +265,14 @@ typedef struct {
 #ifndef ZPICO_MAX_PENDING_REPLIES
 #define ZPICO_MAX_PENDING_REPLIES 4
 #endif
+// Size of the session pool. Unlike its neighbours this knob has NO Kconfig row
+// and no cmake bridge (`nros-zpico-build/src/runner.rs` says so), so on Zephyr
+// the C lane never receives a -D for it and this default is the ONLY definition
+// the TU gets. It therefore has to sit ABOVE the `< 1` guard block — see
+// issue 1167.
+#ifndef ZPICO_MAX_SESSIONS
+#define ZPICO_MAX_SESSIONS 1 // single-session targets keep TODAY's footprint
+#endif
 // `stored_queries` / `stored_query_valid` / `last_reply_seq` are per-session —
 // they live in `struct zpico_session` (defined below). The index of the slot
 // allocated by the most recent `query_handler` invocation is read by
@@ -481,9 +489,10 @@ typedef void (*zpico_waker_fn)(int32_t session_index, int32_t slot);
 #define ZPICO_TX_BATCH_FLUSH_MS 50
 #endif
 
-#ifndef ZPICO_MAX_SESSIONS
-#define ZPICO_MAX_SESSIONS 1 // single-session targets keep TODAY's footprint
-#endif
+// ZPICO_MAX_SESSIONS's default moved UP beside the other extents (issue 1167):
+// the `#if ZPICO_MAX_SESSIONS < 1` guard below the defaults block evaluates an
+// undefined macro as 0, so a default defined down HERE fired the #error on
+// every build that does not pass -DZPICO_MAX_SESSIONS.
 
 struct zpico_session {
     // Session handle + config + lifecycle (per handle — issue 0347's

--- a/scripts/check-c-knob-guard-order.py
+++ b/scripts/check-c-knob-guard-order.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""issue 1167 — a `#if KNOB < 1` guard must come AFTER the knob is defined.
+
+WHY THIS EXISTS. Issue 1015 gave every knob-sized C array a compile-time
+refusal:
+
+    #if ZPICO_MAX_SESSIONS < 1
+    #error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array"
+    #endif
+
+The C preprocessor evaluates an UNDEFINED identifier in `#if` as 0. So a guard
+that runs before its knob's `#ifndef`/`#define` default does not protect the
+array — it refuses the build outright, and only on the configurations that do
+not pass a `-D` for that knob. Nine of the ten guards were fine because their
+defaults sit in the defaults block above; `ZPICO_MAX_SESSIONS`'s default was
+~100 lines BELOW, and it is precisely the knob with no Kconfig row and no cmake
+bridge, so the Zephyr C lane never supplies a `-D`. Every Zephyr zenoh image
+failed to compile, and no merge-gating lane builds Zephyr, so it reached `main`.
+
+The rule is about ORDER, which is why a human reading the diff does not catch
+it: both the guard and the default are correct in isolation.
+
+A knob is considered defined before the guard if either
+  * an `#ifndef KNOB` / `#define KNOB` appears earlier in the same file, or
+  * a header under the same component's `include/` defines it unconditionally.
+
+Usage:
+    python3 scripts/check-c-knob-guard-order.py [--self-test]
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+GUARD_RE = re.compile(r"^#if\s+([A-Z][A-Z0-9_]*)\s*<\s*1\s*$")
+IFNDEF_RE = re.compile(r"^#ifndef\s+([A-Z][A-Z0-9_]*)\s*$")
+DEFINE_RE = re.compile(r"^#\s*define\s+([A-Z][A-Z0-9_]*)\b")
+
+
+def guards_and_defs(text):
+    """(knob -> first guard line, knob -> first define line), 1-indexed."""
+    guards, defs = {}, {}
+    for n, line in enumerate(text.split("\n"), 1):
+        m = GUARD_RE.match(line)
+        if m and m.group(1) not in guards:
+            guards[m.group(1)] = n
+        m = IFNDEF_RE.match(line) or DEFINE_RE.match(line)
+        if m and m.group(1) not in defs:
+            defs[m.group(1)] = n
+    return guards, defs
+
+
+def header_defines(repo: Path, headers):
+    """knob -> header that defines it unconditionally, over TRACKED headers only.
+
+    Built once from `git ls-files`, never by walking: a recursive walk reaches
+    build output and other checkouts' worktrees, and is ~500x slower on this
+    tree (`check-no-tracked-file-find` measures 7m36s -> 0.8s). It also caught
+    the first draft of THIS script, which is the gate working.
+
+    Deliberately coarse — any `#define KNOB` in a tracked header under an
+    `include/` directory counts, wherever it sits. A knob that is genuinely
+    defined by a header the TU does not include would then read as safe here;
+    that is a false negative this gate accepts, because the compiler catches it
+    immediately and loudly (it is the very `#error` this rule is about).
+    """
+    found = {}
+    for rel in headers:
+        if "/include/" not in f"/{rel}":
+            continue
+        path = repo / rel
+        if not path.is_file():
+            continue
+        for line in path.read_text(errors="replace").split("\n"):
+            m = DEFINE_RE.match(line)
+            if m:
+                found.setdefault(m.group(1), rel)
+    return found
+
+
+def check_file(text, in_headers):
+    guards, defs = guards_and_defs(text)
+    bad = []
+    for knob, gline in sorted(guards.items(), key=lambda kv: kv[1]):
+        dline = defs.get(knob)
+        if dline is not None and dline < gline:
+            continue
+        if knob in in_headers:
+            continue
+        bad.append((knob, gline, dline))
+    return bad
+
+
+SELF_TESTS = [
+    # (source, expected offending knobs)
+    ("#ifndef A\n#define A 1\n#endif\n#if A < 1\n#error x\n#endif\n", []),
+    ("#if A < 1\n#error x\n#endif\n#ifndef A\n#define A 1\n#endif\n", ["A"]),
+    ("#if A < 1\n#error x\n#endif\n", ["A"]),
+    # a guard with no `< 1` shape is not this rule's business
+    ("#if A > 3\n#error x\n#endif\n", []),
+    # two knobs, one ordered right and one wrong
+    (
+        "#ifndef A\n#define A 1\n#endif\n#if A < 1\n#error\n#endif\n"
+        "#if B < 1\n#error\n#endif\n#ifndef B\n#define B 2\n#endif\n",
+        ["B"],
+    ),
+    # an unconditional #define (no #ifndef) before the guard also counts
+    ("#define A 4\n#if A < 1\n#error x\n#endif\n", []),
+]
+
+
+def self_test():
+    bad = 0
+    for i, (src, expect) in enumerate(SELF_TESTS, 1):
+        guards, defs = guards_and_defs(src)
+        got = sorted(k for k, g in guards.items() if defs.get(k) is None or defs[k] > g)
+        if got != sorted(expect):
+            print(f"  case {i}: expected {sorted(expect)}, got {got}")
+            bad += 1
+    if bad:
+        print(f"check-c-knob-guard-order --self-test: {bad} case(s) FAILED")
+        return 1
+    print(f"check-c-knob-guard-order --self-test: {len(SELF_TESTS)} case(s) OK")
+    return 0
+
+
+def main():
+    repo = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    )
+    if "--self-test" in sys.argv:
+        return self_test()
+    if self_test():
+        return 1
+
+    # Tracked files only: a filesystem walk reaches build output and other
+    # checkouts' worktrees (issues 1157/1166).
+    files = [
+        f
+        for f in subprocess.run(
+            ["git", "ls-files", "-z", "*.c", "*.h"],
+            capture_output=True, text=True, check=True, cwd=repo,
+        ).stdout.split("\0")
+        if f
+    ]
+    in_headers = header_defines(repo, [f for f in files if f.endswith(".h")])
+
+    failures, scanned, guarded = [], 0, 0
+    for rel in files:
+        path = repo / rel
+        if not path.is_file():
+            continue
+        text = path.read_text(errors="replace")
+        if "< 1" not in text:
+            continue
+        scanned += 1
+        bad = check_file(text, in_headers)
+        guarded += len(guards_and_defs(text)[0])
+        for knob, gline, dline in bad:
+            where = f"defined at line {dline}" if dline else "never defined here"
+            failures.append(f"  {rel}:{gline}: `#if {knob} < 1` — {knob} is {where}")
+
+    if failures:
+        print("check-c-knob-guard-order: FAIL\n")
+        print("\n".join(failures))
+        print(
+            "\nThe preprocessor reads an UNDEFINED identifier in `#if` as 0, so a\n"
+            "guard placed before its knob's default does not protect the array —\n"
+            "it refuses every build that does not pass a -D for that knob. Move\n"
+            "the `#ifndef`/`#define` ABOVE the guard (issue 1167)."
+        )
+        return 1
+
+    print(
+        f"check-c-knob-guard-order: OK ({guarded} `< 1` guard(s) across "
+        f"{scanned} file(s); each knob is defined before its guard)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**A red on `main`, introduced today.** Every Zephyr zenoh build fails to compile:

```
zpico.c:386:2: error: #error "ZPICO_MAX_SESSIONS must be >= 1: it sizes a fixed C array (issue 1015)"
```

## The defect

The C preprocessor evaluates an **undefined** identifier in `#if` as `0`. Issue 1015's guard sits at line 385; `ZPICO_MAX_SESSIONS`'s `#ifndef`/`#define` default sat at line 484. Nine sibling guards are fine because the defaults block is above them:

| knob | guard | default | |
| --- | ---: | ---: | --- |
| `ZPICO_MAX_QUERYABLES` | 373 | 205 | ok |
| `ZPICO_MAX_PENDING_REPLIES` | 382 | 265 | ok |
| **`ZPICO_MAX_SESSIONS`** | **385** | **484** | **guard first** |
| `ZPICO_MAX_PUBLISHERS` | 400 | 199 | ok |

**It is exactly this knob because it is the one guarded knob with no Kconfig row and no cmake bridge** — `nros-zpico-build/src/runner.rs` says so in as many words. Every other guarded knob arrives as a `-D` on the Zephyr C lane's command line, so the ordering never mattered for them. This one does not, so the in-file default was the only definition the TU would ever get, and it came ~100 lines too late. The compile line carries `-DZPICO_MAX_QUERYABLES=8`, `-DZPICO_MAX_PUBLISHERS=8`, `-DZPICO_MAX_SUBSCRIBERS=8`, `-DZPICO_MAX_LIVELINESS=16` … and nothing for sessions.

Both facts are correct in isolation and only wrong together, which is why reading the diff does not catch it.

## Why it reached `main`

Three independent gaps, all open:
- no merge-gating event builds Zephyr;
- the tier-2 lane has produced no runtime verdict in six consecutive runs (#1158);
- the one cortex-m Zephyr build that did run on 2026-09-06 died earlier, on the cross-checkout fault (#1166).

## Fix

The default moves up beside its neighbours, with a comment at both ends saying the order is load-bearing.

**Gate `check-c-knob-guard-order`** (fast lane, buildless, self-testing with six cases): every `#if KNOB < 1` guard must have the knob defined earlier in the same file, or unconditionally by a tracked header under the component's `include/`.

## Verification

**Mutation-tested against the real tree**, not a fixture — reverting the one-block move turns the gate red naming the exact site, and restoring it turns it green.

**Verified by a build, not only by the gate.** The same `west build -b mps2_an385 examples/zephyr/rust/talker` (zenoh) that produced the `#error` now links:

```
FLASH:  505 KB / 4 MB (12.33%)
RAM:    1789196 B / 4 MB (42.66%)
```

`check-fast` 248/248 green via the pre-push hook. That is the fast tier — it does not compile, which is the whole reason this class needed a build to confirm.

One thing worth noting: the first draft of this gate used `rglob` to find headers, and **`check-no-tracked-file-find` caught it** on the pre-push hook. It now goes through `git ls-files`, which is also what keeps it from walking into other checkouts' worktrees (#1157, #1166).

## Not claimed

That any of the other nine guards was ever wrong, or that `ZPICO_MAX_SESSIONS` should gain a Kconfig row — that is phase-392 W5's open question about this knob, and a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyCVgGEqVRY71PYDHKmWSv