### PR TITLE
fix(phase-422 W7): `--check` answered for a board it never looked up

### DIFF
--- a/docs/roadmap/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/phase-422-provisioning-one-path.md
@@ -386,11 +386,11 @@ command, the way `nros setup --system` already does.
 `role = workspace` key names it and prints the install command. Nothing is
 installed without an explicit `--sudo`.
 
-### W7 — one board vocabulary
+### W7 — one board vocabulary — DONE (additively; unification still open)
 
-`board=` in a `package.xml` export and `[board.*]` in the index are two
-namespaces that do not line up: of five boards declared across `examples/`,
-only `threadx-linux` is an index key. `nros setup --workspace` works around it
+`board=` in a `package.xml` export and `[board.*]` in the index were two
+namespaces that did not line up: of five boards declared across `examples/`,
+only `threadx-linux` was an index key. `nros setup --workspace` worked around it
 by validating before printing a command, which is honest but is a workaround.
 
 Same for `deploy=`: `threadx` is not a scope, it splits into `threadx_linux` /
@@ -409,6 +409,51 @@ dispatcher setup spelling.
 **Acceptance.** A gate asserts every `board=` in a package.xml export resolves
 to an index board (or to a documented alias), and every `deploy=` resolves to a
 scope.
+
+### What landed
+
+**The four missing index entries.** `mps2-an385-freertos`, `nuttx-qemu-arm`,
+`nuttx-qemu-riscv` and `riscv64-qemu` are `[board.*]` keys now, each marked
+`# = [board.<other-spelling>]` against the entry it duplicates. All five
+exported boards resolve in both namespaces, and `nros setup <board>` works for
+five of five instead of one.
+
+**`check-board-vocabulary`**, on the fast line, with three assertions:
+
+1. every `board=` resolves in at least one of the five namespaces (cmake board
+   file, index, board crate, fixture coordinate, scope);
+2. every `board=` is specifically an **index key** — the namespace
+   `nros setup <board>` looks up, exact-match with no fallback;
+3. the four `# =` mirrored pairs are byte-identical in `arch`, `platform` and
+   `packages`. The index tells readers to edit both; nothing asserted it, which
+   is the issue-0196 class (a gate credited with a rule wider than the one it
+   enforces).
+
+Assertion 2 is the one that tests what W7 created. Assertion 1 alone was
+satisfied by `cmake/board/*.cmake` for every value, before and after the index
+entries existed — measured A/B, identical OK line either way.
+
+`deploy=` resolves as a scope or splits into `<deploy>_*` scopes by board, which
+is how `threadx` is legal: it is a deploy FAMILY, and the `board=` beside it
+selects `threadx_linux` or `threadx_riscv64`. `check-board-alias-unique`
+(phase-435 W5) enforces the same distinction from the descriptor side.
+
+**A silent hole in the doctor surface, found by running the command.**
+`nros setup <board> --check` dropped the board argument: the arm returned before
+the board was ever looked up, so `nros setup not-a-board --check` printed the
+same all-clear as `nros setup threadx-linux --check` and exited 0. The one
+command a user runs to ASK whether a board is provisionable answered yes for a
+name that is not a board — while the same typo without `--check` was a clear
+error listing the known boards. The board is validated now, and the notice says
+what `--check` actually covered rather than implying the board narrowed it (it
+walks `[system.*]`/`[rust.*]`/`[python.*]`, a different axis from a board's
+package set; narrowing that is a doctor redesign, not this fix).
+
+**Still open:** true unification — picking one canonical spelling and renaming
+through 90+ package.xml files. The index namespace is what USERS type, the
+cmake namespace is what the BUILD uses, and the mirrored pairs are the cost of
+deferring: two entries that a gate now keeps identical rather than one entry
+with an alias key.
 
 ### W8 — refuse a wrong-role dependency — DONE (scoped to `infra`)
 

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -265,6 +265,26 @@ pub fn run(args: Args) -> Result<()> {
         return run_check_tool(&index, args.tool.as_deref().unwrap());
     }
     if args.check {
+        // phase-422 W7 — a BOARD given here must still resolve, even though the
+        // walk below is class-wide and the board does not narrow it.
+        //
+        // Measured: `nros setup not-a-board --check` printed the same
+        // everything-is-fine report as `nros setup threadx-linux --check` and
+        // exited 0, because this arm returned before the board was ever looked
+        // up. So the one command a user runs to ASK whether their board is
+        // provisionable answered yes for a name that is not a board — and W7's
+        // whole subject is that `board=` values resolve. Without `--check` the
+        // same typo is a clear error listing the known boards; the doctor
+        // surface was the one that could not tell.
+        //
+        // The walk itself is deliberately NOT narrowed: `--check` alone probes
+        // `[system.*]`, `[rust.*]` and `[python.*]`, which is a different axis
+        // from a board's `[tool.*]`/`[source.*]` package set. Narrowing it is a
+        // redesign of the doctor, not a fix for the silent typo, so the report
+        // says what it covered instead of implying the board scoped it.
+        if let Some(notice) = check_board_argument(&index, args.board.as_deref())? {
+            eprintln!("{notice}");
+        }
         return run_check_all(&index);
     }
 
@@ -1209,6 +1229,26 @@ fn describe(action: &InstallAction, version: &str, host: &str) -> String {
             format!("UNAVAILABLE {version} (no prebuilt for {host}, no source)")
         }
     }
+}
+
+/// A `--check` that was GIVEN a board must still resolve it — phase-422 W7.
+///
+/// Returns the notice to print, or `None` when no board was named. Split out of
+/// `run` so the contract has a test at all — but be precise about what that
+/// buys: the DEFECT was dispatch order (the `--check` arm returned before the
+/// board was ever looked up), and a unit test on this function cannot see
+/// dispatch order. It binds the rule; the single call site above is what makes
+/// the rule reachable, and only running the binary proves that.
+fn check_board_argument(index: &SdkIndex, board: Option<&str>) -> Result<Option<String>> {
+    let Some(board) = board else {
+        return Ok(None);
+    };
+    resolve_packages(index, board)?;
+    Ok(Some(format!(
+        "nros setup: board '{board}' resolves. --check walks the \
+         [system.*]/[rust.*]/[python.*] classes, which the board does not \
+         narrow; use `nros setup {board}` to see its package set."
+    )))
 }
 
 /// Resolve a board to its SDK package set from the index `[board.*]` table — the
@@ -2463,6 +2503,41 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unknown board") && err.contains("native"));
+    }
+
+    #[test]
+    fn check_validates_a_board_argument_it_does_not_otherwise_use() {
+        // phase-422 W7. `--check` walks the `[system.*]`/`[rust.*]`/`[python.*]`
+        // classes and a board does not narrow that, so the board argument used
+        // to be dropped on the floor: `nros setup not-a-board --check` printed
+        // the same all-clear as `nros setup native --check` and exited 0. The
+        // one command a user runs to ASK whether a board is provisionable
+        // answered yes for a name that is not a board.
+        //
+        // This test binds the RULE, not the dispatch order that broke it —
+        // see the note on `check_board_argument`.
+        let idx = SdkIndex::parse(
+            "[tool.zenohd]\nversion=\"1\"\n[board.native]\npackages=[\"zenohd\"]\n",
+        )
+        .unwrap();
+
+        // No board named: nothing to validate, nothing to say.
+        assert!(check_board_argument(&idx, None).unwrap().is_none());
+
+        // A real board resolves, and the notice says what --check actually
+        // covered rather than implying the board scoped it.
+        let notice = check_board_argument(&idx, Some("native")).unwrap().unwrap();
+        assert!(notice.contains("native") && notice.contains("does not"));
+
+        // The regression itself: an unknown board must be an ERROR here, not a
+        // pass, and must still list what is known.
+        let err = check_board_argument(&idx, Some("not-a-board"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("unknown board") && err.contains("native"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/scripts/check-board-vocabulary.py
+++ b/scripts/check-board-vocabulary.py
@@ -7,10 +7,16 @@ a provisioning command. That only works if the values mean something.
 
 WHAT THE VALUES ACTUALLY MEAN, measured rather than assumed. `board=` is the
 CMAKE BOARD vocabulary: all five values across `examples/` resolve to a
-`cmake/board/nano-ros-board-<name>.cmake` file. They are NOT `[board.*]` index
-keys — only `threadx-linux` is one, so `nros setup <board>` would fail for four
-of five. That mismatch is real and is why `nros setup --workspace` validates
-before printing a command.
+`cmake/board/nano-ros-board-<name>.cmake` file.
+
+They used to resolve to NOTHING ELSE. When this gate was written only
+`threadx-linux` was also an index key, so `nros setup <board>` failed for four
+of five and `nros setup --workspace` had to validate before printing a command.
+W7's additive half closed that: `mps2-an385-freertos`, `nuttx-qemu-arm`,
+`nuttx-qemu-riscv` and `riscv64-qemu` are `[board.*]` entries now, each marked
+`# = [board.<other-spelling>]` against the entry it duplicates. All five values
+resolve in BOTH namespaces, which is what lets the second assertion below —
+`board=` must be an index key — be enforced rather than aspired to.
 
 Five namespaces exist for closely related concepts, overlapping partially:
 
@@ -96,8 +102,12 @@ def fixture_boards(root):
 def cmake_boards(root):
     """Boards defined by `cmake/board/nano-ros-board-<name>.cmake`.
 
-    This is what `board=` in a package.xml export actually names — all five
-    values in this repo resolve here, and only one of them is an index key.
+    This is what `board=` in a package.xml export actually names, and all five
+    values in this repo resolve here. They are ALSO index keys now (W7's
+    additive half); this namespace stays in the OR because it is the one the
+    BUILD uses, and a value that resolved only here would still be a real board
+    — just not a provisionable one, which the stricter check below reports
+    separately.
     """
     d = os.path.join(root, "cmake", "board")
     try:


### PR DESCRIPTION
Stacked on #604 (shares `setup.rs` and the phase doc). W7's additive half and its gate had already landed; finishing the wave meant asking whether either still says something true. Neither did.

## The defect, found by running the command

`nros setup <board> --check` **dropped the board argument** — the `--check` arm returns before the board is ever resolved:

```
nros setup not-a-board   --check  ->  [OK] system aria2 ...  rc=0
nros setup threadx-linux --check  ->  [OK] system aria2 ...  rc=0
```

Byte-identical output, **exit 0 for a name that is not a board**. The one command a user runs to ask whether their board is provisionable answered yes for a typo — while the *same* typo without `--check` is a clear error listing the known boards. The doctor surface was the only one that could not tell, which is precisely the property W7 exists to establish.

Validated now. The walk is deliberately **not** narrowed: `--check` alone probes `[system.*]`/`[rust.*]`/`[python.*]`, a different axis from a board's `[tool.*]`/`[source.*]` package set, and narrowing it is a redesign of the doctor rather than a fix for a silent typo. The notice says what the run actually covered instead of implying the board scoped it.

`check_board_argument` is split out of `run` so the rule has a test — and its doc-comment is explicit that this is **not** full coverage: the defect was dispatch *order*, a unit test cannot see dispatch order, and only running the binary proves the call site is reached. A stated gap beats a test that reads like it closed one.

## The expired premise

`check-board-vocabulary`'s docstring still said `board=` values *"are NOT `[board.*]` index keys — only `threadx-linux` is one, so `nros setup <board>` would fail for four of five"*.

W7's additive half made that false. `mps2-an385-freertos`, `nuttx-qemu-arm`, `nuttx-qemu-riscv` and `riscv64-qemu` are index entries now, and the gate's **own OK line** has been reporting `each resolves AND is an index key` while the prose above it described the state before that. Re-derived from the tree: all five resolve, and `nros setup <board> --check` answers for five of five.

## W7 marked DONE, with what it did and did not buy

Three assertions in the gate, and only one of them tests what the wave created:

| # | assertion | tests W7? |
|---|---|---|
| 1 | `board=` resolves in ≥1 of five namespaces | **no** — `cmake/board/*.cmake` satisfied every value before and after, measured A/B |
| 2 | `board=` is specifically an **index key** | **yes** — the namespace `nros setup <board>` looks up, exact-match, no fallback |
| 3 | the four `# =` mirrored pairs are identical in `arch`/`platform`/`packages` | keeps the deferral honest |

`deploy=` resolves as a scope or splits into `<deploy>_*` by board — which is how `threadx` is legal: a deploy *family*, with `board=` beside it selecting `threadx_linux` or `threadx_riscv64`. `check-board-alias-unique` (phase-435 W5) enforces the same distinction from the descriptor side.

**Still open, deliberately:** true unification — one canonical spelling, renamed through 90+ package.xml files. The index namespace is what users type, the cmake namespace is what the build uses. The cost of deferring is those four mirrored pairs: two entries a gate keeps identical, where one entry with an alias key would do.

`just check fast`: 255/255. `nros-cli-core` lib tests: 967 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK