### PR TITLE
feat(phase-432 W2.5b): a language contributes a FILTER SET, and four checks say so

### DIFF
--- a/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
+++ b/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
@@ -248,15 +248,59 @@ idiomatic and FFI (it speaks the C ABI natively) and no cargo scaffold. That is
 a smaller and much more honest question than "write a pack", and stating it is
 most of what §8 owes a newcomer.
 
+### The surface decision table
+
+The question a newcomer has to answer is not "how do I write a pack" but "which
+of these do I need". Each row is independently optional; each carries its own
+obligation, and the obligations are the part that is easy to miss.
+
+**Message surfaces** — one message package, rendered several ways:
+
+| surface | what it emits | a language needs it when | what it drags in |
+| --- | --- | --- | --- |
+| idiomatic | the type a user of the language writes against | always — this is the point of adding the language | nothing beyond the pack |
+| embedded-idiomatic | the same type without an allocator (`no_std`, bounded storage) | the language runs on the RTOS targets, not just the host | the bounded-storage vocabulary; capacities come from the IR, not from the pack |
+| FFI / ABI | the layout that crosses the C ABI boundary | the language talks to `libnros`, i.e. almost always | **the memory-agreement gate (§5)** — its layout is compared against the C pack's on a cross target |
+| bridge glue | two spellings of ONE type, for a pair of languages | the language must hand structs to another language in-process | both halves move together or the layouts disagree; the `cpp` pack is this, and it emits Rust |
+| packaging | the build files that make the generated tree a unit the toolchain accepts | the language has a package manager the build must satisfy | its own manifest vocabulary — this is the surface with the least in common between languages |
+
+**Entry surfaces** — the generated program that boots the image. A second axis,
+not a sixth row: a language may take an entry surface without any message
+surface (it consumes another language's messages) or the reverse.
+
+| surface | what it emits | a language needs it when |
+| --- | --- | --- |
+| entry TU | the `main` / `app_main` that constructs nodes and hands them to the board | users write ENTRIES in this language, not only components |
+| component seam | the `extern "C"` declarations an entry calls to install a component | users write COMPONENTS in this language that some other entry installs |
+
+Read the two axes together and the honest sizing falls out. Rust today takes
+four message surfaces and both entry surfaces. C takes two message surfaces
+(idiomatic, FFI — they are the same surface for C) and both entry ones. Zig
+would take idiomatic and FFI on the message side, and could ship with only the
+component seam on the entry side — a Zig component installed by a C or C++
+entry — which is a materially smaller first version than "add Zig".
+
+**The costs that do NOT scale down with the surface count** are in §8's closing
+paragraph and in Track 3 of phase-432: the toolchain story. Picking two surfaces
+instead of five shrinks the codegen work and leaves the build integration where
+it was.
+
 The naming should follow: `packs/<surface>/` is what the directories already
 are, and the registry keys (`message.h`, `message.c`, `build.rs`) are already
 surface names rather than language names. The entry side should join that
 convention — `packs/entry/<surface>/` — rather than inventing a second one.
 
-Two entry renderers exist today (`rust_entry.rs.jinja`, `c_entry.c.jinja` +
-`c_service_trailer.c.jinja`) with 20 goldens proving byte-equivalence with the
-emitters they replaced. They should move from `templates/` to
-`packs/entry/<lang>/` so there is one convention.
+All three entry renderers exist today — `rust_entry.rs.jinja`, the C pack
+(`c_entry.c.jinja` + `c_service_trailer.c.jinja`) and, since phase-432 W2.3,
+the C++ pack (`cpp_entry.cpp.jinja` plus partials for one node's construction,
+the boot wrapper and the service trailer) — with **35 goldens** proving
+byte-equivalence with the emitters they replaced. Two partials are SHARED by
+the C and C++ packs rather than duplicated, because their bytes are identical C
+that a C++ entry compiles unchanged: `declare_calls.c.jinja` (the remap and
+param calls, with the executor expression as a field) and `boot_config.c.jinja`
+(the `NROS_BOOT_CONFIG` blob). They should move from `templates/` to
+`packs/entry/<lang>/`, with the shared pair somewhere that says it is shared,
+so there is one convention.
 
 **The tier table must use DESIGNATED initialisers.** It was emitted positionally
 against `nros_native_tier_spec_t` — mirrored by hand across **eight** sites, not
@@ -489,12 +533,13 @@ CMake-side property no pack can state about itself.
 
 ## 8. Adding a language — the whole procedure
 
-0. **Decide which SURFACES the language needs** — idiomatic, embedded-idiomatic,
-   FFI/ABI, bridge glue, packaging. This is the step the first draft omitted by
-   assuming one pack per language, and it is the step that sizes the work: Rust
-   has four packs, and the `cpp` pack emits Rust as well as C++. A language that
-   speaks the C ABI (most of them) needs an FFI surface and inherits the memory
-   agreement gate with it (§5).
+0. **Decide which SURFACES the language needs** — the decision table is in §6.
+   This is the step the first draft omitted by assuming one pack per language,
+   and it is the step that sizes the work: Rust has four message packs, and the
+   `cpp` pack emits Rust as well as C++. A language that speaks the C ABI (most
+   of them) needs an FFI surface and inherits the memory-agreement gate with it
+   (§5). Answer this before writing anything; a language can ship with two
+   surfaces and gain the rest later.
 1. `packs/entry/<lang>/entry.<ext>.jinja` — over `LoweredEntry`. Boot shape,
    board path, tier rows, QoS codes and escaped literals arrive computed.
 2. One row in the pack registry (`include_str!`).

--- a/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
+++ b/docs/design/0091-one-entry-codegen-producer-many-language-packs.md
@@ -446,6 +446,60 @@ alone, so the ROS-ABI mirror (`rmw`) must keep spelling the `.msg` type while
 questions with two answers, which is not the same as one fact with two
 spellings.
 
+### Corrections from implementing W2.5b
+
+The counts above HOLD — measured, not repeated. Ten filters are registered;
+`snake_case` is the one that belongs to no language and the other nine are
+per-language type spellings. Three things the numbers do not say:
+
+**The nine do not split three ways.** It is **C 2, C++ 4, Rust 3** — the C++
+pack carries twice what C does because it emits a PAIR (§6b's W2.5a
+correction), so it needs `cpp_type` / `cpp_array_suffix` for the header AND
+`cpp_repr_c_type` / `cpp_view_repr_type` for the `repr(C)` mirror.
+
+**One of the names is a lie, and it is the one this document quotes.**
+`cpp_repr_c_type` and `cpp_view_repr_type` return **Rust** — `[u8; 32]`, `u32`,
+`nros_cpp_heap_str_t`, straight out of `repr_c_type_for_field`. The `cpp_`
+prefix names the pack that CALLS them, not the language they spell. That is
+§6's "the `cpp` pack emits Rust" showing up in the filter names, and it settles
+how the registry is keyed: **by the pack that calls a filter, not by the syntax
+it emits.** Keying by emitted syntax would file those two under Rust, and then
+the first language that wanted its own FFI mirror would grow the *Rust* set —
+backwards for a procedure whose whole promise is "your language, your set".
+
+**`snake_case`'s neutrality is provable, not merely plausible.** The same
+`utils::to_snake_case` builds C header names in `generator/srv.rs`, C++ header
+names in `generator/cpp.rs`, and Rust constant names in the `nros` pack: one ROS
+naming convention, three languages. It is the rosidl convention, not a Rust one.
+
+The set now lives in `rosidl_codegen::filters` as `FILTER_SETS`, keyed by
+`nros_lang::Language`, and four tests hold it together in both directions —
+every `Language` has a set, every declared name is one its `register` really
+adds, every filter a bundled pack CALLS is registered, and every registered
+filter is CALLED. The third of those is the one with teeth: minijinja resolves a
+filter at render time, so before it, a pack naming a filter nobody registers
+failed at some user's build.
+
+They are Rust tests and not a `just check` gate on purpose. `check-cli-tests`
+is on the required `CI` context for every pull request, so they gate a merge
+either way; and the checks read `bundled_packs()` and the registry directly,
+which a Python gate could only do by re-spelling both — a second spelling of
+one rule is the drift this whole phase is about. (This is also not W3.3: that
+item is a CONFORMANCE gate for ENTRY packs — declared templates, required
+outputs for a reference plan, a golden coordinate — and it depends on W3.2's
+`pack.toml`. This is the message side's own "and nothing more" clause.)
+
+**The entry side's `c_str` is the same shape and is deliberately still
+separate.** It is a per-language escape (`nros-cli-core`'s
+`codegen/entry/render.rs` argues the point itself: C, Rust and Zig escape
+differently, so there is no neutral pre-escaped value), so by KIND it belongs in
+the C set. What keeps it out is not the contract but the ENVIRONMENT: entry
+templates are not in `bundled_packs()`, which feeds the codegen fingerprint, and
+registering them there would tie entry codegen to message-fixture staleness.
+`FilterSet::register` takes an `&mut Environment`, so both environments can
+share one registry without sharing one template list — that unification belongs
+with W2.5/W2.6, when the entry templates become packs.
+
 ### The filters are already the right shape
 
 `c_type` takes a `CTypeSpell` and returns a spelling. That IS the

--- a/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
+++ b/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
@@ -394,12 +394,23 @@ settled work.
   embedded C there — so the blindness is latent, not live. It becomes live the
   moment the routing branch is deleted, which is exactly what W3.1 proposes.
 
-- **W3.1b — the surface decision, written down.** RFC-0091 §6 — a pack is a
-  (language x SURFACE), not a language: Rust has FOUR packs and the `cpp` pack
-  emits Rust. So the first question for a new language is which surfaces it
-  needs (idiomatic / embedded-idiomatic / FFI / bridge / packaging), not "write
-  a pack". Zig would want idiomatic and FFI and no cargo scaffold. Stating this
-  is most of what a newcomer is owed, and it costs a table.
+- **W3.1b — the surface decision, written down. DONE.** RFC-0091 §6 now
+  carries "The surface decision table": five MESSAGE surfaces (idiomatic,
+  embedded-idiomatic, FFI/ABI, bridge glue, packaging) with what each emits,
+  when a language needs it, and — the column that was missing from the prose —
+  **what each one drags in**. An FFI surface is not just a template; it
+  inherits the memory-agreement gate (§5). A bridge surface is two spellings of
+  one type that must move together. A packaging surface has the least in common
+  between languages of any of them.
+
+  Writing it out produced one thing the prose did not have: **entry surfaces
+  are a SECOND AXIS, not a sixth row.** A language may take an entry surface
+  with no message surface (it consumes another language's messages), or the
+  reverse. The two entry surfaces are the entry TU and the component seam, and
+  separating them changes the sizing answer: Zig could ship with the component
+  seam alone — a Zig component installed by a C or C++ entry — which is a much
+  smaller first version than "add Zig". §8 step 0 now points at the table
+  rather than restating it.
 
 - **W3.2 — a pack manifest.** `packs/entry/<lang>/pack.toml`: which template
   renders which output, the file extension, and whether the TU is C-family (so

--- a/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
+++ b/docs/roadmap/phase-432-codegen-one-producer-many-packs.md
@@ -241,6 +241,41 @@ to remove.
   agreement gate (W1.2) exists because two filters can disagree, so the two
   work items are each other's justification.
 
+  **LANDED.** `rosidl_codegen::filters` — `FILTER_SETS`, one entry per
+  `nros_lang::Language` plus the neutral one, each a declared name list beside
+  the `register` fn that adds them. `render.rs` calls `register_all` and knows
+  nothing else about languages. Counted rather than repeated, and the count
+  HELD: ten registered, `snake_case` the one neutral, nine per-language.
+
+  Three findings, all written into RFC-0091 §6b ("Corrections from implementing
+  W2.5b"). The nine split **C 2 / C++ 4 / Rust 3**, not evenly — the C++ pack
+  emits a header/`repr(C)` pair. **`cpp_repr_c_type` and `cpp_view_repr_type`
+  return Rust**, not C++: the `cpp_` prefix names the pack that calls them. So
+  the registry keys ownership by the CALLING PACK, not by emitted syntax —
+  otherwise the first language wanting an FFI mirror would grow the *Rust* set.
+  And `snake_case`'s neutrality is provable by use: the same `to_snake_case`
+  builds C headers, C++ headers and Rust constants.
+
+  What makes it more than a rename is the four tests, in both directions:
+  every `Language` has a set, every declared name is really registered, every
+  filter a bundled pack CALLS is registered, and every registered filter is
+  CALLED. The third is the one with teeth — minijinja resolves filters at
+  RENDER time, so a pack naming an unregistered filter used to fail at a user's
+  build. It reads the packs with minijinja's OWN lexer
+  (`machinery::tokenize`, a dev-dependency feature): the packs emit Rust and
+  C++, so their text is full of `|item|` closures and `a || b`: a textual scan
+  of `|ident` over the packs yields 23 names, of which **12 are not filters**
+  (`item`, `crate`, `i`, `rmw`, `buffer`, `_`, `handler`, `scratch`,
+  `ptr_ref`, `callback`, `response`, `request_scratch`). Each check
+  was mutation-tested (drop the Rust set / declare an unregistered name / typo
+  `c_type` to `c_typo` in `packs/c/message.h.jinja`) — all RED, restored GREEN.
+
+  Not done, on purpose: the entry side's `c_str` filter stays where it is. It
+  belongs to the C set by KIND, but the two ENVIRONMENTS must stay separate
+  (entry templates are not in `bundled_packs()`, which feeds the codegen
+  fingerprint), and `FilterSet::register` takes an `&mut Environment` so both
+  can share one registry when W2.5/W2.6 make the entry templates packs.
+
 - **W2.5 — packs move to `packs/<surface>/` and `packs/entry/<surface>/`.** Mirrors the message side's
   `rosidl-codegen/packs/<lang>/*.jinja` registry rather than the `templates/`
   layout the renderer shipped with. One convention or it drifts, which is the

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "criterion",
  "minijinja",
  "nros-core",
+ "nros-lang",
  "nros-serdes",
  "rosidl-lower",
  "rosidl-parser",

--- a/packages/cli/rosidl-codegen/Cargo.toml
+++ b/packages/cli/rosidl-codegen/Cargo.toml
@@ -34,10 +34,20 @@ nros-serdes = { path = "../../core/nros-serdes", default-features = false }
 # runtime it was built against rather than a second copy of it.
 nros-core = { path = "../../core/nros-core", default-features = false }
 minijinja.workspace = true
+# phase-432 W2.5b (RFC-0091 §6b) — the filter registry is keyed by `Language`,
+# so a variant added to the one enumeration has a compile-time home here. That
+# crate is `serde`-and-nothing-else by design (see its module docs), so this
+# costs the codegen graph nothing.
+nros-lang.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+# phase-432 W2.5b — `machinery::tokenize` is minijinja's OWN lexer. The filter
+# closure check must tell a `|` that is a filter call from a `|item|` closure in
+# the Rust the packs EMIT; a regex cannot, the lexer can. Dev-only, so the
+# shipped binary never carries the unstable API.
+minijinja = { workspace = true, features = ["unstable_machinery"] }
 tempfile = "3.0"
 criterion = "0.7"
 walkdir = "2.0"

--- a/packages/cli/rosidl-codegen/src/filters.rs
+++ b/packages/cli/rosidl-codegen/src/filters.rs
@@ -1,0 +1,461 @@
+//! RFC-0091 §6b / phase-432 W2.5b — **a language contributes a FILTER SET.**
+//!
+//! A pack is `.jinja` text and a serializable context; the only Rust a language
+//! adds is the handful of filters that turn a neutral fact into that language's
+//! syntax. `c_type` takes a [`CTypeSpell`] and returns a C spelling — that IS
+//! the neutral-fact-to-language-syntax boundary, and RFC-0091 §6b names it as
+//! the model the rest of the pipeline should follow.
+//!
+//! Until this module the ten filters were registered flat into one
+//! `Environment`, so the code said nothing about which language owned which.
+//! "Adding a language = a pack plus a filter set" was a claim with no place to
+//! put the second half. Here it has one: [`FILTER_SETS`], one entry per
+//! [`Language`] plus the neutral set, and [`for_language`] answers the question
+//! a newcomer actually asks.
+//!
+//! ## What "owns" means here
+//!
+//! A set is keyed by the language whose PACKS call the filters — the language
+//! you are adding. It is deliberately not keyed by the syntax a filter emits,
+//! and the difference is real rather than pedantic:
+//! [`crate::types::cpp_repr_c_type_spelling`] and its `view` sibling return
+//! **Rust** (`[u8; 32]`, `u32`, `nros_cpp_heap_str_t`), because the `cpp` pack
+//! emits a `repr(C)` Rust mirror beside its header — RFC-0091 §6's "the `cpp`
+//! pack emits Rust", visible in the filter names. Keying by emitted syntax
+//! would file those two under Rust, and then adding a language that needed its
+//! own FFI mirror would grow the *Rust* set, which is exactly backwards for the
+//! procedure this module exists to make honest.
+//!
+//! ## The neutral set
+//!
+//! `snake_case` is the one filter that belongs to no language. It implements
+//! the ROS naming convention (`PoseStamped` -> `pose_stamped`), and the proof
+//! that it is neutral is by USE, not by assertion: the same
+//! [`crate::utils::to_snake_case`] builds C header names in
+//! `generator/srv.rs`, C++ header names in `generator/cpp.rs`, and Rust
+//! constant names in the `nros` pack. One convention, three languages.
+//!
+//! ## What holds the set together
+//!
+//! Four tests at the bottom of this file, in both directions:
+//!
+//! * every [`Language`] has a set (adding a variant to `nros-lang` fails here);
+//! * every name a set DECLARES is one its `register` actually adds;
+//! * every filter a bundled pack CALLS is declared by some set — the check that
+//!   would otherwise happen at render time, i.e. at a user's build;
+//! * every declared filter is called by some pack — no dead spellings.
+
+use minijinja::{Environment, value::ViaDeserialize};
+use nros_lang::Language;
+
+/// The neutral facts a C field carries for the C-type pack filters (RFC-0068
+/// step 2). Deserialized from the field's serialized form; extra keys are
+/// ignored.
+#[derive(serde::Deserialize)]
+struct CTypeSpell {
+    field_type: rosidl_parser::FieldType,
+    is_configurable: bool,
+    is_heap: bool,
+    cap: usize,
+    current_package: String,
+}
+
+/// Neutral facts the Rust-type pack filters (`rust_type_rmw` /
+/// `rust_type_idiomatic`) compose the Rust type string from. `current_package`
+/// drives the self-ref (`crate::` vs `pkg::`) choice inside
+/// `rust_type_for_field`.
+#[derive(serde::Deserialize)]
+struct RustTypeSpell {
+    field_type: rosidl_parser::FieldType,
+    current_package: String,
+}
+
+impl RustTypeSpell {
+    fn pkg(&self) -> Option<&str> {
+        (!self.current_package.is_empty()).then_some(self.current_package.as_str())
+    }
+}
+
+/// Neutral facts the `cpp_type` / `cpp_array_suffix` pack filters compose the
+/// C++ header type from.
+#[derive(serde::Deserialize)]
+struct CppTypeSpell {
+    field_type: rosidl_parser::FieldType,
+    is_borrowed: bool,
+    is_heap: bool,
+    cap: Option<usize>,
+    current_package: String,
+}
+
+/// Neutral facts the `cpp_repr_c_type` / `cpp_view_repr_type` pack filters
+/// compose the C++ FFI Rust `repr(C)` type from.
+#[derive(serde::Deserialize)]
+struct CppReprSpell {
+    field_type: rosidl_parser::FieldType,
+    struct_name: String,
+    cap: Option<usize>,
+    current_package: String,
+    name: String,
+    is_string: bool,
+    is_sequence: bool,
+    is_heap: bool,
+    is_borrowed: bool,
+}
+
+impl CppReprSpell {
+    fn pkg(&self) -> Option<&str> {
+        (!self.current_package.is_empty()).then_some(self.current_package.as_str())
+    }
+}
+
+/// Neutral facts the `nros_type` pack filter composes the nros Rust type from.
+#[derive(serde::Deserialize)]
+struct NrosTypeSpell {
+    field_type: rosidl_parser::FieldType,
+    is_configurable: bool,
+    is_heap: bool,
+    cap: usize,
+    mode: crate::types::NrosCodegenMode,
+    current_package: String,
+}
+
+/// One language's Rust surface area in the codegen — a named set of filters and
+/// the function that registers them.
+///
+/// `filters` is authored beside `register` on purpose and the two are checked
+/// against each other (`declared_names_are_the_registered_ones`): an authored
+/// list nobody compares is the drift this repo has been bitten by before.
+pub struct FilterSet {
+    /// The language whose packs call these filters, or `None` for the neutral
+    /// set that every pack may call.
+    pub language: Option<Language>,
+    /// A short human name for the set, used in diagnostics.
+    pub name: &'static str,
+    /// Every filter name this set registers, in registration order.
+    pub filters: &'static [&'static str],
+    /// Registers `filters` on an environment.
+    pub register: fn(&mut Environment<'_>),
+}
+
+/// The one filter that belongs to no language: the ROS `CamelCase` ->
+/// `snake_case` naming convention, shared by the C, C++ and Rust surfaces.
+const NEUTRAL: FilterSet = FilterSet {
+    language: None,
+    name: "neutral",
+    filters: &["snake_case"],
+    register: |env| {
+        env.add_filter("snake_case", |s: &str| crate::utils::to_snake_case(s));
+    },
+};
+
+/// The C pack's spellings (`packs/c`). RFC-0068 step 2 moved these out of the
+/// pre-baked `CField.c_type` / `.array_suffix`.
+const C: FilterSet = FilterSet {
+    language: Some(Language::C),
+    name: "c",
+    filters: &["c_type", "c_array_suffix"],
+    register: |env| {
+        env.add_filter("c_type", |v: ViaDeserialize<CTypeSpell>| {
+            let c = &v.0;
+            let cp = (!c.current_package.is_empty()).then_some(c.current_package.as_str());
+            crate::types::c_type_spelling(&c.field_type, c.is_configurable, c.is_heap, c.cap, cp)
+        });
+        env.add_filter("c_array_suffix", |v: ViaDeserialize<CTypeSpell>| {
+            let c = &v.0;
+            crate::types::c_array_suffix_spelling(
+                &c.field_type,
+                c.is_configurable,
+                c.is_heap,
+                c.cap,
+            )
+        });
+    },
+};
+
+/// The C++ pack's spellings (`packs/cpp`). Four, not two: the pack emits a
+/// header AND the `repr(C)` Rust mirror the C++ FFI glue needs, so
+/// `cpp_repr_c_type` / `cpp_view_repr_type` return Rust syntax while belonging
+/// to the C++ pack (see the module docs).
+const CPP: FilterSet = FilterSet {
+    language: Some(Language::Cpp),
+    name: "cpp",
+    filters: &[
+        "cpp_type",
+        "cpp_array_suffix",
+        "cpp_repr_c_type",
+        "cpp_view_repr_type",
+    ],
+    register: |env| {
+        env.add_filter("cpp_type", |v: ViaDeserialize<CppTypeSpell>| {
+            let c = &v.0;
+            let cp = (!c.current_package.is_empty()).then_some(c.current_package.as_str());
+            crate::types::cpp_type_spelling(&c.field_type, c.is_borrowed, c.is_heap, c.cap, cp)
+        });
+        env.add_filter("cpp_array_suffix", |v: ViaDeserialize<CppTypeSpell>| {
+            crate::types::cpp_array_suffix_spelling(&v.0.field_type, v.0.is_borrowed)
+        });
+        env.add_filter("cpp_repr_c_type", |v: ViaDeserialize<CppReprSpell>| {
+            let c = &v.0;
+            crate::types::cpp_repr_c_type_spelling(
+                &c.field_type,
+                c.is_sequence,
+                c.is_heap,
+                c.is_string,
+                c.cap,
+                &c.struct_name,
+                &c.name,
+                c.pkg(),
+            )
+        });
+        env.add_filter("cpp_view_repr_type", |v: ViaDeserialize<CppReprSpell>| {
+            let c = &v.0;
+            crate::types::cpp_view_repr_type_spelling(
+                &c.field_type,
+                c.is_borrowed,
+                c.is_sequence,
+                c.is_heap,
+                c.is_string,
+                c.cap,
+                &c.struct_name,
+                &c.name,
+                c.pkg(),
+            )
+        });
+    },
+};
+
+/// The Rust packs' spellings. Three filters for three SURFACES of one language
+/// (RFC-0091 §6): the ROS-ABI mirror (`packs/rmw`), the idiomatic binding
+/// (`packs/rust`) and the embedded `nros` one (`packs/nros`), whose storage
+/// decision and codegen mode make it a different spelling of the same field.
+const RUST: FilterSet = FilterSet {
+    language: Some(Language::Rust),
+    name: "rust",
+    filters: &["rust_type_rmw", "rust_type_idiomatic", "nros_type"],
+    register: |env| {
+        env.add_filter("rust_type_rmw", |v: ViaDeserialize<RustTypeSpell>| {
+            crate::types::rust_type_for_field(&v.0.field_type, true, v.0.pkg())
+        });
+        env.add_filter("rust_type_idiomatic", |v: ViaDeserialize<RustTypeSpell>| {
+            crate::types::rust_type_for_field(&v.0.field_type, false, v.0.pkg())
+        });
+        env.add_filter("nros_type", |v: ViaDeserialize<NrosTypeSpell>| {
+            let n = &v.0;
+            let cp = (!n.current_package.is_empty()).then_some(n.current_package.as_str());
+            crate::types::nros_type_spelling(
+                &n.field_type,
+                n.is_configurable,
+                n.is_heap,
+                n.cap,
+                n.mode,
+                cp,
+            )
+        });
+    },
+};
+
+/// Every filter set: the neutral one, then one per [`Language`].
+///
+/// This is THE registry. A language missing from it fails
+/// `every_language_contributes_a_filter_set`, which is the whole point — the
+/// set has a declared home instead of being ten flat `add_filter` calls.
+pub const FILTER_SETS: &[FilterSet] = &[NEUTRAL, C, CPP, RUST];
+
+/// The filter set a language contributes, if it has one.
+pub fn for_language(language: Language) -> Option<&'static FilterSet> {
+    FILTER_SETS.iter().find(|s| s.language == Some(language))
+}
+
+/// The neutral set — the filters no language owns and every pack may call.
+pub fn neutral() -> &'static FilterSet {
+    FILTER_SETS
+        .iter()
+        .find(|s| s.language.is_none())
+        .expect("the neutral set is a const in this module")
+}
+
+/// Every filter name the renderer registers, across all sets.
+pub fn all_filter_names() -> impl Iterator<Item = &'static str> {
+    FILTER_SETS.iter().flat_map(|s| s.filters.iter().copied())
+}
+
+/// Register every set on an environment. The renderer's one call site.
+pub fn register_all(env: &mut Environment<'_>) {
+    for set in FILTER_SETS {
+        (set.register)(env);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Names a bundled pack passes through a `|` filter, found with minijinja's
+    /// OWN lexer rather than a regex.
+    ///
+    /// That distinction is load-bearing: the packs emit Rust and C++, so their
+    /// raw text is full of `|item|` closures and `a || b`. A textual scan reads
+    /// those as filter calls. The tokenizer only leaves template-expression
+    /// regions as tokens — everything else arrives as one `TemplateData` blob —
+    /// so `Pipe` followed by `Ident` is exactly a filter call and nothing else.
+    fn filters_called_by(source: &str) -> Vec<String> {
+        use minijinja::machinery::{Token, tokenize};
+
+        let mut found = Vec::new();
+        let mut after_pipe = false;
+        for tok in tokenize(source, false, Default::default(), Default::default()) {
+            let (tok, _span) = tok.expect("bundled pack must tokenize");
+            match tok {
+                Token::Pipe => after_pipe = true,
+                Token::Ident(name) if after_pipe => {
+                    found.push(name.to_string());
+                    after_pipe = false;
+                }
+                _ => after_pipe = false,
+            }
+        }
+        found
+    }
+
+    /// Is `name` resolvable as a filter on `env`?
+    ///
+    /// minijinja has no `get_filter`, and it resolves filters at RENDER time —
+    /// which is the defect this file's checks exist to move earlier. So probe:
+    /// render a one-filter expression and look at the error KIND. A registered
+    /// filter that dislikes the argument fails some other way; only an absent
+    /// one is `UnknownFilter`.
+    fn resolves(env: &Environment<'_>, name: &str) -> bool {
+        match env.render_str(&format!("{{{{ 1|{name} }}}}"), ()) {
+            Ok(_) => true,
+            Err(e) => e.kind() != minijinja::ErrorKind::UnknownFilter,
+        }
+    }
+
+    /// The addressability this wave is for. A `Language` variant added to
+    /// `nros-lang` with no filter set fails HERE, in the crate that would
+    /// otherwise discover it as a missing-filter render error at a user's
+    /// build.
+    #[test]
+    fn every_language_contributes_a_filter_set() {
+        for language in Language::ALL {
+            let set = for_language(language)
+                .unwrap_or_else(|| panic!("language `{language}` contributes no filter set"));
+            assert!(
+                !set.filters.is_empty(),
+                "language `{language}` declares an empty filter set"
+            );
+        }
+        // And no set claims a language twice.
+        let mut seen = Vec::new();
+        for set in FILTER_SETS {
+            assert!(
+                !seen.contains(&set.language),
+                "two filter sets claim {:?}",
+                set.language
+            );
+            seen.push(set.language);
+        }
+    }
+
+    /// The authored list and the `register` body are two spellings of one fact,
+    /// so they are compared. Each set is registered ALONE, so a name that
+    /// resolves only because a sibling set happened to add it fails here.
+    #[test]
+    fn declared_names_are_the_registered_ones() {
+        for set in FILTER_SETS {
+            let mut env = Environment::new();
+            (set.register)(&mut env);
+            for name in set.filters {
+                assert!(
+                    resolves(&env, name),
+                    "set `{}` declares `{name}` but its register does not add it",
+                    set.name
+                );
+            }
+        }
+    }
+
+    /// No two sets register the same name — a duplicate would mean the LAST
+    /// registration silently wins and one language's spelling reaches the
+    /// other's pack.
+    #[test]
+    fn filter_names_are_unique_across_sets() {
+        let mut seen: Vec<&str> = Vec::new();
+        for name in all_filter_names() {
+            assert!(
+                !seen.contains(&name),
+                "`{name}` is declared by more than one filter set"
+            );
+            seen.push(name);
+        }
+    }
+
+    /// The check that would otherwise happen at RENDER time, i.e. at some
+    /// user's build: every filter a bundled pack calls is one a set registers.
+    ///
+    /// A name we do not declare is only an error if minijinja does not have it
+    /// either — the packs legitimately use builtins (`upper`). Probing a bare
+    /// `Environment` answers that without this file carrying a list of
+    /// minijinja's builtins that would go stale on every upgrade.
+    #[test]
+    fn every_filter_a_pack_calls_is_registered() {
+        let ours: Vec<&str> = all_filter_names().collect();
+        let builtins = Environment::new();
+        for (pack, source) in crate::render::bundled_packs() {
+            for name in filters_called_by(source) {
+                if ours.contains(&name.as_str()) {
+                    continue;
+                }
+                assert!(
+                    resolves(&builtins, &name),
+                    "pack `{pack}` calls filter `{name}`, which no filter set \
+                     registers and minijinja does not provide"
+                );
+            }
+        }
+    }
+
+    /// The other direction: a declared filter no pack calls is a spelling left
+    /// behind by a pack rewrite. Nine of the ten are per-language type
+    /// spellings and every one of them has a caller today; keeping it that way
+    /// is what makes "a filter set" a description of the packs rather than an
+    /// accumulating list.
+    #[test]
+    fn every_registered_filter_is_called_by_a_pack() {
+        let mut called: Vec<String> = Vec::new();
+        for (_pack, source) in crate::render::bundled_packs() {
+            called.extend(filters_called_by(source));
+        }
+        for name in all_filter_names() {
+            assert!(
+                called.iter().any(|c| c == name),
+                "filter `{name}` is registered but no bundled pack calls it"
+            );
+        }
+    }
+
+    /// The tokenizer must not be fooled by the target-language text the packs
+    /// emit. `|item|` closures and `a || b` appear in real packs; if the helper
+    /// counted those, `every_filter_a_pack_calls_is_registered` would be
+    /// noise-driven and the first person to hit it would delete it.
+    #[test]
+    fn the_lexer_ignores_target_language_pipes() {
+        let source = "let f = |item| item + 1; let b = a || c;\n{{ x|snake_case }}\n";
+        assert_eq!(filters_called_by(source), vec!["snake_case".to_string()]);
+    }
+
+    /// `resolves` must actually distinguish the two cases, or every check built
+    /// on it passes vacuously.
+    #[test]
+    fn the_probe_tells_absent_from_present() {
+        let mut env = Environment::new();
+        (NEUTRAL.register)(&mut env);
+        assert!(resolves(&env, "snake_case"));
+        assert!(!resolves(&env, "no_such_filter_anywhere"));
+        // A registered filter that rejects its argument is still registered:
+        // `c_type` wants a struct and gets an integer.
+        let mut env = Environment::new();
+        (C.register)(&mut env);
+        assert!(resolves(&env, "c_type"));
+    }
+}

--- a/packages/cli/rosidl-codegen/src/lib.rs
+++ b/packages/cli/rosidl-codegen/src/lib.rs
@@ -5,6 +5,8 @@ pub use rosidl_lower::config;
 /// metadata, instead of stopping at a `#define` in a generated header.
 pub mod bounds;
 pub mod codegen_version;
+// RFC-0091 §6b / phase-432 W2.5b — a language's Rust surface area: its filters.
+pub mod filters;
 // RFC-0061 / phase-318 W1 — the tool answers "would I emit different bytes?"
 pub mod fingerprint;
 pub mod generator;

--- a/packages/cli/rosidl-codegen/src/render.rs
+++ b/packages/cli/rosidl-codegen/src/render.rs
@@ -7,82 +7,15 @@
 //!
 //! Every backend AND the per-package scaffolding (Cargo/lib/build) render through
 //! this one `Environment` now — askama is fully removed (phase-335 W6). Type
-//! spelling that used to be pre-baked in the builders is composed here by the
-//! registered `*_type` / `c_type` / `cpp_*` filters (RFC-0068 step 2).
+//! spelling that used to be pre-baked in the builders is composed in the pack by
+//! filters (RFC-0068 step 2), and those filters are the LANGUAGE's contribution,
+//! not this module's: see [`crate::filters`] for the set, who owns each one, and
+//! the checks that keep the packs and the registry in agreement (RFC-0091 §6b /
+//! phase-432 W2.5b). This module owns the templates, the loader and the globals.
 
 use std::sync::LazyLock;
 
-use minijinja::{Environment, value::ViaDeserialize};
-
-/// The neutral facts a `CField` carries for the C-type pack filters (RFC-0068
-/// step 2). Deserialized from the field's serialized form; extra CField keys are
-/// ignored.
-#[derive(serde::Deserialize)]
-struct CTypeSpell {
-    field_type: rosidl_parser::FieldType,
-    is_configurable: bool,
-    is_heap: bool,
-    cap: usize,
-    current_package: String,
-}
-
-/// Neutral facts the Rust-type pack filters (`rust_type_rmw` / `rust_type_idiomatic`)
-/// compose the Rust type string from. `current_package` drives the self-ref
-/// (`crate::` vs `pkg::`) choice inside `rust_type_for_field`.
-#[derive(serde::Deserialize)]
-struct RustTypeSpell {
-    field_type: rosidl_parser::FieldType,
-    current_package: String,
-}
-
-impl RustTypeSpell {
-    fn pkg(&self) -> Option<&str> {
-        (!self.current_package.is_empty()).then_some(self.current_package.as_str())
-    }
-}
-
-/// Neutral facts the `cpp_type` / `cpp_array_suffix` pack filters compose the
-/// C++ header type from.
-#[derive(serde::Deserialize)]
-struct CppTypeSpell {
-    field_type: rosidl_parser::FieldType,
-    is_borrowed: bool,
-    is_heap: bool,
-    cap: Option<usize>,
-    current_package: String,
-}
-
-/// Neutral facts the `cpp_repr_c_type` / `cpp_view_repr_type` pack filters
-/// compose the C++ FFI Rust repr(C) type from.
-#[derive(serde::Deserialize)]
-struct CppReprSpell {
-    field_type: rosidl_parser::FieldType,
-    struct_name: String,
-    cap: Option<usize>,
-    current_package: String,
-    name: String,
-    is_string: bool,
-    is_sequence: bool,
-    is_heap: bool,
-    is_borrowed: bool,
-}
-
-impl CppReprSpell {
-    fn pkg(&self) -> Option<&str> {
-        (!self.current_package.is_empty()).then_some(self.current_package.as_str())
-    }
-}
-
-/// Neutral facts the `nros_type` pack filter composes the nros Rust type from.
-#[derive(serde::Deserialize)]
-struct NrosTypeSpell {
-    field_type: rosidl_parser::FieldType,
-    is_configurable: bool,
-    is_heap: bool,
-    cap: usize,
-    mode: crate::types::NrosCodegenMode,
-    current_package: String,
-}
+use minijinja::Environment;
 
 /// Every bundled pack template, keyed by the stable name a `render(name, …)`
 /// call and any `{% import %}` use. Adding a language = adding rows here plus its
@@ -219,80 +152,11 @@ static ENV: LazyLock<Environment<'static>> = LazyLock::new(|| {
         "codegen_version",
         crate::codegen_version::NROS_CODEGEN_VERSION,
     );
-    // Custom filter parity with the askama path (`templates::filters::snake_case`).
-    env.add_filter("snake_case", |s: &str| crate::utils::to_snake_case(s));
-    // RFC-0068 step 2 — the C type spelling composed in the pack from a CField's
-    // neutral facts (was pre-baked as `CField.c_type` / `.array_suffix`).
-    env.add_filter("c_type", |v: ViaDeserialize<CTypeSpell>| {
-        let c = &v.0;
-        let cp = (!c.current_package.is_empty()).then_some(c.current_package.as_str());
-        crate::types::c_type_spelling(&c.field_type, c.is_configurable, c.is_heap, c.cap, cp)
-    });
-    env.add_filter("c_array_suffix", |v: ViaDeserialize<CTypeSpell>| {
-        let c = &v.0;
-        crate::types::c_array_suffix_spelling(&c.field_type, c.is_configurable, c.is_heap, c.cap)
-    });
-    // RFC-0068 step 2 — Rust type spelling in the pack (rmw layer = true,
-    // idiomatic layer = false), was pre-baked as `RmwField/IdiomaticField.rust_type`.
-    env.add_filter("rust_type_rmw", |v: ViaDeserialize<RustTypeSpell>| {
-        crate::types::rust_type_for_field(&v.0.field_type, true, v.0.pkg())
-    });
-    env.add_filter("rust_type_idiomatic", |v: ViaDeserialize<RustTypeSpell>| {
-        crate::types::rust_type_for_field(&v.0.field_type, false, v.0.pkg())
-    });
-    // RFC-0068 step 2 — C++ header type spelling in the pack, was pre-baked as
-    // `CppField.cpp_type` / `.array_suffix`.
-    env.add_filter("cpp_type", |v: ViaDeserialize<CppTypeSpell>| {
-        let c = &v.0;
-        let cp = (!c.current_package.is_empty()).then_some(c.current_package.as_str());
-        crate::types::cpp_type_spelling(&c.field_type, c.is_borrowed, c.is_heap, c.cap, cp)
-    });
-    env.add_filter("cpp_array_suffix", |v: ViaDeserialize<CppTypeSpell>| {
-        crate::types::cpp_array_suffix_spelling(&v.0.field_type, v.0.is_borrowed)
-    });
-    // RFC-0068 step 2 — C++ FFI repr(C) type spelling in the pack (was pre-baked
-    // as `CppFfiField.repr_c_type` / `.view_repr_type`).
-    env.add_filter("cpp_repr_c_type", |v: ViaDeserialize<CppReprSpell>| {
-        let c = &v.0;
-        crate::types::cpp_repr_c_type_spelling(
-            &c.field_type,
-            c.is_sequence,
-            c.is_heap,
-            c.is_string,
-            c.cap,
-            &c.struct_name,
-            &c.name,
-            c.pkg(),
-        )
-    });
-    env.add_filter("cpp_view_repr_type", |v: ViaDeserialize<CppReprSpell>| {
-        let c = &v.0;
-        crate::types::cpp_view_repr_type_spelling(
-            &c.field_type,
-            c.is_borrowed,
-            c.is_sequence,
-            c.is_heap,
-            c.is_string,
-            c.cap,
-            &c.struct_name,
-            &c.name,
-            c.pkg(),
-        )
-    });
-    // RFC-0068 step 2 — nros embedded Rust type spelling in the pack (storage +
-    // codegen-mode dependent), was pre-baked as `NrosField.rust_type`.
-    env.add_filter("nros_type", |v: ViaDeserialize<NrosTypeSpell>| {
-        let n = &v.0;
-        let cp = (!n.current_package.is_empty()).then_some(n.current_package.as_str());
-        crate::types::nros_type_spelling(
-            &n.field_type,
-            n.is_configurable,
-            n.is_heap,
-            n.cap,
-            n.mode,
-            cp,
-        )
-    });
+    // phase-432 W2.5b — the filters are not registered here any more. A
+    // language's Rust surface area is a FILTER SET (`crate::filters`), so the
+    // environment asks the registry rather than carrying ten `add_filter`
+    // calls that say nothing about which language owns which spelling.
+    crate::filters::register_all(&mut env);
 
     // W4.b — the override dir comes from `set_template_dir` (a CLI flag can call
     // it) or, with no cross-command plumbing, the `NROS_TEMPLATE_DIR` env var.


### PR DESCRIPTION
phase-432 W2.5b. Stacked on #656 (W2.5a) — the diff shrinks once that merges.

## The premise held, and was measured rather than repeated

**10 registered, 9 per-language, `snake_case` the one neutral.** They do not split evenly:

| set | filters | packs that call them |
| --- | --- | --- |
| neutral | `snake_case` | `nros` |
| C | `c_type`, `c_array_suffix` | `c` |
| C++ | `cpp_type`, `cpp_array_suffix`, `cpp_repr_c_type`, `cpp_view_repr_type` | `cpp` |
| Rust | `rust_type_rmw`, `rust_type_idiomatic`, `nros_type` | `rmw`, `rust`, `nros` |

C++ carries twice what C does, because that pack emits a header *and* a `repr(C)` Rust mirror — W2.5a's own correction surfacing one layer down.

## What makes this more than a rename

`rosidl_codegen::filters::FILTER_SETS`, keyed by `nros_lang::Language` (W2.1's enumeration) plus a neutral entry. `render.rs` keeps only templates, loader and globals.

Four checks, each mutation-tested RED then restored GREEN:

- **every `Language` has a set** — dropping `RUST` fails. This is the cross-crate coupling: adding `Language::Zig` to `nros-lang` now fails here until it brings filters.
- **every declared name is really registered** — a declared-but-unregistered name fails.
- **every filter a bundled pack CALLS is registered** — `| c_type` → `| c_typo` in `packs/c/message.h.jinja` fails. This is the one with teeth: minijinja resolves filters at RENDER time, so a half-wired pack fails at some user's build.
- **every registered filter is CALLED** — no dead spellings.

The pack scan uses **minijinja's own lexer**, not a regex, with the measurement to justify it: a textual `|ident` scan over `packs/` yields 23 names of which **12 are not filters** (`item`, `crate`, `buffer`, `handler`, `scratch`, `callback`, …) — the packs emit Rust and C++, so their text is full of closures. Two negative controls keep the checks from passing vacuously.

## The correction, and it changes how the registry is keyed

Both documents pick the same wrong example:

> phase-432 W2.5b: "per-language type spellings (`c_type`, `rust_type_rmw`, **`cpp_repr_c_type`**, `nros_type`, …)"

**`cpp_repr_c_type` and `cpp_view_repr_type` return Rust, not C++** — `[u8; 32]`, `[T; N]`, `u32`. The `cpp_` prefix names the pack that CALLS them. That is §6's own "the `cpp` pack emits Rust" showing up in the filter names, and it settles the keying: **by the calling pack, not by emitted syntax**. Keying the other way files those two under Rust, and the first language wanting an FFI mirror would then grow the *Rust* set. Written into RFC-0091 §6b and the phase doc.

## The tenth filter

`snake_case`, and it is genuinely neutral — provable by use rather than assertion: the same `utils::to_snake_case` builds C header names in `generator/srv.rs`, C++ header names in `generator/cpp.rs`, and Rust constant names in the `nros` pack. It is the rosidl naming convention, not a Rust one.

## Deliberately not done

No `just check/*.just` gate: `check-cli-tests` is on the required `CI` context for every pull request, so these gate a merge anyway, and they read `bundled_packs()` and the registry directly where a Python gate could only re-spell both. No per-filter `emits: Language` metadata either — an authored map nothing derives from is the rmw-parity-map drift shape.

The entry-side `c_str` belongs in the contract **by kind** — it is a per-language spelling, i.e. the C set — but what keeps the two environments apart is staleness, not the contract: entry templates are not in `bundled_packs()`, which feeds the codegen fingerprint. `FilterSet::register` takes `&mut Environment`, so both can share one registry without sharing a template list; that unification belongs with W2.5/W2.6.

Verification: `just check fast` 246 green (1 skip, zenoh-pico not checked out in the agent worktree); `just check repr-memory-agreement` OK at 20 pairs / 186 probes; `cargo nextest run` 1706/1706 in `packages/cli`; message goldens byte-stable — no filter body changed, only where it is registered from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vi3bKPpmrys3J3foFUH9oF