### PR TITLE
feat(phase-436): the poll/wake revision — deadline-driven executor (W1–W5)

### DIFF
--- a/packages/core/nros-node/src/executor/handles.rs
+++ b/packages/core/nros-node/src/executor/handles.rs
@@ -53,6 +53,10 @@ struct WaitBudget {
     deadline_us: u64,
     /// Iterations left, meaningful when `clock` is `None`.
     remaining: u64,
+    /// The TOTAL the caller allowed, in µs. Kept for the no-clock build: it
+    /// cannot measure elapsed time, but it still knows that a single spin must
+    /// never exceed the whole budget (phase-436 W4).
+    timeout_us: u64,
 }
 
 impl WaitBudget {
@@ -63,6 +67,38 @@ impl WaitBudget {
             clock,
             deadline_us: clock.map(|c| c().saturating_add(timeout_us)).unwrap_or(0),
             remaining: max_iterations,
+            timeout_us,
+        }
+    }
+
+    /// phase-436 W4 (issue 1195) — how long the next poll may spin without
+    /// overshooting the caller's deadline.
+    ///
+    /// These loops used a FIXED `DEFAULT_SPIN_INTERVAL_MS` and consulted the
+    /// budget only afterwards, so the last iteration always overshot: with
+    /// `max_spins` flooring at 1, `wait(1ms)` ran a full `spin_once(10ms)`.
+    /// The deadline was already in hand — it was simply checked one spin too
+    /// late.
+    ///
+    /// With no clock the build has no deadline to measure against, so the
+    /// caller's interval stands; that is the same honest fallback `tick`
+    /// makes.
+    fn next_spin_interval(&self, default: core::time::Duration) -> core::time::Duration {
+        let Some(clock) = self.clock else {
+            // No clock: elapsed is unknowable, but the TOTAL budget is not, and
+            // one spin may never exceed it.
+            let whole = core::time::Duration::from_micros(self.timeout_us);
+            return if whole < default { whole } else { default };
+        };
+        let now = clock();
+        if now >= self.deadline_us {
+            return core::time::Duration::ZERO;
+        }
+        let remaining = core::time::Duration::from_micros(self.deadline_us - now);
+        if remaining < default {
+            remaining
+        } else {
+            default
         }
     }
 
@@ -830,7 +866,7 @@ impl<const TX_BUF: usize> EmbeddedRawPublisher<TX_BUF> {
             match self.try_loan(len) {
                 Ok(loan) => return Ok(loan),
                 Err(LoanError::WouldBlock) => {
-                    executor.spin_once(spin_interval);
+                    executor.spin_once(budget.next_spin_interval(spin_interval));
                     if !budget.tick() {
                         return Err(LoanError::WouldBlock);
                     }
@@ -1319,7 +1355,7 @@ impl<M: RosMessage, const RX_BUF: usize> Subscription<M, RX_BUF> {
         let max_spins = (timeout_ms / DEFAULT_SPIN_INTERVAL_MS).max(1);
         let mut budget = WaitBudget::new(max_spins, timeout);
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if let Some(msg) = self.take()? {
                 return Ok(Some(msg));
             }
@@ -1629,7 +1665,7 @@ impl<const RX_BUF: usize> RawSubscription<RX_BUF> {
         let max_spins = (timeout_ms / DEFAULT_SPIN_INTERVAL_MS).max(1);
         let mut budget = WaitBudget::new(max_spins, timeout);
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if self.has_data() {
                 return self.try_borrow();
             }
@@ -2201,7 +2237,7 @@ impl<Svc: RosService, const REQ_BUF: usize, const REPLY_BUF: usize>
         // feeds the set runs on the executor's read path, so each `spin_once`
         // is what lets a freshly declared token land in the set.
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if matches!(self.handle.service_is_ready(), Ok(true)) {
                 return Ok(true);
             }
@@ -2317,7 +2353,7 @@ impl<T> Promise<'_, T> {
         let mut budget = WaitBudget::new(max_spins, timeout);
         // Always spin at least once so a zero-timeout still polls.
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if let Some(result) = self.take()? {
                 return Ok(result);
             }
@@ -2839,7 +2875,7 @@ impl<A: RosAction, const GOAL_BUF: usize, const RESULT_BUF: usize, const FEEDBAC
         let mut budget = WaitBudget::new(max_spins, timeout);
         // phase-428 W13 — spin, then ask again; see `wait_for_service`.
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if matches!(self.core.send_goal_client.service_is_ready(), Ok(true)) {
                 return Ok(true);
             }
@@ -2966,7 +3002,7 @@ impl<A: RosAction, const GOAL_BUF: usize, const RESULT_BUF: usize, const FEEDBAC
         let max_spins = (timeout_ms / DEFAULT_SPIN_INTERVAL_MS).max(1);
         let mut budget = WaitBudget::new(max_spins, timeout);
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if let Some(item) = self.client.try_recv_feedback()? {
                 return Ok(Some(item));
             }
@@ -3060,7 +3096,7 @@ impl<A: RosAction, const GOAL_BUF: usize, const RESULT_BUF: usize, const FEEDBAC
         let max_spins = (timeout_ms / DEFAULT_SPIN_INTERVAL_MS).max(1);
         let mut budget = WaitBudget::new(max_spins, timeout);
         loop {
-            executor.spin_once(spin_interval);
+            executor.spin_once(budget.next_spin_interval(spin_interval));
             if let Some((id, feedback)) = self.client.try_recv_feedback()?
                 && id.uuid == self.goal_id.uuid
             {
@@ -3169,5 +3205,47 @@ mod parse_response_tests {
         assert!(parse_goal_accepted(&frame).unwrap());
         let frame0 = [0x00, 0x01, 0x00, 0x00, 0x00];
         assert!(!parse_goal_accepted(&frame0).unwrap());
+    }
+}
+
+// ===========================================================================
+// phase-436 W4 (issue 1195) — the poll interval never overshoots the caller's
+// deadline.
+// ===========================================================================
+#[cfg(test)]
+mod wait_budget_tests {
+    use super::{DEFAULT_SPIN_INTERVAL_MS, WaitBudget};
+    use core::time::Duration;
+
+    const DEFAULT: Duration = Duration::from_millis(DEFAULT_SPIN_INTERVAL_MS);
+
+    /// A timeout shorter than one poll interval must not be rounded up to one.
+    /// `max_spins` floors at 1, so `wait(1ms)` ran a full `spin_once(10ms)` —
+    /// the caller's deadline exceeded tenfold before the budget was consulted.
+    #[test]
+    fn a_budget_shorter_than_the_interval_shortens_the_spin() {
+        let budget = WaitBudget::new(1, Duration::from_millis(1));
+        let interval = budget.next_spin_interval(DEFAULT);
+        assert!(
+            interval <= Duration::from_millis(1),
+            "a 1 ms budget must not spin for {interval:?}"
+        );
+    }
+
+    /// A budget longer than the interval keeps the interval: this is a cap on
+    /// the last iteration, not a change to the polling cadence.
+    #[test]
+    fn a_longer_budget_keeps_the_default_interval() {
+        let budget = WaitBudget::new(10, Duration::from_millis(100));
+        assert_eq!(budget.next_spin_interval(DEFAULT), DEFAULT);
+    }
+
+    /// An exhausted budget asks for no wait at all rather than one more
+    /// interval — the caller is about to give up, and sleeping first would be
+    /// pure overshoot.
+    #[test]
+    fn an_exhausted_budget_asks_for_a_zero_spin() {
+        let budget = WaitBudget::new(1, Duration::ZERO);
+        assert_eq!(budget.next_spin_interval(DEFAULT), Duration::ZERO);
     }
 }

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -2420,6 +2420,14 @@ impl<'s> Executor<'s> {
     ///
     /// Distinct from issue 0515's audit, which warns that a period does not
     /// divide the spin grid. That takes the grid as given; this moves it.
+    ///
+    /// `#[cfg(test)]`-gated (matching `mod tests`'s own gate in `mod.rs`):
+    /// production code calls `next_wake_bound_attributed_us` directly to get
+    /// the source alongside the bound, so this `.0`-only convenience has no
+    /// caller outside the test module and is dead code in any build that
+    /// does not compile it (every `cargo check`/`cargo doc`, and `cargo test
+    /// --features rmw-cffi`, which excludes `mod tests` too).
+    #[cfg(all(test, feature = "alloc", not(feature = "rmw-cffi")))]
     pub(crate) fn next_wake_bound_us(&self, budget_us: u64) -> u64 {
         self.next_wake_bound_attributed_us(budget_us).0
     }

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1472,6 +1472,12 @@ pub struct Executor<'s> {
     /// that carries a non-zero timeout (which is where the tier's
     /// declared spin period becomes visible to the executor).
     pub(crate) spin_quantization_checked: bool,
+    /// phase-436 W1 — the cadence the quantization audit (issue 0515) actually
+    /// ran against. Recorded because the audit only LOGS: without this a
+    /// regression that fed it the wrong number is invisible to a test, and
+    /// capping the park by the timer deadline is exactly such a regression
+    /// waiting to happen.
+    pub(crate) spin_quantization_us: u64,
     /// Issue #514 — violations discarded because the ring was full.
     /// Saturating. Without this a never-drained (or slowly-drained)
     /// image silently reports a stale prefix of its faults.
@@ -1529,6 +1535,10 @@ pub struct Executor<'s> {
     /// sleeps 30 ms has a 30 ms cadence and a 10 ms timeout, and judging it
     /// against the timeout reports a loop that is late on every single wake.
     pub(crate) spin_nominal_declared_us: u64,
+    /// phase-436 — the bound the last park was computed with, in us, and the
+    /// source that won it. See `WakeSourceId`.
+    pub(crate) last_park_bound_us: u64,
+    pub(crate) last_park_source: WakeSourceId,
     /// Wakes that were already past their nominal deadline, and wakes total.
     ///
     /// The maximum alone cannot distinguish one bad wake from a loop that is
@@ -1714,6 +1724,7 @@ impl<'s> Executor<'s> {
             age_states: [super::monitor::AgeState::default(); super::monitor::MAX_MONITORS],
             fault_fn: None,
             spin_quantization_checked: false,
+            spin_quantization_us: 0,
             monitor_violations_dropped: 0,
             max_release_jitter_us: 0,
             last_spin_entry_us: None,
@@ -1722,6 +1733,8 @@ impl<'s> Executor<'s> {
             stack_headroom_reported: usize::MAX,
             spin_nominal_us: 0,
             spin_nominal_declared_us: 0,
+            last_park_bound_us: 0,
+            last_park_source: WakeSourceId::CallerBudget,
             late_wakes: 0,
             total_wakes: 0,
             report_violations: true,
@@ -1833,6 +1846,21 @@ impl Executor<'static> {
         // forwarded to `from_session_ptr_in`.
         unsafe { Self::from_session_ptr_in(session_ptr, default_backing(sizing), sizing) }
     }
+}
+
+/// phase-436 — which deadline source bounded the last park.
+///
+/// Attribution is what turns "why did we wake" from a guess into a number.
+/// Recording it costs one byte per spin and is the difference between a
+/// schedulability argument you can audit and one you have to trust.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum WakeSourceId {
+    /// The `spin_once` caller's own timeout — always a member of the source
+    /// set, which is why the park is never unbounded.
+    CallerBudget,
+    /// A registered timer's next expiry (issue 1192).
+    Timer,
 }
 
 impl<'s> Executor<'s> {
@@ -2370,6 +2398,75 @@ impl<'s> Executor<'s> {
     /// still — the toolchain holds both numbers before the image is
     /// built — but this backstop needs no board or codegen change and
     /// catches hand-written spin loops too.
+    /// phase-436 W1 (issue 1192) — how long the executor may park, in
+    /// microseconds, given the caller's budget.
+    ///
+    /// The park used to be bounded by the caller's timeout narrowed by exactly
+    /// one input, the BACKEND's `next_deadline_ms`. A registered timer is a
+    /// deadline the EXECUTOR owns, and nothing let it shorten the sleep — so
+    /// `spin_default`'s 50 ms slept straight past a 10 ms timer, and the
+    /// activations then arrived in the burst issue 0505 describes.
+    ///
+    /// This is the `min` over the deadline sources phase-436 names. The
+    /// caller's budget is always a member, so the result is never unbounded
+    /// and never zero-by-omission: with no timers registered the budget
+    /// stands, which keeps a long idle wait a wait rather than a poll.
+    ///
+    /// Distinct from issue 0515's audit, which warns that a period does not
+    /// divide the spin grid. That takes the grid as given; this moves it.
+    pub(crate) fn next_wake_bound_us(&self, budget_us: u64) -> u64 {
+        self.next_wake_bound_attributed_us(budget_us).0
+    }
+
+    /// The bound and the source that produced it.
+    pub(crate) fn next_wake_bound_attributed_us(&self, budget_us: u64) -> (u64, WakeSourceId) {
+        match self.next_timer_deadline_us() {
+            Some(timer_us) if timer_us < budget_us => (timer_us, WakeSourceId::Timer),
+            _ => (budget_us, WakeSourceId::CallerBudget),
+        }
+    }
+
+    /// phase-436 — the bound the last park used, and which source won it.
+    pub fn last_park(&self) -> (u64, WakeSourceId) {
+        (self.last_park_bound_us, self.last_park_source)
+    }
+
+    /// Microseconds until the soonest live timer is due, or `None` when no
+    /// timer is pending.
+    ///
+    /// A timer that is cancelled, or a one-shot that already fired, owes
+    /// nothing and must not hold the park short — otherwise the executor keeps
+    /// waking on a deadline nobody is waiting for.
+    pub(crate) fn next_timer_deadline_us(&self) -> Option<u64> {
+        let arena_ptr = self.arena.as_ptr() as *const u8;
+        let mut soonest: Option<u64> = None;
+        for meta in self.entries.iter().flatten() {
+            if !matches!(meta.kind, EntryKind::Timer) {
+                continue;
+            }
+            // SAFETY: a Timer entry's arena slot holds a `TimerEntry<F>`, whose
+            // leading layout is `TimerHeader` — the same projection
+            // `audit_spin_quantization` relies on.
+            let header = unsafe { &*(arena_ptr.add(meta.offset) as *const TimerHeader) };
+            if header.cancelled || header.period_us == 0 {
+                continue;
+            }
+            if header.oneshot && header.fired {
+                continue;
+            }
+            // Already due: the bound is zero, and no other timer can beat it.
+            let remaining = header.period_us.saturating_sub(header.elapsed_us);
+            soonest = Some(match soonest {
+                Some(cur) => cur.min(remaining),
+                None => remaining,
+            });
+            if remaining == 0 {
+                break;
+            }
+        }
+        soonest
+    }
+
     fn audit_spin_quantization(&mut self, spin_us: u64) {
         if spin_us == 0 {
             return;
@@ -6471,6 +6568,20 @@ impl<'s> Executor<'s> {
             None => timeout_ms,
         };
 
+        // phase-436 W1 (issue 1192) — and by the next TIMER deadline, which is
+        // the one class of deadline the executor itself owns. Before this the
+        // park was bounded by the caller's budget narrowed only by the
+        // BACKEND's next event, so `spin_default`'s 50 ms slept straight past
+        // a registered 10 ms timer.
+        //
+        // Attribution is recorded here rather than derived later: this is the
+        // only point where the losing candidates are still in hand.
+        let (park_bound_us, park_source) =
+            self.next_wake_bound_attributed_us((timeout_ms.max(0) as u64).saturating_mul(1000));
+        self.last_park_bound_us = park_bound_us;
+        self.last_park_source = park_source;
+        let timeout_ms = (park_bound_us / 1000).min(i32::MAX as u64) as i32;
+
         // Wall-clock-accurate timer accumulation. Measure real time
         // since the previous `spin_once` exited (or, on the first call,
         // since `drive_io` started). Two failure modes the requested
@@ -6640,7 +6751,16 @@ impl<'s> Executor<'s> {
 
         if !self.spin_quantization_checked && timeout_ms > 0 {
             self.spin_quantization_checked = true;
-            self.audit_spin_quantization((timeout_ms as u64).saturating_mul(1000));
+            // The TIER's declared cadence, not the capped park bound. Since
+            // phase-436 W1 the two differ whenever a timer is due sooner than
+            // the budget, and auditing the cap would compare the timer period
+            // against itself — an exact multiple every time, so issue 0515's
+            // warning would go silent on precisely the images that have a
+            // timer to quantize. `spin_nominal_us` is the declared cadence
+            // (`set_spin_nominal_us`, else the caller's timeout), recorded at
+            // the top of this spin before any capping.
+            self.spin_quantization_us = self.spin_nominal_us;
+            self.audit_spin_quantization(self.spin_quantization_us);
         }
 
         let arena_ptr = self.arena.as_mut_ptr() as *mut u8;

--- a/packages/core/nros-node/src/executor/spin.rs
+++ b/packages/core/nros-node/src/executor/spin.rs
@@ -1539,6 +1539,11 @@ pub struct Executor<'s> {
     /// source that won it. See `WakeSourceId`.
     pub(crate) last_park_bound_us: u64,
     pub(crate) last_park_source: WakeSourceId,
+    /// phase-436 W2 — the park bound after rounding UP to what the platform's
+    /// wake primitive can express. Kept beside the request rather than
+    /// replacing it: reporting both is what makes the rounding auditable
+    /// instead of silent (issue 1194).
+    pub(crate) last_park_achieved_us: u64,
     /// Wakes that were already past their nominal deadline, and wakes total.
     ///
     /// The maximum alone cannot distinguish one bad wake from a loop that is
@@ -1735,6 +1740,7 @@ impl<'s> Executor<'s> {
             spin_nominal_declared_us: 0,
             last_park_bound_us: 0,
             last_park_source: WakeSourceId::CallerBudget,
+            last_park_achieved_us: 0,
             late_wakes: 0,
             total_wakes: 0,
             report_violations: true,
@@ -2429,6 +2435,74 @@ impl<'s> Executor<'s> {
     /// phase-436 — the bound the last park used, and which source won it.
     pub fn last_park(&self) -> (u64, WakeSourceId) {
         (self.last_park_bound_us, self.last_park_source)
+    }
+
+    /// phase-436 W2 — the park the platform was actually asked for, after
+    /// rounding the request up to an expressible value.
+    ///
+    /// Differs from `last_park().0` exactly when the request did not land on
+    /// the platform's grid. Both are reported because a cadence that cannot be
+    /// waited in must not be presented as if it were met.
+    pub fn last_park_achieved_us(&self) -> u64 {
+        self.last_park_achieved_us
+    }
+
+    /// phase-436 W3 (issue 1194) — the granularity the release-jitter
+    /// measurement was actually made at, in microseconds.
+    ///
+    /// The jitter statistic is reported in microseconds, but the mechanism
+    /// that PACES the loop decides how fine it can honestly be, and there are
+    /// two mechanisms:
+    ///
+    /// * **No declared cadence** — the loop is paced by the blocking wait
+    ///   itself, so it cannot come round more precisely than one park granule.
+    ///   Reporting µs there is precision the wait cannot deliver.
+    /// * **A declared cadence** (`set_spin_nominal_us`) — the caller paces
+    ///   itself, as nros-cpp's tiers do with `platform_sleep_us` between
+    ///   spins. That sleep is finer than the wait, so the measurement really
+    ///   is good to a microsecond and coarsening it would understate it.
+    ///
+    /// Reported rather than applied: this does not change what the monitor
+    /// judges, because silently coarsening a bound could mask real lateness.
+    /// It says what the number is worth.
+    pub fn release_jitter_granularity_us(&self) -> u64 {
+        if self.spin_nominal_declared_us != 0 {
+            1
+        } else {
+            self.park_granularity_us()
+        }
+    }
+
+    /// The finest park this build can actually express, in microseconds.    /// The finest park this build can actually express, in microseconds.
+    ///
+    /// Every `nros_platform_wake_*` port today takes `uint32_t timeout_ms`, so
+    /// the floor is one millisecond on every target — microseconds cannot
+    /// reach the primitive at all. A port that grows a finer slot lowers this,
+    /// and nothing above needs to change: callers ask in microseconds and are
+    /// told what was achieved.
+    pub fn park_granularity_us(&self) -> u64 {
+        // 1 ms — the granularity of `nros_platform_wake_wait_ms`.
+        1_000
+    }
+
+    /// Round a requested park UP to the platform's grid.
+    ///
+    /// Up, not nearest and not down. `as_millis()` truncated, which is how a
+    /// 500 us request became a 0 ms park — the non-blocking path, i.e. a
+    /// 100 % CPU spin with no warning (issue 1193) — and how 1500 us became a
+    /// 1 ms wait that is 33 % short of what was asked.
+    ///
+    /// Zero is preserved exactly: a zero timeout claims no cadence, and
+    /// promoting it to a granule would throttle every deliberate poll.
+    pub(crate) fn round_park_up_us(&self, requested_us: u64) -> u64 {
+        if requested_us == 0 {
+            return 0;
+        }
+        let g = self.park_granularity_us();
+        if g <= 1 {
+            return requested_us;
+        }
+        requested_us.div_ceil(g).saturating_mul(g)
     }
 
     /// Microseconds until the soonest live timer is due, or `None` when no
@@ -6521,7 +6595,13 @@ impl<'s> Executor<'s> {
     }
 
     pub fn spin_once(&mut self, timeout: core::time::Duration) -> SpinOnceResult {
-        let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        // phase-436 W2 (issue 1193) — the budget is carried in MICROSECONDS.
+        // This was `as_millis()`, which truncates: `from_micros(500)` became
+        // `0`, and a zero timeout selects the non-blocking path — so a
+        // sub-millisecond `spin()` was a 100 % CPU loop with no warning. The
+        // conversion to whatever the platform primitive accepts happens once,
+        // at the park, and rounds UP.
+        let timeout_us = timeout.as_micros().min(u64::MAX as u128) as u64;
 
         // phase-425 W3b — bring the `/clock` subscription in line with
         // `use_sim_time`. One bool comparison in the settled case; the work only
@@ -6563,9 +6643,9 @@ impl<'s> Executor<'s> {
         // Default backend impl returns `None`, so this is a no-op
         // unless the active backend opts in.
         #[allow(unused_variables)]
-        let timeout_ms = match self.session.next_deadline_ms() {
-            Some(next) => timeout_ms.min(next.min(i32::MAX as u32) as i32),
-            None => timeout_ms,
+        let timeout_us = match self.session.next_deadline_ms() {
+            Some(next) => timeout_us.min((next as u64).saturating_mul(1000)),
+            None => timeout_us,
         };
 
         // phase-436 W1 (issue 1192) — and by the next TIMER deadline, which is
@@ -6576,11 +6656,15 @@ impl<'s> Executor<'s> {
         //
         // Attribution is recorded here rather than derived later: this is the
         // only point where the losing candidates are still in hand.
-        let (park_bound_us, park_source) =
-            self.next_wake_bound_attributed_us((timeout_ms.max(0) as u64).saturating_mul(1000));
+        let (park_bound_us, park_source) = self.next_wake_bound_attributed_us(timeout_us);
         self.last_park_bound_us = park_bound_us;
         self.last_park_source = park_source;
-        let timeout_ms = (park_bound_us / 1000).min(i32::MAX as u64) as i32;
+        // phase-436 W2 (issue 1193) — round UP to what the primitive can
+        // express. The old `as_millis()` truncated, so a sub-millisecond
+        // request became a zero park: the non-blocking path, a busy loop.
+        let park_achieved_us = self.round_park_up_us(park_bound_us);
+        self.last_park_achieved_us = park_achieved_us;
+        let timeout_ms = (park_achieved_us / 1000).min(i32::MAX as u64) as i32;
 
         // Wall-clock-accurate timer accumulation. Measure real time
         // since the previous `spin_once` exited (or, on the first call,

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -1921,6 +1921,150 @@ fn test_arena_alignment() {
 // Timer callback tests
 // ====================================================================
 
+// ===========================================================================
+// phase-436 W1 (issue 1192) — the park is bounded by the next TIMER deadline.
+// ===========================================================================
+
+/// Issue 0515's audit must keep seeing the TIER's declared cadence, not the
+/// park bound. Capping the park by the timer deadline (issue 1192) makes the
+/// two differ, and if the audit follows the cap it compares the timer period
+/// against itself — always an exact multiple, so the warning that issue 0515
+/// exists to emit would go silent on every image that registers a timer.
+#[test]
+fn the_quantization_audit_sees_the_declared_cadence_not_the_park_bound() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    // The cap only bites when the timer is SHORTER than the budget, so that
+    // is the case to test: a 33 ms timer under `spin_default`'s 50 ms. If the
+    // audit followed the cap it would compare 33 ms against 33 ms — an exact
+    // multiple — and stay silent on a tier whose grid genuinely quantizes.
+    executor
+        .register_timer(TimerDuration::from_millis(33), || {})
+        .unwrap();
+
+    executor.spin_once(core::time::Duration::from_millis(50));
+
+    assert_eq!(
+        executor.spin_quantization_us, 50_000,
+        "the audit must run against the 50 ms declared cadence, not the 33 ms park bound"
+    );
+}
+
+/// The bound is not merely COMPUTED — `spin_once` must USE it, and must
+/// record which source won. Without that the helper could be correct and
+/// unused: the shape issue 0736 recorded, a probe on a path no image takes.
+#[test]
+fn spin_once_parks_on_the_timer_and_says_so() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor
+        .register_timer(TimerDuration::from_millis(10), || {})
+        .unwrap();
+
+    executor.spin_once(core::time::Duration::from_millis(50));
+
+    let (bound_us, source) = executor.last_park();
+    assert_eq!(
+        bound_us, 10_000,
+        "the 10 ms timer must bound the 50 ms park, got {bound_us} us"
+    );
+    assert_eq!(
+        source,
+        super::spin::WakeSourceId::Timer,
+        "the timer won this park, and the attribution must name it"
+    );
+}
+
+/// With no timer, the caller's budget wins and is named as the winner — the
+/// attribution has to distinguish "nothing else was pending" from "a timer
+/// happened to match the budget".
+#[test]
+fn spin_once_attributes_an_unbounded_park_to_the_caller() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::from_millis(50));
+
+    let (bound_us, source) = executor.last_park();
+    assert_eq!(bound_us, 50_000);
+    assert_eq!(source, super::spin::WakeSourceId::CallerBudget);
+}
+
+/// A registered timer is a deadline the EXECUTOR owns. A caller budget longer
+/// than that deadline must not let the executor sleep past it.
+#[test]
+fn a_timer_deadline_shortens_a_longer_caller_budget() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor
+        .register_timer(TimerDuration::from_millis(10), || {})
+        .unwrap();
+
+    // 50 ms is `spin_default`'s budget; the timer is due in 10 ms.
+    let bound_us = executor.next_wake_bound_us(50_000);
+    assert_eq!(
+        bound_us, 10_000,
+        "a 10 ms timer under a 50 ms budget must cap the park at 10 ms, got {bound_us} us"
+    );
+}
+
+/// The budget still wins when it is the tighter of the two: capping must be a
+/// `min`, not "the timer always decides".
+#[test]
+fn a_shorter_caller_budget_wins_over_a_later_timer() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor
+        .register_timer(TimerDuration::from_millis(100), || {})
+        .unwrap();
+
+    let bound_us = executor.next_wake_bound_us(5_000);
+    assert_eq!(
+        bound_us, 5_000,
+        "a 5 ms budget under a 100 ms timer must stay 5 ms, got {bound_us} us"
+    );
+}
+
+/// With no timers registered the budget stands unchanged — the cap must not
+/// invent a deadline and turn a long idle wait into a poll.
+#[test]
+fn no_timers_leaves_the_caller_budget_alone() {
+    let executor: Executor = executor_with_clock(MockSession::new());
+    assert_eq!(executor.next_wake_bound_us(50_000), 50_000);
+}
+
+/// The nearest of several timers decides.
+#[test]
+fn the_nearest_timer_decides_the_bound() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor
+        .register_timer(TimerDuration::from_millis(40), || {})
+        .unwrap();
+    executor
+        .register_timer(TimerDuration::from_millis(7), || {})
+        .unwrap();
+    executor
+        .register_timer(TimerDuration::from_millis(25), || {})
+        .unwrap();
+
+    assert_eq!(
+        executor.next_wake_bound_us(50_000),
+        7_000,
+        "the soonest of three timers is the one that bounds the park"
+    );
+}
+
+/// A cancelled timer owes nothing, so it must not hold the park short. Without
+/// this the cap would keep waking on a deadline nobody is waiting for.
+#[test]
+fn a_cancelled_timer_does_not_bound_the_park() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    let id = executor
+        .register_timer(TimerDuration::from_millis(10), || {})
+        .unwrap();
+    executor.cancel_timer(id).unwrap();
+
+    assert_eq!(
+        executor.next_wake_bound_us(50_000),
+        50_000,
+        "a cancelled timer is not a deadline"
+    );
+}
+
 #[test]
 #[cfg(feature = "std")] // asserts on real elapsed time, not a counter
 fn test_add_timer_and_fire() {

--- a/packages/core/nros-node/src/executor/tests.rs
+++ b/packages/core/nros-node/src/executor/tests.rs
@@ -1925,6 +1925,117 @@ fn test_arena_alignment() {
 // phase-436 W1 (issue 1192) — the park is bounded by the next TIMER deadline.
 // ===========================================================================
 
+// ===========================================================================
+// phase-436 W3 (issue 1194) — the jitter measurement states the granularity
+// it was actually made at, instead of implying microsecond precision the
+// pacing mechanism cannot deliver.
+// ===========================================================================
+
+/// A loop with no declared cadence is paced BY the blocking wait, so its
+/// jitter can only be as fine as the wait — one platform granule.
+#[test]
+fn jitter_granularity_is_the_park_granule_when_the_wait_paces_the_loop() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::from_millis(10));
+
+    assert_eq!(
+        executor.release_jitter_granularity_us(),
+        executor.park_granularity_us(),
+        "with no declared cadence the wait is the pacing mechanism, so it is \
+         also the floor on the measurement"
+    );
+}
+
+/// A loop that DECLARES its cadence paces itself — nros-cpp's tiers sleep
+/// `platform_sleep_us` between spins, which is finer than the blocking wait.
+/// Reporting a millisecond floor there would understate a real measurement.
+#[test]
+fn a_declared_cadence_means_the_loop_paces_itself_at_microseconds() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.set_spin_nominal_us(5_000);
+    executor.spin_once(core::time::Duration::from_millis(10));
+
+    assert_eq!(
+        executor.release_jitter_granularity_us(),
+        1,
+        "a declared cadence is paced by the caller's own sleep, not by the wait"
+    );
+}
+
+// ===========================================================================
+// phase-436 W2 (issue 1193) — the park rounds UP to what the platform can
+// actually achieve, and never truncates to a busy loop.
+// ===========================================================================
+
+/// A zero timeout means "poll, no cadence claimed". Rounding up must not
+/// promote it into a 1 ms sleep — that would turn every `Future::wait` busy
+/// drain into a throttled one.
+#[test]
+fn a_zero_park_stays_zero() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::ZERO);
+    assert_eq!(executor.last_park_achieved_us(), 0);
+}
+
+/// The defect: `as_millis()` truncates, so 500 us became 0 ms, which selects
+/// the non-blocking path and turns `spin()` into a 100 % CPU loop. A park
+/// shorter than the platform can express must round UP to what it can.
+#[test]
+fn a_sub_granularity_park_rounds_up_instead_of_collapsing_to_a_spin() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::from_micros(500));
+
+    let achieved = executor.last_park_achieved_us();
+    assert_eq!(
+        achieved,
+        executor.park_granularity_us(),
+        "500 us must round up to one granule, not down to a busy loop; got {achieved} us"
+    );
+    assert!(achieved > 0, "a non-zero request must never park for zero");
+}
+
+/// Rounding is UP, not nearest and not down: 1500 us on a 1 ms-granular port
+/// waits 2 ms. Truncating it to 1 ms is a 33 % short wait no caller asked for.
+#[test]
+fn a_park_rounds_up_never_down() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::from_micros(1_500));
+
+    let achieved = executor.last_park_achieved_us();
+    let g = executor.park_granularity_us();
+    assert_eq!(
+        achieved,
+        2 * g,
+        "1500 us must round up to two granules, got {achieved} us"
+    );
+}
+
+/// A request that already lands on the grid is left alone — rounding must not
+/// add a granule to a cadence that was already expressible.
+#[test]
+fn an_exact_multiple_is_not_inflated() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::from_millis(5));
+    assert_eq!(executor.last_park_achieved_us(), 5_000);
+}
+
+/// The rounding must be VISIBLE. A monitor that reports jitter in µs against a
+/// cadence the port cannot wait in is reporting precision it does not have
+/// (issue 1194) — so the executor states what it actually achieved.
+#[test]
+fn the_achieved_park_is_reported_separately_from_the_request() {
+    let mut executor: Executor = executor_with_clock(MockSession::new());
+    executor.spin_once(core::time::Duration::from_micros(1_500));
+
+    let (requested_us, _) = executor.last_park();
+    assert_eq!(requested_us, 1_500, "the request is reported as asked");
+    assert_ne!(
+        executor.last_park_achieved_us(),
+        requested_us,
+        "and the achieved value differs, which is the whole point of reporting both"
+    );
+}
+
 /// Issue 0515's audit must keep seeing the TIER's declared cadence, not the
 /// park bound. Capping the park by the timer deadline (issue 1192) makes the
 /// two differ, and if the audit follows the cap it compares the timer period

--- a/packages/platform/nros-platform-api/include/nros/platform.h
+++ b/packages/platform/nros-platform-api/include/nros/platform.h
@@ -644,7 +644,23 @@ int8_t nros_platform_condvar_signal_all(void *cv);
 int8_t nros_platform_condvar_signal_from_isr(void *cv);
 
 /** Atomically release `m` and block on `cv`. The mutex is re-acquired
- *  before this function returns. */
+ *  before this function returns.
+ *
+ *  **NOT REAL-TIME — this wait is UNBOUNDED.** Every port implements it with
+ *  its forever spelling (`TX_WAIT_FOREVER`, `portMAX_DELAY`, `K_FOREVER`), so
+ *  a caller that blocks here has no deadline and no way to be woken by one.
+ *  Nothing on the executor path calls it, and nothing new should: the
+ *  executor's own wait uses the BOUNDED `nros_platform_wake_wait_ms`, and a
+ *  condvar caller that needs a bound has `condvar_wait_until` directly below.
+ *
+ *  Kept rather than deleted because removing an exported symbol breaks
+ *  out-of-tree ports, and marked here rather than left neutral because
+ *  `condvar_wait` is the OBVIOUS spelling — the next port reaches for it and
+ *  loses the bound silently. `scripts/check-no-unbounded-condvar-wait.sh`
+ *  enforces the "nothing new" half; see issue 1196 and phase-436 W5.
+ *
+ *  "No unbounded wait" is only a property of the system if it is a property of
+ *  the API. */
 int8_t nros_platform_condvar_wait(void *cv, void *m);
 
 /** Like `condvar_wait`, but with an absolute monotonic deadline in

--- a/scripts/check-no-unbounded-condvar-wait.sh
+++ b/scripts/check-no-unbounded-condvar-wait.sh
@@ -24,9 +24,14 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 ALLOWED='packages/rmw/zenoh/zpico-sys/c/zpico/platform_aliases.c'
 
 # Match the call, never the bounded `_until` sibling and never a declaration.
-hits="$(grep -rn --include='*.rs' --include='*.c' --include='*.cpp' --include='*.h' --include='*.hpp' \
-    'nros_platform_condvar_wait[^_a-zA-Z]' \
-    packages/core packages/rmw packages/api 2>/dev/null \
+# `git grep` — an index lookup, not a filesystem walk (check-no-tracked-file-find).
+hits="$(git grep -n -e 'nros_platform_condvar_wait[^_a-zA-Z]' -- \
+    'packages/core/**/*.rs' 'packages/core/**/*.c' 'packages/core/**/*.cpp' \
+    'packages/core/**/*.h' 'packages/core/**/*.hpp' \
+    'packages/rmw/**/*.rs' 'packages/rmw/**/*.c' 'packages/rmw/**/*.cpp' \
+    'packages/rmw/**/*.h' 'packages/rmw/**/*.hpp' \
+    'packages/api/**/*.rs' 'packages/api/**/*.c' 'packages/api/**/*.cpp' \
+    'packages/api/**/*.h' 'packages/api/**/*.hpp' 2>/dev/null \
     | grep -v "^${ALLOWED}:" || true)"
 
 if [ -n "$hits" ]; then

--- a/scripts/check-no-unbounded-condvar-wait.sh
+++ b/scripts/check-no-unbounded-condvar-wait.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# phase-436 W5 (issue 1196) — the UNBOUNDED condvar wait stays confined to the
+# shim that bridges an upstream API which is itself unbounded.
+#
+# `nros_platform_condvar_wait` blocks forever by construction: every port
+# implements it with that port's forever spelling (`TX_WAIT_FOREVER`,
+# `portMAX_DELAY`, `K_FOREVER`). A bounded `nros_platform_condvar_wait_until`
+# sits directly beside it, and the executor's own wait already uses the bounded
+# `nros_platform_wake_wait_ms`.
+#
+# ONE exemption, and it is not a grandfathering: `platform_aliases.c` implements
+# zenoh-pico's `_z_condvar_wait`, whose CONTRACT is an unbounded wait. Bridging
+# an unbounded upstream primitive to an unbounded platform primitive is the
+# correct mapping; narrowing it there would silently change zenoh-pico's
+# semantics. The exemption is by path, so a second such call anywhere else
+# still has to be argued for.
+#
+# The risk this guards is the next backend or port: `condvar_wait` is the
+# obvious spelling, so it gets reached for and the bound is lost silently and
+# without review. A marked header states the rule; only a gate keeps it.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+ALLOWED='packages/rmw/zenoh/zpico-sys/c/zpico/platform_aliases.c'
+
+# Match the call, never the bounded `_until` sibling and never a declaration.
+hits="$(grep -rn --include='*.rs' --include='*.c' --include='*.cpp' --include='*.h' --include='*.hpp' \
+    'nros_platform_condvar_wait[^_a-zA-Z]' \
+    packages/core packages/rmw packages/api 2>/dev/null \
+    | grep -v "^${ALLOWED}:" || true)"
+
+if [ -n "$hits" ]; then
+    echo "check-no-unbounded-condvar-wait: the UNBOUNDED condvar wait is called outside the zenoh-pico alias shim:" >&2
+    printf '%s\n' "$hits" | sed 's/^/  /' >&2
+    echo >&2
+    echo '  nros_platform_condvar_wait has no deadline. Use' >&2
+    echo '  nros_platform_condvar_wait_until (absolute ms deadline), or the' >&2
+    echo "  executor's nros_platform_wake_wait_ms. See issue 1196, phase-436 W5." >&2
+    exit 1
+fi
+echo "check-no-unbounded-condvar-wait OK (confined to the zenoh-pico alias shim)."


### PR DESCRIPTION
Implements all five work items of [phase-436](docs/roadmap/phase-436-poll-wake-revision-deadline-driven-executor.md). Written test-first; each item's tests were confirmed to fail before the change.

> **Stacked on #648** (base is `fix/spin-nominal-is-the-period`, in the merge queue). W3 needs `set_spin_nominal_us` to tell "the caller paces itself" from "the wait paces the loop". Rebase to `main` once #648 lands.

## The change in one line

The executor asked **"how long may I block?"**. It now asks **"when is the next thing I owe anybody?"**

## W1 — the park is bounded by the next timer deadline (#1192)

The wait was the caller's timeout narrowed by exactly one input, the *backend's* `next_deadline_ms`. A registered timer is a deadline the executor **owns**, and nothing let it shorten the sleep — `spin_default()`'s 50 ms slept straight past a 10 ms timer.

`next_wake_bound_us` is the `min` over the deadline sources. The caller's budget is always a member, so the result is never unbounded and never zero-by-omission. Cancelled timers and fired one-shots are skipped. `WakeSourceId` records which source won each park.

**A regression this nearly introduced, caught by its own test:** issue 0515's quantization audit ran against `timeout_ms`, which is now the *capped* bound. Auditing the cap compares the timer period against itself — an exact multiple every time — so 0515's warning would have gone silent on exactly the images that have a timer to quantize. The audit now runs against the declared cadence.

## W2 — the park rounds up instead of truncating (#1193)

`as_millis()` truncates: `from_micros(500)` → `0` → the non-blocking path → a 100 % CPU loop with no warning. The budget is now carried in **microseconds** from the top of `spin_once`; conversion happens once, at the park, rounding **up**. Zero is preserved exactly — a zero timeout claims no cadence.

`park_granularity_us()` states what the build can express: 1 ms today, because every `nros_platform_wake_*` port takes `uint32_t timeout_ms`.

## W3 — jitter states the granularity it was measured at (#1194)

Two pacing mechanisms, two honest answers. No declared cadence ⇒ the blocking wait paces the loop ⇒ one granule. A declared cadence ⇒ the caller paces itself with `platform_sleep_us` ⇒ microseconds.

Reported, **not applied** — silently coarsening a bound could mask real lateness.

## W4 — a poll never overshoots the caller's deadline (#1195)

Five loops spun a fixed 10 ms and consulted the budget afterwards, so `wait(1ms)` ran a full `spin_once(10ms)`. The deadline was already in hand, just checked one spin too late. The no-clock path is capped from the total budget — and that is the path the tests exercise, since `default_clock_us_fn()` is `None` under test; the first version capped only the clock path and both tests caught it.

## W5 — the unbounded condvar wait, and a correction to my own issue

**Issue 1196's "no callers" claim was wrong.** The grep I ran was for `nros_platform_cond_wait`; the symbol is `nros_platform_cond**var**_wait`. A clean false negative — the gate found the real callers on its first run.

Both are correct as written: `platform_aliases.c` implements zenoh-pico's `_z_condvar_wait`, whose contract *is* an unbounded wait. So the header now marks the primitive NOT REAL-TIME with the reason, and `check-no-unbounded-condvar-wait.sh` confines it to that shim **by path** — a second call site has to be argued for. Verified by adding a call outside the shim and watching the gate reject it.

## Verification

- `cargo test -p nros-node --features std`: **359 passed, 0 failed** (was 341 on the base)
- Default-feature `cargo test`: **20 errors, same as the base** — this adds none
- `cargo fmt --check` clean; `check-no-unbounded-condvar-wait` OK
- Every new test confirmed RED first; the W1 wiring test, the audit-regression test, and both W4 tests were each re-run against the reverted change

## Not attempted

Making the wait loops wake off the backend's listener rather than a fixed grid (the larger half of #1195), and a `wake_wait_ns` platform slot — that would make every port grow a symbol, and the rounding contract delivers 1193's fix without it. Both are noted in the phase doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP2Rw4c4Hm9qfcbwCMQ1XD