### PR TITLE
fix(#1145, phase-392 W6): the Zephyr talker stops reserving the executor backing twice

### DIFF
--- a/docs/issues/1145-executor-backing-static-unpaired-with-rtos-heap.md
+++ b/docs/issues/1145-executor-backing-static-unpaired-with-rtos-heap.md
@@ -78,6 +78,59 @@ For each RTOS platform, in this order, and one platform per commit:
 Do not do this as one sweeping commit: the failure mode is a runtime allocation
 failure on one platform, and a six-platform diff makes that unattributable.
 
+## Zephyr, one leaf: DONE 2026-09-06
+
+`examples/zephyr/rust/talker` (zenoh), both boards it builds for. `malloc_arena`
+is an `nm`-visible symbol, so both halves of the pairing read off one ELF.
+
+| symbol | before | after |
+| --- | ---: | ---: |
+| `malloc_arena` (mps2_an385) | 1,048,576 | 961,320 |
+| `EXECUTOR_BACKING` (mps2_an385) | 87,256 | 87,256 |
+| `EXECUTOR_BACKING` (native_sim/native/64) | 88,328 | 88,328 |
+
+Lowered by the SMALLER of the two boards' backings (87,256), so neither board
+loses headroom it had before W6.
+
+Whole-image RAM on mps2/an385, west's own report:
+
+```
+before   RAM: 1789196 B / 4 MB  (42.66%)
+after    RAM: 1701940 B / 4 MB  (40.58%)
+delta         -87,256 B
+```
+
+Exactly the backing size. **Boots and delivers, not merely links**:
+native_sim published 20 messages in 25 s — identical to the pre-change control
+run — and a stock ROS 2 consumer received them
+(`ros2 topic echo /chatter std_msgs/msg/String --once` -> `data: 'Hello World: 9'`).
+
+### Found on the way, and fixed first
+
+The Zephyr build could not run at all. Two blockers, both filed and neither
+this issue's:
+
+* **issue 1167** — a red on `main` from the same day: `#if ZPICO_MAX_SESSIONS < 1`
+  sat ABOVE the knob's default, so every Zephyr zenoh image failed to compile.
+  Two sessions found it hours apart from opposite ends and fixed it in opposite
+  directions; `91f3ce7c9` is the one that shipped, and the gate that asks
+  whether a guard can FIRE is on its own branch.
+* **issue 1166** (filed the same day, on its own branch) — the self-hosted
+  runner builds Zephyr into a developer checkout and claims the shared west
+  build dir, so `west` refused this measurement's first build. Worked around
+  here with a private `-d`; that issue is the fix.
+
+## Still open
+
+* **Every other Zephyr Rust leaf** (`listener`, `service-client`,
+  `service-server`, …) still reserves twice. Each needs its own measurement —
+  the backing is knob-derived per image, not a constant.
+* **FreeRTOS, NuttX, ThreadX, ESP32** — untouched. One platform per commit, per
+  the plan above, because the failure mode is a runtime allocation failure and a
+  six-platform diff makes it unattributable.
+* **The subtrahend is a hand-copied literal.** Move an executor knob and it is
+  stale with nothing to say so — [issue 1171](1171-arena-backing-pairing-is-hand-maintained.md).
+
 ## Related
 
 - phase-392 W6 — the change that created this, and the measurement that is done.

--- a/docs/issues/1171-arena-backing-pairing-is-hand-maintained.md
+++ b/docs/issues/1171-arena-backing-pairing-is-hand-maintained.md
@@ -1,0 +1,81 @@
+---
+id: 1171
+title: "The picolibc arena is lowered by a hand-copied `EXECUTOR_BACKING` size, so an
+  executor knob change silently re-creates the double reservation it removed"
+status: open
+type: tech-debt
+area: [core, embedded, build]
+related: [1145, 0163, 0460, phase-392]
+---
+
+## What
+
+Issue 1145 paired the two halves of phase-392 W6 on Zephyr: the executor
+backing became a `.bss` static, so `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` no
+longer has to hold it, and the leaf conf was lowered by the measured size.
+
+The number in the conf is a **literal, copied from `nm` output**:
+
+```
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=961320   # 1048576 - 87256
+```
+
+`EXECUTOR_BACKING`'s size is `ExecutorSizing::DEFAULT.u64_len()`, which is
+derived from the executor knobs (`MAX_CBS`, `ARENA_SIZE`, `RX_BUF_SIZE`, …).
+Move any of those and the subtrahend is wrong, in whichever direction:
+
+* the backing GROWS -> the arena was lowered by too little -> the double
+  reservation is partly back, silently, and only `mem-report` would notice;
+* the backing SHRINKS -> the arena was lowered by too much relative to the
+  saving available, which costs nothing but records a number that no longer
+  means what its comment says.
+
+Nothing checks it. The conf is a Kconfig fragment; the size is a Rust const in
+another crate; and the only thing that has ever related them is a person with
+`nm` output in front of them.
+
+## Why it was not solved in 1145
+
+The obvious fix — have the build derive the arena from the backing — crosses a
+one-way boundary. `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE` is resolved during the
+Zephyr **Kconfig** stage, which completes before the Rust crate that defines the
+size is compiled. Issue 0460 is the same wall from the other side (a knob
+reaching the C lane and not the Rust one), and its answer was to make the Rust
+side READ the dotconfig, which is the direction that works.
+
+So the candidate shapes, none of them free:
+
+1. **A post-link gate.** Read both symbols from the built ELF and assert
+   `malloc_arena` is not larger than the pre-W6 arena minus `EXECUTOR_BACKING`.
+   Needs a built image, so it belongs to a lane that builds Zephyr — which is
+   currently no merge-gating lane (see 1158, 1167).
+2. **Publish the size from `nros-node/build.rs`** into a file the conf
+   generator reads, and emit the fragment rather than authoring it. Moves the
+   arithmetic to one place but adds a generated conf, and the leaf confs are
+   authored files today.
+3. **Declare it and stop deriving.** Give the backing a Kconfig symbol whose
+   default the crate is REQUIRED to match (the `-1` sentinel pattern
+   `nros_cargo_build.cmake` already uses), so both sides read one number.
+
+Shape 3 is the one that matches how every other knob in this tree behaves, and
+it is the one that would let the arena default be written as an expression.
+
+## Scope
+
+Only `examples/zephyr/rust/talker/prj-zenoh.conf` carries the lowered number
+today — that is the one leaf 1145 measured and ran. **Every other Zephyr Rust
+leaf still reserves twice**, and each needs its own measurement because the
+backing is knob-derived per image:
+
+```
+examples/zephyr/rust/{listener,service-client,service-server,...}/prj-*.conf
+```
+
+Doing them by hand multiplies this drift by the number of leaves, which is the
+argument for fixing the mechanism before finishing the sweep.
+
+## Not this issue
+
+Whether the arena should be 1 MiB at all. It is generous, and nothing here
+measured what the backend actually needs — 1145 lowered it by exactly the
+amount W6 stopped drawing, and claimed nothing else.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1244,6 +1244,50 @@ static.
   under the Rust `nros` crate, and plain C's `app` struct under
   `(C / asm / no path)`. → **issue 1147**.
 
+### W6 on Zephyr — MEASURED 2026-09-06, and the pairing is now real
+
+W6's native measurement showed the arena becoming VISIBLE (+21,568 B of `.bss`,
+a move rather than a saving). On an RTOS the second half exists, and issue 1145
+asked for it: the allocator arena the backing used to come out of is itself a
+fixed static, so an image built after W6 without lowering that knob reserves the
+bytes twice.
+
+Done for `examples/zephyr/rust/talker` (zenoh), both boards it builds for.
+`malloc_arena` is an `nm`-visible symbol, so both halves read off one ELF:
+
+| symbol | before | after |
+| --- | ---: | ---: |
+| `malloc_arena` (mps2_an385) | 1,048,576 | 961,320 |
+| `EXECUTOR_BACKING` (mps2_an385) | 87,256 | 87,256 |
+| `EXECUTOR_BACKING` (native_sim/native/64) | 88,328 | 88,328 |
+
+Whole-image RAM on mps2/an385, from west's own report:
+
+    before   RAM: 1789196 B / 4 MB  (42.66%)
+    after    RAM: 1701940 B / 4 MB  (40.58%)
+    delta         -87,256 B
+
+Exactly the backing size, to the byte — which is the claim, not a coincidence:
+the arena was lowered by the smaller of the two boards' measured backings so
+neither loses headroom it had before W6.
+
+**It boots and delivers, not merely links.** `native_sim/native/64` published 20
+messages in 25 s (identical to the pre-change control), and a stock ROS 2
+consumer received them:
+
+    $ ros2 topic echo /chatter std_msgs/msg/String --once
+    data: 'Hello World: 9'
+
+So on this leaf W6 is now free rather than costing 87,256 B, and the executor's
+storage is priceable for the first time.
+
+**Scope, stated plainly.** ONE leaf, ONE platform. Every other Zephyr Rust leaf
+still reserves twice, and FreeRTOS, NuttX, ThreadX and ESP32 are untouched —
+1145 asks for one platform per commit precisely because the failure mode is a
+runtime allocation failure that a six-platform diff makes unattributable. The
+subtrahend is also a HAND-COPIED literal, so an executor knob change makes it
+stale with nothing to say so: issue 1171.
+
 **Interaction with amendment B.** Unchanged: this does not decide whether
 payload buffers become heap-backed, it makes the question measurable. A `.bss`
 arena is the better starting point for that measurement.

--- a/examples/zephyr/rust/talker/prj-zenoh.conf
+++ b/examples/zephyr/rust/talker/prj-zenoh.conf
@@ -28,7 +28,24 @@ CONFIG_NET_CONNECTION_MANAGER=y
 CONFIG_DEBUG=y
 
 # Issue 0163 — the Zephyr Rust global allocator is picolibc malloc, so the
-# executor's ~75 KB leaked default backing (phase-271) and the in-image
-# backend's buffers come from COMMON_LIBC_MALLOC_ARENA_SIZE (default 16 KB),
-# NOT the kernel heap. Mirrors prj-cyclonedds.conf's arena bump.
-CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=1048576
+# in-image backend's buffers come from COMMON_LIBC_MALLOC_ARENA_SIZE
+# (default 16 KB), NOT the kernel heap. Mirrors prj-cyclonedds.conf's bump.
+#
+# issue 1145 / phase-392 W6 — the executor backing NO LONGER comes from here.
+# It was a `Box::leak` out of this arena (the "~75 KB leaked default backing"
+# this comment used to name); W6 made it the named `.bss` static
+# `nros_node::executor::backing::EXECUTOR_BACKING`. Leaving the arena at
+# 1048576 reserves those bytes TWICE — once in the static, once as arena
+# headroom nothing draws on any more.
+#
+# Lowered by the backing MEASURED on this leaf, taking the SMALLER of the two
+# boards it builds for, so neither loses headroom it had before W6:
+#
+#     mps2_an385            EXECUTOR_BACKING = 0x154d8 =  87,256 B
+#     native_sim/native/64  EXECUTOR_BACKING = 0x15908 =  88,328 B
+#     1048576 - 87256                                  = 961,320
+#
+# `malloc_arena` is itself an `nm`-visible symbol, so the before/after reads
+# straight off the ELF. The pairing is HAND-MAINTAINED: move an executor knob
+# and this number is stale with no gate to say so — issue 1171.
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=961320


### PR DESCRIPTION
**Stacked on #639** (the `#1167` red on `main`), because Zephyr could not compile at all without it. Rebase-merge #639 first and this retargets to `main` cleanly.

## What

W6 moved the executor's per-entry storage out of a `Box::leak` and into the named `.bss` static `nros_node::executor::backing::EXECUTOR_BACKING`, so `mem-report` can price it. On a hosted target that is free — the allocator is the OS heap. On Zephyr the Rust global allocator is **picolibc malloc, whose arena is itself a fixed static** sized to hold that backing, so an image built after W6 reserves the same bytes twice.

## Measured

`malloc_arena` is an `nm`-visible symbol, so both halves of the pairing read off one ELF:

| symbol | before | after |
| --- | ---: | ---: |
| `malloc_arena` (mps2_an385) | 1,048,576 | 961,320 |
| `EXECUTOR_BACKING` (mps2_an385) | 87,256 | 87,256 |
| `EXECUTOR_BACKING` (native_sim/native/64) | 88,328 | 88,328 |

Lowered by the **smaller** of the two boards' measured backings, so neither loses headroom it had before W6.

Whole-image RAM on mps2/an385, from west's own report:

```
before   RAM: 1789196 B / 4 MB  (42.66%)
after    RAM: 1701940 B / 4 MB  (40.58%)
delta         -87,256 B
```

Exactly the backing size — the claim, not a coincidence.

## Boots and delivers, not merely links

That is the bar #1145 sets, and it is the right one: an under-sized allocator fails at the first allocation the executor no longer makes but something else still does.

`native_sim/native/64` published 20 messages in 25 s — identical to the pre-change control run — and a stock ROS 2 consumer received them:

```
$ ros2 topic echo /chatter std_msgs/msg/String --once
data: 'Hello World: 9'
```

## Scope, stated plainly

**One leaf, one platform.** Every other Zephyr Rust leaf still reserves twice and each needs its own measurement — the backing is knob-derived per image, not a constant. FreeRTOS, NuttX, ThreadX and ESP32 are untouched. #1145 asks for one platform per commit precisely because the failure mode is a runtime allocation failure that a six-platform diff makes unattributable, so **#1145 stays open** with this row recorded.

## Filed rather than papered over

**#1171** — the subtrahend is a hand-copied literal, so moving an executor knob makes it stale with no gate to say so. The issue lays out the three candidate mechanisms and why the obvious one (derive the arena from the backing) crosses the Kconfig/Rust boundary the wrong way; issue 0460 is the same wall from the other side.

## Found on the way

Two blockers stopped the Zephyr build before any of this could be measured, both filed separately:

- **#1167** (this PR's base) — a red on `main` from the same day: `#if ZPICO_MAX_SESSIONS < 1` sat above the knob's `#ifndef` default, so every Zephyr zenoh image failed to compile.
- **issue 1166** (own branch, #644) — the self-hosted runner builds Zephyr into a developer checkout and claims the shared west build dir, so `west` refused this measurement's first build. Worked around here with a private `-d`.

## Verification

Four Zephyr builds (mps2 and native_sim, before and after), two delivery runs, one ROS 2 end-to-end receipt. `check-doc-refs` and `check-string-conventions` green; the pre-push hook ran `check-fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5