### PR TITLE
fix(zephyr): the C-for-C++ nros-c string must read the C++ one, not restate it

### DIFF
--- a/docs/issues/archived/1156-c-for-cpp-features-miss-alloc.md
+++ b/docs/issues/archived/1156-c-for-cpp-features-miss-alloc.md
@@ -2,10 +2,11 @@
 id: 1156
 title: "#1100 fixed one of the two strings that build `nros-c`; a C++-only
   Zephyr image uses the other, and still carries two units"
-status: open
+status: resolved
 type: bug
 area: build
 related: [issue-1100, issue-0745, rfc-0044]
+resolved_in: "phase-412 follow-up"
 ---
 
 ## Symptom
@@ -82,3 +83,80 @@ condition its sibling uses:
 The one #1100 stated and could not run: build a C++ Zephyr image, then build
 again in the same directory. Both must succeed. ASI's `zephyr-fvp` lane is that
 image, and its CI runs a second build implicitly every time it starts a model.
+
+## What the first fix got wrong, found 2026-09-07 on silicon
+
+The fix above was applied and the acceptance still failed — on the mr_canhubk3
+board build, not the FVP:
+
+```
+nros-cpp: build-<d>/nros-rust/nros-c-generated/nros/nros_config_generated.h was
+written by another crate with DIFFERENT probed sizes.
+  NROS_EXECUTOR_SIZE:  on-disk=63632 vs would-write=63512
+```
+
+Straight from that build's `build.ninja`:
+
+```
+nros_c_cargo_build   --features rmw-cffi,cffi-zenoh-cffi,platform-zephyr,ros-humble,alloc,panic-platform
+nros_cpp_cargo_build --features rmw-zenoh-cffi,platform-zephyr,ros-humble,panic-platform
+```
+
+Two units again, and the split is now the OTHER way round: the C string carries
+`alloc` and the C++ string does not.
+
+The fix appended `,alloc` unconditionally, on the reasoning quoted above -- the
+branch sits inside `if(CONFIG_NROS_CPP_API)`, "so the C++ half has it by
+construction". That is true of two of the three backend strings and false of the
+third:
+
+| `_nros_cpp_features` | line | names `alloc`? |
+| --- | --- | --- |
+| zenoh | 567 | **no** |
+| xrce | 585 | yes |
+| cyclonedds | 604 | yes |
+
+A Zephyr zenoh image is the configuration #1100 and #1156 were both reported
+from, so the append did not close the split there -- it inverted it.
+
+## Fix, second attempt
+
+Ask the C++ string instead of restating what it holds:
+
+```cmake
+if(_nros_cpp_features MATCHES "(^|,)alloc(,|$)")
+    string(APPEND _nros_c_for_cpp_features ",alloc")
+endif()
+if(_nros_cpp_features MATCHES "(^|,)param-services(,|$)")
+    string(APPEND _nros_c_for_cpp_features ",param-services")
+endif()
+```
+
+A condition that restates another string's contents is a second copy of it, and
+this copy has now drifted three times (#1100, #1156, this).
+
+The zenoh branch also named `cffi-zenoh-cffi`, the back-compat alias kept "so
+downstream cmake glue that still passes the old name does not error"
+(`nros-c/Cargo.toml:109`, `cffi-zenoh-cffi = ["rmw-zenoh"]`). It resolves to the
+same feature and gates no code, but cargo keys a unit by the feature SET, so the
+alias spelling asked for a set nothing else names. The in-tree glue is not
+downstream glue; it now names `rmw-zenoh`, which is what `nros-cpp` forwards.
+
+## Acceptance, run
+
+`just BOARD_BUILD_DIR=build-stampfix board-build` three times in one directory
+on `mr_canhubk3/s32k344`, from a wiped dir: `rc=0`, `rc=0`, `rc=0`, and zero
+occurrences of `DIFFERENT probed sizes` in the full log. Before the fix the same
+script reported the panic in pass 1's `rom_report`/`ram_report` step and
+`PASS 2 rc=1`.
+
+Both `nros-c` build-script units now emit the same header:
+
+```
+NROS_EXECUTOR_SIZE 63512
+NROS_CONFIG_VARIANT "critical_section_global_allocator_panic_platform_platform_zephyr_rmw_cffi_rmw_zenoh_ros_humble"
+```
+
+Not verified on the FVP lane this issue was reported from -- no FVP run was made
+here. What it is verified against is the board, which is the harder case
+(#1100's fix was NOT VERIFIED against any Zephyr build at all).

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -649,7 +649,15 @@ if(CONFIG_NROS_CPP_API)
     # via `TARGET nros_c_cargo_build` in nros_cargo_build.cmake).
     if(NOT CONFIG_NROS_C_API)
         if(CONFIG_NROS_RMW_ZENOH)
-            set(_nros_c_for_cpp_features "rmw-cffi,cffi-zenoh-cffi,platform-zephyr,ros-humble")
+            # `rmw-zenoh`, not the `cffi-zenoh-cffi` back-compat alias. The two
+            # are the same feature (`cffi-zenoh-cffi = ["rmw-zenoh"]`, kept only
+            # so downstream cmake glue that still passes the old name does not
+            # error), but cargo keys a unit by the feature SET, so the alias
+            # spelling asks for a feature set no other consumer names.
+            # `nros-cpp` forwards `nros-c/rmw-zenoh`; naming the same thing here
+            # makes both cargo invocations resolve nros-c to the SAME feature
+            # set, which is what the shared generated header needs.
+            set(_nros_c_for_cpp_features "rmw-cffi,rmw-zenoh,platform-zephyr,ros-humble")
         elseif(CONFIG_NROS_RMW_XRCE)
             set(_nros_c_for_cpp_features "rmw-cffi,cffi-xrce-c,platform-zephyr,ros-humble")
         elseif(CONFIG_NROS_RMW_CYCLONEDDS)
@@ -671,11 +679,24 @@ if(CONFIG_NROS_CPP_API)
         # the image still carried two nros-c units with different
         # EXECUTOR_SIZE and the second build script still aborted.
         #
-        # `alloc` unconditionally: this branch is inside `if(CONFIG_NROS_CPP_API)`,
-        # so the C++ half has it by construction. `param-services` under the
-        # same NANO_ROS_FEATURES condition `_nros_cpp_features` gates on.
-        string(APPEND _nros_c_for_cpp_features ",alloc")
-        if("param_services" IN_LIST NANO_ROS_FEATURES)
+        # ASK the C++ string rather than assuming what it holds. #1156 appended
+        # `alloc` unconditionally, reasoning that this branch is inside
+        # `if(CONFIG_NROS_CPP_API)` "so the C++ half has it by construction".
+        # That is true of the xrce (585) and cyclonedds (604) strings and FALSE
+        # of the zenoh one (567), which is the only backend string that does not
+        # name `alloc` — and a Zephyr zenoh image is the configuration #1100 and
+        # #1156 were both reported from. So the append did not close the split
+        # there, it INVERTED it: `nros_c_cargo_build` took `alloc`,
+        # `nros_cpp_cargo_build` did not, and the image carried two nros-c units
+        # again with EXECUTOR_SIZE 63632 against 63512.
+        #
+        # A condition that restates what another string holds is a second copy
+        # of it, and this is the third time that copy has drifted. Read the
+        # string.
+        if(_nros_cpp_features MATCHES "(^|,)alloc(,|$)")
+            string(APPEND _nros_c_for_cpp_features ",alloc")
+        endif()
+        if(_nros_cpp_features MATCHES "(^|,)param-services(,|$)")
             string(APPEND _nros_c_for_cpp_features ",param-services")
         endif()
         nros_cargo_build(


### PR DESCRIPTION
Closes #1156 (again -- the first fix inverted the split for zenoh rather than closing it).

## Symptom

A second build in one directory aborts:

```
nros-cpp: build-<d>/nros-rust/nros-c-generated/nros/nros_config_generated.h was
written by another crate with DIFFERENT probed sizes.
  NROS_EXECUTOR_SIZE: on-disk=63632 vs would-write=63512
```

On this board it lands in the FIRST `just board-build`, because that recipe runs
`rom_report` and `ram_report` itself and those re-enter the build graph.

## Cause

From the failing build's own `build.ninja`:

```
nros_c_cargo_build   --features rmw-cffi,cffi-zenoh-cffi,platform-zephyr,ros-humble,alloc,panic-platform
nros_cpp_cargo_build --features rmw-zenoh-cffi,platform-zephyr,ros-humble,panic-platform
```

Two `nros-c` units writing one shared generated header. #1156 appended `,alloc`
to `_nros_c_for_cpp_features` unconditionally, reasoning that the branch sits
inside `if(CONFIG_NROS_CPP_API)` so the C++ half has it by construction. That
holds for two of the three backend strings and not the third:

| `_nros_cpp_features` | line | names `alloc`? |
| --- | --- | --- |
| zenoh | 567 | no |
| xrce | 585 | yes |
| cyclonedds | 604 | yes |

A Zephyr zenoh image is the configuration #1100 and #1156 were both reported
from, so the append inverted the split instead of closing it.

## Fix

Read the C++ string rather than restating what it holds. A condition that
restates another string's contents is a second copy of it, and this copy has now
drifted three times (#1100, #1156, this).

The zenoh branch also named `cffi-zenoh-cffi`, the back-compat alias kept so
downstream cmake glue passing the old name does not error. It resolves to
`rmw-zenoh` and gates no code, but cargo keys a unit by the feature SET, so the
alias asked for a set nothing else names. The in-tree glue is not downstream
glue; it now names what `nros-cpp` forwards.

## Acceptance

Three `board-build` passes in one wiped directory on `mr_canhubk3/s32k344`:
`rc=0`, `rc=0`, `rc=0`, and zero occurrences of `DIFFERENT probed sizes` in the
full log. Before the fix the same script hit the panic in pass 1's report step
and `PASS 2 rc=1`.

Both `nros-c` units now emit the same header:

```
NROS_EXECUTOR_SIZE 63512
NROS_CONFIG_VARIANT "critical_section_global_allocator_panic_platform_platform_zephyr_rmw_cffi_rmw_zenoh_ros_humble"
```

Not run on the FVP lane the issue was filed from. It is verified on the board,
which #1100's fix was not verified against at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)