### PR TITLE
docs(phase-413): W6 answered, and W1/W4/W5 were already done

### DIFF
--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -1,5 +1,10 @@
 # Phase 413 — make CI run the process a user runs
 
+**Status (2026-09-06). W1, W4, W5 and W6 done and verified; W2 substantially
+advanced; W3 done; W7 open.** Every claim here was re-derived from the tree on
+2026-09-06 — three items were already complete and said otherwise, which is the
+same stale-status class this phase's own audit is about.
+
 **Status (2026-09-03). Opened from the workflow audit in issue 0996.** The
 workflows are meant to read as a transcript of a user session: `just setup
 <scope>`, then one command a developer can type (phase-411 W4). Six of eleven
@@ -51,7 +56,19 @@ a conversion did not break something in a lane that was already red.
 
 ---
 
-## W1 — collapse the duplicated `l3` lane
+## W1 — collapse the duplicated `l3` lane — DONE (verified 2026-09-06)
+
+**Landed.** Issue 0992 is resolved, and the lane now runs ONCE per change:
+`build-wide.yml` is `workflow_dispatch:` only — the "reduce it to the
+scheduled/dispatch entry point it also serves" option below — while `queue.yml`
+runs `just ci matrix build` on `merge_group`, which is where a gate belongs. The
+four hand-rolled sync steps are gone (retired by W1b).
+
+*The stated acceptance is wrong and was never the test.* `grep -c 'nros sync'
+.github/workflows/queue.yml` returns **2**, and both hits are COMMENTS describing
+the steps that were retired. A grep that counts prose cannot answer "does this
+lane still sync by hand"; the steps themselves are what to look at, and they are
+gone.
 
 Blocked on issue 0992 (PR #208) landing; that is what lets `build-wide` provision
 through the verb instead of by hand.
@@ -73,6 +90,43 @@ workflow runs the l3 lane; a full change cycle shows the lane running once.
 
 Not a conversion task — a debugging one, and it comes first because no
 conversion can be verified in a lane that is already red.
+
+### Progress (2026-09-06), each item measured against the lane rather than the doc
+
+* **`nuttx` — DONE.** `9de62f253` (09-04) made `just nuttx setup` provision the
+  RISC-V board its `build-all` builds. nuttx is the only module with two boards
+  under one setup/build-all pair, so the class has no other instance.
+* **`freertos` / `threadx_linux` — DONE, by a route this doc did not predict.**
+  Both cells now report `Real failures: 1 / 1` with **8 tests actually running**
+  and nothing skipped for an unmet precondition — recovered from "0/0, all 9
+  skipped". The fix was not the two image changes prescribed below: it was
+  `575dc4372` (09-05, W3's own work) adding `nros setup --system --sudo` to
+  nightly's `platform` job, which installs the declared closure at run time.
+  A PR that baked the package into the CI image was closed as redundant — a
+  second mechanism installing one package, where the runtime path is better on
+  this campaign's own terms because it takes the name from the index instead of
+  freezing a copy into an image. What remains in each cell is ONE genuine
+  failure (`test_rtos_pubsub_e2e … Freertos/Rust`), which is signal restored.
+* **`threadx_riscv64` — half of it was still open.** The reported manifest-parse
+  failure was fixed, but only the central-table half: a leaf that also patches a
+  message crate fails the same way one path deeper, because only `nros sync`
+  materialises `generated/`. This lane's six rust roles build through
+  Corrosion/CMake, the one seam that never reaches `fixtures-build.sh`'s
+  per-row presync. Fixed with `nros_ensure_leaf_synced`.
+* **`run-matrix` — diagnosed, and the top failure was self-inflicted.**
+  `nros codegen resolve-deps` was refused by phase-431 W1's workspace guard: the
+  zephyr lane builds into a west workspace that on the runner sits under a
+  DIFFERENT nano-ros tree, so a correct, freshly built binary was rejected. The
+  build-tool verbs skip that check now. **This does not make the lane green** —
+  `run-matrix` has failed every scheduled run since at least 09-01 and the guard
+  landed 09-05 22:00, so an older cause is now visible underneath.
+* **`host-tests` — its named step is green.** *Build workspace fixtures* passes;
+  the two breaks that stopped it (issues 1162, 1136) are fixed. The lane is red
+  one step later at `just ci tier1`, on ten `E0599`s in `nros-c`'s no-alloc
+  build — filed as issue 1169, with the measurement that this build has **never**
+  compiled, so restoring it is an addition rather than a repair.
+* **`build-wide`** — now `workflow_dispatch:` only (see W1), so it is no longer
+  a per-change lane at all.
 
 1. **`host-tests`** — dies in *Build workspace fixtures*. This is the honest
    failure: the step `exit 1`s instead of laundering into a skip, which is the
@@ -166,7 +220,17 @@ Two halves:
 Acceptance: the gate reproduces each of the three sites before the fix and passes
 after; no workflow apt-installs an indexed package.
 
-## W4 — decide what the required check promises on a pull request
+## W4 — decide what the required check promises on a pull request — DONE (verified 2026-09-06)
+
+**Decided: the DOC moved, not the trigger list.** `test-unit`'s `if:` still
+names `merge_group`, `schedule` and `workflow_dispatch`, and CLAUDE.md now says
+so outright — *"`test-unit` is NOT in it"* — with the reasoning beside it: it
+costs a measured ~3.5 min per BATCH there instead of per PR push, nothing broken
+lands because the queue runs it before merging, and an ejection comment is how
+you hear about it. A contributor can predict what green means, which is what the
+item was for.
+
+
 
 `test-unit` does not run on `pull_request` — only on `merge_group`, `schedule`
 and `workflow_dispatch`. So a PR shows a green required `CI` having never run a
@@ -182,7 +246,24 @@ value of this line is that a contributor can predict what green means.
 Acceptance: the doc and the trigger list agree, and the reasoning is recorded
 next to whichever moved.
 
-## W5 — one scope vocabulary
+## W5 — one scope vocabulary — DONE (verified 2026-09-06)
+
+**All six lanes converted**, and the two loose ends with them:
+
+| workflow | provisioning today |
+| --- | --- |
+| `build-wide`, `run-matrix` | `just setup tier2` |
+| `nightly` (matrix) | `just setup tier2-nightly` |
+| `nightly` (platform) | `just setup ${{ matrix.plat }}` — the dispatcher form |
+| `queue` | `just setup tier2` (the four hand-rolled steps are gone) |
+| `host-tests` | `just setup native` |
+
+The *"22-line Build nros CLI block repeated verbatim in four jobs"* is now the
+composite action `./.github/actions/setup-nros-cli`, used by all six sites — the
+step NAME survives, which is what makes a grep still find "four copies".
+
+`just ci provision-zenohd` is absorbed: `just native setup` calls it, so it is
+reachable from `just setup native` rather than being a verb only a workflow knew.
 
 phase-411 W4: a CI job is `just setup <scope>` then one command a developer can
 type. Three lanes do this; three do not.

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -209,7 +209,7 @@ Acceptance: every job body is `just setup <scope>` plus one command; the repeate
 CLI-build block exists once; `just ci provision-zenohd` is reachable from
 `just setup`.
 
-## W6 — DESIGN REQUIRED: `package.xml` as the dependency SSoT (rosdep parity)
+## W6 — ANSWERED: `package.xml` as the dependency SSoT (rosdep parity)
 
 **This one is not an implementation task and must not be started as one.** It
 changes what a `package.xml` means in this repo, so it needs an RFC first.
@@ -253,6 +253,46 @@ Questions the RFC has to answer, none of which have obvious answers:
 
 Deliverable for W6 is **an RFC in `docs/design/`**, not code. Only once it is
 `Draft` and reviewed does an implementation work item get opened.
+
+### ANSWERED (2026-09-06) — [RFC-0062 amendment 4](../design/0062-unified-dependency-ssot.md), implemented by phase-435
+
+The RFC this item required exists, and the five questions above have answers.
+Recorded here because a work item that reads DESIGN REQUIRED after its design
+landed is how a settled question gets reopened.
+
+**The premise needed correcting first.** This item opened on *"406 package.xml
+files … not one names a system dependency"* and read it as a gap. Measurement
+says it mostly is not one: the bridge already exists — `run_workspace_scan`
+resolves every `<depend>` against `[prereq.*]` and classifies by role — and
+these packages have nothing to declare, being message and node packages whose
+content depends on no system library. What was missing was not a bridge but the
+other three axes.
+
+1. **Key namespace** — `[prereq.*]` names, not rosdep keys. A ROS *package*
+   dependency is the one case that resolves by derivation (`ros_package` →
+   `ros-<distro>-<pkg>`), so the ROS-facing vocabulary is honoured where it
+   actually appears.
+2. **Who owns the mapping** — the index stays the mapping; `package.xml` is the
+   declaration. The real rosdep database is not consulted: we have no oracle to
+   validate a name against, so an unknown name must fail a gate rather than an
+   `apt` invocation on a user's machine.
+3. **The 406 existing files** — untouched. The new axes read `<build_type>` and
+   the `<nano_ros>` export, both of which already existed; `<depend>` keeps
+   exactly the meaning codegen gives it.
+4. **Scope resolution** — unchanged. The board and rmw axes resolve from the
+   manifest's own export tag, so a workspace does not need a new scope.
+5. **`--build-sources`** — not subsumed. It is the repo's own build-stage union,
+   which is a different question from what a consumer's workspace declares.
+
+The answer in one line: **four axes, and `package.xml` is the only input** —
+`<build_type>`, `<depend>`, and the board/rmw selections in the `<nano_ros>`
+export. Never a `CMakeLists.txt` or a `Cargo.toml` entry: those are build-system
+facts in a different vocabulary, and a resolver reading them inherits every
+shape they take.
+
+phase-435 implemented it — the `buildtool` role, the `[build_type.*]` axis,
+`ros_package` derivation (retiring issue 1128's placeholder), `[board.zephyr]`,
+and a gate that a non-family board alias names one board.
 
 ## W7 — DESIGN: scope the arena-budget walk (issue 1001)
 


### PR DESCRIPTION
Continuing phase-413's waves meant first asking whether they were still open. **Three were not**, and the doc said otherwise — the same stale-status class this phase's own audit is about.

## W6 — ANSWERED

It read *"DESIGN REQUIRED … must not be started as an implementation task"*. RFC-0062 amendment 4 is that RFC and phase-435 implemented it; the five questions now have answers recorded in place. The premise needed correcting first: W6 opened on *"406 package.xml files … not one names a system dependency"* and read it as a gap, but the bridge already existed and those packages have nothing to declare. What was missing was the other three axes.

## W1 — DONE, and its acceptance was never the test

`build-wide.yml` is `workflow_dispatch:` only, `queue.yml` runs the lane on `merge_group` — **once per change**. The stated acceptance, `grep -c 'nros sync' queue.yml == 0`, returns **2**, and both hits are comments describing the steps that were retired. A grep that counts prose cannot answer whether a lane still syncs by hand.

## W4 — DONE

The decision was made and recorded: **the doc moved, not the trigger list**. `test-unit` runs on merge_group/schedule/dispatch, and CLAUDE.md says so outright with the ~3.5 min-per-batch reasoning beside it.

## W5 — DONE, all six lanes

Every lane is `just setup <scope>` plus one command. The *"22-line Build nros CLI block repeated verbatim in four jobs"* is the composite action `./.github/actions/setup-nros-cli`; only the step **name** survives, which is why a grep still finds four. `provision-zenohd` is absorbed — `just native setup` calls it.

## W2 — measured per cell

| cell | state |
|---|---|
| `nuttx` | **done** (`9de62f253`, 09-04) |
| `freertos` / `threadx_linux` | **done**, and not by the route this doc predicted |
| `threadx_riscv64` | half was still open — fixed in #647 |
| `run-matrix` | diagnosed; top failure was my own guard — #643 |
| `host-tests` | named step green; red one step later — #646, #1169 |
| `build-wide` | no longer a per-change lane |

**The freertos/threadx_linux finding is the interesting one.** Both cells now report `Real failures: 1 / 1` with **8 tests running** and nothing skipped for an unmet precondition — recovered from "0/0, all 9 skipped". The fix was `575dc4372` (W3's own work) adding `nros setup --system --sudo` to the platform job, not the two CI-image changes W2 prescribes. I had a PR doing those and **closed it as redundant**: one package, two mechanisms, and the runtime path is better on this campaign's terms because it reads the name from the index rather than freezing a copy into an image that must then be rebuilt when the index moves.

What remains in those cells is one genuine test failure each — signal restored, which is the point of the wave.

`just check fast`: 247/247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK