### PR TITLE
fix(#1183, #1186): the backing latch test needs a virgin process

### DIFF
--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -1085,6 +1085,31 @@ node-std-tests:
     NROS_BOOT_REPORT=1 cargo test -p nros-node --lib --features std --quiet boot_report::tests
     NROS_BOOT_REPORT=1 cargo test -p nros-node --lib --features std --quiet -- \
         --exact executor::tests::arena_exhaustion_reaches_the_boot_record
+    # issues 1183/1186 — a THIRD process-global in this crate, found the same
+    # way and answered the same way. `executor::backing::TAKEN` is a
+    # process-scoped latch, and `spin.rs`'s `default_backing` claims it on every
+    # `Executor::open` under `alloc` — so any of the other 365 tests in this
+    # binary that opens an executor consumes the one handout, and
+    # `the_static_is_handed_out_once_and_only_once` loses its positive control.
+    # Measured: green alone, red in the full lane. It is `#[ignore]`d for that
+    # reason and runs here, in its own process.
+    #
+    # The `1 passed` assertion is not belt-and-braces. `--exact` against a
+    # renamed test matches NOTHING and cargo exits 0 having run none — the
+    # silently-inert shape this file already guards against for
+    # `required-features` targets. A skip must be loud or it is not a lane.
+    backing_out="$(cargo test -p nros-node --lib \
+        --features std,sim-time,param-services --quiet -- --ignored --exact \
+        executor::backing::tests::the_static_is_handed_out_once_and_only_once 2>&1)"
+    printf '%s\n' "$backing_out"
+    case "$backing_out" in
+        *"1 passed"*) ;;
+        *) printf '%s\n' \
+             "node-std-tests: the executor-backing latch test ran 0 tests." \
+             "  \`--exact\` matched nothing, so it was renamed or its cfg is off." \
+             "  A filter that matches nothing exits 0 — fix the name here." >&2
+           exit 1 ;;
+    esac
     # `env,std` and NOT `rmw-cffi`: the cffi flavour makes the wall clock an
     # extern the linker wants a platform port for, and this lane links none.
     cargo test -p nros --lib --features env,std --quiet

--- a/packages/core/nros-node/src/executor/backing.rs
+++ b/packages/core/nros-node/src/executor/backing.rs
@@ -201,8 +201,23 @@ mod tests {
     /// A test that only ever saw `take` return `None` would pass against a `take`
     /// that can never succeed, which is exactly the bug that would make this
     /// whole module inert while reading as if it worked.
+    ///
+    /// `#[ignore]` because it needs a VIRGIN PROCESS, and that is a property of
+    /// the subject rather than a wish: `TAKEN` is process-global, and
+    /// `spin.rs`'s `default_backing` — reached by every `Executor::open` under
+    /// the `alloc` feature — claims it. Any of this binary's other 365 tests
+    /// that opens an executor therefore consumes the one handout first, and
+    /// this test's own positive control (`take` returning `Some`) becomes
+    /// impossible. Measured: passes alone, fails in the full lane at the
+    /// `!is_taken()` assertion below.
+    ///
+    /// `just check node-std-tests` runs it in its own cargo invocation, which
+    /// is a second process. Same shape and same answer as `boot_report::tests`
+    /// one recipe over, and for the same underlying reason.
     #[cfg(nros_executor_backing_static)]
     #[test]
+    #[ignore = "needs a virgin process: TAKEN is a process-global latch that \
+                Executor::open consumes — run via `just check node-std-tests`"]
     fn the_static_is_handed_out_once_and_only_once() {
         // Too large for the reservation: refused BEFORE the latch is touched, so
         // this case cannot consume the one handout.


### PR DESCRIPTION
**A red on `main`.** `just check node-std-tests`:

```
executor::backing::tests::the_static_is_handed_out_once_and_only_once FAILED
panicked at packages/core/nros-node/src/executor/backing.rs:213
```

Three parallel sessions hit this independently today and two filed it (#1183, #1186) — which is itself a signal about how visible a red in this lane is.

## Cause

`executor::backing::TAKEN` is a process-global latch **by design**: two `&'static mut` to one static is UB, so the handout is once per process. `spin.rs`'s `default_backing` claims it on every `Executor::open` under the `alloc` feature.

So any of the other 365 tests in this binary that opens an executor consumes the one handout *before* this test runs, and the test's own positive control — `take` returning `Some` — becomes impossible.

Measured both ways, and the split **is** the diagnosis rather than a flake:

| invocation | result |
| --- | --- |
| `cargo test -p nros-node --lib ... backing` (3 tests) | **green** |
| `just check node-std-tests` (366 tests) | **red** at the `!is_taken()` assertion |

The test's author knew `TAKEN` was process-scoped and consolidated three cases into one test for exactly this reason, with a comment noting that a second test would observe an already-consumed latch and assert nothing. The reasoning was right and did not go far enough: the collision is not with a sibling in this module, it is with **every other test in the binary**.

## Fix

`#[ignore]` with the reason in the attribute, plus a dedicated cargo invocation in `node-std-tests` — a second process. Same shape and same answer as `boot_report::tests` one recipe over, which is already two invocations for the same class of reason (a process-global keeping only the first allocation failure).

The `1 passed` assertion around that invocation is **not** belt-and-braces. `--exact` against a renamed test matches nothing and cargo exits 0 having run none — the silently-inert shape this file already guards against for `required-features` targets, and it would quietly turn this fix into a test that never runs again.

## Verification

- `just check node-std-tests` → exit 0, with `test result: ok. 1 passed` for the moved test in its own process, and `365 passed; 0 failed; 2 ignored` for the main binary.
- **Mutation-tested**: renaming the filter makes the lane exit 1 and print what to fix; restoring it goes green.

```
node-std-tests: the executor-backing latch test ran 0 tests.
  `--exact` matched nothing, so it was renamed or its cfg is off.
```

## Not claimed

That `TAKEN` should stop being process-global (it must be), or that the other 365 tests should avoid `Executor::open` (they are testing the executor). **The placement is the bug, not the latch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4x9AtJRZ4FMUkZeifSQ5