### PR TITLE
docs(phase-436): the poll/wake revision — a deadline-driven, platform-agnostic executor

### DIFF
--- a/docs/issues/1192-executor-wait-ignores-next-timer-deadline.md
+++ b/docs/issues/1192-executor-wait-ignores-next-timer-deadline.md
@@ -1,0 +1,75 @@
+---
+id: 1192
+title: "The executor's blocking wait is not bounded by the next timer deadline, so it sleeps past a deadline it owns"
+status: open
+type: bug
+area: executor
+related: [issue-0505, issue-0515, phase-436]
+---
+
+## Problem
+
+`spin_once` bounds its blocking wait by two things and only two: the caller's
+`timeout`, and `session.next_deadline_ms()` — the *backend's* next internal
+event (lease keepalive, heartbeat, ACK-NACK).
+
+```rust
+let timeout_ms = match self.session.next_deadline_ms() {
+    Some(next) => timeout_ms.min(next.min(i32::MAX as u32) as i32),
+    None => timeout_ms,
+};
+```
+(`packages/core/nros-node/src/executor/spin.rs:6412`)
+
+Nothing caps it by the next **timer** expiry. Grepping `spin.rs` for any
+next-timer computation — `next_timer`, `earliest`, `until_next`, `next_expiry`,
+`soonest` — returns zero hits.
+
+So the executor's wake set is transport-only, while the one class of deadline
+the executor itself *owns* — its registered timers — cannot shorten the sleep.
+
+## Evidence
+
+`spin_default()` uses a 50 ms timeout (`spin.rs:7361`). Register a 10 ms timer
+under it and the executor blocks up to 50 ms in `NodeWake::wait_ms` (or in the
+transport's `recv`), during which the 10 ms deadline passes unserved. Timers
+are only evaluated in the readiness scan *after* the wait returns, driven by
+the accumulated `delta_us` (`spin.rs:6847`).
+
+The consequence at the callback is then the backlog replay that **issue 0505**
+described and fixed policy for: several activations back to back once the
+executor runs again.
+
+## Why this is not 0505 or 0515
+
+* **0505** (resolved) is the *overrun policy* — what to do about a backlog that
+  has already accumulated. It takes the stall as given.
+* **0515** (resolved) is *grid quantization* — a timer period that is not a
+  multiple of the tier's spin period alternates between two values. Its model
+  is explicitly "a timer fires on the first spin boundary at or after its
+  period elapses", and the fix was a runtime warning naming the two values.
+
+Both accept the spin boundary as fixed and describe what happens around it.
+This issue is that **the boundary should move**: a wait that knows a timer is
+due in 10 ms must not sleep for 50 ms. Fixing it removes the input to 0505's
+backlog and shrinks 0515's grid to the timer's own deadline, without replacing
+either — 0515's warning still catches hand-written loops, and 0505's policy
+still governs a genuine preemption stall.
+
+## Fix direction
+
+Compute the wait as `min(caller timeout, next timer expiry, next_deadline_ms)`.
+The timer headers are already walked once per executor in
+`audit_spin_quantization` (`spin.rs:2340`), so the traversal exists; it needs to
+become a per-spin `min` over `period_us - elapsed_us` for live timer entries.
+
+Two constraints on the fix:
+
+* It must not turn a long idle wait into a poll. With no timers registered the
+  bound is absent and the caller's timeout stands, unchanged.
+* The result is what makes the wait **analyzable**: the wake time becomes
+  `min` over a set of declared deadlines rather than an arbitrary caller
+  constant, which is the property a schedulability argument needs.
+
+See also issue 1193 — the bound cannot be expressed below 1 ms today, so a
+sub-millisecond timer deadline is unrepresentable even once this is fixed.

--- a/docs/issues/1193-spin-timeout-truncates-to-milliseconds.md
+++ b/docs/issues/1193-spin-timeout-truncates-to-milliseconds.md
@@ -1,0 +1,76 @@
+---
+id: 1193
+title: "A sub-millisecond spin timeout truncates to zero and silently becomes a busy loop"
+status: open
+type: bug
+area: executor
+related: [issue-0515, issue-1192, issue-1194, phase-436]
+---
+
+## Problem
+
+`spin_once` converts the caller's `Duration` with `as_millis()`, which
+**truncates**:
+
+```rust
+pub fn spin_once(&mut self, timeout: core::time::Duration) -> SpinOnceResult {
+    let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+```
+(`packages/core/nros-node/src/executor/spin.rs:6374`)
+
+`Duration::from_micros(500).as_millis()` is `0`. A zero `timeout_ms` selects
+the non-blocking path — `primary_drive_timeout_ms = 0`, no wake wait — so:
+
+```rust
+executor.spin(core::time::Duration::from_micros(500));
+```
+
+is a **100 % CPU busy loop**, with no error and no warning. `spin()` simply
+loops `spin_once` (`spin.rs:7351`), so nothing throttles it.
+
+The one diagnostic that would have caught it is gated off precisely here:
+
+```rust
+if !self.spin_quantization_checked && timeout_ms > 0 {
+```
+(`spin.rs:6590`) — `audit_spin_quantization` is skipped when `timeout_ms == 0`,
+i.e. exactly in the case where the quantization is total.
+
+This is the same class as issue 0709 (a `spin_period` with no clock would have
+free-run silently), which was fixed by *refusing* rather than degrading. This
+path still degrades.
+
+## Reach across the API surface
+
+Three public spellings, three units, one truncating core:
+
+| API | Unit accepted | Precision reaching the wait |
+|---|---|---|
+| `rclc_executor_spin_period` (C) | **nanoseconds** (`executor.rs:2960`) | ms |
+| `nros::spin_once` (C++) | **milliseconds** (`nros.hpp:88`, `int32_t timeout_ms = 10`) | ms |
+| `Executor::spin_once` (Rust) | `Duration` | ms |
+
+The C API advertises nanosecond resolution and paces itself correctly in ns
+(`invocation_time_ns += period_ns`, `sleep_ns`) — but the value it hands the
+blocking wait is truncated to ms. The C++ API cannot express sub-ms at all.
+
+## Why nothing is broken today
+
+* nros-cpp's tier loops clamp with `period_us.max(1_000)`, so a declared
+  sub-ms tier silently becomes 1 ms rather than a busy loop.
+* ASI's controller declares `spin_period_us = 5000`.
+
+So this is currently a **latent** defect — but `spin_period_us` is a
+microsecond field in `NativeTierSpec`, and it accepts values it cannot honour.
+
+## Fix direction
+
+The floor is the platform layer: all five `nros_platform_wake_wait_ms`
+implementations take `uint32_t timeout_ms` (`packages/platform/*/src/platform.c`),
+so microseconds cannot currently reach the primitive on any target. A real fix
+is a `wake_wait_us` (or `_ns`) slot with the ms one kept as the fallback for
+platforms whose primitive is genuinely ms-granular.
+
+Minimum acceptable interim: **round up, never down**, and refuse or warn on a
+timeout that rounds to zero rather than converting it into a spin. Truncating
+a 1500 us request to 1 ms is a 33 % short wait that no caller asked for.

--- a/docs/issues/1194-jitter-measured-in-microseconds-waited-in-milliseconds.md
+++ b/docs/issues/1194-jitter-measured-in-microseconds-waited-in-milliseconds.md
@@ -1,0 +1,51 @@
+---
+id: 1194
+title: "Release jitter is measured in microseconds against a cadence the executor can only wait in milliseconds"
+status: open
+type: tech-debt
+area: executor
+related: [issue-1193, phase-436]
+---
+
+## Problem
+
+The same quantity is read at two different granularities inside one function.
+
+`record_release_jitter` takes the cadence in **microseconds**:
+
+```rust
+let nominal_us = ... timeout.as_micros().min(u64::MAX as u128) as u64;
+```
+(`packages/core/nros-node/src/executor/spin.rs:2261`)
+
+while the wait that is supposed to realise that cadence takes it in
+**milliseconds**, truncated (`spin.rs:6374`, see issue 1193).
+
+So `spin_once(Duration::from_micros(1500))`:
+
+* is judged against a **1500 us** nominal by `release-jitter-runtime`,
+* but actually waits **1 ms**.
+
+The rule then measures lateness against a period the executor never attempted.
+On a loop that meets its 1 ms wait exactly, the statistic reads as 500 us
+early — or, once the caller's own pacing pushes the interval past 1500 us, as
+lateness that no scheduling decision caused.
+
+## Why it matters beyond tidiness
+
+`release-jitter-runtime` is a **safety monitor**: it exists to say whether a
+tier meets its declared cadence. A monitor whose yardstick and whose mechanism
+disagree by up to a millisecond cannot support that claim. The measurement is
+more precise than the thing being measured, which reads as rigour and is not.
+
+## Fix direction
+
+Bound to issue 1193 — one granularity for the wait and the measurement, chosen
+as the finer of the two. Until the platform wake primitives accept sub-ms
+(1193's fix direction), the honest interim is to record the nominal at the
+granularity actually achievable and say so, rather than reporting µs precision
+the wait cannot deliver.
+
+Do **not** resolve this by coarsening the jitter statistic to ms: 1 ms is
+already the whole budget of a 1 kHz tier, and cyclictest-class numbers are
+reported in µs for that reason.

--- a/docs/issues/1195-promise-wait-polls-instead-of-using-the-waker.md
+++ b/docs/issues/1195-promise-wait-polls-instead-of-using-the-waker.md
@@ -1,0 +1,44 @@
+---
+id: 1195
+title: "`Promise::wait` polls on a fixed 10 ms grid and overshoots timeouts shorter than that"
+status: open
+type: enhancement
+area: executor
+related: [issue-1192, phase-436]
+---
+
+## Problem
+
+`Promise::wait` ignores the wake infrastructure and polls:
+
+```rust
+let spin_interval = core::time::Duration::from_millis(DEFAULT_SPIN_INTERVAL_MS);
+let timeout_ms = timeout.as_millis().min(u64::MAX as u128) as u64;
+let max_spins = (timeout_ms / DEFAULT_SPIN_INTERVAL_MS).max(1);
+```
+(`packages/core/nros-node/src/executor/handles.rs:2328`, with
+`DEFAULT_SPIN_INTERVAL_MS = 10` at `handles.rs:13`)
+
+Two consequences:
+
+1. **Reply latency is quantized to 10 ms** regardless of when the reply lands,
+   on backends that *do* have an async wake source. Cyclone installs a real
+   `dds_set_listener`/`on_data_available` (`vtable.cpp:322`,
+   `session.cpp:105`), so the wake exists and this path does not use it.
+
+2. **A timeout shorter than 10 ms overshoots.** `max_spins` floors at 1, so
+   `wait(Duration::from_millis(1))` still runs one full `spin_once(10ms)` —
+   the caller's 1 ms deadline is exceeded by up to 10x before `WaitBudget`
+   is consulted.
+
+This does not violate the "never blocks forever" property — the loop is
+bounded — but it is the one place in the executor where the waker
+infrastructure exists and is bypassed.
+
+## Fix direction
+
+Spin with `min(remaining_budget, DEFAULT_SPIN_INTERVAL_MS)` so the last
+iteration cannot overshoot the caller's deadline, and let the underlying
+`spin_once` block on the wake primitive rather than returning on a fixed grid.
+The existing `WaitBudget` already tracks the deadline; it is consulted one
+spin too late.

--- a/docs/issues/1196-platform-condvar-wait-is-unbounded.md
+++ b/docs/issues/1196-platform-condvar-wait-is-unbounded.md
@@ -24,11 +24,29 @@ A bounded `nros_platform_condvar_wait_until(cv, m, abstime_ms)` sits directly
 beneath it, and the executor's own wait path correctly uses the *bounded*
 `nros_platform_wake_wait_ms` instead.
 
-## Current exposure: latent, not live
+## Correction (2026-09-07): it HAS callers
 
-Grepping `packages/core/` and `packages/rmw/` for `nros_platform_condvar_wait`
-(excluding generated bindings) returns no callers. Nothing on the executor
-path can block forever today.
+**The original claim here — "no callers" — was wrong, and the error was in the
+grep rather than the reading.** The search run was for
+`nros_platform_cond_wait`; the symbol is `nros_platform_condvar_wait`. The typo
+produced a clean false negative, and this issue was filed calling a live call
+site latent. Phase-436 W5's gate found the real callers on its first run:
+
+```
+packages/rmw/zenoh/zpico-sys/c/zpico/platform_aliases.c:302  _z_condvar_wait
+packages/rmw/zenoh/zpico-sys/c/zpico/platform_aliases.c:320  _z_condvar_wait_until, NULL deadline
+```
+
+Both are **correct as written**, which is why this stays an issue about the API
+rather than becoming a bug about those lines. `_z_condvar_wait` is zenoh-pico's
+own primitive and its contract is an unbounded wait; mapping an unbounded
+upstream call onto the unbounded platform call is the honest bridge, and
+narrowing it there would silently change zenoh-pico's semantics. The `_until`
+variant falls back only when handed a NULL deadline.
+
+The accurate statement: the executor's **own** wait path is bounded
+(`nros_platform_wake_wait_ms`), and the unbounded primitive is reached only
+through a shim implementing an upstream API that is itself unbounded.
 
 ## Why file it anyway
 
@@ -48,8 +66,15 @@ recursive mutexes route through `xQueueSemaphoreTake` → `xTaskPriorityInherit`
 recursive mutexes are a common priority-inheritance exception; here they are
 not one.
 
-## Fix direction
+## Fix direction — DONE in phase-436 W5
 
-Either delete `nros_platform_condvar_wait` in favour of the `_until` variant,
-or keep it and mark it non-RT in `include/nros/platform.h` with the reason —
-so that choosing it is a decision someone made, not a spelling someone picked.
+Deleting the symbol was rejected: it is exported, out-of-tree ports link it,
+and one in-tree caller legitimately needs unbounded semantics.
+
+1. `include/nros/platform.h` marks it **NOT REAL-TIME — this wait is
+   UNBOUNDED**, names the bounded alternatives, and says why it was kept.
+2. `scripts/check-no-unbounded-condvar-wait.sh` confines it to the zenoh-pico
+   alias shim **by path**. A call site anywhere else fails the gate and has to
+   be argued for, rather than inheriting a blanket allowance.
+
+Verified by adding a call outside the shim and watching the gate reject it.

--- a/docs/issues/1196-platform-condvar-wait-is-unbounded.md
+++ b/docs/issues/1196-platform-condvar-wait-is-unbounded.md
@@ -1,0 +1,55 @@
+---
+id: 1196
+title: "`nros_platform_condvar_wait` blocks forever by construction, beside a bounded variant nothing forces you to prefer"
+status: open
+type: tech-debt
+area: platform
+related: [issue-1192, phase-436]
+---
+
+## Problem
+
+The platform API exposes an unbounded condvar wait on every RTOS port:
+
+```c
+int8_t nros_platform_condvar_wait(void *cv, void *m) {
+    if (cv == NULL || m == NULL) return -1;
+    nros_platform_mutex_unlock(m);
+    UINT rc = tx_semaphore_get((TX_SEMAPHORE *) cv, TX_WAIT_FOREVER);
+```
+(`packages/platform/nros-platform-threadx/src/platform.c:683`; the FreeRTOS and
+ESP-IDF ports use `portMAX_DELAY` at `platform.c:702` and `platform.c:423`)
+
+A bounded `nros_platform_condvar_wait_until(cv, m, abstime_ms)` sits directly
+beneath it, and the executor's own wait path correctly uses the *bounded*
+`nros_platform_wake_wait_ms` instead.
+
+## Current exposure: latent, not live
+
+Grepping `packages/core/` and `packages/rmw/` for `nros_platform_condvar_wait`
+(excluding generated bindings) returns no callers. Nothing on the executor
+path can block forever today.
+
+## Why file it anyway
+
+nano-ros claims real-time properties, and "no unbounded wait" is only a
+property of the system if it is a property of the **API**, not of the current
+call graph. An unbounded primitive sitting in the platform header with a
+neutral name is an invitation: the next port, or the next backend, reaches for
+`condvar_wait` because it is the obvious spelling, and the bound is lost
+silently and without review.
+
+The mutex waits in the same files (`K_FOREVER`, `portMAX_DELAY`,
+`TX_WAIT_FOREVER`) are **not** part of this issue — those are short critical
+sections and all three ports have priority inheritance: ThreadX creates with
+`TX_INHERIT` (`platform.c:611`), Zephyr's `k_mutex` inherits, and FreeRTOS
+recursive mutexes route through `xQueueSemaphoreTake` → `xTaskPriorityInherit`
+(`third-party/freertos/kernel/queue.c:1791`). That was checked because
+recursive mutexes are a common priority-inheritance exception; here they are
+not one.
+
+## Fix direction
+
+Either delete `nros_platform_condvar_wait` in favour of the `_until` variant,
+or keep it and mark it non-RT in `include/nros/platform.h` with the reason —
+so that choosing it is a decision someone made, not a spelling someone picked.

--- a/docs/issues/1242-park-granularity-is-hardcoded-not-queried.md
+++ b/docs/issues/1242-park-granularity-is-hardcoded-not-queried.md
@@ -1,0 +1,94 @@
+---
+id: 1242
+title: "`park_granularity_us()` is a hardcoded 1 ms — wrong high on ThreadX, wrong low on POSIX, and never asks the primitive"
+status: open
+type: bug
+area: executor
+related: [issue-1193, issue-1194, phase-436]
+---
+
+## Problem
+
+phase-436 W2 introduced `park_granularity_us()` so the executor could state
+what park it can actually express, and W3 built the jitter-granularity report
+on top of it. It is a constant:
+
+```rust
+pub fn park_granularity_us(&self) -> u64 {
+    // 1 ms — the granularity of `nros_platform_wake_wait_ms`.
+    1_000
+}
+```
+(`packages/core/nros-node/src/executor/spin.rs`)
+
+The justification given was that every `nros_platform_wake_*` port takes
+`uint32_t timeout_ms`, so one millisecond is the floor everywhere. **That
+reasoning is wrong in both directions, and the constant never consults the
+primitive actually installed.**
+
+## Wrong high — ThreadX
+
+The ABI signature is not the only limit; the RTOS tick is a second, coarser
+one. ThreadX converts to ticks:
+
+```c
+ULONG tps = TX_TIMER_TICKS_PER_SECOND;
+ticks = (ULONG)(((uint64_t) timeout_ms * tps + 999u) / 1000u);
+```
+(`packages/platform/nros-platform-threadx/src/platform.c:729-746`)
+
+and both shipped board configs pin `TX_TIMER_TICKS_PER_SECOND = 100`
+(`nros-board-threadx-linux/config/tx_user.h:11`,
+`nros-board-threadx-qemu-riscv64/config/tx_user.h:11`) — a **10 ms** tick.
+
+So on ThreadX the executor reports a 1 ms park as achievable when the platform
+can only deliver 10 ms, and `release_jitter_granularity_us()` inherits that
+over-claim. This is exactly the failure W3 exists to prevent — *a measurement
+claiming precision its mechanism cannot deliver* — reproduced one layer below
+W3 by W3's own dependency.
+
+FreeRTOS by contrast pins `configTICK_RATE_HZ = 1000`, so 1 ms is correct
+there. The constant is right for one RTOS by coincidence.
+
+## Wrong low — POSIX and NuttX
+
+The POSIX primitive is already nanosecond-native: `pthread_cond_timedwait`
+against a `struct timespec` on Apple, `sem_timedwait` against a `struct
+timespec` elsewhere — and the `#else` branch is also the NuttX port, since
+`nros-platform-nuttx/CMakeLists.txt` compiles
+`../nros-platform-posix/src/platform.c` verbatim.
+
+The millisecond floor there is **purely the exported signature**
+(`uint32_t timeout_ms`), not the primitive. A microsecond park needs a unit
+change, not a new mechanism.
+
+## The mechanism defect underneath
+
+`park_granularity_us()` does not look at `park_primitive` at all. So a port
+that installs a genuinely microsecond-capable `ParkUntilFn` through the
+phase-436 W6 seam **still cannot produce a sub-millisecond park**: the
+requested bound is rounded up to 1 ms by `round_park_up_us` before the
+primitive is ever called.
+
+The seam was built to let a platform contribute its own waiting, and this
+constant silently overrides what the platform can do — in both directions.
+
+## Fix direction
+
+1. Make the granularity a property of the installed primitive, not a constant:
+   either a third field alongside `set_park_primitive(park, ctx)` or a probe
+   the port supplies. With no primitive installed, fall back to the current
+   1 ms — that is the honest floor for the `wake_wait_ms` ABI.
+2. ThreadX must report its tick, not the ABI unit. `TX_TIMER_TICKS_PER_SECOND`
+   is a compile-time constant, so the port can state it exactly.
+3. Only then is issue 1193's µs path meaningful end to end: today µs is carried
+   through the core (W2) and thrown away at the boundary.
+
+Do **not** fix this by lowering the constant. A constant cannot be right for a
+1 ms FreeRTOS tick, a 10 ms ThreadX tick and a nanosecond POSIX timespec at the
+same time, which is the whole point.
+
+## Evidence
+
+Found by parallel port surveys during phase-436 W6, verified against the
+sources cited above rather than inferred from the ABI.

--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -1,12 +1,26 @@
 # Phase 436 — The poll/wake revision: a deadline-driven, platform-agnostic executor
 
-**Status (2026-09-07). OPEN, design stated, no work item started.** Opened from
-a review of the executor and the `spin*()` API surface against four properties:
-platform-agnostic core, per-platform wake sources, analyzable real-time bounds,
-no busy waiting. Three of the four are close to met; the fourth — analyzable
-bounds — is not, and the reason is a single modelling choice this phase
-reverses. Five issues were filed from the same review (1192–1196) and are this
-phase's work items.
+**Status (2026-09-07). ALL FIVE WORK ITEMS IMPLEMENTED.** W1–W5 landed
+test-first; the executor now computes a park deadline rather than accepting a
+timeout. Two things the work changed about the phase as written:
+
+* **W5's issue was wrong about its own evidence.** Issue 1196 said the
+  unbounded `condvar_wait` had no callers. It has two — the grep that produced
+  that claim searched `nros_platform_cond_wait`, and the symbol is
+  `nros_platform_condvar_wait`. W5's gate found them on its first run. Both are
+  correct as written (they bridge zenoh-pico's own unbounded primitive), so the
+  fix became "confine by path and mark the header" rather than "delete".
+* **The `wake_wait_ns` platform slot was NOT built.** Adding a required symbol
+  to five ports buys less than the rounding contract does: carrying µs through
+  the core and rounding UP at the boundary fixes issue 1193's actual harm — the
+  truncation to zero, and the 33 % short wait — without making every port grow
+  a slot. A port that gains a finer primitive can lower `park_granularity_us()`
+  and nothing above it changes. §1 below describes the ns slot as the eventual
+  shape; it is deferred, not done.
+
+Also unbuilt, and deliberately: making the wait loops in `handles.rs` wake off
+the backend's listener rather than a fixed grid. W4 fixes the overshoot half of
+issue 1195; the waker half is the larger change and stays open.
 
 ## The one change this phase is about
 

--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -1,0 +1,267 @@
+# Phase 436 — The poll/wake revision: a deadline-driven, platform-agnostic executor
+
+**Status (2026-09-07). OPEN, design stated, no work item started.** Opened from
+a review of the executor and the `spin*()` API surface against four properties:
+platform-agnostic core, per-platform wake sources, analyzable real-time bounds,
+no busy waiting. Three of the four are close to met; the fourth — analyzable
+bounds — is not, and the reason is a single modelling choice this phase
+reverses. Five issues were filed from the same review (1192–1196) and are this
+phase's work items.
+
+## The one change this phase is about
+
+Today the executor asks:
+
+> **How long am I allowed to block?**
+
+The answer comes from one place — the caller's `timeout` argument — and is then
+narrowed by exactly one other input, `session.next_deadline_ms()`.
+
+It should ask:
+
+> **When is the next thing I owe anybody?**
+
+The answer is a `min` over a set of *declared deadlines*, of which the caller's
+budget is only one member. That is the whole design. Everything below is a
+consequence:
+
+* a timer deadline can shorten the sleep (issue 1192),
+* the wake time is a function of declared periods rather than an arbitrary
+  caller constant, so it is **analyzable** — you can enumerate the sources and
+  their periods without running anything,
+* the bare-metal case stops being a degraded mode and becomes the same
+  mechanism with a smaller source set,
+* "no busy wait" becomes structural rather than incidental: there is always a
+  deadline to park until, even when it is far away.
+
+## What is already right, and must not be rebuilt
+
+The review found the wake machinery in good shape. This phase extends it; it
+does not replace it.
+
+* **`NodeWake` is already a platform-agnostic waker.** `nros_platform_wake_{wait_ms,signal,signal_from_isr}`
+  is implemented on five ports — Zephyr (`k_sem_take`/`k_sem_give`), ThreadX
+  (`tx_semaphore_get`), FreeRTOS, POSIX, ESP-IDF — each with an **ISR-safe**
+  signal variant. The core never names an RTOS.
+* **Selection is a runtime probe, not a `cfg`.** `has_async_wake` comes from
+  `supports_wake_callback()` (`spin.rs:2994`), which for C backends is
+  "the vtable slot is non-NULL" (`cffi/src/lib.rs:2591`). A port that gains an
+  async source gets the fast path without a core change. This is the extension
+  point the phase builds on.
+* **Degradation is already correct in kind.** No wake primitive, or a poll-only
+  backend, means blocking in the transport's own `recv` for the full timeout —
+  not a spin.
+* **`spin_period` refuses to run without a clock** (`spin.rs:8343`, issue 0709)
+  rather than silently free-running. That is the standard this phase applies to
+  the remaining degradations: refuse, or declare, but never silently degrade.
+* **Priority inheritance holds on all three RTOSes.** ThreadX `TX_INHERIT`
+  (`platform.c:611`), Zephyr `k_mutex`, and — checked because recursive mutexes
+  are a common exception — FreeRTOS recursive mutexes do inherit, via
+  `xQueueTakeMutexRecursive` → `xQueueSemaphoreTake` → `xTaskPriorityInherit`
+  (`third-party/freertos/kernel/queue.c:1791`). No work item here.
+
+## The design
+
+### 1. One time base, nanoseconds, no truncation
+
+`spin_once` currently does `timeout.as_millis()` — a **truncation**
+(`spin.rs:6374`). `Duration::from_micros(500)` becomes `0`, which selects the
+non-blocking path and turns `spin()` into a 100 % CPU loop with no warning
+(issue 1193). The floor is real: all five `nros_platform_wake_wait_ms` slots
+take `uint32_t timeout_ms`, so sub-ms cannot reach the primitive on any target.
+
+The revision:
+
+* carry `u64` nanoseconds from the public API to the platform slot,
+* add `nros_platform_wake_wait_ns`, keeping `_ms` as the fallback for ports
+  whose primitive is genuinely ms-granular,
+* add `nros_platform_wake_granularity_ns()` — each port **declares** what it
+  can achieve,
+* round deadlines **up** to that granularity, never down, and expose the
+  achieved value.
+
+The last point is what converts issue 1194 from a defect into a contract. A
+1500 us request on a 1 ms-granular port is then reported as *achieving* 2000 us,
+rather than silently waiting 1 ms while the jitter rule judges against 1500.
+A monitor whose yardstick and whose mechanism disagree cannot support a safety
+claim; declaring the rounding makes them agree.
+
+### 2. `WakeSource`: the platform-agnostic seam
+
+```rust
+/// Something that knows when it will next need the executor.
+pub trait WakeSource {
+    /// Absolute time of this source's next event in the executor's clock.
+    /// `None` means "nothing pending" — the source does not shorten the park.
+    fn next_deadline_ns(&self) -> Option<u64>;
+
+    /// Whether this source can also signal ASYNCHRONOUSLY (ISR or another
+    /// thread) via the wake primitive. A source may be deadline-only
+    /// (a timer on a tickless port), signal-only (a socket), or both.
+    fn is_async(&self) -> bool;
+}
+```
+
+Core sources, always present, no platform knowledge:
+
+| Source | `next_deadline_ns` | Fixes |
+|---|---|---|
+| `CallerBudget` | the `spin_once` timeout | — |
+| `TimerSource` | `min(period_us - elapsed_us)` over live timer entries | **1192** |
+| `SessionSource` | today's `session.next_deadline_ms()`, promoted | — |
+
+Platform sources, registered by the port, never named by the core:
+
+| Port | Natural source |
+|---|---|
+| Zephyr | `k_poll` event set (sockets, queues, semaphores) |
+| POSIX | `epoll` / `eventfd` |
+| FreeRTOS | queue set |
+| ThreadX | event flags group |
+| **Bare metal** | hardware timer compare + `WFI`/`WFE`, ISR calls `wake_signal_from_isr` |
+
+The bare-metal row is why the seam is a *deadline* and not a *sleep*. On a
+Cortex-R/M with no RTOS, "park until the earlier of a hardware timer compare
+and any interrupt" is precisely `WFI` with the compare programmed — zero CPU,
+no scheduler, no busy loop. Expressed as `sleep(duration)` that idiom is not
+reachable; expressed as `park_until(deadline)` it is the *primary* case rather
+than a degraded one.
+
+### 3. The wait
+
+```
+deadline = min over sources of next_deadline_ns()      // never empty:
+                                                       // CallerBudget is a member
+park_until(deadline)                                   // platform primitive
+drive_io(0)                                            // drain what arrived
+```
+
+Three-tier realisation, chosen at runtime from the platform probe:
+
+| Port capability | Primitive | Result |
+|---|---|---|
+| Async wake **and** timed park | `wake_wait_ns` | Parks until deadline **or** signal. |
+| Timed park only | `platform_sleep_ns` then `drive_io(0)` | Parks until deadline. |
+| Neither (bare metal) | `WFI`/`WFE` + timer compare | Parks until interrupt or deadline. |
+
+No row busy-waits. That is the point: "avoid busy waiting" stops being a
+property each port has to remember and becomes a property of the only wait the
+core knows how to perform.
+
+### 4. Analyzability
+
+Two additions, both cheap, both turning runtime behaviour into data:
+
+* **Attribution.** Record which source won each park (a `u8` index plus a
+  per-source counter). "Why did we wake" becomes a number instead of a guess,
+  and it feeds the existing jitter and execution-time reporting.
+* **A stated bound.** `spin_once`'s duration is `park + scan + dispatch`. Park
+  is bounded by construction. Scan is `O(entries)`. **Dispatch is user code and
+  the executor cannot bound it** — it can only measure it, which the
+  execution-time high-water probe already does. The contract should say this
+  plainly: *the budget is a floor on the wait, not a bound on the call.*
+  Today `spin_period` silently absorbs an overrun by skipping its sleep, so a
+  tier that chronically overruns looks fine and shows up only in the jitter
+  counter.
+
+## The `spin*()` API surface
+
+The review's second half. The surface has grown three units and two meanings.
+
+### Two meanings wearing one shape
+
+```rust
+executor.spin_once(timeout);   // timeout = a BLOCKING BOUND
+executor.spin_period(period);  // period  = a CADENCE
+```
+
+Identical shape, different quantity. This is not hypothetical: nros-cpp's tier
+loops paced with `platform_sleep_us(period_us)` while passing a hardcoded
+`spin_once(…, 10)`, so `release-jitter-runtime` judged every tier against 10 ms
+whatever the contract declared — a 1 kHz tier could run nine periods late and
+register as on time. Fixed by making the cadence **declared**
+(`set_spin_nominal_us`) rather than inferred from the timeout. That fix is
+step one of this phase; the rest is making the distinction impossible to
+confuse again, rather than merely corrected in two call sites.
+
+### Three units
+
+| API | Accepts | Reaches the wait as |
+|---|---|---|
+| `rclc_executor_spin_period` (C) | **nanoseconds** (`executor.rs:2960`) | ms |
+| `nros::spin_once` (C++) | **milliseconds** (`nros.hpp:88`, `int32_t timeout_ms = 10`) | ms |
+| `Executor::spin_once` (Rust) | `Duration` | ms |
+
+The C API advertises nanoseconds and paces itself correctly in nanoseconds
+(`invocation_time_ns += period_ns`, `sleep_ns`) — then truncates at the wait.
+The C++ API cannot express sub-millisecond at all. §1 collapses this to one
+unit.
+
+### What the usage sites teach
+
+* **The generated workspace entry is the good shape.**
+  `actuation_entry_nros_main_generated.cpp` declares the cadence as *data* —
+  `NativeTierSpec{ …, 5000ull, … }` — and calls `run_tiers`. It never calls
+  `spin_once`. The cadence is declared, the mechanism is the runtime's choice,
+  and a resolver can check it before the image is built. **This is the model
+  the hand-written paths should converge on**, and the reason the tier-loop bug
+  was invisible: the generated entry was right, and the runtime beneath it was
+  not.
+* **Hand-written C is the best of the three spellings.**
+  `rclc_executor_spin_period(&app.executor, 100000000ULL)` — ns, absolute
+  deadline accumulation, no drift.
+* **Hand-written C++ taught the wrong idiom.** `while (…) { nros::spin_once(100); }`
+  across ten examples: a bare bound, no declared cadence, no sleep. `nros::spin()`
+  hardcodes `10` (`nros.hpp:176`). These are what the tier loops were modelled on.
+* **The bridges sit exactly on the truncation floor.**
+  `exec.spin_once(Duration::from_millis(1))` — one step finer and it busy-loops
+  (issue 1193).
+
+### Direction
+
+Make the two quantities syntactically distinct rather than documented apart —
+a cadence is declared once (as the generated entry already does) and a bound is
+passed per call. Keep `spin_once(bound)` as the primitive; every cadence-shaped
+wrapper should route through a declaration, so that "which number is this?"
+cannot be answered wrongly by a caller who never reads the doc comment.
+
+## Work items
+
+Each is a filed issue; the issue holds the evidence.
+
+* **W1 — [issue 1192](../issues/1192-executor-wait-ignores-next-timer-deadline.md):
+  the wait is not bounded by the next timer deadline.** The `TimerSource` of
+  §2, and the highest-value item — it is the one place the executor sleeps past
+  a deadline it owns. Distinct from resolved issues 0505 (overrun policy) and
+  0515 (grid quantization), both of which take the spin boundary as fixed;
+  this moves the boundary.
+* **W2 — [issue 1193](../issues/1193-spin-timeout-truncates-to-milliseconds.md):
+  sub-ms timeouts truncate to a busy loop.** §1. Latent today — nros-cpp clamps
+  `max(1_000)` and ASI runs `spin_period_us = 5000` — but `spin_period_us` is a
+  microsecond field accepting values it cannot honour.
+* **W3 — [issue 1194](../issues/1194-jitter-measured-in-microseconds-waited-in-milliseconds.md):
+  jitter measured in µs, waited in ms.** Falls out of W2; the deliverable is
+  the declared-granularity contract, not a coarser statistic.
+* **W4 — [issue 1195](../issues/1195-promise-wait-polls-instead-of-using-the-waker.md):
+  `Promise::wait` polls a 10 ms grid and overshoots shorter timeouts.** The one
+  place the waker exists and is bypassed.
+* **W5 — [issue 1196](../issues/1196-platform-condvar-wait-is-unbounded.md):
+  the unbounded `condvar_wait` in the platform API.** Latent — no callers on
+  the executor path — but "no unbounded wait" is only a system property if it
+  is an API property.
+
+## Sequencing
+
+W2 before W3 (W3's contract needs W2's granularity probe). W1 is independent
+and should go first — it is the largest real-time win and touches only the
+core. W4 and W5 are independent of everything.
+
+## What this phase does not do
+
+* It does not make dispatch preemptive. Within one executor, dispatch stays
+  non-preemptive; multi-tier preemption comes from the OS scheduler via
+  `open_threaded`, unchanged.
+* It does not bound user callbacks. It measures them and states that they are
+  unbounded.
+* It does not change `spin_period`'s drift compensation, which is already
+  correct (absolute `next_us` accumulation, not `now + period`).

--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -1,35 +1,34 @@
 # Phase 436 — The poll/wake revision: a deadline-driven, platform-agnostic executor
 
-**Status (2026-09-07). ALL SIX WORK ITEMS IMPLEMENTED.** W1–W5 landed first
-and made the park deadline-driven; W6 added the seam they were shaped for. The
-executor now computes a park deadline as a `min` over registered sources and
-hands it to a platform primitive.
+**Status (2026-09-07). W1-W6 IMPLEMENTED; W7 — wiring a port through the seam
+— OPEN and prerequisite-blocked.** The executor computes a park deadline as a
+`min` over registered sources and hands it to a platform primitive. **No port
+registers anything through it yet.**
 
-Three things the work changed about the phase as written:
+Four things the work changed about the phase as written:
 
-* **W1–W5 met the behaviour and missed the seam.** The first five items
-  hardcoded the source set — caller budget and timers, with the backend
-  deadline pre-capped separately — so nothing could contribute `k_poll`,
-  `epoll`, a queue set or a device ISR. The phase is named for that extension
-  point, and it did not exist until W6. Worth recording because everything
-  passed and every test was green throughout: behaviour is not architecture.
+* **W1-W5 met the behaviour and missed the seam.** They made the park
+  deadline-driven, rounded and attributed — and hardcoded the source set, so
+  nothing could contribute `k_poll`, `epoll`, a queue set or a device ISR. The
+  phase is named for that extension point and it did not exist until W6,
+  through five green work items and a full test suite. Behaviour is not
+  architecture, and a passing suite does not tell them apart.
+* **The porting axis is C entry vs Rust entry, not per-RTOS.** ThreadX, bare
+  metal and Zephyr's Rust arm hold a typed `Executor`; FreeRTOS, NuttX and
+  Zephyr's C arm hold an opaque `void*` with no export to call — including the
+  arm the ASI lane takes.
+* **`park_granularity_us()` is wrong in both directions** (issue 1242), and
+  W3's jitter-granularity report inherits the error — the failure W3 exists to
+  prevent, reproduced one layer below W3 by its own dependency.
 * **W5's issue was wrong about its own evidence.** Issue 1196 said the
-  unbounded `condvar_wait` had no callers. It has two — the grep behind that
-  claim searched `nros_platform_cond_wait`, and the symbol is
-  `nros_platform_condvar_wait`. W5's gate found them on its first run. Both
-  are correct as written (they bridge zenoh-pico's own unbounded primitive),
-  so the fix became "confine by path and mark the header" rather than
-  "delete".
-* **The `wake_wait_ns` platform slot was NOT built.** Carrying µs through the
-  core and rounding UP at the boundary fixes issue 1193's actual harm — the
-  truncation to zero, and the 33 % short wait — without making five ports grow
-  a required symbol. A port that gains a finer primitive lowers
-  `park_granularity_us()` and nothing above it changes. §1 describes the ns
-  slot as the eventual shape; it is deferred, not done.
+  unbounded `condvar_wait` had no callers; it has two. The grep behind that
+  claim searched `nros_platform_cond_wait`; the symbol is
+  `nros_platform_condvar_wait`.
 
-Also unbuilt, and deliberately: making the wait loops in `handles.rs` wake off
-the backend's listener rather than a fixed grid. W4 fixes the overshoot half of
-issue 1195; the waker half is the larger change and stays open.
+Deferred deliberately: the `wake_wait_ns` platform slot (the rounding contract
+fixes issue 1193's harm without making five ports grow a required symbol), and
+making the `handles.rs` wait loops wake off the backend's listener rather than
+a fixed grid (issue 1195's larger half).
 
 ## The one change this phase is about
 
@@ -144,43 +143,90 @@ been told about, which is the failure this phase exists to remove.
 the budget upstream meant a park the session won was attributed to
 `CallerBudget` — the one number that explains a wake named the wrong source.
 
-#### Per platform
+#### Per platform — surveyed, not assumed
 
-| Platform | Park primitive | Natural extra sources | State |
+Four parallel read-only surveys, one per port domain. The table below replaced
+an earlier one written from a single reading; three of its rows were wrong.
+
+**The real axis is not per-RTOS. It is C entry vs Rust entry.**
+
+| Port | Entry holds a typed `Executor`? | Park primitive available | Native tick |
 |---|---|---|---|
-| **Zephyr** | `k_sem_take(timeout)`, ISR-safe `k_sem_give` | `k_poll` event set | wake ✓, `k_poll` unused |
-| **FreeRTOS** | `xSemaphoreTake(ticks)` | queue set, `xSemaphoreGiveFromISR` | wake ✓ |
-| **NuttX** | POSIX condvar — compiles the *identical* POSIX `platform.c`, no NuttX-specific source | `poll`/`epoll`, same POSIX path | wake ✓ (inherited) |
-| **ThreadX** | `tx_semaphore_get(ticks)` | event-flags group | wake ✓ |
-| **Bare metal** | `wfi` + hardware timer compare | smoltcp poll, device ISRs | **no wake primitive at all** |
+| **ThreadX** | **Yes** — `nros-board-threadx/src/entry.rs`, via `executor_mut()` | `tx_semaphore_get`, contract already `0/1/<0` | **10 ms** (`TX_TIMER_TICKS_PER_SECOND=100`) |
+| **Bare metal** | **Yes** — `nros-board-mps2-an385/src/entry.rs` `boot()` | none — see below | free-running counters only |
+| **Zephyr** | **Both** — Rust `entry_tiers.rs` yes; C `zephyr_run_tiers.c` no | `k_sem_take`, and `k_timeout_t` accepts `K_USEC` | 1 ms via the ABI, finer in the kernel |
+| **FreeRTOS** | **No** — opaque `void*` behind `nros_cpp_*` | `xSemaphoreTake`, contract already `0/1/<0` | 1 ms (`configTICK_RATE_HZ=1000`) |
+| **NuttX** | **No** — same opaque pattern | inherits POSIX | POSIX |
+| **POSIX** | n/a — `nros_board_native_run_tiers` | `sem_timedwait` / `pthread_cond_timedwait`, **timespec-native** | nanosecond-capable |
 
-#### Bare metal is the case that validates the seam
+**There is no `nros_cpp_executor_register_wake_source` or
+`..._set_park_primitive` C-ABI export.** So FreeRTOS, NuttX and the C arm of
+Zephyr — which is the arm the ASI FVP lane actually takes — cannot reach this
+seam at all without new FFI surface. ThreadX, bare metal and Zephyr's Rust arm
+can wire directly today.
 
-`nros-baremetal-common/src/sleep.rs` already carries these three pieces, as
-untyped function pointers: `ClockMsFn`, `PollFn` (the smoltcp poll — a wake
-source in embryo) and `IdleFn` (`cortex_m::asm::wfi` — the park primitive).
-Its own note states the constraint:
+**No port multiplexes.** `k_poll` does not appear anywhere (the single grep hit
+is `nros_platform_network_poll`, a name collision with a no-op body). FreeRTOS
+queue sets are unused and `configUSE_QUEUE_SETS 0` where set at all. ThreadX
+event flags exist but only as zenoh-pico's task-join signal. Every port waits
+on a socket the same way: blocking `recv` with `SO_RCVTIMEO`. So the "natural
+extra sources" a first reading suggests are aspirations, not wiring waiting to
+be connected.
 
-> *"Without an armed IRQ, leave this unset — `wfi` with no pending interrupt
-> deadlocks."*
+#### The deadline sources that do exist
 
-That is unsatisfiable through a `sleep(duration)` seam, because the sleeper
-cannot know whether anyone armed an interrupt. It falls out of
-`park_until(deadline)`, because the deadline is exactly what the compare is
-armed to:
+* **Zephyr has a one-shot timer facility, and it is dead code.**
+  `nros_zephyr_timer_create_oneshot(timeout_us, cb, user_data)` and its
+  periodic sibling, at `zephyr/nros_platform_zephyr_shims.c:220-278`, take
+  **microseconds** and wrap `k_timer`. Written for Phase 110.E.b sporadic-server
+  refill; **zero callers tree-wide**. That is the shape a `NextDeadlineFn`
+  needs, already built and already paid for.
+* **smoltcp could contribute one and does not.** `Interface::poll_at()` returns
+  when the stack next needs servicing — the natural deadline source. It has
+  **zero hits** in this repo; `SmoltcpBridge::poll` calls `iface.poll()` and
+  discards the timing.
+
+#### Bare metal: the argument, corrected
+
+The design's justification was that `park_until(deadline)` lets a board arm a
+timer compare before `wfi`, which `sleep(duration)` cannot express. That
+argument stands. **What does not stand is the implication that any board here
+can do it today.**
+
+No bare-metal board in this tree has a one-shot, deadline-programmable timer:
+
+* **MPS2-AN385** — CMSDK Timer0 as a free-running down-counter,
+  `RELOAD = 0xFFFF_FFFF`, **no `IRQEN`**, compare register never written.
+* **STM32F4** — DWT cycle counter, no match register ever written.
+* **ESP32-QEMU** — clock read only; no compare or alarm facility.
+
+The one interrupt-driving timer that exists is MPS2's RTIC `arm_tick_timer`,
+a **fixed 1 kHz periodic tick** armed once at init to bound `wfi` yield
+granularity. That is a period, not a deadline.
+
+So an earlier sketch in this document showing
 
 ```rust
-unsafe extern "C" fn park_until_wfi(_ctx: *mut c_void, deadline_us: u64) -> i8 {
-    if deadline_us == 0 { return 1; }
-    arm_timer_compare(deadline_us);   // guarantees an IRQ — no deadlock
-    cortex_m::asm::wfi();             // core clock-gated until IRQ or deadline
-    0
-}
+arm_timer_compare(deadline_us);   // ← no such function exists, on any board
+cortex_m::asm::wfi();
 ```
 
-Today bare metal **busy-waits** in `sleep_ms`, polling a clock, with `wfi` an
-opt-in a board may forget. Under the seam it parks, and the existing `PollFn`
-becomes a registered source rather than a callback invoked inside a spin loop.
+presented as available something that must be **written from scratch, per
+board**. The hardware supports it; the code does not exist. Recording that
+plainly, because "a slot exists, therefore it works" is the overstatement this
+phase has now made twice.
+
+Worse than assumed, too: `sleep_ms` in `nros-baremetal-common` **always**
+busy-loops on the clock condition, with `wfi` an optional per-iteration yield
+rather than a block — and the default MPS2 non-RTIC boot never registers the
+idle hook at all, so it spins with no yield whatsoever.
+
+#### POSIX does not need this
+
+POSIX already blocks in `NodeWake::wait_ms` → `sem_timedwait`, bounded by the
+same min-of-sources. Installing a `ParkUntilFn` there would be redundant unless
+paired with a microsecond primitive **and** a non-hardcoded granularity
+(issue 1242). POSIX being well served is the design working, not a gap.
 
 The seam is **additive**: with no primitive installed the path is unchanged and
 every existing port keeps the behaviour it has. When one IS installed the
@@ -317,6 +363,36 @@ Each is a filed issue; the issue holds the evidence.
   `Session` and `Platform(u8)`, and makes the backend deadline a candidate
   rather than a pre-cap. No issue: this is the phase's own design, not a
   defect found in the field.
+
+* **W7 — wire a port through the seam. OPEN, and blocked on two prerequisites.**
+  W6 built the extension point; nothing extends it. Four parallel port surveys
+  established what each port needs, and produced two items that are not
+  per-port work:
+
+  * **W7.a — a C-ABI surface for the seam.** There is no
+    `nros_cpp_executor_register_wake_source` / `..._set_park_primitive` export,
+    so FreeRTOS, NuttX and Zephyr's C arm cannot reach it. That arm is the one
+    the ASI FVP lane takes, so this gates the lane we ship. ThreadX, bare metal
+    and Zephyr's Rust arm need none of it.
+  * **W7.b — [issue 1242](../issues/1242-park-granularity-is-hardcoded-not-queried.md).**
+    `park_granularity_us()` is a hardcoded 1 ms: wrong high on ThreadX (10 ms
+    tick), wrong low on POSIX (timespec-native), and it never consults the
+    installed primitive — so a port supplying a microsecond `ParkUntilFn` still
+    cannot produce a sub-millisecond park. Until this is fixed, wiring any port
+    buys nothing it does not already have.
+
+  Then the per-port work, cheapest first:
+
+  * **Zephyr deadline source** — `nros_zephyr_timer_create_oneshot` already
+    takes microseconds, already exists, and has zero callers. The smallest real
+    `NextDeadlineFn` available.
+  * **ThreadX and Zephyr-Rust park primitives** — both entries hold a typed
+    `Executor`, and both `wake_wait_ms` implementations already return the
+    `0/1/<0` contract `ParkUntilFn` wants. Adapters are a unit change.
+  * **smoltcp deadline source** — capture `Interface::poll_at()`, which the
+    bridge currently discards.
+  * **Bare-metal park primitive** — the largest, and the only one needing new
+    hardware code: a one-shot compare, per board, that exists nowhere today.
 
 ## Sequencing
 

--- a/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
+++ b/docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md
@@ -1,22 +1,31 @@
 # Phase 436 — The poll/wake revision: a deadline-driven, platform-agnostic executor
 
-**Status (2026-09-07). ALL FIVE WORK ITEMS IMPLEMENTED.** W1–W5 landed
-test-first; the executor now computes a park deadline rather than accepting a
-timeout. Two things the work changed about the phase as written:
+**Status (2026-09-07). ALL SIX WORK ITEMS IMPLEMENTED.** W1–W5 landed first
+and made the park deadline-driven; W6 added the seam they were shaped for. The
+executor now computes a park deadline as a `min` over registered sources and
+hands it to a platform primitive.
 
+Three things the work changed about the phase as written:
+
+* **W1–W5 met the behaviour and missed the seam.** The first five items
+  hardcoded the source set — caller budget and timers, with the backend
+  deadline pre-capped separately — so nothing could contribute `k_poll`,
+  `epoll`, a queue set or a device ISR. The phase is named for that extension
+  point, and it did not exist until W6. Worth recording because everything
+  passed and every test was green throughout: behaviour is not architecture.
 * **W5's issue was wrong about its own evidence.** Issue 1196 said the
-  unbounded `condvar_wait` had no callers. It has two — the grep that produced
-  that claim searched `nros_platform_cond_wait`, and the symbol is
-  `nros_platform_condvar_wait`. W5's gate found them on its first run. Both are
-  correct as written (they bridge zenoh-pico's own unbounded primitive), so the
-  fix became "confine by path and mark the header" rather than "delete".
-* **The `wake_wait_ns` platform slot was NOT built.** Adding a required symbol
-  to five ports buys less than the rounding contract does: carrying µs through
-  the core and rounding UP at the boundary fixes issue 1193's actual harm — the
-  truncation to zero, and the 33 % short wait — without making every port grow
-  a slot. A port that gains a finer primitive can lower `park_granularity_us()`
-  and nothing above it changes. §1 below describes the ns slot as the eventual
-  shape; it is deferred, not done.
+  unbounded `condvar_wait` had no callers. It has two — the grep behind that
+  claim searched `nros_platform_cond_wait`, and the symbol is
+  `nros_platform_condvar_wait`. W5's gate found them on its first run. Both
+  are correct as written (they bridge zenoh-pico's own unbounded primitive),
+  so the fix became "confine by path and mark the header" rather than
+  "delete".
+* **The `wake_wait_ns` platform slot was NOT built.** Carrying µs through the
+  core and rounding UP at the boundary fixes issue 1193's actual harm — the
+  truncation to zero, and the 33 % short wait — without making five ports grow
+  a required symbol. A port that gains a finer primitive lowers
+  `park_granularity_us()` and nothing above it changes. §1 describes the ns
+  slot as the eventual shape; it is deferred, not done.
 
 Also unbuilt, and deliberately: making the wait loops in `handles.rs` wake off
 the backend's listener rather than a fixed grid. W4 fixes the overshoot half of
@@ -100,46 +109,84 @@ rather than silently waiting 1 ms while the jitter rule judges against 1500.
 A monitor whose yardstick and whose mechanism disagree cannot support a safety
 claim; declaring the rounding makes them agree.
 
-### 2. `WakeSource`: the platform-agnostic seam
+### 2. The wake-source seam: many sources say WHEN, one primitive waits
+
+That split is the design. Conflating them is what produced W1's first shape,
+which hardcoded its sources and left no way for a port to contribute one.
 
 ```rust
-/// Something that knows when it will next need the executor.
-pub trait WakeSource {
-    /// Absolute time of this source's next event in the executor's clock.
-    /// `None` means "nothing pending" — the source does not shorten the park.
-    fn next_deadline_ns(&self) -> Option<u64>;
+/// When this source will next need the executor, microseconds FROM NOW.
+/// `u64::MAX` = nothing pending.
+pub type NextDeadlineFn = unsafe extern "C" fn(ctx: *mut c_void) -> u64;
 
-    /// Whether this source can also signal ASYNCHRONOUSLY (ISR or another
-    /// thread) via the wake primitive. A source may be deadline-only
-    /// (a timer on a tickless port), signal-only (a socket), or both.
-    fn is_async(&self) -> bool;
+/// Park until `deadline_us` from now, or until something signals.
+/// 0 = woken by an event, 1 = deadline expired, <0 = cannot park.
+pub type ParkUntilFn = unsafe extern "C" fn(ctx: *mut c_void, deadline_us: u64) -> i8;
+
+pub const MAX_WAKE_SOURCES: usize = 8;   // inline table, no allocator
+
+executor.register_wake_source(next_fn, ctx)?;   // many
+executor.set_park_primitive(park_fn, ctx);      // one
+```
+
+`WakeSourceId` names the winner: `CallerBudget`, `Timer`, `Session`,
+`Platform(u8)`.
+
+An **async** source contributes `u64::MAX` and instead breaks the park by
+signalling — which `nros_rmw_runtime_wake_cb` already does. So async and
+deadline sources compose without a second mechanism.
+
+Registration **refuses past capacity** rather than dropping silently: a source
+quietly discarded would leave the executor sleeping past a deadline it had
+been told about, which is the failure this phase exists to remove.
+
+`Session` is a **candidate, not a pre-cap**. Folding the backend deadline into
+the budget upstream meant a park the session won was attributed to
+`CallerBudget` — the one number that explains a wake named the wrong source.
+
+#### Per platform
+
+| Platform | Park primitive | Natural extra sources | State |
+|---|---|---|---|
+| **Zephyr** | `k_sem_take(timeout)`, ISR-safe `k_sem_give` | `k_poll` event set | wake ✓, `k_poll` unused |
+| **FreeRTOS** | `xSemaphoreTake(ticks)` | queue set, `xSemaphoreGiveFromISR` | wake ✓ |
+| **NuttX** | POSIX condvar — compiles the *identical* POSIX `platform.c`, no NuttX-specific source | `poll`/`epoll`, same POSIX path | wake ✓ (inherited) |
+| **ThreadX** | `tx_semaphore_get(ticks)` | event-flags group | wake ✓ |
+| **Bare metal** | `wfi` + hardware timer compare | smoltcp poll, device ISRs | **no wake primitive at all** |
+
+#### Bare metal is the case that validates the seam
+
+`nros-baremetal-common/src/sleep.rs` already carries these three pieces, as
+untyped function pointers: `ClockMsFn`, `PollFn` (the smoltcp poll — a wake
+source in embryo) and `IdleFn` (`cortex_m::asm::wfi` — the park primitive).
+Its own note states the constraint:
+
+> *"Without an armed IRQ, leave this unset — `wfi` with no pending interrupt
+> deadlocks."*
+
+That is unsatisfiable through a `sleep(duration)` seam, because the sleeper
+cannot know whether anyone armed an interrupt. It falls out of
+`park_until(deadline)`, because the deadline is exactly what the compare is
+armed to:
+
+```rust
+unsafe extern "C" fn park_until_wfi(_ctx: *mut c_void, deadline_us: u64) -> i8 {
+    if deadline_us == 0 { return 1; }
+    arm_timer_compare(deadline_us);   // guarantees an IRQ — no deadlock
+    cortex_m::asm::wfi();             // core clock-gated until IRQ or deadline
+    0
 }
 ```
 
-Core sources, always present, no platform knowledge:
+Today bare metal **busy-waits** in `sleep_ms`, polling a clock, with `wfi` an
+opt-in a board may forget. Under the seam it parks, and the existing `PollFn`
+becomes a registered source rather than a callback invoked inside a spin loop.
 
-| Source | `next_deadline_ns` | Fixes |
-|---|---|---|
-| `CallerBudget` | the `spin_once` timeout | — |
-| `TimerSource` | `min(period_us - elapsed_us)` over live timer entries | **1192** |
-| `SessionSource` | today's `session.next_deadline_ms()`, promoted | — |
-
-Platform sources, registered by the port, never named by the core:
-
-| Port | Natural source |
-|---|---|
-| Zephyr | `k_poll` event set (sockets, queues, semaphores) |
-| POSIX | `epoll` / `eventfd` |
-| FreeRTOS | queue set |
-| ThreadX | event flags group |
-| **Bare metal** | hardware timer compare + `WFI`/`WFE`, ISR calls `wake_signal_from_isr` |
-
-The bare-metal row is why the seam is a *deadline* and not a *sleep*. On a
-Cortex-R/M with no RTOS, "park until the earlier of a hardware timer compare
-and any interrupt" is precisely `WFI` with the compare programmed — zero CPU,
-no scheduler, no busy loop. Expressed as `sleep(duration)` that idiom is not
-reachable; expressed as `park_until(deadline)` it is the *primary* case rather
-than a degraded one.
+The seam is **additive**: with no primitive installed the path is unchanged and
+every existing port keeps the behaviour it has. When one IS installed the
+transport drain drops to non-blocking, because a park plus a blocking drive
+would sum to up to twice the intended cadence — the same trap as passing a
+period to `spin_once` instead of declaring it (#648).
 
 ### 3. The wait
 
@@ -263,6 +310,13 @@ Each is a filed issue; the issue holds the evidence.
   the unbounded `condvar_wait` in the platform API.** Latent — no callers on
   the executor path — but "no unbounded wait" is only a system property if it
   is an API property.
+* **W6 — the wake-source seam itself. DONE.** W1–W5 delivered the BEHAVIOUR —
+  a deadline-driven park, rounded up, attributed — but hardcoded the sources,
+  so the extension point this phase is named for did not exist. W6 adds
+  `register_wake_source` / `set_park_primitive`, widens `WakeSourceId` with
+  `Session` and `Platform(u8)`, and makes the backend deadline a candidate
+  rather than a pre-cap. No issue: this is the phase's own design, not a
+  defect found in the field.
 
 ## Sequencing
 

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1372,8 +1372,9 @@ pub struct Executor<'s> {
     /// installed the wake callback. Drives whether `spin_once`
     /// uses the wake-primitive wait (`NodeWake` / `Condvar`) or
     /// just `drive_io(timeout_ms)`. Poll-only backends
-    /// (XRCE-DDS-Client, current Cyclone/dust-DDS shims) leave
-    /// this `false`; the wait then becomes a no-op sleep that
+    /// (XRCE-DDS-Client, the dust-DDS shim) leave this `false`;
+    /// Cyclone sets it — it fills the slot and backs it with a real
+    /// `dds_set_listener` listener; the wait then becomes a no-op sleep that
     /// starves reliable retransmission (Phase 127.C.4 root
     /// cause: server's `send_response` flushes 100 ms once, then a
     /// blind `wait_ms(100)` sleeps with zero session activity, so
@@ -6463,8 +6464,8 @@ impl<'s> Executor<'s> {
         // entry, the predicate sees flag=true on first eval and
         // exits immediately.
         // Phase 130.4 — only sleep in the wake wait when a backend actually
-        // installed `set_wake_callback`. Poll-only backends (XRCE, current
-        // Cyclone) leave the vtable slot NULL → `has_async_wake == false` →
+        // installed `set_wake_callback`. Poll-only backends (XRCE) leave the
+        // vtable slot NULL → `has_async_wake == false` →
         // drive_io for the caller's full timeout instead of sleeping in a
         // never-signaled wait that starves reliable retransmission (Phase
         // 127.C.4 root cause: the server's `send_response` flushes 100 ms once,

--- a/packages/rmw/cffi/src/lib.rs
+++ b/packages/rmw/cffi/src/lib.rs
@@ -2681,9 +2681,13 @@ impl Session for CffiSession {
 
     fn supports_wake_callback(&self) -> bool {
         // Phase 130.4 — the vtable slot's presence is the truthful
-        // signal. Poll-only backends (XRCE-DDS-Client, current
-        // Cyclone wrapper, current dust-DDS shim) leave the slot
-        // NULL; only backends with an async wake source fill it.
+        // signal. Poll-only backends (XRCE-DDS-Client, current dust-DDS
+        // shim) leave the slot NULL; only backends with an async wake
+        // source fill it. Cyclone DOES fill it (`vtable.cpp:322`) and
+        // backs it with a real `dds_set_listener` / `on_data_available`
+        // firing on a Cyclone worker thread — this comment named it
+        // poll-only long after that landed, which is misleading for
+        // exactly the reader asking whether their lane gets async wakes.
         self.vtable.set_wake_callback.is_some()
     }
 


### PR DESCRIPTION
Review of the executor and the `spin*()` surface against four properties: a platform-agnostic core, per-platform wake sources, analyzable real-time bounds, no busy waiting.

## The finding

Three of the four are close to met. The wake machinery is already platform-agnostic and **runtime-probed** — `NodeWake` over five ports (Zephyr `k_sem`, ThreadX, FreeRTOS, POSIX, ESP-IDF), each with an ISR-safe signal — and it degrades to blocking in the transport's own `recv`, not to a spin.

The fourth is not met, for one reason. The executor asks **"how long may I block?"** when it should ask **"when is the next thing I owe anybody?"**. Today the answer is the caller's timeout narrowed by exactly one input, `session.next_deadline_ms()`. Nothing lets a **timer** deadline shorten the sleep — grep `spin.rs` for any next-timer computation and you get zero hits — so `spin_default()`'s 50 ms sleeps straight past a 10 ms timer it owns.

## The design

A `WakeSource` seam. Core members (no platform knowledge): the caller's budget, the timers, the session. Platform members registered per port: `k_poll` event sets, `epoll`, FreeRTOS queue sets, ThreadX event flags — or, on bare metal, a hardware-timer compare plus `WFI`.

The wait becomes `park_until(min over sources)`. Two consequences worth the change:

- **Bare metal becomes the primary case, not a degraded one.** "Park until the earlier of a timer compare and any interrupt" *is* `WFI`. That idiom is unreachable through a `sleep(duration)` seam and natural through a `park_until(deadline)` one.
- **The wake time becomes a function of declared periods**, so it can be enumerated statically — the property a schedulability argument actually needs.

Plus one time base in ns end to end, and a per-port `wake_granularity_ns()` so rounding is **declared and upward** instead of silent and downward.

## Issues filed

| | |
|---|---|
| [1192](docs/issues/1192-executor-wait-ignores-next-timer-deadline.md) | the wait is not bounded by the next timer deadline |
| [1193](docs/issues/1193-spin-timeout-truncates-to-milliseconds.md) | a sub-ms timeout truncates to zero and becomes a busy loop |
| [1194](docs/issues/1194-jitter-measured-in-microseconds-waited-in-milliseconds.md) | jitter measured in µs against a cadence waited in ms |
| [1195](docs/issues/1195-promise-wait-polls-instead-of-using-the-waker.md) | `Promise::wait` polls a 10 ms grid, overshoots shorter timeouts |
| [1196](docs/issues/1196-platform-condvar-wait-is-unbounded.md) | the platform's unbounded `condvar_wait` |

**1192 is deliberately distinct from resolved 0505 and 0515.** The reservation tool surfaced both, and they are close: 0505 is the overrun *policy* for a backlog, 0515 is grid *quantization*. Both take the spin boundary as fixed and describe what happens around it. This one moves the boundary. The issue says so explicitly so a reader doesn't re-close it as a duplicate.

**1193 is latent, not live** — nros-cpp clamps `max(1_000)` and ASI runs `spin_period_us = 5000`. But `spin_period_us` is a microsecond field that accepts values it cannot honour, and `Duration::from_micros(500)` → `as_millis()` → `0` → a 100 % CPU loop with no warning. The one diagnostic that would catch it, `audit_spin_quantization`, is gated `if timeout_ms > 0`.

## API review

Three units — C takes **ns** (and paces correctly in ns, then truncates at the wait), C++ takes **ms** and cannot express sub-ms, Rust takes `Duration` — all funnelling into one ms-truncating core.

And two meanings wearing one shape: `spin_once(timeout)` is a *bound*, `spin_period(period)` is a *cadence*. That confusion is what produced #648's bug. The generated workspace entry is the shape that got it right — it declares the cadence as data (`NativeTierSpec{…, 5000ull, …}`) and never calls `spin_once` — and the hand-written C++ examples are what taught the tier loops the wrong idiom.

## Also

Corrects **three** comments asserting Cyclone is poll-only. Cyclone fills the slot (`vtable.cpp:322`) with a real `dds_set_listener`/`on_data_available`. I nearly filed a sixth issue against zenoh off the same stale reasoning before checking — zenoh doesn't override `supports_wake_callback`, so it takes the `false` default and never enters the path.

## Verification

`check-issue-index` OK (120 = 120), `check-roadmap-status` OK (73 phases), `issue-ids-check` OK (1113 issues). IDs reserved through `reserve-issue-id.sh` / `reserve-phase-id.sh`. `cargo test -p nros-node --features std`: 340 passed, 1 failed — `backing::tests::the_static_is_handed_out_once_and_only_once`, the known red already fixed by #672 in the queue.

Docs and comments only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP2Rw4c4Hm9qfcbwCMQ1XD