### PR TITLE
fix(#1177): the no-alloc lane is red and ungated, and the core crates now declare no_std

### DIFF
--- a/docs/issues/1177-no-alloc-nros-c-lane-runs-only-on-schedule.md
+++ b/docs/issues/1177-no-alloc-nros-c-lane-runs-only-on-schedule.md
@@ -1,0 +1,102 @@
+---
+id: 1177
+title: "The no-alloc `nros-c` lane exists, is RED on main, and no merge-gating
+  event runs it -- an embedded consumer finds the break instead"
+status: open
+type: bug
+area: testing, build, c-api
+severity: high
+related: [issue-0196, issue-0952, phase-395, phase-417]
+---
+
+## What happens
+
+`check::workspace-features` builds `nros-c` without `std` and without `alloc`:
+
+```
+cargo clippy -p nros-c --no-default-features \
+    --features "panic-platform,rmw-cffi,lending" -- -D warnings
+```
+
+On `origin/main` at `fdc0604c5` that command reports **11 errors**. The lane is
+not missing. It is red, and nothing that gates a merge runs it:
+
+* `workspace-features` sits in the `build-serial` tier, i.e. `check-build`.
+* `gate.yml` states, in its own comment, that `check-build` is **schedule /
+  dispatch ONLY** -- `pull_request` gets `check-fast + compile-smoke +
+  cli-tests`, `merge_group` adds `test-unit + workspace-all`, and only the
+  daily `schedule` adds `check-build`.
+
+So a no-alloc break can land on a green PR, pass the merge queue, and sit on
+main until either the nightly notices or a consumer does.
+
+## How it surfaced
+
+The safety island (MR-CANHUBK344, `thumbv7em-none-eabihf`, no `std`, no
+`alloc`) could not build against main. `nros-c`'s spin loop calls five methods
+that no longer exist for it:
+
+```
+error[E0599]: no method named `enter_spin_loop` found for
+              `&mut Executor<'static>`
+    --> packages/api/nros-c/src/executor.rs:2891:45
+```
+
+`4b80db633` gated `impl Executor` on `#[cfg(feature = "alloc")]`, which is
+CORRECT for `nros-node` -- `halt_flag` is an `Arc` and genuinely needs alloc.
+What it did not do is gate, stub, or otherwise handle the five ungated callers
+in `nros-c`: `enter_spin_loop`, `exit_spin_loop`, `is_halted`, `cancel`,
+`is_spinning`. The fix moved the breakage from one crate to the next, and the
+lane that would have said so does not run on a pull request.
+
+The commit before it, `4b80db633~1`, does not build the island either -- it
+fails with duplicate `halt`/`is_halted` definitions and a missing `spinning`
+field, which is what `4b80db633` was fixing. phase-417 is mid-flight and main
+is red for embedded consumers in a moving way; this issue is about the
+COVERAGE, not about that phase's in-progress state.
+
+## Why this is the issue-0196 shape
+
+A gate that never runs is indistinguishable from a gate that passes. Three
+feature-gate defects of exactly this form -- a `#[cfg]`-gated item with an
+ungated caller -- were found by hand on 2026-09-05/06 rather than by CI:
+
+1. `nros_platform_api::task` gated on `alloc` while the executor's stack-
+   headroom rule called it on every feature set;
+2. `SimTimeGuard` gated on `sim-time` while `ros_time_timer_follows_the_
+   simulated_clock` was not;
+3. this one.
+
+Each was invisible to the lanes that DO gate a merge, because those lanes build
+with `std`, and `std` implies `alloc`.
+
+## The tension, stated rather than wished away
+
+`check-build` was moved off the merge group for a real reason, recorded in
+`gate.yml` and in `check-lane-contracts`: it resolves generated bindings and
+prebuilt `.compile-ok` artifacts that no CI job builds, so it could never pass
+there and left the required check red for every pull request for a day. The
+rule that came out of it -- a gate in an affordability tier may only resolve
+artifacts the job itself builds -- is right and should not be reverted.
+
+So the fix is NOT "put check-build back on the merge group".
+
+## Directions
+
+* **Move only the FEATURE checks.** `workspace-features` is clippy over feature
+  combinations. If it needs no fixture and no SDK, it belongs in a tier that
+  runs per PR. The obstacle is named in `lanes.just` itself: `nros-c`'s build
+  script needs a cross C toolchain, which is why `nros-c` is absent from
+  `check::no-std`. Whether the PR runner has one is the question to answer
+  first, and it is answerable in one CI run.
+* **Or add a narrow no-alloc smoke to `compile-smoke`**, which already runs per
+  PR, covering just the crates an embedded consumer links.
+* **Or accept the daily latency and make it loud** -- `just nightly-triage`
+  exists; a red `workspace-features` that nobody reads is the same defect one
+  level up.
+
+## Do not
+
+Do not fix the symptom by giving `nros-c` `std` in the lane. The whole point of
+the combination is that an embedded image has neither `std` nor `alloc`, and a
+lane that builds the easy configuration is the lane we already have.

--- a/just/check/platform.just
+++ b/just/check/platform.just
@@ -331,6 +331,23 @@ no-direct-kernel-alloc:
 no-std-stdio:
     @python3 scripts/check-no-std-stdio.py
 
+# Its sibling on the other half of the same claim. `no-std-stdio` checks that a
+# `#![no_std]` crate does not reach for `std` stdio; this checks that the core
+# crates SAY `#![no_std]` in the first place, unconditionally.
+#
+# The conditional spelling -- `cfg_attr(not(feature = "std"), no_std)` -- is
+# what makes the first gate's target move: it compiles a different crate per
+# feature, and the configuration an embedded image uses is the one every
+# merge-gating lane skips, because those lanes build with `std`. `nros-log`
+# carried that form until 2026-09-06 while its `std` feature did nothing but
+# alias `alloc`, so the second configuration existed and bought nothing.
+#
+# Buildless, and NOT about the alloc axis: a core crate may still use `alloc`
+# behind its own feature. That axis is issue 1177.
+[group("ci")]
+core-crates-are-no-std:
+    @python3 scripts/check-core-crates-are-no-std.py
+
 # issue 0488 residue 4 follow-up — the NuttX integration Makefile is on a path no
 # lane executes (`CONFIG_NROS` is set by no shipped defconfig), so it rots.
 [private]

--- a/packages/core/nros-log/src/lib.rs
+++ b/packages/core/nros-log/src/lib.rs
@@ -32,7 +32,16 @@
 //! }
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+// UNCONDITIONAL. This was `cfg_attr(not(feature = "std"), no_std)`, which
+// bought nothing: this crate's `std` feature is `std = ["alloc"]` over
+// `alloc = []`, so it enables no std functionality and the crate uses none.
+// The conditional form only meant that building with `std` compiled a
+// DIFFERENT crate -- a second configuration nobody wanted and no lane checked.
+//
+// ARCHITECTURE section 2 / phase-359: the terminal state of a core crate is
+// `core` or `core+alloc`. `check-core-crates-are-no-std` holds every core
+// crate to this spelling.
+#![no_std]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 

--- a/scripts/check-core-crates-are-no-std.py
+++ b/scripts/check-core-crates-are-no-std.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Every core crate declares `#![no_std]` UNCONDITIONALLY.
+
+ARCHITECTURE section 2 / phase-359: the terminal state of the core crates is
+`core` and `core+alloc`. `std` there is a second implementation of the platform
+layer, not a convenience over it.
+
+WHY THE SPELLING MATTERS, and why this is not a style gate.
+
+`#![cfg_attr(not(feature = "std"), no_std)]` compiles a DIFFERENT CRATE
+depending on a feature. Both configurations are then real, both need testing,
+and the one an embedded image uses is the one CI is least likely to build --
+every merge-gating lane in this repo builds with `std`, because `std` is what a
+host test needs. So the conditional form quietly creates the configuration that
+nothing checks.
+
+`#![no_std]` unconditional removes the choice. A core crate that cannot name
+`std` cannot grow a dependency on it, and `check-no-std-stdio` (the sibling
+gate) then has a fixed target rather than a moving one.
+
+This does NOT stop a crate using `alloc` -- that is a separate axis and a
+legitimate one (`extern crate alloc` behind `feature = "alloc"`). Issue 1177 is
+about the alloc axis; this gate is about the std one.
+
+Run: python3 scripts/check-core-crates-are-no-std.py [--self-test]
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# The core crates: the layer that must run on a target with no operating
+# system. Deliberately a LIST rather than a glob over `packages/core` -- a new
+# crate landing there should have to be added here on purpose, with a person
+# deciding it is core, instead of being swept in by a directory name.
+CORE_CRATES = [
+    "packages/core/nros-node",
+    "packages/core/nros-core",
+    "packages/core/nros-rmw",
+    "packages/core/nros-log",
+    "packages/core/nros-params",
+    "packages/platform/nros-platform-api",
+]
+
+UNCONDITIONAL = re.compile(r"^\s*#!\[no_std\]", re.M)
+CONDITIONAL = re.compile(r"^\s*#!\[cfg_attr\([^)]*no_std", re.M)
+
+
+def offenders(roots=None, repo=None):
+    base = Path(repo) if repo else REPO
+    out = []
+    for rel in roots if roots is not None else CORE_CRATES:
+        lib = base / rel / "src" / "lib.rs"
+        if not lib.is_file():
+            out.append((rel, "no src/lib.rs"))
+            continue
+        text = lib.read_text(errors="replace")
+        if UNCONDITIONAL.search(text):
+            continue
+        if CONDITIONAL.search(text):
+            out.append((rel, "conditional `cfg_attr(..., no_std)` -- make it unconditional"))
+        else:
+            out.append((rel, "no `#![no_std]` at all"))
+    return out
+
+
+def self_test():
+    """A crate with each spelling, so the gate is known to be able to fail."""
+    import tempfile
+
+    cases = [
+        ("#![no_std]\n", 0, "unconditional passes"),
+        ('#![cfg_attr(not(feature = "std"), no_std)]\n', 1, "conditional is caught"),
+        ("// nothing\n", 1, "missing is caught"),
+        ("//! docs\n#![no_std]\n", 0, "unconditional after a doc comment passes"),
+    ]
+    failures = 0
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for i, (body, want, name) in enumerate(cases):
+            rel = f"crate{i}"
+            (root / rel / "src").mkdir(parents=True)
+            (root / rel / "src" / "lib.rs").write_text(body)
+            got = len(offenders(roots=[rel], repo=root))
+            if got != want:
+                print(f"  self-test FAIL: {name} -- got {got}, want {want}", file=sys.stderr)
+                failures += 1
+    if failures:
+        print(f"check-core-crates-are-no-std self-test: FAILED ({failures})", file=sys.stderr)
+        return 1
+    print(f"check-core-crates-are-no-std self-test: OK ({len(cases)} cases)")
+    return 0
+
+
+def main(argv):
+    if len(argv) == 2 and argv[1] == "--self-test":
+        return self_test()
+    if self_test():
+        return 1
+    bad = offenders()
+    if not bad:
+        print(f"check-core-crates-are-no-std: OK -- {len(CORE_CRATES)} core crate(s) are unconditionally no_std.")
+        return 0
+    print("check-core-crates-are-no-std: a core crate does not declare `#![no_std]`:", file=sys.stderr)
+    for rel, why in bad:
+        print(f"  {rel}: {why}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  A core crate runs where there is no operating system. The conditional", file=sys.stderr)
+    print("  form compiles a different crate per feature, and the configuration an", file=sys.stderr)
+    print("  embedded image uses is the one no merge-gating lane builds.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-std-census.py
+++ b/scripts/check-std-census.py
@@ -270,7 +270,14 @@ BASELINE = {
     # reads `$NROS_ENTRY_SPIN_MS` — and both had been free-riding on `nros`'s
     # guards until issue 0669's follow-up correctly relaxed one of them.
     "nros-cpp": {"cfg": 3, "path": 2},
-    "nros-log": {"cfg": 1, "path": 0},
+    # 2026-09-06: cfg 1 -> 0. The one site was the crate attribute itself,
+    # `#![cfg_attr(not(feature = "std"), no_std)]`, and it bought nothing --
+    # this crate's `std` is `std = ["alloc"]` over `alloc = []`, so it enables
+    # no std functionality and the crate uses none. The conditional form only
+    # meant `std` compiled a DIFFERENT crate: a second configuration nobody
+    # wanted and no merge-gating lane built. Now `#![no_std]` unconditionally,
+    # held there by `check-core-crates-are-no-std`.
+    "nros-log": {"cfg": 0, "path": 0},
     # phase-361 W8.e: +1, the `signal-fd-wake` `compile_error!` guard — the
     # feature used to list `"std"` and now requires it by name.
     # Two changes met here and both are counted. `c3a16a529` (#607) raised


### PR DESCRIPTION
Two halves of the same problem: an embedded consumer finds breaks that CI never builds.

## Issue 1177 -- filed, not fixed

`check::workspace-features` builds `nros-c` with neither `std` nor `alloc`. On `origin/main` at `fdc0604c5` that clippy invocation reports **11 errors**. The coverage is not missing. It is **red, and nothing that gates a merge runs it** -- `workspace-features` lives in `build-serial` i.e. `check-build`, which `gate.yml` documents as schedule/dispatch ONLY.

Found because the safety island (thumbv7em, no std, no alloc) could not build against main. `4b80db633` gated `impl Executor` on `alloc` -- correct in itself, `halt_flag` is an `Arc` -- and left five ungated callers in `nros-c`'s spin loop: `enter_spin_loop`, `exit_spin_loop`, `is_halted`, `cancel`, `is_spinning`. The breakage moved from one crate to the next.

Third defect of that exact form in two days, after the `nros_platform_api::task` alloc gate and `SimTimeGuard`. All three invisible to the merge-gating lanes for one reason: **those lanes build with `std`, and `std` implies `alloc`.**

Filed rather than fixed: phase-417 is mid-flight and main is red for embedded consumers in a moving way -- the commit *before* the one above fails differently, with duplicate `halt`/`is_halted` and a missing `spinning` field. Patching that from outside would collide. The issue states the tension it must not break (`check-build` was moved off the merge group for a real reason, and `check-lane-contracts` enforces the rule that came out of it) and offers three directions.

## The core crates now declare `#![no_std]`, and a gate says so

ARCHITECTURE section 2 / phase-359 already states the terminal shape -- `core`, or `core+alloc`. Five of six core crates were already there, by convention, with nothing checking it.

`nros-log` was the sixth, spelled `#![cfg_attr(not(feature = "std"), no_std)]`. That bought nothing: its `std` feature is `std = ["alloc"]` over `alloc = []`, so it enables no std functionality and the crate uses none. What it did buy was a **second configuration** -- `std` compiled a different crate -- that nobody wanted and no merge-gating lane built. Now unconditional; verified compiling under no features, `std`, and `alloc`.

`check-core-crates-are-no-std` holds all six there, failing on the conditional spelling as well as a missing attribute. Verified to exit 1 on the conditional form and 0 on the unconditional one, plus four self-test cases. The crate list is explicit rather than a glob, so a new crate under `packages/core` has to be added on purpose.

`std-census` caught the improvement and wanted its baseline lowered -- the ratchet working. nros-log cfg 1 -> 0.

## Scope, because it is easy to over-read

This is the **std axis only**. A core crate may still use `alloc` behind its own feature, and the three recent breakages are the **alloc axis**. This gate does not close 1177; it removes one way for the target to move.

## Verification

`just check fast` -- 248/248 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)