### PR TITLE
fix(phase-413 W3): colcon-parity installs a ROS desktop stack its own CI image already carries

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1192,58 +1192,73 @@ jobs:
           source ./activate.sh
           just scaffold-journey
 
-  # ----- colcon-parity (bare ubuntu — no base image) -----
+  # ----- colcon-parity (the CI image, phase-413 W3) -----
+  #
+  # This lane used to be bare `ubuntu-22.04` and spend its first minutes adding
+  # the ROS apt repository and installing a ROS desktop stack — ten packages —
+  # plus `just`, on EVERY run. `images.yml` has been building
+  # `ghcr.io/newslabntu/nano-ros-ci:humble` and describing it as "ROS 2 Humble +
+  # host tools, the base `container:` for the check / … lanes" the whole time;
+  # only `nightly.yml` and the `check` job above used it.
+  #
+  # MEASURED before converting, not assumed. The image is `FROM
+  # ros:humble-ros-base`, and all ten apt names this lane installed are already
+  # in that upstream base — `python3-colcon-common-extensions`,
+  # `ros-humble-{ros-base,rclcpp,std-msgs,geometry-msgs,sensor-msgs,
+  # rosidl-default-generators,rosidl-default-runtime,ament-cmake,
+  # ament-cmake-auto}` — with `colcon` on PATH. `just` is baked and PINNED by
+  # the image (`JUST_VERSION`), which is stronger than the `curl | sh` this
+  # replaces: that fetched whatever was current at run time. Then
+  # `just colcon-parity` was RUN in the image: 3 packages, consumer binary
+  # produced, 7.63 s.
+  #
+  # The apt repo step goes with them. Its `gnupg`/`lsb-release` were kept
+  # literal on the argument that RFC-0062 cannot express "add this apt
+  # repository first" — true, and moot once nothing adds a repository: the
+  # image's ROS comes from its own base layer.
   colcon-parity:
     name: colcon build examples/templates/local-msg-package/src/
     needs: changes
     if: ${{ needs.changes.outputs.colcon == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/newslabntu/nano-ros-ci:humble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: false  # fixture is self-contained; no nano-ros submodules needed
 
-      - name: Add ROS 2 apt repo
-        run: |
-          sudo apt-get update
-          # `curl` dropped: it is preinstalled on the GitHub runner AND
-          # declared by `[prereq.curl]`, so naming it here was the index's fact
-          # restated in a second place (phase-413 W3). `gnupg` and
-          # `lsb-release` stay literal on purpose — they exist only to ADD the
-          # third-party ROS apt source below, and RFC-0062's providers are
-          # system / sdk / source / submodule, none of which can express "add
-          # this apt repository first". Indexing them would claim the index
-          # provisions something it cannot.
-          sudo apt-get install -y gnupg lsb-release
-          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu jammy main" \
-            | sudo tee /etc/apt/sources.list.d/ros2.list >/dev/null
-
-      - name: Install ROS 2 Humble msg deps + colcon
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            python3-colcon-common-extensions \
-            ros-humble-ros-base \
-            ros-humble-rclcpp \
-            ros-humble-std-msgs \
-            ros-humble-geometry-msgs \
-            ros-humble-sensor-msgs \
-            ros-humble-rosidl-default-generators \
-            ros-humble-rosidl-default-runtime \
-            ros-humble-ament-cmake \
-            ros-humble-ament-cmake-auto
-
-      # No base image on this lane → install `just` so CI calls the SAME recipe a
-      # developer runs (SSoT — phase-253). Official prebuilt installer; the lane
-      # already uses sudo+curl for the ROS apt repo.
-      - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
-
       # `just colcon-parity` sources ROS, scans ONLY src/ (`--base-paths src`:
       # local_msgs → extra_msgs → consumer, skipping the top-level nano-ros umbrella
       # CMakeLists that needs the `nros` codegen tool), builds, and asserts the
       # consumer binary — the same parity check, no inline drift.
+      #
+      # The recipe SKIPS when `colcon` is absent (`nros_check_skip`, exit 0).
+      # That is right for a developer host and wrong here: this job exists to
+      # run it, and an image that lost ROS would report GREEN over nothing —
+      # the fail-open shape issues 0650/1001 are about. Assert the precondition
+      # the container is supposed to provide, so a skip cannot pass for a run.
+      - name: assert this lane can actually run colcon
+        run: |
+          source ./activate.sh
+          if ! command -v colcon >/dev/null; then
+            echo "colcon absent from the CI image: the recipe would SKIP and" >&2
+            echo "this lane would report green over nothing. The image is" >&2
+            echo "FROM ros:humble-ros-base, which carries colcon; if that" >&2
+            echo "changed, fix the image rather than this step." >&2
+            exit 1
+          fi
+          echo "colcon: $(command -v colcon)"
+
       - name: just colcon-parity
         run: |
           source ./activate.sh

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -160,6 +160,16 @@ jobs:
               - 'scripts/ci/scaffold-journey-check.sh'
             colcon:
               - 'examples/templates/local-msg-package/**'
+              # phase-413 W3 — the lane's OWN definition and the recipe it
+              # runs. Without these, a change to the colcon-parity job could
+              # not run the colcon-parity job: converting it from a bare
+              # runner to `container:` touched only `gate.yml`, so the filter
+              # said "colcon: false" and the conversion would have merged
+              # having never executed once. A filter that excludes the thing
+              # under test is the coverage hole issues 0981/1001 keep finding
+              # in a different costume.
+              - '.github/workflows/gate.yml'
+              - 'justfile'
             sdk_index:
               - 'nros-sdk-index.toml'
               - '.gitmodules'

--- a/docs/roadmap/phase-413-ci-workflow-user-parity.md
+++ b/docs/roadmap/phase-413-ci-workflow-user-parity.md
@@ -186,7 +186,7 @@ conversion can be verified in a lane that is already red.
 Acceptance: each lane green at least once, and the date recorded here. A lane
 that cannot be made green is a finding, not a skip — file it.
 
-## W3 — a gate: no workflow installs what the index already declares
+## W3 — a gate: no workflow installs what the index already declares — DONE (verified 2026-09-07)
 
 `nros setup --system` resolves the `[prereq.*]` closure for the detected package
 manager (RFC-0062 / phase-327). Measured on a dev host: 38 present, 5 missing, 3
@@ -219,6 +219,56 @@ Two halves:
 
 Acceptance: the gate reproduces each of the three sites before the fix and passes
 after; no workflow apt-installs an indexed package.
+
+### What landed
+
+**The gate**, `check-workflow-indexed-apt`, on the fast line, self-testing (5
+cases + extraction). Current verdict: *14 workflow(s), 40 indexed apt
+package(s), none restated.*
+
+**All three conversions.** `docs.yml` and `nightly.yml` resolve their names
+through `scripts/sdk/prereq-packages.py --manager apt <key>`, and so does
+`post-submit.yml`'s clang step. Grepping the workflows for `apt-get install`
+now returns three sites and **not one literal package name** among them.
+
+**colcon-parity moved into the CI image.** It was bare `ubuntu-22.04`, adding
+the ROS apt repository and installing ten packages plus `just` on every run,
+while `images.yml` had been building
+`ghcr.io/newslabntu/nano-ros-ci:humble` — described in its own workflow as the
+base `container:` for these lanes — and only `nightly.yml` and the `check` job
+used it.
+
+Measured before converting rather than assumed. The image is `FROM
+ros:humble-ros-base`, and **all ten apt names are already in that upstream
+base**: `python3-colcon-common-extensions`, `ros-humble-ros-base`, `-rclcpp`,
+`-std-msgs`, `-geometry-msgs`, `-sensor-msgs`, `-rosidl-default-generators`,
+`-rosidl-default-runtime`, `-ament-cmake`, `-ament-cmake-auto`, with `colcon`
+on PATH. `just` is baked and PINNED by the image, which is stronger than the
+`curl | sh` it replaces — that fetched whatever was current at run time. Then
+`just colcon-parity` was RUN in the image: 3 packages, consumer binary
+produced, 7.63 s.
+
+The apt-repo step goes with them, and its exception expires cleanly: its
+`gnupg`/`lsb-release` were kept literal because RFC-0062 cannot express "add
+this apt repository first". True, and moot once nothing adds a repository — the
+image's ROS comes from its own base layer.
+
+**One thing the conversion had to add.** `just colcon-parity` SKIPS when
+`colcon` is absent (`nros_check_skip`, exit 0). Right for a developer host,
+wrong for a job that exists to run it: an image that lost ROS would report
+green over nothing, the fail-open shape of issues 0650 and 1001. The lane now
+asserts the precondition its container is supposed to provide, so a skip cannot
+pass for a run.
+
+### The gap this leaves, named rather than papered over
+
+The gate compares **apt** names. `python3-colcon-common-extensions` is the apt
+spelling of `[python.colcon]`, whose index row says `pip =
+"colcon-common-extensions"` — so an indexed *python-layer* tool restated as an
+apt package is invisible to it, which is W3's own asymmetry one namespace over.
+Deriving the apt name from the pip name is a Debian naming convention, not a
+fact the index states, so the rule is not written; the site that would have
+tripped it is gone, and this is recorded so the next one is recognised.
 
 ## W4 — decide what the required check promises on a pull request — DONE (verified 2026-09-06)
 

--- a/docs/roadmap/phase-422-provisioning-one-path.md
+++ b/docs/roadmap/phase-422-provisioning-one-path.md
@@ -386,11 +386,11 @@ command, the way `nros setup --system` already does.
 `role = workspace` key names it and prints the install command. Nothing is
 installed without an explicit `--sudo`.
 
-### W7 — one board vocabulary
+### W7 — one board vocabulary — DONE (additively; unification still open)
 
-`board=` in a `package.xml` export and `[board.*]` in the index are two
-namespaces that do not line up: of five boards declared across `examples/`,
-only `threadx-linux` is an index key. `nros setup --workspace` works around it
+`board=` in a `package.xml` export and `[board.*]` in the index were two
+namespaces that did not line up: of five boards declared across `examples/`,
+only `threadx-linux` was an index key. `nros setup --workspace` worked around it
 by validating before printing a command, which is honest but is a workaround.
 
 Same for `deploy=`: `threadx` is not a scope, it splits into `threadx_linux` /
@@ -409,6 +409,51 @@ dispatcher setup spelling.
 **Acceptance.** A gate asserts every `board=` in a package.xml export resolves
 to an index board (or to a documented alias), and every `deploy=` resolves to a
 scope.
+
+### What landed
+
+**The four missing index entries.** `mps2-an385-freertos`, `nuttx-qemu-arm`,
+`nuttx-qemu-riscv` and `riscv64-qemu` are `[board.*]` keys now, each marked
+`# = [board.<other-spelling>]` against the entry it duplicates. All five
+exported boards resolve in both namespaces, and `nros setup <board>` works for
+five of five instead of one.
+
+**`check-board-vocabulary`**, on the fast line, with three assertions:
+
+1. every `board=` resolves in at least one of the five namespaces (cmake board
+   file, index, board crate, fixture coordinate, scope);
+2. every `board=` is specifically an **index key** — the namespace
+   `nros setup <board>` looks up, exact-match with no fallback;
+3. the four `# =` mirrored pairs are byte-identical in `arch`, `platform` and
+   `packages`. The index tells readers to edit both; nothing asserted it, which
+   is the issue-0196 class (a gate credited with a rule wider than the one it
+   enforces).
+
+Assertion 2 is the one that tests what W7 created. Assertion 1 alone was
+satisfied by `cmake/board/*.cmake` for every value, before and after the index
+entries existed — measured A/B, identical OK line either way.
+
+`deploy=` resolves as a scope or splits into `<deploy>_*` scopes by board, which
+is how `threadx` is legal: it is a deploy FAMILY, and the `board=` beside it
+selects `threadx_linux` or `threadx_riscv64`. `check-board-alias-unique`
+(phase-435 W5) enforces the same distinction from the descriptor side.
+
+**A silent hole in the doctor surface, found by running the command.**
+`nros setup <board> --check` dropped the board argument: the arm returned before
+the board was ever looked up, so `nros setup not-a-board --check` printed the
+same all-clear as `nros setup threadx-linux --check` and exited 0. The one
+command a user runs to ASK whether a board is provisionable answered yes for a
+name that is not a board — while the same typo without `--check` was a clear
+error listing the known boards. The board is validated now, and the notice says
+what `--check` actually covered rather than implying the board narrowed it (it
+walks `[system.*]`/`[rust.*]`/`[python.*]`, a different axis from a board's
+package set; narrowing that is a doctor redesign, not this fix).
+
+**Still open:** true unification — picking one canonical spelling and renaming
+through 90+ package.xml files. The index namespace is what USERS type, the
+cmake namespace is what the BUILD uses, and the mirrored pairs are the cost of
+deferring: two entries that a gate now keeps identical rather than one entry
+with an alias key.
 
 ### W8 — refuse a wrong-role dependency — DONE (scoped to `infra`)
 

--- a/packages/cli/nros-cli-core/src/cmd/setup.rs
+++ b/packages/cli/nros-cli-core/src/cmd/setup.rs
@@ -265,6 +265,26 @@ pub fn run(args: Args) -> Result<()> {
         return run_check_tool(&index, args.tool.as_deref().unwrap());
     }
     if args.check {
+        // phase-422 W7 — a BOARD given here must still resolve, even though the
+        // walk below is class-wide and the board does not narrow it.
+        //
+        // Measured: `nros setup not-a-board --check` printed the same
+        // everything-is-fine report as `nros setup threadx-linux --check` and
+        // exited 0, because this arm returned before the board was ever looked
+        // up. So the one command a user runs to ASK whether their board is
+        // provisionable answered yes for a name that is not a board — and W7's
+        // whole subject is that `board=` values resolve. Without `--check` the
+        // same typo is a clear error listing the known boards; the doctor
+        // surface was the one that could not tell.
+        //
+        // The walk itself is deliberately NOT narrowed: `--check` alone probes
+        // `[system.*]`, `[rust.*]` and `[python.*]`, which is a different axis
+        // from a board's `[tool.*]`/`[source.*]` package set. Narrowing it is a
+        // redesign of the doctor, not a fix for the silent typo, so the report
+        // says what it covered instead of implying the board scoped it.
+        if let Some(notice) = check_board_argument(&index, args.board.as_deref())? {
+            eprintln!("{notice}");
+        }
         return run_check_all(&index);
     }
 
@@ -1209,6 +1229,26 @@ fn describe(action: &InstallAction, version: &str, host: &str) -> String {
             format!("UNAVAILABLE {version} (no prebuilt for {host}, no source)")
         }
     }
+}
+
+/// A `--check` that was GIVEN a board must still resolve it — phase-422 W7.
+///
+/// Returns the notice to print, or `None` when no board was named. Split out of
+/// `run` so the contract has a test at all — but be precise about what that
+/// buys: the DEFECT was dispatch order (the `--check` arm returned before the
+/// board was ever looked up), and a unit test on this function cannot see
+/// dispatch order. It binds the rule; the single call site above is what makes
+/// the rule reachable, and only running the binary proves that.
+fn check_board_argument(index: &SdkIndex, board: Option<&str>) -> Result<Option<String>> {
+    let Some(board) = board else {
+        return Ok(None);
+    };
+    resolve_packages(index, board)?;
+    Ok(Some(format!(
+        "nros setup: board '{board}' resolves. --check walks the \
+         [system.*]/[rust.*]/[python.*] classes, which the board does not \
+         narrow; use `nros setup {board}` to see its package set."
+    )))
 }
 
 /// Resolve a board to its SDK package set from the index `[board.*]` table — the
@@ -2463,6 +2503,41 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unknown board") && err.contains("native"));
+    }
+
+    #[test]
+    fn check_validates_a_board_argument_it_does_not_otherwise_use() {
+        // phase-422 W7. `--check` walks the `[system.*]`/`[rust.*]`/`[python.*]`
+        // classes and a board does not narrow that, so the board argument used
+        // to be dropped on the floor: `nros setup not-a-board --check` printed
+        // the same all-clear as `nros setup native --check` and exited 0. The
+        // one command a user runs to ASK whether a board is provisionable
+        // answered yes for a name that is not a board.
+        //
+        // This test binds the RULE, not the dispatch order that broke it —
+        // see the note on `check_board_argument`.
+        let idx = SdkIndex::parse(
+            "[tool.zenohd]\nversion=\"1\"\n[board.native]\npackages=[\"zenohd\"]\n",
+        )
+        .unwrap();
+
+        // No board named: nothing to validate, nothing to say.
+        assert!(check_board_argument(&idx, None).unwrap().is_none());
+
+        // A real board resolves, and the notice says what --check actually
+        // covered rather than implying the board scoped it.
+        let notice = check_board_argument(&idx, Some("native")).unwrap().unwrap();
+        assert!(notice.contains("native") && notice.contains("does not"));
+
+        // The regression itself: an unknown board must be an ERROR here, not a
+        // pass, and must still list what is known.
+        let err = check_board_argument(&idx, Some("not-a-board"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("unknown board") && err.contains("native"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/scripts/check-board-vocabulary.py
+++ b/scripts/check-board-vocabulary.py
@@ -7,10 +7,16 @@ a provisioning command. That only works if the values mean something.
 
 WHAT THE VALUES ACTUALLY MEAN, measured rather than assumed. `board=` is the
 CMAKE BOARD vocabulary: all five values across `examples/` resolve to a
-`cmake/board/nano-ros-board-<name>.cmake` file. They are NOT `[board.*]` index
-keys — only `threadx-linux` is one, so `nros setup <board>` would fail for four
-of five. That mismatch is real and is why `nros setup --workspace` validates
-before printing a command.
+`cmake/board/nano-ros-board-<name>.cmake` file.
+
+They used to resolve to NOTHING ELSE. When this gate was written only
+`threadx-linux` was also an index key, so `nros setup <board>` failed for four
+of five and `nros setup --workspace` had to validate before printing a command.
+W7's additive half closed that: `mps2-an385-freertos`, `nuttx-qemu-arm`,
+`nuttx-qemu-riscv` and `riscv64-qemu` are `[board.*]` entries now, each marked
+`# = [board.<other-spelling>]` against the entry it duplicates. All five values
+resolve in BOTH namespaces, which is what lets the second assertion below —
+`board=` must be an index key — be enforced rather than aspired to.
 
 Five namespaces exist for closely related concepts, overlapping partially:
 
@@ -96,8 +102,12 @@ def fixture_boards(root):
 def cmake_boards(root):
     """Boards defined by `cmake/board/nano-ros-board-<name>.cmake`.
 
-    This is what `board=` in a package.xml export actually names — all five
-    values in this repo resolve here, and only one of them is an index key.
+    This is what `board=` in a package.xml export actually names, and all five
+    values in this repo resolve here. They are ALSO index keys now (W7's
+    additive half); this namespace stays in the OR because it is the one the
+    BUILD uses, and a value that resolved only here would still be a real board
+    — just not a provisionable one, which the stricter check below reports
+    separately.
     """
     d = os.path.join(root, "cmake", "board")
     try:


### PR DESCRIPTION
W3's gate and two of its three conversions landed earlier. This is the third — the one the wave's own text called out.

`colcon-parity` ran on bare `ubuntu-22.04`, adding the ROS apt repository and installing **ten packages plus `just`** on every run. Meanwhile `images.yml` has been building `ghcr.io/newslabntu/nano-ros-ci:humble` and describing it, in its own workflow, as the base `container:` for these lanes. Only `nightly.yml` and the `check` job used it.

## Measured before converting, not assumed

The image is `FROM ros:humble-ros-base`, and every one of the ten apt names is already in **that upstream base** — checked with `dpkg -s` inside `ros:humble-ros-base` itself, so the answer doesn't depend on which build of our image is published:

| | |
|---|---|
| `python3-colcon-common-extensions` | `ros-humble-rosidl-default-generators` |
| `ros-humble-ros-base` | `ros-humble-rosidl-default-runtime` |
| `ros-humble-rclcpp` | `ros-humble-ament-cmake` |
| `ros-humble-std-msgs` | `ros-humble-ament-cmake-auto` |
| `ros-humble-geometry-msgs` | `colcon` on PATH |
| `ros-humble-sensor-msgs` | |

`just` is baked and **pinned** by the image (`JUST_VERSION`) — strictly stronger than the `curl \| sh` it replaces, which fetched whatever was current at run time (the floating half of the drift axis `docs/development/ci-image-provisioning.md` describes).

Then `just colcon-parity` was **run** in the image rather than reasoned about: 3 packages finished, consumer binary produced, **7.63 s**.

The apt-repo step goes with the rest, and its documented exception expires cleanly: `gnupg`/`lsb-release` were left literal because RFC-0062's providers cannot express *"add this apt repository first"* — true, and moot once nothing adds a repository. The image's ROS comes from its own base layer.

## The fail-open the conversion had to close

`just colcon-parity` **skips** when `colcon` is absent (`nros_check_skip`, exit 0). Right for a developer host, wrong for a job that exists to run it: an image that lost ROS would report green over nothing — the shape issues 0650 and 1001 are about. The lane now asserts the precondition its container is supposed to provide, so a skip cannot stand in for a pass.

## What W3 still does not cover, said plainly

`check-workflow-indexed-apt` compares **apt** names. `python3-colcon-common-extensions` is the apt spelling of `[python.colcon]`, whose row says `pip = "colcon-common-extensions"` — so an indexed *python-layer* tool restated as an apt package is invisible to it. That is W3's own asymmetry, one namespace over. Deriving the apt name from the pip name is a Debian naming convention rather than something the index states, so no rule is written for it; the site that would have tripped it is gone, and the gap is recorded in the phase doc so the next one is recognised rather than rediscovered.

Grepping every workflow for `apt-get install` now returns **three sites and not one literal package name** — all three resolve through `scripts/sdk/prereq-packages.py`.

`just check fast`: 258/258. `check-workflow-indexed-apt`: 14 workflows, 40 indexed apt packages, none restated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RY2HiGXquMv4JoXtpJYzHK