### PR TITLE
fix(ci): the CLI cache stored the whole job, not the CLI build

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -84,8 +84,25 @@ jobs:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after the build below — deliberately split.
+      #
+      # `actions/cache` saves in a POST step, at job end. By then this job has
+      # run `just setup native`, built fixtures and run `just ci tier1`, and all
+      # of them write into `packages/cli/target` too. So the entry stored is not
+      # "the CLI build" but "whatever the whole job left behind".
+      #
+      # Measured on the live cache: eight `nros-cli-*` entries at 138 MB and ONE
+      # at 5 571 MB, the big one on `refs/heads/main` — the branch where the job
+      # runs to completion instead of being cancelled early. That single entry
+      # was 56 % of the repository's 10 GB Actions cache limit, which is why
+      # `gate.yml`'s sccache (1 GB, and the required PR check depends on it) had
+      # no headroom.
+      #
+      # Splitting restore from save bounds the entry to what the CLI build
+      # actually produces, which is the 138 MB the cancelled jobs already show.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -105,6 +122,17 @@ jobs:
           # code the runtime did not expect is what RFC-0090 exists to stop.
           "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
+
+      # SAVE NOW, before anything else writes into this directory. See the
+      # restore step above for the measurement. `if: always()` is deliberately
+      # NOT set: a failed CLI build leaves a target dir that should not become
+      # the entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
 
       # phase-413 W5 — the scope verb, same as the integration job below.
       # `just setup native` expands to `nros setup --build-sources` and
@@ -147,8 +175,25 @@ jobs:
       - name: Checkout nano-ros
         uses: actions/checkout@v4
 
-      - name: Cache CLI build (Phase 218)
-        uses: actions/cache@v4
+      # RESTORE here, SAVE right after the build below — deliberately split.
+      #
+      # `actions/cache` saves in a POST step, at job end. By then this job has
+      # run `just setup native`, built fixtures and run `just ci tier1`, and all
+      # of them write into `packages/cli/target` too. So the entry stored is not
+      # "the CLI build" but "whatever the whole job left behind".
+      #
+      # Measured on the live cache: eight `nros-cli-*` entries at 138 MB and ONE
+      # at 5 571 MB, the big one on `refs/heads/main` — the branch where the job
+      # runs to completion instead of being cancelled early. That single entry
+      # was 56 % of the repository's 10 GB Actions cache limit, which is why
+      # `gate.yml`'s sccache (1 GB, and the required PR check depends on it) had
+      # no headroom.
+      #
+      # Splitting restore from save bounds the entry to what the CLI build
+      # actually produces, which is the 138 MB the cancelled jobs already show.
+      - name: Restore CLI build cache (Phase 218)
+        id: cli-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/cli/target
           key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
@@ -168,6 +213,17 @@ jobs:
           # code the runtime did not expect is what RFC-0090 exists to stop.
           "$GITHUB_WORKSPACE/packages/cli/target/release/nros" source-stamp >/dev/null
           echo "$GITHUB_WORKSPACE/packages/cli/target/release" >> "$GITHUB_PATH"
+
+      # SAVE NOW, before anything else writes into this directory. See the
+      # restore step above for the measurement. `if: always()` is deliberately
+      # NOT set: a failed CLI build leaves a target dir that should not become
+      # the entry every later run restores from.
+      - name: Save CLI build cache (Phase 218)
+        if: steps.cli-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/cli/target
+          key: nros-cli-${{ runner.os }}-${{ hashFiles('packages/cli/Cargo.lock', 'packages/cli/**/Cargo.toml', 'packages/cli/**/*.rs') }}
 
       # phase-437 — the fixture builders' rustc fan-out, DERIVED.
       #


### PR DESCRIPTION
One `nros-cli-*` cache entry is **5 571 MB** — 56% of the repository's 10 GB Actions cache limit, by itself. Eight siblings are 138 MB.

```
5571 MB  ref=refs/heads/main  nros-cli-Linux-d3fa42bd0...
 138 MB                       nros-cli-Linux-ecf9e4dd6...
 138 MB                       nros-cli-Linux-d3fa42bd0...   <- same key
 ... six more at 138 MB
```

Same key, forty times the size. Not a bad key: **`actions/cache` saves in a POST step, at job end.** By then the job has also run `just setup native`, built two sets of fixtures and run `just ci tier1` — all of which write into `packages/cli/target`. The entry is not "the CLI build", it is whatever the whole job left behind. The 138 MB siblings are the same job *cancelled* before it got that far, which is why the branch that runs to completion holds the outlier.

## The fix

Split `actions/cache` into `restore@v4` at the top and `save@v4` immediately after the build, bounding the entry to what the CLI build produces. `gate.yml` already uses the split-action form for sccache, so this is the tree's existing spelling.

`if: steps.cli-cache.outputs.cache-hit != 'true'` skips the save on an exact hit. `if: always()` is deliberately **not** set — a failed CLI build leaves a target dir that must not become the entry every later run restores from.

## Why it matters beyond tidiness

The budget is per repository and shared. With 5.5 GB spent here, `gate.yml`'s sccache (1 GB, and the **required** PR check reads it) has no headroom — and adding sccache to `host-tests`, where two fixture steps compile ~53 minutes with no compile cache at all, would have evicted the required check's cache to speed up a post-merge lane. Freeing ~5.4 GB is the prerequisite for that, not a cleanup.

## Not measured yet

The saving is **predicted** from the 138 MB siblings, not from a run of this change. The first push to `main` after it lands is what confirms the entry size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU5GN5rrqV1fiCwCztA45N