### PR TITLE
fix(#1163): compile-smoke checks nros-c/nros-cpp in the shipped shape, and check-lane-contracts gates the class

### DIFF
--- a/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
+++ b/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
@@ -5,7 +5,7 @@ status: open
 type: bug
 area: ci, c
 severity: high
-related: [1040, 1059, 1080, 1102, 0417, RFC-0061]
+related: [1040, 1059, 1080, 1102, 1162, 0417, RFC-0061]
 found: 2026-09-06
 ---
 
@@ -44,7 +44,9 @@ its job went `failure` on every main run since `4ad88ef86` (07:49Z), which is
 a report, not a gate. #557 adds `clang` to the CI image and leaves a
 placeholder in `gate.yml` (line 789) saying the step is "NOT here yet".
 
-Fix for the symptom: PR #612 (`7b3bab8e9`). This issue is the gate.
+Fix for the symptom: PR #630 (issue 1162, which also asks for a static
+`no_mangle`-uniqueness gate — complementary to this one, which is about the
+feature shape the lanes compile). This issue is the CI gate.
 
 ## Why no other lane covers it
 

--- a/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
+++ b/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
@@ -86,3 +86,39 @@ The merge queue was NOT blocked by this — the batch that merged over the
 duplicate passed, because nothing in it compiles the shipped shape. That is
 the point: green with no signal capacity, the same class the pitfall index
 describes for uniformly-red lanes, seen from the other side.
+
+## Progress
+
+**2026-09-07** — items 1 and 3 landed; item 2 stays open.
+
+- (1) `compile-smoke` now runs `cargo check -p nros-c -p nros-cpp
+  --no-default-features --features "{{C_API_SHIPPED_FEATURES}}"` (25 s warm).
+  The feature list has ONE spelling, `C_API_SHIPPED_FEATURES` in
+  `just/check.just`, read by `check-c`, `check-cpp` (both sites), the nros-c
+  clippy combo and `compile-smoke` — the four literal copies in
+  `just/check/lanes.just` are gone. Negative control: a second
+  `#[no_mangle] nros_node_get_fully_qualified_name` inside an `rmw-cffi`
+  region makes `just check compile-smoke` fail with E0428 (in the commit).
+- (3) `check-lane-contracts` gains the rule. Subjects are DERIVED: every
+  crate under `packages/` with a non-empty default feature set that every
+  consumer takes `default-features = false` (measured: `nros-c` — 3
+  consumers, its `path = "."` dev-dep excluded — `nros-cpp` — 2 — and
+  `nros-board-nuttx`, exempt with a reason as cross-only). The shipped shape
+  is authored once, as the `just` variable the lanes read (`SHIPPED_SHAPES`
+  in the script), and some recipe reachable from a merge-gating lane
+  (`pull_request`/`merge_group`, derived from the workflows) must compile the
+  crate `--no-default-features --features` that variable (or a literal equal
+  to it; a different literal is drift, and two spellings of the variable is a
+  violation). Removing the compile-smoke line on the real tree reports both
+  crates; the selftest carries that control plus the schedule-only,
+  no-`--no-default-features`, undeclared-subject and two-spellings cases.
+  Along the way: the gate's justfile parser did not follow `import`, so since
+  phase-399 every gate in `just/check/*.just` was invisible to it —
+  `check::compile-smoke` was not a recipe and the closure of `check::fast`
+  was two forwarders. It follows imports now; 0 new findings on the real
+  tree, lane invocations resolved 13 → 15.
+- The `nros-node` `int_plus_one` lint at `executor/tests.rs:3438` that kept
+  `check-test-targets` red for an unrelated reason is fixed (separate
+  commit).
+- (2) — `check-api-parity` on `pull_request`/`merge_group` — waits on #557's
+  CI image; not attempted here.

--- a/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
+++ b/docs/issues/1163-compile-smoke-checks-nros-c-under-default-features-only.md
@@ -1,0 +1,86 @@
+---
+id: 1163
+title: "`compile-smoke` checks `nros-c` under its DEFAULT features, so a duplicate `#[no_mangle]` in the shipped feature set reached main green — and `api-parity`, which refuses the header, reports only post-submit"
+status: open
+type: bug
+area: ci, c
+severity: high
+related: [1040, 1059, 1080, 1102, 0417, RFC-0061]
+found: 2026-09-06
+---
+
+# The PR gate compiled the C crate in a shape nothing ships, and the shape that ships was red on main for a morning
+
+## Measured
+
+PR #329 (phase-417, rebase-merged 2026-09-06 07:44Z) landed
+`packages/api/nros-c/src/node.rs` with `nros_node_get_fully_qualified_name`
+defined TWICE — main's #567 four-argument form and the branch's stage-5
+three-argument form, both `#[unsafe(no_mangle)]`, both surviving the restack.
+On that main (`2bcdfa5d0`, still carrying it):
+
+```
+cargo check -p nros-c                                                      # green (default = panic-platform)
+cargo check -p nros-c --no-default-features --features std                 # green
+cargo check -p nros-c --no-default-features --features rmw-cffi            # E0428
+cargo check -p nros-c --no-default-features --features std,rmw-zenoh       # E0428
+cargo check -p nros-c --no-default-features \
+    --features std,rmw-cffi,platform-posix,ros-humble                      # E0428 — the shape `check-c` builds
+```
+
+The second definition sits in a region only an RMW feature compiles. The
+required `CI` context on a pull request runs `compile-smoke` =
+`cargo check --workspace --all-targets` under default features
+(`just/check/lanes.just:336`); its own comment already says "no feature
+combinations". The merge queue's `test-unit` compiles the same default shape.
+So neither could see it, and the first thing that did was a human running the
+C build locally.
+
+`check-api-parity` did refuse it, and said so at the right layer — its C
+extractor parses the committed `nros_generated.h` with clang, and that header
+carries both prototypes (`conflicting declaration` at `nros_generated.h:5859`).
+But since issue 1040 the gate lives on `post-submit.yml`, after the merge:
+its job went `failure` on every main run since `4ad88ef86` (07:49Z), which is
+a report, not a gate. #557 adds `clang` to the CI image and leaves a
+placeholder in `gate.yml` (line 789) saying the step is "NOT here yet".
+
+Fix for the symptom: PR #612 (`7b3bab8e9`). This issue is the gate.
+
+## Why no other lane covers it
+
+- `check-fast` is buildless by contract (RFC-0061).
+- `compile-smoke` is PR-only and default-features-only, by its own comment.
+- `check-build` (which runs `check-c`, the lane that compiles the shipped
+  shape at `lanes.just:71` and `:364`) is `schedule`/`workflow_dispatch` only
+  since phase-396 — it needs artifacts no merge-gating job builds.
+- `test-unit` on `merge_group` compiles the workspace under default features;
+  same blind spot one lane later.
+- Issue 1080 / #1102 closed the `--no-default-features` half of this class on
+  the batch lane for `nros-node`. This is the other direction — a crate whose
+  default (`panic-platform`) compiles almost nothing of its surface, and
+  whose shipped shape is a specific positive feature set that every consumer
+  selects with `default-features = false`.
+
+## What would close this
+
+1. `compile-smoke` adds one `cargo check -p nros-c --no-default-features
+   --features std,rmw-cffi,platform-posix,ros-humble` (and the same for
+   `nros-cpp`, which `check-cpp` builds in the same set at `lanes.just:364`).
+   Seconds warm. The feature list must be read from the ONE place `check-c`
+   reads it, not copied — a second spelling drifts.
+2. `check-api-parity` becomes a step on `pull_request` and `merge_group` in
+   `gate.yml` once #557's image lands. It is offline, 28.6 s, no fixture, no
+   SDK — it satisfies `check-lane-contracts` as written. Its failure mode
+   here (the header will not parse) is a stronger signal than the ledger
+   verdicts it was written for, and it is the one that fired.
+3. `check-lane-contracts` gains the rule: a crate whose consumers all take it
+   with `default-features = false` is compiled in its documented shipped
+   feature set by at least one merge-gating lane. Without the rule, (1) is
+   the next fix that lands only at the reported site.
+
+## Not covered
+
+The merge queue was NOT blocked by this — the batch that merged over the
+duplicate passed, because nothing in it compiles the shipped shape. That is
+the point: green with no signal capacity, the same class the pitfall index
+describes for uniformly-red lanes, seen from the other side.

--- a/just/check.just
+++ b/just/check.just
@@ -35,6 +35,18 @@ NIGHTLY := `awk '/^channel/ {gsub(/"/, "", $3); print $3; exit}' tools/rust-tool
 # here now — the root had no other user.
 HOST_UNCHECKABLE := "--exclude nros-c --exclude nros-cpp --exclude nros-rmw-zenoh-staticlib --exclude nros-rmw-xrce-cffi --exclude nros-rmw-xrce-cffi-staticlib --exclude nros-build-helpers --exclude nros-zpico-build --exclude nros-build-paths"
 
+# The feature set `nros-c` / `nros-cpp` SHIP in on the host — what every
+# consumer selects with `default-features = false` and what cmake's
+# `nros_feature_set(CRATE c|cpp RMW none PLATFORM posix …)` assembles. Their
+# DEFAULT (`panic-platform`) compiles almost none of the C surface, so a crate
+# checked under defaults is not the crate that ships. Issue 1163: a duplicate
+# `#[no_mangle]` in an `rmw-cffi` region reached main green because
+# `compile-smoke` checked the default shape and `check-c` (the lane that reads
+# this set) runs on schedule only. ONE spelling, read by `check-c`,
+# `check-cpp`, the clippy combos and `compile-smoke`; `check-lane-contracts`
+# verifies a merge-gating lane compiles both crates with it.
+C_API_SHIPPED_FEATURES := "std,rmw-cffi,platform-posix,ros-humble"
+
 
 # The gates themselves, by topic. `import` and not `mod`: it MERGES
 # definitions, so every gate keeps the flat name it is invoked and

--- a/just/check/lanes.just
+++ b/just/check/lanes.just
@@ -68,7 +68,7 @@ c: c-fmt
     # "your C headers are broken": every `*_OPAQUE_U64S` came back undeclared
     # from a `cc` line that says nothing about cargo. Diagnosing that cost four
     # wrong hypotheses; the build's own error names the cause in one line.
-    cargo build -p nros-c --no-default-features --features "std,rmw-cffi,platform-posix,ros-humble" --quiet
+    cargo build -p nros-c --no-default-features --features "{{C_API_SHIPPED_FEATURES}}" --quiet
     # Variant dir FIRST so its `nros_config_generated.h` (with the
     # real OPAQUE_U64S macros) wins over the source-tree stub.
     cc -fsyntax-only \
@@ -254,7 +254,7 @@ c: c-fmt
     # "your C headers are broken": every `*_OPAQUE_U64S` came back undeclared
     # from a `cc` line that says nothing about cargo. Diagnosing that cost four
     # wrong hypotheses; the build's own error names the cause in one line.
-    cargo build -p nros-cpp --no-default-features --features "std,rmw-cffi,platform-posix,ros-humble" --quiet
+    cargo build -p nros-cpp --no-default-features --features "{{C_API_SHIPPED_FEATURES}}" --quiet
     cc -fsyntax-only \
         -Itarget/nros-c-generated \
         -Itarget/nros-cpp-generated \
@@ -358,7 +358,18 @@ compile-smoke:
     # on `#[panic_handler] function required` and reports a defect that is not
     # one.
     cargo check --workspace --all-targets --quiet {{HOST_UNCHECKABLE}}
-    echo "compile smoke: workspace + all targets check clean (no lints; see check-build)."
+    # Issue 1163 — the two C-API crates in the shape they SHIP, not their
+    # default. `nros-c` / `nros-cpp` are in `HOST_UNCHECKABLE` because their
+    # LINK step needs a target, but a `cargo check` never links, and their
+    # default feature (`panic-platform`) compiles almost none of the C surface:
+    # a duplicate `#[no_mangle]` inside an `rmw-cffi` region reached main green
+    # through this very smoke test, while `check-c` — the lane that compiles
+    # `C_API_SHIPPED_FEATURES` — runs on schedule only. Measured 25 s warm.
+    # A `check`, not a build: the header generation `check-c` needs from the
+    # build stays where it is.
+    cargo check -p nros-c -p nros-cpp --no-default-features --features "{{C_API_SHIPPED_FEATURES}}" --quiet
+    echo "compile smoke: workspace + all targets check clean (no lints; see check-build);"
+    echo "  nros-c + nros-cpp check clean in the shipped shape ({{C_API_SHIPPED_FEATURES}})."
 
 # Check C++ headers: formatting + freestanding syntax + nros-cpp clippy. The
 # clippy (rmw-zenoh-cffi) + syntax probe COMPILE nros-cpp/nros-c (zpico-sys pulls
@@ -385,7 +396,7 @@ cpp: cpp-fmt
     # "your C headers are broken": every `*_OPAQUE_U64S` came back undeclared
     # from a `cc` line that says nothing about cargo. Diagnosing that cost four
     # wrong hypotheses; the build's own error names the cause in one line.
-    cargo build -p nros-c -p nros-cpp --no-default-features --features "std,rmw-cffi,platform-posix,ros-humble" --quiet
+    cargo build -p nros-c -p nros-cpp --no-default-features --features "{{C_API_SHIPPED_FEATURES}}" --quiet
     # issue 0730 — the (zephyr-embedded × C++ × cyclonedds) coordinate is a
     # pairwise-class gap no runtime tier covers (cyclone fixtures run on
     # native_sim, which appends `,std`), and it failed E0599 at COMPILE time:
@@ -1542,7 +1553,7 @@ workspace-features:
     @echo "  - nros: cffi + iron"
     cargo clippy --quiet -p nros --no-default-features --features "std,rmw-cffi,ros-iron"
     @echo "  - nros-c: zenoh-cffi + posix + humble"
-    cargo clippy --quiet -p nros-c --no-default-features --features "std,rmw-cffi,platform-posix,ros-humble"
+    cargo clippy --quiet -p nros-c --no-default-features --features "{{C_API_SHIPPED_FEATURES}}"
     @echo "  - nros: cffi (no_std)"
     cargo clippy --quiet -p nros --no-default-features --features "rmw-cffi"
     @echo "  - transport: sync-critical-section"

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -3435,7 +3435,7 @@ fn typed_c_subscription_refused_decode_is_loud_and_undelivered() {
     // that THIS refusal was counted. Exactness made it fail in `check::build`'s
     // parallel lane while passing solo.
     assert!(
-        super::arena::typed_deserialize_failures() >= failures_before + 1,
+        super::arena::typed_deserialize_failures() > failures_before,
         "the refusal must also be counted for the rate-limited nros_log report"
     );
     assert_eq!(

--- a/scripts/check-lane-contracts.py
+++ b/scripts/check-lane-contracts.py
@@ -40,6 +40,7 @@ Usage::
 
 import os
 import re
+import subprocess
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -418,24 +419,84 @@ def parse_justfile():
     justfile already spells them.
     """
     recipes = {}
-    sources = [(None, JUSTFILE)]
-    # Beside the justfile being parsed, NOT under ROOT: the self-tests redirect
-    # `JUSTFILE` to a temp tree, and a module dir pinned to ROOT made them read
-    # the real repo's modules while claiming to test a synthetic justfile. Same
-    # answer in production (the root justfile IS in ROOT), honest under test.
-    mod_dir = os.path.join(os.path.dirname(os.path.abspath(JUSTFILE)), "just")
-    if os.path.isdir(mod_dir):
-        sources += [
-            (fn[:-5], os.path.join(mod_dir, fn))
-            for fn in sorted(os.listdir(mod_dir)) if fn.endswith(".just")
-        ]
-    for mod, path in sources:
+    for mod, path in _just_sources():
         try:
             with open(path, encoding="utf8", errors="replace") as fh:
                 recipes.update(_parse_one(fh.read().split("\n"), mod))
         except OSError:
             continue
     return recipes
+
+
+IMPORT = re.compile(r"^import\??\s+['\"]([^'\"]+)['\"]", re.M)
+
+
+def _just_sources():
+    """[(module or None, path)]: the root justfile, every `just/*.just` module,
+    and every file any of them `import`s — keyed to the IMPORTING module.
+
+    Issue 1163 — the gates were invisible. Phase-399 split the 200 gate recipes
+    out of `just/check.just` into `just/check/*.just` behind `import`, which
+    MERGES definitions (a `mod` namespaces them). The walk below stopped at
+    `just/*.just`, so `check::compile-smoke`, `check::c`, `check::build` and
+    every other gate were not recipes to this file: a lane invocation of
+    `just check compile-smoke` resolved to nothing, and the closure of
+    `check::fast` was its two forwarders. The tier rules reported OK over a
+    tree they could not see, which is the vacuous shape this file already
+    carries three cases against.
+
+    Beside the justfile being parsed, NOT under ROOT: the self-tests redirect
+    `JUSTFILE` to a temp tree, and a module dir pinned to ROOT made them read
+    the real repo's modules while claiming to test a synthetic justfile. Same
+    answer in production (the root justfile IS in ROOT), honest under test.
+    """
+    mod_dir = os.path.join(os.path.dirname(os.path.abspath(JUSTFILE)), "just")
+    roots = [(None, os.path.abspath(JUSTFILE))]
+    if os.path.isdir(mod_dir):
+        roots += [
+            (fn[:-5], os.path.join(mod_dir, fn))
+            for fn in sorted(os.listdir(mod_dir)) if fn.endswith(".just")
+        ]
+    out, seen = [], set()
+    for mod, path in roots:
+        # Depth-first from each root so a file the ROOT justfile imports
+        # (`just/sdk-env.just`) is keyed bare, as `just` keys it — not as the
+        # module the directory listing would otherwise make of it.
+        stack = [path]
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            out.append((mod, cur))
+            try:
+                with open(cur, encoding="utf8", errors="replace") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            for m in IMPORT.finditer(text):
+                stack.append(os.path.normpath(
+                    os.path.join(os.path.dirname(cur), m.group(1))))
+    return out
+
+
+VARIABLE = re.compile(r'^([A-Za-z_][A-Za-z0-9_-]*)\s*:=\s*"([^"]*)"\s*$', re.M)
+
+
+def just_variables():
+    """{name: {values}} for every string-literal `NAME := "..."` across the
+    justfile, its modules and their imports. A SET of values, because the
+    point of reading one is to find out whether it has one spelling."""
+    out = {}
+    for _mod, path in _just_sources():
+        try:
+            with open(path, encoding="utf8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for m in VARIABLE.finditer(text):
+            out.setdefault(m.group(1), set()).add(m.group(2))
+    return out
 
 
 def _parse_one(lines, mod):
@@ -600,6 +661,239 @@ def resolvers_used(test_name):
     with open(path, encoding="utf8", errors="replace") as fh:
         text = fh.read()
     return {r for r in RUNTIME_RESOLVERS + COMPILE_RESOLVERS if r in text}, True
+
+
+# ---- issue 1163 — a crate that SHIPS in a non-default shape must be compiled
+# in that shape by a merge-gating lane ----------------------------------------
+#
+# `nros-c`'s default feature is `panic-platform`, which compiles almost none of
+# the C surface; what ships is `std,rmw-cffi,platform-posix,ros-humble`, and
+# every consumer says so with `default-features = false`. PR #329 landed a
+# second `#[no_mangle] nros_node_get_fully_qualified_name` inside an
+# `rmw-cffi` region: `cargo check -p nros-c` green, the shipped shape E0428.
+# `compile-smoke` (the PR gate) checked defaults; `check-c` compiles the
+# shipped set but runs on schedule; `test-unit` on the merge group compiles
+# defaults again. Green with no signal capacity, on every lane that gates.
+#
+# The subject set is DERIVED, not authored: any crate under `packages/` with a
+# non-empty default feature set that EVERY consumer takes `default-features =
+# false` is a crate whose default is not what ships. What the shipped shape IS
+# has to be authored, and the one place it may be authored is a `just`
+# variable, because the lanes read that variable and a second spelling drifts.
+
+# crate -> the justfile variable holding its shipped feature list.
+SHIPPED_SHAPES = {
+    "nros-c": "C_API_SHIPPED_FEATURES",
+    "nros-cpp": "C_API_SHIPPED_FEATURES",
+}
+
+# A subject with no host shape at all, and why. A reason, not a bare name:
+# an exemption without one is a rule with a hole nobody can re-check.
+SHIPPED_EXEMPT = {
+    "nros-board-nuttx": (
+        "cross-only — a NuttX board crate has no host shape; its one consumer "
+        "is the QEMU board family, built by the nuttx fixture lane, a runtime "
+        "tier no merge-gating job runs"
+    ),
+}
+
+# Where a crate's dependency tables live in a manifest, `target.*` included.
+_DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+_MANIFEST_SKIP = {"third-party", ".git", ".claude", "node_modules", "build",
+                  "generated", "tmp"}
+
+
+def _toml():
+    try:
+        import tomllib
+        return tomllib
+    except ModuleNotFoundError:  # python < 3.11
+        try:
+            import tomli as tomllib
+            return tomllib
+        except ModuleNotFoundError:
+            return None
+
+
+def _manifests(root):
+    """Every tracked `Cargo.toml` under `root`, from the INDEX — a walk over
+    `examples/` pays for every build tree beneath it (issue 0721: >300 s
+    against 0.002 s for the same paths). Vendored trees are gitlinks, so they
+    are not listed; `third-party/` is skipped for the one that is not."""
+    r = subprocess.run(["git", "-C", root, "ls-files", "--", "Cargo.toml",
+                        "*/Cargo.toml"], capture_output=True, text=True)
+    if r.returncode == 0:
+        for rel in r.stdout.split():
+            if not rel.startswith("third-party/") and "/third-party/" not in rel:
+                yield os.path.join(root, rel)
+        return
+    # walk-ok: the self-test's temp tree is not a repository, so there is no
+    # index to consult and the tree is a handful of files it wrote itself.
+    for dp, dn, fn in os.walk(root):
+        dn[:] = sorted(d for d in dn
+                       if d not in _MANIFEST_SKIP and not d.startswith("target"))
+        if "Cargo.toml" in fn:
+            yield os.path.join(dp, "Cargo.toml")
+
+
+def _dep_specs(manifest):
+    """[(crate name, spec dict-or-str)] over every dependency table."""
+    out = []
+    tables = [manifest.get(t, {}) for t in _DEP_TABLES]
+    for tgt in manifest.get("target", {}).values():
+        tables += [tgt.get(t, {}) for t in _DEP_TABLES]
+    for table in tables:
+        for key, spec in table.items():
+            name = spec.get("package", key) if isinstance(spec, dict) else key
+            out.append((name, spec))
+    return out
+
+
+def shipped_shape_subjects(root=None, subject_dir="packages"):
+    """{crate: {"default": [...], "consumers": [manifest paths]}} for every
+    crate under `<root>/<subject_dir>` with a non-empty default feature set that
+    EVERY consumer (anywhere under root) takes with `default-features = false`.
+
+    A self-dependency (`nros-c`'s dev-dep on `path = "."`) is not a consumer.
+    A `workspace = true` entry inherits its spec from the nearest ancestor
+    `[workspace.dependencies]`, which is where `default-features` would be.
+    """
+    root = root or ROOT
+    toml = _toml()
+    if toml is None:
+        raise SystemExit("check-lane-contracts: no TOML parser (python >= 3.11 "
+                         "or `tomli`) — the shipped-shape rule cannot run, "
+                         "and a rule that cannot run must not report OK")
+    loaded = {}
+    for path in _manifests(root):
+        try:
+            with open(path, "rb") as fh:
+                loaded[path] = toml.load(fh)
+        except (OSError, ValueError):
+            continue
+    subject_root = os.path.join(root, subject_dir)
+    crates = {}
+    for path, m in loaded.items():
+        name = m.get("package", {}).get("name")
+        if name and path.startswith(subject_root + os.sep):
+            crates[name] = {"default": m.get("features", {}).get("default", []),
+                            "consumers": [], "path": path}
+
+    def inherited(path, name):
+        d = os.path.dirname(path)
+        while True:
+            parent = os.path.dirname(d)
+            cand = os.path.join(parent, "Cargo.toml")
+            spec = loaded.get(cand, {}).get("workspace", {}).get("dependencies", {})
+            for key, val in spec.items():
+                if (val.get("package", key) if isinstance(val, dict) else key) == name:
+                    return val
+            if parent == d or not parent.startswith(root):
+                return None
+            d = parent
+
+    takes_defaults = {}
+    for path, m in loaded.items():
+        me = m.get("package", {}).get("name")
+        for name, spec in _dep_specs(m):
+            if name not in crates or name == me:
+                continue
+            if isinstance(spec, dict) and spec.get("workspace") is True:
+                spec = inherited(path, name) or {}
+            dff = isinstance(spec, dict) and spec.get("default-features") is False
+            crates[name]["consumers"].append(path)
+            takes_defaults.setdefault(name, False)
+            takes_defaults[name] = takes_defaults[name] or not dff
+    return {
+        n: c for n, c in crates.items()
+        if c["default"] and c["consumers"] and not takes_defaults.get(n, True)
+    }
+
+
+CARGO_LINE = re.compile(r"\bcargo\s+(?:\+\S+\s+)?(?:check|build|clippy)\b(.*)$")
+_PKG = re.compile(r"(?:^|\s)(?:-p|--package)[\s=]+([A-Za-z0-9_-]+)")
+_FEATS = re.compile(r"--features[\s=]+(?:\"([^\"]*)\"|'([^']*)'|(\S+))")
+
+
+def _cargo_shapes(line):
+    """[(package, {features}, no_default)] for one cargo check/build/clippy."""
+    m = CARGO_LINE.search(line)
+    if not m:
+        return []
+    args = m.group(1)
+    pkgs = _PKG.findall(args)
+    fm = _FEATS.search(args)
+    raw = next((g for g in fm.groups() if g is not None), "") if fm else ""
+    feats = {f for f in re.split(r"[,\s]+", raw) if f}
+    return [(pkg, feats, "--no-default-features" in args) for pkg in pkgs]
+
+
+def gating_lanes(recipes_map):
+    """Every recipe a workflow job runs on a merge-gating event. Producer jobs
+    INCLUDED — the artifact rule exempts those because they may resolve what
+    they build; this rule asks a different question of them."""
+    out = set()
+    for _wf, _job, recs, _p in workflow_jobs():
+        for recipe, events in lane_invocations(recs, recipes_map):
+            if set(events) & GATING_EVENTS:
+                out.add(recipe)
+    return out
+
+
+def shipped_shape_gaps(recipes, variables, gating, subjects):
+    """([(crate, message)], {crate: [recipes that cover it]}). A gap is a
+    subject NOT compiled in its shipped shape by any recipe reachable from a
+    merge-gating lane."""
+    reached = set()
+    for lane in gating:
+        reached |= closure(recipes, lane)
+    gaps, covered = [], {}
+    for crate in sorted(subjects):
+        if crate in SHIPPED_EXEMPT:
+            continue
+        var = SHIPPED_SHAPES.get(crate)
+        n = len(subjects[crate]["consumers"])
+        if var is None:
+            gaps.append((crate, (
+                f"`{crate}` defaults to {subjects[crate]['default']}, and all {n} of "
+                f"its consumers take it `default-features = false` — so its default "
+                f"is not what ships, and nothing says what does. Name the shipped "
+                f"feature list as a `just` variable and add `{crate}` to "
+                f"SHIPPED_SHAPES in this script (or SHIPPED_EXEMPT, with a reason)."
+            )))
+            continue
+        values = variables.get(var, set())
+        if len(values) != 1:
+            gaps.append((crate, (
+                f"`{crate}`'s shipped shape is the justfile variable `{var}`, which "
+                + ("is not defined as a string literal anywhere." if not values else
+                   f"has {len(values)} spellings: {sorted(values)}. One spelling.")
+            )))
+            continue
+        want = {f for f in next(iter(values)).split(",") if f}
+        hits = []
+        for r in sorted(reached):
+            for line in _join_continuations(recipes.get(r, {}).get("body", [])):
+                for pkg, feats, no_default in _cargo_shapes(line):
+                    if pkg != crate or not no_default:
+                        continue
+                    if feats == {"{{" + var + "}}"} or feats == want:
+                        hits.append(r)
+        if hits:
+            covered[crate] = sorted(set(hits))
+        else:
+            gaps.append((crate, (
+                f"`{crate}` ships as `--no-default-features --features "
+                f"\"{{{{{var}}}}}\"` (= {','.join(sorted(want))}) — all {n} consumers "
+                f"take it `default-features = false` — but NO merge-gating lane "
+                f"({'/'.join(sorted(GATING_EVENTS))}) compiles it in that shape. "
+                f"Its default compiles a different crate, so a green gate says "
+                f"nothing about the one that ships (issue 1163: a duplicate "
+                f"`#[no_mangle]` in an `rmw-cffi` region reached main green). "
+                f"Add `cargo check -p {crate} --no-default-features --features "
+                f"\"{{{{{var}}}}}\"` to a recipe a gating job runs (`compile-smoke`)."
+            )))
+    return gaps, covered
 
 
 def main():
@@ -814,6 +1108,14 @@ def main():
             f"        python3 scripts/check-lane-contracts.py --update"
         )
 
+    # ---- issue 1163 — shipped shapes. A HARD rule, not a ratchet: the subject
+    # set is three crates and every one is either covered or exempt today.
+    subjects = shipped_shape_subjects()
+    shape_gaps, shape_covered = shipped_shape_gaps(
+        recipes_map, just_variables(), gating_lanes(recipes_map), subjects)
+    for _crate, msg in shape_gaps:
+        errs.append(msg)
+
     if errs:
         print(f"check-lane-contracts: {len(errs)} tier violation(s):\n", file=sys.stderr)
         for e in errs:
@@ -854,9 +1156,17 @@ def main():
         f"({gating} merge-gating, {scanned - gating} report-only); none resolves "
         f"an artifact its job does not build. "
         f"{covered} step invocation(s) on any event carry a justfile-ordered "
-        f"`setup-*` precondition; each runs where its producer does."
+        f"`setup-*` precondition; each runs where its producer does. "
+        f"{len(shape_covered)} crate(s) whose default is not what ships "
+        f"({shape_desc(shape_covered)}) are compiled in their shipped shape "
+        f"by a merge-gating lane; "
+        f"{len([c for c in subjects if c in SHIPPED_EXEMPT])} exempt with a reason."
     )
     return 0
+
+
+def shape_desc(covered):
+    return ", ".join(f"{c} via {'/'.join(v)}" for c, v in sorted(covered.items()))
 
 
 def selftest(verbose=False):
@@ -1042,6 +1352,119 @@ def selftest(verbose=False):
     chk("`github.event_name == 'x'` selects exactly x",
         _events_of("if: ${{ github.event_name == 'pull_request' }}", allev)
         == {"pull_request"})
+
+    # ---- issue 1163 — the shipped-shape rule, end to end on a temp tree ----
+    real_wf = WORKFLOW_DIR
+    with tempfile.TemporaryDirectory() as d:
+        jf = os.path.join(d, "justfile")
+        wf = os.path.join(d, "workflows")
+        os.makedirs(os.path.join(d, "just", "check"))
+        os.makedirs(wf)
+        globals()["JUSTFILE"], globals()["WORKFLOW_DIR"] = jf, wf
+        with open(jf, "w", encoding="utf8") as fh:
+            fh.write("mod check 'just/check.just'\n")
+        with open(os.path.join(d, "just", "check.just"), "w", encoding="utf8") as fh:
+            fh.write('SHIPPED := "a,b"\n\nimport \'check/lanes.just\'\n\nfast:\n    echo\n')
+        smoke = ("compile-smoke:\n    cargo check --workspace\n"
+                 "    cargo check -p nros-c --no-default-features "
+                 "--features \"{{SHIPPED}}\" --quiet\n")
+        lanes = os.path.join(d, "just", "check", "lanes.just")
+
+        def write_lanes(text):
+            with open(lanes, "w", encoding="utf8") as fh:
+                fh.write(text)
+            return parse_justfile()
+
+        with open(os.path.join(wf, "gate.yml"), "w", encoding="utf8") as fh:
+            fh.write("on:\n  pull_request:\n  schedule:\njobs:\n  check:\n    steps:\n"
+                     "      - run: just check fast\n"
+                     "      - if: ${{ github.event_name == 'pull_request' }}\n"
+                     "        run: just check compile-smoke\n")
+        subj = {"nros-c": {"default": ["panic-platform"], "consumers": ["x", "y"]}}
+        saved = dict(SHIPPED_SHAPES)
+        SHIPPED_SHAPES.clear()
+        SHIPPED_SHAPES["nros-c"] = "SHIPPED"
+        r = write_lanes(smoke)
+        chk("a recipe in an `import`ed file is keyed to the importing module",
+            "check::compile-smoke" in r)
+        chk("a string-literal `NAME := \"...\"` in a module is read",
+            just_variables().get("SHIPPED") == {"a,b"})
+        gating = gating_lanes(r)
+        chk("a `just check <gate>` on pull_request is a gating lane",
+            "check::compile-smoke" in gating)
+        gaps, cov = shipped_shape_gaps(r, just_variables(), gating, subj)
+        chk("a gating lane compiling the crate as `{{VAR}}` covers it",
+            gaps == [] and cov == {"nros-c": ["check::compile-smoke"]})
+        # THE negative control: the line `compile-smoke` gained for 1163,
+        # removed. This is the state main was in when PR #329 landed.
+        r = write_lanes("compile-smoke:\n    cargo check --workspace\n")
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r), subj)
+        chk("REMOVING the shipped-shape line from the gating lane is a violation",
+            [c for c, _m in gaps] == ["nros-c"])
+        chk("...and the message names the variable and the fix",
+            "SHIPPED" in gaps[0][1] and "compile-smoke" in gaps[0][1])
+        # A literal spelling equal to the variable is accepted (order-free)...
+        r = write_lanes("compile-smoke:\n    cargo check -p nros-c "
+                        "--no-default-features --features \"b,a\"\n")
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r), subj)
+        chk("a literal spelling equal to the variable's value covers it", gaps == [])
+        # ...a DIFFERENT literal is drift, which is the reason the variable exists.
+        r = write_lanes("compile-smoke:\n    cargo check -p nros-c "
+                        "--no-default-features --features \"a\"\n")
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r), subj)
+        chk("a literal that DIFFERS from the variable does not cover it",
+            [c for c, _m in gaps] == ["nros-c"])
+        # The right line on a lane only the nightly runs is the exact shape
+        # `check-c` has today — and it is not coverage.
+        r = write_lanes(smoke.replace("compile-smoke:", "c:"))
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r), subj)
+        chk("the shipped shape on a lane NO gating job runs is a violation",
+            [c for c, _m in gaps] == ["nros-c"])
+        r = write_lanes(smoke.replace("--no-default-features ", ""))
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r), subj)
+        chk("the feature list WITHOUT --no-default-features is not the shipped shape",
+            [c for c, _m in gaps] == ["nros-c"])
+        r = write_lanes(smoke)
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r),
+                                     {"other": subj["nros-c"]})
+        chk("a subject with NO declared shipped shape is a violation, not a skip",
+            [c for c, _m in gaps] == ["other"] and "SHIPPED_SHAPES" in gaps[0][1])
+        r = write_lanes(smoke + '\nSHIPPED := "a,c"\n')
+        gaps, _ = shipped_shape_gaps(r, just_variables(), gating_lanes(r), subj)
+        chk("TWO spellings of the shipped variable is a violation",
+            [c for c, _m in gaps] == ["nros-c"] and "2 spellings" in gaps[0][1])
+        SHIPPED_SHAPES.clear()
+        SHIPPED_SHAPES.update(saved)
+
+        # Subject derivation on a synthetic cargo tree.
+        pk = os.path.join(d, "packages")
+        for name, body in (
+            ("lib", 'name = "lib"\n[features]\ndefault = ["p"]\np = []\n'
+                    '[dev-dependencies]\nlib = { path = "." }\n'),
+            ("lib2", 'name = "lib2"\n[features]\ndefault = ["p"]\np = []\n'),
+            ("nodef", 'name = "nodef"\n'),
+            ("a", 'name = "a"\n[dependencies]\nlib = { path = "../lib", '
+                  'default-features = false }\nnodef = { path = "../nodef", '
+                  'default-features = false }\n'
+                  'lib2 = { path = "../lib2", default-features = false }\n'),
+        ):
+            os.makedirs(os.path.join(pk, name))
+            with open(os.path.join(pk, name, "Cargo.toml"), "w", encoding="utf8") as fh:
+                fh.write("[package]\n" + body)
+        os.makedirs(os.path.join(d, "examples", "b"))
+        with open(os.path.join(d, "examples", "b", "Cargo.toml"), "w",
+                  encoding="utf8") as fh:
+            fh.write('[package]\nname = "b"\n[dependencies]\nlib2 = { path = "x" }\n')
+        subs = shipped_shape_subjects(d)
+        chk("a crate every consumer takes default-features=false is a subject",
+            "lib" in subs and subs["lib"]["consumers"] == [
+                os.path.join(pk, "a", "Cargo.toml")])
+        chk("a self dev-dependency is not a consumer",
+            len(subs["lib"]["consumers"]) == 1)
+        chk("a crate with NO default features is not a subject", "nodef" not in subs)
+        chk("one consumer taking the defaults (even outside packages/) disqualifies",
+            "lib2" not in subs)
+    globals()["JUSTFILE"], globals()["WORKFLOW_DIR"] = real[0], real_wf
 
     if verbose:
         print(f"\n{ok} passed, {fail} failed")


### PR DESCRIPTION
Issue 1163, items 1 and 3 (item 2 — `check-api-parity` on the PR lane — waits on #557's CI image and is not in this PR). The issue file itself rides along from #631 (two cherry-picked commits; whichever lands first, the other rebases clean) with a dated Progress section, and stays open.

## What changed

**`compile-smoke` compiles the shape that ships.** `nros-c` / `nros-cpp` default to `panic-platform`, which compiles almost none of the C surface; every consumer takes them `default-features = false`, and the shipped set `std,rmw-cffi,platform-posix,ros-humble` was compiled only by `check-c` / `check-cpp` on the schedule-only build tier. The pull-request gate now runs `cargo check -p nros-c -p nros-cpp --no-default-features --features "{{C_API_SHIPPED_FEATURES}}"` (25 s warm; a check, so the `HOST_UNCHECKABLE` link problem does not apply).

**One spelling.** The feature list had four literal copies in `just/check/lanes.just`. It is now `C_API_SHIPPED_FEATURES` in `just/check.just` beside `HOST_UNCHECKABLE`, and every site reads it: `check-c` (:71), `check-cpp` (:257, :399), the nros-c clippy combo (:1556), and the new `compile-smoke` line (:370). `grep -rn 'std,rmw-cffi,platform-posix,ros-humble' just scripts .github cmake` names only the definition.

**Negative control** (in the commit): a second `#[unsafe(no_mangle)] pub unsafe extern "C" fn nros_node_get_fully_qualified_name` inside `#[cfg(feature = "rmw-cffi")]` in `nros-c/src/node.rs`:

```
$ just check compile-smoke
error[E0428]: the name `nros_node_get_fully_qualified_name` is defined multiple times
    --> packages/api/nros-c/src/node.rs:1186:1
 683 | / pub unsafe extern "C" fn nros_node_get_fully_qualified_name(
error: could not compile `nros-c` (lib) due to 1 previous error
error: recipe `compile-smoke` failed with exit code 101
```

Reverted; the recipe passes.

**`check-lane-contracts` rule, so this is the class and not the site.** Subjects are derived: every crate under `packages/` with a non-empty default feature set that every consumer takes `default-features = false` (self dev-deps excluded, `workspace = true` inherited). Measured: `nros-c` (3 consumers), `nros-cpp` (2), `nros-board-nuttx` (exempt with a reason: cross-only). The shipped shape is authored once, as the `just` variable the lanes read; a subject with no declared shape is a violation, not a skip. Some recipe reachable from a lane a workflow job runs on `pull_request`/`merge_group` must compile the crate `--no-default-features --features` that variable (`{{VAR}}` or a literal equal to it — a differing literal is drift; two definitions of the variable is its own violation). Removing the compile-smoke line on the real tree reports both crates; the selftest (49 cases, run on every invocation) carries that control end to end plus the schedule-only-lane, no-`--no-default-features`, undeclared-subject and two-spellings cases.

**A blind spot found on the way:** the gate's justfile parser never followed `import`. Since phase-399 every gate lives in `just/check/*.just` behind `import`, so `check::compile-smoke`, `check::c`, `check::build` were not recipes to it and `check::fast`'s closure was two forwarders. It follows imports now; lane invocations resolved 13 → 15, findings stay 0.

**Separate commit:** the `int_plus_one` lint at `nros-node/src/executor/tests.rs:3438` that kept `check-test-targets` red for an unrelated reason.

## Ran

`just check compile-smoke` (with and without the injected duplicate), `just check lane-contracts` (with and without the smoke line), `just check gate-selftests` (148/260, unchanged), `just check gate-lists`, `just check no-tracked-file-find`, `just check fast` (255 gates), `cargo clippy -p nros-node --all-targets --no-default-features --features std -- -D warnings`. Not run: `just ci gate`'s `test-unit` (this worktree has no fixtures/CLI; the merge queue runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXZf5aX9mEQumCj83YAj8j
