### PR TITLE
gate(phase-433 W5, #1127): a live-peer verdict is recorded, or it never happened

### DIFF
--- a/.config/interop-verdicts.toml
+++ b/.config/interop-verdicts.toml
@@ -1,0 +1,51 @@
+# What a LIVE ROS 2 peer has actually answered — issue 1127, phase-433 W5.
+#
+# One `[[verdict]]` per `Tier::Runtime` cell in `nros_tests::interop::CELLS`
+# that has produced a real result. **A cell with no entry has NEVER produced a
+# verdict**, and that is the default rather than an omission: a `skip!` becomes
+# `<skipped>` in the junit, every consumer counts it as not-a-failure, and the
+# lane is green — so absence of an entry is the only honest starting point.
+# Nothing here can be satisfied by a cell that never runs.
+#
+# Gate: `just check interop-verdict-ledger`. Report: `just interop-verdicts`.
+#
+# RECORD ONE FROM A RUN, do not type it:
+#
+#     python3 scripts/check-interop-verdicts.py --record <cell-id> \
+#         --junit target/nextest/default/junit.xml --where 'ros2 distrobox'
+#
+# It refuses a junit in which every case of that cell's binary SKIPPED, which
+# is the whole point. A `fail` verdict must name an OPEN issue — a failing cell
+# is a finding, not a blocker (issue 1127 Direction item 2).
+#
+# `tests` may not cite a BINDING test. Every live-peer binary carries one
+# (`cases_bound_to_interop_cells` and its siblings): body is
+# `interop::assert_test_bound(...)` and nothing else, so it passes on any host
+# with no peer, forever. Citing one would put the defect being fixed inside the
+# fix. The gate rejects it.
+#
+# FIELDS: cell, date, verdict (pass|fail), tests, run, where, evidence;
+# `issue` when the verdict is fail, `note` when something needs saying.
+#
+# This file holds only POSITIVE claims and is written at most once per cell, so
+# it is not the committed generated file that serialised the merge queue in
+# issues 0883/0884 — there is no shared line for a pull request to touch.
+
+[[verdict]]
+cell = "native-graph-rust-cyclone-r2n"
+date = "2026-09-06"
+verdict = "fail"
+tests = ["cyclone_enumerates_a_stock_ros2_node"]
+run = "cargo nextest run -p nros-tests --test graph_interop"
+where = "ros2 distrobox (Humble), nano-ros-box tree — phase-433 W1"
+evidence = "FAIL [37.468s] (2/2) graph_interop cyclone_enumerates_a_stock_ros2_node. get_node_names returns one entry (the probe itself) while a stock talker is on the domain; get_topic_names_and_types errors Transport(Unsupported); nine of twelve slots answer Unsupported. The peer was ruled out first per issues 0859-0862."
+issue = "1137"
+
+[[verdict]]
+cell = "native-graph-rust-zenoh-r2n"
+date = "2026-09-06"
+verdict = "pass"
+tests = ["nano_ros_enumerates_a_stock_ros2_node"]
+run = "cargo nextest run -p nros-tests --test graph_interop"
+where = "ros2 distrobox (Humble), nano-ros-box tree — phase-433 W1"
+evidence = "PASS [18.762s] (1/2) graph_interop nano_ros_enumerates_a_stock_ros2_node. First live run since the cell was written; the twelve graph slots phase-381 shipped and issue 0903 repaired work against a stock rmw_zenoh_cpp peer."

--- a/docs/issues/1127-live-peer-cells-skip-forever.md
+++ b/docs/issues/1127-live-peer-cells-skip-forever.md
@@ -177,3 +177,61 @@ names). The order that works:
    stops the problem recurring.
 
 Phase 433 owns this work.
+
+## Item 5 LANDED 2026-09-06 — a verdict is recorded, or it never happened
+
+`.config/interop-verdicts.toml` + `scripts/check-interop-verdicts.py`
+(`just check interop-verdict-ledger`, fast lane; `just interop-verdicts` for
+the report). Design, and the four shapes rejected, in
+[phase-433 W5.a](../roadmap/phase-433-rmw-live-verification.md).
+
+The shape: **absence of an entry means NEVER RUN.** A cell that has met a peer
+has a dated entry naming the cases, the verdict, the command and what was
+observed; every other cell is unproven by default, so nothing here can be
+satisfied by a cell that never runs and a newly added cell needs no line.
+Seeded with W1's two real verdicts — `native-graph-rust-zenoh-r2n` PASS,
+`native-graph-rust-cyclone-r2n` FAIL (issue 1137). **2 of 17.**
+
+Three properties this had to have, and how:
+
+* **Not satisfiable by absence.** The default is "never", not "fine". A
+  `fail` verdict must name an OPEN issue, so a finding cannot be parked.
+* **Not red for a legitimate skip.** The gate checks the ledger's INTEGRITY,
+  never a host's capability, so it is green on a laptop with no ROS. Age is
+  reported in days, not expired: an expiry over cells only a ROS-carrying lane
+  can refresh would go red for everyone and stay red.
+* **Not a merge-queue serialiser (0883/0884).** The file holds only POSITIVE
+  claims, written at most once per cell — 17 edits ever, not one per pull
+  request. There is no shared generated line for a PR to touch.
+
+The load-bearing rule, and the reason a junit-derived skip streak cannot work:
+**a binding test is not evidence.** Ten of the eleven live-peer binaries carry
+`cases_bound_to_interop_cells` — body is `interop::assert_test_bound(...)` and
+nothing else — which passes on any host, with no peer, forever. So "did this
+binary produce a non-skip result" is TRUE for all of them on a machine with no
+ROS at all, and a mechanism reading that as coverage would be this very bug
+wearing the fix's clothes. The gate refuses an entry citing one, and
+`--record`/`--after-run` exclude them when reading a junit. (Measured across
+the eleven: exactly one such test in ten of them, none in `graph_interop`,
+whose binding call sits inside the real cases.)
+
+Where a human sees it: the gate's own OK line on every push
+(`2/17 … 15 NEVER RUN`), `just interop-verdicts`, and one line at the tail of
+every sweep via `_test-summary` — which distinguishes the two runs that used
+to print the same thing:
+
+```
+Real failures: 0 / 0 total failures
+Live-peer interop: 2/17 cells have ever produced a verdict. This run reached
+1 of their binaries — 0 produced a result, 1 skipped wholesale.
+```
+
+versus, when the case actually ran, the same header followed by `1 produced a
+result, 0 skipped wholesale` and the cell named for recording.
+
+**Still open in this issue:** item 2 (run the other 15 and record them) and
+item 3 (a lane over the ones that pass) — phase-433 W2/W5. The ledger is where
+W2's verdicts land, instead of a prose table nothing can check. This mechanism
+cannot tell that a hand-written entry is TRUE, only that it is well-formed and
+cites real non-binding cases; and it cannot know when a recorded verdict goes
+stale, which is what the scheduled lane is for.

--- a/docs/roadmap/phase-433-rmw-live-verification.md
+++ b/docs/roadmap/phase-433-rmw-live-verification.md
@@ -336,6 +336,117 @@ W1–W3's work decays the moment someone adds a cell.
 *Acceptance:* the gate exists, is on a lane, and fails when a cell's test is
 unreferenced.
 
+### W5.a — the durable half: a verdict is RECORDED, or it never happened
+
+Issue 1127's Direction item 5, and the only one of the five that stops the class
+recurring. W1–W4 make a cell *runnable and aimable*; none of them makes the
+difference between "ran and passed" and "skipped on every host since the day it
+was written" visible to anybody.
+
+**What is being closed.** A `skip!` is not a verdict, and after
+`_rewrite-skipped-junit` it is a `<skipped>` that every consumer counts as
+not-a-failure. So a Runtime interop cell that has never met a peer looks
+exactly like one that passes, on every lane, forever. Five gates surround such
+a cell (`matrix_fixture_coverage.rs` G1–G5) plus W4's runner gate, and all six
+are statements about DECLARATIONS. That is issue 0445's absorbing-verdict class
+one level up: there a STALE fixture replaces the runtime's answer with a
+message explaining itself; here a green tick does the same job. W1 measured the
+cost — `graph_interop` had been "green" since it was written, and the first
+time it was aimed at a live peer, zenoh passed and Cyclone failed nine of
+twelve slots (issue 1137). The cell's own comment had predicted it.
+
+**The mechanism.** `.config/interop-verdicts.toml` records, per cell, that a
+real run produced a real result: the date, the case names, pass or fail, the
+command, where it ran, and the observed output. **Absence of an entry means
+NEVER RUN, and that is the default** — a new cell needs no ledger line and
+starts life honestly unproven, which is the property a mechanism for this must
+have. `scripts/check-interop-verdicts.py` is three things over that one file:
+
+* `--check` — the gate (`just check interop-verdict-ledger`, fast lane).
+  Integrity only, so it is green on a laptop with no ROS: every entry names a
+  real `Tier::Runtime` cell in `interop::CELLS`, carries every required field,
+  names test functions that still EXIST in that cell's declared test binary,
+  and — the load-bearing rule — **names at least one case that is not a
+  binding-only test.** `cases_bound_to_interop_cells` and its siblings call
+  `interop::assert_test_bound` and nothing else; they pass on any host, with no
+  peer, forever. Letting one of those count as evidence would re-create the
+  exact defect inside the mechanism built to catch it. A `fail` verdict must
+  name an OPEN issue (1137 does).
+* `--report` — `just interop-verdicts`. Every Runtime cell, one line each:
+  `PASS`/`FAIL` with its date and age, or `NEVER` with the focused runner W4's
+  gate proved exists. This is the human-facing half.
+* `--record CELL --junit F` — writes an entry FROM a run. It refuses when every
+  case of that cell's binary in that junit skipped: *"no verdict — that is the
+  absence this ledger exists to make visible."* So the honest path is
+  mechanical, and hand-authoring an entry is a visibly different act.
+
+And one line at the tail of every sweep (`_test-summary`, so every `test`,
+`test-all` and tier): `--after-run` reports how many cells have ever produced a
+verdict, how many live-peer binaries this run reached, and how many of them
+skipped wholesale. It stays silent when the run contained no interop binary,
+and it NAMES a cell whose binary produced a result the ledger has not recorded
+— which is the ratchet tightening itself.
+
+**Seeded with the two verdicts that exist.** W1's run is in the ledger:
+`native-graph-rust-zenoh-r2n` PASS, `native-graph-rust-cyclone-r2n` FAIL
+(issue 1137). 2 of 17. W2 fills in the rest by running the cells; the ledger
+is where its "record a verdict per cell" lands, instead of a prose table in
+this document that nothing can check.
+
+**What was rejected, and why.**
+
+* **A generated per-cell last-verdict file, updated by CI.** This is the
+  0883/0884 shape exactly: a committed generated file that many PRs touch
+  serialises the merge queue, and a merge driver cannot fix it because GitHub
+  rebases queue entries server-side. The ledger dodges it by holding only
+  POSITIVE claims, written by a human at most once per cell — 17 edits, ever,
+  not one per push.
+* **Extending `check-skip-budget` (issue 0584).** It is the right neighbour and
+  the wrong shape. Its two assertions are deliberately DERIVED from a single
+  run, with no declaration file, so it cannot express "has never happened on
+  any host" — a property of all history everywhere. 0584 itself named the gap
+  it could not close: *"a `capability` skip on a machine that HAS the
+  capability … is a bug that is currently invisible."* Closing that needs to
+  know what the host has, which the junit does not say.
+* **Deriving the streak from junit alone.** Attractive — CI already produces
+  the XML — and unsound at the granularity that matters. Junit gives (binary,
+  case), and **every one of the eleven live-peer binaries also carries a
+  binding test that passes with no peer**, so "did this binary produce a
+  non-skip result" is TRUE for all eleven on a host with no ROS. A mechanism
+  that reads that as coverage is the bug wearing the fix's clothes. Per-CELL
+  attribution needs someone to say which case exercises which cell, and that
+  is what an entry is. (`--record` and `--after-run` do consume junit, with
+  the binding-only cases excluded by the rule above.)
+* **A count ratchet ("no more than N unverified cells").** One integer in a
+  shared file, edited by every PR that adds a cell — 0883/0884 again, for one
+  line of value. Absence-means-never already makes a new cell unproven without
+  anyone editing anything.
+* **A gate that fails while a cell is unverified.** Uniformly red on every
+  contributor's host, since most have no ROS; a lane with no signal capacity
+  teaches people to ignore it (CLAUDE.md). Visibility is the lever here, not
+  refusal.
+* **A hard expiry on a verified entry**, the way `.config/flake-quarantine.toml`
+  expires a quarantine. Right there, wrong here: quarantine holds a handful of
+  deliberate suppressions, this holds up to 17 cells that only a ROS-carrying
+  lane can refresh, so expiry would go red for everyone and stay red. The age
+  is REPORTED instead, in days, beside every entry.
+
+**What this does not do.** It cannot verify that a hand-written entry is true —
+only that it is well-formed, names a real cell, and cites cases that exist and
+are not binding-only. It cannot see an entry DELETED either — that is a
+coverage regression only review catches, and a ratchet over the count would be
+the shared committed line this design exists to avoid. Nor does it know when a
+recorded verdict goes stale: a
+cell verified today can break tomorrow, and only W5's scheduled lane will say
+so. The ledger's job is to stop *absence* reading as *success*; keeping a
+verdict fresh is what a lane is for.
+
+*Acceptance:* the ledger and gate exist, the gate is on the fast lane and fails
+on a stale entry, on a binding-only case cited as evidence and on an
+unattributed `fail`; the report distinguishes a recorded verdict from a cell
+that has never produced one; `--record` refuses a junit in which the cell's
+binary only skipped.
+
 ### W5 — a lane, over the cells that passed
 
 Box-resident, scheduled (not on the PR path — it needs ROS, a router and a

--- a/just/check/fixtures.just
+++ b/just/check/fixtures.just
@@ -230,6 +230,21 @@ lane-scope-consumers:
 interop-cell-runners:
     @python3 scripts/check-interop-cell-runners.py
 
+# phase-433 W5 / issue 1127 — the half that outlives W4's runner gate. A cell can
+# be aimed at and still never have met a peer: `skip!` becomes `<skipped>`, every
+# consumer counts that as not-a-failure, and a cell that has skipped on every host
+# since the day it was written is indistinguishable from one that passes. So what
+# a live peer has ANSWERED is written down (`.config/interop-verdicts.toml`) and
+# an absent entry means NEVER RUN — the default, so nothing here is satisfiable by
+# a cell that never runs. This gate checks the ledger's integrity only, which is
+# why it is green on a host with no ROS: real cell, required fields, cases that
+# still exist, an OPEN issue behind every `fail`, and no BINDING test cited as
+# evidence (`cases_bound_to_interop_cells` passes with no peer, forever — citing
+# one would put the defect inside the fix). Report: `just interop-verdicts`.
+[private]
+interop-verdict-ledger:
+    @python3 scripts/check-interop-verdicts.py
+
 # Issue 0743 fallout — a `binary()` in .config/nextest.toml naming a deleted test
 # target makes nextest refuse to PARSE the config, which kills every nextest run
 # in the repo, not just that lane. It went unnoticed behind a green `just check`

--- a/justfile
+++ b/justfile
@@ -781,6 +781,23 @@ fixture-staleness:
     echo "Rebuild it (\`just build-test-fixtures\`); if the count keeps climbing,"
     echo "suspect the probe before trusting the verdict (issue 0445)."
 
+# issue 1127 / phase-433 W5 — which live-peer cells have EVER produced a verdict.
+# `just fixture-staleness` above answers "which coordinate is not running"; this
+# answers the same question one level up, over history rather than over one run:
+# a `Tier::Runtime` cell in `interop::CELLS` whose subject is a live ROS 2 peer
+# either has a dated result in `.config/interop-verdicts.toml` or has NEVER met
+# one — and a green sweep cannot tell you which, because `skip!` renders as
+# `<skipped>` and every consumer counts that as not-a-failure.
+#
+# Record one from a run (it refuses a junit in which the cell's binary only
+# skipped, which is the whole point):
+#
+#   python3 scripts/check-interop-verdicts.py --record <cell> \
+#       --junit target/nextest/default/junit.xml --where 'ros2 distrobox'
+[group("test")]
+interop-verdicts:
+    @python3 scripts/check-interop-verdicts.py --report
+
 # Regenerate the committed cbindgen headers (issue 0452). THE single writer:
 # `nros_generated.h`, `nros_cpp_ffi.h` and `zpico.h` are committed, and build
 # scripts only compare against them and warn. Run this after changing any
@@ -1374,6 +1391,13 @@ _test-summary junit="target/nextest/default/junit.xml":
             | sort | uniq -c | sort -rn | sed 's/^/  /'
     fi
     echo "Real failures: $real / $total total failures"
+    # issue 1127 — one line, and only when the run actually reached a live-peer
+    # binary. "Real failures: 0" is also what a sweep prints when every interop
+    # cell skipped, and a cell that has skipped since the day it was written is
+    # indistinguishable from a passing one. This says which it was, names any
+    # cell that produced a result nobody has recorded, and stays silent for a
+    # run with no interop binary in it. Never fails a lane.
+    python3 scripts/check-interop-verdicts.py --after-run "$junit" || true
 
 # Print the slowest nextest tests from junit.xml.
 [private]

--- a/scripts/check-interop-verdicts.py
+++ b/scripts/check-interop-verdicts.py
@@ -1,0 +1,881 @@
+#!/usr/bin/env python3
+"""A live-peer cell that has never produced a VERDICT — issue 1127, phase-433 W5.
+
+`nros_tests::interop::CELLS` declares the cells whose subject is a LIVE ROS 2
+peer. Phase-433 W4 closed "nothing can be AIMED at this cell"
+(`check-interop-cell-runners`). This closes the half that outlives it:
+
+    a `skip!` is not a verdict, and nothing distinguishes a cell that has
+    skipped on every host since the day it was written from one that passes.
+
+`_rewrite-skipped-junit` turns the skip into `<skipped>`, every consumer counts
+that as not-a-failure, and the lane is green. Six checks surround such a cell
+(`matrix_fixture_coverage.rs` G1-G5, plus W4's runner gate) and all six are
+statements about DECLARATIONS. This is issue 0445's absorbing-verdict class one
+level up: there a STALE fixture replaces the runtime's answer with a message
+that explains itself, and 0444 hid behind it for exactly that long; here a green
+tick does the same job. W1 measured what it costs — `graph_interop` had been
+green since it was written, and the first time it was aimed at a live peer,
+zenoh passed and Cyclone failed nine of twelve slots (issue 1137).
+
+WHAT IS RECORDED, AND WHY ABSENCE IS THE DEFAULT
+
+`.config/interop-verdicts.toml` holds one entry per cell that has actually
+produced a result: date, the case names, pass or fail, the command, where it
+ran, the observed output. **A cell with no entry has NEVER produced a verdict**,
+and that is the default on purpose. A new cell needs no ledger line and starts
+life honestly unproven; nothing can be satisfied by a cell that never runs,
+which is the property the mechanism has to have. It also keeps the file out of
+the merge queue's way: it holds only POSITIVE claims, written at most once per
+cell — 17 edits ever, not one per pull request, so it is not the committed
+generated file that serialised the queue in issues 0883/0884.
+
+THE LOAD-BEARING RULE: A BINDING TEST IS NOT EVIDENCE
+
+Every one of the eleven live-peer binaries also carries a test that calls
+`interop::assert_test_bound` and nothing else (`cases_bound_to_interop_cells`
+and its siblings). Those pass on any host, with no peer, forever. So "did this
+binary produce a non-skip result" is TRUE for all eleven on a machine with no
+ROS at all — which is why a junit-derived skip streak cannot work, and why an
+entry citing only such a case is REFUSED here. Letting one count as evidence
+would re-create, inside the mechanism, the exact defect it exists to catch.
+
+WHAT THIS CANNOT DO
+
+It cannot know that a hand-written entry is TRUE — only that it is well-formed,
+names a real Runtime cell, and cites cases that exist in that cell's declared
+test binary and are not binding-only. `--record` is the honest path: it writes
+an entry from a junit and refuses one in which the cell's binary only skipped.
+Nor does it know when a verdict goes stale; a cell verified today can break
+tomorrow, and only phase-433 W5's scheduled lane will say so. The age is
+reported in days rather than expired, because an expiry over cells that only a
+ROS-carrying lane can refresh would go red for every contributor and stay red
+(CLAUDE.md: a uniformly-red lane has no signal capacity).
+
+Usage::
+
+    check-interop-verdicts.py                      # the gate
+    check-interop-verdicts.py --report             # every cell, verdict or not
+    check-interop-verdicts.py --after-run [JUNIT]  # one line at a sweep's tail
+    check-interop-verdicts.py --record CELL --junit F --where TEXT [--issue N]
+    check-interop-verdicts.py --self-test          # the negative controls
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # python < 3.11
+    import tomli as tomllib  # type: ignore
+
+ROOT = Path(__file__).resolve().parent.parent
+LEDGER = ROOT / ".config" / "interop-verdicts.toml"
+TESTS_DIR = ROOT / "packages" / "testing" / "nros-tests" / "tests"
+DEFAULT_JUNIT = ROOT / "target" / "nextest" / "default" / "junit.xml"
+
+# The cell table has exactly one parser, in the sibling gate — the repo rule
+# (`row_coord()` in fixtures-manifest.py is the canonical statement of it: a
+# second derivation left 67 of 240 rows in no lane at all). Importing it also
+# means a shape change in `interop.rs` fails ONE parser loudly rather than
+# leaving this one quietly reading fewer rows.
+_spec = importlib.util.spec_from_file_location(
+    "_interop_cell_runners", ROOT / "scripts" / "check-interop-cell-runners.py"
+)
+_sib = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_sib)  # type: ignore[union-attr]
+
+REQUIRED = ("cell", "date", "verdict", "tests", "run", "where", "evidence")
+OPTIONAL = ("issue", "note")
+VERDICTS = ("pass", "fail")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+FN_RE = re.compile(r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+USE_RE = re.compile(r"^\s*use\s[^;]*;", re.M)
+ATTR_RE = re.compile(r"^\s*#!?\[[^\]]*\]", re.M)
+
+
+class LedgerError(Exception):
+    pass
+
+
+def _rel(p: Path) -> str:
+    """Repo-relative if it is inside the repo, else as given (`--ledger` demos)."""
+    try:
+        return str(p.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(p)
+
+
+# --- the cells -----------------------------------------------------------
+
+
+def runtime_cells() -> list[dict]:
+    """[{id, tier, test, line}] for every `Tier::Runtime` interop cell."""
+    cells = _sib.parse_cells(_sib.INTEROP_RS.read_text(encoding="utf-8"))
+    return [c for c in cells if c["tier"] == "Runtime"]
+
+
+def test_sources(cells: list[dict]) -> dict[str, str | None]:
+    """{test binary: source text or None if the file is gone}."""
+    out: dict[str, str | None] = {}
+    for c in cells:
+        test = c["test"]
+        if test is None or test in out:
+            continue
+        path = TESTS_DIR / f"{test}.rs"
+        out[test] = path.read_text(encoding="utf-8") if path.is_file() else None
+    return out
+
+
+# --- which cases can be EVIDENCE ----------------------------------------
+
+
+def fn_bodies(src: str) -> dict[str, str]:
+    """{fn name: its `{...}` body} for every function in a Rust source."""
+    cat = _sib.categorize(src)
+    out: dict[str, str] = {}
+    for m in FN_RE.finditer(src):
+        if cat[m.start()] != _sib.CODE:
+            continue
+        try:
+            close = _sib._match(src, cat, m.end() - 1, ")")
+        except ValueError:
+            continue
+        brace = src.find("{", close)
+        if brace < 0:
+            continue
+        # `fn f() -> T;` in a trait — a declaration, not a body.
+        if ";" in src[close + 1 : brace]:
+            continue
+        try:
+            end = _sib._match(src, cat, brace, "}")
+        except ValueError:
+            continue
+        out[m.group(1)] = src[brace : end + 1]
+    return out
+
+
+def is_binding_only(body: str) -> bool:
+    """Does this body do NOTHING but bind the test to `interop::CELLS`?
+
+    `cases_bound_to_interop_cells` (params, qos_override_e2e, and seven more) is
+    a `use` line and one `assert_test_bound(...)` call. It needs no fixture, no
+    peer and no ROS, so it PASSES on every host — which is exactly why it may
+    not be cited as evidence that a cell met a peer.
+
+    The test is "nothing else is here", not "no `skip!` is here": `graph_interop`
+    and `interop_e2e` call `assert_test_bound` INSIDE the real case, and reading
+    a keyword out of the body would drop the only cases those binaries have.
+    """
+    if "assert_test_bound" not in body:
+        return False
+    rest = "".join(
+        " " if k != _sib.CODE else ch for ch, k in zip(body, _sib.categorize(body))
+    )
+    rest = ATTR_RE.sub(" ", USE_RE.sub(" ", rest))
+    while True:
+        at = rest.find("assert_test_bound")
+        if at < 0:
+            break
+        # Take the whole path with it (`nros_tests::interop::assert_test_bound`),
+        # or the leading `interop::` is what is left over and every binding test
+        # reads as "does something else too".
+        while at and (rest[at - 1].isalnum() or rest[at - 1] in "_:"):
+            at -= 1
+        cat = _sib.categorize(rest)
+        paren = rest.find("(", at)
+        if paren < 0:
+            break
+        try:
+            close = _sib._match(rest, cat, paren, ")")
+        except ValueError:
+            break
+        semi = rest.find(";", close)
+        rest = rest[:at] + rest[(semi + 1 if semi >= 0 else close + 1) :]
+    return not rest.strip(" \t\r\n{}")
+
+
+def evidence_cases(src: str) -> tuple[set[str], set[str]]:
+    """(every fn, the binding-only ones) for one test source."""
+    bodies = fn_bodies(src)
+    return set(bodies), {n for n, b in bodies.items() if is_binding_only(b)}
+
+
+def base_case(name: str) -> str:
+    """`interop::case_3_zenoh_service` -> `interop`. rstest names its cases
+    under the parent fn, and only the parent appears in the source."""
+    return name.split("::", 1)[0].strip()
+
+
+# --- the ledger ----------------------------------------------------------
+
+
+def load_ledger(text: str) -> list[dict]:
+    try:
+        data = tomllib.loads(text)
+    except Exception as e:  # tomllib raises TOMLDecodeError
+        raise LedgerError(f"{LEDGER.name}: not valid TOML: {e}") from None
+    stray = sorted(k for k in data if k != "verdict")
+    if stray:
+        raise LedgerError(
+            f"{LEDGER.name}: top-level key(s) {', '.join(stray)} — every entry is "
+            f"a `[[verdict]]` table."
+        )
+    entries = data.get("verdict", [])
+    if not isinstance(entries, list):
+        raise LedgerError(f"{LEDGER.name}: `verdict` is not a `[[verdict]]` array.")
+    return entries
+
+
+def issue_status(num: str) -> tuple[bool, str | None]:
+    """(exists, status) for `docs/issues/NNNN-*.md` — mirrors quarantine.py."""
+    base = ROOT / "docs" / "issues"
+    for d in (base, base / "archived"):
+        if not d.is_dir():
+            continue
+        for p in d.iterdir():
+            if p.name.startswith(f"{num}-") and p.suffix == ".md":
+                head = p.read_text(encoding="utf-8", errors="replace")[:4000]
+                m = re.search(r"^status:\s*(\S+)", head, re.M)
+                return True, (m.group(1) if m else "?")
+    return False, None
+
+
+def evaluate(
+    cells: list[dict],
+    ledger_text: str,
+    sources: dict[str, str | None],
+    issue_lookup=issue_status,
+    today: datetime.date | None = None,
+) -> tuple[list[str], dict]:
+    """(problems, stats). The whole rule, over data the caller supplied."""
+    today = today or datetime.date.today()
+    problems: list[str] = []
+    if not cells:
+        problems.append(
+            "  no Runtime cells in interop::CELLS — refusing to report OK over an "
+            "empty set."
+        )
+    by_id = {c["id"]: c for c in cells}
+    entries = load_ledger(ledger_text)
+
+    seen: set[str] = set()
+    verified: dict[str, dict] = {}
+    for i, e in enumerate(entries):
+        cid = str(e.get("cell", "")).strip()
+        who = cid or f"<entry {i + 1}>"
+        unknown = sorted(set(e) - set(REQUIRED) - set(OPTIONAL))
+        if unknown:
+            problems.append(
+                f"  {who}: unknown field(s) {', '.join(unknown)}.\n"
+                f"      A misspelt field is a field that silently carries nothing —\n"
+                f"      the evidence would read as absent while looking present."
+            )
+        missing = [f for f in REQUIRED if not str(e.get(f, "")).strip()]
+        if missing:
+            problems.append(f"  {who}: missing or empty field(s): {', '.join(missing)}")
+            continue
+        if cid in seen:
+            problems.append(
+                f"  {who}: recorded twice. One entry per cell — the history is in "
+                f"git, not in duplicate rows."
+            )
+            continue
+        seen.add(cid)
+
+        cell = by_id.get(cid)
+        if cell is None:
+            problems.append(
+                f"  {who}: not a `Tier::Runtime` cell in interop::CELLS.\n"
+                f"      A verdict for a cell that no longer exists is a claim of\n"
+                f"      coverage nobody can act on, and the next cell to take that\n"
+                f"      id inherits it silently."
+            )
+            continue
+
+        if not DATE_RE.match(str(e["date"])):
+            problems.append(f"  {who}: `date` is not YYYY-MM-DD: {e['date']!r}")
+        else:
+            when = datetime.date.fromisoformat(str(e["date"]))
+            if when > today:
+                problems.append(
+                    f"  {who}: `date` {when} is in the future — a typo, or a run "
+                    f"that has not happened."
+                )
+
+        verdict = str(e["verdict"]).strip()
+        if verdict not in VERDICTS:
+            problems.append(
+                f"  {who}: `verdict` is {verdict!r}, not one of {'/'.join(VERDICTS)}."
+            )
+        elif verdict == "fail":
+            num = str(e.get("issue", "")).strip()
+            if not re.fullmatch(r"\d{3,4}", num):
+                problems.append(
+                    f"  {who}: verdict `fail` with no `issue = \"NNNN\"`.\n"
+                    f"      A failing cell is a FINDING, not a blocker (issue 1127\n"
+                    f"      Direction item 2) — but an unattributed one is debt\n"
+                    f"      nobody owns."
+                )
+            else:
+                exists, status = issue_lookup(num)
+                if not exists:
+                    problems.append(
+                        f"  {who}: issue {num} does not exist under docs/issues/."
+                    )
+                elif status != "open":
+                    problems.append(
+                        f"  {who}: issue {num} is `{status}`, not open. Re-run the "
+                        f"cell and record the new verdict, or reopen the issue."
+                    )
+
+        tests = e["tests"]
+        if not isinstance(tests, list) or not all(isinstance(t, str) for t in tests):
+            problems.append(f"  {who}: `tests` is not a list of case names.")
+            continue
+        src = sources.get(cell["test"])
+        if src is None:
+            problems.append(
+                f"  {who}: its cell names test binary `{cell['test']}`, and\n"
+                f"      packages/testing/nros-tests/tests/{cell['test']}.rs does not\n"
+                f"      exist — the evidence cites a binary nothing can run."
+            )
+            continue
+        known, binding = evidence_cases(src)
+        real = 0
+        for t in tests:
+            fn = base_case(t)
+            if fn not in known:
+                problems.append(
+                    f"  {who}: cites `{t}`, and `{cell['test']}.rs` has no `fn {fn}`.\n"
+                    f"      A renamed or deleted case leaves the entry INERT while it\n"
+                    f"      still reads as coverage (the issue-0743 class)."
+                )
+            elif fn in binding:
+                problems.append(
+                    f"  {who}: cites `{t}`, which is a BINDING test — its whole body\n"
+                    f"      is `interop::assert_test_bound(...)`. It passes on any\n"
+                    f"      host, with no peer, forever, so it is evidence of nothing.\n"
+                    f"      Cite the case that met the peer."
+                )
+            else:
+                real += 1
+        if real == 0:
+            problems.append(
+                f"  {who}: no cited case can be evidence — the entry records a "
+                f"verdict nothing produced."
+            )
+        else:
+            verified[cid] = e
+
+    return problems, {
+        "runtime": len(cells),
+        "verified": len(verified),
+        "passed": sum(1 for e in verified.values() if e["verdict"] == "pass"),
+        "failed": sum(1 for e in verified.values() if e["verdict"] == "fail"),
+        "never": len(cells) - len(verified),
+    }
+
+
+# --- the report ----------------------------------------------------------
+
+
+def report_lines(
+    cells: list[dict], entries: list[dict], runners: dict[str, list[str]], today
+) -> list[str]:
+    by_cell = {str(e.get("cell", "")): e for e in entries}
+    width = max((len(c["id"]) for c in cells), default=10)
+    out = [
+        "Live-peer interop cells — has a real ROS 2 peer ever answered?",
+        f"  {_rel(LEDGER)} — a cell with no entry has NEVER produced a",
+        "  verdict. That is the default, not an omission (issue 1127).",
+        "",
+    ]
+    for c in sorted(cells, key=lambda c: c["id"]):
+        e = by_cell.get(c["id"])
+        if e is None:
+            where = runners.get(c["test"])
+            hint = f"runner: {where[0]}" if where else "NO FOCUSED RUNNER"
+            out.append(
+                f"  NEVER  {'—':<16}  {c['id']:<{width}}  {c['test']}  ({hint})"
+            )
+            continue
+        when = str(e.get("date", "?"))
+        stamp = when
+        if DATE_RE.match(when):
+            stamp = f"{when} {(today - datetime.date.fromisoformat(when)).days}d ago"
+        tag = str(e.get("verdict", "?")).upper()
+        extra = f"  issue {e['issue']}" if e.get("issue") else ""
+        out.append(
+            f"  {tag:<5}  {stamp:<16}  {c['id']:<{width}}  {c['test']}{extra}"
+        )
+    n, tot = len(by_cell), len(cells)
+    out += [
+        "",
+        f"  {n} of {tot} Runtime cells have ever produced a verdict; {tot - n} have not.",
+    ]
+    return out
+
+
+# --- what a RUN saw ------------------------------------------------------
+
+
+def observed(junit: Path, cells: list[dict], sources: dict[str, str | None]) -> dict:
+    """{test binary: {"verdict": [...], "skipped": [...]}} for interop binaries.
+
+    A case that is binding-only is in NEITHER list: it passes with no peer on
+    every host, so counting it as a verdict is the defect this file exists to
+    catch, and counting it as a skip would be a lie in the other direction.
+    """
+    wanted = {c["test"] for c in cells}
+    out: dict[str, dict[str, list[str]]] = {}
+    try:
+        root = ET.parse(junit).getroot()
+    except (OSError, ET.ParseError):
+        return out
+    binding: dict[str, set[str]] = {}
+    for test, src in sources.items():
+        binding[test] = evidence_cases(src)[1] if src else set()
+    for case in root.iter("testcase"):
+        cls = (case.get("classname") or "").split("::")[-1]
+        if cls not in wanted:
+            continue
+        name = case.get("name") or "?"
+        if base_case(name) in binding.get(cls, set()):
+            continue
+        row = out.setdefault(cls, {"verdict": [], "skipped": []})
+        skipped = case.find("skipped") is not None
+        row["skipped" if skipped else "verdict"].append(name)
+    return out
+
+
+def after_run(junit: Path, cells: list[dict], sources, entries) -> list[str]:
+    """The one line a sweep's tail prints. Silent when no interop binary ran."""
+    seen = observed(junit, cells, sources)
+    if not seen:
+        return []
+    recorded = {str(e.get("cell", "")) for e in entries}
+    ran = [t for t, r in seen.items() if r["verdict"]]
+    dumb = [t for t, r in seen.items() if not r["verdict"]]
+    out = [
+        f"Live-peer interop: {len(recorded)}/{len(cells)} cells have ever produced a "
+        f"verdict. This run reached {len(seen)} of their binaries — {len(ran)} "
+        f"produced a result, {len(dumb)} skipped wholesale (`just interop-verdicts`)."
+    ]
+    fresh = sorted(
+        c["id"]
+        for c in cells
+        if c["id"] not in recorded and c["test"] in ran
+    )
+    if fresh:
+        out.append(
+            "  This run produced a result for cells with no recorded verdict: "
+            + ", ".join(fresh)
+        )
+        out.append(
+            "  Record it: python3 scripts/check-interop-verdicts.py --record "
+            f"{fresh[0]} --junit {junit} --where '<host>'"
+        )
+    return out
+
+
+# --- writing an entry ----------------------------------------------------
+
+
+def _toml_str(s: str) -> str:
+    return '"' + str(s).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def render(entries: list[dict], header: str) -> str:
+    out = [header.rstrip("\n"), ""]
+    for e in sorted(entries, key=lambda e: str(e.get("cell", ""))):
+        out.append("[[verdict]]")
+        for k in REQUIRED + OPTIONAL:
+            if k not in e:
+                continue
+            v = e[k]
+            if isinstance(v, list):
+                out.append(f"{k} = [{', '.join(_toml_str(x) for x in v)}]")
+            else:
+                out.append(f"{k} = {_toml_str(v)}")
+        out.append("")
+    return "\n".join(out).rstrip("\n") + "\n"
+
+
+def header_of(text: str) -> str:
+    at = text.find("[[verdict]]")
+    return text if at < 0 else text[:at]
+
+
+def record(args, cells, sources) -> int:
+    cell = next((c for c in cells if c["id"] == args.record), None)
+    if cell is None:
+        print(
+            f"check-interop-verdicts: `{args.record}` is not a Tier::Runtime cell in "
+            f"interop::CELLS.",
+            file=sys.stderr,
+        )
+        return 1
+    junit = Path(args.junit) if args.junit else DEFAULT_JUNIT
+    seen = observed(junit, [cell], sources).get(cell["test"])
+    if not seen:
+        print(
+            f"check-interop-verdicts: {junit} contains no case of `{cell['test']}` "
+            f"(binding tests excluded — they are evidence of nothing).",
+            file=sys.stderr,
+        )
+        return 1
+    if not seen["verdict"]:
+        print(
+            f"check-interop-verdicts: every case of `{cell['test']}` in {junit} "
+            f"SKIPPED — that is no verdict, and it is exactly the absence this "
+            f"ledger exists to make visible. Skipped: "
+            f"{', '.join(seen['skipped'])}",
+            file=sys.stderr,
+        )
+        return 1
+    failed = _failures(junit, cell["test"], seen["verdict"])
+    if failed and not args.issue:
+        # Refuse HERE rather than let the gate reject the file afterwards: a
+        # failing cell is a finding (issue 1127 Direction item 2), and the
+        # moment to attribute it is while the output is still on screen.
+        print(
+            f"check-interop-verdicts: {', '.join(sorted(failed))} FAILED — record it "
+            f"with --issue NNNN. Reserve one with `just issue-new <slug>`; a failing "
+            f"cell is a finding, not a blocker, but an unattributed one is debt "
+            f"nobody owns.",
+            file=sys.stderr,
+        )
+        return 1
+    entry = {
+        "cell": cell["id"],
+        "date": datetime.date.today().isoformat(),
+        "verdict": "fail" if failed else "pass",
+        "tests": sorted(seen["verdict"]),
+        "run": args.run or f"cargo nextest run -p nros-tests --test {cell['test']}",
+        "where": args.where,
+        "evidence": args.evidence
+        or (
+            f"{len(seen['verdict'])} case(s) produced a result in {junit.name}"
+            + (f"; FAILED: {', '.join(sorted(failed))}" if failed else "")
+        ),
+    }
+    if args.issue:
+        entry["issue"] = args.issue
+    text = LEDGER.read_text(encoding="utf-8") if LEDGER.exists() else ""
+    entries = [e for e in load_ledger(text) if e.get("cell") != cell["id"]]
+    entries.append(entry)
+    LEDGER.write_text(render(entries, header_of(text)), encoding="utf-8")
+    print(f"check-interop-verdicts: recorded `{cell['id']}` as {entry['verdict']}")
+    return 0
+
+
+def _failures(junit: Path, test: str, names: list[str]) -> set[str]:
+    out: set[str] = set()
+    try:
+        root = ET.parse(junit).getroot()
+    except (OSError, ET.ParseError):
+        return out
+    for case in root.iter("testcase"):
+        if (case.get("classname") or "").split("::")[-1] != test:
+            continue
+        if (case.get("name") or "") in names and (
+            case.find("failure") is not None or case.find("error") is not None
+        ):
+            out.add(case.get("name") or "?")
+    return out
+
+
+# --- negative controls ---------------------------------------------------
+
+_MINI_RS = '''
+pub const CELLS: &[InteropCell] = &[
+    ic("cell-alpha",
+       c(Linux, Rust, Zenoh, Pubsub, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), NanoToRos, "alpha_e2e"),
+    ic("cell-beta",
+       c(Linux, Rust, Zenoh, Service, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), BiDir, "beta_e2e"),
+];
+'''
+
+_ALPHA_RS = '''
+#[test]
+fn meets_a_peer() {
+    interop::assert_test_bound("alpha_e2e", &CELLS);
+    if !require_ros2() {
+        nros_tests::skip!("ROS 2 not available");
+    }
+    assert!(talks_to(&peer));
+}
+
+/// The binding test — passes on any host, forever.
+#[test]
+fn cases_bound_to_interop_cells() {
+    #[allow(unused_imports)]
+    use nros_tests::matrix::{Lang::*, PlatformId::*};
+    nros_tests::interop::assert_test_bound("alpha_e2e", &[(Linux, Rust, Zenoh, Pubsub)]);
+}
+'''
+
+_BETA_RS = '''
+#[test]
+fn cases_bound_to_interop_cells() {
+    nros_tests::interop::assert_test_bound("beta_e2e", &[(Linux, Rust, Zenoh, Service)]);
+}
+'''
+
+
+def _junit(rows: list[tuple[str, str, str]]) -> str:
+    """rows of (binary, case, outcome in pass/fail/skip)."""
+    body = []
+    for binary, name, outcome in rows:
+        inner = {
+            "pass": "",
+            "fail": "<failure message='boom'>boom</failure>",
+            "skip": "<skipped type='nros:capability' message='[SKIPPED] no ROS'/>",
+        }[outcome]
+        body.append(
+            f"<testcase classname='nros-tests::{binary}' name='{name}'>{inner}</testcase>"
+        )
+    return "<testsuites><testsuite name='s'>" + "".join(body) + "</testsuite></testsuites>"
+
+
+_OK_LEDGER = """
+[[verdict]]
+cell = "cell-alpha"
+date = "2026-09-06"
+verdict = "pass"
+tests = ["meets_a_peer"]
+run = "cargo nextest run -p nros-tests --test alpha_e2e"
+where = "ros2 distrobox"
+evidence = "PASS [18.7s] alpha_e2e meets_a_peer"
+"""
+
+
+def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
+    """Both directions, on synthetic input, on the normal path.
+
+    `check-gate-selftests` requires the call here rather than behind a flag: a
+    negative control nobody runs decays into a comment.
+    """
+    cells = [c for c in _sib.parse_cells(_MINI_RS) if c["tier"] == "Runtime"]
+    assert [c["id"] for c in cells] == ["cell-alpha", "cell-beta"], cells
+    src = {"alpha_e2e": _ALPHA_RS, "beta_e2e": _BETA_RS}
+    today = datetime.date(2026, 9, 6)
+    issues = {"1137": (True, "open"), "0001": (True, "resolved")}
+    look = lambda n: issues.get(n, (False, None))  # noqa: E731
+
+    # The binding-only classifier, both directions — the load-bearing rule.
+    known, binding = evidence_cases(_ALPHA_RS)
+    assert known == {"meets_a_peer", "cases_bound_to_interop_cells"}, known
+    assert binding == {"cases_bound_to_interop_cells"}, (
+        f"selftest: binding-only classifier is wrong: {binding}"
+    )
+    assert "meets_a_peer" not in binding, (
+        "selftest: a real case that ALSO binds its coordinate was classified as "
+        "binding-only — that is graph_interop's and interop_e2e's shape"
+    )
+
+    problems, stats = evaluate(cells, _OK_LEDGER, src, look, today)
+    assert problems == [], f"selftest: rejected a well-formed ledger: {problems}"
+    assert stats == {"runtime": 2, "verified": 1, "passed": 1, "failed": 0,
+                     "never": 1}, stats
+
+    def bad(text, want, why):
+        got = evaluate(cells, text, src, look, today)[0]
+        assert any(want in p for p in got), f"selftest: {why} (got {got})"
+
+    bad(
+        _OK_LEDGER.replace('tests = ["meets_a_peer"]',
+                           'tests = ["cases_bound_to_interop_cells"]'),
+        "BINDING test",
+        "a binding-only case was accepted as evidence",
+    )
+    bad(
+        _OK_LEDGER.replace('tests = ["meets_a_peer"]', 'tests = ["gone_away"]'),
+        "no `fn gone_away`",
+        "a case that no longer exists was accepted",
+    )
+    bad(
+        _OK_LEDGER.replace('cell = "cell-alpha"', 'cell = "cell-ghost"'),
+        "not a `Tier::Runtime` cell",
+        "a verdict for a cell that does not exist was accepted",
+    )
+    bad(
+        _OK_LEDGER.replace('verdict = "pass"', 'verdict = "fail"'),
+        "no `issue",
+        "an unattributed failing verdict was accepted",
+    )
+    bad(
+        _OK_LEDGER.replace('verdict = "pass"', 'verdict = "fail"\nissue = "0001"'),
+        "is `resolved`, not open",
+        "a failing verdict pointing at a closed issue was accepted",
+    )
+    bad(
+        _OK_LEDGER.replace('date = "2026-09-06"', 'date = "2099-01-01"'),
+        "in the future",
+        "a future date was accepted",
+    )
+    bad(
+        _OK_LEDGER.replace("where =", "wehre ="),
+        "unknown field",
+        "a misspelt field was accepted",
+    )
+    bad(_OK_LEDGER + _OK_LEDGER, "recorded twice", "a duplicate entry was accepted")
+    bad(_OK_LEDGER.replace('evidence = "PASS [18.7s] alpha_e2e meets_a_peer"', ""),
+        "missing or empty", "an entry with no evidence was accepted")
+    assert any("empty set" in p for p in evaluate([], "", src, look, today)[0]), (
+        "selftest: reported OK over zero Runtime cells"
+    )
+    for text, want in (
+        ("not = [toml", "not valid TOML"),
+        ('[[verdit]]\ncell = "x"\n', "top-level key"),
+    ):
+        try:
+            evaluate(cells, text, src, look, today)
+        except LedgerError as e:
+            assert want in str(e), f"selftest: wrong error for {want!r}: {e}"
+        else:
+            raise AssertionError(f"selftest: accepted a malformed ledger ({want})")
+
+    # --- what a run saw, on synthetic junit -----------------------------
+    # A TemporaryDirectory, not mkdtemp: this runs on the normal path of every
+    # invocation, `_test-summary` calls it at the tail of every sweep, and a
+    # leaked directory per test run is a slow mess nobody would attribute here.
+    with tempfile.TemporaryDirectory(prefix="nros-interop-verdicts-") as td:
+        _self_test_junit(Path(td) if tmp is None else tmp, cells, src)
+    if verbose:
+        print("check-interop-verdicts: self-test OK")
+
+
+def _self_test_junit(tmp: Path, cells: list[dict], src: dict[str, str | None]) -> None:
+    """The junit half of the negative controls — one temp dir, cleaned up."""
+    only_skips = tmp / "skips.xml"
+    only_skips.write_text(
+        _junit([("alpha_e2e", "meets_a_peer", "skip"),
+                ("alpha_e2e", "cases_bound_to_interop_cells", "pass")])
+    )
+    seen = observed(only_skips, cells, src)
+    assert seen["alpha_e2e"]["verdict"] == [], (
+        "selftest: a binding test was counted as a verdict — the whole defect"
+    )
+    assert seen["alpha_e2e"]["skipped"] == ["meets_a_peer"], seen
+    assert after_run(only_skips, cells, src, load_ledger(_OK_LEDGER)), (
+        "selftest: a wholly-skipped interop binary printed nothing"
+    )
+
+    real = tmp / "real.xml"
+    real.write_text(_junit([("beta_e2e", "delivers", "pass"),
+                            ("beta_e2e", "cases_bound_to_interop_cells", "pass")]))
+    src2 = dict(src, beta_e2e=_BETA_RS + "\n#[test]\nfn delivers() { assert!(x); }\n")
+    seen = observed(real, cells, src2)
+    assert seen["beta_e2e"]["verdict"] == ["delivers"], seen
+    lines = after_run(real, cells, src2, load_ledger(_OK_LEDGER))
+    assert any("cell-beta" in ln for ln in lines), (
+        f"selftest: a cell that produced a verdict with no record was not named: {lines}"
+    )
+
+    assert observed(tmp / "nope.xml", cells, src) == {}, (
+        "selftest: invented results from a junit that does not exist"
+    )
+
+
+# --- entry point ---------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--report", action="store_true")
+    ap.add_argument("--after-run", nargs="?", const=str(DEFAULT_JUNIT), default=None)
+    ap.add_argument("--record", metavar="CELL")
+    ap.add_argument("--junit")
+    ap.add_argument("--where", default="")
+    ap.add_argument("--run", default="")
+    ap.add_argument("--evidence", default="")
+    ap.add_argument("--issue", default="")
+    ap.add_argument("--ledger", default=None, help="override (self-test / demos)")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        self_test(verbose=True)
+        return 0
+    # Always, not behind a flag: a negative control nobody runs is a comment.
+    self_test()
+
+    global LEDGER
+    if args.ledger:
+        LEDGER = Path(args.ledger).resolve()
+
+    try:
+        cells = runtime_cells()
+    except _sib.ParseError as e:
+        print(f"check-interop-verdicts: {e}", file=sys.stderr)
+        return 1
+    sources = test_sources(cells)
+    text = LEDGER.read_text(encoding="utf-8") if LEDGER.exists() else ""
+    today = datetime.date.today()
+
+    if args.record:
+        if not args.where:
+            print(
+                "check-interop-verdicts: --record needs --where (which host, which "
+                "box, which lane produced this). A verdict with no provenance is "
+                "the claim, not the evidence.",
+                file=sys.stderr,
+            )
+            return 1
+        return record(args, cells, sources)
+
+    if args.after_run is not None:
+        try:
+            entries = load_ledger(text)
+        except LedgerError:
+            entries = []
+        for line in after_run(Path(args.after_run), cells, sources, entries):
+            print(line)
+        return 0
+
+    if args.report:
+        try:
+            entries = load_ledger(text)
+        except LedgerError as e:
+            print(f"check-interop-verdicts: {e}", file=sys.stderr)
+            return 1
+        print("\n".join(report_lines(cells, entries, _sib.runners(), today)))
+        return 0
+
+    try:
+        problems, stats = evaluate(cells, text, sources, issue_status, today)
+    except LedgerError as e:
+        print(f"check-interop-verdicts: {e}", file=sys.stderr)
+        return 1
+    if problems:
+        print("check-interop-verdicts: the live-peer verdict ledger is wrong\n")
+        print("\n\n".join(problems))
+        print(
+            f"\n{_rel(LEDGER)} records that a cell HAS met a peer. A cell "
+            f"with no entry has never produced a verdict, which is the default and "
+            f"needs no line."
+        )
+        return 1
+    print(
+        f"check-interop-verdicts OK — {stats['verified']}/{stats['runtime']} Runtime "
+        f"interop cells have ever produced a verdict against a live peer "
+        f"({stats['passed']} pass, {stats['failed']} fail, {stats['never']} NEVER RUN; "
+        f"`just interop-verdicts`)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Issue 1127's Direction item 5 — the durable half, and the only one of the five
that stops the class recurring. Phase-433 W5.a.

## The problem

W4 (`check-interop-cell-runners`) closed "nothing can be AIMED at this cell".
This closes the half that outlives it. A `skip!` is not a verdict:
`_rewrite-skipped-junit` renders it `<skipped>`, every consumer counts that as
not-a-failure, and **a cell that has skipped on every host since the day it was
written is indistinguishable from one that passes.** Six checks surround such a
cell — `matrix_fixture_coverage.rs` G1–G5 plus W4's runner gate — and all six
are statements about DECLARATIONS. Issue 0445's absorbing-verdict class one
level up: there a STALE fixture replaces the runtime's answer with a message
that explains itself; here a green tick does the same job.

W1 measured the cost: `graph_interop` had been green since it was written, and
the first time it was aimed at a live peer, zenoh passed and Cyclone failed
nine of twelve slots (issue 1137). The cell's own comment had predicted it.

## The mechanism

`.config/interop-verdicts.toml` records what a peer has actually ANSWERED —
date, cases, verdict, command, where, observed output. **Absence of an entry
means NEVER RUN**, and that is the default. Seeded with W1's two real verdicts,
so the tree now says **2 of 17** instead of implying seventeen.

| | |
| --- | --- |
| `just check interop-verdict-ledger` | the gate — fast lane, buildless, needs no ROS |
| `just interop-verdicts` | every Runtime cell: PASS/FAIL + age, or NEVER + its runner |
| `_test-summary` | one line at the tail of every sweep |
| `--record CELL --junit F` | writes an entry FROM a run; refuses one that only skipped |

**The load-bearing rule — a binding test is not evidence.** Ten of the eleven
live-peer binaries carry `cases_bound_to_interop_cells`: body is
`interop::assert_test_bound(...)` and nothing else, so it passes on any host,
with no peer, forever. "Did this binary produce a non-skip result" is therefore
TRUE for all of them on a machine with no ROS at all. An entry citing one is
refused; `--record` and `--after-run` exclude them when reading junit. Measured
across the eleven: exactly one such test in ten of them, none in
`graph_interop`, whose binding call sits inside the real cases.

## The three constraints

* **Not satisfiable by a cell that never runs.** The default is "never", not
  "fine"; a `fail` verdict must name an OPEN issue; and `--record` refuses a
  junit in which every case of the cell's binary skipped — *"that is no
  verdict, and it is exactly the absence this ledger exists to make visible."*
* **Not uniformly red.** The gate checks the ledger's INTEGRITY, never a host's
  capability, so it is green on a laptop with no ROS. Age is reported in days,
  never expired — an expiry over cells only a ROS-carrying lane can refresh
  would go red for everyone and stay red.
* **Not a merge-queue serialiser (0883/0884).** The file holds only POSITIVE
  claims, written at most once per cell: 17 edits ever, not one per pull
  request. There is no shared generated line for a PR to touch.

## Rejected, with reasons

Written up in phase-433 W5.a:

* **A CI-updated generated per-cell record** — 0883/0884 exactly; a merge
  driver cannot fix it, GitHub rebases queue entries server-side.
* **Extending `check-skip-budget` (0584)** — right neighbour, wrong shape. Its
  assertions are deliberately derived from ONE run with no declaration file, so
  it cannot express "has never happened on any host". 0584 named this gap
  itself and could not close it.
* **Deriving the streak from junit alone** — unsound at the granularity that
  matters, because of the binding-test confound above.
* **A count ratchet** — one shared integer edited by every cell-adding PR.
* **A gate that fails while a cell is unverified**, and **a hard expiry on a
  verified entry** — both uniformly red, both teach people to ignore the lane.

## Verification

* `--self-test` runs on the normal path: both directions of the binding-only
  classifier, plus eleven negative controls (stale cell id, missing case,
  binding-only case cited as evidence, unattributed `fail`, closed issue,
  future date, misspelt field, duplicate entry, empty evidence, zero cells,
  malformed TOML).
* Gate proved RED on the real ledger for four mutations (unknown cell id,
  renamed case, binding-only case, resolved issue), then reverted.
* **Both directions demonstrated on synthetic junit**, on a host with no ROS:
  a wholly-skipped `qos_override_e2e` prints `0 produced a result, 1 skipped
  wholesale` and `--record` refuses it; the same binary with its live-peer case
  actually run prints `1 produced a result` and names the cell for recording.
  The two runs previously printed the same `Real failures: 0`.
* `just check fast` green (240 gates ran, 8 skipped for host prerequisites);
  `check-gate-lists`, `check-gate-selftests`, `check-gate-visibility`,
  `check-default-gates-run-somewhere`, `check-lane-contracts` and
  `check-doc-recipe-refs` all green.

## What it does not do

It cannot know a hand-written entry is TRUE — only that it is well-formed,
names a real cell and cites real non-binding cases. It cannot see an entry
DELETED (review's job; a ratchet there would be the shared committed line this
design avoids). And it does not know when a recorded verdict goes stale — that
is what W5's scheduled lane is for. Items 2 and 3 of issue 1127 stay open; the
ledger is where W2's verdicts land, instead of a prose table nothing can check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA
