### PR TITLE
feat(phase-432 W2.5a): the message-side template context becomes the IR

### DIFF
--- a/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
+++ b/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
@@ -343,6 +343,39 @@ and there are FOUR such views of one field — `RmwField`, `IdiomaticField`,
 fact, several authored spellings" this RFC exists to remove, one layer above
 where it was found.
 
+### Corrections from implementing W2.5a
+
+The two findings held; three details did not, and each changed the work.
+
+**The count is SIX views across FIVE surfaces, not four.** The `cpp` pack
+builds a PAIR — `CppField` for the header and `CppFfiField` for the `repr(C)`
+Rust glue — and both re-derived from the parser exactly like the other four.
+That pair is also the one the §5 memory-agreement gate exists for, so it was
+the surface least safe to leave out.
+
+**Two of the four were HALF migrated, and that mattered.** `NrosField` and
+`CField` already received the storage decision as a `FieldStorage`
+(phase-335 W1.c) and re-derived only the other fifteen facts. The
+half-migration had a shape worth naming: a `pre_storage: Option<FieldStorage>`
+parameter whose `None` meant "resolve it yourself again". An `Option` like that
+IS the second answer, kept alive as a parameter.
+
+**`align` and `plain` are NOT dropped facts.** The first finding lists four —
+`shape`, `cdr_op`, `align`, `plain` — and only the first two were wanted by a
+surface. `align` and `plain` are per-field inputs to `LoweredType::plain`,
+consumed inside `lower()`; W1.1's `NESTED_ALIGN_STANDIN` comment already says
+`align` exists only to answer plainness. They stay unread per-field on purpose,
+and the struct now says so.
+
+One thing the wave found that §6b does not mention: `element_cap` (phase-403
+W7) was folded into the field type by each storage surface separately, and
+folding it in the IR would have been wrong. It narrows STORAGE and leaves CDR
+alone, so the ROS-ABI mirror (`rmw`) must keep spelling the `.msg` type while
+`c`/`nros`/`cpp` spell the folded one. It is carried as a fact
+(`LoweredField::element_cap`) with one derivation (`storage_type()`) — two
+questions with two answers, which is not the same as one fact with two
+spellings.
+
 ### The filters are already the right shape
 
 `c_type` takes a `CTypeSpell` and returns a spelling. That IS the

--- a/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
+++ b/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
@@ -167,6 +167,23 @@ to remove.
   Do it surface by surface with the message goldens as the guard, not in one
   commit.
 
+  **LANDED.** Six commits, one per surface plus a guard and an IR-prep, every
+  golden byte-identical at each. Three corrections to the measurement, all
+  written into RFC-0091 §6b ("Corrections from implementing W2.5a"): it is SIX
+  views across FIVE surfaces (the `cpp` pack builds a header/`repr(C)` PAIR),
+  two of the four were already half-migrated behind a `pre_storage:
+  Option<FieldStorage>` back-door, and `align`/`plain` are not dropped facts —
+  they answer `LoweredType::plain` inside `lower()`.
+
+  One thing the item did not anticipate: **the goldens could not guard two of
+  the five surfaces.** `emit_corpus()` covers `nros`, `c` and `cpp` and renders
+  no `rmw` or idiomatic bytes at all, so a golden had to be recorded first
+  (`tests/rust_surface_golden.rs`, deliberately outside `emit_corpus` so it does
+  not move the fixture-staleness fingerprint for two surfaces with no production
+  caller). Deleted on the way through: `lowered_storages`,
+  `primitive_to_cdr_method`, `c_cdr_write_method`, `c_cdr_read_method` — the
+  duplicate derivations gone rather than bypassed.
+
 - **W2.5b — a language contributes a FILTER SET.** Nine of the ten registered
   filters are per-language type spellings (`c_type`, `rust_type_rmw`,
   `cpp_repr_c_type`, `nros_type`, …) and they are already the RIGHT shape — a

--- a/packages/cli/rosidl-codegen/src/generator/action.rs
+++ b/packages/cli/rosidl-codegen/src/generator/action.rs
@@ -1,6 +1,6 @@
 use super::common::{
     GeneratorError, PayloadLang, SchemaCaps, build_action_envelope_schemas, build_c_fields,
-    build_nros_fields, build_nros_schema_for_struct, build_rmw_fields, determine_field_kind,
+    build_idiomatic_fields, build_nros_fields, build_nros_schema_for_struct, build_rmw_fields,
     ensure_supported_storage_for_payload,
 };
 use crate::{
@@ -8,11 +8,11 @@ use crate::{
     templates::{
         ActionCHeaderTemplate, ActionCSourceTemplate, ActionIdiomaticTemplate, ActionNrosTemplate,
         ActionRmwTemplate, BuildRsTemplate, CConstant, CargoNrosTomlTemplate, CargoTomlTemplate,
-        IdiomaticField, LibNrosRsTemplate, LibRsTemplate, MessageConstant,
+        LibNrosRsTemplate, LibRsTemplate, MessageConstant,
     },
     types::{
-        NrosCodegenMode, c_type_for_constant, constant_value_to_rust, escape_keyword,
-        nros_type_for_constant, rust_type_for_constant, to_c_package_name,
+        NrosCodegenMode, c_type_for_constant, constant_value_to_rust, nros_type_for_constant,
+        rust_type_for_constant, to_c_package_name,
     },
     utils::{extract_dependencies, needs_big_array, to_snake_case},
 };
@@ -84,22 +84,8 @@ pub fn generate_action_package(
     let message_to_rmw_fields =
         |member: &str, msg: &Message| build_rmw_fields(package_name, member, msg);
 
-    let message_to_idiomatic_fields = |msg: &Message| {
-        msg.fields
-            .iter()
-            .map(|f| IdiomaticField {
-                name: escape_keyword(&f.name),
-                field_type: f.field_type.clone(),
-                current_package: package_name.to_string(),
-                default_value: f
-                    .default_value
-                    .as_ref()
-                    .map(constant_value_to_rust)
-                    .unwrap_or_default(),
-                kind: determine_field_kind(&f.field_type),
-            })
-            .collect()
-    };
+    let message_to_idiomatic_fields =
+        |member: &str, msg: &Message| build_idiomatic_fields(package_name, member, msg);
 
     let message_to_constants = |msg: &Message, _rmw_layer: bool| {
         msg.constants
@@ -131,11 +117,11 @@ pub fn generate_action_package(
     let action_idiomatic_template = ActionIdiomaticTemplate {
         package_name,
         action_name,
-        goal_fields: message_to_idiomatic_fields(&action.spec.goal),
+        goal_fields: message_to_idiomatic_fields(&goal_member, &action.spec.goal),
         goal_constants: message_to_constants(&action.spec.goal, false),
-        result_fields: message_to_idiomatic_fields(&action.spec.result),
+        result_fields: message_to_idiomatic_fields(&result_member, &action.spec.result),
         result_constants: message_to_constants(&action.spec.result, false),
-        feedback_fields: message_to_idiomatic_fields(&action.spec.feedback),
+        feedback_fields: message_to_idiomatic_fields(&feedback_member, &action.spec.feedback),
         feedback_constants: message_to_constants(&action.spec.feedback, false),
     };
     let action_idiomatic = crate::render::render("action_idiomatic.rs", &action_idiomatic_template)

--- a/packages/cli/rosidl-codegen/src/generator/action.rs
+++ b/packages/cli/rosidl-codegen/src/generator/action.rs
@@ -1,6 +1,6 @@
 use super::common::{
     GeneratorError, PayloadLang, SchemaCaps, build_action_envelope_schemas, build_c_fields,
-    build_nros_fields, build_nros_schema_for_struct, determine_field_kind,
+    build_nros_fields, build_nros_schema_for_struct, build_rmw_fields, determine_field_kind,
     ensure_supported_storage_for_payload,
 };
 use crate::{
@@ -8,7 +8,7 @@ use crate::{
     templates::{
         ActionCHeaderTemplate, ActionCSourceTemplate, ActionIdiomaticTemplate, ActionNrosTemplate,
         ActionRmwTemplate, BuildRsTemplate, CConstant, CargoNrosTomlTemplate, CargoTomlTemplate,
-        IdiomaticField, LibNrosRsTemplate, LibRsTemplate, MessageConstant, RmwField,
+        IdiomaticField, LibNrosRsTemplate, LibRsTemplate, MessageConstant,
     },
     types::{
         NrosCodegenMode, c_type_for_constant, constant_value_to_rust, escape_keyword,
@@ -75,22 +75,14 @@ pub fn generate_action_package(
     let lib_rs = crate::render::render("lib.rs", &lib_rs_template)
         .map_err(|e| GeneratorError::RenderError(e.to_string()))?;
 
-    // Helper functions to convert Message to field vectors
-    let message_to_rmw_fields = |msg: &Message| {
-        msg.fields
-            .iter()
-            .map(|f| RmwField {
-                name: escape_keyword(&f.name),
-                field_type: f.field_type.clone(),
-                current_package: package_name.to_string(),
-                default_value: f
-                    .default_value
-                    .as_ref()
-                    .map(constant_value_to_rust)
-                    .unwrap_or_default(),
-            })
-            .collect()
-    };
+    // phase-432 W2.5a — each part is lowered under its rosidl-convention member
+    // name (`<Action>_Goal` / `_Result` / `_Feedback`), the same keys the nros
+    // and C paths use, so all three name one member the same way.
+    let goal_member = format!("{action_name}_Goal");
+    let result_member = format!("{action_name}_Result");
+    let feedback_member = format!("{action_name}_Feedback");
+    let message_to_rmw_fields =
+        |member: &str, msg: &Message| build_rmw_fields(package_name, member, msg);
 
     let message_to_idiomatic_fields = |msg: &Message| {
         msg.fields
@@ -124,11 +116,11 @@ pub fn generate_action_package(
     let action_rmw_template = ActionRmwTemplate {
         package_name,
         action_name,
-        goal_fields: message_to_rmw_fields(&action.spec.goal),
+        goal_fields: message_to_rmw_fields(&goal_member, &action.spec.goal),
         goal_constants: message_to_constants(&action.spec.goal, true),
-        result_fields: message_to_rmw_fields(&action.spec.result),
+        result_fields: message_to_rmw_fields(&result_member, &action.spec.result),
         result_constants: message_to_constants(&action.spec.result, true),
-        feedback_fields: message_to_rmw_fields(&action.spec.feedback),
+        feedback_fields: message_to_rmw_fields(&feedback_member, &action.spec.feedback),
         feedback_constants: message_to_constants(&action.spec.feedback, true),
     };
     // RFC-0068 Stage 3 (phase-335 W3): rmw Rust action from the minijinja pack.

--- a/packages/cli/rosidl-codegen/src/generator/common.rs
+++ b/packages/cli/rosidl-codegen/src/generator/common.rs
@@ -331,24 +331,35 @@ fn element_type_of(ft: &FieldType) -> Option<&FieldType> {
     }
 }
 
-/// Get the CDR primitive method name for a primitive type
-pub(super) fn primitive_to_cdr_method(prim: &rosidl_parser::PrimitiveType) -> String {
-    use rosidl_parser::PrimitiveType;
-    match prim {
-        PrimitiveType::Bool => "bool".to_string(),
-        PrimitiveType::Byte => "u8".to_string(),
-        PrimitiveType::Char => "u8".to_string(),
-        PrimitiveType::Int8 => "i8".to_string(),
-        PrimitiveType::UInt8 => "u8".to_string(),
-        PrimitiveType::Int16 => "i16".to_string(),
-        PrimitiveType::UInt16 => "u16".to_string(),
-        PrimitiveType::Int32 => "i32".to_string(),
-        PrimitiveType::UInt32 => "u32".to_string(),
-        PrimitiveType::Int64 => "i64".to_string(),
-        PrimitiveType::UInt64 => "u64".to_string(),
-        PrimitiveType::Float32 => "f32".to_string(),
-        PrimitiveType::Float64 => "f64".to_string(),
+/// The Rust CDR method suffix for a lowered scalar op — the nros pack's
+/// `reader.read_<x>()` / `writer.write_<x>()` (phase-432 W2.5a).
+///
+/// A per-language SPELLING of a neutral fact, which is the shape W2.5b names as
+/// a language's whole Rust surface area. It replaces `primitive_to_cdr_method`
+/// at the nros builder, and the two agree by construction: `CdrOp` is exactly
+/// as coarse as this mapping — `Byte`, `Char` and `UInt8` all lower to
+/// `CdrOp::U8` and all three spelled `"u8"`.
+///
+/// `String` and `Nested` are not scalars and reach this only through a caller
+/// that ignored `scalar_op` / `element_is_primitive`; they map to the empty
+/// string, which renders as no method rather than a wrong one.
+pub(super) fn cdr_op_rust_method(op: rosidl_lower::CdrOp) -> String {
+    use rosidl_lower::CdrOp;
+    match op {
+        CdrOp::Bool => "bool",
+        CdrOp::U8 => "u8",
+        CdrOp::I8 => "i8",
+        CdrOp::U16 => "u16",
+        CdrOp::I16 => "i16",
+        CdrOp::U32 => "u32",
+        CdrOp::I32 => "i32",
+        CdrOp::U64 => "u64",
+        CdrOp::I64 => "i64",
+        CdrOp::F32 => "f32",
+        CdrOp::F64 => "f64",
+        CdrOp::String | CdrOp::Nested => "",
     }
+    .to_string()
 }
 
 /// Storage-mode policy for a service/action payload struct.
@@ -497,131 +508,72 @@ pub(super) fn ensure_element_caps_apply(
     })
 }
 
+/// Build one nros field from the lowered IR (phase-432 W2.5a).
+///
+/// Every fact below was re-derived here from `rosidl_parser` before this wave:
+/// the element-cap fold, the two configurable shapes, the storage mode flags,
+/// the five shape predicates, the array length, the element classification and
+/// both CDR method names. All of them are now READ off `LoweredField`, so the
+/// nros surface and the C surface cannot answer the same question differently.
+///
+/// What is left is the two things a language owes: the identifier SPELLING
+/// (`escape_keyword`) and the CDR method NAMES (`cdr_op_rust_method`), which is
+/// a `CdrOp` -> Rust suffix mapping and belongs with the other per-language
+/// spellings (W2.5b).
 pub(super) fn field_to_nros_field_with_mode(
-    field: &rosidl_parser::Field,
+    field: &rosidl_lower::LoweredField,
     package_name: &str,
     message_name: &str,
-    resolver: &CapacityResolver,
     mode: NrosCodegenMode,
-    // phase-335 W1.c — when the caller already lowered this field, its resolved
-    // storage is read from the IR instead of resolving a second time. `None`
-    // keeps the resolver path (callers not yet migrated). Only consulted for a
-    // configurable (unbounded string / sequence) field; ignored otherwise.
-    pre_storage: Option<FieldStorage>,
 ) -> Result<NrosField, GeneratorError> {
-    let name = escape_keyword(&field.name);
-
-    // phase-403 W7 — fold any configured ELEMENT bound into the shape first, so
-    // the container spells `heapless::Vec<heapless::String<32>, N>` and the
-    // element's `String::try_from` is what ENFORCES the bound the derived
-    // number claims. Every branch below reads this, not `field.field_type`.
-    let capped =
-        resolver.element_capped(package_name, message_name, &field.name, &field.field_type);
+    // phase-403 W7 — the container spells `heapless::Vec<heapless::String<32>, N>`
+    // so the element's `String::try_from` ENFORCES the bound the derived number
+    // claims. The fold is `LoweredField::storage_type`; it used to be an
+    // `element_capped` call this builder made for itself.
+    let capped = field.storage_type();
     let field_type: &FieldType = capped.as_ref();
 
-    // Resolve per-field capacity for the two configurable shapes: an unbounded
-    // string and an unbounded sequence. Everything else keeps default rendering.
-    let cap_kind = match field_type {
-        FieldType::String | FieldType::WString => Some(CapFieldKind::String),
-        FieldType::Sequence { .. } => Some(CapFieldKind::Sequence),
-        _ => None,
-    };
-    let mut is_heap = false;
-    let mut is_borrowed = false;
     let mut borrowed_rust_type = String::new();
     let mut borrowed_read_expr = String::new();
-    // phase-335 step 2 — resolve storage for the FLAGS + the capacity the
-    // `nros_type` pack filter needs; the type STRING is composed in the pack.
-    let is_configurable = cap_kind.is_some();
-    let mut cap: usize = 0;
-    if let Some(kind) = cap_kind {
-        let storage = pre_storage
-            .unwrap_or_else(|| resolver.resolve(package_name, message_name, &field.name, kind));
-        cap = storage.cap;
-        match storage.mode {
-            StorageMode::Inline => {}
-            StorageMode::Heap => {
-                is_heap = true;
-            }
-            // RFC-0033 `borrowed` (Phase 229.6, issue 0007): the owned `{Msg}`
-            // struct keeps a default-capacity owned container for the publish
-            // path; the additionally-emitted `{Msg}View<'a>` borrows this field
-            // zero-copy (see `borrowed_rust_type` / `borrowed_read_expr`).
-            StorageMode::View => {
-                is_borrowed = true;
-                let (bt, expr) = nros_borrowed_view_for_field(
-                    field_type,
-                    package_name,
-                    message_name,
-                    &field.name,
-                )?;
-                borrowed_rust_type = bt;
-                borrowed_read_expr = expr;
-            }
-        }
+    // RFC-0033 `borrowed` (Phase 229.6, issue 0007): the owned `{Msg}` struct
+    // keeps a default-capacity owned container for the publish path; the
+    // additionally-emitted `{Msg}View<'a>` borrows this field zero-copy.
+    if field.is_borrowed() {
+        let (bt, expr) =
+            nros_borrowed_view_for_field(field_type, package_name, message_name, &field.name)?;
+        borrowed_rust_type = bt;
+        borrowed_read_expr = expr;
     }
 
-    // Determine field properties
-    let (is_primitive, primitive_method) = match field_type {
-        FieldType::Primitive(prim) => (true, primitive_to_cdr_method(prim)),
-        _ => (false, String::new()),
-    };
-
-    let is_string = matches!(
-        field_type,
-        FieldType::String
-            | FieldType::BoundedString(_)
-            | FieldType::WString
-            | FieldType::BoundedWString(_)
-    );
-
-    let (is_array, array_size) = match field_type {
-        FieldType::Array { size, .. } => (true, *size),
-        _ => (false, 0),
-    };
-
-    let is_sequence = matches!(
-        field_type,
-        FieldType::Sequence { .. } | FieldType::BoundedSequence { .. }
-    );
-
-    let is_nested = matches!(field_type, FieldType::NamespacedType { .. });
-
-    // Element type info for arrays and sequences
-    let (is_primitive_element, is_string_element, element_primitive_method) = match field_type {
-        FieldType::Array { element_type, .. }
-        | FieldType::Sequence { element_type }
-        | FieldType::BoundedSequence { element_type, .. } => match element_type.as_ref() {
-            FieldType::Primitive(prim) => (true, false, primitive_to_cdr_method(prim)),
-            FieldType::String
-            | FieldType::BoundedString(_)
-            | FieldType::WString
-            | FieldType::BoundedWString(_) => (false, true, String::new()),
-            _ => (false, false, String::new()),
-        },
-        _ => (false, false, String::new()),
-    };
+    let array_size = field.array_len();
 
     Ok(NrosField {
-        name,
+        name: escape_keyword(&field.name),
         field_type: field_type.clone(),
-        is_configurable,
-        cap,
+        is_configurable: field.configurable,
+        cap: field.configured_cap(),
         mode,
         current_package: package_name.to_string(),
-        primitive_method,
-        element_primitive_method,
+        primitive_method: field
+            .scalar_op()
+            .map(cdr_op_rust_method)
+            .unwrap_or_default(),
+        element_primitive_method: field
+            .element_op()
+            .filter(|_| field.element_is_primitive())
+            .map(cdr_op_rust_method)
+            .unwrap_or_default(),
         array_size,
-        is_primitive,
-        is_string,
-        is_array,
-        is_sequence,
-        is_nested,
-        is_primitive_element,
-        is_string_element,
+        is_primitive: field.is_primitive(),
+        is_string: field.is_string(),
+        is_array: field.is_array(),
+        is_sequence: field.is_sequence(),
+        is_nested: field.is_nested(),
+        is_primitive_element: field.element_is_primitive(),
+        is_string_element: field.element_is_string(),
         is_large_array: array_size > 32,
-        is_heap,
-        is_borrowed,
+        is_heap: field.is_heap(),
+        is_borrowed: field.is_borrowed(),
         borrowed_rust_type,
         borrowed_read_expr,
     })
@@ -722,8 +674,10 @@ pub(super) fn build_idiomatic_fields(
         .collect()
 }
 
-/// Build every nros field of `msg`, sourcing each field's storage from the
-/// lowered IR once (phase-335 W1.c) — no field builder resolves capacity.
+/// Build every nros field of `msg` from the lowered IR (phase-432 W2.5a).
+///
+/// phase-335 W1.c already sourced the STORAGE decision here; the whole field is
+/// sourced here now, so nothing downstream re-reads `rosidl_parser`.
 pub(super) fn build_nros_fields(
     package: &str,
     message: &str,
@@ -731,12 +685,11 @@ pub(super) fn build_nros_fields(
     resolver: &CapacityResolver,
     mode: NrosCodegenMode,
 ) -> Result<Vec<NrosField>, GeneratorError> {
-    let store = lowered_storages(package, message, &msg.fields, resolver);
+    let lowered = rosidl_lower::lower_fields(package, message, &msg.fields, resolver);
     ensure_element_caps_apply(package, message, &msg.fields, resolver)?;
-    msg.fields
+    lowered
         .iter()
-        .zip(store.iter())
-        .map(|(f, s)| field_to_nros_field_with_mode(f, package, message, resolver, mode, Some(*s)))
+        .map(|f| field_to_nros_field_with_mode(f, package, message, mode))
         .collect()
 }
 

--- a/packages/cli/rosidl-codegen/src/generator/common.rs
+++ b/packages/cli/rosidl-codegen/src/generator/common.rs
@@ -1,14 +1,14 @@
 use crate::{
-    config::{CapacityResolver, FieldKind as CapFieldKind, FieldStorage, StorageMode},
+    config::{CapacityResolver, FieldKind as CapFieldKind, StorageMode},
     templates::{
         CField, CppFfiField, CppField, FieldKind, IdiomaticField, NrosField, RmwField,
         SequenceStructDef,
     },
     types::{
         C_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_STRING_CAPACITY,
-        NrosCodegenMode, c_cdr_read_method, c_cdr_read_method_for_op, c_cdr_write_method,
-        c_cdr_write_method_for_op, c_type_for_field_heap, constant_value_to_rust,
-        cpp_type_for_field_heap, escape_keyword, repr_c_type_for_field, to_c_package_name,
+        NrosCodegenMode, c_cdr_read_method_for_op, c_cdr_write_method_for_op,
+        c_type_for_field_heap, constant_value_to_rust, cpp_type_for_field_heap, escape_keyword,
+        repr_c_type_for_field, to_c_package_name,
     },
     utils::to_snake_case,
 };
@@ -560,24 +560,6 @@ pub(super) fn field_to_nros_field_with_mode(
     })
 }
 
-/// Convert a Message field to NrosField (crate mode).
-/// Per-field storage decisions for `msg`, read from the lowered IR (phase-335
-/// W1.c). A generator computes this once and hands each builder the matching
-/// entry (`Some(store[i])`) so no builder resolves capacity a second time.
-/// `lower_fields` calls the same `CapacityResolver` with the same keys, so the
-/// result is byte-identical to an inline `resolver.resolve`.
-pub(super) fn lowered_storages(
-    package: &str,
-    message: &str,
-    fields: &[rosidl_parser::Field],
-    resolver: &CapacityResolver,
-) -> Vec<FieldStorage> {
-    rosidl_lower::lower_fields(package, message, fields, resolver)
-        .iter()
-        .map(|lf| lf.storage.as_field_storage())
-        .collect()
-}
-
 /// The lowered IR for a surface that mirrors ROS's OWN runtime types — the
 /// `rmw` and idiomatic Rust packs (phase-432 W2.5a).
 ///
@@ -936,44 +918,41 @@ fn cpp_borrow_kind(
 /// (rejected for heap strings / sequences of strings / nested messages, and for
 /// `borrowed`). Shared by the C++ header + FFI builders so both agree.
 pub(super) fn resolve_cap_override(
-    name: &str,
-    field_type: &FieldType,
+    field: &rosidl_lower::LoweredField,
     current_package: Option<&str>,
     message_name: &str,
-    resolver: &CapacityResolver,
-    // phase-335 W1.c — storage from the IR when the caller already lowered it.
-    pre_storage: Option<FieldStorage>,
 ) -> Result<CppStorage, GeneratorError> {
-    let kind = match field_type {
-        FieldType::String | FieldType::WString => CapFieldKind::String,
-        FieldType::Sequence { .. } => CapFieldKind::Sequence,
-        _ => return Ok(CppStorage::Owned(None)),
-    };
+    // Only the two configurable shapes carry a resolved capacity; everything
+    // else keeps default rendering. This used to be a `match` on the parsed
+    // type here — the same one the C and nros builders each wrote.
+    if !field.configurable {
+        return Ok(CppStorage::Owned(None));
+    }
+    let capped = field.storage_type();
+    let field_type: &FieldType = capped.as_ref();
     let package = current_package.unwrap_or("");
     let unsupported = |mode: &'static str| GeneratorError::UnsupportedStorageMode {
         package: package.to_string(),
         message: message_name.to_string(),
-        field: name.to_string(),
+        field: field.name.clone(),
         mode,
     };
-    let storage =
-        pre_storage.unwrap_or_else(|| resolver.resolve(package, message_name, name, kind));
-    match storage.mode {
-        StorageMode::Inline => Ok(CppStorage::Owned(Some(storage.cap))),
-        StorageMode::Heap => {
-            // Heap is only bridgeable for primitive sequences (see
-            // cpp_type_for_field_heap); reject heap strings / non-primitive seqs.
-            if cpp_type_for_field_heap(field_type, current_package).is_some() {
-                Ok(CppStorage::Heap)
-            } else {
-                Err(unsupported("heap"))
-            }
-        }
-        StorageMode::View => Ok(CppStorage::Borrowed(
-            cpp_borrow_kind(field_type, package, message_name, name)?,
-            Some(storage.cap),
-        )),
+    if field.is_heap() {
+        // Heap is only bridgeable for primitive sequences (see
+        // cpp_type_for_field_heap); reject heap strings / non-primitive seqs.
+        return if cpp_type_for_field_heap(field_type, current_package).is_some() {
+            Ok(CppStorage::Heap)
+        } else {
+            Err(unsupported("heap"))
+        };
     }
+    if field.is_borrowed() {
+        return Ok(CppStorage::Borrowed(
+            cpp_borrow_kind(field_type, package, message_name, &field.name)?,
+            Some(field.configured_cap()),
+        ));
+    }
+    Ok(CppStorage::Owned(Some(field.configured_cap())))
 }
 
 /// Build a CppField for C++ header generation.
@@ -981,12 +960,13 @@ pub(super) fn resolve_cap_override(
 /// `storage` is the resolved per-field storage (RFC-0033): an owned
 /// fixed-capacity container or an `nros::HeapSequence<T>` heap sequence.
 pub(super) fn build_cpp_field(
-    name: &str,
-    field_type: &FieldType,
+    field: &rosidl_lower::LoweredField,
     current_package: Option<&str>,
     storage: CppStorage,
 ) -> CppField {
-    let escaped_name = escape_keyword(name);
+    let escaped_name = escape_keyword(&field.name);
+    let capped = field.storage_type();
+    let field_type: &FieldType = capped.as_ref();
     // phase-335 step 2 — CppField carries the NEUTRAL facts; the `cpp_type` /
     // `cpp_array_suffix` pack filters compose the C++ type string. The borrowed
     // VIEW type (`nros::StringView` / `Span<T>` / `LeSpan<T>`) stays computed here
@@ -1025,18 +1005,21 @@ pub(super) fn build_cpp_field(
 
 /// Build a CppFfiField and optional SequenceStructDef for Rust FFI glue generation
 pub(super) fn build_cpp_ffi_field(
-    name: &str,
-    field_type: &FieldType,
+    field: &rosidl_lower::LoweredField,
     struct_name: &str,
     current_package: Option<&str>,
     storage: CppStorage,
 ) -> (CppFfiField, Option<SequenceStructDef>) {
+    let name = field.name.as_str();
     let escaped_name = escape_keyword(name);
+    let capped = field.storage_type();
+    let field_type: &FieldType = capped.as_ref();
     let is_heap = matches!(storage, CppStorage::Heap);
+    // The `{Msg}Repr` field's declared capacity: `None` means "no resolved
+    // capacity" (a non-configurable shape, or a heap field that has none).
     let cap_override = match storage {
-        CppStorage::Owned(cap) => cap,
+        CppStorage::Owned(cap) | CppStorage::Borrowed(_, cap) => cap,
         CppStorage::Heap => None,
-        CppStorage::Borrowed(_, cap) => cap,
     };
     // RFC-0033 borrowed (Phase 235): the `{Msg}ViewRepr` FFI struct stores this
     // field as `nros_cpp_borrow_t { *const u8, usize }`, filled from the
@@ -1046,71 +1029,51 @@ pub(super) fn build_cpp_ffi_field(
         _ => (false, String::new(), false),
     };
 
-    // Determine type characteristics
-    let (is_primitive, primitive_type) = match field_type {
-        FieldType::Primitive(prim) => (true, Some(prim)),
-        _ => (false, None),
-    };
+    let element_type = element_type_of(field_type);
+    let array_size = field.array_len();
 
-    let is_string = matches!(
-        field_type,
-        FieldType::String
-            | FieldType::BoundedString(_)
-            | FieldType::WString
-            | FieldType::BoundedWString(_)
-    );
-
-    let is_array = matches!(field_type, FieldType::Array { .. });
-    let is_sequence = matches!(
-        field_type,
-        FieldType::Sequence { .. } | FieldType::BoundedSequence { .. }
-    );
-    let is_nested = matches!(field_type, FieldType::NamespacedType { .. });
-
-    // Array/sequence size info. Unbounded sequences use the resolved capacity.
-    let (array_size, sequence_capacity) = match field_type {
-        FieldType::Array { size, .. } => (*size, 0),
-        FieldType::Sequence { .. } => (0, cap_override.unwrap_or(CPP_DEFAULT_SEQUENCE_CAPACITY)),
-        FieldType::BoundedSequence { max_size, .. } => (0, *max_size),
-        _ => (0, 0),
-    };
-
-    // Element type info
-    let (is_primitive_element, is_string_element, element_type) = match field_type {
-        FieldType::Array { element_type, .. }
-        | FieldType::Sequence { element_type }
-        | FieldType::BoundedSequence { element_type, .. } => {
-            let is_prim = matches!(element_type.as_ref(), FieldType::Primitive(_));
-            let is_str = matches!(
-                element_type.as_ref(),
-                FieldType::String
-                    | FieldType::BoundedString(_)
-                    | FieldType::WString
-                    | FieldType::BoundedWString(_)
-            );
-            (is_prim, is_str, Some(element_type.as_ref()))
+    // A sequence's FFI capacity is its storage's — `LoweredStorage::Bounded`
+    // covers `T[<=N]` and a config-capped `T[]` alike; a heap sequence has no
+    // fixed capacity, so the repr keeps the default. Same derivation as the C
+    // surface's, off the same fact, which is the point (they disagreed only by
+    // luck before: two hand-written matches over one type tree).
+    let sequence_capacity = if field.is_sequence() {
+        match field.storage {
+            rosidl_lower::LoweredStorage::Bounded { cap }
+            | rosidl_lower::LoweredStorage::Borrowed { cap } => cap,
+            rosidl_lower::LoweredStorage::Heap => CPP_DEFAULT_SEQUENCE_CAPACITY,
+            rosidl_lower::LoweredStorage::Inline | rosidl_lower::LoweredStorage::Fixed { .. } => 0,
         }
-        _ => (false, false, None),
+    } else {
+        0
     };
+
+    let (is_primitive, is_string, is_array, is_sequence, is_nested) = (
+        field.is_primitive(),
+        field.is_string(),
+        field.is_array(),
+        field.is_sequence(),
+        field.is_nested(),
+    );
+    let (is_primitive_element, is_string_element) =
+        (field.element_is_primitive(), field.element_is_string());
 
     // CDR methods for primitives
-    let (cdr_write_method, cdr_read_method) = if let Some(prim) = primitive_type {
-        (
-            c_cdr_write_method(prim).to_string(),
-            c_cdr_read_method(prim).to_string(),
-        )
-    } else {
-        (String::new(), String::new())
+    let (cdr_write_method, cdr_read_method) = match field.scalar_op() {
+        Some(op) => (
+            c_cdr_write_method_for_op(op).to_string(),
+            c_cdr_read_method_for_op(op).to_string(),
+        ),
+        None => (String::new(), String::new()),
     };
 
     let (element_cdr_write_method, element_cdr_read_method) =
-        if let Some(FieldType::Primitive(prim)) = element_type {
-            (
-                c_cdr_write_method(prim).to_string(),
-                c_cdr_read_method(prim).to_string(),
-            )
-        } else {
-            (String::new(), String::new())
+        match field.element_op().filter(|_| is_primitive_element) {
+            Some(op) => (
+                c_cdr_write_method_for_op(op).to_string(),
+                c_cdr_read_method_for_op(op).to_string(),
+            ),
+            None => (String::new(), String::new()),
         };
 
     // Nested function names
@@ -1254,7 +1217,7 @@ pub(super) fn build_cpp_ffi_field(
         _ => 0,
     };
 
-    let field = CppFfiField {
+    let ffi_field = CppFfiField {
         name: escaped_name,
         field_type: field_type.clone(),
         struct_name: struct_name.to_string(),
@@ -1285,7 +1248,7 @@ pub(super) fn build_cpp_ffi_field(
         borrowed_le,
     };
 
-    (field, seq_struct)
+    (ffi_field, seq_struct)
 }
 
 // ============================================================================

--- a/packages/cli/rosidl-codegen/src/generator/common.rs
+++ b/packages/cli/rosidl-codegen/src/generator/common.rs
@@ -1,10 +1,11 @@
 use crate::{
     config::{CapacityResolver, FieldKind as CapFieldKind, FieldStorage, StorageMode},
-    templates::{CField, CppFfiField, CppField, FieldKind, NrosField, SequenceStructDef},
+    templates::{CField, CppFfiField, CppField, FieldKind, NrosField, RmwField, SequenceStructDef},
     types::{
         C_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_STRING_CAPACITY,
         NrosCodegenMode, c_cdr_read_method, c_cdr_write_method, c_type_for_field_heap,
-        cpp_type_for_field_heap, escape_keyword, repr_c_type_for_field, to_c_package_name,
+        constant_value_to_rust, cpp_type_for_field_heap, escape_keyword, repr_c_type_for_field,
+        to_c_package_name,
     },
     utils::to_snake_case,
 };
@@ -583,6 +584,56 @@ pub(super) fn lowered_storages(
     rosidl_lower::lower_fields(package, message, fields, resolver)
         .iter()
         .map(|lf| lf.storage.as_field_storage())
+        .collect()
+}
+
+/// The lowered IR for a surface that mirrors ROS's OWN runtime types — the
+/// `rmw` and idiomatic Rust packs (phase-432 W2.5a).
+///
+/// Those two layers spell `rosidl_runtime_rs::Sequence<T>` / `std::vec::Vec<T>`
+/// and `String`: containers with no fixed capacity, chosen by ROS rather than by
+/// us. Nothing in a nano-ros storage config can change them, which is why
+/// `generate_message_package` and its siblings take no [`CapacityResolver`] —
+/// so the empty resolver is not a stand-in here, it is the right answer, and
+/// naming it once keeps the three entry points from each deciding that
+/// separately.
+pub(super) fn lowered_ros_abi_fields(
+    package: &str,
+    message: &str,
+    fields: &[rosidl_parser::Field],
+) -> Vec<rosidl_lower::LoweredField> {
+    rosidl_lower::lower_fields(package, message, fields, &CapacityResolver::empty())
+}
+
+/// Build every `rmw` field of a message, projected from the lowered IR
+/// (phase-432 W2.5a).
+///
+/// The `rmw` surface is the thinnest of the five: a name, the type AS PARSED
+/// (its containers are ROS's, so no storage decision applies) and the `.msg`
+/// default. All three are IR facts, and the only Rust here is the two SPELLINGS
+/// — `escape_keyword` and `constant_value_to_rust`.
+///
+/// It replaces three byte-identical closures in `msg.rs`, `srv.rs` and
+/// `action.rs`, each mapping over `rosidl_parser`'s fields. The projection is
+/// one fact per line; three copies of it was three places for a fourth
+/// surface's habit to be copied from.
+pub(super) fn build_rmw_fields(
+    package_name: &str,
+    message_name: &str,
+    msg: &rosidl_parser::Message,
+) -> Vec<RmwField> {
+    lowered_ros_abi_fields(package_name, message_name, &msg.fields)
+        .iter()
+        .map(|f| RmwField {
+            name: escape_keyword(&f.name),
+            field_type: f.field_type.clone(),
+            current_package: package_name.to_string(),
+            default_value: f
+                .default_value
+                .as_ref()
+                .map(constant_value_to_rust)
+                .unwrap_or_default(),
+        })
         .collect()
 }
 

--- a/packages/cli/rosidl-codegen/src/generator/common.rs
+++ b/packages/cli/rosidl-codegen/src/generator/common.rs
@@ -6,9 +6,9 @@ use crate::{
     },
     types::{
         C_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_STRING_CAPACITY,
-        NrosCodegenMode, c_cdr_read_method, c_cdr_write_method, c_type_for_field_heap,
-        constant_value_to_rust, cpp_type_for_field_heap, escape_keyword, repr_c_type_for_field,
-        to_c_package_name,
+        NrosCodegenMode, c_cdr_read_method, c_cdr_read_method_for_op, c_cdr_write_method,
+        c_cdr_write_method_for_op, c_type_for_field_heap, constant_value_to_rust,
+        cpp_type_for_field_heap, escape_keyword, repr_c_type_for_field, to_c_package_name,
     },
     utils::to_snake_case,
 };
@@ -440,41 +440,22 @@ pub(super) enum PayloadLang {
     C,
 }
 
-/// Convert a Message field to NrosField with explicit codegen mode.
+/// Build every C field of `msg` from the lowered IR (phase-432 W2.5a).
 ///
-/// `resolver` supplies the per-field capacity for **unbounded** sequence/string
-/// fields (RFC-0033). Bounded fields, arrays, primitives, and nested types are
-/// unaffected. A non-`owned` storage mode is rejected in Phase 229 (`heap` and
-/// `borrowed` land in 229.5 / 229.6).
-/// Build every C field of `msg`, sourcing each field's storage from the lowered
-/// IR once (phase-335 W1.c) — no field builder resolves capacity.
+/// phase-335 W1.c already sourced the STORAGE decision here; the whole field is
+/// sourced here now, so nothing downstream re-reads `rosidl_parser`.
 pub(super) fn build_c_fields(
     current_package: Option<&str>,
     message: &str,
     msg: &rosidl_parser::Message,
     resolver: &CapacityResolver,
 ) -> Result<Vec<CField>, GeneratorError> {
-    let store = lowered_storages(
-        current_package.unwrap_or(""),
-        message,
-        &msg.fields,
-        resolver,
-    );
     let package = current_package.unwrap_or("");
+    let lowered = rosidl_lower::lower_fields(package, message, &msg.fields, resolver);
     ensure_element_caps_apply(package, message, &msg.fields, resolver)?;
-    msg.fields
+    lowered
         .iter()
-        .zip(store.iter())
-        .map(|(f, s)| {
-            build_c_field(
-                &f.name,
-                &f.field_type,
-                current_package,
-                message,
-                resolver,
-                Some(*s),
-            )
-        })
+        .map(|f| build_c_field(f, current_package, message))
         .collect()
 }
 
@@ -693,158 +674,91 @@ pub(super) fn build_nros_fields(
         .collect()
 }
 
-/// Build a CField from a field type.
+/// Build one C field from the lowered IR (phase-432 W2.5a).
 ///
-/// `resolver` supplies the per-field capacity for **unbounded** sequence/string
-/// fields (RFC-0033). A non-`owned` storage mode is rejected in Phase 229.
+/// The C twin of `field_to_nros_field_with_mode`, and the reason both had to
+/// move: they answered the same fifteen questions about one field, each with
+/// its own `match` on `rosidl_parser`'s type tree, and nothing checked that the
+/// two agreed. Now both read `LoweredField` and only the SPELLINGS differ —
+/// `c_cdr_*_method_for_op` here where the nros builder has
+/// `cdr_op_rust_method`, which is exactly the difference that should remain.
 pub(super) fn build_c_field(
-    name: &str,
-    field_type: &FieldType,
+    field: &rosidl_lower::LoweredField,
     current_package: Option<&str>,
     message_name: &str,
-    resolver: &CapacityResolver,
-    // phase-335 W1.c — storage from the IR when the caller already lowered it.
-    pre_storage: Option<FieldStorage>,
 ) -> Result<CField, GeneratorError> {
-    let escaped_name = escape_keyword(name);
+    let name = field.name.as_str();
 
-    // phase-403 W7 — fold any configured ELEMENT bound into the shape before
-    // anything reads it, so every branch below sees the `string<=N[]` the `.msg`
-    // could have spelled. `char name[16][32]` and its `sizeof`-bounded
-    // `nros_cdr_read_string` then fall out of the existing bounded-element arms.
-    let capped = resolver.element_capped(
-        current_package.unwrap_or(""),
-        message_name,
-        name,
-        field_type,
-    );
+    // phase-403 W7 — every branch below sees the `string<=N[]` the `.msg` could
+    // have spelled, so `char name[16][32]` and its `sizeof`-bounded
+    // `nros_cdr_read_string` fall out of the existing bounded-element arms. The
+    // fold is `LoweredField::storage_type`; it used to be an `element_capped`
+    // call this builder made for itself.
+    let capped = field.storage_type();
     let field_type: &FieldType = capped.as_ref();
 
-    // Resolve per-field capacity for the two configurable shapes.
-    let cap_kind = match field_type {
-        FieldType::String | FieldType::WString => Some(CapFieldKind::String),
-        FieldType::Sequence { .. } => Some(CapFieldKind::Sequence),
-        _ => None,
-    };
     let unsupported = |mode: &'static str| GeneratorError::UnsupportedStorageMode {
         package: current_package.unwrap_or("").to_string(),
         message: message_name.to_string(),
         field: name.to_string(),
         mode,
     };
-    // (c_type, array_suffix, is_heap, resolved owned sequence capacity).
-    let mut is_heap = false;
-    let mut is_borrowed = false;
+
     let mut borrowed_c_type = String::new();
     let mut borrowed_read_fn = String::new();
-    let mut owned_seq_cap: Option<usize> = None;
-    // phase-335 step 2 — resolve storage for the FLAGS + the capacity the
-    // `c_type` / `c_array_suffix` pack filters need; the type STRING is composed
-    // in the pack from `field_type` + these facts, not pre-baked here.
-    let is_configurable = cap_kind.is_some();
-    let mut cap: usize = 0;
-    if let Some(kind) = cap_kind {
-        let package = current_package.unwrap_or("");
-        let storage =
-            pre_storage.unwrap_or_else(|| resolver.resolve(package, message_name, name, kind));
-        cap = storage.cap;
-        match storage.mode {
-            StorageMode::Inline => {
-                if matches!(field_type, FieldType::Sequence { .. }) {
-                    owned_seq_cap = Some(storage.cap);
-                }
-            }
-            StorageMode::Heap => {
-                // Heap is only bridgeable for shapes `c_type_for_field_heap`
-                // supports — validate here (the filter assumes it holds), reject
-                // otherwise, preserving the pre-step-2 error behaviour.
-                if c_type_for_field_heap(field_type, current_package).is_none() {
-                    return Err(unsupported("heap"));
-                }
-                is_heap = true;
-            }
-            // RFC-0033 `borrowed` (Phase 235, issue 0021): the owned `{Msg}`
-            // struct keeps its resolved-capacity container for the publish path;
-            // the emitted `{Msg}_View` borrows this field zero-copy (see
-            // `borrowed_c_type` / `borrowed_read_fn`).
-            StorageMode::View => {
-                is_borrowed = true;
-                let (bt, bfn) = c_borrowed_view_for_field(field_type, package, message_name, name)?;
-                borrowed_c_type = bt;
-                borrowed_read_fn = bfn;
-                if matches!(field_type, FieldType::Sequence { .. }) {
-                    owned_seq_cap = Some(storage.cap);
-                }
-            }
+    if field.is_heap() {
+        // Heap is only bridgeable for shapes `c_type_for_field_heap` supports —
+        // validate here (the filter assumes it holds), reject otherwise.
+        if c_type_for_field_heap(field_type, current_package).is_none() {
+            return Err(unsupported("heap"));
         }
     }
+    // RFC-0033 `borrowed` (Phase 235, issue 0021): the owned `{Msg}` struct
+    // keeps its resolved-capacity container for the publish path; the emitted
+    // `{Msg}_View` borrows this field zero-copy.
+    if field.is_borrowed() {
+        let (bt, bfn) = c_borrowed_view_for_field(
+            field_type,
+            current_package.unwrap_or(""),
+            message_name,
+            name,
+        )?;
+        borrowed_c_type = bt;
+        borrowed_read_fn = bfn;
+    }
 
-    // Determine type characteristics
-    let (is_primitive, primitive_type) = match field_type {
-        FieldType::Primitive(prim) => (true, Some(prim)),
-        _ => (false, None),
-    };
+    let element_type = element_type_of(field_type);
+    let array_size = field.array_len();
 
-    let is_string = matches!(
-        field_type,
-        FieldType::String
-            | FieldType::BoundedString(_)
-            | FieldType::WString
-            | FieldType::BoundedWString(_)
-    );
-
-    let is_array = matches!(field_type, FieldType::Array { .. });
-    let is_sequence = matches!(
-        field_type,
-        FieldType::Sequence { .. } | FieldType::BoundedSequence { .. }
-    );
-    let is_nested = matches!(field_type, FieldType::NamespacedType { .. });
-
-    // Get array/sequence info. Owned unbounded sequences use the resolved
-    // capacity; heap sequences are unbounded (capacity unused → 0).
-    let (array_size, sequence_capacity) = match field_type {
-        FieldType::Array { size, .. } => (*size, 0),
-        FieldType::Sequence { .. } => (0, owned_seq_cap.unwrap_or(C_DEFAULT_SEQUENCE_CAPACITY)),
-        FieldType::BoundedSequence { max_size, .. } => (0, *max_size),
-        _ => (0, 0),
-    };
-
-    // Get element info for arrays/sequences
-    let (is_primitive_element, is_string_element, element_type) = match field_type {
-        FieldType::Array { element_type, .. }
-        | FieldType::Sequence { element_type }
-        | FieldType::BoundedSequence { element_type, .. } => {
-            let is_prim = matches!(element_type.as_ref(), FieldType::Primitive(_));
-            let is_str = matches!(
-                element_type.as_ref(),
-                FieldType::String
-                    | FieldType::BoundedString(_)
-                    | FieldType::WString
-                    | FieldType::BoundedWString(_)
-            );
-            (is_prim, is_str, Some(element_type.as_ref()))
+    // A sequence's C capacity is its storage's. `LoweredStorage::Bounded`
+    // covers both `T[<=N]` (the `.msg`'s N) and a config-capped `T[]`; a heap
+    // sequence has no fixed capacity, so the emitted struct keeps the default.
+    let sequence_capacity = if field.is_sequence() {
+        match field.storage {
+            rosidl_lower::LoweredStorage::Bounded { cap }
+            | rosidl_lower::LoweredStorage::Borrowed { cap } => cap,
+            rosidl_lower::LoweredStorage::Heap => C_DEFAULT_SEQUENCE_CAPACITY,
+            rosidl_lower::LoweredStorage::Inline | rosidl_lower::LoweredStorage::Fixed { .. } => 0,
         }
-        _ => (false, false, None),
+    } else {
+        0
     };
 
-    // Get CDR methods
-    let (cdr_write_method, cdr_read_method) = if let Some(prim) = primitive_type {
-        (
-            c_cdr_write_method(prim).to_string(),
-            c_cdr_read_method(prim).to_string(),
-        )
-    } else {
-        (String::new(), String::new())
+    let (cdr_write_method, cdr_read_method) = match field.scalar_op() {
+        Some(op) => (
+            c_cdr_write_method_for_op(op).to_string(),
+            c_cdr_read_method_for_op(op).to_string(),
+        ),
+        None => (String::new(), String::new()),
     };
 
     let (element_cdr_write_method, element_cdr_read_method) =
-        if let Some(FieldType::Primitive(prim)) = element_type {
-            (
-                c_cdr_write_method(prim).to_string(),
-                c_cdr_read_method(prim).to_string(),
-            )
-        } else {
-            (String::new(), String::new())
+        match field.element_op().filter(|_| field.element_is_primitive()) {
+            Some(op) => (
+                c_cdr_write_method_for_op(op).to_string(),
+                c_cdr_read_method_for_op(op).to_string(),
+            ),
+            None => (String::new(), String::new()),
         };
 
     // Get nested struct names (use current_package for intra-package references)
@@ -864,10 +778,10 @@ pub(super) fn build_c_field(
         };
 
     Ok(CField {
-        name: escaped_name,
+        name: escape_keyword(name),
         field_type: field_type.clone(),
-        is_configurable,
-        cap,
+        is_configurable: field.configurable,
+        cap: field.configured_cap(),
         current_package: current_package.unwrap_or("").to_string(),
         cdr_write_method,
         cdr_read_method,
@@ -877,15 +791,15 @@ pub(super) fn build_c_field(
         sequence_capacity,
         nested_struct_name,
         element_struct_name,
-        is_primitive,
-        is_string,
-        is_array,
-        is_sequence,
-        is_nested,
-        is_primitive_element,
-        is_string_element,
-        is_heap,
-        is_borrowed,
+        is_primitive: field.is_primitive(),
+        is_string: field.is_string(),
+        is_array: field.is_array(),
+        is_sequence: field.is_sequence(),
+        is_nested: field.is_nested(),
+        is_primitive_element: field.element_is_primitive(),
+        is_string_element: field.element_is_string(),
+        is_heap: field.is_heap(),
+        is_borrowed: field.is_borrowed(),
         borrowed_c_type,
         borrowed_read_fn,
     })

--- a/packages/cli/rosidl-codegen/src/generator/common.rs
+++ b/packages/cli/rosidl-codegen/src/generator/common.rs
@@ -1,6 +1,9 @@
 use crate::{
     config::{CapacityResolver, FieldKind as CapFieldKind, FieldStorage, StorageMode},
-    templates::{CField, CppFfiField, CppField, FieldKind, NrosField, RmwField, SequenceStructDef},
+    templates::{
+        CField, CppFfiField, CppField, FieldKind, IdiomaticField, NrosField, RmwField,
+        SequenceStructDef,
+    },
     types::{
         C_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_SEQUENCE_CAPACITY, CPP_DEFAULT_STRING_CAPACITY,
         NrosCodegenMode, c_cdr_read_method, c_cdr_write_method, c_type_for_field_heap,
@@ -210,66 +213,121 @@ fn c_borrowed_view_for_field(
     }
 }
 
-/// Determine the exhaustive FieldKind enum variant for a given ROS 2 field type
-/// This function provides compile-time guarantees that all field type combinations are handled
-pub(crate) fn determine_field_kind(field_type: &FieldType) -> FieldKind {
-    match field_type {
-        // Scalar types
-        FieldType::Primitive(_) => FieldKind::Primitive,
+/// One string shape, as the idiomatic pack's `FieldKind` splits it: narrow or
+/// wide, `.msg`-bounded or not.
+///
+/// The lowered IR deliberately models NONE of this — `FieldShape::Str` and
+/// `CdrOp::String` are one variant each, because the C, C++, nros and rmw
+/// surfaces all spell a string off `field_type` and none of them branches on
+/// the flavour. Adding four variants to the shared IR for one pack's template
+/// conditionals would put a fact in every surface's context that four of them
+/// ignore, which is the inverse of what W2.5a is for. So this reads the IR's
+/// `field_type` and stays a per-surface FILTER — the same shape as `c_type`.
+#[derive(Clone, Copy)]
+enum StringFlavour {
+    Narrow,
+    NarrowBounded,
+    Wide,
+    WideBounded,
+}
 
-        FieldType::String => FieldKind::UnboundedString,
-        FieldType::BoundedString(_) => FieldKind::BoundedString,
+fn string_flavour(ft: &FieldType) -> Option<StringFlavour> {
+    match ft {
+        FieldType::String => Some(StringFlavour::Narrow),
+        FieldType::BoundedString(_) => Some(StringFlavour::NarrowBounded),
+        FieldType::WString => Some(StringFlavour::Wide),
+        FieldType::BoundedWString(_) => Some(StringFlavour::WideBounded),
+        _ => None,
+    }
+}
 
-        FieldType::WString => FieldKind::UnboundedWString,
-        FieldType::BoundedWString(_) => FieldKind::BoundedWString,
+/// The idiomatic Rust pack's exhaustive field classification, projected from
+/// the lowered IR (phase-432 W2.5a).
+///
+/// The STRUCTURAL spine — scalar / string / array / sequence / nested, the
+/// array length, and what the element is — comes from `LoweredField::shape` and
+/// the element accessors, which is where the IR states those facts. Only the
+/// two questions the IR does not model are answered off `field_type`: the
+/// string flavour (see [`StringFlavour`]) and whether a sequence's bound came
+/// from the `.msg` (`FieldShape::Sequence` covers both `T[]` and `T[<=N]`,
+/// because storage is what every other surface asks about and both are
+/// `LoweredStorage::Bounded`).
+pub(crate) fn determine_field_kind(f: &rosidl_lower::LoweredField) -> FieldKind {
+    use rosidl_lower::FieldShape;
 
-        FieldType::NamespacedType { .. } => FieldKind::NestedMessage,
+    let element = element_type_of(&f.field_type);
+    match f.shape {
+        FieldShape::Scalar => FieldKind::Primitive,
+        FieldShape::Nested => FieldKind::NestedMessage,
 
-        // Array types
-        FieldType::Array { element_type, size } => {
-            // Arrays > 32 elements don't impl Copy/Clone in Rust
-            if *size > 32 {
-                return FieldKind::LargeArray;
-            }
+        FieldShape::Str => match string_flavour(&f.field_type) {
+            Some(StringFlavour::Narrow) => FieldKind::UnboundedString,
+            Some(StringFlavour::NarrowBounded) => FieldKind::BoundedString,
+            Some(StringFlavour::Wide) => FieldKind::UnboundedWString,
+            Some(StringFlavour::WideBounded) => FieldKind::BoundedWString,
+            // Unreachable: `FieldShape::Str` is set by exactly those four arms.
+            None => FieldKind::UnboundedString,
+        },
 
-            match element_type.as_ref() {
-                FieldType::Primitive(_) => FieldKind::PrimitiveArray,
-
-                FieldType::String => FieldKind::UnboundedStringArray,
-                FieldType::BoundedString(_) => FieldKind::BoundedStringArray,
-
-                FieldType::WString => FieldKind::UnboundedWStringArray,
-                FieldType::BoundedWString(_) => FieldKind::BoundedWStringArray,
-
-                _ => FieldKind::NestedMessageArray,
+        // Arrays > 32 elements don't impl Copy/Clone in Rust, so they are their
+        // own kind whatever the element is.
+        FieldShape::Array { len } if len > 32 => FieldKind::LargeArray,
+        FieldShape::Array { .. } => {
+            if f.element_is_primitive() {
+                FieldKind::PrimitiveArray
+            } else {
+                match element.and_then(string_flavour) {
+                    Some(StringFlavour::Narrow) => FieldKind::UnboundedStringArray,
+                    Some(StringFlavour::NarrowBounded) => FieldKind::BoundedStringArray,
+                    Some(StringFlavour::Wide) => FieldKind::UnboundedWStringArray,
+                    Some(StringFlavour::WideBounded) => FieldKind::BoundedWStringArray,
+                    None => FieldKind::NestedMessageArray,
+                }
             }
         }
 
-        // Bounded sequences (T[<=N])
-        FieldType::BoundedSequence { element_type, .. } => match element_type.as_ref() {
-            FieldType::Primitive(_) => FieldKind::BoundedPrimitiveSequence,
+        FieldShape::Sequence => {
+            // `T[<=N]` vs `T[]` — the one distinction `FieldShape::Sequence`
+            // does not carry.
+            let msg_bounded = matches!(f.field_type, FieldType::BoundedSequence { .. });
+            if f.element_is_primitive() {
+                return if msg_bounded {
+                    FieldKind::BoundedPrimitiveSequence
+                } else {
+                    FieldKind::UnboundedPrimitiveSequence
+                };
+            }
+            match (msg_bounded, element.and_then(string_flavour)) {
+                (true, Some(StringFlavour::Narrow)) => FieldKind::BoundedUnboundedStringSequence,
+                (true, Some(StringFlavour::NarrowBounded)) => {
+                    FieldKind::BoundedBoundedStringSequence
+                }
+                (true, Some(StringFlavour::Wide)) => FieldKind::BoundedUnboundedWStringSequence,
+                (true, Some(StringFlavour::WideBounded)) => {
+                    FieldKind::BoundedBoundedWStringSequence
+                }
+                (true, None) => FieldKind::BoundedNestedMessageSequence,
+                (false, Some(StringFlavour::Narrow)) => FieldKind::UnboundedUnboundedStringSequence,
+                (false, Some(StringFlavour::NarrowBounded)) => {
+                    FieldKind::UnboundedBoundedStringSequence
+                }
+                (false, Some(StringFlavour::Wide)) => FieldKind::UnboundedUnboundedWStringSequence,
+                (false, Some(StringFlavour::WideBounded)) => {
+                    FieldKind::UnboundedBoundedWStringSequence
+                }
+                (false, None) => FieldKind::UnboundedNestedMessageSequence,
+            }
+        }
+    }
+}
 
-            FieldType::String => FieldKind::BoundedUnboundedStringSequence,
-            FieldType::BoundedString(_) => FieldKind::BoundedBoundedStringSequence,
-
-            FieldType::WString => FieldKind::BoundedUnboundedWStringSequence,
-            FieldType::BoundedWString(_) => FieldKind::BoundedBoundedWStringSequence,
-
-            _ => FieldKind::BoundedNestedMessageSequence,
-        },
-
-        // Unbounded sequences (T[])
-        FieldType::Sequence { element_type } => match element_type.as_ref() {
-            FieldType::Primitive(_) => FieldKind::UnboundedPrimitiveSequence,
-
-            FieldType::String => FieldKind::UnboundedUnboundedStringSequence,
-            FieldType::BoundedString(_) => FieldKind::UnboundedBoundedStringSequence,
-
-            FieldType::WString => FieldKind::UnboundedUnboundedWStringSequence,
-            FieldType::BoundedWString(_) => FieldKind::UnboundedBoundedWStringSequence,
-
-            _ => FieldKind::UnboundedNestedMessageSequence,
-        },
+/// The element of an array or sequence, or `None` for a non-container.
+fn element_type_of(ft: &FieldType) -> Option<&FieldType> {
+    match ft {
+        FieldType::Array { element_type, .. }
+        | FieldType::Sequence { element_type }
+        | FieldType::BoundedSequence { element_type, .. } => Some(element_type.as_ref()),
+        _ => None,
     }
 }
 
@@ -633,6 +691,33 @@ pub(super) fn build_rmw_fields(
                 .as_ref()
                 .map(constant_value_to_rust)
                 .unwrap_or_default(),
+        })
+        .collect()
+}
+
+/// Build every idiomatic-Rust field of a message, projected from the lowered IR
+/// (phase-432 W2.5a).
+///
+/// The `rmw` surface plus one classification: `determine_field_kind`, which the
+/// pack branches on. Like `build_rmw_fields` it replaces three byte-identical
+/// closures that each mapped over `rosidl_parser`'s fields.
+pub(super) fn build_idiomatic_fields(
+    package_name: &str,
+    message_name: &str,
+    msg: &rosidl_parser::Message,
+) -> Vec<IdiomaticField> {
+    lowered_ros_abi_fields(package_name, message_name, &msg.fields)
+        .iter()
+        .map(|f| IdiomaticField {
+            name: escape_keyword(&f.name),
+            field_type: f.field_type.clone(),
+            current_package: package_name.to_string(),
+            default_value: f
+                .default_value
+                .as_ref()
+                .map(constant_value_to_rust)
+                .unwrap_or_default(),
+            kind: determine_field_kind(f),
         })
         .collect()
 }

--- a/packages/cli/rosidl-codegen/src/generator/cpp.rs
+++ b/packages/cli/rosidl-codegen/src/generator/cpp.rs
@@ -90,51 +90,17 @@ fn build_fields(
     let mut ffi_fields = Vec::new();
     let mut seq_structs = Vec::new();
 
-    // phase-335 W1.c — storage from the lowered IR (byte-identical), resolved once.
-    let store = super::common::lowered_storages(
-        current_package.unwrap_or(""),
-        message_name,
-        fields,
-        resolver,
-    );
-    super::common::ensure_element_caps_apply(
-        current_package.unwrap_or(""),
-        message_name,
-        fields,
-        resolver,
-    )?;
-    for (field, s) in fields.iter().zip(store.iter()) {
-        // phase-403 W7 — fold any configured ELEMENT bound into the shape, so the
-        // C++ container spells `nros::FixedString<32>` and the emitted struct
-        // holds what the derived bound claims. Both builders below read this.
-        let capped = resolver.element_capped(
-            current_package.unwrap_or(""),
-            message_name,
-            &field.name,
-            &field.field_type,
-        );
-        let field_type = capped.as_ref();
-        let storage = resolve_cap_override(
-            &field.name,
-            field_type,
-            current_package,
-            message_name,
-            resolver,
-            Some(*s),
-        )?;
-        cpp_fields.push(build_cpp_field(
-            &field.name,
-            field_type,
-            current_package,
-            storage,
-        ));
-        let (ffi_field, seq_struct) = build_cpp_ffi_field(
-            &field.name,
-            field_type,
-            struct_name,
-            current_package,
-            storage,
-        );
+    // phase-432 W2.5a — the lowered IR is the context both builders read: the
+    // storage decision (phase-335 W1.c had that much), and now the element-cap
+    // fold, the shape predicates and the element classification too.
+    let package = current_package.unwrap_or("");
+    let lowered = rosidl_lower::lower_fields(package, message_name, fields, resolver);
+    super::common::ensure_element_caps_apply(package, message_name, fields, resolver)?;
+    for field in &lowered {
+        let storage = resolve_cap_override(field, current_package, message_name)?;
+        cpp_fields.push(build_cpp_field(field, current_package, storage));
+        let (ffi_field, seq_struct) =
+            build_cpp_ffi_field(field, struct_name, current_package, storage);
         ffi_fields.push(ffi_field);
         if let Some(ss) = seq_struct {
             seq_structs.push(ss);

--- a/packages/cli/rosidl-codegen/src/generator/msg.rs
+++ b/packages/cli/rosidl-codegen/src/generator/msg.rs
@@ -1,6 +1,6 @@
 use super::common::{
     GeneratorError, SchemaCaps, build_c_fields, build_nros_fields, build_nros_message_schema,
-    determine_field_kind,
+    build_rmw_fields, determine_field_kind,
 };
 use crate::{
     config::CapacityResolver,
@@ -69,21 +69,9 @@ pub fn generate_message_package(
     let lib_rs = crate::render::render("lib.rs", &lib_rs_template)
         .map_err(|e| GeneratorError::RenderError(e.to_string()))?;
 
-    // Generate RMW layer message
-    let rmw_fields: Vec<RmwField> = message
-        .fields
-        .iter()
-        .map(|f| RmwField {
-            name: escape_keyword(&f.name),
-            field_type: f.field_type.clone(),
-            current_package: package_name.to_string(),
-            default_value: f
-                .default_value
-                .as_ref()
-                .map(constant_value_to_rust)
-                .unwrap_or_default(),
-        })
-        .collect();
+    // Generate RMW layer message — projected from the lowered IR (phase-432
+    // W2.5a); this used to map over `message.fields` directly.
+    let rmw_fields: Vec<RmwField> = build_rmw_fields(package_name, message_name, message);
 
     let rmw_constants: Vec<MessageConstant> = message
         .constants

--- a/packages/cli/rosidl-codegen/src/generator/msg.rs
+++ b/packages/cli/rosidl-codegen/src/generator/msg.rs
@@ -1,6 +1,6 @@
 use super::common::{
-    GeneratorError, SchemaCaps, build_c_fields, build_nros_fields, build_nros_message_schema,
-    build_rmw_fields, determine_field_kind,
+    GeneratorError, SchemaCaps, build_c_fields, build_idiomatic_fields, build_nros_fields,
+    build_nros_message_schema, build_rmw_fields,
 };
 use crate::{
     config::CapacityResolver,
@@ -11,8 +11,8 @@ use crate::{
         RmwField,
     },
     types::{
-        NrosCodegenMode, c_type_for_constant, constant_value_to_rust, escape_keyword,
-        nros_type_for_constant, rust_type_for_constant, to_c_package_name,
+        NrosCodegenMode, c_type_for_constant, constant_value_to_rust, nros_type_for_constant,
+        rust_type_for_constant, to_c_package_name,
     },
     utils::{extract_dependencies, needs_big_array, to_snake_case},
 };
@@ -96,22 +96,10 @@ pub fn generate_message_package(
     let message_rmw = crate::render::render("message_rmw.rs", &message_rmw_template)
         .map_err(|e| GeneratorError::RenderError(e.to_string()))?;
 
-    // Generate idiomatic layer message
-    let idiomatic_fields: Vec<IdiomaticField> = message
-        .fields
-        .iter()
-        .map(|f| IdiomaticField {
-            name: escape_keyword(&f.name),
-            field_type: f.field_type.clone(),
-            current_package: package_name.to_string(),
-            default_value: f
-                .default_value
-                .as_ref()
-                .map(constant_value_to_rust)
-                .unwrap_or_default(),
-            kind: determine_field_kind(&f.field_type),
-        })
-        .collect();
+    // Generate idiomatic layer message — projected from the lowered IR
+    // (phase-432 W2.5a); this used to map over `message.fields` directly.
+    let idiomatic_fields: Vec<IdiomaticField> =
+        build_idiomatic_fields(package_name, message_name, message);
 
     let idiomatic_constants: Vec<MessageConstant> = message
         .constants

--- a/packages/cli/rosidl-codegen/src/generator/srv.rs
+++ b/packages/cli/rosidl-codegen/src/generator/srv.rs
@@ -1,18 +1,18 @@
 use super::common::{
-    GeneratorError, PayloadLang, SchemaCaps, build_c_fields, build_nros_fields,
-    build_nros_schema_for_struct, build_rmw_fields, determine_field_kind,
+    GeneratorError, PayloadLang, SchemaCaps, build_c_fields, build_idiomatic_fields,
+    build_nros_fields, build_nros_schema_for_struct, build_rmw_fields,
     ensure_supported_storage_for_payload,
 };
 use crate::{
     config::CapacityResolver,
     templates::{
-        BuildRsTemplate, CConstant, CargoNrosTomlTemplate, CargoTomlTemplate, IdiomaticField,
-        LibNrosRsTemplate, LibRsTemplate, MessageConstant, ServiceCHeaderTemplate,
-        ServiceCSourceTemplate, ServiceIdiomaticTemplate, ServiceNrosTemplate, ServiceRmwTemplate,
+        BuildRsTemplate, CConstant, CargoNrosTomlTemplate, CargoTomlTemplate, LibNrosRsTemplate,
+        LibRsTemplate, MessageConstant, ServiceCHeaderTemplate, ServiceCSourceTemplate,
+        ServiceIdiomaticTemplate, ServiceNrosTemplate, ServiceRmwTemplate,
     },
     types::{
-        NrosCodegenMode, c_type_for_constant, constant_value_to_rust, escape_keyword,
-        nros_type_for_constant, rust_type_for_constant, to_c_package_name,
+        NrosCodegenMode, c_type_for_constant, constant_value_to_rust, nros_type_for_constant,
+        rust_type_for_constant, to_c_package_name,
     },
     utils::{extract_dependencies, needs_big_array, to_snake_case},
 };
@@ -80,22 +80,8 @@ pub fn generate_service_package(
     let message_to_rmw_fields =
         |member: &str, msg: &Message| build_rmw_fields(package_name, member, msg);
 
-    let message_to_idiomatic_fields = |msg: &Message| {
-        msg.fields
-            .iter()
-            .map(|f| IdiomaticField {
-                name: escape_keyword(&f.name),
-                field_type: f.field_type.clone(),
-                current_package: package_name.to_string(),
-                default_value: f
-                    .default_value
-                    .as_ref()
-                    .map(constant_value_to_rust)
-                    .unwrap_or_default(),
-                kind: determine_field_kind(&f.field_type),
-            })
-            .collect()
-    };
+    let message_to_idiomatic_fields =
+        |member: &str, msg: &Message| build_idiomatic_fields(package_name, member, msg);
 
     let message_to_constants = |msg: &Message, _rmw_layer: bool| {
         msg.constants
@@ -125,9 +111,9 @@ pub fn generate_service_package(
     let service_idiomatic_template = ServiceIdiomaticTemplate {
         package_name,
         service_name,
-        request_fields: message_to_idiomatic_fields(&service.request),
+        request_fields: message_to_idiomatic_fields(&request_member, &service.request),
         request_constants: message_to_constants(&service.request, false),
-        response_fields: message_to_idiomatic_fields(&service.response),
+        response_fields: message_to_idiomatic_fields(&response_member, &service.response),
         response_constants: message_to_constants(&service.response, false),
     };
     let service_idiomatic =

--- a/packages/cli/rosidl-codegen/src/generator/srv.rs
+++ b/packages/cli/rosidl-codegen/src/generator/srv.rs
@@ -1,12 +1,13 @@
 use super::common::{
     GeneratorError, PayloadLang, SchemaCaps, build_c_fields, build_nros_fields,
-    build_nros_schema_for_struct, determine_field_kind, ensure_supported_storage_for_payload,
+    build_nros_schema_for_struct, build_rmw_fields, determine_field_kind,
+    ensure_supported_storage_for_payload,
 };
 use crate::{
     config::CapacityResolver,
     templates::{
         BuildRsTemplate, CConstant, CargoNrosTomlTemplate, CargoTomlTemplate, IdiomaticField,
-        LibNrosRsTemplate, LibRsTemplate, MessageConstant, RmwField, ServiceCHeaderTemplate,
+        LibNrosRsTemplate, LibRsTemplate, MessageConstant, ServiceCHeaderTemplate,
         ServiceCSourceTemplate, ServiceIdiomaticTemplate, ServiceNrosTemplate, ServiceRmwTemplate,
     },
     types::{
@@ -71,22 +72,13 @@ pub fn generate_service_package(
     let lib_rs = crate::render::render("lib.rs", &lib_rs_template)
         .map_err(|e| GeneratorError::RenderError(e.to_string()))?;
 
-    // Helper functions to convert Message to field vectors
-    let message_to_rmw_fields = |msg: &Message| {
-        msg.fields
-            .iter()
-            .map(|f| RmwField {
-                name: escape_keyword(&f.name),
-                field_type: f.field_type.clone(),
-                current_package: package_name.to_string(),
-                default_value: f
-                    .default_value
-                    .as_ref()
-                    .map(constant_value_to_rust)
-                    .unwrap_or_default(),
-            })
-            .collect()
-    };
+    let request_member = format!("{service_name}_Request");
+    let response_member = format!("{service_name}_Response");
+    // phase-432 W2.5a — the two halves are lowered under their rosidl-convention
+    // member names (`<Svc>_Request` / `<Svc>_Response`), the same keys the nros
+    // and C paths use, so all three name one member the same way.
+    let message_to_rmw_fields =
+        |member: &str, msg: &Message| build_rmw_fields(package_name, member, msg);
 
     let message_to_idiomatic_fields = |msg: &Message| {
         msg.fields
@@ -120,9 +112,9 @@ pub fn generate_service_package(
     let service_rmw_template = ServiceRmwTemplate {
         package_name,
         service_name,
-        request_fields: message_to_rmw_fields(&service.request),
+        request_fields: message_to_rmw_fields(&request_member, &service.request),
         request_constants: message_to_constants(&service.request, true),
-        response_fields: message_to_rmw_fields(&service.response),
+        response_fields: message_to_rmw_fields(&response_member, &service.response),
         response_constants: message_to_constants(&service.response, true),
     };
     // RFC-0068 Stage 3 (phase-335 W3): rmw Rust service from the minijinja pack.

--- a/packages/cli/rosidl-codegen/src/types.rs
+++ b/packages/cli/rosidl-codegen/src/types.rs
@@ -1344,6 +1344,55 @@ pub fn c_type_for_constant(field_type: &FieldType) -> String {
     }
 }
 
+/// The C CDR writer for a lowered scalar op — `nros_cdr_<x>` in the C pack
+/// (phase-432 W2.5a).
+///
+/// A per-language SPELLING of a neutral fact, the C twin of
+/// `cdr_op_rust_method`. It replaces `c_cdr_write_method` at the C field
+/// builder, and the two agree by construction: `CdrOp` is exactly as coarse as
+/// this mapping — `Byte`, `Char` and `UInt8` all lower to `CdrOp::U8` and all
+/// three spelled `"write_u8"`.
+///
+/// `String` and `Nested` are not scalars and reach this only through a caller
+/// that ignored `scalar_op` / `element_is_primitive`; they map to the empty
+/// string, which renders as no method rather than a wrong one.
+pub fn c_cdr_write_method_for_op(op: rosidl_lower::CdrOp) -> &'static str {
+    use rosidl_lower::CdrOp;
+    match op {
+        CdrOp::Bool => "write_bool",
+        CdrOp::U8 => "write_u8",
+        CdrOp::I8 => "write_i8",
+        CdrOp::U16 => "write_u16",
+        CdrOp::I16 => "write_i16",
+        CdrOp::U32 => "write_u32",
+        CdrOp::I32 => "write_i32",
+        CdrOp::U64 => "write_u64",
+        CdrOp::I64 => "write_i64",
+        CdrOp::F32 => "write_f32",
+        CdrOp::F64 => "write_f64",
+        CdrOp::String | CdrOp::Nested => "",
+    }
+}
+
+/// The C CDR reader for a lowered scalar op — see [`c_cdr_write_method_for_op`].
+pub fn c_cdr_read_method_for_op(op: rosidl_lower::CdrOp) -> &'static str {
+    use rosidl_lower::CdrOp;
+    match op {
+        CdrOp::Bool => "read_bool",
+        CdrOp::U8 => "read_u8",
+        CdrOp::I8 => "read_i8",
+        CdrOp::U16 => "read_u16",
+        CdrOp::I16 => "read_i16",
+        CdrOp::U32 => "read_u32",
+        CdrOp::I32 => "read_i32",
+        CdrOp::U64 => "read_u64",
+        CdrOp::I64 => "read_i64",
+        CdrOp::F32 => "read_f32",
+        CdrOp::F64 => "read_f64",
+        CdrOp::String | CdrOp::Nested => "",
+    }
+}
+
 /// Get the CDR write method name for a C primitive type
 pub fn c_cdr_write_method(prim: &rosidl_parser::PrimitiveType) -> &'static str {
     use rosidl_parser::PrimitiveType;

--- a/packages/cli/rosidl-codegen/src/types.rs
+++ b/packages/cli/rosidl-codegen/src/types.rs
@@ -1393,46 +1393,6 @@ pub fn c_cdr_read_method_for_op(op: rosidl_lower::CdrOp) -> &'static str {
     }
 }
 
-/// Get the CDR write method name for a C primitive type
-pub fn c_cdr_write_method(prim: &rosidl_parser::PrimitiveType) -> &'static str {
-    use rosidl_parser::PrimitiveType;
-    match prim {
-        PrimitiveType::Bool => "write_bool",
-        PrimitiveType::Byte => "write_u8",
-        PrimitiveType::Char => "write_u8",
-        PrimitiveType::Int8 => "write_i8",
-        PrimitiveType::Int16 => "write_i16",
-        PrimitiveType::Int32 => "write_i32",
-        PrimitiveType::Int64 => "write_i64",
-        PrimitiveType::UInt8 => "write_u8",
-        PrimitiveType::UInt16 => "write_u16",
-        PrimitiveType::UInt32 => "write_u32",
-        PrimitiveType::UInt64 => "write_u64",
-        PrimitiveType::Float32 => "write_f32",
-        PrimitiveType::Float64 => "write_f64",
-    }
-}
-
-/// Get the CDR read method name for a C primitive type
-pub fn c_cdr_read_method(prim: &rosidl_parser::PrimitiveType) -> &'static str {
-    use rosidl_parser::PrimitiveType;
-    match prim {
-        PrimitiveType::Bool => "read_bool",
-        PrimitiveType::Byte => "read_u8",
-        PrimitiveType::Char => "read_u8",
-        PrimitiveType::Int8 => "read_i8",
-        PrimitiveType::Int16 => "read_i16",
-        PrimitiveType::Int32 => "read_i32",
-        PrimitiveType::Int64 => "read_i64",
-        PrimitiveType::UInt8 => "read_u8",
-        PrimitiveType::UInt16 => "read_u16",
-        PrimitiveType::UInt32 => "read_u32",
-        PrimitiveType::UInt64 => "read_u64",
-        PrimitiveType::Float32 => "read_f32",
-        PrimitiveType::Float64 => "read_f64",
-    }
-}
-
 // ============================================================================
 // C++ Type Mapping (for nros-cpp)
 // ============================================================================

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Bounded.idiomatic.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Bounded.idiomatic.rs
@@ -1,0 +1,174 @@
+// emit:ok
+// Idiomatic Rust layer - user-friendly types
+// Package: fingerprint-corpus
+// Message: Bounded
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Bounded {
+    
+    
+    pub flag: bool,
+    
+    
+    
+    pub wide: i64,
+    
+    
+    
+    pub narrow: u8,
+    
+    
+    
+    pub d: f64,
+    
+    
+    
+    pub label: std::string::String,
+    
+    
+    
+    pub fixed: [i32; 4],
+    
+    
+    
+    pub labels: std::vec::Vec<std::string::String>,
+    
+    
+}
+
+impl Bounded {
+    
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Bounded {
+    fn default() -> Self {
+        // Leverage RMW message's C init function to get correct default values
+        <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::msg::rmw::Bounded::default())
+    }
+}
+
+// Reference-based conversions (idiomatic ↔ RMW)
+impl From<&Bounded> for crate::msg::rmw::Bounded {
+    #[allow(unused_variables)]
+    fn from(idiomatic: &Bounded) -> Self {
+        Self {
+            
+            
+            // Primitives are Copy, just copy the value
+            flag: idiomatic.flag,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            wide: idiomatic.wide,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            narrow: idiomatic.narrow,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            d: idiomatic.d,
+            
+            
+            
+            // String → rosidl_runtime_rs::BoundedString<N> (use try_from)
+            label: crate::rosidl_runtime_rs::BoundedString::try_from(idiomatic.label.as_str()).unwrap(),
+            
+            
+            
+            // [primitive; N] arrays can be cloned directly
+            fixed: idiomatic.fixed.clone(),
+            
+            
+            
+            // Vec<String> → BoundedSequence<rosidl_runtime_rs::BoundedString<N>> (use try_from)
+            labels: crate::rosidl_runtime_rs::BoundedSequence::try_from(
+                idiomatic.labels.iter().map(|item| crate::rosidl_runtime_rs::BoundedString::try_from(item.as_str()).unwrap()).collect::<Vec<_>>()
+            ).unwrap(),
+            
+            
+        }
+    }
+}
+
+impl From<&crate::msg::rmw::Bounded> for Bounded {
+    #[allow(unused_variables)]
+    fn from(rmw: &crate::msg::rmw::Bounded) -> Self {
+        Self {
+            
+            
+            // Primitives are Copy, just copy the value
+            flag: rmw.flag,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            wide: rmw.wide,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            narrow: rmw.narrow,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            d: rmw.d,
+            
+            
+            
+            // rosidl_runtime_rs::BoundedString<N> → String
+            label: rmw.label.to_string(),
+            
+            
+            
+            // [primitive; N] arrays can be cloned directly
+            fixed: rmw.fixed.clone(),
+            
+            
+            
+            // BoundedSequence<rosidl_runtime_rs::BoundedString<N>> → Vec<String>
+            labels: rmw.labels.as_slice().iter().map(|item| item.to_string()).collect(),
+            
+            
+        }
+    }
+}
+
+// Owned conversions delegate to reference-based ones
+impl From<crate::msg::rmw::Bounded> for Bounded {
+    fn from(rmw: crate::msg::rmw::Bounded) -> Self {
+        Self::from(&rmw)
+    }
+}
+
+impl From<Bounded> for crate::msg::rmw::Bounded {
+    fn from(idiomatic: Bounded) -> Self {
+        Self::from(&idiomatic)
+    }
+}
+
+// Message trait implementation for rosidl_runtime_rs
+impl crate::rosidl_runtime_rs::Message for Bounded {
+    type RmwMsg = crate::msg::rmw::Bounded;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Convert from idiomatic to RMW format
+        std::borrow::Cow::Owned(msg_cow.into_owned().into())
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Convert from RMW to idiomatic format
+        msg.into()
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Bounded.rmw.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Bounded.rmw.rs
@@ -1,0 +1,109 @@
+// emit:ok
+// RMW (ROS Middleware) layer - C-compatible FFI types
+// Package: fingerprint-corpus
+// Message: Bounded
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+
+
+// FFI bindings to C libraries
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Bounded() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__msg__Bounded__init(msg: *mut Bounded) -> bool;
+    fn fingerprint-corpus__msg__Bounded__Sequence__init(seq: *mut crate::rosidl_runtime_rs::Sequence<Bounded>, size: usize) -> bool;
+    fn fingerprint-corpus__msg__Bounded__Sequence__fini(seq: *mut crate::rosidl_runtime_rs::Sequence<Bounded>);
+    fn fingerprint-corpus__msg__Bounded__Sequence__copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Bounded>, out_seq: *mut crate::rosidl_runtime_rs::Sequence<Bounded>) -> bool;
+}
+
+// RMW types are C-compatible FFI types
+// Serde support is available via the "serde" feature flag
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bounded {
+    
+    pub flag: bool,
+    
+    pub wide: i64,
+    
+    pub narrow: u8,
+    
+    pub d: f64,
+    
+    pub label: crate::rosidl_runtime_rs::BoundedString<8>,
+    
+    pub fixed: [i32; 4],
+    
+    pub labels: crate::rosidl_runtime_rs::BoundedSequence<crate::rosidl_runtime_rs::BoundedString<8>, 4>,
+    
+}
+
+impl Bounded {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Bounded {
+    fn default() -> Self {
+        unsafe {
+            // SAFETY: Zeroing a message structure is valid for all ROS message types
+            let mut msg = std::mem::zeroed();
+            // SAFETY: The init function is safe to call on a zeroed message
+            if !fingerprint-corpus__msg__Bounded__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__msg__Bounded__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+// Trait implementations for ROS runtime
+
+impl crate::rosidl_runtime_rs::SequenceAlloc for Bounded {
+    fn sequence_init(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Bounded__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Bounded__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Self>, out_seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) -> bool {
+        // SAFETY: Both pointers are guaranteed to be valid since they come from references
+        unsafe { fingerprint-corpus__msg__Bounded__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl crate::rosidl_runtime_rs::Message for Bounded {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Identity conversion: RMW message is already in RMW format
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Identity conversion: RMW message is already in RMW format
+        msg
+    }
+}
+
+impl crate::rosidl_runtime_rs::RmwMessage for Bounded where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/msg/Bounded";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Bounded() }
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Capped.idiomatic.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Capped.idiomatic.rs
@@ -1,0 +1,118 @@
+// emit:ok
+// Idiomatic Rust layer - user-friendly types
+// Package: fingerprint-corpus
+// Message: Capped
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Capped {
+    
+    
+    pub label: std::string::String,
+    
+    
+    
+    pub samples: std::vec::Vec<i64>,
+    
+    
+    
+    pub tags: std::vec::Vec<std::string::String>,
+    
+    
+}
+
+impl Capped {
+    
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Capped {
+    fn default() -> Self {
+        // Leverage RMW message's C init function to get correct default values
+        <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::msg::rmw::Capped::default())
+    }
+}
+
+// Reference-based conversions (idiomatic ↔ RMW)
+impl From<&Capped> for crate::msg::rmw::Capped {
+    #[allow(unused_variables)]
+    fn from(idiomatic: &Capped) -> Self {
+        Self {
+            
+            
+            // String → rosidl_runtime_rs::String (use rosidl_runtime_rs 0.5 API)
+            label: crate::rosidl_runtime_rs::String::from(idiomatic.label.as_str()),
+            
+            
+            
+            // Vec<primitive> → Sequence<primitive> (use rosidl_runtime_rs 0.5 API)
+            samples: crate::rosidl_runtime_rs::Sequence::from(idiomatic.samples.clone()),
+            
+            
+            
+            // Vec<String> → Sequence<rosidl_runtime_rs::String>
+            tags: crate::rosidl_runtime_rs::Sequence::from(
+                idiomatic.tags.iter().map(|item| crate::rosidl_runtime_rs::String::from(item.as_str())).collect::<Vec<_>>()
+            ),
+            
+            
+        }
+    }
+}
+
+impl From<&crate::msg::rmw::Capped> for Capped {
+    #[allow(unused_variables)]
+    fn from(rmw: &crate::msg::rmw::Capped) -> Self {
+        Self {
+            
+            
+            // rosidl_runtime_rs::String → String (use rosidl_runtime_rs 0.5 API)
+            label: rmw.label.to_string(),
+            
+            
+            
+            // Sequence<primitive> → Vec<primitive> (use rosidl_runtime_rs 0.5 API)
+            samples: rmw.samples.as_slice().to_vec(),
+            
+            
+            
+            // Sequence<rosidl_runtime_rs::String> → Vec<String>
+            tags: rmw.tags.as_slice().iter().map(|item| item.to_string()).collect(),
+            
+            
+        }
+    }
+}
+
+// Owned conversions delegate to reference-based ones
+impl From<crate::msg::rmw::Capped> for Capped {
+    fn from(rmw: crate::msg::rmw::Capped) -> Self {
+        Self::from(&rmw)
+    }
+}
+
+impl From<Capped> for crate::msg::rmw::Capped {
+    fn from(idiomatic: Capped) -> Self {
+        Self::from(&idiomatic)
+    }
+}
+
+// Message trait implementation for rosidl_runtime_rs
+impl crate::rosidl_runtime_rs::Message for Capped {
+    type RmwMsg = crate::msg::rmw::Capped;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Convert from idiomatic to RMW format
+        std::borrow::Cow::Owned(msg_cow.into_owned().into())
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Convert from RMW to idiomatic format
+        msg.into()
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Capped.rmw.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Capped.rmw.rs
@@ -1,0 +1,101 @@
+// emit:ok
+// RMW (ROS Middleware) layer - C-compatible FFI types
+// Package: fingerprint-corpus
+// Message: Capped
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+
+
+// FFI bindings to C libraries
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Capped() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__msg__Capped__init(msg: *mut Capped) -> bool;
+    fn fingerprint-corpus__msg__Capped__Sequence__init(seq: *mut crate::rosidl_runtime_rs::Sequence<Capped>, size: usize) -> bool;
+    fn fingerprint-corpus__msg__Capped__Sequence__fini(seq: *mut crate::rosidl_runtime_rs::Sequence<Capped>);
+    fn fingerprint-corpus__msg__Capped__Sequence__copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Capped>, out_seq: *mut crate::rosidl_runtime_rs::Sequence<Capped>) -> bool;
+}
+
+// RMW types are C-compatible FFI types
+// Serde support is available via the "serde" feature flag
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Capped {
+    
+    pub label: crate::rosidl_runtime_rs::String,
+    
+    pub samples: crate::rosidl_runtime_rs::Sequence<i64>,
+    
+    pub tags: crate::rosidl_runtime_rs::Sequence<crate::rosidl_runtime_rs::String>,
+    
+}
+
+impl Capped {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Capped {
+    fn default() -> Self {
+        unsafe {
+            // SAFETY: Zeroing a message structure is valid for all ROS message types
+            let mut msg = std::mem::zeroed();
+            // SAFETY: The init function is safe to call on a zeroed message
+            if !fingerprint-corpus__msg__Capped__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__msg__Capped__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+// Trait implementations for ROS runtime
+
+impl crate::rosidl_runtime_rs::SequenceAlloc for Capped {
+    fn sequence_init(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Capped__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Capped__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Self>, out_seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) -> bool {
+        // SAFETY: Both pointers are guaranteed to be valid since they come from references
+        unsafe { fingerprint-corpus__msg__Capped__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl crate::rosidl_runtime_rs::Message for Capped {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Identity conversion: RMW message is already in RMW format
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Identity conversion: RMW message is already in RMW format
+        msg
+    }
+}
+
+impl crate::rosidl_runtime_rs::RmwMessage for Capped where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/msg/Capped";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Capped() }
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Nested.idiomatic.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Nested.idiomatic.rs
@@ -1,0 +1,104 @@
+// emit:ok
+// Idiomatic Rust layer - user-friendly types
+// Package: fingerprint-corpus
+// Message: Nested
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Nested {
+    
+    
+    pub one: crate::msg::Shapes,
+    
+    
+    
+    pub many: std::vec::Vec<crate::msg::Shapes>,
+    
+    
+}
+
+impl Nested {
+    
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Nested {
+    fn default() -> Self {
+        // Leverage RMW message's C init function to get correct default values
+        <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::msg::rmw::Nested::default())
+    }
+}
+
+// Reference-based conversions (idiomatic ↔ RMW)
+impl From<&Nested> for crate::msg::rmw::Nested {
+    #[allow(unused_variables)]
+    fn from(idiomatic: &Nested) -> Self {
+        Self {
+            
+            
+            // Nested messages need reference conversion
+            one: (&idiomatic.one).into(),
+            
+            
+            
+            // Vec → Sequence conversion with element conversion for nested messages
+            many: crate::rosidl_runtime_rs::Sequence::from(
+                idiomatic.many.iter().map(|item| item.into()).collect::<Vec<_>>()
+            ),
+            
+            
+        }
+    }
+}
+
+impl From<&crate::msg::rmw::Nested> for Nested {
+    #[allow(unused_variables)]
+    fn from(rmw: &crate::msg::rmw::Nested) -> Self {
+        Self {
+            
+            
+            // Nested messages need reference conversion
+            one: (&rmw.one).into(),
+            
+            
+            
+            // Sequence → Vec conversion with element conversion for nested messages
+            many: rmw.many.as_slice().iter().map(|item| item.into()).collect(),
+            
+            
+        }
+    }
+}
+
+// Owned conversions delegate to reference-based ones
+impl From<crate::msg::rmw::Nested> for Nested {
+    fn from(rmw: crate::msg::rmw::Nested) -> Self {
+        Self::from(&rmw)
+    }
+}
+
+impl From<Nested> for crate::msg::rmw::Nested {
+    fn from(idiomatic: Nested) -> Self {
+        Self::from(&idiomatic)
+    }
+}
+
+// Message trait implementation for rosidl_runtime_rs
+impl crate::rosidl_runtime_rs::Message for Nested {
+    type RmwMsg = crate::msg::rmw::Nested;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Convert from idiomatic to RMW format
+        std::borrow::Cow::Owned(msg_cow.into_owned().into())
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Convert from RMW to idiomatic format
+        msg.into()
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Nested.rmw.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Nested.rmw.rs
@@ -1,0 +1,99 @@
+// emit:ok
+// RMW (ROS Middleware) layer - C-compatible FFI types
+// Package: fingerprint-corpus
+// Message: Nested
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+
+
+// FFI bindings to C libraries
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Nested() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__msg__Nested__init(msg: *mut Nested) -> bool;
+    fn fingerprint-corpus__msg__Nested__Sequence__init(seq: *mut crate::rosidl_runtime_rs::Sequence<Nested>, size: usize) -> bool;
+    fn fingerprint-corpus__msg__Nested__Sequence__fini(seq: *mut crate::rosidl_runtime_rs::Sequence<Nested>);
+    fn fingerprint-corpus__msg__Nested__Sequence__copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Nested>, out_seq: *mut crate::rosidl_runtime_rs::Sequence<Nested>) -> bool;
+}
+
+// RMW types are C-compatible FFI types
+// Serde support is available via the "serde" feature flag
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Nested {
+    
+    pub one: crate::msg::rmw::Shapes,
+    
+    pub many: crate::rosidl_runtime_rs::Sequence<crate::msg::rmw::Shapes>,
+    
+}
+
+impl Nested {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Nested {
+    fn default() -> Self {
+        unsafe {
+            // SAFETY: Zeroing a message structure is valid for all ROS message types
+            let mut msg = std::mem::zeroed();
+            // SAFETY: The init function is safe to call on a zeroed message
+            if !fingerprint-corpus__msg__Nested__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__msg__Nested__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+// Trait implementations for ROS runtime
+
+impl crate::rosidl_runtime_rs::SequenceAlloc for Nested {
+    fn sequence_init(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Nested__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Nested__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Self>, out_seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) -> bool {
+        // SAFETY: Both pointers are guaranteed to be valid since they come from references
+        unsafe { fingerprint-corpus__msg__Nested__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl crate::rosidl_runtime_rs::Message for Nested {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Identity conversion: RMW message is already in RMW format
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Identity conversion: RMW message is already in RMW format
+        msg
+    }
+}
+
+impl crate::rosidl_runtime_rs::RmwMessage for Nested where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/msg/Nested";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Nested() }
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.action.idiomatic.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.action.idiomatic.rs
@@ -1,0 +1,320 @@
+// emit:ok
+// Idiomatic Rust layer - user-friendly types
+// Package: fingerprint-corpus
+// Action: Probe
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// Goal message
+pub mod goal {
+    #[cfg(feature = "serde")]
+    use super::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct ProbeGoal {
+        
+        pub waypoints: std::vec::Vec<i64>,
+        
+        pub name: std::string::String,
+        
+    }
+
+    impl ProbeGoal {
+        
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl Default for ProbeGoal {
+        fn default() -> Self {
+            // Leverage FFI message's C init function to get correct default values
+            <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::action::rmw::ProbeGoal::default())
+        }
+    }
+
+    // Conversion from FFI layer
+    impl From<crate::action::rmw::ProbeGoal> for ProbeGoal {
+        #[allow(unused_variables)]
+        fn from(rmw: crate::action::rmw::ProbeGoal) -> Self {
+            Self {
+                
+                
+                waypoints: rmw.waypoints.as_slice().to_vec(),
+                
+                
+                
+                name: rmw.name.to_string(),
+                
+                
+            }
+        }
+    }
+
+    // Conversion to FFI layer
+    impl From<ProbeGoal> for crate::action::rmw::ProbeGoal {
+        #[allow(unused_variables)]
+        fn from(idiomatic: ProbeGoal) -> Self {
+            Self {
+                
+                
+                waypoints: crate::rosidl_runtime_rs::Sequence::from(idiomatic.waypoints.clone()),
+                
+                
+                
+                name: crate::rosidl_runtime_rs::String::from(idiomatic.name.as_str()),
+                
+                
+            }
+        }
+    }
+
+    // Message trait implementation for rosidl_runtime_rs
+    impl crate::rosidl_runtime_rs::Message for ProbeGoal {
+        type RmwMsg = crate::action::rmw::ProbeGoal;
+
+        fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            std::borrow::Cow::Owned(msg_cow.into_owned().into())
+        }
+
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg.into()
+        }
+    }
+}
+
+// Result message
+pub mod result {
+    #[cfg(feature = "serde")]
+    use super::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct ProbeResult {
+        
+        pub total: i64,
+        
+        pub report: std::string::String,
+        
+    }
+
+    impl ProbeResult {
+        
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl Default for ProbeResult {
+        fn default() -> Self {
+            <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::action::rmw::ProbeResult::default())
+        }
+    }
+
+    impl From<crate::action::rmw::ProbeResult> for ProbeResult {
+        #[allow(unused_variables)]
+        fn from(rmw: crate::action::rmw::ProbeResult) -> Self {
+            Self {
+                
+                
+                total: rmw.total,
+                
+                
+                
+                report: rmw.report.to_string(),
+                
+                
+            }
+        }
+    }
+
+    impl From<ProbeResult> for crate::action::rmw::ProbeResult {
+        #[allow(unused_variables)]
+        fn from(idiomatic: ProbeResult) -> Self {
+            Self {
+                
+                
+                total: idiomatic.total,
+                
+                
+                
+                report: crate::rosidl_runtime_rs::String::from(idiomatic.report.as_str()),
+                
+                
+            }
+        }
+    }
+
+    impl crate::rosidl_runtime_rs::Message for ProbeResult {
+        type RmwMsg = crate::action::rmw::ProbeResult;
+
+        fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            std::borrow::Cow::Owned(msg_cow.into_owned().into())
+        }
+
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg.into()
+        }
+    }
+}
+
+// Feedback message
+pub mod feedback {
+    #[cfg(feature = "serde")]
+    use super::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct ProbeFeedback {
+        
+        pub done: i64,
+        
+        pub stage: std::string::String,
+        
+    }
+
+    impl ProbeFeedback {
+        
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl Default for ProbeFeedback {
+        fn default() -> Self {
+            <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::action::rmw::ProbeFeedback::default())
+        }
+    }
+
+    impl From<crate::action::rmw::ProbeFeedback> for ProbeFeedback {
+        #[allow(unused_variables)]
+        fn from(rmw: crate::action::rmw::ProbeFeedback) -> Self {
+            Self {
+                
+                
+                done: rmw.done,
+                
+                
+                
+                stage: rmw.stage.to_string(),
+                
+                
+            }
+        }
+    }
+
+    impl From<ProbeFeedback> for crate::action::rmw::ProbeFeedback {
+        #[allow(unused_variables)]
+        fn from(idiomatic: ProbeFeedback) -> Self {
+            Self {
+                
+                
+                done: idiomatic.done,
+                
+                
+                
+                stage: crate::rosidl_runtime_rs::String::from(idiomatic.stage.as_str()),
+                
+                
+            }
+        }
+    }
+
+    impl crate::rosidl_runtime_rs::Message for ProbeFeedback {
+        type RmwMsg = crate::action::rmw::ProbeFeedback;
+
+        fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            std::borrow::Cow::Owned(msg_cow.into_owned().into())
+        }
+
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            msg.into()
+        }
+    }
+}
+
+// Re-export for convenience
+pub use goal::ProbeGoal;
+pub use result::ProbeResult;
+pub use feedback::ProbeFeedback;
+
+// Action struct (zero-sized type)
+pub struct Probe;
+
+impl crate::rosidl_runtime_rs::Action for Probe {
+    type Goal = ProbeGoal;
+    type Result = ProbeResult;
+    type Feedback = ProbeFeedback;
+    type FeedbackMessage = crate::action::rmw::ProbeFeedbackMessage;
+    type SendGoalService = crate::action::rmw::Probe_SendGoal;
+    type GetResultService = crate::action::rmw::Probe_GetResult;
+    type CancelGoalService = action_msgs::srv::rmw::CancelGoal;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::get_type_support()
+    }
+
+    fn create_goal_request(
+        goal_id: &[u8; 16],
+        goal: crate::action::rmw::ProbeGoal,
+    ) -> crate::action::rmw::Probe_SendGoal_Request {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::create_goal_request(goal_id, goal)
+    }
+
+    fn split_goal_request(
+        request: crate::action::rmw::Probe_SendGoal_Request,
+    ) -> ([u8; 16], crate::action::rmw::ProbeGoal) {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::split_goal_request(request)
+    }
+
+    fn create_goal_response(
+        accepted: bool,
+        stamp: (i32, u32),
+    ) -> crate::action::rmw::Probe_SendGoal_Response {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::create_goal_response(accepted, stamp)
+    }
+
+    fn get_goal_response_accepted(response: &crate::action::rmw::Probe_SendGoal_Response) -> bool {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::get_goal_response_accepted(response)
+    }
+
+    fn get_goal_response_stamp(response: &crate::action::rmw::Probe_SendGoal_Response) -> (i32, u32) {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::get_goal_response_stamp(response)
+    }
+
+    fn create_feedback_message(
+        goal_id: &[u8; 16],
+        feedback: crate::action::rmw::ProbeFeedback,
+    ) -> crate::action::rmw::ProbeFeedbackMessage {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::create_feedback_message(goal_id, feedback)
+    }
+
+    fn split_feedback_message(
+        feedback: crate::action::rmw::ProbeFeedbackMessage,
+    ) -> ([u8; 16], crate::action::rmw::ProbeFeedback) {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::split_feedback_message(feedback)
+    }
+
+    fn create_result_request(goal_id: &[u8; 16]) -> crate::action::rmw::Probe_GetResult_Request {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::create_result_request(goal_id)
+    }
+
+    fn get_result_request_uuid(request: &crate::action::rmw::Probe_GetResult_Request) -> &[u8; 16] {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::get_result_request_uuid(request)
+    }
+
+    fn create_result_response(
+        status: i8,
+        result: crate::action::rmw::ProbeResult,
+    ) -> crate::action::rmw::Probe_GetResult_Response {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::create_result_response(status, result)
+    }
+
+    fn split_result_response(
+        response: crate::action::rmw::Probe_GetResult_Response,
+    ) -> (i8, crate::action::rmw::ProbeResult) {
+        <crate::action::rmw::Probe as crate::rosidl_runtime_rs::Action>::split_result_response(response)
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.action.rmw.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.action.rmw.rs
@@ -1,0 +1,757 @@
+// emit:ok
+// RMW (ROS Middleware) layer - C-compatible FFI types
+// Package: fingerprint-corpus
+// Action: Probe
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// Goal constants
+pub mod goal_constants {
+    
+}
+
+// Result constants
+pub mod result_constants {
+    
+}
+
+// Feedback constants
+pub mod feedback_constants {
+    
+}
+
+// FFI bindings to C libraries for Goal
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_Goal() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_Goal__init(msg: *mut ProbeGoal) -> bool;
+    fn fingerprint-corpus__action__Probe_Goal__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<ProbeGoal>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_Goal__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<ProbeGoal>);
+    fn fingerprint-corpus__action__Probe_Goal__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<ProbeGoal>, out_seq: *mut rosidl_runtime_rs::Sequence<ProbeGoal>) -> bool;
+}
+
+// Goal message type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeGoal {
+    
+    pub waypoints: crate::rosidl_runtime_rs::Sequence<i64>,
+    
+    pub name: crate::rosidl_runtime_rs::String,
+    
+}
+
+impl ProbeGoal {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ProbeGoal {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_Goal__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_Goal__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for ProbeGoal {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_Goal__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_Goal__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_Goal__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for ProbeGoal {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for ProbeGoal where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_Goal";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_Goal() }
+    }
+}
+
+// FFI bindings to C libraries for Result
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_Result() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_Result__init(msg: *mut ProbeResult) -> bool;
+    fn fingerprint-corpus__action__Probe_Result__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<ProbeResult>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_Result__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<ProbeResult>);
+    fn fingerprint-corpus__action__Probe_Result__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<ProbeResult>, out_seq: *mut rosidl_runtime_rs::Sequence<ProbeResult>) -> bool;
+}
+
+// Result message type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeResult {
+    
+    pub total: i64,
+    
+    pub report: crate::rosidl_runtime_rs::String,
+    
+}
+
+impl ProbeResult {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ProbeResult {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_Result__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_Result__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for ProbeResult {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_Result__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_Result__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_Result__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for ProbeResult {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for ProbeResult where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_Result";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_Result() }
+    }
+}
+
+// FFI bindings to C libraries for Feedback
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_Feedback() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_Feedback__init(msg: *mut ProbeFeedback) -> bool;
+    fn fingerprint-corpus__action__Probe_Feedback__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<ProbeFeedback>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_Feedback__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<ProbeFeedback>);
+    fn fingerprint-corpus__action__Probe_Feedback__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<ProbeFeedback>, out_seq: *mut rosidl_runtime_rs::Sequence<ProbeFeedback>) -> bool;
+}
+
+// Feedback message type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeFeedback {
+    
+    pub done: i64,
+    
+    pub stage: crate::rosidl_runtime_rs::String,
+    
+}
+
+impl ProbeFeedback {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ProbeFeedback {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_Feedback__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_Feedback__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for ProbeFeedback {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_Feedback__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_Feedback__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_Feedback__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for ProbeFeedback {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for ProbeFeedback where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_Feedback";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_Feedback() }
+    }
+}
+
+// FFI bindings to C libraries for FeedbackMessage
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_FeedbackMessage() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_FeedbackMessage__init(msg: *mut ProbeFeedbackMessage) -> bool;
+    fn fingerprint-corpus__action__Probe_FeedbackMessage__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<ProbeFeedbackMessage>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_FeedbackMessage__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<ProbeFeedbackMessage>);
+    fn fingerprint-corpus__action__Probe_FeedbackMessage__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<ProbeFeedbackMessage>, out_seq: *mut rosidl_runtime_rs::Sequence<ProbeFeedbackMessage>) -> bool;
+}
+
+// FeedbackMessage type (wraps feedback with goal UUID)
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeFeedbackMessage {
+    pub goal_id: unique_identifier_msgs::msg::rmw::UUID,
+    pub feedback: ProbeFeedback,
+}
+
+impl ProbeFeedbackMessage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ProbeFeedbackMessage {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_FeedbackMessage__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_FeedbackMessage__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for ProbeFeedbackMessage {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_FeedbackMessage__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_FeedbackMessage__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_FeedbackMessage__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for ProbeFeedbackMessage {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for ProbeFeedbackMessage where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_FeedbackMessage";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_FeedbackMessage() }
+    }
+}
+
+// FFI bindings to C libraries for SendGoal_Request
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_SendGoal_Request() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_SendGoal_Request__init(msg: *mut Probe_SendGoal_Request) -> bool;
+    fn fingerprint-corpus__action__Probe_SendGoal_Request__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<Probe_SendGoal_Request>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_SendGoal_Request__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Probe_SendGoal_Request>);
+    fn fingerprint-corpus__action__Probe_SendGoal_Request__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<Probe_SendGoal_Request>, out_seq: *mut rosidl_runtime_rs::Sequence<Probe_SendGoal_Request>) -> bool;
+}
+
+// SendGoal_Request type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Probe_SendGoal_Request {
+    pub goal_id: unique_identifier_msgs::msg::rmw::UUID,
+    pub goal: ProbeGoal,
+}
+
+impl Probe_SendGoal_Request {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Probe_SendGoal_Request {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_SendGoal_Request__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_SendGoal_Request__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for Probe_SendGoal_Request {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_SendGoal_Request__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_SendGoal_Request__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_SendGoal_Request__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for Probe_SendGoal_Request {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for Probe_SendGoal_Request where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_SendGoal_Request";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_SendGoal_Request() }
+    }
+}
+
+// FFI bindings to C libraries for SendGoal_Response
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_SendGoal_Response() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_SendGoal_Response__init(msg: *mut Probe_SendGoal_Response) -> bool;
+    fn fingerprint-corpus__action__Probe_SendGoal_Response__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<Probe_SendGoal_Response>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_SendGoal_Response__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Probe_SendGoal_Response>);
+    fn fingerprint-corpus__action__Probe_SendGoal_Response__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<Probe_SendGoal_Response>, out_seq: *mut rosidl_runtime_rs::Sequence<Probe_SendGoal_Response>) -> bool;
+}
+
+// SendGoal_Response type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Probe_SendGoal_Response {
+    pub accepted: bool,
+    pub stamp: builtin_interfaces::msg::rmw::Time,
+}
+
+impl Probe_SendGoal_Response {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Probe_SendGoal_Response {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_SendGoal_Response__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_SendGoal_Response__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for Probe_SendGoal_Response {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_SendGoal_Response__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_SendGoal_Response__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_SendGoal_Response__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for Probe_SendGoal_Response {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for Probe_SendGoal_Response where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_SendGoal_Response";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_SendGoal_Response() }
+    }
+}
+
+// SendGoal service type support
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__action__Probe_SendGoal() -> *const std::ffi::c_void;
+}
+
+// SendGoal service struct
+#[allow(non_camel_case_types)]
+pub struct Probe_SendGoal;
+
+impl rosidl_runtime_rs::Service for Probe_SendGoal {
+    type Request = Probe_SendGoal_Request;
+    type Response = Probe_SendGoal_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__action__Probe_SendGoal() }
+    }
+}
+
+// FFI bindings to C libraries for GetResult_Request
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_GetResult_Request() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_GetResult_Request__init(msg: *mut Probe_GetResult_Request) -> bool;
+    fn fingerprint-corpus__action__Probe_GetResult_Request__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<Probe_GetResult_Request>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_GetResult_Request__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Probe_GetResult_Request>);
+    fn fingerprint-corpus__action__Probe_GetResult_Request__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<Probe_GetResult_Request>, out_seq: *mut rosidl_runtime_rs::Sequence<Probe_GetResult_Request>) -> bool;
+}
+
+// GetResult_Request type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Probe_GetResult_Request {
+    pub goal_id: unique_identifier_msgs::msg::rmw::UUID,
+}
+
+impl Probe_GetResult_Request {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Probe_GetResult_Request {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_GetResult_Request__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_GetResult_Request__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for Probe_GetResult_Request {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_GetResult_Request__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_GetResult_Request__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_GetResult_Request__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for Probe_GetResult_Request {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for Probe_GetResult_Request where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_GetResult_Request";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_GetResult_Request() }
+    }
+}
+
+// FFI bindings to C libraries for GetResult_Response
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_GetResult_Response() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__action__Probe_GetResult_Response__init(msg: *mut Probe_GetResult_Response) -> bool;
+    fn fingerprint-corpus__action__Probe_GetResult_Response__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<Probe_GetResult_Response>, size: usize) -> bool;
+    fn fingerprint-corpus__action__Probe_GetResult_Response__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<Probe_GetResult_Response>);
+    fn fingerprint-corpus__action__Probe_GetResult_Response__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<Probe_GetResult_Response>, out_seq: *mut rosidl_runtime_rs::Sequence<Probe_GetResult_Response>) -> bool;
+}
+
+// GetResult_Response type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Probe_GetResult_Response {
+    pub status: i8,
+    pub result: ProbeResult,
+}
+
+impl Probe_GetResult_Response {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Probe_GetResult_Response {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__action__Probe_GetResult_Response__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__action__Probe_GetResult_Response__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for Probe_GetResult_Response {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_GetResult_Response__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__action__Probe_GetResult_Response__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__action__Probe_GetResult_Response__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for Probe_GetResult_Response {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for Probe_GetResult_Response where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/action/Probe_GetResult_Response";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__action__Probe_GetResult_Response() }
+    }
+}
+
+// GetResult service type support
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__action__Probe_GetResult() -> *const std::ffi::c_void;
+}
+
+// GetResult service struct
+#[allow(non_camel_case_types)]
+pub struct Probe_GetResult;
+
+impl rosidl_runtime_rs::Service for Probe_GetResult {
+    type Request = Probe_GetResult_Request;
+    type Response = Probe_GetResult_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__action__Probe_GetResult() }
+    }
+}
+
+// Action type support
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_action_type_support_handle__fingerprint-corpus__action__Probe() -> *const std::ffi::c_void;
+}
+
+// Action struct (zero-sized type)
+pub struct Probe;
+
+impl rosidl_runtime_rs::Action for Probe {
+    type Goal = ProbeGoal;
+    type Result = ProbeResult;
+    type Feedback = ProbeFeedback;
+    type FeedbackMessage = ProbeFeedbackMessage;
+    type SendGoalService = Probe_SendGoal;
+    type GetResultService = Probe_GetResult;
+    type CancelGoalService = action_msgs::srv::rmw::CancelGoal;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_action_type_support_handle__fingerprint-corpus__action__Probe() }
+    }
+
+    fn create_goal_request(goal_id: &[u8; 16], goal: ProbeGoal) -> Probe_SendGoal_Request {
+        Probe_SendGoal_Request {
+            goal_id: unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+            goal,
+        }
+    }
+
+    fn split_goal_request(request: Probe_SendGoal_Request) -> ([u8; 16], ProbeGoal) {
+        (request.goal_id.uuid, request.goal)
+    }
+
+    fn create_goal_response(accepted: bool, stamp: (i32, u32)) -> Probe_SendGoal_Response {
+        Probe_SendGoal_Response {
+            accepted,
+            stamp: builtin_interfaces::msg::rmw::Time { sec: stamp.0, nanosec: stamp.1 },
+        }
+    }
+
+    fn get_goal_response_accepted(response: &Probe_SendGoal_Response) -> bool {
+        response.accepted
+    }
+
+    fn get_goal_response_stamp(response: &Probe_SendGoal_Response) -> (i32, u32) {
+        (response.stamp.sec, response.stamp.nanosec)
+    }
+
+    fn create_feedback_message(goal_id: &[u8; 16], feedback: ProbeFeedback) -> ProbeFeedbackMessage {
+        ProbeFeedbackMessage {
+            goal_id: unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+            feedback,
+        }
+    }
+
+    fn split_feedback_message(feedback: ProbeFeedbackMessage) -> ([u8; 16], ProbeFeedback) {
+        (feedback.goal_id.uuid, feedback.feedback)
+    }
+
+    fn create_result_request(goal_id: &[u8; 16]) -> Probe_GetResult_Request {
+        Probe_GetResult_Request {
+            goal_id: unique_identifier_msgs::msg::rmw::UUID { uuid: *goal_id },
+        }
+    }
+
+    fn get_result_request_uuid(request: &Probe_GetResult_Request) -> &[u8; 16] {
+        &request.goal_id.uuid
+    }
+
+    fn create_result_response(status: i8, result: ProbeResult) -> Probe_GetResult_Response {
+        Probe_GetResult_Response {
+            status,
+            result,
+        }
+    }
+
+    fn split_result_response(response: Probe_GetResult_Response) -> (i8, ProbeResult) {
+        (response.status, response.result)
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.srv.idiomatic.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.srv.idiomatic.rs
@@ -1,0 +1,204 @@
+// emit:ok
+// Idiomatic Rust layer - user-friendly types
+// Package: fingerprint-corpus
+// Service: Probe
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// Request message
+pub mod request {
+    #[cfg(feature = "serde")]
+    use super::{Deserialize, Serialize};
+
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct Probe_Request {
+        
+        pub items: std::vec::Vec<i64>,
+        
+        pub note: std::string::String,
+        
+    }
+
+    impl Probe_Request {
+        
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl Default for Probe_Request {
+        fn default() -> Self {
+            // Leverage FFI message's C init function to get correct default values
+            <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::srv::rmw::ProbeRequest::default())
+        }
+    }
+
+    // Conversion from FFI layer
+    impl From<crate::srv::rmw::ProbeRequest> for Probe_Request {
+        #[allow(unused_variables)]
+        fn from(rmw: crate::srv::rmw::ProbeRequest) -> Self {
+            Self {
+                
+                
+                // Sequence<primitive> → Vec<primitive> (use rosidl_runtime_rs 0.5 API)
+                items: rmw.items.as_slice().to_vec(),
+                
+                
+                
+                // rosidl_runtime_rs::String → String (use rosidl_runtime_rs 0.5 API)
+                note: rmw.note.to_string(),
+                
+                
+            }
+        }
+    }
+
+    // Conversion to FFI layer
+    impl From<Probe_Request> for crate::srv::rmw::ProbeRequest {
+        #[allow(unused_variables)]
+        fn from(idiomatic: Probe_Request) -> Self {
+            Self {
+                
+                
+                // Vec<primitive> → Sequence<primitive> (use rosidl_runtime_rs 0.5 API)
+                items: crate::rosidl_runtime_rs::Sequence::from(idiomatic.items.clone()),
+                
+                
+                
+                // String → rosidl_runtime_rs::String (use rosidl_runtime_rs 0.5 API)
+                note: crate::rosidl_runtime_rs::String::from(idiomatic.note.as_str()),
+                
+                
+            }
+        }
+    }
+
+    // Message trait implementation for rosidl_runtime_rs
+    impl crate::rosidl_runtime_rs::Message for Probe_Request {
+        type RmwMsg = crate::srv::rmw::ProbeRequest;
+
+        fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            // Convert from idiomatic to RMW format
+            std::borrow::Cow::Owned(msg_cow.into_owned().into())
+        }
+
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            // Convert from RMW to idiomatic format
+            msg.into()
+        }
+    }
+}
+
+// Response message
+pub mod response {
+    #[cfg(feature = "serde")]
+    use super::{Deserialize, Serialize};
+
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct Probe_Response {
+        
+        pub sum: i64,
+        
+        pub lines: std::vec::Vec<std::string::String>,
+        
+    }
+
+    impl Probe_Response {
+        
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl Default for Probe_Response {
+        fn default() -> Self {
+            // Leverage FFI message's C init function to get correct default values
+            <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::srv::rmw::ProbeResponse::default())
+        }
+    }
+
+    // Conversion from FFI layer
+    impl From<crate::srv::rmw::ProbeResponse> for Probe_Response {
+        #[allow(unused_variables)]
+        fn from(rmw: crate::srv::rmw::ProbeResponse) -> Self {
+            Self {
+                
+                
+                // Primitives are Copy, just copy the value
+                sum: rmw.sum,
+                
+                
+                
+                // Sequence<rosidl_runtime_rs::String> → Vec<String>
+                lines: rmw.lines.as_slice().iter().map(|item| item.to_string()).collect(),
+                
+                
+            }
+        }
+    }
+
+    // Conversion to FFI layer
+    impl From<Probe_Response> for crate::srv::rmw::ProbeResponse {
+        #[allow(unused_variables)]
+        fn from(idiomatic: Probe_Response) -> Self {
+            Self {
+                
+                
+                // Primitives are Copy, just copy the value
+                sum: idiomatic.sum,
+                
+                
+                
+                // Vec<String> → Sequence<rosidl_runtime_rs::String>
+                lines: crate::rosidl_runtime_rs::Sequence::from(
+                    idiomatic.lines.iter().map(|item| crate::rosidl_runtime_rs::String::from(item.as_str())).collect::<Vec<_>>()
+                ),
+                
+                
+            }
+        }
+    }
+
+    // Message trait implementation for rosidl_runtime_rs
+    impl crate::rosidl_runtime_rs::Message for Probe_Response {
+        type RmwMsg = crate::srv::rmw::ProbeResponse;
+
+        fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+            // Convert from idiomatic to RMW format
+            std::borrow::Cow::Owned(msg_cow.into_owned().into())
+        }
+
+        fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+            // Convert from RMW to idiomatic format
+            msg.into()
+        }
+    }
+}
+
+// Re-export for convenience
+pub use request::Probe_Request;
+pub use response::Probe_Response;
+
+// Service type support
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__srv__Probe() -> *const std::ffi::c_void;
+}
+
+// Service struct (zero-sized type)
+pub struct Probe;
+
+impl crate::rosidl_runtime_rs::Service for Probe {
+    type Request = Probe_Request;
+    type Response = Probe_Response;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function
+        unsafe { rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__srv__Probe() }
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.srv.rmw.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Probe.srv.rmw.rs
@@ -1,0 +1,189 @@
+// emit:ok
+// RMW (ROS Middleware) layer - C-compatible FFI types
+// Package: fingerprint-corpus
+// Service: Probe
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+// Request constants
+
+
+// Response constants
+
+
+// FFI bindings to C libraries for Request
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__srv__Probe_Request() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__srv__Probe_Request__init(msg: *mut ProbeRequest) -> bool;
+    fn fingerprint-corpus__srv__Probe_Request__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<ProbeRequest>, size: usize) -> bool;
+    fn fingerprint-corpus__srv__Probe_Request__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<ProbeRequest>);
+    fn fingerprint-corpus__srv__Probe_Request__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<ProbeRequest>, out_seq: *mut rosidl_runtime_rs::Sequence<ProbeRequest>) -> bool;
+}
+
+// Request message type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeRequest {
+    
+    pub items: crate::rosidl_runtime_rs::Sequence<i64>,
+    
+    pub note: crate::rosidl_runtime_rs::String,
+    
+}
+
+impl ProbeRequest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ProbeRequest {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__srv__Probe_Request__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__srv__Probe_Request__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for ProbeRequest {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__srv__Probe_Request__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__srv__Probe_Request__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__srv__Probe_Request__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for ProbeRequest {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for ProbeRequest where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/srv/Probe_Request";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__srv__Probe_Request() }
+    }
+}
+
+// FFI bindings to C libraries for Response
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__srv__Probe_Response() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__srv__Probe_Response__init(msg: *mut ProbeResponse) -> bool;
+    fn fingerprint-corpus__srv__Probe_Response__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<ProbeResponse>, size: usize) -> bool;
+    fn fingerprint-corpus__srv__Probe_Response__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<ProbeResponse>);
+    fn fingerprint-corpus__srv__Probe_Response__Sequence__copy(in_seq: &rosidl_runtime_rs::Sequence<ProbeResponse>, out_seq: *mut rosidl_runtime_rs::Sequence<ProbeResponse>) -> bool;
+}
+
+// Response message type
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProbeResponse {
+    
+    pub sum: i64,
+    
+    pub lines: crate::rosidl_runtime_rs::Sequence<crate::rosidl_runtime_rs::String>,
+    
+}
+
+impl ProbeResponse {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for ProbeResponse {
+    fn default() -> Self {
+        unsafe {
+            let mut msg = std::mem::zeroed();
+            if !fingerprint-corpus__srv__Probe_Response__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__srv__Probe_Response__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+impl rosidl_runtime_rs::SequenceAlloc for ProbeResponse {
+    fn sequence_init(seq: &mut rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        unsafe { fingerprint-corpus__srv__Probe_Response__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut rosidl_runtime_rs::Sequence<Self>) {
+        unsafe { fingerprint-corpus__srv__Probe_Response__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &rosidl_runtime_rs::Sequence<Self>, out_seq: &mut rosidl_runtime_rs::Sequence<Self>) -> bool {
+        unsafe { fingerprint-corpus__srv__Probe_Response__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl rosidl_runtime_rs::Message for ProbeResponse {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        msg
+    }
+}
+
+impl rosidl_runtime_rs::RmwMessage for ProbeResponse where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/srv/Probe_Response";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__srv__Probe_Response() }
+    }
+}
+
+// Service type support
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__srv__Probe() -> *const std::ffi::c_void;
+}
+
+// Service struct (zero-sized type)
+pub struct Probe;
+
+impl rosidl_runtime_rs::Service for Probe {
+    type Request = ProbeRequest;
+    type Response = ProbeResponse;
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        unsafe { rosidl_typesupport_c__get_service_type_support_handle__fingerprint-corpus__srv__Probe() }
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Shapes.idiomatic.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Shapes.idiomatic.rs
@@ -1,0 +1,314 @@
+// emit:ok
+// Idiomatic Rust layer - user-friendly types
+// Package: fingerprint-corpus
+// Message: Shapes
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Shapes {
+    
+    
+    pub flag: bool,
+    
+    
+    
+    pub i8_v: i8,
+    
+    
+    
+    pub u8_v: u8,
+    
+    
+    
+    pub i16_v: i16,
+    
+    
+    
+    pub u16_v: u16,
+    
+    
+    
+    pub i32_v: i32,
+    
+    
+    
+    pub u32_v: u32,
+    
+    
+    
+    pub i64_v: i64,
+    
+    
+    
+    pub u64_v: u64,
+    
+    
+    
+    pub f32_v: f32,
+    
+    
+    
+    pub f64_v: f64,
+    
+    
+    
+    pub text: std::string::String,
+    
+    
+    
+    pub seq_prim: std::vec::Vec<i64>,
+    
+    
+    
+    pub seq_string: std::vec::Vec<std::string::String>,
+    
+    
+    
+    pub arr_fixed: [f64; 3],
+    
+    
+    
+    pub seq_bounded: std::vec::Vec<i32>,
+    
+    
+    
+    pub str_bounded: std::string::String,
+    
+    
+}
+
+impl Shapes {
+    
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Shapes {
+    fn default() -> Self {
+        // Leverage RMW message's C init function to get correct default values
+        <Self as crate::rosidl_runtime_rs::Message>::from_rmw_message(crate::msg::rmw::Shapes::default())
+    }
+}
+
+// Reference-based conversions (idiomatic ↔ RMW)
+impl From<&Shapes> for crate::msg::rmw::Shapes {
+    #[allow(unused_variables)]
+    fn from(idiomatic: &Shapes) -> Self {
+        Self {
+            
+            
+            // Primitives are Copy, just copy the value
+            flag: idiomatic.flag,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i8_v: idiomatic.i8_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u8_v: idiomatic.u8_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i16_v: idiomatic.i16_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u16_v: idiomatic.u16_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i32_v: idiomatic.i32_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u32_v: idiomatic.u32_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i64_v: idiomatic.i64_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u64_v: idiomatic.u64_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            f32_v: idiomatic.f32_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            f64_v: idiomatic.f64_v,
+            
+            
+            
+            // String → rosidl_runtime_rs::String (use rosidl_runtime_rs 0.5 API)
+            text: crate::rosidl_runtime_rs::String::from(idiomatic.text.as_str()),
+            
+            
+            
+            // Vec<primitive> → Sequence<primitive> (use rosidl_runtime_rs 0.5 API)
+            seq_prim: crate::rosidl_runtime_rs::Sequence::from(idiomatic.seq_prim.clone()),
+            
+            
+            
+            // Vec<String> → Sequence<rosidl_runtime_rs::String>
+            seq_string: crate::rosidl_runtime_rs::Sequence::from(
+                idiomatic.seq_string.iter().map(|item| crate::rosidl_runtime_rs::String::from(item.as_str())).collect::<Vec<_>>()
+            ),
+            
+            
+            
+            // [primitive; N] arrays can be cloned directly
+            arr_fixed: idiomatic.arr_fixed.clone(),
+            
+            
+            
+            // Vec<primitive> → BoundedSequence<primitive> (use try_from)
+            seq_bounded: crate::rosidl_runtime_rs::BoundedSequence::try_from(idiomatic.seq_bounded.clone()).unwrap(),
+            
+            
+            
+            // String → rosidl_runtime_rs::BoundedString<N> (use try_from)
+            str_bounded: crate::rosidl_runtime_rs::BoundedString::try_from(idiomatic.str_bounded.as_str()).unwrap(),
+            
+            
+        }
+    }
+}
+
+impl From<&crate::msg::rmw::Shapes> for Shapes {
+    #[allow(unused_variables)]
+    fn from(rmw: &crate::msg::rmw::Shapes) -> Self {
+        Self {
+            
+            
+            // Primitives are Copy, just copy the value
+            flag: rmw.flag,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i8_v: rmw.i8_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u8_v: rmw.u8_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i16_v: rmw.i16_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u16_v: rmw.u16_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i32_v: rmw.i32_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u32_v: rmw.u32_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            i64_v: rmw.i64_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            u64_v: rmw.u64_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            f32_v: rmw.f32_v,
+            
+            
+            
+            // Primitives are Copy, just copy the value
+            f64_v: rmw.f64_v,
+            
+            
+            
+            // rosidl_runtime_rs::String → String (use rosidl_runtime_rs 0.5 API)
+            text: rmw.text.to_string(),
+            
+            
+            
+            // Sequence<primitive> → Vec<primitive> (use rosidl_runtime_rs 0.5 API)
+            seq_prim: rmw.seq_prim.as_slice().to_vec(),
+            
+            
+            
+            // Sequence<rosidl_runtime_rs::String> → Vec<String>
+            seq_string: rmw.seq_string.as_slice().iter().map(|item| item.to_string()).collect(),
+            
+            
+            
+            // [primitive; N] arrays can be cloned directly
+            arr_fixed: rmw.arr_fixed.clone(),
+            
+            
+            
+            // BoundedSequence<primitive> → Vec<primitive> (use rosidl_runtime_rs 0.5 API)
+            seq_bounded: rmw.seq_bounded.as_slice().to_vec(),
+            
+            
+            
+            // rosidl_runtime_rs::BoundedString<N> → String
+            str_bounded: rmw.str_bounded.to_string(),
+            
+            
+        }
+    }
+}
+
+// Owned conversions delegate to reference-based ones
+impl From<crate::msg::rmw::Shapes> for Shapes {
+    fn from(rmw: crate::msg::rmw::Shapes) -> Self {
+        Self::from(&rmw)
+    }
+}
+
+impl From<Shapes> for crate::msg::rmw::Shapes {
+    fn from(idiomatic: Shapes) -> Self {
+        Self::from(&idiomatic)
+    }
+}
+
+// Message trait implementation for rosidl_runtime_rs
+impl crate::rosidl_runtime_rs::Message for Shapes {
+    type RmwMsg = crate::msg::rmw::Shapes;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Convert from idiomatic to RMW format
+        std::borrow::Cow::Owned(msg_cow.into_owned().into())
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Convert from RMW to idiomatic format
+        msg.into()
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Shapes.rmw.rs
+++ b/packages/cli/rosidl-codegen/tests/fixtures/rust-surface-golden/Shapes.rmw.rs
@@ -1,0 +1,129 @@
+// emit:ok
+// RMW (ROS Middleware) layer - C-compatible FFI types
+// Package: fingerprint-corpus
+// Message: Shapes
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+
+
+// FFI bindings to C libraries
+#[link(name = "fingerprint-corpus__rosidl_typesupport_c")]
+extern "C" {
+    fn rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Shapes() -> *const std::ffi::c_void;
+}
+
+#[link(name = "fingerprint-corpus__rosidl_generator_c")]
+#[allow(improper_ctypes)]
+extern "C" {
+    fn fingerprint-corpus__msg__Shapes__init(msg: *mut Shapes) -> bool;
+    fn fingerprint-corpus__msg__Shapes__Sequence__init(seq: *mut crate::rosidl_runtime_rs::Sequence<Shapes>, size: usize) -> bool;
+    fn fingerprint-corpus__msg__Shapes__Sequence__fini(seq: *mut crate::rosidl_runtime_rs::Sequence<Shapes>);
+    fn fingerprint-corpus__msg__Shapes__Sequence__copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Shapes>, out_seq: *mut crate::rosidl_runtime_rs::Sequence<Shapes>) -> bool;
+}
+
+// RMW types are C-compatible FFI types
+// Serde support is available via the "serde" feature flag
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Shapes {
+    
+    pub flag: bool,
+    
+    pub i8_v: i8,
+    
+    pub u8_v: u8,
+    
+    pub i16_v: i16,
+    
+    pub u16_v: u16,
+    
+    pub i32_v: i32,
+    
+    pub u32_v: u32,
+    
+    pub i64_v: i64,
+    
+    pub u64_v: u64,
+    
+    pub f32_v: f32,
+    
+    pub f64_v: f64,
+    
+    pub text: crate::rosidl_runtime_rs::String,
+    
+    pub seq_prim: crate::rosidl_runtime_rs::Sequence<i64>,
+    
+    pub seq_string: crate::rosidl_runtime_rs::Sequence<crate::rosidl_runtime_rs::String>,
+    
+    pub arr_fixed: [f64; 3],
+    
+    pub seq_bounded: crate::rosidl_runtime_rs::BoundedSequence<i32, 4>,
+    
+    pub str_bounded: crate::rosidl_runtime_rs::BoundedString<8>,
+    
+}
+
+impl Shapes {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for Shapes {
+    fn default() -> Self {
+        unsafe {
+            // SAFETY: Zeroing a message structure is valid for all ROS message types
+            let mut msg = std::mem::zeroed();
+            // SAFETY: The init function is safe to call on a zeroed message
+            if !fingerprint-corpus__msg__Shapes__init(&mut msg as *mut _) {
+                panic!("Call to fingerprint-corpus__msg__Shapes__init() failed");
+            }
+            msg
+        }
+    }
+}
+
+// Trait implementations for ROS runtime
+
+impl crate::rosidl_runtime_rs::SequenceAlloc for Shapes {
+    fn sequence_init(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>, size: usize) -> bool {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Shapes__Sequence__init(seq as *mut _, size) }
+    }
+
+    fn sequence_fini(seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) {
+        // SAFETY: The pointer is guaranteed to be valid since it comes from a mutable reference
+        unsafe { fingerprint-corpus__msg__Shapes__Sequence__fini(seq as *mut _) }
+    }
+
+    fn sequence_copy(in_seq: &crate::rosidl_runtime_rs::Sequence<Self>, out_seq: &mut crate::rosidl_runtime_rs::Sequence<Self>) -> bool {
+        // SAFETY: Both pointers are guaranteed to be valid since they come from references
+        unsafe { fingerprint-corpus__msg__Shapes__Sequence__copy(in_seq, out_seq as *mut _) }
+    }
+}
+
+impl crate::rosidl_runtime_rs::Message for Shapes {
+    type RmwMsg = Self;
+
+    fn into_rmw_message(msg_cow: std::borrow::Cow<'_, Self>) -> std::borrow::Cow<'_, Self::RmwMsg> {
+        // Identity conversion: RMW message is already in RMW format
+        msg_cow
+    }
+
+    fn from_rmw_message(msg: Self::RmwMsg) -> Self {
+        // Identity conversion: RMW message is already in RMW format
+        msg
+    }
+}
+
+impl crate::rosidl_runtime_rs::RmwMessage for Shapes where Self: Sized {
+    const TYPE_NAME: &'static str = "fingerprint-corpus/msg/Shapes";
+
+    fn get_type_support() -> *const std::ffi::c_void {
+        // SAFETY: No preconditions for this function
+        unsafe { rosidl_typesupport_c__get_message_type_support_handle__fingerprint-corpus__msg__Shapes() }
+    }
+}

--- a/packages/cli/rosidl-codegen/tests/rust_surface_golden.rs
+++ b/packages/cli/rosidl-codegen/tests/rust_surface_golden.rs
@@ -1,0 +1,263 @@
+//! Golden test for the `rmw` and idiomatic Rust surfaces — phase-432 W2.5a.
+//!
+//! # Why this file exists
+//!
+//! `codegen_golden.rs` is the guard for a codegen change, and it is a good one —
+//! but it renders `emit_corpus()`, which covers the `nros`, `c` and `cpp`
+//! surfaces and NOT the `rmw` or idiomatic ones. Measured while collapsing the
+//! per-surface field views onto the lowered IR: two of the five message surfaces
+//! could be rewritten with no golden asserting a single byte of their output.
+//!
+//! The fingerprint hashes the `packs/rmw/*.jinja` and `packs/rust/*.jinja` TEXT,
+//! so a template edit there does move it. What nothing covered is the Rust side
+//! — the view builders in `generator/{msg,srv,action}.rs`, which is exactly what
+//! W2.5a rewrites.
+//!
+//! # Why it is NOT wired into `emit_corpus`
+//!
+//! `emit_corpus` feeds [`rosidl_codegen::codegen_fingerprint`], which is a
+//! FIXTURE STALENESS signal (RFC-0061 / phase-318): adding rows to it marks
+//! every built workspace fixture in the tree stale. That is the right trade for
+//! a surface whose bytes reach a fixture; `generate_message_package` and its
+//! siblings have no caller outside this crate's own tests and benches today, so
+//! paying a tree-wide rebuild to cover them would be a poor one. Keeping the
+//! corpus here means this test can guard the rewrite without moving the
+//! fingerprint.
+//!
+//! If the rmw/idiomatic surfaces ever gain a production caller, fold this corpus
+//! into `emit_corpus` and delete this file — one golden per surface set, not two.
+//!
+//! # One thing the recorded bytes show that is NOT a spelling to preserve
+//!
+//! The corpus package is named `fingerprint-corpus`, and the Rust surfaces
+//! interpolate it into `extern "C"` symbol names verbatim — so the golden
+//! contains `fingerprint-corpus__msg__Capped__init`, which is not a Rust
+//! identifier. The C and nros surfaces run the same name through
+//! `to_c_package_name` and the Rust ones do not. That is a real, pre-existing
+//! gap and it is recorded here rather than hidden, because a golden's job is to
+//! say what the tool emits. Fixing it SHOULD fail this test.
+//!
+//! # Updating
+//!
+//! An intentional change SHOULD fail this test. Re-record with:
+//!
+//! ```console
+//! $ NROS_UPDATE_GOLDEN=1 cargo test -p rosidl-codegen --test rust_surface_golden
+//! ```
+//!
+//! then READ the diff. A byte moving here means a Rust-layer spelling changed.
+
+use rosidl_codegen::{generate_action_package, generate_message_package, generate_service_package};
+use rosidl_parser::{parse_action, parse_message, parse_service};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+const CORPUS: &str = "fingerprint-corpus";
+
+const SHAPES_MSG: &str = include_str!("fixtures/fingerprint-corpus/msg/Shapes.msg");
+const NESTED_MSG: &str = include_str!("fixtures/fingerprint-corpus/msg/Nested.msg");
+const BOUNDED_MSG: &str = include_str!("fixtures/fingerprint-corpus/msg/Bounded.msg");
+const CAPPED_MSG: &str = include_str!("fixtures/fingerprint-corpus/msg/Capped.msg");
+const PROBE_SRV: &str = include_str!("fixtures/fingerprint-corpus/srv/Probe.srv");
+const PROBE_ACTION: &str = include_str!("fixtures/fingerprint-corpus/action/Probe.action");
+
+/// Every byte the `rmw` and idiomatic Rust surfaces emit for the shared corpus,
+/// keyed by a stable relative path.
+///
+/// Reuses `fingerprint-corpus`'s `.msg`/`.srv`/`.action` deliberately: one set of
+/// shapes, so a shape added for the C side is covered on the Rust side too and
+/// nobody has to remember to add it twice.
+fn emit() -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let deps: HashSet<String> = HashSet::new();
+
+    let mut put = |name: &str, res: Result<String, String>| {
+        // A build whose emitters REJECT a shape is a different tool than one
+        // that accepts it — record the rejection as content rather than
+        // failing, so the diff shows it (same rule as `emit_corpus`).
+        let (tag, body) = match res {
+            Ok(s) => ("ok", s),
+            Err(e) => ("err", e),
+        };
+        out.insert(name.to_string(), format!("// emit:{tag}\n{body}"));
+    };
+
+    for (name, src) in [
+        ("Shapes", SHAPES_MSG),
+        ("Nested", NESTED_MSG),
+        ("Bounded", BOUNDED_MSG),
+        ("Capped", CAPPED_MSG),
+    ] {
+        let Ok(m) = parse_message(src) else {
+            put(&format!("{name}.parse"), Err("parse-error".into()));
+            continue;
+        };
+        let g = generate_message_package(CORPUS, name, &m, &deps);
+        put(
+            &format!("{name}.rmw.rs"),
+            g.as_ref()
+                .map(|g| g.message_rmw.clone())
+                .map_err(ToString::to_string),
+        );
+        put(
+            &format!("{name}.idiomatic.rs"),
+            g.as_ref()
+                .map(|g| g.message_idiomatic.clone())
+                .map_err(ToString::to_string),
+        );
+    }
+
+    match parse_service(PROBE_SRV) {
+        Ok(sv) => {
+            let g = generate_service_package(CORPUS, "Probe", &sv, &deps);
+            put(
+                "Probe.srv.rmw.rs",
+                g.as_ref()
+                    .map(|g| g.service_rmw.clone())
+                    .map_err(ToString::to_string),
+            );
+            put(
+                "Probe.srv.idiomatic.rs",
+                g.as_ref()
+                    .map(|g| g.service_idiomatic.clone())
+                    .map_err(ToString::to_string),
+            );
+        }
+        Err(_) => put("Probe.srv.parse", Err("parse-error".into())),
+    }
+
+    match parse_action(PROBE_ACTION) {
+        Ok(ac) => {
+            let g = generate_action_package(CORPUS, "Probe", &ac, &deps);
+            put(
+                "Probe.action.rmw.rs",
+                g.as_ref()
+                    .map(|g| g.action_rmw.clone())
+                    .map_err(ToString::to_string),
+            );
+            put(
+                "Probe.action.idiomatic.rs",
+                g.as_ref()
+                    .map(|g| g.action_idiomatic.clone())
+                    .map_err(ToString::to_string),
+            );
+        }
+        Err(_) => put("Probe.action.parse", Err("parse-error".into())),
+    }
+
+    out
+}
+
+fn golden_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rust-surface-golden")
+}
+
+fn update_requested() -> bool {
+    std::env::var("NROS_UPDATE_GOLDEN").is_ok_and(|v| v != "0")
+}
+
+fn walk(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for e in fs::read_dir(dir)? {
+        let p = e?.path();
+        if p.is_dir() {
+            out.extend(walk(&p)?);
+        } else {
+            out.push(p);
+        }
+    }
+    Ok(out)
+}
+
+#[test]
+fn the_rust_surfaces_match_their_committed_golden() {
+    let emitted = emit();
+    let dir = golden_dir();
+
+    if update_requested() {
+        let _ = fs::remove_dir_all(&dir);
+        for (rel, body) in &emitted {
+            let path = dir.join(rel);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, body).unwrap();
+        }
+        eprintln!(
+            "re-recorded {} golden files under {}",
+            emitted.len(),
+            dir.display()
+        );
+        return;
+    }
+
+    assert!(
+        dir.is_dir(),
+        "golden dir {} is missing — record it with \
+         NROS_UPDATE_GOLDEN=1 cargo test -p rosidl-codegen --test rust_surface_golden",
+        dir.display()
+    );
+
+    let mut problems = Vec::new();
+    for (rel, body) in &emitted {
+        match fs::read_to_string(dir.join(rel)) {
+            Err(_) => problems.push(format!("  + {rel}   (new output, no golden)")),
+            Ok(on_disk) if &on_disk != body => {
+                problems.push(format!("  ~ {rel}   ({})", first_diff(&on_disk, body)));
+            }
+            Ok(_) => {}
+        }
+    }
+    // A golden nothing emits any more is stale coverage.
+    for p in walk(&dir).unwrap_or_default() {
+        let rel = p
+            .strip_prefix(&dir)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        if !emitted.contains_key(&rel) {
+            problems.push(format!("  - {rel}   (golden nothing emits)"));
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "the rmw / idiomatic Rust surfaces do not match their committed golden:\n{}\n\n\
+         If the change is intended, re-record with \
+         NROS_UPDATE_GOLDEN=1 cargo test -p rosidl-codegen --test rust_surface_golden \
+         and READ the diff.",
+        problems.join("\n")
+    );
+}
+
+/// The first differing line, so the failure names a place rather than dumping
+/// two files.
+fn first_diff(expected: &str, actual: &str) -> String {
+    for (i, (e, a)) in expected.lines().zip(actual.lines()).enumerate() {
+        if e != a {
+            return format!("line {}: expected {e:?}, got {a:?}", i + 1);
+        }
+    }
+    format!(
+        "same prefix, different length: {} vs {} lines",
+        expected.lines().count(),
+        actual.lines().count()
+    )
+}
+
+/// The golden is only a guard if the corpus reaches BOTH surfaces. An empty or
+/// half-emitted map would pass the test above for the wrong reason.
+#[test]
+fn the_corpus_reaches_both_rust_surfaces() {
+    let emitted = emit();
+    let rmw = emitted.keys().filter(|k| k.contains(".rmw.")).count();
+    let idiomatic = emitted.keys().filter(|k| k.contains(".idiomatic.")).count();
+    assert_eq!(rmw, 6, "expected 4 msg + 1 srv + 1 action rmw renders");
+    assert_eq!(idiomatic, 6, "expected 4 msg + 1 srv + 1 action idiomatic");
+    assert!(
+        emitted.values().all(|b| b.starts_with("// emit:ok\n")),
+        "a corpus shape the Rust surfaces reject would freeze its error text as \
+         the golden — fix the emitter or drop the shape, do not record the error"
+    );
+}

--- a/packages/cli/rosidl-lower/src/lowered.rs
+++ b/packages/cli/rosidl-lower/src/lowered.rs
@@ -196,8 +196,18 @@ pub struct LoweredField {
     /// [`Self::element_op`], which say which of the two a caller means.
     pub cdr_op: Option<CdrOp>,
     /// Alignment of the field's payload, bytes.
+    ///
+    /// The one field no message surface reads, and legitimately so (phase-432
+    /// W2.5a): it exists solely to answer [`LoweredType::plain`] inside
+    /// [`lower`], and `NESTED_ALIGN_STANDIN` above records that its VALUE
+    /// cannot change an outcome anywhere else. If a surface ever needs a
+    /// field's alignment, it needs a real per-target answer, not this.
     pub align: usize,
     /// Whether this field is POD-blit eligible.
+    ///
+    /// Also unread per-field: like `align`, it is an input to
+    /// [`LoweredType::plain`], which is a property of the STRUCT (every field
+    /// plain AND one shared alignment) and is what a blit fast path would ask.
     pub plain: bool,
     /// The `.msg` default, as parsed. A language spells it (`constant_value_to_rust`
     /// and friends); the value itself is neutral.

--- a/packages/cli/rosidl-lower/src/lowered.rs
+++ b/packages/cli/rosidl-lower/src/lowered.rs
@@ -6,10 +6,12 @@
 //! op, and the field order. Language spelling is NOT here — a template maps the
 //! neutral facts to `u32`/`uint32_t`/`write_u32`/… (RFC-0068 Stage 3).
 
-use rosidl_parser::ast::{FieldType, PrimitiveType};
+use std::borrow::Cow;
+
+use rosidl_parser::ast::{ConstantValue, FieldType, PrimitiveType};
 use rosidl_resolve::ResolvedMessage;
 
-use crate::config::{CapacityResolver, FieldKind, FieldStorage, StorageMode};
+use crate::config::{CapacityResolver, FieldKind, FieldStorage, StorageMode, with_element_bound};
 
 /// Stand-in alignment for a nested struct field.
 ///
@@ -155,20 +157,144 @@ pub enum FieldShape {
 }
 
 /// One field lowered to concrete, target-specific, language-neutral facts.
+///
+/// phase-432 W2.5a — this IS the render context. Every message surface (`rmw`,
+/// `rust`, `nros`, `c`, `cpp`) projects its view struct from here; none of them
+/// re-matches on `rosidl_parser` to answer a question this struct already
+/// answers. The accessors below are that contract: they are the ONLY sanctioned
+/// spelling of "is this a sequence", "what is the element's CDR op", "how long
+/// is the array".
 #[derive(Debug, Clone)]
 pub struct LoweredField {
     pub name: String,
-    /// The original parsed type (the renderer still needs it for spelling).
+    /// The type AS PARSED — what the `.msg` says, hence what CDR puts on the
+    /// wire and what a ROS-ABI mirror (the `rmw` surface) must spell.
+    ///
+    /// Deliberately NOT the element-capped shape: see [`Self::element_cap`] and
+    /// [`Self::storage_type`], which answer a different question.
     pub field_type: FieldType,
+    /// phase-403 W7 — the codegen config's `element_cap` for this field, when
+    /// one applies (an unbounded-string element inside a container whose mode
+    /// bounds the wire). `None` otherwise.
+    ///
+    /// This is a fact about nano-ros STORAGE, not about the wire: it narrows
+    /// what we keep in RAM, and CDR is unchanged either way. So the storage
+    /// surfaces (`c`, `nros`, `cpp`) render [`Self::storage_type`] while the
+    /// ROS-ABI mirror (`rmw`) renders [`Self::field_type`]. Two questions, two
+    /// answers — not two spellings of one answer.
+    pub element_cap: Option<usize>,
+    /// Whether this field's storage came from the [`CapacityResolver`] — true
+    /// exactly for the two configurable shapes (an unbounded string and an
+    /// unbounded sequence). A `.msg`-bounded string/sequence, an array, a
+    /// scalar and a nested struct are NOT configurable, whatever the config
+    /// says about them.
+    pub configurable: bool,
     pub shape: FieldShape,
     pub storage: LoweredStorage,
     /// CDR op of the field's scalar (or its element, for arrays/sequences);
-    /// `None` for a single nested struct.
+    /// `None` for a single nested struct. Read it through [`Self::scalar_op`] /
+    /// [`Self::element_op`], which say which of the two a caller means.
     pub cdr_op: Option<CdrOp>,
     /// Alignment of the field's payload, bytes.
     pub align: usize,
     /// Whether this field is POD-blit eligible.
     pub plain: bool,
+    /// The `.msg` default, as parsed. A language spells it (`constant_value_to_rust`
+    /// and friends); the value itself is neutral.
+    pub default_value: Option<ConstantValue>,
+}
+
+impl LoweredField {
+    /// The shape a nano-ros STORAGE surface renders: [`Self::field_type`] with
+    /// any [`Self::element_cap`] folded into the element. Identical to
+    /// `field_type` whenever no element cap applies, which is the common case.
+    pub fn storage_type(&self) -> Cow<'_, FieldType> {
+        with_element_bound(&self.field_type, self.element_cap)
+    }
+
+    /// A single scalar (`bool`, `int32`, `float64`, …).
+    pub fn is_primitive(&self) -> bool {
+        matches!(self.shape, FieldShape::Scalar)
+    }
+
+    /// A single string member — bounded or not, narrow or wide.
+    pub fn is_string(&self) -> bool {
+        matches!(self.shape, FieldShape::Str)
+    }
+
+    /// A fixed-size array `type[N]`.
+    pub fn is_array(&self) -> bool {
+        matches!(self.shape, FieldShape::Array { .. })
+    }
+
+    /// A sequence — `type[]` or `type[<=N]`.
+    pub fn is_sequence(&self) -> bool {
+        matches!(self.shape, FieldShape::Sequence)
+    }
+
+    /// A single nested message.
+    pub fn is_nested(&self) -> bool {
+        matches!(self.shape, FieldShape::Nested)
+    }
+
+    /// `N` for `type[N]`, else 0.
+    pub fn array_len(&self) -> usize {
+        match self.shape {
+            FieldShape::Array { len } => len,
+            _ => 0,
+        }
+    }
+
+    /// The CDR op of the field ITSELF — `Some` only for a scalar. A string's op
+    /// is [`CdrOp::String`] and is not a scalar op; ask [`Self::is_string`].
+    pub fn scalar_op(&self) -> Option<CdrOp> {
+        self.is_primitive().then_some(self.cdr_op).flatten()
+    }
+
+    /// The CDR op of the field's ELEMENT — `Some` only for an array or a
+    /// sequence. [`CdrOp::String`] here means a container OF strings.
+    pub fn element_op(&self) -> Option<CdrOp> {
+        (self.is_array() || self.is_sequence())
+            .then_some(self.cdr_op)
+            .flatten()
+    }
+
+    /// The element of an array/sequence is a scalar.
+    pub fn element_is_primitive(&self) -> bool {
+        matches!(self.element_op(), Some(op) if op != CdrOp::String)
+    }
+
+    /// The element of an array/sequence is a string.
+    pub fn element_is_string(&self) -> bool {
+        self.element_op() == Some(CdrOp::String)
+    }
+
+    /// Heap-backed storage (RFC-0033 `mode = "heap"`).
+    pub fn is_heap(&self) -> bool {
+        matches!(self.storage, LoweredStorage::Heap)
+    }
+
+    /// Zero-copy borrow into the receive buffer (RFC-0033 `mode = "view"`).
+    pub fn is_borrowed(&self) -> bool {
+        matches!(self.storage, LoweredStorage::Borrowed { .. })
+    }
+
+    /// The resolved capacity a CONFIGURABLE field's storage carries, else 0.
+    ///
+    /// Zero for a non-configurable field even when its storage has a capacity:
+    /// a `string<=8`'s 8 comes from the `.msg`, not from the resolver, and the
+    /// surfaces spell it off the type.
+    pub fn configured_cap(&self) -> usize {
+        if !self.configurable {
+            return 0;
+        }
+        match self.storage {
+            LoweredStorage::Fixed { cap }
+            | LoweredStorage::Bounded { cap }
+            | LoweredStorage::Borrowed { cap } => cap,
+            LoweredStorage::Inline | LoweredStorage::Heap => 0,
+        }
+    }
 }
 
 /// A message lowered to the target-concrete IR.
@@ -227,17 +353,18 @@ pub fn lower_fields(
 ) -> Vec<LoweredField> {
     fields
         .iter()
-        .map(|f| lower_field(&f.name, &f.field_type, package, message, config))
+        .map(|f| lower_field(f, package, message, config))
         .collect()
 }
 
 fn lower_field(
-    name: &str,
-    ft: &FieldType,
+    field: &rosidl_parser::ast::Field,
     package: &str,
     message: &str,
     config: &CapacityResolver,
 ) -> LoweredField {
+    let name = field.name.as_str();
+    let ft = &field.field_type;
     let (shape, storage, cdr_op, align, plain) = match ft {
         FieldType::Primitive(p) => {
             let op = CdrOp::from_primitive(*p);
@@ -314,14 +441,25 @@ fn lower_field(
         ),
     };
 
+    // The two configurable shapes, named once. `configurable` is the same
+    // predicate the arms above branch on to call `config.resolve` — stated as a
+    // fact so a surface stops re-deriving it (phase-432 W2.5a).
+    let configurable = matches!(
+        ft,
+        FieldType::String | FieldType::WString | FieldType::Sequence { .. }
+    );
+
     LoweredField {
         name: name.to_string(),
         field_type: ft.clone(),
+        element_cap: config.declared_element_bound(package, message, name, ft),
+        configurable,
         shape,
         storage,
         cdr_op,
         align,
         plain,
+        default_value: field.default_value.clone(),
     }
 }
 
@@ -467,6 +605,142 @@ string<=8    str_bounded
         assert!(!lowered.plain);
         // Its align is the stand-in, and nothing downstream reads it.
         assert_eq!(field(&lowered, "child").align, NESTED_ALIGN_STANDIN);
+    }
+
+    /// phase-432 W2.5a — the accessors the five message surfaces now project
+    /// through, checked against the shapes they used to `match` on themselves.
+    ///
+    /// Each assertion below replaced a `matches!(field.field_type, …)` in a view
+    /// builder; if one of them stops agreeing, a surface's private answer and
+    /// the IR's answer have diverged, which is exactly the defect this wave
+    /// removed.
+    #[test]
+    fn the_shape_accessors_answer_what_the_surfaces_used_to_re_derive() {
+        let t = lower_shapes();
+
+        let scalar = field(&t, "u32_v");
+        assert!(scalar.is_primitive() && !scalar.is_string());
+        assert_eq!(scalar.scalar_op(), Some(CdrOp::U32));
+        // A scalar has no element, so no surface may read one off it.
+        assert_eq!(scalar.element_op(), None);
+        assert!(!scalar.element_is_primitive() && !scalar.element_is_string());
+        assert_eq!(scalar.array_len(), 0);
+
+        let text = field(&t, "text");
+        assert!(text.is_string() && !text.is_primitive());
+        // `String`'s CDR op is `String` — but it is NOT a scalar op, so a
+        // surface asking for `primitive_method` gets nothing.
+        assert_eq!(text.scalar_op(), None);
+        assert!(text.configurable, "an unbounded string is config-resolved");
+        assert_eq!(text.configured_cap(), 256);
+
+        let bounded = field(&t, "str_bounded");
+        assert!(bounded.is_string());
+        assert!(
+            !bounded.configurable,
+            "a `.msg`-bounded string states its own cap; the resolver never sees it"
+        );
+        assert_eq!(
+            bounded.configured_cap(),
+            0,
+            "its 8 comes from the type, not the config"
+        );
+
+        let arr = field(&t, "arr_fixed");
+        assert!(arr.is_array() && !arr.is_sequence());
+        assert_eq!(arr.array_len(), 3);
+        assert_eq!(arr.element_op(), Some(CdrOp::F64));
+        assert!(arr.element_is_primitive() && !arr.element_is_string());
+        assert_eq!(arr.scalar_op(), None, "an array is not itself a scalar");
+
+        let seq = field(&t, "seq_prim");
+        assert!(seq.is_sequence() && !seq.is_array());
+        assert!(seq.configurable);
+        assert_eq!(seq.configured_cap(), 64);
+        assert_eq!(seq.element_op(), Some(CdrOp::I64));
+
+        let seq_bounded = field(&t, "seq_bounded");
+        assert!(seq_bounded.is_sequence());
+        assert!(
+            !seq_bounded.configurable,
+            "`int32[<=4]` states its own bound"
+        );
+
+        // No field here is heap or borrowed under the empty resolver.
+        assert!(t.fields.iter().all(|f| !f.is_heap() && !f.is_borrowed()));
+    }
+
+    /// A sequence OF strings: the element op is `String`, so
+    /// `element_is_string` is true and `element_is_primitive` is false. Both
+    /// surfaces (C and nros) branch on exactly this pair.
+    #[test]
+    fn a_string_element_is_not_a_primitive_element() {
+        let msg = parse_message("string[] names\nstring[3] fixed_names\n").unwrap();
+        let r = ResolvedMessage::resolve("m/msg/Names", &msg, no_deps).unwrap();
+        let t = lower(&r, &CapacityResolver::empty());
+        for name in ["names", "fixed_names"] {
+            let f = field(&t, name);
+            assert!(f.element_is_string(), "{name}");
+            assert!(!f.element_is_primitive(), "{name}");
+        }
+    }
+
+    /// A nested field has NO cdr op at all, so neither element predicate fires
+    /// — the arm every view builder spelled as a `_ => (false, false, …)`.
+    #[test]
+    fn a_nested_element_has_no_cdr_op() {
+        let inner = parse_message("int32 a\n").unwrap();
+        let outer = parse_message("test_msgs/Inner one\ntest_msgs/Inner[] many\n").unwrap();
+        let resolve = |fqn: &str| -> Option<rosidl_parser::Message> {
+            fqn.ends_with("Inner").then(|| inner.clone())
+        };
+        let r = ResolvedMessage::resolve("test_msgs/msg/Outer", &outer, resolve).unwrap();
+        let t = lower(&r, &CapacityResolver::empty());
+
+        let one = field(&t, "one");
+        assert!(one.is_nested());
+        assert_eq!(one.cdr_op, None);
+        assert_eq!(one.scalar_op(), None);
+
+        let many = field(&t, "many");
+        assert!(many.is_sequence());
+        assert_eq!(many.element_op(), None);
+        assert!(!many.element_is_primitive() && !many.element_is_string());
+    }
+
+    /// `element_cap` narrows STORAGE, never the wire — so `field_type` keeps
+    /// what the `.msg` said and `storage_type()` carries the fold. The `rmw`
+    /// surface renders the first, the `c`/`nros`/`cpp` surfaces the second.
+    #[test]
+    fn an_element_cap_moves_storage_type_and_leaves_field_type_alone() {
+        let msg = parse_message("string[] tags\n").unwrap();
+        let r = ResolvedMessage::resolve("p/msg/M", &msg, no_deps).unwrap();
+
+        let plain = lower(&r, &CapacityResolver::empty());
+        let f = field(&plain, "tags");
+        assert_eq!(f.element_cap, None);
+        assert_eq!(&*f.storage_type(), &f.field_type);
+
+        let cfg = CapacityResolver::from_toml_str(
+            "[fields]\n\"p/M.tags\" = { cap = 4, element_cap = 8, mode = \"inline\" }\n",
+        )
+        .unwrap();
+        let capped = lower(&r, &cfg);
+        let f = field(&capped, "tags");
+        assert_eq!(f.element_cap, Some(8));
+        assert_eq!(
+            f.field_type,
+            rosidl_parser::ast::FieldType::Sequence {
+                element_type: Box::new(rosidl_parser::ast::FieldType::String),
+            },
+            "the wire type is what the .msg says, cap or no cap"
+        );
+        assert_eq!(
+            &*f.storage_type(),
+            &rosidl_parser::ast::FieldType::Sequence {
+                element_type: Box::new(rosidl_parser::ast::FieldType::BoundedString(8)),
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
phase-432 W2.5a. RFC-0091 §6b measured that each message surface re-derives one field from the PARSER rather than from `LoweredField`, and that lowering computes facts it then drops. Both findings held. Three details of the surrounding prose did not, each in a way that changed the work; all three are now written into §6b as a corrections block.

**"Four views" is the wrong count — it is six, across five surfaces.** The `cpp` pack builds a PAIR: `CppField` for the header and `CppFfiField` for the `repr(C)` Rust glue, both re-derived from the parser exactly like the other four. That pair is the one §5's memory-agreement gate exists for, so it was the surface least safe to leave out.

**"Each surface re-derives from the parser" is only half true for two of them.** `NrosField` and `CField` already received the storage decision as a `FieldStorage` (phase-335 W1.c) and re-derived the other fifteen facts. The half-migration had a specific shape worth naming: a `pre_storage: Option<FieldStorage>` parameter whose `None` meant "resolve it yourself again". The `Option` WAS the second answer, kept alive as an argument.

**`align` and `plain` are not dropped facts.** They are per-field inputs to `LoweredType::plain`, the struct-level POD-blit predicate, consumed inside `lower()` — W1.1's own `NESTED_ALIGN_STANDIN` comment already said `align`'s value cannot change an outcome. Only `shape` and `cdr_op` were genuinely computed and thrown away; both are consumed now, and the other two carry comments saying under what condition that stops being true.

**One fact §6b does not mention, and it nearly broke the wave.** `element_cap` (phase-403 W7) must NOT be folded into the IR's `field_type`. Each storage surface applies `resolver.element_capped()` itself, and collapsing that into `field_type` would silently turn the rmw layer's `Sequence<String>` into `Sequence<BoundedString<N>>` — an ABI change the user's config never asked for, under no golden. It is carried as a fact with one derivation (`storage_type()`): two questions with two answers, not one fact with two spellings.

**A guard had to be built first.** `emit_corpus()`, what `codegen_golden.rs` diffs, covers `nros`, `c` and `cpp` and renders NO `rmw` or idiomatic bytes at all — two of the five surfaces could have been rewritten with nothing asserting an emitted byte. `tests/rust_surface_golden.rs` records them over the same corpus, deliberately outside `emit_corpus` so it does not move the fixture-staleness fingerprint for two surfaces with no production caller today.

All five surfaces collapsed, one commit each, goldens green at every commit. `lowered_storages`, `primitive_to_cdr_method`, `c_cdr_write_method` and `c_cdr_read_method` are deleted rather than bypassed.

**No golden moved — every byte identical at every commit.** One pre-existing defect is now recorded rather than hidden: the Rust surfaces interpolate the package name into `extern "C"` symbols verbatim, so the golden holds `fingerprint-corpus__msg__Capped__init`, which is not a Rust identifier. C and nros run the same name through `to_c_package_name`. The test file says fixing that SHOULD fail it.

Verification: `just check fast` (246 gates, 1 skipped via the skip ledger — zenoh-pico not checked out in the agent worktree); `just check repr-memory-agreement` OK at 20 pairs / 186 probes on armv7a-none-eabi, run after EVERY surface rather than once at the end; `cargo nextest run` in `packages/cli` 1699/1699; `cargo +nightly fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vi3bKPpmrys3J3foFUH9oF