### PR TITLE
fix(entry): one ladder derives NROS_ENTRY_LOCATOR, not three

### DIFF
--- a/packages/api/nros-c/include/nros/app_main.h
+++ b/packages/api/nros-c/include/nros/app_main.h
@@ -58,22 +58,19 @@ int nros_app_main(int argc, char** argv);
  * definitions (NanoRosEntry.cmake board gate — e.g. `tcp/10.0.2.2:7447` for
  * QEMU slirp), so the `#ifndef` defaults below never fire there.
  *
- * Issue 0330 — the fallback is the EMPTY STRING, not a zenoh router
- * endpoint. This header is RMW-blind, so it must not restate a backend fact;
- * `""` is the established "absent — let the backend discover" value (same as
- * `<nros/main.hpp>`'s own `NROS_ENTRY_LOCATOR` fallback). It is consumed as a
- * VALUE (not a nullable pointer) by main.hpp's `run_components` /
- * `run_tiers` overloads and by the CLI entry codegen, so the macro must keep
- * expanding to a string literal. `""` travels through
- * `nros_support_init` / `nros_cpp_init` → the RFC-0045 resolver's empty
- * bottom rung → the linked backend, which substitutes its own default
- * (zenoh: `nros_rmw_zenoh::DEFAULT_LOCATOR`). */
-#ifndef NROS_ENTRY_LOCATOR
-#define NROS_ENTRY_LOCATOR ""
-#endif
-#ifndef NROS_ENTRY_DOMAIN_ID
-#define NROS_ENTRY_DOMAIN_ID 0
-#endif
+ * phase-432 (W3.1 prerequisite) — this used to define both macros HERE, as
+ * `""` and `0`, with no derivation, while `<nros/main.hpp>` derived them from
+ * Kconfig. Same two names, two answers: a TU that saw only this header dialled
+ * nothing on a board whose locator comes from `CONFIG_NROS_ZENOH_LOCATOR`.
+ * That is free today only because an embedded C entry is routed to the C++
+ * emitter; it stops being free the moment a pure C entry exists, and it would
+ * arrive as issue #174's silent no-connect rather than as an error.
+ *
+ * One ladder now, in a C header both entry languages include. Issue 0330's
+ * rule still holds and lives there: the bottom rung is the EMPTY STRING, not a
+ * router endpoint, and the macro must keep expanding to a string literal
+ * because callers pass it by VALUE rather than as a nullable pointer. */
+#include "nros/entry_config.h"
 
 /* ---- Platform-specific entry shims ---- */
 

--- a/packages/api/nros-c/include/nros/entry_config.h
+++ b/packages/api/nros-c/include/nros/entry_config.h
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * @file entry_config.h
+ * @brief The compile-time connect configuration an entry bakes: `NROS_ENTRY_LOCATOR`
+ *        and `NROS_ENTRY_DOMAIN_ID`.
+ *
+ * ONE derivation, in a C header, because both entry languages need it.
+ *
+ * ## Why this file exists
+ *
+ * The ladder used to live in `<nros/main.hpp>` — a C++ header — while the C
+ * sibling `<nros/app_main.h>` defined the same two macros as `""` and `0` with
+ * no derivation at all. Both are consumed as VALUES by `run_components` /
+ * `run_tiers` and by the CLI entry codegen, so the two spellings never
+ * conflicted at link time; they simply disagreed about what the image dials.
+ *
+ * Today that costs nothing, because an embedded C entry is routed to the C++
+ * emitter and compiles as a `.cpp` that includes `main.hpp`. The moment a pure
+ * C entry becomes possible (phase-432 W3.1) it stops being free: the image
+ * would compile, link, boot — and dial nothing, because `""` reaches the
+ * backend as "absent". That is a byte-for-byte re-run of issue #174, which the
+ * XRCE arm below exists to fix, and it would arrive with no diagnostic.
+ *
+ * Same class as issue 0946 one layer down: that gate made the CMAKE-side
+ * locator ladders one producer. This makes the HEADER-side ones one producer.
+ *
+ * ## The contract
+ *
+ * Preprocessor only — no types, no includes, no linkage. Both `main.hpp` and
+ * `app_main.h` include it at the point their own ladder used to sit, so an
+ * entry may still bake a literal by defining either macro BEFORE the include
+ * and the `#ifndef` guards leave it alone.
+ *
+ * Both macros must keep expanding to a value of the right kind:
+ * `NROS_ENTRY_LOCATOR` to a STRING LITERAL (never a nullable pointer — callers
+ * pass it by value) and `NROS_ENTRY_DOMAIN_ID` to an integer constant
+ * expression.
+ */
+#ifndef NROS_ENTRY_CONFIG_H
+#define NROS_ENTRY_CONFIG_H
+
+/* ---- NROS_ENTRY_LOCATOR ----
+ *
+ * Phase 244.C2 — the compile-time connect locator for Zephyr (and NuttX, which
+ * reuses this macro). Defaults to the Kconfig `CONFIG_NROS_ZENOH_LOCATOR` when
+ * the board sets one (the e2e gate threads
+ * `CONFIG_NROS_ZENOH_LOCATOR=tcp/127.0.0.1:<port>` per fixture), else `""`.
+ *
+ * Issue 0330 — the bottom rung is the EMPTY STRING, not a router endpoint.
+ * This header is RMW-blind and must not restate a backend fact; `""` is the
+ * established "absent — let the backend discover" value. It travels through
+ * `nros_support_init` / `nros_cpp_init` to the RFC-0045 resolver's empty bottom
+ * rung and then to the linked backend, which substitutes its own default
+ * (zenoh: `nros_rmw_zenoh::DEFAULT_LOCATOR`).
+ */
+#ifndef NROS_ENTRY_LOCATOR
+#if defined(CONFIG_NROS_ZENOH_LOCATOR)
+#define NROS_ENTRY_LOCATOR CONFIG_NROS_ZENOH_LOCATOR
+#elif defined(CONFIG_NROS_RMW_XRCE) && defined(CONFIG_NROS_XRCE_AGENT_ADDR) &&                     \
+    defined(CONFIG_NROS_XRCE_AGENT_PORT)
+/* #174 / phase-286 W3 — XRCE has NO zenoh locator; its agent endpoint lives in
+ * CONFIG_NROS_XRCE_AGENT_{ADDR,PORT}. Without this, `NROS_ENTRY_LOCATOR` fell
+ * to `""` and the C/C++ XRCE entry opened its session with no agent address —
+ * the transport never connected (`run_components` rc=-100 TRANSPORT_ERROR, 0
+ * delivery). Synthesize the bare `host:port` the XRCE session parser accepts
+ * (`nros-rmw-xrce/session.c` `parse_host_port`) — the C/C++ analog of the Rust
+ * example `build.rs` bake (issue #163, which fixed only the Rust images).
+ * Adjacent string-literal concat + stringize: "127.0.0.1" ":" 2018 →
+ * "127.0.0.1:2018". */
+#define NROS_ENTRY_LOCATOR_STRINGIZE_(x) #x
+#define NROS_ENTRY_LOCATOR_STRINGIZE(x) NROS_ENTRY_LOCATOR_STRINGIZE_(x)
+#define NROS_ENTRY_LOCATOR                                                                         \
+    CONFIG_NROS_XRCE_AGENT_ADDR ":" NROS_ENTRY_LOCATOR_STRINGIZE(CONFIG_NROS_XRCE_AGENT_PORT)
+#else
+#define NROS_ENTRY_LOCATOR ""
+#endif
+#endif /* NROS_ENTRY_LOCATOR */
+
+/* ---- NROS_ENTRY_DOMAIN_ID ----
+ *
+ * Compile-time on embedded, never a runtime env (the CLAUDE.md embedded
+ * domain-id rule). Cyclone keys off `CONFIG_NROS_CYCLONE_DOMAIN_ID` when
+ * present (matching ASI), else the generic `CONFIG_NROS_DOMAIN_ID`.
+ *
+ * Never pin the Cyclone knob to a literal in a board conf: the phase-180
+ * split-brain silently ran every cyclone image on domain 0.
+ */
+#ifndef NROS_ENTRY_DOMAIN_ID
+#if defined(NROS_RMW_CYCLONEDDS) && defined(CONFIG_NROS_CYCLONE_DOMAIN_ID)
+#define NROS_ENTRY_DOMAIN_ID CONFIG_NROS_CYCLONE_DOMAIN_ID
+#elif defined(CONFIG_NROS_DOMAIN_ID)
+#define NROS_ENTRY_DOMAIN_ID CONFIG_NROS_DOMAIN_ID
+#else
+#define NROS_ENTRY_DOMAIN_ID 0
+#endif
+#endif /* NROS_ENTRY_DOMAIN_ID */
+
+#endif /* NROS_ENTRY_CONFIG_H */

--- a/packages/api/nros-cpp/include/nros/main.hpp
+++ b/packages/api/nros-cpp/include/nros/main.hpp
@@ -275,34 +275,14 @@ class LinuxBoard {
 ///     auto-brings-up networking);
 ///   * the spin loop yields cooperatively each tick (`entry_tick_yield`
 ///     → `k_yield()`).
-// Phase 244.C2 enabler — compile-time connect locator for Zephyr (+ NuttX,
-// which reuses this macro). Defaults to the Kconfig `CONFIG_NROS_ZENOH_LOCATOR`
-// when the board sets one (the e2e gate threads
-// `CONFIG_NROS_ZENOH_LOCATOR=tcp/127.0.0.1:<port>` per fixture), else `""`
-// (backend discovery — the in-tree FVP Cyclone path). The typed carrier may
-// also bake a literal by defining `NROS_ENTRY_LOCATOR` before this header.
-#ifndef NROS_ENTRY_LOCATOR
-#if defined(CONFIG_NROS_ZENOH_LOCATOR)
-#define NROS_ENTRY_LOCATOR CONFIG_NROS_ZENOH_LOCATOR
-#elif defined(CONFIG_NROS_RMW_XRCE) && defined(CONFIG_NROS_XRCE_AGENT_ADDR) &&                     \
-    defined(CONFIG_NROS_XRCE_AGENT_PORT)
-// #174 / phase-286 W3 — XRCE has NO zenoh locator; its agent endpoint lives in
-// CONFIG_NROS_XRCE_AGENT_{ADDR,PORT}. Without this, `NROS_ENTRY_LOCATOR` fell to
-// `""` and the C/C++ XRCE entry opened its session with no agent address → the
-// transport never connected (`run_components` rc=-100 TRANSPORT_ERROR, 0
-// delivery). Synthesize the bare `host:port` the XRCE session parser accepts
-// (`nros-rmw-xrce/session.c` `parse_host_port`) — the C/C++ analog of the Rust
-// example `build.rs` bake (issue #163, which fixed only the Rust images).
-// Adjacent string-literal concat + stringize: "127.0.0.1" ":" 2018 →
-// "127.0.0.1:2018".
-#define NROS_ENTRY_LOCATOR_STRINGIZE_(x) #x
-#define NROS_ENTRY_LOCATOR_STRINGIZE(x) NROS_ENTRY_LOCATOR_STRINGIZE_(x)
-#define NROS_ENTRY_LOCATOR                                                                         \
-    CONFIG_NROS_XRCE_AGENT_ADDR ":" NROS_ENTRY_LOCATOR_STRINGIZE(CONFIG_NROS_XRCE_AGENT_PORT)
-#else
-#define NROS_ENTRY_LOCATOR ""
-#endif
-#endif
+// phase-432 (W3.1 prerequisite) — `NROS_ENTRY_LOCATOR` and
+// `NROS_ENTRY_DOMAIN_ID` are derived in ONE place, `<nros/entry_config.h>`,
+// which is a C header so the C entry sees the same ladder. This used to be
+// two: the ladder below, and `<nros/app_main.h>` defining both as `""` and `0`
+// with no derivation — so a pure-C entry would have compiled, linked, booted
+// and dialled nothing. The `#ifndef` guards inside still let a typed carrier
+// bake a literal by defining either macro BEFORE this header.
+#include "nros/entry_config.h"
 
 // #166 / phase-286 W1 — runtime locator override (see nros/platform.h). Declared
 // here (not via a platform-header include) to keep main.hpp's include surface
@@ -312,19 +292,9 @@ extern "C" const char* nros_runtime_locator_override(void);
 
 class ZephyrBoard {
   public:
-    /// Compile-time domain id (CLAUDE.md embedded rule — NOT a runtime
-    /// env). Cyclone keys off `CONFIG_NROS_CYCLONE_DOMAIN_ID` when present
-    /// (matches ASI), else the generic `CONFIG_NROS_DOMAIN_ID`. Override
-    /// by defining `NROS_ENTRY_DOMAIN_ID` before including this header.
-#ifndef NROS_ENTRY_DOMAIN_ID
-#if defined(NROS_RMW_CYCLONEDDS) && defined(CONFIG_NROS_CYCLONE_DOMAIN_ID)
-#define NROS_ENTRY_DOMAIN_ID CONFIG_NROS_CYCLONE_DOMAIN_ID
-#elif defined(CONFIG_NROS_DOMAIN_ID)
-#define NROS_ENTRY_DOMAIN_ID CONFIG_NROS_DOMAIN_ID
-#else
-#define NROS_ENTRY_DOMAIN_ID 0
-#endif
-#endif
+    /// Compile-time domain id (CLAUDE.md embedded rule — NOT a runtime env).
+    /// Derived in `<nros/entry_config.h>`, included above; override by
+    /// defining `NROS_ENTRY_DOMAIN_ID` before this header.
 
     /// Phase 266 (W6) — 3-arg named overload: explicit locator + session name.
     /// `session_name` sets the primary session / node name (`ros2 node list`).
@@ -415,13 +385,14 @@ class ZephyrBoard {
 /// compiled as `APP_MAIN_CPP` and linked into the kernel by the cargo
 /// `nros-nuttx-ffi` build (`nuttx_ffi_build.rs`), driven from the carrier
 /// cmake (`nano_ros_node_register` NuttX branch → `nros_platform_link_app`).
-// Phase 238 — compile-time default connect locator for the locator-less
-// `NuttxBoard::run(lambda)` overload. The carrier normally bakes the real
-// locator into the generated entry TU and calls the 2-arg overload; this
-// default only applies if a hand-written entry uses the 1-arg form.
-#ifndef NROS_ENTRY_LOCATOR
-#define NROS_ENTRY_LOCATOR ""
-#endif
+// Phase 238 had a THIRD `#ifndef NROS_ENTRY_LOCATOR` here, defining `""` for
+// the locator-less `NuttxBoard::run(lambda)` overload, with a comment saying
+// "this default only applies if a hand-written entry uses the 1-arg form".
+// It could never fire: the ladder above this point in the same header has
+// always already defined the macro, so a locator-less NuttX entry inherited
+// the Zephyr/XRCE derivation rather than the `""` the comment promised.
+// Deleted rather than kept as a belt: an unreachable define that claims a
+// value it does not produce is worse than no define at all.
 
 class NuttxBoard {
   public:

--- a/scripts/check-entry-locator-ssot.py
+++ b/scripts/check-entry-locator-ssot.py
@@ -260,6 +260,106 @@ def cmake_files():
     return files
 
 
+
+# --------------------------------------------------------------------------
+# The header-side half (phase-432, W3.1 prerequisite)
+# --------------------------------------------------------------------------
+#
+# The CMake half above makes the locator LITERAL have one producer. It says
+# nothing about the C-preprocessor ladder that turns Kconfig into
+# `NROS_ENTRY_LOCATOR` / `NROS_ENTRY_DOMAIN_ID` inside the headers, and that
+# had THREE spellings:
+#
+#   * `<nros/main.hpp>` derived both from Kconfig (zenoh locator, else a
+#     synthesised XRCE `host:port`, else `""`);
+#   * `<nros/app_main.h>` — the C sibling — defined both as `""` and `0` with
+#     no derivation at all, so a TU that saw only the C header dialled nothing
+#     on a board whose locator comes from `CONFIG_NROS_ZENOH_LOCATOR`;
+#   * a third `#ifndef` further down `main.hpp` for the locator-less NuttX
+#     overload, unreachable because the ladder above it had always already
+#     defined the macro — it promised `""` and delivered whatever the first
+#     ladder produced.
+#
+# Same failure mode as the CMake half and the same reason it needs a gate
+# rather than a convention: a wrong locator compiles, links and boots, and the
+# only symptom is a connection that never happens.
+#
+# The rule is ONE DEFINING HEADER, not "the values agree" — deciding what a
+# board should dial is a per-board question, and this file is not the place it
+# gets answered.
+
+HEADER_SSOT = "packages/api/nros-c/include/nros/entry_config.h"
+HEADER_MACROS = ("NROS_ENTRY_LOCATOR", "NROS_ENTRY_DOMAIN_ID")
+_DEFINE = re.compile(r"^\s*#\s*define\s+(NROS_ENTRY_LOCATOR|NROS_ENTRY_DOMAIN_ID)\b")
+
+
+def header_files():
+    """Every tracked-or-new C/C++ header and source under `packages/api/`.
+
+    `--others --exclude-standard` for the same reason as `cmake_files()`: a
+    second ladder added but not yet committed must red while its author is
+    looking at it. Generated headers are gitignored and so stay out.
+    """
+    out = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "packages/api/"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    files = {}
+    for rel in sorted(set(out)):
+        if not rel.endswith((".h", ".hpp", ".c", ".cpp", ".cc")):
+            continue
+        path = os.path.join(ROOT, rel)
+        if os.path.isfile(path):
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                files[rel] = fh.read()
+    return files
+
+
+def analyze_headers(files):
+    """Definitions of the two entry macros outside the one defining header."""
+    problems = []
+    for rel, text in sorted(files.items()):
+        if rel == HEADER_SSOT:
+            continue
+        for n, line in enumerate(text.splitlines(), 1):
+            m = _DEFINE.match(line)
+            if m:
+                problems.append(
+                    f"{rel}:{n}: defines {m.group(1)} — a second ladder. "
+                    f"Include {HEADER_SSOT} instead."
+                )
+    return problems
+
+
+def header_selftest():
+    """The predicate must catch a planted second ladder and allow a mention.
+
+    Without this the check could pass by examining nothing, which is the shape
+    it exists to prevent one layer up.
+    """
+    planted = {
+        HEADER_SSOT: "#define NROS_ENTRY_LOCATOR \"\"\n",
+        "packages/api/x/other.h": "#define NROS_ENTRY_LOCATOR \"tcp/1.2.3.4:1\"\n",
+    }
+    if len(analyze_headers(planted)) != 1:
+        print("SELFTEST FAIL: a planted second ladder was not caught.", file=sys.stderr)
+        sys.exit(1)
+    allowed = {
+        HEADER_SSOT: "#define NROS_ENTRY_LOCATOR \"\"\n",
+        # A mention, a doc comment and an `#ifdef` are all fine: the rule is
+        # about who DEFINES the macro, not who reads it.
+        "packages/api/x/reader.h": (
+            "/* NROS_ENTRY_LOCATOR is derived in entry_config.h */\n"
+            "#ifdef NROS_ENTRY_LOCATOR\n"
+            "static const char* l = NROS_ENTRY_LOCATOR;\n"
+            "#endif\n"
+        ),
+    }
+    if analyze_headers(allowed):
+        print("SELFTEST FAIL: a mention was reported as a definition.", file=sys.stderr)
+        sys.exit(1)
+
+
 def main():
     selftest()
 
@@ -294,7 +394,42 @@ def main():
             print(f"  {p}", file=sys.stderr)
         return 1
 
-    print(f"check-entry-locator-ssot: OK (one producer: {SSOT})")
+    header_selftest()
+    headers = header_files()
+    if HEADER_SSOT not in headers:
+        print(
+            f"FAIL: the header-side SSoT {HEADER_SSOT} does not exist.",
+            file=sys.stderr,
+        )
+        return 1
+    missing = [m for m in HEADER_MACROS if f"#define {m}" not in headers[HEADER_SSOT]]
+    if missing:
+        print(
+            f"FAIL: {HEADER_SSOT} does not define {', '.join(missing)} — "
+            "it is the SSoT and must be the thing that derives them.",
+            file=sys.stderr,
+        )
+        return 1
+
+    header_problems = analyze_headers(headers)
+    if header_problems:
+        print(
+            "FAIL: the entry connect macros must have exactly ONE defining header.",
+            file=sys.stderr,
+        )
+        print(
+            "  A second ladder drifts silently — the image compiles, links and\n"
+            "  boots, and simply dials the wrong address or none at all (#174).\n",
+            file=sys.stderr,
+        )
+        for p in header_problems:
+            print(f"  {p}", file=sys.stderr)
+        return 1
+
+    print(
+        f"check-entry-locator-ssot: OK (one cmake producer: {SSOT}; "
+        f"one header producer: {HEADER_SSOT}, {len(headers)} header(s) scanned)"
+    )
     return 0
 
 


### PR DESCRIPTION
phase-432 W3.1 named this as a prerequisite and a live trap. It is this phase's own defect class — one fact, several authored spellings — sitting under the C entry.

`NROS_ENTRY_LOCATOR` and `NROS_ENTRY_DOMAIN_ID` are what an embedded image dials and which domain it joins. They had **three** spellings:

1. `<nros/main.hpp>` derived both from Kconfig: the zenoh locator, else a synthesised XRCE `host:port`, else `""`; domain from the Cyclone knob, else the generic one, else 0.
2. `<nros/app_main.h>` — the C sibling — defined the same two names as `""` and `0`, with no derivation at all.
3. A third `#ifndef` further down `main.hpp`, for the locator-less NuttX overload, promising `""`.

**The third could never fire.** The ladder above it in the same header had always already defined the macro, so a locator-less NuttX entry inherited the Zephyr/XRCE derivation rather than the `""` its comment promised. Deleted — an unreachable define that claims a value it does not produce is worse than none.

**The second is the trap.** Measured, before and after, with the flags a Zephyr board passes:

```
$ cc -DCONFIG_NROS_ZENOH_LOCATOR='"tcp/127.0.0.1:7447"' … app_main.h
before: []                      <- dials nothing
after:  [tcp/127.0.0.1:7447]
```

Today that costs nothing, because an embedded C entry is routed to the C++ emitter and compiles as a `.cpp` that includes `main.hpp`. It stops being free the moment a pure C entry exists (W3.1), and it would arrive as **issue #174 exactly**: compiles, links, boots, connects nowhere, rc=-100, zero delivery, no diagnostic.

One ladder now, in `<nros/entry_config.h>` — a C header, preprocessor only, included by both entry languages at the point their own ladder sat, so an entry may still bake a literal by defining either macro first. Issue 0330's rule moves with it: the bottom rung is the EMPTY STRING, not a router endpoint, and the macro must keep expanding to a string literal because callers pass it by VALUE rather than as a nullable pointer.

## The gate

`check-entry-locator-ssot` gains the header half. It already made the CMAKE-side locator ladders one producer (issue 0946); the invariant is the same one layer down, and so is the reason it needs a gate rather than a convention — a wrong locator compiles and links cleanly, and the only symptom is a connection that never happens.

The rule is **ONE DEFINING HEADER**, not "the values agree": what a board should dial is a per-board question this file does not answer.

Mutation-tested: adding `#define NROS_ENTRY_DOMAIN_ID 0` back to `app_main.h` goes red naming file and line; removing it goes green. Two selftests keep the predicate honest — a planted second ladder must be caught, and a mention or `#ifdef` must not be.

Verified: the four ladder arms probed in pure C (default, zenoh Kconfig, XRCE synth, Cyclone domain) plus the pre-baked-literal override; `just check c` and `just check cpp` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vi3bKPpmrys3J3foFUH9oF