### PR TITLE
feat(phase-206 W2): the RTOS image that links Cyclone AND carries a bringup config

### DIFF
--- a/cmake/NanoRosEntry.cmake
+++ b/cmake/NanoRosEntry.cmake
@@ -541,11 +541,30 @@ function(nano_ros_entry)
         # ("NANO_ROS_DEFAULT_RMW;NANO_ROS_RMW"), not that function itself: it
         # FATAL_ERRORs when nothing resolves, and an entry with no RMW chosen yet
         # is a legitimate state here.
+        # ...and then KCONFIG, which is the answer on Zephyr and the reason the
+        # first version of this block baked nothing there (phase-206 W2, final
+        # item). A west Zephyr image selects its backend with
+        # `CONFIG_NROS_RMW_<X>=y` and sets NEITHER cmake variable: measured on
+        # `build-ws-cpp-entry-cyclonedds`, whose CMakeCache has no
+        # `NANO_ROS_RMW` at all while its `.config` carries
+        # `CONFIG_NROS_RMW_CYCLONEDDS=y`. So `_nra_rmw` came out empty, the bake
+        # was skipped, and the image linked Cyclone (`ddsi_` x14283) carrying
+        # none of the user's bytes -- configure clean, compile clean, silently
+        # unconfigured. Exactly the shape this work item exists to stop.
+        #
+        # Same mapping and same order as `nros_system_generate`'s, so the two
+        # wirings cannot disagree about which backend an image is.
         set(_nra_rmw "")
         if(DEFINED NANO_ROS_DEFAULT_RMW AND NOT "${NANO_ROS_DEFAULT_RMW}" STREQUAL "")
             set(_nra_rmw "${NANO_ROS_DEFAULT_RMW}")
         elseif(DEFINED NANO_ROS_RMW AND NOT "${NANO_ROS_RMW}" STREQUAL "")
             set(_nra_rmw "${NANO_ROS_RMW}")
+        elseif(CONFIG_NROS_RMW_CYCLONEDDS)
+            set(_nra_rmw "cyclonedds")
+        elseif(CONFIG_NROS_RMW_XRCE)
+            set(_nra_rmw "xrce")
+        elseif(CONFIG_NROS_RMW_ZENOH)
+            set(_nra_rmw "zenoh")
         endif()
 
         if(_nra_rmw)
@@ -556,7 +575,24 @@ function(nano_ros_entry)
                 OUT_DIR "${_nra_cfg_dir}"
                 RESULT  _nra_cfg_header)
             if(_nra_cfg_header)
-                if(TARGET nros_rmw_${_nra_rmw})
+                # ZEPHYR FIRST: the backend TUs are compiled into the Zephyr
+                # MODULE library (`zephyr_library_sources` in
+                # zephyr/cmake/nros_rmw_<backend>.cmake), so there is no
+                # `nros_rmw_<backend>` target to hang an include on and the
+                # branch below is dead there. Measured on
+                # `build-ws-cpp-entry-cyclonedds`: the bake fired, the header
+                # was byte-identical to the SSoT, Cyclone linked (`ddsi_`
+                # x14283) -- and the ELF carried none of the user's bytes,
+                # because `session.cpp` never saw the directory.
+                #
+                # `zephyr_include_directories` is what the sibling wiring
+                # (`nros_system_generate`) uses for exactly this reason.
+                if(COMMAND zephyr_include_directories)
+                    zephyr_include_directories("${_nra_cfg_dir}")
+                    message(STATUS
+                        "nano-ros: ${_nra_rmw} user config reaches the Zephyr "
+                        "module library (entry ${_NRA_NAME})")
+                elseif(TARGET nros_rmw_${_nra_rmw})
                     target_include_directories(nros_rmw_${_nra_rmw}
                         PRIVATE "${_nra_cfg_dir}")
                     message(STATUS

--- a/docs/roadmap/phase-206-multi-homing-transport-interfaces.md
+++ b/docs/roadmap/phase-206-multi-homing-transport-interfaces.md
@@ -519,13 +519,52 @@ with **zero** bake lines — `rmw/` ships `cyclonedds.xml` and no `zenoh.conf`, 
 the active backend picks the file and an image whose backend has no config
 compiles with no cmake participation at all.
 
-**What the RTOS row adds, and what it still does not.** The Zephyr row above is a
-COMPILE-stage measurement: the bytes reach `session.cpp.obj` but not
-`zephyr.elf`, because that fixture's `main.c` is a 212.H.1 stub that never
-creates a node and the link runs `--gc-sections`. An RTOS image that links
-Cyclone AND carries a bringup config is the remaining gap — smaller than it was,
-and no longer blocking the mechanism, which is now proven end to end on a real
-image.
+**The RTOS gap is CLOSED — 2026-09-07, and closing it found two defects in W2
+itself.** `west_bringup_zephyr_cyclone_user_config` remains a COMPILE-stage
+measurement by construction (its `main.c` is a 212.H.1 stub that never creates a
+node, so `--gc-sections` drops the backend and the bytes stop at
+`session.cpp.obj`). The image that closes the acceptance is
+**`workspace-zephyr-cpp-cyclonedds`** — `examples/workspaces/cpp`'s Zephyr entry,
+which links `talker_pkg` + `listener_pkg`, so the backend is REFERENCED and
+survives the link:
+
+| check | result |
+| --- | --- |
+| Cyclone genuinely linked (`strings \| grep -c ddsi_`) | **14283** |
+| `dds_create_domain` | 6 |
+| `cdds.io/config` in the image | 1 |
+| the SSoT's exact bytes, contiguous, in `zephyr.elf` | **True** |
+| generated header byte-identical to the SSoT | True |
+
+Negative control, same workspace and bringup: `[image.zephyr]` is zenoh, and
+`rmw/` ships `cyclonedds.xml` and no `zenoh.conf`, so that image bakes nothing.
+
+**TWO DEFECTS IN W2, both invisible until an image actually linked the backend.**
+Each left the build green — configure clean, compile clean, silently
+unconfigured — which is the exact failure this work item exists to make
+impossible, sitting inside the fix for it:
+
+1. **The entry path could not see Zephyr's RMW.** It resolved from
+   `NANO_ROS_DEFAULT_RMW` / `NANO_ROS_RMW`; a west Zephyr image sets NEITHER and
+   selects its backend through Kconfig. Measured: that build's `CMakeCache.txt`
+   has no `NANO_ROS_RMW` at all while its `.config` carries
+   `CONFIG_NROS_RMW_CYCLONEDDS=y`. `_nra_rmw` came out empty and the bake was
+   skipped. The path now falls back to Kconfig with the same mapping and order
+   `nros_system_generate` uses, so the two wirings cannot disagree about which
+   backend an image is.
+2. **The include could not reach Zephyr's backend.** It attached to a
+   `nros_rmw_<backend>` TARGET, but Zephyr compiles those TUs into the Zephyr
+   MODULE library (`zephyr_library_sources`), so no such target exists and the
+   branch was dead. With the bake fixed the header was byte-identical and
+   Cyclone linked — and the ELF still carried none of the user's bytes. It now
+   publishes through `zephyr_include_directories()`, as the sibling wiring does.
+
+**A trap worth recording for the next reader:** `NetworkInterface` and
+`autodetermine` appear in the ELF whether or not the bake worked — they are
+Cyclone's OWN config-parser strings. Only `cdds.io/config` and a
+whole-document byte comparison distinguish a baked image from an unbaked one.
+The first run here read as a near-pass on those two strings and was a total
+miss.
 
 A conf-file trap found on the way, recorded because it fails GREEN: omitting
 `CONFIG_CPP=y` leaves `NROS_RMW_CYCLONEDDS`'s `depends on NET_SOCKETS &&

--- a/examples/fixtures.toml
+++ b/examples/fixtures.toml
@@ -4862,6 +4862,53 @@ west_id = "zephyr/native_sim/native/64/workspace-entry-cpp"
 west_zenoh_locator = "tcp/127.0.0.1:7630"
 skip_probe = true
 
+# phase-206 W2, FINAL ITEM — the RTOS image that links Cyclone AND carries a
+# bringup config.
+#
+# W2 shipped two proofs and one hole. The hosted proof
+# (`workspace-cpp-native-cyclonedds`) has the SSoT's exact bytes in a linked
+# ELF. The RTOS proof (`west_bringup_zephyr_cyclone_user_config`) is
+# COMPILE-stage only: its app is a 212.H.1 stub that never creates a node, so
+# `--gc-sections` drops the backend and the bytes reach `session.cpp.obj` but
+# not `zephyr.elf` (`strings | grep -c ddsi_` = 0).
+#
+# This row closes it. Same workspace and bringup as `workspace-zephyr-cpp`
+# above, which links `talker_pkg` + `listener_pkg` -- real nodes, so the
+# backend is referenced and survives the link. It reaches the bake through
+# `nano_ros_add_executable(... BRINGUP ...)`, i.e. the ENTRY path, which is the
+# half of W2 that no RTOS row exercised before.
+#
+# The zenoh row above doubles as the negative control on this platform: the
+# bringup ships `rmw/cyclonedds.xml` and no `zenoh.conf`, so it bakes nothing.
+[[workspace_fixture]]
+id = "workspace-zephyr-cpp-cyclonedds"
+platform = "zephyr"
+lang = "cpp"
+rmw = "cyclonedds"
+dir = "examples/workspaces/cpp"
+bringup = "src/demo_bringup"
+image = "zephyr_cyclonedds"
+board = "native_sim/native/64"
+conf_files = ["prj.conf", "prj-cyclonedds.conf"]
+west_build_name = "build-ws-cpp-entry-cyclonedds"
+west_id = "zephyr/native_sim/native/64/workspace-entry-cpp-cyclonedds"
+# The row AUTHORS its isolation value, as every west leaf does. Not decoration:
+# `zephyr-fixture-leaves.sh` takes the "row authored it" branch only when one of
+# `west_zenoh_locator` / `west_xrce_agent_port` / `west_cyclone_domain` is set;
+# otherwise it falls through to `variant_offset_for_role`, which does not know
+# the role `entry` and exits 2. The zenoh row beside this one supplies a
+# locator, and cyclone's isolation axis is the DOMAIN.
+#
+# 33 is the allocator's answer, not a free number. `alloc::domain_of` is
+# `1 + platform.index()*21 + slot*3 + lang.port_index()`; for
+# (ZephyrNativeSim=1, EntryPubsub slot=3, cpp=2) that is 1+21+9+2 = 33. Both
+# inferred inputs are cross-checked against the shell's own formulas: its
+# cyclone leaves compute `22 + variant*3 + lang` (i.e. 1 + 1*21 + ...), fixing
+# Zephyr's index at 1; and the rust entry's locator 7430 is 7400+30, fixing the
+# Entry slot at 3.
+west_cyclone_domain = 33
+skip_probe = true
+
 # phase-263 C2c-zephyr — the MIXED WORKSPACE entry (C talker + C++ listener
 # + Rust heartbeat). Same native_sim/NSOS west path as the cpp entry; the
 # Zephyr application dir is examples/workspaces/mixed/src/zephyr_entry. The

--- a/examples/workspaces/cpp/src/demo_bringup/system.toml
+++ b/examples/workspaces/cpp/src/demo_bringup/system.toml
@@ -145,6 +145,30 @@ board = "threadx-linux"
 board = "native_sim/native/64"
 conf = ["prj-zenoh.conf"]
 
+# phase-206 W2, final item — the RTOS image that LINKS Cyclone and carries a
+# bringup config. `[image.zephyr]` above is zenoh, and the bringup ships
+# `rmw/cyclonedds.xml` and no `zenoh.conf`, so that image bakes NOTHING; this
+# one bakes the XML. The pair is the same negative control the native images
+# carry, one platform over.
+#
+# It exists because W2's other RTOS row could not close the acceptance: its app
+# is a 212.H.1 stub that never creates a node, so `--gc-sections` dropped the
+# backend and the bytes reached the OBJECT but not the IMAGE. This entry links
+# `talker_pkg` + `listener_pkg`, so the backend is referenced and survives.
+[image.zephyr_cyclonedds]
+board = "native_sim/native/64"
+rmw = "cyclonedds"
+conf = ["prj-cyclonedds.conf"]
+# RFC-0085 D4 — a Zephyr image NAMES its hand-written entry package. This one
+# has its OWN (`zephyr_cyclonedds_entry`, the derived spelling) rather than
+# sharing `zephyr_entry` with `[image.zephyr]`, because the image is resolved
+# ENTRY PACKAGE -> IMAGE by `nros image-facts --for-entry`: sharing makes that
+# lookup ambiguous, and a first-match scan picks the wrong one. Measured, not
+# assumed — sharing built with this image's cyclone overlay while `image-facts`
+# still answered `demo_bringup:zephyr` (rmw=zenoh), and
+# `nros_check_image_agreement` refused it.
+entry = "zephyr_cyclonedds_entry"
+
 # SITE config for this board (RFC-0072 §5): where THIS checkout keeps the
 # SDK roots it builds against. Keyed by BOARD, not by a deploy or image
 # name, because that is what the fact is about (issue 0951).

--- a/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/CMakeLists.txt
+++ b/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/CMakeLists.txt
@@ -1,0 +1,43 @@
+# phase-206 W2, final item — the RTOS image that LINKS Cyclone and carries a
+# bringup config.
+#
+# A SEPARATE entry package from `zephyr_entry`, and that is forced rather than
+# chosen: the image is resolved by `nros image-facts --for-entry <pkg>`, i.e.
+# ENTRY PACKAGE -> IMAGE, one way. Two images cannot share one entry package —
+# the lookup would have to pick, and RFC-0085 D4 records that a first-match scan
+# over candidates picks the wrong one. Trying to share `zephyr_entry` produced
+# exactly that: the build merged this file's `prj-cyclonedds.conf` while
+# `image-facts` still answered `demo_bringup:zephyr` (rmw=zenoh), and
+# `nros_check_image_agreement` refused the build —
+#
+#     image demo_bringup:zephyr declares: zenoh
+#     Kconfig selected:                   cyclonedds
+#
+# which is the gate doing its job. `BOARD` names the image.
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(nros_zephyr_workspace_entry_cpp_cyclonedds)
+
+find_package(nano_ros REQUIRED)
+
+# The same two component packages the zenoh entry links. They are what makes
+# this image a real acceptance for W2: the backend is REFERENCED, so
+# `--gc-sections` cannot drop it the way it dropped Cyclone from the 212.H.1
+# stub app, where the user's bytes reached `session.cpp.obj` and never the ELF.
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../talker_pkg" talker_pkg)
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../listener_pkg" listener_pkg)
+
+# BOARD is the board FAMILY token, not the image id — `board_family()` matches
+# exact strings ("zephyr", "nuttx", "freertos", ...) and an unknown one falls
+# through to the HOST default, which emits `int main(int, char**)` where the
+# Zephyr kernel declares `extern int main(void)`. Measured: naming the image
+# here produced exactly that conflict at
+# `zephyr_cyclonedds_entry_nros_main_generated.cpp:57`. The IMAGE is selected by
+# the entry PACKAGE name instead (`nros image-facts --for-entry`), which is what
+# this directory is for.
+nano_ros_add_executable(zephyr_cyclonedds_entry
+    BOARD   zephyr
+    BRINGUP "${CMAKE_CURRENT_SOURCE_DIR}/../demo_bringup"
+    TYPED
+    DEPLOY  zephyr)

--- a/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/package.xml
+++ b/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>zephyr_cyclonedds_entry</name>
+  <version>0.1.0</version>
+  <description>phase-206 W2 — Zephyr (native_sim) C++ Entry on CycloneDDS, the RTOS image that carries the bringup’s own RMW config.</description>
+  <maintainer email="dev@example.com">Developer</maintainer>
+  <license>Apache-2.0</license>
+  <exec_depend>demo_bringup</exec_depend>
+  <exec_depend>talker_pkg</exec_depend>
+  <exec_depend>listener_pkg</exec_depend>
+  <export>
+    <build_type>nros_cmake</build_type>
+  </export>
+</package>

--- a/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/prj-cyclonedds.conf
+++ b/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/prj-cyclonedds.conf
@@ -1,0 +1,48 @@
+# phase-206 W2 (final item) — CycloneDDS overlay for the Zephyr C++ workspace entry.
+#
+# WHY THIS FILE EXISTS. W2's RTOS row proved the bake fires and that
+# `session.cpp` compiles the user's bytes into its OBJECT on an RTOS target --
+# but not that they reach the IMAGE: that fixture's app is a 212.H.1 stub which
+# never creates a node, so `--gc-sections` dropped the whole Cyclone backend and
+# `strings zephyr.elf | grep -c ddsi_` was 0. This entry links `talker_pkg` and
+# `listener_pkg`, so the backend is referenced and survives the link.
+#
+# `CONFIG_CPP` is not decoration: `NROS_RMW_CYCLONEDDS` reads
+# `depends on NET_SOCKETS && POSIX_API && CPP` (zephyr/Kconfig), and an unmet
+# dependency does NOT fail -- Kconfig silently leaves the choice on its default
+# and builds ZENOH while every conf file says Cyclone. The base `prj.conf`
+# already sets `CONFIG_NROS_CPP_API=y` + `CONFIG_STD_CPP14=y` for the TYPED
+# entry, but `CONFIG_CPP` itself is what the dependency names.
+CONFIG_NROS_RMW_CYCLONEDDS=y
+CONFIG_CPP=y
+
+# RTPS uses UDP multicast for SPDP discovery.
+CONFIG_NET_IPV4_IGMP=y
+CONFIG_POSIX_API=y
+
+# Zephyr's pthread mutex/cond pools are per-OBJECT, so a mutex-per-entity
+# library makes them a cap on WORKLOAD size (issues 0371/0496): Cyclone draws
+# several locks per reader/writer/proxy, and exhaustion aborts mid-SEDP.
+CONFIG_MAX_PTHREAD_MUTEX_COUNT=2048
+CONFIG_MAX_PTHREAD_COND_COUNT=1024
+CONFIG_POSIX_THREAD_THREADS_MAX=16
+
+# Resource sizing — Cyclone is heavy. Matched to the standalone native_sim
+# Cyclone overlays under examples/zephyr/, which are the ones known to boot.
+CONFIG_MAIN_STACK_SIZE=524288
+CONFIG_HEAP_MEM_POOL_SIZE=4194304
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=8192
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=16777216
+CONFIG_DYNAMIC_THREAD_STACK_SIZE=32768
+
+CONFIG_NET_PKT_RX_COUNT=64
+CONFIG_NET_PKT_TX_COUNT=64
+CONFIG_NET_BUF_RX_COUNT=128
+CONFIG_NET_BUF_TX_COUNT=128
+
+# Host socket offload rather than zeth/TAP, as the other native_sim Cyclone
+# images use.
+CONFIG_NET_TCP=y
+CONFIG_NET_DRIVERS=y
+CONFIG_NET_SOCKETS_OFFLOAD=y
+CONFIG_NET_NATIVE_OFFLOADED_SOCKETS=y

--- a/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/prj.conf
+++ b/examples/workspaces/cpp/src/zephyr_cyclonedds_entry/prj.conf
@@ -1,0 +1,29 @@
+# phase-263 C2d — base config for the Zephyr C workspace entry (talker + listener).
+# RMW choice + RMW-specific sizing come from the prj-<rmw>.conf overlay. Mirrors the
+# standalone examples/zephyr/c/talker base.
+
+CONFIG_LOG=y
+CONFIG_LOG_DEFAULT_LEVEL=3
+CONFIG_PRINTK=y
+CONFIG_EARLY_CONSOLE=y
+
+CONFIG_NETWORKING=y
+CONFIG_NET_IPV4=y
+CONFIG_NET_UDP=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_MAX_CONTEXTS=16
+CONFIG_DNS_RESOLVER=n
+
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
+
+CONFIG_NROS=y
+CONFIG_NROS_C_API=y
+# The TYPED Zephyr entry is C++ (drives the C components' factory/configure seams via
+# ZephyrBoard::run_components), so the nros-cpp header surface must be on the app include
+# path and the entry compiles as C++17.
+CONFIG_NROS_CPP_API=y
+CONFIG_STD_CPP17=y
+
+CONFIG_NET_LOG=y
+CONFIG_NET_STATISTICS=y


### PR DESCRIPTION
W2’s last open item. It closes the acceptance — **and closing it found two defects in W2 itself**, neither visible until an image actually *linked* the backend.

## Why a new image

`west_bringup_zephyr_cyclone_user_config` is a compile-stage measurement by construction: its `main.c` is a 212.H.1 stub that never creates a node, so `--gc-sections` drops the backend and the user’s bytes stop at `session.cpp.obj`. `workspace-zephyr-cpp-cyclonedds` builds the **same bringup** through `examples/workspaces/cpp`’s Zephyr entry, which links `talker_pkg` + `listener_pkg` — the backend is *referenced*, so it survives the link.

## Acceptance, on `zephyr.elf`

| check | result |
|---|---|
| `strings \| grep -c ddsi_` (Cyclone really linked) | **14283** |
| `dds_create_domain` | 6 |
| `cdds.io/config` | 1 |
| the SSoT’s exact bytes, contiguous, in the ELF | **True** |
| generated header byte-identical to the SSoT | True |

Negative control, same workspace and bringup: `[image.zephyr]` is zenoh, and `rmw/` ships `cyclonedds.xml` and no `zenoh.conf`, so that image bakes nothing.

## Two defects in W2

**1 — the entry path could not see Zephyr’s RMW.** It resolved from `NANO_ROS_DEFAULT_RMW` / `NANO_ROS_RMW`; a west Zephyr image sets *neither* and selects through Kconfig. Measured: that build’s `CMakeCache.txt` has no `NANO_ROS_RMW` at all while its `.config` carries `CONFIG_NROS_RMW_CYCLONEDDS=y`. `_nra_rmw` came out empty and the bake was skipped. Now falls back to Kconfig with the same mapping and order `nros_system_generate` uses.

**2 — the include could not reach Zephyr’s backend.** It attached to a `nros_rmw_<backend>` **target**, but Zephyr compiles those TUs into the Zephyr *module library* (`zephyr_library_sources`), so no such target exists and the branch was dead. With defect 1 fixed, the header was byte-identical and Cyclone linked — and the ELF **still** carried none of the user’s bytes. Now published via `zephyr_include_directories()`.

Both left the build **green**: configure clean, compile clean, silently unconfigured. That is the exact failure this work item exists to make impossible, sitting inside the fix for it.

## Shape notes

- **A separate entry package is forced, not chosen.** The image resolves *entry package → image*, one way (`nros image-facts --for-entry`). Sharing `zephyr_entry` built with this image’s cyclone overlay while `image-facts` still answered `demo_bringup:zephyr (rmw=zenoh)`, and `nros_check_image_agreement` refused it — the gate doing its job.
- **`BOARD` stays `zephyr`** — it is the board *family* token; `board_family()` matches exact strings and an unknown one falls to `_ => Native`, which emitted the host `int main(int, char**)` against Zephyr’s `extern int main(void)`.
- **`west_cyclone_domain = 33`** because `zephyr-fixture-leaves.sh` only takes its "row authored its isolation values" branch when one is set; otherwise it reaches `variant_offset_for_role`, which does not know the role `entry`. 33 is `alloc::domain_of`’s answer (`1 + 1*21 + 3*3 + 2`), cross-checked against the shell’s own formulas.

## A trap, recorded in the phase doc

`NetworkInterface` and `autodetermine` appear in the ELF **whether or not the bake worked** — they are Cyclone’s own config-parser strings. Only `cdds.io/config` and a whole-document byte comparison separate a baked image from an unbaked one. The first run here read as a near-pass on those two and was a total miss.

Gates: `fixtures-manifest validate-{workspaces,fixtures}`, `check-zephyr-fixture-rows`, and `cxx-standard-floor` all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRhaGy4HrV5TjpeStL742