### PR TITLE
fix(ci_lane): my W3 rename moved the covers and left the table asserting the old numbers

### DIFF
--- a/packages/testing/nros-tests/src/ci_lane.rs
+++ b/packages/testing/nros-tests/src/ci_lane.rs
@@ -38,8 +38,8 @@
 //! | lane | selection | cells | coords | cost |
 //! | --- | --- | --- | --- | --- |
 //! | [`CiLane::Tier1`] | host-exec, 1-wise p,w,k + pairwise l × r | 17 | 12 | 26 % |
-//! | [`CiLane::Tier2`] | 1-wise p, l, r, k | 13 | 14 | 28 % |
-//! | [`CiLane::Tier2Nightly`] | pairwise p × l × r × k | 37 | 37 | 74 % |
+//! | [`CiLane::Tier2`] | 1-wise p, l, r, k | 13 | 13 | 26 % |
+//! | [`CiLane::Tier2Nightly`] | pairwise p × l × r × k | 36 | 36 | 72 % |
 //! | tier 3 | everything | 194 | 50 | 100 % |
 //!
 //! **These numbers are GATED, not transcribed** — `documented_lane_table_is_live`
@@ -870,8 +870,8 @@ _tier-build:
         // (lane, cells, coords) exactly as the module docs above state them.
         let documented = [
             (CiLane::Tier1, 17, 12),
-            (CiLane::Tier2, 13, 14),
-            (CiLane::Tier2Nightly, 37, 37),
+            (CiLane::Tier2, 13, 13),
+            (CiLane::Tier2Nightly, 36, 36),
         ];
         for (lane, want_cells, want_coords) in documented {
             assert_eq!(


### PR DESCRIPTION
**`test-unit` has been red on `main` since 2026-09-06, and it is mine.**

```
Tier2: the ci_lane module table says 14 coords; recomputed 13
```

Measured rather than assumed: `documented_lane_table_is_live` **passes** on `c46588f09^` and **fails** on `c46588f09` — phase-433 W3, PR #587, the commit that corrected the cyclone interop cells from `Lang::Rust` to `Lang::C`. The table's `14` was set on 2026-08-20 and nothing has moved it since.

The drift is exactly what W3 intended and did not follow through on: two cells changed language, and the vacated Rust/Cyclone coordinates became `CarveOut`s rather than Runtime cells, so the 1-wise tier-2 cover needs one fewer coordinate and the pairwise nightly cover one fewer cell. Corrected to **13/13** and **36/36**, percentages recomputed (26 %, 72 %).

## Why it survived four of my own PRs

**This lane runs on the merge queue, not on the PR.** CLAUDE.md is explicit that a green `CI` on a pull request means *"it compiles and the source gates hold"*, never *"the unit tests pass"* — `test-unit` runs on `merge_group`. So W3 went green through every check a PR runs, and the red has been sitting one lane further in ever since, while I pushed four more PRs with `just check fast` green over it.

That the queue kept merging anyway is worth separate attention. This PR only makes the assertion true again.

I verified each corrected number rather than pasting whatever the recomputation printed — the point of a gated table is lost if you update it to match whatever the code now says. The check was the before/after on W3's own boundary.

## Found by

The issue-1191 agent, running `cargo test -p nros-tests --lib` on its own initiative. No lane I ran today would have shown it.

## Verification

`just check fast` 258/258 · `cargo test -p nros-tests --lib ci_lane` 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWKKbKZByZ68C6RXTdUnBA