### PR TITLE
fix(#1190): the arena priced a subscription's QoS history at three slots

### DIFF
--- a/docs/issues/0810-executor-arena-sized-by-worst-case-shape.md
+++ b/docs/issues/0810-executor-arena-sized-by-worst-case-shape.md
@@ -6,7 +6,7 @@ title: "The executor arena is sized at MAX_CBS x sizeof(ActionClient) whatever t
 status: open
 type: tech-debt
 area: core
-related: [phase-392, phase-390]
+related: [phase-392, phase-390, phase-403, 0900, 1190]
 ---
 
 ## Problem
@@ -58,6 +58,25 @@ The thing that knows the real entries is a *different stage*:
 script and cannot see it. So precise sizing means the entry generator emits the
 requirement and build.rs consumes it, rather than deriving a bound it has no
 information for.
+
+## The worst case was not a worst case (issue 1190, 2026-09-07)
+
+The comment quoted above — *"Subscription / service entries are strictly
+smaller"* — was FALSE, and the correction is the opposite direction from this
+issue's. A subscription's arena claim scales with its QoS history, and the model
+priced that history at three slots (the `depth <= 1` triple buffer) when the ROS
+default is KEEP_LAST(10) = eleven slots plus a length array. One ordinary
+subscription costs 12,144 bytes, not 3,584. The action-client term's slack —
+18,048 modelled against 14,600 measured — absorbed it on every image that
+budgets every slot at it, so this issue's over-provision was also what kept that
+under-provision invisible.
+
+So the two are one mechanism: a model nobody could check against the allocator.
+1190 landed the checkable half — the model is emitted as `config::arena_model`
+and each term is asserted to be an upper bound on the entry types it stands for,
+in `executor/arena.rs`, where `size_of` and the linked backend's handle are
+visible. What remains open here is the other half, sizing DOWN from what the
+image really registers.
 
 ## Not covered by this issue
 

--- a/docs/issues/archived/1190-zenoh-listener-buffertoosmall-on-register.md
+++ b/docs/issues/archived/1190-zenoh-listener-buffertoosmall-on-register.md
@@ -1,0 +1,188 @@
+---
+id: 1190
+title: "the arena derivation prices a subscription's QoS history at three slots when the ROS default is eleven, so a one-subscription image derives 8,192 bytes for a 12,144-byte registration"
+status: resolved
+type: bug
+area: core, rmw, api
+severity: high
+found: 2026-09-07
+resolved: 2026-09-07
+related: [0810, 0900, 1137, 0146, phase-403]
+---
+
+# `interop_e2e::case_2_zenoh_pubsub_ros2_to_nano`, measured live
+
+Found by phase-433 W2's after-run, in the `ros2` distrobox against ROS 2
+Humble, box tree at `605d667eb`, all fixtures freshly built.
+
+```
+FAIL [0.923s] interop::case_2_zenoh_pubsub_ros2_to_nano
+nros listener did not become ready: ProcessFailed(
+  "native-rs-listener did not print `Subscriber created for topic:` within 5s")
+```
+
+**Not a timeout and not a flake.** Three solo re-runs, 0.923 s / 0.925 s /
+0.929 s, all FAIL — the process exits almost immediately. Its own output
+carries the cause:
+
+```
+[ERROR] nros: arena exhausted: 3952 more bytes needed, 0/8192 in use.
+nros: application error: NodeRegister("native_rs_listener")
+[ERROR] nros: node declaration failed — NodeError::BufferTooSmall
+```
+
+`want` in that line is the shortfall PAST capacity, not the request
+(`report_arena_exhausted(new_used - arena.len(), …)`), so the single allocation
+asked for **8,192 + 3,952 = 12,144 bytes into an empty 8,192-byte arena**.
+
+## Root cause: the model prices a buffer nothing creates
+
+`packages/core/nros-node/build.rs` billed a pub/sub arena slot at
+
+```
+PUBSUB_SUB_BUFS * rx_buf + PUBSUB_ENTRY_OVERHEAD  =  3 * 1024 + 512  =  3,584
+```
+
+`3` is `TripleBuffer::SLOT_COUNT`, and a triple buffer is what
+`buffered_region_size` returns **only for `depth <= 1`**. Every deeper history
+is an `SpscRing`: `(depth + 1)` slots plus a `usize` length beside each. The
+ROS default is `rmw_qos_profile_default` = KEEP_LAST(**10**)
+(`QoSProfile::QOS_PROFILE_DEFAULT`), which every subscription created without an
+explicit QoS gets — including the listener's.
+
+The model carried no depth term at all, so it was short by a factor of ~3.7 on
+the most ordinary entity in ROS.
+
+**The 12,144 decomposes exactly**, on x86_64 with the cffi backend:
+
+| term | bytes |
+| --- | ---: |
+| `size_of::<SubBufferedRawEntry<F>>()` — the entry the declarative runtime registers | 640 |
+| its callback closure: a `heapless::String<128>` callback id (136) + the cell handle | 152 |
+| `buffered_region_size(10, 1024)` = `11 * 1024 + 11 * 8` | 11,352 |
+| **total** | **12,144** |
+
+against **3,584** modelled. Both halves of the model were short: the region term
+by 8,280 and the entry allowance by 280 — 512 is below *every* concrete entry
+this crate defines (`SubBufferedRawEntry<()>` 640, `SubBufferedEntry<(), ()>`
+and `SubBufferedRawCEntry` 656, `SubBufferedTypedCEntry` 672,
+`SubBufferedRawInfoCEntry` 872), most of that being the backend handle
+(`CffiSubscription` alone is 584, two 256-byte name buffers of it).
+
+## Why it survived four phases, and it is not the floor
+
+`ARENA_FLOOR` = 8,192 was **not** what hid this. `.max()` only raises: the
+listener's declared sum was `1 * 3,584 + 2,048` = 5,632 and the floor lifted it
+to 8,192 — the right direction, and still 3,952 short. Raising the floor to "one
+entry" would tax timer-only and publisher-only images 6,232 bytes for a
+guarantee they cannot use (8,192 holds 128 timers), so the floor stays where it
+is; the fix belongs in the per-entry model, and the model's terms are now
+asserted to be upper bounds rather than trusted.
+
+What hid it is the **action-client term's margin**. An image that does not
+declare its entities budgets every slot at the action-client worst case, 18,048
+bytes, and that term is genuinely an over-estimate: measured, the entry is 5,312
+bytes and its feedback region `buffered_region(8, 1024)` is 9,288, so 14,600
+against 18,048. 3,448 bytes of slack per slot is more than enough to absorb a
+pub/sub term short by 8,560 when the slot count is 4 and the subscriptions are
+2 — which is every image in the tree that predates the entity inventory.
+
+So the bug only becomes fatal on the images phase-403 step 3 made possible: the
+ones whose **declared** entity counts drive the per-kind sum. Across the 1,547
+`nros_node_config.rs` files in a fully-built developer tree, 1,524 read
+`ARENA_SIZE = 74,240` (the undeclared worst case) and 5 read 8,192. This is a
+regression introduced by step 3 (landed 2026-09-03), not a long-standing defect
+that nobody triggered — the derivation only became reachable-and-wrong when an
+image could declare one subscription.
+
+## The fix
+
+`packages/core/nros-node/build.rs`
+
+* `buffered_region(depth, slot)` — a `const fn` mirroring
+  `executor::arena::buffered_region_size`, the function the allocator itself
+  calls. Every term that stands for a buffered receive region goes through it.
+* `PUBSUB_QOS_DEPTH = 10`, restated from `QOS_PROFILE_DEFAULT.depth` because a
+  build script cannot read a const out of the crate it is building, and held to
+  it by `the_modelled_qos_depth_is_the_runtime_default`.
+* `PUBSUB_ENTRY_STRUCT` 512 → 1,024, which covers every concrete entry above
+  plus the declarative runtime's closure.
+* The service term is modelled on its OWN shape now (`2 * rx_buf + 1,024`)
+  rather than as `pubsub_entry + rx_buf`. A service server has no trailing
+  region — both buffers are inline and it reaches the arena through
+  `arena_alloc` — so leaving it hitched to the pub/sub entry would have billed
+  it 13,400 bytes against the 2,592 `SrvRawEntry<1024, 1024>` measures.
+* The model is EMITTED as `config::arena_model`, so nothing retypes it. The
+  compatibility test `the_default_derivation_is_unchanged` had six of its
+  constants copied out of the build script; it reads them now.
+
+`packages/core/nros-node/src/executor/arena.rs`
+
+* Compile-time assertions, gated on `rmw-cffi` (the configuration a real image
+  is built in), that each modelled term is an upper bound on the entry types it
+  stands for. This is the half a build script structurally cannot do: it has no
+  `size_of`, and the dominant term is the linked backend's handle. The
+  unit-test configuration substitutes `MockSubscriber`, whose 8-deep queue of
+  canned 256-byte takes makes it ~2.1 KiB — a fixture, not a handle any image
+  links, so sizing the model to cover it would spend 1.4 KiB of every slot on a
+  mock.
+* `DEFAULT_ACTION_FEEDBACK_DEPTH`, named so the `8u16` literal the action client
+  registers with can be held to the number `build.rs` prices it at.
+* Four unit tests in `arena_model_tests`. The load-bearing one,
+  `the_modelled_pubsub_region_covers_a_default_qos_subscription`, fails on the
+  old derivation with the numbers in it:
+
+  ```
+  the arena derivation budgets 3072 bytes for a subscription's buffered region
+  and the allocator claims 11352 for it (11 slots of 1024 at the default
+  KEEP_LAST(10)) — every image that derives its arena from a declared
+  subscription count is short by 8280 bytes per subscription
+  ```
+
+## What this costs
+
+Nothing, on 1,542 of the 1,547 built configs measured. The corrected pub/sub
+term multiplies `MAX_CBS - ARENA_ACTION_CLIENTS`, which is **zero** at the
+shipped defaults, so the default arena stays at exactly 74,240 — asserted, so a
+future move has to be a decision. It moves only images that declare entities,
+and only by what those entities actually claim: the listener goes
+8,192 → 14,424 for a registration that wants 12,144.
+
+The action-client term is left **byte-identical** on purpose. It is depth-blind
+in the same way the pub/sub term was, but unlike that one it is still an upper
+bound and by 3,448 bytes; rewriting it would move 1,524 images upward by 24,864
+each if the fiction of a 4,096-byte `pending_request` per service client is
+kept, or downward by 10,464 if it is not, and neither is a change this issue
+measured a need for. `the_modelled_action_client_entry_covers_its_feedback_region`
+is what will say so if that margin ever closes.
+
+## What is still owed
+
+`PUBSUB_QOS_DEPTH` is the DEFAULT depth, not a bound over every depth, so a
+subscription built with an explicit `QoS(N > 10)` still out-runs the derivation
+and still needs `NROS_EXECUTOR_ARENA_SIZE`. The right answer is phase-403 step
+2's remaining wiring: `NROS_ENTITY_DECLARED_DEPTHS` and
+`NROS_ENTITY_UNDECLARED_DEPTH_COUNT` reach cmake and stop there, never entering
+the cargo environment this build script reads. Carrying them across would both
+close that gap and let a declared KEEP_LAST(1) image reclaim the 8,280 bytes per
+subscription it is now budgeted and does not use. Recorded in the phase-403
+roadmap beside step 3's correction, not opened as a separate issue.
+
+## Not verified here
+
+The live cell. The fix was proven by arithmetic and by unit tests on a host with
+no ROS; `interop_e2e::case_2_zenoh_pubsub_ros2_to_nano` in the box is
+outstanding.
+
+## Corrections to the original report
+
+* `NodeRegister(…)` was read as possibly a keyexpr-length bound
+  (`node.rs:337` via `tx_writer`, or the three producers in `action_core.rs`).
+  It is not: the producer is `arena_alloc_with_trailing`, and the keyexpr DEBUG
+  lines immediately before it are the successful backend-side creation, not the
+  thing that failed. The arena advisory that named the real cause was already in
+  the output.
+* Whether it is a regression was recorded as unestablished. It is one — see the
+  argument above, which needs no baseline run: the declared-count branch that
+  produces an 8,192-byte arena for a one-subscription image landed on
+  2026-09-03.

--- a/docs/roadmap/phase-403-type-bound-rx-sizing.md
+++ b/docs/roadmap/phase-403-type-bound-rx-sizing.md
@@ -1483,6 +1483,32 @@ publisher's depth today.
 
 ### Step 3 LANDED 2026-09-03 -- the arena. Last, because its failure cannot report itself.
 
+> **Correction, 2026-09-07 (issue 1190). Step 3 shipped WITHOUT step 2's
+> depth, and the direction it guessed is the one this doc named as unsafe.**
+> Step 2's own design says it outright: *"assuming 1 UNDER-sizes an image that
+> took the default -- the unsafe direction"*, and *"the arena then REFUSES to
+> derive rather than defaulting"*. The per-kind sum that landed does neither.
+> It charges `3 * rx_buf + 512` per subscription -- three slots is
+> `TripleBuffer::SLOT_COUNT`, i.e. depth 1 -- and it reads no depth at all;
+> `NROS_ENTITY_DECLARED_DEPTHS` and `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` reach
+> cmake and stop there, never entering the cargo environment `nros-node/build.rs`
+> reads. So the first image whose inventory resolved to one subscription derived
+> an 8,192-byte arena for a 12,144-byte registration and died at
+> `Node::register` with `BufferTooSmall`, measured live on
+> `examples/native/rust/listener` in the ROS 2 box.
+>
+> The fix budgets the RUNTIME default depth (10) instead of refusing, because
+> refusing means "keep the hand-set knob" and these images have no hand-set
+> knob -- refusal there is the 8,192 that just failed. Budgeting the default is
+> not a guess: it is exactly what a subscription created with no QoS argument
+> gets. An image that states a smaller depth in code is over-provisioned and
+> can say so with `NROS_EXECUTOR_ARENA_SIZE`.
+>
+> **What is still owed is step 2's actual wiring**: carry the declared depths
+> (or their maximum) into the cargo env so a declared KEEP_LAST(1) image gets
+> the 3-slot region it really uses instead of the 11-slot default. That is the
+> remaining saving here and it is not what 1190 fixed.
+
 With depth present the arena is a straight sum: `arena_alloc` is a BUMP
 allocator, so the total IS the sum of the allocations. Two things are still
 needed:

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -8,6 +8,39 @@
 
 use std::{env, path::Path};
 
+/// `TripleBuffer::SLOT_COUNT` — the slot count a `KEEP_LAST(<=1)` history uses.
+const TRIPLE_BUFFER_SLOTS: usize = 3;
+
+/// `size_of::<usize>()` for the `SpscRing`'s per-slot length array, taken at
+/// its 64-bit width. A 32-bit target spends 4, so this over-states there by
+/// `(depth + 1) * 4` — the one direction that cannot under-size an arena.
+const RING_LEN_BYTES: usize = 8;
+
+/// The QoS history depth an undeclared subscription actually gets:
+/// `QoSProfile::QOS_PROFILE_DEFAULT.depth`, i.e. `rmw_qos_profile_default`'s
+/// KEEP_LAST(10). Issue 1190 — modelling this as 1 (the triple-buffer case) is
+/// what under-sized the arena by 8,560 bytes per subscription.
+///
+/// RESTATED here because a build script cannot read a const out of the crate it
+/// is building; `the_modelled_qos_depth_is_the_runtime_default` in
+/// `executor/arena.rs` is what keeps the two equal.
+const PUBSUB_QOS_DEPTH: usize = 10;
+
+/// Bytes one buffered receive region claims, mirroring
+/// [`executor::arena::buffered_region_size`] — the function the allocator
+/// itself calls.
+///
+/// `depth <= 1` is a `TripleBuffer`: three slots, no length array. Anything
+/// deeper is an `SpscRing` with `depth + 1` slots (Lamport's extra slot) and a
+/// `usize` length beside each.
+const fn buffered_region(depth: usize, slot: usize) -> usize {
+    if depth <= 1 {
+        TRIPLE_BUFFER_SLOTS * slot
+    } else {
+        (depth + 1) * slot + (depth + 1) * RING_LEN_BYTES
+    }
+}
+
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
@@ -127,9 +160,28 @@ fn main() {
     // smaller, so budget every slot at the action-client size.
     // Per entry: 3 × (4096 + 384) + 3 × rx_buf + 1536 ≈ 14976 + 3·rx_buf
     //
+    // **"Subscription entries are strictly smaller" was FALSE and is the whole
+    // of issue 1190.** A subscription's arena claim is
+    // `size_of(entry) + buffered_region_size(qos.depth, slot)`, and that region
+    // is a TRIPLE BUFFER (3 slots, no length array) only at depth <= 1. The ROS
+    // default is KEEP_LAST(**10**) -- `QoSProfile::QOS_PROFILE_DEFAULT` -- where
+    // the region is an `SpscRing` of `depth + 1 = 11` slots PLUS an 11-entry
+    // `usize` length array. Measured live in the ROS 2 box on
+    // `examples/native/rust/listener`: 792 (the `SubBufferedRawEntry<closure>`
+    // the declarative path registers) + 11 * (1024 + 8) = **12,144 bytes for one
+    // ordinary subscription**, against `3 * 1024 + 512` = 3,584 modelled. The
+    // image had an 8,192-byte arena and died at `Node::register` with
+    // `NodeError::BufferTooSmall`.
+    //
+    // So every term that stands for a buffered receive region goes through
+    // `buffered_region()` below, which mirrors
+    // `executor::arena::buffered_region_size` exactly, at the depth the runtime
+    // will actually use. `arena.rs` holds the const assertions that keep each
+    // modelled term an upper bound on the entry types it stands for; those see
+    // the real backend handle sizes, which a build script cannot.
+    //
     // Embedded targets that never instantiate an `ActionClient` can
-    // override the derived size with `NROS_EXECUTOR_ARENA_SIZE`. A
-    // pub/sub-only workload only needs `3 × rx_buf + 512` per entry.
+    // override the derived size with `NROS_EXECUTOR_ARENA_SIZE`.
     //
     // Phase 214.C.4 — magic-number breakdown for `4480` and friends:
     //   ACTION_CLIENT_SERVICE_BUF   = 4096  // pending_request blocking-fallback buf
@@ -141,14 +193,58 @@ fn main() {
     const ACTION_CLIENT_SERVICES: usize = 3;
     const ACTION_CLIENT_FEEDBACK_SUBS: usize = 3; // goal + result + feedback rx
     const ACTION_CLIENT_SUB_OVERHEAD: usize = 1536;
+    // The depth `NodeHandle::create_action_client_with_callbacks_sized` passes
+    // for the feedback stream. RESTATED, like `PUBSUB_QOS_DEPTH`, and held to
+    // `nros_node::executor::DEFAULT_ACTION_FEEDBACK_DEPTH` by a test.
+    //
+    // It is NOT in the arithmetic below, deliberately. The action-client term
+    // is depth-blind in the same way the pub/sub term was, but unlike that one
+    // it is still an UPPER BOUND and by a wide margin: measured on x86_64 with
+    // the cffi backend, the entry is 5,312 bytes and its feedback region
+    // `buffered_region(8, 1024)` = 9,288, so 14,600 against the 18,048 this
+    // models. Rewriting it to `struct + buffered_region(8, rx)` would move
+    // every one of the 1,524 images built at the default 74,240 -- upward by
+    // 24,864 B if the fiction of a 4,096-byte `pending_request` per service
+    // client is kept, downward by 10,464 B if it is not. Neither is a change
+    // this issue measured a need for, and downward is the direction that
+    // breaks images. So the term is left byte-identical and the PROPERTY is
+    // asserted instead (`arena.rs`), which is what will notice if the margin
+    // ever closes. That margin is also what hid this bug: it is why a 4-slot
+    // image survived a pub/sub term short by 8,560 B per subscription.
+    const ACTION_FEEDBACK_DEPTH: u16 = 8;
     const ARENA_BASE_OVERHEAD: usize = 2048;
+    // The smallest arena the derivation will hand out. Issue 1190 asked whether
+    // this should be at least ONE entry, and the answer is no.
+    //
+    // It did not hide the bug. `.max()` only ever RAISES: the listener's
+    // declared sum was 5,632 and the floor made it 8,192, in the right
+    // direction and still 3,952 short of the 12,144 the registration wanted.
+    // What hid the bug was the action-client term's margin above, on the images
+    // that budget every slot at it.
+    //
+    // Raising it to "one subscription entry" (14,424 at the defaults) would tax
+    // every timer-only and publisher-only image 6,232 bytes for a guarantee it
+    // cannot use -- 8,192 holds 128 timers. A floor is safe exactly when the
+    // per-entry model is right, which is why the fix went there and why the
+    // model's terms are now asserted to be upper bounds rather than trusted.
     const ARENA_FLOOR: usize = 8192;
     // issue 0900 — the budget for the two entry SHAPES, summed over how many
     // slots each may occupy, instead of charging every slot the larger one.
     // With `action_clients == max_cbs` (the default) the second term is zero
     // and this is byte-identical to the old formula.
-    const PUBSUB_SUB_BUFS: usize = 3;
-    const PUBSUB_ENTRY_OVERHEAD: usize = 512;
+    //
+    // issue 1190 — the STRUCT half of a pub/sub entry, with the buffered region
+    // now a separate term. 512 was short of every concrete entry this crate
+    // defines: measured on x86_64 with the cffi backend,
+    // `SubBufferedRawEntry<()>` is 640, `SubBufferedEntry<(), ()>` and
+    // `SubBufferedRawCEntry` 656, `SubBufferedTypedCEntry` 672 and
+    // `SubBufferedRawInfoCEntry` 872 -- the bulk of it the backend handle
+    // (`CffiSubscription` alone is 584, two 256-byte name buffers of it). The
+    // declarative runtime's callback closure carries a 128-byte `heapless`
+    // callback id on top, which is how the failing image reached 792. 1024
+    // covers every one of those; the const assertions in `arena.rs` hold it to
+    // that per backend, since only the crate can see a handle's size.
+    const PUBSUB_ENTRY_STRUCT: usize = 1024;
     let action_client_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
         + ACTION_CLIENT_FEEDBACK_SUBS * rx_buf_size
         + ACTION_CLIENT_SUB_OVERHEAD;
@@ -183,18 +279,33 @@ fn main() {
     // resolutions have already caused in this file's sibling. It is named in
     // phase-403 step 3 rather than guessed at here.
     let rx_recv_size = env_usize("NROS_SUBSCRIBER_BUFFER_SIZE", rx_buf_size);
-    let pubsub_entry = PUBSUB_SUB_BUFS * rx_recv_size + PUBSUB_ENTRY_OVERHEAD;
+    // issue 1190 -- the region a subscription's QoS history actually claims, at
+    // the depth the runtime will actually use. `PUBSUB_QOS_DEPTH` is a
+    // RESTATEMENT of `QoSProfile::QOS_PROFILE_DEFAULT.depth`, which a build
+    // script cannot read; `the_modelled_qos_depth_is_the_runtime_default` in
+    // `arena.rs` holds the two together.
+    //
+    // It is the DEFAULT depth, not a bound over every depth, so a subscription
+    // built with an explicit `QoS(N > 10)` still out-runs it and still needs
+    // `NROS_EXECUTOR_ARENA_SIZE`. Carrying the declared depths here instead is
+    // phase-403 step 2's remaining wiring: `NROS_ENTITY_DECLARED_DEPTHS` and
+    // `NROS_ENTITY_UNDECLARED_DEPTH_COUNT` reach cmake and stop there, so this
+    // lane has nothing better to read yet. Budgeting the default is not a guess
+    // in the meantime -- it is exactly what a subscription created with no QoS
+    // argument gets, which is what "the image declared nothing" means.
+    let pubsub_region = buffered_region(PUBSUB_QOS_DEPTH, rx_recv_size);
+    let pubsub_entry = pubsub_region + PUBSUB_ENTRY_STRUCT;
 
     // phase-403 step 3 -- SUM OVER WHAT THE IMAGE DECLARES, when it declares.
     //
     // The arithmetic below this comment charges EVERY callback slot at the
     // pub/sub entry size. That is a worst case over `max_cbs`, and on an image
     // that declares its entities it is wrong in a measurable direction: a
-    // TIMER claims 32 bytes of arena (measured, `report_arena_costs`) and this
-    // model bills it `3 * rx_buf + 512` -- 5,000 bytes at the reference
-    // island's derived rx_buf of 1,496. Ten subscriptions and four timers cost
-    // 72,048 modelled against ~50,000 actually claimed, which is why that
-    // image pins the knob by hand.
+    // TIMER claims 32 bytes of arena (measured, `report_arena_costs`) and the
+    // undeclared branch bills it a whole pub/sub entry -- 17,568 bytes at the
+    // reference island's derived rx_buf of 1,496, and 5,000 back when this
+    // paragraph was written and the pub/sub term modelled three slots instead
+    // of eleven (issue 1190). Which is why that image pins the knob by hand.
     //
     // So when phase-403 W9's entity inventory reaches this lane, the sum runs
     // per KIND instead. Absence is not zero: a count that is missing means
@@ -206,6 +317,20 @@ fn main() {
     // pointer-generous 64 rather than pinned to the host figure -- the one
     // direction that cannot under-size a 32-bit target.
     const TIMER_ENTRY: usize = 64;
+    // issue 1190 -- a service server is modelled on its OWN shape, not on the
+    // pub/sub entry plus a buffer.
+    //
+    // It has no trailing region at all: `SrvRawEntry<REQ, REPLY>` /
+    // `SrvEntry<..>` carry the request and reply buffers INLINE and reach the
+    // arena through `arena_alloc`, not `arena_alloc_with_trailing`. So it costs
+    // two buffers plus the handle, and it never paid the QoS-depth multiplier
+    // the pub/sub term has just grown. Keeping `pubsub_entry + rx_buf` would
+    // have billed a service 13,400 bytes at the defaults against the 2,592
+    // `SrvRawEntry<1024, 1024>` measures on x86_64 with the cffi backend --
+    // a fix in one term inflating an unrelated one.
+    const SERVICE_ENTRY_BUFS: usize = 2; // request + reply
+    const SERVICE_ENTRY_STRUCT: usize = 1024; // handle + callback + ctx, as above
+    let service_entry = SERVICE_ENTRY_BUFS * rx_buf_size + SERVICE_ENTRY_STRUCT;
     let declared_subs = env_opt_usize("NROS_ENTITY_COUNT_SUBSCRIPTION");
     let declared_timers = env_opt_usize("NROS_ENTITY_COUNT_TIMER");
     let declared_services = env_opt_usize("NROS_ENTITY_COUNT_SERVICE_SERVER");
@@ -219,18 +344,12 @@ fn main() {
         declared_action_clients,
         declared_action_servers,
     ) {
-        (Some(subs), Some(timers), Some(services), Some(acl), Some(asv)) => {
-            // A service server carries a request AND a reply buffer, so it is
-            // billed at the pub/sub entry plus one more buffer rather than
-            // being folded into the pub/sub term.
-            let service_entry = pubsub_entry + rx_buf_size;
-            (subs * pubsub_entry
-                + timers * TIMER_ENTRY
-                + services * service_entry
-                + (acl + asv) * action_client_entry
-                + ARENA_BASE_OVERHEAD)
-                .max(ARENA_FLOOR)
-        }
+        (Some(subs), Some(timers), Some(services), Some(acl), Some(asv)) => (subs * pubsub_entry
+            + timers * TIMER_ENTRY
+            + services * service_entry
+            + (acl + asv) * action_client_entry
+            + ARENA_BASE_OVERHEAD)
+            .max(ARENA_FLOOR),
         // Nobody declared, or declared only partly: keep the pre-step-3
         // arithmetic byte for byte, so no existing image moves.
         _ => (action_clients * action_client_entry
@@ -291,7 +410,51 @@ fn main() {
          /// Shutdown-hook slots PER PHASE -- one table this size for \
          pre-shutdown hooks and a second for on-shutdown hooks \
          (set via NROS_EXECUTOR_MAX_SHUTDOWN_CBS, default 2). Issue 0790.\n\
-         pub const MAX_SHUTDOWN_CBS: usize = {max_shutdown_cbs};\n"
+         pub const MAX_SHUTDOWN_CBS: usize = {max_shutdown_cbs};\n\
+         \n\
+         /// Issue 1190 -- the arena derivation's MODEL, as the consts it \
+         summed.\n\
+         ///\n\
+         /// Emitted rather than retyped: `executor::arena` asserts that each \
+         term\n\
+         /// is an UPPER BOUND on the entry types it stands for, and it can \
+         only do\n\
+         /// that against the numbers the derivation actually used. The \
+         previous\n\
+         /// arrangement had `the_default_derivation_is_unchanged` retyping \
+         six of\n\
+         /// them, which is a second copy that agrees until one side moves.\n\
+         pub mod arena_model {{\n    \
+             /// QoS history depth the pub/sub term budgets \
+             (`QoSProfile::QOS_PROFILE_DEFAULT.depth`).\n    \
+             pub const QOS_DEPTH: u32 = {pubsub_qos_depth};\n    \
+             /// Buffered receive region for ONE subscription at that depth.\n    \
+             pub const PUBSUB_REGION: usize = {pubsub_region};\n    \
+             /// Allowance for the entry STRUCT beside that region.\n    \
+             pub const PUBSUB_STRUCT: usize = {pubsub_entry_struct};\n    \
+             /// Whole modelled cost of one subscription slot.\n    \
+             pub const PUBSUB_ENTRY: usize = {pubsub_entry};\n    \
+             /// Whole modelled cost of one service-server slot.\n    \
+             pub const SERVICE_ENTRY: usize = {service_entry};\n    \
+             /// Whole modelled cost of one timer slot.\n    \
+             pub const TIMER_ENTRY: usize = {timer_entry};\n    \
+             /// Whole modelled cost of one action-client / action-server \
+             slot.\n    \
+             pub const ACTION_CLIENT_ENTRY: usize = {action_client_entry};\n    \
+             /// QoS depth an action client's feedback stream registers with.\n    \
+             pub const ACTION_FEEDBACK_DEPTH: u16 = \
+             {action_feedback_depth};\n    \
+             /// Per-executor overhead the derivation adds once.\n    \
+             pub const BASE_OVERHEAD: usize = {arena_base_overhead};\n    \
+             /// Smallest arena the derivation will produce.\n    \
+             pub const FLOOR: usize = {arena_floor};\n\
+         }}\n",
+        pubsub_qos_depth = PUBSUB_QOS_DEPTH,
+        pubsub_entry_struct = PUBSUB_ENTRY_STRUCT,
+        action_feedback_depth = ACTION_FEEDBACK_DEPTH,
+        arena_base_overhead = ARENA_BASE_OVERHEAD,
+        arena_floor = ARENA_FLOOR,
+        timer_entry = TIMER_ENTRY,
     );
 
     std::fs::write(Path::new(&out_dir).join("nros_node_config.rs"), contents).unwrap();

--- a/packages/core/nros-node/src/executor/arena.rs
+++ b/packages/core/nros-node/src/executor/arena.rs
@@ -424,6 +424,15 @@ impl BufferStrategy {
     }
 }
 
+/// The QoS depth an action client's FEEDBACK stream registers with.
+///
+/// Issue 1190 — was an `8u16` literal at
+/// `NodeHandle::create_action_client_with_callbacks_sized`'s one call site.
+/// Named because `nros-node/build.rs` restates it to price the action-client
+/// arena slot, and a literal is a restatement nothing can be held to; see
+/// [`arena_model_tests`].
+pub const DEFAULT_ACTION_FEEDBACK_DEPTH: u16 = 8;
+
 /// Compute the number of buffer slots and trailing region size for a given
 /// QoS depth and per-slot buffer size.
 ///
@@ -573,9 +582,12 @@ static ARENA_ADVISORY_DONE: portable_atomic::AtomicBool = portable_atomic::Atomi
 /// Report an arena that is far larger than the entities registered in it.
 ///
 /// `ARENA_SIZE` is derived by budgeting EVERY slot at the ActionClient worst
-/// case (`nros-node/build.rs`), so an image with no action client carries
-/// several times what it can use — 74,240 bytes against ~16 KiB for a
-/// pub/sub-only workload at the defaults. The arena is a BUMP allocator, so
+/// case (`nros-node/build.rs`) unless the image declares its entities, so an
+/// image with no action client carries several times what it can use — 74,240
+/// bytes against ~51 KiB for four default-QoS subscriptions. (That comparison
+/// read "~16 KiB" until issue 1190: the pub/sub figure it named came from a
+/// model that priced a subscription's history at three slots when the ROS
+/// default is eleven.) The arena is a BUMP allocator, so
 /// `arena_used` is the exact claimed total rather than a reservation, and the
 /// allocator has therefore always known the right answer and never said it.
 ///
@@ -693,10 +705,14 @@ static ARENA_EXHAUSTED_REPORTED: portable_atomic::AtomicBool =
 
 /// Is this arena grossly larger than what registered in it?
 ///
-/// Half is the threshold because the derivation's own error is a factor of
-/// ~4.5 at the defaults (74,240 bytes budgeted against ~16 KiB for a
-/// pub/sub-only image), so "under half" is unambiguous rather than a rounding
-/// artifact, and an image that genuinely uses most of its arena stays quiet.
+/// Half is the threshold because the derivation's own over-provision at the
+/// defaults is larger than that (74,240 bytes budgeted against ~51 KiB for four
+/// default-QoS subscriptions, and against a few hundred bytes for a timer-only
+/// image), so "under half" is unambiguous rather than a rounding artifact, and
+/// an image that genuinely uses most of its arena stays quiet. Issue 1190 moved
+/// the pub/sub half of that comparison from ~16 KiB to ~51 KiB, which
+/// deliberately takes a four-subscription image OUT of the advisory: it is not
+/// over-provisioned, it was mis-priced.
 ///
 /// A zero capacity is NOT over-provisioned: that is the sentinel bug issue 0460
 /// produced on Zephyr (a literal `0` forwarded instead of the derivation), and
@@ -710,10 +726,181 @@ pub(crate) const fn arena_is_over_provisioned(used: usize, capacity: usize) -> b
     capacity != 0 && used.saturating_mul(2) <= capacity
 }
 
+// ============================================================================
+// Issue 1190 — the arena model is an UPPER BOUND, asserted where the sizes are
+// ============================================================================
+//
+// `nros-node/build.rs` sums a per-kind cost model into `ARENA_SIZE` and says of
+// itself that subscription and service entries are "strictly smaller" than the
+// action-client slot it budgets at. That sentence was false for four phases:
+// the pub/sub term charged `3 * rx_buf + 512`, which is a `TripleBuffer` (the
+// `depth <= 1` case) plus an entry allowance smaller than any entry this crate
+// defines, while an ordinary `KEEP_LAST(10)` subscription claims
+// `size_of(entry) + (depth + 1) * (slot + 8)`. Measured live: 12,144 bytes into
+// an 8,192-byte arena, dying at `Node::register` with `BufferTooSmall`.
+//
+// A build script cannot check this. It has no `size_of`, and the dominant term
+// is the BACKEND's handle — 584 bytes of `CffiSubscription`, most of it two
+// 256-byte name buffers — which is a fact of the linked backend, not of the
+// build script's environment. So the model is emitted (`config::arena_model`)
+// and bounded HERE, per image, per backend, at compile time.
+//
+// Gated on `rmw-cffi` because that is the configuration a real image is built
+// in. The unit-test configuration substitutes `MockSubscriber`, whose 8-deep
+// queue of 256-byte canned takes makes it ~2.1 KiB — a test fixture, not a
+// handle any image links, and sizing the model to cover it would spend 1.4 KiB
+// of every slot on a mock. The depth half of the model is backend-independent
+// and is checked in the unit tests below, which do run in that configuration.
+#[cfg(feature = "rmw-cffi")]
+const _: () = {
+    use crate::config::arena_model as model;
+
+    // The buffered subscription entries. `<(), ()>` and the C entries carry no
+    // user closure, so this bounds the STRUCT the crate owns plus the backend
+    // handle; a caller's own callback is captured by value on top of it and is
+    // the one part no static bound can reach (`PUBSUB_STRUCT` is sized to leave
+    // room for the declarative runtime's, which is the largest in this tree).
+    assert!(
+        core::mem::size_of::<SubBufferedEntry<(), ()>>() <= model::PUBSUB_STRUCT,
+        "arena model: PUBSUB_STRUCT is below size_of::<SubBufferedEntry>() for \
+         this backend — the derived arena would under-size every subscription \
+         (issue 1190). Raise PUBSUB_ENTRY_STRUCT in nros-node/build.rs."
+    );
+    assert!(
+        core::mem::size_of::<SubBufferedRawEntry<()>>() <= model::PUBSUB_STRUCT,
+        "arena model: PUBSUB_STRUCT is below size_of::<SubBufferedRawEntry>() \
+         for this backend (issue 1190)."
+    );
+    assert!(
+        core::mem::size_of::<SubBufferedRawCEntry>() <= model::PUBSUB_STRUCT,
+        "arena model: PUBSUB_STRUCT is below size_of::<SubBufferedRawCEntry>() \
+         for this backend (issue 1190)."
+    );
+    assert!(
+        core::mem::size_of::<SubBufferedTypedCEntry>() <= model::PUBSUB_STRUCT,
+        "arena model: PUBSUB_STRUCT is below \
+         size_of::<SubBufferedTypedCEntry>() for this backend (issue 1190)."
+    );
+    assert!(
+        core::mem::size_of::<SubBufferedRawInfoCEntry>() <= model::PUBSUB_STRUCT,
+        "arena model: PUBSUB_STRUCT is below \
+         size_of::<SubBufferedRawInfoCEntry>() for this backend (issue 1190)."
+    );
+
+    // A service server has NO trailing region: both buffers are inline and it
+    // reaches the arena through `arena_alloc`. So the whole entry is bounded.
+    assert!(
+        core::mem::size_of::<
+            SrvRawEntry<
+                { crate::config::DEFAULT_RX_BUF_SIZE },
+                { crate::config::DEFAULT_RX_BUF_SIZE },
+            >,
+        >() <= model::SERVICE_ENTRY,
+        "arena model: SERVICE_ENTRY is below size_of::<SrvRawEntry>() for this \
+         backend (issue 1190)."
+    );
+
+    // A timer has no buffer at all.
+    assert!(
+        core::mem::size_of::<TimerEntry<()>>() <= model::TIMER_ENTRY,
+        "arena model: TIMER_ENTRY is below size_of::<TimerEntry>() (issue 1190)."
+    );
+};
+
+#[cfg(test)]
+mod arena_model_tests {
+    use crate::config::{DEFAULT_RX_BUF_SIZE, arena_model as model};
+    use nros_rmw::QoSProfile;
+
+    /// Issue 1190, the failure itself. The derivation's pub/sub term must cover
+    /// the buffered region an ORDINARY subscription claims — the one created
+    /// with no QoS argument, which is `QoSProfile::default()`, which is
+    /// `rmw_qos_profile_default`, which is `KEEP_LAST(10)`.
+    ///
+    /// This is the assertion the old model fails: it charged
+    /// `3 * DEFAULT_RX_BUF_SIZE` = 3,072 bytes, a `TripleBuffer`, where the
+    /// allocator claims `11 * (1024 + 8)` = 11,352 — short by 8,280 per
+    /// subscription, on top of a 280-byte shortfall in the entry allowance. An
+    /// image with one declared subscription therefore derived an 8,192-byte
+    /// arena for a 12,144-byte registration.
+    ///
+    /// Deliberately measured through `buffered_region_size`, the function the
+    /// allocator itself calls, and not through a second copy of its arithmetic.
+    #[test]
+    fn the_modelled_pubsub_region_covers_a_default_qos_subscription() {
+        let (slots, region) =
+            super::buffered_region_size(QoSProfile::default().depth, DEFAULT_RX_BUF_SIZE);
+        assert!(
+            model::PUBSUB_REGION >= region,
+            "the arena derivation budgets {} bytes for a subscription's \
+             buffered region and the allocator claims {region} for it \
+             ({slots} slots of {DEFAULT_RX_BUF_SIZE} at the default \
+             KEEP_LAST({}) ) — every image that derives its arena from a \
+             declared subscription count is short by {} bytes per \
+             subscription (issue 1190)",
+            model::PUBSUB_REGION,
+            QoSProfile::default().depth,
+            region.saturating_sub(model::PUBSUB_REGION),
+        );
+    }
+
+    /// The depth the derivation restates must be the depth the runtime uses. A
+    /// build script cannot read `QOS_PROFILE_DEFAULT`, so the number is
+    /// retyped there; this is what stops the two drifting, which is exactly how
+    /// the term came to model a depth nothing creates.
+    #[test]
+    fn the_modelled_qos_depth_is_the_runtime_default() {
+        assert_eq!(
+            model::QOS_DEPTH,
+            QoSProfile::default().depth,
+            "nros-node/build.rs budgets a subscription at KEEP_LAST({}) while \
+             `QoSProfile::default()` is KEEP_LAST({}) (issue 1190)",
+            model::QOS_DEPTH,
+            QoSProfile::default().depth,
+        );
+    }
+
+    /// Same, for the action client's feedback stream.
+    #[test]
+    fn the_modelled_action_feedback_depth_is_what_an_action_client_registers() {
+        assert_eq!(
+            model::ACTION_FEEDBACK_DEPTH,
+            super::DEFAULT_ACTION_FEEDBACK_DEPTH,
+            "nros-node/build.rs prices the action-client slot at feedback \
+             depth {} while the registration uses {} (issue 1190)",
+            model::ACTION_FEEDBACK_DEPTH,
+            super::DEFAULT_ACTION_FEEDBACK_DEPTH,
+        );
+    }
+
+    /// The action-client term is left depth-blind on purpose (see
+    /// `build.rs`), and that is only defensible while it stays an upper bound.
+    /// Its feedback region is real and depth-scaled even though the model does
+    /// not spell it that way, so the region alone must fit inside the term with
+    /// the entry struct still to pay for.
+    #[test]
+    fn the_modelled_action_client_entry_covers_its_feedback_region() {
+        let (_slots, region) = super::buffered_region_size(
+            super::DEFAULT_ACTION_FEEDBACK_DEPTH as u32,
+            DEFAULT_RX_BUF_SIZE,
+        );
+        assert!(
+            model::ACTION_CLIENT_ENTRY > region,
+            "the action-client slot is budgeted at {} bytes and its feedback \
+             region alone claims {region} — the margin that hid issue 1190 has \
+             closed and the term now needs the same treatment the pub/sub one \
+             got",
+            model::ACTION_CLIENT_ENTRY,
+        );
+    }
+}
+
 #[cfg(test)]
 mod arena_headroom_tests {
     use super::arena_is_over_provisioned;
-    use crate::config::{ARENA_ACTION_CLIENTS, ARENA_SIZE, DEFAULT_RX_BUF_SIZE, MAX_CBS};
+    use crate::config::{
+        ARENA_ACTION_CLIENTS, ARENA_SIZE, DEFAULT_RX_BUF_SIZE, MAX_CBS, arena_model as model,
+    };
 
     /// issue 0900 — the per-kind derivation must reproduce the OLD
     /// `max_cbs * action_client_entry + base` arithmetic byte for byte when
@@ -733,22 +920,37 @@ mod arena_headroom_tests {
                  against MAX_CBS {MAX_CBS}"
             );
         }
-        const ACTION_CLIENT_PER_SERVICE: usize = 4096 + 384;
-        const ACTION_CLIENT_SERVICES: usize = 3;
-        const ACTION_CLIENT_FEEDBACK_SUBS: usize = 3;
-        const ACTION_CLIENT_SUB_OVERHEAD: usize = 1536;
-        const ARENA_BASE_OVERHEAD: usize = 2048;
-        const ARENA_FLOOR: usize = 8192;
-
-        let per_entry = ACTION_CLIENT_SERVICES * ACTION_CLIENT_PER_SERVICE
-            + ACTION_CLIENT_FEEDBACK_SUBS * DEFAULT_RX_BUF_SIZE
-            + ACTION_CLIENT_SUB_OVERHEAD;
-        let want = (MAX_CBS * per_entry + ARENA_BASE_OVERHEAD).max(ARENA_FLOOR);
+        // Issue 1190 — these six constants used to be RETYPED here, which is a
+        // second copy of the model that agrees with the first until one of them
+        // moves. They come from `config::arena_model` now, which is what
+        // `build.rs` actually summed.
+        let want = (MAX_CBS * model::ACTION_CLIENT_ENTRY + model::BASE_OVERHEAD).max(model::FLOOR);
         assert_eq!(
             ARENA_SIZE, want,
             "the per-kind derivation moved the default arena; every image's \
-             task-stack frame moves with it (issue 0900)"
+             executor backing moves with it (issue 0900)"
         );
+        // And the shipped number itself, because reading it out of the model
+        // proves the SHAPE and not the size: with both sides emitted from one
+        // build script, a term could move and the identity above would still
+        // hold. 74,240 is what 1,524 of the 1,547 built configs in this tree
+        // carry; issue 1190's fix is required to leave it exactly there,
+        // because the pub/sub term it corrects multiplies
+        // `MAX_CBS - ARENA_ACTION_CLIENTS`, which is zero at the defaults.
+        //
+        // Only when the INPUTS are the shipped ones. A test build that raised
+        // `NROS_EXECUTOR_MAX_CBS` or the buffer size derives a different number
+        // legitimately, and asserting a literal at it would be this file's own
+        // "second copy" mistake wearing a different hat.
+        if MAX_CBS == 4 && DEFAULT_RX_BUF_SIZE == 1024 {
+            assert_eq!(
+                ARENA_SIZE, 74_240,
+                "the shipped default arena moved. That is not forbidden, but \
+                 it is a change to every image built without an entity \
+                 declaration and it has to be a decision, not a side effect \
+                 (issues 0900, 1190)"
+            );
+        }
     }
 
     /// The advisory must actually fire for the shipped defaults — otherwise W1

--- a/packages/core/nros-node/src/executor/node.rs
+++ b/packages/core/nros-node/src/executor/node.rs
@@ -1744,7 +1744,7 @@ impl<'e, 's> NodeCtx<'e, 's> {
                 A::ACTION_HASH,
                 // Feedback is a stream → buffer a short QoS-depth history (Phase
                 // 239.5). Goal-response / result are single-outstanding (gated).
-                8u16,
+                super::arena::DEFAULT_ACTION_FEEDBACK_DEPTH,
                 on_goal_response,
                 on_feedback,
                 on_result,

--- a/scripts/check-action-client-arena-budget.py
+++ b/scripts/check-action-client-arena-budget.py
@@ -91,7 +91,9 @@ measured from `target/nros-cpp-generated/nros/nros_cpp_config_generated.h`
 # is conservative and correct whichever handle is larger. The size ORDERING is
 # recorded as suggestive, not as the justification.
 
-against a pub/sub entry budgeted at `3 * rx_buf + 512` = 3,584 B. So an action
+against a pub/sub entry budgeted at 12,376 B — `11 * (rx_buf + 8) + 1024` at the
+ROS default KEEP_LAST(10); it read `3 * rx_buf + 512` = 3,584 until issue 1190
+found that the model had priced a triple buffer nothing creates. So an action
 SERVER also needs a slot a pub/sub budget cannot hold, and telling an
 action-server image to set `NROS_EXECUTOR_ACTION_CLIENTS=0` would trade this
 gate's advisory for the exact runtime `BufferTooSmall` it exists to prevent. An

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1256,8 +1256,18 @@ config NROS_EXECUTOR_ARENA_SIZE
     help
       Explicit executor arena size. 0 means let nros-node build.rs derive it,
       which budgets EVERY callback slot at action-client size (~18 KiB) --
-      correct, but an order of magnitude over for a pub/sub-only image, which
-      needs about max_cbs * (3 * NROS_SUBSCRIPTION_BUFFER_SIZE + 512) + 2048.
+      correct, but several times over for a pub/sub-only image, which needs
+      about max_cbs * ((depth + 1) * (NROS_SUBSCRIPTION_BUFFER_SIZE + 8) + 1024)
+      + 2048.
+
+      MIND THE DEPTH (issue 1190). A subscription's arena claim scales with its
+      QoS history: KEEP_LAST(N > 1) is a ring of N + 1 slots plus a length
+      beside each, and the ROS default is KEEP_LAST(10), so one ordinary
+      subscription at the default buffer size costs 12 KiB and not 3.5 KiB.
+      This help said "3 * NROS_SUBSCRIPTION_BUFFER_SIZE + 512" until the
+      derivation itself did, and an image sized from that arithmetic dies at
+      entity creation with NodeError::BufferTooSmall.
+
       Set it only with that arithmetic in hand; too small fails at runtime,
       not at link.
 

--- a/zephyr/cmake/nros_cargo_build.cmake
+++ b/zephyr/cmake/nros_cargo_build.cmake
@@ -828,9 +828,11 @@ function(nros_resolve_knobs)
     # subscription in the image (`RX_BUF` is a const generic and the C/C++ path
     # is type-erased), so the number it wants is the largest type the image can
     # receive. The inventory knows that exactly; an eye reading a header does
-    # not. Note the arena scales with it (`max_cbs * (3 * rx_buf + 512) + 2048`),
-    # so an image that also PINS `NROS_EXECUTOR_ARENA_SIZE` must move the two
-    # together -- which is an argument for pinning neither.
+    # not. Note the arena scales with it -- and by the QoS DEPTH as well, issue
+    # 1190: `max_cbs * ((depth + 1) * (rx_buf + 8) + 1024) + 2048` for a pub/sub
+    # image, where the ROS default depth is 10 -- so an image that also PINS
+    # `NROS_EXECUTOR_ARENA_SIZE` must move the two together, which is an
+    # argument for pinning neither.
     _nros_resolve_derivable_knob(NROS_SUBSCRIPTION_BUFFER_SIZE
         "${CONFIG_NROS_SUBSCRIPTION_BUFFER_SIZE}"
         NROS_DERIVED_SUBSCRIPTION_BUFFER_SIZE)


### PR DESCRIPTION
Fixes issue 1190.

## The measurement

`interop_e2e::case_2_zenoh_pubsub_ros2_to_nano` fails live in the ROS 2 box,
deterministically (3/3 solo, ~0.92 s). `examples/native/rust/listener` dies at
`Node::register`:

```
[ERROR] nros: arena exhausted: 3952 more bytes needed, 0/8192 in use.
[ERROR] nros: node declaration failed — NodeError::BufferTooSmall
```

`want` is the shortfall past capacity, so one allocation asked for **12,144
bytes into an empty 8,192-byte arena**.

## Modelled vs real, per subscription entry

| | bytes |
| --- | ---: |
| modelled (`3 * rx_buf + 512`) | **3,584** |
| real | **12,144** |

and the real number decomposes exactly, measured on x86_64 with the cffi
backend:

| term | bytes |
| --- | ---: |
| `size_of::<SubBufferedRawEntry<F>>()` with a ZST callback | 640 |
| the declarative runtime's closure (`heapless::String<128>` cb id + cell) | 152 |
| `buffered_region_size(10, 1024)` = `11 * 1024 + 11 * 8` | 11,352 |
| **total** | **12,144** |

## Root cause

`PUBSUB_SUB_BUFS = 3` is `TripleBuffer::SLOT_COUNT`, and a triple buffer is
what `buffered_region_size` returns **only for `depth <= 1`**. Every deeper
history is an `SpscRing`: `depth + 1` slots plus a `usize` length beside each.
The ROS default is `rmw_qos_profile_default` = KEEP_LAST(**10**), which is what
every subscription created without an explicit QoS gets. The model had no depth
term at all — phase-403 step 2 added declared depths precisely for this, and
step 3 shipped without reading them, guessing the direction its own design doc
had named as unsafe.

`512` was short too: below **every** concrete entry this crate defines (640,
656, 656, 672, 872), most of that being the backend handle — `CffiSubscription`
alone is 584, two 256-byte name buffers of it.

## Two corrections to the diagnosis in the issue

* **`ARENA_FLOOR` did not hide this.** `.max()` only raises: the listener's
  declared sum was 5,632 and the floor lifted it to 8,192 — the right
  direction, and still 3,952 short. What hid it is the **action-client term's
  margin**: 18,048 modelled against 14,600 measured (5,312 entry +
  `buffered_region(8, 1024)` = 9,288), which is enough to absorb a pub/sub term
  short by 8,560 on any 4-slot image budgeting every slot at it. So the floor
  stays at 8,192; raising it to one entry would tax timer-only and
  publisher-only images 6,232 bytes for a guarantee they cannot use.
* **It IS a regression**, which the issue recorded as unestablished. The
  declared-count branch that produces an 8,192-byte arena for a
  one-subscription image landed 2026-09-03 (phase-403 step 3).

## The fix

* `buffered_region(depth, slot)` in `build.rs`, mirroring
  `executor::arena::buffered_region_size` — the function the allocator calls.
* `PUBSUB_QOS_DEPTH = 10`, restated from `QOS_PROFILE_DEFAULT.depth` and held
  to it by a test; `PUBSUB_ENTRY_STRUCT` 512 → 1024.
* The service term is modelled on its own shape (`2 * rx_buf + 1024`) — it has
  no trailing region, so `pubsub_entry + rx_buf` would have billed it 13,400
  against the 2,592 `SrvRawEntry<1024, 1024>` measures.
* The model is EMITTED as `config::arena_model`; `the_default_derivation_is_unchanged`
  had six of its constants retyped and reads them now.
* Compile-time assertions in `arena.rs` (gated on `rmw-cffi`) that each term is
  an upper bound on the entry types it stands for — the half a build script
  structurally cannot do, since it has no `size_of` and the dominant term is
  the linked backend's handle.
* The **action-client term is byte-identical**: depth-blind in the same way,
  but still an upper bound. Rewriting it moves 1,524 images by +24,864 or
  −10,464 each for a need nothing measured;
  `the_modelled_action_client_entry_covers_its_feedback_region` says so if the
  margin closes.

## Static RAM

**Unchanged on 1,542 of the 1,547 built `nros_node_config.rs` in a full
developer tree.** The corrected term multiplies `MAX_CBS - ARENA_ACTION_CLIENTS`,
zero at the defaults, so `ARENA_SIZE` stays at exactly 74,240 — now asserted, so
a future move has to be a decision rather than a side effect. Only declaring
images move, by what their entities claim: the listener 8,192 → 14,424 for a
12,144-byte registration.

## Test, and proof it fails on the old derivation

`the_modelled_pubsub_region_covers_a_default_qos_subscription`, run against the
old model:

```
the arena derivation budgets 3072 bytes for a subscription's buffered region
and the allocator claims 11352 for it (11 slots of 1024 at the default
KEEP_LAST(10)) — every image that derives its arena from a declared
subscription count is short by 8280 bytes per subscription (issue 1190)
```

and with `PUBSUB_STRUCT` at its old 512 the const assertion fires at compile
time:

```
error[E0080]: evaluation panicked: arena model: PUBSUB_STRUCT is below
size_of::<SubBufferedEntry>() for this backend
```

## Verified

* `cargo nextest run -p nros-node --features std,alloc` — 347 pass. (One
  unrelated timing test, `a_stalled_timer_reports_a_timer_overrun_violation`,
  flaked once under a parallel run and passed solo and on re-run.)
* `cargo check -p nros-node --features rmw-cffi,std,alloc` — the const
  assertions compile against the real backend handles.
* `just check fast` — green, 251 gates.

## NOT verified

**The live cell.** This host has no ROS and the box tree is not mine to touch.
The fix is proven by arithmetic and unit tests only;
`interop_e2e::case_2_zenoh_pubsub_ros2_to_nano` in the box is outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA
