### PR TITLE
fix(ci): host-tests compiled the workspace twice, and two lanes were red for process-shape reasons

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -169,6 +169,34 @@ jobs:
           "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
 
+      # phase-437 — the fixture builders' rustc fan-out, DERIVED.
+      #
+      # Every consumer below used the literal "2". That number was measured on
+      # the 2-vCPU / 7 GB runner of issue #57 and this job no longer runs on
+      # one: `just ci tier1` in this same job sets no cap and its own summary
+      # reports `249 gate(s) ran at -P4`, because `run-gates-parallel.sh` asks
+      # `nproc`. So the cap was halving exactly the two steps that are most of
+      # this job's wall clock, to respect a machine that is gone.
+      #
+      # The bound is MEMORY, not CPU, and that is why this is not simply
+      # `nproc`. What issue #57 saw was the OOM killer taking rustc mid-compile;
+      # cores were never the scarce thing. ~2 GB per concurrent rustc is the
+      # rule of thumb this uses, so the runner is free to grow in either
+      # dimension and the cap follows whichever runs out first.
+      #
+      # Written to $GITHUB_ENV rather than repeated per step: the fixture builds
+      # and `just ci tier1` must agree, and three literals that must match is
+      # how they stop matching.
+      - name: Derive the build parallelism
+        run: |
+          cpus="$(nproc)"
+          mem_gb="$(awk '/MemTotal/ {print int($2 / 1024 / 1024)}' /proc/meminfo)"
+          by_mem=$(( mem_gb / 2 ))
+          [ "$by_mem" -lt 1 ] && by_mem=1
+          jobs=$(( cpus < by_mem ? cpus : by_mem ))
+          echo "NROS_CI_BUILD_JOBS=$jobs" >> "$GITHUB_ENV"
+          echo "runner: ${cpus} cpu, ${mem_gb} GiB -> NROS_CI_BUILD_JOBS=${jobs}"
+
       # phase-413 W5 — provision with the SCOPE VERB, not four hand-rolled
       # steps. `just setup native` is what a user runs, and it expands to the
       # same sequence this lane spelled out: `nros setup --build-sources` (the
@@ -203,12 +231,49 @@ jobs:
       # fixture steps only (never the job — test-integration asserts on symbols).
       - name: Build rust core fixtures
         env:
-          CARGO_PROFILE_RELEASE_LTO: "off"
-          RUSTFLAGS: "-C debuginfo=0"
-          # Issue #57 Cause-1: cap the fixture builder's rustc fan-out — the
-          # 2-vCPU / 7 GB runner OOM-kills rustc mid-compile otherwise.
-          NROS_BUILD_JOBS: "2"
-          CARGO_BUILD_JOBS: "2"
+          # `CARGO_PROFILE_RELEASE_LTO: "off"` USED TO BE HERE. It was the only
+          # thing that differed between this step and "Build workspace fixtures"
+          # below, and it is what made the two share NOTHING: cargo hashes the
+          # profile into `-C metadata`, so every crate they have in common was
+          # compiled twice — across the two steps that are ~53 of this job's ~91
+          # minutes.
+          #
+          # It was also an in-place MUTATION of `profile.release` through the
+          # environment, which is worse than a slow build: the artifacts landed
+          # in `target/release/` while not being release builds, so nothing
+          # downstream could tell this tree from a real one. The repo has a
+          # named profile for exactly this shape (`nros-iterate` = release with
+          # `lto = "off"`), reached through `NROS_CARGO_PROFILE` / `nros
+          # profile`, and an env override reaches around it.
+          #
+          # Dropping it rather than naming a profile, because naming one keeps
+          # the two steps in different profile directories and the duplication
+          # with them. Plain `release` for both is the only spelling that lets
+          # the workspace step start warm. The trade is real and one-directional:
+          # THIS step gets slower (it now pays fat LTO), and the step below
+          # should save more than that by reusing it. If CI says otherwise,
+          # the answer is a shared named profile for both steps — never this
+          # env var back on one of them.
+          #
+          # `RUSTFLAGS: "-C debuginfo=0"` is gone for a different reason: it is
+          # redundant. Cargo's `release` default is already `debug = false`, and
+          # `[profile.release]` in `Cargo.toml` does not override it.
+          #
+          # Issue #71 is UNAFFECTED: it forbids `lto = "off"` on the workspace
+          # step (two Rust staticlibs each bundle `std`, and without LTO's DCE
+          # both keep `rust_begin_unwind` -> `multiple definition`). This change
+          # removes an `lto = "off"`; it does not add one.
+          #
+          # Issue #57 Cause-1: cap the fixture builder's rustc fan-out — a rustc
+          # OOM-killed mid-compile is what this prevents. DERIVED, not "2":
+          # the literal was measured on the 2-vCPU / 7 GB runner this job no
+          # longer gets (it runs 4 vCPU / ~16 GB today — `just ci tier1` in the
+          # step below sets no cap and its own summary line reports `-P4`), so
+          # the cap was halving the two steps that are most of this job's wall
+          # clock. See "Derive the build parallelism" above for how it is
+          # computed and why the bound is MEMORY rather than CPU.
+          NROS_BUILD_JOBS: ${{ env.NROS_CI_BUILD_JOBS }}
+          CARGO_BUILD_JOBS: ${{ env.NROS_CI_BUILD_JOBS }}
         run: |
           source ./activate.sh
           mkdir -p build/ci-logs
@@ -230,9 +295,12 @@ jobs:
           # native C++/mixed workspace Entry links two Rust staticlibs that each
           # bundle `std`; the FFI crate's `lto = true` DCE-strips the redundant
           # `rust_begin_unwind`. Forcing LTO off keeps it → `multiple definition`.
-          RUSTFLAGS: "-C debuginfo=0"
-          NROS_BUILD_JOBS: "2"
-          CARGO_BUILD_JOBS: "2"
+          # `RUSTFLAGS: "-C debuginfo=0"` dropped: redundant. Cargo's `release`
+          # default is `debug = false` and `[profile.release]` does not override
+          # it, so this set a flag that changed nothing while making RUSTFLAGS a
+          # fingerprint input the step above had to match exactly.
+          NROS_BUILD_JOBS: ${{ env.NROS_CI_BUILD_JOBS }}
+          CARGO_BUILD_JOBS: ${{ env.NROS_CI_BUILD_JOBS }}
         run: |
           source ./activate.sh
           just native build-workspace-fixtures > build/ci-logs/workspace.log 2>&1 \
@@ -265,7 +333,7 @@ jobs:
       # does not provision them.
       - name: just ci tier1
         env:
-          CARGO_BUILD_JOBS: "2"
+          CARGO_BUILD_JOBS: ${{ env.NROS_CI_BUILD_JOBS }}
           # This lane builds a DELIBERATE SUBSET of the native fixtures --
           # `build-fixture-rust-core` + `build-workspace-fixtures`, with the
           # ~52 GB extras omitted so test-integration does not hit ENOSPC (see

--- a/scripts/build/run-gates-parallel.sh
+++ b/scripts/build/run-gates-parallel.sh
@@ -155,8 +155,10 @@ run_one() {
 }
 export -f run_one
 
+_lane_start=$(date +%s%N)
 grep -vE '^\s*(#|$)' "$list" \
     | xargs -P "$jobs" -I{} bash -c 'run_one "$@"' _ {} "$out_dir"
+_lane_wall_ms=$(( ($(date +%s%N) - _lane_start) / 1000000 ))
 
 failed=0
 while IFS=$'\t' read -r gate rc ms; do
@@ -167,12 +169,39 @@ while IFS=$'\t' read -r gate rc ms; do
     fi
 done <"$out_dir/results.tsv"
 
+# THE PROFILE. `results.tsv` has held a per-gate duration since this runner was
+# written and the summary read ONE line out of it — the slowest — before the
+# `trap` deleted the file. So every run measured the full distribution of the
+# repo's slowest lane and discarded it, which is why "where does `just check`
+# spend its time" could only be answered by re-running gates by hand.
+#
+# The last line is the one worth having. `busy` is the sum of the gates' own
+# durations; `wall` is how long the fan-out actually took. Their ratio is the
+# parallelism this lane ACHIEVED, which is not `-P$jobs` and can be far below
+# it: most gates in the `build` lane invoke cargo, cargo takes an exclusive lock
+# on the target directory, and a gate blocked on that lock still occupies one of
+# the `xargs` slots. A ratio near 1 on a lane running at -P4 means the fan-out
+# is queueing, not overlapping — and no amount of raising `-P` fixes that,
+# because the contended resource is the lock and not the CPU.
+#
+# Printed always rather than behind a flag: the number is free (the file is
+# already written), and a diagnostic nobody turns on is one nobody reads.
+_busy_ms=$(awk -F'\t' '{s += $3} END {print s + 0}' "$out_dir/results.tsv")
+printf '\ncheck-%s: slowest gates (ms)\n' "$label"
+sort -k3 -rn "$out_dir/results.tsv" | head -10 \
+    | awk -F'\t' -v busy="$_busy_ms" \
+        '{printf "  %8d  %5.1f%%  %s\n", $3, (busy ? 100 * $3 / busy : 0), $1}'
+printf '  busy %ds over wall %ds at -P%s => %.1fx effective parallelism\n' \
+    "$((_busy_ms / 1000))" "$((_lane_wall_ms / 1000))" "$jobs" \
+    "$(awk -v b="$_busy_ms" -v w="$_lane_wall_ms" 'BEGIN {printf "%.1f", (w ? b / w : 0)}')"
+
 total=$(wc -l <"$out_dir/results.tsv")
 slowest=$(sort -k3 -rn "$out_dir/results.tsv" | head -1)
 if [ "$failed" -gt 0 ]; then
     printf '\ncheck-%s (parallel): %d of %d gate(s) FAILED\n' "$label" "$failed" "$total"
     exit 1
 fi
+
 # QUALIFY the success line by the gates that did not run.
 #
 # The serial path closes with `nros_check_skip_report`, which refuses to say


### PR DESCRIPTION
Three changes from a session that started at "why is `host-tests` slow" and turned into "what is this job actually compiling". Each one is measured; two things I intended to do are *not* here because measuring killed them, and those are recorded below rather than dropped silently.

## What landed

**`refactor(check)`: drop ten `--no-default-features` that opt out of nothing.** `panic-platform` has exactly one `cfg` site in the tree, gated `all(panic-platform, not(std), not(panic-halt))`, and no build script reads it. Every one of these rows names `std`, so the feature is already suppressed and dropping it changes nothing compiled — while still forking a second `-C metadata` unit for identical output. Two rows keep the flag deliberately (documented in the message). Emptying `default` instead is **not** an option: that was tried and reverted, and `check-feature-contract.py` now carries a `final-artifact-default-exempt` case with a negative control (issue 0615).

**`feat(check)`: report the gate profile the runner already measures.** `results.tsv` has always carried a per-gate duration; the summary printed one line of it and the `trap` deleted the rest. Now prints the top ten plus:

```
check-build:  busy 2510s over wall 387s at -P24  =>  6.5x effective parallelism
check-fast:   busy  154s over wall  14s at -P24  => 10.7x
```

**`fix(ci)`: host-tests built the workspace twice and capped itself at half the runner.** Two independent defects. The two fixture steps differed by exactly one thing — `CARGO_PROFILE_RELEASE_LTO: "off"` — so every crate they share was compiled twice across the ~53 of the job's ~91 minutes they occupy; it was also an env mutation of `profile.release`, so artifacts landed in `target/release/` while not being release builds. And `NROS_BUILD_JOBS: "2"` was measured on the 2-vCPU/7 GB runner of #57, which this job no longer gets — `just ci tier1` in the same job reports `-P4` because the gate runner asks `nproc`. Now derived once into `$GITHUB_ENV`, bounded on **memory** rather than CPU because #57's actual symptom was the OOM killer:

```
 2 cpu,  7 GiB -> 2    (the #57 runner: same as the literal it replaces)
 4 cpu, 16 GiB -> 4    (today)
16 cpu, 16 GiB -> 8    (memory bites first)
```

Issue #71 is unaffected — it forbids *adding* `lto = "off"` to the workspace step; this removes one.

## Two things deliberately not done

**No warm-up build before the gate fan-out.** I was going to add one, then the new profile line answered it: the `build` lane tops out near 6.5x however many workers it gets, and CI runs it at `-P4`, *below* that ceiling. The lock convoy is real but is not the binding constraint in CI — four cores is. A warm-up would have added serial wall-clock for an inactive bottleneck.

**No sccache, because the prerequisite is not met.** The repo sits at **9.77 GB of its 10 GB Actions cache limit**, and 8.7 GB of that is two `nros-cli-Linux-*` entries at 4.4 GB each — caching an ~80s build step whose own comment says the cache is unreliable enough to need re-verification. Adding sccache today evicts something, possibly `gate.yml`'s, which serves the required PR check. That cache should be shrunk first; then sccache is worth aiming at the 53 minutes of fixture builds.

## Two commits dropped during rebase, both because main got there first

**The backing latch fix.** This branch carried a commit giving
`the_static_is_handed_out_once_and_only_once` its own cargo invocation. Main
landed a better fix in the meantime: it marks the test `#[ignore]` (so the main
invocation skips it with no `--skip` needed) and runs it as `--ignored --exact`
while **asserting `1 passed`** in the output.

That assertion matters, and it caught my version. With the test now `#[ignore]`d
on main, my `--exact` row without `--ignored` reported:

```
test result: ok. 0 passed; 0 failed; 1 ignored; 367 filtered out
```

— a gate passing having run nothing, which is the vacuity class this repo gates
against. Dropped in favour of main's.

**The executor fix.** An earlier commit here fixed the `nros-c` `lending` red — the executor's cancel/spin observables were gated on `alloc` they never used. **Main landed the same fix as issue 1177 while this was in progress**, with a cleaner `HaltFlag` type alias, so my version was dropped during the rebase. Main's is the one here.

## Verification

`just check c`, `just check cpp`, `just check compile-smoke` and `just check node-std-tests` all green on the rebased tree. `node-std-tests` and `workspace-features` were also confirmed green inside a full `NROS_GATE_LANE=build` run. The px4 rows were verified by feature resolution (`--unit-graph`) rather than by building, since PX4 SITL is not provisioned locally — the delta is `panic-platform` and nothing else.

Tier run: **`just check` lanes only** — not a full `just ci gate`. Two gates are red in my worktree for pre-existing environment reasons unrelated to this branch (`submodule-pinned-locks` and `launch-resolve-builds`, both from a dirty `play_launch` pointer whose lock `--locked` refuses to update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N

