### PR TITLE
fix(#1038, phase-413 W2): bake the zenoh ROS router the freertos/threadx_linux nightly cells need

### DIFF
--- a/ci/docker/ci-base/Dockerfile
+++ b/ci/docker/ci-base/Dockerfile
@@ -63,22 +63,60 @@ ENV DEBIAN_FRONTEND=noninteractive
 # holds for anything installed into the single `/opt/ros/humble` prefix (the apt
 # packages below are), but a ROS package that installs to a DIFFERENT prefix, or
 # one whose own setup extends these variables further, would need this block
-# updated — `ros-humble-rmw-zenoh-cpp` adding
-# `<prefix>/opt/zenoh_cpp_vendor/lib` to `LD_LIBRARY_PATH` is the case issue
-# 0774 is about. Re-run the capture command above after changing the ROS package
-# set rather than assuming.
+# updated. `ros-humble-rmw-zenoh-cpp` is exactly that case (issue 0774 /
+# issue 1038): it vendors zenoh into `<prefix>/opt/zenoh_cpp_vendor/lib`, an
+# ADDITIONAL directory under the same prefix, and `rmw_zenohd` links its
+# `libzenohc.so` by SONAME — paired with the wrong one, it SEGVs mid-startup
+# rather than failing to load. `AMENT_PREFIX_PATH` does NOT change (still one
+# prefix); only `LD_LIBRARY_PATH` gains that directory. Re-captured 2026-09-06
+# after adding the package below, with the same command:
+#
+#     docker run --rm --entrypoint bash ros:humble-ros-base -c \
+#       'apt-get update -qq && apt-get install -y --no-install-recommends \
+#          ros-humble-rmw-zenoh-cpp ros-humble-example-interfaces \
+#          >/dev/null && env|sort >/tmp/a; . /opt/ros/humble/setup.bash; \
+#          env|sort >/tmp/b; diff /tmp/a /tmp/b'
+#
+# which prints exactly one changed line:
+#
+#     < LD_LIBRARY_PATH=/opt/ros/humble/lib/x86_64-linux-gnu:/opt/ros/humble/lib
+#     > LD_LIBRARY_PATH=/opt/ros/humble/opt/zenoh_cpp_vendor/lib:/opt/ros/humble/lib/x86_64-linux-gnu:/opt/ros/humble/lib
+#
+# Re-run it again after changing the ROS package set rather than assuming.
 ENV AMENT_PREFIX_PATH=/opt/ros/humble \
-    LD_LIBRARY_PATH=/opt/ros/humble/lib/x86_64-linux-gnu:/opt/ros/humble/lib \
+    LD_LIBRARY_PATH=/opt/ros/humble/opt/zenoh_cpp_vendor/lib:/opt/ros/humble/lib/x86_64-linux-gnu:/opt/ros/humble/lib \
     PYTHONPATH=/opt/ros/humble/lib/python3.10/site-packages:/opt/ros/humble/local/lib/python3.10/dist-packages \
     ROS_VERSION=2 \
     ROS_PYTHON_VERSION=3 \
     ROS_LOCALHOST_ONLY=0
 ENV PATH=/opt/ros/humble/bin:$PATH
 
+# python3-tomli, early: `prereq-packages.py` below (COPYed right after) needs
+# it to read `nros-sdk-index.toml` before the package it names is itself
+# installed by the block that follows — a chicken/egg one apt command can't
+# resolve. (Also named again in that block's own package list, harmlessly —
+# apt no-ops on an already-satisfied package — because it belongs there too on
+# its own account, not just for this bootstrap.)
+RUN apt-get update && apt-get install -y --no-install-recommends python3-tomli
+
+# The zenoh ROS RMW's apt package name comes from the index, not a literal
+# here (issue 1038 / phase-413 W2): `[prereq.ros-rmw-zenoh-cpp]` in
+# `nros-sdk-index.toml` is the SSoT, and the name is DISTRO-PARAMETRIC (issue
+# 1128 — `ros-{ros_distro}-rmw-zenoh-cpp`, `{ros_distro}` from `$ROS_DISTRO`,
+# which the base image already sets to `humble`). Mirrored paths under
+# `/opt/nros-ssot`, same convention as `scripts/lib/rust-targets.sh` below.
+COPY scripts/sdk/prereq-packages.py /opt/nros-ssot/scripts/sdk/prereq-packages.py
+COPY nros-sdk-index.toml            /opt/nros-ssot/nros-sdk-index.toml
+
 # Host build deps shared across platforms + the arm cross-compiler (the setup-
 # time zenoh-pico build + freertos/nuttx/threadx/qemu cross builds need it on
 # PATH before `nros setup` provisions the index toolchain). curl/zstd/git for the
 # per-run install.sh + nros source provisioning.
+#
+# `ros-humble-rmw-zenoh-cpp` (issue 1038 / phase-413 W2): without it the image
+# has no zenoh router at all — `rmw_zenohd` does not exist, `zenohd_unavailable_
+# reason()` fails `require_e2e()`, and every e2e case on `freertos`/
+# `threadx_linux` skips on that one shared precondition ("Real failures: 0/0").
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake ninja-build device-tree-compiler gperf \
         git curl ca-certificates zstd xz-utils file wget \
@@ -98,6 +136,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libslirp0 libpixman-1-0 \
         libmbedtls-dev \
         ros-humble-example-interfaces \
+        $(python3 /opt/nros-ssot/scripts/sdk/prereq-packages.py --manager apt ros-rmw-zenoh-cpp) \
     && rm -rf /var/lib/apt/lists/*
 
 # uv (Python 3.12 venvs) + just (recipe runner) via their canonical installers.


### PR DESCRIPTION
phase-413 W2. Both cells report `Real failures: 0 / 0` with all 9 e2e cases skipped on one shared precondition — which `_check-skip-budget` correctly refuses to call a pass.

**Cause, confirmed in #1038:** the CI image is `FROM ros:humble-ros-base` plus an apt list whose only ROS entry is `example-interfaces`. A built image has **no** `rmw_zenoh_cpp` prefix, no `rmw_zenohd`, no `libzenohc*`. No router, so `zenohd_unavailable_reason()` fails `require_e2e()` and every case skips.

## Two changes, because installing the package alone would swap a skip for a SEGV

1. **Install `ros-humble-rmw-zenoh-cpp`, with the name derived from the index.** `[prereq.ros-rmw-zenoh-cpp]` is the SSoT and the name is distro-parametric, so the Dockerfile asks `prereq-packages.py` rather than hardcoding. That needs `python3-tomli` in an earlier layer — the helper must parse the index *before* the package it names is installed, which one apt command cannot resolve.

2. **Re-capture the static `LD_LIBRARY_PATH` `ENV` block.** `rmw_zenohd` links `libzenohc.so` by SONAME, and `<prefix>/opt/zenoh_cpp_vendor/lib` is on the loader path only when `setup.bash` was sourced — which a baked `ENV` replaces. Paired with the wrong `libzenohc.so` it **SEGVs mid-startup** rather than failing to load (#0774). `AMENT_PREFIX_PATH` is unchanged; only `LD_LIBRARY_PATH` gains that directory. The Dockerfile's own comment already said to re-run its capture command after changing the ROS package set — the command and its exact one-line diff are now recorded beside the block.

## Verified by building and running the image, not by reading it

- `dpkg -l` shows `ros-humble-rmw-zenoh-cpp` and `ros-humble-zenoh-cpp-vendor` 0.1.9.
- `rmw_zenohd` and the vendored `libzenohc.so` exist at the expected paths.
- The baked env matches a real before/after `setup.bash` diff in a fresh `ros:humble-ros-base` with the same package set.
- **`rmw_zenohd` starts a router with no SEGV** — #0774's failure mode not happening.

**Not verified:** the nightly cells themselves, which need the published image and the self-hosted runner. W2's acceptance line ("each lane green at least once, and the date recorded here") stays unticked.

`ros-humble-example-interfaces` beside it stays a literal deliberately — it is not an indexed prereq, so there is nothing to derive it from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK