### PR TITLE
fix(#1199): the DECLARED road carries the whole set the leaf road already carries

### DIFF
--- a/cmake/NanoRosEntityFacts.cmake
+++ b/cmake/NanoRosEntityFacts.cmake
@@ -202,12 +202,102 @@ function(_nros_payload_facts_env _out_var)
     if(NOT NROS_MESSAGE_BOUNDS_BASIS STREQUAL "subscribed")
         return()
     endif()
-    if(NOT DEFINED NROS_DERIVED_MAX_LARGE_SUBSCRIBERS)
+    # issue 1199 — the THREE payload keys, and the set is not ours to choose:
+    # it mirrors `DERIVED_PAYLOAD_ENV_KEYS` in
+    # `packages/cli/nros-cli-core/src/leaf_entity_env.rs`, which is the same
+    # decision made for the cargo-LEAF road. Two roads delivering different key
+    # sets is how an image's sizing depends on which lane built it.
+    #
+    # Each of the two SIZES is published by the derivation only under its own
+    # condition, and this reads DEFINED rather than re-deriving them: a small
+    # class of 0 means nothing received fits under the ceiling, and a large
+    # SIZE for a class with no blocks would be inventing a number
+    # (`_nros_bounds_publish_payload_classes`). Absent therefore means "no
+    # answer" here exactly as it does there.
+    set(_out "")
+    if(DEFINED NROS_DERIVED_MAX_LARGE_SUBSCRIBERS)
+        list(APPEND _out
+            "NROS_DECLARED_LARGE_SUBSCRIBERS=${NROS_DERIVED_MAX_LARGE_SUBSCRIBERS}")
+    endif()
+    if(DEFINED NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE)
+        list(APPEND _out
+            "NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE=${NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE}")
+    endif()
+    if(DEFINED NROS_DERIVED_SUBSCRIBER_LARGE_SIZE)
+        list(APPEND _out
+            "NROS_DECLARED_SUBSCRIBER_LARGE_SIZE=${NROS_DERIVED_SUBSCRIBER_LARGE_SIZE}")
+    endif()
+    set(${_out_var} "${_out}" PARENT_SCOPE)
+endfunction()
+
+# _nros_entity_budget_env(<out-var>)
+#
+# issue 1199 — the ENTITY budget half of the DECLARED road, sibling of
+# `_nros_payload_facts_env` above.
+#
+# The key set is NOT a choice made here: it mirrors `DERIVED_ENV_KEYS` in
+# `packages/cli/nros-cli-core/src/leaf_entity_env.rs`, which is the same
+# decision already made for the cargo-LEAF road. Two roads delivering different
+# key sets is how an image's sizing comes to depend on which lane built it, and
+# `check-declared-fact-carriers` holds the two lists together.
+#
+# What that set deliberately EXCLUDES, and why the exclusions are not oversights:
+#
+#   * `ZPICO_MAX_QUERYABLES` -- `max_queryables` counts service servers and
+#     actions and NOT the param (6) or lifecycle (5) service families, which a
+#     FEATURE enables and this inventory cannot see. A short queryable table is
+#     a registration failure at boot, not a smaller pool (issues 1061, 0460).
+#     The CMake road completes it through `NROS_DECLARED_INFRA_QUERYABLES`
+#     instead, which is why that fact exists.
+#   * `NROS_EXECUTOR_MAX_NODES` -- phase-412 withheld it from W1 on the ground
+#     that under-counting HALTS the board, and the leaf road still omits it.
+#   * `NROS_SUBSCRIPTION_BUFFER_SIZE` -- not on the leaf road either; it also
+#     feeds the arena derivation, so it is a second decision and not this one.
+#
+# The guard is a single status. Unlike message bounds there is no BASIS here:
+# `derived` means every `NROS_DERIVED_*` in the fragment is present, and
+# `refused` means none is (`NanoRosEntityInventory.cmake`).
+#
+# NO FLOOR IS APPLIED HERE, on purpose. The derivation publishes DEMAND and the
+# floor belongs to the consumer that names the knob (issues 1015, 1033) -- the
+# two `ZPICO_*` counts size fixed C arrays where zero is not a smaller pool,
+# while the same numbers reach pools where zero IS the answer. On this road the
+# consumer is a build script, so it floors what it takes; the leaf sidecar
+# floors at its own boundary for the same reason, one layer over.
+function(_nros_entity_budget_env _out_var)
+    set(${_out_var} "" PARENT_SCOPE)
+    if(NOT COMMAND nros_entity_inventory_knobs_file)
         return()
     endif()
-    set(${_out_var}
-        "NROS_DECLARED_LARGE_SUBSCRIBERS=${NROS_DERIVED_MAX_LARGE_SUBSCRIBERS}"
-        PARENT_SCOPE)
+    nros_entity_inventory_knobs_file(_inv)
+    if(NOT EXISTS "${_inv}")
+        return()
+    endif()
+    include("${_inv}")
+    if(NOT NROS_ENTITY_INVENTORY_STATUS STREQUAL "derived")
+        return()
+    endif()
+    # Both names are written IN FULL, and the delivered name is never built by
+    # interpolation. phase-412's second delivery failure was exactly that: a
+    # `foreach` composing `NROS_DERIVED_${_pool}` produced a name that matches
+    # nothing, and CMake yields EMPTY for an unknown variable rather than
+    # failing. A constructed name is also invisible to `grep`, which is how
+    # `check-declared-fact-carriers` reads this file -- so a fact spelled only
+    # in pieces would be delivered and still report as unproduced.
+    set(_out "")
+    foreach(_pair
+            "NROS_DECLARED_EXECUTOR_ACTION_CLIENTS;NROS_DERIVED_EXECUTOR_ACTION_CLIENTS"
+            "NROS_DECLARED_EXECUTOR_MAX_CBS;NROS_DERIVED_EXECUTOR_MAX_CBS"
+            "NROS_DECLARED_RMW_SUBSCRIBER_SLOTS;NROS_DERIVED_RMW_SUBSCRIBER_SLOTS"
+            "NROS_DECLARED_MAX_PUBLISHERS;NROS_DERIVED_MAX_PUBLISHERS"
+            "NROS_DECLARED_MAX_SUBSCRIBERS;NROS_DERIVED_MAX_SUBSCRIBERS")
+        list(GET _pair 0 _name)
+        list(GET _pair 1 _src)
+        if(DEFINED ${_src})
+            list(APPEND _out "${_name}=${${_src}}")
+        endif()
+    endforeach()
+    set(${_out_var} "${_out}" PARENT_SCOPE)
 endfunction()
 
 # nros_entity_facts_env(<target>)
@@ -220,6 +310,10 @@ function(nros_entity_facts_env _target)
     # gets a message-bound derivation, so this is computed before the
     # queryable-table early return rather than after it.
     _nros_payload_facts_env(_payload_env)
+    _nros_entity_budget_env(_budget_env)
+    if(_budget_env)
+        list(APPEND _payload_env ${_budget_env})
+    endif()
 
     get_property(_seen GLOBAL PROPERTY NROS_ENTITY_FACTS_SEEN)
     if(NOT _seen)

--- a/docs/issues/archived/1199-derived-counts-need-the-declared-road.md
+++ b/docs/issues/archived/1199-derived-counts-need-the-declared-road.md
@@ -1,0 +1,119 @@
+---
+id: 1199
+title: "Seven more derived pool knobs were computed on every lane and consumed only under `zephyr/` — the DECLARED road now carries the whole set the cargo-leaf road already carries"
+status: resolved
+type: bug
+area: cmake, rmw-zenoh, core, memory
+severity: high
+found: 2026-09-07
+resolved: 2026-09-07
+related: [1122, 1125, 1061, 1033, 1015, 0827, 0460]
+---
+
+# Three roads, and only two of them were built
+
+A number CMake derives reaches a build script by one of three roads:
+
+| road | who it serves | mechanism |
+| --- | --- | --- |
+| resolver | Zephyr images | `nros_resolve_knobs()` -> `NROS_RESOLVED_*` |
+| sidecar | Rust **leaves** | `nros sync` writes cargo `[env]` (`leaf_entity_env.rs`) |
+| declared | CMake images with **no** Rust leaf | `corrosion_set_env_vars` -> `NROS_DECLARED_*` |
+
+Issue 1122 built the third road and put one knob on it. Everything else was
+still computed on every lane, written to `entity_inventory.cmake` /
+`message_bound_knobs.cmake`, and read only under `zephyr/` — so a FreeRTOS,
+ThreadX, NuttX or posix image with no Rust leaf kept every crate default.
+
+## What travels now, and why this set
+
+The set is **not chosen here**. It mirrors `DERIVED_ENV_KEYS` and
+`DERIVED_PAYLOAD_ENV_KEYS` in `packages/cli/nros-cli-core/src/leaf_entity_env.rs`
+— the same decisions already made for the leaf road. Two roads delivering
+different key sets is how an image's sizing comes to depend on which lane built
+it, which is 1122 with the roads swapped.
+
+| knob | declared fact | floor |
+| --- | --- | --- |
+| `ZPICO_MAX_SUBSCRIBERS` | `NROS_DECLARED_MAX_SUBSCRIBERS` | **1**, at the consumer |
+| `ZPICO_MAX_PUBLISHERS` | `NROS_DECLARED_MAX_PUBLISHERS` | **1**, at the consumer |
+| `NROS_RMW_SUBSCRIBER_SLOTS` | `NROS_DECLARED_RMW_SUBSCRIBER_SLOTS` | none — 0 is the answer |
+| `NROS_EXECUTOR_MAX_CBS` | `NROS_DECLARED_EXECUTOR_MAX_CBS` | none |
+| `NROS_EXECUTOR_ACTION_CLIENTS` | `NROS_DECLARED_EXECUTOR_ACTION_CLIENTS` | none — 0 is the point |
+| `NROS_SUBSCRIBER_BUFFER_SIZE` | `NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE` | none |
+| `ZPICO_SUBSCRIBER_LARGE_SIZE` | `NROS_DECLARED_SUBSCRIBER_LARGE_SIZE` | none |
+
+Three names stay off the road, each for a reason the tree already recorded:
+`ZPICO_MAX_QUERYABLES` is deliberately not derived (the count excludes the
+param and lifecycle service families a FEATURE enables — issue 1061, and the
+CMake road completes it through `NROS_DECLARED_INFRA_QUERYABLES` instead);
+`NROS_EXECUTOR_MAX_NODES` was withheld from phase-412 W1 because under-counting
+halts the board; `NROS_SUBSCRIPTION_BUFFER_SIZE` is absent from the leaf road
+too and also feeds the arena derivation, so it is a second decision.
+
+## The two rules this had to respect
+
+**A derived value is a DEFAULT, never an override.** The tree's ladder is
+`env > Kconfig/board > derived > crate default`
+(`_nros_resolve_derivable_knob`). So every consumer takes the declared fact as
+its *default*, and a named knob still wins — verified at each site. Setting the
+knob itself through `corrosion_set_env_vars` would have made the override
+unreachable, because the child environment is not overridable the way cargo
+`[env]` (without `force`) is. That asymmetry is why the two roads spell the
+same number differently, and `ROAD_PAIRS` in the gate is where the pairing is
+written down.
+
+**The floor belongs to the consumer, not the derivation.** The derivation
+publishes DEMAND and zero is a legitimate demand. The two `ZPICO_*` counts size
+fixed C arrays in `zpico.c`, where zero is a `#error` (issue 1015); the same
+numbers reach pools where zero IS the answer and is worth 33,296 bytes a slot
+(issue 1033). So the floor is applied where the knob is named — here in
+`nros-zpico-build`'s `declared_floored`, one boundary over from the sidecar's
+`c_array_pool_floor`, for the same reason.
+
+## Acceptance — every ladder, measured by building
+
+| | default | declared | named override |
+| --- | ---: | ---: | ---: |
+| `ZPICO_MAX_SUBSCRIBERS` | 8 | 3 | 9 |
+| `ZPICO_MAX_PUBLISHERS` | 8 | 2 | 8 |
+| `ZPICO_MAX_{SUB,PUB}` at declared **0** | — | **1** (floored) | — |
+| `NROS_RMW_SUBSCRIBER_SLOTS` | 8 | **0** (honoured) | 3 |
+| `NROS_EXECUTOR_MAX_CBS` | 4 | 7 | 5 |
+| `NROS_EXECUTOR_ACTION_CLIENTS` | 4 | **0** | 5 |
+| `NROS_SUBSCRIBER_BUFFER_SIZE` | 1024 | 880 | 333 |
+| `ZPICO_SUBSCRIBER_LARGE_SIZE` | 16384 | 4096 | 999 |
+
+Carrier: 8 cases in `tests/cmake-message-bounds-tests.sh` §Q, driven in
+`cmake -P` beside the writer. Mutating away either payload guard fails it.
+
+```
+just check declared-fact-carriers  10 facts produced, consumed and watched (was 3)
+just check message-bound-knobs     100 assertions held
+just check entity-inventory-knobs / c-array-pool-floors / knob-delivery / node-std-tests  PASS
+just check fast                    260 ran, 1 ledger skip, 0 failed
+```
+
+## Three gates caught this work, and each was right
+
+* **`check-declared-fact-carriers` caught itself.** The first entity carrier
+  built its names by interpolation (`NROS_DECLARED_${_name}`), so the delivered
+  names appeared nowhere in the file as text. That is phase-412's second
+  recorded delivery failure — a `foreach` composing `NROS_DERIVED_${_pool}`
+  produced a name matching nothing, and CMake yields EMPTY for an unknown
+  variable rather than failing. Both names are now written in full.
+* Its read rule then had to widen: the new readers take the env name as a
+  *parameter*, so `env::var("…")` stopped being where the name appears, and the
+  gate reported a wired fact as unconsumed. Widening it over-reached into CLI
+  sources, where a `NROS_DECLARED_*` literal is the PRODUCER naming what it
+  writes — so the scan is build-side only now.
+* **`config-knob-census`** required the three new read idioms be registered and
+  the seven new facts CLASSIFIED rather than guessed at.
+
+## Not measured here
+
+The byte delta. Issue 1122 priced the whole set by hand at **−324,416 B** on the
+SPE-candidate image and `MAX_LARGE_SUBSCRIBERS` alone at −131,072; the rest of
+that is what this delivers, but confirming it needs the out-of-tree consumer and
+a cross toolchain, which is 1122's Reproduction section and not something the
+in-tree lanes can run. What is proven in-tree is every link in the chain.

--- a/packages/core/nros-node/build.rs
+++ b/packages/core/nros-node/build.rs
@@ -42,6 +42,7 @@ const fn buffered_region(depth: usize, slot: usize) -> usize {
 }
 
 fn main() {
+    watch_declared_facts();
     let out_dir = env::var("OUT_DIR").unwrap();
 
     println!("cargo:rustc-check-cfg=cfg(has_rmw)");
@@ -102,7 +103,9 @@ fn main() {
     }
 
     // --- Primary user-facing knobs ---
-    let max_cbs = env_usize("NROS_EXECUTOR_MAX_CBS", 4);
+    // issue 1199 — the executor callback budget cmake derived for this image,
+    // on the DECLARED road. Mirrors `DERIVED_ENV_KEYS` on the cargo-leaf road.
+    let max_cbs = env_usize_declared("NROS_EXECUTOR_MAX_CBS", "NROS_DECLARED_EXECUTOR_MAX_CBS", 4);
     let max_sc = env_usize("NROS_EXECUTOR_MAX_SC", 8);
     // Phase 214.C.3 — default coordinated with
     // `packages/rmw/zenoh/nros-rmw-zenoh/build.rs::ZPICO_SUBSCRIBER_BUFFER_SIZE`
@@ -149,7 +152,15 @@ fn main() {
     // Too small fails at REGISTRATION (`NodeError::BufferTooSmall`), not at
     // link — same caveat `NROS_EXECUTOR_ARENA_SIZE` carries, and the reason
     // `Executor::arena_used()` plus the first-spin advisory landed first.
-    let action_clients = env_usize("NROS_EXECUTOR_ACTION_CLIENTS", max_cbs).min(max_cbs);
+    // issue 1199 — same road. Zero is the point here rather than a hazard: a
+    // pub/sub-only image takes 74,240 bytes of arena down to 16,384, and the
+    // `.min(max_cbs)` ceiling below is unchanged.
+    let action_clients = env_usize_declared(
+        "NROS_EXECUTOR_ACTION_CLIENTS",
+        "NROS_DECLARED_EXECUTOR_ACTION_CLIENTS",
+        max_cbs,
+    )
+    .min(max_cbs);
 
     // --- Derived arena size ---
     // Arena must hold MAX_CBS entries. Worst-case entry is an
@@ -646,4 +657,42 @@ fn env_usize(name: &str, default: usize) -> usize {
     knob_for_env(name)
         .and_then(|k| rung_value(rungs, k))
         .unwrap_or(default)
+}
+
+/// issue 1199 — [`env_usize`] with the DECLARED rung spliced in.
+///
+/// The extra rung sits BELOW the board/platform descriptor and ABOVE the crate
+/// builtin, which is where the tree's stated precedence puts it: env >
+/// Kconfig/board > derived > crate default
+/// (`_nros_resolve_derivable_knob`). A board rung is a person's statement in
+/// the tree; the DECLARED value is what this image's own entity inventory
+/// derived. So an authored number still wins, and the derivation only replaces
+/// the literal nobody chose.
+///
+/// `None` when cmake made no claim: the carrier is written only when the
+/// inventory's status is `derived`, so absent means "no answer", never "zero".
+// issue 1199 — spelled literally so the wire is greppable; `env_usize_declared`
+// emits the same lines for whatever it is handed.
+fn watch_declared_facts() {
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_EXECUTOR_MAX_CBS");
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_EXECUTOR_ACTION_CLIENTS");
+}
+
+fn env_usize_declared(name: &str, declared: &str, default: usize) -> usize {
+    println!("cargo:rerun-if-env-changed={declared}");
+    let from_cmake = || {
+        std::env::var(declared)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+    };
+    // Re-uses `env_usize`'s three upper rungs by asking it for a sentinel it
+    // cannot produce: if every rung above the builtin is silent it returns the
+    // default we passed, and only then does the declared value apply. Written
+    // this way so the ladder has ONE implementation -- a second copy of the
+    // env/dotconfig/rung order is how the two would drift.
+    let probe = usize::MAX;
+    match env_usize(name, probe) {
+        v if v == probe => from_cmake().unwrap_or(default),
+        v => v,
+    }
 }

--- a/packages/rmw/cffi/build.rs
+++ b/packages/rmw/cffi/build.rs
@@ -17,6 +17,7 @@
 use nros_board_common::platform_config::{BuildRungs, RmwKnobs};
 
 fn main() {
+    watch_declared_facts();
     // phase-400 W6 — the platform/board rungs for `[knobs.rmw]`, resolved once.
     // `None` when no lane named a platform, which is every out-of-tree consumer
     // and every plain `cargo build` here; the builtins then stand.
@@ -47,8 +48,25 @@ fn main() {
 /// it sits between the Kconfig rung and the crate builtin. Passing it as
 /// `knob_usize`'s default is what places it there: env and `$DOTCONFIG` still
 /// win above it, and the builtin only applies when no descriptor said anything.
+// issue 1199 — see the note in `nros-zpico-build`'s `watch_declared_facts`:
+// spelled literally so the wire is greppable, alongside the dynamic emission.
+fn watch_declared_facts() {
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_RMW_SUBSCRIBER_SLOTS");
+}
+
 fn knob(name: &str, rung: Option<usize>, default: usize) -> usize {
     nros_zephyr_build::knob_usize(name, &format!("CONFIG_{name}"), rung.unwrap_or(default))
+}
+
+/// issue 1199 — a `NROS_DECLARED_*` count cmake derived for THIS image.
+///
+/// `None` when cmake made no claim: the carrier is written only when the entity
+/// inventory's status is `derived`, so absent means "no answer" and never
+/// "zero". Zero is a legal answer for this knob, which is exactly why the two
+/// cannot share a spelling.
+fn declared_usize(name: &str) -> Option<usize> {
+    println!("cargo:rerun-if-env-changed={name}");
+    std::env::var(name).ok().and_then(|v| v.trim().parse().ok())
 }
 
 fn emit_max_backends(rungs: &RmwKnobs) {
@@ -88,7 +106,17 @@ fn emit_subscriber_slots() {
     // entity inventory (`COUNT_SUBSCRIPTION`). Two campaigns resolving one
     // knob is the drift issue 0938 cost, so this one keeps env -> Kconfig ->
     // builtin and takes its platform answer from the derivation instead.
-    let parsed = knob("NROS_RMW_SUBSCRIBER_SLOTS", None, 8);
+    // issue 1199 — the rung is the DECLARED count cmake derived for this image.
+    // It was `None` because phase-412 W1 delivered this knob through the Zephyr
+    // resolver only; the DECLARED road carries the same number on the lanes
+    // that have no Kconfig. NOT floored: zero is legal here and measured --
+    // `[T; 0]` is ordinary Rust, the only access is `for index in
+    // 0..SLOT_COUNT`, and issue 1033 retracted the clamp that rounded it to 1.
+    let parsed = knob(
+        "NROS_RMW_SUBSCRIBER_SLOTS",
+        declared_usize("NROS_DECLARED_RMW_SUBSCRIBER_SLOTS"),
+        8,
+    );
 
     // issue 1033 — ZERO is in range. A pub-only image derives 0 subscriptions
     // from the entity inventory, and 0 slots is the honest answer: `[T; 0]` is

--- a/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
+++ b/packages/rmw/zenoh/nros-rmw-zenoh/build.rs
@@ -16,6 +16,8 @@ fn main() {
     // else forces a rebuild, and the sizing then reads as applied while being
     // stale.
     println!("cargo:rerun-if-env-changed=NROS_DECLARED_LARGE_SUBSCRIBERS");
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE");
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_SUBSCRIBER_LARGE_SIZE");
     println!("cargo:rerun-if-env-changed=NROS_EXECUTOR_MAX_NODES");
     println!("cargo:rerun-if-env-changed=ZPICO_PUBLISHER_TX_BUFFER_SIZE");
 
@@ -24,7 +26,15 @@ fn main() {
     // (also 1024). If you change one, change the other — they share the
     // wire-format expectation. Both can be overridden independently via
     // their respective env vars.
-    let sub_size: usize = env_usize("NROS_SUBSCRIBER_BUFFER_SIZE", 1024);
+    // issue 1199 — the derived SMALL class, on the same DECLARED road as the
+    // large count below. The derivation publishes it only when something
+    // received actually fits under the ceiling, so an absent variable is "no
+    // answer" and the crate default stands.
+    let sub_size: usize = env_usize_rung(
+        "NROS_SUBSCRIBER_BUFFER_SIZE",
+        declared_usize("NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE"),
+        1024,
+    );
     let svc_size: usize = env_usize("ZPICO_SERVICE_BUFFER_SIZE", 1024);
     // Phase 160.C.2 — bumped 10_000 → 30_000. The original 10 s default
     // was too short for slow zenoh-pico flushes on Zephyr/NSOS where
@@ -64,7 +74,15 @@ fn main() {
     // messages (images, point clouds). A subscription routes to `large` when its
     // `rx_buffer_hint` exceeds the threshold. `large` is capped at a small count
     // so the big slots don't multiply across every subscriber.
-    let large_size: usize = env_usize("ZPICO_SUBSCRIBER_LARGE_SIZE", 16384);
+    // issue 1199 — the derived LARGE class size. Published only when the large
+    // COUNT is non-zero: a size for a class with no blocks would be inventing a
+    // number, which is the rule `_nros_bounds_publish_payload_classes` states
+    // and `DERIVED_PAYLOAD_ENV_KEYS` repeats for the leaf road.
+    let large_size: usize = env_usize_rung(
+        "ZPICO_SUBSCRIBER_LARGE_SIZE",
+        declared_usize("NROS_DECLARED_SUBSCRIBER_LARGE_SIZE"),
+        16384,
+    );
     let size_threshold: usize = env_usize("ZPICO_SUBSCRIBER_SIZE_THRESHOLD", 2048);
     // Phase 403 W4 — the count of LARGE-class blocks, and 0 is legal.
     //
@@ -96,7 +114,7 @@ fn main() {
     // unreachable, silently.
     let max_large: usize = env_usize_rung(
         "ZPICO_MAX_LARGE_SUBSCRIBERS",
-        declared_large_subscribers(),
+        declared_usize("NROS_DECLARED_LARGE_SUBSCRIBERS"),
         2,
     );
     // Phase 268 — per-session per-node NN liveliness token cap. One zenoh
@@ -233,7 +251,7 @@ fn env_usize_rung(name: &str, rung: Option<usize>, default: usize) -> usize {
     env_usize(name, rung.unwrap_or(default))
 }
 
-/// issue 1122 — the large-payload class count cmake derived for THIS image.
+/// issue 1122 / 1199 — a `NROS_DECLARED_*` fact cmake derived for THIS image.
 ///
 /// `None` when cmake made no claim, which is every build that is not driven by
 /// our CMake lanes (a bare `cargo build`, a Rust leaf) and every configure
@@ -245,8 +263,6 @@ fn env_usize_rung(name: &str, rung: Option<usize>, default: usize) -> usize {
 /// That distinction is the whole point: `0` is a legal and meaningful value
 /// here -- it says this image's types all fit the small class -- so it cannot
 /// share a spelling with "nobody told me".
-fn declared_large_subscribers() -> Option<usize> {
-    std::env::var("NROS_DECLARED_LARGE_SUBSCRIBERS")
-        .ok()
-        .and_then(|v| v.trim().parse().ok())
+fn declared_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok().and_then(|v| v.trim().parse().ok())
 }

--- a/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
+++ b/packages/rmw/zenoh/nros-zpico-build/src/runner.rs
@@ -137,6 +137,17 @@ mod hosted_tests {
 /// With no declaration at all this returns the historical embedded budget and
 /// says nothing; W5.e turns that case into a build-time failure, which needs
 /// the hand-written-`main` question settled first (phase-392 W5, Open).
+// issue 1199 — declared LITERALLY as well as inside `declared_floored`, which
+// emits the same line for whatever name it is handed. The duplicate is
+// deliberate: `cargo:rerun-if-env-changed` is idempotent, and a wire spelled
+// only through a parameter is invisible to `check-declared-fact-carriers`,
+// which reads these files as text. Same redundancy `NROS_RMW_MAX_NODES`
+// already carries one crate over.
+fn watch_declared_facts() {
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_MAX_PUBLISHERS");
+    println!("cargo:rerun-if-env-changed=NROS_DECLARED_MAX_SUBSCRIBERS");
+}
+
 fn resolve_queryable_default() -> QueryableSizing {
     // WATCH what we READ. Both were consumed here and neither was declared, so
     // cargo had no reason to re-run this script when a declaration changed: an
@@ -510,12 +521,27 @@ fn shim_config_from_env() -> ShimConfig {
     // costs a hosted image 144,128 bytes of service buffers whether or not it
     // has a single service. Replacing the guess needs the declaration to reach
     // here from the resolved model; see issue 0827.
+    watch_declared_facts();
     let sizing = resolve_queryable_default();
     let max_queryables = env_usize("ZPICO_MAX_QUERYABLES", sizing.default);
     check_queryable_override(max_queryables, &sizing);
     ShimConfig {
-        max_publishers: env_usize("ZPICO_MAX_PUBLISHERS", 8),
-        max_subscribers: env_usize("ZPICO_MAX_SUBSCRIBERS", 8),
+        // issue 1199 — the DECLARED road supplies the default when cmake
+        // derived one. FLOORED HERE and not at the producer: these two size
+        // fixed C arrays in `zpico.c`, where zero is not a smaller pool but a
+        // `#error` (issue 1015), while the same derived counts reach pools
+        // where zero IS the answer and is worth 33,296 bytes a slot (issue
+        // 1033). The derivation publishes DEMAND; the floor belongs to the
+        // consumer that names the knob, and on this road that is here. A named
+        // `ZPICO_MAX_*` still outranks both.
+        max_publishers: env_usize(
+            "ZPICO_MAX_PUBLISHERS",
+            declared_floored("NROS_DECLARED_MAX_PUBLISHERS").unwrap_or(8),
+        ),
+        max_subscribers: env_usize(
+            "ZPICO_MAX_SUBSCRIBERS",
+            declared_floored("NROS_DECLARED_MAX_SUBSCRIBERS").unwrap_or(8),
+        ),
         max_queryables,
         queryable_table_declared: sizing.declared,
         max_liveliness: env_usize("ZPICO_MAX_LIVELINESS", 16),
@@ -637,6 +663,25 @@ fn kconfig_fallback_str(name: &str) -> Option<String> {
 /// A knob with no [`KCONFIG_KNOBS`] row (`ZPICO_MAX_SESSIONS`,
 /// `ZPICO_BATCH_MULTICAST_SIZE` — neither is exposed as Kconfig) keeps the
 /// plain env-or-default behaviour.
+/// issue 1199 — a `NROS_DECLARED_*` count from cmake, floored for a C array.
+///
+/// `None` when cmake made no claim: the carrier is written only when the entity
+/// inventory's status is `derived`, so an absent variable is "no answer" and
+/// never "zero". The distinction matters because zero is a legal derived DEMAND
+/// -- it is the floor that makes it illegal as a SIZE here, and only here.
+///
+/// The floor is 1, the same constant `c_array_pool_floor` applies on the leaf
+/// road (`leaf_entity_env.rs`), stated rather than shared because the two roads
+/// floor at different boundaries: the sidecar writes the knob name itself and
+/// must floor before writing, while this one is handed a demand to interpret.
+fn declared_floored(name: &str) -> Option<usize> {
+    println!("cargo:rerun-if-env-changed={name}");
+    env::var(name)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .map(|v| v.max(1))
+}
+
 fn env_usize(name: &str, default: usize) -> usize {
     match KCONFIG_KNOBS.iter().find(|(env, _)| *env == name) {
         Some((_, kconfig)) => nros_zephyr_build::knob_usize(name, kconfig, default),

--- a/scripts/check-declared-fact-carriers.py
+++ b/scripts/check-declared-fact-carriers.py
@@ -43,9 +43,55 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
+# issue 1199 — the two roads a derived number takes into cargo, paired.
+#
+# `leaf_entity_env.rs` writes cargo `[env]` for a Rust LEAF; `NanoRosEntityFacts.cmake`
+# writes `NROS_DECLARED_*` through `corrosion_set_env_vars` for a CMake image
+# with no leaf. They must deliver the same KNOBS, or an image's sizing depends
+# on which lane built it -- which is issue 1122 with the roads swapped.
+#
+# The names differ by construction: the sidecar may write the knob itself
+# (cargo `[env]` without `force` is still overridable), while the CMake road
+# must not (the child environment is not), so it hands over a DECLARED fact the
+# build script takes as a default. This map is the one place that pairing is
+# written down.
+ROAD_PAIRS = {
+    # sidecar DERIVED_ENV_KEYS
+    "NROS_EXECUTOR_ACTION_CLIENTS": "NROS_DECLARED_EXECUTOR_ACTION_CLIENTS",
+    "NROS_EXECUTOR_MAX_CBS": "NROS_DECLARED_EXECUTOR_MAX_CBS",
+    "NROS_RMW_SUBSCRIBER_SLOTS": "NROS_DECLARED_RMW_SUBSCRIBER_SLOTS",
+    "ZPICO_MAX_PUBLISHERS": "NROS_DECLARED_MAX_PUBLISHERS",
+    "ZPICO_MAX_SUBSCRIBERS": "NROS_DECLARED_MAX_SUBSCRIBERS",
+    # sidecar DERIVED_PAYLOAD_ENV_KEYS
+    "NROS_SUBSCRIBER_BUFFER_SIZE": "NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE",
+    "ZPICO_MAX_LARGE_SUBSCRIBERS": "NROS_DECLARED_LARGE_SUBSCRIBERS",
+    "ZPICO_SUBSCRIBER_LARGE_SIZE": "NROS_DECLARED_SUBSCRIBER_LARGE_SIZE",
+}
+
+# Facts with no leaf-road twin, each for a stated reason.
+ROAD_UNPAIRED = {
+    "NROS_DECLARED_INFRA_QUERYABLES":
+        "completes ZPICO_MAX_QUERYABLES, which is DELIBERATELY NOT DERIVED "
+        "(issue 1061): the count excludes the param and lifecycle service "
+        "families a feature enables. A leaf has no such channel.",
+    "NROS_DECLARED_SERVICE_SERVERS":
+        "the raw declared count behind the same queryable sizing (phase-392 W5).",
+    "NROS_DECLARED_QOS_MODELS": "QoS wiring, not a pool size.",
+    "NROS_DECLARED_QOS_PENDING": "QoS wiring, not a pool size.",
+    "NROS_DECLARED_QOS_SCHEDULED": "QoS wiring, not a pool size.",
+}
+
+LEAF_ENV = "packages/cli/nros-cli-core/src/leaf_entity_env.rs"
+
 NAME_RE = re.compile(r"\bNROS_DECLARED_[A-Z0-9_]+\b")
 WATCH_RE = re.compile(r"cargo:rerun-if-env-changed=(NROS_DECLARED_[A-Z0-9_]+)")
-READ_RE = re.compile(r'env::var\(\s*"(NROS_DECLARED_[A-Z0-9_]+)"')
+# A quoted literal in a build-side file is the READ. It used to be
+# `env::var("…")`, which stopped being where the name appears once the readers
+# became helpers taking the name as a parameter — and a rule that only sees one
+# spelling reports a wired fact as unconsumed (issue 1199, caught by this gate
+# on itself). Quoted, so a name mentioned in prose does not count; comments in
+# this tree spell them in backticks.
+READ_RE = re.compile(r'"(NROS_DECLARED_[A-Z0-9_]+)"')
 
 
 def tracked(*globs):
@@ -74,7 +120,11 @@ def produced():
 def consumed():
     """name -> {file: (reads, watches)} over the Rust build side."""
     seen = {}
-    for f in tracked("packages/**/build.rs", "packages/**/*.rs"):
+    # BUILD-SIDE only. `packages/**/*.rs` also sweeps CLI and runtime sources,
+    # where a `NROS_DECLARED_*` literal is the PRODUCER naming what it writes,
+    # not a consumer reading it — and demanding `rerun-if-env-changed` of a
+    # non-build script is a finding that cannot be acted on.
+    for f in tracked("packages/**/build.rs", "packages/**/*-build/src/*.rs"):
         text = f.read_text(errors="replace")
         if "NROS_DECLARED_" not in text:
             continue
@@ -83,6 +133,38 @@ def consumed():
         for n in reads | watches:
             seen.setdefault(n, []).append((f, n in reads, n in watches))
     return seen
+
+
+def check_roads(prod):
+    """The two roads must deliver the same knobs (issue 1199)."""
+    findings = []
+    leaf = (ROOT / LEAF_ENV).read_text(errors="replace")
+    leaf_keys = set()
+    for const in ("DERIVED_ENV_KEYS", "DERIVED_PAYLOAD_ENV_KEYS"):
+        m = re.search(const + r"[^=]*=\s*&\[(.*?)\];", leaf, re.S)
+        if m:
+            leaf_keys |= set(re.findall(r'"([A-Z0-9_]+)"', m.group(1)))
+    for key in sorted(leaf_keys - set(ROAD_PAIRS)):
+        findings.append(
+            "%s is on the cargo-LEAF road and has no CMake twin in ROAD_PAIRS.\n"
+            "       An image sized one way by a leaf build and another way by a\n"
+            "       CMake build is issue 1122 with the roads swapped." % key
+        )
+    for key, fact in sorted(ROAD_PAIRS.items()):
+        if key not in leaf_keys:
+            findings.append(
+                "%s is paired to %s here but is no longer on the\n"
+                "       cargo-LEAF road. Either the leaf dropped it deliberately --\n"
+                "       then say so in ROAD_UNPAIRED -- or the roads have drifted."
+                % (key, fact)
+            )
+        elif fact not in prod:
+            findings.append(
+                "%s is on the cargo-LEAF road; its CMake twin %s\n"
+                "       is produced by no cmake file, so a CMake image with no Rust\n"
+                "       leaf keeps the crate default (issue 1122)." % (key, fact)
+            )
+    return findings
 
 
 def check():
@@ -115,6 +197,7 @@ def check():
                     "       sizing reads as applied while being STALE (issue 1122)."
                     % (name, rel, name)
                 )
+    findings += check_roads(prod)
     return findings
 
 
@@ -124,14 +207,15 @@ def self_test():
 
     def case(label, prod_set, cons_map, want):
         nonlocal failures
-        global produced, consumed
-        p_orig, c_orig = produced, consumed
+        global produced, consumed, check_roads
+        p_orig, c_orig, r_orig = produced, consumed, check_roads
+        check_roads = lambda _p: []  # noqa: E731
         produced = lambda: prod_set                      # noqa: E731
         consumed = lambda: cons_map                      # noqa: E731
         try:
             got = len(check())
         finally:
-            produced, consumed = p_orig, c_orig
+            produced, consumed, check_roads = p_orig, c_orig, r_orig
         ok = (got > 0) == want
         if not ok:
             failures += 1

--- a/scripts/check/config-knob-census.py
+++ b/scripts/check/config-knob-census.py
@@ -144,6 +144,17 @@ KNOB_CLASS = {
     # with no Kconfig. Not a knob: `ZPICO_MAX_LARGE_SUBSCRIBERS` is the knob and
     # still outranks it.
     "NROS_DECLARED_LARGE_SUBSCRIBERS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    # issue 1199 — the rest of the DECLARED road, same category as the two
+    # above: each is a number cmake DERIVED for this image and hands to a build
+    # script as a DEFAULT. The knob is the `ZPICO_*` / `NROS_*` name beside it,
+    # which still outranks the declared value.
+    "NROS_DECLARED_MAX_PUBLISHERS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    "NROS_DECLARED_MAX_SUBSCRIBERS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    "NROS_DECLARED_RMW_SUBSCRIBER_SLOTS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    "NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE": ("infra", "a SIZE the resolver passes down, not a knob"),
+    "NROS_DECLARED_SUBSCRIBER_LARGE_SIZE": ("infra", "a SIZE the resolver passes down, not a knob"),
+    "NROS_DECLARED_EXECUTOR_MAX_CBS": ("infra", "a COUNT the resolver passes down, not a knob"),
+    "NROS_DECLARED_EXECUTOR_ACTION_CLIENTS": ("infra", "a COUNT the resolver passes down, not a knob"),
     "NROS_PICOLIBC_SYSROOT": ("infra", "path"),
     "NROS_RISCV64_PREFIX": ("infra", "toolchain prefix"),
     "NROS_SDK_STORE": ("infra", "path"),
@@ -363,6 +374,12 @@ READ_CALLEES = {
     # phase-400 W6. `env_usize` with a ladder rung between the env and the
     # builtin.
     "env_usize_rung",
+    # issue 1199 — the DECLARED road's readers. Each takes the env NAME as a
+    # parameter, so the census sees the literal at the call site rather than
+    # inside the helper.
+    "env_usize_declared",
+    "declared_usize",
+    "declared_floored",
     "env", "env_get", "env_bool", "env_usize", "env_usize_min",
     "env_usize_compat", "env_or_repo_path", "env_path_or", "flag", "knob",
     "knob_usize", "knob_bool", "req", "list", "var", "var_os",

--- a/tests/cmake-message-bounds-tests.sh
+++ b/tests/cmake-message-bounds-tests.sh
@@ -1067,6 +1067,8 @@ payload_env() {
             printf 'set(NROS_MESSAGE_BOUNDS_PAYLOAD_STATUS "%s")\n' "$1"
             printf 'set(NROS_MESSAGE_BOUNDS_BASIS "%s")\n' "$2"
             [ -n "${3:-}" ] && printf 'set(NROS_DERIVED_MAX_LARGE_SUBSCRIBERS %s)\n' "$3"
+            [ -n "${4:-}" ] && printf 'set(NROS_DERIVED_SUBSCRIBER_BUFFER_SIZE %s)\n' "$4"
+            [ -n "${5:-}" ] && printf 'set(NROS_DERIVED_SUBSCRIBER_LARGE_SIZE %s)\n' "$5"
         } > "$dir/nros/message_bound_knobs.cmake"
     fi
     cat > "$dir/run.cmake" <<EOF
@@ -1112,6 +1114,25 @@ check
 _got="$(payload_env NOFILE)"
 if [ "$_got" != "" ]; then
     fail "Q: no knobs file at all carries nothing -- wanted \"\", got ${_got:-<empty>}"
+fi
+check
+
+# issue 1199 — all THREE payload keys travel, and each of the two SIZES only
+# when its own derivation published it. The set mirrors `DERIVED_PAYLOAD_ENV_KEYS`
+# in `leaf_entity_env.rs`; two roads carrying different key sets is how an
+# image's sizing comes to depend on which lane built it.
+_got="$(payload_env derived subscribed 2 880 4096)"
+_want="NROS_DECLARED_LARGE_SUBSCRIBERS=2;NROS_DECLARED_SUBSCRIBER_BUFFER_SIZE=880;NROS_DECLARED_SUBSCRIBER_LARGE_SIZE=4096"
+if [ "$_got" != "$_want" ]; then
+    fail "Q: the three payload keys -- wanted $_want, got ${_got:-<empty>}"
+fi
+check
+# A small class of 0 is not published (nothing received fits under the ceiling),
+# and a large SIZE is not published when the class has no blocks. Absent here
+# must stay absent rather than becoming a zero.
+_got="$(payload_env derived subscribed 0)"
+if [ "$_got" != "NROS_DECLARED_LARGE_SUBSCRIBERS=0" ]; then
+    fail "Q: an unpublished SIZE must not be invented -- got ${_got:-<empty>}"
 fi
 check
 


### PR DESCRIPTION
Continues issue 1122. A number CMake derives reaches a build script by one of three roads:

| road | who it serves | mechanism |
| --- | --- | --- |
| resolver | Zephyr images | `nros_resolve_knobs()` → `NROS_RESOLVED_*` |
| sidecar | Rust **leaves** | `nros sync` writes cargo `[env]` (`leaf_entity_env.rs`) |
| declared | CMake images with **no** Rust leaf | `corrosion_set_env_vars` → `NROS_DECLARED_*` |

1122 built the third road and put one knob on it. Everything else was still computed on every
lane, written to `entity_inventory.cmake` / `message_bound_knobs.cmake`, and read only under
`zephyr/` — so a FreeRTOS, ThreadX, NuttX or posix image with no Rust leaf kept every crate
default.

## The set is not chosen here

It mirrors `DERIVED_ENV_KEYS` and `DERIVED_PAYLOAD_ENV_KEYS` in `leaf_entity_env.rs` — the same
decisions already made for the leaf road. Two roads delivering different key sets is how an
image's sizing comes to depend on which lane built it, which is 1122 with the roads swapped.
`ROAD_PAIRS` in the gate is where the pairing is written down; `ROAD_UNPAIRED` records the facts
with no twin and why.

Three names stay **off** the road, each for a reason already in the tree: `ZPICO_MAX_QUERYABLES`
is deliberately not derived (its count excludes the param and lifecycle families a FEATURE
enables — issue 1061; the CMake road completes it through `NROS_DECLARED_INFRA_QUERYABLES`),
`NROS_EXECUTOR_MAX_NODES` was withheld from phase-412 W1 because under-counting halts the board,
and `NROS_SUBSCRIPTION_BUFFER_SIZE` is off the leaf road too and also feeds the arena derivation.

## Two rules this had to respect

**A derived value is a DEFAULT, never an override** — the ladder is
`env > Kconfig/board > derived > crate default`. So every consumer takes the declared fact as its
*default* and a named knob still wins. Setting the knob itself through `corrosion_set_env_vars`
would have made the override unreachable, because the child environment is not overridable the
way cargo `[env]` (without `force`) is. That asymmetry is why the two roads spell the same number
differently.

**The floor belongs to the consumer, not the derivation.** The two `ZPICO_*` counts size fixed C
arrays where zero is a `#error` (issue 1015); the same numbers reach pools where zero *is* the
answer and is worth 33,296 bytes a slot (issue 1033).

## Acceptance — every ladder, measured by building

| | default | declared | named override |
| --- | ---: | ---: | ---: |
| `ZPICO_MAX_SUBSCRIBERS` | 8 | 3 | 9 |
| `ZPICO_MAX_PUBLISHERS` | 8 | 2 | 8 |
| `ZPICO_MAX_{SUB,PUB}` at declared **0** | — | **1** (floored) | — |
| `NROS_RMW_SUBSCRIBER_SLOTS` | 8 | **0** (honoured) | 3 |
| `NROS_EXECUTOR_MAX_CBS` | 4 | 7 | 5 |
| `NROS_EXECUTOR_ACTION_CLIENTS` | 4 | **0** | 5 |
| `NROS_SUBSCRIBER_BUFFER_SIZE` | 1024 | 880 | 333 |
| `ZPICO_SUBSCRIBER_LARGE_SIZE` | 16384 | 4096 | 999 |

```
just check declared-fact-carriers  10 facts produced, consumed and watched (was 3)
just check message-bound-knobs     100 assertions held
just check entity-inventory-knobs / c-array-pool-floors / knob-delivery / node-std-tests  PASS
just check fast                    260 ran, 1 ledger skip, 0 failed
```

## Three gates caught this work, and each was right

`check-declared-fact-carriers` **caught itself**: the first entity carrier built its names by
interpolation, so the delivered names appeared nowhere in the file as text — phase-412's second
recorded delivery failure, where a `foreach` composing `NROS_DERIVED_${_pool}` produced a name
matching nothing and CMake yielded EMPTY rather than failing. Its read rule then had to widen
(the new readers take the env name as a parameter) and then narrow again (the widened form
reached CLI sources, where such a literal is the PRODUCER naming what it writes).
`config-knob-census` required the three new read idioms be registered and the seven new facts
CLASSIFIED rather than guessed at.

## Not measured here

The byte delta. 1122 priced the whole set by hand at **−324,416 B** on the SPE-candidate image
and `MAX_LARGE_SUBSCRIBERS` alone at −131,072; the rest of that is what this delivers, but
confirming it needs the out-of-tree consumer and a cross toolchain. Every link in the chain is
proven in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119aFbZ4oJ6u4agj4PjknPd