### PR TITLE
fix(#1137): the peer's bus was pinned and ours was not — nine "Unsupported" were never bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,6 +762,14 @@ One-liners; detail in the linked doc. (Many also captured in agent memory.)
   transport beside the whitelisted one and isolates nothing while reading as if it does.
   Without the pin a foreign `add_two_ints_server` on ANOTHER HOST failed our XRCE service
   cell 4 of 15 and cost issue 0741 five wrong diagnoses. Opt out: `NROS_DDS_ALLOW_LAN=1`.
+  **And "both sides" includes OURS — `env_exports_for_rmw` only reaches a process started
+  from a `source setup.bash` STRING, i.e. the `ros2` peer** (issue 1137). Our half is a bare
+  `Command` and had no pin, so from 2026-09-04 every Cyclone pair ran half-pinned: the
+  Cyclone graph cell, green live on 2026-08-30, went back to enumerating only itself.
+  `dds_isolation::apply_to_command` is that half; gate `check-dds-isolation-symmetry`.
+  NOT applied in `ManagedProcess::spawn_command` on purpose — `DockerRosEnv` peers cannot
+  read a host profile path, so those pairs are symmetric-UNPINNED and pinning our half of
+  one would CREATE the bug.
 - **Manual native_sim pair repros need distinct `--seed`** — unseeded processes share the test
   entropy source → identical GUIDs/ports → discovery sees the peer as itself → false-negative
   "no delivery". The test harness seeds automatically; hand-run repros must too. → issue 0157

--- a/docs/issues/1137-cyclone-graph-reader-sees-nothing-live.md
+++ b/docs/issues/1137-cyclone-graph-reader-sees-nothing-live.md
@@ -1,13 +1,22 @@
 ---
 id: 1137
-title: "Cyclone's graph reader sees only itself against a live stock talker, and 9 of its 12 graph slots answer Unsupported — measured, first live run"
+title: "Cyclone's graph reader saw only itself against a live stock talker — the
+  harness pinned the PEER's bus to loopback and not ours, and nine of the twelve
+  `Unsupported` slots were never a defect"
 status: open
 type: bug
 area: rmw, testing
 severity: high
 found: 2026-09-06
-related: [0791, 0903, 1127]
+related: [0791, 0903, 0927, 1009, 1127]
 ---
+
+> **State: root cause identified and a fix landed; OPEN until a live run
+> confirms it.** The fix is in the harness, not in `graph.cpp`, and the only
+> thing that can close this issue is the same measurement that opened it — a
+> `graph_interop` cyclone run against a live peer, which needs the `ros2`
+> distrobox. Marking it resolved on a reasoned diagnosis is what issues
+> 0859–0862 did. See "What remains unverified".
 
 # The first live run of `graph_interop`, and Cyclone fails it
 
@@ -53,70 +62,184 @@ GRAPH_PROBE_SLOTS_PARTIAL
 GRAPH_PROBE_FAIL: expected a node matching "talker", saw ["/|graph_probe"] after 20000 ms
 ```
 
-So on Cyclone: **`get_node_names` returns one entry, the probe itself.
-`get_topic_names_and_types` errors `Transport(Unsupported)`. Nine of the twelve
-slots answer Unsupported outright.** The reader phase-381 W5 added never sees a
-participant.
+## The nine `Unsupported` slots are not a defect, and never were
 
-## The peer is not the problem — control run
+Answered first, because nine of the eleven reported lines are a correct answer
+and treating them as bugs is how a day gets spent in `graph.cpp`.
 
-Before blaming the reader (issues 0859–0862: four ghost issues filed from
-failures whose cause was the harness, two with confident wrong root causes), the
-same box was asked whether a stock Cyclone talker is discoverable at all:
+**Cyclone's vtable fills exactly ONE of the twelve graph slots.**
+`nros-rmw-cyclonedds/src/vtable.cpp:380-391` is eleven consecutive `nullptr`s
+under `/*get_node_names*/ cyclone_get_node_names,`, and a NULL slot is
+`Transport(Unsupported)` by the ABI's own contract. Three independent sources
+say that is the intent, all written when W5 landed:
+
+* phase-381's status paragraph — *"zenoh answers all twelve, Cyclone answers
+  `get_node_names`"*;
+* `bins/graph-probe/src/main.rs:194` — *"Cyclone's W5 reader serves
+  `get_node_names` and nothing else"*, which is why the probe RECORDS an
+  `Unsupported` rather than failing on it;
+* `graph_interop.rs:155` — *"Cyclone answers FEWER slots than zenoh, and that is
+  the point of W6 rather than a defect."*
+
+So the correct count is **10 of 12 `Unsupported` on Cyclone, all intended**: the
+nine the probe classifies, plus `get_topic_names_and_types` (reported separately
+as `GRAPH_PROBE_TOPICS_ERR`, and `nullptr` in the same block). The twelfth,
+`node_get_graph_guard_condition`, is `nullptr` on every backend and is a
+declared inert family in `check-rmw-slot-producers`. `Transport(Unsupported)` on
+topics is an **honest answer**, not a contradiction of a `produced`
+classification — see the classification section below.
+
+That leaves exactly one real symptom: `get_node_names` returning only self.
+
+## Root cause: the harness pinned the peer's bus and not ours
+
+**Not the reader.** `graph.cpp` is unchanged since 2026-08-31 (a `std::fprintf`
+spelling fix for threadx-riscv64) and this exact cell **passed live on
+2026-08-30** — issue 0927 records `PASS cyclone_enumerates_a_stock_ros2_node`
+after fixing the probe's `ROS_DOMAIN_ID`. The regression is dated:
+
+| date | event |
+| --- | --- |
+| 2026-08-30 | issue 0927 fixed; both graph cells PASS live |
+| 2026-09-04 | issue 1009 lands: DDS interop peers pinned to loopback |
+| 2026-09-06 | this cell fails, "sees only itself", identical signature |
+
+Issue 1009 confined every DDS interop peer to loopback, because a participant
+elsewhere on the LAN is otherwise a peer (issue 0741 lost fifteen sections to
+one). It did that in `ros2_env_setup_rmw_with_domain`, which builds a
+`source setup.bash && export …` STRING — so the pin reaches exactly one kind of
+process: **a host `ros2` peer.** Our own side of every pair is a bare
+`std::process::Command`, and it got nothing.
+
+For the Cyclone graph cell that means:
+
+* the talker, via `demo_nodes_cpp_talker_cyclonedds_with_domain`, runs under
+  `CYCLONEDDS_URI` = a profile with `NetworkInterface address="127.0.0.1"`,
+  `multicast="false"`, `AllowMulticast=false` and `<Peer address="localhost"/>`
+  — unicast SPDP on loopback, no multicast at all;
+* `graph-probe` runs with Cyclone's DEFAULT interface pick, which on a
+  distrobox (host networking) is a real ethernet interface, announcing SPDP to
+  `239.255.0.1`.
+
+Neither side's discovery traffic reaches the other. The probe's participant
+still matches its OWN `ros_discovery_info` writer, so it enumerates one node,
+itself — which is bit-for-bit the symptom issue 0927 already produced from a
+different cause, and which reads as a broken reader.
+
+**This is the failure mode issue 1009 measured and then half-applied.** Its own
+conclusion: *pin both sides or neither; half is no discovery* — batch F, 0 of 15
+with EMPTY output, because `ROS_LOCALHOST_ONLY` reached the ROS side and not the
+XRCE Agent. The same asymmetry, one lane over, two days later.
+
+### Why the issue's control run did not catch it
 
 ```
-RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ROS_DOMAIN_ID=77 ros2 run demo_nodes_cpp talker &
-$ ros2 node list --no-daemon
-/talker
-$ ros2 topic list --no-daemon
-/chatter
-/parameter_events
-/rosout
+RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ROS_DOMAIN_ID=77 ros2 run demo_nodes_cpp talker
+ros2 node list --no-daemon   # -> /talker
 ```
 
-Discovery on Cyclone works in this container. The test's own setup is also
-sound: `unique_ros_domain_id()`, a stock
-`demo_nodes_cpp_talker_cyclonedds_with_domain` on that domain, and the probe
-given the same `ROS_DOMAIN_ID`/`NROS_DOMAIN_ID`.
+Neither of those processes has `CYCLONEDDS_URI` set. The control is a
+**both-unpinned** pair, which works; the harness is a **half-pinned** pair,
+which does not. The control was right that discovery works in that container —
+it just could not see the variable that the harness adds to one side only.
 
-## Why nothing caught it earlier
+## The fix
 
-This is phase-393's closing warning, demonstrated a second time. All twelve
-Cyclone graph slots are `produced` by `check-rmw-slot-producers`, the parity
-gate reports 0 gap, and every unit test passes — because each tests our code
-against our own builders and our own parser. `interop::CELLS` even carries the
-prediction, written when the reader landed:
+One helper, applied at every spawn site whose peer is a pinned host `ros2`
+process, plus a gate.
 
-> Cyclone's half. `graph.cpp` PUBLISHED `ros_discovery_info` since phase-177.36
-> and only gained a reader in W5, **which has never been run against a live
-> participant.**
+* `dds_isolation::apply_cyclone_config` / `apply_to_command` — the
+  bare-`Command` twin of `env_exports_for_rmw`, and the sibling
+  `apply_fastdds_profile` had been on its own since 1009.
+* Applied at the five sites that pair a nano-ros DDS participant with a pinned
+  host peer: `graph_interop.rs` (the probe), `interop_e2e.rs`
+  (`spawn_nano_cyclone`, three cyclone scenarios), `ros2_action_e2e.rs` (the
+  action server — the same defect, same day, never noticed),
+  `bridge_zenoh_to_cyclonedds.rs` and
+  `declarative_bridge_zenoh_to_cyclonedds.rs` (the Cyclone egress and the
+  listener it feeds).
+* Gate: **`check-dds-isolation-symmetry`** (fast line, buildless). A tracked
+  test source that starts a pinned host DDS peer must also apply the pin to
+  what it spawns. Mutation-tested: removing one call turns it red.
 
-It had been correct and unmeasured for as long as it had existed. Issue 1127 is
-why: the lane that would have run this has not completed in 30 runs (issue
-1136), so the prediction never became a verdict.
+### What is deliberately NOT pinned
 
-## What needs deciding, before fixing
+`ManagedProcess::spawn_command` is the obvious chokepoint and would be wrong.
+The `DockerRosEnv` editions lanes run their ROS 2 peer inside a container whose
+mount namespace cannot reach a host profile path, so those pairs are
+**symmetric-unpinned** today; pinning our half of one would create this bug
+rather than fix it. The gate therefore keys on `HostRosEnv` and the host
+`Ros2*Process` helpers, never on the `Middleware` enum both backends share, and
+`spawn_command` carries the reasoning in a comment so the next reader does not
+have to re-derive it.
 
-The nine `Unsupported` slots may be a deliberate partial from W5 rather than
-breakage — the phase shipped a reader for `ros_discovery_info`, which carries
-node/topic participation, not every by-node and by-topic query. **Establish
-which of the twelve W5 intended to answer on Cyclone before treating nine
-Unsupported as nine bugs.** If the partial is intended, the honest fix is that
-`check-rmw-slot-producers` should not count a slot as `produced` for a backend
-that answers `Unsupported` at runtime — a distinction the gate does not
-currently draw, and one that would change the "34 of 88 working" headline.
+## The classification question: is `produced` lying?
 
-The remaining three are unambiguous: `get_node_names` returning only self while
-a live participant is on the domain is a defect, and
-`get_topic_names_and_types` answering `Transport(Unsupported)` contradicts its
-`produced` classification.
+The issue was filed saying *"all twelve Cyclone graph slots are `produced` by
+`check-rmw-slot-producers`"*. That is a misreading, and worth recording because
+it aimed at the wrong tool.
 
-## Reproduce
+`check-rmw-slot-producers` answers **"does ANY backend's vtable fill this
+slot"** — it says so in its own docstring, and its output is one number for the
+whole ABI (`produced 58`). It has never made a per-backend claim, so it is not
+lying about Cyclone; it simply never had the answer. Neither did anything else:
+"zenoh 12, Cyclone 1, XRCE 0" lived only in prose, in three comments.
 
-Inside the `ros2` box, on the box tree (issue 0759), sourcing `activate.sh`
-FIRST and `ros2-box-env.sh` SECOND:
+Fixed by measuring it. The report now carries a per-backend table:
+
+```
+## filled per backend (of 68 slots)
+
+  cyclonedds                        38   graph 1/12  [get_node_names]
+  rust-adapter (every Rust backend) 42   graph 11/12 [...]
+  uorb                              18   graph 0/12
+  xrce                              24   graph 0/12
+  zenoh                              4   graph 0/12
+```
+
+**And that table still cannot answer the question for a Rust backend**, which
+the report now says out loud. The adapter's graph slots are trampolines,
+non-NULL for every `R: RustBackend`, forwarding to a `Session` trait method
+whose default returns `Unsupported` — so zenoh reads as filled whether or not it
+implements anything. No static tool closes that: the answer is a live call, and
+`graph_interop` is the only thing that makes it.
+
+So the recommendation is **not** to fail `--check` on a backend that answers
+`Unsupported`. A slot a backend declines is RFC-0035's designed behaviour and
+W6's whole point; the gap was visibility, and visibility is what was added.
+
+## What remains unverified
+
+The fix could not be run against a live peer from the authoring worktree — this
+host has no ROS (`/opt/ros` absent), and the `ros2` distrobox tree was being
+re-synced by another process (issue 0759: every job in the box, on its own
+tree). What is proven locally: the gate, its mutation, the symmetry unit tests,
+and that a child given `CYCLONEDDS_URI` can read the profile it names.
+
+What needs the box to confirm:
 
 ```bash
 bash scripts/build/fixtures-build.sh linux rust cyclonedds
 cargo nextest run -p nros-tests --test graph_interop -E 'test(cyclone)'
 ```
+
+The prediction is a PASS with `GRAPH_PROBE_NODE_COUNT 2` and
+`GRAPH_PROBE_SLOTS_PARTIAL` (ten declared `Unsupported`, which the cell already
+tolerates). If it still reports one node, the next measurement is
+`NROS_GRAPH_DUMP=1`: `matched_publications=1` means the two participants still
+do not see each other (look at the bus, not at `graph.cpp`),
+`matched_publications>=2` with an empty enumeration means the reader really is
+at fault this time.
+
+Four other cells are predicted to change with it, all currently half-pinned and
+all unmeasured since 2026-09-04: `interop_e2e`'s three cyclone scenarios and
+`ros2_action_e2e`.
+
+## The class
+
+Third instance of "a variable that isolates one half of a pair", after issue
+0741's foreign peer and issue 1009's own batch F. And the second time
+`get_node_names` returning only itself has been filed as a Cyclone reader
+defect when the reader was fine (issue 0927 is the first, and it says so in its
+own title). A cyclone peer's BUS is load-bearing and silent when wrong: it does
+not error, it reports an empty graph.

--- a/docs/issues/1137-cyclone-graph-reader-sees-nothing-live.md
+++ b/docs/issues/1137-cyclone-graph-reader-sees-nothing-live.md
@@ -126,6 +126,11 @@ still matches its OWN `ros_discovery_info` writer, so it enumerates one node,
 itself — which is bit-for-bit the symptom issue 0927 already produced from a
 different cause, and which reads as a broken reader.
 
+0927's own cause is excluded by the run's first line: `GRAPH_PROBE_DOMAIN 1`
+is `unique_ros_domain_id()`'s answer for a filtered/solo nextest run
+(`domain_in_slot(0, 0)`), and `graph_interop.rs:188` hands the talker the same
+value. The two sides agree about the domain and disagree about the bus.
+
 **This is the failure mode issue 1009 measured and then half-applied.** Its own
 conclusion: *pin both sides or neither; half is no discovery* — batch F, 0 of 15
 with EMPTY output, because `ROS_LOCALHOST_ONLY` reached the ROS side and not the

--- a/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
+++ b/docs/roadmap/phase-381-graph-queries-read-the-ros-graph.md
@@ -28,6 +28,22 @@ domain's tokens. A standing liveliness SUBSCRIBER with history replaced it.
   exists in `interop::CELLS` and has never been executed; W5's reader is
   verified against our own builders only, which is exactly the state zenoh was
   in before 0903.
+  **Update 2026-09-06 (phase-433 W1, issue 1137).** It ran, and failed —
+  `get_node_names` enumerated only the probe. The reader is NOT at fault: the
+  harness had pinned the stock talker's Cyclone bus to loopback (issue 1009,
+  landed 2026-09-04) and left our side on Cyclone's default interface, so the
+  two participants never discovered each other. This cell had PASSED live on
+  2026-08-30 (issue 0927); the regression is in the test harness and dated. The
+  pin is now applied to both halves, and `check-dds-isolation-symmetry` keeps
+  it that way — but **the cell has still not been seen GREEN since, so W5's
+  reader remains live-unproven**, which is the same sentence this bullet
+  carried before.
+  W5's SCOPE, measured rather than restated: Cyclone's vtable fills
+  `get_node_names` and eleven `nullptr`s
+  (`nros-rmw-cyclonedds/src/vtable.cpp:380-391`), so ten declared
+  `Unsupported`s in that run are correct answers and not ten defects.
+  `check-rmw-slot-producers` now prints the per-backend split, so the number
+  no longer lives only in this paragraph.
 * **Ten of the twelve slots are unproven live.** Only `get_node_names` and
   `get_topic_names_and_types` have been measured against a real peer. The
   service forms, the counts and the six by-node forms are still self-verified.

--- a/just/check/fixtures.just
+++ b/just/check/fixtures.just
@@ -329,3 +329,26 @@ test-domain-assignment:
 # Pure `git ls-files` + line scan, no build, ~0.2 s -- fast line.
 test-scripts-have-callers:
     python3 scripts/check-test-scripts-have-callers.py
+
+# Issue 1137 — if the PEER's bus is pinned, OUR side's must be too.
+#
+# Issue 1009 confined every DDS interop peer to loopback, and measured that
+# pinning ONE side is worse than pinning neither (0 of 15, empty output). It was
+# then half-applied: `ros2_env_setup_rmw_with_domain` builds a shell string, so
+# the pin reached the `ros2` peer and never the bare `std::process::Command` our
+# own binaries are spawned from. Two days later
+# `cyclone_enumerates_a_stock_ros2_node` — which had PASSED live on 2026-08-30
+# (issue 0927) — enumerated exactly one node, itself, against a stock talker
+# that was up, because the talker sat on `127.0.0.1` with multicast off while
+# our probe kept Cyclone's default interface. That symptom is
+# indistinguishable from a broken `ros_discovery_info` reader, and was filed as
+# one twice.
+#
+# Keys on the HOST peer helpers, never on the `Middleware` enum: `DockerRosEnv`
+# names the same variants and its pairs are symmetric-UNPINNED (a container
+# cannot read a host profile path), so pinning our half of one would create the
+# bug rather than fix it.
+#
+# Pure `git ls-files` + line scan, no build, no ROS — fast line.
+dds-isolation-symmetry:
+    python3 scripts/check-dds-isolation-symmetry.py

--- a/packages/testing/nros-tests/src/dds_isolation.rs
+++ b/packages/testing/nros-tests/src/dds_isolation.rs
@@ -212,6 +212,74 @@ pub fn apply_fastdds_profile(cmd: &mut std::process::Command) {
     cmd.env("FASTRTPS_DEFAULT_PROFILES_FILE", fastdds_profile_path());
 }
 
+/// Put the CycloneDDS loopback config on a `Command`'s environment.
+///
+/// The sibling of [`apply_fastdds_profile`], and it did not exist — which is
+/// issue 1137. Cyclone's `dds_create_participant` reads `CYCLONEDDS_URI`
+/// through Cyclone's own loader (`nros-rmw-cyclonedds/src/session.cpp` leaves
+/// the hosted path to it deliberately), so this reaches a nano-ros binary
+/// exactly the way the shell export reaches a `ros2` peer.
+pub fn apply_cyclone_config(cmd: &mut std::process::Command) {
+    if lan_allowed() || std::env::var_os("CYCLONEDDS_URI").is_some() {
+        return;
+    }
+    cmd.env("CYCLONEDDS_URI", cyclone_config_uri());
+}
+
+/// Put EVERY known loopback profile on a `Command`'s environment — the
+/// bare-`Command` twin of [`env_exports_for_rmw`].
+///
+/// # Why this exists, and why it is not per-RMW
+///
+/// Issue 1009 pinned the bus through [`env_exports_for_rmw`], which only ever
+/// reaches a process started from a `source setup.bash` shell string — i.e. the
+/// **ROS 2 peer**. Our own side of every pair is a bare `Command`, and it got
+/// nothing. That is exactly the state the issue's own headline forbids: *pin
+/// both sides or neither; half is no discovery.* Two days later
+/// `cyclone_enumerates_a_stock_ros2_node` — which had PASSED live on 2026-08-30
+/// (issue 0927) — enumerated only itself again with the identical signature,
+/// because the stock talker was pinned to `127.0.0.1` with
+/// `AllowMulticast=false` and an explicit localhost peer while our probe kept
+/// Cyclone's default interface pick. Neither side could see the other's SPDP.
+/// Issue 1137.
+///
+/// It sets BOTH variables rather than asking which middleware the child speaks,
+/// for two reasons:
+///
+/// * the caller usually cannot know. A fixture binary is built per-RMW and the
+///   spawn site holds only a `PathBuf`; `graph-probe` is literally one source
+///   compiled once per backend.
+/// * a variable naming a middleware the child does not link is inert. That is
+///   the opposite of the `ROS_LOCALHOST_ONLY` failure this module was written
+///   about, where the variable was honoured by one side and ignored by the
+///   other — here NEITHER half of a mismatched pair can act on it, so it cannot
+///   create an asymmetry.
+///
+/// # Where to call it, and where NOT to
+///
+/// At the spawn site of a nano-ros process whose PEER is a host `ros2` process
+/// — i.e. one started through [`env_exports_for_rmw`]. Deliberately NOT inside
+/// [`crate::process::ManagedProcess::spawn_command`], which would look like the
+/// chokepoint and be wrong: the `DockerRosEnv` editions lanes run their peer in
+/// a container that cannot read a host profile path, so those pairs are
+/// symmetric-UNPINNED and pinning our half of one would CREATE this bug. What
+/// keeps a new site from forgetting is `check-dds-isolation-symmetry`, not this
+/// function's placement.
+pub fn apply_to_command(cmd: &mut std::process::Command) {
+    apply_fastdds_profile(cmd);
+    apply_cyclone_config(cmd);
+}
+
+/// Is the bus pinned for `rmw` at all? True unless the caller opted out.
+///
+/// The predicate BOTH sides are supposed to agree on, exposed so
+/// `both_spawn_paths_pin_the_same_buses` can assert the agreement rather than
+/// restate it.
+#[must_use]
+pub fn pins_loopback_for(rmw: &str) -> bool {
+    !env_exports_for_rmw(rmw).is_empty()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,5 +324,71 @@ mod tests {
         if std::env::var_os("CYCLONEDDS_URI").is_none() {
             assert!(env_exports_for_rmw("rmw_cyclonedds_cpp").contains("CYCLONEDDS_URI"));
         }
+    }
+
+    /// **Issue 1137 — the two spawn paths must pin the SAME set of buses.**
+    ///
+    /// The shell path ([`env_exports_for_rmw`]) reaches a `ros2` peer; the
+    /// `Command` path ([`apply_to_command`]) reaches our own binary. Issue 1009
+    /// built the first and not the second, so every Cyclone pair ran half
+    /// pinned, and "half is no discovery" is the issue's own conclusion.
+    ///
+    /// Asserted as an equivalence rather than as two separate presence checks:
+    /// a presence check on each side passes when only one of them exists, which
+    /// is the defect.
+    #[test]
+    fn both_spawn_paths_pin_the_same_buses() {
+        if lan_allowed() {
+            return;
+        }
+        for (rmw, var) in [
+            ("rmw_fastrtps_cpp", "FASTRTPS_DEFAULT_PROFILES_FILE"),
+            ("rmw_cyclonedds_cpp", "CYCLONEDDS_URI"),
+        ] {
+            if std::env::var_os(var).is_some() {
+                // An operator's own profile wins on both paths; nothing to compare.
+                continue;
+            }
+            let mut cmd = std::process::Command::new("true");
+            apply_to_command(&mut cmd);
+            let on_command = cmd
+                .get_envs()
+                .any(|(k, v)| k == var && v.is_some_and(|v| !v.is_empty()));
+            assert_eq!(
+                pins_loopback_for(rmw),
+                on_command,
+                "the shell path and the Command path disagree about {var}: a peer \
+                 started through `source setup.bash` and a nano-ros binary started \
+                 as a bare Command would land on different buses, which is issue \
+                 1137 (and 1009's own 'pin both sides or neither')"
+            );
+        }
+    }
+
+    /// The variable actually reaches a CHILD, and the file it names is READABLE
+    /// from there.
+    ///
+    /// Asserted on a real child's environment rather than on the `Command`
+    /// struct, and on the file's CONTENT rather than on its path: a
+    /// `CYCLONEDDS_URI` pointing at a file the child cannot open is how Cyclone
+    /// silently keeps its default interface pick, which is indistinguishable
+    /// from no pin at all — the same "absent vs empty" confusion the whole
+    /// graph family is about.
+    #[test]
+    fn a_child_inherits_a_cyclone_config_it_can_actually_read() {
+        if lan_allowed() || std::env::var_os("CYCLONEDDS_URI").is_some() {
+            return;
+        }
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", r#"cat "${CYCLONEDDS_URI#file://}""#]);
+        apply_to_command(&mut cmd);
+        let out = cmd.output().expect("run sh");
+        let text = String::from_utf8_lossy(&out.stdout).into_owned();
+        assert!(
+            text.contains("<AllowMulticast>false</AllowMulticast>"),
+            "a child given CYCLONEDDS_URI must be able to READ the profile it \
+             names; `cat` of it produced:\n{text}{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 }

--- a/packages/testing/nros-tests/src/process.rs
+++ b/packages/testing/nros-tests/src/process.rs
@@ -554,26 +554,18 @@ impl ManagedProcess {
     /// * `binary` - Path to the executable
     /// * `args` - Command line arguments
     /// * `name` - Human-readable name for error messages
+    ///
+    /// Delegates to [`Self::spawn_command`] rather than duplicating its four
+    /// lines: two copies of the spawn sequence are two places to change when
+    /// the sequence grows, and this file had exactly that shape.
     pub fn spawn(
         binary: &std::path::Path,
         args: &[&str],
         name: impl Into<String>,
     ) -> Result<Self, TestError> {
-        let name = name.into();
         let mut cmd = Command::new(binary);
-        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
-        #[cfg(unix)]
-        set_new_process_group(&mut cmd);
-        let cmdline = crate::qemu::render_command(&cmd);
-        let handle = cmd
-            .spawn()
-            .map_err(|e| TestError::ProcessFailed(format!("Failed to spawn {}: {}", name, e)))?;
-
-        Ok(Self {
-            handle,
-            name,
-            cmdline,
-        })
+        cmd.args(args);
+        Self::spawn_command(cmd, name)
     }
 
     /// Spawn a process from a Command builder
@@ -581,6 +573,19 @@ impl ManagedProcess {
     /// # Arguments
     /// * `command` - Pre-configured Command builder
     /// * `name` - Human-readable name for error messages
+    ///
+    /// # This does NOT pin the DDS bus — and that is deliberate (issue 1137)
+    ///
+    /// It is the obvious place to put [`crate::dds_isolation::apply_to_command`],
+    /// and it would be wrong. The pin is only correct when the PEER is pinned
+    /// too ("pin both sides or neither", issue 1009), and one family of peers
+    /// cannot be: the `DockerRosEnv` editions lanes run their ROS 2 side inside
+    /// a container whose mount namespace cannot reach the host profile path, so
+    /// those pairs are symmetric-UNPINNED today and pinning our half here would
+    /// break them exactly the way 1137 broke the Cyclone graph cell. So the pin
+    /// is applied at the spawn sites whose peer is a host `ros2` process, and
+    /// `check-dds-isolation-symmetry` is what keeps a new such site from
+    /// forgetting.
     pub fn spawn_command(mut command: Command, name: impl Into<String>) -> Result<Self, TestError> {
         let name = name.into();
         command.stdout(Stdio::piped()).stderr(Stdio::piped());

--- a/packages/testing/nros-tests/tests/bridge_zenoh_to_cyclonedds.rs
+++ b/packages/testing/nros-tests/tests/bridge_zenoh_to_cyclonedds.rs
@@ -86,6 +86,12 @@ fn spawn_cyclone_listener(binary: &Path, domain: u8) -> ManagedProcess {
     let mut cmd = Command::new(binary);
     cmd.env("ROS_DOMAIN_ID", domain.to_string())
         .env("RUST_LOG", "info");
+    // Issue 1137 — the same bus as the Cyclone egress it listens to, and as the
+    // `ros2 topic echo` peer the companion case starts. Every one of those goes
+    // through `ros2_env_setup_rmw_with_domain`, which has exported a
+    // loopback-only `CYCLONEDDS_URI` since issue 1009; a participant without it
+    // sits on a different interface and discovers nothing.
+    nros_tests::dds_isolation::apply_to_command(&mut cmd);
     ManagedProcess::spawn_command(cmd, "nano-cyclone-listener-bridge-e2e")
         .expect("spawn nano cyclone listener")
 }
@@ -96,6 +102,9 @@ fn spawn_bridge(bin: &Path, locator: &str, domain: u8, label: &'static str) -> M
     cmd.env("RUST_LOG", "info")
         .env("ZENOH_LOCATOR", locator)
         .env("ROS_DOMAIN_ID", domain.to_string());
+    // Issue 1137 — the bridge's Cyclone EGRESS is a DDS participant, so it needs
+    // the same loopback pin the listener and the `ros2 topic echo` peer get.
+    nros_tests::dds_isolation::apply_to_command(&mut cmd);
     let mut bridge = ManagedProcess::spawn_command(cmd, label).expect("spawn bridge");
     bridge
         .wait_for_output_pattern("Spinning", Duration::from_secs(10))
@@ -142,6 +151,8 @@ fn test_zenoh_to_cyclonedds_bridge_e2e(zenohd_unique: ZenohRouter, talker_binary
         .env("RUST_LOG", "info")
         .env("ZENOH_LOCATOR", &zenoh_locator)
         .env("ROS_DOMAIN_ID", domain.to_string());
+    // Issue 1137 — same bus as the Cyclone listener this feeds.
+    nros_tests::dds_isolation::apply_to_command(&mut bridge_cmd);
     let mut bridge = ManagedProcess::spawn_command(bridge_cmd, "bridge-zenoh-to-cyclonedds-fwd")
         .expect("spawn bridge");
     bridge

--- a/packages/testing/nros-tests/tests/declarative_bridge_zenoh_to_cyclonedds.rs
+++ b/packages/testing/nros-tests/tests/declarative_bridge_zenoh_to_cyclonedds.rs
@@ -100,6 +100,11 @@ fn spawn_cyclone_listener(binary: &Path, domain: u8) -> ManagedProcess {
     // wire keyexpr, and the Int32-typed cyclone topic won't match a String sub.
     cmd.env("ROS_DOMAIN_ID", domain.to_string())
         .env("RUST_LOG", "info");
+    // Issue 1137 — the same bus as the bridge's Cyclone egress and as the
+    // `ros2 topic echo` peer the companion case starts; that peer has carried a
+    // loopback-only `CYCLONEDDS_URI` since issue 1009, and half a pin is no
+    // discovery.
+    nros_tests::dds_isolation::apply_to_command(&mut cmd);
     ManagedProcess::spawn_command(cmd, "nano-cyclone-listener-declarative-bridge")
         .expect("spawn nano cyclone listener")
 }
@@ -167,6 +172,8 @@ fn declarative_zenoh_to_cyclonedds_bridge_to_nano_listener() {
             format!("NROS_BRIDGE_{CYCLONE_NODE}_DOMAIN"),
             domain.to_string(),
         );
+    // Issue 1137 — the Cyclone egress is a DDS participant; same bus as its peer.
+    nros_tests::dds_isolation::apply_to_command(&mut bridge_cmd);
     let mut bridge = ManagedProcess::spawn_command(bridge_cmd, "bridge-cyclonedds-native_entry")
         .expect("spawn declarative bridge entry");
     std::thread::sleep(Duration::from_secs(2));
@@ -246,6 +253,9 @@ fn declarative_zenoh_to_cyclonedds_nested_header_to_ros2() {
             format!("NROS_BRIDGE_{CYCLONE_NODE}_DOMAIN"),
             domain.to_string(),
         );
+    // Issue 1137 — the Cyclone egress is a DDS participant; same bus as the
+    // `ros2 topic echo` peer below.
+    nros_tests::dds_isolation::apply_to_command(&mut bridge_cmd);
     let mut bridge =
         ManagedProcess::spawn_command(bridge_cmd, "bridge-cyclonedds-native_entry-nested")
             .expect("spawn declarative bridge entry");

--- a/packages/testing/nros-tests/tests/graph_interop.rs
+++ b/packages/testing/nros-tests/tests/graph_interop.rs
@@ -182,13 +182,24 @@ fn cyclone_enumerates_a_stock_ros2_node() {
 
     let probe = fixtures::build_graph_probe_rmw(nros_tests::fixtures::Rmw::Cyclonedds)
         .expect("prebuilt cyclone graph-probe");
-    let out = Command::new(probe)
-        .env("GRAPH_PROBE_EXPECT_NODE", "talker")
+    let mut cmd = Command::new(probe);
+    cmd.env("GRAPH_PROBE_EXPECT_NODE", "talker")
         .env("GRAPH_PROBE_TIMEOUT_MS", "20000")
         .env("ROS_DOMAIN_ID", domain.to_string())
-        .env("NROS_DOMAIN_ID", domain.to_string())
-        .output()
-        .expect("run graph-probe");
+        .env("NROS_DOMAIN_ID", domain.to_string());
+    // Issue 1137 — the SAME bus as the talker.
+    //
+    // `demo_nodes_cpp_talker_cyclonedds_with_domain` funnels through
+    // `ros2_env_setup_rmw_with_domain`, which since issue 1009 exports a
+    // `CYCLONEDDS_URI` confining that participant to `127.0.0.1` with
+    // `AllowMulticast=false` and an explicit localhost peer. This probe is a
+    // bare `Command` — not a `ManagedProcess`, which pins itself — so without
+    // this line the two sides sit on different interfaces and neither one's
+    // SPDP reaches the other. The probe then enumerates exactly one node,
+    // itself, which is indistinguishable from a broken `ros_discovery_info`
+    // reader and was filed as one twice (0927, then 1137).
+    nros_tests::dds_isolation::apply_to_command(&mut cmd);
+    let out = cmd.output().expect("run graph-probe");
     let output = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),

--- a/packages/testing/nros-tests/tests/interop_e2e.rs
+++ b/packages/testing/nros-tests/tests/interop_e2e.rs
@@ -209,6 +209,13 @@ fn spawn_nano_cyclone(binary: &Path, name: &str, domain_id: u8) -> ManagedProces
         _ => cyclone_lib.into_os_string(),
     };
     cmd.env("LD_LIBRARY_PATH", ld);
+    // Issue 1137 — the SAME bus as the `ros2` peer on the other side of every
+    // cyclone cell. Those peers go through `ros2_env_setup_rmw_with_domain`,
+    // which has exported a loopback-only `CYCLONEDDS_URI` since issue 1009;
+    // this half got nothing, so the pair sat on two different interfaces and
+    // discovered nothing at all. "Pin both sides or neither" is 1009's own
+    // conclusion, and this is the other side.
+    nros_tests::dds_isolation::apply_to_command(&mut cmd);
     ManagedProcess::spawn_command(cmd, name).unwrap_or_else(|_| panic!("Failed to start {name}"))
 }
 

--- a/packages/testing/nros-tests/tests/ros2_action_e2e.rs
+++ b/packages/testing/nros-tests/tests/ros2_action_e2e.rs
@@ -62,9 +62,17 @@ fn a_stock_ros2_client_drives_the_nano_ros_action_server() {
     });
 
     let domain = action_domain();
-    let mut server = Command::new(&server_bin)
+    let mut server_cmd = Command::new(&server_bin);
+    server_cmd
         .env("RMW_IMPLEMENTATION", "rmw_cyclonedds_cpp")
-        .env("ROS_DOMAIN_ID", domain.to_string())
+        .env("ROS_DOMAIN_ID", domain.to_string());
+    // Issue 1137 — the same bus as the `HostRosEnv` peer below. That env string
+    // funnels through `ros2_env_setup_rmw_with_domain`, which has exported a
+    // loopback-only `CYCLONEDDS_URI` since issue 1009; without the matching pin
+    // here the two participants sit on different interfaces and `send_goal`
+    // fails to discover the action at all.
+    nros_tests::dds_isolation::apply_to_command(&mut server_cmd);
+    let mut server = server_cmd
         .spawn()
         .expect("start the nano-ros action server");
 

--- a/scripts/check-dds-isolation-symmetry.py
+++ b/scripts/check-dds-isolation-symmetry.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""issue 1137 — if the PEER's bus is pinned, OUR side's must be too.
+
+Issue 1009 confined every DDS interop peer to loopback, because a participant on
+the LAN is otherwise a peer: `ros2_env_setup_rmw_with_domain` exports a
+`FASTRTPS_DEFAULT_PROFILES_FILE` / `CYCLONEDDS_URI` naming a whitelist profile.
+That helper builds a `source setup.bash && export …` STRING, so it reaches
+exactly one kind of process — a host `ros2` peer. Our own side of every pair is
+a bare `std::process::Command`, and it got nothing.
+
+The issue's own headline says what that costs: **pin both sides or neither; half
+is no discovery.** It was measured for Fast-DDS (0 of 15 with the variable on one
+side) and then half-applied. Two days later `cyclone_enumerates_a_stock_ros2_node`
+— which had PASSED live on 2026-08-30, issue 0927 — enumerated one node, itself,
+against a stock talker that was up. The stock talker was pinned to `127.0.0.1`
+with `AllowMulticast=false`; the nano-ros probe kept Cyclone's default interface
+pick. Neither side's SPDP could reach the other, and the symptom is
+indistinguishable from a broken `ros_discovery_info` reader — which is what it
+was filed as, for the second time.
+
+What this checks
+----------------
+A tracked test source that starts a HOST ROS 2 DDS peer (the helpers that pin,
+listed in PINNING_PEERS) must also apply the matching pin to the processes it
+spawns itself — `nros_tests::dds_isolation::apply_to_command` /
+`apply_cyclone_config` / `apply_fastdds_profile`.
+
+Two things are structurally out of scope rather than allowlisted:
+
+  1. The implementation files themselves (`src/dds_isolation.rs`, `src/ros2.rs`,
+     `src/ros_env.rs`). Those ARE the procedure.
+  2. `DockerRosEnv` peers. A container has its own mount namespace, so it cannot
+     read a host profile path, and those pairs are symmetric-UNPINNED today.
+     Pinning our half of one would CREATE this bug rather than fix it — so the
+     detector keys on `HostRosEnv` / the host `Ros2*Process` helpers, never on
+     the `Middleware` enum both backends share.
+
+Anything else legitimate is in ALLOWLIST, path-keyed, one reason each.
+
+Dependency-free Python 3.10, house style per `scripts/check-ros-env-spelling.py`.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TESTS = "packages/testing/nros-tests/"
+
+# Helpers that start a host ROS 2 peer whose env is pinned by
+# `ros2_env_setup_rmw_with_domain`. Every one of these funnels through it.
+PINNING_PEERS = (
+    "Ros2DdsProcess::",
+    "ros2_env_setup_dds",
+    "ros2_env_setup_cyclonedds",
+    "ros2_env_setup_rmw_with_domain",
+)
+
+# `HostRosEnv` is only a pinning peer for a DDS middleware — a zenoh peer is
+# keyed by locator, not by a bus, and nothing pins it. Requires BOTH tokens,
+# because `DockerRosEnv` names the same `Middleware` variants and must not match.
+HOST_ENV = "HostRosEnv::new"
+DDS_MIDDLEWARE = ("Middleware::Cyclonedds", "Middleware::FastRtps")
+
+# Our side of the pair, applied to a `Command`.
+APPLIES_PIN = (
+    "dds_isolation::apply_to_command",
+    "dds_isolation::apply_cyclone_config",
+    "dds_isolation::apply_fastdds_profile",
+)
+
+# The files that ARE the procedure — see docstring rule 1.
+SANCTIONED = {
+    TESTS + "src/dds_isolation.rs",
+    TESTS + "src/ros2.rs",
+    TESTS + "src/ros_env.rs",
+}
+
+ALLOWLIST = {
+    TESTS
+    + "tests/xrce_ros2_interop.rs": (
+        "The nano-ros side is an XRCE client, not a DDS participant: it speaks "
+        "XRCE to the micro-XRCE Agent, and the Agent is the process that joins "
+        "the peer's DDS bus. The Agent IS pinned, by "
+        "`fixtures::xrce_agent`'s `apply_fastdds_profile` (issue 1009). "
+        "Pinning the XRCE client would export a variable it cannot read, which "
+        "is the `ROS_LOCALHOST_ONLY` mistake one layer over."
+    ),
+}
+
+REMEDY = (
+    "call `nros_tests::dds_isolation::apply_to_command(&mut cmd)` on every "
+    "Command this file spawns that joins the peer's DDS bus"
+)
+CONSEQUENCE = (
+    "the peer is confined to 127.0.0.1 with AllowMulticast=false and our side "
+    "keeps the middleware's default interface pick, so neither one's discovery "
+    "traffic reaches the other. The cell then reports an EMPTY graph / no "
+    "delivery, which reads as a backend defect (issues 0927 and 1137 were both "
+    "filed as exactly that)."
+)
+
+
+def tracked_files():
+    out = subprocess.run(
+        ["git", "ls-files", TESTS + "tests", TESTS + "src", TESTS + "bins"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [p for p in out.stdout.splitlines() if p.endswith(".rs")]
+
+
+def starts_a_pinned_peer(text):
+    """Does this source start a HOST ROS 2 peer whose bus issue 1009 pinned?"""
+    for token in PINNING_PEERS:
+        if token in text:
+            return token
+    if HOST_ENV in text:
+        for mw in DDS_MIDDLEWARE:
+            if mw in text:
+                return f"{HOST_ENV} + {mw}"
+    return None
+
+
+def applies_the_pin(text):
+    return any(token in text for token in APPLIES_PIN)
+
+
+def self_test(quiet=False):
+    bad = []
+
+    # A host DDS peer with no pin on our side is the defect.
+    defect = 'Ros2DdsProcess::topic_echo_cyclonedds_with_domain(...);\nCommand::new(bin)'
+    if starts_a_pinned_peer(defect) is None or applies_the_pin(defect):
+        bad.append("the 1137 shape is not detected")
+
+    # The same file, fixed.
+    fixed = defect + "\nnros_tests::dds_isolation::apply_to_command(&mut cmd);"
+    if not applies_the_pin(fixed):
+        bad.append("a fixed file is still reported")
+
+    # A DOCKER peer must NOT be treated as a pinned peer: those pairs are
+    # symmetric-unpinned, and pinning our half would create the bug. This is the
+    # case that makes the `HostRosEnv`/`Middleware` distinction load-bearing.
+    docker = 'DockerRosEnv::new(&ed, Middleware::Cyclonedds { domain_id: d });'
+    if starts_a_pinned_peer(docker) is not None:
+        bad.append("a DockerRosEnv peer was read as a pinned peer")
+
+    # A zenoh host peer is not a DDS bus at all.
+    zenoh = "HostRosEnv::new(distro, Middleware::zenoh_default());"
+    if starts_a_pinned_peer(zenoh) is not None:
+        bad.append("a zenoh HostRosEnv peer was read as a pinned peer")
+
+    # Every allowlisted / sanctioned path still exists — a stale entry is a hole
+    # that reads like a decision.
+    for path in sorted(SANCTIONED | set(ALLOWLIST)):
+        if not (ROOT / path).is_file():
+            bad.append(f"{path} is named here but does not exist")
+
+    if bad:
+        for b in bad:
+            sys.stderr.write("check-dds-isolation-symmetry --self-test: " + b + "\n")
+        return 2
+    if not quiet:
+        print("check-dds-isolation-symmetry --self-test: OK (4 case(s), "
+              f"{len(SANCTIONED)} sanctioned, {len(ALLOWLIST)} allowlisted)")
+    return 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        return self_test()
+    if self_test(quiet=True) != 0:
+        return 2
+
+    findings = []
+    peers = 0
+    for path in tracked_files():
+        if path in SANCTIONED:
+            continue
+        full = ROOT / path
+        if not full.is_file():
+            continue
+        try:
+            text = full.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        token = starts_a_pinned_peer(text)
+        if token is None:
+            continue
+        peers += 1
+        if path in ALLOWLIST or applies_the_pin(text):
+            continue
+        findings.append((path, token))
+
+    print(
+        f"DDS isolation symmetry: {peers} file(s) start a pinned host ROS 2 DDS "
+        f"peer, {len(ALLOWLIST)} allowlisted"
+    )
+
+    if findings:
+        print(
+            "\n[FAIL] a pinned ROS 2 DDS peer with an UNPINNED nano-ros side:",
+            file=sys.stderr,
+        )
+        for path, token in findings:
+            print(f"  - {path}: starts a peer via `{token}`", file=sys.stderr)
+        print(f"\n  WHAT TO DO: {REMEDY}", file=sys.stderr)
+        print(f"\n  WHY IT MATTERS: {CONSEQUENCE}", file=sys.stderr)
+        return 1
+
+    print("Every pinned peer has a pinned partner.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-rmw-slot-producers.py
+++ b/scripts/check-rmw-slot-producers.py
@@ -82,6 +82,27 @@ PRODUCER_GLOBS = (
 
 NULL_VALUES = {"nullptr", "NULL", "None", "0"}
 
+# The graph family (phase-381). Called out per backend because it is the one
+# family where the backends legitimately differ by an order of magnitude —
+# zenoh reads `@ros2_lv` liveliness tokens and answers all of it, Cyclone reads
+# the `ros_discovery_info` topic and answers node enumeration, XRCE has no graph
+# at all — and because reading the ANY-backend aggregate as a per-backend claim
+# is issue 1137.
+GRAPH_SLOTS = {
+    "get_node_names",
+    "get_topic_names_and_types",
+    "get_service_names_and_types",
+    "get_publisher_names_and_types_by_node",
+    "get_subscriber_names_and_types_by_node",
+    "get_service_names_and_types_by_node",
+    "get_client_names_and_types_by_node",
+    "get_publishers_info_by_topic",
+    "get_subscriptions_info_by_topic",
+    "count_publishers",
+    "count_subscribers",
+    "node_get_graph_guard_condition",
+}
+
 # A NULL slot's documented behaviour, in the header, near the declaration.
 NULL_DOC = re.compile(r"NULL (slot|function pointer|=)", re.IGNORECASE)
 
@@ -190,6 +211,46 @@ def consumers_in(text, slots):
     return {s for s in slots if re.search(CONSUME.format(re.escape(s)), text)}
 
 
+def backend_of(rel):
+    """The backend a producer file belongs to — `packages/rmw/<b>/...`.
+
+    The Rust adapter is not a backend: it fills slots for EVERY `R:
+    RustBackend`, so attributing its slots to one name would be a lie in both
+    directions. It is reported under its own label.
+    """
+    if rel.endswith("rust_adapter.rs"):
+        return "rust-adapter (every Rust backend)"
+    parts = rel.split("/")
+    if len(parts) > 2 and parts[0] == "packages" and parts[1] == "rmw":
+        return parts[2]
+    return rel
+
+
+def producers_by_backend(slots):
+    """backend -> the slots ITS vtable fills.
+
+    Issue 1137 — the aggregate `produced` answers "does ANY backend fill this",
+    which is what this tool documents and exactly what it should answer for a
+    question about the ABI. It was then READ as a per-backend claim: the issue
+    was filed saying "all twelve Cyclone graph slots are `produced`", and nine
+    answering `UNSUPPORTED` live looked like nine regressions. Cyclone fills ONE
+    of the twelve (`get_node_names`) and the other eleven are `nullptr` on
+    purpose — phase-381 W5's stated scope, which lived only in prose. So the
+    per-backend split is MEASURED here rather than argued anywhere, and the
+    aggregate keeps meaning what it always meant.
+    """
+    out = {}
+    for rel in _git("ls-files", *PRODUCER_GLOBS):
+        try:
+            text = open(os.path.join(ROOT, rel), encoding="utf-8").read()
+        except OSError:
+            continue
+        got = producers_in(text, slots)
+        if got:
+            out.setdefault(backend_of(rel), set()).update(got)
+    return out
+
+
 def scan():
     slots = header_slots()
 
@@ -257,6 +318,20 @@ def self_test():
     if consumers_in("context->ops->publish(x)", slots):
         bad.append("an unrelated ops table was counted as a vtable consumer")
 
+    # Per-backend attribution (issue 1137). The adapter must NOT be attributed
+    # to a backend name — it fills slots for every Rust backend, so calling it
+    # "zenoh" would be wrong in both directions.
+    if backend_of("packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp") != "cyclonedds":
+        bad.append("a backend vtable was not attributed to its backend")
+    if backend_of("packages/rmw/cffi/src/rust_adapter.rs") == "cffi":
+        bad.append("the Rust adapter was attributed to a backend")
+
+    # Every graph slot named here is a real slot. A typo would silently shrink
+    # the family and make a backend look more complete than it is.
+    for s in sorted(GRAPH_SLOTS):
+        if s not in set(header_slots()):
+            bad.append(f"GRAPH_SLOTS names {s}, which is not a slot")
+
     # Every family member is a real slot, and no slot is in two families.
     real = set(header_slots())
     seen = set()
@@ -272,7 +347,7 @@ def self_test():
         for b in bad:
             sys.stderr.write("check-rmw-slot-producers --self-test: " + b + "\n")
         return 2
-    print(f"check-rmw-slot-producers --self-test: OK ({len(seen)} family member(s), 5 case(s))")
+    print(f"check-rmw-slot-producers --self-test: OK ({len(seen)} family member(s), 8 case(s))")
     return 0
 
 
@@ -294,6 +369,36 @@ def main(argv):
     print(f"# vtable slots: {total}\n")
     for k in ("produced", "default", "unimplemented", "inert"):
         print(f"  {k:<14} {counts.get(k, 0):>3}")
+
+    # Per-backend, and the graph family called out — issue 1137. `produced`
+    # above is an ANY-backend answer about the ABI; this is the per-backend one,
+    # and it is the difference between "the slot works" and "the slot works on
+    # the backend you are running".
+    by_backend = producers_by_backend(list(kinds))
+    if by_backend:
+        print("\n## filled per backend (of {} slots)\n".format(len(kinds)))
+        for name in sorted(by_backend):
+            got = by_backend[name]
+            graph = sorted(GRAPH_SLOTS & got)
+            print(
+                f"  {name:<32} {len(got):>3}   graph {len(graph)}/{len(GRAPH_SLOTS)}"
+                + (f"  [{', '.join(graph)}]" if graph else "")
+            )
+        print(
+            "\n  A slot this backend does not fill answers UNSUPPORTED at runtime,\n"
+            "  which is a DECLARED 'cannot tell you' — never an empty result\n"
+            "  (RFC-0035 / phase-381 W6). Do not read the aggregate above as a\n"
+            "  per-backend capability: issue 1137 did, and nine correct\n"
+            "  UNSUPPORTEDs were filed as nine bugs.\n"
+            "\n"
+            "  AND THIS TABLE STILL CANNOT ANSWER IT FOR A RUST BACKEND. The\n"
+            "  adapter row is a trampoline per slot, non-NULL for EVERY\n"
+            "  `R: RustBackend`, and the trampoline forwards to a `Session`\n"
+            "  trait method whose default returns `Unsupported`. So a Rust\n"
+            "  backend reads as filled here whether or not it implements the\n"
+            "  method. Nothing static closes that gap — the answer is a live\n"
+            "  call, which is what `graph_interop` is for."
+        )
 
     for k in ("default", "unimplemented", "inert"):
         members = [s for s, v in kinds.items() if v == k]


### PR DESCRIPTION
Fixes the largest defect phase-433 found. **The Cyclone graph reader was never at fault**, and nine of the twelve "Unsupported" slots were never bugs.

## What W5 intended, measured

`nros-rmw-cyclonedds/src/vtable.cpp:380-391` fills **one** of the twelve graph slots — `get_node_names` — followed by eleven consecutive `nullptr`s. A NULL slot is `Transport(Unsupported)` by the ABI's contract. Three sources written when W5 landed agree: phase-381's status line ("zenoh answers all twelve, Cyclone answers `get_node_names`"), `graph-probe`'s own comment, and `graph_interop.rs`'s.

So the correct reading of the failing run is **10 of 12 declared `Unsupported` on Cyclone, all intended** (the nine the probe classifies plus `get_topic_names_and_types`, reported separately as `GRAPH_PROBE_TOPICS_ERR`). `Transport(Unsupported)` on topics is an **honest answer**, not a contradiction.

That leaves exactly one real symptom: `get_node_names` returning only self.

## Root cause: the harness pinned the PEER's bus and not ours

| date | event |
| --- | --- |
| 2026-08-30 | issue 0927 fixed; **both graph cells PASS live** |
| 2026-09-04 | issue 1009 lands: DDS interop peers pinned to loopback |
| 2026-09-06 | this cell fails, "sees only itself", identical signature |

Issue 1009 pins the bus in `ros2_env_setup_rmw_with_domain`, which builds a `source setup.bash && export …` **string** — so it reaches one kind of process, a host `ros2` peer. Our side of every pair is a bare `std::process::Command` and got nothing.

* talker: `NetworkInterface address="127.0.0.1"`, `multicast="false"`, `AllowMulticast=false`, `<Peer address="localhost"/>`
* `graph-probe`: Cyclone's default interface pick, multicast SPDP

Neither side's discovery reaches the other. The probe still matches its **own** `ros_discovery_info` writer → one node. This is the failure 1009 itself measured (batch F: 0/15, empty output) and whose conclusion it wrote down — *pin both sides or neither; half is no discovery* — and then half-applied.

`graph.cpp` is unchanged since 2026-08-31 (a `std::fprintf` spelling fix). The issue's control run used **no** `CYCLONEDDS_URI` on either process — a both-unpinned pair, which works; only the harness is half-pinned.

## The fix

Sweep: `git grep -n 'Ros2DdsProcess::\|ros2_env_setup_\(dds\|cyclonedds\|rmw_with_domain\)\|HostRosEnv::new' -- packages/testing/nros-tests/tests`

Five files, all half-pinned since 2026-09-04, all fixed: `graph_interop`, `interop_e2e` (`spawn_nano_cyclone`, three cyclone scenarios), `ros2_action_e2e` (same defect, same day, unnoticed), and both zenoh→cyclone bridges.

* `dds_isolation::apply_cyclone_config` / `apply_to_command` — the bare-`Command` twin of `env_exports_for_rmw`; `apply_fastdds_profile` had been the only half.
* gate **`check-dds-isolation-symmetry`** (fast line, buildless), mutation-tested.
* two unit tests that fail on the same mutation: `both_spawn_paths_pin_the_same_buses` (an **equivalence** — a presence check on each side passes while only one exists, which is the defect) and `a_child_inherits_a_cyclone_config_it_can_actually_read` (reads the profile from inside a real child).

**Deliberately NOT in `ManagedProcess::spawn_command`.** It looks like the chokepoint and would be wrong: `DockerRosEnv` editions peers run in a container that cannot read a host profile path, so those pairs are symmetric-**unpinned** and pinning our half of one would *create* this bug. The gate keys on `HostRosEnv` / host `Ros2*Process`, never on the `Middleware` enum both backends share.

## `produced` vs `Unsupported`

`check-rmw-slot-producers` was **not** lying. It answers "does ANY backend fill this slot", says so in its docstring, and prints one number for the whole ABI. The issue read that as a per-backend claim. The per-backend answer lived only in prose; it is measured now:

```
cyclonedds                        38   graph 1/12  [get_node_names]
rust-adapter (every Rust backend) 42   graph 11/12 [...]
uorb / xrce / zenoh(own table)         graph 0/12
```

…and the report says out loud what that **still** cannot answer: the adapter's slots are trampolines, non-NULL for every `R: RustBackend`, forwarding to a trait method whose default is `Unsupported`. No static tool closes that; a live call does. So `--check` is unchanged — a declined slot is RFC-0035's designed behaviour and W6's whole point, and the gap was visibility.

## What remains unverified

This host has no ROS and the `ros2` box tree was being re-synced (issue 0759), so **the fix has not met a live peer**. Issue 1137 stays `open` for that reason.

Proven locally: `just check fast` green (241 ran, 7 provisioning skips, 0 failed), `cargo build -p nros-tests --tests`, the gate + its mutation, the two unit tests + their mutation.

To close it, in the box:

```bash
bash scripts/build/fixtures-build.sh linux rust cyclonedds
cargo nextest run -p nros-tests --test graph_interop -E 'test(cyclone)'
```

expecting `GRAPH_PROBE_NODE_COUNT 2` + `GRAPH_PROBE_SLOTS_PARTIAL`. If it still reports one node, `NROS_GRAPH_DUMP=1` separates the two explanations in one number: `matched_publications=1` means the bus, `>=2` with an empty enumeration means the reader really is at fault this time.

Four other cells are predicted to change with it, all unmeasured since 2026-09-04: `interop_e2e`'s three cyclone scenarios and `ros2_action_e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA
