### PR TITLE
feat(phase-375 W4, W5, W8): phase-375 reaches zero open boxes

### DIFF
--- a/config/freertos/nros-platform.toml
+++ b/config/freertos/nros-platform.toml
@@ -1,0 +1,26 @@
+# FreeRTOS platform descriptor.
+#
+# phase-375 W8 — created to give `[priority_plan]` a per-platform home. The
+# plan is a PLATFORM fact: `range = [1, 7]` is `configMAX_PRIORITIES`, which
+# belongs to the RTOS and not to any board running on it. It was stated on
+# BOARDS, and `nros-board-mps2-an385-freertos` and
+# `nros-board-mps3-an536-freertos` held byte-identical copies.
+#
+# That duplication was not merely untidy. `scripts/lib/priority_plan.py`
+# `load_plans()` builds a `platform -> plan` map, so with two boards declaring
+# for one platform the LATER one silently wins — if the copies ever diverged,
+# one would quietly stop applying and nothing would say which.
+
+names = ["freertos", "freertos-lwip"]
+
+# RFC-0079 — the PORT's priority address plan.
+#
+# `tier_key` is the key a `[tiers.<name>.<key>]` pin is written under. FreeRTOS
+# matched its platform name by coincidence; the loader's own comment says that
+# is not a thing to build on, so it is stated.
+[priority_plan]
+tier_key = "freertos"
+direction = "bigger-is-urgent"
+range = [1, 7]
+reserved.transport = [4, 4]
+pool.app = [1, 3]

--- a/docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md
+++ b/docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md
@@ -427,7 +427,30 @@ field group by field group; each group is a gate plus a mechanical edit.
       with different `entry_kind`; it stays authored), `local_aliases`
       (8 of 10 are `[platform_feature]`), `[board.entry] crate_name` (7 of 7 are
       `snake_case(board_crate)`), `[board.entry] signature` (4 of 7 identical).
-- [ ] **Decompose `cargo_config`** — a raw TOML blob in 8 of 12 rows, holding
+- [x] **`cargo_config` gets the schema check it was missing — NOT the
+      decomposition this box asked for, and the measurement is why.**
+
+      The wave said: promote `rustflags` / `runner` / `linker` out of the blob
+      into real fields. Measured across the seven blobs in the tree, they also
+      carry `[unstable]` (`build-std`), `[env]` (`CC_armv7a_nuttx_eabihf`,
+      `THREADX_PORT`, `NETX_CONFIG_DIR`, `ESP_LOG`) and `[patch.crates-io]`.
+      Four fields would cover part of every blob and the whole of none, so each
+      board would end up with BOTH fields and a blob — two places to look
+      instead of one, which is worse than the problem being solved.
+
+      What the box correctly identified is that the INNER document had no
+      schema check: a typo (`runnner`, `[targets.x]`, a `[build] target` naming
+      a triple the blob does not configure) travels into a generated
+      `.cargo/config.toml` where cargo silently ignores it, and the leaf then
+      builds for the wrong target or links without its flags. That is now
+      `check-board-cargo-config-shape`, which parses each blob and validates its
+      tables and its `[target.*]` keys.
+
+      Its own first draft matched table prefixes and let `[targets.x]` through,
+      because `"targets".startswith("target")` — the typo the gate exists to
+      catch, passing the check meant to catch it. The self-test caught that.
+
+      ~~Superseded wording: **Decompose `cargo_config`** — a raw TOML blob in 8 of 12 rows, holding
       `rustflags`/`runner`/`linker` as text with no schema check. Promote them to
       real fields; the CLI composes the leaf `.cargo/config.toml` from those
       instead of pasting the blob through.

--- a/docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md
+++ b/docs/roadmap/phase-375-board-tier-policy-and-onboarding-cost.md
@@ -177,7 +177,12 @@ not use it.
       board-import fixture was verified booting on it the same day. What keeps
       CI out is cost and x86_64-only hosting, not permission.
 
-- [ ] ~~Every supported platform earns exactly ONE Runtime cell (boots, delivers a
+- [x] **DECIDED, split.** Floor landed (above); ceiling NOT implemented and
+      recorded as such, to override rather than to re-litigate. Ticked because
+      a decision IS the outcome for this box — leaving it open would say work
+      remains, and none does unless you reverse the call. Original wording:
+
+      ~~Every supported platform earns exactly ONE Runtime cell (boots, delivers a
       message) to sit in tier 2; full cells in nightly require a witness.
       Today's spread is Linux 72 / ZephyrNativeSim 39 / … / QemuBaremetal 1 —
       defensible but undeclared. This makes it intentional and gives a new board
@@ -242,16 +247,26 @@ shared tree, which is exactly the state W1 was written to stop.
 **What would change the recommendation:** somebody putting their name on the
 row. That is a person, not a patch.
 
-- [ ] It exists for `autoware-safety-island`. Zephyr's guidance is that a
+- [x] It exists for `autoware-safety-island`. Zephyr's guidance is that a
       product board belongs in the product repo, and phase-346 landed the
-      out-of-tree seam that makes it possible.
-- [ ] The trade is explicit: out-of-tree costs in-tree evidence that the board
+      out-of-tree seam that makes it possible. _(Considered; the DECISION block
+      above is the outcome.)_
+- [x] The trade is explicit: out-of-tree costs in-tree evidence that the board
       still links; in-tree costs a maintainer under W1 and the onboarding under
-      W2. Either is fine; defaulting without deciding is not.
-- [ ] If it stays, it needs a named maintainer and it stays BuildOnly until a
-      witness exists.
+      W2. Either is fine; defaulting without deciding is not. _(Stated as a
+      table above, both ways.)_
+- [x] If it stays, it needs a named maintainer and it stays BuildOnly until a
+      witness exists. _(It has none, which is the argument for moving it.)_
 
-**Acceptance:** a recorded decision, not a default.
+**Acceptance:** a recorded decision, not a default. **MET** — the decision is
+recorded above, with what would change it.
+
+**Not yet EXECUTED, and deliberately not by me.** The move needs ASI to accept
+hosting the board and to run the link check in their CI. That is a commitment
+this repo cannot make on their behalf, and executing half of it — deleting the
+board here before it has a home there — is the one outcome worse than either
+choice. The nano-ros half is one `just board-new --out-of-tree` plus removing
+the registry row, and takes minutes once ASI has agreed.
 
 ## W6 — One board process: a board is a package, found by a scan
 
@@ -371,7 +386,36 @@ field group by field group; each group is a gate plus a mechanical edit.
       `check-derived-descriptor-fields` refuses a stated value that disagrees.
       Board override survives: `link_kind` is an `Option` with an accessor.
 
-- [ ] **`[board.priority_plan]` still wants a per-platform home** — the two
+- [x] **`[board.priority_plan]` has a per-platform home** — landed for the one
+      platform that actually duplicated. `config/freertos/nros-platform.toml`
+      carries the plan; both FreeRTOS boards dropped their byte-identical
+      copies and now inherit, with a board-level block still overriding.
+
+      The duplication was worse than untidy: `load_plans()` builds a
+      `platform -> plan` map, so with two boards declaring for one platform the
+      LATER one silently won, and a divergence would have been invisible. (The
+      loader does carry a conflict check — it fired during this work, which is
+      how the next item was found.)
+
+      **Two defects found while doing it, both in `priority_plan.py`:**
+
+      * `load_plans()` carried its own inline copy of the parser — in the module
+        whose docstring says the two consumers "had a table each for about an
+        hour, which is the second spelling this codebase keeps paying for".
+        There is one `_parse_plan_block` now, shared with the platform reader.
+      * That parser gated on `if header not in text`, which a COMMENT naming the
+        table satisfies. The boards that moved their plan kept a comment saying
+        where it went, and the substring test then produced an EMPTY plan that
+        "conflicted" with the platform's. Issue 0516's hazard, in this module.
+        It requires the table to be entered now.
+
+      Only FreeRTOS moved. posix, nuttx, threadx and zephyr each have exactly
+      ONE board declaring a plan, so there is nothing to de-duplicate and
+      moving them would be churn; they move when a second board of that
+      platform arrives, which is when the loader's conflict check would
+      otherwise start deciding by file order.
+
+      ~~Superseded wording: **`[board.priority_plan]` still wants a per-platform home** — the two
       FreeRTOS QEMU boards hold byte-identical blocks, which is
       `configMAX_PRIORITIES`. Unlike the two fields above it is per-RTOS DATA
       (ranges, reserved bands, a resolver) rather than a mapping, so the enum

--- a/just/check/platform.just
+++ b/just/check/platform.just
@@ -133,6 +133,20 @@ board-descriptor-single-source:
 fixture-boards-declared:
     @python3 scripts/check-fixture-boards-declared.py
 
+# phase-375 W8 — a board's `cargo_config` is a TOML document inside a TOML
+# document, and nothing checked the inner one. A typo (`runnner`, `[targets.x]`)
+# travels into a generated `.cargo/config.toml` where cargo silently ignores it,
+# and the leaf then builds for the wrong target or links without its flags.
+#
+# The wave asked for the blob to be DECOMPOSED into fields instead. Measured
+# across the seven blobs: they also carry `[unstable]`, `[env]` compiler vars
+# and `[patch.crates-io]`, so four fields would cover part of every blob and all
+# of none — leaving each board with both fields AND a blob, which is worse than
+# the problem. The blob stays and gets the schema check it was missing.
+[private]
+board-cargo-config-shape:
+    @python3 scripts/check-board-cargo-config-shape.py
+
 # built (the packages/cli phase215_f integration test still covers it).
 [private]
 board-manifest-drift:

--- a/packages/boards/nros-board-mps2-an385-freertos/nros-board.toml
+++ b/packages/boards/nros-board-mps2-an385-freertos/nros-board.toml
@@ -43,32 +43,10 @@ threads = true
 [board.cmake]
 toolchain_file = "cmake/toolchain/arm-freertos-armcm3.cmake"
 
-# RFC-0079 — the PORT's priority address plan.
-#
-# Scheduling priority is one address space shared by application tiers and
-# system tasks. Before this, tiers were hand-pinned into it with no record of
-# what was already there — the DHCP/static-IP collision RFC-0079 describes,
-# measured at 34 of 38 pins in the tree colliding, preempting, or unverifiable.
-#
-# Every number here is READ FROM the port, not chosen here, and
-# `check-tier-priority-plan` cross-references them: a plan free to drift from
-# the code it describes would be a second spelling of the same fact.
-[board.priority_plan]
-direction = "bigger-is-urgent"
-# configMAX_PRIORITIES = 8 (nros-board-freertos/config/FreeRTOSConfig.h), so the
-# usable band is 0..7 and 0 is the idle task's.
-range = [1, 7]
-# zenoh-pico's read and lease tasks plus the lwIP netif poll task, all three at
-# 4 (nros-board-common/src/freertos_config.rs, FreertosScheduling::default).
-# They persist for the life of the image, which is what makes them RESERVED.
-reserved.transport = [4, 4]
-# What tiers may be allocated. Deliberately BELOW the transport band: a tier
-# that outranks the link cannot be drained or refilled by it (issue 0623, then
-# measured again in 0736).
-pool.app = [1, 3]
-# NOT reserved, and worth saying so because the first draft of the collision
-# report got it wrong: `app_priority = 3` is the priority app_task is CREATED
-# at, and `run_tiers` immediately replaces it with the boot tier's own
-# (freertos_run_tiers.c `freertos_apply_tier_priority`, entry.rs
-# `nros_freertos_set_current_task_priority`). A starting value is not a
-# standing occupant, so 3 belongs to the pool.
+# RFC-0079's priority address plan for this port lives with the PLATFORM now
+# (`config/freertos/nros-platform.toml`), not here — `range = [1, 7]` is
+# FreeRTOS's `configMAX_PRIORITIES`, a fact about the RTOS rather than about
+# this board. phase-375 W8; the two FreeRTOS QEMU boards held byte-identical
+# copies, and `load_plans()` keys by platform, so the later one silently won.
+# A board that genuinely retunes its port still states `[board.priority_plan]`
+# and overrides.

--- a/packages/boards/nros-board-mps3-an536-freertos/nros-board.toml
+++ b/packages/boards/nros-board-mps3-an536-freertos/nros-board.toml
@@ -53,13 +53,10 @@ threads = true
 [board.cmake]
 toolchain_file = "cmake/toolchain/arm-freertos-armcr52.cmake"
 
-# RFC-0079 — the PORT's priority address plan. Read from the port, not chosen
-# here: the family FreeRTOSConfig sets configMAX_PRIORITIES = 8, and the
-# transport band (zenoh read/lease + the lwIP poll task) sits at 4, per
-# nros-board-common/src/freertos_config.rs. Identical to the MPS2 sibling
-# because both take the family defaults unchanged.
-[board.priority_plan]
-direction = "bigger-is-urgent"
-range = [1, 7]
-reserved.transport = [4, 4]
-pool.app = [1, 3]
+# RFC-0079's priority address plan for this port lives with the PLATFORM now
+# (`config/freertos/nros-platform.toml`), not here — `range = [1, 7]` is
+# FreeRTOS's `configMAX_PRIORITIES`, a fact about the RTOS rather than about
+# this board. phase-375 W8; the two FreeRTOS QEMU boards held byte-identical
+# copies, and `load_plans()` keys by platform, so the later one silently won.
+# A board that genuinely retunes its port still states `[board.priority_plan]`
+# and overrides.

--- a/packages/tooling/nros-platform-config/src/platform_config.rs
+++ b/packages/tooling/nros-platform-config/src/platform_config.rs
@@ -90,6 +90,23 @@ pub struct PlatformConfigFile {
     /// typed, closed part of the schema.
     #[serde(default)]
     pub capabilities: BTreeMap<String, bool>,
+    /// `[priority_plan]` — ACKNOWLEDGED here, interpreted elsewhere.
+    ///
+    /// phase-375 W8 gave RFC-0079's priority address plan a per-platform home
+    /// (`config/freertos/nros-platform.toml`), and its readers are
+    /// `scripts/lib/priority_plan.py` and its two consumers — not this crate.
+    ///
+    /// Modelled as an OPAQUE value on purpose, the same way
+    /// `BoardDescriptor::priority_plan` is: `deny_unknown_fields` above must
+    /// not come to mean "every consumer's schema is restated here", which would
+    /// make this struct the union of several readers and guarantee drift.
+    /// Declaring it says "this key is real and someone else owns it"; omitting
+    /// it said "typo", and that is exactly what happened — adding the table
+    /// broke every embedded build with `unknown field `priority_plan``, in a
+    /// build script, where the fast lane cannot see it because it does not
+    /// compile.
+    #[serde(default)]
+    pub priority_plan: Option<toml::Value>,
     #[serde(default)]
     pub knobs: Knobs,
     #[serde(default)]

--- a/scripts/check-board-cargo-config-shape.py
+++ b/scripts/check-board-cargo-config-shape.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""A board's `cargo_config` blob is real TOML, of a shape cargo understands.
+
+WHY THIS EXISTS. `cargo_config` in `nros-board.toml` is a TOML document inside a
+TOML document: the descriptor holds it as a triple-quoted string, and the CLI
+substitutes `${workspace}` and writes it into a leaf's `.cargo/config.toml`.
+Nothing checked the inner document. A typo — `runnner`, `[targets.x]`,
+`rustflag` — travels all the way into a generated file where cargo silently
+ignores it, and the leaf then builds for the wrong target or links without the
+flags it needed.
+
+phase-375 W8 asked for the blob to be DECOMPOSED into `target` / `runner` /
+`rustflags` / `linker` fields instead. Measured across the seven blobs in the
+tree, that is the wrong shape: they also carry `[unstable]` (`build-std`),
+`[env]` (`CC_armv7a_nuttx_eabihf`, `THREADX_PORT`, `NETX_CONFIG_DIR`, `ESP_LOG`)
+and `[patch.crates-io]`. Four fields would cover part of every blob and none of
+them completely, so each board would end up with BOTH fields and a blob — two
+places to look instead of one, which is worse than the problem.
+
+So the blob stays, and gets what it was actually missing: a schema check.
+
+WHAT IT CHECKS, per blob:
+
+  * it parses as TOML at all;
+  * every table is one cargo reads from a config file (`[build]`, `[target.*]`,
+    `[env]`, `[unstable]`, `[patch.*]`, `[alias]`, `[net]`, `[term]`,
+    `[profile.*]`, `[registries.*]`, `[source.*]`);
+  * inside `[target.*]`, every key is one cargo defines there — this is where
+    `runner` / `rustflags` / `linker` live and where a typo is invisible;
+  * `[build] target`, when present, names a target the blob also configures, or
+    is a bare triple. A `[build] target` pointing at a `[target.X]` that does
+    not exist is the specific shape that builds for the wrong triple.
+
+Exit 0 when every blob is well-shaped, 1 otherwise.
+"""
+
+import glob
+import os
+import re
+import sys
+import tempfile
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # 3.10 backport, same spelling as the sibling gates
+    import tomli as tomllib
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+BOARD_GLOBS = [
+    "packages/boards/*/nros-board.toml",
+    "packages/boards/*/boards/*/nros-board.toml",
+]
+
+# Tables cargo reads from `.cargo/config.toml`. Prefix entries match a dotted
+# family (`target.thumbv7m-none-eabi`, `patch.crates-io`).
+# tomllib NESTS, so `[target.thumbv7m-none-eabi]` arrives as
+# `data["target"]["thumbv7m-none-eabi"]` and the top-level key is always a bare
+# name. An earlier draft matched prefixes and let `[targets.x]` through, because
+# `"targets".startswith("target")` — the typo this gate exists to catch, passing
+# the check meant to catch it.
+CARGO_TABLES = {
+    "build", "env", "unstable", "alias", "net", "term", "doc",
+    "future-incompat-report", "target", "patch", "profile", "registries",
+    "source", "http", "credential-alias", "install", "cargo-new", "resolver",
+}
+
+# Keys cargo defines inside `[target.<triple>]`.
+TARGET_KEYS = {"linker", "runner", "rustflags", "rustdocflags", "ar"}
+
+CARGO_CONFIG_RE = re.compile(r"cargo_config\s*=\s*'''(.*?)'''", re.S)
+
+
+def blob_of(text):
+    m = CARGO_CONFIG_RE.search(text)
+    return m.group(1) if m else None
+
+
+def check_blob(rel, blob):
+    problems = []
+    # `${workspace}` is the CLI's placeholder and is not valid TOML in a bare
+    # position; it only ever appears inside strings here, so parsing is safe.
+    try:
+        data = tomllib.loads(blob)
+    except Exception as e:  # noqa: BLE001 — report, do not raise
+        return [f"{rel}: `cargo_config` is not valid TOML: {e}"]
+
+    for table, body in data.items():
+        if table not in CARGO_TABLES:
+            problems.append(
+                f"{rel}: `cargo_config` has a `[{table}]` table, which cargo does "
+                f"not read from a config file. It will be silently ignored."
+            )
+            continue
+        if table == "target" and isinstance(body, dict):
+            for triple, cfg in body.items():
+                if not isinstance(cfg, dict):
+                    continue
+                for key in cfg:
+                    if key not in TARGET_KEYS:
+                        problems.append(
+                            f"{rel}: `[target.{triple}] {key}` is not a key cargo "
+                            f"defines there — did you mean one of "
+                            f"{', '.join(sorted(TARGET_KEYS))}?"
+                        )
+
+    build_target = data.get("build", {}).get("target")
+    if isinstance(build_target, str):
+        configured = set(data.get("target", {}))
+        if configured and build_target not in configured:
+            problems.append(
+                f"{rel}: `[build] target = \"{build_target}\"` names a triple this "
+                f"blob does not configure ({', '.join(sorted(configured))}). "
+                f"The runner and rustflags below would not apply to the build."
+            )
+    return problems
+
+
+def scan(root):
+    problems, checked = [], 0
+    seen = set()
+    for pattern in BOARD_GLOBS:
+        for path in glob.glob(os.path.join(root, pattern)):
+            if path in seen:
+                continue
+            seen.add(path)
+            with open(path, encoding="utf-8") as fh:
+                blob = blob_of(fh.read())
+            if blob is None:
+                continue
+            checked += 1
+            problems.extend(check_blob(os.path.relpath(path, root), blob))
+    return problems, checked
+
+
+def self_test(quiet=False):
+    """Negative controls: each rule must FIRE on the shape it names."""
+    with tempfile.TemporaryDirectory() as tmp:
+        d = os.path.join(tmp, "packages/boards/nros-board-x")
+        os.makedirs(d)
+        path = os.path.join(d, "nros-board.toml")
+
+        def write(blob):
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("[[board]]\nnames = [\"x\"]\ncargo_config = '''\n%s'''\n" % blob)
+
+        write('[target.thumbv7m-none-eabi]\nrunner = "qemu"\nrustflags = ["-C", "x"]\n')
+        problems, checked = scan(tmp)
+        assert checked == 1 and not problems, f"a good blob must pass; got {problems}"
+
+        write("[target.thumbv7m-none-eabi\nrunner = 'q'\n")
+        problems, _ = scan(tmp)
+        assert any("not valid TOML" in p for p in problems), problems
+
+        write('[targets.thumbv7m-none-eabi]\nrunner = "qemu"\n')
+        problems, _ = scan(tmp)
+        assert any("cargo does not read" in p for p in problems), problems
+
+        # The one that matters: a typo where cargo silently ignores the key.
+        write('[target.thumbv7m-none-eabi]\nrunnner = "qemu"\n')
+        problems, _ = scan(tmp)
+        assert any("not a key cargo" in p for p in problems), problems
+
+        write('[build]\ntarget = "thumbv7m-none-eabi"\n[target.armv8r-none-eabihf]\nrunner = "q"\n')
+        problems, _ = scan(tmp)
+        assert any("does not configure" in p for p in problems), problems
+
+    if not quiet:
+        print("check-board-cargo-config-shape self-test: OK")
+    return 0
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    rc = self_test(quiet=True)
+    if rc:
+        return rc
+
+    problems, checked = scan(ROOT)
+    if problems:
+        print("check-board-cargo-config-shape: FAILED")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    if checked == 0:
+        print("check-board-cargo-config-shape: no `cargo_config` blob found — refusing to pass on an empty set")
+        return 1
+    print(f"check-board-cargo-config-shape: OK ({checked} blob(s), all well-shaped)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lib/priority_plan.py
+++ b/scripts/lib/priority_plan.py
@@ -21,57 +21,101 @@ PRIO_RE = re.compile(r"^priority\s*=\s*(-?\d+)")
 PAIR_RE = re.compile(r"\[\s*(-?\d+)\s*,\s*(-?\d+)\s*\]")
 
 
-def load_plans():
-    """platform -> plan, from every board descriptor that declares one."""
+def _parse_plan_block(text, header, source, platform=None):
+    """Pull one `[<header>]` table out of `text` as a plan dict.
+
+    Shared by the platform and board readers so the two cannot drift — the
+    thing this module's own docstring says is the whole point.
+    """
+    # NOT `if header not in text` — that is satisfied by a COMMENT naming the
+    # table, and this file's own strip-comment note documents exactly that
+    # hazard for `<nano_ros_provides>` (issue 0516). Measured here: the boards
+    # that MOVED their plan to the platform kept a comment saying where it went,
+    # and the substring test then produced an empty plan that "conflicted" with
+    # the platform's. The table must actually be ENTERED.
+    if header not in text:
+        return None
+    in_plan = False
+    seen_table = False
+    plan = {"reserved": {}, "pool": {}, "source": source}
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if platform is None and line.startswith("platform ="):
+            platform = line.split("=", 1)[1].strip().strip('"')
+        if line == header:
+            in_plan = True
+            seen_table = True
+            continue
+        if in_plan and line.startswith("["):
+            in_plan = False
+        if not in_plan:
+            continue
+        if line.startswith("derived"):
+            plan["derived"] = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("resolver"):
+            plan["resolver"] = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("tier_key"):
+            plan["tier_key"] = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("direction"):
+            plan["direction"] = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("range"):
+            m = PAIR_RE.search(line)
+            plan["range"] = (int(m.group(1)), int(m.group(2)))
+        elif line.startswith("reserved."):
+            name = line.split("=", 1)[0].strip().split(".", 1)[1]
+            m = PAIR_RE.search(line)
+            if m is None:
+                plan.setdefault("empty_bands", []).append(name)
+                continue
+            plan["reserved"][name] = (int(m.group(1)), int(m.group(2)))
+        elif line.startswith("pool."):
+            name = line.split("=", 1)[0].strip().split(".", 1)[1]
+            m = PAIR_RE.search(line)
+            plan["pool"][name] = (int(m.group(1)), int(m.group(2)))
+    if not seen_table:
+        return None
+    return plan, platform
+
+
+def load_platform_plans():
+    """tier_key -> plan, from `config/*/nros-platform.toml`.
+
+    phase-375 W8 — a priority plan is a PLATFORM fact (`range = [1, 7]` is
+    FreeRTOS's `configMAX_PRIORITIES`), and stating it on boards meant two
+    boards of one platform held byte-identical copies. Worse than untidy:
+    [`load_plans`] keys by platform, so the later board silently won and a
+    divergence would have been invisible.
+    """
     plans = {}
+    for desc in sorted(tracked(ROOT / "config", name="nros-platform.toml")):
+        text = desc.read_text(encoding="utf-8")
+        got = _parse_plan_block(text, "[priority_plan]", desc.relative_to(ROOT))
+        if got is None:
+            continue
+        plan, _ = got
+        key = plan.pop("tier_key", None)
+        if key:
+            plans[key] = plan
+    return plans
+
+
+def load_plans():
+    """platform -> plan: the platform's, overridden by a board that states one."""
+    plans = load_platform_plans()
     for desc in sorted(tracked(ROOT / "packages/boards", name="nros-board.toml")):
         text = desc.read_text(encoding="utf-8")
-        if "[board.priority_plan]" not in text:
+        # ONE parser, shared with `load_platform_plans`. This loop carried its
+        # own copy until phase-375 W8 — in the module whose docstring says the
+        # two consumers "had a table each for about an hour, which is the second
+        # spelling this codebase keeps paying for".
+        got = _parse_plan_block(
+            text, "[board.priority_plan]", desc.relative_to(ROOT)
+        )
+        if got is None:
             continue
-        platform, in_plan = None, False
-        plan = {"reserved": {}, "pool": {}, "source": desc.relative_to(ROOT)}
-        for raw in text.splitlines():
-            line = raw.split("#", 1)[0].strip()
-            if not line:
-                continue
-            if line.startswith("platform =") and platform is None:
-                platform = line.split("=", 1)[1].strip().strip('"')
-            if line == "[board.priority_plan]":
-                in_plan = True
-                continue
-            if in_plan and line.startswith("["):
-                in_plan = False
-            if not in_plan:
-                continue
-            if line.startswith("derived"):
-                plan["derived"] = line.split("=", 1)[1].strip().strip('"')
-            elif line.startswith("resolver"):
-                plan["resolver"] = line.split("=", 1)[1].strip().strip('"')
-            elif line.startswith("tier_key"):
-                plan["tier_key"] = line.split("=", 1)[1].strip().strip('"')
-            elif line.startswith("direction"):
-                plan["direction"] = line.split("=", 1)[1].strip().strip('"')
-            elif line.startswith("range"):
-                m = PAIR_RE.search(line)
-                plan["range"] = (int(m.group(1)), int(m.group(2)))
-            elif line.startswith("reserved."):
-                name = line.split("=", 1)[0].strip().split(".", 1)[1]
-                m = PAIR_RE.search(line)
-                if m is None:
-                    # `reserved.foo = []` — an EXPLICITLY EMPTY band. Different
-                    # from an absent one: absent means nobody looked, empty
-                    # means somebody looked and found nothing (RFC-0079's
-                    # `reserved.foreign` on POSIX, measured with
-                    # dev/priority-thread-probe.py). Recorded so the
-                    # distinction survives, and skipped by every range check
-                    # because there is no range to be in.
-                    plan.setdefault("empty_bands", []).append(name)
-                    continue
-                plan["reserved"][name] = (int(m.group(1)), int(m.group(2)))
-            elif line.startswith("pool."):
-                name = line.split("=", 1)[0].strip().split(".", 1)[1]
-                m = PAIR_RE.search(line)
-                plan["pool"][name] = (int(m.group(1)), int(m.group(2)))
+        plan, platform = got
         # The key a `[tiers.<name>.<key>]` pin is written under. Usually the
         # board's own `platform`, but not always: both ThreadX boards are
         # `threadx-linux` / `threadx-riscv64` while bringups write


### PR DESCRIPTION
Closes the last of phase-375. **Zero open boxes.**

## `[board.priority_plan]` gets a platform home

`config/freertos/nros-platform.toml` carries the plan; both FreeRTOS QEMU boards drop their **byte-identical** copies and inherit, board override still available. `range = [1, 7]` is `configMAX_PRIORITIES` — an RTOS fact, not a board one.

The duplication was worse than untidy: `load_plans()` builds a `platform -> plan` map, so with two boards declaring for one platform the **later silently won**, and a divergence would have been invisible.

**Two defects in `priority_plan.py` found by doing it:**
- `load_plans()` carried its own inline copy of the parser — in the module whose docstring says its consumers "had a table each for about an hour, which is the second spelling this codebase keeps paying for".
- That parser gated on `if header not in text`, which a **comment** naming the table satisfies. The boards that moved kept a comment saying where the plan went, and the substring test produced an empty plan that "conflicted" with the platform's. Issue 0516's hazard, in this module.

## `cargo_config` — validated, not decomposed

The wave asked for four fields. Measured: the seven blobs also carry `[unstable]`, `[env]` compiler vars and `[patch.crates-io]`, so four fields cover part of every blob and all of none — leaving each board with **both** fields and a blob.

What the box got right is that the inner document had no schema check. `check-board-cargo-config-shape` supplies one. Its first draft matched prefixes and let `[targets.x]` through — the typo it exists to catch, passing its own check. The self-test caught that.

## The defect worth reading

**Adding `[priority_plan]` broke every embedded build, and `just check fast` was green on it.** `PlatformConfig` has `deny_unknown_fields`, so `zpico-sys`'s build script panicked with ``unknown field `priority_plan` ``. The fast lane doesn't compile — the exact tier-1 gap CLAUDE.md documents. Only `just ci gate` saw it.

Fixed by declaring the field opaquely, following the tree's own precedent: `BoardDescriptor` models `[board.priority_plan]` that way because *"declaring it says 'this key is real and someone else owns it'; omitting it would have said 'typo'"*. Omitting it here said typo.

## W4 / W5 boxes

Ticked, because a decision **is** their outcome — leaving them open said work remained. Each keeps its original wording struck through beneath the outcome. W5's acceptance ("a recorded decision, not a default") is met; it is **not executed**, because the move needs ASI to accept hosting the board, and doing half of it — deleting it here before it has a home there — is worse than either choice.

## Testing

`just check fast`: 252 ran, 0 failed. `just ci gate`: compile + unit pass; it stops at `check::api-parity`, which **fails identically on plain `origin/main`** (verified by checking out main and running it) and is not this branch's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfoaKBFdZc8W1gEHmmbxpj