### PR TITLE
fix(phase-428 W13.c): cyclone answers service_server_is_available from the DDS cache; XRCE says it cannot

### DIFF
--- a/.config/gate-lane-exempt.txt
+++ b/.config/gate-lane-exempt.txt
@@ -54,7 +54,6 @@ fast-parallel  # retired alias for `fast`, kept for muscle memory
 fast-serial  # lane verb: the same lane, one gate at a time, fail-fast
 nextest-test-filters  # in no lane and no caller found — issue 1071's class
 no-std  # gate.yml + `just ci` run it by name; cross-compiles riscv32
-rmw-feature-matrix  # generator `--check`; in no lane and no caller found
 rustdoc-links  # `cargo doc` over the deployed crate set; compiles `zpico-sys`, whose build script needs the zenoh-pico source. Its own pull-request step in gate.yml runs it AFTER provisioning
 sched-matrix  # generator `--check`; in no lane and no caller found
 sdk-index  # NETWORK — downloads and sha256-checks SDK release assets

--- a/book/src/reference/rmw-feature-matrix.md
+++ b/book/src/reference/rmw-feature-matrix.md
@@ -26,22 +26,21 @@ backends land implementations.
 | Publish / subscribe | wired | wired | wired |
 | Services (server side) | wired | wired | wired |
 | Service clients | wired | wired | wired |
-| Server-availability probe | wired | — | — |
+| Server-availability probe | wired | — | wired |
 | Status events (deadline / liveliness / lost) | wired | — | — |
 | Manual liveliness assert | wired | — | — |
-| Event-driven wake (`set_wake_callback`) | wired | — | — |
+| Event-driven wake (`set_wake_callback`) | wired | — | wired |
 | Deadline hint (`next_deadline_ms`) | wired | — | — |
 | Zero-copy loan API | — | — | — |
 | Batch receive (`take_sequence`) | wired | — | wired |
 | Streamed publish | wired | wired | — |
 | Connectivity ping | wired | wired | — |
 | Identity / feature probe | — | — | — |
-| Publisher GID / matched counts | — | — | — |
-| Actual-QoS read-back | — | — | — |
+| Publisher GID / matched counts | — | — | wired |
+| Actual-QoS read-back | — | — | wired |
 | Wait-for-acked | — | — | — |
-| Take-with-info | — | — | — |
-| Entity new-data callbacks | — | — | — |
-| Graph introspection (names/types/counts) | — | — | — |
+| Take-with-info | wired | — | — |
+| Graph introspection (names/types/counts) | wired | — | — |
 
 ## Node-layer features
 

--- a/docs/issues/archived/1087-server-availability-assumed-true-no-vtable-slot.md
+++ b/docs/issues/archived/1087-server-availability-assumed-true-no-vtable-slot.md
@@ -74,12 +74,45 @@ and the `ZenohServiceRos2Server` interop cell now starts the client BEFORE the
 ROS 2 `add_two_ints_server` and asserts both halves: the waiting line with no
 server (and no request sent), then the result once the server's token lands.
 
+## Resolution — phase-428 W13.c (2026-09-07)
+
+**Cyclone fills the slot.** `nros_rmw_cyclonedds::client_server_is_available`
+(`service.cpp`) mirrors upstream `rmw_cyclonedds_cpp`'s
+`check_for_service_reader_writer` (humble `rmw_node.cpp`): the request writer's
+matched readers (`dds_get_matched_subscriptions`) AND the reply reader's
+matched writers (`dds_get_matched_publications`) must both be non-empty; when
+any matched reader advertises `serviceid=<guid>` in its user data (stock
+`rmw_cyclonedds_cpp` servers do), a matched reply writer must carry the SAME
+id — that pairs the two halves to one server — and when none does (every
+nano-ros server; this backend sets no user data) both-non-empty is the answer.
+Read from the matched sets Cyclone already keeps, no query issued, bounded
+storage (32 handles a side, no `std::vector`). Upstream's graph-cache
+reader/writer pre-count is a copy of the same discovery state, not a second
+source, so it is not reproduced. Test
+`nros_rmw_cyclonedds_service_server_available` (Cyclone lane): one client on
+its own participant reads false with no server, true once a server on a
+SECOND participant matches both halves, false for a client of another name on
+the same busy bus, and false again after the server is destroyed — polled, so
+cross-participant SEDP jitter costs time rather than a red.
+
+**XRCE keeps the slot NULL, on purpose.** The Agent owns the DDS participant,
+so the matched-endpoint state lives Agent-side and micro-XRCE-DDS-Client has
+no read for it (no `dds_get_matched_*`, no built-in topic readers, no
+participant enumeration). What the session CAN know — the Agent acknowledged
+`create_requester` — says only that the client's own endpoints exist, nothing
+about a server; answering from it would be this issue's "yes without asking"
+one layer down. NULL is `Err(Unsupported)` at `CffiClient::service_is_ready`,
+the three-answer contract's "cannot know", and the wait loops then wait their
+budget rather than send into the void. `vtable.c` records the decision at the
+slot.
+
 ## What this does NOT close
 
-* **W13.c** — cyclone and XRCE still leave the `service_server_is_available`
-  vtable slot NULL, so on those backends `service_is_ready` is `Err` and
-  `wait_for_service` waits out its budget and reports `false`: honest, and
-  slower than the DDS cache could answer. Tracked as phase-428 W13.c.
+* QoS compatibility is not part of the Cyclone match beyond what DDS matching
+  itself enforces (an incompatible-QoS server never enters the matched set).
+* nano-ros servers do not advertise `serviceid`, so a nano-ros client against
+  two nano-ros servers where one is half-torn-down takes the both-non-empty
+  fallback, the same as pre-#191 upstream.
 * QoS compatibility is not part of the match (upstream's slot folds it in).
 * Whether a zenoh-pico liveliness subscriber sees its OWN session's tokens
   (client and server in one image) is not measured here; the `wait_for_service`

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/internal.hpp
@@ -148,6 +148,13 @@ dds_entity_t client_response_reader(const rmw_client_t *client);
 dds_entity_t service_request_reader(const rmw_service_t *service);
 dds_entity_t service_response_writer(const rmw_service_t *service);
 
+/** phase-428 W13.c — the `service_server_is_available` slot: does a server
+ *  hold BOTH halves of this client's pair (a matched reader on the request
+ *  writer and a matched writer on the reply reader), paired by `serviceid`
+ *  user data when the server advertises one. Read from Cyclone's matched
+ *  sets, no query issued. `*out_available` is written only on OK. */
+rmw_ret_t client_server_is_available(const rmw_client_t *client, bool *out_available);
+
 
 /* ---- session.cpp ---- */
 rmw_ret_t session_create(const char *locator, uint8_t mode,

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/service.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/service.cpp
@@ -1324,4 +1324,143 @@ dds_entity_t service_response_writer(const rmw_service_t* service) {
     return static_cast<const ServerState*>(service->backend_data)->writer;
 }
 
+/* phase-428 W13.c — `service_server_is_available`, answered from the DDS
+ * discovery cache the way upstream `rmw_cyclonedds_cpp` answers it
+ * (`rmw_node.cpp`, `check_for_service_reader_writer`, humble).
+ *
+ * The slot sat NULL since phase 124.C, so `service_is_ready` was
+ * `Err(Unsupported)` here and `wait_for_service` spent its whole budget and
+ * reported `false` with a server up. Nothing needed wiring: Cyclone keeps the
+ * matched-endpoint sets on every writer and reader, so this is a read.
+ *
+ * Upstream's logic, mirrored:
+ *   1. the request WRITER must have at least one matched reader AND the reply
+ *      READER at least one matched writer — a server is both halves;
+ *   2. a server that advertises `serviceid=<guid>` in the USER DATA of both
+ *      its endpoints (stock `rmw_cyclonedds_cpp` does) is available only when
+ *      the SAME id is seen on a matched request reader and a matched reply
+ *      writer — that pairs the two halves to one server, so a dead server's
+ *      lingering reader plus a different server's writer do not add up to
+ *      "available";
+ *   3. when no matched reader carries a `serviceid`, fall back to (1) — that
+ *      is every nano-ros server (this backend sets no user data).
+ *
+ * Upstream also consults its user-space graph cache for the topic's reader /
+ * writer counts first; that cache is a copy of the same discovery state the
+ * matched sets are read from, so it is a pre-check, not a second source. */
+namespace {
+
+/* Bounded, not `std::vector`: the answer wanted is "is there at least one",
+ * and a client sees a handful of servers, not hundreds. If more are matched
+ * than fit, the first `kMaxMatched` are examined and the rest ignored — which
+ * can only under-report on a bus with 32+ servers of one service. */
+constexpr std::size_t kMaxMatched = 32;
+
+/* Cyclone's `dds_get_matched_*(h, buf, n)` returns the TOTAL count and fills
+ * at most `n`; the same shape upstream's `get_matched_endpoints` grows a
+ * vector for. */
+using matched_fn_t = dds_return_t (*)(dds_entity_t, dds_instance_handle_t*, size_t);
+
+std::size_t matched_handles(dds_entity_t h, matched_fn_t fn, dds_instance_handle_t* out,
+                            bool* failed) {
+    dds_return_t n = fn(h, out, kMaxMatched);
+    if (n < 0) {
+        *failed = true;
+        return 0;
+    }
+    return static_cast<std::size_t>(n) < kMaxMatched ? static_cast<std::size_t>(n) : kMaxMatched;
+}
+
+/* `rmw_dds_common`'s user-data grammar (`parse_key_value`): `key=value;` pairs.
+ * Extract `serviceid`'s value into `out` (NUL-terminated); false when absent.
+ * Upstream's `get_user_data_key`, minus the std::map. */
+bool user_data_serviceid(const dds_qos_t* qos, char* out, std::size_t out_cap) {
+    void* ud = nullptr;
+    size_t sz = 0;
+    if (qos == nullptr || !dds_qget_userdata(qos, &ud, &sz) || ud == nullptr) return false;
+    const char* p = static_cast<const char*>(ud);
+    const char* end = p + sz;
+    bool found = false;
+    static const char kKey[] = "serviceid";
+    const std::size_t klen = sizeof(kKey) - 1;
+    while (p < end && !found) {
+        const char* semi =
+            static_cast<const char*>(std::memchr(p, ';', static_cast<size_t>(end - p)));
+        const char* pair_end = semi != nullptr ? semi : end;
+        const char* eq =
+            static_cast<const char*>(std::memchr(p, '=', static_cast<size_t>(pair_end - p)));
+        if (eq != nullptr && static_cast<std::size_t>(eq - p) == klen &&
+            std::memcmp(p, kKey, klen) == 0) {
+            std::size_t vlen = static_cast<std::size_t>(pair_end - (eq + 1));
+            if (vlen + 1 <= out_cap) {
+                std::memcpy(out, eq + 1, vlen);
+                out[vlen] = '\0';
+                found = true;
+            }
+        }
+        p = pair_end + 1;
+    }
+    dds_free(ud);
+    return found;
+}
+
+} // namespace
+
+rmw_ret_t client_server_is_available(const rmw_client_t* client, bool* out_available) {
+    if (client == nullptr || client->backend_data == nullptr || out_available == nullptr) {
+        return NROS_RMW_RET_INVALID_ARGUMENT;
+    }
+    const auto* state = static_cast<const ClientState*>(client->backend_data);
+
+    dds_instance_handle_t rds[kMaxMatched];
+    dds_instance_handle_t wrs[kMaxMatched];
+    bool failed = false;
+    std::size_t n_rds = matched_handles(state->writer, dds_get_matched_subscriptions, rds, &failed);
+    std::size_t n_wrs = matched_handles(state->reader, dds_get_matched_publications, wrs, &failed);
+    if (failed) return NROS_RMW_RET_ERROR;
+
+    /* (1) — both halves, or nothing. Answered before any allocation, which is
+     * also the common "no server yet" path `wait_for_service` spins on. */
+    if (n_rds == 0 || n_wrs == 0) {
+        *out_available = false;
+        return NROS_RMW_RET_OK;
+    }
+
+    /* (2) — collect the serviceids the matched request readers advertise. */
+    constexpr std::size_t kIdCap = 64;
+    char needles[kMaxMatched][kIdCap];
+    std::size_t n_needles = 0;
+    for (std::size_t i = 0; i < n_rds; ++i) {
+        dds_builtintopic_endpoint_t* ep = dds_get_matched_subscription_data(state->writer, rds[i]);
+        if (ep == nullptr) continue; /* unmatched between the two calls */
+        if (user_data_serviceid(ep->qos, needles[n_needles], kIdCap)) ++n_needles;
+        dds_builtintopic_free_endpoint(ep);
+    }
+
+    /* (3) — no server names itself: existence of both matches is the answer. */
+    if (n_needles == 0) {
+        *out_available = true;
+        return NROS_RMW_RET_OK;
+    }
+
+    /* (2), second half — a matched reply writer with one of those ids. */
+    bool available = false;
+    for (std::size_t i = 0; i < n_wrs && !available; ++i) {
+        dds_builtintopic_endpoint_t* ep = dds_get_matched_publication_data(state->reader, wrs[i]);
+        if (ep == nullptr) continue;
+        char id[kIdCap];
+        if (user_data_serviceid(ep->qos, id, kIdCap)) {
+            for (std::size_t k = 0; k < n_needles; ++k) {
+                if (std::strcmp(id, needles[k]) == 0) {
+                    available = true;
+                    break;
+                }
+            }
+        }
+        dds_builtintopic_free_endpoint(ep);
+    }
+    *out_available = available;
+    return NROS_RMW_RET_OK;
+}
+
 } // namespace nros_rmw_cyclonedds

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/src/vtable.cpp
@@ -331,11 +331,12 @@ const nros_rmw_vtable_t kVtable = {
     /*take_loaned_message*/       nullptr,
     /*return_loaned_message_from_subscription*/               nullptr,
 
-    /* Phase 124.C — service availability probe. Deferred until the
-     * Cyclone DDS built-in topic readers are wired through (matches
-     * the 124.C.2 DDS blocker). nullptr → runtime surfaces
-     * NROS_RMW_RET_UNSUPPORTED, no stub. */
-    /*service_server_is_available*/  nullptr,
+    /* phase-428 W13.c — service availability, from the matched-endpoint
+     * sets Cyclone keeps on every writer/reader (the DDS discovery cache
+     * upstream `rmw_service_server_is_available` reads). Was nullptr since
+     * phase 124.C, so `wait_for_service` on this backend spent its whole
+     * budget and reported false with a server up (issue 1087). */
+    /*service_server_is_available*/  nros_rmw_cyclonedds::client_server_is_available,
 
     /* Phase 124.D.3 — native batch take. Cyclone provides
      * `dds_take(reader, buf, info, count, maxs)` as a single-call

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/CMakeLists.txt
@@ -322,6 +322,28 @@ if(_addtwoints_sources)
         COMMAND nros_rmw_cyclonedds_service_two_outstanding
     )
 
+    # phase-428 W13.c — `service_server_is_available` from the DDS matched
+    # sets: false with no server, true once a server on a SECOND participant
+    # matches both halves, false again after it is destroyed. Polled, not
+    # slept, so cross-participant SEDP jitter costs time rather than a red.
+    add_executable(nros_rmw_cyclonedds_service_server_available
+        service_server_available.cpp
+        ${_addtwoints_sources}
+    )
+    target_link_libraries(nros_rmw_cyclonedds_service_server_available
+        PRIVATE
+            nros_rmw_cyclonedds
+            pthread
+    )
+    target_include_directories(nros_rmw_cyclonedds_service_server_available
+        PRIVATE
+            ${NROS_RMW_CFFI_DIR}
+    )
+    add_test(
+        NAME nros_rmw_cyclonedds_service_server_available
+        COMMAND nros_rmw_cyclonedds_service_server_available
+    )
+
     # Phase 117.7.B concurrent-call correlation. With Phase 117.X.3
     # this now goes through the typed-IDL header path; the
     # AddTwoInts type must be registered.
@@ -600,6 +622,7 @@ if(_addtwoints_sources)
     set_tests_properties(
         nros_rmw_cyclonedds_service_smoke
         nros_rmw_cyclonedds_service_roundtrip
+        nros_rmw_cyclonedds_service_server_available
         PROPERTIES
             ENVIRONMENT "${_nros_rmw_test_env}"
     )

--- a/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/service_server_available.cpp
+++ b/packages/rmw/cyclonedds/nros-rmw-cyclonedds/tests/service_server_available.cpp
@@ -1,0 +1,172 @@
+// phase-428 W13.c — `service_server_is_available` answers from the DDS
+// discovery cache, in both directions.
+//
+// Three assertions, in order, on ONE client:
+//   1. no server anywhere       → OK, false   (not UNSUPPORTED: the slot is filled)
+//   2. a server comes up        → OK, true    (within a discovery window)
+//   3. that server is destroyed → OK, false   (CURRENT, not latched — the thing
+//                                              issue 1087 was about)
+//
+// The server lives on a SECOND session (= its own participant), because that
+// is the case `wait_for_service` exists for: a server in another process. A
+// same-participant pair would match through Cyclone's local delivery and never
+// exercise SEDP. Cross-participant discovery is where `service_concurrent`
+// flakes, so the window here is polled (up to 10 s, 20 ms steps), not slept,
+// and the assertion is on the FIRST true — a slow match costs time, not a red.
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+
+#include "nros/rmw_ret.h"
+#include "nros/rmw_vtable.h"
+#include "nros_rmw_cyclonedds.h"
+#include "nros_test_domain.h"
+
+namespace {
+const nros_rmw_vtable_t* g_vt = nullptr;
+
+constexpr int kPollStepMs = 20;
+constexpr int kPollBudgetMs = 10000;
+
+// Poll `service_server_is_available` until it reports `want`, or the budget
+// runs out. Every call must return OK — an error is a failed test, not a
+// retry. Returns true when `want` was observed.
+bool poll_until(const rmw_client_t* cli, bool want, const char* what) {
+    for (int elapsed = 0; elapsed <= kPollBudgetMs; elapsed += kPollStepMs) {
+        bool avail = !want;
+        rmw_ret_t rc = g_vt->service_server_is_available(cli, &avail);
+        if (rc != NROS_RMW_RET_OK) {
+            std::fprintf(stderr, "%s: service_server_is_available returned %d\n", what, (int)rc);
+            return false;
+        }
+        if (avail == want) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(kPollStepMs));
+    }
+    std::fprintf(stderr, "%s: still %s after %d ms\n", what, want ? "unavailable" : "available",
+                 kPollBudgetMs);
+    return false;
+}
+} // namespace
+
+extern "C" rmw_ret_t nros_rmw_cffi_register_named(const char* /*name*/,
+                                                  const nros_rmw_vtable_t* vt) {
+    g_vt = vt;
+    return NROS_RMW_RET_OK;
+}
+
+int main() {
+    if (nros_rmw_cyclonedds_register() != NROS_RMW_RET_OK || g_vt == nullptr) {
+        std::fprintf(stderr, "register failed\n");
+        return 1;
+    }
+    if (g_vt->service_server_is_available == nullptr) {
+        std::fprintf(stderr, "service_server_is_available slot is NULL\n");
+        return 2;
+    }
+
+    const uint32_t domain = nros_test_domain(99);
+
+    // --- client side: its own session/participant ---------------------------
+    rmw_session_t cs{};
+    cs.node_name = "server_available_client";
+    cs.namespace_ = "/";
+    if (g_vt->create_session(nullptr, 0, domain, cs.node_name, nullptr, &cs) != NROS_RMW_RET_OK) {
+        std::fprintf(stderr, "client create_session failed\n");
+        return 3;
+    }
+    rmw_node_t cnode{};
+    cnode.name = cs.node_name;
+    cnode.namespace_ = cs.namespace_;
+    cnode.session = &cs;
+
+    rmw_client_t cli{};
+    cli.service_name = "server_available";
+    cli.type_name = "nros_test::srv::dds_::AddTwoInts";
+    const rmw_service_type_support_t cts{cli.type_name, ""};
+    if (g_vt->create_client(&cnode, &cts, cli.service_name, domain, nullptr, &cli) !=
+        NROS_RMW_RET_OK) {
+        std::fprintf(stderr, "create_client failed\n");
+        (void)g_vt->destroy_session(&cs);
+        return 4;
+    }
+
+    // (1) Nobody serves this name: false, and OK — not UNSUPPORTED, not true.
+    {
+        bool avail = true;
+        rmw_ret_t rc = g_vt->service_server_is_available(&cli, &avail);
+        if (rc != NROS_RMW_RET_OK) {
+            std::fprintf(stderr, "no-server: returned %d, want OK\n", (int)rc);
+            return 5;
+        }
+        if (avail) {
+            std::fprintf(stderr, "no-server: reported available with no server on the bus\n");
+            return 6;
+        }
+    }
+    // NULL out-pointer is INVALID_ARGUMENT, not a write through NULL.
+    if (g_vt->service_server_is_available(&cli, nullptr) != NROS_RMW_RET_INVALID_ARGUMENT) {
+        std::fprintf(stderr, "NULL out_available should be INVALID_ARGUMENT\n");
+        return 7;
+    }
+
+    // --- server side: a SECOND session/participant --------------------------
+    rmw_session_t ss{};
+    ss.node_name = "server_available_server";
+    ss.namespace_ = "/";
+    if (g_vt->create_session(nullptr, 0, domain, ss.node_name, nullptr, &ss) != NROS_RMW_RET_OK) {
+        std::fprintf(stderr, "server create_session failed\n");
+        return 8;
+    }
+    rmw_node_t snode{};
+    snode.name = ss.node_name;
+    snode.namespace_ = ss.namespace_;
+    snode.session = &ss;
+
+    rmw_service_t srv{};
+    srv.service_name = "server_available";
+    srv.type_name = "nros_test::srv::dds_::AddTwoInts";
+    const rmw_service_type_support_t sts{srv.type_name, ""};
+    if (g_vt->create_service(&snode, &sts, srv.service_name, domain, nullptr, &srv) !=
+        NROS_RMW_RET_OK) {
+        std::fprintf(stderr, "create_service failed\n");
+        return 9;
+    }
+
+    // (2) The server's request reader matches our writer AND its reply writer
+    // matches our reader — both halves, across SEDP.
+    if (!poll_until(&cli, true, "server-up")) return 10;
+
+    // A server of a DIFFERENT name on the same bus is not this one: still true
+    // for ours, and this is also the "unrelated endpoints do not count" half —
+    // an `other` client with no server of ITS name must read false while the
+    // bus is busy.
+    rmw_client_t other{};
+    other.service_name = "server_available_nobody";
+    other.type_name = "nros_test::srv::dds_::AddTwoInts";
+    const rmw_service_type_support_t ots{other.type_name, ""};
+    if (g_vt->create_client(&cnode, &ots, other.service_name, domain, nullptr, &other) !=
+        NROS_RMW_RET_OK) {
+        std::fprintf(stderr, "create_client(other) failed\n");
+        return 11;
+    }
+    {
+        bool avail = true;
+        if (g_vt->service_server_is_available(&other, &avail) != NROS_RMW_RET_OK || avail) {
+            std::fprintf(stderr, "other-name: a server of another name counted as ours\n");
+            return 12;
+        }
+    }
+    g_vt->destroy_client(&other);
+
+    // (3) The server goes away: unavailable again. Nothing is latched.
+    g_vt->destroy_service(&srv);
+    if (!poll_until(&cli, false, "server-down")) return 13;
+
+    (void)g_vt->destroy_session(&ss);
+    g_vt->destroy_client(&cli);
+    (void)g_vt->destroy_session(&cs);
+    std::printf("OK\n");
+    return 0;
+}

--- a/packages/rmw/xrce/nros-rmw-xrce/src/vtable.c
+++ b/packages/rmw/xrce/nros-rmw-xrce/src/vtable.c
@@ -83,9 +83,16 @@ static const nros_rmw_vtable_t kVtable = {
     .take_loaned_message        = NULL,
     .return_loaned_message_from_subscription                = NULL,
 
-    /* Phase 124.C — service availability probe. micro-XRCE-DDS-Client
-     * has no participant enumeration; leave NULL → runtime surfaces
-     * NROS_RMW_RET_UNSUPPORTED. */
+    /* Phase 124.C / phase-428 W13.c — service availability probe: NULL,
+     * DELIBERATELY, and revisited. The Agent owns the DDS participant, so
+     * matched-endpoint state lives on the Agent side and micro-XRCE-DDS-Client
+     * has no read for it (no `dds_get_matched_*`, no built-in topic readers,
+     * no participant enumeration). What the client CAN see — the Agent
+     * acknowledged `create_requester` — says only that the Agent built the
+     * client's own endpoints, nothing about a server. Answering from that
+     * would be issue 1087's "yes without asking" one layer down. NULL is how
+     * the runtime says `Err(Unsupported)` ("cannot know"), and every wait loop
+     * then waits its budget rather than sending into the void. */
     .service_server_is_available = NULL,
 
     /* Phase 124.D — native batch take. XRCE delivers one sample per

--- a/scripts/gen-rmw-feature-matrix.py
+++ b/scripts/gen-rmw-feature-matrix.py
@@ -57,8 +57,10 @@ FEATURES = [
      r"fn (create_service|send_response)"),
     ("Service clients", ["create_client", "send_request", "take_response"],
      r"fn (create_client|send_request)"),
+    # phase-428 W13: the zenoh trait method is `service_is_ready` (rclcpp's
+    # name); `server_available` was the pre-#638 spelling.
     ("Server-availability probe", ["service_server_is_available"],
-     r"fn server_available"),
+     r"fn (server_available|service_is_ready)"),
     ("Status events (deadline / liveliness / lost)",
      ["subscription_event_init", "publisher_event_init"],
      r"fn register_event_callback"),
@@ -85,9 +87,11 @@ FEATURES = [
     ("Wait-for-acked", ["publisher_wait_for_all_acked"],
      r"fn wait_for_all_acked"),
     ("Take-with-info", ["take_with_info"], r"fn take_with_info"),
-    ("Entity new-data callbacks",
-     ["subscription_set_on_new_message_callback"],
-     r"fn set_on_new_message"),
+    # "Entity new-data callbacks" (`subscription_set_on_new_message_callback`)
+    # was a row here until phase-407 retired the slot (issue 0960 DECLINED the
+    # trio); the generator then refused to run for four days — and nothing
+    # noticed, because `check rmw-feature-matrix` is on no lane. A row names a
+    # slot the canonical vtable has; a declined capability is not one.
     ("Graph introspection (names/types/counts)",
      ["get_node_names", "get_topic_names_and_types", "count_publishers"],
      r"fn (get_node_names|get_topic_names)"),


### PR DESCRIPTION
phase-428 W13.c. PR #638 made zenoh's `service_is_ready` read a maintained matched-server set; Cyclone and XRCE still left the `service_server_is_available` vtable slot NULL, so `wait_for_service` on both waited out its budget and reported `false` with a server up.

## Cyclone — slot filled

`nros_rmw_cyclonedds::client_server_is_available` (`service.cpp`) mirrors upstream `rmw_cyclonedds_cpp`'s `check_for_service_reader_writer` (humble `rmw_node.cpp`):

1. the request writer's matched readers (`dds_get_matched_subscriptions`) **and** the reply reader's matched writers (`dds_get_matched_publications`) must both be non-empty;
2. when a matched reader advertises `serviceid=<guid>` in its user data (stock `rmw_cyclonedds_cpp` servers do), a matched reply writer must carry the **same** id — pairs both halves to one server;
3. when no matched reader carries a `serviceid` (every nano-ros server), both-non-empty is the answer.

Bounded storage (32 handles a side, no `std::vector`), no query at call time. Upstream's graph-cache pre-count is a copy of the same discovery state, not reproduced. No header change, so no bindgen regeneration.

## XRCE — slot stays NULL, deliberately

The Agent owns the DDS participant; matched-endpoint state lives Agent-side and micro-XRCE-DDS-Client has no read for it. The only thing the session can know (the Agent acknowledged `create_requester`) says nothing about a server, and answering from it would be issue 1087's "yes without asking" one layer down. NULL is `Err(Unsupported)` at `CffiClient::service_is_ready` — the contract's "cannot know" — and the wait loops wait their budget. Written at the slot in `vtable.c`.

## Test

`nros_rmw_cyclonedds_service_server_available` (Cyclone lane): one client on its own participant reads false with no server → true once a server on a second participant matches both halves → false for a client of another name on the same busy bus → false again after the server is destroyed; NULL out-pointer is `INVALID_ARGUMENT`. Polled, so cross-participant SEDP jitter costs time, not a red. 0.22 s.

## Also

`scripts/gen-rmw-feature-matrix.py` had refused to run since phase-407 (a row named the retired `subscription_set_on_new_message_callback` slot) and its zenoh probe regex still spelled the pre-#638 method; the gate was lane-exempt as "in no lane and no caller found". Row dropped, regex widened, page regenerated, exemption deleted (it is buildless, so it derives onto the fast lane).

## Ran

- `just cyclonedds ci` — 27/27 passed
- `just check fast` — OK
- `just check rmw-api-parity` / `rmw-abi-shape` / `cbindgen-headers` / `rmw-feature-matrix` — OK
- `cargo test -p nros-rmw --lib` — 53 passed
- `cargo test -p nros-node --lib --features std client` — 4 passed

Issue 1087 (archived) gets a dated W13.c resolution paragraph; the phase-428 doc lives on another branch and is not edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
