### PR TITLE
feat(phase-392 W3c): a subscription's receive buffer is derived from its type unless the consumer names a number

### DIFF
--- a/docs/issues/1179-derived-rx-default-unreachable-without-schema.md
+++ b/docs/issues/1179-derived-rx-default-unreachable-without-schema.md
@@ -1,0 +1,106 @@
+---
+id: 1179
+title: "Derived-by-default receive buffers reach only backends declaring `type-descriptors` — `MessageForRmw` carries no schema on zenoh or XRCE"
+status: open
+type: enhancement
+area: core
+related: [phase-392, phase-403, issue-0896]
+---
+
+## Problem
+
+phase-392 W3c made the arena receive buffer derive from the message type by
+default: `register_subscription_buffered_on` is the one choke point every
+default registration funnels through, and a `None` receive size there now means
+DERIVE rather than "the global". Measured saving on a 12-byte bounded type at
+`QoSProfile::default().depth` (10): the registration's arena claim falls
+13,632 -> 2,500 bytes, and at depth 2 it falls 5,376 -> 2,340.
+
+**It is live on one backend of three.** The derivation reads
+`nros_serdes::size::max_serialized_bound::<M>()`, which needs
+`M: nros_serdes::schema::Message`. At the registration site the only bound in
+scope is `M: MessageForRmw`, and that trait has two arms:
+
+```rust
+#[cfg(rmw_needs_type_descriptors)]
+pub trait MessageForRmw: RosMessage + nros_serdes::schema::Message {}
+
+#[cfg(not(rmw_needs_type_descriptors))]
+pub trait MessageForRmw: RosMessage {}
+```
+
+`rmw_needs_type_descriptors` is emitted from the `needs-type-descriptors`
+capability feature, which a backend requests by declaring `type-descriptors` in
+its `nros-rmw.toml`. Measured across the four descriptors in the tree
+(`packages/rmw/{zenoh,xrce,uorb,cyclonedds}/*/nros-rmw.toml`): **only Cyclone
+declares it.** So on a zenoh or XRCE image there is no bound to read at a
+type-erased registration site at all, and
+`rmw_type_registry::default_subscription_rx_bytes::<M>` returns `None` for
+every type — the default is unchanged, correctly and by construction.
+
+This is the same reason phase-392 W3a's `subscription_rx_hint::<M>` is inert
+there. Worth stating plainly, because the phase doc's W3a entry reads as
+tree-wide: *"A Rust subscription to a 4 KiB type now routes large"* is true on
+Cyclone and false on zenoh — and zenoh is the backend that HAS the small/large
+payload classes the sentence is about.
+
+The consumer-visible workaround is not a workaround so much as the honest
+shape: `.rx_buffer_from_type()` and `nros::rx_buffer_for!(M)` NAME
+`nros_serdes::schema::Message` themselves, so they derive on every backend.
+They are opt-in, which is exactly what W3c set out to stop being the only
+route.
+
+## Why the obvious fix was refused, and what is left
+
+Tightening `MessageForRmw` to require `schema::Message` on both arms is the
+one-line version, and phase-380 W4 already refused it, in a comment on the arm
+itself: it broke `examples/native/rust/custom-msg`, whose `SensorReading` is
+hand-written (`RosMessage` + `Serialize` + `Deserialize`, no schema) precisely
+to demonstrate that codegen is not mandatory for a user's own message type.
+Requiring a schema there makes codegen mandatory for anyone subscribing to a
+type they wrote, which is a much larger decision than a buffer default.
+
+Two candidate designs, neither obviously right:
+
+* **(a) Carry the bound on `RosMessage`.** Add
+  `const MAX_SERIALIZED_SIZE: Option<usize> = None;` to `RosMessage` — which
+  `MessageForRmw` requires under *both* arms — and have `emit_rust.rs` emit the
+  override in every generated `impl RosMessage`, computed as
+  `nros_serdes::size::max_serialized_bound::<Self>()`. That is the SAME
+  computation, not a mirror of it, so it does not reopen the sizes-header drift
+  class (0088 -> 0114 -> 0122 -> 0123 -> 0245 -> 0268) that issue 0896 warns
+  about. Universal across backends; a hand-written type keeps the `None`
+  default and behaves exactly as today. Cost: it touches the message ABI trait
+  and needs the 88 committed files under `packages/interfaces/*/generated/`
+  regenerated.
+* **(b) Split the typed entry point.** `.typed::<M>()` requires
+  `M: schema::Message` and derives; a second spelling takes schema-less types
+  at the global. Cheap, and it forces a one-line source edit on every consumer
+  with a hand-written type — loud rather than silent, but a breaking change to
+  a documented pattern.
+
+(a) preserves every consumer and costs regeneration; (b) preserves the build
+and costs a documented API. **Choose deliberately, not by whichever is
+implemented first** — the same instruction phase-392's own W3 remainder gives
+for the C/C++ fork one lane over.
+
+## Reproduce
+
+```
+cargo test -p nros-node --features std,alloc                          --lib -- derived_from_the_type
+cargo test -p nros-node --features std,alloc,needs-type-descriptors   --lib -- derived_from_the_type
+```
+
+`the_default_subscription_buffer_is_derived_from_the_type` asserts both arms —
+that naming nothing costs what `.rx_buffer_from_type()` costs where a schema is
+present, and what `.rx_buffer::<GLOBAL>()` costs where it is not — so the test
+is green either way and says which arm it ran in when it is not.
+
+## Coverage gap this leaves
+
+`test-unit` runs `cargo nextest --workspace` with no features, so the
+descriptor arm — the arm on which W3c does anything — is exercised by no lane.
+The assertion above is real on both arms, but only the second invocation above
+can catch a regression in the derivation itself. Verified by reverting the
+choke-point change and re-running: the descriptor arm fails with
+`left: 5376, right: 2340`, the default arm stays green.

--- a/docs/issues/1180-mem-report-baseline-cannot-match-llvm-suffixed-symbols.md
+++ b/docs/issues/1180-mem-report-baseline-cannot-match-llvm-suffixed-symbols.md
@@ -1,0 +1,72 @@
+---
+id: 1180
+title: "`mem-report --baseline` silently reports no delta for LLVM-internalised symbols — including `EXECUTOR_BACKING`, the largest RAM symbol in every Rust image"
+status: open
+type: bug
+area: tooling
+related: [phase-392]
+---
+
+## Problem
+
+`scripts/nros-mem-report.py --baseline` matches symbols by NAME:
+
+```python
+base_syms = {t["symbol"]: t["bytes"] for t in baseline.get("top_ram", [])}
+...
+if row["symbol"] in base_syms:
+    d = row["bytes"] - base_syms[row["symbol"]]
+```
+
+A symbol LLVM internalises carries a per-build `.llvm.<hash>` suffix, and the
+reporter keeps it in the name. The hash is not stable across builds of the same
+crate, so the lookup misses and the row is printed with **no delta annotation** —
+which is exactly how the tool prints a symbol that did not change.
+
+Measured, two builds of the same test binary differing only in one source line:
+
+```
+baseline: nros_node::executor::backing::EXECUTOR_BACKING (.llvm.12488621184790092911)  86,216
+current : nros_node::executor::backing::EXECUTOR_BACKING (.llvm.13033674138034542000)  86,216
+```
+
+Same bytes here, so the missing annotation happened to be right — but it would
+have been printed identically had the number moved, because the two names never
+met. `EXECUTOR_BACKING` is 38.1% of that image's attributed RAM and is the
+single symbol phase-392 W6 created *in order to be measurable*, so this is the
+worst possible symbol to be unable to diff.
+
+## Why it matters more than it looks
+
+phase-392's standing rule is that no wave claims a saving it did not measure,
+and `mem-report --json --baseline` is the named instrument. A `--baseline` run
+that cannot match a symbol produces the same output as one that measured no
+change, so a wave can read a clean before/after out of a probe that compared
+nothing. W5 already had to withdraw a causal claim for the adjacent reason (a
+before/after that built the same configuration twice) and W6 discarded a
+-11,199 B reading for it.
+
+## Fix
+
+Normalise the symbol key before comparing: strip a trailing `.llvm.<digits>`
+(and the sibling `.<digits>` suffixes LLVM appends for local symbols) when
+building both `base_syms` and the lookup, keeping the full name for DISPLAY.
+Where two symbols collide after normalisation, sum or report both rather than
+silently taking one.
+
+Give it a positive control, per `check-gate-selftests`' rule: a fixture pair
+whose only difference is the `.llvm.` suffix must report the byte delta, and a
+pair with equal bytes must report none. A `--baseline` that cannot fail is the
+defect being fixed.
+
+## Workaround until then
+
+Read the number directly and compare it yourself:
+
+```
+nm -S <elf> | grep EXECUTOR_BACKING
+```
+
+Positive control for that reading, measured: rebuilding with
+`NROS_SUBSCRIPTION_BUFFER_SIZE=2048` moves the symbol
+`0x150c8` (86,216) -> `0x180c8` (98,504), +12,288 bytes.

--- a/docs/issues/1183-node-std-tests-latch-test-red-in-shared-process.md
+++ b/docs/issues/1183-node-std-tests-latch-test-red-in-shared-process.md
@@ -1,0 +1,70 @@
+---
+id: 1183
+title: "`check node-std-tests` is red on main — the executor-backing latch test asserts a process-global that 367 sibling tests share"
+status: open
+type: bug
+area: testing
+related: [phase-392, issue-1145]
+---
+
+## Problem
+
+`just check node-std-tests` fails on `main`, reproducibly:
+
+```
+cargo test -p nros-node --lib --features std,sim-time,param-services --quiet
+...
+---- executor::backing::tests::the_static_is_handed_out_once_and_only_once stdout ----
+panicked at packages/core/nros-node/src/executor/backing.rs:213:9:
+an over-large request must not claim the latch
+test result: FAILED. 365 passed; 1 failed; 1 ignored
+```
+
+Measured 3/3 on `bd204b986` with no local changes (`git stash` of every touched
+file, three consecutive runs, identical result). It is NOT caused by whatever
+change you are holding — check this issue before spending time on it.
+
+## Why it fails
+
+`EXECUTOR_BACKING` is handed out ONCE per process, guarded by a `TAKEN` latch.
+The test's own doc comment says so and explains that all three cases live in one
+test for exactly that reason: *"`TAKEN` is process-scoped by design, so a second
+test would observe an already-consumed latch and assert nothing — the vacuous
+shape `check-no-vacuous-tests` exists to catch."*
+
+The reasoning is right and one scope too small. `cargo test` runs the whole
+`--lib` suite in ONE process on a thread pool, and every sibling that builds an
+`Executor` through the static path claims the same latch. So the test races 367
+other tests for a resource it must observe untouched, and the assertion that
+loses is the second one — `!is_taken()` after a refused over-large request.
+
+The suite is green under **nextest**, which gives each test its own process
+(`cargo nextest run -p nros-node --features std,alloc --lib` — 339 passed).
+That is why `test-unit` does not see this and the `node-std-tests` lane does:
+the lane is the one place in the tree that runs `nros-node`'s unit tests through
+plain `cargo test`, and it does that deliberately, to reach the seven
+`cfg(feature = "std")` tests `--workspace` never builds (its own comment
+records the four days that cost).
+
+## Fix, and the shape it has to keep
+
+Not "delete the test" and not "serialise the suite". The test is a positive
+control for a module that would otherwise be inert while reading as working, so
+it has to keep observing a virgin latch. Either:
+
+* run this lane under `nextest` (process per test) with a filter that still
+  reaches the std-only tests, or
+* give the test its own cargo invocation, the way the same recipe ALREADY does
+  for `boot_report::tests` — that block's comment explains the identical defect
+  ("the record is a process-global static... Sharing a binary means sharing a
+  process... Two cargo invocations are two processes") and then does not apply
+  the lesson one function down.
+
+The second is a two-line change and reuses a pattern the recipe already
+documents.
+
+## Signal cost while it stands
+
+A lane that is red for every input has no signal capacity — a regression landing
+in it looks exactly like this failure. `node-std-tests` is in the derived
+fast-serial gate list, so that is the whole lane.

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -9,7 +9,8 @@ is RESOLVED. Open: W6, and amendment B's wave.**
 than an omission — read its wave entry before quoting it.** The default now
 derives; no image in the tree can show that in `mem-report`, because every
 consumer of the derived number is a RUNTIME arena allocation inside a
-build-time-sized static.**
+build-time-sized static.
+
 Opened from a memory-allocation review that measured a real 320 KiB-class board
 image.
 

--- a/docs/roadmap/phase-392-static-memory-space-campaign.md
+++ b/docs/roadmap/phase-392-static-memory-space-campaign.md
@@ -1,9 +1,15 @@
 # Phase 392 — 27% of a safety-island image is message buffers nobody can price
 
-**Status (2026-09-06). W1, W2, W4 and W5.a-W5.g landed. W3 is complete except
-W3c: W3a/W3b landed here, W3d landed as phase-408 W1, W3g as phase-403 W0/W6,
-W3e is superseded by phase 408 and W3f was delivered as a recorded refusal. W2
-IS issue 0900, which is RESOLVED. Open: W3c, W6, and amendment B's wave.**
+**Status (2026-09-07). W1, W2, W3, W4 and W5.a-W5.g landed. W3a/W3b/W3c landed
+here, W3d landed as phase-408 W1, W3g as phase-403 W0/W6, W3e is superseded by
+phase 408 and W3f was delivered as a recorded refusal. W2 IS issue 0900, which
+is RESOLVED. Open: W6, and amendment B's wave.**
+
+**W3c landed with its acceptance NOT met, and the reason is a finding rather
+than an omission — read its wave entry before quoting it.** The default now
+derives; no image in the tree can show that in `mem-report`, because every
+consumer of the derived number is a RUNTIME arena allocation inside a
+build-time-sized static.**
 Opened from a memory-allocation review that measured a real 320 KiB-class board
 image.
 
@@ -469,6 +475,15 @@ written to prevent — the sample is received, ACKed and dropped. Making the
 derived size the DEFAULT at a site that names the type, with the global as the
 explicit opt-out, is the whole of W3c.
 
+**RESOLVED by W3c (2026-09-07), on the backends that can reach the bound.** The
+derivation is what a subscription gets without asking and `.rx_buffer::<N>()`
+is the opt-out. The residue is issue 1179: at a type-erased registration site
+the only bound in scope is `MessageForRmw`, which requires
+`nros_serdes::schema::Message` only on a backend declaring `type-descriptors`
+(Cyclone), so on zenoh and XRCE the default is unchanged and
+`.rx_buffer_from_type()` / `rx_buffer_for!` — which name the schema themselves
+— remain the route.
+
 **2. C/C++ has no site that names the type — and this is the design fork.**
 RFC-0043 typed components subscribe RAW: the type reaches the runtime as a
 STRING. `add_arena_subscription_c_callback::<BUF>` therefore takes
@@ -520,6 +535,78 @@ whole lever exists to stop.
 subscription gets without asking; the global becomes the opt-out. Acceptance:
 an example that subscribes to a bounded type over the small class shows the
 change in `mem-report --baseline` without its source being edited.
+
+**LANDED 2026-09-07, and the acceptance is NOT met. Three things about the
+wave were different from what this entry assumed, and all three were measured
+before any code was written.**
+
+*1. The mechanism moved.* `rx_buffer_for!` is no longer the thing to make
+default. phase-403 W2 landed `.rx_buffer_from_type()`, a RUNTIME-sized sibling
+that sizes the arena ALLOCATION rather than a const-generic array, and its own
+doc named this wave as the decision it was deferring: "sizing every
+subscription from its type by default would move every image's arena occupancy
+at once, which is a decision, not a refactor". W3c is that decision, taken on
+that mechanism. `rx_buffer_for!` keeps a narrower job — `.message_info()` and
+`.safety()` entries hold a real inline `[u8; RX]`, so their size can still only
+come from a const-generic argument named at the call site.
+
+*What landed:* the derivation moved into
+`Executor::register_subscription_buffered_on`, the ONE choke point all four
+default registration sites funnel through (`create_subscription`,
+`create_subscription_in`, the builder's `build()`, and the `/clock` time
+source), so it is the default at all four rather than at whichever one a wave
+happened to touch. `rx_bytes: None` there means DERIVE; `.rx_buffer::<N>()`
+passes `Some(N)` and is the opt-out. Naming a number is now the only way to
+spend more arena than the type needs, which is the direction that should
+require saying so.
+
+*The saving, measured* (`cargo test -p nros-node --features
+std,alloc,needs-type-descriptors --lib`, positive control = revert the
+choke-point line and watch the same test go red at `left: 5376, right: 2340`):
+a 12-byte bounded type at `QoSProfile::default().depth` costs **13,632 -> 2,500
+bytes** of arena per registration, 11,132 recovered; at depth 2, **5,376 ->
+2,340**.
+
+*2. The acceptance names an example that does not exist.* "A bounded type over
+the small class" means a bound above `SMALL_CLASS_CEILING` (2048). Every Rust
+subscription in `examples/` was enumerated: `StringMsg` (`FieldType::String`,
+unbounded — so no bound to derive), `Int32` (4 bytes), `SensorReading`
+(hand-written, no schema), the px4 types (all well under 2048). None is over
+the small class. This wave's own W3 section already recorded the fact —
+"no example in the tree has one today, which is its own finding about the
+fixture corpus rather than about the wave" — and W3c's acceptance was written
+as though it had been fixed.
+
+*3. `mem-report` cannot see this saving on ANY image, and that is structural.*
+The derived number reaches `buffered_region_size` / `TripleBuffer::init` /
+`SpscRing::init` — runtime allocations out of the executor arena. The arena is
+`nros_node::executor::backing::EXECUTOR_BACKING`, a `.bss` static whose size is
+`config::ARENA_SIZE`, derived in `nros-node/build.rs` from KNOBS and declared
+entity COUNTS. No registration can move it. Measured directly, before and
+after, on a real ELF containing a derived-default registration:
+`EXECUTOR_BACKING` is **86,216 bytes on both sides**, and every other RAM
+symbol is unchanged. Positive control for that probe: rebuilding with
+`NROS_SUBSCRIPTION_BUFFER_SIZE=2048` moves the same symbol to **98,504**
+(+12,288), so the probe detects exactly the class of change W3c would have had
+to produce.
+
+So a mem-report delta from this lever needs the BUILD-TIME arena derivation to
+learn the per-type bounds, which is `nros-node/build.rs`'s `rx_recv_size` term
+and `nros_derive_message_bound_knobs` — phase-403 step 3's lane, not this one,
+and deliberately deferred there ("a DESIGN choice with two bad options").
+
+*Filed:* [issue 1179](../issues/1179-derived-rx-default-unreachable-without-schema.md)
+— the default derives only on a backend declaring `type-descriptors` (today:
+Cyclone alone, verified across all four `nros-rmw.toml`), because
+`MessageForRmw` carries no schema on the other arm and phase-380 W4 refused to
+tighten it. The same constraint makes W3a inert on zenoh, which is worth
+knowing before quoting W3a's "a Rust subscription to a 4 KiB type now routes
+large" — true on Cyclone, false on the backend that has the size classes.
+[issue 1180](../issues/1180-mem-report-baseline-cannot-match-llvm-suffixed-symbols.md)
+— `mem-report --baseline` matches symbols by name including the per-build
+`.llvm.<hash>` suffix, so it silently prints "no delta" for `EXECUTOR_BACKING`
+whatever happened to it. That one nearly turned this wave's measurement into a
+probe that could only return nothing.
 
 **W3d — emit the constants, and retarget the publish helper.** 0896 layers 1-3.
 Acceptance: the emitted constant equals the Rust const for every type in the

--- a/packages/api/nros/src/lib.rs
+++ b/packages/api/nros/src/lib.rs
@@ -42,8 +42,11 @@
 //! - **`NROS_EXECUTOR_ARENA_SIZE`** (default 4096) — byte budget for storing
 //!   callback closures inline.
 //!
-//! For messages larger than the default 1024-byte receive buffer, size the
-//! subscription via the builder's `.rx_buffer::<N>()` knob (e.g.
+//! A subscription's arena receive buffer is sized from the MESSAGE TYPE's own
+//! serialized bound (phase-392 W3c), not from that knob, wherever the bound is
+//! reachable. `.rx_buffer::<N>()` is the opt-out: it says "give me exactly `N`
+//! bytes per slot" and skips the derivation, which is what a peer that pads or
+//! a `.msg` bound looser than the traffic needs (e.g.
 //! `node_mut(id).subscription(t).typed::<M>().rx_buffer::<4096>().build(cb)`).
 //!
 //! ## Transport Backends
@@ -639,6 +642,14 @@ pub use nros_macros::main;
 /// (`report_dropped_take`, and the 13.4 KiB Autoware trajectory case). This
 /// expands to the type's own bound, computed from its schema by phase 380, so
 /// appending a field moves the buffer with it.
+///
+/// **phase-392 W3c narrowed what this is FOR.** A plain
+/// `.typed::<M>().build()` now derives its arena receive buffer from `M` on its
+/// own, and `.rx_buffer::<N>()` is the opt-out, so the macro is no longer how a
+/// buffered subscription gets a type-sized buffer. What still needs it is the
+/// entry shapes whose buffer is a real inline `[u8; RX]` and therefore a
+/// const-generic argument: `.message_info()` and `.safety()`. Those are the
+/// call sites this expands for.
 ///
 /// **Why a macro and not a method.** The builder cannot do this for you:
 /// inside `impl<M> TypedSubscriptionBuilder<M>` the type is a generic

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -2055,6 +2055,7 @@ impl<'c, 'e, 't, 's> SubscriptionBuilder<'c, 'e, 't, 's> {
             topic: self.topic,
             qos: self.qos,
             sched: None,
+            rx_explicit: false,
             _phantom: PhantomData,
         }
     }
@@ -2090,6 +2091,13 @@ pub struct TypedSubscriptionBuilder<
     topic: &'t str,
     qos: QoSProfile,
     sched: Option<super::sched_context::SchedContextId>,
+    /// phase-392 W3c -- did the CONSUMER name `RX`, or is it just the default?
+    ///
+    /// The two are the same const generic and mean opposite things now: an
+    /// unnamed `RX` is a ceiling the derivation clamps to, a named one is the
+    /// number the consumer asked for. `.rx_buffer::<N>()` is the only thing that
+    /// sets this, so the flag cannot drift from "somebody wrote a number".
+    rx_explicit: bool,
     _phantom: PhantomData<M>,
 }
 
@@ -2108,12 +2116,24 @@ impl<'c, 'e, 't, 's, M: MessageForRmw + 'static, const RX: usize>
     }
 
     /// Set the staging-buffer size (const-generic).
+    ///
+    /// phase-392 W3c -- **this is the opt-out.** A subscription that does not
+    /// call it is sized from `M`'s own serialized bound; calling it says "give
+    /// me exactly `N` bytes per slot" and the derivation is skipped. Naming a
+    /// number is the only way to spend more arena than the type needs, which is
+    /// the direction that should require saying so.
+    ///
+    /// It stays the way to raise a buffer above the type's bound -- for a peer
+    /// that pads, or a type whose `.msg` bound is looser than what it really
+    /// sends -- and `.rx_buffer_from_type()` after it re-enters the derivation
+    /// with `N` as the ceiling.
     pub fn rx_buffer<const N: usize>(self) -> TypedSubscriptionBuilder<'c, 'e, 't, 's, M, N> {
         TypedSubscriptionBuilder {
             ctx: self.ctx,
             topic: self.topic,
             qos: self.qos,
             sched: self.sched,
+            rx_explicit: true,
             _phantom: PhantomData,
         }
     }
@@ -2128,12 +2148,25 @@ impl<'c, 'e, 't, 's, M: MessageForRmw + 'static, const RX: usize>
     ///     .build(on_msg)?;
     /// ```
     ///
-    /// **Opt-in, and that is the design.** A subscription that does not call
-    /// this claims exactly the bytes it claimed before the knob existed, so an
-    /// image that does not opt in is byte-identical -- the same rule issue 0900's
-    /// arena knob keeps (`the_default_derivation_is_unchanged`). Sizing every
-    /// subscription from its type by default would move every image's arena
-    /// occupancy at once, which is a decision, not a refactor.
+    /// **No longer the only way to get it (phase-392 W3c).** This was opt-in,
+    /// and its own doc said making it the default "would move every image's
+    /// arena occupancy at once, which is a decision, not a refactor". W3c is
+    /// that decision: a plain `.typed::<M>().build()` now derives too, wherever
+    /// the bound is reachable, and `.rx_buffer::<N>()` is the opt-out.
+    ///
+    /// Two jobs are left, and they are why this method stays:
+    ///
+    /// * **It REFUSES an unbounded `M` at build time.** The default path cannot
+    ///   -- erroring there would make a bound mandatory for every message type
+    ///   in every image at once -- so it keeps `RX` for a type with no bound.
+    ///   Calling this says the bound must exist, and the `const` assert below
+    ///   is the error that says so.
+    /// * **It reaches the derivation where `MessageForRmw` carries no schema.**
+    ///   Only a backend declaring `type-descriptors` makes the type-erased
+    ///   default site able to read a bound at all (see
+    ///   [`default_subscription_rx_bytes`](crate::rmw_type_registry::default_subscription_rx_bytes));
+    ///   this method names `M: nros_serdes::schema::Message` itself, so it works
+    ///   on every backend.
     ///
     /// **What it costs and what it buys.** The buffered path stores `depth <= 1
     /// ? 3 : depth+1` slots of this size in the executor arena, so a bounded
@@ -2230,7 +2263,10 @@ impl<'c, 'e, 't, 's, M: MessageForRmw + 'static, const RX: usize>
                 self.qos,
                 callback,
                 None, // group threaded via create_subscription_in; builder uses sched override
-                None, // phase-403 W2: `RX` verbatim, the pre-knob behaviour
+                // phase-392 W3c -- `None` asks the choke point to DERIVE from
+                // `M`; `Some(RX)` is the consumer's own number, and only
+                // `.rx_buffer::<N>()` sets that flag.
+                if self.rx_explicit { Some(RX) } else { None },
             )?;
         if let Some(sc) = self.sched {
             self.ctx.executor.bind_handle_to_sched_context(handle, sc)?;

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -4113,10 +4113,16 @@ impl<'s> Executor<'s> {
     /// .typed::<M>()` builder lowers here). Routes the typed subscription
     /// through the [`NodeId`]'s session + identity (rclcpp `add_node` pattern).
     ///
-    /// Phase 403 W2 -- `rx_bytes` overrides how many bytes each buffer slot
-    /// claims from the arena. `None` means `RX_BUF`, which is what every caller
-    /// did before the knob existed and is what every caller that does not opt in
-    /// still does: the default derivation is byte-for-byte unchanged.
+    /// Phase 403 W2 -- `rx_bytes` says how many bytes each buffer slot claims
+    /// from the arena.
+    ///
+    /// phase-392 W3c -- `Some(n)` is verbatim; **`None` now means DERIVE from
+    /// `M`**, falling back to `RX_BUF` only where no bound is reachable (an
+    /// unbounded type, or a backend whose `MessageForRmw` carries no schema).
+    /// It used to mean `RX_BUF` unconditionally, so a subscription that named no
+    /// number was charged the global for every slot and a consumer who did not
+    /// know `.rx_buffer_from_type()` existed paid it silently. The opt-out is
+    /// now the explicit one: `.rx_buffer::<N>()` passes `Some(N)`.
     ///
     /// It is a RUNTIME `usize` and not a second const generic because on THIS
     /// path `RX_BUF` was never an array length -- it reaches
@@ -4225,7 +4231,20 @@ impl<'s> Executor<'s> {
         // Phase 403 W2 -- one number for the whole allocation. The region size,
         // the strategy's slot size and the pointer arithmetic must agree, so
         // they read the same local rather than each spelling `RX_BUF`.
-        let slot_size = rx_bytes.unwrap_or(RX_BUF);
+        //
+        // phase-392 W3c -- and `None` no longer means `RX_BUF`, it means DERIVE.
+        // This is the one choke point every default registration funnels
+        // through, so putting the derivation here is what makes it the default
+        // at all four of them (`create_subscription`, `create_subscription_in`,
+        // the builder's `build()`, and the `/clock` time source) instead of at
+        // whichever one a wave happened to touch. An explicit `Some(n)` -- what
+        // `.rx_buffer::<N>()` and `.rx_buffer_from_type()` pass -- is still
+        // verbatim, so the opt-out and the opt-in both bypass this line.
+        let slot_size = match rx_bytes {
+            Some(n) => n,
+            None => crate::rmw_type_registry::default_subscription_rx_bytes::<M>(RX_BUF)
+                .unwrap_or(RX_BUF),
+        };
 
         let (_slot_count, trailing_bytes) = buffered_region_size(qos.depth, slot_size);
 

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -260,32 +260,74 @@ impl Deserialize for UnboundedTestMsg {
     }
 }
 
+/// How a `TestMsg` subscription asks for its receive buffer -- the three states
+/// phase-392 W3c makes distinguishable, and the reason this is an enum and not
+/// the `bool` it was: "did not ask" and "asked for a number" used to mean the
+/// same thing.
+#[derive(Clone, Copy)]
+enum RxAsk {
+    /// Name nothing. Derived from the type wherever the bound is reachable.
+    Default,
+    /// `.rx_buffer::<4096>()` -- the opt-out, exact, and deliberately ABOVE
+    /// the global so an opt-out that silently fell back is distinguishable.
+    Exact,
+    /// `.rx_buffer::<DEFAULT_RX_BUF_SIZE>()` -- the opt-out spelled with the
+    /// global. phase-392 W3c: this is what "the global" costs now that it is a
+    /// thing a consumer asks for rather than what everyone silently gets.
+    Global,
+    /// `.rx_buffer_from_type()` -- the explicit derivation, on every backend.
+    FromType,
+}
+
 /// Arena bytes one `TestMsg` subscription registration claims.
 fn arena_delta(
     executor: &mut Executor<'_>,
     nid: super::node_record::NodeId,
     topic: &str,
     qos: QoSProfile,
-    from_type: bool,
+    ask: RxAsk,
 ) -> usize {
     let before = executor.arena_used();
-    if from_type {
-        executor
-            .node_mut(nid)
-            .subscription(topic)
-            .typed::<TestMsg>()
-            .qos(qos)
-            .rx_buffer_from_type()
-            .build(|_: &TestMsg| {})
-            .unwrap();
-    } else {
-        executor
-            .node_mut(nid)
-            .subscription(topic)
-            .typed::<TestMsg>()
-            .qos(qos)
-            .build(|_: &TestMsg| {})
-            .unwrap();
+    match ask {
+        RxAsk::FromType => {
+            executor
+                .node_mut(nid)
+                .subscription(topic)
+                .typed::<TestMsg>()
+                .qos(qos)
+                .rx_buffer_from_type()
+                .build(|_: &TestMsg| {})
+                .unwrap();
+        }
+        RxAsk::Exact => {
+            executor
+                .node_mut(nid)
+                .subscription(topic)
+                .typed::<TestMsg>()
+                .qos(qos)
+                .rx_buffer::<4096>()
+                .build(|_: &TestMsg| {})
+                .unwrap();
+        }
+        RxAsk::Global => {
+            executor
+                .node_mut(nid)
+                .subscription(topic)
+                .typed::<TestMsg>()
+                .qos(qos)
+                .rx_buffer::<{ crate::config::DEFAULT_RX_BUF_SIZE }>()
+                .build(|_: &TestMsg| {})
+                .unwrap();
+        }
+        RxAsk::Default => {
+            executor
+                .node_mut(nid)
+                .subscription(topic)
+                .typed::<TestMsg>()
+                .qos(qos)
+                .build(|_: &TestMsg| {})
+                .unwrap();
+        }
     }
     executor.arena_used() - before
 }
@@ -297,34 +339,120 @@ fn qos_with_depth(depth: u32) -> QoSProfile {
     }
 }
 
-/// The compatibility gate, the sibling of issue 0900's
-/// `the_default_derivation_is_unchanged`: the knob exists so an image CAN
-/// shrink its receive buffers, not so every image silently does.
+/// phase-392 W3c -- what a subscription that names NO number is charged.
+///
+/// This test was `the_default_subscription_buffer_is_unchanged` and asserted the
+/// opposite: that a non-opted-in subscription still paid `DEFAULT_RX_BUF_SIZE`
+/// per slot. W3c is the decision to invert that -- `.rx_buffer_from_type()`'s
+/// own doc named it ("sizing every subscription from its type by default would
+/// move every image's arena occupancy at once, which is a decision, not a
+/// refactor") -- so the assertion moves with it rather than being deleted.
+///
+/// It is written against
+/// [`default_subscription_rx_bytes`](crate::rmw_type_registry::default_subscription_rx_bytes)
+/// rather than a literal because that function has TWO arms and both are
+/// correct: it derives where `MessageForRmw` carries a schema (a backend
+/// declaring `type-descriptors`) and answers `None` where it does not, and the
+/// wiring under test -- "the choke point charges exactly what the default
+/// derivation says" -- is the same claim either way. `arm_note` puts the arm in
+/// the failure message so a red is never ambiguous about which one ran.
 ///
 /// Two depths rather than one absolute number, because the entry STRUCT's size
 /// is a target detail this test has no business asserting while the SLOT size is
 /// exactly what it must pin. `region_size` is linear in the slot size with a
-/// depth-dependent slot count, so the difference between two depths isolates the
-/// slot size: it comes out right only if a non-opted-in subscription is still
-/// charged `DEFAULT_RX_BUF_SIZE` per slot. Sizing it from `TestMsg` (12 bytes)
-/// instead fails here by 8128 bytes.
+/// depth-dependent slot count, so the difference between two depths isolates it.
 #[test]
-fn the_default_subscription_buffer_is_unchanged() {
+fn the_default_subscription_buffer_is_derived_from_the_type() {
+    let default = crate::config::DEFAULT_RX_BUF_SIZE;
+    let derived = crate::rmw_type_registry::default_subscription_rx_bytes::<TestMsg>(default);
+
     let mut executor: Executor = executor_with_clock(MockSession::new());
     let nid = executor.node_builder("default_sizing").build().unwrap();
+    let depth = qos_with_depth(2);
 
-    let shallow = arena_delta(&mut executor, nid, "/shallow", qos_with_depth(2), false);
-    let deep = arena_delta(&mut executor, nid, "/deep", qos_with_depth(10), false);
+    let named_nothing = arena_delta(&mut executor, nid, "/nothing", depth, RxAsk::Default);
+    let named_global = arena_delta(&mut executor, nid, "/global", depth, RxAsk::Global);
+    let named_type = arena_delta(&mut executor, nid, "/from_type", depth, RxAsk::FromType);
 
-    let default = crate::config::DEFAULT_RX_BUF_SIZE;
-    let (_s, shallow_region) = super::arena::buffered_region_size(2, default);
-    let (_d, deep_region) = super::arena::buffered_region_size(10, default);
+    // Costs are compared against a REGISTRATION rather than against
+    // `buffered_region_size`, because the arena aligns what it hands out and a
+    // 12-byte slot is not aligned: the raw region formula is off by the padding
+    // at small slot sizes and exact at 1024, which would make this pass on one
+    // arm for the wrong reason.
+    match derived {
+        Some(bound) => {
+            assert_eq!(
+                named_nothing, named_type,
+                "with a schema on `MessageForRmw`, naming nothing must cost \
+                 exactly what `.rx_buffer_from_type()` costs -- the derivation \
+                 IS the default (bound {bound})"
+            );
+            assert!(
+                named_nothing < named_global,
+                "and that must be a saving against the global: naming nothing \
+                 claimed {named_nothing} bytes, `.rx_buffer::<{default}>()` \
+                 claimed {named_global}"
+            );
+        }
+        None => {
+            assert_eq!(
+                named_nothing, named_global,
+                "without a schema on `MessageForRmw` there is no bound to read \
+                 at a type-erased registration site, so naming nothing must \
+                 still cost the global {default}"
+            );
+            assert!(
+                named_type < named_nothing,
+                "and `.rx_buffer_from_type()`, which names the schema itself, \
+                 must still be the cheaper answer on this arm \
+                 ({named_type} vs {named_nothing})"
+            );
+        }
+    }
+}
+
+/// phase-392 W3c -- `.rx_buffer::<N>()` is the OPT-OUT, and it is exact.
+///
+/// The consumer named a number, so the derivation is skipped and every slot
+/// costs `N` -- including when `N` is far larger than the type needs, which is
+/// the whole reason the opt-out exists (a peer that pads, a `.msg` bound looser
+/// than the traffic). Measured against `buffered_region_size(depth, N)` at two
+/// depths for the same reason as its sibling above.
+#[test]
+fn naming_a_receive_buffer_opts_out_of_the_derivation() {
+    const N: usize = 4096;
+    assert!(
+        N > crate::config::DEFAULT_RX_BUF_SIZE,
+        "the fixture is only meaningful while N is off the default, or an \
+         opt-out that silently fell back would still pass"
+    );
+
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let nid = executor.node_builder("explicit_sizing").build().unwrap();
+
+    let shallow = arena_delta(
+        &mut executor,
+        nid,
+        "/shallow",
+        qos_with_depth(2),
+        RxAsk::Exact,
+    );
+    let deep = arena_delta(
+        &mut executor,
+        nid,
+        "/deep",
+        qos_with_depth(10),
+        RxAsk::Exact,
+    );
+
+    let (_s, shallow_region) = super::arena::buffered_region_size(2, N);
+    let (_d, deep_region) = super::arena::buffered_region_size(10, N);
 
     assert_eq!(
         deep - shallow,
         deep_region - shallow_region,
-        "a subscription that does not opt in must still be charged {default} \
-         bytes per slot; depth 2 claimed {shallow} and depth 10 claimed {deep}"
+        "`.rx_buffer::<{N}>()` must claim exactly {N} bytes per slot; depth 2 \
+         claimed {shallow} and depth 10 claimed {deep}"
     );
 }
 
@@ -335,6 +463,13 @@ fn the_default_subscription_buffer_is_unchanged() {
 /// `TestMsg`'s bound is 12 bytes, the buffer region falls 11352 -> 220, and the
 /// registration's total arena claim falls **13632 -> 2500 bytes**, i.e. 11132
 /// recovered -- 15% of the 74240-byte default arena, from one subscription.
+///
+/// phase-392 W3c -- the baseline is now `.rx_buffer::<DEFAULT_RX_BUF_SIZE>()`,
+/// the OPT-OUT, and not a subscription that names nothing: naming nothing
+/// derives too wherever the bound is reachable, so comparing against it would
+/// measure zero on exactly the arm the saving is real on. The number under test
+/// is unchanged -- this is the same 11132 bytes, priced against the global that
+/// a consumer now has to ask for.
 #[test]
 fn a_bounded_type_shrinks_its_own_receive_buffer() {
     let bound = nros_serdes::size::max_serialized_bound::<TestMsg>()
@@ -350,8 +485,20 @@ fn a_bounded_type_shrinks_its_own_receive_buffer() {
     let nid = executor.node_builder("bound_sizing").build().unwrap();
 
     let depth = QoSProfile::default().depth;
-    let default_delta = arena_delta(&mut executor, nid, "/plain", qos_with_depth(depth), false);
-    let bound_delta = arena_delta(&mut executor, nid, "/sized", qos_with_depth(depth), true);
+    let default_delta = arena_delta(
+        &mut executor,
+        nid,
+        "/plain",
+        qos_with_depth(depth),
+        RxAsk::Global,
+    );
+    let bound_delta = arena_delta(
+        &mut executor,
+        nid,
+        "/sized",
+        qos_with_depth(depth),
+        RxAsk::FromType,
+    );
 
     let (_s, default_region) =
         super::arena::buffered_region_size(depth, crate::config::DEFAULT_RX_BUF_SIZE);
@@ -6302,8 +6449,11 @@ fn an_unbounded_subscription_costs_more_than_a_bounded_one() {
         .node_builder("bounded_vs_not")
         .build()
         .expect("node");
-    let bounded = arena_delta(&mut executor, nid, "/b", qos_with_depth(1), true);
-    let unbounded = arena_delta(&mut executor, nid, "/u", qos_with_depth(1), false);
+    let bounded = arena_delta(&mut executor, nid, "/b", qos_with_depth(1), RxAsk::FromType);
+    // phase-392 W3c -- the fallback is now spelled `.rx_buffer::<GLOBAL>()`.
+    // A subscription that names nothing DERIVES where the bound is reachable,
+    // so it is no longer the fallback and would measure equal on that arm.
+    let unbounded = arena_delta(&mut executor, nid, "/u", qos_with_depth(1), RxAsk::Global);
     assert!(
         unbounded > bounded,
         "the unbounded fallback must cost MORE than a derived bound \
@@ -6350,9 +6500,9 @@ fn report_arena_costs() {
     let (d1, d10, unb) = {
         let mut e: Executor = executor_with_clock(MockSession::new());
         let nid = e.node_builder("arena_report").build().expect("node");
-        let a = arena_delta(&mut e, nid, "/r1", qos_with_depth(1), true);
-        let b = arena_delta(&mut e, nid, "/r10", qos_with_depth(10), true);
-        let c = arena_delta(&mut e, nid, "/ru", qos_with_depth(1), false);
+        let a = arena_delta(&mut e, nid, "/r1", qos_with_depth(1), RxAsk::FromType);
+        let b = arena_delta(&mut e, nid, "/r10", qos_with_depth(10), RxAsk::FromType);
+        let c = arena_delta(&mut e, nid, "/ru", qos_with_depth(1), RxAsk::Default);
         (a, b, c)
     };
     let svc = {
@@ -6396,8 +6546,20 @@ fn a_subscriptions_arena_cost_scales_with_declared_depth() {
     let mut executor: Executor = executor_with_clock(MockSession::new());
     let nid = executor.node_builder("arena_probe").build().expect("node");
 
-    let d1 = arena_delta(&mut executor, nid, "/d1", qos_with_depth(1), true);
-    let d10 = arena_delta(&mut executor, nid, "/d10", qos_with_depth(10), true);
+    let d1 = arena_delta(
+        &mut executor,
+        nid,
+        "/d1",
+        qos_with_depth(1),
+        RxAsk::FromType,
+    );
+    let d10 = arena_delta(
+        &mut executor,
+        nid,
+        "/d10",
+        qos_with_depth(10),
+        RxAsk::FromType,
+    );
 
     assert!(
         d10 > d1,

--- a/packages/core/nros-node/src/rmw_type_registry.rs
+++ b/packages/core/nros-node/src/rmw_type_registry.rs
@@ -282,3 +282,52 @@ pub const fn subscription_buffer_ok<M: MessageForRmw>() -> bool {
 pub const fn subscription_buffer_ok<M: MessageForRmw>() -> bool {
     true
 }
+
+/// phase-392 W3c — the receive-buffer size a subscription to `M` gets WITHOUT
+/// asking, or `None` when there is nothing to derive from.
+///
+/// This is the inversion the wave is: before it, a subscription that named no
+/// number was charged `DEFAULT_RX_BUF_SIZE` per slot and the type's own bound
+/// reached the arena only if the consumer wrote
+/// [`rx_buffer_from_type`](crate::executor::node::TypedSubscriptionBuilder::rx_buffer_from_type)
+/// or `nros::rx_buffer_for!`. A consumer who did not know those exist got the
+/// global, silently — the same failure the derivation was written to prevent.
+/// Now the derivation is the default and `.rx_buffer::<N>()` is the opt-out.
+///
+/// # `None` is never a fallback, it is "no answer exists"
+///
+/// Two DIFFERENT facts both produce `None`, and neither may be turned into a
+/// number here (phase 380):
+///
+/// * **`M` has no bound.** An unbounded member means no bound EXISTS, and
+///   inventing one is the substitution that rule forbids. The opt-in spelling
+///   refuses to compile in this case ([`subscription_rx_bytes`] returns `None`
+///   and `rx_buffer_from_type`'s `const` assert reads it); the DEFAULT path
+///   cannot refuse, because that would make a bound mandatory for every message
+///   type in every image at once, so it keeps the caller's `RX_BUF` — which is
+///   exactly what it was charged before this wave, so no image moves.
+/// * **This backend's `MessageForRmw` carries no schema.** Only a backend that
+///   declares `type-descriptors` in its `nros-rmw.toml` (today: Cyclone) makes
+///   `MessageForRmw` require `nros_serdes::schema::Message`; the other arm
+///   deliberately does not, so a hand-written message type keeps working
+///   (phase-380 W4, `examples/native/rust/custom-msg`). Under that arm there is
+///   no bound to read at a type-erased registration site at ALL, so this returns
+///   `None` for every type and the default is unchanged. A consumer on such a
+///   backend reaches the derivation by NAMING the schema itself, which is what
+///   `.rx_buffer_from_type()` and `rx_buffer_for!` do.
+///
+/// Same two-arm shape, and the same reason for it, as [`subscription_rx_hint`]
+/// and [`subscription_buffer_ok`]: the branch on "does this backend have
+/// schemas" is spelled once, here, so no second spelling of it grows at a call
+/// site.
+#[cfg(rmw_needs_type_descriptors)]
+pub const fn default_subscription_rx_bytes<M: MessageForRmw>(rx_buf: usize) -> Option<usize> {
+    subscription_rx_bytes::<M>(rx_buf)
+}
+
+/// See the documented sibling — no schema on this backend, so no bound is
+/// reachable from a `MessageForRmw` bound alone and the default is unchanged.
+#[cfg(not(rmw_needs_type_descriptors))]
+pub const fn default_subscription_rx_bytes<M: MessageForRmw>(_rx_buf: usize) -> Option<usize> {
+    None
+}


### PR DESCRIPTION
phase-392 **W3c**: a subscription's arena receive buffer is now derived from its message type unless the consumer names a number. `.rx_buffer::<N>()` becomes the opt-out.

## What landed

The derivation already existed and nobody got it without asking. `.rx_buffer_from_type()` (phase-403 W2) sized the arena slot from the message's own bound, and its own doc named this wave as the decision it was deferring — *"sizing every subscription from its type by default would move every image's arena occupancy at once, which is a decision, not a refactor"*. This is that decision.

It lands at the **one choke point** every default registration funnels through, `Executor::register_subscription_buffered_on`, so it is the default at all four sites at once (`create_subscription`, `create_subscription_in`, the builder's `build()`, the `/clock` time source) rather than at whichever one a wave happened to touch. `rx_bytes: None` there now means DERIVE; `.rx_buffer::<N>()` passes `Some(N)` and bypasses it.

Sweep for the class: `grep -n 'register_subscription_buffered_on' packages/core/nros-node/src/`

## Measured

`cargo test -p nros-node --features std,alloc,needs-type-descriptors --lib` — a 12-byte bounded type at `QoSProfile::default().depth`: **13,632 → 2,500 bytes** of arena per registration (11,132 recovered); at depth 2, **5,376 → 2,340**.

Positive control: reverting the choke-point line turns `the_default_subscription_buffer_is_derived_from_the_type` red at `left: 5376, right: 2340`, and leaves the no-schema arm green.

Both arms green under nextest, 339 tests each:

```
cargo nextest run -p nros-node --features std,alloc                        --lib
cargo nextest run -p nros-node --features std,alloc,needs-type-descriptors --lib
```

## The wave's acceptance is NOT met, and that is the finding

W3c asked for the change to show in `mem-report --baseline` on an example subscribing to a bounded type over the small class. Three things, all measured before any code was written:

1. **No such example exists.** Every Rust subscription in `examples/` was enumerated: `StringMsg` is `FieldType::String` (unbounded — nothing to derive), `Int32` is 4 bytes, `SensorReading` is hand-written with no schema, the px4 types are far under 2048. The phase's own W3 section already recorded this.
2. **`mem-report` cannot see this saving on any image.** The derived number reaches runtime arena allocations; the arena is `EXECUTOR_BACKING`, a `.bss` static sized in `nros-node/build.rs` from knobs and declared counts. Measured before and after on a real ELF: **86,216 bytes both sides**, every other RAM symbol unchanged. Positive control: `NROS_SUBSCRIPTION_BUFFER_SIZE=2048` moves that symbol to **98,504** (+12,288), so the probe detects exactly the class of change W3c would have had to produce.
3. **The default derives only where the bound is reachable.** `MessageForRmw` requires `nros_serdes::schema::Message` only under `cfg(rmw_needs_type_descriptors)`, and of the four `nros-rmw.toml` descriptors in the tree only Cyclone declares `type-descriptors`. The same constraint makes W3a inert on zenoh — worth knowing before quoting *"a Rust subscription to a 4 KiB type now routes large"*, which is true on Cyclone and false on the backend that has the size classes.

The phase doc records all three at the wave entry rather than leaving it reading as complete.

## Filed

* **#1179** — make the derivation reachable without a schema-carrying `MessageForRmw`. Two candidate designs (carry the bound on `RosMessage`; split the typed entry point), neither obviously right — the same "choose deliberately" instruction W3's own remainder gives for the C/C++ fork.
* **#1180** — `mem-report --baseline` matches symbols by name *including* the per-build `.llvm.<hash>` suffix, so it silently prints "no delta" for `EXECUTOR_BACKING` whatever happened to it. This nearly turned the measurement above into a probe that could only return nothing.
* **#1183** — `check node-std-tests` is red on `main` (3/3 on a stashed clean tree): a process-global latch test racing 367 siblings under plain `cargo test`. Green under nextest.

## Tier run

`just ci gate` — `check::fast` **green** (252/252), `test-unit` **green** (1187/1188, one skip for an absent live zenoh router). `check::build` has four reds, none of them this change:

| gate | cause |
| --- | --- |
| `node-std-tests` | pre-existing red on `main`, verified 3/3 on a stashed tree → #1183 |
| `workspace-features` | pre-existing red on `main`, 11 identical `E0599` on `HEAD~1` → already #1169 |
| `cli-tests` | `nros-launch-resolve` not built in this worktree |
| `source-gates` | another agent's build held the subtree guard; **passes on re-run** |

The remaining `check::build` gates (`workspace-all`, `required-features-tests`, `staticlib-symbols`, `test-targets`, `cpp`) went green once the zenoh-pico / cyclonedds / micro-xrce / micro-cdr submodules were provisioned in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5
