### PR TITLE
fix(#1038, phase-413 W2): the threadx_riscv64 rust leaves are synced, not just central-patched

### DIFF
--- a/just/threadx-riscv64.just
+++ b/just/threadx-riscv64.just
@@ -1,3 +1,9 @@
+# The six Rust roles this lane builds. ONE list: it was written out three times
+# (the codegen pre-sync, the Corrosion fan-out, the fixture loop), and a role
+# added to two of the three is a leaf that silently never gets synced or never
+# gets built — the "one shared spelling, not a second one" rule.
+RV64_RUST_ROLES := "talker listener service-server service-client action-server action-client"
+
 set working-directory := '..'
 
 default:
@@ -223,6 +229,26 @@ build-fixture-extras:
     if [ -z "$(nros_riscv64_prefix)" ]; then
         nros_lane_skip_note threadx-riscv64 "no riscv64 bare-metal gcc (run: nros setup qemu-riscv64-threadx)"; exit 0
     fi
+    # issue 1038 follow-up — sync the six rust roles' message crates BEFORE
+    # cmake ever configures them.
+    #
+    # `nros_ensure_central_patch` above (and again, idempotently, before the
+    # `logging-smoke` cargo row below) fixes the include-target half of issue
+    # 0463 for this lane, but talker/listener/service-{server,client}/
+    # action-{server,client} each also patch a generated message crate
+    # (`std_msgs`, `builtin_interfaces`, …) that ONLY `nros sync` — not
+    # `ws central-patch` — materialises. They build through
+    # `nros_threadx_rv64_rust_app` (Corrosion/CMake), the one seam in this repo
+    # that never goes through `fixtures-build.sh`'s per-row presync, so nothing
+    # else in this lane ever ran it. Serial, once per role, before the six
+    # leaves fan out below — same shape as `nros_presync_row_dirs`.
+    for _rc_sync in {{RV64_RUST_ROLES}}; do
+        _rc_sync_dir="examples/qemu-riscv64-threadx/rust/$_rc_sync"
+        if [ -d "$_rc_sync_dir" ]; then
+            echo "  → (role codegen) $_rc_sync_dir"
+            nros_ensure_leaf_synced "$_rc_sync_dir"
+        fi
+    done
     echo "Building ThreadX-RV64 test fixtures..."
     # Phase 176 — cmake parallelism via the fifo jobserver when present.
     if [ "${NROS_JOBSERVER:-}" = "1" ] || [ "${NROS_INHERIT_JOBSERVER:-}" = "1" ]; then unset CMAKE_BUILD_PARALLEL_LEVEL; else export CMAKE_BUILD_PARALLEL_LEVEL="${NROS_BUILD_JOBS:-8}"; fi
@@ -400,7 +426,7 @@ build-fixture-extras:
             _tx_jobs="$(nros_cargo_frontend_jobs)"
             _tx_status_dir="$(mktemp -d)"
             _tx_n=0
-            for _rc in talker listener service-server service-client action-server action-client; do
+            for _rc in {{RV64_RUST_ROLES}}; do
                 if [ -d "examples/qemu-riscv64-threadx/rust/$_rc" ]; then
                     for _tx_pair in "cyclonedds build-cyclonedds" "zenoh build-zenoh"; do
                         # shellcheck disable=SC2086
@@ -545,7 +571,7 @@ zenohd:
 clean:
     #!/usr/bin/env bash
     rm -rf build/cmake-threadx-riscv64-zenoh
-    for example in talker listener service-server service-client action-server action-client; do
+    for example in {{RV64_RUST_ROLES}}; do
         rm -rf "examples/qemu-riscv64-threadx/rust/$example/target" \
                "examples/qemu-riscv64-threadx/rust/$example/target-zenoh"
         rm -rf "examples/qemu-riscv64-threadx/c/$example/build-zenoh" \

--- a/scripts/build/cargo.sh
+++ b/scripts/build/cargo.sh
@@ -479,3 +479,30 @@ nros_cargo_fetch_standalone_manifests() {
 nros_ensure_central_patch() {
     NROS_REPO_DIR="${NROS_REPO_DIR:-$PWD}" "$(nros_cli_bin)" ws central-patch >/dev/null
 }
+
+# issue 1038 follow-up — ensure ONE leaf's `generated/<pkg>` message crates
+# exist, not just the central include target above.
+#
+# `nros_ensure_central_patch` closes the manifest-parse failure for a leaf
+# whose `.cargo/config.toml` only reaches `nros-patch.toml`. A leaf that ALSO
+# patches a message crate (any `std_msgs = { path = "generated/std_msgs" }`
+# row — RFC-0067) fails the SAME way one path deeper: cargo cannot read a
+# `generated/` dir that was never materialised, central table or not. Measured
+# by reproducing it (`cargo metadata` on `examples/qemu-riscv64-threadx/rust/
+# talker` after `nros ws central-patch` alone: parse still fails, now on
+# `generated/std_msgs/Cargo.toml`).
+#
+# Every OTHER lane's rust leaves reach `fixtures-build.sh`'s cargo-row path,
+# which pre-syncs each row directory once before it fans out
+# (`nros_presync_row_dirs`). `threadx-riscv64`'s six rust roles build through
+# Corrosion/CMake instead (`nros_threadx_rv64_rust_app` /
+# `nros_cmake_fixture_build`), a seam `fixtures-build.sh` never runs for them,
+# so nothing there ever synced them.
+#
+# `nros sync <dir>` is a strict superset of `ws central-patch` — same central
+# table, plus the leaf's own `generated/` crates — so this is the ONE call a
+# CMake-driven message-dependent leaf needs, not two. Idempotent.
+nros_ensure_leaf_synced() {
+    local dir="$1"
+    NROS_REPO_DIR="${NROS_REPO_DIR:-$PWD}" "$(nros_cli_bin)" sync "$dir" >/dev/null
+}


### PR DESCRIPTION
phase-413 W2. The nightly cell's reported failure — a cargo manifest-parse error on the leaf's `include` of the central `nros-patch.toml` (#0463's shape) — **was already fixed** by `947a301b0`/`63af20660`.

Reproducing it by hand (deleting a leaf's `generated/` and `nros-patch.toml`, then `cargo metadata`) showed that fix is **correct but incomplete**: it closes the central-table half, and the same failure returns one path deeper. A leaf that also patches a message crate — `std_msgs = { path = "generated/std_msgs" }`, RFC-0067 — needs that directory to *exist*, and only `nros sync <leaf>` produces it. `ws central-patch` does not.

**Why only this lane.** Every other platform's rust leaves reach `fixtures-build.sh`'s cargo-row path, which pre-syncs each row directory before fanning out (`nros_presync_row_dirs`). threadx-riscv64's six rust roles build through Corrosion/CMake (`nros_threadx_rv64_rust_app`) — the one seam that never goes through that presync — so nothing in the lane had ever synced them.

`nros_ensure_leaf_synced` is the one call such a leaf needs: `nros sync <dir>` is a strict superset of `ws central-patch`, so one call rather than two.

## One list where there were three

The six role names were already written out **twice** in this file — the Corrosion fan-out and the fixture loop — and the pre-sync would have made a third. A role added to two of three is a leaf that silently never gets synced or never gets built, which is the same shape this fix exists to close. `RV64_RUST_ROLES` is now the one spelling.

**Verified:** both failures reproduced; `cargo metadata` succeeds on all six leaves after the pre-sync; `git status` clean afterwards (sync touches only gitignored paths); `just check fast` 247/247.

**Not verified:** the nightly cell itself, and the CMake/Corrosion build past manifest-parse — that needs the ThreadX/NetX submodules and a self-hosted runner. The class of manifest-parse failure is closed at both layers reachable here; the cell is not claimed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK