### PR TITLE
fix(#1177): the island builds against main again -- halt flag, hollow <chrono>, and two vacuous gates

### DIFF
--- a/packages/api/nros-cpp/include/nros/nros.hpp
+++ b/packages/api/nros-cpp/include/nros/nros.hpp
@@ -293,7 +293,41 @@ inline Result spin(uint32_t duration_ms, int32_t poll_ms = 10) {
 //
 // `NROS_CPP_STD` stays as an explicit override for a consumer who knows better
 // than the probes, which is what the parity extractor and the docs use it for.
-#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<chrono>))
+// CORRECTED AGAIN 2026-09-07, and this time the discriminator is the library's
+// own feature-test macro rather than a guess about which RTOS ships what.
+//
+// The conjunction above is still not enough. Measured under the safety island's
+// OWN recorded compile command (`-nostdinc++`, arm-zephyr-eabi, picolibc), not
+// inferred:
+//
+//     __STDC_HOSTED__          1
+//     __has_include(<chrono>)  TRUE
+//     __cpp_lib_chrono         ABSENT
+//
+// So Zephyr does NOT merely "have no <chrono> at all" -- this toolchain ships
+// one that is present and hollow, which is the case the note above attributes
+// to FreeRTOS alone. Both halves of the conjunction answer yes and
+// `duration_cast` is still missing, so `Rate`'s duration constructor failed to
+// compile on the island exactly as it did before that note was written.
+//
+// `<ratio>` is the third test, and it is a PREREQUISITE rather than a proxy.
+// `duration_cast<To>(duration<Rep, Period>)` is defined in terms of
+// `std::ratio_divide` -- a duration's `Period` IS a `std::ratio` -- so a
+// `<chrono>` shipped without `<ratio>` cannot provide `duration_cast`, and that
+// is exactly the shape this toolchain ships. Measured on both sides:
+//
+//                        island (Zephyr)   hosted g++ -std=c++14
+//   __has_include(<chrono>)   TRUE              TRUE
+//   __has_include(<ratio>)    FALSE             TRUE
+//
+// `__cpp_lib_chrono` was tried first and is WRONG here: it is a C++17
+// feature-test macro, so it is absent under `-std=c++14` even where the library
+// is complete. `check-cpp` compiles the phase-417 probes at C++14 and caught
+// that immediately -- gating on it removed `create_wall_timer` from the hosted
+// build, which is the same over-tightening the note above records.
+// `_GLIBCXX_CHRONO` also separates the two but is libstdc++'s private spelling;
+// `__has_include` is the portable question.
+#if defined(NROS_CPP_STD) || (defined(__STDC_HOSTED__) && __STDC_HOSTED__ && __has_include(<chrono>) && __has_include(<ratio>))
 #include <chrono>
 #define NROS_CPP_HAS_STD_CHRONO 1
 #endif

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1070,6 +1070,22 @@ pub(crate) struct RemapRule {
     pub(crate) to: heapless::String<{ crate::names::MAX_RESOLVED_NAME_LEN }>,
 }
 
+/// The executor's halt flag, in the one shape each configuration can hold.
+///
+/// Issue 1177. With an allocator it is refcounted, because `halt_flag()` hands
+/// a caller its own handle to set from a signal handler or another thread.
+/// Without one there is no handle to hand out -- a C caller reaches the
+/// executor through its own pointer and calls `cancel()` directly -- so a plain
+/// atomic is the whole requirement.
+///
+/// `Arc<AtomicBool>` derefs to `AtomicBool`, so every `load`/`store` below is
+/// written once and only construction and the getter are cfg'd.
+#[cfg(feature = "alloc")]
+pub(crate) type HaltFlag = portable_atomic_util::Arc<portable_atomic::AtomicBool>;
+/// See [`HaltFlag`] above -- the no-allocator shape.
+#[cfg(not(feature = "alloc"))]
+pub(crate) type HaltFlag = portable_atomic::AtomicBool;
+
 pub struct Executor<'s> {
     /// Issue 0656 — the ROS domain this executor's entities belong to.
     ///
@@ -1285,22 +1301,35 @@ pub struct Executor<'s> {
     // phase-359 W3 — `portable_atomic_util::Arc`, not `std::sync::Arc`. Same
     // atomically-refcounted pointer, available without `std`, and it compiles on
     // std too. W3 left the GATE on `std` because the public `halt_flag()` getter
-    // was std-gated; W10 split that impl, so the field joins `wake_flag` on
-    // `alloc` — the allocator is the real requirement, and without this a no_std
-    // executor had no halt flag at all and so could not be stopped.
-    #[cfg(feature = "alloc")]
-    pub(crate) halt_flag: portable_atomic_util::Arc<portable_atomic::AtomicBool>,
+    // was std-gated; W10 split that impl, so the field joined `wake_flag` on
+    // `alloc`.
+    //
+    // Issue 1177 — the ALLOCATOR was never the requirement of the FLAG, only of
+    // SHARING it. The flag is an `AtomicBool`; what needs an allocator is
+    // `halt_flag()`, the getter that hands a caller its own refcounted handle to
+    // set from a signal handler or another thread. Gating the flag on `alloc`
+    // therefore gated the ability to STOP a no_std executor on a feature it does
+    // not need -- and `nros-c`'s spin loop calls `cancel`/`is_halted`/
+    // `enter_spin_loop`/`exit_spin_loop`/`is_spinning` unconditionally, so an
+    // embedded image did not merely lose cancellation, it failed to compile.
+    //
+    // `HaltFlag` is the one type name that differs, so every reader below is
+    // written once: `Arc<AtomicBool>` derefs to `AtomicBool`, so `load`/`store`
+    // are identical on both sides and only construction and the getter are
+    // cfg'd.
+    pub(crate) halt_flag: HaltFlag,
     /// Is a spin loop running right now? — the observable behind
     /// `is_spinning()` (phase-417 W4.c, rclcpp's `Executor::is_spinning`).
     ///
-    /// A plain atomic, not an `Arc` like `halt_flag`: nothing hands this one
+    /// A plain atomic, not refcounted like `halt_flag`: nothing hands this one
     /// out. `halt_flag()` is a public getter that gives a caller its own
     /// handle to set from another thread; `spinning` is only ever set by the
     /// executor's own loops through `&self`, so it needs no shared ownership.
     ///
-    /// It rides `alloc` for the same reason the impl that reads it does: the
-    /// lifecycle block also touches `halt_flag`.
-    #[cfg(feature = "alloc")]
+    /// Issue 1177 — this used to ride `alloc` "for the same reason the impl
+    /// that reads it does". It never needed an allocator itself; it was gated
+    /// by ASSOCIATION with `halt_flag`, and when that association turned out to
+    /// be wrong this went with it.
     pub(crate) spinning: portable_atomic::AtomicBool,
     /// Phase 104.C.6 — shared executor wake flag. Any source of work
     /// (foreign thread handing off a callback, signal handler, future
@@ -1613,9 +1642,13 @@ impl<'s> Executor<'s> {
                 let _ = ns.push_str("/");
                 ns
             },
+            // Issue 1177 -- the only cfg the halt flag still needs. `HaltFlag`
+            // is refcounted with an allocator and plain without one, and
+            // nothing below this line can tell the difference.
             #[cfg(feature = "alloc")]
             halt_flag: portable_atomic_util::Arc::new(portable_atomic::AtomicBool::new(false)),
-            #[cfg(feature = "alloc")]
+            #[cfg(not(feature = "alloc"))]
+            halt_flag: portable_atomic::AtomicBool::new(false),
             spinning: portable_atomic::AtomicBool::new(false),
             #[cfg(feature = "alloc")]
             wake_flag: portable_atomic_util::Arc::new(portable_atomic::AtomicBool::new(false)),
@@ -8012,10 +8045,16 @@ impl<'s> Executor<'s> {
 // Executor lifecycle — cancel / is_spinning (phase-417 W4.c)
 // ============================================================================
 
-// `alloc`, because every method here reads `halt_flag` or `spinning` and both
-// are `alloc` fields. Un-gated, this block did not compile without the feature
-// at all — `cancel()` stores into a field that is not there.
-#[cfg(feature = "alloc")]
+// Issue 1177 -- UN-GATED. This block was `#[cfg(feature = "alloc")]` because
+// `halt_flag` and `spinning` were `alloc` fields, and neither needed to be: the
+// allocator is required to SHARE the halt flag (`halt_flag()` hands out a
+// refcounted handle), never to hold it.
+//
+// Gating it meant a no_std executor could not be stopped, and worse, that
+// `nros-c`'s spin loop -- which calls `cancel`, `is_halted`, `is_spinning`,
+// `enter_spin_loop` and `exit_spin_loop` with no cfg of its own -- did not
+// COMPILE for an embedded image. The safety island found that; no
+// merge-gating lane builds this crate without `alloc`.
 impl<'s> Executor<'s> {
     /// Request the executor to stop spinning — `rclcpp::Executor::cancel`.
     ///

--- a/scripts/check-config-header-single-writer.py
+++ b/scripts/check-config-header-single-writer.py
@@ -127,7 +127,22 @@ def main() -> int:
         + list(REPO.glob("zephyr/**/*.cmake"))
         + list(REPO.glob("integrations/**/*.cmake"))
     )
-    files = [f for f in files if "third-party" not in f.parts]
+    # RELATIVE to the repo. Against the ABSOLUTE path this skipped every file
+    # whenever the checkout itself lived under a directory called
+    # `third-party` -- which is how the safety island vendors this repo -- and
+    # the gate then reported "OK -- 0 cmake file(s)" while examining nothing.
+    files = [f for f in files if "third-party" not in f.relative_to(REPO).parts]
+    # A gate that scanned nothing must not read as a pass. This one had no such
+    # floor, so the vacuous state was indistinguishable from a clean one; its
+    # sibling `check-ret-code-citations` had the identical path bug AND a floor,
+    # went red instead of green, and is how the class was found at all.
+    if not files:
+        print(
+            "check-config-header-single-writer: scanned NO cmake files -- this "
+            "gate would pass vacuously.",
+            file=sys.stderr,
+        )
+        return 1
 
     hits = []
     for f in files:

--- a/scripts/check-ret-code-citations.py
+++ b/scripts/check-ret-code-citations.py
@@ -130,7 +130,17 @@ def files():
         for p in tracked(ROOT / root):
             if p.suffix not in SUFFIXES:
                 continue
-            if any(part in SKIP_PARTS for part in p.parts):
+            # RELATIVE to the repo. Tested against the ABSOLUTE path, this
+            # skipped every file whenever the checkout itself lived under a
+            # directory named `third-party` -- which is how the safety island
+            # vendors this repo (`<super>/third-party/nano-ros`). The gate then
+            # scanned 0 files.
+            #
+            # It refuses to pass on an empty scan, so it went RED rather than
+            # silently green, which is the only reason this was noticed at all.
+            # `check-doc-recipe-refs` had the identical bug and no such floor,
+            # so it read as passing while examining nothing.
+            if any(part in SKIP_PARTS for part in p.relative_to(ROOT).parts):
                 continue
             yield p
 


### PR DESCRIPTION
Main did not build the safety island (thumbv7em, no std, no alloc). Three defects, each measured rather than reasoned about, and the island now reaches FirstSpin on real hardware again.

## 1. The halt flag needed an allocator to be SHARED, not to exist

`nros-c`'s spin loop calls `cancel`, `is_halted`, `is_spinning`, `enter_spin_loop` and `exit_spin_loop` with no cfg of its own. All five lived in an `#[cfg(feature = "alloc")]` impl block, so an embedded image did not merely lose cancellation -- it failed to compile.

The gate was wrong about its own reason. `halt_flag` was `Arc<AtomicBool>` and the block claimed "the allocator is the real requirement". The allocator is the requirement of **sharing** the flag -- of `halt_flag()`, the getter handing out a refcounted handle -- never of holding it. `spinning` was worse: a plain atomic, gated "for the same reason the impl that reads it does", i.e. by association with a requirement that was not real either.

`HaltFlag` is now the one name that differs. `Arc<AtomicBool>` derefs to `AtomicBool`, so every `load`/`store` reads identically and only construction and the getter carry a cfg. The getter stays `alloc`-only, correctly: without an allocator there is no handle to hand out, and a C caller reaches the executor through its own pointer. Its only users are this crate's tests.

**Measured:** the no-alloc lane went **11 errors -> 0**; `nros-node` builds clean with no features, `alloc`, and `std`.

## 2. `<chrono>` can be present and hollow on Zephyr too

```
nros.hpp:1073: error: 'duration_cast' is not a member of 'std::chrono'
```

The guard already anticipated a hollow `<chrono>` and got the boundary one RTOS too narrow -- it held that Zephyr has no `<chrono>` at all so `__has_include` answers FALSE. Measured under the island's own recorded compile command:

```
                        island (Zephyr)   hosted g++ -std=c++14
__STDC_HOSTED__               1                  1
__has_include(<chrono>)     TRUE               TRUE
__has_include(<ratio>)      FALSE              TRUE
```

`<ratio>` is a **prerequisite, not a proxy**: `duration_cast<To>(duration<Rep, Period>)` is defined via `std::ratio_divide`, so a `<chrono>` without `<ratio>` cannot provide it.

I tried `__cpp_lib_chrono` first and it is **wrong** -- a C++17 feature-test macro, absent under the `-std=c++14` the phase-417 probes compile at, so it removed `create_wall_timer` from the hosted build. `check-cpp` caught that immediately; it is the same over-tightening the existing note records, reached by a different route.

## 3. Two more gates skipped every file when the repo sits under `third-party`

Same defect as `check-doc-recipe-refs`: a SKIP list tested against the **absolute** path.

```
check-ret-code-citations          scanned 0 files -> 2587
check-config-header-single-writer scanned 0 files -> 373
```

They failed **differently**, and that is the lesson. `ret-code-citations` refuses to pass on an empty scan, so it went red -- which is how the class was found. `config-header-single-writer` had no floor, printed "OK -- 0 cmake file(s)", and read as clean while examining nothing. The floor is added to the one that lacked it and verified to fire.

Sweep done: every `scripts/*.py` testing a skip name against `.parts` was checked. `check-just-recipe-refs` has the shape but is not vacuous here (162 recipes, 19 modules), so it is left alone -- a change with no measured effect is how a sweep becomes churn.

## Verification

`just check fast` **255/255**, `just check cpp` green. Island builds and, flashed to an MR-CANHUBK344 with a serial router: **stage 6 FirstSpin, arena 17736/46272 (38.3%), 4 nodes, 25 topics, both operate services.**

Two pre-existing reds on main confirmed unrelated by stashing this diff: `executor::backing::tests::the_static_is_handed_out_once_and_only_once` (fails in-binary, passes solo) and the sizes-probe re-build disagreement described below.

## Known, not fixed

A **second** `board-build` in the same directory fails with `nros_config_generated.h ... DIFFERENT probed sizes` (`NROS_EXECUTOR_SIZE` 63632 vs 63512) -- same rlib, same content hash, different computed sizes across invocations. This change makes it visible by moving `Executor`'s size; the mechanism (sizes header written at one pass, knobs settling at another) is the 0088/0834 family and predates it. A clean build is correct, which is how the island was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)