### PR TITLE
fix(#1191): a verdict belongs to a CELL, and four binaries host several

### DIFF
--- a/docs/issues/archived/1191-verdict-ledger-cannot-attribute-cases-to-cells.md
+++ b/docs/issues/archived/1191-verdict-ledger-cannot-attribute-cases-to-cells.md
@@ -1,0 +1,105 @@
+---
+id: 1191
+title: "one failing case blocks recording verdicts for the four other cells sharing that binary — the ledger keys on the BINARY, not the cell"
+status: resolved
+type: bug
+area: testing
+severity: medium
+found: 2026-09-07
+related: [1127, 1190]
+resolved_in: "phase-433 — interop::CASE_CELLS, the case → cell map"
+---
+
+# Five cells, one binary, one veto
+
+`scripts/check-interop-verdicts.py --record <cell> --junit <f>` refuses a junit
+in which every case of that cell's binary skipped, and refuses a `fail` with no
+`--issue`. Both are right, and both are what make the ledger trustworthy.
+
+But it decided on the **binary**, not the cell. `interop_e2e` hosts FIVE
+`Tier::Runtime` cells:
+
+    native-pubsub-rust-zenoh-n2r    native-service-rust-zenoh-r2n
+    native-pubsub-c-cyclone-n2r     native-service-c-cyclone-r2n
+    native-lifecycle-rust-zenoh
+
+Measured 2026-09-07 in the box, that binary ran 10 cases: **9 passed, 1
+failed** (`case_2_zenoh_pubsub_ros2_to_nano`, issue 1190). Recording the four
+cells whose own cases had all passed was refused, five times, with the same
+message about `case_2`:
+
+```
+check-interop-verdicts: interop::case_2_zenoh_pubsub_ros2_to_nano FAILED —
+record it with --issue NNNN
+```
+
+So four cells that DID produce a live pass stayed `NEVER` in the report, and the
+count read 6 of 19 where it should have read 10 of 19. The ledger's whole
+purpose is to distinguish "never ran" from "ran and passed", and there it could
+not.
+
+## Why the conservative behaviour was nonetheless correct
+
+Without a case→cell mapping the tool could not know that `case_2` belongs to
+`native-pubsub-rust-zenoh-n2r` and not to `native-lifecycle-rust-zenoh`.
+Recording a pass for a cell whose case actually failed would be exactly the
+false claim the ledger exists to prevent — worse than an undercount. Refusing
+was the right default for a tool that cannot tell. **The fix was to supply the
+map, not to loosen the refusal.**
+
+## Resolution — `interop::CASE_CELLS`
+
+Four binaries host more than one Runtime cell: `interop_e2e` (5),
+`graph_interop` (2), `ros2_action_e2e` (2), `xrce_ros2_interop` (2). The other
+seven host one each, where binary-wide attribution IS cell-wide and nothing
+changes.
+
+`packages/testing/nros-tests/src/interop.rs` gained `CASE_CELLS`: one row per
+case of a shared binary, naming the cell that case is evidence for, plus
+`unowned(...)` rows for a case that is evidence for none. The case is spelled as
+the JUNIT spells it (`interop::case_2_zenoh_pubsub_ros2_to_nano`).
+
+The map is **authored**, because nothing in the tree derives it and for
+`ros2_action_e2e` nothing could: its two cells are ONE
+`(Linux, Rust, Cyclonedds, Action)` coordinate and differ only by direction,
+which `coords_for` collapses on purpose. What makes an authored map trustworthy
+is that it is checked, statically, against the cases each binary really runs:
+
+* `check-interop-verdicts.py::source_cases` DERIVES a binary's junit case names
+  from its source — `#[test]` / `#[rstest]` plus rstest 0.24's own
+  `case_<n>_<description>` naming, zero-padding included. A shape it cannot
+  name (`#[values(...)]`) raises rather than guessing.
+* `map_problems` requires the map to be exhaustive and disjoint over those
+  names, in both directions: a renamed, added or deleted case turns the gate
+  red instead of moving evidence quietly. A shared binary with no map is an
+  error, and so is a cell of a shared binary that owns no case.
+* `--record` refuses a junit carrying a case of a mapped binary that the map
+  does not name: the binary that RAN and the map disagree, so attribution is
+  unknown.
+* The ledger check now rejects an entry citing a SIBLING cell's case — the same
+  false claim the binary-wide attribution used to make, written into the file.
+* Rust-side unit tests in `interop.rs` bind the map to `CELLS`: every row names
+  a Runtime cell OF THAT BINARY, no case is claimed twice, every cell of a
+  shared binary owns a case.
+
+Attribution by SUBSTRING (matching a cell id against a case name) was
+considered and rejected in the issue text, and is still not done: they are
+different vocabularies, and it reads as working until a rename.
+
+Verified on the measured run: with the phase-433 W2 ledger and a junit carrying
+the nine `interop_e2e` results as recorded (case_2 failed, the rest passed), the
+four cells record cleanly and `--report` moves from **6 of 19** to **10 of 19**,
+while `native-pubsub-rust-zenoh-n2r` — the cell whose own case failed — is still
+refused without `--issue`.
+
+## Fallout to expect
+
+Ledger entries written by the binary-wide recorder cite cases belonging to other
+cells (phase-433 W2 gave both `graph_interop` cells both cases, and
+`native-pubsub-rust-zenoh-n2r` all nine `interop_e2e` cases). Those entries are
+now gate failures and must be re-recorded from the same junit.
+
+`xrce_ros2_interop` runs three ACTION cases and `interop::CELLS` declares no
+Xrce/Action cell, so they are `unowned(...)` with that reason: they counted as
+the pubsub and service cells' evidence until this map said otherwise. The gap is
+a missing CELL, not a missing case.

--- a/just/check/fixtures.just
+++ b/just/check/fixtures.just
@@ -233,7 +233,11 @@ interop-cell-runners:
 # why it is green on a host with no ROS: real cell, required fields, cases that
 # still exist, an OPEN issue behind every `fail`, and no BINDING test cited as
 # evidence (`cases_bound_to_interop_cells` passes with no peer, forever — citing
-# one would put the defect inside the fix). Report: `just interop-verdicts`.
+# one would put the defect inside the fix). Issue 1191 added the half that says
+# WHICH cell a case belongs to: four binaries host more than one Runtime cell
+# (interop_e2e hosts five), so `interop::CASE_CELLS` maps case → cell and this
+# gate checks that map against the cases each binary actually runs, both ways.
+# Report: `just interop-verdicts`.
 [private]
 interop-verdict-ledger:
     @python3 scripts/check-interop-verdicts.py

--- a/packages/testing/nros-tests/src/interop.rs
+++ b/packages/testing/nros-tests/src/interop.rs
@@ -366,6 +366,158 @@ pub const CELLS: &[InteropCell] = &[
        NativeFixtures, RosEdition(Zenoh), NanoToRos, "cpp_multi_node_entry"),
 ];
 
+/// `cell` sentinel for a case that is evidence for NO interop cell.
+pub const NO_CELL: &str = "(no cell — evidence for none)";
+
+/// One CASE of a shared interop binary and the cell it is evidence FOR —
+/// issue 1191.
+///
+/// Eleven binaries host the nineteen Runtime cells, and four of them host more
+/// than one: `interop_e2e` (5), `graph_interop` (2), `ros2_action_e2e` (2),
+/// `xrce_ros2_interop` (2). Until this table existed, the verdict ledger
+/// (`scripts/check-interop-verdicts.py`) attributed a junit case to the BINARY,
+/// so every case of `interop_e2e` was evidence — and counter-evidence — for all
+/// five of its cells at once: one failing case (issue 1190's
+/// `case_2_zenoh_pubsub_ros2_to_nano`) refused a recording for the four cells
+/// whose own cases had all passed.
+///
+/// A coordinate cannot do this job. `native-action-rust-cyclone-{r2n,n2r}` are
+/// ONE `(Linux, Rust, Cyclonedds, Action)` coordinate in ONE binary and differ
+/// only by direction, which [`coords_for`] collapses on purpose. Nor may a case
+/// be matched to a cell by NAME: a cell id and a case name are different
+/// vocabularies, and a substring rule reads as working until a rename.
+///
+/// So the assignment is WRITTEN DOWN here, and gated from both ends:
+///
+/// * Rust (below): every `cell` is a real `Tier::Runtime` cell of that same
+///   binary, no `(test, case)` pair is claimed twice, and every cell of a
+///   shared binary owns at least one case — a cell owning none could never be
+///   recorded again.
+/// * Python (`check-interop-verdicts.py`): the case names here are exactly the
+///   cases the binary's source actually runs — derived from `#[test]` /
+///   `#[rstest]` and rstest's own `case_<n>_<description>` naming — so a
+///   renamed, added or deleted case turns the gate RED instead of silently
+///   dropping or inventing evidence. A junit that carries a case this table
+///   does not name is REFUSED at `--record` time for the same reason.
+///
+/// `case` is spelled AS THE JUNIT SPELLS IT: `<fn>` for a plain `#[test]`, and
+/// `<fn>::case_<n>_<description>` for an rstest `#[case::<description>(…)]`
+/// (`n` left-zero-padded to the width of the case count, which is rstest's
+/// rule, not ours).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CaseOwner {
+    /// The test binary — an `ic(...)` row's `test`.
+    pub test: &'static str,
+    /// The case, as the junit spells it.
+    pub case: &'static str,
+    /// The [`CELLS`] id this case is evidence for, or [`NO_CELL`].
+    pub cell: &'static str,
+    /// Why no cell owns it. Non-empty exactly when `cell` is [`NO_CELL`] — an
+    /// unowned case is a DECISION (a lane that does not exist), not an
+    /// omission, and it stops being evidence for anybody.
+    pub reason: &'static str,
+}
+
+const fn co(test: &'static str, case: &'static str, cell: &'static str) -> CaseOwner {
+    CaseOwner {
+        test,
+        case,
+        cell,
+        reason: "",
+    }
+}
+
+const fn unowned(test: &'static str, case: &'static str, reason: &'static str) -> CaseOwner {
+    CaseOwner {
+        test,
+        case,
+        cell: NO_CELL,
+        reason,
+    }
+}
+
+/// The case → cell map for every binary that hosts more than one Runtime cell.
+///
+/// A binary listed here is mapped EXHAUSTIVELY: the Python gate requires its
+/// rows to cover exactly the cases the source runs (binding tests excluded —
+/// they are evidence of nothing). A binary with a single Runtime cell needs no
+/// rows: its every case is that cell's, which is what the ledger already
+/// assumed. Such a binary gaining a second cell turns the gate red, which is
+/// the moment the map becomes necessary.
+#[rustfmt::skip]
+pub const CASE_CELLS: &[CaseOwner] = &[
+    // ── interop_e2e — five cells, nine cases ────────────────────────────
+    // Each row is `scenario_coord()`'s answer for that case's `Scenario`
+    // (tests/interop_e2e.rs), and those five coordinates are distinct, so the
+    // assignment is the one the per-case tripwire already asserts — written
+    // where a tool without a compiler can read it. Direction does NOT split a
+    // cell: `case_2`/`case_3` run ROS-2-to-nano against the cell whose id ends
+    // `-n2r`, exactly as `coords_for` collapses the two.
+    co("interop_e2e", "interop::case_1_zenoh_pubsub_nano_to_ros2",      "native-pubsub-rust-zenoh-n2r"),
+    co("interop_e2e", "interop::case_2_zenoh_pubsub_ros2_to_nano",      "native-pubsub-rust-zenoh-n2r"),
+    co("interop_e2e", "interop::case_3_zenoh_pubsub_stock_demo_nodes_cpp", "native-pubsub-rust-zenoh-n2r"),
+    co("interop_e2e", "interop::case_4_zenoh_service_nano_server",      "native-service-rust-zenoh-r2n"),
+    co("interop_e2e", "interop::case_5_zenoh_service_ros2_server",      "native-service-rust-zenoh-r2n"),
+    co("interop_e2e", "interop::case_6_cyclone_pubsub_nano_to_ros2",    "native-pubsub-c-cyclone-n2r"),
+    co("interop_e2e", "interop::case_7_cyclone_pubsub_ros2_to_nano",    "native-pubsub-c-cyclone-n2r"),
+    co("interop_e2e", "interop::case_8_cyclone_service_nano_server",    "native-service-c-cyclone-r2n"),
+    co("interop_e2e", "interop::case_9_zenoh_lifecycle_full_cycle",     "native-lifecycle-rust-zenoh"),
+
+    // ── graph_interop — one case per RMW, and the RMW is in the body ────
+    // (`require_ros2()` vs `require_ros2_cyclonedds()`), not only in the name.
+    co("graph_interop", "nano_ros_enumerates_a_stock_ros2_node", "native-graph-rust-zenoh-r2n"),
+    co("graph_interop", "cyclone_enumerates_a_stock_ros2_node",  "native-graph-rust-cyclone-r2n"),
+
+    // ── ros2_action_e2e — ONE coordinate, two directions ────────────────
+    // The pair no coordinate can separate: which side drives is the whole
+    // difference between the two cells, and it is what each case does.
+    co("ros2_action_e2e", "a_stock_ros2_client_drives_the_nano_ros_action_server",
+       "native-action-rust-cyclone-r2n"),
+    co("ros2_action_e2e", "the_nano_ros_action_client_drives_a_stock_ros2_server",
+       "native-action-rust-cyclone-n2r"),
+
+    // ── xrce_ros2_interop — pubsub, service, and three cases with no cell ─
+    co("xrce_ros2_interop", "test_xrce_to_ros2_pubsub",      "native-pubsub-rust-xrce-n2r"),
+    co("xrce_ros2_interop", "test_ros2_to_xrce_pubsub",      "native-pubsub-rust-xrce-n2r"),
+    co("xrce_ros2_interop", "test_xrce_service_ros2_client", "native-service-rust-xrce-r2n"),
+    co("xrce_ros2_interop", "test_ros2_service_xrce_client", "native-service-rust-xrce-r2n"),
+    // The file runs three ACTION cases and `interop::CELLS` declares no
+    // Xrce/Action cell — `cases_bound_to_interop_cells` names Pubsub and
+    // Service only, and a coordinate set cannot show what has no row. They ran
+    // as the pubsub and service cells' evidence until this table said
+    // otherwise. Recorded rather than assigned: the gap is a missing CELL, not
+    // a missing case.
+    unowned("xrce_ros2_interop", "test_xrce_action_ros2_client",
+            "no Xrce/Action interop cell exists; the case runs, and nothing in \
+             interop::CELLS claims its coordinate"),
+    unowned("xrce_ros2_interop", "test_xrce_action_ros2_concurrent",
+            "no Xrce/Action interop cell exists (the concurrent-goal variant of \
+             the case above)"),
+    unowned("xrce_ros2_interop", "test_ros2_action_xrce_client",
+            "no Xrce/Action interop cell exists (the ROS-2-drives-nano direction \
+             of the two above)"),
+];
+
+/// Which cell, if any, a case of `test` is evidence for. `None` when the binary
+/// carries no map (it has one cell, so every case is that cell's) — callers
+/// that need the difference ask [`is_mapped`] first.
+pub fn owner_of_case(test: &str, case: &str) -> Option<&'static CaseOwner> {
+    CASE_CELLS.iter().find(|o| o.test == test && o.case == case)
+}
+
+/// Does this binary carry a case → cell map?
+pub fn is_mapped(test: &str) -> bool {
+    CASE_CELLS.iter().any(|o| o.test == test)
+}
+
+/// The cases declared as evidence for one cell id.
+pub fn cases_of(cell_id: &str) -> impl Iterator<Item = &'static str> {
+    CASE_CELLS
+        .iter()
+        .filter(move |o| o.cell == cell_id)
+        .map(|o| o.case)
+}
+
 /// Runtime interop/bridge cells only.
 pub fn runtime_cells() -> impl Iterator<Item = &'static InteropCell> {
     CELLS
@@ -467,6 +619,94 @@ mod tests {
         let mut seen = std::collections::HashSet::new();
         for c in CELLS {
             assert!(seen.insert(c.id), "duplicate interop cell id: {}", c.id);
+        }
+    }
+
+    /// Issue 1191 — every mapped case names a real Runtime cell OF THAT
+    /// BINARY. A row pointing at another binary's cell, or at a cell that no
+    /// longer exists, would attribute a live result to the wrong place, which
+    /// is worse than the undercount the map replaces.
+    #[test]
+    fn case_owners_name_a_runtime_cell_of_their_own_binary() {
+        for o in CASE_CELLS {
+            if o.cell == NO_CELL {
+                assert!(
+                    !o.reason.is_empty(),
+                    "`{}` of `{}` owns no cell and says no why — an unowned case \
+                     is a decision, not an omission",
+                    o.case,
+                    o.test
+                );
+                continue;
+            }
+            assert!(
+                o.reason.is_empty(),
+                "`{}` of `{}` names cell `{}` AND a reason; the reason field is \
+                 for NO_CELL rows only",
+                o.case,
+                o.test,
+                o.cell
+            );
+            let cell = by_id(o.cell)
+                .unwrap_or_else(|| panic!("no interop cell `{}` (case `{}`)", o.cell, o.case));
+            assert!(
+                matches!(cell.cell.tier, Tier::Runtime),
+                "case `{}` names `{}`, which is not Tier::Runtime",
+                o.case,
+                o.cell
+            );
+            assert_eq!(
+                cell.test, o.test,
+                "case `{}` of `{}` names cell `{}`, whose test binary is `{}`",
+                o.case, o.test, o.cell, cell.test
+            );
+        }
+    }
+
+    /// One case, one owner. Two rows for the same case would make a result
+    /// count twice — and, with different cells, count for a cell that did not
+    /// produce it.
+    #[test]
+    fn case_owners_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for o in CASE_CELLS {
+            assert!(
+                seen.insert((o.test, o.case)),
+                "case `{}` of `{}` is claimed twice",
+                o.case,
+                o.test
+            );
+        }
+    }
+
+    /// Every binary hosting more than one Runtime cell is mapped, and every one
+    /// of its cells owns at least one case. A cell owning none could never be
+    /// recorded from a run again — the undercount of issue 1191, made
+    /// permanent.
+    #[test]
+    fn every_shared_binary_maps_all_of_its_cells() {
+        let mut per_test: std::collections::BTreeMap<&str, Vec<&str>> = Default::default();
+        for c in runtime_cells() {
+            per_test.entry(c.test).or_default().push(c.id);
+        }
+        for (test, ids) in per_test {
+            if ids.len() < 2 {
+                continue;
+            }
+            assert!(
+                is_mapped(test),
+                "`{test}` hosts {} Runtime cells ({ids:?}) and no CASE_CELLS row \
+                 says which case is whose — every case would be evidence for \
+                 every one of them (issue 1191)",
+                ids.len()
+            );
+            for id in ids {
+                assert!(
+                    cases_of(id).next().is_some(),
+                    "cell `{id}` shares binary `{test}` with others and owns no \
+                     case — nothing could ever record it"
+                );
+            }
         }
     }
 

--- a/scripts/check-interop-cell-runners.py
+++ b/scripts/check-interop-cell-runners.py
@@ -104,6 +104,8 @@ LEDGER = ROOT / ".config" / "interop-cells-without-runner.txt"
 RUNNER_PATHSPECS = ("justfile", "just", ".github/workflows")
 
 CELLS_HEADER = "pub const CELLS: &[InteropCell] = &["
+# The case -> cell map for shared test binaries (issue 1191).
+CASE_CELLS_HEADER = "pub const CASE_CELLS: &[CaseOwner] = &["
 
 # `Tier`'s three variants, as `matrix.rs` spells them. Listed so an unknown
 # token is an ERROR rather than a silent "not Runtime" -- a tier added later
@@ -290,6 +292,62 @@ def _parse_test(arg: str, line: int) -> dict:
             f"string test name nor `NO_TEST`: {arg[:40]!r}"
         )
     return {"test": test}
+
+
+# --- which CASE is which cell's (issue 1191) -----------------------------
+
+
+def parse_case_owners(src: str) -> list[dict]:
+    """[{test, case, cell, reason, line}] for every `CASE_CELLS` row.
+
+    The case -> cell map for the binaries that host more than one Runtime cell
+    (issue 1191). Parsed HERE, beside `parse_cells`, because the repo rule is
+    one parser per table: `check-interop-verdicts.py` imports this module rather
+    than growing a second reader that would drift row by row.
+
+    An EMPTY table is legitimate (nothing is mapped yet); a malformed row is
+    not, and neither is a missing `CASE_CELLS` -- both raise, so a shape change
+    fails loudly instead of quietly reading fewer rows.
+    """
+    cat = categorize(src)
+    head = src.find(CASE_CELLS_HEADER)
+    if head < 0:
+        raise ParseError(f"no `{CASE_CELLS_HEADER}` in {INTEROP_RS.name}")
+    open_at = head + len(CASE_CELLS_HEADER) - 1
+    end = _match(src, cat, open_at, "]")
+
+    rows = []
+    for m in re.finditer(r"\b(co|unowned)\s*\(", src):
+        if m.start() < open_at or m.end() > end or cat[m.start()] != CODE:
+            continue
+        kind = m.group(1)
+        paren = m.end() - 1
+        close = _match(src, cat, paren, ")")
+        line = src.count("\n", 0, m.start()) + 1
+        args = _split_args(src, cat, paren + 1, close)
+        if len(args) != 3:
+            raise ParseError(
+                f"{INTEROP_RS.name}:{line}: `{kind}(...)` has {len(args)} "
+                f"argument(s), expected 3 "
+                f"({'test, case, cell' if kind == 'co' else 'test, case, reason'})"
+            )
+        vals = [_string_of(a) for a in args]
+        if any(v is None for v in vals):
+            raise ParseError(
+                f"{INTEROP_RS.name}:{line}: `{kind}(...)` takes three string "
+                f"literals; got {args!r}"
+            )
+        test, case, third = vals
+        rows.append(
+            {
+                "test": test,
+                "case": case,
+                "cell": None if kind == "unowned" else third,
+                "reason": third if kind == "unowned" else "",
+                "line": line,
+            }
+        )
+    return rows
 
 
 # --- who invokes a test binary ------------------------------------------
@@ -510,6 +568,14 @@ pub const CELLS: &[InteropCell] = &[
          CarveOut("no lane; the string mentions ic( and Runtime on purpose")),
        ZephyrWestLeaves, RosEdition(Cyclonedds), BiDir, NO_TEST),
 ];
+
+/// A doc comment naming co( and unowned(, which are not rows.
+#[rustfmt::skip]
+pub const CASE_CELLS: &[CaseOwner] = &[
+    co("alpha_e2e", "meets_a_peer", "cell-alpha"),
+    unowned("alpha_e2e", "meets_nobody",
+            "no cell for this shape; the string mentions co( on purpose"),
+];
 '''
 
 
@@ -545,6 +611,30 @@ def self_test(verbose: bool = False) -> None:
             assert want in str(e), f"selftest: wrong error for {want!r}: {e}"
         else:
             raise AssertionError(f"selftest: accepted malformed source ({want})")
+
+    # --- the case -> cell map (issue 1191) --------------------------------
+    owners = parse_case_owners(_MINI_RS)
+    assert [o["case"] for o in owners] == ["meets_a_peer", "meets_nobody"], owners
+    assert owners[0]["cell"] == "cell-alpha" and owners[0]["reason"] == "", owners[0]
+    assert owners[1]["cell"] is None and owners[1]["reason"], (
+        "selftest: `unowned(...)` did not read as an unowned case"
+    )
+    for bad, want in (
+        ('pub const CASE_CELLS: &[CaseOwner] = &[\n    co("t", "c"),\n];',
+         "expected 3"),
+        ('pub const CASE_CELLS: &[CaseOwner] = &[\n    co("t", "c", CELL),\n];',
+         "three string literals"),
+        ("nothing here", "no `pub const CASE_CELLS"),
+    ):
+        try:
+            parse_case_owners(bad)
+        except ParseError as e:
+            assert want in str(e), f"selftest: wrong error for {want!r}: {e}"
+        else:
+            raise AssertionError(f"selftest: accepted a malformed map ({want})")
+    assert parse_case_owners("pub const CASE_CELLS: &[CaseOwner] = &[\n];") == [], (
+        "selftest: an empty map was not read as empty"
+    )
 
     # --- the runner scan -------------------------------------------------
     just = "\n".join([

--- a/scripts/check-interop-verdicts.py
+++ b/scripts/check-interop-verdicts.py
@@ -354,6 +354,9 @@ def map_problems(
     the binary REALLY runs, in both directions, so a rename, an addition or a
     deletion turns this red rather than moving evidence quietly.
     """
+    # Every message names its test binary: `record()` selects the ones about
+    # the cell it is recording, and a message that named only a case would let
+    # a broken map through for exactly the binary being attributed.
     problems: list[str] = []
     by_test: dict[str, list[dict]] = {}
     for c in cells:
@@ -373,15 +376,16 @@ def map_problems(
         if o["cell"] is None:
             if not o["reason"].strip():
                 problems.append(
-                    f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` owns no "
-                    f"cell and says no why."
+                    f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` of "
+                    f"`{o['test']}` owns no cell and says no why."
                 )
             continue
         owner = next((c for c in cells if c["id"] == o["cell"]), None)
         if owner is None:
             problems.append(
-                f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` names "
-                f"`{o['cell']}`, which is not a `Tier::Runtime` interop cell."
+                f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` of "
+                f"`{o['test']}` names `{o['cell']}`, which is not a "
+                f"`Tier::Runtime` interop cell."
             )
         elif owner["test"] != o["test"]:
             problems.append(
@@ -1194,10 +1198,23 @@ def _self_test_case_map(
     ghost = [dict(o) for o in owners]
     ghost[0] = dict(ghost[0], cell="cell-nowhere")
     bad_map(ghost, "not a `Tier::Runtime` interop cell", "a case naming no cell")
+    reasonless = [dict(o, reason="") if o["cell"] is None else o for o in owners]
+    bad_map(reasonless, "owns no cell and says no why", "an unexplained unowned case")
     binding_cited = owners + [
         dict(owners[0], case="cases_bound_to_interop_cells", cell="cell-gamma-pubsub")
     ]
     bad_map(binding_cited, "BINDING test", "a binding test named as a cell's case")
+    # `record()` filters these by the binary they name, so every message must
+    # name one — a map problem invisible to that filter is a broken map used.
+    for rows in (
+        [], renamed, twice, elsewhere, ghost, reasonless, binding_cited,
+        [o for o in owners if o["case"] != "host_only_probe"],
+    ):
+        for p in map_problems(cells, src, rows):
+            assert "gamma_e2e" in p, (
+                f"selftest: a map problem names no test binary, so `--record` "
+                f"would not see it: {p!r}"
+            )
 
 
 def _self_test_junit(

--- a/scripts/check-interop-verdicts.py
+++ b/scripts/check-interop-verdicts.py
@@ -40,11 +40,32 @@ ROS at all — which is why a junit-derived skip streak cannot work, and why an
 entry citing only such a case is REFUSED here. Letting one count as evidence
 would re-create, inside the mechanism, the exact defect it exists to catch.
 
+A VERDICT BELONGS TO A CELL, NOT TO A BINARY (issue 1191)
+
+Eleven binaries host nineteen cells, and four host more than one: `interop_e2e`
+alone hosts five. This tool used to key everything on the BINARY, so every case
+of `interop_e2e` was evidence — and counter-evidence — for all five of its
+cells at once. Measured 2026-09-07: nine cases ran, eight passed and one failed
+(issue 1190), and the four cells whose own cases had all passed were refused a
+recording five times over, with the same message about someone else's case.
+
+The map that fixes it is `interop::CASE_CELLS` — one row per case of a shared
+binary, naming the cell it is evidence for (or `unowned(...)`, evidence for
+none). It is AUTHORED, because nothing derives it: `ros2_action_e2e`'s two cells
+are ONE coordinate and differ only by direction. What makes it trustworthy is
+that `map_problems` checks it against the cases the binary really runs —
+derived from `#[test]` / `#[rstest]` and rstest's own case naming — in both
+directions, and `--record` refuses a junit carrying a case the map does not
+name. Attribution by SUBSTRING (a cell id inside a case name) is deliberately
+not done: they are different vocabularies, and it reads as working until a
+rename.
+
 WHAT THIS CANNOT DO
 
 It cannot know that a hand-written entry is TRUE — only that it is well-formed,
 names a real Runtime cell, and cites cases that exist in that cell's declared
-test binary and are not binding-only. `--record` is the honest path: it writes
+test binary, are not binding-only, and belong to that cell rather than to a
+sibling sharing its binary. `--record` is the honest path: it writes
 an entry from a junit and refuses one in which the cell's binary only skipped.
 Nor does it know when a verdict goes stale; a cell verified today can break
 tomorrow, and only phase-433 W5's scheduled lane will say so. The age is
@@ -64,8 +85,10 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime
 import importlib.util
+import io
 import re
 import sys
 import tempfile
@@ -215,6 +238,218 @@ def base_case(name: str) -> str:
     return name.split("::", 1)[0].strip()
 
 
+# --- which cases a binary actually RUNS (issue 1191) ---------------------
+
+ATTR_OPEN = re.compile(r"#!?\[")
+FN_DECL = re.compile(r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*[(<]")
+# `#[case::zenoh_pubsub_nano_to_ros2(...)]` and the undescribed `#[case(...)]`.
+CASE_ATTR = re.compile(r"^#\[case(?:::([A-Za-z_][A-Za-z0-9_]*))?\s*\(", re.S)
+TEST_ATTR = re.compile(r"^#\[(test|rstest)\b")
+# rstest's matrix axis. It names cases `f::case_1::axis_1_value`, which this
+# derivation does not model — raise rather than emit a name that is wrong.
+VALUES_ATTR = re.compile(r"^#\[values\s*\(")
+
+
+def _attributes(src: str, cat: list[int]) -> list[tuple[int, int, str]]:
+    """(start, end, text) for every attribute at CODE — nesting-aware."""
+    out = []
+    for m in ATTR_OPEN.finditer(src):
+        if cat[m.start()] != _sib.CODE:
+            continue
+        close = _sib._match(src, cat, m.end() - 1, "]")
+        out.append((m.start(), close + 1, src[m.start() : close + 1]))
+    return out
+
+
+def source_cases(src: str, test: str) -> list[str]:
+    """The junit case names `<test>.rs` runs, in source order.
+
+    A plain `#[test] fn f` is `f`; an `#[rstest]` with `#[case::<desc>(...)]`
+    attributes is `f::case_<n>_<desc>`, `n` left-zero-padded to the width of the
+    case count — that is rstest 0.24's own `format_case_name`, not a convention
+    of ours, and the recorded ledger entries (`interop::case_2_…`) are what it
+    produces. An `#[rstest]` with no cases is a plain `f`.
+
+    DERIVED, not authored: it is what makes `interop::CASE_CELLS` checkable — a
+    renamed or added case turns the gate red instead of silently dropping or
+    inventing evidence (issue 1191). A shape it cannot name raises.
+    """
+    cat = _sib.categorize(src)
+    attrs = _attributes(src, cat)
+    out: list[str] = []
+    for m in FN_DECL.finditer(src):
+        if cat[m.start()] != _sib.CODE:
+            continue
+        block: list[str] = []
+        cursor = m.start()
+        for start, end, text in reversed(attrs):
+            if end > cursor:
+                continue
+            # Only comments and whitespace may sit between an attribute and
+            # what it decorates; anything else ends the block.
+            gap = "".join(
+                " " if cat[k] != _sib.CODE else src[k] for k in range(end, cursor)
+            )
+            if gap.strip():
+                break
+            block.append(text)
+            cursor = start
+        block.reverse()
+        if not any(TEST_ATTR.match(b) for b in block):
+            continue
+        fn = m.group(1)
+        line = src.count("\n", 0, m.start()) + 1
+        if any(VALUES_ATTR.match(b) for b in block):
+            raise _sib.ParseError(
+                f"{test}.rs:{line}: `fn {fn}` carries `#[values(...)]`, whose "
+                f"generated case names this derivation does not model. Teach "
+                f"`source_cases` the shape — a guessed name would attribute a "
+                f"live result to the wrong cell (issue 1191)."
+            )
+        descs = [CASE_ATTR.match(b) for b in block]
+        descs = [d for d in descs if d]
+        if not descs:
+            out.append(fn)
+            continue
+        width = len(str(len(descs)))
+        for i, d in enumerate(descs, 1):
+            suffix = f"_{d.group(1)}" if d.group(1) else ""
+            out.append(f"{fn}::case_{i:0{width}d}{suffix}")
+    return out
+
+
+def runnable_cases(src: str, test: str) -> list[str]:
+    """`source_cases` minus the binding-only ones — what can be EVIDENCE."""
+    binding = evidence_cases(src)[1]
+    return [c for c in source_cases(src, test) if base_case(c) not in binding]
+
+
+# --- which cell a CASE is evidence for (issue 1191) ----------------------
+
+
+def case_map(owners: list[dict]) -> dict[str, dict[str, str | None]]:
+    """{test: {case: cell id or None}} — `interop::CASE_CELLS` as authored.
+
+    `None` is an `unowned(...)` row: a case that runs and is evidence for no
+    cell, written down so it cannot be silently dropped OR silently counted.
+    A binary absent from this map has ONE Runtime cell (gated below), so every
+    case of it is that cell's — which is what the ledger assumed for all of
+    them before issue 1191.
+    """
+    out: dict[str, dict[str, str | None]] = {}
+    for o in owners:
+        out.setdefault(o["test"], {})[o["case"]] = o["cell"]
+    return out
+
+
+def map_problems(
+    cells: list[dict], sources: dict[str, str | None], owners: list[dict]
+) -> list[str]:
+    """The case → cell map is EXHAUSTIVE, DISJOINT and current (issue 1191).
+
+    The map is authored — nothing in the tree derives which cell a case belongs
+    to, and for `ros2_action_e2e` nothing could: its two cells are one
+    coordinate and differ only by direction, which `coords_for` collapses. What
+    makes an authored map trustworthy is that it is checked against the cases
+    the binary REALLY runs, in both directions, so a rename, an addition or a
+    deletion turns this red rather than moving evidence quietly.
+    """
+    problems: list[str] = []
+    by_test: dict[str, list[dict]] = {}
+    for c in cells:
+        by_test.setdefault(c["test"], []).append(c)
+    declared = case_map(owners)
+
+    seen: set[tuple[str, str]] = set()
+    for o in owners:
+        key = (o["test"], o["case"])
+        if key in seen:
+            problems.append(
+                f"  interop::CASE_CELLS: `{o['case']}` of `{o['test']}` is "
+                f"claimed twice (line {o['line']}). One case, one owner — two "
+                f"rows make one result count for two cells."
+            )
+        seen.add(key)
+        if o["cell"] is None:
+            if not o["reason"].strip():
+                problems.append(
+                    f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` owns no "
+                    f"cell and says no why."
+                )
+            continue
+        owner = next((c for c in cells if c["id"] == o["cell"]), None)
+        if owner is None:
+            problems.append(
+                f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` names "
+                f"`{o['cell']}`, which is not a `Tier::Runtime` interop cell."
+            )
+        elif owner["test"] != o["test"]:
+            problems.append(
+                f"  interop::CASE_CELLS:{o['line']}: `{o['case']}` of "
+                f"`{o['test']}` names `{o['cell']}`, whose test binary is "
+                f"`{owner['test']}` — a case cannot be evidence for a cell "
+                f"another binary runs."
+            )
+
+    for test, rows in sorted(by_test.items()):
+        src = sources.get(test)
+        shared = len(rows) > 1
+        if test not in declared:
+            if shared:
+                problems.append(
+                    f"  `{test}` runs {len(rows)} Runtime cells "
+                    f"({', '.join(sorted(r['id'] for r in rows))}) and "
+                    f"interop::CASE_CELLS says which case is whose for NONE of\n"
+                    f"      them. Every case would be evidence — and "
+                    f"counter-evidence — for every one of them, which is issue\n"
+                    f"      1191: one failing case refused a recording for four "
+                    f"cells whose own cases had all passed."
+                )
+            continue
+        if src is None:
+            problems.append(
+                f"  interop::CASE_CELLS maps `{test}`, and "
+                f"packages/testing/nros-tests/tests/{test}.rs does not exist."
+            )
+            continue
+        try:
+            real = runnable_cases(src, test)
+        except _sib.ParseError as e:
+            problems.append(f"  {e}")
+            continue
+        binding = evidence_cases(src)[1]
+        mapped = declared[test]
+        for case in sorted(set(mapped) - set(real)):
+            why = (
+                "is a BINDING test — it passes on any host with no peer, so it "
+                "is evidence of nothing"
+                if base_case(case) in binding
+                else f"`{test}.rs` does not run any such case"
+            )
+            problems.append(
+                f"  interop::CASE_CELLS: `{case}` of `{test}`: {why}.\n"
+                f"      A stale row moves a live result to the wrong cell, or to "
+                f"no cell at all (issue 1191)."
+            )
+        for case in sorted(set(real) - set(mapped)):
+            problems.append(
+                f"  `{test}` runs `{case}` and interop::CASE_CELLS does not name "
+                f"it. Give it a cell,\n"
+                f"      or an `unowned(...)` row saying why it is evidence for "
+                f"none — a case in a mapped\n"
+                f"      binary that nobody claims would silently stop counting."
+            )
+        if shared:
+            for r in rows:
+                if not any(v == r["id"] for v in mapped.values()):
+                    problems.append(
+                        f"  `{r['id']}` shares `{test}` with "
+                        f"{len(rows) - 1} other cell(s) and owns no case — "
+                        f"nothing could ever record it."
+                    )
+    return problems
+
+
 # --- the ledger ----------------------------------------------------------
 
 
@@ -255,10 +490,13 @@ def evaluate(
     sources: dict[str, str | None],
     issue_lookup=issue_status,
     today: datetime.date | None = None,
+    owners: list[dict] | None = None,
 ) -> tuple[list[str], dict]:
     """(problems, stats). The whole rule, over data the caller supplied."""
     today = today or datetime.date.today()
-    problems: list[str] = []
+    owners = owners or []
+    problems: list[str] = list(map_problems(cells, sources, owners))
+    declared = case_map(owners)
     if not cells:
         problems.append(
             "  no Runtime cells in interop::CELLS — refusing to report OK over an "
@@ -366,6 +604,27 @@ def evaluate(
                     f"      host, with no peer, forever, so it is evidence of nothing.\n"
                     f"      Cite the case that met the peer."
                 )
+            elif cell["test"] in declared and declared[cell["test"]].get(t) != cid:
+                # Issue 1191 — a case of a shared binary is evidence for ONE
+                # cell. Citing a sibling's case is the same false claim the
+                # binary-wide attribution used to make, written down.
+                whose = declared[cell["test"]].get(t)
+                blame = (
+                    f"it belongs to `{whose}`"
+                    if whose
+                    else (
+                        "interop::CASE_CELLS declares it evidence for NO cell"
+                        if t in declared[cell["test"]]
+                        else "interop::CASE_CELLS does not name it at all"
+                    )
+                )
+                problems.append(
+                    f"  {who}: cites `{t}`, and {blame}.\n"
+                    f"      `{cell['test']}` runs "
+                    f"{len([c for c in cells if c['test'] == cell['test']])} cells; a "
+                    f"case is evidence for the ONE\n"
+                    f"      whose coordinate it exercises (issue 1191)."
+                )
             else:
                 real += 1
         if real == 0:
@@ -428,53 +687,98 @@ def report_lines(
 # --- what a RUN saw ------------------------------------------------------
 
 
-def observed(junit: Path, cells: list[dict], sources: dict[str, str | None]) -> dict:
-    """{test binary: {"verdict": [...], "skipped": [...]}} for interop binaries.
-
-    A case that is binding-only is in NEITHER list: it passes with no peer on
-    every host, so counting it as a verdict is the defect this file exists to
-    catch, and counting it as a skip would be a lie in the other direction.
-    """
-    wanted = {c["test"] for c in cells}
-    out: dict[str, dict[str, list[str]]] = {}
+def junit_cases(junit: Path, wanted: set[str]) -> list[tuple[str, str, str]]:
+    """(binary, case, "pass" | "fail" | "skip") for every case of a wanted
+    binary. An unreadable or absent junit is an empty run, not an error."""
+    out: list[tuple[str, str, str]] = []
     try:
         root = ET.parse(junit).getroot()
     except (OSError, ET.ParseError):
         return out
-    binding: dict[str, set[str]] = {}
-    for test, src in sources.items():
-        binding[test] = evidence_cases(src)[1] if src else set()
     for case in root.iter("testcase"):
         cls = (case.get("classname") or "").split("::")[-1]
         if cls not in wanted:
             continue
-        name = case.get("name") or "?"
-        if base_case(name) in binding.get(cls, set()):
-            continue
-        row = out.setdefault(cls, {"verdict": [], "skipped": []})
-        skipped = case.find("skipped") is not None
-        row["skipped" if skipped else "verdict"].append(name)
+        if case.find("skipped") is not None:
+            outcome = "skip"
+        elif case.find("failure") is not None or case.find("error") is not None:
+            outcome = "fail"
+        else:
+            outcome = "pass"
+        out.append((cls, case.get("name") or "?", outcome))
     return out
 
 
-def after_run(junit: Path, cells: list[dict], sources, entries) -> list[str]:
-    """The one line a sweep's tail prints. Silent when no interop binary ran."""
-    seen = observed(junit, cells, sources)
-    if not seen:
+def observed(
+    junit: Path,
+    cells: list[dict],
+    sources: dict[str, str | None],
+    owners: list[dict],
+) -> tuple[dict, dict]:
+    """({cell id: {"verdict", "skipped", "failed"}}, {test: unattributed cases}).
+
+    Keyed by CELL, not by binary — issue 1191. `interop_e2e` hosts five cells
+    and one run of it produced nine results; attributing all nine to all five
+    made one failure (issue 1190's `case_2`) refuse a recording for the four
+    cells whose own cases had passed.
+
+    A case that is binding-only appears nowhere: it passes with no peer on
+    every host, so counting it as a verdict is the defect this file exists to
+    catch, and counting it as a skip would be a lie in the other direction. A
+    case an `unowned(...)` row declares is likewise evidence for nobody. A case
+    of a MAPPED binary that the map does not name is neither dropped nor
+    spread: it is returned separately, and `--record` refuses on it.
+    """
+    wanted = {c["test"] for c in cells}
+    by_test: dict[str, list[str]] = {}
+    for c in cells:
+        by_test.setdefault(c["test"], []).append(c["id"])
+    binding = {
+        t: (evidence_cases(s)[1] if s else set()) for t, s in sources.items()
+    }
+    declared = case_map(owners)
+    out: dict[str, dict[str, list[str]]] = {}
+    orphan: dict[str, list[str]] = {}
+    for binary, name, outcome in junit_cases(junit, wanted):
+        if base_case(name) in binding.get(binary, set()):
+            continue
+        if binary in declared:
+            if name not in declared[binary]:
+                orphan.setdefault(binary, []).append(name)
+                continue
+            owner = declared[binary][name]
+            if owner is None:  # written down as evidence for no cell
+                continue
+            targets = [owner]
+        else:
+            targets = by_test.get(binary, [])
+        for cid in targets:
+            row = out.setdefault(
+                cid, {"verdict": [], "skipped": [], "failed": []}
+            )
+            if outcome == "skip":
+                row["skipped"].append(name)
+            else:
+                row["verdict"].append(name)
+                if outcome == "fail":
+                    row["failed"].append(name)
+    return out, orphan
+
+
+def after_run(junit: Path, cells: list[dict], sources, owners, entries) -> list[str]:
+    """The one line a sweep's tail prints. Silent when no interop cell ran."""
+    seen, orphan = observed(junit, cells, sources, owners)
+    if not seen and not orphan:
         return []
     recorded = {str(e.get("cell", "")) for e in entries}
-    ran = [t for t, r in seen.items() if r["verdict"]]
-    dumb = [t for t, r in seen.items() if not r["verdict"]]
+    ran = [cid for cid, r in seen.items() if r["verdict"]]
+    dumb = [cid for cid, r in seen.items() if not r["verdict"]]
     out = [
         f"Live-peer interop: {len(recorded)}/{len(cells)} cells have ever produced a "
-        f"verdict. This run reached {len(seen)} of their binaries — {len(ran)} "
+        f"verdict. This run reached {len(seen)} of them — {len(ran)} "
         f"produced a result, {len(dumb)} skipped wholesale (`just interop-verdicts`)."
     ]
-    fresh = sorted(
-        c["id"]
-        for c in cells
-        if c["id"] not in recorded and c["test"] in ran
-    )
+    fresh = sorted(c["id"] for c in cells if c["id"] not in recorded and c["id"] in ran)
     if fresh:
         out.append(
             "  This run produced a result for cells with no recorded verdict: "
@@ -483,6 +787,12 @@ def after_run(junit: Path, cells: list[dict], sources, entries) -> list[str]:
         out.append(
             "  Record it: python3 scripts/check-interop-verdicts.py --record "
             f"{fresh[0]} --junit {junit} --where '<host>'"
+        )
+    for binary, names in sorted(orphan.items()):
+        out.append(
+            f"  `{binary}` ran {len(names)} case(s) interop::CASE_CELLS does not "
+            f"name ({', '.join(sorted(names)[:3])}…) — no cell can be recorded "
+            f"from this run until the map covers them (issue 1191)."
         )
     return out
 
@@ -515,7 +825,7 @@ def header_of(text: str) -> str:
     return text if at < 0 else text[:at]
 
 
-def record(args, cells, sources) -> int:
+def record(args, cells, sources, owners) -> int:
     cell = next((c for c in cells if c["id"] == args.record), None)
     if cell is None:
         print(
@@ -524,25 +834,55 @@ def record(args, cells, sources) -> int:
             file=sys.stderr,
         )
         return 1
-    junit = Path(args.junit) if args.junit else DEFAULT_JUNIT
-    seen = observed(junit, [cell], sources).get(cell["test"])
-    if not seen:
+    # The map has to hold before a single case is attributed through it: a
+    # stale map is how a result reaches the wrong cell, which is worse than the
+    # undercount it replaces (issue 1191).
+    broken = [p for p in map_problems(cells, sources, owners) if cell["test"] in p]
+    if broken:
         print(
-            f"check-interop-verdicts: {junit} contains no case of `{cell['test']}` "
-            f"(binding tests excluded — they are evidence of nothing).",
+            "check-interop-verdicts: the case → cell map for "
+            f"`{cell['test']}` is wrong, so nothing can be attributed from this "
+            "run:\n\n" + "\n\n".join(broken),
+            file=sys.stderr,
+        )
+        return 1
+    junit = Path(args.junit) if args.junit else DEFAULT_JUNIT
+    all_seen, orphan = observed(junit, cells, sources, owners)
+    if orphan.get(cell["test"]):
+        print(
+            f"check-interop-verdicts: {junit} carries case(s) of "
+            f"`{cell['test']}` that interop::CASE_CELLS does not name — "
+            f"{', '.join(sorted(orphan[cell['test']]))}. The binary that RAN "
+            f"and the map disagree, so which cell produced what is unknown "
+            f"(issue 1191). Update the map, then re-record.",
+            file=sys.stderr,
+        )
+        return 1
+    seen = all_seen.get(cell["id"])
+    if not seen:
+        mapped = sorted(
+            c for c, o in case_map(owners).get(cell["test"], {}).items()
+            if o == cell["id"]
+        )
+        print(
+            f"check-interop-verdicts: {junit} contains no case attributed to "
+            f"`{cell['id']}`"
+            + (f" (its cases: {', '.join(mapped)})" if mapped else "")
+            + f". Cases of `{cell['test']}` belonging to another cell, and "
+            f"binding tests, are not this cell's evidence.",
             file=sys.stderr,
         )
         return 1
     if not seen["verdict"]:
         print(
-            f"check-interop-verdicts: every case of `{cell['test']}` in {junit} "
+            f"check-interop-verdicts: every case of `{cell['id']}` in {junit} "
             f"SKIPPED — that is no verdict, and it is exactly the absence this "
             f"ledger exists to make visible. Skipped: "
             f"{', '.join(seen['skipped'])}",
             file=sys.stderr,
         )
         return 1
-    failed = _failures(junit, cell["test"], seen["verdict"])
+    failed = set(seen["failed"])
     if failed and not args.issue:
         # Refuse HERE rather than let the gate reject the file afterwards: a
         # failing cell is a finding (issue 1127 Direction item 2), and the
@@ -578,22 +918,6 @@ def record(args, cells, sources) -> int:
     return 0
 
 
-def _failures(junit: Path, test: str, names: list[str]) -> set[str]:
-    out: set[str] = set()
-    try:
-        root = ET.parse(junit).getroot()
-    except (OSError, ET.ParseError):
-        return out
-    for case in root.iter("testcase"):
-        if (case.get("classname") or "").split("::")[-1] != test:
-            continue
-        if (case.get("name") or "") in names and (
-            case.find("failure") is not None or case.find("error") is not None
-        ):
-            out.add(case.get("name") or "?")
-    return out
-
-
 # --- negative controls ---------------------------------------------------
 
 _MINI_RS = '''
@@ -604,6 +928,19 @@ pub const CELLS: &[InteropCell] = &[
     ic("cell-beta",
        c(Linux, Rust, Zenoh, Service, Interop, Runtime),
        NativeFixtures, RosEdition(Zenoh), BiDir, "beta_e2e"),
+    // The shared binary — two cells, one file, which is issue 1191's shape.
+    ic("cell-gamma-pubsub",
+       c(Linux, Rust, Zenoh, Pubsub, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), NanoToRos, "gamma_e2e"),
+    ic("cell-gamma-service",
+       c(Linux, Rust, Zenoh, Service, Interop, Runtime),
+       NativeFixtures, RosEdition(Zenoh), BiDir, "gamma_e2e"),
+];
+
+pub const CASE_CELLS: &[CaseOwner] = &[
+    co("gamma_e2e", "pair::case_1_pubsub", "cell-gamma-pubsub"),
+    co("gamma_e2e", "pair::case_2_service", "cell-gamma-service"),
+    unowned("gamma_e2e", "host_only_probe", "no peer in this case at all"),
 ];
 '''
 
@@ -630,6 +967,30 @@ _BETA_RS = '''
 #[test]
 fn cases_bound_to_interop_cells() {
     nros_tests::interop::assert_test_bound("beta_e2e", &[(Linux, Rust, Zenoh, Service)]);
+}
+'''
+
+# The shared binary: an rstest pair (one case per cell), a host-only case that
+# is evidence for neither, and the binding test. `#[case]` also appears in the
+# SIGNATURE, where it is a parameter marker and not a case.
+_GAMMA_RS = '''
+#[rstest]
+#[case::pubsub(Cell { scenario: Scenario::Pubsub })]
+#[case::service(Cell { scenario: Scenario::Service })]
+fn pair(#[case] cell: Cell) {
+    interop::assert_test_bound("gamma_e2e", &CELLS);
+    assert!(talks_to(&peer, cell));
+}
+
+/// Runs here, needs no peer, and is evidence for no cell.
+#[test]
+fn host_only_probe() {
+    assert!(parses_a_plan());
+}
+
+#[test]
+fn cases_bound_to_interop_cells() {
+    nros_tests::interop::assert_test_bound("gamma_e2e", &[(Linux, Rust, Zenoh, Pubsub)]);
 }
 '''
 
@@ -668,8 +1029,11 @@ def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
     negative control nobody runs decays into a comment.
     """
     cells = [c for c in _sib.parse_cells(_MINI_RS) if c["tier"] == "Runtime"]
-    assert [c["id"] for c in cells] == ["cell-alpha", "cell-beta"], cells
-    src = {"alpha_e2e": _ALPHA_RS, "beta_e2e": _BETA_RS}
+    assert [c["id"] for c in cells] == [
+        "cell-alpha", "cell-beta", "cell-gamma-pubsub", "cell-gamma-service",
+    ], cells
+    owners = _sib.parse_case_owners(_MINI_RS)
+    src = {"alpha_e2e": _ALPHA_RS, "beta_e2e": _BETA_RS, "gamma_e2e": _GAMMA_RS}
     today = datetime.date(2026, 9, 6)
     issues = {"1137": (True, "open"), "0001": (True, "resolved")}
     look = lambda n: issues.get(n, (False, None))  # noqa: E731
@@ -685,13 +1049,15 @@ def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
         "binding-only — that is graph_interop's and interop_e2e's shape"
     )
 
-    problems, stats = evaluate(cells, _OK_LEDGER, src, look, today)
+    _self_test_case_map(cells, owners, src)
+
+    problems, stats = evaluate(cells, _OK_LEDGER, src, look, today, owners)
     assert problems == [], f"selftest: rejected a well-formed ledger: {problems}"
-    assert stats == {"runtime": 2, "verified": 1, "passed": 1, "failed": 0,
-                     "never": 1}, stats
+    assert stats == {"runtime": 4, "verified": 1, "passed": 1, "failed": 0,
+                     "never": 3}, stats
 
     def bad(text, want, why):
-        got = evaluate(cells, text, src, look, today)[0]
+        got = evaluate(cells, text, src, look, today, owners)[0]
         assert any(want in p for p in got), f"selftest: {why} (got {got})"
 
     bad(
@@ -733,7 +1099,7 @@ def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
     bad(_OK_LEDGER + _OK_LEDGER, "recorded twice", "a duplicate entry was accepted")
     bad(_OK_LEDGER.replace('evidence = "PASS [18.7s] alpha_e2e meets_a_peer"', ""),
         "missing or empty", "an entry with no evidence was accepted")
-    assert any("empty set" in p for p in evaluate([], "", src, look, today)[0]), (
+    assert any("empty set" in p for p in evaluate([], "", src, look, today, [])[0]), (
         "selftest: reported OK over zero Runtime cells"
     )
     for text, want in (
@@ -741,7 +1107,7 @@ def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
         ('[[verdit]]\ncell = "x"\n', "top-level key"),
     ):
         try:
-            evaluate(cells, text, src, look, today)
+            evaluate(cells, text, src, look, today, owners)
         except LedgerError as e:
             assert want in str(e), f"selftest: wrong error for {want!r}: {e}"
         else:
@@ -752,24 +1118,104 @@ def self_test(verbose: bool = False, tmp: Path | None = None) -> None:
     # invocation, `_test-summary` calls it at the tail of every sweep, and a
     # leaked directory per test run is a slow mess nobody would attribute here.
     with tempfile.TemporaryDirectory(prefix="nros-interop-verdicts-") as td:
-        _self_test_junit(Path(td) if tmp is None else tmp, cells, src)
+        _self_test_junit(Path(td) if tmp is None else tmp, cells, src, owners)
     if verbose:
         print("check-interop-verdicts: self-test OK")
 
 
-def _self_test_junit(tmp: Path, cells: list[dict], src: dict[str, str | None]) -> None:
+def _self_test_case_map(
+    cells: list[dict], owners: list[dict], src: dict[str, str | None]
+) -> None:
+    """The case → cell map's negative controls (issue 1191).
+
+    Two halves: the case names are DERIVED from the source (so the map cannot
+    quietly go stale), and the map is exhaustive and disjoint over them (so no
+    case is evidence twice, and none stops being evidence unnoticed).
+    """
+    # rstest's naming, including the padding rule — `case_{i:0width}`, width =
+    # the digit count of the case TOTAL, which is why nine cases are `case_1`
+    # and ten would be `case_01`.
+    assert source_cases(_GAMMA_RS, "gamma_e2e") == [
+        "pair::case_1_pubsub", "pair::case_2_service",
+        "host_only_probe", "cases_bound_to_interop_cells",
+    ], source_cases(_GAMMA_RS, "gamma_e2e")
+    wide = "#[rstest]\n" + "".join(
+        f"#[case::v{i}(x)]\n" for i in range(1, 11)
+    ) + "fn many(#[case] x: u8) { }\n"
+    assert source_cases(wide, "wide")[:2] == ["many::case_01_v1", "many::case_02_v2"], (
+        f"selftest: rstest's zero-padding is not modelled: {source_cases(wide, 'wide')[:2]}"
+    )
+    assert source_cases("#[rstest]\nfn solo(f: Fix) { }\n", "solo") == ["solo"], (
+        "selftest: an rstest with no cases is not the plain fn name"
+    )
+    assert source_cases("fn helper(#[case] x: u8) { }\n", "h") == [], (
+        "selftest: an un-annotated fn was read as a test case"
+    )
+    try:
+        source_cases("#[rstest]\n#[values(1, 2)]\nfn m(x: u8) { }\n", "m")
+    except _sib.ParseError as e:
+        assert "values" in str(e), e
+    else:
+        raise AssertionError(
+            "selftest: a case-naming shape the derivation cannot model was "
+            "given a guessed name instead of raising"
+        )
+    assert runnable_cases(_GAMMA_RS, "gamma_e2e") == [
+        "pair::case_1_pubsub", "pair::case_2_service", "host_only_probe",
+    ], "selftest: the binding test was left in the evidence set"
+
+    assert map_problems(cells, src, owners) == [], (
+        f"selftest: rejected a correct map: {map_problems(cells, src, owners)}"
+    )
+
+    def bad_map(rows, want, why):
+        got = map_problems(cells, src, rows)
+        assert any(want in p for p in got), f"selftest: {why} (got {got})"
+
+    bad_map([], "says which case is whose for NONE", "an unmapped shared binary")
+    bad_map(
+        [o for o in owners if o["case"] != "pair::case_2_service"],
+        "owns no case",
+        "a cell of a shared binary owning no case",
+    )
+    bad_map(
+        [o for o in owners if o["case"] != "host_only_probe"],
+        "does not name it",
+        "a case the map forgot",
+    )
+    renamed = [dict(o) for o in owners]
+    renamed[0]["case"] = "pair::case_1_renamed"
+    bad_map(renamed, "does not run any such case", "a stale case name")
+    twice = owners + [dict(owners[0], cell="cell-gamma-service")]
+    bad_map(twice, "claimed twice", "one case owned by two cells")
+    elsewhere = [dict(o) for o in owners]
+    elsewhere[0] = dict(elsewhere[0], cell="cell-alpha")
+    bad_map(elsewhere, "whose test binary is", "a case naming another binary's cell")
+    ghost = [dict(o) for o in owners]
+    ghost[0] = dict(ghost[0], cell="cell-nowhere")
+    bad_map(ghost, "not a `Tier::Runtime` interop cell", "a case naming no cell")
+    binding_cited = owners + [
+        dict(owners[0], case="cases_bound_to_interop_cells", cell="cell-gamma-pubsub")
+    ]
+    bad_map(binding_cited, "BINDING test", "a binding test named as a cell's case")
+
+
+def _self_test_junit(
+    tmp: Path, cells: list[dict], src: dict[str, str | None], owners: list[dict]
+) -> None:
     """The junit half of the negative controls — one temp dir, cleaned up."""
     only_skips = tmp / "skips.xml"
     only_skips.write_text(
         _junit([("alpha_e2e", "meets_a_peer", "skip"),
                 ("alpha_e2e", "cases_bound_to_interop_cells", "pass")])
     )
-    seen = observed(only_skips, cells, src)
-    assert seen["alpha_e2e"]["verdict"] == [], (
+    seen, orphan = observed(only_skips, cells, src, owners)
+    assert seen["cell-alpha"]["verdict"] == [], (
         "selftest: a binding test was counted as a verdict — the whole defect"
     )
-    assert seen["alpha_e2e"]["skipped"] == ["meets_a_peer"], seen
-    assert after_run(only_skips, cells, src, load_ledger(_OK_LEDGER)), (
+    assert seen["cell-alpha"]["skipped"] == ["meets_a_peer"], seen
+    assert not orphan, orphan
+    assert after_run(only_skips, cells, src, owners, load_ledger(_OK_LEDGER)), (
         "selftest: a wholly-skipped interop binary printed nothing"
     )
 
@@ -777,15 +1223,103 @@ def _self_test_junit(tmp: Path, cells: list[dict], src: dict[str, str | None]) -
     real.write_text(_junit([("beta_e2e", "delivers", "pass"),
                             ("beta_e2e", "cases_bound_to_interop_cells", "pass")]))
     src2 = dict(src, beta_e2e=_BETA_RS + "\n#[test]\nfn delivers() { assert!(x); }\n")
-    seen = observed(real, cells, src2)
-    assert seen["beta_e2e"]["verdict"] == ["delivers"], seen
-    lines = after_run(real, cells, src2, load_ledger(_OK_LEDGER))
+    seen, _ = observed(real, cells, src2, owners)
+    assert seen["cell-beta"]["verdict"] == ["delivers"], seen
+    lines = after_run(real, cells, src2, owners, load_ledger(_OK_LEDGER))
     assert any("cell-beta" in ln for ln in lines), (
         f"selftest: a cell that produced a verdict with no record was not named: {lines}"
     )
 
-    assert observed(tmp / "nope.xml", cells, src) == {}, (
+    assert observed(tmp / "nope.xml", cells, src, owners) == ({}, {}), (
         "selftest: invented results from a junit that does not exist"
+    )
+
+    # --- issue 1191: one binary, two cells, one failure -------------------
+    # The measured shape, in miniature: a run where one cell's case FAILS and
+    # the other's PASSES. Before the map, the failure vetoed both.
+    mixed = tmp / "mixed.xml"
+    mixed.write_text(
+        _junit([("gamma_e2e", "pair::case_1_pubsub", "pass"),
+                ("gamma_e2e", "pair::case_2_service", "fail"),
+                ("gamma_e2e", "host_only_probe", "pass"),
+                ("gamma_e2e", "cases_bound_to_interop_cells", "pass")])
+    )
+    seen, orphan = observed(mixed, cells, src, owners)
+    assert not orphan, f"selftest: a mapped case read as unattributed: {orphan}"
+    assert seen["cell-gamma-pubsub"] == {
+        "verdict": ["pair::case_1_pubsub"], "skipped": [], "failed": []
+    }, seen["cell-gamma-pubsub"]
+    assert seen["cell-gamma-service"]["failed"] == ["pair::case_2_service"], seen
+    assert "host_only_probe" not in str(seen), (
+        "selftest: an `unowned(...)` case was counted as some cell's evidence"
+    )
+
+    def rec(cell, junit, issue=""):
+        """`--record`, against a ledger of its own, output captured.
+
+        Captured because this runs on the NORMAL path of every invocation
+        (`_test-summary` calls it at the tail of every sweep): a negative
+        control must not print `recorded ...` where a real recording would.
+        """
+        global LEDGER
+        keep, LEDGER = LEDGER, tmp / f"ledger-{cell}.toml"
+        out, err = io.StringIO(), io.StringIO()
+        try:
+            args = argparse.Namespace(
+                record=cell, junit=str(junit), where="selftest", run="",
+                evidence="", issue=issue,
+            )
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = record(args, cells, src, owners)
+            said = out.getvalue() + err.getvalue()
+            return rc, (LEDGER.read_text() if LEDGER.exists() else ""), said
+        finally:
+            LEDGER = keep
+
+    rc, text, _ = rec("cell-gamma-pubsub", mixed)
+    assert rc == 0 and "cell-gamma-pubsub" in text, (
+        f"selftest: a cell whose OWN case passed was refused a verdict because a "
+        f"sibling cell's case failed — that is issue 1191 (rc={rc})"
+    )
+    assert "pair::case_2_service" not in text, (
+        "selftest: recorded another cell's case as this cell's evidence"
+    )
+    rc, _, said = rec("cell-gamma-service", mixed)
+    assert rc == 1 and "pair::case_2_service FAILED" in said, (
+        f"selftest: recorded a FAILING cell with no --issue — attribution must "
+        f"still refuse in the failing direction ({said!r})"
+    )
+    rc, text, _ = rec("cell-gamma-service", mixed, issue="1137")
+    assert rc == 0 and 'issue = "1137"' in text, (
+        f"selftest: a failing cell with an issue was refused (rc={rc})"
+    )
+
+    # A junit whose binary ran a case the map does not name: neither dropped
+    # nor spread — the recording is refused until the map covers it.
+    strange = tmp / "strange.xml"
+    strange.write_text(
+        _junit([("gamma_e2e", "pair::case_1_pubsub", "pass"),
+                ("gamma_e2e", "pair::case_3_lifecycle", "pass")])
+    )
+    seen, orphan = observed(strange, cells, src, owners)
+    assert orphan == {"gamma_e2e": ["pair::case_3_lifecycle"]}, orphan
+    rc, _, said = rec("cell-gamma-pubsub", strange)
+    assert rc == 1 and "does not name" in said, (
+        f"selftest: recorded from a junit carrying a case interop::CASE_CELLS "
+        f"does not name — the map and the binary that RAN disagree ({said!r})"
+    )
+
+    # And a cell whose own cases all skipped is still refused, even though a
+    # sibling cell in the same binary produced a result.
+    half = tmp / "half.xml"
+    half.write_text(
+        _junit([("gamma_e2e", "pair::case_1_pubsub", "pass"),
+                ("gamma_e2e", "pair::case_2_service", "skip")])
+    )
+    rc, _, said = rec("cell-gamma-service", half)
+    assert rc == 1 and "SKIPPED" in said, (
+        f"selftest: recorded a verdict for a cell whose every case SKIPPED, on "
+        f"the strength of a sibling's pass ({said!r})"
     )
 
 
@@ -818,6 +1352,7 @@ def main(argv: list[str]) -> int:
 
     try:
         cells = runtime_cells()
+        owners = _sib.parse_case_owners(_sib.INTEROP_RS.read_text(encoding="utf-8"))
     except _sib.ParseError as e:
         print(f"check-interop-verdicts: {e}", file=sys.stderr)
         return 1
@@ -834,14 +1369,16 @@ def main(argv: list[str]) -> int:
                 file=sys.stderr,
             )
             return 1
-        return record(args, cells, sources)
+        return record(args, cells, sources, owners)
 
     if args.after_run is not None:
         try:
             entries = load_ledger(text)
         except LedgerError:
             entries = []
-        for line in after_run(Path(args.after_run), cells, sources, entries):
+        for line in after_run(
+            Path(args.after_run), cells, sources, owners, entries
+        ):
             print(line)
         return 0
 
@@ -855,7 +1392,9 @@ def main(argv: list[str]) -> int:
         return 0
 
     try:
-        problems, stats = evaluate(cells, text, sources, issue_status, today)
+        problems, stats = evaluate(
+            cells, text, sources, issue_status, today, owners
+        )
     except LedgerError as e:
         print(f"check-interop-verdicts: {e}", file=sys.stderr)
         return 1


### PR DESCRIPTION
Fixes issue 1191 — the live-peer verdict ledger keyed on the test **binary**,
not on the cell, so one failing case vetoed the four other cells sharing that
binary.

## The problem, as measured

`interop_e2e` hosts five `Tier::Runtime` cells. Measured 2026-09-07 in the box:
nine cases ran, eight passed, one failed (`case_2_zenoh_pubsub_ros2_to_nano`,
issue 1190). `--record` refused all five cells with the same message about
`case_2`, and the report read **6 of 19** where it should have read **10**.

The refusals were right and are untouched. Without a case → cell map the tool
could not know that `case_2` belongs to `native-pubsub-rust-zenoh-n2r` and not
to `native-lifecycle-rust-zenoh`, and a pass recorded for a cell whose case
failed is the exact false claim the ledger exists to prevent. **This supplies
the map.**

## The map, and why it is trustworthy

`interop::CASE_CELLS` — one row per case of a shared binary naming the cell it
is evidence for, or `unowned(...)` with a reason for a case that is evidence
for none.

Four binaries need it — `interop_e2e` (5 cells), `graph_interop` (2),
`ros2_action_e2e` (2), `xrce_ros2_interop` (2). The other seven host one cell
each, where binary-wide attribution IS cell-wide; a binary gaining a second
cell turns the gate red, which is when the map becomes necessary.

It is AUTHORED, because nothing in the tree derives it and for
`ros2_action_e2e` nothing could: its two cells are ONE
`(Linux, Rust, Cyclonedds, Action)` coordinate and differ only by direction,
which `coords_for` collapses on purpose. What makes an authored map
trustworthy is that it is checked against the cases each binary REALLY runs:

* `source_cases()` **derives** the junit case names from the source — `#[test]`
  / `#[rstest]` plus rstest 0.24's own `case_<n>_<desc>` naming, zero-padding
  included (`rstest_macros::render::format_case_name`). A shape it cannot name
  (`#[values(...)]`) raises rather than guessing.
* `map_problems()` requires the map to be exhaustive and disjoint over those
  names, **in both directions**: a rename, an addition or a deletion is red
  rather than a silent move of evidence.
* `--record` refuses a junit carrying a case of a mapped binary the map does
  not name — the binary that RAN and the map disagree — and refuses outright
  when the map for that binary is broken.
* The ledger check rejects an entry citing a SIBLING cell's case.
* Rust unit tests in `interop.rs` bind the rows to `CELLS`: real Runtime cell,
  same binary, no case claimed twice, every cell of a shared binary owns one.

Attribution by SUBSTRING (a cell id inside a case name) is the non-fix the
issue names, and is not done here: different vocabularies, works until a
rename.

## Verification

* Against the measured run — the phase-433 W2 ledger plus a junit carrying
  those nine results — the four passing cells record cleanly and `--report`
  goes from **6 of 19 → 10 of 19**, while `native-pubsub-rust-zenoh-n2r` is
  still refused without `--issue`. The same shape is a negative control in
  `self_test()`, which runs on the normal path of every invocation.
* `just check fast`: 256 gates green, 2 reported skips (no arm-none-eabi,
  zenoh-pico submodule not checked out).
* `cargo test -p nros-tests --lib interop` and `--test matrix_fixture_coverage`
  green.

## Fallout for whoever lands the W2 verdicts

Entries written by the binary-wide recorder cite other cells' cases —
phase-433 W2 gave both `graph_interop` cells both cases, and
`native-pubsub-rust-zenoh-n2r` all nine `interop_e2e` cases. Those are now gate
failures and want re-recording from the same junit. The issue record is at
`docs/issues/archived/1191-*.md`; the open copy on
`work/1189-action-list-no-daemon` should be dropped rather than merged
alongside it.

`xrce_ros2_interop` runs three ACTION cases that no `interop::CELLS` row
claims. They are `unowned(...)` with that reason — until now they counted as
the pubsub and service cells' evidence. The gap is a missing cell, not a
missing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA
