### PR TITLE
fix(phase-431 W1): the workspace guard refused a build output directory, and turned tier 2 red

### DIFF
--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -209,7 +209,7 @@ Acceptance: every job body is `just setup <scope>` plus one command; the repeate
 CLI-build block exists once; `just ci provision-zenohd` is reachable from
 `just setup`.
 
-## W6 — DESIGN REQUIRED: `package.xml` as the dependency SSoT (rosdep parity)
+## W6 — ANSWERED: `package.xml` as the dependency SSoT (rosdep parity)
 
 **This one is not an implementation task and must not be started as one.** It
 changes what a `package.xml` means in this repo, so it needs an RFC first.
@@ -253,6 +253,46 @@ Questions the RFC has to answer, none of which have obvious answers:
 
 Deliverable for W6 is **an RFC in `docs/design/`**, not code. Only once it is
 `Draft` and reviewed does an implementation work item get opened.
+
+### ANSWERED (2026-09-06) — [RFC-0062 amendment 4](../design/0062-unified-dependency-ssot.md), implemented by phase-435
+
+The RFC this item required exists, and the five questions above have answers.
+Recorded here because a work item that reads DESIGN REQUIRED after its design
+landed is how a settled question gets reopened.
+
+**The premise needed correcting first.** This item opened on *"406 package.xml
+files … not one names a system dependency"* and read it as a gap. Measurement
+says it mostly is not one: the bridge already exists — `run_workspace_scan`
+resolves every `<depend>` against `[prereq.*]` and classifies by role — and
+these packages have nothing to declare, being message and node packages whose
+content depends on no system library. What was missing was not a bridge but the
+other three axes.
+
+1. **Key namespace** — `[prereq.*]` names, not rosdep keys. A ROS *package*
+   dependency is the one case that resolves by derivation (`ros_package` →
+   `ros-<distro>-<pkg>`), so the ROS-facing vocabulary is honoured where it
+   actually appears.
+2. **Who owns the mapping** — the index stays the mapping; `package.xml` is the
+   declaration. The real rosdep database is not consulted: we have no oracle to
+   validate a name against, so an unknown name must fail a gate rather than an
+   `apt` invocation on a user's machine.
+3. **The 406 existing files** — untouched. The new axes read `<build_type>` and
+   the `<nano_ros>` export, both of which already existed; `<depend>` keeps
+   exactly the meaning codegen gives it.
+4. **Scope resolution** — unchanged. The board and rmw axes resolve from the
+   manifest's own export tag, so a workspace does not need a new scope.
+5. **`--build-sources`** — not subsumed. It is the repo's own build-stage union,
+   which is a different question from what a consumer's workspace declares.
+
+The answer in one line: **four axes, and `package.xml` is the only input** —
+`<build_type>`, `<depend>`, and the board/rmw selections in the `<nano_ros>`
+export. Never a `CMakeLists.txt` or a `Cargo.toml` entry: those are build-system
+facts in a different vocabulary, and a resolver reading them inherits every
+shape they take.
+
+phase-435 implemented it — the `buildtool` role, the `[build_type.*]` axis,
+`ros_package` derivation (retiring issue 1128's placeholder), `[board.zephyr]`,
+and a gate that a non-family board alias names one board.
 
 ## W7 — DESIGN: scope the arena-budget walk (issue 1001)
 

--- a/packages/cli/nros-cli-core/src/stale_guard.rs
+++ b/packages/cli/nros-cli-core/src/stale_guard.rs
@@ -43,6 +43,32 @@ fn command_is_guarded(name: &str) -> bool {
     )
 }
 
+/// Does the WORKSPACE check apply to this verb? — issue filed by phase-413 W2.
+///
+/// The staleness check (case 1) asks about the BINARY and applies to every
+/// guarded verb. This one asks "which checkout is my cwd in", and that question
+/// is meaningless for the build-tool verbs: cmake invokes `nros codegen` with
+/// the tool path it was CONFIGURED with (`-D_NANO_ROS_CODEGEN_TOOL`), so the
+/// caller has already answered "which binary", and the cwd is wherever the
+/// build system put its output.
+///
+/// It fired on exactly that. The tier-2 `zephyr` lane builds into a west
+/// workspace which, on the CI runner, sits under a DIFFERENT nano-ros tree from
+/// the one being built — the runner's checkout and the workspace root are two
+/// separate directories, and `NROS_ZEPHYR_WORKSPACE` may point anywhere.
+///
+/// So the refusal read: running `<runner checkout>/packages/cli/target/release/
+/// nros`, checkout `<the west workspace's parent>`. The binary was the runner
+/// checkout's own — correct, freshly built — and the guard refused it because
+/// the cwd walked up into another checkout. A build OUTPUT directory is not a
+/// consumer workspace, and nothing tells the two apart by path alone.
+///
+/// The verbs a USER types in their own workspace keep the check, which is what
+/// phase-431 W1 was for: `sync`, `plan`, `ws`, `setup`.
+fn workspace_check_applies(name: &str) -> bool {
+    !matches!(name, "codegen" | "codegen-system" | "generate-rust")
+}
+
 /// Refuse to run when this binary is older than the sources it was built from,
 /// or when it is a FOREIGN binary being run against a checkout.
 ///
@@ -79,8 +105,10 @@ pub fn refuse_if_stale(command_name: &str) -> Result<(), String> {
     // decision is a pure function of two paths and its tests need no
     // `set_current_dir` — a process-global that leaks between parallel tests
     // (issue 1101 is that hazard, one crate over).
-    if let Ok(cwd) = std::env::current_dir() {
-        refuse_if_foreign_to_workspace(&exe, &cwd)?;
+    if workspace_check_applies(command_name) {
+        if let Ok(cwd) = std::env::current_dir() {
+            refuse_if_foreign_to_workspace(&exe, &cwd)?;
+        }
     }
     let Some(root) = checkout_root_of(&exe) else {
         return Ok(());
@@ -218,6 +246,28 @@ pub fn stamp_pair() -> Option<(String, String)> {
 
 #[cfg(test)]
 mod foreign_binary_tests {
+    /// The build-tool verbs are exempt from the WORKSPACE check — the
+    /// regression phase-413 W2 found on the tier-2 lane.
+    ///
+    /// cmake invokes `nros codegen` with the tool it was configured with, and
+    /// the cwd is wherever the build put its output. On the CI runner the
+    /// zephyr west workspace lives under a different nano-ros tree, so the cwd
+    /// walked up into a checkout the binary did not come from and a correct,
+    /// freshly built binary was refused.
+    #[test]
+    fn the_build_tool_verbs_skip_the_workspace_check() {
+        for verb in ["codegen", "codegen-system", "generate-rust"] {
+            assert!(!workspace_check_applies(verb), "{verb} must be exempt");
+            // …but they are still STALENESS-guarded: that question is about the
+            // binary, and is the one that protects a build-time emitter.
+            assert!(command_is_guarded(verb), "{verb} must stay stale-guarded");
+        }
+        // What a user types in their own workspace keeps the check.
+        for verb in ["sync", "plan", "ws", "setup"] {
+            assert!(workspace_check_applies(verb), "{verb} must keep the check");
+        }
+    }
+
     use super::*;
     use std::fs;
 


### PR DESCRIPTION
**My regression, found while diagnosing phase-413 W2.** The tier-2 `zephyr` lane fails at configure:

```
CMake Error … nros-codegen resolve-deps failed (exit 1):
  Error: this `nros` does not belong to the checkout it is being run against.
      running:  <runner checkout>/packages/cli/target/release/nros
      checkout: <the west workspace's parent>
```

The binary it refused was **the runner checkout's own, freshly built**.

## Why the guard was wrong here

phase-431 W1 asks *"which checkout is my cwd in?"*. The zephyr lane builds into a west workspace which, on the CI runner, sits under a different nano-ros tree from the one being built — so the cwd walked up into a checkout the binary did not come from.

`nros codegen` is the **build-tool interface**: cmake invokes it with the tool path it was configured with (`-D_NANO_ROS_CODEGEN_TOOL`), so the caller has already answered "which binary", and the cwd is wherever the build system put its output. **A build output directory is not a consumer workspace**, and nothing tells the two apart by path alone.

So `codegen`, `codegen-system` and `generate-rust` skip the **workspace** check. They keep the **staleness** check — the one that protects a build-time emitter, asks about the binary rather than the cwd, and was never what fired here. `sync`, `plan`, `ws` and `setup` keep both, which is what W1 was for.

## This does not claim tier 2 is green

`run-matrix` has failed on every scheduled run since at least **2026-09-01**, and this guard landed **09-05 22:00**. So this was the *current* top failure with an older one underneath — the "a lane already red reports its FIRST failure" shape CLAUDE.md records. Fixing this is what makes the older cause visible, and that is phase-413 W2 item 2's remaining work.

## Two gates caught my first draft

I pasted the runner's literal paths into the doc comment. `check-absolute-paths` refused a host-specific path in tracked code; `check-string-conventions` read `aeon/nano-ros` as the wrong org. Both correct — the comment describes the shape instead.

`just check fast`: 247/247. `nros-cli-core`: 963/963, one new test asserting the build-tool verbs are exempt from the workspace check *and* still staleness-guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK